### PR TITLE
Work around Darwin pthread_rwlock losing wakeups under signals

### DIFF
--- a/base/darwin-compatibility/CMakeLists.txt
+++ b/base/darwin-compatibility/CMakeLists.txt
@@ -2,12 +2,16 @@ if (NOT OS_DARWIN)
     message (FATAL_ERROR "darwin-compatibility can only be used on Darwin")
 endif ()
 
-add_library(darwin-compatibility STATIC pthread_rwlock_shim.c)
-
-# Sanitizers (TSan in particular) interpose pthread_rwlock_* themselves.
-if (SANITIZE)
-    message (FATAL_ERROR "darwin-compatibility must not be linked into sanitizer builds")
+if (SANITIZE STREQUAL "thread")
+    # TSan interposes pthread_rwlock_* itself to track lock order, so a second interposition
+    # would either lose those annotations or fight over the symbols. Only TSan does this:
+    # ASan, MSan and UBSan leave these functions alone, and since they keep the query
+    # profiler enabled (see sanitize.cmake), they need the workaround as much as release
+    # builds do.
+    message (FATAL_ERROR "darwin-compatibility must not be linked into TSan builds")
 endif ()
+
+add_library(darwin-compatibility STATIC pthread_rwlock_shim.c)
 
 # The shim must be force-loaded, and must be the ONLY link entry for this archive:
 # - Lazy archive scanning cannot be relied on: `Threads::Threads` puts -lpthread in the

--- a/base/darwin-compatibility/CMakeLists.txt
+++ b/base/darwin-compatibility/CMakeLists.txt
@@ -1,0 +1,33 @@
+if (NOT OS_DARWIN)
+    message (FATAL_ERROR "darwin-compatibility can only be used on Darwin")
+endif ()
+
+add_library(darwin-compatibility STATIC pthread_rwlock_shim.c)
+
+# Sanitizers (TSan in particular) interpose pthread_rwlock_* themselves.
+if (SANITIZE)
+    message (FATAL_ERROR "darwin-compatibility must not be linked into sanitizer builds")
+endif ()
+
+# The shim must be force-loaded, and must be the ONLY link entry for this archive:
+# - Lazy archive scanning cannot be relied on: `Threads::Threads` puts -lpthread in the
+#   middle of the link line, and once ld64 processes that dylib, every outstanding
+#   pthread_rwlock_* undefined (including a -u seed) binds to libSystem, so a normal
+#   archive entry after it is never fetched. A force-loaded object's definitions, by
+#   contrast, override earlier dylib bindings.
+# - A normal entry alongside -force_load is a duplicate-symbol error in links where a
+#   pthread_rwlock reference does reach the archive entry first (spelled with a different
+#   path, ld64.lld loads the member twice; spelled identically, it skips the force load).
+# The flag is a link-libraries entry (not a link option) with a literal path (not a
+# generator expression) because the root CMakeLists propagates global-libs into
+# global-group via $<TARGET_PROPERTY:global-libs,INTERFACE_LINK_LIBRARIES>, which drops
+# INTERFACE_LINK_OPTIONS and does not evaluate generator expressions.
+# The stub archive exists only to make consumers depend on this directory's build, since
+# a bare linker flag carries no target dependency.
+add_library(darwin-compatibility-dep STATIC dep_anchor.c)
+add_dependencies(darwin-compatibility-dep darwin-compatibility)
+target_link_libraries(global-libs INTERFACE
+    darwin-compatibility-dep
+    "-Wl,-force_load,${CMAKE_CURRENT_BINARY_DIR}/libdarwin-compatibility.a")
+
+message (STATUS "pthread_rwlock will be replaced to work around a lost wakeup in Darwin psynch (FB24027930)")

--- a/base/darwin-compatibility/dep_anchor.c
+++ b/base/darwin-compatibility/dep_anchor.c
@@ -1,0 +1,2 @@
+/* Build-order anchor for darwin-compatibility; see CMakeLists.txt. */
+typedef int darwin_compatibility_dep_translation_unit_is_not_empty;

--- a/base/darwin-compatibility/pthread_rwlock_shim.c
+++ b/base/darwin-compatibility/pthread_rwlock_shim.c
@@ -233,16 +233,9 @@ int pthread_rwlock_destroy(pthread_rwlock_t * rwlock)
 
     shim_rwlock * impl = &storage->impl;
 
-    int ret = pthread_mutex_lock(&impl->lock);
-    if (ret != 0)
-        return ret;
-    if (impl->state != 0 || impl->blocked_writers != 0)
-    {
-        pthread_mutex_unlock(&impl->lock);
-        return EBUSY;
-    }
-    pthread_mutex_unlock(&impl->lock);
-
+    /* Like the donor, this does not try to detect destruction of a lock that is still held or
+     * still has waiters: POSIX leaves that undefined for the caller, and the EBUSY result is
+     * only a "may fail". */
     pthread_cond_destroy(&impl->read_signal);
     pthread_cond_destroy(&impl->write_signal);
     pthread_mutex_destroy(&impl->lock);

--- a/base/darwin-compatibility/pthread_rwlock_shim.c
+++ b/base/darwin-compatibility/pthread_rwlock_shim.c
@@ -26,58 +26,50 @@
  * $FreeBSD: src/lib/libc_r/uthread/uthread_rwlock.c,v 1.6 2001/04/10 04:19:20 deischen Exp $
  */
 
-/* Replacement for macOS pthread_rwlock, which permanently deadlocks (loses wakeups)
- * when waiting threads receive signals at a high rate, e.g. from the sampling query
- * profiler. Darwin's psynch rwlock retries an interrupted kernel wait with the
- * sequence snapshot captured before the first sleep (`_pthread_rwlock_lock_wait` in
- * libpthread `src/pthread_rwlock.c`, unchanged since libpthread-454.40.3), so a
- * waiter that takes EINTR while the lock generation moves on re-enters a wait that
- * is never signaled again, and the lock wedges with no holder.
- * See https://github.com/ClickHouse/ClickHouse/issues/111579 (reported to Apple as
- * FB24027930).
- *
- * These strong definitions override libpthread's for every call from code linked
- * into ClickHouse binaries (all contribs are linked statically: libfiu, OpenSSL,
- * Poco, RocksDB, kj, ...). Calls made inside Apple's dylibs keep binding to the
- * real libpthread via the two-level namespace, which is intended: we must not
- * replace locks we do not own. If a rwlock ever crossed that boundary (created by
- * a dylib, used by us), the signature check below aborts loudly instead of
- * corrupting it.
- *
- * The implementation is the classic mutex + two condition variables read-write
- * lock by Alex Nash, taken from FreeBSD libc_r (BSD-2-Clause, see above), which
- * Apple's own pthread_rwlock was based on before the psynch rewrite in Mac OS X
- * 10.6 introduced the bug. Condition variables tolerate spurious wakeups, so
- * signal interruption has no correctness role here. Donor file (last revision,
- * including the 2004 recursive-rdlock workaround, removed from FreeBSD only
- * because libc_r itself was retired in 2010):
- * https://github.com/freebsd/freebsd-src/blob/d79326ecc875fe7885e8b19012c3c1fcf8ad89d3/lib/libc_r/uthread/uthread_rwlock.c
- *
- * Adaptations to the donor:
- *  - FreeBSD's pthread_rwlock_t is a pointer to a malloc'd struct; ours must be
- *    the caller's pthread_rwlock_t itself, so the state lives inside its 192
- *    opaque bytes, and locks born from PTHREAD_RWLOCK_INITIALIZER (which never
- *    call init) are initialized lazily via an atomic signature word.
- *  - libc_r's per-thread `curthread->rdlock_count` (the recursive-rdlock
- *    deadlock workaround) becomes a C11 thread-local; current FreeBSD libthr
- *    still uses the same counter, paired with the same decrement on unlock.
- *  - libc_r internals (`_pthread_*` names, `_get_curthread`) become the public
- *    pthread API; the waits run on Darwin's psynch mutex/condvar, which handle
- *    signal interruption correctly (condvars may simply wake spuriously).
- *
- * Not supported, by design: process-shared rwlocks (EINVAL at init; nothing we
- * link uses them, and an in-binary override could not work across processes)
- * and thread cancellation while blocked inside these locks (ClickHouse never
- * calls pthread_cancel; the donor had the same property).
- */
+/// ClickHouse: replacement for the macOS pthread_rwlock, which permanently deadlocks (loses
+/// wakeups) when waiting threads receive signals at a high rate, e.g. from the sampling query
+/// profiler. Darwin's psynch rwlock retries an interrupted kernel wait with the sequence snapshot
+/// captured before the first sleep (`_pthread_rwlock_lock_wait` in libpthread
+/// `src/pthread_rwlock.c`, unchanged since libpthread-454.40.3), so a waiter that takes EINTR
+/// while the lock generation moves on re-enters a wait that is never signaled again, and the lock
+/// wedges with no holder. See https://github.com/ClickHouse/ClickHouse/issues/111579 (reported to
+/// Apple as FB24027930).
+///
+/// ClickHouse: these strong definitions override libpthread's for every call from code linked
+/// into ClickHouse binaries (all contribs are linked statically: libfiu, OpenSSL, Poco, RocksDB,
+/// kj, ...). Calls made inside Apple's dylibs keep binding to the real libpthread via the
+/// two-level namespace, which is intended: we must not replace locks we do not own.
+///
+/// ClickHouse: the implementation below is the read-write lock from FreeBSD libc_r, which Apple's
+/// own pthread_rwlock was based on before the psynch rewrite in Mac OS X 10.6 introduced the bug.
+/// It blocks on a mutex and condition variables, and condition variables tolerate spurious
+/// wakeups, so signal interruption has no correctness role. The donor file (last revision,
+/// removed from FreeBSD only because libc_r itself was retired in 2010) is
+/// https://github.com/freebsd/freebsd-src/blob/d79326ecc875fe7885e8b19012c3c1fcf8ad89d3/lib/libc_r/uthread/uthread_rwlock.c
+/// and its code and comments below are kept verbatim, in the donor's formatting, so that a diff
+/// against it stays readable. Only these mechanical substitutions were applied:
+///   - `pthread_rwlock_t prwlock` (a pointer to a malloc'd struct in the donor) becomes
+///     `shim_rwlock *prwlock` stored inside the caller's pthread_rwlock_t, because the caller
+///     owns that storage; consequently `init_static` becomes `ensureReady`, and destroy marks
+///     the storage instead of calling free.
+///   - `curthread->rdlock_count` becomes a thread-local of the same name. Current FreeBSD libthr
+///     still keeps this counter, with the same comment and the same pairing on unlock.
+///   - the donor's internal `_pthread_*` entry points become the public pthread API, and the
+///     definitions here are named `pthread_rwlock_*` so they interpose.
+///   - `MAX_READ_LOCKS` came from the donor's private header pthread_private.h.
+///
+/// ClickHouse: not supported, by design: process-shared rwlocks (EINVAL at init; nothing we link
+/// uses them, and an in-binary override could not work across processes) and thread cancellation
+/// while blocked inside these locks (ClickHouse never calls pthread_cancel; the donor had the
+/// same property).
 
 #if defined(__APPLE__)
 
 #include <errno.h>
 #include <limits.h>
 #include <pthread.h>
-#include <stddef.h>
 #include <stdatomic.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sched.h>
@@ -85,317 +77,383 @@
 
 #define MAX_READ_LOCKS (INT_MAX - 1)
 
+/// ClickHouse: the donor's `struct pthread_rwlock`.
 typedef struct
 {
-    pthread_mutex_t lock;
-    pthread_cond_t read_signal;
-    pthread_cond_t write_signal;
-    int state; /* > 0 read locks held, -1 write lock held, 0 free */
-    int blocked_writers;
+	pthread_mutex_t	lock;	/* monitor lock */
+	pthread_cond_t	read_signal;
+	pthread_cond_t	write_signal;
+	int		state;	/* 0 = idle  >0 = # of readers  -1 = writer */
+	int		blocked_writers;
 } shim_rwlock;
 
+/// ClickHouse: the donor allocated the struct above and stored a pointer to it in the caller's
+/// pthread_rwlock_t. We cannot: locks born from PTHREAD_RWLOCK_INITIALIZER never call init, so
+/// there is no allocation point. The state therefore lives inside the caller's storage, behind a
+/// signature word that overlays Apple's `__sig` field and tells the three cases apart.
 typedef struct
 {
-    _Atomic long sig;
-    shim_rwlock impl;
+	_Atomic long sig;
+	shim_rwlock impl;
 } shim_rwlock_storage;
 
-/* The shim state must fit into the caller's pthread_rwlock_t, whose layout is
- * { long __sig; char __opaque[192]; } on 64-bit Darwin. */
 _Static_assert(sizeof(shim_rwlock_storage) <= sizeof(pthread_rwlock_t), "shim state must fit into pthread_rwlock_t");
 _Static_assert(_Alignof(shim_rwlock_storage) <= _Alignof(pthread_rwlock_t), "shim state must not need stricter alignment");
-/* The sig word must overlay Apple's __sig field, so PTHREAD_RWLOCK_INITIALIZER
- * (which sets __sig to _PTHREAD_RWLOCK_SIG_init) is visible through it. */
-_Static_assert(offsetof(shim_rwlock_storage, sig) == 0, "sig must be the first field");
+_Static_assert(offsetof(shim_rwlock_storage, sig) == 0, "sig must overlay Apple's __sig field");
 
-/* Set by PTHREAD_RWLOCK_INITIALIZER (a Darwin ABI constant, stable since it is
- * compiled into every binary that ever used the static initializer). */
+/// ClickHouse: set by PTHREAD_RWLOCK_INITIALIZER (a Darwin ABI constant, compiled into every
+/// binary that ever used the static initializer).
 #define APPLE_SIG_STATIC_INIT 0x2DA8B3B4L
 _Static_assert(APPLE_SIG_STATIC_INIT == _PTHREAD_RWLOCK_SIG_init, "PTHREAD_RWLOCK_INITIALIZER signature changed");
 
-/* 'ShRW' / the same with the last letter changed: states of the shim sig word. */
+/// ClickHouse: states of the shim signature word.
 #define SHIM_SIG_READY 0x53685257L
 #define SHIM_SIG_INITIALIZING 0x53685249L
 #define SHIM_SIG_DESTROYED 0x53685244L
 
-static void abortWithMessage(const char * message)
-{
-    size_t len = strlen(message);
-    ssize_t unused = write(STDERR_FILENO, message, len);
-    (void)unused;
-    abort();
-}
-
-/* The recursive-rdlock deadlock workaround from the donor: if this thread holds
- * any read locks, a new rdlock bypasses writer priority, because blocking behind
- * a writer that in turn waits for this thread's earlier read lock would deadlock.
- * "I hope the reader can follow that logic ;-)" (Alex Nash / FreeBSD). */
+/// ClickHouse: see the comment on `curthread->rdlock_count` in pthread_rwlock_rdlock below.
 static _Thread_local int rdlock_count = 0;
 
-static int initImpl(shim_rwlock * impl)
+static void abortWithMessage(const char * message)
 {
-    int ret = pthread_mutex_init(&impl->lock, NULL);
-    if (ret != 0)
-        return ret;
-
-    ret = pthread_cond_init(&impl->read_signal, NULL);
-    if (ret != 0)
-    {
-        pthread_mutex_destroy(&impl->lock);
-        return ret;
-    }
-
-    ret = pthread_cond_init(&impl->write_signal, NULL);
-    if (ret != 0)
-    {
-        pthread_cond_destroy(&impl->read_signal);
-        pthread_mutex_destroy(&impl->lock);
-        return ret;
-    }
-
-    impl->state = 0;
-    impl->blocked_writers = 0;
-    return 0;
+	size_t len = strlen(message);
+	ssize_t unused = write(STDERR_FILENO, message, len);
+	(void)unused;
+	abort();
 }
 
-/* Returns the ready-to-use shim, lazily initializing storage that came from
- * PTHREAD_RWLOCK_INITIALIZER. Anything else (a lock initialized by the real
- * libpthread in a dylib, a destroyed lock, garbage) aborts: silently returning
- * an error would let lock-free execution continue unnoticed, since callers
- * like libfiu do not check the return code. */
-static shim_rwlock * ensureReady(pthread_rwlock_t * rwlock)
+static int initImpl(shim_rwlock *prwlock);
+
+/// ClickHouse: replaces the donor's `init_static`. Returns the ready-to-use lock, initializing
+/// storage that came from PTHREAD_RWLOCK_INITIALIZER on first use. Anything else (a lock
+/// initialized by the real libpthread inside a dylib, a destroyed lock, garbage) aborts:
+/// returning an error would let callers that do not check it, such as libfiu, run lock-free.
+static shim_rwlock *ensureReady(pthread_rwlock_t *rwlock)
 {
-    shim_rwlock_storage * storage = (shim_rwlock_storage *)rwlock;
+	shim_rwlock_storage *storage = (shim_rwlock_storage *)rwlock;
 
-    for (;;)
-    {
-        long sig = atomic_load_explicit(&storage->sig, memory_order_acquire);
-        if (sig == SHIM_SIG_READY)
-            return &storage->impl;
+	for (;;) {
+		long sig = atomic_load_explicit(&storage->sig, memory_order_acquire);
+		if (sig == SHIM_SIG_READY)
+			return &storage->impl;
 
-        if (sig == APPLE_SIG_STATIC_INIT)
-        {
-            if (atomic_compare_exchange_strong_explicit(
-                    &storage->sig, &sig, SHIM_SIG_INITIALIZING, memory_order_acq_rel, memory_order_acquire))
-            {
-                if (initImpl(&storage->impl) != 0)
-                    abortWithMessage("pthread_rwlock shim: lazy initialization failed\n");
-                atomic_store_explicit(&storage->sig, SHIM_SIG_READY, memory_order_release);
-                return &storage->impl;
-            }
-            /* Lost the race, re-read the sig. */
-        }
-        else if (sig == SHIM_SIG_INITIALIZING)
-            sched_yield();
-        else
-            abortWithMessage("pthread_rwlock shim: rwlock is destroyed, foreign or corrupted\n");
-    }
+		if (sig == APPLE_SIG_STATIC_INIT) {
+			if (atomic_compare_exchange_strong_explicit(
+					&storage->sig, &sig, SHIM_SIG_INITIALIZING,
+					memory_order_acq_rel, memory_order_acquire)) {
+				if (initImpl(&storage->impl) != 0)
+					abortWithMessage("pthread_rwlock shim: lazy initialization failed\n");
+				atomic_store_explicit(&storage->sig, SHIM_SIG_READY, memory_order_release);
+				return &storage->impl;
+			}
+			/* lost the race, re-read the signature */
+		} else if (sig == SHIM_SIG_INITIALIZING)
+			sched_yield();
+		else
+			abortWithMessage("pthread_rwlock shim: rwlock is destroyed, foreign or corrupted\n");
+	}
 }
 
-int pthread_rwlock_init(pthread_rwlock_t * rwlock, const pthread_rwlockattr_t * attr)
+/// ClickHouse: the body of the donor's _pthread_rwlock_init, minus the allocation.
+static int
+initImpl(shim_rwlock *prwlock)
 {
-    if (rwlock == NULL)
-        return EINVAL;
+	int ret;
 
-    if (attr != NULL)
-    {
-        int pshared = PTHREAD_PROCESS_PRIVATE;
-        if (pthread_rwlockattr_getpshared(attr, &pshared) == 0 && pshared != PTHREAD_PROCESS_PRIVATE)
-            return EINVAL; /* see the header comment: process-shared is unsupported */
-    }
+	/* initialize the lock */
+	if ((ret = pthread_mutex_init(&prwlock->lock, NULL)) != 0)
+		return (ret);
+	else {
+		/* initialize the read condition signal */
+		ret = pthread_cond_init(&prwlock->read_signal, NULL);
 
-    shim_rwlock_storage * storage = (shim_rwlock_storage *)rwlock;
-    int ret = initImpl(&storage->impl);
-    if (ret != 0)
-        return ret;
+		if (ret != 0) {
+			pthread_mutex_destroy(&prwlock->lock);
+		} else {
+			/* initialize the write condition signal */
+			ret = pthread_cond_init(&prwlock->write_signal, NULL);
 
-    atomic_store_explicit(&storage->sig, SHIM_SIG_READY, memory_order_release);
-    return 0;
+			if (ret != 0) {
+				pthread_cond_destroy(&prwlock->read_signal);
+				pthread_mutex_destroy(&prwlock->lock);
+			} else {
+				/* success */
+				prwlock->state = 0;
+				prwlock->blocked_writers = 0;
+			}
+		}
+	}
+
+	return (ret);
 }
 
-int pthread_rwlock_destroy(pthread_rwlock_t * rwlock)
+int
+pthread_rwlock_init (pthread_rwlock_t *rwlock, const pthread_rwlockattr_t *attr)
 {
-    if (rwlock == NULL)
-        return EINVAL;
+	shim_rwlock_storage *storage;
+	int ret;
 
-    shim_rwlock_storage * storage = (shim_rwlock_storage *)rwlock;
-    long sig = atomic_load_explicit(&storage->sig, memory_order_acquire);
+	if (rwlock == NULL)
+		return(EINVAL);
 
-    /* Statically initialized and never used: nothing was ever created. */
-    if (sig == APPLE_SIG_STATIC_INIT)
-    {
-        atomic_store_explicit(&storage->sig, SHIM_SIG_DESTROYED, memory_order_release);
-        return 0;
-    }
+	/// ClickHouse: process-shared rwlocks are not supported, see the notes at the top.
+	if (attr != NULL) {
+		int pshared = PTHREAD_PROCESS_PRIVATE;
+		if (pthread_rwlockattr_getpshared(attr, &pshared) == 0 &&
+		    pshared != PTHREAD_PROCESS_PRIVATE)
+			return(EINVAL);
+	}
 
-    if (sig != SHIM_SIG_READY)
-        abortWithMessage("pthread_rwlock shim: destroying a rwlock that is not initialized\n");
+	storage = (shim_rwlock_storage *)rwlock;
 
-    shim_rwlock * impl = &storage->impl;
+	if ((ret = initImpl(&storage->impl)) != 0)
+		return (ret);
 
-    /* Like the donor, this does not try to detect destruction of a lock that is still held or
-     * still has waiters: POSIX leaves that undefined for the caller, and the EBUSY result is
-     * only a "may fail". */
-    pthread_cond_destroy(&impl->read_signal);
-    pthread_cond_destroy(&impl->write_signal);
-    pthread_mutex_destroy(&impl->lock);
-    atomic_store_explicit(&storage->sig, SHIM_SIG_DESTROYED, memory_order_release);
-    return 0;
+	atomic_store_explicit(&storage->sig, SHIM_SIG_READY, memory_order_release);
+
+	return (ret);
 }
 
-int pthread_rwlock_rdlock(pthread_rwlock_t * rwlock)
+int
+pthread_rwlock_destroy (pthread_rwlock_t *rwlock)
 {
-    if (rwlock == NULL)
-        return EINVAL;
+	int ret;
 
-    shim_rwlock * impl = ensureReady(rwlock);
+	if (rwlock == NULL)
+		ret = EINVAL;
+	else {
+		shim_rwlock_storage *storage = (shim_rwlock_storage *)rwlock;
+		long sig = atomic_load_explicit(&storage->sig, memory_order_acquire);
+		shim_rwlock *prwlock;
 
-    int ret = pthread_mutex_lock(&impl->lock);
-    if (ret != 0)
-        return ret;
+		/// ClickHouse: statically initialized and never used, so nothing was ever created.
+		/// The donor would dereference a NULL pointer here.
+		if (sig == APPLE_SIG_STATIC_INIT) {
+			atomic_store_explicit(&storage->sig, SHIM_SIG_DESTROYED, memory_order_release);
+			return (0);
+		}
 
-    if (impl->state == MAX_READ_LOCKS)
-    {
-        pthread_mutex_unlock(&impl->lock);
-        return EAGAIN;
-    }
+		if (sig != SHIM_SIG_READY)
+			abortWithMessage("pthread_rwlock shim: destroying a rwlock that is not initialized\n");
 
-    if (rdlock_count > 0 && impl->state > 0)
-    {
-        /* Recursive rdlock: bypass writer priority (see rdlock_count above). */
-    }
-    else
-    {
-        /* Give writers priority over readers (matches the Darwin man page). */
-        while (impl->blocked_writers || impl->state < 0)
-        {
-            ret = pthread_cond_wait(&impl->read_signal, &impl->lock);
-            if (ret != 0)
-            {
-                pthread_mutex_unlock(&impl->lock);
-                return ret;
-            }
-        }
-    }
+		prwlock = &storage->impl;
 
-    ++rdlock_count;
-    ++impl->state;
+		pthread_mutex_destroy(&prwlock->lock);
+		pthread_cond_destroy(&prwlock->read_signal);
+		pthread_cond_destroy(&prwlock->write_signal);
 
-    pthread_mutex_unlock(&impl->lock);
-    return 0;
+		/// ClickHouse: the donor freed the object and set *rwlock to NULL here.
+		atomic_store_explicit(&storage->sig, SHIM_SIG_DESTROYED, memory_order_release);
+
+		ret = 0;
+	}
+	return (ret);
 }
 
-int pthread_rwlock_tryrdlock(pthread_rwlock_t * rwlock)
+int
+pthread_rwlock_rdlock (pthread_rwlock_t *rwlock)
 {
-    if (rwlock == NULL)
-        return EINVAL;
+	shim_rwlock *prwlock;
+	int ret;
 
-    shim_rwlock * impl = ensureReady(rwlock);
+	if (rwlock == NULL)
+		return(EINVAL);
 
-    int ret = pthread_mutex_lock(&impl->lock);
-    if (ret != 0)
-        return ret;
+	/// ClickHouse: replaces the donor's `prwlock = *rwlock` and its static initialization check.
+	prwlock = ensureReady(rwlock);
 
-    if (impl->state == MAX_READ_LOCKS)
-        ret = EAGAIN;
-    else if (rdlock_count > 0 && impl->state > 0)
-    {
-        /* Recursive rdlock: bypass writer priority (see rdlock_count above). */
-        ++rdlock_count;
-        ++impl->state;
-    }
-    else if (impl->blocked_writers || impl->state < 0)
-        ret = EBUSY;
-    else
-    {
-        ++rdlock_count;
-        ++impl->state;
-    }
+	/* grab the monitor lock */
+	if ((ret = pthread_mutex_lock(&prwlock->lock)) != 0)
+		return(ret);
 
-    pthread_mutex_unlock(&impl->lock);
-    return ret;
+	/* check lock count */
+	if (prwlock->state == MAX_READ_LOCKS) {
+		pthread_mutex_unlock(&prwlock->lock);
+		return (EAGAIN);
+	}
+
+	if ((rdlock_count > 0) && (prwlock->state > 0)) {
+		/*
+		 * To avoid having to track all the rdlocks held by
+		 * a thread or all of the threads that hold a rdlock,
+		 * we keep a simple count of all the rdlocks held by
+		 * a thread.  If a thread holds any rdlocks it is
+		 * possible that it is attempting to take a recursive
+		 * rdlock.  If there are blocked writers and precedence
+		 * is given to them, then that would result in the thread
+		 * deadlocking.  So allowing a thread to take the rdlock
+		 * when it already has one or more rdlocks avoids the
+		 * deadlock.  I hope the reader can follow that logic ;-)
+		 */
+		;	/* nothing needed */
+	} else {
+		/* give writers priority over readers */
+		while (prwlock->blocked_writers || prwlock->state < 0) {
+			ret = pthread_cond_wait(&prwlock->read_signal,
+			    &prwlock->lock);
+
+			if (ret != 0) {
+				/* can't do a whole lot if this fails */
+				pthread_mutex_unlock(&prwlock->lock);
+				return(ret);
+			}
+		}
+	}
+
+	rdlock_count++;
+	prwlock->state++; /* indicate we are locked for reading */
+
+	/*
+	 * Something is really wrong if this call fails.  Returning
+	 * error won't do because we've already obtained the read
+	 * lock.  Decrementing 'state' is no good because we probably
+	 * don't have the monitor lock.
+	 */
+	pthread_mutex_unlock(&prwlock->lock);
+
+	return (ret);
 }
 
-int pthread_rwlock_wrlock(pthread_rwlock_t * rwlock)
+int
+pthread_rwlock_tryrdlock (pthread_rwlock_t *rwlock)
 {
-    if (rwlock == NULL)
-        return EINVAL;
+	shim_rwlock *prwlock;
+	int ret;
 
-    shim_rwlock * impl = ensureReady(rwlock);
+	if (rwlock == NULL)
+		return(EINVAL);
 
-    int ret = pthread_mutex_lock(&impl->lock);
-    if (ret != 0)
-        return ret;
+	/// ClickHouse: replaces the donor's `prwlock = *rwlock` and its static initialization check.
+	prwlock = ensureReady(rwlock);
 
-    while (impl->state != 0)
-    {
-        ++impl->blocked_writers;
-        ret = pthread_cond_wait(&impl->write_signal, &impl->lock);
-        --impl->blocked_writers;
-        if (ret != 0)
-        {
-            pthread_mutex_unlock(&impl->lock);
-            return ret;
-        }
-    }
+	/* grab the monitor lock */
+	if ((ret = pthread_mutex_lock(&prwlock->lock)) != 0)
+		return(ret);
 
-    impl->state = -1;
+	if (prwlock->state == MAX_READ_LOCKS)
+		ret = EAGAIN; /* too many read locks acquired */
+	else if ((rdlock_count > 0) && (prwlock->state > 0)) {
+		/* see comment for pthread_rwlock_rdlock() */
+		rdlock_count++;
+		prwlock->state++;
+	}
+	/* give writers priority over readers */
+	else if (prwlock->blocked_writers || prwlock->state < 0)
+		ret = EBUSY;
+	else {
+		prwlock->state++; /* indicate we are locked for reading */
+		rdlock_count++;
+	}
 
-    pthread_mutex_unlock(&impl->lock);
-    return 0;
+	/* see the comment on this in pthread_rwlock_rdlock */
+	pthread_mutex_unlock(&prwlock->lock);
+
+	return (ret);
 }
 
-int pthread_rwlock_trywrlock(pthread_rwlock_t * rwlock)
+int
+pthread_rwlock_trywrlock (pthread_rwlock_t *rwlock)
 {
-    if (rwlock == NULL)
-        return EINVAL;
+	shim_rwlock *prwlock;
+	int ret;
 
-    shim_rwlock * impl = ensureReady(rwlock);
+	if (rwlock == NULL)
+		return(EINVAL);
 
-    int ret = pthread_mutex_lock(&impl->lock);
-    if (ret != 0)
-        return ret;
+	/// ClickHouse: replaces the donor's `prwlock = *rwlock` and its static initialization check.
+	prwlock = ensureReady(rwlock);
 
-    if (impl->state != 0)
-        ret = EBUSY;
-    else
-        impl->state = -1;
+	/* grab the monitor lock */
+	if ((ret = pthread_mutex_lock(&prwlock->lock)) != 0)
+		return(ret);
 
-    pthread_mutex_unlock(&impl->lock);
-    return ret;
+	if (prwlock->state != 0)
+		ret = EBUSY;
+	else
+		/* indicate we are locked for writing */
+		prwlock->state = -1;
+
+	/* see the comment on this in pthread_rwlock_rdlock */
+	pthread_mutex_unlock(&prwlock->lock);
+
+	return (ret);
 }
 
-int pthread_rwlock_unlock(pthread_rwlock_t * rwlock)
+int
+pthread_rwlock_unlock (pthread_rwlock_t *rwlock)
 {
-    if (rwlock == NULL)
-        return EINVAL;
+	shim_rwlock *prwlock;
+	int ret;
 
-    shim_rwlock * impl = ensureReady(rwlock);
+	if (rwlock == NULL)
+		return(EINVAL);
 
-    int ret = pthread_mutex_lock(&impl->lock);
-    if (ret != 0)
-        return ret;
+	/// ClickHouse: replaces the donor's `prwlock = *rwlock` and its NULL check.
+	prwlock = ensureReady(rwlock);
 
-    if (impl->state > 0)
-    {
-        --rdlock_count;
-        --impl->state;
-        if (impl->state == 0 && impl->blocked_writers)
-            pthread_cond_signal(&impl->write_signal);
-    }
-    else if (impl->state < 0)
-    {
-        impl->state = 0;
-        if (impl->blocked_writers)
-            pthread_cond_signal(&impl->write_signal);
-        else
-            pthread_cond_broadcast(&impl->read_signal);
-    }
-    else
-        ret = EINVAL;
+	/* grab the monitor lock */
+	if ((ret = pthread_mutex_lock(&prwlock->lock)) != 0)
+		return(ret);
 
-    pthread_mutex_unlock(&impl->lock);
-    return ret;
+	if (prwlock->state > 0) {
+		rdlock_count--;
+		prwlock->state--;
+		if (prwlock->state == 0 && prwlock->blocked_writers)
+			ret = pthread_cond_signal(&prwlock->write_signal);
+	} else if (prwlock->state < 0) {
+		prwlock->state = 0;
+
+		if (prwlock->blocked_writers)
+			ret = pthread_cond_signal(&prwlock->write_signal);
+		else
+			ret = pthread_cond_broadcast(&prwlock->read_signal);
+	} else
+		ret = EINVAL;
+
+	/* see the comment on this in pthread_rwlock_rdlock */
+	pthread_mutex_unlock(&prwlock->lock);
+
+	return (ret);
+}
+
+int
+pthread_rwlock_wrlock (pthread_rwlock_t *rwlock)
+{
+	shim_rwlock *prwlock;
+	int ret;
+
+	if (rwlock == NULL)
+		return(EINVAL);
+
+	/// ClickHouse: replaces the donor's `prwlock = *rwlock` and its static initialization check.
+	prwlock = ensureReady(rwlock);
+
+	/* grab the monitor lock */
+	if ((ret = pthread_mutex_lock(&prwlock->lock)) != 0)
+		return(ret);
+
+	while (prwlock->state != 0) {
+		prwlock->blocked_writers++;
+
+		ret = pthread_cond_wait(&prwlock->write_signal,
+		    &prwlock->lock);
+
+		if (ret != 0) {
+			prwlock->blocked_writers--;
+			pthread_mutex_unlock(&prwlock->lock);
+			return(ret);
+		}
+
+		prwlock->blocked_writers--;
+	}
+
+	/* indicate we are locked for writing */
+	prwlock->state = -1;
+
+	/* see the comment on this in pthread_rwlock_rdlock */
+	pthread_mutex_unlock(&prwlock->lock);
+
+	return (ret);
 }
 
 #endif

--- a/base/darwin-compatibility/pthread_rwlock_shim.c
+++ b/base/darwin-compatibility/pthread_rwlock_shim.c
@@ -1,0 +1,408 @@
+/*-
+ * Copyright (c) 1998 Alex Nash
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD: src/lib/libc_r/uthread/uthread_rwlock.c,v 1.6 2001/04/10 04:19:20 deischen Exp $
+ */
+
+/* Replacement for macOS pthread_rwlock, which permanently deadlocks (loses wakeups)
+ * when waiting threads receive signals at a high rate, e.g. from the sampling query
+ * profiler. Darwin's psynch rwlock retries an interrupted kernel wait with the
+ * sequence snapshot captured before the first sleep (`_pthread_rwlock_lock_wait` in
+ * libpthread `src/pthread_rwlock.c`, unchanged since libpthread-454.40.3), so a
+ * waiter that takes EINTR while the lock generation moves on re-enters a wait that
+ * is never signaled again, and the lock wedges with no holder.
+ * See https://github.com/ClickHouse/ClickHouse/issues/111579 (reported to Apple as
+ * FB24027930).
+ *
+ * These strong definitions override libpthread's for every call from code linked
+ * into ClickHouse binaries (all contribs are linked statically: libfiu, OpenSSL,
+ * Poco, RocksDB, kj, ...). Calls made inside Apple's dylibs keep binding to the
+ * real libpthread via the two-level namespace, which is intended: we must not
+ * replace locks we do not own. If a rwlock ever crossed that boundary (created by
+ * a dylib, used by us), the signature check below aborts loudly instead of
+ * corrupting it.
+ *
+ * The implementation is the classic mutex + two condition variables read-write
+ * lock by Alex Nash, taken from FreeBSD libc_r (BSD-2-Clause, see above), which
+ * Apple's own pthread_rwlock was based on before the psynch rewrite in Mac OS X
+ * 10.6 introduced the bug. Condition variables tolerate spurious wakeups, so
+ * signal interruption has no correctness role here. Donor file (last revision,
+ * including the 2004 recursive-rdlock workaround, removed from FreeBSD only
+ * because libc_r itself was retired in 2010):
+ * https://github.com/freebsd/freebsd-src/blob/d79326ecc875fe7885e8b19012c3c1fcf8ad89d3/lib/libc_r/uthread/uthread_rwlock.c
+ *
+ * Adaptations to the donor:
+ *  - FreeBSD's pthread_rwlock_t is a pointer to a malloc'd struct; ours must be
+ *    the caller's pthread_rwlock_t itself, so the state lives inside its 192
+ *    opaque bytes, and locks born from PTHREAD_RWLOCK_INITIALIZER (which never
+ *    call init) are initialized lazily via an atomic signature word.
+ *  - libc_r's per-thread `curthread->rdlock_count` (the recursive-rdlock
+ *    deadlock workaround) becomes a C11 thread-local; current FreeBSD libthr
+ *    still uses the same counter, paired with the same decrement on unlock.
+ *  - libc_r internals (`_pthread_*` names, `_get_curthread`) become the public
+ *    pthread API; the waits run on Darwin's psynch mutex/condvar, which handle
+ *    signal interruption correctly (condvars may simply wake spuriously).
+ *
+ * Not supported, by design: process-shared rwlocks (EINVAL at init; nothing we
+ * link uses them, and an in-binary override could not work across processes)
+ * and thread cancellation while blocked inside these locks (ClickHouse never
+ * calls pthread_cancel; the donor had the same property).
+ */
+
+#if defined(__APPLE__)
+
+#include <errno.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stddef.h>
+#include <stdatomic.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sched.h>
+#include <unistd.h>
+
+#define MAX_READ_LOCKS (INT_MAX - 1)
+
+typedef struct
+{
+    pthread_mutex_t lock;
+    pthread_cond_t read_signal;
+    pthread_cond_t write_signal;
+    int state; /* > 0 read locks held, -1 write lock held, 0 free */
+    int blocked_writers;
+} shim_rwlock;
+
+typedef struct
+{
+    _Atomic long sig;
+    shim_rwlock impl;
+} shim_rwlock_storage;
+
+/* The shim state must fit into the caller's pthread_rwlock_t, whose layout is
+ * { long __sig; char __opaque[192]; } on 64-bit Darwin. */
+_Static_assert(sizeof(shim_rwlock_storage) <= sizeof(pthread_rwlock_t), "shim state must fit into pthread_rwlock_t");
+_Static_assert(_Alignof(shim_rwlock_storage) <= _Alignof(pthread_rwlock_t), "shim state must not need stricter alignment");
+/* The sig word must overlay Apple's __sig field, so PTHREAD_RWLOCK_INITIALIZER
+ * (which sets __sig to _PTHREAD_RWLOCK_SIG_init) is visible through it. */
+_Static_assert(offsetof(shim_rwlock_storage, sig) == 0, "sig must be the first field");
+
+/* Set by PTHREAD_RWLOCK_INITIALIZER (a Darwin ABI constant, stable since it is
+ * compiled into every binary that ever used the static initializer). */
+#define APPLE_SIG_STATIC_INIT 0x2DA8B3B4L
+_Static_assert(APPLE_SIG_STATIC_INIT == _PTHREAD_RWLOCK_SIG_init, "PTHREAD_RWLOCK_INITIALIZER signature changed");
+
+/* 'ShRW' / the same with the last letter changed: states of the shim sig word. */
+#define SHIM_SIG_READY 0x53685257L
+#define SHIM_SIG_INITIALIZING 0x53685249L
+#define SHIM_SIG_DESTROYED 0x53685244L
+
+static void abortWithMessage(const char * message)
+{
+    size_t len = strlen(message);
+    ssize_t unused = write(STDERR_FILENO, message, len);
+    (void)unused;
+    abort();
+}
+
+/* The recursive-rdlock deadlock workaround from the donor: if this thread holds
+ * any read locks, a new rdlock bypasses writer priority, because blocking behind
+ * a writer that in turn waits for this thread's earlier read lock would deadlock.
+ * "I hope the reader can follow that logic ;-)" (Alex Nash / FreeBSD). */
+static _Thread_local int rdlock_count = 0;
+
+static int initImpl(shim_rwlock * impl)
+{
+    int ret = pthread_mutex_init(&impl->lock, NULL);
+    if (ret != 0)
+        return ret;
+
+    ret = pthread_cond_init(&impl->read_signal, NULL);
+    if (ret != 0)
+    {
+        pthread_mutex_destroy(&impl->lock);
+        return ret;
+    }
+
+    ret = pthread_cond_init(&impl->write_signal, NULL);
+    if (ret != 0)
+    {
+        pthread_cond_destroy(&impl->read_signal);
+        pthread_mutex_destroy(&impl->lock);
+        return ret;
+    }
+
+    impl->state = 0;
+    impl->blocked_writers = 0;
+    return 0;
+}
+
+/* Returns the ready-to-use shim, lazily initializing storage that came from
+ * PTHREAD_RWLOCK_INITIALIZER. Anything else (a lock initialized by the real
+ * libpthread in a dylib, a destroyed lock, garbage) aborts: silently returning
+ * an error would let lock-free execution continue unnoticed, since callers
+ * like libfiu do not check the return code. */
+static shim_rwlock * ensureReady(pthread_rwlock_t * rwlock)
+{
+    shim_rwlock_storage * storage = (shim_rwlock_storage *)rwlock;
+
+    for (;;)
+    {
+        long sig = atomic_load_explicit(&storage->sig, memory_order_acquire);
+        if (sig == SHIM_SIG_READY)
+            return &storage->impl;
+
+        if (sig == APPLE_SIG_STATIC_INIT)
+        {
+            if (atomic_compare_exchange_strong_explicit(
+                    &storage->sig, &sig, SHIM_SIG_INITIALIZING, memory_order_acq_rel, memory_order_acquire))
+            {
+                if (initImpl(&storage->impl) != 0)
+                    abortWithMessage("pthread_rwlock shim: lazy initialization failed\n");
+                atomic_store_explicit(&storage->sig, SHIM_SIG_READY, memory_order_release);
+                return &storage->impl;
+            }
+            /* Lost the race, re-read the sig. */
+        }
+        else if (sig == SHIM_SIG_INITIALIZING)
+            sched_yield();
+        else
+            abortWithMessage("pthread_rwlock shim: rwlock is destroyed, foreign or corrupted\n");
+    }
+}
+
+int pthread_rwlock_init(pthread_rwlock_t * rwlock, const pthread_rwlockattr_t * attr)
+{
+    if (rwlock == NULL)
+        return EINVAL;
+
+    if (attr != NULL)
+    {
+        int pshared = PTHREAD_PROCESS_PRIVATE;
+        if (pthread_rwlockattr_getpshared(attr, &pshared) == 0 && pshared != PTHREAD_PROCESS_PRIVATE)
+            return EINVAL; /* see the header comment: process-shared is unsupported */
+    }
+
+    shim_rwlock_storage * storage = (shim_rwlock_storage *)rwlock;
+    int ret = initImpl(&storage->impl);
+    if (ret != 0)
+        return ret;
+
+    atomic_store_explicit(&storage->sig, SHIM_SIG_READY, memory_order_release);
+    return 0;
+}
+
+int pthread_rwlock_destroy(pthread_rwlock_t * rwlock)
+{
+    if (rwlock == NULL)
+        return EINVAL;
+
+    shim_rwlock_storage * storage = (shim_rwlock_storage *)rwlock;
+    long sig = atomic_load_explicit(&storage->sig, memory_order_acquire);
+
+    /* Statically initialized and never used: nothing was ever created. */
+    if (sig == APPLE_SIG_STATIC_INIT)
+    {
+        atomic_store_explicit(&storage->sig, SHIM_SIG_DESTROYED, memory_order_release);
+        return 0;
+    }
+
+    if (sig != SHIM_SIG_READY)
+        abortWithMessage("pthread_rwlock shim: destroying a rwlock that is not initialized\n");
+
+    shim_rwlock * impl = &storage->impl;
+
+    int ret = pthread_mutex_lock(&impl->lock);
+    if (ret != 0)
+        return ret;
+    if (impl->state != 0 || impl->blocked_writers != 0)
+    {
+        pthread_mutex_unlock(&impl->lock);
+        return EBUSY;
+    }
+    pthread_mutex_unlock(&impl->lock);
+
+    pthread_cond_destroy(&impl->read_signal);
+    pthread_cond_destroy(&impl->write_signal);
+    pthread_mutex_destroy(&impl->lock);
+    atomic_store_explicit(&storage->sig, SHIM_SIG_DESTROYED, memory_order_release);
+    return 0;
+}
+
+int pthread_rwlock_rdlock(pthread_rwlock_t * rwlock)
+{
+    if (rwlock == NULL)
+        return EINVAL;
+
+    shim_rwlock * impl = ensureReady(rwlock);
+
+    int ret = pthread_mutex_lock(&impl->lock);
+    if (ret != 0)
+        return ret;
+
+    if (impl->state == MAX_READ_LOCKS)
+    {
+        pthread_mutex_unlock(&impl->lock);
+        return EAGAIN;
+    }
+
+    if (rdlock_count > 0 && impl->state > 0)
+    {
+        /* Recursive rdlock: bypass writer priority (see rdlock_count above). */
+    }
+    else
+    {
+        /* Give writers priority over readers (matches the Darwin man page). */
+        while (impl->blocked_writers || impl->state < 0)
+        {
+            ret = pthread_cond_wait(&impl->read_signal, &impl->lock);
+            if (ret != 0)
+            {
+                pthread_mutex_unlock(&impl->lock);
+                return ret;
+            }
+        }
+    }
+
+    ++rdlock_count;
+    ++impl->state;
+
+    pthread_mutex_unlock(&impl->lock);
+    return 0;
+}
+
+int pthread_rwlock_tryrdlock(pthread_rwlock_t * rwlock)
+{
+    if (rwlock == NULL)
+        return EINVAL;
+
+    shim_rwlock * impl = ensureReady(rwlock);
+
+    int ret = pthread_mutex_lock(&impl->lock);
+    if (ret != 0)
+        return ret;
+
+    if (impl->state == MAX_READ_LOCKS)
+        ret = EAGAIN;
+    else if (rdlock_count > 0 && impl->state > 0)
+    {
+        /* Recursive rdlock: bypass writer priority (see rdlock_count above). */
+        ++rdlock_count;
+        ++impl->state;
+    }
+    else if (impl->blocked_writers || impl->state < 0)
+        ret = EBUSY;
+    else
+    {
+        ++rdlock_count;
+        ++impl->state;
+    }
+
+    pthread_mutex_unlock(&impl->lock);
+    return ret;
+}
+
+int pthread_rwlock_wrlock(pthread_rwlock_t * rwlock)
+{
+    if (rwlock == NULL)
+        return EINVAL;
+
+    shim_rwlock * impl = ensureReady(rwlock);
+
+    int ret = pthread_mutex_lock(&impl->lock);
+    if (ret != 0)
+        return ret;
+
+    while (impl->state != 0)
+    {
+        ++impl->blocked_writers;
+        ret = pthread_cond_wait(&impl->write_signal, &impl->lock);
+        --impl->blocked_writers;
+        if (ret != 0)
+        {
+            pthread_mutex_unlock(&impl->lock);
+            return ret;
+        }
+    }
+
+    impl->state = -1;
+
+    pthread_mutex_unlock(&impl->lock);
+    return 0;
+}
+
+int pthread_rwlock_trywrlock(pthread_rwlock_t * rwlock)
+{
+    if (rwlock == NULL)
+        return EINVAL;
+
+    shim_rwlock * impl = ensureReady(rwlock);
+
+    int ret = pthread_mutex_lock(&impl->lock);
+    if (ret != 0)
+        return ret;
+
+    if (impl->state != 0)
+        ret = EBUSY;
+    else
+        impl->state = -1;
+
+    pthread_mutex_unlock(&impl->lock);
+    return ret;
+}
+
+int pthread_rwlock_unlock(pthread_rwlock_t * rwlock)
+{
+    if (rwlock == NULL)
+        return EINVAL;
+
+    shim_rwlock * impl = ensureReady(rwlock);
+
+    int ret = pthread_mutex_lock(&impl->lock);
+    if (ret != 0)
+        return ret;
+
+    if (impl->state > 0)
+    {
+        --rdlock_count;
+        --impl->state;
+        if (impl->state == 0 && impl->blocked_writers)
+            pthread_cond_signal(&impl->write_signal);
+    }
+    else if (impl->state < 0)
+    {
+        impl->state = 0;
+        if (impl->blocked_writers)
+            pthread_cond_signal(&impl->write_signal);
+        else
+            pthread_cond_broadcast(&impl->read_signal);
+    }
+    else
+        ret = EINVAL;
+
+    pthread_mutex_unlock(&impl->lock);
+    return ret;
+}
+
+#endif

--- a/cmake/darwin/default_libs.cmake
+++ b/cmake/darwin/default_libs.cmake
@@ -16,9 +16,11 @@ set_target_properties(Threads::Threads PROPERTIES INTERFACE_LINK_LIBRARIES pthre
 include (cmake/unwind.cmake)
 include (cmake/cxx.cmake)
 
-if (NOT SANITIZE)
+if (NOT SANITIZE STREQUAL "thread")
     # Replaces pthread_rwlock, which loses wakeups when waiters receive signals
     # (e.g. from the query profiler), permanently deadlocking the process.
+    # Excluded only under TSan, which interposes these functions itself; the other
+    # sanitizers run the query profiler too, so they need the workaround as well.
     # See base/darwin-compatibility/pthread_rwlock_shim.c and FB24027930.
     add_subdirectory(base/darwin-compatibility)
 endif ()

--- a/cmake/darwin/default_libs.cmake
+++ b/cmake/darwin/default_libs.cmake
@@ -15,3 +15,10 @@ set_target_properties(Threads::Threads PROPERTIES INTERFACE_LINK_LIBRARIES pthre
 
 include (cmake/unwind.cmake)
 include (cmake/cxx.cmake)
+
+if (NOT SANITIZE)
+    # Replaces pthread_rwlock, which loses wakeups when waiters receive signals
+    # (e.g. from the query profiler), permanently deadlocking the process.
+    # See base/darwin-compatibility/pthread_rwlock_shim.c and FB24027930.
+    add_subdirectory(base/darwin-compatibility)
+endif ()

--- a/src/Common/QueryProfiler.cpp
+++ b/src/Common/QueryProfiler.cpp
@@ -475,7 +475,7 @@ QueryProfilerBase<ProfilerImpl>::QueryProfilerBase(
     [[maybe_unused]] UInt64 thread_id, [[maybe_unused]] int clock_type, [[maybe_unused]] UInt64 period, [[maybe_unused]] int pause_signal_)
     : log(getLogger("QueryProfiler")), pause_signal(pause_signal_)
 {
-#if defined(SIGEV_THREAD_ID) || defined(OS_DARWIN)
+#if defined(QUERY_PROFILER_SUPPORTED)
     /// Under TSan we use frame-pointer-based unwinding (via abseil) which does not
     /// call dl_iterate_phdr in the signal handler, so the PHDR cache is not needed for
     /// stack capture. Symbolization happens later in a normal thread context.

--- a/src/Common/QueryProfiler.h
+++ b/src/Common/QueryProfiler.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <base/types.h>
+#include <base/sanitizer_defs.h> /// THREAD_SANITIZER, used by QUERY_PROFILER_SUPPORTED below
 #include <signal.h>
 #include <time.h>
 
@@ -12,6 +13,16 @@ namespace Poco
 {
     class Logger;
 }
+
+/// Whether the sampling query profiler can run in this build.
+/// It is disabled under TSan on macOS: the profiler pauses threads with signals, and a signal
+/// delivered to a thread waiting on a `pthread_rwlock` makes Darwin's implementation lose the
+/// wakeup and deadlock the process (Apple FB24027930). Other Darwin builds link the replacement
+/// in `base/darwin-compatibility`, but TSan builds cannot, because TSan interposes those same
+/// functions to track lock order.
+#if (defined(SIGEV_THREAD_ID) || defined(OS_DARWIN)) && !(defined(THREAD_SANITIZER) && defined(OS_DARWIN))
+#    define QUERY_PROFILER_SUPPORTED 1
+#endif
 
 namespace DB
 {

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -652,7 +652,7 @@ void ThreadStatus::resetPerformanceCountersLastUsage()
 
 void ThreadStatus::initGlobalProfiler([[maybe_unused]] UInt64 global_profiler_real_time_period, [[maybe_unused]] UInt64 global_profiler_cpu_time_period)
 {
-#if defined(SIGEV_THREAD_ID) || defined(OS_DARWIN)
+#if defined(QUERY_PROFILER_SUPPORTED)
     /// profilers are useless without trace collector
     auto context = Context::getGlobalContextInstance();
     if (!context->hasTraceCollector())
@@ -678,6 +678,7 @@ void ThreadStatus::initGlobalProfiler([[maybe_unused]] UInt64 global_profiler_re
 
 void ThreadStatus::initQueryProfiler()
 {
+#if defined(QUERY_PROFILER_SUPPORTED)
     /// query profilers are useless without trace collector
     auto global_context_ptr = global_context.lock();
     if (!global_context_ptr || !global_context_ptr->hasTraceCollector())
@@ -714,6 +715,7 @@ void ThreadStatus::initQueryProfiler()
         /// QueryProfiler is optional.
         tryLogCurrentException(LogFrequencyLimiter(log, 10), "Cannot initialize QueryProfiler. This usually happens when RLIMIT_SIGPENDING is too low. You may tune it via pending_signals in config.", LogsLevel::warning);
     }
+#endif
 }
 
 void ThreadStatus::finalizeQueryProfiler()


### PR DESCRIPTION
macOS `pthread_rwlock` permanently deadlocks when waiting threads receive signals at a high rate: Darwin's psynch rwlock retries an interrupted kernel wait with the sequence snapshot captured before the first sleep (`_pthread_rwlock_lock_wait` in libpthread), so a waiter that takes `EINTR` while the lock generation moves on re-enters a wait that is never signaled again, and the lock wedges with no holder. Reported to Apple as FB24027930; a standalone reproducer wedges in about 2 seconds.

With the sampling query profiler enabled on macOS (https://github.com/ClickHouse/ClickHouse/pull/109825), the profiler's `pthread_kill` delivery provides exactly that signal storm, and the hottest `pthread_rwlock` in the process is libfiu's fail point cache lock, taken on every fail point check (`ThreadStatus::attachToGroupImpl` on every query start, `TCPHandler::runImpl`, `SystemLog::flushImpl`, ...). Once it wedges, every new query, connection and system log flush blocks: this is the hang half of the `Fast test (arm_darwin)` `Server died` failures (~3% of runs), which survived the crash fix https://github.com/ClickHouse/ClickHouse/pull/111656.

This PR interposes `pthread_rwlock_*` for all code linked into ClickHouse binaries on Darwin (`base/darwin-compatibility`): a mutex + condition variable read-write lock taken from FreeBSD `libc_r` (BSD-2-Clause, including its recursive-rdlock workaround), with the state stored inside `pthread_rwlock_t` itself and lazy initialization for statically initialized locks. Condition variables tolerate spurious wakeups, so signal interruption has no correctness role. This covers every static `pthread_rwlock` user at once (libfiu, OpenSSL `CRYPTO_THREAD`, `Poco::RWLock`, RocksDB, kj, ...); calls inside Apple's dylibs keep the system implementation, as they must.

Validation: the standalone reproducer runs indefinitely with the shim (wedges in 2 s without); a server under fail point churn plus profiler storm wedged twice in ~90 s on the pre-fix binary with thread dumps matching the CI hang signature exactly, and ran clean with the shim; POSIX semantics covered by a dedicated test (recursion past a blocked writer, `try*` under contention, destroy/re-init, pshared rejection).

Closes: https://github.com/ClickHouse/ClickHouse/issues/111579
Related: https://github.com/ClickHouse/ClickHouse/pull/111656
Related: https://github.com/ClickHouse/ClickHouse/pull/109825

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Fixed a permanent server hang on macOS caused by `pthread_rwlock` losing wakeups when the sampling query profiler is enabled (Apple bug FB24027930): `pthread_rwlock` is now replaced with a signal-robust implementation on Darwin.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.435` (included in `26.8` and later)
- Backported to: `26.7.2.42`
<!-- ch-version-info:end -->