### PR TITLE
Do not abort the server when DDL cleanup removes the shard lock

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeperLock.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperLock.cpp
@@ -90,7 +90,8 @@ void ZooKeeperLock::unlock()
     }
     /// A foreign owner means someone else holds the lock we believe we hold, so it is always a bug,
     /// no matter whether the caller tolerates a missing node. Only the absence of the node below is
-    /// tolerable, because it is indistinguishable from a legitimate removal of the lock's parent.
+    /// tolerable, because it is indistinguishable from a legitimate removal of the lock's parent,
+    /// which is why `throw_if_lost` gates that branch alone.
     else if (result) /// NOTE: What if session expired exactly here?
         throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Lock is lost, it has another owner. Path: {}, message: {}, owner: {}, our id: {}",
                         lock_path, lock_message, stat.ephemeralOwner, zookeeper->getClientID());

--- a/src/Common/ZooKeeper/ZooKeeperLock.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperLock.cpp
@@ -88,7 +88,10 @@ void ZooKeeperLock::unlock()
         zookeeper->remove(lock_path, -1);
         LOG_TRACE(log, "Lock on path {} for session {} is unlocked", lock_path, zookeeper->getClientID());
     }
-    else if (result && throw_if_lost) /// NOTE: What if session expired exactly here?
+    /// A foreign owner means someone else holds the lock we believe we hold, so it is always a bug,
+    /// no matter whether the caller tolerates a missing node. Only the absence of the node below is
+    /// tolerable, because it is indistinguishable from a legitimate removal of the lock's parent.
+    else if (result) /// NOTE: What if session expired exactly here?
         throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Lock is lost, it has another owner. Path: {}, message: {}, owner: {}, our id: {}",
                         lock_path, lock_message, stat.ephemeralOwner, zookeeper->getClientID());
     else if (throw_if_lost)

--- a/src/Common/ZooKeeper/tests/gtest_zookeeper_lock.cpp
+++ b/src/Common/ZooKeeper/tests/gtest_zookeeper_lock.cpp
@@ -1,0 +1,77 @@
+#include <Common/ZooKeeper/TestKeeper.h>
+#include <Common/ZooKeeper/ZooKeeper.h>
+#include <Common/ZooKeeper/ZooKeeperArgs.h>
+#include <Common/ZooKeeper/ZooKeeperLock.h>
+
+#include <base/defines.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace
+{
+
+/// `TestKeeper::getSessionID` returns 0 while `TestKeeperCreateRequest::process` stamps
+/// `ephemeralOwner = 1` on every ephemeral node, and `ZooKeeper::getClientID` forwards to the
+/// former. So a lock node taken through `TestKeeper` always looks like it belongs to somebody
+/// else, which makes the foreign-owner branch of `ZooKeeperLock::unlock` reachable with no second
+/// session and no stealing of the node. Do not "simplify" that away: it is the only reason these
+/// tests need no Keeper.
+zkutil::ZooKeeperPtr makeTestKeeperClient()
+{
+    zkutil::ZooKeeperArgs args;
+    /// `createWithoutKillingPreviousSessions` reaches the `ZooKeeper(std::unique_ptr<IKeeper>)`
+    /// constructor, which does not call `initSession` and therefore needs no global context.
+    return zkutil::ZooKeeper::createWithoutKillingPreviousSessions(std::make_unique<Coordination::TestKeeper>(args));
+}
+
+}
+
+#ifdef DEBUG_OR_SANITIZER_BUILD
+
+TEST(ZooKeeperLockDeathTest, ForeignOwnerIsFatalEvenWhenLostIsTolerated)
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+    /// A foreign owner is a bug regardless of `throw_if_lost`: the caller only tolerates the node
+    /// being gone, not somebody else holding the lock it believes it holds.
+    auto zookeeper = makeTestKeeperClient();
+    auto lock = zkutil::createSimpleZooKeeperLock(zookeeper, "/zk_lock_foreign_tolerant", "lock", "msg", /*throw_if_lost=*/false);
+    ASSERT_TRUE(lock->tryLock());
+
+    EXPECT_DEATH(lock->unlock(), "Lock is lost, it has another owner");
+
+    /// Only the forked child died, so this process still believes it holds the lock and
+    /// `~ZooKeeperLock` would reach the same branch. Expire the session so `unlock` early-returns.
+    zookeeper->finalize("test finished");
+}
+
+TEST(ZooKeeperLockDeathTest, ForeignOwnerIsFatalForTheDefaultStrictCaller)
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+    /// Regression guard for the two callers that keep the default strict `throw_if_lost`.
+    auto zookeeper = makeTestKeeperClient();
+    auto lock = zkutil::createSimpleZooKeeperLock(zookeeper, "/zk_lock_foreign_strict", "lock", "msg");
+    ASSERT_TRUE(lock->tryLock());
+
+    EXPECT_DEATH(lock->unlock(), "Lock is lost, it has another owner");
+
+    zookeeper->finalize("test finished");
+}
+
+#endif
+
+TEST(ZooKeeperLockTest, MissingNodeIsToleratedWhenLostIsTolerated)
+{
+    /// A caller that tolerates a lost lock must survive the node being removed under it, which is
+    /// what DDL queue cleanup does to the shard lock when it drops the whole entry subtree.
+    auto zookeeper = makeTestKeeperClient();
+    auto lock = zkutil::createSimpleZooKeeperLock(zookeeper, "/zk_lock_missing_tolerant", "lock", "msg", /*throw_if_lost=*/false);
+    ASSERT_TRUE(lock->tryLock());
+
+    zookeeper->remove(lock->getLockPath(), -1);
+
+    EXPECT_NO_THROW(lock->unlock());
+}

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -886,9 +886,9 @@ bool DDLWorker::tryExecuteQueryOnSingleReplica(
 
     pcg64 rng(randomSeed());
 
-    /// `throw_if_lost = false`: `cleanupQueue` removes the whole entry subtree (including this lock
-    /// node) once the entry becomes outdated, so a missing lock node at unlock time is expected here.
-    /// A lock taken over by another session is still reported as a logical error.
+    /// `throw_if_lost = false`: this lock node is a child of the queue entry, a subtree this code does
+    /// not own, so it cannot rule out a recursive removal while the lock is held. An absent node at
+    /// unlock time is therefore not a bug here; a foreign owner still is (reported as a logical error).
     execute_on_single_replica_lock
         = createSimpleZooKeeperLock(zookeeper, shard_path, "lock", task.host_id_str, /*throw_if_lost=*/false);
 

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -886,7 +886,11 @@ bool DDLWorker::tryExecuteQueryOnSingleReplica(
 
     pcg64 rng(randomSeed());
 
-    execute_on_single_replica_lock = createSimpleZooKeeperLock(zookeeper, shard_path, "lock", task.host_id_str);
+    /// throw_if_lost = false: cleanupQueue removes the whole entry subtree (including this lock node)
+    /// once the entry becomes outdated, so a missing lock node at unlock time is expected here.
+    /// A lock taken over by another session is still reported as a logical error.
+    execute_on_single_replica_lock
+        = createSimpleZooKeeperLock(zookeeper, shard_path, "lock", task.host_id_str, /*throw_if_lost=*/false);
 
     Stopwatch stopwatch;
 

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -886,8 +886,8 @@ bool DDLWorker::tryExecuteQueryOnSingleReplica(
 
     pcg64 rng(randomSeed());
 
-    /// throw_if_lost = false: cleanupQueue removes the whole entry subtree (including this lock node)
-    /// once the entry becomes outdated, so a missing lock node at unlock time is expected here.
+    /// `throw_if_lost = false`: `cleanupQueue` removes the whole entry subtree (including this lock
+    /// node) once the entry becomes outdated, so a missing lock node at unlock time is expected here.
     /// A lock taken over by another session is still reported as a logical error.
     execute_on_single_replica_lock
         = createSimpleZooKeeperLock(zookeeper, shard_path, "lock", task.host_id_str, /*throw_if_lost=*/false);

--- a/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.reference
+++ b/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.reference
@@ -1,0 +1,2 @@
+server is alive
+0

--- a/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.reference
+++ b/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.reference
@@ -1,2 +1,3 @@
 server is alive
+1
 0

--- a/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.sh
+++ b/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.sh
@@ -4,9 +4,10 @@
 # no-shared-merge-tree: uses an explicit `ReplicatedMergeTree` `zookeeper_path` for the second replica.
 #
 # Regression test: the DDL shard lock at `<ddl entry>/shards/<shard>/lock` may legitimately
-# disappear while its owning session is still healthy, because `DDLWorker::cleanupQueue` removes
-# the whole entry subtree. `ZooKeeperLock::unlock` must tolerate that instead of raising
-# `LOGICAL_ERROR` "Lock is lost, node does not exist", which aborts the server.
+# disappear while its owning session is still healthy, because the lock lives inside the queue entry
+# subtree and other actors remove that subtree recursively. `ZooKeeperLock::unlock` must tolerate that
+# instead of raising `LOGICAL_ERROR` "Lock is lost, node does not exist", which aborts the server.
+# The removal below stands in for any such actor; what is asserted is `unlock`'s reaction to it.
 #
 # Synchronization invariant: the test proceeds only once the lock node is observed to EXIST, which
 # is the point at which the executor provably holds it; the node is then removed, and its absence
@@ -110,8 +111,8 @@ if [ -z "$lock_entry" ]; then
     exit 1
 fi
 
-# What `DDLWorker::cleanupQueue` does to an outdated entry: recursively remove the entry subtree,
-# which takes the live ephemeral shard lock with it.
+# Remove the entry subtree recursively, which takes the live ephemeral shard lock with it. The lock's
+# owner does not own this subtree, so it cannot rule out such a removal while the lock is held.
 ${CLICKHOUSE_KEEPER_CLIENT} -q "rmr '${DB_ZK}/log/${lock_entry}'" > /dev/null 2>&1
 
 # Assert the lock node is really gone, so a passing test cannot mean "the race was not set up".

--- a/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.sh
+++ b/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.sh
@@ -25,12 +25,16 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 RDB="rdb_${CLICKHOUSE_TEST_UNIQUE_NAME}"
 AUX="aux_${CLICKHOUSE_TEST_UNIQUE_NAME}"
 DB_ZK="/test/${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}/rdb"
+TABLE_ZK="/clickhouse/tables/${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}/t"
 
 function cleanup()
 {
     ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${AUX} SYNC SETTINGS ignore_drop_queries_probability = 0" 2>/dev/null ||:
     ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${RDB} SYNC SETTINGS ignore_drop_queries_probability = 0" 2>/dev/null ||:
     ${CLICKHOUSE_KEEPER_CLIENT} -q "rmr '${DB_ZK}'" 2>/dev/null ||:
+    # The second replica is dropped while DETACHed, which leaves its replica znode behind, so the
+    # explicit table path has to be removed here or a re-run would find a stale replica.
+    ${CLICKHOUSE_KEEPER_CLIENT} -q "rmr '${TABLE_ZK}'" 2>/dev/null ||:
 }
 trap cleanup EXIT
 cleanup
@@ -40,8 +44,17 @@ start_time=$(${CLICKHOUSE_CLIENT} -q "SELECT now64(6)")
 # `distributed_ddl_output_mode = 'none'` on every setup statement: the per-host status rows a
 # `Replicated` database prints otherwise are not part of what this test asserts.
 ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "CREATE DATABASE ${RDB} ENGINE = Replicated('${DB_ZK}', 's1', 'r1')"
-${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "CREATE TABLE ${RDB}.t (x UInt64, y String) ENGINE = ReplicatedMergeTree ORDER BY x"
+# The table path is given explicitly and scoped to the per-run test prefix, so that the second
+# replica below can name the same path. The `{shard}`/`{replica}` macros are required: a
+# `Replicated` database rejects an explicit path that cannot differ between shards and replicas.
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "
+    CREATE TABLE ${RDB}.t (x UInt64, y String)
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/t/{shard}', '{replica}') ORDER BY x
+    SETTINGS database_replicated_allow_replicated_engine_arguments = 3
+"
 
+# Read the resolved path back rather than re-deriving it, so the second replica provably attaches
+# to the first one's table instead of to a path this test merely believes is the same.
 table_zk=$(${CLICKHOUSE_CLIENT} -q "SELECT zookeeper_path FROM system.replicas WHERE database = '${RDB}' AND table = 't'")
 
 # Register a second replica of the same table and detach it, so it never processes the log entry.
@@ -53,6 +66,17 @@ ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "
     ENGINE = ReplicatedMergeTree('${table_zk}', 'r2') ORDER BY x
     SETTINGS database_replicated_allow_replicated_engine_arguments = 3
 "
+
+# Assert the two replicas really share one table, so a passing test cannot mean the second replica
+# silently landed on a different path and the `alter_sync = 2` wait had nothing to wait for.
+replicas=$(${CLICKHOUSE_CLIENT} -q "
+    SELECT uniqExact(zookeeper_path) = 1 AND count() = 2
+    FROM system.replicas WHERE database IN ('${RDB}', '${AUX}') AND table IN ('t', 't2')")
+if [ "$replicas" != "1" ]; then
+    echo "FAIL: the two replicas do not share one zookeeper_path, the test did not set up the race"
+    exit 1
+fi
+
 ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "DETACH TABLE ${AUX}.t2 SYNC"
 
 # `MODIFY COLUMN` on a `ReplicatedMergeTree` is routed to a single replica per shard

--- a/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.sh
+++ b/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.sh
@@ -14,7 +14,7 @@
 # is the point at which the executor provably holds it; the node is then removed, and its absence
 # is re-checked. Both checks fail loudly, so a pass cannot mean the race was never set up.
 #
-# The `ALTER` under test is EXPECTED to end in Code 341 UNFINISHED on every build (the
+# The `ALTER` under test is EXPECTED to end in `Code 341 UNFINISHED` on every build (the
 # `alter_sync = 2` wait for the detached replica genuinely times out), so its own status can never
 # be the assertion.
 
@@ -60,7 +60,7 @@ ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "
 table_zk=$(${CLICKHOUSE_CLIENT} -q "SELECT zookeeper_path FROM system.replicas WHERE database = '${RDB}' AND table = 't'")
 
 # Register a second replica of the same table and detach it, so it never processes the log entry.
-# `alter_sync = 2` then waits for it and finally fails with Code 341 UNFINISHED. `DETACH` must be
+# `alter_sync = 2` then waits for it and finally fails with `Code 341 UNFINISHED`. `DETACH` must be
 # `SYNC`: a later `ATTACH` is not performed here, but `SYNC` keeps the shutdown deterministic.
 ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "CREATE DATABASE ${AUX}"
 ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "

--- a/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.sh
+++ b/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.sh
@@ -6,7 +6,8 @@
 # Regression test: the DDL shard lock at `<ddl entry>/shards/<shard>/lock` may legitimately
 # disappear while its owning session is still healthy, because the lock lives inside the queue entry
 # subtree and other actors remove that subtree recursively. `ZooKeeperLock::unlock` must tolerate that
-# instead of raising `LOGICAL_ERROR` "Lock is lost, node does not exist", which aborts the server.
+# instead of raising `LOGICAL_ERROR` `Lock is lost, node does not exist`, which aborts the server in
+# debug and sanitizer builds (in a release build it is caught in `~ZooKeeperLock` and only logged).
 # The removal below stands in for any such actor; what is asserted is `unlock`'s reaction to it.
 #
 # Synchronization invariant: the test proceeds only once the lock node is observed to EXIST, which
@@ -127,7 +128,8 @@ fi
 
 wait "$alter_pid" 2>/dev/null ||:
 
-# Liveness half: without the fix the `LOGICAL_ERROR` aborted the server here.
+# Liveness half: without the fix the `LOGICAL_ERROR` aborted the server here. Stateless CI always
+# links `abort_on_logical_error.yaml`, so this holds even on the non-sanitizer flavours.
 ${CLICKHOUSE_CLIENT} -q "SELECT 'server is alive'"
 
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS text_log"

--- a/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.sh
+++ b/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.sh
@@ -31,8 +31,8 @@ TABLE_ZK="/clickhouse/tables/${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}/t"
 
 function cleanup()
 {
-    ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${AUX} SYNC SETTINGS ignore_drop_queries_probability = 0" 2>/dev/null ||:
-    ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${RDB} SYNC SETTINGS ignore_drop_queries_probability = 0" 2>/dev/null ||:
+    ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${AUX} SYNC" 2>/dev/null ||:
+    ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${RDB} SYNC" 2>/dev/null ||:
     ${CLICKHOUSE_KEEPER_CLIENT} -q "rmr '${DB_ZK}'" 2>/dev/null ||:
     # The second replica is dropped while DETACHed, which leaves its replica znode behind, so the
     # explicit table path has to be removed here or a re-run would find a stale replica.

--- a/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.sh
+++ b/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.sh
@@ -1,23 +1,20 @@
 #!/usr/bin/env bash
 # Tags: zookeeper, no-fasttest, no-shared-merge-tree
-# no-fasttest: needs ZooKeeper/Keeper and a Replicated database.
-# no-shared-merge-tree: uses an explicit ReplicatedMergeTree zookeeper_path for the second replica.
+# no-fasttest: needs ZooKeeper/Keeper and a `Replicated` database.
+# no-shared-merge-tree: uses an explicit `ReplicatedMergeTree` `zookeeper_path` for the second replica.
 #
-# Regression test: DDLWorker::tryExecuteQueryOnSingleReplica takes an ephemeral lock at
-# <ddl entry>/shards/<shard>/lock and holds it until processTask returns. DDLWorker::cleanupQueue
-# recursively deletes an outdated entry's whole subtree (its keep list holds only "finished"), so
-# that lock node can legitimately disappear while the executing session is still healthy.
-# ~ZooKeeperLock -> unlock() used to raise
-#   LOGICAL_ERROR "Lock is lost, node does not exist. Path: .../shards/<shard>/lock"
-# for exactly that case, which aborts the server in debug/sanitizer builds and whenever
-# abort_on_logical_error is set (as CI does). The DDL lock is now constructed with
-# throw_if_lost = false, so a missing node is logged instead.
+# Regression test: the DDL shard lock at `<ddl entry>/shards/<shard>/lock` may legitimately
+# disappear while its owning session is still healthy, because `DDLWorker::cleanupQueue` removes
+# the whole entry subtree. `ZooKeeperLock::unlock` must tolerate that instead of raising
+# `LOGICAL_ERROR` "Lock is lost, node does not exist", which aborts the server.
 #
-# The window is produced the same way as in the original occurrence: alter_sync = 2 blocks inside
-# StorageReplicatedMergeTree::alter waiting for an inactive replica, so the executor sits in
-# processTask holding the lock; the entry subtree is then removed (what cleanupQueue does), and the
-# subsequent Code 341 UNFINISHED is rethrown on the initial-query path, unwinding processTask and
-# destroying the lock.
+# Synchronization invariant: the test proceeds only once the lock node is observed to EXIST, which
+# is the point at which the executor provably holds it; the node is then removed, and its absence
+# is re-checked. Both checks fail loudly, so a pass cannot mean the race was never set up.
+#
+# The `ALTER` under test is EXPECTED to end in Code 341 UNFINISHED on every build (the
+# `alter_sync = 2` wait for the detached replica genuinely times out), so its own status can never
+# be the assertion.
 
 set -e
 
@@ -40,16 +37,16 @@ cleanup
 
 start_time=$(${CLICKHOUSE_CLIENT} -q "SELECT now64(6)")
 
-# distributed_ddl_output_mode = 'none' on every setup statement: the per-host status rows a
-# Replicated database prints otherwise are not part of what this test asserts.
+# `distributed_ddl_output_mode = 'none'` on every setup statement: the per-host status rows a
+# `Replicated` database prints otherwise are not part of what this test asserts.
 ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "CREATE DATABASE ${RDB} ENGINE = Replicated('${DB_ZK}', 's1', 'r1')"
 ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "CREATE TABLE ${RDB}.t (x UInt64, y String) ENGINE = ReplicatedMergeTree ORDER BY x"
 
 table_zk=$(${CLICKHOUSE_CLIENT} -q "SELECT zookeeper_path FROM system.replicas WHERE database = '${RDB}' AND table = 't'")
 
 # Register a second replica of the same table and detach it, so it never processes the log entry.
-# alter_sync = 2 then waits for it and finally fails with Code 341 UNFINISHED. DETACH must be SYNC:
-# a later ATTACH is not performed here, but SYNC keeps the shutdown deterministic.
+# `alter_sync = 2` then waits for it and finally fails with Code 341 UNFINISHED. `DETACH` must be
+# `SYNC`: a later `ATTACH` is not performed here, but `SYNC` keeps the shutdown deterministic.
 ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "CREATE DATABASE ${AUX}"
 ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "
     CREATE TABLE ${AUX}.t2 (x UInt64, y String)
@@ -58,8 +55,8 @@ ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "
 "
 ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "DETACH TABLE ${AUX}.t2 SYNC"
 
-# MODIFY COLUMN on a ReplicatedMergeTree is routed to a single replica per shard
-# (DDLWorker::taskShouldBeExecutedOnLeader), which is what makes the shard lock be taken.
+# `MODIFY COLUMN` on a `ReplicatedMergeTree` is routed to a single replica per shard
+# (`DDLWorker::taskShouldBeExecutedOnLeader`), which is what makes the shard lock be taken.
 ${CLICKHOUSE_CLIENT} -q "
     ALTER TABLE ${RDB}.t MODIFY COLUMN y Nullable(String)
     SETTINGS alter_sync = 2, replication_wait_for_inactive_replica_timeout = 15,
@@ -89,8 +86,8 @@ if [ -z "$lock_entry" ]; then
     exit 1
 fi
 
-# This is what DDLWorker::cleanupQueue does to an outdated entry: recursively remove the entry
-# subtree, which takes the live ephemeral shard lock with it.
+# What `DDLWorker::cleanupQueue` does to an outdated entry: recursively remove the entry subtree,
+# which takes the live ephemeral shard lock with it.
 ${CLICKHOUSE_KEEPER_CLIENT} -q "rmr '${DB_ZK}/log/${lock_entry}'" > /dev/null 2>&1
 
 # Assert the lock node is really gone, so a passing test cannot mean "the race was not set up".
@@ -103,21 +100,32 @@ if [ "$gone" != "0" ]; then
     exit 1
 fi
 
-# The ALTER is EXPECTED to fail with Code 341 UNFINISHED on both the fixed and the broken build
-# (the wait for the detached replica genuinely times out), so its status is not the assertion.
 wait "$alter_pid" 2>/dev/null ||:
 
-# The server must still be running: without the fix the LOGICAL_ERROR above aborted it.
+# Liveness half: without the fix the `LOGICAL_ERROR` aborted the server here.
 ${CLICKHOUSE_CLIENT} -q "SELECT 'server is alive'"
 
-# The discriminating observable. ~ZooKeeperLock swallows unlock() exceptions, and with the fix the
-# very same text is still emitted at <Information> from the tolerant branch, so neither server
-# liveness alone nor the absence of the message can tell the fixed and the broken build apart on a
-# build where LOGICAL_ERROR does not abort. Assert instead that the message was never Fatal, i.e.
-# that no LOGICAL_ERROR was raised for it.
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS text_log"
+
+# Positive control: the tolerant branch of `unlock` reported the loss for OUR lock path exactly
+# once. Liveness alone cannot see this, so without it a change turning `unlock` into a silent
+# no-op would pass. `max_rows_to_read = 0` is required because `system.text_log` is ordered by
+# `event_date, event_time`, so the timestamp predicate is not a primary-key range.
 ${CLICKHOUSE_CLIENT} -q "
     SELECT count() FROM system.text_log
     WHERE event_time_microseconds >= toDateTime64('${start_time}', 6)
-      AND level = 'Fatal' AND message LIKE '%Lock is lost%'
+      AND level = 'Information'
+      AND message LIKE '%Lock is lost, node does not exist%'
+      AND message LIKE '%${DB_ZK}/log/${lock_entry}/shards/s1/lock%'
+    SETTINGS max_rows_to_read = 0
+"
+
+# Negative control: that loss was not reported as an error for OUR lock path.
+${CLICKHOUSE_CLIENT} -q "
+    SELECT count() FROM system.text_log
+    WHERE event_time_microseconds >= toDateTime64('${start_time}', 6)
+      AND level IN ('Fatal', 'Critical', 'Error')
+      AND message LIKE '%Lock is lost%'
+      AND message LIKE '%${DB_ZK}/log/${lock_entry}/shards/s1/lock%'
+    SETTINGS max_rows_to_read = 0
 "

--- a/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.sh
+++ b/tests/queries/0_stateless/04648_ddl_shard_lock_removed_by_queue_cleanup.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Tags: zookeeper, no-fasttest, no-shared-merge-tree
+# no-fasttest: needs ZooKeeper/Keeper and a Replicated database.
+# no-shared-merge-tree: uses an explicit ReplicatedMergeTree zookeeper_path for the second replica.
+#
+# Regression test: DDLWorker::tryExecuteQueryOnSingleReplica takes an ephemeral lock at
+# <ddl entry>/shards/<shard>/lock and holds it until processTask returns. DDLWorker::cleanupQueue
+# recursively deletes an outdated entry's whole subtree (its keep list holds only "finished"), so
+# that lock node can legitimately disappear while the executing session is still healthy.
+# ~ZooKeeperLock -> unlock() used to raise
+#   LOGICAL_ERROR "Lock is lost, node does not exist. Path: .../shards/<shard>/lock"
+# for exactly that case, which aborts the server in debug/sanitizer builds and whenever
+# abort_on_logical_error is set (as CI does). The DDL lock is now constructed with
+# throw_if_lost = false, so a missing node is logged instead.
+#
+# The window is produced the same way as in the original occurrence: alter_sync = 2 blocks inside
+# StorageReplicatedMergeTree::alter waiting for an inactive replica, so the executor sits in
+# processTask holding the lock; the entry subtree is then removed (what cleanupQueue does), and the
+# subsequent Code 341 UNFINISHED is rethrown on the initial-query path, unwinding processTask and
+# destroying the lock.
+
+set -e
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+RDB="rdb_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+AUX="aux_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+DB_ZK="/test/${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}/rdb"
+
+function cleanup()
+{
+    ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${AUX} SYNC SETTINGS ignore_drop_queries_probability = 0" 2>/dev/null ||:
+    ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${RDB} SYNC SETTINGS ignore_drop_queries_probability = 0" 2>/dev/null ||:
+    ${CLICKHOUSE_KEEPER_CLIENT} -q "rmr '${DB_ZK}'" 2>/dev/null ||:
+}
+trap cleanup EXIT
+cleanup
+
+start_time=$(${CLICKHOUSE_CLIENT} -q "SELECT now64(6)")
+
+# distributed_ddl_output_mode = 'none' on every setup statement: the per-host status rows a
+# Replicated database prints otherwise are not part of what this test asserts.
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "CREATE DATABASE ${RDB} ENGINE = Replicated('${DB_ZK}', 's1', 'r1')"
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "CREATE TABLE ${RDB}.t (x UInt64, y String) ENGINE = ReplicatedMergeTree ORDER BY x"
+
+table_zk=$(${CLICKHOUSE_CLIENT} -q "SELECT zookeeper_path FROM system.replicas WHERE database = '${RDB}' AND table = 't'")
+
+# Register a second replica of the same table and detach it, so it never processes the log entry.
+# alter_sync = 2 then waits for it and finally fails with Code 341 UNFINISHED. DETACH must be SYNC:
+# a later ATTACH is not performed here, but SYNC keeps the shutdown deterministic.
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "CREATE DATABASE ${AUX}"
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "
+    CREATE TABLE ${AUX}.t2 (x UInt64, y String)
+    ENGINE = ReplicatedMergeTree('${table_zk}', 'r2') ORDER BY x
+    SETTINGS database_replicated_allow_replicated_engine_arguments = 3
+"
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none -q "DETACH TABLE ${AUX}.t2 SYNC"
+
+# MODIFY COLUMN on a ReplicatedMergeTree is routed to a single replica per shard
+# (DDLWorker::taskShouldBeExecutedOnLeader), which is what makes the shard lock be taken.
+${CLICKHOUSE_CLIENT} -q "
+    ALTER TABLE ${RDB}.t MODIFY COLUMN y Nullable(String)
+    SETTINGS alter_sync = 2, replication_wait_for_inactive_replica_timeout = 15,
+             distributed_ddl_task_timeout = 120, distributed_ddl_output_mode = 'throw'
+" > /dev/null 2>&1 &
+alter_pid=$!
+
+# Wait until the executor has actually created the shard lock node. Synchronizing on the lock node
+# itself (rather than on the entry, which exists earlier) guarantees the lock is held right now.
+lock_entry=""
+for _ in {1..600}; do
+    entry=$(${CLICKHOUSE_CLIENT} -q "
+        SELECT name FROM system.zookeeper
+        WHERE path = '${DB_ZK}/log' AND name LIKE 'query-%' ORDER BY name DESC LIMIT 1" 2>/dev/null)
+    if [ -n "$entry" ]; then
+        present=$(${CLICKHOUSE_CLIENT} -q "
+            SELECT count() FROM system.zookeeper
+            WHERE path = '${DB_ZK}/log/${entry}/shards/s1' AND name = 'lock'" 2>/dev/null || echo 0)
+        if [ "$present" = "1" ]; then lock_entry="$entry"; break; fi
+    fi
+    sleep 0.05
+done
+
+if [ -z "$lock_entry" ]; then
+    echo "FAIL: the DDL shard lock node never appeared, the test did not set up the race"
+    wait "$alter_pid" 2>/dev/null ||:
+    exit 1
+fi
+
+# This is what DDLWorker::cleanupQueue does to an outdated entry: recursively remove the entry
+# subtree, which takes the live ephemeral shard lock with it.
+${CLICKHOUSE_KEEPER_CLIENT} -q "rmr '${DB_ZK}/log/${lock_entry}'" > /dev/null 2>&1
+
+# Assert the lock node is really gone, so a passing test cannot mean "the race was not set up".
+gone=$(${CLICKHOUSE_CLIENT} -q "
+    SELECT count() FROM system.zookeeper
+    WHERE path = '${DB_ZK}/log/${lock_entry}/shards/s1' AND name = 'lock'" 2>/dev/null || echo 0)
+if [ "$gone" != "0" ]; then
+    echo "FAIL: the shard lock node is still present, the race was not set up"
+    wait "$alter_pid" 2>/dev/null ||:
+    exit 1
+fi
+
+# The ALTER is EXPECTED to fail with Code 341 UNFINISHED on both the fixed and the broken build
+# (the wait for the detached replica genuinely times out), so its status is not the assertion.
+wait "$alter_pid" 2>/dev/null ||:
+
+# The server must still be running: without the fix the LOGICAL_ERROR above aborted it.
+${CLICKHOUSE_CLIENT} -q "SELECT 'server is alive'"
+
+# The discriminating observable. ~ZooKeeperLock swallows unlock() exceptions, and with the fix the
+# very same text is still emitted at <Information> from the tolerant branch, so neither server
+# liveness alone nor the absence of the message can tell the fixed and the broken build apart on a
+# build where LOGICAL_ERROR does not abort. Assert instead that the message was never Fatal, i.e.
+# that no LOGICAL_ERROR was raised for it.
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS text_log"
+${CLICKHOUSE_CLIENT} -q "
+    SELECT count() FROM system.text_log
+    WHERE event_time_microseconds >= toDateTime64('${start_time}', 6)
+      AND level = 'Fatal' AND message LIKE '%Lock is lost%'
+"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/106231


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a spurious `LOGICAL_ERROR` exception (`Lock is lost, node does not exist`) during `ALTER TABLE ... MODIFY COLUMN` on a table in a `Replicated` database. The distributed DDL worker holds an ephemeral lock inside the DDL queue entry while it executes the query, and that entry is a subtree the worker neither owns nor controls the lifetime of, so the lock node can disappear before the worker releases it. A lock node removed together with its parent is now tolerated and logged, while a lock taken over by another session is still reported as a logical error.


### Description

The reported failure is a `LOGICAL_ERROR` raised by a plain user query, which in the reporting
environment (a sanitizer build, where `LOGICAL_ERROR` is treated as an assertion failure) terminated
the server:

```
<Fatal> : Logical error: 'Lock is lost, node does not exist.
  Path: /test/clickhouse/db/test_5/log/query-0000000772/shards/s1/lock, message: s1|r1, our id: 3'
Received signal Aborted (6)
(query: ALTER TABLE test_5.part_header_r1 (MODIFY COLUMN y Nullable(String)) SETTINGS alter_sync = 2)
```

**Root cause.** `DDLWorker::tryExecuteQueryOnSingleReplica` takes an ephemeral lock at
`<ddl entry>/shards/<shard>/lock` and holds it until `processTask` returns, so the execution status is
committed before another replica may retry (`DDLWorker.cpp:725-726`). Unlike the other two lock sites,
this lock node is not a top-level node of its own: it is a grandchild of the DDL queue entry, a subtree
this code neither creates nor controls the lifetime of, and recursive removals of that subtree take the
live lock node with them.

`ZooKeeperLock::unlock` treated a missing node as an assertion violation. That assertion says *"nobody
but me removes my own ephemeral node"*, which is true for a lock that owns its own path, and false for
one nested inside somebody else's subtree.

An earlier revision of this description named `DDLWorker::cleanupQueue` as the remover in the shown
`ALTER`. That was too strong and is corrected here: for a `Replicated` database `canRemoveQueueEntry`
requires `entry_number + logs_to_keep < max_log_ptr` while the initial-query transaction sets
`max_log_ptr` to the executing entry's number (`DDLTask.cpp:704`), so the gap is zero by construction;
and `DatabaseReplicatedDDLWorker` is built with `pool_size = 1`, so `processTask` runs inline on the
main thread, which is the only per-iteration setter of `cleanup_event`. For plain `ON CLUSTER` the
entry's `active` node is present for the whole execution, so the existing guard skips the live entry.
The tolerated case is therefore stated as the invariant above rather than as one named remover.

The severity depends on the build. In a release build with the default
`abort_on_logical_error = false` the exception is caught by the `catch (...)` in `~ZooKeeperLock` and
logged, so the user-visible effect is a spurious error record on a query that in fact completed its DDL
commit. In a debug or sanitizer build, and wherever `abort_on_logical_error` is enabled (CI always),
`LOGICAL_ERROR` is treated as an assertion failure: the process is aborted inside the `Exception`
constructor (`Exception.cpp:108` -> `abortOnFailedAssertion` -> `abort`), before any throw, so that
`catch (...)` never runs and the server terminates. That is the reported failure.

**Fix, two lines of logic.**

1. `ZooKeeperLock::unlock`: `else if (result && throw_if_lost)` -> `else if (result)`. A node that is
   PRESENT with a foreign owner is a bug for every lock, regardless of `throw_if_lost`; only the
   node's ABSENCE is what a garbage collector can produce. This restores the semantics that
   `da4690f1dab8400d581906c544c409cec4b5a224` deliberately introduced when it added `throw_if_lost` and
   applied it to the missing-node branch only, and that `4caef03e6a4109c47ac19385f0854c8c66058153` had
   since January 2022. The two branches were coupled by
   `a581593eecad14169b1664adf882b0fd6c98cc36`, a one-line change titled "ZooKeeperLock.cpp sync".
2. The DDL shard lock is constructed with `throw_if_lost = false`.

Result, per `unlock` outcome:

| outcome | before | after |
|---|---|---|
| node present, owned by us | removed | removed (unchanged) |
| node present, **foreign owner** | `LOGICAL_ERROR` | **`LOGICAL_ERROR` (kept)** |
| node absent | `LOGICAL_ERROR` (aborts under `abort_on_logical_error` or a debug/sanitizer build) | logged at `Information` |
| session expired | warning, return | unchanged |

**Why this is not silencing an assertion.** Change 1 makes the shared class STRICTER for any caller
that opts out, and what actually prevents double execution was never the destructor: it is the
persistent `shards/<shard>/executed` flag committed with the status (`DDLWorker.cpp:866`, pushed
`:945`, checked `:879` and `:922`). The lock is still held past the commit, so its documented contract
is untouched. The two ways of keeping the missing-node assertion are unavailable: releasing the lock
earlier cannot reach the failing path, because `tryExecuteQuery` rethrows for an initial query
(`DDLWorker.cpp:601-604`) and never returns; and releasing it atomically inside the status transaction
is unsound here, because this lock's path is fixed and reusable while Keeper has no ownership-guarded
remove, so an enqueued blind remove could delete a replacement owner's live lock.

**Blast radius.** There are exactly three constructions of `zkutil::ZooKeeperLock` in production code
(`git grep -n ZooKeeperLock -- src/`, excluding the class's own files and the unit test added by this
PR, which also catches `make_shared` and `make_unique` forms). Only one is nested inside a subtree
owned by other code:

| site | `throw_if_lost` | znode nested in another owner's subtree | effect |
|---|---|---|---|
| `DDLWorker.cpp` shard lock | **false** (this change) | yes, the DDL queue entry | the fix |
| `ZeroCopyLock.cpp` `part_exclusive_lock` | `true` (default) | no | unchanged: with `throw_if_lost == true`, `result && throw_if_lost` is `result` |
| `ACME/Client.cpp` `active_order` | `true` (default) | no | unchanged, same reason |

Change 1 is therefore a no-op for every current caller and for any future caller that keeps the
default. Both DDL worker flavours share the changed line, since `DatabaseReplicatedDDLWorker` overrides
neither `processTask` nor `tryExecuteQueryOnSingleReplica`, so `Replicated` databases and plain
`ON CLUSTER` DDL are both covered.

**Testing.** `04648_ddl_shard_lock_removed_by_queue_cleanup` reproduces the failure deterministically
with no failpoint: `alter_sync = 2` blocks the executor inside `StorageReplicatedMergeTree::alter`
waiting for a detached replica, the entry subtree is removed while the lock node is provably present,
and the resulting `Code 341 UNFINISHED` unwinds `processTask`. On a master binary the test aborts the
server with the exact reported message and the exact frame chain
(`ZooKeeperLock.cpp:95` `unlock` <- `:40` `~ZooKeeperLock` <- `DDLWorker.cpp:815` `processTask`);
with this change it passes, 50 out of 50 runs with randomized settings.

Liveness alone is not the oracle, because a change turning `unlock` into a silent no-op would also
keep the server alive. The test therefore adds a positive control (the tolerant branch reported the
loss for the test's own lock path exactly once, at `Information`) and a negative control (nothing at
`Error` or worse for that path). Both are scoped to the test's own znode path, so a concurrent test
cannot satisfy them. Note that the message text alone cannot be the oracle either: the tolerant branch
logs the same text as the removed `LOGICAL_ERROR`, only at `Information`, and the `ALTER` is expected
to end in `Code 341 UNFINISHED` on every build because the `alter_sync = 2` wait for the detached
replica genuinely times out.

Reverting change 2 alone brings back the reported `LOGICAL_ERROR`. Change 1 is pinned separately, by a
unit test rather than a functional one: this caller passes `throw_if_lost = false`, so the difference
change 1 makes is invisible to any test driving the DDL path, and observing a foreign owner requires a
second Keeper session taking over the node. `src/Common/ZooKeeper/tests/gtest_zookeeper_lock.cpp`
gets that for free from `TestKeeper`, whose `getSessionID` returns `0` while every ephemeral node it
creates is stamped with `ephemeralOwner = 1`, so the foreign-owner branch is reachable with no second
session and no stealing:

* `ForeignOwnerIsFatalEvenWhenLostIsTolerated` - a `throw_if_lost = false` lock whose node has a
  foreign owner must still die. Reverting change 1 alone makes this case fail with
  `Result: failed to die.` and the tolerant `Lock is lost, node does not exist` message instead, which
  is also the direct evidence that the mutant fell through to the wrong branch. The same failure
  appears on a pristine `master` binary.
* `ForeignOwnerIsFatalForTheDefaultStrictCaller` - the same for the default strict callers
  (`ZeroCopyLock`, `ACME/Client`); this one passes before and after, as a regression guard.
* `MissingNodeIsToleratedWhenLostIsTolerated` - the tolerated case the DDL worker now relies on.

The two death tests are guarded by `#ifdef DEBUG_OR_SANITIZER_BUILD`, because `LOGICAL_ERROR` only
aborts there; every unit-test CI flavour is a sanitizer build, so they do run. A sweep of the DDL and
`Replicated`-database stateless tests produces an identical pass/fail set before and after.

**Frequency.** Over 30 days CIDB records this exact signature once
(`Stress test (arm_tsan)`, PR #110073) and zero times on master, and the independent
`test_context_raw` sweep returns the same single row. The signature undercounts, though: the
occurrence that prompted this fix is recorded only as `test_name = 'Test script failed'` with no row
naming the failure, so the real rate is higher than one. The exception is raised after the DDL status is
committed, so there is no data-loss or divergence component.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=112186&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/112186](https://github.com/search?q=head%3Async-upstream%2Fpr%2F112186+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
