### PR TITLE
Fix a 6x performance regression in system.query_log ingestion

### DIFF
--- a/src/Interpreters/QueryLog.cpp
+++ b/src/Interpreters/QueryLog.cpp
@@ -273,11 +273,22 @@ void QueryLogElement::appendToBlock(MutableColumns & columns) const
     }
 
     {
-        Map map;
-        map.reserve(query_settings.size());
+        /// Write into the subcolumns directly: IColumn::insert(Field) reaches
+        /// ColumnUnique::uniqueInsert(Field), which clones a whole ColumnString per boxed value.
+        /// Both key and value are LowCardinality here, so that would be two clones per entry.
+        auto & column_map = typeid_cast<ColumnMap &>(*columns[i++]);
+        auto & offsets = column_map.getNestedColumn().getOffsets();
+        auto & tuple_column = column_map.getNestedData();
+        auto & key_column = typeid_cast<ColumnLowCardinality &>(tuple_column.getColumn(0));
+        auto & value_column = typeid_cast<ColumnLowCardinality &>(tuple_column.getColumn(1));
+
         for (const auto & [name, value] : query_settings)
-            map.push_back(Tuple{name, value});
-        columns[i++]->insert(map);
+        {
+            key_column.insertData(name.data(), name.size());
+            value_column.insertData(value.data(), value.size());
+        }
+
+        offsets.push_back(offsets.back() + query_settings.size());
     }
 
     {
@@ -336,11 +347,20 @@ void QueryLogElement::appendToBlock(MutableColumns & columns) const
     typeid_cast<ColumnInt8 &>(*columns[i++]).getData().push_back(uint8_t(query_result_cache_usage));
 
     {
-        Map map;
-        map.reserve(async_read_counters.size());
+        /// Same as for Settings above: avoid boxing through Field. Only the key is LowCardinality.
+        auto & column_map = typeid_cast<ColumnMap &>(*columns[i++]);
+        auto & offsets = column_map.getNestedColumn().getOffsets();
+        auto & tuple_column = column_map.getNestedData();
+        auto & key_column = typeid_cast<ColumnLowCardinality &>(tuple_column.getColumn(0));
+        auto & value_column = typeid_cast<ColumnUInt64 &>(tuple_column.getColumn(1));
+
         for (const auto & [name, value] : async_read_counters)
-            map.push_back(Tuple{name, value});
-        columns[i++]->insert(map);
+        {
+            key_column.insertData(name.data(), name.size());
+            value_column.getData().push_back(value);
+        }
+
+        offsets.push_back(offsets.back() + async_read_counters.size());
     }
 
     typeid_cast<ColumnUInt8 &>(*columns[i++]).getData().push_back(is_internal);

--- a/tests/queries/0_stateless/04640_query_log_map_columns_serialization.reference
+++ b/tests/queries/0_stateless/04640_query_log_map_columns_serialization.reference
@@ -1,0 +1,5 @@
+19999900000
+1
+65413	iso	\'probe_value\'	04640_settings_probe	1
+['max_parallel_prefetch_tasks','total_prefetch_tasks']
+1	1

--- a/tests/queries/0_stateless/04640_query_log_map_columns_serialization.sql
+++ b/tests/queries/0_stateless/04640_query_log_map_columns_serialization.sql
@@ -1,0 +1,74 @@
+-- Tags: no-parallel-replicas
+-- The Settings and asynchronous_read_counters columns of system.query_log are written by
+-- QueryLogElement::appendToBlock straight into the Map subcolumns. This asserts they still
+-- serialize with the right contents and row alignment.
+
+DROP TABLE IF EXISTS t_query_log_maps;
+
+CREATE TABLE t_query_log_maps (k UInt64, s String) ENGINE = MergeTree ORDER BY k
+    SETTINGS index_granularity = 128, min_bytes_for_wide_part = 0;
+
+INSERT INTO t_query_log_maps SELECT number, repeat('x', 200) FROM numbers(200000);
+
+-- Settings: a numeric value, a string value and a custom setting.
+SET max_block_size = 65413;
+SET date_time_output_format = 'iso';
+SET SQL_query_log_maps_probe = 'probe_value';
+
+-- asynchronous_read_counters is only non-empty when the prefetched read pool runs, so the three
+-- settings that decide that are pinned (both the local and the remote variant, so the test also
+-- works on object-storage runs where the parts are not local):
+--   * the read method must be pread_threadpool / threadpool (MergeTreePrefetchedReadPool::checkReadMethodAllowed);
+--   * allow_prefetched_read_pool_for_* must be on;
+--   * the PartsSplitter fault injection must be off - it takes precedence in ReadFromMergeTree and
+--     reads ReadType::InOrder, which uses no prefetch pool at all.
+SELECT sum(k) FROM t_query_log_maps
+SETTINGS log_comment = '04640_settings_probe',
+         merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0,
+         local_filesystem_read_method = 'pread_threadpool',
+         remote_filesystem_read_method = 'threadpool',
+         allow_prefetched_read_pool_for_local_filesystem = 1,
+         allow_prefetched_read_pool_for_remote_filesystem = 1,
+         filesystem_prefetch_step_marks = 1,
+         filesystem_prefetches_limit = 100,
+         merge_tree_min_rows_for_concurrent_read = 1,
+         merge_tree_min_bytes_for_concurrent_read = 1,
+         max_threads = 4;
+
+SYSTEM FLUSH LOGS query_log;
+
+-- Exactly one QueryFinish row: a wrong Map offset would misalign every later column.
+SELECT count() FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600
+  AND current_database = currentDatabase() AND type = 'QueryFinish'
+  AND log_comment = '04640_settings_probe';
+
+-- Settings keys and values round-trip, including the custom setting.
+SELECT
+    Settings['max_block_size'],
+    Settings['date_time_output_format'],
+    Settings['SQL_query_log_maps_probe'],
+    Settings['log_comment'],
+    has(mapKeys(Settings), 'max_threads')
+FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600
+  AND current_database = currentDatabase() AND type = 'QueryFinish'
+  AND log_comment = '04640_settings_probe';
+
+-- asynchronous_read_counters is written by the second changed hunk. The prefetched read pool
+-- above makes it non-empty; assert the key set, not the (load-dependent) counter values.
+SELECT arraySort(mapKeys(asynchronous_read_counters))
+FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600
+  AND current_database = currentDatabase() AND type = 'QueryFinish'
+  AND log_comment = '04640_settings_probe';
+
+-- ProfileEvents is written by the unchanged sibling site right before Settings: this guards
+-- against a shifted columns[i++] index.
+SELECT ProfileEvents['SelectedRows'] = 200000, length(mapKeys(ProfileEvents)) > 10
+FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600
+  AND current_database = currentDatabase() AND type = 'QueryFinish'
+  AND log_comment = '04640_settings_probe';
+
+DROP TABLE t_query_log_maps;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/112191
Related: https://github.com/ClickHouse/ClickHouse/pull/110708
-->


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a performance regression in `system.query_log` ingestion. Building the `Settings` and `asynchronous_read_counters` map columns was about 6 times slower than before, which could make `SYSTEM FLUSH LOGS query_log` exceed its 180 second timeout on servers that log many queries with many changed settings. Closes #112191.


### Description

`QueryLogElement::appendToBlock` serialized these two `Map` columns by boxing every key and value through `Field` and calling `IColumn::insert`:

```cpp
Map map;
map.reserve(query_settings.size());
for (const auto & [name, value] : query_settings)
    map.push_back(Tuple{name, value});
columns[i++]->insert(map);
```

`ColumnMap::insert(Field)` copies every `Field` again into a fresh `Array`, `ColumnArray::insert` and `ColumnTuple::insert` recurse per element, and `ColumnLowCardinality::insert(Field)` reaches `ColumnUnique::uniqueInsert(Field)`, which clones a whole `ColumnString`, writes one value into it, reads it back and destroys it, for every boxed value. `Settings` is `Map(LowCardinality(String), LowCardinality(String))`, so both sides go through that path and a query with N changed settings paid 2N column clones. `log_query_settings` is on by default.

This restores the direct subcolumn dump for the two affected sites, which is the same shape the sibling `ProfileEvents` site in that function already uses (`ProfileEvents::dumpToMapColumn`). The self-contained owning `std::map` members are kept, so the per-user memory tracker fix from #110708 is unaffected. Column contents, row counts and offsets are identical; there is no schema, setting or format change.

Measured in one run on one host, base being this branch with only these two hunks reverted, three flush rounds of about 8400 `query_log` entries each with 193 changed settings per query:

| | Entries | Block | us/entry | Insert | us/entry |
|---|---|---|---|---|---|
| before | 8408 / 8404 / 8404 | 1003 / 1033 / 1043 ms | 119 / 123 / 124 | 24 / 24 / 25 ms | 2.9 |
| after | 8408 / 8404 / 8404 | 121 / 220 / 172 ms | 14 / 26 / 21 | 22 / 24 / 23 ms | 2.7 |

Mean block building goes from 122 to 20 us/entry (6.0x) with no overlap between the two sets, while the INSERT phase is unchanged at 1.06x, which rules out a host or disk artifact. The regression is also visible on master across the #110708 boundary in `Stateless tests (amd_tsan, parallel)` server logs (885-1053 us/entry before, 4938-6233 after), and in a failing job's own flush profile, where block building was 89.9% of a 748 second flush. The win is on log ingestion, not on any CI performance test metric.

The new stateless test asserts correctness, not timing: that both maps still serialize with the right contents (including a custom setting and a string and a numeric value), that exactly one row is produced, and that the unchanged neighbouring `ProfileEvents` column is still correct, which is what a shifted `columns[i++]` index would break. Reverting the fix leaves that test green, since this is a pure performance change; the measurement above is the only evidence for the speedup. `tests/integration/test_user_memory_tracker_log_drift/test.py`, the guard added by #110708, still passes.

Deliberately out of scope: the same `Field`-boxed map serialization exists in `PartLog` (`projections_duration_ms`), `BackupLog` (`settings`, `engine_settings`), `MetricLog` (`labels`, `histogram`) and `OpenTelemetrySpanLog` (`attribute`). The boxing in all five predates #110708, verified per hunk rather than per file: `PartLog`, `BackupLog` and `OpenTelemetrySpanLog` do not appear in its diff at all, and its two `MetricLog` lines are the same statements moved by the `add()` refactor, so it adds and removes the same two `push_back(Tuple{...})` there, whereas in `QueryLog.cpp` it adds two and removes none. They are left for a separate change rather than turning this regression fix into a general sweep. `MetricLog`'s `histogram` is `Map(Float64, UInt64)` and has no `LowCardinality` side at all, so the clone-per-value cost does not apply there.

Regarding the two candidates listed in #112191: `CompressionCodecAdaptive` from #111134 can be excluded, as it has no production caller (`git grep` finds it only in its own two files and its unit test, and its `doCompressData` throws "must not be invoked directly: it never appears on disk"), so it is not on the system-log write path.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.268` (included in `26.8` and later)
<!-- ch-version-info:end -->