### PR TITLE
Docs: remove incorrect note about optimize_on_insert and materialized views

### DIFF
--- a/docs/en/sql-reference/statements/create/view.md
+++ b/docs/en/sql-reference/statements/create/view.md
@@ -167,8 +167,6 @@ A `SELECT` query can contain `DISTINCT`, `GROUP BY`, `ORDER BY`, `LIMIT`. Note t
 
 If the materialized view uses the construction `TO [db.]name`, you can `DETACH` the view, run `ALTER` for the target table, and then `ATTACH` the previously detached (`DETACH`) view.
 
-Note that materialized view is influenced by [optimize_on_insert](/operations/settings/settings#optimize_on_insert) setting. The data is merged before the insertion into a view.
-
 Views look the same as normal tables. For example, they are listed in the result of the `SHOW TABLES` query.
 
 To delete a view, use [DROP VIEW](../../../sql-reference/statements/drop.md#drop-view). Although `DROP TABLE` works for VIEWs as well.

--- a/docs/reference/statements/create/view.mdx
+++ b/docs/reference/statements/create/view.mdx
@@ -164,8 +164,6 @@ A `SELECT` query can contain `DISTINCT`, `GROUP BY`, `ORDER BY`, `LIMIT`. Note t
 
 If the materialized view uses the construction `TO [db.]name`, you can `DETACH` the view, run `ALTER` for the target table, and then `ATTACH` the previously detached (`DETACH`) view.
 
-Note that materialized view is influenced by [optimize_on_insert](/reference/settings/session-settings#optimize_on_insert) setting. The data is merged before the insertion into a view.
-
 Views look the same as normal tables. For example, they are listed in the result of the `SHOW TABLES` query.
 
 To delete a view, use [DROP VIEW](/reference/statements/drop#drop-view). Although `DROP TABLE` works for VIEWs as well.


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/80034

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Removed an incorrect note from the `CREATE VIEW` documentation which claimed that data is merged before the insertion into a materialized view.

### Documentation

This removes the following sentence from `docs/en/sql-reference/statements/create/view.md`:

> Note that materialized view is influenced by [optimize_on_insert](/operations/settings/settings#optimize_on_insert) setting. The data is merged before the insertion into a view.

**Why it is incorrect:**

- `optimize_on_insert` does not merge data "before the insertion into a view". It transforms each inserted block when the block is written to MergeTree storage, as if a merge was performed on that single block — see [`MergeTreeDataWriter.cpp#L822`](https://github.com/ClickHouse/ClickHouse/blob/fe659adb82faa809924151c690fe36ff08515193/src/Storages/MergeTree/MergeTreeDataWriter.cpp#L822) and the setting description in [`Settings.cpp#L5549-L5550`](https://github.com/ClickHouse/ClickHouse/blob/fe659adb82faa809924151c690fe36ff08515193/src/Core/Settings.cpp#L5549-L5550). For a materialized view this happens when the transformed block is flushed into the view's target table, i.e. *after* the view's `SELECT` has been applied — not before.
- The sentence reads as if materialized view delivery depends on merges. It does not: the reproduction in #80034 shows that with `SYSTEM STOP MERGES` the target table still receives rows on every insert, and `system.part_log` confirms only `NewPart` events (no merges).
- den-crane confirmed in the issue that the statement "is incorrect / not true and should be removed".

Since the setting behaves the same for a materialized view's target table as for any other MergeTree insert, there is nothing view-specific to document here, so the sentence is removed rather than reworded (as suggested in the issue).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.188` (included in `26.8` and later)
<!-- ch-version-info:end -->