### PR TITLE
Fix flaky `03394_distributed_shuffle_join_with_aggregation` under runtime-filter randomization

### DIFF
--- a/tests/queries/0_stateless/03394_distributed_shuffle_join_with_aggregation.sql
+++ b/tests/queries/0_stateless/03394_distributed_shuffle_join_with_aggregation.sql
@@ -18,6 +18,9 @@ INSERT INTO test SELECT 'path_' || number::String, 'en', number FROM numbers(5);
 INSERT INTO test SELECT 'path_' || (number%3)::String, 'de', number%4 FROM numbers(10);
 
 SET query_plan_join_swap_table = 0;
+-- Pin off: the test asserts on the `BuildRuntimeFilter` steps of the plan, and a nonzero value skips
+-- the runtime filter whenever a probe-side row estimate is available and does not exceed it.
+SET join_runtime_filter_min_probe_rows = 0;
 
 SET
     optimize_move_to_prewhere = 1,


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Documentation entry for user-facing changes

CI randomizes `join_runtime_filter_min_probe_rows` (`tests/clickhouse-test`: `0` with probability 0.1, otherwise `1..10000`). The test asserts on the distributed query plan, which contains two `BuildRuntimeFilter` steps; when the setting is nonzero and a probe-side row estimate is available, `joinRuntimeFilter.cpp` skips installing the runtime filter, so those steps disappear from the plan and the test fails with a plan diff:

```
-            BuildRuntimeFilter (Build runtime join filter on __table3.path)
-              Expression ((Change column names to column identifiers + (Project names + Projection)))
```

The failing run used `--join_runtime_filter_min_probe_rows 7099`. The fix pins the setting to `0`, exactly as the sibling test `03394_distributed_shuffle_join_with_prewhere` already does.

Observed in the CI report of #110567: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110567&sha=f1bb40ed1844641f81efce3a2266f95abfb4e515&name_0=PR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%29 — and, over the last two weeks, on the unrelated pull requests #110456, #109620, #107074, #109940, #111762 and #106231, so it is not specific to any of them.

Related: https://github.com/ClickHouse/ClickHouse/pull/110567

Related: https://github.com/ClickHouse/ClickHouse/pull/112188 — that pull request pins the same setting in this test (plus `query_plan_optimize_join_order_randomize`, and the same pins in `03394_distributed_shuffle_join_with_in`), so the two overlap in this file and whichever is merged second will need a trivial conflict resolution there.
