### PR TITLE
Docs: document read-after-write consistency for replica-aware routing

### DIFF
--- a/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
+++ b/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'Replica-aware routing'
 slug: /manage/replica-aware-routing
-description: 'Route related requests to the same ClickHouse Cloud replica for temporary tables, sessions, and cache reuse'
-keywords: ['cloud', 'sticky endpoints', 'sticky', 'endpoints', 'sticky routing', 'routing', 'replica aware routing', 'session_id', 'session affinity', 'temporary tables']
+description: 'Route related requests to the same ClickHouse Cloud replica for read-after-write consistency, temporary tables, sessions, and cache reuse'
+keywords: ['cloud', 'sticky endpoints', 'sticky', 'endpoints', 'sticky routing', 'routing', 'replica aware routing', 'session_id', 'session affinity', 'read-after-write consistency', 'temporary tables']
 doc_type: 'guide'
 noindex: true
 ---
@@ -11,7 +11,7 @@ import { PrivatePreviewBadge } from "/snippets/components/PrivatePreviewBadge/Pr
 
 <PrivatePreviewBadge/>
 
-Replica-aware routing (also known as sticky sessions, sticky routing, or session affinity) routes related requests to the same ClickHouse replica. Use it when you need [temporary tables](/sql-reference/statements/create/table#temporary-tables) or [named session state](/interfaces/http#using-clickhouse-sessions-in-the-http-protocol) to stay reachable across queries, or when you want related queries to reuse the same replica's local caches.
+Replica-aware routing (also known as sticky sessions, sticky routing, or session affinity) routes related requests to the same ClickHouse replica. Use it when you need read-after-write consistency, [temporary tables](/sql-reference/statements/create/table#temporary-tables) or [named session state](/interfaces/http#using-clickhouse-sessions-in-the-http-protocol) to stay reachable across queries, or when you want related queries to reuse the same replica's local caches.
 
 It's best-effort and doesn't guarantee isolation. Scaling, upgrades, and restarts can remap which replica a given `session_id` lands on.
 
@@ -50,6 +50,10 @@ Every request carrying `session_id=my-workload-1` lands on the same replica. A d
 `session_id` is any string you choose (application name, user id, or workload label). Requests without `session_id` keep normal load balancing.
 
 Any HTTP client that can add a query parameter works, including `curl`, [clickhouse-connect](/integrations/python), JDBC/ODBC, and others. For `clickhouse-go` (v2), use HTTP mode as noted above.
+
+### Read-after-write consistency {#read-after-write-consistency}
+
+Use the same `session_id` for a write and its subsequent read queries. Replica-aware routing sends those requests to the same replica, so the reads see the latest write even if the other replicas haven't received it yet. This provides read-after-write consistency for as long as the `session_id` continues to map to the same replica.
 
 ### Check which replica you hit {#check-which-replica}
 


### PR DESCRIPTION
Document read-after-write consistency as a use case for HTTP replica-aware routing. Clients can reuse the same `session_id` for a write and its dependent reads so they are routed to the same replica, including while other replicas are still catching up.

This also adds the use case to the page overview, description, and search keywords so readers can discover it.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.219` (included in `26.8` and later)
<!-- ch-version-info:end -->