### PR TITLE
Fix AMBIGUOUS_COLUMN_NAME when a JOIN ON condition is repeated in WHERE

### DIFF
--- a/src/Processors/QueryPlan/FilterStep.cpp
+++ b/src/Processors/QueryPlan/FilterStep.cpp
@@ -198,7 +198,7 @@ static ActionsAndName splitSingleAndFilter(ActionsDAG & dag, const ActionsDAG::N
 {
     /// avoid_duplicate_inputs: the split promotes the atom into an input of the remainder DAG, copying its
     /// name verbatim. Duplicate names are legal inside a DAG but break the Block invariant, so a colliding
-    /// input has to be renamed (split() adds an ALIAS so the original name stays resolvable).
+    /// input has to be renamed (`split` adds an ALIAS so the original name stays resolvable).
     auto split_result = dag.split({filter_node}, true, true);
     dag = std::move(split_result.second);
 

--- a/src/Processors/QueryPlan/FilterStep.cpp
+++ b/src/Processors/QueryPlan/FilterStep.cpp
@@ -196,7 +196,10 @@ struct ActionsAndName
 
 static ActionsAndName splitSingleAndFilter(ActionsDAG & dag, const ActionsDAG::Node * filter_node)
 {
-    auto split_result = dag.split({filter_node}, true);
+    /// avoid_duplicate_inputs: the split promotes the atom into an input of the remainder DAG, copying its
+    /// name verbatim. Duplicate names are legal inside a DAG but break the Block invariant, so a colliding
+    /// input has to be renamed (split() adds an ALIAS so the original name stays resolvable).
+    auto split_result = dag.split({filter_node}, true, true);
     dag = std::move(split_result.second);
 
     const auto * split_filter_node = split_result.split_nodes_mapping[filter_node];

--- a/src/Processors/QueryPlan/FilterStep.cpp
+++ b/src/Processors/QueryPlan/FilterStep.cpp
@@ -197,8 +197,8 @@ struct ActionsAndName
 static ActionsAndName splitSingleAndFilter(ActionsDAG & dag, const ActionsDAG::Node * filter_node)
 {
     /// avoid_duplicate_inputs: the split promotes the atom into an input of the remainder DAG, copying its
-    /// name verbatim. Duplicate names are legal inside a DAG but break the Block invariant, so a colliding
-    /// input has to be renamed (`split` adds an ALIAS so the original name stays resolvable).
+    /// name verbatim. Duplicate names are legal inside a DAG but break the `Block` invariant, so a colliding
+    /// input has to be renamed (`split` adds an `ALIAS` so the original name stays resolvable).
     auto split_result = dag.split({filter_node}, true, true);
     dag = std::move(split_result.second);
 

--- a/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.reference
+++ b/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.reference
@@ -2,6 +2,8 @@ left join, right-side ON condition repeated in WHERE
 1	100
 the colliding AND atom is renamed
 1
+the AND chain is split at runtime
+1
 right join, left-side ON condition repeated in WHERE
 1	100
 full join

--- a/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.reference
+++ b/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.reference
@@ -1,7 +1,7 @@
 left join, right-side ON condition repeated in WHERE
 1	100
-left join, legacy join step
-1	100
+the colliding AND atom is renamed
+1
 right join, left-side ON condition repeated in WHERE
 1	100
 full join
@@ -9,6 +9,11 @@ full join
 inner join
 1	100
 left join, non-Bool repeated condition
+1	100
+left join, ARRAY JOIN above the join
+1	100	1
+1	100	2
+left join, ORDER BY an expression above the join
 1	100
 left join, String repeated condition
 1	100

--- a/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.reference
+++ b/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.reference
@@ -1,0 +1,22 @@
+left join, right-side ON condition repeated in WHERE
+1	100
+left join, legacy join step
+1	100
+right join, left-side ON condition repeated in WHERE
+1	100
+full join
+1	100
+inner join
+1	100
+left join, non-Bool repeated condition
+1	100
+left join, String repeated condition
+1	100
+left join, LowCardinality repeated condition
+1	100
+left join, LowCardinality(Nullable) repeated condition
+1	100
+left join, already Nullable repeated condition
+1	100
+left join over ReplacingMergeTree with FINAL, prewhere disabled
+1	100

--- a/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.reference
+++ b/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.reference
@@ -21,9 +21,11 @@ left join, String repeated condition
 1	100
 left join, LowCardinality repeated condition
 1	100
-left join, LowCardinality(Nullable) repeated condition
+left join, plain UInt8 repeated condition
 1	100
-left join, already Nullable repeated condition
+left join, already Nullable repeated condition (non-regression)
+1	100
+left join, LowCardinality(Nullable) repeated condition (no promotion, non-regression)
 1	100
 left join over ReplacingMergeTree with FINAL, prewhere disabled
 1	100

--- a/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.sql
+++ b/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.sql
@@ -8,6 +8,7 @@ DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;
 DROP TABLE IF EXISTS t2_string;
 DROP TABLE IF EXISTS t2_lc;
+DROP TABLE IF EXISTS t2_uint8;
 DROP TABLE IF EXISTS t2_lc_nullable;
 DROP TABLE IF EXISTS t2_nullable;
 DROP TABLE IF EXISTS mt1;
@@ -25,7 +26,7 @@ WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
 ORDER BY t1.id
 SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
--- The AND-chain split has to rename the colliding boundary input. Assert the rename is in the
+-- The `AND`-chain split has to rename the colliding boundary input. Assert the rename is in the
 -- plan: a plan shape that never reaches the split would make every case below pass vacuously.
 -- The extra settings are pinned (all randomized in CI) because the assertion needs both colliding
 -- atoms to stay on one shared filter step below the join.
@@ -123,23 +124,39 @@ WHERE t1.grp = 10 AND t2_lc.reviewer = 100 AND t2_lc.tag = 'x'
 ORDER BY t1.id
 SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
-CREATE TABLE t2_lc_nullable (id Int64, reviewer Int64, tag LowCardinality(Nullable(String))) ENGINE = Memory;
-INSERT INTO t2_lc_nullable VALUES (1, 100, 'x'), (2, 200, NULL);
+-- `Bool` is a `UInt8` domain (a display name over `UInt8`), so it does not cover a plain `UInt8`
+-- column: the colliding name carries the type spelling (`1_Bool` vs `1_UInt8`). Pin both.
+CREATE TABLE t2_uint8 (id Int64, reviewer Int64, flag UInt8) ENGINE = Memory;
+INSERT INTO t2_uint8 VALUES (1, 100, 1), (2, 200, 0);
 
-SELECT 'left join, LowCardinality(Nullable) repeated condition';
-SELECT t1.id, t2_lc_nullable.reviewer
-FROM t1 LEFT JOIN t2_lc_nullable ON t1.id = t2_lc_nullable.id AND t2_lc_nullable.tag = 'x'
-WHERE t1.grp = 10 AND t2_lc_nullable.reviewer = 100 AND t2_lc_nullable.tag = 'x'
+SELECT 'left join, plain UInt8 repeated condition';
+SELECT t1.id, t2_uint8.reviewer
+FROM t1 LEFT JOIN t2_uint8 ON t1.id = t2_uint8.id AND t2_uint8.flag = 1
+WHERE t1.grp = 10 AND t2_uint8.reviewer = 100 AND t2_uint8.flag = 1
 ORDER BY t1.id
 SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
 CREATE TABLE t2_nullable (id Int64, reviewer Int64, enabled Nullable(Bool)) ENGINE = Memory;
 INSERT INTO t2_nullable VALUES (1, 100, true), (2, 200, false), (3, 300, NULL);
 
-SELECT 'left join, already Nullable repeated condition';
+SELECT 'left join, already Nullable repeated condition (non-regression)';
 SELECT t1.id, t2_nullable.reviewer
 FROM t1 LEFT JOIN t2_nullable ON t1.id = t2_nullable.id AND t2_nullable.enabled = true
 WHERE t1.grp = 10 AND t2_nullable.reviewer = 100 AND t2_nullable.enabled = true
+ORDER BY t1.id
+SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
+
+-- Also non-regression, for the same reason as the case above: `makeNullableOrLowCardinalityNullable`
+-- early-returns on `isLowCardinalityNullable`, so promoting this column is a no-op and the `ON` and
+-- `WHERE` copies of the predicate are computed on the identical type. Kept as the negative half of
+-- the LowCardinality wrapper matrix.
+CREATE TABLE t2_lc_nullable (id Int64, reviewer Int64, tag LowCardinality(Nullable(String))) ENGINE = Memory;
+INSERT INTO t2_lc_nullable VALUES (1, 100, 'x'), (2, 200, NULL);
+
+SELECT 'left join, LowCardinality(Nullable) repeated condition (no promotion, non-regression)';
+SELECT t1.id, t2_lc_nullable.reviewer
+FROM t1 LEFT JOIN t2_lc_nullable ON t1.id = t2_lc_nullable.id AND t2_lc_nullable.tag = 'x'
+WHERE t1.grp = 10 AND t2_lc_nullable.reviewer = 100 AND t2_lc_nullable.tag = 'x'
 ORDER BY t1.id
 SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
@@ -162,6 +179,7 @@ DROP TABLE t1;
 DROP TABLE t2;
 DROP TABLE t2_string;
 DROP TABLE t2_lc;
+DROP TABLE t2_uint8;
 DROP TABLE t2_lc_nullable;
 DROP TABLE t2_nullable;
 DROP TABLE mt1;

--- a/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.sql
+++ b/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.sql
@@ -1,5 +1,5 @@
 -- The plan assertions below match analyzer-generated column identifiers (`__table2.`) in the legacy
--- EXPLAIN output, so both are pinned for the whole file. The old analyzer does not build the plan
+-- `EXPLAIN` output, so both are pinned for the whole file. The old analyzer does not build the plan
 -- shape that triggers this bug, so nothing is lost by pinning.
 SET enable_analyzer = 1;
 SET explain_query_plan_default = 'legacy';
@@ -41,12 +41,13 @@ SELECT count() > 0 FROM (
              query_plan_optimize_prewhere = 0
 ) WHERE position(explain, 'AND column: equals(__table2.enabled, 1_Bool)_0') > 0;
 
--- The rename above is printed by FilterStep::describeActions, which splits a clone of the DAG and
--- never builds a pipeline. Assert the AND chain is also split on the real execution path: the
--- resulting FilterTransform multiplicity is >= 2 only when the split happens at runtime.
--- max_threads is pinned so the multiplicity counts split atoms, not parallel streams.
+-- The rename above is printed by `FilterStep::describeActions`, which splits a clone of the DAG and
+-- never builds a pipeline. Assert the `AND` chain is also split on the real execution path. One
+-- `FilterTransform` is emitted per extracted atom plus one for the remainder, so a multiplicity of 3
+-- means two atoms were extracted: the collision this fixes needs that second, iterated split.
+-- `max_threads` is pinned so the multiplicity counts split atoms, not parallel streams.
 SELECT 'the AND chain is split at runtime';
-SELECT max(toUInt32OrZero(extract(explain, 'FilterTransform[^0-9]+([0-9]+)'))) >= 2 FROM (
+SELECT max(toUInt32OrZero(extract(explain, 'FilterTransform[^0-9]+([0-9]+)'))) >= 3 FROM (
     EXPLAIN PIPELINE
     SELECT t1.id, t2.reviewer
     FROM t1 LEFT JOIN t2 ON t1.id = t2.id AND t2.enabled = true
@@ -85,8 +86,8 @@ WHERE t1.grp = 10 AND t2.enabled = true AND t2.reviewer = 100
 ORDER BY t1.id
 SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
--- The remainder DAG produced by the split is split again by the ARRAY JOIN and sorting lift
--- passes, through ActionsDAG::splitActionsBeforeArrayJoin and splitActionsBySortingDescription.
+-- Two further affected shapes: with an `ARRAY JOIN` above the join, and with `ORDER BY` on an
+-- expression. Both throw the same 352 on master and return the correct result with the fix.
 SELECT 'left join, ARRAY JOIN above the join';
 SELECT t1.id, t2.reviewer, x
 FROM t1 LEFT JOIN t2 ON t1.id = t2.id AND t2.enabled = true

--- a/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.sql
+++ b/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.sql
@@ -1,0 +1,119 @@
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t2_nullable;
+DROP TABLE IF EXISTS mt1;
+DROP TABLE IF EXISTS mt2;
+
+CREATE TABLE t1 (id Int64, grp Int64) ENGINE = Memory;
+CREATE TABLE t2 (id Int64, reviewer Int64, enabled Bool) ENGINE = Memory;
+INSERT INTO t1 VALUES (1, 10), (2, 20);
+INSERT INTO t2 VALUES (1, 100, true), (2, 200, false);
+
+SELECT 'left join, right-side ON condition repeated in WHERE';
+SELECT t1.id, t2.reviewer
+FROM t1 LEFT JOIN t2 ON t1.id = t2.id AND t2.enabled = true
+WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
+ORDER BY t1.id
+SETTINGS join_use_nulls = 1;
+
+SELECT 'left join, legacy join step';
+SELECT t1.id, t2.reviewer
+FROM t1 LEFT JOIN t2 ON t1.id = t2.id AND t2.enabled = true
+WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
+ORDER BY t1.id
+SETTINGS join_use_nulls = 1, query_plan_use_logical_join_step = 0;
+
+SELECT 'right join, left-side ON condition repeated in WHERE';
+SELECT t1.id, t2.reviewer
+FROM t2 RIGHT JOIN t1 ON t1.id = t2.id AND t1.grp = 10
+WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
+ORDER BY t1.id
+SETTINGS join_use_nulls = 1;
+
+SELECT 'full join';
+SELECT t1.id, t2.reviewer
+FROM t1 FULL JOIN t2 ON t1.id = t2.id AND t2.enabled = true
+WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
+ORDER BY t1.id
+SETTINGS join_use_nulls = 1;
+
+SELECT 'inner join';
+SELECT t1.id, t2.reviewer
+FROM t1 INNER JOIN t2 ON t1.id = t2.id AND t2.enabled = true
+WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
+ORDER BY t1.id
+SETTINGS join_use_nulls = 1;
+
+SELECT 'left join, non-Bool repeated condition';
+SELECT t1.id, t2.reviewer
+FROM t1 LEFT JOIN t2 ON t1.id = t2.id AND t2.reviewer = 100
+WHERE t1.grp = 10 AND t2.enabled = true AND t2.reviewer = 100
+ORDER BY t1.id
+SETTINGS join_use_nulls = 1;
+
+DROP TABLE IF EXISTS t2_string;
+DROP TABLE IF EXISTS t2_lc;
+DROP TABLE IF EXISTS t2_lc_nullable;
+
+CREATE TABLE t2_string (id Int64, reviewer Int64, tag String) ENGINE = Memory;
+INSERT INTO t2_string VALUES (1, 100, 'x'), (2, 200, 'y');
+
+SELECT 'left join, String repeated condition';
+SELECT t1.id, t2_string.reviewer
+FROM t1 LEFT JOIN t2_string ON t1.id = t2_string.id AND t2_string.tag = 'x'
+WHERE t1.grp = 10 AND t2_string.reviewer = 100 AND t2_string.tag = 'x'
+ORDER BY t1.id
+SETTINGS join_use_nulls = 1;
+
+CREATE TABLE t2_lc (id Int64, reviewer Int64, tag LowCardinality(String)) ENGINE = Memory;
+INSERT INTO t2_lc VALUES (1, 100, 'x'), (2, 200, 'y');
+
+SELECT 'left join, LowCardinality repeated condition';
+SELECT t1.id, t2_lc.reviewer
+FROM t1 LEFT JOIN t2_lc ON t1.id = t2_lc.id AND t2_lc.tag = 'x'
+WHERE t1.grp = 10 AND t2_lc.reviewer = 100 AND t2_lc.tag = 'x'
+ORDER BY t1.id
+SETTINGS join_use_nulls = 1;
+
+CREATE TABLE t2_lc_nullable (id Int64, reviewer Int64, tag LowCardinality(Nullable(String))) ENGINE = Memory;
+INSERT INTO t2_lc_nullable VALUES (1, 100, 'x'), (2, 200, NULL);
+
+SELECT 'left join, LowCardinality(Nullable) repeated condition';
+SELECT t1.id, t2_lc_nullable.reviewer
+FROM t1 LEFT JOIN t2_lc_nullable ON t1.id = t2_lc_nullable.id AND t2_lc_nullable.tag = 'x'
+WHERE t1.grp = 10 AND t2_lc_nullable.reviewer = 100 AND t2_lc_nullable.tag = 'x'
+ORDER BY t1.id
+SETTINGS join_use_nulls = 1;
+
+CREATE TABLE t2_nullable (id Int64, reviewer Int64, enabled Nullable(Bool)) ENGINE = Memory;
+INSERT INTO t2_nullable VALUES (1, 100, true), (2, 200, false), (3, 300, NULL);
+
+SELECT 'left join, already Nullable repeated condition';
+SELECT t1.id, t2_nullable.reviewer
+FROM t1 LEFT JOIN t2_nullable ON t1.id = t2_nullable.id AND t2_nullable.enabled = true
+WHERE t1.grp = 10 AND t2_nullable.reviewer = 100 AND t2_nullable.enabled = true
+ORDER BY t1.id
+SETTINGS join_use_nulls = 1;
+
+CREATE TABLE mt1 (id Int64, grp Int64) ENGINE = ReplacingMergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, ratio_of_defaults_for_sparse_serialization = 1.0;
+CREATE TABLE mt2 (id Int64, reviewer Int64, enabled Bool) ENGINE = ReplacingMergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, ratio_of_defaults_for_sparse_serialization = 1.0;
+INSERT INTO mt1 VALUES (1, 10), (2, 20);
+INSERT INTO mt2 VALUES (1, 100, true), (2, 200, false);
+
+SELECT 'left join over ReplacingMergeTree with FINAL, prewhere disabled';
+SELECT mt1.id, mt2.reviewer
+FROM mt1 LEFT JOIN mt2 ON mt1.id = mt2.id AND mt2.enabled = true
+WHERE mt1.grp = 10 AND mt2.reviewer = 100 AND mt2.enabled = true
+ORDER BY mt1.id
+SETTINGS join_use_nulls = 1, final = 1, optimize_move_to_prewhere = 0, query_plan_optimize_prewhere = 0;
+
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t2_string;
+DROP TABLE t2_lc;
+DROP TABLE t2_lc_nullable;
+DROP TABLE t2_nullable;
+DROP TABLE mt1;
+DROP TABLE mt2;

--- a/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.sql
+++ b/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.sql
@@ -149,7 +149,7 @@ SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_ou
 -- Also non-regression, for the same reason as the case above: `makeNullableOrLowCardinalityNullable`
 -- early-returns on `isLowCardinalityNullable`, so promoting this column is a no-op and the `ON` and
 -- `WHERE` copies of the predicate are computed on the identical type. Kept as the negative half of
--- the LowCardinality wrapper matrix.
+-- the `LowCardinality` wrapper matrix.
 CREATE TABLE t2_lc_nullable (id Int64, reviewer Int64, tag LowCardinality(Nullable(String))) ENGINE = Memory;
 INSERT INTO t2_lc_nullable VALUES (1, 100, 'x'), (2, 200, NULL);
 

--- a/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.sql
+++ b/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.sql
@@ -1,3 +1,9 @@
+-- The plan assertions below match analyzer-generated column identifiers (`__table2.`) in the legacy
+-- EXPLAIN output, so both are pinned for the whole file. The old analyzer does not build the plan
+-- shape that triggers this bug, so nothing is lost by pinning.
+SET enable_analyzer = 1;
+SET explain_query_plan_default = 'legacy';
+
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;
 DROP TABLE IF EXISTS t2_string;
@@ -21,14 +27,35 @@ SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_ou
 
 -- The AND-chain split has to rename the colliding boundary input. Assert the rename is in the
 -- plan: a plan shape that never reaches the split would make every case below pass vacuously.
+-- The extra settings are pinned (all randomized in CI) because the assertion needs both colliding
+-- atoms to stay on one shared filter step below the join.
 SELECT 'the colliding AND atom is renamed';
 SELECT count() > 0 FROM (
     EXPLAIN actions = 1, pretty = 0
     SELECT t1.id, t2.reviewer
     FROM t1 LEFT JOIN t2 ON t1.id = t2.id AND t2.enabled = true
     WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
-    SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1
+    SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1,
+             query_plan_remove_unused_columns = 1, query_plan_merge_filter_into_join_condition = 0,
+             query_plan_optimize_join_order_randomize = 0, optimize_move_to_prewhere = 0,
+             query_plan_optimize_prewhere = 0
 ) WHERE position(explain, 'AND column: equals(__table2.enabled, 1_Bool)_0') > 0;
+
+-- The rename above is printed by FilterStep::describeActions, which splits a clone of the DAG and
+-- never builds a pipeline. Assert the AND chain is also split on the real execution path: the
+-- resulting FilterTransform multiplicity is >= 2 only when the split happens at runtime.
+-- max_threads is pinned so the multiplicity counts split atoms, not parallel streams.
+SELECT 'the AND chain is split at runtime';
+SELECT max(toUInt32OrZero(extract(explain, 'FilterTransform[^0-9]+([0-9]+)'))) >= 2 FROM (
+    EXPLAIN PIPELINE
+    SELECT t1.id, t2.reviewer
+    FROM t1 LEFT JOIN t2 ON t1.id = t2.id AND t2.enabled = true
+    WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
+    SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1,
+             query_plan_remove_unused_columns = 1, query_plan_merge_filter_into_join_condition = 0,
+             query_plan_optimize_join_order_randomize = 0, optimize_move_to_prewhere = 0,
+             query_plan_optimize_prewhere = 0, max_threads = 1
+);
 
 SELECT 'right join, left-side ON condition repeated in WHERE';
 SELECT t1.id, t2.reviewer

--- a/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.sql
+++ b/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.sql
@@ -1,5 +1,8 @@
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t2_string;
+DROP TABLE IF EXISTS t2_lc;
+DROP TABLE IF EXISTS t2_lc_nullable;
 DROP TABLE IF EXISTS t2_nullable;
 DROP TABLE IF EXISTS mt1;
 DROP TABLE IF EXISTS mt2;
@@ -14,46 +17,63 @@ SELECT t1.id, t2.reviewer
 FROM t1 LEFT JOIN t2 ON t1.id = t2.id AND t2.enabled = true
 WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
 ORDER BY t1.id
-SETTINGS join_use_nulls = 1;
+SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
-SELECT 'left join, legacy join step';
-SELECT t1.id, t2.reviewer
-FROM t1 LEFT JOIN t2 ON t1.id = t2.id AND t2.enabled = true
-WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
-ORDER BY t1.id
-SETTINGS join_use_nulls = 1, query_plan_use_logical_join_step = 0;
+-- The AND-chain split has to rename the colliding boundary input. Assert the rename is in the
+-- plan: a plan shape that never reaches the split would make every case below pass vacuously.
+SELECT 'the colliding AND atom is renamed';
+SELECT count() > 0 FROM (
+    EXPLAIN actions = 1, pretty = 0
+    SELECT t1.id, t2.reviewer
+    FROM t1 LEFT JOIN t2 ON t1.id = t2.id AND t2.enabled = true
+    WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
+    SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1
+) WHERE position(explain, 'AND column: equals(__table2.enabled, 1_Bool)_0') > 0;
 
 SELECT 'right join, left-side ON condition repeated in WHERE';
 SELECT t1.id, t2.reviewer
 FROM t2 RIGHT JOIN t1 ON t1.id = t2.id AND t1.grp = 10
 WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
 ORDER BY t1.id
-SETTINGS join_use_nulls = 1;
+SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
 SELECT 'full join';
 SELECT t1.id, t2.reviewer
 FROM t1 FULL JOIN t2 ON t1.id = t2.id AND t2.enabled = true
 WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
 ORDER BY t1.id
-SETTINGS join_use_nulls = 1;
+SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
 SELECT 'inner join';
 SELECT t1.id, t2.reviewer
 FROM t1 INNER JOIN t2 ON t1.id = t2.id AND t2.enabled = true
 WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
 ORDER BY t1.id
-SETTINGS join_use_nulls = 1;
+SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
 SELECT 'left join, non-Bool repeated condition';
 SELECT t1.id, t2.reviewer
 FROM t1 LEFT JOIN t2 ON t1.id = t2.id AND t2.reviewer = 100
 WHERE t1.grp = 10 AND t2.enabled = true AND t2.reviewer = 100
 ORDER BY t1.id
-SETTINGS join_use_nulls = 1;
+SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
-DROP TABLE IF EXISTS t2_string;
-DROP TABLE IF EXISTS t2_lc;
-DROP TABLE IF EXISTS t2_lc_nullable;
+-- The remainder DAG produced by the split is split again by the ARRAY JOIN and sorting lift
+-- passes, through ActionsDAG::splitActionsBeforeArrayJoin and splitActionsBySortingDescription.
+SELECT 'left join, ARRAY JOIN above the join';
+SELECT t1.id, t2.reviewer, x
+FROM t1 LEFT JOIN t2 ON t1.id = t2.id AND t2.enabled = true
+ARRAY JOIN [1, 2] AS x
+WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
+ORDER BY t1.id, x
+SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
+
+SELECT 'left join, ORDER BY an expression above the join';
+SELECT t1.id, t2.reviewer
+FROM t1 LEFT JOIN t2 ON t1.id = t2.id AND t2.enabled = true
+WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
+ORDER BY t2.reviewer + 1
+SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
 CREATE TABLE t2_string (id Int64, reviewer Int64, tag String) ENGINE = Memory;
 INSERT INTO t2_string VALUES (1, 100, 'x'), (2, 200, 'y');
@@ -63,7 +83,7 @@ SELECT t1.id, t2_string.reviewer
 FROM t1 LEFT JOIN t2_string ON t1.id = t2_string.id AND t2_string.tag = 'x'
 WHERE t1.grp = 10 AND t2_string.reviewer = 100 AND t2_string.tag = 'x'
 ORDER BY t1.id
-SETTINGS join_use_nulls = 1;
+SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
 CREATE TABLE t2_lc (id Int64, reviewer Int64, tag LowCardinality(String)) ENGINE = Memory;
 INSERT INTO t2_lc VALUES (1, 100, 'x'), (2, 200, 'y');
@@ -73,7 +93,7 @@ SELECT t1.id, t2_lc.reviewer
 FROM t1 LEFT JOIN t2_lc ON t1.id = t2_lc.id AND t2_lc.tag = 'x'
 WHERE t1.grp = 10 AND t2_lc.reviewer = 100 AND t2_lc.tag = 'x'
 ORDER BY t1.id
-SETTINGS join_use_nulls = 1;
+SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
 CREATE TABLE t2_lc_nullable (id Int64, reviewer Int64, tag LowCardinality(Nullable(String))) ENGINE = Memory;
 INSERT INTO t2_lc_nullable VALUES (1, 100, 'x'), (2, 200, NULL);
@@ -83,7 +103,7 @@ SELECT t1.id, t2_lc_nullable.reviewer
 FROM t1 LEFT JOIN t2_lc_nullable ON t1.id = t2_lc_nullable.id AND t2_lc_nullable.tag = 'x'
 WHERE t1.grp = 10 AND t2_lc_nullable.reviewer = 100 AND t2_lc_nullable.tag = 'x'
 ORDER BY t1.id
-SETTINGS join_use_nulls = 1;
+SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
 CREATE TABLE t2_nullable (id Int64, reviewer Int64, enabled Nullable(Bool)) ENGINE = Memory;
 INSERT INTO t2_nullable VALUES (1, 100, true), (2, 200, false), (3, 300, NULL);
@@ -93,7 +113,7 @@ SELECT t1.id, t2_nullable.reviewer
 FROM t1 LEFT JOIN t2_nullable ON t1.id = t2_nullable.id AND t2_nullable.enabled = true
 WHERE t1.grp = 10 AND t2_nullable.reviewer = 100 AND t2_nullable.enabled = true
 ORDER BY t1.id
-SETTINGS join_use_nulls = 1;
+SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
 CREATE TABLE mt1 (id Int64, grp Int64) ENGINE = ReplacingMergeTree ORDER BY id
 SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, ratio_of_defaults_for_sparse_serialization = 1.0;
@@ -107,7 +127,8 @@ SELECT mt1.id, mt2.reviewer
 FROM mt1 LEFT JOIN mt2 ON mt1.id = mt2.id AND mt2.enabled = true
 WHERE mt1.grp = 10 AND mt2.reviewer = 100 AND mt2.enabled = true
 ORDER BY mt1.id
-SETTINGS join_use_nulls = 1, final = 1, optimize_move_to_prewhere = 0, query_plan_optimize_prewhere = 0;
+SETTINGS join_use_nulls = 1, final = 1, optimize_move_to_prewhere = 0, query_plan_optimize_prewhere = 0,
+         query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1;
 
 DROP TABLE t1;
 DROP TABLE t2;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/111955
Related: https://github.com/ClickHouse/ClickHouse/pull/111930

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes `AMBIGUOUS_COLUMN_NAME` (`Block structure mismatch in (columns with identical name must have identical structure)`) for a query that repeats a `JOIN ON` condition in `WHERE` with `join_use_nulls = 1`. Such a query now returns its result instead of failing.

### Description

`FilterStep::transformPipeline` splits an `AND` chain into one `FilterTransform` per atom via
`ActionsDAG::split`. The split promotes each split-out atom into an `INPUT` of the remainder DAG,
copying `result_name` verbatim. Duplicate names are legal inside an `ActionsDAG` but break the
`Block` invariant, so the remainder's `updateHeader` throws in `Block::insert`.

Filter push-down placed both copies of the repeated condition into one filter step: the `ON` copy
computed on the plain column and the `WHERE` copy on the `join_use_nulls`-promoted `Nullable`
column, both carrying the same name. Splitting that filter's `AND` chain then made them two
same-named columns of different types in one block.

`ActionsDAG::split` already owns the guard for this: `avoid_duplicate_inputs` renames the colliding
input and inserts a compensating `ALIAS`. `FilterStep` was the only one of its four external callers
that did not pass it (`optimizePrewhere` and `optimizeLazyMaterialization` both do). This passes it
there too.

The two optimizer passes that create the shape (outer-to-inner join conversion and filter push-down)
produce a semantically correct plan: `query_plan_convert_outer_join_to_inner_join = 0`,
`query_plan_merge_filters = 0` and `join_use_nulls = 0` all return the same result the fixed build
returns, so the defect is in the split consumer, not in those passes.

The affected set is wider than the report: the collision does not need `final = 1`, `MergeTree`, or a
`Bool` column. Measured throwing on master: `Bool`, plain `UInt8`, `Int64`, `String` and
`LowCardinality(String)` repeated predicates, over `Memory` as well as `MergeTree`. Measured NOT
throwing, because `join_use_nulls` promotion is a no-op once the type is already nullable
(`makeNullableOrLowCardinalityNullable` returns early on `isNullableOrLowCardinalityNullable`, so both
copies of the predicate are computed on the identical type): `Nullable` and
`LowCardinality(Nullable(String))`. The fix keys on the name collision itself, so it covers every
throwing shape, and the test pins both halves of that matrix. The report notes that #104017 made the
logical join step unconditional and thereby widened exposure; the defect itself is not confined to that
step. It does require the analyzer: with `enable_analyzer = 0` master builds a plan that never reaches
this split and returns the correct result, so the test pins `enable_analyzer = 1`.

`ActionsDAG` also splits internally in `splitActionsBeforeArrayJoin`, `splitActionsBySortingDescription`
and `splitActionsForFilter`, none of which pass the flag on master. `splitActionsForFilter` has the same
class of defect on a different trigger (a promoted node whose name equals an existing input name) and is
fixed separately in #111930; that change and this one are file-disjoint. For the other two I could not
construct a colliding shape: they split in one pass, on nodes that do not depend on ARRAY JOIN or on
outputs resolved by distinct `SortDescription` names, so no promoted boundary node takes a name that is
already an input.

The test also covers the `ARRAY JOIN` and `ORDER BY <expression>` shapes, which are further affected
forms of the same collision: both throw on master and return the correct result with the fix. Besides
the thirteen result queries it pins the plan shape two ways so the coverage cannot silently go vacuous.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.2.26`, `26.6.2.151`, `26.5.6.82`, `26.3.17.87`
<!-- ch-version-info:end -->