### PR TITLE
Fix clang 23 build

### DIFF
--- a/src/Processors/Formats/Impl/ArrowIPC/ArrowIPCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowIPC/ArrowIPCBlockInputFormat.cpp
@@ -396,9 +396,8 @@ void ArrowIPCBlockInputFormat::prepareFileReader()
         if (is_stopped)
             return;
         file_size = file_data.size();
-        auto in_memory = std::make_unique<ReadBufferFromMemory>(file_data.data(), file_data.size());
-        seekable = in_memory.get(); /// `ReadBufferFromMemory` is a `SeekableReadBuffer` (implicit upcast).
-        memory_buffer = std::move(in_memory);
+        memory_buffer = std::make_unique<ReadBufferFromMemory>(file_data.data(), file_data.size());
+        seekable = memory_buffer.get();
     }
     message_reader.emplace(*seekable);
 

--- a/src/Processors/Formats/Impl/ArrowIPC/ArrowIPCBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ArrowIPC/ArrowIPCBlockInputFormat.h
@@ -105,7 +105,7 @@ private:
     /// File format: random access to record batches via the footer.
     SeekableReadBuffer * seekable = nullptr;
     String file_data;                       /// Owns the bytes when the input had to be loaded into memory.
-    std::unique_ptr<ReadBuffer> memory_buffer;
+    std::unique_ptr<SeekableReadBuffer> memory_buffer;
     struct BlockInfo { Int64 offset = 0; Int64 metadata_length = 0; Int64 body_length = 0; };
     VectorWithMemoryTracking<BlockInfo> record_batch_blocks;
     size_t record_batch_current = 0;


### PR DESCRIPTION
clang23 complains

    /home/ubuntu/ch/ClickHouse/src/Processors/Formats/Impl/ArrowIPC/ArrowIPCBlockInputFormat.cpp:401:34: error: incompatible pointer types assigning to 'SeekableReadBuffer *' from 'pointer' (aka 'DB::ReadBuffer *')
      401 |         seekable = memory_buffer.get(); /// `ReadBufferFromMemory` is a `SeekableReadBuffer` (implicit upcast).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.298` (included in `26.8` and later)
<!-- ch-version-info:end -->