### PR TITLE
Do not write to the query condition cache for vector-search reads

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
@@ -532,6 +532,18 @@ bool optimizeVectorSearchWithVectorIndexSecondPass(QueryPlan::Node & /*root*/, S
     }
 
     const bool vector_optimization_applied = optimize_plan || apply_row_filter_for_rescoring;
+
+    /// Both vector-search optimizations narrow each granule to the candidate rows returned by the
+    /// vector index before the WHERE/PREWHERE filter runs. The query condition cache key encodes
+    /// only the filter predicate, so a granule whose candidates all fail the filter would be
+    /// recorded as "the predicate matches nothing" and a later ordinary query with the same
+    /// predicate would skip it and lose rows. Same reasoning as the SAMPLE exclusion in
+    /// ReadFromMergeTree::initializePipeline. Reading and index analysis are already excluded for
+    /// vector search (MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache and
+    /// ReadFromMergeTree::selectRangesToRead); this covers the remaining write paths.
+    if (vector_optimization_applied)
+        read_from_mergetree_step->disableQueryConditionCache();
+
     if (!vector_optimization_applied && settings.optimize_prewhere && filter_step)
         optimizePrewhere(*filter_or_prewhere_node, settings.remove_unused_columns, false);
 

--- a/tests/queries/0_stateless/04648_query_condition_cache_vector_search.reference
+++ b/tests/queries/0_stateless/04648_query_condition_cache_vector_search.reference
@@ -1,0 +1,19 @@
+The table contains 298 rows with flag = 1.
+298
+--- optimized plan (vector_search_with_rescoring = 0)
+A vector-search query must NOT write to the query condition cache.
+0
+A later ordinary query must still find all 298 rows.
+298
+--- rescoring plan (vector_search_with_rescoring = 1)
+A vector-search query must NOT write to the query condition cache.
+0
+A later ordinary query must still find all 298 rows.
+298
+--- the query condition cache stays enabled for reads without the vector optimization
+An ordinary query still writes to the query condition cache.
+1
+A vector-search query with an explicit PREWHERE still writes to the query condition cache.
+1
+And that entry does not lose rows either.
+298

--- a/tests/queries/0_stateless/04648_query_condition_cache_vector_search.reference
+++ b/tests/queries/0_stateless/04648_query_condition_cache_vector_search.reference
@@ -1,12 +1,16 @@
 The table contains 298 rows with flag = 1.
 298
 --- optimized plan (vector_search_with_rescoring = 0)
-A vector-search query must NOT write to the query condition cache.
+The vector index is read and the plan uses `_distance`.
+1	1
+A vector-search query must NOT write to the query condition cache. It returns no rows.
 0
 A later ordinary query must still find all 298 rows.
 298
 --- rescoring plan (vector_search_with_rescoring = 1)
-A vector-search query must NOT write to the query condition cache.
+The vector index is read and rescoring does not use `_distance`.
+1	0
+A vector-search query must NOT write to the query condition cache. It returns no rows.
 0
 A later ordinary query must still find all 298 rows.
 298

--- a/tests/queries/0_stateless/04648_query_condition_cache_vector_search.sql
+++ b/tests/queries/0_stateless/04648_query_condition_cache_vector_search.sql
@@ -25,13 +25,14 @@ DROP TABLE IF EXISTS tab;
 -- One part with a single data granule:
 --   rows 0, 1   -> vector near the origin (the nearest neighbours), flag = 0 (fail the WHERE)
 --   rows 2..299 -> vector far away,                                flag = 1 (must stay findable)
--- `index_granularity` is randomized by the test runner. All 300 rows must land in ONE granule: the
--- two nearest neighbours have to share a granule with the flag = 1 rows, otherwise the index returns
--- candidates from a granule the WHERE does accept and the query below returns rows.
+-- `index_granularity` and `index_granularity_bytes` are both randomized by the test runner, and
+-- either one splits the part. All 300 rows must land in ONE granule: the two nearest neighbours have
+-- to share a granule with the flag = 1 rows, otherwise the index returns candidates from a granule
+-- the WHERE does accept and the query below returns rows.
 CREATE TABLE tab (id UInt64, flag UInt8, vec Array(Float32),
     INDEX idx vec TYPE vector_similarity('hnsw', 'L2Distance', 3) GRANULARITY 1)
 ENGINE = MergeTree ORDER BY id
-SETTINGS index_granularity = 8192;
+SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 
 SYSTEM STOP MERGES tab;
 -- `materialize_statistics_on_insert` is randomized by the test runner. With statistics materialized,

--- a/tests/queries/0_stateless/04648_query_condition_cache_vector_search.sql
+++ b/tests/queries/0_stateless/04648_query_condition_cache_vector_search.sql
@@ -66,8 +66,11 @@ FROM (EXPLAIN header = 1, indexes = 1
 -- The query itself returns no rows: the index returns rows 0 and 1 as the two nearest neighbours and
 -- both have flag = 0, so the WHERE removes them. An ordinary read would return the two nearest
 -- flag = 1 rows instead, which is why the rows are printed rather than discarded.
+-- Both lazy-materialization settings are randomized by the test runner. Without lazy materialization
+-- the vector rewrite drops the cache-tagged filter and nothing re-tags it, so this section stops
+-- failing on unfixed code. They are pinned so that it keeps proving the non-rescoring write path.
 SELECT 'A vector-search query must NOT write to the query condition cache. It returns no rows.';
-SELECT id FROM tab WHERE flag = 1 ORDER BY L2Distance(vec, [0., 0., 0.]) LIMIT 2 SETTINGS vector_search_with_rescoring = 0, use_query_condition_cache = 1;
+SELECT id FROM tab WHERE flag = 1 ORDER BY L2Distance(vec, [0., 0., 0.]) LIMIT 2 SETTINGS vector_search_with_rescoring = 0, use_query_condition_cache = 1, query_plan_optimize_lazy_materialization = 1, query_plan_max_limit_for_lazy_materialization = 10;
 SELECT count() FROM system.query_condition_cache;
 
 SELECT 'A later ordinary query must still find all 298 rows.';

--- a/tests/queries/0_stateless/04648_query_condition_cache_vector_search.sql
+++ b/tests/queries/0_stateless/04648_query_condition_cache_vector_search.sql
@@ -1,4 +1,8 @@
--- Tags: no-parallel, no-parallel-replicas
+-- Tags: no-fasttest, no-ordinary-database, no-parallel, no-parallel-replicas
+-- no-fasttest: the Fast test build has no USearch, so `vector_similarity` is not a registered index
+--   type there and CREATE TABLE would fail
+-- no-ordinary-database: an Ordinary database gives the table a nil UUID, and the query condition
+--   cache is never written for a nil table UUID
 -- no-parallel: drops the (instance-wide) query condition cache
 -- no-parallel-replicas: the query condition cache is populated per replica, and the vector-search
 --   optimization is disabled for parallel replicas, so the poisoning is not reproducible there
@@ -12,15 +16,22 @@
 -- The vector-search optimization only exists in the new analyzer, so the assertions below are
 -- vacuous under the `old analyzer` CI variant unless it is pinned here.
 SET enable_analyzer = 1;
+-- The plan assertions below read the legacy `EXPLAIN` format; the default `pretty` format rewrites
+-- the step descriptions.
+SET explain_query_plan_default = 'legacy';
 
 DROP TABLE IF EXISTS tab;
 
 -- One part with a single data granule:
 --   rows 0, 1   -> vector near the origin (the nearest neighbours), flag = 0 (fail the WHERE)
 --   rows 2..299 -> vector far away,                                flag = 1 (must stay findable)
+-- `index_granularity` is randomized by the test runner. All 300 rows must land in ONE granule: the
+-- two nearest neighbours have to share a granule with the flag = 1 rows, otherwise the index returns
+-- candidates from a granule the WHERE does accept and the query below returns rows.
 CREATE TABLE tab (id UInt64, flag UInt8, vec Array(Float32),
     INDEX idx vec TYPE vector_similarity('hnsw', 'L2Distance', 3) GRANULARITY 1)
-ENGINE = MergeTree ORDER BY id;
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 8192;
 
 SYSTEM STOP MERGES tab;
 -- `materialize_statistics_on_insert` is randomized by the test runner. With statistics materialized,
@@ -41,8 +52,21 @@ SELECT '--- optimized plan (vector_search_with_rescoring = 0)';
 
 SYSTEM DROP QUERY CONDITION CACHE;
 
-SELECT 'A vector-search query must NOT write to the query condition cache.';
-SELECT id FROM tab WHERE flag = 1 ORDER BY L2Distance(vec, [0., 0., 0.]) LIMIT 2 SETTINGS vector_search_with_rescoring = 0 FORMAT Null;
+-- Every path that makes the vector-search optimization decline produces an ordinary read, whose
+-- output is byte-identical to the intended output below, so the plan is pinned explicitly. The
+-- optimized plan reads the vector index and replaces the vector column by the virtual `_distance`
+-- column.
+SELECT 'The vector index is read and the plan uses `_distance`.';
+SELECT countIf(trimLeft(explain) LIKE 'Description: vector_similarity%') > 0, countIf(explain LIKE '%_distance%') > 0
+FROM (EXPLAIN header = 1, indexes = 1
+    SELECT id FROM tab WHERE flag = 1 ORDER BY L2Distance(vec, [0., 0., 0.]) LIMIT 2
+    SETTINGS vector_search_with_rescoring = 0, use_query_condition_cache = 1);
+
+-- The query itself returns no rows: the index returns rows 0 and 1 as the two nearest neighbours and
+-- both have flag = 0, so the WHERE removes them. An ordinary read would return the two nearest
+-- flag = 1 rows instead, which is why the rows are printed rather than discarded.
+SELECT 'A vector-search query must NOT write to the query condition cache. It returns no rows.';
+SELECT id FROM tab WHERE flag = 1 ORDER BY L2Distance(vec, [0., 0., 0.]) LIMIT 2 SETTINGS vector_search_with_rescoring = 0, use_query_condition_cache = 1;
 SELECT count() FROM system.query_condition_cache;
 
 SELECT 'A later ordinary query must still find all 298 rows.';
@@ -52,8 +76,17 @@ SELECT '--- rescoring plan (vector_search_with_rescoring = 1)';
 
 SYSTEM DROP QUERY CONDITION CACHE;
 
-SELECT 'A vector-search query must NOT write to the query condition cache.';
-SELECT id FROM tab WHERE flag = 1 ORDER BY L2Distance(vec, [0., 0., 0.]) LIMIT 2 SETTINGS vector_search_with_rescoring = 1 FORMAT Null;
+-- The rescoring plan reads the vector index too, but keeps the vector column and re-computes the
+-- distance for the candidate rows, so `_distance` is deliberately absent here (the same expectation
+-- as in 02354_vector_search_rescoring).
+SELECT 'The vector index is read and rescoring does not use `_distance`.';
+SELECT countIf(trimLeft(explain) LIKE 'Description: vector_similarity%') > 0, countIf(explain LIKE '%_distance%') > 0
+FROM (EXPLAIN header = 1, indexes = 1
+    SELECT id FROM tab WHERE flag = 1 ORDER BY L2Distance(vec, [0., 0., 0.]) LIMIT 2
+    SETTINGS vector_search_with_rescoring = 1, use_query_condition_cache = 1);
+
+SELECT 'A vector-search query must NOT write to the query condition cache. It returns no rows.';
+SELECT id FROM tab WHERE flag = 1 ORDER BY L2Distance(vec, [0., 0., 0.]) LIMIT 2 SETTINGS vector_search_with_rescoring = 1, use_query_condition_cache = 1;
 SELECT count() FROM system.query_condition_cache;
 
 SELECT 'A later ordinary query must still find all 298 rows.';

--- a/tests/queries/0_stateless/04648_query_condition_cache_vector_search.sql
+++ b/tests/queries/0_stateless/04648_query_condition_cache_vector_search.sql
@@ -13,7 +13,7 @@
 -- on the granule's other rows. A later ordinary query with the same predicate then skipped the
 -- granule and silently returned fewer rows.
 
--- The vector-search optimization only exists in the new analyzer, so the assertions below are
+-- The vector-search optimization needs the analyzer, so the assertions below are
 -- vacuous under the `old analyzer` CI variant unless it is pinned here.
 SET enable_analyzer = 1;
 -- The plan assertions below read the legacy `EXPLAIN` format; the default `pretty` format rewrites

--- a/tests/queries/0_stateless/04648_query_condition_cache_vector_search.sql
+++ b/tests/queries/0_stateless/04648_query_condition_cache_vector_search.sql
@@ -1,0 +1,81 @@
+-- Tags: no-parallel, no-parallel-replicas
+-- no-parallel: drops the (instance-wide) query condition cache
+-- no-parallel-replicas: the query condition cache is populated per replica, and the vector-search
+--   optimization is disabled for parallel replicas, so the poisoning is not reproducible there
+
+-- A vector-search read narrows every granule to the candidate rows returned by the vector index
+-- before the WHERE filter runs. A granule whose candidates all fail the WHERE was therefore
+-- recorded as "this WHERE predicate matches nothing", although the predicate was never evaluated
+-- on the granule's other rows. A later ordinary query with the same predicate then skipped the
+-- granule and silently returned fewer rows.
+
+-- The vector-search optimization only exists in the new analyzer, so the assertions below are
+-- vacuous under the `old analyzer` CI variant unless it is pinned here.
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS tab;
+
+-- One part with a single data granule:
+--   rows 0, 1   -> vector near the origin (the nearest neighbours), flag = 0 (fail the WHERE)
+--   rows 2..299 -> vector far away,                                flag = 1 (must stay findable)
+CREATE TABLE tab (id UInt64, flag UInt8, vec Array(Float32),
+    INDEX idx vec TYPE vector_similarity('hnsw', 'L2Distance', 3) GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id;
+
+SYSTEM STOP MERGES tab;
+-- `materialize_statistics_on_insert` is randomized by the test runner. With statistics materialized,
+-- implicit column statistics prune the granule of the last control query below before it is read, so
+-- no cache entry is written and the control would stop proving that the guard is narrow.
+INSERT INTO tab SELECT
+    number,
+    if(number < 2, 0, 1),
+    if(number < 2, [toFloat32(number) * 0.001, 0., 0.],
+                   [toFloat32(5000 + number), toFloat32(5000 + number), toFloat32(5000 + number)])
+FROM numbers(300)
+SETTINGS materialize_statistics_on_insert = 0;
+
+SELECT 'The table contains 298 rows with flag = 1.';
+SELECT count() FROM tab WHERE flag = 1 SETTINGS use_query_condition_cache = 0;
+
+SELECT '--- optimized plan (vector_search_with_rescoring = 0)';
+
+SYSTEM DROP QUERY CONDITION CACHE;
+
+SELECT 'A vector-search query must NOT write to the query condition cache.';
+SELECT id FROM tab WHERE flag = 1 ORDER BY L2Distance(vec, [0., 0., 0.]) LIMIT 2 SETTINGS vector_search_with_rescoring = 0 FORMAT Null;
+SELECT count() FROM system.query_condition_cache;
+
+SELECT 'A later ordinary query must still find all 298 rows.';
+SELECT count() FROM tab WHERE flag = 1 SETTINGS use_query_condition_cache = 1;
+
+SELECT '--- rescoring plan (vector_search_with_rescoring = 1)';
+
+SYSTEM DROP QUERY CONDITION CACHE;
+
+SELECT 'A vector-search query must NOT write to the query condition cache.';
+SELECT id FROM tab WHERE flag = 1 ORDER BY L2Distance(vec, [0., 0., 0.]) LIMIT 2 SETTINGS vector_search_with_rescoring = 1 FORMAT Null;
+SELECT count() FROM system.query_condition_cache;
+
+SELECT 'A later ordinary query must still find all 298 rows.';
+SELECT count() FROM tab WHERE flag = 1 SETTINGS use_query_condition_cache = 1;
+
+SELECT '--- the query condition cache stays enabled for reads without the vector optimization';
+
+SYSTEM DROP QUERY CONDITION CACHE;
+
+SELECT 'An ordinary query still writes to the query condition cache.';
+SELECT count() FROM tab WHERE flag = 7 SETTINGS use_query_condition_cache = 1 FORMAT Null;
+SELECT count() FROM system.query_condition_cache;
+
+SYSTEM DROP QUERY CONDITION CACHE;
+
+-- An explicit PREWHERE turns the vector-search optimization off, so no candidate-row filter runs
+-- ahead of the filter and the cache entry is sound. This pins that the guard is narrow.
+SELECT 'A vector-search query with an explicit PREWHERE still writes to the query condition cache.';
+SELECT id FROM tab PREWHERE flag = 1 ORDER BY L2Distance(vec, [0., 0., 0.]) LIMIT 2 SETTINGS use_query_condition_cache = 1 FORMAT Null;
+SELECT count() FROM system.query_condition_cache;
+
+SELECT 'And that entry does not lose rows either.';
+SELECT count() FROM tab WHERE flag = 1 SETTINGS use_query_condition_cache = 1;
+
+DROP TABLE tab;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/111492


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes wrong results caused by a vector-search query poisoning the query condition cache. A `SELECT ... WHERE <condition> ORDER BY <distance function> LIMIT n` query over a table with a `vector_similarity` index could record granules as not matching `<condition>`, so a later ordinary `SELECT ... WHERE <condition>` on the same table silently returned fewer rows. Vector-search reads no longer write to the query condition cache.


### Description

A vector-similarity index read narrows every granule to the candidate rows returned by the index **before** the `WHERE` filter runs. If none of a granule's candidate rows satisfies the `WHERE`, `FilterTransform` observes zero surviving rows and records that granule's mark in the query condition cache as "this predicate matches nothing" — although the predicate was never evaluated on the granule's other rows. Because the cache key encodes only the filter predicate, a later ordinary query with the same predicate reads that entry, skips the granule and silently loses rows.

Reproducer on `master` (all settings default):

```sql
CREATE TABLE tab (id UInt64, flag UInt8, vec Array(Float32),
    INDEX idx vec TYPE vector_similarity('hnsw', 'L2Distance', 3) GRANULARITY 1)
ENGINE = MergeTree ORDER BY id;

-- rows 0, 1 are the nearest neighbours and have flag = 0; rows 2..299 have flag = 1
INSERT INTO tab SELECT number, if(number < 2, 0, 1),
    if(number < 2, [toFloat32(number) * 0.001, 0., 0.],
                   [toFloat32(5000 + number), toFloat32(5000 + number), toFloat32(5000 + number)])
FROM numbers(300);

SELECT id FROM tab WHERE flag = 1 ORDER BY L2Distance(vec, [0., 0., 0.]) LIMIT 2 FORMAT Null;

SELECT count() FROM tab WHERE flag = 1;                                    -- 0     <-- wrong
SELECT count() FROM tab WHERE flag = 1 SETTINGS use_query_condition_cache = 0;  -- 298
```

Both vector-search plans are affected: the optimized `_distance` plan (`vector_search_with_rescoring = 0`, the default) and the rescoring plan (`= 1`).

The fix disables the query condition cache for the read step whenever the vector-search optimization is actually applied, which is the same approach already taken for `SAMPLE` in `ReadFromMergeTree::initializePipeline` ("SAMPLE-ing narrows the marks too, but the query condition cache cache key encodes only the WHERE predicate"). It also completes a guard set the codebase already asserts twice for vector search:

- `MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache` — cache **reads** are already excluded (`/// vector search has filter in the ORDER BY`).
- `ReadFromMergeTree::selectRangesToRead` — index-analysis **writes** are already excluded (`/// Vector search filters through the ORDER BY, so excluded ranges are not described by the WHERE DAG hash alone.`).
- The runtime **write** paths were not excluded. This PR excludes them.

The guard is deliberately keyed on `vector_optimization_applied` rather than on `getVectorSearchParameters().has_value()`: the second pass can bail out (explicit `PREWHERE`, parallel replicas, the search column being selected, and so on), and in that case the read is an ordinary read with no candidate-row filter, so the cache stays sound and remains enabled. Setting the flag on the read step covers both runtime writers — the `WHERE` writer in `FilterTransform` and the `PREWHERE` writer in `MergeTreeSelectProcessor` — because `initializePipeline` turns it into `reader_settings.use_query_condition_cache = false`, and `ReadFromMergeTree::clone` propagates it.

Vector-search queries lose nothing measurable: they already never read from the query condition cache, so only an unsound write is removed.

The new test pins the plan before it asserts anything about the cache: an `EXPLAIN` projection per vector plan checks that the vector index is really read (and that `_distance` is used by the optimized plan but not by the rescoring plan), so a silently declining optimization fails the test instead of passing it vacuously. It then asserts the vector query's own rows (none - both index candidates have `flag = 0`), the cache state (no entry is written) and the user-visible consequence (the later ordinary query still returns all 298 rows). Two negative controls prove the guard is narrow: an ordinary query and a vector query whose second pass bails out must both still populate the cache.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.416` (included in `26.8` and later)
<!-- ch-version-info:end -->