### PR TITLE
Add chunked samples storage to the TimeSeries engine

### DIFF
--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -220,6 +220,39 @@ public:
         }
     }
 
+    /// The default implementation merges with a copy and then destroys the source. The source is doomed
+    /// anyway, so move the buckets out of it instead when the bucket type supports destructive merging.
+    void mergeAndDestroyBatch(
+        AggregateDataPtr * dst_places,
+        AggregateDataPtr * rhs_places,
+        size_t size,
+        size_t offset,
+        ThreadPool & thread_pool,
+        std::atomic<bool> & is_cancelled,
+        Arena * arena) const override
+    {
+        if constexpr (!requires (Bucket & dst, Bucket & src) { dst.mergeDestructive(src); })
+        {
+            Base::mergeAndDestroyBatch(dst_places, rhs_places, size, offset, thread_pool, is_cancelled, arena);
+        }
+        else
+        {
+            for (size_t i = 0; i < size; ++i)
+            {
+                chassert(dst_places[i] + offset != rhs_places[i] + offset,
+                         "IAggregateFunction::mergeAndDestroyBatch called with the same source and destination state");
+
+                auto & dst_buckets = data(dst_places[i] + offset)->buckets;
+                auto & src_buckets = data(rhs_places[i] + offset)->buckets;
+                dst_buckets.reserve(src_buckets.size());
+                for (auto & src_bucket : src_buckets)
+                    dst_buckets[src_bucket.getKey()].mergeDestructive(src_bucket.getMapped());
+
+                destroy(rhs_places[i] + offset);
+            }
+        }
+    }
+
     void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
     {
         writeBinaryLittleEndian(FORMAT_VERSION, buf);
@@ -907,8 +940,97 @@ private:
 
     void addMany(AggregateDataPtr __restrict place, const TimestampType * __restrict timestamp_ptr, const ValueType * __restrict value_ptr, size_t start, size_t end) const
     {
-        for (size_t i = start; i < end; ++i)
-            add(place, timestamp_ptr[i], value_ptr[i]);
+        if (!use_int64_arithmetic)
+        {
+            for (size_t i = start; i < end; ++i)
+                add(place, timestamp_ptr[i], value_ptr[i]);
+            return;
+        }
+
+        /// Process the samples as runs over timestamp zones (see `bucketIndexAndZoneInt64`): samples arrive
+        /// in ascending-timestamp runs, so whole stretches share one bucket (bulk-appended) or fall into one
+        /// between-windows gap (skipped) with two comparisons per sample and no per-sample calls.
+        auto & state = *data(place);
+        size_t i = start;
+        while (i < end)
+        {
+            size_t bucket_index;
+            const Int64 ts = static_cast<Int64>(timestamp_ptr[i]);
+            if (ts > state.zone_lo && ts <= state.zone_hi)
+            {
+                bucket_index = state.zone_bucket;
+            }
+            else
+            {
+                bucket_index = bucketIndexAndZoneInt64(timestamp_ptr[i], state.zone_lo, state.zone_hi);
+                state.zone_bucket = bucket_index;
+            }
+
+            const Int64 zone_lo = state.zone_lo;
+            const Int64 zone_hi = state.zone_hi;
+            size_t run_end = i + 1;
+            while (run_end < end)
+            {
+                const Int64 t = static_cast<Int64>(timestamp_ptr[run_end]);
+                if (t > zone_lo && t <= zone_hi)
+                    ++run_end;
+                else
+                    break;
+            }
+
+            if (bucket_index != NO_BUCKET)
+            {
+                auto & bucket = state.buckets[bucket_index];
+                if constexpr (requires { bucket.addRun(timestamp_ptr, value_ptr, size_t{}); })
+                {
+                    bucket.addRun(timestamp_ptr + i, value_ptr + i, run_end - i);
+                }
+                else
+                {
+                    for (size_t k = i; k < run_end; ++k)
+                        bucket.add(timestamp_ptr[k], value_ptr[k]);
+                }
+            }
+
+            i = run_end;
+        }
+    }
+
+    /// The default `addBatch` dispatches row by row. The samples input is sorted by series, so consecutive
+    /// rows usually target the same aggregation state - process such runs with `addMany` instead.
+    void addBatch(
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr * places,
+        size_t place_offset,
+        const IColumn ** columns,
+        Arena * arena,
+        ssize_t if_argument_pos) const override
+    {
+        if (array_arguments || (if_argument_pos >= 0))
+        {
+            Base::addBatch(row_begin, row_end, places, place_offset, columns, arena, if_argument_pos);
+            return;
+        }
+
+        const auto & timestamp_column = typeid_cast<const ColVecType &>(*columns[0]);
+        const auto & value_column = typeid_cast<const ColVecResultType &>(*columns[1]);
+        const TimestampType * timestamp_data = timestamp_column.getData().data();
+        const ValueType * value_data = value_column.getData().data();
+
+        size_t i = row_begin;
+        while (i < row_end)
+        {
+            AggregateDataPtr place = places[i];
+            size_t run_end = i + 1;
+            while (run_end < row_end && places[run_end] == place)
+                ++run_end;
+
+            if (place)
+                addMany(place + place_offset, timestamp_data, value_data, i, run_end);
+
+            i = run_end;
+        }
     }
 
     void addManyNotNull(AggregateDataPtr __restrict place, const TimestampType * __restrict timestamp_ptr, const ValueType * __restrict value_ptr, const UInt8 * __restrict null_map, size_t start, size_t end) const

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -106,6 +106,9 @@ public:
         , odd_bucket_step(bucketStep(true, step, window_remainder, buckets_per_step, buckets_per_first_window))
         , first_bucket_end_time(firstBucketEndTimestamp(start_timestamp_, step, window_remainder, buckets_per_step, buckets_per_first_window))
         , first_bucket_is_clamped(firstBucketIsClamped(first_bucket_end_time, even_bucket_width))
+        , use_int64_arithmetic(useInt64Arithmetic(start_timestamp, end_timestamp, step, window, buckets_per_window))
+        , min_contributing_timestamp(use_int64_arithmetic
+            ? static_cast<Int64>(start_timestamp) - static_cast<Int64>(window) : 0)
     {
     }
 
@@ -414,6 +417,8 @@ protected:
     const IntervalType odd_bucket_step{};         /// End-to-end spacing of odd-indexed buckets
     const TimestampType first_bucket_end_time{};  /// End timestamp of bucket #0
     const bool first_bucket_is_clamped{};         /// Whether bucket #0's start is below the type minimum (only it can be)
+    const bool use_int64_arithmetic{};            /// Whether the per-sample bucket math provably fits in Int64 (see `useInt64Arithmetic`)
+    const Int64 min_contributing_timestamp{};     /// `start - window`: samples at or below it can't contribute (valid only with `use_int64_arithmetic`)
 
 private:
     /// `HashMap` relocates cells with `memcpy`, so it requires position-independent buckets: trivially
@@ -426,6 +431,14 @@ private:
     {
         /// Maps bucket index to the set of all timestamps and values
         TimeSeriesBucketsMap<Bucket> buckets;
+
+        /// Cache of the last resolved timestamp zone (see `bucketIndexAndZoneInt64`): timestamps in
+        /// `(zone_lo, zone_hi]` map to `zone_bucket` (which may be `NO_BUCKET` for a between-windows gap).
+        /// Samples arrive in ascending-timestamp runs, so consecutive samples usually hit the same zone,
+        /// turning the per-sample bucket arithmetic into two comparisons. `zone_lo == zone_hi` means empty.
+        Int64 zone_lo = 0;
+        Int64 zone_hi = 0;
+        size_t zone_bucket = NO_BUCKET;
     };
 
     static DataTypePtr createResultType()
@@ -652,11 +665,111 @@ private:
 
     static constexpr size_t NO_BUCKET = -1;
 
+    /// Whether `bucketIndexForTimestampInt64` may be used: every intermediate value of the per-sample bucket
+    /// math must fit in `Int64`. This is decided once per aggregator; the per-sample hot path then runs in
+    /// 64-bit instead of the overflow-proof but much slower `Int128`. The conditions (checked in `Int128`):
+    /// - `end + step + window` does not overflow upwards, which bounds `ts + window`, `offset + remainder`
+    ///   and `unclamped_grid_index * step` (the latter never exceeds `offset` by more than one `step`);
+    /// - `start - window` does not underflow, making the early-sample cutoff exact in `Int64`;
+    /// - `buckets_per_window` is small enough that bucket indices of in-window samples fit comfortably.
+    static bool useInt64Arithmetic(TimestampType start, TimestampType end, IntervalType step_, IntervalType window_,
+        size_t buckets_per_window_)
+    {
+        constexpr Int128 int64_max = std::numeric_limits<Int64>::max();
+        constexpr Int128 int64_min = std::numeric_limits<Int64>::min();
+
+        const Int128 end_128 = static_cast<Int128>(static_cast<Int64>(end));
+        const Int128 start_128 = static_cast<Int128>(static_cast<Int64>(start));
+        const Int128 step_128 = static_cast<Int128>(static_cast<Int64>(step_));
+        const Int128 window_128 = static_cast<Int128>(static_cast<Int64>(window_));
+
+        return end_128 + step_128 + window_128 <= int64_max
+            && start_128 - window_128 >= int64_min
+            && buckets_per_window_ <= (1ull << 40);
+    }
+
+    /// `Int64` twin of the `Int128` arithmetic in `bucketIndexForTimestamp`, taken when `use_int64_arithmetic`
+    /// proved it overflow-free. This runs for every sample, and 128-bit division dominated the profile.
+    /// Besides the bucket index it returns the containing zone `(zone_lo, zone_hi]` - the full preimage of the
+    /// result - so the caller can cache it and resolve subsequent samples of the same zone with two comparisons.
+    size_t ALWAYS_INLINE bucketIndexAndZoneInt64(const TimestampType timestamp, Int64 & zone_lo, Int64 & zone_hi) const
+    {
+        const Int64 ts = static_cast<Int64>(timestamp);
+        if (ts > static_cast<Int64>(end_timestamp))
+        {
+            zone_lo = static_cast<Int64>(end_timestamp);
+            zone_hi = std::numeric_limits<Int64>::max();
+            return NO_BUCKET;
+        }
+        if (ts <= min_contributing_timestamp)
+        {
+            zone_lo = std::numeric_limits<Int64>::min();
+            zone_hi = min_contributing_timestamp;
+            return NO_BUCKET;
+        }
+
+        const Int64 step_64 = static_cast<Int64>(step);
+        const Int64 offset = ts - static_cast<Int64>(start_timestamp);
+
+        Int64 unclamped_grid_index = 0;
+        if (step > 0)
+        {
+            unclamped_grid_index = offset / step_64;
+            unclamped_grid_index += (offset % step_64) > 0;
+        }
+
+        /// Skip a sample that is already out of window (`isSampleOutOfWindow` on the clamped grid point).
+        const Int64 clamped_grid_index = unclamped_grid_index > 0 ? unclamped_grid_index : 0;
+        const Int64 grid_timestamp = static_cast<Int64>(start_timestamp) + clamped_grid_index * step_64;
+        if (ts + static_cast<Int64>(window) <= grid_timestamp)
+        {
+            /// The between-windows gap `(previous grid point, this grid point - window]`. The sample is past
+            /// `min_contributing_timestamp`, so its grid index is at least 1 and the gap's start is in range.
+            zone_lo = grid_timestamp - step_64;
+            zone_hi = grid_timestamp - static_cast<Int64>(window);
+            return NO_BUCKET;
+        }
+
+        const Int64 leading_buckets = static_cast<Int64>(buckets_per_first_window);
+        Int64 bucket_index;
+        if (window_remainder == 0)
+        {
+            /// One bucket per step.
+            bucket_index = unclamped_grid_index + leading_buckets - 1;
+        }
+        else
+        {
+            /// Each step is split at (grid timestamp - window_remainder).
+            const Int64 remainder = static_cast<Int64>(window_remainder);
+            const bool before_split_point = (offset + remainder) <= (unclamped_grid_index * step_64);
+            bucket_index = 2 * unclamped_grid_index + leading_buckets - 1 - (before_split_point ? 1 : 0);
+        }
+
+        chassert(bucket_index >= 0 && bucket_index < static_cast<Int64>(bucket_count));
+
+        /// The bucket's own time range (see `bucketTimeRange`): buckets tile the in-window timeline, so this
+        /// is the exact preimage of `bucket_index`.
+        zone_hi = static_cast<Int64>(bucketEndTimestamp(static_cast<size_t>(bucket_index)));
+        if (bucket_index == 0 && first_bucket_is_clamped)
+            zone_lo = std::numeric_limits<Int64>::min();
+        else
+            zone_lo = zone_hi - static_cast<Int64>((bucket_index % 2 != 0) ? odd_bucket_width : even_bucket_width);
+
+        return static_cast<size_t>(bucket_index);
+    }
+
     /// Returns the index of the bucket a sample at `timestamp` contributes to.
     /// The function returns NO_BUCKET if the specified timestamp can't contribute to any buckets
     /// because it's too early, or too late, or already out of window.
     size_t bucketIndexForTimestamp(const TimestampType timestamp) const
     {
+        if (use_int64_arithmetic)
+        {
+            Int64 ignored_zone_lo;
+            Int64 ignored_zone_hi;
+            return bucketIndexAndZoneInt64(timestamp, ignored_zone_lo, ignored_zone_hi);
+        }
+
         if (timestamp > end_timestamp)
             return NO_BUCKET;
 
@@ -766,11 +879,29 @@ private:
 
     void ALWAYS_INLINE add(AggregateDataPtr __restrict place, TimestampType timestamp, ValueType value) const
     {
-        const size_t bucket_index = bucketIndexForTimestamp(timestamp);
+        auto & state = *data(place);
+
+        size_t bucket_index;
+        const Int64 ts = static_cast<Int64>(timestamp);
+        if (ts > state.zone_lo && ts <= state.zone_hi)
+        {
+            /// Samples arrive in ascending-timestamp runs, so most fall into the zone of the previous one.
+            bucket_index = state.zone_bucket;
+        }
+        else if (use_int64_arithmetic)
+        {
+            bucket_index = bucketIndexAndZoneInt64(timestamp, state.zone_lo, state.zone_hi);
+            state.zone_bucket = bucket_index;
+        }
+        else
+        {
+            bucket_index = bucketIndexForTimestamp(timestamp);
+        }
+
         if (bucket_index == NO_BUCKET)
             return;  /// The sample can't contribute to any bucket.
 
-        auto & bucket = data(place)->buckets[bucket_index];
+        auto & bucket = state.buckets[bucket_index];
         bucket.add(timestamp, value);
     }
 

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesChanges.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesChanges.h
@@ -90,7 +90,6 @@ struct AggregateFunctionTimeseriesChangesTraits
     struct Aggregator
     {
         AggregateFunctionTimeseriesSlidingSum<TimestampType, Summary> sliding_sum;
-        VectorWithMemoryTracking<std::pair<TimestampType, ValueType>> temp_buffer;  /// reused sort buffer
 
         /// `Summary::merge` is order-dependent (not commutative), so it must take the invertible running-sum path,
         /// not the two-stacks path which combines values out of time order.
@@ -108,7 +107,7 @@ struct AggregateFunctionTimeseriesChangesTraits
                     ++summary.changes;
                 summary.last_value = value;
                 ++summary.count;
-            }, temp_buffer);
+            });
             add(std::move(summary), bucket_end_timestamp);
         }
 

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesExtrapolatedValue.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesExtrapolatedValue.h
@@ -95,7 +95,6 @@ struct AggregateFunctionTimeseriesExtrapolatedValueTraits
     struct Aggregator
     {
         AggregateFunctionTimeseriesSlidingSum<TimestampType, Summary> sliding_sum;
-        VectorWithMemoryTracking<std::pair<TimestampType, ValueType>> temp_buffer;  /// reused sort buffer
 
         /// `Summary::merge` is order-dependent (not commutative), so it must take the invertible running-sum path,
         /// not the two-stacks path which combines values out of time order.
@@ -129,7 +128,7 @@ struct AggregateFunctionTimeseriesExtrapolatedValueTraits
                 summary.last_timestamp = timestamp;
                 summary.last_value = value;
                 ++summary.count;
-            }, temp_buffer);
+            });
             add(std::move(summary), bucket_end_timestamp);
         }
 

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
@@ -43,10 +43,39 @@ public:
         compacted = false;
     }
 
+    /// Appends `count` samples at once. Semantically `add` in a loop, but with a single size bump and
+    /// raw writes - this is the hot path when whole runs of samples fall into one bucket.
+    void addRun(const TimestampType * timestamps, const ValueType * values, size_t count)
+    {
+        const size_t old_size = buffer.size();
+        buffer.resize(old_size + count);
+        auto * out = buffer.data() + old_size;
+        for (size_t i = 0; i < count; ++i)
+        {
+            out[i].first = timestamps[i];
+            out[i].second = values[i];
+        }
+        compacted = false;
+    }
+
     void merge(const AggregateFunctionTimeseriesSamples & other)
     {
         buffer.insert(buffer.end(), other.buffer.begin(), other.buffer.end());
         compacted = false;
+    }
+
+    /// Merge that may leave `other` empty. During the merge of partial aggregation states each
+    /// (series, bucket) usually exists in exactly one source state, so the destination bucket is
+    /// empty and the samples are stolen instead of copied.
+    void mergeDestructive(AggregateFunctionTimeseriesSamples & other)
+    {
+        if (buffer.empty())
+        {
+            buffer.swap(other.buffer);
+            compacted = other.compacted;
+            return;
+        }
+        merge(other);
     }
 
     void serialize(WriteBuffer & buf) const
@@ -125,8 +154,10 @@ private:
             return;
 
         /// Sorting by (timestamp, value) makes the last sample of each equal-timestamp run the one with
-        /// the larger value.
-        ::sort(buffer.begin(), buffer.end());
+        /// the larger value. Samples arrive as ascending runs, so the buffer is usually sorted already -
+        /// checking is much cheaper than re-sorting.
+        if (!std::is_sorted(buffer.begin(), buffer.end()))
+            ::sort(buffer.begin(), buffer.end());
 
         auto out = buffer.begin();
         for (auto it = buffer.begin(); it != buffer.end();)

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
@@ -4,8 +4,6 @@
 #include <functional>
 #include <utility>
 
-#include <absl/container/flat_hash_map.h>
-
 #include <base/sort.h>
 
 #include <Common/AllocatorWithMemoryTracking.h>
@@ -23,35 +21,39 @@ namespace ErrorCodes
     extern const int INCORRECT_DATA;
 }
 
-/// Per-bucket storage of timeseries samples keyed by timestamp.
+/// Per-bucket storage of timeseries samples.
 /// When two samples share a timestamp the larger value is kept.
+///
+/// Samples are stored in an append-only vector and canonicalized (sorted by timestamp, duplicates collapsed
+/// to the larger value) lazily, on first ordered access. Inputs arrive as ascending-timestamp runs (the
+/// samples table is sorted by timestamp within each series), so the canonicalization sort runs on
+/// almost-sorted data and is cheap, while appends stay O(1) without any per-sample hashing.
 template <typename TimestampType, typename ValueType>
 class AggregateFunctionTimeseriesSamples
 {
 public:
     /// The bucket map (`HashMap`) relocates cells with `memcpy` and abandons the source, which is safe for
-    /// any type without pointers into itself. `absl::flat_hash_map` qualifies: the address of its inline
-    /// single-element storage (small object optimization) is computed from `this`, the rest is on the heap.
-    /// No standard trait expresses this (weaker than `std::is_trivially_copyable`) property, hence the
-    /// explicit declaration.
+    /// any type without pointers into itself. A vector qualifies: its buffer is on the heap. No standard
+    /// trait expresses this (weaker than `std::is_trivially_copyable`) property, hence the explicit declaration.
     static constexpr bool is_position_independent = true;
 
     void add(TimestampType timestamp, ValueType value)
     {
-        auto [it, inserted] = buffer.emplace(timestamp, value);
-        if (!inserted)
-            it->second = std::max(it->second, value);
+        buffer.emplace_back(timestamp, value);
+        compacted = false;
     }
 
     void merge(const AggregateFunctionTimeseriesSamples & other)
     {
-        buffer.reserve(buffer.size() + other.buffer.size());
-        for (const auto & [timestamp, value] : other.buffer)
-            add(timestamp, value);
+        buffer.insert(buffer.end(), other.buffer.begin(), other.buffer.end());
+        compacted = false;
     }
 
     void serialize(WriteBuffer & buf) const
     {
+        /// Canonicalize first so duplicates don't inflate the serialized state.
+        compact();
+
         writeBinaryLittleEndian(buffer.size(), buf);
         for (const auto & [timestamp, value] : buffer)
         {
@@ -64,6 +66,7 @@ public:
     {
         /// Deserialize replaces any previous contents.
         buffer.clear();
+        compacted = false;
 
         size_t sample_count = 0;
         readBinaryLittleEndian(sample_count, buf);
@@ -74,7 +77,7 @@ public:
             readBinaryLittleEndian(timestamp, buf);
             ValueType value;
             readBinaryLittleEndian(value, buf);
-            add(timestamp, value);
+            buffer.emplace_back(timestamp, value);
         }
     }
 
@@ -82,47 +85,67 @@ public:
     template <typename RangeType>
     void checkTimestampsInRange(const RangeType & range) const
     {
-        forEachSample([&range](TimestampType timestamp, ValueType)
+        for (const auto & [timestamp, value] : buffer)
         {
             if (!range.contains(timestamp))
                 throw Exception(ErrorCodes::INCORRECT_DATA,
                     "Cannot deserialize data: timestamp {} is outside its bucket's range",
                     static_cast<Int64>(timestamp));
-        });
+        }
     }
 
-    /// Invokes `f(timestamp, value)` for every sample, in arbitrary order. Used by the per-function sliding
-    /// aggregators for order-independent aggregates (e.g. linear regression moments).
+    /// Invokes `f(timestamp, value)` for every distinct-timestamp sample, in arbitrary order. Used by the
+    /// per-function sliding aggregators for order-independent aggregates (e.g. linear regression moments).
+    /// Canonicalizes first: duplicate-timestamp semantics (keep the larger value) must hold here too.
     template <typename F>
     void forEachSample(F && f) const
     {
+        compact();
         for (const auto & [timestamp, value] : buffer)
             f(timestamp, value);
     }
 
-    /// Invokes `f(timestamp, value)` for every sample in ascending timestamp order, using `temp_buffer` as a
-    /// reused sort buffer. Used by the order-dependent aggregators (rate reset accounting, counting transitions).
+    /// Invokes `f(timestamp, value)` for every distinct-timestamp sample in ascending timestamp order.
+    /// Used by the order-dependent aggregators (rate reset accounting, counting transitions).
     template <typename F>
-    void forEachSampleSorted(F && f, VectorWithMemoryTracking<std::pair<TimestampType, ValueType>> & temp_buffer) const
+    void forEachSampleSorted(F && f) const
     {
-        temp_buffer.clear();
-        temp_buffer.reserve(buffer.size());
+        compact();
         for (const auto & [timestamp, value] : buffer)
-            temp_buffer.emplace_back(timestamp, value);
-        ::sort(temp_buffer.begin(), temp_buffer.end());
-        for (const auto & [timestamp, value] : temp_buffer)
             f(timestamp, value);
     }
 
 private:
-    /// Samples keyed by timestamp. Uses `AllocatorWithMemoryTracking` so per-bucket sample memory is counted by
-    /// the `MemoryTracker`, like the rest of the aggregate state.
-    absl::flat_hash_map<
-        TimestampType,
-        ValueType,
-        absl::container_internal::hash_default_hash<TimestampType>,
-        std::equal_to<>,
-        AllocatorWithMemoryTracking<std::pair<const TimestampType, ValueType>>> buffer;
+    /// Sorts samples by timestamp and collapses samples sharing a timestamp to the one with the larger value.
+    /// Logically const: canonicalization only changes the representation, not the sample set, and states are
+    /// never accessed concurrently.
+    void compact() const
+    {
+        if (compacted)
+            return;
+
+        /// Sorting by (timestamp, value) makes the last sample of each equal-timestamp run the one with
+        /// the larger value.
+        ::sort(buffer.begin(), buffer.end());
+
+        auto out = buffer.begin();
+        for (auto it = buffer.begin(); it != buffer.end();)
+        {
+            auto run_end = it + 1;
+            while (run_end != buffer.end() && run_end->first == it->first)
+                ++run_end;
+            *out++ = *(run_end - 1);
+            it = run_end;
+        }
+        buffer.erase(out, buffer.end());
+
+        compacted = true;
+    }
+
+    /// Samples in insertion order until `compact` canonicalizes them. Uses `AllocatorWithMemoryTracking` so
+    /// per-bucket sample memory is counted by the `MemoryTracker`, like the rest of the aggregate state.
+    mutable VectorWithMemoryTracking<std::pair<TimestampType, ValueType>> buffer;
+    mutable bool compacted = false;
 };
 
 }

--- a/src/Common/ColumnsHashing/HashMethod.h
+++ b/src/Common/ColumnsHashing/HashMethod.h
@@ -420,6 +420,10 @@ struct HashMethodKeysFixed
 
     PaddedPODArray<Key> prepared_keys;
 
+    /// When a single key column exactly fills the Key, its raw data is used as the keys directly,
+    /// with no packing pass at all (see the constructor).
+    const Key * direct_keys = nullptr;
+
     static bool usePreparedKeys(const Sizes & key_sizes)
     {
         if (has_low_cardinality || has_nullable_keys || sizeof(Key) > 16)
@@ -455,7 +459,18 @@ struct HashMethodKeysFixed
 
         if (usePreparedKeys(key_sizes))
         {
-            packFixedBatch(keys_size, Base::getActualColumns(), key_sizes, prepared_keys);
+            if (keys_size == 1 && key_sizes[0] == sizeof(Key))
+            {
+                /// The single key occupies the whole Key: the column's raw data already is the packed
+                /// keys array, so use it directly instead of zero-filling and copying a buffer.
+                /// (Same aliasing note as in fillFixedBatch.)
+                direct_keys = reinterpret_cast<const Key *>(
+                    static_cast<const ColumnFixedSizeHelper *>(Base::getActualColumns()[0])->template getRawDataBegin<sizeof(Key)>());
+            }
+            else
+            {
+                packFixedBatch(keys_size, Base::getActualColumns(), key_sizes, prepared_keys);
+            }
         }
 
 #if defined(__SSSE3__) && !defined(MEMORY_SANITIZER)
@@ -523,6 +538,9 @@ struct HashMethodKeysFixed
             if constexpr (has_low_cardinality)
                 return packFixed<Key, true>(row, keys_size, low_cardinality_keys.nested_columns, key_sizes,
                                             &low_cardinality_keys.positions, &low_cardinality_keys.position_sizes);
+
+            if (direct_keys)
+                return direct_keys[row];
 
             if (!prepared_keys.empty())
                 return prepared_keys[row];

--- a/src/Storages/StoragePrometheusQuery.cpp
+++ b/src/Storages/StoragePrometheusQuery.cpp
@@ -16,6 +16,7 @@
 #include <Storages/StorageTimeSeries.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/Converter.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
+#include <Storages/TimeSeries/TimeSeriesSettings.h>
 #include <Storages/TimeSeries/splitTimeSeriesType.h>
 
 
@@ -26,6 +27,11 @@ namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+}
+
+namespace TimeSeriesSetting
+{
+    extern const TimeSeriesSettingsBool store_samples_in_chunks;
 }
 
 namespace
@@ -140,6 +146,7 @@ StoragePrometheusQuery::Configuration StoragePrometheusQuery::getConfiguration(A
     evaluation_settings.time_series_storage_id = std::move(time_series_storage_id);
     evaluation_settings.timestamp_data_type = std::move(timestamp_data_type);
     evaluation_settings.scalar_data_type = std::move(scalar_data_type);
+    evaluation_settings.samples_stored_in_chunks = (*time_series_storage->getStorageSettings())[TimeSeriesSetting::store_samples_in_chunks];
     evaluation_settings.mode = mode;
     evaluation_settings.start_time = start_time;
     evaluation_settings.end_time = end_time;

--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -3,6 +3,8 @@
 #include <Common/logger_useful.h>
 #include <Common/quoteString.h>
 #include <Columns/IColumn.h>
+#include <Core/DecimalFunctions.h>
+#include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesDecimal.h>
@@ -64,7 +66,9 @@ namespace TimeSeriesSetting
 {
     extern const TimeSeriesSettingsMap tags_to_columns;
     extern const TimeSeriesSettingsBool filter_by_min_time_and_max_time;
+    extern const TimeSeriesSettingsUInt64 samples_chunk_interval;
     extern const TimeSeriesSettingsBool store_min_time_and_max_time;
+    extern const TimeSeriesSettingsBool store_samples_in_chunks;
 }
 
 StorageTimeSeriesSelector::Configuration StorageTimeSeriesSelector::getConfiguration(ASTs & args, const ContextPtr & context)
@@ -144,6 +148,15 @@ StorageTimeSeriesSelector::Configuration StorageTimeSeriesSelector::getConfigura
     config.selector = std::move(selector);
     config.min_time = min_time;
     config.max_time = max_time;
+
+    const auto & storage_settings = *time_series_storage->getStorageSettings();
+    config.samples_stored_in_chunks = storage_settings[TimeSeriesSetting::store_samples_in_chunks];
+    if (config.samples_stored_in_chunks)
+    {
+        config.samples_chunk_interval = static_cast<Int64>(UInt64{storage_settings[TimeSeriesSetting::samples_chunk_interval]})
+            * DecimalUtils::scaleMultiplier<Int64>(timestamp_scale);
+    }
+
     return config;
 }
 
@@ -325,7 +338,9 @@ namespace
         ASTPtr select_query_from_tags_table,
         DateTime64 min_time,
         DateTime64 max_time,
-        const DataTypePtr & timestamp_data_type)
+        const DataTypePtr & timestamp_data_type,
+        bool samples_stored_in_chunks,
+        Int64 samples_chunk_interval)
     {
         ASTs conditions;
 
@@ -334,17 +349,40 @@ namespace
         auto select_as_subquery = make_intrusive<ASTSubquery>(std::move(select_query_from_tags_table));
         conditions.push_back(makeASTFunction("in", make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID), std::move(select_as_subquery)));
 
-        /// timestamp >= min_time
-        conditions.push_back(makeASTFunction(
-            "greaterOrEquals",
-            make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Timestamp),
-            timeSeriesTimestampToAST(min_time, timestamp_data_type)));
+        if (samples_stored_in_chunks)
+        {
+            /// A chunk covers `[chunk_start, chunk_start + interval)`; it intersects `[min_time, max_time]`
+            /// iff `chunk_start > min_time - interval` and `chunk_start <= max_time`.
+            Int64 lower_bound = (min_time.value > std::numeric_limits<Int64>::min() + samples_chunk_interval)
+                ? (min_time.value - samples_chunk_interval + 1)
+                : std::numeric_limits<Int64>::min();
 
-        /// timestamp <= max_time
-        conditions.push_back(makeASTFunction(
-            "lessOrEquals",
-            make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Timestamp),
-            timeSeriesTimestampToAST(max_time, timestamp_data_type)));
+            /// chunk_start >= min_time - interval + 1
+            conditions.push_back(makeASTFunction(
+                "greaterOrEquals",
+                make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ChunkStart),
+                timeSeriesTimestampToAST(DateTime64(lower_bound), timestamp_data_type)));
+
+            /// chunk_start <= max_time
+            conditions.push_back(makeASTFunction(
+                "lessOrEquals",
+                make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ChunkStart),
+                timeSeriesTimestampToAST(max_time, timestamp_data_type)));
+        }
+        else
+        {
+            /// timestamp >= min_time
+            conditions.push_back(makeASTFunction(
+                "greaterOrEquals",
+                make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Timestamp),
+                timeSeriesTimestampToAST(min_time, timestamp_data_type)));
+
+            /// timestamp <= max_time
+            conditions.push_back(makeASTFunction(
+                "lessOrEquals",
+                make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Timestamp),
+                timeSeriesTimestampToAST(max_time, timestamp_data_type)));
+        }
 
         return makeASTForLogicalAnd(std::move(conditions));
     }
@@ -356,47 +394,56 @@ namespace
                                         const DataTypePtr & id_data_type,
                                         const DataTypePtr & timestamp_data_type,
                                         const DataTypePtr & scalar_data_type,
-                                        const ColumnsDescription & data_table_columns)
+                                        const ColumnsDescription & data_table_columns,
+                                        bool samples_stored_in_chunks,
+                                        Int64 samples_chunk_interval)
     {
         auto select_query = make_intrusive<ASTSelectQuery>();
 
-        /// SELECT id, timestamp, value
+        /// SELECT id, timestamp, value  (or, for the chunked layout: SELECT id, timestamps, `values`)
         /// Casts to the expected types are added only when a column's type in the data table differs:
         /// a same-type CAST would not be a no-op - it would be evaluated for every sample row.
         {
             auto select_list_exp = make_intrusive<ASTExpressionList>();
             auto & select_list = select_list_exp->children;
 
-            if (data_table_columns.get(TimeSeriesColumnNames::ID).type->equals(*id_data_type))
+            /// Adds a column to the select list, casting it to `expected_type` if the data table declares
+            /// a different type (e.g. a `SimpleAggregateFunction(groupArrayArray, ...)` wrapper).
+            auto add_column = [&](const char * column_name, const DataTypePtr & expected_type, bool timestamp_cast)
             {
-                select_list.push_back(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID));
-            }
-            else
-            {
-                select_list.push_back(makeASTFunction(
-                    "CAST", make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID), make_intrusive<ASTLiteral>(id_data_type->getName())));
-                select_list.back()->setAlias(TimeSeriesColumnNames::ID);
-            }
+                if (data_table_columns.get(column_name).type->equals(*expected_type))
+                {
+                    select_list.push_back(make_intrusive<ASTIdentifier>(column_name));
+                    return;
+                }
+                if (timestamp_cast)
+                    select_list.push_back(timeSeriesTimestampASTCast(make_intrusive<ASTIdentifier>(column_name), expected_type));
+                else
+                    select_list.push_back(makeASTFunction(
+                        "CAST", make_intrusive<ASTIdentifier>(column_name), make_intrusive<ASTLiteral>(expected_type->getName())));
+                select_list.back()->setAlias(column_name);
+            };
 
-            if (data_table_columns.get(TimeSeriesColumnNames::Timestamp).type->equals(*timestamp_data_type))
-            {
-                select_list.push_back(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Timestamp));
-            }
-            else
-            {
-                select_list.push_back(
-                    timeSeriesTimestampASTCast(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Timestamp), timestamp_data_type));
-                select_list.back()->setAlias(TimeSeriesColumnNames::Timestamp);
-            }
+            add_column(TimeSeriesColumnNames::ID, id_data_type, /* timestamp_cast = */ false);
 
-            if (data_table_columns.get(TimeSeriesColumnNames::Value).type->equals(*scalar_data_type))
+            if (samples_stored_in_chunks)
             {
-                select_list.push_back(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Value));
+                add_column(TimeSeriesColumnNames::Timestamps, std::make_shared<DataTypeArray>(timestamp_data_type), /* timestamp_cast = */ false);
+                add_column(TimeSeriesColumnNames::Values, std::make_shared<DataTypeArray>(scalar_data_type), /* timestamp_cast = */ false);
             }
             else
             {
-                select_list.push_back(timeSeriesScalarASTCast(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Value), scalar_data_type));
-                select_list.back()->setAlias(TimeSeriesColumnNames::Value);
+                add_column(TimeSeriesColumnNames::Timestamp, timestamp_data_type, /* timestamp_cast = */ true);
+
+                if (data_table_columns.get(TimeSeriesColumnNames::Value).type->equals(*scalar_data_type))
+                {
+                    select_list.push_back(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Value));
+                }
+                else
+                {
+                    select_list.push_back(timeSeriesScalarASTCast(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Value), scalar_data_type));
+                    select_list.back()->setAlias(TimeSeriesColumnNames::Value);
+                }
             }
 
             select_query->setExpression(ASTSelectQuery::Expression::SELECT, select_list_exp);
@@ -422,7 +469,9 @@ namespace
         /// where <select_query_from_tags_table> is roughly:
         ///   SELECT timeSeriesStoreTags(id, tags, '__name__', metric_name, ...) FROM tags_table WHERE <matchers>
         {
-            auto where_filter = makeWhereFilterForDataTable(select_query_from_tags_table, min_time, max_time, timestamp_data_type);
+            auto where_filter = makeWhereFilterForDataTable(
+                select_query_from_tags_table, min_time, max_time, timestamp_data_type,
+                samples_stored_in_chunks, samples_chunk_interval);
             select_query->setExpression(ASTSelectQuery::Expression::WHERE, std::move(where_filter));
         }
 
@@ -498,7 +547,9 @@ void StorageTimeSeriesSelector::readImpl(
         config.id_data_type,
         config.timestamp_data_type,
         config.scalar_data_type,
-        samples_table_columns);
+        samples_table_columns,
+        config.samples_stored_in_chunks,
+        config.samples_chunk_interval);
 
     LOG_DEBUG(log, "Building SQL for selector: {}", config.selector.toString());
     LOG_DEBUG(log, "Will execute query:\n{}", select_query_from_data_table->formatForLogging());

--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -20,6 +20,7 @@
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/Prometheus/parseTimeSeriesTypes.h>
 #include <Parsers/makeASTForLogicalFunction.h>
+#include <Storages/ColumnsDescription.h>
 #include <Storages/SelectQueryInfo.h>
 #include <Storages/StorageTimeSeries.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
@@ -354,25 +355,49 @@ namespace
                                         DateTime64 max_time,
                                         const DataTypePtr & id_data_type,
                                         const DataTypePtr & timestamp_data_type,
-                                        const DataTypePtr & scalar_data_type)
+                                        const DataTypePtr & scalar_data_type,
+                                        const ColumnsDescription & data_table_columns)
     {
         auto select_query = make_intrusive<ASTSelectQuery>();
 
         /// SELECT id, timestamp, value
+        /// Casts to the expected types are added only when a column's type in the data table differs:
+        /// a same-type CAST would not be a no-op - it would be evaluated for every sample row.
         {
             auto select_list_exp = make_intrusive<ASTExpressionList>();
             auto & select_list = select_list_exp->children;
 
-            select_list.push_back(makeASTFunction(
-                "CAST", make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID), make_intrusive<ASTLiteral>(id_data_type->getName())));
-            select_list.back()->setAlias(TimeSeriesColumnNames::ID);
+            if (data_table_columns.get(TimeSeriesColumnNames::ID).type->equals(*id_data_type))
+            {
+                select_list.push_back(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID));
+            }
+            else
+            {
+                select_list.push_back(makeASTFunction(
+                    "CAST", make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID), make_intrusive<ASTLiteral>(id_data_type->getName())));
+                select_list.back()->setAlias(TimeSeriesColumnNames::ID);
+            }
 
-            select_list.push_back(
-                timeSeriesTimestampASTCast(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Timestamp), timestamp_data_type));
-            select_list.back()->setAlias(TimeSeriesColumnNames::Timestamp);
+            if (data_table_columns.get(TimeSeriesColumnNames::Timestamp).type->equals(*timestamp_data_type))
+            {
+                select_list.push_back(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Timestamp));
+            }
+            else
+            {
+                select_list.push_back(
+                    timeSeriesTimestampASTCast(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Timestamp), timestamp_data_type));
+                select_list.back()->setAlias(TimeSeriesColumnNames::Timestamp);
+            }
 
-            select_list.push_back(timeSeriesScalarASTCast(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Value), scalar_data_type));
-            select_list.back()->setAlias(TimeSeriesColumnNames::Value);
+            if (data_table_columns.get(TimeSeriesColumnNames::Value).type->equals(*scalar_data_type))
+            {
+                select_list.push_back(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Value));
+            }
+            else
+            {
+                select_list.push_back(timeSeriesScalarASTCast(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Value), scalar_data_type));
+                select_list.back()->setAlias(TimeSeriesColumnNames::Value);
+            }
 
             select_query->setExpression(ASTSelectQuery::Expression::SELECT, select_list_exp);
         }
@@ -461,6 +486,10 @@ void StorageTimeSeriesSelector::readImpl(
     ASTPtr select_query_from_tags_table = makeSelectQueryFromTagsTable(
         tags_table_id, matchers, column_name_by_tag_name, min_time_to_filter_ids, max_time_to_filter_ids, config.timestamp_data_type);
 
+    auto samples_table = time_series_storage->getTargetTable(ViewTarget::Samples, context);
+    auto samples_table_metadata = samples_table->getInMemoryMetadataPtr(context, false);
+    const auto & samples_table_columns = samples_table_metadata->columns;
+
     ASTPtr select_query_from_data_table = makeSelectQueryFromDataTable(
         samples_table_id,
         select_query_from_tags_table,
@@ -468,7 +497,8 @@ void StorageTimeSeriesSelector::readImpl(
         config.max_time,
         config.id_data_type,
         config.timestamp_data_type,
-        config.scalar_data_type);
+        config.scalar_data_type,
+        samples_table_columns);
 
     LOG_DEBUG(log, "Building SQL for selector: {}", config.selector.toString());
     LOG_DEBUG(log, "Will execute query:\n{}", select_query_from_data_table->formatForLogging());

--- a/src/Storages/StorageTimeSeriesSelector.h
+++ b/src/Storages/StorageTimeSeriesSelector.h
@@ -27,6 +27,15 @@ public:
         /// The scale of these fields is the same as the scale used in `timestamp_data_type`.
         DateTime64 min_time{};
         DateTime64 max_time{};
+
+        /// Whether the TimeSeries table stores samples in the chunked layout (`store_samples_in_chunks`).
+        /// In that case the selector returns columns (id, timestamps, values) with per-series arrays of
+        /// samples covering whole chunks (at least the [min_time, max_time] range), instead of one row
+        /// per sample clipped to exactly that range.
+        bool samples_stored_in_chunks = false;
+
+        /// The chunk interval in raw timestamp units (valid when `samples_stored_in_chunks` is set).
+        Int64 samples_chunk_interval = 0;
     };
 
     static Configuration getConfiguration(ASTs & args, const ContextPtr & context);

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -10,6 +10,7 @@
 #include <Parsers/Prometheus/parseTimeSeriesTypes.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/Converter.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
+#include <Storages/TimeSeries/TimeSeriesSettings.h>
 #include <Storages/TimeSeries/splitTimeSeriesType.h>
 #include <Interpreters/executeQuery.h>
 #include <Interpreters/Context.h>
@@ -36,6 +37,11 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
 }
 
+namespace TimeSeriesSetting
+{
+    extern const TimeSeriesSettingsBool store_samples_in_chunks;
+}
+
 PrometheusHTTPProtocolAPI::PrometheusHTTPProtocolAPI(ConstStoragePtr time_series_storage_, const ContextMutablePtr & context_)
     : WithMutableContext{context_}
     , time_series_storage(storagePtrToTimeSeries(time_series_storage_))
@@ -55,6 +61,7 @@ void PrometheusHTTPProtocolAPI::executePromQLQuery(
     auto time_series_metadata = time_series_storage->getInMemoryMetadataPtr(getContext(), false);
     std::tie(evaluation_settings.timestamp_data_type, evaluation_settings.scalar_data_type)
         = splitTimeSeriesType(time_series_metadata->columns.get(TimeSeriesColumnNames::TimeSeries).type);
+    evaluation_settings.samples_stored_in_chunks = (*time_series_storage->getStorageSettings())[TimeSeriesSetting::store_samples_in_chunks];
     UInt32 timestamp_scale = tryGetDecimalScale(*evaluation_settings.timestamp_data_type).value_or(0);
 
     auto query_tree = std::make_shared<PrometheusQueryTree>();

--- a/src/Storages/TimeSeries/PrometheusQueryEvaluationSettings.h
+++ b/src/Storages/TimeSeries/PrometheusQueryEvaluationSettings.h
@@ -33,6 +33,10 @@ struct PrometheusQueryEvaluationSettings
     DataTypePtr timestamp_data_type;
     DataTypePtr scalar_data_type;
 
+    /// Whether the TimeSeries table stores samples in the chunked layout (`store_samples_in_chunks`),
+    /// in which case `timeSeriesSelector` returns per-series arrays of samples instead of sample rows.
+    bool samples_stored_in_chunks = false;
+
     PrometheusQueryEvaluationMode mode = PrometheusQueryEvaluationMode::QUERY;
 
     /// Specifies that a prometheus query should be evaluated at the current time.

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.cpp
@@ -15,6 +15,7 @@ ConverterContext::ConverterContext(std::shared_ptr<const PrometheusQueryTree> pr
     , timestamp_data_type(settings_.timestamp_data_type)
     , timestamp_scale(tryGetDecimalScale(*timestamp_data_type).value_or(0))
     , scalar_data_type(settings_.scalar_data_type)
+    , samples_stored_in_chunks(settings_.samples_stored_in_chunks)
     , node_range_getter(promql_tree_, settings_)
     , result_type(getResultType(*promql_tree_, settings_))
 {

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h
@@ -17,6 +17,7 @@ struct ConverterContext
     DataTypePtr timestamp_data_type;
     UInt32 timestamp_scale;
     DataTypePtr scalar_data_type;
+    const bool samples_stored_in_chunks;
     const NodeEvaluationRangeGetter node_range_getter;
     const ResultType result_type;
     SQLSubqueries subqueries;

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/SQLQueryPiece.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/SQLQueryPiece.h
@@ -86,6 +86,14 @@ struct SQLQueryPiece
     /// If `store_method` is RAW_DATA then the SELECT query outputs three columns `group` (UInt64), `timestamp` (timestamp_data_type), `value` (scalar_data_type).
     /// If `store_method` is CONST_SCALAR or CONST_STRING then the SELECT query is not used.
     ASTPtr select_query;
+
+    /// Used only if `store_method` is RAW_DATA and the samples are stored in the chunked layout
+    /// (see the `store_samples_in_chunks` setting of the TimeSeries engine). An alternative SELECT query
+    /// which outputs three columns `id`, `timestamps` (array of timestamps), `values` (array of scalars),
+    /// with whole chunks unclipped by the selector's time range. The `timeSeries*ToGrid` aggregate functions
+    /// accept this form directly (and ignore out-of-range samples), skipping the per-sample ARRAY JOIN
+    /// of `select_query`.
+    ASTPtr chunked_select_query;
 };
 
 String getPromQLText(const SQLQueryPiece & query_piece, const ConverterContext & context);

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyFunctionOverRange.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyFunctionOverRange.cpp
@@ -282,10 +282,24 @@ SQLQueryPiece applyFunctionOverRange(
             /// FROM <raw_data>
             /// GROUP BY id
             has_group = true;
-            group_by_raw_id = argument.select_query && rewriteGroupColumnToRawID(argument.select_query);
 
-            timestamps = make_intrusive<ASTIdentifier>(ColumnNames::Timestamp);
-            values = make_intrusive<ASTIdentifier>(ColumnNames::Value);
+            if (argument.chunked_select_query)
+            {
+                /// Chunked samples: consume the array form of the selector's output directly. Whole chunks
+                /// are unclipped by the selector's time range, which is fine for the ToGrid aggregate
+                /// functions - samples outside the grid don't fall into any bucket.
+                argument.select_query = std::move(argument.chunked_select_query);
+                group_by_raw_id = true;
+                timestamps = make_intrusive<ASTIdentifier>(ColumnNames::Timestamps);
+                values = make_intrusive<ASTIdentifier>(ColumnNames::Values);
+            }
+            else
+            {
+                group_by_raw_id = argument.select_query && rewriteGroupColumnToRawID(argument.select_query);
+                timestamps = make_intrusive<ASTIdentifier>(ColumnNames::Timestamp);
+                values = make_intrusive<ASTIdentifier>(ColumnNames::Value);
+            }
+
             res.store_method = StoreMethod::VECTOR_GRID;
 
             break;

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyFunctionOverRange.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyFunctionOverRange.cpp
@@ -4,6 +4,8 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/Prometheus/stepsInTimeSeriesRange.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/NodeEvaluationRange.h>
@@ -121,6 +123,40 @@ namespace
 
         return &it->second;
     }
+
+    /// If `select_query` has the exact shape produced by `fromRangeSelector` - a single
+    /// `SELECT timeSeriesIdToGroup(id) AS group, ...` - rewrites its first result column to the raw `id`
+    /// and returns true. The caller then aggregates with `GROUP BY id` and applies `timeSeriesIdToGroup`
+    /// to the aggregated keys, evaluating it once per series instead of once per sample.
+    /// (`id` and `group` are in bijection: `timeSeriesIdToGroup` is a plain per-`id` mapping.)
+    bool rewriteGroupColumnToRawID(const ASTPtr & select_query)
+    {
+        const auto * select_with_union = select_query->as<ASTSelectWithUnionQuery>();
+        if (!select_with_union || !select_with_union->list_of_selects
+            || (select_with_union->list_of_selects->children.size() != 1))
+            return false;
+
+        auto * select = select_with_union->list_of_selects->children[0]->as<ASTSelectQuery>();
+        if (!select)
+            return false;
+
+        const auto & select_list = select->select();
+        if (!select_list || select_list->children.empty())
+            return false;
+
+        auto & first_column = select_list->children[0];
+        const auto * function = first_column->as<ASTFunction>();
+        if (!function || (function->name != "timeSeriesIdToGroup") || (function->tryGetAlias() != ColumnNames::Group)
+            || !function->arguments || (function->arguments->children.size() != 1))
+            return false;
+
+        const auto * id_identifier = function->arguments->children[0]->as<ASTIdentifier>();
+        if (!id_identifier || (id_identifier->name() != ColumnNames::ID))
+            return false;
+
+        first_column = make_intrusive<ASTIdentifier>(ColumnNames::ID);
+        return true;
+    }
 }
 
 
@@ -164,6 +200,7 @@ SQLQueryPiece applyFunctionOverRange(
     res.type = ResultType::INSTANT_VECTOR;
 
     bool has_group = false;
+    bool group_by_raw_id = false;
     ASTPtr timestamps;
     ASTPtr values;
 
@@ -237,7 +274,15 @@ SQLQueryPiece applyFunctionOverRange(
             ///        <aggregate_function>(timestamp, value) AS values
             /// FROM <raw_data>
             /// GROUP BY group
+            ///
+            /// or, when <raw_data> comes straight from a selector (see rewriteGroupColumnToRawID):
+            ///
+            /// SELECT timeSeriesIdToGroup(id) AS group,
+            ///        <aggregate_function>(timestamp, value) AS values
+            /// FROM <raw_data>
+            /// GROUP BY id
             has_group = true;
+            group_by_raw_id = argument.select_query && rewriteGroupColumnToRawID(argument.select_query);
 
             timestamps = make_intrusive<ASTIdentifier>(ColumnNames::Timestamp);
             values = make_intrusive<ASTIdentifier>(ColumnNames::Value);
@@ -269,7 +314,15 @@ SQLQueryPiece applyFunctionOverRange(
     SelectQueryBuilder builder;
 
     if (has_group)
-        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
+    {
+        if (group_by_raw_id)
+        {
+            builder.select_list.push_back(makeASTFunction("timeSeriesIdToGroup", make_intrusive<ASTIdentifier>(ColumnNames::ID)));
+            builder.select_list.back()->setAlias(ColumnNames::Group);
+        }
+        else
+            builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
+    }
 
     /// <aggregate_function>(<timestamps>, <values>) AS values
     builder.select_list.push_back(addParametersToAggregateFunction(
@@ -282,7 +335,7 @@ SQLQueryPiece applyFunctionOverRange(
     builder.select_list.back()->setAlias(ColumnNames::Values);
 
     if (has_group)
-        builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
+        builder.group_by.push_back(make_intrusive<ASTIdentifier>(group_by_raw_id ? ColumnNames::ID : ColumnNames::Group));
 
     if (argument.select_query)
     {

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/fromSelector.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/fromSelector.cpp
@@ -1,8 +1,13 @@
 #include <Storages/TimeSeries/PrometheusQueryToSQL/fromSelector.h>
 
+#include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Parsers/ASTTablesInSelectQuery.h>
+#include <Parsers/makeASTForLogicalFunction.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/NodeEvaluationRange.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/SelectQueryBuilder.h>
@@ -15,6 +20,102 @@ namespace DB::PrometheusQueryToSQL
 
 namespace
 {
+    /// Makes an AST for the table function call `timeSeriesSelector(db, table, selector, min_time, max_time)`.
+    ASTPtr makeSelectorTableFunction(std::string_view instant_selector_text,
+                                     TimestampType min_time,
+                                     TimestampType max_time,
+                                     const ConverterContext & context)
+    {
+        return makeASTFunction(
+            "timeSeriesSelector",
+            make_intrusive<ASTLiteral>(context.time_series_storage_id.getDatabaseName()),
+            make_intrusive<ASTLiteral>(context.time_series_storage_id.getTableName()),
+            make_intrusive<ASTLiteral>(String{instant_selector_text}),
+            timeSeriesTimestampToAST(min_time, context.timestamp_data_type),
+            timeSeriesTimestampToAST(max_time, context.timestamp_data_type));
+    }
+
+    /// For a TimeSeries table with chunked samples the selector returns per-series arrays covering whole
+    /// chunks. This function builds the query converting them to the scalar RAW_DATA form:
+    ///
+    /// SELECT timeSeriesIdToGroup(id) AS group, timestamp, value
+    /// FROM timeSeriesSelector(...)
+    /// ARRAY JOIN timestamps AS timestamp, `values` AS value
+    /// WHERE (timestamp >= <min_time>) AND (timestamp <= <max_time>)
+    ///
+    /// The WHERE clips the chunks to the selector's exact time range.
+    ASTPtr makeArrayJoinedSelectorQuery(ASTPtr table_function,
+                                        TimestampType min_time,
+                                        TimestampType max_time,
+                                        const ConverterContext & context)
+    {
+        auto select_query = make_intrusive<ASTSelectQuery>();
+
+        {
+            auto select_list = make_intrusive<ASTExpressionList>();
+            select_list->children.push_back(makeASTFunction("timeSeriesIdToGroup", make_intrusive<ASTIdentifier>(ColumnNames::ID)));
+            select_list->children.back()->setAlias(ColumnNames::Group);
+            select_list->children.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Timestamp));
+            select_list->children.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Value));
+            select_query->setExpression(ASTSelectQuery::Expression::SELECT, std::move(select_list));
+        }
+
+        auto tables = make_intrusive<ASTTablesInSelectQuery>();
+
+        {
+            auto table_exp = make_intrusive<ASTTableExpression>();
+            table_exp->table_function = std::move(table_function);
+            table_exp->children.emplace_back(table_exp->table_function);
+
+            auto table_element = make_intrusive<ASTTablesInSelectQueryElement>();
+            table_element->table_expression = table_exp;
+            table_element->children.push_back(std::move(table_exp));
+            tables->children.push_back(std::move(table_element));
+        }
+
+        {
+            auto array_join_expressions = make_intrusive<ASTExpressionList>();
+            auto timestamps_identifier = make_intrusive<ASTIdentifier>(ColumnNames::Timestamps);
+            timestamps_identifier->setAlias(ColumnNames::Timestamp);
+            array_join_expressions->children.push_back(std::move(timestamps_identifier));
+            auto values_identifier = make_intrusive<ASTIdentifier>(ColumnNames::Values);
+            values_identifier->setAlias(ColumnNames::Value);
+            array_join_expressions->children.push_back(std::move(values_identifier));
+
+            auto array_join = make_intrusive<ASTArrayJoin>();
+            array_join->kind = ASTArrayJoin::Kind::Inner;
+            array_join->expression_list = array_join_expressions;
+            array_join->children.push_back(std::move(array_join_expressions));
+
+            auto array_join_element = make_intrusive<ASTTablesInSelectQueryElement>();
+            array_join_element->array_join = array_join;
+            array_join_element->children.push_back(std::move(array_join));
+            tables->children.push_back(std::move(array_join_element));
+        }
+
+        select_query->setExpression(ASTSelectQuery::Expression::TABLES, std::move(tables));
+
+        {
+            ASTs conditions;
+            conditions.push_back(makeASTFunction(
+                "greaterOrEquals",
+                make_intrusive<ASTIdentifier>(ColumnNames::Timestamp),
+                timeSeriesTimestampToAST(min_time, context.timestamp_data_type)));
+            conditions.push_back(makeASTFunction(
+                "lessOrEquals",
+                make_intrusive<ASTIdentifier>(ColumnNames::Timestamp),
+                timeSeriesTimestampToAST(max_time, context.timestamp_data_type)));
+            select_query->setExpression(ASTSelectQuery::Expression::WHERE, makeASTForLogicalAnd(std::move(conditions)));
+        }
+
+        auto list_of_selects = make_intrusive<ASTExpressionList>();
+        list_of_selects->children.push_back(std::move(select_query));
+        auto select_with_union_query = make_intrusive<ASTSelectWithUnionQuery>();
+        select_with_union_query->list_of_selects = list_of_selects;
+        select_with_union_query->children.push_back(std::move(list_of_selects));
+        return select_with_union_query;
+    }
+
     SQLQueryPiece fromRangeSelector(std::string_view instant_selector_text,
                                     const Node * node,
                                     ConverterContext & context)
@@ -25,28 +126,42 @@ namespace
 
         SQLQueryPiece res{node, ResultType::RANGE_VECTOR, StoreMethod::RAW_DATA};
 
-        /// SELECT timeSeriesIdToGroup(id) AS group, timestamp, value
-        /// FROM timeSeriesSelectorToGrid(<selector>, <start_time>, <end_time>, <step>, <window>)
-        SelectQueryBuilder builder;
-
-        builder.select_list.push_back(makeASTFunction("timeSeriesIdToGroup", make_intrusive<ASTIdentifier>(ColumnNames::ID)));
-        builder.select_list.back()->setAlias(ColumnNames::Group);
-
-        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Timestamp));
-        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Value));
-
         TimestampType min_time = node_range.start_time - node_range.window + 1;
         TimestampType max_time = node_range.end_time;
 
-        builder.from_table_function = makeASTFunction(
-            "timeSeriesSelector",
-            make_intrusive<ASTLiteral>(context.time_series_storage_id.getDatabaseName()),
-            make_intrusive<ASTLiteral>(context.time_series_storage_id.getTableName()),
-            make_intrusive<ASTLiteral>(String{instant_selector_text}),
-            timeSeriesTimestampToAST(min_time, context.timestamp_data_type),
-            timeSeriesTimestampToAST(max_time, context.timestamp_data_type));
+        if (context.samples_stored_in_chunks)
+        {
+            /// The scalar RAW_DATA form (via ARRAY JOIN) works for every consumer;
+            /// the array form is picked up instead by applyFunctionOverRange().
+            res.select_query = makeArrayJoinedSelectorQuery(
+                makeSelectorTableFunction(instant_selector_text, min_time, max_time, context), min_time, max_time, context);
 
-        res.select_query = builder.getSelectQuery();
+            /// SELECT id, timestamps, `values`
+            /// FROM timeSeriesSelector(<selector>, <start_time>, <end_time>)
+            SelectQueryBuilder builder;
+            builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::ID));
+            builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Timestamps));
+            builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Values));
+            builder.from_table_function = makeSelectorTableFunction(instant_selector_text, min_time, max_time, context);
+            res.chunked_select_query = builder.getSelectQuery();
+        }
+        else
+        {
+            /// SELECT timeSeriesIdToGroup(id) AS group, timestamp, value
+            /// FROM timeSeriesSelector(<selector>, <start_time>, <end_time>)
+            SelectQueryBuilder builder;
+
+            builder.select_list.push_back(makeASTFunction("timeSeriesIdToGroup", make_intrusive<ASTIdentifier>(ColumnNames::ID)));
+            builder.select_list.back()->setAlias(ColumnNames::Group);
+
+            builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Timestamp));
+            builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Value));
+
+            builder.from_table_function = makeSelectorTableFunction(instant_selector_text, min_time, max_time, context);
+
+            res.select_query = builder.getSelectQuery();
+        }
+
         return res;
     }
 }

--- a/src/Storages/TimeSeries/PrometheusRemoteReadProtocol.cpp
+++ b/src/Storages/TimeSeries/PrometheusRemoteReadProtocol.cpp
@@ -23,6 +23,7 @@
 #include <Parsers/Prometheus/PrometheusQueryTree.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Storages/StorageTimeSeries.h>
+#include <Storages/TimeSeries/TimeSeriesSettings.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
 #include <optional>
 
@@ -33,11 +34,17 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int NOT_IMPLEMENTED;
 }
 
 namespace Setting
 {
     extern const SettingsBool allow_experimental_analyzer;
+}
+
+namespace TimeSeriesSetting
+{
+    extern const TimeSeriesSettingsBool store_samples_in_chunks;
 }
 
 namespace
@@ -228,6 +235,11 @@ void PrometheusRemoteReadProtocol::readTimeSeries(google::protobuf::RepeatedPtrF
     out_time_series.Clear();
 
     auto time_series_storage_id = time_series_storage->getStorageID();
+
+    if ((*time_series_storage->getStorageSettings())[TimeSeriesSetting::store_samples_in_chunks])
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED,
+            "{}: The remote-read protocol is not implemented for TimeSeries tables with `store_samples_in_chunks` enabled",
+            time_series_storage_id.getNameForLogs());
 
     ASTPtr select_query = buildSelectQueryForReadingTimeSeries(
         time_series_storage_id, label_matcher, start_timestamp_ms, end_timestamp_ms);

--- a/src/Storages/TimeSeries/TimeSeriesColumnNames.h
+++ b/src/Storages/TimeSeries/TimeSeriesColumnNames.h
@@ -11,6 +11,14 @@ struct TimeSeriesColumnNames
     static constexpr const char * Timestamp = "timestamp";
     static constexpr const char * Value = "value";
 
+    /// The "samples" table with the `store_samples_in_chunks` setting enabled stores samples as per-series
+    /// arrays chunked by time intervals: "chunk_start" is the beginning of the chunk's time interval, and
+    /// "timestamps"/"values" (the latter already declared below for the query evaluation steps) are arrays
+    /// of the samples' timestamps and values within that interval.
+    static constexpr const char * ChunkStart = "chunk_start";
+    static constexpr const char * Timestamps = "timestamps";
+
+
     /// The "tags" table contains identifiers for each combination of a metric name with corresponding tags (labels):
 
     /// The default expression specified for the "id" column contains an expression for calculating an identifier of a time series by a metric name and tags.

--- a/src/Storages/TimeSeries/TimeSeriesSettings.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesSettings.cpp
@@ -28,6 +28,8 @@ namespace ErrorCodes
     DECLARE(Bool, store_min_time_and_max_time, true, "If set to true then the table will store 'min_time' and 'max_time' for each time series", 0) \
     DECLARE(Bool, aggregate_min_time_and_max_time, true, "When creating an inner target 'tags' table, this flag enables using 'SimpleAggregateFunction(min, Nullable(DateTime64(3)))' instead of just 'Nullable(DateTime64(3))' as the type of the 'min_time' column, and the same for the 'max_time' column", 0) \
     DECLARE(Bool, filter_by_min_time_and_max_time, true, "If set to true then the table will use the 'min_time' and 'max_time' columns for filtering time series", 0) \
+    DECLARE(Bool, store_samples_in_chunks, false, "If set to true then the inner 'samples' table stores samples as per-series arrays chunked by time intervals instead of one row per sample. This speeds up range queries (like 'rate' over long ranges) considerably because the series identifier is stored once per chunk instead of once per sample.", 0) \
+    DECLARE(UInt64, samples_chunk_interval, 86400, "The length in seconds of the time interval covered by one chunk of samples when 'store_samples_in_chunks' is enabled.", 0) \
 
 DECLARE_SETTINGS_TRAITS(TimeSeriesSettingsTraits, LIST_OF_TIME_SERIES_SETTINGS, TIMESERIES_SETTINGS_SUPPORTED_TYPES)
 IMPLEMENT_SETTINGS_TRAITS(TimeSeriesSettingsTraits, LIST_OF_TIME_SERIES_SETTINGS, TimeSeriesSettings, TimeSeriesSetting)
@@ -115,6 +117,10 @@ void checkTimeSeriesSettings(const TimeSeriesSettings & settings)
             throw Exception(ErrorCodes::INVALID_SETTING_VALUE,
                 "Setting `aggregate_min_time_and_max_time` cannot be enabled when `store_min_time_and_max_time` is disabled");
     }
+
+    if (settings[TimeSeriesSetting::store_samples_in_chunks] && (settings[TimeSeriesSetting::samples_chunk_interval] == 0))
+        throw Exception(ErrorCodes::INVALID_SETTING_VALUE,
+            "Setting `samples_chunk_interval` must be greater than zero when `store_samples_in_chunks` is enabled");
 
     const Map & tags_to_columns = settings[TimeSeriesSetting::tags_to_columns];
     if (!tags_to_columns.empty())

--- a/src/Storages/TimeSeries/TimeSeriesSettings.h
+++ b/src/Storages/TimeSeries/TimeSeriesSettings.h
@@ -16,6 +16,7 @@ struct TimeSeriesSettingsImpl;
     M(CLASS_NAME, ASTFunction) \
     M(CLASS_NAME, Bool) \
     M(CLASS_NAME, Map) \
+    M(CLASS_NAME, UInt64) \
 
 TIMESERIES_SETTINGS_SUPPORTED_TYPES(TimeSeriesSettings, DECLARE_SETTING_TRAIT)
 

--- a/src/Storages/TimeSeries/TimeSeriesSink.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesSink.cpp
@@ -1,9 +1,12 @@
 #include <Storages/TimeSeries/TimeSeriesSink.h>
 
 #include <Columns/ColumnArray.h>
+#include <Columns/ColumnDecimal.h>
 #include <Columns/ColumnMap.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnTuple.h>
+#include <Core/DecimalFunctions.h>
+#include <DataTypes/DataTypesDecimal.h>
 #include <Common/logger_useful.h>
 #include <Common/typeid_cast.h>
 #include <Core/Field.h>
@@ -41,7 +44,9 @@ namespace DB
 namespace TimeSeriesSetting
 {
     extern const TimeSeriesSettingsASTFunction id_generator;
+    extern const TimeSeriesSettingsUInt64 samples_chunk_interval;
     extern const TimeSeriesSettingsBool store_min_time_and_max_time;
+    extern const TimeSeriesSettingsBool store_samples_in_chunks;
     extern const TimeSeriesSettingsMap tags_to_columns;
     extern const TimeSeriesSettingsBool use_all_tags_column_to_generate_id;
 }
@@ -179,6 +184,86 @@ namespace
                 out_id_column.insertManyFrom(id_column, id_index, num_samples);
                 out_timestamp_column.insertRangeFrom(ts_timestamps, ts_start, num_samples);
                 out_value_column.insertRangeFrom(ts_values, ts_start, num_samples);
+            }
+
+            ++id_index;
+        }
+    }
+
+    /// Reads the raw integer representation of a timestamp (the decimal mantissa for DateTime64).
+    Int64 getRawTimestamp(const IColumn & column, size_t index)
+    {
+        if (const auto * decimal_column = typeid_cast<const ColumnDecimal<DateTime64> *>(&column))
+            return decimal_column->getData()[index].value;
+        if (const auto * uint32_column = typeid_cast<const ColumnVector<UInt32> *>(&column))
+            return uint32_column->getData()[index];
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Unexpected column {} for timestamps", column.getName());
+    }
+
+    /// Inserts a timestamp given by its raw integer representation.
+    void insertRawTimestamp(IColumn & column, Int64 raw_value)
+    {
+        if (auto * decimal_column = typeid_cast<ColumnDecimal<DateTime64> *>(&column))
+        {
+            decimal_column->getData().push_back(DateTime64(raw_value));
+            return;
+        }
+        if (auto * uint32_column = typeid_cast<ColumnVector<UInt32> *>(&column))
+        {
+            uint32_column->getData().push_back(static_cast<UInt32>(raw_value));
+            return;
+        }
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Unexpected column {} for timestamps", column.getName());
+    }
+
+    /// Fills columns for the "samples" table in the chunked layout (`store_samples_in_chunks`):
+    /// one output row per run of one series' samples falling into one chunk interval.
+    void fillSamplesChunkedColumns(
+        const PaddedPODArray<UInt8> & filter,
+        const IColumn & id_column,
+        const IColumn & ts_timestamps,
+        const IColumn & ts_values,
+        const ColumnArray::Offsets & ts_offsets,
+        Int64 chunk_interval,
+        IColumn & out_id_column,
+        IColumn & out_chunk_start_column,
+        ColumnArray & out_timestamps_column,
+        ColumnArray & out_values_column)
+    {
+        auto floor_div = [](Int64 x, Int64 y) { return (x >= 0) ? (x / y) : -((-x + y - 1) / y); };
+
+        size_t id_index = 0;
+        for (size_t i = 0; i < filter.size(); ++i)
+        {
+            size_t ts_start = (i == 0) ? 0 : ts_offsets[i - 1];
+            size_t ts_end = ts_offsets[i];
+
+            if (!filter[i])
+            {
+                if (ts_end != ts_start)
+                    throw Exception(ErrorCodes::INCORRECT_DATA, "Got {} samples without a metric name or tags", ts_end - ts_start);
+                continue;
+            }
+
+            /// Split the series' samples into runs falling into one chunk interval. Timestamps usually come
+            /// sorted, so this normally produces one output row per (series, chunk); out-of-order samples
+            /// just produce more rows, which the merges of the aggregating engine concatenate later.
+            size_t j = ts_start;
+            while (j < ts_end)
+            {
+                const Int64 chunk_index = floor_div(getRawTimestamp(ts_timestamps, j), chunk_interval);
+                size_t run_end = j + 1;
+                while ((run_end < ts_end) && (floor_div(getRawTimestamp(ts_timestamps, run_end), chunk_interval) == chunk_index))
+                    ++run_end;
+
+                out_id_column.insertFrom(id_column, id_index);
+                insertRawTimestamp(out_chunk_start_column, chunk_index * chunk_interval);
+                out_timestamps_column.getData().insertRangeFrom(ts_timestamps, j, run_end - j);
+                out_timestamps_column.getOffsets().push_back(out_timestamps_column.getData().size());
+                out_values_column.getData().insertRangeFrom(ts_values, j, run_end - j);
+                out_values_column.getOffsets().push_back(out_values_column.getData().size());
+
+                j = run_end;
             }
 
             ++id_index;
@@ -604,8 +689,17 @@ void TimeSeriesSink::initTagsAndSamplesPipelines()
     /// Build source header for samples block.
     Block samples_header;
     samples_header.insert(ColumnWithTypeAndName{id_type, TimeSeriesColumnNames::ID});
-    samples_header.insert(ColumnWithTypeAndName{timestamp_type, TimeSeriesColumnNames::Timestamp});
-    samples_header.insert(ColumnWithTypeAndName{scalar_type, TimeSeriesColumnNames::Value});
+    if ((*time_series_settings)[TimeSeriesSetting::store_samples_in_chunks])
+    {
+        samples_header.insert(ColumnWithTypeAndName{timestamp_type, TimeSeriesColumnNames::ChunkStart});
+        samples_header.insert(ColumnWithTypeAndName{std::make_shared<DataTypeArray>(timestamp_type), TimeSeriesColumnNames::Timestamps});
+        samples_header.insert(ColumnWithTypeAndName{std::make_shared<DataTypeArray>(scalar_type), TimeSeriesColumnNames::Values});
+    }
+    else
+    {
+        samples_header.insert(ColumnWithTypeAndName{timestamp_type, TimeSeriesColumnNames::Timestamp});
+        samples_header.insert(ColumnWithTypeAndName{scalar_type, TimeSeriesColumnNames::Value});
+    }
     samples_pipeline = createTargetPipeline(ViewTarget::Samples, samples_header);
 }
 
@@ -774,22 +868,47 @@ void TimeSeriesSink::consumeTagsAndSamples(const Block & block)
         auto samples_id_column = id_type->createColumn();
         samples_id_column->reserve(total_samples);
 
-        auto timestamp_column = timestamp_type->createColumn();
-        timestamp_column->reserve(total_samples);
-
-        auto value_column = scalar_type->createColumn();
-        value_column->reserve(total_samples);
-
-        fillSamplesColumns(
-            filter,
-            *id_column, ts_timestamps, ts_values, ts_offsets,
-            *samples_id_column, *timestamp_column, *value_column);
-
-        /// Assemble the block and push it to the "samples" table.
         Block samples_block;
-        samples_block.insert(ColumnWithTypeAndName{std::move(samples_id_column), id_type, TimeSeriesColumnNames::ID});
-        samples_block.insert(ColumnWithTypeAndName{std::move(timestamp_column), timestamp_type, TimeSeriesColumnNames::Timestamp});
-        samples_block.insert(ColumnWithTypeAndName{std::move(value_column), scalar_type, TimeSeriesColumnNames::Value});
+
+        if (settings[TimeSeriesSetting::store_samples_in_chunks])
+        {
+            Int64 chunk_interval = static_cast<Int64>(UInt64{settings[TimeSeriesSetting::samples_chunk_interval]});
+            if (auto scale = tryGetDecimalScale(*timestamp_type))
+                chunk_interval *= DecimalUtils::scaleMultiplier<Int64>(*scale);
+
+            auto chunk_start_column = timestamp_type->createColumn();
+            auto timestamps_column = ColumnArray::create(timestamp_type->createColumn());
+            auto values_column = ColumnArray::create(scalar_type->createColumn());
+
+            fillSamplesChunkedColumns(
+                filter,
+                *id_column, ts_timestamps, ts_values, ts_offsets,
+                chunk_interval,
+                *samples_id_column, *chunk_start_column,
+                *timestamps_column, *values_column);
+
+            samples_block.insert(ColumnWithTypeAndName{std::move(samples_id_column), id_type, TimeSeriesColumnNames::ID});
+            samples_block.insert(ColumnWithTypeAndName{std::move(chunk_start_column), timestamp_type, TimeSeriesColumnNames::ChunkStart});
+            samples_block.insert(ColumnWithTypeAndName{std::move(timestamps_column), std::make_shared<DataTypeArray>(timestamp_type), TimeSeriesColumnNames::Timestamps});
+            samples_block.insert(ColumnWithTypeAndName{std::move(values_column), std::make_shared<DataTypeArray>(scalar_type), TimeSeriesColumnNames::Values});
+        }
+        else
+        {
+            auto timestamp_column = timestamp_type->createColumn();
+            timestamp_column->reserve(total_samples);
+
+            auto value_column = scalar_type->createColumn();
+            value_column->reserve(total_samples);
+
+            fillSamplesColumns(
+                filter,
+                *id_column, ts_timestamps, ts_values, ts_offsets,
+                *samples_id_column, *timestamp_column, *value_column);
+
+            samples_block.insert(ColumnWithTypeAndName{std::move(samples_id_column), id_type, TimeSeriesColumnNames::ID});
+            samples_block.insert(ColumnWithTypeAndName{std::move(timestamp_column), timestamp_type, TimeSeriesColumnNames::Timestamp});
+            samples_block.insert(ColumnWithTypeAndName{std::move(value_column), scalar_type, TimeSeriesColumnNames::Value});
+        }
 
         samples_pipeline->push(std::move(samples_block));
     }

--- a/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
+++ b/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
@@ -44,6 +44,7 @@ namespace TimeSeriesSetting
     extern const TimeSeriesSettingsBool aggregate_min_time_and_max_time;
     extern const TimeSeriesSettingsASTFunction id_generator;
     extern const TimeSeriesSettingsBool store_min_time_and_max_time;
+    extern const TimeSeriesSettingsBool store_samples_in_chunks;
     extern const TimeSeriesSettingsMap tags_to_columns;
     extern const TimeSeriesSettingsBool use_all_tags_column_to_generate_id;
 }
@@ -391,8 +392,32 @@ namespace
                 /// inner table because it depends on columns like "metric_name" or "all_tags" which don't
                 /// exist in samples.
                 add_column_if_missing(TimeSeriesColumnNames::ID, dataTypeToAST(resolved_types.id_type));
-                add_column_if_missing(TimeSeriesColumnNames::Timestamp, dataTypeToAST(resolved_types.timestamp_type));
-                add_column_if_missing(TimeSeriesColumnNames::Value, dataTypeToAST(resolved_types.scalar_type));
+
+                if (time_series_settings[TimeSeriesSetting::store_samples_in_chunks])
+                {
+                    /// Chunked layout: one row per (series, time interval) with arrays of samples. The arrays
+                    /// use `SimpleAggregateFunction(groupArrayArray, ...)` so that merges of the aggregating
+                    /// engine concatenate the chunks written by separate inserts.
+                    auto make_group_array_array_type = [&](const DataTypePtr & element_type) -> ASTPtr
+                    {
+                        DataTypePtr array_type = std::make_shared<DataTypeArray>(element_type);
+                        AggregateFunctionProperties properties;
+                        auto func = AggregateFunctionFactory::instance().get(
+                            "groupArrayArray", NullsAction::EMPTY, {array_type}, {}, properties);
+                        auto custom_name = std::make_unique<DataTypeCustomSimpleAggregateFunction>(func, DataTypes{array_type}, Array{});
+                        auto type = DataTypeFactory::instance().getCustom(std::make_unique<DataTypeCustomDesc>(std::move(custom_name)));
+                        return dataTypeToAST(type);
+                    };
+
+                    add_column_if_missing(TimeSeriesColumnNames::ChunkStart, dataTypeToAST(resolved_types.timestamp_type));
+                    add_column_if_missing(TimeSeriesColumnNames::Timestamps, make_group_array_array_type(resolved_types.timestamp_type));
+                    add_column_if_missing(TimeSeriesColumnNames::Values, make_group_array_array_type(resolved_types.scalar_type));
+                }
+                else
+                {
+                    add_column_if_missing(TimeSeriesColumnNames::Timestamp, dataTypeToAST(resolved_types.timestamp_type));
+                    add_column_if_missing(TimeSeriesColumnNames::Value, dataTypeToAST(resolved_types.scalar_type));
+                }
 
                 break;
             }
@@ -735,13 +760,28 @@ namespace
 
         if (target_kind == ViewTarget::Samples)
         {
-            auto engine = makeASTFunction("MergeTree");
-            engine->setNoEmptyArgs(false);
-            storage->set(storage->engine, engine);
-            storage->set(storage->order_by,
-                makeASTOperator("tuple",
-                    make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID),
-                    make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Timestamp)));
+            if (settings[TimeSeriesSetting::store_samples_in_chunks])
+            {
+                /// Merges of the aggregating engine concatenate the sample arrays of the rows sharing
+                /// (id, chunk_start), consolidating each series' chunk over time.
+                auto engine = makeASTFunction("AggregatingMergeTree");
+                engine->setNoEmptyArgs(false);
+                storage->set(storage->engine, engine);
+                storage->set(storage->order_by,
+                    makeASTOperator("tuple",
+                        make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID),
+                        make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ChunkStart)));
+            }
+            else
+            {
+                auto engine = makeASTFunction("MergeTree");
+                engine->setNoEmptyArgs(false);
+                storage->set(storage->engine, engine);
+                storage->set(storage->order_by,
+                    makeASTOperator("tuple",
+                        make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID),
+                        make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Timestamp)));
+            }
         }
         else if (target_kind == ViewTarget::Tags)
         {
@@ -883,8 +923,37 @@ namespace
             case ViewTarget::Samples:
             {
                 check_column_type(TimeSeriesColumnNames::ID, resolved_types.id_type);
-                check_column_type(TimeSeriesColumnNames::Timestamp, resolved_types.timestamp_type);
-                check_column_type(TimeSeriesColumnNames::Value, resolved_types.scalar_type);
+
+                if (time_series_settings[TimeSeriesSetting::store_samples_in_chunks])
+                {
+                    /// A `SimpleAggregateFunction(f, Array(T))` column has `Array(T)` as its storage type,
+                    /// so a single array check accepts both the plain and the aggregating declaration.
+                    auto check_column_samples_array = [&](std::string_view column_name, const DataTypePtr & element_type)
+                    {
+                        check_column(column_name);
+                        const auto * col = target_table_columns.tryGet(String(column_name));
+                        const auto * array_type = typeid_cast<const DataTypeArray *>(col->type.get());
+                        if (!array_type || !array_type->getNestedType()->equals(*element_type))
+                            throw Exception(
+                                ErrorCodes::BAD_TYPE_OF_FIELD,
+                                "{}: Column {} in the {} table has type {}, but expected Array({}) "
+                                "(optionally wrapped in SimpleAggregateFunction(groupArrayArray, ...))",
+                                table_id.getNameForLogs(),
+                                column_name,
+                                target_kind,
+                                col->type->getName(),
+                                element_type->getName());
+                    };
+
+                    check_column_type(TimeSeriesColumnNames::ChunkStart, resolved_types.timestamp_type);
+                    check_column_samples_array(TimeSeriesColumnNames::Timestamps, resolved_types.timestamp_type);
+                    check_column_samples_array(TimeSeriesColumnNames::Values, resolved_types.scalar_type);
+                }
+                else
+                {
+                    check_column_type(TimeSeriesColumnNames::Timestamp, resolved_types.timestamp_type);
+                    check_column_type(TimeSeriesColumnNames::Value, resolved_types.scalar_type);
+                }
                 break;
             }
 

--- a/src/TableFunctions/TableFunctionTimeSeriesSelector.cpp
+++ b/src/TableFunctions/TableFunctionTimeSeriesSelector.cpp
@@ -1,5 +1,6 @@
 #include <TableFunctions/TableFunctionTimeSeriesSelector.h>
 
+#include <DataTypes/DataTypeArray.h>
 #include <Parsers/ASTFunction.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
 #include <TableFunctions/TableFunctionFactory.h>
@@ -27,6 +28,16 @@ void TableFunctionTimeSeriesSelector::parseArguments(const ASTPtr & ast_function
 
 ColumnsDescription TableFunctionTimeSeriesSelector::getActualTableStructure(ContextPtr /* context */, bool /* is_insert_query */) const
 {
+    if (config.samples_stored_in_chunks)
+    {
+        /// For the chunked samples layout the selector returns per-series arrays of samples.
+        return ColumnsDescription({
+            {TimeSeriesColumnNames::ID, config.id_data_type},
+            {TimeSeriesColumnNames::Timestamps, std::make_shared<DataTypeArray>(config.timestamp_data_type)},
+            {TimeSeriesColumnNames::Values, std::make_shared<DataTypeArray>(config.scalar_data_type)}
+        });
+    }
+
     return ColumnsDescription({
         {TimeSeriesColumnNames::ID, config.id_data_type},
         {TimeSeriesColumnNames::Timestamp, config.timestamp_data_type},


### PR DESCRIPTION
### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

New TimeSeries settings `store_samples_in_chunks`/`samples_chunk_interval`: the samples inner table stores one row per (series, interval) with timestamp/value arrays, storing the series id once per chunk.

Part 3/3, stacked on the timeseries aggregation speedup PR.