### PR TITLE
Add Claude regional-use terms

### DIFF
--- a/docs/products/cloud/features/ai-ml/model-developer-terms.mdx
+++ b/docs/products/cloud/features/ai-ml/model-developer-terms.mdx
@@ -15,9 +15,9 @@ Following is a table of models with their terms, and other pertinent information
 
 | Model | Terms and policies |
 | :---- | :---- |
-| [Anthropic Claude Opus 4.6](https://www.anthropic.com/news/claude-opus-4-6) | Customer may use Claude only in supported countries and regions, [Usage policy](https://www.anthropic.com/legal/aup) |
-| [Anthropic Claude Sonnet 4.6](https://www.anthropic.com/news/claude-sonnet-4-6) | Customer may use Claude only in supported countries and regions, [Usage policy](https://www.anthropic.com/legal/aup) |
-| [Anthropic Claude Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5) | Customer may use Claude only in supported countries and regions, [Usage policy](https://www.anthropic.com/legal/aup) |
-| [Anthropic Claude Sonnet 4.5](https://www.anthropic.com/news/claude-sonnet-4-5) | Customer may use Claude only in supported countries and regions, [Usage policy](https://www.anthropic.com/legal/aup) |
-| [Anthropic Claude Haiku 4.5](https://www.anthropic.com/news/claude-haiku-4-5) | Customer may use Claude only in supported countries and regions, [Usage policy](https://www.anthropic.com/legal/aup) |
-| [Anthropic Claude Opus 4.1](https://www.anthropic.com/news/claude-opus-4-1) | Customer may use Claude only in supported countries and regions, [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Opus 4.6](https://www.anthropic.com/news/claude-opus-4-6) | Customer may use Claude only in [supported countries and regions](https://www.anthropic.com/supported-countries), [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Sonnet 4.6](https://www.anthropic.com/news/claude-sonnet-4-6) | Customer may use Claude only in [supported countries and regions](https://www.anthropic.com/supported-countries), [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5) | Customer may use Claude only in [supported countries and regions](https://www.anthropic.com/supported-countries), [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Sonnet 4.5](https://www.anthropic.com/news/claude-sonnet-4-5) | Customer may use Claude only in [supported countries and regions](https://www.anthropic.com/supported-countries), [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Haiku 4.5](https://www.anthropic.com/news/claude-haiku-4-5) | Customer may use Claude only in [supported countries and regions](https://www.anthropic.com/supported-countries), [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Opus 4.1](https://www.anthropic.com/news/claude-opus-4-1) | Customer may use Claude only in [supported countries and regions](https://www.anthropic.com/supported-countries), [Usage policy](https://www.anthropic.com/legal/aup) |

--- a/docs/products/cloud/features/ai-ml/model-developer-terms.mdx
+++ b/docs/products/cloud/features/ai-ml/model-developer-terms.mdx
@@ -15,9 +15,9 @@ Following is a table of models with their terms, and other pertinent information
 
 | Model | Terms and policies |
 | :---- | :---- |
-| [Anthropic Claude Opus 4.6](https://www.anthropic.com/news/claude-opus-4-6) | [Usage policy](https://www.anthropic.com/legal/aup) |
-| [Anthropic Claude Sonnet 4.6](https://www.anthropic.com/news/claude-sonnet-4-6) | [Usage policy](https://www.anthropic.com/legal/aup) |
-| [Anthropic Claude Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5) | [Usage policy](https://www.anthropic.com/legal/aup) |
-| [Anthropic Claude Sonnet 4.5](https://www.anthropic.com/news/claude-sonnet-4-5) | [Usage policy](https://www.anthropic.com/legal/aup) |
-| [Anthropic Claude Haiku 4.5](https://www.anthropic.com/news/claude-haiku-4-5) | [Usage policy](https://www.anthropic.com/legal/aup) |
-| [Anthropic Claude Opus 4.1](https://www.anthropic.com/news/claude-opus-4-1) | [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Opus 4.6](https://www.anthropic.com/news/claude-opus-4-6) | Customer may use Claude only in supported countries and regions, [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Sonnet 4.6](https://www.anthropic.com/news/claude-sonnet-4-6) | Customer may use Claude only in supported countries and regions, [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5) | Customer may use Claude only in supported countries and regions, [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Sonnet 4.5](https://www.anthropic.com/news/claude-sonnet-4-5) | Customer may use Claude only in supported countries and regions, [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Haiku 4.5](https://www.anthropic.com/news/claude-haiku-4-5) | Customer may use Claude only in supported countries and regions, [Usage policy](https://www.anthropic.com/legal/aup) |
+| [Anthropic Claude Opus 4.1](https://www.anthropic.com/news/claude-opus-4-1) | Customer may use Claude only in supported countries and regions, [Usage policy](https://www.anthropic.com/legal/aup) |


### PR DESCRIPTION
Adds the requested regional-use restriction to every Anthropic Claude model row on the applicable model developer terms page.

Related: https://github.com/ClickHouse/ClickHouse/pull/112190

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.244` (included in `26.8` and later)
<!-- ch-version-info:end -->