### PR TITLE
Docs: decrease code block font size

### DIFF
--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -831,9 +831,11 @@ html:not(.dark) .pagination-prev:hover {
     font-feature-settings: "kern" 0 !important;
 }
 
-/* Tighten line-height for code blocks to match monospace table output
-   while ensuring box-drawing characters render fully */
+/* Slightly reduce the code-block font size to limit horizontal scrolling.
+   Tighten line-height to match monospace table output while ensuring
+   box-drawing characters render fully. */
 [data-component-part="code-block-root"] .font-mono {
+    font-size: 0.8125rem !important;
     line-height: 1.5 !important;
 }
 


### PR DESCRIPTION
Decrease the font size of code blocks from 14px to 13px so more content fits within the documentation column and readers need to scroll horizontally less often.


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.114` (included in `26.8` and later)
<!-- ch-version-info:end -->