### PR TITLE
Fix flaky 02346_text_index_parallel_replicas

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_parallel_replicas.sql
+++ b/tests/queries/0_stateless/02346_text_index_parallel_replicas.sql
@@ -11,14 +11,12 @@ SET enable_analyzer = 1;
 -- With small index granularity, the amount of rows left to read after the index analysis might be too small to utilize parallel replicas. So, we set it to 0.
 SET parallel_replicas_min_number_of_rows_per_replica = 0;
 
--- The probe at the end reads TextIndexUsedEmbeddedPostings, which is incremented by text
--- index analysis (TextIndexSerialization::deserializeTokenInfo) on the server that performs
--- it. With parallel_replicas_local_plan = 0 the initiator builds no local plan and does no
--- index analysis, so only followers can increment the counter - and a follower increments it
--- only if it wins the shared tokens-cache race for a part, and reports it only if the
--- coordinator did not cancel it (a cancelled replica logs an exception row, not QueryFinish).
--- Keep the local plan so the initiator performs the analysis itself. This is the setting's
--- default; the test runner randomizes it, so the pin is not redundant.
+-- The probe below reads `TextIndexUsedEmbeddedPostings`, which is incremented by text index
+-- analysis on whichever server performs it. With `parallel_replicas_local_plan = 0` the
+-- initiator builds no local plan and does no index analysis, so the counter lands only on
+-- follower `query_log` rows, which is scheduling-dependent. Pin the setting to its default so
+-- the initiator does the analysis itself; the test runner randomizes it, so this is not
+-- redundant.
 SET parallel_replicas_local_plan = 1;
 
 DROP TABLE IF EXISTS tab;

--- a/tests/queries/0_stateless/02346_text_index_parallel_replicas.sql
+++ b/tests/queries/0_stateless/02346_text_index_parallel_replicas.sql
@@ -11,6 +11,16 @@ SET enable_analyzer = 1;
 -- With small index granularity, the amount of rows left to read after the index analysis might be too small to utilize parallel replicas. So, we set it to 0.
 SET parallel_replicas_min_number_of_rows_per_replica = 0;
 
+-- The probe at the end reads TextIndexUsedEmbeddedPostings, which is incremented by text
+-- index analysis (TextIndexSerialization::deserializeTokenInfo) on the server that performs
+-- it. With parallel_replicas_local_plan = 0 the initiator builds no local plan and does no
+-- index analysis, so only followers can increment the counter - and a follower increments it
+-- only if it wins the shared tokens-cache race for a part, and reports it only if the
+-- coordinator did not cancel it (a cancelled replica logs an exception row, not QueryFinish).
+-- Keep the local plan so the initiator performs the analysis itself. This is the setting's
+-- default; the test runner randomizes it, so the pin is not redundant.
+SET parallel_replicas_local_plan = 1;
+
 DROP TABLE IF EXISTS tab;
 
 CREATE TABLE tab


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110057
Related: https://github.com/ClickHouse/ClickHouse/pull/111138


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The fix was requested in #110057. It supersedes #111138, which is closed.

`02346_text_index_parallel_replicas` flaps on line 3 of its output:

```
 15	30
 3	3
-1	1
+1	0
```

i.e. `sum(ProfileEvents['TextIndexUsedEmbeddedPostings']) > 0` reads `0`. Column 1 of the same
statement (`ParallelReplicasUsedCount > 0`) never flaps.

This is the fix requested in #110057. It replaces #111138, which I closed as wrong:
that PR blamed a warm global `TextIndexTokensCache` persisting across stateless runs, which is
impossible because the cache key is `disk:part_path:index_file` and every stateless run gets a
fresh database. That concession stands. The mechanism below is a different one, it comes from
the CI settings data rather than from a hand-built local probe, and the two arms that establish
it are stated at the end so you can check them.

#### The data

Over 60 days, 15 CIDB rows match this test name. Split by failure signature, only 6 are this
flap; the other 9 fall in four unrelated classes (5 x `return code: 241`, a host-OOM class,
`current RSS` between 41.84 and 53.68 GiB; 2 x `Code: 49` from one PR's own analyzer change; 1 x `Code: 36`;
1 x deb-unpack `server died`). Those 6 flap rows are 5 distinct pull requests (#111690, #110057,
#108673, #109696, #109083) plus 1 master run, so this is cross-author flakiness rather than any
PR's own test.

Extracting the runner's `Settings used in the test:` line from each of the 6 rows and
intersecting them, one randomized setting is constant across all of them:

| Setting | Value in all 6 | Control base rate |
|---|---|---|
| `parallel_replicas_local_plan` | **0** | 153/397 = 0.385 |
| `enable_vertical_final` | 1 | 0.506 |
| `distributed_aggregation_memory_efficient` | 0 | 0.473 |
| `use_top_k_dynamic_filtering_for_variable_length_types` | False | 0.742 |

The control base rate is measured over 400 failing rows of *other* tests from the same two
check types in the same window, i.e. the same randomizer population. It also matches the runner
arithmetic: `tests/clickhouse-test:1548` draws the setting with `random.randint(0, 1)`, and
`adjust_settings_for_autopr` (`:1687-1700`) force-sets it to `1` whenever
`automatic_parallel_replicas_mode == 2`, itself drawn with probability `0.25` (`:1608`), so
`P(local_plan = 0) = 0.75 * 0.5 = 0.375`. `0.375^6` is about `2.8e-3`. More decisively,
`parallel_replicas_local_plan` is the only one of those settings with a source path to this
counter.

#### The mechanism

`TextIndexUsedEmbeddedPostings` is incremented at exactly one place,
`MergeTreeIndexText.cpp:1193` in `TextIndexSerialization::deserializeTokenInfo`, reached from
`MergeTreeIndexGranuleText::analyzeDictionaryForTokens`. That is index-analysis work, performed
by whichever server does the index analysis. `ParallelReplicasUsedCount` is incremented in the
coordinator (`ParallelReplicasReadingCoordinator.cpp:1335`), which always lives on the
initiator, which is why column 1 of the probe never flaps.

With `parallel_replicas_local_plan = 1` (the default),
`ClusterProxy::canUseLocalPlanForParallelReplicas` returns true and
`executeQueryWithParallelReplicas` builds a local plan for the local replica, so the initiator
reads parts itself and the counter lands in the initiator's own `query_log` row.

With `parallel_replicas_local_plan = 0` that predicate returns false and only
`ReadFromParallelRemoteReplicasStep` is built. The initiator performs no local read and no index
analysis at all, so every increment happens on a follower and reaches the test's `sum(...)` only
through a follower's `query_log` row.

#### Measured, on a 3-replica loopback cluster

Running the test body verbatim in a fresh database and reading `system.query_log` per row
instead of via `sum()` (no `type = 'QueryFinish'` predicate, since the row type is itself part of
the story):

`--parallel_replicas_local_plan 1`

```
type	is_init	ep	prc	hits	misses	dict_blocks
QueryFinish	0	0	0	0	0	0
QueryFinish	0	0	0	0	0	0
QueryFinish	1	3	1	0	9	8
```

`--parallel_replicas_local_plan 0`

```
type	is_init	ep	prc	hits	misses	dict_blocks
QueryFinish	0	1	0	0	3	3
QueryFinish	0	2	0	0	6	5
QueryFinish	0	0	0	0	0	0
QueryFinish	1	0	2	0	0	0
```

The initiator row carries `ep = 3` in the first arm and `ep = 0` with
`hits = misses = dict_blocks = 0` in the second: it did no index analysis whatsoever. Repeated
20 times, the initiator's `ep` was 0 in 20 out of 20 runs with `local_plan = 0`, and how many
followers actually perform the analysis varied run to run (`ParallelReplicasUsedCount` on the
initiator was 1 in 15 runs and 2 in 5).

Two controls. `ParallelReplicasUsedCount` on the initiator's row is non-zero in *both* arms, so
the `ep = 0` reading is not "parallel replicas never ran". And re-running the first arm with
`use_text_index_tokens_cache = 0` still gives the initiator `ep = 3`, so the effect is about
replica placement and not about the tokens cache.

#### Why the CI reruns pass

Every failing row carries the runner's own `Runs: 94..113, Failed: 0` block. That is expected
and not a contradiction: `local_plan = 0` is necessary but not sufficient. On top of it, no
surviving follower must have contributed the counter. Locally I did not reproduce the flap
either (`sum` was non-zero in 20 out of 20 runs), and I did not tune the harness until it
failed. So this PR does not claim a reproduced failure; it claims, and measures, that
`local_plan = 0` moves the counter off the row the probe is anchored on, which is the dependence
that makes the assertion a race.

For completeness about what I did *not* observe: with `local_plan = 0` a follower could in
principle also fail to contribute because the coordinator cancelled it (a cancelled replica logs
an exception row, which the probe's `type = 'QueryFinish'` filter excludes) or because it took a
tokens-cache hit for a part another replica had already analysed. Neither showed up in my 20
runs (0 exception rows, 0 cache hits), so I am listing them as possible and not asserting them.

#### The change

One `SET parallel_replicas_local_plan = 1;` with a comment, in the test only. No source change
and no `.reference` change. This restores the setting's own product default, keeps the assertion
verbatim, and leaves every other randomized setting varying.

This is the established idiom for text index tests, and three of them already do it:

- `02346_text_index_function_hasAnyAllTokens_partially_materialized.sql:2` --
  `SET parallel_replicas_local_plan = 1; -- this setting may skip index analysis when false` (#88392)
- `02346_text_index_part_format.sql:6` --
  `SET parallel_replicas_local_plan=1; -- this setting is randomized, set it explicitly to have local plan for parallel replicas` (#80852)
- `03776_text_index_covered_sparse_grams.sql:7` -- `SET parallel_replicas_local_plan = 1;` (#94077)

It is also the same shape as #93287, which fixed an earlier flake in this same file by pinning one
parallel-replicas setting with an explanatory comment (still lines 11-12 today).

Worth adding as a second, independent reason the pin is the right lever: with
`parallel_replicas_local_plan = 1` the followers stop doing the index analysis too, because
`ReadFromMergeTree.cpp:2788-2796` skips it on a follower when
`parallel_replicas_index_analysis_only_on_coordinator` (default `true`) is set. So the pin does not
just add the initiator as one more candidate incrementer; it concentrates the analysis on the one
server whose `query_log` row the probe is anchored to.

#### Alternatives, in case you prefer one

- Anchor the probe on the initial query only (`query_id = initial_query_id`, the form
  `02950_parallel_replicas_used_count.sql` uses). That narrows the assertion to what the
  initiator does. I did not do it because under `local_plan = 0` the initiator's `ep` is 0, so it
  would turn the flaky failure into a deterministic one unless the pin is added as well.
- Propagate follower `ProfileEvents` into the initiator's `query_log` row. Remote profile events
  currently reach the initiator only through `Protocol::Server::ProfileEvents` into the internal
  profile-events queue, which feeds the client display, not `logQueryFinishImpl`'s map. That is a
  cross-cutting change to every parallel-replicas query and does not belong in a flaky-test fix,
  but say the word and I will open it separately.

#### How to check the two arms

```
--parallel_replicas_local_plan 1 : initiator query_log row has TextIndexUsedEmbeddedPostings > 0
--parallel_replicas_local_plan 0 : initiator query_log row has TextIndexUsedEmbeddedPostings = 0
```

Run the test body in a fresh database against a cluster of three loopback replicas, then read
`system.query_log` selecting `ProfileEvents['TextIndexUsedEmbeddedPostings']` and
`query_id = initial_query_id` per row rather than `sum()`. The `sum()` in the test hides which
row the counter landed on, which is the whole point.