### PR TITLE
Unthrottle mutations in 02899_restore_parts_replicated_merge_tree

### DIFF
--- a/tests/queries/0_stateless/02899_restore_parts_replicated_merge_tree.sh
+++ b/tests/queries/0_stateless/02899_restore_parts_replicated_merge_tree.sh
@@ -9,11 +9,9 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS table_with_unsuccessful_commits"
 
 # will be flaky in 2031
-# number_of_free_entries_in_pool_to_execute_mutation=0 unthrottles the mutations below. Concurrent
-# tests can hold enough of the server-global merges/mutations pool that the default threshold refuses
-# to assign a mutation; that refusal re-arms the merge-selecting backoff, which the OPTIMIZE FINAL
-# loop below has already driven to its 60s ceiling, and no wake-up fires when the pool frees up. The
-# mutations_sync=2 ALTERs then wait past the 60s max_execution_time of the Fast test profile.
+# `number_of_free_entries_in_pool_to_execute_mutation = 0` isolates this table's mutations from global
+# pool contention: concurrent tests can occupy enough of the server-global merges/mutations pool that
+# the default threshold refuses to assign a mutation, and nothing wakes assignment when it frees up.
 $CLICKHOUSE_CLIENT --query "CREATE TABLE table_with_unsuccessful_commits (key UInt64, value String) ENGINE ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/unsuccessful', '1') ORDER BY tuple() SETTINGS cleanup_delay_period=1000, max_cleanup_delay_period=1000, old_parts_lifetime = 1949748529, remove_rolled_back_parts_immediately=0, replicated_max_ratio_of_wrong_parts=1, max_suspicious_broken_parts=1000000, max_suspicious_broken_parts_bytes=10000000000, number_of_free_entries_in_pool_to_execute_mutation=0"
 
 $CLICKHOUSE_CLIENT --query "INSERT INTO table_with_unsuccessful_commits SELECT rand(), toString(rand()) FROM numbers(10)"

--- a/tests/queries/0_stateless/02899_restore_parts_replicated_merge_tree.sh
+++ b/tests/queries/0_stateless/02899_restore_parts_replicated_merge_tree.sh
@@ -9,7 +9,12 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS table_with_unsuccessful_commits"
 
 # will be flaky in 2031
-$CLICKHOUSE_CLIENT --query "CREATE TABLE table_with_unsuccessful_commits (key UInt64, value String) ENGINE ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/unsuccessful', '1') ORDER BY tuple() SETTINGS cleanup_delay_period=1000, max_cleanup_delay_period=1000, old_parts_lifetime = 1949748529, remove_rolled_back_parts_immediately=0, replicated_max_ratio_of_wrong_parts=1, max_suspicious_broken_parts=1000000, max_suspicious_broken_parts_bytes=10000000000"
+# number_of_free_entries_in_pool_to_execute_mutation=0 unthrottles the mutations below. Concurrent
+# tests can hold enough of the server-global merges/mutations pool that the default threshold refuses
+# to assign a mutation; that refusal re-arms the merge-selecting backoff, which the OPTIMIZE FINAL
+# loop below has already driven to its 60s ceiling, and no wake-up fires when the pool frees up. The
+# mutations_sync=2 ALTERs then wait past the 60s max_execution_time of the Fast test profile.
+$CLICKHOUSE_CLIENT --query "CREATE TABLE table_with_unsuccessful_commits (key UInt64, value String) ENGINE ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/unsuccessful', '1') ORDER BY tuple() SETTINGS cleanup_delay_period=1000, max_cleanup_delay_period=1000, old_parts_lifetime = 1949748529, remove_rolled_back_parts_immediately=0, replicated_max_ratio_of_wrong_parts=1, max_suspicious_broken_parts=1000000, max_suspicious_broken_parts_bytes=10000000000, number_of_free_entries_in_pool_to_execute_mutation=0"
 
 $CLICKHOUSE_CLIENT --query "INSERT INTO table_with_unsuccessful_commits SELECT rand(), toString(rand()) FROM numbers(10)"
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/110935

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`02899_restore_parts_replicated_merge_tree` intermittently fails on `Fast test` and
`Fast test (arm_darwin)`. The runner kills the test at its per-test budget while one of the
`mutations_sync=2` ALTERs is still in flight:

```
[ 2086 / 12705] 02899_restore_parts_replicated_merge_tree:   [ FAIL ] 60.16 sec.
Reason: Timeout! Killing process group 64263
...
64584 clickhouse-client ... --query ALTER TABLE table_with_unsuccessful_commits DELETE WHERE value = 'hello' SETTINGS mutations_sync=2
```

The process list at kill time names the blocking statement in both failing runs. On the
server side that ALTER is then terminated by the shutdown that follows the kill:

```
Code: 341. DB::Exception: Mutation is not finished because table shutdown was called.
It will be done after table restart. (UNFINISHED) (version 26.8.1.1)
... TCPHandler: Processed in 59.129 sec.
```

The 60 s that expires is `clickhouse-test --timeout 60`, which only the Fast test jobs pass
(`ci/jobs/fast_test.py:378` is the sole `--timeout 60` in all of `ci/`); it is enforced by
`proc.wait(args.timeout)` at `tests/clickhouse-test:3516` and the process-group kill at
`:695`. Every other stateless job leaves the 600 s default, which is why only these two
jobs can turn a ~60 s stall into a failure. (Note in passing that
`tests/config/users.d/limits_fast.yaml`, which would pin a server-side
`max_execution_time: 60`, is in fact never installed: `tests/config/install.sh:273-275`
gates its symlink on `[[ $(is_fast_build) == 1 ]]`, but `is_fast_build` only `return`s an
exit code and prints nothing, so the substitution is always empty. That is a separate
issue and not addressed here.)

This is a blocking wait, not a slow run. The measured quantity is the runner's per-test
wall clock (`test_duration_ms`): over 30 days the maximum *passing* test duration is 7.51 s
on `Fast test` and 13.59 s on `Fast test (arm_darwin)` against the 60 s per-test cap, the
12-59 s band is essentially empty, and both failures sit exactly at the cap.

#### Root cause

`StorageReplicatedMergeTree::mutate` creates the mutation znode, schedules
`mergeSelectingTask` and waits. That task asks
`CompactionStatistics::getMaxSourcePartBytesForMutation`, whose pool guard is

```cpp
// Compaction/CompactionStatistics.cpp:155
if (occupied <= 1 || max_tasks_count - occupied >= number_of_free_entries_in_pool_to_execute_mutation)
```

`occupied` is the **server-global** `CurrentMetrics::BackgroundMergesAndMutationsPoolTask`
gauge, so it is driven by whatever else the server happens to be doing — in CI, the other
tests running in parallel, not this test. When the inequality fails the function returns
0 and `StorageReplicatedMergeTree.cpp:4527` returns `AttemptStatus::Limited`, so no
`MUTATE_PART` log entry is created and `waitMutationToFinishOnReplicas` just spins its
one-second recheck loop. The failing job's own server log shows the refusal:

```
max_tasks_count (32) - occupied (25) < number_of_free_entries_in_pool_to_execute_mutation (8)
```

What turns a transient refusal into a 60 s stall is that nothing re-attempts the
assignment promptly. The reschedule block at the end of `mergeSelectingTask` is

```cpp
// StorageReplicatedMergeTree.cpp:4579-4584 (settings accessors elided for readability)
Float32 new_sleep_ms = static_cast<Float32>(merge_selecting_sleep_ms);
if (result == AttemptStatus::EntryCreated || result == AttemptStatus::NeedRetry)
    new_sleep_ms /= merge_selecting_sleep_slowdown_factor;
else if (result == AttemptStatus::CannotSelect)
    new_sleep_ms *= merge_selecting_sleep_slowdown_factor;
new_sleep_ms *= std::uniform_real_distribution<Float32>(1.f, 1.1f)(thread_local_rng);
```

so the next attempt is `scheduleAfter(merge_selecting_sleep_ms)` (`:4594`), and the
interval is only ever shortened by an attempt that *succeeded*. In the failing job the
interval was already at its `max_merge_selecting_sleep_ms` ceiling of 60000 ms when the
mutation was created, driven there by the `OPTIMIZE ... FINAL` loop's `CannotSelect`
returns, and the refusals simply re-armed it:

```
00:32:08.944182 Scheduling next merge selecting task after 60000ms, current attempt status: CannotSelect
00:32:09.005420 Created mutation with ID 0000000000 (data versions: all = 2; )
00:32:09.005701 ... there are not enough free threads for mutations (max_tasks_count (32) - occupied (25) < ...(8))
00:32:09.005712 Scheduling next merge selecting task after 60000ms, current attempt status: Limited
```

After that line the table's merge-selecting task does not run again at all: for the
following 58 s the only log lines for this table are `Failed to wait for mutation
'0000000000', will recheck` (58 of them, roughly one per second), until the runner's kill
triggers shutdown at `00:33:07`. Note the asymmetry that makes this self-inflicted rather
than merely unlucky: `Limited` matches neither branch above, so a refusal never shortens
the interval, yet the unconditional jitter multiply on the last line means a run of
refusals can only *lengthen* it — measured on the reproduction, starting from the
`merge_selecting_sleep_ms` floor rather than the ceiling, 20 consecutive `Limited`
attempts went `5052 -> 15389 ms` (mean ratio 1.0607, 3.05x overall). So the same stall is
reachable with or without the `OPTIMIZE ... FINAL` loop.

Nor does anything wake the assigner when pool slots free up again. Tree-wide there are
eight `merge_selecting_task->schedule()` sites — `StorageReplicatedMergeTree.cpp:4590`,
`:5691`, `:7154`, `:8493`, `MergeFromLogEntryTask.cpp:493`,
`MutateFromLogEntryTask.cpp:346`, `ReplicatedMergeTreeQueue.cpp:1276` and
`ReplicatedMergeTreeSink.cpp:1220` — and none of them fires for this table in this
situation. `:8493` is the one in `mutate` and has already fired; the two
`finish_callback`s in `MergeFromLogEntryTask` / `MutateFromLogEntryTask` are per-table
(they run when *this* table's own merge or mutation completes, not when some other table
releases a slot, which is what `occupied` is counting); `:5691` and
`ReplicatedMergeTreeSink.cpp:1220` need a local commit or INSERT that the blocked test is
not doing; `:7154` is the metadata-ALTER path; and `ReplicatedMergeTreeQueue.cpp:1276`
only runs when `updateMutations` actually loads new entries. So the blocker clears in
milliseconds, the assigner stays asleep for a full minute, and the runner's 60 s per-test
budget expires first.

#### The fix

Set `number_of_free_entries_in_pool_to_execute_mutation = 0` on this test's table.

With the threshold at 0, `max_tasks_count - occupied >= 0` is always true, so
`getMaxSourcePartBytesForMutation` can never return 0 for pool reasons and the `Limited`
return at `:4527` becomes unreachable for this table. The mutation is assigned on the
first merge-selecting attempt, with no dependence on how long the backoff sleeps. `= 0`
is always a legal value — `MergeTreeSettings.cpp:2489` rejects only values *greater than*
`background_pool_size * background_merges_mutations_concurrency_ratio`.

This is the remedy a maintainer already applied to the same starvation in
`03518_alter_logical_race.sh` ("Disable the throttles that defer `MODIFY COLUMN`'s data
mutation behind merges: under this test's concurrent INSERT load they can starve the first
mutation"), and 12 further stateless tests set this setting to 0 for the same purpose.

I deliberately did not pin the sleep ceiling instead: that bounds the symptom and makes
the table poll ZooKeeper more often for its whole lifetime, whereas removing the refusal
changes no interval at all. The reproduction confirms the distinction — with the fix the
backoff still reaches its 60 s ceiling (six `after 60000ms, current attempt status:
CannotSelect`) and the ALTER completes in 0 s, so a saturated sleep on its own is
harmless; only the `Limited` refusal blocks assignment. This also means the fix is
indifferent to which of the two routes to a long interval a given run took.

I also did not add a `no-random-*` tag: none of the five relevant settings appears among
the 61 keys of `MergeTreeSettingsRandomizer`, so the runner cannot move them.

#### Verification

Note that CI does not run at the shipped default of this setting:
`tests/config/config.d/merge_tree.xml:4` overrides
`number_of_free_entries_in_pool_to_execute_mutation` to **8** server-wide, which is the
value in the failing job's log line quoted above. The reproduction below deliberately uses
the stricter shipped default of 20 instead, by shrinking the pool.

Reproduced with a server whose merges/mutations pool is 26 while
`number_of_free_entries_in_pool_to_execute_mutation` stays at its shipped default of 20,
with 7 pool slots held by unrelated tables (the test's own table has no projections, so
its work never contributes), giving `26 - 7 = 19 < 20`:

```
there are not enough free threads for mutations
(max_tasks_count (26) - occupied (7) < number_of_free_entries_in_pool_to_execute_mutation (20)),
so won't select new parts to merge or mutate.
```

A/B on the same binary, same fixture, differing only in that setting:

| | ALTER result | elapsed |
|---|---|---|
| without the setting | `Code: 159 TIMEOUT_EXCEEDED` | 61 s |
| with the setting | success | 0 s |

Through `clickhouse-test` with its normal randomized settings, on the same server: the
current version of the test **fails** (`Having 1 errors!`, the 60 s timeout on the
`mutations_sync=2` ALTER, reported via stderr since the shell does not check exit codes),
the fixed version **passes** in 6.6 s.

Mechanism check, per-arm, scoped to each arm's own table: `there are not enough free
threads for mutations` 20 -> 0, `current attempt status: Limited` 20 -> 0, and the
`waitMutationToFinishOnReplicas` recheck spins 60 -> 0. With the fix the `MUTATE_PART`
entry appears 5 ms after the mutation znode is created.

`--test-runs 50` with default randomization, under the same sustained pool pressure:
50/50 passed, 5.79-6.24 s per run.

I swept the other stateless tests for the same shape (ReplicatedMergeTree, a synchronous
mutation, an `OPTIMIZE ... FINAL`, and neither of the two protections). An earlier revision
of this description named `04144_skip_index_after_alter_modify_column_replicated` as the
same class and promised a follow-up. That was wrong and there is no follow-up:
`StorageReplicatedMergeTree::optimize` never reads `mutations_sync` (its only two readers
in `src/` are `StorageMergeTree.cpp:1126` and `StorageReplicatedMergeTree.cpp:8509`), so
that test cannot reach this mechanism. Its two `Timeout!` hits are one pull request at one
commit, built with `enable_block_number_column` and `enable_block_offset_column` defaulted
to `true`; the same pull request reverted that before merging, and the test has 0
timeout-shaped failures in about 155000 runs since.

No related open issue found for this test.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.980` (included in `26.8` and later)
<!-- ch-version-info:end -->