### PR TITLE
Fix wrong results for intDiv by an effective -1 in key analysis

### DIFF
--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -3539,13 +3539,24 @@ public:
                         return {false, true, false, false};
 
                     // `intDiv(unsigned, signed-integer-const)` reinterprets the dividend through a signed
-                    // cast (see `DivideIntegralImpl`/`intDivRangeCrossesSignedWrap`); a Float divisor
-                    // computes through floating point and never wraps. An unbounded range over an unsigned
-                    // domain always contains the discontinuity, so it is never always-monotonic; report
-                    // monotonicity only when an endpoint keeps the range on one side of it.
+                    // cast (see `DivideIntegralImpl`/`intDivRangeCrossesSignedWrap`). An unbounded range
+                    // over an unsigned domain always contains the discontinuity, so it is never
+                    // always-monotonic; report monotonicity only when an endpoint keeps the range on one
+                    // side of it.
                     if (name_view == "intDiv" && isUInt(arg_type) && isInt(divisor_type))
                     {
                         if (intDivRangeCrossesSignedWrap(arg_type, left_point, right_point))
+                            return {false, true, false, false};
+                        return {true, is_constant_positive, false};
+                    }
+
+                    // `intDiv(signed, -1)` folds the signed minimum onto itself instead of mapping it to
+                    // the maximum (see `intDivWrapsInsteadOfThrowing`), so it is non-monotonic on any range
+                    // containing that minimum. The whole domain of a signed type always contains its
+                    // minimum, so such a division is never always-monotonic.
+                    if (name_view == "intDiv" && intDivWrapsInsteadOfThrowing(arg_type, divisor_type, constant))
+                    {
+                        if (intDivRangeContainsResultWrapPoint(arg_type, left_point, right_point))
                             return {false, true, false, false};
                         return {true, is_constant_positive, false};
                     }
@@ -3715,6 +3726,17 @@ public:
                     return {true, is_constant_positive, false, is_strict};
                 }
 
+                // `intDiv(signed, -1)` folds the signed minimum onto itself instead of mapping it to the
+                // maximum (see `intDivWrapsInsteadOfThrowing`): a range containing that minimum is
+                // non-monotonic, so reject it (no pruning); a range excluding it is monotonic on that
+                // range, but never on the whole domain, which always contains the minimum.
+                if (name_view == "intDiv" && intDivWrapsInsteadOfThrowing(arg_type, divisor_type, constant))
+                {
+                    if (intDivRangeContainsResultWrapPoint(arg_type, left_point, right_point))
+                        return {false, true, false, false};
+                    return {true, is_constant_positive, false, is_strict};
+                }
+
                 // Mirror case: a signed dividend with an unsigned constant divisor whose high bit
                 // is set reinterprets the divisor as negative (see `intDivConstReinterpretsNegative`),
                 // so the function is monotonic decreasing even though the raw constant looks positive.
@@ -3869,6 +3891,46 @@ public:
         const size_t divisor_width_bytes = divisor_type->getSizeOfValueInMemory();
         const Field wrap_field(UInt256(1) << (8 * divisor_width_bytes - 1));
         return accurateLessOrEqual(wrap_field, constant);
+    }
+
+    /// `intDiv(x, -1)` is mathematically `-x`, which is not representable at the signed minimum of the
+    /// computation width: `TYPE_MIN / -1` overflows and folds back onto `TYPE_MIN`, while `TYPE_MIN + 1`
+    /// maps to `TYPE_MAX`. So on a range containing that minimum the function is neither non-decreasing
+    /// nor non-increasing, and reporting monotonicity makes key analysis drop matching rows.
+    ///
+    /// The generic `DivideIntegralImpl::apply` throws `ILLEGAL_DIVISION` in that situation, but
+    /// `DivideIntegralByConstantImpl::vectorConstant` (`src/Functions/intDiv.cpp`) short-circuits
+    /// `b == -1` and deliberately avoids the FPE, silently producing the wrapped value instead. Only
+    /// operand pairs taking that vectorized path can therefore be mis-pruned, and those are exactly the
+    /// registered specializations with a signed dividend: an `Int32`/`Int64` dividend and a native signed
+    /// divisor. Every other pair throws (on `ENGINE=Memory` too, i.e. at runtime), so it is not a
+    /// monotonicity problem. Returns true when this operand pair divides by an effective `-1` through
+    /// that FPE-suppressing path. `arg_type` and `divisor_type` are already stripped of
+    /// Nullable/LowCardinality.
+    static bool intDivWrapsInsteadOfThrowing(const DataTypePtr & arg_type, const DataTypePtr & divisor_type, const Field & constant)
+    {
+        if (!isInt32(arg_type) && !isInt64(arg_type))
+            return false;
+        if (!isNativeInt(divisor_type))
+            return false;
+        return accurateEquals(constant, Field(-1));
+    }
+
+    /// Does [left_point, right_point] contain the signed minimum of the computation width, i.e. the single
+    /// input at which `intDiv(x, -1)` wraps (see `intDivWrapsInsteadOfThrowing`)? The result width of
+    /// integer division is the dividend's width (`ResultOfIntegerDivision` in `NumberTraits.h`), so the
+    /// wrap point is `-2^(8 * dividend_width - 1)`. A null endpoint means the range is unbounded on that
+    /// side, which is decided per side: unbounded on the left reaches the minimum, unbounded on the right
+    /// does not by itself (a range like `[0, +Inf)` genuinely excludes it and must keep being pruned).
+    /// `arg_type` is the signed dividend type (already stripped of Nullable/LowCardinality).
+    static bool intDivRangeContainsResultWrapPoint(const DataTypePtr & arg_type, const Field & left_point, const Field & right_point)
+    {
+        const size_t width_bytes = arg_type->getSizeOfValueInMemory();
+        const Field wrap_field(-(Int256(1) << (8 * width_bytes - 1)));
+
+        const bool left_at_or_below = left_point.isNull() || accurateLessOrEqual(left_point, wrap_field);
+        const bool right_at_or_above = right_point.isNull() || accurateLessOrEqual(wrap_field, right_point);
+        return left_at_or_below && right_at_or_above;
     }
 
 private:

--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -3561,6 +3561,13 @@ public:
                         return {true, is_constant_positive, false};
                     }
 
+                    // The same wrap through a compound dividend (see
+                    // `intDivCompoundDividendWrapsInsteadOfThrowing`). The endpoints are `Array`/`Tuple`
+                    // Fields, whose element-wise containment of the wrap point is not cheaply modelled,
+                    // so reject unconditionally rather than trying to decide per element.
+                    if (name_view == "intDiv" && intDivCompoundDividendWrapsInsteadOfThrowing(arg_type, divisor_type, constant))
+                        return {false, true, false, false};
+
                     // Mirror case: a signed dividend with an unsigned constant divisor whose high bit
                     // is set reinterprets the divisor as negative (see `intDivConstReinterpretsNegative`),
                     // so the function is monotonic decreasing even though the raw constant looks positive.
@@ -3717,8 +3724,7 @@ public:
                 // `intDiv(unsigned, signed-integer-const)` is a step function (see
                 // `intDivRangeCrossesSignedWrap`): a range crossing the discontinuity is non-monotonic,
                 // so reject it (no pruning); a range on one side is monotonic on that range but not
-                // always-monotonic. The wrap is exclusive to the signed-integer divisor path; a Float
-                // divisor computes through floating point and never wraps.
+                // always-monotonic. The wrap is exclusive to the signed-integer divisor path.
                 if (name_view == "intDiv" && isUInt(arg_type) && isInt(divisor_type))
                 {
                     if (intDivRangeCrossesSignedWrap(arg_type, left_point, right_point))
@@ -3736,6 +3742,13 @@ public:
                         return {false, true, false, false};
                     return {true, is_constant_positive, false, is_strict};
                 }
+
+                // The same wrap through a compound dividend (see
+                // `intDivCompoundDividendWrapsInsteadOfThrowing`). The endpoints are `Array`/`Tuple`
+                // Fields, whose element-wise containment of the wrap point is not cheaply modelled, so
+                // reject unconditionally rather than trying to decide per element.
+                if (name_view == "intDiv" && intDivCompoundDividendWrapsInsteadOfThrowing(arg_type, divisor_type, constant))
+                    return {false, true, false, false};
 
                 // Mirror case: a signed dividend with an unsigned constant divisor whose high bit
                 // is set reinterprets the divisor as negative (see `intDivConstReinterpretsNegative`),
@@ -3903,10 +3916,11 @@ public:
     /// `b == -1` and deliberately avoids the FPE, silently producing the wrapped value instead. Only
     /// operand pairs taking that vectorized path can therefore be mis-pruned, and those are exactly the
     /// registered specializations with a signed dividend: an `Int32`/`Int64` dividend and a native signed
-    /// divisor. Every other pair throws (on `ENGINE=Memory` too, i.e. at runtime), so it is not a
-    /// monotonicity problem. Returns true when this operand pair divides by an effective `-1` through
-    /// that FPE-suppressing path. `arg_type` and `divisor_type` are already stripped of
-    /// Nullable/LowCardinality.
+    /// divisor. Every other SCALAR pair throws (on `ENGINE=Memory` too, i.e. at runtime), so it is not a
+    /// monotonicity problem; a compound dividend whose elements are of a wrapping type is a separate
+    /// carrier, see `intDivCompoundDividendWrapsInsteadOfThrowing`. Returns true when this scalar operand
+    /// pair divides by an effective `-1` through that FPE-suppressing path. `arg_type` and `divisor_type`
+    /// are already stripped of Nullable/LowCardinality.
     static bool intDivWrapsInsteadOfThrowing(const DataTypePtr & arg_type, const DataTypePtr & divisor_type, const Field & constant)
     {
         if (!isInt32(arg_type) && !isInt64(arg_type))
@@ -3914,6 +3928,39 @@ public:
         if (!isNativeInt(divisor_type))
             return false;
         return accurateEquals(constant, Field(-1));
+    }
+
+    /// Same defect one type wrapper up: an `Array`/`Tuple` dividend divided by a scalar constant is
+    /// evaluated element-wise (`executeArrayWithNumericImpl` / `tupleIntDivByNumber` unpack to the element
+    /// type and re-enter the arithmetic), so an element type that wraps instead of throwing makes the
+    /// compound result non-monotonic exactly as the scalar case does. `getMonotonicityForRange` sees only
+    /// the OUTER type, so the scalar predicate above cannot detect it. A `Tuple` is a carrier as soon as
+    /// ANY of its elements is: the verdict is about the outer comparison, and one wrapping element is
+    /// enough to break its order. Nesting is followed recursively (`Array(Array(Int64))` is a measured
+    /// carrier), stripping Nullable/LowCardinality at each level like the scalar path does.
+    static bool intDivCompoundDividendWrapsInsteadOfThrowing(
+        const DataTypePtr & arg_type, const DataTypePtr & divisor_type, const Field & constant)
+    {
+        const auto unwrapped = removeNullable(recursiveRemoveLowCardinality(arg_type));
+
+        if (const auto * array_type = typeid_cast<const DataTypeArray *>(unwrapped.get()))
+        {
+            const auto & nested = array_type->getNestedType();
+            return intDivWrapsInsteadOfThrowing(removeNullable(recursiveRemoveLowCardinality(nested)), divisor_type, constant)
+                || intDivCompoundDividendWrapsInsteadOfThrowing(nested, divisor_type, constant);
+        }
+
+        if (const auto * tuple_type = typeid_cast<const DataTypeTuple *>(unwrapped.get()))
+        {
+            for (const auto & element : tuple_type->getElements())
+            {
+                if (intDivWrapsInsteadOfThrowing(removeNullable(recursiveRemoveLowCardinality(element)), divisor_type, constant)
+                    || intDivCompoundDividendWrapsInsteadOfThrowing(element, divisor_type, constant))
+                    return true;
+            }
+        }
+
+        return false;
     }
 
     /// Does [left_point, right_point] contain the signed minimum of the computation width, i.e. the single

--- a/tests/queries/0_stateless/04648_intdiv_minus_one_monotonicity.reference
+++ b/tests/queries/0_stateless/04648_intdiv_minus_one_monotonicity.reference
@@ -10,17 +10,28 @@ Int32 / toInt8(-1)	1	1
 Int32 / toInt64(-1)	1	1
 Nullable(Int64) / toInt64(-1)	1	1
 LowCardinality(Int64) / toInt64(-1)	1	1
+Array(Int64) / toInt64(-1)	1	1
+Array(Int32) / toInt32(-1)	1	1
+Array(Array(Int64)) / toInt64(-1)	1	1
+Array(LowCardinality(Int64)) / toInt64(-1)	1	1
+Tuple(Int64, Int64) / toInt64(-1)	1	1
+Tuple(Int64, Int8) / toInt64(-1)	1	1
 wrong ORDER BY: the keyed order must equal the Memory oracle
 ORDER BY intDiv(a, -1)	[-9223372036854775808,-5,5,9223372036854775807]	[-9223372036854775808,-5,5,9223372036854775807]
+ORDER BY intDiv(Array(Int64), -1)	[[-9223372036854775808],[-5],[5],[9223372036854775807]]	[[-9223372036854775808],[-5],[5],[9223372036854775807]]
 preserved pruning: the guard must not fire outside the wrap
-single-point range at the minimum	2	2
+single-point range at the minimum	8	8
+single-point range at the minimum still prunes	1
+single-point range at the minimum prunes correctly	0	0
 ordinary intDiv still prunes	1
 range excluding the minimum still prunes	1
 range excluding the minimum answers	1	1
 divisor -2 still prunes	1
 divisor -2 answers	1	1
-UInt8 / toUInt8(255)	4	4
-UInt16 / toUInt16(65535)	4	4
+UInt8 / toUInt8(255)	1	1
+UInt8 / toUInt8(255) still prunes	1
+UInt16 / toUInt16(65535)	1	1
+UInt16 / toUInt16(65535) still prunes	1
 Float divisor still prunes	1
 Float divisor answers	1	1
 Float divisor keeps read-in-order	1
@@ -28,3 +39,7 @@ Int128 divisor keeps read-in-order	1
 Int16 dividend keeps read-in-order	1
 half-bounded range prunes exactly	1
 half-bounded range answers	17	17
+Array dividend, positive divisor still prunes	1
+Array dividend, positive divisor answers	1	1
+Array(UInt8) element is not a carrier, still prunes	1
+Array(UInt8) element is not a carrier, answers	1	1

--- a/tests/queries/0_stateless/04648_intdiv_minus_one_monotonicity.reference
+++ b/tests/queries/0_stateless/04648_intdiv_minus_one_monotonicity.reference
@@ -1,0 +1,30 @@
+wrong results: keyed count must equal the Memory oracle
+Int64 / toInt64(-1)	1	1
+Int64 / toInt64(-1), IN	1	1
+Int64 / toInt32(-1)	1	1
+Int64 / toInt16(-1)	1	1
+Int64 / toInt8(-1)	1	1
+Int32 / toInt32(-1)	1	1
+Int32 / toInt16(-1)	1	1
+Int32 / toInt8(-1)	1	1
+Int32 / toInt64(-1)	1	1
+Nullable(Int64) / toInt64(-1)	1	1
+LowCardinality(Int64) / toInt64(-1)	1	1
+wrong ORDER BY: the keyed order must equal the Memory oracle
+ORDER BY intDiv(a, -1)	[-9223372036854775808,-5,5,9223372036854775807]	[-9223372036854775808,-5,5,9223372036854775807]
+preserved pruning: the guard must not fire outside the wrap
+single-point range at the minimum	2	2
+ordinary intDiv still prunes	1
+range excluding the minimum still prunes	1
+range excluding the minimum answers	1	1
+divisor -2 still prunes	1
+divisor -2 answers	1	1
+UInt8 / toUInt8(255)	4	4
+UInt16 / toUInt16(65535)	4	4
+Float divisor still prunes	1
+Float divisor answers	1	1
+Float divisor keeps read-in-order	1
+Int128 divisor keeps read-in-order	1
+Int16 dividend keeps read-in-order	1
+half-bounded range prunes exactly	1
+half-bounded range answers	17	17

--- a/tests/queries/0_stateless/04648_intdiv_minus_one_monotonicity.sql
+++ b/tests/queries/0_stateless/04648_intdiv_minus_one_monotonicity.sql
@@ -1,0 +1,174 @@
+-- Tags: no-random-settings, no-random-merge-tree-settings
+
+-- `intDiv(x, -1)` is mathematically `-x`, which is not representable at the signed minimum of the
+-- computation width: the minimum folds back onto itself while `minimum + 1` maps to the maximum.
+-- The function is therefore non-monotonic on any range containing that minimum, and claiming
+-- monotonicity makes MergeTree key analysis prune a granule that really holds a matching row.
+-- Every assertion below compares the keyed MergeTree table against an `ENGINE=Memory` oracle on
+-- identical data, so the oracle is the test's own control.
+
+SET allow_suspicious_low_cardinality_types = 1;
+
+DROP TABLE IF EXISTS t_key_i64_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_i64_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_i32_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_i32_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_null_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_null_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_lc_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_lc_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_minonly_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_minonly_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_range_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_range_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_u8_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_u8_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_u16_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_u16_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_i8f_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_i8f_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_i16_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_multi_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_multi_04648 SETTINGS ignore_drop_queries_probability = 0;
+
+CREATE TABLE t_key_i64_04648 (a Int64) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_i64_04648 (a Int64) ENGINE = Memory;
+INSERT INTO t_key_i64_04648 VALUES (-9223372036854775808), (-9223372036854775807), (-5), (5);
+INSERT INTO t_mem_i64_04648 VALUES (-9223372036854775808), (-9223372036854775807), (-5), (5);
+
+CREATE TABLE t_key_i32_04648 (a Int32) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_i32_04648 (a Int32) ENGINE = Memory;
+INSERT INTO t_key_i32_04648 VALUES (-2147483648), (-2147483647), (-5), (5);
+INSERT INTO t_mem_i32_04648 VALUES (-2147483648), (-2147483647), (-5), (5);
+
+CREATE TABLE t_key_null_04648 (a Nullable(Int64)) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1, allow_nullable_key = 1;
+CREATE TABLE t_mem_null_04648 (a Nullable(Int64)) ENGINE = Memory;
+INSERT INTO t_key_null_04648 VALUES (-9223372036854775808), (-9223372036854775807), (-5), (5);
+INSERT INTO t_mem_null_04648 VALUES (-9223372036854775808), (-9223372036854775807), (-5), (5);
+
+CREATE TABLE t_key_lc_04648 (a LowCardinality(Int64)) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_lc_04648 (a LowCardinality(Int64)) ENGINE = Memory;
+INSERT INTO t_key_lc_04648 VALUES (-9223372036854775808), (-9223372036854775807), (-5), (5);
+INSERT INTO t_mem_lc_04648 VALUES (-9223372036854775808), (-9223372036854775807), (-5), (5);
+
+SELECT 'wrong results: keyed count must equal the Memory oracle';
+
+-- Every spelling of an effective `-1` divisor that takes `DivideIntegralByConstantImpl::vectorConstant`
+-- (an `Int32`/`Int64` dividend with a native signed divisor), plus the `IN` spelling, which goes through
+-- `MergeTreeSetIndex::checkInRange` instead of `KeyCondition::checkInRange`.
+SELECT 'Int64 / toInt64(-1)', (SELECT count() FROM t_key_i64_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808)) AS keyed, (SELECT count() FROM t_mem_i64_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808)) AS oracle;
+SELECT 'Int64 / toInt64(-1), IN', (SELECT count() FROM t_key_i64_04648 WHERE intDiv(a, toInt64(-1)) IN (toInt64(-9223372036854775808))) AS keyed, (SELECT count() FROM t_mem_i64_04648 WHERE intDiv(a, toInt64(-1)) IN (toInt64(-9223372036854775808))) AS oracle;
+SELECT 'Int64 / toInt32(-1)', (SELECT count() FROM t_key_i64_04648 WHERE intDiv(a, toInt32(-1)) = toInt64(-9223372036854775808)) AS keyed, (SELECT count() FROM t_mem_i64_04648 WHERE intDiv(a, toInt32(-1)) = toInt64(-9223372036854775808)) AS oracle;
+SELECT 'Int64 / toInt16(-1)', (SELECT count() FROM t_key_i64_04648 WHERE intDiv(a, toInt16(-1)) = toInt64(-9223372036854775808)) AS keyed, (SELECT count() FROM t_mem_i64_04648 WHERE intDiv(a, toInt16(-1)) = toInt64(-9223372036854775808)) AS oracle;
+SELECT 'Int64 / toInt8(-1)', (SELECT count() FROM t_key_i64_04648 WHERE intDiv(a, toInt8(-1)) = toInt64(-9223372036854775808)) AS keyed, (SELECT count() FROM t_mem_i64_04648 WHERE intDiv(a, toInt8(-1)) = toInt64(-9223372036854775808)) AS oracle;
+SELECT 'Int32 / toInt32(-1)', (SELECT count() FROM t_key_i32_04648 WHERE intDiv(a, toInt32(-1)) = toInt32(-2147483648)) AS keyed, (SELECT count() FROM t_mem_i32_04648 WHERE intDiv(a, toInt32(-1)) = toInt32(-2147483648)) AS oracle;
+SELECT 'Int32 / toInt16(-1)', (SELECT count() FROM t_key_i32_04648 WHERE intDiv(a, toInt16(-1)) = toInt32(-2147483648)) AS keyed, (SELECT count() FROM t_mem_i32_04648 WHERE intDiv(a, toInt16(-1)) = toInt32(-2147483648)) AS oracle;
+SELECT 'Int32 / toInt8(-1)', (SELECT count() FROM t_key_i32_04648 WHERE intDiv(a, toInt8(-1)) = toInt32(-2147483648)) AS keyed, (SELECT count() FROM t_mem_i32_04648 WHERE intDiv(a, toInt8(-1)) = toInt32(-2147483648)) AS oracle;
+SELECT 'Int32 / toInt64(-1)', (SELECT count() FROM t_key_i32_04648 WHERE intDiv(a, toInt64(-1)) = toInt32(-2147483648)) AS keyed, (SELECT count() FROM t_mem_i32_04648 WHERE intDiv(a, toInt64(-1)) = toInt32(-2147483648)) AS oracle;
+
+-- Wrapper carriers: the guard reads types stripped with `removeNullable(recursiveRemoveLowCardinality(...))`.
+SELECT 'Nullable(Int64) / toInt64(-1)', (SELECT count() FROM t_key_null_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808)) AS keyed, (SELECT count() FROM t_mem_null_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808)) AS oracle;
+SELECT 'LowCardinality(Int64) / toInt64(-1)', (SELECT count() FROM t_key_lc_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808)) AS keyed, (SELECT count() FROM t_mem_lc_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808)) AS oracle;
+
+SELECT 'wrong ORDER BY: the keyed order must equal the Memory oracle';
+
+-- `ReadInOrderOptimizer` probes with unbounded endpoints and only reads `is_monotonic`/`is_positive`,
+-- so the same false claim makes it read the part in reverse order and emit mis-sorted rows. There is no
+-- `WHERE`, so nothing here can be pruned: this assertion pins the read-in-order consumer only.
+SELECT 'ORDER BY intDiv(a, -1)',
+       (SELECT groupArray(x) FROM (SELECT intDiv(a, toInt64(-1)) AS x FROM t_key_i64_04648 ORDER BY intDiv(a, toInt64(-1)))) AS keyed,
+       (SELECT groupArray(x) FROM (SELECT intDiv(a, toInt64(-1)) AS x FROM t_mem_i64_04648 ORDER BY intDiv(a, toInt64(-1)))) AS oracle;
+
+SELECT 'preserved pruning: the guard must not fire outside the wrap';
+
+-- A single-point range is trivially monotonic and the transform is exact there, so pruning a table
+-- that contains only the minimum must keep working.
+CREATE TABLE t_key_minonly_04648 (a Int64) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_minonly_04648 (a Int64) ENGINE = Memory;
+INSERT INTO t_key_minonly_04648 VALUES (-9223372036854775808), (-9223372036854775808);
+INSERT INTO t_mem_minonly_04648 VALUES (-9223372036854775808), (-9223372036854775808);
+SELECT 'single-point range at the minimum', (SELECT count() FROM t_key_minonly_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808)) AS keyed, (SELECT count() FROM t_mem_minonly_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808)) AS oracle;
+
+CREATE TABLE t_key_range_04648 (a Int64) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_range_04648 (a Int64) ENGINE = Memory;
+INSERT INTO t_key_range_04648 SELECT number * 100 FROM numbers(100);
+INSERT INTO t_mem_range_04648 SELECT number * 100 FROM numbers(100);
+
+-- An ordinary positive divisor is untouched.
+SELECT 'ordinary intDiv still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_key_range_04648 WHERE intDiv(a, 10) = 50) WHERE explain ILIKE '%Granules: 2/100%';
+
+-- A half-bounded range that excludes the minimum must keep pruning: this is what pins the
+-- containment helper's side-awareness (an unbounded RIGHT endpoint does not reach the minimum).
+SELECT 'range excluding the minimum still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_key_range_04648 WHERE a >= 0 AND intDiv(a, toInt64(-1)) = -5000) WHERE explain ILIKE '%Granules: 2/100%';
+SELECT 'range excluding the minimum answers', (SELECT count() FROM t_key_range_04648 WHERE a >= 0 AND intDiv(a, toInt64(-1)) = -5000) AS keyed, (SELECT count() FROM t_mem_range_04648 WHERE a >= 0 AND intDiv(a, toInt64(-1)) = -5000) AS oracle;
+
+-- A divisor that is not effectively `-1` is untouched.
+SELECT 'divisor -2 still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_key_range_04648 WHERE intDiv(a, toInt8(-2)) = -2500) WHERE explain ILIKE '%Granules: 2/100%';
+SELECT 'divisor -2 answers', (SELECT count() FROM t_key_range_04648 WHERE intDiv(a, toInt8(-2)) = -2500) AS keyed, (SELECT count() FROM t_mem_range_04648 WHERE intDiv(a, toInt8(-2)) = -2500) AS oracle;
+
+-- Unsigned/unsigned never reaches the signed wrap: `intDiv(UInt8, toUInt8(255))` is not a carrier and
+-- must keep answering. This pins the dividend-type gate.
+CREATE TABLE t_key_u8_04648 (a UInt8) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_u8_04648 (a UInt8) ENGINE = Memory;
+INSERT INTO t_key_u8_04648 VALUES (0), (1), (200), (254), (255);
+INSERT INTO t_mem_u8_04648 VALUES (0), (1), (200), (254), (255);
+SELECT 'UInt8 / toUInt8(255)', (SELECT count() FROM t_key_u8_04648 WHERE intDiv(a, toUInt8(255)) = 0) AS keyed, (SELECT count() FROM t_mem_u8_04648 WHERE intDiv(a, toUInt8(255)) = 0) AS oracle;
+
+CREATE TABLE t_key_u16_04648 (a UInt16) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_u16_04648 (a UInt16) ENGINE = Memory;
+INSERT INTO t_key_u16_04648 VALUES (0), (1), (40000), (65534), (65535);
+INSERT INTO t_mem_u16_04648 VALUES (0), (1), (40000), (65534), (65535);
+SELECT 'UInt16 / toUInt16(65535)', (SELECT count() FROM t_key_u16_04648 WHERE intDiv(a, toUInt16(65535)) = 0) AS keyed, (SELECT count() FROM t_mem_u16_04648 WHERE intDiv(a, toUInt16(65535)) = 0) AS oracle;
+
+-- A Float divisor takes the floating-point path, whose unsafe set is different and not `-1`-specific,
+-- so it stays outside the guard and must keep pruning. This pins the divisor-type gate.
+CREATE TABLE t_key_i8f_04648 (a Int8) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_i8f_04648 (a Int8) ENGINE = Memory;
+INSERT INTO t_key_i8f_04648 SELECT toInt8(number - 126) FROM numbers(254);
+INSERT INTO t_mem_i8f_04648 SELECT toInt8(number - 126) FROM numbers(254);
+SELECT 'Float divisor still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_key_i8f_04648 WHERE intDiv(a, toFloat64(-1)) = 50) WHERE explain ILIKE '%Granules: 2/254%';
+SELECT 'Float divisor answers', (SELECT count() FROM t_key_i8f_04648 WHERE intDiv(a, toFloat64(-1)) = 50) AS keyed, (SELECT count() FROM t_mem_i8f_04648 WHERE intDiv(a, toFloat64(-1)) = 50) AS oracle;
+
+-- Read-in-order is what the null-endpoint verdict decides, so it is the only observable that can pin the
+-- two type gates for a divisor that is `-1`: widening either gate would silently cost this optimization
+-- for operand pairs that never wrap silently. `Int64 / toFloat64(-1)` pins the divisor gate (a Float
+-- divisor computes through floating point), `Int16 / toInt16(-1)` pins the dividend gate (an `Int16`
+-- dividend has no vectorized specialization and throws instead of wrapping).
+SELECT 'Float divisor keeps read-in-order', count() > 0 FROM (EXPLAIN SELECT intDiv(a, toFloat64(-1)) FROM t_key_range_04648 ORDER BY intDiv(a, toFloat64(-1)) SETTINGS optimize_read_in_order = 1) WHERE explain ILIKE '%Read type: InReverseOrder%';
+SELECT 'Int128 divisor keeps read-in-order', count() > 0 FROM (EXPLAIN SELECT intDiv(a, toInt128(-1)) FROM t_key_range_04648 ORDER BY intDiv(a, toInt128(-1)) SETTINGS optimize_read_in_order = 1) WHERE explain ILIKE '%Read type: InReverseOrder%';
+
+CREATE TABLE t_key_i16_04648 (a Int16) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+INSERT INTO t_key_i16_04648 SELECT toInt16(number * 100 - 3000) FROM numbers(60);
+SELECT 'Int16 dividend keeps read-in-order', count() > 0 FROM (EXPLAIN SELECT intDiv(a, toInt16(-1)) FROM t_key_i16_04648 ORDER BY intDiv(a, toInt16(-1)) SETTINGS optimize_read_in_order = 1) WHERE explain ILIKE '%Read type: InReverseOrder%';
+
+-- A multi-column key reaches the null-endpoint branch with a genuinely HALF-BOUNDED range
+-- (a concrete left bound and an unbounded right one), which is the shape that pins the containment
+-- helper's side-awareness: treating any null endpoint as "contains the minimum" reads one granule more.
+CREATE TABLE t_key_multi_04648 (x UInt8, a Int64) ENGINE = MergeTree ORDER BY (x, a) SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_multi_04648 (x UInt8, a Int64) ENGINE = Memory;
+INSERT INTO t_key_multi_04648 SELECT number % 3, number * 100 FROM numbers(100);
+INSERT INTO t_mem_multi_04648 SELECT number % 3, number * 100 FROM numbers(100);
+SELECT 'half-bounded range prunes exactly', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_key_multi_04648 WHERE x = 1 AND intDiv(a, toInt64(-1)) >= -5000) WHERE explain ILIKE '%Granules: 18/100%';
+SELECT 'half-bounded range answers', (SELECT count() FROM t_key_multi_04648 WHERE x = 1 AND intDiv(a, toInt64(-1)) >= -5000) AS keyed, (SELECT count() FROM t_mem_multi_04648 WHERE x = 1 AND intDiv(a, toInt64(-1)) >= -5000) AS oracle;
+
+DROP TABLE t_key_i64_04648;
+DROP TABLE t_mem_i64_04648;
+DROP TABLE t_key_i32_04648;
+DROP TABLE t_mem_i32_04648;
+DROP TABLE t_key_null_04648;
+DROP TABLE t_mem_null_04648;
+DROP TABLE t_key_lc_04648;
+DROP TABLE t_mem_lc_04648;
+DROP TABLE t_key_minonly_04648;
+DROP TABLE t_mem_minonly_04648;
+DROP TABLE t_key_range_04648;
+DROP TABLE t_mem_range_04648;
+DROP TABLE t_key_u8_04648;
+DROP TABLE t_mem_u8_04648;
+DROP TABLE t_key_u16_04648;
+DROP TABLE t_mem_u16_04648;
+DROP TABLE t_key_i8f_04648;
+DROP TABLE t_mem_i8f_04648;
+DROP TABLE t_key_i16_04648;
+DROP TABLE t_key_multi_04648;
+DROP TABLE t_mem_multi_04648;

--- a/tests/queries/0_stateless/04648_intdiv_minus_one_monotonicity.sql
+++ b/tests/queries/0_stateless/04648_intdiv_minus_one_monotonicity.sql
@@ -30,6 +30,22 @@ DROP TABLE IF EXISTS t_mem_i8f_04648 SETTINGS ignore_drop_queries_probability = 
 DROP TABLE IF EXISTS t_key_i16_04648 SETTINGS ignore_drop_queries_probability = 0;
 DROP TABLE IF EXISTS t_key_multi_04648 SETTINGS ignore_drop_queries_probability = 0;
 DROP TABLE IF EXISTS t_mem_multi_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_arr64_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_arr64_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_arr32_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_arr32_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_arrarr_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_arrarr_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_arrlc_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_arrlc_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_tup_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_tup_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_tupmix_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_tupmix_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_arrrange_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_arrrange_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_key_arru8_04648 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_arru8_04648 SETTINGS ignore_drop_queries_probability = 0;
 
 CREATE TABLE t_key_i64_04648 (a Int64) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
 CREATE TABLE t_mem_i64_04648 (a Int64) ENGINE = Memory;
@@ -51,6 +67,39 @@ CREATE TABLE t_mem_lc_04648 (a LowCardinality(Int64)) ENGINE = Memory;
 INSERT INTO t_key_lc_04648 VALUES (-9223372036854775808), (-9223372036854775807), (-5), (5);
 INSERT INTO t_mem_lc_04648 VALUES (-9223372036854775808), (-9223372036854775807), (-5), (5);
 
+-- Compound dividends: an `Array`/`Tuple` divided by a scalar constant is evaluated element-wise, so an
+-- element type that wraps carries the same defect while the monotonicity verdict sees only the outer type.
+CREATE TABLE t_key_arr64_04648 (a Array(Int64)) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_arr64_04648 (a Array(Int64)) ENGINE = Memory;
+INSERT INTO t_key_arr64_04648 VALUES ([-9223372036854775808]), ([-9223372036854775807]), ([-5]), ([5]);
+INSERT INTO t_mem_arr64_04648 VALUES ([-9223372036854775808]), ([-9223372036854775807]), ([-5]), ([5]);
+
+CREATE TABLE t_key_arr32_04648 (a Array(Int32)) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_arr32_04648 (a Array(Int32)) ENGINE = Memory;
+INSERT INTO t_key_arr32_04648 VALUES ([-2147483648]), ([-2147483647]), ([-5]), ([5]);
+INSERT INTO t_mem_arr32_04648 VALUES ([-2147483648]), ([-2147483647]), ([-5]), ([5]);
+
+CREATE TABLE t_key_arrarr_04648 (a Array(Array(Int64))) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_arrarr_04648 (a Array(Array(Int64))) ENGINE = Memory;
+INSERT INTO t_key_arrarr_04648 VALUES ([[-9223372036854775808]]), ([[-9223372036854775807]]), ([[-5]]), ([[5]]);
+INSERT INTO t_mem_arrarr_04648 VALUES ([[-9223372036854775808]]), ([[-9223372036854775807]]), ([[-5]]), ([[5]]);
+
+CREATE TABLE t_key_arrlc_04648 (a Array(LowCardinality(Int64))) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_arrlc_04648 (a Array(LowCardinality(Int64))) ENGINE = Memory;
+INSERT INTO t_key_arrlc_04648 VALUES ([-9223372036854775808]), ([-9223372036854775807]), ([-5]), ([5]);
+INSERT INTO t_mem_arrlc_04648 VALUES ([-9223372036854775808]), ([-9223372036854775807]), ([-5]), ([5]);
+
+CREATE TABLE t_key_tup_04648 (a Tuple(Int64, Int64)) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_tup_04648 (a Tuple(Int64, Int64)) ENGINE = Memory;
+INSERT INTO t_key_tup_04648 VALUES ((-9223372036854775808, -9223372036854775808)), ((-9223372036854775807, -9223372036854775807)), ((-5, -5)), ((5, 5));
+INSERT INTO t_mem_tup_04648 VALUES ((-9223372036854775808, -9223372036854775808)), ((-9223372036854775807, -9223372036854775807)), ((-5, -5)), ((5, 5));
+
+-- A MIXED tuple: only the first element is of a wrapping type, and one wrapping element is enough.
+CREATE TABLE t_key_tupmix_04648 (a Tuple(Int64, Int8)) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_tupmix_04648 (a Tuple(Int64, Int8)) ENGINE = Memory;
+INSERT INTO t_key_tupmix_04648 VALUES ((-9223372036854775808, 3)), ((-9223372036854775807, 3)), ((-5, 3)), ((5, 3));
+INSERT INTO t_mem_tupmix_04648 VALUES ((-9223372036854775808, 3)), ((-9223372036854775807, 3)), ((-5, 3)), ((5, 3));
+
 SELECT 'wrong results: keyed count must equal the Memory oracle';
 
 -- Every spelling of an effective `-1` divisor that takes `DivideIntegralByConstantImpl::vectorConstant`
@@ -70,6 +119,16 @@ SELECT 'Int32 / toInt64(-1)', (SELECT count() FROM t_key_i32_04648 WHERE intDiv(
 SELECT 'Nullable(Int64) / toInt64(-1)', (SELECT count() FROM t_key_null_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808)) AS keyed, (SELECT count() FROM t_mem_null_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808)) AS oracle;
 SELECT 'LowCardinality(Int64) / toInt64(-1)', (SELECT count() FROM t_key_lc_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808)) AS keyed, (SELECT count() FROM t_mem_lc_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808)) AS oracle;
 
+-- Compound carriers: `getMonotonicityForRange` sees only the OUTER type, so the scalar dividend gate
+-- cannot detect an `Array`/`Tuple` whose ELEMENTS are of a wrapping type. Nesting is followed
+-- recursively, and a tuple is a carrier as soon as any one of its elements is.
+SELECT 'Array(Int64) / toInt64(-1)', (SELECT count() FROM t_key_arr64_04648 WHERE intDiv(a, toInt64(-1)) = [toInt64(-9223372036854775808)]) AS keyed, (SELECT count() FROM t_mem_arr64_04648 WHERE intDiv(a, toInt64(-1)) = [toInt64(-9223372036854775808)]) AS oracle;
+SELECT 'Array(Int32) / toInt32(-1)', (SELECT count() FROM t_key_arr32_04648 WHERE intDiv(a, toInt32(-1)) = [toInt32(-2147483648)]) AS keyed, (SELECT count() FROM t_mem_arr32_04648 WHERE intDiv(a, toInt32(-1)) = [toInt32(-2147483648)]) AS oracle;
+SELECT 'Array(Array(Int64)) / toInt64(-1)', (SELECT count() FROM t_key_arrarr_04648 WHERE intDiv(a, toInt64(-1)) = [[toInt64(-9223372036854775808)]]) AS keyed, (SELECT count() FROM t_mem_arrarr_04648 WHERE intDiv(a, toInt64(-1)) = [[toInt64(-9223372036854775808)]]) AS oracle;
+SELECT 'Array(LowCardinality(Int64)) / toInt64(-1)', (SELECT count() FROM t_key_arrlc_04648 WHERE intDiv(a, toInt64(-1)) = [toInt64(-9223372036854775808)]) AS keyed, (SELECT count() FROM t_mem_arrlc_04648 WHERE intDiv(a, toInt64(-1)) = [toInt64(-9223372036854775808)]) AS oracle;
+SELECT 'Tuple(Int64, Int64) / toInt64(-1)', (SELECT count() FROM t_key_tup_04648 WHERE intDiv(a, toInt64(-1)) = (toInt64(-9223372036854775808), toInt64(-9223372036854775808))) AS keyed, (SELECT count() FROM t_mem_tup_04648 WHERE intDiv(a, toInt64(-1)) = (toInt64(-9223372036854775808), toInt64(-9223372036854775808))) AS oracle;
+SELECT 'Tuple(Int64, Int8) / toInt64(-1)', (SELECT count() FROM t_key_tupmix_04648 WHERE intDiv(a, toInt64(-1)) = (toInt64(-9223372036854775808), toInt8(-3))) AS keyed, (SELECT count() FROM t_mem_tupmix_04648 WHERE intDiv(a, toInt64(-1)) = (toInt64(-9223372036854775808), toInt8(-3))) AS oracle;
+
 SELECT 'wrong ORDER BY: the keyed order must equal the Memory oracle';
 
 -- `ReadInOrderOptimizer` probes with unbounded endpoints and only reads `is_monotonic`/`is_positive`,
@@ -78,16 +137,23 @@ SELECT 'wrong ORDER BY: the keyed order must equal the Memory oracle';
 SELECT 'ORDER BY intDiv(a, -1)',
        (SELECT groupArray(x) FROM (SELECT intDiv(a, toInt64(-1)) AS x FROM t_key_i64_04648 ORDER BY intDiv(a, toInt64(-1)))) AS keyed,
        (SELECT groupArray(x) FROM (SELECT intDiv(a, toInt64(-1)) AS x FROM t_mem_i64_04648 ORDER BY intDiv(a, toInt64(-1)))) AS oracle;
+SELECT 'ORDER BY intDiv(Array(Int64), -1)',
+       (SELECT groupArray(x) FROM (SELECT intDiv(a, toInt64(-1)) AS x FROM t_key_arr64_04648 ORDER BY intDiv(a, toInt64(-1)))) AS keyed,
+       (SELECT groupArray(x) FROM (SELECT intDiv(a, toInt64(-1)) AS x FROM t_mem_arr64_04648 ORDER BY intDiv(a, toInt64(-1)))) AS oracle;
 
 SELECT 'preserved pruning: the guard must not fire outside the wrap';
 
--- A single-point range is trivially monotonic and the transform is exact there, so pruning a table
--- that contains only the minimum must keep working.
+-- A single-point range is trivially monotonic and the transform is exact there (the equal-endpoint branch
+-- decides it, and this PR does not touch that branch), so pruning a table whose every adjacent mark pair
+-- is `(minimum, minimum)` must keep working. Eight rows so that a non-matching predicate has marks to
+-- reject: `intDiv(min, -1)` is `min`, so `= 5` must prune the whole part away.
 CREATE TABLE t_key_minonly_04648 (a Int64) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
 CREATE TABLE t_mem_minonly_04648 (a Int64) ENGINE = Memory;
-INSERT INTO t_key_minonly_04648 VALUES (-9223372036854775808), (-9223372036854775808);
-INSERT INTO t_mem_minonly_04648 VALUES (-9223372036854775808), (-9223372036854775808);
+INSERT INTO t_key_minonly_04648 SELECT -9223372036854775808 FROM numbers(8);
+INSERT INTO t_mem_minonly_04648 SELECT -9223372036854775808 FROM numbers(8);
 SELECT 'single-point range at the minimum', (SELECT count() FROM t_key_minonly_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808)) AS keyed, (SELECT count() FROM t_mem_minonly_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808)) AS oracle;
+SELECT 'single-point range at the minimum still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_key_minonly_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(5)) WHERE explain ILIKE '%Granules: 0/8%';
+SELECT 'single-point range at the minimum prunes correctly', (SELECT count() FROM t_key_minonly_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(5)) AS keyed, (SELECT count() FROM t_mem_minonly_04648 WHERE intDiv(a, toInt64(-1)) = toInt64(5)) AS oracle;
 
 CREATE TABLE t_key_range_04648 (a Int64) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
 CREATE TABLE t_mem_range_04648 (a Int64) ENGINE = Memory;
@@ -107,18 +173,21 @@ SELECT 'divisor -2 still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT c
 SELECT 'divisor -2 answers', (SELECT count() FROM t_key_range_04648 WHERE intDiv(a, toInt8(-2)) = -2500) AS keyed, (SELECT count() FROM t_mem_range_04648 WHERE intDiv(a, toInt8(-2)) = -2500) AS oracle;
 
 -- Unsigned/unsigned never reaches the signed wrap: `intDiv(UInt8, toUInt8(255))` is not a carrier and
--- must keep answering. This pins the dividend-type gate.
+-- must keep answering AND keep pruning. This pins the dividend-type gate. The tables span the full
+-- unsigned domain so that a predicate selecting a single quotient has marks to reject.
 CREATE TABLE t_key_u8_04648 (a UInt8) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
 CREATE TABLE t_mem_u8_04648 (a UInt8) ENGINE = Memory;
-INSERT INTO t_key_u8_04648 VALUES (0), (1), (200), (254), (255);
-INSERT INTO t_mem_u8_04648 VALUES (0), (1), (200), (254), (255);
-SELECT 'UInt8 / toUInt8(255)', (SELECT count() FROM t_key_u8_04648 WHERE intDiv(a, toUInt8(255)) = 0) AS keyed, (SELECT count() FROM t_mem_u8_04648 WHERE intDiv(a, toUInt8(255)) = 0) AS oracle;
+INSERT INTO t_key_u8_04648 SELECT number FROM numbers(256);
+INSERT INTO t_mem_u8_04648 SELECT number FROM numbers(256);
+SELECT 'UInt8 / toUInt8(255)', (SELECT count() FROM t_key_u8_04648 WHERE intDiv(a, toUInt8(255)) = 1) AS keyed, (SELECT count() FROM t_mem_u8_04648 WHERE intDiv(a, toUInt8(255)) = 1) AS oracle;
+SELECT 'UInt8 / toUInt8(255) still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_key_u8_04648 WHERE intDiv(a, toUInt8(255)) = 1) WHERE explain ILIKE '%Granules: 2/256%';
 
 CREATE TABLE t_key_u16_04648 (a UInt16) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
 CREATE TABLE t_mem_u16_04648 (a UInt16) ENGINE = Memory;
-INSERT INTO t_key_u16_04648 VALUES (0), (1), (40000), (65534), (65535);
-INSERT INTO t_mem_u16_04648 VALUES (0), (1), (40000), (65534), (65535);
-SELECT 'UInt16 / toUInt16(65535)', (SELECT count() FROM t_key_u16_04648 WHERE intDiv(a, toUInt16(65535)) = 0) AS keyed, (SELECT count() FROM t_mem_u16_04648 WHERE intDiv(a, toUInt16(65535)) = 0) AS oracle;
+INSERT INTO t_key_u16_04648 SELECT if(number = 66, 65535, number * 1000) FROM numbers(67);
+INSERT INTO t_mem_u16_04648 SELECT if(number = 66, 65535, number * 1000) FROM numbers(67);
+SELECT 'UInt16 / toUInt16(65535)', (SELECT count() FROM t_key_u16_04648 WHERE intDiv(a, toUInt16(65535)) = 1) AS keyed, (SELECT count() FROM t_mem_u16_04648 WHERE intDiv(a, toUInt16(65535)) = 1) AS oracle;
+SELECT 'UInt16 / toUInt16(65535) still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_key_u16_04648 WHERE intDiv(a, toUInt16(65535)) = 1) WHERE explain ILIKE '%Granules: 2/67%';
 
 -- A Float divisor takes the floating-point path, whose unsafe set is different and not `-1`-specific,
 -- so it stays outside the guard and must keep pruning. This pins the divisor-type gate.
@@ -151,6 +220,22 @@ INSERT INTO t_mem_multi_04648 SELECT number % 3, number * 100 FROM numbers(100);
 SELECT 'half-bounded range prunes exactly', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_key_multi_04648 WHERE x = 1 AND intDiv(a, toInt64(-1)) >= -5000) WHERE explain ILIKE '%Granules: 18/100%';
 SELECT 'half-bounded range answers', (SELECT count() FROM t_key_multi_04648 WHERE x = 1 AND intDiv(a, toInt64(-1)) >= -5000) AS keyed, (SELECT count() FROM t_mem_multi_04648 WHERE x = 1 AND intDiv(a, toInt64(-1)) >= -5000) AS oracle;
 
+-- The compound guard must not over-fire: it is keyed on the ELEMENT type and the constant, so an ordinary
+-- positive divisor and a non-carrier element type must both keep pruning through an `Array` key.
+CREATE TABLE t_key_arrrange_04648 (a Array(Int64)) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_arrrange_04648 (a Array(Int64)) ENGINE = Memory;
+INSERT INTO t_key_arrrange_04648 SELECT [number * 100] FROM numbers(100);
+INSERT INTO t_mem_arrrange_04648 SELECT [number * 100] FROM numbers(100);
+SELECT 'Array dividend, positive divisor still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_key_arrrange_04648 WHERE intDiv(a, toInt64(10)) = [toInt64(50)]) WHERE explain ILIKE '%Granules: 2/100%';
+SELECT 'Array dividend, positive divisor answers', (SELECT count() FROM t_key_arrrange_04648 WHERE intDiv(a, toInt64(10)) = [toInt64(50)]) AS keyed, (SELECT count() FROM t_mem_arrrange_04648 WHERE intDiv(a, toInt64(10)) = [toInt64(50)]) AS oracle;
+
+CREATE TABLE t_key_arru8_04648 (a Array(UInt8)) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_arru8_04648 (a Array(UInt8)) ENGINE = Memory;
+INSERT INTO t_key_arru8_04648 SELECT [toUInt8(number)] FROM numbers(256);
+INSERT INTO t_mem_arru8_04648 SELECT [toUInt8(number)] FROM numbers(256);
+SELECT 'Array(UInt8) element is not a carrier, still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_key_arru8_04648 WHERE intDiv(a, toUInt8(255)) = [toUInt8(1)]) WHERE explain ILIKE '%Granules: 2/256%';
+SELECT 'Array(UInt8) element is not a carrier, answers', (SELECT count() FROM t_key_arru8_04648 WHERE intDiv(a, toUInt8(255)) = [toUInt8(1)]) AS keyed, (SELECT count() FROM t_mem_arru8_04648 WHERE intDiv(a, toUInt8(255)) = [toUInt8(1)]) AS oracle;
+
 DROP TABLE t_key_i64_04648;
 DROP TABLE t_mem_i64_04648;
 DROP TABLE t_key_i32_04648;
@@ -172,3 +257,19 @@ DROP TABLE t_mem_i8f_04648;
 DROP TABLE t_key_i16_04648;
 DROP TABLE t_key_multi_04648;
 DROP TABLE t_mem_multi_04648;
+DROP TABLE t_key_arr64_04648;
+DROP TABLE t_mem_arr64_04648;
+DROP TABLE t_key_arr32_04648;
+DROP TABLE t_mem_arr32_04648;
+DROP TABLE t_key_arrarr_04648;
+DROP TABLE t_mem_arrarr_04648;
+DROP TABLE t_key_arrlc_04648;
+DROP TABLE t_mem_arrlc_04648;
+DROP TABLE t_key_tup_04648;
+DROP TABLE t_mem_tup_04648;
+DROP TABLE t_key_tupmix_04648;
+DROP TABLE t_mem_tupmix_04648;
+DROP TABLE t_key_arrrange_04648;
+DROP TABLE t_mem_arrrange_04648;
+DROP TABLE t_key_arru8_04648;
+DROP TABLE t_mem_arru8_04648;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/90461
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/90461

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes wrong results for queries where a `MergeTree` primary key expression is wrapped in `intDiv` with an effective divisor of `-1`. `intDiv(x, -1)` maps the signed minimum of the computation width onto itself instead of onto the maximum, so it is not monotonic on any range containing that minimum, but it was reported as monotonic. Primary-key analysis therefore pruned a granule that did hold a matching row, and `ORDER BY intDiv(x, -1)` returned mis-sorted rows through the read-in-order optimization. Both now return correct results.


### Description

`intDiv(x, -1)` is mathematically `-x`, which is not representable at the signed minimum of the computation width: `TYPE_MIN / -1` overflows and folds back onto `TYPE_MIN`, while `TYPE_MIN + 1` maps to `TYPE_MAX`. The function is therefore neither non-decreasing nor non-increasing on any range containing that minimum.

`FunctionBinaryArithmeticWithConstants::getMonotonicityForRange` already models two other `intDiv` wraps (`intDivRangeCrossesSignedWrap` for an unsigned dividend, `intDivConstReinterpretsNegative` for an unsigned divisor) but never modelled this **result** wrap, so it reported the function monotonic there. `multiply` already carries the equivalent guard in its `check_overflow` lambda (`/// TYPE_MIN / -1 is UB for native signed types.`); `intDiv` simply lacked it.

Two user-visible, silent, default-reachable symptoms (no error, `RC=0`):

```sql
CREATE TABLE t (a Int64) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
INSERT INTO t VALUES (-9223372036854775808), (-9223372036854775807), (-5), (5);

-- primary-key pruning drops the matching row
SELECT count() FROM t WHERE intDiv(a, toInt64(-1)) = toInt64(-9223372036854775808);
-- before: 0   after: 1   (ENGINE = Memory, which runs no key analysis, returns 1)

-- ORDER BY returns mis-sorted rows via read-in-order
SELECT intDiv(a, toInt64(-1)) FROM t ORDER BY intDiv(a, toInt64(-1));
-- before: -5, 5, MAX, MIN   after: MIN, -5, 5, MAX
```

The fix adds three helpers next to the existing ones and two guards in each of the two branches that decide `intDiv`'s monotonicity:

- `intDivWrapsInsteadOfThrowing` — is this operand pair one that divides by an effective `-1` **and** takes the FPE-suppressing vectorized path? The wrap is produced only by `DivideIntegralByConstantImpl::vectorConstant`, which short-circuits `b == -1` and deliberately avoids `throwIfDivisionLeadsToFPE`. With a signed dividend those registered specializations are an `Int32`/`Int64` dividend with a native signed divisor. Every other **scalar** operand pair throws `ILLEGAL_DIVISION` instead — at runtime as well as during analysis, verified on `ENGINE = Memory` — so it is not a monotonicity problem and is deliberately left alone here.
- `intDivCompoundDividendWrapsInsteadOfThrowing` — the same wrap one type wrapper up. An `Array`/`Tuple` dividend divided by a scalar constant is evaluated element-wise, so an element type that wraps carries the same defect, while `getMonotonicityForRange` sees only the outer type and the scalar predicate above cannot detect it. Nesting is followed recursively, and a tuple is a carrier as soon as any one of its elements is. Measured carriers: `Array(Int64)`, `Array(Int32)`, `Array(Array(Int64))`, `Array(LowCardinality(Int64))`, `Tuple(Int64, Int64)` and the mixed `Tuple(Int64, Int8)` — each returned the wrong `count()` and a mis-sorted `ORDER BY` before this change. A compound dividend with a Float, `Int128` or high-bit-unsigned divisor throws `ILLEGAL_DIVISION` and is not a carrier. Because the endpoints are `Array`/`Tuple` Fields whose element-wise containment of the wrap point is not cheaply modelled, a compound carrier is reported non-monotonic unconditionally, mirroring the Decimal-divisor case immediately above.
- `intDivRangeContainsResultWrapPoint` — does the analysed range contain that minimum? Decided **per side**, so a range like `[0, +Inf)` genuinely excludes it and keeps being pruned.

A range containing the wrap point now reports `{false, true, false, false}` (non-monotonic, no pruning), exactly as `multiply` does on overflow. A range excluding it stays monotonic on that range, but `is_always_monotonic` becomes `false`: it means "monotonic on the whole input range", and the whole domain of a signed type always contains its minimum.

#### Cost, stated explicitly

The unbounded-endpoint verdict is what `ReadInOrderOptimizer` reads, and it has no range to narrow with, so `ORDER BY intDiv(x, -1)` loses the read-in-order optimization **even when the minimum is absent from the data** (measured: such a query uses `InReverseOrder` today and `Default` after this change). That is unavoidable at this layer — the whole column may contain the minimum and the unbounded probe cannot know — and it is the same trade `intDivRangeCrossesSignedWrap` already makes for unbounded unsigned ranges. It is a deliberate correctness-over-optimization choice, not a free fix.

Ordinary `intDiv` pruning is unaffected, and the test asserts that: a positive divisor, a divisor that is not effectively `-1`, unsigned/unsigned, a Float divisor, a half-bounded range excluding the minimum, and a single-point range at the minimum all keep pruning exactly as before, with the granule counts pinned — ten `EXPLAIN indexes = 1` assertions in all, including two that pin an `Array` dividend with a positive divisor and an `Array(UInt8)` dividend, so the new compound guard is provably keyed on the element type and the constant rather than on "is compound".

#### Deliberately out of scope

- **`Code 153` throws at other widths.** No verdict this function can return fixes them. If the analysed range excludes the minimum a correct guard must report the range monotonic (otherwise valid pruning is lost), and `KeyCondition::applyFunction` then evaluates the chain over the **entire** index column, so an out-of-range minimum still in that column still throws. If the analysed range contains the minimum at a throwing width, the query throws at runtime too (the `ENGINE = Memory` oracle exits with the same error), so it was never analysis-injected. Same reason `single_point` partition pruning is untouched: `applyMonotonicFunctionsChainToRange` short-circuits monotonicity when `single_point`, so nothing inside `getMonotonicityForRange` can reach it.
- **The two sibling `intDiv` predicates read the outer dividend type too.** `intDivRangeCrossesSignedWrap` gates on `isUInt(arg_type)` and `intDivConstReinterpretsNegative` on `isInt(arg_type) && isUInt(divisor_type)`, so an `Array`/`Tuple` dividend fails both exactly as it failed the scalar wrap predicate before this change. They model different mechanisms (a step function at `2^(w-1)` for an unsigned dividend, and a direction flip for a high-bit-unsigned divisor), so extending them is a separate concern with its own root cause and its own test matrix, and is tracked separately rather than bundled here.
- **Two further defects found while investigating this one**, each with its own root cause and therefore its own PR rather than being bundled here: the `const / variable` branch reports the inverted direction on a strictly-negative range (wrong results for `intDiv` *and* `divide`, no wrap involved), and `throwIfDivisionLeadsToFPE` compares a floating-point dividend against `numeric_limits<Float>::min()`, which is the smallest *positive* value, so `intDiv(2.2250738585072014e-308, -1.0)` throws spuriously.