### PR TITLE
Fix flaky 04257/04258 text-index ProfileEvents assertions under parallel replicas

### DIFF
--- a/tests/queries/0_stateless/04257_text_index_lazy_profile_events.sql
+++ b/tests/queries/0_stateless/04257_text_index_lazy_profile_events.sql
@@ -138,6 +138,21 @@ SELECT count() FROM tab_lazy_pe WHERE hasAllTokens(s, ['adense', 'dwide'])
 SYSTEM FLUSH LOGS query_log;
 
 SELECT 'all events fired across tagged queries:';
+-- The counters are incremented on whichever replica reads the granule, so under
+-- parallel replicas they land on secondary rows whose `current_database` is `default`.
+-- Resolve the initiator rows by `current_database` (the style check also requires that
+-- filter in any test reading `system.query_log`), then aggregate over every row of
+-- those queries via `initial_query_id`.
+WITH initial_query_ids AS
+(
+    SELECT query_id
+    FROM system.query_log
+    WHERE event_date >= yesterday() AND event_time >= now() - 600
+      AND current_database = currentDatabase()
+      AND type = 'QueryFinish'
+      AND is_initial_query = 1
+      AND log_comment LIKE '04257_pe_%'
+)
 SELECT
     sum(ProfileEvents['TextIndexLazyPackedBlocksDecoded'])      > 0 AS blocks_decoded,
     sum(ProfileEvents['TextIndexLazySegmentsPrepared'])         > 0 AS segs_prepared,
@@ -150,8 +165,7 @@ SELECT
     sum(ProfileEvents['TextIndexLazyAdvanceCount'])             > 0 AS advance_called
 FROM system.query_log
 WHERE event_date >= yesterday() AND event_time >= now() - 600
-  AND current_database = currentDatabase()
   AND type = 'QueryFinish'
-  AND log_comment LIKE '04257_pe_%';
+  AND initial_query_id IN (SELECT query_id FROM initial_query_ids);
 
 DROP TABLE tab_lazy_pe;

--- a/tests/queries/0_stateless/04258_text_index_lazy_intersect_heap.sql
+++ b/tests/queries/0_stateless/04258_text_index_lazy_intersect_heap.sql
@@ -118,14 +118,28 @@ SETTINGS text_index_posting_list_apply_mode = 'materialize';
 -- advance ~n times across iterations).
 SYSTEM FLUSH LOGS query_log;
 
+-- The counters are incremented on whichever replica reads the granule, so under
+-- parallel replicas they land on secondary rows whose `current_database` is `default`.
+-- Resolve the initiator rows by `current_database` (the style check also requires that
+-- filter in any test reading `system.query_log`), then aggregate over every row of
+-- those queries via `initial_query_id`.
+WITH initial_query_ids AS
+(
+    SELECT query_id
+    FROM system.query_log
+    WHERE event_date >= yesterday() AND event_time >= now() - 600
+      AND current_database = currentDatabase()
+      AND type = 'QueryFinish'
+      AND is_initial_query = 1
+      AND log_comment IN ('04258_heap_9way', '04258_heap_9way_rows', '04258_heap_11way')
+)
 SELECT 'heap leapfrog telemetry:',
     sum(ProfileEvents['TextIndexLazyLeapfrogIntersections'])   > 0 AS leapfrog_fired,
     sum(ProfileEvents['TextIndexLazyBruteForceIntersections']) = 0 AS brute_force_not_fired,
     sum(ProfileEvents['TextIndexLazyAdvanceCount'])            > 9 AS advance_called_many_times
 FROM system.query_log
 WHERE event_date >= yesterday() AND event_time >= now() - 600
-  AND current_database = currentDatabase()
   AND type = 'QueryFinish'
-  AND log_comment IN ('04258_heap_9way', '04258_heap_9way_rows', '04258_heap_11way');
+  AND initial_query_id IN (SELECT query_id FROM initial_query_ids);
 
 DROP TABLE tab_heap;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/111918
Related: https://github.com/ClickHouse/ClickHouse/pull/112008
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`04257_text_index_lazy_profile_events` and `04258_text_index_lazy_intersect_heap` assert that the
`TextIndexLazy*` ProfileEvents fire, reading them from `system.query_log`. Under parallel replicas the
assertions intermittently see `0` for one or more events, e.g.

```
 all events fired across tagged queries:
-1	1	1	1	1	1	1	1	1
+1	1	1	1	1	1	1	0	0
```

The events do fire; they are counted on a row the assertion does not select.

`PostingListCursor::~PostingListCursor` increments six of the nine counters in the destructor
(`src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp:111-125`), i.e. on whichever thread
destroys the cursor, which is the replica that read the granule; the other three are incremented at
`:166` and `:1116`/`:1134`, equally on the reading replica. Remote ProfileEvents are not merged into the
initiator's `query_log` row: the packet the initiator receives goes into
`CurrentThread::getInternalProfileEventsQueue()` (`RemoteQueryExecutor.cpp:808-812`), which is drained only
for transmission to the client (`ProfileEventsExt.cpp:194`, reached only from
`TCPHandler::sendSelectProfileEvents` at `TCPHandler.cpp:1838`), while the `query_log` column comes from the
thread-group snapshot (`ProcessList.cpp:892` -> `executeQuery.cpp:719` -> `QueryLog.cpp:265-273`).

So the counters land on secondary `query_log` rows, whose `current_database` is not the test database (the
parallel-replica cluster entries declare no `default_database`, so the secondary session keeps the server
default), and the assertions' `current_database = currentDatabase()` predicate excludes them.

`04257`'s table is a single granule (2000 rows, `index_granularity = 8192`), so each tagged query has one
mark, served by exactly one replica; four of its nine columns are fed by exactly one query each, so those
columns drop individually and the observed shapes differ between occurrences. `04258`'s table is larger
(50000 rows, so at least seven granules), which is also why its exposure is only latent: with marks spread
over the replicas, the initiator usually gets some of them and the counters show up on its own row anyway.

The engine behaviour is correct - ProfileEvents are process-local counters and the initiator does not own
counters incremented on a peer. The test predicate is what is wrong, so that is what this PR changes: both
assertions resolve the initiator query ids by `current_database` and then aggregate over every row of those
queries via `initial_query_id`, the same idiom already used by
`04201_max_bytes_ratio_before_external_join_distributed.sh:112-133`,
`02875_parallel_replicas_remote.sql:13-16` and `02950_parallel_replicas_used_count.sql:22`.

This only widens the row set: an initiator row has `initial_query_id = query_id`
(`Context.cpp:3607-3608`), so it is still selected, and the secondary rows of the same queries are selected
too. For `sum(...) > 0` assertions that can turn a spurious `0` into the expected `1` and nothing else.

All twelve assertion expressions, their aliases and the expected output are unchanged, so the "every event
must fire" contract is preserved verbatim and parallel-replica coverage of the lazy text-index read path is
kept. No tag, no setting pin, no `.reference` change: 2 files, +32/-4.

Unlike the two SQL precedents above, the assertion queries here do not additionally pin
`enable_parallel_replicas = 0` / `parallel_replicas_for_non_replicated_merge_tree = 0` on themselves. That
is not needed for correctness: `currentDatabase()` is constant-folded on the initiator before the query is
distributed (`currentDatabase.cpp:22,49-52`), and a query's own secondary rows are written after it has
finished reading, so the CTE can neither resolve against the wrong database nor race its own rows.

`04258` is fixed together with `04257` because it is the same carrier - the same lazy counters (`:122-124`
before this change), the same `current_database` predicate, no guard; its failure mode is the same one, just
less likely to be hit. Of the 20 text-index tests that read
`ProfileEvents` from `system.query_log`, 17 already carry `no-parallel-replicas`; the only other one that
does not is `02346_text_index_parallel_replicas.sql`, which deliberately asserts parallel-replica behaviour
and already handles the secondary rows its own way, by matching them on the query text. None of those is
touched.

#### Verification

`parallel_replicas_local_plan` is randomized 0/1 by the test runner (`tests/clickhouse-test:1548`). Forcing
it to `0` serves every mark remotely and makes the flake deterministic; the fix was measured in both
directions on a 3-replica loopback cluster:

| `parallel_replicas_local_plan` | predicate | 04257 | 04258 |
|---|---|---|---|
| 0 | before | `0 0 0 0 0 0 0 0 0` | `0 1 0` |
| 0 | after | `1 1 1 1 1 1 1 1 1` | `1 1 1` |
| 1 | after | `1 1 1 1 1 1 1 1 1` | `1 1 1` |
| parallel replicas off | after | `1 1 1 1 1 1 1 1 1` | `1 1 1` |

With the `current_database` filter removed, the event-bearing rows are visibly the secondary ones
(`is_initial_query = 0`, `current_database = 'default'`), and all 24 of them resolve to an initiator
`query_id` through `initial_query_id` - the premise the new predicate relies on. Reverting only the outer
`WHERE` on the fixed files reproduces the failure exactly, which pins the predicate as the load-bearing
change. Both files then ran 50 times with randomized settings and 50 times without, 200/200 green.

Note the tests deliberately do not pin `parallel_replicas_local_plan` or
`automatic_parallel_replicas_mode`. Pinning them would make the assertion always take the remote path, but
it would also fix the topology the test runs under, and the point of leaving them randomized is that the
assertion must hold under every topology the lane can produce - which is what the four rows above show. The
consequence is that any single run may or may not exercise the remote path, so the fix is not observable
from one green run; the deterministic evidence is the forced-remote arm.

`04258`'s negative assertion (`BruteForceIntersections = 0`) is the one place a wider row set could in
principle turn a pass into a failure. It cannot here: all three of its tagged queries set
`text_index_lazy_intersection_density_threshold = 1.0`, which forces leapfrog on whichever replica runs
them, so no replica increments the brute-force counter for those query ids. It stayed green in every arm
above.

#### Correction to my earlier comment on #111918

In https://github.com/ClickHouse/ClickHouse/pull/111918#issuecomment-5096515026 I proposed pinning the
tests with `SET enable_parallel_replicas = 0`. That would remove parallel-replica coverage of this read
path for no reason, so this PR takes the different route above and selects the rows that own the events
instead.

That comment also mis-attributed the breadth, and my first attempt at correcting it was itself too narrow
because it only looked back 30 days. Over 60 days, `04257` shows this exact signature on three unrelated
PRs, all on lanes whose name contains `ParallelReplicas` (only those lanes get
`config.d/enable_parallel_replicas.xml`, via `--parallel-rep` at `tests/config/install.sh:484-485`):
#112008 (columns 8 and 9), #111918 (column 6) and #97261 (column 6, 2026-06-11, outside the window I
originally queried). A fourth row, the all-nine-zeros one, is on an `amd_asan_ubsan, distributed plan`
lane, which does not enable parallel replicas; it is collateral from a host-memory-pressure job (131
failures in that job, 120 of them `memory limit exceeded`) and its own recorded settings show
`parallel_replicas_local_plan 1`. The other `04257` rows in that window are unrelated classes: `Code: 241`
host memory pressure, and one `Code: 36` settings error. For `04258` the recorded failures are host memory
pressure plus a cluster of self-caused ones on the branch that introduced the test, so its exposure to this
mechanism is latent rather than observed. This fix therefore addresses the parallel-replica shapes; it is
not expected to remove reds caused by host memory pressure.

A tracking issue was also requested. I do not open issues on my own initiative, so that offer still stands
on the #111918 thread.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.431` (included in `26.8` and later)
<!-- ch-version-info:end -->