### PR TITLE
fix some missed out S3Queue settings

### DIFF
--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -105,6 +105,10 @@ namespace ObjectStorageQueueSetting
     extern const ObjectStorageQueueSettingsUInt32 enable_logging_to_queue_log;
     extern const ObjectStorageQueueSettingsString keeper_path;
     extern const ObjectStorageQueueSettingsObjectStorageQueueMode mode;
+    extern const ObjectStorageQueueSettingsObjectStorageQueueBucketingMode bucketing_mode;
+    extern const ObjectStorageQueueSettingsObjectStorageQueuePartitioningMode partitioning_mode;
+    extern const ObjectStorageQueueSettingsString partition_regex;
+    extern const ObjectStorageQueueSettingsString partition_component;
     extern const ObjectStorageQueueSettingsUInt64 max_processed_bytes_before_commit;
     extern const ObjectStorageQueueSettingsUInt64 max_processed_files_before_commit;
     extern const ObjectStorageQueueSettingsUInt64 max_processed_rows_before_commit;
@@ -1762,6 +1766,10 @@ ObjectStorageQueueSettings StorageObjectStorageQueue::getSettings() const
     settings[ObjectStorageQueueSetting::parallel_inserts] = table_metadata.parallel_inserts;
     settings[ObjectStorageQueueSetting::enable_logging_to_queue_log] = enable_logging_to_queue_log;
     settings[ObjectStorageQueueSetting::last_processed_path] = table_metadata.last_processed_path;
+    settings[ObjectStorageQueueSetting::bucketing_mode] = table_metadata.bucketing_mode;
+    settings[ObjectStorageQueueSetting::partitioning_mode] = table_metadata.partitioning_mode;
+    settings[ObjectStorageQueueSetting::partition_regex] = table_metadata.partition_regex;
+    settings[ObjectStorageQueueSetting::partition_component] = table_metadata.partition_component;
     settings[ObjectStorageQueueSetting::tracked_file_ttl_sec] = table_metadata.tracked_files_ttl_sec;
     settings[ObjectStorageQueueSetting::tracked_files_limit] = table_metadata.tracked_files_limit;
     settings[ObjectStorageQueueSetting::buckets] = table_metadata.buckets;

--- a/tests/integration/test_storage_s3_queue/test_6.py
+++ b/tests/integration/test_storage_s3_queue/test_6.py
@@ -352,6 +352,7 @@ def test_ordered_mode_with_regex_partitioning(started_cluster, engine_name, proc
             partition_regex=partition_regex,
             partition_component=partition_component,
         )
+
         create_mv(node, table_name, dst_table_name)
 
     # Wait for tables to be created and queryable on all instances
@@ -722,6 +723,31 @@ def test_bucketing_mode_with_regex_partitioning(started_cluster, engine_name, bu
             partition_regex=partition_regex,
             partition_component=partition_component,
         )
+
+        reported_settings = dict(
+            line.split("\t", 1)
+            for line in node.query(
+                f"""
+                SELECT name, value
+                FROM system.s3_queue_settings
+                WHERE table = '{table_name}'
+                    AND name IN (
+                        'bucketing_mode',
+                        'partitioning_mode',
+                        'partition_regex',
+                        'partition_component'
+                    )
+                FORMAT TabSeparatedRaw
+                """
+            ).strip().splitlines()
+        )
+        assert reported_settings == {
+            "bucketing_mode": bucketing_mode,
+            "partitioning_mode": "regex",
+            "partition_regex": partition_regex,
+            "partition_component": partition_component,
+        }
+
         create_mv(node, table_name, dst_table_name)
 
     # Wait for tables to be created


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
`StorageObjectStorageQueue::getSettings` omitted partitioning and bucketing settings when reconstructing runtime configuration. As a result, `system.s3_queue_settings` reported generic defaults instead of the table’s configured values. Reconstruct these settings from `ObjectStorageQueueTableMetadata` and add regression test coverage.


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `system.s3_queue_settings` reporting incorrect values for `bucketing_mode`, `partitioning_mode`, `partition_regex`, and `partition_component`.
