### PR TITLE
Fix TYPE_MISMATCH in direct dictionary join with a Nullable or LowCardinality key

### DIFF
--- a/src/Dictionaries/IDictionary.h
+++ b/src/Dictionaries/IDictionary.h
@@ -4,6 +4,8 @@
 #include <mutex>
 
 #include <Columns/ColumnConst.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnSparse.h>
 #include <Core/Names.h>
 #include <Core/ColumnsWithTypeAndName.h>
 #include <Core/UUID.h>
@@ -15,6 +17,8 @@
 #include <Dictionaries/IDictionarySource.h>
 #include <Dictionaries/DictionaryStructure.h>
 #include <DataTypes/IDataType.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 
 namespace DB
 {
@@ -367,6 +371,40 @@ public:
             key_types.emplace_back(key.type);
         }
 
+        /// Normalize wrapper-compatible key columns to the declared key schema via `convertKeyColumns`.
+        /// Track NULL rows and unwrap the outer `Nullable` first: casting a real NULL to a
+        /// non-Nullable declared type would throw.
+        PaddedPODArray<UInt8> key_row_is_null;
+        for (size_t i = 0; i < key_columns.size(); ++i)
+        {
+            if (!isNullableOrLowCardinalityNullable(key_types[i]))
+                continue;
+
+            /// Drop `Const`/`Sparse`/`ColumnReplicated` and `LowCardinality` (as `HashJoin` prepares
+            /// probe keys) so the null map is exposed, then peel off the outer `Nullable`.
+            ColumnPtr full_column = recursiveRemoveLowCardinality(removeSpecialRepresentations(key_columns[i]->convertToFullColumnIfConst()));
+            DataTypePtr full_type = recursiveRemoveLowCardinality(key_types[i]);
+
+            if (const auto * nullable = checkAndGetColumn<ColumnNullable>(full_column.get()))
+            {
+                const auto & row_null_map = nullable->getNullMapData();
+                if (key_row_is_null.empty())
+                    key_row_is_null.resize_fill(row_null_map.size(), 0);
+                for (size_t row = 0; row < row_null_map.size(); ++row)
+                    key_row_is_null[row] |= row_null_map[row];
+
+                key_columns[i] = nullable->getNestedColumnPtr();
+                key_types[i] = removeNullable(full_type);
+            }
+            else
+            {
+                key_columns[i] = std::move(full_column);
+                key_types[i] = std::move(full_type);
+            }
+        }
+
+        convertKeyColumns(key_columns, key_types);
+
         /// Fill null map
         {
             out_null_map.clear();
@@ -376,6 +414,12 @@ public:
 
             out_null_map.resize(mask_data.size(), 0);
             std::copy(mask_data.begin(), mask_data.end(), out_null_map.begin());
+
+            /// A NULL key never matches, even if its unwrapped value coincides with a stored key
+            /// (e.g. NULL unwrapped to the empty string could otherwise hit a stored empty key).
+            for (size_t row = 0; row < key_row_is_null.size(); ++row)
+                if (key_row_is_null[row])
+                    out_null_map[row] = 0;
         }
 
         Names attribute_names;
@@ -407,6 +451,11 @@ public:
             default_cols[i] = result_types[i]->createColumnConstWithDefaultValue(out_null_map.size());
 
         Columns result_columns = getColumns(attribute_names, result_types, key_columns, key_types, default_cols);
+
+        /// Blank attributes for NULL-key rows so a coincidental match yields defaults like a miss.
+        if (!key_row_is_null.empty())
+            for (auto & result_column : result_columns)
+                result_column = JoinCommon::filterWithBlanks(result_column, out_null_map);
 
         /// Result block should consist of key columns and then attributes
         for (const auto & key_col : key_columns)

--- a/tests/queries/0_stateless/04627_direct_join_dictionary_nullable_key.reference
+++ b/tests/queries/0_stateless/04627_direct_join_dictionary_nullable_key.reference
@@ -1,0 +1,40 @@
+Nullable(String) key, LEFT, join_use_nulls=0
+a	A
+b	B
+x	
+\N	
+Nullable(String) key, LEFT, join_use_nulls=1
+a	A
+b	B
+x	\N
+\N	\N
+Nullable(String) key, INNER
+a	A
+b	B
+LowCardinality(String) key, LEFT
+a	A
+x	
+LowCardinality(Nullable(String)) key, LEFT
+a	A
+b	B
+\N	
+NULL key does not match a real empty-string dictionary key
+a	A
+\N	
+A genuine empty-string key still matches
+	EMPTYHIT
+A constant NULL key does not match the empty-string dictionary key
+\N	
+Dictionary with Nullable(UInt64) key, Nullable probe with NULL
+1	one
+2	two
+\N	
+Nullable key carried by a sparse column, LEFT
+a	A
+\N	
+Nullable key replicated by ARRAY JOIN, LEFT
+a	A
+a	A
+\N	
+Direct join is still chosen for the Nullable key
+1

--- a/tests/queries/0_stateless/04627_direct_join_dictionary_nullable_key.sql
+++ b/tests/queries/0_stateless/04627_direct_join_dictionary_nullable_key.sql
@@ -1,0 +1,109 @@
+-- Tags: no-parallel-replicas
+-- DirectKeyValueJoin (the algorithm under test) cannot be chosen with parallel replicas, so the
+-- ParallelReplicas runner variant would throw NOT_IMPLEMENTED instead of exercising the fix.
+-- Direct JOIN onto a dictionary with a wrapped (Nullable / LowCardinality / LowCardinality(Nullable))
+-- left join key used to throw "Key type for complex key ... does not match" (TYPE_MISMATCH).
+-- The direct-join lookup now normalizes the key to the dictionary's declared key schema, and a NULL
+-- key never matches. See https://github.com/ClickHouse/ClickHouse/issues/111829
+
+DROP DICTIONARY IF EXISTS dict_str;
+DROP DICTIONARY IF EXISTS dict_empty;
+DROP DICTIONARY IF EXISTS dict_nullable_key;
+DROP TABLE IF EXISTS src_str;
+DROP TABLE IF EXISTS src_empty;
+DROP TABLE IF EXISTS src_nullable_key;
+
+CREATE TABLE src_str (k String, v String) ENGINE = MergeTree ORDER BY k;
+INSERT INTO src_str VALUES ('a', 'A'), ('b', 'B'), ('c', 'C');
+CREATE DICTIONARY dict_str (k String, v String)
+PRIMARY KEY k SOURCE(CLICKHOUSE(TABLE 'src_str' DB currentDatabase())) LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(0);
+
+-- Dictionary that has a real empty-string key: a NULL probe key must not coincide with it.
+CREATE TABLE src_empty (k String, v String) ENGINE = MergeTree ORDER BY k;
+INSERT INTO src_empty VALUES ('', 'EMPTYHIT'), ('a', 'A');
+CREATE DICTIONARY dict_empty (k String, v String)
+PRIMARY KEY k SOURCE(CLICKHOUSE(TABLE 'src_empty' DB currentDatabase())) LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(0);
+
+-- Dictionary whose declared key is itself Nullable: normalizing the probe wrapper must not break it.
+CREATE TABLE src_nullable_key (k Nullable(UInt64), v String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO src_nullable_key VALUES (1, 'one'), (2, 'two');
+CREATE DICTIONARY dict_nullable_key (k Nullable(UInt64), v String)
+PRIMARY KEY k SOURCE(CLICKHOUSE(TABLE 'src_nullable_key' DB currentDatabase())) LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(0);
+
+-- A Nullable key can also be carried by a sparse column or replicated by ARRAY JOIN; the lookup must
+-- expose the null map through those special representations too.
+CREATE TABLE src_sparse (k Nullable(String)) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0.0;
+INSERT INTO src_sparse VALUES ('a'), (NULL);
+
+-- `k` is carried (not array-joined) through ARRAY JOIN of `arr`, so with lazy replication it becomes
+-- a ColumnReplicated wrapping a Nullable column.
+CREATE TABLE src_array (k Nullable(String), arr Array(UInt8)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO src_array VALUES ('a', [1, 2]), (NULL, [3]);
+
+SET join_algorithm = 'direct';
+
+SELECT 'Nullable(String) key, LEFT, join_use_nulls=0';
+SELECT t.pref, dd.v FROM (SELECT arrayJoin(['a', 'b', 'x', NULL]::Array(Nullable(String))) AS pref) AS t
+LEFT JOIN dict_str AS dd ON t.pref = dd.k ORDER BY t.pref NULLS LAST, dd.v SETTINGS join_use_nulls = 0;
+
+SELECT 'Nullable(String) key, LEFT, join_use_nulls=1';
+SELECT t.pref, dd.v FROM (SELECT arrayJoin(['a', 'b', 'x', NULL]::Array(Nullable(String))) AS pref) AS t
+LEFT JOIN dict_str AS dd ON t.pref = dd.k ORDER BY t.pref NULLS LAST, dd.v SETTINGS join_use_nulls = 1;
+
+SELECT 'Nullable(String) key, INNER';
+SELECT t.pref, dd.v FROM (SELECT arrayJoin(['a', 'b', 'x', NULL]::Array(Nullable(String))) AS pref) AS t
+INNER JOIN dict_str AS dd ON t.pref = dd.k ORDER BY t.pref, dd.v;
+
+-- The analyzer casts LowCardinality away before the join; enable_analyzer = 0 keeps the
+-- LowCardinality key so it survives to the dictionary lookup and exercises the stripping in getByKeys.
+SELECT 'LowCardinality(String) key, LEFT';
+SELECT t.pref, dd.v FROM (SELECT arrayJoin(['a', 'x']::Array(LowCardinality(String))) AS pref) AS t
+LEFT JOIN dict_str AS dd ON t.pref = dd.k ORDER BY t.pref, dd.v SETTINGS enable_analyzer = 0;
+
+SELECT 'LowCardinality(Nullable(String)) key, LEFT';
+SELECT t.pref, dd.v FROM (SELECT arrayJoin(['a', 'b', NULL]::Array(LowCardinality(Nullable(String)))) AS pref) AS t
+LEFT JOIN dict_str AS dd ON t.pref = dd.k ORDER BY t.pref NULLS LAST, dd.v SETTINGS enable_analyzer = 0;
+
+SELECT 'NULL key does not match a real empty-string dictionary key';
+SELECT t.pref, dd.v FROM (SELECT arrayJoin(['a', NULL]::Array(Nullable(String))) AS pref) AS t
+LEFT JOIN dict_empty AS dd ON t.pref = dd.k ORDER BY t.pref NULLS LAST, dd.v;
+
+SELECT 'A genuine empty-string key still matches';
+SELECT t.pref, dd.v FROM (SELECT CAST('', 'Nullable(String)') AS pref) AS t
+LEFT JOIN dict_empty AS dd ON t.pref = dd.k;
+
+-- A constant NULL arrives as a ColumnConst, unlike the arrayJoin NULLs above; it must still not match.
+SELECT 'A constant NULL key does not match the empty-string dictionary key';
+SELECT t.pref, dd.v FROM (SELECT CAST(NULL, 'Nullable(String)') AS pref) AS t
+LEFT JOIN dict_empty AS dd ON t.pref = dd.k;
+
+-- Nullable-declared dictionary key with a Nullable probe: direct join is selected here, so the
+-- wrapper normalization must keep both non-null lookups and the NULL non-match correct.
+SELECT 'Dictionary with Nullable(UInt64) key, Nullable probe with NULL';
+SELECT t.pref, dd.v FROM (SELECT arrayJoin([1, 2, NULL]::Array(Nullable(UInt64))) AS pref) AS t
+LEFT JOIN dict_nullable_key AS dd ON t.pref = dd.k ORDER BY t.pref NULLS LAST, dd.v;
+
+SELECT 'Nullable key carried by a sparse column, LEFT';
+SELECT s.k, dd.v FROM src_sparse AS s
+LEFT JOIN dict_str AS dd ON s.k = dd.k ORDER BY s.k NULLS LAST, dd.v;
+
+SELECT 'Nullable key replicated by ARRAY JOIN, LEFT';
+SELECT p.k, dd.v FROM (SELECT k FROM src_array ARRAY JOIN arr) AS p
+LEFT JOIN dict_str AS dd ON p.k = dd.k ORDER BY p.k NULLS LAST, dd.v
+SETTINGS enable_lazy_columns_replication = 1;
+
+SELECT 'Direct join is still chosen for the Nullable key';
+SELECT count() > 0 FROM (EXPLAIN actions = 1
+    SELECT count() FROM (SELECT CAST('a', 'Nullable(String)') AS pref) AS t
+    LEFT JOIN dict_str AS dd ON t.pref = dd.k)
+WHERE explain ILIKE '%Algorithm: DirectKeyValueJoin%';
+
+DROP DICTIONARY dict_str;
+DROP DICTIONARY dict_empty;
+DROP DICTIONARY dict_nullable_key;
+DROP TABLE src_str;
+DROP TABLE src_empty;
+DROP TABLE src_nullable_key;
+DROP TABLE src_sparse;
+DROP TABLE src_array;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/111829
Related: https://github.com/ClickHouse/ClickHouse/pull/105253
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/111829


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `TYPE_MISMATCH` ("Key type for complex key ... does not match") when a `JOIN` onto a dictionary uses a `Nullable`, `LowCardinality`, or `LowCardinality(Nullable)` join key while the dictionary key is not wrapped. The direct-join dictionary lookup now normalizes the key to the dictionary's declared key type (as `dictGet`/`dictHas` already do), and a `NULL` key never matches.


### Description

A `LEFT`/`INNER JOIN` onto a `COMPLEX_KEY` dictionary threw `Code: 53 TYPE_MISMATCH` when the left join key carried a `Nullable`/`LowCardinality(Nullable)` wrapper the dictionary key does not have. This became easy to hit after #104017 made the direct-join path always-on (e.g. a first `LEFT JOIN` under `join_use_nulls=1` makes a key `Nullable`, which is then used as the key of a second dictionary join). Workaround was `join_algorithm='hash'`.

Root cause: the join framework already treats such wrappers as compatible (`JoinCommon::checkTypesOfKeys` strips them), but `IDictionary::getByKeys` (the direct-join adapter) forwarded the raw key type into `DictionaryStructure::validateKeyTypes`, which requires an exact type match. Every other dictionary entry point (`dictGet`/`dictHas`) first calls `IDictionary::convertKeyColumns`; `getByKeys` did not.

Fix: in `IDictionary::getByKeys`, normalize the key columns to the dictionary's declared key schema via the existing `convertKeyColumns` (handles stripping/adding `Nullable` and `LowCardinality`), and ensure a `NULL` key never matches a stored key (including a stored empty value). `validateKeyTypes` stays strict, so genuinely incompatible key types still error.

This mirrors #105253, which fixes the same class for the `EmbeddedRocksDB`/`Redis`/`KeeperMap` key-value storages; this PR covers the dictionary backend and touches disjoint files.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.157` (included in `26.8` and later)
- Backported to: `26.7.2.22`, `26.6.2.117`
<!-- ch-version-info:end -->