### PR TITLE
Stabilize test_split_cache_system_files_no_eviction test

### DIFF
--- a/tests/integration/test_filesystem_split_cache/test.py
+++ b/tests/integration/test_filesystem_split_cache/test.py
@@ -165,49 +165,59 @@ def test_split_cache_system_files_no_eviction(started_cluster, storage_policy):
     node.restart_clickhouse()
     wait_for_cache_initialized(node, storage_policy)
 
-    def get_system_cache_count():
-        return int(
+    def system_segments():
+        """
+        Identify each cached System segment, not just how many there are: a count can stay the
+        same (or grow) while the original segments are evicted and replaced by different ones.
+        """
+        return set(
             node.query(
-                f"SELECT count(*) FROM system.filesystem_cache WHERE cache_name = '{filesystem_cache_name}' AND segment_type='System'"
+                f"SELECT key, file_segment_range_begin, size FROM system.filesystem_cache "
+                f"WHERE cache_name = '{filesystem_cache_name}' AND segment_type = 'System' AND size > 0"
             )
+            .strip()
+            .splitlines()
         )
 
-    def wait_for_stable_system_cache_count(max_attempts=50):
+    def wait_for_stable_system_segments(max_attempts=50):
         """
         `wait_for_cache_initialized` only reports that the cache became usable; background
-        loading keeps adding System segments afterwards. Sample until the count stops
-        changing, otherwise a partially populated snapshot is compared and the assertions
-        below measure that race instead of eviction.
+        loading keeps adding System segments afterwards. Sample until the set stops changing,
+        otherwise a partially populated snapshot is compared and the assertions below measure
+        that race instead of eviction.
         """
-        previous = -1
+        previous = None
         for _ in range(max_attempts):
-            current = get_system_cache_count()
-            if current > 0 and current == previous:
+            current = system_segments()
+            if current and current == previous:
                 return current
             previous = current
             time.sleep(0.5)
         return previous
 
-    count = wait_for_stable_system_cache_count()
-    assert count > 0
+    baseline = wait_for_stable_system_segments()
+    assert len(baseline) > 0
 
-    def assert_no_eviction(current_count):
+    def assert_no_eviction(current):
         """
         System files live in their own cache partition, so the full scan (17 MiB of data through
         a separate 4 MiB data partition) must not push them out, and they must survive a restart.
-        Nothing in this test removes them either: merges are stopped, so no part becomes outdated
-        and no cleanup invalidates their cache entries. The count may only stay the same or grow.
+        Startup and the scan may cache more of them, hence a subset check rather than equality:
+        what must not happen is one of the baseline segments disappearing.
         """
-        assert current_count >= count, f"System cache count dropped: {count} -> {current_count}"
+        evicted = baseline - current
+        assert not evicted, (
+            f"{len(evicted)} of {len(baseline)} System segments were evicted, e.g. {sorted(evicted)[:5]}"
+        )
 
     node.query("SELECT * FROM t0 FORMAT NULL")
 
-    assert_no_eviction(get_system_cache_count())
+    assert_no_eviction(system_segments())
 
     node.restart_clickhouse()
     wait_for_cache_initialized(node, storage_policy)
     # Same race as the baseline: a cache that is still reloading looks like eviction, so only
-    # compare once the count has settled.
-    assert_no_eviction(wait_for_stable_system_cache_count())
+    # compare once the set has settled.
+    assert_no_eviction(wait_for_stable_system_segments())
 
     node.query("DROP TABLE t0 SYNC")

--- a/tests/integration/test_filesystem_split_cache/test.py
+++ b/tests/integration/test_filesystem_split_cache/test.py
@@ -184,7 +184,9 @@ def test_split_cache_system_files_no_eviction(started_cluster, storage_policy):
         `wait_for_cache_initialized` only reports that the cache became usable; background
         loading keeps adding System segments afterwards. Sample until the set stops changing,
         otherwise a partially populated snapshot is compared and the assertions below measure
-        that race instead of eviction.
+        that race instead of eviction. Failing to stabilize is itself a test failure, not a
+        signal to fall back to whatever was last observed: a returned-but-still-moving set
+        would let the caller compare against a partial snapshot, defeating this wait entirely.
         """
         previous = None
         for _ in range(max_attempts):
@@ -193,7 +195,10 @@ def test_split_cache_system_files_no_eviction(started_cluster, storage_policy):
                 return current
             previous = current
             time.sleep(0.5)
-        return previous
+        raise Exception(
+            f"System segment set for cache '{filesystem_cache_name}' did not stabilize "
+            f"after {max_attempts} attempts"
+        )
 
     baseline = wait_for_stable_system_segments()
     assert len(baseline) > 0

--- a/tests/integration/test_filesystem_split_cache/test.py
+++ b/tests/integration/test_filesystem_split_cache/test.py
@@ -179,25 +179,32 @@ def test_split_cache_system_files_no_eviction(started_cluster, storage_policy):
             .splitlines()
         )
 
-    def wait_for_stable_system_segments(max_attempts=50):
+    def wait_for_stable_system_segments(required_stable_seconds=3.0, timeout_seconds=30.0):
         """
         `wait_for_cache_initialized` only reports that the cache became usable; background
-        loading keeps adding System segments afterwards. Sample until the set stops changing,
-        otherwise a partially populated snapshot is compared and the assertions below measure
-        that race instead of eviction. Failing to stabilize is itself a test failure, not a
-        signal to fall back to whatever was last observed: a returned-but-still-moving set
-        would let the caller compare against a partial snapshot, defeating this wait entirely.
+        loading keeps adding System segments afterwards, sometimes in batches with a gap
+        between them, so a single repeated sample can land in such a gap and look settled
+        right before the next batch arrives. Require the set to stay unchanged for a
+        continuous window, not just across one poll, before accepting it as the baseline;
+        otherwise the assertions below would compare against a still-partial snapshot,
+        defeating this wait entirely. Failing to reach that window within the timeout is
+        itself a test failure, not a signal to fall back to whatever was last observed.
         """
-        previous = None
-        for _ in range(max_attempts):
-            current = system_segments()
-            if current and current == previous:
-                return current
-            previous = current
+        deadline = time.monotonic() + timeout_seconds
+        current = system_segments()
+        stable_since = time.monotonic()
+        while time.monotonic() < deadline:
             time.sleep(0.5)
+            sample = system_segments()
+            if sample != current:
+                current = sample
+                stable_since = time.monotonic()
+                continue
+            if current and time.monotonic() - stable_since >= required_stable_seconds:
+                return current
         raise Exception(
-            f"System segment set for cache '{filesystem_cache_name}' did not stabilize "
-            f"after {max_attempts} attempts"
+            f"System segment set for cache '{filesystem_cache_name}' did not stay "
+            f"unchanged for {required_stable_seconds}s within {timeout_seconds}s"
         )
 
     baseline = wait_for_stable_system_segments()

--- a/tests/integration/test_filesystem_split_cache/test.py
+++ b/tests/integration/test_filesystem_split_cache/test.py
@@ -165,31 +165,49 @@ def test_split_cache_system_files_no_eviction(started_cluster, storage_policy):
     node.restart_clickhouse()
     wait_for_cache_initialized(node, storage_policy)
 
-    count = int(
-        node.query(
-            f"SELECT count(*) FROM system.filesystem_cache WHERE cache_name = '{filesystem_cache_name}' AND segment_type='System'"
-        )
-    )
-    assert count > 0
-
-    def assert_cache_state():
-        """
-        The state of cache can change with background processes, so make sure that the state does not change dramatically.
-        """
-        current_count = int(
+    def get_system_cache_count():
+        return int(
             node.query(
                 f"SELECT count(*) FROM system.filesystem_cache WHERE cache_name = '{filesystem_cache_name}' AND segment_type='System'"
             )
         )
-        fraction = abs(current_count - count) / count
-        assert fraction <= 0.5, f"System cache count changed too much: {count} -> {current_count}"
+
+    def wait_for_stable_system_cache_count(max_attempts=50):
+        """
+        `wait_for_cache_initialized` only reports that the cache became usable; background
+        loading keeps adding System segments afterwards. Sample until the count stops
+        changing, otherwise a partially populated snapshot is compared and the assertions
+        below measure that race instead of eviction.
+        """
+        previous = -1
+        for _ in range(max_attempts):
+            current = get_system_cache_count()
+            if current > 0 and current == previous:
+                return current
+            previous = current
+            time.sleep(0.5)
+        return previous
+
+    count = wait_for_stable_system_cache_count()
+    assert count > 0
+
+    def assert_no_eviction(current_count):
+        """
+        System files live in their own cache partition, so the full scan (17 MiB of data through
+        a separate 4 MiB data partition) must not push them out, and they must survive a restart.
+        Nothing in this test removes them either: merges are stopped, so no part becomes outdated
+        and no cleanup invalidates their cache entries. The count may only stay the same or grow.
+        """
+        assert current_count >= count, f"System cache count dropped: {count} -> {current_count}"
 
     node.query("SELECT * FROM t0 FORMAT NULL")
 
-    assert_cache_state()
+    assert_no_eviction(get_system_cache_count())
 
     node.restart_clickhouse()
     wait_for_cache_initialized(node, storage_policy)
-    assert_cache_state()
+    # Same race as the baseline: a cache that is still reloading looks like eviction, so only
+    # compare once the count has settled.
+    assert_no_eviction(wait_for_stable_system_cache_count())
 
     node.query("DROP TABLE t0 SYNC")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix flaky `test_filesystem_split_cache::test_split_cache_system_files_no_eviction`.
The baseline System-segment count was sampled straight after `wait_for_cache_initialized`,
which only reports that the cache became usable while background loading keeps adding
segments, so the baseline was a partially populated snapshot (416 or 467 against a steady
state of 701). The assertion was also two-sided (`abs`), so it failed when the count *grew* —
the opposite of what a no-eviction test should check, and the cause of every observed failure.
Both comparison points now sample once the count has settled, and the assertion only fails
on a drop.
Fixes failures like this one https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111406&sha=6282394660bff978c2f06b63ecfd9f27d28b1e97&name_0=PR&name_1=Integration+tests+%28amd_tsan%2C+3%2F6%29

Closes https://github.com/ClickHouse/ClickHouse/issues/112091


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.9.8`, `26.6.7.9`, `26.3.33.82`
<!-- ch-version-info:end -->