### PR TITLE
Fix dropped constant JOIN ON conjunct in splitFilter

### DIFF
--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -1516,10 +1516,26 @@ std::optional<ActionsDAG::ActionsForFilterPushDown> JoinStepLogical::getFilterAc
         return {};
 
     auto & join_expression = join_operator.expression;
-    if (auto filter_condition = concatConditions(join_expression, side))
-        return ActionsDAG::createActionsForConjunction({filter_condition.getNode()}, stream_header->getColumnsWithTypeAndName());
 
-    return {};
+    auto belongs_to_side = [side](const JoinActionRef & condition)
+    {
+        return side == JoinTableSide::Left ? condition.fromLeft() || condition.fromNone() : condition.fromRight();
+    };
+
+    auto conditions = std::ranges::to<std::vector>(join_expression | std::views::filter(belongs_to_side));
+    if (conditions.empty())
+        return {};
+
+    auto condition = conditions.size() == 1
+        ? toBoolIfNeeded(conditions.front())
+        : toBoolIfNeeded(JoinActionRef::transform(conditions, JoinActionRef::AddFunction(JoinConditionOperator::And)));
+
+    auto filter_actions = ActionsDAG::createActionsForConjunction({condition.getNode()}, stream_header->getColumnsWithTypeAndName());
+    if (!filter_actions)
+        return {};
+
+    std::erase_if(join_expression, belongs_to_side);
+    return filter_actions;
 }
 
 static void remapNodes(ActionsDAG::NodeRawConstPtrs & keys, const ActionsDAG::NodeMapping & node_map)

--- a/tests/queries/0_stateless/04648_join_on_constant_null_conjunct.reference
+++ b/tests/queries/0_stateless/04648_join_on_constant_null_conjunct.reference
@@ -16,4 +16,3 @@ right anti	10
 pushdown
 3
 0
-Join filter

--- a/tests/queries/0_stateless/04648_join_on_constant_null_conjunct.reference
+++ b/tests/queries/0_stateless/04648_join_on_constant_null_conjunct.reference
@@ -1,0 +1,19 @@
+inner
+right
+variant
+0
+plan
+Join conditions: id = id AND NULL
+kinds
+inner	0
+left	10
+right	10
+full	20
+left semi	0
+right semi	0
+left anti	10
+right anti	10
+pushdown
+3
+0
+Join filter

--- a/tests/queries/0_stateless/04648_join_on_constant_null_conjunct.sql
+++ b/tests/queries/0_stateless/04648_join_on_constant_null_conjunct.sql
@@ -1,3 +1,5 @@
+-- Tags: no-old-analyzer
+
 -- A constant conjunct of the ON expression belongs to neither side, so it is grouped with the left
 -- one when conditions are pushed out of the join. No filter can be built from a constant predicate,
 -- and the conjunct used to be dropped instead of staying in the ON expression.

--- a/tests/queries/0_stateless/04648_join_on_constant_null_conjunct.sql
+++ b/tests/queries/0_stateless/04648_join_on_constant_null_conjunct.sql
@@ -42,9 +42,5 @@ SELECT 'right anti', count() FROM (SELECT r.id FROM t_04648 AS l RIGHT ANTI JOIN
 SELECT 'pushdown';
 SELECT count() FROM t_04648 AS l INNER JOIN t_04648 AS r ON l.id = r.id AND l.pk = 'cc';
 SELECT count() FROM t_04648 AS l INNER JOIN t_04648 AS r ON l.id = r.id AND l.pk = 'cc' AND CAST(NULL AS Nullable(UInt8));
-SELECT extract(explain, 'Join filter') AS step FROM (
-    EXPLAIN SELECT l.* FROM t_04648 AS l INNER JOIN t_04648 AS r ON l.id = r.id AND r.v > 4
-    SETTINGS query_plan_optimize_prewhere = 0
-) WHERE step != '';
 
 DROP TABLE t_04648;

--- a/tests/queries/0_stateless/04648_join_on_constant_null_conjunct.sql
+++ b/tests/queries/0_stateless/04648_join_on_constant_null_conjunct.sql
@@ -1,0 +1,50 @@
+-- A constant conjunct of the ON expression belongs to neither side, so it is grouped with the left
+-- one when conditions are pushed out of the join. No filter can be built from a constant predicate,
+-- and the conjunct used to be dropped instead of staying in the ON expression.
+-- `query_plan_short_circuit_constant_false_join = 0` keeps the constant-false join on the general path.
+
+SET query_plan_short_circuit_constant_false_join = 0;
+
+DROP TABLE IF EXISTS t_04648;
+CREATE TABLE t_04648 (id UInt32, v Int64, pk String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_04648 SELECT number, number * 2, ['aa', 'bb', 'cc'][number % 3 + 1] FROM numbers(10);
+
+SELECT 'inner';
+SELECT l.* FROM t_04648 AS l INNER JOIN t_04648 AS r ON l.id = r.id AND CAST(NULL AS Nullable(UInt8))
+WHERE l.pk = 'cc' AND r.id >= 3;
+
+SELECT 'right';
+SELECT l.* FROM t_04648 AS l RIGHT JOIN t_04648 AS r ON l.id = r.id AND CAST(NULL AS Nullable(UInt8))
+WHERE l.pk = 'cc' AND r.id >= 3;
+
+SELECT 'variant';
+SELECT count() FROM t_04648 AS l INNER JOIN t_04648 AS r
+ON l.id = r.id AND CAST(CAST(NULL AS Variant(UInt8, String)) AS Nullable(UInt8))
+SETTINGS enable_variant_type = 1;
+
+SELECT 'plan';
+SELECT extract(explain, 'Join conditions:.*') AS cond FROM (
+    EXPLAIN SELECT l.* FROM t_04648 AS l INNER JOIN t_04648 AS r ON l.id = r.id AND CAST(NULL AS Nullable(UInt8))
+    WHERE l.pk = 'cc' AND r.id >= 3
+) WHERE cond != '';
+
+SELECT 'kinds';
+SELECT 'inner', count() FROM (SELECT l.id FROM t_04648 AS l INNER JOIN t_04648 AS r ON l.id = r.id AND CAST(NULL AS Nullable(UInt8)));
+SELECT 'left', count() FROM (SELECT l.id FROM t_04648 AS l LEFT JOIN t_04648 AS r ON l.id = r.id AND CAST(NULL AS Nullable(UInt8)));
+SELECT 'right', count() FROM (SELECT r.id FROM t_04648 AS l RIGHT JOIN t_04648 AS r ON l.id = r.id AND CAST(NULL AS Nullable(UInt8)));
+SELECT 'full', count() FROM (SELECT l.id FROM t_04648 AS l FULL JOIN t_04648 AS r ON l.id = r.id AND CAST(NULL AS Nullable(UInt8)));
+SELECT 'left semi', count() FROM (SELECT l.id FROM t_04648 AS l LEFT SEMI JOIN t_04648 AS r ON l.id = r.id AND CAST(NULL AS Nullable(UInt8)));
+SELECT 'right semi', count() FROM (SELECT r.id FROM t_04648 AS l RIGHT SEMI JOIN t_04648 AS r ON l.id = r.id AND CAST(NULL AS Nullable(UInt8)));
+SELECT 'left anti', count() FROM (SELECT l.id FROM t_04648 AS l LEFT ANTI JOIN t_04648 AS r ON l.id = r.id AND CAST(NULL AS Nullable(UInt8)));
+SELECT 'right anti', count() FROM (SELECT r.id FROM t_04648 AS l RIGHT ANTI JOIN t_04648 AS r ON l.id = r.id AND CAST(NULL AS Nullable(UInt8)));
+
+-- A one-sided ON predicate must still be pushed out of the join, alone or next to the constant.
+SELECT 'pushdown';
+SELECT count() FROM t_04648 AS l INNER JOIN t_04648 AS r ON l.id = r.id AND l.pk = 'cc';
+SELECT count() FROM t_04648 AS l INNER JOIN t_04648 AS r ON l.id = r.id AND l.pk = 'cc' AND CAST(NULL AS Nullable(UInt8));
+SELECT extract(explain, 'Join filter') AS step FROM (
+    EXPLAIN SELECT l.* FROM t_04648 AS l INNER JOIN t_04648 AS r ON l.id = r.id AND r.v > 4
+    SETTINGS query_plan_optimize_prewhere = 0
+) WHERE step != '';
+
+DROP TABLE t_04648;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/111820
Related: https://github.com/ClickHouse/ClickHouse/pull/110234

The `query_plan_split_filter` pass (`trySplitJoin`) asks `JoinStepLogical::getFilterActions` for a
filter it can lower onto one side of the join. `concatConditions` removed the matched conjuncts from
the ON expression up front, but `ActionsDAG::createActionsForConjunction` then gives up on a constant
predicate and returns `nullopt` — so the conjunct was gone with nothing taking its place. A constant
reads from neither side, so it is grouped with the left one, which is how
`ON l.id = r.id AND CAST(NULL AS Nullable(UInt8))` ended up executing as `ON l.id = r.id`:

```
Join conditions: id = id AND NULL   -- query_plan_enable_optimizations = 0
Join conditions: id = id            -- at defaults
```

`getFilterActions` now collects the side's conjuncts without touching the ON expression and removes
them only after a filter has actually been built.

Since 26.8 the wrong result was masked at default settings by
`query_plan_short_circuit_constant_false_join`, which empties the inputs of a constant-false join
before this pass runs; it reproduced with that setting turned off.

Only the pre-folded constant forms were affected — a bare `NULL`, a `materialize`d one, or a constant
next to another one-sided predicate are not plain constant columns in the DAG and survived. `LEFT`,
`RIGHT`, `FULL` and `LEFT ANTI` were never affected, since a left-side condition may not be pushed
out of `ON` for those kinds.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a wrong result for a `JOIN` whose `ON` expression contains a constant conjunct, for example
`ON l.id = r.id AND CAST(NULL AS Nullable(UInt8))`. The constant was silently dropped by query plan
optimization, so the join ran as if it were not there: `INNER`, `LEFT SEMI` and `RIGHT SEMI` joins
returned matched rows where a never-true condition must return none, and `RIGHT ANTI` returned no
rows instead of all of them.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.353` (included in `26.8` and later)
<!-- ch-version-info:end -->