### PR TITLE
Fix flaky test_prometheus_before_tables: wait for the log line

### DIFF
--- a/tests/integration/test_prometheus_before_tables/test.py
+++ b/tests/integration/test_prometheus_before_tables/test.py
@@ -33,8 +33,14 @@ def start_cluster():
 
 
 def first_log_line_number(pattern, instance=None):
+    instance = instance or node
+    # The instance is reported as started as soon as its TCP port accepts, but the port is bound
+    # and listening before the "Listening for ..." lines are written, so the line may still be
+    # missing here. Wait for it in that case.
+    if not instance.contains_in_log(pattern):
+        instance.wait_for_log_line(pattern)
     # `grep -n` prints "<line>:<text>"; `-m1` stops at the first match.
-    output = (instance or node).exec_in_container(["bash", "-c", f"grep -n -m1 '{pattern}' {LOG_FILE}"])
+    output = instance.exec_in_container(["bash", "-c", f"grep -n -m1 '{pattern}' {LOG_FILE}"])
     assert output, f"log line not found: {pattern}"
     return int(output.split(":", 1)[0])
 

--- a/tests/integration/test_prometheus_before_tables/test.py
+++ b/tests/integration/test_prometheus_before_tables/test.py
@@ -35,7 +35,7 @@ def start_cluster():
 def first_log_line_number(pattern, instance=None):
     instance = instance or node
     # The instance is reported as started as soon as its TCP port accepts, but the port is bound
-    # and listening before the "Listening for ..." lines are written, so the line may still be
+    # and listening before the `Listening for ...` lines are written, so the line may still be
     # missing here. Wait for it in that case.
     if not instance.contains_in_log(pattern):
         instance.wait_for_log_line(pattern)


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/111782


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`test_prometheus_with_handlers_starts_after_tables_are_loaded` failed with

```
Exception: Command [docker exec ...-node_handlers-1 bash -c
  grep -n -m1 'Application: Listening for Prometheus' /var/log/clickhouse-server/clickhouse-server.log]
  return non-zero code 1
```

`grep` exit 1 means the line was not in the log yet, so the assertion never ran. Startup
ordering itself is correct in both configurations and is not changed here.

The integration harness reports an instance as started as soon as a bare
`sock.connect((ip, 9000))` succeeds (`ClickHouseInstance.wait_until_port_is_ready` in
`helpers/cluster.py`). But `createServers`
(`programs/server/Server.cpp:3454`, `start_servers=false`) already calls
`socketBindListen`, which ends in `socket.listen(backlog)`
(`src/Server/socketBindListen.cpp:31`), so the kernel accepts into the backlog with no
accept loop and no log line. The `Listening for {}` lines are written later, in the
sequential start loop at `Server.cpp:3692`, and Prometheus is pushed last
(`:4162`). The `prometheus.handlers` instance skips the early-start path
(`:3318`, gated on `!config().has("prometheus.handlers")`), so its Prometheus line is the
last line of startup. `first_log_line_number` read it with a one-shot `grep` and no wait.

On the failing run the harness wait returned at 00:51:18.720 while the line was written at
00:51:19.011710, i.e. 291 ms later. The harness's own probe being accepted
(`TCPHandlerFactory: TCP Request. Address: 172.16.1.1:62718`) is logged 10 us before that
line, which shows the socket was reachable well before the loop reached Prometheus. The
two `Application: Loaded metadata` greps in the same module had only about 5 ms of margin
on that run, so they were latently racy too; the fix is in the shared helper and covers all
four call sites.

`first_log_line_number` now waits for the line when it is not there yet:

```python
if not instance.contains_in_log(pattern):
    instance.wait_for_log_line(pattern)
```

The `contains_in_log` guard matters for runtime: `wait_for_log_line` runs
`tail -F ... | grep -Em1` in the container and `grep` exits on the match, but `tail -F`
only notices the closed pipe on the server's next log write, so an unconditional barrier
costs about 7 s per call even when the line is already present. Measured on the whole
module: 17.19 s pristine, 35.88 s with an unconditional barrier, 16.17 s as written here.

This cannot mask an ordering regression. The failure mode being fixed is a missing line,
not a wrong order; if the lines were ever emitted in the wrong order, both would still be
found and the `assert` would still fail.

Verification (integration harness, debug build):

* Deterministic reproducer: a slow `startup_scripts` entry on `node_handlers`.
  `loadStartupScripts` (`Server.cpp:3541`) runs between the bind at `:3454` and the
  `Listening for` loop at `:3692`, so it widens the window while port 9000 already accepts.
  On the unpatched test this fails every time with the exact signature above; with the fix
  it passes and the assertion is really evaluated (line 324 before line 562).
* Inverting the ordering assertion under that reproducer fails (`assert 536 < 324`), so the
  wait did not make the test vacuous.
* Disabling the new wait under that reproducer fails again with the original `grep` error.
* `pytest --count 10` over the module (50 executions): 50 passed.

CI reports for the two failures:

* master: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3c38d2e4ec1983207d79969c09e47cae4ce371a1&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29
* PR 109944: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109944&sha=367cd4bf040d64f2bef558090da8497a2da5779a&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29

An alternative would be to wait once for `Application: Ready for connections.`
(`Server.cpp:3699`) in the fixture. That is also a sound barrier, but it is coarser and
would leave `first_log_line_number` unsafe for any future caller.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.211` (included in `26.8` and later)
<!-- ch-version-info:end -->