### PR TITLE
Fix TTL merge slot leak when a selected merge is dropped before execution

### DIFF
--- a/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
@@ -16,6 +16,8 @@
 
 #include <Core/BackgroundSchedulePool.h>
 
+#include <base/scope_guard.h>
+
 namespace ProfileEvents
 {
     extern const Event DataAfterMergeDiffersFromReplica;
@@ -353,9 +355,15 @@ ReplicatedMergeMutateTaskBase::PrepareResult MergeFromLogEntryTask::prepare()
         }
     }
 
-    /// Account TTL merge
+    /// Account TTL merge. The booking is handed to the `MergeList` entry below (released in
+    /// `onEntryDestroy`); the guard releases it if anything between here and the insert throws.
+    scope_guard ttl_merge_booking;
     if (isTTLMergeType(future_merged_part->merge_type))
-        storage.getContext()->getMergeList().bookMergeWithTTL();
+    {
+        auto & merge_list = storage.getContext()->getMergeList();
+        ttl_merge_booking = [&merge_list] { merge_list.cancelMergeWithTTL(); };
+        merge_list.bookMergeWithTTL();
+    }
 
     auto table_id = storage.getStorageID();
 
@@ -368,6 +376,7 @@ ReplicatedMergeMutateTaskBase::PrepareResult MergeFromLogEntryTask::prepare()
         storage.getStorageID(),
         future_merged_part,
         task_context);
+    ttl_merge_booking.release();
 
     storage.writePartLog(
         PartLogElement::MERGE_PARTS_START, {}, 0,

--- a/src/Storages/MergeTree/MergeList.h
+++ b/src/Storages/MergeTree/MergeList.h
@@ -167,7 +167,10 @@ public:
     void onEntryDestroy(const Parent::Entry & entry) override
     {
         if (isTTLMergeType(entry->merge_type))
-            --merges_with_ttl_counter;
+        {
+            [[maybe_unused]] const size_t prev = merges_with_ttl_counter.fetch_sub(1);
+            chassert(prev > 0);
+        }
     }
 
     void cancelPartMutations(const StorageID & table_id, const String & partition_id, Int64 mutation_version)
@@ -217,7 +220,8 @@ public:
 
     void cancelMergeWithTTL()
     {
-        --merges_with_ttl_counter;
+        [[maybe_unused]] const size_t prev = merges_with_ttl_counter.fetch_sub(1);
+        chassert(prev > 0);
     }
 
     size_t getMergesWithTTLCount() const

--- a/src/Storages/MergeTree/MergeMutateSelectedEntry.h
+++ b/src/Storages/MergeTree/MergeMutateSelectedEntry.h
@@ -3,6 +3,8 @@
 #include <Storages/MergeTree/FutureMergedMutatedPart.h>
 #include <Storages/MutationCommands.h>
 
+#include <base/scope_guard.h>
+
 namespace DB
 {
 
@@ -47,6 +49,9 @@ struct MergeMutateSelectedEntry
     MergeTreeTransactionPtr txn;
     Strings mutation_ids; /// List of mutation version strings being applied
     bool finalized{false};
+    /// Releases the TTL merge slot booked in `MergeList` for this entry if the merge is abandoned
+    /// before its `MergeListEntry` is created. Disarmed once that entry takes over the accounting.
+    scope_guard ttl_merge_booking;
     MergeMutateSelectedEntry(FutureMergedMutatedPartPtr future_part_, CurrentlyMergingPartsTaggerPtr tagger_,
                              MutationCommandsConstPtr commands_, const MergeTreeTransactionPtr & txn_ = NO_TRANSACTION_PTR,
                              Strings mutation_ids_ = {})

--- a/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
@@ -99,6 +99,10 @@ void MergePlainMergeTreeTask::prepare()
         storage.getStorageID(),
         future_part,
         task_context);
+    /// The `MergeList` entry now carries the TTL merge slot booking (released in `onEntryDestroy`),
+    /// so hand it over: disarm the guard without releasing. Must be the next statement after a
+    /// successful insert so nothing in between can throw and double-release the slot.
+    merge_mutate_entry->ttl_merge_booking.release();
 
     storage.writePartLog(
         PartLogElement::MERGE_PARTS_START, {}, 0,

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -1685,24 +1685,24 @@ std::expected<MergeMutateSelectedEntryPtr, SelectMergeFailure> StorageMergeTree:
 
     const auto construct_merge_select_entry = [&](FutureMergedMutatedPartPtr future_part) -> std::expected<MergeMutateSelectedEntryPtr, SelectMergeFailure>
     {
-        /// Account TTL merge here to avoid exceeding the max_number_of_merges_with_ttl_in_pool limit
+        /// Account TTL merge here to avoid exceeding the `max_number_of_merges_with_ttl_in_pool` limit.
+        /// The guard captures the global `MergeList` (outlives all storages and tasks) and releases the
+        /// booking on any path that abandons the merge before its `MergeListEntry` exists; it is handed
+        /// to the entry and disarmed by `MergePlainMergeTreeTask::prepare` once that entry takes over.
+        scope_guard ttl_merge_booking;
         if (isTTLMergeType(future_part->merge_type))
-            getContext()->getMergeList().bookMergeWithTTL();
-
-        try
         {
-            uint64_t needed_disk_space = CompactionStatistics::estimateNeededDiskSpace(future_part->parts, true);
-            auto tagger = std::make_unique<CurrentlyMergingPartsTagger>(future_part, needed_disk_space, *this, metadata_snapshot, false);
-
-            return std::make_shared<MergeMutateSelectedEntry>(future_part, std::move(tagger), std::make_shared<MutationCommands>());
+            auto & merge_list = getContext()->getMergeList();
+            ttl_merge_booking = [&merge_list] { merge_list.cancelMergeWithTTL(); };
+            merge_list.bookMergeWithTTL();
         }
-        catch (...)
-        {
-            if (isTTLMergeType(future_part->merge_type))
-                getContext()->getMergeList().cancelMergeWithTTL();
 
-            throw;
-        }
+        uint64_t needed_disk_space = CompactionStatistics::estimateNeededDiskSpace(future_part->parts, true);
+        auto tagger = std::make_unique<CurrentlyMergingPartsTagger>(future_part, needed_disk_space, *this, metadata_snapshot, false);
+
+        auto entry = std::make_shared<MergeMutateSelectedEntry>(future_part, std::move(tagger), std::make_shared<MutationCommands>());
+        entry->ttl_merge_booking = std::move(ttl_merge_booking);
+        return entry;
     };
 
     if (partition_id.empty())
@@ -2110,10 +2110,6 @@ bool StorageMergeTree::scheduleDataProcessingJob(BackgroundJobsAssignee & assign
         }
 
         bool scheduled = assignee.scheduleMergeMutateTask(task);
-        /// The problem that we already booked a slot for TTL merge, but a merge list entry will be created only in a prepare method
-        /// in MergePlainMergeTreeTask. So, this slot will never be freed.
-        if (!scheduled && isTTLMergeType(merge_entry->future_part->merge_type))
-            getContext()->getMergeList().cancelMergeWithTTL();
 
         fiu_do_on(FailPoints::storage_merge_tree_background_schedule_merge_fail,
         {

--- a/tests/queries/0_stateless/04641_ttl_merge_slot_leak_unscheduled.reference
+++ b/tests/queries/0_stateless/04641_ttl_merge_slot_leak_unscheduled.reference
@@ -1,0 +1,3 @@
+count after inserts: 2
+OK: background TTL merge ran after a dropped selection
+OK: second background TTL merge cycle ran

--- a/tests/queries/0_stateless/04641_ttl_merge_slot_leak_unscheduled.sh
+++ b/tests/queries/0_stateless/04641_ttl_merge_slot_leak_unscheduled.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Tags: long, no-parallel, no-shared-merge-tree, no-random-settings, no-random-merge-tree-settings
+# ^ long: waits for the background merge pool to make progress within a bounded time window.
+# ^ no-parallel: uses the global `mt_skip_scheduling_merge_once` failpoint (same as 04492).
+# ^ no-shared-merge-tree: the `Manual` merge selector and the failpoint apply to plain `MergeTree`.
+# ^ no-random-settings, no-random-merge-tree-settings: the test pins the settings that drive
+#   the background TTL selection (cap, selector, `ttl_only_drop_parts`).
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# A TTL merge books a slot against `max_number_of_merges_with_ttl_in_pool` at SELECTION time; the
+# booking is handed to the `MergeList` entry only when the merge starts executing. If the selected
+# merge is dropped before that (here: the `mt_skip_scheduling_merge_once` failpoint, standing in for
+# the pending-queue kill a `DROP`/`DETACH TABLE` performs), the slot must still be released. Otherwise
+# the global counter leaks and, once it reaches the cap, background TTL merges stop server-wide until
+# restart. cap=1 makes a single leak decisive. A second cycle on a fresh table, run after `DROP`ping
+# the first so its whole task (and the slot accounting it carries) is destroyed, catches the opposite
+# error: an over-released slot wraps the counter, so no further TTL merge is ever admitted.
+
+${CLICKHOUSE_CLIENT} -m -q "
+DROP TABLE IF EXISTS t_ttl_slot_leak;
+DROP TABLE IF EXISTS t_ttl_slot_leak_2;
+
+CREATE TABLE t_ttl_slot_leak (d Date, x UInt64)
+ENGINE = MergeTree ORDER BY x
+TTL d + INTERVAL 1 MONTH
+SETTINGS ttl_only_drop_parts = 1, merge_with_ttl_timeout = 0,
+         max_number_of_merges_with_ttl_in_pool = 1,
+         merge_selector_algorithm = 'Manual';
+
+SYSTEM STOP MERGES t_ttl_slot_leak;
+
+-- One fully expired part and one fresh part. The TTL margin is much larger than one day so a
+-- randomized \`session_timezone\` cannot shift \`today\` across the expiry boundary.
+INSERT INTO t_ttl_slot_leak VALUES (today() - 100, 1);
+INSERT INTO t_ttl_slot_leak VALUES (today(), 2);
+"
+
+# Both parts exist before the failpoint drops the first selected TTL merge (merges are still stopped).
+echo "count after inserts: $(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_ttl_slot_leak")"
+
+# Wait until the expired part is dropped by a background TTL merge. On a leaking build the slot is
+# stuck at the cap (1), `merge_with_ttl_allowed` is false forever, and the expired part is never
+# dropped; `count()` stays 2 until the deadline. On a fixed build the freed slot lets the next
+# selection round re-pick the TTL-drop, and `count()` becomes 1 within seconds.
+wait_for_count_1() {
+    local table=$1
+    for _ in $(seq 1 120); do
+        if [[ "$(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM $table")" -eq 1 ]]; then
+            return 0
+        fi
+        # Nudge the background assignee so it re-evaluates promptly instead of sleeping on its backoff.
+        ${CLICKHOUSE_CLIENT} -q "SYSTEM START MERGES $table"
+        sleep 0.5
+    done
+    return 1
+}
+
+# Drop the first scheduled background merge exactly once. The TTL-drop is selected before any
+# regular merge (and the `Manual` selector has no manual queue entry), so the failpoint consumes
+# the TTL merge: its slot is booked, then the merge is dropped without ever executing.
+${CLICKHOUSE_CLIENT} -m -q "
+SYSTEM ENABLE FAILPOINT mt_skip_scheduling_merge_once;
+SYSTEM START MERGES t_ttl_slot_leak;
+"
+
+if wait_for_count_1 t_ttl_slot_leak; then
+    echo "OK: background TTL merge ran after a dropped selection"
+else
+    echo "FAIL: background TTL merge did not run (slot leaked)"
+fi
+
+# The `ONCE` failpoint auto-disables when it fires; still enabled here means cycle 1 never
+# exercised the dropped-selection path. (Empty `system.fail_points` = failpoints compiled out.)
+if [[ "$(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.fail_points WHERE name = 'mt_skip_scheduling_merge_once' AND enabled")" -ne 0 ]]; then
+    echo "FAIL: failpoint was not consumed by the first cycle"
+fi
+
+# Barrier: `DROP TABLE` waits (`removeTasksCorrespondingToStorage`) for cycle 1's task to be fully
+# destroyed, including the entry that carries the slot accounting, so the counter has settled in
+# every build type before cycle 2 begins.
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_slot_leak"
+
+# Second cycle on a fresh table, with the `ONCE` failpoint already consumed: this merge must be
+# selected, booked, executed, and destroyed with correct accounting against the GLOBAL counter.
+# If cycle 1 over-released the slot, the counter wrapped when its task was destroyed and no TTL
+# merge is ever admitted again (the cap can never exceed the wrapped value).
+${CLICKHOUSE_CLIENT} -m -q "
+CREATE TABLE t_ttl_slot_leak_2 (d Date, x UInt64)
+ENGINE = MergeTree ORDER BY x
+TTL d + INTERVAL 1 MONTH
+SETTINGS ttl_only_drop_parts = 1, merge_with_ttl_timeout = 0,
+         max_number_of_merges_with_ttl_in_pool = 1,
+         merge_selector_algorithm = 'Manual';
+
+SYSTEM STOP MERGES t_ttl_slot_leak_2;
+
+INSERT INTO t_ttl_slot_leak_2 VALUES (today() - 100, 1);
+INSERT INTO t_ttl_slot_leak_2 VALUES (today(), 2);
+
+SYSTEM START MERGES t_ttl_slot_leak_2;
+"
+
+if wait_for_count_1 t_ttl_slot_leak_2; then
+    echo "OK: second background TTL merge cycle ran"
+else
+    echo "FAIL: second TTL merge cycle did not run (slot over-released or leaked)"
+fi
+
+${CLICKHOUSE_CLIENT} -m -q "
+SYSTEM DISABLE FAILPOINT mt_skip_scheduling_merge_once;
+DROP TABLE IF EXISTS t_ttl_slot_leak_2;
+"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/96130

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes background TTL merges stopping server-wide when a selected TTL merge is dropped before it starts executing (for example, when its table is dropped or detached while the merge is still queued in the background pool). Each such merge leaked a slot booked against `max_number_of_merges_with_ttl_in_pool`; once the counter reached the limit, no further TTL merges were scheduled until the server was restarted.

### Description

A non-replicated TTL merge books a slot in the global counter for `max_number_of_merges_with_ttl_in_pool` at merge selection time (to close the assign-vs-execute race), and the booking is handed over to the `MergeList` entry only when the merge starts executing. If the selected merge is abandoned before that handover, the slot was leaked. Two abandonment paths were compensated; several were not, most notably the pending-queue removal that `DROP`/`DETACH TABLE` performs on a merge still waiting in the background pool. Each leak permanently decrements the number of TTL merges the server can run; once it reaches the per-table limit (default 2), `merge_with_ttl_allowed` is false for every default-limit table and background TTL merges stop server-wide until restart, while regular merges keep running.

The fix makes the booking a scope guard owned by the selected-merge entry, released automatically on any path that abandons the merge before its `MergeList` entry exists, and disarmed once that entry takes over the accounting. This replaces the two ad-hoc per-path compensations with a single mechanism covering every abandonment path. The same book-to-insert gap in the replicated path (`MergeFromLogEntryTask`) is guarded symmetrically. A debug/sanitizer assertion guards the counter against underflow.

The flaky test `04321_table_readonly_background_merges` surfaced this: its writable control table relies on a background TTL merge, which never ran once the global counter had leaked to the limit earlier in the run (test `02293_part_log_has_merge_reason`, the only test setting the limit to 100, was unaffected, which pinpointed the counter). Report where it was observed: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96130&sha=0aa6569f3e6563c982227857effd5d2d19c97527&name_0=PR&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20azure%2C%20parallel%29

Regression test `04641_ttl_merge_slot_leak_unscheduled` reproduces the leak deterministically via the `mt_skip_scheduling_merge_once` failpoint (which drops a selected merge exactly once, the same accounting gap the table-drop hits) with the limit set to 1, and verifies that a later background TTL merge still runs after the dropped selection, and that a second TTL merge cycle runs afterwards (either a leaked or an over-released slot makes the second cycle time out, so the test discriminates both accounting errors in all build types).