### PR TITLE
Do not retry a Kafka topic delete that already succeeded

### DIFF
--- a/tests/integration/helpers/kafka/common.py
+++ b/tests/integration/helpers/kafka/common.py
@@ -80,10 +80,16 @@ def kafka_create_topic(
 
 def kafka_delete_topic(admin_client, topic, max_retries=50):
     # Retry the delete RPC on transient broker/controller errors, like kafka_create_topic.
+    # UnknownTopicOrPartitionError means the topic is absent, which is the requested end
+    # state, so it is not retried; the listing loop below is what confirms it.
+    result = None
     retries = 0
     while True:
         try:
             result = admin_client.delete_topics([topic])
+            break
+        except kafka.errors.UnknownTopicOrPartitionError as e:
+            logging.debug(f"Topic {topic} is already absent: {e}")
             break
         except Exception as e:
             retries += 1
@@ -93,11 +99,12 @@ def kafka_delete_topic(admin_client, topic, max_retries=50):
             else:
                 raise
 
-    for topic, e in result.topic_error_codes:
-        if e == 0:
-            logging.debug(f"Topic {topic} deleted")
-        else:
-            logging.error(f"Failed to delete topic {topic}: {e}")
+    if result is not None:
+        for deleted_topic, e in result.topic_error_codes:
+            if e == 0:
+                logging.debug(f"Topic {deleted_topic} deleted")
+            else:
+                logging.error(f"Failed to delete topic {deleted_topic}: {e}")
 
     retries = 0
     while True:

--- a/tests/integration/test_kafka_bad_messages/test_delete_topic_helper.py
+++ b/tests/integration/test_kafka_bad_messages/test_delete_topic_helper.py
@@ -1,0 +1,148 @@
+"""Regression tests for the kafka_delete_topic teardown helper.
+
+These tests drive helpers.kafka.common.kafka_delete_topic with a stub admin client and
+need neither a ClickHouse instance nor a Kafka broker. A real broker cannot be made to
+drop exactly one DeleteTopicsResponse on demand, so the interleaving that broke teardown
+in CI is only reproducible deterministically with a stub. The stub replays the exact RPC
+sequence recorded in the failing job's client log:
+
+    18:44:18.560  DeleteTopicsRequest_v3(topics=['<topic>'], timeout=30000) sent
+    18:44:48.570  BrokerConnection ... timed out after 30000 ms. [Error 7] RequestTimedOutError
+    18:44:49.077  MetadataResponse ... ClusterMetadata(brokers: 1, topics: 3, groups: 0)
+    18:44:49.078+ DeleteTopicsResponse_v3(topic_error_codes=[(topic='<topic>', error_code=3)]) x49
+
+i.e. the delete succeeded broker-side, its response was lost, and every retry then
+reported UnknownTopicOrPartitionError (error_code 3) - "the topic does not exist", which
+for a delete is the requested end state.
+"""
+
+from types import SimpleNamespace
+
+import kafka.errors
+import pytest
+
+import helpers.kafka.common as k
+
+TOPIC = "test_delete_topic_helper_topic"
+
+# Keep the master-side failure fast: the production default of 50 burns ~23 seconds.
+MAX_RETRIES = 3
+
+
+class StubAdminClient:
+    """Admin client whose delete_topics replays a scripted sequence of outcomes.
+
+    Each element of `outcomes` is either an exception instance to raise or a
+    DeleteTopicsResponse-like object to return. The last element is repeated once the
+    script is exhausted.
+    """
+
+    def __init__(self, outcomes, listed_topics):
+        self.outcomes = outcomes
+        self.listed_topics = listed_topics
+        self.delete_calls = 0
+        self.list_calls = 0
+
+    def delete_topics(self, topics):
+        self.delete_calls += 1
+        outcome = self.outcomes[min(self.delete_calls, len(self.outcomes)) - 1]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    def list_topics(self):
+        self.list_calls += 1
+        return list(self.listed_topics)
+
+
+def deleted_response(topic):
+    return SimpleNamespace(topic_error_codes=[(topic, 0)])
+
+
+def test_lost_response_then_topic_absent_is_success():
+    """The observed CI interleaving must not fail teardown.
+
+    Attempt 1 loses its response (RequestTimedOutError); every later attempt reports
+    error_code 3 because the topic is in fact already gone. Without the fix the helper
+    retries error 3 to exhaustion and raises UnknownTopicOrPartitionError out of teardown.
+    """
+    stub = StubAdminClient(
+        outcomes=[
+            kafka.errors.RequestTimedOutError(),
+            kafka.errors.UnknownTopicOrPartitionError(),
+        ],
+        listed_topics=["_schemas", "__consumer_offsets"],
+    )
+
+    k.kafka_delete_topic(stub, TOPIC, max_retries=MAX_RETRIES)
+
+    # Error 3 is terminal, not retryable: attempt 1 (lost response) plus one attempt that
+    # reports the topic as absent. A fix that kept retrying to max_retries and only then
+    # gave up would still return, so bound the attempts explicitly.
+    assert stub.delete_calls == 2
+    # The absent-topic branch must reach the authoritative listing check rather than
+    # returning blind.
+    assert stub.list_calls >= 1
+
+
+def test_topic_absent_on_first_attempt_is_success():
+    """A delete of an already-absent topic succeeds without retrying.
+
+    This is the routine case for tests/casa_del_dolor/catalogs/kafkatest.py, which deletes
+    randomly chosen topic names.
+    """
+    stub = StubAdminClient(
+        outcomes=[kafka.errors.UnknownTopicOrPartitionError()],
+        listed_topics=[],
+    )
+
+    k.kafka_delete_topic(stub, TOPIC, max_retries=MAX_RETRIES)
+
+    assert stub.delete_calls == 1
+    assert stub.list_calls >= 1
+
+
+def test_topic_still_listed_after_error_3_still_raises():
+    """Negative control: the listing check, not error 3, decides success.
+
+    If the broker claims the topic does not exist while still listing it, the helper must
+    still fail. This is what makes the fix "trust the listing" instead of "swallow the
+    error".
+    """
+    stub = StubAdminClient(
+        outcomes=[kafka.errors.UnknownTopicOrPartitionError()],
+        listed_topics=[TOPIC],
+    )
+
+    with pytest.raises(Exception):
+        k.kafka_delete_topic(stub, TOPIC, max_retries=MAX_RETRIES)
+
+
+def test_transient_errors_are_still_retried():
+    """Genuinely transient RPC failures must keep being retried."""
+    stub = StubAdminClient(
+        outcomes=[
+            kafka.errors.RequestTimedOutError(),
+            kafka.errors.RequestTimedOutError(),
+            deleted_response(TOPIC),
+        ],
+        listed_topics=[],
+    )
+
+    k.kafka_delete_topic(stub, TOPIC, max_retries=MAX_RETRIES)
+
+    assert stub.delete_calls == 3
+    assert stub.list_calls >= 1
+
+
+def test_transient_errors_are_still_raised_when_exhausted():
+    """A permanently failing delete RPC must still fail loudly."""
+    stub = StubAdminClient(
+        outcomes=[kafka.errors.RequestTimedOutError()],
+        listed_topics=[],
+    )
+
+    with pytest.raises(kafka.errors.RequestTimedOutError):
+        k.kafka_delete_topic(stub, TOPIC, max_retries=MAX_RETRIES)
+
+    assert stub.delete_calls == MAX_RETRIES


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/83683

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`kafka_delete_topic` (`tests/integration/helpers/kafka/common.py`), the shared
single-topic teardown helper for the whole Kafka integration family, retries a
*successful* delete as if it had failed, and can never converge. An otherwise fully
passing test is then reported FAILED from teardown.

`UnknownTopicOrPartitionError` (error code 3) on a `DeleteTopicsRequest` means "that
topic does not exist" — which for a delete is exactly the requested end state, not a
failure. Today it lands in the helper's generic `except Exception: retry`, so the helper
asks the broker 49 more times to delete something that is already gone, burns ~23 s, and
then raises.

The interleaving, read off the failing job's own kafka-python client log (topic
`Native_stream_err_1784918653`, all timestamps 2026-07-24):

```
18:44:18.560  DeleteTopicsRequest_v3(topics=['Native_stream_err_1784918653'], timeout=30000) sent
18:44:48.570  BrokerConnection ... timed out after 30000 ms. Closing connection. [Error 7] RequestTimedOutError
18:44:49.077  <BrokerConnection ...> Updated cluster metadata to ClusterMetadata(brokers: 1, topics: 3, groups: 0)
18:44:49.078  DeleteTopicsResponse_v3(throttle_time_ms=0, topic_error_codes=[(topic='Native_...', error_code=3)])
              ... x49
```

Attempt 1 succeeded broker-side and only its **response** was lost to the kafka-python
30 s request timeout (the shard runs three xdist workers under TSan). The reconnect's
metadata refresh proves it: `topics: 3` is only the three internal topics
(`_schemas`, `__confluent.support.metrics`, `__consumer_offsets`) — the topic is already
gone. Every later attempt therefore returns error code 3, and
`kafka/admin/client.py:409` raises on any non-`NoError` code.

So this is a **classification** bug, not a missing retry. More retries provably cannot
help: each error-3 response came back in 1-4 ms, and the condition is permanent. This PR
does not add a guard — it removes an incorrect failure classification, making the
teardown operation idempotent, which is the correct property for a delete.

#### The fix

`UnknownTopicOrPartitionError` is caught ahead of the generic handler and treated as the
absent-topic path. It is **not** a blind `return`: it falls through to the helper's
existing post-verification loop, which independently confirms
`topic not in admin_client.list_topics()` and still raises if the broker claims the topic
is absent while continuing to list it. The generic `except Exception` retry is untouched
— it is load-bearing for the transient `RequestTimedOutError` in step 1.

The `result.topic_error_codes` reporting block is now guarded (`result` can legitimately
be unset on the absent-topic path), and its loop variable is renamed so it no longer
shadows the `topic` parameter that the listing loop reads.

`kafka.errors.UnknownTopicOrPartitionError` carries `retriable = True`, but that flag
describes stale-client-metadata semantics on the produce/fetch paths, where a later
metadata refresh can make the topic appear. On the delete path the same code means the
opposite, and the refresh above confirms it — so keying the retry on the library's flag
would preserve the bug.

#### Blast radius

Not a single-test flake. CIDB, window strictly after the retry loop was added
(#108635, merged 2026-06-27T00:27:38Z), filtered on
`position(test_context_raw, 'kafka_delete_topic') > 0`:

| test | PR | check |
|---|---|---|
| `test_kafka_bad_messages/test.py::test_bad_messages_parsing_stream` | #111572 | Integration tests (amd_tsan, 4/6) |
| `test_storage_kafka/test_poll_timeout_after_assignment.py::test_kafka_poll_timeout_restored_after_assignment` | #110292 | Integration tests (amd_tsan, 4/6) |
| `test_kafka_bad_messages/test.py::test_bad_messages_parsing_dead_letter_queue` | #94695 | Integration tests (amd_asan_ubsan, db disk, old analyzer, 4/6) |
| `test_storage_kafka/test_batch_slow_5.py::test_formats_errors` | #110166 | Integration tests (amd_msan, 4/8) |

4 hits / 4 unrelated PRs / 3 modules / 3 sanitizer flavours / 0 master, all through the
same frame — two via a direct `kafka_delete_topic` call, two via the `kafka_topic`
context manager's `finally`. Over the same window, of all 363 `kafka`-named FAIL/ERROR
rows, every delete-topic teardown failure is this one signature (`via_helper = 4`,
`any_delete_topics = 4`, `unknown_topic_any = 4`, `listing_loop_fail = 0`) — one
mechanism, no residue.

There is a second, independent motivation. `tests/casa_del_dolor/catalogs/kafkatest.py`
also calls this helper, and `KafkaTable.update_table` deletes a *randomly chosen* topic
name `t{random.randint(0, 19)}`, so deleting a topic that does not exist is that caller's
**routine** case. Today each such call burns the full 50-attempt / ~23 s loop before the
exception is swallowed by its broad `except Exception`, making a normal fuzzer operation
both slow and log-noisy.

#### Tests

The regression test drives `kafka_delete_topic` directly with a stub admin client and
needs neither a ClickHouse instance nor a broker. That shape is deliberate: a real broker
cannot be made to drop exactly one `DeleteTopicsResponse` on demand, and the passing path
is byte-identical to today's, so a broker-driven test of this interleaving would be
non-deterministic — which is the property this PR exists to remove. The stub replays the
exact RPC sequence quoted above. It lives under
`tests/integration/test_kafka_bad_messages/` because that is the module which owns the
reported failure, and because no other in-tree pytest harness covers
`tests/integration/helpers`; that path is also what makes the flaky check select and
repeat the module.

The five tests are: the observed interleaving now succeeds; a delete of an already-absent
topic succeeds without retrying; a topic that is still listed after error 3 still makes
the helper raise; a transient error followed by success still succeeds; and a permanently
failing delete RPC is still raised once `max_retries` is exhausted. The first two also
assert a bounded attempt count — so a fix that merely looped to `max_retries` and then
gave up would not pass — and that the listing check is reached rather than bypassed.

Verification:

- Against pristine `origin/master`: 2 failed, 3 passed — the two new oracles fail with
  the exact CIDB signature `kafka.errors.UnknownTopicOrPartitionError: [Error 3]`, and
  the three existing-behaviour assertions pass, so the test is discriminating rather
  than uniformly red. With the fix: 5 passed.
- Two mutations, two distinct assertions. Removing only the error-3 branch re-breaks the
  two oracles. Replacing it with an unconditional `return` that skips the listing check
  breaks the still-listed negative control. Both halves are load-bearing.
- 50 repeats of the new module: 250/250 passed (5 tests x 50).
- The three previously-observed victim modules pass on the fixed tree against a real
  broker: `test_kafka_bad_messages/test.py` (4 passed),
  `test_storage_kafka/test_poll_timeout_after_assignment.py`,
  `test_storage_kafka/test_batch_slow_5.py`.
- Liveness of the unchanged happy path: on `test_bad_messages_parsing_stream` the
  post-verification loop is reached the same number of times before and after the change
  (`TOPICS LISTED` 24 vs 24, `Topic ... deleted` 24 vs 24), and the new branch never
  fires there (0 occurrences) — the fix does not short-circuit the authoritative check.

CI report for the #111572 occurrence:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111572&sha=43ca40c8c0beb217e3edc66236a546332bb3c000&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%204%2F6%29