### PR TITLE
Add cardinality estimates for boolean predicates

### DIFF
--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -1,23 +1,23 @@
 #include <Storages/Statistics/ConditionSelectivityEstimator.h>
 
-#include <stack>
 #include <cmath>
+#include <stack>
 
-#include <Common/logger_useful.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/DataTypeNullable.h>
-#include <DataTypes/getLeastSupertype.h>
-#include <DataTypes/DataTypeLowCardinality.h>
-#include <DataTypes/IDataType.h>
 #include <DataTypes/DataTypesNumber.h>
-#include <Interpreters/convertFieldToType.h>
-#include <Interpreters/misc.h>
+#include <DataTypes/IDataType.h>
+#include <DataTypes/getLeastSupertype.h>
+#include <Formats/ParseError.h>
 #include <Interpreters/PreparedSets.h>
 #include <Interpreters/Set.h>
-#include <Storages/StorageInMemoryMetadata.h>
-#include <Storages/MergeTree/RPNBuilder.h>
+#include <Interpreters/convertFieldToType.h>
+#include <Interpreters/misc.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
-#include <Formats/ParseError.h>
+#include <Storages/MergeTree/RPNBuilder.h>
+#include <Storages/StorageInMemoryMetadata.h>
+#include <Common/logger_useful.h>
 
 
 namespace DB
@@ -106,6 +106,37 @@ static bool isCompatibleStatistics(const StorageMetadataPtr & metadata, const Co
     return column->type->equals(*stats->getDataType());
 }
 
+static bool isBoolColumnType(const DataTypePtr & type)
+{
+    return isBool(removeLowCardinalityAndNullable(removeNullable(type)));
+}
+
+static bool normalizeBoolField(Field & value)
+{
+    if (value.getType() == Field::Types::Bool)
+        return true;
+
+    if (value.getType() == Field::Types::UInt64)
+    {
+        UInt64 numeric_value = value.safeGet<UInt64>();
+        if (numeric_value > 1)
+            return false;
+        value = Field(numeric_value != 0);
+        return true;
+    }
+
+    if (value.getType() == Field::Types::Int64)
+    {
+        Int64 numeric_value = value.safeGet<Int64>();
+        if (numeric_value != 0 && numeric_value != 1)
+            return false;
+        value = Field(numeric_value != 0);
+        return true;
+    }
+
+    return false;
+}
+
 RelationProfile ConditionSelectivityEstimator::estimateRelationProfileImpl(std::vector<RPNElement> & rpn, const StorageMetadataPtr & metadata) const
 {
     /// walk through the tree and calculate selectivity for every rpn node.
@@ -159,6 +190,7 @@ RelationProfile ConditionSelectivityEstimator::estimateRelationProfileImpl(std::
                 {
                     std::swap(last_element->column_ranges, last_element->column_not_ranges);
                     std::swap(last_element->null_check_columns, last_element->not_null_check_columns);
+                    std::swap(last_element->null_true_columns, last_element->null_false_columns);
                     switch (last_element->function)
                     {
                         case RPNElement::FUNCTION_AND:        last_element->function = RPNElement::FUNCTION_OR;       break;
@@ -249,8 +281,12 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
         size_t num_args = func.getArgumentsSize();
 
         String func_name = func.getFunctionName();
+        bool is_null_safe_equal = func_name == "isNotDistinctFrom";
+        bool is_null_safe_not_equal = func_name == "isDistinctFrom";
+        bool is_null_safe_predicate = is_null_safe_equal || is_null_safe_not_equal;
+        bool column_can_be_null = false;
         auto atom_it = atom_map.find(func_name);
-        if (atom_it == atom_map.end())
+        if (atom_it == atom_map.end() && !is_null_safe_predicate)
         {
             /// LIKE/ILIKE cannot be represented as a range. Pre-set selectivity
             /// so the estimator uses a tighter default than `default_unknown_cond_factor`.
@@ -271,7 +307,7 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
             return false;
         }
 
-        if (num_args == 1)
+        if (num_args == 1 && atom_it != atom_map.end())
         {
             /// `isNull(col)` / `isNotNull(col)` — populate the corresponding null-check set.
             column_name = func.getArgumentAt(0).getColumnName();
@@ -315,22 +351,44 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
             }
             else if (func.getArgumentAt(1).tryGetConstant(const_value, const_type))
             {
+                column_name = func.getArgumentAt(0).getColumnName();
                 if (const_value.isNull())
                 {
-                    out.function = RPNElement::ALWAYS_FALSE;
+                    if (is_null_safe_predicate)
+                    {
+                        if (metadata && !metadata->getColumns().tryGet(column_name))
+                            return false;
+                        out.function = is_null_safe_equal ? RPNElement::FUNCTION_IS_NULL : RPNElement::FUNCTION_IS_NOT_NULL;
+                        if (is_null_safe_equal)
+                            out.null_check_columns.insert(column_name);
+                        else
+                            out.not_null_check_columns.insert(column_name);
+                    }
+                    else
+                        out.function = RPNElement::ALWAYS_FALSE;
                     return true;
                 }
-                column_name = func.getArgumentAt(0).getColumnName();
             }
             else if (func.getArgumentAt(0).tryGetConstant(const_value, const_type))
             {
+                column_name = func.getArgumentAt(1).getColumnName();
                 if (const_value.isNull())
                 {
-                    out.function = RPNElement::ALWAYS_FALSE;
+                    if (is_null_safe_predicate)
+                    {
+                        if (metadata && !metadata->getColumns().tryGet(column_name))
+                            return false;
+                        out.function = is_null_safe_equal ? RPNElement::FUNCTION_IS_NULL : RPNElement::FUNCTION_IS_NOT_NULL;
+                        if (is_null_safe_equal)
+                            out.null_check_columns.insert(column_name);
+                        else
+                            out.not_null_check_columns.insert(column_name);
+                    }
+                    else
+                        out.function = RPNElement::ALWAYS_FALSE;
                     return true;
                 }
 
-                column_name = func.getArgumentAt(1).getColumnName();
                 if (func_name == "less")
                     func_name = "greater";
                 else if (func_name == "greater")
@@ -347,11 +405,21 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
             {
                 const ColumnDescription * column_desc = metadata->getColumns().tryGet(column_name);
                 if (column_desc)
+                {
+                    column_can_be_null = isNullableOrLowCardinalityNullable(column_desc->type);
                     column_type = removeLowCardinalityAndNullable(column_desc->type);
+                    if (is_null_safe_predicate && (!isBoolColumnType(column_desc->type) || !normalizeBoolField(const_value)))
+                        return false;
+                }
                 else
                 {
                     /// Not a real column (e.g. a function expression like lower(col) or toDecimal64(col, 3)).
                     /// Skip range analysis to avoid bad cast when merging ranges of incompatible Field types.
+                    /// Null-safe predicates are used to represent `expr IS TRUE` / `expr IS FALSE`; keep
+                    /// arbitrary boolean-returning expressions unknown instead of treating them as column statistics.
+                    if (is_null_safe_predicate)
+                        return false;
+
                     /// Pre-set selectivity based on the function type so prewhere ordering is still reasonable.
                     if (func_name == "equals" || func_name == "in")
                         out.selectivity.true_sel = default_cond_equal_factor;
@@ -387,9 +455,14 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
                         LOG_DEBUG(getLogger("ConditionSelectivityEstimator"),
                             "Cannot convert value to column type, skipping statistics estimation. The exception is : {}",
                             getCurrentExceptionMessage(false));
-                        if (func_name == "equals")
+                        if (func_name == "equals" || is_null_safe_equal)
                         {
                             out.function = RPNElement::ALWAYS_FALSE;
+                            return true;
+                        }
+                        if (is_null_safe_not_equal)
+                        {
+                            out.function = RPNElement::ALWAYS_TRUE;
                             return true;
                         }
                         return false;
@@ -435,12 +508,13 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
                         /// representable value and make an impossible predicate look selective, which can
                         /// reorder PREWHERE incorrectly. Detect this with a round-trip and short-circuit
                         /// equality/inequality instead of estimating from the narrowed value.
-                        if (func_name == "equals" || func_name == "notEquals")
+                        if (func_name == "equals" || func_name == "notEquals" || is_null_safe_predicate)
                         {
                             Field round_trip = tryConvertFieldToType(converted, *common_type, column_type.get(), {});
                             if (round_trip.isNull() || round_trip != const_value)
                             {
-                                out.function = func_name == "equals" ? RPNElement::ALWAYS_FALSE : RPNElement::ALWAYS_TRUE;
+                                out.function
+                                    = (func_name == "equals" || is_null_safe_equal) ? RPNElement::ALWAYS_FALSE : RPNElement::ALWAYS_TRUE;
                                 return true;
                             }
                         }
@@ -448,6 +522,25 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
                         const_value = converted;
                     }
                 }
+            }
+
+            if (is_null_safe_predicate)
+            {
+                out.function = RPNElement::FUNCTION_IN_RANGE;
+                if (is_null_safe_equal)
+                {
+                    out.column_ranges.emplace(column_name, Range(const_value));
+                    /// `IS NOT DISTINCT FROM value` is two-valued: NULL rows are FALSE, not NULL.
+                    out.null_false_columns.insert(column_name);
+                }
+                else
+                {
+                    out.column_not_ranges.emplace(column_name, Range(const_value));
+                    /// Nullable rows are TRUE for `IS DISTINCT FROM value` when value is non-NULL.
+                    if (column_can_be_null)
+                        out.null_true_columns.insert(column_name);
+                }
+                return true;
             }
 
             /// The atom handlers for IN / NOT IN expect a Tuple but we may have parsed a single scalar in the case of IN (single_value).
@@ -460,11 +553,23 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
         }
     }
 
-    /// Bare `<col>.null` UInt8 subcolumn reference, e.g. `SELECT … WHERE x.null`. Treat it as `IS NULL`.
     if (!node.isFunction() && !node.isConstant() && metadata)
     {
         String bare_column_name = node.getColumnName();
 
+        /// Bare Bool column reference, e.g. `WHERE flag`. Treat it as `flag = true`.
+        /// Do this only for real metadata Bool columns; UInt8 and arbitrary boolean expressions
+        /// must keep their existing unknown/default behavior.
+        if (const ColumnDescription * column_desc = metadata->getColumns().tryGet(bare_column_name);
+            column_desc && isBoolColumnType(column_desc->type))
+        {
+            out.function = RPNElement::FUNCTION_IN_RANGE;
+            out.column_ranges.emplace(bare_column_name, Range(Field(true)));
+            out.range_unknown_columns.insert(bare_column_name);
+            return true;
+        }
+
+        /// Bare `<col>.null` UInt8 subcolumn reference, e.g. `SELECT … WHERE x.null`. Treat it as `IS NULL`.
         auto dot_pos = bare_column_name.rfind('.');
         if (dot_pos != std::string::npos && bare_column_name.compare(dot_pos + 1, std::string::npos, "null") == 0)
         {
@@ -576,99 +681,85 @@ UInt64 ConditionSelectivityEstimator::ColumnEstimator::estimateCardinality() con
     return stats->estimateCardinality();
 }
 
-const ConditionSelectivityEstimator::AtomMap ConditionSelectivityEstimator::atom_map
-{
-        {
-            "notEquals",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                out.column_not_ranges.emplace(column, Range(value));
-            }
-        },
-        {
-            "equals",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                out.column_ranges.emplace(column, Range(value));
-            }
-        },
-        {
-            "in",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                Ranges ranges;
-                for (const Field & field : value.safeGet<Tuple>())
-                {
-                    ranges.emplace_back(field);
-                }
-                out.column_ranges.emplace(column, PlainRanges(ranges, /*intersect*/ true, /*ordered*/ false));
-            }
-        },
-        {
-            "notIn",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                Ranges ranges;
-                for (const Field & field : value.safeGet<Tuple>())
-                {
-                    ranges.emplace_back(field);
-                }
-                out.column_not_ranges.emplace(column, PlainRanges(ranges, /*intersect*/ true, /*ordered*/ false));
-            }
-        },
-        {
-            "less",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                out.column_ranges.emplace(column, Range::createRightBounded(value, false));
-            }
-        },
-        {
-            "greater",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                out.column_ranges.emplace(column, Range::createLeftBounded(value, false));
-            }
-        },
-        {
-            "lessOrEquals",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                out.column_ranges.emplace(column, Range::createRightBounded(value, true));
-            }
-        },
-        {
-            "greaterOrEquals",
-            [] (RPNElement & out, const String & column, const Field & value)
-            {
-                out.function = RPNElement::FUNCTION_IN_RANGE;
-                out.column_ranges.emplace(column, Range::createLeftBounded(value, true));
-            }
-        },
-        {
-            "isNull",
-            [] (RPNElement & out, const String & column, const Field &)
-            {
-                out.function = RPNElement::FUNCTION_IS_NULL;
-                out.null_check_columns.insert(column);
-            }
-        },
-        {
-            "isNotNull",
-            [] (RPNElement & out, const String & column, const Field &)
-            {
-                out.function = RPNElement::FUNCTION_IS_NOT_NULL;
-                out.not_null_check_columns.insert(column);
-            }
-        }
-};
+const ConditionSelectivityEstimator::AtomMap ConditionSelectivityEstimator::atom_map{
+    {"notEquals",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         out.column_not_ranges.emplace(column, Range(value));
+         out.range_unknown_columns.insert(column);
+     }},
+    {"equals",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         out.column_ranges.emplace(column, Range(value));
+         out.range_unknown_columns.insert(column);
+     }},
+    {"in",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         Ranges ranges;
+         for (const Field & field : value.safeGet<Tuple>())
+         {
+             ranges.emplace_back(field);
+         }
+         out.column_ranges.emplace(column, PlainRanges(ranges, /*intersect*/ true, /*ordered*/ false));
+         out.range_unknown_columns.insert(column);
+     }},
+    {"notIn",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         Ranges ranges;
+         for (const Field & field : value.safeGet<Tuple>())
+         {
+             ranges.emplace_back(field);
+         }
+         out.column_not_ranges.emplace(column, PlainRanges(ranges, /*intersect*/ true, /*ordered*/ false));
+         out.range_unknown_columns.insert(column);
+     }},
+    {"less",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         out.column_ranges.emplace(column, Range::createRightBounded(value, false));
+         out.range_unknown_columns.insert(column);
+     }},
+    {"greater",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         out.column_ranges.emplace(column, Range::createLeftBounded(value, false));
+         out.range_unknown_columns.insert(column);
+     }},
+    {"lessOrEquals",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         out.column_ranges.emplace(column, Range::createRightBounded(value, true));
+         out.range_unknown_columns.insert(column);
+     }},
+    {"greaterOrEquals",
+     [](RPNElement & out, const String & column, const Field & value)
+     {
+         out.function = RPNElement::FUNCTION_IN_RANGE;
+         out.column_ranges.emplace(column, Range::createLeftBounded(value, true));
+         out.range_unknown_columns.insert(column);
+     }},
+    {"isNull",
+     [](RPNElement & out, const String & column, const Field &)
+     {
+         out.function = RPNElement::FUNCTION_IS_NULL;
+         out.null_check_columns.insert(column);
+     }},
+    {"isNotNull",
+     [](RPNElement & out, const String & column, const Field &)
+     {
+         out.function = RPNElement::FUNCTION_IS_NOT_NULL;
+         out.not_null_check_columns.insert(column);
+     }}};
 
 /// merge CNF or DNF
 bool ConditionSelectivityEstimator::RPNElement::tryToMergeClauses(RPNElement & lhs, RPNElement & rhs)
@@ -718,6 +809,12 @@ bool ConditionSelectivityEstimator::RPNElement::tryToMergeClauses(RPNElement & l
         null_check_columns.insert(rhs.null_check_columns.begin(), rhs.null_check_columns.end());
         not_null_check_columns.insert(lhs.not_null_check_columns.begin(), lhs.not_null_check_columns.end());
         not_null_check_columns.insert(rhs.not_null_check_columns.begin(), rhs.not_null_check_columns.end());
+        range_unknown_columns.insert(lhs.range_unknown_columns.begin(), lhs.range_unknown_columns.end());
+        range_unknown_columns.insert(rhs.range_unknown_columns.begin(), rhs.range_unknown_columns.end());
+        null_true_columns.insert(lhs.null_true_columns.begin(), lhs.null_true_columns.end());
+        null_true_columns.insert(rhs.null_true_columns.begin(), rhs.null_true_columns.end());
+        null_false_columns.insert(lhs.null_false_columns.begin(), lhs.null_false_columns.end());
+        null_false_columns.insert(rhs.null_false_columns.begin(), rhs.null_false_columns.end());
         return true;
     }
     return false;
@@ -773,25 +870,101 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
         return &it->second;
     };
 
+    auto estimate_null_selectivity = [&](const String & column_name) -> Float64
+    {
+        if (const auto * est = get_estimator(column_name))
+            return est->stats->estimateIsNull();
+        return default_cond_equal_factor;
+    };
+
+    auto estimate_not_null_selectivity = [&](const String & column_name) -> Float64
+    {
+        if (const auto * est = get_estimator(column_name))
+            return est->stats->estimateIsNotNull();
+        return 1.0 - default_cond_equal_factor;
+    };
+
+    auto is_bool_metadata_column = [&](const String & column_name) -> bool
+    {
+        if (!metadata)
+            return false;
+        const ColumnDescription * column_desc = metadata->getColumns().tryGet(column_name);
+        return column_desc && isBoolColumnType(column_desc->type);
+    };
+
+    auto can_metadata_column_be_null = [&](const String & column_name) -> bool
+    {
+        if (!metadata)
+            return true;
+        const ColumnDescription * column_desc = metadata->getColumns().tryGet(column_name);
+        return column_desc && isNullableOrLowCardinalityNullable(column_desc->type);
+    };
+
+    auto estimate_ranges = [&](const String & column_name, const PlainRanges & ranges) -> Selectivity
+    {
+        if (is_bool_metadata_column(column_name))
+        {
+            bool contains_false = false;
+            bool contains_true = false;
+            for (const auto & range : ranges.ranges)
+            {
+                contains_false |= range.intersectsRange(Range(Field(false)));
+                contains_true |= range.intersectsRange(Range(Field(true)));
+            }
+
+            Float64 null_sel = can_metadata_column_be_null(column_name) ? estimate_null_selectivity(column_name) : 0.0;
+            if (contains_false && contains_true)
+                return Selectivity{std::max(0.0, 1.0 - null_sel), null_sel};
+            if (!contains_false && !contains_true)
+                return Selectivity{0.0, null_sel};
+        }
+
+        if (const auto * est = get_estimator(column_name))
+            return est->estimateRanges(ranges);
+        return estimate_unknown_ranges(ranges);
+    };
+
+    auto subtract_ranges = [](const PlainRanges & include, const PlainRanges & exclude)
+    {
+        PlainRanges result = include;
+        for (const auto & range : exclude.ranges)
+            result = result.intersectWith(PlainRanges(range.invertRange(), /*may_have_intersection=*/true, /*ordered=*/true));
+        return result;
+    };
+
     /// Per-column accumulator. The map enforces independence across columns: each column
     /// contributes a single `Selectivity` to the final AND/OR product, with intra-column
     /// merging (e.g. `col > 0 AND col IS NOT NULL`) folded in via `applyAnd`/`applyOr`.
     std::unordered_map<String, Selectivity> estimate_results;
+    std::unordered_set<String> processed_not_range_columns;
     for (const auto & [column_name, ranges] : column_ranges)
     {
-        if (const auto * est = get_estimator(column_name))
-            estimate_results.emplace(column_name, est->estimateRanges(ranges));
+        if (auto not_ranges_it = column_not_ranges.find(column_name);
+            not_ranges_it != column_not_ranges.end() && is_bool_metadata_column(column_name))
+        {
+            /// Bool predicates such as `flag AND NOT flag` should be treated as exact
+            /// complements instead of independent conditions.
+            if (function == FUNCTION_AND)
+            {
+                estimate_results.emplace(column_name, estimate_ranges(column_name, subtract_ranges(ranges, not_ranges_it->second)));
+            }
+            else /// FUNCTION_OR or FUNCTION_IN_RANGE
+            {
+                auto only_not_ranges = subtract_ranges(not_ranges_it->second, ranges);
+                estimate_results.emplace(column_name, estimate_ranges(column_name, only_not_ranges).applyNot());
+            }
+            processed_not_range_columns.insert(column_name);
+        }
         else
-            estimate_results.emplace(column_name, estimate_unknown_ranges(ranges));
+            estimate_results.emplace(column_name, estimate_ranges(column_name, ranges));
     }
 
     for (const auto & [column_name, ranges] : column_not_ranges)
     {
-        Selectivity not_ranges_selectivity;
-        if (const auto * est = get_estimator(column_name))
-            not_ranges_selectivity = est->estimateRanges(ranges).applyNot();
-        else
-            not_ranges_selectivity = estimate_unknown_ranges(ranges).applyNot();
+        if (processed_not_range_columns.contains(column_name))
+            continue;
+
+        Selectivity not_ranges_selectivity = estimate_ranges(column_name, ranges).applyNot();
 
         auto it = estimate_results.find(column_name);
         if (it == estimate_results.end())
@@ -805,6 +978,43 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
         else /// FUNCTION_OR or FUNCTION_IN_RANGE
         {
             it->second = it->second.applyOr(not_ranges_selectivity);
+        }
+    }
+
+    std::unordered_set<String> null_behavior_columns = null_true_columns;
+    null_behavior_columns.insert(null_false_columns.begin(), null_false_columns.end());
+    for (const auto & column_name : null_behavior_columns)
+    {
+        bool null_true = null_true_columns.contains(column_name);
+        bool null_false = null_false_columns.contains(column_name);
+        /// When two null-safe predicates on the same column are merged, combine their NULL-row
+        /// result with the outer connective. TRUE OR FALSE is TRUE; TRUE AND FALSE is FALSE.
+        bool force_true = null_true && !(null_false && function == FUNCTION_AND);
+        bool force_false = null_false && !(null_true && function == FUNCTION_OR);
+
+        auto it = estimate_results.find(column_name);
+        if (it == estimate_results.end())
+        {
+            estimate_results.emplace(column_name, Selectivity{force_true ? estimate_null_selectivity(column_name) : 0.0, 0.0});
+        }
+        else if (force_true)
+        {
+            /// TRUE on NULL rows overrides an unknown NULL result under OR / a standalone
+            /// null-safe predicate. Under AND, a regular range predicate still makes the
+            /// combined NULL-row result unknown; without one, TRUE remains TRUE.
+            if (function != FUNCTION_AND || !range_unknown_columns.contains(column_name))
+            {
+                it->second.true_sel = std::min(1.0, it->second.true_sel + estimate_null_selectivity(column_name));
+                it->second.null_sel = 0;
+            }
+        }
+        else if (force_false)
+        {
+            /// FALSE on NULL rows overrides an unknown NULL result under AND / a standalone
+            /// null-safe predicate. Under OR, a regular range predicate still makes the
+            /// combined NULL-row result unknown; without one, FALSE remains FALSE.
+            if (function != FUNCTION_OR || !range_unknown_columns.contains(column_name))
+                it->second.null_sel = 0;
         }
     }
 
@@ -838,9 +1048,7 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
 
     for (const auto & column_name : null_check_columns)
     {
-        Float64 cur_selectivity = default_cond_equal_factor;
-        if (const auto * est = get_estimator(column_name))
-            cur_selectivity = est->stats->estimateIsNull();
+        Float64 cur_selectivity = estimate_null_selectivity(column_name);
 
         if (!estimate_results.contains(column_name))
         {
@@ -848,25 +1056,32 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
         }
         else if (function == FUNCTION_AND)
         {
-            /// `x IS NULL AND <other predicate on x>`: any non-IS-NULL predicate on the same
-            /// column has `true_sel = 0` on NULL rows, so the AND's `true_sel` is 0. The NULL
-            /// share is `P(x IS NULL)` — IS NULL is TRUE there but the range predicate is NULL,
-            /// so the AND evaluates to NULL on those rows. Store this per-column result so the
-            /// final cross-column AND keeps folding in predicates on other columns.
-            estimate_results[column_name] = Selectivity(0, cur_selectivity);
+            if (null_true_columns.contains(column_name) && !null_false_columns.contains(column_name))
+                estimate_results[column_name] = Selectivity(cur_selectivity, 0);
+            else if (null_false_columns.contains(column_name))
+                estimate_results[column_name] = Selectivity(0, 0);
+            else
+            {
+                /// `x IS NULL AND <other predicate on x>`: any non-IS-NULL predicate on the same
+                /// column has `true_sel = 0` on NULL rows, so the AND's `true_sel` is 0. The NULL
+                /// share is `P(x IS NULL)` — IS NULL is TRUE there but the range predicate is NULL,
+                /// so the AND evaluates to NULL on those rows. Store this per-column result so the
+                /// final cross-column AND keeps folding in predicates on other columns.
+                estimate_results[column_name] = Selectivity(0, cur_selectivity);
+            }
         }
         else
         {
-            Float64 is_true = std::min(1.0, estimate_results[column_name].true_sel + cur_selectivity);
+            Float64 is_true = estimate_results[column_name].true_sel;
+            if (!null_true_columns.contains(column_name))
+                is_true = std::min(1.0, is_true + cur_selectivity);
             estimate_results[column_name] = Selectivity(is_true, 0);
         }
     }
 
     for (const auto & column_name : not_null_check_columns)
     {
-        Float64 cur_selectivity = 1.0 - default_cond_equal_factor;
-        if (const auto * est = get_estimator(column_name))
-            cur_selectivity = est->stats->estimateIsNotNull();
+        Float64 cur_selectivity = estimate_not_null_selectivity(column_name);
 
         if (!estimate_results.contains(column_name))
         {
@@ -876,10 +1091,19 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
         {
             /// Under OR, `IS NOT NULL` dominates any range predicate on the same column,
             /// because non-NULL rows where the range is FALSE still satisfy IS NOT NULL.
-            estimate_results[column_name].true_sel = cur_selectivity;
+            if (null_true_columns.contains(column_name))
+                estimate_results[column_name] = Selectivity(1.0, 0.0);
+            else
+                estimate_results[column_name].true_sel = cur_selectivity;
         }
         else
         {
+            if (null_true_columns.contains(column_name) && !null_false_columns.contains(column_name)
+                && !range_unknown_columns.contains(column_name))
+            {
+                Float64 null_selectivity = std::max(0.0, 1.0 - cur_selectivity);
+                estimate_results[column_name].true_sel = std::max(0.0, estimate_results[column_name].true_sel - null_selectivity);
+            }
             /// Under AND, the range predicate already filters NULLs; the only effect of
             /// `IS NOT NULL` is to zero out the column's NULL share.
             estimate_results[column_name].null_sel = 0;

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.h
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.h
@@ -93,6 +93,13 @@ public:
         std::unordered_set<String> null_check_columns;
         /// columns checked with IS NOT NULL predicate
         std::unordered_set<String> not_null_check_columns;
+        /// columns with regular range predicates, which evaluate to NULL on NULL rows.
+        std::unordered_set<String> range_unknown_columns;
+        /// NULL-row behavior that belongs to a null-safe predicate itself, not to a standalone
+        /// IS [NOT] NULL condition. This keeps parser-lowered `IS TRUE` / `IS NOT TRUE`
+        /// compositional with explicit null checks on the same column.
+        std::unordered_set<String> null_true_columns;
+        std::unordered_set<String> null_false_columns;
         bool finalized = false;
         Selectivity selectivity;
 

--- a/src/Storages/Statistics/tests/gtest_stats.cpp
+++ b/src/Storages/Statistics/tests/gtest_stats.cpp
@@ -6,7 +6,6 @@
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnNullable.h>
 #include <Columns/IColumn.h>
-#include <Common/Exception.h>
 #include <Core/Block.h>
 #include <Core/ColumnWithTypeAndName.h>
 #include <DataTypes/DataTypeFactory.h>
@@ -14,15 +13,17 @@
 #include <DataTypes/DataTypesDecimal.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Interpreters/convertFieldToType.h>
+#include <Parsers/ExpressionListParsers.h>
+#include <Parsers/parseQuery.h>
+#include <Storages/ColumnsDescription.h>
 #include <Storages/MergeTree/RPNBuilder.h>
+#include <Storages/Statistics/ConditionSelectivityEstimator.h>
 #include <Storages/Statistics/Statistics.h>
 #include <Storages/Statistics/StatisticsMinMax.h>
-#include <Storages/StatisticsDescription.h>
-#include <Storages/ColumnsDescription.h>
 #include <Storages/Statistics/StatisticsTDigest.h>
-#include <Storages/Statistics/ConditionSelectivityEstimator.h>
-#include <Parsers/parseQuery.h>
-#include <Parsers/ExpressionListParsers.h>
+#include <Storages/StatisticsDescription.h>
+#include <Storages/StorageInMemoryMetadata.h>
+#include <Common/Exception.h>
 
 using namespace DB;
 
@@ -238,7 +239,7 @@ ColumnStatisticsPtr buildNullableInt32Stats(
 
 /// Estimate the row count for a SQL boolean expression evaluated against `estimator`.
 template <class Estimator>
-Float64 estimateRowsFor(Estimator & estimator, const String & expression)
+Float64 estimateRowsFor(Estimator & estimator, const StorageMetadataPtr & metadata, const String & expression)
 {
     ParserExpressionWithOptionalAlias exp_parser(false);
     ContextPtr context = getContext().context;
@@ -248,7 +249,51 @@ Float64 estimateRowsFor(Estimator & estimator, const String & expression)
         {});
     ASTPtr ast = parseQuery(exp_parser, expression, 10000, 10000, 10000);
     RPNBuilderTreeNode node(ast.get(), tree_context);
-    return static_cast<Float64>(estimator->estimateRelationProfile(nullptr, node).rows);
+    return static_cast<Float64>(estimator->estimateRelationProfile(metadata, node).rows);
+}
+
+template <class Estimator>
+Float64 estimateRowsFor(Estimator & estimator, const String & expression)
+{
+    return estimateRowsFor(estimator, nullptr, expression);
+}
+
+ColumnStatisticsPtr buildBoolStats(
+    const std::vector<StatisticsType> & types, const DataTypePtr & data_type, size_t true_count, size_t false_count, size_t null_count = 0)
+{
+    MutableColumnPtr col = data_type->createColumn();
+    for (size_t i = 0; i < true_count; ++i)
+        col->insert(true);
+    for (size_t i = 0; i < false_count; ++i)
+        col->insert(false);
+    for (size_t i = 0; i < null_count; ++i)
+        col->insertDefault();
+
+    auto stats = createTestStats(types, data_type);
+    ColumnPtr built_col = std::move(col);
+    stats->build(built_col);
+    return stats;
+}
+
+ColumnStatisticsPtr buildBoolStats(const DataTypePtr & data_type, size_t true_count, size_t false_count, size_t null_count = 0)
+{
+    return buildBoolStats({StatisticsType::Basic, StatisticsType::CountMinSketch}, data_type, true_count, false_count, null_count);
+}
+
+ColumnStatisticsPtr buildUInt8Stats(const DataTypePtr & data_type, size_t one_count, size_t zero_count, size_t null_count = 0)
+{
+    MutableColumnPtr col = data_type->createColumn();
+    for (size_t i = 0; i < one_count; ++i)
+        col->insert(UInt64(1));
+    for (size_t i = 0; i < zero_count; ++i)
+        col->insert(UInt64(0));
+    for (size_t i = 0; i < null_count; ++i)
+        col->insertDefault();
+
+    auto stats = createTestStats({StatisticsType::Basic, StatisticsType::CountMinSketch}, data_type);
+    ColumnPtr built_col = std::move(col);
+    stats->build(built_col);
+    return stats;
 }
 
 }
@@ -343,6 +388,90 @@ TEST(Statistics, NullableEstimatorWithBasic)
     /// Contradictions spanning two columns.
     check("a > 500 AND b > 500 AND b IS NULL", 0.0, 1e-6);  /// b > 500 contradicts b IS NULL
     check("a IS NULL AND a > 500 AND b IS NULL", 0.0, 1e-6); /// a IS NULL contradicts a > 500
+}
+
+TEST(Statistics, BooleanPredicateEstimator)
+{
+    tryRegisterFunctions();
+
+    auto bool_type = DataTypeFactory::instance().get("Bool");
+    auto nullable_bool_type = std::make_shared<DataTypeNullable>(bool_type);
+    auto low_cardinality_nullable_bool_type = DataTypeFactory::instance().get("LowCardinality(Nullable(Bool))");
+    auto uint8_type = std::make_shared<DataTypeUInt8>();
+    auto nullable_uint8_type = std::make_shared<DataTypeNullable>(uint8_type);
+
+    auto metadata = std::make_shared<StorageInMemoryMetadata>();
+    metadata->setColumns(
+        ColumnsDescription{
+            ColumnDescription{"flag", bool_type},
+            ColumnDescription{"nullable_flag", nullable_bool_type},
+            ColumnDescription{"basic_nullable_flag", nullable_bool_type},
+            ColumnDescription{"lc_nullable_flag", low_cardinality_nullable_bool_type},
+            ColumnDescription{"u8", uint8_type},
+            ColumnDescription{"nullable_u8", nullable_uint8_type},
+        });
+
+    ConditionSelectivityEstimatorBuilder builder(getContext().context);
+    builder.addStatistics("flag", buildBoolStats(bool_type, /*true_count=*/300, /*false_count=*/700));
+    builder.addStatistics("nullable_flag", buildBoolStats(nullable_bool_type, /*true_count=*/250, /*false_count=*/650, /*null_count=*/100));
+    builder.addStatistics(
+        "basic_nullable_flag",
+        buildBoolStats({StatisticsType::Basic}, nullable_bool_type, /*true_count=*/250, /*false_count=*/650, /*null_count=*/100));
+    builder.addStatistics(
+        "lc_nullable_flag",
+        buildBoolStats(low_cardinality_nullable_bool_type, /*true_count=*/400, /*false_count=*/500, /*null_count=*/100));
+    builder.addStatistics("u8", buildUInt8Stats(uint8_type, /*one_count=*/300, /*zero_count=*/700));
+    builder.addStatistics("nullable_u8", buildUInt8Stats(nullable_uint8_type, /*one_count=*/250, /*zero_count=*/650, /*null_count=*/100));
+    builder.incrementRowCount(1000);
+    auto estimator = builder.getEstimator();
+
+    auto check = [&](const String & expression, Float64 expected, Float64 eps = 1e-6)
+    {
+        Float64 actual = estimateRowsFor(estimator, metadata, expression);
+        EXPECT_NEAR(actual, expected, eps) << "Expression: " << expression;
+    };
+
+    /// Bare Bool column predicates are estimated like equality with TRUE/FALSE.
+    check("flag", 300.0);
+    check("not flag", 700.0);
+    check("flag = true", 300.0);
+    check("flag = false", 700.0);
+    check("flag AND NOT flag", 0.0);
+    check("flag OR NOT flag", 1000.0);
+
+    /// Nullable Bool preserves SQL three-valued logic for bare predicates and NOT.
+    check("nullable_flag", 250.0);
+    check("not nullable_flag", 650.0);
+
+    /// Truth-value predicates are parsed as null-safe equality/distinctness.
+    check("nullable_flag IS TRUE", 250.0);
+    check("nullable_flag IS FALSE", 650.0);
+    check("nullable_flag IS NOT TRUE", 750.0);
+    check("nullable_flag IS NOT FALSE", 350.0);
+    check("isNotDistinctFrom(nullable_flag, 1)", 250.0);
+    check("isDistinctFrom(nullable_flag, 1)", 750.0);
+    check("not(nullable_flag IS TRUE)", 750.0);
+    check("nullable_flag IS TRUE OR nullable_flag IS NULL", 350.0);
+    check("nullable_flag IS TRUE AND nullable_flag IS NULL", 0.0);
+    check("nullable_flag IS TRUE AND nullable_flag IS NOT TRUE", 0.0);
+    check("nullable_flag IS TRUE OR nullable_flag IS NOT TRUE", 1000.0);
+    check("nullable_flag IS NOT TRUE AND nullable_flag IS NOT NULL", 650.0);
+    check("nullable_flag IS NOT TRUE OR nullable_flag IS NOT NULL", 1000.0);
+    check("nullable_flag IS NOT TRUE AND nullable_flag = false", 650.0);
+    check("nullable_flag IS NOT TRUE AND nullable_flag IS NOT FALSE", 100.0, 1.0);
+    check("not(nullable_flag IS TRUE OR nullable_flag = false)", 0.0);
+    check("not(nullable_flag IS TRUE OR nullable_flag IS FALSE)", 100.0, 1.0);
+    check("basic_nullable_flag IS NOT TRUE AND basic_nullable_flag IS NOT FALSE", 100.0, 1.0);
+    check("not(basic_nullable_flag IS TRUE OR basic_nullable_flag IS FALSE)", 100.0, 1.0);
+
+    /// LowCardinality wrappers should still be recognized as Bool.
+    check("lc_nullable_flag", 400.0);
+    check("lc_nullable_flag IS NOT TRUE", 600.0);
+
+    /// UInt8 is not Bool sugar: bare numeric columns keep the unknown-condition fallback.
+    check("u8", 330.0);
+    check("nullable_u8", 330.0);
+    check("u8 = 1", 300.0);
 }
 
 TEST(Statistics, LikeSelectivity)

--- a/tests/queries/0_stateless/04266_statistics_basic_prewhere.reference
+++ b/tests/queries/0_stateless/04266_statistics_basic_prewhere.reference
@@ -22,3 +22,27 @@ Fallback selectivity uses non-null row count (b before a)
 1
 Const-null insert: basic null count drives correct prewhere ordering
 1
+Bool predicate: bare Bool uses true-value statistics before range
+1
+Bool predicate: NOT Bool uses false-value statistics after range
+1
+Bool predicate: Nullable Bool IS TRUE uses null-safe equality estimate
+1
+Bool predicate: Nullable Bool IS NOT TRUE includes NULL rows
+1
+Bool predicate: Nullable Bool IS FALSE uses exact false-value statistics
+1
+Bool predicate: Nullable Bool IS NOT FALSE includes NULL rows
+1
+Bool predicate: explicit isNotDistinctFrom uses Bool statistics
+1
+Bool predicate: explicit isDistinctFrom includes NULL rows
+1
+Bool predicate: flag AND NOT flag estimated as contradiction
+1
+Bool predicate: flag OR NOT flag estimated as tautology
+1
+Bool predicate: LowCardinality Nullable Bool is recognized as Bool
+1
+Bool predicate: bare UInt8 does not use Bool sugar
+1

--- a/tests/queries/0_stateless/04266_statistics_basic_prewhere.sql
+++ b/tests/queries/0_stateless/04266_statistics_basic_prewhere.sql
@@ -219,3 +219,133 @@ SELECT position(prewhere_line, 'b.null') < position(prewhere_line, 'a.null') AS 
 );
 
 DROP TABLE test_const_null;
+
+-- =============================================================================
+-- Bool predicates: the selectivity estimator should treat real Bool columns as
+-- boolean predicates (including NOT and SQL truth-value predicates), while a
+-- bare UInt8 column must keep the generic unknown-condition fallback.
+-- =============================================================================
+DROP TABLE IF EXISTS test_bool_prewhere;
+
+CREATE TABLE test_bool_prewhere (
+    id UInt64,
+    flag Bool STATISTICS(tdigest, uniq),
+    nullable_flag Nullable(Bool) STATISTICS(basic),
+    nullable_flag_exact Nullable(Bool) STATISTICS(basic, tdigest, uniq),
+    lc_nullable_flag LowCardinality(Nullable(Bool)) STATISTICS(basic),
+    u8 UInt8 STATISTICS(tdigest, uniq),
+    range_probe UInt64 STATISTICS(basic)
+) Engine = MergeTree() ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, auto_statistics_types = '';
+
+-- flag/u8: 100 true/1 rows and 900 false/0 rows.
+-- nullable_flag/nullable_flag_exact/lc_nullable_flag: 100 TRUE, 800 FALSE, 100 NULL.
+INSERT INTO test_bool_prewhere
+SELECT
+    number,
+    number < 100,
+    if(number < 100, true, if(number < 900, false, NULL)),
+    if(number < 100, true, if(number < 900, false, NULL)),
+    if(number < 100, true, if(number < 900, false, NULL)),
+    number < 100,
+    number
+FROM numbers(1000);
+
+SELECT 'Bool predicate: bare Bool uses true-value statistics before range';
+SELECT position(prewhere_line, 'flag') > 0 AND position(prewhere_line, 'less') > 0 AND position(prewhere_line, 'flag') < position(prewhere_line, 'less') AS bool_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_bool_prewhere
+        WHERE flag AND range_probe < 200
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+SELECT 'Bool predicate: NOT Bool uses false-value statistics after range';
+SELECT position(prewhere_line, 'flag') > 0 AND position(prewhere_line, 'less') > 0 AND position(prewhere_line, 'less') < position(prewhere_line, 'flag') AS range_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_bool_prewhere
+        WHERE NOT flag AND range_probe < 750
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+SELECT 'Bool predicate: Nullable Bool IS TRUE uses null-safe equality estimate';
+SELECT position(prewhere_line, 'nullable_flag') > 0 AND position(prewhere_line, 'less') > 0 AND position(prewhere_line, 'nullable_flag') < position(prewhere_line, 'less') AS nullable_bool_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_bool_prewhere
+        WHERE nullable_flag IS TRUE AND range_probe < 200
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+SELECT 'Bool predicate: Nullable Bool IS NOT TRUE includes NULL rows';
+-- The range threshold separates false-only from false-or-NULL estimates for basic-only Bool stats.
+SELECT position(prewhere_line, 'nullable_flag') > 0 AND position(prewhere_line, 'less') > 0 AND position(prewhere_line, 'less') < position(prewhere_line, 'nullable_flag') AS range_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_bool_prewhere
+        WHERE nullable_flag IS NOT TRUE AND range_probe < 950
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+SELECT 'Bool predicate: Nullable Bool IS FALSE uses exact false-value statistics';
+SELECT position(prewhere_line, 'nullable_flag_exact') > 0 AND position(prewhere_line, 'less') > 0 AND position(prewhere_line, 'less') < position(prewhere_line, 'nullable_flag_exact') AS range_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_bool_prewhere
+        WHERE nullable_flag_exact IS FALSE AND range_probe < 500
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+SELECT 'Bool predicate: Nullable Bool IS NOT FALSE includes NULL rows';
+SELECT position(prewhere_line, 'nullable_flag_exact') > 0 AND position(prewhere_line, 'less') > 0 AND position(prewhere_line, 'less') < position(prewhere_line, 'nullable_flag_exact') AS range_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_bool_prewhere
+        WHERE nullable_flag_exact IS NOT FALSE AND range_probe < 150
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+SELECT 'Bool predicate: explicit isNotDistinctFrom uses Bool statistics';
+SELECT position(prewhere_line, 'nullable_flag_exact') > 0 AND position(prewhere_line, 'less') > 0 AND position(prewhere_line, 'less') < position(prewhere_line, 'nullable_flag_exact') AS range_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_bool_prewhere
+        WHERE isNotDistinctFrom(nullable_flag_exact, false) AND range_probe < 500
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+SELECT 'Bool predicate: explicit isDistinctFrom includes NULL rows';
+SELECT position(prewhere_line, 'nullable_flag_exact') > 0 AND position(prewhere_line, 'less') > 0 AND position(prewhere_line, 'less') < position(prewhere_line, 'nullable_flag_exact') AS range_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_bool_prewhere
+        WHERE isDistinctFrom(nullable_flag_exact, false) AND range_probe < 150
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+SELECT 'Bool predicate: flag AND NOT flag estimated as contradiction';
+SELECT position(prewhere_line, 'flag') > 0 AND position(prewhere_line, 'less') > 0 AND position(prewhere_line, 'flag') < position(prewhere_line, 'less') AS bool_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_bool_prewhere
+        WHERE flag AND NOT flag AND range_probe < 50
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+SELECT 'Bool predicate: flag OR NOT flag estimated as tautology';
+SELECT position(prewhere_line, 'flag') > 0 AND position(prewhere_line, 'less') > 0 AND position(prewhere_line, 'less') < position(prewhere_line, 'flag') AS range_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_bool_prewhere
+        WHERE (flag OR NOT flag) AND range_probe < 950
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+SELECT 'Bool predicate: LowCardinality Nullable Bool is recognized as Bool';
+SELECT position(prewhere_line, 'lc_nullable_flag') > 0 AND position(prewhere_line, 'less') > 0 AND position(prewhere_line, 'lc_nullable_flag') < position(prewhere_line, 'less') AS lc_nullable_bool_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_bool_prewhere
+        WHERE lc_nullable_flag IS TRUE AND range_probe < 200
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+SELECT 'Bool predicate: bare UInt8 does not use Bool sugar';
+SELECT position(prewhere_line, 'u8') > 0 AND position(prewhere_line, 'less') > 0 AND position(prewhere_line, 'less') < position(prewhere_line, 'u8') AS range_first FROM (
+    SELECT extractAll(explain, 'Prewhere filter column: ([^\n]+)')[1] AS prewhere_line FROM (
+        EXPLAIN actions=1 SELECT count(*) FROM test_bool_prewhere
+        WHERE u8 AND range_probe < 200
+    ) WHERE explain LIKE '%Prewhere filter column%'
+);
+
+DROP TABLE test_bool_prewhere;


### PR DESCRIPTION
Add statistics-based selectivity/cardinality estimation for boolean predicates so PREWHERE ordering can use real Bool column distributions instead of falling back to unknown selectivity.

 - Treat bare `Bool` predicates like `WHERE` flag as `flag = true`, while preserving the existing fallback behavior for bare `UInt8`.
- Support nullable `Bool` truth-value predicates lowered to null-safe comparisons, including:                            
     - `IS TRUE` / `IS FALSE`
     - `IS NOT TRUE` / `IS NOT FALSE`
     - `isNotDistinctFrom(...)` / `isDistinctFrom(...)`
 - Preserve SQL three-valued logic for `NOT`, `AND`, and `OR`, including `NULL`-row behavior.
 - Handle `Bool` contradictions/tautologies such as `AND NOT` flag and flag `OR NOT` flag.
 - Recognize `Bool` types through `Nullable` and `LowCardinality` wrappers.

 ### Changelog category

 - Improvement

 ### Changelog entry

Use column statistics to estimate selectivity for Bool predicates, including bare Bool filters and nullable truth-value predicates, improving statistics-based PREWHERE condition ordering.