### PR TITLE
Play UI: hand focus off before hiding the close-other-tabs button

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -8170,8 +8170,13 @@ function renderTabBar() {
     /// fresh page can be backgrounded: the user needs the `[+]` button to open a second tab (or
     /// switch away) while that first query is still in flight.
     tab_bar_elem.hidden = (tabs.length <= 1 && !(active && active.result && active.result.ran) && !anyInFlight());
-    /// With a single tab there are no "other" tabs to close; show it only for 2+.
+    /// With a single tab there are no "other" tabs to close; show it only for 2+. Hiding a
+    /// focused element strands keyboard focus (same problem `syncConnectionUI` solves for the
+    /// 🔑 button): activating this button with Enter/Space on exactly two tabs hides it in the
+    /// resulting rerender, so hand focus to the query area — always visible — before hiding.
+    const closeOthersHadFocus = document.activeElement === tab_close_others_elem;
     tab_close_others_elem.hidden = tabs.length < 2;
+    if (closeOthersHadFocus && tab_close_others_elem.hidden) query_area.focus();
     syncConnectionUI();
 
     tabs_elem.textContent = '';


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Follow-up to https://github.com/ClickHouse/ClickHouse/pull/111835: when the `#tab-close-others` button in `play.html` is activated with Enter/Space and exactly two tabs are open, the rerender in `renderTabBar` hides the button while it still owns keyboard focus, stranding focus on a hidden element. Mirror the handoff `syncConnectionUI` performs for the 🔑 button and move focus to the always-visible query area before hiding the button. Addresses the unresolved review thread in the original PR.

Related: https://github.com/ClickHouse/ClickHouse/pull/111835


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.130` (included in `26.8` and later)
<!-- ch-version-info:end -->