### PR TITLE
Fix LOGICAL_ERROR in StorageKafka2 on concurrent Keeper cleanup

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -129,6 +129,8 @@ static struct InitFiu
     PAUSEABLE_ONCE(query_metric_log_pause_before_finish) \
     PAUSEABLE_ONCE(replicated_table_remove_zk_before_get_children) \
     PAUSEABLE_ONCE(replicated_table_remove_zk_before_final_multi) \
+    PAUSEABLE_ONCE(kafka2_remove_zk_before_get_children) \
+    PAUSEABLE_ONCE(kafka2_remove_zk_before_final_multi) \
     PAUSEABLE(dummy_pausable_failpoint) \
     ONCE(execute_query_calling_empty_set_result_func_on_exception) \
     ONCE(terminate_with_exception) \

--- a/src/Storages/Kafka/StorageKafka2.cpp
+++ b/src/Storages/Kafka/StorageKafka2.cpp
@@ -41,6 +41,7 @@
 #include <Poco/Util/AbstractConfiguration.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 #include <Common/Macros.h>
 #include <Common/ProfileEvents.h>
 #include <Common/Stopwatch.h>
@@ -122,6 +123,12 @@ namespace KafkaSetting
 }
 
 namespace fs = std::filesystem;
+
+namespace FailPoints
+{
+extern const char kafka2_remove_zk_before_get_children[];
+extern const char kafka2_remove_zk_before_final_multi[];
+}
 
 namespace ErrorCodes
 {
@@ -768,13 +775,22 @@ bool StorageKafka2::removeTableNodesFromZooKeeper(zkutil::ZooKeeperPtr keeper_to
 {
     bool completely_removed = false;
 
+    FailPointInjection::pauseFailPoint(FailPoints::kafka2_remove_zk_before_get_children);
+
     Strings children;
     if (const auto code = keeper_to_use->tryGetChildren(keeper_path, children); code == Coordination::Error::ZNONODE)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "There is a race condition between creation and removal. It's a bug");
+    {
+        /// It is possible if the Keeper session expired and the ephemeral drop lock was deleted,
+        /// allowing another process to complete the removal. The table is completely gone.
+        LOG_WARNING(log, "Table {} was already removed from Keeper, looks like a concurrent operation removed it", keeper_path);
+        return true;
+    }
 
     for (const auto & child : children)
         if (child != "dropped")
             keeper_to_use->tryRemoveRecursive(fs_keeper_path / child);
+
+    FailPointInjection::pauseFailPoint(FailPoints::kafka2_remove_zk_before_final_multi);
 
     Coordination::Requests ops;
     Coordination::Responses responses;
@@ -785,10 +801,14 @@ bool StorageKafka2::removeTableNodesFromZooKeeper(zkutil::ZooKeeperPtr keeper_to
 
     if (code == Coordination::Error::ZNONODE)
     {
-        throw Exception(
-            ErrorCodes::LOGICAL_ERROR, "There is a race condition between creation and removal of replicated table. It's a bug");
+        /// It is possible if the Keeper session expired and the ephemeral drop lock was deleted,
+        /// allowing another process to complete the removal or create a new table.
+        LOG_WARNING(
+            log,
+            "Table {} was not completely removed from Keeper, some nodes were already removed by a concurrent operation",
+            keeper_path);
     }
-    if (code == Coordination::Error::ZNOTEMPTY)
+    else if (code == Coordination::Error::ZNOTEMPTY)
     {
         LOG_ERROR(
             log,

--- a/tests/queries/0_stateless/04648_kafka2_race_creation_removal.reference
+++ b/tests/queries/0_stateless/04648_kafka2_race_creation_removal.reference
@@ -1,0 +1,2 @@
+Scenario A passed
+Scenario B passed

--- a/tests/queries/0_stateless/04648_kafka2_race_creation_removal.sh
+++ b/tests/queries/0_stateless/04648_kafka2_race_creation_removal.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Tags: zookeeper, no-parallel, no-fasttest, no-replicated-database
+# no-parallel: uses PAUSEABLE_ONCE failpoints that fire exactly once globally; a concurrent test
+#   from another parallel run could steal the failpoint pause and cause this test to hang.
+# no-fasttest: requires Keeper, and the Kafka engine is not available in fast tests.
+# no-replicated-database: uses an explicit `kafka_keeper_path` that conflicts with the DDL
+#   replication mechanism of DatabaseReplicated.
+#
+# Regression test: LOGICAL_ERROR "There is a race condition between creation and removal[ of
+# replicated table]" must not be thrown by StorageKafka2::removeTableNodesFromZooKeeper when a
+# Keeper session expires mid-cleanup and a concurrent operation finishes removing the nodes.
+#
+# The same class was fixed for StorageReplicatedMergeTree by #99557 (see
+# 04036_replicated_table_race_creation_removal.sh); StorageKafka2 is a copy of the same
+# create/drop coordination protocol and kept both throws.
+#
+# Two scenarios are exercised via DROP TABLE SYNC (which calls removeTableNodesFromZooKeeper):
+#   A) the path is gone before tryGetChildren    -> ZNONODE on tryGetChildren
+#   B) the path is gone before the final tryMulti -> ZNONODE on tryMulti
+#
+# Case A returns true (the root znode is gone, so the table IS completely removed); case B
+# leaves completely_removed == false (only some of the three nodes may be gone).
+#
+# The broker address is deliberately unreachable: StorageKafka2's constructor only creates the
+# Keeper nodes, consumers are created later in startup() and a broker failure there is not fatal.
+
+set -e
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+ZK_PATH="/clickhouse/kafka2/${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}/k2_race"
+
+function cleanup()
+{
+    ${CLICKHOUSE_CLIENT} -q "SYSTEM DISABLE FAILPOINT kafka2_remove_zk_before_get_children" 2>/dev/null ||:
+    ${CLICKHOUSE_CLIENT} -q "SYSTEM DISABLE FAILPOINT kafka2_remove_zk_before_final_multi" 2>/dev/null ||:
+    ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS k2_race SYNC" 2>/dev/null ||:
+    ${CLICKHOUSE_KEEPER_CLIENT} -q "rmr '${ZK_PATH}'" 2>/dev/null ||:
+}
+trap cleanup EXIT
+cleanup
+
+function create_table()
+{
+    ${CLICKHOUSE_CLIENT} --allow_experimental_kafka_offsets_storage_in_keeper=1 -q "
+        CREATE TABLE k2_race (a String) ENGINE = Kafka
+        SETTINGS kafka_broker_list = 'localhost:1',
+                 kafka_topic_list = 'k2_race_topic',
+                 kafka_group_name = '${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}',
+                 kafka_format = 'RawBLOB',
+                 kafka_keeper_path = '${ZK_PATH}',
+                 kafka_replica_name = 'r1'
+    "
+}
+
+# Remove the whole Keeper subtree, emulating a concurrent operation that finished the cleanup.
+# NOTE: `clickhouse keeper-client -q` always exits with 0, even when the Keeper request fails,
+# so the removal MUST be verified explicitly — otherwise the race is never set up and the test
+# would pass vacuously even with the fix reverted.
+function remove_keeper_subtree_and_verify()
+{
+    ${CLICKHOUSE_KEEPER_CLIENT} -q "rmr '${ZK_PATH}'" 2>/dev/null ||:
+
+    local still_there
+    still_there=$(${CLICKHOUSE_CLIENT} -q "
+        SELECT count() FROM system.zookeeper
+        WHERE path = '/clickhouse/kafka2/${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}' AND name = 'k2_race'
+    ")
+    if [[ "$still_there" != "0" ]]; then
+        echo "FAIL: ${ZK_PATH} is still present in Keeper, the race was not set up"
+        exit 1
+    fi
+}
+
+function wait_for_pause()
+{
+    local failpoint=$1
+    if ! timeout 60 ${CLICKHOUSE_CLIENT} -q "SYSTEM WAIT FAILPOINT ${failpoint} PAUSE"; then
+        echo "FAIL: DROP never reached the failpoint ${failpoint}"
+        exit 1
+    fi
+}
+
+function wait_for_drop()
+{
+    local drop_pid=$1
+    local scenario=$2
+    if ! wait "$drop_pid"; then
+        echo "FAIL: DROP TABLE failed in scenario ${scenario} (LOGICAL_ERROR thrown or server died)"
+        exit 1
+    fi
+}
+
+# ===== Scenario A: ZNONODE on tryGetChildren =====
+
+create_table
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM ENABLE FAILPOINT kafka2_remove_zk_before_get_children"
+
+# DROP TABLE SYNC triggers dropReplica -> removeTableNodesFromZooKeeper, which pauses on the
+# failpoint before calling tryGetChildren.
+${CLICKHOUSE_CLIENT} -q "DROP TABLE k2_race SYNC" &
+DROP_PID=$!
+
+wait_for_pause kafka2_remove_zk_before_get_children
+remove_keeper_subtree_and_verify
+
+# Resume: tryGetChildren returns ZNONODE. With the fix we log a warning and return true
+# instead of throwing LOGICAL_ERROR.
+${CLICKHOUSE_CLIENT} -q "SYSTEM NOTIFY FAILPOINT kafka2_remove_zk_before_get_children"
+
+wait_for_drop $DROP_PID A
+
+echo "Scenario A passed"
+
+# ===== Scenario B: ZNONODE on the final tryMulti =====
+
+create_table
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM ENABLE FAILPOINT kafka2_remove_zk_before_final_multi"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE k2_race SYNC" &
+DROP_PID=$!
+
+wait_for_pause kafka2_remove_zk_before_final_multi
+remove_keeper_subtree_and_verify
+
+# Resume: tryMulti returns ZNONODE. With the fix we log a warning and leave
+# completely_removed == false instead of throwing LOGICAL_ERROR.
+${CLICKHOUSE_CLIENT} -q "SYSTEM NOTIFY FAILPOINT kafka2_remove_zk_before_final_multi"
+
+wait_for_drop $DROP_PID B
+
+echo "Scenario B passed"

--- a/tests/queries/0_stateless/04648_kafka2_race_creation_removal.sh
+++ b/tests/queries/0_stateless/04648_kafka2_race_creation_removal.sh
@@ -36,7 +36,11 @@ function cleanup()
 {
     ${CLICKHOUSE_CLIENT} -q "SYSTEM DISABLE FAILPOINT kafka2_remove_zk_before_get_children" 2>/dev/null ||:
     ${CLICKHOUSE_CLIENT} -q "SYSTEM DISABLE FAILPOINT kafka2_remove_zk_before_final_multi" 2>/dev/null ||:
-    ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS k2_race SYNC" 2>/dev/null ||:
+    # Every DROP here must really execute: it is what reaches removeTableNodesFromZooKeeper.
+    # The stress runner injects `ignore_drop_queries_probability=0.2` and `clickhouse-client
+    # --fake-drop` (upgrade check) injects 1; for a storage that keeps nothing on disk the
+    # injection rewrites DROP into a TRUNCATE that Kafka does not implement. Hence the pin.
+    ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS k2_race SYNC SETTINGS ignore_drop_queries_probability = 0" 2>/dev/null ||:
     ${CLICKHOUSE_KEEPER_CLIENT} -q "rmr '${ZK_PATH}'" 2>/dev/null ||:
 }
 trap cleanup EXIT
@@ -93,6 +97,34 @@ function wait_for_drop()
     fi
 }
 
+# "The DROP did not throw" is not enough: each of the two tolerate branches leads to a successful
+# DROP, so removing one of them alone would still leave the other one making the DROP succeed.
+# Assert the warning that only the branch under test can emit.
+# The predicate is scoped to this run's own ZK_PATH (which embeds the per-run random database), so
+# rows left in text_log by a previous `--test-runs` iteration or a concurrent test cannot satisfy
+# it, and to level = 'Warning', so the query text of this very SELECT (which the server also logs,
+# at Debug level, needle and all) cannot satisfy it either.
+function assert_warning_logged()
+{
+    local needle=$1
+    local scenario=$2
+
+    local found
+    found=$(${CLICKHOUSE_CLIENT} -m -q "
+        SYSTEM FLUSH LOGS text_log;
+
+        SELECT count() > 0 FROM system.text_log
+        WHERE event_date >= yesterday() AND event_time >= now() - 600
+          AND level = 'Warning'
+          AND message LIKE '%${ZK_PATH}%${needle}%'
+        SETTINGS max_rows_to_read = 0
+    ")
+    if [[ "$found" != "1" ]]; then
+        echo "FAIL: scenario ${scenario} did not log the expected warning: ${needle}"
+        exit 1
+    fi
+}
+
 # ===== Scenario A: ZNONODE on tryGetChildren =====
 
 create_table
@@ -101,7 +133,7 @@ ${CLICKHOUSE_CLIENT} -q "SYSTEM ENABLE FAILPOINT kafka2_remove_zk_before_get_chi
 
 # DROP TABLE SYNC triggers dropReplica -> removeTableNodesFromZooKeeper, which pauses on the
 # failpoint before calling tryGetChildren.
-${CLICKHOUSE_CLIENT} -q "DROP TABLE k2_race SYNC" &
+${CLICKHOUSE_CLIENT} -q "DROP TABLE k2_race SYNC SETTINGS ignore_drop_queries_probability = 0" &
 DROP_PID=$!
 
 wait_for_pause kafka2_remove_zk_before_get_children
@@ -112,6 +144,7 @@ remove_keeper_subtree_and_verify
 ${CLICKHOUSE_CLIENT} -q "SYSTEM NOTIFY FAILPOINT kafka2_remove_zk_before_get_children"
 
 wait_for_drop $DROP_PID A
+assert_warning_logged "was already removed from Keeper, looks like a concurrent operation removed it" A
 
 echo "Scenario A passed"
 
@@ -121,7 +154,7 @@ create_table
 
 ${CLICKHOUSE_CLIENT} -q "SYSTEM ENABLE FAILPOINT kafka2_remove_zk_before_final_multi"
 
-${CLICKHOUSE_CLIENT} -q "DROP TABLE k2_race SYNC" &
+${CLICKHOUSE_CLIENT} -q "DROP TABLE k2_race SYNC SETTINGS ignore_drop_queries_probability = 0" &
 DROP_PID=$!
 
 wait_for_pause kafka2_remove_zk_before_final_multi
@@ -132,5 +165,6 @@ remove_keeper_subtree_and_verify
 ${CLICKHOUSE_CLIENT} -q "SYSTEM NOTIFY FAILPOINT kafka2_remove_zk_before_final_multi"
 
 wait_for_drop $DROP_PID B
+assert_warning_logged "some nodes were already removed by a concurrent operation" B
 
 echo "Scenario B passed"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/99557


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`StorageKafka2::removeTableNodesFromZooKeeper` is, by its own comment, a copy of the
`StorageReplicatedMergeTree` create/drop coordination protocol. It kept both `LOGICAL_ERROR`
throw sites that https://github.com/ClickHouse/ClickHouse/pull/99557 removed from the
original:

| site (on `master`) | Keeper call | code |
|---|---|---|
| `src/Storages/Kafka/StorageKafka2.cpp:773` | `tryGetChildren(keeper_path, children)` | `ZNONODE` |
| `src/Storages/Kafka/StorageKafka2.cpp:789` | final `tryMulti({drop_lock, dropped, keeper_path})` | `ZNONODE` |

The second message, `There is a race condition between creation and removal of replicated
table. It's a bug`, is byte-identical to the one #99557 fixed for `StorageReplicatedMergeTree`,
so that signature is still reachable in trunk through this sibling storage. On `master` the
count of the message per file is:

```
$ git grep -c 'race condition between creation and removal' origin/master -- src/
origin/master:src/Storages/Kafka/StorageKafka2.cpp:2    <- this PR
origin/master:src/Storages/StorageKeeperMap.cpp:1       <- different message/protocol, see below
```

#### Root cause

The function is entered while holding an **ephemeral** `<keeper_path>/dropped/lock` node. Both
throws encode the invariant *"while I hold the drop lock, the table's Keeper path cannot
disappear"*. That invariant only holds **while the Keeper session is alive**. When the session
expires, Keeper itself deletes the ephemeral lock; another replica (or the same table's
`createTableIfNotExists` retry loop) then legitimately takes over and completes the removal.
When the original thread reconnects and resumes, it observes `ZNONODE` — a normal
distributed-systems outcome, not a code bug. Session expiry mid-cleanup is common under the
thread fuzzer and fault injection, which is why every occurrence in the CI database is on a
`Stress test` check.

Neither caller relied on the throw: `createTableIfNotExists` retries on a `false` return, and
`dropReplica` ignores the return value altogether.

#### The fix

Both branches now log a warning, matching the resolution the maintainers already reviewed and
merged for `StorageReplicatedMergeTree` in #99557 (commit `333d1f5018d9ab` plus the review
follow-up `2c82024b003f43`):

* `tryGetChildren` returning `ZNONODE` means the **root znode is gone**, i.e. the table IS
  completely removed, so the function returns `true` — the same value the #99557 reviewers
  asked for when they changed that branch from `completely_removed` to `true`. This lets
  `createTableIfNotExists` proceed to create instead of spinning.
* The final `tryMulti` returning `ZNONODE` means only some of the three nodes are gone, so
  `completely_removed` stays `false` and the caller retries.

`ZNOTEMPTY`, the `KeeperMultiException::check` default and `drop_lock->setAlreadyRemoved()` on
`ZOK` are untouched. `EphemeralNodeHolder`'s destructor already tolerates a vanished node, so
not calling `setAlreadyRemoved` on the new path leaks nothing.

#### Reproduction and verification

Two `PAUSEABLE_ONCE` failpoints (`kafka2_remove_zk_before_get_children`,
`kafka2_remove_zk_before_final_multi`) make both races deterministic. The new test
`04648_kafka2_race_creation_removal.sh` is modelled on #99557's own
`04036_replicated_table_race_creation_removal.sh`.

Verified in both directions on a Debug build:

* **Without the fix** (failpoints present, throws restored) the server aborts on each
  scenario — `Logical error: 'There is a race condition between creation and removal[ of
  replicated table]. It's a bug'` at `StorageKafka2.cpp` ← `dropReplica` ←
  `DatabaseCatalog::dropTableFinally`, the same call chain the CI report shows.
* **With the fix** the test passes, and each scenario **asserts** — from `system.text_log`,
  scoped to that run's own `kafka_keeper_path` and to `level = 'Warning'` — the warning that
  only its tolerate branch can emit, so the branch provably executed rather than the race
  simply not happening. Each branch was additionally mutated on its own: deleting either
  warning fails that scenario's assertion while the other scenario still passes, and both
  mutants pass the earlier revision of the test.
* `--test-runs 50`: 50/50 pass, with **87 distinct** `kafka_keeper_path` values among the
  matched `Warning` rows — i.e. each run's assertion was satisfied by its own run, not by a
  previous one.

The test verifies explicitly that the Keeper subtree really was removed before resuming the
paused `DROP`, because `clickhouse keeper-client -q` exits 0 even when its request fails;
without that check the test would pass vacuously with the fix reverted. Every `DROP TABLE` in
the test pins `ignore_drop_queries_probability = 0`, so neither the stress runner's injection
nor `clickhouse-client --fake-drop` can rewrite the load-bearing `DROP` into a `TRUNCATE` that
the `Kafka` engine does not implement.

#### Not fixed here, deliberately

`StorageKeeperMap.cpp:995` throws a similar-looking `There is a race condition between
creation and removal of metadata. It's a bug`, but it is a different message guarding a
different (6-node) protocol in a different function, it has no occurrences in the CI database,
and https://github.com/ClickHouse/ClickHouse/pull/111966 already modifies that file's
create/drop cleanup. Keeping it separate avoids bundling two unrelated fixes and a
self-inflicted conflict.