### PR TITLE
Remove the racing async-insert flush from 02015_async_inserts_2

### DIFF
--- a/tests/queries/0_stateless/02015_async_inserts_2.sh
+++ b/tests/queries/0_stateless/02015_async_inserts_2.sh
@@ -23,8 +23,9 @@ ${CLICKHOUSE_CURL} -sS "$url" -d 'INSERT INTO async_inserts FORMAT CSV
 4,"c"
 3,"d"' &
 
-sleep 2
-${CLICKHOUSE_CURL} -sS "$url" -d 'SYSTEM FLUSH ASYNC INSERT QUEUE async_inserts;'
+# Do not add an explicit `SYSTEM FLUSH ASYNC INSERT QUEUE` here: it only snapshots the queue and does not block
+# concurrent pushes, so it can flush a partial batch and leave a late insert waiting for `async_insert_busy_timeout_ms`.
+# `async_insert_max_query_number` = 3 flushes all three inserts as one batch regardless of their arrival order.
 wait
 
 ${CLICKHOUSE_CLIENT} -q "SELECT * FROM async_inserts ORDER BY id"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/107974


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`02015_async_inserts_2` intermittently fails on master and on unrelated PRs with one of its three
concurrent HTTP inserts never getting a response:

```
Reason: having stderror:
curl: (28) Operation timed out after 120001 milliseconds with 0 bytes received
stdout:
Code: 27
1	a
2	b
all_1_1_0	2	0
```

Only 2 of the 4 expected rows land, the part carries 2 rows instead of 4, and the test burns its
whole 120 s curl budget. The two most recent occurrences are 2026-07-21 (`pull_request_number = 0`,
`head_ref = 'master'`, `Stateless tests (amd_tsan, parallel)`) and 2026-07-26 on an unrelated PR, so
it is not caused by any change under test.

#### Root cause

The test pins `async_insert_busy_timeout_ms=600000`, `async_insert_max_query_number=3`,
`async_insert_deduplicate=1` and `async_insert_use_adaptive_busy_timeout=0`, then fires three
`wait_for_async_insert=1` inserts concurrently in the background (two well-formed, one malformed).
All three share one batching key, so with those settings the only reachable flush trigger is
`has_enough_queries` (`AsynchronousInsertQueue.cpp:604`): `async_insert_max_data_size` is 10 MiB
against ~12 bytes of data, `async_insert_use_adaptive_busy_timeout = 0` makes
`max_busy_timeout_exceeded` return false on its first clause, and the deadline flush is 600 s away.

That threshold trigger is timing-independent. `data->entries.emplace_back` at
`AsynchronousInsertQueue.cpp:595` is unconditional at push time, so the malformed entry counts toward
the threshold as well - parsing happens later at flush time, where the parse error finishes only its
own promise while its batch-mates succeed. Whichever request arrives third therefore completes the
batch and flushes all three atomically under the shard mutex, acking all three waiters and producing
one part with 4 rows.

The explicit `SYSTEM FLUSH ASYNC INSERT QUEUE` in the test defeats it. `flush(tables)` is a snapshot:
unlike `flushAll` it deliberately does not set `flush_stopped`, so the guard at
`AsynchronousInsertQueue.cpp:620` stays open and a concurrent push can create a brand-new queue entry
immediately after. Its own comments say so - *"jobs scheduled before the call of 'flush' are not
counted here"* (`:801`) and *"Other pending inserts are not blocked and can be processed
concurrently"* (`:809`). If the third insert has not reached `:595` when the flush snapshots the shard
queue, the flush drains a partial batch of two and the late insert lands in a fresh entry whose only
remaining trigger is its 600 s deadline. Its waiting client then parks until curl gives up - exactly
the observed output.

`sleep 2` does not prevent this: `bash` forks the three `&` children and reaches `sleep 2`
immediately, so it only bets that three HTTP requests reach the queue within 2 s of the fork. On a
loaded runner that bet occasionally loses. In the failing job's own debug log `sleep 2` is even
traced *before* the three curls.

#### Two routes to the same symptom, and which one is left

This visible signature is older than the two lines being deleted here. Keyed on the test name and
`curl: (28)` in `test_context_raw`, the CI database has 30 such rows all the way back to 2024-03-11
(PR #61112, `Stateless tests (aarch64)`, with the same `all_1_1_0 2 0` partial shape), i.e. long
before `sleep 2` and the explicit flush were added to this test by `bf6826835ce5c7` (merged as
`dc5086b93f0959` from https://github.com/ClickHouse/ClickHouse/pull/89140). So this change is not a
revert that removes the only cause; it removes one of two routes, and the other route is already
closed:

* **Route A - a global flush from another test.** Until `36fc6e58b55cff` ("Run async-insert queue
  tests in parallel via table-scoped flush", 2026-05-21) several stateless tests issued the
  table-less `SYSTEM FLUSH ASYNC INSERT QUEUE`, which drains *every* table's queue. A concurrently
  running `02015_async_inserts_2` could therefore be partially drained by an unrelated test and hang
  in exactly this way while having no flush of its own. Counting the sites that the style check now
  rejects: 16 of them across 10 test files at 2025-08-14, 13 across 9 at 2026-05-18, and **0** from
  `36fc6e58b55cff` onwards. `ci/jobs/scripts/check_style/various_checks.sh` now rejects the global
  form outright, so the route cannot reopen.
* **Route B - this test's own flush**, the mechanism above. Both remaining occurrences
  (2026-07-21 and 2026-07-26) are *after* route A was removed, so route B is what is still live, and
  it is what this change deletes.

For completeness, the per-era counts (the four settings pins reached their current form at
`7c715e66a270e5`, 2024-01-30, so only rows after that date are comparable): 475006 runs and 27
`curl: (28)` failures while route A was open and this test had no flush of its own, then 563983 runs
and 3 failures once the flush was added, of which one predates route A's removal and two follow it.
The raw rates do not isolate either route, which is why the causal claim below rests on a
forced-ordering experiment rather than on CI statistics.

#### Fix

Delete `sleep 2` and the explicit flush, restoring `async_insert_max_query_number = 3` as the sole,
order-independent trigger, and leave a short comment so the lines are not reinstated later.

Nothing is weakened. The URL settings, all three inserts, the `Code: 27` check, the `wait`, both
`SELECT`s and the `.reference` are byte-identical. The single-part assertion actually becomes
stronger: with the flush gone the only reachable outcome is one batch, hence one part with 4 rows,
whereas today a partial flush can legitimately produce two parts. `SYSTEM FLUSH ASYNC INSERT QUEUE`
coverage is unaffected - `02726_async_insert_flush_queue`, `03708_flush_async_insert_queue_for_table`,
`02726_async_insert_flush_stress` and around 25 further tests exercise that statement; this test is
the carrier for waiting-client partial-batch parse-error isolation, which it keeps asserting.

#### Verification

The natural race window is sub-second, so the losing interleaving was forced instead of looped for:
the third background curl was wrapped in `( sleep 3; ... ) &` so it registers after the flush, with
`CLICKHOUSE_CURL_TIMEOUT` reduced to 10 s. Both are local harness knobs, not part of the change.
Same binary throughout (a debug build of this PR's merge base).

| test form, same forced ordering | result |
|---|---|
| before this change (`sleep 2` + explicit flush) | **FAIL 10/10**, byte-exact CI signature, ~13.9 s per run |
| after this change | **PASS 10/10**, ~3.9 s per run |
| only the explicit flush re-added | FAIL 4/10 |
| only `sleep 2` re-added | PASS 10/10 |

The last two rows isolate the cause within this test: re-adding the flush alone brings the failure
back, re-adding `sleep 2` alone never fails. The flush-only arm is 4/10 rather than 10/10 because
without `sleep 2` the flush often arrives before any push registers, drains nothing, and leaves the
threshold to do its job - which is precisely why the shipped combination was worse than either line
by itself.

The server's own log shows the mechanism directly: before the change,
`Will wait for finishing of 1 flushing jobs (about 2 inserts, ...)` followed by `Flushed 2 rows`;
after it, `Scheduling async insert processing job because enough queries accumulated` followed by
`Flushed 4 rows`.

`--test-runs 50` with randomization: **50 passed, 0 failed**. The test also gets faster on every run,
since the deleted `sleep 2` was paid unconditionally: median duration goes from **3.04 s** to
**1.04 s**.

The whole async-insert-flush family (`00408_http_keep_alive`, `02015_async_inserts_1..7`,
`02726_async_insert_flush_queue`, `02726_async_insert_flush_stress`,
`03708_flush_async_insert_queue_for_table`, `04326_async_insert_flush_processors_profile_log`,
`04547_async_insert_flush_cancellation`) is 13/13 green both before and after, with an identical
failure set.

#### Why the threshold trigger is trustworthy without an explicit flush

`00408_http_keep_alive` runs the same three requests (two well-formed plus one `qqqqqqqqqqq`) with
the same five pinned settings, in the background, with a bare `wait` and **no** `sleep` and **no**
flush before that `wait` - its `SYSTEM FLUSH ASYNC INSERT QUEUE` runs afterwards as inter-iteration
cleanup - and it covers both `wait_for_async_insert=0` and `=1`. Over the last 30 days it recorded
136038 OK / 2 FAIL, and neither failure is a hang (both are a host-memory-pressure window).

One caveat so this is not read as more than it is: `00408` pipes each curl through
`|& grep 'Connection:' > $file_N`, so a `curl: (28)` message never reaches the runner's stderr - a
hang there would surface as an empty file and a missing `< Connection: Keep-Alive` line, i.e. as
`result differs`, not as a `curl: (28)` row. Its zero `curl: (28)` count is therefore a property of
its output routing and not a hang count, and the two tests' failure counts are not comparable on that
signature. What `00408` does establish is that these three requests plus these pins complete on their
own, without an explicit flush, at comparable volume.

I also re-derived which tests can carry this failure mode by scanning every blob under
`tests/queries/` on `master` for `FLUSH ASYNC INSERT QUEUE` (33 files, 28 excluding `.reference`) and
keeping those that combine a background async insert, `wait_for_async_insert=1`, and an explicit flush
before their `wait`: `02015_async_inserts_2` is the only one. In the three other tests where a flush
and a `wait` coexist the flush runs after the `wait` (`00408_http_keep_alive`), or inside a background
loop with every insert at `wait_for_async_insert=0` (`02726_async_insert_flush_stress`), or after a
`wait` that has no background jobs to wait for (`02884_async_insert_native_protocol_3`). No sibling
test needs the same change.

#### What I deliberately did not change

Making table-scoped `flush(tables)` set `flush_stopped` like `flushAll` would fix the test the other
way round, but `flush_stopped` is process-wide, so a table-scoped flush would stall inserts to every
other table on the server for its duration - a user-visible regression traded for a test convenience.
The engine behaves as documented here; the test's ordering assumption was the problem.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.434` (included in `26.8` and later)
<!-- ch-version-info:end -->