### PR TITLE
[CI Proof] generateManifestOnlySnapshot still seeds refs with a raw Poco::JSON::Object pointer (same bug the PR fixes in generateNextMetadata)

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_metadata_generator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_metadata_generator.cpp
@@ -131,4 +131,26 @@ TEST(IcebergMetadataGenerator, ThrowsWhenSnapshotsArrayMissingButParentSnapshotE
     EXPECT_FALSE(metadata->has(Iceberg::f_snapshots));
 }
 
+/// `refs` is optional per the Iceberg spec (an object, not an array), so external engines may
+/// omit it. generateManifestOnlySnapshot must seed it as an Object::Ptr and populate `main`,
+/// mirroring generateNextMetadata; seeding it with a raw Poco::JSON::Object pointer stores the
+/// wrong Var type, so getObject(f_refs) returns a null Ptr and the following ->has(f_main)
+/// dereferences it (Poco::NullPointerException).
+TEST(IcebergMetadataGenerator, ManifestOnlySnapshotWhenRefsMissing)
+{
+    auto metadata = makeMinimalV2Metadata();
+    appendSnapshot(metadata);
+    Int64 parent_id = metadata->getValue<Int64>(Iceberg::f_current_snapshot_id);
+
+    metadata->remove(Iceberg::f_refs);
+
+    FileNamesGenerator generator("s3://bucket/table", /*use_uuid_in_metadata=*/ false, CompressionMethod::None, "Parquet");
+    generator.setVersion(2);
+    auto metadata_info = generator.generateMetadataPathWithInfo();
+
+    EXPECT_NO_THROW(
+        MetadataGenerator(metadata).generateManifestOnlySnapshot(generator, metadata_info.path, parent_id));
+    EXPECT_TRUE(metadata->getObject(Iceberg::f_refs)->has(Iceberg::f_main));
+}
+
 #endif


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

> ⚠️ **This is a CI proof PR — not a fix and not intended for merge.** It submits a test that could not be confirmed locally (code analysis strongly suggests a bug but local test did not trigger it — CI sanitizers and stress runs may catch it). **This PR will be closed automatically** once CI completes. If CI confirms the bug (TSan/ASan/cluster failure), a bug Issue will be filed separately.

**Suspected bug:** generateManifestOnlySnapshot still seeds refs with a raw Poco::JSON::Object pointer (same bug the PR fixes in generateNextMetadata)

**Root cause:** MetadataGenerator.cpp:374 uses `metadata_object->set(Iceberg::f_refs, new Poco::JSON::Object)` (raw pointer) rather than the fixed `Poco::JSON::Object::Ptr(new Poco::JSON::Object)`. The PR corrected the identical line at 262 in `generateNextMetadata` but missed this sibling.

**Affected locations:**
- `src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.cpp:374` — generateManifestOnlySnapshot seeds f_refs with a raw pointer
- `src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.cpp:376` — getObject(f_refs)->has(f_main) dereferences the null Ptr

**Why CI is needed:** Iceberg manifest compaction (OPTIMIZE) fails with a Null pointer POCO_EXCEPTION on any table created outside ClickHouse that omits the optional `refs` object — the exact scenario the PR set out to fix, still broken on the compaction path.

**Suggested fix:** Change MetadataGenerator.cpp:374 to `metadata_object->set(Iceberg::f_refs, Poco::JSON::Object::Ptr(new Poco::JSON::Object));`, mirroring the fix applied at line 262.

## Assumptions
The bot recorded these claims it could not verify directly from source. A maintainer ✅ confirms; ❌ flags a wrong premise (the bot should rework or close the finding).

- [ ] **An externally-created Iceberg table can have more than iceberg_manifest_min_count_to_compact manifests while omitting `refs`.**
  - *Why unverifiable:* requires a real external catalog (BigLake) table; not reproducible from a stock ClickHouse server without object-storage/catalog infra.
  - *Falsifiable test:* Create Iceberg metadata with a live snapshot but no `refs` object, enough manifests to exceed the threshold, then run OPTIMIZE with allow_experimental_iceberg_compaction=1 and observe the Null pointer exception.

[Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/06437c03-c855-4ccd-b9de-e74b9975b246)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — temporary CI proof PR, will be closed automatically.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
