### PR TITLE
Fix spurious receive timeout on distributed reads caused by a latched timer-readiness flag

### DIFF
--- a/src/Client/Connection.h
+++ b/src/Client/Connection.h
@@ -24,6 +24,10 @@
 
 #include "config.h"
 
+/// Lets the PacketReceiver unit test attach an already-connected socket without a server.
+/// Keep in sync with the struct name in src/Client/tests/gtest_packet_receiver_timeout_latch.cpp.
+struct PacketReceiverTestAccess;
+
 namespace DB
 {
 
@@ -51,6 +55,7 @@ class NativeWriter;
 class Connection : public IServerConnection
 {
     friend class MultiplexedConnections;
+    friend struct ::PacketReceiverTestAccess;
 
 public:
     Connection(const String & host_, UInt16 port_,

--- a/src/Client/PacketReceiver.cpp
+++ b/src/Client/PacketReceiver.cpp
@@ -35,6 +35,7 @@ void PacketReceiver::clearAsyncEvent()
 bool PacketReceiver::checkTimeout()
 {
     bool is_socket_ready = false;
+    bool is_timeout_ready = false;
 
     epoll_event events[2];
     events[0].data.fd = events[1].data.fd = -1;
@@ -45,11 +46,15 @@ bool PacketReceiver::checkTimeout()
         if (events[i].data.fd == socket_fd)
             is_socket_ready = true;
         if (events[i].data.fd == timeout_descriptor.getDescriptor())
-            is_timeout_expired = true;
+            is_timeout_ready = true;
     }
 
-    if (is_timeout_expired && !is_socket_ready)
+    /// Timer readiness is only meaningful together with socket readiness observed in the
+    /// SAME wake: if both are ready the packet is delivered and no timeout happened, so
+    /// the observation must not be remembered as connection state.
+    if (is_timeout_ready && !is_socket_ready)
     {
+        is_timeout_expired = true;
         timeout_descriptor.reset();
         return false;
     }

--- a/src/Client/PacketReceiver.h
+++ b/src/Client/PacketReceiver.h
@@ -8,6 +8,11 @@
 #include <Common/TimerDescriptor.h>
 #include <Common/AsyncTaskExecutor.h>
 
+/// Grants the unit test access to checkTimeout() and to the receive-timeout state,
+/// which are otherwise internal. Keep in sync with the struct name in
+/// src/Client/tests/gtest_packet_receiver_timeout_latch.cpp.
+struct PacketReceiverTestAccess;
+
 namespace DB
 {
 
@@ -35,6 +40,9 @@ public:
     {
         timeout_descriptor.setRelative(timeout_);
         timeout = timeout_;
+        /// Re-arming the timer starts a new receive interval, so any previously declared
+        /// timeout no longer applies.
+        is_timeout_expired = false;
     }
 
     int getFileDescriptor() const { return epoll.getFileDescriptor(); }
@@ -68,6 +76,8 @@ private:
     /// We use timer descriptor for checking socket timeouts.
     TimerDescriptor timeout_descriptor;
     Poco::Timespan timeout;
+    /// Whether a receive timeout was DECLARED (timer fd ready while the socket was not),
+    /// not merely whether the timer fd was ever observed ready. Cleared by setTimeout().
     bool is_timeout_expired = false;
 
     /// In read callback we add socket file descriptor and timer descriptor with receive timeout
@@ -78,6 +88,8 @@ private:
     std::exception_ptr exception;
 
     bool is_read_in_process = false;
+
+    friend struct ::PacketReceiverTestAccess;
 };
 
 }

--- a/src/Client/tests/gtest_packet_receiver_timeout_latch.cpp
+++ b/src/Client/tests/gtest_packet_receiver_timeout_latch.cpp
@@ -16,7 +16,7 @@
 
 using namespace DB;
 
-/// Drives PacketReceiver::checkTimeout() directly against a real connected socket, without a
+/// Drives PacketReceiver::checkTimeout directly against a real connected socket, without a
 /// ClickHouse server: PacketReceiver only needs the socket's file descriptor, so the test
 /// attaches an already-connected socket to an unconnected Connection.
 struct PacketReceiverTestAccess
@@ -118,14 +118,8 @@ struct ConnectedPair
 
 }
 
-/// PacketReceiver::checkTimeout() observes the timer fd and the socket fd of one epoll wake.
-/// Timer readiness alone means nothing: it is a receive timeout only if the socket was NOT
-/// ready in the SAME wake. Historically the observation was stored in the `is_timeout_expired`
-/// MEMBER before the conjunction was evaluated and nothing ever cleared it, so a single wake
-/// carrying both a data packet and the timer expiry delivered its packet correctly and then
-/// left the receiver permanently "timed out": isPacketReady() was stuck false and
-/// HedgedConnections::resumePacketReceiver() threw a spurious SOCKET_TIMEOUT on every
-/// subsequent packet.
+/// Timer readiness in one epoll wake is a receive timeout only if the socket was NOT ready in
+/// that same wake, so it must leave no residue on the receiver.
 TEST(PacketReceiverTimeoutLatch, SimultaneousReadinessLeavesNoTimeoutResidue)
 {
     ConnectedPair pair;
@@ -153,11 +147,8 @@ TEST(PacketReceiverTimeoutLatch, SimultaneousReadinessLeavesNoTimeoutResidue)
     EXPECT_TRUE(receiver.isPacketReady());
 }
 
-/// The regression guard for the opposite direction: a genuine receive timeout (timer ready,
-/// socket NOT ready) must still be declared, and must still be visible to
-/// HedgedConnections::resumePacketReceiver() through isTimeoutExpired() after checkTimeout()
-/// returned, i.e. the verdict has to persist across calls even though the raw observation
-/// must not.
+/// The opposite direction: the verdict must persist across calls, because
+/// HedgedConnections::resumePacketReceiver reads it only after checkTimeout returned.
 TEST(PacketReceiverTimeoutLatch, GenuineTimeoutIsStillDeclaredAndPersists)
 {
     ConnectedPair pair;
@@ -173,14 +164,12 @@ TEST(PacketReceiverTimeoutLatch, GenuineTimeoutIsStillDeclaredAndPersists)
     EXPECT_TRUE(receiver.isTimeoutExpired());
     EXPECT_FALSE(receiver.isPacketReady());
 
-    /// The verdict persists for the caller, which reads it only after checkTimeout() returned.
+    /// The verdict persists for the caller, which reads it only after checkTimeout returned.
     EXPECT_TRUE(receiver.isTimeoutExpired());
 }
 
-/// HedgedConnections::resumePacketReceiver() re-arms the receive timeout after every received
-/// packet (setTimeout()); that per-packet re-arm is the invariant of "receive_timeout is a
-/// per-packet idle timeout, not a total-query timeout". A declared timeout must therefore be
-/// cleared by the re-arm, or the re-arm would be unreachable for the rest of the connection.
+/// HedgedConnections::resumePacketReceiver re-arms the timeout after every packet, which is what
+/// makes receive_timeout a per-packet idle timeout; the re-arm must therefore clear the verdict.
 TEST(PacketReceiverTimeoutLatch, SetTimeoutClearsADeclaredTimeout)
 {
     ConnectedPair pair;

--- a/src/Client/tests/gtest_packet_receiver_timeout_latch.cpp
+++ b/src/Client/tests/gtest_packet_receiver_timeout_latch.cpp
@@ -1,0 +1,173 @@
+#if defined(OS_LINUX)
+
+#include <gtest/gtest.h>
+
+#include <Client/Connection.h>
+#include <Client/PacketReceiver.h>
+
+#include <Poco/Net/ServerSocket.h>
+#include <Poco/Net/SocketAddress.h>
+#include <Poco/Net/StreamSocket.h>
+
+#include <unistd.h>
+
+using namespace DB;
+
+/// Drives PacketReceiver::checkTimeout() directly against a real connected socket, without a
+/// ClickHouse server: PacketReceiver only needs the socket's file descriptor, so the test
+/// attaches an already-connected socket to an unconnected Connection.
+struct PacketReceiverTestAccess
+{
+    Connection connection;
+    std::unique_ptr<PacketReceiver> receiver;
+
+    explicit PacketReceiverTestAccess(const Poco::Net::StreamSocket & socket)
+        : connection(
+              "127.0.0.1",
+              /*port_=*/0,
+              /*default_database_=*/"",
+              /*user_=*/"default",
+              /*password_=*/"",
+              /*proto_send_chunked_=*/"notchunked",
+              /*proto_recv_chunked_=*/"notchunked",
+              SSHKey(),
+              /*jwt_=*/"",
+              /*quota_key_=*/"",
+              /*cluster_=*/"",
+              /*cluster_secret_=*/"",
+              /*client_name_=*/"gtest",
+              Protocol::Compression::Disable,
+              Protocol::Secure::Disable,
+              /*tls_sni_override_=*/"",
+              /*bind_host_=*/"")
+    {
+        connection.socket = std::make_unique<Poco::Net::StreamSocket>(socket);
+        receiver = std::make_unique<PacketReceiver>(&connection);
+    }
+
+    bool checkTimeout() { return receiver->checkTimeout(); }
+    bool isTimeoutExpired() const { return receiver->isTimeoutExpired(); }
+    bool isPacketReady() const { return receiver->isPacketReady(); }
+    void setTimeout(const Poco::Timespan & t) { receiver->setTimeout(t); }
+};
+
+namespace
+{
+
+/// A connected TCP socket pair whose client end can be made readable on demand.
+/// The kernel listen backlog completes the handshake, so no server thread is needed.
+struct ConnectedPair
+{
+    Poco::Net::ServerSocket listener{Poco::Net::SocketAddress("127.0.0.1", 0), 1};
+    Poco::Net::StreamSocket client;
+    Poco::Net::StreamSocket server;
+
+    ConnectedPair()
+    {
+        client.connect(listener.address());
+        server = listener.acceptConnection();
+    }
+
+    /// Make the client end readable, and wait until the kernel reports it as such,
+    /// so that a subsequent epoll wake deterministically sees the socket ready.
+    void makeClientReadable()
+    {
+        const char byte = 'x';
+        server.sendBytes(&byte, 1);
+        ASSERT_TRUE(client.poll(Poco::Timespan(5, 0), Poco::Net::Socket::SELECT_READ));
+    }
+
+    void drainClient()
+    {
+        char buf[64];
+        while (client.poll(Poco::Timespan(0, 0), Poco::Net::Socket::SELECT_READ))
+        {
+            if (client.receiveBytes(buf, sizeof(buf)) <= 0)
+                break;
+        }
+    }
+};
+
+}
+
+/// PacketReceiver::checkTimeout() observes the timer fd and the socket fd of one epoll wake.
+/// Timer readiness alone means nothing: it is a receive timeout only if the socket was NOT
+/// ready in the SAME wake. Historically the observation was stored in the `is_timeout_expired`
+/// MEMBER before the conjunction was evaluated and nothing ever cleared it, so a single wake
+/// carrying both a data packet and the timer expiry delivered its packet correctly and then
+/// left the receiver permanently "timed out": isPacketReady() was stuck false and
+/// HedgedConnections::resumePacketReceiver() threw a spurious SOCKET_TIMEOUT on every
+/// subsequent packet.
+TEST(PacketReceiverTimeoutLatch, SimultaneousReadinessLeavesNoTimeoutResidue)
+{
+    ConnectedPair pair;
+    PacketReceiverTestAccess receiver(pair.client);
+
+    /// Arm the timer and let it expire, then make the socket readable as well, so that the
+    /// next epoll wake reports BOTH descriptors.
+    receiver.setTimeout(Poco::Timespan(0, 10'000));
+    pair.makeClientReadable();
+    ::usleep(200'000);
+
+    /// Both ready => a packet is available => this is not a timeout.
+    ASSERT_TRUE(receiver.checkTimeout());
+    EXPECT_FALSE(receiver.isTimeoutExpired())
+        << "a wake in which the socket was ready must not declare a receive timeout";
+    EXPECT_TRUE(receiver.isPacketReady())
+        << "the receiver must still be able to deliver packets after a simultaneous-readiness wake";
+
+    /// And the receiver must remain usable: with the timer re-armed and unexpired, a further
+    /// wake on a readable socket must again report "no timeout".
+    receiver.setTimeout(Poco::Timespan(10, 0));
+    ASSERT_TRUE(receiver.checkTimeout());
+    EXPECT_FALSE(receiver.isTimeoutExpired());
+    EXPECT_TRUE(receiver.isPacketReady());
+}
+
+/// The regression guard for the opposite direction: a genuine receive timeout (timer ready,
+/// socket NOT ready) must still be declared, and must still be visible to
+/// HedgedConnections::resumePacketReceiver() through isTimeoutExpired() after checkTimeout()
+/// returned, i.e. the verdict has to persist across calls even though the raw observation
+/// must not.
+TEST(PacketReceiverTimeoutLatch, GenuineTimeoutIsStillDeclaredAndPersists)
+{
+    ConnectedPair pair;
+    PacketReceiverTestAccess receiver(pair.client);
+
+    pair.drainClient();
+    receiver.setTimeout(Poco::Timespan(0, 10'000));
+    ::usleep(200'000);
+
+    /// Timer ready, socket not ready => genuine receive timeout.
+    ASSERT_FALSE(receiver.checkTimeout());
+    EXPECT_TRUE(receiver.isTimeoutExpired());
+    EXPECT_FALSE(receiver.isPacketReady());
+
+    /// The verdict persists for the caller, which reads it only after checkTimeout() returned.
+    EXPECT_TRUE(receiver.isTimeoutExpired());
+}
+
+/// HedgedConnections::resumePacketReceiver() re-arms the receive timeout after every received
+/// packet (setTimeout()); that per-packet re-arm is the invariant of "receive_timeout is a
+/// per-packet idle timeout, not a total-query timeout". A declared timeout must therefore be
+/// cleared by the re-arm, or the re-arm would be unreachable for the rest of the connection.
+TEST(PacketReceiverTimeoutLatch, SetTimeoutClearsADeclaredTimeout)
+{
+    ConnectedPair pair;
+    PacketReceiverTestAccess receiver(pair.client);
+
+    pair.drainClient();
+    receiver.setTimeout(Poco::Timespan(0, 10'000));
+    ::usleep(200'000);
+    ASSERT_FALSE(receiver.checkTimeout());
+    ASSERT_TRUE(receiver.isTimeoutExpired());
+
+    /// Re-arming starts a new receive interval.
+    receiver.setTimeout(Poco::Timespan(10, 0));
+    EXPECT_FALSE(receiver.isTimeoutExpired())
+        << "re-arming the receive timeout must clear a previously declared timeout";
+    EXPECT_TRUE(receiver.isPacketReady())
+        << "after the per-packet re-arm the receiver must be usable again";
+}
+
+#endif

--- a/src/Client/tests/gtest_packet_receiver_timeout_latch.cpp
+++ b/src/Client/tests/gtest_packet_receiver_timeout_latch.cpp
@@ -48,10 +48,11 @@ struct PacketReceiverTestAccess
         receiver = std::make_unique<PacketReceiver>(&connection);
     }
 
-    bool checkTimeout() { return receiver->checkTimeout(); }
+    /// All const: these mutate the owned receiver through the pointer, not this struct.
+    bool checkTimeout() const { return receiver->checkTimeout(); }
     bool isTimeoutExpired() const { return receiver->isTimeoutExpired(); }
     bool isPacketReady() const { return receiver->isPacketReady(); }
-    void setTimeout(const Poco::Timespan & t) { receiver->setTimeout(t); }
+    void setTimeout(const Poco::Timespan & t) const { receiver->setTimeout(t); }
 
     /// The receive timer's descriptor, so a test can wait for it to actually fire instead of
     /// assuming a fixed sleep was long enough.

--- a/src/Client/tests/gtest_packet_receiver_timeout_latch.cpp
+++ b/src/Client/tests/gtest_packet_receiver_timeout_latch.cpp
@@ -9,6 +9,9 @@
 #include <Poco/Net/SocketAddress.h>
 #include <Poco/Net/StreamSocket.h>
 
+#include <chrono>
+#include <cerrno>
+#include <poll.h>
 #include <unistd.h>
 
 using namespace DB;
@@ -49,10 +52,34 @@ struct PacketReceiverTestAccess
     bool isTimeoutExpired() const { return receiver->isTimeoutExpired(); }
     bool isPacketReady() const { return receiver->isPacketReady(); }
     void setTimeout(const Poco::Timespan & t) { receiver->setTimeout(t); }
+
+    /// The receive timer's descriptor, so a test can wait for it to actually fire instead of
+    /// assuming a fixed sleep was long enough.
+    int timerFd() const { return receiver->timeout_descriptor.getDescriptor(); }
 };
 
 namespace
 {
+
+/// Wait until the receive timer's descriptor is readable, so the following epoll wake is
+/// guaranteed to report it. A fixed sleep can return early (EINTR, or an oversubscribed host),
+/// and in a test where the socket is deliberately readable that would leave a socket-only wake,
+/// which satisfies the same assertions for the wrong reason.
+[[nodiscard]] bool waitTimerReady(int timer_fd, Poco::Timespan limit)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::microseconds(limit.totalMicroseconds());
+    while (true)
+    {
+        pollfd p{.fd = timer_fd, .events = POLLIN, .revents = 0};
+        const int rc = ::poll(&p, 1, 50);
+        if (rc == 1 && (p.revents & POLLIN))
+            return true;
+        if (rc == -1 && errno != EINTR)
+            return false;
+        if (std::chrono::steady_clock::now() >= deadline)
+            return false;
+    }
+}
 
 /// A connected TCP socket pair whose client end can be made readable on demand.
 /// The kernel listen backlog completes the handshake, so no server thread is needed.
@@ -107,7 +134,8 @@ TEST(PacketReceiverTimeoutLatch, SimultaneousReadinessLeavesNoTimeoutResidue)
     /// next epoll wake reports BOTH descriptors.
     receiver.setTimeout(Poco::Timespan(0, 10'000));
     pair.makeClientReadable();
-    ::usleep(200'000);
+    ASSERT_TRUE(waitTimerReady(receiver.timerFd(), Poco::Timespan(5, 0)))
+        << "the receive timer never became ready, so this wake would not exercise the latch";
 
     /// Both ready => a packet is available => this is not a timeout.
     ASSERT_TRUE(receiver.checkTimeout());
@@ -136,7 +164,8 @@ TEST(PacketReceiverTimeoutLatch, GenuineTimeoutIsStillDeclaredAndPersists)
 
     pair.drainClient();
     receiver.setTimeout(Poco::Timespan(0, 10'000));
-    ::usleep(200'000);
+    ASSERT_TRUE(waitTimerReady(receiver.timerFd(), Poco::Timespan(5, 0)))
+        << "the receive timer never became ready, so this wake would not exercise the latch";
 
     /// Timer ready, socket not ready => genuine receive timeout.
     ASSERT_FALSE(receiver.checkTimeout());
@@ -158,7 +187,8 @@ TEST(PacketReceiverTimeoutLatch, SetTimeoutClearsADeclaredTimeout)
 
     pair.drainClient();
     receiver.setTimeout(Poco::Timespan(0, 10'000));
-    ::usleep(200'000);
+    ASSERT_TRUE(waitTimerReady(receiver.timerFd(), Poco::Timespan(5, 0)))
+        << "the receive timer never became ready, so this wake would not exercise the latch";
     ASSERT_FALSE(receiver.checkTimeout());
     ASSERT_TRUE(receiver.isTimeoutExpired());
 

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
@@ -115,13 +115,14 @@ bool RemoteQueryExecutorReadContext::checkTimeout(bool blocking)
     size_t num_events = epoll.getManyReady(3, events, blocking ? -1 : 0);
 
     bool is_socket_ready = false;
+    bool is_timer_ready = false;
 
     for (size_t i = 0; i < num_events; ++i)
     {
         if (events[i].data.fd == connection_fd)
             is_socket_ready = true;
         if (events[i].data.fd == timer.getDescriptor())
-            is_timer_alarmed = true;
+            is_timer_ready = true;
         if (events[i].data.fd == pipe_fd[0])
             is_pipe_alarmed = true;
     }
@@ -129,8 +130,14 @@ bool RemoteQueryExecutorReadContext::checkTimeout(bool blocking)
     if (is_pipe_alarmed)
         return false;
 
-    if (is_timer_alarmed && !is_socket_ready)
+    /// Timer readiness is only meaningful together with socket readiness observed in the
+    /// SAME wake: if both are ready the packet is delivered and no timeout happened, so
+    /// the observation must not be remembered as connection state.
+    if (is_timer_ready && !is_socket_ready)
     {
+        /// A timeout is declared for this connection; cancelBefore() relies on this to skip
+        /// waiting for a pending packet that can no longer arrive within the timeout.
+        is_timeout_declared = true;
         /// Socket timeout. Drain it in case of error, or it may be hide by timeout exception.
         timer.drain();
         const String exception_message = getSocketTimeoutExceededMessageByTimeoutType(timeout_type, timeout, connection_fd_description);
@@ -146,7 +153,7 @@ void RemoteQueryExecutorReadContext::cancelBefore()
     /// timeout because this will exceed the timeout.
     /// Anyway if the timeout is exceeded, then the connection will be shutdown
     /// (disconnected), so it will not left in an unsynchronised state.
-    if (!is_timer_alarmed)
+    if (!is_timeout_declared)
     {
         /// If query wasn't sent, just complete sending it.
         if (!is_query_sent)

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.h
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.h
@@ -16,6 +16,11 @@ namespace Poco::Net
 class Socket;
 }
 
+/// Grants the unit test access to checkTimeout()/cancelBefore() and to the receive-timeout state,
+/// which are otherwise internal. Keep in sync with the struct name in
+/// src/QueryPipeline/tests/gtest_remote_read_context_timeout_latch.cpp.
+struct RemoteReadContextTestAccess;
+
 namespace DB
 {
 
@@ -97,7 +102,9 @@ private:
     TimerDescriptor timer;
     Poco::Timespan timeout;
     AsyncEventTimeoutType timeout_type{};
-    std::atomic_bool is_timer_alarmed = false;
+    /// Whether a receive timeout was DECLARED (timer fd ready while the socket was not),
+    /// not merely whether the timer fd was ever observed ready.
+    std::atomic_bool is_timeout_declared = false;
     int connection_fd = -1;
     int pipe_fd[2] = { -1, -1 };
     std::atomic_bool is_pipe_alarmed = false;
@@ -108,6 +115,8 @@ private:
     bool suspend_when_query_sent = false;
     bool is_query_sent = false;
     const bool read_packet_type_separately = false;
+
+    friend struct ::RemoteReadContextTestAccess;
 };
 
 }

--- a/src/QueryPipeline/tests/gtest_remote_read_context_timeout_latch.cpp
+++ b/src/QueryPipeline/tests/gtest_remote_read_context_timeout_latch.cpp
@@ -25,7 +25,7 @@ namespace DB::ErrorCodes
 extern const int SOCKET_TIMEOUT;
 }
 
-/// Drives RemoteQueryExecutorReadContext::checkTimeout() and cancelBefore() directly. The read
+/// Drives RemoteQueryExecutorReadContext::checkTimeout and cancelBefore directly. The read
 /// context only needs a socket file descriptor and a timer, so a plain connected TCP socket pair
 /// is enough - no ClickHouse server and no query are involved.
 struct RemoteReadContextTestAccess
@@ -68,7 +68,7 @@ struct RemoteReadContextTestAccess
     void disarm() { context.clearAsyncEvent(); }
 
     /// Re-arm only the timer, leaving the epoll registration and `is_in_progress` untouched.
-    /// Used to put a bound on a blocking checkTimeout() so that a lost timeout verdict shows up
+    /// Used to put a bound on a blocking checkTimeout so that a lost timeout verdict shows up
     /// as a failure instead of an unobservable hang.
     void armTimerOnly(Poco::Timespan relative) { context.timer.setRelative(relative); }
 
@@ -78,7 +78,7 @@ struct RemoteReadContextTestAccess
 
     bool checkTimeout() { return context.checkTimeout(); }
 
-    /// cancelBefore() is only reachable through AsyncTaskExecutor::cancel(), which also destroys
+    /// cancelBefore is only reachable through AsyncTaskExecutor::cancel, which also destroys
     /// the fiber; calling it directly keeps the test to the state machine under test.
     void cancelBefore() { context.cancelBefore(); }
 
@@ -148,14 +148,8 @@ struct ConnectedPair
 
 }
 
-/// RemoteQueryExecutorReadContext::checkTimeout() observes the timer fd and the connection fd of
-/// one epoll wake. Timer readiness alone means nothing: it is a receive timeout only if the socket
-/// was NOT ready in the SAME wake. Historically the observation was stored in the
-/// `is_timer_alarmed` MEMBER before the conjunction was evaluated, and nothing ever cleared it, so
-/// a single wake carrying both a data packet and the timer expiry returned true (delivering the
-/// packet) and then left the context permanently "timed out": every later wake without socket
-/// readiness threw a spurious SOCKET_TIMEOUT even though the remote was sending progress packets
-/// on time.
+/// Timer readiness in one epoll wake is a receive timeout only if the socket was NOT ready in
+/// that same wake, so it must leave no residue on the context.
 TEST(RemoteReadContextTimeoutLatch, SimultaneousReadinessLeavesNoTimeoutResidue)
 {
     ConnectedPair pair;
@@ -172,7 +166,7 @@ TEST(RemoteReadContextTimeoutLatch, SimultaneousReadinessLeavesNoTimeoutResidue)
     EXPECT_NO_THROW(EXPECT_TRUE(ctx.checkTimeout()));
 
     /// The packet is consumed and the timer re-armed for the next one, as the async read path does
-    /// via clearAsyncEvent()/processAsyncEvent(). Consuming the bytes matters: epoll is
+    /// via clearAsyncEvent/processAsyncEvent. Consuming the bytes matters: epoll is
     /// level-triggered, so an unread byte would keep the socket ready and mask a latched timer.
     pair.drainClient();
     ctx.disarm();
@@ -207,11 +201,8 @@ TEST(RemoteReadContextTimeoutLatch, GenuineTimeoutStillThrows)
     }
 }
 
-/// cancelBefore() uses the "a timeout was declared" fact to decide whether it is safe to wait for
-/// the pending packet ("One should not try to wait for the current packet here in case of timeout
-/// because this will exceed the timeout"). That fact must survive across calls even though the raw
-/// per-wake observation must not: if it were lost, cancelling a genuinely timed-out connection
-/// would block for a full receive_timeout inside the drain loop.
+/// cancelBefore skips the drain when a timeout was declared, so that verdict must survive across
+/// calls: losing it would block cancellation for a full receive_timeout inside the drain loop.
 TEST(RemoteReadContextTimeoutLatch, CancelAfterDeclaredTimeoutDoesNotWaitForPendingPacket)
 {
     ConnectedPair pair;
@@ -223,28 +214,23 @@ TEST(RemoteReadContextTimeoutLatch, CancelAfterDeclaredTimeoutDoesNotWaitForPend
         << "the receive timer never became ready, so this wake would not exercise the latch";
     EXPECT_THROW(ctx.checkTimeout(), NetException);
 
-    /// The read is still in progress (no packet was delivered), so if the timeout verdict were
-    /// lost, cancelBefore() would enter its drain loop and call checkTimeout(blocking = true).
     ASSERT_TRUE(ctx.isInProgress());
 
-    /// Re-arm the timer with a short expiry so that such a blocking call is guaranteed to return
-    /// (by throwing SOCKET_TIMEOUT from inside cancelBefore()) instead of hanging the test
-    /// process forever. With the fix, cancelBefore() never looks at the timer at all.
+    /// Bounds the blocking checkTimeout the drain loop would make, so a lost verdict fails instead
+    /// of hanging. With the fix cancelBefore never looks at the timer at all.
     ctx.armTimerOnly(Poco::Timespan(1, 0));
 
-    /// The absence of a throw IS the structural signal that the drain loop was skipped: entering
-    /// it would call checkTimeout(blocking = true), which with the re-armed timer necessarily
-    /// throws SOCKET_TIMEOUT out of cancelBefore(). Asserting elapsed time instead would only
-    /// measure the re-armed expiry, not the branch taken.
+    /// The absence of a throw is the signal that the drain loop was skipped: entering it calls
+    /// checkTimeout(blocking = true), which with the re-armed timer necessarily throws out of
+    /// cancelBefore. Asserting elapsed time would only measure the re-armed expiry.
     EXPECT_NO_THROW(ctx.cancelBefore())
         << "cancelBefore() must not re-enter the read path for a connection that already timed out";
 }
 
-/// The other direction of the same contract, and the one the changelog entry promises: when NO
-/// timeout was declared, cancellation must still wait for the pending packet, because skipping
-/// the drain leaves the connection unsynchronised and its teardown surfaces as
-/// "Connection to ... terminated (NETWORK_ERROR)". This is exactly the state produced by a
-/// simultaneous-readiness wake, which the latch used to turn into "a timeout was seen".
+/// The other direction: without a declared timeout the drain must still happen, because skipping
+/// it leaves the connection unsynchronised and teardown surfaces as
+/// "Connection to ... terminated (NETWORK_ERROR)" - the state a simultaneous-readiness wake used
+/// to produce.
 TEST(RemoteReadContextTimeoutLatch, CancelWithoutDeclaredTimeoutDrainsPendingPacket)
 {
     ConnectedPair pair;
@@ -257,15 +243,11 @@ TEST(RemoteReadContextTimeoutLatch, CancelWithoutDeclaredTimeoutDrainsPendingPac
         << "the receive timer never became ready, so this wake would not exercise the latch";
     EXPECT_NO_THROW(EXPECT_TRUE(ctx.checkTimeout()));
 
-    /// The read is still pending, so cancellation owes it a drain.
     ASSERT_TRUE(ctx.isInProgress());
 
-    /// Consume the byte and re-arm the timer with a short expiry. The drain loop's first statement
-    /// is checkTimeout(blocking = true), which then observes "timer ready, socket not ready" and
-    /// throws SOCKET_TIMEOUT out of cancelBefore(). That throw is the observable: it can only
-    /// originate inside the drain loop, so it proves the loop was entered, and it also keeps the
-    /// loop from reaching resumeUnlocked() on a connection that has no server behind it. A guard
-    /// that always skipped the drain would make cancelBefore() return without throwing.
+    /// The throw is the observable: it can only originate in the drain loop's blocking
+    /// checkTimeout, so it proves the loop was entered, and it stops the loop short of
+    /// resumeUnlocked on a connection with no server behind it.
     pair.drainClient();
     ctx.armTimerOnly(Poco::Timespan(0, 100'000));
 

--- a/src/QueryPipeline/tests/gtest_remote_read_context_timeout_latch.cpp
+++ b/src/QueryPipeline/tests/gtest_remote_read_context_timeout_latch.cpp
@@ -1,0 +1,215 @@
+#if defined(OS_LINUX) || defined(OS_DARWIN)
+
+#include <gtest/gtest.h>
+
+#include <Client/Connection.h>
+#include <Common/NetException.h>
+#include <Common/tests/gtest_global_context.h>
+#include <Core/Block.h>
+#include <QueryPipeline/RemoteQueryExecutor.h>
+#include <QueryPipeline/RemoteQueryExecutorReadContext.h>
+
+#include <Poco/Net/ServerSocket.h>
+#include <Poco/Net/SocketAddress.h>
+#include <Poco/Net/StreamSocket.h>
+
+#include <chrono>
+#include <unistd.h>
+
+using namespace DB;
+
+namespace DB::ErrorCodes
+{
+extern const int SOCKET_TIMEOUT;
+}
+
+/// Drives RemoteQueryExecutorReadContext::checkTimeout() and cancelBefore() directly. The read
+/// context only needs a socket file descriptor and a timer, so a plain connected TCP socket pair
+/// is enough - no ClickHouse server and no query are involved.
+struct RemoteReadContextTestAccess
+{
+    Connection connection;
+    RemoteQueryExecutor executor;
+    RemoteQueryExecutorReadContext context;
+
+    explicit RemoteReadContextTestAccess(const ContextPtr & query_context)
+        : connection(
+              "127.0.0.1",
+              /*port_=*/0,
+              /*default_database_=*/"",
+              /*user_=*/"default",
+              /*password_=*/"",
+              /*proto_send_chunked_=*/"notchunked",
+              /*proto_recv_chunked_=*/"notchunked",
+              SSHKey(),
+              /*jwt_=*/"",
+              /*quota_key_=*/"",
+              /*cluster_=*/"",
+              /*cluster_secret_=*/"",
+              /*client_name_=*/"gtest",
+              Protocol::Compression::Disable,
+              Protocol::Secure::Disable,
+              /*tls_sni_override_=*/"",
+              /*bind_host_=*/"")
+        , executor(connection, "SELECT 1", std::make_shared<const Block>(Block{}), query_context)
+        , context(executor, /*suspend_when_query_sent_=*/false, /*read_packet_type_separately_=*/false)
+    {
+    }
+
+    /// Register `fd` as the connection descriptor and arm the receive timer, exactly as the
+    /// async read path does when a read on the socket would block.
+    void armReceiveTimeout(int fd, Poco::Timespan receive_timeout)
+    {
+        context.processAsyncEvent(fd, receive_timeout, AsyncEventTimeoutType::RECEIVE, "socket (test)", AsyncTaskExecutor::Event::READ);
+    }
+
+    void disarm() { context.clearAsyncEvent(); }
+
+    /// Re-arm only the timer, leaving the epoll registration and `is_in_progress` untouched.
+    /// Used to put a bound on a blocking checkTimeout() so that a lost timeout verdict shows up
+    /// as a failure instead of an unobservable hang.
+    void armTimerOnly(Poco::Timespan relative) { context.timer.setRelative(relative); }
+
+    bool checkTimeout() { return context.checkTimeout(); }
+
+    /// cancelBefore() is only reachable through AsyncTaskExecutor::cancel(), which also destroys
+    /// the fiber; calling it directly keeps the test to the state machine under test.
+    void cancelBefore() { context.cancelBefore(); }
+
+    bool isInProgress() const { return context.isInProgress(); }
+};
+
+namespace
+{
+
+/// A connected TCP socket pair whose client end can be made readable on demand. The kernel
+/// listen backlog completes the handshake, so no server thread is needed.
+struct ConnectedPair
+{
+    Poco::Net::ServerSocket listener{Poco::Net::SocketAddress("127.0.0.1", 0), 1};
+    Poco::Net::StreamSocket client;
+    Poco::Net::StreamSocket server;
+
+    ConnectedPair()
+    {
+        client.connect(listener.address());
+        server = listener.acceptConnection();
+    }
+
+    int clientFd() const { return const_cast<Poco::Net::StreamSocket &>(client).impl()->sockfd(); }
+
+    /// Make the client end readable and wait until the kernel reports it as such, so a
+    /// subsequent epoll wake deterministically sees the socket ready.
+    void makeClientReadable()
+    {
+        const char byte = 'x';
+        server.sendBytes(&byte, 1);
+        ASSERT_TRUE(client.poll(Poco::Timespan(5, 0), Poco::Net::Socket::SELECT_READ));
+    }
+
+    /// epoll is level-triggered, so unread bytes keep the socket ready in every later wake.
+    /// Consuming them is what lets a subsequent wake observe "neither descriptor ready".
+    void drainClient()
+    {
+        char buf[64];
+        while (client.poll(Poco::Timespan(0, 0), Poco::Net::Socket::SELECT_READ))
+        {
+            if (client.receiveBytes(buf, sizeof(buf)) <= 0)
+                break;
+        }
+    }
+};
+
+}
+
+/// RemoteQueryExecutorReadContext::checkTimeout() observes the timer fd and the connection fd of
+/// one epoll wake. Timer readiness alone means nothing: it is a receive timeout only if the socket
+/// was NOT ready in the SAME wake. Historically the observation was stored in the
+/// `is_timer_alarmed` MEMBER before the conjunction was evaluated, and nothing ever cleared it, so
+/// a single wake carrying both a data packet and the timer expiry returned true (delivering the
+/// packet) and then left the context permanently "timed out": every later wake without socket
+/// readiness threw a spurious SOCKET_TIMEOUT even though the remote was sending progress packets
+/// on time.
+TEST(RemoteReadContextTimeoutLatch, SimultaneousReadinessLeavesNoTimeoutResidue)
+{
+    ConnectedPair pair;
+    RemoteReadContextTestAccess ctx(getContext().context);
+
+    /// Arm a short receive timeout, let it expire, and make the socket readable as well, so the
+    /// next epoll wake reports BOTH descriptors.
+    ctx.armReceiveTimeout(pair.clientFd(), Poco::Timespan(0, 10'000));
+    pair.makeClientReadable();
+    ::usleep(200'000);
+
+    /// Both ready => a packet is available => this is not a receive timeout.
+    EXPECT_NO_THROW(EXPECT_TRUE(ctx.checkTimeout()));
+
+    /// The packet is consumed and the timer re-armed for the next one, as the async read path does
+    /// via clearAsyncEvent()/processAsyncEvent(). Consuming the bytes matters: epoll is
+    /// level-triggered, so an unread byte would keep the socket ready and mask a latched timer.
+    pair.drainClient();
+    ctx.disarm();
+    ctx.armReceiveTimeout(pair.clientFd(), Poco::Timespan(30, 0));
+
+    /// Now NEITHER descriptor is ready. A latched observation from the previous wake is the only
+    /// thing that could make this throw.
+    EXPECT_NO_THROW(EXPECT_TRUE(ctx.checkTimeout()))
+        << "a wake in which the socket was ready must not leave the connection permanently timed out";
+}
+
+/// The regression guard for the opposite direction: a genuine receive timeout (timer ready, socket
+/// NOT ready) must still throw SOCKET_TIMEOUT.
+TEST(RemoteReadContextTimeoutLatch, GenuineTimeoutStillThrows)
+{
+    ConnectedPair pair;
+    RemoteReadContextTestAccess ctx(getContext().context);
+
+    ctx.armReceiveTimeout(pair.clientFd(), Poco::Timespan(0, 10'000));
+    ::usleep(200'000);
+
+    try
+    {
+        ctx.checkTimeout();
+        FAIL() << "a genuine receive timeout must throw";
+    }
+    catch (const NetException & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::SOCKET_TIMEOUT);
+        EXPECT_NE(std::string(e.message()).find("Timeout exceeded while reading from socket"), std::string::npos) << e.message();
+    }
+}
+
+/// cancelBefore() uses the "a timeout was declared" fact to decide whether it is safe to wait for
+/// the pending packet ("One should not try to wait for the current packet here in case of timeout
+/// because this will exceed the timeout"). That fact must survive across calls even though the raw
+/// per-wake observation must not: if it were lost, cancelling a genuinely timed-out connection
+/// would block for a full receive_timeout inside the drain loop.
+TEST(RemoteReadContextTimeoutLatch, CancelAfterDeclaredTimeoutDoesNotWaitForPendingPacket)
+{
+    ConnectedPair pair;
+    RemoteReadContextTestAccess ctx(getContext().context);
+
+    /// Declare a timeout: timer ready, socket not ready.
+    ctx.armReceiveTimeout(pair.clientFd(), Poco::Timespan(0, 10'000));
+    ::usleep(200'000);
+    EXPECT_THROW(ctx.checkTimeout(), NetException);
+
+    /// The read is still in progress (no packet was delivered), so if the timeout verdict were
+    /// lost, cancelBefore() would enter its drain loop and call checkTimeout(blocking = true).
+    ASSERT_TRUE(ctx.isInProgress());
+
+    /// Re-arm the timer with a short expiry so that such a blocking call is guaranteed to return
+    /// (by throwing SOCKET_TIMEOUT from inside cancelBefore()) instead of hanging the test
+    /// process forever. With the fix, cancelBefore() never looks at the timer at all.
+    ctx.armTimerOnly(Poco::Timespan(1, 0));
+
+    const auto start = std::chrono::steady_clock::now();
+    EXPECT_NO_THROW(ctx.cancelBefore())
+        << "cancelBefore() must not re-enter the read path for a connection that already timed out";
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 500)
+        << "cancelBefore() must skip waiting for a packet that can no longer arrive within the timeout";
+}
+
+#endif

--- a/src/QueryPipeline/tests/gtest_remote_read_context_timeout_latch.cpp
+++ b/src/QueryPipeline/tests/gtest_remote_read_context_timeout_latch.cpp
@@ -13,7 +13,9 @@
 #include <Poco/Net/SocketAddress.h>
 #include <Poco/Net/StreamSocket.h>
 
+#include <cerrno>
 #include <chrono>
+#include <poll.h>
 #include <unistd.h>
 
 using namespace DB;
@@ -70,6 +72,10 @@ struct RemoteReadContextTestAccess
     /// as a failure instead of an unobservable hang.
     void armTimerOnly(Poco::Timespan relative) { context.timer.setRelative(relative); }
 
+    /// The receive timer's descriptor, so a test can wait for it to actually fire instead of
+    /// assuming a fixed sleep was long enough.
+    int timerFd() const { return context.timer.getDescriptor(); }
+
     bool checkTimeout() { return context.checkTimeout(); }
 
     /// cancelBefore() is only reachable through AsyncTaskExecutor::cancel(), which also destroys
@@ -120,6 +126,26 @@ struct ConnectedPair
     }
 };
 
+/// Wait until the receive timer's descriptor is readable, so the following epoll wake is
+/// guaranteed to report it. A fixed sleep can return early (EINTR, or an oversubscribed host),
+/// and in a test where the socket is deliberately readable that would leave a socket-only wake,
+/// which satisfies the same assertions for the wrong reason.
+[[nodiscard]] bool waitTimerReady(int timer_fd, Poco::Timespan limit)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::microseconds(limit.totalMicroseconds());
+    while (true)
+    {
+        pollfd p{.fd = timer_fd, .events = POLLIN, .revents = 0};
+        const int rc = ::poll(&p, 1, 50);
+        if (rc == 1 && (p.revents & POLLIN))
+            return true;
+        if (rc == -1 && errno != EINTR)
+            return false;
+        if (std::chrono::steady_clock::now() >= deadline)
+            return false;
+    }
+}
+
 }
 
 /// RemoteQueryExecutorReadContext::checkTimeout() observes the timer fd and the connection fd of
@@ -139,7 +165,8 @@ TEST(RemoteReadContextTimeoutLatch, SimultaneousReadinessLeavesNoTimeoutResidue)
     /// next epoll wake reports BOTH descriptors.
     ctx.armReceiveTimeout(pair.clientFd(), Poco::Timespan(0, 10'000));
     pair.makeClientReadable();
-    ::usleep(200'000);
+    ASSERT_TRUE(waitTimerReady(ctx.timerFd(), Poco::Timespan(5, 0)))
+        << "the receive timer never became ready, so this wake would not exercise the latch";
 
     /// Both ready => a packet is available => this is not a receive timeout.
     EXPECT_NO_THROW(EXPECT_TRUE(ctx.checkTimeout()));
@@ -165,7 +192,8 @@ TEST(RemoteReadContextTimeoutLatch, GenuineTimeoutStillThrows)
     RemoteReadContextTestAccess ctx(getContext().context);
 
     ctx.armReceiveTimeout(pair.clientFd(), Poco::Timespan(0, 10'000));
-    ::usleep(200'000);
+    ASSERT_TRUE(waitTimerReady(ctx.timerFd(), Poco::Timespan(5, 0)))
+        << "the receive timer never became ready, so this wake would not exercise the latch";
 
     try
     {
@@ -191,7 +219,8 @@ TEST(RemoteReadContextTimeoutLatch, CancelAfterDeclaredTimeoutDoesNotWaitForPend
 
     /// Declare a timeout: timer ready, socket not ready.
     ctx.armReceiveTimeout(pair.clientFd(), Poco::Timespan(0, 10'000));
-    ::usleep(200'000);
+    ASSERT_TRUE(waitTimerReady(ctx.timerFd(), Poco::Timespan(5, 0)))
+        << "the receive timer never became ready, so this wake would not exercise the latch";
     EXPECT_THROW(ctx.checkTimeout(), NetException);
 
     /// The read is still in progress (no packet was delivered), so if the timeout verdict were
@@ -203,13 +232,52 @@ TEST(RemoteReadContextTimeoutLatch, CancelAfterDeclaredTimeoutDoesNotWaitForPend
     /// process forever. With the fix, cancelBefore() never looks at the timer at all.
     ctx.armTimerOnly(Poco::Timespan(1, 0));
 
-    const auto start = std::chrono::steady_clock::now();
+    /// The absence of a throw IS the structural signal that the drain loop was skipped: entering
+    /// it would call checkTimeout(blocking = true), which with the re-armed timer necessarily
+    /// throws SOCKET_TIMEOUT out of cancelBefore(). Asserting elapsed time instead would only
+    /// measure the re-armed expiry, not the branch taken.
     EXPECT_NO_THROW(ctx.cancelBefore())
         << "cancelBefore() must not re-enter the read path for a connection that already timed out";
-    const auto elapsed = std::chrono::steady_clock::now() - start;
+}
 
-    EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 500)
-        << "cancelBefore() must skip waiting for a packet that can no longer arrive within the timeout";
+/// The other direction of the same contract, and the one the changelog entry promises: when NO
+/// timeout was declared, cancellation must still wait for the pending packet, because skipping
+/// the drain leaves the connection unsynchronised and its teardown surfaces as
+/// "Connection to ... terminated (NETWORK_ERROR)". This is exactly the state produced by a
+/// simultaneous-readiness wake, which the latch used to turn into "a timeout was seen".
+TEST(RemoteReadContextTimeoutLatch, CancelWithoutDeclaredTimeoutDrainsPendingPacket)
+{
+    ConnectedPair pair;
+    RemoteReadContextTestAccess ctx(getContext().context);
+
+    /// A simultaneous-readiness wake: the packet is there, so no timeout is declared.
+    ctx.armReceiveTimeout(pair.clientFd(), Poco::Timespan(0, 10'000));
+    pair.makeClientReadable();
+    ASSERT_TRUE(waitTimerReady(ctx.timerFd(), Poco::Timespan(5, 0)))
+        << "the receive timer never became ready, so this wake would not exercise the latch";
+    EXPECT_NO_THROW(EXPECT_TRUE(ctx.checkTimeout()));
+
+    /// The read is still pending, so cancellation owes it a drain.
+    ASSERT_TRUE(ctx.isInProgress());
+
+    /// Consume the byte and re-arm the timer with a short expiry. The drain loop's first statement
+    /// is checkTimeout(blocking = true), which then observes "timer ready, socket not ready" and
+    /// throws SOCKET_TIMEOUT out of cancelBefore(). That throw is the observable: it can only
+    /// originate inside the drain loop, so it proves the loop was entered, and it also keeps the
+    /// loop from reaching resumeUnlocked() on a connection that has no server behind it. A guard
+    /// that always skipped the drain would make cancelBefore() return without throwing.
+    pair.drainClient();
+    ctx.armTimerOnly(Poco::Timespan(0, 100'000));
+
+    try
+    {
+        ctx.cancelBefore();
+        FAIL() << "cancelBefore() must drain the pending packet when no timeout was declared";
+    }
+    catch (const NetException & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::SOCKET_TIMEOUT);
+    }
 }
 
 #endif


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

No related open issue found. The regression test whose invariant this restores is `02805_distributed_queries_timeouts`, added by commit 4669951db550f4 ("Fix timeout for hedged requests"), removed for flakiness by https://github.com/ClickHouse/ClickHouse/pull/66563 and reintroduced with a wider margin by https://github.com/ClickHouse/ClickHouse/pull/67106.

CI reports for the failures this fixes (the failing checks belong to unrelated pull requests, so they are linked as reports rather than as pull request references). Each one is labelled with the statement of `02805_distributed_queries_timeouts` that failed, so the attribution can be checked in one click:

- line 4, hedged path, `HedgedConnections::resumePacketReceiver`, `Stateless tests (amd_msan, WasmEdge, parallel, 2/2)`: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112083&sha=67a6ecc5b2e584b344f5208cddeee29b4895f14a&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F2%29
- line 4, hedged path, `Stateless tests (arm_asan_ubsan, azure, parallel)`: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110215&sha=f34341a1daeac43163f56f8712e96181bcf4f7ac&name_0=PR&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20azure%2C%20parallel%29
- line 5, async path, `RemoteQueryExecutorReadContext::checkTimeout`, `Stateless tests (amd_tsan, parallel)`: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109490&sha=0ad689784288cc72d7976732460395359de7171b&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%29

The same test has also failed once on its synchronous statement (line 6, on master, commit 862617d42f2b1afd2dee121b90f02e3a86114e0a). That failure carries the `peer: ..., local: ..., 7000 ms` message, which only `ReadBufferFromPocoSocket` emits from a `Poco::TimeoutException` on a single `recv`, rather than the `(socket description, receive timeout N ms)` message that both changed carriers produce. It comes from the synchronous path and this change does not address it. That report also contains a `RemoteSource: Error occurs on cancellation ... (NETWORK_ERROR)` line, so that log alone does not identify the latch: it appears on the synchronous failure too, and on neither of the two hedged failures above. It does appear on the async failure, which is the one path where the latch reaches `cancelBefore()`. The message that identifies a carrier is the timeout message form, not the cancellation log.


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a spurious `SOCKET_TIMEOUT` ("Timeout exceeded while reading from socket") on distributed queries. When one epoll wake reported the receive timer and the socket as ready at the same time, the packet was delivered correctly but the connection was permanently marked as timed out, so a later packet failed the query even though the remote replica was responding on time. Affects reads with `use_hedged_requests = 1` and with `async_socket_for_remote = 1`.


### Description

`PacketReceiver::checkTimeout` and `RemoteQueryExecutorReadContext::checkTimeout` inspect the descriptors returned by one epoll wake, and both set a member flag (`is_timeout_expired`, `is_timer_alarmed`) as soon as the timer descriptor appears, before the flag is combined with socket readiness on the next line. Nothing ever clears either flag: each has exactly one write and no assignment back to `false`, and neither `clearAsyncEvent()` nor `AsyncTaskExecutor::restart()` resets it.

A wake in which the socket and the timer are ready at the same time therefore returns `true` and delivers its packet correctly, while leaving the connection permanently flagged as timed out. What follows depends on the read path:

* With `use_hedged_requests = 1`, `isPacketReady()` is stuck `false`, so `HedgedConnections::resumePacketReceiver` can no longer take the packet-ready branch, falls through to `isTimeoutExpired()` and throws `SOCKET_TIMEOUT`. The per-packet `setTimeout()` re-arm in the packet-ready branch also becomes unreachable, which silently disables the property that `receive_timeout` is a per-packet idle timeout rather than a total query timeout.
* With `async_socket_for_remote = 1`, the latched flag makes the guard throw on the first later wake in which the socket is not ready, which is the ordinary case while the remote is still producing the result. It also makes `cancelBefore()` skip draining the pending packet, so the connection is torn down unsynchronised and cancellation logs `Connection to ... terminated (NETWORK_ERROR)`.

The synchronous path (`use_hedged_requests = 0`, `async_socket_for_remote = 0`) has no epoll timer and is unaffected.

Timer readiness observed in a single wake only means "a receive timeout happened" when the socket was not ready in that same wake, so it must not be stored as connection state. This makes the observation a function-local in both places, and keeps a member that records only the verdict of the conjunction, set exclusively in the branch that already declares the timeout. `PacketReceiver::setTimeout()` clears that verdict, because re-arming the timer starts a new receive interval. `ConnectionEstablisherAsync::checkTimeout`, the third and only other `AsyncTaskExecutor`, already uses a function-local for the identical loop and is left unchanged as the reference. No setting, no on-disk or wire format and no protocol is affected.

One consumer therefore sees a narrower predicate, deliberately. `cancelBefore()` skips draining the pending packet when a timeout has been declared, because waiting would exceed the timeout that already fired. Previously it skipped the drain after any wake in which the timer descriptor had merely appeared, including a wake that delivered a packet; now it skips it only after a timeout was actually declared. For a connection that saw such a wake and is later cancelled, cancellation therefore drains the pending packet again, which is what every connection that never hit the coincidence already did, and is the reason the `NETWORK_ERROR` on cancellation disappears together with the spurious timeout.

#### How it was verified

The end-to-end failure needs a scheduling coincidence and is not reliably reproducible, so the fix was measured rather than raced. Instrumented builds counted, on the hedged path under the same scenario: on unfixed master, 12 thrown timeouts arising from a single wake that genuinely observed "timer expired and no data", so 11 of 12 were spurious; with the fix, 8 thrown timeouts backed by exactly 8 such wakes, while simultaneous-readiness wakes were more than twice as frequent. The invariant the fix establishes is that a thrown timeout always corresponds to a wake that actually observed an idle socket.

Two unit tests (seven cases) drive the production `checkTimeout()` and `cancelBefore()` against a real connected socket pair without a server or a query, and cover both directions: a simultaneous-readiness wake leaves no residue and the receiver stays usable; a genuine timeout is still declared, still throws `SOCKET_TIMEOUT`, still persists for `HedgedConnections`, and still lets `cancelBefore()` skip waiting for a packet that can no longer arrive; and cancelling a connection that never declared a timeout still drains its pending packet, which is the half that keeps the connection synchronised. Instead of sleeping for a fixed interval, each case waits for the timer descriptor to become readable and fails if it does not, so no case can pass on a wake that never carried the timer. Each of the six production hunks was reverted individually and at least one assertion fails per hunk while the rest still pass; two of the six break two assertions each, because the verdict they record is read in two places.

Because both unit tests reach internals through a `friend` declaration added to the production headers, the `Bugfix validation (unit tests)` job cannot build its merge-base "before" binary with only the test files overlaid, and reports that as inconclusive rather than as a reproduction. The equivalent evidence is the mutation run above, which reverts each production hunk on the current tree instead of the whole commit.

`02805_distributed_queries_timeouts` is the regression test for the per-packet timeout property that the latch was disabling. It is not modified: the fix makes its invariant hold rather than relaxing the test, which had already been widened once and removed once (#66563) for this flakiness. These seven stateless tests were run against a pristine master binary and against the fixed binary, and the failure sets are identical: `01602_max_distributed_connections`, `01731_async_task_queue_wait`, `01822_async_read_from_socket_crash`, `01851_hedged_connections_external_tables`, `02466_distributed_query_profiler`, `02805_distributed_queries_timeouts`, `03444_distributed_hedged_requests_async_socket`. They were picked by hand as the ones whose subject is the async or hedged remote-read path itself; a plain grep for `receive_timeout`, `use_hedged_requests` or `async_socket_for_remote` matches 46 stateless tests, of which 19 also perform a distributed or remote read, so the seven are a selection rather than the full grep result.
