### PR TITLE
Estimate null-safe distinctness predicates in statistics

### DIFF
--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -1,23 +1,25 @@
 #include <Storages/Statistics/ConditionSelectivityEstimator.h>
 
-#include <stack>
+#include <algorithm>
 #include <cmath>
+#include <optional>
+#include <stack>
 
-#include <Common/logger_useful.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/DataTypeNullable.h>
-#include <DataTypes/getLeastSupertype.h>
-#include <DataTypes/DataTypeLowCardinality.h>
-#include <DataTypes/IDataType.h>
 #include <DataTypes/DataTypesNumber.h>
-#include <Interpreters/convertFieldToType.h>
-#include <Interpreters/misc.h>
+#include <DataTypes/IDataType.h>
+#include <DataTypes/getLeastSupertype.h>
+#include <Formats/ParseError.h>
 #include <Interpreters/PreparedSets.h>
 #include <Interpreters/Set.h>
-#include <Storages/StorageInMemoryMetadata.h>
-#include <Storages/MergeTree/RPNBuilder.h>
+#include <Interpreters/convertFieldToType.h>
+#include <Interpreters/misc.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
-#include <Formats/ParseError.h>
+#include <Storages/MergeTree/RPNBuilder.h>
+#include <Storages/StorageInMemoryMetadata.h>
+#include <Common/logger_useful.h>
 
 
 namespace DB
@@ -155,9 +157,20 @@ RelationProfile ConditionSelectivityEstimator::estimateRelationProfileImpl(std::
                 auto* last_element = rpn_stack.top();
                 if (last_element->finalized)
                     last_element->selectivity = last_element->selectivity.applyNot();
+                else if (last_element->function == RPNElement::FUNCTION_NULL_SAFE_EQUAL)
+                {
+                    last_element->function = RPNElement::FUNCTION_NULL_SAFE_NOT_EQUAL;
+                    std::swap(last_element->null_safe_column_ranges, last_element->null_safe_column_not_ranges);
+                }
+                else if (last_element->function == RPNElement::FUNCTION_NULL_SAFE_NOT_EQUAL)
+                {
+                    last_element->function = RPNElement::FUNCTION_NULL_SAFE_EQUAL;
+                    std::swap(last_element->null_safe_column_ranges, last_element->null_safe_column_not_ranges);
+                }
                 else
                 {
                     std::swap(last_element->column_ranges, last_element->column_not_ranges);
+                    std::swap(last_element->null_safe_column_ranges, last_element->null_safe_column_not_ranges);
                     std::swap(last_element->null_check_columns, last_element->not_null_check_columns);
                     switch (last_element->function)
                     {
@@ -178,8 +191,15 @@ RelationProfile ConditionSelectivityEstimator::estimateRelationProfileImpl(std::
     }
     auto * final_element = rpn_stack.top();
     final_element->finalize(column_estimators, metadata);
+    return final_element->selectivity;
+}
+
+RelationProfile
+ConditionSelectivityEstimator::estimateRelationProfileImpl(std::vector<RPNElement> & rpn, const StorageMetadataPtr & metadata) const
+{
+    Selectivity final_selectivity = estimateSelectivityImpl(rpn, metadata);
     RelationProfile result;
-    Float64 final_rows = final_element->selectivity.true_sel * static_cast<Float64>(total_rows);
+    Float64 final_rows = final_selectivity.true_sel * static_cast<Float64>(total_rows);
     /// Clamp to [0, total_rows] and handle NaN/Inf to avoid undefined behavior
     /// in the float-to-UInt64 cast below (UBSAN float-cast-overflow).
     if (!std::isfinite(final_rows) || final_rows < 0)
@@ -213,6 +233,16 @@ RelationProfile ConditionSelectivityEstimator::estimateRelationProfile(const Sto
 {
     RPNBuilderTreeContext tree_context(getContext());
     return estimateRelationProfile(metadata, RPNBuilderTreeNode(node, tree_context));
+}
+
+ConditionSelectivityEstimator::Selectivity
+ConditionSelectivityEstimator::estimateSelectivity(const StorageMetadataPtr & metadata, const RPNBuilderTreeNode & node) const
+{
+    std::vector<RPNElement> rpn
+        = RPNBuilder<RPNElement>(
+              node, [&](const RPNBuilderTreeNode & node_, RPNElement & out) { return extractAtomFromTree(metadata, node_, out); })
+              .extractRPN();
+    return estimateSelectivityImpl(rpn, metadata);
 }
 
 bool ConditionSelectivityEstimator::isStale(const std::vector<DataPartPtr> & data_parts) const
@@ -249,6 +279,7 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
         size_t num_args = func.getArgumentsSize();
 
         String func_name = func.getFunctionName();
+        const bool is_null_safe_comparison = func_name == "isNotDistinctFrom" || func_name == "isDistinctFrom";
         auto atom_it = atom_map.find(func_name);
         if (atom_it == atom_map.end())
         {
@@ -284,6 +315,8 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
         if (num_args == 2)
         {
             const bool is_in_operator = functionIsInOperator(func_name);
+            bool const_value_is_null = false;
+            std::optional<size_t> const_arg_pos;
 
             /// If the second argument is built from `ASTNode`, it should fall into next branch, which directly
             /// extracts constant value from `ASTLiteral`. Otherwise we try to build `Set` from `ActionsDAG::Node`,
@@ -310,26 +343,19 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
                 for (size_t i = 0; i < columns[0]->size(); ++i)
                     tuple[i] = (*columns[0])[i];
 
-                const_value = std::move(tuple);
+                const_value = tuple;
                 column_name = func.getArgumentAt(0).getColumnName();
             }
             else if (func.getArgumentAt(1).tryGetConstant(const_value, const_type))
             {
-                if (const_value.isNull())
-                {
-                    out.function = RPNElement::ALWAYS_FALSE;
-                    return true;
-                }
+                const_arg_pos = 1;
+                const_value_is_null = const_value.isNull();
                 column_name = func.getArgumentAt(0).getColumnName();
             }
             else if (func.getArgumentAt(0).tryGetConstant(const_value, const_type))
             {
-                if (const_value.isNull())
-                {
-                    out.function = RPNElement::ALWAYS_FALSE;
-                    return true;
-                }
-
+                const_arg_pos = 0;
+                const_value_is_null = const_value.isNull();
                 column_name = func.getArgumentAt(1).getColumnName();
                 if (func_name == "less")
                     func_name = "greater";
@@ -343,6 +369,114 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
             else
                 return false;
 
+            auto clamp_selectivity_value = [](Float64 value)
+            {
+                if (!std::isfinite(value))
+                    return default_unknown_cond_factor;
+                return std::max(0.0, std::min(1.0, value));
+            };
+
+            auto try_get_bool_constant = [](const Field & value, bool & bool_value)
+            {
+                switch (value.getType())
+                {
+                    case Field::Types::Bool: bool_value = value.safeGet<bool>() != 0; return true;
+                    case Field::Types::UInt64: {
+                        UInt64 numeric_value = value.safeGet<UInt64>();
+                        if (numeric_value > 1)
+                            return false;
+                        bool_value = numeric_value != 0;
+                        return true;
+                    }
+                    case Field::Types::Int64: {
+                        Int64 numeric_value = value.safeGet<Int64>();
+                        if (numeric_value < 0 || numeric_value > 1)
+                            return false;
+                        bool_value = numeric_value != 0;
+                        return true;
+                    }
+                    default: return false;
+                }
+            };
+
+            auto is_boolean_predicate = [](const RPNBuilderTreeNode & predicate_node)
+            {
+                if (!predicate_node.isFunction())
+                    return false;
+
+                const String predicate_func_name = predicate_node.toFunctionNode().getFunctionName();
+                return predicate_func_name == "and" || predicate_func_name == "or" || predicate_func_name == "not"
+                    || predicate_func_name == "equals" || predicate_func_name == "notEquals" || predicate_func_name == "less"
+                    || predicate_func_name == "greater" || predicate_func_name == "lessOrEquals" || predicate_func_name == "greaterOrEquals"
+                    || predicate_func_name == "isNull" || predicate_func_name == "isNotNull" || predicate_func_name == "isNotDistinctFrom"
+                    || predicate_func_name == "isDistinctFrom" || predicate_func_name == "like" || predicate_func_name == "notLike"
+                    || predicate_func_name == "ilike" || predicate_func_name == "notILike" || predicate_func_name == "__applyFilter"
+                    || functionIsInOperator(predicate_func_name);
+            };
+
+            if (is_null_safe_comparison && const_arg_pos)
+            {
+                const auto predicate_arg = func.getArgumentAt(1 - *const_arg_pos);
+                if (is_boolean_predicate(predicate_arg))
+                {
+                    Selectivity predicate_selectivity = estimateSelectivity(metadata, predicate_arg);
+
+                    if (const_value_is_null)
+                    {
+                        out.selectivity.true_sel = func_name == "isNotDistinctFrom"
+                            ? clamp_selectivity_value(predicate_selectivity.null_sel)
+                            : clamp_selectivity_value(1.0 - predicate_selectivity.null_sel);
+                        out.selectivity.null_sel = 0;
+                        out.finalized = true;
+                        return true;
+                    }
+
+                    bool bool_value = false;
+                    if (try_get_bool_constant(const_value, bool_value))
+                    {
+                        if (func_name == "isNotDistinctFrom")
+                        {
+                            out.selectivity.true_sel = bool_value
+                                ? clamp_selectivity_value(predicate_selectivity.true_sel)
+                                : clamp_selectivity_value(1.0 - predicate_selectivity.true_sel - predicate_selectivity.null_sel);
+                        }
+                        else
+                        {
+                            out.selectivity.true_sel = bool_value
+                                ? clamp_selectivity_value(1.0 - predicate_selectivity.true_sel)
+                                : clamp_selectivity_value(predicate_selectivity.true_sel + predicate_selectivity.null_sel);
+                        }
+                        out.selectivity.null_sel = 0;
+                        out.finalized = true;
+                        return true;
+                    }
+                }
+            }
+
+            if (const_value_is_null)
+            {
+                if (is_null_safe_comparison)
+                {
+                    if (metadata && !metadata->getColumns().tryGet(column_name))
+                        return false;
+
+                    if (func_name == "isNotDistinctFrom")
+                    {
+                        out.function = RPNElement::FUNCTION_IS_NULL;
+                        out.null_check_columns.insert(column_name);
+                    }
+                    else
+                    {
+                        out.function = RPNElement::FUNCTION_IS_NOT_NULL;
+                        out.not_null_check_columns.insert(column_name);
+                    }
+                    return true;
+                }
+
+                out.function = RPNElement::ALWAYS_FALSE;
+                return true;
+            }
+
             if (metadata)
             {
                 const ColumnDescription * column_desc = metadata->getColumns().tryGet(column_name);
@@ -353,9 +487,9 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
                     /// Not a real column (e.g. a function expression like lower(col) or toDecimal64(col, 3)).
                     /// Skip range analysis to avoid bad cast when merging ranges of incompatible Field types.
                     /// Pre-set selectivity based on the function type so prewhere ordering is still reasonable.
-                    if (func_name == "equals" || func_name == "in")
+                    if (func_name == "equals" || func_name == "in" || func_name == "isNotDistinctFrom")
                         out.selectivity.true_sel = default_cond_equal_factor;
-                    else if (func_name == "notEquals" || func_name == "notIn")
+                    else if (func_name == "notEquals" || func_name == "notIn" || func_name == "isDistinctFrom")
                         out.selectivity.true_sel = 1.0 - default_cond_equal_factor;
                     else /// less, greater, lessOrEquals, greaterOrEquals
                         out.selectivity.true_sel = default_cond_range_factor;
@@ -363,12 +497,16 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
                     return false;
                 }
             }
-            /// In some cases we need to cast the type of const
-            bool cast_not_needed = !column_type || !const_type ||
-                ((isNativeInteger(column_type) || isDateTime(column_type))
-                && (isNativeInteger(const_type) || isDateTime(const_type)));
+            /// In some cases we need to cast the type of const.
+            /// AST literals may arrive with an imprecise type hint from RPNBuilderTreeContext,
+            /// so still convert a String Field when the real column type is not String-compatible.
+            const bool force_string_conversion = column_type && const_value.getType() == Field::Types::String
+                && (!const_type || !isStringOrFixedString(column_type) || !column_type->equals(*const_type));
+            bool cast_not_needed = !column_type || (!const_type && !force_string_conversion)
+                || (!force_string_conversion && (isNativeInteger(column_type) || isDateTime(column_type))
+                    && (isNativeInteger(const_type) || isDateTime(const_type)));
 
-            if (!cast_not_needed && !column_type->equals(*const_type))
+            if (!cast_not_needed && (force_string_conversion || !column_type->equals(*const_type)))
             {
                 if (const_value.getType() == Field::Types::String)
                 {
@@ -387,9 +525,14 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
                         LOG_DEBUG(getLogger("ConditionSelectivityEstimator"),
                             "Cannot convert value to column type, skipping statistics estimation. The exception is : {}",
                             getCurrentExceptionMessage(false));
-                        if (func_name == "equals")
+                        if (func_name == "equals" || func_name == "isNotDistinctFrom")
                         {
                             out.function = RPNElement::ALWAYS_FALSE;
+                            return true;
+                        }
+                        if (func_name == "isDistinctFrom")
+                        {
+                            out.function = RPNElement::ALWAYS_TRUE;
                             return true;
                         }
                         return false;
@@ -425,7 +568,14 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
 
                         Field converted = tryConvertFieldToType(const_value, *column_type, const_type.get(), {});
                         if (converted.isNull())
+                        {
+                            if (is_null_safe_comparison)
+                            {
+                                out.function = func_name == "isNotDistinctFrom" ? RPNElement::ALWAYS_FALSE : RPNElement::ALWAYS_TRUE;
+                                return true;
+                            }
                             return false;
+                        }
 
                         /// Narrowing to the column type is only semantically sound when the literal is
                         /// exactly representable in that type. At execution time the column value is
@@ -435,12 +585,13 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
                         /// representable value and make an impossible predicate look selective, which can
                         /// reorder PREWHERE incorrectly. Detect this with a round-trip and short-circuit
                         /// equality/inequality instead of estimating from the narrowed value.
-                        if (func_name == "equals" || func_name == "notEquals")
+                        if (func_name == "equals" || func_name == "notEquals" || is_null_safe_comparison)
                         {
                             Field round_trip = tryConvertFieldToType(converted, *common_type, column_type.get(), {});
                             if (round_trip.isNull() || round_trip != const_value)
                             {
-                                out.function = func_name == "equals" ? RPNElement::ALWAYS_FALSE : RPNElement::ALWAYS_TRUE;
+                                out.function = (func_name == "equals" || func_name == "isNotDistinctFrom") ? RPNElement::ALWAYS_FALSE
+                                                                                                           : RPNElement::ALWAYS_TRUE;
                                 return true;
                             }
                         }
@@ -576,116 +727,107 @@ UInt64 ConditionSelectivityEstimator::ColumnEstimator::estimateCardinality() con
     return stats->estimateCardinality();
 }
 
-const ConditionSelectivityEstimator::AtomMap ConditionSelectivityEstimator::atom_map
-{
-        {
-            "notEquals",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                out.column_not_ranges.emplace(column, Range(value));
-            }
-        },
-        {
-            "equals",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                out.column_ranges.emplace(column, Range(value));
-            }
-        },
-        {
-            "in",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                Ranges ranges;
-                for (const Field & field : value.safeGet<Tuple>())
-                {
-                    ranges.emplace_back(field);
-                }
-                out.column_ranges.emplace(column, PlainRanges(ranges, /*intersect*/ true, /*ordered*/ false));
-            }
-        },
-        {
-            "notIn",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                Ranges ranges;
-                for (const Field & field : value.safeGet<Tuple>())
-                {
-                    ranges.emplace_back(field);
-                }
-                out.column_not_ranges.emplace(column, PlainRanges(ranges, /*intersect*/ true, /*ordered*/ false));
-            }
-        },
-        {
-            "less",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                out.column_ranges.emplace(column, Range::createRightBounded(value, false));
-            }
-        },
-        {
-            "greater",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                out.column_ranges.emplace(column, Range::createLeftBounded(value, false));
-            }
-        },
-        {
-            "lessOrEquals",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                out.column_ranges.emplace(column, Range::createRightBounded(value, true));
-            }
-        },
-        {
-            "greaterOrEquals",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                out.column_ranges.emplace(column, Range::createLeftBounded(value, true));
-            }
-        },
-        {
-            "isNull",
-            [] (RPNElement & out, const String & column, const Field &)
-            {
-                out.function = RPNElement::FUNCTION_IS_NULL;
-                out.null_check_columns.insert(column);
-            }
-        },
-        {
-            "isNotNull",
-            [] (RPNElement & out, const String & column, const Field &)
-            {
-                out.function = RPNElement::FUNCTION_IS_NOT_NULL;
-                out.not_null_check_columns.insert(column);
-            }
-        }
-};
+const ConditionSelectivityEstimator::AtomMap ConditionSelectivityEstimator::atom_map{
+    {"notEquals",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         out.column_not_ranges.emplace(column, Range(value));
+     }},
+    {"equals",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         out.column_ranges.emplace(column, Range(value));
+     }},
+    {"isNotDistinctFrom",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_NULL_SAFE_EQUAL;
+         out.null_safe_column_ranges.emplace(column, Range(value));
+     }},
+    {"isDistinctFrom",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_NULL_SAFE_NOT_EQUAL;
+         out.null_safe_column_not_ranges.emplace(column, Range(value));
+     }},
+    {"in",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         Ranges ranges;
+         for (const Field & field : value.safeGet<Tuple>())
+         {
+             ranges.emplace_back(field);
+         }
+         out.column_ranges.emplace(column, PlainRanges(ranges, /*intersect*/ true, /*ordered*/ false));
+     }},
+    {"notIn",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         Ranges ranges;
+         for (const Field & field : value.safeGet<Tuple>())
+         {
+             ranges.emplace_back(field);
+         }
+         out.column_not_ranges.emplace(column, PlainRanges(ranges, /*intersect*/ true, /*ordered*/ false));
+     }},
+    {"less",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         out.column_ranges.emplace(column, Range::createRightBounded(value, false));
+     }},
+    {"greater",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         out.column_ranges.emplace(column, Range::createLeftBounded(value, false));
+     }},
+    {"lessOrEquals",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         out.column_ranges.emplace(column, Range::createRightBounded(value, true));
+     }},
+    {"greaterOrEquals",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         out.column_ranges.emplace(column, Range::createLeftBounded(value, true));
+     }},
+    {"isNull",
+     [](RPNElement & out, const String & column, const Field &)
+     {
+         out.function = RPNElement::FUNCTION_IS_NULL;
+         out.null_check_columns.insert(column);
+     }},
+    {"isNotNull",
+     [](RPNElement & out, const String & column, const Field &)
+     {
+         out.function = RPNElement::FUNCTION_IS_NOT_NULL;
+         out.not_null_check_columns.insert(column);
+     }}};
 
 /// merge CNF or DNF
 bool ConditionSelectivityEstimator::RPNElement::tryToMergeClauses(RPNElement & lhs, RPNElement & rhs)
 {
     auto can_merge_with = [](const RPNElement & e, Function function_to_merge)
     {
-        return (e.function == FUNCTION_IN_RANGE
+        return (e.function == FUNCTION_IN_RANGE || e.function == FUNCTION_NULL_SAFE_EQUAL || e.function == FUNCTION_NULL_SAFE_NOT_EQUAL
                 || e.function == FUNCTION_IS_NULL
                 || e.function == FUNCTION_IS_NOT_NULL
                 /// if the sub-clause is also cnf/dnf, it's good to merge
                 || e.function == function_to_merge
                 /// if the sub-clause is different, but has only one column, it also works, e.g
                 /// (a > 0 and a < 5) or (a > 3 and a < 10) can be merged to (a > 0 and a < 10)
-                || (e.column_ranges.size() + e.column_not_ranges.size()
-                    + e.null_check_columns.size() + e.not_null_check_columns.size()) == 1
+                || (e.column_ranges.size() + e.column_not_ranges.size() + e.null_safe_column_ranges.size()
+                    + e.null_safe_column_not_ranges.size() + e.null_check_columns.size() + e.not_null_check_columns.size())
+                    == 1
                 || e.function == FUNCTION_UNKNOWN)
-                && !e.finalized;
+            && !e.finalized;
     };
     /// we will merge normal expression and not expression separately.
     auto merge_column_ranges = [this](ColumnRanges & result_ranges, ColumnRanges & l_ranges, ColumnRanges & r_ranges, bool is_not)
@@ -714,6 +856,8 @@ bool ConditionSelectivityEstimator::RPNElement::tryToMergeClauses(RPNElement & l
     {
         merge_column_ranges(column_ranges, lhs.column_ranges, rhs.column_ranges, false);
         merge_column_ranges(column_not_ranges, lhs.column_not_ranges, rhs.column_not_ranges, true);
+        merge_column_ranges(null_safe_column_ranges, lhs.null_safe_column_ranges, rhs.null_safe_column_ranges, false);
+        merge_column_ranges(null_safe_column_not_ranges, lhs.null_safe_column_not_ranges, rhs.null_safe_column_not_ranges, true);
         null_check_columns.insert(lhs.null_check_columns.begin(), lhs.null_check_columns.end());
         null_check_columns.insert(rhs.null_check_columns.begin(), rhs.null_check_columns.end());
         not_null_check_columns.insert(lhs.not_null_check_columns.begin(), lhs.not_null_check_columns.end());
@@ -773,12 +917,201 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
         return &it->second;
     };
 
+    auto clamp_probability = [](Float64 value, Float64 fallback = default_unknown_cond_factor)
+    {
+        if (!std::isfinite(value))
+            return fallback;
+        return std::max(0.0, std::min(1.0, value));
+    };
+
+    auto estimate_ranges_selectivity = [&](const String & column_name, const PlainRanges & ranges) -> Selectivity
+    {
+        Selectivity result;
+        if (const auto * est = get_estimator(column_name))
+            result = est->estimateRanges(ranges);
+        else
+            result = estimate_unknown_ranges(ranges);
+
+        result.true_sel = clamp_probability(result.true_sel);
+        result.null_sel = clamp_probability(result.null_sel, 0.0);
+        if (result.true_sel + result.null_sel > 1.0)
+            result.null_sel = std::max(0.0, 1.0 - result.true_sel);
+        return result;
+    };
+
+    auto estimate_ranges_true
+        = [&](const String & column_name, const PlainRanges & ranges) { return estimate_ranges_selectivity(column_name, ranges).true_sel; };
+
+    auto get_ranges = [](const ColumnRanges & ranges_by_column, const String & column_name) -> const PlainRanges *
+    {
+        auto it = ranges_by_column.find(column_name);
+        return it == ranges_by_column.end() ? nullptr : &it->second;
+    };
+
+    auto union_into = [](std::optional<PlainRanges> & result, const PlainRanges & ranges)
+    {
+        if (result)
+        {
+            PlainRanges current = *result;
+            result = current.unionWith(ranges);
+        }
+        else
+            result = ranges;
+    };
+
+    auto intersect_into = [](std::optional<PlainRanges> & result, const PlainRanges & ranges)
+    {
+        if (result)
+        {
+            PlainRanges current = *result;
+            result = current.intersectWith(ranges);
+        }
+        else
+            result = ranges;
+    };
+
+    std::unordered_set<String> null_safe_columns;
+    for (const auto & entry : null_safe_column_ranges)
+        null_safe_columns.insert(entry.first);
+    for (const auto & entry : null_safe_column_not_ranges)
+        null_safe_columns.insert(entry.first);
+
+    auto estimate_column_with_null_safe = [&](const String & column_name) -> Selectivity
+    {
+        const PlainRanges * positive_ranges = get_ranges(column_ranges, column_name);
+        const PlainRanges * negative_ranges = get_ranges(column_not_ranges, column_name);
+        const PlainRanges * null_safe_equal_ranges = get_ranges(null_safe_column_ranges, column_name);
+        const PlainRanges * null_safe_not_equal_ranges = get_ranges(null_safe_column_not_ranges, column_name);
+        const bool has_null_check = null_check_columns.contains(column_name);
+        const bool has_not_null_check = not_null_check_columns.contains(column_name);
+        const bool is_or = function == FUNCTION_OR;
+
+        PlainRanges universe = PlainRanges::makeUniverse();
+        Selectivity universe_selectivity = estimate_ranges_selectivity(column_name, universe);
+        Float64 domain_non_null_sel = universe_selectivity.true_sel;
+        Float64 domain_null_sel = universe_selectivity.null_sel;
+
+        Float64 explicit_null_sel = domain_null_sel;
+        if (has_null_check)
+        {
+            explicit_null_sel = default_cond_equal_factor;
+            if (const auto * est = get_estimator(column_name))
+                explicit_null_sel = est->stats->estimateIsNull();
+            explicit_null_sel = clamp_probability(explicit_null_sel, 0.0);
+        }
+
+        Float64 non_null_true_sel = 0.0;
+        if (is_or)
+        {
+            if (has_not_null_check)
+            {
+                non_null_true_sel = domain_non_null_sel;
+            }
+            else
+            {
+                std::optional<PlainRanges> included_ranges;
+                if (positive_ranges)
+                    union_into(included_ranges, *positive_ranges);
+                if (null_safe_equal_ranges)
+                    union_into(included_ranges, *null_safe_equal_ranges);
+
+                std::optional<PlainRanges> complement_excluded_ranges;
+                if (negative_ranges)
+                    intersect_into(complement_excluded_ranges, *negative_ranges);
+                if (null_safe_not_equal_ranges)
+                    intersect_into(complement_excluded_ranges, *null_safe_not_equal_ranges);
+
+                if (complement_excluded_ranges)
+                {
+                    PlainRanges false_ranges = *complement_excluded_ranges;
+                    Float64 false_sel = estimate_ranges_true(column_name, false_ranges);
+                    if (included_ranges)
+                    {
+                        PlainRanges included_in_false = false_ranges.intersectWith(*included_ranges);
+                        false_sel -= estimate_ranges_true(column_name, included_in_false);
+                    }
+                    non_null_true_sel = domain_non_null_sel - false_sel;
+                }
+                else if (included_ranges)
+                    non_null_true_sel = estimate_ranges_true(column_name, *included_ranges);
+            }
+        }
+        else
+        {
+            if (!has_null_check)
+            {
+                std::optional<PlainRanges> allowed_ranges;
+                if (positive_ranges)
+                    intersect_into(allowed_ranges, *positive_ranges);
+                if (null_safe_equal_ranges)
+                    intersect_into(allowed_ranges, *null_safe_equal_ranges);
+
+                PlainRanges non_null_true_ranges = allowed_ranges ? *allowed_ranges : universe;
+                non_null_true_sel = estimate_ranges_true(column_name, non_null_true_ranges);
+
+                std::optional<PlainRanges> excluded_ranges;
+                if (negative_ranges)
+                    union_into(excluded_ranges, *negative_ranges);
+                if (null_safe_not_equal_ranges)
+                    union_into(excluded_ranges, *null_safe_not_equal_ranges);
+
+                if (excluded_ranges)
+                {
+                    PlainRanges excluded_from_true = non_null_true_ranges.intersectWith(*excluded_ranges);
+                    non_null_true_sel -= estimate_ranges_true(column_name, excluded_from_true);
+                }
+            }
+        }
+
+        non_null_true_sel = clamp_probability(non_null_true_sel, 0.0);
+
+        enum class NullTruth
+        {
+            False,
+            Null,
+            True,
+        };
+
+        const bool ordinary_value_predicate = positive_ranges || negative_ranges;
+        NullTruth null_truth = NullTruth::False;
+        if (is_or)
+        {
+            if (null_safe_not_equal_ranges || has_null_check)
+                null_truth = NullTruth::True;
+            else if (ordinary_value_predicate)
+                null_truth = NullTruth::Null;
+        }
+        else
+        {
+            if (null_safe_equal_ranges || has_not_null_check)
+                null_truth = NullTruth::False;
+            else if (ordinary_value_predicate)
+                null_truth = NullTruth::Null;
+            else if (null_safe_not_equal_ranges || has_null_check)
+                null_truth = NullTruth::True;
+        }
+
+        Float64 null_sel = has_null_check ? explicit_null_sel : domain_null_sel;
+        Selectivity result(non_null_true_sel, 0.0);
+        if (null_truth == NullTruth::True)
+            result.true_sel = clamp_probability(result.true_sel + null_sel);
+        else if (null_truth == NullTruth::Null)
+            result.null_sel = std::min(null_sel, std::max(0.0, 1.0 - result.true_sel));
+        return result;
+    };
+
     /// Per-column accumulator. The map enforces independence across columns: each column
     /// contributes a single `Selectivity` to the final AND/OR product, with intra-column
     /// merging (e.g. `col > 0 AND col IS NOT NULL`) folded in via `applyAnd`/`applyOr`.
     std::unordered_map<String, Selectivity> estimate_results;
+    for (const auto & column_name : null_safe_columns)
+        estimate_results.emplace(column_name, estimate_column_with_null_safe(column_name));
+
     for (const auto & [column_name, ranges] : column_ranges)
     {
+        if (null_safe_columns.contains(column_name))
+            continue;
+
         if (const auto * est = get_estimator(column_name))
             estimate_results.emplace(column_name, est->estimateRanges(ranges));
         else
@@ -787,6 +1120,9 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
 
     for (const auto & [column_name, ranges] : column_not_ranges)
     {
+        if (null_safe_columns.contains(column_name))
+            continue;
+
         Selectivity not_ranges_selectivity;
         if (const auto * est = get_estimator(column_name))
             not_ranges_selectivity = est->estimateRanges(ranges).applyNot();
@@ -816,6 +1152,9 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
         /// because range predicates have `true_sel = 0` on rows where the column is NULL.
         for (const auto & col : null_check_columns)
         {
+            if (null_safe_columns.contains(col))
+                continue;
+
             if (not_null_check_columns.contains(col))
             {
                 selectivity = Selectivity();
@@ -828,6 +1167,9 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
         /// `x IS NULL OR x IS NOT NULL` is a tautology → selectivity = 1
         for (const auto & col : null_check_columns)
         {
+            if (null_safe_columns.contains(col))
+                continue;
+
             if (not_null_check_columns.contains(col))
             {
                 selectivity = Selectivity(1, 0);
@@ -838,6 +1180,9 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
 
     for (const auto & column_name : null_check_columns)
     {
+        if (null_safe_columns.contains(column_name))
+            continue;
+
         Float64 cur_selectivity = default_cond_equal_factor;
         if (const auto * est = get_estimator(column_name))
             cur_selectivity = est->stats->estimateIsNull();
@@ -864,6 +1209,9 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
 
     for (const auto & column_name : not_null_check_columns)
     {
+        if (null_safe_columns.contains(column_name))
+            continue;
+
         Float64 cur_selectivity = 1.0 - default_cond_equal_factor;
         if (const auto * est = get_estimator(column_name))
             cur_selectivity = est->stats->estimateIsNotNull();

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.h
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.h
@@ -70,6 +70,11 @@ public:
         {
             /// Atoms of a Boolean expression.
             FUNCTION_IN_RANGE,
+            /// Column <=> non-NULL constant / column IS DISTINCT FROM non-NULL constant.
+            /// These predicates are two-valued, so NULL input is folded into TRUE/FALSE directly
+            /// instead of being carried in Selectivity::null_sel like ordinary comparisons.
+            FUNCTION_NULL_SAFE_EQUAL,
+            FUNCTION_NULL_SAFE_NOT_EQUAL,
             FUNCTION_IS_NULL,
             FUNCTION_IS_NOT_NULL,
             FUNCTION_UNKNOWN,
@@ -89,6 +94,12 @@ public:
         /// column not in range (a, b) ...
         /// we use 'not ranges' to estimate condition a != 1 and a != 2 better.
         ColumnRanges column_not_ranges;
+        /// column IS NOT DISTINCT FROM a non-NULL constant/range. Unlike ordinary ranges,
+        /// these predicates are FALSE (not NULL) when the input column is NULL.
+        ColumnRanges null_safe_column_ranges;
+        /// column IS DISTINCT FROM a non-NULL constant/range. These predicates are TRUE
+        /// when the input column is NULL, and TRUE for non-NULL values outside the range.
+        ColumnRanges null_safe_column_not_ranges;
         /// columns checked with IS NULL predicate
         std::unordered_set<String> null_check_columns;
         /// columns checked with IS NOT NULL predicate
@@ -113,8 +124,9 @@ private:
     };
 
     RelationProfile estimateRelationProfileImpl(std::vector<RPNElement> & rpn, const StorageMetadataPtr & metadata) const;
+    Selectivity estimateSelectivityImpl(std::vector<RPNElement> & rpn, const StorageMetadataPtr & metadata) const;
+    Selectivity estimateSelectivity(const StorageMetadataPtr & metadata, const RPNBuilderTreeNode & node) const;
     bool extractAtomFromTree(const StorageMetadataPtr & metadata, const RPNBuilderTreeNode & node, RPNElement & out) const;
-    UInt64 estimateSelectivity(const RPNBuilderTreeNode & node) const;
 
     /// Magic constants for estimating the selectivity of a condition no statistics exists.
     static constexpr Float64 default_cond_range_factor = 0.33;

--- a/src/Storages/Statistics/tests/gtest_stats.cpp
+++ b/src/Storages/Statistics/tests/gtest_stats.cpp
@@ -6,23 +6,25 @@
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnNullable.h>
 #include <Columns/IColumn.h>
-#include <Common/Exception.h>
 #include <Core/Block.h>
 #include <Core/ColumnWithTypeAndName.h>
+#include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesDecimal.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Interpreters/convertFieldToType.h>
+#include <Parsers/ExpressionListParsers.h>
+#include <Parsers/parseQuery.h>
+#include <Storages/ColumnsDescription.h>
 #include <Storages/MergeTree/RPNBuilder.h>
+#include <Storages/Statistics/ConditionSelectivityEstimator.h>
 #include <Storages/Statistics/Statistics.h>
 #include <Storages/Statistics/StatisticsMinMax.h>
-#include <Storages/StatisticsDescription.h>
-#include <Storages/ColumnsDescription.h>
 #include <Storages/Statistics/StatisticsTDigest.h>
-#include <Storages/Statistics/ConditionSelectivityEstimator.h>
-#include <Parsers/parseQuery.h>
-#include <Parsers/ExpressionListParsers.h>
+#include <Storages/StatisticsDescription.h>
+#include <Storages/StorageInMemoryMetadata.h>
+#include <Common/Exception.h>
 
 using namespace DB;
 
@@ -214,6 +216,38 @@ ColumnStatisticsPtr createTestStats(
     return MergeTreeStatisticsFactory::instance().get(desc);
 }
 
+ColumnStatisticsPtr buildInt32Stats(const std::vector<StatisticsType> & types, size_t total)
+{
+    auto data_type = std::make_shared<DataTypeInt32>();
+    MutableColumnPtr col = data_type->createColumn();
+    for (size_t i = 0; i < total; ++i)
+        col->insert(static_cast<Int32>(i));
+
+    auto stats = createTestStats(types, data_type);
+    stats->build(std::move(col));
+    return stats;
+}
+
+ColumnStatisticsPtr buildDateStats(const std::vector<StatisticsType> & types, size_t total)
+{
+    auto data_type = std::make_shared<DataTypeDate>();
+    MutableColumnPtr col = data_type->createColumn();
+    for (size_t i = 0; i < total; ++i)
+        col->insert(static_cast<UInt16>(i));
+
+    auto stats = createTestStats(types, data_type);
+    ColumnPtr column = static_cast<const IColumn &>(*col).getPtr();
+    stats->build(column);
+    return stats;
+}
+
+StorageMetadataPtr makeMetadata(std::initializer_list<ColumnDescription> columns)
+{
+    auto metadata = std::make_shared<StorageInMemoryMetadata>();
+    metadata->setColumns(ColumnsDescription(columns));
+    return metadata;
+}
+
 /// Build a `Nullable(Int32)` column with `total` rows where every `null_every`-th row is NULL.
 /// Non-NULL row `i` carries value `static_cast<Int32>(i)`. Returns built statistics.
 ColumnStatisticsPtr buildNullableInt32Stats(
@@ -238,7 +272,7 @@ ColumnStatisticsPtr buildNullableInt32Stats(
 
 /// Estimate the row count for a SQL boolean expression evaluated against `estimator`.
 template <class Estimator>
-Float64 estimateRowsFor(Estimator & estimator, const String & expression)
+Float64 estimateRowsFor(Estimator & estimator, const String & expression, const StorageMetadataPtr & metadata = nullptr)
 {
     ParserExpressionWithOptionalAlias exp_parser(false);
     ContextPtr context = getContext().context;
@@ -248,7 +282,7 @@ Float64 estimateRowsFor(Estimator & estimator, const String & expression)
         {});
     ASTPtr ast = parseQuery(exp_parser, expression, 10000, 10000, 10000);
     RPNBuilderTreeNode node(ast.get(), tree_context);
-    return static_cast<Float64>(estimator->estimateRelationProfile(nullptr, node).rows);
+    return static_cast<Float64>(estimator->estimateRelationProfile(metadata, node).rows);
 }
 
 }
@@ -345,6 +379,92 @@ TEST(Statistics, NullableEstimatorWithBasic)
     check("a IS NULL AND a > 500 AND b IS NULL", 0.0, 1e-6); /// a IS NULL contradicts a > 500
 }
 
+TEST(Statistics, NullSafeEqualityEstimator)
+{
+    tryRegisterFunctions();
+
+    auto int_type = std::make_shared<DataTypeInt32>();
+    auto nullable_int_type = std::make_shared<DataTypeNullable>(int_type);
+
+    auto stats_a = buildInt32Stats({StatisticsType::Basic}, /*total=*/1000);
+    auto stats_n = buildNullableInt32Stats({StatisticsType::Basic}, /*total=*/1000, /*null_every=*/5);
+    auto stats_d = buildDateStats({StatisticsType::Basic}, /*total=*/1000);
+    ASSERT_EQ(stats_n->getNonNullRowCount(), 800u);
+
+    ConditionSelectivityEstimatorBuilder builder(getContext().context);
+    builder.addStatistics("a", stats_a);
+    builder.addStatistics("n", stats_n);
+    builder.addStatistics("d", stats_d);
+    builder.incrementRowCount(1000);
+    auto estimator = builder.getEstimator();
+
+    auto metadata = makeMetadata(
+        {ColumnDescription("a", int_type), ColumnDescription("n", nullable_int_type), ColumnDescription("d", stats_d->getDataType())});
+
+    auto check = [&](const String & expression, Float64 expected)
+    {
+        Float64 actual = estimateRowsFor(estimator, expression, metadata);
+        EXPECT_NEAR(actual, expected, 1e-6) << "Expression: " << expression;
+    };
+
+    /// Non-nullable column: null-safe equality uses the same equality estimate and distinct is its complement.
+    check("a = 5", 10.0);
+    check("a IS NOT DISTINCT FROM 5", 10.0);
+    check("a <=> 5", 10.0);
+    check("isNotDistinctFrom(a, 5)", 10.0);
+    check("5 IS NOT DISTINCT FROM a", 10.0);
+    check("a IS DISTINCT FROM 5", 990.0);
+    check("isDistinctFrom(a, 5)", 990.0);
+    check("5 IS DISTINCT FROM a", 990.0);
+
+    /// NULL constants are IS NULL / IS NOT NULL.
+    check("n IS NOT DISTINCT FROM NULL", 200.0);
+    check("n <=> NULL", 200.0);
+    check("isNotDistinctFrom(n, NULL)", 200.0);
+    check("n IS DISTINCT FROM NULL", 800.0);
+    check("isDistinctFrom(n, NULL)", 800.0);
+    check("NULL IS NOT DISTINCT FROM n", 200.0);
+    check("NULL IS DISTINCT FROM n", 800.0);
+
+    /// Non-NULL constants on Nullable columns are two-valued: NULL rows are not UNKNOWN.
+    check("n IS NOT DISTINCT FROM 5", 8.0);
+    check("n <=> 5", 8.0);
+    check("isNotDistinctFrom(n, 5)", 8.0);
+    check("n IS DISTINCT FROM 5", 992.0);
+    check("isDistinctFrom(n, 5)", 992.0);
+    check("not(n IS NOT DISTINCT FROM 5)", 992.0);
+    check("not(n IS DISTINCT FROM 5)", 8.0);
+    check("not(n = 5)", 792.0);
+
+    /// Same-column null-safe predicates must be combined with NULL checks and ranges,
+    /// not multiplied as if the predicates were independent columns.
+    check("n IS NOT DISTINCT FROM 5 AND n IS NULL", 0.0);
+    check("n IS NOT DISTINCT FROM 5 OR n IS NULL", 208.0);
+    check("n IS DISTINCT FROM 5 AND n IS NULL", 200.0);
+    check("n IS DISTINCT FROM 5 OR n IS NULL", 992.0);
+    check("n IS NOT DISTINCT FROM 5 AND n IS NOT NULL", 8.0);
+    check("n IS DISTINCT FROM 5 AND n IS NOT NULL", 792.0);
+    check("n IS DISTINCT FROM 5 OR n IS NOT NULL", 1000.0);
+    check("n IS NOT DISTINCT FROM 5 AND n > 10", 0.0);
+    check("n IS NOT DISTINCT FROM 5 OR n > 500", 408.0);
+    check("n IS DISTINCT FROM 5 AND n > 500", 400.0);
+
+    /// Boolean IS TRUE / IS FALSE wrappers are null-safe comparisons around a predicate.
+    /// They should use the predicate estimate, but collapse to a two-valued result.
+    check("(n > 500) IS TRUE", 400.0);
+    check("(n > 500) IS NOT TRUE", 600.0);
+    check("(n > 500) IS FALSE", 400.0);
+    check("(n > 500) IS NOT FALSE", 600.0);
+    check("not((n > 500) IS TRUE)", 600.0);
+    check("not(n > 500)", 400.0);
+
+    /// Impossible converted constants fold like equality/inequality.
+    check("d IS NOT DISTINCT FROM 'not_a_date'", 0.0);
+    check("'not_a_date' IS NOT DISTINCT FROM d", 0.0);
+    check("d IS DISTINCT FROM 'not_a_date'", 1000.0);
+    check("'not_a_date' IS DISTINCT FROM d", 1000.0);
+}
+
 TEST(Statistics, LikeSelectivity)
 {
     /// Build a simple estimator to test LIKE / NOT LIKE / ILIKE / NOT ILIKE
@@ -414,7 +534,7 @@ TEST(Statistics, LikeSelectivity)
 /// STID 3524-3a4b (nullability) and STID 2404-35eb (value type): a statistics collector is declared
 /// on one column type, then the block column reaching `build` has a different type (a pending MODIFY
 /// COLUMN mutation, or an asymmetric merge where `structureEquals` only compares statistics types and
-/// misses a type-only change). Feeding the mismatched column to the collector previously mis-cast
+/// misses a type-only change). Feeding the mismatched column to the collector was previously incorrectly cast
 /// inside the aggregate function and aborted: `Bad cast ... ColumnNullable` for `uniq` on a Nullable
 /// type (3524-3a4b), and `Bad cast ColumnDecimal<Decimal256> to ColumnVector<long>` for `uniq` whose
 /// `<long>` (Int64) specialization was fed a Decimal256 block during mutation statistics rebuild

--- a/tests/queries/0_stateless/04266_statistics_basic_prewhere.reference
+++ b/tests/queries/0_stateless/04266_statistics_basic_prewhere.reference
@@ -22,3 +22,16 @@ Fallback selectivity uses non-null row count (b before a)
 1
 Const-null insert: basic null count drives correct prewhere ordering
 1
+Null-safe equality with non-NULL constants uses equality statistics
+1
+1
+1
+Null-safe distinct with non-NULL constants includes NULL rows as TRUE
+1
+1
+NULL constants use basic null-count statistics
+1
+1
+Impossible Float32 literal folds for null-safe predicates
+1
+1

--- a/tests/queries/0_stateless/04266_statistics_basic_prewhere.sql
+++ b/tests/queries/0_stateless/04266_statistics_basic_prewhere.sql
@@ -219,3 +219,97 @@ SELECT position(prewhere_line, 'b.null') < position(prewhere_line, 'a.null') AS 
 );
 
 DROP TABLE test_const_null;
+
+-- =============================================================================
+-- `IS [NOT] DISTINCT FROM` / `<=>` selectivity uses `basic` statistics for
+-- `Nullable` columns. The checks compare `PREWHERE` order against a `probe`
+-- range whose selectivity is chosen so that the old unknown-condition fallback
+-- would pick the opposite order.
+-- =============================================================================
+DROP TABLE IF EXISTS test_null_safe_distinct_prewhere;
+
+CREATE TABLE test_null_safe_distinct_prewhere
+(
+    id UInt64,
+    nullable_value Nullable(Int64),
+    probe Int64,
+    float_key Float32
+) Engine = MergeTree() ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, auto_statistics_types = '';
+
+INSERT INTO test_null_safe_distinct_prewhere
+SELECT
+    number,
+    if(number % 5 = 0, NULL, number % 100),
+    number,
+    toFloat32(number % 10)
+FROM numbers(1000);
+
+ALTER TABLE test_null_safe_distinct_prewhere ADD STATISTICS nullable_value TYPE basic;
+ALTER TABLE test_null_safe_distinct_prewhere ADD STATISTICS probe TYPE basic;
+ALTER TABLE test_null_safe_distinct_prewhere ADD STATISTICS float_key TYPE basic;
+ALTER TABLE test_null_safe_distinct_prewhere MATERIALIZE STATISTICS nullable_value, probe, float_key SETTINGS mutations_sync = 1;
+
+SELECT 'Null-safe equality with non-NULL constants uses equality statistics';
+SELECT position(prewhere_line, 'nullable_value') < position(prewhere_line, 'probe') AS null_safe_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_null_safe_distinct_prewhere
+        WHERE nullable_value IS NOT DISTINCT FROM 7 AND probe < 50
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+SELECT position(prewhere_line, 'nullable_value') < position(prewhere_line, 'probe') AS null_safe_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_null_safe_distinct_prewhere
+        WHERE isNotDistinctFrom(nullable_value, 7) AND probe < 50
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+SELECT position(prewhere_line, 'nullable_value') < position(prewhere_line, 'probe') AS null_safe_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_null_safe_distinct_prewhere
+        WHERE nullable_value <=> 7 AND probe < 50
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+SELECT 'Null-safe distinct with non-NULL constants includes NULL rows as TRUE';
+SELECT position(prewhere_line, 'probe') < position(prewhere_line, 'nullable_value') AS probe_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_null_safe_distinct_prewhere
+        WHERE nullable_value IS DISTINCT FROM 7 AND probe < 950
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+SELECT position(prewhere_line, 'probe') < position(prewhere_line, 'nullable_value') AS probe_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_null_safe_distinct_prewhere
+        WHERE isDistinctFrom(7, nullable_value) AND probe < 950
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+SELECT 'NULL constants use basic null-count statistics';
+SELECT position(prewhere_line, 'nullable_value') < position(prewhere_line, 'probe') AS null_safe_null_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_null_safe_distinct_prewhere
+        WHERE nullable_value IS NOT DISTINCT FROM NULL AND probe < 300
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+SELECT position(prewhere_line, 'probe') < position(prewhere_line, 'nullable_value') AS probe_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_null_safe_distinct_prewhere
+        WHERE isDistinctFrom(nullable_value, NULL) AND probe < 500
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+SELECT 'Impossible Float32 literal folds for null-safe predicates';
+SELECT position(prewhere_line, 'float_key') < position(prewhere_line, 'probe') AS impossible_equal_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_null_safe_distinct_prewhere
+        WHERE float_key IS NOT DISTINCT FROM 0.1 AND probe < 1
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+SELECT position(prewhere_line, 'probe') < position(prewhere_line, 'float_key') AS probe_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_null_safe_distinct_prewhere
+        WHERE float_key IS DISTINCT FROM 0.1 AND probe < 950
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+DROP TABLE test_null_safe_distinct_prewhere;


### PR DESCRIPTION
 Improve selectivity estimation from column statistics for null-safe distinctness predicates: `IS NOT DISTINCT FROM`, `IS  
 DISTINCT FROM`, `<=>`, `isNotDistinctFrom`, and `isDistinctFrom`.

 Previously these predicates mostly used unknown-condition fallbacks, which could lead to worse PREWHERE ordering,
 especially for Nullable columns. The estimator now uses equality/range estimates and null-count statistics for these predicates, including NULL constants and impossible constant conversions. The change also adds gtest and stateless coverage.

 ### Changelog category (leave one):

 - Improvement

 ### Changelog entry (a user-readable short description)                                           

 Use column statistics to estimate selectivity for `IS NOT DISTINCT FROM`, `IS DISTINCT FROM`, `<=>`, `isNotDistinctFrom`, and `isDistinctFrom`, improving PREWHERE ordering for Nullable columns.