### PR TITLE
Add OverwriteCache table engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,6 @@ tests/casa_del_dolor/_instances*
 ci/praktika/json_test.html
 ci/praktika/json_test.html.gz
 ci/praktika/json.html.gz
+
+# Local design notes
+/NEW_DESIGN.md

--- a/docs/en/engines/table-engines/special/overwrite-cache.md
+++ b/docs/en/engines/table-engines/special/overwrite-cache.md
@@ -114,6 +114,24 @@ FROM latest_state
 WHERE website_type = 1 AND tag = 'risk';
 ```
 
+## Deleting rows {#deleting-rows}
+
+`DELETE FROM` and `ALTER TABLE ... DELETE WHERE` remove rows by key. The rows to remove are resolved through the read path, so a delete accepts exactly the predicates a `SELECT` accepts — a complete `KEYS` tuple, or one or more declared `INDEX (...)` tuples — and a predicate that would need a scan is rejected with the same error. Further predicates can narrow an indexed delete, exactly as they narrow an indexed `SELECT`.
+
+```sql
+DELETE FROM latest_state WHERE website_type = 1 AND user_id = 42 AND tag = 'risk';
+DELETE FROM latest_state WHERE tag = 'risk';
+DELETE FROM latest_state WHERE tag = 'risk' AND value = 'stale';
+```
+
+A delete is applied synchronously and is not a mutation left in the background: when the statement returns, the rows are no longer visible to new queries. It is published as one generation change, so a query never observes a partially applied delete, and, like an insert, it does not wait for in-flight readers. A query that captured an earlier generation keeps resolving the rows it already found.
+
+A deleted key can be inserted again. Winner selection has nothing to compare against after a delete, so the next inserted row wins whatever its version is — a delete is not a version floor.
+
+A delete publishes a tombstone rather than removing the key from the primary index and the lookup postings, because reclaiming those would require waiting for readers. The row payload is reclaimed: when every row of an immutable segment is gone the segment is released, and a segment that a delete leaves at least half dead is compacted just as a replacement compacts it. What a delete does not return is the key bytes in the primary index and the entry identifier in each lookup posting, so deleting and reinserting the same keys repeatedly leaves those growing. Only `TRUNCATE` and `DROP` release them.
+
+Deleting a key that is absent, or already deleted, is a no-op. `UPDATE` is not supported: a stored row is replaced by inserting a row with a greater version.
+
 ## Scalar lookup functions {#scalar-lookup-functions}
 
 `overwriteCacheGet` and `overwriteCacheGetOrNull` perform full composite-key lookups. The table name and returned column name must be constant strings. Key arguments follow the order in `KEYS (...)`.

--- a/docs/en/engines/table-engines/special/overwrite-cache.md
+++ b/docs/en/engines/table-engines/special/overwrite-cache.md
@@ -9,7 +9,7 @@ doc_type: 'reference'
 
 The `OverwriteCache` engine stores exactly one winning row for each composite key in RAM. It is intended for bounded latest-state caches that are rebuilt from an upstream source.
 
-Data is not persisted. Restarting the server, detaching and attaching the table, or recreating the table produces an empty cache.
+Rows are held in RAM and are served from RAM, but they are also written to disk, so the cache survives a restart, a `DETACH`, and a `RENAME`. See [Persistence](#persistence). Setting `persist_mode = 'none'` gives a purely in-memory table whose content is lost on restart.
 
 ## Creating a table {#creating-a-table}
 
@@ -28,7 +28,8 @@ KEYS (website_type, user_id, tag)
 INDEX (tag), (website_type), (website_type, tag)
 SETTINGS
     max_memory_bytes = 1073741824,
-    equal_version_tiebreak_columns = 'source_sequence';
+    equal_version_tiebreak_columns = 'source_sequence',
+    persist_mode = 'async';
 ```
 
 `OverwriteCache` requires one engine argument identifying the version column and a nonempty storage-level `KEYS (...)` clause. The version column cannot also be a key column.
@@ -87,11 +88,36 @@ ALTER TABLE latest_state DROP INDEX (user_id);
 
 An added index is privately populated and becomes available to new readers only after atomic publication. If population or metadata persistence fails, the previous index catalog remains active. Dropping an index atomically publishes a catalog without that family; readers that already planned against the previous catalog retain its immutable index generation until they finish.
 
+## Persistence {#persistence}
+
+The unit of persistence is the immutable row segment. A publication builds exactly one segment, which is written to its own file, is never rewritten, and whose file is removed when the segment is released. Nothing else is written: the primary index, the lookup postings, the entry table and the version chains are all rebuilt when the table is loaded, because every indexed column must belong to the `KEYS` tuple and is therefore stored inside the segment itself. Adding or dropping a lookup index does not touch the data files.
+
+A `manifest` file holds one record per publication, in publication order: the segments it added, the segments it retired, and the keys it deleted. Deletions have to be recorded because a segment that a `DELETE` leaves partially dead is not superseded by any later segment, so replaying that segment alone would bring the deleted keys back. `manifest` records are collapsed in the background once the bookkeeping grows well past the segments it describes.
+
+Loading replays the log: it skips the added segments that a later record retired, then applies the surviving segments in publication order through ordinary winner selection. Every stored row was a winner when it was published, so the replayed state is the exact state that was lost, including the equal-version tie-break rule, which resolves in favour of the row already stored and therefore depends on insertion order. Because the segments in memory mirror the files one to one, the loaded table occupies exactly the memory it occupied before, and segment compaction is left alone during replay.
+
+Loading happens while the table is being attached, so a table whose log cannot be replayed fails to attach rather than coming up as a silently empty cache. With `async_load_databases` enabled, which is the default, the table loads in the background after startup and a query that reaches it before it is ready waits for that load, exactly as it does for a `MergeTree` table.
+
+The stored log records the columns, the `KEYS` tuple, the version column and the tie-break columns it was written for. Attaching a table whose definition no longer matches fails instead of reinterpreting the stored rows.
+
+`persist_mode` selects when a publication reaches the disk:
+
+- `async`, the default, queues the publication and makes it visible immediately. A crash can lose the tail of the log; the manifest records are framed and checksummed, so an incomplete tail is recognized and dropped rather than read as a record. This suits a cache that can be topped up from its upstream source, and re-delivering rows is harmless because winner selection ignores a row that ties on the version and the tie-break columns.
+- `sync` returns from the `INSERT` only once its publication is durable. The wait happens after the writer lock is released, so a durable write never holds up another publication, but the throughput of the table is then bounded by the disk.
+
+A clean shutdown drains the queue, so restarting the server loses nothing even in `async` mode. Publication does not outrun the disk without bound: once the queue holds enough payload, the next publication waits for the writer rather than letting the queue become a second copy of the table.
+
+If persisting fails, the error is not swallowed - the table stops accepting publications and reports the failure, instead of continuing as an in-memory table whose disk copy has silently stopped advancing.
+
+`BACKUP` copies the immutable segment files together with a self-contained `manifest`, and holds back segment retirement while it does, so a concurrent publication cannot delete a file the backup was told to copy. `RESTORE` replaces the table's files and replays them; it refuses a table that already holds rows unless `allow_non_empty_tables` is set. A table created with `persist_mode = 'none'` cannot be backed up, because it keeps nothing on disk.
+
 ## Settings {#settings}
 
 - `max_memory_bytes` — Optional hard admission limit for engine-accounted memory. If omitted, allocations remain subject to the normal ClickHouse memory tracker and query limits.
 - `equal_version_tiebreak_columns` — Optional comma-separated column names used to select a deterministic winner when versions are equal. These columns cannot be key or version columns.
-- `compress_segments` — Optional flag, `0` by default. When set to `1`, payload columns are compressed in memory. This trades a large per-row read cost for lower residency; see [Memory representation](#memory-representation).
+- `compress_segments` — Optional flag, `0` by default. When set to `1`, payload columns are compressed in memory. This trades a large per-row read cost for lower residency; see [Memory representation](#memory-representation). Segment files are always compressed, so this setting does not change them, and a table can be recreated with a different value for it over the same data.
+- `persist_mode` — `'async'` by default. One of `'async'`, `'sync'` or `'none'`; see [Persistence](#persistence).
+- `disk` — Disk holding the segment files, `'default'` by default. Ignored when `persist_mode = 'none'`.
 
 Lookup indexes are declared only through `INDEX (...)`. The legacy settings `max_index_probe_rows`, `max_index_result_rows`, `index_each_key_column`, `secondary_index_columns`, `secondary_index_segment_column`, and `max_secondary_index_rows` are not supported. Every lookup-index column must occur in `KEYS`, and duplicate tuples are rejected.
 

--- a/docs/en/engines/table-engines/special/overwrite-cache.md
+++ b/docs/en/engines/table-engines/special/overwrite-cache.md
@@ -49,7 +49,11 @@ Conflict and memory-limit validation occurs before publishing mutations from an 
 
 `OverwriteCache` addresses primary keys and lookup-index postings through fixed hash shards. Existing rows use a fixed set of striped row locks rather than one lock per row. This bounds lock memory independently of the number of stored keys.
 
-An inserted block is prepared as a pending publication. Readers continue using the previously committed rows while the writer installs pending rows across the affected shards. One atomic generation change then makes the complete block visible. A query captures one generation, so it does not mix rows from before and after the same publication.
+An inserted block is prepared as a pending publication. Each affected row gets a new version tagged with the not-yet-published generation, so readers keep resolving the previous version while the writer works. One atomic generation change then makes the complete block visible. A query captures one generation, so it does not mix rows from before and after the same publication.
+
+A writer never waits for readers. A query that captured an older generation keeps its own versions of the rows it can still reach, and those versions are released once no live query can observe them. A long-running `SELECT` therefore delays reclamation rather than blocking concurrent inserts, and `INSERT INTO ... SELECT` reading the same table completes normally. While such a query is open, replaced rows stay resident and are reported as reclaimed by `system.tables.total_bytes` before their memory is actually returned.
+
+`TRUNCATE`, `DROP`, and `ALTER ... DROP INDEX` release storage outright rather than superseding it, so those do wait for in-flight readers to finish.
 
 The atomicity boundary is one input block received by the table-engine sink. A SQL `INSERT` can be divided into multiple input blocks by its pipeline; earlier blocks remain committed if a later block is rejected. Buffering a complete statement would make publication size unbounded and is intentionally not part of this in-memory engine's contract.
 

--- a/docs/en/engines/table-engines/special/overwrite-cache.md
+++ b/docs/en/engines/table-engines/special/overwrite-cache.md
@@ -55,9 +55,13 @@ The atomicity boundary is one input block received by the table-engine sink. A S
 
 ## Memory representation {#memory-representation}
 
-Committed payloads are stored in immutable native column segments. A segment preserves compact column representations such as `LowCardinality` dictionaries and can use ClickHouse's in-memory column compression. Rows retain only a segment reference and row offset; serialized primary and lookup keys used while preparing an insert are not retained in the row payload.
+Committed payloads are stored in immutable native column segments. A segment preserves compact column representations such as `LowCardinality` dictionaries. Rows retain only a segment reference and row offset; serialized primary and lookup keys used while preparing an insert are not retained in the row payload.
 
-Lookup postings store compact numeric entry identifiers instead of owning row pointers. They use `UInt32` identifiers while the ID range permits and upgrade to `UInt64` when required. Replacing a winner does not change postings because every indexed column must belong to the immutable `KEYS` tuple. When replacements leave at least half of a segment dead, its remaining live rows are compacted into a new immutable segment. Fully dead segments are reclaimed after readers of the previous publication epoch have drained.
+Segments are uncompressed by default. `compress_segments` enables ClickHouse's in-memory column compression, which lowers residency at a large cost per accessed row: reading one row of a compressed column decompresses the whole column, so it suits caches that are scanned by large lookups rather than probed one key at a time. The version and tie-break columns are never compressed, so winner selection compares values in place and never materializes a stored payload.
+
+Lookup postings store compact numeric entry identifiers instead of owning row pointers. They use `UInt32` identifiers while the ID range permits and upgrade to `UInt64` when required. Replacing a winner does not change postings because every indexed column must belong to the immutable `KEYS` tuple. When replacements leave at least half of a segment dead, its remaining live rows are compacted into a new immutable segment. Each segment carries one entry identifier per stored row, so selecting the survivors costs one pass over that segment rather than a scan of the whole table. Fully dead segments are reclaimed after readers of the previous publication epoch have drained.
+
+Entries live in a chunked array that never relocates, and the primary index and lookup postings are open-addressed hash tables keyed by arena-owned bytes. A reader therefore reaches a row without taking any table-wide lock, and a writer hashes each key once and locks each affected shard once per published block.
 
 Writers are serialized, but a large replacement publication does not take an engine-wide exclusive reader lock. New primary keys can briefly contend with readers of the same primary or posting shard. Large lookup-index results can still require substantial traversal work; sharding does not make an unbounded result inexpensive.
 
@@ -80,6 +84,7 @@ An added index is privately populated and becomes available to new readers only 
 
 - `max_memory_bytes` — Optional hard admission limit for engine-accounted memory. If omitted, allocations remain subject to the normal ClickHouse memory tracker and query limits.
 - `equal_version_tiebreak_columns` — Optional comma-separated column names used to select a deterministic winner when versions are equal. These columns cannot be key or version columns.
+- `compress_segments` — Optional flag, `0` by default. When set to `1`, payload columns are compressed in memory. This trades a large per-row read cost for lower residency; see [Memory representation](#memory-representation).
 
 Lookup indexes are declared only through `INDEX (...)`. The legacy settings `max_index_probe_rows`, `max_index_result_rows`, `index_each_key_column`, `secondary_index_columns`, `secondary_index_segment_column`, and `max_secondary_index_rows` are not supported. Every lookup-index column must occur in `KEYS`, and duplicate tuples are rejected.
 

--- a/docs/en/engines/table-engines/special/overwrite-cache.md
+++ b/docs/en/engines/table-engines/special/overwrite-cache.md
@@ -40,10 +40,13 @@ For each composite key, an inserted row is handled as follows:
 1. A greater version replaces the current row.
 2. A lower version is ignored.
 3. Equal versions compare `equal_version_tiebreak_columns` in declaration order.
-4. Equal winner metadata and an identical payload is an idempotent no-op.
-5. Equal winner metadata and a different payload causes the complete inserted block to be rejected.
+4. A row that is equal on both the version and the tie-break columns is ignored, whatever its payload is.
 
-Conflict and memory-limit validation occurs before publishing mutations from an inserted block. `OverwriteCache` does not evict rows when its memory limit is reached.
+Rule 4 makes a repeated insert of the same data a no-op, so re-delivering rows from the upstream source is harmless. It also means that rows which are genuinely different but indistinguishable to winner selection do not fail the insert: the row already stored wins. Which row that is depends on insertion order, and insertion order is not stable — a `INSERT ... SELECT` is divided into blocks by its pipeline, and concurrent inserts are ordered by arrival. Two caches rebuilt from the same upstream source can therefore hold different payloads for such a key. If the result has to be reproducible, `equal_version_tiebreak_columns` must fully determine the winner.
+
+The `OverwriteCacheEqualVersionTies` profile event counts inserted rows ignored by rule 4. A nonzero value on a table whose tie-break columns are meant to be unique points at duplicate rows in the upstream query.
+
+Memory-limit validation occurs before publishing mutations from an inserted block. `OverwriteCache` does not evict rows when its memory limit is reached.
 
 ## Concurrent publication {#concurrent-publication}
 

--- a/docs/en/engines/table-engines/special/overwrite-cache.md
+++ b/docs/en/engines/table-engines/special/overwrite-cache.md
@@ -25,12 +25,10 @@ CREATE TABLE latest_state
 )
 ENGINE = OverwriteCache(version)
 KEYS (website_type, user_id, tag)
+INDEX (tag), (website_type), (website_type, tag)
 SETTINGS
     max_memory_bytes = 1073741824,
-    equal_version_tiebreak_columns = 'source_sequence',
-    secondary_index_columns = 'tag',
-    secondary_index_segment_column = 'website_type',
-    max_secondary_index_rows = 1000000;
+    equal_version_tiebreak_columns = 'source_sequence';
 ```
 
 `OverwriteCache` requires one engine argument identifying the version column and a nonempty storage-level `KEYS (...)` clause. The version column cannot also be a key column.
@@ -49,30 +47,48 @@ Conflict and memory-limit validation occurs before publishing mutations from an 
 
 ## Concurrent publication {#concurrent-publication}
 
-`OverwriteCache` addresses primary keys and secondary postings through fixed hash shards. Existing rows use a fixed set of striped row locks rather than one lock per row. This bounds lock memory independently of the number of stored keys.
+`OverwriteCache` addresses primary keys and lookup-index postings through fixed hash shards. Existing rows use a fixed set of striped row locks rather than one lock per row. This bounds lock memory independently of the number of stored keys.
 
 An inserted block is prepared as a pending publication. Readers continue using the previously committed rows while the writer installs pending rows across the affected shards. One atomic generation change then makes the complete block visible. A query captures one generation, so it does not mix rows from before and after the same publication.
 
 The atomicity boundary is one input block received by the table-engine sink. A SQL `INSERT` can be divided into multiple input blocks by its pipeline; earlier blocks remain committed if a later block is rejected. Buffering a complete statement would make publication size unbounded and is intentionally not part of this in-memory engine's contract.
 
-Writers are serialized, but a large replacement publication does not take an engine-wide exclusive reader lock. New primary keys can briefly contend with readers of the same primary or posting shard. Large secondary-index results can still require substantial traversal and result-materialization work; sharding does not make an unbounded secondary result inexpensive.
+## Memory representation {#memory-representation}
+
+Committed payloads are stored in immutable native column segments. A segment preserves compact column representations such as `LowCardinality` dictionaries and can use ClickHouse's in-memory column compression. Rows retain only a segment reference and row offset; serialized primary and lookup keys used while preparing an insert are not retained in the row payload.
+
+Lookup postings store compact numeric entry identifiers instead of owning row pointers. They use `UInt32` identifiers while the ID range permits and upgrade to `UInt64` when required. Replacing a winner does not change postings because every indexed column must belong to the immutable `KEYS` tuple. When replacements leave at least half of a segment dead, its remaining live rows are compacted into a new immutable segment. Fully dead segments are reclaimed after readers of the previous publication epoch have drained.
+
+Writers are serialized, but a large replacement publication does not take an engine-wide exclusive reader lock. New primary keys can briefly contend with readers of the same primary or posting shard. Large lookup-index results can still require substantial traversal work; sharding does not make an unbounded result inexpensive.
+
+## Lookup indexes {#lookup-indexes}
+
+The complete `KEYS` tuple always has a primary lookup and must not be repeated in `INDEX`. Each `INDEX (...)` tuple creates one exact lookup family. A composite family does not implicitly create indexes for its individual columns.
+
+When no exact composite family matches a query, `OverwriteCache` can intersect multiple declared families. Within one family, `IN` values are combined as a union; families constrained by `AND` are intersected smallest-first. For example, `INDEX (website_type), (tag)` supports predicates on either column and their intersection, while `INDEX (website_type, tag)` avoids that intersection for the hot composite path.
+
+An index can be added to an existing table without exposing a partial backfill:
+
+```sql
+ALTER TABLE latest_state ADD INDEX (user_id);
+ALTER TABLE latest_state DROP INDEX (user_id);
+```
+
+An added index is privately populated and becomes available to new readers only after atomic publication. If population or metadata persistence fails, the previous index catalog remains active. Dropping an index atomically publishes a catalog without that family; readers that already planned against the previous catalog retain its immutable index generation until they finish.
 
 ## Settings {#settings}
 
-- `max_memory_bytes` — Required hard admission limit for engine-accounted memory. It must be greater than zero.
+- `max_memory_bytes` — Optional hard admission limit for engine-accounted memory. If omitted, allocations remain subject to the normal ClickHouse memory tracker and query limits.
 - `equal_version_tiebreak_columns` — Optional comma-separated column names used to select a deterministic winner when versions are equal. These columns cannot be key or version columns.
-- `secondary_index_columns` — Optional comma-separated key columns used for indexed equality and `IN` reads.
-- `secondary_index_segment_column` — Optional key column prepended to the configured secondary index.
-- `max_secondary_index_rows` — Required when a secondary index is configured. A lookup is rejected before returning more candidate rows than this value.
 
-Column names in each list must be unique. Every secondary-index column must be present in `KEYS (...)`.
+Lookup indexes are declared only through `INDEX (...)`. The legacy settings `max_index_probe_rows`, `max_index_result_rows`, `index_each_key_column`, `secondary_index_columns`, `secondary_index_segment_column`, and `max_secondary_index_rows` are not supported. Every lookup-index column must occur in `KEYS`, and duplicate tuples are rejected.
 
 ## Reading rows {#reading-rows}
 
 Normal `SELECT` queries must contain either:
 
 - equality or `IN` predicates that fully specify all columns in `KEYS (...)`; or
-- equality or `IN` predicates on all `secondary_index_columns`, optionally narrowed by `secondary_index_segment_column`.
+- equality or `IN` predicates covered by one or more declared `INDEX (...)` tuples.
 
 Other predicates can be applied after an indexed lookup, but they cannot be the only access path. Queries that require an unrestricted or partial-key scan are rejected.
 

--- a/docs/en/engines/table-engines/special/overwrite-cache.md
+++ b/docs/en/engines/table-engines/special/overwrite-cache.md
@@ -1,0 +1,103 @@
+---
+description: 'Stores one deterministic latest row per composite key in memory and serves indexed lookups.'
+sidebar_label: 'OverwriteCache'
+sidebar_position: 115
+slug: /engines/table-engines/special/overwrite-cache
+title: 'OverwriteCache table engine'
+doc_type: 'reference'
+---
+
+The `OverwriteCache` engine stores exactly one winning row for each composite key in RAM. It is intended for bounded latest-state caches that are rebuilt from an upstream source.
+
+Data is not persisted. Restarting the server, detaching and attaching the table, or recreating the table produces an empty cache.
+
+## Creating a table {#creating-a-table}
+
+```sql
+CREATE TABLE latest_state
+(
+    website_type UInt8,
+    user_id UInt64,
+    tag LowCardinality(String),
+    version DateTime64(3),
+    source_sequence UInt64,
+    value String
+)
+ENGINE = OverwriteCache(version)
+KEYS (website_type, user_id, tag)
+SETTINGS
+    max_memory_bytes = 1073741824,
+    equal_version_tiebreak_columns = 'source_sequence',
+    secondary_index_columns = 'tag',
+    secondary_index_segment_column = 'website_type',
+    max_secondary_index_rows = 1000000;
+```
+
+`OverwriteCache` requires one engine argument identifying the version column and a nonempty storage-level `KEYS (...)` clause. The version column cannot also be a key column.
+
+## Winner selection {#winner-selection}
+
+For each composite key, an inserted row is handled as follows:
+
+1. A greater version replaces the current row.
+2. A lower version is ignored.
+3. Equal versions compare `equal_version_tiebreak_columns` in declaration order.
+4. Equal winner metadata and an identical payload is an idempotent no-op.
+5. Equal winner metadata and a different payload causes the complete inserted block to be rejected.
+
+Conflict and memory-limit validation occurs before publishing mutations from an inserted block. `OverwriteCache` does not evict rows when its memory limit is reached.
+
+## Concurrent publication {#concurrent-publication}
+
+`OverwriteCache` addresses primary keys and secondary postings through fixed hash shards. Existing rows use a fixed set of striped row locks rather than one lock per row. This bounds lock memory independently of the number of stored keys.
+
+An inserted block is prepared as a pending publication. Readers continue using the previously committed rows while the writer installs pending rows across the affected shards. One atomic generation change then makes the complete block visible. A query captures one generation, so it does not mix rows from before and after the same publication.
+
+The atomicity boundary is one input block received by the table-engine sink. A SQL `INSERT` can be divided into multiple input blocks by its pipeline; earlier blocks remain committed if a later block is rejected. Buffering a complete statement would make publication size unbounded and is intentionally not part of this in-memory engine's contract.
+
+Writers are serialized, but a large replacement publication does not take an engine-wide exclusive reader lock. New primary keys can briefly contend with readers of the same primary or posting shard. Large secondary-index results can still require substantial traversal and result-materialization work; sharding does not make an unbounded secondary result inexpensive.
+
+## Settings {#settings}
+
+- `max_memory_bytes` — Required hard admission limit for engine-accounted memory. It must be greater than zero.
+- `equal_version_tiebreak_columns` — Optional comma-separated column names used to select a deterministic winner when versions are equal. These columns cannot be key or version columns.
+- `secondary_index_columns` — Optional comma-separated key columns used for indexed equality and `IN` reads.
+- `secondary_index_segment_column` — Optional key column prepended to the configured secondary index.
+- `max_secondary_index_rows` — Required when a secondary index is configured. A lookup is rejected before returning more candidate rows than this value.
+
+Column names in each list must be unique. Every secondary-index column must be present in `KEYS (...)`.
+
+## Reading rows {#reading-rows}
+
+Normal `SELECT` queries must contain either:
+
+- equality or `IN` predicates that fully specify all columns in `KEYS (...)`; or
+- equality or `IN` predicates on all `secondary_index_columns`, optionally narrowed by `secondary_index_segment_column`.
+
+Other predicates can be applied after an indexed lookup, but they cannot be the only access path. Queries that require an unrestricted or partial-key scan are rejected.
+
+```sql
+SELECT value
+FROM latest_state
+WHERE website_type = 1 AND user_id = 42 AND tag = 'risk';
+
+SELECT user_id, value
+FROM latest_state
+WHERE website_type = 1 AND tag = 'risk';
+```
+
+## Scalar lookup functions {#scalar-lookup-functions}
+
+`overwriteCacheGet` and `overwriteCacheGetOrNull` perform full composite-key lookups. The table name and returned column name must be constant strings. Key arguments follow the order in `KEYS (...)`.
+
+```sql
+SELECT overwriteCacheGetOrNull(
+    'default.latest_state',
+    'value',
+    toUInt8(1),
+    toUInt64(42),
+    'risk'
+);
+```
+
+`overwriteCacheGet` returns the column default for a missing key. `overwriteCacheGetOrNull` returns `NULL`.

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -34,7 +34,12 @@ static struct InitFiu
 #define APPLY_FOR_FAILPOINTS(ONCE, REGULAR, PAUSEABLE_ONCE, PAUSEABLE) \
     ONCE(replicated_merge_tree_commit_zk_fail_after_op) \
     ONCE(overwrite_cache_throw_during_publish) \
+    ONCE(overwrite_cache_throw_during_index_build) \
+    PAUSEABLE_ONCE(overwrite_cache_pause_after_lookup_catalog_snapshot) \
+    PAUSEABLE_ONCE(overwrite_cache_pause_after_drop_index_publication) \
     PAUSEABLE_ONCE(overwrite_cache_pause_before_commit) \
+    PAUSEABLE_ONCE(overwrite_cache_pause_during_index_build) \
+    PAUSEABLE_ONCE(overwrite_cache_pause_during_lookup) \
     ONCE(replicated_queue_fail_next_entry) \
     REGULAR(replicated_queue_unfail_entries) \
     ONCE(replicated_merge_tree_insert_quorum_fail_0) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -33,6 +33,8 @@ static struct InitFiu
 
 #define APPLY_FOR_FAILPOINTS(ONCE, REGULAR, PAUSEABLE_ONCE, PAUSEABLE) \
     ONCE(replicated_merge_tree_commit_zk_fail_after_op) \
+    ONCE(overwrite_cache_throw_during_publish) \
+    PAUSEABLE_ONCE(overwrite_cache_pause_before_commit) \
     ONCE(replicated_queue_fail_next_entry) \
     REGULAR(replicated_queue_unfail_entries) \
     ONCE(replicated_merge_tree_insert_quorum_fail_0) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -36,7 +36,9 @@ static struct InitFiu
     ONCE(overwrite_cache_throw_during_publish) \
     ONCE(overwrite_cache_throw_during_index_build) \
     PAUSEABLE_ONCE(overwrite_cache_pause_after_lookup_catalog_snapshot) \
+    PAUSEABLE_ONCE(overwrite_cache_pause_after_lookup_ids) \
     PAUSEABLE_ONCE(overwrite_cache_pause_after_drop_index_publication) \
+    PAUSEABLE_ONCE(overwrite_cache_pause_before_rollback) \
     PAUSEABLE_ONCE(overwrite_cache_pause_before_commit) \
     PAUSEABLE_ONCE(overwrite_cache_pause_during_index_build) \
     PAUSEABLE_ONCE(overwrite_cache_pause_during_lookup) \

--- a/src/Common/MultiVersion.h
+++ b/src/Common/MultiVersion.h
@@ -76,6 +76,13 @@ public:
         current_version = std::move(version);
     }
 
+    /// Update with an already allocated version. Useful when publication must not allocate.
+    void setAllocated(Version value)
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        current_version = std::move(value);
+    }
+
 private:
     mutable std::mutex mutex;
     Version current_version;

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -609,6 +609,8 @@
     M(StorageBufferLayerLockReadersWaitMilliseconds, "Time for waiting for Buffer layer during reading.", ValueType::Milliseconds) \
     M(StorageBufferLayerLockWritersWaitMilliseconds, "Time for waiting free Buffer layer to write to (can be used to tune Buffer layers).", ValueType::Milliseconds) \
     \
+    M(OverwriteCacheEqualVersionTies, "Number of rows inserted into an 'OverwriteCache' table that were ignored because a row with the same key already had the same version and tie-break values. A nonzero value means the tie-break columns do not fully determine the winner, so the stored payload depends on insertion order.", ValueType::Number) \
+    \
     M(SystemLogErrorOnFlush, "Number of times any of the system logs have failed to flush to the corresponding system table. Attempts to flush are repeated.", ValueType::Number) \
     \
     M(DictCacheKeysRequested, "Number of keys requested from the data source for the dictionaries of 'cache' types.", ValueType::Number) \

--- a/src/Common/setThreadName.h
+++ b/src/Common/setThreadName.h
@@ -109,6 +109,7 @@ namespace DB
     M(MYSQL_HANDLER, "MySQLHandler") \
     M(OBJECT_STORAGE_SHUTDOWN, "ObjStorShutdwn") \
     M(ORC_FILE, "ORCFile") \
+    M(OVERWRITE_CACHE_PERSIST, "OWCachePersist") \
     M(PARALLEL_COMPRESSORS_POOL, "ParallelCompres") \
     M(PARALLEL_FORMATER, "Formatter") \
     M(PARALLEL_FORMATER_COLLECTOR, "Collector") \

--- a/src/Databases/DatabasesCommon.cpp
+++ b/src/Databases/DatabasesCommon.cpp
@@ -226,8 +226,8 @@ void applyMetadataChangesToCreateQuery(const ASTPtr & query, const StorageInMemo
     {
         ASTStorage & storage_ast = *ast_create_query.storage;
 
-        bool is_extended_storage_def
-            = storage_ast.partition_by || storage_ast.primary_key || storage_ast.order_by || storage_ast.unique_key || storage_ast.sample_by || storage_ast.settings;
+        bool is_extended_storage_def = storage_ast.partition_by || storage_ast.primary_key || storage_ast.order_by || storage_ast.unique_key
+            || storage_ast.sample_by || storage_ast.settings || storage_ast.lookup_indexes || metadata.lookup_indexes;
 
         if (is_extended_storage_def)
         {
@@ -254,6 +254,11 @@ void applyMetadataChangesToCreateQuery(const ASTPtr & query, const StorageInMemo
 
             if (metadata.settings_changes)
                 storage_ast.set(storage_ast.settings, metadata.settings_changes);
+
+            if (metadata.lookup_indexes)
+                storage_ast.set(storage_ast.lookup_indexes, metadata.lookup_indexes);
+            else if (storage_ast.lookup_indexes)
+                storage_ast.reset(storage_ast.lookup_indexes);
         }
         else if (metadata.settings_changes)
         {

--- a/src/Functions/FunctionOverwriteCacheGet.cpp
+++ b/src/Functions/FunctionOverwriteCacheGet.cpp
@@ -1,0 +1,312 @@
+#include <Access/Common/AccessFlags.h>
+#include <Access/Common/AccessType.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnVector.h>
+#include <Core/QualifiedTableName.h>
+#include <Core/Settings.h>
+#include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+#include <Functions/IFunction.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/DatabaseCatalog.h>
+#include <Interpreters/castColumn.h>
+
+#include <Storages/StorageOverwriteCache.h>
+#include <Storages/TableLockHolder.h>
+#include <Common/Exception.h>
+#include <Common/typeid_cast.h>
+
+namespace DB
+{
+
+namespace Setting
+{
+extern const SettingsSeconds lock_acquire_timeout;
+}
+
+namespace ErrorCodes
+{
+extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+extern const int TYPE_MISMATCH;
+}
+
+namespace
+{
+
+using StorageOverwriteCachePtr = std::shared_ptr<StorageOverwriteCache>;
+
+class ExecutableOverwriteCacheGet final : public IExecutableFunction
+{
+public:
+    ExecutableOverwriteCacheGet(
+        String function_name_,
+        TableLockHolder table_lock_,
+        StorageOverwriteCachePtr storage_,
+        String attribute_,
+        bool or_null_,
+        DataTypes key_types_)
+        : function_name(std::move(function_name_))
+        , table_lock(std::move(table_lock_))
+        , storage(std::move(storage_))
+        , attribute(std::move(attribute_))
+        , or_null(or_null_)
+        , key_types(std::move(key_types_))
+    {
+    }
+
+    String getName() const override { return function_name; }
+    bool useDefaultImplementationForNulls() const override { return false; }
+    bool useDefaultImplementationForLowCardinalityColumns() const override { return false; }
+    bool useDefaultImplementationForConstants() const override { return true; }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t) const override
+    {
+        ColumnsWithTypeAndName keys;
+        keys.reserve(arguments.size() - 2);
+        for (size_t index = 2; index < arguments.size(); ++index)
+        {
+            auto key = arguments[index];
+            const auto & expected_type = key_types[index - 2];
+            if (!key.type->equals(*expected_type))
+            {
+                key.column = castColumn(key, expected_type);
+                key.type = expected_type;
+            }
+            keys.push_back(std::move(key));
+        }
+
+        PaddedPODArray<UInt8> found_map;
+        IColumn::Offsets offsets;
+        auto result = storage->getByKeys(keys, {attribute}, found_map, offsets);
+        auto columns = result.detachColumns();
+        auto result_column = IColumn::mutate(std::move(columns.front()));
+
+        if (!or_null)
+            return result_column;
+
+        result_column = IColumn::mutate(result_column->convertToFullColumnIfLowCardinality());
+        auto missing_map = ColumnUInt8::create();
+        auto & missing_data = missing_map->getData();
+        missing_data.resize(found_map.size());
+        for (size_t row = 0; row < found_map.size(); ++row)
+            missing_data[row] = !found_map[row];
+
+        if (auto * nullable = typeid_cast<ColumnNullable *>(result_column.get()))
+        {
+            nullable->applyNullMap(*missing_map);
+            return result_column;
+        }
+        return ColumnNullable::create(std::move(result_column), std::move(missing_map));
+    }
+
+private:
+    String function_name;
+    TableLockHolder table_lock;
+    StorageOverwriteCachePtr storage;
+    String attribute;
+    bool or_null;
+    DataTypes key_types;
+};
+
+class OverwriteCacheGetFunction final : public IFunctionBase
+{
+public:
+    OverwriteCacheGetFunction(
+        String function_name_,
+        ContextPtr context_,
+        TableLockHolder table_lock_,
+        StorageOverwriteCachePtr storage_,
+        String attribute_,
+        bool or_null_,
+        DataTypes key_types_,
+        DataTypes argument_types_,
+        DataTypePtr return_type_)
+        : function_name(std::move(function_name_))
+        , context(std::move(context_))
+        , table_lock(std::move(table_lock_))
+        , storage(std::move(storage_))
+        , attribute(std::move(attribute_))
+        , or_null(or_null_)
+        , key_types(std::move(key_types_))
+        , argument_types(std::move(argument_types_))
+        , return_type(std::move(return_type_))
+    {
+    }
+
+    String getName() const override { return function_name; }
+    const DataTypes & getArgumentTypes() const override { return argument_types; }
+    const DataTypePtr & getResultType() const override { return return_type; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override { return true; }
+
+    ExecutableFunctionPtr prepare(const ColumnsWithTypeAndName &) const override
+    {
+        Names columns = storage->getPrimaryKey();
+        columns.push_back(attribute);
+        context->checkAccess(AccessType::SELECT, storage->getStorageID(), columns);
+        return std::make_unique<ExecutableOverwriteCacheGet>(function_name, table_lock, storage, attribute, or_null, key_types);
+    }
+
+private:
+    String function_name;
+    ContextPtr context;
+    TableLockHolder table_lock;
+    StorageOverwriteCachePtr storage;
+    String attribute;
+    bool or_null;
+    DataTypes key_types;
+    DataTypes argument_types;
+    DataTypePtr return_type;
+};
+
+class OverwriteCacheGetResolver final : public IFunctionOverloadResolver, WithContext
+{
+public:
+    OverwriteCacheGetResolver(String function_name_, bool or_null_, ContextPtr context_)
+        : WithContext(std::move(context_))
+        , function_name(std::move(function_name_))
+        , or_null(or_null_)
+    {
+    }
+
+    static FunctionOverloadResolverPtr create(String function_name, bool or_null, ContextPtr context_)
+    {
+        return std::make_unique<OverwriteCacheGetResolver>(std::move(function_name), or_null, std::move(context_));
+    }
+
+    String getName() const override { return function_name; }
+    bool isDeterministic() const override { return false; }
+    bool isVariadic() const override { return true; }
+    size_t getNumberOfArguments() const override { return 0; }
+    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {0, 1}; }
+    bool useDefaultImplementationForNulls() const override { return false; }
+    bool useDefaultImplementationForLowCardinalityColumns() const override { return false; }
+
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName &) const override { return {}; }
+
+    FunctionBasePtr buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &) const override
+    {
+        if (arguments.size() < 3)
+            throw Exception(
+                ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                "Function {} requires a table, an attribute, and at least one key argument",
+                function_name);
+
+        const auto * table_column = checkAndGetColumnConst<ColumnString>(arguments[0].column.get());
+        if (!table_column)
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "First argument of function {} must be a constant String table name", function_name);
+        const String table_name = table_column->getValue<String>();
+        const auto qualified_name = QualifiedTableName::parseFromString(table_name);
+        const auto storage_id = getContext()->resolveStorageID({qualified_name.database, qualified_name.table});
+        auto table = DatabaseCatalog::instance().getTable(storage_id, std::const_pointer_cast<Context>(getContext()));
+        auto storage = std::dynamic_pointer_cast<StorageOverwriteCache>(table);
+        if (!storage)
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Table {} must use engine `OverwriteCache`", table_name);
+
+        const auto * attribute_column = checkAndGetColumnConst<ColumnString>(arguments[1].column.get());
+        if (!attribute_column)
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Second argument of function {} must be a constant String attribute name",
+                function_name);
+        const String attribute = attribute_column->getValue<String>();
+
+        const auto & expected_key_types = storage->getKeyColumnTypes();
+        if (arguments.size() - 2 != expected_key_types.size())
+            throw Exception(
+                ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                "Function {} requires {} key arguments, got {}",
+                function_name,
+                expected_key_types.size(),
+                arguments.size() - 2);
+        auto attribute_header = storage->getSampleBlock({attribute});
+        auto return_type = attribute_header.getByName(attribute).type;
+        if (or_null)
+            return_type = makeNullable(removeLowCardinality(return_type));
+
+        DataTypes argument_types;
+        argument_types.reserve(arguments.size());
+        for (const auto & argument : arguments)
+            argument_types.push_back(argument.type);
+
+        for (size_t index = 0; index < expected_key_types.size(); ++index)
+        {
+            const auto actual_type = removeLowCardinality(arguments[index + 2].type);
+            const auto expected_type = removeLowCardinality(expected_key_types[index]);
+            if (!actual_type->equals(*expected_type))
+                throw Exception(
+                    ErrorCodes::TYPE_MISMATCH,
+                    "Key argument {} has type {}, expected {}",
+                    index + 1,
+                    arguments[index + 2].type->getName(),
+                    expected_key_types[index]->getName());
+        }
+
+        auto table_lock
+            = storage->lockForShare(getContext()->getInitialQueryId(), getContext()->getSettingsRef()[Setting::lock_acquire_timeout]);
+        return std::make_unique<OverwriteCacheGetFunction>(
+            function_name,
+            getContext(),
+            std::move(table_lock),
+            std::move(storage),
+            attribute,
+            or_null,
+            expected_key_types,
+            std::move(argument_types),
+            std::move(return_type));
+    }
+
+private:
+    String function_name;
+    bool or_null;
+};
+
+}
+
+REGISTER_FUNCTION(OverwriteCacheGet)
+{
+    FunctionDocumentation::Description description = R"(
+Looks up a value in an `OverwriteCache` table by its complete composite key.
+)";
+    FunctionDocumentation::Arguments arguments = {
+        {"table", "Qualified `OverwriteCache` table name.", {"const String"}},
+        {"value_column", "Column whose value is returned.", {"const String"}},
+        {"keys", "Composite key values in the order declared by `KEYS`.", {"Any"}},
+    };
+    FunctionDocumentation::Examples examples;
+    FunctionDocumentation::IntroducedIn introduced_in = {26, 8};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation_get
+        = {description,
+           "overwriteCacheGet(table, value_column, keys)",
+           arguments,
+           {},
+           {"Returns the stored value, or the value column's default when the key is absent.", {"Any"}},
+           examples,
+           introduced_in,
+           category};
+    FunctionDocumentation documentation_get_or_null
+        = {description,
+           "overwriteCacheGetOrNull(table, value_column, keys)",
+           arguments,
+           {},
+           {"Returns the stored value, or `NULL` when the key is absent.", {"Any"}},
+           examples,
+           introduced_in,
+           category};
+
+    factory.registerFunction(
+        "overwriteCacheGet",
+        [](ContextPtr context) { return OverwriteCacheGetResolver::create("overwriteCacheGet", false, std::move(context)); },
+        documentation_get);
+    factory.registerFunction(
+        "overwriteCacheGetOrNull",
+        [](ContextPtr context) { return OverwriteCacheGetResolver::create("overwriteCacheGetOrNull", true, std::move(context)); },
+        documentation_get_or_null);
+}
+
+}

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -189,7 +189,14 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
     {
         ostr << "ADD INDEX " << (if_not_exists ? "IF NOT EXISTS " : "")
                      ;
-        index_decl->format(ostr, settings, state, frame);
+        if (index_decl->as<ASTExpressionList>())
+        {
+            ostr << '(';
+            index_decl->format(ostr, settings, state, frame);
+            ostr << ')';
+        }
+        else
+            index_decl->format(ostr, settings, state, frame);
 
         if (first)
             ostr << " FIRST ";
@@ -203,7 +210,14 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
     {
         ostr << (clear_index ? "CLEAR " : "DROP ") << "INDEX "
                       << (if_exists ? "IF EXISTS " : "");
-        index->format(ostr, settings, state, frame);
+        if (index_decl && index_decl->as<ASTExpressionList>())
+        {
+            ostr << '(';
+            index_decl->format(ostr, settings, state, frame);
+            ostr << ')';
+        }
+        else
+            index->format(ostr, settings, state, frame);
         if (partition)
         {
             ostr << " IN PARTITION ";

--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -57,6 +57,8 @@ ASTPtr ASTStorage::clone() const
         res->set(res->engine, engine->clone());
     if (keys)
         res->set(res->keys, keys->clone());
+    if (lookup_indexes)
+        res->set(res->lookup_indexes, lookup_indexes->clone());
     if (partition_by)
         res->set(res->partition_by, partition_by->clone());
     if (primary_key)
@@ -92,6 +94,20 @@ void ASTStorage::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Format
         nested_frame.expression_list_prepend_whitespace = false;
         keys->format(ostr, s, state, nested_frame);
         ostr << ')';
+    }
+    if (lookup_indexes)
+    {
+        ostr << s.nl_or_ws << "INDEX ";
+        for (size_t index = 0; index < lookup_indexes->children.size(); ++index)
+        {
+            if (index)
+                ostr << ", ";
+            ostr << '(';
+            auto nested_frame = modified_frame;
+            nested_frame.expression_list_prepend_whitespace = false;
+            lookup_indexes->children[index]->format(ostr, s, state, nested_frame);
+            ostr << ')';
+        }
     }
     if (partition_by)
     {
@@ -157,6 +173,8 @@ void ASTStorage::normalizeChildrenOrder()
     if (engine) children.emplace_back(engine);
     if (keys)
         children.emplace_back(keys);
+    if (lookup_indexes)
+        children.emplace_back(lookup_indexes);
     if (partition_by) children.emplace_back(partition_by);
     if (primary_key) children.emplace_back(primary_key);
     if (order_by) children.emplace_back(order_by);
@@ -169,7 +187,7 @@ void ASTStorage::normalizeChildrenOrder()
 
 bool ASTStorage::isExtendedStorageDefinition() const
 {
-    return keys || partition_by || primary_key || order_by || unique_key || sample_by || settings;
+    return keys || lookup_indexes || partition_by || primary_key || order_by || unique_key || sample_by || settings;
 }
 
 

--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -55,6 +55,8 @@ ASTPtr ASTStorage::clone() const
     /// `normalizeChildrenOrder`. `IAST::updateTreeHash` iterates `children` in sequence.
     if (engine)
         res->set(res->engine, engine->clone());
+    if (keys)
+        res->set(res->keys, keys->clone());
     if (partition_by)
         res->set(res->partition_by, partition_by->clone());
     if (primary_key)
@@ -82,6 +84,14 @@ void ASTStorage::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Format
         modified_frame.create_engine_name = engine->name;
         ostr << s.nl_or_ws << "ENGINE" << " = ";
         engine->format(ostr, s, state, modified_frame);
+    }
+    if (keys)
+    {
+        ostr << s.nl_or_ws << "KEYS (";
+        auto nested_frame = modified_frame;
+        nested_frame.expression_list_prepend_whitespace = false;
+        keys->format(ostr, s, state, nested_frame);
+        ostr << ')';
     }
     if (partition_by)
     {
@@ -145,6 +155,8 @@ void ASTStorage::normalizeChildrenOrder()
     old_children.swap(children);
 
     if (engine) children.emplace_back(engine);
+    if (keys)
+        children.emplace_back(keys);
     if (partition_by) children.emplace_back(partition_by);
     if (primary_key) children.emplace_back(primary_key);
     if (order_by) children.emplace_back(order_by);
@@ -157,7 +169,7 @@ void ASTStorage::normalizeChildrenOrder()
 
 bool ASTStorage::isExtendedStorageDefinition() const
 {
-    return partition_by || primary_key || order_by || unique_key || sample_by || settings;
+    return keys || partition_by || primary_key || order_by || unique_key || sample_by || settings;
 }
 
 

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -16,6 +16,7 @@ namespace DB
 class ASTFunction;
 class ASTSetQuery;
 class ASTSelectWithUnionQuery;
+class ASTExpressionList;
 struct CreateQueryUUIDs;
 
 
@@ -24,6 +25,7 @@ class ASTStorage : public IAST
 public:
     ASTFunction * engine = nullptr;
     IAST * keys = nullptr;
+    ASTExpressionList * lookup_indexes = nullptr;
     IAST * partition_by = nullptr;
     IAST * primary_key = nullptr;
     IAST * order_by = nullptr;
@@ -46,6 +48,7 @@ public:
     {
         f(reinterpret_cast<IAST **>(&engine), nullptr);
         f(&keys, nullptr);
+        f(reinterpret_cast<IAST **>(&lookup_indexes), nullptr);
         f(&partition_by, nullptr);
         f(&primary_key, nullptr);
         f(&order_by, nullptr);
@@ -59,8 +62,6 @@ protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 };
 
-
-class ASTExpressionList;
 
 class ASTColumns : public IAST
 {

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -23,6 +23,7 @@ class ASTStorage : public IAST
 {
 public:
     ASTFunction * engine = nullptr;
+    IAST * keys = nullptr;
     IAST * partition_by = nullptr;
     IAST * primary_key = nullptr;
     IAST * order_by = nullptr;
@@ -37,13 +38,14 @@ public:
 
     bool isExtendedStorageDefinition() const;
 
-    /// Rebuild `children` in canonical order (engine, partition_by, primary_key, order_by, ...).
+    /// Rebuild `children` in canonical order (engine, keys, partition_by, primary_key, order_by, ...).
     /// Needed after moving primary_key from columns_list because `set()` always appends.
     void normalizeChildrenOrder();
 
     void forEachPointerToChild(std::function<void(IAST **, boost::intrusive_ptr<IAST> *)> f) override
     {
         f(reinterpret_cast<IAST **>(&engine), nullptr);
+        f(&keys, nullptr);
         f(&partition_by, nullptr);
         f(&primary_key, nullptr);
         f(&order_by, nullptr);

--- a/src/Parsers/ParserAlterQuery.cpp
+++ b/src/Parsers/ParserAlterQuery.cpp
@@ -155,6 +155,7 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
         /* allow_empty = */ false);
 
     ParserExpressionList parser_add_enum_values(false);
+    ParserExpressionList parser_lookup_index_columns(false);
     ParserSelectWithUnionQuery select_p;
     ParserSQLSecurity sql_security_p;
     ParserRefreshStrategy refresh_p;
@@ -333,7 +334,13 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
                 if (s_if_not_exists.ignore(pos, expected))
                     command->if_not_exists = true;
 
-                if (!parser_idx_decl.parse(pos, command_index_decl, expected))
+                if (parser_opening_round_bracket.ignore(pos, expected))
+                {
+                    if (!parser_lookup_index_columns.parse(pos, command_index_decl, expected)
+                        || !parser_closing_round_bracket.ignore(pos, expected))
+                        return false;
+                }
+                else if (!parser_idx_decl.parse(pos, command_index_decl, expected))
                     return false;
 
                 if (s_first.ignore(pos, expected))
@@ -351,7 +358,13 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
                 if (s_if_exists.ignore(pos, expected))
                     command->if_exists = true;
 
-                if (!parser_name.parse(pos, command_index, expected))
+                if (parser_opening_round_bracket.ignore(pos, expected))
+                {
+                    if (!parser_lookup_index_columns.parse(pos, command_index_decl, expected)
+                        || !parser_closing_round_bracket.ignore(pos, expected))
+                        return false;
+                }
+                else if (!parser_name.parse(pos, command_index, expected))
                     return false;
 
                 command->type = ASTAlterCommand::DROP_INDEX;

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -602,12 +602,14 @@ bool ParserStorage::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ParserKeyword s_settings(Keyword::SETTINGS);
     ParserKeyword s_unique_key(Keyword::UNIQUE_KEY);
     ParserKeyword s_keys(Keyword::KEYS);
+    ParserKeyword s_index(Keyword::INDEX);
 
     ParserIdentifierWithOptionalParameters ident_with_optional_params_p;
     ParserExpression expression_p;
     ParserExpressionList expression_list_p(false);
     ParserToken opening_round_bracket_p(TokenType::OpeningRoundBracket);
     ParserToken closing_round_bracket_p(TokenType::ClosingRoundBracket);
+    ParserToken comma_p(TokenType::Comma);
     ParserStorageOrderByClause order_by_p(/*allow_order_*/ true);
     ParserSetQuery settings_p(/* parse_only_internals_ = */ true);
     ParserTTLExpressionList parser_ttl_list;
@@ -621,6 +623,7 @@ bool ParserStorage::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ASTPtr ttl_table;
     ASTPtr unique_key;
     ASTPtr keys;
+    ASTPtr lookup_indexes;
     ASTPtr settings;
 
     bool storage_like = false;
@@ -688,6 +691,24 @@ bool ParserStorage::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             return false;
         }
 
+        if (engine_kind == TABLE_ENGINE && !lookup_indexes && s_index.ignore(pos, expected))
+        {
+            auto indexes = make_intrusive<ASTExpressionList>();
+            while (true)
+            {
+                ASTPtr index_columns;
+                if (!opening_round_bracket_p.ignore(pos, expected) || !expression_list_p.parse(pos, index_columns, expected)
+                    || !closing_round_bracket_p.ignore(pos, expected))
+                    return false;
+                indexes->children.emplace_back(std::move(index_columns));
+                if (!comma_p.ignore(pos, expected))
+                    break;
+            }
+            lookup_indexes = std::move(indexes);
+            storage_like = true;
+            continue;
+        }
+
         if (!sample_by && s_sample_by.ignore(pos, expected))
         {
             if (expression_p.parse(pos, sample_by, expected))
@@ -747,6 +768,7 @@ bool ParserStorage::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     /// in `executeQueryImpl` with `Inconsistent AST formatting`.
     storage->set(storage->engine, engine);
     storage->set(storage->keys, keys);
+    storage->set(storage->lookup_indexes, lookup_indexes);
     storage->set(storage->partition_by, partition_by);
     storage->set(storage->primary_key, primary_key);
     storage->set(storage->order_by, order_by);

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -601,9 +601,13 @@ bool ParserStorage::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ParserKeyword s_ttl(Keyword::TTL);
     ParserKeyword s_settings(Keyword::SETTINGS);
     ParserKeyword s_unique_key(Keyword::UNIQUE_KEY);
+    ParserKeyword s_keys(Keyword::KEYS);
 
     ParserIdentifierWithOptionalParameters ident_with_optional_params_p;
     ParserExpression expression_p;
+    ParserExpressionList expression_list_p(false);
+    ParserToken opening_round_bracket_p(TokenType::OpeningRoundBracket);
+    ParserToken closing_round_bracket_p(TokenType::ClosingRoundBracket);
     ParserStorageOrderByClause order_by_p(/*allow_order_*/ true);
     ParserSetQuery settings_p(/* parse_only_internals_ = */ true);
     ParserTTLExpressionList parser_ttl_list;
@@ -616,6 +620,7 @@ bool ParserStorage::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ASTPtr sample_by;
     ASTPtr ttl_table;
     ASTPtr unique_key;
+    ASTPtr keys;
     ASTPtr settings;
 
     bool storage_like = false;
@@ -665,6 +670,17 @@ bool ParserStorage::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         if (!unique_key && s_unique_key.ignore(pos, expected))
         {
             if (expression_p.parse(pos, unique_key, expected))
+            {
+                storage_like = true;
+                continue;
+            }
+            return false;
+        }
+
+        if (engine_kind == TABLE_ENGINE && !keys && s_keys.ignore(pos, expected))
+        {
+            if (opening_round_bracket_p.ignore(pos, expected) && expression_list_p.parse(pos, keys, expected)
+                && closing_round_bracket_p.ignore(pos, expected))
             {
                 storage_like = true;
                 continue;
@@ -730,6 +746,7 @@ bool ParserStorage::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     /// produces a different `children` order, breaking the round-trip check
     /// in `executeQueryImpl` with `Inconsistent AST formatting`.
     storage->set(storage->engine, engine);
+    storage->set(storage->keys, keys);
     storage->set(storage->partition_by, partition_by);
     storage->set(storage->primary_key, primary_key);
     storage->set(storage->order_by, order_by);

--- a/src/Parsers/ParserCreateQuery.h
+++ b/src/Parsers/ParserCreateQuery.h
@@ -549,7 +549,8 @@ protected:
 
 
 /**
-  * [ENGINE = name] [PARTITION BY expr] [ORDER BY expr] [PRIMARY KEY expr] [SAMPLE BY expr] [SETTINGS name = value, ...]
+  * [ENGINE = name] [KEYS (expr, ...)] [PARTITION BY expr] [PRIMARY KEY expr]
+  * [ORDER BY expr] [UNIQUE KEY expr] [SAMPLE BY expr] [SETTINGS name = value, ...]
   */
 class ParserStorage : public IParserBase
 {

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -325,6 +325,13 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
         AlterCommand command;
         command.ast = command_ast->clone();
         command.index_decl = command_ast->index_decl->clone();
+        if (command_ast->index_decl->as<ASTExpressionList>())
+        {
+            command.type = AlterCommand::ADD_LOOKUP_INDEX;
+            command.lookup_index = command_ast->index_decl->clone();
+            command.if_not_exists = command_ast->if_not_exists;
+            return command;
+        }
         command.type = AlterCommand::ADD_INDEX;
 
         const auto & ast_index_decl = command_ast->index_decl->as<ASTIndexDeclaration &>();
@@ -432,6 +439,13 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
     {
         AlterCommand command;
         command.ast = command_ast->clone();
+        if (command_ast->index_decl && command_ast->index_decl->as<ASTExpressionList>())
+        {
+            command.type = AlterCommand::DROP_LOOKUP_INDEX;
+            command.lookup_index = command_ast->index_decl->clone();
+            command.if_exists = command_ast->if_exists;
+            return command;
+        }
         command.type = AlterCommand::DROP_INDEX;
         command.index_name = command_ast->index->as<ASTIdentifier &>().name();
         command.if_exists = command_ast->if_exists;
@@ -804,6 +818,14 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
             insert_it,
             IndexDescription::getIndexFromAST(
                 index_decl, metadata.columns, /* is_implicitly_created */ false, metadata.escape_index_filenames, context));
+    }
+    else if (type == ADD_LOOKUP_INDEX)
+    {
+        auto indexes = metadata.lookup_indexes
+            ? metadata.lookup_indexes->clone()->as<ASTExpressionList &>().clone()
+            : make_intrusive<ASTExpressionList>();
+        indexes->children.push_back(lookup_index->clone());
+        metadata.lookup_indexes = std::move(indexes);
     }
     else if (type == DROP_INDEX)
     {

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -327,6 +327,8 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
         command.index_decl = command_ast->index_decl->clone();
         if (command_ast->index_decl->as<ASTExpressionList>())
         {
+            if (command_ast->first || command_ast->index)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Lookup `INDEX (...)` does not support `FIRST` or `AFTER`");
             command.type = AlterCommand::ADD_LOOKUP_INDEX;
             command.lookup_index = command_ast->index_decl->clone();
             command.if_not_exists = command_ast->if_not_exists;
@@ -1708,6 +1710,10 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
     for (size_t i = 0; i < size(); ++i)
     {
         const auto & command = (*this)[i];
+
+        if ((command.type == AlterCommand::ADD_LOOKUP_INDEX || command.type == AlterCommand::DROP_LOOKUP_INDEX)
+            && !StorageFactory::instance().getStorageFeatures(table->getName()).supports_lookup_indexes)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine {} doesn't support lookup `INDEX (...)`", table->getName());
 
         if (command.ttl && !table->supportsTTL())
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine {} doesn't support TTL clause", table->getName());

--- a/src/Storages/AlterCommands.h
+++ b/src/Storages/AlterCommands.h
@@ -33,6 +33,8 @@ struct AlterCommand
         MODIFY_SAMPLE_BY,
         ADD_INDEX,
         DROP_INDEX,
+        ADD_LOOKUP_INDEX,
+        DROP_LOOKUP_INDEX,
         ADD_CONSTRAINT,
         DROP_CONSTRAINT,
         MODIFY_CONSTRAINT,
@@ -111,6 +113,9 @@ struct AlterCommand
 
     /// For ADD/DROP INDEX
     String index_name;
+
+    /// For engine-specific `ADD INDEX (...)`.
+    ASTPtr lookup_index;
 
     // For ADD/MODIFY CONSTRAINT
     ASTPtr constraint_decl = nullptr;

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -230,6 +230,12 @@ public:
         metadata.set(std::make_unique<StorageInMemoryMetadata>(metadata_));
     }
 
+    /// Publish metadata whose allocation and copying were completed before a critical section.
+    void setInMemoryMetadata(StorageMetadataPtr metadata_)
+    {
+        metadata.setAllocated(std::move(metadata_));
+    }
+
     VectorWithMemoryTracking<String> getAllRegisteredNames() const override;
 
     NameDependencies getDependentViewsByColumn(ContextPtr context) const;

--- a/src/Storages/KVStorageUtils.cpp
+++ b/src/Storages/KVStorageUtils.cpp
@@ -124,16 +124,19 @@ bool traverseDAGFilterSingleColumn(
             return false;
 
         const auto * key = elem->children.at(0);
+        const auto * value = elem->children.at(1);
         while (key->type == ActionsDAG::ActionType::ALIAS)
             key = key->children.at(0);
+        while (value->type == ActionsDAG::ActionType::ALIAS)
+            value = value->children.at(0);
 
-        if (key->type != ActionsDAG::ActionType::INPUT)
-            return false;
+        if (key->type != ActionsDAG::ActionType::INPUT || key->result_name != primary_key)
+        {
+            std::swap(key, value);
+            if (key->type != ActionsDAG::ActionType::INPUT || key->result_name != primary_key)
+                return false;
+        }
 
-        if (key->result_name != primary_key)
-            return false;
-
-        const auto * value = elem->children.at(1);
         if (value->type != ActionsDAG::ActionType::COLUMN)
             return false;
 
@@ -251,57 +254,60 @@ bool traverseDAGFilter(
         const auto * left = elem->children.at(0);
         const auto * right = elem->children.at(1);
 
-        // Skip aliases
         while (left->type == ActionsDAG::ActionType::ALIAS)
             left = left->children.at(0);
+        while (right->type == ActionsDAG::ActionType::ALIAS)
+            right = right->children.at(0);
 
-        // Check if left side is tuple function with our key columns
-        if (left->type == ActionsDAG::ActionType::FUNCTION && left->function_base->getName() == "tuple")
+        const auto is_primary_key_tuple = [&](const ActionsDAG::Node * node)
         {
-            // Verify all tuple elements are our primary key columns in order
-            if (left->children.size() != primary_keys.size())
+            if (node->type != ActionsDAG::ActionType::FUNCTION || node->function_base->getName() != "tuple")
+                return false;
+            if (node->children.size() != primary_keys.size())
                 return false;
 
             for (size_t i = 0; i < primary_keys.size(); ++i)
             {
-                const auto * key_node = left->children.at(i);
+                const auto * key_node = node->children.at(i);
                 while (key_node->type == ActionsDAG::ActionType::ALIAS)
                     key_node = key_node->children.at(0);
 
                 if (key_node->type != ActionsDAG::ActionType::INPUT || key_node->result_name != primary_keys[i])
                     return false;
             }
-
-            // Extract tuple value from right side
-            if (right->type != ActionsDAG::ActionType::COLUMN)
-                return false;
-
-            auto value_field = right->column->getField();
-            if (value_field.getType() != Field::Types::Tuple)
-                return false;
-
-            const auto & tuple_value = value_field.safeGet<Tuple>();
-            if (tuple_value.size() != primary_keys.size())
-                return false;
-
-            // Convert each tuple element to the correct type
-            std::vector<Field> converted_values;
-            converted_values.reserve(tuple_value.size());
-            for (size_t i = 0; i < tuple_value.size(); ++i)
-            {
-                auto converted = convertFieldToType(tuple_value[i], *primary_key_types[i]);
-                if (converted.isNull())
-                    return false;
-                converted_values.push_back(converted);
-            }
-
-            res->push_back(createTupleField(converted_values));
             return true;
+        };
+
+        if (!is_primary_key_tuple(left))
+        {
+            std::swap(left, right);
+            if (!is_primary_key_tuple(left))
+                return false;
         }
 
-        // Fall back to single-column handling for individual column equality
-        // This will be caught by AND handler below
-        return false;
+        if (right->type != ActionsDAG::ActionType::COLUMN)
+            return false;
+
+        auto value_field = right->column->getField();
+        if (value_field.getType() != Field::Types::Tuple)
+            return false;
+
+        const auto & tuple_value = value_field.safeGet<Tuple>();
+        if (tuple_value.size() != primary_keys.size())
+            return false;
+
+        std::vector<Field> converted_values;
+        converted_values.reserve(tuple_value.size());
+        for (size_t i = 0; i < tuple_value.size(); ++i)
+        {
+            auto converted = convertFieldToType(tuple_value[i], *primary_key_types[i]);
+            if (converted.isNull())
+                return false;
+            converted_values.push_back(converted);
+        }
+
+        res->push_back(createTupleField(converted_values));
+        return true;
     }
 
     // Handle tuple IN: (key1, key2) IN ((v1, v2), (v3, v4))
@@ -359,7 +365,7 @@ bool traverseDAGFilter(
             const auto & set_elements = set->getSetElements();
 
             if (set_elements.empty())
-                return false;
+                return true;
 
             size_t num_rows = set_elements[0]->size();
 
@@ -386,7 +392,7 @@ bool traverseDAGFilter(
                     res->push_back(createTupleField(tuple_values));
             }
 
-            return !res->empty();
+            return true;
         }
 
         return false;
@@ -395,6 +401,18 @@ bool traverseDAGFilter(
     // Handle AND: key1 = v1 AND key2 = v2
     if (func_name == "and")
     {
+        /// A complete tuple predicate provides a bounded candidate set. Any other
+        /// conjuncts remain in the query filter and are applied to those candidates.
+        for (const auto * child : elem->children)
+        {
+            FieldVectorPtr child_res = std::make_shared<FieldVector>();
+            if (traverseDAGFilter(primary_keys, primary_key_types, child, context, child_res))
+            {
+                res->insert(res->end(), child_res->begin(), child_res->end());
+                return true;
+            }
+        }
+
         // Collect filters for each key column separately
         std::unordered_map<String, FieldVector> column_filters;
 
@@ -406,11 +424,11 @@ bool traverseDAGFilter(
                 FieldVectorPtr child_res = std::make_shared<FieldVector>();
                 if (traverseDAGFilterSingleColumn(primary_keys[i], primary_key_types[i], child, context, child_res))
                 {
-                    if (!child_res->empty())
-                    {
-                        for (const auto & val : *child_res)
-                            column_filters[primary_keys[i]].push_back(val);
-                    }
+                    /// An explicitly matched empty set makes the whole conjunction empty.
+                    if (child_res->empty())
+                        return true;
+                    for (const auto & val : *child_res)
+                        column_filters[primary_keys[i]].push_back(val);
                 }
             }
         }

--- a/src/Storages/OverwriteCachePersistence.cpp
+++ b/src/Storages/OverwriteCachePersistence.cpp
@@ -1,0 +1,835 @@
+#include <Storages/OverwriteCachePersistence.h>
+
+#include <Columns/IColumn.h>
+#include <Compression/CompressedReadBuffer.h>
+#include <Compression/CompressedWriteBuffer.h>
+#include <Formats/NativeReader.h>
+#include <Formats/NativeWriter.h>
+#include <IO/ReadBufferFromFileBase.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/ReadHelpers.h>
+#include <IO/ReadSettings.h>
+#include <IO/WriteBufferFromFileBase.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
+#include <IO/copyData.h>
+#include <Common/SipHash.h>
+#include <Common/logger_useful.h>
+#include <Common/setThreadName.h>
+
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ABORTED;
+    extern const int BAD_ARGUMENTS;
+    extern const int CANNOT_RESTORE_TABLE;
+    extern const int INCORRECT_DATA;
+    extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+
+/// The log is framed rather than plainly appended, so that the torn tail an `Async` crash leaves behind
+/// is recognizable instead of being read as a record.
+constexpr std::string_view manifest_magic = "OverwriteCacheManifest\n";
+constexpr std::string_view segment_file_suffix = ".seg";
+constexpr std::string_view tmp_directory = "tmp";
+
+/// Written revision-independently: the file has to outlive the server that produced it.
+constexpr UInt64 native_revision = 0;
+
+}
+
+OverwriteCachePersistMode parseOverwriteCachePersistMode(const String & value)
+{
+    if (value == "none")
+        return OverwriteCachePersistMode::None;
+    if (value == "async")
+        return OverwriteCachePersistMode::Async;
+    if (value == "sync")
+        return OverwriteCachePersistMode::Sync;
+    throw Exception(
+        ErrorCodes::BAD_ARGUMENTS, "Setting `persist_mode` of storage `OverwriteCache` must be 'none', 'async' or 'sync'");
+}
+
+std::string_view toString(OverwriteCachePersistMode mode)
+{
+    switch (mode)
+    {
+        case OverwriteCachePersistMode::None:
+            return "none";
+        case OverwriteCachePersistMode::Async:
+            return "async";
+        case OverwriteCachePersistMode::Sync:
+            return "sync";
+    }
+}
+
+OverwriteCachePersistence::OverwriteCachePersistence(
+    OverwriteCachePersistMode mode_, DiskPtr disk_, String path_, Block header_, String fingerprint_, String log_name_)
+    : mode(mode_)
+    , disk(std::move(disk_))
+    , header(std::move(header_))
+    , shared_header(std::make_shared<const Block>(header.cloneEmpty()))
+    , fingerprint(std::move(fingerprint_))
+    , log(getLogger(log_name_))
+    , path(std::move(path_))
+{
+    if (!isEnabled())
+        return;
+    if (!disk)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Storage `OverwriteCache` requires a disk to persist data");
+    if (path.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Storage `OverwriteCache` requires a data path to persist data");
+}
+
+OverwriteCachePersistence::~OverwriteCachePersistence()
+{
+    try
+    {
+        shutdown();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(log, "Failed to shut down `OverwriteCache` persistence");
+    }
+}
+
+String OverwriteCachePersistence::getPath() const
+{
+    std::lock_guard lock(path_mutex);
+    return path;
+}
+
+String OverwriteCachePersistence::segmentFileName(UInt64 segment_id) const
+{
+    return fmt::format("{:020}{}", segment_id, segment_file_suffix);
+}
+
+void OverwriteCachePersistence::createDirectories()
+{
+    const auto table_path = getPath();
+    disk->createDirectories(fs::path(table_path) / tmp_directory);
+}
+
+void OverwriteCachePersistence::openManifest(bool rewrite)
+{
+    const auto manifest_path = fs::path(getPath()) / manifest_file_name;
+    if (rewrite || !disk->existsFile(manifest_path))
+    {
+        manifest_buffer = disk->writeFile(manifest_path, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite);
+        writeString(manifest_magic, *manifest_buffer);
+        writeBinaryLittleEndian(format_version, *manifest_buffer);
+        writeStringBinary(fingerprint, *manifest_buffer);
+        manifest_buffer->next();
+        manifest_buffer->sync();
+        return;
+    }
+    manifest_buffer = disk->writeFile(manifest_path, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Append);
+}
+
+void OverwriteCachePersistence::closeManifest()
+{
+    if (!manifest_buffer)
+        return;
+    manifest_buffer->finalize();
+    manifest_buffer.reset();
+}
+
+void OverwriteCachePersistence::load(const std::function<void(LoadedRecord &&)> & apply)
+{
+    if (!isEnabled())
+        return;
+
+    createDirectories();
+    const auto table_path = getPath();
+    const auto manifest_path = fs::path(table_path) / manifest_file_name;
+    if (!disk->existsFile(manifest_path))
+    {
+        /// A fresh table, or one whose log was removed. Any segment file left behind belongs to no log.
+        for (auto it = disk->iterateDirectory(table_path); it->isValid(); it->next())
+        {
+            if (it->name().ends_with(segment_file_suffix))
+                disk->removeFileIfExists(fs::path(table_path) / it->name());
+        }
+        return;
+    }
+
+    std::unordered_set<UInt64> removed_segments;
+    const auto records = readManifest(removed_segments);
+
+    UInt64 max_segment_id = 0;
+    size_t applied_rows = 0;
+    size_t deletions = 0;
+    std::vector<Record::Segment> loaded_segments;
+    std::unordered_set<UInt64> loaded_segment_ids;
+    for (const auto & record : records)
+    {
+        for (const auto & segment : record.added)
+            max_segment_id = std::max(max_segment_id, segment.segment_id);
+
+        if (!record.deleted_keys.empty())
+        {
+            deletions += record.deleted_keys.size();
+            LoadedRecord loaded;
+            loaded.deleted_keys = record.deleted_keys;
+            apply(std::move(loaded));
+        }
+
+        for (const auto & segment : record.added)
+        {
+            if (removed_segments.contains(segment.segment_id))
+                continue;
+
+            const auto segment_path = fs::path(table_path) / segmentFileName(segment.segment_id);
+            if (!disk->existsFile(segment_path))
+                throw Exception(
+                    ErrorCodes::INCORRECT_DATA,
+                    "Segment file {} of storage `OverwriteCache` is referenced by {} but is missing",
+                    segment_path.string(),
+                    manifest_path.string());
+
+            auto file_buffer = disk->readFile(segment_path, getReadSettings());
+            CompressedReadBuffer compressed(*file_buffer);
+            NativeReader reader(compressed, header, native_revision);
+            Block block = reader.read();
+            if (block.rows() != segment.rows)
+                throw Exception(
+                    ErrorCodes::INCORRECT_DATA,
+                    "Segment file {} of storage `OverwriteCache` holds {} rows, but {} records {}",
+                    segment_path.string(),
+                    block.rows(),
+                    manifest_path.string(),
+                    segment.rows);
+
+            LoadedRecord loaded;
+            loaded.segment_id = segment.segment_id;
+            loaded.block = std::move(block);
+            applied_rows += loaded.block.rows();
+            apply(std::move(loaded));
+
+            loaded_segments.push_back(segment);
+            loaded_segment_ids.emplace(segment.segment_id);
+        }
+    }
+
+    next_segment_id.store(max_segment_id + 1, std::memory_order_relaxed);
+
+    /// A crash between writing a segment and recording it, or between recording a retirement and
+    /// deleting the file, leaves a file no live record refers to.
+    size_t orphan_files = 0;
+    for (auto it = disk->iterateDirectory(table_path); it->isValid(); it->next())
+    {
+        const auto & name = it->name();
+        if (!name.ends_with(segment_file_suffix))
+            continue;
+        UInt64 segment_id = 0;
+        if (!tryParse(segment_id, std::string_view{name}.substr(0, name.size() - segment_file_suffix.size()))
+            || !loaded_segment_ids.contains(segment_id))
+        {
+            disk->removeFileIfExists(fs::path(table_path) / name);
+            ++orphan_files;
+        }
+    }
+
+    LOG_INFO(
+        log,
+        "Loaded {} segments with {} rows and {} deletions from {} log records, removed {} orphan files",
+        loaded_segments.size(),
+        applied_rows,
+        deletions,
+        records.size(),
+        orphan_files);
+
+    std::lock_guard state_lock(state_mutex);
+    live_segments = std::move(loaded_segments);
+    live_segment_ids = std::move(loaded_segment_ids);
+    records_since_checkpoint = records.size();
+}
+
+std::vector<OverwriteCachePersistence::Record>
+OverwriteCachePersistence::readManifest(std::unordered_set<UInt64> & removed_segments) const
+{
+    const auto manifest_path = fs::path(getPath()) / manifest_file_name;
+    auto file_buffer = disk->readFile(manifest_path, getReadSettings());
+
+    String magic;
+    magic.resize(manifest_magic.size());
+    file_buffer->readStrict(magic.data(), magic.size());
+    if (magic != manifest_magic)
+        throw Exception(
+            ErrorCodes::INCORRECT_DATA, "File {} is not an `OverwriteCache` manifest", manifest_path.string());
+
+    UInt8 version = 0;
+    readBinaryLittleEndian(version, *file_buffer);
+    if (version != format_version)
+        throw Exception(
+            ErrorCodes::INCORRECT_DATA,
+            "Manifest {} of storage `OverwriteCache` has format version {}, but this server writes version {}",
+            manifest_path.string(),
+            static_cast<UInt16>(version),
+            static_cast<UInt16>(format_version));
+
+    String stored_fingerprint;
+    readStringBinary(stored_fingerprint, *file_buffer);
+    if (stored_fingerprint != fingerprint)
+        throw Exception(
+            ErrorCodes::INCORRECT_DATA,
+            "Persisted data of storage `OverwriteCache` was written for a different table definition. "
+            "Stored: {}. Current: {}. Attaching would silently reinterpret the stored rows",
+            stored_fingerprint,
+            fingerprint);
+
+    std::vector<Record> records;
+    size_t truncated_bytes = 0;
+    while (!file_buffer->eof())
+    {
+        UInt64 payload_size = 0;
+        UInt128 expected_checksum{};
+        String payload;
+        /// A record whose frame or payload is incomplete, or whose checksum does not match, is the tail an
+        /// `Async` publication never got to finish. Everything from there on is treated as absent.
+        try
+        {
+            readBinaryLittleEndian(payload_size, *file_buffer);
+            readPODBinary(expected_checksum, *file_buffer);
+            payload.resize(payload_size);
+            file_buffer->readStrict(payload.data(), payload_size);
+        }
+        catch (const Exception &)
+        {
+            truncated_bytes = 1;
+            break;
+        }
+
+        if (sipHash128(payload.data(), payload.size()) != expected_checksum)
+        {
+            truncated_bytes = payload_size;
+            break;
+        }
+
+        ReadBufferFromString payload_buffer(payload);
+        Record record;
+        readBinaryLittleEndian(record.generation, payload_buffer);
+
+        UInt64 count = 0;
+        readBinaryLittleEndian(count, payload_buffer);
+        record.added.resize(count);
+        for (auto & segment : record.added)
+        {
+            readBinaryLittleEndian(segment.segment_id, payload_buffer);
+            readBinaryLittleEndian(segment.rows, payload_buffer);
+        }
+
+        readBinaryLittleEndian(count, payload_buffer);
+        record.removed.resize(count);
+        for (auto & segment_id : record.removed)
+        {
+            readBinaryLittleEndian(segment_id, payload_buffer);
+            removed_segments.emplace(segment_id);
+        }
+
+        readBinaryLittleEndian(count, payload_buffer);
+        record.deleted_keys.resize(count);
+        for (auto & key : record.deleted_keys)
+            readStringBinary(key, payload_buffer);
+
+        records.push_back(std::move(record));
+    }
+
+    if (truncated_bytes)
+        LOG_WARNING(
+            log,
+            "Manifest {} of storage `OverwriteCache` ends with an incomplete record. The publications it "
+            "covered were not durable and are dropped",
+            manifest_path.string());
+
+    return records;
+}
+
+void OverwriteCachePersistence::start()
+{
+    if (!isEnabled())
+        return;
+
+    {
+        std::lock_guard state_lock(state_mutex);
+        openManifest(/*rewrite=*/false);
+    }
+
+    std::lock_guard lock(mutex);
+    if (writer_thread)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Persistence of storage `OverwriteCache` is already started");
+    started = true;
+    stopped = false;
+    writer_exception = {};
+    writer_thread.emplace([this] { writerThread(); });
+}
+
+UInt64 OverwriteCachePersistence::enqueue(Commit && commit)
+{
+    if (!isEnabled())
+        return 0;
+    if (commit.added.empty() && commit.removed.empty() && commit.deleted_keys.empty())
+        return 0;
+
+    UInt64 bytes = 0;
+    for (const auto & segment : commit.added)
+        for (const auto & column : segment.columns)
+            bytes += column->allocatedBytes();
+
+    std::unique_lock lock(mutex);
+    if (writer_exception)
+        std::rethrow_exception(writer_exception);
+    if (!started)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Persistence of storage `OverwriteCache` is not started");
+
+    /// Waiting here keeps the queue from becoming a second copy of the table. The writer lock is held, so
+    /// this is the one place where a slow disk slows publication down even in `Async` mode.
+    queue_changed.wait(lock, [&]() TSA_NO_THREAD_SAFETY_ANALYSIS
+    { return stopped || writer_exception || queued_bytes < max_queued_bytes; });
+    if (writer_exception)
+        std::rethrow_exception(writer_exception);
+    if (stopped)
+        return 0;
+
+    const UInt64 sequence = next_sequence++;
+    queued_bytes += bytes;
+    queue.emplace_back(sequence, std::move(commit));
+    queue_changed.notify_all();
+    return sequence;
+}
+
+void OverwriteCachePersistence::waitDurable(UInt64 sequence)
+{
+    if (!isEnabled() || !sequence)
+        return;
+
+    std::unique_lock lock(mutex);
+    durable_changed.wait(lock, [&]() TSA_NO_THREAD_SAFETY_ANALYSIS
+    { return stopped || writer_exception || durable_sequence >= sequence; });
+    if (writer_exception)
+        std::rethrow_exception(writer_exception);
+    /// The caller asked for a durability guarantee, so a shutdown that races the wait is an error rather
+    /// than something to pass over quietly.
+    if (durable_sequence < sequence)
+        throw Exception(
+            ErrorCodes::ABORTED, "Persistence of storage `OverwriteCache` stopped before the publication was durable");
+}
+
+void OverwriteCachePersistence::setException()
+{
+    std::lock_guard lock(mutex);
+    if (!writer_exception)
+        writer_exception = std::current_exception();
+    queue_changed.notify_all();
+    durable_changed.notify_all();
+}
+
+void OverwriteCachePersistence::writerThread()
+{
+    setThreadName(ThreadName::OVERWRITE_CACHE_PERSIST);
+
+    while (true)
+    {
+        UInt64 sequence = 0;
+        Commit commit;
+        UInt64 bytes = 0;
+        {
+            std::unique_lock lock(mutex);
+            queue_changed.wait(lock, [&]() TSA_NO_THREAD_SAFETY_ANALYSIS { return stopped || !queue.empty(); });
+            if (queue.empty())
+                return;
+            sequence = queue.front().first;
+            commit = std::move(queue.front().second);
+            queue.pop_front();
+            for (const auto & segment : commit.added)
+                for (const auto & column : segment.columns)
+                    bytes += column->allocatedBytes();
+        }
+
+        try
+        {
+            writeCommit(commit);
+        }
+        catch (...)
+        {
+            tryLogCurrentException(log, "Failed to persist an `OverwriteCache` publication");
+            setException();
+            return;
+        }
+
+        {
+            std::lock_guard lock(mutex);
+            queued_bytes -= std::min(queued_bytes, bytes);
+            durable_sequence = sequence;
+            queue_changed.notify_all();
+            durable_changed.notify_all();
+        }
+    }
+}
+
+void OverwriteCachePersistence::writeCommit(const Commit & commit)
+{
+    /// A segment file has to be durable before the record that claims it exists, and a retired file may
+    /// only be deleted once the record that stops referring to it is durable.
+    for (const auto & segment : commit.added)
+        writeSegmentFile(segment);
+
+    Record record;
+    record.generation = commit.generation;
+    record.added.reserve(commit.added.size());
+    for (const auto & segment : commit.added)
+        record.added.push_back({segment.segment_id, segment.rows});
+    record.removed = commit.removed;
+    record.deleted_keys = commit.deleted_keys;
+
+    {
+        std::lock_guard state_lock(state_mutex);
+        appendManifestRecord(record);
+
+        for (const auto & segment : record.added)
+        {
+            live_segments.push_back(segment);
+            live_segment_ids.emplace(segment.segment_id);
+        }
+        for (const auto segment_id : record.removed)
+        {
+            live_segment_ids.erase(segment_id);
+            std::erase_if(live_segments, [&](const Record::Segment & segment) { return segment.segment_id == segment_id; });
+        }
+        ++records_since_checkpoint;
+
+        if (needsCheckpoint())
+            checkpointManifest();
+    }
+
+    removeSegmentFiles(record.removed);
+}
+
+void OverwriteCachePersistence::writeSegmentFile(const AddedSegment & segment)
+{
+    const auto table_path = getPath();
+    const auto file_name = segmentFileName(segment.segment_id);
+    const auto tmp_path = fs::path(table_path) / tmp_directory / file_name;
+
+    Block block = header.cloneEmpty();
+    if (block.columns() != segment.columns.size())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Row segment of storage `OverwriteCache` does not match the table header");
+    for (size_t position = 0; position < segment.columns.size(); ++position)
+        block.getByPosition(position).column = segment.columns[position]->decompress();
+
+    {
+        auto file_buffer = disk->writeFile(tmp_path, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite);
+        CompressedWriteBuffer compressed(*file_buffer);
+        NativeWriter writer(compressed, native_revision, shared_header);
+        writer.write(block);
+        writer.flush();
+        compressed.finalize();
+        file_buffer->next();
+        file_buffer->sync();
+        file_buffer->finalize();
+    }
+
+    /// A rename makes the file appear complete or not at all, so a crash never leaves a half-written
+    /// segment where the manifest expects a whole one.
+    disk->replaceFile(tmp_path, fs::path(table_path) / file_name);
+}
+
+void OverwriteCachePersistence::appendManifestRecord(const Record & record)
+{
+    WriteBufferFromOwnString payload_buffer;
+    writeBinaryLittleEndian(record.generation, payload_buffer);
+    writeBinaryLittleEndian(static_cast<UInt64>(record.added.size()), payload_buffer);
+    for (const auto & segment : record.added)
+    {
+        writeBinaryLittleEndian(segment.segment_id, payload_buffer);
+        writeBinaryLittleEndian(segment.rows, payload_buffer);
+    }
+    writeBinaryLittleEndian(static_cast<UInt64>(record.removed.size()), payload_buffer);
+    for (const auto segment_id : record.removed)
+        writeBinaryLittleEndian(segment_id, payload_buffer);
+    writeBinaryLittleEndian(static_cast<UInt64>(record.deleted_keys.size()), payload_buffer);
+    for (const auto & key : record.deleted_keys)
+        writeStringBinary(key, payload_buffer);
+
+    const auto payload = payload_buffer.str();
+    const auto checksum = sipHash128(payload.data(), payload.size());
+
+    if (!manifest_buffer)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Manifest of storage `OverwriteCache` is not open");
+    writeBinaryLittleEndian(static_cast<UInt64>(payload.size()), *manifest_buffer);
+    writePODBinary(checksum, *manifest_buffer);
+    manifest_buffer->write(payload.data(), payload.size());
+    manifest_buffer->next();
+    manifest_buffer->sync();
+}
+
+void OverwriteCachePersistence::removeSegmentFiles(const std::vector<UInt64> & segment_ids)
+{
+    if (segment_ids.empty())
+        return;
+
+    {
+        std::lock_guard lock(mutex);
+        if (backup_pins)
+        {
+            /// A backup already listed these files. Deleting them now would make it fail on a file it was
+            /// told to copy, so the removal waits for the backup to finish.
+            deferred_removals.insert(deferred_removals.end(), segment_ids.begin(), segment_ids.end());
+            return;
+        }
+    }
+
+    const auto table_path = getPath();
+    for (const auto segment_id : segment_ids)
+        disk->removeFileIfExists(fs::path(table_path) / segmentFileName(segment_id));
+}
+
+bool OverwriteCachePersistence::needsCheckpoint() const
+{
+    /// The bookkeeping is worth collapsing once the log holds far more records than the segments it
+    /// describes, which is what a steadily churning cache produces.
+    return records_since_checkpoint > checkpoint_min_records
+        && records_since_checkpoint > 2 * live_segments.size();
+}
+
+void OverwriteCachePersistence::checkpointManifest()
+{
+    std::unordered_set<UInt64> removed_segments;
+    auto records = readManifest(removed_segments);
+
+    /// Drop the added segments a later record retired, and the retirements themselves.
+    std::vector<Record> compacted;
+    compacted.reserve(records.size());
+    bool seen_live_segment = false;
+    size_t dropped_deletions = 0;
+    for (auto & record : records)
+    {
+        Record kept;
+        kept.generation = record.generation;
+        for (const auto & segment : record.added)
+        {
+            if (!removed_segments.contains(segment.segment_id))
+                kept.added.push_back(segment);
+        }
+        /// A deletion still shadows the key in every surviving segment written before it. One written
+        /// before every surviving segment shadows nothing, because replay reaches it first.
+        if (seen_live_segment)
+            kept.deleted_keys = std::move(record.deleted_keys);
+        else
+            dropped_deletions += record.deleted_keys.size();
+        seen_live_segment = seen_live_segment || !kept.added.empty();
+
+        if (!kept.added.empty() || !kept.deleted_keys.empty())
+            compacted.push_back(std::move(kept));
+    }
+
+    writeManifest(compacted);
+
+    records_since_checkpoint = compacted.size();
+    LOG_INFO(
+        log,
+        "Collapsed the `OverwriteCache` log from {} to {} records, describing {} segments, and dropped {} deletions that no "
+        "surviving segment shadows",
+        records.size(),
+        compacted.size(),
+        live_segments.size(),
+        dropped_deletions);
+}
+
+void OverwriteCachePersistence::writeManifest(const std::vector<Record> & records)
+{
+    closeManifest();
+
+    const auto table_path = getPath();
+    const auto tmp_path = fs::path(table_path) / tmp_directory / manifest_file_name;
+    {
+        manifest_buffer = disk->writeFile(tmp_path, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite);
+        writeString(manifest_magic, *manifest_buffer);
+        writeBinaryLittleEndian(format_version, *manifest_buffer);
+        writeStringBinary(fingerprint, *manifest_buffer);
+        for (const auto & record : records)
+            appendManifestRecord(record);
+        manifest_buffer->finalize();
+        manifest_buffer.reset();
+    }
+
+    disk->replaceFile(tmp_path, fs::path(table_path) / manifest_file_name);
+    openManifest(/*rewrite=*/false);
+}
+
+void OverwriteCachePersistence::truncate()
+{
+    if (!isEnabled())
+        return;
+
+    shutdown();
+
+    const auto table_path = getPath();
+    if (disk->existsDirectory(table_path))
+        disk->removeRecursive(table_path);
+    createDirectories();
+
+    {
+        std::lock_guard state_lock(state_mutex);
+        live_segments.clear();
+        live_segment_ids.clear();
+        records_since_checkpoint = 0;
+    }
+    next_segment_id.store(1, std::memory_order_relaxed);
+
+    {
+        std::lock_guard lock(mutex);
+        queue.clear();
+        queued_bytes = 0;
+        durable_sequence = next_sequence - 1;
+        deferred_removals.clear();
+    }
+    {
+        std::lock_guard state_lock(state_mutex);
+        openManifest(/*rewrite=*/true);
+    }
+
+    std::lock_guard lock(mutex);
+    started = true;
+    stopped = false;
+    writer_exception = {};
+    writer_thread.emplace([this] { writerThread(); });
+}
+
+void OverwriteCachePersistence::removeAllFiles()
+{
+    if (!isEnabled())
+        return;
+
+    shutdown();
+
+    const auto table_path = getPath();
+    if (disk->existsDirectory(table_path))
+        disk->removeRecursive(table_path);
+}
+
+void OverwriteCachePersistence::rename(const String & new_path)
+{
+    if (!isEnabled())
+        return;
+
+    std::lock_guard state_lock(state_mutex);
+    {
+        /// A database that addresses a table by its UUID keeps the same data path across a rename, and
+        /// replacing a directory with itself is not a move.
+        std::lock_guard lock(path_mutex);
+        if (path == new_path)
+            return;
+    }
+
+    closeManifest();
+    {
+        std::lock_guard lock(path_mutex);
+        disk->replaceFile(path, new_path);
+        path = new_path;
+    }
+    openManifest(/*rewrite=*/false);
+}
+
+void OverwriteCachePersistence::shutdown()
+{
+    if (!isEnabled())
+        return;
+
+    {
+        std::lock_guard lock(mutex);
+        if (stopped)
+            return;
+        stopped = true;
+        queue_changed.notify_all();
+        durable_changed.notify_all();
+    }
+
+    if (writer_thread)
+    {
+        writer_thread->join();
+        writer_thread.reset();
+    }
+
+    std::lock_guard state_lock(state_mutex);
+    closeManifest();
+}
+
+OverwriteCachePersistence::BackupPin::BackupPin(OverwriteCachePersistence & persistence_) : persistence(persistence_)
+{
+    std::lock_guard lock(persistence.mutex);
+    ++persistence.backup_pins;
+}
+
+OverwriteCachePersistence::BackupPin::~BackupPin()
+{
+    std::vector<UInt64> to_remove;
+    {
+        std::lock_guard lock(persistence.mutex);
+        if (--persistence.backup_pins == 0)
+            to_remove.swap(persistence.deferred_removals);
+    }
+
+    try
+    {
+        persistence.removeSegmentFiles(to_remove);
+    }
+    catch (...)
+    {
+        tryLogCurrentException(persistence.log, "Failed to remove retired `OverwriteCache` segment files");
+    }
+}
+
+std::vector<String> OverwriteCachePersistence::collectFilesForBackup()
+{
+    if (!isEnabled())
+        return {};
+
+    /// The queue has to be empty for the log to describe everything the table holds, and the log has to
+    /// be self-contained so that a restore does not need the retired files it still mentions.
+    UInt64 sequence = 0;
+    {
+        std::lock_guard lock(mutex);
+        if (backup_pins == 0)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "A `BACKUP` of storage `OverwriteCache` requires a pin");
+        sequence = next_sequence - 1;
+    }
+    waitDurable(sequence);
+
+    std::vector<String> result;
+    {
+        std::lock_guard state_lock(state_mutex);
+        checkpointManifest();
+        result.reserve(live_segments.size() + 1);
+        result.emplace_back(manifest_file_name);
+        for (const auto & segment : live_segments)
+            result.push_back(segmentFileName(segment.segment_id));
+    }
+    return result;
+}
+
+void OverwriteCachePersistence::restoreFileFromBackup(const String & file_name, ReadBuffer & in)
+{
+    if (!isEnabled())
+        throw Exception(
+            ErrorCodes::CANNOT_RESTORE_TABLE,
+            "Storage `OverwriteCache` cannot restore data into a table created with `persist_mode = 'none'`");
+
+    createDirectories();
+    auto out = disk->writeFile(fs::path(getPath()) / file_name, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite);
+    copyData(in, *out);
+    out->next();
+    out->sync();
+    out->finalize();
+}
+
+}

--- a/src/Storages/OverwriteCachePersistence.h
+++ b/src/Storages/OverwriteCachePersistence.h
@@ -1,0 +1,222 @@
+#pragma once
+
+#include <Core/Block.h>
+#include <Disks/IDisk.h>
+#include <Common/ThreadPool.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <unordered_set>
+#include <vector>
+
+namespace DB
+{
+
+enum class OverwriteCachePersistMode : uint8_t
+{
+    /// The table is in-memory only. Nothing is written and a restart produces an empty cache.
+    None,
+    /// A publication is queued for persistence and becomes visible immediately. A crash can lose the
+    /// tail of the log, which a cache rebuilt from an upstream source can afford.
+    Async,
+    /// An `INSERT` returns only once its publication is durable.
+    Sync,
+};
+
+OverwriteCachePersistMode parseOverwriteCachePersistMode(const String & value);
+std::string_view toString(OverwriteCachePersistMode mode);
+
+/** On-disk log that lets an `OverwriteCache` table survive a restart.
+  *
+  * Committed payloads already live in immutable row segments, so a segment is written to its own file
+  * once, is never rewritten, and its file is deleted when the segment it mirrors is released. Nothing
+  * else is written: the primary index, the lookup postings, the entry table and the version chains are
+  * all rebuilt at load time, because every indexed column must belong to the `KEYS` tuple and is
+  * therefore stored inside the segment itself.
+  *
+  * `manifest` holds one commit record per publication, in publication order: the segments the
+  * publication added, the segments it retired, and the keys it deleted. Deletions have to be recorded
+  * because a segment that a `DELETE` leaves partially dead is not superseded by any later segment, so
+  * replaying that segment alone would resurrect the deleted keys.
+  *
+  * Replay skips the added segments that a later commit retired and applies the surviving ones in
+  * publication order through ordinary winner selection. Every stored row was a winner when it was
+  * published, so this reproduces the exact state, including the equal-version tie-break rule - which
+  * resolves in favour of the row already stored and therefore depends on insertion order.
+  */
+class OverwriteCachePersistence
+{
+public:
+    struct AddedSegment
+    {
+        UInt64 segment_id = 0;
+        /// Segment columns as stored, which for `compress_segments` are compressed in memory. They are
+        /// written out decompressed, so that the file does not depend on that setting.
+        Columns columns;
+        UInt64 rows = 0;
+    };
+
+    /// Everything one publication changed on disk. An insert adds a segment and retires the segments its
+    /// replacements emptied; a delete records its keys and adds the segments compaction rewrote.
+    struct Commit
+    {
+        UInt64 generation = 0;
+        std::vector<AddedSegment> added;
+        std::vector<UInt64> removed;
+        std::vector<String> deleted_keys;
+    };
+
+    /// One replayed record. Either a segment block or a batch of deleted keys, never both: a commit is
+    /// handed to the loader as its deletions followed by its segments.
+    struct LoadedRecord
+    {
+        UInt64 segment_id = 0;
+        Block block;
+        std::vector<String> deleted_keys;
+    };
+
+    OverwriteCachePersistence(
+        OverwriteCachePersistMode mode_,
+        DiskPtr disk_,
+        String path_,
+        Block header_,
+        String fingerprint_,
+        String log_name_);
+
+    ~OverwriteCachePersistence();
+
+    bool isEnabled() const { return mode != OverwriteCachePersistMode::None; }
+
+    /// Replays the log. `apply` runs on the loading thread in log order, before `start`, so replay
+    /// itself writes nothing. A segment that replay leaves without a live row is retired by the caller
+    /// through an ordinary commit once persistence has started.
+    void load(const std::function<void(LoadedRecord &&)> & apply);
+
+    /// Starts persisting. Called once the table is loaded, so that replay itself writes nothing.
+    void start();
+
+    UInt64 allocateSegmentId() { return next_segment_id.fetch_add(1, std::memory_order_relaxed); }
+
+    /// Called with the storage's writer lock held, so that the log order is the publication order.
+    /// Returns the sequence number to wait for in `Sync` mode.
+    UInt64 enqueue(Commit && commit) TSA_NO_THREAD_SAFETY_ANALYSIS;
+
+    /// Called without the writer lock, so a durable write never blocks another publication.
+    void waitDurable(UInt64 sequence) TSA_NO_THREAD_SAFETY_ANALYSIS;
+
+    /// Drops every segment and starts a fresh log. `TRUNCATE` already holds the table exclusively.
+    void truncate();
+
+    /// Removes the whole directory for `DROP TABLE`.
+    void removeAllFiles();
+
+    void rename(const String & new_path);
+
+    void shutdown();
+
+    /// Defers file removal for the duration of a `BACKUP`, so that the entries it collected stay
+    /// readable while a concurrent publication retires their segments.
+    class BackupPin
+    {
+    public:
+        explicit BackupPin(OverwriteCachePersistence & persistence_);
+        ~BackupPin();
+
+    private:
+        OverwriteCachePersistence & persistence;
+    };
+
+    /// Makes the log self-contained and returns the files a backup has to copy, the manifest first.
+    /// Requires a live `BackupPin`.
+    std::vector<String> collectFilesForBackup();
+
+    /// Replaces the table's data with files taken from a backup. The table must be empty.
+    void restoreFileFromBackup(const String & file_name, ReadBuffer & in);
+
+    String getPath() const;
+    DiskPtr getDisk() const { return disk; }
+    static constexpr std::string_view manifest_file_name = "manifest";
+
+private:
+    struct Record
+    {
+        struct Segment
+        {
+            UInt64 segment_id = 0;
+            UInt64 rows = 0;
+        };
+
+        UInt64 generation = 0;
+        std::vector<Segment> added;
+        std::vector<UInt64> removed;
+        std::vector<String> deleted_keys;
+    };
+
+    void writerThread() TSA_NO_THREAD_SAFETY_ANALYSIS;
+    void writeCommit(const Commit & commit);
+    void writeSegmentFile(const AddedSegment & segment);
+    void appendManifestRecord(const Record & record) TSA_REQUIRES(state_mutex);
+    void openManifest(bool rewrite) TSA_REQUIRES(state_mutex);
+    void closeManifest() TSA_REQUIRES(state_mutex);
+    void createDirectories();
+    void removeSegmentFiles(const std::vector<UInt64> & segment_ids);
+    /// Collapses the added/retired bookkeeping of the log. Deletions are kept, because a surviving
+    /// segment written before one still shadows the key it removed; only those that precede every
+    /// surviving segment can be dropped.
+    void checkpointManifest() TSA_REQUIRES(state_mutex);
+    bool needsCheckpoint() const TSA_REQUIRES(state_mutex);
+    std::vector<Record> readManifest(std::unordered_set<UInt64> & removed_segments) const;
+    void writeManifest(const std::vector<Record> & records) TSA_REQUIRES(state_mutex);
+    String segmentFileName(UInt64 segment_id) const;
+    void setException();
+
+    const OverwriteCachePersistMode mode;
+    const DiskPtr disk;
+    const Block header;
+    const SharedHeader shared_header;
+    const String fingerprint;
+    const LoggerPtr log;
+
+    mutable std::mutex path_mutex;
+    String path TSA_GUARDED_BY(path_mutex);
+
+    std::atomic<UInt64> next_segment_id{1};
+
+    /// The log itself and the segments it references. Normally touched only by the writer thread, but a
+    /// `BACKUP` collapses the log from its own thread, so it needs a lock of its own. Taken before
+    /// `mutex` wherever both are needed.
+    mutable std::mutex state_mutex;
+    std::unique_ptr<WriteBufferFromFileBase> manifest_buffer TSA_GUARDED_BY(state_mutex);
+    std::vector<Record::Segment> live_segments TSA_GUARDED_BY(state_mutex);
+    std::unordered_set<UInt64> live_segment_ids TSA_GUARDED_BY(state_mutex);
+    /// Records written since the last checkpoint, to decide when the bookkeeping is worth collapsing.
+    size_t records_since_checkpoint TSA_GUARDED_BY(state_mutex) = 0;
+
+    mutable std::mutex mutex;
+    std::condition_variable queue_changed;
+    std::condition_variable durable_changed;
+    std::deque<std::pair<UInt64, Commit>> queue TSA_GUARDED_BY(mutex);
+    UInt64 queued_bytes TSA_GUARDED_BY(mutex) = 0;
+    UInt64 next_sequence TSA_GUARDED_BY(mutex) = 1;
+    UInt64 durable_sequence TSA_GUARDED_BY(mutex) = 0;
+    std::exception_ptr writer_exception TSA_GUARDED_BY(mutex);
+    bool started TSA_GUARDED_BY(mutex) = false;
+    bool stopped TSA_GUARDED_BY(mutex) = false;
+    size_t backup_pins TSA_GUARDED_BY(mutex) = 0;
+    std::vector<UInt64> deferred_removals TSA_GUARDED_BY(mutex);
+
+    std::optional<ThreadFromGlobalPool> writer_thread;
+
+    /// A publication may not outrun the disk without bound, or the queued payloads become a second copy
+    /// of the table. Reaching the limit makes the next publication wait for the writer.
+    static constexpr UInt64 max_queued_bytes = 256ULL * 1024 * 1024;
+    static constexpr size_t checkpoint_min_records = 4096;
+    static constexpr UInt8 format_version = 1;
+};
+
+using OverwriteCachePersistencePtr = std::shared_ptr<OverwriteCachePersistence>;
+
+}

--- a/src/Storages/StorageFactory.cpp
+++ b/src/Storages/StorageFactory.cpp
@@ -195,6 +195,9 @@ StoragePtr StorageFactory::get(
             if (storage_def->keys)
                 check_feature("KEYS clause", [](StorageFeatures features) { return features.supports_keys; });
 
+            if (storage_def->lookup_indexes)
+                check_feature("lookup INDEX clause", [](StorageFeatures features) { return features.supports_lookup_indexes; });
+
             if (storage_def->ttl_table || !columns.getColumnTTLs().empty())
                 check_feature(
                     "TTL clause",

--- a/src/Storages/StorageFactory.cpp
+++ b/src/Storages/StorageFactory.cpp
@@ -192,6 +192,9 @@ StoragePtr StorageFactory::get(
                     "UNIQUE KEY clause",
                     [](StorageFeatures features) { return features.supports_unique_key; });
 
+            if (storage_def->keys)
+                check_feature("KEYS clause", [](StorageFeatures features) { return features.supports_keys; });
+
             if (storage_def->ttl_table || !columns.getColumnTTLs().empty())
                 check_feature(
                     "TTL clause",

--- a/src/Storages/StorageFactory.h
+++ b/src/Storages/StorageFactory.h
@@ -78,6 +78,8 @@ public:
         /// non-replicated MergeTree variants — replicated metadata does not yet
         /// serialize `unique_key`, which would allow replicas to diverge silently.
         bool supports_unique_key = false;
+        /// Whether the engine-specific `KEYS` clause is accepted at CREATE time.
+        bool supports_keys = false;
         bool supports_sql_security = false;
         std::optional<AccessTypeObjects::Source> source_access_type = std::nullopt;
 
@@ -117,6 +119,7 @@ public:
         .supports_parallel_insert = false,
         .supports_schema_inference = false,
         .supports_unique_key = false,
+        .supports_keys = false,
         .supports_sql_security = false,
         .source_access_type = std::nullopt,
         .has_builtin_setting_fn = nullptr,

--- a/src/Storages/StorageFactory.h
+++ b/src/Storages/StorageFactory.h
@@ -80,6 +80,8 @@ public:
         bool supports_unique_key = false;
         /// Whether the engine-specific `KEYS` clause is accepted at CREATE time.
         bool supports_keys = false;
+        /// Whether engine-specific lookup `INDEX (...)` clauses are accepted at CREATE time.
+        bool supports_lookup_indexes = false;
         bool supports_sql_security = false;
         std::optional<AccessTypeObjects::Source> source_access_type = std::nullopt;
 
@@ -120,6 +122,7 @@ public:
         .supports_schema_inference = false,
         .supports_unique_key = false,
         .supports_keys = false,
+        .supports_lookup_indexes = false,
         .supports_sql_security = false,
         .source_access_type = std::nullopt,
         .has_builtin_setting_fn = nullptr,

--- a/src/Storages/StorageInMemoryMetadata.cpp
+++ b/src/Storages/StorageInMemoryMetadata.cpp
@@ -62,6 +62,7 @@ StorageInMemoryMetadata::StorageInMemoryMetadata(const StorageInMemoryMetadata &
     , column_ttls_by_name(other.column_ttls_by_name)
     , table_ttl(other.table_ttl)
     , settings_changes(other.settings_changes ? other.settings_changes->clone() : nullptr)
+    , lookup_indexes(other.lookup_indexes ? other.lookup_indexes->clone() : nullptr)
     , select(other.select)
     , refresh(other.refresh ? other.refresh->clone() : nullptr)
     , definer(other.definer)
@@ -103,6 +104,7 @@ StorageInMemoryMetadata & StorageInMemoryMetadata::operator=(const StorageInMemo
         settings_changes = other.settings_changes->clone();
     else
         settings_changes.reset();
+    lookup_indexes = other.lookup_indexes ? other.lookup_indexes->clone() : nullptr;
     select = other.select;
     refresh = other.refresh ? other.refresh->clone() : nullptr;
     definer = other.definer;

--- a/src/Storages/StorageInMemoryMetadata.h
+++ b/src/Storages/StorageInMemoryMetadata.h
@@ -64,6 +64,8 @@ struct StorageInMemoryMetadata
     TTLTableDescription table_ttl;
     /// SETTINGS expression. Supported for MergeTree, Buffer, Kafka, RabbitMQ.
     ASTPtr settings_changes;
+    /// Engine-specific lookup `INDEX (...)` declarations stored in `ASTStorage`.
+    ASTPtr lookup_indexes;
     /// SELECT QUERY. Supported for MaterializedView and View.
     SelectQueryDescription select;
     /// Materialized view REFRESH parameters.

--- a/src/Storages/StorageOverwriteCache.cpp
+++ b/src/Storages/StorageOverwriteCache.cpp
@@ -8,10 +8,12 @@
 #include <IO/WriteBufferFromVector.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
+#include <Interpreters/MutationsInterpreter.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTSetQuery.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Processors/ISource.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/QueryPlanFormat.h>
@@ -21,6 +23,7 @@
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Storages/KVStorageUtils.h>
 #include <Storages/AlterCommands.h>
+#include <Storages/MutationCommands.h>
 #include <Storages/StorageFactory.h>
 #include <Storages/extractKeyExpressionList.h>
 #include <Common/Exception.h>
@@ -284,8 +287,15 @@ public:
     {
         SourceStepWithFilter::applyFilters(std::move(added_filter_nodes));
 
+        /// A mutation hands its predicate over through `SelectQueryInfo` rather than through a `FilterStep`
+        /// the optimizer could push down, and when the predicate contains a subquery the resulting
+        /// `DelayedCreatingSetsStep` stops the push-down walk before it reaches that step at all.
+        /// `ReadFromMergeTree` reconciles the same two sources of the predicate for the same reason.
+        const ActionsDAG * filter_dag
+            = filter_actions_dag ? filter_actions_dag.get() : query_info.filter_actions_dag.get();
+
         std::tie(filter_keys, all_scan)
-            = getFilterKeys(storage.getKeyColumns(), storage.getKeyColumnTypes(), filter_actions_dag.get(), context);
+            = getFilterKeys(storage.getKeyColumns(), storage.getKeyColumnTypes(), filter_dag, context);
         if (!all_scan)
         {
             read_kind = ReadKind::Primary;
@@ -296,7 +306,7 @@ public:
         for (auto & index : indexes)
         {
             auto [keys, requires_scan]
-                = getFilterKeys(index.columns, index.types, filter_actions_dag.get(), context);
+                = getFilterKeys(index.columns, index.types, filter_dag, context);
             if (!requires_scan)
             {
                 lookup_filters.push_back({std::move(index), std::move(keys)});
@@ -693,8 +703,13 @@ StorageOverwriteCache::RowDataPtr StorageOverwriteCache::resolveEntry(EntryId en
     std::lock_guard row_lock(row_mutexes[rowLockIndex(entry_id)]);
     for (const auto * version = entries.at(entry_id).head.get(); version; version = version->older.get())
     {
-        if (version->generation <= snapshot_generation)
-            return version->row;
+        if (version->generation > snapshot_generation)
+            continue;
+        /// A version without a segment is the tombstone left by `DELETE`. The key is gone as of this
+        /// snapshot, so older versions must not be consulted.
+        if (!version->row.segment)
+            return {};
+        return version->row;
     }
     return {};
 }
@@ -765,6 +780,9 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
         std::unique_ptr<RowData> row;
         std::optional<RowData> previous;
         bool is_new = false;
+        /// A key whose entry is still published but currently tombstoned by `DELETE`. It needs a new
+        /// version like any replacement, but no primary-index slot and no posting: it already has both.
+        bool is_resurrected = false;
         bool primary_inserted = false;
         bool version_installed = false;
     };
@@ -799,7 +817,14 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
 
         const auto current = resolveEntry(*entry, snapshot_generation);
         if (!current)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Corrupted `OverwriteCache` primary index");
+        {
+            /// The key was deleted. Nothing is left to compare against, so the row wins outright and is
+            /// resurrected in place of the tombstone.
+            mutation.entry_id = *entry;
+            mutation.is_resurrected = true;
+            mutations.push_back(std::move(mutation));
+            continue;
+        }
 
         const int comparison = compareWinner(block, mutation.source_row, *current);
         if (comparison <= 0)
@@ -1254,10 +1279,13 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
         throw;
     }
 
+    const auto resurrected_entries
+        = static_cast<UInt64>(std::ranges::count_if(mutations, [](const auto & mutation) { return mutation.is_resurrected; }));
+
     published_generation.store(new_generation, std::memory_order_release);
     next_entry_id = staged_next_entry_id;
     total_size_bytes.store(prospective_bytes, std::memory_order_relaxed);
-    total_size_rows.fetch_add(new_entries, std::memory_order_relaxed);
+    total_size_rows.fetch_add(new_entries + resurrected_entries, std::memory_order_relaxed);
     for (size_t index = 0; index < lookup_indexes.size(); ++index)
         lookup_indexes[index]->accounted_bytes.fetch_add(lookup_bytes_delta[index], std::memory_order_relaxed);
 
@@ -1294,6 +1322,322 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
         }
         recycleVersions(std::move(obsolete));
     }
+}
+
+void StorageOverwriteCache::deleteBlock(const Block & block)
+{
+    const size_t rows = block.rows();
+    if (rows == 0)
+        return;
+
+    /// The bytes must match what an insert produced for the same key, so serialize through the
+    /// storage's own serializations rather than through whatever the mutation pipeline hands over.
+    Columns key_column_data;
+    key_column_data.reserve(key_columns.size());
+    for (const auto & name : key_columns)
+        key_column_data.push_back(recursiveRemoveSparse(block.getByName(name).column->convertToFullColumnIfConst()));
+
+    std::vector<String> serialized_keys;
+    serialized_keys.reserve(rows);
+    for (size_t row = 0; row < rows; ++row)
+    {
+        WriteBufferFromOwnString out;
+        for (size_t index = 0; index < key_column_data.size(); ++index)
+            serializations[key_positions[index]]->serializeBinary(*key_column_data[index], row, out, format_settings);
+        serialized_keys.push_back(out.str());
+    }
+
+    deleteKeys(serialized_keys);
+}
+
+size_t StorageOverwriteCache::deleteKeys(const std::vector<String> & serialized_keys)
+{
+    if (serialized_keys.empty())
+        return 0;
+
+    struct Deletion
+    {
+        EntryId entry_id = 0;
+        /// Absent for a tombstone, set for a row relocated into a compacted segment.
+        std::unique_ptr<RowData> row;
+        std::optional<RowData> previous;
+        bool version_installed = false;
+    };
+
+    std::lock_guard writer_lock(writer_mutex);
+
+    const UInt64 snapshot_generation = published_generation.load(std::memory_order_acquire);
+
+    std::vector<Deletion> deletions;
+    deletions.reserve(serialized_keys.size());
+    std::unordered_set<EntryId> seen;
+    seen.reserve(serialized_keys.size());
+    for (const auto & key : serialized_keys)
+    {
+        const auto entry = findEntry(key, StringViewHash{}(key));
+        if (!entry || !seen.emplace(*entry).second)
+            continue;
+        auto current = resolveEntry(*entry, snapshot_generation);
+        /// No row means the key is already deleted, so there is nothing left to publish for it.
+        if (!current)
+            continue;
+        Deletion deletion;
+        deletion.entry_id = *entry;
+        deletion.previous = std::move(current);
+        deletions.push_back(std::move(deletion));
+    }
+
+    if (deletions.empty())
+        return 0;
+
+    const size_t deleted_rows = deletions.size();
+
+    std::vector<EntryId> deleted_entry_ids;
+    deleted_entry_ids.reserve(deleted_rows);
+    for (const auto & deletion : deletions)
+        deleted_entry_ids.push_back(deletion.entry_id);
+    std::ranges::sort(deleted_entry_ids);
+
+    /// A deletion leaves the same partially dead segment a replacement leaves, so the same rule applies:
+    /// rewrite a segment once at least half of it is dead.
+    struct SegmentCompaction
+    {
+        std::shared_ptr<RowSegment> source;
+        UInt64 deleted_rows = 0;
+        UInt64 projected_live_rows = 0;
+        bool selected = false;
+        std::vector<std::pair<EntryId, RowData>> live_entries;
+    };
+
+    std::vector<SegmentCompaction> segment_compactions;
+    std::unordered_map<RowSegment *, size_t> segment_compaction_positions;
+    for (const auto & deletion : deletions)
+    {
+        auto [it, inserted]
+            = segment_compaction_positions.emplace(deletion.previous->segment.get(), segment_compactions.size());
+        if (inserted)
+        {
+            segment_compactions.emplace_back();
+            segment_compactions.back().source = deletion.previous->segment;
+        }
+        ++segment_compactions[it->second].deleted_rows;
+    }
+
+    const UInt64 bytes_before = total_size_bytes.load(std::memory_order_relaxed);
+    UInt64 compaction_budget = 0;
+    for (auto & compaction : segment_compactions)
+    {
+        const UInt64 live_rows = compaction.source->live_rows.load(std::memory_order_acquire);
+        if (compaction.deleted_rows > live_rows)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` row-segment live-row count");
+        compaction.projected_live_rows = live_rows - compaction.deleted_rows;
+        const UInt64 total_rows = compaction.source->entry_ids.size();
+        if (compaction.projected_live_rows > total_rows)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` row-segment size");
+        const UInt64 projected_dead_rows = total_rows - compaction.projected_live_rows;
+        if (compaction.projected_live_rows == 0 || projected_dead_rows < (total_rows + 1) / 2)
+            continue;
+
+        /// A rewritten segment coexists with its source until the readers of the previous epoch drain, so
+        /// it needs room beside it. Freeing memory must never fail for want of memory, so a segment whose
+        /// source-sized upper bound does not fit is simply left alone instead of failing the `DELETE`.
+        const UInt64 headroom
+            = settings.max_memory_bytes - std::min(bytes_before + compaction_budget, settings.max_memory_bytes);
+        if (compaction.source->allocated_bytes > headroom)
+            continue;
+        compaction_budget += compaction.source->allocated_bytes;
+
+        compaction.selected = true;
+        compaction.live_entries.reserve(compaction.projected_live_rows);
+        for (size_t row = 0; row < compaction.source->entry_ids.size(); ++row)
+        {
+            if ((row & 4095) == 0 && CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
+                throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled while compacting `OverwriteCache` row segments");
+            const EntryId entry_id = compaction.source->entry_ids[row];
+            if (std::ranges::binary_search(deleted_entry_ids, entry_id))
+                continue;
+            const auto & entry = entries.at(entry_id);
+            std::lock_guard row_lock(row_mutexes[rowLockIndex(entry_id)]);
+            if (!entry.head || entry.head->row.segment.get() != compaction.source.get() || entry.head->row.segment_row != row)
+                continue;
+            compaction.live_entries.emplace_back(entry_id, entry.head->row);
+        }
+    }
+
+    UInt64 prospective_bytes = bytes_before;
+    for (auto & compaction : segment_compactions)
+    {
+        if (!compaction.selected)
+            continue;
+        if (compaction.live_entries.size() != compaction.projected_live_rows)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` row-segment references");
+
+        auto compaction_selector = ColumnUInt64::create();
+        compaction_selector->reserve(compaction.live_entries.size());
+        for (const auto & [entry_id, row] : compaction.live_entries)
+        {
+            static_cast<void>(entry_id);
+            compaction_selector->insertValue(row.segment_row);
+        }
+
+        auto compacted_segment = std::make_shared<RowSegment>();
+        compacted_segment->columns.reserve(compaction.source->columns.size());
+        for (size_t position = 0; position < compaction.source->columns.size(); ++position)
+        {
+            auto selected = compaction.source->columns[position]->decompress()->index(*compaction_selector, 0);
+            if (!keep_uncompressed[position])
+                selected = selected->compress(/*force_compression=*/true);
+            compacted_segment->allocated_bytes += selected->allocatedBytes();
+            compacted_segment->columns.push_back(std::move(selected));
+        }
+        compacted_segment->live_rows.store(compaction.live_entries.size(), std::memory_order_relaxed);
+        compacted_segment->entry_ids.reserve(compaction.live_entries.size());
+        if (prospective_bytes > std::numeric_limits<UInt64>::max() - compacted_segment->allocated_bytes)
+            throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
+        prospective_bytes += compacted_segment->allocated_bytes;
+
+        for (size_t row = 0; row < compaction.live_entries.size(); ++row)
+        {
+            const auto & [entry_id, previous] = compaction.live_entries[row];
+            auto compacted_row = std::make_unique<RowData>();
+            compacted_row->segment = compacted_segment;
+            compacted_row->segment_row = static_cast<UInt32>(row);
+            compacted_segment->entry_ids.push_back(entry_id);
+            Deletion relocation;
+            relocation.entry_id = entry_id;
+            relocation.row = std::move(compacted_row);
+            relocation.previous = previous;
+            deletions.push_back(std::move(relocation));
+        }
+    }
+
+    const UInt64 current_generation = published_generation.load(std::memory_order_acquire);
+    if (current_generation == std::numeric_limits<UInt64>::max())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "`OverwriteCache` publication generation space is exhausted");
+    const UInt64 new_generation = current_generation + 1;
+
+    try
+    {
+        /// A tombstone is a version without a segment. It is published exactly like a replacement, so a
+        /// reader that captured an earlier generation keeps resolving the row it already found.
+        for (auto & deletion : deletions)
+        {
+            auto & entry = entries.at(deletion.entry_id);
+            auto version = takeVersion();
+            version->row = deletion.row ? std::move(*deletion.row) : RowData{};
+            version->generation = new_generation;
+            std::lock_guard lock(row_mutexes[rowLockIndex(deletion.entry_id)]);
+            version->older = std::move(entry.head);
+            entry.head = std::move(version);
+            deletion.version_installed = true;
+        }
+
+        fiu_do_on(FailPoints::overwrite_cache_throw_during_publish, {
+            throw Exception(ErrorCodes::FAULT_INJECTED, "Injected failure during `OverwriteCache` publication");
+        });
+
+        FailPointInjection::pauseFailPoint(FailPoints::overwrite_cache_pause_before_commit);
+    }
+    catch (...)
+    {
+        FailPointInjection::pauseFailPoint(FailPoints::overwrite_cache_pause_before_rollback);
+        for (auto & deletion : deletions)
+        {
+            if (!deletion.version_installed)
+                continue;
+            auto & entry = entries.at(deletion.entry_id);
+            std::unique_ptr<EntryVersion> discarded;
+            {
+                std::lock_guard lock(row_mutexes[rowLockIndex(deletion.entry_id)]);
+                discarded = std::move(entry.head);
+                entry.head = std::move(discarded->older);
+            }
+            discarded->older.reset();
+            recycleVersions(std::move(discarded));
+        }
+        /// Nothing was published, so the compacted segments are dropped here and were never accounted.
+        throw;
+    }
+
+    published_generation.store(new_generation, std::memory_order_release);
+    total_size_bytes.store(prospective_bytes, std::memory_order_relaxed);
+    total_size_rows.fetch_sub(deleted_rows, std::memory_order_relaxed);
+
+    UInt64 reclaim_bytes = 0;
+    std::vector<std::shared_ptr<RowSegment>> retired_segments;
+    retired_segments.reserve(segment_compactions.size());
+    for (const auto & deletion : deletions)
+    {
+        if (deletion.previous->segment->live_rows.fetch_sub(1, std::memory_order_acq_rel) == 1)
+            retired_segments.push_back(deletion.previous->segment);
+    }
+    for (const auto & retired_segment : retired_segments)
+        reclaim_bytes += retired_segment->allocated_bytes;
+    total_size_bytes.fetch_sub(reclaim_bytes, std::memory_order_relaxed);
+
+    const UInt64 watermark = oldestLiveGeneration();
+    for (const auto & deletion : deletions)
+    {
+        auto & entry = entries.at(deletion.entry_id);
+        std::unique_ptr<EntryVersion> obsolete;
+        {
+            std::lock_guard lock(row_mutexes[rowLockIndex(deletion.entry_id)]);
+            for (auto * version = entry.head.get(); version; version = version->older.get())
+            {
+                if (version->generation <= watermark)
+                {
+                    obsolete = std::move(version->older);
+                    break;
+                }
+            }
+        }
+        recycleVersions(std::move(obsolete));
+    }
+
+    return deleted_rows;
+}
+
+void StorageOverwriteCache::checkMutationIsPossible(const MutationCommands & commands, const Settings &) const
+{
+    if (commands.empty())
+        return;
+    if (commands.size() > 1)
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Storage `OverwriteCache` supports only one mutation command per query");
+    if (commands.front().type != MutationCommand::Type::DELETE)
+        throw Exception(
+            ErrorCodes::NOT_IMPLEMENTED,
+            "Storage `OverwriteCache` supports only `DELETE` mutations; a stored row is replaced by inserting a greater version");
+}
+
+void StorageOverwriteCache::mutate(const MutationCommands & commands, ContextPtr context)
+{
+    if (commands.empty())
+        return;
+    checkMutationIsPossible(commands, context->getSettingsRef());
+
+    const auto metadata_snapshot = getInMemoryMetadataPtr(context, false);
+    const auto storage_ptr = DatabaseCatalog::instance().getTable(getStorageID(), context);
+
+    MutationsInterpreter::Settings mutation_settings(true);
+    mutation_settings.return_all_columns = true;
+    mutation_settings.return_mutated_rows = true;
+
+    /// The rows to delete are produced by the read path, so a `DELETE` accepts exactly the predicates a
+    /// `SELECT` accepts: a complete `KEYS` tuple, or one or more declared lookup indexes.
+    MutationsInterpreter interpreter(
+        storage_ptr,
+        metadata_snapshot,
+        commands,
+        metadata_snapshot->getColumns().getNamesOfPhysical(),
+        context,
+        mutation_settings);
+
+    auto pipeline = QueryPipelineBuilder::getPipeline(interpreter.execute());
+    PullingPipelineExecutor executor(pipeline);
+
+    Block block;
+    while (executor.pull(block))
+        deleteBlock(block);
 }
 
 StorageOverwriteCache::ReadResult StorageOverwriteCache::getRowsForPrimaryKeys(const std::vector<String> & serialized_keys) const

--- a/src/Storages/StorageOverwriteCache.cpp
+++ b/src/Storages/StorageOverwriteCache.cpp
@@ -1,9 +1,15 @@
 #include <Storages/StorageOverwriteCache.h>
 
+#include <Backups/BackupEntriesCollector.h>
+#include <Backups/BackupEntryFromImmutableFile.h>
+#include <Backups/BackupEntryWrappedWith.h>
+#include <Backups/IBackup.h>
+#include <Backups/RestorerFromBackup.h>
 #include <Core/Block.h>
 #include <Columns/ColumnSparse.h>
 #include <Columns/ColumnVector.h>
 #include <DataTypes/IDataType.h>
+#include <Disks/IDisk.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteBufferFromVector.h>
 #include <Interpreters/Context.h>
@@ -51,6 +57,7 @@ namespace DB
 namespace ErrorCodes
 {
 extern const int BAD_ARGUMENTS;
+extern const int CANNOT_RESTORE_TABLE;
 extern const int FAULT_INJECTED;
 extern const int LOGICAL_ERROR;
 extern const int MEMORY_LIMIT_EXCEEDED;
@@ -141,6 +148,10 @@ OverwriteCacheSettings parseSettings(const ASTStorage & storage_def)
             result.equal_version_tiebreak_columns = parseColumnList(getStringSetting(change), change.name);
         else if (change.name == "compress_segments")
             result.compress_segments = getUInt64Setting(change) != 0;
+        else if (change.name == "persist_mode")
+            result.persist_mode = parseOverwriteCachePersistMode(getStringSetting(change));
+        else if (change.name == "disk")
+            result.disk_name = getStringSetting(change);
         else
             throw Exception(ErrorCodes::UNKNOWN_SETTING, "Unknown setting {} for storage `OverwriteCache`", backQuote(change.name));
     }
@@ -191,7 +202,8 @@ void validateColumn(const ColumnsDescription & columns, const String & name, con
 
 bool isOverwriteCacheSetting(std::string_view name)
 {
-    return name == "max_memory_bytes" || name == "equal_version_tiebreak_columns" || name == "compress_segments";
+    return name == "max_memory_bytes" || name == "equal_version_tiebreak_columns" || name == "compress_segments"
+        || name == "persist_mode" || name == "disk";
 }
 
 class OverwriteCacheSink final : public SinkToStorage
@@ -423,7 +435,9 @@ StorageOverwriteCache::StorageOverwriteCache(
     std::vector<Names> lookup_indexes_,
     ASTPtr lookup_indexes_ast_,
     OverwriteCacheSettings settings_,
-    ASTPtr settings_changes_)
+    ASTPtr settings_changes_,
+    DiskPtr disk_,
+    const String & relative_data_path_)
     : IStorage(table_id_)
     , version_column(std::move(version_column_))
     , key_columns(std::move(key_columns_))
@@ -478,6 +492,80 @@ StorageOverwriteCache::StorageOverwriteCache(
         lookup_index_positions.push_back(std::move(positions));
         lookup_index_column_types.push_back(std::move(types));
         lookup_indexes.push_back(std::make_shared<LookupIndex>());
+    }
+
+    persistence = std::make_shared<OverwriteCachePersistence>(
+        settings.persist_mode,
+        std::move(disk_),
+        relative_data_path_,
+        sample_block,
+        getPersistenceFingerprint(),
+        fmt::format("StorageOverwriteCache ({})", table_id_.getNameForLogs()));
+    loadPersistedData();
+}
+
+String StorageOverwriteCache::getPersistenceFingerprint() const
+{
+    WriteBufferFromOwnString out;
+    for (const auto & column : sample_block)
+    {
+        writeString(column.name, out);
+        writeChar(' ', out);
+        writeString(column.type->getName(), out);
+        writeChar('\n', out);
+    }
+    writeString("KEYS ", out);
+    for (const auto & name : key_columns)
+    {
+        writeString(name, out);
+        writeChar(',', out);
+    }
+    writeString("\nVERSION ", out);
+    writeString(version_column, out);
+    writeString("\nTIEBREAK ", out);
+    for (const auto & name : settings.equal_version_tiebreak_columns)
+    {
+        writeString(name, out);
+        writeChar(',', out);
+    }
+    /// Lookup indexes are deliberately absent: they are rebuilt from the segments, so `ALTER ADD INDEX`
+    /// must not invalidate a log.
+    return out.str();
+}
+
+void StorageOverwriteCache::loadPersistedData()
+{
+    if (!persistence->isEnabled())
+        return;
+
+    loading = true;
+    try
+    {
+        persistence->load([&](OverwriteCachePersistence::LoadedRecord && record)
+        {
+            if (!record.deleted_keys.empty())
+                deleteKeys(record.deleted_keys);
+            else
+                insertBlock(record.block, record.segment_id);
+        });
+    }
+    catch (...)
+    {
+        loading = false;
+        throw;
+    }
+    loading = false;
+
+    persistence->start();
+
+    /// A file whose every row lost to a later one contributes nothing, so the log stops referring to it.
+    if (!retired_during_load.empty())
+    {
+        OverwriteCachePersistence::Commit commit;
+        commit.generation = published_generation.load(std::memory_order_relaxed);
+        commit.removed = std::move(retired_during_load);
+        persistence->enqueue(std::move(commit));
+        retired_during_load.clear();
     }
 }
 
@@ -716,6 +804,11 @@ StorageOverwriteCache::RowDataPtr StorageOverwriteCache::resolveEntry(EntryId en
 
 void StorageOverwriteCache::insertBlock(const Block & input_block)
 {
+    insertBlock(input_block, 0);
+}
+
+void StorageOverwriteCache::insertBlock(const Block & input_block, UInt64 replay_segment_id)
+{
     const size_t input_rows = input_block.rows();
     if (input_rows == 0)
         return;
@@ -788,7 +881,7 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
     };
 
     FailPointInjection::pauseFailPoint(FailPoints::overwrite_cache_pause_after_lookup_catalog_snapshot);
-    std::lock_guard writer_lock(writer_mutex);
+    std::unique_lock writer_lock(writer_mutex);
     if (lookup_positions_snapshot != lookup_index_positions)
     {
         lookup_positions_snapshot = lookup_index_positions;
@@ -864,6 +957,8 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
     }
     segment->live_rows.store(block_mutation_count, std::memory_order_relaxed);
     segment->entry_ids.resize(block_mutation_count);
+    if (persistence->isEnabled())
+        segment->persistent_id = replay_segment_id ? replay_segment_id : persistence->allocateSegmentId();
 
     UInt64 prospective_bytes = total_size_bytes.load(std::memory_order_relaxed);
     if (prospective_bytes > std::numeric_limits<UInt64>::max() - segment->allocated_bytes)
@@ -876,6 +971,10 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
         compact_row->segment_row = static_cast<UInt32>(row);
         mutations[row].row = std::move(compact_row);
     }
+
+    /// Every segment this publication creates, so that it can be recorded once the publication succeeds.
+    std::vector<std::shared_ptr<RowSegment>> added_segments;
+    added_segments.push_back(segment);
 
     struct SegmentCompaction
     {
@@ -917,6 +1016,10 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` row-segment size");
         const UInt64 projected_dead_rows = total_rows - compaction.projected_live_rows;
         if (compaction.projected_live_rows == 0 || projected_dead_rows < (total_rows + 1) / 2)
+            continue;
+        /// Replay must not rewrite a segment: the log is not being written yet, so the rewritten segment
+        /// would have no file while the segment it replaced still has one.
+        if (loading)
             continue;
         compaction.selected = true;
         compaction.live_entries.reserve(compaction.projected_live_rows);
@@ -966,9 +1069,12 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
         }
         compacted_segment->live_rows.store(compaction.live_entries.size(), std::memory_order_relaxed);
         compacted_segment->entry_ids.reserve(compaction.live_entries.size());
+        if (persistence->isEnabled())
+            compacted_segment->persistent_id = persistence->allocateSegmentId();
         if (prospective_bytes > std::numeric_limits<UInt64>::max() - compacted_segment->allocated_bytes)
             throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
         prospective_bytes += compacted_segment->allocated_bytes;
+        added_segments.push_back(compacted_segment);
 
         for (size_t row = 0; row < compaction.live_entries.size(); ++row)
         {
@@ -1322,6 +1428,38 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
         }
         recycleVersions(std::move(obsolete));
     }
+
+    if (!persistence->isEnabled())
+        return;
+
+    if (loading)
+    {
+        for (const auto & retired_segment : retired_segments)
+        {
+            if (retired_segment->persistent_id)
+                retired_during_load.push_back(retired_segment->persistent_id);
+        }
+        return;
+    }
+
+    OverwriteCachePersistence::Commit commit;
+    commit.generation = new_generation;
+    commit.added.reserve(added_segments.size());
+    for (const auto & added_segment : added_segments)
+        commit.added.push_back({added_segment->persistent_id, added_segment->columns, added_segment->entry_ids.size()});
+    commit.removed.reserve(retired_segments.size());
+    for (const auto & retired_segment : retired_segments)
+    {
+        if (retired_segment->persistent_id)
+            commit.removed.push_back(retired_segment->persistent_id);
+    }
+
+    const UInt64 sequence = persistence->enqueue(std::move(commit));
+    /// The wait releases the writer lock first, so a durable write never holds up another publication.
+    /// The log is written in order, so waiting for this sequence covers every publication before it.
+    writer_lock.unlock();
+    if (settings.persist_mode == OverwriteCachePersistMode::Sync)
+        persistence->waitDurable(sequence);
 }
 
 void StorageOverwriteCache::deleteBlock(const Block & block)
@@ -1364,7 +1502,7 @@ size_t StorageOverwriteCache::deleteKeys(const std::vector<String> & serialized_
         bool version_installed = false;
     };
 
-    std::lock_guard writer_lock(writer_mutex);
+    std::unique_lock writer_lock(writer_mutex);
 
     const UInt64 snapshot_generation = published_generation.load(std::memory_order_acquire);
 
@@ -1437,6 +1575,10 @@ size_t StorageOverwriteCache::deleteKeys(const std::vector<String> & serialized_
         const UInt64 projected_dead_rows = total_rows - compaction.projected_live_rows;
         if (compaction.projected_live_rows == 0 || projected_dead_rows < (total_rows + 1) / 2)
             continue;
+        /// Replay must not rewrite a segment, for the same reason an insert must not: the log is not being
+        /// written yet, so a rewritten segment would have no file of its own.
+        if (loading)
+            continue;
 
         /// A rewritten segment coexists with its source until the readers of the previous epoch drain, so
         /// it needs room beside it. Freeing memory must never fail for want of memory, so a segment whose
@@ -1465,6 +1607,7 @@ size_t StorageOverwriteCache::deleteKeys(const std::vector<String> & serialized_
     }
 
     UInt64 prospective_bytes = bytes_before;
+    std::vector<std::shared_ptr<RowSegment>> added_segments;
     for (auto & compaction : segment_compactions)
     {
         if (!compaction.selected)
@@ -1492,9 +1635,12 @@ size_t StorageOverwriteCache::deleteKeys(const std::vector<String> & serialized_
         }
         compacted_segment->live_rows.store(compaction.live_entries.size(), std::memory_order_relaxed);
         compacted_segment->entry_ids.reserve(compaction.live_entries.size());
+        if (persistence->isEnabled())
+            compacted_segment->persistent_id = persistence->allocateSegmentId();
         if (prospective_bytes > std::numeric_limits<UInt64>::max() - compacted_segment->allocated_bytes)
             throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
         prospective_bytes += compacted_segment->allocated_bytes;
+        added_segments.push_back(compacted_segment);
 
         for (size_t row = 0; row < compaction.live_entries.size(); ++row)
         {
@@ -1593,6 +1739,39 @@ size_t StorageOverwriteCache::deleteKeys(const std::vector<String> & serialized_
         }
         recycleVersions(std::move(obsolete));
     }
+
+    if (!persistence->isEnabled())
+        return deleted_rows;
+
+    if (loading)
+    {
+        for (const auto & retired_segment : retired_segments)
+        {
+            if (retired_segment->persistent_id)
+                retired_during_load.push_back(retired_segment->persistent_id);
+        }
+        return deleted_rows;
+    }
+
+    /// A deletion has to be recorded even though it creates no segment: the segment it emptied a row of
+    /// is not superseded by anything, so replaying that segment alone would bring the key back.
+    OverwriteCachePersistence::Commit commit;
+    commit.generation = new_generation;
+    commit.deleted_keys = serialized_keys;
+    commit.added.reserve(added_segments.size());
+    for (const auto & added_segment : added_segments)
+        commit.added.push_back({added_segment->persistent_id, added_segment->columns, added_segment->entry_ids.size()});
+    commit.removed.reserve(retired_segments.size());
+    for (const auto & retired_segment : retired_segments)
+    {
+        if (retired_segment->persistent_id)
+            commit.removed.push_back(retired_segment->persistent_id);
+    }
+
+    const UInt64 sequence = persistence->enqueue(std::move(commit));
+    writer_lock.unlock();
+    if (settings.persist_mode == OverwriteCachePersistMode::Sync)
+        persistence->waitDurable(sequence);
 
     return deleted_rows;
 }
@@ -2146,11 +2325,95 @@ void StorageOverwriteCache::alter(const AlterCommands & commands, ContextPtr con
 void StorageOverwriteCache::truncate(const ASTPtr &, const StorageMetadataPtr &, ContextPtr, TableExclusiveLockHolder &)
 {
     clearData();
+    persistence->truncate();
 }
 
 void StorageOverwriteCache::drop()
 {
     clearData();
+    persistence->removeAllFiles();
+}
+
+void StorageOverwriteCache::shutdown(bool)
+{
+    /// Draining the queue makes a clean restart lose nothing even in `Async` mode.
+    persistence->shutdown();
+}
+
+void StorageOverwriteCache::rename(const String & new_path_to_table_data, const StorageID & new_table_id)
+{
+    persistence->rename(new_path_to_table_data);
+    renameInMemory(new_table_id);
+}
+
+void StorageOverwriteCache::backupData(
+    BackupEntriesCollector & backup_entries_collector, const String & data_path_in_backup, const std::optional<ASTs> &)
+{
+    if (!persistence->isEnabled())
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Storage `OverwriteCache` cannot be backed up with `persist_mode = 'none'`, because it keeps no data on disk");
+
+    /// The files are immutable, so a backup copies them instead of reading the table. Retirement is held
+    /// back until every entry has been read, or a publication could delete a file the collector was told
+    /// to copy - which is why the pin travels with the entries instead of being released here.
+    auto pin = std::make_shared<OverwriteCachePersistence::BackupPin>(*persistence);
+    const auto file_names = persistence->collectFilesForBackup();
+    const auto data_path = persistence->getPath();
+    const auto disk = persistence->getDisk();
+
+    const std::filesystem::path data_path_in_backup_fs = data_path_in_backup;
+    BackupEntries backup_entries;
+    backup_entries.reserve(file_names.size());
+    for (const auto & file_name : file_names)
+    {
+        const auto file_path = std::filesystem::path(data_path) / file_name;
+        BackupEntryPtr entry = std::make_shared<BackupEntryFromImmutableFile>(
+            disk, file_path, /*copy_encrypted=*/false, disk->getFileSize(file_path));
+        backup_entries.emplace_back(data_path_in_backup_fs / file_name, wrapBackupEntryWith(std::move(entry), pin));
+    }
+
+    backup_entries_collector.addBackupEntries(std::move(backup_entries));
+}
+
+void StorageOverwriteCache::restoreDataFromBackup(
+    RestorerFromBackup & restorer, const String & data_path_in_backup, const std::optional<ASTs> &)
+{
+    auto backup = restorer.getBackup();
+    if (!backup->hasFiles(data_path_in_backup))
+        return;
+
+    if (!restorer.isNonEmptyTableAllowed() && total_size_rows.load(std::memory_order_relaxed))
+        RestorerFromBackup::throwTableIsNotEmpty(getStorageID());
+
+    restorer.addDataRestoreTask(
+        [storage = std::static_pointer_cast<StorageOverwriteCache>(shared_from_this()), backup, data_path_in_backup]
+        { storage->restoreDataImpl(backup, data_path_in_backup); });
+}
+
+void StorageOverwriteCache::restoreDataImpl(const BackupPtr & backup, const String & data_path_in_backup)
+{
+    const auto file_names = backup->listFiles(data_path_in_backup, /*recursive=*/false);
+    if (std::ranges::find(file_names, OverwriteCachePersistence::manifest_file_name) == file_names.end())
+        throw Exception(
+            ErrorCodes::CANNOT_RESTORE_TABLE,
+            "Backup of storage `OverwriteCache` at {} has no {} file",
+            data_path_in_backup,
+            OverwriteCachePersistence::manifest_file_name);
+
+    /// Replacing the files means replacing the table, so the cache is dropped first and rebuilt from the
+    /// restored log rather than merged with whatever it happened to hold.
+    clearData();
+    persistence->removeAllFiles();
+
+    const std::filesystem::path data_path_in_backup_fs = data_path_in_backup;
+    for (const auto & file_name : file_names)
+    {
+        auto in = backup->readFile(data_path_in_backup_fs / file_name);
+        persistence->restoreFileFromBackup(file_name, *in);
+    }
+
+    loadPersistedData();
 }
 
 std::optional<UInt64> StorageOverwriteCache::totalRows(ContextPtr) const
@@ -2240,6 +2503,35 @@ void registerStorageOverwriteCache(StorageFactory & factory)
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Duplicate lookup `INDEX` declaration");
             }
 
+            /// A temporary table cannot outlive the session that created it, so there is nothing for a log
+            /// to restore. Asking for one anyway is a request that cannot be honoured rather than a
+            /// default to quietly override.
+            const bool persist_mode_given = args.storage_def->settings
+                && std::ranges::any_of(
+                       args.storage_def->settings->changes,
+                       [](const SettingChange & change) { return change.name == "persist_mode"; });
+            if (args.query.isTemporary())
+            {
+                if (persist_mode_given && settings.persist_mode != OverwriteCachePersistMode::None)
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "A temporary table of storage `OverwriteCache` cannot use `persist_mode = '{}'`, because it does not "
+                        "outlive its session",
+                        toString(settings.persist_mode));
+                settings.persist_mode = OverwriteCachePersistMode::None;
+            }
+
+            DiskPtr disk;
+            if (settings.persist_mode != OverwriteCachePersistMode::None)
+            {
+                if (args.relative_data_path.empty())
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "Storage `OverwriteCache` requires a data path to persist data. Use `persist_mode = 'none'` for a "
+                        "table that is not meant to survive a restart");
+                disk = args.getContext()->getDisk(settings.disk_name);
+            }
+
             return std::make_shared<StorageOverwriteCache>(
                 args.table_id,
                 args.columns,
@@ -2250,7 +2542,9 @@ void registerStorageOverwriteCache(StorageFactory & factory)
                 std::move(lookup_index_columns),
                 args.storage_def->lookup_indexes ? args.storage_def->lookup_indexes->clone() : nullptr,
                 std::move(settings),
-                args.storage_def->settings ? args.storage_def->settings->clone() : nullptr);
+                args.storage_def->settings ? args.storage_def->settings->clone() : nullptr,
+                std::move(disk),
+                args.relative_data_path);
         },
         {
             .supports_settings = true,

--- a/src/Storages/StorageOverwriteCache.cpp
+++ b/src/Storages/StorageOverwriteCache.cpp
@@ -1,9 +1,12 @@
 #include <Storages/StorageOverwriteCache.h>
 
 #include <Core/Block.h>
+#include <Columns/ColumnVector.h>
 #include <DataTypes/IDataType.h>
 #include <IO/WriteBufferFromString.h>
+#include <IO/ReadBufferFromMemory.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/DatabaseCatalog.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTIdentifier.h>
@@ -16,10 +19,13 @@
 #include <QueryPipeline/Pipe.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Storages/KVStorageUtils.h>
+#include <Storages/AlterCommands.h>
 #include <Storages/StorageFactory.h>
 #include <Storages/extractKeyExpressionList.h>
 #include <Common/Exception.h>
+#include <Common/CurrentThread.h>
 #include <Common/FailPoint.h>
+#include <Common/ThreadStatus.h>
 #include <Common/quoteString.h>
 
 #include <algorithm>
@@ -37,14 +43,21 @@ extern const int BAD_ARGUMENTS;
 extern const int FAULT_INJECTED;
 extern const int LOGICAL_ERROR;
 extern const int MEMORY_LIMIT_EXCEEDED;
+extern const int NOT_IMPLEMENTED;
 extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+extern const int QUERY_WAS_CANCELLED;
 extern const int TYPE_MISMATCH;
 extern const int UNKNOWN_SETTING;
 }
 
 namespace FailPoints
 {
+extern const char overwrite_cache_pause_after_lookup_catalog_snapshot[];
+extern const char overwrite_cache_pause_after_drop_index_publication[];
 extern const char overwrite_cache_pause_before_commit[];
+extern const char overwrite_cache_pause_during_index_build[];
+extern const char overwrite_cache_pause_during_lookup[];
+extern const char overwrite_cache_throw_during_index_build[];
 extern const char overwrite_cache_throw_during_publish[];
 }
 
@@ -103,8 +116,9 @@ String getStringSetting(const SettingChange & change)
 OverwriteCacheSettings parseSettings(const ASTStorage & storage_def)
 {
     OverwriteCacheSettings result;
+    result.max_memory_bytes = std::numeric_limits<UInt64>::max();
     if (!storage_def.settings)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Storage `OverwriteCache` requires setting `max_memory_bytes`");
+        return result;
 
     for (const auto & change : storage_def.settings->changes)
     {
@@ -112,27 +126,12 @@ OverwriteCacheSettings parseSettings(const ASTStorage & storage_def)
             result.max_memory_bytes = getUInt64Setting(change);
         else if (change.name == "equal_version_tiebreak_columns")
             result.equal_version_tiebreak_columns = parseColumnList(getStringSetting(change), change.name);
-        else if (change.name == "secondary_index_columns")
-            result.secondary_index_columns = parseColumnList(getStringSetting(change), change.name);
-        else if (change.name == "secondary_index_segment_column")
-        {
-            auto value = getStringSetting(change);
-            if (!value.empty())
-                result.secondary_index_segment_column = std::move(value);
-        }
-        else if (change.name == "max_secondary_index_rows")
-            result.max_secondary_index_rows = getUInt64Setting(change);
         else
             throw Exception(ErrorCodes::UNKNOWN_SETTING, "Unknown setting {} for storage `OverwriteCache`", backQuote(change.name));
     }
 
     if (!result.max_memory_bytes)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Storage `OverwriteCache` requires a positive `max_memory_bytes`");
-    if (!result.secondary_index_columns.empty() && !result.max_secondary_index_rows)
-        throw Exception(
-            ErrorCodes::BAD_ARGUMENTS,
-            "Storage `OverwriteCache` requires a positive `max_secondary_index_rows` when `secondary_index_columns` is set");
-
     return result;
 }
 
@@ -157,6 +156,15 @@ Names extractIdentifierList(const IAST & key_ast, const String & clause_name)
     return result;
 }
 
+ASTPtr makeLookupIndexAST(const Names & columns)
+{
+    auto result = make_intrusive<ASTExpressionList>();
+    result->children.reserve(columns.size());
+    for (const auto & column : columns)
+        result->children.push_back(make_intrusive<ASTIdentifier>(column));
+    return result;
+}
+
 void validateColumn(const ColumnsDescription & columns, const String & name, const String & role, bool require_comparable)
 {
     if (!columns.has(name))
@@ -168,8 +176,7 @@ void validateColumn(const ColumnsDescription & columns, const String & name, con
 
 bool isOverwriteCacheSetting(std::string_view name)
 {
-    return name == "max_memory_bytes" || name == "equal_version_tiebreak_columns" || name == "secondary_index_columns"
-        || name == "secondary_index_segment_column" || name == "max_secondary_index_rows";
+    return name == "max_memory_bytes" || name == "equal_version_tiebreak_columns";
 }
 
 class OverwriteCacheSink final : public SinkToStorage
@@ -193,9 +200,13 @@ class OverwriteCacheSource final : public ISource
 {
 public:
     OverwriteCacheSource(
-        SharedHeader header_, StorageOverwriteCache::RowDataPtrs rows_, std::vector<size_t> positions_, size_t max_block_size_)
+        SharedHeader header_,
+        StorageOverwriteCache::ReadResult result_,
+        std::vector<size_t> positions_,
+        size_t max_block_size_)
         : ISource(std::move(header_))
-        , rows(std::move(rows_))
+        , read_guard(std::move(result_.guard))
+        , rows(std::move(result_.rows))
         , positions(std::move(positions_))
         , max_block_size(std::max<size_t>(1, max_block_size_))
     {
@@ -215,10 +226,19 @@ protected:
         for (size_t i = 0; i < columns.size(); ++i)
             columns[i] = header.getByPosition(i).type->createColumn();
 
-        for (size_t row = offset; row < offset + rows_to_emit; ++row)
+        for (size_t output_position = 0; output_position < positions.size(); ++output_position)
         {
-            for (size_t column = 0; column < positions.size(); ++column)
-                columns[column]->insert(rows[row]->values[positions[column]]);
+            std::shared_ptr<StorageOverwriteCache::RowSegment> current_segment;
+            ColumnPtr source_column;
+            for (size_t row = offset; row < offset + rows_to_emit; ++row)
+            {
+                if (current_segment != rows[row].segment)
+                {
+                    current_segment = rows[row].segment;
+                    source_column = current_segment->columns[positions[output_position]]->decompress();
+                }
+                columns[output_position]->insertFrom(*source_column, rows[row].segment_row);
+            }
         }
 
         offset += rows_to_emit;
@@ -226,6 +246,8 @@ protected:
     }
 
 private:
+    /// Keep the guard before rows so rows release their segment references before the epoch is released.
+    StorageOverwriteCache::ReadGuardPtr read_guard;
     StorageOverwriteCache::RowDataPtrs rows;
     std::vector<size_t> positions;
     size_t max_block_size;
@@ -263,68 +285,73 @@ public:
             return;
         }
 
-        if (!storage.getSecondaryIndexColumns().empty())
+        auto indexes = storage.getLookupIndexSnapshot();
+        for (auto & index : indexes)
         {
-            if (!storage.getSegmentedSecondaryIndexColumns().empty())
+            auto [keys, requires_scan]
+                = getFilterKeys(index.columns, index.types, filter_actions_dag.get(), context);
+            if (!requires_scan)
             {
-                std::tie(filter_keys, all_scan) = getFilterKeys(
-                    storage.getSegmentedSecondaryIndexColumns(),
-                    storage.getSegmentedSecondaryIndexColumnTypes(),
-                    filter_actions_dag.get(),
-                    context);
-                if (!all_scan)
-                {
-                    read_kind = ReadKind::SegmentedSecondary;
-                    return;
-                }
+                lookup_filters.push_back({std::move(index), std::move(keys)});
+                all_scan = false;
             }
-
-            std::tie(filter_keys, all_scan) = getFilterKeys(
-                storage.getSecondaryIndexColumns(), storage.getSecondaryIndexColumnTypes(), filter_actions_dag.get(), context);
-            if (!all_scan)
-                read_kind = ReadKind::Secondary;
         }
+        std::ranges::stable_sort(lookup_filters, [&](const LookupFilter & lhs, const LookupFilter & rhs)
+        {
+            return lhs.index.columns.size() > rhs.index.columns.size();
+        });
+        std::unordered_set<String> covered_columns;
+        std::erase_if(lookup_filters, [&](const LookupFilter & filter)
+        {
+            bool contributes_column = false;
+            for (const auto & column : filter.index.columns)
+                contributes_column |= covered_columns.emplace(column).second;
+            return !contributes_column;
+        });
+        if (!all_scan)
+            read_kind = ReadKind::Lookup;
     }
 
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override
     {
-        if (read_kind == ReadKind::None || all_scan || !filter_keys)
+        if (read_kind == ReadKind::None || all_scan || (read_kind == ReadKind::Primary && !filter_keys)
+            || (read_kind == ReadKind::Lookup && lookup_filters.empty()))
             throw Exception(
                 ErrorCodes::BAD_ARGUMENTS,
-                "Storage `OverwriteCache` requires a complete `KEYS` predicate or an equality/IN predicate on all "
-                "`secondary_index_columns`");
+                "Storage `OverwriteCache` requires a complete `KEYS` predicate or an equality/IN predicate on a declared "
+                "lookup `INDEX`");
 
-        auto iterator = filter_keys->cbegin();
-        std::vector<String> serialized_keys;
-        StorageOverwriteCache::RowDataPtrs rows;
+        StorageOverwriteCache::ReadResult result;
         if (read_kind == ReadKind::Primary)
         {
+            auto iterator = filter_keys->cbegin();
+            std::vector<String> serialized_keys;
             while (iterator != filter_keys->cend())
             {
                 auto batch = serializeKeysToRawString(iterator, filter_keys->cend(), storage.getKeyColumnTypes(), max_block_size);
                 serialized_keys.insert(serialized_keys.end(), std::make_move_iterator(batch.begin()), std::make_move_iterator(batch.end()));
             }
-            rows = storage.getRowsForPrimaryKeys(serialized_keys);
-        }
-        else if (read_kind == ReadKind::Secondary)
-        {
-            while (iterator != filter_keys->cend())
-            {
-                auto batch
-                    = serializeKeysToRawString(iterator, filter_keys->cend(), storage.getSecondaryIndexColumnTypes(), max_block_size);
-                serialized_keys.insert(serialized_keys.end(), std::make_move_iterator(batch.begin()), std::make_move_iterator(batch.end()));
-            }
-            rows = storage.getRowsForSecondaryKeys(serialized_keys);
+            result = storage.getRowsForPrimaryKeys(serialized_keys);
         }
         else
         {
-            while (iterator != filter_keys->cend())
+            std::vector<StorageOverwriteCache::LookupRequest> requests;
+            requests.reserve(lookup_filters.size());
+            for (const auto & lookup_filter : lookup_filters)
             {
-                auto batch = serializeKeysToRawString(
-                    iterator, filter_keys->cend(), storage.getSegmentedSecondaryIndexColumnTypes(), max_block_size);
-                serialized_keys.insert(serialized_keys.end(), std::make_move_iterator(batch.begin()), std::make_move_iterator(batch.end()));
+                auto iterator = lookup_filter.keys->cbegin();
+                std::vector<String> serialized_keys;
+                while (iterator != lookup_filter.keys->cend())
+                {
+                    auto batch = serializeKeysToRawString(
+                        iterator, lookup_filter.keys->cend(), lookup_filter.index.types, max_block_size);
+                    serialized_keys.insert(
+                        serialized_keys.end(), std::make_move_iterator(batch.begin()), std::make_move_iterator(batch.end()));
+                }
+                requests.push_back(
+                    {lookup_filter.index.guard, lookup_filter.index.index, std::move(serialized_keys)});
             }
-            rows = storage.getRowsForSegmentedSecondaryKeys(serialized_keys);
+            result = storage.getRowsForLookupRequests(requests);
         }
 
         std::vector<size_t> positions;
@@ -332,7 +359,8 @@ public:
         for (const auto & column : *getOutputHeader())
             positions.push_back(storage.getColumnPosition(column.name));
 
-        auto source = std::make_shared<OverwriteCacheSource>(getOutputHeader(), std::move(rows), std::move(positions), max_block_size);
+        auto source = std::make_shared<OverwriteCacheSource>(
+            getOutputHeader(), std::move(result), std::move(positions), max_block_size);
         source->setStorageLimits(query_info.storage_limits);
         pipeline.init(Pipe(std::move(source)));
     }
@@ -349,13 +377,19 @@ private:
     {
         None,
         Primary,
-        Secondary,
-        SegmentedSecondary,
+        Lookup,
+    };
+
+    struct LookupFilter
+    {
+        StorageOverwriteCache::LookupIndexSnapshot index;
+        FieldVectorPtr keys;
     };
 
     const StorageOverwriteCache & storage;
     size_t max_block_size;
     FieldVectorPtr filter_keys;
+    std::vector<LookupFilter> lookup_filters;
     bool all_scan = true;
     ReadKind read_kind = ReadKind::None;
 };
@@ -369,11 +403,14 @@ StorageOverwriteCache::StorageOverwriteCache(
     String comment_,
     String version_column_,
     Names key_columns_,
+    std::vector<Names> lookup_indexes_,
+    ASTPtr lookup_indexes_ast_,
     OverwriteCacheSettings settings_,
     ASTPtr settings_changes_)
     : IStorage(table_id_)
     , version_column(std::move(version_column_))
     , key_columns(std::move(key_columns_))
+    , lookup_index_columns(std::move(lookup_indexes_))
     , settings(std::move(settings_))
 {
     StorageInMemoryMetadata metadata;
@@ -381,6 +418,7 @@ StorageOverwriteCache::StorageOverwriteCache(
     metadata.setConstraints(std::move(constraints_));
     metadata.setComment(std::move(comment_));
     metadata.setSettingsChanges(std::move(settings_changes_));
+    metadata.lookup_indexes = std::move(lookup_indexes_ast_);
     setInMemoryMetadata(metadata);
 
     sample_block = metadata.getSampleBlock();
@@ -399,24 +437,36 @@ StorageOverwriteCache::StorageOverwriteCache(
     }
     for (const auto & name : settings.equal_version_tiebreak_columns)
         tiebreak_positions.push_back(getColumnPosition(name));
-    for (const auto & name : settings.secondary_index_columns)
+    lookup_index_positions.reserve(lookup_index_columns.size());
+    lookup_index_column_types.reserve(lookup_index_columns.size());
+    lookup_indexes.reserve(lookup_index_columns.size());
+    for (const auto & index_columns : lookup_index_columns)
     {
-        const auto position = getColumnPosition(name);
-        secondary_index_positions.push_back(position);
-        secondary_index_column_types.push_back(sample_block.getByPosition(position).type);
-    }
-    if (settings.secondary_index_segment_column)
-    {
-        segmented_secondary_index_columns.push_back(*settings.secondary_index_segment_column);
-        segmented_secondary_index_columns.insert(
-            segmented_secondary_index_columns.end(), settings.secondary_index_columns.begin(), settings.secondary_index_columns.end());
-        for (const auto & name : segmented_secondary_index_columns)
+        std::vector<size_t> positions;
+        DataTypes types;
+        positions.reserve(index_columns.size());
+        types.reserve(index_columns.size());
+        for (const auto & name : index_columns)
         {
             const auto position = getColumnPosition(name);
-            segmented_secondary_index_positions.push_back(position);
-            segmented_secondary_index_column_types.push_back(sample_block.getByPosition(position).type);
+            positions.push_back(position);
+            types.push_back(sample_block.getByPosition(position).type);
         }
+        lookup_index_positions.push_back(std::move(positions));
+        lookup_index_column_types.push_back(std::move(types));
+        lookup_indexes.push_back(std::make_shared<LookupIndex>());
     }
+}
+
+std::vector<StorageOverwriteCache::LookupIndexSnapshot> StorageOverwriteCache::getLookupIndexSnapshot() const
+{
+    auto guard = std::make_shared<ReadGuard>(*this);
+    std::shared_lock lock(lookup_catalog_mutex);
+    std::vector<LookupIndexSnapshot> result;
+    result.reserve(lookup_indexes.size());
+    for (size_t index = 0; index < lookup_indexes.size(); ++index)
+        result.push_back({guard, lookup_index_columns[index], lookup_index_column_types[index], lookup_indexes[index]});
+    return result;
 }
 
 size_t StorageOverwriteCache::getColumnPosition(const String & column_name) const
@@ -435,15 +485,46 @@ String StorageOverwriteCache::serializeColumns(const Block & block, size_t row, 
     return out.str();
 }
 
-String StorageOverwriteCache::serializeFields(const std::vector<Field> & fields, const std::vector<size_t> & positions) const
+String StorageOverwriteCache::serializeRowColumns(const RowData & row, const std::vector<size_t> & positions) const
 {
     WriteBufferFromOwnString out;
     for (const auto position : positions)
-        serializations[position]->serializeBinary(fields[position], out, {});
+    {
+        const auto column = row.segment->columns[position]->decompress();
+        serializations[position]->serializeBinary(*column, row.segment_row, out, {});
+    }
     return out.str();
 }
 
-int StorageOverwriteCache::compareWinner(const RowData & lhs, const RowData & rhs) const
+void StorageOverwriteCache::insertValueIntoColumn(const RowData & row, size_t position, IColumn & column) const
+{
+    const auto source = row.segment->columns[position]->decompress();
+    column.insertFrom(*source, row.segment_row);
+}
+
+Field StorageOverwriteCache::getRowField(const RowData & row, size_t position) const
+{
+    const auto column = row.segment->columns[position]->decompress();
+    Field result;
+    column->get(row.segment_row, result);
+    return result;
+}
+
+Field StorageOverwriteCache::getCandidateField(const CandidateRow & row, size_t position) const
+{
+    if (position >= row.value_offsets.size())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` candidate row offsets");
+    const size_t begin = position ? row.value_offsets[position - 1] : 0;
+    const size_t end = row.value_offsets[position];
+    auto column = sample_block.getByPosition(position).type->createColumn();
+    ReadBufferFromMemory input(row.encoded_values.data() + begin, end - begin);
+    serializations[position]->deserializeBinary(*column, input, {});
+    Field result;
+    column->get(0, result);
+    return result;
+}
+
+int StorageOverwriteCache::compareWinner(const CandidateRow & lhs, const CandidateRow & rhs) const
 {
     const auto compare_field = [](const Field & left, const Field & right)
     {
@@ -454,12 +535,37 @@ int StorageOverwriteCache::compareWinner(const RowData & lhs, const RowData & rh
         return 0;
     };
 
-    if (const int result = compare_field(lhs.values[version_position], rhs.values[version_position]))
+    if (const int result = compare_field(getCandidateField(lhs, version_position), getCandidateField(rhs, version_position)))
         return result;
 
     for (const auto position : tiebreak_positions)
     {
-        if (const int result = compare_field(lhs.values[position], rhs.values[position]))
+        if (const int result = compare_field(getCandidateField(lhs, position), getCandidateField(rhs, position)))
+            return result;
+    }
+
+    if (lhs.encoded_values != rhs.encoded_values || lhs.value_offsets != rhs.value_offsets)
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS, "Conflicting rows for the same `OverwriteCache` key have identical version and tie-break values");
+    return 0;
+}
+
+int StorageOverwriteCache::compareWinner(const CandidateRow & lhs, const RowData & rhs) const
+{
+    const auto compare_field = [](const Field & left, const Field & right)
+    {
+        if (left < right)
+            return -1;
+        if (right < left)
+            return 1;
+        return 0;
+    };
+
+    if (const int result = compare_field(getCandidateField(lhs, version_position), getRowField(rhs, version_position)))
+        return result;
+    for (const auto position : tiebreak_positions)
+    {
+        if (const int result = compare_field(getCandidateField(lhs, position), getRowField(rhs, position)))
             return result;
     }
 
@@ -469,21 +575,14 @@ int StorageOverwriteCache::compareWinner(const RowData & lhs, const RowData & rh
     return 0;
 }
 
-bool StorageOverwriteCache::rowsEqual(const RowData & lhs, const RowData & rhs) const
+bool StorageOverwriteCache::rowsEqual(const CandidateRow & lhs, const RowData & rhs) const
 {
-    return lhs.values == rhs.values;
+    for (size_t position = 0; position < sample_block.columns(); ++position)
+        if (getCandidateField(lhs, position) != getRowField(rhs, position))
+            return false;
+    return true;
 }
 
-UInt64 StorageOverwriteCache::estimateRowBytes(const Block & block, size_t row, const RowData & data) const
-{
-    UInt64 payload_bytes = 0;
-    for (const auto & column : block)
-        payload_bytes += column.column->byteSizeAt(row);
-
-    constexpr UInt64 entry_overhead = 256;
-    return entry_overhead + static_cast<UInt64>(sizeof(Field) * data.values.size()) + static_cast<UInt64>(data.primary_key.size())
-        + static_cast<UInt64>(data.secondary_key.size()) + static_cast<UInt64>(data.segmented_secondary_key.size()) + payload_bytes;
-}
 
 StorageOverwriteCache::ReadGuard::ReadGuard(const StorageOverwriteCache & storage_)
     : storage(storage_)
@@ -523,7 +622,7 @@ size_t StorageOverwriteCache::rowLockIndex(EntryId entry_id) const
     return std::hash<EntryId>{}(entry_id) % row_lock_count;
 }
 
-StorageOverwriteCache::EntryPtr StorageOverwriteCache::findEntry(const String & key) const
+std::optional<StorageOverwriteCache::EntryId> StorageOverwriteCache::findEntry(const String & key) const
 {
     const auto & shard = primary_shards[primaryShardIndex(key)];
     std::shared_lock lock(shard.mutex);
@@ -532,37 +631,46 @@ StorageOverwriteCache::EntryPtr StorageOverwriteCache::findEntry(const String & 
     return {};
 }
 
-StorageOverwriteCache::RowDataPtr StorageOverwriteCache::resolveEntry(const EntryPtr & entry, UInt64 snapshot_generation) const
+StorageOverwriteCache::RowDataPtr StorageOverwriteCache::resolveEntry(EntryId entry_id, UInt64 snapshot_generation) const
 {
-    std::lock_guard lock(row_mutexes[rowLockIndex(entry->id)]);
-    if (entry->pending_publication && entry->pending_publication->generation <= snapshot_generation
-        && entry->pending_publication->state.load(std::memory_order_acquire) == PublicationState::Committed)
-        return entry->pending;
-    return entry->committed;
+    std::shared_lock entries_lock(entries_by_id_mutex);
+    if (entry_id == 0 || entry_id > entries_by_id.size())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` entry identifier");
+    std::lock_guard row_lock(row_mutexes[rowLockIndex(entry_id)]);
+    const auto & entry = entries_by_id[entry_id - 1];
+    if (entry.pending_generation != 0 && entry.pending_generation <= snapshot_generation)
+        return *entry.pending;
+    return entry.committed;
 }
 
 void StorageOverwriteCache::insertBlock(const Block & block)
 {
-    std::unordered_map<String, std::shared_ptr<RowData>> candidates;
+    std::vector<std::vector<size_t>> lookup_positions_snapshot;
+    {
+        std::shared_lock catalog_lock(lookup_catalog_mutex);
+        lookup_positions_snapshot = lookup_index_positions;
+    }
+    std::unordered_map<String, std::shared_ptr<CandidateRow>> candidates;
     candidates.reserve(block.rows());
 
     for (size_t row = 0; row < block.rows(); ++row)
     {
-        auto candidate = std::make_shared<RowData>();
-        candidate->values.reserve(block.columns());
-        for (const auto & column : block)
+        auto candidate = std::make_shared<CandidateRow>();
+        candidate->source_row = static_cast<UInt32>(row);
+        WriteBufferFromOwnString encoded;
+        candidate->value_offsets.reserve(block.columns());
+        for (size_t position = 0; position < block.columns(); ++position)
         {
-            Field value;
-            column.column->get(row, value);
-            candidate->values.push_back(std::move(value));
+            serializations[position]->serializeBinary(*block.getByPosition(position).column, row, encoded, {});
+            if (encoded.count() > std::numeric_limits<UInt32>::max())
+                throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "An `OverwriteCache` row exceeds the compact 4 GiB row limit");
+            candidate->value_offsets.push_back(static_cast<UInt32>(encoded.count()));
         }
+        candidate->encoded_values = encoded.str();
         candidate->primary_key = serializeColumns(block, row, key_positions);
-        if (!secondary_index_positions.empty())
-            candidate->secondary_key = serializeColumns(block, row, secondary_index_positions);
-        if (!segmented_secondary_index_positions.empty())
-            candidate->segmented_secondary_key = serializeColumns(block, row, segmented_secondary_index_positions);
-        candidate->accounted_bytes = estimateRowBytes(block, row, *candidate);
-
+        candidate->lookup_keys.reserve(lookup_positions_snapshot.size());
+        for (const auto & positions : lookup_positions_snapshot)
+            candidate->lookup_keys.push_back(serializeColumns(block, row, positions));
         auto [it, inserted] = candidates.emplace(candidate->primary_key, candidate);
         if (!inserted && compareWinner(*candidate, *it->second) > 0)
             it->second = std::move(candidate);
@@ -571,15 +679,29 @@ void StorageOverwriteCache::insertBlock(const Block & block)
     struct Mutation
     {
         String key;
-        EntryPtr entry;
-        std::shared_ptr<RowData> row;
+        EntryId entry_id = 0;
+        std::shared_ptr<CandidateRow> candidate;
+        std::unique_ptr<RowData> row;
+        std::optional<RowData> previous;
+        std::vector<String> lookup_keys;
         bool is_new = false;
         bool primary_inserted = false;
         bool pending_installed = false;
     };
 
+    FailPointInjection::pauseFailPoint(FailPoints::overwrite_cache_pause_after_lookup_catalog_snapshot);
     std::lock_guard writer_lock(writer_mutex);
-    UInt64 prospective_bytes = total_size_bytes.load(std::memory_order_relaxed);
+    if (lookup_positions_snapshot != lookup_index_positions)
+    {
+        for (auto & [key, candidate] : candidates)
+        {
+            static_cast<void>(key);
+            candidate->lookup_keys.clear();
+            candidate->lookup_keys.reserve(lookup_index_positions.size());
+            for (const auto & positions : lookup_index_positions)
+                candidate->lookup_keys.push_back(serializeColumns(block, candidate->source_row, positions));
+        }
+    }
     std::vector<Mutation> mutations;
     mutations.reserve(candidates.size());
 
@@ -588,14 +710,12 @@ void StorageOverwriteCache::insertBlock(const Block & block)
         auto entry = findEntry(key);
         if (!entry)
         {
-            if (prospective_bytes > std::numeric_limits<UInt64>::max() - candidate->accounted_bytes)
-                throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
-            prospective_bytes += candidate->accounted_bytes;
-            mutations.push_back({key, {}, std::move(candidate), true});
+            auto lookup_keys = candidate->lookup_keys;
+            mutations.push_back({key, {}, std::move(candidate), {}, {}, std::move(lookup_keys), true});
             continue;
         }
 
-        const auto current = resolveEntry(entry, published_generation.load(std::memory_order_acquire));
+        const auto current = resolveEntry(*entry, published_generation.load(std::memory_order_acquire));
         if (!current)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Corrupted `OverwriteCache` primary index");
 
@@ -603,12 +723,155 @@ void StorageOverwriteCache::insertBlock(const Block & block)
         if (winner <= 0)
             continue;
 
-        prospective_bytes -= current->accounted_bytes;
-        if (prospective_bytes > std::numeric_limits<UInt64>::max() - candidate->accounted_bytes)
-            throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
-        prospective_bytes += candidate->accounted_bytes;
-        mutations.push_back({key, std::move(entry), std::move(candidate), false});
+        auto lookup_keys = candidate->lookup_keys;
+        mutations.push_back({key, *entry, std::move(candidate), {}, current, std::move(lookup_keys), false});
     }
+
+    if (mutations.empty())
+        return;
+
+    auto selector = ColumnUInt64::create();
+    selector->reserve(mutations.size());
+    for (const auto & mutation : mutations)
+        selector->insertValue(mutation.candidate->source_row);
+
+    auto segment = std::make_shared<RowSegment>();
+    segment->columns.reserve(block.columns());
+    for (const auto & source : block)
+    {
+        auto selected = source.column->index(*selector, 0)->compress(/*force_compression=*/true);
+        segment->allocated_bytes += selected->allocatedBytes();
+        segment->columns.push_back(std::move(selected));
+    }
+    segment->live_rows.store(mutations.size(), std::memory_order_relaxed);
+
+    UInt64 prospective_bytes = total_size_bytes.load(std::memory_order_relaxed);
+    if (prospective_bytes > std::numeric_limits<UInt64>::max() - segment->allocated_bytes)
+        throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
+    prospective_bytes += segment->allocated_bytes;
+    for (size_t row = 0; row < mutations.size(); ++row)
+    {
+        auto compact_row = std::make_unique<RowData>();
+        compact_row->segment = segment;
+        compact_row->segment_row = static_cast<UInt32>(row);
+        UInt64 added_bytes = 0;
+        if (mutations[row].is_new)
+            added_bytes += sizeof(std::pair<const String, EntryId>) + mutations[row].key.size() + 64;
+        if (prospective_bytes > std::numeric_limits<UInt64>::max() - added_bytes)
+            throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
+        prospective_bytes += added_bytes;
+        mutations[row].row = std::move(compact_row);
+        mutations[row].candidate.reset();
+    }
+
+    struct SegmentCompaction
+    {
+        std::shared_ptr<RowSegment> source;
+        UInt64 replaced_rows = 0;
+        UInt64 projected_live_rows = 0;
+        bool selected = false;
+        std::vector<std::pair<EntryId, RowData>> live_entries;
+    };
+
+    std::vector<SegmentCompaction> segment_compactions;
+    std::unordered_map<RowSegment *, size_t> segment_compaction_positions;
+    std::unordered_set<EntryId> mutated_entry_ids;
+    mutated_entry_ids.reserve(mutations.size());
+    for (const auto & mutation : mutations)
+    {
+        if (mutation.is_new || !mutation.previous || !mutation.previous->segment)
+            continue;
+        mutated_entry_ids.insert(mutation.entry_id);
+        auto [it, inserted] = segment_compaction_positions.emplace(
+            mutation.previous->segment.get(), segment_compactions.size());
+        if (inserted)
+        {
+            segment_compactions.emplace_back();
+            segment_compactions.back().source = mutation.previous->segment;
+        }
+        ++segment_compactions[it->second].replaced_rows;
+    }
+
+    std::unordered_map<RowSegment *, size_t> selected_compaction_positions;
+    for (size_t position = 0; position < segment_compactions.size(); ++position)
+    {
+        auto & compaction = segment_compactions[position];
+        const UInt64 live_rows = compaction.source->live_rows.load(std::memory_order_acquire);
+        if (compaction.replaced_rows > live_rows)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` row-segment live-row count");
+        compaction.projected_live_rows = live_rows - compaction.replaced_rows;
+        const UInt64 total_rows = compaction.source->columns.empty() ? 0 : compaction.source->columns.front()->size();
+        if (compaction.projected_live_rows > total_rows)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` row-segment size");
+        const UInt64 projected_dead_rows = total_rows - compaction.projected_live_rows;
+        if (compaction.projected_live_rows == 0 || projected_dead_rows < (total_rows + 1) / 2)
+            continue;
+        compaction.selected = true;
+        compaction.live_entries.reserve(compaction.projected_live_rows);
+        selected_compaction_positions.emplace(compaction.source.get(), position);
+    }
+
+    if (!selected_compaction_positions.empty())
+    {
+        std::shared_lock entries_lock(entries_by_id_mutex);
+        for (EntryId entry_id = 1; entry_id <= entries_by_id.size(); ++entry_id)
+        {
+            if ((entry_id & 4095) == 0 && CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
+                throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled while compacting `OverwriteCache` row segments");
+            if (mutated_entry_ids.contains(entry_id))
+                continue;
+            const auto & entry = entries_by_id[entry_id - 1];
+            std::lock_guard row_lock(row_mutexes[rowLockIndex(entry_id)]);
+            if (!entry.committed)
+                continue;
+            const auto it = selected_compaction_positions.find(entry.committed->segment.get());
+            if (it != selected_compaction_positions.end())
+                segment_compactions[it->second].live_entries.emplace_back(entry_id, *entry.committed);
+        }
+    }
+
+    for (auto & compaction : segment_compactions)
+    {
+        if (!compaction.selected)
+            continue;
+        if (compaction.live_entries.size() != compaction.projected_live_rows)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` row-segment references");
+
+        auto compaction_selector = ColumnUInt64::create();
+        compaction_selector->reserve(compaction.live_entries.size());
+        for (const auto & [entry_id, row] : compaction.live_entries)
+        {
+            static_cast<void>(entry_id);
+            compaction_selector->insertValue(row.segment_row);
+        }
+
+        auto compacted_segment = std::make_shared<RowSegment>();
+        compacted_segment->columns.reserve(compaction.source->columns.size());
+        for (const auto & source_column : compaction.source->columns)
+        {
+            auto selected = source_column->decompress()->index(*compaction_selector, 0)->compress(/*force_compression=*/true);
+            compacted_segment->allocated_bytes += selected->allocatedBytes();
+            compacted_segment->columns.push_back(std::move(selected));
+        }
+        compacted_segment->live_rows.store(compaction.live_entries.size(), std::memory_order_relaxed);
+        if (prospective_bytes > std::numeric_limits<UInt64>::max() - compacted_segment->allocated_bytes)
+            throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
+        prospective_bytes += compacted_segment->allocated_bytes;
+
+        for (size_t row = 0; row < compaction.live_entries.size(); ++row)
+        {
+            const auto & [entry_id, previous] = compaction.live_entries[row];
+            auto compacted_row = std::make_unique<RowData>();
+            compacted_row->segment = compacted_segment;
+            compacted_row->segment_row = static_cast<UInt32>(row);
+            Mutation compacted_mutation;
+            compacted_mutation.entry_id = entry_id;
+            compacted_mutation.row = std::move(compacted_row);
+            compacted_mutation.previous = previous;
+            mutations.push_back(std::move(compacted_mutation));
+        }
+    }
+    candidates.clear();
 
     if (prospective_bytes > settings.max_memory_bytes)
         throw Exception(
@@ -617,74 +880,157 @@ void StorageOverwriteCache::insertBlock(const Block & block)
             prospective_bytes,
             settings.max_memory_bytes);
 
-    if (mutations.empty())
-        return;
-
     const auto new_entries = static_cast<EntryId>(std::ranges::count_if(mutations, [](const auto & mutation) { return mutation.is_new; }));
     if (new_entries > std::numeric_limits<EntryId>::max() - next_entry_id)
         throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` entry identifier space is exhausted");
 
     EntryId staged_next_entry_id = next_entry_id;
-    std::unordered_map<String, size_t> secondary_additions;
-    std::unordered_map<String, size_t> segmented_secondary_additions;
-    secondary_additions.reserve(new_entries);
-    segmented_secondary_additions.reserve(new_entries);
+    std::vector<std::unordered_map<String, size_t>> lookup_additions(lookup_indexes.size());
+    for (auto & additions : lookup_additions)
+        additions.reserve(new_entries);
     for (auto & mutation : mutations)
     {
         if (mutation.is_new)
         {
-            mutation.entry = std::make_shared<Entry>();
-            mutation.entry->id = staged_next_entry_id++;
-            if (!mutation.row->secondary_key.empty())
-                ++secondary_additions[mutation.row->secondary_key];
-            if (!mutation.row->segmented_secondary_key.empty())
-                ++segmented_secondary_additions[mutation.row->segmented_secondary_key];
+            mutation.entry_id = staged_next_entry_id++;
+            for (size_t index = 0; index < mutation.lookup_keys.size(); ++index)
+                ++lookup_additions[index][mutation.lookup_keys[index]];
         }
     }
 
     struct PreparedPosting
     {
-        bool segmented = false;
+        size_t index = 0;
         size_t shard_index = 0;
         String key;
         size_t additional_rows = 0;
         size_t old_size = 0;
+        UInt64 old_allocated_bytes = 0;
+        UInt64 reserved_allocated_bytes = 0;
+        UInt64 node_bytes = 0;
+        UInt64 bucket_bytes_delta = 0;
         bool inserted = false;
         bool prepared = false;
     };
 
     std::vector<PreparedPosting> prepared_postings;
-    prepared_postings.reserve(secondary_additions.size() + segmented_secondary_additions.size());
-    for (const auto & [key, count] : secondary_additions)
-        prepared_postings.push_back({false, postingShardIndex(key), key, count});
-    for (const auto & [key, count] : segmented_secondary_additions)
-        prepared_postings.push_back({true, postingShardIndex(key), key, count});
+    for (size_t index = 0; index < lookup_additions.size(); ++index)
+    {
+        prepared_postings.reserve(prepared_postings.size() + lookup_additions[index].size());
+        for (const auto & [key, count] : lookup_additions[index])
+            prepared_postings.push_back({index, postingShardIndex(key), key, count});
+    }
+
+    std::vector<std::shared_ptr<RowSegment>> retired_segments;
+    retired_segments.reserve(mutations.size());
 
     const UInt64 current_generation = published_generation.load(std::memory_order_acquire);
     if (current_generation == std::numeric_limits<UInt64>::max())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "`OverwriteCache` publication generation space is exhausted");
-    const auto publication = std::make_shared<Publication>(current_generation + 1);
-    for (auto & mutation : mutations)
+
+    size_t old_entries_by_id_size = 0;
+    UInt64 entries_capacity_delta = 0;
+    {
+        std::unique_lock lock(entries_by_id_mutex);
+        old_entries_by_id_size = entries_by_id.size();
+        const size_t old_capacity = entries_by_id.capacity();
+        entries_by_id.reserve(entries_by_id.size() + new_entries);
+        entries_capacity_delta = static_cast<UInt64>(entries_by_id.capacity() - old_capacity) * sizeof(Entry);
+    }
+    if (prospective_bytes > std::numeric_limits<UInt64>::max() - entries_capacity_delta)
+    {
+        total_size_bytes.fetch_add(entries_capacity_delta, std::memory_order_relaxed);
+        throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
+    }
+    prospective_bytes += entries_capacity_delta;
+    const UInt64 new_generation = current_generation + 1;
+    std::vector<UInt64> lookup_bytes_delta(lookup_indexes.size());
+    std::vector<UInt64> retained_lookup_bytes(lookup_indexes.size());
+    std::vector<size_t> primary_additions(primary_shards.size());
+    std::vector<UInt64> primary_bucket_bytes_delta(primary_shards.size());
+    for (const auto & mutation : mutations)
     {
         if (mutation.is_new)
-        {
-            mutation.entry->pending = mutation.row;
-            mutation.entry->pending_publication = publication;
-        }
+            ++primary_additions[primaryShardIndex(mutation.key)];
     }
 
     try
     {
+        for (size_t shard_index = 0; shard_index < primary_shards.size(); ++shard_index)
+        {
+            if (primary_additions[shard_index] == 0)
+                continue;
+            auto & shard = primary_shards[shard_index];
+            std::unique_lock lock(shard.mutex);
+            const size_t old_bucket_count = shard.entries.bucket_count();
+            const size_t required_size = shard.entries.size() + primary_additions[shard_index];
+            if (static_cast<double>(required_size)
+                > static_cast<double>(old_bucket_count) * static_cast<double>(shard.entries.max_load_factor()))
+                shard.entries.reserve(required_size);
+            primary_bucket_bytes_delta[shard_index]
+                = static_cast<UInt64>(shard.entries.bucket_count() - old_bucket_count) * sizeof(void *);
+            if (prospective_bytes > std::numeric_limits<UInt64>::max() - primary_bucket_bytes_delta[shard_index])
+                throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` primary-index memory accounting overflow");
+            prospective_bytes += primary_bucket_bytes_delta[shard_index];
+        }
+
         for (auto & prepared : prepared_postings)
         {
-            auto & shards = prepared.segmented ? segmented_secondary_shards : secondary_shards;
-            auto & shard = shards[prepared.shard_index];
+            auto & shard = lookup_indexes[prepared.index]->shards[prepared.shard_index];
             std::unique_lock lock(shard.mutex);
+            const size_t old_bucket_count = shard.postings.bucket_count();
+            const size_t required_size = shard.postings.size() + 1;
+            if (static_cast<double>(required_size)
+                > static_cast<double>(old_bucket_count) * static_cast<double>(shard.postings.max_load_factor()))
+                shard.postings.reserve(required_size);
+            prepared.bucket_bytes_delta
+                = static_cast<UInt64>(shard.postings.bucket_count() - old_bucket_count) * sizeof(void *);
+            prepared.prepared = true;
+            if (prospective_bytes > std::numeric_limits<UInt64>::max() - prepared.bucket_bytes_delta)
+                throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` lookup-index memory accounting overflow");
+            prospective_bytes += prepared.bucket_bytes_delta;
+            if (lookup_bytes_delta[prepared.index] > std::numeric_limits<UInt64>::max() - prepared.bucket_bytes_delta)
+                throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` lookup-index memory accounting overflow");
+            lookup_bytes_delta[prepared.index] += prepared.bucket_bytes_delta;
+
             auto [it, inserted] = shard.postings.try_emplace(prepared.key);
             prepared.old_size = it->second.size();
+            prepared.old_allocated_bytes = it->second.allocatedBytes();
             prepared.inserted = inserted;
-            prepared.prepared = true;
-            it->second.reserve(it->second.size() + prepared.additional_rows);
+            prepared.node_bytes = inserted
+                ? sizeof(std::pair<const String, PostingShard::Posting>) + prepared.key.size() + 64
+                : 0;
+            it->second.reserve(it->second.size() + prepared.additional_rows, staged_next_entry_id - 1);
+            prepared.reserved_allocated_bytes = it->second.allocatedBytes();
+            const UInt64 allocated_delta
+                = prepared.reserved_allocated_bytes - prepared.old_allocated_bytes + prepared.node_bytes;
+            if (prospective_bytes > std::numeric_limits<UInt64>::max() - allocated_delta)
+                throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
+            prospective_bytes += allocated_delta;
+            if (lookup_bytes_delta[prepared.index] > std::numeric_limits<UInt64>::max() - allocated_delta)
+                throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` lookup-index memory accounting overflow");
+            lookup_bytes_delta[prepared.index] += allocated_delta;
+        }
+
+        if (prospective_bytes > settings.max_memory_bytes)
+            throw Exception(
+                ErrorCodes::MEMORY_LIMIT_EXCEEDED,
+                "`OverwriteCache` insert requires {} bytes, exceeding `max_memory_bytes` = {}",
+                prospective_bytes,
+                settings.max_memory_bytes);
+
+        {
+            std::unique_lock lock(entries_by_id_mutex);
+            for (auto & mutation : mutations)
+            {
+                if (!mutation.is_new)
+                    continue;
+                if (mutation.entry_id != entries_by_id.size() + 1)
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` entry identifier sequence");
+                auto & entry = entries_by_id.emplace_back();
+                entry.pending = std::move(mutation.row);
+                entry.pending_generation = new_generation;
+            }
         }
 
         for (auto & mutation : mutations)
@@ -694,33 +1040,29 @@ void StorageOverwriteCache::insertBlock(const Block & block)
                 auto & primary_shard = primary_shards[primaryShardIndex(mutation.key)];
                 {
                     std::unique_lock lock(primary_shard.mutex);
-                    mutation.primary_inserted = primary_shard.entries.emplace(mutation.key, mutation.entry).second;
+                    mutation.primary_inserted = primary_shard.entries.emplace(mutation.key, mutation.entry_id).second;
                 }
                 if (!mutation.primary_inserted)
                     throw Exception(ErrorCodes::LOGICAL_ERROR, "Duplicate `OverwriteCache` key during publication");
 
-                if (!mutation.row->secondary_key.empty())
+                for (size_t index = 0; index < mutation.lookup_keys.size(); ++index)
                 {
-                    auto & shard = secondary_shards[postingShardIndex(mutation.row->secondary_key)];
+                    const auto & lookup_key = mutation.lookup_keys[index];
+                    auto & shard = lookup_indexes[index]->shards[postingShardIndex(lookup_key)];
                     std::unique_lock lock(shard.mutex);
-                    shard.postings.find(mutation.row->secondary_key)->second.push_back(mutation.entry);
-                }
-                if (!mutation.row->segmented_secondary_key.empty())
-                {
-                    auto & shard = segmented_secondary_shards[postingShardIndex(mutation.row->segmented_secondary_key)];
-                    std::unique_lock lock(shard.mutex);
-                    shard.postings.find(mutation.row->segmented_secondary_key)->second.push_back(mutation.entry);
+                    shard.postings.find(lookup_key)->second.push_back(mutation.entry_id);
                 }
             }
             else
             {
                 /// Every indexed column is part of the immutable composite key, so a replacement
                 /// publishes only the new payload and retains the existing postings.
-                std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry->id)]);
-                if (mutation.entry->pending_publication)
+                auto & entry = entries_by_id[mutation.entry_id - 1];
+                std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry_id)]);
+                if (entry.pending_generation != 0)
                     throw Exception(ErrorCodes::LOGICAL_ERROR, "Concurrent `OverwriteCache` publication for the same entry");
-                mutation.entry->pending = mutation.row;
-                mutation.entry->pending_publication = publication;
+                entry.pending = std::move(mutation.row);
+                entry.pending_generation = new_generation;
                 mutation.pending_installed = true;
             }
 
@@ -733,27 +1075,37 @@ void StorageOverwriteCache::insertBlock(const Block & block)
     }
     catch (...)
     {
-        publication->state.store(PublicationState::Aborted, std::memory_order_release);
+        UInt64 retained_bytes = entries_capacity_delta;
+        for (const UInt64 bucket_delta : primary_bucket_bytes_delta)
+            retained_bytes += bucket_delta;
         for (auto & mutation : mutations)
         {
             if (!mutation.pending_installed)
                 continue;
-            std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry->id)]);
-            mutation.entry->pending.reset();
-            mutation.entry->pending_publication.reset();
+            auto & entry = entries_by_id[mutation.entry_id - 1];
+            std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry_id)]);
+            entry.pending.reset();
+            entry.pending_generation = 0;
         }
         for (const auto & prepared : prepared_postings)
         {
             if (!prepared.prepared)
                 continue;
-            auto & shards = prepared.segmented ? segmented_secondary_shards : secondary_shards;
-            auto & shard = shards[prepared.shard_index];
+            auto & shard = lookup_indexes[prepared.index]->shards[prepared.shard_index];
             std::unique_lock lock(shard.mutex);
+            retained_bytes += prepared.bucket_bytes_delta;
+            retained_lookup_bytes[prepared.index] += prepared.bucket_bytes_delta;
             if (const auto it = shard.postings.find(prepared.key); it != shard.postings.end())
             {
                 it->second.resize(prepared.old_size);
                 if (prepared.inserted)
                     shard.postings.erase(it);
+                else
+                {
+                    const UInt64 retained_delta = it->second.allocatedBytes() - prepared.old_allocated_bytes;
+                    retained_bytes += retained_delta;
+                    retained_lookup_bytes[prepared.index] += retained_delta;
+                }
             }
         }
         for (const auto & mutation : mutations)
@@ -764,14 +1116,31 @@ void StorageOverwriteCache::insertBlock(const Block & block)
             std::unique_lock lock(shard.mutex);
             shard.entries.erase(mutation.key);
         }
+        {
+            std::unique_lock lock(entries_by_id_mutex);
+            entries_by_id.resize(old_entries_by_id_size);
+        }
+        total_size_bytes.fetch_add(retained_bytes, std::memory_order_relaxed);
+        for (size_t index = 0; index < retained_lookup_bytes.size(); ++index)
+            lookup_indexes[index]->accounted_bytes.fetch_add(retained_lookup_bytes[index], std::memory_order_relaxed);
         throw;
     }
 
-    publication->state.store(PublicationState::Committed, std::memory_order_release);
-    published_generation.store(publication->generation, std::memory_order_release);
+    published_generation.store(new_generation, std::memory_order_release);
     next_entry_id = staged_next_entry_id;
     total_size_bytes.store(prospective_bytes, std::memory_order_relaxed);
     total_size_rows.fetch_add(new_entries, std::memory_order_relaxed);
+    for (size_t index = 0; index < lookup_indexes.size(); ++index)
+        lookup_indexes[index]->accounted_bytes.fetch_add(lookup_bytes_delta[index], std::memory_order_relaxed);
+
+    UInt64 reclaim_bytes = 0;
+    for (const auto & mutation : mutations)
+    {
+        if (!mutation.previous)
+            continue;
+        if (mutation.previous->segment && mutation.previous->segment->live_rows.fetch_sub(1, std::memory_order_acq_rel) == 1)
+            retired_segments.push_back(mutation.previous->segment);
+    }
 
     const UInt8 old_epoch = active_reader_epoch.fetch_xor(1, std::memory_order_acq_rel);
     UInt64 active = active_readers[old_epoch].load(std::memory_order_acquire);
@@ -781,87 +1150,160 @@ void StorageOverwriteCache::insertBlock(const Block & block)
         active = active_readers[old_epoch].load(std::memory_order_acquire);
     }
 
+    for (const auto & retired_segment : retired_segments)
+        reclaim_bytes += retired_segment->allocated_bytes;
+    total_size_bytes.fetch_sub(reclaim_bytes, std::memory_order_relaxed);
+
     for (auto & mutation : mutations)
     {
-        std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry->id)]);
-        mutation.entry->committed = std::move(mutation.entry->pending);
-        mutation.entry->pending_publication.reset();
+        auto & entry = entries_by_id[mutation.entry_id - 1];
+        std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry_id)]);
+        entry.committed = std::move(*entry.pending);
+        entry.pending.reset();
+        entry.pending_generation = 0;
     }
 }
 
-StorageOverwriteCache::RowDataPtrs StorageOverwriteCache::getRowsForPrimaryKeys(const std::vector<String> & serialized_keys) const
+StorageOverwriteCache::ReadResult StorageOverwriteCache::getRowsForPrimaryKeys(const std::vector<String> & serialized_keys) const
 {
-    ReadGuard read_guard(*this);
-    RowDataPtrs result;
-    result.reserve(serialized_keys.size());
+    ReadResult result;
+    result.guard = std::make_shared<ReadGuard>(*this);
+    result.rows.reserve(serialized_keys.size());
     std::unordered_set<EntryId> seen;
     for (const auto & key : serialized_keys)
     {
         const auto entry = findEntry(key);
-        if (!entry || !seen.emplace(entry->id).second)
+        if (!entry || !seen.emplace(*entry).second)
             continue;
-        if (auto row = resolveEntry(entry, read_guard.generation()))
-            result.push_back(std::move(row));
+        if (auto row = resolveEntry(*entry, result.guard->generation()))
+            result.rows.push_back(std::move(*row));
     }
     return result;
 }
 
-StorageOverwriteCache::RowDataPtrs StorageOverwriteCache::getRowsForPostingKeys(
-    const std::vector<String> & serialized_keys,
-    const std::array<PostingShard, posting_shard_count> & index,
-    const char * index_name) const
+UInt64 StorageOverwriteCache::getPostingCardinality(const LookupIndexPtr & index, const std::vector<String> & serialized_keys) const
 {
-    ReadGuard read_guard(*this);
+    UInt64 result = 0;
     std::unordered_set<String> seen_keys;
     seen_keys.reserve(serialized_keys.size());
-    std::vector<EntryPtr> entries;
     for (const auto & key : serialized_keys)
     {
         if (!seen_keys.emplace(key).second)
             continue;
-        const auto & shard = index[postingShardIndex(key)];
+        const auto & shard = index->shards[postingShardIndex(key)];
         std::shared_lock lock(shard.mutex);
         if (const auto it = shard.postings.find(key); it != shard.postings.end())
-        {
-            const UInt64 remaining_rows
-                = settings.max_secondary_index_rows - std::min<UInt64>(entries.size(), settings.max_secondary_index_rows);
-            if (it->second.size() > remaining_rows)
-                throw Exception(
-                    ErrorCodes::MEMORY_LIMIT_EXCEEDED,
-                    "`OverwriteCache` {} lookup exceeds `max_secondary_index_rows` = {}",
-                    index_name,
-                    settings.max_secondary_index_rows);
-            entries.insert(entries.end(), it->second.begin(), it->second.end());
-        }
-    }
-
-    RowDataPtrs result;
-    result.reserve(std::min<UInt64>(entries.size(), settings.max_secondary_index_rows));
-    for (const auto & entry : entries)
-    {
-        auto row = resolveEntry(entry, read_guard.generation());
-        if (!row)
-            continue;
-        if (result.size() >= settings.max_secondary_index_rows)
-            throw Exception(
-                ErrorCodes::MEMORY_LIMIT_EXCEEDED,
-                "`OverwriteCache` {} lookup exceeds `max_secondary_index_rows` = {}",
-                index_name,
-                settings.max_secondary_index_rows);
-        result.push_back(std::move(row));
+            result += it->second.size();
     }
     return result;
 }
 
-StorageOverwriteCache::RowDataPtrs StorageOverwriteCache::getRowsForSecondaryKeys(const std::vector<String> & serialized_keys) const
+std::vector<StorageOverwriteCache::EntryId>
+StorageOverwriteCache::getPostingIds(const LookupIndexPtr & index, const std::vector<String> & serialized_keys) const
 {
-    return getRowsForPostingKeys(serialized_keys, secondary_shards, "secondary");
+    std::vector<EntryId> result;
+    result.reserve(getPostingCardinality(index, serialized_keys));
+    std::unordered_set<String> seen_keys;
+    seen_keys.reserve(serialized_keys.size());
+    for (const auto & key : serialized_keys)
+    {
+        if (!seen_keys.emplace(key).second)
+            continue;
+        const auto & shard = index->shards[postingShardIndex(key)];
+        std::shared_lock lock(shard.mutex);
+        if (const auto it = shard.postings.find(key); it != shard.postings.end())
+        {
+            it->second.forEach([&](EntryId entry_id)
+            {
+                if ((result.size() & 4095) == 0 && CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
+                    throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled while reading an `OverwriteCache` posting");
+                result.push_back(entry_id);
+            });
+        }
+    }
+    std::ranges::sort(result);
+    result.erase(std::unique(result.begin(), result.end()), result.end());
+    return result;
 }
 
-StorageOverwriteCache::RowDataPtrs
-StorageOverwriteCache::getRowsForSegmentedSecondaryKeys(const std::vector<String> & serialized_keys) const
+void StorageOverwriteCache::intersectPostingIds(
+    std::vector<EntryId> & entry_ids, const LookupIndexPtr & index, const std::vector<String> & serialized_keys) const
 {
-    return getRowsForPostingKeys(serialized_keys, segmented_secondary_shards, "segmented secondary");
+    if (entry_ids.empty())
+        return;
+
+    std::vector<UInt8> matched(entry_ids.size(), 0);
+    std::unordered_set<String> seen_keys;
+    seen_keys.reserve(serialized_keys.size());
+    for (const auto & key : serialized_keys)
+    {
+        if (!seen_keys.emplace(key).second)
+            continue;
+        const auto & shard = index->shards[postingShardIndex(key)];
+        std::shared_lock lock(shard.mutex);
+        const auto it = shard.postings.find(key);
+        if (it == shard.postings.end())
+            continue;
+        for (size_t position = 0; position < entry_ids.size(); ++position)
+        {
+            if ((position & 4095) == 0 && CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
+                throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled while intersecting `OverwriteCache` postings");
+            if (!matched[position] && it->second.contains(entry_ids[position]))
+                matched[position] = 1;
+        }
+    }
+
+    size_t output = 0;
+    for (size_t position = 0; position < entry_ids.size(); ++position)
+    {
+        if (matched[position])
+            entry_ids[output++] = entry_ids[position];
+    }
+    entry_ids.resize(output);
+}
+
+StorageOverwriteCache::ReadResult StorageOverwriteCache::getRowsForLookupRequests(const std::vector<LookupRequest> & requests) const
+{
+    if (requests.empty())
+        return {};
+    ReadResult result;
+    result.guard = requests.front().guard;
+    if (!result.guard)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Missing `OverwriteCache` lookup snapshot guard");
+    for (const auto & request : requests)
+    {
+        if (request.guard != result.guard)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Mismatched `OverwriteCache` lookup snapshot guards");
+    }
+    FailPointInjection::pauseFailPoint(FailPoints::overwrite_cache_pause_during_lookup);
+    size_t driver = 0;
+    UInt64 driver_cardinality = getPostingCardinality(requests[0].index, requests[0].serialized_keys);
+    for (size_t index = 1; index < requests.size(); ++index)
+    {
+        const UInt64 cardinality = getPostingCardinality(requests[index].index, requests[index].serialized_keys);
+        if (cardinality < driver_cardinality)
+        {
+            driver = index;
+            driver_cardinality = cardinality;
+        }
+    }
+
+    auto entry_ids = getPostingIds(requests[driver].index, requests[driver].serialized_keys);
+    for (size_t index = 0; index < requests.size() && !entry_ids.empty(); ++index)
+    {
+        if (index != driver)
+            intersectPostingIds(entry_ids, requests[index].index, requests[index].serialized_keys);
+    }
+
+    result.rows.reserve(entry_ids.size());
+    for (size_t position = 0; position < entry_ids.size(); ++position)
+    {
+        if ((position & 4095) == 0 && CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
+            throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled while resolving `OverwriteCache` postings");
+        if (auto row = resolveEntry(entry_ids[position], result.guard->generation()))
+            result.rows.push_back(std::move(*row));
+    }
+    return result;
 }
 
 Block StorageOverwriteCache::getSampleBlock(const Names & required_columns) const
@@ -923,14 +1365,12 @@ Chunk StorageOverwriteCache::getByKeys(
         serialized_keys.push_back(out.str());
     }
 
+    ReadGuard read_guard(*this);
     std::vector<RowDataPtr> resolved_rows(rows);
+    for (size_t row = 0; row < rows; ++row)
     {
-        ReadGuard read_guard(*this);
-        for (size_t row = 0; row < rows; ++row)
-        {
-            if (const auto entry = findEntry(serialized_keys[row]))
-                resolved_rows[row] = resolveEntry(entry, read_guard.generation());
-        }
+        if (const auto entry = findEntry(serialized_keys[row]))
+            resolved_rows[row] = resolveEntry(*entry, read_guard.generation());
     }
 
     for (size_t row = 0; row < rows; ++row)
@@ -943,7 +1383,7 @@ Chunk StorageOverwriteCache::getByKeys(
         }
         out_null_map[row] = 1;
         for (size_t column = 0; column < result_positions.size(); ++column)
-            result_columns[column]->insert(resolved_rows[row]->values[result_positions[column]]);
+            insertValueIntoColumn(*resolved_rows[row], result_positions[column], *result_columns[column]);
     }
 
     return Chunk(std::move(result_columns), rows);
@@ -974,25 +1414,255 @@ SinkToStoragePtr StorageOverwriteCache::write(const ASTPtr &, const StorageMetad
 void StorageOverwriteCache::clearData()
 {
     std::lock_guard writer_lock(writer_mutex);
-    for (auto & shard : secondary_shards)
+    for (auto & index : lookup_indexes)
     {
-        std::unique_lock lock(shard.mutex);
-        shard.postings.clear();
-    }
-    for (auto & shard : segmented_secondary_shards)
-    {
-        std::unique_lock lock(shard.mutex);
-        shard.postings.clear();
+        for (auto & shard : index->shards)
+        {
+            std::unique_lock lock(shard.mutex);
+            decltype(shard.postings) empty;
+            shard.postings.swap(empty);
+        }
+        index->accounted_bytes.store(0, std::memory_order_relaxed);
     }
     for (auto & shard : primary_shards)
     {
         std::unique_lock lock(shard.mutex);
-        shard.entries.clear();
+        decltype(shard.entries) empty;
+        shard.entries.swap(empty);
+    }
+    {
+        std::unique_lock lock(entries_by_id_mutex);
+        decltype(entries_by_id) empty;
+        entries_by_id.swap(empty);
     }
     next_entry_id = 1;
     published_generation.store(0, std::memory_order_release);
     total_size_bytes.store(0, std::memory_order_relaxed);
     total_size_rows.store(0, std::memory_order_relaxed);
+}
+
+void StorageOverwriteCache::checkAlterIsPossible(const AlterCommands & commands, ContextPtr) const
+{
+    if (commands.size() != 1
+        || (commands.front().type != AlterCommand::ADD_LOOKUP_INDEX && commands.front().type != AlterCommand::DROP_LOOKUP_INDEX))
+        throw Exception(
+            ErrorCodes::NOT_IMPLEMENTED,
+            "Storage `OverwriteCache` supports only one `ADD INDEX (...)` or `DROP INDEX (...)` command per ALTER");
+
+    auto columns = extractIdentifierList(*commands.front().lookup_index, "lookup `INDEX` clause");
+    std::unordered_map<String, size_t> key_order;
+    for (size_t position = 0; position < key_columns.size(); ++position)
+        key_order.emplace(key_columns[position], position);
+    std::unordered_set<String> index_column_set;
+    for (const auto & column : columns)
+    {
+        if (!key_order.contains(column))
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Lookup-index column {} must be declared in `KEYS`", backQuote(column));
+        if (!index_column_set.emplace(column).second)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Duplicate column {} in lookup `INDEX`", backQuote(column));
+    }
+    std::ranges::sort(columns, {}, [&](const String & column) { return key_order.at(column); });
+    if (commands.front().type == AlterCommand::ADD_LOOKUP_INDEX && columns == key_columns)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Lookup `INDEX` duplicates the complete `KEYS` tuple, which already has a primary index");
+
+    std::shared_lock lock(lookup_catalog_mutex);
+    const bool exists = std::ranges::find(lookup_index_columns, columns) != lookup_index_columns.end();
+    if (commands.front().type == AlterCommand::ADD_LOOKUP_INDEX && exists && !commands.front().if_not_exists)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Duplicate lookup `INDEX` declaration");
+    if (commands.front().type == AlterCommand::DROP_LOOKUP_INDEX && !exists && !commands.front().if_exists)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Lookup `INDEX` does not exist");
+}
+
+void StorageOverwriteCache::alter(const AlterCommands & commands, ContextPtr context, AlterLockHolder &)
+{
+    checkAlterIsPossible(commands, context);
+    const auto & command = commands.front();
+
+    Names columns = extractIdentifierList(*command.lookup_index, "lookup `INDEX` clause");
+    std::unordered_map<String, size_t> key_order;
+    for (size_t position = 0; position < key_columns.size(); ++position)
+        key_order.emplace(key_columns[position], position);
+    std::ranges::sort(columns, {}, [&](const String & column) { return key_order.at(column); });
+
+    const bool drop_index = command.type == AlterCommand::DROP_LOOKUP_INDEX;
+    {
+        std::shared_lock lock(lookup_catalog_mutex);
+        const bool exists = std::ranges::find(lookup_index_columns, columns) != lookup_index_columns.end();
+        if ((!drop_index && exists) || (drop_index && !exists))
+            return;
+    }
+
+    const auto table_id = getStorageID();
+    const auto metadata_snapshot = getInMemoryMetadataPtr(context, false);
+    StorageInMemoryMetadata new_metadata = *metadata_snapshot;
+    ASTPtr metadata_indexes = new_metadata.lookup_indexes
+        ? new_metadata.lookup_indexes->clone()
+        : make_intrusive<ASTExpressionList>();
+    auto & metadata_index_list = metadata_indexes->as<ASTExpressionList &>();
+
+    if (drop_index)
+    {
+        const auto erase_begin = std::remove_if(metadata_index_list.children.begin(), metadata_index_list.children.end(), [&](const ASTPtr & index_ast)
+        {
+            auto current_columns = extractIdentifierList(*index_ast, "lookup `INDEX` clause");
+            std::ranges::sort(current_columns, {}, [&](const String & column) { return key_order.at(column); });
+            return current_columns == columns;
+        });
+        metadata_index_list.children.erase(erase_begin, metadata_index_list.children.end());
+        new_metadata.lookup_indexes = metadata_index_list.children.empty() ? nullptr : metadata_indexes;
+        auto prepared_metadata = std::make_shared<const StorageInMemoryMetadata>(new_metadata);
+
+        std::unique_lock writer_lock(writer_mutex);
+        const UInt64 current_generation = published_generation.load(std::memory_order_acquire);
+        if (current_generation == std::numeric_limits<UInt64>::max())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "`OverwriteCache` publication generation space is exhausted");
+
+        auto next_lookup_index_columns = lookup_index_columns;
+        auto next_lookup_index_positions = lookup_index_positions;
+        auto next_lookup_index_column_types = lookup_index_column_types;
+        auto next_lookup_indexes = lookup_indexes;
+        const auto next_it = std::ranges::find(next_lookup_index_columns, columns);
+        if (next_it == next_lookup_index_columns.end())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Lookup-index catalog changed while preparing `DROP INDEX`");
+        const size_t position = next_it - next_lookup_index_columns.begin();
+        const UInt64 removed_bytes = next_lookup_indexes[position]->accounted_bytes.load(std::memory_order_relaxed);
+        LookupIndexPtr removed_index = next_lookup_indexes[position];
+        next_lookup_index_columns.erase(next_lookup_index_columns.begin() + position);
+        next_lookup_index_positions.erase(next_lookup_index_positions.begin() + position);
+        next_lookup_index_column_types.erase(next_lookup_index_column_types.begin() + position);
+        next_lookup_indexes.erase(next_lookup_indexes.begin() + position);
+
+        DatabaseCatalog::instance().getDatabase(table_id.database_name)->alterTable(
+            context, table_id, new_metadata, /*validate_new_create_query=*/true);
+
+        {
+            std::unique_lock lock(lookup_catalog_mutex);
+            lookup_index_columns.swap(next_lookup_index_columns);
+            lookup_index_positions.swap(next_lookup_index_positions);
+            lookup_index_column_types.swap(next_lookup_index_column_types);
+            lookup_indexes.swap(next_lookup_indexes);
+        }
+        next_lookup_indexes.clear();
+        published_generation.store(current_generation + 1, std::memory_order_release);
+        const UInt8 old_epoch = active_reader_epoch.fetch_xor(1, std::memory_order_acq_rel);
+        FailPointInjection::pauseFailPoint(FailPoints::overwrite_cache_pause_after_drop_index_publication);
+        UInt64 active = active_readers[old_epoch].load(std::memory_order_acquire);
+        while (active != 0)
+        {
+            active_readers[old_epoch].wait(active, std::memory_order_relaxed);
+            active = active_readers[old_epoch].load(std::memory_order_acquire);
+        }
+        removed_index.reset();
+        total_size_bytes.fetch_sub(removed_bytes, std::memory_order_relaxed);
+        setInMemoryMetadata(std::move(prepared_metadata));
+        return;
+    }
+
+    std::vector<size_t> positions;
+    DataTypes types;
+    positions.reserve(columns.size());
+    types.reserve(columns.size());
+    for (const auto & column : columns)
+    {
+        const auto position = getColumnPosition(column);
+        positions.push_back(position);
+        types.push_back(sample_block.getByPosition(position).type);
+    }
+
+    auto shadow = std::make_shared<LookupIndex>();
+    UInt64 index_bytes = 0;
+    size_t snapshot_entry_count = 0;
+    std::unique_ptr<ReadGuard> snapshot_guard;
+    {
+        std::lock_guard writer_lock(writer_mutex);
+        {
+            std::shared_lock lock(entries_by_id_mutex);
+            snapshot_entry_count = entries_by_id.size();
+        }
+        snapshot_guard = std::make_unique<ReadGuard>(*this);
+    }
+    for (EntryId entry_id = 1; entry_id <= snapshot_entry_count; ++entry_id)
+    {
+        const auto row = resolveEntry(entry_id, snapshot_guard->generation());
+        if (!row)
+            continue;
+        String key = serializeRowColumns(*row, positions);
+        auto & posting = shadow->shards[postingShardIndex(key)].postings[key];
+        posting.push_back(entry_id);
+    }
+    snapshot_guard.reset();
+
+    FailPointInjection::pauseFailPoint(FailPoints::overwrite_cache_pause_during_index_build);
+
+    fiu_do_on(FailPoints::overwrite_cache_throw_during_index_build, {
+        throw Exception(ErrorCodes::FAULT_INJECTED, "Injected failure during `OverwriteCache` lookup-index build");
+    });
+
+    std::unique_lock writer_lock(writer_mutex);
+    size_t catch_up_entry_count = 0;
+    {
+        std::shared_lock lock(entries_by_id_mutex);
+        catch_up_entry_count = entries_by_id.size();
+    }
+    ReadGuard catch_up_guard(*this);
+    for (EntryId entry_id = snapshot_entry_count + 1; entry_id <= catch_up_entry_count; ++entry_id)
+    {
+        const auto row = resolveEntry(entry_id, catch_up_guard.generation());
+        if (!row)
+            continue;
+        String key = serializeRowColumns(*row, positions);
+        auto & posting = shadow->shards[postingShardIndex(key)].postings[key];
+        posting.push_back(entry_id);
+    }
+    for (const auto & shard : shadow->shards)
+    {
+        const UInt64 bucket_bytes = static_cast<UInt64>(shard.postings.bucket_count()) * sizeof(void *);
+        if (index_bytes > std::numeric_limits<UInt64>::max() - bucket_bytes)
+            throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` lookup-index memory accounting overflow");
+        index_bytes += bucket_bytes;
+        for (const auto & [key, posting] : shard.postings)
+        {
+            const UInt64 posting_bytes
+                = key.size() + sizeof(std::pair<const String, PostingShard::Posting>) + 64 + posting.allocatedBytes();
+            if (index_bytes > std::numeric_limits<UInt64>::max() - posting_bytes)
+                throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` lookup-index memory accounting overflow");
+            index_bytes += posting_bytes;
+        }
+    }
+
+    const UInt64 current_bytes = total_size_bytes.load(std::memory_order_relaxed);
+    if (index_bytes > settings.max_memory_bytes - std::min(current_bytes, settings.max_memory_bytes))
+        throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` cannot add lookup index within `max_memory_bytes`");
+
+    auto next_lookup_index_columns = lookup_index_columns;
+    auto next_lookup_index_positions = lookup_index_positions;
+    auto next_lookup_index_column_types = lookup_index_column_types;
+    auto next_lookup_indexes = lookup_indexes;
+    next_lookup_index_columns.reserve(next_lookup_index_columns.size() + 1);
+    next_lookup_index_positions.reserve(next_lookup_index_positions.size() + 1);
+    next_lookup_index_column_types.reserve(next_lookup_index_column_types.size() + 1);
+    next_lookup_indexes.reserve(next_lookup_indexes.size() + 1);
+    next_lookup_index_columns.push_back(columns);
+    next_lookup_index_positions.push_back(positions);
+    next_lookup_index_column_types.push_back(types);
+    next_lookup_indexes.push_back(shadow);
+
+    metadata_index_list.children.push_back(makeLookupIndexAST(columns));
+    new_metadata.lookup_indexes = metadata_indexes;
+    auto prepared_metadata = std::make_shared<const StorageInMemoryMetadata>(new_metadata);
+    DatabaseCatalog::instance().getDatabase(table_id.database_name)->alterTable(
+        context, table_id, new_metadata, /*validate_new_create_query=*/true);
+
+    shadow->accounted_bytes.store(index_bytes, std::memory_order_relaxed);
+    {
+        std::unique_lock lock(lookup_catalog_mutex);
+        lookup_index_columns.swap(next_lookup_index_columns);
+        lookup_index_positions.swap(next_lookup_index_positions);
+        lookup_index_column_types.swap(next_lookup_index_column_types);
+        lookup_indexes.swap(next_lookup_indexes);
+    }
+    total_size_bytes.fetch_add(index_bytes, std::memory_order_relaxed);
+    setInMemoryMetadata(std::move(prepared_metadata));
 }
 
 void StorageOverwriteCache::truncate(const ASTPtr &, const StorageMetadataPtr &, ContextPtr, TableExclusiveLockHolder &)
@@ -1034,6 +1704,13 @@ void registerStorageOverwriteCache(StorageFactory & factory)
             if (!args.storage_def->keys)
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `OverwriteCache` requires a `KEYS (...)` clause");
             Names key_columns = extractIdentifierList(*args.storage_def->keys, "`KEYS` clause");
+            std::vector<Names> lookup_index_columns;
+            if (args.storage_def->lookup_indexes)
+            {
+                lookup_index_columns.reserve(args.storage_def->lookup_indexes->children.size());
+                for (const auto & index_ast : args.storage_def->lookup_indexes->children)
+                    lookup_index_columns.push_back(extractIdentifierList(*index_ast, "lookup `INDEX` clause"));
+            }
             OverwriteCacheSettings settings = parseSettings(*args.storage_def);
 
             validateColumn(args.columns, version_column, "version", true);
@@ -1054,29 +1731,35 @@ void registerStorageOverwriteCache(StorageFactory & factory)
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Duplicate tie-break column {}", backQuote(column));
             }
 
-            std::unordered_set<String> secondary_set;
-            for (const auto & column : settings.secondary_index_columns)
-            {
-                if (!key_set.contains(column))
-                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Secondary-index column {} must be declared in `KEYS`", backQuote(column));
-                if (!secondary_set.emplace(column).second)
-                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Duplicate secondary-index column {}", backQuote(column));
-            }
+            std::unordered_map<String, size_t> key_order;
+            for (size_t position = 0; position < key_columns.size(); ++position)
+                key_order.emplace(key_columns[position], position);
 
-            if (settings.secondary_index_segment_column)
+            std::unordered_set<String> index_signatures;
+            for (auto & index_columns : lookup_index_columns)
             {
-                const auto & segment = *settings.secondary_index_segment_column;
-                if (settings.secondary_index_columns.empty())
-                    throw Exception(
-                        ErrorCodes::BAD_ARGUMENTS, "Setting `secondary_index_segment_column` requires `secondary_index_columns`");
-                if (!key_set.contains(segment))
-                    throw Exception(
-                        ErrorCodes::BAD_ARGUMENTS, "Secondary-index segment column {} must be declared in `KEYS`", backQuote(segment));
-                if (secondary_set.contains(segment))
+                std::unordered_set<String> index_column_set;
+                for (const auto & column : index_columns)
+                {
+                    if (!key_set.contains(column))
+                        throw Exception(
+                            ErrorCodes::BAD_ARGUMENTS, "Lookup-index column {} must be declared in `KEYS`", backQuote(column));
+                    if (!index_column_set.emplace(column).second)
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Duplicate column {} in lookup `INDEX`", backQuote(column));
+                }
+                std::ranges::sort(index_columns, {}, [&](const String & column) { return key_order.at(column); });
+                if (index_columns == key_columns)
                     throw Exception(
                         ErrorCodes::BAD_ARGUMENTS,
-                        "Secondary-index segment column {} cannot also be a secondary-index column",
-                        backQuote(segment));
+                        "Lookup `INDEX` duplicates the complete `KEYS` tuple, which already has a primary index");
+                String signature;
+                for (const auto & column : index_columns)
+                {
+                    signature += column;
+                    signature.push_back('\0');
+                }
+                if (!index_signatures.emplace(signature).second)
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Duplicate lookup `INDEX` declaration");
             }
 
             return std::make_shared<StorageOverwriteCache>(
@@ -1086,12 +1769,15 @@ void registerStorageOverwriteCache(StorageFactory & factory)
                 args.comment,
                 version_column,
                 std::move(key_columns),
+                std::move(lookup_index_columns),
+                args.storage_def->lookup_indexes ? args.storage_def->lookup_indexes->clone() : nullptr,
                 std::move(settings),
-                args.storage_def->settings->clone());
+                args.storage_def->settings ? args.storage_def->settings->clone() : nullptr);
         },
         {
             .supports_settings = true,
             .supports_keys = true,
+            .supports_lookup_indexes = true,
             .has_builtin_setting_fn = isOverwriteCacheSetting,
         });
 }

--- a/src/Storages/StorageOverwriteCache.cpp
+++ b/src/Storages/StorageOverwriteCache.cpp
@@ -53,7 +53,9 @@ extern const int UNKNOWN_SETTING;
 namespace FailPoints
 {
 extern const char overwrite_cache_pause_after_lookup_catalog_snapshot[];
+extern const char overwrite_cache_pause_after_lookup_ids[];
 extern const char overwrite_cache_pause_after_drop_index_publication[];
+extern const char overwrite_cache_pause_before_rollback[];
 extern const char overwrite_cache_pause_before_commit[];
 extern const char overwrite_cache_pause_during_index_build[];
 extern const char overwrite_cache_pause_during_lookup[];
@@ -1075,6 +1077,7 @@ void StorageOverwriteCache::insertBlock(const Block & block)
     }
     catch (...)
     {
+        FailPointInjection::pauseFailPoint(FailPoints::overwrite_cache_pause_before_rollback);
         UInt64 retained_bytes = entries_capacity_delta;
         for (const UInt64 bucket_delta : primary_bucket_bytes_delta)
             retained_bytes += bucket_delta;
@@ -1116,13 +1119,27 @@ void StorageOverwriteCache::insertBlock(const Block & block)
             std::unique_lock lock(shard.mutex);
             shard.entries.erase(mutation.key);
         }
+
+        total_size_bytes.fetch_add(retained_bytes, std::memory_order_relaxed);
+        for (size_t index = 0; index < retained_lookup_bytes.size(); ++index)
+            lookup_indexes[index]->accounted_bytes.fetch_add(retained_lookup_bytes[index], std::memory_order_relaxed);
+
+        if (new_entries != 0)
+        {
+            /// A reader may have copied an identifier from a posting before rollback removed it.
+            /// Keep the dense entry slots alive until every such reader has left its epoch.
+            const UInt8 old_epoch = active_reader_epoch.fetch_xor(1, std::memory_order_acq_rel);
+            UInt64 active = active_readers[old_epoch].load(std::memory_order_acquire);
+            while (active != 0)
+            {
+                active_readers[old_epoch].wait(active, std::memory_order_relaxed);
+                active = active_readers[old_epoch].load(std::memory_order_acquire);
+            }
+        }
         {
             std::unique_lock lock(entries_by_id_mutex);
             entries_by_id.resize(old_entries_by_id_size);
         }
-        total_size_bytes.fetch_add(retained_bytes, std::memory_order_relaxed);
-        for (size_t index = 0; index < retained_lookup_bytes.size(); ++index)
-            lookup_indexes[index]->accounted_bytes.fetch_add(retained_lookup_bytes[index], std::memory_order_relaxed);
         throw;
     }
 
@@ -1294,6 +1311,8 @@ StorageOverwriteCache::ReadResult StorageOverwriteCache::getRowsForLookupRequest
         if (index != driver)
             intersectPostingIds(entry_ids, requests[index].index, requests[index].serialized_keys);
     }
+
+    FailPointInjection::pauseFailPoint(FailPoints::overwrite_cache_pause_after_lookup_ids);
 
     result.rows.reserve(entry_ids.size());
     for (size_t position = 0; position < entry_ids.size(); ++position)

--- a/src/Storages/StorageOverwriteCache.cpp
+++ b/src/Storages/StorageOverwriteCache.cpp
@@ -597,13 +597,6 @@ void StorageOverwriteCache::EntryTable::grow(size_t new_size)
     entry_count.store(new_size, std::memory_order_release);
 }
 
-void StorageOverwriteCache::EntryTable::shrink(size_t new_size)
-{
-    for (size_t index = new_size; index < entry_count.load(std::memory_order_relaxed); ++index)
-        at(index + 1) = Entry{};
-    entry_count.store(new_size, std::memory_order_release);
-}
-
 void StorageOverwriteCache::EntryTable::clear()
 {
     entry_count.store(0, std::memory_order_release);
@@ -631,13 +624,70 @@ StorageOverwriteCache::ReadGuard::ReadGuard(const StorageOverwriteCache & storag
             storage.active_readers[epoch].notify_all();
     }
 
+    /// Registering the snapshot under the same lock a writer uses to compute the pruning watermark
+    /// keeps a writer from dropping a version this guard is about to rely on.
+    std::lock_guard registry_lock(storage.snapshot_registry_mutex);
     snapshot_generation = storage.published_generation.load(std::memory_order_acquire);
+    ++storage.live_snapshots[snapshot_generation];
 }
 
 StorageOverwriteCache::ReadGuard::~ReadGuard()
 {
+    {
+        std::lock_guard registry_lock(storage.snapshot_registry_mutex);
+        const auto it = storage.live_snapshots.find(snapshot_generation);
+        if (it != storage.live_snapshots.end() && --it->second == 0)
+            storage.live_snapshots.erase(it);
+    }
+
     if (storage.active_readers[epoch].fetch_sub(1, std::memory_order_acq_rel) == 1)
         storage.active_readers[epoch].notify_all();
+}
+
+UInt64 StorageOverwriteCache::oldestLiveGeneration() const
+{
+    std::lock_guard registry_lock(snapshot_registry_mutex);
+    if (live_snapshots.empty())
+        return published_generation.load(std::memory_order_acquire);
+    return live_snapshots.begin()->first;
+}
+
+std::unique_ptr<StorageOverwriteCache::EntryVersion> StorageOverwriteCache::takeVersion()
+{
+    if (!recycled_versions)
+        return std::make_unique<EntryVersion>();
+    auto version = std::move(recycled_versions);
+    recycled_versions = std::move(version->older);
+    --recycled_version_count;
+    return version;
+}
+
+void StorageOverwriteCache::recycleVersions(std::unique_ptr<EntryVersion> chain)
+{
+    while (chain)
+    {
+        auto version = std::move(chain);
+        chain = std::move(version->older);
+        if (recycled_version_count >= max_recycled_versions)
+            continue;
+        /// Drop the row so a recycled version stops keeping its segment alive.
+        version->row = RowData{};
+        version->generation = 0;
+        version->older = std::move(recycled_versions);
+        recycled_versions = std::move(version);
+        ++recycled_version_count;
+    }
+}
+
+void StorageOverwriteCache::drainReaders()
+{
+    const UInt8 old_epoch = active_reader_epoch.fetch_xor(1, std::memory_order_acq_rel);
+    UInt64 active = active_readers[old_epoch].load(std::memory_order_acquire);
+    while (active != 0)
+    {
+        active_readers[old_epoch].wait(active, std::memory_order_relaxed);
+        active = active_readers[old_epoch].load(std::memory_order_acquire);
+    }
 }
 
 size_t StorageOverwriteCache::rowLockIndex(EntryId entry_id) const
@@ -659,10 +709,12 @@ StorageOverwriteCache::RowDataPtr StorageOverwriteCache::resolveEntry(EntryId en
     if (entry_id == 0 || entry_id > entries.size())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` entry identifier");
     std::lock_guard row_lock(row_mutexes[rowLockIndex(entry_id)]);
-    const auto & entry = entries.at(entry_id);
-    if (entry.pending_generation != 0 && entry.pending_generation <= snapshot_generation)
-        return *entry.pending;
-    return entry.committed;
+    for (const auto * version = entries.at(entry_id).head.get(); version; version = version->older.get())
+    {
+        if (version->generation <= snapshot_generation)
+            return version->row;
+    }
+    return {};
 }
 
 void StorageOverwriteCache::insertBlock(const Block & input_block)
@@ -720,7 +772,7 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
         std::optional<RowData> previous;
         bool is_new = false;
         bool primary_inserted = false;
-        bool pending_installed = false;
+        bool version_installed = false;
     };
 
     FailPointInjection::pauseFailPoint(FailPoints::overwrite_cache_pause_after_lookup_catalog_snapshot);
@@ -853,10 +905,10 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
                 continue;
             const auto & entry = entries.at(entry_id);
             std::lock_guard row_lock(row_mutexes[rowLockIndex(entry_id)]);
-            if (!entry.committed || entry.committed->segment.get() != compaction.source.get()
-                || entry.committed->segment_row != row)
+            if (!entry.head || entry.head->row.segment.get() != compaction.source.get()
+                || entry.head->row.segment_row != row)
                 continue;
-            compaction.live_entries.emplace_back(entry_id, *entry.committed);
+            compaction.live_entries.emplace_back(entry_id, entry.head->row);
         }
     }
 
@@ -1099,17 +1151,18 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
                 prospective_bytes,
                 settings.max_memory_bytes);
 
-        /// Install the pending rows before the keys become reachable, so a reader that finds a key
-        /// either resolves the new row or sees nothing committed yet.
+        /// Push the new versions before the keys become reachable. They carry the not-yet-published
+        /// generation, so no reader can see them until `published_generation` is bumped.
         for (auto & mutation : mutations)
         {
             auto & entry = entries.at(mutation.entry_id);
+            auto version = takeVersion();
+            version->row = std::move(*mutation.row);
+            version->generation = new_generation;
             std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry_id)]);
-            if (entry.pending_generation != 0)
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "Concurrent `OverwriteCache` publication for the same entry");
-            entry.pending = std::move(mutation.row);
-            entry.pending_generation = new_generation;
-            mutation.pending_installed = true;
+            version->older = std::move(entry.head);
+            entry.head = std::move(version);
+            mutation.version_installed = true;
         }
 
         for (size_t shard_index = 0; shard_index < primary_shard_count; ++shard_index)
@@ -1157,12 +1210,17 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
             retained_bytes += bucket_delta;
         for (auto & mutation : mutations)
         {
-            if (!mutation.pending_installed)
+            if (!mutation.version_installed)
                 continue;
             auto & entry = entries.at(mutation.entry_id);
-            std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry_id)]);
-            entry.pending.reset();
-            entry.pending_generation = 0;
+            std::unique_ptr<EntryVersion> discarded;
+            {
+                std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry_id)]);
+                discarded = std::move(entry.head);
+                entry.head = std::move(discarded->older);
+            }
+            discarded->older.reset();
+            recycleVersions(std::move(discarded));
         }
         for (const auto & prepared : prepared_postings)
         {
@@ -1187,19 +1245,10 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
         for (size_t index = 0; index < lookup_bytes_delta.size(); ++index)
             lookup_indexes[index]->accounted_bytes.fetch_add(lookup_bytes_delta[index], std::memory_order_relaxed);
 
-        if (new_entries != 0)
-        {
-            /// A reader may have copied an identifier from a posting before rollback removed it.
-            /// Keep the dense entry slots alive until every such reader has left its epoch.
-            const UInt8 old_epoch = active_reader_epoch.fetch_xor(1, std::memory_order_acq_rel);
-            UInt64 active = active_readers[old_epoch].load(std::memory_order_acquire);
-            while (active != 0)
-            {
-                active_readers[old_epoch].wait(active, std::memory_order_relaxed);
-                active = active_readers[old_epoch].load(std::memory_order_acquire);
-            }
-        }
-        entries.shrink(old_entry_count);
+        /// The slots staged for this block keep their identifiers: a reader may have copied one from a
+        /// posting before rollback removed it, and an empty slot resolves to no row. Reusing them would
+        /// need a wait for readers, which is exactly what publication must never do.
+        next_entry_id = staged_next_entry_id;
         throw;
     }
 
@@ -1219,25 +1268,29 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
             retired_segments.push_back(mutation.previous->segment);
     }
 
-    const UInt8 old_epoch = active_reader_epoch.fetch_xor(1, std::memory_order_acq_rel);
-    UInt64 active = active_readers[old_epoch].load(std::memory_order_acquire);
-    while (active != 0)
-    {
-        active_readers[old_epoch].wait(active, std::memory_order_relaxed);
-        active = active_readers[old_epoch].load(std::memory_order_acquire);
-    }
-
     for (const auto & retired_segment : retired_segments)
         reclaim_bytes += retired_segment->allocated_bytes;
     total_size_bytes.fetch_sub(reclaim_bytes, std::memory_order_relaxed);
 
-    for (auto & mutation : mutations)
+    /// Drop the versions no live snapshot can reach any more. A reader holding an older snapshot keeps
+    /// its versions instead of forcing this writer to wait for it.
+    const UInt64 watermark = oldestLiveGeneration();
+    for (const auto & mutation : mutations)
     {
         auto & entry = entries.at(mutation.entry_id);
-        std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry_id)]);
-        entry.committed = std::move(*entry.pending);
-        entry.pending.reset();
-        entry.pending_generation = 0;
+        std::unique_ptr<EntryVersion> obsolete;
+        {
+            std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry_id)]);
+            for (auto * version = entry.head.get(); version; version = version->older.get())
+            {
+                if (version->generation <= watermark)
+                {
+                    obsolete = std::move(version->older);
+                    break;
+                }
+            }
+        }
+        recycleVersions(std::move(obsolete));
     }
 }
 
@@ -1516,14 +1569,10 @@ void StorageOverwriteCache::clearData()
         shard.arena = std::make_unique<Arena>();
     }
     /// Entries are reachable without a lock, so no reader that already resolved an identifier may
-    /// still be inside the table when its storage is released.
-    const UInt8 old_epoch = active_reader_epoch.fetch_xor(1, std::memory_order_acq_rel);
-    UInt64 active = active_readers[old_epoch].load(std::memory_order_acquire);
-    while (active != 0)
-    {
-        active_readers[old_epoch].wait(active, std::memory_order_relaxed);
-        active = active_readers[old_epoch].load(std::memory_order_acquire);
-    }
+    /// still be inside the table when its storage is released. Unlike publication, releasing storage
+    /// outright has no alternative to waiting - and `TRUNCATE` and `DROP` already hold the table
+    /// exclusively, so nothing can be reading through this storage anyway.
+    drainReaders();
     entries.clear();
     next_entry_id = 1;
     published_generation.store(0, std::memory_order_release);
@@ -1634,14 +1683,8 @@ void StorageOverwriteCache::alter(const AlterCommands & commands, ContextPtr con
         }
         next_lookup_indexes.clear();
         published_generation.store(current_generation + 1, std::memory_order_release);
-        const UInt8 old_epoch = active_reader_epoch.fetch_xor(1, std::memory_order_acq_rel);
         FailPointInjection::pauseFailPoint(FailPoints::overwrite_cache_pause_after_drop_index_publication);
-        UInt64 active = active_readers[old_epoch].load(std::memory_order_acquire);
-        while (active != 0)
-        {
-            active_readers[old_epoch].wait(active, std::memory_order_relaxed);
-            active = active_readers[old_epoch].load(std::memory_order_acquire);
-        }
+        drainReaders();
         removed_index.reset();
         total_size_bytes.fetch_sub(removed_bytes, std::memory_order_relaxed);
         setInMemoryMetadata(std::move(prepared_metadata));

--- a/src/Storages/StorageOverwriteCache.cpp
+++ b/src/Storages/StorageOverwriteCache.cpp
@@ -1,0 +1,1099 @@
+#include <Storages/StorageOverwriteCache.h>
+
+#include <Core/Block.h>
+#include <DataTypes/IDataType.h>
+#include <IO/WriteBufferFromString.h>
+#include <Interpreters/Context.h>
+#include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTSetQuery.h>
+#include <Processors/ISource.h>
+#include <Processors/QueryPlan/QueryPlan.h>
+#include <Processors/QueryPlan/QueryPlanFormat.h>
+#include <Processors/QueryPlan/SourceStepWithFilter.h>
+#include <Processors/Sinks/SinkToStorage.h>
+#include <QueryPipeline/Pipe.h>
+#include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Storages/KVStorageUtils.h>
+#include <Storages/StorageFactory.h>
+#include <Storages/extractKeyExpressionList.h>
+#include <Common/Exception.h>
+#include <Common/FailPoint.h>
+#include <Common/quoteString.h>
+
+#include <algorithm>
+#include <cctype>
+#include <iterator>
+#include <limits>
+#include <utility>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int BAD_ARGUMENTS;
+extern const int FAULT_INJECTED;
+extern const int LOGICAL_ERROR;
+extern const int MEMORY_LIMIT_EXCEEDED;
+extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+extern const int TYPE_MISMATCH;
+extern const int UNKNOWN_SETTING;
+}
+
+namespace FailPoints
+{
+extern const char overwrite_cache_pause_before_commit[];
+extern const char overwrite_cache_throw_during_publish[];
+}
+
+namespace
+{
+
+Names parseColumnList(const String & value, const String & setting_name)
+{
+    Names result;
+    size_t begin = 0;
+    while (begin <= value.size())
+    {
+        size_t end = value.find(',', begin);
+        if (end == String::npos)
+            end = value.size();
+
+        size_t first = begin;
+        while (first < end && std::isspace(static_cast<unsigned char>(value[first])))
+            ++first;
+        size_t last = end;
+        while (last > first && std::isspace(static_cast<unsigned char>(value[last - 1])))
+            --last;
+
+        if (last > first)
+            result.emplace_back(value.substr(first, last - first));
+        else if (!value.empty())
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Setting {} contains an empty column name", backQuote(setting_name));
+
+        if (end == value.size())
+            break;
+        begin = end + 1;
+    }
+    return result;
+}
+
+UInt64 getUInt64Setting(const SettingChange & change)
+{
+    if (change.value.getType() == Field::Types::UInt64)
+        return change.value.safeGet<UInt64>();
+    if (change.value.getType() == Field::Types::Int64)
+    {
+        const auto value = change.value.safeGet<Int64>();
+        if (value >= 0)
+            return static_cast<UInt64>(value);
+    }
+    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Setting {} must be a non-negative UInt64", backQuote(change.name));
+}
+
+String getStringSetting(const SettingChange & change)
+{
+    if (change.value.getType() != Field::Types::String)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Setting {} must be a String", backQuote(change.name));
+    return change.value.safeGet<String>();
+}
+
+OverwriteCacheSettings parseSettings(const ASTStorage & storage_def)
+{
+    OverwriteCacheSettings result;
+    if (!storage_def.settings)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Storage `OverwriteCache` requires setting `max_memory_bytes`");
+
+    for (const auto & change : storage_def.settings->changes)
+    {
+        if (change.name == "max_memory_bytes")
+            result.max_memory_bytes = getUInt64Setting(change);
+        else if (change.name == "equal_version_tiebreak_columns")
+            result.equal_version_tiebreak_columns = parseColumnList(getStringSetting(change), change.name);
+        else if (change.name == "secondary_index_columns")
+            result.secondary_index_columns = parseColumnList(getStringSetting(change), change.name);
+        else if (change.name == "secondary_index_segment_column")
+        {
+            auto value = getStringSetting(change);
+            if (!value.empty())
+                result.secondary_index_segment_column = std::move(value);
+        }
+        else if (change.name == "max_secondary_index_rows")
+            result.max_secondary_index_rows = getUInt64Setting(change);
+        else
+            throw Exception(ErrorCodes::UNKNOWN_SETTING, "Unknown setting {} for storage `OverwriteCache`", backQuote(change.name));
+    }
+
+    if (!result.max_memory_bytes)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Storage `OverwriteCache` requires a positive `max_memory_bytes`");
+    if (!result.secondary_index_columns.empty() && !result.max_secondary_index_rows)
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Storage `OverwriteCache` requires a positive `max_secondary_index_rows` when `secondary_index_columns` is set");
+
+    return result;
+}
+
+Names extractIdentifierList(const IAST & key_ast, const String & clause_name)
+{
+    auto list = key_ast.as<ASTExpressionList>() ? key_ast.clone() : extractKeyExpressionList(key_ast.clone());
+    Names result;
+    std::unordered_set<String> seen;
+    for (const auto & child : list->children)
+    {
+        const auto * identifier = child->as<ASTIdentifier>();
+        if (!identifier || identifier->compound())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS, "{} of storage `OverwriteCache` must contain only unqualified column identifiers", clause_name);
+        const auto & name = identifier->name();
+        if (!seen.emplace(name).second)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Duplicate column {} in {}", backQuote(name), clause_name);
+        result.push_back(name);
+    }
+    if (result.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "{} of storage `OverwriteCache` cannot be empty", clause_name);
+    return result;
+}
+
+void validateColumn(const ColumnsDescription & columns, const String & name, const String & role, bool require_comparable)
+{
+    if (!columns.has(name))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown {} column {} for storage `OverwriteCache`", role, backQuote(name));
+    const auto & type = columns.get(name).type;
+    if (require_comparable && !type->isComparable())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "{} column {} has non-comparable type {}", role, backQuote(name), type->getName());
+}
+
+bool isOverwriteCacheSetting(std::string_view name)
+{
+    return name == "max_memory_bytes" || name == "equal_version_tiebreak_columns" || name == "secondary_index_columns"
+        || name == "secondary_index_segment_column" || name == "max_secondary_index_rows";
+}
+
+class OverwriteCacheSink final : public SinkToStorage
+{
+public:
+    OverwriteCacheSink(StorageOverwriteCache & storage_, const StorageMetadataPtr & metadata_snapshot_)
+        : SinkToStorage(std::make_shared<const Block>(metadata_snapshot_->getSampleBlock()))
+        , storage(storage_)
+    {
+    }
+
+    String getName() const override { return "OverwriteCacheSink"; }
+
+    void consume(Chunk & chunk) override { storage.insertBlock(getHeader().cloneWithColumns(chunk.getColumns())); }
+
+private:
+    StorageOverwriteCache & storage;
+};
+
+class OverwriteCacheSource final : public ISource
+{
+public:
+    OverwriteCacheSource(
+        SharedHeader header_, StorageOverwriteCache::RowDataPtrs rows_, std::vector<size_t> positions_, size_t max_block_size_)
+        : ISource(std::move(header_))
+        , rows(std::move(rows_))
+        , positions(std::move(positions_))
+        , max_block_size(std::max<size_t>(1, max_block_size_))
+    {
+    }
+
+    String getName() const override { return "OverwriteCacheSource"; }
+
+protected:
+    Chunk generate() override
+    {
+        if (offset >= rows.size())
+            return {};
+
+        const size_t rows_to_emit = std::min(max_block_size, rows.size() - offset);
+        const auto & header = getPort().getHeader();
+        MutableColumns columns(header.columns());
+        for (size_t i = 0; i < columns.size(); ++i)
+            columns[i] = header.getByPosition(i).type->createColumn();
+
+        for (size_t row = offset; row < offset + rows_to_emit; ++row)
+        {
+            for (size_t column = 0; column < positions.size(); ++column)
+                columns[column]->insert(rows[row]->values[positions[column]]);
+        }
+
+        offset += rows_to_emit;
+        return Chunk(std::move(columns), rows_to_emit);
+    }
+
+private:
+    StorageOverwriteCache::RowDataPtrs rows;
+    std::vector<size_t> positions;
+    size_t max_block_size;
+    size_t offset = 0;
+};
+
+class ReadFromOverwriteCache final : public SourceStepWithFilter
+{
+public:
+    ReadFromOverwriteCache(
+        const Names & column_names_,
+        const SelectQueryInfo & query_info_,
+        const StorageSnapshotPtr & storage_snapshot_,
+        ContextPtr context_,
+        SharedHeader sample_block_,
+        const StorageOverwriteCache & storage_,
+        size_t max_block_size_)
+        : SourceStepWithFilter(std::move(sample_block_), column_names_, query_info_, storage_snapshot_, context_)
+        , storage(storage_)
+        , max_block_size(std::max<size_t>(1, max_block_size_))
+    {
+    }
+
+    String getName() const override { return "ReadFromOverwriteCache"; }
+
+    void applyFilters(ActionDAGNodes added_filter_nodes) override
+    {
+        SourceStepWithFilter::applyFilters(std::move(added_filter_nodes));
+
+        std::tie(filter_keys, all_scan)
+            = getFilterKeys(storage.getKeyColumns(), storage.getKeyColumnTypes(), filter_actions_dag.get(), context);
+        if (!all_scan)
+        {
+            read_kind = ReadKind::Primary;
+            return;
+        }
+
+        if (!storage.getSecondaryIndexColumns().empty())
+        {
+            if (!storage.getSegmentedSecondaryIndexColumns().empty())
+            {
+                std::tie(filter_keys, all_scan) = getFilterKeys(
+                    storage.getSegmentedSecondaryIndexColumns(),
+                    storage.getSegmentedSecondaryIndexColumnTypes(),
+                    filter_actions_dag.get(),
+                    context);
+                if (!all_scan)
+                {
+                    read_kind = ReadKind::SegmentedSecondary;
+                    return;
+                }
+            }
+
+            std::tie(filter_keys, all_scan) = getFilterKeys(
+                storage.getSecondaryIndexColumns(), storage.getSecondaryIndexColumnTypes(), filter_actions_dag.get(), context);
+            if (!all_scan)
+                read_kind = ReadKind::Secondary;
+        }
+    }
+
+    void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override
+    {
+        if (read_kind == ReadKind::None || all_scan || !filter_keys)
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Storage `OverwriteCache` requires a complete `KEYS` predicate or an equality/IN predicate on all "
+                "`secondary_index_columns`");
+
+        auto iterator = filter_keys->cbegin();
+        std::vector<String> serialized_keys;
+        StorageOverwriteCache::RowDataPtrs rows;
+        if (read_kind == ReadKind::Primary)
+        {
+            while (iterator != filter_keys->cend())
+            {
+                auto batch = serializeKeysToRawString(iterator, filter_keys->cend(), storage.getKeyColumnTypes(), max_block_size);
+                serialized_keys.insert(serialized_keys.end(), std::make_move_iterator(batch.begin()), std::make_move_iterator(batch.end()));
+            }
+            rows = storage.getRowsForPrimaryKeys(serialized_keys);
+        }
+        else if (read_kind == ReadKind::Secondary)
+        {
+            while (iterator != filter_keys->cend())
+            {
+                auto batch
+                    = serializeKeysToRawString(iterator, filter_keys->cend(), storage.getSecondaryIndexColumnTypes(), max_block_size);
+                serialized_keys.insert(serialized_keys.end(), std::make_move_iterator(batch.begin()), std::make_move_iterator(batch.end()));
+            }
+            rows = storage.getRowsForSecondaryKeys(serialized_keys);
+        }
+        else
+        {
+            while (iterator != filter_keys->cend())
+            {
+                auto batch = serializeKeysToRawString(
+                    iterator, filter_keys->cend(), storage.getSegmentedSecondaryIndexColumnTypes(), max_block_size);
+                serialized_keys.insert(serialized_keys.end(), std::make_move_iterator(batch.begin()), std::make_move_iterator(batch.end()));
+            }
+            rows = storage.getRowsForSegmentedSecondaryKeys(serialized_keys);
+        }
+
+        std::vector<size_t> positions;
+        positions.reserve(getOutputHeader()->columns());
+        for (const auto & column : *getOutputHeader())
+            positions.push_back(storage.getColumnPosition(column.name));
+
+        auto source = std::make_shared<OverwriteCacheSource>(getOutputHeader(), std::move(rows), std::move(positions), max_block_size);
+        source->setStorageLimits(query_info.storage_limits);
+        pipeline.init(Pipe(std::move(source)));
+    }
+
+    void describeActions(FormatSettings & format_settings) const override
+    {
+        SourceStepWithFilter::describeActions(format_settings);
+        format_settings.out << format_settings.detail_prefix
+                            << "ReadType: " << (read_kind == ReadKind::Primary ? "PrimaryKey" : "SecondaryIndex") << '\n';
+    }
+
+private:
+    enum class ReadKind : UInt8
+    {
+        None,
+        Primary,
+        Secondary,
+        SegmentedSecondary,
+    };
+
+    const StorageOverwriteCache & storage;
+    size_t max_block_size;
+    FieldVectorPtr filter_keys;
+    bool all_scan = true;
+    ReadKind read_kind = ReadKind::None;
+};
+
+}
+
+StorageOverwriteCache::StorageOverwriteCache(
+    const StorageID & table_id_,
+    ColumnsDescription columns_description_,
+    ConstraintsDescription constraints_,
+    String comment_,
+    String version_column_,
+    Names key_columns_,
+    OverwriteCacheSettings settings_,
+    ASTPtr settings_changes_)
+    : IStorage(table_id_)
+    , version_column(std::move(version_column_))
+    , key_columns(std::move(key_columns_))
+    , settings(std::move(settings_))
+{
+    StorageInMemoryMetadata metadata;
+    metadata.setColumns(std::move(columns_description_));
+    metadata.setConstraints(std::move(constraints_));
+    metadata.setComment(std::move(comment_));
+    metadata.setSettingsChanges(std::move(settings_changes_));
+    setInMemoryMetadata(metadata);
+
+    sample_block = metadata.getSampleBlock();
+    serializations = sample_block.getSerializations();
+    column_types = sample_block.getDataTypes();
+
+    for (size_t position = 0; position < sample_block.columns(); ++position)
+        column_positions.emplace(sample_block.getByPosition(position).name, position);
+
+    version_position = getColumnPosition(version_column);
+    for (const auto & name : key_columns)
+    {
+        const auto position = getColumnPosition(name);
+        key_positions.push_back(position);
+        key_column_types.push_back(sample_block.getByPosition(position).type);
+    }
+    for (const auto & name : settings.equal_version_tiebreak_columns)
+        tiebreak_positions.push_back(getColumnPosition(name));
+    for (const auto & name : settings.secondary_index_columns)
+    {
+        const auto position = getColumnPosition(name);
+        secondary_index_positions.push_back(position);
+        secondary_index_column_types.push_back(sample_block.getByPosition(position).type);
+    }
+    if (settings.secondary_index_segment_column)
+    {
+        segmented_secondary_index_columns.push_back(*settings.secondary_index_segment_column);
+        segmented_secondary_index_columns.insert(
+            segmented_secondary_index_columns.end(), settings.secondary_index_columns.begin(), settings.secondary_index_columns.end());
+        for (const auto & name : segmented_secondary_index_columns)
+        {
+            const auto position = getColumnPosition(name);
+            segmented_secondary_index_positions.push_back(position);
+            segmented_secondary_index_column_types.push_back(sample_block.getByPosition(position).type);
+        }
+    }
+}
+
+size_t StorageOverwriteCache::getColumnPosition(const String & column_name) const
+{
+    const auto it = column_positions.find(column_name);
+    if (it == column_positions.end())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown column {} in storage `OverwriteCache`", backQuote(column_name));
+    return it->second;
+}
+
+String StorageOverwriteCache::serializeColumns(const Block & block, size_t row, const std::vector<size_t> & positions) const
+{
+    WriteBufferFromOwnString out;
+    for (const auto position : positions)
+        serializations[position]->serializeBinary(*block.getByPosition(position).column, row, out, {});
+    return out.str();
+}
+
+String StorageOverwriteCache::serializeFields(const std::vector<Field> & fields, const std::vector<size_t> & positions) const
+{
+    WriteBufferFromOwnString out;
+    for (const auto position : positions)
+        serializations[position]->serializeBinary(fields[position], out, {});
+    return out.str();
+}
+
+int StorageOverwriteCache::compareWinner(const RowData & lhs, const RowData & rhs) const
+{
+    const auto compare_field = [](const Field & left, const Field & right)
+    {
+        if (left < right)
+            return -1;
+        if (right < left)
+            return 1;
+        return 0;
+    };
+
+    if (const int result = compare_field(lhs.values[version_position], rhs.values[version_position]))
+        return result;
+
+    for (const auto position : tiebreak_positions)
+    {
+        if (const int result = compare_field(lhs.values[position], rhs.values[position]))
+            return result;
+    }
+
+    if (!rowsEqual(lhs, rhs))
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS, "Conflicting rows for the same `OverwriteCache` key have identical version and tie-break values");
+    return 0;
+}
+
+bool StorageOverwriteCache::rowsEqual(const RowData & lhs, const RowData & rhs) const
+{
+    return lhs.values == rhs.values;
+}
+
+UInt64 StorageOverwriteCache::estimateRowBytes(const Block & block, size_t row, const RowData & data) const
+{
+    UInt64 payload_bytes = 0;
+    for (const auto & column : block)
+        payload_bytes += column.column->byteSizeAt(row);
+
+    constexpr UInt64 entry_overhead = 256;
+    return entry_overhead + static_cast<UInt64>(sizeof(Field) * data.values.size()) + static_cast<UInt64>(data.primary_key.size())
+        + static_cast<UInt64>(data.secondary_key.size()) + static_cast<UInt64>(data.segmented_secondary_key.size()) + payload_bytes;
+}
+
+StorageOverwriteCache::ReadGuard::ReadGuard(const StorageOverwriteCache & storage_)
+    : storage(storage_)
+{
+    while (true)
+    {
+        epoch = storage.active_reader_epoch.load(std::memory_order_acquire);
+        storage.active_readers[epoch].fetch_add(1, std::memory_order_acq_rel);
+        if (epoch == storage.active_reader_epoch.load(std::memory_order_acquire))
+            break;
+
+        if (storage.active_readers[epoch].fetch_sub(1, std::memory_order_acq_rel) == 1)
+            storage.active_readers[epoch].notify_all();
+    }
+
+    snapshot_generation = storage.published_generation.load(std::memory_order_acquire);
+}
+
+StorageOverwriteCache::ReadGuard::~ReadGuard()
+{
+    if (storage.active_readers[epoch].fetch_sub(1, std::memory_order_acq_rel) == 1)
+        storage.active_readers[epoch].notify_all();
+}
+
+size_t StorageOverwriteCache::primaryShardIndex(const String & key) const
+{
+    return std::hash<String>{}(key) % primary_shard_count;
+}
+
+size_t StorageOverwriteCache::postingShardIndex(const String & key) const
+{
+    return std::hash<String>{}(key) % posting_shard_count;
+}
+
+size_t StorageOverwriteCache::rowLockIndex(EntryId entry_id) const
+{
+    return std::hash<EntryId>{}(entry_id) % row_lock_count;
+}
+
+StorageOverwriteCache::EntryPtr StorageOverwriteCache::findEntry(const String & key) const
+{
+    const auto & shard = primary_shards[primaryShardIndex(key)];
+    std::shared_lock lock(shard.mutex);
+    if (const auto it = shard.entries.find(key); it != shard.entries.end())
+        return it->second;
+    return {};
+}
+
+StorageOverwriteCache::RowDataPtr StorageOverwriteCache::resolveEntry(const EntryPtr & entry, UInt64 snapshot_generation) const
+{
+    std::lock_guard lock(row_mutexes[rowLockIndex(entry->id)]);
+    if (entry->pending_publication && entry->pending_publication->generation <= snapshot_generation
+        && entry->pending_publication->state.load(std::memory_order_acquire) == PublicationState::Committed)
+        return entry->pending;
+    return entry->committed;
+}
+
+void StorageOverwriteCache::insertBlock(const Block & block)
+{
+    std::unordered_map<String, std::shared_ptr<RowData>> candidates;
+    candidates.reserve(block.rows());
+
+    for (size_t row = 0; row < block.rows(); ++row)
+    {
+        auto candidate = std::make_shared<RowData>();
+        candidate->values.reserve(block.columns());
+        for (const auto & column : block)
+        {
+            Field value;
+            column.column->get(row, value);
+            candidate->values.push_back(std::move(value));
+        }
+        candidate->primary_key = serializeColumns(block, row, key_positions);
+        if (!secondary_index_positions.empty())
+            candidate->secondary_key = serializeColumns(block, row, secondary_index_positions);
+        if (!segmented_secondary_index_positions.empty())
+            candidate->segmented_secondary_key = serializeColumns(block, row, segmented_secondary_index_positions);
+        candidate->accounted_bytes = estimateRowBytes(block, row, *candidate);
+
+        auto [it, inserted] = candidates.emplace(candidate->primary_key, candidate);
+        if (!inserted && compareWinner(*candidate, *it->second) > 0)
+            it->second = std::move(candidate);
+    }
+
+    struct Mutation
+    {
+        String key;
+        EntryPtr entry;
+        std::shared_ptr<RowData> row;
+        bool is_new = false;
+        bool primary_inserted = false;
+        bool pending_installed = false;
+    };
+
+    std::lock_guard writer_lock(writer_mutex);
+    UInt64 prospective_bytes = total_size_bytes.load(std::memory_order_relaxed);
+    std::vector<Mutation> mutations;
+    mutations.reserve(candidates.size());
+
+    for (auto & [key, candidate] : candidates)
+    {
+        auto entry = findEntry(key);
+        if (!entry)
+        {
+            if (prospective_bytes > std::numeric_limits<UInt64>::max() - candidate->accounted_bytes)
+                throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
+            prospective_bytes += candidate->accounted_bytes;
+            mutations.push_back({key, {}, std::move(candidate), true});
+            continue;
+        }
+
+        const auto current = resolveEntry(entry, published_generation.load(std::memory_order_acquire));
+        if (!current)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Corrupted `OverwriteCache` primary index");
+
+        const int winner = compareWinner(*candidate, *current);
+        if (winner <= 0)
+            continue;
+
+        prospective_bytes -= current->accounted_bytes;
+        if (prospective_bytes > std::numeric_limits<UInt64>::max() - candidate->accounted_bytes)
+            throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
+        prospective_bytes += candidate->accounted_bytes;
+        mutations.push_back({key, std::move(entry), std::move(candidate), false});
+    }
+
+    if (prospective_bytes > settings.max_memory_bytes)
+        throw Exception(
+            ErrorCodes::MEMORY_LIMIT_EXCEEDED,
+            "`OverwriteCache` insert requires {} bytes, exceeding `max_memory_bytes` = {}",
+            prospective_bytes,
+            settings.max_memory_bytes);
+
+    if (mutations.empty())
+        return;
+
+    const auto new_entries = static_cast<EntryId>(std::ranges::count_if(mutations, [](const auto & mutation) { return mutation.is_new; }));
+    if (new_entries > std::numeric_limits<EntryId>::max() - next_entry_id)
+        throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` entry identifier space is exhausted");
+
+    EntryId staged_next_entry_id = next_entry_id;
+    std::unordered_map<String, size_t> secondary_additions;
+    std::unordered_map<String, size_t> segmented_secondary_additions;
+    secondary_additions.reserve(new_entries);
+    segmented_secondary_additions.reserve(new_entries);
+    for (auto & mutation : mutations)
+    {
+        if (mutation.is_new)
+        {
+            mutation.entry = std::make_shared<Entry>();
+            mutation.entry->id = staged_next_entry_id++;
+            if (!mutation.row->secondary_key.empty())
+                ++secondary_additions[mutation.row->secondary_key];
+            if (!mutation.row->segmented_secondary_key.empty())
+                ++segmented_secondary_additions[mutation.row->segmented_secondary_key];
+        }
+    }
+
+    struct PreparedPosting
+    {
+        bool segmented = false;
+        size_t shard_index = 0;
+        String key;
+        size_t additional_rows = 0;
+        size_t old_size = 0;
+        bool inserted = false;
+        bool prepared = false;
+    };
+
+    std::vector<PreparedPosting> prepared_postings;
+    prepared_postings.reserve(secondary_additions.size() + segmented_secondary_additions.size());
+    for (const auto & [key, count] : secondary_additions)
+        prepared_postings.push_back({false, postingShardIndex(key), key, count});
+    for (const auto & [key, count] : segmented_secondary_additions)
+        prepared_postings.push_back({true, postingShardIndex(key), key, count});
+
+    const UInt64 current_generation = published_generation.load(std::memory_order_acquire);
+    if (current_generation == std::numeric_limits<UInt64>::max())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "`OverwriteCache` publication generation space is exhausted");
+    const auto publication = std::make_shared<Publication>(current_generation + 1);
+    for (auto & mutation : mutations)
+    {
+        if (mutation.is_new)
+        {
+            mutation.entry->pending = mutation.row;
+            mutation.entry->pending_publication = publication;
+        }
+    }
+
+    try
+    {
+        for (auto & prepared : prepared_postings)
+        {
+            auto & shards = prepared.segmented ? segmented_secondary_shards : secondary_shards;
+            auto & shard = shards[prepared.shard_index];
+            std::unique_lock lock(shard.mutex);
+            auto [it, inserted] = shard.postings.try_emplace(prepared.key);
+            prepared.old_size = it->second.size();
+            prepared.inserted = inserted;
+            prepared.prepared = true;
+            it->second.reserve(it->second.size() + prepared.additional_rows);
+        }
+
+        for (auto & mutation : mutations)
+        {
+            if (mutation.is_new)
+            {
+                auto & primary_shard = primary_shards[primaryShardIndex(mutation.key)];
+                {
+                    std::unique_lock lock(primary_shard.mutex);
+                    mutation.primary_inserted = primary_shard.entries.emplace(mutation.key, mutation.entry).second;
+                }
+                if (!mutation.primary_inserted)
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Duplicate `OverwriteCache` key during publication");
+
+                if (!mutation.row->secondary_key.empty())
+                {
+                    auto & shard = secondary_shards[postingShardIndex(mutation.row->secondary_key)];
+                    std::unique_lock lock(shard.mutex);
+                    shard.postings.find(mutation.row->secondary_key)->second.push_back(mutation.entry);
+                }
+                if (!mutation.row->segmented_secondary_key.empty())
+                {
+                    auto & shard = segmented_secondary_shards[postingShardIndex(mutation.row->segmented_secondary_key)];
+                    std::unique_lock lock(shard.mutex);
+                    shard.postings.find(mutation.row->segmented_secondary_key)->second.push_back(mutation.entry);
+                }
+            }
+            else
+            {
+                /// Every indexed column is part of the immutable composite key, so a replacement
+                /// publishes only the new payload and retains the existing postings.
+                std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry->id)]);
+                if (mutation.entry->pending_publication)
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Concurrent `OverwriteCache` publication for the same entry");
+                mutation.entry->pending = mutation.row;
+                mutation.entry->pending_publication = publication;
+                mutation.pending_installed = true;
+            }
+
+            fiu_do_on(FailPoints::overwrite_cache_throw_during_publish, {
+                throw Exception(ErrorCodes::FAULT_INJECTED, "Injected failure during `OverwriteCache` publication");
+            });
+        }
+
+        FailPointInjection::pauseFailPoint(FailPoints::overwrite_cache_pause_before_commit);
+    }
+    catch (...)
+    {
+        publication->state.store(PublicationState::Aborted, std::memory_order_release);
+        for (auto & mutation : mutations)
+        {
+            if (!mutation.pending_installed)
+                continue;
+            std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry->id)]);
+            mutation.entry->pending.reset();
+            mutation.entry->pending_publication.reset();
+        }
+        for (const auto & prepared : prepared_postings)
+        {
+            if (!prepared.prepared)
+                continue;
+            auto & shards = prepared.segmented ? segmented_secondary_shards : secondary_shards;
+            auto & shard = shards[prepared.shard_index];
+            std::unique_lock lock(shard.mutex);
+            if (const auto it = shard.postings.find(prepared.key); it != shard.postings.end())
+            {
+                it->second.resize(prepared.old_size);
+                if (prepared.inserted)
+                    shard.postings.erase(it);
+            }
+        }
+        for (const auto & mutation : mutations)
+        {
+            if (!mutation.primary_inserted)
+                continue;
+            auto & shard = primary_shards[primaryShardIndex(mutation.key)];
+            std::unique_lock lock(shard.mutex);
+            shard.entries.erase(mutation.key);
+        }
+        throw;
+    }
+
+    publication->state.store(PublicationState::Committed, std::memory_order_release);
+    published_generation.store(publication->generation, std::memory_order_release);
+    next_entry_id = staged_next_entry_id;
+    total_size_bytes.store(prospective_bytes, std::memory_order_relaxed);
+    total_size_rows.fetch_add(new_entries, std::memory_order_relaxed);
+
+    const UInt8 old_epoch = active_reader_epoch.fetch_xor(1, std::memory_order_acq_rel);
+    UInt64 active = active_readers[old_epoch].load(std::memory_order_acquire);
+    while (active != 0)
+    {
+        active_readers[old_epoch].wait(active, std::memory_order_relaxed);
+        active = active_readers[old_epoch].load(std::memory_order_acquire);
+    }
+
+    for (auto & mutation : mutations)
+    {
+        std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry->id)]);
+        mutation.entry->committed = std::move(mutation.entry->pending);
+        mutation.entry->pending_publication.reset();
+    }
+}
+
+StorageOverwriteCache::RowDataPtrs StorageOverwriteCache::getRowsForPrimaryKeys(const std::vector<String> & serialized_keys) const
+{
+    ReadGuard read_guard(*this);
+    RowDataPtrs result;
+    result.reserve(serialized_keys.size());
+    std::unordered_set<EntryId> seen;
+    for (const auto & key : serialized_keys)
+    {
+        const auto entry = findEntry(key);
+        if (!entry || !seen.emplace(entry->id).second)
+            continue;
+        if (auto row = resolveEntry(entry, read_guard.generation()))
+            result.push_back(std::move(row));
+    }
+    return result;
+}
+
+StorageOverwriteCache::RowDataPtrs StorageOverwriteCache::getRowsForPostingKeys(
+    const std::vector<String> & serialized_keys,
+    const std::array<PostingShard, posting_shard_count> & index,
+    const char * index_name) const
+{
+    ReadGuard read_guard(*this);
+    std::unordered_set<String> seen_keys;
+    seen_keys.reserve(serialized_keys.size());
+    std::vector<EntryPtr> entries;
+    for (const auto & key : serialized_keys)
+    {
+        if (!seen_keys.emplace(key).second)
+            continue;
+        const auto & shard = index[postingShardIndex(key)];
+        std::shared_lock lock(shard.mutex);
+        if (const auto it = shard.postings.find(key); it != shard.postings.end())
+        {
+            const UInt64 remaining_rows
+                = settings.max_secondary_index_rows - std::min<UInt64>(entries.size(), settings.max_secondary_index_rows);
+            if (it->second.size() > remaining_rows)
+                throw Exception(
+                    ErrorCodes::MEMORY_LIMIT_EXCEEDED,
+                    "`OverwriteCache` {} lookup exceeds `max_secondary_index_rows` = {}",
+                    index_name,
+                    settings.max_secondary_index_rows);
+            entries.insert(entries.end(), it->second.begin(), it->second.end());
+        }
+    }
+
+    RowDataPtrs result;
+    result.reserve(std::min<UInt64>(entries.size(), settings.max_secondary_index_rows));
+    for (const auto & entry : entries)
+    {
+        auto row = resolveEntry(entry, read_guard.generation());
+        if (!row)
+            continue;
+        if (result.size() >= settings.max_secondary_index_rows)
+            throw Exception(
+                ErrorCodes::MEMORY_LIMIT_EXCEEDED,
+                "`OverwriteCache` {} lookup exceeds `max_secondary_index_rows` = {}",
+                index_name,
+                settings.max_secondary_index_rows);
+        result.push_back(std::move(row));
+    }
+    return result;
+}
+
+StorageOverwriteCache::RowDataPtrs StorageOverwriteCache::getRowsForSecondaryKeys(const std::vector<String> & serialized_keys) const
+{
+    return getRowsForPostingKeys(serialized_keys, secondary_shards, "secondary");
+}
+
+StorageOverwriteCache::RowDataPtrs
+StorageOverwriteCache::getRowsForSegmentedSecondaryKeys(const std::vector<String> & serialized_keys) const
+{
+    return getRowsForPostingKeys(serialized_keys, segmented_secondary_shards, "segmented secondary");
+}
+
+Block StorageOverwriteCache::getSampleBlock(const Names & required_columns) const
+{
+    if (required_columns.empty())
+        return sample_block;
+
+    Block result;
+    for (const auto & name : required_columns)
+        result.insert(sample_block.getByName(name));
+    return result;
+}
+
+Chunk StorageOverwriteCache::getByKeys(
+    const ColumnsWithTypeAndName & keys,
+    const Names & required_columns,
+    PaddedPODArray<UInt8> & out_null_map,
+    IColumn::Offsets & out_offsets) const
+{
+    if (keys.size() != key_columns.size())
+        throw Exception(
+            ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+            "Storage `OverwriteCache` requires {} key columns, got {}",
+            key_columns.size(),
+            keys.size());
+
+    const size_t rows = keys.empty() ? 0 : keys.front().column->size();
+    for (size_t index = 0; index < keys.size(); ++index)
+    {
+        if (keys[index].column->size() != rows)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "All `OverwriteCache` key columns must have equal size");
+        if (!key_column_types[index]->equals(*keys[index].type))
+            throw Exception(
+                ErrorCodes::TYPE_MISMATCH,
+                "Key column {} has type {}, expected {}",
+                backQuote(key_columns[index]),
+                keys[index].type->getName(),
+                key_column_types[index]->getName());
+    }
+
+    const Block result_header = getSampleBlock(required_columns);
+    MutableColumns result_columns = result_header.cloneEmptyColumns();
+    std::vector<size_t> result_positions;
+    result_positions.reserve(result_header.columns());
+    for (const auto & column : result_header)
+        result_positions.push_back(getColumnPosition(column.name));
+
+    out_offsets.clear();
+    out_null_map.clear();
+    out_null_map.resize_fill(rows, 0);
+
+    std::vector<String> serialized_keys;
+    serialized_keys.reserve(rows);
+    for (size_t row = 0; row < rows; ++row)
+    {
+        WriteBufferFromOwnString out;
+        for (size_t key_index = 0; key_index < keys.size(); ++key_index)
+            key_column_types[key_index]->getDefaultSerialization()->serializeBinary(*keys[key_index].column, row, out, {});
+        serialized_keys.push_back(out.str());
+    }
+
+    std::vector<RowDataPtr> resolved_rows(rows);
+    {
+        ReadGuard read_guard(*this);
+        for (size_t row = 0; row < rows; ++row)
+        {
+            if (const auto entry = findEntry(serialized_keys[row]))
+                resolved_rows[row] = resolveEntry(entry, read_guard.generation());
+        }
+    }
+
+    for (size_t row = 0; row < rows; ++row)
+    {
+        if (!resolved_rows[row])
+        {
+            for (auto & column : result_columns)
+                column->insertDefault();
+            continue;
+        }
+        out_null_map[row] = 1;
+        for (size_t column = 0; column < result_positions.size(); ++column)
+            result_columns[column]->insert(resolved_rows[row]->values[result_positions[column]]);
+    }
+
+    return Chunk(std::move(result_columns), rows);
+}
+
+void StorageOverwriteCache::read(
+    QueryPlan & query_plan,
+    const Names & column_names,
+    const StorageSnapshotPtr & storage_snapshot,
+    SelectQueryInfo & query_info,
+    ContextPtr context,
+    QueryProcessingStage::Enum,
+    size_t max_block_size,
+    size_t)
+{
+    storage_snapshot->check(column_names);
+    auto sample = std::make_shared<const Block>(storage_snapshot->metadata->getSampleBlock());
+    query_plan.addStep(
+        std::make_unique<ReadFromOverwriteCache>(
+            column_names, query_info, storage_snapshot, context, std::move(sample), *this, max_block_size));
+}
+
+SinkToStoragePtr StorageOverwriteCache::write(const ASTPtr &, const StorageMetadataPtr & metadata_snapshot, ContextPtr, bool)
+{
+    return std::make_shared<OverwriteCacheSink>(*this, metadata_snapshot);
+}
+
+void StorageOverwriteCache::clearData()
+{
+    std::lock_guard writer_lock(writer_mutex);
+    for (auto & shard : secondary_shards)
+    {
+        std::unique_lock lock(shard.mutex);
+        shard.postings.clear();
+    }
+    for (auto & shard : segmented_secondary_shards)
+    {
+        std::unique_lock lock(shard.mutex);
+        shard.postings.clear();
+    }
+    for (auto & shard : primary_shards)
+    {
+        std::unique_lock lock(shard.mutex);
+        shard.entries.clear();
+    }
+    next_entry_id = 1;
+    published_generation.store(0, std::memory_order_release);
+    total_size_bytes.store(0, std::memory_order_relaxed);
+    total_size_rows.store(0, std::memory_order_relaxed);
+}
+
+void StorageOverwriteCache::truncate(const ASTPtr &, const StorageMetadataPtr &, ContextPtr, TableExclusiveLockHolder &)
+{
+    clearData();
+}
+
+void StorageOverwriteCache::drop()
+{
+    clearData();
+}
+
+std::optional<UInt64> StorageOverwriteCache::totalRows(ContextPtr) const
+{
+    return total_size_rows.load(std::memory_order_relaxed);
+}
+
+std::optional<UInt64> StorageOverwriteCache::totalBytes(ContextPtr) const
+{
+    return total_size_bytes.load(std::memory_order_relaxed);
+}
+
+void registerStorageOverwriteCache(StorageFactory & factory)
+{
+    factory.registerStorage(
+        "OverwriteCache",
+        [](const StorageFactory::Arguments & args) -> StoragePtr
+        {
+            if (args.engine_args.size() != 1)
+                throw Exception(
+                    ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Engine `OverwriteCache` requires exactly one version-column argument");
+
+            const auto * version_identifier = args.engine_args[0]->as<ASTIdentifier>();
+            if (!version_identifier || version_identifier->compound())
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS, "The argument of engine `OverwriteCache` must be an unqualified version-column identifier");
+            const String version_column = version_identifier->name();
+
+            if (!args.storage_def->keys)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `OverwriteCache` requires a `KEYS (...)` clause");
+            Names key_columns = extractIdentifierList(*args.storage_def->keys, "`KEYS` clause");
+            OverwriteCacheSettings settings = parseSettings(*args.storage_def);
+
+            validateColumn(args.columns, version_column, "version", true);
+            std::unordered_set<String> key_set;
+            for (const auto & key : key_columns)
+            {
+                validateColumn(args.columns, key, "key", true);
+                key_set.emplace(key);
+            }
+            if (key_set.contains(version_column))
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Version column {} cannot be declared in `KEYS`", backQuote(version_column));
+
+            std::unordered_set<String> tiebreak_set;
+            for (const auto & column : settings.equal_version_tiebreak_columns)
+            {
+                validateColumn(args.columns, column, "tie-break", true);
+                if (!tiebreak_set.emplace(column).second)
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Duplicate tie-break column {}", backQuote(column));
+            }
+
+            std::unordered_set<String> secondary_set;
+            for (const auto & column : settings.secondary_index_columns)
+            {
+                if (!key_set.contains(column))
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Secondary-index column {} must be declared in `KEYS`", backQuote(column));
+                if (!secondary_set.emplace(column).second)
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Duplicate secondary-index column {}", backQuote(column));
+            }
+
+            if (settings.secondary_index_segment_column)
+            {
+                const auto & segment = *settings.secondary_index_segment_column;
+                if (settings.secondary_index_columns.empty())
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS, "Setting `secondary_index_segment_column` requires `secondary_index_columns`");
+                if (!key_set.contains(segment))
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS, "Secondary-index segment column {} must be declared in `KEYS`", backQuote(segment));
+                if (secondary_set.contains(segment))
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "Secondary-index segment column {} cannot also be a secondary-index column",
+                        backQuote(segment));
+            }
+
+            return std::make_shared<StorageOverwriteCache>(
+                args.table_id,
+                args.columns,
+                args.constraints,
+                args.comment,
+                version_column,
+                std::move(key_columns),
+                std::move(settings),
+                args.storage_def->settings->clone());
+        },
+        {
+            .supports_settings = true,
+            .supports_keys = true,
+            .has_builtin_setting_fn = isOverwriteCacheSetting,
+        });
+}
+
+}

--- a/src/Storages/StorageOverwriteCache.cpp
+++ b/src/Storages/StorageOverwriteCache.cpp
@@ -27,7 +27,7 @@
 #include <Common/CurrentThread.h>
 #include <Common/FailPoint.h>
 #include <Common/HashTable/HashTableKeyHolder.h>
-#include <Common/SipHash.h>
+#include <Common/ProfileEvents.h>
 #include <Common/ThreadStatus.h>
 #include <Common/quoteString.h>
 
@@ -36,6 +36,11 @@
 #include <iterator>
 #include <limits>
 #include <utility>
+
+namespace ProfileEvents
+{
+extern const Event OverwriteCacheEqualVersionTies;
+}
 
 namespace DB
 {
@@ -527,22 +532,6 @@ void StorageOverwriteCache::insertValueIntoColumn(
     column.insertFrom(cache.get(*row.segment, position), row.segment_row);
 }
 
-UInt128 StorageOverwriteCache::rowDigest(const Block & block, size_t row) const
-{
-    SipHash hash;
-    for (size_t position = 0; position < block.columns(); ++position)
-        block.getByPosition(position).column->updateHashWithValue(row, hash);
-    return hash.get128();
-}
-
-UInt128 StorageOverwriteCache::rowDigest(const RowData & row, SegmentColumnCache & cache) const
-{
-    SipHash hash;
-    for (size_t position = 0; position < sample_block.columns(); ++position)
-        cache.get(*row.segment, position).updateHashWithValue(row.segment_row, hash);
-    return hash.get128();
-}
-
 int StorageOverwriteCache::compareWinner(const Block & block, size_t lhs_row, size_t rhs_row) const
 {
     const auto & version = *block.getByPosition(version_position).column;
@@ -556,9 +545,6 @@ int StorageOverwriteCache::compareWinner(const Block & block, size_t lhs_row, si
             return result;
     }
 
-    if (rowDigest(block, lhs_row) != rowDigest(block, rhs_row))
-        throw Exception(
-            ErrorCodes::BAD_ARGUMENTS, "Conflicting rows for the same `OverwriteCache` key have identical version and tie-break values");
     return 0;
 }
 
@@ -576,10 +562,6 @@ int StorageOverwriteCache::compareWinner(const Block & block, size_t lhs_row, co
             return result;
     }
 
-    SegmentColumnCache cache;
-    if (rowDigest(block, lhs_row) != rowDigest(rhs, cache))
-        throw Exception(
-            ErrorCodes::BAD_ARGUMENTS, "Conflicting rows for the same `OverwriteCache` key have identical version and tie-break values");
     return 0;
 }
 
@@ -753,13 +735,25 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
     using CandidateMap = HashMapWithSavedHash<std::string_view, UInt32, StringViewHash>;
     CandidateMap candidates;
     candidates.reserve(input_rows);
+    /// A row that ties on version and tie-break loses to the row already chosen. That is a silent
+    /// resolution of an ambiguity in the data, so it is counted for the user to notice.
+    size_t equal_version_ties = 0;
     for (size_t row = 0; row < input_rows; ++row)
     {
         CandidateMap::LookupResult it = nullptr;
         bool inserted = false;
         candidates.emplace(primary_keys.at(row), it, inserted, primary_keys.hashes[row]);
-        if (inserted || compareWinner(block, row, it->getMapped()) > 0)
+        if (inserted)
+        {
             it->getMapped() = static_cast<UInt32>(row);
+            continue;
+        }
+
+        const int comparison = compareWinner(block, row, it->getMapped());
+        if (comparison > 0)
+            it->getMapped() = static_cast<UInt32>(row);
+        else if (comparison == 0)
+            ++equal_version_ties;
     }
 
     struct Mutation
@@ -807,13 +801,21 @@ void StorageOverwriteCache::insertBlock(const Block & input_block)
         if (!current)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Corrupted `OverwriteCache` primary index");
 
-        if (compareWinner(block, mutation.source_row, *current) <= 0)
+        const int comparison = compareWinner(block, mutation.source_row, *current);
+        if (comparison <= 0)
+        {
+            if (comparison == 0)
+                ++equal_version_ties;
             continue;
+        }
 
         mutation.entry_id = *entry;
         mutation.previous = current;
         mutations.push_back(std::move(mutation));
     }
+
+    if (equal_version_ties)
+        ProfileEvents::increment(ProfileEvents::OverwriteCacheEqualVersionTies, equal_version_ties);
 
     if (mutations.empty())
         return;

--- a/src/Storages/StorageOverwriteCache.cpp
+++ b/src/Storages/StorageOverwriteCache.cpp
@@ -1,10 +1,11 @@
 #include <Storages/StorageOverwriteCache.h>
 
 #include <Core/Block.h>
+#include <Columns/ColumnSparse.h>
 #include <Columns/ColumnVector.h>
 #include <DataTypes/IDataType.h>
 #include <IO/WriteBufferFromString.h>
-#include <IO/ReadBufferFromMemory.h>
+#include <IO/WriteBufferFromVector.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Parsers/ASTCreateQuery.h>
@@ -25,6 +26,8 @@
 #include <Common/Exception.h>
 #include <Common/CurrentThread.h>
 #include <Common/FailPoint.h>
+#include <Common/HashTable/HashTableKeyHolder.h>
+#include <Common/SipHash.h>
 #include <Common/ThreadStatus.h>
 #include <Common/quoteString.h>
 
@@ -128,6 +131,8 @@ OverwriteCacheSettings parseSettings(const ASTStorage & storage_def)
             result.max_memory_bytes = getUInt64Setting(change);
         else if (change.name == "equal_version_tiebreak_columns")
             result.equal_version_tiebreak_columns = parseColumnList(getStringSetting(change), change.name);
+        else if (change.name == "compress_segments")
+            result.compress_segments = getUInt64Setting(change) != 0;
         else
             throw Exception(ErrorCodes::UNKNOWN_SETTING, "Unknown setting {} for storage `OverwriteCache`", backQuote(change.name));
     }
@@ -178,7 +183,7 @@ void validateColumn(const ColumnsDescription & columns, const String & name, con
 
 bool isOverwriteCacheSetting(std::string_view name)
 {
-    return name == "max_memory_bytes" || name == "equal_version_tiebreak_columns";
+    return name == "max_memory_bytes" || name == "equal_version_tiebreak_columns" || name == "compress_segments";
 }
 
 class OverwriteCacheSink final : public SinkToStorage
@@ -230,16 +235,10 @@ protected:
 
         for (size_t output_position = 0; output_position < positions.size(); ++output_position)
         {
-            std::shared_ptr<StorageOverwriteCache::RowSegment> current_segment;
-            ColumnPtr source_column;
             for (size_t row = offset; row < offset + rows_to_emit; ++row)
             {
-                if (current_segment != rows[row].segment)
-                {
-                    current_segment = rows[row].segment;
-                    source_column = current_segment->columns[positions[output_position]]->decompress();
-                }
-                columns[output_position]->insertFrom(*source_column, rows[row].segment_row);
+                const auto & source_column = segment_columns.get(*rows[row].segment, positions[output_position]);
+                columns[output_position]->insertFrom(source_column, rows[row].segment_row);
             }
         }
 
@@ -251,6 +250,7 @@ private:
     /// Keep the guard before rows so rows release their segment references before the epoch is released.
     StorageOverwriteCache::ReadGuardPtr read_guard;
     StorageOverwriteCache::RowDataPtrs rows;
+    StorageOverwriteCache::SegmentColumnCache segment_columns;
     std::vector<size_t> positions;
     size_t max_block_size;
     size_t offset = 0;
@@ -439,6 +439,12 @@ StorageOverwriteCache::StorageOverwriteCache(
     }
     for (const auto & name : settings.equal_version_tiebreak_columns)
         tiebreak_positions.push_back(getColumnPosition(name));
+
+    keep_uncompressed.assign(sample_block.columns(), !settings.compress_segments);
+    keep_uncompressed[version_position] = true;
+    for (const auto position : tiebreak_positions)
+        keep_uncompressed[position] = true;
+
     lookup_index_positions.reserve(lookup_index_columns.size());
     lookup_index_column_types.reserve(lookup_index_columns.size());
     lookup_indexes.reserve(lookup_index_columns.size());
@@ -479,110 +485,135 @@ size_t StorageOverwriteCache::getColumnPosition(const String & column_name) cons
     return it->second;
 }
 
+void StorageOverwriteCache::serializeKeys(const Block & block, const std::vector<size_t> & positions, SerializedKeys & result) const
+{
+    const size_t rows = block.rows();
+    result.offsets.resize(rows);
+    result.hashes.resize(rows);
+    {
+        WriteBufferFromVector<PODArray<char>> out(result.data);
+        for (size_t row = 0; row < rows; ++row)
+        {
+            for (const auto position : positions)
+                serializations[position]->serializeBinary(*block.getByPosition(position).column, row, out, format_settings);
+            result.offsets[row] = out.count();
+        }
+        out.finalize();
+    }
+    for (size_t row = 0; row < rows; ++row)
+        result.hashes[row] = StringViewHash{}(result.at(row));
+}
+
 String StorageOverwriteCache::serializeColumns(const Block & block, size_t row, const std::vector<size_t> & positions) const
 {
     WriteBufferFromOwnString out;
     for (const auto position : positions)
-        serializations[position]->serializeBinary(*block.getByPosition(position).column, row, out, {});
+        serializations[position]->serializeBinary(*block.getByPosition(position).column, row, out, format_settings);
     return out.str();
 }
 
-String StorageOverwriteCache::serializeRowColumns(const RowData & row, const std::vector<size_t> & positions) const
+String StorageOverwriteCache::serializeRowColumns(
+    const RowData & row, const std::vector<size_t> & positions, SegmentColumnCache & cache) const
 {
     WriteBufferFromOwnString out;
     for (const auto position : positions)
-    {
-        const auto column = row.segment->columns[position]->decompress();
-        serializations[position]->serializeBinary(*column, row.segment_row, out, {});
-    }
+        serializations[position]->serializeBinary(cache.get(*row.segment, position), row.segment_row, out, format_settings);
     return out.str();
 }
 
-void StorageOverwriteCache::insertValueIntoColumn(const RowData & row, size_t position, IColumn & column) const
+void StorageOverwriteCache::insertValueIntoColumn(
+    const RowData & row, size_t position, IColumn & column, SegmentColumnCache & cache) const
 {
-    const auto source = row.segment->columns[position]->decompress();
-    column.insertFrom(*source, row.segment_row);
+    column.insertFrom(cache.get(*row.segment, position), row.segment_row);
 }
 
-Field StorageOverwriteCache::getRowField(const RowData & row, size_t position) const
+UInt128 StorageOverwriteCache::rowDigest(const Block & block, size_t row) const
 {
-    const auto column = row.segment->columns[position]->decompress();
-    Field result;
-    column->get(row.segment_row, result);
-    return result;
+    SipHash hash;
+    for (size_t position = 0; position < block.columns(); ++position)
+        block.getByPosition(position).column->updateHashWithValue(row, hash);
+    return hash.get128();
 }
 
-Field StorageOverwriteCache::getCandidateField(const CandidateRow & row, size_t position) const
+UInt128 StorageOverwriteCache::rowDigest(const RowData & row, SegmentColumnCache & cache) const
 {
-    if (position >= row.value_offsets.size())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` candidate row offsets");
-    const size_t begin = position ? row.value_offsets[position - 1] : 0;
-    const size_t end = row.value_offsets[position];
-    auto column = sample_block.getByPosition(position).type->createColumn();
-    ReadBufferFromMemory input(row.encoded_values.data() + begin, end - begin);
-    serializations[position]->deserializeBinary(*column, input, {});
-    Field result;
-    column->get(0, result);
-    return result;
-}
-
-int StorageOverwriteCache::compareWinner(const CandidateRow & lhs, const CandidateRow & rhs) const
-{
-    const auto compare_field = [](const Field & left, const Field & right)
-    {
-        if (left < right)
-            return -1;
-        if (right < left)
-            return 1;
-        return 0;
-    };
-
-    if (const int result = compare_field(getCandidateField(lhs, version_position), getCandidateField(rhs, version_position)))
-        return result;
-
-    for (const auto position : tiebreak_positions)
-    {
-        if (const int result = compare_field(getCandidateField(lhs, position), getCandidateField(rhs, position)))
-            return result;
-    }
-
-    if (lhs.encoded_values != rhs.encoded_values || lhs.value_offsets != rhs.value_offsets)
-        throw Exception(
-            ErrorCodes::BAD_ARGUMENTS, "Conflicting rows for the same `OverwriteCache` key have identical version and tie-break values");
-    return 0;
-}
-
-int StorageOverwriteCache::compareWinner(const CandidateRow & lhs, const RowData & rhs) const
-{
-    const auto compare_field = [](const Field & left, const Field & right)
-    {
-        if (left < right)
-            return -1;
-        if (right < left)
-            return 1;
-        return 0;
-    };
-
-    if (const int result = compare_field(getCandidateField(lhs, version_position), getRowField(rhs, version_position)))
-        return result;
-    for (const auto position : tiebreak_positions)
-    {
-        if (const int result = compare_field(getCandidateField(lhs, position), getRowField(rhs, position)))
-            return result;
-    }
-
-    if (!rowsEqual(lhs, rhs))
-        throw Exception(
-            ErrorCodes::BAD_ARGUMENTS, "Conflicting rows for the same `OverwriteCache` key have identical version and tie-break values");
-    return 0;
-}
-
-bool StorageOverwriteCache::rowsEqual(const CandidateRow & lhs, const RowData & rhs) const
-{
+    SipHash hash;
     for (size_t position = 0; position < sample_block.columns(); ++position)
-        if (getCandidateField(lhs, position) != getRowField(rhs, position))
-            return false;
-    return true;
+        cache.get(*row.segment, position).updateHashWithValue(row.segment_row, hash);
+    return hash.get128();
+}
+
+int StorageOverwriteCache::compareWinner(const Block & block, size_t lhs_row, size_t rhs_row) const
+{
+    const auto & version = *block.getByPosition(version_position).column;
+    if (const int result = version.compareAt(lhs_row, rhs_row, version, 1))
+        return result;
+
+    for (const auto position : tiebreak_positions)
+    {
+        const auto & column = *block.getByPosition(position).column;
+        if (const int result = column.compareAt(lhs_row, rhs_row, column, 1))
+            return result;
+    }
+
+    if (rowDigest(block, lhs_row) != rowDigest(block, rhs_row))
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS, "Conflicting rows for the same `OverwriteCache` key have identical version and tie-break values");
+    return 0;
+}
+
+int StorageOverwriteCache::compareWinner(const Block & block, size_t lhs_row, const RowData & rhs) const
+{
+    /// The version and tie-break columns of a segment are never compressed, so they can be compared in place.
+    if (const int result = block.getByPosition(version_position).column->compareAt(
+            lhs_row, rhs.segment_row, *rhs.segment->columns[version_position], 1))
+        return result;
+
+    for (const auto position : tiebreak_positions)
+    {
+        if (const int result = block.getByPosition(position).column->compareAt(
+                lhs_row, rhs.segment_row, *rhs.segment->columns[position], 1))
+            return result;
+    }
+
+    SegmentColumnCache cache;
+    if (rowDigest(block, lhs_row) != rowDigest(rhs, cache))
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS, "Conflicting rows for the same `OverwriteCache` key have identical version and tie-break values");
+    return 0;
+}
+
+void StorageOverwriteCache::EntryTable::grow(size_t new_size)
+{
+    while (allocated_entries < new_size)
+    {
+        if (chunk_count == max_chunks)
+            throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` entry table is exhausted");
+        const size_t capacity = chunkCapacity(chunk_count);
+        chunks[chunk_count].store(new Entry[capacity], std::memory_order_release);
+        ++chunk_count;
+        allocated_entries += capacity;
+    }
+    entry_count.store(new_size, std::memory_order_release);
+}
+
+void StorageOverwriteCache::EntryTable::shrink(size_t new_size)
+{
+    for (size_t index = new_size; index < entry_count.load(std::memory_order_relaxed); ++index)
+        at(index + 1) = Entry{};
+    entry_count.store(new_size, std::memory_order_release);
+}
+
+void StorageOverwriteCache::EntryTable::clear()
+{
+    entry_count.store(0, std::memory_order_release);
+    for (size_t level = 0; level < chunk_count; ++level)
+    {
+        delete[] chunks[level].load(std::memory_order_relaxed);
+        chunks[level].store(nullptr, std::memory_order_release);
+    }
+    chunk_count = 0;
+    allocated_entries = 0;
 }
 
 
@@ -609,83 +640,84 @@ StorageOverwriteCache::ReadGuard::~ReadGuard()
         storage.active_readers[epoch].notify_all();
 }
 
-size_t StorageOverwriteCache::primaryShardIndex(const String & key) const
-{
-    return std::hash<String>{}(key) % primary_shard_count;
-}
-
-size_t StorageOverwriteCache::postingShardIndex(const String & key) const
-{
-    return std::hash<String>{}(key) % posting_shard_count;
-}
-
 size_t StorageOverwriteCache::rowLockIndex(EntryId entry_id) const
 {
     return std::hash<EntryId>{}(entry_id) % row_lock_count;
 }
 
-std::optional<StorageOverwriteCache::EntryId> StorageOverwriteCache::findEntry(const String & key) const
+std::optional<StorageOverwriteCache::EntryId> StorageOverwriteCache::findEntry(std::string_view key, size_t hash) const
 {
-    const auto & shard = primary_shards[primaryShardIndex(key)];
+    const auto & shard = primary_shards[shardIndex(hash)];
     std::shared_lock lock(shard.mutex);
-    if (const auto it = shard.entries.find(key); it != shard.entries.end())
-        return it->second;
+    if (const auto * it = shard.entries.find(key, hash))
+        return it->getMapped();
     return {};
 }
 
 StorageOverwriteCache::RowDataPtr StorageOverwriteCache::resolveEntry(EntryId entry_id, UInt64 snapshot_generation) const
 {
-    std::shared_lock entries_lock(entries_by_id_mutex);
-    if (entry_id == 0 || entry_id > entries_by_id.size())
+    if (entry_id == 0 || entry_id > entries.size())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` entry identifier");
     std::lock_guard row_lock(row_mutexes[rowLockIndex(entry_id)]);
-    const auto & entry = entries_by_id[entry_id - 1];
+    const auto & entry = entries.at(entry_id);
     if (entry.pending_generation != 0 && entry.pending_generation <= snapshot_generation)
         return *entry.pending;
     return entry.committed;
 }
 
-void StorageOverwriteCache::insertBlock(const Block & block)
+void StorageOverwriteCache::insertBlock(const Block & input_block)
 {
+    const size_t input_rows = input_block.rows();
+    if (input_rows == 0)
+        return;
+
+    /// Normalize column representations once, so that every later comparison between an input row and a
+    /// stored row is between columns of the same implementation.
+    Block block = input_block;
+    for (auto & element : block)
+        element.column = recursiveRemoveSparse(element.column->convertToFullColumnIfConst());
+
     std::vector<std::vector<size_t>> lookup_positions_snapshot;
     {
         std::shared_lock catalog_lock(lookup_catalog_mutex);
         lookup_positions_snapshot = lookup_index_positions;
     }
-    std::unordered_map<String, std::shared_ptr<CandidateRow>> candidates;
-    candidates.reserve(block.rows());
 
-    for (size_t row = 0; row < block.rows(); ++row)
+    SerializedKeys primary_keys;
+    serializeKeys(block, key_positions, primary_keys);
+
+    std::vector<SerializedKeys> lookup_keys;
+    const auto build_lookup_keys = [&]
     {
-        auto candidate = std::make_shared<CandidateRow>();
-        candidate->source_row = static_cast<UInt32>(row);
-        WriteBufferFromOwnString encoded;
-        candidate->value_offsets.reserve(block.columns());
-        for (size_t position = 0; position < block.columns(); ++position)
-        {
-            serializations[position]->serializeBinary(*block.getByPosition(position).column, row, encoded, {});
-            if (encoded.count() > std::numeric_limits<UInt32>::max())
-                throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "An `OverwriteCache` row exceeds the compact 4 GiB row limit");
-            candidate->value_offsets.push_back(static_cast<UInt32>(encoded.count()));
-        }
-        candidate->encoded_values = encoded.str();
-        candidate->primary_key = serializeColumns(block, row, key_positions);
-        candidate->lookup_keys.reserve(lookup_positions_snapshot.size());
-        for (const auto & positions : lookup_positions_snapshot)
-            candidate->lookup_keys.push_back(serializeColumns(block, row, positions));
-        auto [it, inserted] = candidates.emplace(candidate->primary_key, candidate);
-        if (!inserted && compareWinner(*candidate, *it->second) > 0)
-            it->second = std::move(candidate);
+        std::vector<SerializedKeys> result(lookup_positions_snapshot.size());
+        for (size_t index = 0; index < lookup_positions_snapshot.size(); ++index)
+            serializeKeys(block, lookup_positions_snapshot[index], result[index]);
+        lookup_keys = std::move(result);
+    };
+    build_lookup_keys();
+
+    /// Deduplicate inside the block. The map holds the winning source row per key; keys reference the
+    /// single serialization buffer, so no per-row allocation happens here.
+    using CandidateMap = HashMapWithSavedHash<std::string_view, UInt32, StringViewHash>;
+    CandidateMap candidates;
+    candidates.reserve(input_rows);
+    for (size_t row = 0; row < input_rows; ++row)
+    {
+        CandidateMap::LookupResult it = nullptr;
+        bool inserted = false;
+        candidates.emplace(primary_keys.at(row), it, inserted, primary_keys.hashes[row]);
+        if (inserted || compareWinner(block, row, it->getMapped()) > 0)
+            it->getMapped() = static_cast<UInt32>(row);
     }
 
     struct Mutation
     {
-        String key;
+        std::string_view key;
+        size_t key_hash = 0;
+        UInt32 source_row = 0;
         EntryId entry_id = 0;
-        std::shared_ptr<CandidateRow> candidate;
         std::unique_ptr<RowData> row;
         std::optional<RowData> previous;
-        std::vector<String> lookup_keys;
         bool is_new = false;
         bool primary_inserted = false;
         bool pending_installed = false;
@@ -695,75 +727,75 @@ void StorageOverwriteCache::insertBlock(const Block & block)
     std::lock_guard writer_lock(writer_mutex);
     if (lookup_positions_snapshot != lookup_index_positions)
     {
-        for (auto & [key, candidate] : candidates)
-        {
-            static_cast<void>(key);
-            candidate->lookup_keys.clear();
-            candidate->lookup_keys.reserve(lookup_index_positions.size());
-            for (const auto & positions : lookup_index_positions)
-                candidate->lookup_keys.push_back(serializeColumns(block, candidate->source_row, positions));
-        }
+        lookup_positions_snapshot = lookup_index_positions;
+        build_lookup_keys();
     }
+    const size_t index_count = lookup_positions_snapshot.size();
+
     std::vector<Mutation> mutations;
     mutations.reserve(candidates.size());
 
-    for (auto & [key, candidate] : candidates)
+    const UInt64 snapshot_generation = published_generation.load(std::memory_order_acquire);
+    for (const auto & candidate : candidates)
     {
-        auto entry = findEntry(key);
+        Mutation mutation;
+        mutation.source_row = candidate.getMapped();
+        mutation.key = primary_keys.at(mutation.source_row);
+        mutation.key_hash = primary_keys.hashes[mutation.source_row];
+
+        const auto entry = findEntry(mutation.key, mutation.key_hash);
         if (!entry)
         {
-            auto lookup_keys = candidate->lookup_keys;
-            mutations.push_back({key, {}, std::move(candidate), {}, {}, std::move(lookup_keys), true});
+            mutation.is_new = true;
+            mutations.push_back(std::move(mutation));
             continue;
         }
 
-        const auto current = resolveEntry(*entry, published_generation.load(std::memory_order_acquire));
+        const auto current = resolveEntry(*entry, snapshot_generation);
         if (!current)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Corrupted `OverwriteCache` primary index");
 
-        const int winner = compareWinner(*candidate, *current);
-        if (winner <= 0)
+        if (compareWinner(block, mutation.source_row, *current) <= 0)
             continue;
 
-        auto lookup_keys = candidate->lookup_keys;
-        mutations.push_back({key, *entry, std::move(candidate), {}, current, std::move(lookup_keys), false});
+        mutation.entry_id = *entry;
+        mutation.previous = current;
+        mutations.push_back(std::move(mutation));
     }
 
     if (mutations.empty())
         return;
 
+    const size_t block_mutation_count = mutations.size();
+
     auto selector = ColumnUInt64::create();
-    selector->reserve(mutations.size());
+    selector->reserve(block_mutation_count);
     for (const auto & mutation : mutations)
-        selector->insertValue(mutation.candidate->source_row);
+        selector->insertValue(mutation.source_row);
 
     auto segment = std::make_shared<RowSegment>();
     segment->columns.reserve(block.columns());
-    for (const auto & source : block)
+    for (size_t position = 0; position < block.columns(); ++position)
     {
-        auto selected = source.column->index(*selector, 0)->compress(/*force_compression=*/true);
+        auto selected = block.getByPosition(position).column->index(*selector, 0);
+        if (!keep_uncompressed[position])
+            selected = selected->compress(/*force_compression=*/true);
         segment->allocated_bytes += selected->allocatedBytes();
         segment->columns.push_back(std::move(selected));
     }
-    segment->live_rows.store(mutations.size(), std::memory_order_relaxed);
+    segment->live_rows.store(block_mutation_count, std::memory_order_relaxed);
+    segment->entry_ids.resize(block_mutation_count);
 
     UInt64 prospective_bytes = total_size_bytes.load(std::memory_order_relaxed);
     if (prospective_bytes > std::numeric_limits<UInt64>::max() - segment->allocated_bytes)
         throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
     prospective_bytes += segment->allocated_bytes;
-    for (size_t row = 0; row < mutations.size(); ++row)
+    for (size_t row = 0; row < block_mutation_count; ++row)
     {
         auto compact_row = std::make_unique<RowData>();
         compact_row->segment = segment;
         compact_row->segment_row = static_cast<UInt32>(row);
-        UInt64 added_bytes = 0;
-        if (mutations[row].is_new)
-            added_bytes += sizeof(std::pair<const String, EntryId>) + mutations[row].key.size() + 64;
-        if (prospective_bytes > std::numeric_limits<UInt64>::max() - added_bytes)
-            throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
-        prospective_bytes += added_bytes;
         mutations[row].row = std::move(compact_row);
-        mutations[row].candidate.reset();
     }
 
     struct SegmentCompaction
@@ -777,13 +809,13 @@ void StorageOverwriteCache::insertBlock(const Block & block)
 
     std::vector<SegmentCompaction> segment_compactions;
     std::unordered_map<RowSegment *, size_t> segment_compaction_positions;
-    std::unordered_set<EntryId> mutated_entry_ids;
-    mutated_entry_ids.reserve(mutations.size());
+    std::vector<EntryId> mutated_entry_ids;
+    mutated_entry_ids.reserve(block_mutation_count);
     for (const auto & mutation : mutations)
     {
         if (mutation.is_new || !mutation.previous || !mutation.previous->segment)
             continue;
-        mutated_entry_ids.insert(mutation.entry_id);
+        mutated_entry_ids.push_back(mutation.entry_id);
         auto [it, inserted] = segment_compaction_positions.emplace(
             mutation.previous->segment.get(), segment_compactions.size());
         if (inserted)
@@ -793,16 +825,15 @@ void StorageOverwriteCache::insertBlock(const Block & block)
         }
         ++segment_compactions[it->second].replaced_rows;
     }
+    std::ranges::sort(mutated_entry_ids);
 
-    std::unordered_map<RowSegment *, size_t> selected_compaction_positions;
-    for (size_t position = 0; position < segment_compactions.size(); ++position)
+    for (auto & compaction : segment_compactions)
     {
-        auto & compaction = segment_compactions[position];
         const UInt64 live_rows = compaction.source->live_rows.load(std::memory_order_acquire);
         if (compaction.replaced_rows > live_rows)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` row-segment live-row count");
         compaction.projected_live_rows = live_rows - compaction.replaced_rows;
-        const UInt64 total_rows = compaction.source->columns.empty() ? 0 : compaction.source->columns.front()->size();
+        const UInt64 total_rows = compaction.source->entry_ids.size();
         if (compaction.projected_live_rows > total_rows)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` row-segment size");
         const UInt64 projected_dead_rows = total_rows - compaction.projected_live_rows;
@@ -810,25 +841,22 @@ void StorageOverwriteCache::insertBlock(const Block & block)
             continue;
         compaction.selected = true;
         compaction.live_entries.reserve(compaction.projected_live_rows);
-        selected_compaction_positions.emplace(compaction.source.get(), position);
-    }
 
-    if (!selected_compaction_positions.empty())
-    {
-        std::shared_lock entries_lock(entries_by_id_mutex);
-        for (EntryId entry_id = 1; entry_id <= entries_by_id.size(); ++entry_id)
+        /// Segments carry a back-reference per row, so collecting survivors costs one pass over the
+        /// segment instead of a scan of every entry in the table.
+        for (size_t row = 0; row < compaction.source->entry_ids.size(); ++row)
         {
-            if ((entry_id & 4095) == 0 && CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
+            if ((row & 4095) == 0 && CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
                 throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled while compacting `OverwriteCache` row segments");
-            if (mutated_entry_ids.contains(entry_id))
+            const EntryId entry_id = compaction.source->entry_ids[row];
+            if (std::ranges::binary_search(mutated_entry_ids, entry_id))
                 continue;
-            const auto & entry = entries_by_id[entry_id - 1];
+            const auto & entry = entries.at(entry_id);
             std::lock_guard row_lock(row_mutexes[rowLockIndex(entry_id)]);
-            if (!entry.committed)
+            if (!entry.committed || entry.committed->segment.get() != compaction.source.get()
+                || entry.committed->segment_row != row)
                 continue;
-            const auto it = selected_compaction_positions.find(entry.committed->segment.get());
-            if (it != selected_compaction_positions.end())
-                segment_compactions[it->second].live_entries.emplace_back(entry_id, *entry.committed);
+            compaction.live_entries.emplace_back(entry_id, *entry.committed);
         }
     }
 
@@ -849,13 +877,16 @@ void StorageOverwriteCache::insertBlock(const Block & block)
 
         auto compacted_segment = std::make_shared<RowSegment>();
         compacted_segment->columns.reserve(compaction.source->columns.size());
-        for (const auto & source_column : compaction.source->columns)
+        for (size_t position = 0; position < compaction.source->columns.size(); ++position)
         {
-            auto selected = source_column->decompress()->index(*compaction_selector, 0)->compress(/*force_compression=*/true);
+            auto selected = compaction.source->columns[position]->decompress()->index(*compaction_selector, 0);
+            if (!keep_uncompressed[position])
+                selected = selected->compress(/*force_compression=*/true);
             compacted_segment->allocated_bytes += selected->allocatedBytes();
             compacted_segment->columns.push_back(std::move(selected));
         }
         compacted_segment->live_rows.store(compaction.live_entries.size(), std::memory_order_relaxed);
+        compacted_segment->entry_ids.reserve(compaction.live_entries.size());
         if (prospective_bytes > std::numeric_limits<UInt64>::max() - compacted_segment->allocated_bytes)
             throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
         prospective_bytes += compacted_segment->allocated_bytes;
@@ -866,6 +897,7 @@ void StorageOverwriteCache::insertBlock(const Block & block)
             auto compacted_row = std::make_unique<RowData>();
             compacted_row->segment = compacted_segment;
             compacted_row->segment_row = static_cast<UInt32>(row);
+            compacted_segment->entry_ids.push_back(entry_id);
             Mutation compacted_mutation;
             compacted_mutation.entry_id = entry_id;
             compacted_mutation.row = std::move(compacted_row);
@@ -873,7 +905,6 @@ void StorageOverwriteCache::insertBlock(const Block & block)
             mutations.push_back(std::move(compacted_mutation));
         }
     }
-    candidates.clear();
 
     if (prospective_bytes > settings.max_memory_bytes)
         throw Exception(
@@ -887,40 +918,99 @@ void StorageOverwriteCache::insertBlock(const Block & block)
         throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` entry identifier space is exhausted");
 
     EntryId staged_next_entry_id = next_entry_id;
-    std::vector<std::unordered_map<String, size_t>> lookup_additions(lookup_indexes.size());
-    for (auto & additions : lookup_additions)
-        additions.reserve(new_entries);
     for (auto & mutation : mutations)
     {
         if (mutation.is_new)
-        {
             mutation.entry_id = staged_next_entry_id++;
-            for (size_t index = 0; index < mutation.lookup_keys.size(); ++index)
-                ++lookup_additions[index][mutation.lookup_keys[index]];
-        }
     }
+    for (size_t row = 0; row < block_mutation_count; ++row)
+        segment->entry_ids[row] = mutations[row].entry_id;
 
+    /// One prepared posting per distinct lookup key, plus a slot per (mutation, index) pair so that
+    /// publication never re-hashes or re-looks-up a posting.
     struct PreparedPosting
     {
         size_t index = 0;
         size_t shard_index = 0;
-        String key;
-        size_t additional_rows = 0;
+        std::string_view key;
+        size_t key_hash = 0;
+        UInt32 posting_position = 0;
+        UInt32 additional_rows = 0;
+        UInt32 entry_id_offset = 0;
         size_t old_size = 0;
-        UInt64 old_allocated_bytes = 0;
-        UInt64 reserved_allocated_bytes = 0;
-        UInt64 node_bytes = 0;
-        UInt64 bucket_bytes_delta = 0;
-        bool inserted = false;
+        UInt64 bytes_delta = 0;
         bool prepared = false;
     };
 
     std::vector<PreparedPosting> prepared_postings;
-    for (size_t index = 0; index < lookup_additions.size(); ++index)
+    std::vector<UInt32> posting_slots;
     {
-        prepared_postings.reserve(prepared_postings.size() + lookup_additions[index].size());
-        for (const auto & [key, count] : lookup_additions[index])
-            prepared_postings.push_back({index, postingShardIndex(key), key, count});
+        using PostingLookup = HashMapWithSavedHash<std::string_view, UInt32, StringViewHash>;
+        std::vector<PostingLookup> posting_lookup(index_count);
+        posting_slots.assign(block_mutation_count * index_count, 0);
+        for (size_t position = 0; position < block_mutation_count; ++position)
+        {
+            if (!mutations[position].is_new)
+                continue;
+            for (size_t index = 0; index < index_count; ++index)
+            {
+                const std::string_view key = lookup_keys[index].at(mutations[position].source_row);
+                const size_t hash = lookup_keys[index].hashes[mutations[position].source_row];
+                PostingLookup::LookupResult it = nullptr;
+                bool inserted = false;
+                posting_lookup[index].emplace(key, it, inserted, hash);
+                if (inserted)
+                {
+                    it->getMapped() = static_cast<UInt32>(prepared_postings.size());
+                    prepared_postings.push_back({index, shardIndex(hash), key, hash, 0, 0, 0, 0, 0, false});
+                }
+                const UInt32 slot = it->getMapped();
+                ++prepared_postings[slot].additional_rows;
+                posting_slots[position * index_count + index] = slot;
+            }
+        }
+    }
+
+    /// Flatten the entry identifiers of every prepared posting into one array.
+    std::vector<EntryId> posting_entry_ids;
+    {
+        UInt32 offset = 0;
+        for (auto & prepared : prepared_postings)
+        {
+            prepared.entry_id_offset = offset;
+            offset += prepared.additional_rows;
+        }
+        posting_entry_ids.resize(offset);
+        std::vector<UInt32> filled(prepared_postings.size(), 0);
+        for (size_t position = 0; position < block_mutation_count; ++position)
+        {
+            if (!mutations[position].is_new)
+                continue;
+            for (size_t index = 0; index < index_count; ++index)
+            {
+                const UInt32 slot = posting_slots[position * index_count + index];
+                posting_entry_ids[prepared_postings[slot].entry_id_offset + filled[slot]++] = mutations[position].entry_id;
+            }
+        }
+    }
+
+    /// Group new keys by primary shard with a counting sort so each shard is locked once.
+    std::vector<UInt32> primary_shard_offsets(primary_shard_count + 1, 0);
+    std::vector<UInt32> primary_order(new_entries);
+    for (const auto & mutation : mutations)
+    {
+        if (mutation.is_new)
+            ++primary_shard_offsets[shardIndex(mutation.key_hash) + 1];
+    }
+    for (size_t shard_index = 0; shard_index < primary_shard_count; ++shard_index)
+        primary_shard_offsets[shard_index + 1] += primary_shard_offsets[shard_index];
+    {
+        std::vector<UInt32> cursor(primary_shard_offsets.begin(), primary_shard_offsets.end() - 1);
+        for (UInt32 position = 0; position < mutations.size(); ++position)
+        {
+            if (mutations[position].is_new)
+                primary_order[cursor[shardIndex(mutations[position].key_hash)]++] = position;
+        }
     }
 
     std::vector<std::shared_ptr<RowSegment>> retired_segments;
@@ -929,89 +1019,77 @@ void StorageOverwriteCache::insertBlock(const Block & block)
     const UInt64 current_generation = published_generation.load(std::memory_order_acquire);
     if (current_generation == std::numeric_limits<UInt64>::max())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "`OverwriteCache` publication generation space is exhausted");
+    const UInt64 new_generation = current_generation + 1;
 
-    size_t old_entries_by_id_size = 0;
-    UInt64 entries_capacity_delta = 0;
+    const size_t old_entry_count = entries.size();
+    if (next_entry_id != old_entry_count + 1)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` entry identifier sequence");
+    const UInt64 entries_bytes_before = entries.allocatedBytes();
+    entries.grow(old_entry_count + new_entries);
+    const UInt64 entries_bytes_delta = entries.allocatedBytes() - entries_bytes_before;
+    if (prospective_bytes > std::numeric_limits<UInt64>::max() - entries_bytes_delta)
     {
-        std::unique_lock lock(entries_by_id_mutex);
-        old_entries_by_id_size = entries_by_id.size();
-        const size_t old_capacity = entries_by_id.capacity();
-        entries_by_id.reserve(entries_by_id.size() + new_entries);
-        entries_capacity_delta = static_cast<UInt64>(entries_by_id.capacity() - old_capacity) * sizeof(Entry);
-    }
-    if (prospective_bytes > std::numeric_limits<UInt64>::max() - entries_capacity_delta)
-    {
-        total_size_bytes.fetch_add(entries_capacity_delta, std::memory_order_relaxed);
+        total_size_bytes.fetch_add(entries_bytes_delta, std::memory_order_relaxed);
         throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
     }
-    prospective_bytes += entries_capacity_delta;
-    const UInt64 new_generation = current_generation + 1;
+    prospective_bytes += entries_bytes_delta;
+
     std::vector<UInt64> lookup_bytes_delta(lookup_indexes.size());
-    std::vector<UInt64> retained_lookup_bytes(lookup_indexes.size());
-    std::vector<size_t> primary_additions(primary_shards.size());
-    std::vector<UInt64> primary_bucket_bytes_delta(primary_shards.size());
-    for (const auto & mutation : mutations)
-    {
-        if (mutation.is_new)
-            ++primary_additions[primaryShardIndex(mutation.key)];
-    }
+    std::vector<UInt64> primary_shard_bytes_delta(primary_shard_count);
 
     try
     {
-        for (size_t shard_index = 0; shard_index < primary_shards.size(); ++shard_index)
+        for (size_t shard_index = 0; shard_index < primary_shard_count; ++shard_index)
         {
-            if (primary_additions[shard_index] == 0)
+            const UInt32 begin = primary_shard_offsets[shard_index];
+            const UInt32 end = primary_shard_offsets[shard_index + 1];
+            if (begin == end)
                 continue;
             auto & shard = primary_shards[shard_index];
             std::unique_lock lock(shard.mutex);
-            const size_t old_bucket_count = shard.entries.bucket_count();
-            const size_t required_size = shard.entries.size() + primary_additions[shard_index];
-            if (static_cast<double>(required_size)
-                > static_cast<double>(old_bucket_count) * static_cast<double>(shard.entries.max_load_factor()))
-                shard.entries.reserve(required_size);
-            primary_bucket_bytes_delta[shard_index]
-                = static_cast<UInt64>(shard.entries.bucket_count() - old_bucket_count) * sizeof(void *);
-            if (prospective_bytes > std::numeric_limits<UInt64>::max() - primary_bucket_bytes_delta[shard_index])
+            const UInt64 bytes_before = shard.entries.getBufferSizeInBytes() + shard.arena->allocatedBytes();
+            shard.entries.reserve(shard.entries.size() + (end - begin));
+            /// Move the key bytes into the shard arena up front, so publication itself cannot allocate.
+            for (UInt32 position = begin; position < end; ++position)
+            {
+                auto & mutation = mutations[primary_order[position]];
+                mutation.key = std::string_view(shard.arena->insert(mutation.key.data(), mutation.key.size()), mutation.key.size());
+            }
+            primary_shard_bytes_delta[shard_index]
+                = shard.entries.getBufferSizeInBytes() + shard.arena->allocatedBytes() - bytes_before;
+            if (prospective_bytes > std::numeric_limits<UInt64>::max() - primary_shard_bytes_delta[shard_index])
                 throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` primary-index memory accounting overflow");
-            prospective_bytes += primary_bucket_bytes_delta[shard_index];
+            prospective_bytes += primary_shard_bytes_delta[shard_index];
         }
 
         for (auto & prepared : prepared_postings)
         {
             auto & shard = lookup_indexes[prepared.index]->shards[prepared.shard_index];
             std::unique_lock lock(shard.mutex);
-            const size_t old_bucket_count = shard.postings.bucket_count();
-            const size_t required_size = shard.postings.size() + 1;
-            if (static_cast<double>(required_size)
-                > static_cast<double>(old_bucket_count) * static_cast<double>(shard.postings.max_load_factor()))
-                shard.postings.reserve(required_size);
-            prepared.bucket_bytes_delta
-                = static_cast<UInt64>(shard.postings.bucket_count() - old_bucket_count) * sizeof(void *);
-            prepared.prepared = true;
-            if (prospective_bytes > std::numeric_limits<UInt64>::max() - prepared.bucket_bytes_delta)
-                throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` lookup-index memory accounting overflow");
-            prospective_bytes += prepared.bucket_bytes_delta;
-            if (lookup_bytes_delta[prepared.index] > std::numeric_limits<UInt64>::max() - prepared.bucket_bytes_delta)
-                throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` lookup-index memory accounting overflow");
-            lookup_bytes_delta[prepared.index] += prepared.bucket_bytes_delta;
+            const UInt64 bytes_before = shard.index.getBufferSizeInBytes() + shard.arena->allocatedBytes();
 
-            auto [it, inserted] = shard.postings.try_emplace(prepared.key);
-            prepared.old_size = it->second.size();
-            prepared.old_allocated_bytes = it->second.allocatedBytes();
-            prepared.inserted = inserted;
-            prepared.node_bytes = inserted
-                ? sizeof(std::pair<const String, PostingShard::Posting>) + prepared.key.size() + 64
-                : 0;
-            it->second.reserve(it->second.size() + prepared.additional_rows, staged_next_entry_id - 1);
-            prepared.reserved_allocated_bytes = it->second.allocatedBytes();
-            const UInt64 allocated_delta
-                = prepared.reserved_allocated_bytes - prepared.old_allocated_bytes + prepared.node_bytes;
-            if (prospective_bytes > std::numeric_limits<UInt64>::max() - allocated_delta)
-                throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` memory accounting overflow");
-            prospective_bytes += allocated_delta;
-            if (lookup_bytes_delta[prepared.index] > std::numeric_limits<UInt64>::max() - allocated_delta)
+            PostingShard::PostingMap::LookupResult it = nullptr;
+            bool inserted = false;
+            shard.index.emplace(ArenaKeyHolder{prepared.key, *shard.arena}, it, inserted, prepared.key_hash);
+            if (inserted)
+            {
+                it->getMapped() = static_cast<UInt32>(shard.postings.size());
+                shard.postings.emplace_back();
+            }
+            prepared.posting_position = it->getMapped();
+            prepared.prepared = true;
+
+            auto & posting = shard.postings[prepared.posting_position];
+            prepared.old_size = posting.size();
+            const UInt64 posting_bytes_before = posting.allocatedBytes();
+            posting.reserve(posting.size() + prepared.additional_rows, staged_next_entry_id - 1);
+
+            prepared.bytes_delta = shard.index.getBufferSizeInBytes() + shard.arena->allocatedBytes() - bytes_before
+                + posting.allocatedBytes() - posting_bytes_before + (inserted ? sizeof(PostingShard::Posting) : 0);
+            if (prospective_bytes > std::numeric_limits<UInt64>::max() - prepared.bytes_delta)
                 throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` lookup-index memory accounting overflow");
-            lookup_bytes_delta[prepared.index] += allocated_delta;
+            prospective_bytes += prepared.bytes_delta;
+            lookup_bytes_delta[prepared.index] += prepared.bytes_delta;
         }
 
         if (prospective_bytes > settings.max_memory_bytes)
@@ -1021,71 +1099,67 @@ void StorageOverwriteCache::insertBlock(const Block & block)
                 prospective_bytes,
                 settings.max_memory_bytes);
 
-        {
-            std::unique_lock lock(entries_by_id_mutex);
-            for (auto & mutation : mutations)
-            {
-                if (!mutation.is_new)
-                    continue;
-                if (mutation.entry_id != entries_by_id.size() + 1)
-                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupted `OverwriteCache` entry identifier sequence");
-                auto & entry = entries_by_id.emplace_back();
-                entry.pending = std::move(mutation.row);
-                entry.pending_generation = new_generation;
-            }
-        }
-
+        /// Install the pending rows before the keys become reachable, so a reader that finds a key
+        /// either resolves the new row or sees nothing committed yet.
         for (auto & mutation : mutations)
         {
-            if (mutation.is_new)
-            {
-                auto & primary_shard = primary_shards[primaryShardIndex(mutation.key)];
-                {
-                    std::unique_lock lock(primary_shard.mutex);
-                    mutation.primary_inserted = primary_shard.entries.emplace(mutation.key, mutation.entry_id).second;
-                }
-                if (!mutation.primary_inserted)
-                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Duplicate `OverwriteCache` key during publication");
-
-                for (size_t index = 0; index < mutation.lookup_keys.size(); ++index)
-                {
-                    const auto & lookup_key = mutation.lookup_keys[index];
-                    auto & shard = lookup_indexes[index]->shards[postingShardIndex(lookup_key)];
-                    std::unique_lock lock(shard.mutex);
-                    shard.postings.find(lookup_key)->second.push_back(mutation.entry_id);
-                }
-            }
-            else
-            {
-                /// Every indexed column is part of the immutable composite key, so a replacement
-                /// publishes only the new payload and retains the existing postings.
-                auto & entry = entries_by_id[mutation.entry_id - 1];
-                std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry_id)]);
-                if (entry.pending_generation != 0)
-                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Concurrent `OverwriteCache` publication for the same entry");
-                entry.pending = std::move(mutation.row);
-                entry.pending_generation = new_generation;
-                mutation.pending_installed = true;
-            }
-
-            fiu_do_on(FailPoints::overwrite_cache_throw_during_publish, {
-                throw Exception(ErrorCodes::FAULT_INJECTED, "Injected failure during `OverwriteCache` publication");
-            });
+            auto & entry = entries.at(mutation.entry_id);
+            std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry_id)]);
+            if (entry.pending_generation != 0)
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Concurrent `OverwriteCache` publication for the same entry");
+            entry.pending = std::move(mutation.row);
+            entry.pending_generation = new_generation;
+            mutation.pending_installed = true;
         }
+
+        for (size_t shard_index = 0; shard_index < primary_shard_count; ++shard_index)
+        {
+            const UInt32 begin = primary_shard_offsets[shard_index];
+            const UInt32 end = primary_shard_offsets[shard_index + 1];
+            if (begin == end)
+                continue;
+            auto & shard = primary_shards[shard_index];
+            std::unique_lock lock(shard.mutex);
+            for (UInt32 position = begin; position < end; ++position)
+            {
+                auto & mutation = mutations[primary_order[position]];
+                PrimaryMap::LookupResult it = nullptr;
+                bool inserted = false;
+                shard.entries.emplace(mutation.key, it, inserted, mutation.key_hash);
+                if (!inserted)
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Duplicate `OverwriteCache` key during publication");
+                it->getMapped() = mutation.entry_id;
+                mutation.primary_inserted = true;
+            }
+        }
+
+        for (const auto & prepared : prepared_postings)
+        {
+            auto & shard = lookup_indexes[prepared.index]->shards[prepared.shard_index];
+            std::unique_lock lock(shard.mutex);
+            auto & posting = shard.postings[prepared.posting_position];
+            for (UInt32 position = 0; position < prepared.additional_rows; ++position)
+                posting.push_back(posting_entry_ids[prepared.entry_id_offset + position]);
+        }
+
+        fiu_do_on(FailPoints::overwrite_cache_throw_during_publish, {
+            throw Exception(ErrorCodes::FAULT_INJECTED, "Injected failure during `OverwriteCache` publication");
+        });
 
         FailPointInjection::pauseFailPoint(FailPoints::overwrite_cache_pause_before_commit);
     }
     catch (...)
     {
         FailPointInjection::pauseFailPoint(FailPoints::overwrite_cache_pause_before_rollback);
-        UInt64 retained_bytes = entries_capacity_delta;
-        for (const UInt64 bucket_delta : primary_bucket_bytes_delta)
+        /// Hash-table buffers and arena pages cannot shrink, so whatever was reserved stays accounted.
+        UInt64 retained_bytes = entries_bytes_delta;
+        for (const UInt64 bucket_delta : primary_shard_bytes_delta)
             retained_bytes += bucket_delta;
         for (auto & mutation : mutations)
         {
             if (!mutation.pending_installed)
                 continue;
-            auto & entry = entries_by_id[mutation.entry_id - 1];
+            auto & entry = entries.at(mutation.entry_id);
             std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry_id)]);
             entry.pending.reset();
             entry.pending_generation = 0;
@@ -1096,33 +1170,22 @@ void StorageOverwriteCache::insertBlock(const Block & block)
                 continue;
             auto & shard = lookup_indexes[prepared.index]->shards[prepared.shard_index];
             std::unique_lock lock(shard.mutex);
-            retained_bytes += prepared.bucket_bytes_delta;
-            retained_lookup_bytes[prepared.index] += prepared.bucket_bytes_delta;
-            if (const auto it = shard.postings.find(prepared.key); it != shard.postings.end())
-            {
-                it->second.resize(prepared.old_size);
-                if (prepared.inserted)
-                    shard.postings.erase(it);
-                else
-                {
-                    const UInt64 retained_delta = it->second.allocatedBytes() - prepared.old_allocated_bytes;
-                    retained_bytes += retained_delta;
-                    retained_lookup_bytes[prepared.index] += retained_delta;
-                }
-            }
+            /// An empty posting left behind stays correct: it is reachable but contributes no rows.
+            shard.postings[prepared.posting_position].resize(prepared.old_size);
+            retained_bytes += prepared.bytes_delta;
         }
         for (const auto & mutation : mutations)
         {
             if (!mutation.primary_inserted)
                 continue;
-            auto & shard = primary_shards[primaryShardIndex(mutation.key)];
+            auto & shard = primary_shards[shardIndex(mutation.key_hash)];
             std::unique_lock lock(shard.mutex);
-            shard.entries.erase(mutation.key);
+            shard.entries.erase(mutation.key, mutation.key_hash);
         }
 
         total_size_bytes.fetch_add(retained_bytes, std::memory_order_relaxed);
-        for (size_t index = 0; index < retained_lookup_bytes.size(); ++index)
-            lookup_indexes[index]->accounted_bytes.fetch_add(retained_lookup_bytes[index], std::memory_order_relaxed);
+        for (size_t index = 0; index < lookup_bytes_delta.size(); ++index)
+            lookup_indexes[index]->accounted_bytes.fetch_add(lookup_bytes_delta[index], std::memory_order_relaxed);
 
         if (new_entries != 0)
         {
@@ -1136,10 +1199,7 @@ void StorageOverwriteCache::insertBlock(const Block & block)
                 active = active_readers[old_epoch].load(std::memory_order_acquire);
             }
         }
-        {
-            std::unique_lock lock(entries_by_id_mutex);
-            entries_by_id.resize(old_entries_by_id_size);
-        }
+        entries.shrink(old_entry_count);
         throw;
     }
 
@@ -1173,7 +1233,7 @@ void StorageOverwriteCache::insertBlock(const Block & block)
 
     for (auto & mutation : mutations)
     {
-        auto & entry = entries_by_id[mutation.entry_id - 1];
+        auto & entry = entries.at(mutation.entry_id);
         std::lock_guard lock(row_mutexes[rowLockIndex(mutation.entry_id)]);
         entry.committed = std::move(*entry.pending);
         entry.pending.reset();
@@ -1189,7 +1249,7 @@ StorageOverwriteCache::ReadResult StorageOverwriteCache::getRowsForPrimaryKeys(c
     std::unordered_set<EntryId> seen;
     for (const auto & key : serialized_keys)
     {
-        const auto entry = findEntry(key);
+        const auto entry = findEntry(key, StringViewHash{}(key));
         if (!entry || !seen.emplace(*entry).second)
             continue;
         if (auto row = resolveEntry(*entry, result.guard->generation()))
@@ -1207,10 +1267,11 @@ UInt64 StorageOverwriteCache::getPostingCardinality(const LookupIndexPtr & index
     {
         if (!seen_keys.emplace(key).second)
             continue;
-        const auto & shard = index->shards[postingShardIndex(key)];
+        const size_t hash = StringViewHash{}(key);
+        const auto & shard = index->shards[shardIndex(hash)];
         std::shared_lock lock(shard.mutex);
-        if (const auto it = shard.postings.find(key); it != shard.postings.end())
-            result += it->second.size();
+        if (const auto * posting = shard.find(key, hash))
+            result += posting->size();
     }
     return result;
 }
@@ -1226,11 +1287,12 @@ StorageOverwriteCache::getPostingIds(const LookupIndexPtr & index, const std::ve
     {
         if (!seen_keys.emplace(key).second)
             continue;
-        const auto & shard = index->shards[postingShardIndex(key)];
+        const size_t hash = StringViewHash{}(key);
+        const auto & shard = index->shards[shardIndex(hash)];
         std::shared_lock lock(shard.mutex);
-        if (const auto it = shard.postings.find(key); it != shard.postings.end())
+        if (const auto * posting = shard.find(key, hash))
         {
-            it->second.forEach([&](EntryId entry_id)
+            posting->forEach([&](EntryId entry_id)
             {
                 if ((result.size() & 4095) == 0 && CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
                     throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled while reading an `OverwriteCache` posting");
@@ -1256,16 +1318,17 @@ void StorageOverwriteCache::intersectPostingIds(
     {
         if (!seen_keys.emplace(key).second)
             continue;
-        const auto & shard = index->shards[postingShardIndex(key)];
+        const size_t hash = StringViewHash{}(key);
+        const auto & shard = index->shards[shardIndex(hash)];
         std::shared_lock lock(shard.mutex);
-        const auto it = shard.postings.find(key);
-        if (it == shard.postings.end())
+        const auto * posting = shard.find(key, hash);
+        if (!posting)
             continue;
         for (size_t position = 0; position < entry_ids.size(); ++position)
         {
             if ((position & 4095) == 0 && CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
                 throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled while intersecting `OverwriteCache` postings");
-            if (!matched[position] && it->second.contains(entry_ids[position]))
+            if (!matched[position] && posting->contains(entry_ids[position]))
                 matched[position] = 1;
         }
     }
@@ -1380,7 +1443,8 @@ Chunk StorageOverwriteCache::getByKeys(
     {
         WriteBufferFromOwnString out;
         for (size_t key_index = 0; key_index < keys.size(); ++key_index)
-            key_column_types[key_index]->getDefaultSerialization()->serializeBinary(*keys[key_index].column, row, out, {});
+            key_column_types[key_index]->getDefaultSerialization()->serializeBinary(
+                *keys[key_index].column, row, out, format_settings);
         serialized_keys.push_back(out.str());
     }
 
@@ -1388,10 +1452,11 @@ Chunk StorageOverwriteCache::getByKeys(
     std::vector<RowDataPtr> resolved_rows(rows);
     for (size_t row = 0; row < rows; ++row)
     {
-        if (const auto entry = findEntry(serialized_keys[row]))
+        if (const auto entry = findEntry(serialized_keys[row], StringViewHash{}(serialized_keys[row])))
             resolved_rows[row] = resolveEntry(*entry, read_guard.generation());
     }
 
+    SegmentColumnCache segment_columns;
     for (size_t row = 0; row < rows; ++row)
     {
         if (!resolved_rows[row])
@@ -1402,7 +1467,7 @@ Chunk StorageOverwriteCache::getByKeys(
         }
         out_null_map[row] = 1;
         for (size_t column = 0; column < result_positions.size(); ++column)
-            insertValueIntoColumn(*resolved_rows[row], result_positions[column], *result_columns[column]);
+            insertValueIntoColumn(*resolved_rows[row], result_positions[column], *result_columns[column], segment_columns);
     }
 
     return Chunk(std::move(result_columns), rows);
@@ -1438,22 +1503,28 @@ void StorageOverwriteCache::clearData()
         for (auto & shard : index->shards)
         {
             std::unique_lock lock(shard.mutex);
-            decltype(shard.postings) empty;
-            shard.postings.swap(empty);
+            shard.index = PostingShard::PostingMap{};
+            std::deque<PostingShard::Posting>().swap(shard.postings);
+            shard.arena = std::make_unique<Arena>();
         }
         index->accounted_bytes.store(0, std::memory_order_relaxed);
     }
     for (auto & shard : primary_shards)
     {
         std::unique_lock lock(shard.mutex);
-        decltype(shard.entries) empty;
-        shard.entries.swap(empty);
+        shard.entries = PrimaryMap{};
+        shard.arena = std::make_unique<Arena>();
     }
+    /// Entries are reachable without a lock, so no reader that already resolved an identifier may
+    /// still be inside the table when its storage is released.
+    const UInt8 old_epoch = active_reader_epoch.fetch_xor(1, std::memory_order_acq_rel);
+    UInt64 active = active_readers[old_epoch].load(std::memory_order_acquire);
+    while (active != 0)
     {
-        std::unique_lock lock(entries_by_id_mutex);
-        decltype(entries_by_id) empty;
-        entries_by_id.swap(empty);
+        active_readers[old_epoch].wait(active, std::memory_order_relaxed);
+        active = active_readers[old_epoch].load(std::memory_order_acquire);
     }
+    entries.clear();
     next_entry_id = 1;
     published_generation.store(0, std::memory_order_release);
     total_size_bytes.store(0, std::memory_order_relaxed);
@@ -1591,13 +1662,26 @@ void StorageOverwriteCache::alter(const AlterCommands & commands, ContextPtr con
     auto shadow = std::make_shared<LookupIndex>();
     UInt64 index_bytes = 0;
     size_t snapshot_entry_count = 0;
+    SegmentColumnCache segment_columns;
+    const auto add_to_shadow = [&](EntryId entry_id, const RowData & row)
+    {
+        const String key = serializeRowColumns(row, positions, segment_columns);
+        auto & shard = shadow->shards[shardIndex(StringViewHash{}(key))];
+        PostingShard::PostingMap::LookupResult it = nullptr;
+        bool inserted = false;
+        shard.index.emplace(ArenaKeyHolder{key, *shard.arena}, it, inserted, StringViewHash{}(key));
+        if (inserted)
+        {
+            it->getMapped() = static_cast<UInt32>(shard.postings.size());
+            shard.postings.emplace_back();
+        }
+        shard.postings[it->getMapped()].push_back(entry_id);
+    };
+
     std::unique_ptr<ReadGuard> snapshot_guard;
     {
         std::lock_guard writer_lock(writer_mutex);
-        {
-            std::shared_lock lock(entries_by_id_mutex);
-            snapshot_entry_count = entries_by_id.size();
-        }
+        snapshot_entry_count = entries.size();
         snapshot_guard = std::make_unique<ReadGuard>(*this);
     }
     for (EntryId entry_id = 1; entry_id <= snapshot_entry_count; ++entry_id)
@@ -1605,9 +1689,7 @@ void StorageOverwriteCache::alter(const AlterCommands & commands, ContextPtr con
         const auto row = resolveEntry(entry_id, snapshot_guard->generation());
         if (!row)
             continue;
-        String key = serializeRowColumns(*row, positions);
-        auto & posting = shadow->shards[postingShardIndex(key)].postings[key];
-        posting.push_back(entry_id);
+        add_to_shadow(entry_id, *row);
     }
     snapshot_guard.reset();
 
@@ -1618,35 +1700,23 @@ void StorageOverwriteCache::alter(const AlterCommands & commands, ContextPtr con
     });
 
     std::unique_lock writer_lock(writer_mutex);
-    size_t catch_up_entry_count = 0;
-    {
-        std::shared_lock lock(entries_by_id_mutex);
-        catch_up_entry_count = entries_by_id.size();
-    }
+    const size_t catch_up_entry_count = entries.size();
     ReadGuard catch_up_guard(*this);
     for (EntryId entry_id = snapshot_entry_count + 1; entry_id <= catch_up_entry_count; ++entry_id)
     {
         const auto row = resolveEntry(entry_id, catch_up_guard.generation());
         if (!row)
             continue;
-        String key = serializeRowColumns(*row, positions);
-        auto & posting = shadow->shards[postingShardIndex(key)].postings[key];
-        posting.push_back(entry_id);
+        add_to_shadow(entry_id, *row);
     }
     for (const auto & shard : shadow->shards)
     {
-        const UInt64 bucket_bytes = static_cast<UInt64>(shard.postings.bucket_count()) * sizeof(void *);
-        if (index_bytes > std::numeric_limits<UInt64>::max() - bucket_bytes)
+        UInt64 shard_bytes = shard.index.getBufferSizeInBytes() + shard.arena->allocatedBytes();
+        for (const auto & posting : shard.postings)
+            shard_bytes += sizeof(PostingShard::Posting) + posting.allocatedBytes();
+        if (index_bytes > std::numeric_limits<UInt64>::max() - shard_bytes)
             throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` lookup-index memory accounting overflow");
-        index_bytes += bucket_bytes;
-        for (const auto & [key, posting] : shard.postings)
-        {
-            const UInt64 posting_bytes
-                = key.size() + sizeof(std::pair<const String, PostingShard::Posting>) + 64 + posting.allocatedBytes();
-            if (index_bytes > std::numeric_limits<UInt64>::max() - posting_bytes)
-                throw Exception(ErrorCodes::MEMORY_LIMIT_EXCEEDED, "`OverwriteCache` lookup-index memory accounting overflow");
-            index_bytes += posting_bytes;
-        }
+        index_bytes += shard_bytes;
     }
 
     const UInt64 current_bytes = total_size_bytes.load(std::memory_order_relaxed);

--- a/src/Storages/StorageOverwriteCache.h
+++ b/src/Storages/StorageOverwriteCache.h
@@ -5,6 +5,7 @@
 #include <Formats/FormatSettings.h>
 #include <Interpreters/IKeyValueEntity.h>
 #include <Storages/IStorage.h>
+#include <Storages/OverwriteCachePersistence.h>
 
 #include <Common/Arena.h>
 #include <Common/HashTable/HashMap.h>
@@ -31,12 +32,16 @@ namespace DB
 {
 
 class StorageFactory;
+class IBackup;
+using BackupPtr = std::shared_ptr<const IBackup>;
 
 struct OverwriteCacheSettings
 {
     UInt64 max_memory_bytes = 0;
     Names equal_version_tiebreak_columns;
     bool compress_segments = false;
+    OverwriteCachePersistMode persist_mode = OverwriteCachePersistMode::Async;
+    String disk_name = "default";
 };
 
 class StorageOverwriteCache final : public IStorage, public IKeyValueEntity
@@ -51,6 +56,9 @@ public:
         std::vector<EntryId> entry_ids;
         UInt64 allocated_bytes = 0;
         std::atomic<UInt64> live_rows{0};
+        /// The file this segment is stored in, or zero while the table is not persisted. A segment is
+        /// immutable, so it is written once and its file is removed when the segment is released.
+        UInt64 persistent_id = 0;
     };
 
     struct RowData
@@ -126,7 +134,9 @@ public:
         std::vector<Names> lookup_indexes_,
         ASTPtr lookup_indexes_ast_,
         OverwriteCacheSettings settings_,
-        ASTPtr settings_changes_);
+        ASTPtr settings_changes_,
+        DiskPtr disk_,
+        const String & relative_data_path_);
 
     String getName() const override { return "OverwriteCache"; }
 
@@ -152,6 +162,12 @@ public:
         ContextPtr context,
         TableExclusiveLockHolder & table_lock_holder) override;
     void drop() override;
+    void shutdown(bool is_drop) override;
+    void rename(const String & new_path_to_table_data, const StorageID & new_table_id) override;
+
+    void backupData(BackupEntriesCollector & backup_entries_collector, const String & data_path_in_backup, const std::optional<ASTs> & partitions) override;
+    void restoreDataFromBackup(RestorerFromBackup & restorer, const String & data_path_in_backup, const std::optional<ASTs> & partitions) override;
+
     void checkAlterIsPossible(const AlterCommands & commands, ContextPtr context) const override;
     void alter(const AlterCommands & commands, ContextPtr context, AlterLockHolder & lock_holder) override;
 
@@ -184,10 +200,21 @@ public:
     void insertBlock(const Block & block);
 
 private:
+    /// While replaying the persisted log, `replay_segment_id` names the file the block came from, so that
+    /// the segment it produces keeps mirroring that file instead of being written out a second time.
+    void insertBlock(const Block & block, UInt64 replay_segment_id);
     /// Removes the keys of `block` from the cache. The rows to remove are produced by the read path,
     /// so a `DELETE` accepts exactly the predicates a `SELECT` accepts.
     void deleteBlock(const Block & block);
     size_t deleteKeys(const std::vector<String> & serialized_keys);
+
+    /// Replays the persisted log, then starts persisting. Runs from the constructor, so an `ATTACH` that
+    /// cannot restore the table fails instead of exposing an incomplete cache.
+    void loadPersistedData();
+    void restoreDataImpl(const BackupPtr & backup, const String & data_path_in_backup);
+    /// Builds the identity a persisted log is checked against. A log written for different columns, keys,
+    /// version or tie-break columns would be reinterpreted rather than rejected.
+    String getPersistenceFingerprint() const;
 
     struct EntryVersion
     {
@@ -464,6 +491,13 @@ private:
 
     std::atomic<UInt64> total_size_bytes = 0;
     std::atomic<UInt64> total_size_rows = 0;
+
+    OverwriteCachePersistencePtr persistence;
+    /// Set while the log is being replayed. Segment compaction is left alone during replay, so that the
+    /// segments in memory keep mirroring the files one to one and no rewritten segment goes unrecorded.
+    bool loading = false;
+    /// Files whose every row lost during replay. They are retired once persistence has started.
+    std::vector<UInt64> retired_during_load;
 };
 
 void registerStorageOverwriteCache(StorageFactory & factory);

--- a/src/Storages/StorageOverwriteCache.h
+++ b/src/Storages/StorageOverwriteCache.h
@@ -155,6 +155,12 @@ public:
     void checkAlterIsPossible(const AlterCommands & commands, ContextPtr context) const override;
     void alter(const AlterCommands & commands, ContextPtr context, AlterLockHolder & lock_holder) override;
 
+    /// `DELETE FROM` is executed by the storage itself rather than translated into a lightweight
+    /// update, because there is no part to rewrite and no `_row_exists` column to mask.
+    bool supportsDelete() const override { return true; }
+    void checkMutationIsPossible(const MutationCommands & commands, const Settings & settings) const override;
+    void mutate(const MutationCommands & commands, ContextPtr context) override;
+
     std::optional<UInt64> totalRows(ContextPtr) const override;
     std::optional<UInt64> totalBytes(ContextPtr) const override;
 
@@ -178,6 +184,11 @@ public:
     void insertBlock(const Block & block);
 
 private:
+    /// Removes the keys of `block` from the cache. The rows to remove are produced by the read path,
+    /// so a `DELETE` accepts exactly the predicates a `SELECT` accepts.
+    void deleteBlock(const Block & block);
+    size_t deleteKeys(const std::vector<String> & serialized_keys);
+
     struct EntryVersion
     {
         RowData row;

--- a/src/Storages/StorageOverwriteCache.h
+++ b/src/Storages/StorageOverwriteCache.h
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <Core/Block.h>
+#include <Core/Field.h>
+#include <Core/Names.h>
+#include <Interpreters/IKeyValueEntity.h>
+#include <Storages/IStorage.h>
+
+#include <array>
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace DB
+{
+
+class StorageFactory;
+
+struct OverwriteCacheSettings
+{
+    UInt64 max_memory_bytes = 0;
+    Names equal_version_tiebreak_columns;
+    Names secondary_index_columns;
+    std::optional<String> secondary_index_segment_column;
+    UInt64 max_secondary_index_rows = 0;
+};
+
+class StorageOverwriteCache final : public IStorage, public IKeyValueEntity
+{
+public:
+    using EntryId = UInt64;
+
+    struct RowData
+    {
+        std::vector<Field> values;
+        String primary_key;
+        String secondary_key;
+        String segmented_secondary_key;
+        UInt64 accounted_bytes = 0;
+    };
+
+    using RowDataPtr = std::shared_ptr<const RowData>;
+    using RowDataPtrs = std::vector<RowDataPtr>;
+
+    StorageOverwriteCache(
+        const StorageID & table_id_,
+        ColumnsDescription columns_description_,
+        ConstraintsDescription constraints_,
+        String comment_,
+        String version_column_,
+        Names key_columns_,
+        OverwriteCacheSettings settings_,
+        ASTPtr settings_changes_);
+
+    String getName() const override { return "OverwriteCache"; }
+
+    bool prefersLargeBlocks() const override { return false; }
+    bool supportsParallelInsert() const override { return false; }
+
+    void read(
+        QueryPlan & query_plan,
+        const Names & column_names,
+        const StorageSnapshotPtr & storage_snapshot,
+        SelectQueryInfo & query_info,
+        ContextPtr context,
+        QueryProcessingStage::Enum processed_stage,
+        size_t max_block_size,
+        size_t num_streams) override;
+
+    SinkToStoragePtr
+    write(const ASTPtr & query, const StorageMetadataPtr & metadata_snapshot, ContextPtr context, bool async_insert) override;
+
+    void truncate(
+        const ASTPtr & query,
+        const StorageMetadataPtr & metadata_snapshot,
+        ContextPtr context,
+        TableExclusiveLockHolder & table_lock_holder) override;
+
+    void drop() override;
+
+    std::optional<UInt64> totalRows(ContextPtr) const override;
+    std::optional<UInt64> totalBytes(ContextPtr) const override;
+
+    Names getPrimaryKey() const override { return key_columns; }
+    Chunk getByKeys(
+        const ColumnsWithTypeAndName & keys,
+        const Names & required_columns,
+        PaddedPODArray<UInt8> & out_null_map,
+        IColumn::Offsets & out_offsets) const override;
+    Block getSampleBlock(const Names & required_columns) const override;
+
+    const Names & getKeyColumns() const { return key_columns; }
+    const DataTypes & getKeyColumnTypes() const { return key_column_types; }
+    const Names & getSecondaryIndexColumns() const { return settings.secondary_index_columns; }
+    const DataTypes & getSecondaryIndexColumnTypes() const { return secondary_index_column_types; }
+    const Names & getSegmentedSecondaryIndexColumns() const { return segmented_secondary_index_columns; }
+    const DataTypes & getSegmentedSecondaryIndexColumnTypes() const { return segmented_secondary_index_column_types; }
+    UInt64 getMaxSecondaryIndexRows() const { return settings.max_secondary_index_rows; }
+
+    RowDataPtrs getRowsForPrimaryKeys(const std::vector<String> & serialized_keys) const;
+    RowDataPtrs getRowsForSecondaryKeys(const std::vector<String> & serialized_keys) const;
+    RowDataPtrs getRowsForSegmentedSecondaryKeys(const std::vector<String> & serialized_keys) const;
+    size_t getColumnPosition(const String & column_name) const;
+
+    void insertBlock(const Block & block);
+
+private:
+    struct Candidate;
+
+    enum class PublicationState : UInt8
+    {
+        Preparing,
+        Committed,
+        Aborted,
+    };
+
+    struct Publication
+    {
+        explicit Publication(UInt64 generation_) : generation(generation_) {}
+
+        const UInt64 generation;
+        std::atomic<PublicationState> state = PublicationState::Preparing;
+    };
+
+    struct Entry
+    {
+        EntryId id = 0;
+        RowDataPtr committed;
+        RowDataPtr pending;
+        std::shared_ptr<Publication> pending_publication;
+    };
+
+    using EntryPtr = std::shared_ptr<Entry>;
+
+    static constexpr size_t primary_shard_count = 256;
+    static constexpr size_t posting_shard_count = 256;
+    static constexpr size_t row_lock_count = 4096;
+
+    struct PrimaryShard
+    {
+        mutable std::shared_mutex mutex;
+        std::unordered_map<String, EntryPtr> entries;
+    };
+
+    struct PostingShard
+    {
+        mutable std::shared_mutex mutex;
+        std::unordered_map<String, std::vector<EntryPtr>> postings;
+    };
+
+    class ReadGuard
+    {
+    public:
+        explicit ReadGuard(const StorageOverwriteCache & storage_);
+        ~ReadGuard();
+
+        UInt64 generation() const { return snapshot_generation; }
+
+    private:
+        const StorageOverwriteCache & storage;
+        UInt8 epoch = 0;
+        UInt64 snapshot_generation = 0;
+    };
+
+    String serializeColumns(const Block & block, size_t row, const std::vector<size_t> & positions) const;
+    String serializeFields(const std::vector<Field> & fields, const std::vector<size_t> & positions) const;
+    int compareWinner(const RowData & lhs, const RowData & rhs) const;
+    bool rowsEqual(const RowData & lhs, const RowData & rhs) const;
+    UInt64 estimateRowBytes(const Block & block, size_t row, const RowData & data) const;
+    size_t primaryShardIndex(const String & key) const;
+    size_t postingShardIndex(const String & key) const;
+    size_t rowLockIndex(EntryId entry_id) const;
+    EntryPtr findEntry(const String & key) const;
+    RowDataPtr resolveEntry(const EntryPtr & entry, UInt64 snapshot_generation) const;
+    RowDataPtrs getRowsForPostingKeys(
+        const std::vector<String> & serialized_keys,
+        const std::array<PostingShard, posting_shard_count> & index,
+        const char * index_name) const;
+    void clearData();
+
+    const String version_column;
+    const Names key_columns;
+    const OverwriteCacheSettings settings;
+
+    Block sample_block;
+    Serializations serializations;
+    DataTypes column_types;
+    std::unordered_map<String, size_t> column_positions;
+    std::vector<size_t> key_positions;
+    DataTypes key_column_types;
+    size_t version_position = 0;
+    std::vector<size_t> tiebreak_positions;
+    std::vector<size_t> secondary_index_positions;
+    DataTypes secondary_index_column_types;
+    Names segmented_secondary_index_columns;
+    std::vector<size_t> segmented_secondary_index_positions;
+    DataTypes segmented_secondary_index_column_types;
+
+    mutable std::mutex writer_mutex;
+    std::array<PrimaryShard, primary_shard_count> primary_shards;
+    std::array<PostingShard, posting_shard_count> secondary_shards;
+    std::array<PostingShard, posting_shard_count> segmented_secondary_shards;
+    mutable std::array<std::mutex, row_lock_count> row_mutexes;
+    EntryId next_entry_id = 1;
+
+    std::atomic<UInt64> published_generation = 0;
+    mutable std::atomic<UInt8> active_reader_epoch = 0;
+    mutable std::array<std::atomic<UInt64>, 2> active_readers{};
+
+    std::atomic<UInt64> total_size_bytes = 0;
+    std::atomic<UInt64> total_size_rows = 0;
+};
+
+void registerStorageOverwriteCache(StorageFactory & factory);
+
+}

--- a/src/Storages/StorageOverwriteCache.h
+++ b/src/Storages/StorageOverwriteCache.h
@@ -9,6 +9,7 @@
 #include <Common/Arena.h>
 #include <Common/HashTable/HashMap.h>
 #include <Common/PODArray.h>
+#include <Common/SharedMutex.h>
 #include <base/StringViewHash.h>
 
 #include <algorithm>
@@ -20,7 +21,6 @@
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <shared_mutex>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
@@ -246,7 +246,7 @@ private:
 
     struct PrimaryShard
     {
-        mutable std::shared_mutex mutex;
+        mutable SharedMutex mutex;
         PrimaryMap entries;
         /// Owns the key bytes referenced by `entries`.
         std::unique_ptr<Arena> arena = std::make_unique<Arena>();
@@ -342,7 +342,7 @@ public:
             return it ? &postings[it->getMapped()] : nullptr;
         }
 
-        mutable std::shared_mutex mutex;
+        mutable SharedMutex mutex;
         PostingMap index;
         std::deque<Posting> postings;
         std::unique_ptr<Arena> arena = std::make_unique<Arena>();
@@ -398,7 +398,7 @@ private:
     std::vector<DataTypes> lookup_index_column_types;
 
     mutable std::mutex writer_mutex;
-    mutable std::shared_mutex lookup_catalog_mutex;
+    mutable SharedMutex lookup_catalog_mutex;
     std::array<PrimaryShard, primary_shard_count> primary_shards;
     std::vector<LookupIndexPtr> lookup_indexes;
     EntryTable entries;

--- a/src/Storages/StorageOverwriteCache.h
+++ b/src/Storages/StorageOverwriteCache.h
@@ -394,11 +394,10 @@ private:
     String serializeRowColumns(const RowData & row, const std::vector<size_t> & positions, SegmentColumnCache & cache) const;
 
     /// Winner selection compares values in place: the version and tie-break columns are never compressed,
-    /// so no row payload is ever materialized to pick a winner.
+    /// so no row payload is ever materialized to pick a winner. A row that ties on both never replaces the
+    /// row already stored, whatever its payload is.
     int compareWinner(const Block & block, size_t lhs_row, size_t rhs_row) const;
     int compareWinner(const Block & block, size_t lhs_row, const RowData & rhs) const;
-    UInt128 rowDigest(const Block & block, size_t row) const;
-    UInt128 rowDigest(const RowData & row, SegmentColumnCache & cache) const;
 
     /// The hash tables index themselves by the low bits, so the shard is chosen from the high ones.
     static size_t shardIndex(size_t hash) { return hash >> 56; }

--- a/src/Storages/StorageOverwriteCache.h
+++ b/src/Storages/StorageOverwriteCache.h
@@ -1,19 +1,27 @@
 #pragma once
 
 #include <Core/Block.h>
-#include <Core/Field.h>
 #include <Core/Names.h>
+#include <Formats/FormatSettings.h>
 #include <Interpreters/IKeyValueEntity.h>
 #include <Storages/IStorage.h>
+
+#include <Common/Arena.h>
+#include <Common/HashTable/HashMap.h>
+#include <Common/PODArray.h>
+#include <base/StringViewHash.h>
 
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <bit>
+#include <deque>
 #include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -27,6 +35,7 @@ struct OverwriteCacheSettings
 {
     UInt64 max_memory_bytes = 0;
     Names equal_version_tiebreak_columns;
+    bool compress_segments = false;
 };
 
 class StorageOverwriteCache final : public IStorage, public IKeyValueEntity
@@ -36,6 +45,9 @@ public:
     struct RowSegment
     {
         Columns columns;
+        /// One entry identifier per stored row. A row is dead when its entry no longer points back here,
+        /// which makes compaction proportional to the segment instead of to the whole table.
+        std::vector<EntryId> entry_ids;
         UInt64 allocated_bytes = 0;
         std::atomic<UInt64> live_rows{0};
     };
@@ -46,13 +58,24 @@ public:
         UInt32 segment_row = 0;
     };
 
-    struct CandidateRow
+    /// Memoizes decompressed segment columns for the duration of one operation. Without it every row
+    /// access decompresses a whole segment column, which makes reads and replacements quadratic.
+    class SegmentColumnCache
     {
-        UInt32 source_row = 0;
-        String encoded_values;
-        std::vector<UInt32> value_offsets;
-        String primary_key;
-        std::vector<String> lookup_keys;
+    public:
+        const IColumn & get(const RowSegment & segment, size_t position)
+        {
+            auto & columns = cache[&segment];
+            if (columns.empty())
+                columns.resize(segment.columns.size());
+            auto & column = columns[position];
+            if (!column)
+                column = segment.columns[position]->decompress();
+            return *column;
+        }
+
+    private:
+        std::unordered_map<const RowSegment *, Columns> cache;
     };
 
     using RowDataPtr = std::optional<RowData>;
@@ -149,13 +172,11 @@ public:
     ReadResult getRowsForPrimaryKeys(const std::vector<String> & serialized_keys) const;
     ReadResult getRowsForLookupRequests(const std::vector<LookupRequest> & requests) const;
     size_t getColumnPosition(const String & column_name) const;
-    void insertValueIntoColumn(const RowData & row, size_t position, IColumn & column) const;
+    void insertValueIntoColumn(const RowData & row, size_t position, IColumn & column, SegmentColumnCache & cache) const;
 
     void insertBlock(const Block & block);
 
 private:
-    struct Candidate;
-
     struct Entry
     {
         std::optional<RowData> committed;
@@ -163,15 +184,72 @@ private:
         UInt64 pending_generation = 0;
     };
 
+    /// Chunked, never-relocating entry array. Chunk sizes double, so a tiny table costs a few entries
+    /// while a large one needs only a handful of chunks. Readers reach an entry without any lock.
+    class EntryTable
+    {
+    public:
+        ~EntryTable() { clear(); }
+
+        size_t size() const { return entry_count.load(std::memory_order_acquire); }
+
+        Entry & at(EntryId entry_id) const
+        {
+            const size_t index = static_cast<size_t>(entry_id) - 1;
+            if (index < base_size)
+                return chunks[0].load(std::memory_order_acquire)[index];
+            const size_t level = std::bit_width(index) - base_shift;
+            return chunks[level].load(std::memory_order_acquire)[index - (1ULL << (level + base_shift - 1))];
+        }
+
+        /// Both grow and shrink run under the writer lock.
+        void grow(size_t new_size);
+        void shrink(size_t new_size);
+        void clear();
+
+        UInt64 allocatedBytes() const { return static_cast<UInt64>(allocated_entries) * sizeof(Entry); }
+
+    private:
+        static constexpr size_t base_shift = 2;
+        static constexpr size_t base_size = 1ULL << base_shift;
+        static constexpr size_t max_chunks = 8 * sizeof(size_t) - base_shift + 1;
+
+        static size_t chunkCapacity(size_t level) { return level ? 1ULL << (level + base_shift - 1) : base_size; }
+
+        std::array<std::atomic<Entry *>, max_chunks> chunks{};
+        size_t chunk_count = 0;
+        size_t allocated_entries = 0;
+        std::atomic<size_t> entry_count = 0;
+    };
+
+    /// Serialized keys of one input block for one column tuple, packed into a single buffer.
+    struct SerializedKeys
+    {
+        PODArray<char> data;
+        PODArray<UInt64> offsets;
+        PODArray<UInt64> hashes;
+
+        std::string_view at(size_t row) const
+        {
+            const UInt64 begin = row ? offsets[row - 1] : 0;
+            return {data.data() + begin, offsets[row] - begin};
+        }
+    };
 
     static constexpr size_t primary_shard_count = 256;
     static constexpr size_t posting_shard_count = 256;
     static constexpr size_t row_lock_count = 4096;
+    static_assert(primary_shard_count == 256 && posting_shard_count == 256, "shardIndex takes the top eight hash bits");
+
+    /// A small initial capacity keeps the fixed cost of a nearly empty shard low.
+    using PrimaryMap = HashMapWithSavedHash<std::string_view, EntryId, StringViewHash, HashTableGrowerWithPrecalculation<3>>;
 
     struct PrimaryShard
     {
         mutable std::shared_mutex mutex;
-        std::unordered_map<String, EntryId> entries;
+        PrimaryMap entries;
+        /// Owns the key bytes referenced by `entries`.
+        std::unique_ptr<Arena> arena = std::make_unique<Arena>();
     };
 
 public:
@@ -254,8 +332,20 @@ public:
             std::vector<EntryId> wide;
         };
 
+        /// The hash map stores only a position, so its cells stay trivially relocatable while the
+        /// postings themselves keep stable addresses in the deque.
+        using PostingMap = HashMapWithSavedHash<std::string_view, UInt32, StringViewHash, HashTableGrowerWithPrecalculation<3>>;
+
+        const Posting * find(std::string_view key, size_t hash) const
+        {
+            const auto * it = index.find(key, hash);
+            return it ? &postings[it->getMapped()] : nullptr;
+        }
+
         mutable std::shared_mutex mutex;
-        std::unordered_map<String, Posting> postings;
+        PostingMap index;
+        std::deque<Posting> postings;
+        std::unique_ptr<Arena> arena = std::make_unique<Arena>();
     };
 
 
@@ -266,18 +356,21 @@ public:
     };
 
 private:
+    void serializeKeys(const Block & block, const std::vector<size_t> & positions, SerializedKeys & result) const;
     String serializeColumns(const Block & block, size_t row, const std::vector<size_t> & positions) const;
-    String serializeRowColumns(const RowData & row, const std::vector<size_t> & positions) const;
-    Field getRowField(const RowData & row, size_t position) const;
-    Field getCandidateField(const CandidateRow & row, size_t position) const;
-    int compareWinner(const CandidateRow & lhs, const CandidateRow & rhs) const;
-    int compareWinner(const CandidateRow & lhs, const RowData & rhs) const;
-    bool rowsEqual(const CandidateRow & lhs, const RowData & rhs) const;
+    String serializeRowColumns(const RowData & row, const std::vector<size_t> & positions, SegmentColumnCache & cache) const;
 
-    size_t primaryShardIndex(const String & key) const;
-    size_t postingShardIndex(const String & key) const;
+    /// Winner selection compares values in place: the version and tie-break columns are never compressed,
+    /// so no row payload is ever materialized to pick a winner.
+    int compareWinner(const Block & block, size_t lhs_row, size_t rhs_row) const;
+    int compareWinner(const Block & block, size_t lhs_row, const RowData & rhs) const;
+    UInt128 rowDigest(const Block & block, size_t row) const;
+    UInt128 rowDigest(const RowData & row, SegmentColumnCache & cache) const;
+
+    /// The hash tables index themselves by the low bits, so the shard is chosen from the high ones.
+    static size_t shardIndex(size_t hash) { return hash >> 56; }
     size_t rowLockIndex(EntryId entry_id) const;
-    std::optional<EntryId> findEntry(const String & key) const;
+    std::optional<EntryId> findEntry(std::string_view key, size_t hash) const;
     RowDataPtr resolveEntry(EntryId entry_id, UInt64 snapshot_generation) const;
     std::vector<EntryId> getPostingIds(const LookupIndexPtr & index, const std::vector<String> & serialized_keys) const;
     UInt64 getPostingCardinality(const LookupIndexPtr & index, const std::vector<String> & serialized_keys) const;
@@ -292,12 +385,15 @@ private:
 
     Block sample_block;
     Serializations serializations;
+    FormatSettings format_settings;
     DataTypes column_types;
     std::unordered_map<String, size_t> column_positions;
     std::vector<size_t> key_positions;
     DataTypes key_column_types;
     size_t version_position = 0;
     std::vector<size_t> tiebreak_positions;
+    /// The version and tie-break columns must stay directly comparable inside a segment.
+    std::vector<bool> keep_uncompressed;
     std::vector<std::vector<size_t>> lookup_index_positions;
     std::vector<DataTypes> lookup_index_column_types;
 
@@ -305,8 +401,7 @@ private:
     mutable std::shared_mutex lookup_catalog_mutex;
     std::array<PrimaryShard, primary_shard_count> primary_shards;
     std::vector<LookupIndexPtr> lookup_indexes;
-    mutable std::shared_mutex entries_by_id_mutex;
-    std::vector<Entry> entries_by_id;
+    EntryTable entries;
     mutable std::array<std::mutex, row_lock_count> row_mutexes;
     EntryId next_entry_id = 1;
 

--- a/src/Storages/StorageOverwriteCache.h
+++ b/src/Storages/StorageOverwriteCache.h
@@ -18,6 +18,7 @@
 #include <bit>
 #include <deque>
 #include <limits>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -177,11 +178,44 @@ public:
     void insertBlock(const Block & block);
 
 private:
+    struct EntryVersion
+    {
+        RowData row;
+        /// The publication generation at which this version became visible.
+        UInt64 generation = 0;
+        std::unique_ptr<EntryVersion> older;
+    };
+
+    /// Chains are normally one version long. They grow only while a reader holds an older snapshot,
+    /// which is what lets a writer publish without ever waiting for readers to finish.
+    static void releaseVersions(std::unique_ptr<EntryVersion> version)
+    {
+        /// Iteratively, because a chain can outgrow the stack if a reader lags far behind.
+        while (version)
+            version = std::move(version->older);
+    }
+
+    /// A publication takes one version per row and usually hands it straight back once the previous
+    /// one becomes unreachable, so recycling keeps that off the allocator. Writer-only: every caller
+    /// holds `writer_mutex`.
+    std::unique_ptr<EntryVersion> takeVersion();
+    void recycleVersions(std::unique_ptr<EntryVersion> chain);
+    static constexpr size_t max_recycled_versions = 1 << 16;
+
     struct Entry
     {
-        std::optional<RowData> committed;
-        std::unique_ptr<RowData> pending;
-        UInt64 pending_generation = 0;
+        Entry() = default;
+        Entry(Entry &&) = default;
+        Entry & operator=(Entry && rhs) noexcept
+        {
+            releaseVersions(std::move(head));
+            head = std::move(rhs.head);
+            return *this;
+        }
+        ~Entry() { releaseVersions(std::move(head)); }
+
+        /// Newest first. A reader takes the first version at or below its snapshot generation.
+        std::unique_ptr<EntryVersion> head;
     };
 
     /// Chunked, never-relocating entry array. Chunk sizes double, so a tiny table costs a few entries
@@ -202,9 +236,8 @@ private:
             return chunks[level].load(std::memory_order_acquire)[index - (1ULL << (level + base_shift - 1))];
         }
 
-        /// Both grow and shrink run under the writer lock.
+        /// Runs under the writer lock.
         void grow(size_t new_size);
-        void shrink(size_t new_size);
         void clear();
 
         UInt64 allocatedBytes() const { return static_cast<UInt64>(allocated_entries) * sizeof(Entry); }
@@ -370,6 +403,9 @@ private:
     /// The hash tables index themselves by the low bits, so the shard is chosen from the high ones.
     static size_t shardIndex(size_t hash) { return hash >> 56; }
     size_t rowLockIndex(EntryId entry_id) const;
+    /// The oldest snapshot any live reader can still observe. Versions below it are unreachable.
+    UInt64 oldestLiveGeneration() const;
+    void drainReaders();
     std::optional<EntryId> findEntry(std::string_view key, size_t hash) const;
     RowDataPtr resolveEntry(EntryId entry_id, UInt64 snapshot_generation) const;
     std::vector<EntryId> getPostingIds(const LookupIndexPtr & index, const std::vector<String> & serialized_keys) const;
@@ -403,9 +439,16 @@ private:
     std::vector<LookupIndexPtr> lookup_indexes;
     EntryTable entries;
     mutable std::array<std::mutex, row_lock_count> row_mutexes;
+    std::unique_ptr<EntryVersion> recycled_versions;
+    size_t recycled_version_count = 0;
     EntryId next_entry_id = 1;
 
     std::atomic<UInt64> published_generation = 0;
+    /// Snapshot generations of the live read guards, so a writer knows which versions it may drop.
+    mutable std::mutex snapshot_registry_mutex;
+    mutable std::map<UInt64, size_t> live_snapshots;
+    /// Only the paths that release entry storage outright - `TRUNCATE`, `DROP` and `DROP INDEX` -
+    /// wait for readers. Publishing a block never does.
     mutable std::atomic<UInt8> active_reader_epoch = 0;
     mutable std::array<std::atomic<UInt64>, 2> active_readers{};
 

--- a/src/Storages/StorageOverwriteCache.h
+++ b/src/Storages/StorageOverwriteCache.h
@@ -6,8 +6,10 @@
 #include <Interpreters/IKeyValueEntity.h>
 #include <Storages/IStorage.h>
 
+#include <algorithm>
 #include <array>
 #include <atomic>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -25,27 +27,70 @@ struct OverwriteCacheSettings
 {
     UInt64 max_memory_bytes = 0;
     Names equal_version_tiebreak_columns;
-    Names secondary_index_columns;
-    std::optional<String> secondary_index_segment_column;
-    UInt64 max_secondary_index_rows = 0;
 };
 
 class StorageOverwriteCache final : public IStorage, public IKeyValueEntity
 {
 public:
     using EntryId = UInt64;
+    struct RowSegment
+    {
+        Columns columns;
+        UInt64 allocated_bytes = 0;
+        std::atomic<UInt64> live_rows{0};
+    };
 
     struct RowData
     {
-        std::vector<Field> values;
-        String primary_key;
-        String secondary_key;
-        String segmented_secondary_key;
-        UInt64 accounted_bytes = 0;
+        std::shared_ptr<RowSegment> segment;
+        UInt32 segment_row = 0;
     };
 
-    using RowDataPtr = std::shared_ptr<const RowData>;
-    using RowDataPtrs = std::vector<RowDataPtr>;
+    struct CandidateRow
+    {
+        UInt32 source_row = 0;
+        String encoded_values;
+        std::vector<UInt32> value_offsets;
+        String primary_key;
+        std::vector<String> lookup_keys;
+    };
+
+    using RowDataPtr = std::optional<RowData>;
+    using RowDataPtrs = std::vector<RowData>;
+    class ReadGuard
+    {
+    public:
+        explicit ReadGuard(const StorageOverwriteCache & storage_);
+        ~ReadGuard();
+
+        UInt64 generation() const { return snapshot_generation; }
+
+    private:
+        const StorageOverwriteCache & storage;
+        UInt8 epoch = 0;
+        UInt64 snapshot_generation = 0;
+    };
+    using ReadGuardPtr = std::shared_ptr<ReadGuard>;
+    struct ReadResult
+    {
+        ReadGuardPtr guard;
+        RowDataPtrs rows;
+    };
+    struct LookupIndex;
+    using LookupIndexPtr = std::shared_ptr<LookupIndex>;
+    struct LookupIndexSnapshot
+    {
+        ReadGuardPtr guard;
+        Names columns;
+        DataTypes types;
+        LookupIndexPtr index;
+    };
+    struct LookupRequest
+    {
+        ReadGuardPtr guard;
+        LookupIndexPtr index;
+        std::vector<String> serialized_keys;
+    };
 
     StorageOverwriteCache(
         const StorageID & table_id_,
@@ -54,6 +99,8 @@ public:
         String comment_,
         String version_column_,
         Names key_columns_,
+        std::vector<Names> lookup_indexes_,
+        ASTPtr lookup_indexes_ast_,
         OverwriteCacheSettings settings_,
         ASTPtr settings_changes_);
 
@@ -80,8 +127,9 @@ public:
         const StorageMetadataPtr & metadata_snapshot,
         ContextPtr context,
         TableExclusiveLockHolder & table_lock_holder) override;
-
     void drop() override;
+    void checkAlterIsPossible(const AlterCommands & commands, ContextPtr context) const override;
+    void alter(const AlterCommands & commands, ContextPtr context, AlterLockHolder & lock_holder) override;
 
     std::optional<UInt64> totalRows(ContextPtr) const override;
     std::optional<UInt64> totalBytes(ContextPtr) const override;
@@ -96,46 +144,25 @@ public:
 
     const Names & getKeyColumns() const { return key_columns; }
     const DataTypes & getKeyColumnTypes() const { return key_column_types; }
-    const Names & getSecondaryIndexColumns() const { return settings.secondary_index_columns; }
-    const DataTypes & getSecondaryIndexColumnTypes() const { return secondary_index_column_types; }
-    const Names & getSegmentedSecondaryIndexColumns() const { return segmented_secondary_index_columns; }
-    const DataTypes & getSegmentedSecondaryIndexColumnTypes() const { return segmented_secondary_index_column_types; }
-    UInt64 getMaxSecondaryIndexRows() const { return settings.max_secondary_index_rows; }
+    std::vector<LookupIndexSnapshot> getLookupIndexSnapshot() const;
 
-    RowDataPtrs getRowsForPrimaryKeys(const std::vector<String> & serialized_keys) const;
-    RowDataPtrs getRowsForSecondaryKeys(const std::vector<String> & serialized_keys) const;
-    RowDataPtrs getRowsForSegmentedSecondaryKeys(const std::vector<String> & serialized_keys) const;
+    ReadResult getRowsForPrimaryKeys(const std::vector<String> & serialized_keys) const;
+    ReadResult getRowsForLookupRequests(const std::vector<LookupRequest> & requests) const;
     size_t getColumnPosition(const String & column_name) const;
+    void insertValueIntoColumn(const RowData & row, size_t position, IColumn & column) const;
 
     void insertBlock(const Block & block);
 
 private:
     struct Candidate;
 
-    enum class PublicationState : UInt8
-    {
-        Preparing,
-        Committed,
-        Aborted,
-    };
-
-    struct Publication
-    {
-        explicit Publication(UInt64 generation_) : generation(generation_) {}
-
-        const UInt64 generation;
-        std::atomic<PublicationState> state = PublicationState::Preparing;
-    };
-
     struct Entry
     {
-        EntryId id = 0;
-        RowDataPtr committed;
-        RowDataPtr pending;
-        std::shared_ptr<Publication> pending_publication;
+        std::optional<RowData> committed;
+        std::unique_ptr<RowData> pending;
+        UInt64 pending_generation = 0;
     };
 
-    using EntryPtr = std::shared_ptr<Entry>;
 
     static constexpr size_t primary_shard_count = 256;
     static constexpr size_t posting_shard_count = 256;
@@ -144,47 +171,123 @@ private:
     struct PrimaryShard
     {
         mutable std::shared_mutex mutex;
-        std::unordered_map<String, EntryPtr> entries;
+        std::unordered_map<String, EntryId> entries;
     };
 
+public:
     struct PostingShard
     {
+        struct Posting
+        {
+            size_t size() const { return wide.empty() ? narrow.size() : wide.size(); }
+
+            void reserve(size_t capacity, EntryId max_entry_id)
+            {
+                if (wide.empty() && max_entry_id > std::numeric_limits<UInt32>::max())
+                {
+                    wide.reserve(capacity);
+                    wide.assign(narrow.begin(), narrow.end());
+                    std::vector<UInt32>().swap(narrow);
+                }
+                else if (wide.empty())
+                    narrow.reserve(capacity);
+                else
+                    wide.reserve(capacity);
+            }
+
+            void push_back(EntryId entry_id)
+            {
+                if (wide.empty() && entry_id <= std::numeric_limits<UInt32>::max())
+                {
+                    narrow.push_back(static_cast<UInt32>(entry_id));
+                    return;
+                }
+                if (wide.empty())
+                {
+                    wide.reserve(narrow.size() + 1);
+                    wide.assign(narrow.begin(), narrow.end());
+                    std::vector<UInt32>().swap(narrow);
+                }
+                wide.push_back(entry_id);
+            }
+
+            void resize(size_t new_size)
+            {
+                if (wide.empty())
+                    narrow.resize(new_size);
+                else
+                    wide.resize(new_size);
+            }
+
+            template <typename Callback>
+            void forEach(Callback && callback) const
+            {
+                if (wide.empty())
+                {
+                    for (const auto entry_id : narrow)
+                        callback(static_cast<EntryId>(entry_id));
+                }
+                else
+                {
+                    for (const auto entry_id : wide)
+                        callback(entry_id);
+                }
+            }
+
+            bool contains(EntryId entry_id) const
+            {
+                if (wide.empty())
+                {
+                    return entry_id <= std::numeric_limits<UInt32>::max()
+                        && std::ranges::binary_search(narrow, static_cast<UInt32>(entry_id));
+                }
+                return std::ranges::binary_search(wide, entry_id);
+            }
+
+            UInt64 allocatedBytes() const
+            {
+                return static_cast<UInt64>(narrow.capacity()) * sizeof(UInt32)
+                    + static_cast<UInt64>(wide.capacity()) * sizeof(EntryId);
+            }
+
+            std::vector<UInt32> narrow;
+            std::vector<EntryId> wide;
+        };
+
         mutable std::shared_mutex mutex;
-        std::unordered_map<String, std::vector<EntryPtr>> postings;
+        std::unordered_map<String, Posting> postings;
     };
 
-    class ReadGuard
+
+    struct LookupIndex
     {
-    public:
-        explicit ReadGuard(const StorageOverwriteCache & storage_);
-        ~ReadGuard();
-
-        UInt64 generation() const { return snapshot_generation; }
-
-    private:
-        const StorageOverwriteCache & storage;
-        UInt8 epoch = 0;
-        UInt64 snapshot_generation = 0;
+        std::array<PostingShard, posting_shard_count> shards;
+        std::atomic<UInt64> accounted_bytes = 0;
     };
 
+private:
     String serializeColumns(const Block & block, size_t row, const std::vector<size_t> & positions) const;
-    String serializeFields(const std::vector<Field> & fields, const std::vector<size_t> & positions) const;
-    int compareWinner(const RowData & lhs, const RowData & rhs) const;
-    bool rowsEqual(const RowData & lhs, const RowData & rhs) const;
-    UInt64 estimateRowBytes(const Block & block, size_t row, const RowData & data) const;
+    String serializeRowColumns(const RowData & row, const std::vector<size_t> & positions) const;
+    Field getRowField(const RowData & row, size_t position) const;
+    Field getCandidateField(const CandidateRow & row, size_t position) const;
+    int compareWinner(const CandidateRow & lhs, const CandidateRow & rhs) const;
+    int compareWinner(const CandidateRow & lhs, const RowData & rhs) const;
+    bool rowsEqual(const CandidateRow & lhs, const RowData & rhs) const;
+
     size_t primaryShardIndex(const String & key) const;
     size_t postingShardIndex(const String & key) const;
     size_t rowLockIndex(EntryId entry_id) const;
-    EntryPtr findEntry(const String & key) const;
-    RowDataPtr resolveEntry(const EntryPtr & entry, UInt64 snapshot_generation) const;
-    RowDataPtrs getRowsForPostingKeys(
-        const std::vector<String> & serialized_keys,
-        const std::array<PostingShard, posting_shard_count> & index,
-        const char * index_name) const;
+    std::optional<EntryId> findEntry(const String & key) const;
+    RowDataPtr resolveEntry(EntryId entry_id, UInt64 snapshot_generation) const;
+    std::vector<EntryId> getPostingIds(const LookupIndexPtr & index, const std::vector<String> & serialized_keys) const;
+    UInt64 getPostingCardinality(const LookupIndexPtr & index, const std::vector<String> & serialized_keys) const;
+    void intersectPostingIds(
+        std::vector<EntryId> & entry_ids, const LookupIndexPtr & index, const std::vector<String> & serialized_keys) const;
     void clearData();
 
     const String version_column;
     const Names key_columns;
+    std::vector<Names> lookup_index_columns;
     const OverwriteCacheSettings settings;
 
     Block sample_block;
@@ -195,16 +298,15 @@ private:
     DataTypes key_column_types;
     size_t version_position = 0;
     std::vector<size_t> tiebreak_positions;
-    std::vector<size_t> secondary_index_positions;
-    DataTypes secondary_index_column_types;
-    Names segmented_secondary_index_columns;
-    std::vector<size_t> segmented_secondary_index_positions;
-    DataTypes segmented_secondary_index_column_types;
+    std::vector<std::vector<size_t>> lookup_index_positions;
+    std::vector<DataTypes> lookup_index_column_types;
 
     mutable std::mutex writer_mutex;
+    mutable std::shared_mutex lookup_catalog_mutex;
     std::array<PrimaryShard, primary_shard_count> primary_shards;
-    std::array<PostingShard, posting_shard_count> secondary_shards;
-    std::array<PostingShard, posting_shard_count> segmented_secondary_shards;
+    std::vector<LookupIndexPtr> lookup_indexes;
+    mutable std::shared_mutex entries_by_id_mutex;
+    std::vector<Entry> entries_by_id;
     mutable std::array<std::mutex, row_lock_count> row_mutexes;
     EntryId next_entry_id = 1;
 

--- a/src/Storages/registerStorages.cpp
+++ b/src/Storages/registerStorages.cpp
@@ -15,6 +15,7 @@ void registerStorageBuffer(StorageFactory & factory);
 void registerStorageDistributed(StorageFactory & factory);
 void registerStorageRemote(StorageFactory & factory);
 void registerStorageMemory(StorageFactory & factory);
+void registerStorageOverwriteCache(StorageFactory & factory);
 void registerStorageQueryRunner(StorageFactory & factory);
 void registerStorageFile(StorageFactory & factory);
 void registerStorageURL(StorageFactory & factory);
@@ -127,6 +128,7 @@ void registerStorages()
     registerStorageDistributed(factory);
     registerStorageRemote(factory);
     registerStorageMemory(factory);
+    registerStorageOverwriteCache(factory);
     registerStorageQueryRunner(factory);
     registerStorageFile(factory);
     registerStorageURL(factory);

--- a/tests/queries/0_stateless/04626_overwrite_cache_engine.reference
+++ b/tests/queries/0_stateless/04626_overwrite_cache_engine.reference
@@ -63,5 +63,6 @@ tie-winner
 site-two
 indexed-row
 indexed-row
+tie-winner
 same-version-a
 0	0

--- a/tests/queries/0_stateless/04626_overwrite_cache_engine.reference
+++ b/tests/queries/0_stateless/04626_overwrite_cache_engine.reference
@@ -55,7 +55,6 @@ tie-winner
 1
 Nullable(String)
 1	1
-tie-winner
 after-failure
 after-failure
 tie-winner

--- a/tests/queries/0_stateless/04626_overwrite_cache_engine.reference
+++ b/tests/queries/0_stateless/04626_overwrite_cache_engine.reference
@@ -1,0 +1,36 @@
+CREATE TABLE default.overwrite_cache
+(
+    `website_type` UInt8,
+    `user_id` UInt64,
+    `tag` LowCardinality(String),
+    `version` UInt64,
+    `tie` UInt64,
+    `payload` String
+)
+ENGINE = OverwriteCache(version)
+KEYS (website_type, user_id, tag)
+SETTINGS max_memory_bytes = 10000000, equal_version_tiebreak_columns = 'tie', secondary_index_columns = 'tag', secondary_index_segment_column = 'website_type', max_secondary_index_rows = 2
+2	2	tie-winner
+1	100	tie-winner
+2	200	site-two
+1	100	tie-winner
+1	100	tie-winner
+tie-winner
+tie-winner
+tie-winner
+tie-winner
+tie-winner
+0
+0
+batch-new
+tie-winner
+1
+Nullable(String)
+1	1
+tie-winner
+after-failure
+after-failure
+tie-winner
+batch-new
+index-limit
+same-version-a

--- a/tests/queries/0_stateless/04626_overwrite_cache_engine.reference
+++ b/tests/queries/0_stateless/04626_overwrite_cache_engine.reference
@@ -9,7 +9,8 @@ CREATE TABLE default.overwrite_cache
 )
 ENGINE = OverwriteCache(version)
 KEYS (website_type, user_id, tag)
-SETTINGS max_memory_bytes = 10000000, equal_version_tiebreak_columns = 'tie', secondary_index_columns = 'tag', secondary_index_segment_column = 'website_type', max_secondary_index_rows = 2
+INDEX (tag), (website_type), (website_type, tag)
+SETTINGS max_memory_bytes = 10000000, equal_version_tiebreak_columns = 'tie'
 2	2	tie-winner
 1	100	tie-winner
 2	200	site-two
@@ -20,6 +21,33 @@ tie-winner
 tie-winner
 tie-winner
 tie-winner
+tie-winner
+CREATE TABLE default.overwrite_cache
+(
+    `website_type` UInt8,
+    `user_id` UInt64,
+    `tag` LowCardinality(String),
+    `version` UInt64,
+    `tie` UInt64,
+    `payload` String
+)
+ENGINE = OverwriteCache(version)
+KEYS (website_type, user_id, tag)
+INDEX (tag), (website_type), (website_type, tag), (user_id)
+SETTINGS max_memory_bytes = 10000000, equal_version_tiebreak_columns = 'tie'
+CREATE TABLE default.overwrite_cache
+(
+    `website_type` UInt8,
+    `user_id` UInt64,
+    `tag` LowCardinality(String),
+    `version` UInt64,
+    `tie` UInt64,
+    `payload` String
+)
+ENGINE = OverwriteCache(version)
+KEYS (website_type, user_id, tag)
+INDEX (tag), (website_type), (website_type, tag)
+SETTINGS max_memory_bytes = 10000000, equal_version_tiebreak_columns = 'tie'
 0
 0
 batch-new
@@ -32,5 +60,9 @@ after-failure
 after-failure
 tie-winner
 batch-new
-index-limit
+tie-winner
+site-two
+indexed-row
+indexed-row
 same-version-a
+0	0

--- a/tests/queries/0_stateless/04626_overwrite_cache_engine.sql
+++ b/tests/queries/0_stateless/04626_overwrite_cache_engine.sql
@@ -115,6 +115,8 @@ INSERT INTO overwrite_cache VALUES (1, 201, 'A', 1, 1, 'indexed-row');
 SELECT payload FROM overwrite_cache WHERE tag = 'A' ORDER BY user_id;
 SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 201 AND tag = 'A';
 
+-- The rows are persisted, so a detach and attach replays the log instead of emptying the cache.
+-- 04633_overwrite_cache_persistence covers what replay has to reproduce.
 DETACH TABLE overwrite_cache;
 ATTACH TABLE overwrite_cache;
 SELECT payload

--- a/tests/queries/0_stateless/04626_overwrite_cache_engine.sql
+++ b/tests/queries/0_stateless/04626_overwrite_cache_engine.sql
@@ -138,9 +138,9 @@ CREATE TABLE overwrite_cache_small
 )
 ENGINE = OverwriteCache(version)
 KEYS (key)
-SETTINGS max_memory_bytes = 800;
+SETTINGS max_memory_bytes = 131072;
 
-INSERT INTO overwrite_cache_small VALUES (1, 1, repeat('x', 100)), (2, 1, repeat('y', 100)); -- { serverError MEMORY_LIMIT_EXCEEDED }
+INSERT INTO overwrite_cache_small VALUES (1, 1, repeat('x', 200000)), (2, 1, repeat('y', 200000)); -- { serverError MEMORY_LIMIT_EXCEEDED }
 SELECT payload FROM overwrite_cache_small WHERE key = 1;
 
 INSERT INTO overwrite_cache_small VALUES (1, 1, 'same-version-a');

--- a/tests/queries/0_stateless/04626_overwrite_cache_engine.sql
+++ b/tests/queries/0_stateless/04626_overwrite_cache_engine.sql
@@ -1,0 +1,150 @@
+DROP TABLE IF EXISTS overwrite_cache;
+DROP TABLE IF EXISTS overwrite_cache_small;
+
+CREATE TABLE overwrite_cache
+(
+    website_type UInt8,
+    user_id UInt64,
+    tag LowCardinality(String),
+    version UInt64,
+    tie UInt64,
+    payload String
+)
+ENGINE = OverwriteCache(version)
+KEYS (website_type, user_id, tag)
+SETTINGS
+    max_memory_bytes = 10000000,
+    equal_version_tiebreak_columns = 'tie',
+    secondary_index_columns = 'tag',
+    secondary_index_segment_column = 'website_type',
+    max_secondary_index_rows = 2;
+
+SHOW CREATE TABLE overwrite_cache FORMAT TSVRaw;
+
+INSERT INTO overwrite_cache VALUES
+    (1, 100, 'A', 1, 1, 'old'),
+    (2, 200, 'A', 1, 1, 'site-two'),
+    (1, 300, 'B', 1, 1, 'tag-b');
+
+INSERT INTO overwrite_cache VALUES (1, 100, 'A', 2, 1, 'new');
+INSERT INTO overwrite_cache VALUES (1, 100, 'A', 1, 9, 'stale-version');
+INSERT INTO overwrite_cache VALUES (1, 100, 'A', 2, 1, 'new');
+INSERT INTO overwrite_cache VALUES (1, 100, 'A', 2, 2, 'tie-winner');
+INSERT INTO overwrite_cache VALUES (1, 100, 'A', 2, 1, 'stale-tie');
+INSERT INTO overwrite_cache VALUES
+    (1, 300, 'C', 1, 1, 'batch-old'),
+    (1, 300, 'C', 3, 1, 'batch-new'),
+    (1, 300, 'C', 2, 1, 'batch-middle');
+
+SELECT version, tie, payload
+FROM overwrite_cache
+WHERE website_type = 1 AND user_id = 100 AND tag = 'A';
+
+SELECT website_type, user_id, payload
+FROM overwrite_cache
+WHERE tag = 'A'
+ORDER BY website_type, user_id;
+
+SELECT website_type, user_id, payload
+FROM overwrite_cache
+WHERE tag = 'A' AND website_type = 1;
+
+SELECT website_type, user_id, payload
+FROM overwrite_cache
+WHERE tag = 'A' AND website_type != 2;
+
+SELECT payload
+FROM overwrite_cache
+WHERE website_type = 1 AND user_id IN (100, 999) AND tag = 'A';
+SELECT payload FROM overwrite_cache WHERE 1 = website_type AND 100 = user_id AND 'A' = tag;
+SELECT payload FROM overwrite_cache WHERE (website_type, user_id, tag) = (1, 100, 'A');
+SELECT payload FROM overwrite_cache WHERE (1, 100, 'A') = (website_type, user_id, tag);
+SELECT payload FROM overwrite_cache WHERE (website_type, user_id, tag) IN ((1, 100, 'A')) AND length(payload) = 10;
+SELECT payload FROM overwrite_cache WHERE (website_type, user_id, tag) IN ((1, 100, 'A')) AND length(payload) = 999;
+SELECT payload FROM overwrite_cache WHERE user_id = 100; -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM overwrite_cache WHERE website_type = 1 AND user_id IN tuple() AND tag = 'A';
+SELECT count() FROM overwrite_cache WHERE tag IN tuple();
+SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 300 AND tag = 'C';
+
+SELECT overwriteCacheGet(
+    'overwrite_cache', 'payload', toUInt8(1), toUInt64(100), 'A');
+SELECT overwriteCacheGetOrNull(
+    'overwrite_cache', 'payload', toUInt8(9), toUInt64(999), 'missing') IS NULL;
+SELECT toTypeName(overwriteCacheGetOrNull(
+    'overwrite_cache', 'tag', toUInt8(1), toUInt64(100), 'A'));
+SELECT
+    countIf(overwriteCacheGet('overwrite_cache', 'payload', website_type, user_id, tag) = ''),
+    countIf(overwriteCacheGetOrNull('overwrite_cache', 'payload', website_type, user_id, tag) IS NULL)
+FROM VALUES(
+    'website_type UInt8, user_id UInt64, tag String',
+    (1, 100, 'A'),
+    (9, 999, 'missing'));
+
+INSERT INTO overwrite_cache VALUES (1, 100, 'A', 2, 2, 'conflict'); -- { serverError BAD_ARGUMENTS }
+INSERT INTO overwrite_cache VALUES
+    (1, 400, 'D', 1, 1, 'conflict-a'),
+    (1, 400, 'D', 1, 1, 'conflict-b'); -- { serverError BAD_ARGUMENTS }
+SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 400 AND tag = 'D';
+INSERT INTO overwrite_cache VALUES
+    (1, 100, 'A', 3, 1, 'must-not-commit'),
+    (1, 300, 'B', 1, 1, 'conflict-existing'); -- { serverError BAD_ARGUMENTS }
+SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 100 AND tag = 'A';
+SYSTEM ENABLE FAILPOINT overwrite_cache_throw_during_publish;
+INSERT INTO overwrite_cache VALUES
+    (1, 500, 'E', 1, 1, 'must-roll-back'),
+    (1, 501, 'F', 1, 1, 'must-also-roll-back'); -- { serverError FAULT_INJECTED }
+SYSTEM DISABLE FAILPOINT overwrite_cache_throw_during_publish;
+SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 500 AND tag = 'E';
+SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 501 AND tag = 'F';
+SELECT payload FROM overwrite_cache WHERE tag = 'E';
+SELECT payload FROM overwrite_cache WHERE website_type = 1 AND tag = 'F';
+INSERT INTO overwrite_cache VALUES (1, 500, 'E', 2, 1, 'after-failure');
+SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 500 AND tag = 'E';
+SELECT payload FROM overwrite_cache WHERE tag = 'E';
+SYSTEM ENABLE FAILPOINT overwrite_cache_throw_during_publish;
+INSERT INTO overwrite_cache VALUES
+    (1, 100, 'A', 4, 1, 'replacement-must-roll-back'),
+    (1, 300, 'C', 4, 1, 'other-replacement-must-roll-back'); -- { serverError FAULT_INJECTED }
+SYSTEM DISABLE FAILPOINT overwrite_cache_throw_during_publish;
+SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 100 AND tag = 'A';
+SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 300 AND tag = 'C';
+SELECT count() FROM overwrite_cache; -- { serverError BAD_ARGUMENTS }
+INSERT INTO overwrite_cache VALUES (1, 201, 'A', 1, 1, 'index-limit');
+SELECT payload FROM overwrite_cache WHERE tag = 'A'; -- { serverError MEMORY_LIMIT_EXCEEDED }
+SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 201 AND tag = 'A';
+
+DETACH TABLE overwrite_cache;
+ATTACH TABLE overwrite_cache;
+SELECT payload
+FROM overwrite_cache
+WHERE website_type = 1 AND user_id = 100 AND tag = 'A';
+
+CREATE TABLE overwrite_cache_small
+(
+    key UInt64,
+    version UInt64,
+    payload String
+)
+ENGINE = OverwriteCache(version)
+KEYS (key)
+SETTINGS max_memory_bytes = 800;
+
+INSERT INTO overwrite_cache_small VALUES (1, 1, repeat('x', 100)), (2, 1, repeat('y', 100)); -- { serverError MEMORY_LIMIT_EXCEEDED }
+SELECT payload FROM overwrite_cache_small WHERE key = 1;
+
+INSERT INTO overwrite_cache_small VALUES (1, 1, 'same-version-a');
+INSERT INTO overwrite_cache_small VALUES (1, 1, 'same-version-b'); -- { serverError BAD_ARGUMENTS }
+SELECT payload FROM overwrite_cache_small WHERE key = 1;
+
+TRUNCATE TABLE overwrite_cache_small;
+SELECT payload FROM overwrite_cache_small WHERE key = 1;
+
+CREATE TABLE bad_keys (key UInt64, version UInt64) ENGINE = Memory KEYS (key); -- { serverError BAD_ARGUMENTS }
+CREATE TABLE bad_keys_syntax (key UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS key SETTINGS max_memory_bytes = 10000; -- { clientError SYNTAX_ERROR }
+CREATE TABLE missing_keys (key UInt64, version UInt64) ENGINE = OverwriteCache(version) SETTINGS max_memory_bytes = 10000; -- { serverError BAD_ARGUMENTS }
+CREATE TABLE version_in_keys (key UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key, version) SETTINGS max_memory_bytes = 10000; -- { serverError BAD_ARGUMENTS }
+CREATE TABLE bad_secondary (key UInt64, other UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key) SETTINGS max_memory_bytes = 10000, secondary_index_columns = 'other', max_secondary_index_rows = 10; -- { serverError BAD_ARGUMENTS }
+CREATE TABLE duplicate_secondary_segment (key UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key) SETTINGS max_memory_bytes = 10000, secondary_index_columns = 'key', secondary_index_segment_column = 'key', max_secondary_index_rows = 10; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE overwrite_cache_small;
+DROP TABLE overwrite_cache;

--- a/tests/queries/0_stateless/04626_overwrite_cache_engine.sql
+++ b/tests/queries/0_stateless/04626_overwrite_cache_engine.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS overwrite_cache;
 DROP TABLE IF EXISTS overwrite_cache_small;
+DROP TABLE IF EXISTS bad_lookup_alter;
 
 CREATE TABLE overwrite_cache
 (
@@ -162,6 +163,12 @@ CREATE TABLE duplicate_lookup_column (key UInt64, other UInt64, version UInt64) 
 CREATE TABLE canonical_duplicate_lookup (key UInt64, other UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key, other) INDEX (key, other), (other, key); -- { serverError BAD_ARGUMENTS }
 CREATE TABLE primary_lookup (key UInt64, other UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key, other) INDEX (key, other); -- { serverError BAD_ARGUMENTS }
 CREATE TABLE bad_lookup_engine (key UInt64, version UInt64) ENGINE = Memory INDEX (key); -- { serverError BAD_ARGUMENTS }
+ALTER TABLE overwrite_cache ADD INDEX (user_id) FIRST; -- { serverError BAD_ARGUMENTS }
+ALTER TABLE overwrite_cache ADD INDEX (user_id) AFTER tag; -- { serverError BAD_ARGUMENTS }
+CREATE TABLE bad_lookup_alter (key UInt64) ENGINE = MergeTree ORDER BY tuple();
+ALTER TABLE bad_lookup_alter ADD INDEX (key); -- { serverError BAD_ARGUMENTS }
+ALTER TABLE bad_lookup_alter DROP INDEX (key); -- { serverError BAD_ARGUMENTS }
+DROP TABLE bad_lookup_alter;
 CREATE TABLE old_lookup_settings (key UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key) SETTINGS secondary_index_columns = 'key'; -- { serverError UNKNOWN_SETTING }
 
 DROP TABLE overwrite_cache_small;

--- a/tests/queries/0_stateless/04626_overwrite_cache_engine.sql
+++ b/tests/queries/0_stateless/04626_overwrite_cache_engine.sql
@@ -12,12 +12,10 @@ CREATE TABLE overwrite_cache
 )
 ENGINE = OverwriteCache(version)
 KEYS (website_type, user_id, tag)
+INDEX (tag), (website_type), (website_type, tag)
 SETTINGS
     max_memory_bytes = 10000000,
-    equal_version_tiebreak_columns = 'tie',
-    secondary_index_columns = 'tag',
-    secondary_index_segment_column = 'website_type',
-    max_secondary_index_rows = 2;
+    equal_version_tiebreak_columns = 'tie';
 
 SHOW CREATE TABLE overwrite_cache FORMAT TSVRaw;
 
@@ -62,9 +60,21 @@ SELECT payload FROM overwrite_cache WHERE (1, 100, 'A') = (website_type, user_id
 SELECT payload FROM overwrite_cache WHERE (website_type, user_id, tag) IN ((1, 100, 'A')) AND length(payload) = 10;
 SELECT payload FROM overwrite_cache WHERE (website_type, user_id, tag) IN ((1, 100, 'A')) AND length(payload) = 999;
 SELECT payload FROM overwrite_cache WHERE user_id = 100; -- { serverError BAD_ARGUMENTS }
+ALTER TABLE overwrite_cache ADD INDEX (user_id);
+ALTER TABLE overwrite_cache ADD INDEX IF NOT EXISTS (user_id);
+ALTER TABLE overwrite_cache ADD INDEX (user_id); -- { serverError BAD_ARGUMENTS }
+SELECT payload FROM overwrite_cache WHERE user_id = 100;
+SHOW CREATE TABLE overwrite_cache FORMAT TSVRaw;
+ALTER TABLE overwrite_cache DROP INDEX (user_id);
+ALTER TABLE overwrite_cache DROP INDEX IF EXISTS (user_id);
+ALTER TABLE overwrite_cache DROP INDEX (user_id); -- { serverError BAD_ARGUMENTS }
+SELECT payload FROM overwrite_cache WHERE user_id = 100; -- { serverError BAD_ARGUMENTS }
+SHOW CREATE TABLE overwrite_cache FORMAT TSVRaw;
 SELECT count() FROM overwrite_cache WHERE website_type = 1 AND user_id IN tuple() AND tag = 'A';
 SELECT count() FROM overwrite_cache WHERE tag IN tuple();
 SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 300 AND tag = 'C';
+SELECT payload FROM overwrite_cache WHERE tag = 'A' OR payload = 'site-two'; -- { serverError BAD_ARGUMENTS }
+SELECT payload FROM overwrite_cache WHERE user_id > 100; -- { serverError BAD_ARGUMENTS }
 
 SELECT overwriteCacheGet(
     'overwrite_cache', 'payload', toUInt8(1), toUInt64(100), 'A');
@@ -109,8 +119,8 @@ SYSTEM DISABLE FAILPOINT overwrite_cache_throw_during_publish;
 SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 100 AND tag = 'A';
 SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 300 AND tag = 'C';
 SELECT count() FROM overwrite_cache; -- { serverError BAD_ARGUMENTS }
-INSERT INTO overwrite_cache VALUES (1, 201, 'A', 1, 1, 'index-limit');
-SELECT payload FROM overwrite_cache WHERE tag = 'A'; -- { serverError MEMORY_LIMIT_EXCEEDED }
+INSERT INTO overwrite_cache VALUES (1, 201, 'A', 1, 1, 'indexed-row');
+SELECT payload FROM overwrite_cache WHERE tag = 'A' ORDER BY user_id;
 SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 201 AND tag = 'A';
 
 DETACH TABLE overwrite_cache;
@@ -138,13 +148,21 @@ SELECT payload FROM overwrite_cache_small WHERE key = 1;
 
 TRUNCATE TABLE overwrite_cache_small;
 SELECT payload FROM overwrite_cache_small WHERE key = 1;
+SELECT total_rows, total_bytes
+FROM system.tables
+WHERE database = currentDatabase() AND name = 'overwrite_cache_small';
 
 CREATE TABLE bad_keys (key UInt64, version UInt64) ENGINE = Memory KEYS (key); -- { serverError BAD_ARGUMENTS }
 CREATE TABLE bad_keys_syntax (key UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS key SETTINGS max_memory_bytes = 10000; -- { clientError SYNTAX_ERROR }
-CREATE TABLE missing_keys (key UInt64, version UInt64) ENGINE = OverwriteCache(version) SETTINGS max_memory_bytes = 10000; -- { serverError BAD_ARGUMENTS }
-CREATE TABLE version_in_keys (key UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key, version) SETTINGS max_memory_bytes = 10000; -- { serverError BAD_ARGUMENTS }
-CREATE TABLE bad_secondary (key UInt64, other UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key) SETTINGS max_memory_bytes = 10000, secondary_index_columns = 'other', max_secondary_index_rows = 10; -- { serverError BAD_ARGUMENTS }
-CREATE TABLE duplicate_secondary_segment (key UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key) SETTINGS max_memory_bytes = 10000, secondary_index_columns = 'key', secondary_index_segment_column = 'key', max_secondary_index_rows = 10; -- { serverError BAD_ARGUMENTS }
+CREATE TABLE missing_keys (key UInt64, version UInt64) ENGINE = OverwriteCache(version); -- { serverError BAD_ARGUMENTS }
+CREATE TABLE version_in_keys (key UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key, version); -- { serverError BAD_ARGUMENTS }
+CREATE TABLE bad_lookup_column (key UInt64, other UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key) INDEX (other); -- { serverError BAD_ARGUMENTS }
+CREATE TABLE duplicate_lookup (key UInt64, other UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key, other) INDEX (key), (key); -- { serverError BAD_ARGUMENTS }
+CREATE TABLE duplicate_lookup_column (key UInt64, other UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key, other) INDEX (key, key); -- { serverError BAD_ARGUMENTS }
+CREATE TABLE canonical_duplicate_lookup (key UInt64, other UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key, other) INDEX (key, other), (other, key); -- { serverError BAD_ARGUMENTS }
+CREATE TABLE primary_lookup (key UInt64, other UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key, other) INDEX (key, other); -- { serverError BAD_ARGUMENTS }
+CREATE TABLE bad_lookup_engine (key UInt64, version UInt64) ENGINE = Memory INDEX (key); -- { serverError BAD_ARGUMENTS }
+CREATE TABLE old_lookup_settings (key UInt64, version UInt64) ENGINE = OverwriteCache(version) KEYS (key) SETTINGS secondary_index_columns = 'key'; -- { serverError UNKNOWN_SETTING }
 
 DROP TABLE overwrite_cache_small;
 DROP TABLE overwrite_cache;

--- a/tests/queries/0_stateless/04626_overwrite_cache_engine.sql
+++ b/tests/queries/0_stateless/04626_overwrite_cache_engine.sql
@@ -91,15 +91,6 @@ FROM VALUES(
     (1, 100, 'A'),
     (9, 999, 'missing'));
 
-INSERT INTO overwrite_cache VALUES (1, 100, 'A', 2, 2, 'conflict'); -- { serverError BAD_ARGUMENTS }
-INSERT INTO overwrite_cache VALUES
-    (1, 400, 'D', 1, 1, 'conflict-a'),
-    (1, 400, 'D', 1, 1, 'conflict-b'); -- { serverError BAD_ARGUMENTS }
-SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 400 AND tag = 'D';
-INSERT INTO overwrite_cache VALUES
-    (1, 100, 'A', 3, 1, 'must-not-commit'),
-    (1, 300, 'B', 1, 1, 'conflict-existing'); -- { serverError BAD_ARGUMENTS }
-SELECT payload FROM overwrite_cache WHERE website_type = 1 AND user_id = 100 AND tag = 'A';
 SYSTEM ENABLE FAILPOINT overwrite_cache_throw_during_publish;
 INSERT INTO overwrite_cache VALUES
     (1, 500, 'E', 1, 1, 'must-roll-back'),
@@ -144,7 +135,7 @@ INSERT INTO overwrite_cache_small VALUES (1, 1, repeat('x', 200000)), (2, 1, rep
 SELECT payload FROM overwrite_cache_small WHERE key = 1;
 
 INSERT INTO overwrite_cache_small VALUES (1, 1, 'same-version-a');
-INSERT INTO overwrite_cache_small VALUES (1, 1, 'same-version-b'); -- { serverError BAD_ARGUMENTS }
+INSERT INTO overwrite_cache_small VALUES (1, 1, 'same-version-b');
 SELECT payload FROM overwrite_cache_small WHERE key = 1;
 
 TRUNCATE TABLE overwrite_cache_small;

--- a/tests/queries/0_stateless/04627_overwrite_cache_sharded_publication.reference
+++ b/tests/queries/0_stateless/04627_overwrite_cache_sharded_publication.reference
@@ -1,0 +1,6 @@
+pending-primary	2	0
+pending-secondary	1000	0
+committed-primary	0	4
+committed-secondary	0	2000
+second-pending	2000	0
+second-committed	0	2000

--- a/tests/queries/0_stateless/04627_overwrite_cache_sharded_publication.reference
+++ b/tests/queries/0_stateless/04627_overwrite_cache_sharded_publication.reference
@@ -10,4 +10,5 @@ index-build-rollback	0
 index-catch-up	index-catch-up
 drop-during-insert-prep	drop-race
 add-during-insert-prep	add-race
+rollback-old-reader	0
 drop-old-reader	2001

--- a/tests/queries/0_stateless/04627_overwrite_cache_sharded_publication.reference
+++ b/tests/queries/0_stateless/04627_overwrite_cache_sharded_publication.reference
@@ -4,3 +4,10 @@ committed-primary	0	4
 committed-secondary	0	2000
 second-pending	2000	0
 second-committed	0	2000
+rollback-publication	2000	0
+rollback-new-key	0
+index-build-rollback	0
+index-catch-up	index-catch-up
+drop-during-insert-prep	drop-race
+add-during-insert-prep	add-race
+drop-old-reader	2001

--- a/tests/queries/0_stateless/04627_overwrite_cache_sharded_publication.sh
+++ b/tests/queries/0_stateless/04627_overwrite_cache_sharded_publication.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+table="${CLICKHOUSE_DATABASE}.overwrite_cache_sharded_publication"
+writer_pid=""
+
+cleanup()
+{
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_pause_before_commit" >/dev/null 2>&1 ||:
+    if [[ -n "$writer_pid" ]]; then
+        wait "$writer_pid" >/dev/null 2>&1 ||:
+    fi
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS $table" >/dev/null 2>&1 ||:
+}
+trap cleanup EXIT
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS $table"
+$CLICKHOUSE_CLIENT -q "
+    CREATE TABLE $table
+    (
+        key UInt64,
+        tag UInt8,
+        version UInt64,
+        payload String
+    )
+    ENGINE = OverwriteCache(version)
+    KEYS (key, tag)
+    SETTINGS
+        max_memory_bytes = 10000000,
+        secondary_index_columns = 'tag',
+        max_secondary_index_rows = 3000"
+
+$CLICKHOUSE_CLIENT -q "INSERT INTO $table SELECT number, 1, 1, 'old' FROM numbers(1000)"
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_pause_before_commit"
+$CLICKHOUSE_CLIENT -q "INSERT INTO $table SELECT number, 1, 2, 'new' FROM numbers(2000)" >/dev/null &
+writer_pid=$!
+
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT overwrite_cache_pause_before_commit PAUSE"
+
+timeout 10 $CLICKHOUSE_CLIENT -q "
+    SELECT 'pending-primary', countIf(version = 1), countIf(version = 2)
+    FROM $table
+    WHERE key IN (0, 999, 1000, 1999) AND tag = 1"
+timeout 10 $CLICKHOUSE_CLIENT -q "
+    SELECT 'pending-secondary', countIf(version = 1), countIf(version = 2)
+    FROM $table
+    WHERE tag = 1"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM NOTIFY FAILPOINT overwrite_cache_pause_before_commit"
+wait "$writer_pid"
+writer_pid=""
+
+$CLICKHOUSE_CLIENT -q "
+    SELECT 'committed-primary', countIf(version = 1), countIf(version = 2)
+    FROM $table
+    WHERE key IN (0, 999, 1000, 1999) AND tag = 1"
+$CLICKHOUSE_CLIENT -q "
+    SELECT 'committed-secondary', countIf(version = 1), countIf(version = 2)
+    FROM $table
+    WHERE tag = 1"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_pause_before_commit"
+$CLICKHOUSE_CLIENT -q "INSERT INTO $table SELECT number, 1, 3, 'newer' FROM numbers(2000)" >/dev/null &
+writer_pid=$!
+
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT overwrite_cache_pause_before_commit PAUSE"
+timeout 10 $CLICKHOUSE_CLIENT -q "
+    SELECT 'second-pending', countIf(version = 2), countIf(version = 3)
+    FROM $table
+    WHERE tag = 1"
+$CLICKHOUSE_CLIENT -q "SYSTEM NOTIFY FAILPOINT overwrite_cache_pause_before_commit"
+wait "$writer_pid"
+writer_pid=""
+
+$CLICKHOUSE_CLIENT -q "
+    SELECT 'second-committed', countIf(version = 2), countIf(version = 3)
+    FROM $table
+    WHERE tag = 1"

--- a/tests/queries/0_stateless/04627_overwrite_cache_sharded_publication.sh
+++ b/tests/queries/0_stateless/04627_overwrite_cache_sharded_publication.sh
@@ -20,7 +20,9 @@ cleanup()
     $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_pause_during_index_build" >/dev/null 2>&1 ||:
     $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_pause_during_lookup" >/dev/null 2>&1 ||:
     $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_pause_after_lookup_catalog_snapshot" >/dev/null 2>&1 ||:
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_pause_after_lookup_ids" >/dev/null 2>&1 ||:
     $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_pause_after_drop_index_publication" >/dev/null 2>&1 ||:
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_pause_before_rollback" >/dev/null 2>&1 ||:
     if [[ -n "$writer_pid" ]]; then
         wait "$writer_pid" >/dev/null 2>&1 ||:
     fi
@@ -160,6 +162,31 @@ $CLICKHOUSE_CLIENT -q "SYSTEM NOTIFY FAILPOINT overwrite_cache_pause_after_looku
 wait "$writer_pid"
 writer_pid=""
 $CLICKHOUSE_CLIENT -q "SELECT 'add-during-insert-prep', payload FROM $table WHERE key = 4001"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_throw_during_publish"
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_pause_before_rollback"
+$CLICKHOUSE_CLIENT -q "INSERT INTO $table VALUES (5000, 79, 1, 'rollback-reader')" >/dev/null 2>&1 &
+writer_pid=$!
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT overwrite_cache_pause_before_rollback PAUSE"
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_pause_after_lookup_ids"
+$CLICKHOUSE_CLIENT -q "SELECT 'rollback-old-reader', count() FROM $table WHERE tag = 79" > "$reader_output" &
+reader_pid=$!
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT overwrite_cache_pause_after_lookup_ids PAUSE"
+$CLICKHOUSE_CLIENT -q "SYSTEM NOTIFY FAILPOINT overwrite_cache_pause_before_rollback"
+if timeout 1 tail --pid="$writer_pid" -f /dev/null; then
+    echo "Rollback completed before a reader released its entry identifier" >&2
+    exit 1
+fi
+$CLICKHOUSE_CLIENT -q "SYSTEM NOTIFY FAILPOINT overwrite_cache_pause_after_lookup_ids"
+wait "$reader_pid"
+reader_pid=""
+if wait "$writer_pid"; then
+    echo "Expected injected publication failure" >&2
+    exit 1
+fi
+writer_pid=""
+$CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_throw_during_publish"
+cat "$reader_output"
 
 $CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_pause_during_lookup"
 $CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_pause_after_drop_index_publication"

--- a/tests/queries/0_stateless/04627_overwrite_cache_sharded_publication.sh
+++ b/tests/queries/0_stateless/04627_overwrite_cache_sharded_publication.sh
@@ -8,13 +8,29 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 table="${CLICKHOUSE_DATABASE}.overwrite_cache_sharded_publication"
 writer_pid=""
+reader_pid=""
+drop_pid=""
+reader_output=$(mktemp "$CLICKHOUSE_TMP/overwrite-cache-reader-XXXXXX")
 
 cleanup()
 {
     $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_pause_before_commit" >/dev/null 2>&1 ||:
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_throw_during_publish" >/dev/null 2>&1 ||:
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_throw_during_index_build" >/dev/null 2>&1 ||:
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_pause_during_index_build" >/dev/null 2>&1 ||:
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_pause_during_lookup" >/dev/null 2>&1 ||:
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_pause_after_lookup_catalog_snapshot" >/dev/null 2>&1 ||:
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_pause_after_drop_index_publication" >/dev/null 2>&1 ||:
     if [[ -n "$writer_pid" ]]; then
         wait "$writer_pid" >/dev/null 2>&1 ||:
     fi
+    if [[ -n "$reader_pid" ]]; then
+        wait "$reader_pid" >/dev/null 2>&1 ||:
+    fi
+    if [[ -n "$drop_pid" ]]; then
+        wait "$drop_pid" >/dev/null 2>&1 ||:
+    fi
+    rm -f "$reader_output"
     $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS $table" >/dev/null 2>&1 ||:
 }
 trap cleanup EXIT
@@ -30,10 +46,8 @@ $CLICKHOUSE_CLIENT -q "
     )
     ENGINE = OverwriteCache(version)
     KEYS (key, tag)
-    SETTINGS
-        max_memory_bytes = 10000000,
-        secondary_index_columns = 'tag',
-        max_secondary_index_rows = 3000"
+    INDEX (tag)
+    SETTINGS max_memory_bytes = 10000000"
 
 $CLICKHOUSE_CLIENT -q "INSERT INTO $table SELECT number, 1, 1, 'old' FROM numbers(1000)"
 $CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_pause_before_commit"
@@ -81,3 +95,84 @@ $CLICKHOUSE_CLIENT -q "
     SELECT 'second-committed', countIf(version = 2), countIf(version = 3)
     FROM $table
     WHERE tag = 1"
+
+bytes_before_rollback=$($CLICKHOUSE_CLIENT -q "
+    SELECT total_bytes
+    FROM system.tables
+    WHERE database = currentDatabase() AND name = 'overwrite_cache_sharded_publication'")
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_throw_during_publish"
+if $CLICKHOUSE_CLIENT -q "INSERT INTO $table SELECT number, toUInt8(number % 250 + 2), 4, 'rolled-back' FROM numbers(2500)" >/dev/null 2>&1; then
+    echo "Expected injected publication failure" >&2
+    exit 1
+fi
+$CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_throw_during_publish"
+bytes_after_rollback=$($CLICKHOUSE_CLIENT -q "
+    SELECT total_bytes
+    FROM system.tables
+    WHERE database = currentDatabase() AND name = 'overwrite_cache_sharded_publication'")
+if (( bytes_after_rollback <= bytes_before_rollback )); then
+    echo "Rollback did not account retained vector or hash-bucket capacity" >&2
+    exit 1
+fi
+$CLICKHOUSE_CLIENT -q "
+    SELECT 'rollback-publication', countIf(version = 3), countIf(version = 4)
+    FROM $table
+    WHERE tag = 1"
+$CLICKHOUSE_CLIENT -q "SELECT 'rollback-new-key', count() FROM $table WHERE key = 2499 AND tag = 251"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_throw_during_index_build"
+if $CLICKHOUSE_CLIENT -q "ALTER TABLE $table ADD INDEX (key)" >/dev/null 2>&1; then
+    echo "Expected injected lookup-index build failure" >&2
+    exit 1
+fi
+$CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT overwrite_cache_throw_during_index_build"
+$CLICKHOUSE_CLIENT -q "
+    SELECT 'index-build-rollback', position(create_table_query, 'INDEX (key)')
+    FROM system.tables
+    WHERE database = currentDatabase() AND name = 'overwrite_cache_sharded_publication'"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_pause_during_index_build"
+$CLICKHOUSE_CLIENT -q "ALTER TABLE $table ADD INDEX (key)" >/dev/null &
+writer_pid=$!
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT overwrite_cache_pause_during_index_build PAUSE"
+$CLICKHOUSE_CLIENT -q "INSERT INTO $table VALUES (3000, 1, 1, 'index-catch-up')"
+$CLICKHOUSE_CLIENT -q "SYSTEM NOTIFY FAILPOINT overwrite_cache_pause_during_index_build"
+wait "$writer_pid"
+writer_pid=""
+$CLICKHOUSE_CLIENT -q "SELECT 'index-catch-up', payload FROM $table WHERE key = 3000"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_pause_after_lookup_catalog_snapshot"
+$CLICKHOUSE_CLIENT -q "INSERT INTO $table VALUES (4000, 77, 1, 'drop-race')" >/dev/null &
+writer_pid=$!
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT overwrite_cache_pause_after_lookup_catalog_snapshot PAUSE"
+$CLICKHOUSE_CLIENT -q "ALTER TABLE $table DROP INDEX (key)"
+$CLICKHOUSE_CLIENT -q "SYSTEM NOTIFY FAILPOINT overwrite_cache_pause_after_lookup_catalog_snapshot"
+wait "$writer_pid"
+writer_pid=""
+$CLICKHOUSE_CLIENT -q "SELECT 'drop-during-insert-prep', payload FROM $table WHERE tag = 77"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_pause_after_lookup_catalog_snapshot"
+$CLICKHOUSE_CLIENT -q "INSERT INTO $table VALUES (4001, 78, 1, 'add-race')" >/dev/null &
+writer_pid=$!
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT overwrite_cache_pause_after_lookup_catalog_snapshot PAUSE"
+$CLICKHOUSE_CLIENT -q "ALTER TABLE $table ADD INDEX (key)"
+$CLICKHOUSE_CLIENT -q "SYSTEM NOTIFY FAILPOINT overwrite_cache_pause_after_lookup_catalog_snapshot"
+wait "$writer_pid"
+writer_pid=""
+$CLICKHOUSE_CLIENT -q "SELECT 'add-during-insert-prep', payload FROM $table WHERE key = 4001"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_pause_during_lookup"
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT overwrite_cache_pause_after_drop_index_publication"
+$CLICKHOUSE_CLIENT -q "SELECT 'drop-old-reader', count() FROM $table WHERE tag = 1" > "$reader_output" &
+reader_pid=$!
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT overwrite_cache_pause_during_lookup PAUSE"
+$CLICKHOUSE_CLIENT -q "ALTER TABLE $table DROP INDEX (tag)" >/dev/null &
+drop_pid=$!
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT overwrite_cache_pause_after_drop_index_publication PAUSE"
+$CLICKHOUSE_CLIENT -q "SYSTEM NOTIFY FAILPOINT overwrite_cache_pause_during_lookup"
+$CLICKHOUSE_CLIENT -q "SYSTEM NOTIFY FAILPOINT overwrite_cache_pause_after_drop_index_publication"
+wait "$reader_pid"
+reader_pid=""
+wait "$drop_pid"
+drop_pid=""
+cat "$reader_output"

--- a/tests/queries/0_stateless/04628_overwrite_cache_segment_compaction.reference
+++ b/tests/queries/0_stateless/04628_overwrite_cache_segment_compaction.reference
@@ -1,0 +1,3 @@
+compacted	1
+new-row	2	1
+retained-row	1	1

--- a/tests/queries/0_stateless/04628_overwrite_cache_segment_compaction.sql
+++ b/tests/queries/0_stateless/04628_overwrite_cache_segment_compaction.sql
@@ -1,0 +1,38 @@
+DROP TABLE IF EXISTS overwrite_cache_segment_compaction;
+
+CREATE TABLE overwrite_cache_segment_compaction
+(
+    key UInt64,
+    version UInt64,
+    payload String
+)
+ENGINE = OverwriteCache(version)
+KEYS (key)
+SETTINGS max_memory_bytes = 100000000;
+
+INSERT INTO overwrite_cache_segment_compaction
+SELECT number, 1, repeat('x', 100)
+FROM numbers(1000);
+
+CREATE TEMPORARY TABLE overwrite_cache_segment_bytes_before
+ENGINE = Memory
+AS SELECT total_bytes AS bytes
+FROM system.tables
+WHERE database = currentDatabase() AND name = 'overwrite_cache_segment_compaction';
+
+INSERT INTO overwrite_cache_segment_compaction
+SELECT number, 2, repeat('y', 100)
+FROM numbers(600);
+
+SELECT 'compacted', current.total_bytes < previous.bytes * 3 / 2
+FROM system.tables AS current
+CROSS JOIN overwrite_cache_segment_bytes_before AS previous
+WHERE current.database = currentDatabase() AND current.name = 'overwrite_cache_segment_compaction';
+SELECT 'new-row', version, payload = repeat('y', 100)
+FROM overwrite_cache_segment_compaction
+WHERE key = 100;
+SELECT 'retained-row', version, payload = repeat('x', 100)
+FROM overwrite_cache_segment_compaction
+WHERE key = 800;
+
+DROP TABLE overwrite_cache_segment_compaction;

--- a/tests/queries/0_stateless/04629_overwrite_cache_compress_segments.reference
+++ b/tests/queries/0_stateless/04629_overwrite_cache_compress_segments.reference
@@ -1,0 +1,10 @@
+winners agree with the reference
+1	1	0	0
+lookup indexes agree
+1	1
+point lookups agree
+0
+repeated replacement
+0	0
+0	0
+rejects an unsupported value

--- a/tests/queries/0_stateless/04629_overwrite_cache_compress_segments.sql
+++ b/tests/queries/0_stateless/04629_overwrite_cache_compress_segments.sql
@@ -1,0 +1,103 @@
+DROP TABLE IF EXISTS overwrite_cache_compressed;
+DROP TABLE IF EXISTS overwrite_cache_plain;
+DROP TABLE IF EXISTS overwrite_cache_source;
+
+CREATE TABLE overwrite_cache_source ENGINE = Memory AS
+SELECT
+    toUInt8(number % 5) AS website_type,
+    toUInt32(number % 3000) AS user_id,
+    concat('tag', toString(number % 7))::LowCardinality(String) AS tag,
+    toUInt64(number % 40) AS version,
+    toUInt64(number) AS source_sequence,
+    repeat('payload', 1 + number % 3) AS value
+FROM numbers(50000);
+
+CREATE TABLE overwrite_cache_plain
+(
+    website_type UInt8,
+    user_id UInt32,
+    tag LowCardinality(String),
+    version UInt64,
+    source_sequence UInt64,
+    value String
+)
+ENGINE = OverwriteCache(version)
+KEYS (website_type, user_id, tag)
+INDEX (tag), (website_type), (website_type, tag)
+SETTINGS max_memory_bytes = 1073741824, equal_version_tiebreak_columns = 'source_sequence';
+
+CREATE TABLE overwrite_cache_compressed
+(
+    website_type UInt8,
+    user_id UInt32,
+    tag LowCardinality(String),
+    version UInt64,
+    source_sequence UInt64,
+    value String
+)
+ENGINE = OverwriteCache(version)
+KEYS (website_type, user_id, tag)
+INDEX (tag), (website_type), (website_type, tag)
+SETTINGS max_memory_bytes = 1073741824, equal_version_tiebreak_columns = 'source_sequence', compress_segments = 1;
+
+INSERT INTO overwrite_cache_plain SELECT * FROM overwrite_cache_source
+SETTINGS max_insert_block_size = 4000, min_insert_block_size_rows = 4000, min_insert_block_size_bytes = 0;
+INSERT INTO overwrite_cache_compressed SELECT * FROM overwrite_cache_source
+SETTINGS max_insert_block_size = 4000, min_insert_block_size_rows = 4000, min_insert_block_size_bytes = 0;
+
+-- Compression must change neither which row wins nor the stored payload.
+SELECT 'winners agree with the reference';
+WITH reference AS
+(
+    SELECT
+        website_type,
+        user_id,
+        tag,
+        argMax(version, (version, source_sequence)) AS winner_version,
+        argMax(source_sequence, (version, source_sequence)) AS winner_sequence,
+        argMax(value, (version, source_sequence)) AS winner_value
+    FROM overwrite_cache_source
+    GROUP BY website_type, user_id, tag
+)
+SELECT
+    (SELECT count() FROM reference) = (SELECT count() FROM overwrite_cache_plain WHERE website_type IN (0, 1, 2, 3, 4)),
+    (SELECT count() FROM reference) = (SELECT count() FROM overwrite_cache_compressed WHERE website_type IN (0, 1, 2, 3, 4)),
+    (SELECT count() FROM (SELECT * FROM overwrite_cache_plain WHERE website_type IN (0, 1, 2, 3, 4) EXCEPT SELECT * FROM reference)),
+    (SELECT count() FROM (SELECT * FROM overwrite_cache_compressed WHERE website_type IN (0, 1, 2, 3, 4) EXCEPT SELECT * FROM reference));
+
+SELECT 'lookup indexes agree';
+SELECT
+    (SELECT count() FROM overwrite_cache_plain WHERE tag = 'tag3') = (SELECT count() FROM overwrite_cache_compressed WHERE tag = 'tag3'),
+    (SELECT sum(cityHash64(value)) FROM overwrite_cache_plain WHERE website_type = 2 AND tag = 'tag3')
+        = (SELECT sum(cityHash64(value)) FROM overwrite_cache_compressed WHERE website_type = 2 AND tag = 'tag3');
+
+SELECT 'point lookups agree';
+SELECT countIf(
+    overwriteCacheGetOrNull(concat(currentDatabase(), '.overwrite_cache_plain'), 'value', website_type, user_id, tag)
+    != overwriteCacheGetOrNull(concat(currentDatabase(), '.overwrite_cache_compressed'), 'value', website_type, user_id, tag))
+FROM overwrite_cache_plain
+WHERE website_type IN (0, 1, 2, 3, 4);
+
+-- Replacing every key retires and compacts segments in both representations.
+SELECT 'repeated replacement';
+CREATE TABLE overwrite_cache_replacement ENGINE = Memory AS
+SELECT DISTINCT website_type, user_id, tag, toUInt64(100) AS version, toUInt64(0) AS source_sequence, 'final' AS value
+FROM overwrite_cache_source;
+INSERT INTO overwrite_cache_plain SELECT * FROM overwrite_cache_replacement
+SETTINGS max_insert_block_size = 4000, min_insert_block_size_rows = 4000, min_insert_block_size_bytes = 0;
+INSERT INTO overwrite_cache_compressed SELECT * FROM overwrite_cache_replacement
+SETTINGS max_insert_block_size = 4000, min_insert_block_size_rows = 4000, min_insert_block_size_bytes = 0;
+SELECT countIf(value != 'final'), countIf(version != 100)
+FROM overwrite_cache_plain WHERE website_type IN (0, 1, 2, 3, 4);
+SELECT countIf(value != 'final'), countIf(version != 100)
+FROM overwrite_cache_compressed WHERE website_type IN (0, 1, 2, 3, 4);
+
+SELECT 'rejects an unsupported value';
+CREATE TABLE overwrite_cache_bad (key UInt64, version UInt64)
+ENGINE = OverwriteCache(version) KEYS (key)
+SETTINGS max_memory_bytes = 1048576, compress_segments = 'yes'; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE overwrite_cache_replacement;
+DROP TABLE overwrite_cache_compressed;
+DROP TABLE overwrite_cache_plain;
+DROP TABLE overwrite_cache_source;

--- a/tests/queries/0_stateless/04630_overwrite_cache_reader_does_not_block_writer.reference
+++ b/tests/queries/0_stateless/04630_overwrite_cache_reader_does_not_block_writer.reference
@@ -1,0 +1,3 @@
+reader kept its snapshot
+1
+1

--- a/tests/queries/0_stateless/04630_overwrite_cache_reader_does_not_block_writer.sh
+++ b/tests/queries/0_stateless/04630_overwrite_cache_reader_does_not_block_writer.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+table="${CLICKHOUSE_DATABASE}.overwrite_cache_reader_does_not_block_writer"
+reader_pid=""
+reader_output=$(mktemp "$CLICKHOUSE_TMP/overwrite-cache-nonblocking-XXXXXX")
+
+cleanup()
+{
+    if [[ -n "$reader_pid" ]]; then
+        wait "$reader_pid" >/dev/null 2>&1 ||:
+    fi
+    rm -f "$reader_output"
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS $table" >/dev/null 2>&1 ||:
+}
+trap cleanup EXIT
+
+$CLICKHOUSE_CLIENT -q "
+CREATE TABLE $table (key UInt64, version UInt64, payload UInt64)
+ENGINE = OverwriteCache(version)
+KEYS (key)
+SETTINGS max_memory_bytes = 1073741824"
+
+$CLICKHOUSE_CLIENT -q "INSERT INTO $table SELECT number, 1, 111 FROM numbers(200)"
+
+# A reader that keeps its snapshot open across several publications. Publishing supersedes the rows it
+# reads instead of waiting for it, so it must still observe the generation it captured.
+$CLICKHOUSE_CLIENT -q "
+SELECT sum(payload + sleepEachRow(0.01))
+FROM $table
+WHERE key IN (SELECT number FROM numbers(200))
+SETTINGS max_block_size = 4" > "$reader_output" 2>&1 &
+reader_pid=$!
+
+$CLICKHOUSE_CLIENT -q "SELECT sleep(1) FORMAT Null"
+
+for version in 2 3 4 5
+do
+    $CLICKHOUSE_CLIENT -q "INSERT INTO $table SELECT number, $version, 999 FROM numbers(200)"
+done
+
+wait "$reader_pid"
+reader_pid=""
+
+if [[ "$(cat "$reader_output")" == "22200" ]]
+then
+    echo "reader kept its snapshot"
+else
+    echo "reader saw $(cat "$reader_output"), expected 22200"
+fi
+
+$CLICKHOUSE_CLIENT -q "SELECT sum(payload) = 199800 FROM $table WHERE key IN (SELECT number FROM numbers(200))"
+
+# Reading a table while inserting into it must not deadlock: the writer would otherwise wait for a
+# reader that cannot finish until the writer does.
+$CLICKHOUSE_CLIENT -q "
+INSERT INTO $table
+SELECT key, 6, 777 FROM $table WHERE key IN (SELECT number FROM numbers(200))"
+$CLICKHOUSE_CLIENT -q "SELECT sum(payload) = 155400 FROM $table WHERE key IN (SELECT number FROM numbers(200))"

--- a/tests/queries/0_stateless/04631_overwrite_cache_equal_version_tie.reference
+++ b/tests/queries/0_stateless/04631_overwrite_cache_equal_version_tie.reference
@@ -1,0 +1,13 @@
+-- a tie across separate inserts keeps the stored row
+first
+-- an identical row is still a no-op
+first
+-- a tie inside one block keeps the earlier row
+earlier
+-- a greater tie-break and a greater version still win over a tie
+tie-winner
+version-winner
+-- the same holds without tie-break columns
+first
+-- ignored rows are counted
+3

--- a/tests/queries/0_stateless/04631_overwrite_cache_equal_version_tie.sql
+++ b/tests/queries/0_stateless/04631_overwrite_cache_equal_version_tie.sql
@@ -1,0 +1,84 @@
+-- Rows that tie on the version and tie-break columns never replace the row already stored, even when
+-- their payload differs. A duplicate produced by a faulty upstream query must not fail the insert.
+
+DROP TABLE IF EXISTS overwrite_cache_tie;
+
+CREATE TABLE overwrite_cache_tie
+(
+    user_id UInt64,
+    version UInt64,
+    tie UInt64,
+    payload String
+)
+ENGINE = OverwriteCache(version)
+KEYS (user_id)
+SETTINGS equal_version_tiebreak_columns = 'tie';
+
+SELECT '-- a tie across separate inserts keeps the stored row';
+INSERT INTO overwrite_cache_tie VALUES (1, 5, 1, 'first');
+INSERT INTO overwrite_cache_tie VALUES (1, 5, 1, 'second');
+SELECT payload FROM overwrite_cache_tie WHERE user_id = 1;
+
+SELECT '-- an identical row is still a no-op';
+INSERT INTO overwrite_cache_tie VALUES (1, 5, 1, 'first');
+SELECT payload FROM overwrite_cache_tie WHERE user_id = 1;
+
+SELECT '-- a tie inside one block keeps the earlier row';
+INSERT INTO overwrite_cache_tie VALUES (2, 5, 1, 'earlier'), (2, 5, 1, 'later');
+SELECT payload FROM overwrite_cache_tie WHERE user_id = 2;
+
+SELECT '-- a greater tie-break and a greater version still win over a tie';
+INSERT INTO overwrite_cache_tie VALUES (1, 5, 2, 'tie-winner');
+SELECT payload FROM overwrite_cache_tie WHERE user_id = 1;
+INSERT INTO overwrite_cache_tie VALUES (1, 6, 1, 'version-winner');
+SELECT payload FROM overwrite_cache_tie WHERE user_id = 1;
+
+DROP TABLE overwrite_cache_tie;
+
+SELECT '-- the same holds without tie-break columns';
+
+CREATE TABLE overwrite_cache_no_tiebreak
+(
+    user_id UInt64,
+    version UInt64,
+    payload String
+)
+ENGINE = OverwriteCache(version)
+KEYS (user_id);
+
+INSERT INTO overwrite_cache_no_tiebreak VALUES (1, 5, 'first');
+INSERT INTO overwrite_cache_no_tiebreak VALUES (1, 5, 'second');
+SELECT payload FROM overwrite_cache_no_tiebreak WHERE user_id = 1;
+
+DROP TABLE overwrite_cache_no_tiebreak;
+
+SELECT '-- ignored rows are counted';
+
+CREATE TABLE overwrite_cache_counted
+(
+    user_id UInt64,
+    version UInt64,
+    payload String
+)
+ENGINE = OverwriteCache(version)
+KEYS (user_id);
+
+INSERT INTO overwrite_cache_counted VALUES (1, 5, 'first');
+
+SET log_queries = 1;
+SET async_insert = 0;
+INSERT INTO overwrite_cache_counted VALUES (1, 5, 'a'), (1, 5, 'b'), (2, 5, 'c'), (2, 5, 'd');
+SET log_queries = 0;
+
+SYSTEM FLUSH LOGS query_log;
+
+-- Three rows lose a tie: one inside the block for each key, and the survivor for key 1 against the stored row.
+SELECT ProfileEvents['OverwriteCacheEqualVersionTies']
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type = 'QueryFinish'
+  AND query LIKE 'INSERT INTO overwrite_cache_counted VALUES%'
+ORDER BY event_time_microseconds DESC
+LIMIT 1;
+
+DROP TABLE overwrite_cache_counted;

--- a/tests/queries/0_stateless/04632_overwrite_cache_delete.reference
+++ b/tests/queries/0_stateless/04632_overwrite_cache_delete.reference
@@ -1,0 +1,38 @@
+-- a complete KEYS predicate deletes one row
+a-two
+-- a lookup-index predicate deletes every matching row
+b-one
+-- an extra predicate narrows an indexed delete
+b-one
+-- rows behind another index value are untouched
+c-one
+-- a predicate that needs a scan is rejected
+c-one
+-- deleting an absent key is a no-op
+1
+-- a deleted key can be inserted again, at any version
+a-one-again
+a-one-again
+2
+-- a resurrected row is replaced by a greater version as usual
+a-one-again
+a-one-newer
+-- the scalar lookup functions see the deletion
+1
+-- ALTER TABLE ... DELETE WHERE works the same way
+0
+-- other mutations stay unsupported
+-- a failed publication leaves every row in place
+one
+one
+two
+2
+two
+1
+64
+-- an IN list and an IN subquery both resolve keys
+60
+0
+-- a segment left at least half dead is compacted
+16
+1	1

--- a/tests/queries/0_stateless/04632_overwrite_cache_delete.sql
+++ b/tests/queries/0_stateless/04632_overwrite_cache_delete.sql
@@ -1,0 +1,152 @@
+-- `DELETE` accepts exactly the predicates a `SELECT` accepts: a complete `KEYS` tuple, or one or more
+-- declared lookup indexes. Anything that would need a scan is rejected instead.
+
+DROP TABLE IF EXISTS overwrite_cache_delete;
+
+CREATE TABLE overwrite_cache_delete
+(
+    website_type UInt8,
+    user_id UInt64,
+    tag LowCardinality(String),
+    version UInt64,
+    payload String
+)
+ENGINE = OverwriteCache(version)
+KEYS (website_type, user_id, tag)
+INDEX (tag), (website_type);
+
+INSERT INTO overwrite_cache_delete VALUES
+    (1, 100, 'A', 1, 'a-one'),
+    (1, 200, 'A', 1, 'a-two'),
+    (1, 300, 'B', 1, 'b-one'),
+    (2, 400, 'C', 1, 'c-one');
+
+SELECT '-- a complete KEYS predicate deletes one row';
+DELETE FROM overwrite_cache_delete WHERE website_type = 1 AND user_id = 100 AND tag = 'A';
+SELECT payload FROM overwrite_cache_delete WHERE website_type = 1 AND user_id = 100 AND tag = 'A';
+SELECT payload FROM overwrite_cache_delete WHERE tag = 'A';
+
+SELECT '-- a lookup-index predicate deletes every matching row';
+DELETE FROM overwrite_cache_delete WHERE tag = 'A';
+SELECT payload FROM overwrite_cache_delete WHERE tag = 'A';
+SELECT payload FROM overwrite_cache_delete ORDER BY payload SETTINGS max_threads = 1; -- { serverError BAD_ARGUMENTS }
+SELECT payload FROM overwrite_cache_delete WHERE website_type = 1 ORDER BY payload;
+
+SELECT '-- an extra predicate narrows an indexed delete';
+DELETE FROM overwrite_cache_delete WHERE website_type = 1 AND payload = 'nothing-matches';
+SELECT payload FROM overwrite_cache_delete WHERE website_type = 1 ORDER BY payload;
+DELETE FROM overwrite_cache_delete WHERE website_type = 1 AND payload = 'b-one';
+SELECT payload FROM overwrite_cache_delete WHERE website_type = 1 ORDER BY payload;
+
+SELECT '-- rows behind another index value are untouched';
+SELECT payload FROM overwrite_cache_delete WHERE tag = 'C';
+
+SELECT '-- a predicate that needs a scan is rejected';
+DELETE FROM overwrite_cache_delete WHERE payload = 'c-one'; -- { serverError BAD_ARGUMENTS }
+DELETE FROM overwrite_cache_delete WHERE 1; -- { serverError BAD_ARGUMENTS }
+DELETE FROM overwrite_cache_delete WHERE user_id = 400; -- { serverError BAD_ARGUMENTS }
+SELECT payload FROM overwrite_cache_delete WHERE tag = 'C';
+
+SELECT '-- deleting an absent key is a no-op';
+DELETE FROM overwrite_cache_delete WHERE website_type = 9 AND user_id = 999 AND tag = 'missing';
+SELECT total_rows FROM system.tables WHERE database = currentDatabase() AND name = 'overwrite_cache_delete';
+
+SELECT '-- a deleted key can be inserted again, at any version';
+INSERT INTO overwrite_cache_delete VALUES (1, 100, 'A', 1, 'a-one-again');
+SELECT payload FROM overwrite_cache_delete WHERE website_type = 1 AND user_id = 100 AND tag = 'A';
+SELECT payload FROM overwrite_cache_delete WHERE tag = 'A';
+SELECT total_rows FROM system.tables WHERE database = currentDatabase() AND name = 'overwrite_cache_delete';
+
+SELECT '-- a resurrected row is replaced by a greater version as usual';
+INSERT INTO overwrite_cache_delete VALUES (1, 100, 'A', 1, 'stale');
+SELECT payload FROM overwrite_cache_delete WHERE website_type = 1 AND user_id = 100 AND tag = 'A';
+INSERT INTO overwrite_cache_delete VALUES (1, 100, 'A', 2, 'a-one-newer');
+SELECT payload FROM overwrite_cache_delete WHERE website_type = 1 AND user_id = 100 AND tag = 'A';
+
+SELECT '-- the scalar lookup functions see the deletion';
+DELETE FROM overwrite_cache_delete WHERE website_type = 2 AND user_id = 400 AND tag = 'C';
+SELECT overwriteCacheGetOrNull(concat(currentDatabase(), '.overwrite_cache_delete'), 'payload', toUInt8(2), toUInt64(400), 'C') IS NULL;
+
+SELECT '-- ALTER TABLE ... DELETE WHERE works the same way';
+ALTER TABLE overwrite_cache_delete DELETE WHERE website_type = 1 AND user_id = 100 AND tag = 'A';
+SELECT payload FROM overwrite_cache_delete WHERE tag = 'A';
+SELECT total_rows FROM system.tables WHERE database = currentDatabase() AND name = 'overwrite_cache_delete';
+
+SELECT '-- other mutations stay unsupported';
+ALTER TABLE overwrite_cache_delete UPDATE payload = 'x' WHERE website_type = 1; -- { serverError NOT_IMPLEMENTED }
+
+DROP TABLE overwrite_cache_delete;
+
+SELECT '-- a failed publication leaves every row in place';
+
+CREATE TABLE overwrite_cache_delete_rollback
+(
+    key UInt64,
+    tag String,
+    version UInt64,
+    payload String
+)
+ENGINE = OverwriteCache(version)
+KEYS (key, tag)
+INDEX (tag);
+
+INSERT INTO overwrite_cache_delete_rollback VALUES (1, 'a', 1, 'one'), (2, 'a', 1, 'two');
+
+SYSTEM ENABLE FAILPOINT overwrite_cache_throw_during_publish;
+DELETE FROM overwrite_cache_delete_rollback WHERE key = 1 AND tag = 'a'; -- { serverError FAULT_INJECTED }
+SYSTEM DISABLE FAILPOINT overwrite_cache_throw_during_publish;
+
+SELECT payload FROM overwrite_cache_delete_rollback WHERE key = 1 AND tag = 'a';
+SELECT payload FROM overwrite_cache_delete_rollback WHERE tag = 'a' ORDER BY payload;
+SELECT total_rows FROM system.tables WHERE database = currentDatabase() AND name = 'overwrite_cache_delete_rollback';
+
+DELETE FROM overwrite_cache_delete_rollback WHERE key = 1 AND tag = 'a';
+SELECT payload FROM overwrite_cache_delete_rollback WHERE tag = 'a' ORDER BY payload;
+SELECT total_rows FROM system.tables WHERE database = currentDatabase() AND name = 'overwrite_cache_delete_rollback';
+
+DROP TABLE overwrite_cache_delete_rollback;
+
+DROP TABLE IF EXISTS overwrite_cache_delete_bytes;
+DROP TABLE IF EXISTS overwrite_cache_delete_probe;
+
+CREATE TABLE overwrite_cache_delete_bytes
+(
+    key UInt64,
+    version UInt64,
+    payload String
+)
+ENGINE = OverwriteCache(version)
+KEYS (key);
+
+CREATE TABLE overwrite_cache_delete_probe (stage String, bytes UInt64) ENGINE = Memory;
+
+INSERT INTO overwrite_cache_delete_bytes SELECT number, 1, repeat('x', 1000) FROM numbers(64);
+SELECT total_rows FROM system.tables WHERE database = currentDatabase() AND name = 'overwrite_cache_delete_bytes';
+INSERT INTO overwrite_cache_delete_probe
+SELECT 'filled', total_bytes FROM system.tables WHERE database = currentDatabase() AND name = 'overwrite_cache_delete_bytes';
+
+SELECT '-- an IN list and an IN subquery both resolve keys';
+DELETE FROM overwrite_cache_delete_bytes WHERE key IN (0, 1, 2, 3);
+SELECT total_rows FROM system.tables WHERE database = currentDatabase() AND name = 'overwrite_cache_delete_bytes';
+DELETE FROM overwrite_cache_delete_bytes WHERE key IN (SELECT number FROM numbers(64));
+SELECT total_rows FROM system.tables WHERE database = currentDatabase() AND name = 'overwrite_cache_delete_bytes';
+INSERT INTO overwrite_cache_delete_probe
+SELECT 'emptied', total_bytes FROM system.tables WHERE database = currentDatabase() AND name = 'overwrite_cache_delete_bytes';
+
+SELECT '-- a segment left at least half dead is compacted';
+INSERT INTO overwrite_cache_delete_bytes SELECT number, 1, repeat('y', 1000) FROM numbers(64);
+DELETE FROM overwrite_cache_delete_bytes WHERE key IN (SELECT number FROM numbers(48));
+SELECT total_rows FROM system.tables WHERE database = currentDatabase() AND name = 'overwrite_cache_delete_bytes';
+INSERT INTO overwrite_cache_delete_probe
+SELECT 'compacted', total_bytes FROM system.tables WHERE database = currentDatabase() AND name = 'overwrite_cache_delete_bytes';
+
+-- The primary index and the entry table never shrink, so the fully deleted table is the baseline the
+-- payload is measured against. Deleting three quarters of a segment must leave about a quarter of it.
+SELECT
+    (SELECT bytes FROM overwrite_cache_delete_probe WHERE stage = 'filled')
+        - (SELECT bytes FROM overwrite_cache_delete_probe WHERE stage = 'emptied') > 60000,
+    (SELECT bytes FROM overwrite_cache_delete_probe WHERE stage = 'compacted')
+        - (SELECT bytes FROM overwrite_cache_delete_probe WHERE stage = 'emptied') BETWEEN 1 AND 30000;
+
+DROP TABLE overwrite_cache_delete_probe;
+DROP TABLE overwrite_cache_delete_bytes;

--- a/tests/queries/0_stateless/04633_overwrite_cache_persistence.reference
+++ b/tests/queries/0_stateless/04633_overwrite_cache_persistence.reference
@@ -1,0 +1,16 @@
+before detach	3
+after attach	3
+primary lookup	first
+index lookup	42	first
+index lookup	43	second
+replacement survives	replaced	2026-01-02 00:00:00.000
+rows after replacement	3
+lower version still ignored	replaced
+deleted key stays deleted	0
+rows after delete	2
+resurrected row survives	resurrected
+added index rebuilt	third
+truncate is persisted	0
+volatile before detach	1
+volatile after attach	0
+sync mode	durable again

--- a/tests/queries/0_stateless/04633_overwrite_cache_persistence.sql
+++ b/tests/queries/0_stateless/04633_overwrite_cache_persistence.sql
@@ -1,0 +1,141 @@
+-- `DETACH` destroys the storage and `ATTACH` builds it again, which is the same path a restart takes:
+-- the log is replayed and the primary index and the lookup postings are rebuilt from the segments.
+
+DROP TABLE IF EXISTS overwrite_cache_persistence;
+
+CREATE TABLE overwrite_cache_persistence
+(
+    website_type UInt8,
+    user_id UInt64,
+    tag LowCardinality(String),
+    version DateTime64(3),
+    source_sequence UInt64,
+    value String
+)
+ENGINE = OverwriteCache(version)
+KEYS (website_type, user_id, tag)
+INDEX (tag), (website_type)
+SETTINGS equal_version_tiebreak_columns = 'source_sequence';
+
+INSERT INTO overwrite_cache_persistence VALUES (1, 42, 'risk', toDateTime64('2026-01-01 00:00:00.000', 3), 1, 'first');
+INSERT INTO overwrite_cache_persistence VALUES (1, 43, 'risk', toDateTime64('2026-01-01 00:00:00.000', 3), 1, 'second');
+INSERT INTO overwrite_cache_persistence VALUES (2, 44, 'vip', toDateTime64('2026-01-01 00:00:00.000', 3), 1, 'third');
+
+SELECT 'before detach', count() FROM overwrite_cache_persistence WHERE tag IN ('risk', 'vip');
+
+DETACH TABLE overwrite_cache_persistence;
+ATTACH TABLE overwrite_cache_persistence;
+
+SELECT 'after attach', count() FROM overwrite_cache_persistence WHERE tag IN ('risk', 'vip');
+SELECT 'primary lookup', value FROM overwrite_cache_persistence WHERE website_type = 1 AND user_id = 42 AND tag = 'risk';
+SELECT 'index lookup', user_id, value FROM overwrite_cache_persistence WHERE website_type = 1 ORDER BY user_id;
+
+-- A replacement published before the detach has to be the row that comes back, and the row it replaced
+-- must not: the segment holding it is retired and its file is removed.
+INSERT INTO overwrite_cache_persistence VALUES (1, 42, 'risk', toDateTime64('2026-01-02 00:00:00.000', 3), 1, 'replaced');
+
+DETACH TABLE overwrite_cache_persistence;
+ATTACH TABLE overwrite_cache_persistence;
+
+SELECT 'replacement survives', value, version FROM overwrite_cache_persistence WHERE website_type = 1 AND user_id = 42 AND tag = 'risk';
+SELECT 'rows after replacement', count() FROM overwrite_cache_persistence WHERE tag IN ('risk', 'vip');
+
+-- A lower version stays ignored after the reload, so replay does not reorder winner selection.
+INSERT INTO overwrite_cache_persistence VALUES (1, 42, 'risk', toDateTime64('2025-01-01 00:00:00.000', 3), 1, 'stale');
+
+DETACH TABLE overwrite_cache_persistence;
+ATTACH TABLE overwrite_cache_persistence;
+
+SELECT 'lower version still ignored', value FROM overwrite_cache_persistence WHERE website_type = 1 AND user_id = 42 AND tag = 'risk';
+
+-- A deleted key must not come back. Its row is dead inside a segment that nothing supersedes, so the
+-- deletion itself has to be part of the log.
+DELETE FROM overwrite_cache_persistence WHERE website_type = 1 AND user_id = 43 AND tag = 'risk';
+
+DETACH TABLE overwrite_cache_persistence;
+ATTACH TABLE overwrite_cache_persistence;
+
+SELECT 'deleted key stays deleted', count() FROM overwrite_cache_persistence WHERE website_type = 1 AND user_id = 43 AND tag = 'risk';
+SELECT 'rows after delete', count() FROM overwrite_cache_persistence WHERE tag IN ('risk', 'vip');
+
+-- A delete is not a version floor, and replay must not turn it into one: the reinserted row wins even
+-- though its version is below the one that was deleted.
+INSERT INTO overwrite_cache_persistence VALUES (1, 43, 'risk', toDateTime64('2020-01-01 00:00:00.000', 3), 1, 'resurrected');
+
+DETACH TABLE overwrite_cache_persistence;
+ATTACH TABLE overwrite_cache_persistence;
+
+SELECT 'resurrected row survives', value FROM overwrite_cache_persistence WHERE website_type = 1 AND user_id = 43 AND tag = 'risk';
+
+-- An index added after the data was written is rebuilt from the segments, so it is complete afterwards.
+ALTER TABLE overwrite_cache_persistence ADD INDEX (user_id);
+
+DETACH TABLE overwrite_cache_persistence;
+ATTACH TABLE overwrite_cache_persistence;
+
+SELECT 'added index rebuilt', value FROM overwrite_cache_persistence WHERE user_id = 44;
+
+TRUNCATE TABLE overwrite_cache_persistence;
+
+DETACH TABLE overwrite_cache_persistence;
+ATTACH TABLE overwrite_cache_persistence;
+
+SELECT 'truncate is persisted', count() FROM overwrite_cache_persistence WHERE tag IN ('risk', 'vip');
+
+DROP TABLE overwrite_cache_persistence;
+
+-- `persist_mode = 'none'` keeps the behaviour of a purely in-memory table.
+DROP TABLE IF EXISTS overwrite_cache_volatile;
+
+CREATE TABLE overwrite_cache_volatile
+(
+    key UInt64,
+    version UInt64,
+    value String
+)
+ENGINE = OverwriteCache(version)
+KEYS (key)
+SETTINGS persist_mode = 'none';
+
+INSERT INTO overwrite_cache_volatile VALUES (1, 1, 'gone');
+SELECT 'volatile before detach', count() FROM overwrite_cache_volatile WHERE key = 1;
+
+DETACH TABLE overwrite_cache_volatile;
+ATTACH TABLE overwrite_cache_volatile;
+
+SELECT 'volatile after attach', count() FROM overwrite_cache_volatile WHERE key = 1;
+
+DROP TABLE overwrite_cache_volatile;
+
+-- `sync` waits for the publication to be durable before the `INSERT` returns.
+DROP TABLE IF EXISTS overwrite_cache_sync;
+
+CREATE TABLE overwrite_cache_sync
+(
+    key UInt64,
+    version UInt64,
+    value String
+)
+ENGINE = OverwriteCache(version)
+KEYS (key)
+SETTINGS persist_mode = 'sync';
+
+INSERT INTO overwrite_cache_sync VALUES (1, 1, 'durable');
+INSERT INTO overwrite_cache_sync VALUES (1, 2, 'durable again');
+
+DETACH TABLE overwrite_cache_sync;
+ATTACH TABLE overwrite_cache_sync;
+
+SELECT 'sync mode', value FROM overwrite_cache_sync WHERE key = 1;
+
+DROP TABLE overwrite_cache_sync;
+
+-- An unknown mode is rejected at `CREATE` time rather than falling back to a default.
+CREATE TABLE overwrite_cache_bad_mode
+(
+    key UInt64,
+    version UInt64
+)
+ENGINE = OverwriteCache(version)
+KEYS (key)
+SETTINGS persist_mode = 'eventually'; -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/04634_overwrite_cache_backup.reference
+++ b/tests/queries/0_stateless/04634_overwrite_cache_backup.reference
@@ -1,0 +1,5 @@
+restored primary lookup	replaced
+restored index lookup	1
+deleted key stays deleted	0
+1
+1

--- a/tests/queries/0_stateless/04634_overwrite_cache_backup.sh
+++ b/tests/queries/0_stateless/04634_overwrite_cache_backup.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# A `BACKUP` copies the immutable segment files and a self-contained manifest, and a `RESTORE` replays
+# them, so the restored table has to answer both a primary and a lookup-index query.
+
+${CLICKHOUSE_CLIENT} -m --query "
+DROP TABLE IF EXISTS overwrite_cache_backup;
+
+CREATE TABLE overwrite_cache_backup
+(
+    website_type UInt8,
+    user_id UInt64,
+    tag LowCardinality(String),
+    version UInt64,
+    value String
+)
+ENGINE = OverwriteCache(version)
+KEYS (website_type, user_id, tag)
+INDEX (tag);
+
+INSERT INTO overwrite_cache_backup VALUES (1, 42, 'risk', 1, 'first');
+INSERT INTO overwrite_cache_backup VALUES (1, 43, 'risk', 1, 'second');
+INSERT INTO overwrite_cache_backup VALUES (1, 42, 'risk', 2, 'replaced');
+DELETE FROM overwrite_cache_backup WHERE website_type = 1 AND user_id = 43 AND tag = 'risk';
+"
+
+backup_name="Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}')"
+
+${CLICKHOUSE_CLIENT} --query "BACKUP TABLE overwrite_cache_backup TO ${backup_name} FORMAT Null"
+
+${CLICKHOUSE_CLIENT} -m --query "
+DROP TABLE overwrite_cache_backup;
+RESTORE TABLE overwrite_cache_backup FROM ${backup_name} FORMAT Null;
+"
+
+${CLICKHOUSE_CLIENT} -m --query "
+SELECT 'restored primary lookup', value FROM overwrite_cache_backup WHERE website_type = 1 AND user_id = 42 AND tag = 'risk';
+SELECT 'restored index lookup', count() FROM overwrite_cache_backup WHERE tag = 'risk';
+SELECT 'deleted key stays deleted', count() FROM overwrite_cache_backup WHERE website_type = 1 AND user_id = 43 AND tag = 'risk';
+"
+
+# Restoring over a table that already holds rows would merge two unrelated caches, so it is refused.
+${CLICKHOUSE_CLIENT} --query "RESTORE TABLE overwrite_cache_backup FROM ${backup_name} FORMAT Null" 2>&1 \
+    | grep -c -m1 "CANNOT_RESTORE_TABLE"
+
+${CLICKHOUSE_CLIENT} -m --query "
+DROP TABLE overwrite_cache_backup;
+
+-- A table that keeps nothing on disk has nothing to back up, which is an error rather than an empty backup.
+CREATE TABLE overwrite_cache_volatile
+(
+    key UInt64,
+    version UInt64
+)
+ENGINE = OverwriteCache(version)
+KEYS (key)
+SETTINGS persist_mode = 'none';
+INSERT INTO overwrite_cache_volatile VALUES (1, 1);
+"
+
+${CLICKHOUSE_CLIENT} --query "BACKUP TABLE overwrite_cache_volatile TO Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_volatile') FORMAT Null" 2>&1 \
+    | grep -c -m1 "BAD_ARGUMENTS"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE overwrite_cache_volatile"


### PR DESCRIPTION
## What is `OverwriteCache`

`OverwriteCache` is a new table engine for keeping a materialized, point-lookup-friendly copy of rows keyed by a `KEYS` tuple, where later writes for the same key overwrite earlier ones according to a `VERSION` column. It is meant for the "cache a slowly changing upstream source and look rows up by key" workload: an `INSERT` publishes a batch of rows, and each key ends up holding only the highest-`VERSION` row it has ever seen, resolved through a dedicated `overwriteCacheGet` function or a `SELECT` over one or more declared `INDEX (...)` lookup tuples.

The design favors point lookups and inserts over scans: there is no full-table `SELECT`, only lookups that fully specify the `KEYS` tuple or a declared index tuple. In exchange, both inserts and lookups are backed by in-memory hash indexes and stay fast independent of table size (see the throughput notes below).

### Correctness and concurrency

* Winner selection between two rows for the same key compares the `VERSION` column (and an optional tie-break column) in place with `IColumn::compareAt`, instead of materializing and comparing full rows. Rows whose version and tie-break columns are equal to what is already stored are treated as harmless duplicates rather than rejecting the whole inserted block; the `OverwriteCacheEqualVersionTies` profile event counts how often that happens, since a nonzero count means the tie-break columns don't fully determine the winner.
* Publishing a block (or applying a `DELETE`) never waits for concurrent readers: each entry holds a small chain of generation-tagged versions, and readers resolve the first version at or below their own snapshot generation. This means `INSERT INTO t SELECT ... FROM t` no longer deadlocks, and a long-running `SELECT` no longer stalls concurrent inserts.
* `DELETE FROM` / `ALTER TABLE ... DELETE WHERE` are supported, resolved through the same read path as `SELECT` (a full `KEYS` tuple or a declared `INDEX (...)` tuple), and published as one generation change with the same non-blocking semantics as an insert. A deleted key can be re-inserted afterwards. `UPDATE` is not supported — replace a row by inserting a new one with a higher version.
* `ALTER TABLE ... ADD/DROP INDEX` is supported for lookup indexes over columns already covered by `KEYS`.

### Persistence

Tables can survive server restarts and `DETACH`/`ATTACH`. The unit of persistence is the immutable row segment a publication already builds in memory: it's written to its own file once and never rewritten, and the file is removed when the segment is released. A `manifest` log records, per publication, the segments added, the segments retired, and any keys deleted, and is replayed at load time to rebuild the primary index, lookup postings, and version chains — none of that is stored on disk directly. `persist_mode` (`async` / `sync` / `none`) controls whether an `INSERT` returns before or after its publication is durable; `BACKUP`/`RESTORE` are supported by copying/replaying the segment files and manifest.

### Performance

Measured on 1M rows, six columns, three-column key, insert throughput went from roughly 150k rows/s (no index) / 143k rows/s (three indexes) to 926k–1.31M rows/s after the point-lookup and hashing rework described in the commit history, and point lookups went from ~1.2k/s (7-byte payload) / ~135/s (500-byte payload) to ~86k–91k/s independent of payload size. Segments are uncompressed by default; the `compress_segments` setting restores the previous LZ4-compressed representation for callers who prefer memory residency over per-row read cost.

See `docs/en/engines/table-engines/special/overwrite-cache.md` for the full SQL surface (`CREATE TABLE ... ENGINE = OverwriteCache`, settings, `overwriteCacheGet`) and `tests/queries/0_stateless/04626`–`04634_overwrite_cache_*` for behavior coverage (basic engine semantics, sharded publication, segment compaction, segment compression, non-blocking reads, equal-version ties, `DELETE`, persistence, and `BACKUP`/`RESTORE`).

### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added the `OverwriteCache` table engine: a persistent, point-lookup-oriented cache keyed by a `KEYS` tuple, where an `INSERT` overwrites a key's row when the new row's `VERSION` column is higher, and rows are read back through `overwriteCacheGet` or a `SELECT` filtered by the full key or a declared `INDEX (...)` tuple. Supports `DELETE FROM`/`ALTER TABLE ... DELETE WHERE`, `ALTER TABLE ... ADD/DROP INDEX`, non-blocking publication against concurrent readers, and persistence across restarts with configurable `persist_mode` and `BACKUP`/`RESTORE` support.
