### PR TITLE
Fix 04320_url_engine_dispatch_partition_and_format test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2150,13 +2150,12 @@ class TestCase:
         else:
             # If --database is not specified, we will create temporary database with
             # unique name and we will recreate and drop it for each test
-            def random_str(length=8):
-                # Alternate letters and digits so the name never contains two consecutive
-                # characters of the same class - hence no English word (or digit run) can
-                # ever appear in it. The name is embedded into DDL, paths and table names,
-                # and tests assert substring absence over those (e.g. LIKE '%auto%');
-                # a fully random name produces such words once in ~340k runs (seen in CI:
-                # test_q2autogn). 26^4 * 10^4 ~ 4.6e9 names keep collisions negligible.
+            def random_str(length=12):
+                # Alternate letters and digits so no two consecutive characters share a class,
+                # hence no word can appear in the name. It is embedded into DDL, paths and table
+                # names, and tests assert substring absence over those (e.g. NOT ILIKE '%auto%');
+                # an 8-char [a-z0-9] name spelled "auto" once in ~340k runs (CI: test_q2autogn).
+                # 26^6 * 10^6 is ~110x the namespace of the previous 36^8, so collisions get rarer.
                 # NOTE: it is important not to use default random generator, since it shares state.
                 rng = random.SystemRandom()
                 return "".join(

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2151,10 +2151,17 @@ class TestCase:
             # If --database is not specified, we will create temporary database with
             # unique name and we will recreate and drop it for each test
             def random_str(length=8):
-                alphabet = string.ascii_lowercase + string.digits
+                # Alternate letters and digits so the name never contains two consecutive
+                # characters of the same class - hence no English word (or digit run) can
+                # ever appear in it. The name is embedded into DDL, paths and table names,
+                # and tests assert substring absence over those (e.g. LIKE '%auto%');
+                # a fully random name produces such words once in ~340k runs (seen in CI:
+                # test_q2autogn). 26^4 * 10^4 ~ 4.6e9 names keep collisions negligible.
                 # NOTE: it is important not to use default random generator, since it shares state.
+                rng = random.SystemRandom()
                 return "".join(
-                    random.SystemRandom().choice(alphabet) for _ in range(length)
+                    rng.choice(string.ascii_lowercase if i % 2 == 0 else string.digits)
+                    for i in range(length)
                 )
 
             database = f"test_{random_str()}"

--- a/tests/queries/0_stateless/01825_json_type_in_other_types.sh
+++ b/tests/queries/0_stateless/01825_json_type_in_other_types.sh
@@ -7,13 +7,17 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_json_nested"
 
+# The test prints whole `Map` values, whose key order `with_buckets` serialization does not
+# preserve (keys are reassembled in hash-bucket order). Pin the serialization, which CI randomizes.
 ${CLICKHOUSE_CLIENT} -q "
     CREATE TABLE t_json_nested
     (
         id UInt32,
         data Tuple(String, Map(String, Array(JSON)), JSON)
     )
-    ENGINE = MergeTree ORDER BY id" --enable_json_type 1
+    ENGINE = MergeTree ORDER BY id
+    SETTINGS map_serialization_version = 'basic',
+             map_serialization_version_for_zero_level_parts = 'basic'" --enable_json_type 1
 
 cat <<EOF | $CLICKHOUSE_CLIENT -q "INSERT INTO t_json_nested FORMAT JSONEachRow"
 {

--- a/tests/queries/0_stateless/03008_azure_plain_rewr_data_paths.sh
+++ b/tests/queries/0_stateless/03008_azure_plain_rewr_data_paths.sh
@@ -9,8 +9,13 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-# Base container name
-base_container="cont-$(echo "${CLICKHOUSE_TEST_UNIQUE_NAME}" | tr _ -)"
+# Base container name. Azure caps container names at 64 chars and a per-config suffix is appended
+# below, so the full ${CLICKHOUSE_TEST_UNIQUE_NAME} does not fit. Shorten it without losing
+# uniqueness: a readable prefix, a hash of the *full* test name, and the database. Truncating the
+# test name alone would not do - several 03008_azure_plain_rewritable_* tests share their first 24
+# characters. The test name must stay in the name at all because `clickhouse-test --database=X`
+# runs every test against one shared database.
+base_container="cont-$(echo "${CLICKHOUSE_TEST_NAME}" | tr _ - | cut -c1-16)-$(echo -n "${CLICKHOUSE_TEST_NAME}" | md5sum | cut -c1-6)-$(echo "${CLICKHOUSE_DATABASE}" | tr _ -)"
 
 declare -A disk_configs
 

--- a/tests/queries/0_stateless/03008_azure_plain_rewritable_alter_partition.sh
+++ b/tests/queries/0_stateless/03008_azure_plain_rewritable_alter_partition.sh
@@ -9,7 +9,12 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-container="cont-$(echo "${CLICKHOUSE_TEST_UNIQUE_NAME}" | tr _ -)"
+# Azure caps container names at 64 chars, so the full ${CLICKHOUSE_TEST_UNIQUE_NAME} does not fit.
+# Shorten it without losing uniqueness: a readable prefix, a hash of the *full* test name, and the
+# database. Truncating the test name alone would not do - several 03008_azure_plain_rewritable_*
+# tests share their first 24 characters. The test name must stay in the name at all because
+# `clickhouse-test --database=X` runs every test against one shared database.
+container="cont-$(echo "${CLICKHOUSE_TEST_NAME}" | tr _ - | cut -c1-16)-$(echo -n "${CLICKHOUSE_TEST_NAME}" | md5sum | cut -c1-6)-$(echo "${CLICKHOUSE_DATABASE}" | tr _ -)"
 
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS 03008_alter_partition"
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS 03008_alter_partition_dst"

--- a/tests/queries/0_stateless/03008_azure_plain_rewritable_with_empty_col.sh
+++ b/tests/queries/0_stateless/03008_azure_plain_rewritable_with_empty_col.sh
@@ -9,7 +9,12 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-container="cont-$(echo "${CLICKHOUSE_TEST_UNIQUE_NAME}" | tr _ -)"
+# Azure caps container names at 64 chars, so the full ${CLICKHOUSE_TEST_UNIQUE_NAME} does not fit.
+# Shorten it without losing uniqueness: a readable prefix, a hash of the *full* test name, and the
+# database. Truncating the test name alone would not do - several 03008_azure_plain_rewritable_*
+# tests share their first 24 characters. The test name must stay in the name at all because
+# `clickhouse-test --database=X` runs every test against one shared database.
+container="cont-$(echo "${CLICKHOUSE_TEST_NAME}" | tr _ - | cut -c1-16)-$(echo -n "${CLICKHOUSE_TEST_NAME}" | md5sum | cut -c1-6)-$(echo "${CLICKHOUSE_DATABASE}" | tr _ -)"
 
 ${CLICKHOUSE_CLIENT} --query "drop table if exists test_azure_mt"
 

--- a/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format.sh
+++ b/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format.sh
@@ -20,8 +20,10 @@ printf '{"a":1,"b":"Hello"}\n{"a":2,"b":"World"}\n' > "$ABS_NOEXT"
 echo "--- ENGINE = URL('file://<extensionless>') with format = auto persists the inferred format ---"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_f"
 ${CLICKHOUSE_CLIENT} -q "CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_f ENGINE = URL('file://${ABS_NOEXT}')"
-# The persisted engine definition carries a concrete format, not 'auto'.
-${CLICKHOUSE_CLIENT} -q "SELECT create_table_query NOT ILIKE '%auto%' FROM system.tables WHERE database = currentDatabase() AND name = '${CLICKHOUSE_TEST_UNIQUE_NAME}_f'"
+# The persisted engine definition carries a concrete format, not 'auto'. Match the quoted literal:
+# a bare '%auto%' also scans the random database name embedded in the DDL and the file path, and an
+# 8-char [a-z0-9] name contains "auto" once in ~340k runs (seen in CI: test_q2autogn).
+${CLICKHOUSE_CLIENT} -q "SELECT create_table_query NOT ILIKE '%''auto''%' FROM system.tables WHERE database = currentDatabase() AND name = '${CLICKHOUSE_TEST_UNIQUE_NAME}_f'"
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_f"
 
 echo "--- reload after the source file is removed succeeds (no format re-inference) ---"
@@ -52,8 +54,8 @@ ${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION IF EXISTS ${NC}"
 ${CLICKHOUSE_CLIENT} -q "CREATE NAMED COLLECTION ${NC} AS url = 'file://${ABS_NOEXT_NC}'"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
 ${CLICKHOUSE_CLIENT} -q "CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n ENGINE = URL(${NC})"
-# The persisted engine definition carries a concrete format, not 'auto'.
-${CLICKHOUSE_CLIENT} -q "SELECT create_table_query NOT ILIKE '%auto%' FROM system.tables WHERE database = currentDatabase() AND name = '${CLICKHOUSE_TEST_UNIQUE_NAME}_n'"
+# The persisted engine definition carries a concrete format, not 'auto' (quoted literal, see above).
+${CLICKHOUSE_CLIENT} -q "SELECT create_table_query NOT ILIKE '%''auto''%' FROM system.tables WHERE database = currentDatabase() AND name = '${CLICKHOUSE_TEST_UNIQUE_NAME}_n'"
 # Reload after the source file is removed succeeds (no format re-inference).
 ${CLICKHOUSE_CLIENT} -q "DETACH TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
 rm -f "$ABS_NOEXT_NC"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a rare flake in 04320_url_engine_dispatch_partition_and_format (NOT ILIKE '%auto%' matched the random database name test_q2autogn), and make clickhouse-test generate word-free database names by alternating letters and digits.

Also fixes 01825_json_type_in_other_types test flakiness

Closes https://github.com/ClickHouse/ClickHouse/issues/112310

cc @alexey-milovidov 