### PR TITLE
Validate the database engine of a non-APPEND refreshable materialized view on ATTACH and RESTORE

### DIFF
--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -799,6 +799,11 @@ bool DatabaseReplicatedDDLWorker::canRemoveQueueEntry(const String & entry_name,
 
 bool DatabaseReplicatedDDLWorker::checkParentTableExists(const UUID & uuid) const
 {
+    /// Metadata written before the fresh-definition validation existed can carry a Nil view UUID;
+    /// Nil never identifies a table, so treat the parent as missing (mirrors getRMVCoordinationInfo)
+    /// and let the refresh fail cleanly instead of tripping the tryGetByUUID assertion.
+    if (uuid == UUIDHelpers::Nil)
+        return false;
     auto [db, table] = DatabaseCatalog::instance().tryGetByUUID(uuid);
     return db.get() == database && table != nullptr && !table->is_dropped.load() && !table->is_detached.load();
 }

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1853,14 +1853,15 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     /// introduced and must keep loading; plain Replicated-DDL replay re-executes an already
     /// validated initiator query. A full-definition ATTACH is fresh input and is validated like
     /// CREATE. A RESTORE counts as fresh only when the backed-up definition carried a UUID: such a
-    /// view lived in a UUID database, so landing it in a non-UUID one is a remap that loses the
-    /// UUID. `has_uuid` reflects the backup's own metadata (RESTORE overwrites `uuid` with a freshly
-    /// generated one before this point, but never `has_uuid`), so a UUID-less backup is a definition
-    /// that already lived without a UUID and must stay restorable.
-    const bool is_remapping_restore = is_restore_from_backup && create.has_uuid;
+    /// view lived in a UUID database, so landing it in a non-UUID one loses the UUID and is what
+    /// must be rejected. `has_uuid` reflects the backup's own metadata (RESTORE overwrites `uuid`
+    /// with a freshly generated one before this point, but never `has_uuid`), so a UUID-less backup
+    /// is a definition that already lived without a UUID: it stays restorable under any name, and
+    /// the Nil guard in checkParentTableExists keeps its refresh failing cleanly.
+    const bool is_uuid_losing_restore = is_restore_from_backup && create.has_uuid;
     const bool is_fresh_definition = mode <= LoadingStrictnessLevel::CREATE
         || (mode == LoadingStrictnessLevel::ATTACH && !create.attach_short_syntax)
-        || is_remapping_restore;
+        || is_uuid_losing_restore;
     if (create.refresh_strategy && !create.refresh_strategy->append && is_fresh_definition)
     {
         if (database && database->getEngineName() != "Atomic" && database->getEngineName() != "Replicated")

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1847,17 +1847,11 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     if (need_add_to_database)
         database = DatabaseCatalog::instance().tryGetDatabase(database_name);
 
-    /// Non-APPEND refreshable MVs only work in Atomic/Replicated databases (uncoordinated refresh
-    /// would diverge across replicas, and the view needs a real UUID for parent-table tracking in
-    /// Replicated DDL). Stored definitions (attach_short_syntax) were validated when first
-    /// introduced and must keep loading; plain Replicated-DDL replay re-executes an already
-    /// validated initiator query. A full-definition ATTACH is fresh input and is validated like
-    /// CREATE. A RESTORE counts as fresh only when the backed-up definition carried a UUID: such a
-    /// view lived in a UUID database, so landing it in a non-UUID one loses the UUID and is what
-    /// must be rejected. `has_uuid` reflects the backup's own metadata (RESTORE overwrites `uuid`
-    /// with a freshly generated one before this point, but never `has_uuid`), so a UUID-less backup
-    /// is a definition that already lived without a UUID: it stays restorable under any name, and
-    /// the Nil guard in checkParentTableExists keeps its refresh failing cleanly.
+    /// Non-APPEND refreshable MVs only work in Atomic/Replicated databases. Validate only definitions
+    /// the user supplies now: a stored definition (attach_short_syntax) and a Replicated-DDL replay
+    /// were already validated, and rejecting them would make existing metadata unloadable.
+    /// `has_uuid` is the backup's own metadata, not the UUID this restore generated, so it tells a
+    /// view that had a UUID (about to lose it here) from one that never had one.
     const bool is_uuid_losing_restore = is_restore_from_backup && create.has_uuid;
     const bool is_fresh_definition = mode <= LoadingStrictnessLevel::CREATE
         || (mode == LoadingStrictnessLevel::ATTACH && !create.attach_short_syntax)

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1070,7 +1070,7 @@ void InterpreterCreateQuery::validateTableStructure(const ASTCreateQuery & creat
     }
 }
 
-void InterpreterCreateQuery::validateMaterializedViewColumnsAndEngine(const ASTCreateQuery & create, const TableProperties & properties, const DatabasePtr & database)
+void InterpreterCreateQuery::validateMaterializedViewColumnsAndEngine(const ASTCreateQuery & create, const TableProperties & properties)
 {
     /// This is not strict validation, just catches common errors that would make the view not work.
     /// It's possible to circumvent these checks by ALTERing the view or target table after creation;
@@ -1103,18 +1103,6 @@ void InterpreterCreateQuery::validateMaterializedViewColumnsAndEngine(const ASTC
     {
         all_output_columns = properties.columns.getInsertable();
         check_columns = true;
-    }
-
-    if (create.refresh_strategy && !create.refresh_strategy->append)
-    {
-        if (database && database->getEngineName() != "Atomic" && database->getEngineName() != "Replicated")
-            throw Exception(ErrorCodes::INCORRECT_QUERY,
-                "Refreshable materialized views (except with APPEND) only support Atomic and Replicated database engines, but database {} has engine {}", create.getDatabase(), database->getEngineName());
-
-        std::string message;
-        if (!supportsAtomicRename(&message))
-            throw Exception(ErrorCodes::NOT_IMPLEMENTED,
-                "Can't create refreshable materialized view because exchanging files is not supported by the OS ({})", message);
     }
 
     SharedHeader input_block;
@@ -1859,13 +1847,34 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     if (need_add_to_database)
         database = DatabaseCatalog::instance().tryGetDatabase(database_name);
 
+    /// Non-APPEND refreshable MVs only work in Atomic/Replicated databases (uncoordinated refresh
+    /// would diverge across replicas, and the view needs a real UUID for parent-table tracking in
+    /// Replicated DDL). Stored definitions (attach_short_syntax) were validated when first
+    /// introduced and must keep loading; plain Replicated-DDL replay re-executes an already
+    /// validated initiator query. A full-definition ATTACH and a RESTORE (which can remap the view
+    /// into a different database) are fresh input and are validated like CREATE.
+    const bool is_fresh_definition = mode <= LoadingStrictnessLevel::CREATE
+        || (mode == LoadingStrictnessLevel::ATTACH && !create.attach_short_syntax)
+        || is_restore_from_backup;
+    if (create.refresh_strategy && !create.refresh_strategy->append && is_fresh_definition)
+    {
+        if (database && database->getEngineName() != "Atomic" && database->getEngineName() != "Replicated")
+            throw Exception(ErrorCodes::INCORRECT_QUERY,
+                "Refreshable materialized views (except with APPEND) only support Atomic and Replicated database engines, but database {} has engine {}", create.getDatabase(), database->getEngineName());
+
+        std::string message;
+        if (!supportsAtomicRename(&message))
+            throw Exception(ErrorCodes::NOT_IMPLEMENTED,
+                "Can't create refreshable materialized view because exchanging files is not supported by the OS ({})", message);
+    }
+
     /// Check type compatible for materialized dest table and select columns
     if (create.select && create.is_materialized_view && mode <= LoadingStrictnessLevel::CREATE)
     {
         // An MV with a flattened nested column in an inner table can never be filled
         if (create.is_materialized_view_with_inner_table())
             getContext()->setSetting("flatten_nested", false);
-        validateMaterializedViewColumnsAndEngine(create, properties, database);
+        validateMaterializedViewColumnsAndEngine(create, properties);
     }
 
     bool is_storage_replicated = false;

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1851,11 +1851,16 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     /// would diverge across replicas, and the view needs a real UUID for parent-table tracking in
     /// Replicated DDL). Stored definitions (attach_short_syntax) were validated when first
     /// introduced and must keep loading; plain Replicated-DDL replay re-executes an already
-    /// validated initiator query. A full-definition ATTACH and a RESTORE (which can remap the view
-    /// into a different database) are fresh input and are validated like CREATE.
+    /// validated initiator query. A full-definition ATTACH is fresh input and is validated like
+    /// CREATE. A RESTORE counts as fresh only when the backed-up definition carried a UUID: such a
+    /// view lived in a UUID database, so landing it in a non-UUID one is a remap that loses the
+    /// UUID. `has_uuid` reflects the backup's own metadata (RESTORE overwrites `uuid` with a freshly
+    /// generated one before this point, but never `has_uuid`), so a UUID-less backup is a definition
+    /// that already lived without a UUID and must stay restorable.
+    const bool is_remapping_restore = is_restore_from_backup && create.has_uuid;
     const bool is_fresh_definition = mode <= LoadingStrictnessLevel::CREATE
         || (mode == LoadingStrictnessLevel::ATTACH && !create.attach_short_syntax)
-        || is_restore_from_backup;
+        || is_remapping_restore;
     if (create.refresh_strategy && !create.refresh_strategy->append && is_fresh_definition)
     {
         if (database && database->getEngineName() != "Atomic" && database->getEngineName() != "Replicated")

--- a/src/Interpreters/InterpreterCreateQuery.h
+++ b/src/Interpreters/InterpreterCreateQuery.h
@@ -103,7 +103,7 @@ private:
     /// Calculate list of columns, constraints, indices, etc... of table. Rewrite query in canonical way.
     TableProperties getTablePropertiesAndNormalizeCreateQuery(ASTCreateQuery & create, LoadingStrictnessLevel mode);
     void validateTableStructure(const ASTCreateQuery & create, const TableProperties & properties) const;
-    void validateMaterializedViewColumnsAndEngine(const ASTCreateQuery & create, const TableProperties & properties, const DatabasePtr & database);
+    void validateMaterializedViewColumnsAndEngine(const ASTCreateQuery & create, const TableProperties & properties);
     void setEngine(ASTCreateQuery & create) const;
     AccessRightsElements getRequiredAccess() const;
 

--- a/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.reference
+++ b/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.reference
@@ -6,4 +6,5 @@ restore_rejected
 legacy_uuid_is_nil
 legacy_short_attach_ok
 legacy_refresh_refused
+legacy_restore_ok
 server_alive

--- a/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.reference
+++ b/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.reference
@@ -7,4 +7,6 @@ legacy_uuid_is_nil
 legacy_short_attach_ok
 legacy_refresh_refused
 legacy_restore_ok
+legacy_restore_as_ok
+legacy_restore_as_refresh_refused
 server_alive

--- a/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.reference
+++ b/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.reference
@@ -1,0 +1,5 @@
+create_rejected
+attach_rejected
+append_allowed
+atomic_allowed
+restore_rejected

--- a/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.reference
+++ b/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.reference
@@ -3,3 +3,7 @@ attach_rejected
 append_allowed
 atomic_allowed
 restore_rejected
+legacy_uuid_is_nil
+legacy_short_attach_ok
+legacy_refresh_refused
+server_alive

--- a/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.sh
+++ b/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.sh
@@ -83,7 +83,15 @@ $CLICKHOUSE_CLIENT --force_remove_data_recursively_on_drop=1 -q "DROP TABLE ${OR
 $CLICKHOUSE_CLIENT -q "RESTORE TABLE ${ORD_DB}.legacy_v FROM Disk('backups', '${CLICKHOUSE_DATABASE}/legacy_v')" > /dev/null \
     && echo "legacy_restore_ok"
 
-# A server that aborted during that refresh cannot answer this.
+# Restoring it under another name is accepted for the same reason (there is no UUID to lose), and the
+# copy stays harmless: its refresh is refused by the same Nil guard rather than aborting the server.
+$CLICKHOUSE_CLIENT -q "RESTORE TABLE ${ORD_DB}.legacy_v AS ${ORD_DB}.legacy_v_copy FROM Disk('backups', '${CLICKHOUSE_DATABASE}/legacy_v')" > /dev/null \
+    && echo "legacy_restore_as_ok"
+$CLICKHOUSE_CLIENT -q "SYSTEM REFRESH VIEW ${ORD_DB}.legacy_v_copy"
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT VIEW ${ORD_DB}.legacy_v_copy" 2>&1 \
+    | grep -q "Parent table doesn't exist" && echo "legacy_restore_as_refresh_refused"
+
+# A server that aborted during any of those refreshes cannot answer this.
 $CLICKHOUSE_CLIENT -q "SELECT 'server_alive'"
 
 $CLICKHOUSE_CLIENT -q "DROP DATABASE IF EXISTS ${MEM_DB} SYNC"

--- a/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.sh
+++ b/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
-# Tags: atomic-database, no-fasttest
+# Tags: atomic-database, no-fasttest, zookeeper, no-replicated-database, no-ordinary-database
 # no-fasttest: BACKUP/RESTORE needs the backups disk from the full test config.
+# no-replicated-database, no-ordinary-database: the test creates its own Replicated and Ordinary databases.
 # A non-APPEND refreshable materialized view must live in an Atomic or Replicated database. CREATE
 # enforced this, but a full-definition ATTACH and a RESTORE (which can remap the view into another
 # database) bypassed the check, producing a Nil-UUID view whose refresh aborted the server in a
 # Replicated-DDL parent-table lookup. All fresh definition paths are validated the same way now.
+# Definitions stored before the validation existed must keep loading, and their refresh must be
+# refused cleanly; a cross-engine RENAME reaches that state without InterpreterCreateQuery.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-# $CLICKHOUSE_DATABASE is created by the runner (Atomic); create the Memory database ourselves.
+# $CLICKHOUSE_DATABASE is created by the runner (Atomic); create the other databases ourselves.
 MEM_DB="${CLICKHOUSE_DATABASE}_mem"
+ORD_DB="${CLICKHOUSE_DATABASE}_ord"
+RDB="${CLICKHOUSE_DATABASE}_rdb"
 
 $CLICKHOUSE_CLIENT -q "CREATE DATABASE ${MEM_DB} ENGINE = Memory"
 $CLICKHOUSE_CLIENT -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.target0 (c0 Int32) ENGINE = MergeTree ORDER BY c0"
@@ -43,4 +48,39 @@ $CLICKHOUSE_CLIENT -q "BACKUP TABLE ${CLICKHOUSE_DATABASE}.v3 TO Disk('backups',
 $CLICKHOUSE_CLIENT -q "RESTORE TABLE ${CLICKHOUSE_DATABASE}.v3 AS ${MEM_DB}.v3 FROM Disk('backups', '${CLICKHOUSE_DATABASE}/v3')" 2>&1 \
     | grep -q "INCORRECT_QUERY" && echo "restore_rejected"
 
-$CLICKHOUSE_CLIENT -q "DROP DATABASE ${MEM_DB} SYNC"
+# Metadata written before the validation existed must keep working. Moving a view from an Atomic to
+# an Ordinary database clears its UUID and installs the definition through the target database's own
+# createTable, so it reaches that state without going through InterpreterCreateQuery.
+# send_logs_level=fatal drops the once-per-server "Ordinary engine is deprecated" warning.
+$CLICKHOUSE_CLIENT --send_logs_level=fatal --allow_deprecated_database_ordinary=1 -q "CREATE DATABASE ${ORD_DB} ENGINE = Ordinary"
+$CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -q "CREATE DATABASE ${RDB} ENGINE = Replicated('/test/{database}/rmv_fresh_definition', 'shard1', 'replica1')"
+# The target is deliberately in the Replicated database: that is what routes the refresh's
+# CREATE OR REPLACE of the temporary inner table through the Replicated DDL log, where the view's
+# UUID is looked up as the parent table.
+$CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -q "CREATE TABLE ${RDB}.legacy_target (c0 Int32) ENGINE = MergeTree ORDER BY c0"
+# EMPTY so no refresh runs before the rename.
+$CLICKHOUSE_CLIENT -q "CREATE MATERIALIZED VIEW ${CLICKHOUSE_DATABASE}.legacy_v REFRESH EVERY 100 YEAR TO ${RDB}.legacy_target (c0 Int32) EMPTY AS SELECT 1 AS c0"
+$CLICKHOUSE_CLIENT -q "RENAME TABLE ${CLICKHOUSE_DATABASE}.legacy_v TO ${ORD_DB}.legacy_v"
+$CLICKHOUSE_CLIENT -q "SELECT 'legacy_uuid_is_nil' FROM system.tables WHERE database = '${ORD_DB}' AND name = 'legacy_v' AND uuid = toUUID('00000000-0000-0000-0000-000000000000')"
+
+# The stored definition still loads: a short ATTACH rewrites the query from metadata, so it must not
+# be validated as a fresh definition.
+$CLICKHOUSE_CLIENT -q "DETACH TABLE ${ORD_DB}.legacy_v"
+$CLICKHOUSE_CLIENT -q "ATTACH TABLE ${ORD_DB}.legacy_v"
+$CLICKHOUSE_CLIENT -q "SELECT 'legacy_short_attach_ok' FROM system.tables WHERE database = '${ORD_DB}' AND name = 'legacy_v'"
+
+# Its refresh is refused cleanly instead of tripping the parent-table UUID assertion.
+$CLICKHOUSE_CLIENT -q "SYSTEM REFRESH VIEW ${ORD_DB}.legacy_v"
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT VIEW ${ORD_DB}.legacy_v" 2>&1 \
+    | grep -q "Parent table doesn't exist" && echo "legacy_refresh_refused"
+# A server that aborted during that refresh cannot answer this.
+$CLICKHOUSE_CLIENT -q "SELECT 'server_alive'"
+
+$CLICKHOUSE_CLIENT -q "DROP DATABASE IF EXISTS ${MEM_DB} SYNC"
+# force_remove_data_recursively_on_drop: an Ordinary database keeps metadata for a detached table,
+# so without it a mid-test failure would cascade into a confusing DATABASE_NOT_EMPTY error here.
+$CLICKHOUSE_CLIENT --force_remove_data_recursively_on_drop=1 -q "DROP DATABASE IF EXISTS ${ORD_DB} SYNC"
+$CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -q "DROP DATABASE IF EXISTS ${RDB} SYNC"
+for t in v_ok v3 target0 target1 target2 target3 target_ok; do
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.${t} SYNC"
+done

--- a/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.sh
+++ b/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.sh
@@ -6,8 +6,9 @@
 # enforced this, but a full-definition ATTACH and a RESTORE (which can remap the view into another
 # database) bypassed the check, producing a Nil-UUID view whose refresh aborted the server in a
 # Replicated-DDL parent-table lookup. All fresh definition paths are validated the same way now.
-# Definitions stored before the validation existed must keep loading, and their refresh must be
-# refused cleanly; a cross-engine RENAME reaches that state without InterpreterCreateQuery.
+# Definitions stored before the validation existed must keep loading, their refresh must be refused
+# cleanly, and their backups must stay restorable; a cross-engine RENAME reaches that state without
+# InterpreterCreateQuery.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -73,6 +74,15 @@ $CLICKHOUSE_CLIENT -q "SELECT 'legacy_short_attach_ok' FROM system.tables WHERE 
 $CLICKHOUSE_CLIENT -q "SYSTEM REFRESH VIEW ${ORD_DB}.legacy_v"
 $CLICKHOUSE_CLIENT -q "SYSTEM WAIT VIEW ${ORD_DB}.legacy_v" 2>&1 \
     | grep -q "Parent table doesn't exist" && echo "legacy_refresh_refused"
+
+# A backup of such a definition must stay restorable into the same database it was taken from: it
+# carries no UUID, so the restore is replaying a definition that already lived without one rather
+# than remapping a UUID view into a database that cannot hold its UUID.
+$CLICKHOUSE_CLIENT -q "BACKUP TABLE ${ORD_DB}.legacy_v TO Disk('backups', '${CLICKHOUSE_DATABASE}/legacy_v') FORMAT Null" > /dev/null
+$CLICKHOUSE_CLIENT --force_remove_data_recursively_on_drop=1 -q "DROP TABLE ${ORD_DB}.legacy_v SYNC"
+$CLICKHOUSE_CLIENT -q "RESTORE TABLE ${ORD_DB}.legacy_v FROM Disk('backups', '${CLICKHOUSE_DATABASE}/legacy_v')" > /dev/null \
+    && echo "legacy_restore_ok"
+
 # A server that aborted during that refresh cannot answer this.
 $CLICKHOUSE_CLIENT -q "SELECT 'server_alive'"
 

--- a/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.sh
+++ b/tests/queries/0_stateless/04628_rmv_non_append_fresh_definition_engine_validation.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Tags: atomic-database, no-fasttest
+# no-fasttest: BACKUP/RESTORE needs the backups disk from the full test config.
+# A non-APPEND refreshable materialized view must live in an Atomic or Replicated database. CREATE
+# enforced this, but a full-definition ATTACH and a RESTORE (which can remap the view into another
+# database) bypassed the check, producing a Nil-UUID view whose refresh aborted the server in a
+# Replicated-DDL parent-table lookup. All fresh definition paths are validated the same way now.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# $CLICKHOUSE_DATABASE is created by the runner (Atomic); create the Memory database ourselves.
+MEM_DB="${CLICKHOUSE_DATABASE}_mem"
+
+$CLICKHOUSE_CLIENT -q "CREATE DATABASE ${MEM_DB} ENGINE = Memory"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.target0 (c0 Int32) ENGINE = MergeTree ORDER BY c0"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.target1 (c0 Int32) ENGINE = MergeTree ORDER BY c0"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.target2 (c0 Int32) ENGINE = MergeTree ORDER BY c0"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.target_ok (c0 Int32) ENGINE = MergeTree ORDER BY c0"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.target3 (c0 Int32) ENGINE = MergeTree ORDER BY c0"
+
+# CREATE of a non-APPEND refreshable MV in a Memory database is rejected (unchanged behavior).
+$CLICKHOUSE_CLIENT -q "CREATE MATERIALIZED VIEW ${MEM_DB}.v0 REFRESH AFTER 1 YEAR TO ${CLICKHOUSE_DATABASE}.target0 (c0 Int32) AS SELECT 1 AS c0" 2>&1 \
+    | grep -q "INCORRECT_QUERY" && echo "create_rejected"
+
+# Full-definition ATTACH used to bypass the check (this is the query that reproduced the crash).
+$CLICKHOUSE_CLIENT -q "ATTACH MATERIALIZED VIEW ${MEM_DB}.v1 REFRESH AFTER 1 YEAR TO ${CLICKHOUSE_DATABASE}.target1 (c0 Int32) AS SELECT 1 AS c0" 2>&1 \
+    | grep -q "INCORRECT_QUERY" && echo "attach_rejected"
+
+# APPEND refreshable MVs are allowed in any database engine (no over-blocking). Full-definition
+# ATTACH prints a "not recommended" warning to stderr, which is expected here; drop it.
+$CLICKHOUSE_CLIENT --send_logs_level=none -q "ATTACH MATERIALIZED VIEW ${MEM_DB}.v2 REFRESH AFTER 1 YEAR APPEND TO ${CLICKHOUSE_DATABASE}.target2 (c0 Int32) AS SELECT 1 AS c0" 2>/dev/null \
+    && echo "append_allowed"
+
+# A non-APPEND refreshable MV in an Atomic database stays allowed.
+$CLICKHOUSE_CLIENT -q "CREATE MATERIALIZED VIEW ${CLICKHOUSE_DATABASE}.v_ok REFRESH AFTER 1 YEAR TO ${CLICKHOUSE_DATABASE}.target_ok (c0 Int32) AS SELECT 1 AS c0" \
+    && echo "atomic_allowed"
+
+# RESTORE that remaps the view into a Memory database is fresh input too.
+$CLICKHOUSE_CLIENT -q "CREATE MATERIALIZED VIEW ${CLICKHOUSE_DATABASE}.v3 REFRESH AFTER 1 YEAR TO ${CLICKHOUSE_DATABASE}.target3 (c0 Int32) AS SELECT 1 AS c0"
+$CLICKHOUSE_CLIENT -q "BACKUP TABLE ${CLICKHOUSE_DATABASE}.v3 TO Disk('backups', '${CLICKHOUSE_DATABASE}/v3') FORMAT Null" > /dev/null
+$CLICKHOUSE_CLIENT -q "RESTORE TABLE ${CLICKHOUSE_DATABASE}.v3 AS ${MEM_DB}.v3 FROM Disk('backups', '${CLICKHOUSE_DATABASE}/v3')" 2>&1 \
+    | grep -q "INCORRECT_QUERY" && echo "restore_rejected"
+
+$CLICKHOUSE_CLIENT -q "DROP DATABASE ${MEM_DB} SYNC"


### PR DESCRIPTION

<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/111370
Related: https://github.com/ClickHouse/ClickHouse/pull/109454
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a logical error (server abort in debug and sanitizer builds) when a non-APPEND refreshable materialized view was created in a non-Atomic/Replicated database via a full-definition `ATTACH`, or via a `RESTORE` of a view that had a UUID into such a database. `CREATE` already rejected this combination; `ATTACH` and `RESTORE` bypassed the check and produced a view with a Nil UUID whose refresh tripped a `DatabaseCatalog::tryGetByUUID` assertion in the Replicated-DDL parent-table lookup. Backups of views that never had a UUID stay restorable, and their refresh now fails cleanly instead of aborting.


### Description

A non-APPEND refreshable materialized view is only supported in `Atomic` and `Replicated` databases: its refresh swaps the inner table through an atomic `EXCHANGE`, and it needs a real UUID for parent-table tracking when the target lives in a `Replicated` database. `CREATE` enforces this in `validateMaterializedViewColumnsAndEngine`, but that call is gated on `mode <= LoadingStrictnessLevel::CREATE`, so two fresh-definition paths bypassed it:

- a full-definition `ATTACH MATERIALIZED VIEW ... REFRESH ... TO ...` (runs at `LoadingStrictnessLevel::ATTACH`), and
- a `RESTORE ... AS <other_db>.<view>` that lands the view in a non-Atomic/Replicated database (runs at `SECONDARY_CREATE` with `is_restore_from_backup`).

In a `Memory` database the view gets a Nil StorageID UUID. When its refresh fires and issues `CREATE OR REPLACE` for the temp inner table into a `Replicated`-database target, the Nil UUID is written into `DDLLogEntry.parent_table_uuid`, and `DatabaseReplicatedDDLWorker::checkParentTableExists(Nil)` calls `DatabaseCatalog::tryGetByUUID(Nil)`, hitting `chassert(uuid != UUIDHelpers::Nil && ...)`. In release builds the assertion is compiled out and the refresh instead fails permanently with a misleading `TABLE_IS_DROPPED "Parent table doesn't exist"`.

Fix:

- Hoist the non-APPEND-RMV database-engine check out of `validateMaterializedViewColumnsAndEngine` into `createTable`, gated on `is_fresh_definition = mode <= CREATE || (mode == ATTACH && !attach_short_syntax) || (is_restore_from_backup && create.has_uuid)`. This mirrors the existing `is_fresh_definition` predicate in `registerStorageMergeTree.cpp`: stored definitions (short `ATTACH`, `ATTACH DATABASE`, restart) were validated when introduced and keep loading; plain Replicated-DDL replay stays exempt (its database is `Replicated` anyway); fresh full-definition `ATTACH` is user input and is validated like `CREATE`. The exception text is unchanged.
- Add a fail-close Nil guard in `checkParentTableExists`: a Nil UUID never identifies a table, so return false (mirrors the existing Nil guard in `getRMVCoordinationInfo` in the same file). This keeps metadata written by older binaries loadable and makes its refresh fail cleanly instead of aborting debug/sanitizer servers.

A `RESTORE` is only validated when the backed-up definition carried a UUID (`create.has_uuid`, which reflects the backup's own metadata: `RESTORE` overwrites `uuid` with a freshly generated one before the interpreter runs, but never `has_uuid`). A view that had a UUID lived in a database that holds UUIDs, so landing it in one that does not is the UUID-losing case that must be rejected. A backup of a view that never had a UUID (for example one moved to an `Ordinary` database by an earlier `RENAME`) is a definition that already lived without one: rejecting it would make such backups unrestorable on newer servers while the same metadata still loads on restart and on a short `ATTACH`, so it stays restorable under any name and the Nil guard keeps its refresh failing cleanly.

Found by BuzzHouse:
- `Logical error: 'uuid != UUIDHelpers::Nil && getFirstLevelIdx(uuid) < uuid_map.size()'`, BuzzHouse (arm_asan_ubsan): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111370&sha=3c509b961097528327cfb981dbef8957a5f9237a&name_0=PR&name_1=BuzzHouse%20%28arm_asan_ubsan%29
- same assertion, BuzzHouse (amd_msan): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109454&sha=5cf32f88e08f93010cf061d9bee9e626fd959d1f&name_0=PR&name_1=BuzzHouse%20%28amd_msan%29

Both sighting PRs are unrelated to this code path (a datetime-function change and an unrelated change); the failure is a latent engine bug, not caused by either PR.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=111928&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/111928](https://github.com/search?q=head%3Async-upstream%2Fpr%2F111928+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
