### PR TITLE
Fix flaky test_hedged_requests::test_async_connect

### DIFF
--- a/tests/integration/test_hedged_requests/test.py
+++ b/tests/integration/test_hedged_requests/test.py
@@ -7,6 +7,7 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from helpers.cluster import ClickHouseCluster
+from helpers.network import PartitionManager
 from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
@@ -432,28 +433,46 @@ def test_async_connect(started_cluster):
         Distributed('test_cluster_connect', 'default', 'test_hedged')"""
     )
 
-    NODES["node"].query(
-        "SELECT hostName(), id FROM distributed_connect ORDER BY id LIMIT 1 SETTINGS prefer_localhost_replica = 0, connect_timeout_with_failover_ms=5000, async_query_sending_for_remote=0, max_threads=1, max_distributed_connections=1"
-    )
-    check_changing_replica_events(2)
-    check_if_query_sending_was_not_suspended()
+    # The first replica of each shard in test_cluster_connect is an unreachable
+    # address (129.0.0.1 / 129.0.0.2). Silently drop the initiator's packets to
+    # them so the connect always stalls and is preempted by the
+    # hedged_connection_timeout_ms timer (the path HedgedRequestsChangeReplica
+    # counts). Otherwise, on slow builds the connect can fail fast (host
+    # unreachable), switching the replica through the connection-failure path,
+    # which does not increment that event.
+    with PartitionManager() as pm:
+        for unreachable_ip in ("129.0.0.1", "129.0.0.2"):
+            pm.add_rule(
+                {
+                    "instance": NODES["node"],
+                    "chain": "OUTPUT",
+                    "destination": unreachable_ip,
+                    "action": "DROP",
+                }
+            )
 
-    # Restart server to reset connection pool state
-    NODES["node"].restart_clickhouse()
-
-    attempt = 0
-    while attempt < 100:
         NODES["node"].query(
-            "SELECT hostName(), id FROM distributed_connect ORDER BY id LIMIT 1 SETTINGS prefer_localhost_replica = 0, connect_timeout_with_failover_ms=5000, async_query_sending_for_remote=1, max_threads=1, max_distributed_connections=1"
+            "SELECT hostName(), id FROM distributed_connect ORDER BY id LIMIT 1 SETTINGS prefer_localhost_replica = 0, connect_timeout_with_failover_ms=5000, async_query_sending_for_remote=0, max_threads=1, max_distributed_connections=1"
         )
-
         check_changing_replica_events(2)
-        if check_if_query_sending_was_suspended():
-            break
+        check_if_query_sending_was_not_suspended()
 
-        attempt += 1
+        # Restart server to reset connection pool state
+        NODES["node"].restart_clickhouse()
 
-    assert attempt < 100
+        attempt = 0
+        while attempt < 100:
+            NODES["node"].query(
+                "SELECT hostName(), id FROM distributed_connect ORDER BY id LIMIT 1 SETTINGS prefer_localhost_replica = 0, connect_timeout_with_failover_ms=5000, async_query_sending_for_remote=1, max_threads=1, max_distributed_connections=1"
+            )
+
+            check_changing_replica_events(2)
+            if check_if_query_sending_was_suspended():
+                break
+
+            attempt += 1
+
+        assert attempt < 100
 
     NODES["node"].query("DROP TABLE distributed_connect")
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110073
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #110073 (the CI triage that requested this fix in a separate PR)

`test_async_connect` verifies async-connect preemption: the first replica of each shard in
`test_cluster_connect` is an unreachable address (`129.0.0.1` / `129.0.0.2`), so the in-progress
connect must be preempted by the `hedged_connection_timeout_ms` timer and switch to the good
replica. That timer path is the only one counted by the `HedgedRequestsChangeReplica` event, and
the test asserts it fired (>= 2, one per shard).

The connect to an unreachable `129.0.0.x` address does not always stall. Depending on the
runner's network routing it can fail fast (host unreachable) before the 100 ms timer. A fast
failure switches the replica through the connection-failure path
(`ConnectionEstablisher`/`processFinishedConnection`), which increments
`DistributedConnectionFailTry`, not `HedgedRequestsChangeReplica`. When both shards fail fast the
event stays 0; `system.events` omits zero-valued events, so `SELECT value ... WHERE event=...`
returns an empty string and `int('')` raises `ValueError: invalid literal for int() with base 10: ''`.
Slow builds (ASan, MSan, coverage) hit the fast-fail path often enough to flake there while
master stays green.

Fix: in `test_async_connect`, drop the initiator's outbound packets to `129.0.0.1`/`129.0.0.2`
with `PartitionManager` (iptables `OUTPUT ... DROP`). A dropped SYN makes the connect stall, so
the hedged timer always fires and the replica change goes through the counted path. This keeps
the original assertion and the test's async-connect-preemption intent, and makes it
deterministic regardless of routing. The engine is not changed: hedged failover already reaches
the good replica on both paths; only the test's assumption about which path is taken was
fragile.

Cross-PR flake: 15 failures across 7 unrelated PRs over 90 days (first 2026-05-05), 0 on master.
Example CI report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110073&sha=a04d1dd1622603cebbf04ec8089fc6015db94b65&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%206%2F6%29
