### PR TITLE
Fix reading a LowCardinality subcolumn of Nullable(Tuple(...)) together with its parent

### DIFF
--- a/src/DataTypes/NullableUtils.cpp
+++ b/src/DataTypes/NullableUtils.cpp
@@ -197,9 +197,13 @@ SerializationPtr NullableSubcolumnCreator::create(const SerializationPtr & prev_
         /// (non-nullable) serialization so the on-disk stream layout is unchanged; the wrapper reads the
         /// `LowCardinality(T)` column and `applyParentNullMapToExtractedSubcolumn` promotes it to
         /// `LowCardinality(Nullable(T))` before folding in the outer null map, keeping the read
-        /// (type, column) pair consistent with the in-memory one.
-        if (canContainNull(*prev_type) || prev_type->lowCardinality())
+        /// (type, column) pair consistent with the in-memory one. `prev_type` is passed to the wrapper in
+        /// that case, because the promoted result column is not the on-disk representation to deserialize
+        /// into.
+        if (canContainNull(*prev_type))
             return SerializationNullableWithParentNullMap::create(prev_serialization);
+        if (prev_type->lowCardinality())
+            return SerializationNullableWithParentNullMap::create(prev_serialization, prev_type);
         return prev_serialization;
     }
 

--- a/src/DataTypes/Serializations/SerializationNullableWithParentNullMap.cpp
+++ b/src/DataTypes/Serializations/SerializationNullableWithParentNullMap.cpp
@@ -33,7 +33,11 @@ UInt128 SerializationNullableWithParentNullMap::getHash(const SerializationPtr &
     /// a pooled instance.
     hash.update(on_disk_type_ != nullptr);
     if (on_disk_type_)
-        hash.update(on_disk_type_->getName());
+    {
+        auto on_disk_type_name = on_disk_type_->getName();
+        hash.update(on_disk_type_name.size());
+        hash.update(on_disk_type_name);
+    }
     return hash.get128();
 }
 

--- a/src/DataTypes/Serializations/SerializationNullableWithParentNullMap.cpp
+++ b/src/DataTypes/Serializations/SerializationNullableWithParentNullMap.cpp
@@ -1,5 +1,6 @@
 #include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/IDataType.h>
 #include <DataTypes/NullableUtils.h>
 #include <DataTypes/Serializations/SerializationNullableWithParentNullMap.h>
 #include <DataTypes/Serializations/SerializationNumber.h>
@@ -16,24 +17,32 @@ namespace ErrorCodes
 extern const int LOGICAL_ERROR;
 }
 
-SerializationNullableWithParentNullMap::SerializationNullableWithParentNullMap(const SerializationPtr & nested_)
+SerializationNullableWithParentNullMap::SerializationNullableWithParentNullMap(
+    const SerializationPtr & nested_, const DataTypePtr & on_disk_type_)
     : SerializationWrapper(nested_)
+    , on_disk_type(on_disk_type_)
 {
 }
 
-UInt128 SerializationNullableWithParentNullMap::getHash(const SerializationPtr & nested_)
+UInt128 SerializationNullableWithParentNullMap::getHash(const SerializationPtr & nested_, const DataTypePtr & on_disk_type_)
 {
     SipHash hash;
     hash.update("NullableWithParentNullMap");
     hash.update(nested_->getHash());
+    /// The on-disk type decides how the deserialization buffer is built, so the two flavours must not share
+    /// a pooled instance.
+    hash.update(on_disk_type_ != nullptr);
+    if (on_disk_type_)
+        hash.update(on_disk_type_->getName());
     return hash.get128();
 }
 
-SerializationPtr SerializationNullableWithParentNullMap::create(const SerializationPtr & nested_)
+SerializationPtr SerializationNullableWithParentNullMap::create(const SerializationPtr & nested_, const DataTypePtr & on_disk_type_)
 {
     if (!nested_->supportsPooling())
-        return std::shared_ptr<ISerialization>(new SerializationNullableWithParentNullMap(nested_));
-    return ISerialization::pooled(getHash(nested_), [&] { return new SerializationNullableWithParentNullMap(nested_); });
+        return std::shared_ptr<ISerialization>(new SerializationNullableWithParentNullMap(nested_, on_disk_type_));
+    return ISerialization::pooled(
+        getHash(nested_, on_disk_type_), [&] { return new SerializationNullableWithParentNullMap(nested_, on_disk_type_); });
 }
 
 void SerializationNullableWithParentNullMap::enumerateStreams(
@@ -93,7 +102,11 @@ void SerializationNullableWithParentNullMap::deserializeBinaryBulkWithMultipleSt
     /// applied below physically removes the parent-NULL rows from them. A column that is published must
     /// never be mutated afterwards, otherwise a reader of the whole parent column adopts the shortened
     /// substream from the cache while computing its own offsets from the unfiltered row count.
-    ColumnPtr range_column = column->cloneEmpty();
+    /// For a promoted non-nullable `LowCardinality(T)` the result column is `LowCardinality(Nullable(T))`,
+    /// which is not the on-disk representation: build the buffer from the on-disk type instead, so that the
+    /// published substreams are the ones a reader of the whole parent column expects. The promotion of this
+    /// private buffer happens below, in `applyParentNullMapToExtractedSubcolumn`.
+    ColumnPtr range_column = on_disk_type ? on_disk_type->createColumn(*nested_serialization) : column->cloneEmpty();
 
     /// A cached column can contain rows from multiple ranges, so copy only the rows of the current range
     /// from it, keeping `range_column` exactly the size of the current range.

--- a/src/DataTypes/Serializations/SerializationNullableWithParentNullMap.h
+++ b/src/DataTypes/Serializations/SerializationNullableWithParentNullMap.h
@@ -22,7 +22,10 @@ namespace DB
 class SerializationNullableWithParentNullMap final : public SerializationWrapper
 {
 public:
-    static SerializationPtr create(const SerializationPtr & nested_);
+    /// `on_disk_type_` is set only when the subcolumn's type was promoted from a non-nullable
+    /// `LowCardinality(T)` to `LowCardinality(Nullable(T))`; the deserialization buffer is then built from
+    /// it so that the substreams published to the shared cache keep the on-disk representation.
+    static SerializationPtr create(const SerializationPtr & nested_, const DataTypePtr & on_disk_type_ = nullptr);
 
     void enumerateStreams(EnumerateStreamsSettings & settings, const StreamCallback & callback, const SubstreamData & data) const override;
 
@@ -40,8 +43,11 @@ public:
         SubstreamsCache * cache) const override;
 
 private:
-    explicit SerializationNullableWithParentNullMap(const SerializationPtr & nested_);
-    static UInt128 getHash(const SerializationPtr & nested_);
+    SerializationNullableWithParentNullMap(const SerializationPtr & nested_, const DataTypePtr & on_disk_type_);
+    static UInt128 getHash(const SerializationPtr & nested_, const DataTypePtr & on_disk_type_);
+
+    /// Not null only for the promoted non-nullable `LowCardinality(T)` case, see `create()`.
+    const DataTypePtr on_disk_type;
 };
 
 }

--- a/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.reference
+++ b/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.reference
@@ -23,17 +23,20 @@ SELECT x.a.b, x.a FROM t_04651_no_nulls;
 3	(3)
 DROP TABLE t_04651_no_nulls;
 -- The reported shape: child, whole column, parent, and `assumeNotNull` over the parent in one query.
+-- `assumeNotNull` has an unspecified result on a NULL input, so its value is never asserted here: it is
+-- wrapped in `ignore` so that it is still evaluated, because what the bug breaks is its return-type
+-- post-condition and not the value it returns.
 DROP TABLE IF EXISTS t_04651_compact;
 CREATE TABLE t_04651_compact (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
 SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, write_marks_for_substreams_in_compact_parts = 1;
 INSERT INTO t_04651_compact SELECT number % 2 ? tuple(NULL) : tuple(tuple(number)) FROM numbers(4);
 SELECT toTypeName(x.a.b), toTypeName(x.a) FROM t_04651_compact LIMIT 1;
 LowCardinality(Nullable(UInt32))	Nullable(Tuple(b LowCardinality(UInt32)))
-SELECT x.a.b, x, x.a, isNull(x.a.b), assumeNotNull(x.a) FROM t_04651_compact;
-0	((0))	(0)	0	(0)
-\N	(NULL)	\N	1	(1)
-2	((2))	(2)	0	(2)
-\N	(NULL)	\N	1	(3)
+SELECT x.a.b, x, x.a, isNull(x.a.b), ignore(assumeNotNull(x.a)) FROM t_04651_compact;
+0	((0))	(0)	0	0
+\N	(NULL)	\N	1	0
+2	((2))	(2)	0	0
+\N	(NULL)	\N	1	0
 SELECT x.a.b, x.a FROM t_04651_compact;
 0	(0)
 \N	\N
@@ -71,11 +74,11 @@ s0	('s0')	s0\0	('s0\0')	1970-01-01	('1970-01-01')	0	(0,0)
 \N	\N	\N	\N	\N	\N	\N	\N
 s2	('s2')	s2\0	('s2\0')	1970-01-03	('1970-01-03')	2	(2,2)
 \N	\N	\N	\N	\N	\N	\N	\N
-SELECT assumeNotNull(s.a), assumeNotNull(m.a) FROM t_04651_leaves;
-('s0')	(0,0)
-('')	(1,1)
-('s2')	(2,2)
-('')	(3,3)
+SELECT ignore(assumeNotNull(s.a)), ignore(assumeNotNull(m.a)) FROM t_04651_leaves;
+0	0
+0	0
+0	0
+0	0
 DROP TABLE t_04651_leaves;
 -- A leaf that is `LowCardinality(Nullable(T))` on disk must NOT be de-nullabilised: its stream really is
 -- nullable, so the buffer has to stay as it is.
@@ -101,22 +104,22 @@ DROP TABLE IF EXISTS t_04651_wide;
 CREATE TABLE t_04651_wide (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
 SETTINGS index_granularity = 1, min_bytes_for_wide_part = 0;
 INSERT INTO t_04651_wide SELECT number % 2 ? tuple(NULL) : tuple(tuple(number)) FROM numbers(4);
-SELECT x.a.b, x.a, assumeNotNull(x.a) FROM t_04651_wide;
-0	(0)	(0)
-\N	\N	(1)
-2	(2)	(2)
-\N	\N	(3)
+SELECT x.a.b, x.a, ignore(assumeNotNull(x.a)) FROM t_04651_wide;
+0	(0)	0
+\N	\N	0
+2	(2)	0
+\N	\N	0
 DROP TABLE t_04651_wide;
 -- Top-level `Nullable(Tuple(...))` control: the element is read without the outer `Tuple` in the path.
 DROP TABLE IF EXISTS t_04651_top_level;
 CREATE TABLE t_04651_top_level (id UInt8, x Nullable(Tuple(b LowCardinality(UInt32)))) ENGINE = MergeTree ORDER BY id
 SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
 INSERT INTO t_04651_top_level SELECT number, number % 2 ? NULL : tuple(number) FROM numbers(4);
-SELECT x.b, x, assumeNotNull(x) FROM t_04651_top_level ORDER BY id;
-0	(0)	(0)
-\N	\N	(1)
-2	(2)	(2)
-\N	\N	(3)
+SELECT x.b, x, ignore(assumeNotNull(x)) FROM t_04651_top_level ORDER BY id;
+0	(0)	0
+\N	\N	0
+2	(2)	0
+\N	\N	0
 DROP TABLE t_04651_top_level;
 -- Several granule ranges per block, so the cached substream carries rows of more than one range.
 DROP TABLE IF EXISTS t_04651_ranges;

--- a/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.reference
+++ b/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.reference
@@ -6,8 +6,8 @@
 
 SET enable_nullable_tuple_type = 1;
 SET allow_suspicious_low_cardinality_types = 1;
--- Reading the child `x.a.b` must not change what the parent `x.a` reads: the parent's dictionary stayed
--- non-nullable, so it gained the NULL placeholder even though the data holds no NULL at all.
+-- Reading the child `x.a.b` must not change what the parent `x.a` reads: the parent's dictionary must stay
+-- non-nullable and must not gain a NULL placeholder. Before the fix it gained one, with no NULL in the data.
 DROP TABLE IF EXISTS t_04651_no_nulls;
 CREATE TABLE t_04651_no_nulls (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
 SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;

--- a/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.reference
+++ b/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.reference
@@ -10,7 +10,7 @@ SET allow_suspicious_low_cardinality_types = 1;
 -- non-nullable and must not gain a NULL placeholder. Before the fix it gained one, with no NULL in the data.
 DROP TABLE IF EXISTS t_04651_no_nulls;
 CREATE TABLE t_04651_no_nulls (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
-SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, write_marks_for_substreams_in_compact_parts = 1;
 INSERT INTO t_04651_no_nulls SELECT tuple(tuple(number)) FROM numbers(4);
 SELECT dumpColumnStructure(x.a) FROM t_04651_no_nulls LIMIT 1;
 Nullable(Tuple(b LowCardinality(UInt32))), Nullable(size = 1, Tuple(size = 1, LowCardinality(size = 1, UInt8(size = 1), Unique(size = 1, UInt32(size = 1)))), UInt8(size = 1))
@@ -25,7 +25,7 @@ DROP TABLE t_04651_no_nulls;
 -- The reported shape: child, whole column, parent, and `assumeNotNull` over the parent in one query.
 DROP TABLE IF EXISTS t_04651_compact;
 CREATE TABLE t_04651_compact (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
-SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, write_marks_for_substreams_in_compact_parts = 1;
 INSERT INTO t_04651_compact SELECT number % 2 ? tuple(NULL) : tuple(tuple(number)) FROM numbers(4);
 SELECT toTypeName(x.a.b), toTypeName(x.a) FROM t_04651_compact LIMIT 1;
 LowCardinality(Nullable(UInt32))	Nullable(Tuple(b LowCardinality(UInt32)))
@@ -59,7 +59,7 @@ CREATE TABLE t_04651_leaves
     d Tuple(a Nullable(Tuple(b LowCardinality(Date)))),
     m Tuple(a Nullable(Tuple(b LowCardinality(UInt32), c UInt8)))
 )
-ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, write_marks_for_substreams_in_compact_parts = 1;
 INSERT INTO t_04651_leaves SELECT
     number % 2 ? tuple(NULL) : tuple(tuple(concat('s', toString(number)))),
     number % 2 ? tuple(NULL) : tuple(tuple(toFixedString(concat('s', toString(number)), 3))),
@@ -81,7 +81,7 @@ DROP TABLE t_04651_leaves;
 -- nullable, so the buffer has to stay as it is.
 DROP TABLE IF EXISTS t_04651_lc_nullable;
 CREATE TABLE t_04651_lc_nullable (x Tuple(a Nullable(Tuple(b LowCardinality(Nullable(UInt32)))))) ENGINE = MergeTree ORDER BY tuple()
-SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, write_marks_for_substreams_in_compact_parts = 1;
 INSERT INTO t_04651_lc_nullable VALUES ((NULL)), (((NULL))), (((7))), ((NULL));
 SELECT toTypeName(x.a.b), toTypeName(x.a) FROM t_04651_lc_nullable LIMIT 1;
 LowCardinality(Nullable(UInt32))	Nullable(Tuple(b LowCardinality(Nullable(UInt32))))
@@ -96,7 +96,7 @@ SELECT x.a.b, x.a FROM t_04651_lc_nullable;
 7	(7)
 \N	\N
 DROP TABLE t_04651_lc_nullable;
--- Wide part control: each column gets its own read, so nothing is shared through the cache.
+-- Wide part control: measured as unaffected.
 DROP TABLE IF EXISTS t_04651_wide;
 CREATE TABLE t_04651_wide (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
 SETTINGS index_granularity = 1, min_bytes_for_wide_part = 0;
@@ -121,7 +121,7 @@ DROP TABLE t_04651_top_level;
 -- Several granule ranges per block, so the cached substream carries rows of more than one range.
 DROP TABLE IF EXISTS t_04651_ranges;
 CREATE TABLE t_04651_ranges (x Tuple(a Nullable(Tuple(b LowCardinality(String))))) ENGINE = MergeTree ORDER BY tuple()
-SETTINGS index_granularity = 3, min_bytes_for_wide_part = 1000000000;
+SETTINGS index_granularity = 3, min_bytes_for_wide_part = 1000000000, write_marks_for_substreams_in_compact_parts = 1;
 INSERT INTO t_04651_ranges SELECT number % 3 = 0 ? tuple(NULL) : tuple(tuple(concat('s', toString(number % 5)))) FROM numbers(30);
 SELECT count(), countIf(x.a IS NULL), uniqExact(x.a.b), sum(cityHash64(x.a.b, x.a)) FROM t_04651_ranges SETTINGS max_block_size = 4;
 30	10	5	17833582760983350256

--- a/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.reference
+++ b/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.reference
@@ -1,0 +1,130 @@
+-- { echo }
+-- A subcolumn extracted from `Nullable(Tuple(...))` with a non-nullable `LowCardinality(T)` element gets
+-- its type promoted to `LowCardinality(Nullable(T))`. On a Compact part read the parent-null-map wrapper
+-- must still deserialize into the on-disk `LowCardinality(T)` representation, because the substreams it
+-- publishes to the shared substreams cache are adopted directly by a reader of the parent subcolumn.
+
+SET enable_nullable_tuple_type = 1;
+SET allow_suspicious_low_cardinality_types = 1;
+-- Reading the child `x.a.b` must not change what the parent `x.a` reads: the parent's dictionary stayed
+-- non-nullable, so it gained the NULL placeholder even though the data holds no NULL at all.
+DROP TABLE IF EXISTS t_04651_no_nulls;
+CREATE TABLE t_04651_no_nulls (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+INSERT INTO t_04651_no_nulls SELECT tuple(tuple(number)) FROM numbers(4);
+SELECT dumpColumnStructure(x.a) FROM t_04651_no_nulls LIMIT 1;
+Nullable(Tuple(b LowCardinality(UInt32))), Nullable(size = 1, Tuple(size = 1, LowCardinality(size = 1, UInt8(size = 1), Unique(size = 1, UInt32(size = 1)))), UInt8(size = 1))
+SELECT x.a.b, dumpColumnStructure(x.a) FROM t_04651_no_nulls LIMIT 1;
+0	Nullable(Tuple(b LowCardinality(UInt32))), Nullable(size = 1, Tuple(size = 1, LowCardinality(size = 1, UInt8(size = 1), Unique(size = 1, UInt32(size = 1)))), UInt8(size = 1))
+SELECT x.a.b, x.a FROM t_04651_no_nulls;
+0	(0)
+1	(1)
+2	(2)
+3	(3)
+DROP TABLE t_04651_no_nulls;
+-- The reported shape: child, whole column, parent, and `assumeNotNull` over the parent in one query.
+DROP TABLE IF EXISTS t_04651_compact;
+CREATE TABLE t_04651_compact (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+INSERT INTO t_04651_compact SELECT number % 2 ? tuple(NULL) : tuple(tuple(number)) FROM numbers(4);
+SELECT toTypeName(x.a.b), toTypeName(x.a) FROM t_04651_compact LIMIT 1;
+LowCardinality(Nullable(UInt32))	Nullable(Tuple(b LowCardinality(UInt32)))
+SELECT x.a.b, x, x.a, isNull(x.a.b), assumeNotNull(x.a) FROM t_04651_compact;
+0	((0))	(0)	0	(0)
+\N	(NULL)	\N	1	(1)
+2	((2))	(2)	0	(2)
+\N	(NULL)	\N	1	(3)
+SELECT x.a.b, x.a FROM t_04651_compact;
+0	(0)
+\N	\N
+2	(2)
+\N	\N
+SELECT x.a, x.a.b FROM t_04651_compact;
+(0)	0
+\N	\N
+(2)	2
+\N	\N
+SELECT x.a.b, x.a FROM t_04651_compact SETTINGS max_block_size = 1;
+0	(0)
+\N	\N
+2	(2)
+\N	\N
+DROP TABLE t_04651_compact;
+-- Leaf types other than UInt32 read through the same path.
+DROP TABLE IF EXISTS t_04651_leaves;
+CREATE TABLE t_04651_leaves
+(
+    s Tuple(a Nullable(Tuple(b LowCardinality(String)))),
+    f Tuple(a Nullable(Tuple(b LowCardinality(FixedString(3))))),
+    d Tuple(a Nullable(Tuple(b LowCardinality(Date)))),
+    m Tuple(a Nullable(Tuple(b LowCardinality(UInt32), c UInt8)))
+)
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+INSERT INTO t_04651_leaves SELECT
+    number % 2 ? tuple(NULL) : tuple(tuple(concat('s', toString(number)))),
+    number % 2 ? tuple(NULL) : tuple(tuple(toFixedString(concat('s', toString(number)), 3))),
+    number % 2 ? tuple(NULL) : tuple(tuple(toDate(number))),
+    number % 2 ? tuple(NULL) : tuple(tuple(number, number))
+FROM numbers(4);
+SELECT s.a.b, s.a, f.a.b, f.a, d.a.b, d.a, m.a.b, m.a FROM t_04651_leaves;
+s0	('s0')	s0\0	('s0\0')	1970-01-01	('1970-01-01')	0	(0,0)
+\N	\N	\N	\N	\N	\N	\N	\N
+s2	('s2')	s2\0	('s2\0')	1970-01-03	('1970-01-03')	2	(2,2)
+\N	\N	\N	\N	\N	\N	\N	\N
+SELECT assumeNotNull(s.a), assumeNotNull(m.a) FROM t_04651_leaves;
+('s0')	(0,0)
+('')	(1,1)
+('s2')	(2,2)
+('')	(3,3)
+DROP TABLE t_04651_leaves;
+-- A leaf that is `LowCardinality(Nullable(T))` on disk must NOT be de-nullabilised: its stream really is
+-- nullable, so the buffer has to stay as it is.
+DROP TABLE IF EXISTS t_04651_lc_nullable;
+CREATE TABLE t_04651_lc_nullable (x Tuple(a Nullable(Tuple(b LowCardinality(Nullable(UInt32)))))) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+INSERT INTO t_04651_lc_nullable VALUES ((NULL)), (((NULL))), (((7))), ((NULL));
+SELECT toTypeName(x.a.b), toTypeName(x.a) FROM t_04651_lc_nullable LIMIT 1;
+LowCardinality(Nullable(UInt32))	Nullable(Tuple(b LowCardinality(Nullable(UInt32))))
+SELECT x.a.b, x, x.a, isNull(x.a.b) FROM t_04651_lc_nullable;
+\N	(NULL)	\N	1
+\N	((NULL))	(NULL)	1
+7	((7))	(7)	0
+\N	(NULL)	\N	1
+SELECT x.a.b, x.a FROM t_04651_lc_nullable;
+\N	\N
+\N	(NULL)
+7	(7)
+\N	\N
+DROP TABLE t_04651_lc_nullable;
+-- Wide part control: each column gets its own read, so nothing is shared through the cache.
+DROP TABLE IF EXISTS t_04651_wide;
+CREATE TABLE t_04651_wide (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 0;
+INSERT INTO t_04651_wide SELECT number % 2 ? tuple(NULL) : tuple(tuple(number)) FROM numbers(4);
+SELECT x.a.b, x.a, assumeNotNull(x.a) FROM t_04651_wide;
+0	(0)	(0)
+\N	\N	(1)
+2	(2)	(2)
+\N	\N	(3)
+DROP TABLE t_04651_wide;
+-- Top-level `Nullable(Tuple(...))` control: the element is read without the outer `Tuple` in the path.
+DROP TABLE IF EXISTS t_04651_top_level;
+CREATE TABLE t_04651_top_level (id UInt8, x Nullable(Tuple(b LowCardinality(UInt32)))) ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+INSERT INTO t_04651_top_level SELECT number, number % 2 ? NULL : tuple(number) FROM numbers(4);
+SELECT x.b, x, assumeNotNull(x) FROM t_04651_top_level ORDER BY id;
+0	(0)	(0)
+\N	\N	(1)
+2	(2)	(2)
+\N	\N	(3)
+DROP TABLE t_04651_top_level;
+-- Several granule ranges per block, so the cached substream carries rows of more than one range.
+DROP TABLE IF EXISTS t_04651_ranges;
+CREATE TABLE t_04651_ranges (x Tuple(a Nullable(Tuple(b LowCardinality(String))))) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 3, min_bytes_for_wide_part = 1000000000;
+INSERT INTO t_04651_ranges SELECT number % 3 = 0 ? tuple(NULL) : tuple(tuple(concat('s', toString(number % 5)))) FROM numbers(30);
+SELECT count(), countIf(x.a IS NULL), uniqExact(x.a.b), sum(cityHash64(x.a.b, x.a)) FROM t_04651_ranges SETTINGS max_block_size = 4;
+30	10	5	17833582760983350256
+SELECT groupArray(x.a) FROM (SELECT x.a.b, x.a FROM t_04651_ranges SETTINGS max_block_size = 2);
+[('s1'),('s2'),('s4'),('s0'),('s2'),('s3'),('s0'),('s1'),('s3'),('s4'),('s1'),('s2'),('s4'),('s0'),('s2'),('s3'),('s0'),('s1'),('s3'),('s4')]
+DROP TABLE t_04651_ranges;

--- a/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.sql
+++ b/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.sql
@@ -1,0 +1,87 @@
+-- { echo }
+-- A subcolumn extracted from `Nullable(Tuple(...))` with a non-nullable `LowCardinality(T)` element gets
+-- its type promoted to `LowCardinality(Nullable(T))`. On a Compact part read the parent-null-map wrapper
+-- must still deserialize into the on-disk `LowCardinality(T)` representation, because the substreams it
+-- publishes to the shared substreams cache are adopted directly by a reader of the parent subcolumn.
+
+SET enable_nullable_tuple_type = 1;
+SET allow_suspicious_low_cardinality_types = 1;
+
+-- Reading the child `x.a.b` must not change what the parent `x.a` reads: the parent's dictionary stayed
+-- non-nullable, so it gained the NULL placeholder even though the data holds no NULL at all.
+DROP TABLE IF EXISTS t_04651_no_nulls;
+CREATE TABLE t_04651_no_nulls (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+INSERT INTO t_04651_no_nulls SELECT tuple(tuple(number)) FROM numbers(4);
+SELECT dumpColumnStructure(x.a) FROM t_04651_no_nulls LIMIT 1;
+SELECT x.a.b, dumpColumnStructure(x.a) FROM t_04651_no_nulls LIMIT 1;
+SELECT x.a.b, x.a FROM t_04651_no_nulls;
+DROP TABLE t_04651_no_nulls;
+
+-- The reported shape: child, whole column, parent, and `assumeNotNull` over the parent in one query.
+DROP TABLE IF EXISTS t_04651_compact;
+CREATE TABLE t_04651_compact (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+INSERT INTO t_04651_compact SELECT number % 2 ? tuple(NULL) : tuple(tuple(number)) FROM numbers(4);
+SELECT toTypeName(x.a.b), toTypeName(x.a) FROM t_04651_compact LIMIT 1;
+SELECT x.a.b, x, x.a, isNull(x.a.b), assumeNotNull(x.a) FROM t_04651_compact;
+SELECT x.a.b, x.a FROM t_04651_compact;
+SELECT x.a, x.a.b FROM t_04651_compact;
+SELECT x.a.b, x.a FROM t_04651_compact SETTINGS max_block_size = 1;
+DROP TABLE t_04651_compact;
+
+-- Leaf types other than UInt32 read through the same path.
+DROP TABLE IF EXISTS t_04651_leaves;
+CREATE TABLE t_04651_leaves
+(
+    s Tuple(a Nullable(Tuple(b LowCardinality(String)))),
+    f Tuple(a Nullable(Tuple(b LowCardinality(FixedString(3))))),
+    d Tuple(a Nullable(Tuple(b LowCardinality(Date)))),
+    m Tuple(a Nullable(Tuple(b LowCardinality(UInt32), c UInt8)))
+)
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+INSERT INTO t_04651_leaves SELECT
+    number % 2 ? tuple(NULL) : tuple(tuple(concat('s', toString(number)))),
+    number % 2 ? tuple(NULL) : tuple(tuple(toFixedString(concat('s', toString(number)), 3))),
+    number % 2 ? tuple(NULL) : tuple(tuple(toDate(number))),
+    number % 2 ? tuple(NULL) : tuple(tuple(number, number))
+FROM numbers(4);
+SELECT s.a.b, s.a, f.a.b, f.a, d.a.b, d.a, m.a.b, m.a FROM t_04651_leaves;
+SELECT assumeNotNull(s.a), assumeNotNull(m.a) FROM t_04651_leaves;
+DROP TABLE t_04651_leaves;
+
+-- A leaf that is `LowCardinality(Nullable(T))` on disk must NOT be de-nullabilised: its stream really is
+-- nullable, so the buffer has to stay as it is.
+DROP TABLE IF EXISTS t_04651_lc_nullable;
+CREATE TABLE t_04651_lc_nullable (x Tuple(a Nullable(Tuple(b LowCardinality(Nullable(UInt32)))))) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+INSERT INTO t_04651_lc_nullable VALUES ((NULL)), (((NULL))), (((7))), ((NULL));
+SELECT toTypeName(x.a.b), toTypeName(x.a) FROM t_04651_lc_nullable LIMIT 1;
+SELECT x.a.b, x, x.a, isNull(x.a.b) FROM t_04651_lc_nullable;
+SELECT x.a.b, x.a FROM t_04651_lc_nullable;
+DROP TABLE t_04651_lc_nullable;
+
+-- Wide part control: each column gets its own read, so nothing is shared through the cache.
+DROP TABLE IF EXISTS t_04651_wide;
+CREATE TABLE t_04651_wide (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 0;
+INSERT INTO t_04651_wide SELECT number % 2 ? tuple(NULL) : tuple(tuple(number)) FROM numbers(4);
+SELECT x.a.b, x.a, assumeNotNull(x.a) FROM t_04651_wide;
+DROP TABLE t_04651_wide;
+
+-- Top-level `Nullable(Tuple(...))` control: the element is read without the outer `Tuple` in the path.
+DROP TABLE IF EXISTS t_04651_top_level;
+CREATE TABLE t_04651_top_level (id UInt8, x Nullable(Tuple(b LowCardinality(UInt32)))) ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+INSERT INTO t_04651_top_level SELECT number, number % 2 ? NULL : tuple(number) FROM numbers(4);
+SELECT x.b, x, assumeNotNull(x) FROM t_04651_top_level ORDER BY id;
+DROP TABLE t_04651_top_level;
+
+-- Several granule ranges per block, so the cached substream carries rows of more than one range.
+DROP TABLE IF EXISTS t_04651_ranges;
+CREATE TABLE t_04651_ranges (x Tuple(a Nullable(Tuple(b LowCardinality(String))))) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 3, min_bytes_for_wide_part = 1000000000;
+INSERT INTO t_04651_ranges SELECT number % 3 = 0 ? tuple(NULL) : tuple(tuple(concat('s', toString(number % 5)))) FROM numbers(30);
+SELECT count(), countIf(x.a IS NULL), uniqExact(x.a.b), sum(cityHash64(x.a.b, x.a)) FROM t_04651_ranges SETTINGS max_block_size = 4;
+SELECT groupArray(x.a) FROM (SELECT x.a.b, x.a FROM t_04651_ranges SETTINGS max_block_size = 2);
+DROP TABLE t_04651_ranges;

--- a/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.sql
+++ b/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.sql
@@ -11,7 +11,7 @@ SET allow_suspicious_low_cardinality_types = 1;
 -- non-nullable and must not gain a NULL placeholder. Before the fix it gained one, with no NULL in the data.
 DROP TABLE IF EXISTS t_04651_no_nulls;
 CREATE TABLE t_04651_no_nulls (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
-SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, write_marks_for_substreams_in_compact_parts = 1;
 INSERT INTO t_04651_no_nulls SELECT tuple(tuple(number)) FROM numbers(4);
 SELECT dumpColumnStructure(x.a) FROM t_04651_no_nulls LIMIT 1;
 SELECT x.a.b, dumpColumnStructure(x.a) FROM t_04651_no_nulls LIMIT 1;
@@ -21,7 +21,7 @@ DROP TABLE t_04651_no_nulls;
 -- The reported shape: child, whole column, parent, and `assumeNotNull` over the parent in one query.
 DROP TABLE IF EXISTS t_04651_compact;
 CREATE TABLE t_04651_compact (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
-SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, write_marks_for_substreams_in_compact_parts = 1;
 INSERT INTO t_04651_compact SELECT number % 2 ? tuple(NULL) : tuple(tuple(number)) FROM numbers(4);
 SELECT toTypeName(x.a.b), toTypeName(x.a) FROM t_04651_compact LIMIT 1;
 SELECT x.a.b, x, x.a, isNull(x.a.b), assumeNotNull(x.a) FROM t_04651_compact;
@@ -39,7 +39,7 @@ CREATE TABLE t_04651_leaves
     d Tuple(a Nullable(Tuple(b LowCardinality(Date)))),
     m Tuple(a Nullable(Tuple(b LowCardinality(UInt32), c UInt8)))
 )
-ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, write_marks_for_substreams_in_compact_parts = 1;
 INSERT INTO t_04651_leaves SELECT
     number % 2 ? tuple(NULL) : tuple(tuple(concat('s', toString(number)))),
     number % 2 ? tuple(NULL) : tuple(tuple(toFixedString(concat('s', toString(number)), 3))),
@@ -54,14 +54,14 @@ DROP TABLE t_04651_leaves;
 -- nullable, so the buffer has to stay as it is.
 DROP TABLE IF EXISTS t_04651_lc_nullable;
 CREATE TABLE t_04651_lc_nullable (x Tuple(a Nullable(Tuple(b LowCardinality(Nullable(UInt32)))))) ENGINE = MergeTree ORDER BY tuple()
-SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, write_marks_for_substreams_in_compact_parts = 1;
 INSERT INTO t_04651_lc_nullable VALUES ((NULL)), (((NULL))), (((7))), ((NULL));
 SELECT toTypeName(x.a.b), toTypeName(x.a) FROM t_04651_lc_nullable LIMIT 1;
 SELECT x.a.b, x, x.a, isNull(x.a.b) FROM t_04651_lc_nullable;
 SELECT x.a.b, x.a FROM t_04651_lc_nullable;
 DROP TABLE t_04651_lc_nullable;
 
--- Wide part control: each column gets its own read, so nothing is shared through the cache.
+-- Wide part control: measured as unaffected.
 DROP TABLE IF EXISTS t_04651_wide;
 CREATE TABLE t_04651_wide (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
 SETTINGS index_granularity = 1, min_bytes_for_wide_part = 0;
@@ -80,7 +80,7 @@ DROP TABLE t_04651_top_level;
 -- Several granule ranges per block, so the cached substream carries rows of more than one range.
 DROP TABLE IF EXISTS t_04651_ranges;
 CREATE TABLE t_04651_ranges (x Tuple(a Nullable(Tuple(b LowCardinality(String))))) ENGINE = MergeTree ORDER BY tuple()
-SETTINGS index_granularity = 3, min_bytes_for_wide_part = 1000000000;
+SETTINGS index_granularity = 3, min_bytes_for_wide_part = 1000000000, write_marks_for_substreams_in_compact_parts = 1;
 INSERT INTO t_04651_ranges SELECT number % 3 = 0 ? tuple(NULL) : tuple(tuple(concat('s', toString(number % 5)))) FROM numbers(30);
 SELECT count(), countIf(x.a IS NULL), uniqExact(x.a.b), sum(cityHash64(x.a.b, x.a)) FROM t_04651_ranges SETTINGS max_block_size = 4;
 SELECT groupArray(x.a) FROM (SELECT x.a.b, x.a FROM t_04651_ranges SETTINGS max_block_size = 2);

--- a/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.sql
+++ b/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.sql
@@ -7,8 +7,8 @@
 SET enable_nullable_tuple_type = 1;
 SET allow_suspicious_low_cardinality_types = 1;
 
--- Reading the child `x.a.b` must not change what the parent `x.a` reads: the parent's dictionary stayed
--- non-nullable, so it gained the NULL placeholder even though the data holds no NULL at all.
+-- Reading the child `x.a.b` must not change what the parent `x.a` reads: the parent's dictionary must stay
+-- non-nullable and must not gain a NULL placeholder. Before the fix it gained one, with no NULL in the data.
 DROP TABLE IF EXISTS t_04651_no_nulls;
 CREATE TABLE t_04651_no_nulls (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
 SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;

--- a/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.sql
+++ b/tests/queries/0_stateless/04651_nullable_tuple_lowcardinality_subcolumn_shared_cache.sql
@@ -19,12 +19,15 @@ SELECT x.a.b, x.a FROM t_04651_no_nulls;
 DROP TABLE t_04651_no_nulls;
 
 -- The reported shape: child, whole column, parent, and `assumeNotNull` over the parent in one query.
+-- `assumeNotNull` has an unspecified result on a NULL input, so its value is never asserted here: it is
+-- wrapped in `ignore` so that it is still evaluated, because what the bug breaks is its return-type
+-- post-condition and not the value it returns.
 DROP TABLE IF EXISTS t_04651_compact;
 CREATE TABLE t_04651_compact (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
 SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, write_marks_for_substreams_in_compact_parts = 1;
 INSERT INTO t_04651_compact SELECT number % 2 ? tuple(NULL) : tuple(tuple(number)) FROM numbers(4);
 SELECT toTypeName(x.a.b), toTypeName(x.a) FROM t_04651_compact LIMIT 1;
-SELECT x.a.b, x, x.a, isNull(x.a.b), assumeNotNull(x.a) FROM t_04651_compact;
+SELECT x.a.b, x, x.a, isNull(x.a.b), ignore(assumeNotNull(x.a)) FROM t_04651_compact;
 SELECT x.a.b, x.a FROM t_04651_compact;
 SELECT x.a, x.a.b FROM t_04651_compact;
 SELECT x.a.b, x.a FROM t_04651_compact SETTINGS max_block_size = 1;
@@ -47,7 +50,7 @@ INSERT INTO t_04651_leaves SELECT
     number % 2 ? tuple(NULL) : tuple(tuple(number, number))
 FROM numbers(4);
 SELECT s.a.b, s.a, f.a.b, f.a, d.a.b, d.a, m.a.b, m.a FROM t_04651_leaves;
-SELECT assumeNotNull(s.a), assumeNotNull(m.a) FROM t_04651_leaves;
+SELECT ignore(assumeNotNull(s.a)), ignore(assumeNotNull(m.a)) FROM t_04651_leaves;
 DROP TABLE t_04651_leaves;
 
 -- A leaf that is `LowCardinality(Nullable(T))` on disk must NOT be de-nullabilised: its stream really is
@@ -66,7 +69,7 @@ DROP TABLE IF EXISTS t_04651_wide;
 CREATE TABLE t_04651_wide (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree ORDER BY tuple()
 SETTINGS index_granularity = 1, min_bytes_for_wide_part = 0;
 INSERT INTO t_04651_wide SELECT number % 2 ? tuple(NULL) : tuple(tuple(number)) FROM numbers(4);
-SELECT x.a.b, x.a, assumeNotNull(x.a) FROM t_04651_wide;
+SELECT x.a.b, x.a, ignore(assumeNotNull(x.a)) FROM t_04651_wide;
 DROP TABLE t_04651_wide;
 
 -- Top-level `Nullable(Tuple(...))` control: the element is read without the outer `Tuple` in the path.
@@ -74,7 +77,7 @@ DROP TABLE IF EXISTS t_04651_top_level;
 CREATE TABLE t_04651_top_level (id UInt8, x Nullable(Tuple(b LowCardinality(UInt32)))) ENGINE = MergeTree ORDER BY id
 SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
 INSERT INTO t_04651_top_level SELECT number, number % 2 ? NULL : tuple(number) FROM numbers(4);
-SELECT x.b, x, assumeNotNull(x) FROM t_04651_top_level ORDER BY id;
+SELECT x.b, x, ignore(assumeNotNull(x)) FROM t_04651_top_level ORDER BY id;
 DROP TABLE t_04651_top_level;
 
 -- Several granule ranges per block, so the cached substream carries rows of more than one range.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/100394
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/100394


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed reading a subcolumn of a `Nullable(Tuple(...))` column whose element is a non-nullable `LowCardinality(T)` when the same query also reads the parent subcolumn. On a Compact part the parent returned wrong values, or the query failed with `Unexpected return type from assumeNotNull`, or the server was killed by a `string_view` hardening assertion, because the extracted subcolumn was deserialized into a `LowCardinality(Nullable(T))` buffer whose substreams were then shared with the parent's read.


### Description

Reported as an `AST fuzzer (amd_debug)` failure on #100394: [CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100394&sha=31ba0886721b3229c5bfaab61ee49af289b53479&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29).

```
Logical error: 'Unexpected return type from assumeNotNull. Expected Tuple(b UInt32). Got Tuple(Nullable(UInt32)).'
```

This is not an analyzer or executor type-derivation problem. It is a regression from my own merged #108679, which introduced this read path. Carriers are `master` and `26.7`: both #108679 commits are ancestors of `26.7` and of `master`, and of neither `26.6` nor anything older.

I measured the official release binaries `26.6.2.120` and `26.7.2.26` on the shape below, a Compact part with `index_granularity = 1`. `26.6` is correct on every query. On `26.7` the same queries give three different outcomes, selected by the element type and the projection list rather than by build flags:

| query | `26.6.2.120` | `26.7.2.26` |
|---|---|---|
| `SELECT x.a FROM t`, the parent alone | correct | correct, the parent on its own is never wrong |
| `SELECT x.a.b, x.a FROM t`, `LowCardinality(UInt32)` element | correct | exit status 0, wrong values, and unstable: one row came back as `(32438)`, `(31553)`, `(31542)`, `(31253)` on four runs where `(2)` is correct |
| `SELECT x.a.b, x, x.a, isNull(x.a.b), assumeNotNull(x.a) FROM t` | correct | exit status 49 on 4 of 4 runs, `Unexpected return type from assumeNotNull. Expected Tuple(b UInt32). Got Tuple(Nullable(UInt32))` |
| `SELECT x.a.b, x.a FROM s`, `LowCardinality(String)` element | correct | the process is killed by `SIGABRT` on 4 of 4 runs, exit status 134, no rows on stdout: `libcxx/include/string_view:331: libc++ Hardening assertion __len <= ... failed` |

The last row is a real termination on a release build, and it is not a bad cast: the parent reads a nullable dictionary's index data under a declared type that is not nullable and derives a nonsensical string length, which libc++ hardening catches, and `std::__libcpp_verbose_abort` then calls `std::abort()`. `Code: 49` and the termination are not the same condition selected by build type: on the same release binary the `UInt32` element throws while the `String` element aborts. What the build type does change is the fate of that `Code: 49`, since `LOGICAL_ERROR` is turned into an abort in debug and sanitizer builds, which is the form the fuzzer reported.

#### Root cause

An extracted subcolumn of `Nullable(Tuple(...))` with a non-nullable `LowCardinality(T)` element has its type promoted to `LowCardinality(Nullable(T))`, so that it can carry the parent's NULLs. `MergeTreeReaderCompact` therefore creates the result column already as `LowCardinality(Nullable(T))`, and `SerializationNullableWithParentNullMap::deserializeBinaryBulkWithMultipleStreams` built its per-range deserialization buffer from it with `column->cloneEmpty()`.

The nested `SerializationLowCardinality` deserializes into that nullable-dictionary buffer and publishes it to the shared `SubstreamsCache`. The published substream is therefore not the on-disk `LowCardinality(T)` representation. A sibling reader of the same streams in the same query, that is the parent subcolumn `x.a` or `assumeNotNull(x.a)`, adopts the cached column directly, so the parent holds a nullable-dictionary column while its declared type is still `Nullable(Tuple(b LowCardinality(UInt32)))`, and the `columnMatchesType` post-condition in `ExpressionActions` throws.

Nothing mutates the published column. It simply was never the right representation. That is also why the parent on its own is always correct and only becomes wrong when the child is read in the same query: without the child read there is nothing in the cache to adopt.

#### Reproducer

```sql
SET enable_nullable_tuple_type = 1;
SET allow_suspicious_low_cardinality_types = 1;

CREATE TABLE t (x Tuple(a Nullable(Tuple(b LowCardinality(UInt32))))) ENGINE = MergeTree
ORDER BY tuple() SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000;
INSERT INTO t SELECT number % 2 ? tuple(NULL) : tuple(tuple(number)) FROM numbers(4);

SELECT x.a.b, x, x.a, isNull(x.a.b), assumeNotNull(x.a) FROM t;
```

The sharpest form of the bug needs no NULL in the data at all. On a table with zero parent-NULL rows, `SELECT dumpColumnStructure(x.a)` and `SELECT x.a.b, dumpColumnStructure(x.a)` must report the same dictionary size, and before this change the second one reported one entry more: the parent's dictionary gained a NULL placeholder purely because the child was also selected. That equality is asserted in the new test, and it is what distinguishes this fix from one that merely stops the exception.

#### The fix

Deserialize into a buffer that has the on-disk representation, and promote the private per-range column afterwards:

* `SerializationNullableWithParentNullMap` now carries the pre-promotion (on-disk) type, passed in at construction by `NullableSubcolumnCreator`, which is where that type is still known. When it is set, the per-range buffer is built from it instead of from the promoted result column.
* The new constructor parameter is folded into `getHash()`, otherwise the two flavours of the wrapper would collide on a single pooled instance.
* No second promotion is added. With a genuinely non-nullable buffer, the existing promotion inside `applyParentNullMapToExtractedSubcolumn` becomes reachable and correct and remains the single promotion owner. It runs on the `IColumn::mutate`d private column, so it can never touch the published one. Deleting it now makes the reproducer fail with `Cannot apply a null map to LowCardinality(UInt32) with a non-nullable dictionary`, so that line is load-bearing.

I first evaluated promoting on a private copy at the in-place promotion instead, and measured it to be a no-op: while the buffer is pre-promoted, that code is unreachable, since its guard is `!nestedIsNullable()`.

Wide parts were measured and are not affected. With `write_marks_for_substreams_in_compact_parts = 0` the reader takes the `getSubcolumn` branch, which already copies, so that path was correct too, and the new test pins that setting to `1` on its Compact tables so it keeps exercising the branch that was broken. A top-level `Nullable(Tuple(b LowCardinality(UInt32)))` without the outer `Tuple` is not a carrier either.

The change is in the serialization layer, so it also reaches `StorageLog`, which builds this wrapper through `IDataType::getSerialization` and likewise shares one `SubstreamsCache` per name in storage across subcolumn reads. I am not claiming a Log symptom: reading this shape from a `Log` table fails with `Code: 33` on `26.6`, on `26.7`, and on master alike, so that is a separate pre-existing problem which this change neither causes nor fixes.

There is no on-disk format change, no new or changed setting, and the non-LowCardinality flavour of the wrapper is unchanged.

#### Testing

New stateless test `04651_nullable_tuple_lowcardinality_subcolumn_shared_cache`, covering the reported query shape, both projection orders, the zero-parent-NULL structural assertion, the leaf types `LowCardinality` of `UInt32`, `String`, `FixedString` and `Date`, a multi-element inner tuple, an already-`LowCardinality(Nullable(T))` leaf (which must not be de-nullabilised), a wide-part control, a top-level `Nullable(Tuple(...))` control, and a multi-range read with a small `max_block_size`.

Every value in the test was cross-checked against an `ENGINE = Memory` twin of the same shape, which has no read path and therefore no substreams cache. The test fails on master and passes with this change. It ran 50 times with the default randomization, and the whole `nullable_tuple` test family ran 50 times each, 1150 runs in total, with no failures.

Note that the fix does not restore the `26.6` output of the child subcolumn: on a parent-NULL row `x.a.b` is `\N` here and was `1` or `3` on `26.6`, because the promotion to `LowCardinality(Nullable(T))` is exactly what #108679 added. What is restored is that reading the child no longer changes what the parent returns.

`ColumnsOwnershipValidator` (#110471) does not catch this, because the published column is legitimately shared. Only its representation was wrong. I did not extend the validator here.

`26.7` is affected, so this wants `v26.7-must-backport` after merge.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.474` (included in `26.8` and later)
<!-- ch-version-info:end -->