### PR TITLE
Speed up timeseries aggregation batches, merges and fixed-key hashing

### DIFF
--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -220,6 +220,39 @@ public:
         }
     }
 
+    /// The default implementation merges with a copy and then destroys the source. The source is doomed
+    /// anyway, so move the buckets out of it instead when the bucket type supports destructive merging.
+    void mergeAndDestroyBatch(
+        AggregateDataPtr * dst_places,
+        AggregateDataPtr * rhs_places,
+        size_t size,
+        size_t offset,
+        ThreadPool & thread_pool,
+        std::atomic<bool> & is_cancelled,
+        Arena * arena) const override
+    {
+        if constexpr (!requires (Bucket & dst, Bucket & src) { dst.mergeDestructive(src); })
+        {
+            Base::mergeAndDestroyBatch(dst_places, rhs_places, size, offset, thread_pool, is_cancelled, arena);
+        }
+        else
+        {
+            for (size_t i = 0; i < size; ++i)
+            {
+                chassert(dst_places[i] + offset != rhs_places[i] + offset,
+                         "IAggregateFunction::mergeAndDestroyBatch called with the same source and destination state");
+
+                auto & dst_buckets = data(dst_places[i] + offset)->buckets;
+                auto & src_buckets = data(rhs_places[i] + offset)->buckets;
+                dst_buckets.reserve(src_buckets.size());
+                for (auto & src_bucket : src_buckets)
+                    dst_buckets[src_bucket.getKey()].mergeDestructive(src_bucket.getMapped());
+
+                destroy(rhs_places[i] + offset);
+            }
+        }
+    }
+
     void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
     {
         writeBinaryLittleEndian(FORMAT_VERSION, buf);
@@ -907,8 +940,97 @@ private:
 
     void addMany(AggregateDataPtr __restrict place, const TimestampType * __restrict timestamp_ptr, const ValueType * __restrict value_ptr, size_t start, size_t end) const
     {
-        for (size_t i = start; i < end; ++i)
-            add(place, timestamp_ptr[i], value_ptr[i]);
+        if (!use_int64_arithmetic)
+        {
+            for (size_t i = start; i < end; ++i)
+                add(place, timestamp_ptr[i], value_ptr[i]);
+            return;
+        }
+
+        /// Process the samples as runs over timestamp zones (see `bucketIndexAndZoneInt64`): samples arrive
+        /// in ascending-timestamp runs, so whole stretches share one bucket (bulk-appended) or fall into one
+        /// between-windows gap (skipped) with two comparisons per sample and no per-sample calls.
+        auto & state = *data(place);
+        size_t i = start;
+        while (i < end)
+        {
+            size_t bucket_index;
+            const Int64 ts = static_cast<Int64>(timestamp_ptr[i]);
+            if (ts > state.zone_lo && ts <= state.zone_hi)
+            {
+                bucket_index = state.zone_bucket;
+            }
+            else
+            {
+                bucket_index = bucketIndexAndZoneInt64(timestamp_ptr[i], state.zone_lo, state.zone_hi);
+                state.zone_bucket = bucket_index;
+            }
+
+            const Int64 zone_lo = state.zone_lo;
+            const Int64 zone_hi = state.zone_hi;
+            size_t run_end = i + 1;
+            while (run_end < end)
+            {
+                const Int64 t = static_cast<Int64>(timestamp_ptr[run_end]);
+                if (t > zone_lo && t <= zone_hi)
+                    ++run_end;
+                else
+                    break;
+            }
+
+            if (bucket_index != NO_BUCKET)
+            {
+                auto & bucket = state.buckets[bucket_index];
+                if constexpr (requires { bucket.addRun(timestamp_ptr, value_ptr, size_t{}); })
+                {
+                    bucket.addRun(timestamp_ptr + i, value_ptr + i, run_end - i);
+                }
+                else
+                {
+                    for (size_t k = i; k < run_end; ++k)
+                        bucket.add(timestamp_ptr[k], value_ptr[k]);
+                }
+            }
+
+            i = run_end;
+        }
+    }
+
+    /// The default `addBatch` dispatches row by row. The samples input is sorted by series, so consecutive
+    /// rows usually target the same aggregation state - process such runs with `addMany` instead.
+    void addBatch(
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr * places,
+        size_t place_offset,
+        const IColumn ** columns,
+        Arena * arena,
+        ssize_t if_argument_pos) const override
+    {
+        if (array_arguments || (if_argument_pos >= 0))
+        {
+            Base::addBatch(row_begin, row_end, places, place_offset, columns, arena, if_argument_pos);
+            return;
+        }
+
+        const auto & timestamp_column = typeid_cast<const ColVecType &>(*columns[0]);
+        const auto & value_column = typeid_cast<const ColVecResultType &>(*columns[1]);
+        const TimestampType * timestamp_data = timestamp_column.getData().data();
+        const ValueType * value_data = value_column.getData().data();
+
+        size_t i = row_begin;
+        while (i < row_end)
+        {
+            AggregateDataPtr place = places[i];
+            size_t run_end = i + 1;
+            while (run_end < row_end && places[run_end] == place)
+                ++run_end;
+
+            if (place)
+                addMany(place + place_offset, timestamp_data, value_data, i, run_end);
+
+            i = run_end;
+        }
     }
 
     void addManyNotNull(AggregateDataPtr __restrict place, const TimestampType * __restrict timestamp_ptr, const ValueType * __restrict value_ptr, const UInt8 * __restrict null_map, size_t start, size_t end) const

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -106,6 +106,9 @@ public:
         , odd_bucket_step(bucketStep(true, step, window_remainder, buckets_per_step, buckets_per_first_window))
         , first_bucket_end_time(firstBucketEndTimestamp(start_timestamp_, step, window_remainder, buckets_per_step, buckets_per_first_window))
         , first_bucket_is_clamped(firstBucketIsClamped(first_bucket_end_time, even_bucket_width))
+        , use_int64_arithmetic(useInt64Arithmetic(start_timestamp, end_timestamp, step, window, buckets_per_window))
+        , min_contributing_timestamp(use_int64_arithmetic
+            ? static_cast<Int64>(start_timestamp) - static_cast<Int64>(window) : 0)
     {
     }
 
@@ -414,6 +417,8 @@ protected:
     const IntervalType odd_bucket_step{};         /// End-to-end spacing of odd-indexed buckets
     const TimestampType first_bucket_end_time{};  /// End timestamp of bucket #0
     const bool first_bucket_is_clamped{};         /// Whether bucket #0's start is below the type minimum (only it can be)
+    const bool use_int64_arithmetic{};            /// Whether the per-sample bucket math provably fits in Int64 (see `useInt64Arithmetic`)
+    const Int64 min_contributing_timestamp{};     /// `start - window`: samples at or below it can't contribute (valid only with `use_int64_arithmetic`)
 
 private:
     /// `HashMap` relocates cells with `memcpy`, so it requires position-independent buckets: trivially
@@ -426,6 +431,14 @@ private:
     {
         /// Maps bucket index to the set of all timestamps and values
         TimeSeriesBucketsMap<Bucket> buckets;
+
+        /// Cache of the last resolved timestamp zone (see `bucketIndexAndZoneInt64`): timestamps in
+        /// `(zone_lo, zone_hi]` map to `zone_bucket` (which may be `NO_BUCKET` for a between-windows gap).
+        /// Samples arrive in ascending-timestamp runs, so consecutive samples usually hit the same zone,
+        /// turning the per-sample bucket arithmetic into two comparisons. `zone_lo == zone_hi` means empty.
+        Int64 zone_lo = 0;
+        Int64 zone_hi = 0;
+        size_t zone_bucket = NO_BUCKET;
     };
 
     static DataTypePtr createResultType()
@@ -652,11 +665,111 @@ private:
 
     static constexpr size_t NO_BUCKET = -1;
 
+    /// Whether `bucketIndexForTimestampInt64` may be used: every intermediate value of the per-sample bucket
+    /// math must fit in `Int64`. This is decided once per aggregator; the per-sample hot path then runs in
+    /// 64-bit instead of the overflow-proof but much slower `Int128`. The conditions (checked in `Int128`):
+    /// - `end + step + window` does not overflow upwards, which bounds `ts + window`, `offset + remainder`
+    ///   and `unclamped_grid_index * step` (the latter never exceeds `offset` by more than one `step`);
+    /// - `start - window` does not underflow, making the early-sample cutoff exact in `Int64`;
+    /// - `buckets_per_window` is small enough that bucket indices of in-window samples fit comfortably.
+    static bool useInt64Arithmetic(TimestampType start, TimestampType end, IntervalType step_, IntervalType window_,
+        size_t buckets_per_window_)
+    {
+        constexpr Int128 int64_max = std::numeric_limits<Int64>::max();
+        constexpr Int128 int64_min = std::numeric_limits<Int64>::min();
+
+        const Int128 end_128 = static_cast<Int128>(static_cast<Int64>(end));
+        const Int128 start_128 = static_cast<Int128>(static_cast<Int64>(start));
+        const Int128 step_128 = static_cast<Int128>(static_cast<Int64>(step_));
+        const Int128 window_128 = static_cast<Int128>(static_cast<Int64>(window_));
+
+        return end_128 + step_128 + window_128 <= int64_max
+            && start_128 - window_128 >= int64_min
+            && buckets_per_window_ <= (1ull << 40);
+    }
+
+    /// `Int64` twin of the `Int128` arithmetic in `bucketIndexForTimestamp`, taken when `use_int64_arithmetic`
+    /// proved it overflow-free. This runs for every sample, and 128-bit division dominated the profile.
+    /// Besides the bucket index it returns the containing zone `(zone_lo, zone_hi]` - the full preimage of the
+    /// result - so the caller can cache it and resolve subsequent samples of the same zone with two comparisons.
+    size_t ALWAYS_INLINE bucketIndexAndZoneInt64(const TimestampType timestamp, Int64 & zone_lo, Int64 & zone_hi) const
+    {
+        const Int64 ts = static_cast<Int64>(timestamp);
+        if (ts > static_cast<Int64>(end_timestamp))
+        {
+            zone_lo = static_cast<Int64>(end_timestamp);
+            zone_hi = std::numeric_limits<Int64>::max();
+            return NO_BUCKET;
+        }
+        if (ts <= min_contributing_timestamp)
+        {
+            zone_lo = std::numeric_limits<Int64>::min();
+            zone_hi = min_contributing_timestamp;
+            return NO_BUCKET;
+        }
+
+        const Int64 step_64 = static_cast<Int64>(step);
+        const Int64 offset = ts - static_cast<Int64>(start_timestamp);
+
+        Int64 unclamped_grid_index = 0;
+        if (step > 0)
+        {
+            unclamped_grid_index = offset / step_64;
+            unclamped_grid_index += (offset % step_64) > 0;
+        }
+
+        /// Skip a sample that is already out of window (`isSampleOutOfWindow` on the clamped grid point).
+        const Int64 clamped_grid_index = unclamped_grid_index > 0 ? unclamped_grid_index : 0;
+        const Int64 grid_timestamp = static_cast<Int64>(start_timestamp) + clamped_grid_index * step_64;
+        if (ts + static_cast<Int64>(window) <= grid_timestamp)
+        {
+            /// The between-windows gap `(previous grid point, this grid point - window]`. The sample is past
+            /// `min_contributing_timestamp`, so its grid index is at least 1 and the gap's start is in range.
+            zone_lo = grid_timestamp - step_64;
+            zone_hi = grid_timestamp - static_cast<Int64>(window);
+            return NO_BUCKET;
+        }
+
+        const Int64 leading_buckets = static_cast<Int64>(buckets_per_first_window);
+        Int64 bucket_index;
+        if (window_remainder == 0)
+        {
+            /// One bucket per step.
+            bucket_index = unclamped_grid_index + leading_buckets - 1;
+        }
+        else
+        {
+            /// Each step is split at (grid timestamp - window_remainder).
+            const Int64 remainder = static_cast<Int64>(window_remainder);
+            const bool before_split_point = (offset + remainder) <= (unclamped_grid_index * step_64);
+            bucket_index = 2 * unclamped_grid_index + leading_buckets - 1 - (before_split_point ? 1 : 0);
+        }
+
+        chassert(bucket_index >= 0 && bucket_index < static_cast<Int64>(bucket_count));
+
+        /// The bucket's own time range (see `bucketTimeRange`): buckets tile the in-window timeline, so this
+        /// is the exact preimage of `bucket_index`.
+        zone_hi = static_cast<Int64>(bucketEndTimestamp(static_cast<size_t>(bucket_index)));
+        if (bucket_index == 0 && first_bucket_is_clamped)
+            zone_lo = std::numeric_limits<Int64>::min();
+        else
+            zone_lo = zone_hi - static_cast<Int64>((bucket_index % 2 != 0) ? odd_bucket_width : even_bucket_width);
+
+        return static_cast<size_t>(bucket_index);
+    }
+
     /// Returns the index of the bucket a sample at `timestamp` contributes to.
     /// The function returns NO_BUCKET if the specified timestamp can't contribute to any buckets
     /// because it's too early, or too late, or already out of window.
     size_t bucketIndexForTimestamp(const TimestampType timestamp) const
     {
+        if (use_int64_arithmetic)
+        {
+            Int64 ignored_zone_lo;
+            Int64 ignored_zone_hi;
+            return bucketIndexAndZoneInt64(timestamp, ignored_zone_lo, ignored_zone_hi);
+        }
+
         if (timestamp > end_timestamp)
             return NO_BUCKET;
 
@@ -766,11 +879,29 @@ private:
 
     void ALWAYS_INLINE add(AggregateDataPtr __restrict place, TimestampType timestamp, ValueType value) const
     {
-        const size_t bucket_index = bucketIndexForTimestamp(timestamp);
+        auto & state = *data(place);
+
+        size_t bucket_index;
+        const Int64 ts = static_cast<Int64>(timestamp);
+        if (ts > state.zone_lo && ts <= state.zone_hi)
+        {
+            /// Samples arrive in ascending-timestamp runs, so most fall into the zone of the previous one.
+            bucket_index = state.zone_bucket;
+        }
+        else if (use_int64_arithmetic)
+        {
+            bucket_index = bucketIndexAndZoneInt64(timestamp, state.zone_lo, state.zone_hi);
+            state.zone_bucket = bucket_index;
+        }
+        else
+        {
+            bucket_index = bucketIndexForTimestamp(timestamp);
+        }
+
         if (bucket_index == NO_BUCKET)
             return;  /// The sample can't contribute to any bucket.
 
-        auto & bucket = data(place)->buckets[bucket_index];
+        auto & bucket = state.buckets[bucket_index];
         bucket.add(timestamp, value);
     }
 

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesChanges.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesChanges.h
@@ -90,7 +90,6 @@ struct AggregateFunctionTimeseriesChangesTraits
     struct Aggregator
     {
         AggregateFunctionTimeseriesSlidingSum<TimestampType, Summary> sliding_sum;
-        VectorWithMemoryTracking<std::pair<TimestampType, ValueType>> temp_buffer;  /// reused sort buffer
 
         /// `Summary::merge` is order-dependent (not commutative), so it must take the invertible running-sum path,
         /// not the two-stacks path which combines values out of time order.
@@ -108,7 +107,7 @@ struct AggregateFunctionTimeseriesChangesTraits
                     ++summary.changes;
                 summary.last_value = value;
                 ++summary.count;
-            }, temp_buffer);
+            });
             add(std::move(summary), bucket_end_timestamp);
         }
 

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesExtrapolatedValue.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesExtrapolatedValue.h
@@ -95,7 +95,6 @@ struct AggregateFunctionTimeseriesExtrapolatedValueTraits
     struct Aggregator
     {
         AggregateFunctionTimeseriesSlidingSum<TimestampType, Summary> sliding_sum;
-        VectorWithMemoryTracking<std::pair<TimestampType, ValueType>> temp_buffer;  /// reused sort buffer
 
         /// `Summary::merge` is order-dependent (not commutative), so it must take the invertible running-sum path,
         /// not the two-stacks path which combines values out of time order.
@@ -129,7 +128,7 @@ struct AggregateFunctionTimeseriesExtrapolatedValueTraits
                 summary.last_timestamp = timestamp;
                 summary.last_value = value;
                 ++summary.count;
-            }, temp_buffer);
+            });
             add(std::move(summary), bucket_end_timestamp);
         }
 

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
@@ -43,10 +43,39 @@ public:
         compacted = false;
     }
 
+    /// Appends `count` samples at once. Semantically `add` in a loop, but with a single size bump and
+    /// raw writes - this is the hot path when whole runs of samples fall into one bucket.
+    void addRun(const TimestampType * timestamps, const ValueType * values, size_t count)
+    {
+        const size_t old_size = buffer.size();
+        buffer.resize(old_size + count);
+        auto * out = buffer.data() + old_size;
+        for (size_t i = 0; i < count; ++i)
+        {
+            out[i].first = timestamps[i];
+            out[i].second = values[i];
+        }
+        compacted = false;
+    }
+
     void merge(const AggregateFunctionTimeseriesSamples & other)
     {
         buffer.insert(buffer.end(), other.buffer.begin(), other.buffer.end());
         compacted = false;
+    }
+
+    /// Merge that may leave `other` empty. During the merge of partial aggregation states each
+    /// (series, bucket) usually exists in exactly one source state, so the destination bucket is
+    /// empty and the samples are stolen instead of copied.
+    void mergeDestructive(AggregateFunctionTimeseriesSamples & other)
+    {
+        if (buffer.empty())
+        {
+            buffer.swap(other.buffer);
+            compacted = other.compacted;
+            return;
+        }
+        merge(other);
     }
 
     void serialize(WriteBuffer & buf) const
@@ -125,8 +154,10 @@ private:
             return;
 
         /// Sorting by (timestamp, value) makes the last sample of each equal-timestamp run the one with
-        /// the larger value.
-        ::sort(buffer.begin(), buffer.end());
+        /// the larger value. Samples arrive as ascending runs, so the buffer is usually sorted already -
+        /// checking is much cheaper than re-sorting.
+        if (!std::is_sorted(buffer.begin(), buffer.end()))
+            ::sort(buffer.begin(), buffer.end());
 
         auto out = buffer.begin();
         for (auto it = buffer.begin(); it != buffer.end();)

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
@@ -4,8 +4,6 @@
 #include <functional>
 #include <utility>
 
-#include <absl/container/flat_hash_map.h>
-
 #include <base/sort.h>
 
 #include <Common/AllocatorWithMemoryTracking.h>
@@ -23,35 +21,39 @@ namespace ErrorCodes
     extern const int INCORRECT_DATA;
 }
 
-/// Per-bucket storage of timeseries samples keyed by timestamp.
+/// Per-bucket storage of timeseries samples.
 /// When two samples share a timestamp the larger value is kept.
+///
+/// Samples are stored in an append-only vector and canonicalized (sorted by timestamp, duplicates collapsed
+/// to the larger value) lazily, on first ordered access. Inputs arrive as ascending-timestamp runs (the
+/// samples table is sorted by timestamp within each series), so the canonicalization sort runs on
+/// almost-sorted data and is cheap, while appends stay O(1) without any per-sample hashing.
 template <typename TimestampType, typename ValueType>
 class AggregateFunctionTimeseriesSamples
 {
 public:
     /// The bucket map (`HashMap`) relocates cells with `memcpy` and abandons the source, which is safe for
-    /// any type without pointers into itself. `absl::flat_hash_map` qualifies: the address of its inline
-    /// single-element storage (small object optimization) is computed from `this`, the rest is on the heap.
-    /// No standard trait expresses this (weaker than `std::is_trivially_copyable`) property, hence the
-    /// explicit declaration.
+    /// any type without pointers into itself. A vector qualifies: its buffer is on the heap. No standard
+    /// trait expresses this (weaker than `std::is_trivially_copyable`) property, hence the explicit declaration.
     static constexpr bool is_position_independent = true;
 
     void add(TimestampType timestamp, ValueType value)
     {
-        auto [it, inserted] = buffer.emplace(timestamp, value);
-        if (!inserted)
-            it->second = std::max(it->second, value);
+        buffer.emplace_back(timestamp, value);
+        compacted = false;
     }
 
     void merge(const AggregateFunctionTimeseriesSamples & other)
     {
-        buffer.reserve(buffer.size() + other.buffer.size());
-        for (const auto & [timestamp, value] : other.buffer)
-            add(timestamp, value);
+        buffer.insert(buffer.end(), other.buffer.begin(), other.buffer.end());
+        compacted = false;
     }
 
     void serialize(WriteBuffer & buf) const
     {
+        /// Canonicalize first so duplicates don't inflate the serialized state.
+        compact();
+
         writeBinaryLittleEndian(buffer.size(), buf);
         for (const auto & [timestamp, value] : buffer)
         {
@@ -64,6 +66,7 @@ public:
     {
         /// Deserialize replaces any previous contents.
         buffer.clear();
+        compacted = false;
 
         size_t sample_count = 0;
         readBinaryLittleEndian(sample_count, buf);
@@ -74,7 +77,7 @@ public:
             readBinaryLittleEndian(timestamp, buf);
             ValueType value;
             readBinaryLittleEndian(value, buf);
-            add(timestamp, value);
+            buffer.emplace_back(timestamp, value);
         }
     }
 
@@ -82,47 +85,67 @@ public:
     template <typename RangeType>
     void checkTimestampsInRange(const RangeType & range) const
     {
-        forEachSample([&range](TimestampType timestamp, ValueType)
+        for (const auto & [timestamp, value] : buffer)
         {
             if (!range.contains(timestamp))
                 throw Exception(ErrorCodes::INCORRECT_DATA,
                     "Cannot deserialize data: timestamp {} is outside its bucket's range",
                     static_cast<Int64>(timestamp));
-        });
+        }
     }
 
-    /// Invokes `f(timestamp, value)` for every sample, in arbitrary order. Used by the per-function sliding
-    /// aggregators for order-independent aggregates (e.g. linear regression moments).
+    /// Invokes `f(timestamp, value)` for every distinct-timestamp sample, in arbitrary order. Used by the
+    /// per-function sliding aggregators for order-independent aggregates (e.g. linear regression moments).
+    /// Canonicalizes first: duplicate-timestamp semantics (keep the larger value) must hold here too.
     template <typename F>
     void forEachSample(F && f) const
     {
+        compact();
         for (const auto & [timestamp, value] : buffer)
             f(timestamp, value);
     }
 
-    /// Invokes `f(timestamp, value)` for every sample in ascending timestamp order, using `temp_buffer` as a
-    /// reused sort buffer. Used by the order-dependent aggregators (rate reset accounting, counting transitions).
+    /// Invokes `f(timestamp, value)` for every distinct-timestamp sample in ascending timestamp order.
+    /// Used by the order-dependent aggregators (rate reset accounting, counting transitions).
     template <typename F>
-    void forEachSampleSorted(F && f, VectorWithMemoryTracking<std::pair<TimestampType, ValueType>> & temp_buffer) const
+    void forEachSampleSorted(F && f) const
     {
-        temp_buffer.clear();
-        temp_buffer.reserve(buffer.size());
+        compact();
         for (const auto & [timestamp, value] : buffer)
-            temp_buffer.emplace_back(timestamp, value);
-        ::sort(temp_buffer.begin(), temp_buffer.end());
-        for (const auto & [timestamp, value] : temp_buffer)
             f(timestamp, value);
     }
 
 private:
-    /// Samples keyed by timestamp. Uses `AllocatorWithMemoryTracking` so per-bucket sample memory is counted by
-    /// the `MemoryTracker`, like the rest of the aggregate state.
-    absl::flat_hash_map<
-        TimestampType,
-        ValueType,
-        absl::container_internal::hash_default_hash<TimestampType>,
-        std::equal_to<>,
-        AllocatorWithMemoryTracking<std::pair<const TimestampType, ValueType>>> buffer;
+    /// Sorts samples by timestamp and collapses samples sharing a timestamp to the one with the larger value.
+    /// Logically const: canonicalization only changes the representation, not the sample set, and states are
+    /// never accessed concurrently.
+    void compact() const
+    {
+        if (compacted)
+            return;
+
+        /// Sorting by (timestamp, value) makes the last sample of each equal-timestamp run the one with
+        /// the larger value.
+        ::sort(buffer.begin(), buffer.end());
+
+        auto out = buffer.begin();
+        for (auto it = buffer.begin(); it != buffer.end();)
+        {
+            auto run_end = it + 1;
+            while (run_end != buffer.end() && run_end->first == it->first)
+                ++run_end;
+            *out++ = *(run_end - 1);
+            it = run_end;
+        }
+        buffer.erase(out, buffer.end());
+
+        compacted = true;
+    }
+
+    /// Samples in insertion order until `compact` canonicalizes them. Uses `AllocatorWithMemoryTracking` so
+    /// per-bucket sample memory is counted by the `MemoryTracker`, like the rest of the aggregate state.
+    mutable VectorWithMemoryTracking<std::pair<TimestampType, ValueType>> buffer;
+    mutable bool compacted = false;
 };
 
 }

--- a/src/Common/ColumnsHashing/HashMethod.h
+++ b/src/Common/ColumnsHashing/HashMethod.h
@@ -420,6 +420,10 @@ struct HashMethodKeysFixed
 
     PaddedPODArray<Key> prepared_keys;
 
+    /// When a single key column exactly fills the Key, its raw data is used as the keys directly,
+    /// with no packing pass at all (see the constructor).
+    const Key * direct_keys = nullptr;
+
     static bool usePreparedKeys(const Sizes & key_sizes)
     {
         if (has_low_cardinality || has_nullable_keys || sizeof(Key) > 16)
@@ -455,7 +459,18 @@ struct HashMethodKeysFixed
 
         if (usePreparedKeys(key_sizes))
         {
-            packFixedBatch(keys_size, Base::getActualColumns(), key_sizes, prepared_keys);
+            if (keys_size == 1 && key_sizes[0] == sizeof(Key))
+            {
+                /// The single key occupies the whole Key: the column's raw data already is the packed
+                /// keys array, so use it directly instead of zero-filling and copying a buffer.
+                /// (Same aliasing note as in fillFixedBatch.)
+                direct_keys = reinterpret_cast<const Key *>(
+                    static_cast<const ColumnFixedSizeHelper *>(Base::getActualColumns()[0])->template getRawDataBegin<sizeof(Key)>());
+            }
+            else
+            {
+                packFixedBatch(keys_size, Base::getActualColumns(), key_sizes, prepared_keys);
+            }
         }
 
 #if defined(__SSSE3__) && !defined(MEMORY_SANITIZER)
@@ -523,6 +538,9 @@ struct HashMethodKeysFixed
             if constexpr (has_low_cardinality)
                 return packFixed<Key, true>(row, keys_size, low_cardinality_keys.nested_columns, key_sizes,
                                             &low_cardinality_keys.positions, &low_cardinality_keys.position_sizes);
+
+            if (direct_keys)
+                return direct_keys[row];
 
             if (!prepared_keys.empty())
                 return prepared_keys[row];

--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -20,6 +20,7 @@
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/Prometheus/parseTimeSeriesTypes.h>
 #include <Parsers/makeASTForLogicalFunction.h>
+#include <Storages/ColumnsDescription.h>
 #include <Storages/SelectQueryInfo.h>
 #include <Storages/StorageTimeSeries.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
@@ -354,25 +355,49 @@ namespace
                                         DateTime64 max_time,
                                         const DataTypePtr & id_data_type,
                                         const DataTypePtr & timestamp_data_type,
-                                        const DataTypePtr & scalar_data_type)
+                                        const DataTypePtr & scalar_data_type,
+                                        const ColumnsDescription & data_table_columns)
     {
         auto select_query = make_intrusive<ASTSelectQuery>();
 
         /// SELECT id, timestamp, value
+        /// Casts to the expected types are added only when a column's type in the data table differs:
+        /// a same-type CAST would not be a no-op - it would be evaluated for every sample row.
         {
             auto select_list_exp = make_intrusive<ASTExpressionList>();
             auto & select_list = select_list_exp->children;
 
-            select_list.push_back(makeASTFunction(
-                "CAST", make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID), make_intrusive<ASTLiteral>(id_data_type->getName())));
-            select_list.back()->setAlias(TimeSeriesColumnNames::ID);
+            if (data_table_columns.get(TimeSeriesColumnNames::ID).type->equals(*id_data_type))
+            {
+                select_list.push_back(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID));
+            }
+            else
+            {
+                select_list.push_back(makeASTFunction(
+                    "CAST", make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID), make_intrusive<ASTLiteral>(id_data_type->getName())));
+                select_list.back()->setAlias(TimeSeriesColumnNames::ID);
+            }
 
-            select_list.push_back(
-                timeSeriesTimestampASTCast(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Timestamp), timestamp_data_type));
-            select_list.back()->setAlias(TimeSeriesColumnNames::Timestamp);
+            if (data_table_columns.get(TimeSeriesColumnNames::Timestamp).type->equals(*timestamp_data_type))
+            {
+                select_list.push_back(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Timestamp));
+            }
+            else
+            {
+                select_list.push_back(
+                    timeSeriesTimestampASTCast(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Timestamp), timestamp_data_type));
+                select_list.back()->setAlias(TimeSeriesColumnNames::Timestamp);
+            }
 
-            select_list.push_back(timeSeriesScalarASTCast(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Value), scalar_data_type));
-            select_list.back()->setAlias(TimeSeriesColumnNames::Value);
+            if (data_table_columns.get(TimeSeriesColumnNames::Value).type->equals(*scalar_data_type))
+            {
+                select_list.push_back(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Value));
+            }
+            else
+            {
+                select_list.push_back(timeSeriesScalarASTCast(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Value), scalar_data_type));
+                select_list.back()->setAlias(TimeSeriesColumnNames::Value);
+            }
 
             select_query->setExpression(ASTSelectQuery::Expression::SELECT, select_list_exp);
         }
@@ -461,6 +486,10 @@ void StorageTimeSeriesSelector::readImpl(
     ASTPtr select_query_from_tags_table = makeSelectQueryFromTagsTable(
         tags_table_id, matchers, column_name_by_tag_name, min_time_to_filter_ids, max_time_to_filter_ids, config.timestamp_data_type);
 
+    auto samples_table = time_series_storage->getTargetTable(ViewTarget::Samples, context);
+    auto samples_table_metadata = samples_table->getInMemoryMetadataPtr(context, false);
+    const auto & samples_table_columns = samples_table_metadata->columns;
+
     ASTPtr select_query_from_data_table = makeSelectQueryFromDataTable(
         samples_table_id,
         select_query_from_tags_table,
@@ -468,7 +497,8 @@ void StorageTimeSeriesSelector::readImpl(
         config.max_time,
         config.id_data_type,
         config.timestamp_data_type,
-        config.scalar_data_type);
+        config.scalar_data_type,
+        samples_table_columns);
 
     LOG_DEBUG(log, "Building SQL for selector: {}", config.selector.toString());
     LOG_DEBUG(log, "Will execute query:\n{}", select_query_from_data_table->formatForLogging());

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyFunctionOverRange.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyFunctionOverRange.cpp
@@ -4,6 +4,8 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/Prometheus/stepsInTimeSeriesRange.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/NodeEvaluationRange.h>
@@ -121,6 +123,40 @@ namespace
 
         return &it->second;
     }
+
+    /// If `select_query` has the exact shape produced by `fromRangeSelector` - a single
+    /// `SELECT timeSeriesIdToGroup(id) AS group, ...` - rewrites its first result column to the raw `id`
+    /// and returns true. The caller then aggregates with `GROUP BY id` and applies `timeSeriesIdToGroup`
+    /// to the aggregated keys, evaluating it once per series instead of once per sample.
+    /// (`id` and `group` are in bijection: `timeSeriesIdToGroup` is a plain per-`id` mapping.)
+    bool rewriteGroupColumnToRawID(const ASTPtr & select_query)
+    {
+        const auto * select_with_union = select_query->as<ASTSelectWithUnionQuery>();
+        if (!select_with_union || !select_with_union->list_of_selects
+            || (select_with_union->list_of_selects->children.size() != 1))
+            return false;
+
+        auto * select = select_with_union->list_of_selects->children[0]->as<ASTSelectQuery>();
+        if (!select)
+            return false;
+
+        const auto & select_list = select->select();
+        if (!select_list || select_list->children.empty())
+            return false;
+
+        auto & first_column = select_list->children[0];
+        const auto * function = first_column->as<ASTFunction>();
+        if (!function || (function->name != "timeSeriesIdToGroup") || (function->tryGetAlias() != ColumnNames::Group)
+            || !function->arguments || (function->arguments->children.size() != 1))
+            return false;
+
+        const auto * id_identifier = function->arguments->children[0]->as<ASTIdentifier>();
+        if (!id_identifier || (id_identifier->name() != ColumnNames::ID))
+            return false;
+
+        first_column = make_intrusive<ASTIdentifier>(ColumnNames::ID);
+        return true;
+    }
 }
 
 
@@ -164,6 +200,7 @@ SQLQueryPiece applyFunctionOverRange(
     res.type = ResultType::INSTANT_VECTOR;
 
     bool has_group = false;
+    bool group_by_raw_id = false;
     ASTPtr timestamps;
     ASTPtr values;
 
@@ -237,7 +274,15 @@ SQLQueryPiece applyFunctionOverRange(
             ///        <aggregate_function>(timestamp, value) AS values
             /// FROM <raw_data>
             /// GROUP BY group
+            ///
+            /// or, when <raw_data> comes straight from a selector (see rewriteGroupColumnToRawID):
+            ///
+            /// SELECT timeSeriesIdToGroup(id) AS group,
+            ///        <aggregate_function>(timestamp, value) AS values
+            /// FROM <raw_data>
+            /// GROUP BY id
             has_group = true;
+            group_by_raw_id = argument.select_query && rewriteGroupColumnToRawID(argument.select_query);
 
             timestamps = make_intrusive<ASTIdentifier>(ColumnNames::Timestamp);
             values = make_intrusive<ASTIdentifier>(ColumnNames::Value);
@@ -269,7 +314,15 @@ SQLQueryPiece applyFunctionOverRange(
     SelectQueryBuilder builder;
 
     if (has_group)
-        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
+    {
+        if (group_by_raw_id)
+        {
+            builder.select_list.push_back(makeASTFunction("timeSeriesIdToGroup", make_intrusive<ASTIdentifier>(ColumnNames::ID)));
+            builder.select_list.back()->setAlias(ColumnNames::Group);
+        }
+        else
+            builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
+    }
 
     /// <aggregate_function>(<timestamps>, <values>) AS values
     builder.select_list.push_back(addParametersToAggregateFunction(
@@ -282,7 +335,7 @@ SQLQueryPiece applyFunctionOverRange(
     builder.select_list.back()->setAlias(ColumnNames::Values);
 
     if (has_group)
-        builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
+        builder.group_by.push_back(make_intrusive<ASTIdentifier>(group_by_raw_id ? ColumnNames::ID : ColumnNames::Group));
 
     if (argument.select_query)
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Faster timeseries aggregation: single-key fast path in HashMethodKeysFixed, run-based sample appends with per-state batching, move semantics in state merges.

Part 2/3, stacked on #112179.