### PR TITLE
Backport #111589 to 26.7 without the stray 26.8 settings-history block

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7847,6 +7847,14 @@ When enabled, the analyzer mimics the legacy behavior of moving non-aggregate AN
     DECLARE(Bool, analyzer_compatibility_prefer_alias_over_subcolumn, false, R"(
 When a multi-part identifier like `b.id` could refer to either the column `id` of a table aliased `b` or to a Tuple subcolumn `b.id` of some other column, prefer the alias-prefix interpretation (column `id` of `b`). By default the analyzer prefers the subcolumn. Enable to match the old analyzer's resolution.
 )", 0) \
+    DECLARE(Bool, analyzer_compatibility_apply_final_to_all_joined_tables, false, R"(
+Restores the behavior of versions before 26.6, where the `FINAL` modifier specified on the left-most table of a JOIN was incorrectly applied to all other joined tables as well (for engines that support `FINAL`, e.g. `ReplacingMergeTree`). By default `FINAL` applies only to the table it is written on. Enable for compatibility with queries that rely on the old behavior; the recommended fix is to write `FINAL` explicitly on every table that needs it.
+
+Possible values:
+
+- 0 - `FINAL` applies only to the table it is specified on.
+- 1 - `FINAL` on the left-most table of a JOIN is applied to all joined tables.
+)", 0) \
     DECLARE(Bool, enable_identifier_resolve_cache, true, R"(
 Enable the identifier resolution cache in the query analyzer. The cache shares resolved alias nodes to prevent AST explosion when the same alias is referenced multiple times. Set to false to disable caching if incorrect results are suspected.
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -39,14 +39,6 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// controls new feature and it's 'true' by default, use 'false' as previous_value).
         /// It's used to implement `compatibility` setting (see https://github.com/ClickHouse/ClickHouse/issues/35972)
         /// Note: please check if the key already exists to prevent duplicate entries.
-        addSettingsChanges(settings_changes_history, "26.8",
-        {
-            {"unique_key_probe_implementation", "auto", "auto", "New setting: selects the UNIQUE KEY probe implementation (currently only the simple baseline exists)"},
-            {"allow_lossy_numeric_supertype", false, false, "New setting that lets if/multiIf/coalesce/ifNull/array/map resolve all-numeric branches with no lossless common type (e.g. Decimal + Float64) to a numeric supertype (Float64, with possible precision loss), so the result can be aggregated. Independent of use_variant_as_common_type: with it off such branches previously raised NO_COMMON_TYPE, with it on they became a Variant; either way they now resolve to Float64."},
-            {"analyzer_compatibility_apply_final_to_all_joined_tables", false, false, "New setting on master (default false = the fixed behavior). The behavior flip itself is recorded under 26.6, and the introduction for backports to older release branches (with default true) under 26.4."},
-            {"join_runtime_filter_min_probe_rows", 0, 1000, "New setting to control minimum probe side size for installing JOIN runtime filters. It wasn't limited before, so previous value is 0 meaning always install."},
-            {"query_plan_short_circuit_constant_false_join", false, true, "New setting to short-circuit a JOIN with a constant-false ON condition so the non-contributing side is not read. previous_value=false so `compatibility` with versions before 26.8 restores the pre-existing behavior (no short-circuit)."},
-        });
         addSettingsChanges(settings_changes_history, "26.7",
         {
             {"analyzer_compatibility_allow_non_aggregate_in_having", false, false, "New compatibility setting. When enabled, the analyzer mimics the legacy `HAVING`-to-`WHERE` rewrite for non-aggregate AND-conjuncts instead of raising `NOT_AN_AGGREGATE`."},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -39,6 +39,14 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// controls new feature and it's 'true' by default, use 'false' as previous_value).
         /// It's used to implement `compatibility` setting (see https://github.com/ClickHouse/ClickHouse/issues/35972)
         /// Note: please check if the key already exists to prevent duplicate entries.
+        addSettingsChanges(settings_changes_history, "26.8",
+        {
+            {"unique_key_probe_implementation", "auto", "auto", "New setting: selects the UNIQUE KEY probe implementation (currently only the simple baseline exists)"},
+            {"allow_lossy_numeric_supertype", false, false, "New setting that lets if/multiIf/coalesce/ifNull/array/map resolve all-numeric branches with no lossless common type (e.g. Decimal + Float64) to a numeric supertype (Float64, with possible precision loss), so the result can be aggregated. Independent of use_variant_as_common_type: with it off such branches previously raised NO_COMMON_TYPE, with it on they became a Variant; either way they now resolve to Float64."},
+            {"analyzer_compatibility_apply_final_to_all_joined_tables", false, false, "New setting on master (default false = the fixed behavior). The behavior flip itself is recorded under 26.6, and the introduction for backports to older release branches (with default true) under 26.4."},
+            {"join_runtime_filter_min_probe_rows", 0, 1000, "New setting to control minimum probe side size for installing JOIN runtime filters. It wasn't limited before, so previous value is 0 meaning always install."},
+            {"query_plan_short_circuit_constant_false_join", false, true, "New setting to short-circuit a JOIN with a constant-false ON condition so the non-contributing side is not read. previous_value=false so `compatibility` with versions before 26.8 restores the pre-existing behavior (no short-circuit)."},
+        });
         addSettingsChanges(settings_changes_history, "26.7",
         {
             {"analyzer_compatibility_allow_non_aggregate_in_having", false, false, "New compatibility setting. When enabled, the analyzer mimics the legacy `HAVING`-to-`WHERE` rewrite for non-aggregate AND-conjuncts instead of raising `NOT_AN_AGGREGATE`."},
@@ -101,6 +109,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
 
         addSettingsChanges(settings_changes_history, "26.6",
         {
+            {"analyzer_compatibility_apply_final_to_all_joined_tables", true, false, "Fixed a bug in the analyzer where FINAL on the left-most table of a JOIN was incorrectly applied to the other joined tables as well. previous_value=true so `compatibility` with versions before 26.6 restores the old behavior."},
             {"cloud_mode_database_engine", 1, 1, "Obsolete setting, the database engine in Cloud no longer depends on it."},
             {"output_format_image_width", 1024, 1024, "New setting controlling the width of the output image for image output formats such as PNG."},
             {"output_format_image_height", 1024, 1024, "New setting controlling the height of the output image for image output formats such as PNG."},
@@ -205,6 +214,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         });
         addSettingsChanges(settings_changes_history, "26.4",
         {
+            {"analyzer_compatibility_apply_final_to_all_joined_tables", true, true, "New compatibility setting controlling whether FINAL on the left-most table of a JOIN is applied to the other joined tables. Introduced with default true (the old behavior) for backports to versions before 26.6."},
             {"max_bytes_before_external_join", 0, 0, "New setting to control automatic spilling of hash joins to disk. Non-zero value enables spilling and sets the byte threshold."},
             {"allow_iceberg_remove_orphan_files", false, false, "New setting to gate Iceberg orphan file removal"},
             {"iceberg_orphan_files_older_than_seconds", 259200, 259200, "New setting for default orphan file age threshold"},

--- a/src/Planner/Utils.cpp
+++ b/src/Planner/Utils.cpp
@@ -59,6 +59,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsString additional_result_filter;
+    extern const SettingsBool analyzer_compatibility_apply_final_to_all_joined_tables;
     extern const SettingsUInt64 max_bytes_to_read;
     extern const SettingsUInt64 max_bytes_to_read_leaf;
     extern const SettingsSeconds max_estimated_execution_time;
@@ -559,6 +560,8 @@ SelectQueryInfo buildSelectQueryInfo(const QueryTreeNodePtr & query_tree, const 
     select_query_info.query = queryNodeToSelectQuery(query_tree);
     select_query_info.query_tree = query_tree;
     select_query_info.planner_context = planner_context;
+    select_query_info.apply_query_level_final_if_no_modifiers
+        = planner_context->getQueryContext()->getSettingsRef()[Setting::analyzer_compatibility_apply_final_to_all_joined_tables];
     return select_query_info;
 }
 

--- a/src/Storages/SelectQueryInfo.cpp
+++ b/src/Storages/SelectQueryInfo.cpp
@@ -15,7 +15,7 @@ bool SelectQueryInfo::isFinal() const
     if (table_expression_modifiers)
         return table_expression_modifiers->hasFinal();
 
-    if (query_tree)
+    if (query_tree && !apply_query_level_final_if_no_modifiers)
         return false;
 
     const auto & select = query->as<ASTSelectQuery &>();

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -140,6 +140,12 @@ struct SelectQueryInfo
     /// Table expression modifiers for storage
     std::optional<TableExpressionModifiers> table_expression_modifiers;
 
+    /// Value of the `analyzer_compatibility_apply_final_to_all_joined_tables` setting.
+    /// When true, `isFinal` falls back to the query-level FINAL (the left-most table's modifier)
+    /// for table expressions without their own modifiers, restoring the pre-26.6 behavior
+    /// where FINAL on one table of a JOIN leaked onto the other joined tables.
+    bool apply_query_level_final_if_no_modifiers = false;
+
     std::shared_ptr<const StorageLimitsList> storage_limits;
 
     /// Local storage limits

--- a/tests/queries/0_stateless/04627_analyzer_compatibility_final_all_joined_tables.reference
+++ b/tests/queries/0_stateless/04627_analyzer_compatibility_final_all_joined_tables.reference
@@ -1,0 +1,12 @@
+FINAL on the left table only, default behavior
+2
+FINAL on the left table only, compatibility setting enabled
+1
+FINAL on the left table only, compatibility with an older version
+1
+FINAL on both tables is unaffected by the setting
+1
+1
+FINAL on the right table only does not leak to the left table even with the setting
+2
+2

--- a/tests/queries/0_stateless/04627_analyzer_compatibility_final_all_joined_tables.sql
+++ b/tests/queries/0_stateless/04627_analyzer_compatibility_final_all_joined_tables.sql
@@ -1,0 +1,41 @@
+-- Compatibility setting for the fix of FINAL leaking onto other tables of a JOIN
+-- (https://github.com/ClickHouse/ClickHouse/pull/108979).
+
+DROP TABLE IF EXISTS t_left;
+DROP TABLE IF EXISTS t_right;
+
+CREATE TABLE t_left (id Int64, right_id Int64, ver UInt64) ENGINE = ReplacingMergeTree(ver) ORDER BY id;
+CREATE TABLE t_right (id Int64, attr String, ver UInt64) ENGINE = ReplacingMergeTree(ver) ORDER BY id;
+
+SYSTEM STOP MERGES t_left;
+SYSTEM STOP MERGES t_right;
+
+-- One logical row per table, two unmerged versions each (separate parts).
+INSERT INTO t_left VALUES (1, 10, 1);
+INSERT INTO t_left VALUES (1, 10, 2);
+INSERT INTO t_right VALUES (10, 'car', 1);
+INSERT INTO t_right VALUES (10, 'car', 2);
+
+SELECT 'FINAL on the left table only, default behavior';
+SELECT count() FROM t_left AS l FINAL INNER JOIN t_right AS r ON r.id = l.right_id;
+
+SELECT 'FINAL on the left table only, compatibility setting enabled';
+SELECT count() FROM t_left AS l FINAL INNER JOIN t_right AS r ON r.id = l.right_id
+SETTINGS analyzer_compatibility_apply_final_to_all_joined_tables = 1;
+
+SELECT 'FINAL on the left table only, compatibility with an older version';
+SELECT count() FROM t_left AS l FINAL INNER JOIN t_right AS r ON r.id = l.right_id
+SETTINGS compatibility = '26.5';
+
+SELECT 'FINAL on both tables is unaffected by the setting';
+SELECT count() FROM t_left AS l FINAL INNER JOIN t_right AS r FINAL ON r.id = l.right_id;
+SELECT count() FROM t_left AS l FINAL INNER JOIN t_right AS r FINAL ON r.id = l.right_id
+SETTINGS analyzer_compatibility_apply_final_to_all_joined_tables = 1;
+
+SELECT 'FINAL on the right table only does not leak to the left table even with the setting';
+SELECT count() FROM t_left AS l INNER JOIN t_right AS r FINAL ON r.id = l.right_id;
+SELECT count() FROM t_left AS l INNER JOIN t_right AS r FINAL ON r.id = l.right_id
+SETTINGS analyzer_compatibility_apply_final_to_all_joined_tables = 1;
+
+DROP TABLE t_left;
+DROP TABLE t_right;


### PR DESCRIPTION

<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/111589
Related: https://github.com/ClickHouse/ClickHouse/pull/111978
Related: https://github.com/ClickHouse/ClickHouse/pull/111987
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

This is an alternative to https://github.com/ClickHouse/ClickHouse/pull/111978, which currently fails its CI. It carries the same backport of #111589 to `26.7`, minus the one hunk that causes the failures. @fm4v asked me to fix it; I cannot push to the robot's branch, so this is the same change on a branch of mine. Merge whichever you prefer and close the other.

**What was wrong with #111978.** The automated backport commit `b17829bf545742` imported master's newest version block:

```
addSettingsChanges(settings_changes_history, "26.8", { ... 5 settings ... });
```

`origin/26.7` has no `26.8` block, and four of that block's five settings do not exist anywhere in the `26.7` tree (`git grep` finds each only in `SettingsChangesHistory.cpp` itself): `unique_key_probe_implementation`, `allow_lossy_numeric_supertype`, `join_runtime_filter_min_probe_rows`, `query_plan_short_circuit_constant_false_join`. The `26.8` header itself came from the unrelated master commit `bce71f11a6875d`.

`SettingsImpl::applyCompatibilitySetting` (`src/Core/Settings.cpp`) walks the history newest-first and calls `getTier(final_name)` for every entry of every version above the requested one; `BaseSettings::getTier` reaches `throwSettingNotFound` for a name the build does not have. So on `b17829bf545742` **every** `compatibility` value below `26.8` fails with `Code: 115 UNKNOWN_SETTING`, which is what breaks the stateless suite, the stress smoke run and all eight integration shards on that PR.

**This PR** keeps only the two entries the backport actually needs: the `26.6` behaviour flip (`true` -> `false`) and the `26.4` introduction (`true`, `true`). That is byte-for-byte what the already-merged `26.6` sibling #111987 does, and it preserves the release-branch invariant that the newest block equals the branch version.

**Verification** (debug build of this branch, `26.7.2.1`, Build ID `a96a132022ece7990b71ca3de723ba6d2bded3e6`):

| `compatibility` | #111978 head `b17829bf545742` | this branch |
|---|---|---|
| `21.1`, `24.7`, `24.9`, `24.10`, `24.11`, `25.6`, `25.8`, `26.4`, `26.5`, `26.6`, `26.7` | `Code: 115 ... Unknown setting 'unique_key_probe_implementation'` | `1` |
| `26.8` | `1` | n/a (no such block on 26.7) |

Reverting just this one hunk and rebuilding reproduces the failing column, and restoring it rebuilds to the identical Build ID, so nothing else in the tree moved.

The backported setting itself resolves correctly through `compatibility`: `26.4` and `26.5` give `true` (the old behaviour), `26.6` and `26.7` give `false`, and the default is `false`. `04627_analyzer_compatibility_final_all_joined_tables` matches its reference.