### PR TITLE
Docs: improve external integration link contrast

### DIFF
--- a/docs/snippets/components/IntegrationGrid/IntegrationGrid.jsx
+++ b/docs/snippets/components/IntegrationGrid/IntegrationGrid.jsx
@@ -579,7 +579,7 @@ function useCMSIntegrations() {
           color: #fff;
         }
         .dark .integration-external-overlay svg {
-          color: #1f1f1f;
+          color: #fff;
         }
         .integration-card:hover .integration-external-overlay {
           opacity: 1;


### PR DESCRIPTION
Improves the contrast of external-link overlay icons on integration cards in dark mode. The icon previously used `#1f1f1f` against a translucent light overlay, making the hover affordance difficult to see; it now renders white.

Validated with `git diff --check` and a static assertion of the dark-theme selector.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved external-link icon contrast on the integration landing page in dark mode.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.191` (included in `26.8` and later)
<!-- ch-version-info:end -->