### PR TITLE
darwin fast test: clean up diagnostics DB, retire the Intel mac pool, gate jobs behind style/fast tests

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -236,7 +236,7 @@ class JobConfigs:
             # cannot fail the job, and a timed-out job already fails).
             'for i in $(seq 2 16); do sudo ifconfig lo0 -alias 127.0.0.$i 2>/dev/null || true; done',
             "python3 ./ci/jobs/scripts/job_hooks/clickhouse_test_cleanup_hook.py",
-            "sudo rm -rf /Users/ec2-user/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/run* /System/Volumes/Data/System/Library/Caches/com.apple.coresymbolicationd/data",
+            "sudo rm -rf /Users/ec2-user/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/run* /System/Volumes/Data/System/Library/Caches/com.apple.coresymbolicationd/data /System/Volumes/Data/private/var/db/diagnostics/*",
         ],
     ).parametrize(
         Job.ParamSet(

--- a/ci/infra/cloud.py
+++ b/ci/infra/cloud.py
@@ -5,18 +5,12 @@ from praktika.infrastructure.ec2_instance import EC2Instance
 from ci.defs.defs import RunnerLabels
 
 MAC_OS_TAHOE_IMAGE_AMI = "ami-0f8ce53a93ab42329"
-MAC_OS_SEQUOIA_AMD_IMAGE_AMI = "ami-0d66088cfc49c54b0"
 MAC_OS_TAHOE_ARM_IMAGE_AMI = "ami-0cbd6d494543c15b3"
 
 MAC_VPC_NAME = "ci-cd"
-MAC_SECURITY_GROUP_IDS = ["sg-061fd9184274476c0"]
 
 EC2_INSTANCE_PROFILE_NAME = "untrusted_runner"
 
-MACOS_AMD_SMALL_RUNNER_LABELS = [
-    RunnerLabels.MACOS_AMD_SMALL[1],
-    f"pr-{RunnerLabels.MACOS_AMD_SMALL[1]}",
-]
 MACOS_ARM_SMALL_RUNNER_LABELS = [
     RunnerLabels.MACOS_ARM_SMALL[1],
     f"pr-{RunnerLabels.MACOS_ARM_SMALL[1]}",
@@ -28,48 +22,19 @@ CLOUD = CloudInfrastructure.Config(
     lambda_functions=[*CloudInfrastructure.SLACK_APP_LAMBDAS],
     dedicated_hosts=[
         DedicatedHost.Config(
-            name="mac1.metal",
-            availability_zones=[
-                "us-east-1a",
-            ],
-            instance_type="mac1.metal",
-            auto_placement="on",
-            quantity_per_az=2,
-            praktika_resource_tag="mac",
-        ),
-        DedicatedHost.Config(
             name="mac2-m2pro.metal",
             availability_zones=[
                 "ap-southeast-2b",
             ],
             instance_type="mac2-m2pro.metal",
             auto_placement="on",
-            # 10 of the 16 hosts allowed by quota `L-14F120D1`. One of them was
-            # allocated outside praktika and carries the name
-            # `clickhouse-pr-macos-m2-e753fc`; it is counted here because it
-            # occupies a slot under the quota, but it runs no managed instance.
+            # 10 of the 16 hosts allowed by quota `L-14F120D1`, all managed by
+            # praktika.
             quantity_per_az=10,
             praktika_resource_tag="mac_m2_pro",
         ),
     ],
     ec2_instances=[
-        EC2Instance.Config(
-            name=RunnerLabels.MACOS_AMD_SMALL[1],
-            image_id=MAC_OS_SEQUOIA_AMD_IMAGE_AMI,
-            instance_type="mac1.metal",
-            subnet_id="subnet-0a3886c4db842da5b",
-            security_group_ids=MAC_SECURITY_GROUP_IDS,
-            iam_instance_profile_name=EC2_INSTANCE_PROFILE_NAME,
-            key_name="awswork",
-            user_data_file="./ci/infra/scripts/user_data_macos.txt",
-            root_volume_type="gp3",
-            root_volume_size=100,
-            root_volume_encrypted=True,
-            tenancy="host",
-            praktika_resource_tag="mac",
-            runner_labels=MACOS_AMD_SMALL_RUNNER_LABELS,
-            quantity=2,
-        ),
         EC2Instance.Config(
             name=RunnerLabels.MACOS_ARM_SMALL[1],
             image_id=MAC_OS_TAHOE_ARM_IMAGE_AMI,
@@ -86,11 +51,11 @@ CLOUD = CloudInfrastructure.Config(
             tenancy="host",
             praktika_resource_tag="mac_m2_pro",
             runner_labels=MACOS_ARM_SMALL_RUNNER_LABELS,
-            # One instance per managed host: 10 hosts minus the one allocated
-            # outside praktika. A single instance completes about three fast
-            # test runs per hour, so 9 of them absorb the ~18 runs per hour
-            # that were queueing up behind 6 instances.
-            quantity=9,
+            # One instance per host across all 10 managed hosts. A single
+            # instance completes about three fast test runs per hour, so 10 of
+            # them absorb the ~18 runs per hour that were queueing up behind 6
+            # instances.
+            quantity=10,
         ),
     ]
 )

--- a/ci/infra/cloud.py
+++ b/ci/infra/cloud.py
@@ -44,7 +44,7 @@ CLOUD = CloudInfrastructure.Config(
             ],
             instance_type="mac2-m2pro.metal",
             auto_placement="on",
-            quantity_per_az=6,
+            quantity_per_az=10,
             praktika_resource_tag="mac_m2_pro",
         ),
     ],
@@ -82,7 +82,7 @@ CLOUD = CloudInfrastructure.Config(
             tenancy="host",
             praktika_resource_tag="mac_m2_pro",
             runner_labels=MACOS_ARM_SMALL_RUNNER_LABELS,
-            quantity=6,
+            quantity=9,
         ),
     ]
 )

--- a/ci/infra/cloud.py
+++ b/ci/infra/cloud.py
@@ -44,6 +44,10 @@ CLOUD = CloudInfrastructure.Config(
             ],
             instance_type="mac2-m2pro.metal",
             auto_placement="on",
+            # 10 of the 16 hosts allowed by quota `L-14F120D1`. One of them was
+            # allocated outside praktika and carries the name
+            # `clickhouse-pr-macos-m2-e753fc`; it is counted here because it
+            # occupies a slot under the quota, but it runs no managed instance.
             quantity_per_az=10,
             praktika_resource_tag="mac_m2_pro",
         ),
@@ -82,6 +86,10 @@ CLOUD = CloudInfrastructure.Config(
             tenancy="host",
             praktika_resource_tag="mac_m2_pro",
             runner_labels=MACOS_ARM_SMALL_RUNNER_LABELS,
+            # One instance per managed host: 10 hosts minus the one allocated
+            # outside praktika. A single instance completes about three fast
+            # test runs per hour, so 9 of them absorb the ~18 runs per hour
+            # that were queueing up behind 6 instances.
             quantity=9,
         ),
     ]

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -64,7 +64,10 @@ workflow = Workflow.Config(
         JobConfigs.docs_job_mintlify,
         JobConfigs.fast_test,
         JobConfigs.ci_tests.set_run_after(CORE_BLOCKING_JOB_NAMES),
-        *JobConfigs.darwin_fast_test_jobs,
+        *[
+            job.set_run_after(STYLE_AND_FAST_TESTS)
+            for job in JobConfigs.darwin_fast_test_jobs
+        ],
         *JobConfigs.tidy_build_arm_jobs,
         *[job.set_run_after(STYLE_AND_FAST_TESTS) for job in JobConfigs.build_jobs],
         *[

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -64,10 +64,7 @@ workflow = Workflow.Config(
         JobConfigs.docs_job_mintlify,
         JobConfigs.fast_test,
         JobConfigs.ci_tests.set_run_after(CORE_BLOCKING_JOB_NAMES),
-        *[
-            job.set_run_after(STYLE_AND_FAST_TESTS)
-            for job in JobConfigs.darwin_fast_test_jobs
-        ],
+        *JobConfigs.darwin_fast_test_jobs,
         *JobConfigs.tidy_build_arm_jobs,
         *[job.set_run_after(STYLE_AND_FAST_TESTS) for job in JobConfigs.build_jobs],
         *[


### PR DESCRIPTION
The Darwin fast test pool is small and heavily contended, and its post hook leaked state between runs. This PR bundles the related fixes.

### Diagnostics DB cleanup

The post hook already removes leaked run directories and the `coresymbolicationd` cache. macOS also accumulates diagnostic reports under `/System/Volumes/Data/private/var/db/diagnostics`, which persist across runs on the self-hosted runners and can gradually fill the disk. That path is added to the same best-effort post-hook cleanup so state does not leak between fast test runs.

### Capacity

Darwin fast test jobs waited over 3 hours, with 25-31 jobs queued against only 6 instances. One instance completes about 3 runs per hour, so 6 instances served ~18 runs per hour while ~18 were arriving per hour - no headroom. Enabling more tests raised a single run from 7 to 20 minutes, cutting per-instance throughput further.

The `mac2-m2pro` (ARM) pool is grown to 10 hosts, each running one runner, using 10 of the 16 hosts allowed by quota `L-14F120D1`. The tenth host, previously allocated outside praktika, is now managed like the rest. A quota increase for `mac2-m2pro.metal` Dedicated Hosts to 16 has been requested; two more instances follow once it is granted.

### Retire the Intel pool

The Intel `mac1.metal` dedicated host and its two `amd_macos_m1` EC2 instances are removed - Darwin fast tests run on the `mac2-m2pro` ARM pool. Their now-dead helpers (`MAC_OS_SEQUOIA_AMD_IMAGE_AMI`, `MACOS_AMD_SMALL_RUNNER_LABELS`, `MAC_SECURITY_GROUP_IDS`) are dropped with them.

### Gate jobs behind style and fast tests

Darwin fast test jobs previously started immediately, competing for the constrained pool even on PRs that fail the cheap style/fast/tidy checks. They now run after `STYLE_AND_FAST_TESTS`, like the build jobs, so mac capacity is spent only once those pass.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.441` (included in `26.8` and later)
<!-- ch-version-info:end -->