### PR TITLE
Docs: highlight `View` dropdown border

### DIFF
--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -33,6 +33,13 @@ html:not(.dark) .ch-usecase-arrow {
 .dark .ch-usecase-arrow {
     color: #FCFF74;
 }
+/* Highlight the `View` selector above the table of contents with theme accents. */
+html:not(.dark) .multi-view-dropdown-trigger {
+    border-color: #135BE6 !important;
+}
+.dark .multi-view-dropdown-trigger {
+    border-color: #FDFF75 !important;
+}
 /* Homepage content hidden until React has mounted and child effects have settled.
    Double-RAF in PageWrapper ensures FullWidthDivider's own RAF fires first. */
 .ch-page-hidden {


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/112187

Adds theme-specific border colors to the `View` dropdown above the table of contents: the existing documentation blue in light mode and the ClickHouse brand yellow in dark mode. This makes the multi-view selector easier to notice while keeping the styling consistent with each theme.

Validated with `git diff --check`.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.261` (included in `26.8` and later)
<!-- ch-version-info:end -->