### PR TITLE
Fix classification of a parameterized view whose SELECT body is not a flat UNION list

### DIFF
--- a/src/Parsers/ASTSelectWithUnionQuery.cpp
+++ b/src/Parsers/ASTSelectWithUnionQuery.cpp
@@ -12,13 +12,9 @@ namespace DB
 namespace
 {
 
-/// A child of `list_of_selects` is not always exactly an `ASTSelectQuery`: interpreter passes rewrite
-/// the list in place. `SelectIntersectExceptQueryVisitor` replaces children with an
-/// `ASTSelectIntersectExceptQuery`, which derives from `ASTSelectQuery` and therefore does NOT match
-/// `as<ASTSelectQuery>()` (that is an exact typeid check), and `NormalizeSelectWithUnionQueryVisitor`
-/// can nest a fresh `ASTSelectWithUnionQuery`. Query parameters must remain visible for every kind,
-/// otherwise a parameterized view is classified as an ordinary one and its metadata cannot be read
-/// back (`Invalid storage definition in metadata file`).
+/// `as<ASTSelectQuery>()` is an exact typeid check, so a derived or nested child of
+/// `list_of_selects` (interpreter passes substitute both) would be skipped and its query
+/// parameters lost. The last branch is the general answer; the first two only keep the memo.
 
 bool childHasQueryParameters(const ASTPtr & child)
 {

--- a/src/Parsers/ASTSelectWithUnionQuery.cpp
+++ b/src/Parsers/ASTSelectWithUnionQuery.cpp
@@ -3,10 +3,42 @@
 #include <Parsers/SelectUnionMode.h>
 #include <IO/Operators.h>
 #include <Parsers/ASTSelectQuery.h>
+#include <Parsers/QueryParameterVisitor.h>
 
 
 namespace DB
 {
+
+namespace
+{
+
+/// A child of `list_of_selects` is not always exactly an `ASTSelectQuery`: interpreter passes rewrite
+/// the list in place. `SelectIntersectExceptQueryVisitor` replaces children with an
+/// `ASTSelectIntersectExceptQuery`, which derives from `ASTSelectQuery` and therefore does NOT match
+/// `as<ASTSelectQuery>()` (that is an exact typeid check), and `NormalizeSelectWithUnionQueryVisitor`
+/// can nest a fresh `ASTSelectWithUnionQuery`. Query parameters must remain visible for every kind,
+/// otherwise a parameterized view is classified as an ordinary one and its metadata cannot be read
+/// back (`Invalid storage definition in metadata file`).
+
+bool childHasQueryParameters(const ASTPtr & child)
+{
+    if (const auto * select_node = child->as<ASTSelectQuery>())
+        return select_node->hasQueryParameters();
+    if (const auto * union_node = child->as<ASTSelectWithUnionQuery>())
+        return union_node->hasQueryParameters();
+    return !analyzeReceiveQueryParams(child).empty();
+}
+
+NameToNameMap childQueryParameters(const ASTPtr & child)
+{
+    if (const auto * select_node = child->as<ASTSelectQuery>())
+        return select_node->getQueryParameters();
+    if (const auto * union_node = child->as<ASTSelectWithUnionQuery>())
+        return union_node->getQueryParameters();
+    return analyzeReceiveQueryParamsWithType(child);
+}
+
+}
 
 ASTPtr ASTSelectWithUnionQuery::clone() const
 {
@@ -142,13 +174,10 @@ bool ASTSelectWithUnionQuery::hasQueryParameters() const
     {
         for (const auto & child : list_of_selects->children)
         {
-            if (auto * select_node = child->as<ASTSelectQuery>())
+            if (childHasQueryParameters(child))
             {
-                if (select_node->hasQueryParameters())
-                {
-                    has_query_parameters = true;
-                    return has_query_parameters.value();
-                }
+                has_query_parameters = true;
+                return has_query_parameters.value();
             }
         }
         has_query_parameters = false;
@@ -166,14 +195,8 @@ NameToNameMap ASTSelectWithUnionQuery::getQueryParameters() const
 
     for (const auto & child : list_of_selects->children)
     {
-        if (auto * select_node = child->as<ASTSelectQuery>())
-        {
-            if (select_node->hasQueryParameters())
-            {
-                NameToNameMap select_node_param = select_node->getQueryParameters();
-                query_params.insert(select_node_param.begin(), select_node_param.end());
-            }
-        }
+        NameToNameMap child_params = childQueryParameters(child);
+        query_params.insert(child_params.begin(), child_params.end());
     }
 
     return query_params;

--- a/tests/queries/0_stateless/04651_parameterized_view_union_child_metadata.reference
+++ b/tests/queries/0_stateless/04651_parameterized_view_union_child_metadata.reference
@@ -1,0 +1,26 @@
+--- create ---
+v_except	[('n','UInt64')]
+v_flat	[('n','UInt64')]
+v_intersect	[('n','UInt64')]
+v_nested_union	[('n','UInt64')]
+v_not_parameterized	[]
+--- reload ---
+v_except	[('n','UInt64')]
+v_flat	[('n','UInt64')]
+v_intersect	[('n','UInt64')]
+v_nested_union	[('n','UInt64')]
+v_not_parameterized	[]
+--- query after reload ---
+2
+7
+2
+3
+9
+5
+--- create (parenthesized) ---
+v_paren	[('n','UInt64')]
+--- reload (parenthesized) ---
+v_paren	[('n','UInt64')]
+1
+3
+8

--- a/tests/queries/0_stateless/04651_parameterized_view_union_child_metadata.sh
+++ b/tests/queries/0_stateless/04651_parameterized_view_union_child_metadata.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: spawns clickhouse-local and writes an on-disk metadata directory.
+
+# A parameterized view whose SELECT body is not a flat list of ASTSelectQuery children (INTERSECT/
+# EXCEPT, or a UNION chain mixing DISTINCT and ALL) used to lose its "parameterized" classification
+# once the interpreter rewrote the union list, so its metadata could not be read back: loading it
+# threw "Invalid storage definition in metadata file" and aborted the server on startup.
+# The second clickhouse-local invocation over the same --path is what exercises the load path.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+dir=${CLICKHOUSE_TEST_UNIQUE_NAME}
+[[ -d $dir ]] && rm -rf "$dir"
+mkdir "$dir"
+
+echo '--- create ---'
+$CLICKHOUSE_LOCAL --path "$dir" --multiline -q """
+CREATE DATABASE db ENGINE = Atomic;
+CREATE VIEW db.v_intersect AS SELECT {n:UInt64} AS x INTERSECT SELECT 2;
+CREATE VIEW db.v_except AS SELECT {n:UInt64} AS x EXCEPT SELECT 2;
+CREATE VIEW db.v_nested_union AS SELECT {n:UInt64} AS x UNION DISTINCT SELECT 2 UNION ALL SELECT 3;
+CREATE VIEW db.v_flat AS SELECT {n:UInt64} AS x;
+CREATE VIEW db.v_not_parameterized AS SELECT 1 AS x INTERSECT SELECT 2;
+SELECT name, parameterized_view_parameters FROM system.tables WHERE database = 'db' ORDER BY name;
+"""
+
+echo '--- reload ---'
+$CLICKHOUSE_LOCAL --path "$dir" -q "SELECT name, parameterized_view_parameters FROM system.tables WHERE database = 'db' ORDER BY name"
+
+echo '--- query after reload ---'
+$CLICKHOUSE_LOCAL --path "$dir" --multiline -q """
+SELECT * FROM db.v_intersect(n = 2);
+SELECT * FROM db.v_except(n = 7);
+SELECT * FROM db.v_nested_union(n = 9) ORDER BY x;
+SELECT * FROM db.v_flat(n = 5);
+SELECT * FROM db.v_not_parameterized;
+"""
+
+rm -rf "$dir"
+
+# The explicitly parenthesized nested union is a distinct shape: the parser (not a rewrite pass)
+# nests it, so before the fix the parameter was already invisible at CREATE time and the parameter
+# got substituted instead of being kept. It never wrote unreadable metadata, but the same accessor
+# governs it, so the view is now preserved as parameterized. It needs its own invocation because on
+# an unfixed binary the CREATE fails and would abort the script above.
+dir2=${CLICKHOUSE_TEST_UNIQUE_NAME}_paren
+[[ -d $dir2 ]] && rm -rf "$dir2"
+mkdir "$dir2"
+
+echo '--- create (parenthesized) ---'
+$CLICKHOUSE_LOCAL --path "$dir2" --multiline -q """
+CREATE DATABASE db ENGINE = Atomic;
+CREATE VIEW db.v_paren AS SELECT 1 AS x UNION DISTINCT (SELECT {n:UInt64} AS x UNION ALL SELECT 3);
+SELECT name, parameterized_view_parameters FROM system.tables WHERE database = 'db' ORDER BY name;
+"""
+
+echo '--- reload (parenthesized) ---'
+$CLICKHOUSE_LOCAL --path "$dir2" --multiline -q """
+SELECT name, parameterized_view_parameters FROM system.tables WHERE database = 'db' ORDER BY name;
+SELECT * FROM db.v_paren(n = 8) ORDER BY x;
+"""
+
+rm -rf "$dir2"

--- a/tests/queries/0_stateless/04651_parameterized_view_union_child_metadata.sh
+++ b/tests/queries/0_stateless/04651_parameterized_view_union_child_metadata.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
-# no-fasttest: spawns clickhouse-local and writes an on-disk metadata directory.
 
 # A parameterized view whose SELECT body is not a flat list of ASTSelectQuery children (INTERSECT/
 # EXCEPT, or a UNION chain mixing DISTINCT and ALL) used to lose its "parameterized" classification


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/111542
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a parameterized view whose `SELECT` body uses `INTERSECT`/`EXCEPT`, or a `UNION` chain that mixes `UNION DISTINCT` with `UNION ALL`, being classified as an ordinary view. Such a view was created successfully but its metadata could not be read back: loading it threw `Invalid storage definition in metadata file`, which made the view permanently unloadable and aborted a debug or sanitizer server on startup. `system.tables.parameterized_view_parameters` also reported no parameters for those views.

### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/111542

`ASTSelectWithUnionQuery::hasQueryParameters()` inspected a `list_of_selects` child only when `child->as<ASTSelectQuery>()` succeeded. `IAST::as<T>()` is `typeid_cast`, an exact typeid match, so a child of any other type was skipped silently and its query parameters became invisible. Two child kinds reach that hole, and interpreter passes create both:

- `ASTSelectIntersectExceptQuery`, which `SelectIntersectExceptQueryVisitor` substitutes into the list. It derives from `ASTSelectQuery`, so the exact typeid check does not match it.
- a nested `ASTSelectWithUnionQuery`, which `NormalizeSelectWithUnionQueryVisitor` creates for a chain that mixes `UNION DISTINCT` with `UNION ALL`. This carrier involves no `INTERSECT` or `EXCEPT` at all.

The two code paths ask the question in opposite orders. On `CREATE`, classification runs before both rewrites and is memoized, so the answer is correct and the metadata written is correct for a parameterized view. On startup load, `DatabaseOrdinary::loadTablesMetadata` runs both rewrites before any classification, so the answer is computed on the already-rewritten tree and comes out false. `createTableFromAST` then keeps `has_columns = true`, finds no column list and (for a view) no engine, and throws `LOGICAL_ERROR` at `DatabaseOnDisk.cpp:137-139`. Because a logical error aborts at construction in debug and sanitizer builds, that happens before the `AsyncLoader` worker's `catch(...)`, so a single such view stops the whole server from starting, even under `FORCE_ATTACH`.

The fix makes both `hasQueryParameters()` and `getQueryParameters()` answer for the whole `SELECT` body, reusing the existing `analyzeReceiveQueryParams`/`analyzeReceiveQueryParamsWithType` helpers that `ASTSelectQuery::hasQueryParameters()` already uses. Both accessors are changed, otherwise a view would load but `system.tables.parameterized_view_parameters` would still report nothing for it.

The accessor is the single point of truth: every consumer (`isParameterizedView()`, the create-time substitution gate, `system.tables`, `createTableFromAST`) already calls these two functions and already expects the whole-body answer. Reordering the visitors would add a third classification point and leave `system.tables` wrong; relaxing the `DatabaseOnDisk.cpp` check would leave the view unloadable while removing a guard that legitimately detects hand-edited metadata.

Reproducible without a server, object storage or a fuzzer:

```
D=$(mktemp -d)
clickhouse local --path $D -q "CREATE DATABASE d ENGINE=Atomic;
                               CREATE VIEW d.v AS SELECT {n:UInt64} AS x INTERSECT SELECT 2;"
clickhouse local --path $D -q "SELECT name FROM system.tables WHERE database='d'"
```

The second invocation aborts before this change and succeeds after it. A directory written by an unpatched binary loads correctly with a patched one, because the classification is recomputed when the metadata is parsed again, so existing broken views recover on upgrade without manual repair. The metadata format is unchanged: a parameterized view simply stores no column list, exactly as the already-working flat spelling does.

One behaviour change is worth calling out. A view written with explicit parentheses, such as `SELECT 1 AS x UNION DISTINCT (SELECT {n:UInt64} AS x UNION ALL SELECT 3)`, is nested by the parser rather than by a rewrite, so its parameter was invisible at `CREATE` time too. It never wrote unreadable metadata: with the parameter unset the `CREATE` failed with `UNKNOWN_QUERY_PARAMETER`, and with it set the parameter was substituted and an ordinary view was stored. The same accessor governs that shape, so it is now preserved as a parameterized view, matching what the equivalent flat spelling already did. The regression test covers it.

This does not claim to close the torn-read race that issue #111542 is titled after: the reporter's own failing tables do not look like parameterized views, so that instance may be a different mechanism. What it fixes is the deterministic carrier of the same fatal message, reproduced above and seen aborting the same table across six consecutive restarts in a CI artifact on that issue. #110906 is disjoint: it only degrades a future variant of this failure from a server abort to an exception, and is not the fix for these views.