### PR TITLE
Lock the alter lock when stamping metadata_version in the restarting thread

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -51,6 +51,7 @@ static struct InitFiu
     ONCE(smt_restore_attach_retry) \
     PAUSEABLE_ONCE(smt_commit_tweaks_gate_open) \
     PAUSEABLE_ONCE(smt_commit_tweaks_gate_close) \
+    PAUSEABLE_ONCE(rmt_restarting_thread_pause_after_alter_lock) \
     ONCE(smt_commit_merge_change_version_before_op) \
     ONCE(smt_merge_mutate_intention_freeze_in_destructor) \
     ONCE(smt_add_part_sleep_after_add_before_commit) \

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -29,6 +29,7 @@ namespace DB
 namespace MergeTreeSetting
 {
     extern const MergeTreeSettingsSeconds zookeeper_session_expiration_check_period;
+    extern const MergeTreeSettingsSeconds lock_acquire_timeout_for_background_operations;
 }
 
 namespace ErrorCodes
@@ -41,6 +42,7 @@ namespace ErrorCodes
 namespace FailPoints
 {
     extern const char finish_clean_quorum_failed_parts[];
+    extern const char rmt_restarting_thread_pause_after_alter_lock[];
 };
 
 /// Used to check whether it's us who set node `is_active`, or not.
@@ -221,6 +223,19 @@ bool ReplicatedMergeTreeRestartingThread::tryStartup()
         const bool replica_metadata_version_exists = replica_metadata_version != -1;
         if (replica_metadata_version_exists)
         {
+            /// Stamp the metadata version under lockForAlter. This is an in-memory read-modify-write of
+            /// the committed metadata, and a concurrent settings/comment ALTER commits under the same
+            /// lock without touching ZooKeeper (see StorageReplicatedMergeTree::alter, non-replicated
+            /// branches). Without the lock, such an ALTER could interleave between the read and the set
+            /// below and be reverted in memory while it stays in the durable .sql. Mirrors the lock taken
+            /// in executeMetadataAlter before setTableStructure.
+            auto table_lock_holder = storage.lockForAlter(
+                (*storage.getSettings())[MergeTreeSetting::lock_acquire_timeout_for_background_operations]);
+
+            /// Test barrier: pause here while holding the alter lock, so a test can verify a concurrent
+            /// settings/comment ALTER cannot interleave with this metadata_version stamp.
+            FailPointInjection::pauseFailPoint(FailPoints::rmt_restarting_thread_pause_after_alter_lock);
+
             auto storage_metadata_snapshot = storage.getInMemoryMetadataPtr(storage.getContext(), false);
             /// This metadata snapshot lives for the table's lifetime, so route the clone into the
             /// dedicated MergeTree arena like the ALTER paths (this runs on the restarting thread,

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -223,17 +223,11 @@ bool ReplicatedMergeTreeRestartingThread::tryStartup()
         const bool replica_metadata_version_exists = replica_metadata_version != -1;
         if (replica_metadata_version_exists)
         {
-            /// Stamp the metadata version under lockForAlter. This is an in-memory read-modify-write of
-            /// the committed metadata, and a concurrent settings/comment ALTER commits under the same
-            /// lock without touching ZooKeeper (see StorageReplicatedMergeTree::alter, non-replicated
-            /// branches). Without the lock, such an ALTER could interleave between the read and the set
-            /// below and be reverted in memory while it stays in the durable .sql. Mirrors the lock taken
-            /// in executeMetadataAlter before setTableStructure.
+            /// Serialize this in-memory metadata_version read-modify-write with concurrent ALTERs
+            /// (which commit under the same lock); otherwise a settings/comment ALTER could be reverted.
             auto table_lock_holder = storage.lockForAlter(
                 (*storage.getSettings())[MergeTreeSetting::lock_acquire_timeout_for_background_operations]);
 
-            /// Test barrier: pause here while holding the alter lock, so a test can verify a concurrent
-            /// settings/comment ALTER cannot interleave with this metadata_version stamp.
             FailPointInjection::pauseFailPoint(FailPoints::rmt_restarting_thread_pause_after_alter_lock);
 
             auto storage_metadata_snapshot = storage.getInMemoryMetadataPtr(storage.getContext(), false);

--- a/tests/queries/0_stateless/04651_wp_s9_restart_metadata_version_lock.reference
+++ b/tests/queries/0_stateless/04651_wp_s9_restart_metadata_version_lock.reference
@@ -1,0 +1,2 @@
+locked
+after

--- a/tests/queries/0_stateless/04651_wp_s9_restart_metadata_version_lock.sh
+++ b/tests/queries/0_stateless/04651_wp_s9_restart_metadata_version_lock.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Tags: zookeeper, no-parallel
+# - zookeeper: uses ReplicatedMergeTree
+# - no-parallel: the pause failpoint is process-global
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_wp_s9 SYNC"
+$CLICKHOUSE_CLIENT -q "
+    CREATE TABLE t_wp_s9 (a UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/t_wp_s9', 'r1')
+    ORDER BY a"
+
+# The restarting thread stamps metadata_version with an in-memory read-modify-write. It now takes the
+# table's alter_lock around it; pause there (holding the lock).
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT rmt_restarting_thread_pause_after_alter_lock"
+
+# Trigger the stamp path; it pauses while holding the alter_lock.
+$CLICKHOUSE_CLIENT -q "SYSTEM RESTART REPLICA t_wp_s9" &
+RESTART_PID=$!
+
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT rmt_restarting_thread_pause_after_alter_lock PAUSE"
+
+# A concurrent settings/comment ALTER must not acquire the alter_lock while the restarting thread holds
+# it -> it times out. Before the fix the stamp took no lock, so this ALTER would run concurrently with
+# the metadata_version stamp and could be reverted in memory.
+$CLICKHOUSE_CLIENT --lock_acquire_timeout=1 -q "ALTER TABLE t_wp_s9 MODIFY COMMENT 'wp_s9'" 2>&1 \
+    | grep -qiE "DEADLOCK_AVOIDED|timed out" && echo "locked" || echo "not locked"
+
+# Resume the restarting thread.
+$CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT rmt_restarting_thread_pause_after_alter_lock"
+wait "$RESTART_PID"
+
+# The table is functional after the restart: a comment ALTER now applies.
+$CLICKHOUSE_CLIENT -q "ALTER TABLE t_wp_s9 MODIFY COMMENT 'after'"
+$CLICKHOUSE_CLIENT -q "SELECT comment FROM system.tables WHERE database = currentDatabase() AND name = 't_wp_s9'"
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE t_wp_s9 SYNC"

--- a/tests/queries/0_stateless/04651_wp_s9_restart_metadata_version_lock.sh
+++ b/tests/queries/0_stateless/04651_wp_s9_restart_metadata_version_lock.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-# Tags: zookeeper, no-parallel
+# Tags: zookeeper, no-parallel, no-shared-merge-tree
 # - zookeeper: uses ReplicatedMergeTree
 # - no-parallel: the pause failpoint is process-global
+# - no-shared-merge-tree: targets ReplicatedMergeTreeRestartingThread; under the SharedMergeTree test
+#   mode the table becomes SharedMergeTree, SYSTEM RESTART REPLICA is rejected, the RMT failpoint never
+#   fires, and SYSTEM WAIT FAILPOINT ... PAUSE would hang until the test timeout
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04651_wp_s9_restart_metadata_version_lock.sh
+++ b/tests/queries/0_stateless/04651_wp_s9_restart_metadata_version_lock.sh
@@ -10,6 +10,13 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+FP=rmt_restarting_thread_pause_after_alter_lock
+
+# Always disable the failpoint on exit, so an unexpected failure never leaves the restarting thread
+# paused while holding alter_lock (which would contaminate later tests / stall shutdown).
+cleanup() { $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT $FP" >/dev/null 2>&1; }
+trap cleanup EXIT
+
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_wp_s9 SYNC"
 $CLICKHOUSE_CLIENT -q "
     CREATE TABLE t_wp_s9 (a UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/t_wp_s9', 'r1')
@@ -17,22 +24,23 @@ $CLICKHOUSE_CLIENT -q "
 
 # The restarting thread stamps metadata_version with an in-memory read-modify-write. It now takes the
 # table's alter_lock around it; pause there (holding the lock).
-$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT rmt_restarting_thread_pause_after_alter_lock"
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT $FP"
 
 # Trigger the stamp path; it pauses while holding the alter_lock.
 $CLICKHOUSE_CLIENT -q "SYSTEM RESTART REPLICA t_wp_s9" &
 RESTART_PID=$!
 
-$CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT rmt_restarting_thread_pause_after_alter_lock PAUSE"
+# Bounded so a missed pause fails the test instead of hanging until the global timeout.
+timeout 60 $CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT $FP PAUSE"
 
 # A concurrent settings/comment ALTER must not acquire the alter_lock while the restarting thread holds
-# it -> it times out. Before the fix the stamp took no lock, so this ALTER would run concurrently with
-# the metadata_version stamp and could be reverted in memory.
+# it -> lockForAlter times out with DEADLOCK_AVOIDED. Before the fix the stamp took no lock, so this
+# ALTER would run concurrently with the metadata_version stamp and could be reverted in memory.
 $CLICKHOUSE_CLIENT --lock_acquire_timeout=1 -q "ALTER TABLE t_wp_s9 MODIFY COMMENT 'wp_s9'" 2>&1 \
-    | grep -qiE "DEADLOCK_AVOIDED|timed out" && echo "locked" || echo "not locked"
+    | grep -qF "DEADLOCK_AVOIDED" && echo "locked" || echo "not locked"
 
 # Resume the restarting thread.
-$CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT rmt_restarting_thread_pause_after_alter_lock"
+$CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT $FP"
 wait "$RESTART_PID"
 
 # The table is functional after the restart: a comment ALTER now applies.


### PR DESCRIPTION
## Problem

On a `ReplicatedMergeTree` table, a settings/comment `ALTER` that runs concurrently with the
replica's restarting thread (triggered on ZooKeeper session (re)connection, or by `SYSTEM RESTART
REPLICA`) can be silently reverted in the running server's in-memory metadata while it stays in the
durable `.sql` — leaving in-memory metadata behind disk until the next restart.

## Root cause

`ReplicatedMergeTreeRestartingThread::tryStartup` stamps the replica's `metadata_version` onto the
in-memory metadata with an **unlocked read-modify-write**: it reads a metadata snapshot and then calls
`setInMemoryMetadata(snapshot->withMetadataVersion(...))`.

A settings-only / comment-only `ALTER` (and the settings/comment part of a mixed alter) commits its
in-memory change **inline, under `alter_lock`**, in the non-replicated branches of
`StorageReplicatedMergeTree::alter` (`isSettingsAlter` / `isCommentAlter` /
`areNonReplicatedAlterCommands`). On a plain `Atomic` database these touch no ZooKeeper — they are
local operations (`We don't replicate storage_settings_ptr ALTER. It's local operation.` and `The
comment is not replicated as of today`). If such an `ALTER` had already passed `assertNotReadonly` and
is still committing when a ZooKeeper session loss triggers the restarting thread, the two run
concurrently; the stamp takes no lock, reads a pre-`ALTER` snapshot, and later writes it back, clobbering
the `ALTER`:

```
ALTER thread                                     restarting thread
------------                                     -----------------
assertNotReadonly()  -> OK    
(replica active, ZooKeeper session alive)
// passes just before the session drops; 
// a new ALTER after this point is rejected
take alter_lock
                                                [ZooKeeper session expires]
                                                partialShutdown(): is_readonly = true
                                                // takes no alter_lock; the ALTER already cleared the gate
                                                tryStartup():
                                                M0 = getInMemoryMetadataPtr(...)      
                                                // comment='' , unlocked read
setInMemoryMetadata(comment='hello')
 -->   in-memory = M1
alterTable(.sql = 'hello')
// durable .sql = 'hello'
release alter_lock
                                               setInMemoryMetadata(M0.withMetadataVersion(v))
                                               // in-memory = comment='' , clobbers M1
```

The `assertNotReadonly` gate is why the window is narrow: a fresh `ALTER` issued after the session
drops is rejected (`TABLE_IS_READ_ONLY`); only an `ALTER` that had already passed the gate and is still
committing when the session drops can overlap the restarting thread's stamp.

Result: in-memory `comment=''` (reverted) while the durable `.sql` has `comment='hello'`; the divergence
persists until the next restart reloads the `.sql`. Violated invariant: an in-memory read-modify-write of
committed metadata must be serialized with `ALTER`s (both under `alter_lock`).

Only settings/comment are exposed to this race. Pure `ADD`/`DROP`/`MODIFY COLUMN` do not commit the new
structure in memory inline: the interpreter writes an `ALTER_METADATA` ZooKeeper log entry, and the
structure is applied later by the replication queue's `executeMetadataAlter` -> `setTableStructure`, which
`runImpl` starts only after `tryStartup` finishes (and which takes `alter_lock` itself) — so it never
overlaps the stamp.

## Solution

Take `lockForAlter` around the stamp (using the background-operation lock timeout), so it is
serialized with `ALTER`s — mirroring the lock `executeMetadataAlter` already holds before
`setTableStructure`. `lockForAlter` is a timed acquire that throws `DEADLOCK_AVOIDED` on timeout (the
restarting thread then retries), so it cannot hang. Add a `PAUSEABLE_ONCE` failpoint and a stateless
regression test that pauses the stamp while it holds the lock (triggered via `SYSTEM RESTART REPLICA`)
and asserts a concurrent `ALTER` on the table cannot acquire the lock, then that the table is functional
afterwards.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a race where a `ReplicatedMergeTree` replica restart could revert a concurrent settings or comment `ALTER` in the server's in-memory metadata (while the change stayed on disk) until the next restart.
