### PR TITLE
Read JSON null as NaN for Float elements of composite types

### DIFF
--- a/src/DataTypes/Serializations/SerializationArray.cpp
+++ b/src/DataTypes/Serializations/SerializationArray.cpp
@@ -816,14 +816,14 @@ ReturnType SerializationArray::deserializeTextJSONImpl(IColumn & column, ReadBuf
         if constexpr (std::is_same_v<ReturnType, void>)
         {
             if (settings.null_as_default && !isColumnNullableOrLowCardinalityNullable(nested_column))
-                SerializationNullable::deserializeNullAsDefaultOrNestedTextJSON(nested_column, buf, settings, nested);
+                SerializationNullable::deserializeNullAsDefaultOrNestedTextJSON(nested_column, buf, settings, nested, /*is_composite_element=*/true);
             else
                 nested->deserializeTextJSON(nested_column, buf, settings);
         }
         else
         {
             if (settings.null_as_default && !isColumnNullableOrLowCardinalityNullable(nested_column))
-                return SerializationNullable::tryDeserializeNullAsDefaultOrNestedTextJSON(nested_column, buf, settings, nested);
+                return SerializationNullable::tryDeserializeNullAsDefaultOrNestedTextJSON(nested_column, buf, settings, nested, /*is_composite_element=*/true);
             return nested->tryDeserializeTextJSON(nested_column, buf, settings);
         }
     };

--- a/src/DataTypes/Serializations/SerializationMap.cpp
+++ b/src/DataTypes/Serializations/SerializationMap.cpp
@@ -414,14 +414,14 @@ ReturnType SerializationMap::deserializeTextJSONImpl(IColumn & column, ReadBuffe
         if constexpr (std::is_same_v<ReturnType, void>)
         {
             if (settings.null_as_default && !isColumnNullableOrLowCardinalityNullable(subcolumn))
-                SerializationNullable::deserializeNullAsDefaultOrNestedTextJSON(subcolumn, buf, settings, subcolumn_serialization);
+                SerializationNullable::deserializeNullAsDefaultOrNestedTextJSON(subcolumn, buf, settings, subcolumn_serialization, /*is_composite_element=*/true);
             else
                 subcolumn_serialization->deserializeTextJSON(subcolumn, buf, settings);
         }
         else
         {
             if (settings.null_as_default && !isColumnNullableOrLowCardinalityNullable(subcolumn))
-                return SerializationNullable::tryDeserializeNullAsDefaultOrNestedTextJSON(subcolumn, buf, settings, subcolumn_serialization);
+                return SerializationNullable::tryDeserializeNullAsDefaultOrNestedTextJSON(subcolumn, buf, settings, subcolumn_serialization, /*is_composite_element=*/true);
             return subcolumn_serialization->tryDeserializeTextJSON(subcolumn, buf, settings);
         }
     };

--- a/src/DataTypes/Serializations/SerializationNullable.cpp
+++ b/src/DataTypes/Serializations/SerializationNullable.cpp
@@ -6,7 +6,9 @@
 #include <DataTypes/NullableUtils.h>
 #include <DataTypes/DataTypesNumber.h>
 
+#include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnNullable.h>
+#include <Columns/ColumnsNumber.h>
 #include <Core/Field.h>
 #include <Formats/ParseError.h>
 #include <IO/ReadBuffer.h>
@@ -15,6 +17,7 @@
 #include <IO/WriteHelpers.h>
 #include <IO/PeekableReadBuffer.h>
 #include <Common/assert_cast.h>
+#include <Common/typeid_cast.h>
 #include <base/scope_guard.h>
 
 namespace DB
@@ -921,15 +924,49 @@ bool SerializationNullable::tryDeserializeTextJSON(IColumn & column, ReadBuffer 
     return deserializeTextJSONImpl<bool>(col.getNestedColumn(), istr, settings, nested, is_null) && safeAppendToNullMap<bool>(col, is_null);
 }
 
-bool SerializationNullable::deserializeNullAsDefaultOrNestedTextJSON(DB::IColumn & nested_column, DB::ReadBuffer & istr, const DB::FormatSettings & settings, const DB::SerializationPtr & nested_serialization)
+namespace
 {
+
+/// JSON has no literal for NaN: ClickHouse writes NaN (and Inf, unless output_format_json_quote_denormals
+/// is set) as `null`, so a Float read back from `null` has to decode to NaN for the round trip to hold.
+/// Substituting the type default instead is what made `Point` (= Tuple(Float64, Float64)) read
+/// `[11, null]` as `(11,0)` rather than `(11,nan)`, while TSV/CSV parse `NaN` correctly -- issue #111917.
+///
+/// This applies only to elements of a composite type. A whole column may carry a DEFAULT expression that
+/// input_format_null_as_default is meant to trigger, but a tuple/array/map element has no default of its
+/// own, so there is nothing to substitute and turning the value into 0 is pure information loss.
+///
+/// SerializationNumber<Float32|Float64>::deserializeTextJSON already maps the `null` literal to
+/// NaNOrZero<T>(), so it is enough to let the nested serialization consume the value itself.
+bool nullShouldBeReadAsNaN(const IColumn & column)
+{
+    const IColumn * col = &column;
+    if (const auto * low_cardinality = typeid_cast<const ColumnLowCardinality *>(col))
+        col = low_cardinality->getDictionary().getNestedColumn().get();
+
+    return typeid_cast<const ColumnFloat32 *>(col) || typeid_cast<const ColumnFloat64 *>(col);
+}
+
+}
+
+bool SerializationNullable::deserializeNullAsDefaultOrNestedTextJSON(DB::IColumn & nested_column, DB::ReadBuffer & istr, const DB::FormatSettings & settings, const DB::SerializationPtr & nested_serialization, bool is_composite_element)
+{
+    if (is_composite_element && nullShouldBeReadAsNaN(nested_column))
+    {
+        nested_serialization->deserializeTextJSON(nested_column, istr, settings);
+        return true;
+    }
+
     bool is_null = false;
     deserializeTextJSONImpl<void>(nested_column, istr, settings, nested_serialization, is_null);
     return !is_null;
 }
 
-bool SerializationNullable::tryDeserializeNullAsDefaultOrNestedTextJSON(DB::IColumn & nested_column, DB::ReadBuffer & istr, const DB::FormatSettings & settings, const DB::SerializationPtr & nested_serialization)
+bool SerializationNullable::tryDeserializeNullAsDefaultOrNestedTextJSON(DB::IColumn & nested_column, DB::ReadBuffer & istr, const DB::FormatSettings & settings, const DB::SerializationPtr & nested_serialization, bool is_composite_element)
 {
+    if (is_composite_element && nullShouldBeReadAsNaN(nested_column))
+        return nested_serialization->tryDeserializeTextJSON(nested_column, istr, settings);
+
     bool is_null = false;
     return deserializeTextJSONImpl<bool>(nested_column, istr, settings, nested_serialization, is_null);
 }

--- a/src/DataTypes/Serializations/SerializationNullable.h
+++ b/src/DataTypes/Serializations/SerializationNullable.h
@@ -105,7 +105,10 @@ public:
     static bool deserializeNullAsDefaultOrNestedTextEscaped(IColumn & nested_column, ReadBuffer & istr, const FormatSettings & settings, const SerializationPtr & nested_serialization);
     static bool deserializeNullAsDefaultOrNestedTextQuoted(IColumn & nested_column, ReadBuffer & istr, const FormatSettings &, const SerializationPtr & nested_serialization);
     static bool deserializeNullAsDefaultOrNestedTextCSV(IColumn & nested_column, ReadBuffer & istr, const FormatSettings & settings, const SerializationPtr & nested_serialization);
-    static bool deserializeNullAsDefaultOrNestedTextJSON(IColumn & nested_column, ReadBuffer & istr, const FormatSettings &, const SerializationPtr & nested_serialization);
+    /// Set `is_composite_element` when the value is an element of a tuple, array or map. Such an element
+    /// has no DEFAULT expression of its own, so for a Float element `null` is decoded as NaN instead of a
+    /// default -- JSON writes NaN as `null`, and this keeps the round trip intact. See issue #111917.
+    static bool deserializeNullAsDefaultOrNestedTextJSON(IColumn & nested_column, ReadBuffer & istr, const FormatSettings &, const SerializationPtr & nested_serialization, bool is_composite_element = false);
     static bool deserializeNullAsDefaultOrNestedTextRaw(IColumn & nested_column, ReadBuffer & istr, const FormatSettings & settings, const SerializationPtr & nested_serialization);
 
     /// If Check for NULL and deserialize value into non-nullable column or insert default value of nested type.
@@ -114,7 +117,7 @@ public:
     static bool tryDeserializeNullAsDefaultOrNestedTextEscaped(IColumn & nested_column, ReadBuffer & istr, const FormatSettings & settings, const SerializationPtr & nested_serialization);
     static bool tryDeserializeNullAsDefaultOrNestedTextQuoted(IColumn & nested_column, ReadBuffer & istr, const FormatSettings &, const SerializationPtr & nested_serialization);
     static bool tryDeserializeNullAsDefaultOrNestedTextCSV(IColumn & nested_column, ReadBuffer & istr, const FormatSettings & settings, const SerializationPtr & nested_serialization);
-    static bool tryDeserializeNullAsDefaultOrNestedTextJSON(IColumn & nested_column, ReadBuffer & istr, const FormatSettings &, const SerializationPtr & nested_serialization);
+    static bool tryDeserializeNullAsDefaultOrNestedTextJSON(IColumn & nested_column, ReadBuffer & istr, const FormatSettings &, const SerializationPtr & nested_serialization, bool is_composite_element = false);
     static bool tryDeserializeNullAsDefaultOrNestedTextRaw(IColumn & nested_column, ReadBuffer & istr, const FormatSettings & settings, const SerializationPtr & nested_serialization);
 
     static void serializeNullEscaped(WriteBuffer & ostr, const FormatSettings & settings);

--- a/src/DataTypes/Serializations/SerializationTuple.cpp
+++ b/src/DataTypes/Serializations/SerializationTuple.cpp
@@ -574,14 +574,14 @@ ReturnType SerializationTuple::deserializeTextJSONImpl(IColumn & column, ReadBuf
         if constexpr (std::is_same_v<ReturnType, void>)
         {
             if (settings.null_as_default && !isColumnNullableOrLowCardinalityNullable(nested_column))
-                SerializationNullable::deserializeNullAsDefaultOrNestedTextJSON(nested_column, buf, settings, nested_column_serialization);
+                SerializationNullable::deserializeNullAsDefaultOrNestedTextJSON(nested_column, buf, settings, nested_column_serialization, /*is_composite_element=*/true);
             else
                 nested_column_serialization->deserializeTextJSON(nested_column, buf, settings);
         }
         else
         {
             if (settings.null_as_default && !isColumnNullableOrLowCardinalityNullable(nested_column))
-                return SerializationNullable::tryDeserializeNullAsDefaultOrNestedTextJSON(nested_column, buf, settings, nested_column_serialization);
+                return SerializationNullable::tryDeserializeNullAsDefaultOrNestedTextJSON(nested_column, buf, settings, nested_column_serialization, /*is_composite_element=*/true);
             return nested_column_serialization->tryDeserializeTextJSON(nested_column, buf, settings);
         }
     };

--- a/tests/queries/0_stateless/04511_json_null_as_nan_for_point.reference
+++ b/tests/queries/0_stateless/04511_json_null_as_nan_for_point.reference
@@ -1,0 +1,45 @@
+JSON
+(11,nan)
+JSONColumns
+(11,nan)
+JSONColumnsWithMetadata
+(11,nan)
+JSONCompact
+(11,nan)
+JSONCompactColumns
+(11,nan)
+JSONEachRow
+(11,nan)
+(nan,nan)
+JSONCompactEachRow
+(11,nan)
+JSONCompactEachRowWithNames
+(11,nan)
+JSONCompactEachRowWithNamesAndTypes
+(11,nan)
+JSONObjectEachRow
+(11,nan)
+other geo types built on Point
+[(11,nan),(nan,12)]
+[(11,nan)]
+[[(11,nan),(nan,12)]]
+float elements of tuple, array and map
+(11,nan)
+[11,nan,13]
+[11,nan,13]
+[11,nan,13]
+{'x':nan}
+non-float elements still take the element default
+(11,0)
+[11,0]
+(11,'')
+a top-level null still uses the column default
+0
+0
+nullable is untouched
+(11,NULL)
+\N
+round trip
+{"a":[11,null]}
+null_as_default = 0 was already correct
+(11,nan)

--- a/tests/queries/0_stateless/04511_json_null_as_nan_for_point.sql
+++ b/tests/queries/0_stateless/04511_json_null_as_nan_for_point.sql
@@ -1,0 +1,70 @@
+-- A `null` in a Float element of a composite type must decode to NaN, not to the element default.
+-- ClickHouse writes NaN as `null` in JSON output, so decoding it back as 0 broke the round trip and
+-- made `Point` (= Tuple(Float64, Float64)) read [11,null] as (11,0) while TSV parses NaN correctly.
+-- Covers every format listed in issue #111917.
+
+SET allow_suspicious_low_cardinality_types = 1;
+
+SELECT 'JSON';
+SELECT * FROM format(JSON, 'a Point', '{"meta":[{"name":"a","type":"Point"}],"data":[{"a":[11,null]}]}');
+
+SELECT 'JSONColumns';
+SELECT * FROM format(JSONColumns, 'a Point', '{"a":[[11,null]]}');
+
+SELECT 'JSONColumnsWithMetadata';
+SELECT * FROM format(JSONColumnsWithMetadata, 'a Point', '{"meta":[{"name":"a","type":"Point"}],"data":{"a":[[11,null]]}}');
+
+SELECT 'JSONCompact';
+SELECT * FROM format(JSONCompact, 'a Point', '{"meta":[{"name":"a","type":"Point"}],"data":[[[11,null]]]}');
+
+SELECT 'JSONCompactColumns';
+SELECT * FROM format(JSONCompactColumns, 'a Point', '[[[11,null]]]');
+
+SELECT 'JSONEachRow';
+SELECT * FROM format(JSONEachRow, 'a Point', '{"a":[11,null]}');
+SELECT * FROM format(JSONEachRow, 'a Point', '{"a":[null,null]}');
+
+SELECT 'JSONCompactEachRow';
+SELECT * FROM format(JSONCompactEachRow, 'a Point', '[[11,null]]');
+
+SELECT 'JSONCompactEachRowWithNames';
+SELECT * FROM format(JSONCompactEachRowWithNames, 'a Point', '["a"]\n[[11,null]]');
+
+SELECT 'JSONCompactEachRowWithNamesAndTypes';
+SELECT * FROM format(JSONCompactEachRowWithNamesAndTypes, 'a Point', '["a"]\n["Point"]\n[[11,null]]');
+
+SELECT 'JSONObjectEachRow';
+SELECT * FROM format(JSONObjectEachRow, 'a Point', '{"r1":{"a":[11,null]}}');
+
+SELECT 'other geo types built on Point';
+SELECT * FROM format(JSONEachRow, 'a Ring', '{"a":[[11,null],[null,12]]}');
+SELECT * FROM format(JSONEachRow, 'a LineString', '{"a":[[11,null]]}');
+SELECT * FROM format(JSONEachRow, 'a Polygon', '{"a":[[[11,null],[null,12]]]}');
+
+SELECT 'float elements of tuple, array and map';
+SELECT * FROM format(JSONEachRow, 'a Tuple(Float64, Float64)', '{"a":[11,null]}');
+SELECT * FROM format(JSONEachRow, 'a Array(Float64)', '{"a":[11,null,13]}');
+SELECT * FROM format(JSONEachRow, 'a Array(Float32)', '{"a":[11,null,13]}');
+SELECT * FROM format(JSONEachRow, 'a Array(LowCardinality(Float64))', '{"a":[11,null,13]}');
+SELECT * FROM format(JSONEachRow, 'a Map(String, Float64)', '{"a":{"x":null}}');
+
+SELECT 'non-float elements still take the element default';
+SELECT * FROM format(JSONEachRow, 'a Tuple(UInt64, UInt64)', '{"a":[11,null]}');
+SELECT * FROM format(JSONEachRow, 'a Array(Int32)', '{"a":[11,null]}');
+SELECT * FROM format(JSONEachRow, 'a Tuple(Float64, String)', '{"a":[11,null]}') SETTINGS input_format_null_as_default = 1;
+
+-- A whole column is not a composite element: it may carry a DEFAULT expression that
+-- input_format_null_as_default is meant to trigger, so a top-level null keeps using the default.
+SELECT 'a top-level null still uses the column default';
+SELECT * FROM format(JSONEachRow, 'a Float64', '{"a":null}') SETTINGS input_format_null_as_default = 1;
+SELECT * FROM format(JSONEachRow, 'a Float32', '{"a":null}') SETTINGS input_format_null_as_default = 1;
+
+SELECT 'nullable is untouched';
+SELECT * FROM format(JSONEachRow, 'a Tuple(Float64, Nullable(Float64))', '{"a":[11,null]}');
+SELECT * FROM format(JSONEachRow, 'a Nullable(Float64)', '{"a":null}');
+
+SELECT 'round trip';
+SELECT CAST((11, nan), 'Point') AS a FORMAT JSONEachRow;
+
+SELECT 'null_as_default = 0 was already correct';
+SELECT * FROM format(JSONEachRow, 'a Point', '{"a":[11,null]}') SETTINGS input_format_null_as_default = 0;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/111917

### Changelog category:
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry:
Fixed JSON input formats reading `null` as `0` instead of `nan` for Float elements of composite types, so `Point` decoded `[11, null]` as `(11,0)` instead of `(11,nan)`.

### Documentation entry for user-facing changes
Not needed, this just brings JSON in line with TSV and CSV.

---

### Why it happens

`Point` is not its own type. `DataTypeCustomGeo.cpp` registers it as `Tuple(Float64, Float64)` with a custom name and no custom serialization, so reading JSON goes through `SerializationTuple::deserializeTextJSONImpl` and then down into the element serialization.

`SerializationNumber<Float64>::deserializeTextJSON` already handles `null` correctly. It maps the literal to `NaNOrZero<T>()`, which is NaN for floats and 0 for integers. The problem is that it never gets called. `input_format_null_as_default` is 1 by default, so `SerializationTuple` catches the `null` first and calls `insertDefault()`, which gives `0`. TSV never goes through that path, which is why `(11,NaN)` works there.

The round trip is the annoying part. The JSON writer prints NaN as `null` unless `output_format_json_quote_denormals` is set, so writing a `Point` out and reading it back turned NaN into 0 with no error anywhere.

### What I changed

For Float elements of a tuple, array or map, the nested serialization now consumes the `null` itself. I added an `is_composite_element` flag to the two `SerializationNullable` JSON helpers and pass it only from `SerializationTuple`, `SerializationArray` and `SerializationMap`.

I kept this to elements instead of changing the helper for every column. The return value of that helper feeds `read_columns[]` in `JSONEachRowRowInputFormat`, and that is what decides whether a column's `DEFAULT` expression runs. Changing it at the top level would quietly skip `DEFAULT`:

```sql
CREATE TABLE t (x Float64 DEFAULT 100) ENGINE = Memory;
-- {"x": null} gives 100 today, a global change would make it nan
```

A column can have a `DEFAULT` expression that `input_format_null_as_default` is meant to trigger. A tuple or array element has no default of its own, so there is nothing useful to fall back to and 0 just throws the value away. Top level behavior is unchanged, and there is a test pinning that.

### Tests

`04511_json_null_as_nan_for_point` covers the ten formats listed in the issue, plus `Ring`, `LineString`, `Polygon`, `Tuple(Float64, Float64)`, `Array(Float32)`, `Array(Float64)`, `Array(LowCardinality(Float64))` and `Map(String, Float64)`.

It also checks what should stay the same: integer elements still get the element default, `Nullable` is untouched, and a top level `Float64` still respects `input_format_null_as_default`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=111926&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/111926](https://github.com/search?q=head%3Async-upstream%2Fpr%2F111926+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
