### PR TITLE
Fix flaky 02423_ddl_for_opentelemetry by retrying the span-log read in check_span

### DIFF
--- a/tests/queries/0_stateless/02423_ddl_for_opentelemetry.sh
+++ b/tests/queries/0_stateless/02423_ddl_for_opentelemetry.sh
@@ -39,17 +39,31 @@ function check_span()
         extra_condition=""
     fi
 
-    ret=$(${CLICKHOUSE_CLIENT} -q "
-        SYSTEM FLUSH LOGS opentelemetry_span_log;
+    # A span is enqueued into the async opentelemetry_span_log only when its holder is
+    # destroyed, and the TCPHandler holder is destroyed after the client already has its
+    # answer, so a single flush+count can legitimately read a short count. Retry while the
+    # count is below the expectation; a non-numeric result (client or flush error) breaks
+    # out immediately, and the sleep budget is shared by the whole test so a genuinely
+    # broken assertion cannot multiply the added wall time by the number of call sites.
+    for _ in {1..30}; do
+        ret=$(${CLICKHOUSE_CLIENT} -q "
+            SYSTEM FLUSH LOGS opentelemetry_span_log;
 
-        SELECT count()
-        FROM system.opentelemetry_span_log
-        WHERE finish_date >= yesterday()
-        AND   lower(hex(trace_id)) =    '${2}'
-        AND   operation_name       like '${3}'
-        ${extra_condition};")
+            SELECT count()
+            FROM system.opentelemetry_span_log
+            WHERE finish_date >= yesterday()
+            AND   lower(hex(trace_id)) =    '${2}'
+            AND   operation_name       like '${3}'
+            ${extra_condition};")
 
-    if [ $ret = $1 ]; then
+        [[ "$ret" =~ ^[0-9]+$ ]] || break
+        [[ "$ret" -ge "$1" ]] && break
+        [[ "${span_poll_sleeps_left:-0}" -gt 0 ]] || break
+        span_poll_sleeps_left=$((span_poll_sleeps_left - 1))
+        sleep 1
+    done
+
+    if [ "$ret" = "$1" ]; then
         echo 1
     else
         echo "[operation_name like '${3}' ${extra_condition}]=$ret, expected: ${1}"
@@ -79,6 +93,9 @@ cluster_name=$($CLICKHOUSE_CLIENT -q "select if(engine = 'Replicated', name, 'te
 #
 # Only format_version 4 enables the tracing
 #
+# Total number of 1-second sleeps check_span may spend waiting for spans to be enqueued.
+span_poll_sleeps_left=15
+
 for ddl_version in 3 4; do
     # Echo a separator so that the reference file is more clear for reading
     echo "===ddl_format_version ${ddl_version}===="


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/102192
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`02423_ddl_for_opentelemetry` intermittently fails with a diff produced by its own `check_span` helper:

```
===ddl_format_version 3====
-1
+[operation_name like 'TCPHandler' ]=0, expected: 1
```

Observed on `Stateless tests (amd_tsan, parallel)` at
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102192&sha=fd4d5ca77e721b5dd7f31b6a4afc663263c9d18c&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%29
The test's own diagnostic dump lists every other span for that trace id (`query`,
`DB::InterpreterCreateQuery::execute()`, `executeDDLQueryOnCluster`, `QueryCompPipeEx`,
`PipelineExecutor::execute()`) and only the `TCPHandler` one is missing, so the span is late rather
than lost. The runner's rerun agreed: `Runs: 3, Failed: 0, Passed: 3 ... not reproducible`.

**Root cause.** A span is enqueued into the asynchronous `opentelemetry_span_log` only when its
holder is destroyed: `TracingContextHolder::~TracingContextHolder` calls `shared_span_log->add(...)`
(`src/Common/OpenTelemetryTraceContext.cpp:469-472`), and `SpanHolder::finish()` does the same
(`:207-210`). `SYSTEM FLUSH LOGS opentelemetry_span_log` flushes what is already queued, so it cannot
flush a span whose holder is still alive. The `TCPHandler` SERVER span is exactly such a span: the
holder is declared one scope out of the query block with the comment *"Initialized later. It has to
be destroyed after query_state is destroyed."* (`src/Server/TCPHandler.cpp:572-573`), constructed at
`:604-609`, and destroyed only at the end of the connection-loop iteration, i.e. after
`query_state->finalizeOut(out)` at `:1153` has already sent the client its answer. `check_span` read
the count once, so a flush issued by the very next statement can legitimately observe a short count.

**Fix.** Retry the read inside `check_span` while the numeric count is below the expectation, then let
the existing exact comparison decide. The assertion, the failure line and the span dump are unchanged;
only the read is retried. This is the same shape as the already merged fixes for the two sibling tests
carrying the identical race. `02417_opentelemetry_insert_on_distributed_table` (#111419, merged
2026-07-24) went from 16 failures in the preceding 100 days to 0 afterwards.
`01455_opentelemetry_distributed` (merged 2026-06-12) went from 30 to 9, of which only 4 are not
host-memory-pressure rows, and 2 of those 4 are the poll's own explicit `spans not flushed within 20s`
message. That last detail is the useful one: it is field evidence that the timeout path keeps failing
loudly when a span is genuinely absent, which is the property this change has to preserve.

Three details worth noting:

- The sleep budget is **test-wide** (15 one-second sleeps), not per call. The default path has 11
  `check_span` calls with a positive expectation, so a per-call bound would cost up to ~165 s when
  many assertions are short, and Fast test runs this file with `--timeout 60`
  (`ci/jobs/fast_test.py:378`) - the run would be killed and the diagnostic lost. Measured with all
  11 sites made unreachable: 20 s total and all 11 reported as a diff.
- A count that is already **above** the expectation is reported immediately (the loop breaks because
  `count < expected` is false), so an unexpected extra span still fails fast. A site expecting `0`
  reads exactly once.
- A non-numeric result (client or flush error) breaks out at once instead of spinning. The comparison
  operands in `check_span` are now quoted, which also removes a real shell error visible in CI when the
  client failed and the count came back empty:
  `02423_ddl_for_opentelemetry.sh: line 52: [: =: unary operator expected` (17 rows in 180 days). The
  file has six more unquoted `[ $cluster_name = ... ]` / `[ $ddl_version = ... ]` comparisons that emit
  the same message from other lines, but those only fire when the setup query itself failed, which is a
  separate concern from the span race, so they are left alone here.

**Known limitation, pre-existing.** If a regression made an extra span arrive after the helper has
already observed exactly `expected`, the check still passes. The previous single-read helper has the
same hole, so this change neither creates nor widens it; closing it would require polling for a stable
count across several reads, which costs wall time on every run for a failure mode with no occurrences
in 60 days of CI history.

**Scope.** Only `02423_ddl_for_opentelemetry.sh` changes. Exactly four shell tests read
`system.opentelemetry_span_log`; the two siblings above already poll.
`02421_simple_queries_for_opentelemetry` also reads it once, but it is not a carrier of this race: it
asserts on the `query` span created by `SpanHolder` (`src/Interpreters/executeQuery.cpp:1185`), which is
finished from `logQueryFinish` / `logQueryException` (`:782`, `:897`, `:1031`) before the response
completes, so it does not depend on the `TCPHandler` holder outliving the answer. Its 14 failures in 60
days are 10 host-memory-pressure rows, 3 rows of a randomized-settings incompatibility from 2026-06-08,
and one `QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING` collision. It is deliberately left out of this PR.

**Verification.** The natural window is sub-millisecond on a quiet machine, and a 440-iteration loop
probe against an unmodified binary never reproduced it, so I proved the mechanism with a temporary
instrumented build that widened exactly the gap described above (a sleep after `finalizeOut`, reverted
before committing). Against that one binary the unmodified test failed 5 out of 5 runs with the same
signature as CI, and the fixed test passed 5 out of 5. On an unmodified binary the fixed test passes 50
out of 50 runs with randomized settings and 50 out of 50 without, and 5 out of 5 against a `Replicated`
database, which exercises the branch owning the assertions that expect zero spans. Separately, mutating
one expectation upwards still fails with the short count and the span dump, mutating one downwards fails
on the first read with no added delay, and forcing a client error is reported immediately with no shell
error.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.429` (included in `26.8` and later)
<!-- ch-version-info:end -->