### PR TITLE
Text index: write zeros when decoding a zero-bit-width bitpacked block

### DIFF
--- a/src/Storages/MergeTree/BitpackingBlockCodec.h
+++ b/src/Storages/MergeTree/BitpackingBlockCodec.h
@@ -311,8 +311,7 @@ struct BitpackingBlockCodecImpl<false>
         /// written: callers may decode into a reused buffer, and SIMDComp's SIMD_nullunpacker32 writes them too.
         if constexpr (Bits == 0)
         {
-            for (size_t i = 0; i < groups * 4; ++i)
-                out[i] = 0;
+            std::memset(out, 0, groups * 4 * sizeof(uint32_t));
             return in;
         }
 
@@ -533,8 +532,7 @@ struct BitpackingBlockCodecImpl<false>
         /// callers may decode into a reused buffer, and SIMDComp's simdunpack_shortlength writes them too.
         if constexpr (Bits == 0)
         {
-            for (size_t i = 0; i < tail; ++i)
-                out[i] = 0;
+            std::memset(out, 0, tail * sizeof(uint32_t));
             return in;
         }
 

--- a/src/Storages/MergeTree/BitpackingBlockCodec.h
+++ b/src/Storages/MergeTree/BitpackingBlockCodec.h
@@ -287,7 +287,7 @@ struct BitpackingBlockCodecImpl<false>
     /// memcpy-ing 16 bytes from the byte stream into four uint32_t words.
     ///
     /// Behavior by Bits:
-    /// - Bits == 0  : no payload is stored/consumed. (Caller may treat decoded values as zeros.)
+    /// - Bits == 0  : no payload is stored/consumed, but all `groups * 4` decoded values are written as zeros.
     /// - Bits == 32 : values are stored as raw uint32_t; copy groups*4 words and advance by groups*16 bytes.
     /// - Bits 1..31 : use four 64-bit lane accumulators (acc0..acc3) as bit reservoirs.
     ///               Refill by reading one 16-byte chunk (4×uint32_t, 32 bits per lane)
@@ -307,9 +307,14 @@ struct BitpackingBlockCodecImpl<false>
         static_assert(Bits <= 32, "Bits must be 0..32");
         if (groups == 0) return in;
 
-        /// Bits==0: no payload in the stream;
+        /// Bits==0: no payload in the stream, so every decoded value is zero. The zeros must still be
+        /// written: callers may decode into a reused buffer, and SIMDComp's SIMD_nullunpacker32 writes them too.
         if constexpr (Bits == 0)
+        {
+            for (size_t i = 0; i < groups * 4; ++i)
+                out[i] = 0;
             return in;
+        }
 
         /// Bits==32: stream stores raw uint32_t values (4 per group / per m128i).
         if constexpr (Bits == 32)
@@ -507,7 +512,7 @@ struct BitpackingBlockCodecImpl<false>
     /// (e.g. 128 integers).
     ///
     /// Special cases:
-    /// - Bits == 0  : no payload is stored/consumed. (Caller may treat decoded values as zeros.)
+    /// - Bits == 0  : no payload is stored/consumed, but all `tail` decoded values are written as zeros.
     /// - Bits == 32 : values are stored as raw uint32_t, tightly packed (tail * 4 bytes),
     ///               with no 16-byte chunk padding.
     ///
@@ -524,9 +529,14 @@ struct BitpackingBlockCodecImpl<false>
         static_assert(Bits <= 32, "Bits must be 0..32");
         if (tail == 0) return in;
 
-        /// Bits==0: no stored bits;
+        /// Bits==0: no stored bits, so every decoded value is zero. The zeros must still be written:
+        /// callers may decode into a reused buffer, and SIMDComp's simdunpack_shortlength writes them too.
         if constexpr (Bits == 0)
+        {
+            for (size_t i = 0; i < tail; ++i)
+                out[i] = 0;
             return in;
+        }
 
         /// Bits==32: raw uint32_t values are stored tightly (SIMDComp's special-case behavior).
         if constexpr (Bits == 32)

--- a/src/Storages/MergeTree/tests/gtest_posting_list_codec.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_codec.cpp
@@ -73,11 +73,10 @@ void verifyRoundTrip(const std::vector<uint32_t> & original, std::optional<uint3
         << "decode used bytes must equal encode used bytes";
     ASSERT_EQ(in_span.size(), 0u)
         << "decode must consume exactly used bytes from input span";
-    /// If bits is 0, it means no data will be stored in a compressed form. In the decode/encode implementation,
-    /// we return early and don’t clear the output buffer,
-    /// because there’s no data to write into that buffer anyway. So the check can be skipped here.
-    if (use_bits > 0)
-        ASSERT_EQ(decoded, original) << "roundtrip mismatch";
+    /// `bits == 0` stores no payload, but the decoded values are still `original.size()` zeros and the
+    /// decoder must write them: `decoded` is sentinel-filled above, so a decoder that returns without
+    /// writing leaves the sentinel behind and fails here.
+    ASSERT_EQ(decoded, original) << "roundtrip mismatch";
 }
 }
 
@@ -506,6 +505,45 @@ TEST(PostingListCodecTest, MixedRandomMonotonicLarger)
     }
 }
 
+/// `bits == 0` stores no payload, so a decoder is tempted to return without touching `out`.
+/// Callers must not be required to pre-clear: PostingListCursor::decodeBlock decodes into a
+/// persistent, reused buffer and then runs an in-place inclusive_scan over it, so a value left over
+/// from an earlier block becomes a bogus absolute row id and a posting is silently dropped.
+TEST(PostingListCodecTest, DecodeZeroBitsWritesZeros)
+{
+    /// Covers the full-block (groups) path, the tail path, and both combined.
+    for (size_t count : {size_t(1), size_t(2), size_t(3), size_t(4), size_t(5), size_t(7),
+                         size_t(127), size_t(128), size_t(129), size_t(256), size_t(257)})
+    {
+        const std::vector<uint32_t> expected(count, 0u);
+
+        std::vector<uint32_t> decoded(count, 0xDEADBEEFu);
+        std::span<uint32_t> decoded_span(decoded.data(), decoded.size());
+        std::span<const std::byte> in_span;
+
+        const size_t used = Portable::decode(in_span, count, /*max_bits=*/0, decoded_span);
+
+        EXPECT_EQ(used, 0u) << "bits == 0 must consume no input (count=" << count << ")";
+        EXPECT_EQ(decoded, expected)
+            << "bits == 0 must write `count` zeros instead of leaving the caller's buffer untouched"
+            << " (count=" << count << ")";
+
+#if USE_SIMDCOMP
+        std::vector<uint32_t> decoded_simd(count, 0xDEADBEEFu);
+        std::span<uint32_t> decoded_simd_span(decoded_simd.data(), decoded_simd.size());
+        std::span<const std::byte> in_span_simd;
+
+        const size_t used_simd = SIMDComp::decode(in_span_simd, count, /*max_bits=*/0, decoded_simd_span);
+
+        EXPECT_EQ(used_simd, 0u) << "bits == 0 must consume no input (count=" << count << ")";
+        EXPECT_EQ(decoded_simd, expected)
+            << "SIMDComp bits == 0 must write `count` zeros (count=" << count << ")";
+        EXPECT_EQ(decoded, decoded_simd)
+            << "the two implementations must decode bits == 0 identically (count=" << count << ")";
+#endif
+    }
+}
+
 [[maybe_unused]] static size_t expectedCompressedBytes(size_t length, uint32_t bit)
 {
     if (bit == 0) return 0;
@@ -585,10 +623,15 @@ TEST(PostingListCodecTest, MixedRandomMonotonicLarger)
     return used;
 }
 
+/// Decode destinations are pre-filled with this rather than 0, so that a decoder which returns
+/// without writing (as `bit == 0` used to do on the portable path) is caught instead of matching an
+/// all-zero expectation by luck.
+static constexpr uint32_t DECODE_SENTINEL = 0xDEADBEEFu;
+
 // Portable decode helper: decodes `n` integers from `in` (expected payload length) into `out`.
 [[maybe_unused]] static size_t decodePortable(const std::vector<std::byte> & in, size_t n, uint32_t bit, std::vector<uint32_t> & out)
 {
-    out.assign(n, 0u);
+    out.assign(n, DECODE_SENTINEL);
 
     std::span<const std::byte> in_span(in.data(), in.size());
     std::span<uint32_t> out_span(out.data(), out.size());
@@ -616,7 +659,7 @@ static size_t encodeSIMDComp(const std::vector<uint32_t> & in, uint32_t bit, std
 // Portable decode helper: decodes `n` integers from `in` (expected payload length) into `out`.
 static size_t decodeSIMDComp(const std::vector<std::byte> & in, size_t n, uint32_t bit, std::vector<uint32_t> & out)
 {
-    out.assign(n, 0u);
+    out.assign(n, DECODE_SENTINEL);
 
     std::span<const std::byte> in_span(in.data(), in.size());
     std::span<uint32_t> out_span(out.data(), out.size());

--- a/tests/queries/0_stateless/04647_text_index_lazy_single_posting_segment.reference
+++ b/tests/queries/0_stateless/04647_text_index_lazy_single_posting_segment.reference
@@ -1,0 +1,10 @@
+fixture	129	1	1025
+parts	1
+rowscan	129	66177
+lazy leapfrog, on_data_read=1	129	66177
+lazy leapfrog, on_data_read=0	129	66177
+lazy brute force (control)	129	66177
+materialize (control)	129	66177
+bruteforce	0	1	1
+leapfrog_0	1	0	1
+leapfrog_1	1	0	1

--- a/tests/queries/0_stateless/04647_text_index_lazy_single_posting_segment.sql
+++ b/tests/queries/0_stateless/04647_text_index_lazy_single_posting_segment.sql
@@ -1,4 +1,5 @@
--- Tags: no-random-merge-tree-settings
+-- Tags: no-random-merge-tree-settings, no-parallel-replicas
+-- no-parallel-replicas: the ProfileEvents guard below is read from the initiator's query_log.
 -- Regression test for a wrong-results bug in the bitpacking posting list codec: a segment holding
 -- exactly one posting is encoded with `bits == 0` (its only delta is 0), and the portable decoder
 -- used on every non-x86_64-Linux build returned without writing the decoded zero. The lazy cursor
@@ -33,6 +34,8 @@ INSERT INTO t_lazy_single_posting_segment
 SELECT number, concat(if(number = 1026, 'zzz', 'aaa'), ' ', if(number % 8 = 1 AND number <= 1025, 'bbb', 'ccc'))
 FROM numbers(4096);
 
+-- `numbers(...)` is a single-stream source (`num_streams` is forced to 1), so the INSERT above
+-- produces exactly one part regardless of the randomized `max_insert_threads`.
 -- Fixture preconditions: a single part, and 'bbb' has 129 postings starting at row 1.
 SELECT 'fixture', count(), min(id), max(id) FROM t_lazy_single_posting_segment WHERE hasToken(s, 'bbb') SETTINGS use_skip_indexes = 0;
 SELECT 'parts', count() FROM system.parts WHERE database = currentDatabase() AND table = 't_lazy_single_posting_segment' AND active;
@@ -84,13 +87,18 @@ SETTINGS text_index_posting_list_apply_mode = 'materialize',
 -- instead of leaving the assertions above trivially satisfied.
 SYSTEM FLUSH LOGS query_log;
 
+-- The time bound below is the in-tree convention, not a correctness requirement: it does NOT close
+-- the stress-regime residual where odd workers share `--database=test_{i}` and the retry loop re-runs
+-- this script against the same database without cleanup, so a retried run can still see both
+-- attempts' rows. Closing that would need a per-run discriminator inside `log_comment`.
 SELECT
     replaceOne(log_comment, 'test_04647_', '') AS which,
     ProfileEvents['TextIndexLazyLeapfrogIntersections'] > 0 AS used_leapfrog,
     ProfileEvents['TextIndexLazyBruteForceIntersections'] > 0 AS used_brute_force,
     ProfileEvents['TextIndexLazyPackedBlocksDecoded'] > 0 AS decoded_packed_blocks
 FROM system.query_log
-WHERE current_database = currentDatabase()
+WHERE event_date >= yesterday() AND event_time >= now() - 600
+  AND current_database = currentDatabase()
   AND log_comment LIKE 'test_04647_%'
   AND type = 'QueryFinish'
 ORDER BY which

--- a/tests/queries/0_stateless/04647_text_index_lazy_single_posting_segment.sql
+++ b/tests/queries/0_stateless/04647_text_index_lazy_single_posting_segment.sql
@@ -1,0 +1,99 @@
+-- Tags: no-random-merge-tree-settings
+-- Regression test for a wrong-results bug in the bitpacking posting list codec: a segment holding
+-- exactly one posting is encoded with `bits == 0` (its only delta is 0), and the portable decoder
+-- used on every non-x86_64-Linux build returned without writing the decoded zero. The lazy cursor
+-- decodes into a reused buffer and then runs an in-place inclusive_scan over it, so the stale value
+-- from the previous block turned into a bogus absolute row id and the posting was silently dropped.
+--
+-- The fixture is built so that all of the following hold; without any one of them the test passes
+-- even on an unfixed build:
+--   * `posting_list_codec` / `posting_list_block_size` are WRITE-TIME index properties, so they must
+--     be given in the index definition. `posting_list_block_size = 64` rounds the segment capacity to
+--     128 row ids, and 'bbb' has exactly 129 postings, so its last segment holds one posting.
+--   * 'bbb' starts at row 1 (not row 0): the stale slot-0 value is the previous segment's first
+--     absolute row id, so a series starting at 0 makes the wrong answer coincide with the right one.
+--   * 'aaa' is absent at row 1026 (the bogus id 1025 + 1), otherwise the lost row is replaced by a
+--     spurious match and `count()` alone is unchanged.
+--   * `text_index_lazy_intersection_density_threshold = 1.0` forces the leapfrog intersection, which
+--     is the only one reaching the block decoder; brute force takes the dense-segment shortcut.
+
+SET use_query_condition_cache = 0;
+
+DROP TABLE IF EXISTS t_lazy_single_posting_segment;
+
+CREATE TABLE t_lazy_single_posting_segment
+(
+    id UInt64,
+    s String,
+    INDEX idx s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_codec = 'bitpacking', posting_list_block_size = 64) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8192;
+
+INSERT INTO t_lazy_single_posting_segment
+SELECT number, concat(if(number = 1026, 'zzz', 'aaa'), ' ', if(number % 8 = 1 AND number <= 1025, 'bbb', 'ccc'))
+FROM numbers(4096);
+
+-- Fixture preconditions: a single part, and 'bbb' has 129 postings starting at row 1.
+SELECT 'fixture', count(), min(id), max(id) FROM t_lazy_single_posting_segment WHERE hasToken(s, 'bbb') SETTINGS use_skip_indexes = 0;
+SELECT 'parts', count() FROM system.parts WHERE database = currentDatabase() AND table = 't_lazy_single_posting_segment' AND active;
+
+-- Ground truth: the row-scan spelling of the same predicate, with no index involved.
+SELECT 'rowscan', count(), sum(id) FROM t_lazy_single_posting_segment WHERE hasToken(s, 'aaa') AND hasToken(s, 'bbb') SETTINGS use_skip_indexes = 0;
+
+-- FAILING REGIME (leapfrog). Both `use_skip_indexes_on_data_read` values are covered because the two
+-- drifting blocks of 02346_text_index_hits differ only in that setting.
+SELECT 'lazy leapfrog, on_data_read=1', count(), sum(id) FROM t_lazy_single_posting_segment
+WHERE hasAllTokens(s, ['aaa', 'bbb'])
+SETTINGS text_index_posting_list_apply_mode = 'lazy',
+         text_index_lazy_intersection_density_threshold = 1.0,
+         query_plan_direct_read_from_text_index = 1,
+         use_skip_indexes = 1,
+         use_skip_indexes_on_data_read = 1,
+         log_comment = 'test_04647_leapfrog_1';
+
+SELECT 'lazy leapfrog, on_data_read=0', count(), sum(id) FROM t_lazy_single_posting_segment
+WHERE hasAllTokens(s, ['aaa', 'bbb'])
+SETTINGS text_index_posting_list_apply_mode = 'lazy',
+         text_index_lazy_intersection_density_threshold = 1.0,
+         query_plan_direct_read_from_text_index = 1,
+         use_skip_indexes = 1,
+         use_skip_indexes_on_data_read = 0,
+         log_comment = 'test_04647_leapfrog_0';
+
+-- CONTROL: brute-force intersection takes the dense-segment shortcut and never decodes the
+-- one-posting block, so it must be correct on every build, fixed or not.
+SELECT 'lazy brute force (control)', count(), sum(id) FROM t_lazy_single_posting_segment
+WHERE hasAllTokens(s, ['aaa', 'bbb'])
+SETTINGS text_index_posting_list_apply_mode = 'lazy',
+         text_index_lazy_intersection_density_threshold = 0.0,
+         query_plan_direct_read_from_text_index = 1,
+         use_skip_indexes = 1,
+         use_skip_indexes_on_data_read = 1,
+         log_comment = 'test_04647_bruteforce';
+
+-- CONTROL: the eager path builds a fresh decoder per segment, so it never sees a stale buffer.
+SELECT 'materialize (control)', count(), sum(id) FROM t_lazy_single_posting_segment
+WHERE hasAllTokens(s, ['aaa', 'bbb'])
+SETTINGS text_index_posting_list_apply_mode = 'materialize',
+         query_plan_direct_read_from_text_index = 1,
+         use_skip_indexes = 1;
+
+-- Non-vacuity guard: prove from ProfileEvents that the two failing-regime statements really reached
+-- the lazy leapfrog intersection and decoded packed blocks, and that the control took brute force.
+-- A settings randomization that removes the direct-read path or the lazy mode makes this fail loudly
+-- instead of leaving the assertions above trivially satisfied.
+SYSTEM FLUSH LOGS query_log;
+
+SELECT
+    replaceOne(log_comment, 'test_04647_', '') AS which,
+    ProfileEvents['TextIndexLazyLeapfrogIntersections'] > 0 AS used_leapfrog,
+    ProfileEvents['TextIndexLazyBruteForceIntersections'] > 0 AS used_brute_force,
+    ProfileEvents['TextIndexLazyPackedBlocksDecoded'] > 0 AS decoded_packed_blocks
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND log_comment LIKE 'test_04647_%'
+  AND type = 'QueryFinish'
+ORDER BY which
+SETTINGS max_rows_to_read = 0;
+
+DROP TABLE t_lazy_single_posting_segment;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes wrong results (silently missing rows) for `hasAllTokens` and other multi-token `text` index searches on builds that do not use `simdcomp` (every target except x86_64 Linux, e.g. aarch64) when `text_index_posting_list_apply_mode = 'lazy'`. The portable bitpacking decoder did not write the decoded zeros for a block whose bit width is zero, so a posting living in a single-posting segment was dropped. The on-disk format is unchanged and existing data reads correctly after the fix.


### Description

`contrib/simdcomp` is compiled only for `OS_LINUX AND ARCH_AMD64`
(`contrib/simdcomp-cmake/CMakeLists.txt`), which is what sets `USE_SIMDCOMP`. So
`BitpackingBlockCodec` is the SIMD implementation on x86_64 Linux and a hand-written
portable fallback everywhere else - aarch64 Linux, macOS, FreeBSD, RISC-V, s390x, and any
`ENABLE_SIMDCOMP=0` build. That fallback's own doc comment states it "aims to produce a
100% binary-compatible output as simdcomp".

The two implementations disagreed in exactly one case, `bits == 0`:

| | `bits == 0` decode behaviour |
|---|---|
| simdcomp full block (`SIMD_nullunpacker32`) | `memset(out, 0, 32 * 4 * 4)` - writes zeros |
| simdcomp short length (`simdunpack_shortlength`) | `for (k = 0; k < length; ++k) out[k] = 0;` - writes zeros |
| portable `unpackFixed<0>` | `return in;` - writes nothing |
| portable `unpackTail<0>` | `return in;` - writes nothing |

The encoded bytes are identical in both implementations for every `(bits, length)` pair, so
this is a decode-side divergence only. **The on-disk format is unchanged, no migration is
needed, and parts written by an unfixed build read correctly after this change.**

#### Why "writes nothing" loses exactly one row

`PostingListCursor::decodeBlock` decodes into the cursor's persistent, reused buffer
`decoded_values` and then converts deltas to absolute row ids in place with
`std::inclusive_scan`. After any block, that buffer therefore holds absolute row ids. When a
later block has `bits == 0` and the portable decoder writes nothing, `decoded_values[0]`
still holds the previous block's absolute row id, and the scan computes
`last_decoded_doc_id + <that stale absolute id>` - a bogus row id far outside the segment.
The one real posting of that block is never emitted.

`encodeBlock` derives `bits` from the block's delta array, so `bits == 0` means every delta
is zero. The first row id of a segment is stored as `row_id - prev_row_id` with
`prev_row_id = row_id`, i.e. delta 0, so `bits == 0` occurs exactly when a segment's only
block holds exactly one posting - that is, when a token's cardinality is
`1 (mod max_rowids_in_segment)`.

#### Why only `hasAllTokens` was affected

A one-posting segment has `doc_count == range_span == 1`, which triggers the dense-segment
shortcut in `PostingListCursor::linearSegments`: it pads the range and continues without ever
calling `decodeBlock`. So single-token queries (`linearOr`) and the brute-force intersection
(`linearOr` + `linearAnd`) are structurally immune. Only the leapfrog intersection
(`intersectTwo` driving `advance` and `next`) reaches the block decoder, and it is selected
when `min_density < text_index_lazy_intersection_density_threshold`.

#### Observed symptom

`02346_text_index_hits` intermittently reported
`SELECT count() FROM hits_text WHERE hasAllTokens(URL, ['com', 'mail'])` as `111668` instead
of `111669` - exactly one row short - on `Stateless tests (arm_binary, sequential)`. Over 20
days that job shows 6 failures in 6475 runs while `amd_debug, sequential` shows 0 in 5526,
and the logically equivalent `hasToken(URL, 'com') AND hasToken(URL, 'mail')` in the same
output never drifted. The failure needs `posting_list_codec = 'bitpacking'`,
`posting_list_block_size` in `{16, 64}` (the only values whose segment capacity rounds to
128) and `text_index_posting_list_apply_mode = 'lazy'`, all of which the test randomizer
picks with probability about 1/12 - which is what made it look like a flaky test.

#### The test guard that hid this

`gtest_posting_list_codec.cpp` skipped its round-trip assertion for `bits == 0`, with a
comment claiming "there's no data to write into that buffer anyway". That premise is false:
the decoded value of a `bits == 0` block is `count` zeros, and the caller does not pre-clear.
The two cross-implementation differential tests do cover `bit = 0` but pre-fill their output
vectors with zeros, so they could not observe it either. This change removes the guard and
fills those destinations with a sentinel instead.

#### Which test covers which arch

`04647_text_index_lazy_single_posting_segment` passes on unfixed **x86_64 Linux** by
construction, because that is the only target where `simdcomp` is compiled in and its
`bits == 0` decode already writes the zeros. A green run of it on amd64 (or on
[fiddle](https://fiddle.clickhouse.com), which is x86_64 Linux) therefore says nothing about the
fix. This is exactly what the per-arch bugfix validation reports on this PR: `aarch64` fails on
the before-binary (bug reproduced) while `amd64` reports
`Bug does not reproduce on this arch - bugfix validation N/A`.

The primitive is pinned on **every** arch, amd64 included, by `gtest_posting_list_codec.cpp`,
which instantiates the portable specialization explicitly
(`using Portable = DB::impl::BitpackingBlockCodecImpl<false>;`). `Bugfix validation (unit tests)`
runs on an x86_64 runner and still reproduces: 7 tests fail on the before-binary, including
`DecodeZeroBitsWritesZeros` and the two cross-implementation differential tests.

#### Verification

* A `bits == 0` decode against a sentinel-filled buffer leaves `0xDEADBEEF` on the unfixed
  portable path and writes zeros with the fix, while simdcomp writes zeros in both cases.
* Reverting either `Bits == 0` branch independently fails the strengthened round-trip tests
  and the new `DecodeZeroBitsWritesZeros` test.
* With the codec forced to the portable implementation (simulating aarch64) and the fix
  reverted, the new stateless test loses exactly the expected row:
  `129 / 66177` becomes `128 / 65152`, i.e. row id 1025 - the single-posting segment's only
  row - while the brute-force, materialize and row-scan controls in the same test stay
  correct. With the fix it passes 50 out of 50 randomized runs.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.271` (included in `26.8` and later)
<!-- ch-version-info:end -->