### PR TITLE
Actually disable Dependabot in CI and test directories

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,148 +1,113 @@
-# Test-level dependencies: the older the better. Inhibit dependabot, so we only accept manual updates.
+# ClickHouse pins its CI, test and tooling dependencies on purpose - for test-level
+# dependencies the older the better - and updates them manually, so Dependabot should not open
+# pull requests anywhere in this repository.
+#
+# Switching Dependabot off takes two settings per block, because its two features follow
+# different rules:
+#
+# 1. Version updates run only for the (`package-ecosystem`, directory) pairs listed in this
+#    file, and `open-pull-requests-limit: 0` turns them off.
+# 2. Security updates are triggered by Dependabot alerts against the dependency graph, not by
+#    this file. They are not subject to `open-pull-requests-limit` and are not delayed by
+#    `cooldown` - both of those apply to version updates only. The only way to suppress a
+#    security update from here is `ignore` with `dependency-name: "*"` in a block whose
+#    `package-ecosystem` and directory match the manifest that the alert points at.
+#
+# The directory has to match the manifest: `directory` is a single literal path, it is neither
+# recursive nor does it accept wildcards, so `directory: "/ci/docker"` has no effect on
+# `ci/docker/fuzzer/requirements.txt`. Use `directories` (plural) with the `**/*` globstar,
+# which does match nested directories, and list the repository root separately.
+#
+# There has to be a block for every package manager that has manifests in the repository - add
+# one whenever a new kind of manifest is introduced.
+#
+# This file only suppresses pull requests, not the alerts themselves. The repository-wide
+# switch is `Dependabot security updates` in Settings -> Code security.
 version: 2
 updates:
-  # Disable Dependabot for ci/docker (all ecosystems)
-  - package-ecosystem: "docker"
-    directory: "/ci/docker"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 90
-    open-pull-requests-limit: 0
-    ignore:
-      - dependency-name: "*"
-
+  # Python: `requirements.txt` under `ci/docker`, `pyproject.toml`, `setup.py`, `utils`, tests.
   - package-ecosystem: "pip"
-    directory: "/ci/docker"
+    directories:
+      - "/"
+      - "**/*"
     schedule:
       interval: "monthly"
-    cooldown:
-      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
 
-  - package-ecosystem: "npm"
-    directory: "/ci/docker"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 90
-    open-pull-requests-limit: 0
-    ignore:
-      - dependency-name: "*"
-
-  - package-ecosystem: "github-actions"
-    directory: "/ci/docker"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 90
-    open-pull-requests-limit: 0
-    ignore:
-      - dependency-name: "*"
-
-  # Disable Dependabot for tests/integration (all ecosystems)
+  # Base images in `Dockerfile`s.
   - package-ecosystem: "docker"
-    directory: "/tests/integration"
+    directories:
+      - "/"
+      - "**/*"
     schedule:
       interval: "monthly"
-    cooldown:
-      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
 
-  - package-ecosystem: "pip"
-    directory: "/tests/integration"
+  # Images in the Compose files of integration tests.
+  - package-ecosystem: "docker-compose"
+    directories:
+      - "/"
+      - "**/*"
     schedule:
       interval: "monthly"
-    cooldown:
-      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
 
+  # Java clients and catalogs used by integration tests (`pom.xml`).
+  - package-ecosystem: "maven"
+    directories:
+      - "/"
+      - "**/*"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+
+  # .NET clients used by integration tests (`*.csproj`).
+  - package-ecosystem: "nuget"
+    directories:
+      - "/"
+      - "**/*"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+
+  # JavaScript, e.g. the reports UI.
   - package-ecosystem: "npm"
-    directory: "/tests/integration"
+    directories:
+      - "/"
+      - "**/*"
     schedule:
       interval: "monthly"
-    cooldown:
-      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
 
-  - package-ecosystem: "github-actions"
-    directory: "/tests/integration"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 90
-    open-pull-requests-limit: 0
-    ignore:
-      - dependency-name: "*"
-
-  # Disable Dependabot for docker/test (all ecosystems)
-  - package-ecosystem: "docker"
-    directory: "/docker/test"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 90
-    open-pull-requests-limit: 0
-    ignore:
-      - dependency-name: "*"
-
-  - package-ecosystem: "pip"
-    directory: "/docker/test"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 90
-    open-pull-requests-limit: 0
-    ignore:
-      - dependency-name: "*"
-
-  - package-ecosystem: "npm"
-    directory: "/docker/test"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 90
-    open-pull-requests-limit: 0
-    ignore:
-      - dependency-name: "*"
-
-  - package-ecosystem: "github-actions"
-    directory: "/docker/test"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 90
-    open-pull-requests-limit: 0
-    ignore:
-      - dependency-name: "*"
-
-  # Disable Dependabot for all Rust (cargo) dependencies.
-  # Rust crates are pinned via Cargo.lock and built reproducibly; updates must be
-  # done manually together with lockfile and vendored-source refreshes.
+  # Rust crates are pinned via `Cargo.lock` and built reproducibly; updates must be done
+  # manually together with lockfile and vendored-source refreshes.
   - package-ecosystem: "cargo"
-    directory: "/rust/chcache"
+    directories:
+      - "/"
+      - "**/*"
     schedule:
       interval: "monthly"
-    cooldown:
-      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
 
-  - package-ecosystem: "cargo"
-    directory: "/rust/workspace"
+  # Actions in the workflows. For `github-actions` the directory is always the root.
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "monthly"
-    cooldown:
-      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,7 @@
-# ClickHouse pins its CI, test and tooling dependencies on purpose - for test-level
-# dependencies the older the better - and updates them manually, so Dependabot should not open
-# pull requests anywhere in this repository.
+# Test-level dependencies: the older the better. Inhibit dependabot, so we only accept manual updates.
+#
+# ClickHouse pins its CI, test and tooling dependencies on purpose and updates them manually,
+# so Dependabot should not open pull requests anywhere in this repository.
 #
 # Switching Dependabot off takes two settings per block, because its two features follow
 # different rules:
@@ -97,6 +98,15 @@ updates:
     directories:
       - "/"
       - "**/*"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+
+  # Submodules in `contrib`, listed in `.gitmodules` at the repository root.
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 0


### PR DESCRIPTION
The `updates` blocks in `.github/dependabot.yaml` did not match the manifests they were supposed to silence, so Dependabot kept opening pull requests for CI and test dependencies, e.g. https://github.com/ClickHouse/ClickHouse/pull/111886 for `ci/docker/performance-comparison/requirements.txt`.

Three separate reasons:

- `directory` is a single literal path: it is not recursive and does not accept wildcards. `directory: "/ci/docker"` therefore covered nothing, because there is no manifest directly in `ci/docker` - they all live in subdirectories such as `ci/docker/fuzzer`. Only the `directories` key (plural) supports globbing, so `**/*` is used instead.
- `open-pull-requests-limit: 0` and `cooldown` apply to version updates only. The pull requests we keep getting are security updates, triggered by Dependabot alerts rather than by this file, and the only thing here that suppresses them is `ignore` with `dependency-name: "*"` in a block whose `package-ecosystem` and directory match the manifest that the alert points at. The `cargo` blocks did match, which is why Rust pull requests stopped in May.
- `maven`, `nuget` and `docker-compose` manifests were not covered by any block, and `/docker/test` no longer exists - the images moved to `ci/docker`.

Now there is one block per package manager that has manifests in the repository, each covering the whole repository, with a comment explaining which option is needed for which kind of update.

Note that this only stops the pull requests; the alerts themselves are controlled by the `Dependabot security updates` repository setting.

Related: https://github.com/ClickHouse/ClickHouse/pull/111886
Related: https://github.com/ClickHouse/ClickHouse/pull/111885
Related: https://github.com/ClickHouse/ClickHouse/pull/111887
Related: https://github.com/ClickHouse/ClickHouse/pull/111889

### Changelog category (leave one):
- CI Fix or Improvement


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.179` (included in `26.8` and later)
<!-- ch-version-info:end -->