### PR TITLE
Add time-series codecs to auto-created TimeSeries samples columns

### DIFF
--- a/docs/en/engines/table-engines/integrations/time-series.md
+++ b/docs/en/engines/table-engines/integrations/time-series.md
@@ -106,7 +106,7 @@ This is equivalent to declaring the timestamp and value column types in the samp
 
 ```sql
 CREATE TABLE my_table ENGINE=TimeSeries
-SAMPLES INNER COLUMNS (timestamp UInt32, value Float32)
+SAMPLES INNER COLUMNS (timestamp UInt32 CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(Gorilla, ZSTD(1)))
 ```
 
 If both forms are used in the same `CREATE TABLE` statement, the declared types must match.
@@ -137,10 +137,10 @@ The _samples_ table must have columns:
 | `timestamp` | [x] | `DateTime64(3)` | `DateTime64(X)` | A time point |
 | `value` | [x] | `Float64` | `Float32` or `Float64` | A value associated with the `timestamp` |
 
-When the `timestamp` and `value` columns are created automatically they get time-series compression codecs:
+Columns the engine creates itself get time-series compression codecs:
 `timestamp CODEC(DoubleDelta, ZSTD(1))` and `value CODEC(Gorilla, ZSTD(1))`. Near-monotonic timestamps barely
 compress under generic codecs and can otherwise dominate the on-disk size of the samples table.
-Declare the columns explicitly to use different codecs.
+See also [Adjusting types of columns](#adjusting-column-types).
 
 ### Tags table {#tags-table}
 
@@ -197,8 +197,8 @@ ENGINE = TimeSeries
 SAMPLES INNER COLUMNS
 (
     `id` UUID,
-    `timestamp` DateTime64(3),
-    `value` Float64
+    `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
+    `value` Float64 CODEC(Gorilla, ZSTD(1))
 )
 SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp)
 TAGS INNER COLUMNS
@@ -232,8 +232,8 @@ and each target table has its own set of columns:
 CREATE TABLE default.`.inner_id.samples.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 (
     `id` UUID,
-    `timestamp` DateTime64(3),
-    `value` Float64
+    `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
+    `value` Float64 CODEC(Gorilla(8), ZSTD(1))
 )
 ENGINE = MergeTree
 ORDER BY (id, timestamp)
@@ -280,18 +280,18 @@ The outer column list is regenerated and not copied.
 
 ## Adjusting types of columns {#adjusting-column-types}
 
-You can adjust the types of columns in the inner target tables using the `INNER COLUMNS` clause. For example, to store timestamps in microseconds and values as `Float32`:
+You can adjust the types of columns in the inner target tables using the `INNER COLUMNS` clause. For example, to store timestamps in microseconds and values as `Float32` use:
+
+```sql
+CREATE TABLE my_table ENGINE=TimeSeries
+SAMPLES INNER COLUMNS (timestamp DateTime64(6) CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(Gorilla, ZSTD(1)))
+```
+
+Specifying inner columns without codecs means using the default codec for them:
 
 ```sql
 CREATE TABLE my_table ENGINE=TimeSeries
 SAMPLES INNER COLUMNS (timestamp DateTime64(6), value Float32)
-```
-
-The same clause can be used to specify codecs and other column attributes:
-
-```sql
-CREATE TABLE my_table ENGINE=TimeSeries
-SAMPLES INNER COLUMNS (timestamp DateTime64(3) CODEC(DoubleDelta))
 ```
 
 ## The `id` column {#id-column}

--- a/docs/en/engines/table-engines/integrations/time-series.md
+++ b/docs/en/engines/table-engines/integrations/time-series.md
@@ -137,6 +137,11 @@ The _samples_ table must have columns:
 | `timestamp` | [x] | `DateTime64(3)` | `DateTime64(X)` | A time point |
 | `value` | [x] | `Float64` | `Float32` or `Float64` | A value associated with the `timestamp` |
 
+When the `timestamp` and `value` columns are created automatically they get time-series compression codecs:
+`timestamp CODEC(DoubleDelta, ZSTD(1))` and `value CODEC(Gorilla, ZSTD(1))`. Near-monotonic timestamps barely
+compress under generic codecs and can otherwise dominate the on-disk size of the samples table.
+Declare the columns explicitly to use different codecs.
+
 ### Tags table {#tags-table}
 
 The _tags_ table contains identifiers calculated for each combination of a metric name and tags.

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -766,7 +766,7 @@ This is equivalent to declaring the timestamp and value column types in the samp
 
 ```sql
 CREATE TABLE my_table ENGINE=TimeSeries
-SAMPLES INNER COLUMNS (timestamp UInt32, value Float32)
+SAMPLES INNER COLUMNS (timestamp UInt32 CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(Gorilla, ZSTD(1)))
 ```
 
 If both forms are used in the same `CREATE TABLE` statement, the declared types must match.
@@ -796,6 +796,11 @@ The _samples_ table must have columns:
 | `id` | [x] | `UUID` | any | Identifies a combination of a metric names and tags |
 | `timestamp` | [x] | `DateTime64(3)` | `DateTime64(X)` | A time point |
 | `value` | [x] | `Float64` | `Float32` or `Float64` | A value associated with the `timestamp` |
+
+Columns the engine creates itself get time-series compression codecs:
+`timestamp CODEC(DoubleDelta, ZSTD(1))` and `value CODEC(Gorilla, ZSTD(1))`. Near-monotonic timestamps barely
+compress under generic codecs and can otherwise dominate the on-disk size of the samples table.
+See also [Adjusting types of columns](#adjusting-column-types).
 
 ### Tags table {#tags-table}
 
@@ -852,8 +857,8 @@ ENGINE = TimeSeries
 SAMPLES INNER COLUMNS
 (
     `id` UUID,
-    `timestamp` DateTime64(3),
-    `value` Float64
+    `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
+    `value` Float64 CODEC(Gorilla, ZSTD(1))
 )
 SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp)
 TAGS INNER COLUMNS
@@ -887,8 +892,8 @@ and each target table has its own set of columns:
 CREATE TABLE default.`.inner_id.samples.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 (
     `id` UUID,
-    `timestamp` DateTime64(3),
-    `value` Float64
+    `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
+    `value` Float64 CODEC(Gorilla(8), ZSTD(1))
 )
 ENGINE = MergeTree
 ORDER BY (id, timestamp)
@@ -935,18 +940,18 @@ The outer column list is regenerated and not copied.
 
 ## Adjusting types of columns {#adjusting-column-types}
 
-You can adjust the types of columns in the inner target tables using the `INNER COLUMNS` clause. For example, to store timestamps in microseconds and values as `Float32`:
+You can adjust the types of columns in the inner target tables using the `INNER COLUMNS` clause. For example, to store timestamps in microseconds and values as `Float32` use:
+
+```sql
+CREATE TABLE my_table ENGINE=TimeSeries
+SAMPLES INNER COLUMNS (timestamp DateTime64(6) CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(Gorilla, ZSTD(1)))
+```
+
+Specifying inner columns without codecs means using the default codec for them:
 
 ```sql
 CREATE TABLE my_table ENGINE=TimeSeries
 SAMPLES INNER COLUMNS (timestamp DateTime64(6), value Float32)
-```
-
-The same clause can be used to specify codecs and other column attributes:
-
-```sql
-CREATE TABLE my_table ENGINE=TimeSeries
-SAMPLES INNER COLUMNS (timestamp DateTime64(3) CODEC(DoubleDelta))
 ```
 
 ## The `id` column {#id-column}

--- a/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
+++ b/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
@@ -366,22 +366,22 @@ namespace
         auto new_list = make_intrusive<ASTExpressionList>();
         bool changed = false;
 
-        /// If `name` exists in `original`, move it to new_list (erasing from map) and return false.
-        /// Otherwise create a new column with `type_ast`, mark `changed`, and return true.
-        auto add_column_if_missing = [&](const String & name, ASTPtr type_ast) -> bool
+        /// If `name` exists in `original`, move it to new_list (erasing from map) and return nullptr.
+        /// Otherwise create a new column with `type_ast`, mark `changed`, and return the new declaration.
+        auto add_column_if_missing = [&](const String & name, ASTPtr type_ast) -> ASTColumnDeclaration *
         {
             if (auto it = original.find(name); it != original.end())
             {
                 new_list->children.push_back(it->second);
                 original.erase(it);
-                return false;
+                return nullptr;
             }
             auto decl = make_intrusive<ASTColumnDeclaration>();
             decl->name = name;
             decl->setType(std::move(type_ast));
             new_list->children.push_back(decl);
             changed = true;
-            return true;
+            return decl.get();
         };
 
         switch (inner_table_kind)
@@ -398,17 +398,16 @@ namespace
                 /// (>90% of on-disk bytes on a scrape-like corpus). All types accepted by the validation
                 /// above are compatible: DoubleDelta takes DateTime64/DateTime/UInt32, Gorilla takes
                 /// Float64/Float32. Explicitly declared columns keep whatever the user wrote.
-                auto set_codec_for_new_column = [&](const char * codec_name)
+                auto make_codec = [](const char * codec_name)
                 {
-                    auto & decl = new_list->children.back()->as<ASTColumnDeclaration &>();
-                    decl.setCodec(makeASTFunction("CODEC",
+                    return makeASTFunction("CODEC",
                         make_intrusive<ASTIdentifier>(codec_name),
-                        makeASTFunction("ZSTD", make_intrusive<ASTLiteral>(UInt64{1}))));
+                        makeASTFunction("ZSTD", make_intrusive<ASTLiteral>(UInt64{1})));
                 };
-                if (add_column_if_missing(TimeSeriesColumnNames::Timestamp, dataTypeToAST(resolved_types.timestamp_type)))
-                    set_codec_for_new_column("DoubleDelta");
-                if (add_column_if_missing(TimeSeriesColumnNames::Value, dataTypeToAST(resolved_types.scalar_type)))
-                    set_codec_for_new_column("Gorilla");
+                if (auto * timestamp_decl = add_column_if_missing(TimeSeriesColumnNames::Timestamp, dataTypeToAST(resolved_types.timestamp_type)))
+                    timestamp_decl->setCodec(make_codec("DoubleDelta"));
+                if (auto * value_decl = add_column_if_missing(TimeSeriesColumnNames::Value, dataTypeToAST(resolved_types.scalar_type)))
+                    value_decl->setCodec(make_codec("Gorilla"));
 
                 break;
             }
@@ -450,15 +449,11 @@ namespace
                 /// Column "all_tags" is ephemeral - only used to calculate the "id" column.
                 if (time_series_settings[TimeSeriesSetting::use_all_tags_column_to_generate_id])
                 {
-                    if (add_column_if_missing(TimeSeriesColumnNames::AllTags,
+                    if (auto * all_tags_decl = add_column_if_missing(TimeSeriesColumnNames::AllTags,
                         makeASTDataType("Map", makeASTDataType("String"), makeASTDataType("String"))))
                     {
-                        auto & column = new_list->children.back();
-                        column = column->clone();
-                        auto & new_decl = column->as<ASTColumnDeclaration &>();
-                        new_decl.default_specifier = ColumnDefaultSpecifier::Ephemeral;
-                        new_decl.ephemeral_default = true;
-                        changed = true;
+                        all_tags_decl->default_specifier = ColumnDefaultSpecifier::Ephemeral;
+                        all_tags_decl->ephemeral_default = true;
                     }
                 }
 

--- a/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
+++ b/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
@@ -29,6 +29,7 @@
 #include <Parsers/ASTDataType.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
 #include <Storages/TimeSeries/TimeSeriesSettings.h>
@@ -391,8 +392,23 @@ namespace
                 /// inner table because it depends on columns like "metric_name" or "all_tags" which don't
                 /// exist in samples.
                 add_column_if_missing(TimeSeriesColumnNames::ID, dataTypeToAST(resolved_types.id_type));
-                add_column_if_missing(TimeSeriesColumnNames::Timestamp, dataTypeToAST(resolved_types.timestamp_type));
-                add_column_if_missing(TimeSeriesColumnNames::Value, dataTypeToAST(resolved_types.scalar_type));
+
+                /// Auto-created "timestamp" and "value" columns get time-series codecs: under generic LZ4
+                /// near-monotonic millisecond timestamps barely compress and dominate the table size
+                /// (>90% of on-disk bytes on a scrape-like corpus). All types accepted by the validation
+                /// above are compatible: DoubleDelta takes DateTime64/DateTime/UInt32, Gorilla takes
+                /// Float64/Float32. Explicitly declared columns keep whatever the user wrote.
+                auto set_codec_for_new_column = [&](const char * codec_name)
+                {
+                    auto & decl = new_list->children.back()->as<ASTColumnDeclaration &>();
+                    decl.setCodec(makeASTFunction("CODEC",
+                        make_intrusive<ASTIdentifier>(codec_name),
+                        makeASTFunction("ZSTD", make_intrusive<ASTLiteral>(UInt64{1}))));
+                };
+                if (add_column_if_missing(TimeSeriesColumnNames::Timestamp, dataTypeToAST(resolved_types.timestamp_type)))
+                    set_codec_for_new_column("DoubleDelta");
+                if (add_column_if_missing(TimeSeriesColumnNames::Value, dataTypeToAST(resolved_types.scalar_type)))
+                    set_codec_for_new_column("Gorilla");
 
                 break;
             }

--- a/tests/queries/0_stateless/04600_timeseries_column_validation.reference
+++ b/tests/queries/0_stateless/04600_timeseries_column_validation.reference
@@ -1,6 +1,6 @@
 ok
 Array(Tuple(UInt32, Float32))
-`id` UUID, `timestamp` UInt32, `value` Float32
+`id` UUID, `timestamp` UInt32 CODEC(DoubleDelta, ZSTD(1)), `value` Float32 CODEC(Gorilla, ZSTD(1))
 metric_name	String
 tags	Map(String, String)
 time_series	Array(Tuple(DateTime64(3), Float64))

--- a/tests/queries/0_stateless/04600_timeseries_column_validation.sql
+++ b/tests/queries/0_stateless/04600_timeseries_column_validation.sql
@@ -50,7 +50,9 @@ DROP TABLE ts_valid;
 -- extracting the `SAMPLES INNER COLUMNS` block from the stored definition.
 CREATE TABLE ts_override (time_series Array(Tuple(UInt32, Float32))) ENGINE = TimeSeries;
 SELECT type FROM system.columns WHERE database = currentDatabase() AND table = 'ts_override' AND name = 'time_series';
-SELECT extract(create_table_query, 'SAMPLES INNER COLUMNS \(([^)]*)\)') FROM system.tables WHERE database = currentDatabase() AND name = 'ts_override';
+-- The lazy `(.*?)` anchored at `SAMPLES INNER ENGINE` (instead of `[^)]*`) is needed because the
+-- auto-created columns carry `CODEC(...)` clauses with nested parentheses.
+SELECT extract(create_table_query, 'SAMPLES INNER COLUMNS \((.*?)\) SAMPLES INNER ENGINE') FROM system.tables WHERE database = currentDatabase() AND name = 'ts_override';
 DROP TABLE ts_override;
 
 -- Extra outer columns other than `time_series` (e.g. `metric_name`, `tags`) are NOT rejected: the outer

--- a/tests/queries/0_stateless/04648_timeseries_samples_codecs.reference
+++ b/tests/queries/0_stateless/04648_timeseries_samples_codecs.reference
@@ -1,0 +1,12 @@
+default codecs:
+id	UUID	
+timestamp	DateTime64(3)	CODEC(DoubleDelta, ZSTD(1))
+value	Float64	CODEC(Gorilla(8), ZSTD(1))
+after detach/attach:
+id	UUID	
+timestamp	DateTime64(3)	CODEC(DoubleDelta, ZSTD(1))
+value	Float64	CODEC(Gorilla(8), ZSTD(1))
+explicit columns keep user codecs:
+id	UUID	
+timestamp	DateTime64(3)	
+value	Float64	

--- a/tests/queries/0_stateless/04648_timeseries_samples_codecs.sql
+++ b/tests/queries/0_stateless/04648_timeseries_samples_codecs.sql
@@ -1,0 +1,36 @@
+-- Tags: no-replicated-database
+-- Tag no-replicated-database: the experimental TimeSeries table engine does not round-trip through DatabaseReplicated.
+
+-- Auto-created `timestamp` and `value` columns of the TimeSeries samples inner table
+-- get time-series compression codecs; explicitly declared columns keep the user's codecs
+-- (or none), and the normalized table round-trips through DETACH/ATTACH unchanged.
+
+SET allow_experimental_time_series_table = 1;
+
+DROP TABLE IF EXISTS ts_codecs;
+CREATE TABLE ts_codecs ENGINE = TimeSeries;
+
+SELECT 'default codecs:';
+SELECT name, type, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table LIKE '.inner_id.samples.%' ORDER BY position;
+
+-- The codecs survive a DETACH/ATTACH round-trip and are not applied twice.
+DETACH TABLE ts_codecs;
+ATTACH TABLE ts_codecs;
+
+SELECT 'after detach/attach:';
+SELECT name, type, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table LIKE '.inner_id.samples.%' ORDER BY position;
+
+DROP TABLE ts_codecs;
+
+-- Explicitly declared samples columns keep the user's choice (here: no codec).
+CREATE TABLE ts_explicit ENGINE = TimeSeries
+SAMPLES INNER COLUMNS (id UUID, timestamp DateTime64(3), value Float64)
+SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp);
+
+SELECT 'explicit columns keep user codecs:';
+SELECT name, type, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table LIKE '.inner_id.samples.%' ORDER BY position;
+
+DROP TABLE ts_explicit;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Auto-created `timestamp` and `value` columns of the TimeSeries samples inner table now default to `CODEC(DoubleDelta, ZSTD(1))` and `CODEC(Gorilla, ZSTD(1))` respectively.

### Documentation entry for user-facing changes

Extracted from #111697 (rebased onto master so it can be reviewed independently). Companion PR: #112108 (parallelize the Prometheus query API).

Under generic LZ4, the near-monotonic millisecond timestamps of a scrape-like workload barely compress (ratio ~0.65) and dominate the samples inner table. On a ~15.7B-sample kube-mixin corpus (tsbench, scale 16) the `timestamp` column was 76.3 of 83.1 GiB — 92% of the table — and decompression+deserialization was ~45% of PromQL query CPU. DoubleDelta for timestamps and Gorilla (XOR) for float values are the standard encodings for this kind of data (the same family Prometheus uses natively).

Scope and compatibility:

- Only columns the engine creates itself are affected; explicitly declared samples columns keep whatever codec the user wrote (or none).
- Existing tables are untouched: on ATTACH the columns already exist in the stored DDL, so normalization keeps them as-is (round-trip covered by the new `04648_timeseries_samples_codecs` test).
- All types accepted by the samples-column validation are codec-compatible (timestamp: DateTime64/DateTime/UInt32; value: Float64/Float32).

Measured on the corpus above (debug build): samples storage 82.8 GiB → 30.6 GiB (5.68 → 2.09 bytes/sample); ingest of 15.7B samples unchanged within noise (1095 s → 1037 s); identical results on all 24 benchmark queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.315` (included in `26.8` and later)
<!-- ch-version-info:end -->