### PR TITLE
Fix flaky test 02465_limit_trivial_max_rows_to_read

### DIFF
--- a/tests/queries/0_stateless/02465_limit_trivial_max_rows_to_read.sql
+++ b/tests/queries/0_stateless/02465_limit_trivial_max_rows_to_read.sql
@@ -15,7 +15,10 @@ SELECT number FROM numbers(30) LIMIT 21; -- { serverError TOO_MANY_ROWS }
 SELECT number FROM numbers(30) LIMIT 1;
 SELECT number FROM numbers(5);
 
-SELECT a FROM t_max_rows_to_read LIMIT 1;
+-- Under parallel replicas this read is split into per-replica mark ranges, so an
+-- ORDER-less LIMIT 1 may legally return any row (CI saw 32, the first row of the
+-- second task). Project a constant: only `max_rows_to_read` is measured here.
+SELECT 0 FROM t_max_rows_to_read LIMIT 1;
 SELECT a FROM t_max_rows_to_read LIMIT 11 offset 11; -- { serverError TOO_MANY_ROWS }
 SELECT a FROM t_max_rows_to_read WHERE a > 50 LIMIT 1; -- { serverError TOO_MANY_ROWS }
 

--- a/tests/queries/0_stateless/02465_limit_trivial_max_rows_to_read.sql
+++ b/tests/queries/0_stateless/02465_limit_trivial_max_rows_to_read.sql
@@ -15,9 +15,9 @@ SELECT number FROM numbers(30) LIMIT 21; -- { serverError TOO_MANY_ROWS }
 SELECT number FROM numbers(30) LIMIT 1;
 SELECT number FROM numbers(5);
 
--- Under parallel replicas this read is split into per-replica mark ranges, so an
--- ORDER-less LIMIT 1 may legally return any row (CI saw 32, the first row of the
--- second task). Project a constant: only `max_rows_to_read` is measured here.
+-- `LIMIT 1` without `ORDER BY` may return any row under parallel replicas, which split the
+-- read into per-replica mark ranges. Project a constant, so the assertion does not depend on
+-- which replica answered; `max_rows_to_read` is what this line measures.
 SELECT 0 FROM t_max_rows_to_read LIMIT 1;
 SELECT a FROM t_max_rows_to_read LIMIT 11 offset 11; -- { serverError TOO_MANY_ROWS }
 SELECT a FROM t_max_rows_to_read WHERE a > 50 LIMIT 1; -- { serverError TOO_MANY_ROWS }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/111968


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed flaky test `02465_limit_trivial_max_rows_to_read`.

### Description

The statement `SELECT a FROM t_max_rows_to_read LIMIT 1` has no `ORDER BY`, so its result is
unspecified: any row of the table is a legal answer. On a single reader one stream reads the
first granule first, so the answer happened to be `0` and the `.reference` file has asserted
that one particular unspecified answer since the test was written. Under parallel replicas the
read is split into per-replica mark ranges and whichever replica answers first supplies the row
that `LIMIT 1` keeps, so the assertion is not stable.

The test therefore fails intermittently with a one-line reference diff, always the same wrong
value:

```
@@ -1,7 +1,7 @@
 0 / 0 / 1 / 2 / 3 / 4
-0
+32
```

`32` is not a random row. On this lane all parts are on object storage, so
`PartRangesReadInfo` takes the remote branch where both
`merge_tree_min_rows_for_concurrent_read_for_remote_filesystem` and
`merge_tree_min_bytes_for_concurrent_read_for_remote_filesystem` default to `0`, and
`minMarksForConcurrentRead` collapses to `merge_tree_min_read_task_size` = 8 marks per task.
With `index_granularity = 4` the second task begins at mark 8, whose first row is
`8 * 4 = 32`. On a local disk the same formula yields one task covering the whole part, which
is why the failure only ever appears on the object-storage lanes.

The fix makes the asserted output invariant instead of pinning the reader: the statement now
projects a constant, so every legal row selection produces the reference value. The
`.reference` file is unchanged, because it already asserts `0`.

What the line measures is unchanged, and I verified that rather than assuming it:

* `EXPLAIN` still shows `ReadFromMergeTree` and `ReadFromRemoteParallelReplicas`, and
  `EXPLAIN PIPELINE` still shows `MergeTreeSelect(pool: ReadPoolParallelReplicas, ...)`. The
  read is not eliminated: with no column referenced, `chooseSmallestColumnToReadFromStorage`
  injects the table's single column.
* `read_rows` and `ProfileEvents['SelectedMarks']` from `system.query_log` are identical
  before and after the change (`4` and `25`).
* `max_rows_to_read` accounting is still live on the new form: lowering it to 3, 2 or 1 still
  raises `TOO_MANY_ROWS`, at exactly the same thresholds as the old form. This also holds with
  `enable_analyzer = 0`.

The assertion is also self-protecting, which is why a constant projection does not make it
vacuous: the line prints exactly one row only if a row was really read, so if the read were
ever eliminated the output would lose a line and the test would fail, and if the original
trivial-`LIMIT` accounting regressed the statement would raise `TOO_MANY_ROWS` and the test
would fail too. Only the identity of the returned row stopped being asserted.

`max_rows_to_read = 20` and `index_granularity = 4`, which are what the test actually
measures, are untouched, and no setting is pinned, so nothing leaks into the following
statements. The two `TOO_MANY_ROWS` statements on this table keep exercising parallel-replica
limit enforcement on this lane.

I did not add `-- Tags: no-parallel-replicas` and did not add the test to
`tests/parallel_replicas_blacklist.txt`: either would remove the whole test from the
ParallelReplicas lane, where it otherwise runs green thousands of times, and only one of its
seven statements is affected. A blacklist entry would additionally report the test as
`NOT_FAILED` ("test succeeded but is listed in the blacklist") on every passing run.

The same shape is already used in the tree for the same reason, in
`tests/queries/0_stateless/01913_exact_rows_before_limit.sql`.

**CI report.** The failure this fixes, on the lane it appears on:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111968&sha=3084113c10b2726a333dc26732034c039ac441ab&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29
There is no open issue for this test; I searched and found none, so there is nothing to close
here. Over the last 30 days the test failed this way on four unrelated pull requests and never
on master, always on the object-storage ParallelReplicas lanes.

**Reproduction.** An object-storage server with a three-replica parallel-replicas cluster.
With the test's own settings the broken form returned `32` on 1 of 2000 runs, and the fixed
form returned `0` on 2000 of 2000. With `parallel_replicas_local_plan = 0`, which the test
runner randomizes, the rate rises: the broken form returned `32` on 7 of 200 runs and the
fixed form on 0 of 200. `clickhouse-test --s3-storage --test-runs 50` is green, as is a run
with `enable_analyzer = 0`.

**Not fixed here.** The same statement has a second, unrelated failure mode on the
`distributed plan` variant of this lane: `TOO_MANY_ROWS max rows: 20.00, current rows:`
followed by `24.00`, `25.00` or `100.00`. That is per-replica limit accounting rather than row
identity, so an output-invariance change cannot address it, and all three occurrences over the
last 90 days are confined to one open pull request that changes exactly that machinery.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.433` (included in `26.8` and later)
<!-- ch-version-info:end -->