### PR TITLE
Make the part directory rename crash-durable with fsync_part_directory=1

### DIFF
--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -716,9 +716,22 @@ void DataPartStorageOnDiskBase::rename(
         disk.moveDirectory(from, to);
 
         /// Only after moveDirectory() since before the directory does not exist.
-        SyncGuardPtr to_sync_guard;
         if (fsync_part_dir)
-            to_sync_guard = volume->getDisk()->getDirectorySyncGuard(to);
+        {
+            /// Sync child before parent so a parent dentry never points at a not-yet-synced
+            /// child: the moved dir, then the parent(s) holding the renamed dentry.
+            { SyncGuardPtr to_sync_guard = volume->getDisk()->getDirectorySyncGuard(to); }
+
+            /// parent_path() twice: step past the trailing slash on `to`/`from`, then to the container.
+            const String to_parent = fs::path(to).parent_path().parent_path().string();
+            const String from_parent = fs::path(from).parent_path().parent_path().string();
+
+            if (!to_parent.empty())
+                { SyncGuardPtr to_parent_sync_guard = volume->getDisk()->getDirectorySyncGuard(to_parent); }
+
+            if (!from_parent.empty() && from_parent != to_parent)
+                { SyncGuardPtr from_parent_sync_guard = volume->getDisk()->getDirectorySyncGuard(from_parent); }
+        }
     });
 
     part_dir = new_part_dir;

--- a/tests/queries/0_stateless/02361_fsync_profile_events.sh
+++ b/tests/queries/0_stateless/02361_fsync_profile_events.sh
@@ -89,7 +89,9 @@ done
 # part directory plus BOTH distinct parents (3), which guards the source-parent fsync that a
 # same-parent insert does not exercise.
 if [[ $ret -eq 0 ]]; then
-    attach_query_id="attach-$CLICKHOUSE_DATABASE"
+    # Unique per run: a fixed query_id would match older rows of a rerun against the same
+    # server, and the multi-line result then breaks the numeric comparison below.
+    attach_query_id="attach-$CLICKHOUSE_DATABASE-$(random_str 10)"
     part_name=$($CLICKHOUSE_CLIENT -q "select name from system.parts where table='data_fsync_pe' and active and database=currentDatabase() order by name limit 1")
     $CLICKHOUSE_CLIENT -q "alter table data_fsync_pe detach part '$part_name'"
     $CLICKHOUSE_CLIENT --query_id "$attach_query_id" -q "alter table data_fsync_pe attach part '$part_name'"
@@ -97,7 +99,13 @@ if [[ $ret -eq 0 ]]; then
         system flush logs query_log;
         select ProfileEvents['DirectorySync']
         from system.query_log
-        where current_database = currentDatabase() and query_id = {query_id:String} and type = 'QueryFinish';
+        where
+            event_date >= yesterday() AND event_time >= now() - 600 and
+            current_database = currentDatabase() and
+            query_id = {query_id:String} and
+            type = 'QueryFinish'
+        order by event_time_microseconds desc
+        limit 1;
     ")
     if [[ $AttachDirectorySync -ne 3 ]]; then
         echo "ATTACH PART DirectorySync: $AttachDirectorySync != 3" >&2

--- a/tests/queries/0_stateless/02361_fsync_profile_events.sh
+++ b/tests/queries/0_stateless/02361_fsync_profile_events.sh
@@ -21,6 +21,10 @@ $CLICKHOUSE_CLIENT -m -q "
         write_marks_for_substreams_in_compact_parts = 1,
         auto_statistics_types = '',
         add_minmax_index_for_numeric_columns=0;
+
+    -- Keep every inserted part active (the retry loop below can create several) so the
+    -- part selected for the ATTACH check further down cannot be replaced by a merge.
+    system stop merges data_fsync_pe;
 "
 
 ret=1
@@ -59,8 +63,11 @@ for i in {1..100}; do
         echo "$FileSync (FileSync) != $FileOpen (FileOpen)" >&2
         exit 3
     fi
-    if [[ $DirectorySync -ne 2 ]]; then
-        echo "DirectorySync: $DirectorySync != 2" >&2
+    # With fsync_part_directory=1 an insert now fsyncs 3 directories: the 2 for the part
+    # directory itself (write + tmp->final rename) plus its parent directory, so the rename
+    # is itself crash-durable (the parent holds the part's new dentry).
+    if [[ $DirectorySync -ne 3 ]]; then
+        echo "DirectorySync: $DirectorySync != 3" >&2
         exit 4
     fi
 
@@ -76,6 +83,27 @@ for i in {1..100}; do
     ret=0
     break
 done
+
+# Cross-parent rename: ATTACH PART commits a part from detached/attaching_* to the table root,
+# so the source and destination parents differ. With fsync_part_directory=1 this fsyncs the moved
+# part directory plus BOTH distinct parents (3), which guards the source-parent fsync that a
+# same-parent insert does not exercise.
+if [[ $ret -eq 0 ]]; then
+    attach_query_id="attach-$CLICKHOUSE_DATABASE"
+    part_name=$($CLICKHOUSE_CLIENT -q "select name from system.parts where table='data_fsync_pe' and active and database=currentDatabase() order by name limit 1")
+    $CLICKHOUSE_CLIENT -q "alter table data_fsync_pe detach part '$part_name'"
+    $CLICKHOUSE_CLIENT --query_id "$attach_query_id" -q "alter table data_fsync_pe attach part '$part_name'"
+    AttachDirectorySync=$($CLICKHOUSE_CLIENT -m --param_query_id "$attach_query_id" -q "
+        system flush logs query_log;
+        select ProfileEvents['DirectorySync']
+        from system.query_log
+        where current_database = currentDatabase() and query_id = {query_id:String} and type = 'QueryFinish';
+    ")
+    if [[ $AttachDirectorySync -ne 3 ]]; then
+        echo "ATTACH PART DirectorySync: $AttachDirectorySync != 3" >&2
+        ret=5
+    fi
+fi
 
 $CLICKHOUSE_CLIENT -q "drop table data_fsync_pe"
 


### PR DESCRIPTION

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/111537
Related: https://github.com/ClickHouse/ClickHouse/issues/111799
Related: https://github.com/ClickHouse/ClickHouse/issues/111800


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
With `fsync_part_directory = 1`, the rename of a part directory from its temporary to its final name is now itself made durable by fsyncing the parent directory (and, for moves across parents, the source parent too). Previously only the moved directory was fsynced, so a power loss right after a part was committed could leave the part missing on disk even though its files were already written, losing rows despite the setting being enabled.


### Description

`DataPartStorageOnDiskBase::rename` fsynced only the moved (destination) directory when `fsync_part_directory = 1`. A directory rename is durable only once the directory that holds the affected dentry is fsynced, so the `tmp_*` -> final rename was not crash-durable: after a power cut the new part directory entry could be absent while the part files were already on disk, making the part disappear entirely.

The fix fsyncs, under the same `fsync_part_directory` guard, the destination parent directory (which holds the new dentry) and, for a move that crosses parents, the source parent directory (from which the old dentry was removed), coalescing them when equal. The moved directory is fsynced before its parent so the parent's dentry never references a not-yet-durable child. This fixes the owning function, so every part-directory rename (insert commit, merge, mutation, fetch, move, detach) becomes durable uniformly.

This also makes the target-table durability setting itself trustworthy for the `S3Queue`/`Kafka`/`RabbitMQ` power-loss data-loss reports (#111537, #111799, #111800): with `fsync_after_insert = 1` and `fsync_part_directory = 1` the consumed part, including its rename, is now actually durable once the insert completes, instead of only appearing on disk until the next fsync. It does not by itself fix the engine-side ordering (when the source offset is committed or the source object removed relative to that durable insert); that cross-engine ordering contract is tracked separately on #111799.

`02361_fsync_profile_events.sh` asserts the per-insert `DirectorySync` count is now 3 (was 2), and adds an `ATTACH PART` case (a cross-parent rename from `detached/attaching_*` to the table root) that also asserts 3, guarding the source-parent fsync that a same-parent insert does not exercise. Both assertions fail on the current master build and pass with this change; with `fsync_part_directory = 0` the counts are unchanged (0), so there is no behavior change when the setting is off.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.152` (included in `26.8` and later)
<!-- ch-version-info:end -->