### PR TITLE
Disable memory tracker debug checks on macOS

### DIFF
--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -10,7 +10,9 @@
 #include <Common/CurrentMetrics.h>
 #include <Common/VariableContext.h>
 
-#if !defined(NDEBUG)
+/// Disabled on macOS: the malloc-zone hook observes system-library allocations (e.g. dyld mallocs
+/// on a thread's first `absl::Mutex` lock) that can occur inside deny scopes and cannot be prevented.
+#if !defined(NDEBUG) && !defined(OS_DARWIN)
 #define MEMORY_TRACKER_DEBUG_CHECKS
 #endif
 

--- a/src/Common/malloc.cpp
+++ b/src/Common/malloc.cpp
@@ -273,6 +273,7 @@ void * __libc_pvalloc(size_t size) __attribute__((alias("pvalloc"))); // NOLINT(
 
 #include <base/getPageSize.h>
 #include <Common/CurrentMemoryTracker.h>
+#include <Common/MemoryTracker.h>
 #include <Common/memory.h>
 
 /// macOS counterpart of the symbol interposition above.
@@ -316,18 +317,34 @@ pthread_key_t reentrancy_key;
 struct ReentrancyGuard
 {
     bool engaged;
+#ifdef MEMORY_TRACKER_DEBUG_CHECKS
+    bool saved_deny_flag;
+#endif
 
     ReentrancyGuard()
         : engaged(pthread_getspecific(reentrancy_key) == nullptr)
     {
         if (engaged)
+        {
             pthread_setspecific(reentrancy_key, reinterpret_cast<void *>(1));
+#ifdef MEMORY_TRACKER_DEBUG_CHECKS
+            /// The zone also observes system-library allocations we cannot prevent (e.g. dyld mallocs on
+            /// the first absl::Mutex lock of a thread), so suspend the ClickHouse-only deny-allocations check.
+            saved_deny_flag = memory_tracker_always_throw_logical_error_on_allocation;
+            memory_tracker_always_throw_logical_error_on_allocation = false;
+#endif
+        }
     }
 
     ~ReentrancyGuard()
     {
         if (engaged)
+        {
+#ifdef MEMORY_TRACKER_DEBUG_CHECKS
+            memory_tracker_always_throw_logical_error_on_allocation = saved_deny_flag;
+#endif
             pthread_setspecific(reentrancy_key, nullptr);
+        }
     }
 };
 

--- a/src/Common/malloc.cpp
+++ b/src/Common/malloc.cpp
@@ -273,7 +273,6 @@ void * __libc_pvalloc(size_t size) __attribute__((alias("pvalloc"))); // NOLINT(
 
 #include <base/getPageSize.h>
 #include <Common/CurrentMemoryTracker.h>
-#include <Common/MemoryTracker.h>
 #include <Common/memory.h>
 
 /// macOS counterpart of the symbol interposition above.
@@ -317,34 +316,18 @@ pthread_key_t reentrancy_key;
 struct ReentrancyGuard
 {
     bool engaged;
-#ifdef MEMORY_TRACKER_DEBUG_CHECKS
-    bool saved_deny_flag;
-#endif
 
     ReentrancyGuard()
         : engaged(pthread_getspecific(reentrancy_key) == nullptr)
     {
         if (engaged)
-        {
             pthread_setspecific(reentrancy_key, reinterpret_cast<void *>(1));
-#ifdef MEMORY_TRACKER_DEBUG_CHECKS
-            /// The zone also observes system-library allocations we cannot prevent (e.g. dyld mallocs on
-            /// the first absl::Mutex lock of a thread), so suspend the ClickHouse-only deny-allocations check.
-            saved_deny_flag = memory_tracker_always_throw_logical_error_on_allocation;
-            memory_tracker_always_throw_logical_error_on_allocation = false;
-#endif
-        }
     }
 
     ~ReentrancyGuard()
     {
         if (engaged)
-        {
-#ifdef MEMORY_TRACKER_DEBUG_CHECKS
-            memory_tracker_always_throw_logical_error_on_allocation = saved_deny_flag;
-#endif
             pthread_setspecific(reentrancy_key, nullptr);
-        }
     }
 };
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110370

### Problem

Since https://github.com/ClickHouse/ClickHouse/pull/110370, the macOS malloc-zone hook routes every `malloc` in the process — including those made by system libraries — into `CurrentMemoryTracker`. The `DENY_ALLOCATIONS_IN_SCOPE` debug check assumes only ClickHouse code can reach the tracker, so it now throws `Logical error: 'Memory tracker: allocations not allowed.'` for allocations we do not make and cannot prevent.

Any macOS debug build of `clickhouse server` aborts 100% at startup: `OvercommitTracker` methods lock a `SharedMutex` (`absl::Mutex` on macOS) under `DENY_ALLOCATIONS_IN_SCOPE`, and the first absl lock on each thread makes `dyld` call `malloc` while registering a thread-termination callback — inside the deny scope.

### Fix

Disable `MEMORY_TRACKER_DEBUG_CHECKS` (and with it `DENY_ALLOCATIONS_IN_SCOPE` / `ALLOW_ALLOCATIONS_IN_SCOPE`) on macOS. The check is built on the assumption that only ClickHouse's own allocations reach the memory tracker; with the zone hook observing every allocation in the process, that assumption no longer holds on this platform, and any system-library allocation inside a deny scope produces a false positive that cannot be fixed on our side. Allocations are still tracked as before; release builds are unchanged; the checks remain fully active on Linux, where they do their job.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a startup abort in macOS debug builds: since the malloc-zone memory tracking was introduced, the `DENY_ALLOCATIONS_IN_SCOPE` debug check fired on allocations made by system libraries, which ClickHouse cannot prevent. Memory tracker debug checks are now disabled on macOS.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.236` (included in `26.8` and later)
<!-- ch-version-info:end -->