### PR TITLE
Restore the dropped `factor` when reserving dynamic paths in `ColumnObject::prepareForSquashing`

### DIFF
--- a/src/Columns/ColumnObject.cpp
+++ b/src/Columns/ColumnObject.cpp
@@ -1813,7 +1813,7 @@ void ColumnObject::prepareForSquashing(const VectorWithMemoryTracking<ColumnPtr>
         /// For this reason we first call ColumnDynamic::reserve with resulting size to preallocate memory for
         /// discriminators and offsets and ColumnDynamic::prepareVariantsForSquashing to preallocate memory
         /// for all variants inside Dynamic.
-        dynamic_paths_ptrs[path]->reserve(total_size);
+        dynamic_paths_ptrs[path]->reserve(total_size * factor);
         dynamic_paths_ptrs[path]->prepareVariantsForSquashing(source_dynamic_columns, factor);
     }
 }

--- a/src/Columns/tests/gtest_column_object.cpp
+++ b/src/Columns/tests/gtest_column_object.cpp
@@ -492,3 +492,35 @@ TEST(ColumnObject, TryInsertRestoresSortedDynamicPaths)
     ASSERT_EQ(col_object.size(), 2u);
     ASSERT_EQ(col_object[1], col_object[0]);
 }
+
+TEST(ColumnObject, PrepareForSquashingScalesDynamicPathsByFactor)
+{
+    /// `factor` declares how many source-sized batches will be appended, so it must reach the
+    /// dynamic paths' discriminators/offsets too, not only their variants. Regression:
+    /// reserve(total_size) instead of reserve(total_size * factor) left them sized for one batch.
+    auto type = DataTypeFactory::instance().get("JSON(max_dynamic_types=10, max_dynamic_paths=10)");
+
+    auto source = type->createColumn();
+    auto & source_object = assert_cast<ColumnObject &>(*source);
+    for (size_t i = 0; i != 100; ++i)
+        source_object.insert(Object{{"a", Field{UInt64(i)}}});
+    /// Load-bearing precondition: if "a" landed in shared data the assertions below would be vacuous.
+    ASSERT_EQ(source_object.getDynamicPaths().size(), 1u);
+    ASSERT_TRUE(source_object.getDynamicPaths().contains("a"));
+
+    auto target = type->createColumn();
+    auto & target_object = assert_cast<ColumnObject &>(*target);
+
+    VectorWithMemoryTracking<ColumnPtr> sources;
+    sources.push_back(std::move(source));
+
+    static constexpr size_t factor = 8;
+    target_object.prepareForSquashing(sources, factor);
+
+    /// Control, asserted first so it is reached even while the regression below still fails:
+    /// shared_data already scales by `factor`, and must keep doing so.
+    ASSERT_GE(target_object.getSharedDataPtr()->capacity(), 100u * factor);
+
+    ASSERT_TRUE(target_object.getDynamicPathsPtrs().contains("a"));
+    ASSERT_GE(target_object.getDynamicPathsPtrs().at("a")->capacity(), 100u * factor);
+}


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/74945
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/74945

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Restore the memory pre-allocation for dynamic paths of a `JSON` column during asynchronous `INSERT` flush. `ColumnObject::prepareForSquashing` reserved space for a single batch instead of the whole batch group, so each dynamic path's internal discriminators and offsets arrays were reallocated repeatedly while the flush appended rows.

### Description

`ColumnObject::prepareForSquashing(source_columns, factor)` reserves space for `sum of source sizes * factor` rows; that is the contract on the base declaration in `src/Columns/IColumn.h`. The `ColumnObject` override honours `factor` for three of its four children and drops it for the fourth:

```cpp
shared_data->prepareForSquashing(shared_data_source_columns, factor);              // honoured
typed_paths[path]->prepareForSquashing(source_typed_columns, factor);              // honoured
dynamic_paths_ptrs[path]->reserve(total_size);                                     // factor dropped
dynamic_paths_ptrs[path]->prepareVariantsForSquashing(source_dynamic_columns, factor);  // honoured
```

So each dynamic path's `ColumnVariant` discriminators and offsets are sized for one source batch while the caller has declared it is about to append `factor` of them.

This is a regression from a single commit, not an omission from the start. `git log -L` on that line shows `a33ad1d4383a` ("prealloc_stream: prepareForSquashing without squashing, works") introducing `factor` and writing the line correctly as `reserve(total_size * factor)`, and `e4368f6de726` ("prealloc_stream: code cleanup", same author, same day, same PR #74945) stripping it. Reading the whole hunk, that commit's purpose was to move `factor` out of the `std::vector::reserve` calls that were sizing bookkeeping vectors, where `factor` is meaningless, and into the recursive `prepareForSquashing` calls, where it belongs. It removes eight such spurious multiplications (five in `ColumnObject.cpp`, three in `ColumnDynamic.cpp`) and took one load-bearing `* factor` with them. This PR restores exactly that one multiplication.

`ColumnObject.cpp` is the only `prepareForSquashing` implementation in `src/Columns/` that drops `factor`; `IColumn`, `ColumnArray`, `ColumnString`, `ColumnNullable`, `ColumnTuple`, `ColumnMap`, `ColumnQBit`, `ColumnVariant` and `ColumnDynamic` all scale by it, and the wrapper columns forward it, so a `JSON` column nested under `Array`/`Map`/`Tuple`/`Nullable`/`Dynamic` inherits the fix.

### Which path is affected

`prepareForSquashing` has five call sites outside `src/Columns/`. Four pass a literal `1`, so this change is a provable no-op for them (`total_size * 1`): `Squashing.cpp`, two calls in `SerializationMap.cpp`, and `SerializationMapKeysOrValues.cpp`. The fifth is `StreamingFormatExecutor::preallocateResultColumns`, which computes `factor = ceil(total_bytes / num_bytes)`.

Of the callers that construct a `StreamingFormatExecutor`, only asynchronous `INSERT` passes `total_bytes` and `total_chunks` (`AsynchronousInsertQueue.cpp`). Kafka, FileLog, NATS and RabbitMQ construct it with the defaults `total_bytes_ = 0, total_chunks_ = 0`, and `preallocateResultColumns` is gated on `total_bytes && num_bytes && total_chunks > 1`, so it returns immediately for all of them. So today the behaviour change is confined to the async-insert flush path.

There is no bug report or CI failure behind this: it is an evident regression found by reading the function, and the effect is a missing pre-allocation, not a wrong result. `IColumn::reserve` is documented as affecting performance only. `PODArray::reserve` is geometric (`reallocPowerOfTwoElements`), so the append loop after an under-reservation is amortised linear, not quadratic; what is lost is the batch-sized pre-allocation the code already declares and already performs for the column's three other children.

### Memory effect, measured in both directions

Since this *increases* a reservation, and `StreamingFormatExecutor` exists to over-reserve deliberately, here is the number. Async `INSERT` of a `JSON` column over HTTP, one request per async-insert entry, 500 entries of 4000 rows each (2,000,000 rows, 32 dynamic paths, `MergeTree`, debug build). `system.asynchronous_insert_log` confirms a single flush of all 500 entries and 856 MB, i.e. `factor` around 500, so the path really is exercised.

Peak accounted memory of the flush query, from `system.query_log`, 4 runs per build with the builds alternated:

| build | min `memory_usage` |
|---|---|
| before | 1,250,563,337 |
| after | 1,292,860,937 |

That is +40.3 MiB, or +3.4% of a 1.25 GB flush. The arithmetic worst case is 9 bytes per row per dynamic path (a `ColumnVariant::Discriminator`, which is `UInt8`, plus an `IColumn::Offset`, which is `UInt64`), here `32 * 2,000,000 * 9` = 549 MiB, so the measured increase is 7% of the bound: the flush appends those rows anyway, so the reservation mostly shifts *when* the memory is taken rather than raising the high-water mark. Server-level peak RSS could not resolve the difference at all (`VmHWM` ranges 201.9-211.8 MB before and 196.3-211.9 MB after, fully overlapping).

The increase is exactly what `IColumn.h` declares and what the sibling children already reserve on the same line range, so a flush that survives those survives this one.

Two properties of `StreamingFormatExecutor` are pre-existing and deliberately not changed here: `factor` is derived from the *first* entry's size, so a batch whose first entry is unusually small yields a large `factor` (bounded in practice by `async_insert_max_data_size`, default 10 MiB), and this is shared by the three children that already scale. Adding a clamp would be a separate, user-visible policy change.

### Testing

`src/Columns/tests/gtest_column_object.cpp` gains `ColumnObject.PrepareForSquashingScalesDynamicPathsByFactor`. The oracle is `IColumn::capacity()`, which for a dynamic path resolves to `ColumnVariant::capacity()`, i.e. the discriminators buffer this line sizes: exact, deterministic, no server and no timing. With 100 source rows and `factor = 8` it requires `capacity() >= 800`; before this change it is `100`. The test also asserts, as a labelled control, that `shared_data` reaches `>= 800`: that child already honoured `factor`, and the control is asserted first so it is evaluated even while the regression assertion still fails.

The test was confirmed to fail on unmodified master before the fix was written, and to fail again when `* factor` is mutated back to `* 1`. The `json`, `dynamic` and `object` stateless families (564 tests) were run against both binaries: the failure sets are identical, and the failures are sandbox-only (no MinIO, and no second listen host for `remote()` shards).

No changelog-visible behaviour changes, no settings, no serialization format. Note that the `Performance Improvement` category makes the performance comparison jobs run; they are not expected to move, since nothing here is on a `SELECT` path.