### PR TITLE
Bind parameterized-view parameters only from top-level equals args

### DIFF
--- a/src/Parsers/FunctionParameterValuesVisitor.cpp
+++ b/src/Parsers/FunctionParameterValuesVisitor.cpp
@@ -18,10 +18,18 @@ namespace DB
 /// Collects the `parameter = value` assignments of a parameterized-view call.
 ///
 /// Only the top-level arguments of the call are inspected, and only those that are genuine
-/// `identifier = <constant expression>` assignments. This mirrors the query-tree collector in
-/// `QueryAnalyzer::resolveTableFunction`, so the legacy-AST and analyzer paths bind exactly the
-/// same set of parameters. An argument of any other shape binds nothing, which leaves the
-/// parameter unset and makes `ReplaceQueryParameterVisitor` report `UNKNOWN_QUERY_PARAMETER`.
+/// `identifier = <constant expression>` assignments. The accepted argument SHAPES mirror the
+/// query-tree collector in `QueryAnalyzer::resolveTableFunction`, so a positional argument, a
+/// non-`equals` function or an assignment nested inside another expression binds nothing on
+/// either path. An argument of any other shape is ignored, which leaves the parameter unset;
+/// `ReplaceQueryParameterVisitor` then reports `UNKNOWN_QUERY_PARAMETER`, except for a
+/// `Nullable` parameter, which it substitutes as `NULL`.
+///
+/// Value ACCEPTANCE is not identical to the analyzer's: here the value must already be a
+/// literal, function call or subquery, while the analyzer resolves the value node and accepts
+/// anything that folds to a constant (e.g. a `WITH` alias). That difference is pre-existing
+/// and out of scope; both of its current verdicts are pinned in
+/// `04648_parameterized_view_non_equals_argument.sql`.
 NameToNameMap analyzeFunctionParamValues(const ASTPtr & ast, ContextPtr context)
 {
     NameToNameMap parameter_values;

--- a/src/Parsers/FunctionParameterValuesVisitor.cpp
+++ b/src/Parsers/FunctionParameterValuesVisitor.cpp
@@ -15,74 +15,58 @@
 namespace DB
 {
 
-class FunctionParameterValuesVisitor
+/// Collects the `parameter = value` assignments of a parameterized-view call.
+///
+/// Only the top-level arguments of the call are inspected, and only those that are genuine
+/// `identifier = <constant expression>` assignments. This mirrors the query-tree collector in
+/// `QueryAnalyzer::resolveTableFunction`, so the legacy-AST and analyzer paths bind exactly the
+/// same set of parameters. An argument of any other shape binds nothing, which leaves the
+/// parameter unset and makes `ReplaceQueryParameterVisitor` report `UNKNOWN_QUERY_PARAMETER`.
+NameToNameMap analyzeFunctionParamValues(const ASTPtr & ast, ContextPtr context)
 {
-public:
-    explicit FunctionParameterValuesVisitor(NameToNameMap & parameter_values_, ContextPtr context_)
-        : parameter_values(parameter_values_)
-         , context(context_)
+    NameToNameMap parameter_values;
+
+    const auto * view_call = ast->as<ASTFunction>();
+    if (!view_call || !view_call->arguments)
+        return parameter_values;
+
+    const auto * call_arguments = view_call->arguments->as<ASTExpressionList>();
+    if (!call_arguments)
+        return parameter_values;
+
+    for (const auto & argument : call_arguments->children)
     {
-    }
+        /// Key on `arguments` rather than on `children`: a parametric spelling such as
+        /// `equals(7)(name, 'a')` keeps its parameters in a separate child, and the analyzer
+        /// accepts it, so a child-count test would reject it and re-introduce a divergence.
+        const auto * assignment = argument->as<ASTFunction>();
+        if (!assignment || assignment->name != "equals" || !assignment->arguments)
+            continue;
 
-    void visit(const ASTPtr & ast)
-    {
-        if (const auto * function = ast->as<ASTFunction>())
-        {
-            /// A recognized `parameter = value` assignment consumes the whole subtree: the value
-            /// expression must not be descended into, otherwise an inner predicate that happens to
-            /// reference the same parameter name (e.g. a subquery `... WHERE p = 1`) would overwrite
-            /// the collected value.
-            if (visitFunction(*function))
-                return;
-        }
-        for (const auto & child : ast->children)
-            visit(child);
-    }
+        const auto * assignment_arguments = assignment->arguments->as<ASTExpressionList>();
+        if (!assignment_arguments || assignment_arguments->children.size() != 2)
+            continue;
 
-private:
-    NameToNameMap & parameter_values;
-    ContextPtr context;
-
-    /// Returns true if this function is a `parameter = value` assignment that was collected.
-    bool visitFunction(const ASTFunction & parameter_function)
-    {
-        if (parameter_function.name != "equals" && parameter_function.children.size() != 1)
-            return false;
-
-        const auto * expression_list = parameter_function.children[0]->as<ASTExpressionList>();
-
-        if (!expression_list || expression_list->children.size() != 2)
-            return false;
-
-        const auto * identifier = expression_list->children[0]->as<ASTIdentifier>();
+        const auto * identifier = assignment_arguments->children[0]->as<ASTIdentifier>();
         if (!identifier)
-            return false;
+            continue;
 
-        const ASTPtr & value = expression_list->children[1];
+        const ASTPtr & value = assignment_arguments->children[1];
+        if (!value->as<ASTLiteral>() && !value->as<ASTFunction>() && !value->as<ASTSubquery>())
+            continue;
 
         /// Evaluate the value to a constant and serialize it with its own data type so the result
         /// is text-escaped the way `ReplaceQueryParameterVisitor` expects (it reads the value back
         /// with `deserializeTextEscaped`). This mirrors the analyzer counterpart in `QueryAnalyzer`,
         /// which likewise has no separate literal path.
-        if (value->as<ASTLiteral>() || value->as<ASTFunction>() || value->as<ASTSubquery>())
-        {
-            auto [field, type] = evaluateConstantExpression(value, context);
-            auto column = type->createColumn();
-            column->insert(field);
-            WriteBufferFromOwnString buffer;
-            type->getDefaultSerialization()->serializeTextEscaped(*column, 0, buffer, {});
-            parameter_values[identifier->name()] = buffer.str();
-            return true;
-        }
-
-        return false;
+        auto [field, type] = evaluateConstantExpression(value, context);
+        auto column = type->createColumn();
+        column->insert(field);
+        WriteBufferFromOwnString buffer;
+        type->getDefaultSerialization()->serializeTextEscaped(*column, 0, buffer, {});
+        parameter_values[identifier->name()] = buffer.str();
     }
-};
 
-NameToNameMap analyzeFunctionParamValues(const ASTPtr & ast, ContextPtr context)
-{
-    NameToNameMap parameter_values;
-    FunctionParameterValuesVisitor(parameter_values, context).visit(ast);
     return parameter_values;
 }
 

--- a/tests/queries/0_stateless/04648_parameterized_view_non_equals_argument.reference
+++ b/tests/queries/0_stateless/04648_parameterized_view_non_equals_argument.reference
@@ -1,0 +1,38 @@
+positive controls
+a	1
+a	1
+a	1
+a	1
+a	1
+a	1
+a	1
+a	1
+a	1
+a	1
+a	1
+a	1
+b	2
+b	2
+non-equals arguments
+positional arguments
+nested assignments
+already rejected before
+with alias right-hand side
+a	1
+explain syntax
+SELECT *
+FROM
+(
+    SELECT *
+    FROM default.`04648_t`
+    WHERE equals(name, \'a\')
+) AS `04648_pv`
+SETTINGS enable_analyzer = 1
+SELECT *
+FROM
+(
+    SELECT *
+    FROM default.`04648_t`
+    WHERE equals(name, \'a\')
+) AS `04648_pv`
+SETTINGS enable_analyzer = 1

--- a/tests/queries/0_stateless/04648_parameterized_view_non_equals_argument.sql
+++ b/tests/queries/0_stateless/04648_parameterized_view_non_equals_argument.sql
@@ -1,0 +1,113 @@
+-- A parameterized-view parameter must be bound only by a top-level
+-- `identifier = <constant expression>` argument of the view call, identically on the
+-- legacy-AST path (`enable_analyzer = 0`, `EXPLAIN SYNTAX`) and on the query-tree path.
+-- Every statement pins `enable_analyzer` explicitly, because the `old analyzer` CI jobs
+-- link `users.d/analyzer.xml` and would otherwise make the convergence rows vacuous.
+
+DROP TABLE IF EXISTS 04648_t;
+DROP VIEW IF EXISTS 04648_pv;
+DROP VIEW IF EXISTS 04648_pv2;
+
+CREATE TABLE 04648_t (name String, x UInt32) ENGINE = Memory;
+INSERT INTO 04648_t VALUES ('a', 1), ('b', 2), ('!', 9);
+CREATE VIEW 04648_pv AS SELECT * FROM 04648_t WHERE name = {name:String};
+CREATE VIEW 04648_pv2 AS SELECT * FROM 04648_t WHERE name = {name:String} AND x = {xx:UInt32};
+
+SELECT 'positive controls';
+
+-- A genuine assignment binds the parameter, in every accepted spelling.
+SELECT * FROM 04648_pv(name = 'a') SETTINGS enable_analyzer = 0;
+SELECT * FROM 04648_pv(name = 'a') SETTINGS enable_analyzer = 1;
+SELECT * FROM 04648_pv(equals(name, 'a')) SETTINGS enable_analyzer = 0;
+SELECT * FROM 04648_pv(equals(name, 'a')) SETTINGS enable_analyzer = 1;
+
+-- A parametric spelling keeps its parameters in a separate child of the `ASTFunction`, so
+-- the shape check must key on `arguments`, not on the child count. Both paths accept it.
+SELECT * FROM 04648_pv(equals(7)(name, 'a')) SETTINGS enable_analyzer = 0;
+SELECT * FROM 04648_pv(equals(7)(name, 'a')) SETTINGS enable_analyzer = 1;
+
+-- Several assignments, and non-literal constant right-hand sides.
+SELECT * FROM 04648_pv2(name = 'a', xx = 1) SETTINGS enable_analyzer = 0;
+SELECT * FROM 04648_pv2(name = 'a', xx = 1) SETTINGS enable_analyzer = 1;
+SELECT * FROM 04648_pv(name = (SELECT 'a')) SETTINGS enable_analyzer = 0;
+SELECT * FROM 04648_pv(name = (SELECT 'a')) SETTINGS enable_analyzer = 1;
+SELECT * FROM 04648_pv(name = CAST('a', 'String')) SETTINGS enable_analyzer = 0;
+SELECT * FROM 04648_pv(name = CAST('a', 'String')) SETTINGS enable_analyzer = 1;
+
+-- The last assignment to the same parameter wins, on both paths.
+SELECT * FROM 04648_pv(name = 'a', name = 'b') SETTINGS enable_analyzer = 0;
+SELECT * FROM 04648_pv(name = 'a', name = 'b') SETTINGS enable_analyzer = 1;
+
+SELECT 'non-equals arguments';
+
+-- A non-`equals` function argument is not an assignment: it must not bind the parameter
+-- from its own second argument. `concat` used to bind `name = '!'` on the legacy path.
+SELECT * FROM 04648_pv(concat(name, '!')) SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(concat(name, '!')) SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(name != 'a') SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(name != 'a') SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(name > 'a') SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(name > 'a') SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(name + 1) SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(name + 1) SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+
+-- Function names are case sensitive here: only the canonical `equals` is an assignment.
+SELECT * FROM 04648_pv(EQUALS(name, 'a')) SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(EQUALS(name, 'a')) SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+
+SELECT 'positional arguments';
+
+-- A positional call has no assignment at all: the view call's own argument list used to be
+-- read as if it were an `equals` argument list, binding `name = 'a'` on the legacy path.
+SELECT * FROM 04648_pv(name, 'a') SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(name, 'a') SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv2(name = 'a', concat(xx, 'q')) SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv2(name = 'a', concat(xx, 'q')) SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+
+SELECT 'nested assignments';
+
+-- An assignment nested inside a rejected argument must not be collected either: only the
+-- top-level arguments of the view call are inspected.
+SELECT * FROM 04648_pv((name = 'a') AND 1) SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv((name = 'a') AND 1) SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(tuple(name = 'a')) SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(tuple(name = 'a')) SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(if(1, name = 'a', name = 'b')) SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(if(1, name = 'a', name = 'b')) SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+
+SELECT 'already rejected before';
+
+-- Shapes that both paths already rejected, pinned as unchanged.
+SELECT * FROM 04648_pv() SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv() SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(equals()) SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(equals()) SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(other = 1) SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(other = 1) SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv('a' = name) SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv('a' = name) SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(04648_t.name = 'a') SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SELECT * FROM 04648_pv(04648_t.name = 'a') SETTINGS enable_analyzer = 1; -- { serverError UNKNOWN_QUERY_PARAMETER }
+
+SELECT 'with alias right-hand side';
+
+-- PRE-EXISTING and out of scope: the legacy path cannot evaluate a `WITH` alias to a
+-- constant, so this diverges for a reason unrelated to argument-shape validation
+-- (constant-expression evaluation). Pinned here as unchanged.
+WITH 'a' AS s SELECT * FROM 04648_pv(name = s) SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_QUERY_PARAMETER }
+WITH 'a' AS s SELECT * FROM 04648_pv(name = s) SETTINGS enable_analyzer = 1;
+
+SELECT 'explain syntax';
+
+-- `EXPLAIN SYNTAX` reaches the same collector, so it must stop rendering a plan that
+-- execution refuses to run. These reject identically under both analyzers; the accepted
+-- rows are pinned because the two analyzers render the projection list differently.
+EXPLAIN SYNTAX SELECT * FROM 04648_pv(concat(name, '!')); -- { serverError UNKNOWN_QUERY_PARAMETER }
+EXPLAIN SYNTAX SELECT * FROM 04648_pv(name, 'a'); -- { serverError UNKNOWN_QUERY_PARAMETER }
+EXPLAIN SYNTAX SELECT * FROM 04648_pv(tuple(name = 'a')); -- { serverError UNKNOWN_QUERY_PARAMETER }
+EXPLAIN SYNTAX SELECT * FROM 04648_pv(name = 'a') SETTINGS enable_analyzer = 1;
+EXPLAIN SYNTAX SELECT * FROM 04648_pv(equals(7)(name, 'a')) SETTINGS enable_analyzer = 1;
+
+DROP VIEW 04648_pv2;
+DROP VIEW 04648_pv;
+DROP TABLE 04648_t;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/111790


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes wrong results when a parameterized view is called with an argument that is not a `parameter = value` assignment. With `enable_analyzer = 0`, and in `EXPLAIN SYNTAX` at default settings, calls such as `pv(concat(name, '!'))`, `pv(name, 'a')`, `pv(name != 'a')` and `pv(tuple(name = 'a'))` silently bound a view parameter to an unrelated expression instead of reporting `UNKNOWN_QUERY_PARAMETER` as the analyzer does. Such calls are now rejected identically on both execution paths.

### Description

`analyzeFunctionParamValues` in `src/Parsers/FunctionParameterValuesVisitor.cpp` is the legacy-AST parameterized-view parameter collector. It is reached from `Context::executeTableFunction` (execution at `enable_analyzer = 0`) and from `InterpreterExplainQuery`'s `ExpandParameterizedViewsMatcher` (`EXPLAIN SYNTAX`, **at default settings**). The query-tree collector in `QueryAnalyzer::resolveTableFunction` accepts only genuine `equals` assignments among the *top-level* arguments of the view call, so the two paths diverged: on the legacy paths a bogus argument silently satisfied or overrode a parameter and the view returned wrong rows, while the analyzer rejected the same query with `UNKNOWN_QUERY_PARAMETER`.

**Two independent mechanisms produced the divergence.**

The outer guard read `if (parameter_function.name != "equals" && parameter_function.children.size() != 1) return false;`. It rejects only when the name is not `equals` *and* the child count is not 1, and every ordinary parsed function has exactly one child (its `arguments` list), so the second conjunct was always false and the name check never fired. Two consequences followed: a non-`equals` binary function such as `concat(name, '!')` was read as `name = '!'`; and the **view call itself** was not rejected either, so for a positional call `pv(name, 'a')` the view's own argument list was read as if it were an `equals` argument list, binding `name = 'a'`.

Separately, the visitor recursed into every child of a rejected node, so a nested well-formed assignment was still collected: `pv(tuple(name = 'a'))`, `pv((name = 'a') AND 1)` and `pv(if(1, name = 'a', name = 'b'))` all bound a parameter. Correcting the guard alone does not close this.

**The fix** replaces the free recursion and the broken guard with an explicit walk that mirrors the analyzer: iterate the top-level arguments of the view call, and accept an argument only when it is an `ASTFunction` named `equals` whose `arguments` list holds exactly two children, the first an `ASTIdentifier` and the second a constant expression. Any other argument shape binds nothing, which leaves the parameter unset and gives it exactly the treatment the analyzer path already gives it. The value-serialization branch is unchanged.

The shape check deliberately keys on `ASTFunction::arguments` rather than on `children[0]` / `children.size()`. A parametric spelling `equals(7)(name, 'a')` stores its parameters as a *second* child (`ASTFunction.h`, `addParametersToAggregateFunction`) and is accepted on **both** paths today, so a child-count test would make the legacy path start rejecting it: a fresh divergence in the opposite direction. Three positive controls in the new test pin that shape, two of which run through this collector, and the mutation matrix below confirms those two are the only rows a child-count implementation breaks (the third is served by the query-tree collector and is insensitive to any change here).

**Behavior change.** Argument spellings that are not assignments now leave the parameter unset on the legacy path and in `EXPLAIN SYNTAX`, where they were previously accepted, so the query raises `UNKNOWN_QUERY_PARAMETER` (or, for a `Nullable` parameter, substitutes `NULL`, exactly as on the analyzer path). That is the point of the change: it aligns those paths with the default-settings analyzer behavior, and the documented `pv(param = value)` spelling has always worked on both. No setting default moves, so no `SettingsChangesHistory.cpp` entry is needed (that file tracks `Settings` only, and this PR touches nothing under `src/Core/`). No serialization, format or protocol change.

**Out of scope, pinned as unchanged.** `WITH 'a' AS s SELECT * FROM pv(name = s)` also diverges (`UNKNOWN_QUERY_PARAMETER` at `enable_analyzer = 0`, correct rows at `= 1`), but for an unrelated reason: the legacy path cannot evaluate a `WITH` alias to a constant. That is constant-expression *evaluation*, not argument-shape *validation*, and the new test asserts both of its current verdicts so the behavior is not silently changed here.

**Verification.** Debug build, Build ID `53b7b30946688c2b1425ff81ba7fbd7098dc8319`; base measurements on the pristine master snapshot, Build ID `9ebd11fe9bc8d54774fc02e726da1a5923b741c0` (byte-identical `FunctionParameterValuesVisitor.cpp`, `QueryAnalyzer.cpp`, `Context.cpp`, `InterpreterExplainQuery.cpp` and `StorageView.cpp` to `origin/master`). The head commit adds a comment-only edit on top of the measured commit and so builds to `a4bfa6f1ed8481848c71881abc184e3821981243`; the comment-stripped source hash is identical for the two, and the new test was re-run on the rebuilt binary.

Both directions, driven statement by statement against a server of each binary: the new test's 68 statements produce **13 failures on pristine master and 0 with the fix**. The 13 are the four non-`equals` binary/unary shapes, the uppercase `EQUALS` spelling, the two positional shapes, the three nested-assignment shapes and the three `EXPLAIN SYNTAX` shapes.

Mutation matrix (predictions written before building each mutant; all three matched exactly):

| mutant | predicted | measured |
|---|---|---|
| restore the free recursion | only the 3 nested-assignment rows regress | exactly those 3 |
| drop the `equals`-name check | the 4 non-`equals` shapes plus their `EXPLAIN SYNTAX` row regress | exactly those 5 |
| key on `children[0]`/`children.size()` (the naive guard flip) | only the 2 parametric-`equals` rows regress | exactly those 2 |

The matrix shows the two halves of the fix are each load-bearing, and for *different* rows: the `equals`-name check closes the non-`equals` functions, while the top-level-only walk closes the positional and nested shapes. Restoring the source after the matrix rebuilt to the bit-identical Build ID.

50 randomized runs of the new test: 50/50 pass.

Existing-test blast radius. First, a static sweep of all of `tests/`, functional and integration: every view created with a `{parameter:Type}` placeholder is located, then every top-level argument of every call of that view name that is not an `identifier = ...` assignment. Outside the new test itself there are exactly **three** such arguments tree-wide, and all three are `numbers(3)`, `numbers(10)` and `numbers(100)` in `04105_explain_syntax_parameterized_view`, where `numbers` is a registered table function and takes precedence over the same-named view before this collector is reached (that precedence is itself asserted by `04105`). `02428_parameterized_view`'s `SELECT * FROM test_02428_mv1(test)` is a call on a MATERIALIZED view, whose reference already expects `ERROR`, and it was additionally checked on both binaries and still reports `ERROR`. In the integration suite only `test_parameterized_view` defines a placeholder view, and every call there is a `name = value` assignment. So no existing `.reference` can change.

Second, executed: the 26 pre-existing stateless tests whose sources mention `parameterized`/`parametrized` were run on both binaries and produced **identical failure sets**: 25 pass, and `02428_parameterized_view` fails on both with a `ReplicatedMergeTree` async-insert timeout against a bare local server (an environment limitation, not a regression).