### PR TITLE
Fix flaky 03203_system_query_metric_log amount-of-events upper bound

### DIFF
--- a/tests/queries/0_stateless/03203_system_query_metric_log.sh
+++ b/tests/queries/0_stateless/03203_system_query_metric_log.sh
@@ -25,20 +25,36 @@ function check_log()
     interval=$1
 
     # Check that the amount of events collected is correct.
-    # The upper bound catches runaway over-collection with a generous 80% margin.
+    # The upper bound catches runaway over-collection. It must be derived from the
+    # OBSERVED duration, not from the nominal sleep: rows are produced on wall-clock
+    # time for as long as the query is alive, and `QueryMetricLogStatus::scheduleNext`
+    # skips lost runs instead of catching up, so at most one periodic row exists per
+    # interval. `+2` covers the extra sample of the half-open sampling grid plus the
+    # always-emitted final row. `duration_ms IS NOT NULL` keeps a missing
+    # `QueryFinish` row a failure instead of a vacuously passing bound.
     # The lower bound is only 1: on a heavily oversubscribed runner the
-    # `BackgroundSchedulePool` task that samples the metrics can be starved, and
-    # `QueryMetricLogStatus::scheduleNext` deliberately skips the lost runs instead
-    # of catching up, so few events are collected. The smaller the interval, the
-    # more likely this is, so any lower bound that scales up as the interval shrinks
-    # is exactly backwards for robustness. Requiring at least one row still verifies
-    # that collection happened for a positive interval (the disabled and short-query
-    # cases below assert 0), and the always-emitted final row guarantees it is
-    # attainable regardless of scheduling.
+    # `BackgroundSchedulePool` task that samples the metrics can be starved, so few
+    # events are collected, and this is likelier the smaller the interval is.
+    # Requiring at least one row still verifies that collection happened for a
+    # positive interval (the disabled and short-query cases below assert 0), and the
+    # always-emitted final row guarantees it is attainable regardless of scheduling.
     $CLICKHOUSE_CLIENT -m -q """
         SELECT '--Interval $interval: check that amount of events is correct';
+        WITH
+        (
+            SELECT query_duration_ms
+            FROM system.query_log
+            WHERE event_date >= yesterday()
+              AND event_time >= now() - 600
+              AND current_database = currentDatabase()
+              AND query_id = '${query_prefix}_${interval}'
+              AND type = 'QueryFinish'
+            ORDER BY event_time_microseconds DESC
+            LIMIT 1
+        ) AS duration_ms
         SELECT
-            count() BETWEEN 1 AND ((ceil(2500 / $interval) + 1) * 1.8)
+            duration_ms IS NOT NULL
+            AND count() BETWEEN 1 AND (intDiv(duration_ms, $interval) + 2)
         FROM system.query_metric_log
         WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_id = '${query_prefix}_${interval}'
     """

--- a/tests/queries/0_stateless/03203_system_query_metric_log.sh
+++ b/tests/queries/0_stateless/03203_system_query_metric_log.sh
@@ -25,24 +25,18 @@ function check_log()
     interval=$1
 
     # Check that the amount of events collected is correct.
-    # The upper bound catches runaway over-collection. It must be derived from the
-    # OBSERVED duration, not from the nominal sleep: rows are produced on wall-clock
-    # time for as long as the query is alive, and `QueryMetricLogStatus::scheduleNext`
-    # skips lost runs instead of catching up, so at most one periodic row exists per
-    # interval. `+2` covers the extra sample of the half-open sampling grid plus the
-    # always-emitted final row. `duration_ms IS NOT NULL` keeps a missing
-    # `QueryFinish` row a failure instead of a vacuously passing bound.
-    # The lower bound is only 1: on a heavily oversubscribed runner the
-    # `BackgroundSchedulePool` task that samples the metrics can be starved, so few
-    # events are collected, and this is likelier the smaller the interval is.
-    # Requiring at least one row still verifies that collection happened for a
-    # positive interval (the disabled and short-query cases below assert 0), and the
-    # always-emitted final row guarantees it is attainable regardless of scheduling.
+    # Upper bound: rows are emitted on wall-clock time for as long as the query is
+    # alive, so it is derived from the observed sampling window of the query's own
+    # rows. `+2` covers `dateDiff` millisecond truncation plus the always-emitted
+    # final row; `start_time IS NOT NULL` keeps a missing `QueryFinish` row a failure.
+    # Lower bound is only 1: the sampling task can be starved on an oversubscribed
+    # runner, the more so the smaller the interval, so a bound that grows as the
+    # interval shrinks is backwards. The final row makes 1 always attainable.
     $CLICKHOUSE_CLIENT -m -q """
         SELECT '--Interval $interval: check that amount of events is correct';
         WITH
         (
-            SELECT query_duration_ms
+            SELECT query_start_time_microseconds
             FROM system.query_log
             WHERE event_date >= yesterday()
               AND event_time >= now() - 600
@@ -51,10 +45,11 @@ function check_log()
               AND type = 'QueryFinish'
             ORDER BY event_time_microseconds DESC
             LIMIT 1
-        ) AS duration_ms
+        ) AS start_time
         SELECT
-            duration_ms IS NOT NULL
-            AND count() BETWEEN 1 AND (intDiv(duration_ms, $interval) + 2)
+            start_time IS NOT NULL
+            AND count() BETWEEN 1
+                AND (intDiv(dateDiff('millisecond', start_time, max(event_time_microseconds)), $interval) + 2)
         FROM system.query_metric_log
         WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_id = '${query_prefix}_${interval}'
     """


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110628
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/110628

`03203_system_query_metric_log` intermittently fails on the
`--Interval N: check that amount of events is correct` line. The row-count upper bound is anchored
on the nominal 2500 ms sleep:

```
count() BETWEEN 1 AND ((ceil(2500 / $interval) + 1) * 1.8)
```

but rows are produced on wall-clock time for as long as the query stays alive.
`QueryMetricLogStatus::scheduleNext` re-arms every `interval` ms and skips lost runs instead of
firing catch-up runs, and `finishQuery` emits the always-present final row, so at most one periodic
row exists per interval and the row count grows with the query's lifetime. When a loaded runner
stretches the 2.5 s query, the server emits proportionally more rows and the bound trips even
though collection was perfectly healthy.

The slack also shrinks as the interval shrinks: the `* 1.8` tolerates only 1.95x the nominal
duration at interval 123, but 2.88x at interval 1000. That is the same asymmetry #110628 removed
from the lower bound, still present on the upper bound because that PR only analysed the lower one.
This completes it: I derive the bound from the observed sampling window of the query's own metric
rows, so the assertion is a function of the quantity the invariant actually depends on.

```
start_time IS NOT NULL
AND count() BETWEEN 1
    AND (intDiv(dateDiff('millisecond', start_time, max(event_time_microseconds)), $interval) + 2)
```

where `start_time` is `query_start_time_microseconds` from the query's `QueryFinish` row.

`query_duration_ms` is deliberately not used: it is the `elapsed_microseconds` snapshot taken by
`getInfo` one statement before `logQueryMetricLogFinish`, so a periodic sample can still be
accepted and emit a row after that snapshot but before `finishQuery` sets `finished`. A bound
anchored on it would tolerate only a gap smaller than one interval, which at interval 123 is a
123 ms deschedule on an oversubscribed runner. A bound derived from the rows themselves cannot be
escaped by any such gap, and `+ 2` is enough because consecutive samples are spaced by at least one
interval whichever branch of `scheduleNext` runs: it either advances `info.next_collect_time` by
exactly one interval, or, when the sample is already late, skips the lost runs by resetting it to
`now`, which is itself at least one interval further on. The scheduled time of the K-th sample is
therefore never earlier than `K * interval` after the start, and since the wait is truncated down to
whole milliseconds a row can fire at most 1 ms early. The `+ 2` covers exactly that one millisecond
plus the always-emitted final row.
The `IS NOT NULL` guard keeps a missing `QueryFinish` row a failure instead of a vacuously passing
bound. The lower bound from #110628 is unchanged, as is every other assertion in the file, and the
reference output is untouched.

Over-collection detection is preserved, which is what this bound is for: with the server sampling
at half the declared interval (two rows per interval) the new bound fails at both interval 400 and
interval 123, and inflating only the bound term makes that case pass, so the bound is provably what
rejects it.

Two failures backed by the published job artifacts, both breaches of this upper bound and both
passing under the new one. The published artifacts record the row count but not
`max(event_time_microseconds)`, so the "new bound" column is evaluated at the smallest sampling
window consistent with the observed row count, `(rows - 1) * interval - 1 ms`, which is the
worst case for the new bound; every larger window only widens it:

| run | interval | rows | old bound | new bound at the minimum consistent window |
|---|---|---|---|---|
| PR CI, `Stateless tests (amd_asan_ubsan, distributed plan, parallel)` | 123 | 41 | 39.60 (fail) | 41 (pass) |
| master, `Stateless tests (amd_tsan, parallel)` | 1000 | 8 | 7.20 (fail) | 8 (pass) |

The other four interval/run combinations in those two jobs passed before and still pass (6 of 7.20
and 14 of 14.40 on the first job, 21 of 39.60 and 7 of 14.40 on the second; under the new bound
6 of 6, 14 of 14, 21 of 21 and 7 of 7 at the corresponding minimum windows).

In the first of those the interval-123 inter-row deltas were a clean 122-125 ms, so sampling was
healthy and there was no over-collection, and interval 400 sat at exactly 14 of 14.40, one row from
failing as well.

Reports:
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105667&sha=2edf3bd1cf73c69205a8ebdff6ca85fde7ce0e97&name_0=PR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%29
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=104b5acb841c7fea8a56aa8dcf035f5b780d6cfb&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%29

Verified locally on a debug build by stretching the three checked sleeps to 5 s, which reproduces
the CI diff exactly: the current test fails 10 of 10 runs on that variant, the fixed test passes 30
of 30. Unmodified, the fixed test passes 50 of 50 randomized runs, and both sibling
`query_metric_log` tests pass 50 of 50.

Gap robustness was measured rather than argued, using the existing
`query_metric_log_pause_before_finish` failpoint to hold `finishQuery` after the `getInfo` snapshot
so that late periodic rows accumulate. Across 18 runs at intervals 100 and 123 with gaps of
1.0 to 4.1 s, i.e. 8 to 40 intervals, the `query_duration_ms`-anchored bound failed every time and
the max-row-anchored bound passed every time.

No related open issue: #71244 is closed.