### PR TITLE
Report failed HTTP requests in 00265 instead of dropping the evidence

### DIFF
--- a/tests/queries/0_stateless/00265_http_content_type_format_timezone.sh
+++ b/tests/queries/0_stateless/00265_http_content_type_format_timezone.sh
@@ -6,23 +6,47 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 CLICKHOUSE_TIMEZONE_ESCAPED=$($CLICKHOUSE_CLIENT --query="SELECT timezone()" | sed 's/[]\/$*.^+:()[]/\\&/g')
 
-${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}&default_format=JSONCompact" --data-binary @- <<< "SELECT 1" 2>&1 | grep -e '< Content-Type' -e '< X-ClickHouse-Format' -e '< X-ClickHouse-Timezone' | sed "s|$CLICKHOUSE_TIMEZONE_ESCAPED|CLICKHOUSE_TIMEZONE|" | sed 's/\r$//' | sort;
-${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT 1 FORMAT JSON"         2>&1 | grep -e '< Content-Type' -e '< X-ClickHouse-Format' -e '< X-ClickHouse-Timezone' | sed "s|$CLICKHOUSE_TIMEZONE_ESCAPED|CLICKHOUSE_TIMEZONE|" | sed 's/\r$//' | sort;
-${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT 1"                     2>&1 | grep -e '< Content-Type' -e '< X-ClickHouse-Format' -e '< X-ClickHouse-Timezone' | sed "s|$CLICKHOUSE_TIMEZONE_ESCAPED|CLICKHOUSE_TIMEZONE|" | sed 's/\r$//' | sort;
-${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT 1 FORMAT TabSeparated" 2>&1 | grep -e '< Content-Type' -e '< X-ClickHouse-Format' -e '< X-ClickHouse-Timezone' | sed "s|$CLICKHOUSE_TIMEZONE_ESCAPED|CLICKHOUSE_TIMEZONE|" | sed 's/\r$//' | sort;
-${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT 1 FORMAT Vertical"     2>&1 | grep -e '< Content-Type' -e '< X-ClickHouse-Format' -e '< X-ClickHouse-Timezone' | sed "s|$CLICKHOUSE_TIMEZONE_ESCAPED|CLICKHOUSE_TIMEZONE|" | sed 's/\r$//' | sort;
-${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT 1 FORMAT Native"       2>&1 | grep -e '< Content-Type' -e '< X-ClickHouse-Format' -e '< X-ClickHouse-Timezone' | sed "s|$CLICKHOUSE_TIMEZONE_ESCAPED|CLICKHOUSE_TIMEZONE|" | sed 's/\r$//' | sort;
-${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT 1 FORMAT RowBinary"    2>&1 | grep -e '< Content-Type' -e '< X-ClickHouse-Format' -e '< X-ClickHouse-Timezone' | sed "s|$CLICKHOUSE_TIMEZONE_ESCAPED|CLICKHOUSE_TIMEZONE|" | sed 's/\r$//' | sort;
+tmpdir="$(mktemp -d "${CLICKHOUSE_TMP}/00265_http_content_type_format_timezone.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
 
-${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT timezone() SETTINGS session_timezone='Europe/Berlin'" 2>&1 | grep '< X-ClickHouse-Timezone' | grep -v 'GET' | tr -d '\r';
-${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT timezone() SETTINGS session_timezone='Africa/Cairo'"  2>&1 | grep '< X-ClickHouse-Timezone' | grep -v 'GET' | tr -d '\r';
+# Every request below must answer with `X-ClickHouse-Timezone`, including the deliberately failing
+# query, which still reports it. Its absence means the request never reached query execution, e.g.
+# the server refused it before parsing or the connection was reset. Report that on stderr: piping
+# curl's merged output into `grep` drops the diagnostic and leaves only missing header lines.
+# Keep the response body in a file, it is binary for `Native` and `RowBinary`.
+curl_headers() {
+    # Truncate first: on an early transport failure curl never opens -o, so the previous request's
+    # body would be reported as belonging to this one.
+    : > "$tmpdir/body"
+    : > "$tmpdir/diag"
+    ${CLICKHOUSE_CURL} -vsS -o "$tmpdir/body" "$@" 2>"$tmpdir/diag"
+    local rc=$?
+    # Anchored: `Access-Control-Expose-Headers` lists this name on every response.
+    if [ $rc -ne 0 ] || ! grep -qE '^< X-ClickHouse-Timezone:' "$tmpdir/diag"; then
+        echo "HTTP request did not reach query execution (curl exit $rc):" >&2
+        cat "$tmpdir/diag" "$tmpdir/body" >&2
+        return 1
+    fi
+    cat "$tmpdir/diag"
+}
+
+curl_headers "${CLICKHOUSE_URL}&default_format=JSONCompact" --data-binary @- <<< "SELECT 1" | grep -e '< Content-Type' -e '< X-ClickHouse-Format' -e '< X-ClickHouse-Timezone' | sed "s|$CLICKHOUSE_TIMEZONE_ESCAPED|CLICKHOUSE_TIMEZONE|" | sed 's/\r$//' | sort;
+curl_headers "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT 1 FORMAT JSON"         | grep -e '< Content-Type' -e '< X-ClickHouse-Format' -e '< X-ClickHouse-Timezone' | sed "s|$CLICKHOUSE_TIMEZONE_ESCAPED|CLICKHOUSE_TIMEZONE|" | sed 's/\r$//' | sort;
+curl_headers "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT 1"                     | grep -e '< Content-Type' -e '< X-ClickHouse-Format' -e '< X-ClickHouse-Timezone' | sed "s|$CLICKHOUSE_TIMEZONE_ESCAPED|CLICKHOUSE_TIMEZONE|" | sed 's/\r$//' | sort;
+curl_headers "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT 1 FORMAT TabSeparated" | grep -e '< Content-Type' -e '< X-ClickHouse-Format' -e '< X-ClickHouse-Timezone' | sed "s|$CLICKHOUSE_TIMEZONE_ESCAPED|CLICKHOUSE_TIMEZONE|" | sed 's/\r$//' | sort;
+curl_headers "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT 1 FORMAT Vertical"     | grep -e '< Content-Type' -e '< X-ClickHouse-Format' -e '< X-ClickHouse-Timezone' | sed "s|$CLICKHOUSE_TIMEZONE_ESCAPED|CLICKHOUSE_TIMEZONE|" | sed 's/\r$//' | sort;
+curl_headers "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT 1 FORMAT Native"       | grep -e '< Content-Type' -e '< X-ClickHouse-Format' -e '< X-ClickHouse-Timezone' | sed "s|$CLICKHOUSE_TIMEZONE_ESCAPED|CLICKHOUSE_TIMEZONE|" | sed 's/\r$//' | sort;
+curl_headers "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT 1 FORMAT RowBinary"    | grep -e '< Content-Type' -e '< X-ClickHouse-Format' -e '< X-ClickHouse-Timezone' | sed "s|$CLICKHOUSE_TIMEZONE_ESCAPED|CLICKHOUSE_TIMEZONE|" | sed 's/\r$//' | sort;
+
+curl_headers "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT timezone() SETTINGS session_timezone='Europe/Berlin'" | grep '< X-ClickHouse-Timezone' | grep -v 'GET' | tr -d '\r';
+curl_headers "${CLICKHOUSE_URL}" --data-binary @- <<< "SELECT timezone() SETTINGS session_timezone='Africa/Cairo'"  | grep '< X-ClickHouse-Timezone' | grep -v 'GET' | tr -d '\r';
 
 # Not pretty but working way of removing randomized session_timezone for this part of test
 CLICKHOUSE_URL_WO_SESSION_TZ=$(echo "${CLICKHOUSE_URL}" |sed 's/\&session_timezone\=[A-Za-z0-9\/\%\_\-\+\-]*//g' | sed 's/\?session_timezone\=[A-Za-z0-9\/\%\_\-\+\-]*\&/\?/g');
 
-${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL_WO_SESSION_TZ}&session_timezone=Europe/Berlin&query=SELECT+timezone()" 2>&1 | grep '< X-ClickHouse-Timezone' | grep -v 'GET' | tr -d '\r';
-${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL_WO_SESSION_TZ}&session_timezone=America/Denver&query=SELECT+timezone()" 2>&1 | grep '< X-ClickHouse-Timezone' | grep -v 'GET' | tr -d '\r';
+curl_headers "${CLICKHOUSE_URL_WO_SESSION_TZ}&session_timezone=Europe/Berlin&query=SELECT+timezone()" | grep '< X-ClickHouse-Timezone' | grep -v 'GET' | tr -d '\r';
+curl_headers "${CLICKHOUSE_URL_WO_SESSION_TZ}&session_timezone=America/Denver&query=SELECT+timezone()" | grep '< X-ClickHouse-Timezone' | grep -v 'GET' | tr -d '\r';
 # check that proper X-ClickHouse-Timezone returned on query fail
-${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL_WO_SESSION_TZ}&session_timezone=UTC&query=SELECT+intDiv(1,+(3600-timeZoneOffset('2024-05-06+12:00:00'::DateTime)))+SETTINGS+session_timezone+=+'Europe/Lisbon'" 2>&1 | grep '< X-ClickHouse-Timezone' | grep -v 'GET' | tr -d '\r';
+curl_headers "${CLICKHOUSE_URL_WO_SESSION_TZ}&session_timezone=UTC&query=SELECT+intDiv(1,+(3600-timeZoneOffset('2024-05-06+12:00:00'::DateTime)))+SETTINGS+session_timezone+=+'Europe/Lisbon'" | grep '< X-ClickHouse-Timezone' | grep -v 'GET' | tr -d '\r';
 # main query's session_timezone shall be set in header
-${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL_WO_SESSION_TZ}&session_timezone=America/New_York&query=SELECT+1,(SELECT+1+SETTINGS+session_timezone='UTC')+SETTINGS+session_timezone='Europe/Lisbon'" 2>&1 | grep '< X-ClickHouse-Timezone' | grep -v 'GET' | tr -d '\r';
+curl_headers "${CLICKHOUSE_URL_WO_SESSION_TZ}&session_timezone=America/New_York&query=SELECT+1,(SELECT+1+SETTINGS+session_timezone='UTC')+SETTINGS+session_timezone='Europe/Lisbon'" | grep '< X-ClickHouse-Timezone' | grep -v 'GET' | tr -d '\r';

--- a/tests/queries/0_stateless/00265_http_content_type_format_timezone.sh
+++ b/tests/queries/0_stateless/00265_http_content_type_format_timezone.sh
@@ -10,9 +10,11 @@ tmpdir="$(mktemp -d "${CLICKHOUSE_TMP}/00265_http_content_type_format_timezone.X
 trap 'rm -rf "$tmpdir"' EXIT
 
 # Every request below must answer with `X-ClickHouse-Timezone`, including the deliberately failing
-# query, which still reports it. Its absence means the request never reached query execution, e.g.
-# the server refused it before parsing or the connection was reset. Report that on stderr: piping
-# curl's merged output into `grep` drops the diagnostic and leaves only missing header lines.
+# query, which still reports it. A missing header means the request never reached query execution,
+# e.g. the server refused it before parsing; a non-zero `curl` exit means the request itself
+# failed, e.g. the connection was reset, which counts even when the headers had already arrived.
+# Report either on stderr: piping `curl`'s merged output into `grep` drops the diagnostic and
+# leaves only missing header lines.
 # Keep the response body in a file, it is binary for `Native` and `RowBinary`.
 curl_headers() {
     # Truncate first: on an early transport failure curl never opens -o, so the previous request's
@@ -23,7 +25,7 @@ curl_headers() {
     local rc=$?
     # Anchored: `Access-Control-Expose-Headers` lists this name on every response.
     if [ $rc -ne 0 ] || ! grep -qE '^< X-ClickHouse-Timezone:' "$tmpdir/diag"; then
-        echo "HTTP request did not reach query execution (curl exit $rc):" >&2
+        echo "HTTP request failed or did not reach query execution (curl exit $rc):" >&2
         cat "$tmpdir/diag" "$tmpdir/body" >&2
         return 1
     fi


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/111777
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/111777

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`00265_http_content_type_format_timezone` discards the evidence when one of its HTTP
requests fails, so a failed request is reported as a bare `result differs` with no error
text anywhere.

Every one of its 13 invocations has the shape

```
${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}" ... 2>&1 | grep -e '< Content-Type' ... | sort
```

`2>&1` merges curl's diagnostics into the pipe, `grep` drops them, and the pipeline's exit
status is `grep`/`sort`'s rather than curl's. `CLICKHOUSE_CURL` carries no `--fail`
(`tests/queries/shell_config.sh:156`) and stateless `.sh` tests do not `set -e`. Measured
against a listener that accepts and then resets the connection, the current shape yields
`pipeline_rc=0`, empty stdout and **zero bytes** of stderr: the failure leaves no trace at
all, and the only symptom is that whole 3-line header groups are missing from the output.

**Why that matters beyond cosmetics.** `tests/clickhouse-test` already knows how to handle
these runs: `process_result_impl` checks `if stderr:` and returns `FailureReason.STDERR`
*before* the `RESULT_DIFF` branch, and `MESSAGES_TO_RETRY` already contains
`(total) memory limit exceeded`. Because the test deleted curl's stderr, the description
contains only a diff, so the existing retry machinery is blind to it. Of the three
occurrences of this failure recorded in the CI database over 30 days, the one that happened
to let the server's error text through was classified correctly and is retryable today,
while the two that swallowed it produced an unattributable `result differs`. Same trigger,
opposite outcomes, and the difference is entirely the discard.

**What changed.** A local `curl_headers` helper writes curl's `-v` diagnostics to a file and
pipes that file into the existing `grep`/`sed`/`sort` chains unchanged. When curl reports a
non-zero exit status, or when the response carries no `X-ClickHouse-Timezone` header (which
every request here must answer with), it reports curl's own diagnostic and the response body
on stderr instead of letting `grep` eat them. URLs, settings, filter chains and the
`.reference` file are untouched.

Both conditions are needed and neither subsumes the other, which is why the message names
both: a server that refuses the request before parsing answers `200`-style with
`curl` exit `0` and no timezone header, while a connection reset gives a non-zero curl exit.
A response whose headers are complete but whose body is then truncated satisfies the header
condition and is caught by the exit status alone; that shape passes on `master` today and
becomes a loud failure here, which is intended: a request that did not complete should not
be reported as a success.

Three details are load-bearing and each is covered by a mutation test:

* **Classification is by the required response header, not by the exception code.** One
  invocation deliberately runs a failing query (`intDiv` by zero) and the reference
  *expects* its `X-ClickHouse-Timezone` header, so keying on the exception code would
  redden every healthy run. The reference has exactly 13 `X-ClickHouse-Timezone` lines for
  13 invocations, so requiring that header is universal here. The match must stay anchored
  (`^< X-ClickHouse-Timezone:`), because the server lists that name in
  `Access-Control-Expose-Headers` on every response.
* **The response body goes to a file, never a shell variable.** The test requests `Native`
  and `RowBinary`, whose bodies contain NUL; command substitution truncates at the NUL and
  makes bash print `warning: command substitution: ignored null byte in input`, which would
  itself fail the test.
* **Both files are truncated before each request.** On an early transport failure curl never
  opens `-o`, so a previous request's body would otherwise be reported as belonging to this
  one. That is not cosmetic: `(total) memory limit exceeded` is a live `MESSAGES_TO_RETRY`
  entry, so a stale body could attribute a false cause.

**Scope.** Nine sibling stateless tests share the same "run curl verbosely, then grep the
response header lines" shape and are deliberately left out of this PR: each needs its own
error-path reasoning (some of their lines legitimately expect no match, one greps non-2xx
responses on purpose, and two *count* matches, so for those a silently empty response is a
false pass rather than a red, which is worse than the failure fixed here). The shared
`CLICKHOUSE_CURL` definition in `tests/queries/shell_config.sh` is also deliberately
untouched: 319 tests use it and several depend on reading error bodies, non-2xx responses,
or specific curl exit codes.

**Verification.** Healthy requests emit exactly zero bytes of stderr (12 consecutive runs),
the test's stdout is byte-identical to `origin/master`'s output on the same binary
(`sha256 7611820edd3674d2...`, which is also the `.reference` hash), 50/50 randomized runs
pass, and six concurrent copies pass with no temporary-directory collisions. Reverting the
helper makes both real-world failure shapes silent again; dropping the header guard alone,
replacing the body file with command substitution, dropping the truncation, or leaving a
single invocation un-routed each re-break exactly one measured property.