### PR TITLE
Do not share a join-tree table expression with an IN argument

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -3253,8 +3253,8 @@ ProjectionNames QueryAnalyzer::resolveExpressionNode(
                     {
                         /// A table expression that also appears in an enclosing query's join tree must
                         /// not be shared with this argument: later stages rewrite each argument instance
-                        /// in place (createUniqueAliasesIfNecessary, GLOBAL IN external tables,
-                        /// rewrite_in_to_join), and with a shared node those edits land in the join tree.
+                        /// in place (`createUniqueAliasesIfNecessary`, `GLOBAL IN` external tables,
+                        /// `rewrite_in_to_join`), and with a shared node those edits land in the join tree.
                         for (const auto * scope_to_check = &scope; scope_to_check != nullptr;
                              scope_to_check = scope_to_check->parent_scope)
                         {

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -3249,6 +3249,22 @@ ProjectionNames QueryAnalyzer::resolveExpressionNode(
                                 /*throw_on_mismatch=*/ true);
                         }
                     }
+                    else if (isTableExpressionNodeType(resolved_identifier_node->getNodeType()))
+                    {
+                        /// A table expression that also appears in an enclosing query's join tree must
+                        /// not be shared with this argument: later stages rewrite each argument instance
+                        /// in place (createUniqueAliasesIfNecessary, GLOBAL IN external tables,
+                        /// rewrite_in_to_join), and with a shared node those edits land in the join tree.
+                        for (const auto * scope_to_check = &scope; scope_to_check != nullptr;
+                             scope_to_check = scope_to_check->parent_scope)
+                        {
+                            if (scope_to_check->registered_table_expression_nodes.contains(resolved_identifier_node))
+                            {
+                                resolved_identifier_node = resolved_identifier_node->clone();
+                                break;
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src/Analyzer/SortNode.cpp
+++ b/src/Analyzer/SortNode.cpp
@@ -123,9 +123,9 @@ void SortNode::updateTreeHashImpl(HashState & hash_state, CompareOptions) const
 QueryTreeNodePtr SortNode::cloneImpl() const
 {
     auto result = std::make_shared<SortNode>(nullptr /*expression*/, sort_direction, nulls_sort_direction, collator, with_fill);
-    /// column_name is derived from the original AST identifier, not from a child node, so the base
-    /// clone machinery does not reproduce it. The planner reads it (PlannerSorting) and it appears
-    /// in EXPLAIN, so a clone must carry it explicitly.
+    /// `column_name` is derived from the original AST identifier, not from a child node, so the base
+    /// clone machinery does not reproduce it. The planner reads it (`PlannerSorting`) and it appears
+    /// in `EXPLAIN`, so a clone must carry it explicitly.
     result->column_name = column_name;
     return result;
 }

--- a/src/Analyzer/SortNode.cpp
+++ b/src/Analyzer/SortNode.cpp
@@ -122,7 +122,12 @@ void SortNode::updateTreeHashImpl(HashState & hash_state, CompareOptions) const
 
 QueryTreeNodePtr SortNode::cloneImpl() const
 {
-    return std::make_shared<SortNode>(nullptr /*expression*/, sort_direction, nulls_sort_direction, collator, with_fill);
+    auto result = std::make_shared<SortNode>(nullptr /*expression*/, sort_direction, nulls_sort_direction, collator, with_fill);
+    /// column_name is derived from the original AST identifier, not from a child node, so the base
+    /// clone machinery does not reproduce it. The planner reads it (PlannerSorting) and it appears
+    /// in EXPLAIN, so a clone must carry it explicitly.
+    result->column_name = column_name;
+    return result;
 }
 
 ASTPtr SortNode::toASTImpl(const ConvertToASTOptions & options) const

--- a/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.reference
+++ b/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.reference
@@ -18,7 +18,12 @@ table function source
 0
 1
 2
-GLOBAL IN, bare table name
+GLOBAL IN, subquery alias
+0
+GLOBAL IN, bare one-part table name
+2
+3
+GLOBAL IN, two-part db.table name
 0
 rewrite_in_to_join
 0
@@ -66,3 +71,13 @@ QUALIFY source, GLOBAL IN the same source
 3
 4
 QUALIFY source, globalNotIn in QUALIFY
+clone fidelity of SortNode::column_name, uncloned spelling
+clone fidelity of SortNode::column_name, CTE clone
+clone fidelity of SortNode::column_name, IN-argument clone
+control: INTERPOLATE a column other than the fill key
+1	10
+2	20
+3	30
+4	40
+clone fidelity of SortNode::column_name, visible in EXPLAIN
+1

--- a/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.reference
+++ b/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.reference
@@ -1,0 +1,68 @@
+ground truth (unshared subquery on the right of IN)
+2
+3
+WHERE
+2
+3
+QUALIFY
+2
+3
+ORDER BY
+2
+3
+inside a lambda
+2
+3
+NOT IN (empty result)
+table function source
+0
+1
+2
+GLOBAL IN, bare table name
+0
+rewrite_in_to_join
+0
+control: CTE (the pre-existing clone path)
+2
+3
+control: IN names the LEFT subquery
+2
+3
+control: bare table alias on the right of IN
+2
+3
+control: union subquery alias
+2
+2
+3
+3
+control: single table expression, no join
+2
+3
+9
+control: GLOBAL IN over an unshared subquery
+0
+control: tuple IN
+2
+3
+control: old analyzer rejects the shape
+control: Set engine on the right of IN
+2
+3
+2
+3
+QUALIFY source, IN the same source
+0
+1
+2
+3
+4
+QUALIFY source, NOT IN the same source
+0
+QUALIFY source, GLOBAL IN the same source
+0
+1
+2
+3
+4
+QUALIFY source, globalNotIn in QUALIFY

--- a/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.sql
+++ b/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.sql
@@ -7,11 +7,15 @@
 -- instance in place (createUniqueAliasesIfNecessary, GLOBAL IN external tables, rewrite_in_to_join),
 -- and with a shared node those edits land in the join tree.
 -- The measured pre-fix failures for the shapes below are noted per group.
+-- (The exists consumer of the same resolution site cannot carry this: its argument is always a
+-- parsed subquery, never an identifier.)
 
-DROP TABLE IF EXISTS t_04650_l;
-DROP TABLE IF EXISTS t_04650_r;
-DROP TABLE IF EXISTS t_04650_set;
-DROP TABLE IF EXISTS t_04650_mt;
+-- The cleanup statements pin ignore_drop_queries_probability: the stress runner injects 0.2 for
+-- every statement, which would silently skip these drops and leak tables into a shared database.
+DROP TABLE IF EXISTS t_04650_l SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_04650_r SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_04650_set SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_04650_mt SETTINGS ignore_drop_queries_probability = 0;
 
 CREATE TABLE t_04650_l (x Int32) ENGINE = Memory;
 CREATE TABLE t_04650_r (x Int32) ENGINE = Memory;
@@ -169,7 +173,7 @@ SELECT count() > 0 FROM (EXPLAIN QUERY TREE run_passes = 1
   WITH c AS (SELECT x AS a FROM t_04650_l ORDER BY a WITH FILL FROM 1 TO 9 STEP 1) SELECT * FROM c
 ) WHERE explain ILIKE '%EXPRESSION a%';
 
-DROP TABLE t_04650_mt;
-DROP TABLE t_04650_set;
-DROP TABLE t_04650_r;
-DROP TABLE t_04650_l;
+DROP TABLE t_04650_mt SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE t_04650_set SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE t_04650_r SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE t_04650_l SETTINGS ignore_drop_queries_probability = 0;

--- a/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.sql
+++ b/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.sql
@@ -10,12 +10,10 @@
 -- (The exists consumer of the same resolution site cannot carry this: its argument is always a
 -- parsed subquery, never an identifier.)
 
--- The cleanup statements pin ignore_drop_queries_probability: the stress runner injects 0.2 for
--- every statement, which would silently skip these drops and leak tables into a shared database.
-DROP TABLE IF EXISTS t_04650_l SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_04650_r SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_04650_set SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_04650_mt SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_04650_l;
+DROP TABLE IF EXISTS t_04650_r;
+DROP TABLE IF EXISTS t_04650_set;
+DROP TABLE IF EXISTS t_04650_mt;
 
 CREATE TABLE t_04650_l (x Int32) ENGINE = Memory;
 CREATE TABLE t_04650_r (x Int32) ENGINE = Memory;
@@ -173,7 +171,7 @@ SELECT count() > 0 FROM (EXPLAIN QUERY TREE run_passes = 1
   WITH c AS (SELECT x AS a FROM t_04650_l ORDER BY a WITH FILL FROM 1 TO 9 STEP 1) SELECT * FROM c
 ) WHERE explain ILIKE '%EXPRESSION a%';
 
-DROP TABLE t_04650_mt SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE t_04650_set SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE t_04650_r SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE t_04650_l SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE t_04650_mt;
+DROP TABLE t_04650_set;
+DROP TABLE t_04650_r;
+DROP TABLE t_04650_l;

--- a/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.sql
+++ b/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.sql
@@ -4,10 +4,10 @@
 
 -- A table expression that is also a join-tree table expression of the enclosing query must not be
 -- shared with the right argument of an IN-family function: later stages rewrite each argument
--- instance in place (createUniqueAliasesIfNecessary, GLOBAL IN external tables, rewrite_in_to_join),
--- and with a shared node those edits land in the join tree.
+-- instance in place (`createUniqueAliasesIfNecessary`, `GLOBAL IN` external tables,
+-- `rewrite_in_to_join`), and with a shared node those edits land in the join tree.
 -- The measured pre-fix failures for the shapes below are noted per group.
--- (The exists consumer of the same resolution site cannot carry this: its argument is always a
+-- (The `exists` consumer of the same resolution site cannot carry this: its argument is always a
 -- parsed subquery, never an identifier.)
 
 DROP TABLE IF EXISTS t_04650_l;

--- a/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.sql
+++ b/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.sql
@@ -1,4 +1,6 @@
--- Tags: shard, no-parallel-replicas
+-- Tags: no-old-analyzer, shard, no-parallel-replicas
+-- The fix lives in the analyzer; the old analyzer never resolves an IN argument as a table
+-- expression at all, so it rejects these shapes outright and the bug cannot manifest there.
 
 -- A table expression that is also a join-tree table expression of the enclosing query must not be
 -- shared with the right argument of an IN-family function: later stages rewrite each argument
@@ -55,10 +57,24 @@ WHERE t1.number IN t2 ORDER BY t1.number;
 -- GLOBAL IN rewrites the argument into an external table. Before the fix, sharing the node with the
 -- join tree made the rewrite collide on the generated FROM alias:
 --   Code: 179 Duplicate aliases __table2 for table expressions in FROM section are not allowed
-SELECT 'GLOBAL IN, bare table name';
+-- An identifier naming a join-tree table expression resolves through two distinct paths -- the alias
+-- map (tryResolveIdentifierFromAliases) and the table-expression lookup
+-- (tryResolveIdentifierFromTableExpression) -- so all three spellings are exercised. Each of the
+-- three aborted with Code 179 before the fix.
+SELECT 'GLOBAL IN, subquery alias';
 SELECT t1.dummy FROM remote('127.0.0.1', system.one) AS t1
 INNER JOIN system.one AS t2 ON t1.dummy = t2.dummy
 WHERE t1.dummy GLOBAL IN t2;
+
+SELECT 'GLOBAL IN, bare one-part table name';
+SELECT t1.x FROM remote('127.0.0.1', currentDatabase(), t_04650_r) AS t1
+INNER JOIN t_04650_l ON t1.x = t_04650_l.x
+WHERE t1.x GLOBAL IN t_04650_l ORDER BY t1.x;
+
+SELECT 'GLOBAL IN, two-part db.table name';
+SELECT t1.dummy FROM remote('127.0.0.1', system.one) AS t1
+INNER JOIN system.one AS t2 ON t1.dummy = t2.dummy
+WHERE t1.dummy GLOBAL IN system.one;
 
 -- The rewrite_in_to_join rewrite resolves the argument on its own path. Before the fix that path
 -- produced Code: 10 Columns [__table2.dummy] are not found in blocks [__table1.dummy], [].
@@ -127,6 +143,31 @@ SELECT y FROM (SELECT y FROM t_04650_mt QUALIFY 1) AS src WHERE y GLOBAL IN src 
 SELECT 'QUALIFY source, globalNotIn in QUALIFY';
 SELECT count() FROM (SELECT y FROM t_04650_mt QUALIFY 1) AS t_04650_mt
 QUALIFY globalNotIn((SELECT 1), t_04650_mt);
+
+-- SortNode::cloneImpl must carry column_name: it is derived from the original AST identifier rather
+-- than from a child node, so the base clone machinery drops it. The planner puts it into
+-- SortColumnDescription::alias, which is the name FillingTransform matches against the INTERPOLATE
+-- outputs -- so without it a clone silently loses the ORDER BY / INTERPOLATE conflict check. The
+-- uncloned spellings of the query below already raise the error, so the clone must too.
+SELECT 'clone fidelity of SortNode::column_name, uncloned spelling';
+SELECT x AS a FROM t_04650_l ORDER BY a WITH FILL FROM 1 TO 5 STEP 1 INTERPOLATE (a AS a); -- { serverError INVALID_WITH_FILL_EXPRESSION }
+SELECT 'clone fidelity of SortNode::column_name, CTE clone';
+WITH c AS (SELECT x AS a FROM t_04650_l ORDER BY a WITH FILL FROM 1 TO 5 STEP 1 INTERPOLATE (a AS a))
+SELECT * FROM c; -- { serverError INVALID_WITH_FILL_EXPRESSION }
+SELECT 'clone fidelity of SortNode::column_name, IN-argument clone';
+SELECT l.x FROM t_04650_l AS l
+INNER JOIN (SELECT x AS a FROM t_04650_l ORDER BY a WITH FILL FROM 1 TO 5 STEP 1 INTERPOLATE (a AS a)) AS r
+  ON l.x = r.a
+WHERE l.x IN r ORDER BY l.x; -- { serverError INVALID_WITH_FILL_EXPRESSION }
+SELECT 'control: INTERPOLATE a column other than the fill key';
+WITH c AS (SELECT x AS a, x * 10 AS y FROM t_04650_l ORDER BY a WITH FILL FROM 1 TO 5 STEP 1 INTERPOLATE (y AS y))
+SELECT * FROM c ORDER BY a;
+-- column_name also reaches EXPLAIN through SortNode::dumpTreeImpl, so the clone is pinned a second,
+-- error-independent way: without the clone fix the CTE copy prints a bare EXPRESSION.
+SELECT 'clone fidelity of SortNode::column_name, visible in EXPLAIN';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE run_passes = 1
+  WITH c AS (SELECT x AS a FROM t_04650_l ORDER BY a WITH FILL FROM 1 TO 9 STEP 1) SELECT * FROM c
+) WHERE explain ILIKE '%EXPRESSION a%';
 
 DROP TABLE t_04650_mt;
 DROP TABLE t_04650_set;

--- a/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.sql
+++ b/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.sql
@@ -52,7 +52,7 @@ SELECT 'NOT IN (empty result)';
 SELECT l.x FROM t_04650_l AS l INNER JOIN (SELECT x FROM t_04650_r) AS r ON l.x = r.x
 WHERE l.x NOT IN r ORDER BY l.x;
 
--- A table function source: same abort before the fix, reported as __table1.number.
+-- A table function source: same abort before the fix, reported as `__table1.number`.
 SELECT 'table function source';
 SELECT t1.number FROM numbers(3) AS t1 INNER JOIN numbers(3) AS t2 ON t1.number = t2.number
 WHERE t1.number IN t2 ORDER BY t1.number;
@@ -123,7 +123,7 @@ SELECT 'control: old analyzer rejects the shape';
 SELECT l.x FROM t_04650_l AS l INNER JOIN (SELECT x FROM t_04650_r) AS r ON l.x = r.x
 WHERE l.x IN r ORDER BY l.x SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_TABLE }
 
--- A Set-engine table on the right of IN is looked up by tree hash in CollectSets and is never the
+-- A `Set`-engine table on the right of IN is looked up by tree hash in `CollectSets` and is never the
 -- shared join-tree node, so the clone cannot reach it.
 CREATE TABLE t_04650_set (x Int32) ENGINE = Set;
 INSERT INTO t_04650_set VALUES (2), (3);

--- a/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.sql
+++ b/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.sql
@@ -1,0 +1,134 @@
+-- Tags: shard, no-parallel-replicas
+
+-- A table expression that is also a join-tree table expression of the enclosing query must not be
+-- shared with the right argument of an IN-family function: later stages rewrite each argument
+-- instance in place (createUniqueAliasesIfNecessary, GLOBAL IN external tables, rewrite_in_to_join),
+-- and with a shared node those edits land in the join tree.
+-- The measured pre-fix failures for the shapes below are noted per group.
+
+DROP TABLE IF EXISTS t_04650_l;
+DROP TABLE IF EXISTS t_04650_r;
+DROP TABLE IF EXISTS t_04650_set;
+DROP TABLE IF EXISTS t_04650_mt;
+
+CREATE TABLE t_04650_l (x Int32) ENGINE = Memory;
+CREATE TABLE t_04650_r (x Int32) ENGINE = Memory;
+INSERT INTO t_04650_l VALUES (1), (2), (3), (4);
+INSERT INTO t_04650_r VALUES (2), (3), (9);
+
+-- The join restricts the result to {2, 3}; the ground truth for every IN shape below is therefore
+-- 2, 3 and for the NOT IN shape the empty set (checked against the spelled-out subquery form).
+
+SELECT 'ground truth (unshared subquery on the right of IN)';
+SELECT l.x FROM t_04650_l AS l INNER JOIN (SELECT x FROM t_04650_r) AS r ON l.x = r.x
+WHERE l.x IN (SELECT x FROM t_04650_r) ORDER BY l.x;
+
+-- Aborted before the fix with
+--   Logical error: 'Column identifier __table1.x is already registered'
+-- in every one of the clause positions below (all measured; WHERE / HAVING / ORDER BY / QUALIFY /
+-- ON / comma join / inside a lambda were verified, a representative subset is kept here).
+SELECT 'WHERE';
+SELECT l.x FROM t_04650_l AS l INNER JOIN (SELECT x FROM t_04650_r) AS r ON l.x = r.x
+WHERE l.x IN r ORDER BY l.x;
+
+SELECT 'QUALIFY';
+SELECT l.x FROM t_04650_l AS l INNER JOIN (SELECT x FROM t_04650_r) AS r ON l.x = r.x
+QUALIFY l.x IN r ORDER BY l.x;
+
+SELECT 'ORDER BY';
+SELECT l.x FROM t_04650_l AS l INNER JOIN (SELECT x FROM t_04650_r) AS r ON l.x = r.x
+ORDER BY l.x IN r, l.x;
+
+SELECT 'inside a lambda';
+SELECT l.x FROM t_04650_l AS l INNER JOIN (SELECT x FROM t_04650_r) AS r ON l.x = r.x
+WHERE arrayExists(z -> z IN r, [l.x]) ORDER BY l.x;
+
+SELECT 'NOT IN (empty result)';
+SELECT l.x FROM t_04650_l AS l INNER JOIN (SELECT x FROM t_04650_r) AS r ON l.x = r.x
+WHERE l.x NOT IN r ORDER BY l.x;
+
+-- A table function source: same abort before the fix, reported as __table1.number.
+SELECT 'table function source';
+SELECT t1.number FROM numbers(3) AS t1 INNER JOIN numbers(3) AS t2 ON t1.number = t2.number
+WHERE t1.number IN t2 ORDER BY t1.number;
+
+-- GLOBAL IN rewrites the argument into an external table. Before the fix, sharing the node with the
+-- join tree made the rewrite collide on the generated FROM alias:
+--   Code: 179 Duplicate aliases __table2 for table expressions in FROM section are not allowed
+SELECT 'GLOBAL IN, bare table name';
+SELECT t1.dummy FROM remote('127.0.0.1', system.one) AS t1
+INNER JOIN system.one AS t2 ON t1.dummy = t2.dummy
+WHERE t1.dummy GLOBAL IN t2;
+
+-- The rewrite_in_to_join rewrite resolves the argument on its own path. Before the fix that path
+-- produced Code: 10 Columns [__table2.dummy] are not found in blocks [__table1.dummy], [].
+SELECT 'rewrite_in_to_join';
+SELECT t1.dummy FROM system.one AS t1
+INNER JOIN (SELECT * FROM system.one) AS t2 ON t1.dummy = t2.dummy
+WHERE t1.dummy IN t2
+SETTINGS rewrite_in_to_join = 1, allow_experimental_correlated_subqueries = 1;
+
+-- Shapes below are CONTROLS: each already produced its expected value before the fix, so they pin
+-- that the fix did not widen behaviour.
+SELECT 'control: CTE (the pre-existing clone path)';
+WITH c AS (SELECT x FROM t_04650_r)
+SELECT l.x FROM t_04650_l AS l INNER JOIN c ON l.x = c.x WHERE l.x IN c ORDER BY l.x;
+
+SELECT 'control: IN names the LEFT subquery';
+SELECT l.x FROM (SELECT x FROM t_04650_l) AS l INNER JOIN (SELECT x FROM t_04650_r) AS r ON l.x = r.x
+WHERE l.x IN l ORDER BY l.x;
+
+SELECT 'control: bare table alias on the right of IN';
+SELECT l.x FROM t_04650_l AS l INNER JOIN t_04650_r AS r ON l.x = r.x WHERE l.x IN r ORDER BY l.x;
+
+SELECT 'control: union subquery alias';
+SELECT l.x FROM t_04650_l AS l
+INNER JOIN (SELECT x FROM t_04650_r UNION ALL SELECT x FROM t_04650_r) AS r ON l.x = r.x
+WHERE l.x IN r ORDER BY l.x;
+
+SELECT 'control: single table expression, no join';
+SELECT x FROM (SELECT x FROM t_04650_r) AS r WHERE x IN r ORDER BY x;
+
+SELECT 'control: GLOBAL IN over an unshared subquery';
+SELECT t1.dummy FROM remote('127.0.0.1', system.one) AS t1
+INNER JOIN system.one AS t2 ON t1.dummy = t2.dummy
+WHERE t1.dummy GLOBAL IN (SELECT dummy FROM system.one);
+
+SELECT 'control: tuple IN';
+SELECT l.x FROM t_04650_l AS l INNER JOIN (SELECT x FROM t_04650_r) AS r ON l.x = r.x
+WHERE (l.x, l.x) IN (SELECT x, x FROM t_04650_r) ORDER BY l.x;
+
+-- The old analyzer never resolves an IN argument as a table expression at all, so it rejects the
+-- shape outright. Measured identical before and after the fix.
+SELECT 'control: old analyzer rejects the shape';
+SELECT l.x FROM t_04650_l AS l INNER JOIN (SELECT x FROM t_04650_r) AS r ON l.x = r.x
+WHERE l.x IN r ORDER BY l.x SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_TABLE }
+
+-- A Set-engine table on the right of IN is looked up by tree hash in CollectSets and is never the
+-- shared join-tree node, so the clone cannot reach it.
+CREATE TABLE t_04650_set (x Int32) ENGINE = Set;
+INSERT INTO t_04650_set VALUES (2), (3);
+SELECT 'control: Set engine on the right of IN';
+SELECT x FROM t_04650_l WHERE x IN t_04650_set ORDER BY x;
+SELECT l.x FROM t_04650_l AS l INNER JOIN t_04650_l AS l2 ON l.x = l2.x
+WHERE l.x IN t_04650_set ORDER BY l.x;
+
+-- The shapes below come from the same sharing reached through QUALIFY on a MergeTree source; before
+-- the fix they aborted with Logical error: 'No set is registered for key ...'.
+CREATE TABLE t_04650_mt (y Int32) ENGINE = MergeTree ORDER BY y;
+INSERT INTO t_04650_mt SELECT number FROM numbers(5);
+
+SELECT 'QUALIFY source, IN the same source';
+SELECT y FROM (SELECT y FROM t_04650_mt QUALIFY 1) AS t_04650_mt WHERE y IN t_04650_mt ORDER BY y;
+SELECT 'QUALIFY source, NOT IN the same source';
+SELECT count() FROM (SELECT y FROM t_04650_mt QUALIFY 1) AS t_04650_mt WHERE y NOT IN t_04650_mt;
+SELECT 'QUALIFY source, GLOBAL IN the same source';
+SELECT y FROM (SELECT y FROM t_04650_mt QUALIFY 1) AS src WHERE y GLOBAL IN src ORDER BY y;
+SELECT 'QUALIFY source, globalNotIn in QUALIFY';
+SELECT count() FROM (SELECT y FROM t_04650_mt QUALIFY 1) AS t_04650_mt
+QUALIFY globalNotIn((SELECT 1), t_04650_mt);
+
+DROP TABLE t_04650_mt;
+DROP TABLE t_04650_set;
+DROP TABLE t_04650_r;
+DROP TABLE t_04650_l;

--- a/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.sql
+++ b/tests/queries/0_stateless/04650_in_argument_shared_with_join_tree.sql
@@ -28,9 +28,10 @@ SELECT l.x FROM t_04650_l AS l INNER JOIN (SELECT x FROM t_04650_r) AS r ON l.x 
 WHERE l.x IN (SELECT x FROM t_04650_r) ORDER BY l.x;
 
 -- Aborted before the fix with
---   Logical error: 'Column identifier __table1.x is already registered'
--- in every one of the clause positions below (all measured; WHERE / HAVING / ORDER BY / QUALIFY /
--- ON / comma join / inside a lambda were verified, a representative subset is kept here).
+--   `Logical error: 'Column identifier __table1.x is already registered'`
+-- in every one of the clause positions below (all measured; `WHERE` / `HAVING` / `ORDER BY` /
+-- `QUALIFY` / `ON` / comma join / inside a lambda were verified, a representative subset is kept
+-- here).
 SELECT 'WHERE';
 SELECT l.x FROM t_04650_l AS l INNER JOIN (SELECT x FROM t_04650_r) AS r ON l.x = r.x
 WHERE l.x IN r ORDER BY l.x;
@@ -56,13 +57,13 @@ SELECT 'table function source';
 SELECT t1.number FROM numbers(3) AS t1 INNER JOIN numbers(3) AS t2 ON t1.number = t2.number
 WHERE t1.number IN t2 ORDER BY t1.number;
 
--- GLOBAL IN rewrites the argument into an external table. Before the fix, sharing the node with the
--- join tree made the rewrite collide on the generated FROM alias:
---   Code: 179 Duplicate aliases __table2 for table expressions in FROM section are not allowed
--- An identifier naming a join-tree table expression resolves through two distinct paths -- the alias
--- map (tryResolveIdentifierFromAliases) and the table-expression lookup
--- (tryResolveIdentifierFromTableExpression) -- so all three spellings are exercised. Each of the
--- three aborted with Code 179 before the fix.
+-- `GLOBAL IN` rewrites the argument into an external table. Before the fix, sharing the node with
+-- the join tree made the rewrite collide on the generated `FROM` alias:
+--   `Code: 179 Duplicate aliases __table2 for table expressions in FROM section are not allowed`
+-- An identifier naming a join-tree table expression resolves through two distinct paths, the alias
+-- map (`tryResolveIdentifierFromAliases`) and the table-expression lookup
+-- (`tryResolveIdentifierFromTableExpression`), so all three spellings are exercised. Each of the
+-- three aborted with `Code: 179` before the fix.
 SELECT 'GLOBAL IN, subquery alias';
 SELECT t1.dummy FROM remote('127.0.0.1', system.one) AS t1
 INNER JOIN system.one AS t2 ON t1.dummy = t2.dummy
@@ -78,8 +79,8 @@ SELECT t1.dummy FROM remote('127.0.0.1', system.one) AS t1
 INNER JOIN system.one AS t2 ON t1.dummy = t2.dummy
 WHERE t1.dummy GLOBAL IN system.one;
 
--- The rewrite_in_to_join rewrite resolves the argument on its own path. Before the fix that path
--- produced Code: 10 Columns [__table2.dummy] are not found in blocks [__table1.dummy], [].
+-- The `rewrite_in_to_join` rewrite resolves the argument on its own path. Before the fix that path
+-- produced `Code: 10 Columns [__table2.dummy] are not found in blocks [__table1.dummy], []`.
 SELECT 'rewrite_in_to_join';
 SELECT t1.dummy FROM system.one AS t1
 INNER JOIN (SELECT * FROM system.one) AS t2 ON t1.dummy = t2.dummy
@@ -131,8 +132,8 @@ SELECT x FROM t_04650_l WHERE x IN t_04650_set ORDER BY x;
 SELECT l.x FROM t_04650_l AS l INNER JOIN t_04650_l AS l2 ON l.x = l2.x
 WHERE l.x IN t_04650_set ORDER BY l.x;
 
--- The shapes below come from the same sharing reached through QUALIFY on a MergeTree source; before
--- the fix they aborted with Logical error: 'No set is registered for key ...'.
+-- The shapes below come from the same sharing reached through `QUALIFY` on a `MergeTree` source;
+-- before the fix they aborted with `Logical error: 'No set is registered for key ...'`.
 CREATE TABLE t_04650_mt (y Int32) ENGINE = MergeTree ORDER BY y;
 INSERT INTO t_04650_mt SELECT number FROM numbers(5);
 
@@ -146,11 +147,12 @@ SELECT 'QUALIFY source, globalNotIn in QUALIFY';
 SELECT count() FROM (SELECT y FROM t_04650_mt QUALIFY 1) AS t_04650_mt
 QUALIFY globalNotIn((SELECT 1), t_04650_mt);
 
--- SortNode::cloneImpl must carry column_name: it is derived from the original AST identifier rather
--- than from a child node, so the base clone machinery drops it. The planner puts it into
--- SortColumnDescription::alias, which is the name FillingTransform matches against the INTERPOLATE
--- outputs -- so without it a clone silently loses the ORDER BY / INTERPOLATE conflict check. The
--- uncloned spellings of the query below already raise the error, so the clone must too.
+-- `SortNode::cloneImpl` must carry `column_name`: it is derived from the original AST identifier
+-- rather than from a child node, so the base clone machinery drops it. The planner puts it into
+-- `SortColumnDescription::alias`, which is the name `FillingTransform` matches against the
+-- `INTERPOLATE` outputs, so without it a clone silently loses the `ORDER BY` / `INTERPOLATE`
+-- conflict check. The uncloned spellings of the query below already raise the error, so the clone
+-- must too.
 SELECT 'clone fidelity of SortNode::column_name, uncloned spelling';
 SELECT x AS a FROM t_04650_l ORDER BY a WITH FILL FROM 1 TO 5 STEP 1 INTERPOLATE (a AS a); -- { serverError INVALID_WITH_FILL_EXPRESSION }
 SELECT 'clone fidelity of SortNode::column_name, CTE clone';
@@ -164,8 +166,8 @@ WHERE l.x IN r ORDER BY l.x; -- { serverError INVALID_WITH_FILL_EXPRESSION }
 SELECT 'control: INTERPOLATE a column other than the fill key';
 WITH c AS (SELECT x AS a, x * 10 AS y FROM t_04650_l ORDER BY a WITH FILL FROM 1 TO 5 STEP 1 INTERPOLATE (y AS y))
 SELECT * FROM c ORDER BY a;
--- column_name also reaches EXPLAIN through SortNode::dumpTreeImpl, so the clone is pinned a second,
--- error-independent way: without the clone fix the CTE copy prints a bare EXPRESSION.
+-- `column_name` also reaches `EXPLAIN` through `SortNode::dumpTreeImpl`, so the clone is pinned a
+-- second, error-independent way: without the clone fix the CTE copy prints a bare `EXPRESSION`.
 SELECT 'clone fidelity of SortNode::column_name, visible in EXPLAIN';
 SELECT count() > 0 FROM (EXPLAIN QUERY TREE run_passes = 1
   WITH c AS (SELECT x AS a FROM t_04650_l ORDER BY a WITH FILL FROM 1 TO 9 STEP 1) SELECT * FROM c


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/99931
Related: https://github.com/ClickHouse/ClickHouse/pull/107603


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a `LOGICAL_ERROR` (`Column identifier ... is already registered`), a
`MULTIPLE_EXPRESSIONS_FOR_ALIAS` error and a `NOT_FOUND_COLUMN_IN_BLOCK` error for a query whose
`IN` / `NOT IN` / `GLOBAL IN` right operand names a table expression that also appears in the
`FROM` section, for example `SELECT l.x FROM l JOIN (SELECT x FROM r) AS r ON l.x = r.x WHERE l.x IN r`.
Also makes `ORDER BY <alias> WITH FILL ... INTERPOLATE (<alias> ...)` inside a CTE or any other
copied subquery raise `INVALID_WITH_FILL_EXPRESSION`, as the same query already does when it is not
copied: the check was silently skipped for the copy, and such a query returned rows instead of the
error.


### Description

#### Root cause

When the right operand of an `IN`-family function is an identifier, `resolveFunction` allows it to be
resolved as a table expression (`allow_table_expressions` at
`src/Analyzer/Resolve/resolveFunction.cpp:1199`). The resolution at
`src/Analyzer/Resolve/QueryAnalyzer.cpp:3137-3139` returns the join tree's **own node pointer** - the
alias path deliberately does not clone for a table-expression lookup
(`tryResolveIdentifierFromAliases`, `:1173-1177`), and the name / `db.table` paths return the
registered node directly. The block clones only for CTEs (`:3153`) and materialized CTEs (`:3183`), so
a plain subquery-with-alias, bare table alias or table function ends up as **one shared node in two
places in the query tree** (visible as the same `QUERY id` twice in `EXPLAIN QUERY TREE
run_passes = 1`).

The same invariant is already written down in the tree, for a neighbouring mechanism:
`IdentifierResolveScope.h:260-265` explains why the identifier-resolve cache must hand out a copy of
any subquery-bearing tree, and names the three downstream stages that rewrite each instance
independently. That cache never sees a table expression - `canCacheIdentifier` rejects such a lookup
outright (`IdentifierResolveScope.cpp:190-195`, with the same reasoning spelled out in the comment
there) - but the same three stages break for the sharing this PR fixes:

| stage | symptom before this PR |
|---|---|
| `createUniqueAliasesIfNecessary` | `Logical error: 'Column identifier __table1.<col> is already registered'` (`PlannerContext.cpp:42` <- `CollectTableExpressionData.cpp:164`) - aborts the server on debug/sanitizer builds |
| `GLOBAL IN` external-table rewriting | `Code: 179 Duplicate aliases __table2 for table expressions in FROM section are not allowed` |
| `rewrite_in_to_join` | `Code: 10 Columns [__table2.dummy] are not found in blocks [__table1.dummy], []` |

The second and third are reachable on release builds too, for queries that are legal SQL and that
ClickHouse answers correctly when the same subquery is spelled out instead of referenced by alias.

#### Fix

Clone the resolved node when it is a table expression (`isTableExpressionNodeType`) that is a member
of `registered_table_expression_nodes` in the current or any enclosing scope. This is the single
retrieval site **both** consuming paths reach, so one hunk fixes all three symptoms: the
`rewrite_in_to_join` path resolves the operand itself and then clears `is_special_function_in`
(`resolveFunction.cpp:915`/`:923`) before the regular `IN` block runs, so a clone placed inside that
block cannot help it. The detector is spelling-independent, so the alias, bare-name and `db.table`
spellings and the `TABLE` / `TABLE_FUNCTION` / `QUERY` / `UNION` node types are all covered.

The change is a strict extension of the two pre-existing cloning rules earlier in the same `if`
chain (plain CTE at `:3153`, materialized CTE at `:3183`) - rewriting any of the failing shapes to
use a CTE already makes every symptom disappear on master, because that path forces the clone.

The branch fires for every `IN`-family argument that names a join-tree table expression, which is a
superset of the failing shapes: a bare table alias on the right of `IN` (`... JOIN r AS r ... WHERE
x IN r`) and an `IN` naming the LEFT table expression already work on master, because
`createUniqueAliasesIfNecessary` skips a plain `TABLE` argument (`:120`) and the left side does not
collide. Those now get a copy too. Both are kept as explicit controls in the test and are
byte-identical before and after. The cost is one `clone()` of an already-resolved table expression
per such argument at analysis time - the same cost the CTE spelling of the identical query already
pays on master.

#### Relationship to #107603

#107603 (also mine, still open) clones the same shared node inside the regular `IN` block of
`resolveFunction.cpp`, which covers the first symptom but not the `rewrite_in_to_join` path. **This PR
supersedes that hunk**: its committed test
(`04338_in_set_source_aliases_from_table.sql`, 4 assertions, `Logical error: 'No set is registered for
key ...'` before the fix) passes byte-identically against master + this change **without** its
`resolveFunction.cpp` hunk, and all four of its shapes are carried into the test added here so nothing
is lost if it is closed.

Its second hunk, `SortNode::cloneImpl` carrying `column_name`, is carried here as well, since master
still lacks it and this is now the branch that supersedes #107603. `column_name` is derived from the
original AST identifier rather than from a child node, so the base clone machinery does not reproduce
it, and dropping it **does** change a user-visible verdict.

`PlannerSorting.cpp:173`/`:176` puts `SortNode::column_name` into `SortColumnDescription::alias` (the
identifier name, `a`) while `SortColumnDescription::column_name` gets
`calculateActionNodeName(expression)`, which for a resolved column is the column identifier
(`__table1.a`). `InterpolateDescription::result_columns_set` is keyed on the identifier name
(`Planner.cpp:1070`, `InterpolateDescription.cpp:27-34`). So for
`ORDER BY a WITH FILL ... INTERPOLATE (a AS a)` inside a cloned subquery, the conflict check at
`FillingTransform.cpp:259-270` finds `a` through `alias` and correctly raises
`INVALID_WITH_FILL_EXPRESSION`; with `column_name` dropped by the clone, `alias` is empty, the check
is skipped and the query returns rows instead. The `column_name` half of that pair only substitutes
for a constant `ORDER BY` expression, where the two names coincide.

This is reachable on master today through the existing CTE clone paths
(`QueryAnalyzer.cpp:3153`, `:4170`), so the fix also changes that case, and the test added here pins
both spellings. `column_name` is likewise printed by `EXPLAIN QUERY TREE`
(`SortNode::dumpTreeImpl`).

Whether to close #107603 is of course for a maintainer to decide.

#### Verification

Both directions were measured against a pristine `origin/master` binary built in the same run
(`8780cd4022ebb73d...` vs `9cdc70208d665069...`), and each hunk was reverted individually to confirm it is
load-bearing. On the base binary the failure reproduces for `WHERE`, `HAVING`, `ORDER BY`, `QUALIFY`,
join `ON`, a comma join, inside a lambda, `NOT IN`, a `numbers()` table-function source, and with the
shared column typed `Nullable`, `LowCardinality`, `LowCardinality(Nullable)` or `Array`; all are
correct with the fix, and each is asserted against the row set the equivalent spelled-out subquery
returns rather than merely against "no crash". Ten control shapes (unshared `IN (SELECT ...)`, the CTE
path, a `Set`-engine right operand, a union-subquery alias, tuple `IN`, the old analyzer, ...) are
byte-identical before and after.

The new test passes 50/50 under randomized settings. The targeted suites from the plan (every
stateless test using `IN t<N>` / `GLOBAL IN t<N>`, every test naming
`allow_experimental_correlated_subqueries` or `GLOBAL IN`, plus the sibling fixes' regression tests
and the `PreparedSets` alias-stability test - 282 tests) were run on both binaries with identical
failing sets; every failure in that set also fails on the pristine base binary and is caused by the
local sandbox lacking a second listener on `127.0.0.2` for the `shard` / distributed /
parallel-replicas tests.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=112219&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/112219](https://github.com/search?q=head%3Async-upstream%2Fpr%2F112219+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.858` (included in `26.9` and later)
<!-- ch-version-info:end -->