### PR TITLE
Do not construct remote-I/O fibers on AArch64 with MemorySanitizer

### DIFF
--- a/src/Client/ConnectionPoolWithFailover.cpp
+++ b/src/Client/ConnectionPoolWithFailover.cpp
@@ -9,6 +9,7 @@
 #include <base/getFQDNOrHostName.h>
 #include <Common/isLocalAddress.h>
 #include <Common/ProfileEvents.h>
+#include <Common/RemoteAsyncCapability.h>
 #include <Core/Settings.h>
 
 #include <IO/ConnectionTimeouts.h>
@@ -253,7 +254,7 @@ ConnectionPoolWithFailover::tryGetEntry(
         const QualifiedTableName * table_to_check,
         [[maybe_unused]] AsyncCallback async_callback)
 {
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) && CH_FIBERS_SUPPORTED
     if (async_callback)
     {
         ConnectionEstablisherAsync connection_establisher_async(pool, &timeouts, settings, log, table_to_check);

--- a/src/Common/Fiber.h
+++ b/src/Common/Fiber.h
@@ -1,6 +1,7 @@
 #pragma once
 /// BOOST_USE_ASAN, BOOST_USE_MSAN, BOOST_USE_TSAN and BOOST_USE_UCONTEXT are defined via CMake for sanitizer builds.
 #include <base/defines.h>
+#include <Common/RemoteAsyncCapability.h> /// CH_FIBERS_SUPPORTED
 #include <boost/context/fiber.hpp>
 #include <map>
 

--- a/src/Common/RemoteAsyncCapability.h
+++ b/src/Common/RemoteAsyncCapability.h
@@ -2,6 +2,9 @@
 
 #include <base/defines.h> /// MEMORY_SANITIZER, via base/sanitizer_defs.h
 
+/// Both macros below are consumed by `#if`, so they cannot be enums.
+/// NOLINTBEGIN(modernize-macro-to-enum)
+
 /// Whether fibers may be used in this build.
 ///
 /// On AArch64, MemorySanitizer reaches its shadow TLS through the thread pointer (TPIDR_EL0),
@@ -27,3 +30,5 @@
 #else
 #    define CH_REMOTE_ASYNC_IO 0
 #endif
+
+/// NOLINTEND(modernize-macro-to-enum)

--- a/src/Common/RemoteAsyncCapability.h
+++ b/src/Common/RemoteAsyncCapability.h
@@ -19,10 +19,10 @@
 #endif
 
 /// Whether the asynchronous (fiber-backed) remote read/send path is compiled in. This is the
-/// single definition of that condition: RemoteQueryExecutor's guards are written in terms of it,
+/// single definition of that condition: `RemoteQueryExecutor`'s guards are written in terms of it,
 /// so no copy of the condition can drift from it.
 ///
-/// Note that RemoteSource and the epoll/eventfd/timerfd helpers keep their own
+/// Note that `RemoteSource` and the epoll/eventfd/timerfd helpers keep their own
 /// `OS_LINUX || OS_DARWIN` guards - those select platform primitives that exist regardless of
 /// fibers, and are a different condition from this one.
 #if (defined(OS_LINUX) || defined(OS_DARWIN)) && CH_FIBERS_SUPPORTED

--- a/src/Common/RemoteAsyncCapability.h
+++ b/src/Common/RemoteAsyncCapability.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <base/defines.h> /// MEMORY_SANITIZER, via base/sanitizer_defs.h
+
+/// Whether fibers may be used in this build.
+///
+/// On AArch64, MemorySanitizer reaches its shadow TLS through the thread pointer (TPIDR_EL0),
+/// which the compiler may read once and keep in a callee-saved register across a call. A fiber
+/// stack switch inside that call can resume the frame on another OS thread, leaving the cached
+/// pointer naming the old thread, and the next shadow access faults.
+/// Always defined (0 or 1) so it can be used in #if without tripping -Wundef.
+#if defined(__aarch64__) && defined(MEMORY_SANITIZER)
+#    define CH_FIBERS_SUPPORTED 0
+#else
+#    define CH_FIBERS_SUPPORTED 1
+#endif
+
+/// Whether the asynchronous (fiber-backed) remote read/send path is compiled in. This is the
+/// single definition of that condition: RemoteQueryExecutor's guards are written in terms of it,
+/// so no copy of the condition can drift from it.
+///
+/// Note that RemoteSource and the epoll/eventfd/timerfd helpers keep their own
+/// `OS_LINUX || OS_DARWIN` guards - those select platform primitives that exist regardless of
+/// fibers, and are a different condition from this one.
+#if (defined(OS_LINUX) || defined(OS_DARWIN)) && CH_FIBERS_SUPPORTED
+#    define CH_REMOTE_ASYNC_IO 1
+#else
+#    define CH_REMOTE_ASYNC_IO 0
+#endif

--- a/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
+++ b/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
@@ -259,9 +259,9 @@ public:
         , context(std::move(context_))
         , logger(getLogger("DistributedIndexAnalysis"))
         , settings(context->getSettingsRef())
-/// Both flags stay false without fibers, so establishConnections() and executeRemoteAnalysis()
-/// select their synchronous counterparts. Gating here rather than in establishConnectionsAsync()
-/// or executeRemoteAnalysisAsync(): those have throwing #else branches, not sync fallbacks.
+/// Both flags stay false without fibers, so `establishConnections` and `executeRemoteAnalysis`
+/// select their synchronous counterparts. Gating here rather than in `establishConnectionsAsync`
+/// or `executeRemoteAnalysisAsync`: those have throwing `#else` branches, not sync fallbacks.
 #if defined(OS_LINUX) && CH_FIBERS_SUPPORTED
         , use_hedged_requests(settings[Setting::use_hedged_requests])
         , use_async_reading(settings[Setting::async_socket_for_remote])
@@ -420,7 +420,7 @@ private:
 
         return connections;
     }
-/// Where fibers are unsupported establishConnections() drops the call, so no stub is needed.
+/// Where fibers are unsupported `establishConnections` drops the call, so no stub is needed.
 #elif CH_FIBERS_SUPPORTED
     std::vector<Connection *> establishConnectionsAsync(const ConnectionTimeouts &)
     {
@@ -745,7 +745,7 @@ private:
         if (cancellation_exception)
             std::rethrow_exception(cancellation_exception);
     }
-/// Where fibers are unsupported executeRemoteAnalysis() drops the call, so no stub is needed.
+/// Where fibers are unsupported `executeRemoteAnalysis` drops the call, so no stub is needed.
 #elif CH_FIBERS_SUPPORTED
     void executeRemoteAnalysisAsync(
         const std::vector<size_t> &,

--- a/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
+++ b/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
@@ -14,6 +14,7 @@
 #include <Interpreters/ClusterProxy/executeQuery.h>
 #include <Client/ConnectionPool.h>
 #include <Client/ConnectionPoolWithFailover.h>
+#include <Common/RemoteAsyncCapability.h> /// CH_FIBERS_SUPPORTED
 #if defined(OS_LINUX)
 #include <Client/HedgedConnectionsFactory.h>
 #include <Common/Epoll.h>
@@ -258,7 +259,10 @@ public:
         , context(std::move(context_))
         , logger(getLogger("DistributedIndexAnalysis"))
         , settings(context->getSettingsRef())
-#if defined(OS_LINUX)
+/// Both flags stay false without fibers, so establishConnections() and executeRemoteAnalysis()
+/// select their synchronous counterparts. Gating here rather than in establishConnectionsAsync()
+/// or executeRemoteAnalysisAsync(): those have throwing #else branches, not sync fallbacks.
+#if defined(OS_LINUX) && CH_FIBERS_SUPPORTED
         , use_hedged_requests(settings[Setting::use_hedged_requests])
         , use_async_reading(settings[Setting::async_socket_for_remote])
 #endif
@@ -345,7 +349,7 @@ private:
     /// so that subsequent queries can deprioritize replicas that failed during this analysis.
     void propagateErrorCounts()
     {
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) && CH_FIBERS_SUPPORTED
         if (hedged_factory.has_value())
         {
             /// Reset the factory so its destructor propagates error counts into remote_pool via updateSharedError.
@@ -367,12 +371,14 @@ private:
     /// Returns connections[remote_replicas], nullptr for unavailable.
     std::vector<Connection *> establishConnections(const ConnectionTimeouts & timeouts)
     {
+#if CH_FIBERS_SUPPORTED
         if (use_hedged_requests)
             return establishConnectionsAsync(timeouts);
+#endif
         return establishConnectionsSync(timeouts);
     }
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) && CH_FIBERS_SUPPORTED
     std::vector<Connection *> establishConnectionsAsync(const ConnectionTimeouts & timeouts)
     {
         std::vector<Connection *> connections(remote_replicas, nullptr);
@@ -414,7 +420,8 @@ private:
 
         return connections;
     }
-#else
+/// Where fibers are unsupported establishConnections() drops the call, so no stub is needed.
+#elif CH_FIBERS_SUPPORTED
     std::vector<Connection *> establishConnectionsAsync(const ConnectionTimeouts &)
     {
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Hedged connections are not supported on this platform");
@@ -589,13 +596,17 @@ private:
         const std::vector<size_t> & remote_rows,
         DistributedIndexAnalysisPartsRanges & res)
     {
+#if CH_FIBERS_SUPPORTED
         if (use_async_reading)
+        {
             executeRemoteAnalysisAsync(active_remote_indexes, connections, remote_parts, remote_marks, remote_rows, res);
-        else
-            executeRemoteAnalysisSync(active_remote_indexes, connections, remote_parts, remote_marks, remote_rows, res);
+            return;
+        }
+#endif
+        executeRemoteAnalysisSync(active_remote_indexes, connections, remote_parts, remote_marks, remote_rows, res);
     }
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) && CH_FIBERS_SUPPORTED
     void executeRemoteAnalysisAsync(
         const std::vector<size_t> & active_remote_indexes,
         const std::vector<Connection *> & connections,
@@ -734,7 +745,8 @@ private:
         if (cancellation_exception)
             std::rethrow_exception(cancellation_exception);
     }
-#else
+/// Where fibers are unsupported executeRemoteAnalysis() drops the call, so no stub is needed.
+#elif CH_FIBERS_SUPPORTED
     void executeRemoteAnalysisAsync(
         const std::vector<size_t> &,
         const std::vector<Connection *> &,
@@ -834,8 +846,9 @@ private:
 
     LoggerPtr logger;
     const Settings & settings;
-    bool use_hedged_requests = false;
-    bool use_async_reading = false;
+    /// Read only by the fiber-backed selectors, which are compiled out where fibers are unsupported.
+    [[maybe_unused]] bool use_hedged_requests = false;
+    [[maybe_unused]] bool use_async_reading = false;
     size_t total_replicas;
     size_t remote_replicas;
     size_t max_active_replicas;
@@ -860,7 +873,7 @@ private:
     /// Keep `ConnectionPool::Entry` objects alive for the sync path.
     std::vector<ConnectionPool::Entry> connection_entries;
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) && CH_FIBERS_SUPPORTED
     /// Keep `HedgedConnectionsFactory` alive for the async path.
     std::optional<HedgedConnectionsFactory> hedged_factory;
 #endif

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -8,6 +8,7 @@
 #include <Common/CurrentThread.h>
 #include <Common/FailPoint.h>
 #include <Common/Logger.h>
+#include <Common/RemoteAsyncCapability.h>
 #include <Common/OpenTelemetryTraceContext.h>
 #include <Common/logger_useful.h>
 #include <Core/Protocol.h>
@@ -296,7 +297,7 @@ RemoteQueryExecutor::RemoteQueryExecutor(
         const Settings & current_settings = context->getSettingsRef();
         auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(current_settings);
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) && CH_FIBERS_SUPPORTED
         if (current_settings[Setting::use_hedged_requests])
         {
             std::shared_ptr<QualifiedTableName> table_to_check = nullptr;
@@ -554,7 +555,7 @@ void RemoteQueryExecutor::sendQueryUnlocked(ClientInfo::QueryKind query_kind, As
 
 int RemoteQueryExecutor::sendQueryAsync()
 {
-#if defined(OS_LINUX) || defined(OS_DARWIN)
+#if CH_REMOTE_ASYNC_IO
     LockAndBlocker lock(was_cancelled_mutex);
     if (was_cancelled)
         return -1;
@@ -637,7 +638,7 @@ RemoteQueryExecutor::ReadResult RemoteQueryExecutor::read()
 
 RemoteQueryExecutor::ReadResult RemoteQueryExecutor::readAsync()
 {
-#if defined(OS_LINUX) || defined(OS_DARWIN)
+#if CH_REMOTE_ASYNC_IO
     if (!read_context)
     {
         LockAndBlocker lock(was_cancelled_mutex);
@@ -1205,7 +1206,9 @@ void RemoteQueryExecutor::reportShardSkipped()
 
 bool RemoteQueryExecutor::processParallelReplicaPacketIfAny()
 {
-#if defined(OS_LINUX) || defined(OS_DARWIN)
+/// Without the asynchronous path `read_context` is never created, and this function dereferences
+/// it unguarded.
+#if CH_REMOTE_ASYNC_IO
 
     if (!read_context->readPacketTypeSeparately())
         return false;

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -328,8 +328,8 @@ private:
       */
     bool got_unknown_packet_from_replica = false;
 
-    /// Used only by the fiber-backed paths (readAsync, processParallelReplicaPacketIfAny), which
-    /// are compiled out where CH_REMOTE_ASYNC_IO is 0 (see Common/RemoteAsyncCapability.h).
+    /// Used only by the fiber-backed paths (`readAsync`, `processParallelReplicaPacketIfAny`),
+    /// which are compiled out where `CH_REMOTE_ASYNC_IO` is 0 (see `Common/RemoteAsyncCapability.h`).
 #if defined(OS_LINUX) || defined(OS_DARWIN)
     [[maybe_unused]] bool packet_in_progress = false;
 #endif

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -328,8 +328,10 @@ private:
       */
     bool got_unknown_packet_from_replica = false;
 
+    /// Used only by the fiber-backed paths (readAsync, processParallelReplicaPacketIfAny), which
+    /// are compiled out where CH_REMOTE_ASYNC_IO is 0 (see Common/RemoteAsyncCapability.h).
 #if defined(OS_LINUX) || defined(OS_DARWIN)
-    bool packet_in_progress = false;
+    [[maybe_unused]] bool packet_in_progress = false;
 #endif
 
     PoolMode pool_mode = PoolMode::GET_MANY;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/110124


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`Stress test (arm_msan)` fails roughly once a week with `Segmentation fault (STID: 4348-2010)` in the `RemoteQueryExecutorReadContext` fiber during teardown. CIDB over the last 100 days: 16 hits, **all** on `Stress test (arm_msan)` (15 distinct pull requests plus one master hit on 2026-06-10, sha `7bd1b86ef3ef`), and zero hits on every other check, architecture and sanitizer. Each hit kills the server mid-run and discards the remainder of that job's coverage.

**Root cause.** On AArch64 with `-fsanitize=memory`, clang materialises the thread pointer (`mrs xN, TPIDR_EL0`) into a callee-saved register and keeps it live across a call. When that call switches to another OS thread's stack, the cached value still names the *old* thread, so the next MemorySanitizer shadow-TLS access dereferences an address that is unmapped in the current thread. ClickHouse resumes suspended remote-I/O fibers on threads other than the suspending one, and destroys them while suspended (`force_unwind`) on the caller's thread, which is why every hit is a shutdown or timeout teardown.

Disassembling the exact failing binary (`clickhouse-common-static_26.8.1.1_arm64.deb` from a `build_arm_msan` job, `readelf -n` Build ID `b337b381a47106833eee64c02435cbed21e2b920`, matching the `build id:` line in `fatal.log`), in `boost::context::fiber::resume() &&`:

```
357d4da4: mrs  x22, TPIDR_EL0          ; thread pointer, read once in the prologue
357d4dc0: ldr  x25, [x22, x23]         ; pre-switch shadow read (correct thread)
357d4e10: bl   fiber_activation_record::resume()   ; contains ::swapcontext()
357d4e54: b.eq 0x357d4ed4              ; force_unwind -> cold throw block
357d4ee0: str  xzr, [x22, x23]         ; faults: x22 is the stale thread pointer
```

`x22` is provably not reloaded on that path: its only writes in the function are that prologue `mrs` and an epilogue `ldp x22, x21, [sp,#0x40]` which sits on the fall-through *return* path that the `b.eq` skips. The offsets resolve against the binary's own symbol table to `__msan_param_tls`, `__msan_retval_tls` and `__msan_va_arg_tls` — MemorySanitizer's own shadow area, no user data.

This is arch-exclusive for a mechanical reason. On x86-64 MSan TLS is `%fs`-relative and resolved by the CPU per access, so there is no register to go stale; compiling the same translation unit `--target=x86_64-linux-gnu` produces 30 `fs:` accesses and **0** `mrs`. AArch64 has no segment register, so the thread pointer must live in a general-purpose register, and once there it is hoistable. AddressSanitizer is immune (per-context `fake_stack` save and restore) and ThreadSanitizer switches fibers explicitly. That matches the CIDB distribution exactly.

**What this pull request does.** It compiles out the fiber-backed remote-I/O paths on AArch64 with MemorySanitizer, at the five places where the code *already* makes a build-conditional asynchronous-versus-synchronous choice, driven by one capability macro in a new `src/Common/RemoteAsyncCapability.h`:

| Site | Existing guard, and its synchronous counterpart |
|---|---|
| `RemoteQueryExecutor::readAsync` | `#if defined(OS_LINUX) \|\| defined(OS_DARWIN)`, `#else return read();` |
| `RemoteQueryExecutor::sendQueryAsync` | same, `#else sendQuery(); return -1;` |
| the hedged branch building `HedgedConnections` | `#if defined(OS_LINUX)`, falls through to `MultiplexedConnections` |
| `ConnectionPoolWithFailover::tryGetEntry`'s asynchronous block | `#if defined(OS_LINUX)` plus `if (async_callback)`, synchronous `ConnectionEstablisher` beside it |
| `distributedIndexAnalysis`'s connection and read **selectors** | plain `if (use_hedged_requests)` / `if (use_async_reading)` with the synchronous variants beside them |

No mechanism is invented; each of the five conditions is widened, and every `#else` branch already runs today on non-Linux builds. `processParallelReplicaPacketIfAny` is guarded too because it dereferences `read_context` unconditionally and `read_context` is never created without the asynchronous path.

Note for the last row: the selectors are gated, **not** `establishConnectionsAsync`/`executeRemoteAnalysisAsync`'s own `#if`s, whose `#else` throws `LOGICAL_ERROR "Hedged connections are not supported on this platform"`. Gating the implementations would have converted a crash into an exception.

Settings values are deliberately left untouched. The guard is at build level rather than in `applySettingsQuirks` because a settings-level scheme is bypassable: `Context::setSettings`, `setSettingWithLock` and `resetSettingsToDefaultValue` never call it, and `InterpreterSetQuery::executeForCurrentContext` applies changes and *then* resets defaults, so `SETTINGS async_socket_for_remote = DEFAULT` restores the compiled default after any quirk ran. One of the six fiber construction sites (`ConnectionPoolWithFailover.cpp`) is gated on `async_callback` rather than on any setting, so no settings-level scheme could ever have covered it. Gating at build level makes the property structural: no setting value, `SET`, profile, `DEFAULT` reset or test randomizer can produce a fiber in this build.

**Verification.** The change is verified at object level, because the crash needs an aarch64 plus MemorySanitizer build and cannot be reproduced by any functional test.

- The mechanism is witnessed directly: a checker over the generated assembly of the unmodified boost header reports 3 stale-thread-pointer uses at exactly the instructions that fault in CI, and 0 for a control build.
- `CH_FIBERS_SUPPORTED` and `CH_REMOTE_ASYNC_IO` were asserted with the real build flags across 7 configurations: both 0 for aarch64 with MemorySanitizer, both 1 for x86 with MemorySanitizer, and for AddressSanitizer, ThreadSanitizer, UndefinedBehaviorSanitizer and release builds on aarch64, and release on x86.
- On aarch64 with MemorySanitizer, all four fiber constructor references disappear from the objects (2+1+1 to 0+0+0) and are **retained** in every other configuration.
- Reverting any one of the six guards individually makes the constructor it dominates reappear, so no guard is decorative.
- For every configuration where `CH_REMOTE_ASYNC_IO` is 1, the generated code is identical to master across 24 translation-unit-by-configuration combinations, with a control proving the comparison can detect a real difference. Release behaviour is unchanged.
- The synchronous fallbacks were exercised end to end on a real binary with the predicate forced on locally: correct results, no hangs, `SuspendSendingQueryToShard` stays 0, and the four tests that set these settings explicitly pass.
- The new header costs **0** preprocessed lines in all six affected translation units (`base/defines.h` is already in their closures). Because both macros are always defined as 0 or 1, a dropped include is a build failure under `-Werror,-Wundef` rather than a silently disarmed guard.
- Every translation unit that touches fibers compiles clean for `aarch64-linux-gnu -fsanitize=memory` with the real build flags and `-Weverything -Werror`: `RemoteQueryExecutor`, `ConnectionPoolWithFailover`, `distributedIndexAnalysis`, `HedgedConnectionsFactory`, `RemoteQueryExecutorReadContext`, `checkStackSize`, `PacketReceiver`, `ConnectionEstablisher`, `HedgedConnections`, `AsyncTaskExecutor`, `RemoteSource` — 11 of 11, zero diagnostics. Compiling out a code path can strand a private member, so this is checked rather than assumed: `packet_in_progress` needs the `[[maybe_unused]]` this pull request adds (dropping it is a hard `-Wunused-private-field` error on that configuration), while `read_packet_type_separately` needs none, because its constructor initializer is a function call and clang counts that as a use. The second case is an incidental suppression rather than a designed one: if that initializer is ever simplified to a literal, this configuration stops building.

Because the base rate is roughly one hit per week fleet-wide, **a single green `Stress test (arm_msan)` run on this pull request is not proof**. The durable check is the CIDB signature count over three or more weeks against the 16 hits in the preceding 100 days.

**Costs, disclosed.** Two, and neither is hidden.

First, the arm_msan lane stops exercising fiber code; it takes the same synchronous paths that non-Linux builds always take. That is a real coverage loss on one lane, traded against that lane crashing weekly and discarding the rest of the run.

Second, on this configuration a multi-shard read at low `max_threads` is serialized. Measured on a real binary, `SELECT sleep(1.5) FROM remote('127.{1..10}', system.one)` at `--max_threads 1 --max_distributed_connections 10` takes 15.15 s instead of 1.65 s. `01602_max_distributed_connections` and `01514_distributed_cancel_query_on_error` would fail if that lane ran stateless tests. It does not. `arm_msan` has exactly one job in the whole configuration — `Stress test (arm_msan)` — and on it the stress runner records only its own script status: `run_func_test` collects each worker's return code into a local list it uses solely as a completion counter, and its caller discards the return value. Neither test is in that job's smoke check or hung check. The arm_msan *binary* does reach stateless tests through one other door, `Bugfix validation (functional tests, aarch64)`, which runs each ARM build type in turn — but that job runs only the tests a pull request itself changes, this one changes none, and it is `allow_failure` regardless. `01602` costs 600 s of one stress worker's time budget when it does run (its two retry loops each spend 30 attempts at `timeout 10`, reaching the runner's per-test cap), and no individual query can reach the hung-check threshold because each is killed at 10 s.

The cause of that serialization is a **pre-existing defect on master**, not something this change introduces. The planner raises stream parallelism to compensate for blocking remote reads, but it keys that on the *setting* rather than on whether the read will actually block:

```
bool is_sync_remote = table_expression_data.isRemote() && !settings[Setting::async_socket_for_remote];
```

`readAsync` is already `#if defined(OS_LINUX) || defined(OS_DARWIN)` with `#else return read();`, and the planner is platform-blind, so on a FreeBSD, SunOS or Android build of master today `readAsync` returns synchronously while `async_socket_for_remote` is still true and no compensation engages. The control measurement confirms the mechanism: with `async_socket_for_remote = 0` the same query takes 1.60 s on **both** binaries, so synchronous remote reads are not slow — synchronous reads while the setting claims asynchronous are.

That residual is being fixed separately and is not a prerequisite for this change. It is kept out of this pull request deliberately: three successively larger designs for it were reviewed and rejected, and the shape that survives requires defining thread-accounting composition semantics for unions, joins, selectors and completed pipelines, which is a change with its own design questions and its own review surface. I will link the follow-up pull request here when it opens. If you would rather see that one first, say so and I will reorder.

Finally, the underlying compiler behaviour is not fixed here. `swapcontext` changing the thread pointer is outside LLVM's model, and the right long-term home is upstream. This change makes the crash unreachable in the one configuration where it can occur.

My merged #110152 does not cover this. That pull request fixes a *different* aarch64 MemorySanitizer fiber defect (padding shadow), and its content is compiled into the binary that produced this crash — inside `contrib/boost`, `git merge-base --is-ancestor 24df31b3e5c13c e24b1b25e334` is true — and the signature fired anyway. Both are needed.