### PR TITLE
Fix PromQL operations on instant vectors without tags

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyLabelManipulationFunction.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyLabelManipulationFunction.cpp
@@ -158,7 +158,8 @@ applyLabelManipulationFunction(const PQT::Function * function_node, std::vector<
             SelectQueryBuilder builder;
 
             ASTs group_function_args;
-            group_function_args.push_back(make_intrusive<ASTLiteral>(0u)); /// Group "0" means no tags
+            group_function_args.push_back(makeASTFunction(
+                "CAST", make_intrusive<ASTLiteral>(0u), make_intrusive<ASTLiteral>("UInt64"))); /// Group "0" means no tags
 
             size_t array_argument_index = impl_info->array_argument_index;
             insertAtEnd(group_function_args, collectStringArguments(arguments, 1, array_argument_index));

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/toVectorGrid.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/toVectorGrid.cpp
@@ -55,13 +55,13 @@ SQLQueryPiece toVectorGrid(SQLQueryPiece && query_piece, ConverterContext & cont
         case StoreMethod::SINGLE_SCALAR:
         {
             /// For const scalar:
-            /// SELECT 0 AS group, arrayResize([], <count_of_time_steps>, <scalar_value>) AS values
+            /// SELECT CAST(0, 'UInt64') AS group, arrayResize([], <count_of_time_steps>, <scalar_value>) AS values
             ///
             /// For single scalar:
-            /// SELECT 0 AS group, arrayResize([], <count_of_time_steps>, value) AS values FROM <subquery>
+            /// SELECT CAST(0, 'UInt64') AS group, arrayResize([], <count_of_time_steps>, value) AS values FROM <subquery>
             SelectQueryBuilder builder;
 
-            builder.select_list.push_back(make_intrusive<ASTLiteral>(0u));
+            builder.select_list.push_back(makeASTFunction("CAST", make_intrusive<ASTLiteral>(0u), make_intrusive<ASTLiteral>("UInt64")));
             builder.select_list.back()->setAlias(ColumnNames::Group);
 
             ASTPtr value = (query_piece.store_method == StoreMethod::CONST_SCALAR)
@@ -92,11 +92,11 @@ SQLQueryPiece toVectorGrid(SQLQueryPiece && query_piece, ConverterContext & cont
 
         case StoreMethod::SCALAR_GRID:
         {
-            /// SELECT 0 AS group, values
+            /// SELECT CAST(0, 'UInt64') AS group, values
             /// FROM <scalar_grid>
             SelectQueryBuilder builder;
 
-            builder.select_list.push_back(make_intrusive<ASTLiteral>(0u));
+            builder.select_list.push_back(makeASTFunction("CAST", make_intrusive<ASTLiteral>(0u), make_intrusive<ASTLiteral>("UInt64")));
             builder.select_list.back()->setAlias(ColumnNames::Group);
 
             builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Values));

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/transformGroupASTForBinaryOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/transformGroupASTForBinaryOperator.cpp
@@ -8,6 +8,24 @@
 namespace DB::PrometheusQueryToSQL
 {
 
+namespace
+{
+    /// Checks whether the specified AST is the zero group, i.e. either the literal 0 or CAST(0, 'UInt64').
+    bool isZeroGroupAST(const ASTPtr & group)
+    {
+        if (const auto * literal = group->as<const ASTLiteral>())
+            return literal->value == Field{0u};
+        if (const auto * function = group->as<const ASTFunction>(); function && (function->name == "CAST") && function->arguments
+            && (function->arguments->children.size() == 2))
+        {
+            const auto * value = function->arguments->children[0]->as<const ASTLiteral>();
+            const auto * type = function->arguments->children[1]->as<const ASTLiteral>();
+            return value && type && (value->value == Field{0u}) && (type->value == Field{"UInt64"});
+        }
+        return false;
+    }
+}
+
 ASTPtr transformGroupASTForBinaryOperator(
     const PQT::BinaryOperator * operator_node,
     ASTPtr && group,
@@ -15,7 +33,7 @@ ASTPtr transformGroupASTForBinaryOperator(
     bool & metric_name_dropped)
 {
     /// Group #0 always means a group with no tags.
-    if (const auto * literal = group->as<const ASTLiteral>(); literal && literal->value == Field{0u})
+    if (isZeroGroupAST(group))
     {
         metric_name_dropped = true;
         return std::move(group);
@@ -27,7 +45,7 @@ ASTPtr transformGroupASTForBinaryOperator(
         {
             /// on() means we ignore all tags.
             metric_name_dropped = true;
-            return make_intrusive<ASTLiteral>(0u);
+            return makeASTFunction("CAST", make_intrusive<ASTLiteral>(0u), make_intrusive<ASTLiteral>("UInt64"));
         }
         else
         {

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -3003,6 +3003,36 @@ def test_binary_operators_on_vectors_without_tags():
         [["[('a','b')]", "1970-01-01 00:03:00.000", 1]],
     )
 
+    # Range queries evaluate time-dependent tag-less vectors as scalar grids,
+    # exercising the StoreMethod::SCALAR_GRID conversion paths.
+    do_range_query_test(
+        "vector(time()) + vector(1)",
+        150,
+        180,
+        10,
+        '{"resultType": "matrix", "result": [{"metric": {}, "values": [[150, "151"], [160, "161"], [170, "171"], [180, "181"]]}]}',
+        [
+            [
+                "[]",
+                "[('1970-01-01 00:02:30.000',151),('1970-01-01 00:02:40.000',161),('1970-01-01 00:02:50.000',171),('1970-01-01 00:03:00.000',181)]",
+            ]
+        ],
+    )
+
+    do_range_query_test(
+        'label_replace(vector(time()), "a", "b", "", "")',
+        150,
+        180,
+        10,
+        '{"resultType": "matrix", "result": [{"metric": {"a": "b"}, "values": [[150, "150"], [160, "160"], [170, "170"], [180, "180"]]}]}',
+        [
+            [
+                "[('a','b')]",
+                "[('1970-01-01 00:02:30.000',150),('1970-01-01 00:02:40.000',160),('1970-01-01 00:02:50.000',170),('1970-01-01 00:03:00.000',180)]",
+            ]
+        ],
+    )
+
 
 def test_aggregation_operators():
     do_query_test(

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -2943,6 +2943,67 @@ def test_set_binary_operators():
     )
 
 
+def test_binary_operators_on_vectors_without_tags():
+    # Operations on instant vectors without any tags used to fail with
+    # "Argument #1 of function timeSeriesGroupToTags has wrong type UInt8, it must be UInt64"
+    # because the group #0 constant was generated as a UInt8 literal.
+    do_query_test(
+        "vector(1) + vector(2)",
+        180,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [180, "3"]}]}',
+        [["[]", "1970-01-01 00:03:00.000", 3]],
+    )
+
+    do_query_test(
+        "vector(1) and vector(2)",
+        180,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [180, "1"]}]}',
+        [["[]", "1970-01-01 00:03:00.000", 1]],
+    )
+
+    do_query_test(
+        "vector(1) or vector(2)",
+        180,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [180, "1"]}]}',
+        [["[]", "1970-01-01 00:03:00.000", 1]],
+    )
+
+    do_query_test(
+        "vector(1) unless vector(2)",
+        180,
+        '{"resultType": "vector", "result": []}',
+        [],
+    )
+
+    do_query_test(
+        "sum(vector(5)) + on() sum(vector(7))",
+        180,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [180, "12"]}]}',
+        [["[]", "1970-01-01 00:03:00.000", 12]],
+    )
+
+    do_query_test(
+        "hour(vector(time())) + minute(vector(time()))",
+        180,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [180, "3"]}]}',
+        [["[]", "1970-01-01 00:03:00.000", 3]],
+    )
+
+    do_query_test(
+        "topk(1, vector(1))",
+        180,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [180, "1"]}]}',
+        [["[]", "1970-01-01 00:03:00.000", 1]],
+    )
+
+    do_query_test(
+        'label_replace(vector(1), "a", "b", "", "")',
+        180,
+        '{"resultType": "vector", "result": [{"metric": {"a": "b"}, "value": [180, "1"]}]}',
+        [["[('a','b')]", "1970-01-01 00:03:00.000", 1]],
+    )
+
+
 def test_aggregation_operators():
     do_query_test(
         "sum(bar)",


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/57545

### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
PromQL: fixed operations on instant vectors without tags, e.g. `vector(1) + vector(2)`, `topk(1, vector(1))`, `label_replace(vector(1), ...)` and binary operators with `on()`, which failed with a type error.

### Description

Binary operators between instant vectors without any tags failed with an error:

```
$ curl 'http://127.0.0.1:9093/api/v1/query?query=vector(1)%2Bvector(2)'
{"status":"error","errorType":"bad_data","error":"Argument #1 of function timeSeriesGroupToTags has wrong type UInt8, it must be UInt64"}
```

The same error affected every construct that materializes a tag-less vector into a vector grid and then feeds its group into a `timeSeries*` function: `vector(1) and/or/unless vector(2)`, `topk(1, vector(1))`, `label_replace(vector(1), ...)` (via `timeSeriesReplaceTag`), binary operators with an empty `on()` (via `timeSeriesThrowDuplicateSeriesIf`), and combinations of date functions such as `hour(vector(time())) + minute(vector(time()))`.

**Root cause**: the group #0 constant (meaning "a group with no tags") was generated as a plain literal `0` in `toVectorGrid`, `applyLabelManipulationFunction` and `transformGroupASTForBinaryOperator`. ClickHouse infers type `UInt8` for such a literal, while all `timeSeries*` functions working with groups require `UInt64`. The aggregation path (`transformGroupASTForAggregationOperator`) already generates `CAST(0, 'UInt64')` for exactly this reason.

**Fix**: generate `CAST(0, 'UInt64')` in the remaining three places, following the existing pattern, and teach the group #0 short-circuit in `transformGroupASTForBinaryOperator` to recognize the CAST form in addition to the plain literal.

**Verified against Prometheus 3.5.0**: all the constructs above now return identical results. The PromQL compliance suite score is unchanged (no regressions; the suite does not cover binary operations between tag-less vectors, which is why this was not caught earlier).

**Testing**: new `test_binary_operators_on_vectors_without_tags` in `tests/integration/test_prometheus_protocols/test_evaluation.py` with 8 cases covering arithmetic/set binary operators, empty `on()`, `topk`, `label_replace` and date-function combinations over tag-less vectors.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.509` (included in `26.8` and later)
<!-- ch-version-info:end -->