### PR TITLE
Fix a data race on publication of per-user ProfileEvents counters

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1729,8 +1729,8 @@ void Counters::setUserCounters(Counters * user)
         parent_val = current_val->parent.load(std::memory_order_acquire);
     }
 
-    /// Release: see `setParent`. `user` is typically a just-constructed `ProcessListForUser`'s
-    /// `user_performance_counters`, published into a chain shared with already-running threads.
+    /// Release: see `setParent`. `user` is a `ProcessListForUser`'s `user_performance_counters`,
+    /// possibly just constructed, published into a chain shared with already-running threads.
     current_val->parent.store(user, std::memory_order_release);
 }
 

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1712,21 +1712,26 @@ Count Counters::load(Event event) const
 
 void Counters::setParent(Counters * parent_)
 {
-    parent.store(parent_, std::memory_order_relaxed);
+    /// Release: a `Counters` may be published into a chain that another thread traverses lock-free
+    /// (`increment*`), so the pointee's construction must be visible to whoever observes the pointer.
+    parent.store(parent_, std::memory_order_release);
 }
 
 void Counters::setUserCounters(Counters * user)
 {
     auto * current_val = this;
-    auto * parent_val = this->parent.load(std::memory_order_relaxed);
+    /// Acquire: the loaded pointer is dereferenced below (`->level`).
+    auto * parent_val = this->parent.load(std::memory_order_acquire);
 
     while (parent_val != nullptr && parent_val->level != VariableContext::Global && parent_val->level != VariableContext::User)
     {
         current_val = parent_val;
-        parent_val = current_val->parent.load(std::memory_order_relaxed);
+        parent_val = current_val->parent.load(std::memory_order_acquire);
     }
 
-    current_val->parent.store(user, std::memory_order_relaxed);
+    /// Release: see `setParent`. `user` is typically a just-constructed `ProcessListForUser`'s
+    /// `user_performance_counters`, published into a chain shared with already-running threads.
+    current_val->parent.store(user, std::memory_order_release);
 }
 
 void Counters::setTraceAllProfileEvents()
@@ -1950,7 +1955,9 @@ void Counters::increment(Event event, Count amount)
             send_to_trace_log |= trace_arr[event].load(std::memory_order_relaxed);
         send_to_trace_log |= current->trace_all_profile_events.load(std::memory_order_relaxed);
 
-        current = current->parent;
+        /// Acquire: pairs with the release store in `setParent`/`setUserCounters`, so a
+        /// freshly published parent is fully constructed before it is dereferenced.
+        current = current->parent.load(std::memory_order_acquire);
     } while (current != nullptr);
 
     if (unlikely(send_to_trace_log))
@@ -1964,7 +1971,8 @@ void Counters::incrementNoTrace(Event event, Count amount)
     do
     {
         current->fetchAdd(event, amount, cpu);
-        current = current->parent;
+        /// Acquire: see `increment`.
+        current = current->parent.load(std::memory_order_acquire);
     } while (current != nullptr);
 }
 
@@ -1978,7 +1986,8 @@ void Counters::incrementSignalSafe(Event event, Count amount)
     do
     {
         current->fetchAdd(event, amount, -1);
-        current = current->parent;
+        /// Acquire: see `increment`.
+        current = current->parent.load(std::memory_order_acquire);
     } while (current != nullptr);
 }
 

--- a/tests/integration/test_startup_scripts/configs/profiler_race_logs.xml
+++ b/tests/integration/test_startup_scripts/configs/profiler_race_logs.xml
@@ -1,0 +1,10 @@
+<clickhouse>
+    <!-- Removed by the integration common config, and needed here: only this table reports profile
+         events per thread instead of per thread group. -->
+    <query_thread_log>
+        <database>system</database>
+        <table>query_thread_log</table>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <flush_interval_milliseconds>1000</flush_interval_milliseconds>
+    </query_thread_log>
+</clickhouse>

--- a/tests/integration/test_startup_scripts/configs/profiler_race_script.xml
+++ b/tests/integration/test_startup_scripts/configs/profiler_race_script.xml
@@ -1,0 +1,26 @@
+<clickhouse>
+    <!--
+        The startup script creates a non-lazy dictionary, so `registerStorageDictionary` blocks the
+        main thread in `ExternalLoader::LoadingDispatcher::loadImpl` (a condition_variable wait) while
+        the loader thread, sharing the main thread's ThreadGroup, runs the source query as
+        `dict_source_user`. That source query performs the first `ProcessList::insert` for that user,
+        which constructs a `ProcessListForUser` and publishes its embedded `user_performance_counters`
+        into the shared Counters chain the main thread's profiler signal handler is walking.
+    -->
+    <startup_scripts>
+        <scripts>
+            <query>
+                CREATE OR REPLACE DICTIONARY profiler_race_dict
+                (
+                    `key` String,
+                    `value` String
+                )
+                PRIMARY KEY key
+                SOURCE(CLICKHOUSE(USER 'dict_source_user' PASSWORD '' QUERY `SELECT toString(number) AS key, toString(number) AS value FROM numbers(3000000)`))
+                LIFETIME(MIN 0 MAX 0)
+                LAYOUT(COMPLEX_KEY_HASHED)
+                SETTINGS(dictionary_lazy_load = 0);
+            </query>
+        </scripts>
+    </startup_scripts>
+</clickhouse>

--- a/tests/integration/test_startup_scripts/configs/profiler_race_script.xml
+++ b/tests/integration/test_startup_scripts/configs/profiler_race_script.xml
@@ -1,12 +1,8 @@
 <clickhouse>
-    <!--
-        The startup script creates a non-lazy dictionary, so `registerStorageDictionary` blocks the
-        main thread in `ExternalLoader::LoadingDispatcher::loadImpl` (a condition_variable wait) while
-        the loader thread, sharing the main thread's ThreadGroup, runs the source query as
-        `dict_source_user`. That source query performs the first `ProcessList::insert` for that user,
-        which constructs a `ProcessListForUser` and publishes its embedded `user_performance_counters`
-        into the shared Counters chain the main thread's profiler signal handler is walking.
-    -->
+    <!-- Non-lazy dictionary plus a non-default source user: that combination makes the loader thread
+         perform the first `ProcessListForUser` allocation for that user while the main thread is
+         blocked inside the loader, sharing one Counters chain with it. The 3000000-row source query
+         keeps the main thread in that wait for seconds, so the 1 ms profiler samples it there. -->
     <startup_scripts>
         <scripts>
             <query>

--- a/tests/integration/test_startup_scripts/configs/profiler_race_users.xml
+++ b/tests/integration/test_startup_scripts/configs/profiler_race_users.xml
@@ -1,0 +1,21 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <!-- Sample the startup thread every 1 ms so the profiler signal lands while the loader
+                 thread publishes the new per-user Counters. -->
+            <query_profiler_real_time_period_ns>1000000</query_profiler_real_time_period_ns>
+        </default>
+    </profiles>
+    <users>
+        <default>
+            <access_management>1</access_management>
+        </default>
+        <!-- A user distinct from `default`, so the dictionary source query forces a first-time
+             `ProcessListForUser` allocation on the loader thread. -->
+        <dict_source_user>
+            <password></password>
+            <profile>default</profile>
+            <networks><ip>::/0</ip></networks>
+        </dict_source_user>
+    </users>
+</clickhouse>

--- a/tests/integration/test_startup_scripts/configs/profiler_race_users.xml
+++ b/tests/integration/test_startup_scripts/configs/profiler_race_users.xml
@@ -4,6 +4,9 @@
             <!-- Sample the startup thread every 1 ms so the profiler signal lands while the loader
                  thread publishes the new per-user Counters. -->
             <query_profiler_real_time_period_ns>1000000</query_profiler_real_time_period_ns>
+            <!-- Off by default; without it system.query_thread_log stays empty, and that table is
+                 the only place profile events are reported per thread instead of per thread group. -->
+            <log_query_threads>1</log_query_threads>
         </default>
     </profiles>
     <users>

--- a/tests/integration/test_startup_scripts/test.py
+++ b/tests/integration/test_startup_scripts/test.py
@@ -150,6 +150,11 @@ def test_reload_config_does_not_rerun_startup_scripts(start_cluster):
 
 
 def restart_profiler_race_instance():
+    # The thread log survives the restart, so return the server's own clock reading first: it scopes
+    # the queries below to the run that is about to start. Python's clock is not interchangeable here
+    # because the container may be skewed against the host.
+    before = profiler_race.query("SELECT toString(now64(6))").strip()
+
     # Stop by pid and wait for the process to be gone: the shared `stop_clickhouse()` helper was
     # observed to skip the stop here, silently turning every restart into a no-op. Restarting
     # explicitly keeps each iteration a real startup, which is what this test measures.
@@ -164,6 +169,7 @@ def restart_profiler_race_instance():
         time.sleep(0.5)
     assert profiler_race.get_process_pid("clickhouse") is None, "server did not stop"
     profiler_race.start_clickhouse(start_wait_sec=180)
+    return before
 
 
 def test_profiler_vs_processlist_publication(start_cluster):
@@ -185,38 +191,72 @@ def test_profiler_vs_processlist_publication(start_cluster):
             or 0
         )
 
-    def startup_thread_profiler_samples():
+    def startup_thread_row(since):
         # Neither `system.events` nor `system.query_log` can answer this: the former is process-wide
         # and also fed by the always-on global profiler, the latter reports the thread GROUP
         # aggregate, and the dictionary loader thread joins that same group with its own profiler.
         # The race needs the thread running `loadStartupScripts` as its reader, so count the samples
         # that thread booked itself: `query_thread_log` reports each thread's own counters, and the
-        # startup thread is the group's master thread.
+        # startup thread is the group's master thread. It is not renamed, so its thread_name is
+        # `Unknown` and cannot be used to identify it.
         profiler_race.query("SYSTEM FLUSH LOGS")
+        row = profiler_race.query(
+            "SELECT thread_id, ProfileEvents['QueryProfilerRuns'] "
+            "FROM system.query_thread_log "
+            "WHERE query LIKE '%profiler_race_dict%' AND thread_id = master_thread_id "
+            # This query is logged too and mentions the dictionary; the table name it reads is
+            # what tells its own rows apart from the startup script's.
+            "AND query NOT LIKE '%query_thread_log%' "
+            # The log is a persistent table and the restarts do not wipe the data directory, so
+            # without this the newest row can belong to an earlier restart that did pass.
+            f"AND event_time_microseconds > toDateTime64('{since}', 6) "
+            "ORDER BY event_time_microseconds DESC LIMIT 1"
+        ).split()
+        assert row, (
+            "the startup thread logged no row for the dictionary query in this run, so neither "
+            "assertion below can be evaluated"
+        )
+        return int(row[0]), int(row[1])
+
+    def loader_threads_sharing_group(startup_tid, since):
+        # A thread that joined the startup thread's group reports that thread as its master; a loader
+        # that failed to inherit the group and built its own reports itself instead. Only in the
+        # former case does `ProcessList::insert` publish the new per-user Counters into the chain the
+        # startup thread walks, which is the whole point of this test. The loader's own row carries
+        # the source SELECT rather than the CREATE DICTIONARY, because `ProcessList::insert`
+        # overwrites the query it inherited at attach.
         return int(
             profiler_race.query(
-                "SELECT ProfileEvents['QueryProfilerRuns'] FROM system.query_thread_log "
-                "WHERE query LIKE '%profiler_race_dict%' AND thread_id = master_thread_id "
-                # This query is logged too and mentions the dictionary; the table name it reads is
-                # what tells its own rows apart from the startup script's.
-                "AND query NOT LIKE '%query_thread_log%' "
-                "ORDER BY event_time_microseconds DESC LIMIT 1"
+                "SELECT count() FROM system.query_thread_log "
+                f"WHERE master_thread_id = {startup_tid} AND thread_id != master_thread_id "
+                "AND thread_name = 'ExternalLoader' "
+                f"AND event_time_microseconds > toDateTime64('{since}', 6)"
             ).strip()
             or 0
         )
 
     for _ in range(PROFILER_RACE_RESTARTS):
-        restart_profiler_race_instance()
+        since = restart_profiler_race_instance()
         assert get_execution_state(profiler_race) == STATE_SUCCESS
         # The profiler is armed per thread on a best-effort basis: `initQueryProfiler` returns early
         # when there is no trace collector and swallows timer-creation failures. Without a positive
         # oracle a silently disarmed startup thread would never enter the racing window, yet the
         # absence of a TSan report would still read as a pass. A healthy startup samples thousands
         # of times.
-        samples = startup_thread_profiler_samples()
+        startup_tid, samples = startup_thread_row(since)
         assert samples > 1000, (
             f"the query profiler sampled the startup thread only {samples} times, so the racing "
             "window was not meaningfully exercised and the absence of a TSan report proves nothing"
+        )
+        # The assertion above covers the reader side only. The group is handed to the loader thread
+        # on a best-effort basis too: `ThreadGroupSwitcher` swallows attach failures and nulls its
+        # group, after which the dictionary source opens its own and publishes out of the startup
+        # thread's reach. Every other assertion here still passes in that state.
+        loaders = loader_threads_sharing_group(startup_tid, since)
+        assert loaders > 0, (
+            "the dictionary loader did not join the startup thread's group, so the per-user "
+            "Counters were published into a chain that thread never walks and the cross-thread "
+            "publication this test targets was not exercised"
         )
 
     # Log rotation keeps a bounded number of files, so this cannot be compared against the restart

--- a/tests/integration/test_startup_scripts/test.py
+++ b/tests/integration/test_startup_scripts/test.py
@@ -147,10 +147,9 @@ def test_reload_config_does_not_rerun_startup_scripts(start_cluster):
 
 
 def restart_profiler_race_instance():
-    # `stop_clickhouse()` finds the process with `ps -C clickhouse`, which matches on `comm`. The
-    # server re-execs itself for `--daemon`, so its `comm` is `exe` and `ps -C clickhouse` finds
-    # nothing: the helper would log "already stopped" and skip the restart, leaving the test
-    # asserting nothing. Stop it by pid instead, then wait for the process to be gone.
+    # Stop by pid and wait for the process to be gone: the shared `stop_clickhouse()` helper was
+    # observed to skip the stop here, silently turning every restart into a no-op. Restarting
+    # explicitly keeps each iteration a real startup, which is what this test measures.
     pid = profiler_race.get_process_pid("clickhouse")
     assert pid is not None, "server is not running, cannot restart it"
     profiler_race.exec_in_container(
@@ -165,13 +164,11 @@ def restart_profiler_race_instance():
 
 
 def test_profiler_vs_processlist_publication(start_cluster):
-    # Guard against the test silently degenerating into a no-op: every iteration must actually run
-    # the startup script, which is what puts the loader thread and the profiled startup thread on
-    # the same Counters chain.
+    if not profiler_race.is_built_with_thread_sanitizer():
+        pytest.skip("the race is only observable under ThreadSanitizer")
+
     def dictionary_source_logins():
-        # The server rotates its log on open, so each restart leaves a compressed
-        # clickhouse-server.log.N.gz. Count over all of them (zcat -f handles both the plain
-        # current log and the gzipped rotations).
+        # zcat -f reads the current log and the gzipped rotations left by earlier restarts.
         return int(
             profiler_race.exec_in_container(
                 [
@@ -185,22 +182,43 @@ def test_profiler_vs_processlist_publication(start_cluster):
             or 0
         )
 
+    def startup_query_profiler_samples():
+        # Per-query, not the global `system.events` counter: that one is also fed by the always-on
+        # global profiler (`global_profiler_real_time_period_ns`), so it is non-zero even when the
+        # query profiler is off. This attributes the samples to the startup script's own query.
+        profiler_race.query("SYSTEM FLUSH LOGS")
+        return int(
+            profiler_race.query(
+                "SELECT ProfileEvents['QueryProfilerRuns'] FROM system.query_log "
+                "WHERE query LIKE '%profiler_race_dict%' AND type = 'QueryFinish' "
+                "ORDER BY event_time_microseconds DESC LIMIT 1"
+            ).strip()
+            or 0
+        )
+
     for _ in range(PROFILER_RACE_RESTARTS):
         restart_profiler_race_instance()
         assert get_execution_state(profiler_race) == STATE_SUCCESS
+        # The profiler is armed on a best-effort basis: `initQueryProfiler` returns early when there
+        # is no trace collector and swallows timer-creation failures. Without a positive oracle a
+        # silently disarmed profiler would never enter the racing window, yet the absence of a TSan
+        # report would still read as a pass. A healthy startup samples thousands of times.
+        samples = startup_query_profiler_samples()
+        assert samples > 1000, (
+            f"the query profiler sampled the startup script only {samples} times, so the racing "
+            "window was not meaningfully exercised and the absence of a TSan report proves nothing"
+        )
 
     # Log rotation keeps a bounded number of files, so this cannot be compared against the restart
     # count directly. What matters is that the startup script really ran on the restarts that are
-    # still on disk: if it had silently stopped running, this would be 0 and the test would be
-    # asserting nothing.
+    # still on disk.
     assert dictionary_source_logins() > 0, (
         "the dictionary source query never ran, so the startup path this test is meant to "
         "exercise was not exercised at all"
     )
 
-    # A ThreadSanitizer report here means the loader thread published the freshly constructed
-    # per-user Counters into the shared chain without ordering, while the profiler signal handler
-    # on the startup thread was walking it.
+    # Both files are checked because the sanitizer writes to stderr while the server also mirrors
+    # fatal output into its own error log.
     for filename in ("stderr.log", "clickhouse-server.err.log"):
         report = profiler_race.grep_in_log(
             "ThreadSanitizer: data race", from_host=True, filename=filename, after=40

--- a/tests/integration/test_startup_scripts/test.py
+++ b/tests/integration/test_startup_scripts/test.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -23,10 +25,20 @@ bad = cluster.add_instance(
     main_configs=["configs/bad_script.xml"],
     stay_alive=True,
 )
+profiler_race = cluster.add_instance(
+    "profiler_race",
+    main_configs=["configs/profiler_race_script.xml"],
+    user_configs=["configs/profiler_race_users.xml"],
+    stay_alive=True,
+)
 
 # Values of the StartupScriptsExecutionState metric.
 STATE_SUCCESS = 1
 STATE_FAILURE = 2
+
+# How many times the profiler-race instance is restarted. Each restart is one chance for the
+# profiler signal to land while the loader thread publishes the new per-user Counters.
+PROFILER_RACE_RESTARTS = 12
 
 
 @pytest.fixture(scope="module")
@@ -132,3 +144,65 @@ def test_reload_config_does_not_rerun_startup_scripts(start_cluster):
     assert get_execution_state(node) == STATE_SUCCESS
     node.query("SYSTEM RELOAD CONFIG")
     assert get_execution_state(node) == STATE_SUCCESS
+
+
+def restart_profiler_race_instance():
+    # `stop_clickhouse()` finds the process with `ps -C clickhouse`, which matches on `comm`. The
+    # server re-execs itself for `--daemon`, so its `comm` is `exe` and `ps -C clickhouse` finds
+    # nothing: the helper would log "already stopped" and skip the restart, leaving the test
+    # asserting nothing. Stop it by pid instead, then wait for the process to be gone.
+    pid = profiler_race.get_process_pid("clickhouse")
+    assert pid is not None, "server is not running, cannot restart it"
+    profiler_race.exec_in_container(
+        ["bash", "-c", f"kill -9 {pid}"], user="root", nothrow=True
+    )
+    for _ in range(120):
+        if profiler_race.get_process_pid("clickhouse") is None:
+            break
+        time.sleep(0.5)
+    assert profiler_race.get_process_pid("clickhouse") is None, "server did not stop"
+    profiler_race.start_clickhouse(start_wait_sec=180)
+
+
+def test_profiler_vs_processlist_publication(start_cluster):
+    # Guard against the test silently degenerating into a no-op: every iteration must actually run
+    # the startup script, which is what puts the loader thread and the profiled startup thread on
+    # the same Counters chain.
+    def dictionary_source_logins():
+        # The server rotates its log on open, so each restart leaves a compressed
+        # clickhouse-server.log.N.gz. Count over all of them (zcat -f handles both the plain
+        # current log and the gzipped rotations).
+        return int(
+            profiler_race.exec_in_container(
+                [
+                    "bash",
+                    "-c",
+                    "zcat -f /var/log/clickhouse-server/clickhouse-server.log* "
+                    "| grep -ac \"Authenticating user 'dict_source_user'\" || true",
+                ],
+                user="root",
+            ).strip()
+            or 0
+        )
+
+    for _ in range(PROFILER_RACE_RESTARTS):
+        restart_profiler_race_instance()
+        assert get_execution_state(profiler_race) == STATE_SUCCESS
+
+    # Log rotation keeps a bounded number of files, so this cannot be compared against the restart
+    # count directly. What matters is that the startup script really ran on the restarts that are
+    # still on disk: if it had silently stopped running, this would be 0 and the test would be
+    # asserting nothing.
+    assert dictionary_source_logins() > 0, (
+        "the dictionary source query never ran, so the startup path this test is meant to "
+        "exercise was not exercised at all"
+    )
+
+    # A ThreadSanitizer report here means the loader thread published the freshly constructed
+    # per-user Counters into the shared chain without ordering, while the profiler signal handler
+    # on the startup thread was walking it.
+    for filename in ("stderr.log", "clickhouse-server.err.log"):
+        report = profiler_race.grep_in_log(
+            "ThreadSanitizer: data race", from_host=True, filename=filename, after=40
+        )
+        assert not report, f"ThreadSanitizer report in {filename}:\n{report}"

--- a/tests/integration/test_startup_scripts/test.py
+++ b/tests/integration/test_startup_scripts/test.py
@@ -27,7 +27,10 @@ bad = cluster.add_instance(
 )
 profiler_race = cluster.add_instance(
     "profiler_race",
-    main_configs=["configs/profiler_race_script.xml"],
+    main_configs=[
+        "configs/profiler_race_script.xml",
+        "configs/profiler_race_logs.xml",
+    ],
     user_configs=["configs/profiler_race_users.xml"],
     stay_alive=True,
 )
@@ -182,15 +185,21 @@ def test_profiler_vs_processlist_publication(start_cluster):
             or 0
         )
 
-    def startup_query_profiler_samples():
-        # Per-query, not the global `system.events` counter: that one is also fed by the always-on
-        # global profiler (`global_profiler_real_time_period_ns`), so it is non-zero even when the
-        # query profiler is off. This attributes the samples to the startup script's own query.
+    def startup_thread_profiler_samples():
+        # Neither `system.events` nor `system.query_log` can answer this: the former is process-wide
+        # and also fed by the always-on global profiler, the latter reports the thread GROUP
+        # aggregate, and the dictionary loader thread joins that same group with its own profiler.
+        # The race needs the thread running `loadStartupScripts` as its reader, so count the samples
+        # that thread booked itself: `query_thread_log` reports each thread's own counters, and the
+        # startup thread is the group's master thread.
         profiler_race.query("SYSTEM FLUSH LOGS")
         return int(
             profiler_race.query(
-                "SELECT ProfileEvents['QueryProfilerRuns'] FROM system.query_log "
-                "WHERE query LIKE '%profiler_race_dict%' AND type = 'QueryFinish' "
+                "SELECT ProfileEvents['QueryProfilerRuns'] FROM system.query_thread_log "
+                "WHERE query LIKE '%profiler_race_dict%' AND thread_id = master_thread_id "
+                # This query is logged too and mentions the dictionary; the table name it reads is
+                # what tells its own rows apart from the startup script's.
+                "AND query NOT LIKE '%query_thread_log%' "
                 "ORDER BY event_time_microseconds DESC LIMIT 1"
             ).strip()
             or 0
@@ -199,13 +208,14 @@ def test_profiler_vs_processlist_publication(start_cluster):
     for _ in range(PROFILER_RACE_RESTARTS):
         restart_profiler_race_instance()
         assert get_execution_state(profiler_race) == STATE_SUCCESS
-        # The profiler is armed on a best-effort basis: `initQueryProfiler` returns early when there
-        # is no trace collector and swallows timer-creation failures. Without a positive oracle a
-        # silently disarmed profiler would never enter the racing window, yet the absence of a TSan
-        # report would still read as a pass. A healthy startup samples thousands of times.
-        samples = startup_query_profiler_samples()
+        # The profiler is armed per thread on a best-effort basis: `initQueryProfiler` returns early
+        # when there is no trace collector and swallows timer-creation failures. Without a positive
+        # oracle a silently disarmed startup thread would never enter the racing window, yet the
+        # absence of a TSan report would still read as a pass. A healthy startup samples thousands
+        # of times.
+        samples = startup_thread_profiler_samples()
         assert samples > 1000, (
-            f"the query profiler sampled the startup script only {samples} times, so the racing "
+            f"the query profiler sampled the startup thread only {samples} times, so the racing "
             "window was not meaningfully exercised and the absence of a TSan report proves nothing"
         )
 
@@ -217,8 +227,8 @@ def test_profiler_vs_processlist_publication(start_cluster):
         "exercise was not exercised at all"
     )
 
-    # Both files are checked because the sanitizer writes to stderr while the server also mirrors
-    # fatal output into its own error log.
+    # The sanitizer writes to stderr, which the logger config redirects to stderr.log. The error log
+    # is grepped too as a cheap fallback in case that redirection is not in place.
     for filename in ("stderr.log", "clickhouse-server.err.log"):
         report = profiler_race.grep_in_log(
             "ThreadSanitizer: data race", from_host=True, filename=filename, after=40

--- a/tests/integration/test_startup_scripts/test.py
+++ b/tests/integration/test_startup_scripts/test.py
@@ -40,8 +40,10 @@ STATE_SUCCESS = 1
 STATE_FAILURE = 2
 
 # How many times the profiler-race instance is restarted. Each restart is one chance for the
-# profiler signal to land while the loader thread publishes the new per-user Counters.
-PROFILER_RACE_RESTARTS = 12
+# profiler signal to land while the loader thread publishes the new per-user Counters. One restart
+# samples that window thousands of times and reports the race on its own, so the repetitions are
+# margin only and a handful of them keeps the cost of a sanitizer run bounded.
+PROFILER_RACE_RESTARTS = 6
 
 
 @pytest.fixture(scope="module")
@@ -150,6 +152,13 @@ def test_reload_config_does_not_rerun_startup_scripts(start_cluster):
 
 
 def restart_profiler_race_instance():
+    # `SETTINGS(dictionary_lazy_load = 0)` is stored in the dictionary metadata, so a surviving
+    # dictionary is loaded again while its table is attached, before the startup script runs. That
+    # earlier load creates the source user's ProcessListForUser, leaving the startup script with the
+    # existing-user branch, which is not the racing scenario. Dropping it makes the startup script
+    # the only creator.
+    profiler_race.query("DROP DICTIONARY IF EXISTS profiler_race_dict")
+
     # The thread log survives the restart, so return the server's own clock reading first: it scopes
     # the queries below to the run that is about to start. Python's clock is not interchangeable here
     # because the container may be skewed against the host.
@@ -176,14 +185,19 @@ def test_profiler_vs_processlist_publication(start_cluster):
     if not profiler_race.is_built_with_thread_sanitizer():
         pytest.skip("the race is only observable under ThreadSanitizer")
 
-    def dictionary_source_logins():
-        # zcat -f reads the current log and the gzipped rotations left by earlier restarts.
+    def dictionary_source_logins(current_run_only):
+        # `rotateOnOpen` is set for these instances, so every start moves the previous log aside and
+        # the un-globbed file covers exactly the current run. The glob adds the gzipped rotations of
+        # earlier runs, which is what the cumulative check at the end of the test wants.
+        path = "/var/log/clickhouse-server/clickhouse-server.log"
+        if not current_run_only:
+            path += "*"
         return int(
             profiler_race.exec_in_container(
                 [
                     "bash",
                     "-c",
-                    "zcat -f /var/log/clickhouse-server/clickhouse-server.log* "
+                    f"zcat -f {path} "
                     "| grep -ac \"Authenticating user 'dict_source_user'\" || true",
                 ],
                 user="root",
@@ -258,11 +272,21 @@ def test_profiler_vs_processlist_publication(start_cluster):
             "Counters were published into a chain that thread never walks and the cross-thread "
             "publication this test targets was not exercised"
         )
+        # Only the FIRST insert for a user constructs the ProfileEvents::Counters this test races
+        # against; later ones find the entry and publish an address that has long been visible. A
+        # dictionary left over from the previous run is loaded once more at attach time, ahead of the
+        # startup script, which would silently reduce the script to that second case.
+        logins = dictionary_source_logins(current_run_only=True)
+        assert logins == 1, (
+            f"the dictionary source user logged in {logins} times in this run instead of once, so "
+            "something loaded the dictionary before the startup script did and the first-time "
+            "per-user Counters construction was not exercised on the startup path"
+        )
 
     # Log rotation keeps a bounded number of files, so this cannot be compared against the restart
     # count directly. What matters is that the startup script really ran on the restarts that are
     # still on disk.
-    assert dictionary_source_logins() > 0, (
+    assert dictionary_source_logins(current_run_only=False) > 0, (
         "the dictionary source query never ran, so the startup path this test is meant to "
         "exercise was not exercised at all"
     )

--- a/tests/integration/test_startup_scripts/test.py
+++ b/tests/integration/test_startup_scripts/test.py
@@ -1,3 +1,4 @@
+import subprocess
 import time
 
 import pytest
@@ -25,14 +26,49 @@ bad = cluster.add_instance(
     main_configs=["configs/bad_script.xml"],
     stay_alive=True,
 )
-profiler_race = cluster.add_instance(
-    "profiler_race",
-    main_configs=[
-        "configs/profiler_race_script.xml",
-        "configs/profiler_race_logs.xml",
-    ],
-    user_configs=["configs/profiler_race_users.xml"],
-    stay_alive=True,
+
+
+def _built_with_thread_sanitizer():
+    # `ClickHouseInstance.is_built_with_thread_sanitizer()` needs a running server, which is too
+    # late: `cluster.start()` starts every registered instance before any test body runs, so the
+    # in-test skip cannot avoid the cost of this instance. Ask the binary directly instead.
+    # Unknown answers count as ThreadSanitizer: skipping is a silent loss of the only coverage
+    # this race has, while a needless instance is only slower.
+    # `cluster.server_bin_path` is the binary the instances will run. Re-deriving it here would
+    # diverge from it, because the fallback used when the environment does not name one searches
+    # `PATH` before `/usr/bin`.
+    try:
+        flags = subprocess.run(
+            [
+                cluster.server_bin_path,
+                "local",
+                "--query",
+                "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS'",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=True,
+        ).stdout
+    except Exception:
+        return True
+    return "-fsanitize=thread" in flags
+
+
+# Registering this instance costs a whole extra server plus a non-lazy dictionary load on every run
+# of this file, and only a ThreadSanitizer build can observe the race it reproduces.
+profiler_race = (
+    cluster.add_instance(
+        "profiler_race",
+        main_configs=[
+            "configs/profiler_race_script.xml",
+            "configs/profiler_race_logs.xml",
+        ],
+        user_configs=["configs/profiler_race_users.xml"],
+        stay_alive=True,
+    )
+    if _built_with_thread_sanitizer()
+    else None
 )
 
 # Values of the StartupScriptsExecutionState metric.
@@ -182,7 +218,10 @@ def restart_profiler_race_instance():
 
 
 def test_profiler_vs_processlist_publication(start_cluster):
-    if not profiler_race.is_built_with_thread_sanitizer():
+    # The instance is only registered on ThreadSanitizer. The server-side check still runs when it
+    # is: it is the authoritative one, and it covers the case where the pre-start probe above had to
+    # guess.
+    if profiler_race is None or not profiler_race.is_built_with_thread_sanitizer():
         pytest.skip("the race is only observable under ThreadSanitizer")
 
     def dictionary_source_logins(current_run_only):


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/105056


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a data race on the `ProfileEvents::Counters` parent chain. A freshly constructed per-user counters object was published into a chain that other threads traverse lock-free using a relaxed store, so a thread that observed the pointer was not guaranteed to see the pointee fully constructed. The publication is now release-ordered and the loads that dereference it are acquire-ordered.


### Description

`ProcessList::insert` constructs a new `ProcessListForUser` for a user that has no entry yet. Its embedded `user_performance_counters` is initialized with ordinary non-atomic writes, and its address is then published into the shared `ThreadGroup`'s counters chain by `setUserCounters`, which stored `parent` with `std::memory_order_relaxed`. A relaxed store pairs with nothing, so the constructor's writes were not ordered before a consumer's reads. Any thread walking the same chain (`Counters::increment` / `incrementNoTrace` / `incrementSignalSafe`) could therefore dereference a pointer to an object it was not guaranteed to see initialized.

`setParent` had the same relaxed publication, and it is used on every thread-group attach and by `attachProfileCountersScope`, which publishes a scope-local `Counters`.

The fix is local to `Counters`, which owns both the chain and its traversal: the two publication stores become `memory_order_release`, and every load that dereferences what it loads becomes `memory_order_acquire`. The traversal loads were previously implicit `std::atomic` conversions, that is `seq_cst`, so on the increment path this is a small relaxation rather than a strengthening. On x86-64 all of these compile to a plain `mov`; on ARM the loads go from `ldar` to `ldapr`. The publication stores are cold: once per thread-group attach, and once per `ProcessList` insertion.

This is a publication-ordering defect, not a use-after-free and not a rehash invalidation. `user_to_queries` entries are never erased (`ProcessListEntry::~ProcessListEntry` documents this, and `getUserInfo` relies on it), and `UserToQueries` is node-based so element addresses are stable. The write side is the initial construction.

The report shape only became possible after #105056, which introduced the `cpus` field and `fetchAdd` that the read side touches.

Reproduced locally on a ThreadSanitizer build, where the reported stacks are:

```
  Read of size 8 by main thread (mutexes: write M0):
    ProfileEvents::Counters::fetchAdd(...)                  src/Common/ProfileEvents.cpp
    ProfileEvents::Counters::incrementSignalSafe(...)       src/Common/ProfileEvents.cpp:1980
    DB::(anonymous namespace)::writeTraceInfo(...)           src/Common/QueryProfiler.cpp:132
    DB::QueryProfilerReal::signalHandler(...)                src/Common/QueryProfiler.cpp:595
    ... std::condition_variable::wait interrupted in
    DB::ExternalLoader::LoadingDispatcher::loadImpl(...)
    DB::registerStorageDictionary(...)                       src/Storages/StorageDictionary.cpp:385
    DB::InterpreterCreateQuery::execute()
    DB::(anonymous namespace)::loadStartupScripts(...)        programs/server/Server.cpp:1134
    DB::Server::main(...)                                    programs/server/Server.cpp:3541

  Previous write of size 8 by thread T190 (mutexes: write M1):
    ProfileEvents::Counters::Counters(VariableContext, ProfileEvents::Counters*) src/Common/ProfileEvents.cpp:1678
    DB::ProcessListForUser::ProcessListForUser(...)          src/Interpreters/ProcessList.h:335
    ... operator new of the __hash_node<..., DB::ProcessListForUser> for ProcessList::insert
```

The mutexes on the two sides are disjoint, so nothing synchronized the publication with the traversal.

The regression test added to `tests/integration/test_startup_scripts/` reproduces this without any private configuration: a startup script creates a non-lazy dictionary whose `CLICKHOUSE` source authenticates a user other than `default`. `registerStorageDictionary` then blocks the main thread in `ExternalLoader::LoadingDispatcher::loadImpl` while the loader thread, sharing the main thread's `ThreadGroup`, performs the first `ProcessList::insert` for that user. With the profiler sampling the startup thread every 1 ms, the signal handler walks the chain while the new counters are being published. Verified in both directions on a ThreadSanitizer build: without the change the test fails on every attempt with the stacks above, with the change it passes 12 consecutive runs (144 server restarts) with no report.
