### PR TITLE
Docs: fix invalid `WITH` clause documentation example

### DIFF
--- a/docs/en/sql-reference/statements/select/with.md
+++ b/docs/en/sql-reference/statements/select/with.md
@@ -272,11 +272,24 @@ ORDER BY table_disk_usage DESC
 LIMIT 10;
 ```
 
-**Example 6:** Reusing expression in a subquery
+**Example 6:** Reusing a common scalar expression in a subquery
 
 ```sql
-WITH test1 AS (SELECT i + 1, j + 1 FROM test1)
-SELECT * FROM test1;
+WITH (value) -> value + 1 AS increment
+SELECT increment(first_increment) AS second_increment
+FROM
+(
+    SELECT increment(number) AS first_increment
+    FROM numbers(3)
+);
+```
+
+```response
+┌─second_increment─┐
+│                2 │
+│                3 │
+│                4 │
+└──────────────────┘
 ```
 
 ## Recursive Queries {#recursive-queries}

--- a/docs/reference/statements/select/with.mdx
+++ b/docs/reference/statements/select/with.mdx
@@ -272,11 +272,24 @@ ORDER BY table_disk_usage DESC
 LIMIT 10;
 ```
 
-**Example 6:** Reusing expression in a subquery
+**Example 6:** Reusing a common scalar expression in a subquery
 
 ```sql
-WITH test1 AS (SELECT i + 1, j + 1 FROM test1)
-SELECT * FROM test1;
+WITH (value) -> value + 1 AS increment
+SELECT increment(first_increment) AS second_increment
+FROM
+(
+    SELECT increment(number) AS first_increment
+    FROM numbers(3)
+);
+```
+
+```response
+┌─second_increment─┐
+│                2 │
+│                3 │
+│                4 │
+└──────────────────┘
 ```
 
 ## Recursive Queries {#recursive-queries}


### PR DESCRIPTION
Reported via docs feedback widget

Replace the invalid self-referential `WITH` example in the English documentation with a self-contained common scalar expression example. The previous query referenced `test1`, `i`, and `j` without defining a source and could not be executed.

The replacement demonstrates applying a bound lambda inside a subquery and reusing it in the outer query. The exact query was validated with `clickhouse local`, and its output matches the documented values.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.277` (included in `26.8` and later)
<!-- ch-version-info:end -->