### PR TITLE
Fix flaky test 04546_constant_join_shrink_stored_blocks

### DIFF
--- a/tests/queries/0_stateless/04546_constant_join_shrink_stored_blocks.sql
+++ b/tests/queries/0_stateless/04546_constant_join_shrink_stored_blocks.sql
@@ -22,12 +22,16 @@ WHERE (event_date >= yesterday())
 AND (event_time >= (now() - 600))
 AND (query_id IN
 (
+    -- Newest matching query only: `clickhouse-test --database` reuses the database across runs,
+    -- so an earlier run's row must not satisfy the assertion for the current one.
     SELECT query_id
         FROM system.query_log
         WHERE (log_comment = '04546_constant_join_shrink')
         AND (current_database = currentDatabase())
         AND (type = 'QueryFinish')
         AND (event_date >= yesterday())
+        ORDER BY event_time_microseconds DESC
+        LIMIT 1
     )
 )
 AND (logger_name = 'ConstantJoin')

--- a/tests/queries/0_stateless/04546_constant_join_shrink_stored_blocks.sql
+++ b/tests/queries/0_stateless/04546_constant_join_shrink_stored_blocks.sql
@@ -18,7 +18,8 @@ SYSTEM FLUSH LOGS query_log, text_log;
 SELECT count() > 0 AS shrunk_stored_blocks
 FROM system.text_log
 WHERE (event_date >= yesterday())
-AND (event_time >= (now() - 60))
+-- Must exceed any `SYSTEM FLUSH LOGS` delay possible within the 600s per-test timeout: `event_time` is the emission time.
+AND (event_time >= (now() - 600))
 AND (query_id IN
 (
     SELECT query_id


### PR DESCRIPTION
Fix flaky test 04546_constant_join_shrink_stored_blocks

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110886
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/110886

`04546_constant_join_shrink_stored_blocks` intermittently outputs `0` instead of `1` for its middle assertion `shrunk_stored_blocks`.

The assertion reads the `ConstantJoin` "Shrinking stored blocks" line from `system.text_log`, filtered by a 60-second recency window (`event_time >= now() - 60`). `text_log.event_time` is the message emission time, not the flush time, so the window races the duration of the preceding `SYSTEM FLUSH LOGS`. On a loaded parallel runner that flush takes tens of seconds, the emitted line ages out of the window, and `count()` returns 0.

Measured on four failing runs. In each the shrink line was emitted and only the time predicate excluded it, and the line's age at the assertion sits at or just past the 60-second boundary:

| Run | `SYSTEM FLUSH LOGS` | line age at assertion |
|---|---|---|
| master `693a303c1017` | 65.8 s | ~66 s |
| #110886 `06b7c4b127f` | 59.7 s | ~60.4 s |
| #111790 | 101.2 s | ~101 s |
| #111691 `19338ecf1813` | 60.9 s | ~62 s |

For the master and #110886 runs the server log holds the line for the exact failing query id (`ConstantJoin: Shrinking stored blocks` at 06:26:18.990 and 01:55:02.893), so the shrink did happen. `system.text_log` dropped nothing: the failing master run logs no `Queue is full for system log` and its flush offsets advance continuously.

The in-place reruns point at runner load rather than at randomized settings: in the #110886 job 19 databases ran this test, 18 of them flushed in 148-420 ms, and only the failing one took 59.7 s. The master job likewise ran the test once, at 65.8 s.

Since the test reached master on 2026-07-24 this signature has hit 10 runs in CIDB: master once plus 9 unrelated PRs, 9 of them on `Stateless tests (amd_tsan, parallel)` and one on `Stateless tests (amd_msan, WasmEdge, parallel, 1/2)`. Those 10 runs have a median duration of 74 s, against a few seconds for the several thousand passing runs on the same checks.

Fix: widen the window to 600 s. The per-test timeout is 600 s (`clickhouse-test --timeout` default, and no CI stateless job overrides it), so a flush slow enough to push the line past a 600 s window trips that timeout first; the observed worst case leaves a 6x margin. The assertion is not weakened: `count() > 0` and the reference are unchanged, and rows stay scoped exactly by `query_id` from `system.query_log` filtered on `log_comment` and `current_database = currentDatabase()`, with a fresh database per test run, so the time predicate only prunes the scan. If shrinking ever regressed, the line would be absent and the test would still fail. 600 s is the common outer recency bound among the stateless tests that time-bound a `system.text_log` read, and the 60 s bound here was the outlier; `00177_memory_bound_merging.sh` uses `now() - 600` on the same text_log-via-query_id pattern.

Reports:
- master: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=693a303c1017477fc39aaa7706af0ec078e13fbc&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%29
- #110886: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110886&sha=06b7c4b127f65dbc45d7c26d867a4801c0742209&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.153` (included in `26.8` and later)
<!-- ch-version-info:end -->