### PR TITLE
Honour query cancellation in the `ReadWriteBufferFromHTTP` retry loop

### DIFF
--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -389,7 +389,9 @@ void ReadWriteBufferFromHTTP::doWithRetries(std::function<void()> && callable,
                          milliseconds_to_wait, read_settings.http_settings.retry_max_backoff_ms);
 
             /// Checked only on the retry path: an error from the first attempt must keep propagating
-            /// as itself, and a cancelled query must not start another attempt.
+            /// as itself, and a cancelled query must not start another attempt. This observes
+            /// cancellation only once the query is marked as killed, so `max_execution_time` with
+            /// `timeout_overflow_mode = 'break'` (which does not mark it) does not stop the loop.
             CurrentThread::checkIfNotCancelled();
 
             sleepForMilliseconds(milliseconds_to_wait);

--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -2,6 +2,7 @@
 
 #include <IO/HTTPCommon.h>
 #include <IO/WriteHelpers.h>
+#include <Common/CurrentThread.h>
 #include <Common/NetException.h>
 #include <Poco/Net/NetException.h>
 #include <Common/ProxyConfigurationResolverProvider.h>
@@ -387,8 +388,15 @@ void ReadWriteBufferFromHTTP::doWithRetries(std::function<void()> && callable,
                          attempt + 1, read_settings.http_settings.max_tries,
                          milliseconds_to_wait, read_settings.http_settings.retry_max_backoff_ms);
 
+            /// Checked only on the retry path: an error from the first attempt must keep propagating
+            /// as itself, and a cancelled query must not start another attempt.
+            CurrentThread::checkIfNotCancelled();
+
             sleepForMilliseconds(milliseconds_to_wait);
             milliseconds_to_wait = std::min(milliseconds_to_wait * 2, read_settings.http_settings.retry_max_backoff_ms);
+
+            /// The sleep above is not interruptible, so check again after it.
+            CurrentThread::checkIfNotCancelled();
         }
     }
 }

--- a/tests/queries/0_stateless/04648_url_retry_loop_honors_cancellation.reference
+++ b/tests/queries/0_stateless/04648_url_retry_loop_honors_cancellation.reference
@@ -2,11 +2,8 @@
 TIMEOUT_EXCEEDED
 requests sent: 1
 stopped early
---- cancelled during a backoff ---
-TIMEOUT_EXCEEDED
-requests sent: 1
-stopped early
---- KILL QUERY ---
+--- KILL QUERY during a backoff ---
+backoff phase observed
 QUERY_WAS_CANCELLED
 requests sent: 1
 stopped early

--- a/tests/queries/0_stateless/04648_url_retry_loop_honors_cancellation.reference
+++ b/tests/queries/0_stateless/04648_url_retry_loop_honors_cancellation.reference
@@ -1,0 +1,6 @@
+--- max_execution_time ---
+TIMEOUT_EXCEEDED
+stopped early
+--- KILL QUERY ---
+QUERY_WAS_CANCELLED
+stopped early

--- a/tests/queries/0_stateless/04648_url_retry_loop_honors_cancellation.reference
+++ b/tests/queries/0_stateless/04648_url_retry_loop_honors_cancellation.reference
@@ -1,6 +1,12 @@
---- max_execution_time ---
+--- cancelled during a read ---
 TIMEOUT_EXCEEDED
+requests sent: 1
+stopped early
+--- cancelled during a backoff ---
+TIMEOUT_EXCEEDED
+requests sent: 1
 stopped early
 --- KILL QUERY ---
 QUERY_WAS_CANCELLED
+requests sent: 1
 stopped early

--- a/tests/queries/0_stateless/04648_url_retry_loop_honors_cancellation.sh
+++ b/tests/queries/0_stateless/04648_url_retry_loop_honors_cancellation.sh
@@ -21,6 +21,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # http_make_head_request = 0 keeps the request counts exact: it defaults to true and the
 # stress runner randomizes it, and a HEAD probe issues its own requests through the same
 # counter.
+# parallel_replicas_for_cluster_engines = 0 keeps the read on the initiator. With parallel
+# replicas enabled, url() is served by StorageURLCluster, so the HTTP reads happen in
+# secondary queries on the replicas and neither system.processes nor the initiator's
+# system.query_log row ever reports ReadWriteBufferFromHTTPRequestsSent.
 
 PORT=$(python3 -c "
 import socket
@@ -83,7 +87,7 @@ ${CLICKHOUSE_CLIENT} --query_id "$QUERY_ID_READ" --query "
     SELECT * FROM url('http://127.0.0.1:$PORT/', 'TSV', 'c1 UInt64')
     SETTINGS max_execution_time = 5, http_receive_timeout = 10, http_max_tries = 3,
              http_retry_initial_backoff_ms = 20000, http_retry_max_backoff_ms = 30000,
-             http_make_head_request = 0
+             http_make_head_request = 0, parallel_replicas_for_cluster_engines = 0
 " 2>&1 | grep -o -m1 -e TIMEOUT_EXCEEDED -e POCO_EXCEPTION
 ELAPSED_MS=$(( ($(date +%s%N) - START) / 1000000 ))
 requests_sent "$QUERY_ID_READ"
@@ -98,7 +102,7 @@ ${CLICKHOUSE_CLIENT} --query_id "$QUERY_ID_BACKOFF" --query "
     SELECT * FROM url('http://127.0.0.1:$PORT/', 'TSV', 'c1 UInt64')
     SETTINGS max_execution_time = 0, http_receive_timeout = 2, http_max_tries = 4,
              http_retry_initial_backoff_ms = 20000, http_retry_max_backoff_ms = 30000,
-             http_make_head_request = 0
+             http_make_head_request = 0, parallel_replicas_for_cluster_engines = 0
 " > /dev/null 2> "$BACKOFF_ERR" &
 CLIENT_PID=$!
 

--- a/tests/queries/0_stateless/04648_url_retry_loop_honors_cancellation.sh
+++ b/tests/queries/0_stateless/04648_url_retry_loop_honors_cancellation.sh
@@ -9,12 +9,15 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # ReadWriteBufferFromHTTP::doWithRetries must stop retrying once the query is cancelled.
 # The listener accepts every connection and never answers, so each attempt ends with a
 # receive timeout. The two checks on the retry path are pinned separately:
-#   - the check BEFORE the backoff sleep, by the first section: cancellation happens while
-#     attempt 1 is still reading, so the loop must throw as soon as that attempt fails
-#     instead of sleeping out a 20s backoff first (pinned by the elapsed time);
-#   - the check AFTER the backoff sleep, by the second section: cancellation happens during
-#     a 9s backoff, so the loop must throw when the sleep ends with exactly one request
-#     sent, instead of starting another attempt (pinned by the request count).
+#   - the check BEFORE the backoff sleep, by the first section: cancellation is observed
+#     while attempt 1 is still reading, so the loop must throw as soon as that attempt
+#     fails instead of sleeping out a 20s backoff first (pinned by the elapsed time);
+#   - the check AFTER the backoff sleep, by the second section: the query is killed while
+#     the loop is inside a 20s backoff, so it must throw when the sleep ends with exactly
+#     one request sent, instead of starting another attempt (pinned by the request count).
+# The second section does not derive that phase from a clock started before the query ran:
+# it waits until the server itself reports one request sent and more elapsed time than the
+# receive timeout, so the backoff phase is observed rather than assumed.
 # http_make_head_request = 0 keeps the request counts exact: it defaults to true and the
 # stress runner randomizes it, and a HEAD probe issues its own requests through the same
 # counter.
@@ -39,8 +42,11 @@ while True:
     accepted.append(conn)  # hold the connection open and never write a response
 " &
 LISTENER_PID=$!
-KILL_ERR="${CLICKHOUSE_TMP}/04648_kill_err_${CLICKHOUSE_DATABASE}.txt"
-trap 'kill $LISTENER_PID 2>/dev/null ||:; wait $LISTENER_PID 2>/dev/null ||:; rm -f "$KILL_ERR"' EXIT
+# CLICKHOUSE_TMP is shared between concurrently running copies of the suite when the runner
+# is given --database, so every temp file is scoped with the test database name.
+BACKOFF_ERR="${CLICKHOUSE_TMP}/04648_backoff_err_${CLICKHOUSE_DATABASE}.txt"
+PHASE_LOG="${CLICKHOUSE_TMP}/04648_phase_${CLICKHOUSE_DATABASE}.txt"
+trap 'kill $LISTENER_PID 2>/dev/null ||:; wait $LISTENER_PID 2>/dev/null ||:; rm -f "$BACKOFF_ERR" "$PHASE_LOG"' EXIT
 
 for _ in $(seq 1 100); do
     python3 -c "
@@ -67,61 +73,58 @@ requests_sent()
         ORDER BY event_time_microseconds DESC LIMIT 1"
 }
 
-# Cancellation lands while attempt 1 is still reading, so only the check before the backoff
-# sleep can stop the loop before a 20s sleep.
+# Cancellation is observed while attempt 1 is still reading: max_execution_time fires at 5s,
+# long before the 10s receive timeout expires, so only the check before the backoff sleep can
+# stop the loop before it sleeps for 20s.
 echo "--- cancelled during a read ---"
 QUERY_ID_READ="04648_read_${CLICKHOUSE_DATABASE}"
 START=$(date +%s%N)
 ${CLICKHOUSE_CLIENT} --query_id "$QUERY_ID_READ" --query "
     SELECT * FROM url('http://127.0.0.1:$PORT/', 'TSV', 'c1 UInt64')
-    SETTINGS max_execution_time = 1, http_receive_timeout = 2, http_max_tries = 3,
+    SETTINGS max_execution_time = 5, http_receive_timeout = 10, http_max_tries = 3,
              http_retry_initial_backoff_ms = 20000, http_retry_max_backoff_ms = 30000,
              http_make_head_request = 0
 " 2>&1 | grep -o -m1 -e TIMEOUT_EXCEEDED -e POCO_EXCEPTION
 ELAPSED_MS=$(( ($(date +%s%N) - START) / 1000000 ))
 requests_sent "$QUERY_ID_READ"
-if [ "$ELAPSED_MS" -lt 12000 ]; then echo "stopped early"; else echo "kept retrying for ${ELAPSED_MS} ms"; fi
+if [ "$ELAPSED_MS" -lt 20000 ]; then echo "stopped early"; else echo "kept retrying for ${ELAPSED_MS} ms"; fi
 
-# Cancellation lands during the 9s backoff, so only the check after the sleep can stop the
-# loop from sending a second request.
-echo "--- cancelled during a backoff ---"
+# The query is killed while the loop is inside a 20s backoff, so only the check after the
+# sleep can stop it from sending a second request.
+echo "--- KILL QUERY during a backoff ---"
 QUERY_ID_BACKOFF="04648_backoff_${CLICKHOUSE_DATABASE}"
 START=$(date +%s%N)
 ${CLICKHOUSE_CLIENT} --query_id "$QUERY_ID_BACKOFF" --query "
     SELECT * FROM url('http://127.0.0.1:$PORT/', 'TSV', 'c1 UInt64')
-    SETTINGS max_execution_time = 5, http_receive_timeout = 2, http_max_tries = 4,
-             http_retry_initial_backoff_ms = 9000, http_retry_max_backoff_ms = 10000,
-             http_make_head_request = 0
-" 2>&1 | grep -o -m1 -e TIMEOUT_EXCEEDED -e POCO_EXCEPTION
-ELAPSED_MS=$(( ($(date +%s%N) - START) / 1000000 ))
-requests_sent "$QUERY_ID_BACKOFF"
-if [ "$ELAPSED_MS" -lt 25000 ]; then echo "stopped early"; else echo "kept retrying for ${ELAPSED_MS} ms"; fi
-
-# The same loop, cancelled by KILL QUERY instead of by a timeout.
-echo "--- KILL QUERY ---"
-QUERY_ID="04648_kill_${CLICKHOUSE_DATABASE}"
-START=$(date +%s%N)
-${CLICKHOUSE_CLIENT} --query_id "$QUERY_ID" --query "
-    SELECT * FROM url('http://127.0.0.1:$PORT/', 'TSV', 'c1 UInt64')
     SETTINGS max_execution_time = 0, http_receive_timeout = 2, http_max_tries = 4,
-             http_retry_initial_backoff_ms = 9000, http_retry_max_backoff_ms = 10000,
+             http_retry_initial_backoff_ms = 20000, http_retry_max_backoff_ms = 30000,
              http_make_head_request = 0
-" > /dev/null 2> "$KILL_ERR" &
+" > /dev/null 2> "$BACKOFF_ERR" &
 CLIENT_PID=$!
 
-# Wait until the first request is actually on the wire, so the cancellation lands while the
-# read is in flight and is therefore observed on the retry path, not before the first attempt.
-for _ in $(seq 1 100); do
-    RETRIES=$(${CLICKHOUSE_CLIENT} --query "
-        SELECT ProfileEvents['ReadWriteBufferFromHTTPRequestsSent'] FROM system.processes WHERE query_id = '$QUERY_ID'")
-    if [ "${RETRIES:-0}" -ge 1 ]; then break; fi
+# Wait until the server reports that one request has been sent AND that more time has passed
+# than the 2s receive timeout: attempt 1 has then already failed and the loop is inside the
+# 20s backoff, which leaves ample slack for the KILL to be delivered before the sleep ends.
+BACKOFF_OBSERVED=0
+for _ in $(seq 1 200); do
+    PAIR=$(${CLICKHOUSE_CLIENT} --query "
+        SELECT toString(ProfileEvents['ReadWriteBufferFromHTTPRequestsSent']) || ' ' || toString(toUInt64(elapsed))
+        FROM system.processes WHERE query_id = '$QUERY_ID_BACKOFF'")
+    REQUESTS=${PAIR%% *}
+    SECONDS_ELAPSED=${PAIR##* }
+    if [ "${REQUESTS:-0}" -ge 1 ] && [ "${SECONDS_ELAPSED:-0}" -ge 6 ]; then
+        BACKOFF_OBSERVED=1
+        echo "accepted requests=$REQUESTS elapsed=${SECONDS_ELAPSED}s" >> "$PHASE_LOG"
+        break
+    fi
     sleep 0.2
 done
-${CLICKHOUSE_CLIENT} --query "KILL QUERY WHERE query_id = '$QUERY_ID' SYNC" > /dev/null
+if [ "$BACKOFF_OBSERVED" -eq 1 ]; then echo "backoff phase observed"; fi
+${CLICKHOUSE_CLIENT} --query "KILL QUERY WHERE query_id = '$QUERY_ID_BACKOFF' SYNC" > /dev/null
 wait $CLIENT_PID 2>/dev/null ||:
 ELAPSED_MS=$(( ($(date +%s%N) - START) / 1000000 ))
-grep -o -m1 -e QUERY_WAS_CANCELLED -e POCO_EXCEPTION "$KILL_ERR"
-requests_sent "$QUERY_ID"
-if [ "$ELAPSED_MS" -lt 6000 ]; then echo "stopped early"; else echo "kept retrying for ${ELAPSED_MS} ms"; fi
+grep -o -m1 -e QUERY_WAS_CANCELLED -e POCO_EXCEPTION "$BACKOFF_ERR"
+requests_sent "$QUERY_ID_BACKOFF"
+if [ "$ELAPSED_MS" -lt 35000 ]; then echo "stopped early"; else echo "kept retrying for ${ELAPSED_MS} ms"; fi
 
-rm -f "$KILL_ERR"
+rm -f "$BACKOFF_ERR" "$PHASE_LOG"

--- a/tests/queries/0_stateless/04648_url_retry_loop_honors_cancellation.sh
+++ b/tests/queries/0_stateless/04648_url_retry_loop_honors_cancellation.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Tag no-fasttest: needs a local HTTP listener and the url() table function
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# ReadWriteBufferFromHTTP::doWithRetries must stop retrying once the query is cancelled.
+# The listener accepts the connection and never answers, so every attempt ends with
+# a receive timeout. With http_max_tries = 10, http_receive_timeout = 2 and the backoff
+# below, the whole loop takes ~50s when cancellation is ignored, and a few seconds when
+# it is honoured.
+
+PORT=$(python3 -c "
+import socket
+s = socket.socket()
+s.bind(('127.0.0.1', 0))
+print(s.getsockname()[1])
+s.close()
+")
+
+python3 -c "
+import socket
+srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+srv.bind(('127.0.0.1', $PORT))
+srv.listen(128)
+accepted = []
+while True:
+    conn, _ = srv.accept()
+    accepted.append(conn)  # hold the connection open and never write a response
+" &
+LISTENER_PID=$!
+trap 'kill $LISTENER_PID 2>/dev/null ||:; wait $LISTENER_PID 2>/dev/null ||:' EXIT
+
+for _ in $(seq 1 100); do
+    python3 -c "
+import socket, sys
+s = socket.socket()
+s.settimeout(1)
+try:
+    s.connect(('127.0.0.1', $PORT))
+except OSError:
+    sys.exit(1)
+s.close()
+" && break
+    sleep 0.1
+done
+
+RETRY_SETTINGS="http_receive_timeout = 2, http_max_tries = 10, http_retry_initial_backoff_ms = 100, http_retry_max_backoff_ms = 10000"
+# The loop needs at least ~50s when cancellation is ignored; allow a generous margin
+# for a loaded CI host while still failing the unfixed build.
+LIMIT_MS=25000
+
+echo "--- max_execution_time ---"
+START=$(date +%s%N)
+${CLICKHOUSE_CLIENT} --query "
+    SELECT * FROM url('http://127.0.0.1:$PORT/', 'TSV', 'c1 UInt64')
+    SETTINGS max_execution_time = 3, $RETRY_SETTINGS
+" 2>&1 | grep -o -m1 -e TIMEOUT_EXCEEDED -e POCO_EXCEPTION
+ELAPSED_MS=$(( ($(date +%s%N) - START) / 1000000 ))
+if [ "$ELAPSED_MS" -lt "$LIMIT_MS" ]; then echo "stopped early"; else echo "kept retrying for ${ELAPSED_MS} ms"; fi
+
+echo "--- KILL QUERY ---"
+QUERY_ID="04648_kill_${CLICKHOUSE_DATABASE}"
+START=$(date +%s%N)
+${CLICKHOUSE_CLIENT} --query_id "$QUERY_ID" --query "
+    SELECT * FROM url('http://127.0.0.1:$PORT/', 'TSV', 'c1 UInt64')
+    SETTINGS max_execution_time = 0, $RETRY_SETTINGS
+" > /dev/null 2> "${CLICKHOUSE_TMP}/04648_kill_err.txt" &
+CLIENT_PID=$!
+
+# Wait until the query has entered the retry loop (i.e. the first attempt already timed out),
+# so the cancellation lands on the retry path rather than before the first attempt.
+for _ in $(seq 1 100); do
+    RETRIES=$(${CLICKHOUSE_CLIENT} --query "
+        SELECT ProfileEvents['ReadWriteBufferFromHTTPRequestsSent'] FROM system.processes WHERE query_id = '$QUERY_ID'")
+    if [ "${RETRIES:-0}" -ge 2 ]; then break; fi
+    sleep 0.2
+done
+${CLICKHOUSE_CLIENT} --query "KILL QUERY WHERE query_id = '$QUERY_ID' SYNC" > /dev/null
+wait $CLIENT_PID 2>/dev/null ||:
+ELAPSED_MS=$(( ($(date +%s%N) - START) / 1000000 ))
+grep -o -m1 -e QUERY_WAS_CANCELLED -e POCO_EXCEPTION "${CLICKHOUSE_TMP}/04648_kill_err.txt"
+if [ "$ELAPSED_MS" -lt "$LIMIT_MS" ]; then echo "stopped early"; else echo "kept retrying for ${ELAPSED_MS} ms"; fi
+
+rm -f "${CLICKHOUSE_TMP}/04648_kill_err.txt"

--- a/tests/queries/0_stateless/04648_url_retry_loop_honors_cancellation.sh
+++ b/tests/queries/0_stateless/04648_url_retry_loop_honors_cancellation.sh
@@ -7,10 +7,17 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 # ReadWriteBufferFromHTTP::doWithRetries must stop retrying once the query is cancelled.
-# The listener accepts the connection and never answers, so every attempt ends with
-# a receive timeout. With http_max_tries = 10, http_receive_timeout = 2 and the backoff
-# below, the whole loop takes ~50s when cancellation is ignored, and a few seconds when
-# it is honoured.
+# The listener accepts every connection and never answers, so each attempt ends with a
+# receive timeout. The two checks on the retry path are pinned separately:
+#   - the check BEFORE the backoff sleep, by the first section: cancellation happens while
+#     attempt 1 is still reading, so the loop must throw as soon as that attempt fails
+#     instead of sleeping out a 20s backoff first (pinned by the elapsed time);
+#   - the check AFTER the backoff sleep, by the second section: cancellation happens during
+#     a 9s backoff, so the loop must throw when the sleep ends with exactly one request
+#     sent, instead of starting another attempt (pinned by the request count).
+# http_make_head_request = 0 keeps the request counts exact: it defaults to true and the
+# stress runner randomizes it, and a HEAD probe issues its own requests through the same
+# counter.
 
 PORT=$(python3 -c "
 import socket
@@ -32,7 +39,8 @@ while True:
     accepted.append(conn)  # hold the connection open and never write a response
 " &
 LISTENER_PID=$!
-trap 'kill $LISTENER_PID 2>/dev/null ||:; wait $LISTENER_PID 2>/dev/null ||:' EXIT
+KILL_ERR="${CLICKHOUSE_TMP}/04648_kill_err_${CLICKHOUSE_DATABASE}.txt"
+trap 'kill $LISTENER_PID 2>/dev/null ||:; wait $LISTENER_PID 2>/dev/null ||:; rm -f "$KILL_ERR"' EXIT
 
 for _ in $(seq 1 100); do
     python3 -c "
@@ -48,41 +56,72 @@ s.close()
     sleep 0.1
 done
 
-RETRY_SETTINGS="http_receive_timeout = 2, http_max_tries = 10, http_retry_initial_backoff_ms = 100, http_retry_max_backoff_ms = 10000"
-# The loop needs at least ~50s when cancellation is ignored; allow a generous margin
-# for a loaded CI host while still failing the unfixed build.
-LIMIT_MS=25000
+# How many HTTP requests the finished query actually sent.
+requests_sent()
+{
+    ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS query_log"
+    ${CLICKHOUSE_CLIENT} --query "
+        SELECT 'requests sent: ' || toString(ProfileEvents['ReadWriteBufferFromHTTPRequestsSent'])
+        FROM system.query_log
+        WHERE current_database = currentDatabase() AND query_id = '$1' AND type != 'QueryStart'
+        ORDER BY event_time_microseconds DESC LIMIT 1"
+}
 
-echo "--- max_execution_time ---"
+# Cancellation lands while attempt 1 is still reading, so only the check before the backoff
+# sleep can stop the loop before a 20s sleep.
+echo "--- cancelled during a read ---"
+QUERY_ID_READ="04648_read_${CLICKHOUSE_DATABASE}"
 START=$(date +%s%N)
-${CLICKHOUSE_CLIENT} --query "
+${CLICKHOUSE_CLIENT} --query_id "$QUERY_ID_READ" --query "
     SELECT * FROM url('http://127.0.0.1:$PORT/', 'TSV', 'c1 UInt64')
-    SETTINGS max_execution_time = 3, $RETRY_SETTINGS
+    SETTINGS max_execution_time = 1, http_receive_timeout = 2, http_max_tries = 3,
+             http_retry_initial_backoff_ms = 20000, http_retry_max_backoff_ms = 30000,
+             http_make_head_request = 0
 " 2>&1 | grep -o -m1 -e TIMEOUT_EXCEEDED -e POCO_EXCEPTION
 ELAPSED_MS=$(( ($(date +%s%N) - START) / 1000000 ))
-if [ "$ELAPSED_MS" -lt "$LIMIT_MS" ]; then echo "stopped early"; else echo "kept retrying for ${ELAPSED_MS} ms"; fi
+requests_sent "$QUERY_ID_READ"
+if [ "$ELAPSED_MS" -lt 12000 ]; then echo "stopped early"; else echo "kept retrying for ${ELAPSED_MS} ms"; fi
 
+# Cancellation lands during the 9s backoff, so only the check after the sleep can stop the
+# loop from sending a second request.
+echo "--- cancelled during a backoff ---"
+QUERY_ID_BACKOFF="04648_backoff_${CLICKHOUSE_DATABASE}"
+START=$(date +%s%N)
+${CLICKHOUSE_CLIENT} --query_id "$QUERY_ID_BACKOFF" --query "
+    SELECT * FROM url('http://127.0.0.1:$PORT/', 'TSV', 'c1 UInt64')
+    SETTINGS max_execution_time = 5, http_receive_timeout = 2, http_max_tries = 4,
+             http_retry_initial_backoff_ms = 9000, http_retry_max_backoff_ms = 10000,
+             http_make_head_request = 0
+" 2>&1 | grep -o -m1 -e TIMEOUT_EXCEEDED -e POCO_EXCEPTION
+ELAPSED_MS=$(( ($(date +%s%N) - START) / 1000000 ))
+requests_sent "$QUERY_ID_BACKOFF"
+if [ "$ELAPSED_MS" -lt 25000 ]; then echo "stopped early"; else echo "kept retrying for ${ELAPSED_MS} ms"; fi
+
+# The same loop, cancelled by KILL QUERY instead of by a timeout.
 echo "--- KILL QUERY ---"
 QUERY_ID="04648_kill_${CLICKHOUSE_DATABASE}"
 START=$(date +%s%N)
 ${CLICKHOUSE_CLIENT} --query_id "$QUERY_ID" --query "
     SELECT * FROM url('http://127.0.0.1:$PORT/', 'TSV', 'c1 UInt64')
-    SETTINGS max_execution_time = 0, $RETRY_SETTINGS
-" > /dev/null 2> "${CLICKHOUSE_TMP}/04648_kill_err.txt" &
+    SETTINGS max_execution_time = 0, http_receive_timeout = 2, http_max_tries = 4,
+             http_retry_initial_backoff_ms = 9000, http_retry_max_backoff_ms = 10000,
+             http_make_head_request = 0
+" > /dev/null 2> "$KILL_ERR" &
 CLIENT_PID=$!
 
-# Wait until the query has entered the retry loop (i.e. the first attempt already timed out),
-# so the cancellation lands on the retry path rather than before the first attempt.
+# Wait until the first request is actually on the wire, so the cancellation lands while the
+# read is in flight and is therefore observed on the retry path, not before the first attempt.
 for _ in $(seq 1 100); do
     RETRIES=$(${CLICKHOUSE_CLIENT} --query "
         SELECT ProfileEvents['ReadWriteBufferFromHTTPRequestsSent'] FROM system.processes WHERE query_id = '$QUERY_ID'")
-    if [ "${RETRIES:-0}" -ge 2 ]; then break; fi
+    if [ "${RETRIES:-0}" -ge 1 ]; then break; fi
     sleep 0.2
 done
 ${CLICKHOUSE_CLIENT} --query "KILL QUERY WHERE query_id = '$QUERY_ID' SYNC" > /dev/null
 wait $CLIENT_PID 2>/dev/null ||:
 ELAPSED_MS=$(( ($(date +%s%N) - START) / 1000000 ))
-grep -o -m1 -e QUERY_WAS_CANCELLED -e POCO_EXCEPTION "${CLICKHOUSE_TMP}/04648_kill_err.txt"
-if [ "$ELAPSED_MS" -lt "$LIMIT_MS" ]; then echo "stopped early"; else echo "kept retrying for ${ELAPSED_MS} ms"; fi
+grep -o -m1 -e QUERY_WAS_CANCELLED -e POCO_EXCEPTION "$KILL_ERR"
+requests_sent "$QUERY_ID"
+if [ "$ELAPSED_MS" -lt 6000 ]; then echo "stopped early"; else echo "kept retrying for ${ELAPSED_MS} ms"; fi
 
-rm -f "${CLICKHOUSE_TMP}/04648_kill_err.txt"
+rm -f "$KILL_ERR"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/107941
Related: https://github.com/ClickHouse/ClickHouse/pull/111930



### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Makes `KILL QUERY`, and `max_execution_time` with the default `timeout_overflow_mode = 'throw'`, take effect promptly for reads over HTTP (the `url`, `odbc` and `jdbc` table functions, the `URL` table engine, the `web` disk, and HTTP dictionaries whose source runs on the query's own thread). `ReadWriteBufferFromHTTP` retried an unresponsive server up to `http_max_tries` times, sleeping up to `http_retry_max_backoff_ms` between attempts, without ever checking whether the query had been cancelled, so a cancelled query could keep working for several minutes.


### Description

`ReadWriteBufferFromHTTP::doWithRetries` never consulted query cancellation, and the backoff between attempts is an uninterruptible `sleepForMilliseconds`. Against a server that accepts the connection but does not answer, every attempt runs into its own receive timeout, so the worst case is `http_max_tries * http_receive_timeout` plus about 33 seconds of accumulated backoff: about 330 seconds with the product defaults (`http_max_tries = 10`, `http_receive_timeout = 30`), and about 630 seconds under the CI test profile, which sets `http_receive_timeout = 60`. Throughout that window `KILL QUERY` and `max_execution_time` have no effect, and a pipeline worker plus two waiter threads stay occupied. `PipelineExecutor` observes cancellation only between tasks, so it cannot interrupt this single task either.

The fix adds two `CurrentThread::checkIfNotCancelled` calls on the retry path only: one after the failed attempt has been classified as retriable, one after the backoff sleep. This is the same shape already used by `ZooKeeperRetriesControl` in `ZooKeeperRetries.h` and by the S3 client in `S3/Client.cpp`.

Because both checks are on the retry path, the attempt that is already in flight when cancellation arrives still runs to its own receive timeout. The worst-case window therefore shrinks from the full retry budget to a single `http_receive_timeout` plus the current backoff, roughly 40 seconds with the defaults, rather than to zero. Making the in-flight wait itself interruptible is a larger change and is the subject of #104929.

The checks observe cancellation through `QueryStatus::throwIfKilled`, which requires the query to have been marked as killed. `KILL QUERY` always marks it, and so does a `max_execution_time` timeout with the default `timeout_overflow_mode = 'throw'`. With `timeout_overflow_mode = 'break'` the cancellation checker deliberately does not mark the query (it calls `checkTimeLimit`, which only returns false), so the retry loop is unaffected in that mode. Returning a partial result from a read that never produced one would be a different change, so the scope is stated rather than widened.

Both checks sit after the attempt has thrown and been classified, so a genuine first-attempt error still propagates as itself. That matters here: the earlier attempt at this fix (#102801, reverted in `4cf703f916c496`) checked at the top of every attempt, which suppressed `CANNOT_PARSE_INPUT_ASSERTION_FAILED` and made `02270_errors_in_files_s3` flaky. That test's `url()` assertion was re-run against this build and is unchanged.

Because the primitive is thread-local, no constructor parameter or per-caller wiring is needed, so every `ReadWriteBufferFromHTTP` consumer is covered rather than just `StorageURLSource`, and all three retry entry points (`nextImpl`, `readBigAt`, the `getFileInfo` HEAD probe) share the single guarded loop. Threads with no query attached are unaffected: `checkIfNotCancelled` returns early when there is no current thread status, and `throwIfQueryCanceled` returns early when there is no thread group.

That last property also bounds what this change can reach, which is why the entry above says "whose source runs on the query's own thread". A `direct` dictionary calls its source inline on the query thread, and the `flat`/`hashed` layouts are loaded through `ExternalLoader`, which captures the requesting query's thread group (`CurrentThread::getGroup` in `startLoading`, restored by `ThreadGroupSwitcher` in `doLoading`), so both observe cancellation. The `cache` family (`cache`, `ssd_cache` and their `complex_key_` variants) instead hands the update to a persistent worker of its own `CacheDictionaryUpdateQueue` pool, which attaches no thread group, while the query thread waits separately for up to `query_wait_timeout_milliseconds` (60 seconds by default). On that path the new checks are no-ops and the retry loop can outlive the waiting query, exactly as before this change. Propagating cancellation into those detached update units is a separate change in a different component and is tracked separately; nothing here regresses it.

Found while triaging a `Stress test (amd_msan)` hung check where a cancelled `odbc()` query kept retrying for about nine minutes after `max_execution_time = 60` fired: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111930&sha=84788620b746b5c00af1121143172495ae3f13fe&name_0=PR&name_1=Stress%20test%20%28amd_msan%29

Relationship to open pull requests in this area, for reviewers deciding where the fix belongs:

- #104089 addresses the same defect by threading a `CheckCancelled` callback through the `ReadWriteBufferFromHTTP` constructor, `BuilderRWBufferFromHTTP` and `StorageURLSource`. This change is disjoint from it: it touches only `ReadWriteBufferFromHTTP.cpp`, changes no signatures, and uses `CurrentThread::checkIfNotCancelled`, which did not exist when #104089 was written (added in `b82d83174e9956`, 2026-07-03).
- #109785 adds a cancellation check at the entry of `ReadBuffer::next`. It cannot shorten this hang, because the whole retry loop runs inside a single `next` call that was already entered before cancellation. The two are complementary, and this check would respect `CancellationChecksBlockerInThread` if that lands.

No new setting and no default change, so `SettingsChangesHistory.cpp` needs no entry.