### PR TITLE
Fix stale rows in a normal projection after lightweight DELETE in rebuild mode

### DIFF
--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -3,6 +3,7 @@
 
 #include <Access/AccessControl.h>
 #include <Columns/ColumnConst.h>
+#include <Columns/ColumnsNumber.h>
 #include <Common/iota.h>
 #include <Core/Defines.h>
 #include <Core/Settings.h>
@@ -700,13 +701,20 @@ Block ProjectionDescription::calculateByQuery(
 
     ASTPtr query_ast_copy = nullptr;
 
+    /// A normal projection with no WHERE runs at `QueryProcessingStage::FetchColumns`, which stops
+    /// before the WHERE step, so injecting `_row_exists = 1` into the query is silently ignored and
+    /// lightweight-deleted rows stay in the rebuilt projection (issue #111791). For that path the
+    /// deleted rows are dropped from the input block directly below instead.
+    const bool filter_deleted_rows_in_source
+        = block.has(RowExistsColumn::name) && type == ProjectionDescription::Type::Normal && !where_clause_ast;
+
     /// Only keep required columns
     Block source_block;
     for (const auto & column : required_columns)
         source_block.insert(block.getByName(column));
 
     /// Respect the _row_exists column.
-    if (block.has(RowExistsColumn::name))
+    if (block.has(RowExistsColumn::name) && !filter_deleted_rows_in_source)
     {
         query_ast_copy = query_ast->clone();
         auto * select_row_exists = query_ast_copy->as<ASTSelectQuery>();
@@ -755,6 +763,16 @@ Block ProjectionDescription::calculateByQuery(
         }
 
         source_block.insert({std::move(column), std::move(uint64), "_part_offset"});
+    }
+
+    /// Filter every source column (including `_part_offset`, so surviving rows keep their original
+    /// parent offsets) by the deletion mask. `_row_exists` may be const-folded, so materialize it.
+    if (filter_deleted_rows_in_source)
+    {
+        auto row_exists = block.getByName(RowExistsColumn::name).column->convertToFullColumnIfConst();
+        const auto & filter = assert_cast<const ColumnUInt8 &>(*row_exists).getData();
+        for (auto & col : source_block)
+            col.column = col.column->filter(filter, /*result_size_hint=*/ -1);
     }
 
     auto builder = InterpreterSelectQuery(

--- a/tests/queries/0_stateless/04627_lwd_rebuild_normal_projection_no_where.reference
+++ b/tests/queries/0_stateless/04627_lwd_rebuild_normal_projection_no_where.reference
@@ -1,0 +1,14 @@
+compact storage	Compact	Full
+compact base rows	90
+compact projection rows	90
+compact deleted leaked via projection	0
+compact projection == no-projection	1
+wide storage	Wide	Full
+wide base rows	90
+wide projection rows	90
+wide deleted leaked via projection	0
+wide projection == no-projection	1
+offset base rows	90
+offset projection rows	90
+offset deleted in projection	0
+offset parent-offset matches	90	90

--- a/tests/queries/0_stateless/04627_lwd_rebuild_normal_projection_no_where.sql
+++ b/tests/queries/0_stateless/04627_lwd_rebuild_normal_projection_no_where.sql
@@ -1,0 +1,96 @@
+-- A lightweight DELETE in rebuild mode must rebuild a normal (non-aggregate) projection
+-- that has no WHERE clause. Such a projection is calculated at FetchColumns stage, which
+-- skips the injected `_row_exists = 1` filter, so before the fix the rebuilt projection
+-- kept every deleted row and a projection read-in-order returned stale (deleted) rows.
+-- See issue #111791. Both Compact (MutateAllPartColumns) and Wide (MutateSomePartColumns)
+-- parts are covered. The projection sort key (g, id) matches the query ORDER BY so the
+-- optimizer can serve the ORDER BY ... LIMIT read from the projection; force_optimize_projection
+-- makes that read mandatory so the assertions actually exercise the projection.
+SET mutations_sync = 2, lightweight_deletes_sync = 2;
+
+-- Compact part
+DROP TABLE IF EXISTS t_lwd_norm_proj_compact;
+CREATE TABLE t_lwd_norm_proj_compact (id UInt64, g UInt8, v Int64,
+    PROJECTION p (SELECT id, g, v ORDER BY (g, id)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS lightweight_mutation_projection_mode = 'rebuild', index_granularity = 4,
+         min_bytes_for_wide_part = 10485760, min_bytes_for_full_part_storage = 0;
+
+INSERT INTO t_lwd_norm_proj_compact SELECT number, number % 7, number * 10 FROM numbers(100);
+DELETE FROM t_lwd_norm_proj_compact WHERE id % 11 = 0;
+
+SELECT 'compact storage', part_type, part_storage_type FROM system.parts
+WHERE database = currentDatabase() AND table = 't_lwd_norm_proj_compact' AND active;
+
+-- 100 inserted, 10 deleted (id in {0,11,...,99}) => 90 rows survive in both base and projection.
+SELECT 'compact base rows', count() FROM t_lwd_norm_proj_compact;
+SELECT 'compact projection rows', sum(rows) FROM system.projection_parts
+WHERE database = currentDatabase() AND table = 't_lwd_norm_proj_compact' AND name = 'p' AND active;
+
+-- A read forced through the projection must not return deleted rows, and must match the same
+-- read without the projection.
+SELECT 'compact deleted leaked via projection', countIf(id % 11 = 0)
+FROM (SELECT id FROM t_lwd_norm_proj_compact WHERE g BETWEEN 2 AND 5 ORDER BY g, id LIMIT 20
+      SETTINGS optimize_use_projections = 1, force_optimize_projection = 1);
+
+SELECT 'compact projection == no-projection',
+    (SELECT groupArray(id) FROM (SELECT id FROM t_lwd_norm_proj_compact WHERE g BETWEEN 2 AND 5 ORDER BY g, id LIMIT 20 SETTINGS optimize_use_projections = 1, force_optimize_projection = 1))
+  = (SELECT groupArray(id) FROM (SELECT id FROM t_lwd_norm_proj_compact WHERE g BETWEEN 2 AND 5 ORDER BY g, id LIMIT 20 SETTINGS optimize_use_projections = 0));
+
+DROP TABLE t_lwd_norm_proj_compact;
+
+-- Wide part (MutateSomePartColumns path). Pin min_bytes_for_full_part_storage = 0 so the runner
+-- cannot randomize this small part into Packed storage, which would reroute to MutateAllPartColumns.
+DROP TABLE IF EXISTS t_lwd_norm_proj_wide;
+CREATE TABLE t_lwd_norm_proj_wide (id UInt64, g UInt8, v Int64,
+    PROJECTION p (SELECT id, g, v ORDER BY (g, id)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS lightweight_mutation_projection_mode = 'rebuild', index_granularity = 4,
+         min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage = 0;
+
+INSERT INTO t_lwd_norm_proj_wide SELECT number, number % 7, number * 10 FROM numbers(100);
+DELETE FROM t_lwd_norm_proj_wide WHERE id % 11 = 0;
+
+SELECT 'wide storage', part_type, part_storage_type FROM system.parts
+WHERE database = currentDatabase() AND table = 't_lwd_norm_proj_wide' AND active;
+
+SELECT 'wide base rows', count() FROM t_lwd_norm_proj_wide;
+SELECT 'wide projection rows', sum(rows) FROM system.projection_parts
+WHERE database = currentDatabase() AND table = 't_lwd_norm_proj_wide' AND name = 'p' AND active;
+
+SELECT 'wide deleted leaked via projection', countIf(id % 11 = 0)
+FROM (SELECT id FROM t_lwd_norm_proj_wide WHERE g BETWEEN 2 AND 5 ORDER BY g, id LIMIT 20
+      SETTINGS optimize_use_projections = 1, force_optimize_projection = 1);
+
+SELECT 'wide projection == no-projection',
+    (SELECT groupArray(id) FROM (SELECT id FROM t_lwd_norm_proj_wide WHERE g BETWEEN 2 AND 5 ORDER BY g, id LIMIT 20 SETTINGS optimize_use_projections = 1, force_optimize_projection = 1))
+  = (SELECT groupArray(id) FROM (SELECT id FROM t_lwd_norm_proj_wide WHERE g BETWEEN 2 AND 5 ORDER BY g, id LIMIT 20 SETTINGS optimize_use_projections = 0));
+
+DROP TABLE t_lwd_norm_proj_wide;
+
+-- Projection storing the parent `_part_offset` (with_parent_part_offset path). The deletion mask
+-- must filter the generated offset column too, so surviving rows keep their original parent offsets.
+DROP TABLE IF EXISTS t_lwd_norm_proj_offset;
+CREATE TABLE t_lwd_norm_proj_offset (a Int32, b Int32,
+    PROJECTION p (SELECT a, b, _part_offset ORDER BY b))
+ENGINE = MergeTree ORDER BY a
+SETTINGS lightweight_mutation_projection_mode = 'rebuild', index_granularity = 4, min_bytes_for_full_part_storage = 0;
+
+INSERT INTO t_lwd_norm_proj_offset SELECT number, number % 13 FROM numbers(100);
+DELETE FROM t_lwd_norm_proj_offset WHERE a % 11 = 0;
+
+SELECT 'offset base rows', count() FROM t_lwd_norm_proj_offset;
+SELECT 'offset projection rows', sum(rows) FROM system.projection_parts
+WHERE database = currentDatabase() AND table = 't_lwd_norm_proj_offset' AND name = 'p' AND active;
+
+-- No deleted row survives in the projection.
+SELECT 'offset deleted in projection', count()
+FROM mergeTreeProjection(currentDatabase(), t_lwd_norm_proj_offset, p) WHERE a % 11 = 0 SETTINGS enable_analyzer = 1;
+
+-- Every surviving projection row's _parent_part_offset equals the base row's _part_offset.
+SELECT 'offset parent-offset matches', sum(l._part_offset = r._parent_part_offset), count()
+FROM t_lwd_norm_proj_offset l
+JOIN mergeTreeProjection(currentDatabase(), t_lwd_norm_proj_offset, p) r USING (a)
+SETTINGS enable_analyzer = 1;
+
+DROP TABLE t_lwd_norm_proj_offset;


### PR DESCRIPTION

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
Closes: https://github.com/ClickHouse/ClickHouse/issues/111791


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a bug where a lightweight `DELETE` with `lightweight_mutation_projection_mode = 'rebuild'` did not remove the deleted rows from a normal (non-aggregate) `PROJECTION` that has no `WHERE` clause. A query served by such a projection (for example an `ORDER BY` matching the projection sort key) could return already-deleted rows.

### Description

A normal projection with no `WHERE` is calculated at `QueryProcessingStage::FetchColumns`, which stops before the `WHERE` step. The rebuild path injected `WHERE _row_exists = 1` into the projection query to drop the lightweight-deleted rows, but at `FetchColumns` that filter was never applied, so the projection was rebuilt from all rows including the deleted ones.

The deletion mask is a data-level filter that is independent of the projection query, so for the `FetchColumns` path the deleted rows are now dropped from the input block directly (the `_part_offset` column, when present, is filtered by the same mask so surviving rows keep their original parent offsets). This keeps `FetchColumns` (the projection part is sorted afterwards by `writeTempProjectionPart`, so no `ORDER BY` is needed during calculation). Filtered and aggregate projections already ran at `WithMergeableState` and applied the injected filter correctly; that path is unchanged.
