### PR TITLE
Give `00084_external_aggregation` real memory headroom

### DIFF
--- a/tests/queries/0_stateless/00084_external_aggregation.sql
+++ b/tests/queries/0_stateless/00084_external_aggregation.sql
@@ -8,7 +8,14 @@ SET max_memory_usage = 1500000000;
 SET max_threads = 12;
 SELECT URL, uniq(SearchPhrase) AS u FROM test.hits GROUP BY URL ORDER BY u DESC, URL LIMIT 10;
 
-SET max_memory_usage = 300000000;
+-- The query below peaks at around 260 MiB when it spills, and at around 855 MiB when it does not,
+-- so `max_memory_usage` has to sit between the two for the test to keep checking that the
+-- aggregation goes to disk. It used to be 300000000, which left only a few percent of headroom
+-- over the spilling peak and made the test fail with `MEMORY_LIMIT_EXCEEDED` from time to time.
+-- Anything that adds to the query on top of the aggregation state was enough to cross the limit,
+-- in particular hash tables preallocated from `collect_hash_table_stats_during_aggregation`,
+-- which add over 100 MiB once the statistics cache holds an entry for this aggregation.
+SET max_memory_usage = 600000000;
 SET max_threads = 2;
 SET aggregation_memory_efficient_merge_threads = 1;
 SELECT URL, uniq(SearchPhrase) AS u FROM test.hits GROUP BY URL ORDER BY u DESC, URL LIMIT 10;


### PR DESCRIPTION
Fixes the recurring `MEMORY_LIMIT_EXCEEDED` flakiness of `00084_external_aggregation`, e.g. [this MasterCI run](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a8c156e623333d40936998a3b0d273966835912c&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29):

```
Code: 241. DB::Exception: Query memory limit exceeded: would use 316.72 MiB
(attempt to allocate chunk of 1.75 MiB), maximum: 286.10 MiB.
Untracked memory across all threads: -9.28 MiB: While executing AggregatingTransform.
```

29 failures over 2026-07-26 and 2026-07-27 across `amd_tsan`, `arm_binary`, `amd_debug`, `amd_msan` and `amd_asan_ubsan`, always on the second query and always with code 241. The settings randomizer is not the trigger: CI's own diagnosis reruns the same randomized settings 16-22 times and they all pass.

### What is going on

The second query spills at 200 MB (`max_bytes_before_external_group_by`) and was capped at `300000000` (286.10 MiB) by `max_memory_usage`. Measured against `test.hits` on an idle machine, over 10 runs of the query pair on a freshly started server, the second query peaks at **258-290 MiB** - 90-97% of its own limit. There is essentially no headroom, so anything the query allocates on top of the aggregation state crosses the limit.

One reproducible source of that extra memory is the aggregation hash-table size statistics. Once the statistics cache holds an entry for this aggregation, `collect_hash_table_stats_during_aggregation` preallocates the hash tables and the peak jumps by more than 100 MiB:

| server state | `AggregationPreallocatedElementsInHashTables` | peak of the second query | test at 300000000 |
| --- | --- | --- | --- |
| fresh (10 runs) | 0 | 258-278 MiB | 10/10 pass |
| statistics cache populated (5 runs) | 2712170 | 362-387 MiB | 3/3 fail |

In the second state the current test fails on every single run with exactly the CI message:

```
Query memory limit exceeded: would use 288.69 MiB
(attempt to allocate chunk of 4.06 MiB), maximum: 286.10 MiB
```

This is the same interaction between external aggregation and the hash-table statistics that https://github.com/ClickHouse/ClickHouse/pull/111984 describes for `04625_hash_table_sizes_stats_table_expression_modifiers`.

### The fix

Raise `max_memory_usage` for the second query to `600000000` (572.20 MiB) and record why in a comment. The number is picked so the test keeps its meaning:

* with spilling the query needs 258-290 MiB normally and 362-387 MiB with preallocated hash tables - both pass with room to spare;
* without spilling (`max_bytes_before_external_group_by = 0`) the same query needs ~855 MiB and still fails under the new limit (`would use 687.22 MiB ... maximum: 572.20 MiB`), so the test still verifies that the aggregation goes to disk;
* the first query of the test is untouched - it peaks at 550-601 MiB against its 1500000000 limit.

Verified locally on an ARM release build of master (`26.8.1.144`) with `test.hits` loaded from the stateful web disk: the patched test passes and matches the reference both on a fresh server and on a server whose statistics cache makes the current version fail 3/3.

Related: https://github.com/ClickHouse/ClickHouse/pull/102618
Related: https://github.com/ClickHouse/ClickHouse/pull/111984

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
