### PR TITLE
Infer leading-zero decimals as numbers in TSV schema inference

### DIFF
--- a/src/Formats/EscapingRuleUtils.cpp
+++ b/src/Formats/EscapingRuleUtils.cpp
@@ -338,15 +338,17 @@ DataTypePtr tryInferDataTypeByEscapingRule(const String & field, const FormatSet
             if (auto date_type = tryInferDateOrDateTimeFromString(field, format_settings))
                 return date_type;
 
-            /// Special case when we have number that starts with 0. In TSV we don't parse such numbers,
-            /// see readIntTextUnsafe in ReadHelpers.h. If we see data started with 0, we can determine it
-            /// as a String, so parsing won't fail.
-            /// When allow_number_leading_zeros is set (for hive partitioning), skip this check
-            /// because hive partitioning handles leading zeros
-            if (field[0] == '0' && field.size() != 1 && !format_settings.allow_number_leading_zeros)
+            auto type = tryInferDataTypeForSingleField(field, format_settings);
+
+            /// A number starting with 0 must stay a String when the value parser cannot read the inferred type
+            /// back: an integer, because readIntTextUnsafe (see ReadHelpers.h) reads the leading '0' as the
+            /// whole value; or an exponent form, because inference accepts values such as `0.5e+` that
+            /// readFloatTextPrecise rejects. allow_number_leading_zeros (hive partitioning) opts out.
+            if (type && field[0] == '0' && field.size() != 1 && !format_settings.allow_number_leading_zeros
+                && (isInteger(removeNullable(recursiveRemoveLowCardinality(type)))
+                    || field.find_first_of("eE") != String::npos))
                 return std::make_shared<DataTypeString>();
 
-            auto type = tryInferDataTypeForSingleField(field, format_settings);
             if (!type)
                 return std::make_shared<DataTypeString>();
             return type;

--- a/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
@@ -4,6 +4,8 @@
 #include <Formats/FormatFactory.h>
 #include <Formats/EscapingRuleUtils.h>
 #include <DataTypes/Serializations/SerializationNullable.h>
+#include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 
 
@@ -270,8 +272,19 @@ NamesAndTypesList TSKVSchemaReader::readRowAndGetNamesAndDataTypes(bool & eof)
         String name = String(name_ref);
         if (has_value)
         {
+            const size_t bytes_before = in.count();
             readEscapedString(value, in);
-            names_and_types.emplace_back(std::move(name), tryInferDataTypeByEscapingRule(value, format_settings, FormatSettings::EscapingRule::Escaped));
+            /// This reader decodes escape sequences while the value path parses the original bytes, so a
+            /// field whose escapes were decoded must not infer a number: the number readers would stop at
+            /// the backslash. A decoded escape always changes the byte count, and the one escape branch
+            /// that does not keeps the backslash in the value, which never infers a number.
+            const bool had_escape = (in.count() - bytes_before) != value.size();
+
+            auto type = tryInferDataTypeByEscapingRule(value, format_settings, FormatSettings::EscapingRule::Escaped);
+            if (had_escape && type && isNumber(removeNullable(recursiveRemoveLowCardinality(type))))
+                type = std::make_shared<DataTypeString>();
+
+            names_and_types.emplace_back(std::move(name), std::move(type));
         }
         else
         {

--- a/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.reference
+++ b/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.reference
@@ -144,3 +144,6 @@ x	Nullable(String)
 a.b
 x	Nullable(String)					
 0\\p
+group 15: a decoded escape outside the numeric guard keeps its type
+x	Nullable(Date)					
+c	Array(Nullable(Float64))					

--- a/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.reference
+++ b/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.reference
@@ -69,7 +69,17 @@ c1	Nullable(String)
 c1	Nullable(String)					
 c1	Nullable(String)					
 c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+group 10: the malformed exponent is readable only because it stays String
+0.5e+
+0e+
+0.5e-
+0.5e+	String
+0e+	String
 group 10: the CSV divergence that deliberately remains
+c1	Nullable(Float64)					
 c1	Nullable(Float64)					
 c1	Nullable(Float64)					
 group 11: try_infer_integers = 1 (the default)
@@ -111,3 +121,13 @@ group 14: Dynamic runtime path
 0	Float64
 007	String
 0	Float64
+group 15: TSKV plain values
+x	Nullable(Float64)					
+0.5
+x	Nullable(String)					
+007
+group 15: TSKV null representation and escapes
+x	Nullable(String)					
+y	Nullable(Int64)					
+1	1
+a\tb

--- a/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.reference
+++ b/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.reference
@@ -43,6 +43,25 @@ c1	Nullable(Float64)
 c1	Nullable(Float64)					
 c1	Nullable(Float64)					
 c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+group 5: and they read back as the inferred type
+-0.5
+0.5
+0.5
+-0.5
+0.5
+-0
+-0.5
+0.5
+group 5: CSV agrees on all of them
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
 group 6: date-shaped controls stay String
 c1	Nullable(String)					
 c1	Nullable(String)					

--- a/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.reference
+++ b/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.reference
@@ -131,3 +131,16 @@ x	Nullable(String)
 y	Nullable(Int64)					
 1	1
 a\tb
+group 15: TSKV decoded escape must stay String and read back
+x	Nullable(String)					
+0.5
+group 15: the same holds without a leading zero
+x	Nullable(String)					
+1.5
+x	Nullable(String)					
+10
+group 15: a non-numeric decoded escape is unaffected
+x	Nullable(String)					
+a.b
+x	Nullable(String)					
+0\\p

--- a/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.reference
+++ b/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.reference
@@ -1,0 +1,113 @@
+group 1: TSV infers Float64
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+group 2: CSV control, must equal group 1
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+group 3: zero-padded integers stay String
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+group 4: non-numbers stay String
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+group 5: already-working values unchanged
+c1	Nullable(Int64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+group 6: date-shaped controls stay String
+c1	Nullable(String)					
+c1	Nullable(String)					
+group 7: round trip through Float64
+0
+0.5
+0
+0
+0.5
+8.5
+0
+0.1
+1e-25
+group 8: no row is lost
+3
+3
+3
+3
+group 9: type merge
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+group 10: exponent forms stay String in TSV
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+group 10: the CSV divergence that deliberately remains
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+group 11: try_infer_integers = 1 (the default)
+c1	Nullable(Float64)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+group 11: try_infer_integers = 0
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+group 11: try_infer_integers = 0, the admitted type is readable
+0
+7
+3242
+100
+9
+1
+0
+18446744073709552000
+group 12: TSV-family siblings
+c1	Nullable(Float64)					
+c1	Nullable(String)					
+c1	Nullable(Float64)					
+c1	Nullable(String)					
+group 13: multiple leading zeros with a fractional part
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+group 14: Dynamic runtime path
+0	Float64
+007	String
+0	Float64

--- a/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.sql
+++ b/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.sql
@@ -46,7 +46,10 @@ DESC format(TSV, '0.5f');
 DESC format(CSV, '0x10');
 DESC format(CSV, '0.1.2');
 
--- 5. Values that already worked before the fix must not move.
+-- 5. Values that already worked before the fix must not move. The check the fix rewrites only ever
+-- looked at the first byte, so any sign or bare fractional dot moved the leading zero out of its reach
+-- and these spellings inferred a float on their own. They are pinned here so that stays true, and so a
+-- future rewrite of the check cannot start demoting them.
 SELECT 'group 5: already-working values unchanged';
 DESC format(TSV, '0');
 DESC format(TSV, '1.5');
@@ -55,6 +58,25 @@ DESC format(TSV, '-0.5');
 DESC format(TSV, '-0.0');
 DESC format(TSV, '+0.5');
 DESC format(TSV, '.5');
+DESC format(TSV, '-.5');
+DESC format(TSV, '+.5');
+DESC format(TSV, '-.0');
+DESC format(TSV, '-00.5');
+DESC format(TSV, '+00.5');
+SELECT 'group 5: and they read back as the inferred type';
+SELECT * FROM format(TSV, '-0.5');
+SELECT * FROM format(TSV, '+0.5');
+SELECT * FROM format(TSV, '.5');
+SELECT * FROM format(TSV, '-.5');
+SELECT * FROM format(TSV, '+.5');
+SELECT * FROM format(TSV, '-.0');
+SELECT * FROM format(TSV, '-00.5');
+SELECT * FROM format(TSV, '+00.5');
+SELECT 'group 5: CSV agrees on all of them';
+DESC format(CSV, '-.5');
+DESC format(CSV, '+.5');
+DESC format(CSV, '-.0');
+DESC format(CSV, '-00.5');
 
 -- 6. Date-shaped controls: date inference runs before the leading-zero check, so these cannot move.
 SELECT 'group 6: date-shaped controls stay String';

--- a/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.sql
+++ b/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.sql
@@ -1,0 +1,153 @@
+-- Tags: no-fasttest
+-- no-fasttest: the format() table function and the Dynamic type are not available in the fast test build.
+
+-- 1. Leading-zero decimals must now infer Float64 in the TSV family, as they always did in CSV.
+SELECT 'group 1: TSV infers Float64';
+DESC format(TSV, '0.0');
+DESC format(TSV, '0.5');
+DESC format(TSV, '0.000');
+DESC format(TSV, '0.');
+DESC format(TSV, '000.5');
+DESC format(TSV, '08.5');
+DESC format(TSV, '00.0');
+DESC format(TSV, '0000000.1');
+DESC format(TSV, '0.0000000000000000000000001');
+
+-- 2. The same values in CSV, so the CSV/TSV agreement this fixes is asserted and not assumed.
+SELECT 'group 2: CSV control, must equal group 1';
+DESC format(CSV, '0.0');
+DESC format(CSV, '0.5');
+DESC format(CSV, '0.000');
+DESC format(CSV, '0.');
+DESC format(CSV, '000.5');
+DESC format(CSV, '08.5');
+DESC format(CSV, '00.0');
+DESC format(CSV, '0000000.1');
+DESC format(CSV, '0.0000000000000000000000001');
+
+-- 3. Zero-padded integers deliberately stay String. Do not "simplify" this group away: with integer
+-- inference enabled these values infer an integer type, and the TSV value parser (readIntTextUnsafe)
+-- reads the leading '0' as the whole value, so inferring a number would turn a wrong type into a hard
+-- parse error on data that reads today. This is the parser-side limitation of issue #5999.
+SELECT 'group 3: zero-padded integers stay String';
+DESC format(TSV, '00');
+DESC format(TSV, '007');
+DESC format(TSV, '03242');
+DESC format(TSV, '0100');
+DESC format(TSV, '09');
+DESC format(TSV, '01');
+DESC format(TSV, '00000');
+DESC format(TSV, '018446744073709551615');
+
+-- 4. Fields that are not numbers at all are unaffected in both formats.
+SELECT 'group 4: non-numbers stay String';
+DESC format(TSV, '0x10');
+DESC format(TSV, '0b101');
+DESC format(TSV, '0o7');
+DESC format(TSV, '0.1.2');
+DESC format(TSV, '0.5f');
+DESC format(CSV, '0x10');
+DESC format(CSV, '0.1.2');
+
+-- 5. Values that already worked before the fix must not move.
+SELECT 'group 5: already-working values unchanged';
+DESC format(TSV, '0');
+DESC format(TSV, '1.5');
+DESC format(TSV, '10.0');
+DESC format(TSV, '-0.5');
+DESC format(TSV, '-0.0');
+DESC format(TSV, '+0.5');
+DESC format(TSV, '.5');
+
+-- 6. Date-shaped controls: date inference runs before the leading-zero check, so these cannot move.
+SELECT 'group 6: date-shaped controls stay String';
+DESC format(TSV, '0001-01-01');
+DESC format(TSV, '09:30:00');
+
+-- 7. Round trip: the admitted type must actually be readable, so a type the parser rejects fails loudly.
+SELECT 'group 7: round trip through Float64';
+SELECT * FROM format(TSV, 'x Float64', '0.0');
+SELECT * FROM format(TSV, 'x Float64', '0.5');
+SELECT * FROM format(TSV, 'x Float64', '0.000');
+SELECT * FROM format(TSV, 'x Float64', '0.');
+SELECT * FROM format(TSV, 'x Float64', '000.5');
+SELECT * FROM format(TSV, 'x Float64', '08.5');
+SELECT * FROM format(TSV, 'x Float64', '00.0');
+SELECT * FROM format(TSV, 'x Float64', '0000000.1');
+SELECT * FROM format(TSV, 'x Float64', '0.0000000000000000000000001');
+
+-- 8. Silent row loss: a first row inferring String while a later row infers a number makes TSV header
+-- auto-detection consume the data row as a column name, so the row disappears from the result.
+SELECT 'group 8: no row is lost';
+SELECT count() FROM format(TSV, '0.0\n10.5\n2.3');
+SELECT count() FROM format(CSV, '0.0\n10.5\n2.3');
+SELECT count() FROM format(TSV, '1.5\n10.5\n2.3');
+SELECT count() FROM format(CSV, '1.5\n10.5\n2.3');
+
+-- 9. Type merge across rows.
+SELECT 'group 9: type merge';
+DESC format(TSV, '0.0\n0.5');
+DESC format(TSV, '0.5\n1.5');
+
+-- 10. Exponent forms deliberately keep inferring String in the TSV family. Do not remove this group:
+-- schema inference accepts exponent values (for example `0.5e+`) that the value parser's precise float
+-- reader rejects, so admitting them here would turn a wrong type into a hard parse error.
+SELECT 'group 10: exponent forms stay String in TSV';
+DESC format(TSV, '0e5') SETTINGS input_format_try_infer_exponent_floats = 1;
+DESC format(TSV, '0E5') SETTINGS input_format_try_infer_exponent_floats = 1;
+DESC format(TSV, '0e-5') SETTINGS input_format_try_infer_exponent_floats = 1;
+DESC format(TSV, '0.5e10') SETTINGS input_format_try_infer_exponent_floats = 1;
+SELECT 'group 10: the CSV divergence that deliberately remains';
+DESC format(CSV, '0e5') SETTINGS input_format_try_infer_exponent_floats = 1;
+DESC format(CSV, '0.5e10') SETTINGS input_format_try_infer_exponent_floats = 1;
+
+-- 11. The integer part of the check is derived from the inferred type, so it follows
+-- input_format_try_infer_integers: with integer inference disabled, inference yields Float64, the value
+-- is readable, and the check no longer applies.
+SELECT 'group 11: try_infer_integers = 1 (the default)';
+DESC format(TSV, '0.5') SETTINGS input_format_try_infer_integers = 1;
+DESC format(TSV, '00') SETTINGS input_format_try_infer_integers = 1;
+DESC format(TSV, '007') SETTINGS input_format_try_infer_integers = 1;
+DESC format(TSV, '03242') SETTINGS input_format_try_infer_integers = 1;
+DESC format(TSV, '018446744073709551615') SETTINGS input_format_try_infer_integers = 1;
+SELECT 'group 11: try_infer_integers = 0';
+DESC format(TSV, '0.5') SETTINGS input_format_try_infer_integers = 0;
+DESC format(TSV, '00') SETTINGS input_format_try_infer_integers = 0;
+DESC format(TSV, '007') SETTINGS input_format_try_infer_integers = 0;
+DESC format(TSV, '03242') SETTINGS input_format_try_infer_integers = 0;
+DESC format(TSV, '0100') SETTINGS input_format_try_infer_integers = 0;
+DESC format(TSV, '09') SETTINGS input_format_try_infer_integers = 0;
+DESC format(TSV, '01') SETTINGS input_format_try_infer_integers = 0;
+DESC format(TSV, '00000') SETTINGS input_format_try_infer_integers = 0;
+DESC format(TSV, '018446744073709551615') SETTINGS input_format_try_infer_integers = 0;
+SELECT 'group 11: try_infer_integers = 0, the admitted type is readable';
+SELECT * FROM format(TSV, 'x Float64', '00');
+SELECT * FROM format(TSV, 'x Float64', '007');
+SELECT * FROM format(TSV, 'x Float64', '03242');
+SELECT * FROM format(TSV, 'x Float64', '0100');
+SELECT * FROM format(TSV, 'x Float64', '09');
+SELECT * FROM format(TSV, 'x Float64', '01');
+SELECT * FROM format(TSV, 'x Float64', '00000');
+SELECT * FROM format(TSV, 'x Float64', '018446744073709551615');
+
+-- 12. The other formats sharing the Raw and Escaped escaping rules.
+SELECT 'group 12: TSV-family siblings';
+DESC format(TSVRaw, '0.0');
+DESC format(TSVRaw, '007');
+DESC format(TabSeparated, '0.0');
+DESC format(TabSeparated, '007');
+
+-- 13. Several leading zeros with a fractional part: the check is about the inferred type, not about
+-- having exactly one leading zero.
+SELECT 'group 13: multiple leading zeros with a fractional part';
+DESC format(TSV, '00.0');
+DESC format(TSV, '00.');
+DESC format(TSV, '08.5');
+DESC format(TSV, '0000000000.5');
+
+-- 14. The Dynamic runtime path: this arm is not schema-inference only, the inferred type is immediately
+-- used to deserialize the value.
+SELECT 'group 14: Dynamic runtime path';
+SELECT d, dynamicType(d) FROM format(TSV, 'd Dynamic', '0.0');
+SELECT d, dynamicType(d) FROM format(TSV, 'd Dynamic', '007');
+SELECT d, dynamicType(d) FROM format(CSV, 'd Dynamic', '0.0');

--- a/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.sql
+++ b/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.sql
@@ -1,6 +1,3 @@
--- Tags: no-fasttest
--- no-fasttest: the format() table function and the Dynamic type are not available in the fast test build.
-
 -- 1. Leading-zero decimals must now infer Float64 in the TSV family, as they always did in CSV.
 SELECT 'group 1: TSV infers Float64';
 DESC format(TSV, '0.0');
@@ -90,16 +87,28 @@ DESC format(TSV, '0.0\n0.5');
 DESC format(TSV, '0.5\n1.5');
 
 -- 10. Exponent forms deliberately keep inferring String in the TSV family. Do not remove this group:
--- schema inference accepts exponent values (for example `0.5e+`) that the value parser's precise float
--- reader rejects, so admitting them here would turn a wrong type into a hard parse error.
+-- schema inference accepts exponent values whose exponent has no digits, such as `0.5e+`, that the value
+-- parser's precise float reader rejects, so admitting them here would turn a wrong type into a hard parse
+-- error.
 SELECT 'group 10: exponent forms stay String in TSV';
 DESC format(TSV, '0e5') SETTINGS input_format_try_infer_exponent_floats = 1;
 DESC format(TSV, '0E5') SETTINGS input_format_try_infer_exponent_floats = 1;
 DESC format(TSV, '0e-5') SETTINGS input_format_try_infer_exponent_floats = 1;
 DESC format(TSV, '0.5e10') SETTINGS input_format_try_infer_exponent_floats = 1;
+DESC format(TSV, '0.5e+') SETTINGS input_format_try_infer_exponent_floats = 1;
+DESC format(TSV, '0e+') SETTINGS input_format_try_infer_exponent_floats = 1;
+DESC format(TSV, '0.5e-') SETTINGS input_format_try_infer_exponent_floats = 1;
+SELECT 'group 10: the malformed exponent is readable only because it stays String';
+SELECT * FROM format(TSV, '0.5e+') SETTINGS input_format_try_infer_exponent_floats = 1;
+SELECT * FROM format(TSV, '0e+') SETTINGS input_format_try_infer_exponent_floats = 1;
+SELECT * FROM format(TSV, '0.5e-') SETTINGS input_format_try_infer_exponent_floats = 1;
+SELECT d, dynamicType(d) FROM format(TSV, 'd Dynamic', '0.5e+') SETTINGS input_format_try_infer_exponent_floats = 1;
+SELECT d, dynamicType(d) FROM format(TSV, 'd Dynamic', '0e+') SETTINGS input_format_try_infer_exponent_floats = 1;
 SELECT 'group 10: the CSV divergence that deliberately remains';
 DESC format(CSV, '0e5') SETTINGS input_format_try_infer_exponent_floats = 1;
 DESC format(CSV, '0.5e10') SETTINGS input_format_try_infer_exponent_floats = 1;
+DESC format(CSV, '0.5e+') SETTINGS input_format_try_infer_exponent_floats = 1;
+SELECT * FROM format(CSV, '0.5e+') SETTINGS input_format_try_infer_exponent_floats = 1; -- { serverError CANNOT_PARSE_NUMBER }
 
 -- 11. The integer part of the check is derived from the inferred type, so it follows
 -- input_format_try_infer_integers: with integer inference disabled, inference yields Float64, the value
@@ -151,3 +160,17 @@ SELECT 'group 14: Dynamic runtime path';
 SELECT d, dynamicType(d) FROM format(TSV, 'd Dynamic', '0.0');
 SELECT d, dynamicType(d) FROM format(TSV, 'd Dynamic', '007');
 SELECT d, dynamicType(d) FROM format(CSV, 'd Dynamic', '0.0');
+
+-- 15. TSKV also uses the Escaped rule, so a leading-zero decimal now infers Float64 there too. TSKV
+-- decodes escape sequences before inferring but parses the original bytes when reading, so a decimal
+-- written as an escape sequence infers a type its own value path cannot read. That asymmetry is
+-- pre-existing and independent of leading zeros, and it is deliberately not addressed here.
+SELECT 'group 15: TSKV plain values';
+DESC format(TSKV, 'x=0.5\n');
+SELECT * FROM format(TSKV, 'x=0.5\n');
+DESC format(TSKV, 'x=007\n');
+SELECT * FROM format(TSKV, 'x=007\n');
+SELECT 'group 15: TSKV null representation and escapes';
+DESC format(TSKV, 'x=\\N\ty=1\n');
+SELECT x IS NULL, y FROM format(TSKV, 'x=\\N\ty=1\n');
+SELECT * FROM format(TSKV, 'x=a\\tb\n');

--- a/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.sql
+++ b/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.sql
@@ -162,9 +162,10 @@ SELECT d, dynamicType(d) FROM format(TSV, 'd Dynamic', '007');
 SELECT d, dynamicType(d) FROM format(CSV, 'd Dynamic', '0.0');
 
 -- 15. TSKV also uses the Escaped rule, so a leading-zero decimal now infers Float64 there too. TSKV
--- decodes escape sequences before inferring but parses the original bytes when reading, so a decimal
--- written as an escape sequence infers a type its own value path cannot read. That asymmetry is
--- pre-existing and independent of leading zeros, and it is deliberately not addressed here.
+-- decodes escape sequences before inferring but parses the original bytes when reading, so a field whose
+-- escapes were decoded must keep inferring String. Nested values are out of that guard's reach, so an
+-- escaped number inside an array still infers a numeric element type. The escaped forms below use unhex
+-- so the exact wire bytes are unambiguous: 783D305C783245350A is `x=0\x2E5` plus a newline.
 SELECT 'group 15: TSKV plain values';
 DESC format(TSKV, 'x=0.5\n');
 SELECT * FROM format(TSKV, 'x=0.5\n');
@@ -174,3 +175,16 @@ SELECT 'group 15: TSKV null representation and escapes';
 DESC format(TSKV, 'x=\\N\ty=1\n');
 SELECT x IS NULL, y FROM format(TSKV, 'x=\\N\ty=1\n');
 SELECT * FROM format(TSKV, 'x=a\\tb\n');
+SELECT 'group 15: TSKV decoded escape must stay String and read back';
+DESC format(TSKV, unhex('783D305C783245350A'));
+SELECT * FROM format(TSKV, unhex('783D305C783245350A'));
+SELECT 'group 15: the same holds without a leading zero';
+DESC format(TSKV, unhex('783D315C783245350A'));
+SELECT * FROM format(TSKV, unhex('783D315C783245350A'));
+DESC format(TSKV, unhex('783D315C7833300A'));
+SELECT * FROM format(TSKV, unhex('783D315C7833300A'));
+SELECT 'group 15: a non-numeric decoded escape is unaffected';
+DESC format(TSKV, unhex('783D615C783245620A'));
+SELECT * FROM format(TSKV, unhex('783D615C783245620A'));
+DESC format(TSKV, unhex('783D305C700A'));
+SELECT * FROM format(TSKV, unhex('783D305C700A'));

--- a/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.sql
+++ b/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.sql
@@ -188,3 +188,10 @@ DESC format(TSKV, unhex('783D615C783245620A'));
 SELECT * FROM format(TSKV, unhex('783D615C783245620A'));
 DESC format(TSKV, unhex('783D305C700A'));
 SELECT * FROM format(TSKV, unhex('783D305C700A'));
+-- The guard requires both a decoded escape and a numeric inferred type, so a decoded escape in a Date or
+-- in a nested value keeps that type. DESC only: both reads fail here and on master alike.
+-- 783D323032302D30312D305C7833310A is `x=2020-01-0\x31` plus a newline, 633D5B305C783245355D0A is
+-- `c=[0\x2E5]` plus a newline.
+SELECT 'group 15: a decoded escape outside the numeric guard keeps its type';
+DESC format(TSKV, unhex('783D323032302D30312D305C7833310A'));
+DESC format(TSKV, unhex('633D5B305C783245355D0A'));


### PR DESCRIPTION
Infer leading-zero decimals as numbers in TSV schema inference
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/112105
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes schema inference for the `TSV` family of formats inferring `String` for a decimal value written with a leading zero, such as `0.0` or `0.5`, where `CSV` correctly infers `Float64`. A first row of such values was additionally consumed as a header by `TSV` header auto-detection and disappeared from the result. Also fixes `TSKV` inferring a numeric type for a value written using an escape sequence, such as `x=1\x2E5`, which then failed to parse. Values whose leading zero is padding of an integer, such as `007`, keep inferring `String` because the `TSV` value parser cannot read them back. Closes #112105.


### Description

`tryInferDataTypeByEscapingRule` returned `String` for any TSV field starting with `0` and longer than one character, before number inference was attempted at all. The check is a proxy for a real limitation of the value parser, and the proxy was too wide: it also caught genuine decimals whose leading zero is not padding.

```
$ printf 'a\n0.0\n' | clickhouse local --input-format=TSVWithNames -q "DESCRIBE TABLE table"
a	Nullable(String)
$ printf 'a\n0.0\n' | clickhouse local --input-format=CSVWithNames -q "DESCRIBE TABLE table"
a	Nullable(Float64)
```

The sign sensitivity the reporter observed shares that single cause: `-0.0`, `+0.5` and `.5` all worked because the check reads `field[0]`, which is not `0` in those cases.

#### The limitation being protected against is in the integer read path only

The check's own comment names the reason: `SerializationNumber<T>::deserializeText` calls `readIntTextUnsafe` for integral `T`, and that reader consumes the leading `0` as the complete value, leaving the rest of the field unparsed. Measured with an explicit structure, so that inference is out of the picture:

| field | read as `Float64` | read as `Int64` |
|---|---|---|
| `0.0` `0.5` `0.000` `0.` `000.5` `08.5` `00.0` `0000000.1` | parses (0, 0.5, 0, 0, 0.5, 8.5, 0, 0.1) | `Code: 27` |
| `00` `007` `03242` `0100` `09` `01` `00000` | parses (0, 7, 3242, 100, 9, 1, 0) | `Code: 27` |
| control `0` `1` `42` `-7` | parses | parses |

So the check is correct for integer-shaped fields and unnecessary for genuine decimals.

#### The change

Move the existing `tryInferDataTypeForSingleField` call above the check and keep `String` only when the inferred type is one the TSV value parser cannot read back. The integer case is decided by asking the inferred type instead of re-deriving the field's shape from its punctuation, because `tryInferNumber` documents its own float-versus-integer decomposition as a current assumption, so a punctuation proxy would silently rot as inference evolves. The exponent case stays a field test, since the divergence it guards sits between two float readers and is not visible in the inferred type.

On cost: this is a reordering of a call the function already makes, so no path gains a call. Fields not starting with `0` are unaffected. Fields that do start with `0` now run inference before the check where they previously returned early, which is one `ReadBufferFromString` parse of a short field. This path is not schema inference only, `SerializationDynamic` calls this function once per value, so that is worth stating rather than describing the change as free everywhere.

One consequence is that the behaviour for `input_format_try_infer_integers = 0` now falls out for free: with integer inference disabled, inference yields `Float64`, `readIntTextUnsafe` is never involved, and zero-padded integers are readable, so the check no longer applies to them.

`allow_number_leading_zeros` (used by hive partitioning, where the tolerant `readIntText` branch handles leading zeros) keeps its exact position and polarity.

#### `TSKV` needs a second, narrower guard, and it also fixes a pre-existing failure

`TSKV` shares this escaping rule, so a leading-zero decimal now infers `Float64` there too, which is the intended part of the change. But its schema reader reads the value with `readEscapedString`, which **decodes** escape sequences, while its value path parses the **original** bytes. So the wire bytes `x=0\x2E5`, which decode to `0.5`, would newly infer `Float64` and then fail the read with `Code: 27`, because the float reader stops at the backslash. On master that subset was accidentally shielded by the old check, so leaving it alone would have turned working data into a hard error.

The second hunk closes it in `TSKVSchemaReader::readRowAndGetNamesAndDataTypes`: compare the bytes the read consumed against the length of the value it produced, and if they differ, an escape was decoded, so refuse a numeric inferred type. Every decoding branch of `parseComplexEscapeSequence` changes that count (`\xAA` consumes 4 and emits 1, `\N` consumes 2 and emits 0, the kept-as-is and control branches consume 2 and emit 1); the one branch that does not retains the backslash in the value, and a value containing a backslash can never infer a number. So the condition is exactly the unsafe set, with no false positives and no false negatives.

Because the discriminator is "an escape was decoded and the inferred type is a number" rather than "the field starts with a zero", it also repairs cases that fail on master today: `x=1\x2E5` and `x=1\x30` currently infer `Float64` and `Int64` and then fail `Code: 27`, and now read back correctly as `1.5` and `10`. Narrowing the guard to leading-zero fields only would have left those erroring for no principled reason.

#### What this deliberately does not change

- **Zero-padded integers such as `007` keep inferring `String`** at default settings. Inferring a number for them would turn a wrong type into a hard `Code: 27` on data that reads today. The parser side of this is the sibling of issue #5999, which is closed as completed yet still reproduces: `printf '03242\n' | clickhouse local --input-format=TSV --structure="a Int32"` fails while CSV reads `3242`. That is a separate concern and not touched here.
- **A zero-padded integer carrying a sign, such as `-007`, still infers `Int64` and then fails `Code: 27`.** The check reads the first byte of the field while `readIntTextUnsafe` skips a leading minus before applying the same leading-zero short-circuit, and it rejects a leading plus outright, so signed spellings never reach the check. Measured identical on master and on this branch for `-007`, `+007` and `-00`, so it is neither introduced nor repaired here. Making the check sign-aware would demote those values to `String`, which is a behaviour change for a class this PR does not otherwise touch, so it belongs with the parser half above rather than in this change.
- **Exponent forms such as `0e5` and `0.5e10` keep inferring `String`** in the TSV family under `input_format_try_infer_exponent_floats = 1`, so a divergence from CSV remains for them. Schema inference uses the permissive `tryReadFloatTextExt`, while deserialization uses `readFloatTextPrecise` (`precise_float_parsing` defaults to true), and the permissive reader accepts values the precise one rejects: `0.5e+` would infer `Float64` and then fail `Code: 72`. That matters because this code path is not inference only, `SerializationDynamic` immediately deserializes the value into the inferred variant, so an unsafe inference is a hard error at insert time rather than a mis-typed column. The same divergence already exists for `1.5e+`, `1e+` and `1.5e-` on both TSV and CSV. Aligning the two float readers is the right fix for that half and is a much wider change, so it is left out of this one.
- **`TSKV` values whose escape sequence sits inside a nested value, or inside a date, keep failing.** The nested case (`c=[0\x2E5]`) infers `Array(Nullable(Float64))` and the date case (`x=2020-01-0\x31`) infers `Nullable(Date)`, and both then fail the read on master and with this change alike, because the guard described above tests the top-level inferred type and neither an `Array` nor a `Date` is a number. Unchanged behaviour, so not a regression, but a real boundary rather than a fully closed class.

#### Silent row loss, which is the strongest symptom

With TSV header auto-detection on by default, a first row whose fields all infer `String` is treated as a header when a later row infers a number. Because `0.0` inferred `String` while `10.5` inferred `Float64`, the first data row was consumed as a column name and silently dropped:

```
$ printf '0.0\n10.5\n2.3\n' | clickhouse local --input-format=TSV -q "SELECT count() FROM table"
2                     -- three rows in, two rows out; the column is even named "0.0"
$ printf '0.0\n10.5\n2.3\n' | clickhouse local --input-format=CSV -q "SELECT count() FROM table"
3
$ printf '1.5\n10.5\n2.3\n' | clickhouse local --input-format=TSV -q "SELECT count() FROM table"
3                     -- control: same shape without a leading zero
```

This is fixed for decimals. It is **not** fixed for zero-padded integers, where the value legitimately stays `String`; that half belongs to the #5999 family above.

#### Verification

New stateless test `04648_tsv_schema_inference_leading_zero_decimals`, 15 groups: the newly working decimals, a CSV control for each so the agreement is asserted rather than assumed, the values that deliberately stay `String`, non-numbers, the values that already worked, date-shaped controls, a round trip that reads every admitted value back, the row-loss regression, type merge across rows, the exponent exclusion in both the type and the read direction, both values of `input_format_try_infer_integers`, the `TSVRaw` and `TabSeparated` siblings, several leading zeros with a fractional part, the `Dynamic` runtime path, and `TSKV` (plain values, the null representation, and the escaped forms in both the type and the read direction, including a non-numeric escaped control and an escaped `Date` and escaped nested value, so neither conjunct of the guard can be dropped without a failure). The test carries no skip tags and runs in the fast test.

The test fails on master HEAD and passes with the change. Eight mutations were run, one per behaviour, each rebuilt and diffed against the committed reference: reverting the change reproduces master's output byte for byte; removing the check entirely fails the `String`-preserving groups; dropping either disjunct fails exactly the group it protects, with the exponent one failing in the read direction with `Code: 72` rather than only on a type assertion; replacing the type test with an unconditional true fails only the `input_format_try_infer_integers = 0` group; removing the `TSKV` guard fails group 15 with `Code: 27`, again on a read rather than on a type assertion; and dropping only the `isNumber` conjunct of the `TSKV` guard fails exactly the two rows asserting that an escaped `Date` and an escaped number inside an array keep their own inferred type. One mutation, dropping the `Nullable` and `LowCardinality` strip, is undetected by design: for a field starting with `0` inference can only return a bare numeric type, so the strip guards a state that is unreachable here and is kept as future-proofing rather than covered by an assertion. Restoring the source afterwards rebuilds bit-identically.

Every file under `tests/queries/0_stateless` was swept for a committed reference that depends on the old behaviour and none was found; the 39 candidates that mention `TSKV` or sit in the TSV inference neighbourhood were all run and moved zero references, including `02514_tsv_zero_started_number`, `02982_dont_infer_exponent_floats`, and the two the `TSKV` guard could most plausibly have disturbed, `02240_tskv_schema_inference_bug` and `02247_names_order_in_json_and_tskv`. Three of the 39 fail identically on a pristine master binary for reasons unrelated to this change: a missing `test_shard_localhost` cluster, an absent `system.query_log`, and an Avro schema registry.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.299` (included in `26.8` and later)
<!-- ch-version-info:end -->