### PR TITLE
Fix the flaky pre-PAUSE checkpoint in test_pause_stops_after_current_batch

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -120,6 +120,7 @@ static struct InitFiu
     REGULAR(shared_set_sleep_during_update) \
     REGULAR(smt_outdated_parts_exception_response) \
     REGULAR(object_storage_queue_fail_in_the_middle_of_file) \
+    PAUSEABLE_ONCE(object_storage_queue_pause_after_commit) \
     PAUSEABLE_ONCE(replicated_merge_tree_insert_retry_pause) \
     ONCE(replicated_merge_tree_restore_attach_retry) \
     PAUSEABLE_ONCE(finish_set_quorum_failed_parts) \

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -89,6 +89,7 @@ namespace FailPoints
     extern const char object_storage_queue_fail_commit_after_success[];
     extern const char object_storage_queue_fail_after_insert[];
     extern const char object_storage_queue_fail_startup[];
+    extern const char object_storage_queue_pause_after_commit[];
 }
 
 namespace ServerSetting
@@ -1104,6 +1105,14 @@ bool StorageObjectStorageQueue::streamToViews(size_t streaming_tasks_index, UInt
         file_iterator->releaseFinishedBuckets();
         max_files_override = 0;
         total_rows += rows;
+
+        /// Park after the durable boundary and before the blocked check below, so a test can
+        /// observe a frozen row count with the backlog still pending and have a SYSTEM PAUSE
+        /// issued while parked be seen by that very check. No-op unless explicitly enabled.
+        /// An empty cycle has no durable boundary, and skipping it keeps a concurrently polling
+        /// idle table from consuming the one-shot pause.
+        if (rows > 0)
+            FailPointInjection::pauseFailPoint(FailPoints::object_storage_queue_pause_after_commit);
 
         if (stream_control.isBlocked())
             break;

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -1109,8 +1109,8 @@ bool StorageObjectStorageQueue::streamToViews(size_t streaming_tasks_index, UInt
         /// Park after the durable boundary and before the blocked check below, so a test can
         /// observe a frozen row count with the backlog still pending and have a SYSTEM PAUSE
         /// issued while parked be seen by that very check. No-op unless explicitly enabled.
-        /// An empty cycle has no durable boundary, and skipping it keeps a concurrently polling
-        /// idle table from consuming the one-shot pause.
+        /// Only a cycle that produced rows parks: the failpoint is process-global and one-shot,
+        /// so an idle table polling concurrently must not consume the pause.
         if (rows > 0)
             FailPointInjection::pauseFailPoint(FailPoints::object_storage_queue_pause_after_commit);
 

--- a/tests/integration/test_storage_s3_queue/test_system_stop.py
+++ b/tests/integration/test_storage_s3_queue/test_system_stop.py
@@ -1,5 +1,6 @@
 """Test SYSTEM STOP/PAUSE/CANCEL/REFRESH and ALL BACKGROUND controls on an S3Queue table."""
 
+import concurrent.futures
 import logging
 import threading
 import time
@@ -65,6 +66,25 @@ def assert_dst_count_stable(node, table, expected, seconds=5):
     while time.time() < deadline:
         assert int(node.query(f"SELECT count() FROM {table}_dst")) == expected
         time.sleep(1)
+
+
+PAUSE_AFTER_COMMIT_FAILPOINT = "object_storage_queue_pause_after_commit"
+
+
+def wait_failpoint_paused(node, failpoint, timeout=60):
+    """Block until a background thread parks at `failpoint`.
+
+    `SYSTEM WAIT FAILPOINT ... PAUSE` blocks, so it runs on a worker thread: a failpoint that is
+    never reached must fail the test rather than hang it. The executor is not joined on the failure
+    path, because its worker is still stuck inside the blocking query."""
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    future = pool.submit(node.query, f"SYSTEM WAIT FAILPOINT {failpoint} PAUSE")
+    done, _ = concurrent.futures.wait([future], timeout=timeout)
+    if not done:
+        pool.shutdown(wait=False, cancel_futures=True)
+        raise AssertionError(f"failpoint {failpoint} was not reached within {timeout}s")
+    pool.shutdown(wait=False)
+    future.result()
 
 
 def wait_count_stabilizes(node, table, checks=8, interval=0.5, timeout=60):
@@ -680,12 +700,21 @@ def test_pause_stops_after_current_batch(started_cluster):
     # over all the files and drains them slowly, one committed file at a time.
     node.query(f"SYSTEM STOP {table}")
     generate_random_files(started_cluster, files_path, count=n_files, start_ind=0)
-    node.query(f"SYSTEM START {table}")
 
-    # Wait until the drain is demonstrably in progress (a couple of files committed), then PAUSE
-    # mid-drain with most of the backlog still pending.
-    wait_dst_count(node, table, 2 * ROWS_PER_FILE)
-    node.query(f"SYSTEM PAUSE {table}")
+    # The drain must be paused mid-backlog, which means acting at a point the client cannot observe
+    # by polling `count()`: the count only holds an intermediate value for about as long as one
+    # commit takes. The failpoint parks the streaming task right after a commit instead, so the
+    # count is frozen, the rest of the backlog is provably pending, and the PAUSE below is
+    # guaranteed to reach the blocked check that ends the cycle.
+    node.query(f"SYSTEM ENABLE FAILPOINT {PAUSE_AFTER_COMMIT_FAILPOINT}")
+    try:
+        node.query(f"SYSTEM START {table}")
+        wait_failpoint_paused(node, PAUSE_AFTER_COMMIT_FAILPOINT)
+        assert int(node.query(f"SELECT count() FROM {table}_dst")) == ROWS_PER_FILE
+        node.query(f"SYSTEM PAUSE {table}")
+    finally:
+        # Also releases the parked task, so the cycle resumes even if an assertion above fired.
+        node.query(f"SYSTEM DISABLE FAILPOINT {PAUSE_AFTER_COMMIT_FAILPOINT}")
 
     # The in-flight batch reaches its durable boundary and consumption stops: the count settles well
     # below the full backlog instead of draining every remaining file.
@@ -693,6 +722,13 @@ def test_pause_stops_after_current_batch(started_cluster):
     assert 0 < settled < n_files * ROWS_PER_FILE, (
         "PAUSE should stop after the current batch's durable boundary, but "
         f"{settled // ROWS_PER_FILE}/{n_files} files were processed"
+    )
+    # PAUSE arrived while the task was parked at the boundary, so the cycle must end at exactly that
+    # boundary: no further file may be committed. Without the barrier the stopping point is whatever
+    # the drain happened to reach, which the range check above cannot distinguish.
+    assert settled == ROWS_PER_FILE, (
+        f"PAUSE was issued at a committed boundary of {ROWS_PER_FILE} rows, so the cycle must end "
+        f"there, but {settled} rows were committed"
     )
 
     # The files left pending are genuinely unprocessed: START drains the rest.
@@ -742,15 +778,25 @@ def test_azure_queue_pause_stops_after_current_batch(started_cluster):
     generate_random_files(
         started_cluster, files_path, count=n_files, start_ind=0, storage="azure"
     )
-    node.query(f"SYSTEM START {table}")
 
-    wait_dst_count(node, table, 2 * ROWS_PER_FILE)
-    node.query(f"SYSTEM PAUSE {table}")
+    # Same post-commit barrier as the S3Queue variant: see the comment there.
+    node.query(f"SYSTEM ENABLE FAILPOINT {PAUSE_AFTER_COMMIT_FAILPOINT}")
+    try:
+        node.query(f"SYSTEM START {table}")
+        wait_failpoint_paused(node, PAUSE_AFTER_COMMIT_FAILPOINT)
+        assert int(node.query(f"SELECT count() FROM {table}_dst")) == ROWS_PER_FILE
+        node.query(f"SYSTEM PAUSE {table}")
+    finally:
+        node.query(f"SYSTEM DISABLE FAILPOINT {PAUSE_AFTER_COMMIT_FAILPOINT}")
 
     settled = wait_count_stabilizes(node, table)
     assert 0 < settled < n_files * ROWS_PER_FILE, (
         "PAUSE should stop after the current batch's durable boundary, but "
         f"{settled // ROWS_PER_FILE}/{n_files} files were processed"
+    )
+    assert settled == ROWS_PER_FILE, (
+        f"PAUSE was issued at a committed boundary of {ROWS_PER_FILE} rows, so the cycle must end "
+        f"there, but {settled} rows were committed"
     )
 
     node.query(f"SYSTEM START {table}")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/107476
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/107476 (introduced these tests)

`test_storage_s3_queue/test_system_stop.py::test_pause_stops_after_current_batch` and
`::test_azure_queue_pause_stops_after_current_batch` are flaky. Reported here:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110052&sha=e6dd5ec8cfb66f316a610457e842607677696d9a&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%202%2F6%29

PAUSE semantics are not at fault. The failure is in the test's pre-PAUSE checkpoint: both
tracebacks stop at `wait_dst_count(node, table, 2 * ROWS_PER_FILE)`, which runs before
`SYSTEM PAUSE` is issued. `SYSTEM PAUSE <table>` appears zero times in the failing run's
server log for either table, so the PAUSE assertion was never reached and the reported
`expected 20 rows ... got '100'` is that checkpoint's own assert.

Root cause: the checkpoint waits for exact equality against an intermediate value of a
monotonically growing count. In the failing job the commit period was 1.05s while a poll
round trip cost 1.29s, so the observed sequence was 0, 10, 30, 40, ... - the 20 rung was
stepped over, and because the count only grows, equality could never hold again. All 120
retries burned and the test asserted at the terminal 100.

Widening the wait to `>=` would only make the window larger, not remove the race, so
instead the batch boundary is made observable. A new `PAUSEABLE_ONCE` failpoint parks the
streaming task right after a batch commits and before the `isBlocked()` check that ends
the cycle. The tests enable it, wait for the park, assert the frozen count, issue PAUSE,
and release it in a `finally`. The count can no longer move under the assertion, and PAUSE
is now guaranteed to land on the very check under test rather than at an arbitrary point.
That determinism also allows asserting the stopping point exactly (`settled ==
ROWS_PER_FILE`) in addition to the existing range assertion, which is unchanged.

The failpoint is inert unless explicitly enabled, so it is test scaffolding rather than a
behaviour change. Only a cycle that produced rows parks, so an idle table polling
concurrently cannot consume the one-shot pause.
`AzureQueue` and `S3Queue` share `StorageObjectStorageQueue::streamToViews`, so one
failpoint covers both variants.

Verified on a local debug build: with the old checkpoint and an induced 1.5s poll delay
that reproduces the measured CI ordering, the test fails with the exact CI signature and
the observed sequence 10, 30, 50, 70, 90, 100 (20 skipped); with the barrier the same
delay has no effect. Moving the failpoint after the `isBlocked()` check, or removing it,
makes both tests fail. 20 repeats of both tests, the whole `test_system_stop.py`, and the
whole `test_storage_s3_queue/` directory all pass.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.174` (included in `26.8` and later)
<!-- ch-version-info:end -->