### PR TITLE
Fix unreadable persisted metadata for `substr`/`mid`/`byteSlice`

### DIFF
--- a/src/Interpreters/FunctionNameNormalizer.cpp
+++ b/src/Interpreters/FunctionNameNormalizer.cpp
@@ -11,6 +11,39 @@
 namespace DB
 {
 
+namespace
+{
+
+/// True when `canonical_name` re-parses the shape of `node`.
+///
+/// Some names are routed to a dedicated grammar layer (see `getFunctionLayer` in
+/// ExpressionListParsers.cpp) while their aliases take the generic function layer, which
+/// accepts shapes the dedicated layer rejects. Renaming such an alias turns a parseable AST
+/// into one that does not re-parse; the AST is persisted verbatim (view metadata, SQL UDF
+/// bodies), so every later read of it throws SYNTAX_ERROR. Keep the alias in that case.
+///
+/// This is an allowlist of provably re-parseable shapes: an unknown or future shape keeps the
+/// alias, which always re-parses because it takes the generic layer.
+bool canonicalNameCanReparseShape(const String & canonical_name, const ASTFunction & node)
+{
+    /// SubstringLayer accepts `substring(expr, start[, length, ...])` and
+    /// `substring(expr FROM start [FOR length])`, but not fewer than two arguments, nor
+    /// parameters, nor a window clause, nor a NULLS modifier. The aliases `substr`, `mid` and
+    /// `byteSlice` accept all of those.
+    if (canonical_name == "substring")
+        return node.arguments && node.arguments->children.size() >= 2
+            && !node.parameters
+            && !node.isWindowFunction() && node.window_name.empty() && !node.window_definition
+            && node.getNullsAction() == NullsAction::EMPTY;
+
+    /// Any other alias shares its grammar layer with its canonical name, so renaming cannot
+    /// change what re-parses. Add a case here if an alias is registered for another name with
+    /// a dedicated layer (`overlay`, `position`, `cast`, `date_part`, ...).
+    return true;
+}
+
+}
+
 void FunctionNameNormalizer::visit(IAST * ast)
 {
     if (!ast)
@@ -38,7 +71,12 @@ void FunctionNameNormalizer::visit(IAST * ast)
     }
 
     if (auto * node_func = ast->as<ASTFunction>())
-        node_func->name = getAggregateFunctionCanonicalNameIfAny(getFunctionCanonicalNameIfAny(node_func->name));
+    {
+        const String & canonical_name
+            = getAggregateFunctionCanonicalNameIfAny(getFunctionCanonicalNameIfAny(node_func->name));
+        if (canonicalNameCanReparseShape(canonical_name, *node_func))
+            node_func->name = canonical_name;
+    }
 
     for (auto & child : ast->children)
         visit(child.get());

--- a/src/Interpreters/FunctionNameNormalizer.cpp
+++ b/src/Interpreters/FunctionNameNormalizer.cpp
@@ -17,16 +17,16 @@ namespace
 /// True when `canonical_name` re-parses the shape of `node`.
 ///
 /// Some names are routed to a dedicated grammar layer (see `getFunctionLayer` in
-/// ExpressionListParsers.cpp) while their aliases take the generic function layer, which
+/// `ExpressionListParsers.cpp`) while their aliases take the generic function layer, which
 /// accepts shapes the dedicated layer rejects. Renaming such an alias turns a parseable AST
 /// into one that does not re-parse; the AST is persisted verbatim (view metadata, SQL UDF
-/// bodies), so every later read of it throws SYNTAX_ERROR. Keep the alias in that case.
+/// bodies), so every later read of it throws `SYNTAX_ERROR`. Keep the alias in that case.
 ///
 /// This is an allowlist of provably re-parseable shapes: an unknown or future shape keeps the
 /// alias, which always re-parses because it takes the generic layer.
 bool canonicalNameCanReparseShape(const String & canonical_name, const ASTFunction & node)
 {
-    /// SubstringLayer accepts `substring(expr, start[, length, ...])` and
+    /// `SubstringLayer` accepts `substring(expr, start[, length, ...])` and
     /// `substring(expr FROM start [FOR length])`, but not fewer than two arguments, nor
     /// parameters, nor a window clause, nor a NULLS modifier. The aliases `substr`, `mid` and
     /// `byteSlice` accept all of those.

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -2012,8 +2012,10 @@ public:
         /// In the purely functional form, accept further arguments so that a too-long call is
         /// reported by the function as `NUMBER_OF_ARGUMENTS_DOESNT_MATCH` rather than as a
         /// syntax error. `substr`/`mid`/`byteSlice` go through the generic `FunctionLayer` and
-        /// already accept any argument count; DDL normalization rewrites them to `substring`,
-        /// so without this the persisted definition would not re-parse (issue #69141).
+        /// already accept any argument count, so a definition that was persisted after DDL
+        /// normalization rewrote one of them to `substring` (see `canonicalNameCanReparseShape`
+        /// in `FunctionNameNormalizer.cpp`, which now prevents that rewrite) would otherwise
+        /// not re-parse.
         /// Both flags are required: a further comma is accepted only when EVERY separator so
         /// far was a comma, so a form that used the SQL-standard FROM or FOR keyword anywhere
         /// keeps its fixed shape and stays a syntax error, exactly as before this change.

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -1924,7 +1924,8 @@ protected:
 
 class SubstringLayer : public Layer
 {
-    bool comma_mode = false; /// true after the first separator was a comma, i.e. the functional form
+    bool comma_mode = false; /// true when the first separator was a comma
+    bool second_separator_was_comma = false; /// true when the second separator was a comma
 public:
     SubstringLayer() : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true) {}
 
@@ -1936,7 +1937,8 @@ public:
         ///    when a lambda is pending (round-trip for the merged-tuple lambda
         ///    sugar, see issue #104605)
         /// 1: Parse second separator: FOR or comma (-> 2)
-        /// 2: In the functional form, parse further commas (stays at 2)
+        /// 2: Parse further commas, but only when every separator so far was a
+        ///    comma, i.e. in the purely functional form (stays at 2)
         /// 1 or 2: Parse closing bracket (finished)
 
         if (state == 0)
@@ -1987,8 +1989,17 @@ public:
 
         if (state == 1)
         {
-            if (ParserToken(TokenType::Comma).ignore(pos, expected) ||
-                ParserKeyword(Keyword::FOR).ignore(pos, expected))
+            if (ParserToken(TokenType::Comma).ignore(pos, expected))
+            {
+                second_separator_was_comma = true;
+                action = Action::OPERAND;
+
+                if (!mergeElement())
+                    return false;
+
+                state = 2;
+            }
+            else if (ParserKeyword(Keyword::FOR).ignore(pos, expected))
             {
                 action = Action::OPERAND;
 
@@ -1998,13 +2009,15 @@ public:
                 state = 2;
             }
         }
-        /// In the functional form, accept further arguments so that a too-long call is
+        /// In the purely functional form, accept further arguments so that a too-long call is
         /// reported by the function as NUMBER_OF_ARGUMENTS_DOESNT_MATCH rather than as a
         /// syntax error. `substr`/`mid`/`byteSlice` go through the generic FunctionLayer and
         /// already accept any argument count; DDL normalization rewrites them to `substring`,
         /// so without this the persisted definition would not re-parse (issue #69141).
-        /// The SQL-standard FROM/FOR grammar keeps its fixed shape.
-        else if (comma_mode && state == 2)
+        /// Both flags are required: a further comma is accepted only when EVERY separator so
+        /// far was a comma, so a form that used the SQL-standard FROM or FOR keyword anywhere
+        /// keeps its fixed shape and stays a syntax error, exactly as before this change.
+        else if (comma_mode && second_separator_was_comma && state == 2)
         {
             if (ParserToken(TokenType::Comma).ignore(pos, expected))
             {

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -1924,23 +1924,34 @@ protected:
 
 class SubstringLayer : public Layer
 {
+    bool comma_mode = false; /// true after the first separator was a comma, i.e. the functional form
 public:
     SubstringLayer() : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true) {}
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & action) override
     {
-        /// Either SUBSTRING(expr FROM start [FOR length]) or SUBSTRING(expr, start, length)
+        /// Either SUBSTRING(expr FROM start [FOR length]) or SUBSTRING(expr, start, length, ...)
         ///
         /// 0: Parse first separator: FROM or comma (-> 1), or closing bracket
         ///    when a lambda is pending (round-trip for the merged-tuple lambda
         ///    sugar, see issue #104605)
         /// 1: Parse second separator: FOR or comma (-> 2)
+        /// 2: In the functional form, parse further commas (stays at 2)
         /// 1 or 2: Parse closing bracket (finished)
 
         if (state == 0)
         {
-            if (ParserToken(TokenType::Comma).ignore(pos, expected) ||
-                ParserKeyword(Keyword::FROM).ignore(pos, expected))
+            if (ParserToken(TokenType::Comma).ignore(pos, expected))
+            {
+                comma_mode = true;
+                action = Action::OPERAND;
+
+                if (!mergeElement())
+                    return false;
+
+                state = 1;
+            }
+            else if (ParserKeyword(Keyword::FROM).ignore(pos, expected))
             {
                 action = Action::OPERAND;
 
@@ -1985,6 +1996,22 @@ public:
                     return false;
 
                 state = 2;
+            }
+        }
+        /// In the functional form, accept further arguments so that a too-long call is
+        /// reported by the function as NUMBER_OF_ARGUMENTS_DOESNT_MATCH rather than as a
+        /// syntax error. `substr`/`mid`/`byteSlice` go through the generic FunctionLayer and
+        /// already accept any argument count; DDL normalization rewrites them to `substring`,
+        /// so without this the persisted definition would not re-parse (issue #69141).
+        /// The SQL-standard FROM/FOR grammar keeps its fixed shape.
+        else if (comma_mode && state == 2)
+        {
+            if (ParserToken(TokenType::Comma).ignore(pos, expected))
+            {
+                action = Action::OPERAND;
+
+                if (!mergeElement())
+                    return false;
             }
         }
 

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -2010,8 +2010,8 @@ public:
             }
         }
         /// In the purely functional form, accept further arguments so that a too-long call is
-        /// reported by the function as NUMBER_OF_ARGUMENTS_DOESNT_MATCH rather than as a
-        /// syntax error. `substr`/`mid`/`byteSlice` go through the generic FunctionLayer and
+        /// reported by the function as `NUMBER_OF_ARGUMENTS_DOESNT_MATCH` rather than as a
+        /// syntax error. `substr`/`mid`/`byteSlice` go through the generic `FunctionLayer` and
         /// already accept any argument count; DDL normalization rewrites them to `substring`,
         /// so without this the persisted definition would not re-parse (issue #69141).
         /// Both flags are required: a further comma is accepted only when EVERY separator so

--- a/tests/queries/0_stateless/04650_substring_alias_normalization_metadata_roundtrip.reference
+++ b/tests/queries/0_stateless/04650_substring_alias_normalization_metadata_roundtrip.reference
@@ -15,6 +15,8 @@ SELECT substring(a, 2)
 SELECT substr(a, 2, 3)
 SELECT mid(a, 2)
 SELECT byteSlice(a, 2)
+SELECT substring(a, 1, 2)
+SELECT substring(a, 1, 2)
 -- parser: shapes that must keep failing
 -- semantics: all four spellings agree, and a too-long call is a function error
 bcd	bcd	bcd	bcd
@@ -39,6 +41,6 @@ v_sqlstandard	substring
 v_window	substr
 -- view metadata: ATTACH re-reads the file from disk
 attach ok	16
--- SQL UDF body: the definition survives a reload
+-- SQL UDF body: the persisted definition re-parses
 1	CREATE FUNCTION f_default AS a -> substring(a, 1, 2, 3)
 1	CREATE FUNCTION f_default AS a -> substr(a)

--- a/tests/queries/0_stateless/04650_substring_alias_normalization_metadata_roundtrip.reference
+++ b/tests/queries/0_stateless/04650_substring_alias_normalization_metadata_roundtrip.reference
@@ -1,0 +1,44 @@
+-- parser: canonical name accepts the comma form with any argument count
+SELECT substring(a, 1, 2, 3)
+SELECT substring(a, 1, 2, 3, 4)
+SELECT substr(a, 1, 2, 3)
+SELECT mid(a, 1, 2, 3)
+SELECT byteSlice(a, 1, 2, 3)
+-- parser: the metadata text a pre-fix server wrote re-parses
+ATTACH VIEW _ UUID \'00000000-0000-4000-8000-000000000001\' (`x` String) AS SELECT substring(a, 1, 2, 3) FROM (SELECT \'q\' AS a)
+-- parser: formatting is idempotent
+1
+1
+-- parser: the SQL standard form and the alias spelling are untouched
+SELECT substring(a, 2, 3)
+SELECT substring(a, 2)
+SELECT substr(a, 2, 3)
+SELECT mid(a, 2)
+SELECT byteSlice(a, 2)
+-- parser: shapes that must keep failing
+-- semantics: all four spellings agree, and a too-long call is a function error
+bcd	bcd	bcd	bcd
+bcd	bcdef	bcdef
+bcdef	bcdef	bcdef
+-- view metadata: every shape round-trips, and safe shapes still canonicalize
+v_all	substring
+v_arity0	substr
+v_arity1	substr
+v_arity2	substring
+v_arity3	substring
+v_arity4	substring
+v_arity5	substring
+v_byteslice4	substring
+v_canonical4	substring
+v_filter	substrIf
+v_ignore	substr
+v_mid4	substring
+v_params	substr
+v_respect	substr
+v_sqlstandard	substring
+v_window	substr
+-- view metadata: ATTACH re-reads the file from disk
+attach ok	16
+-- SQL UDF body: the definition survives a reload
+1	CREATE FUNCTION f_default AS a -> substring(a, 1, 2, 3)
+1	CREATE FUNCTION f_default AS a -> substr(a)

--- a/tests/queries/0_stateless/04650_substring_alias_normalization_metadata_roundtrip.sh
+++ b/tests/queries/0_stateless/04650_substring_alias_normalization_metadata_roundtrip.sh
@@ -10,15 +10,30 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 FUNC="f_${CLICKHOUSE_DATABASE}"
 VIEWS="v_arity0 v_arity1 v_arity2 v_arity3 v_arity4 v_arity5 v_params v_window v_respect v_ignore v_filter v_all v_mid4 v_byteslice4 v_canonical4 v_sqlstandard"
 
+VIEWS_SQL_LIST=$(for v in $VIEWS; do printf "'%s'," "$v"; done | sed 's/,$//')
+
 # `DROP VIEW` must pin `ignore_drop_queries_probability`: the stress runner injects 0.2, and for a
 # storage whose `storesDataOnDisk` is false (a view) `InterpreterDropQuery` rewrites the DROP to a
 # TRUNCATE, which `StorageView` does not implement, so the statement would fail with
 # `NOT_IMPLEMENTED`. The setting is pinned per statement, not with `SET`, because the runner passes
-# its value as a client option, which beats a session `SET`.
+# its value as a client option, which beats a session `SET`; a statement-level `SETTINGS` clause is
+# applied per statement inside a batch too, so all the DROPs share one client invocation.
 drop_views() {
+    local sql
+    # A view left detached by an attempt that died between DETACH and ATTACH keeps its metadata
+    # file, which `DROP VIEW IF EXISTS` skips (it only sees attached objects) and which makes the
+    # next `CREATE VIEW` fail with `TABLE_ALREADY_EXISTS ... (detached)`, so reattach those first.
+    # `ATTACH TABLE IF NOT EXISTS` cannot be used unconditionally: it throws when there is no
+    # metadata at all.
+    sql=$($CLICKHOUSE_CLIENT -q "
+SELECT 'ATTACH TABLE ' || table || ';'
+FROM system.detached_tables
+WHERE database = currentDatabase() AND table IN (${VIEWS_SQL_LIST})
+")
     for v in $VIEWS; do
-        $CLICKHOUSE_CLIENT -q "DROP VIEW IF EXISTS $v SETTINGS ignore_drop_queries_probability = 0"
+        sql+="DROP VIEW IF EXISTS $v SETTINGS ignore_drop_queries_probability = 0; "
     done
+    $CLICKHOUSE_CLIENT -q "$sql"
 }
 
 $CLICKHOUSE_CLIENT -q "SELECT '-- parser: canonical name accepts the comma form with any argument count'"

--- a/tests/queries/0_stateless/04650_substring_alias_normalization_metadata_roundtrip.sh
+++ b/tests/queries/0_stateless/04650_substring_alias_normalization_metadata_roundtrip.sh
@@ -149,7 +149,7 @@ SELECT 'attach ok', count() FROM system.tables WHERE database = currentDatabase(
 # row that does not error proves the persisted definition re-parses. Limitation: the
 # load-from-disk path, where an unparseable body is silently dropped, needs a fresh process and is
 # not asserted here. The reference records `f_default` because `tests/clickhouse-test` rewrites the
-# randomized database name to `default` in stdout — the function is created as `f_${CLICKHOUSE_DATABASE}`.
+# randomized database name to `default` in stdout - the function is created as `f_${CLICKHOUSE_DATABASE}`.
 $CLICKHOUSE_CLIENT -q "SELECT '-- SQL UDF body: the persisted definition re-parses'"
 $CLICKHOUSE_CLIENT -q "
 DROP FUNCTION IF EXISTS ${FUNC};

--- a/tests/queries/0_stateless/04650_substring_alias_normalization_metadata_roundtrip.sh
+++ b/tests/queries/0_stateless/04650_substring_alias_normalization_metadata_roundtrip.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# `substr`/`mid`/`byteSlice` are aliases of `substring` but are parsed by the generic function
+# layer, so they accept shapes `SubstringLayer` rejects. DDL normalization renamed them to
+# `substring`, and the persisted definition then did not re-parse.
+FUNC="f_${CLICKHOUSE_DATABASE}"
+
+$CLICKHOUSE_CLIENT -q "SELECT '-- parser: canonical name accepts the comma form with any argument count'"
+$CLICKHOUSE_CLIENT -q "
+SELECT formatQuerySingleLine('SELECT substring(a, 1, 2, 3)');
+SELECT formatQuerySingleLine('SELECT substring(a, 1, 2, 3, 4)');
+SELECT formatQuerySingleLine('SELECT substr(a, 1, 2, 3)');
+SELECT formatQuerySingleLine('SELECT mid(a, 1, 2, 3)');
+SELECT formatQuerySingleLine('SELECT byteSlice(a, 1, 2, 3)');
+"
+
+$CLICKHOUSE_CLIENT -q "SELECT '-- parser: the metadata text a pre-fix server wrote re-parses'"
+$CLICKHOUSE_CLIENT -q "
+SELECT formatQuerySingleLine(\$\$ATTACH VIEW _ UUID '00000000-0000-4000-8000-000000000001' (\`x\` String) AS SELECT substring(a, 1, 2, 3) FROM (SELECT 'q' AS a)\$\$);
+"
+
+$CLICKHOUSE_CLIENT -q "SELECT '-- parser: formatting is idempotent'"
+$CLICKHOUSE_CLIENT -q "
+SELECT formatQuerySingleLine(formatQuerySingleLine('SELECT substring(a, 1, 2, 3)')) = formatQuerySingleLine('SELECT substring(a, 1, 2, 3)');
+SELECT formatQuerySingleLine(formatQuerySingleLine('SELECT substr(a, 1, 2, 3)')) = formatQuerySingleLine('SELECT substr(a, 1, 2, 3)');
+"
+
+$CLICKHOUSE_CLIENT -q "SELECT '-- parser: the SQL standard form and the alias spelling are untouched'"
+$CLICKHOUSE_CLIENT -q "
+SELECT formatQuerySingleLine('SELECT substring(a FROM 2 FOR 3)');
+SELECT formatQuerySingleLine('SELECT substring(a FROM 2)');
+SELECT formatQuerySingleLine('SELECT substr(a, 2, 3)');
+SELECT formatQuerySingleLine('SELECT mid(a, 2)');
+SELECT formatQuerySingleLine('SELECT byteSlice(a, 2)');
+"
+
+# A trailing comma, a mixed FROM/FOR + comma form and fewer than two arguments must stay parse
+# errors for the canonical name; `02154_parser_backtracking` relies on the last one. Asserted
+# through a server-side parse because the runner aborts a batch on a top-level SYNTAX_ERROR.
+$CLICKHOUSE_CLIENT -q "SELECT '-- parser: shapes that must keep failing'"
+$CLICKHOUSE_CLIENT -q "
+SELECT formatQuerySingleLine('SELECT substring(a)'); -- { serverError SYNTAX_ERROR }
+"
+$CLICKHOUSE_CLIENT -q "
+SELECT formatQuerySingleLine('SELECT substring()'); -- { serverError SYNTAX_ERROR }
+"
+$CLICKHOUSE_CLIENT -q "
+SELECT formatQuerySingleLine('SELECT substring(a, 1,)'); -- { serverError SYNTAX_ERROR }
+"
+$CLICKHOUSE_CLIENT -q "
+SELECT formatQuerySingleLine('SELECT substring(a FROM 1 FOR 2, 3)'); -- { serverError SYNTAX_ERROR }
+"
+
+$CLICKHOUSE_CLIENT -q "SELECT '-- semantics: all four spellings agree, and a too-long call is a function error'"
+$CLICKHOUSE_CLIENT -q "
+SELECT substring('abcdef', 2, 3), substr('abcdef', 2, 3), mid('abcdef', 2, 3), byteSlice('abcdef', 2, 3);
+SELECT substring('abcdef' FROM 2 FOR 3), substring('abcdef' FROM 2), substring('abcdef', 2);
+SELECT substr(ALL 'abcdef', 2), mid(ALL 'abcdef', 2), byteSlice(ALL 'abcdef', 2);
+"
+$CLICKHOUSE_CLIENT -q "SELECT substring('abcdef', 2, 3, 4); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }"
+$CLICKHOUSE_CLIENT -q "SELECT substr('abcdef', 2, 3, 4); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }"
+$CLICKHOUSE_CLIENT -q "SELECT substr('abcdef'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }"
+$CLICKHOUSE_CLIENT -q "SELECT substr(1)('abcdef', 2); -- { serverError FUNCTION_CANNOT_HAVE_PARAMETERS }"
+
+# `create_table_query` is produced by re-parsing the metadata file, so a non-empty value proves
+# the persisted definition round-trips. It is empty (not an error) when the parse fails.
+$CLICKHOUSE_CLIENT -q "SELECT '-- view metadata: every shape round-trips, and safe shapes still canonicalize'"
+$CLICKHOUSE_CLIENT -q "
+CREATE VIEW v_arity0 (x String) AS SELECT substr() FROM (SELECT 'abc' AS a);
+CREATE VIEW v_arity1 (x String) AS SELECT substr(a) FROM (SELECT 'abc' AS a);
+CREATE VIEW v_arity2 (x String) AS SELECT substr(a, 1) FROM (SELECT 'abc' AS a);
+CREATE VIEW v_arity3 (x String) AS SELECT substr(a, 1, 2) FROM (SELECT 'abc' AS a);
+CREATE VIEW v_arity4 (x String) AS SELECT substr(a, 1, 2, 3) FROM (SELECT 'abc' AS a);
+CREATE VIEW v_arity5 (x String) AS SELECT substr(a, 1, 2, 3, 4) FROM (SELECT 'abc' AS a);
+CREATE VIEW v_params (x String) AS SELECT substr(1)(a, 2) FROM (SELECT 'abc' AS a);
+CREATE VIEW v_window (x String) AS SELECT substr(a, 1) OVER () FROM (SELECT 'abc' AS a);
+CREATE VIEW v_respect (x String) AS SELECT substr(a, 1) RESPECT NULLS FROM (SELECT 'abc' AS a);
+CREATE VIEW v_ignore (x String) AS SELECT substr(a, 1) IGNORE NULLS FROM (SELECT 'abc' AS a);
+CREATE VIEW v_filter (x String) AS SELECT substr(a, 1) FILTER (WHERE 1) FROM (SELECT 'abc' AS a);
+CREATE VIEW v_all (x String) AS SELECT substr(ALL a, 1) FROM (SELECT 'abc' AS a);
+CREATE VIEW v_mid4 (x String) AS SELECT mid(a, 1, 2, 3) FROM (SELECT 'abc' AS a);
+CREATE VIEW v_byteslice4 (x String) AS SELECT byteSlice(a, 1, 2, 3) FROM (SELECT 'abc' AS a);
+CREATE VIEW v_canonical4 (x String) AS SELECT substring(a, 1, 2, 3) FROM (SELECT 'abc' AS a);
+CREATE VIEW v_sqlstandard (x String) AS SELECT substring(a FROM 1 FOR 2) FROM (SELECT 'abc' AS a);
+SELECT name, extract(create_table_query, '(substring|substr|mid|byteSlice|substrIf)\(') AS persisted_name
+FROM system.tables WHERE database = currentDatabase() AND name LIKE 'v\_%' ORDER BY name;
+"
+
+$CLICKHOUSE_CLIENT -q "SELECT '-- view metadata: ATTACH re-reads the file from disk'"
+$CLICKHOUSE_CLIENT -q "
+DETACH TABLE v_arity0; ATTACH TABLE v_arity0;
+DETACH TABLE v_arity1; ATTACH TABLE v_arity1;
+DETACH TABLE v_arity4; ATTACH TABLE v_arity4;
+DETACH TABLE v_params; ATTACH TABLE v_params;
+DETACH TABLE v_window; ATTACH TABLE v_window;
+DETACH TABLE v_respect; ATTACH TABLE v_respect;
+DETACH TABLE v_ignore; ATTACH TABLE v_ignore;
+DETACH TABLE v_canonical4; ATTACH TABLE v_canonical4;
+SELECT 'attach ok', count() FROM system.tables WHERE database = currentDatabase() AND name LIKE 'v\_%';
+"
+
+$CLICKHOUSE_CLIENT -q "SELECT '-- SQL UDF body: the definition survives a reload'"
+$CLICKHOUSE_CLIENT -q "
+DROP FUNCTION IF EXISTS ${FUNC};
+CREATE FUNCTION ${FUNC} AS (a) -> substr(a, 1, 2, 3);
+SYSTEM RELOAD FUNCTIONS;
+SELECT count(), formatQuerySingleLine(create_query) FROM system.functions WHERE name = '${FUNC}' GROUP BY create_query;
+DROP FUNCTION ${FUNC};
+"
+$CLICKHOUSE_CLIENT -q "
+CREATE FUNCTION ${FUNC} AS (a) -> substr(a);
+SYSTEM RELOAD FUNCTIONS;
+SELECT count(), formatQuerySingleLine(create_query) FROM system.functions WHERE name = '${FUNC}' GROUP BY create_query;
+DROP FUNCTION ${FUNC};
+"

--- a/tests/queries/0_stateless/04650_substring_alias_normalization_metadata_roundtrip.sh
+++ b/tests/queries/0_stateless/04650_substring_alias_normalization_metadata_roundtrip.sh
@@ -8,6 +8,18 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # layer, so they accept shapes `SubstringLayer` rejects. DDL normalization renamed them to
 # `substring`, and the persisted definition then did not re-parse.
 FUNC="f_${CLICKHOUSE_DATABASE}"
+VIEWS="v_arity0 v_arity1 v_arity2 v_arity3 v_arity4 v_arity5 v_params v_window v_respect v_ignore v_filter v_all v_mid4 v_byteslice4 v_canonical4 v_sqlstandard"
+
+# `DROP VIEW` must pin `ignore_drop_queries_probability`: the stress runner injects 0.2, and for a
+# storage whose `storesDataOnDisk` is false (a view) `InterpreterDropQuery` rewrites the DROP to a
+# TRUNCATE, which `StorageView` does not implement, so the statement would fail with
+# `NOT_IMPLEMENTED`. The setting is pinned per statement, not with `SET`, because the runner passes
+# its value as a client option, which beats a session `SET`.
+drop_views() {
+    for v in $VIEWS; do
+        $CLICKHOUSE_CLIENT -q "DROP VIEW IF EXISTS $v SETTINGS ignore_drop_queries_probability = 0"
+    done
+}
 
 $CLICKHOUSE_CLIENT -q "SELECT '-- parser: canonical name accepts the comma form with any argument count'"
 $CLICKHOUSE_CLIENT -q "
@@ -79,6 +91,7 @@ $CLICKHOUSE_CLIENT -q "SELECT substr('abcdef', 2, 3, 4); -- { serverError NUMBER
 $CLICKHOUSE_CLIENT -q "SELECT substr('abcdef'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }"
 $CLICKHOUSE_CLIENT -q "SELECT substr(1)('abcdef', 2); -- { serverError FUNCTION_CANNOT_HAVE_PARAMETERS }"
 
+drop_views
 # `create_table_query` is produced by re-parsing the metadata file, so a non-empty value proves
 # the persisted definition round-trips. It is empty (not an error) when the parse fails.
 $CLICKHOUSE_CLIENT -q "SELECT '-- view metadata: every shape round-trips, and safe shapes still canonicalize'"
@@ -134,3 +147,6 @@ CREATE FUNCTION ${FUNC} AS (a) -> substr(a);
 SELECT count(), formatQuerySingleLine(create_query) FROM system.functions WHERE name = '${FUNC}' GROUP BY create_query;
 DROP FUNCTION ${FUNC};
 "
+
+drop_views
+$CLICKHOUSE_CLIENT -q "DROP FUNCTION IF EXISTS ${FUNC}"

--- a/tests/queries/0_stateless/04650_substring_alias_normalization_metadata_roundtrip.sh
+++ b/tests/queries/0_stateless/04650_substring_alias_normalization_metadata_roundtrip.sh
@@ -29,6 +29,8 @@ SELECT formatQuerySingleLine(formatQuerySingleLine('SELECT substring(a, 1, 2, 3)
 SELECT formatQuerySingleLine(formatQuerySingleLine('SELECT substr(a, 1, 2, 3)')) = formatQuerySingleLine('SELECT substr(a, 1, 2, 3)');
 "
 
+# The last two rows are three-argument mixed forms that the canonical name already accepted
+# before this change; they are pinned here so that tightening them cannot land silently.
 $CLICKHOUSE_CLIENT -q "SELECT '-- parser: the SQL standard form and the alias spelling are untouched'"
 $CLICKHOUSE_CLIENT -q "
 SELECT formatQuerySingleLine('SELECT substring(a FROM 2 FOR 3)');
@@ -36,11 +38,16 @@ SELECT formatQuerySingleLine('SELECT substring(a FROM 2)');
 SELECT formatQuerySingleLine('SELECT substr(a, 2, 3)');
 SELECT formatQuerySingleLine('SELECT mid(a, 2)');
 SELECT formatQuerySingleLine('SELECT byteSlice(a, 2)');
+SELECT formatQuerySingleLine('SELECT substring(a, 1 FOR 2)');
+SELECT formatQuerySingleLine('SELECT substring(a FROM 1, 2)');
 "
 
-# A trailing comma, a mixed FROM/FOR + comma form and fewer than two arguments must stay parse
-# errors for the canonical name; `02154_parser_backtracking` relies on the last one. Asserted
-# through a server-side parse because the runner aborts a batch on a top-level SYNTAX_ERROR.
+# A trailing comma, fewer than two arguments, and an extra argument after a form that used the
+# SQL-standard FROM or FOR keyword must stay parse errors for the canonical name;
+# `02154_parser_backtracking` relies on the too-few-arguments one. Both separator orderings of
+# the mixed-plus-extra-argument form are asserted, because the extra-argument branch is gated on
+# both separators having been commas. Asserted through a server-side parse because the runner
+# aborts a batch on a top-level SYNTAX_ERROR.
 $CLICKHOUSE_CLIENT -q "SELECT '-- parser: shapes that must keep failing'"
 $CLICKHOUSE_CLIENT -q "
 SELECT formatQuerySingleLine('SELECT substring(a)'); -- { serverError SYNTAX_ERROR }
@@ -53,6 +60,12 @@ SELECT formatQuerySingleLine('SELECT substring(a, 1,)'); -- { serverError SYNTAX
 "
 $CLICKHOUSE_CLIENT -q "
 SELECT formatQuerySingleLine('SELECT substring(a FROM 1 FOR 2, 3)'); -- { serverError SYNTAX_ERROR }
+"
+$CLICKHOUSE_CLIENT -q "
+SELECT formatQuerySingleLine('SELECT substring(a, 1 FOR 2, 3)'); -- { serverError SYNTAX_ERROR }
+"
+$CLICKHOUSE_CLIENT -q "
+SELECT formatQuerySingleLine('SELECT substring(a FROM 1, 2, 3)'); -- { serverError SYNTAX_ERROR }
 "
 
 $CLICKHOUSE_CLIENT -q "SELECT '-- semantics: all four spellings agree, and a too-long call is a function error'"
@@ -103,17 +116,21 @@ DETACH TABLE v_canonical4; ATTACH TABLE v_canonical4;
 SELECT 'attach ok', count() FROM system.tables WHERE database = currentDatabase() AND name LIKE 'v\_%';
 "
 
-$CLICKHOUSE_CLIENT -q "SELECT '-- SQL UDF body: the definition survives a reload'"
+# `create_query` in `system.functions` is a formatting of the same normalized AST that is written
+# to `user_defined/function_*.sql`, and `formatQuerySingleLine` throws on unparseable text, so a
+# row that does not error proves the persisted definition re-parses. Limitation: the
+# load-from-disk path, where an unparseable body is silently dropped, needs a fresh process and is
+# not asserted here. The reference records `f_default` because `tests/clickhouse-test` rewrites the
+# randomized database name to `default` in stdout — the function is created as `f_${CLICKHOUSE_DATABASE}`.
+$CLICKHOUSE_CLIENT -q "SELECT '-- SQL UDF body: the persisted definition re-parses'"
 $CLICKHOUSE_CLIENT -q "
 DROP FUNCTION IF EXISTS ${FUNC};
 CREATE FUNCTION ${FUNC} AS (a) -> substr(a, 1, 2, 3);
-SYSTEM RELOAD FUNCTIONS;
 SELECT count(), formatQuerySingleLine(create_query) FROM system.functions WHERE name = '${FUNC}' GROUP BY create_query;
 DROP FUNCTION ${FUNC};
 "
 $CLICKHOUSE_CLIENT -q "
 CREATE FUNCTION ${FUNC} AS (a) -> substr(a);
-SYSTEM RELOAD FUNCTIONS;
 SELECT count(), formatQuerySingleLine(create_query) FROM system.functions WHERE name = '${FUNC}' GROUP BY create_query;
 DROP FUNCTION ${FUNC};
 "


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a bug where a `CREATE VIEW` or `CREATE FUNCTION` whose definition calls `substr`, `mid` or `byteSlice` in a form the `substring` grammar cannot re-parse is accepted, but the metadata ClickHouse writes for it is not valid SQL. Reading that definition afterwards fails with `SYNTAX_ERROR`, and at server startup it aborts metadata loading, so the server cannot start at all. Such definitions now round-trip, and existing metadata files of the form `substring(x, a, b, c)` become readable again, so an affected server starts up without manual intervention.


### Description

A `CREATE VIEW` whose `SELECT` calls `substr`, `mid` or `byteSlice` with an argument count (or a
parameter list, window clause, or `NULLS` modifier) that the `SUBSTRING` grammar cannot re-parse is
accepted at DDL time, but the metadata ClickHouse itself writes for it is not valid SQL. Every later
read of that definition throws `Code: 62 SYNTAX_ERROR`, and at server startup this aborts metadata
loading permanently, so the server never comes up:

```
<Error> Application: Caught exception while loading metadata: Code: 62. DB::Exception:
Syntax error (in file store/.../test_view__fuzz_77.sql): failed at position 259 (,)
... Cannot parse definition from metadata file store/.../test_view__fuzz_77.sql. (SYNTAX_ERROR)
```

This is reachable with ordinary user DDL, no fuzzer needed:

```sql
CREATE VIEW v (x String) AS SELECT substr(a, 1, 2, 3) FROM (SELECT 'q' AS a);  -- accepted
SELECT count() FROM system.tables WHERE name = 'v' AND database = currentDatabase();
-- Code: 62. SYNTAX_ERROR ... Cannot parse definition from metadata file .../v.sql
```

The persisted file contains `AS SELECT substring(a, 1, 2, 3)` - a form the parser rejects.

#### Cause

`substr`, `mid` and `byteSlice` are registered as aliases of `substring`
(`src/Functions/substring.cpp`), but `getFunctionLayer` routes only the literal name `substring` to
the dedicated `SubstringLayer`. The alias spellings are parsed by the generic function layer, which
accepts node shapes the dedicated layer rejects. `CREATE VIEW` does not analyze its inner `SELECT`,
so such a call survives DDL; `FunctionNameNormalizer` then rewrites the alias to the canonical
`substring` in the AST that gets persisted, and the formatter faithfully emits text that cannot be
read back.

The formatter is not at fault and the AST is not corrupt. The defect is the asymmetry: name
normalization moves an AST from the permissive parse route onto the strict one.

Two persisted surfaces are affected, with different symptoms:

* **view / MV metadata** - the server cannot start (the CI signature above);
* **SQL UDF bodies** - the function is silently dropped when the objects are loaded from disk
  (`UserDefinedSQLObjectsDiskStorage::tryLoadObject` logs and returns `nullptr` for an object it
  cannot parse), i.e. silent loss of a user object on the next server start.

#### Changes

1. **`FunctionNameNormalizer`** - rename an alias to its canonical name only when the canonical name
   can re-parse that node's shape; otherwise keep the alias spelling. The check is an allowlist of
   provably re-parseable shapes, so an unknown or future shape keeps the alias, which always
   re-parses because it takes the generic layer. This prevents new unreadable files of every shape.
   Keeping the alias is semantically free - all four spellings resolve to the same function - and
   plain 2- and 3-argument calls still canonicalize to `substring` exactly as before, so replicated
   metadata name stability is unaffected.

   Keeping the alias is also inert for the normalizer's documented purpose (canonical names for
   projection matching), because every shape the check keeps as an alias fails analysis anyway:
   fewer than two or more than three arguments give `NUMBER_OF_ARGUMENTS_DOESNT_MATCH`, a parameter
   list gives `FUNCTION_CANNOT_HAVE_PARAMETERS`, `RESPECT`/`IGNORE NULLS` on a non-aggregate gives
   `SYNTAX_ERROR`, and `OVER` fails window resolution. So a query that actually runs never carries an
   un-canonicalized name, and the DDL surfaces whose expressions are analyzed at `CREATE` time
   (column `DEFAULT`, `TTL`, `ORDER BY`, `PARTITION BY` - the ones normalized into
   `ReplicatedMergeTreeTableMetadata`) reject the unsafe shapes outright, so they cannot carry one
   either.

2. **`SubstringLayer`** - accept further comma-separated arguments in the all-comma functional form,
   so a too-long call is reported by the function as `NUMBER_OF_ARGUMENTS_DOESNT_MATCH` instead of as
   a syntax error. This is what **recovers metadata files that already exist on disk**, because
   metadata loading parses the raw text before any normalization runs. Four of the five observed CI
   failures are comma-form calls (they fail at a `,`), so this un-bricks those servers; the fifth,
   the master hit, was persisted from a one-argument `substr(x)` and is **not** recovered - see
   Behaviour below. The extra-argument branch is gated on both
   separators having been commas, mirroring `OverlayLayer`'s `comma_mode`/`keyword_mode` locking, so
   no separator sequence other than the all-comma one changes what it accepted before. The
   SQL-standard `SUBSTRING(x FROM a FOR b)` grammar and the bare-`substring(x)` / `substring()`
   parse errors are unchanged - the latter are deliberately kept as errors for parser-backtracking
   protection (#104626), and the new test pins them so a future change cannot weaken
   `02154_parser_backtracking`.

Neither change alone closes the issue: (1) stops new bad files, (2) recovers existing ones.

#### Behaviour

Nothing that works today stops working. Change 2 deliberately widens what the canonical spelling
parses, in exactly one direction: `substring(x, a, b, ...)` with four or more comma-separated
arguments is now accepted by the parser and rejected by the function with
`NUMBER_OF_ARGUMENTS_DOESNT_MATCH` instead of failing as a syntax error. That is the whole point -
it is what makes an already-persisted `substring(x, a, b, c)` metadata file loadable again - and it
is also why a `CREATE VIEW ... AS SELECT substring(a, 1, 2, 3)` with an explicit column list (which
does not analyze its inner query) is now accepted where it previously failed at parse time; reading
that view back reports the argument-count error from the function, as it already did for the alias
spellings. The SQL-standard `SUBSTRING(x FROM a FOR b)` grammar, the mixed spellings
`substring(x, a FOR b)` / `substring(x FROM a, b)` that master already accepts, and the
bare-`substring(x)` / `substring()` parse errors are all unchanged. No setting, serialization
format, metadata version or protocol change.

Recovery of existing bad files is partial by design, and the split is worth being precise about. A
server whose bad metadata is a comma-form call, `substring(x, a, b, c)` and longer, starts again with
no intervention; that is four of the five failures observed in CI, including all four on pull
requests. Metadata of the remaining shapes (`substring()`, `substring(x)`, `substring(...)(...)`,
`... OVER ()`, `... RESPECT NULLS`) is **not** recovered and still needs manual remediation - the
master failure linked below is one of these, persisted from a one-argument `substr(x)`, and its
server would still not start with this patch. Bare `substring(x)` is deliberately kept a parse error
for parser-backtracking protection (#104626), and no tolerant metadata reader was added, since
silently accepting unparseable metadata would hide real corruption. For every unrecovered shape,
change 1 still stops the file from being written in the first place.

One consequence of change 1 worth naming for a `Replicated` database: for an unsafe-shape call, a
patched replica now persists the alias spelling where an unpatched one persists `substring`, and
replica recovery compares the local metadata text against the ZooKeeper copy byte for byte. This can
only differ for exactly the shapes that are unreadable on an unpatched replica today, so no
configuration that works now is affected, but during a rolling upgrade such a table can be treated
as diverged on the replica that has not been upgraded yet.

#### Testing

New test `04650_substring_alias_normalization_metadata_roundtrip`, covering the parser round-trip
for the canonical name and all three aliases, the shapes that must keep failing, unchanged
semantics and values, every affected view-metadata shape plus `DETACH`/`ATTACH` (which re-reads the
file from disk), the SQL UDF surface, and the recovery of a definition a pre-fix server wrote.

Verified against a binary built from the same base commit with only these two hunks reverted:
over a 16-shape view-metadata matrix, ten shapes go from `Code 62` on read to a successful read,
and one more (`substring(a, 1, 2, 3)`) goes from a parse error at `CREATE` to being created and
read back; a file written by the pre-fix binary is unreadable by it and loads on the fixed one;
the SQL UDF goes from silently dropped to present.
Six single-clause mutant builds show each part of the shape check is load-bearing on exactly its
own axis and that the two changes are not redundant, and the new test fails on every one of them.
Zero `.reference` changes anywhere; `02154_parser_backtracking` and
`04227_inconsistent_ast_function_lambda_after_comma_104605` pass, and deeply nested `substring`
calls show no parse-time blowup. 50/50 randomized runs of the new test pass.

CI provenance. Failing rows `Cannot start clickhouse-server` + `Check failed`, sub-signature
`Cannot parse definition from metadata file`. Seen on four unrelated pull requests and on master,
across `arm_msan` / `amd_asan_ubsan` / `amd_tsan` / `amd_debug`, so it is architecture- and
sanitizer-independent. There is no existing issue for it.

Reports:

* master, `Stress test (amd_debug)`:
  https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=57afe3cff9c045050f6b865709fe174031fef28b&name_0=MasterCI&name_1=Stress%20test%20%28amd_debug%29
* `Stress test (amd_asan_ubsan)`:
  https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111806&sha=31faeb3c2fd4dbbfdb9099ef8d16ff8349f9a526&name_0=PR&name_1=Stress%20test%20%28amd_asan_ubsan%29

The long-term shape a maintainer may prefer instead of change 2: make `SubstringLayer` generic
outside the `FROM`/`FOR` sugar, which would fix every shape for the canonical name and recover
every existing bad file. That requires accepting bare `substring(x)`, which #104626 deliberately
kept as a parse error for backtracking protection, so it is an owner-level call about the parser's
guarantees rather than a bug fix; I did not make it here.