### PR TITLE
Fix flaky `03100_lwu_15_future_reads`

### DIFF
--- a/tests/queries/0_stateless/03100_lwu_15_future_reads.sh
+++ b/tests/queries/0_stateless/03100_lwu_15_future_reads.sh
@@ -26,7 +26,11 @@ $CLICKHOUSE_CLIENT --query "
     ORDER BY id
     SETTINGS
         enable_block_number_column = 1,
-        enable_block_offset_column = 1;
+        enable_block_offset_column = 1,
+        -- The test checks the number of rows in patch parts at the end.
+        -- Once the patches are applied, the cleanup thread is free to drop them,
+        -- so keep them around to make the last query deterministic.
+        remove_unused_patch_parts = 0;
 
     INSERT INTO t_lwu_future_reads SELECT number, number FROM numbers(1000);
     SYSTEM ENABLE FAILPOINT $failpoint_name;


### PR DESCRIPTION
`03100_lwu_15_future_reads` is flaky. It ends with

```sql
SELECT sum(rows) FROM system.parts
WHERE database = currentDatabase() AND table = 't_lwu_future_reads' AND startsWith(name, 'patch');
```

and expects `200`, but that query was racing against the background cleanup thread.

Once `OPTIMIZE TABLE ... FINAL` has applied the patches, the data version of the merged part reaches the patches' max data version, so `clearUnusedPatchParts` considers both patch parts unused and drops them. For `ReplicatedMergeTree` the drop goes through a `DROP_PART` log entry, which removes the parts outright rather than leaving them `Outdated`, so they disappear from `system.parts` and the last query returns `0` - or `100`, when only one of them had been dropped yet.

On a fast runner the test finishes long before the first iteration of the cleanup thread, so the race is invisible. On a loaded runner it gets a turn before the last query; accordingly, all observed failures are on `amd_tsan`, `amd_msan` and flaky checks. The two sums the test checks were always correct, so this is a test-only race and not a product bug.

The fix pins `remove_unused_patch_parts = 0` on the table, the same way `03100_lwu_01_basics` and other lightweight-update tests already do, so the patch parts stay in place for the final check. The future-reads check itself is unaffected.

Verified locally on a `ReplicatedMergeTree` setup by making the cleanup thread run every second (`cleanup_delay_period = 1`) and widening the window before the last query, which turns the race into a deterministic failure:

* without this change the test fails with exactly the diff seen in CI (`-200` / `+0`);
* with this change the test passes (repeated runs, including with randomized settings).

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=107275200b9ab432ec9375a091aad62690484bfd&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.302` (included in `26.8` and later)
<!-- ch-version-info:end -->