### PR TITLE
Do not prefetch in aggregation when building the key holder is expensive

### DIFF
--- a/src/Common/ColumnsHashing.h
+++ b/src/Common/ColumnsHashing.h
@@ -95,6 +95,7 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
     using FindResult = columns_hashing_impl::FindResultImpl<Mapped>;
 
     static constexpr bool has_cheap_key_calculation = Base::has_cheap_key_calculation;
+    static constexpr bool has_cheap_key_holder = Base::has_cheap_key_holder;
     static constexpr bool has_pre_computed_hashes = Base::has_pre_computed_hashes;
 
     static HashMethodContextPtr createContext(const HashMethodContextSettings & settings)
@@ -360,6 +361,13 @@ struct HashMethodSerialized
     }
 
     static constexpr bool has_cheap_key_calculation = false;
+    /// `getKeyHolder` serializes every key column for the row. With `prealloc = false` that means a
+    /// fresh `serializeKeysToPoolContiguous` into the arena; with `prealloc = true` and batch
+    /// serialization disabled it means a per-row heap allocation plus the same serialization. This is
+    /// the dominant cost of the aggregation, so `Aggregator` must not pay it twice per row to
+    /// prefetch. When the keys *are* batch-serialized upfront this method prefetches on its own,
+    /// using `precomputed_hashes` below, which needs no second `getKeyHolder` call.
+    static constexpr bool has_cheap_key_holder = false;
     static constexpr bool has_pre_computed_hashes = prealloc;
 
     ColumnRawPtrs key_columns;

--- a/src/Common/ColumnsHashing/HashMethod.h
+++ b/src/Common/ColumnsHashing/HashMethod.h
@@ -30,6 +30,41 @@ static inline UInt128 ALWAYS_INLINE hash128( /// NOLINT
     return hash.get128();
 }
 
+/** Hash methods declare two independent prefetch predicates. They are not interchangeable, and the
+  * places that read them are disjoint.
+  *
+  * `has_cheap_key_holder` - read by `Aggregator::executeImpl`.
+  *
+  * Is it acceptable to call `getKeyHolder(row)` a second time for the same row purely to issue a
+  * software prefetch? The aggregation prefetch pipeline runs
+  *
+  *     auto && key_holder = state.getKeyHolder(i + look_ahead, pool);
+  *     data.prefetch(std::move(key_holder));
+  *
+  * ahead of the `emplaceKey`/`findKey` loop, so the look-ahead row's key holder is built once for
+  * the prefetch and once again when that row is actually processed. Hiding a cache miss is only a
+  * win when that duplicated work is cheaper than the miss.
+  *
+  * `true` means `getKeyHolder` reads the key in place: an unaligned load, a `packFixed`, or a
+  * `string_view` over the column's own memory. Rebuilding it costs a handful of instructions.
+  *
+  * `false` means `getKeyHolder` materializes the key - serializing every key column into the arena,
+  * or hashing every key column through virtual `IColumn` calls. For those methods building the key
+  * *is* the dominant cost of the aggregation, so paying it twice per row costs far more than the
+  * miss it hides.
+  *
+  * Note this is deliberately not "is the hash cheap". Hashing a string is not cheap, but a prefetch
+  * has to hash the key by definition, and `HashMethodString`/`HashMethodPackedString` still profit
+  * because building their key holder is free.
+  *
+  * `has_cheap_key_calculation` - read by the JOIN probe loop, via `join_prefetch_supported` in
+  * HashJoinMethodsImpl.h (the `KeyGetterForType` aliases in HashJoin/KeyGetter.h resolve to these
+  * same hash methods). It is the stricter "the whole key calculation, hashing included, is cheap",
+  * and is left as it was: the JOIN probe loop has its own cost balance, which this file's
+  * aggregation-side reasoning says nothing about. Only the aggregator reads
+  * `has_cheap_key_holder`.
+  */
+
 /// For the case when there is one numeric key.
 /// UInt8/16/32/64 for any type with corresponding bit width.
 template <typename Value, typename Mapped, typename FieldType, bool use_cache = true, bool need_offset = false, bool nullable = false>
@@ -45,6 +80,8 @@ struct HashMethodOneNumber : public columns_hashing_impl::HashMethodBase<
     using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset, nullable>;
 
     static constexpr bool has_cheap_key_calculation = true;
+    /// An unaligned load from the column's own memory.
+    static constexpr bool has_cheap_key_holder = true;
     static constexpr bool has_pre_computed_hashes = false;
 
     const char * vec;
@@ -113,6 +150,8 @@ struct HashMethodOneNumberInRange : public columns_hashing_impl::HashMethodBase<
 
     static constexpr bool has_range_check = true;
     static constexpr bool has_cheap_key_calculation = true;
+    /// An unaligned load from the column's own memory.
+    static constexpr bool has_cheap_key_holder = true;
 
     const char * vec;
     FieldType min_key{};
@@ -176,6 +215,8 @@ struct HashMethodString : public columns_hashing_impl::HashMethodBase<
     using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset, nullable>;
 
     static constexpr bool has_cheap_key_calculation = false;
+    /// A `string_view` over the column's own chars; the arena copy only happens on persist.
+    static constexpr bool has_cheap_key_holder = true;
     static constexpr bool has_pre_computed_hashes = false;
 
     const IColumn::Offset * offsets;
@@ -231,6 +272,9 @@ struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
     using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, false, false>;
 
     static constexpr bool has_cheap_key_calculation = false;
+    /// `PackedStringRef::build` reads the key in place; see the note on `Hash` below for why
+    /// rebuilding it (and its content hash) in the look-ahead is an accepted trade here.
+    static constexpr bool has_cheap_key_holder = true;
 
     const IColumn::Offset * offsets;
     const UInt8 * chars;
@@ -334,6 +378,8 @@ struct HashMethodFixedString : public columns_hashing_impl::HashMethodBase<
     using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset, nullable>;
 
     static constexpr bool has_cheap_key_calculation = false;
+    /// A `string_view` over the column's own chars; the arena copy only happens on persist.
+    static constexpr bool has_cheap_key_holder = true;
     static constexpr bool has_pre_computed_hashes = false;
 
     size_t n;
@@ -406,6 +452,8 @@ struct HashMethodKeysFixed
     static constexpr bool has_low_cardinality = has_low_cardinality_;
 
     static constexpr bool has_cheap_key_calculation = true;
+    /// `packFixed` copies a few fixed-width fields into the key; no allocation.
+    static constexpr bool has_cheap_key_holder = true;
     static constexpr bool has_pre_computed_hashes = false;
 
     LowCardinalityKeys<has_low_cardinality> low_cardinality_keys;
@@ -580,6 +628,8 @@ struct HashMethodHashed
     using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset>;
 
     static constexpr bool has_cheap_key_calculation = false;
+    /// `hash128` SipHashes every key column through a virtual `IColumn::updateHashWithValue`.
+    static constexpr bool has_cheap_key_holder = false;
     static constexpr bool has_pre_computed_hashes = false;
 
     ColumnRawPtrs key_columns;

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -997,9 +997,11 @@ void NO_INLINE Aggregator::executeImpl(
     if (!no_more_keys)
     {
         /// Prefetching doesn't make sense for small hash tables, because they fit in caches entirely.
-        /// Enable prefetch for all key types including strings — the adaptive PrefetchingHelper
-        /// handles variable hash computation cost by measuring actual iteration latency.
-        const bool prefetch = params.enable_prefetch
+        /// It also doesn't make sense when building the key holder is expensive: the look-ahead
+        /// below calls `getKeyHolder` a second time for every row, so a method that materializes
+        /// its key there (e.g. serializing all key columns) would pay its dominant per-row cost
+        /// twice - far more than the cache miss the prefetch hides. See `has_cheap_key_holder`.
+        const bool prefetch = State::has_cheap_key_holder && params.enable_prefetch
             && (method.data.getBufferSizeInBytes() > min_bytes_for_prefetch);
 
 #if USE_EMBEDDED_COMPILER
@@ -3337,8 +3339,9 @@ void NO_INLINE Aggregator::mergeSingleLevelDataImpl(
     AggregatedDataVariantsPtr & res = non_empty_data[0];
     bool no_more_keys = false;
 
-    /// Enable prefetch for all key types including strings — the adaptive PrefetchingHelper
-    /// handles variable hash computation cost by measuring actual iteration latency.
+    /// Enabled for all key types: unlike `executeImplBatch`, the merge path prefetches by the hash
+    /// already stored in the source cell (`mergeToViaEmplace`), so it never rebuilds a key and
+    /// `has_cheap_key_holder` does not apply here.
     const bool prefetch = params.enable_prefetch
         && (getDataVariant<Method>(*res).data.getBufferSizeInBytes() > min_bytes_for_prefetch);
 
@@ -3424,8 +3427,9 @@ void NO_INLINE Aggregator::mergeBucketImpl(
     /// We merge all aggregation results to the first.
     AggregatedDataVariantsPtr & res = data[0];
 
-    /// Enable prefetch for all key types including strings — the adaptive PrefetchingHelper
-    /// handles variable hash computation cost by measuring actual iteration latency.
+    /// Enabled for all key types: unlike `executeImplBatch`, the merge path prefetches by the hash
+    /// already stored in the source cell (`mergeToViaEmplace`), so it never rebuilds a key and
+    /// `has_cheap_key_holder` does not apply here.
     const bool prefetch = params.enable_prefetch
         && (Method::Data::NUM_BUCKETS * getDataVariant<Method>(*res).data.impls[bucket].getBufferSizeInBytes() > min_bytes_for_prefetch);
 

--- a/tests/performance/group_by_dynamic_keys.xml
+++ b/tests/performance/group_by_dynamic_keys.xml
@@ -1,0 +1,57 @@
+<test>
+    <!--
+        GROUP BY over Dynamic keys, and over JSON path subcolumns (which yield a Dynamic).
+
+        Several such keys select AggregationMethodSerialized, whose getKeyHolder serializes every
+        key column for the row. That serialization is the dominant cost of the aggregation, so the
+        Aggregator's look-ahead prefetch - which builds the key holder a second time per row - must
+        stay disabled for this method. See has_cheap_key_holder.
+    -->
+    <settings>
+        <max_threads>1</max_threads>
+        <max_insert_threads>8</max_insert_threads>
+        <allow_suspicious_types_in_group_by>1</allow_suspicious_types_in_group_by>
+    </settings>
+
+    <create_query>CREATE TABLE t_json_group_by (j JSON) ENGINE = MergeTree ORDER BY tuple()</create_query>
+    <fill_query>
+        INSERT INTO t_json_group_by
+        SELECT toJSONString(map('a', toString(number % 1000), 'b', toString(number % 7),
+                                'c', toString(number % 13),   'd', toString(number % 97),
+                                'e', toString(number % 31),   'f', toString(number % 53),
+                                'g', toString(number % 11)))::JSON
+        FROM numbers(1000000)
+    </fill_query>
+
+    <query>
+        SELECT (number % 1000)::Dynamic AS a,
+               (number %    7)::Dynamic AS b,
+               (number %   13)::Dynamic AS c,
+               (number %   97)::Dynamic AS d,
+               (number %   31)::Dynamic AS e,
+               (number %   53)::Dynamic AS f,
+               (number %   11)::Dynamic AS g
+        FROM numbers(2000000)
+        GROUP BY 1, 2, 3, 4, 5, 6, 7
+        FORMAT Null
+    </query>
+
+    <!-- Control: the same shape with plain String keys, which uses the prealloc serialized
+         method and does its own prefetching from precomputed hashes. -->
+    <query>
+        SELECT toString(number % 1000) AS a,
+               toString(number %    7) AS b,
+               toString(number %   13) AS c,
+               toString(number %   97) AS d,
+               toString(number %   31) AS e,
+               toString(number %   53) AS f,
+               toString(number %   11) AS g
+        FROM numbers(2000000)
+        GROUP BY 1, 2, 3, 4, 5, 6, 7
+        FORMAT Null
+    </query>
+
+    <query>SELECT j.a, j.b, j.c, j.d, j.e, j.f, j.g FROM t_json_group_by GROUP BY 1, 2, 3, 4, 5, 6, 7 FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS t_json_group_by</drop_query>
+</test>


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/112264
Related: https://github.com/ClickHouse/ClickHouse/pull/101007

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a ~1.5x performance regression introduced in 26.5 in `GROUP BY` over `Dynamic` keys and over `JSON` path subcolumns.


### Documentation entry for user-facing changes

<!--- Bug fixes and performance optimizations should not require any documentation. -->


### Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

---

## What regressed

`GROUP BY` over several `Dynamic` keys selects `AggregationMethodSerialized` with `prealloc = false`, whose `getKeyHolder` calls `serializeKeysToPoolContiguous` — it serializes every key column into the arena, for every row. That serialization is the dominant cost of the aggregation.

#101007 removed the `has_cheap_key_calculation` guard on the aggregation prefetch path so that single-`String`-key aggregation could prefetch. The look-ahead in `executeImplBatch` builds a key holder a **second** time per row:

```cpp
auto && key_holder = state.getKeyHolder(i + prefetch_look_ahead, *aggregates_pool);
method.data.prefetch(std::move(key_holder));
```

For a method that reads its key in place — an unaligned load, a `packFixed`, a `string_view` over the column's own chars — that is a handful of extra instructions, and the cache miss it hides pays for them. For the serialized method it means serializing every key column twice per row, which costs far more than the miss. This is why `SETTINGS enable_software_prefetch_in_aggregation = 0` restores the old timing exactly.

## Why not just restore the old guard

`has_cheap_key_calculation` means "the whole key calculation, hashing included, is cheap". It is `false` for `HashMethodString` and `HashMethodPackedString` — but their key holders are free to rebuild (the arena copy only happens on persist), and they are exactly what #101007 sped up. `HashMethodPackedString`, added since, is built around the aggregator prefetch pipeline and documents the double `getKeyHolder` call as an accepted trade. Restoring the old guard would have undone that work and regressed `prefetch_in_aggregation.xml`.

## The fix

Gate the aggregation prefetch on a new `has_cheap_key_holder`, which asks only the question this call site actually needs: is `getKeyHolder` cheap enough to call redundantly?

| hash method | `has_cheap_key_holder` | why |
| --- | --- | --- |
| `OneNumber`, `OneNumberInRange` | `true` | unaligned load |
| `String`, `FixedString` | `true` | `string_view` over the column's chars |
| `PackedString` | `true` | `PackedStringRef::build` reads in place |
| `KeysFixed` | `true` | `packFixed`, no allocation |
| `Hashed` | `false` | `hash128` over every key column through virtual `IColumn::updateHashWithValue` |
| `Serialized` | `false` | serializes every key column per row |

For `Serialized` this also removes redundant work in the `prealloc` case: when keys are batch-serialized upfront the method already prefetches on its own from `precomputed_hashes`, with no second `getKeyHolder` call.

`has_cheap_key_calculation` keeps its current values and is untouched — its only reader is `join_prefetch_supported` on the JOIN side, whose probe loop has its own cost balance that this change says nothing about. (The `KeyGetterForType` aliases in `HashJoin/KeyGetter.h` resolve to these same hash methods, so the two predicates deliberately coexist.)

The two merge-path prefetch sites need no guard: `mergeToViaEmplace` prefetches by the hash already stored in the source cell and never rebuilds a key. Their comments are corrected — the previous justification ("the adaptive `PrefetchingHelper` handles variable hash computation cost by measuring actual iteration latency") does not hold, since `calcPrefetchLookAhead` only tunes the look-ahead distance and never decides *whether* to prefetch.

## Test

`tests/performance/group_by_dynamic_keys.xml` covers `GROUP BY` over 7 `Dynamic` keys, the same shape through `JSON` path subcolumns, and the plain-`String` control that must not regress.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.882` (included in `26.8` and later)
<!-- ch-version-info:end -->