### PR TITLE
Make `match_max` effective in `04615_client_progress_table_toggle_config`

### DIFF
--- a/tests/queries/0_stateless/04615_client_progress_table_toggle_config.expect
+++ b/tests/queries/0_stateless/04615_client_progress_table_toggle_config.expect
@@ -41,7 +41,13 @@ set stty_init "rows 40 cols 120"
 
 log_user 0
 set timeout 120
-match_max 100000
+# `match_max` without `-d` sets the buffer of the *current* spawn id only, and there
+# is none yet at this point, so every process spawned below silently keeps expect's
+# 2000-byte default instead of the 100000 asked for here. 2000 bytes is less than a
+# single rendering of the live progress table, so expect keeps discarding the oldest
+# part of its buffer while this test streams tens of kilobytes of continuously
+# redrawn table through the pty. Set the default that later `spawn` commands inherit.
+match_max -d 100000
 expect_after {
     # Do not ignore eof from expect
     -i $any_spawn_id eof { exp_continue }


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

Make `match_max` actually take effect in `04615_client_progress_table_toggle_config`.

`match_max 100000` without `-d` applies to the *current* spawn id, and there is none at the point where the test sets it, so all three clients spawned later ran with expect's 2000-byte default buffer instead. That is smaller than a single rendering of the live progress table, while this test streams tens of kilobytes of continuously redrawn table through the pty, so expect kept discarding the oldest part of its buffer while matching.

The test fails by timeout on loaded runners (9 failures in 12036 runs over the last week, none on `master` head), for example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100173&sha=0b83f4eaa78570a1cb035da08702534fe3c4bfe7&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29 — the expect debug log there shows matching against a buffer whose beginning had been cut mid-token.

Verified locally: `[match_max]` right after a `spawn` reports `2000` without `-d` and `100000` with it, and the test still passes (3/3 runs).

Note that all 53 `.expect` tests under `tests/queries/0_stateless` set `match_max 100000` the same ineffective way. This change touches only the test that is currently failing, because a larger buffer also makes expect retain older output, which could change how negative `expect` patterns behave in the other tests — that sweep is better done deliberately.

Related: https://github.com/ClickHouse/ClickHouse/pull/100173


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.303` (included in `26.8` and later)
<!-- ch-version-info:end -->