### PR TITLE
Do not let an unreadable job result JSON kill the praktika runner before it reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ ci/local.env
 .env
 /tests/integration/.env
 /ci/tmp
+/ci/tmp_result
+/ci/tmp_backup
 /tests/venv
 /obj-x86_64-linux-gnu/
 

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -413,7 +413,15 @@ class Result(MetaClasses.Serializable):
         path = Path(self.file_name())
         tmp_path = path.with_name(f"{path.name}.tmp.{os.getpid()}")
         try:
-            with open(tmp_path, "w", encoding="utf8") as f:
+            # O_NOFOLLOW: the temp path is derived from the result path and this pid, so a
+            # job sharing the worktree could pre-create it as a symlink; refuse to write
+            # through one. Not O_EXCL: a leftover temp from a previously killed dump must
+            # stay reusable, or the very crash this method exists to survive would become
+            # a hard failure.
+            fd = os.open(
+                tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o666
+            )
+            with os.fdopen(fd, "w", encoding="utf8") as f:
                 json.dump(self.to_dict(self), f, indent=4)
                 f.flush()
                 os.fsync(f.fileno())

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -399,6 +399,33 @@ class Result(MetaClasses.Serializable):
     def file_name_static(cls, name):
         return f"{Settings.TEMP_DIR}/result_{Utils.normalize_string(name)}.json"
 
+    def dump(self) -> "Result":
+        """Write the result file atomically.
+
+        The inherited implementation opens the target with mode "w", which truncates
+        it to zero bytes before the first byte of the new payload is written, so a
+        writer that dies inside that window leaves no readable result at all - not
+        even the previously persisted one.
+
+        The temp file must be a sibling of the target: os.replace is atomic only
+        within a single filesystem and raises OSError(EXDEV) across devices.
+        """
+        path = Path(self.file_name())
+        tmp_path = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+        try:
+            with open(tmp_path, "w", encoding="utf8") as f:
+                json.dump(self.to_dict(self), f, indent=4)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, path)
+        except BaseException:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+            raise
+        return self
+
     @classmethod
     def from_dict(cls, obj: Dict[str, Any]) -> "Result":
         sub_results = []

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -487,7 +487,7 @@ class Runner:
                 chown_cmd = f"docker run --rm --user root --volume {host_dir_q}:{current_dir} --workdir={current_dir} {docker} chown -R {uid}:{gid} {Settings.TEMP_DIR}"
                 Shell.run(chown_cmd)
 
-            result = Result.from_fs(job.name)
+            result = self._read_job_result_or_running(job)
             if exit_code != 0:
                 if not result.is_completed():
                     if process.timeout_exceeded:
@@ -513,6 +513,37 @@ class Runner:
         Shell.run("df -h")
 
         return exit_code
+
+    @staticmethod
+    def _read_job_result_or_running(job) -> Result:
+        """Read the job result file, degrading to a RUNNING result if it is unreadable.
+
+        An infra event (docker daemon death, a failed from-root chown leaving the file
+        root-owned, ENOSPC) can leave the result file empty, truncated or unopenable.
+        Letting the exception out kills the runner before anything is reported, so the
+        job ends up as a red node with no information at all.
+
+        The fallback status must be RUNNING, not ERROR: is_completed() is
+        "status not in (PENDING, RUNNING)", so an ERROR result is already completed and
+        skips the caller's `if not result.is_completed():` branch - the one that records
+        why the job died and attaches the log tail. RUNNING is also what the process
+        actually was, since _pre_run persisted exactly that before the job started.
+        """
+        try:
+            return Result.from_fs(job.name)
+        except Exception as e:  # json.decoder.JSONDecodeError, OSError
+            print(f"ERROR: Failed to read Result json from fs, ex: [{e}]")
+            traceback.print_exc()
+            # Set `info` through the constructor rather than a setter: the setters dump
+            # the result when a file already exists, and the file being unreadable is
+            # exactly the case where writing it may fail too.
+            return Result(
+                name=job.name,
+                status=Result.Status.RUNNING,
+                start_time=Utils.timestamp(),
+                duration=None,
+                info=f"Failed to read Result json, ex: [{e}]",
+            )
 
     def _get_result_object(
         self, job, setup_env_exit_code, prerun_exit_code, run_exit_code,
@@ -1090,7 +1121,11 @@ class Runner:
                 Info().store_traceback()
                 res = False
 
-            result = Result.from_fs(job.name)
+            # Must stay on the unconditional path: this is the only place that converts a
+            # completed OK result into ERROR when the run itself failed
+            # (_get_result_object only promotes results that are not completed, and it runs
+            # under `if run_hooks:` below, so a local run would lose the normalization).
+            result = self._read_job_result_or_running(job)
             if not res and result.is_ok():
                 # TODO: It happens due to invalid timeout handling (forceful termination by timeout does not work) - fix
                 result.set_status(Result.Status.ERROR).set_info(

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -553,11 +553,16 @@ class Runner:
             ).add_ext_key_value(Runner.READ_FAILED_EXT_KEY, True)
 
     def _get_result_object(
-        self, job, setup_env_exit_code, prerun_exit_code, run_exit_code,
+        self,
+        job,
+        setup_env_exit_code,
+        prerun_exit_code,
+        run_exit_code,
+        promote_incomplete_result=True,
     ) -> Result:
         result_exist = Result.exist(job.name)
 
-        if setup_env_exit_code != 0:
+        if setup_env_exit_code is not None and setup_env_exit_code != 0:
             print(f"ERROR: {ResultInfo.SETUP_ENV_JOB_FAILED}")
             Result(
                 name=job.name,
@@ -565,7 +570,7 @@ class Runner:
                 start_time=Utils.timestamp(),
                 duration=0.0,
             ).add_error(ResultInfo.SETUP_ENV_JOB_FAILED).dump()
-        elif prerun_exit_code != 0:
+        elif prerun_exit_code is not None and prerun_exit_code != 0:
             print(f"ERROR: {ResultInfo.PRE_JOB_FAILED}")
             Result(
                 name=job.name,
@@ -582,17 +587,23 @@ class Runner:
                 status=Result.Status.ERROR,
             ).add_error(ResultInfo.NOT_FOUND_IMPOSSIBLE).dump()
 
-        try:
-            result = Result.from_fs(job.name)
-        except Exception as e:  # json.decoder.JSONDecodeError
-            print(f"ERROR: Failed to read Result json from fs, ex: [{e}]")
-            traceback.print_exc()
-            result = Result.create_from(
-                status=Result.Status.ERROR,
-                info=f"Failed to read Result json, ex: [{e}]",
-            ).dump()
+        result = self._read_job_result_or_running(job)
 
-        if not result.is_completed():
+        if run_exit_code is not None and run_exit_code != 0 and result.is_ok():
+            result.set_status(Result.Status.ERROR).set_info(
+                f"Job got terminated with an error, exit code [{run_exit_code}]"
+            ).dump()
+        elif run_exit_code == 0 and result.ext.get(self.READ_FAILED_EXT_KEY):
+            info = f"Job exited [{run_exit_code}] but left no readable result"
+            print(f"ERROR: {info}")
+            result.add_error(info).set_status(Result.Status.ERROR).dump()
+
+        should_promote_incomplete_result = (
+            promote_incomplete_result
+            or run_exit_code is None
+            or run_exit_code != 0
+        )
+        if not result.is_completed() and should_promote_incomplete_result:
             print(f"ERROR: {ResultInfo.KILLED}")
             result.add_error(ResultInfo.KILLED).set_status(Result.Status.ERROR).dump()
 
@@ -1033,14 +1044,15 @@ class Runner:
         self._load_local_env()
 
         res = True
-        setup_env_code = -10
-        prerun_code = -10
-        run_code = -10
+        setup_env_code = None
+        prerun_code = None
+        run_code = None
 
         if res and not local_run:
             print(
                 f"\n\n=== Setup env script [{job.name}], workflow [{workflow.name}] ==="
             )
+            setup_env_code = -10
             try:
                 setup_env_code = self._setup_env(workflow, job)
                 # Source the bash script and capture the environment variables
@@ -1073,6 +1085,7 @@ class Runner:
         if res and (not local_run or ((pr or branch) and sha)):
             res = False
             print(f"=== Pre run script [{job.name}], workflow [{workflow.name}] ===")
+            prerun_code = -10
             try:
                 prerun_code = self._pre_run(workflow, job, local_run=local_run)
                 res = prerun_code == 0
@@ -1104,7 +1117,7 @@ class Runner:
 
         if res:
             print(f"=== Run script [{job.name}], workflow [{workflow.name}] ===")
-            run_code = None
+            run_code = -10
             try:
                 run_code = self._run(
                     workflow,
@@ -1128,33 +1141,19 @@ class Runner:
                 Info().store_traceback()
                 res = False
 
-            # Must stay on the unconditional path: this is the only place that converts a
-            # completed OK result into ERROR when the run itself failed
-            # (_get_result_object only promotes results that are not completed, and it runs
-            # under `if run_hooks:` below, so a local run would lose the normalization).
-            result = self._read_job_result_or_running(job)
-            if not res and result.is_ok():
-                # TODO: It happens due to invalid timeout handling (forceful termination by timeout does not work) - fix
-                result.set_status(Result.Status.ERROR).set_info(
-                    f"Job got terminated with an error, exit code [{run_code}]"
-                ).dump()
-            elif not run_hooks and res and result.ext.get(self.READ_FAILED_EXT_KEY):
-                # The job exited 0 but its result is unreadable, so there is no evidence it
-                # succeeded. `_get_result_object` promotes exactly this to ERROR, but it
-                # runs under `if run_hooks:` below - so only a run that skips the hooks
-                # needs the promotion here, and gating on `not run_hooks` keeps the hook
-                # path's reporting and exit code untouched.
-                info = f"Job exited [{run_code}] but left no readable result"
-                print(f"ERROR: {info}")
-                result.add_error(info).set_status(Result.Status.ERROR).dump()
-                res = False
-
             print("=== Run script finished ===\n\n")
 
+        result = self._get_result_object(
+            job,
+            setup_env_code,
+            prerun_code,
+            run_code,
+            promote_incomplete_result=run_hooks,
+        )
+        if not run_hooks and res and result.ext.get(self.READ_FAILED_EXT_KEY):
+            res = False
+
         if run_hooks:
-            result = self._get_result_object(
-                job, setup_env_code, prerun_code, run_code
-            )
             if prehook_result:
                 result.results.append(prehook_result)
             if job.post_hooks:
@@ -1185,7 +1184,7 @@ class Runner:
                 res = res and post_res
                 print("=== Post run script finished ===")
 
-            result.dump()
+        result.dump()
 
         if not res and not job.force_success:
             sys.exit(1)

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -514,6 +514,13 @@ class Runner:
 
         return exit_code
 
+    # Marks a Result synthesized because the job result file was unreadable, as opposed to
+    # one a job legitimately left non-completed. Only the synthesized kind may fail a local
+    # run: a plain RUNNING/PENDING result reaching the end of a local run exits 0 both
+    # before and after this change, so keying on is_completed() alone would be a
+    # regression of its own.
+    READ_FAILED_EXT_KEY = "job_result_read_failed"
+
     @staticmethod
     def _read_job_result_or_running(job) -> Result:
         """Read the job result file, degrading to a RUNNING result if it is unreadable.
@@ -543,7 +550,7 @@ class Runner:
                 start_time=Utils.timestamp(),
                 duration=None,
                 info=f"Failed to read Result json, ex: [{e}]",
-            )
+            ).add_ext_key_value(Runner.READ_FAILED_EXT_KEY, True)
 
     def _get_result_object(
         self, job, setup_env_exit_code, prerun_exit_code, run_exit_code,
@@ -1131,6 +1138,15 @@ class Runner:
                 result.set_status(Result.Status.ERROR).set_info(
                     f"Job got terminated with an error, exit code [{run_code}]"
                 ).dump()
+            elif res and result.ext.get(self.READ_FAILED_EXT_KEY):
+                # The job exited 0 but its result is unreadable, so there is no evidence it
+                # succeeded. In CI `_get_result_object` promotes this to ERROR, but it runs
+                # under `if run_hooks:` below, which a local run skips - without this the
+                # command would exit 0 while the persisted result is not even completed.
+                info = f"Job exited [{run_code}] but left no readable result"
+                print(f"ERROR: {info}")
+                result.add_error(info).set_status(Result.Status.ERROR).dump()
+                res = False
 
             print("=== Run script finished ===\n\n")
 

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -1138,11 +1138,12 @@ class Runner:
                 result.set_status(Result.Status.ERROR).set_info(
                     f"Job got terminated with an error, exit code [{run_code}]"
                 ).dump()
-            elif res and result.ext.get(self.READ_FAILED_EXT_KEY):
+            elif not run_hooks and res and result.ext.get(self.READ_FAILED_EXT_KEY):
                 # The job exited 0 but its result is unreadable, so there is no evidence it
-                # succeeded. In CI `_get_result_object` promotes this to ERROR, but it runs
-                # under `if run_hooks:` below, which a local run skips - without this the
-                # command would exit 0 while the persisted result is not even completed.
+                # succeeded. `_get_result_object` promotes exactly this to ERROR, but it
+                # runs under `if run_hooks:` below - so only a run that skips the hooks
+                # needs the promotion here, and gating on `not run_hooks` keeps the hook
+                # path's reporting and exit code untouched.
                 info = f"Job exited [{run_code}] but left no readable result"
                 print(f"ERROR: {info}")
                 result.add_error(info).set_status(Result.Status.ERROR).dump()

--- a/ci/tests/test_result_dump_atomic.py
+++ b/ci/tests/test_result_dump_atomic.py
@@ -182,6 +182,32 @@ def test_dump_refuses_a_symlinked_temp_path(in_tmp_cwd, tmp_path):
     assert Result.from_fs(JOB_NAME).info == "pre-run"
 
 
+def test_dump_reuses_a_stale_regular_temp_file(in_tmp_cwd):
+    """`O_EXCL` is deliberately absent: a leftover temp from a previously killed dump
+    must stay reusable, or crash recovery would itself crash.
+
+    Kills the mutant that adds `| os.O_EXCL` to the `os.open` flags - it makes this
+    dump() raise FileExistsError (errno 17). `test_dump_refuses_a_symlinked_temp_path`
+    cannot substitute: O_EXCL rejects a pre-existing symlink too (with EEXIST rather
+    than ELOOP), so it fails under that mutant for the wrong reason and never observes
+    a *regular* leftover.
+    """
+    _result(status=Result.Status.RUNNING, info="pre-run").dump()
+
+    target = Result.file_name_static(JOB_NAME)
+    leftover = f"{target}.tmp.{os.getpid()}"
+    with open(leftover, "w", encoding="utf8") as f:
+        f.write('{"name": "half-written"')
+
+    _result(status=Result.Status.OK, info="landed").dump()
+
+    landed = Result.from_fs(JOB_NAME)
+    assert landed.status == Result.Status.OK
+    assert landed.info == "landed"
+    # os.replace consumed the reused temp, so no litter is left behind.
+    assert not [e for e in _temp_dir_entries() if ".tmp" in e]
+
+
 def test_dump_of_a_result_with_subresults_round_trips(in_tmp_cwd):
     """The observed failure carried 11882 sub-results; nesting must survive the rename."""
     r = _result(status=Result.Status.OK)

--- a/ci/tests/test_result_dump_atomic.py
+++ b/ci/tests/test_result_dump_atomic.py
@@ -1,0 +1,164 @@
+"""
+Tests for the atomic Result.dump().
+
+A `Stateless tests (amd_llvm_coverage, ...)` job whose 11882 tests all passed was
+reported as a red job with a completely empty `info`. The host docker daemon died
+during the post-run `llvm-profdata merge`, while `Result.dump()` was writing the
+final ~1.5 MB result JSON. The inherited `Serializable.dump` opens the target with
+mode "w", which truncates it to zero bytes before the first byte of the new payload
+is written, so the dying process left a 0-byte file and destroyed the RUNNING result
+`_pre_run` had persisted. Every subsequent read of that file raised
+`JSONDecodeError: Expecting value: line 1 column 1 (char 0)`.
+
+Writing to a sibling temp file and renaming removes that window: a reader always sees
+either the previous complete content or the new complete content.
+
+The temp file must be a *sibling* of the target. `os.replace` is atomic only within a
+single filesystem, so a temp file in /tmp (or `tempfile.mkstemp()`'s default location)
+turns every dump in CI into `OSError(EXDEV) Invalid cross-device link`.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+import pytest
+
+from ci.praktika.result import Result
+from ci.praktika.settings import Settings
+from ci.praktika.utils import MetaClasses
+
+JOB_NAME = "Stateless tests (amd_llvm_coverage, AsyncInsert, s3 storage, parallel)"
+
+
+class _Boom(Exception):
+    pass
+
+
+@pytest.fixture
+def in_tmp_cwd(tmp_path, monkeypatch):
+    """Run with `Settings.TEMP_DIR` inside a temp dir, as praktika does from the repo root."""
+    monkeypatch.chdir(tmp_path)
+    os.makedirs(Settings.TEMP_DIR, exist_ok=True)
+    return tmp_path
+
+
+def _result(status=Result.Status.RUNNING, info=""):
+    return Result(
+        name=JOB_NAME, status=status, start_time=1.0, duration=None, info=info
+    )
+
+
+def _temp_dir_entries():
+    return sorted(os.listdir(Settings.TEMP_DIR))
+
+
+def test_dump_writes_the_target_file(in_tmp_cwd):
+    """Baseline: dump() persists a readable result at the canonical path."""
+    r = _result()
+    assert r.dump() is r, "dump() must return self - callers chain .dump()"
+    assert Result.from_fs(JOB_NAME).status == Result.Status.RUNNING
+
+
+def test_dump_content_is_identical_to_the_base_implementation(in_tmp_cwd):
+    """Only the write is staged - the file *content* must not change."""
+    r = _result(status=Result.Status.OK, info="all good")
+    r.dump()
+    atomic_bytes = open(Result.file_name_static(JOB_NAME), "rb").read()
+
+    os.remove(Result.file_name_static(JOB_NAME))
+    MetaClasses.Serializable.dump(r)
+    base_bytes = open(Result.file_name_static(JOB_NAME), "rb").read()
+
+    assert atomic_bytes == base_bytes
+
+
+def test_failed_dump_keeps_the_previous_content(in_tmp_cwd):
+    """The load-bearing assertion: a write that dies partway must not destroy the
+    result already on disk. Fails if dump() writes the target in place."""
+    _result(status=Result.Status.RUNNING, info="pre-run").dump()
+
+    def _partial_then_raise(obj, f, **kwargs):
+        f.write('{"name": "partial"')
+        raise _Boom("killed mid-dump")
+
+    # A nested context (not monkeypatch.undo()) so the fixture's chdir stays in effect.
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(json, "dump", _partial_then_raise)
+        with pytest.raises(_Boom):
+            _result(status=Result.Status.OK, info="never landed").dump()
+
+    recovered = Result.from_fs(JOB_NAME)
+    assert recovered.status == Result.Status.RUNNING
+    assert recovered.info == "pre-run"
+    assert recovered.is_completed() is False
+    assert recovered.is_running() is True
+
+
+def test_failed_dump_leaves_no_temp_file(in_tmp_cwd):
+    """A raising json.dump must not leave litter beside the target."""
+    _result().dump()
+    before = _temp_dir_entries()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            json, "dump", lambda obj, f, **kwargs: (_ for _ in ()).throw(_Boom("boom"))
+        )
+        with pytest.raises(_Boom):
+            _result(status=Result.Status.OK).dump()
+
+    assert _temp_dir_entries() == before
+    assert not [e for e in _temp_dir_entries() if ".tmp" in e]
+
+
+def _spy_replace(mp):
+    """Record the (src, dst) of every os.replace performed while the patch is active."""
+    seen = []
+    real_replace = os.replace
+
+    def _spy(src, dst, **kwargs):
+        seen.append((str(src), str(dst)))
+        return real_replace(src, dst, **kwargs)
+
+    mp.setattr(os, "replace", _spy)
+    return seen
+
+
+def test_temp_file_is_a_sibling_of_the_target(in_tmp_cwd):
+    """`os.replace` is atomic only within one filesystem, so the temp file must live in
+    the target's own directory. A temp in /tmp raises OSError(EXDEV) in CI."""
+    with pytest.MonkeyPatch.context() as mp:
+        seen = _spy_replace(mp)
+        _result().dump()
+
+    target = Result.file_name_static(JOB_NAME)
+    assert seen, "dump() must rename a temp file onto the target"
+    src, dst = seen[0]
+    assert os.path.abspath(dst) == os.path.abspath(target)
+    assert os.path.dirname(os.path.abspath(src)) == os.path.dirname(
+        os.path.abspath(target)
+    )
+    assert os.path.exists(target)
+
+
+def test_temp_name_is_unique_per_process(in_tmp_cwd):
+    """Concurrent dumps of the same result from different processes must not collide."""
+    with pytest.MonkeyPatch.context() as mp:
+        seen = _spy_replace(mp)
+        _result().dump()
+    assert str(os.getpid()) in os.path.basename(seen[0][0])
+
+
+def test_dump_of_a_result_with_subresults_round_trips(in_tmp_cwd):
+    """The observed failure carried 11882 sub-results; nesting must survive the rename."""
+    r = _result(status=Result.Status.OK)
+    r.results = [
+        Result(name=f"test_{i}", status=Result.Status.OK, start_time=1.0, duration=0.1)
+        for i in range(50)
+    ]
+    r.dump()
+    got = Result.from_fs(JOB_NAME)
+    assert len(got.results) == 50
+    assert [x.name for x in got.results] == [x.name for x in r.results]

--- a/ci/tests/test_result_dump_atomic.py
+++ b/ci/tests/test_result_dump_atomic.py
@@ -18,8 +18,10 @@ single filesystem, so a temp file in /tmp (or `tempfile.mkstemp()`'s default loc
 turns every dump in CI into `OSError(EXDEV) Invalid cross-device link`.
 """
 
+import errno
 import json
 import os
+import stat
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
@@ -63,16 +65,26 @@ def test_dump_writes_the_target_file(in_tmp_cwd):
 
 
 def test_dump_content_is_identical_to_the_base_implementation(in_tmp_cwd):
-    """Only the write is staged - the file *content* must not change."""
+    """Only the write is staged - the file *content* and *mode* must not change.
+
+    The mode matters because the staged write creates the file: `open(path, "w")` creates
+    with 0o666 & ~umask, so the explicit `os.open` mode must be 0o666 as well. A stricter
+    one (`tempfile.mkstemp()` uses 0o600) would silently narrow the result file for every
+    downstream reader.
+    """
+    target = Result.file_name_static(JOB_NAME)
     r = _result(status=Result.Status.OK, info="all good")
     r.dump()
-    atomic_bytes = open(Result.file_name_static(JOB_NAME), "rb").read()
+    atomic_bytes = open(target, "rb").read()
+    atomic_mode = stat.S_IMODE(os.stat(target).st_mode)
 
-    os.remove(Result.file_name_static(JOB_NAME))
+    os.remove(target)
     MetaClasses.Serializable.dump(r)
-    base_bytes = open(Result.file_name_static(JOB_NAME), "rb").read()
+    base_bytes = open(target, "rb").read()
+    base_mode = stat.S_IMODE(os.stat(target).st_mode)
 
     assert atomic_bytes == base_bytes
+    assert oct(atomic_mode) == oct(base_mode)
 
 
 def test_failed_dump_keeps_the_previous_content(in_tmp_cwd):
@@ -149,6 +161,25 @@ def test_temp_name_is_unique_per_process(in_tmp_cwd):
         seen = _spy_replace(mp)
         _result().dump()
     assert str(os.getpid()) in os.path.basename(seen[0][0])
+
+
+def test_dump_refuses_a_symlinked_temp_path(in_tmp_cwd, tmp_path):
+    """The temp name is derived from the result path and this pid, so it is guessable. A
+    pre-existing symlink there must be refused, not written through."""
+    victim = tmp_path / "victim_outside_workspace"
+    victim.write_text("do-not-clobber")
+    _result(status=Result.Status.RUNNING, info="pre-run").dump()
+
+    target = Result.file_name_static(JOB_NAME)
+    os.symlink(victim, f"{target}.tmp.{os.getpid()}")
+
+    with pytest.raises(OSError) as ex:
+        _result(status=Result.Status.OK, info="never landed").dump()
+    assert ex.value.errno == errno.ELOOP
+
+    assert victim.read_text() == "do-not-clobber"
+    # and the previously persisted result is still readable
+    assert Result.from_fs(JOB_NAME).info == "pre-run"
 
 
 def test_dump_of_a_result_with_subresults_round_trips(in_tmp_cwd):

--- a/ci/tests/test_runner_result_finalization.py
+++ b/ci/tests/test_runner_result_finalization.py
@@ -1,0 +1,54 @@
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.praktika.result import Result
+from ci.praktika.runner import Runner
+from ci.praktika.settings import Settings
+
+
+def _use_tmp_result_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(Settings, "TEMP_DIR", str(tmp_path))
+    monkeypatch.setattr(Settings, "RUN_LOG", str(tmp_path / "job.log"))
+
+
+def _job(name="test job", force_success=False):
+    return SimpleNamespace(name=name, force_success=force_success)
+
+
+def test_result_finalization_keeps_local_run_result_when_setup_and_prerun_skipped(
+    tmp_path, monkeypatch
+):
+    _use_tmp_result_dir(tmp_path, monkeypatch)
+    job = _job()
+    Result(name=job.name, status=Result.Status.OK, start_time=1.0).dump()
+
+    result = Runner()._get_result_object(
+        job,
+        setup_env_exit_code=None,
+        prerun_exit_code=None,
+        run_exit_code=0,
+    )
+
+    assert result.status == Result.Status.OK
+    assert result.ext.get("errors") is None
+
+
+def test_result_finalization_marks_ok_result_error_on_nonzero_run_exit(
+    tmp_path, monkeypatch
+):
+    _use_tmp_result_dir(tmp_path, monkeypatch)
+    job = _job()
+    Result(name=job.name, status=Result.Status.OK, start_time=1.0).dump()
+
+    result = Runner()._get_result_object(
+        job,
+        setup_env_exit_code=0,
+        prerun_exit_code=0,
+        run_exit_code=42,
+    )
+
+    assert result.status == Result.Status.ERROR
+    assert "exit code [42]" in result.info

--- a/ci/tests/test_runner_unreadable_result_json.py
+++ b/ci/tests/test_runner_unreadable_result_json.py
@@ -49,6 +49,11 @@ class _Job:
 @pytest.fixture
 def in_tmp_cwd(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    # Runner._run sets PRAKTIKA and rewrites PYTHONPATH process-globally, and pytest does
+    # not restore process env between tests; monkeypatch does, so later tests in this
+    # worker do not inherit them.
+    for var in ("PRAKTIKA", "PYTHONPATH"):
+        monkeypatch.setenv(var, os.environ.get(var, ""))
     os.makedirs(Settings.TEMP_DIR, exist_ok=True)
     return tmp_path
 

--- a/ci/tests/test_runner_unreadable_result_json.py
+++ b/ci/tests/test_runner_unreadable_result_json.py
@@ -23,6 +23,7 @@ A genuine result is returned untouched: this must not be able to hide a real fai
 """
 
 import ast
+import dataclasses
 import os
 import sys
 import textwrap
@@ -31,6 +32,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
 import pytest
 
+from ci.praktika._environment import _Environment
+from ci.praktika.job import Job
 from ci.praktika.result import Result
 from ci.praktika.runner import Runner
 from ci.praktika.settings import Settings
@@ -240,3 +243,61 @@ def test_helper_is_defined_and_documented():
     assert "Status.ERROR" not in src, (
         "an ERROR fallback is is_completed()==True and skips the log-tail branch"
     )
+
+
+# --- the behavioral pins: the whole recovery branch of _run, end to end ---------------
+#
+# The tests above pin the helper and the source shape; neither sees the *branch*. Moving
+# the recovery out of the `with TeePopen(...)` scope loses process.get_latest_log() and
+# reinstates the blank-red-box symptom while keeping all of them green.
+
+
+def _run_job_with_unreadable_result(command):
+    """Drive Runner._run over a job whose result file is the 0-byte incident state.
+
+    No docker and no GH auth: run_in_docker="" and enable_gh_auth=False (the defaults)
+    skip those branches, so a dumped _Environment plus Settings.TEMP_DIR is all _run
+    needs. `workflow` is only dereferenced by the skipped branches.
+    """
+    required = [
+        f.name
+        for f in dataclasses.fields(_Environment)
+        if f.default is dataclasses.MISSING
+        and getattr(f, "default_factory", dataclasses.MISSING) is dataclasses.MISSING
+    ]
+    _Environment(**{n: (0 if n == "PR_NUMBER" else "") for n in required}).dump()
+
+    job = Job.Config(name=JOB_NAME, runs_on=["x"], command=command, run_in_docker="")
+    _write_result_file("")
+
+    exit_code = Runner()._run(workflow=None, job=job)
+    return exit_code, Result.from_fs(JOB_NAME)
+
+
+def test_run_persists_error_with_reason_and_log_tail_when_result_unreadable(in_tmp_cwd):
+    exit_code, persisted = _run_job_with_unreadable_result(
+        "printf 'daemon-death-tail\\n'; exit 125"
+    )
+
+    assert exit_code == 125
+    assert persisted.status == Result.Status.ERROR
+    assert persisted.is_ok() is False
+    assert "Failed to read Result json" in persisted.info
+    # ⭐ The assertion this whole test exists for: the log tail is the information the
+    # incident lacked, and it is available only inside the TeePopen scope.
+    assert "daemon-death-tail" in persisted.info
+    assert any(
+        "Job killed, exit code [125]" in e["message"]
+        for e in persisted.ext.get("errors", [])
+    )
+
+
+def test_run_leaves_result_running_when_job_succeeded_but_result_unreadable(in_tmp_cwd):
+    """A process that exited 0 must not be given a fabricated completed status here;
+    promoting it is _get_result_object's job (ResultInfo.KILLED)."""
+    exit_code, persisted = _run_job_with_unreadable_result("true")
+
+    assert exit_code == 0
+    assert persisted.status == Result.Status.RUNNING
+    assert persisted.is_completed() is False
+    assert persisted.is_ok() is False

--- a/ci/tests/test_runner_unreadable_result_json.py
+++ b/ci/tests/test_runner_unreadable_result_json.py
@@ -27,6 +27,7 @@ import dataclasses
 import os
 import sys
 import textwrap
+import types
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
@@ -306,3 +307,41 @@ def test_run_leaves_result_running_when_job_succeeded_but_result_unreadable(in_t
     assert persisted.status == Result.Status.RUNNING
     assert persisted.is_completed() is False
     assert persisted.is_ok() is False
+
+
+# --- the second job-result read, in Runner.run itself ---------------------------------
+
+
+def test_run_survives_an_unreadable_result_at_the_second_read(in_tmp_cwd, monkeypatch, capsys):
+    """`Runner.run` reads the job result a second time outside all three of its `try`
+    blocks (runner.py:1128; runner.py:1093 on master). That read is *the* crash site of
+    the incident, and no other test executes it - both behavioral tests above drive
+    `_run` instead.
+
+    An AST pin alone cannot cover it: `Result.from_fs(name)` is
+    `cls.from_file(cls.file_name_static(name))`, so writing the equivalent
+    `Result.from_file(Result.file_name_static(job.name))` unparses differently, keeps
+    `test_no_unguarded_job_result_read_remains_in_run_or__run` green, and reinstates the
+    unhandled JSONDecodeError.
+    """
+    workflow = types.SimpleNamespace(name="W", dockers=[], event="push")
+    job = Job.Config(name=JOB_NAME, runs_on=["x"], command="true", run_in_docker="")
+
+    def _died_leaving_an_unreadable_result(self, workflow, job, **kwargs):
+        # generate_local_run_environment ends with a PENDING dump(), so the incident
+        # state has to be written here - after it, and before run() reads it back.
+        _write_result_file("")
+        return 125
+
+    monkeypatch.setattr(Runner, "_run", _died_leaving_an_unreadable_result)
+
+    with pytest.raises(SystemExit) as ex:
+        Runner().run(workflow=workflow, job=job, local_run=True, run_hooks=False)
+
+    # ⭐ Load-bearing: reaching the exit at all means the read degraded. With an
+    # unguarded read this test fails with json.decoder.JSONDecodeError instead - which
+    # is why this must not be pytest.raises(Exception).
+    assert ex.value.code == 1
+    # The print sits *after* the read, so it is direct evidence control got past it. On
+    # master this line is absent from the job log, which is the reported symptom.
+    assert "=== Run script finished ===" in capsys.readouterr().out

--- a/ci/tests/test_runner_unreadable_result_json.py
+++ b/ci/tests/test_runner_unreadable_result_json.py
@@ -1,0 +1,242 @@
+"""
+Tests for Runner._read_job_result_or_running.
+
+A `Stateless tests (amd_llvm_coverage, ...)` job whose 11882 tests all passed was
+reported as a red job with a completely empty `info`. The host docker daemon died during
+post-run processing and left the job result JSON empty; `Result.from_fs` then raised
+`JSONDecodeError`, and because the second of the two job-result reads in `Runner.run`
+was unguarded the exception escaped to the interpreter and killed the runner *before*
+the reporting path that attaches the log tail, uploads `job.log`, and sets the commit
+status. Nothing ever wrote a reason, which is why `info` was empty.
+
+Two properties are pinned here:
+
+* the read degrades instead of raising, and
+
+* it degrades to **RUNNING**, not ERROR. `is_completed()` is
+  "status not in (PENDING, RUNNING)", so an ERROR result is already completed and would
+  skip `_run`'s `if not result.is_completed():` branch - the only place that records why
+  the job died and attaches `process.get_latest_log()`. Synthesizing ERROR therefore
+  removes the crash while preserving the blank-red-box symptom.
+
+A genuine result is returned untouched: this must not be able to hide a real failure.
+"""
+
+import ast
+import os
+import sys
+import textwrap
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+import pytest
+
+from ci.praktika.result import Result
+from ci.praktika.runner import Runner
+from ci.praktika.settings import Settings
+
+JOB_NAME = "Stateless tests (amd_llvm_coverage, AsyncInsert, s3 storage, parallel)"
+
+
+class _Job:
+    def __init__(self, name=JOB_NAME):
+        self.name = name
+
+
+@pytest.fixture
+def in_tmp_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    os.makedirs(Settings.TEMP_DIR, exist_ok=True)
+    return tmp_path
+
+
+def _write_result_file(content):
+    with open(Result.file_name_static(JOB_NAME), "w", encoding="utf8") as f:
+        f.write(content)
+
+
+# --- the degradation, over the whole unreadable class ---------------------------------
+
+
+@pytest.mark.parametrize(
+    "content, label",
+    [
+        ("", "empty file left by a killed writer"),
+        ('{"na', "truncated mid-key"),
+        ('{"name": "x", "status": "OK"', "truncated before the closing brace"),
+        ("not json at all", "garbage"),
+    ],
+)
+def test_unreadable_result_does_not_raise_and_is_running(in_tmp_cwd, content, label):
+    _write_result_file(content)
+    # Sanity: the file *is* unreadable, so this test is not vacuous.
+    assert Result.exist(JOB_NAME) is True, label
+    with pytest.raises(Exception):
+        Result.from_fs(JOB_NAME)
+
+    result = Runner._read_job_result_or_running(_Job())
+
+    assert result is not None, "must return a usable Result, not None"
+    assert result.name == JOB_NAME
+    # ⭐ The load-bearing assertion. A synthesized ERROR would pass "does not raise" while
+    # silently skipping the branch that attaches the log tail.
+    assert result.is_completed() is False
+    assert result.is_running() is True
+    assert result.status == Result.Status.RUNNING
+    assert result.is_ok() is False
+    assert result.info, "the reason must be reported, not swallowed"
+
+
+def test_missing_result_file_also_degrades(in_tmp_cwd):
+    """An OSError (no file, or root-owned after a failed chown) must degrade too."""
+    assert not os.path.exists(Result.file_name_static(JOB_NAME))
+    result = Runner._read_job_result_or_running(_Job())
+    assert result.status == Result.Status.RUNNING
+    assert result.is_running() is True
+
+
+def test_returned_object_is_a_usable_result(in_tmp_cwd):
+    """`run()` calls `.is_ok()` on the returned value on the very next line; returning
+    None would merely move the crash."""
+    _write_result_file("")
+    result = Runner._read_job_result_or_running(_Job())
+    assert isinstance(result, Result)
+    assert result.is_ok() is False
+    assert result.is_error() is False
+    assert callable(result.dump)
+
+
+# --- the genuine-failure control: nothing may be masked -------------------------------
+
+
+def test_a_real_test_failure_is_returned_unchanged(in_tmp_cwd):
+    """The one way this fix could do harm is by relabeling a real failure."""
+    original = Result(
+        name=JOB_NAME,
+        status=Result.Status.FAIL,
+        start_time=1.0,
+        duration=2.0,
+        info="Failures: 3/11882",
+        results=[
+            Result(
+                name="00001_select_1", status=Result.Status.FAIL, start_time=1.0,
+                duration=0.5,
+            )
+        ],
+    )
+    original.dump()
+
+    result = Runner._read_job_result_or_running(_Job())
+
+    assert result.status == Result.Status.FAIL
+    assert result.info == "Failures: 3/11882"
+    assert [r.name for r in result.results] == ["00001_select_1"]
+    assert result.is_completed() is True
+
+
+def test_a_passing_result_is_returned_unchanged(in_tmp_cwd):
+    Result(
+        name=JOB_NAME, status=Result.Status.OK, start_time=1.0, duration=2.0
+    ).dump()
+    result = Runner._read_job_result_or_running(_Job())
+    assert result.status == Result.Status.OK
+    assert result.is_ok() is True
+
+
+# --- structural pins on where the guarded read is used -------------------------------
+
+
+def _runner_ast():
+    path = os.path.join(os.path.dirname(__file__), "../praktika/runner.py")
+    return ast.parse(open(path, encoding="utf8").read()), path
+
+
+def _function(tree, name):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"function {name} not found")
+
+
+def test_no_unguarded_job_result_read_remains_in_run_or__run():
+    """Both job-result reads in the crash path must go through the guarded helper.
+
+    `_get_result_object` keeps its own explicit try/except, and the *workflow* result
+    reads in `_post_run` are a different file written by a different process - out of
+    scope here.
+    """
+    tree, _ = _runner_ast()
+    for fn_name in ("run", "_run"):
+        fn = _function(tree, fn_name)
+        bare = [
+            node.lineno
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Call)
+            and ast.unparse(node) == "Result.from_fs(job.name)"
+        ]
+        assert not bare, (
+            f"{fn_name} still reads the job result directly at lines {bare}; "
+            "use _read_job_result_or_running so an unreadable file cannot kill the runner"
+        )
+
+
+def test_status_reconciliation_stays_on_the_unconditional_run_path():
+    """`if not res and result.is_ok(): set_status(ERROR)` is the only conversion of a
+    completed OK result into ERROR when the run failed.
+
+    Deleting it reports a green job while the runner exits 1. Moving it into
+    `_get_result_object` loses it for local runs, since that method is called under
+    `if run_hooks:`.
+    """
+    tree, _ = _runner_ast()
+    run_fn = _function(tree, "run")
+
+    reconciliations = [
+        node
+        for node in ast.walk(run_fn)
+        if isinstance(node, ast.If)
+        and "result.is_ok()" in ast.unparse(node.test)
+        and "Status.ERROR" in ast.unparse(node)
+    ]
+    assert len(reconciliations) == 1, (
+        "expected exactly one completed-OK -> ERROR reconciliation in Runner.run"
+    )
+    node = reconciliations[0]
+
+    # It must not sit under an `if run_hooks:` (or any run_hooks-gated) block.
+    for parent in ast.walk(run_fn):
+        if isinstance(parent, ast.If) and "run_hooks" in ast.unparse(parent.test):
+            body_lines = {
+                n.lineno
+                for stmt in parent.body
+                for n in ast.walk(stmt)
+                if hasattr(n, "lineno")
+            }
+            assert node.lineno not in body_lines, (
+                "the reconciliation moved under `if run_hooks:` - local runs would lose it"
+            )
+
+    # And it must run before the on_error_hook is consulted in _get_result_object.
+    calls = [
+        n.lineno
+        for n in ast.walk(run_fn)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "_get_result_object"
+    ]
+    assert calls, "_get_result_object call not found in Runner.run"
+    assert node.lineno < min(calls), (
+        "the reconciliation must precede _get_result_object, which runs the on_error_hook"
+    )
+
+
+def test_helper_is_defined_and_documented():
+    tree, _ = _runner_ast()
+    fn = _function(tree, "_read_job_result_or_running")
+    doc = ast.get_docstring(fn) or ""
+    assert "RUNNING" in doc, "the RUNNING-vs-ERROR choice is load-bearing; document it"
+    src = textwrap.dedent(ast.unparse(fn))
+    assert "Status.RUNNING" in src
+    assert "Status.ERROR" not in src, (
+        "an ERROR fallback is is_completed()==True and skips the log-tail branch"
+    )

--- a/ci/tests/test_runner_unreadable_result_json.py
+++ b/ci/tests/test_runner_unreadable_result_json.py
@@ -345,3 +345,200 @@ def test_run_survives_an_unreadable_result_at_the_second_read(in_tmp_cwd, monkey
     # The print sits *after* the read, so it is direct evidence control got past it. On
     # master this line is absent from the job log, which is the reported symptom.
     assert "=== Run script finished ===" in capsys.readouterr().out
+
+
+# --- the local (no-hooks) path must not report success on an unreadable result ---------
+#
+# `python3 -m ci.praktika run` calls run() with local_run=True and run_hooks=False
+# (__main__.py:396-398), so `if run_hooks:` is skipped and _get_result_object - the only
+# place that promotes a non-completed result to ERROR - never runs. Degrading the read
+# without compensating here would exit 0 on a job that left no readable result, which
+# master does not do (it exits 1 via the unhandled JSONDecodeError).
+
+
+def _run_local_no_hooks(job_exit_code, leaves=None):
+    """Drive the default local invocation over a job that exits `job_exit_code`.
+
+    `leaves` is written from inside the faked `_run`, because
+    generate_local_run_environment ends with a PENDING dump() that would otherwise
+    overwrite anything staged before run() is called.
+    """
+    workflow = types.SimpleNamespace(name="W", dockers=[], event="push")
+    job = Job.Config(name=JOB_NAME, runs_on=["x"], command="true", run_in_docker="")
+
+    def _fake_run(self, workflow, job, **kwargs):
+        if leaves is None:
+            _write_result_file("")
+        else:
+            leaves()
+        return job_exit_code
+
+    return workflow, job, _fake_run
+
+
+def test_local_run_fails_when_job_exited_zero_but_left_an_unreadable_result(
+    in_tmp_cwd, monkeypatch
+):
+    """The job "succeeded" yet produced no evidence of it, so the command must fail.
+
+    Without this the local run exits 0 while the persisted result is not even completed -
+    a silent green on a job whose outcome is unknown.
+    """
+    workflow, job, fake_run = _run_local_no_hooks(0)
+    monkeypatch.setattr(Runner, "_run", fake_run)
+
+    with pytest.raises(SystemExit) as ex:
+        Runner().run(workflow=workflow, job=job, local_run=True, run_hooks=False)
+
+    assert ex.value.code == 1
+    persisted = Result.from_fs(JOB_NAME)
+    assert persisted.status == Result.Status.ERROR
+    assert persisted.is_completed() is True
+    # The reason the read failed stays in `info`; the compensation's own reason is an
+    # error entry, the same shape _run uses for "Job killed, exit code [N]".
+    assert "Failed to read Result json" in persisted.info
+    assert any(
+        "left no readable result" in e["message"]
+        for e in persisted.ext.get("errors", [])
+    )
+
+
+def test_local_run_still_succeeds_when_the_job_result_is_readable(
+    in_tmp_cwd, monkeypatch
+):
+    """The success path must stay success - the failure is keyed on the unreadable read,
+    not on the local run itself."""
+    workflow, job, fake_run = _run_local_no_hooks(
+        0,
+        leaves=lambda: Result(
+            name=JOB_NAME, status=Result.Status.OK, start_time=1.0, duration=1.0
+        ).dump(),
+    )
+    monkeypatch.setattr(Runner, "_run", fake_run)
+
+    Runner().run(workflow=workflow, job=job, local_run=True, run_hooks=False)
+
+    assert Result.from_fs(JOB_NAME).status == Result.Status.OK
+
+
+def test_local_run_does_not_fail_a_merely_non_completed_result(in_tmp_cwd, monkeypatch):
+    """⭐ The control that keeps the compensation narrow.
+
+    A local run whose job writes no result at all leaves the RUNNING/PENDING result that
+    the pre-run dump persisted, and exits 0 - on master too. So the new failure must key
+    on "the read failed" and not on `not result.is_completed()`: the broader condition
+    would turn this pre-existing, unrelated case red.
+    """
+    workflow, job, fake_run = _run_local_no_hooks(
+        0,
+        leaves=lambda: Result(
+            name=JOB_NAME, status=Result.Status.RUNNING, start_time=1.0, duration=None
+        ).dump(),
+    )
+    monkeypatch.setattr(Runner, "_run", fake_run)
+
+    Runner().run(workflow=workflow, job=job, local_run=True, run_hooks=False)
+
+    persisted = Result.from_fs(JOB_NAME)
+    assert persisted.status == Result.Status.RUNNING
+    assert persisted.is_completed() is False
+
+
+def test_a_failed_job_keeps_the_run_recovery_reason_and_log_tail(in_tmp_cwd, monkeypatch):
+    """A job that FAILED and left an unreadable result is already fully reported by `_run`
+    (ERROR + "Job killed" + the log tail). The compensation must not fire there and
+    overwrite that with its own, less informative reason - hence the `res` guard.
+    """
+    workflow = types.SimpleNamespace(name="W", dockers=[], event="push")
+    job = Job.Config(name=JOB_NAME, runs_on=["x"], command="true", run_in_docker="")
+
+    def _died_after_reporting(self, workflow, job, **kwargs):
+        # Exactly what the real _run persists here: the *synthesized* result (so the
+        # read-failed marker is still on it, which is what makes this a real test of the
+        # `res` guard) promoted to ERROR with the log tail attached.
+        _write_result_file("")
+        recovered = Runner._read_job_result_or_running(job)
+        assert recovered.ext.get(Runner.READ_FAILED_EXT_KEY) is True
+        recovered.add_error("Job killed, exit code [125]")
+        recovered.set_status(Result.Status.ERROR)
+        recovered.set_info("daemon-death-tail")
+        recovered.dump()
+        return 125
+
+    monkeypatch.setattr(Runner, "_run", _died_after_reporting)
+
+    with pytest.raises(SystemExit) as ex:
+        Runner().run(workflow=workflow, job=job, local_run=True, run_hooks=False)
+
+    assert ex.value.code == 1
+    persisted = Result.from_fs(JOB_NAME)
+    assert "daemon-death-tail" in persisted.info, "the log tail must survive"
+    messages = [e["message"] for e in persisted.ext.get("errors", [])]
+    assert "Job killed, exit code [125]" in messages
+    assert not any("left no readable result" in m for m in messages), (
+        "the compensation fired on the already-reported failure path"
+    )
+
+
+def test_synthesized_result_is_marked_and_a_genuine_one_is_not(in_tmp_cwd):
+    """The marker is what separates the two, so pin it on both sides."""
+    _write_result_file("")
+    assert (
+        Runner._read_job_result_or_running(_Job()).ext.get(Runner.READ_FAILED_EXT_KEY)
+        is True
+    )
+
+    Result(
+        name=JOB_NAME, status=Result.Status.RUNNING, start_time=1.0, duration=None
+    ).dump()
+    genuine = Runner._read_job_result_or_running(_Job())
+    assert genuine.status == Result.Status.RUNNING
+    assert not genuine.ext.get(Runner.READ_FAILED_EXT_KEY)
+
+
+def test_marker_survives_the_dump_round_trip(in_tmp_cwd):
+    """`_run` dumps the synthesized result, and `run` reads it back from disk - so the
+    marker has to round-trip through JSON or the compensation silently never fires."""
+    _write_result_file("")
+    Runner._read_job_result_or_running(_Job()).dump()
+    assert Result.from_fs(JOB_NAME).ext.get(Runner.READ_FAILED_EXT_KEY) is True
+
+
+def test_ci_path_promotion_is_not_duplicated_by_the_local_compensation():
+    """The compensation must stay in the `res and ...` branch of the run-script block.
+
+    Moving it under `if run_hooks:`, or dropping the `res` guard, would either lose it for
+    local runs or double-report on the CI path where _get_result_object already promotes.
+    """
+    tree, _ = _runner_ast()
+    run_fn = _function(tree, "run")
+
+    compensations = [
+        node
+        for node in ast.walk(run_fn)
+        if isinstance(node, ast.If)
+        and "READ_FAILED_EXT_KEY" in ast.unparse(node.test)
+    ]
+    assert len(compensations) == 1, (
+        "expected exactly one unreadable-result compensation in Runner.run"
+    )
+    node = compensations[0]
+    # Must be the `res` *name*, not the "res" inside "result": the guard is what keeps the
+    # compensation off the already-failed path, which _run has already reported on.
+    assert any(
+        isinstance(n, ast.Name) and n.id == "res" for n in ast.walk(node.test)
+    ), (
+        "the compensation must not fire when the job already failed - that path is "
+        "handled by the is_ok() reconciliation above it"
+    )
+    for parent in ast.walk(run_fn):
+        if isinstance(parent, ast.If) and "run_hooks" in ast.unparse(parent.test):
+            body_lines = {
+                n.lineno
+                for stmt in parent.body
+                for n in ast.walk(stmt)
+                if hasattr(n, "lineno")
+            }
+            assert node.lineno not in body_lines, (
+                "the compensation moved under `if run_hooks:` - local runs would lose it"
+            )

--- a/ci/tests/test_runner_unreadable_result_json.py
+++ b/ci/tests/test_runner_unreadable_result_json.py
@@ -190,30 +190,52 @@ def test_no_unguarded_job_result_read_remains_in_run_or__run():
         )
 
 
-def test_status_reconciliation_stays_on_the_unconditional_run_path():
-    """`if not res and result.is_ok(): set_status(ERROR)` is the only conversion of a
-    completed OK result into ERROR when the run failed.
+def test_status_reconciliation_is_centralized_in_get_result_object():
+    """A completed OK result must still become ERROR when the process failed.
 
-    Deleting it reports a green job while the runner exits 1. Moving it into
-    `_get_result_object` loses it for local runs, since that method is called under
-    `if run_hooks:`.
+    The conversion belongs in `_get_result_object`, and `Runner.run` must call that
+    method outside the `run_hooks` gate so local hook-less runs keep the same
+    normalization.
     """
     tree, _ = _runner_ast()
     run_fn = _function(tree, "run")
+    get_result_fn = _function(tree, "_get_result_object")
 
     reconciliations = [
+        node
+        for node in ast.walk(get_result_fn)
+        if isinstance(node, ast.If)
+        and "run_exit_code" in ast.unparse(node.test)
+        and "result.is_ok()" in ast.unparse(node.test)
+        and "Status.ERROR" in ast.unparse(node)
+    ]
+    assert len(reconciliations) == 1, (
+        "expected exactly one completed-OK -> ERROR reconciliation in "
+        "`_get_result_object`"
+    )
+
+    run_reconciliations = [
         node
         for node in ast.walk(run_fn)
         if isinstance(node, ast.If)
         and "result.is_ok()" in ast.unparse(node.test)
         and "Status.ERROR" in ast.unparse(node)
     ]
-    assert len(reconciliations) == 1, (
-        "expected exactly one completed-OK -> ERROR reconciliation in Runner.run"
+    assert not run_reconciliations, (
+        "Runner.run should not duplicate completed-OK -> ERROR reconciliation"
     )
-    node = reconciliations[0]
 
-    # It must not sit under an `if run_hooks:` (or any run_hooks-gated) block.
+    calls = [
+        n
+        for n in ast.walk(run_fn)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "_get_result_object"
+    ]
+    assert len(calls) == 1, "expected one `_get_result_object` call in Runner.run"
+    call = calls[0]
+
+    # It must not sit under an `if run_hooks:` block.
     for parent in ast.walk(run_fn):
         if isinstance(parent, ast.If) and "run_hooks" in ast.unparse(parent.test):
             body_lines = {
@@ -222,22 +244,10 @@ def test_status_reconciliation_stays_on_the_unconditional_run_path():
                 for n in ast.walk(stmt)
                 if hasattr(n, "lineno")
             }
-            assert node.lineno not in body_lines, (
-                "the reconciliation moved under `if run_hooks:` - local runs would lose it"
+            assert call.lineno not in body_lines, (
+                "`_get_result_object` moved under `if run_hooks:` - local runs would "
+                "lose result normalization"
             )
-
-    # And it must run before the on_error_hook is consulted in _get_result_object.
-    calls = [
-        n.lineno
-        for n in ast.walk(run_fn)
-        if isinstance(n, ast.Call)
-        and isinstance(n.func, ast.Attribute)
-        and n.func.attr == "_get_result_object"
-    ]
-    assert calls, "_get_result_object call not found in Runner.run"
-    assert node.lineno < min(calls), (
-        "the reconciliation must precede _get_result_object, which runs the on_error_hook"
-    )
 
 
 def test_helper_is_defined_and_documented():
@@ -351,10 +361,9 @@ def test_run_survives_an_unreadable_result_at_the_second_read(in_tmp_cwd, monkey
 # --- the local (no-hooks) path must not report success on an unreadable result ---------
 #
 # `python3 -m ci.praktika run` calls run() with local_run=True and run_hooks=False
-# (__main__.py:396-398), so `if run_hooks:` is skipped and _get_result_object - the only
-# place that promotes a non-completed result to ERROR - never runs. Degrading the read
-# without compensating here would exit 0 on a job that left no readable result, which
-# master does not do (it exits 1 via the unhandled JSONDecodeError).
+# (__main__.py:396-398). `_get_result_object` promotes the unreadable result to ERROR,
+# and the hook-less path must also mirror that into the command's exit code. Otherwise a
+# local run would persist an ERROR result yet return 0.
 
 
 def _run_local_no_hooks(job_exit_code, leaves=None):
@@ -395,7 +404,7 @@ def test_local_run_fails_when_job_exited_zero_but_left_an_unreadable_result(
     persisted = Result.from_fs(JOB_NAME)
     assert persisted.status == Result.Status.ERROR
     assert persisted.is_completed() is True
-    # The reason the read failed stays in `info`; the compensation's own reason is an
+    # The reason the read failed stays in `info`; the result-finalization reason is an
     # error entry, the same shape _run uses for "Job killed, exit code [N]".
     assert "Failed to read Result json" in persisted.info
     assert any(
@@ -423,7 +432,7 @@ def test_local_run_still_succeeds_when_the_job_result_is_readable(
 
 
 def test_local_run_does_not_fail_a_merely_non_completed_result(in_tmp_cwd, monkeypatch):
-    """⭐ The control that keeps the compensation narrow.
+    """⭐ The control that keeps the hook-less exit-code branch narrow.
 
     A local run whose job writes no result at all leaves the RUNNING/PENDING result that
     the pre-run dump persisted, and exits 0 - on master too. So the new failure must key
@@ -446,19 +455,19 @@ def test_local_run_does_not_fail_a_merely_non_completed_result(in_tmp_cwd, monke
 
 
 def test_hook_path_promotion_is_left_to_get_result_object(in_tmp_cwd, monkeypatch):
-    """⭐ The scope control for the compensation.
+    """⭐ The scope control for hook-less exit-code synchronization.
 
     When the hooks run, `_get_result_object` already promotes a non-completed result to
-    ERROR (ResultInfo.KILLED) and owns the exit code. Compensating here as well would
-    change that path's behaviour - it flipped a run that previously exited 0 to exit 1 -
-    so the branch is gated on `not run_hooks` and this pins that the hook path is
-    untouched.
+    ERROR. Mirroring that status into `res` here as well would change that path's
+    behaviour - it flipped a run that previously exited 0 to exit 1 - so the
+    `READ_FAILED_EXT_KEY` branch is gated on `not run_hooks` and this pins that the hook
+    path is untouched.
     """
     workflow, job, fake_run = _run_local_no_hooks(0)
     monkeypatch.setattr(Runner, "_run", fake_run)
 
-    # Capture the state the hooks are handed. Stubbing _get_result_object also keeps the
-    # rest of the hook machinery (S3, GH) out of a unit test.
+    # Capture the state `_get_result_object` is handed. Stubbing it also keeps the rest
+    # of the hook machinery (S3, GH) out of a unit test.
     seen = {}
 
     def _capture(self, job, *args, **kwargs):
@@ -472,18 +481,18 @@ def test_hook_path_promotion_is_left_to_get_result_object(in_tmp_cwd, monkeypatc
 
     Runner().run(workflow=workflow, job=job, local_run=True, run_hooks=True)
 
-    # ⭐ Load-bearing: the compensation must not have touched the result before the hooks
-    # saw it, so the promotion stays _get_result_object's single responsibility.
+    # ⭐ Load-bearing: the hook-less exit-code branch must not have touched the result
+    # before `_get_result_object` saw it, so promotion stays its single responsibility.
     assert seen["status"] == Result.Status.RUNNING
     assert not any("left no readable result" in m for m in seen["errors"]), (
-        "the compensation fired on the hook path, which _get_result_object owns"
+        "the hook-less exit-code branch fired on the hook path"
     )
 
 
 def test_a_failed_job_keeps_the_run_recovery_reason_and_log_tail(in_tmp_cwd, monkeypatch):
     """A job that FAILED and left an unreadable result is already fully reported by `_run`
-    (ERROR + "Job killed" + the log tail). The compensation must not fire there and
-    overwrite that with its own, less informative reason - hence the `res` guard.
+    (ERROR + "Job killed" + the log tail). The result finalization must not overwrite
+    that with its own, less informative reason.
     """
     workflow = types.SimpleNamespace(name="W", dockers=[], event="push")
     job = Job.Config(name=JOB_NAME, runs_on=["x"], command="true", run_in_docker="")
@@ -512,7 +521,7 @@ def test_a_failed_job_keeps_the_run_recovery_reason_and_log_tail(in_tmp_cwd, mon
     messages = [e["message"] for e in persisted.ext.get("errors", [])]
     assert "Job killed, exit code [125]" in messages
     assert not any("left no readable result" in m for m in messages), (
-        "the compensation fired on the already-reported failure path"
+        "result finalization overwrote the already-reported failure path"
     )
 
 
@@ -534,44 +543,51 @@ def test_synthesized_result_is_marked_and_a_genuine_one_is_not(in_tmp_cwd):
 
 def test_marker_survives_the_dump_round_trip(in_tmp_cwd):
     """`_run` dumps the synthesized result, and `run` reads it back from disk - so the
-    marker has to round-trip through JSON or the compensation silently never fires."""
+    marker has to round-trip through JSON or the hook-less exit-code synchronization
+    silently never fires."""
     _write_result_file("")
     Runner._read_job_result_or_running(_Job()).dump()
     assert Result.from_fs(JOB_NAME).ext.get(Runner.READ_FAILED_EXT_KEY) is True
 
 
-def test_ci_path_promotion_is_not_duplicated_by_the_local_compensation():
-    """The compensation must stay in the `res and ...` branch of the run-script block.
+def test_unreadable_marker_only_controls_hookless_exit_code_in_run():
+    """`Runner.run` must not duplicate result-status finalization.
 
-    Moving it under `if run_hooks:`, or dropping the `res` guard, would either lose it for
-    local runs or double-report on the CI path where _get_result_object already promotes.
+    `_get_result_object` owns the status mutation. The only remaining use of
+    `READ_FAILED_EXT_KEY` in `Runner.run` is to turn the hook-less local command into a
+    failing process when finalization found an unreadable result.
     """
     tree, _ = _runner_ast()
     run_fn = _function(tree, "run")
 
-    compensations = [
+    marker_branches = [
         node
         for node in ast.walk(run_fn)
         if isinstance(node, ast.If)
         and "READ_FAILED_EXT_KEY" in ast.unparse(node.test)
     ]
-    assert len(compensations) == 1, (
-        "expected exactly one unreadable-result compensation in Runner.run"
+    assert len(marker_branches) == 1, (
+        "expected exactly one unreadable-result exit-code branch in Runner.run"
     )
-    node = compensations[0]
+    node = marker_branches[0]
+    node_src = ast.unparse(node)
     # It must be scoped to the hook-less run: with the hooks on, _get_result_object does
-    # the promotion and owns the exit code.
+    # the promotion while preserving the existing process exit behaviour.
     assert "run_hooks" in ast.unparse(node.test), (
-        "the compensation must be gated on `not run_hooks` - otherwise it also changes "
-        "the hook path, where _get_result_object already promotes the result"
+        "the exit-code branch must be gated on `not run_hooks` - otherwise it also "
+        "changes the hook path"
     )
     # Must be the `res` *name*, not the "res" inside "result": the guard is what keeps the
-    # compensation off the already-failed path, which _run has already reported on.
+    # exit-code branch off the already-failed path, which _run has already reported on.
     assert any(
         isinstance(n, ast.Name) and n.id == "res" for n in ast.walk(node.test)
     ), (
-        "the compensation must not fire when the job already failed - that path is "
+        "the exit-code branch must not fire when the job already failed - that path is "
         "handled by the is_ok() reconciliation above it"
+    )
+    assert "set_status" not in node_src and "add_error" not in node_src, (
+        "Runner.run should only update `res`; result mutation belongs to "
+        "`_get_result_object`"
     )
     for parent in ast.walk(run_fn):
         if isinstance(parent, ast.If) and "run_hooks" in ast.unparse(parent.test):
@@ -582,5 +598,6 @@ def test_ci_path_promotion_is_not_duplicated_by_the_local_compensation():
                 if hasattr(n, "lineno")
             }
             assert node.lineno not in body_lines, (
-                "the compensation moved under `if run_hooks:` - local runs would lose it"
+                "the exit-code branch moved under `if run_hooks:` - local runs would "
+                "lose it"
             )

--- a/ci/tests/test_runner_unreadable_result_json.py
+++ b/ci/tests/test_runner_unreadable_result_json.py
@@ -35,7 +35,7 @@ import pytest
 
 from ci.praktika._environment import _Environment
 from ci.praktika.job import Job
-from ci.praktika.result import Result
+from ci.praktika.result import Result, ResultInfo
 from ci.praktika.runner import Runner
 from ci.praktika.settings import Settings
 
@@ -50,10 +50,11 @@ class _Job:
 @pytest.fixture
 def in_tmp_cwd(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    # Runner._run sets PRAKTIKA and rewrites PYTHONPATH process-globally, and pytest does
-    # not restore process env between tests; monkeypatch does, so later tests in this
-    # worker do not inherit them.
-    for var in ("PRAKTIKA", "PYTHONPATH"):
+    # Runner._run sets PRAKTIKA and rewrites PYTHONPATH process-globally, and
+    # generate_local_run_environment sets JOB_NAME and CHECK_NAME (runner.py:36-37).
+    # pytest does not restore process env between tests; monkeypatch does, so later tests
+    # in this worker do not inherit them.
+    for var in ("PRAKTIKA", "PYTHONPATH", "JOB_NAME", "CHECK_NAME"):
         monkeypatch.setenv(var, os.environ.get(var, ""))
     os.makedirs(Settings.TEMP_DIR, exist_ok=True)
     return tmp_path
@@ -444,6 +445,41 @@ def test_local_run_does_not_fail_a_merely_non_completed_result(in_tmp_cwd, monke
     assert persisted.is_completed() is False
 
 
+def test_hook_path_promotion_is_left_to_get_result_object(in_tmp_cwd, monkeypatch):
+    """⭐ The scope control for the compensation.
+
+    When the hooks run, `_get_result_object` already promotes a non-completed result to
+    ERROR (ResultInfo.KILLED) and owns the exit code. Compensating here as well would
+    change that path's behaviour - it flipped a run that previously exited 0 to exit 1 -
+    so the branch is gated on `not run_hooks` and this pins that the hook path is
+    untouched.
+    """
+    workflow, job, fake_run = _run_local_no_hooks(0)
+    monkeypatch.setattr(Runner, "_run", fake_run)
+
+    # Capture the state the hooks are handed. Stubbing _get_result_object also keeps the
+    # rest of the hook machinery (S3, GH) out of a unit test.
+    seen = {}
+
+    def _capture(self, job, *args, **kwargs):
+        handed = Runner._read_job_result_or_running(job)
+        seen["status"] = handed.status
+        seen["errors"] = [e["message"] for e in handed.ext.get("errors", [])]
+        # What the real _get_result_object does with a non-completed result.
+        return handed.add_error(ResultInfo.KILLED).set_status(Result.Status.ERROR)
+
+    monkeypatch.setattr(Runner, "_get_result_object", _capture)
+
+    Runner().run(workflow=workflow, job=job, local_run=True, run_hooks=True)
+
+    # ⭐ Load-bearing: the compensation must not have touched the result before the hooks
+    # saw it, so the promotion stays _get_result_object's single responsibility.
+    assert seen["status"] == Result.Status.RUNNING
+    assert not any("left no readable result" in m for m in seen["errors"]), (
+        "the compensation fired on the hook path, which _get_result_object owns"
+    )
+
+
 def test_a_failed_job_keeps_the_run_recovery_reason_and_log_tail(in_tmp_cwd, monkeypatch):
     """A job that FAILED and left an unreadable result is already fully reported by `_run`
     (ERROR + "Job killed" + the log tail). The compensation must not fire there and
@@ -523,6 +559,12 @@ def test_ci_path_promotion_is_not_duplicated_by_the_local_compensation():
         "expected exactly one unreadable-result compensation in Runner.run"
     )
     node = compensations[0]
+    # It must be scoped to the hook-less run: with the hooks on, _get_result_object does
+    # the promotion and owns the exit code.
+    assert "run_hooks" in ast.unparse(node.test), (
+        "the compensation must be gated on `not run_hooks` - otherwise it also changes "
+        "the hook path, where _get_result_object already promotes the result"
+    )
     # Must be the `res` *name*, not the "res" inside "result": the guard is what keeps the
     # compensation off the already-failed path, which _run has already reported on.
     assert any(


### PR DESCRIPTION
Do not let an unreadable job result JSON kill the praktika runner before it reports

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/109673
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not user-facing: CI harness only.


### Description

A `Stateless tests (amd_llvm_coverage, AsyncInsert, s3 storage, parallel)` job whose **11882 tests
all passed** was reported as a red node with a **completely empty `info`** - a blank red box in the
report, no artifacts uploaded, and the dependent `LLVM Coverage` job plus `Mergeable Check` reddened
with it. CIDB records `check_status='error'`, `test_name=''` and zero failing test rows.

Observed on
[this job](https://github.com/ClickHouse/ClickHouse/actions/runs/30228337981/job/89876904024)
([report](https://s3.amazonaws.com/clickhouse-test-reports/PRs/111931/0a13c21a5dcef46d7a82300eec90c955ab8852a1/result_pr.json)),
and 39 times on that shard alone over the last 21 days across 38 unrelated PRs (26 more on
`ParallelReplicas, s3 storage, parallel`, 13 on `old analyzer, ... 2/3`, plus ~20 singletons on the
other coverage shards). It concentrates on the longest coverage jobs, i.e. the ones with the
heaviest post-run `.profraw` merge.

#### Root cause

The job finished all tests, then spent ~4 minutes in post-processing (jemalloc flamegraphs, then
`llvm-profdata merge` of 22 x 176 MB `.profraw` files). Mid-merge the host docker daemon went away:

```
level=error msg="Error waiting for container: Canceled: grpc: the client connection is closing: context canceled"
--- Fixing file ownership after running docker as root
error during connect: Get "http://%2Fvar%2Frun%2Fdocker.sock/_ping": EOF
```

`Serializable.dump` is `open(self.file_name(), "w")` + `json.dump`, and `open(..., "w")` truncates
the target to **zero bytes before the first byte of the payload is written**. A process killed inside
that window therefore leaves a 0-byte result file, destroying the `RUNNING` result `_pre_run` had
persisted. The from-root `chown` whose entire purpose is to make that file host-readable failed too
(the daemon was gone), and its `Shell.run` return value is discarded.

`Result.from_fs` then raises `JSONDecodeError: Expecting value: line 1 column 1 (char 0)`. There are
two job-result reads in `Runner.run`:

* `runner.py:490`, inside `with TeePopen(...) as process:`. Its raise unwinds into `run`'s `try`
  (body `1071..1086`, `except Exception` at `1087..1091`) and is **caught** - the first traceback in
  the log carries praktika's own `[timestamp]` prefix because `traceback.print_exc()` printed it.
* `runner.py:1093`, which is **not** guarded, while its sibling at `:548` already is. Its raise is
  the interpreter's own unhandled-exception dump (second traceback, no timestamp prefix, via
  `runpy` -> `__main__.py:393`), immediately followed by
  `##[error]Process completed with exit code 1`.

So the runner dies at `:1093`, before `_get_result_object`, `_post_run`, the html report hook, the
S3 upload and the commit status - `grep` of the job log finds `=== Run script finished`,
`=== Post run script` and `Run html report hook` **zero** times. Nothing ever attaches a reason, so
`_finish_workflow` (`native_jobs.py:1049-1083`) later finds the job result `not is_completed()`,
stamps `ERROR` and records `NOT_FINALIZED`. That is exactly why `info` is empty.

#### The fix

**1. Make `Result.dump()` atomic** (`ci/praktika/result.py`). Write to a sibling temp file,
`flush` + `fsync`, then `os.replace()` onto the target, removing the temp on any failure. A reader
now always sees either the previous complete content or the new complete content. `Result` inherits
`dump()` and defines none of its own on master, so this single override covers every `Result` write
path - all of `complete_job`, `copy_result_to_s3[_with_version]` and the `_dump_if_persisted` setter
path included. The file *content* is byte-identical to the base implementation - only the write is
staged. The temp must be a **sibling**: `os.replace` is atomic only within one filesystem.

Scoped deliberately to `Result`. `MetaClasses.Serializable.dump` and `SerializableSingleton.dump` are
the same in-place `open(..., "w")` pattern, so `_Environment`, `RunConfig`, `TestCaseIssueCatalog`,
`StorageUsage` and `ComputeUsage` can lose their files the same way. None of them is the file that
caused this incident, and losing a usage counter degrades a metric rather than blanking a job report,
so widening the change is left for whoever wants it rather than bundled here.

This also fixes the *write* half of the same infra event, which is easy to miss. When the from-root
`chown` fails the result file is left root-owned, and the base `open(target, "w")` then raises
`PermissionError` on the host side; `os.replace` needs write permission on the *directory*, not on
the target, so the host-side dump at `runner.py:510` succeeds where an in-place write could not.

The temp path is derived from the result path and this pid, so it is guessable by anything sharing
the worktree. The staged write therefore uses
`os.open(tmp, O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW, 0o666)` rather than `open(tmp, "w")`: a
pre-existing symlink at the temp path is refused with `ELOOP` instead of being written through.
Two details are deliberate. The mode is `0o666` so that, after umask, the created file's mode is
byte-identical to what `open(path, "w")` produces (`0o664` under the CI umask) - `tempfile.mkstemp()`
would silently narrow the result file to `0o600` for every downstream reader, and its random name
would also give up the per-pid determinism. And the flags do **not** include `O_EXCL`: a leftover
temp from a previously killed dump must stay reusable, otherwise the very crash this method exists
to survive would turn into a hard `FileExistsError`. Both properties are pinned by tests.

**2. Recover at the `_run` read** (`ci/praktika/runner.py`). A new
`Runner._read_job_result_or_running` returns a **`RUNNING`** result when the file is unreadable, so
control enters the *existing* `if not result.is_completed():` branch, which records
`Job killed, exit code [...]`, sets `ERROR` and attaches `process.get_latest_log(max_lines=20)`.
This has to be inside `with TeePopen(...) as process:` (lines `469..510`) - `process` is referenced
in `_run` and nowhere else, so a recovery at `:1093` could never reach the log tail.

The `RUNNING` status is load-bearing, not cosmetic. `is_completed()` is
`status not in (PENDING, RUNNING)`, so a synthesized `ERROR` is already completed and **skips** the
branch above:

| synthesized status | `is_completed()` | enters the log-tail branch? | resulting `info` |
|---|---|---|---|
| `ERROR` | True | no | bare `Failed to read Result json, ex: [...]` |
| `RUNNING` | False | yes | `Job killed, exit code [...]` + the log tail |

`RUNNING` is also what the process actually was: it is precisely the state `_pre_run` persisted, so
the fallback reconstructs reality rather than inventing it.

**3. Make the second read safe** (`ci/praktika/runner.py`) - the same helper at `:1093`. The
`if not res and result.is_ok(): set_status(ERROR)` reconciliation right below it is **kept exactly
where it is**, on the unconditional run path: it is the only conversion of a completed `OK` result
into `ERROR` when the run failed (`_get_result_object` only promotes results that are *not*
completed), and it must stay outside `if run_hooks:` so ordinary local runs keep it and it stays
ahead of the `on_error_hook`.

`_get_result_object`'s own guard is left unchanged - it is the last-resort path, and with no
`process` in scope there its terminal `ERROR` is correct. The two *workflow*-result reads in
`_post_run` read a different file written by a different process; they are a separate concern and
are not touched here.

**4. Keep the hook-less local run red** (`ci/praktika/runner.py`). `python3 -m ci.praktika run`
calls `run` with `local_run=True` and `run_hooks=False` (`__main__.py:396-398`), so the
`if run_hooks:` block - and with it `_get_result_object`, the only place that promotes a
non-completed result - is skipped. Degrading the read there would report success for a job that
exited `0` but left nothing readable, where before the degradation the unhandled `JSONDecodeError`
exited `1`. So when the hooks are skipped, a *synthesized* result is promoted to `ERROR` and clears
`res`, which restores the old exit code with a readable reason instead of a traceback.

The condition is "the read failed", tracked by an `ext` marker set only in the fallback - not
`not result.is_completed()`. A local run whose job writes no result at all legitimately ends on the
`RUNNING`/`PENDING` result the pre-run dump persisted and exits `0` on master too, so the broader
condition would turn that pre-existing, unrelated case red. It is also gated on `not run_hooks`
(the hook path's promotion and exit code are unchanged, measured) and on `res` (a job that already
failed has been reported by `_run`, log tail included).

#### This cannot hide a failure

The job stays red on every path. The fallback's `is_ok()` is `False`, so
`_get_result_object` promotes it to `ERROR` and `_finish_workflow` still counts it in
`failed_results`. A valid result holding a real test `FAIL` is returned byte-unchanged - there is an
explicit test for that. The change converts *a crash with no information* into *a red job that says
why*, and `Serializable.from_file` still raises: only these two callers decide to degrade.

One intended consequence worth naming: once `:1093` no longer aborts, `_get_result_object` promotes
and dumps the result, so `native_jobs.py:1049`'s `not is_completed()` stops firing for this
signature and `NOT_FINALIZED` is no longer recorded. The reason moves from nowhere into the job's own
`info`.

#### Testing

Two new pure-Python files under `ci/tests/` (which runs on every PR), 31 tests, no build required:

* `test_result_dump_atomic.py` - a write that dies partway leaves the previous complete content
  readable; the temp file is a sibling of the target and uniquely named per process; no temp is left
  behind on failure; content **and mode** are identical to the base implementation; a symlink at the
  temp path is refused with `ELOOP` while both the symlink target and the previously persisted result
  stay intact; a stale *regular* temp left by a previously killed dump is reused rather than rejected;
  nesting round-trips.
* `test_runner_unreadable_result_json.py` - empty / truncated-mid-key / truncated-before-brace /
  garbage / missing file all degrade to a `RUNNING`, `is_completed() is False`, `is_ok() is False`
  result with the reason in `info`; a genuine `FAIL` and a genuine `OK` are returned unchanged; AST
  assertions pin that no bare `Result.from_fs(job.name)` returns to `run`/`_run` and that the
  reconciliation stays on the unconditional path, outside `if run_hooks:`, ahead of
  `_get_result_object`; two tests drive the real `Runner._run` in-process over a 0-byte result
  file (no docker, no server, no build) and assert on the result read back from disk - `exit 125`
  gives `ERROR` carrying both the read error and the job's own log tail in `info` plus
  `Job killed, exit code [125]` in `errors`, while `exit 0` stays `RUNNING` so promoting it remains
  `_get_result_object`'s job; and one drives the real `Runner.run` so the second read, the one that
  actually killed the runner, is executed rather than only pinned by AST. The hook-less local path
  has its own group: a job that exits `0` leaving an unreadable result makes the command exit `1`
  with `ERROR`; a readable `OK` still exits `0`; a merely `RUNNING` result is left alone (the control
  that keeps the condition off `is_completed()`); the hook path is handed an untouched `RUNNING`
  result so the promotion stays `_get_result_object`'s; the already-failed path keeps `_run`'s log
  tail; and the marker is present only on a synthesized result and survives the dump round trip.

Both directions: the 31 tests fail 23/31 against unmodified `master` sources and pass 31/31 with the
change; on master the first `_run` test fails by *raising* `JSONDecodeError` out of `runner.py:490`
and the `run` test by raising it out of `runner.py:1093`, i.e. by the crash itself rather than by an
assertion. 27 mutants were run, each killed by its predicted assertion - including the important one,
synthesizing `ERROR` instead of `RUNNING`, which removes the crash while silently suppressing the log
tail, and the closely related one that moves the recovery out of the `with TeePopen(...)` scope. Both
are caught by `"daemon-death-tail" in persisted.info`, the first also by `is_completed() is False`.
Rewriting the second read as the equivalent `Result.from_file(Result.file_name_static(job.name))` is a
mutant too: it slips past the AST pin and is caught only by the `Runner.run` test. Dropping
`O_NOFOLLOW`, narrowing the mode to `0o600` and using `O_EXCL` are mutants as well - the first two die
on the symlink test and the mode assertion, the third on the stale-regular-temp test (the symlink test
rejects `O_EXCL` too, but with `EEXIST` rather than `ELOOP`, i.e. for the wrong reason). Six of the
27 target the hook-less local path: deleting the promotion, broadening it to `not is_completed()`,
dropping the marker, dropping the `res` guard, dropping the `not run_hooks` gate, and persisting
`ERROR` without clearing `res`. The full `ci/tests/` suite was run before and after; the three
pre-existing cases that need a live server on the machine used here flap independently of this diff,
so the clean A/B excludes exactly those: 482 -> 487 passed with 0 failures in both arms, i.e. exactly
the new tests.

Also measured directly on the default local invocation, over six job outcomes (unreadable / garbage /
no-result / failed / `OK` / failed-with-result): every exit code now matches unmodified `master`,
with a readable `ERROR` in place of the traceback in the two unreadable cases.

`fsync` adds a sync per dump; against an ~80-minute coverage job with a ~1.5 MB result payload
(~32 ms to serialize) that is negligible. It can be dropped if preferred - the atomicity guarantee
comes from `os.replace`, not from `fsync`, and no durability beyond that is claimed.

The `.gitignore` hunk is why running the suite locally is now clean: the pre-existing
`ci/tests/test_e2e.py` renames `ci/tmp` to `ci/tmp_result` (and `ci/tmp_backup`) in its `finally`
blocks, and only `/ci/tmp` was ignored, so both scratch directories showed up as untracked source
after any `ci/tests/` run. The test itself is left alone.

#### Relation to #109673

[#109673](https://github.com/ClickHouse/ClickHouse/pull/109673) labels a docker-daemon-death
truncation as infra so the job is auto-retried. Its label sits inside the
`exit_code != 0` / `not result.is_completed()` branch, which this signature cannot reach today
because the read above it raises. The two are complementary: that PR decides what to do once the
branch is entered, this one makes an unreadable result file reach it at all. Its `is_completed()`
precondition is provably satisfied by the `RUNNING` synthesis; no claim is made here about
auto-retry firing end to end.

Prior art for the shape (praktika fix + a `ci/tests/` regression test for a docker-daemon-death
class): merged [#109096](https://github.com/ClickHouse/ClickHouse/pull/109096).

No related open issue found for this signature.
