### PR TITLE
Make 04650_join_use_nulls_repeated_on_condition_in_where runnable on release branches

### DIFF
--- a/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.sql
+++ b/tests/queries/0_stateless/04650_join_use_nulls_repeated_on_condition_in_where.sql
@@ -1,8 +1,9 @@
--- The plan assertions below match analyzer-generated column identifiers (`__table2.`) in the legacy
--- `EXPLAIN` output, so both are pinned for the whole file. The old analyzer does not build the plan
--- shape that triggers this bug, so nothing is lost by pinning.
+-- The plan assertions below match analyzer-generated column identifiers (`__table2.`), so the
+-- analyzer is pinned for the whole file. The old analyzer does not build the plan shape that
+-- triggers this bug, so nothing is lost by pinning. The plan-asserting `EXPLAIN` spells its output
+-- options in the statement itself instead of relying on a session default, so this file stays
+-- runnable on release branches that predate `explain_query_plan_default`.
 SET enable_analyzer = 1;
-SET explain_query_plan_default = 'legacy';
 
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;
@@ -32,13 +33,13 @@ SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_ou
 -- atoms to stay on one shared filter step below the join.
 SELECT 'the colliding AND atom is renamed';
 SELECT count() > 0 FROM (
-    EXPLAIN actions = 1, pretty = 0
+    EXPLAIN actions = 1, compact = 0, pretty = 0
     SELECT t1.id, t2.reviewer
     FROM t1 LEFT JOIN t2 ON t1.id = t2.id AND t2.enabled = true
     WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
     SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1,
              query_plan_remove_unused_columns = 1, query_plan_merge_filter_into_join_condition = 0,
-             query_plan_optimize_join_order_randomize = 0, optimize_move_to_prewhere = 0,
+             query_plan_optimize_join_order_limit = 0, optimize_move_to_prewhere = 0,
              query_plan_optimize_prewhere = 0
 ) WHERE position(explain, 'AND column: equals(__table2.enabled, 1_Bool)_0') > 0;
 
@@ -55,7 +56,7 @@ SELECT max(toUInt32OrZero(extract(explain, 'FilterTransform[^0-9]+([0-9]+)'))) >
     WHERE t1.grp = 10 AND t2.reviewer = 100 AND t2.enabled = true
     SETTINGS join_use_nulls = 1, query_plan_merge_filters = 1, query_plan_convert_outer_join_to_inner_join = 1,
              query_plan_remove_unused_columns = 1, query_plan_merge_filter_into_join_condition = 0,
-             query_plan_optimize_join_order_randomize = 0, optimize_move_to_prewhere = 0,
+             query_plan_optimize_join_order_limit = 0, optimize_move_to_prewhere = 0,
              query_plan_optimize_prewhere = 0, max_threads = 1
 );
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112007
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/112007
Related: https://github.com/ClickHouse/ClickHouse/pull/112173
Related: https://github.com/ClickHouse/ClickHouse/pull/112174
Related: https://github.com/ClickHouse/ClickHouse/pull/112175
Related: https://github.com/ClickHouse/ClickHouse/pull/112176

`04650_join_use_nulls_repeated_on_condition_in_where` was added by #112007, which carries
`v26.3-must-backport` and `v26.4-must-backport`. The test names two settings that do not exist on
all backport targets, so the backported copies abort deterministically:

- `explain_query_plan_default` was added in 26.7, so on 26.6/26.5/26.4/26.3 the test's second
  statement fails with `Code: 115 ... Unknown setting 'explain_query_plan_default'` at line 5. This
  is what CI reported on #112173 (26.3) and #112174 (26.5).
- `query_plan_optimize_join_order_randomize` was added in 26.4, so it is also missing on 26.3. This
  one is latent: the run aborts on the first setting before reaching it, so fixing only the reported
  setting would have left the 26.3 backport red a second time.

Neither is a real dependency of the assertions, so both are replaced with portable spellings instead
of the test being weakened or split:

- The session pin is deleted and the one plan-asserting `EXPLAIN` spells its output options in the
  statement itself: `EXPLAIN actions = 1, compact = 0, pretty = 0`. `explain_query_plan_default`
  has a single consumer, which only installs `actions/compact/pretty` as *defaults* that
  AST-spelled options override, so the explicit spelling reproduces exactly the output the pin was
  there to guarantee. All three option names exist on every branch back to 26.3.
- `query_plan_optimize_join_order_randomize = 0` becomes `query_plan_optimize_join_order_limit = 0`,
  which exists on every branch back to 26.3 and is strictly stronger: with the limit at zero
  `optimizeJoinLogicalImpl` early-returns before the query graph is built, and that builder is the
  only consumer of the randomize seed, so the seed is never used for join-order optimization. (The
  optimization settings still materialize a seed value; nothing reads it.) So pinning the limit
  subsumes "do not fabricate join-order statistics".

`.reference` is unchanged, which is the check that the change is output-preserving. Every assertion,
every behaviour case and the whole wrapper matrix are kept as-is.

Validation, using the published per-release binaries for 26.3, 26.4, 26.5, 26.6 and 26.7:

- All 14 settings the test names are accepted on all five branches after the change; before it,
  26.3-26.6 reject `explain_query_plan_default` and 26.3 also rejects
  `query_plan_optimize_join_order_randomize`.
- The `AND column:` lines the assertion greps are emitted identically on all six branches with the
  new spelling, with the `_0` rename suffix appearing exactly where the #112007 fix is present.
- The 26.7 binary, which already carries the fix (#112176 is merged), produces output byte-identical
  to the unchanged `.reference`; so does a master build.
- On master: the test passes through the normal runner, and 50 runs with randomized settings plus 50
  without are all green. This matters because the runner randomizes
  `query_plan_optimize_join_order_limit` too, so the statement-level pin has to hold under injection.
- Mutation checks: dropping `pretty = 0` flips the rename assertion to `0` (so the assertion is
  alive, not vacuous), and reverting the join-order setting reproduces `Code: 115` on 26.3.

The 26.3/26.5/26.6 backport PRs (#112173, #112174, #112175) are bot-authored and copy the test
verbatim from master, so this has to land here and then be re-backported; I have not touched those
PRs. #112176 (26.7) is already merged and is unaffected, since the setting exists there.

Other tests that pin `explain_query_plan_default` are out of scope here: none of them is currently
failing, and it is a separate concern.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.432` (included in `26.8` and later)
<!-- ch-version-info:end -->