### PR TITLE
Measure cancellation server-side in test_cancel_backup.py

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -524,18 +524,10 @@ def test_cancel_backup():
 
         kill_start_time = get_query_start_time(node_to_cancel, kill_query_id)
 
-        # Measured between two server-recorded timestamps: the start of the KILL QUERY on the
-        # node it was sent to, and the moment the initiator reached the terminal status (which
-        # is stamped after the initiator waited for the other hosts, capped on the error path
-        # by backup_restore_finish_timeout_after_error_sec, which this module's profile sets to
-        # 3 s). So the cluster-wide cancellation is inside the interval up to that cap, which is
-        # the same terminus the previous client-side stopwatch had; a host still cancelling
-        # after that is caught by the get_num_system_processes() check below. wait_status still
-        # polls over the same period, but neither endpoint can be moved by a poll: the left one
-        # was written before the polling started, and the right one is stamped by the backup
-        # thread, not by the observing SELECT. So no client round trip is added to the
-        # measurement, including the system.query_log lookup above, which runs after end_time
-        # was stamped.
+        # Both endpoints are server-recorded, so neither wait_status's polling nor the query_log
+        # lookup above can move them: the KILL's start precedes the polling, and the terminal
+        # status is stamped by the backup thread after it waited for the other hosts, capped on
+        # the error path by backup_restore_finish_timeout_after_error_sec (3 s in this module).
         time_to_cancel = seconds_between(kill_start_time, end_time)
         print(f"Cancellation took {time_to_cancel} seconds (server-side)")
 

--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -116,6 +116,24 @@ def seconds_between(from_time, to_time):
     return (parse_server_time(to_time) - parse_server_time(from_time)).total_seconds()
 
 
+# Reads the server-recorded start time of a query from system.query_log by its query_id.
+# Called after the measured operation has finished, so that neither the flush nor the read
+# can perturb the interval being measured.
+def get_query_start_time(node, query_id):
+    node.query("SYSTEM FLUSH LOGS query_log")
+    rows = node.query(
+        "SELECT query_start_time_microseconds FROM system.query_log "
+        f"WHERE (query_id = '{query_id}') AND (type = 'QueryFinish')"
+    ).splitlines()
+    # Exactly one row must be found, so that a vanished oracle fails loudly here instead of
+    # silently skipping the caller's timing check.
+    assert (
+        len(rows) == 1
+    ), f"Expected 1 query_log row for query_id={query_id}, got {rows}"
+    print(f"{get_node_name(node)}: query {query_id} started at {rows[0]} (server time)")
+    return rows[0]
+
+
 # Reads the status of a backup or a restore from system.backups.
 def get_status(initiator, backup_id=None, restore_id=None):
     id = backup_id if backup_id is not None else restore_id
@@ -253,10 +271,10 @@ def wait_num_system_processes(
 
 
 # Kills a BACKUP or RESTORE query.
-# Returns the server-recorded `query_start_time_microseconds` of the KILL QUERY itself
-# (a DateTime64(6) value read from system.query_log by the KILL's own query_id), so that
-# callers can measure the cancellation without any clickhouse-client launch inside the
-# measured interval.
+# Returns the `query_id` of the KILL QUERY it issued, so that the caller can look up its
+# server-recorded start time later (see get_query_start_time()), after the measured
+# operation has finished, so that no clickhouse-client launch is inside the measured
+# interval.
 def kill_query(
     node, backup_id=None, restore_id=None, is_initial_query=None, timeout=None
 ):
@@ -281,21 +299,7 @@ def kill_query(
     )
     if timeout is not None:
         assert waited < timeout
-    node.query("SYSTEM FLUSH LOGS")
-    rows = node.query(
-        "SELECT query_start_time_microseconds FROM system.query_log "
-        f"WHERE (query_id = '{kill_query_id}') AND (type = 'QueryFinish')"
-    ).splitlines()
-    # Exactly one row must be found, so that a vanished oracle fails loudly here instead of
-    # silently skipping the caller's timing check.
-    assert (
-        len(rows) == 1
-    ), f"Expected 1 query_log row for KILL query_id={kill_query_id}, got {rows}"
-    kill_start_time = rows[0]
-    print(
-        f"{get_node_name(node)}: KILL QUERY {kill_query_id} started at {kill_start_time} (server time)"
-    )
-    return kill_start_time
+    return kill_query_id
 
 
 # Sleeps for random amount of time.
@@ -509,7 +513,7 @@ def test_cancel_backup():
             f"Cancelling on {'initiator' if cancel_as_initiator else 'node'} {get_node_name(node_to_cancel)} at {format_current_time()}"
         )
 
-        kill_start_time = kill_query(
+        kill_query_id = kill_query(
             node_to_cancel, backup_id=backup_id, is_initial_query=cancel_as_initiator
         )
 
@@ -517,17 +521,22 @@ def test_cancel_backup():
             assert get_status(initiator, backup_id=backup_id) == "BACKUP_CANCELLED"
         end_time = wait_status(initiator, "BACKUP_CANCELLED", backup_id=backup_id)
 
+        kill_start_time = get_query_start_time(node_to_cancel, kill_query_id)
+
         # Measured between two server-recorded timestamps: the start of the KILL QUERY on the
         # node it was sent to, and the moment the initiator reached the terminal status (which
         # is stamped after the initiator finished waiting for the other hosts). So the whole
         # cluster-wide cancellation is inside the interval, while the harness round trips are
-        # not.
+        # not. The system.query_log lookup above happens after the operation finished, so it
+        # cannot perturb the interval either.
         time_to_cancel = seconds_between(kill_start_time, end_time)
         print(f"Cancellation took {time_to_cancel} seconds (server-side)")
 
         assert "QUERY_WAS_CANCELLED" in get_error(initiator, backup_id=backup_id)
         assert get_num_system_processes(nodes, backup_id=backup_id) == 0
-        assert time_to_cancel <= 6  # A backup should be cancelled quite quickly.
+        # Two independent wall-clock reads, so a backward clock step would otherwise make a
+        # too-slow cancellation look fast; the lower bound turns that into a failure.
+        assert 0 <= time_to_cancel <= 6  # A backup should be cancelled quite quickly.
         no_trash_checker.expect_errors = ["QUERY_WAS_CANCELLED"]
 
 
@@ -573,7 +582,7 @@ def test_cancel_restore():
             f"Cancelling on {'initiator' if cancel_as_initiator else 'node'} {get_node_name(node_to_cancel)} at {format_current_time()}"
         )
 
-        kill_start_time = kill_query(
+        kill_query_id = kill_query(
             node_to_cancel, restore_id=restore_id, is_initial_query=cancel_as_initiator
         )
 
@@ -581,13 +590,17 @@ def test_cancel_restore():
             assert get_status(initiator, restore_id=restore_id) == "RESTORE_CANCELLED"
         end_time = wait_status(initiator, "RESTORE_CANCELLED", restore_id=restore_id)
 
+        kill_start_time = get_query_start_time(node_to_cancel, kill_query_id)
+
         # Both endpoints are server-recorded, see the comment in test_cancel_backup.
         time_to_cancel = seconds_between(kill_start_time, end_time)
         print(f"Cancellation took {time_to_cancel} seconds (server-side)")
 
         assert "QUERY_WAS_CANCELLED" in get_error(initiator, restore_id=restore_id)
         assert get_num_system_processes(nodes, restore_id=restore_id) == 0
-        assert time_to_cancel <= 6  # A restore should be cancelled quite quickly.
+        # Two independent wall-clock reads, so a backward clock step would otherwise make a
+        # too-slow cancellation look fast; the lower bound turns that into a failure.
+        assert 0 <= time_to_cancel <= 6  # A restore should be cancelled quite quickly.
         no_trash_checker.expect_errors = ["QUERY_WAS_CANCELLED"]
 
     # Restore successfully.

--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -526,12 +526,16 @@ def test_cancel_backup():
 
         # Measured between two server-recorded timestamps: the start of the KILL QUERY on the
         # node it was sent to, and the moment the initiator reached the terminal status (which
-        # is stamped after the initiator finished waiting for the other hosts). So the whole
-        # cluster-wide cancellation is inside the interval. wait_status still polls over the
-        # same period, but neither endpoint can be moved by a poll: the left one was written
-        # before the polling started, and the right one is stamped by the backup thread, not
-        # by the observing SELECT. So no client round trip is added to the measurement,
-        # including the system.query_log lookup above, which runs after end_time was stamped.
+        # is stamped after the initiator waited for the other hosts, capped on the error path
+        # by backup_restore_finish_timeout_after_error_sec, which this module's profile sets to
+        # 3 s). So the cluster-wide cancellation is inside the interval up to that cap, which is
+        # the same terminus the previous client-side stopwatch had; a host still cancelling
+        # after that is caught by the get_num_system_processes() check below. wait_status still
+        # polls over the same period, but neither endpoint can be moved by a poll: the left one
+        # was written before the polling started, and the right one is stamped by the backup
+        # thread, not by the observing SELECT. So no client round trip is added to the
+        # measurement, including the system.query_log lookup above, which runs after end_time
+        # was stamped.
         time_to_cancel = seconds_between(kill_start_time, end_time)
         print(f"Cancellation took {time_to_cancel} seconds (server-side)")
 

--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -110,8 +110,9 @@ def parse_server_time(value):
 
 
 # Returns the number of seconds between two DateTime64(6) values produced by the server.
-# Both endpoints must be server-recorded so that no clickhouse-client launch (each costs
-# 0.5-1 s, and much more on a contended runner) is inside the measured interval.
+# Both endpoints must be server-recorded, so that the cost of the clickhouse-client launches
+# the test makes in between (0.5-1 s each, and much more on a contended runner) is not added
+# to the measured interval.
 def seconds_between(from_time, to_time):
     return (parse_server_time(to_time) - parse_server_time(from_time)).total_seconds()
 
@@ -273,8 +274,8 @@ def wait_num_system_processes(
 # Kills a BACKUP or RESTORE query.
 # Returns the `query_id` of the KILL QUERY it issued, so that the caller can look up its
 # server-recorded start time later (see get_query_start_time()), after the measured
-# operation has finished, so that no clickhouse-client launch is inside the measured
-# interval.
+# operation has finished. Looking it up afterwards keeps the lookup's own cost out of the
+# interval being measured.
 def kill_query(
     node, backup_id=None, restore_id=None, is_initial_query=None, timeout=None
 ):
@@ -526,16 +527,20 @@ def test_cancel_backup():
         # Measured between two server-recorded timestamps: the start of the KILL QUERY on the
         # node it was sent to, and the moment the initiator reached the terminal status (which
         # is stamped after the initiator finished waiting for the other hosts). So the whole
-        # cluster-wide cancellation is inside the interval, while the harness round trips are
-        # not. The system.query_log lookup above happens after the operation finished, so it
-        # cannot perturb the interval either.
+        # cluster-wide cancellation is inside the interval. wait_status still polls over the
+        # same period, but neither endpoint can be moved by a poll: the left one was written
+        # before the polling started, and the right one is stamped by the backup thread, not
+        # by the observing SELECT. So no client round trip is added to the measurement,
+        # including the system.query_log lookup above, which runs after end_time was stamped.
         time_to_cancel = seconds_between(kill_start_time, end_time)
         print(f"Cancellation took {time_to_cancel} seconds (server-side)")
 
         assert "QUERY_WAS_CANCELLED" in get_error(initiator, backup_id=backup_id)
         assert get_num_system_processes(nodes, backup_id=backup_id) == 0
-        # Two independent wall-clock reads, so a backward clock step would otherwise make a
-        # too-slow cancellation look fast; the lower bound turns that into a failure.
+        # Unlike the previous time.monotonic() stopwatch, these are two independent
+        # CLOCK_REALTIME reads, so the interval can now come out negative if the wall clock
+        # steps backwards between them. The lower bound makes that a loud failure instead of a
+        # negative value silently satisfying the upper bound.
         assert 0 <= time_to_cancel <= 6  # A backup should be cancelled quite quickly.
         no_trash_checker.expect_errors = ["QUERY_WAS_CANCELLED"]
 
@@ -598,8 +603,10 @@ def test_cancel_restore():
 
         assert "QUERY_WAS_CANCELLED" in get_error(initiator, restore_id=restore_id)
         assert get_num_system_processes(nodes, restore_id=restore_id) == 0
-        # Two independent wall-clock reads, so a backward clock step would otherwise make a
-        # too-slow cancellation look fast; the lower bound turns that into a failure.
+        # Unlike the previous time.monotonic() stopwatch, these are two independent
+        # CLOCK_REALTIME reads, so the interval can now come out negative if the wall clock
+        # steps backwards between them. The lower bound makes that a loud failure instead of a
+        # negative value silently satisfying the upper bound.
         assert 0 <= time_to_cancel <= 6  # A restore should be cancelled quite quickly.
         no_trash_checker.expect_errors = ["QUERY_WAS_CANCELLED"]
 

--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import random
 import time
@@ -103,6 +104,18 @@ def get_backup_name(backup_id):
     return f"Disk('backups', '{backup_id}')"
 
 
+# Converts a DateTime64(6) value as printed by clickhouse-client to a datetime.
+def parse_server_time(value):
+    return datetime.datetime.strptime(value.strip(), "%Y-%m-%d %H:%M:%S.%f")
+
+
+# Returns the number of seconds between two DateTime64(6) values produced by the server.
+# Both endpoints must be server-recorded so that no clickhouse-client launch (each costs
+# 0.5-1 s, and much more on a contended runner) is inside the measured interval.
+def seconds_between(from_time, to_time):
+    return (parse_server_time(to_time) - parse_server_time(from_time)).total_seconds()
+
+
 # Reads the status of a backup or a restore from system.backups.
 def get_status(initiator, backup_id=None, restore_id=None):
     id = backup_id if backup_id is not None else restore_id
@@ -120,7 +133,7 @@ def get_error(initiator, backup_id=None, restore_id=None):
 
 
 # Waits until the status of a backup or a restore becomes a desired one.
-# Returns how many seconds the function was waiting.
+# Returns the server-recorded `end_time` of the operation (a DateTime64(6) value).
 def wait_status(
     initiator,
     status="BACKUP_CREATED",
@@ -156,6 +169,7 @@ def wait_status(
         f"(start_time = {start_time}, end_time = {end_time})"
     )
     assert current_status == status
+    return end_time
 
 
 # Returns how many entries are in system.processes corresponding to a specified backup or restore.
@@ -239,7 +253,10 @@ def wait_num_system_processes(
 
 
 # Kills a BACKUP or RESTORE query.
-# Returns how many seconds the KILL QUERY was executing.
+# Returns the server-recorded `query_start_time_microseconds` of the KILL QUERY itself
+# (a DateTime64(6) value read from system.query_log by the KILL's own query_id), so that
+# callers can measure the cancellation without any clickhouse-client launch inside the
+# measured interval.
 def kill_query(
     node, backup_id=None, restore_id=None, is_initial_query=None, timeout=None
 ):
@@ -252,9 +269,11 @@ def kill_query(
         if is_initial_query is not None
         else ""
     )
+    kill_query_id = uuid.uuid4().hex
     old_time = time.monotonic()
     node.query(
-        f"KILL QUERY WHERE (query_kind='{query_kind}') AND (query LIKE '%{id}%'){filter_for_is_initial_query} SYNC"
+        f"KILL QUERY WHERE (query_kind='{query_kind}') AND (query LIKE '%{id}%'){filter_for_is_initial_query} SYNC",
+        query_id=kill_query_id,
     )
     waited = time.monotonic() - old_time
     print(
@@ -262,6 +281,21 @@ def kill_query(
     )
     if timeout is not None:
         assert waited < timeout
+    node.query("SYSTEM FLUSH LOGS")
+    rows = node.query(
+        "SELECT query_start_time_microseconds FROM system.query_log "
+        f"WHERE (query_id = '{kill_query_id}') AND (type = 'QueryFinish')"
+    ).splitlines()
+    # Exactly one row must be found, so that a vanished oracle fails loudly here instead of
+    # silently skipping the caller's timing check.
+    assert (
+        len(rows) == 1
+    ), f"Expected 1 query_log row for KILL query_id={kill_query_id}, got {rows}"
+    kill_start_time = rows[0]
+    print(
+        f"{get_node_name(node)}: KILL QUERY {kill_query_id} started at {kill_start_time} (server time)"
+    )
+    return kill_start_time
 
 
 # Sleeps for random amount of time.
@@ -439,6 +473,11 @@ def get_backup_id_of_successful_backup():
 # Test that a BACKUP operation can be cancelled with KILL QUERY.
 def test_cancel_backup():
     with NoTrashChecker() as no_trash_checker:
+        # QUERY_WAS_CANCELLED is allowed from here on, so that if the test body fails before
+        # reaching the `expect_errors` assignment below, __exit__ reports that failure instead
+        # of masking it with its own "unexpected error" assert.
+        no_trash_checker.allow_errors = ["QUERY_WAS_CANCELLED"]
+
         create_and_fill_table(random_node())
 
         initiator = random_node()
@@ -470,17 +509,21 @@ def test_cancel_backup():
             f"Cancelling on {'initiator' if cancel_as_initiator else 'node'} {get_node_name(node_to_cancel)} at {format_current_time()}"
         )
 
-        time_before_kill_query = time.monotonic()
-
-        kill_query(
+        kill_start_time = kill_query(
             node_to_cancel, backup_id=backup_id, is_initial_query=cancel_as_initiator
         )
 
         if cancel_as_initiator:
             assert get_status(initiator, backup_id=backup_id) == "BACKUP_CANCELLED"
-        wait_status(initiator, "BACKUP_CANCELLED", backup_id=backup_id)
+        end_time = wait_status(initiator, "BACKUP_CANCELLED", backup_id=backup_id)
 
-        time_to_cancel = time.monotonic() - time_before_kill_query
+        # Measured between two server-recorded timestamps: the start of the KILL QUERY on the
+        # node it was sent to, and the moment the initiator reached the terminal status (which
+        # is stamped after the initiator finished waiting for the other hosts). So the whole
+        # cluster-wide cancellation is inside the interval, while the harness round trips are
+        # not.
+        time_to_cancel = seconds_between(kill_start_time, end_time)
+        print(f"Cancellation took {time_to_cancel} seconds (server-side)")
 
         assert "QUERY_WAS_CANCELLED" in get_error(initiator, backup_id=backup_id)
         assert get_num_system_processes(nodes, backup_id=backup_id) == 0
@@ -495,6 +538,11 @@ def test_cancel_restore():
 
     # Cancel restoring.
     with NoTrashChecker() as no_trash_checker:
+        # QUERY_WAS_CANCELLED is allowed from here on, so that if the test body fails before
+        # reaching the `expect_errors` assignment below, __exit__ reports that failure instead
+        # of masking it with its own "unexpected error" assert.
+        no_trash_checker.allow_errors = ["QUERY_WAS_CANCELLED"]
+
         print("Will cancel restoring")
         initiator = random_node()
         print(f"Using {get_node_name(initiator)} as initiator")
@@ -525,17 +573,17 @@ def test_cancel_restore():
             f"Cancelling on {'initiator' if cancel_as_initiator else 'node'} {get_node_name(node_to_cancel)} at {format_current_time()}"
         )
 
-        time_before_kill_query = time.monotonic()
-
-        kill_query(
+        kill_start_time = kill_query(
             node_to_cancel, restore_id=restore_id, is_initial_query=cancel_as_initiator
         )
 
         if cancel_as_initiator:
             assert get_status(initiator, restore_id=restore_id) == "RESTORE_CANCELLED"
-        wait_status(initiator, "RESTORE_CANCELLED", restore_id=restore_id)
+        end_time = wait_status(initiator, "RESTORE_CANCELLED", restore_id=restore_id)
 
-        time_to_cancel = time.monotonic() - time_before_kill_query
+        # Both endpoints are server-recorded, see the comment in test_cancel_backup.
+        time_to_cancel = seconds_between(kill_start_time, end_time)
+        print(f"Cancellation took {time_to_cancel} seconds (server-side)")
 
         assert "QUERY_WAS_CANCELLED" in get_error(initiator, restore_id=restore_id)
         assert get_num_system_processes(nodes, restore_id=restore_id) == 0


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/108459


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_backup_restore_on_cluster/test_cancel_backup.py::test_cancel_backup` and
`::test_cancel_restore` are flaky: **14 FAIL/ERROR rows over 24 days, 11 distinct PRs, plus one
run on `master` and one on `26.6`** (30-day CIDB window, excluding the unrelated signature
separated at the end of this description).

**The signature CIDB shows is a mask, not the defect.** `test_context_raw` is truncated to the
last frames, so what CIDB reports is `NoTrashChecker.__exit__` asserting with both relaxation
lists empty:

```
test_cancel_backup.py:441 - in test_cancel_backup
    with NoTrashChecker() as no_trash_checker:
test_cancel_backup.py:375 - in __exit__
    assert (error in self.expect_errors) or (error in self.allow_errors)
E   AssertionError: assert ('QUERY_WAS_CANCELLED' in [] or 'QUERY_WAS_CANCELLED' in [])
```

The job logs show the body exception that ran first, identically in all 12 rows whose logs were
fetched (the 12 that existed when this was investigated; two more have landed since):

```
test_cancel_backup.py:487: in test_cancel_backup
    assert time_to_cancel <= 6  # A backup should be cancelled quite quickly.
E   assert 6.5760968409999805 <= 6
```

**`time_to_cancel` was a client-side stopwatch, so it measured the integration harness rather
than the cancellation.** Every `node.query(...)` here is a `docker exec` of a fresh
`clickhouse-client`, and the measured window spanned 3-4 of them plus `wait_status`'s whole-second
poll quantum. Decomposing each failure using timestamps the test already prints
(`system.backups.end_time` minus the wall clock at the KILL):

| PR | reported `time_to_cancel` | engine-side upper bound | harness overhead |
|---|---|---|---|
| 104484 | 6.58 | 2.28 | 4.29 |
| 105684 | 6.93 | 2.50 | 4.43 |
| 109374 | 6.18 | 3.24 | 2.94 |
| 110186 | 8.13 | 2.22 | 5.91 |
| 110199 | 8.64 | 2.76 | 5.87 |
| 110231 | 6.22 | 2.38 | 3.85 |
| 110254 | 6.97 | 2.02 | 4.96 |
| 111196 | 6.72 | 2.49 | 4.23 |
| 111353 | 6.68 | 2.08 | 4.60 |
| `26.6` (release branch) | 7.74 | 2.59 | 5.15 |
| 98472 | 6.51 | 1.90 | 4.61 |
| `master` | 6.48 | 2.15 | 4.34 |

**Engine-side: max 3.24 s, median 2.33 s, i.e. every single failure is comfortably inside the
6 s intent.** The cancellation was prompt in all 12; the assertion failed on measurement
overhead alone, which is why the failure is rare, recurring, and both arch- and
sanitizer-agnostic. There is nothing to fix in the engine.

**The fix measures the same interval between two server-recorded timestamps**, so client
round-trip latency is no longer added to it while the cluster-wide cancellation is still inside
it (up to the error-path cap described below). `wait_status` does still poll over the same
period, but neither endpoint can be moved by a poll: the left one is written before the polling
starts, and the right one is stamped by the backup thread rather than by the observing `SELECT`.

* `kill_query` issues the `KILL ... SYNC` with an explicit `query_id` and returns it. Once the
  operation has finished, `get_query_start_time` reads that query's own
  `query_start_time_microseconds` from `system.query_log`. Taking the start from the KILL
  statement itself (rather than a separately issued `SELECT now64(6)`) is what stops a client
  launch from being added to the interval: in the `104484` run one client-to-server transition
  stalled **4.192 s**, which alone would consume the whole budget. Doing the lookup after the
  fact keeps the lookup's own cost out of the measurement too.
* `wait_status` returns the `end_time` it already reads and prints. `BackupsWorker::setStatus`
  stamps it at the terminal transition, which the initiator reaches only after
  `waitOtherHostsFinish`, so distributed propagation stays inside the bound. That matters: the
  KILL's own duration is not a sufficient oracle, because `waitOtherHostsFinish` is gated on
  `!is_internal_backup`, so a KILL aimed at a non-initiator returns before the initiator reaches
  the terminal status (measured 0.65-1.10 s of propagation in 9 of the 12 rows). On the error
  path that wait is itself capped by `backup_restore_finish_timeout_after_error_sec`, which this
  module sets to 3 s, so what the interval bounds is the cancellation up to that cap rather than
  an unconditional last-host completion. That is the same terminus the previous assertion had -
  `time_to_cancel` ended at the same `wait_status` return - so nothing is narrowed here; a remote
  host still cancelling afterwards is caught by the existing
  `assert get_num_system_processes(nodes, ...) == 0` on the next line.

**The 6 s upper bound is unchanged, and it stays a single end-to-end assertion.** Nothing is
loosened, no second oracle is added, and a genuinely slow cancellation still fails: measured on
this branch, tightening the bound to `1` fails, and to `0.001` fails.

The assertion is now two-sided (`assert 0 <= time_to_cancel <= 6`), which only tightens it. The
previous oracle was a single `time.monotonic()` stopwatch and so could not produce a negative
value; these are two independent `CLOCK_REALTIME` reads, so a backward wall-clock step between
them can now yield a negative interval, which would otherwise satisfy `<= 6` silently. The lower
bound makes that a loud failure instead. (It catches the negative case, not every backward step:
a step smaller than the true interval still leaves a positive value.) All 20 runs of the
verification below produced positive intervals (min 0.146 s), so the clause cannot flake on the
normal path.

Second, independent change: `no_trash_checker.allow_errors = ["QUERY_WAS_CANCELLED"]` is now set
on entry to the checker, while `expect_errors` stays where it was, after the cancellation has
been observed. That removes the mask for this failure mode, so a body exception raised after the
cancellation was induced reports itself instead of costing another investigation. The list is
deliberately minimal rather than broad, so `__exit__` still fails on any *other* unexpected error
name. `allow_errors` is deliberately the hoisted one:
`__exit__` treats `expect_errors` as must-have-been-observed, so hoisting *that* would create a
new mask with inverted polarity for any failure before the cancellation. This matches
[#108459](https://github.com/ClickHouse/ClickHouse/pull/108459), which hoisted `allow_errors`
for two sibling functions in this file and never `expect_errors`.

`test_cancel_restore` has the same defect and is fixed identically. It is a confirmed carrier
rather than a speculative one: PR #109374's log shows `assert 6.143040713999653 <= 6` followed by
the same mask. It has one recorded row against `test_cancel_backup`'s 13, but the defective
construct is identical, so fixing only one of the two would leave a known carrier in place.

**Why not the `query_duration_ms` oracle that `test_backup_restore_new/test_cancel_backup.py`
uses.** It was deliberately removed from *this* file in `19bcc5550bad04`, and
`c26e0b413fa619` then replaced the per-step timeouts with the single end-to-end
`assert time_to_cancel <= 6`. This PR keeps that single end-to-end assertion and changes only how
its two endpoints are obtained.

#### Verification

* Mechanism reproduced deterministically by injecting a 6 s harness delay into the measured
  window: on `master` the old assertion fails at `assert 6.660929953679442 <= 6` followed by the
  mask, byte-matching the CI signature; on this branch the *same* injection passes, because the
  server-recorded interval cannot see a delay that happens after `end_time` was stamped. A second
  injection *before* the KILL also passes, confirming that client round-trip cost outside the two
  server-recorded endpoints is not added to the measurement.
  (A 4 s injection is marginal, because whether it trips the old bound depends on how long the
  KILL itself took that run, so both directions are measured at one common 6 s delay.)
* Both measurements taken in the same run, 10 runs: server-side interval 0.887-1.993 s (median
  1.291), old client stopwatch 1.528-3.147 s (median 2.193), i.e. **0.605-1.166 s of harness
  overhead removed per run**. Worst server-side observation leaves **3.0x headroom** under the
  unchanged 6 s bound.
* Each change proven load-bearing by mutation: reverting only the measurement makes the injected
  delay fail again; removing only the `allow_errors` hoist brings the mask back; hoisting
  `expect_errors` instead reproduces the inverted-polarity mask.
* Whole module 7/7 passing, and 20/20 passing under `pytest --count 10` of both fixed functions
  (server-side interval min 0.146 / median 1.186 / max 2.151 s across those 20 runs, no negative
  values, i.e. ~2.8x headroom under the unchanged 6 s bound at the worst observation).

Out of scope, so that the row accounting is unambiguous. A 30-day CIDB search for
`%test_cancel_backup.py::test_cancel_%` returns 40 rows in total, which decompose as:

| module | test | signature | rows | PRs |
|---|---|---|---|---|
| `test_backup_restore_on_cluster` | `test_cancel_backup` | timing / mask | **13** | **11** + `master` + `26.6` |
| `test_backup_restore_on_cluster` | `test_cancel_restore` | timing / mask | **1** | **1** (#109374) |
| `test_backup_restore_on_cluster` | `test_cancel_backup` | leftover znode | 12 | 2 |
| `test_backup_restore_on_cluster` | `test_cancel_restore` | leftover znode | 12 | 2 |
| `test_backup_restore_new` | `test_cancel_backup` | timing / mask | 2 | 1 |

The 14 bold rows are what this PR fixes. The 24 leftover-znode rows are a different assertion in
the same file (`__exit__` reporting a leftover `/clickhouse/backups/...` node) and occur only on
[#109785](https://github.com/ClickHouse/ClickHouse/pull/109785) and
[#109786](https://github.com/ClickHouse/ClickHouse/pull/109786), never on `master` or any other
PR, so they belong to those cancellation-engine branches. The remaining 2 rows are a different
module, `test_backup_restore_new/test_cancel_backup.py`, which this PR does not touch and which
contains no timing assertion at all.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.470` (included in `26.8` and later)
<!-- ch-version-info:end -->