### PR TITLE
Wait for the FileLog watcher in 02025_storage_filelog_virtual_col

### DIFF
--- a/tests/queries/0_stateless/02025_storage_filelog_virtual_col.sh
+++ b/tests/queries/0_stateless/02025_storage_filelog_virtual_col.sh
@@ -48,8 +48,20 @@ ${CLICKHOUSE_CLIENT} --query "select *, _filename, _offset from file_log order b
 
 truncate ${USER_FILES_PATH}/${CLICKHOUSE_TEST_UNIQUE_NAME}/a.txt --size 0
 
-# exception will happen when a file unexpectedly changed the size to zero without changing the inode
-${CLICKHOUSE_CLIENT} --query "select * from file_log order by k settings stream_like_engine_allow_direct_select=1;" 2>&1 | grep -q "CANNOT_READ_ALL_DATA" && echo 'OK' || echo 'FAIL'
+# An exception is expected: the file shrank to zero without its inode changing.
+# The directory watcher reports that change asynchronously, so retry until the
+# server has observed it.
+deadline=$((EPOCHSECONDS + 60))
+result=FAIL
+while ((EPOCHSECONDS < deadline))
+do
+	if ${CLICKHOUSE_CLIENT} --query "select * from file_log order by k settings stream_like_engine_allow_direct_select=1;" 2>&1 | grep -q "CANNOT_READ_ALL_DATA"; then
+		result=OK
+		break
+	fi
+	sleep 1
+done
+echo "$result"
 
 ${CLICKHOUSE_CLIENT} --query "drop table file_log;"
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/84430

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`02025_storage_filelog_virtual_col` asserts that a `FileLog` `SELECT` raises
`CANNOT_READ_ALL_DATA` after `truncate --size 0` shrinks a file without changing its
inode. That assertion requires the server to have already observed the truncation, and
the test provides no synchronization point, so it is a race:

- the preceding `SELECT` drives `a.txt` to `FileStatus::NO_CHANGE`
  (`FileLogConsumer.cpp:135-138`);
- the only exit from `NO_CHANGE` is `updateFileInfos` handling a `DW_ITEM_MODIFIED`
  event (`StorageFileLog.cpp:1113-1122`), which the `SELECT` drains once via `makePipe`
  (`:122`) before `openFilesAndSetPos` (`:139`);
- if the watcher has not queued that event yet, the gate at `StorageFileLog.cpp:503`
  skips the file, the throw at `:519` never happens, the `SELECT` returns 0 rows
  successfully, and the test prints `FAIL`.

Observed only on `Fast test (arm_darwin)`: 2 hits in 90 days against 4896 `OK` on the
same check (0.041 %), 0 on master. macOS has no inotify, so `DirectoryWatcherBase`
reconstructs the event stream by diffing a directory snapshot
(`DirectoryWatcherBase.cpp:164-579`), which has much higher latency than the Linux
`IN_MODIFY` path — hence the platform skew.

The event is not lost, it is merely late. `02023_storage_filelog.sh` ends with a
byte-identical sequence (detach, attach, `SELECT`, `truncate --size 0`, assert the same
error); the only difference is its `sleep 2` at line 70, and on the same check over the
same window it is 4896 `OK` / 0 `FAIL` while this test is 4896 / 2. Waiting fixes it.

This replaces the single unguarded assertion with a bounded 60 s retry of the identical
query. The bound is derived from `poll_directory_watch_events_backoff_max`, whose default
is 32 s (`FileLogSettings.cpp:26`): 60 s is a little under twice the worst-case idle
wake-up interval, so a healthy server always converges well inside it. The asserted
error string, the emitted `OK`/`FAIL` tokens and the `.reference` are unchanged; only
the waiting is added. A bounded poll is used rather than copying
`02023`'s `sleep 2` because the poll converges on the first iteration for every passing
run (measured: 3.74 s before, 3.79 s after, within noise) instead of taxing all ~4896 of
them, and it still prints `FAIL` if the error never arrives, so a genuine regression
still fails the test. Same shape as the existing waits in
`02024_storage_filelog_mv.sh:34-48` and `04031_filelog_drop_mv_no_exception.sh:57-70`.

Verified with local instrumentation that delays delivery of an already-queued inotify
event by 5 s, emulating the macOS watcher's latency (the instrumentation is local only
and is not part of this PR; the source tree is byte-identical to master, confirmed by
the binary's Build ID returning to its pre-instrumentation value):

- unmodified test on the instrumented build: 10/10 `FAIL`, each diff being exactly the
  `-OK` / `+FAIL` tail seen in CI;
- this PR's test on the instrumented build: 50/50 `OK`;
- reducing the loop to a single attempt reproduces `FAIL` 3/3, so the retry is
  load-bearing rather than decorative;
- `--test-runs 50` with randomized settings on an uninstrumented debug build: 50/50;
- `02023_storage_filelog` and `02022_storage_filelog_one_file` 20x each: 40/40.

macOS cannot be built or run on the machine used for this work, so the failing platform
itself is exercised only by CI's `Fast test (arm_darwin)`; the instrumented Linux build
above is the local proxy for its watcher latency.

Investigating this also surfaced that the directory watch is installed inside the
background task (`DirectoryWatcherBase.cpp:86`, and the Darwin baseline seeding at
`:305-333`), which `start()` only schedules asynchronously, so `CREATE`/`ATTACH` returns
before the directory is watched. I have no evidence that window ever bites — the
comparison with `02023` above says these CI failures are latency, not loss — so I am not
changing product code for it here; it is tracked separately for investigation.

CI report for one of the two failures:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106961&sha=06909d1fb78cea463ffbab7774d740545064186e&name_0=PR&name_1=Fast%20test%20%28arm_darwin%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.226` (included in `26.8` and later)
<!-- ch-version-info:end -->