### PR TITLE
Fix no-op cleanup prologue in 04104_any_join_semi_anti_not_ready_set

### DIFF
--- a/tests/queries/0_stateless/04104_any_join_semi_anti_not_ready_set.sql
+++ b/tests/queries/0_stateless/04104_any_join_semi_anti_not_ready_set.sql
@@ -2,9 +2,9 @@
 -- containing IN (subquery); on debug/sanitizer builds FunctionIn on a not-ready Set aborted via
 -- LOGICAL_ERROR before the surrounding try/catch could intercept
 
-DROP TABLE IF EXISTS t_left_004104;
-DROP TABLE IF EXISTS t_right_004104;
-DROP TABLE IF EXISTS t_subq_004104;
+DROP TABLE IF EXISTS t_left_04104;
+DROP TABLE IF EXISTS t_right_04104;
+DROP TABLE IF EXISTS t_subq_04104;
 
 CREATE TABLE t_left_04104  (a UInt64, b UInt64) ENGINE = MergeTree ORDER BY a;
 CREATE TABLE t_right_04104 (a UInt64, c UInt64) ENGINE = MergeTree ORDER BY a;

--- a/tests/queries/0_stateless/04104_any_join_semi_anti_not_ready_set.sql
+++ b/tests/queries/0_stateless/04104_any_join_semi_anti_not_ready_set.sql
@@ -2,9 +2,9 @@
 -- containing IN (subquery); on debug/sanitizer builds FunctionIn on a not-ready Set aborted via
 -- LOGICAL_ERROR before the surrounding try/catch could intercept
 
-DROP TABLE IF EXISTS t_left_04104;
-DROP TABLE IF EXISTS t_right_04104;
-DROP TABLE IF EXISTS t_subq_04104;
+DROP TABLE IF EXISTS t_left_04104  SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_right_04104 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_subq_04104  SETTINGS ignore_drop_queries_probability = 0;
 
 CREATE TABLE t_left_04104  (a UInt64, b UInt64) ENGINE = MergeTree ORDER BY a;
 CREATE TABLE t_right_04104 (a UInt64, c UInt64) ENGINE = MergeTree ORDER BY a;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`04104_any_join_semi_anti_not_ready_set.sql` drops `t_left_004104`,
`t_right_004104`, `t_subq_004104` (three zeros) but creates and uses
`t_left_04104`, `t_right_04104`, `t_subq_04104` (two zeros). Every prologue name
is a misspelled twin of a created name, so the prologue matches nothing and the
test has no leftover-state cleanup.

This is latent on the default path, where each test gets a fresh
`test_<random>` database. It is live in the stress runner's shared-database mode:
`ci/jobs/scripts/stress/stress.py:158-161` passes `--database=test_{i}` to every
odd thread ("Run some threads with one database for all tests"), and
`tests/clickhouse-test:3755` skips per-test cleanup when `--database` is set, so
tables survive between tests. Leftovers then arise within a single job in three
ways: a mid-test abort; a same-database retry, since `clickhouse-test:4582`
re-runs the test with the same `args.database` (`:2085-2086`) and
`MESSAGES_TO_RETRY` includes `(total) memory limit exceeded`, one of this test's
own attested failure reasons; and the drop injection described below, which skips
the epilogue DROPs on an otherwise successful run. The next run then fails
`TABLE_ALREADY_EXISTS` at `CREATE TABLE t_left_04104`, because the prologue
cleared nothing and the CREATEs have no `IF NOT EXISTS`.

Correcting the three identifiers alone is not enough in that same mode.
`stress.py:222` also passes `ignore_drop_queries_probability=0.2` to every
non-upgrade thread, and `InterpreterDropQuery.cpp:220-228` reports success
without dropping when the roll fires and `storesDataOnDisk` is true, which is
always the case for `MergeTree`. Each prologue `DROP` is therefore skipped with
p=0.2, so all three would clear only 0.8^3 = 0.512 of the time. Pinning
`ignore_drop_queries_probability = 0` on those three statements makes the cleanup
deterministic. The pin is per statement rather than a file-level `SET`, so the
epilogue DROPs keep exercising the injection.

I did not add `IF NOT EXISTS` to the CREATEs: that would run the test against a
stale table instead of clearing it.

Verified with the real harness in shared-database mode, with the injection forced
to 1 so the pin is the only thing that can clear the tables. With a prior run's
tables left behind the test passes; it fails `return code: 57` with the pin
removed, and also with the rename reverted, so neither line is redundant. At the
probability CI actually uses, 30 consecutive runs against the same database
without reseeding pass with both lines, against 27 passes and 3 failures with the
pin removed. The default path is unaffected (50/50 randomized runs pass) and the
`.reference` is unchanged.

I am not claiming this fixes the CI failures previously observed on this test.
Those decompose into unrelated external causes (other PRs' own regressions, a
runner filesystem error, host OOM kills, and server deaths caused by other
tests' queries); none involves this prologue, and this change makes no behavioural
difference on the default per-test-database path where they occurred.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.228` (included in `26.8` and later)
<!-- ch-version-info:end -->