### PR TITLE
Fix flaky test_kafka_flush_by_time by reusing one Kafka producer

### DIFF
--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -2259,10 +2259,19 @@ def test_kafka_flush_by_time(kafka_cluster, create_query_generator):
 
         cancel = threading.Event()
 
+        # Reuse one producer: `k.kafka_produce` opens a new connection per call,
+        # and a single broker-version probe there can cost seconds, which is
+        # enough to miss the row count asserted below.
+        producer = k.get_kafka_producer(
+            kafka_cluster.kafka_port, k.producer_serializer, retries=15
+        )
+
         def produce():
             while not cancel.is_set():
-                messages = [json.dumps({"key": 0, "value": 0})]
-                k.kafka_produce(kafka_cluster, topic_name, messages)
+                producer.send(
+                    topic=topic_name, value=json.dumps({"key": 0, "value": 0})
+                )
+                producer.flush()
                 time.sleep(0.8)
 
         kafka_thread = threading.Thread(target=produce)
@@ -2280,6 +2289,7 @@ def test_kafka_flush_by_time(kafka_cluster, create_query_generator):
 
         cancel.set()
         kafka_thread.join()
+        producer.close()
 
         instance.query(f"""
             DROP TABLE test.{kafka_table}_consumer;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`test_storage_kafka/test_batch_fast.py::test_kafka_flush_by_time` asserts

```sql
SELECT uniqExact(ts), count() >= 15 FROM test.{kafka_table}_view
```

after an 18 second window. The first column, the number of flushes, is what the test is named
for and it is correct in every failure I looked at. The second column is the one that fails:
fewer than 15 rows arrive in time.

The produce loop sent one message per `k.kafka_produce` call, and that helper builds a new
`KafkaProducer` on every call, so every single message paid a full client bootstrap including
kafka-python's broker-version probe. In the failing CI run that probe took 2.1 s on one
iteration (3.023 s for the whole iteration, against 0.107-0.113 s for the other 17), which cost
about 3 messages out of a budget that had roughly half a message of slack. Result: 5 + 9 = 14
rows with `uniqExact(ts)` = 2, i.e. the flush behaviour was correct and only the row count was
short. Both engines flushed on schedule (7841/7599 ms, versus 7537/7535 ms in the run of the
other parametrization that passed 21 seconds earlier on the same server), so this is not a
`StorageKafka`/`StorageKafka2` flush race.

This hoists one producer out of the loop, using the existing `k.get_kafka_producer` and
`k.producer_serializer` helpers that five other producers in the same file already use, and
closes it after the producer thread is joined. The per-iteration cost drops from 0.107-3.02 s to
a single send plus flush round trip.

The assertion, the `>= 15` threshold, the 18 second window and the 0.8 s message rate are
unchanged. Nothing is weakened: no threshold lowered, no sleep lengthened, no retry wrapper, no
determinism tag.

Measurements on the fixed test, locally:

- Producer constructions per run go from 17 (one per message) to 1.
- Exactly 2 in-window flushes in 25 out of 25 runs, never 3, so `uniqExact(ts) == 2` stays a
  live assertion and the flush cadence stays on the `stream_flush_interval_ms` default
  (measured 7514-9020 ms).
- In-window row totals are now 19 to 21 against the threshold of 15, instead of 14.
- 50 executions (`--count 25`, both parametrizations) pass.

Verified in both directions by injecting the measured 2.9 s stall into the produce path: on
master the test fails with `assert 2\t0 == 2\t1`, matching the CI signature exactly, and with
this change it passes even when the stall fires inside the loop. Reverting only the hoist and
keeping the injected stall brings the failure back.

One behaviour note: `retries=15` now guards producer construction once at test start instead of
per iteration, so a transient broker outage surfaces as a clear setup error rather than a silent
under-count. That matches how the other call sites in this file already use the helper.

CI report for the failure this addresses:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110344&sha=006dde1db1b596687365eddd7a30586f45c4f332&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%204%2F6%29

No related open issue found for this test.

The `kafka_setup_teardown` / `DROP DATABASE IF EXISTS test SYNC` failures filed under the same
test name are a different root cause and are not addressed here.