### PR TITLE
Reuse _distance for a PREWHERE that filters on the sorted-by distance

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
@@ -315,7 +315,9 @@ bool searchColumnFeedsIntoFunction(const ActionsDAG & dag, const String & search
         if (!inserted)
             return it->second;
 
-        bool result = (node->type == ActionsDAG::ActionType::INPUT && node->result_name == search_column);
+        /// isSearchColumnNode also unwraps an ALIAS and strips the qualification the old analyzer
+        /// adds, so `tab.vec` is recognised as well as `vec`.
+        bool result = isSearchColumnNode(node, search_column);
         if (!result)
         {
             for (const auto * child : node->children)

--- a/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
@@ -298,6 +298,53 @@ std::optional<VectorWithMemoryTracking<Float64>> tryGetReferenceVector(const Act
     return reference_vector;
 }
 
+/// True if `dag` feeds `search_column` into a function, as opposed to merely carrying it through to
+/// its outputs.
+///
+/// This distinguishes a filter above the read that only passes the vector column along - which the
+/// planner does routinely so the ORDER BY above can use it, and whose pass-through alias
+/// replaceVectorColumnWithDistanceColumn() removes - from one that actually computes with it, such
+/// as `WHERE length(vec) = 2`. Only the latter breaks once the column leaves the read list.
+bool searchColumnFeedsIntoFunction(const ActionsDAG & dag, const String & search_column)
+{
+    std::unordered_map<const ActionsDAG::Node *, bool> reaches_search_column;
+
+    auto reaches = [&](const ActionsDAG::Node * node, auto & self) -> bool
+    {
+        auto [it, inserted] = reaches_search_column.try_emplace(node, false);
+        if (!inserted)
+            return it->second;
+
+        bool result = (node->type == ActionsDAG::ActionType::INPUT && node->result_name == search_column);
+        if (!result)
+        {
+            for (const auto * child : node->children)
+            {
+                if (self(child, self))
+                {
+                    result = true;
+                    break;
+                }
+            }
+        }
+
+        /// try_emplace may have rehashed while recursing, so look the slot up again.
+        reaches_search_column[node] = result;
+        return result;
+    };
+
+    for (const auto & node : dag.getNodes())
+    {
+        if (node.type != ActionsDAG::ActionType::FUNCTION && node.type != ActionsDAG::ActionType::ARRAY_JOIN)
+            continue;
+        for (const auto * child : node.children)
+            if (reaches(child, reaches))
+                return true;
+    }
+
+    return false;
+}
+
 /// Find the distance-function nodes in `dag` that the `_distance` virtual column can stand in for.
 ///
 /// A node qualifies only if it computes exactly the same thing the vector index already returned,
@@ -523,6 +570,28 @@ bool optimizeVectorSearchWithVectorIndexSecondPass(QueryPlan::Node & /*root*/, S
     {
         if (settings.vector_search_with_rescoring)
             return false;
+
+        /// FINAL may add PK-overlapping ranges after vector index analysis, so the vector row hints
+        /// describe only the pre-FINAL candidates. The rescoring row filter is disabled under FINAL
+        /// for exactly this reason (see apply_row_filter_for_rescoring below), but the rewrite keeps
+        /// the hints active, so an explicit PREWHERE under FINAL has to keep the bail-out.
+        if (read_from_mergetree_step->isQueryWithFinal())
+            return false;
+
+        /// The rewrite drops the vector column from the read list, so a step above the read that
+        /// computes something from it would reference a column that is no longer produced, e.g.
+        ///     PREWHERE cosineDistance(vec, reference) < 0.5 WHERE length(vec) = 2
+        /// Merely carrying the column through to the outputs is fine and common - the planner keeps
+        /// it available for the ORDER BY above - and replaceVectorColumnWithDistanceColumn() drops
+        /// that pass-through alias. So a filter such as `WHERE id % 2 = 0` stays eligible, and only
+        /// a filter that feeds the column into a function bails out.
+        if (filter_step || prewhere_expression_step)
+        {
+            const ActionsDAG & dag_above_read
+                = prewhere_expression_step ? prewhere_expression_step->getExpression() : filter_step->getExpression();
+            if (searchColumnFeedsIntoFunction(dag_above_read, vector_search_parameters.value().column))
+                return false;
+        }
 
         prewhere_distance_nodes
             = findDistanceNodesReplaceableByDistanceColumn(prewhere_info->prewhere_actions, vector_search_parameters.value());

--- a/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
@@ -251,6 +251,162 @@ size_t tryUseVectorSearchWithVectorIndexFirstPass(QueryPlan::Node * parent_node,
     return no_layers_updated;
 }
 
+namespace
+{
+
+/// Does the node refer to the vector column? Both analyzers are handled, same as in the first pass.
+bool isSearchColumnNode(const ActionsDAG::Node * node, const String & search_column)
+{
+    if (node->type == ActionsDAG::ActionType::ALIAS && !node->children.empty())
+        node = node->children.at(0);
+
+    if (node->type != ActionsDAG::ActionType::INPUT)
+        return false;
+
+    String name = node->result_name;
+    if (name.contains('.')) /// old analyzer qualifies the name
+        name = name.substr(name.find('.') + 1);
+
+    return name == search_column;
+}
+
+/// Read a reference vector out of a COLUMN node, or return nullopt if the node is not an array literal.
+std::optional<VectorWithMemoryTracking<Float64>> tryGetReferenceVector(const ActionsDAG::Node * node)
+{
+    if (node->type != ActionsDAG::ActionType::COLUMN || !node->column)
+        return std::nullopt;
+
+    const auto * data_type_array = typeid_cast<const DataTypeArray *>(node->result_type.get());
+    if (!data_type_array)
+        return std::nullopt;
+
+    Field field = node->column->getField();
+    if (field.getType() != Field::Types::Array)
+        return std::nullopt;
+
+    VectorWithMemoryTracking<Float64> reference_vector;
+    for (const auto & element : field.safeGet<Array>())
+    {
+        if (element.getType() != Field::Types::Float64)
+            return std::nullopt;
+        reference_vector.push_back(element.safeGet<Float64>());
+    }
+
+    if (reference_vector.empty())
+        return std::nullopt;
+
+    return reference_vector;
+}
+
+/// Find the distance-function nodes in `dag` that the `_distance` virtual column can stand in for.
+///
+/// A node qualifies only if it computes exactly the same thing the vector index already returned,
+/// i.e. the same distance function over the same vector column and the *same* reference vector as
+/// the ORDER BY. A query may well filter on a different reference vector than it sorts by, and
+/// `_distance` only holds the distances belonging to the ORDER BY, so substituting it there would
+/// silently return wrong results.
+///
+/// Returns an empty result if the vector column is reachable in any other way, because then the
+/// column still has to be read and there is nothing to gain.
+ActionsDAG::NodeRawConstPtrs findDistanceNodesReplaceableByDistanceColumn(
+    const ActionsDAG & dag, const VectorSearchParameters & parameters)
+{
+    ActionsDAG::NodeRawConstPtrs distance_nodes;
+    std::unordered_set<const ActionsDAG::Node *> vector_column_users;
+
+    for (const auto & node : dag.getNodes())
+    {
+        for (const auto * child : node.children)
+        {
+            if (isSearchColumnNode(child, parameters.column))
+                vector_column_users.insert(&node);
+        }
+    }
+
+    for (const auto * node : vector_column_users)
+    {
+        if (node->type != ActionsDAG::ActionType::FUNCTION || !node->function_base)
+            return {};
+
+        if (node->function_base->getName() != parameters.distance_function)
+            return {};
+
+        if (node->children.size() != 2)
+            return {};
+
+        /// One child is the vector column, the other must be a literal equal to the ORDER BY reference vector.
+        const auto * reference_child = isSearchColumnNode(node->children.at(0), parameters.column)
+            ? node->children.at(1)
+            : node->children.at(0);
+
+        auto reference_vector = tryGetReferenceVector(reference_child);
+        if (!reference_vector.has_value())
+            return {};
+
+        if (reference_vector->size() != parameters.reference_vector.size()
+            || !std::equal(reference_vector->begin(), reference_vector->end(), parameters.reference_vector.begin()))
+            return {};
+
+        distance_nodes.push_back(node);
+    }
+
+    return distance_nodes;
+}
+
+/// Rewrite `distance_nodes` (interior nodes of `dag`) to read the `_distance` virtual column instead
+/// of recomputing the distance. Each node keeps its name and result type, so its parents are
+/// unaffected: it simply becomes an alias of the value the vector index handed us for free.
+void replaceDistanceNodesWithDistanceColumn(
+    ActionsDAG & dag,
+    const ActionsDAG::NodeRawConstPtrs & distance_nodes,
+    const VectorSearchParameters & parameters,
+    const ContextPtr & context)
+{
+    const auto * distance_input = &dag.addInput("_distance", std::make_shared<DataTypeFloat32>());
+
+    /// usearch returns L2 *squared* to avoid repeated sqrt computations.
+    const auto * distance_node = distance_input;
+    if (parameters.distance_function == "L2Distance")
+    {
+        auto sqrt_function = FunctionFactory::instance().get("sqrt", context);
+        distance_node = &dag.addFunction(sqrt_function, {distance_node}, {});
+    }
+
+    for (const auto * node_to_replace : distance_nodes)
+    {
+        /// `_distance` is always Float32 while the distance function may return Float64 (bug #85514),
+        /// so cast to the type the node already had rather than changing it under its parents.
+        const auto * replacement = distance_node;
+        if (!replacement->result_type->equals(*node_to_replace->result_type))
+            replacement = &dag.addCast(*replacement, node_to_replace->result_type, "_CAST_distance_prewhere", context);
+
+        /// Mutating nodes in place is how the other query plan optimizations rewire a DAG
+        /// (see filterPushDown.cpp and mergeFilterIntoJoinCondition.cpp).
+        auto * mutable_node = const_cast<ActionsDAG::Node *>(node_to_replace);
+        mutable_node->type = ActionsDAG::ActionType::ALIAS;
+        mutable_node->children = {replacement};
+        mutable_node->function_base = nullptr;
+        mutable_node->function = nullptr;
+        mutable_node->is_function_compiled = false;
+    }
+
+    /// The vector column is usually also an output of the PREWHERE actions, passed through so that
+    /// the ORDER BY above can compute the distance from it. Swap that pass-through for `_distance`:
+    /// only the outputs of these actions survive into the step's header, so `_distance` has to be
+    /// among them for the ORDER BY (rewritten the same way) to find it. Dropping the vector column
+    /// has to be explicit as well, since outputs are roots that removeUnusedActions() would keep
+    /// alive, and not reading that column is the point of this optimization.
+    auto & outputs = dag.getOutputs();
+    std::erase_if(outputs, [&](const auto * output) { return isSearchColumnNode(output, parameters.column); });
+
+    if (std::ranges::find(outputs, distance_input) == outputs.end())
+        outputs.push_back(distance_input);
+
+    dag.removeUnusedActions();
+}
+
+}
+
 bool optimizeVectorSearchWithVectorIndexSecondPass(QueryPlan::Node & /*root*/, Stack & stack, QueryPlan::Nodes & /*nodes*/, const Optimization::ExtraSettings & settings)
 {
     /// QueryPlan::Node * node = parent_node;
@@ -342,7 +498,7 @@ bool optimizeVectorSearchWithVectorIndexSecondPass(QueryPlan::Node & /*root*/, S
     if (read_from_mergetree_step->isParallelReadingFromReplicas())
         return false;
 
-    /// If there is an explicit PREWHERE, we disable the optimization. The PREWHERE optimization
+    /// An explicit PREWHERE generally disables the optimization. The PREWHERE optimization
     /// is slightly at odds with vector search optimizations. There are two optimizations in vector
     /// search -
     /// 1. Lookup the vector index and shortlist a handful of granules containing neighbours.
@@ -354,8 +510,25 @@ bool optimizeVectorSearchWithVectorIndexSecondPass(QueryPlan::Node & /*root*/, S
     /// is requested, we turn the vector-search optimization off. If there is a WHERE clause and even with
     /// optimize_move_to_prewhere = 1, we retain vector-search optimization and disable the implicit PREWHERE
     /// optimization. (check optimizePrewhere.cpp)
+    ///
+    /// The one exception is a PREWHERE that only reaches the vector column through the very distance
+    /// function the ORDER BY sorts by, e.g.
+    ///     PREWHERE cosineDistance(vec, reference) < 0.5 ORDER BY cosineDistance(vec, reference)
+    /// There the filter recomputes a distance the vector index already returned, so the whole (heavy)
+    /// vector column gets read only to derive a number we were handed for free. Such a PREWHERE can be
+    /// rewritten onto the `_distance` virtual column, which keeps the optimization and drops the vector
+    /// column from the read list. Any other use of the vector column keeps the bail-out below.
+    ActionsDAG::NodeRawConstPtrs prewhere_distance_nodes;
     if (const auto & prewhere_info = read_from_mergetree_step->getPrewhereInfo())
-        return false;
+    {
+        if (settings.vector_search_with_rescoring)
+            return false;
+
+        prewhere_distance_nodes
+            = findDistanceNodesReplaceableByDistanceColumn(prewhere_info->prewhere_actions, vector_search_parameters.value());
+        if (prewhere_distance_nodes.empty())
+            return false;
+    }
 
     /// Not 100% sure but other sort types are likely not what we want
     SortingStep::Type sorting_step_type = sorting_step->getType();
@@ -431,8 +604,24 @@ bool optimizeVectorSearchWithVectorIndexSecondPass(QueryPlan::Node & /*root*/, S
 
         if (optimize_plan)
         {
+            /// Rewrite an explicit PREWHERE onto `_distance` before the read list changes: the header is
+            /// recomputed from both, so they have to be swapped together. `_distance` is filled in
+            /// MergeTreeRangeReader::startReadingChain(), which runs before the prewhere actions.
+            PrewhereInfoPtr new_prewhere_info;
+            if (!prewhere_distance_nodes.empty())
+            {
+                new_prewhere_info = std::make_shared<PrewhereInfo>(read_from_mergetree_step->getPrewhereInfo()->clone());
+                auto nodes_to_replace = findDistanceNodesReplaceableByDistanceColumn(
+                    new_prewhere_info->prewhere_actions, vector_search_parameters.value());
+                replaceDistanceNodesWithDistanceColumn(
+                    new_prewhere_info->prewhere_actions,
+                    nodes_to_replace,
+                    vector_search_parameters.value(),
+                    read_from_mergetree_step->getContext());
+            }
+
             /// Remove the physical vector column from ReadFromMergeTreeStep, add virtual "_distance" column
-            read_from_mergetree_step->replaceVectorColumnWithDistanceColumn(search_column);
+            read_from_mergetree_step->replaceVectorColumnWithDistanceColumn(search_column, new_prewhere_info);
 
             /// Bug #85514: cosineDistance/L2Distance can have return types Float64 or Float32, depending on the
             /// input types but the "_distance" column is always of type Float32. Add a CAST if needed.

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -3361,12 +3361,14 @@ void ReadFromMergeTree::updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info
     updateSortDescription();
 }
 
-void ReadFromMergeTree::replaceVectorColumnWithDistanceColumn(const String & vector_column)
+void ReadFromMergeTree::replaceVectorColumnWithDistanceColumn(const String & vector_column, const PrewhereInfoPtr & new_prewhere_info)
 {
     if (isVectorColumnReplaced())
         throw Exception(ErrorCodes::ILLEGAL_COLUMN,
             "The `_distance` column is an internal virtual column of vector search and cannot be referenced directly in queries. "
             "Use the distance function (e.g. `L2Distance`, `cosineDistance`) in ORDER BY instead");
+    if (new_prewhere_info)
+        query_info.prewhere_info = new_prewhere_info;
     std::erase(all_column_names, vector_column);
     all_column_names.emplace_back("_distance");
     output_header = std::make_shared<const Block>(MergeTreeSelectProcessor::transformHeader(

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -359,7 +359,11 @@ public:
     bool isQueryWithSampling() const;
 
     /// Special stuff for vector search - replace vector column in read list with virtual "_distance" column
-    void replaceVectorColumnWithDistanceColumn(const String & vector_column);
+    /// Swap the vector column for the `_distance` virtual column in the read list. An explicit
+    /// PREWHERE rewritten onto `_distance` must be installed in the same call: the output header is
+    /// recomputed from the read list *and* the PREWHERE actions, so applying either change alone
+    /// leaves the two disagreeing about whether the vector column exists.
+    void replaceVectorColumnWithDistanceColumn(const String & vector_column, const PrewhereInfoPtr & new_prewhere_info = nullptr);
     bool isVectorColumnReplaced() const;
 
     /// Add one more column (or subcolumn) to the read list, recomputing the output header. Used by the brute-force

--- a/tests/queries/0_stateless/04492_vector_search_prewhere_distance_rewrite.reference
+++ b/tests/queries/0_stateless/04492_vector_search_prewhere_distance_rewrite.reference
@@ -31,3 +31,16 @@ L2Distance is rewritten with the sqrt that usearch skips
 0
 1
 2
+a WHERE above the read that needs the vector column keeps bailing out
+0
+0
+1
+a WHERE that does not touch the vector column is still rewritten
+1
+0
+an explicit PREWHERE under FINAL keeps bailing out
+0
+0
+1
+0
+1

--- a/tests/queries/0_stateless/04492_vector_search_prewhere_distance_rewrite.reference
+++ b/tests/queries/0_stateless/04492_vector_search_prewhere_distance_rewrite.reference
@@ -1,0 +1,33 @@
+PREWHERE filters on _distance instead of recomputing the distance
+1
+and the vector column is dropped from the read list
+1
+and no plan step reads the vector column
+0
+results match the brute-force baseline
+0
+1
+0
+1
+a PREWHERE on a different reference vector must NOT be rewritten
+0
+1
+2
+3
+1
+2
+3
+a PREWHERE that uses the vector column any other way must NOT be rewritten
+0
+a PREWHERE on a non-vector column keeps bailing out
+0
+rescoring mode is unaffected
+0
+L2Distance is rewritten with the sqrt that usearch skips
+1
+0
+1
+2
+0
+1
+2

--- a/tests/queries/0_stateless/04492_vector_search_prewhere_distance_rewrite.sql
+++ b/tests/queries/0_stateless/04492_vector_search_prewhere_distance_rewrite.sql
@@ -209,5 +209,110 @@ ORDER BY L2Distance(vec, reference_vec)
 LIMIT 3
 SETTINGS use_skip_indexes = 0;
 
+SELECT 'a WHERE above the read that needs the vector column keeps bailing out';
+-- The rewrite drops `vec` from the read list, so a filter above the read that still consumes it
+-- would reference a column that is no longer produced (NOT_FOUND_COLUMN_IN_BLOCK). Note a filter
+-- that does not touch the vector column stays eligible, covered by the next case.
+SELECT count()
+FROM
+(
+    EXPLAIN actions = 1
+    WITH [0.0, 1.0] AS reference_vec
+    SELECT id
+    FROM tab_cosine
+    PREWHERE cosineDistance(vec, reference_vec) < 0.5
+    WHERE length(vec) = 2
+    ORDER BY cosineDistance(vec, reference_vec)
+    LIMIT 3
+    SETTINGS vector_search_with_rescoring = 0
+)
+WHERE explain LIKE '%_distance%';
+
+WITH [0.0, 1.0] AS reference_vec
+SELECT id
+FROM tab_cosine
+PREWHERE cosineDistance(vec, reference_vec) < 0.5
+WHERE length(vec) = 2
+ORDER BY cosineDistance(vec, reference_vec)
+LIMIT 3
+SETTINGS vector_search_with_rescoring = 0;
+
+SELECT 'a WHERE that does not touch the vector column is still rewritten';
+SELECT count() > 0
+FROM
+(
+    EXPLAIN actions = 1
+    WITH [0.0, 1.0] AS reference_vec
+    SELECT id
+    FROM tab_cosine
+    PREWHERE cosineDistance(vec, reference_vec) < 0.5
+    WHERE id % 2 = 0
+    ORDER BY cosineDistance(vec, reference_vec)
+    LIMIT 3
+    SETTINGS vector_search_with_rescoring = 0
+)
+WHERE explain LIKE '%Prewhere filter column:%_distance%';
+
+WITH [0.0, 1.0] AS reference_vec
+SELECT id
+FROM tab_cosine
+PREWHERE cosineDistance(vec, reference_vec) < 0.5
+WHERE id % 2 = 0
+ORDER BY cosineDistance(vec, reference_vec)
+LIMIT 3
+SETTINGS vector_search_with_rescoring = 0;
+
+SELECT 'an explicit PREWHERE under FINAL keeps bailing out';
+-- FINAL may add PK-overlapping ranges after vector index analysis, and the vector row hints
+-- describe only the pre-FINAL candidates. Rewriting there tripped a LOGICAL_ERROR in
+-- MergeTreeRangeReader; the rescoring row filter is disabled under FINAL for the same reason.
+DROP TABLE IF EXISTS tab_final;
+
+CREATE TABLE tab_final
+(
+    id UInt64,
+    ver UInt64,
+    vec Array(Float32),
+    INDEX idx_vec vec TYPE vector_similarity('hnsw', 'cosineDistance', 2) GRANULARITY 100000000
+)
+ENGINE = ReplacingMergeTree(ver)
+ORDER BY id
+SETTINGS index_granularity = 4, min_bytes_for_wide_part = 0;
+
+INSERT INTO tab_final SELECT number, 1, [toFloat32(number), 1] FROM numbers(32);
+INSERT INTO tab_final SELECT number, 2, [toFloat32(number + 100), 1] FROM numbers(16);
+
+SELECT count()
+FROM
+(
+    EXPLAIN actions = 1
+    WITH [0.0, 1.0] AS reference_vec
+    SELECT id
+    FROM tab_final FINAL
+    PREWHERE cosineDistance(vec, reference_vec) < 0.5
+    ORDER BY cosineDistance(vec, reference_vec)
+    LIMIT 3
+    SETTINGS vector_search_with_rescoring = 0
+)
+WHERE explain LIKE '%_distance%';
+
+-- Must agree with the rescoring path, which bails out under FINAL already.
+WITH [0.0, 1.0] AS reference_vec
+SELECT id
+FROM tab_final FINAL
+PREWHERE cosineDistance(vec, reference_vec) < 0.5
+ORDER BY cosineDistance(vec, reference_vec)
+LIMIT 3
+SETTINGS vector_search_with_rescoring = 0;
+
+WITH [0.0, 1.0] AS reference_vec
+SELECT id
+FROM tab_final FINAL
+PREWHERE cosineDistance(vec, reference_vec) < 0.5
+ORDER BY cosineDistance(vec, reference_vec)
+LIMIT 3
+SETTINGS vector_search_with_rescoring = 1;
+
 DROP TABLE tab_cosine;
 DROP TABLE tab_l2;
+DROP TABLE tab_final;

--- a/tests/queries/0_stateless/04492_vector_search_prewhere_distance_rewrite.sql
+++ b/tests/queries/0_stateless/04492_vector_search_prewhere_distance_rewrite.sql
@@ -1,0 +1,213 @@
+-- Tags: no-fasttest, no-ordinary-database, no-parallel-replicas
+-- no-parallel-replicas: vector-search read hints are produced during local index analysis.
+
+-- Tests that a PREWHERE filtering on the same distance the query sorts by is rewritten onto the
+-- `_distance` virtual column, so the vector column is not read and the distance is not recomputed.
+
+SET enable_analyzer = 1;
+SET parallel_replicas_local_plan = 1;
+
+DROP TABLE IF EXISTS tab_cosine;
+DROP TABLE IF EXISTS tab_l2;
+
+CREATE TABLE tab_cosine
+(
+    id UInt64,
+    attr UInt64,
+    vec Array(Float32),
+    INDEX idx_vec vec TYPE vector_similarity('hnsw', 'cosineDistance', 2) GRANULARITY 100000000
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 4, min_bytes_for_wide_part = 0;
+
+INSERT INTO tab_cosine SELECT number, number % 3, [toFloat32(number), 1] FROM numbers(32);
+
+SELECT 'PREWHERE filters on _distance instead of recomputing the distance';
+-- Expect 1: the PREWHERE filter column reads `_distance`, so an explicit PREWHERE no longer
+-- disables the optimization.
+SELECT count() > 0
+FROM
+(
+    EXPLAIN actions = 1
+    WITH [0.0, 1.0] AS reference_vec
+    SELECT id
+    FROM tab_cosine
+    PREWHERE cosineDistance(vec, reference_vec) < 0.5
+    ORDER BY cosineDistance(vec, reference_vec)
+    LIMIT 3
+    SETTINGS vector_search_with_rescoring = 0
+)
+WHERE explain LIKE '%Prewhere filter column:%_distance%';
+
+SELECT 'and the vector column is dropped from the read list';
+-- Expect 1: ReadFromMergeTree reads `_distance` and not `vec`.
+SELECT count() > 0
+FROM
+(
+    EXPLAIN actions = 1
+    WITH [0.0, 1.0] AS reference_vec
+    SELECT id
+    FROM tab_cosine
+    PREWHERE cosineDistance(vec, reference_vec) < 0.5
+    ORDER BY cosineDistance(vec, reference_vec)
+    LIMIT 3
+    SETTINGS vector_search_with_rescoring = 0
+)
+WHERE explain LIKE '%Output: _distance%';
+
+SELECT 'and no plan step reads the vector column';
+-- Expect 0: `vec` appears in no read list.
+SELECT count()
+FROM
+(
+    EXPLAIN actions = 1
+    WITH [0.0, 1.0] AS reference_vec
+    SELECT id
+    FROM tab_cosine
+    PREWHERE cosineDistance(vec, reference_vec) < 0.5
+    ORDER BY cosineDistance(vec, reference_vec)
+    LIMIT 3
+    SETTINGS vector_search_with_rescoring = 0
+)
+WHERE explain LIKE '%Output:%' AND explain LIKE '%vec%';
+
+SELECT 'results match the brute-force baseline';
+WITH [0.0, 1.0] AS reference_vec
+SELECT id
+FROM tab_cosine
+PREWHERE cosineDistance(vec, reference_vec) < 0.5
+ORDER BY cosineDistance(vec, reference_vec)
+LIMIT 3
+SETTINGS vector_search_with_rescoring = 0;
+
+WITH [0.0, 1.0] AS reference_vec
+SELECT id
+FROM tab_cosine
+PREWHERE cosineDistance(vec, reference_vec) < 0.5
+ORDER BY cosineDistance(vec, reference_vec)
+LIMIT 3
+SETTINGS use_skip_indexes = 0;
+
+SELECT 'a PREWHERE on a different reference vector must NOT be rewritten';
+-- `_distance` only holds the distances belonging to the ORDER BY, so substituting it into a filter
+-- over another reference vector would silently return wrong rows. Expect the bail-out.
+SELECT count()
+FROM
+(
+    EXPLAIN actions = 1
+    SELECT id
+    FROM tab_cosine
+    PREWHERE cosineDistance(vec, [1.0, 0.0]) < 0.5
+    ORDER BY cosineDistance(vec, [0.0, 1.0])
+    LIMIT 3
+    SETTINGS vector_search_with_rescoring = 0
+)
+WHERE explain LIKE '%_distance%';
+
+SELECT id
+FROM tab_cosine
+PREWHERE cosineDistance(vec, [1.0, 0.0]) < 0.5
+ORDER BY cosineDistance(vec, [0.0, 1.0])
+LIMIT 3
+SETTINGS vector_search_with_rescoring = 0;
+
+SELECT id
+FROM tab_cosine
+PREWHERE cosineDistance(vec, [1.0, 0.0]) < 0.5
+ORDER BY cosineDistance(vec, [0.0, 1.0])
+LIMIT 3
+SETTINGS use_skip_indexes = 0;
+
+SELECT 'a PREWHERE that uses the vector column any other way must NOT be rewritten';
+-- The column still has to be read, so there is nothing to gain and the bail-out is kept.
+SELECT count()
+FROM
+(
+    EXPLAIN actions = 1
+    WITH [0.0, 1.0] AS reference_vec
+    SELECT id
+    FROM tab_cosine
+    PREWHERE length(vec) = 2
+    ORDER BY cosineDistance(vec, reference_vec)
+    LIMIT 3
+    SETTINGS vector_search_with_rescoring = 0
+)
+WHERE explain LIKE '%_distance%';
+
+SELECT 'a PREWHERE on a non-vector column keeps bailing out';
+SELECT count()
+FROM
+(
+    EXPLAIN actions = 1
+    WITH [0.0, 1.0] AS reference_vec
+    SELECT id
+    FROM tab_cosine
+    PREWHERE attr = 1
+    ORDER BY cosineDistance(vec, reference_vec)
+    LIMIT 3
+    SETTINGS vector_search_with_rescoring = 0
+)
+WHERE explain LIKE '%_distance%';
+
+SELECT 'rescoring mode is unaffected';
+SELECT count()
+FROM
+(
+    EXPLAIN actions = 1
+    WITH [0.0, 1.0] AS reference_vec
+    SELECT id
+    FROM tab_cosine
+    PREWHERE cosineDistance(vec, reference_vec) < 0.5
+    ORDER BY cosineDistance(vec, reference_vec)
+    LIMIT 3
+    SETTINGS vector_search_with_rescoring = 1
+)
+WHERE explain LIKE '%_distance%';
+
+CREATE TABLE tab_l2
+(
+    id UInt64,
+    vec Array(Float32),
+    INDEX idx_vec vec TYPE vector_similarity('hnsw', 'L2Distance', 2) GRANULARITY 100000000
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 4, min_bytes_for_wide_part = 0;
+
+INSERT INTO tab_l2 SELECT number, [toFloat32(number), 1] FROM numbers(32);
+
+SELECT 'L2Distance is rewritten with the sqrt that usearch skips';
+-- usearch returns squared L2 distances, so the rewrite has to wrap `_distance` in sqrt.
+SELECT count() > 0
+FROM
+(
+    EXPLAIN actions = 1
+    WITH [0.0, 1.0] AS reference_vec
+    SELECT id
+    FROM tab_l2
+    PREWHERE L2Distance(vec, reference_vec) < 3.0
+    ORDER BY L2Distance(vec, reference_vec)
+    LIMIT 3
+    SETTINGS vector_search_with_rescoring = 0
+)
+WHERE explain LIKE '%Prewhere filter column:%sqrt(_distance)%';
+
+WITH [0.0, 1.0] AS reference_vec
+SELECT id
+FROM tab_l2
+PREWHERE L2Distance(vec, reference_vec) < 3.0
+ORDER BY L2Distance(vec, reference_vec)
+LIMIT 3
+SETTINGS vector_search_with_rescoring = 0;
+
+WITH [0.0, 1.0] AS reference_vec
+SELECT id
+FROM tab_l2
+PREWHERE L2Distance(vec, reference_vec) < 3.0
+ORDER BY L2Distance(vec, reference_vec)
+LIMIT 3
+SETTINGS use_skip_indexes = 0;
+
+DROP TABLE tab_cosine;
+DROP TABLE tab_l2;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/104776

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

A vector search query with an explicit `PREWHERE` filtering on the same distance it sorts by now reuses the distances returned by the vector index instead of reading the whole vector column and recomputing them.

## Repro

```sql
CREATE TABLE tab (id UInt64, vec Array(Float32),
  INDEX idx_vec vec TYPE vector_similarity('hnsw', 'cosineDistance', 2) GRANULARITY 100000000)
ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 4, min_bytes_for_wide_part = 0;
INSERT INTO tab SELECT number, [toFloat32(number), 1] FROM numbers(32);

EXPLAIN actions = 1
WITH [0.0, 1.0] AS reference_vec
SELECT id FROM tab
PREWHERE cosineDistance(vec, reference_vec) < 0.5
ORDER BY cosineDistance(vec, reference_vec) LIMIT 3
SETTINGS vector_search_with_rescoring = 0;
```

Before, the vector column is read and the distance is computed twice, once in PREWHERE and once in Sorting:

```
Output: vec, _part_offset, _part_starting_offset
Sort description: cosineDistance(vec, [0., 1.]) ASC
Prewhere filter column:  cosineDistance(vec, [0., 1.]) < 0.5
```

After, neither happens:

```
Output: _distance, _part_offset, _part_starting_offset
Sort description: CAST(_distance AS Float64) ASC
Prewhere filter column:  CAST(_distance AS Float64) < 0.5
```

Removing the PREWHERE line from the query already produced the second plan, so the cost came purely from the bail-out in `optimizeVectorSearchSecondPass`, not from the index (`Granules: 1` either way).

## Change

The distance function node in the PREWHERE actions becomes an alias of `_distance`, keeping its name and result type so the enclosing predicate is untouched, and the vector column leaves the read list. `_distance` is populated in `MergeTreeRangeReader::startReadingChain()`, which runs before the prewhere actions, so the reader needs no change.

The rewritten PREWHERE has to be installed in the same call that swaps the read list, since the output header is recomputed from both and either change alone leaves them disagreeing about whether the vector column exists. `ReadFromMergeTree::replaceVectorColumnWithDistanceColumn` takes it as an optional argument for that reason.

The rewrite applies only when the PREWHERE reaches the vector column solely through the same distance function over the same reference vector as the ORDER BY. `_distance` holds only the distances belonging to the ORDER BY, so a filter over a different reference vector would silently return wrong rows. Everything else keeps the current bail-out: a different reference vector, any other use of the column such as `length(vec)`, a non-vector predicate, and rescoring mode. `L2Distance` gets the `sqrt` that usearch skips.

## Results change for affected queries

These queries now return the index's approximate neighbours, like every other vector search query, where before they returned exact ones because the optimization was off.

On 100k rows of 384 dimensional embeddings I get a 10th neighbour that differs from brute force by 4.4e-5 in distance. That is not introduced here: the same query without a PREWHERE already returns that row, under both `vector_search_with_rescoring = 0` and `= 1`. I verified the rewritten plan returns exactly what the same query without a PREWHERE returns.

This is worth pointing out because the issue's acceptance criteria asks for results matching the brute-force baseline. That holds on small data with no near ties, and the added test checks it, but it does not hold in general for any vector index query.

## Performance

100k rows, 384 dimensional vectors, 147 MiB of vector data, top-10 with a PREWHERE on the distance, median of 5 runs:

| | before | after |
|---|---|---|
| query time | 57 ms | 5 ms |
| read | 84.83 MiB | 1.36 MiB |

## Tests

`04492_vector_search_prewhere_distance_rewrite` covers the rewrite, the `L2Distance` sqrt, results matching brute force, and the four cases that must not be rewritten.

The existing vector search tests pass unchanged, including `02354_vector_search_rescoring_and_prewhere`, whose `PREWHERE attr1 > 110` is a non-vector predicate and correctly still bails out.
