### PR TITLE
Avoid redundant JOIN table-side extraction during general join planning

### DIFF
--- a/src/Planner/PlannerJoins.cpp
+++ b/src/Planner/PlannerJoins.cpp
@@ -561,6 +561,24 @@ static JoinClauses buildJoinClauses(
     std::stack<QueryTreeNodePtr> nodes_to_process;
     nodes_to_process.push(join_expression);
 
+    /// A node stays on the stack until its children are built, so it is visited twice.
+    /// Its table sides do not change in between, so avoid walking the subtree again.
+    std::unordered_map<const IQueryTreeNode *, std::set<JoinTableSide>> expression_sides_cache;
+
+    auto get_expression_sides = [&](const QueryTreeNodePtr & node) -> const std::set<JoinTableSide> &
+    {
+        auto it = expression_sides_cache.find(node.get());
+        if (it == expression_sides_cache.end())
+            it = expression_sides_cache
+                     .emplace(
+                         node.get(),
+                         extractJoinTableSidesFromExpression(
+                             node.get(), left_table_expressions, right_table_expressions, join_node))
+                     .first;
+
+        return it->second;
+    };
+
     auto get_and_check_built_clause = [&built_clauses](const IQueryTreeNode* node) -> JoinClauses &
     {
         auto it = built_clauses.find(node);
@@ -577,11 +595,10 @@ static JoinClauses buildJoinClauses(
     {
         auto node = nodes_to_process.top();
         auto * function_node = node->as<FunctionNode>();
-        const auto function_name = function_node ? function_node->getFunctionName() : String();
-        const auto expression_sides
-            = extractJoinTableSidesFromExpression(node.get(), left_table_expressions, right_table_expressions, join_node);
+        const bool is_logical_function
+            = function_node && (function_node->getFunctionName() == "and" || function_node->getFunctionName() == "or");
         // If the expression is a logical expression and it contains expressions from both sides, let's combine the clauses, otherwise let's just build one join clause
-        if ((function_name == "and" || function_name == "or") && expression_sides.size() == 2)
+        if (is_logical_function && get_expression_sides(node).size() == 2)
         {
             auto & arguments = function_node->getArguments().getNodes();
             auto * first_argument = arguments.front().get();
@@ -595,7 +612,7 @@ static JoinClauses buildJoinClauses(
 
             nodes_to_process.pop();
             JoinClauses result;
-            if (function_name == "or")
+            if (function_node->getFunctionName() == "or")
             {
                 for (auto & argument : arguments)
                 {

--- a/tests/queries/0_stateless/04628_join_general_planning_clause_building.reference
+++ b/tests/queries/0_stateless/04628_join_general_planning_clause_building.reference
@@ -1,0 +1,51 @@
+-- single equality
+0	0
+1	1
+2	2
+3	3
+4	4
+-- n-ary AND, flattened by the analyzer into one node with many children
+0	0
+1	1
+2	2
+3	3
+4	4
+-- OR of equalities: each branch becomes a separate join clause
+0	0
+0	5
+0	10
+0	15
+1	1
+-- AND over OR: cross product of child clauses
+0	0
+0	5
+0	10
+0	15
+1	1
+-- alternating AND/OR nesting: the shape that survives analyzer flattening as a deep tree
+0	0
+1	1
+2	2
+3	3
+4	4
+-- logical node touching only one side: must not be split into multiple clauses
+1	1
+2	2
+6	6
+7	7
+11	11
+-- residual inequality condition alongside key conditions
+5	5
+10	10
+11	11
+-- same results with general join planning disabled
+0	0
+1	1
+2	2
+3	3
+4	4
+0	0
+0	5
+0	10
+0	15
+1	1

--- a/tests/queries/0_stateless/04628_join_general_planning_clause_building.sql
+++ b/tests/queries/0_stateless/04628_join_general_planning_clause_building.sql
@@ -1,0 +1,48 @@
+-- Covers `buildJoinClauses` in `src/Planner/PlannerJoins.cpp`, which walks the `JOIN ON` expression
+-- with a peek-don't-pop stack and combines per-node join clauses. The traversal runs only when
+-- general join planning is enabled, so the expression shapes below are otherwise not exercised.
+
+SET enable_analyzer = 1;
+SET join_algorithm = 'hash';
+SET allow_general_join_planning = 1;
+
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+
+CREATE TABLE t1 (a UInt32, b UInt32, c UInt32) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t2 (a UInt32, b UInt32, c UInt32) ENGINE = MergeTree ORDER BY a;
+
+INSERT INTO t1 SELECT number, number % 5, number % 3 FROM numbers(20);
+INSERT INTO t2 SELECT number, number % 5, number % 3 FROM numbers(20);
+
+SELECT '-- single equality';
+SELECT t1.a, t2.a FROM t1 JOIN t2 ON t1.a = t2.a ORDER BY t1.a, t2.a LIMIT 5;
+
+SELECT '-- n-ary AND, flattened by the analyzer into one node with many children';
+SELECT t1.a, t2.a FROM t1 JOIN t2 ON t1.a = t2.a AND t1.b = t2.b AND t1.c = t2.c ORDER BY t1.a, t2.a LIMIT 5;
+
+SELECT '-- OR of equalities: each branch becomes a separate join clause';
+SELECT t1.a, t2.a FROM t1 JOIN t2 ON t1.a = t2.a OR t1.b = t2.b ORDER BY t1.a, t2.a LIMIT 5;
+
+SELECT '-- AND over OR: cross product of child clauses';
+SELECT t1.a, t2.a FROM t1 JOIN t2 ON (t1.a = t2.a OR t1.b = t2.b) AND (t1.c = t2.c OR t1.a = t2.b) ORDER BY t1.a, t2.a LIMIT 5;
+
+SELECT '-- alternating AND/OR nesting: the shape that survives analyzer flattening as a deep tree';
+SELECT t1.a, t2.a FROM t1 JOIN t2
+ON t1.a = t2.a AND (t1.b = t2.b OR (t1.c = t2.c AND (t1.a = t2.b OR t1.b = t2.c)))
+ORDER BY t1.a, t2.a LIMIT 5;
+
+SELECT '-- logical node touching only one side: must not be split into multiple clauses';
+SELECT t1.a, t2.a FROM t1 JOIN t2 ON t1.a = t2.a AND (t1.b = 1 OR t1.b = 2) ORDER BY t1.a, t2.a LIMIT 5;
+
+SELECT '-- residual inequality condition alongside key conditions';
+SELECT t1.a, t2.a FROM t1 JOIN t2 ON t1.a = t2.a AND t1.b < t2.c ORDER BY t1.a, t2.a LIMIT 5;
+
+SELECT '-- same results with general join planning disabled';
+SELECT t1.a, t2.a FROM t1 JOIN t2 ON t1.a = t2.a AND t1.b = t2.b AND t1.c = t2.c
+ORDER BY t1.a, t2.a LIMIT 5 SETTINGS allow_general_join_planning = 0;
+SELECT t1.a, t2.a FROM t1 JOIN t2 ON (t1.a = t2.a OR t1.b = t2.b) AND (t1.c = t2.c OR t1.a = t2.b)
+ORDER BY t1.a, t2.a LIMIT 5 SETTINGS allow_general_join_planning = 0;
+
+DROP TABLE t1;
+DROP TABLE t2;


### PR DESCRIPTION
fixes: https://github.com/ClickHouse/ClickHouse/issues/111865

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add a stateless test for JOIN ON clause building under `allow_general_join_planning`, and cache per-node table-side information during planner traversal to avoid redundant subtree walks.

---

## Summary

This change adds regression coverage for `allow_general_join_planning` and removes redundant planner work performed while building JOIN ON clauses.

The optimization is behavior-neutral: it caches per-node table-side information that was previously recomputed on repeated visits during the planner traversal. The accompanying stateless test covers the previously untested planner path.

---

## Problem

`buildJoinClauses` (`src/Planner/PlannerJoins.cpp`) traverses the JOIN ON expression using a peek-without-pop stack.

When visiting an `AND`/`OR` node whose children have not yet been processed, the children are pushed onto the stack and the loop continues without popping the parent. Once the children have been processed, the parent node is visited a second time.

`extractJoinTableSidesFromExpression()` was executed unconditionally at the beginning of every iteration, before the `built_clauses` early-exit check. Since the function performs a complete traversal of the current subtree, the second visit repeated exactly the same computation even though:

- the result depends only on the expression node itself and the immutable `left_table_expressions` / `right_table_expressions`;
- the planner does not modify the query tree during traversal;
- only auxiliary structures (`built_clauses` and generated DAGs) are updated.

This path is exercised only when the join algorithm is `HASH` or `AUTO` and `allow_general_join_planning = 1`.

---

## Impact

This change removes redundant planning work only.

There is **no correctness change**. The repeated computation always produced the same result, so query plans and query results were already identical.

The amount of redundant subtree traversal is illustrated below.

| Expression shape | Before | After | Reduction |
|------------------|-------:|------:|----------:|
| n-ary AND (3 conjuncts) | 11 | 4 | 2.75× |
| n-ary AND (10 conjuncts) | 32 | 11 | 2.91× |
| n-ary AND (50 conjuncts) | 152 | 51 | 2.98× |
| AND over 5 ORs | 72 | 31 | 2.32× |
| Alternating AND/OR (depth 4) | 53 | 24 | 2.21× |
| Alternating AND/OR (depth 8) | 169 | 80 | 2.11× |
| Alternating AND/OR (depth 16) | 593 | 288 | 2.06× |

The saving is a constant-factor reduction in planner traversal work. It is **not quadratic** in ON-clause size because `LogicalExpressionOptimizerPass` flattens nested AND/OR expressions before planning, leaving only alternating AND/OR trees as deep structures.

This affects planning only; there is no per-row execution cost.

### Methodology

The traversal counts above were obtained from a standalone C++ simulation of the planner traversal rather than an instrumented ClickHouse build.

The simulation reproduces the planner's control flow (peek-without-pop traversal, child expansion, and second parent visit) and counts every node visited by a stand-in for `extractJoinTableSidesFromExpression()` using identical synthetic expression trees.

The reported metric is **node visits**, not execution time. It quantifies redundant traversal only and does not imply a runtime improvement.

---

## Solution

The planner now memoizes the result of `extractJoinTableSidesFromExpression()` in

```cpp
std::unordered_map<const IQueryTreeNode *, std::set<JoinTableSide>>
```

alongside `built_clauses`.

When a logical node is revisited, the cached table-side information is reused instead of traversing the subtree again.

The change also removes a redundant per-iteration `String` allocation from `getFunctionName()` that occurred during repeated visits.

The planner logic is otherwise unchanged. The condition

```cpp
(and || or) && sides.size() == 2
```

remains identical, ensuring that logical expressions referencing only one table side continue to follow the existing single-clause path.

---

## Performance

No measurable wall-clock improvement was observed.

Planning time for a synthetic depth-40 alternating AND/OR expression (61 runs, measured using `system.query_log`):

| Binary | Mean | Median |
|--------|-----:|-------:|
| With change | 6.885 ms | 7 ms |
| Baseline | 7.049 ms | 7 ms |

The observed difference (~0.16 ms, ~2.3%) is within normal run-to-run variation, and the medians are identical.

This optimisation is therefore justified by removing provably redundant work and by improving regression coverage rather than by measurable runtime gains.

---

## Testing

Added a new stateless test:

```
tests/queries/0_stateless/04628_join_general_planning_clause_building.sql
```

This planner path previously had no stateless coverage.

The test covers:

- single equality;
- n-ary AND;
- OR of equalities;
- AND over OR (cross-product of clauses);
- alternating AND/OR nesting;
- logical nodes referencing only one table side (must not be split);
- residual inequalities alongside join keys;
- equivalence between `allow_general_join_planning = 1` and `0`.

Because the change is behavior-neutral, the same reference file was validated against both binaries:

| Binary | Planner | Result |
|--------|---------|--------|
| With change | Modified | ✅ PASS |
| Baseline | Unmodified master | ✅ PASS |

The test was executed with:

```text
tests/clickhouse-test \
    --no-random-settings \
    --no-random-merge-tree-settings
```

The reference output was generated from the built server rather than written manually
