### PR TITLE
Fix test 04627_analyzer_compatibility_final_all_joined_tables with old analyzer

### DIFF
--- a/tests/queries/0_stateless/04627_analyzer_compatibility_final_all_joined_tables.sql
+++ b/tests/queries/0_stateless/04627_analyzer_compatibility_final_all_joined_tables.sql
@@ -1,9 +1,9 @@
 -- Compatibility setting for the fix of FINAL leaking onto other tables of a JOIN
 -- (https://github.com/ClickHouse/ClickHouse/pull/108979).
 
--- The setting `analyzer_compatibility_apply_final_to_all_joined_tables` affects only the new
--- analyzer. The old analyzer has different semantics of FINAL in JOIN (it ignores FINAL on the
--- right table), so pin the analyzer explicitly.
+-- The setting `analyzer_compatibility_apply_final_to_all_joined_tables` has an effect only when
+-- the analyzer is enabled. The old analyzer has different semantics of FINAL in JOIN (it ignores
+-- FINAL on the right table), so pin the analyzer explicitly.
 SET enable_analyzer = 1;
 
 DROP TABLE IF EXISTS t_left;

--- a/tests/queries/0_stateless/04627_analyzer_compatibility_final_all_joined_tables.sql
+++ b/tests/queries/0_stateless/04627_analyzer_compatibility_final_all_joined_tables.sql
@@ -1,6 +1,11 @@
 -- Compatibility setting for the fix of FINAL leaking onto other tables of a JOIN
 -- (https://github.com/ClickHouse/ClickHouse/pull/108979).
 
+-- The setting `analyzer_compatibility_apply_final_to_all_joined_tables` affects only the new
+-- analyzer. The old analyzer has different semantics of FINAL in JOIN (it ignores FINAL on the
+-- right table), so pin the analyzer explicitly.
+SET enable_analyzer = 1;
+
 DROP TABLE IF EXISTS t_left;
 DROP TABLE IF EXISTS t_right;
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/111589

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

The test `04627_analyzer_compatibility_final_all_joined_tables` (added in https://github.com/ClickHouse/ClickHouse/pull/111589) fails deterministically on the `Stateless tests (amd_llvm_coverage, old analyzer, s3 storage, DBReplicated, WasmEdge, parallel, 2/3)` check: the setting `analyzer_compatibility_apply_final_to_all_joined_tables` affects only the new analyzer, and with `enable_analyzer = 0` the old analyzer ignores `FINAL` on the right table of a JOIN, so every count in the test differs from the reference. Pin `enable_analyzer = 1` in the test.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8aab14806e3a4bafcea95428b8fba17398d2a778&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20old%20analyzer%2C%20s3%20storage%2C%20DBReplicated%2C%20WasmEdge%2C%20parallel%2C%202%2F3%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.178` (included in `26.8` and later)
- Backported to: `26.7.2.36`, `26.6.2.126`
<!-- ch-version-info:end -->