### PR TITLE
Fix flaky 03394 shuffle-join tests under join-order randomization

### DIFF
--- a/tests/queries/0_stateless/03394_distributed_shuffle_join_with_aggregation.sql
+++ b/tests/queries/0_stateless/03394_distributed_shuffle_join_with_aggregation.sql
@@ -18,6 +18,10 @@ INSERT INTO test SELECT 'path_' || number::String, 'en', number FROM numbers(5);
 INSERT INTO test SELECT 'path_' || (number%3)::String, 'de', number%4 FROM numbers(10);
 
 SET query_plan_join_swap_table = 0;
+SET query_plan_optimize_join_order_randomize = 0; -- Pinned because the test asserts on join plan/order
+-- Pinned because the test asserts that the runtime join filter is built; the default threshold
+-- skips it when the probe side is estimated to be tiny.
+SET join_runtime_filter_min_probe_rows = 0;
 
 SET
     optimize_move_to_prewhere = 1,

--- a/tests/queries/0_stateless/03394_distributed_shuffle_join_with_in.sql
+++ b/tests/queries/0_stateless/03394_distributed_shuffle_join_with_in.sql
@@ -18,6 +18,10 @@ INSERT INTO test SELECT 'path_' || number::String, 'en', number FROM numbers(5);
 INSERT INTO test SELECT 'path_' || (number%3)::String, 'de', number%4 FROM numbers(10);
 
 SET query_plan_join_swap_table = 0;
+SET query_plan_optimize_join_order_randomize = 0; -- Pinned because the test asserts on join plan/order
+-- Pinned because the test asserts that the runtime join filter is built; the default threshold
+-- skips it when the probe side is estimated to be tiny.
+SET join_runtime_filter_min_probe_rows = 0;
 
 
 SET


### PR DESCRIPTION
`03394_distributed_shuffle_join_with_in` and `03394_distributed_shuffle_join_with_aggregation` assert that `BuildRuntimeFilter` appears in the `EXPLAIN` plan, but neither pins the two settings that decide whether the runtime join filter is built at all.

Reproduced locally with the exact randomized setting set from the CI report below and minimized to a two-setting combination: `query_plan_optimize_join_order_randomize` nonzero together with `join_runtime_filter_min_probe_rows` above the estimated probe size. Join-order randomization changes which side is the probe side, and `joinRuntimeFilter` then skips the filter because the probe side is estimated to produce at most `join_runtime_filter_min_probe_rows` rows, so the `BuildRuntimeFilter` step disappears from the plan and the plan diff fails. Neither setting reproduces the failure alone.

Both settings are pinned, mirroring `03394_distributed_shuffle_join_with_prewhere`, which already pins them for the same reason.

Verified: with the randomized setting set the plan output of both tests now matches the reference exactly (before the fix `BuildRuntimeFilter` was absent in both).

CI report where this was observed: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110321&sha=fbebd96fb7f9dcee3d3bdb40df67558ffeaa1b40&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%201%2F2%29

Related: https://github.com/ClickHouse/ClickHouse/pull/110321
Related: https://github.com/ClickHouse/ClickHouse/pull/109386

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)
