### PR TITLE
Update applicable model developer terms

### DIFF
--- a/docs/products/cloud/features/ai-ml/model-developer-terms.mdx
+++ b/docs/products/cloud/features/ai-ml/model-developer-terms.mdx
@@ -11,8 +11,13 @@ These links are provided for your convenience. You are responsible for ensuring 
 
 ## Models and terms {#model-and-terms}
 
-The following is a table of models with their terms, and other pertinent information.
+Following is a table of models with their terms, and other pertinent information.
 
-| Model            | Terms and policies                                  |
-|------------------|-----------------------------------------------------|
-| Anthropic Models | [Usage policy](https://www.anthropic.com/legal/aup) |
+| Model | Terms and policies |
+| :---- | :---- |
+| [Anthropic Claude Sonnet 4.5](https://www.anthropic.com/news/claude-sonnet-4-5) | [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Haiku 4.5](https://www.anthropic.com/news/claude-haiku-4-5) | [Usage policy](https://www.anthropic.com/legal/aup) |
+| Anthropic Claude Sonnet 4.6 | [Usage policy](https://www.anthropic.com/legal/aup) |
+| Anthropic Claude Opus 4.6 | [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5) | [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Opus 4.1](https://www.anthropic.com/news/claude-4) | [Usage policy](https://www.anthropic.com/legal/aup) |

--- a/docs/products/cloud/features/ai-ml/model-developer-terms.mdx
+++ b/docs/products/cloud/features/ai-ml/model-developer-terms.mdx
@@ -20,4 +20,4 @@ Following is a table of models with their terms, and other pertinent information
 | [Anthropic Claude Sonnet 4.6](https://www.anthropic.com/news/claude-sonnet-4-6) | [Usage policy](https://www.anthropic.com/legal/aup) |
 | [Anthropic Claude Opus 4.6](https://www.anthropic.com/news/claude-opus-4-6) | [Usage policy](https://www.anthropic.com/legal/aup) |
 | [Anthropic Claude Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5) | [Usage policy](https://www.anthropic.com/legal/aup) |
-| [Anthropic Claude Opus 4.1](https://www.anthropic.com/news/claude-4) | [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Opus 4.1](https://www.anthropic.com/news/claude-opus-4-1) | [Usage policy](https://www.anthropic.com/legal/aup) |

--- a/docs/products/cloud/features/ai-ml/model-developer-terms.mdx
+++ b/docs/products/cloud/features/ai-ml/model-developer-terms.mdx
@@ -17,7 +17,7 @@ Following is a table of models with their terms, and other pertinent information
 | :---- | :---- |
 | [Anthropic Claude Sonnet 4.5](https://www.anthropic.com/news/claude-sonnet-4-5) | [Usage policy](https://www.anthropic.com/legal/aup) |
 | [Anthropic Claude Haiku 4.5](https://www.anthropic.com/news/claude-haiku-4-5) | [Usage policy](https://www.anthropic.com/legal/aup) |
-| Anthropic Claude Sonnet 4.6 | [Usage policy](https://www.anthropic.com/legal/aup) |
-| Anthropic Claude Opus 4.6 | [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Sonnet 4.6](https://www.anthropic.com/news/claude-sonnet-4-6) | [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Opus 4.6](https://www.anthropic.com/news/claude-opus-4-6) | [Usage policy](https://www.anthropic.com/legal/aup) |
 | [Anthropic Claude Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5) | [Usage policy](https://www.anthropic.com/legal/aup) |
 | [Anthropic Claude Opus 4.1](https://www.anthropic.com/news/claude-4) | [Usage policy](https://www.anthropic.com/legal/aup) |

--- a/docs/products/cloud/features/ai-ml/model-developer-terms.mdx
+++ b/docs/products/cloud/features/ai-ml/model-developer-terms.mdx
@@ -15,9 +15,9 @@ Following is a table of models with their terms, and other pertinent information
 
 | Model | Terms and policies |
 | :---- | :---- |
+| [Anthropic Claude Opus 4.6](https://www.anthropic.com/news/claude-opus-4-6) | [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Sonnet 4.6](https://www.anthropic.com/news/claude-sonnet-4-6) | [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5) | [Usage policy](https://www.anthropic.com/legal/aup) |
 | [Anthropic Claude Sonnet 4.5](https://www.anthropic.com/news/claude-sonnet-4-5) | [Usage policy](https://www.anthropic.com/legal/aup) |
 | [Anthropic Claude Haiku 4.5](https://www.anthropic.com/news/claude-haiku-4-5) | [Usage policy](https://www.anthropic.com/legal/aup) |
-| [Anthropic Claude Sonnet 4.6](https://www.anthropic.com/news/claude-sonnet-4-6) | [Usage policy](https://www.anthropic.com/legal/aup) |
-| [Anthropic Claude Opus 4.6](https://www.anthropic.com/news/claude-opus-4-6) | [Usage policy](https://www.anthropic.com/legal/aup) |
-| [Anthropic Claude Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5) | [Usage policy](https://www.anthropic.com/legal/aup) |
 | [Anthropic Claude Opus 4.1](https://www.anthropic.com/news/claude-opus-4-1) | [Usage policy](https://www.anthropic.com/legal/aup) |


### PR DESCRIPTION
Updates the applicable model developer terms page to list the individual Anthropic Claude models available through AWS Bedrock, with links to the relevant model announcements and Anthropic usage policy.

Linear issue: https://linear.app/clickhouse/issue/DOC-927/update-applicable-model-developer-terms-page

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.243` (included in `26.8` and later)
<!-- ch-version-info:end -->