### PR TITLE
Do not consume a source block number for row-less chunks in insert deduplication

### DIFF
--- a/src/Processors/Transforms/DeduplicationTokenTransforms.cpp
+++ b/src/Processors/Transforms/DeduplicationTokenTransforms.cpp
@@ -141,7 +141,10 @@ void AddDeduplicationInfoTransform::transform(Chunk & chunk)
     if (info->getVisitedViews().empty())
     {
         info->setRootViewID(root_view_id);
-        info->setSourceBlockNumber(block_number++);
+        /// A row-less chunk carries no dedup token (`setUserToken` with count 0 is a no-op)
+        /// and is dropped by squashing, so it must not consume a source block number.
+        if (chunk.getNumRows() > 0)
+            info->setSourceBlockNumber(block_number++);
     }
     info->updateOriginalBlock(chunk, getInputPort().getSharedHeader());
 }

--- a/src/Processors/tests/gtest_dedup_source_block_number.cpp
+++ b/src/Processors/tests/gtest_dedup_source_block_number.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+
+#include <Columns/ColumnsNumber.h>
+#include <Core/Block.h>
+#include <Core/ColumnWithTypeAndName.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Interpreters/InsertDeduplication.h>
+#include <Processors/Chunk.h>
+#include <Processors/Transforms/DeduplicationTokenTransforms.h>
+
+using namespace DB;
+
+/// Row-less chunks (0 rows, header columns) reach `AddDeduplicationInfoTransform`
+/// (`ISimpleTransform` only skips chunks with neither rows nor columns). They contribute
+/// no token and are dropped by squashing, so numbering one only leaves a gap in the
+/// otherwise-contiguous source block numbers of the data chunks. A unit test rather than
+/// SQL: the interleaved row-less chunk only forms under real multi-host parallel-replicas
+/// timing, which no local single-node query shape reproduces.
+
+namespace
+{
+
+SharedHeader makeHeader()
+{
+    Block header{ColumnWithTypeAndName(std::make_shared<DataTypeUInt64>(), "a")};
+    return std::make_shared<const Block>(std::move(header));
+}
+
+Chunk makeDataChunk(size_t rows)
+{
+    auto column = ColumnUInt64::create();
+    for (size_t i = 0; i < rows; ++i)
+        column->insertValue(i);
+    return Chunk(Columns{std::move(column)}, rows);
+}
+
+/// 0 rows but the header's columns -- what `ISimpleTransform` manufactures downstream.
+Chunk makeRowlessChunk(const SharedHeader & header)
+{
+    return Chunk(header->cloneEmpty().getColumns(), 0);
+}
+
+DeduplicationInfo::Ptr infoOf(const Chunk & chunk)
+{
+    return chunk.getChunkInfos().getSafe<DeduplicationInfo>();
+}
+
+}
+
+/// Fails without the fix, passes with it. Shape: data / row-less / data / data.
+/// Two adjacent data chunks separated only by the row-less chunk must merge into one
+/// token (`getCount` 1) -- the row-less chunk must not split them. Two data chunks
+/// separated by another data chunk carry non-adjacent numbers and must stay two tokens
+/// (`getCount` 2); this second assertion also fails if source numbering is silently
+/// removed, so it pins that numbers are actually assigned.
+///
+/// `getCount` (offsets, == deduplication hashes when enabled) is asserted, not
+/// `getDeduplicationHashes`: the header-only ctor leaves `insert_dependencies` null, so
+/// the info is disabled and `getDeduplicationHashes` early-returns {} -- while the
+/// extend/concat and numbering logic is unaffected. So `getCount` is the disabled-agnostic
+/// signal (a value check, not a `chassert` abort).
+TEST(DedupSourceNumberHole, RowlessChunkDoesNotBreakTokenMerge)
+{
+    auto header = makeHeader();
+    AddDeduplicationInfoTransform transform(header);
+
+    Chunk first = makeDataChunk(2);
+    transform.transform(first);
+
+    Chunk rowless = makeRowlessChunk(header);
+    transform.transform(rowless);
+
+    Chunk second = makeDataChunk(2);
+    transform.transform(second);
+
+    Chunk third = makeDataChunk(2);
+    transform.transform(third);
+
+    auto merged_adjacent = infoOf(first)->mergeSelf(infoOf(second));
+    EXPECT_EQ(merged_adjacent->getCount(), 1u)
+        << "a row-less chunk must not consume a source block number and split the token "
+           "of the surrounding data chunks";
+
+    auto merged_non_adjacent = infoOf(first)->mergeSelf(infoOf(third));
+    EXPECT_EQ(merged_non_adjacent->getCount(), 2u)
+        << "data chunks with non-adjacent source numbers must stay two tokens; if numbering "
+           "silently stopped this merge would wrongly collapse into one";
+}
+
+/// The gap a row-less chunk would leave: source numbers 0 and 2 concat into two tokens and
+/// two hashes -- the state that trips the sink assert. Pins that `canBeExtended` must not
+/// tolerate gaps, or the block id would depend on how many empty chunks interleaved.
+TEST(DedupSourceNumberHole, HoleProducesTwoHashes)
+{
+    auto left = DeduplicationInfo::create(/*async_insert*/ false);
+    left->setUserToken("x", 2);
+    left->setSourceBlockNumber(0);
+
+    auto right = DeduplicationInfo::create(/*async_insert*/ false);
+    right->setUserToken("x", 2);
+    right->setSourceBlockNumber(2);
+
+    auto merged = left->mergeSelf(right);
+    auto hashes = merged->getDeduplicationHashes("", /*deduplication_enabled*/ true);
+    EXPECT_EQ(hashes.size(), 2u) << "non-contiguous source numbers must concat into two tokens";
+}
+
+/// Healthy path: contiguous source numbers 0 and 1 extend into one token and one hash.
+TEST(DedupSourceNumberHole, ContiguousProducesOneHash)
+{
+    auto left = DeduplicationInfo::create(/*async_insert*/ false);
+    left->setUserToken("x", 2);
+    left->setSourceBlockNumber(0);
+
+    auto right = DeduplicationInfo::create(/*async_insert*/ false);
+    right->setUserToken("x", 2);
+    right->setSourceBlockNumber(1);
+
+    auto merged = left->mergeSelf(right);
+    auto hashes = merged->getDeduplicationHashes("", /*deduplication_enabled*/ true);
+    EXPECT_EQ(hashes.size(), 1u) << "contiguous source numbers must extend into one token";
+}


### PR DESCRIPTION
<!--
No related open issue found (searched: deduplication_hashes.size, dedup LOGICAL_ERROR, source block number).
Surfaced by CI Stress test (amd_msan):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111754&sha=79ec7ed9daf6348f4d886d723048dbacf5a4324a&name_0=PR&name_1=Stress%20test%20%28amd_msan%29
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes nondeterministic insert deduplication block ids when a row-less chunk interleaves with data chunks during an `INSERT SELECT` (for example under parallel replicas). Such an insert can miss deduplication and produce duplicate rows on retry, and asserts `deduplication_hashes.size() == 1` in debug and sanitizer builds.


### Description

`AddDeduplicationInfoTransform` numbered every arriving chunk with an incrementing source block number, including row-less chunks (0 rows, with columns; these reach the transform because `ISimpleTransform` only skips chunks that have neither rows nor columns). A row-less chunk contributes no deduplication token (`setUserToken` with count 0 is a no-op) and is later dropped by squashing, so numbering it only leaves a gap in the source block numbers.

That gap breaks the contiguity check in `TokenDefinition::canBeExtended` (source number ranges must be adjacent), so squashing merges the two surrounding data blocks with `do_concat` instead of extending a single token. The squashed single part then carries several deduplication tokens, `getDeduplicationHashes` returns several hashes for one part, and `ReplicatedMergeTreeSink` asserts `deduplication_hashes.size() == 1`. In release builds the assert is compiled out and the part commits with two block ids whose values depend on where the row-less chunk interleaved (thread-timing dependent), so an identical retried insert computes different ids, misses deduplication, and duplicates rows.

Fix: do not consume a source block number for row-less chunks. Source numbers then stay contiguous arrival indices of data chunks, a squashed block keeps a single deduplication token and hash, and the assert holds.

The regression test is a unit test (`gtest_dedup_source_block_number`) rather than an SQL test: the interleaved row-less chunk only forms under real multi-host parallel-replicas timing, so no local single-node SQL shape delivers one to the transform (verified across six query shapes and eighty iterations). The test drives `AddDeduplicationInfoTransform` directly and fails without this fix (two tokens) and passes with it (one token).

Surfaced as `Logical error: 'deduplication_hashes.size() == 1'` by the `Stress test (amd_msan)` check on an unrelated docs-only PR: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111754&sha=79ec7ed9daf6348f4d886d723048dbacf5a4324a&name_0=PR&name_1=Stress%20test%20%28amd_msan%29