### PR TITLE
Make ReadFromSystemOneStep serializable for distributed query plans

### DIFF
--- a/src/Processors/QueryPlan/ReadFromPreparedSource.cpp
+++ b/src/Processors/QueryPlan/ReadFromPreparedSource.cpp
@@ -10,6 +10,8 @@
 #include <Processors/QueryPlan/QueryPlanStepRegistry.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
 #include <Columns/ColumnConst.h>
+#include <Core/Block.h>
+#include <DataTypes/IDataType.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <IO/WriteHelpers.h>
 #include <IO/ReadHelpers.h>
@@ -24,8 +26,23 @@ namespace Setting
 
 namespace ErrorCodes
 {
-    extern const int LOGICAL_ERROR;
+    extern const int INCORRECT_DATA;
     extern const int NOT_IMPLEMENTED;
+}
+
+namespace
+{
+
+/// `system.one` always reads as a single UInt8 column named `dummy`, and both writers of its
+/// pipeline (`ReadFromSystemOneStep::initializePipeline` and `ReadFromStorageStep::deserialize` below)
+/// build a chunk of exactly that shape.
+bool isCanonicalSystemOneHeader(const Block & header)
+{
+    return header.columns() == 1
+        && header.getByPosition(0).name == "dummy"
+        && WhichDataType(header.getByPosition(0).type).isUInt8();
+}
+
 }
 
 ReadFromPreparedSource::ReadFromPreparedSource(Pipe pipe_)
@@ -76,10 +93,23 @@ bool ReadFromStorageStep::isSerializable() const
 
 std::unique_ptr<IQueryPlanStep> ReadFromStorageStep::deserialize(Deserialization & ctx)
 {
+    /// PAIRED ENCODERS: this step's own `serialize` above, and
+    /// `ReadFromSystemOneStep::serialize` in `src/Storages/System/StorageSystemOne.cpp`, which
+    /// serializes under this step's registered name ("ReadFromStorage"). Both write exactly one
+    /// string, "SystemOne" - keep all three in sync.
     String storage_name;
     readStringBinary(storage_name, ctx.in);
+    /// Query plans can be sent by a client (`TCPHandler::receiveQueryPlan`), so a malformed payload is
+    /// bad input, not a logical error: a logical error would abort debug/sanitizer builds.
     if (storage_name != "SystemOne")
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "ReadFromStorageStep deserialization is implemented only for StorageSystemOne, got: {}", storage_name);
+        throw Exception(ErrorCodes::INCORRECT_DATA, "ReadFromStorageStep deserialization is implemented only for StorageSystemOne, got: {}", storage_name);
+
+    /// The chunk below is hardcoded to the canonical shape, so a header of any other shape could not
+    /// be executed: it would fail much deeper, inside `OutputPort`, with a logical error.
+    if (!ctx.output_header || !isCanonicalSystemOneHeader(*ctx.output_header))
+        throw Exception(ErrorCodes::INCORRECT_DATA,
+            "ReadFromStorageStep deserialization for StorageSystemOne expects a single UInt8 column 'dummy', got: {}",
+            ctx.output_header ? ctx.output_header->dumpStructure() : "(none)");
 
     /// "Fake" system.one represented by a chunk with single row
     auto column = DataTypeUInt8().createColumnConst(1, 0u)->convertToFullColumnIfConst();

--- a/src/Processors/QueryPlan/tests/gtest_read_from_storage_system_one_deserialize.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_read_from_storage_system_one_deserialize.cpp
@@ -1,0 +1,185 @@
+#include <gtest/gtest.h>
+
+#include <Core/Block.h>
+#include <Core/ProtocolDefines.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
+#include <Interpreters/Context.h>
+#include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
+#include <Processors/QueryPlan/ISourceStep.h>
+#include <Processors/QueryPlan/QueryPlan.h>
+#include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
+#include <Processors/QueryPlan/QueryPlanStepRegistry.h>
+#include <Processors/QueryPlan/Serialization.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
+#include <QueryPipeline/QueryPipeline.h>
+#include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Common/Exception.h>
+#include <Common/tests/gtest_global_context.h>
+
+#include <mutex>
+
+using namespace DB;
+
+namespace DB::ErrorCodes
+{
+    extern const int INCORRECT_DATA;
+    extern const int LOGICAL_ERROR;
+}
+
+/// `ReadFromStorageStep::deserialize` reads a client-supplied plan (TCPHandler::receiveQueryPlan),
+/// so it is a trust boundary: it must reject a payload naming another storage and a header that is
+/// not the canonical `system.one` shape, because the chunk it builds is hardcoded to one UInt8
+/// column. Those rejections are unreachable from SQL (no legitimate sender produces such a plan),
+/// hence this gtest. The paired encoders are `ReadFromStorageStep::serialize` and
+/// `ReadFromSystemOneStep::serialize`; both write exactly one string, "SystemOne".
+namespace
+{
+
+/// A stand-in for the encoders: serializes under the registered "ReadFromStorage" name with a
+/// caller-chosen payload and output header, which is what lets a test feed both well-formed and
+/// hostile streams through the real registry.
+class FakeReadFromStorageStep final : public ISourceStep
+{
+public:
+    FakeReadFromStorageStep(SharedHeader output_header_, String payload_)
+        : ISourceStep(std::move(output_header_)), payload(std::move(payload_))
+    {
+    }
+
+    String getName() const override { return "FakeReadFromStorage"; }
+    String getSerializationName() const override { return "ReadFromStorage"; }
+
+    void initializePipeline(QueryPipelineBuilder &, const BuildQueryPipelineSettings &) override
+    {
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "FakeReadFromStorageStep is not executable");
+    }
+
+    void serialize(Serialization & ctx) const override { writeStringBinary(payload, ctx.out); }
+    bool isSerializable() const override { return true; }
+
+private:
+    String payload;
+};
+
+SharedHeader canonicalSystemOneHeader()
+{
+    auto type = std::make_shared<DataTypeUInt8>();
+    return std::make_shared<const Block>(Block{ColumnWithTypeAndName(type->createColumn(), type, "dummy")});
+}
+
+String serializePlanWith(SharedHeader output_header, const String & payload)
+{
+    QueryPlan plan;
+    plan.addStep(std::make_unique<FakeReadFromStorageStep>(std::move(output_header), payload));
+
+    WriteBufferFromOwnString out;
+    plan.serialize(out, DBMS_QUERY_PLAN_SERIALIZATION_VERSION);
+    out.finalize();
+    return out.str();
+}
+
+QueryPlan deserializePlan(const String & data, const ContextPtr & context)
+{
+    ReadBufferFromString in(data);
+    return QueryPlan::makeSets(QueryPlan::deserialize(in, context, /*max_type_complexity=*/0), context);
+}
+
+}
+
+namespace DB
+{
+void registerReadFromStorageStep(QueryPlanStepRegistry & registry);
+}
+
+class ReadFromStorageSystemOneDeserialize : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        /// The registry is a process-wide singleton and throws on a duplicate name, so register the
+        /// one step under test exactly once. Registering the whole set (registerPlanSteps) would
+        /// collide with gtest_distributed_query, which registers its own subset in the same binary.
+        static std::once_flag registered;
+        std::call_once(registered, [] { registerReadFromStorageStep(QueryPlanStepRegistry::instance()); });
+    }
+};
+
+/// The legacy stream that senders already produce must keep working: a canonical header plus the
+/// "SystemOne" payload deserializes into a source yielding the single `system.one` row.
+TEST_F(ReadFromStorageSystemOneDeserialize, WellFormedStreamYieldsSingleRow)
+{
+    auto context = Context::createCopy(getContext().context);
+
+    auto plan = deserializePlan(serializePlanWith(canonicalSystemOneHeader(), "SystemOne"), context);
+    ASSERT_TRUE(plan.isInitialized());
+
+    auto builder = plan.buildQueryPipeline(
+        QueryPlanOptimizationSettings(context), BuildQueryPipelineSettings(context));
+    QueryPipeline pipeline(QueryPipelineBuilder::getPipeline(std::move(*builder)));
+
+    PullingPipelineExecutor executor(pipeline);
+    Block block;
+    size_t total_rows = 0;
+    while (executor.pull(block))
+        total_rows += block.rows();
+
+    EXPECT_EQ(total_rows, 1u);
+}
+
+/// A payload naming any other storage is bad input, not a logical error: a logical error would
+/// abort debug/sanitizer builds on a client-controlled path.
+TEST_F(ReadFromStorageSystemOneDeserialize, ForeignStorageNamePayloadIsRejected)
+{
+    auto context = Context::createCopy(getContext().context);
+    auto data = serializePlanWith(canonicalSystemOneHeader(), "NotSystemOne");
+
+    try
+    {
+        deserializePlan(data, context);
+        FAIL() << "expected INCORRECT_DATA";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::INCORRECT_DATA) << e.displayText();
+    }
+}
+
+/// A non-canonical header must be rejected at deserialization. Without the check the step is built
+/// from the wire header while its chunk stays hardcoded to one UInt8 column, and the mismatch only
+/// surfaces much deeper, inside OutputPort, as a remote-triggerable logical error.
+TEST_F(ReadFromStorageSystemOneDeserialize, NonCanonicalHeaderIsRejected)
+{
+    auto context = Context::createCopy(getContext().context);
+
+    auto uint8_type = std::make_shared<DataTypeUInt8>();
+    auto string_type = std::make_shared<DataTypeString>();
+
+    std::vector<SharedHeader> hostile_headers = {
+        /// Right count and name, wrong type.
+        std::make_shared<const Block>(Block{ColumnWithTypeAndName(string_type->createColumn(), string_type, "dummy")}),
+        /// Right count and type, wrong name.
+        std::make_shared<const Block>(Block{ColumnWithTypeAndName(uint8_type->createColumn(), uint8_type, "not_dummy")}),
+        /// Too many columns: this is the shape that reaches OutputPort unchecked.
+        std::make_shared<const Block>(Block{
+            ColumnWithTypeAndName(uint8_type->createColumn(), uint8_type, "dummy"),
+            ColumnWithTypeAndName(uint8_type->createColumn(), uint8_type, "extra")}),
+    };
+
+    for (const auto & header : hostile_headers)
+    {
+        auto data = serializePlanWith(header, "SystemOne");
+        try
+        {
+            deserializePlan(data, context);
+            FAIL() << "expected INCORRECT_DATA for header " << header->dumpStructure();
+        }
+        catch (const Exception & e)
+        {
+            EXPECT_EQ(e.code(), ErrorCodes::INCORRECT_DATA) << e.displayText();
+        }
+    }
+}

--- a/src/Storages/System/StorageSystemOne.cpp
+++ b/src/Storages/System/StorageSystemOne.cpp
@@ -7,7 +7,9 @@
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <IO/WriteHelpers.h>
 #include <Processors/QueryPlan/QueryPlan.h>
+#include <Processors/QueryPlan/Serialization.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
 #include <QueryPipeline/Pipe.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
@@ -71,6 +73,17 @@ void ReadFromSystemOneStep::initializePipeline(QueryPipelineBuilder & pipeline, 
     source->addTotalRowsApprox(1);
 
     pipeline.init(Pipe(source));
+}
+
+
+void ReadFromSystemOneStep::serialize(Serialization & ctx) const
+{
+    /// The step is stateless: the output header (invariantly `dummy UInt8`) already travels in the
+    /// generic per-node preamble, so the body is just the storage name the paired decoder expects.
+    /// PAIRED DECODER: `ReadFromStorageStep::deserialize` in
+    /// src/Processors/QueryPlan/ReadFromPreparedSource.cpp, registered as "ReadFromStorage" (see
+    /// `getSerializationName`). Payload = exactly one string, "SystemOne" - keep both sides in sync.
+    writeStringBinary("SystemOne", ctx.out);
 }
 
 }

--- a/src/Storages/System/StorageSystemOne.h
+++ b/src/Storages/System/StorageSystemOne.h
@@ -53,12 +53,25 @@ public:
 
     String getName() const override { return "ReadFromSystemOne"; }
 
+    /// Serialized under the already-registered "ReadFromStorage" name rather than under `getName`:
+    /// `ReadFromStorageStep` holds a complete `system.one` codec, and its decoder is what reads the
+    /// bytes written by `serialize` below. `getName` is deliberately left alone (`EXPLAIN` output and
+    /// `optimizeJoin.cpp` match on it).
+    /// Note: the wire name is consumed only by `QueryPlan::serialize`. The other users of
+    /// `getSerializationName` (hash-table-statistics cache keys, join runtime-filter fingerprints)
+    /// dispatch on `SourceStepWithFilter` / `ITransformingStep` / `JoinStepLogical`; this step derives
+    /// from `ISourceStep` only, so they cannot see it. Revisit if that ever changes.
+    String getSerializationName() const override { return "ReadFromStorage"; }
+
     QueryPlanStepPtr clone() const override
     {
         return std::make_unique<ReadFromSystemOneStep>(*this);
     }
 
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings) override;
+
+    void serialize(Serialization & ctx) const override;
+    bool isSerializable() const override { return true; }
 };
 
 }

--- a/tests/queries/0_stateless/04650_read_from_system_one_serializable.reference
+++ b/tests/queries/0_stateless/04650_read_from_system_one_serializable.reference
@@ -6,10 +6,10 @@ constant select
 aggregation over system.one distributes
 constant select distributes
 unioned with a populated table
-4999900000
-4999950000
-5000000000
-5000050000
+4999900000	50001
+4999950000	50000
+5000000000	50000
+5000050000	50000
 joined with a populated table
 1
 virtual columns through the step

--- a/tests/queries/0_stateless/04650_read_from_system_one_serializable.reference
+++ b/tests/queries/0_stateless/04650_read_from_system_one_serializable.reference
@@ -1,0 +1,16 @@
+aggregation over system.one
+1
+0
+constant select
+1
+aggregation over system.one distributes
+constant select distributes
+unioned with a populated table
+4999900000
+4999950000
+5000000000
+5000050000
+joined with a populated table
+1
+virtual columns through the step
+1	one	system

--- a/tests/queries/0_stateless/04650_read_from_system_one_serializable.sql
+++ b/tests/queries/0_stateless/04650_read_from_system_one_serializable.sql
@@ -35,7 +35,7 @@ WHERE explain LIKE '%ReadFromDistributedPlanSource%' LIMIT 1;
 
 -- The step beside a real reader, i.e. the shape join-order estimation feeds on.
 SELECT 'unioned with a populated table';
-SELECT sum(x) FROM (SELECT dummy AS x FROM system.one UNION ALL SELECT x FROM t_system_one_full)
+SELECT sum(x), count() FROM (SELECT dummy AS x FROM system.one UNION ALL SELECT x FROM t_system_one_full)
 GROUP BY x % 4 ORDER BY 1;
 SELECT 'joined with a populated table';
 SELECT count() FROM t_system_one_full a INNER JOIN system.one b ON a.x = b.dummy;

--- a/tests/queries/0_stateless/04650_read_from_system_one_serializable.sql
+++ b/tests/queries/0_stateless/04650_read_from_system_one_serializable.sql
@@ -1,0 +1,49 @@
+-- Tags: no-old-analyzer
+-- no-old-analyzer: make_distributed_plan requires the analyzer.
+
+DROP TABLE IF EXISTS t_system_one_full;
+
+CREATE TABLE t_system_one_full (x UInt64) ENGINE = MergeTree ORDER BY tuple() AS SELECT number FROM numbers(200000);
+
+SET distributed_plan_default_shuffle_join_bucket_count = 3, distributed_plan_default_reader_bucket_count = 3;
+-- Distributed aggregation cannot enforce a global max_rows_to_group_by, and the functional-test
+-- profile sets it nonzero, so pin it off. Trivial-count would fold the aggregation away.
+SET make_distributed_plan = 1, enable_parallel_replicas = 0, automatic_parallel_replicas_mode = 0,
+    distributed_plan_execute_locally = 1, distributed_plan_max_rows_to_broadcast = 0,
+    max_rows_to_group_by = 0, optimize_trivial_count_query = 0;
+
+-- All of the following previously failed with
+-- SUPPORT_IS_DISABLED: step 'ReadFromSystemOne' is not serializable for remote execution.
+SELECT 'aggregation over system.one';
+SELECT count() FROM system.one GROUP BY dummy;
+-- Not count(), so a trivial-count rewrite cannot be what makes this pass.
+SELECT sum(dummy) FROM system.one GROUP BY dummy;
+SELECT 'constant select';
+SELECT count() FROM (SELECT 1 AS x) GROUP BY x;
+
+-- The serializability check only runs once a plan splits into more than one stage, so a query that
+-- stays single-stage would pass without ever serializing the step. Assert that these plans really do
+-- distribute: the row is absent unless an exchange was planted, so removing `make_distributed_plan`
+-- above makes the test fail instead of silently covering nothing. The oracle must not aggregate --
+-- an aggregating query over EXPLAIN is itself distributed and would fail on its own source step.
+SELECT 'aggregation over system.one distributes'
+FROM (EXPLAIN PIPELINE SELECT count() FROM system.one GROUP BY dummy)
+WHERE explain LIKE '%ReadFromDistributedPlanSource%' LIMIT 1;
+SELECT 'constant select distributes'
+FROM (EXPLAIN PIPELINE SELECT count() FROM (SELECT 1 AS x) GROUP BY x)
+WHERE explain LIKE '%ReadFromDistributedPlanSource%' LIMIT 1;
+
+-- The step beside a real reader, i.e. the shape join-order estimation feeds on.
+SELECT 'unioned with a populated table';
+SELECT sum(x) FROM (SELECT dummy AS x FROM system.one UNION ALL SELECT x FROM t_system_one_full)
+GROUP BY x % 4 ORDER BY 1;
+SELECT 'joined with a populated table';
+SELECT count() FROM t_system_one_full a INNER JOIN system.one b ON a.x = b.dummy;
+
+-- The output header is the step's whole state and the decoder rebuilds a hardcoded single UInt8
+-- 'dummy' chunk, so pin that the virtual columns are materialized above the step and do not widen
+-- the header it carries. Assert the values, not merely that nothing threw.
+SELECT 'virtual columns through the step';
+SELECT count(), min(_table), min(_database) FROM system.one GROUP BY dummy;
+
+DROP TABLE t_system_one_full;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/111941

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Support distributed query plans (`make_distributed_plan`) for multi-stage queries that read `system.one`. Such queries previously failed with `SUPPORT_IS_DISABLED: step 'ReadFromSystemOne' ... is not serializable for remote execution`. `system.one` is the DUAL-table analog that backs constant selects, so this affected ordinary query shapes such as `SELECT count() FROM system.one GROUP BY dummy` and `SELECT count() FROM (SELECT 1 AS x) GROUP BY x`.

### Description

`ReadFromSystemOneStep` (`src/Storages/System/StorageSystemOne.h`) does not override `isSerializable()`, so it inherits `false` from `IQueryPlanStep`. `assertFragmentSerializable` (`src/Processors/QueryPlan/QueryPlan.cpp`) then throws `SUPPORT_IS_DISABLED` for any plan fragment containing it. The check only runs once a plan splits into more than one stage, which is why a bare `SELECT 1` is unaffected and an aggregation over `system.one` is not.

#### A codec with no encoder

The step is trivially serializable: it has **zero data members**, its constructor only computes the output header, and `initializePipeline` synthesizes its single row from nothing. And the wire codec for exactly this data **already exists and is already registered**: `ReadFromStorageStep` carries a hand-written `"SystemOne"` special case (`src/Processors/QueryPlan/ReadFromPreparedSource.cpp`) whose `deserialize` rebuilds a single-row `system.one` source, registered under the wire name `"ReadFromStorage"`.

That decoder's send side was born dead on master. `system.one` used to be read via a Pipe (producing a `ReadFromStorageStep`), but `eb5c15d308ad` ("Introduce ReadFromSystemOneStep") replaced that with a plan-based `readImpl` that always adds a `ReadFromSystemOneStep`; `eb5c15d308ad` is an ancestor of `f609a45f6846d2`, which landed `ReadFromStorageStep::serialize`. So the receiving half of this feature shipped for a step that is no longer produced.

#### The fix

Give `ReadFromSystemOneStep` the missing send half, aimed at the codec that already exists:

- `isSerializable() -> true`;
- `getSerializationName() -> "ReadFromStorage"`, so the step serializes under the already-registered name. `getName()` stays `"ReadFromSystemOne"`, so `EXPLAIN` output, the `assertFragmentSerializable` message and the `getName()` comparison in `optimizeJoin.cpp` are untouched and no existing `.reference` file moves;
- `serialize` writing the one-string `"SystemOne"` payload, byte-identical to what `ReadFromStorageStep::serialize` writes.

The runtime-name / serialization-name split is existing machinery for exactly this: `JoinStepLogical` already serializes under `"Join"`, and `DistinctStep` picks its name dynamically (`"PreDistinct"` / `"Distinct"`). A decoder returning a class other than the encoder's is likewise established: `ReadFromMergeTree::deserialize` returns a `ReadNothingStep` on its `skipping` path. Here `ReadFromSystemOneStep` deserializes into `ReadFromPreparedSource`, which is what this decoder already returned for its (dead) `ReadFromStorageStep` encoder, so the decoder's return class is unchanged by this PR.

**Reusing the existing name means receivers older than this PR already decode the plans this starts emitting**, because their decoder is registered and already expects the `"SystemOne"` payload. Registering a new name would make the feature work only once both ends are upgraded. There is no wire-vocabulary change at all, hence no plan-serialization version bump. It also avoids the `clickhouse_storages_system` layering problem entirely: no registry entry is added, so `dbms` never has to name a symbol from a library that links it downstream (the constraint documented in `optimizeJoin.cpp` and hit from the other side in `fb6059e78547c2`).

Considered and rejected: moving the class into `Processors/QueryPlan` and registering a new `"ReadFromSystemOne"` name. That is implementable (`ReadFromSystemNumbersStep` shows the layering works) but strictly worse here: a new wire name gives up backward compatibility, it needs a class move plus optimizer and registry edits, and it would leave the existing `"ReadFromStorage"` `system.one` codec in the tree as a second, doubly dead implementation.

#### Hardening the decoder it now feeds

`ReadFromStorageStep::deserialize` handed the **unvalidated** wire header to `SourceFromSingleChunk` alongside a hardcoded single-`UInt8`-column chunk. The payload is peer-controlled on both receiving paths (a distributed-plan task on a worker, `StatelessTaskExecutor`, and a `QueryPlan` packet over TCP, `TCPHandler::receiveQueryPlan`; that packet is additionally gated by the `process_query_plan_packet` server setting, off by default and enabled in the functional-test config), and the framework's own post-deserialize header check cannot catch a bad shape here because the step is built *from* that header (`checkBlockStructure` short-circuits on pointer identity). A wire header with a different column count therefore reached `OutputPort::pushData` and threw `LOGICAL_ERROR: Invalid number of columns in chunk pushed to OutputPort` (measured), which aborts debug and sanitizer builds. This PR makes that path reachable in practice, so it validates the header against the canonical `dummy UInt8` shape and turns the peer-controlled bad-name path from `LOGICAL_ERROR` into `INCORRECT_DATA`, matching the reasoning already recorded in this file for the `serialize` side and the `INCORRECT_DATA`-on-wire-shape convention used by `FilterStep`, `AggregatingStep`, `JoinStepLogical` and others.

The canonical shape is not an assumption: `system.one` declares exactly one physical column `dummy UInt8`, its `_table` / `_database` virtuals are ephemeral and materialized by later `ExpressionStep`s, and the header was measured as `dummy UInt8` for `SELECT 1 FROM system.one`, bare `SELECT 1`, `SELECT _table`, `SELECT _database, _table`, `SELECT count() ... GROUP BY dummy`, an aliased projection, `remote('127.0.0.1', system.one)`, and the secondary-query form a shard actually receives.

`ReadFromStorageStep::serialize` and `::isSerializable` are deliberately left in place. They are now redundant for `system.one` (nothing constructs a `ReadFromStorageStep` for it, and no other storage reports `getName() == "SystemOne"`), but removing a registered path is a separate cleanup with no bearing on this fix; happy to do it in a follow-up.

#### Tests

- `04650_read_from_system_one_serializable` covers the reported repro, a non-`count` aggregate, the `SELECT 1` path, `system.one` unioned and joined with a populated MergeTree table, and the virtual columns read through the step. Every statement fails on a master-HEAD binary with `Code: 344`. The test also asserts that the plans really distribute (via a non-aggregating `EXPLAIN PIPELINE` row), because the serializability check only runs for multi-stage plans; removing `make_distributed_plan = 1` makes the test fail rather than silently cover nothing.
- `gtest_read_from_storage_system_one_deserialize` drives the real registered decoder over hand-built streams: a well-formed legacy stream still yields the single row (so existing senders are unaffected), a foreign storage name is rejected with `INCORRECT_DATA`, and three non-canonical headers are rejected with `INCORRECT_DATA` instead of reaching `OutputPort`. Those rejections are unreachable from SQL, hence the gtest.

Verified in both directions with the server's `buildId()` asserted against the built binary on every verdict, and per-hunk: reverting `isSerializable` restores `Code: 344`; reverting `getSerializationName` gives `Code: 47 UNKNOWN_IDENTIFIER: Unknown query plan step: ReadFromSystemOne` (which also proves a real serialize/deserialize round trip happens even under `distributed_plan_execute_locally = 1`, and that the existing `"ReadFromStorage"` decoder is what executes); changing the payload string gives `INCORRECT_DATA`; removing the header guard makes the non-canonical case abort inside `OutputPort` instead. 50/50 randomized runs pass, and a 56-test neighbourhood sweep of every stateless test mentioning `ReadFromSystemOne`, `ReadFromStorage` or `ReadFromPreparedSource` plus the `serialize_query_plan` / `make_distributed_plan` tests has a failure set identical to the same sweep on a pristine master binary.