### PR TITLE
Preserve the replaced node's header in lazy materialization

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
@@ -677,6 +677,11 @@ bool optimizeLazyMaterialization2(QueryPlan::Node & root, QueryPlan & query_plan
         main_plan.addStep(std::move(new_sorting_step));
     }
 
+    /// The replacement plan must produce the header `root` produces. Capture it here, before the
+    /// next line: `LimitStep::updateOutputHeader` mirrors its input header, so `updateInputHeader`
+    /// overwrites it with the main branch header, and `root.step` is moved away right after.
+    auto expected_header = root.step->getOutputHeader();
+
     limit_step->updateInputHeader(main_plan.getCurrentHeader());
     main_plan.addStep(std::move(root.step));
 
@@ -737,7 +742,7 @@ bool optimizeLazyMaterialization2(QueryPlan::Node & root, QueryPlan & query_plan
         result_plan.addStep(std::make_unique<ExpressionStep>(result_plan.getCurrentHeader(), std::move(dag)));
     }
 
-    query_plan.replaceNodeWithPlan(&root, std::move(result_plan));
+    query_plan.replaceNodeWithPlan(&root, std::move(result_plan), std::move(expected_header));
 
     return true;
 }

--- a/tests/queries/0_stateless/04095_lazy_final_with_lazy_materialization.reference
+++ b/tests/queries/0_stateless/04095_lazy_final_with_lazy_materialization.reference
@@ -15,26 +15,27 @@
 === Full EXPLAIN ===
 Expression ((Project names + (Before ORDER BY + Projection) [lifted up part]))
   Expression
-    JoinLazyColumnsStep
-      Limit (preliminary LIMIT)
-        Sorting (Sorting for ORDER BY)
-          Expression
-            Filter
-              Union
-                InputSelector
-                  LazyFinalKeyAnalysis
-                    CreatingSet
-                      Expression
+    Expression
+      JoinLazyColumnsStep
+        Limit (preliminary LIMIT)
+          Sorting (Sorting for ORDER BY)
+            Expression
+              Filter
+                Union
+                  InputSelector
+                    LazyFinalKeyAnalysis
+                      CreatingSet
                         Expression
-                          ReadFromMergeTree (default.t_lazy_both)
-                  JoinLazyColumnsStep
-                    LazyReadReplacingFinal
-                      Expression
-                        Aggregating
                           Expression
+                            ReadFromMergeTree (default.t_lazy_both)
+                    JoinLazyColumnsStep
+                      LazyReadReplacingFinal
+                        Expression
+                          Aggregating
                             Expression
-                              ReadFromMergeTree (default.t_lazy_both)
-                    LazilyReadFromMergeTree
+                              Expression
+                                ReadFromMergeTree (default.t_lazy_both)
+                      LazilyReadFromMergeTree
+                    ReadFromMergeTree (default.t_lazy_both)
                   ReadFromMergeTree (default.t_lazy_both)
-                ReadFromMergeTree (default.t_lazy_both)
-      LazilyReadFromMergeTree
+        LazilyReadFromMergeTree

--- a/tests/queries/0_stateless/04652_lazy_materialization_replace_node_header_order.reference
+++ b/tests/queries/0_stateless/04652_lazy_materialization_replace_node_header_order.reference
@@ -1,0 +1,9 @@
+lazy materialization applied:	1
+100	1	1
+200	1	2
+300	1	3
+400	1	4
+300	3
+400	4
+distributed == local:	1
+lazy == not lazy:	1

--- a/tests/queries/0_stateless/04652_lazy_materialization_replace_node_header_order.reference
+++ b/tests/queries/0_stateless/04652_lazy_materialization_replace_node_header_order.reference
@@ -1,4 +1,5 @@
 lazy materialization applied:	1
+lazy materialization applied (distributed):	1
 100	1	1
 200	1	2
 300	1	3

--- a/tests/queries/0_stateless/04652_lazy_materialization_replace_node_header_order.sql
+++ b/tests/queries/0_stateless/04652_lazy_materialization_replace_node_header_order.sql
@@ -1,0 +1,51 @@
+-- Tags: no-parallel-replicas
+-- no-parallel-replicas: the test checks the shape of the local query plan.
+
+DROP TABLE IF EXISTS t_lm_header_order;
+
+CREATE TABLE t_lm_header_order (k Int32, v UInt64, ver UInt64)
+ENGINE = ReplacingMergeTree(ver) ORDER BY k
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_lm_header_order VALUES (1, 100, 1), (2, 200, 1), (3, 300, 1), (4, 400, 1);
+
+-- The test relies on settings that are randomized by the test runner: pin them.
+SET enable_analyzer = 1;
+SET query_plan_optimize_lazy_materialization = 1, query_plan_max_limit_for_lazy_materialization = 10;
+
+-- Lazy materialization must fire for all the queries below, otherwise they assert nothing.
+SELECT 'lazy materialization applied:', countIf(explain LIKE '%LazilyReadFromMergeTree%') > 0
+FROM (EXPLAIN SELECT v, ver, k FROM t_lm_header_order FINAL PREWHERE k > 0 LIMIT 4);
+
+-- Lazy materialization replaces the LimitStep node with a JoinLazyColumnsStep subplan whose
+-- header follows the main/lazy split, not the projection. make_distributed_plan rebuilds the
+-- plan bottom-up and re-derives every header, so a replacement that lost the replaced node's
+-- header order raised LOGICAL_ERROR "incompatible header with root step".
+SELECT v, ver, k FROM t_lm_header_order FINAL PREWHERE k > 0 LIMIT 4
+SETTINGS make_distributed_plan = 1, distributed_plan_execute_locally = 1;
+
+SELECT v, k FROM t_lm_header_order FINAL PREWHERE k > 2 LIMIT 4
+SETTINGS make_distributed_plan = 1, distributed_plan_execute_locally = 1;
+
+SELECT ver, v, k FROM t_lm_header_order FINAL PREWHERE k = NULL LIMIT 4
+SETTINGS make_distributed_plan = 1, distributed_plan_execute_locally = 1;
+
+-- The distributed plan must return exactly what the local plan returns.
+SELECT 'distributed == local:', (
+    SELECT groupArray((v, ver, k)) FROM (
+        SELECT v, ver, k FROM t_lm_header_order FINAL PREWHERE k > 0 LIMIT 4
+        SETTINGS make_distributed_plan = 1, distributed_plan_execute_locally = 1))
+    = (
+    SELECT groupArray((v, ver, k)) FROM (
+        SELECT v, ver, k FROM t_lm_header_order FINAL PREWHERE k > 0 LIMIT 4));
+
+-- Restoring the header must not change what lazy materialization returns.
+SELECT 'lazy == not lazy:', (
+    SELECT groupArray((v, ver, k)) FROM (
+        SELECT v, ver, k FROM t_lm_header_order FINAL PREWHERE k > 0 LIMIT 4))
+    = (
+    SELECT groupArray((v, ver, k)) FROM (
+        SELECT v, ver, k FROM t_lm_header_order FINAL PREWHERE k > 0 LIMIT 4
+        SETTINGS query_plan_optimize_lazy_materialization = 0));
+
+DROP TABLE t_lm_header_order;

--- a/tests/queries/0_stateless/04652_lazy_materialization_replace_node_header_order.sql
+++ b/tests/queries/0_stateless/04652_lazy_materialization_replace_node_header_order.sql
@@ -14,13 +14,20 @@ SET enable_analyzer = 1;
 SET query_plan_optimize_lazy_materialization = 1, query_plan_max_limit_for_lazy_materialization = 10;
 
 -- Lazy materialization must fire for all the queries below, otherwise they assert nothing.
+-- Both the local and the distributed plan are checked: the bug only shows under
+-- `make_distributed_plan`, so a guard covering the local plan alone could pass vacuously.
 SELECT 'lazy materialization applied:', countIf(explain LIKE '%LazilyReadFromMergeTree%') > 0
 FROM (EXPLAIN SELECT v, ver, k FROM t_lm_header_order FINAL PREWHERE k > 0 LIMIT 4);
 
--- Lazy materialization replaces the LimitStep node with a JoinLazyColumnsStep subplan whose
--- header follows the main/lazy split, not the projection. make_distributed_plan rebuilds the
+SELECT 'lazy materialization applied (distributed):', countIf(explain LIKE '%LazilyReadFromMergeTree%') > 0
+FROM (EXPLAIN SELECT v, ver, k FROM t_lm_header_order FINAL PREWHERE k > 0 LIMIT 4
+      SETTINGS make_distributed_plan = 1, distributed_plan_execute_locally = 1);
+
+-- Lazy materialization replaces the `LimitStep` node with a `JoinLazyColumnsStep` subplan whose
+-- header follows the main/lazy split, not the projection. `make_distributed_plan` rebuilds the
 -- plan bottom-up and re-derives every header, so a replacement that lost the replaced node's
--- header order raised LOGICAL_ERROR "incompatible header with root step".
+-- header order raised `LOGICAL_ERROR` `Cannot add step Expression to QueryPlan because it has
+-- incompatible header with root step JoinLazyColumnsStep`.
 SELECT v, ver, k FROM t_lm_header_order FINAL PREWHERE k > 0 LIMIT 4
 SETTINGS make_distributed_plan = 1, distributed_plan_execute_locally = 1;
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a logical error `Cannot add step Expression to QueryPlan because it has incompatible header with root step JoinLazyColumnsStep` for a query with `FINAL`, a `PREWHERE` filter, a small `LIMIT` and `make_distributed_plan = 1`, when the selected columns are listed in an order that differs from the table's column order. Lazy materialization replaced a plan node without preserving that node's output header, which made the query plan inconsistent.


### Description

Found by the AST fuzzer: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96844&sha=6e71cbb97c5957abacd33ef2fe464a3af4755cb9&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29 (`AST fuzzer (amd_debug)`, STID `2004-4338`). PR #96844 is only where the fuzzer ran; it does not cause this.

No related open issue found for this signature.

#### Reproducer

```sql
CREATE TABLE t (k Int32, v UInt64, ver UInt64)
ENGINE = ReplacingMergeTree(ver) ORDER BY k
SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;

INSERT INTO t SELECT number, number, 1 FROM numbers(1000);

SELECT v, k FROM t FINAL PREWHERE NULL LIMIT 4
SETTINGS query_plan_max_limit_for_lazy_materialization = 10,
         make_distributed_plan = 1,
         distributed_plan_execute_locally = 1;
```

```
Logical error: 'Cannot add step Expression to QueryPlan because it has incompatible header
 with root step JoinLazyColumnsStep
 root header: k Int32 Int32(size = 0), v UInt64 UInt64(size = 0)
 step header: v UInt64 UInt64(size = 0), k Int32 Int32(size = 0)'
```

Both headers hold the same columns in the opposite order.

#### Root cause

`optimizeLazyMaterialization2` rewrites the read into a main branch and a lazy branch joined by a `JoinLazyColumnsStep`, replacing the `LimitStep` node with that subplan. `JoinLazyColumnsStep::updateOutputHeader` recomputes its header from the main/lazy split (main columns first, lazy columns appended), so the subplan's root header follows the split rather than the projection.

The replacement is supposed to keep producing the header the replaced node produced, and the two-argument `QueryPlan::replaceNodeWithPlan` does that by reading `node->step->getOutputHeader()`. Here it cannot:

* `limit_step->updateInputHeader(main_plan.getCurrentHeader())` overwrites the Limit's output header, because `LimitStep::updateOutputHeader` mirrors its input header and `updateInputHeader` calls it;
* the next line moves `root.step` into the main branch, so `node->step` is null and the two-argument overload plants no converting step.

The resulting plan is inconsistent even though it still answers correctly: the `Expression` above the join produces the requested order, so only the edge below it is wrong. `unitePlans` and `addStep` validate stored headers and never re-derive them, so nothing noticed until `make_distributed_plan = 1` made `makeDistributedPlan` rebuild the plan bottom-up and re-derive every header. It then re-stacked that `Expression` (stored input header `v, k`) onto the re-united `JoinLazyColumnsStep` (re-derived `k, v`) and `QueryPlan::addStep` threw.

#### Fix

Capture the replaced node's output header before it is overwritten, and pass it to the three-argument `replaceNodeWithPlan`. That overload adds a name-based converting step only when the headers differ structurally, so plans whose projection already matches the split order are unchanged, and the `addStep` assertion keeps its diagnostic value.

Lazy FINAL already does exactly this: `optimizeLazyFinal.cpp` captures `reading_step->getOutputHeader()` before moving the step and reconciles branch header order explicitly. Lazy materialization was the one rewrite that did not.

`make_distributed_plan` defaults to `false`, so exposure is limited to queries that opt into it.

#### Verification

* The reproducer fails on the unpatched build and returns the correct rows with the fix.
* Reverting only the source change makes the new test fail with the same logical error, so each asserted line is load-bearing.
* Result equivalence over a 90-row matrix (6 projections x 5 filter shapes x 3 fixtures, comparing `make_distributed_plan` on/off and lazy materialization on/off): 16 shapes hit the logical error before the fix, 0 after, and no result changes in either direction.
* Plans for projections that already match the split order are byte-identical before and after.
* Where the orders do differ the repaired plan gains one `Expression` step that only reorders columns, and it is added whether or not `make_distributed_plan` is set, because the stored header was wrong in both cases. Only the reported logical error needed `make_distributed_plan`, since that is what re-derives the headers.
* That plan change moves the `EXPLAIN` output of one existing test, `04095_lazy_final_with_lazy_materialization`, whose reference was recorded against the malformed plan. Its reference is updated to the plan the fix produces; the rows and the `LazilyReadFromMergeTree` / `InputSelector` counts the same test asserts are unchanged, and the updated reference no longer matches the unpatched build. Across all 55 existing `lazy_materialization` / `lazy_final` stateless tests run on both builds it is the only test whose output moves.
* The new test passes 50 runs with CI randomization and 50 without.
