### PR TITLE
Sync Introduce Invalidated System Columns

### DIFF
--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -1579,7 +1579,15 @@ void MutationsInterpreter::prepare(bool dry_run)
     for (const auto & projection : metadata_snapshot->getProjections())
     {
         if (!source.hasProjection(projection.name))
+        {
+            if (projection.with_block_number || projection.with_block_offset)
+            {
+                LOG_DEBUG(logger, "Will rebuild commit-order projection {}", projection.name);
+                materialized_projections.insert(projection.name);
+            }
+
             continue;
+        }
 
         /// Always rebuild broken projections.
         if (source.hasBrokenProjection(projection.name))

--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -205,7 +205,7 @@ void collectTextIndexReadInfos(const ReadFromMergeTree * read_from_merge_tree_st
         /// Index may be not materialized in some parts, e.g. after ALTER ADD INDEX query.
         size_t num_materialized_parts = std::ranges::count_if(unique_parts, [&](const auto & part)
         {
-            return !!index.index->getDeserializedFormat(part->checksums, index.index->getFileName(), &part->getDataPartStorage());
+            return !!index.index->getDeserializedFormat(*part, index.index->getFileName());
         });
 
         text_index_read_infos[index.index->index.name] =

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2341,7 +2341,7 @@ void ReadFromMergeTree::buildIndexes(
             for (const auto & idx : skip_indexes.useful_indices)
             {
                 size_t index_size = 0;
-                auto format = idx.index->getDeserializedFormat(part.data_part->checksums, idx.index->getFileName(), &part.data_part->getDataPartStorage());
+                auto format = idx.index->getDeserializedFormat(*part.data_part, idx.index->getFileName());
 
                 for (const auto & substream : format.substreams)
                 {

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -541,6 +541,7 @@ MutableDataPartStoragePtr DataPartStorageOnDiskBase::freeze(
         params.external_transaction->removeFileIfExists(fs::path(to) / dir_path / VersionMetadata::TXN_VERSION_METADATA_FILE_NAME);
         if (!params.keep_metadata_version)
             params.external_transaction->removeFileIfExists(fs::path(to) / dir_path / IMergeTreeDataPart::METADATA_VERSION_FILE_NAME);
+        IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*params.external_transaction, fs::path(to) / dir_path, params.invalidated_columns_to_write, write_settings);
     }
     else
     {
@@ -549,6 +550,7 @@ MutableDataPartStoragePtr DataPartStorageOnDiskBase::freeze(
         disk->removeFileIfExists(fs::path(to) / dir_path / VersionMetadata::TXN_VERSION_METADATA_FILE_NAME);
         if (!params.keep_metadata_version)
             disk->removeFileIfExists(fs::path(to) / dir_path / IMergeTreeDataPart::METADATA_VERSION_FILE_NAME);
+        IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*disk, fs::path(to) / dir_path, params.invalidated_columns_to_write, write_settings);
     }
 
     /// The SingleDiskVolume and the DataPartStorageOnDiskFull built by `create` are stored on the
@@ -559,7 +561,9 @@ MutableDataPartStoragePtr DataPartStorageOnDiskBase::freeze(
 
     /// Do not initialize storage in case of DETACH because part may be broken.
     bool to_detached = dir_path.starts_with(std::string_view((fs::path(MergeTreeData::DETACHED_DIR_NAME) / "").string()));
-    return create(single_disk_volume, to, dir_path, /*initialize=*/ !to_detached && !params.external_transaction);
+    auto frozen_storage = create(single_disk_volume, to, dir_path, /*initialize=*/ !to_detached && !params.external_transaction);
+
+    return frozen_storage;
 }
 
 MutableDataPartStoragePtr DataPartStorageOnDiskBase::freezeRemote(
@@ -608,6 +612,7 @@ MutableDataPartStoragePtr DataPartStorageOnDiskBase::freezeRemote(
         params.external_transaction->removeFileIfExists(fs::path(to) / dir_path / VersionMetadata::TXN_VERSION_METADATA_FILE_NAME);
         if (!params.keep_metadata_version)
             params.external_transaction->removeFileIfExists(fs::path(to) / dir_path / IMergeTreeDataPart::METADATA_VERSION_FILE_NAME);
+        IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*params.external_transaction, fs::path(to) / dir_path, params.invalidated_columns_to_write, write_settings);
     }
     else
     {
@@ -616,6 +621,7 @@ MutableDataPartStoragePtr DataPartStorageOnDiskBase::freezeRemote(
         dst_disk->removeFileIfExists(fs::path(to) / dir_path / VersionMetadata::TXN_VERSION_METADATA_FILE_NAME);
         if (!params.keep_metadata_version)
             dst_disk->removeFileIfExists(fs::path(to) / dir_path / IMergeTreeDataPart::METADATA_VERSION_FILE_NAME);
+        IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*dst_disk, fs::path(to) / dir_path, params.invalidated_columns_to_write, write_settings);
     }
 
     /// The SingleDiskVolume and the DataPartStorageOnDiskFull built by `create` are stored on the
@@ -625,7 +631,9 @@ MutableDataPartStoragePtr DataPartStorageOnDiskBase::freezeRemote(
 
     /// Do not initialize storage in case of DETACH because part may be broken.
     bool to_detached = dir_path.starts_with(std::string_view((fs::path(MergeTreeData::DETACHED_DIR_NAME) / "").string()));
-    return create(single_disk_volume, to, dir_path, /*initialize=*/ !to_detached && !params.external_transaction);
+    auto frozen_storage = create(single_disk_volume, to, dir_path, /*initialize=*/ !to_detached && !params.external_transaction);
+
+    return frozen_storage;
 }
 
 MutableDataPartStoragePtr DataPartStorageOnDiskBase::clonePart(
@@ -970,6 +978,7 @@ void DataPartStorageOnDiskBase::clearDirectory(
         request.emplace_back(fs::path(dir) / VersionMetadata::TMP_TXN_VERSION_METADATA_FILE_NAME, true);
         request.emplace_back(fs::path(dir) / "metadata_version.txt", true);
         request.emplace_back(fs::path(dir) / IMergeTreeDataPart::COLUMNS_SUBSTREAMS_FILE_NAME, true);
+        request.emplace_back(fs::path(dir) / IMergeTreeDataPart::INVALIDATED_SYSTEM_COLUMNS_FILE_NAME, true);
 
         disk->removeSharedFiles(request, !can_remove_shared_data, names_not_to_remove);
         disk->removeDirectory(dir);

--- a/src/Storages/MergeTree/DataPartStorageOnDiskPacked.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskPacked.cpp
@@ -966,6 +966,8 @@ MutableDataPartStoragePtr DataPartStorageOnDiskPacked::freeze(
             disk->createHardLink(getRelativeDataPath(), dest_storage->getRelativeDataPath());
     }
 
+    IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*dest_storage, "", params.invalidated_columns_to_write, write_settings);
+
     std::vector<std::string> all_files;
     src_disk->listFiles(getRelativePath(), all_files);
     for (const auto & file : all_files)
@@ -1097,6 +1099,8 @@ MutableDataPartStoragePtr DataPartStorageOnDiskPacked::freezeRemote(
             src_disk->copyFile(getRelativeDataPath(), *dst_disk, dest_storage->getRelativeDataPath(), read_settings, write_settings);
         }
     }
+
+    IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*dest_storage, "", params.invalidated_columns_to_write, write_settings);
 
     std::vector<std::string> all_files;
     src_disk->listFiles(getRelativePath(), all_files);

--- a/src/Storages/MergeTree/DataPartStorageOnDiskPacked.h
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskPacked.h
@@ -21,6 +21,7 @@ public:
     {
         "delete-on-destroy.txt",
         "txn_version.txt",
+        "invalidated_system_columns.txt",
     };
 
     DataPartStorageOnDiskPacked(

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -14,6 +14,7 @@
 #include <Server/HTTP/HTMLForm.h>
 #include <Server/HTTP/HTTPServerResponse.h>
 #include <Storages/MergeTree/DataPartStorageOnDiskFull.h>
+#include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/MergedBlockOutputStream.h>
@@ -69,6 +70,7 @@ namespace DataPartsExchange
 
 namespace
 {
+
 constexpr auto REPLICATION_PROTOCOL_VERSION_WITH_PARTS_SIZE = 1;
 constexpr auto REPLICATION_PROTOCOL_VERSION_WITH_PARTS_SIZE_AND_TTL_INFOS = 2;
 constexpr auto REPLICATION_PROTOCOL_VERSION_WITH_PARTS_TYPE = 3;
@@ -78,6 +80,7 @@ constexpr auto REPLICATION_PROTOCOL_VERSION_WITH_PARTS_ZERO_COPY = 6;
 constexpr auto REPLICATION_PROTOCOL_VERSION_WITH_PARTS_PROJECTION = 7;
 constexpr auto REPLICATION_PROTOCOL_VERSION_WITH_METADATA_VERSION = 8;
 constexpr auto REPLICATION_PROTOCOL_VERSION_WITH_COLUMNS_SUBSTREAMS = 9;
+constexpr auto REPLICATION_PROTOCOL_VERSION_WITH_INVALIDATED_SYSTEM_COLUMNS = 10;
 
 std::string getEndpointId(const std::string & node_id)
 {
@@ -145,7 +148,7 @@ void Service::processQuery(const HTMLForm & params, ReadBufferPtr body, WriteBuf
     MergeTreePartInfo::fromPartName(part_name, data.format_version);
 
     /// We pretend to work as older server version, to be sure that client will correctly process our version
-    response.addCookie({"server_protocol_version", toString(std::min(client_protocol_version, REPLICATION_PROTOCOL_VERSION_WITH_COLUMNS_SUBSTREAMS))});
+    response.addCookie({"server_protocol_version", toString(std::min(client_protocol_version, REPLICATION_PROTOCOL_VERSION_WITH_INVALIDATED_SYSTEM_COLUMNS))});
 
     LOG_TRACE(log, "Sending part {}", part_name);
 
@@ -264,6 +267,10 @@ MergeTreeData::DataPart::Checksums Service::sendPartFromDisk(
 
         if (client_protocol_version < REPLICATION_PROTOCOL_VERSION_WITH_COLUMNS_SUBSTREAMS
             && name == IMergeTreeDataPart::COLUMNS_SUBSTREAMS_FILE_NAME)
+            continue;
+
+        if (client_protocol_version < REPLICATION_PROTOCOL_VERSION_WITH_INVALIDATED_SYSTEM_COLUMNS
+            && name == IMergeTreeDataPart::INVALIDATED_SYSTEM_COLUMNS_FILE_NAME)
             continue;
 
         files_to_replicate.insert(name);
@@ -454,7 +461,7 @@ std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> Fetcher::fetchSelected
     {
         {"endpoint",                endpoint_id},
         {"part",                    part_name},
-        {"client_protocol_version", toString(REPLICATION_PROTOCOL_VERSION_WITH_COLUMNS_SUBSTREAMS)},
+        {"client_protocol_version", toString(REPLICATION_PROTOCOL_VERSION_WITH_INVALIDATED_SYSTEM_COLUMNS)},
         {"compress",                "false"}
     });
 
@@ -753,7 +760,8 @@ void Fetcher::downloadBaseOrProjectionPartToDisk(
             file_name != "columns.txt" &&
             file_name != IMergeTreeDataPart::COLUMNS_SUBSTREAMS_FILE_NAME &&
             file_name != IMergeTreeDataPart::DEFAULT_COMPRESSION_CODEC_FILE_NAME &&
-            file_name != IMergeTreeDataPart::METADATA_VERSION_FILE_NAME)
+            file_name != IMergeTreeDataPart::METADATA_VERSION_FILE_NAME &&
+            file_name != IMergeTreeDataPart::INVALIDATED_SYSTEM_COLUMNS_FILE_NAME)
             checksums.addFile(file_name, file_size, expected_hash);
     }
 

--- a/src/Storages/MergeTree/IDataPartStorage.h
+++ b/src/Storages/MergeTree/IDataPartStorage.h
@@ -275,6 +275,7 @@ public:
         bool make_source_readonly = false;
         DiskTransactionPtr external_transaction = nullptr;
         std::optional<int32_t> metadata_version_to_write = std::nullopt;
+        NameSet invalidated_columns_to_write = {};
     };
 
     /// For packed storage the whole data.packed archive is rewritten (copied) during a clone whenever

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -67,6 +67,8 @@
 
 #include <Disks/DiskObjectStorage/DiskObjectStorage.h>
 #include <Disks/IO/CachedOnDiskReadBufferFromFile.h>
+#include <Disks/IDiskTransaction.h>
+#include <Disks/IDisk.h>
 
 #include <base/defines.h>
 #include <atomic>
@@ -172,23 +174,23 @@ void IMergeTreeDataPart::MinMaxIndex::load(const IMergeTreeDataPart & part)
     FormatSettings format_settings;
     for (const auto & [column_name, column_type] : MergeTreeData::getMinMaxColumns(partition_key, data_settings))
     {
-        if (fill_virtuals)
-        {
-            if (metadata_snapshot->isVirtualColumn(BlockNumberColumn::name) && column_name == BlockNumberColumn::name)
-            {
-                const Field block_number = getFieldForConstVirtualColumn(BlockNumberColumn::name, part);
-                hyperrectangle.emplace_back(block_number, true, block_number, true);
-                continue;
-            }
+        const bool synth_block_number = (fill_virtuals || part.isSystemColumnInvalidated(BlockNumberColumn::name)) && metadata_snapshot->isVirtualColumn(BlockNumberColumn::name) && column_name == BlockNumberColumn::name;
+        const bool synth_block_offset = (fill_virtuals || part.isSystemColumnInvalidated(BlockOffsetColumn::name)) && metadata_snapshot->isVirtualColumn(BlockOffsetColumn::name) && column_name == BlockOffsetColumn::name;
 
-            if (metadata_snapshot->isVirtualColumn(BlockOffsetColumn::name) && column_name == BlockOffsetColumn::name)
-            {
-                if (part.rows_count == 0)
-                    hyperrectangle.emplace_back(Range::createWholeUniverse());
-                else
-                    hyperrectangle.emplace_back(Field(UInt64(0)), true, Field(UInt64(part.rows_count - 1)), true);
-                continue;
-            }
+        if (synth_block_number)
+        {
+            const Field block_number = getFieldForConstVirtualColumn(BlockNumberColumn::name, part);
+            hyperrectangle.emplace_back(block_number, true, block_number, true);
+            continue;
+        }
+
+        if (synth_block_offset)
+        {
+            if (part.rows_count == 0)
+                hyperrectangle.emplace_back(Range::createWholeUniverse());
+            else
+                hyperrectangle.emplace_back(Field(UInt64(0)), true, Field(UInt64(part.rows_count - 1)), true);
+            continue;
         }
 
         const String file_name = "minmax_" + getFileColumnName(column_name, part.checksums) + ".idx";
@@ -884,7 +886,7 @@ void IMergeTreeDataPart::loadIndexMarksToCache(MarkCache * index_mark_cache) con
     {
         auto skip_index = MergeTreeIndexFactory::instance().get(metadata_snapshot, index_description, *storage.getSettings());
         auto index_name = skip_index->getFileName();
-        auto index_format = skip_index->getDeserializedFormat(checksums, index_name, &getDataPartStorage());
+        auto index_format = skip_index->getDeserializedFormat(*this, index_name);
 
         if (!index_format)
             continue;
@@ -935,7 +937,7 @@ void IMergeTreeDataPart::removeIndexMarksFromCache(MarkCache * index_mark_cache)
     {
         auto skip_index = MergeTreeIndexFactory::instance().get(metadata_snapshot, index_description, *storage.getSettings());
         auto index_name = skip_index->getFileName();
-        auto index_format = skip_index->getDeserializedFormat(checksums, index_name, &getDataPartStorage());
+        auto index_format = skip_index->getDeserializedFormat(*this, index_name);
 
         if (!index_format)
             continue;
@@ -1373,6 +1375,7 @@ void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checks
             ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
 
             loadColumnsSubstreams();
+            loadInvalidatedSystemColumns();
             loadChecksums(require_columns_checksums);
             loadIndexGranularity();
 
@@ -1490,6 +1493,12 @@ void IMergeTreeDataPart::loadProjections(
     auto metadata_snapshot = storage.getInMemoryMetadataPtr(storage.getContext(), false);
     for (const auto & projection : metadata_snapshot->projections)
     {
+        if (projection.with_block_number && isSystemColumnInvalidated(BlockNumberColumn::name))
+            continue;
+
+        if (projection.with_block_offset && isSystemColumnInvalidated(BlockOffsetColumn::name))
+            continue;
+
         auto path = projection.name + ".proj";
         if (getDataPartStorage().existsDirectory(path))
         {
@@ -1675,6 +1684,9 @@ NameSet IMergeTreeDataPart::getFileNamesWithoutChecksums() const
     if (getDataPartStorage().existsFile(COLUMNS_SUBSTREAMS_FILE_NAME))
         result.emplace(COLUMNS_SUBSTREAMS_FILE_NAME);
 
+    if (getDataPartStorage().existsFile(INVALIDATED_SYSTEM_COLUMNS_FILE_NAME))
+        result.emplace(INVALIDATED_SYSTEM_COLUMNS_FILE_NAME);
+
     /// UNIQUE KEY per-part SST. Enumerated based on the part's own on-disk
     /// presence (a part property), not table metadata, so `MergeTreeData::backupParts`
     /// and `DataPartsExchange::sendPart` transfer it — both build the transferred
@@ -1684,6 +1696,79 @@ NameSet IMergeTreeDataPart::getFileNamesWithoutChecksums() const
         result.emplace(SSTIndexWriter::FILE_NAME);
 
     return result;
+}
+
+bool IMergeTreeDataPart::isSystemColumnInvalidated(const String & column_name) const
+{
+    return invalidated_system_columns.contains(column_name);
+}
+
+void IMergeTreeDataPart::loadInvalidatedSystemColumns()
+{
+    if (parent_part)
+        return;
+
+    if (auto file_buf = readFileIfExists(INVALIDATED_SYSTEM_COLUMNS_FILE_NAME))
+        invalidated_system_columns = readInvalidatedSystemColumns(*file_buf);
+}
+
+void IMergeTreeDataPart::writeInvalidatedSystemColumns(WriteBuffer & out, const NameSet & columns)
+{
+    for (const auto & column_name : columns)
+    {
+        writeEscapedString(column_name, out);
+        writeChar('\n', out);
+    }
+}
+
+NameSet IMergeTreeDataPart::readInvalidatedSystemColumns(ReadBuffer & in)
+{
+    NameSet columns;
+    while (!in.eof())
+    {
+        String column_name;
+        readEscapedStringUntilEOL(column_name, in);
+        if (!in.eof())
+            in.ignore(); /// skip '\n'
+
+        columns.insert(column_name);
+    }
+
+    return columns;
+}
+
+namespace
+{
+
+template <typename Storage>
+void writeInvalidatedSystemColumnsFileImpl(Storage & storage, const std::filesystem::path & part_dir, const NameSet & columns, const WriteSettings & settings)
+{
+    const std::string path = part_dir / IMergeTreeDataPart::INVALIDATED_SYSTEM_COLUMNS_FILE_NAME;
+    storage.removeFileIfExists(path);
+
+    if (columns.empty())
+        return;
+
+    auto out = storage.writeFile(path, 4096, WriteMode::Rewrite, settings);
+    IMergeTreeDataPart::writeInvalidatedSystemColumns(*out, columns);
+    out->finalize();
+}
+
+}
+
+void IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(IDataPartStorage & storage, const std::filesystem::path & part_dir, const NameSet & columns, const WriteSettings & settings)
+{
+    writeInvalidatedSystemColumnsFileImpl(storage, part_dir, columns, settings);
+}
+
+void IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(IDisk & disk, const std::filesystem::path & part_dir, const NameSet & columns, const WriteSettings & settings)
+{
+    writeInvalidatedSystemColumnsFileImpl(disk, part_dir, columns, settings);
+}
+
+void IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(IDiskTransaction & transaction, const std::filesystem::path & part_dir, const NameSet & columns, const WriteSettings & settings)
+{
+    writeInvalidatedSystemColumnsFileImpl(transaction, part_dir, columns, settings);
 }
 
 std::optional<String> IMergeTreeDataPart::getDenseIndexBackingPath() const
@@ -2595,7 +2680,7 @@ DataPartStoragePtr IMergeTreeDataPart::makeCloneInDetached(const String & prefix
         .copy_instead_of_hardlink = isStoredOnRemoteDiskWithZeroCopySupport() && storage.supportsReplication() && (*storage_settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication],
         .keep_metadata_version = true,
         .make_source_readonly = true,
-        .external_transaction = disk_transaction
+        .external_transaction = disk_transaction,
     };
     return getDataPartStorage().freeze(
         storage.relative_data_path,

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <filesystem>
 #include <mutex>
 #include <Core/NamesAndTypes.h>
 #include <Core/UUID.h>
@@ -65,6 +66,8 @@ class DeleteBitmapCache;
 using DeleteBitmapCachePtr = std::shared_ptr<DeleteBitmapCache>;
 
 class VersionMetadata;
+class WriteBuffer;
+class ReadBuffer;
 enum class DataPartRemovalState : uint8_t
 {
     NOT_ATTEMPTED,
@@ -419,6 +422,14 @@ public:
     /// Columns with values, that all have been zeroed by expired ttl
     NameSet expired_columns;
 
+    NameSet invalidated_system_columns;
+    bool isSystemColumnInvalidated(const String & column_name) const;
+    static void writeInvalidatedSystemColumns(WriteBuffer & out, const NameSet & columns);
+    static NameSet readInvalidatedSystemColumns(ReadBuffer & in);
+    static void writeInvalidatedSystemColumnsFile(IDataPartStorage & storage, const std::filesystem::path & part_dir, const NameSet & columns, const WriteSettings & settings);
+    static void writeInvalidatedSystemColumnsFile(IDisk & disk, const std::filesystem::path & part_dir, const NameSet & columns, const WriteSettings & settings);
+    static void writeInvalidatedSystemColumnsFile(IDiskTransaction & transaction, const std::filesystem::path & part_dir, const NameSet & columns, const WriteSettings & settings);
+
     CompressionCodecPtr default_codec;
 
     mutable std::unique_ptr<VersionMetadata> version;
@@ -590,6 +601,9 @@ public:
     static constexpr auto SERIALIZATION_FILE_NAME = "serialization.json";
 
     static constexpr auto METADATA_VERSION_FILE_NAME = "metadata_version.txt";
+
+    /// File that lists persisted system columns whose stored values became stale.
+    static constexpr auto INVALIDATED_SYSTEM_COLUMNS_FILE_NAME = "invalidated_system_columns.txt";
 
     /// One of part files which is used to check how many references (I'd like
     /// to say hardlinks, but it will confuse even more) we have for the part
@@ -838,6 +852,9 @@ private:
 
     /// Reads columns substreams from columns_substreams.txt.
     void loadColumnsSubstreams();
+
+    /// Reads invalidated_system_columns.txt if present.
+    void loadInvalidatedSystemColumns();
 
     /// Loads marks index granularity into memory
     virtual void loadIndexGranularity();

--- a/src/Storages/MergeTree/IMergeTreeDataPartInfoForReader.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPartInfoForReader.h
@@ -76,6 +76,8 @@ public:
 
     virtual std::optional<size_t> getColumnPosition(const String & column_name) const = 0;
 
+    virtual bool isSystemColumnInvalidated(const String & column_name) const = 0;
+
     virtual String getColumnNameWithMinimumCompressedSize(const NamesAndTypesList & available_columns) const = 0;
 
     virtual const MergeTreeDataPartChecksums & getChecksums() const = 0;

--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -107,6 +107,11 @@ bool IMergeTreeReader::isColumnDroppedByPendingMutation(size_t pos) const
     return alter_conversions && alter_conversions->isColumnDropped(columns_to_read[pos].getNameInStorage(), share_nested);
 }
 
+bool IMergeTreeReader::isSystemColumnInvalidated(size_t pos) const
+{
+    return data_part_info_for_read->isSystemColumnInvalidated(columns_to_read[pos].getNameInStorage());
+}
+
 void IMergeTreeReader::fillVirtualColumns(Columns & columns, size_t rows) const
 {
     chassert(columns.size() == getColumns().size());

--- a/src/Storages/MergeTree/IMergeTreeReader.h
+++ b/src/Storages/MergeTree/IMergeTreeReader.h
@@ -162,6 +162,9 @@ protected:
     /// Such columns should not be read from the part; defaults should be used instead.
     bool isColumnDroppedByPendingMutation(size_t pos) const;
 
+    /// Returns true if the column at position @pos in columns_to_read is a system column that was invalidated.
+    bool isSystemColumnInvalidated(size_t pos) const;
+
 private:
     friend class MergeTreeReaderIndex;
     friend class MergeTreeReaderTextIndex;

--- a/src/Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h
+++ b/src/Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h
@@ -58,6 +58,8 @@ public:
 
     std::optional<size_t> getColumnPosition(const String & column_name) const override { return data_part->getColumnPosition(column_name); }
 
+    bool isSystemColumnInvalidated(const String & column_name) const override { return data_part->isSystemColumnInvalidated(column_name); }
+
     AlterConversionsPtr getAlterConversions() const override { return alter_conversions; }
 
     String getColumnNameWithMinimumCompressedSize(const NamesAndTypesList & available_columns) const override

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -1268,7 +1268,7 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::prepareProjectionsToMergeAndRe
             global_ctx->projections_to_merge.push_back(&projection);
             global_ctx->projections_to_merge_parts[projection.name].assign(projection_parts.begin(), projection_parts.end());
         }
-        else if (projection.with_block_number)
+        else if (projection.with_block_number || projection.with_block_offset)
         {
             /// Commit-order projections are not written during insert (block number is not yet finalized).
             /// When some source parts don't have the projection, rebuild it during the horizontal phase
@@ -2352,7 +2352,7 @@ bool MergeTask::MergeTextIndexStage::prepare() const
             {
                 const auto & part = global_ctx->future_part->parts[part_idx];
 
-                if (index_ptr->getDeserializedFormat(part->checksums, index_ptr->getFileName(), &part->getDataPartStorage()))
+                if (index_ptr->getDeserializedFormat(*part, index_ptr->getFileName()))
                 {
                     /// If text index exists in the source part, take it as is.
                     segments.emplace_back(part->getDataPartStoragePtr(), index_ptr->getFileName(), part_idx);
@@ -2929,7 +2929,7 @@ void MergeTask::addBuildTextIndexesStep(QueryPlan & plan, const IMergeTreeDataPa
 
         /// Rebuild index if merge may reduce rows because we cannot adjust parts offsets in that case.
         /// Build index if it is not materialized in the data part.
-        if (global_ctx->merge_may_reduce_rows || !index_ptr->getDeserializedFormat(data_part.checksums, index_ptr->getFileName(), &data_part.getDataPartStorage()))
+        if (global_ctx->merge_may_reduce_rows || !index_ptr->getDeserializedFormat(data_part, index_ptr->getFileName()))
         {
             description_to_build.push_back(index);
             indexes_to_build.push_back(std::move(index_ptr));

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7323,6 +7323,7 @@ void MergeTreeData::loadPartAndFixMetadataImpl(MergeTreeData::MutableDataPartPtr
     /// If the part has no metadata_version.txt (very old parts), the fallback in
     /// loadColumnsChecksumsIndexes will use the table's current version with a special flag.
 
+    IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*part->getDataPartStoragePtr(), "", {BlockNumberColumn::name, BlockOffsetColumn::name}, getContext()->getWriteSettings());
     part->loadColumnsChecksumsIndexes(false, true);
     part->modification_time = part->getDataPartStorage().getLastModified().epochTime();
     part->removeDeleteOnDestroyMarker();
@@ -8357,6 +8358,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeData::loadPartRestoredFromBackup(cons
         builder.withPartFormatFromDisk();
         part = std::move(builder).build();
         part->version->setAndStoreCreationTID(Tx::NonTransactionalTID, nullptr);
+        IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*part->getDataPartStoragePtr(), "", {BlockNumberColumn::name, BlockOffsetColumn::name}, getContext()->getWriteSettings());
         part->loadColumnsChecksumsIndexes(/* require_columns_checksums= */ false, /* check_consistency= */ true);
         /// UNIQUE KEY: a restored part may not ship its `unique_key_index.sst`
         /// (older backup, or one taken before UK). Build it here so the part is

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -2488,7 +2488,7 @@ std::pair<MarkRanges, RangesInDataPartReadHints> MergeTreeDataSelectExecutor::fi
     PartialDisjunctionResult & partial_disjunction_result,
     LoggerPtr log)
 {
-    if (!index_helper->getDeserializedFormat(part->checksums, index_helper->getFileName(), &part->getDataPartStorage()))
+    if (!index_helper->getDeserializedFormat(*part, index_helper->getFileName()))
     {
         LOG_DEBUG(log, "File for index {} does not exist ({}.*). Skipping it.", backQuote(index_helper->index.name),
             (fs::path(part->getDataPartStorage().getFullPath()) / index_helper->getFileName()).string());
@@ -2865,7 +2865,7 @@ MergeTreeIndexBulkGranulesMinMaxPtr MergeTreeDataSelectExecutor::getMinMaxIndexG
     UncompressedCache * uncompressed_cache,
     VectorSimilarityIndexCache * vector_similarity_index_cache)
 {
-    if (!skip_index_minmax->getDeserializedFormat(part->checksums, skip_index_minmax->getFileName(), &part->getDataPartStorage()))
+    if (!skip_index_minmax->getDeserializedFormat(*part, skip_index_minmax->getFileName()))
     {
         return nullptr;
     }

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -254,15 +254,18 @@ MergeTreeIndexConditionPtr MergeTreeIndexMinMax::createIndexCondition(
     return std::make_shared<MergeTreeIndexConditionMinMax>(index, filter_dag, context);
 }
 
-MergeTreeIndexFormat MergeTreeIndexMinMax::getDeserializedFormat(
-    const MergeTreeDataPartChecksums & checksums,
-    const std::string & relative_path_prefix,
-    const IDataPartStorage * storage) const
+MergeTreeIndexFormat MergeTreeIndexMinMax::getDeserializedFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const
 {
-    if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx2", storage))
+    for (const auto & [column, _] : getColumnsWithTypesRequiredForIndexCalc())
+        if (part.isSystemColumnInvalidated(column))
+            return {0 /*unknown*/, {}};
+
+    if (indexFileExistsInChecksums(part.checksums, relative_path_prefix, ".idx2", &part.getDataPartStorage()))
         return {2, {{MergeTreeIndexSubstream::Type::Regular, "", ".idx2"}}};
-    if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx", storage))
+
+    if (indexFileExistsInChecksums(part.checksums, relative_path_prefix, ".idx", &part.getDataPartStorage()))
         return {1, {{MergeTreeIndexSubstream::Type::Regular, "", ".idx"}}};
+
     return {0 /* unknown */, {}};
 }
 

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.h
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.h
@@ -87,10 +87,7 @@ public:
         const ActionsDAG::Node * predicate, ContextPtr context) const override;
 
     MergeTreeIndexSubstreams getSubstreams() const override { return {{MergeTreeIndexSubstream::Type::Regular, "", ".idx2"}}; }
-    MergeTreeIndexFormat getDeserializedFormat(
-        const MergeTreeDataPartChecksums & checksums,
-        const std::string & path_prefix,
-        const IDataPartStorage * storage) const override;
+    MergeTreeIndexFormat getDeserializedFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const override;
 };
 
 struct MergeTreeIndexBulkGranulesMinMax final : public IMergeTreeIndexBulkGranules

--- a/src/Storages/MergeTree/MergeTreeIndexReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexReader.cpp
@@ -82,7 +82,7 @@ void MergeTreeIndexReader::initStreamIfNeeded()
     if (!streams.empty())
         return;
 
-    auto index_format = index->getDeserializedFormat(part->checksums, index->getFileName(), &part->getDataPartStorage());
+    auto index_format = index->getDeserializedFormat(*part, index->getFileName());
     auto index_name = index->getFileName();
     auto last_mark = getLastMark(all_mark_ranges);
 

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1779,12 +1779,13 @@ MergeTreeIndexSubstreams MergeTreeIndexText::getSubstreams() const
     return substreams;
 }
 
-MergeTreeIndexFormat MergeTreeIndexText::getDeserializedFormat(
-    const MergeTreeDataPartChecksums & checksums,
-    const std::string & path_prefix,
-    const IDataPartStorage * storage) const
+MergeTreeIndexFormat MergeTreeIndexText::getDeserializedFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const
 {
-    if (!indexFileExistsInChecksums(checksums, path_prefix, ".idx", storage))
+    for (const auto & [column, _] : getColumnsWithTypesRequiredForIndexCalc())
+        if (part.isSystemColumnInvalidated(column))
+            return {0, {}};
+
+    if (!indexFileExistsInChecksums(part.checksums, relative_path_prefix, ".idx", &part.getDataPartStorage()))
         return {0, {}};
 
     MergeTreeIndexSubstreams substreams =
@@ -1795,7 +1796,7 @@ MergeTreeIndexFormat MergeTreeIndexText::getDeserializedFormat(
     };
 
     /// V2: positions file exists on disk.
-    if (indexFileExistsInChecksums(checksums, path_prefix + ".pos", ".idx", storage))
+    if (indexFileExistsInChecksums(part.checksums, relative_path_prefix + ".pos", ".idx", part.getDataPartStoragePtr().get()))
     {
         substreams.push_back({MergeTreeIndexSubstream::Type::TextIndexPositions, ".pos", ".idx"});
         return {2, std::move(substreams)};

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -543,10 +543,7 @@ public:
     bool isTextIndex() const override { return true; }
 
     MergeTreeIndexSubstreams getSubstreams() const override;
-    MergeTreeIndexFormat getDeserializedFormat(
-        const MergeTreeDataPartChecksums & checksums,
-        const std::string & path_prefix,
-        const IDataPartStorage * storage) const override;
+    MergeTreeIndexFormat getDeserializedFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const override;
 
     MergeTreeIndexGranulePtr createIndexGranule() const override;
     MergeTreeIndexAggregatorPtr createIndexAggregator() const override;

--- a/src/Storages/MergeTree/MergeTreeIndices.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndices.cpp
@@ -5,6 +5,7 @@
 #include <Columns/IColumn.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Storages/MergeTree/IDataPartStorage.h>
+#include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Common/escapeForFileName.h>
 #include <Common/SipHash.h>
 
@@ -63,12 +64,18 @@ Names IMergeTreeIndex::getColumnsRequiredForIndexCalc() const
     return index.expression->getRequiredColumns();
 }
 
-MergeTreeIndexFormat IMergeTreeIndex::getDeserializedFormat(
-    const MergeTreeDataPartChecksums & checksums,
-    const std::string & relative_path_prefix,
-    const IDataPartStorage * storage) const
+const NamesAndTypesList & IMergeTreeIndex::getColumnsWithTypesRequiredForIndexCalc() const
 {
-    if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx", storage))
+    return index.expression->getRequiredColumnsWithTypes();
+}
+
+MergeTreeIndexFormat IMergeTreeIndex::getDeserializedFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const
+{
+    for (const auto & [column, _] : getColumnsWithTypesRequiredForIndexCalc())
+        if (part.isSystemColumnInvalidated(column))
+            return {0 /*unknown*/, {}};
+
+    if (indexFileExistsInChecksums(part.checksums, relative_path_prefix, ".idx", &part.getDataPartStorage()))
         return {1, {{MergeTreeIndexSubstream::Type::Regular, "", ".idx"}}};
 
     return {0 /*unknown*/, {}};

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -4,6 +4,7 @@
 #include <Common/Documentation.h>
 #include <Storages/IndicesDescription.h>
 #include <Interpreters/ActionsDAG.h>
+#include <Storages/MergeTree/Compaction/PartProperties.h>
 #include <Storages/MergeTree/KeyCondition.h>
 #include <Storages/MergeTree/ConditionTemplate.h>
 #include <Storages/MergeTree/MergeTreeIndicesSerialization.h>
@@ -18,6 +19,7 @@ namespace DB
 {
 
 class IDataPartStorage;
+class IMergeTreeDataPart;
 
 namespace Internal
 {
@@ -269,10 +271,7 @@ struct IMergeTreeIndex
     /// Returns substreams and version for deserialization. @storage is consulted so that packed
     /// substreams (whose virtual filenames are not in @checksums) can still be discovered via
     /// the skp_idx.packed overlay. Passing null disables the archive check.
-    virtual MergeTreeIndexFormat getDeserializedFormat(
-        const MergeTreeDataPartChecksums & checksums,
-        const std::string & relative_path_prefix,
-        const IDataPartStorage * storage) const;
+    virtual MergeTreeIndexFormat getDeserializedFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const;
 
     virtual MergeTreeIndexGranulePtr createIndexGranule() const = 0;
 
@@ -307,6 +306,7 @@ struct IMergeTreeIndex
     virtual bool isInert() const { return false; }
 
     Names getColumnsRequiredForIndexCalc() const;
+    const NamesAndTypesList & getColumnsWithTypesRequiredForIndexCalc() const;
 
     StorageMetadataPtr metadata_snapshot;
     const IndexDescription & index;

--- a/src/Storages/MergeTree/MergeTreeReadTask.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadTask.cpp
@@ -146,7 +146,7 @@ static const IndexReadTask * getIndexReadTaskForReadStep(const IndexReadTasks & 
     const auto & index_task = index_read_tasks.at(index_for_step);
     const auto & index = index_task.index.index;
 
-    if (!index->getDeserializedFormat(data_part.checksums, index->getFileName(), &data_part.getDataPartStorage()))
+    if (!index->getDeserializedFormat(data_part, index->getFileName()))
         return nullptr;
 
     return &index_task;

--- a/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
@@ -80,8 +80,8 @@ void MergeTreeReaderCompact::fillColumnPositions()
         auto & column_to_read = columns_to_read[i];
         auto position = data_part_info_for_read->getColumnPosition(column_to_read.getNameInStorage());
 
-        /// Column was dropped by a pending mutation. Don't read stale data; let defaults be used.
-        if (position.has_value() && isColumnDroppedByPendingMutation(i))
+        /// Column was dropped by a pending mutation or invalidated. Don't read stale data;
+        if (position.has_value() && (isColumnDroppedByPendingMutation(i) || isSystemColumnInvalidated(i)))
             position.reset();
 
         if (position.has_value() && column_to_read.isSubcolumn())

--- a/src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp
@@ -79,7 +79,7 @@ MergeTreeReaderTextIndex::MergeTreeReaderTextIndex(
     prebuilt_cursors.resize(columns_.size());
 
     auto data_part = getDataPart();
-    auto index_format = index.index->getDeserializedFormat(data_part->checksums, index.index->getFileName(), &data_part->getDataPartStorage());
+    auto index_format = index.index->getDeserializedFormat(*data_part, index.index->getFileName());
     chassert(index_format);
 
     MergeTreeIndexDeserializationState state
@@ -384,7 +384,7 @@ void MergeTreeReaderTextIndex::initializePositionsStream()
 {
     const auto & data_part = getDataPart();
 
-    auto index_format = index.index->getDeserializedFormat(data_part->checksums, index.index->getFileName(), &data_part->getDataPartStorage());
+    auto index_format = index.index->getDeserializedFormat(*data_part, index.index->getFileName());
     if (index_format.version != 2)
         return;
 

--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -65,7 +65,8 @@ MergeTreeReaderWide::MergeTreeReaderWide(
     {
         for (size_t i = 0; i < columns_to_read.size(); ++i)
         {
-            if (!isColumnDroppedByPendingMutation(i))
+            /// Column was dropped by a pending mutation or invalidated. Don't read stale data;
+            if (!isColumnDroppedByPendingMutation(i) && !isSystemColumnInvalidated(i))
                 addStreams(columns_to_read[i], serializations[i]);
         }
     }
@@ -132,7 +133,7 @@ void MergeTreeReaderWide::prefetchForAllColumns(
     /// so if reading can be asynchronous, it will also be performed in parallel for all columns.
     for (size_t pos = 0; pos < num_columns; ++pos)
     {
-        if (isColumnDroppedByPendingMutation(pos))
+        if (isColumnDroppedByPendingMutation(pos) || isSystemColumnInvalidated(pos))
             continue;
 
         try
@@ -175,8 +176,7 @@ size_t MergeTreeReaderWide::readRows(
 
         for (size_t pos = 0; pos < num_columns; ++pos)
         {
-            /// Column was dropped by a pending mutation. Don't read stale data; let defaults be used.
-            if (isColumnDroppedByPendingMutation(pos))
+            if (isColumnDroppedByPendingMutation(pos) || isSystemColumnInvalidated(pos))
             {
                 res_columns[pos] = nullptr;
                 continue;
@@ -495,7 +495,7 @@ void MergeTreeReaderWide::deserializePrefixForAllColumnsImpl(size_t num_columns,
         DeserializeBinaryBulkStateMap deserialize_state_map;
         for (size_t pos = 0; pos < num_columns; ++pos)
         {
-            if (isColumnDroppedByPendingMutation(pos))
+            if (isColumnDroppedByPendingMutation(pos) || isSystemColumnInvalidated(pos))
                 continue;
 
             try

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1084,6 +1084,9 @@ static NameSet collectFilesToSkip(
     /// Do not hardlink this file because it's always rewritten at the end of mutation.
     files_to_skip.insert(IMergeTreeDataPart::SERIALIZATION_FILE_NAME);
 
+    /// We need to hardlink this file because otherwise hardlinked persistent virtual columns may be rolled back.
+    files_to_skip.erase(IMergeTreeDataPart::INVALIDATED_SYSTEM_COLUMNS_FILE_NAME);
+
     auto skip_index = [&files_to_skip, &mrk_extension, &source_part](const MergeTreeIndexPtr & index)
     {
         /// The substream may live on disk under either its logical name (skp_idx_<name>) or a
@@ -2626,6 +2629,7 @@ private:
         (*ctx->mutate_entry)->columns_written = ctx->storage_columns.size() - ctx->updated_header.columns();
 
         ctx->new_data_part->checksums = ctx->source_part->checksums;
+        ctx->new_data_part->invalidated_system_columns = ctx->source_part->invalidated_system_columns;
 
         /// When the archive will not be hardlinked from source (packed_skip_index_archive_dirty),
         /// the inherited skp_idx.packed entry must not survive untouched into the new part's

--- a/src/Storages/MergeTree/PatchParts/RangesInPatchParts.cpp
+++ b/src/Storages/MergeTree/PatchParts/RangesInPatchParts.cpp
@@ -269,7 +269,7 @@ MaybeMinMaxStats getPatchMinMaxStats(const DataPartPtr & patch_part, const MarkR
     static const MergeTreeSettings default_settings;
     auto index_ptr = MergeTreeIndexFactory::instance().get(metadata_snapshot, *it, default_settings);
     /// Check that index exists in data part. It may be absent for parts created in earlier versions.
-    if (!index_ptr->getDeserializedFormat(patch_part->checksums, index_ptr->getFileName(), &patch_part->getDataPartStorage()))
+    if (!index_ptr->getDeserializedFormat(*patch_part, index_ptr->getFileName()))
         return {};
 
     size_t total_marks_without_final = patch_part->index_granularity->getMarksCountWithoutFinal();

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -48,6 +48,7 @@
 #include <Storages/MergeTree/MergeTreeMutationStatus.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/MergeTreeSink.h>
+#include <Storages/MergeTree/MergeTreeVirtualColumns.h>
 #include <Storages/MergeTree/MergeTreeSinkPatch.h>
 #include <Storages/MergeTree/PatchParts/PatchPartsUtils.h>
 #include <Storages/MergeTree/checkDataPart.h>
@@ -3072,7 +3073,11 @@ void StorageMergeTree::replacePartitionFrom(const StoragePtr & source_table, con
         Int64 temp_index = insert_increment.get();
         MergeTreePartInfo dst_part_info(partition_id, temp_index, temp_index, getLevelForAdoptedPart(src_data, src_part->info.level));
 
-        IDataPartStorage::ClonePartParams clone_params{.txn = local_context->getCurrentTransaction()};
+        IDataPartStorage::ClonePartParams clone_params
+        {
+            .txn = local_context->getCurrentTransaction(),
+            .invalidated_columns_to_write = {BlockNumberColumn::name, BlockOffsetColumn::name},
+        };
         if (replace)
         {
             /// Replace can only work on the same disk
@@ -3267,6 +3272,7 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
         {
             .txn = local_context->getCurrentTransaction(),
             .copy_instead_of_hardlink = (*getSettings())[MergeTreeSetting::always_use_copy_instead_of_hardlinks],
+            .invalidated_columns_to_write = {BlockNumberColumn::name, BlockOffsetColumn::name},
         };
 
         auto [dst_part, part_lock] = dest_table_storage->cloneAndLoadDataPart(

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -55,6 +55,7 @@
 #include <Storages/MergeTree/MergeTreeReaderCompact.h>
 #include <Storages/MergeTree/MergeTreeMutationStatus.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
+#include <Storages/MergeTree/MergeTreeVirtualColumns.h>
 #include <Storages/MergeTree/MutateFromLogEntryTask.h>
 #include <Storages/MergeTree/OverlappingPartCovering.h>
 #include <Storages/MergeTree/PinnedPartUUIDs.h>
@@ -3353,7 +3354,8 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
             IDataPartStorage::ClonePartParams clone_params
             {
                 .copy_instead_of_hardlink = (*storage_settings_ptr)[MergeTreeSetting::always_use_copy_instead_of_hardlinks] || ((our_zero_copy_enabled || source_zero_copy_enabled) && part_desc->src_table_part->isStoredOnRemoteDiskWithZeroCopySupport()),
-                .metadata_version_to_write = metadata_snapshot->getMetadataVersion()
+                .metadata_version_to_write = metadata_snapshot->getMetadataVersion(),
+                .invalidated_columns_to_write = {BlockNumberColumn::name, BlockOffsetColumn::name},
             };
             auto [res_part, temporary_part_lock] = cloneAndLoadDataPart(
                 part_desc->src_table_part,
@@ -9281,7 +9283,8 @@ std::unique_ptr<ReplicatedMergeTreeLogEntryData> StorageReplicatedMergeTree::rep
             IDataPartStorage::ClonePartParams clone_params
             {
                 .copy_instead_of_hardlink = always_use_copy_instead_of_hardlinks || (zero_copy_enabled && src_part->isStoredOnRemoteDiskWithZeroCopySupport()),
-                .metadata_version_to_write = metadata_snapshot->getMetadataVersion()
+                .metadata_version_to_write = metadata_snapshot->getMetadataVersion(),
+                .invalidated_columns_to_write = {BlockNumberColumn::name, BlockOffsetColumn::name},
             };
             if (replace)
             {
@@ -9572,7 +9575,8 @@ void StorageReplicatedMergeTree::movePartitionToTable(const StoragePtr & dest_ta
             IDataPartStorage::ClonePartParams clone_params
             {
                 .copy_instead_of_hardlink = (*storage_settings_ptr)[MergeTreeSetting::always_use_copy_instead_of_hardlinks] || (zero_copy_enabled && src_part->isStoredOnRemoteDiskWithZeroCopySupport()),
-                .metadata_version_to_write = dest_metadata_snapshot->getMetadataVersion()
+                .metadata_version_to_write = dest_metadata_snapshot->getMetadataVersion(),
+                .invalidated_columns_to_write = {BlockNumberColumn::name, BlockOffsetColumn::name},
             };
             auto [dst_part, dst_part_lock] = dest_table_storage->cloneAndLoadDataPart(
                 src_part,

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -87,6 +87,7 @@ FILES_OVERHEAD_PER_PART_COMPACT = (
     + FILES_OVERHEAD_METADATA_VERSION
     + FILES_OVERHEAD_COLUMNS_SUBSTREAMS
 )
+FILES_OVERHEAD_PER_INVALIDATED_COLUMN = 1
 
 
 def create_table(node, table_name, **additional_settings):
@@ -412,7 +413,7 @@ def test_attach_detach_partition(cluster, node_name):
 
     node.query("ALTER TABLE s3_test ATTACH PARTITION '2020-01-03'")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(8192)"
-    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2)
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2 + FILES_OVERHEAD_PER_INVALIDATED_COLUMN)
 
     node.query("ALTER TABLE s3_test DROP PARTITION '2020-01-03'")
     wait_for_delete_empty_parts(node, "s3_test")
@@ -431,7 +432,7 @@ def test_attach_detach_partition(cluster, node_name):
         settings={"allow_drop_detached": 1},
     )
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(0)"
-    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 0)
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD)
 
     check_no_objects_after_drop(cluster)
 
@@ -534,7 +535,8 @@ def test_move_replace_partition_to_another_table(cluster, node_name):
         cluster,
         FILES_OVERHEAD * 2
         + FILES_OVERHEAD_PER_PART_WIDE * 4
-        - FILES_OVERHEAD_METADATA_VERSION * 2,
+        - FILES_OVERHEAD_METADATA_VERSION * 2
+        + FILES_OVERHEAD_PER_INVALIDATED_COLUMN * 2,
     )
 
     # Add new partitions to source table, but with different values and replace them from copied table.
@@ -552,7 +554,8 @@ def test_move_replace_partition_to_another_table(cluster, node_name):
         cluster,
         FILES_OVERHEAD * 2
         + FILES_OVERHEAD_PER_PART_WIDE * 6
-        - FILES_OVERHEAD_METADATA_VERSION * 2,
+        - FILES_OVERHEAD_METADATA_VERSION * 2
+        + FILES_OVERHEAD_PER_INVALIDATED_COLUMN * 2,
     )
 
     node.query("ALTER TABLE s3_test REPLACE PARTITION '2020-01-03' FROM s3_clone")
@@ -567,7 +570,8 @@ def test_move_replace_partition_to_another_table(cluster, node_name):
         cluster,
         FILES_OVERHEAD * 2
         + FILES_OVERHEAD_PER_PART_WIDE * 4
-        - FILES_OVERHEAD_METADATA_VERSION * 2,
+        - FILES_OVERHEAD_METADATA_VERSION * 2
+        + FILES_OVERHEAD_PER_INVALIDATED_COLUMN * 4,
     )
 
     node.query("DROP TABLE s3_clone SYNC")
@@ -579,7 +583,8 @@ def test_move_replace_partition_to_another_table(cluster, node_name):
         cluster,
         FILES_OVERHEAD
         + FILES_OVERHEAD_PER_PART_WIDE * 4
-        - FILES_OVERHEAD_METADATA_VERSION * 2,
+        - FILES_OVERHEAD_METADATA_VERSION * 2
+        + FILES_OVERHEAD_PER_INVALIDATED_COLUMN * 2,
     )
 
     node.query("ALTER TABLE s3_test FREEZE")
@@ -589,7 +594,8 @@ def test_move_replace_partition_to_another_table(cluster, node_name):
         cluster,
         FILES_OVERHEAD
         + FILES_OVERHEAD_PER_PART_WIDE * 4
-        - FILES_OVERHEAD_METADATA_VERSION * 2,
+        - FILES_OVERHEAD_METADATA_VERSION * 2
+        + FILES_OVERHEAD_PER_INVALIDATED_COLUMN * 2,
     )
 
     node.query("DROP TABLE s3_test SYNC")

--- a/tests/queries/0_stateless/04411_block_number_wide_part_mutations.reference
+++ b/tests/queries/0_stateless/04411_block_number_wide_part_mutations.reference
@@ -1,0 +1,39 @@
+insert	1	1	1	0
+insert	2	1	1	1
+insert	3	1	2	0
+insert	4	1	2	1
+
+DETACH ATTACH
+attach	1	1	3	0
+attach	2	1	3	1
+attach	3	1	4	0
+attach	4	1	4	1
+
+ALTER TABLE t UPDATE b = 2 WHERE a = 1
+update	1	2	3	0
+update	2	1	3	1
+update	3	1	4	0
+update	4	1	4	1
+
+ALTER TABLE t UPDATE b = 3 WHERE a = 2
+update_again	1	2	3	0
+update_again	2	3	3	1
+update_again	3	1	4	0
+update_again	4	1	4	1
+
+ALTER TABLE t DELETE WHERE a = 4
+delete	1	2	3	0
+delete	2	3	3	1
+delete	3	1	4	0
+
+OPTIMIZE TABLE t FINAL
+merge	1	2	3	0
+merge	2	3	3	1
+merge	3	1	4	0
+
+INSERT INTO t VALUES (5, 1), (6, 1)
+merge_after_insert	1	2	3	0
+merge_after_insert	2	3	3	1
+merge_after_insert	3	1	4	0
+merge_after_insert	5	1	8	0
+merge_after_insert	6	1	8	1

--- a/tests/queries/0_stateless/04411_block_number_wide_part_mutations.sql
+++ b/tests/queries/0_stateless/04411_block_number_wide_part_mutations.sql
@@ -1,0 +1,50 @@
+DROP TABLE IF EXISTS t;
+
+-- Wide + full storage (so columns are hardlinked) with persisted _block_number/_block_offset.
+CREATE TABLE t (a UInt64, b UInt64) ENGINE = MergeTree ORDER BY a
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, min_bytes_for_full_part_storage = 0,
+         always_use_copy_instead_of_hardlinks = 0;
+
+SET mutations_sync = 1;
+
+INSERT INTO t VALUES (1, 1), (2, 1);
+INSERT INTO t VALUES (3, 1), (4, 1);
+
+SELECT 'insert', a, b, _block_number, _block_offset FROM t ORDER BY a;
+SELECT '';
+
+-- Re-home before any read: rows get fresh block numbers, offsets become part offsets.
+ALTER TABLE t DETACH PARTITION tuple();
+ALTER TABLE t ATTACH PARTITION tuple();
+SELECT 'DETACH ATTACH';
+SELECT 'attach', a, b, _block_number, _block_offset FROM t ORDER BY a;
+SELECT '';
+
+-- Partial mutations must keep the post-attach block, not the stale on-disk one.
+ALTER TABLE t UPDATE b = 2 WHERE a = 1;
+SELECT 'ALTER TABLE t UPDATE b = 2 WHERE a = 1';
+SELECT 'update', a, b, _block_number, _block_offset FROM t ORDER BY a;
+SELECT '';
+
+ALTER TABLE t UPDATE b = 3 WHERE a = 2;
+SELECT 'ALTER TABLE t UPDATE b = 3 WHERE a = 2';
+SELECT 'update_again', a, b, _block_number, _block_offset FROM t ORDER BY a;
+SELECT '';
+
+ALTER TABLE t DELETE WHERE a = 4;
+SELECT 'ALTER TABLE t DELETE WHERE a = 4';
+SELECT 'delete', a, b, _block_number, _block_offset FROM t ORDER BY a;
+SELECT '';
+
+OPTIMIZE TABLE t FINAL;
+SELECT 'OPTIMIZE TABLE t FINAL';
+SELECT 'merge', a, b, _block_number, _block_offset FROM t ORDER BY a;
+SELECT '';
+
+INSERT INTO t VALUES (5, 1), (6, 1);
+OPTIMIZE TABLE t FINAL;
+SELECT 'INSERT INTO t VALUES (5, 1), (6, 1)';
+SELECT 'merge_after_insert', a, b, _block_number, _block_offset FROM t ORDER BY a;
+
+DROP TABLE t;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

During attach/detach/move/clone part manipulations, materialized into part `block_number` and `block_offset` become stale. This patch changes the behavior to regenerate these columns.

Fix is implemented as a materialization of an additional file, `invalidated_system_columns.txt`, which will not be included in packed/compact archives and will be written during attach/clone partition operations. 
