### PR TITLE
Fix praktika `is_merge_queue_event` comparing the event type against GitHub's event name

### DIFF
--- a/ci/praktika/info.py
+++ b/ci/praktika/info.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 from .settings import Settings
+from .workflow import Workflow
 
 class Info:
 
@@ -130,7 +131,10 @@ class Info:
 
     @property
     def is_merge_queue_event(self):
-        return self.env.EVENT_TYPE == "merge_group"
+        # EVENT_TYPE always holds a Workflow.Event value, never GitHub's event
+        # name: the GitHub event is called "merge_group", praktika's value is
+        # "merge_queue". Compare against the enum so the two cannot drift.
+        return self.env.EVENT_TYPE == Workflow.Event.MERGE_QUEUE
 
     @property
     def is_push_event(self):

--- a/ci/tests/test_info_event_type.py
+++ b/ci/tests/test_info_event_type.py
@@ -1,0 +1,127 @@
+"""
+Tests for `Info.is_merge_queue_event` and its sibling event predicates.
+
+`_Environment.EVENT_TYPE` always holds a `Workflow.Event` value, never GitHub's
+event name. GitHub calls the merge-queue event `merge_group` while
+`Workflow.Event.MERGE_QUEUE` is `"merge_queue"`, so a predicate comparing
+`EVENT_TYPE` against `"merge_group"` is never true and every merge-queue
+consumer silently takes the pull-request branch.
+
+These tests drive the real chain - a GitHub event payload through
+`_Environment.from_env()` into the real `Info` property - on purpose. The
+merge-queue tests in `test_gh.py` build a `SimpleNamespace` with
+`is_merge_queue_event=True`, i.e. they stub out the predicate itself, so they
+cannot catch a broken predicate. Do not replace the payload below with a
+mocked `Info`.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.praktika._environment import _Environment
+from ci.praktika.info import Info
+from ci.praktika.workflow import Workflow
+
+QUEUE_HEAD_REF = (
+    "gh-readonly-queue/master/pr-110395-4a44dcefc451d3da3f7a9e7c8a38f74180b34ebc"
+)
+
+REPOSITORY = {"html_url": "https://github.com/ClickHouse/ClickHouse"}
+
+# One payload per event praktika understands, shaped like the GitHub webhook.
+PAYLOADS = {
+    Workflow.Event.MERGE_QUEUE: {
+        "merge_group": {"head_ref": QUEUE_HEAD_REF},
+        "repository": REPOSITORY,
+    },
+    Workflow.Event.PULL_REQUEST: {
+        "pull_request": {
+            "number": 110395,
+            "head": {"sha": "a" * 40, "repo": {"full_name": "ClickHouse/ClickHouse"}},
+            "html_url": "https://github.com/ClickHouse/ClickHouse/pull/110395",
+            "body": "",
+            "title": "",
+            "labels": [],
+            "user": {"login": "nobody"},
+            "updated_at": "2026-07-28T00:00:00Z",
+        },
+    },
+    Workflow.Event.PUSH: {
+        "commits": [],
+        "after": "b" * 40,
+        "head_commit": {"url": "https://github.com/o/r/commit/b", "message": "m"},
+        "repository": {"updated_at": "2026-07-28T00:00:00Z"},
+    },
+    Workflow.Event.SCHEDULE: {"schedule": "0 0 * * *", "repository": REPOSITORY},
+    Workflow.Event.DISPATCH: {"inputs": {}, "repository": REPOSITORY},
+}
+
+
+def _info_for(event, tmp_path, monkeypatch):
+    """Build a real `_Environment` from the event payload and hand it to `Info`.
+
+    Only `_Environment.get` is stubbed, so the property under test and the
+    `EVENT_TYPE` it reads are both the production ones.
+    """
+    event_file = tmp_path / f"event_{event}.json"
+    event_file.write_text(json.dumps(PAYLOADS[event]), encoding="utf-8")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
+    monkeypatch.setenv("GITHUB_SHA", "c" * 40)
+    # Avoid the ec2metadata / IMDS lookups from_env falls back to.
+    monkeypatch.setenv("INSTANCE_TYPE", "test-instance-type")
+    monkeypatch.setenv("INSTANCE_ID", "test-instance-id")
+    monkeypatch.setenv("INSTANCE_LIFE_CYCLE", "on-demand")
+    env = _Environment.from_env()
+    monkeypatch.setattr(_Environment, "get", classmethod(lambda cls: env))
+    return Info()
+
+
+def test_merge_group_payload_yields_merge_queue_event_type(tmp_path, monkeypatch):
+    """The GitHub `merge_group` event is stored as `Workflow.Event.MERGE_QUEUE`."""
+    info = _info_for(Workflow.Event.MERGE_QUEUE, tmp_path, monkeypatch)
+    assert info.env.EVENT_TYPE == Workflow.Event.MERGE_QUEUE
+    assert info.env.EVENT_TYPE != "merge_group"
+
+
+def test_is_merge_queue_event_true_in_merge_queue(tmp_path, monkeypatch):
+    info = _info_for(Workflow.Event.MERGE_QUEUE, tmp_path, monkeypatch)
+    assert info.is_merge_queue_event
+
+
+def test_is_merge_queue_event_false_for_other_events(tmp_path, monkeypatch):
+    for event in (
+        Workflow.Event.PULL_REQUEST,
+        Workflow.Event.PUSH,
+        Workflow.Event.SCHEDULE,
+        Workflow.Event.DISPATCH,
+    ):
+        info = _info_for(event, tmp_path, monkeypatch)
+        assert info.env.EVENT_TYPE == event, event
+        assert not info.is_merge_queue_event, event
+
+
+def test_merge_queue_run_exposes_the_linked_pr(tmp_path, monkeypatch):
+    """The predicate is only useful together with the linked PR number the
+    merge-queue consumers query the GitHub API with."""
+    info = _info_for(Workflow.Event.MERGE_QUEUE, tmp_path, monkeypatch)
+    assert info.pr_number == 0
+    assert info.linked_pr_number == 110395
+
+
+def test_push_and_dispatch_predicates(tmp_path, monkeypatch):
+    """The sibling predicates compare literals that happen to equal their enum
+    values; pin that so a later rename of `Workflow.Event` cannot silently
+    break them the way `MERGE_QUEUE` was broken."""
+    assert Workflow.Event.PUSH == "push"
+    assert Workflow.Event.DISPATCH == "dispatch"
+
+    info = _info_for(Workflow.Event.PUSH, tmp_path, monkeypatch)
+    assert info.is_push_event
+    assert not info.is_dispatch_event
+
+    info = _info_for(Workflow.Event.DISPATCH, tmp_path, monkeypatch)
+    assert info.is_dispatch_event
+    assert not info.is_push_event


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110395
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`Info.is_merge_queue_event` compared `_Environment.EVENT_TYPE` against `"merge_group"`, but
`EVENT_TYPE` only ever holds a `Workflow.Event` value, and `Workflow.Event.MERGE_QUEUE` is
`"merge_queue"`. `merge_group` is GitHub's *event name*; `merge_queue` is praktika's *enum value*.
So the predicate was never true in a real merge-queue run, and every consumer silently took the
pull-request branch. Fixed by comparing against the enum constant, so the two cannot drift again.

How it surfaced: `Style check` / `settings_changes_history` fails deterministically in the merge
queue for any PR that touches `src/Core/SettingsChangesHistory.cpp`, with

> `src/Core/SettingsChangesHistory.cpp changed but its diff could not be fetched to validate the
> settings history (the check must not be skipped when the file changed). Error: no data recorded
> by the store_data.py workflow hook.`

Report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=gh-readonly-queue/master/pr-110395-4a44dcefc451d3da3f7a9e7c8a38f74180b34ebc&sha=999b2e18000966dd17c2060fb5c0e83f955bfb11&name_0=MergeQueueCI&name_1=Style%20check

`store_data.py`'s `__main__` computes `strict=bool(info.pr_number) or info.is_merge_queue_event`,
which is `False` in the queue (`pr_number` is 0 there), and gates the settings-history block on
`(info.pr_number or info.is_merge_queue_event) and settings_history_file in changed_files`, also
`False`, so `settings_history_changed_settings` is never stored. `check_style.py`'s
`check_settings_changes_history` then sees the file in `changed_files` with no recorded data and
fail-closes. The check is behaving correctly; the hook silently skipped half its work. The failing
job's own environment dump confirms `EVENT_TYPE='merge_queue'`, `PR_NUMBER=0`,
`LINKED_PR_NUMBER=110395`, and that the stored kv keys are exactly
`['changed_files', 'build_digest', 'master_commits']`.

CIDB, `test_name = 'settings_changes_history'`, last 10 days as of 2026-07-28 06:37 UTC:

| scope | FAIL | OK |
|---|---|---|
| merge queue (`head_ref LIKE 'gh-readonly-queue/%'`) | 5 (all with the message above) | 40 |
| PR workflow | 26 (all genuine settings-history violations) | 337 |

The 5 merge-queue failures are exactly the merge-queue entries that touched the file (2 PRs), i.e.
100% on qualifying entries. The 40 passing merge-queue rows span 36 distinct PRs and none of those
36 touches the file, so every one of them took the `path not in changed_files` early return: the
validator has never actually validated anything in a merge queue. The PR workflow is unaffected.

Consumers that were on the wrong branch and now work:

- `GH.get_changed_files` is called with `strict=True`, i.e. fail-closed changed-file detection.
- The settings-history block runs, resolving the diff through `linked_pr_number`.
- `GH.get_changed_files` itself queries `pulls/<linked>/files --paginate` instead of the
  300-entry-capped `commits/<sha>` API, regaining the fail-closed guarantee its own comment exists
  for. For the #110395 queue entry both endpoints return the same 17 files, so nothing changes on a
  small PR while the cap disappears on a large one.
- `functional_tests.py` merge-queue flaky `rerun_count` 50 -> 20.
- `functional_tests.py` `FLAKY_CHECK_TIME_LIMIT` 45 min -> 20 min.

The sibling predicates `is_push_event` and `is_dispatch_event` compare literals that happen to
equal their enum values (`"push"`, `"dispatch"`), so they were never broken; converting them to the
enum form is behaviour-neutral hygiene and is out of scope here. The new test pins those two
equalities, so a later rename of `Workflow.Event` fails a test instead of silently repeating this
bug. `_environment.py`'s `elif "merge_group" in github_event:` is correct as written - that one
legitimately reads the GitHub payload before storing the enum value - and is unchanged.

Behaviour changes worth calling out:

1. The settings-history validator starts running in the merge queue for the first time. Expect
   newly-enforced reds on queued PRs that add or change a setting without an entry under the
   current version block. That is the intended behaviour of the check.
2. `GH.get_changed_files`'s fail-closed `raise` becomes reachable inside a pre-hook. If a
   merge-queue head ref ever yields no linked PR number, `store_data.py` now raises where it
   previously fell through; `native_jobs.py` wraps each pre-hook in a `Pre Hooks` result whose
   non-OK status gates the rest of the config job, so that surfaces as a loud failure rather than a
   hang or a silent skip. In practice it should not fire: all 6510 distinct merge-queue head refs
   in the last 180 days match the canonical `gh-readonly-queue/<base>/pr-<N>-<sha>` shape and none
   is unparseable.
3. The tighter merge-queue flaky-check budget starts applying, as intended by the design that
   introduced it.

Test: `ci/tests/test_info_event_type.py` drives a real GitHub `merge_group` payload through
`_Environment.from_env()` into the real `Info` property and asserts the full event matrix
(`merge_group` -> True; `pull_request`, `push`, `schedule`, `dispatch` -> False), plus that the
queue head ref yields `linked_pr_number == 110395`. It deliberately does not mock the predicate:
the existing merge-queue tests in `ci/tests/test_gh.py` build a `SimpleNamespace` with
`is_merge_queue_event=True`, which is why they could not catch this. Reverting the one-line change
makes the new test fail on exactly that assertion.

Separately, `check_style.py` reads a `settings_history_fetch_error` key that nothing ever writes, so
a genuine diff-fetch failure reports the generic "no data recorded" text instead of its real cause.
That is a distinct root cause (the fetch goes through `Shell.get_output`, which returns stdout even
on a nonzero exit, so simply storing the exception would record a mislabelled reason) and is being
fixed separately rather than folded in here.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.254` (included in `26.8` and later)
<!-- ch-version-info:end -->