### PR TITLE
Sync private #65699: skip snapshot data-part bookkeeping during UNLOCK

### DIFF
--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -726,20 +726,30 @@ void BackupImpl::readBackupMetadata()
             info.encrypted_by_disk = get_bool("encrypted_by_disk", false);
         }
 
-        file_names.emplace(info.file_name, std::pair{info.size, info.checksum});
         if (!info.object_key.empty())
         {
             if (original_endpoint.empty() || original_namespace.empty())
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "In lightweight snapshot backup, the endpoint or namespace should be not empty. We cannot restore this file.");
 
-            if (open_mode == OpenMode::READ)
-                lightweight_snapshot_reader = lightweight_snapshot_reader_creator(original_endpoint, original_namespace);
+            /// UNLOCK only reads table metadata to remove the snapshot's locks, never the data parts
+            /// (`object_key` entries). Skipping their bookkeeping avoids holding one `BackupFileInfo` per
+            /// part, which OOMs the server for snapshots with millions of parts.
+            if (open_mode != OpenMode::UNLOCK)
+            {
+                if (open_mode == OpenMode::READ)
+                    lightweight_snapshot_reader = lightweight_snapshot_reader_creator(original_endpoint, original_namespace);
 
-            file_object_keys.emplace(info.file_name, info.object_key);
-            lightweight_snapshot_file_infos.try_emplace(info.object_key, info);
+                file_names.emplace(info.file_name, std::pair{info.size, info.checksum});
+                file_object_keys.emplace(info.file_name, info.object_key);
+                lightweight_snapshot_file_infos.try_emplace(info.object_key, info);
+            }
         }
-        else if (info.size)
-            file_infos.try_emplace(std::pair{info.size, info.checksum}, info);
+        else
+        {
+            file_names.emplace(info.file_name, std::pair{info.size, info.checksum});
+            if (info.size)
+                file_infos.try_emplace(std::pair{info.size, info.checksum}, info);
+        }
 
         ++num_files;
         total_size += info.size;


### PR DESCRIPTION
`UNLOCK` (used by `UNLOCK SNAPSHOT`) opens the backup and, like a read, parses the whole `.backup` manifest. For a lightweight snapshot every data part is an entry carrying an `object_key`, and `readBackupMetadata` recorded each one in `file_names`, `file_object_keys` and `lightweight_snapshot_file_infos` (the last holding a full `BackupFileInfo` per part). For a snapshot with millions of parts this is gigabytes of memory.

The unlock path only reads table metadata to remove the snapshot's locks; it never lists or reads the data parts. This change skips populating those maps for `object_key` entries when `open_mode` is `UNLOCK`. Regular files are recorded exactly as before, and the read/restore path is unchanged.

Syncs clickhouse-private#65699.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduce memory usage of `UNLOCK SNAPSHOT` by not loading per-data-part metadata that the unlock path does not use, avoiding out-of-memory for snapshots with a very large number of parts.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.485` (included in `26.8` and later)
<!-- ch-version-info:end -->