### PR TITLE
Enforce parent table row policy in mergeTreeProjection table function

### DIFF
--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -1,14 +1,26 @@
 #include <Storages/MergeTree/StorageFromMergeTreeProjection.h>
 
 #include <Access/Common/AccessFlags.h>
+#include <Access/Common/RowPolicyDefs.h>
+#include <Access/EnabledRowPolicies.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/ExpressionActions.h>
+#include <Interpreters/ExpressionAnalyzer.h>
+#include <Interpreters/RequiredSourceColumnsVisitor.h>
+#include <Interpreters/TreeRewriter.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadNothingStep.h>
 #include <Processors/Sources/NullSource.h>
 #include <Storages/MergeTree/MergeTreeDataSelectExecutor.h>
+#include <Storages/SelectQueryInfo.h>
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int ACCESS_DENIED;
+}
 
 StorageFromMergeTreeProjection::StorageFromMergeTreeProjection(
     StorageID storage_id_, StoragePtr parent_storage_, StorageMetadataPtr parent_metadata_, ProjectionDescriptionRawPtr projection_)
@@ -31,7 +43,50 @@ void StorageFromMergeTreeProjection::read(
     size_t max_block_size,
     size_t num_streams)
 {
-    context->checkAccess(AccessType::SELECT, parent_storage->getStorageID());
+    const auto parent_storage_id = parent_storage->getStorageID();
+    context->checkAccess(AccessType::SELECT, parent_storage_id);
+
+    /// Row policies are attached to the parent table, not to this synthetic projection storage, so the
+    /// planner never applies them here; a projection part stores real row data, so enforce the policy.
+    auto row_policy_filter = context->getRowPolicyFilter(
+        parent_storage_id.getDatabaseName(), parent_storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
+
+    if (row_policy_filter && !row_policy_filter->isAlwaysTrue())
+    {
+        const auto & projection_columns = projection->metadata->getColumns();
+
+        RequiredSourceColumnsVisitor::Data columns_context;
+        RequiredSourceColumnsVisitor(columns_context).visit(row_policy_filter->expression);
+        for (const auto & column_name : columns_context.requiredColumns())
+        {
+            if (!projection_columns.hasColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column_name))
+                throw Exception(ErrorCodes::ACCESS_DENIED,
+                    "Cannot read from projection `{}` of table {} because a row policy references "
+                    "column `{}`, which is not stored in the projection, so the row policy cannot be enforced",
+                    projection->name, parent_storage_id.getNameForLogs(), column_name);
+        }
+
+        /// Build the filter against the projection's own columns; the reading step then reads the
+        /// referenced columns, filters the rows, and drops any of them that were not requested.
+        ASTPtr expr = row_policy_filter->expression->clone();
+        auto syntax_result = TreeRewriter(context).analyze(expr, projection_columns.getAll());
+        ExpressionAnalyzer analyzer(expr, syntax_result, context);
+        auto filter_actions_dag = analyzer.getActionsDAG(false /* add_aliases */, false /* remove_unused_result */);
+
+        /// The filter column is the single output the expression adds on top of its inputs.
+        ExpressionActions filter_actions(filter_actions_dag.clone(), ExpressionActionsSettings(context));
+        NamesAndTypesList added;
+        NamesAndTypesList deleted;
+        filter_actions.getSampleBlock().getNamesAndTypesList().getDifference(
+            filter_actions.getRequiredColumnsWithTypes(), added, deleted);
+        if (!deleted.empty() || added.size() != 1)
+            throw Exception(ErrorCodes::ACCESS_DENIED,
+                "Cannot determine row policy filter column for projection `{}` of table {}",
+                projection->name, parent_storage_id.getNameForLogs());
+
+        query_info.row_level_filter = std::make_shared<FilterDAGInfo>(
+            FilterDAGInfo{std::move(filter_actions_dag), added.front().name, true /* do_remove_column */});
+    }
 
     /// A UNIQUE KEY parent rejects projection reads in the MergeTreeDataSelectExecutor
     /// constructor below (the universal projection-read chokepoint), since reading a

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -23,6 +23,8 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ACCESS_DENIED;
+    extern const int UNKNOWN_IDENTIFIER;
+    extern const int NO_SUCH_COLUMN_IN_TABLE;
 }
 
 /// A row policy resolved against a projection's columns, ready to be applied as a FilterStep.
@@ -136,11 +138,28 @@ std::unique_ptr<MergeTreeProjectionRowPolicyFilter> StorageFromMergeTreeProjecti
     if (!row_policy_filter || row_policy_filter->isAlwaysTrue())
         return nullptr;
 
-    /// Resolve the policy against the parent table columns so its referenced columns are known.
+    /// Resolve the policy against the parent's persistent columns. If it references anything the
+    /// projection cannot provide (e.g. a virtual column), fail closed with a clear ACCESS_DENIED
+    /// instead of a confusing UNKNOWN_IDENTIFIER from the resolver.
     ASTPtr expr = row_policy_filter->expression->clone();
-    auto syntax_result = TreeRewriter(context).analyze(expr, parent_metadata->getColumns().getAll());
-    ExpressionAnalyzer analyzer(expr, syntax_result, context);
-    auto dag = analyzer.getActionsDAG(false /* add_aliases */, false /* remove_unused_result */);
+    ActionsDAG dag = [&]
+    {
+        try
+        {
+            auto syntax_result = TreeRewriter(context).analyze(expr, parent_metadata->getColumns().getAll());
+            ExpressionAnalyzer analyzer(expr, syntax_result, context);
+            return analyzer.getActionsDAG(false /* add_aliases */, false /* remove_unused_result */);
+        }
+        catch (const Exception & e)
+        {
+            if (e.code() != ErrorCodes::UNKNOWN_IDENTIFIER && e.code() != ErrorCodes::NO_SUCH_COLUMN_IN_TABLE)
+                throw;
+            throw Exception(ErrorCodes::ACCESS_DENIED,
+                "Cannot read from projection `{}` of table {} because its row policy references a column "
+                "the projection cannot provide (e.g. a virtual column), so the row policy cannot be enforced",
+                projection->name, parent_storage_id.getNameForLogs());
+        }
+    }();
 
     /// the filter column is the single output added on top of the inputs
     ExpressionActions filter_actions(dag.clone(), ExpressionActionsSettings(context));
@@ -153,9 +172,8 @@ std::unique_ptr<MergeTreeProjectionRowPolicyFilter> StorageFromMergeTreeProjecti
             "Cannot determine row policy filter column for projection `{}` of table {}",
             projection->name, parent_storage_id.getNameForLogs());
 
-    /// Refuse the read when the policy needs a column the projection does not store. This includes
-    /// ALIAS/DEFAULT columns: the projection stores their physical dependencies under different names
-    /// and does not carry the column itself, so the policy cannot be evaluated here. Fail closed.
+    /// Refuse the read when the policy needs a column the projection does not physically store, e.g.
+    /// an ALIAS/DEFAULT column (the projection keeps only its physical deps, under other names).
     const auto & projection_columns = projection->metadata->getColumns();
     for (const auto & column_name : filter_actions.getRequiredColumns())
     {

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -3,11 +3,14 @@
 #include <Access/Common/AccessFlags.h>
 #include <Access/Common/RowPolicyDefs.h>
 #include <Access/EnabledRowPolicies.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Interpreters/ActionsDAG.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>
+#include <Interpreters/replaceAliasColumnsInQuery.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadNothingStep.h>
@@ -34,6 +37,19 @@ struct MergeTreeProjectionRowPolicyFilter
     String filter_column_name;
     Names required_columns;
 };
+
+/// Rewrite references to the parent `_part_offset` into the projection's stored `_parent_part_offset`.
+static void remapPartOffsetToParent(ASTPtr & ast)
+{
+    if (auto * identifier = ast->as<ASTIdentifier>())
+    {
+        if (identifier->name() == "_part_offset")
+            ast = make_intrusive<ASTIdentifier>("_parent_part_offset");
+        return;
+    }
+    for (auto & child : ast->children)
+        remapPartOffsetToParent(child);
+}
 
 StorageFromMergeTreeProjection::StorageFromMergeTreeProjection(
     StorageID storage_id_, StoragePtr parent_storage_, StorageMetadataPtr parent_metadata_, ProjectionDescriptionRawPtr projection_)
@@ -138,15 +154,29 @@ std::unique_ptr<MergeTreeProjectionRowPolicyFilter> StorageFromMergeTreeProjecti
     if (!row_policy_filter || row_policy_filter->isAlwaysTrue())
         return nullptr;
 
-    /// Resolve the policy against the parent's persistent columns. If it references anything the
-    /// projection cannot provide (e.g. a virtual column), fail closed with a clear ACCESS_DENIED
-    /// instead of a confusing UNKNOWN_IDENTIFIER from the resolver.
     ASTPtr expr = row_policy_filter->expression->clone();
+
+    /// Expand parent ALIAS/DEFAULT columns to their physical dependencies, which the projection may
+    /// store even though it does not expose the alias itself (e.g. `c ALIAS b + 1` -> reads `b`).
+    replaceAliasColumnsInQuery(expr, parent_metadata->getColumns(), {}, context);
+
+    /// The parent `_part_offset` is materialized as `_parent_part_offset` in projections that carry it,
+    /// so a policy on `_part_offset` keeps its parent-row semantics when read through such a projection.
+    if (projection->with_parent_part_offset)
+        remapPartOffsetToParent(expr);
+
+    /// Resolve against exactly what the projection read can serve: its physical columns plus the parent
+    /// offset when preserved. Anything else (a column not stored here, a virtual with no projection
+    /// equivalent) fails to resolve, and we fail closed with a clear ACCESS_DENIED.
+    auto available_columns = projection->metadata->getColumns().getAllPhysical();
+    if (projection->with_parent_part_offset)
+        available_columns.emplace_back("_parent_part_offset", std::make_shared<DataTypeUInt64>());
+
     ActionsDAG dag = [&]
     {
         try
         {
-            auto syntax_result = TreeRewriter(context).analyze(expr, parent_metadata->getColumns().getAll());
+            auto syntax_result = TreeRewriter(context).analyze(expr, available_columns);
             ExpressionAnalyzer analyzer(expr, syntax_result, context);
             return analyzer.getActionsDAG(false /* add_aliases */, false /* remove_unused_result */);
         }
@@ -156,7 +186,7 @@ std::unique_ptr<MergeTreeProjectionRowPolicyFilter> StorageFromMergeTreeProjecti
                 throw;
             throw Exception(ErrorCodes::ACCESS_DENIED,
                 "Cannot read from projection `{}` of table {} because its row policy references a column "
-                "the projection cannot provide (e.g. a virtual column), so the row policy cannot be enforced",
+                "that the projection does not store, so the row policy cannot be enforced",
                 projection->name, parent_storage_id.getNameForLogs());
         }
     }();
@@ -171,18 +201,6 @@ std::unique_ptr<MergeTreeProjectionRowPolicyFilter> StorageFromMergeTreeProjecti
         throw Exception(ErrorCodes::ACCESS_DENIED,
             "Cannot determine row policy filter column for projection `{}` of table {}",
             projection->name, parent_storage_id.getNameForLogs());
-
-    /// Refuse the read when the policy needs a column the projection does not physically store, e.g.
-    /// an ALIAS/DEFAULT column (the projection keeps only its physical deps, under other names).
-    const auto & projection_columns = projection->metadata->getColumns();
-    for (const auto & column_name : filter_actions.getRequiredColumns())
-    {
-        if (!projection_columns.hasColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column_name))
-            throw Exception(ErrorCodes::ACCESS_DENIED,
-                "Cannot read from projection `{}` of table {} because a row policy needs "
-                "column `{}`, which is not stored in the projection, so the row policy cannot be enforced",
-                projection->name, parent_storage_id.getNameForLogs(), column_name);
-    }
 
     /// record the applied policies so they show up in system.query_log, like a normal table read
     if (context->hasQueryContext())

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -10,6 +10,7 @@
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>
 #include <Interpreters/replaceAliasColumnsInQuery.h>
+#include <Functions/UserDefined/UserDefinedSQLFunctionVisitor.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/QueryPlan.h>
@@ -158,6 +159,11 @@ std::unique_ptr<MergeTreeProjectionRowPolicyFilter> StorageFromMergeTreeProjecti
         return nullptr;
 
     ASTPtr expr = row_policy_filter->expression->clone();
+
+    /// Expand SQL UDFs first so any column reference they introduce (e.g. a `_part_offset` argument or a
+    /// column named directly in the UDF body) is visible to the alias expansion and offset remap below,
+    /// rather than being reintroduced later by `TreeRewriter`.
+    UserDefinedSQLFunctionVisitor::visit(expr, context);
 
     /// Expand parent ALIAS/DEFAULT columns to their physical dependencies, which the projection may
     /// store even though it does not expose the alias itself (e.g. `c ALIAS b + 1` -> reads `b`).

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -168,14 +168,26 @@ std::unique_ptr<MergeTreeProjectionRowPolicyFilter> StorageFromMergeTreeProjecti
     if (projection->with_parent_part_offset)
         remapPartOffsetToParent(expr);
 
-    /// Resolve against exactly what the projection read can serve: its physical columns plus the parent
-    /// offsets it preserves (`_part_starting_offset` from `part_starting_offset_in_query`, and the parent
-    /// `_part_offset` as `_parent_part_offset`). Anything else fails to resolve, and we fail closed with a
-    /// clear ACCESS_DENIED.
+    /// Resolve against exactly what the projection read can serve. Anything else fails to resolve, and we
+    /// fail closed with a clear ACCESS_DENIED. What the projection read can serve:
+    ///  - its stored physical columns;
+    ///  - part-identity virtuals (`_part`, `_partition_id`, ...): a projection part maps back to its parent
+    ///    part (`RangesInDataPart::getDescription`), so these keep parent-row semantics;
+    ///  - the parent offsets it preserves: `_part_starting_offset`, and the parent `_part_offset` remapped
+    ///    to `_parent_part_offset` above.
+    /// Position-relative virtuals (`_part_offset`, `_part_index`, ...) are intentionally NOT offered: on a
+    /// reordered projection they point at different rows than the parent, so enforcing a policy on them
+    /// would filter the wrong rows. That is why we use this explicit set instead of the whole snapshot.
     auto available_columns = projection->metadata->getColumns().getAllPhysical();
     available_columns.emplace_back("_part_starting_offset", std::make_shared<DataTypeUInt64>());
     if (projection->with_parent_part_offset)
         available_columns.emplace_back("_parent_part_offset", std::make_shared<DataTypeUInt64>());
+
+    auto parent_snapshot = merge_tree.getStorageSnapshot(parent_metadata, context);
+    auto virtual_options = GetColumnsOptions(GetColumnsOptions::AllPhysical).withVirtuals(VirtualsKind::All, VirtualsMaterializationPlace::All);
+    for (const auto & name : MergeTreeData::virtuals_useful_for_filter)
+        if (auto virtual_column = parent_snapshot->tryGetColumn(virtual_options, name))
+            available_columns.push_back(*virtual_column);
 
     ActionsDAG dag = [&]
     {

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -3,16 +3,20 @@
 #include <Access/Common/AccessFlags.h>
 #include <Access/Common/RowPolicyDefs.h>
 #include <Access/EnabledRowPolicies.h>
+#include <Interpreters/ActionsDAG.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/RequiredSourceColumnsVisitor.h>
 #include <Interpreters/TreeRewriter.h>
+#include <Processors/QueryPlan/ExpressionStep.h>
+#include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadNothingStep.h>
 #include <Processors/Sources/NullSource.h>
 #include <Storages/MergeTree/MergeTreeDataSelectExecutor.h>
-#include <Storages/SelectQueryInfo.h>
+
+#include <algorithm>
 
 namespace DB
 {
@@ -21,6 +25,14 @@ namespace ErrorCodes
 {
     extern const int ACCESS_DENIED;
 }
+
+/// A row policy resolved against a projection's columns, ready to be applied as a FilterStep.
+struct MergeTreeProjectionRowPolicyFilter
+{
+    ActionsDAG dag;
+    String filter_column_name;
+    Names required_columns;
+};
 
 StorageFromMergeTreeProjection::StorageFromMergeTreeProjection(
     StorageID storage_id_, StoragePtr parent_storage_, StorageMetadataPtr parent_metadata_, ProjectionDescriptionRawPtr projection_)
@@ -46,8 +58,14 @@ void StorageFromMergeTreeProjection::read(
     context->checkAccess(AccessType::SELECT, parent_storage->getStorageID());
 
     /// row policies live on the parent table, so enforce them here or the projection leaks hidden rows
-    if (auto row_level_filter = buildRowPolicyFilter(context))
-        query_info.row_level_filter = std::move(row_level_filter);
+    auto row_policy = buildRowPolicyFilter(context);
+
+    /// read the policy columns too, even if the query did not ask for them
+    Names read_column_names = column_names;
+    if (row_policy)
+        for (const auto & name : row_policy->required_columns)
+            if (std::find(read_column_names.begin(), read_column_names.end(), name) == read_column_names.end())
+                read_column_names.push_back(name);
 
     /// A UNIQUE KEY parent rejects projection reads in the MergeTreeDataSelectExecutor
     /// constructor below (the universal projection-read chokepoint), since reading a
@@ -72,7 +90,7 @@ void StorageFromMergeTreeProjection::read(
                     .readFromParts(
                         std::make_shared<RangesInDataParts>(projection_parts),
                         snapshot_data.mutations_snapshot->cloneEmpty(),
-                        column_names,
+                        read_column_names,
                         storage_snapshot,
                         query_info,
                         context,
@@ -89,9 +107,27 @@ void StorageFromMergeTreeProjection::read(
         read_nothing->setStepDescription("Read from NullSource (Projection)");
         query_plan.addStep(std::move(read_nothing));
     }
+
+    if (row_policy)
+    {
+        query_plan.addStep(std::make_unique<FilterStep>(
+            query_plan.getCurrentHeader(), std::move(row_policy->dag), row_policy->filter_column_name, true /* remove filter column */));
+
+        /// drop the policy columns we added on top of what the query requested
+        if (read_column_names.size() != column_names.size())
+        {
+            auto target = storage_snapshot->getSampleBlockForColumns(column_names);
+            auto convert = ActionsDAG::makeConvertingActions(
+                query_plan.getCurrentHeader()->getColumnsWithTypeAndName(),
+                target.getColumnsWithTypeAndName(),
+                ActionsDAG::MatchColumnsMode::Name,
+                context);
+            query_plan.addStep(std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(), std::move(convert)));
+        }
+    }
 }
 
-FilterDAGInfoPtr StorageFromMergeTreeProjection::buildRowPolicyFilter(const ContextPtr & context) const
+std::unique_ptr<MergeTreeProjectionRowPolicyFilter> StorageFromMergeTreeProjection::buildRowPolicyFilter(const ContextPtr & context) const
 {
     const auto parent_storage_id = parent_storage->getStorageID();
     auto row_policy_filter = context->getRowPolicyFilter(
@@ -114,14 +150,14 @@ FilterDAGInfoPtr StorageFromMergeTreeProjection::buildRowPolicyFilter(const Cont
                 projection->name, parent_storage_id.getNameForLogs(), column_name);
     }
 
-    /// resolve the policy against the projection columns so the read can filter and drop extra columns
+    /// resolve the policy against the projection columns
     ASTPtr expr = row_policy_filter->expression->clone();
     auto syntax_result = TreeRewriter(context).analyze(expr, projection_columns.getAll());
     ExpressionAnalyzer analyzer(expr, syntax_result, context);
-    auto filter_actions_dag = analyzer.getActionsDAG(false /* add_aliases */, false /* remove_unused_result */);
+    auto dag = analyzer.getActionsDAG(false /* add_aliases */, false /* remove_unused_result */);
 
     /// the filter column is the single output added on top of the inputs
-    ExpressionActions filter_actions(filter_actions_dag.clone(), ExpressionActionsSettings(context));
+    ExpressionActions filter_actions(dag.clone(), ExpressionActionsSettings(context));
     NamesAndTypesList added;
     NamesAndTypesList deleted;
     filter_actions.getSampleBlock().getNamesAndTypesList().getDifference(
@@ -136,8 +172,11 @@ FilterDAGInfoPtr StorageFromMergeTreeProjection::buildRowPolicyFilter(const Cont
         for (const auto & row_policy : row_policy_filter->policies)
             context->getQueryContext()->addUsedRowPolicy(row_policy->getFullName().toString());
 
-    return std::make_shared<FilterDAGInfo>(
-        FilterDAGInfo{std::move(filter_actions_dag), added.front().name, true /* do_remove_column */});
+    auto result = std::make_unique<MergeTreeProjectionRowPolicyFilter>();
+    result->filter_column_name = added.front().name;
+    result->required_columns = filter_actions.getRequiredColumns();
+    result->dag = std::move(dag);
+    return result;
 }
 
 StorageSnapshotPtr

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -131,6 +131,11 @@ FilterDAGInfoPtr StorageFromMergeTreeProjection::buildRowPolicyFilter(const Cont
             "Cannot determine row policy filter column for projection `{}` of table {}",
             projection->name, parent_storage_id.getNameForLogs());
 
+    /// record the applied policies so they show up in system.query_log, like a normal table read
+    if (context->hasQueryContext())
+        for (const auto & row_policy : row_policy_filter->policies)
+            context->getQueryContext()->addUsedRowPolicy(row_policy->getFullName().toString());
+
     return std::make_shared<FilterDAGInfo>(
         FilterDAGInfo{std::move(filter_actions_dag), added.front().name, true /* do_remove_column */});
 }

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -7,7 +7,6 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/ExpressionAnalyzer.h>
-#include <Interpreters/RequiredSourceColumnsVisitor.h>
 #include <Interpreters/TreeRewriter.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
@@ -136,23 +135,9 @@ std::unique_ptr<MergeTreeProjectionRowPolicyFilter> StorageFromMergeTreeProjecti
     if (!row_policy_filter || row_policy_filter->isAlwaysTrue())
         return nullptr;
 
-    const auto & projection_columns = projection->metadata->getColumns();
-
-    /// refuse the read when the policy needs a column the projection does not store
-    RequiredSourceColumnsVisitor::Data columns_context;
-    RequiredSourceColumnsVisitor(columns_context).visit(row_policy_filter->expression);
-    for (const auto & column_name : columns_context.requiredColumns())
-    {
-        if (!projection_columns.hasColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column_name))
-            throw Exception(ErrorCodes::ACCESS_DENIED,
-                "Cannot read from projection `{}` of table {} because a row policy references "
-                "column `{}`, which is not stored in the projection, so the row policy cannot be enforced",
-                projection->name, parent_storage_id.getNameForLogs(), column_name);
-    }
-
-    /// resolve the policy against the projection columns
+    /// Resolve the policy against the parent table columns so its referenced columns are known.
     ASTPtr expr = row_policy_filter->expression->clone();
-    auto syntax_result = TreeRewriter(context).analyze(expr, projection_columns.getAll());
+    auto syntax_result = TreeRewriter(context).analyze(expr, parent_metadata->getColumns().getAll());
     ExpressionAnalyzer analyzer(expr, syntax_result, context);
     auto dag = analyzer.getActionsDAG(false /* add_aliases */, false /* remove_unused_result */);
 
@@ -166,6 +151,19 @@ std::unique_ptr<MergeTreeProjectionRowPolicyFilter> StorageFromMergeTreeProjecti
         throw Exception(ErrorCodes::ACCESS_DENIED,
             "Cannot determine row policy filter column for projection `{}` of table {}",
             projection->name, parent_storage_id.getNameForLogs());
+
+    /// Refuse the read when the policy needs a column the projection does not store. This includes
+    /// ALIAS/DEFAULT columns: the projection stores their physical dependencies under different names
+    /// and does not carry the column itself, so the policy cannot be evaluated here. Fail closed.
+    const auto & projection_columns = projection->metadata->getColumns();
+    for (const auto & column_name : filter_actions.getRequiredColumns())
+    {
+        if (!projection_columns.hasColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column_name))
+            throw Exception(ErrorCodes::ACCESS_DENIED,
+                "Cannot read from projection `{}` of table {} because a row policy needs "
+                "column `{}`, which is not stored in the projection, so the row policy cannot be enforced",
+                projection->name, parent_storage_id.getNameForLogs(), column_name);
+    }
 
     /// record the applied policies so they show up in system.query_log, like a normal table read
     if (context->hasQueryContext())

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -9,11 +9,11 @@
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
-#include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadNothingStep.h>
 #include <Processors/Sources/NullSource.h>
 #include <Storages/MergeTree/MergeTreeDataSelectExecutor.h>
+#include <Storages/SelectQueryInfo.h>
 
 #include <algorithm>
 
@@ -59,12 +59,19 @@ void StorageFromMergeTreeProjection::read(
     /// row policies live on the parent table, so enforce them here or the projection leaks hidden rows
     auto row_policy = buildRowPolicyFilter(context);
 
-    /// read the policy columns too, even if the query did not ask for them
     Names read_column_names = column_names;
     if (row_policy)
+    {
+        /// read the policy columns too, even if the query did not ask for them
         for (const auto & name : row_policy->required_columns)
             if (std::find(read_column_names.begin(), read_column_names.end(), name) == read_column_names.end())
                 read_column_names.push_back(name);
+
+        /// Apply as a row-level filter so it runs ahead of any user PREWHERE, exactly like a normal
+        /// MergeTree read. A post-read FilterStep would let a PREWHERE predicate observe hidden rows first.
+        query_info.row_level_filter = std::make_shared<FilterDAGInfo>(
+            FilterDAGInfo{std::move(row_policy->dag), row_policy->filter_column_name, true /* do_remove_column */});
+    }
 
     /// A UNIQUE KEY parent rejects projection reads in the MergeTreeDataSelectExecutor
     /// constructor below (the universal projection-read chokepoint), since reading a
@@ -107,22 +114,16 @@ void StorageFromMergeTreeProjection::read(
         query_plan.addStep(std::move(read_nothing));
     }
 
-    if (row_policy)
+    /// drop the policy columns we added on top of what the query requested
+    if (row_policy && read_column_names.size() != column_names.size())
     {
-        query_plan.addStep(std::make_unique<FilterStep>(
-            query_plan.getCurrentHeader(), std::move(row_policy->dag), row_policy->filter_column_name, true /* remove filter column */));
-
-        /// drop the policy columns we added on top of what the query requested
-        if (read_column_names.size() != column_names.size())
-        {
-            auto target = storage_snapshot->getSampleBlockForColumns(column_names);
-            auto convert = ActionsDAG::makeConvertingActions(
-                query_plan.getCurrentHeader()->getColumnsWithTypeAndName(),
-                target.getColumnsWithTypeAndName(),
-                ActionsDAG::MatchColumnsMode::Name,
-                context);
-            query_plan.addStep(std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(), std::move(convert)));
-        }
+        auto target = storage_snapshot->getSampleBlockForColumns(column_names);
+        auto convert = ActionsDAG::makeConvertingActions(
+            query_plan.getCurrentHeader()->getColumnsWithTypeAndName(),
+            target.getColumnsWithTypeAndName(),
+            ActionsDAG::MatchColumnsMode::Name,
+            context);
+        query_plan.addStep(std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(), std::move(convert)));
     }
 }
 

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -87,8 +87,11 @@ void StorageFromMergeTreeProjection::read(
 
         /// Apply as a row-level filter so it runs ahead of any user PREWHERE, exactly like a normal
         /// MergeTree read. A post-read FilterStep would let a PREWHERE predicate observe hidden rows first.
+        /// Keep the filter column if the query selects it too (a bare-column policy like `USING flag`).
+        const bool remove_filter_column
+            = std::find(column_names.begin(), column_names.end(), row_policy->filter_column_name) == column_names.end();
         query_info.row_level_filter = std::make_shared<FilterDAGInfo>(
-            FilterDAGInfo{std::move(row_policy->dag), row_policy->filter_column_name, true /* do_remove_column */});
+            FilterDAGInfo{std::move(row_policy->dag), row_policy->filter_column_name, remove_filter_column});
     }
 
     /// A UNIQUE KEY parent rejects projection reads in the MergeTreeDataSelectExecutor
@@ -166,9 +169,11 @@ std::unique_ptr<MergeTreeProjectionRowPolicyFilter> StorageFromMergeTreeProjecti
         remapPartOffsetToParent(expr);
 
     /// Resolve against exactly what the projection read can serve: its physical columns plus the parent
-    /// offset when preserved. Anything else (a column not stored here, a virtual with no projection
-    /// equivalent) fails to resolve, and we fail closed with a clear ACCESS_DENIED.
+    /// offsets it preserves (`_part_starting_offset` from `part_starting_offset_in_query`, and the parent
+    /// `_part_offset` as `_parent_part_offset`). Anything else fails to resolve, and we fail closed with a
+    /// clear ACCESS_DENIED.
     auto available_columns = projection->metadata->getColumns().getAllPhysical();
+    available_columns.emplace_back("_part_starting_offset", std::make_shared<DataTypeUInt64>());
     if (projection->with_parent_part_offset)
         available_columns.emplace_back("_parent_part_offset", std::make_shared<DataTypeUInt64>());
 
@@ -191,13 +196,10 @@ std::unique_ptr<MergeTreeProjectionRowPolicyFilter> StorageFromMergeTreeProjecti
         }
     }();
 
-    /// the filter column is the single output added on top of the inputs
-    ExpressionActions filter_actions(dag.clone(), ExpressionActionsSettings(context));
-    NamesAndTypesList added;
-    NamesAndTypesList deleted;
-    filter_actions.getSampleBlock().getNamesAndTypesList().getDifference(
-        filter_actions.getRequiredColumnsWithTypes(), added, deleted);
-    if (!deleted.empty() || added.size() != 1)
+    /// The filter column is the policy expression's own output node (which may be a bare input column,
+    /// e.g. `USING c0`), mirroring `generateFilterActions`/`buildFilterInfo` rather than assuming a new node.
+    String filter_column_name = expr->getColumnName();
+    if (!dag.tryFindInOutputs(filter_column_name))
         throw Exception(ErrorCodes::ACCESS_DENIED,
             "Cannot determine row policy filter column for projection `{}` of table {}",
             projection->name, parent_storage_id.getNameForLogs());
@@ -208,8 +210,8 @@ std::unique_ptr<MergeTreeProjectionRowPolicyFilter> StorageFromMergeTreeProjecti
             context->getQueryContext()->addUsedRowPolicy(row_policy->getFullName().toString());
 
     auto result = std::make_unique<MergeTreeProjectionRowPolicyFilter>();
-    result->filter_column_name = added.front().name;
-    result->required_columns = filter_actions.getRequiredColumns();
+    result->required_columns = dag.getRequiredColumnsNames();
+    result->filter_column_name = std::move(filter_column_name);
     result->dag = std::move(dag);
     return result;
 }

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -43,50 +43,11 @@ void StorageFromMergeTreeProjection::read(
     size_t max_block_size,
     size_t num_streams)
 {
-    const auto parent_storage_id = parent_storage->getStorageID();
-    context->checkAccess(AccessType::SELECT, parent_storage_id);
+    context->checkAccess(AccessType::SELECT, parent_storage->getStorageID());
 
-    /// Row policies are attached to the parent table, not to this synthetic projection storage, so the
-    /// planner never applies them here; a projection part stores real row data, so enforce the policy.
-    auto row_policy_filter = context->getRowPolicyFilter(
-        parent_storage_id.getDatabaseName(), parent_storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
-
-    if (row_policy_filter && !row_policy_filter->isAlwaysTrue())
-    {
-        const auto & projection_columns = projection->metadata->getColumns();
-
-        RequiredSourceColumnsVisitor::Data columns_context;
-        RequiredSourceColumnsVisitor(columns_context).visit(row_policy_filter->expression);
-        for (const auto & column_name : columns_context.requiredColumns())
-        {
-            if (!projection_columns.hasColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column_name))
-                throw Exception(ErrorCodes::ACCESS_DENIED,
-                    "Cannot read from projection `{}` of table {} because a row policy references "
-                    "column `{}`, which is not stored in the projection, so the row policy cannot be enforced",
-                    projection->name, parent_storage_id.getNameForLogs(), column_name);
-        }
-
-        /// Build the filter against the projection's own columns; the reading step then reads the
-        /// referenced columns, filters the rows, and drops any of them that were not requested.
-        ASTPtr expr = row_policy_filter->expression->clone();
-        auto syntax_result = TreeRewriter(context).analyze(expr, projection_columns.getAll());
-        ExpressionAnalyzer analyzer(expr, syntax_result, context);
-        auto filter_actions_dag = analyzer.getActionsDAG(false /* add_aliases */, false /* remove_unused_result */);
-
-        /// The filter column is the single output the expression adds on top of its inputs.
-        ExpressionActions filter_actions(filter_actions_dag.clone(), ExpressionActionsSettings(context));
-        NamesAndTypesList added;
-        NamesAndTypesList deleted;
-        filter_actions.getSampleBlock().getNamesAndTypesList().getDifference(
-            filter_actions.getRequiredColumnsWithTypes(), added, deleted);
-        if (!deleted.empty() || added.size() != 1)
-            throw Exception(ErrorCodes::ACCESS_DENIED,
-                "Cannot determine row policy filter column for projection `{}` of table {}",
-                projection->name, parent_storage_id.getNameForLogs());
-
-        query_info.row_level_filter = std::make_shared<FilterDAGInfo>(
-            FilterDAGInfo{std::move(filter_actions_dag), added.front().name, true /* do_remove_column */});
-    }
+    /// row policies live on the parent table, so enforce them here or the projection leaks hidden rows
+    if (auto row_level_filter = buildRowPolicyFilter(context))
+        query_info.row_level_filter = std::move(row_level_filter);
 
     /// A UNIQUE KEY parent rejects projection reads in the MergeTreeDataSelectExecutor
     /// constructor below (the universal projection-read chokepoint), since reading a
@@ -128,6 +89,50 @@ void StorageFromMergeTreeProjection::read(
         read_nothing->setStepDescription("Read from NullSource (Projection)");
         query_plan.addStep(std::move(read_nothing));
     }
+}
+
+FilterDAGInfoPtr StorageFromMergeTreeProjection::buildRowPolicyFilter(const ContextPtr & context) const
+{
+    const auto parent_storage_id = parent_storage->getStorageID();
+    auto row_policy_filter = context->getRowPolicyFilter(
+        parent_storage_id.getDatabaseName(), parent_storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
+
+    if (!row_policy_filter || row_policy_filter->isAlwaysTrue())
+        return nullptr;
+
+    const auto & projection_columns = projection->metadata->getColumns();
+
+    /// refuse the read when the policy needs a column the projection does not store
+    RequiredSourceColumnsVisitor::Data columns_context;
+    RequiredSourceColumnsVisitor(columns_context).visit(row_policy_filter->expression);
+    for (const auto & column_name : columns_context.requiredColumns())
+    {
+        if (!projection_columns.hasColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column_name))
+            throw Exception(ErrorCodes::ACCESS_DENIED,
+                "Cannot read from projection `{}` of table {} because a row policy references "
+                "column `{}`, which is not stored in the projection, so the row policy cannot be enforced",
+                projection->name, parent_storage_id.getNameForLogs(), column_name);
+    }
+
+    /// resolve the policy against the projection columns so the read can filter and drop extra columns
+    ASTPtr expr = row_policy_filter->expression->clone();
+    auto syntax_result = TreeRewriter(context).analyze(expr, projection_columns.getAll());
+    ExpressionAnalyzer analyzer(expr, syntax_result, context);
+    auto filter_actions_dag = analyzer.getActionsDAG(false /* add_aliases */, false /* remove_unused_result */);
+
+    /// the filter column is the single output added on top of the inputs
+    ExpressionActions filter_actions(filter_actions_dag.clone(), ExpressionActionsSettings(context));
+    NamesAndTypesList added;
+    NamesAndTypesList deleted;
+    filter_actions.getSampleBlock().getNamesAndTypesList().getDifference(
+        filter_actions.getRequiredColumnsWithTypes(), added, deleted);
+    if (!deleted.empty() || added.size() != 1)
+        throw Exception(ErrorCodes::ACCESS_DENIED,
+            "Cannot determine row policy filter column for projection `{}` of table {}",
+            projection->name, parent_storage_id.getNameForLogs());
+
+    return std::make_shared<FilterDAGInfo>(
+        FilterDAGInfo{std::move(filter_actions_dag), added.front().name, true /* do_remove_column */});
 }
 
 StorageSnapshotPtr

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -93,6 +93,12 @@ void StorageFromMergeTreeProjection::read(
             = std::find(column_names.begin(), column_names.end(), row_policy->filter_column_name) == column_names.end();
         query_info.row_level_filter = std::make_shared<FilterDAGInfo>(
             FilterDAGInfo{std::move(row_policy->dag), row_policy->filter_column_name, remove_filter_column});
+
+        /// The planner disables the trivial-LIMIT optimization whenever a row policy applies, but it checks
+        /// the policy through this table function's own storage id, which has none - so the optimization is
+        /// left on and `query_info.trivial_limit` may already be set for `... LIMIT n`. Reading only n rows
+        /// and then filtering could return fewer than n visible rows, so restore that invariant here.
+        query_info.trivial_limit = 0;
     }
 
     /// A UNIQUE KEY parent rejects projection reads in the MergeTreeDataSelectExecutor

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -89,9 +89,12 @@ void StorageFromMergeTreeProjection::read(
                 projection->name, parent_storage_id.getNameForLogs());
         }
 
-        /// read the policy's columns even if the query didn't ask for them; refuse position-relative
-        /// virtuals - the projection can reorder rows, so its value for them isn't the parent's
-        static const NameSet not_row_preserving{"_part_offset", "_part_index", "_part_granule_offset", "_block_offset", "_block_number"};
+        /// read the policy's columns even if the query didn't ask for them; refuse virtuals the projection
+        /// does not preserve (position-relative ones - it can reorder rows) or exposes under a
+        /// projection-only name absent on the parent (`_parent_part_offset`), since a parent policy binding
+        /// to those does not carry parent-row semantics
+        static const NameSet not_row_preserving{
+            "_part_offset", "_part_index", "_part_granule_offset", "_block_offset", "_block_number", "_parent_part_offset"};
         for (const auto & name : filter_info.actions.getRequiredColumnsNames())
         {
             if (not_row_preserving.contains(name))
@@ -102,6 +105,15 @@ void StorageFromMergeTreeProjection::read(
             if (std::find(read_column_names.begin(), read_column_names.end(), name) == read_column_names.end())
                 read_column_names.push_back(name);
         }
+
+        /// the planner may have already installed a filter for a policy on the table function itself
+        /// (`_table_function.*`); overwriting it would drop that restriction, so refuse rather than
+        /// silently apply only the parent policy
+        if (query_info.row_level_filter)
+            throw Exception(ErrorCodes::ACCESS_DENIED,
+                "Cannot read from projection `{}` of table {}: a row policy already applies to the table "
+                "function itself and cannot be combined with the parent table's row policy",
+                projection->name, parent_storage_id.getNameForLogs());
 
         /// row-level filter runs before any user PREWHERE (a post-read filter would let PREWHERE see hidden rows)
         query_info.row_level_filter = std::make_shared<FilterDAGInfo>(std::move(filter_info));

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -3,16 +3,8 @@
 #include <Access/Common/AccessFlags.h>
 #include <Access/Common/RowPolicyDefs.h>
 #include <Access/EnabledRowPolicies.h>
-#include <DataTypes/DataTypesNumber.h>
-#include <Interpreters/ActionsDAG.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/ExpressionActions.h>
-#include <Interpreters/ExpressionAnalyzer.h>
-#include <Interpreters/TreeRewriter.h>
-#include <Interpreters/replaceAliasColumnsInQuery.h>
-#include <Functions/UserDefined/UserDefinedSQLFunctionVisitor.h>
-#include <Parsers/ASTIdentifier.h>
-#include <Processors/QueryPlan/ExpressionStep.h>
+#include <Planner/Utils.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadNothingStep.h>
 #include <Processors/Sources/NullSource.h>
@@ -29,27 +21,6 @@ namespace ErrorCodes
     extern const int ACCESS_DENIED;
     extern const int UNKNOWN_IDENTIFIER;
     extern const int NO_SUCH_COLUMN_IN_TABLE;
-}
-
-/// A row policy resolved against a projection's columns, ready to be applied as a FilterStep.
-struct MergeTreeProjectionRowPolicyFilter
-{
-    ActionsDAG dag;
-    String filter_column_name;
-    Names required_columns;
-};
-
-/// Rewrite references to the parent `_part_offset` into the projection's stored `_parent_part_offset`.
-static void remapPartOffsetToParent(ASTPtr & ast)
-{
-    if (auto * identifier = ast->as<ASTIdentifier>())
-    {
-        if (identifier->name() == "_part_offset")
-            ast = make_intrusive<ASTIdentifier>("_parent_part_offset");
-        return;
-    }
-    for (auto & child : ast->children)
-        remapPartOffsetToParent(child);
 }
 
 StorageFromMergeTreeProjection::StorageFromMergeTreeProjection(
@@ -75,29 +46,58 @@ void StorageFromMergeTreeProjection::read(
 {
     context->checkAccess(AccessType::SELECT, parent_storage->getStorageID());
 
-    /// row policies live on the parent table, so enforce them here or the projection leaks hidden rows
-    auto row_policy = buildRowPolicyFilter(context);
+    const auto parent_storage_id = parent_storage->getStorageID();
+    auto row_policy_filter = context->getRowPolicyFilter(
+        parent_storage_id.getDatabaseName(), parent_storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
 
     Names read_column_names = column_names;
-    if (row_policy)
+    if (row_policy_filter && !row_policy_filter->isAlwaysTrue())
     {
-        /// read the policy columns too, even if the query did not ask for them
-        for (const auto & name : row_policy->required_columns)
+        /// the policy is on the parent table; enforce it here or the projection leaks hidden rows
+        if (!query_info.planner_context || !query_info.table_expression)
+            throw Exception(ErrorCodes::ACCESS_DENIED,
+                "Cannot enforce the row policy of table {} on projection `{}` without the analyzer",
+                parent_storage_id.getNameForLogs(), projection->name);
+
+        for (const auto & policy : row_policy_filter->policies)
+            if (context->hasQueryContext())
+                context->getQueryContext()->addUsedRowPolicy(policy->getFullName().toString());
+
+        FilterDAGInfo filter_info;
+        try
+        {
+            /// resolve against the projection's own columns; anything it can't provide throws below
+            filter_info = buildFilterInfo(
+                row_policy_filter->expression->clone(), query_info.table_expression, query_info.planner_context);
+        }
+        catch (const Exception & e)
+        {
+            if (e.code() != ErrorCodes::UNKNOWN_IDENTIFIER && e.code() != ErrorCodes::NO_SUCH_COLUMN_IN_TABLE)
+                throw;
+            throw Exception(ErrorCodes::ACCESS_DENIED,
+                "Cannot read from projection `{}` of table {} because its row policy references a column "
+                "the projection does not store, so it cannot be enforced",
+                projection->name, parent_storage_id.getNameForLogs());
+        }
+
+        /// read the policy's columns even if the query didn't ask for them; refuse position-relative
+        /// virtuals - the projection can reorder rows, so its value for them isn't the parent's
+        static const NameSet not_row_preserving{"_part_offset", "_part_index", "_part_granule_offset", "_block_offset"};
+        for (const auto & name : filter_info.actions.getRequiredColumnsNames())
+        {
+            if (not_row_preserving.contains(name))
+                throw Exception(ErrorCodes::ACCESS_DENIED,
+                    "Cannot read from projection `{}` of table {} because its row policy uses virtual column "
+                    "`{}`, whose value the projection does not preserve, so it cannot be enforced",
+                    projection->name, parent_storage_id.getNameForLogs(), name);
             if (std::find(read_column_names.begin(), read_column_names.end(), name) == read_column_names.end())
                 read_column_names.push_back(name);
+        }
 
-        /// Apply as a row-level filter so it runs ahead of any user PREWHERE, exactly like a normal
-        /// MergeTree read. A post-read FilterStep would let a PREWHERE predicate observe hidden rows first.
-        /// Keep the filter column if the query selects it too (a bare-column policy like `USING flag`).
-        const bool remove_filter_column
-            = std::find(column_names.begin(), column_names.end(), row_policy->filter_column_name) == column_names.end();
-        query_info.row_level_filter = std::make_shared<FilterDAGInfo>(
-            FilterDAGInfo{std::move(row_policy->dag), row_policy->filter_column_name, remove_filter_column});
+        /// row-level filter runs before any user PREWHERE (a post-read filter would let PREWHERE see hidden rows)
+        query_info.row_level_filter = std::make_shared<FilterDAGInfo>(std::move(filter_info));
 
-        /// The planner disables the trivial-LIMIT optimization whenever a row policy applies, but it checks
-        /// the policy through this table function's own storage id, which has none - so the optimization is
-        /// left on and `query_info.trivial_limit` may already be set for `... LIMIT n`. Reading only n rows
-        /// and then filtering could return fewer than n visible rows, so restore that invariant here.
+        /// planner left trivial-LIMIT on (it checks this tf's storage id, which has no policy); n rows then filter could yield < n
         query_info.trivial_limit = 0;
     }
 
@@ -141,103 +141,6 @@ void StorageFromMergeTreeProjection::read(
         read_nothing->setStepDescription("Read from NullSource (Projection)");
         query_plan.addStep(std::move(read_nothing));
     }
-
-    /// drop the policy columns we added on top of what the query requested
-    if (row_policy && read_column_names.size() != column_names.size())
-    {
-        auto target = storage_snapshot->getSampleBlockForColumns(column_names);
-        auto convert = ActionsDAG::makeConvertingActions(
-            query_plan.getCurrentHeader()->getColumnsWithTypeAndName(),
-            target.getColumnsWithTypeAndName(),
-            ActionsDAG::MatchColumnsMode::Name,
-            context);
-        query_plan.addStep(std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(), std::move(convert)));
-    }
-}
-
-std::unique_ptr<MergeTreeProjectionRowPolicyFilter> StorageFromMergeTreeProjection::buildRowPolicyFilter(const ContextPtr & context) const
-{
-    const auto parent_storage_id = parent_storage->getStorageID();
-    auto row_policy_filter = context->getRowPolicyFilter(
-        parent_storage_id.getDatabaseName(), parent_storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
-
-    if (!row_policy_filter || row_policy_filter->isAlwaysTrue())
-        return nullptr;
-
-    ASTPtr expr = row_policy_filter->expression->clone();
-
-    /// Expand SQL UDFs first so any column reference they introduce (e.g. a `_part_offset` argument or a
-    /// column named directly in the UDF body) is visible to the alias expansion and offset remap below,
-    /// rather than being reintroduced later by `TreeRewriter`.
-    UserDefinedSQLFunctionVisitor::visit(expr, context);
-
-    /// Expand parent ALIAS/DEFAULT columns to their physical dependencies, which the projection may
-    /// store even though it does not expose the alias itself (e.g. `c ALIAS b + 1` -> reads `b`).
-    replaceAliasColumnsInQuery(expr, parent_metadata->getColumns(), {}, context);
-
-    /// The parent `_part_offset` is materialized as `_parent_part_offset` in projections that carry it,
-    /// so a policy on `_part_offset` keeps its parent-row semantics when read through such a projection.
-    if (projection->with_parent_part_offset)
-        remapPartOffsetToParent(expr);
-
-    /// Resolve against exactly what the projection read can serve. Anything else fails to resolve, and we
-    /// fail closed with a clear ACCESS_DENIED. What the projection read can serve:
-    ///  - its stored physical columns;
-    ///  - part-identity virtuals (`_part`, `_partition_id`, ...): a projection part maps back to its parent
-    ///    part (`RangesInDataPart::getDescription`), so these keep parent-row semantics;
-    ///  - the parent offsets it preserves: `_part_starting_offset`, and the parent `_part_offset` remapped
-    ///    to `_parent_part_offset` above.
-    /// Position-relative virtuals (`_part_offset`, `_part_index`, ...) are intentionally NOT offered: on a
-    /// reordered projection they point at different rows than the parent, so enforcing a policy on them
-    /// would filter the wrong rows. That is why we use this explicit set instead of the whole snapshot.
-    auto available_columns = projection->metadata->getColumns().getAllPhysical();
-    available_columns.emplace_back("_part_starting_offset", std::make_shared<DataTypeUInt64>());
-    if (projection->with_parent_part_offset)
-        available_columns.emplace_back("_parent_part_offset", std::make_shared<DataTypeUInt64>());
-
-    auto parent_snapshot = merge_tree.getStorageSnapshot(parent_metadata, context);
-    auto virtual_options = GetColumnsOptions(GetColumnsOptions::AllPhysical).withVirtuals(VirtualsKind::All, VirtualsMaterializationPlace::All);
-    for (const auto & name : MergeTreeData::virtuals_useful_for_filter)
-        if (auto virtual_column = parent_snapshot->tryGetColumn(virtual_options, name))
-            available_columns.push_back(*virtual_column);
-
-    ActionsDAG dag = [&]
-    {
-        try
-        {
-            auto syntax_result = TreeRewriter(context).analyze(expr, available_columns);
-            ExpressionAnalyzer analyzer(expr, syntax_result, context);
-            return analyzer.getActionsDAG(false /* add_aliases */, false /* remove_unused_result */);
-        }
-        catch (const Exception & e)
-        {
-            if (e.code() != ErrorCodes::UNKNOWN_IDENTIFIER && e.code() != ErrorCodes::NO_SUCH_COLUMN_IN_TABLE)
-                throw;
-            throw Exception(ErrorCodes::ACCESS_DENIED,
-                "Cannot read from projection `{}` of table {} because its row policy references a column "
-                "that the projection does not store, so the row policy cannot be enforced",
-                projection->name, parent_storage_id.getNameForLogs());
-        }
-    }();
-
-    /// The filter column is the policy expression's own output node (which may be a bare input column,
-    /// e.g. `USING c0`), mirroring `generateFilterActions`/`buildFilterInfo` rather than assuming a new node.
-    String filter_column_name = expr->getColumnName();
-    if (!dag.tryFindInOutputs(filter_column_name))
-        throw Exception(ErrorCodes::ACCESS_DENIED,
-            "Cannot determine row policy filter column for projection `{}` of table {}",
-            projection->name, parent_storage_id.getNameForLogs());
-
-    /// record the applied policies so they show up in system.query_log, like a normal table read
-    if (context->hasQueryContext())
-        for (const auto & row_policy : row_policy_filter->policies)
-            context->getQueryContext()->addUsedRowPolicy(row_policy->getFullName().toString());
-
-    auto result = std::make_unique<MergeTreeProjectionRowPolicyFilter>();
-    result->required_columns = dag.getRequiredColumnsNames();
-    result->filter_column_name = std::move(filter_column_name);
-    result->dag = std::move(dag);
-    return result;
 }
 
 StorageSnapshotPtr

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -54,8 +54,7 @@ void StorageFromMergeTreeProjection::read(
     Names read_column_names = column_names;
     if (row_policy_filter && !row_policy_filter->isAlwaysTrue())
     {
-        /// an aggregate projection stores states built from many parent rows, so a per-row policy
-        /// cannot be enforced after aggregation - refuse rather than expose hidden rows in the state
+        /// aggregate projections fold many parent rows into one state, so a per-row policy can't be applied
         if (projection->type != ProjectionDescription::Type::Normal)
             throw Exception(ErrorCodes::ACCESS_DENIED,
                 "Cannot read from projection `{}` of table {} under a row policy: it is not a normal "
@@ -89,10 +88,8 @@ void StorageFromMergeTreeProjection::read(
                 projection->name, parent_storage_id.getNameForLogs());
         }
 
-        /// read the policy's columns even if the query didn't ask for them; refuse virtuals the projection
-        /// does not preserve (position-relative ones - it can reorder rows) or exposes under a
-        /// projection-only name absent on the parent (`_parent_part_offset`), since a parent policy binding
-        /// to those does not carry parent-row semantics
+        /// pull in the policy's columns; reject virtuals the projection reorders (position-relative) or
+        /// only exposes under a projection name absent on the parent (`_parent_part_offset`)
         static const NameSet not_row_preserving{
             "_part_offset", "_part_index", "_part_granule_offset", "_block_offset", "_block_number", "_parent_part_offset"};
         for (const auto & name : filter_info.actions.getRequiredColumnsNames())
@@ -106,9 +103,7 @@ void StorageFromMergeTreeProjection::read(
                 read_column_names.push_back(name);
         }
 
-        /// the planner may have already installed a filter for a policy on the table function itself
-        /// (`_table_function.*`); overwriting it would drop that restriction, so refuse rather than
-        /// silently apply only the parent policy
+        /// don't clobber a filter the planner already set for a policy on the table function (`_table_function.*`)
         if (query_info.row_level_filter)
             throw Exception(ErrorCodes::ACCESS_DENIED,
                 "Cannot read from projection `{}` of table {}: a row policy already applies to the table "

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -9,6 +9,7 @@
 #include <Processors/QueryPlan/ReadNothingStep.h>
 #include <Processors/Sources/NullSource.h>
 #include <Storages/MergeTree/MergeTreeDataSelectExecutor.h>
+#include <Storages/ProjectionsDescription.h>
 #include <Storages/SelectQueryInfo.h>
 
 #include <algorithm>
@@ -53,6 +54,14 @@ void StorageFromMergeTreeProjection::read(
     Names read_column_names = column_names;
     if (row_policy_filter && !row_policy_filter->isAlwaysTrue())
     {
+        /// an aggregate projection stores states built from many parent rows, so a per-row policy
+        /// cannot be enforced after aggregation - refuse rather than expose hidden rows in the state
+        if (projection->type != ProjectionDescription::Type::Normal)
+            throw Exception(ErrorCodes::ACCESS_DENIED,
+                "Cannot read from projection `{}` of table {} under a row policy: it is not a normal "
+                "projection, so the policy cannot be enforced before aggregation",
+                projection->name, parent_storage_id.getNameForLogs());
+
         /// the policy is on the parent table; enforce it here or the projection leaks hidden rows
         if (!query_info.planner_context || !query_info.table_expression)
             throw Exception(ErrorCodes::ACCESS_DENIED,
@@ -82,7 +91,7 @@ void StorageFromMergeTreeProjection::read(
 
         /// read the policy's columns even if the query didn't ask for them; refuse position-relative
         /// virtuals - the projection can reorder rows, so its value for them isn't the parent's
-        static const NameSet not_row_preserving{"_part_offset", "_part_index", "_part_granule_offset", "_block_offset"};
+        static const NameSet not_row_preserving{"_part_offset", "_part_index", "_part_granule_offset", "_block_offset", "_block_number"};
         for (const auto & name : filter_info.actions.getRequiredColumnsNames())
         {
             if (not_row_preserving.contains(name))

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -51,8 +51,10 @@ void StorageFromMergeTreeProjection::read(
     auto row_policy_filter = context->getRowPolicyFilter(
         parent_storage_id.getDatabaseName(), parent_storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
 
+    const bool has_row_policy = row_policy_filter && !row_policy_filter->isAlwaysTrue();
+
     Names read_column_names = column_names;
-    if (row_policy_filter && !row_policy_filter->isAlwaysTrue())
+    if (has_row_policy)
     {
         /// aggregate projections fold many parent rows into one state, so a per-row policy can't be applied
         if (projection->type != ProjectionDescription::Type::Normal)
@@ -123,6 +125,15 @@ void StorageFromMergeTreeProjection::read(
 
     const auto & snapshot_data = assert_cast<const MergeTreeData::SnapshotData &>(*storage_snapshot->data);
     const auto & parts = snapshot_data.parts;
+
+    /// on-the-fly data mutations and patch parts are applied to the parent read but not to the projection
+    /// (mutations_snapshot is cleared below), so under a policy the projection could show stale hidden rows
+    if (has_row_policy
+        && (snapshot_data.mutations_snapshot->hasDataMutations() || snapshot_data.mutations_snapshot->hasPatchParts()))
+        throw Exception(ErrorCodes::ACCESS_DENIED,
+            "Cannot read from projection `{}` of table {} under a row policy while it has unmaterialized "
+            "mutations, since the projection may show stale values the policy would hide",
+            projection->name, parent_storage_id.getNameForLogs());
 
     RangesInDataParts projection_parts;
     for (const auto & part : *parts)

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.h
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.h
@@ -6,6 +6,8 @@ namespace DB
 {
 
 class MergeTreeData;
+struct FilterDAGInfo;
+using FilterDAGInfoPtr = std::shared_ptr<FilterDAGInfo>;
 
 /// A Storage that allows reading from a projection of MergeTree.
 class StorageFromMergeTreeProjection final : public IStorage
@@ -31,6 +33,9 @@ public:
     StorageSnapshotPtr getStorageSnapshot(const StorageMetadataPtr & metadata_snapshot, ContextPtr query_context) const override;
 
 private:
+    /// build the parent table's row policy filter against the projection columns, or throw if it can't be enforced
+    FilterDAGInfoPtr buildRowPolicyFilter(const ContextPtr & context) const;
+
     StoragePtr parent_storage;
     const MergeTreeData & merge_tree;
     StorageMetadataPtr parent_metadata;

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.h
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.h
@@ -6,8 +6,7 @@ namespace DB
 {
 
 class MergeTreeData;
-struct FilterDAGInfo;
-using FilterDAGInfoPtr = std::shared_ptr<FilterDAGInfo>;
+struct MergeTreeProjectionRowPolicyFilter;
 
 /// A Storage that allows reading from a projection of MergeTree.
 class StorageFromMergeTreeProjection final : public IStorage
@@ -34,7 +33,7 @@ public:
 
 private:
     /// build the parent table's row policy filter against the projection columns, or throw if it can't be enforced
-    FilterDAGInfoPtr buildRowPolicyFilter(const ContextPtr & context) const;
+    std::unique_ptr<MergeTreeProjectionRowPolicyFilter> buildRowPolicyFilter(const ContextPtr & context) const;
 
     StoragePtr parent_storage;
     const MergeTreeData & merge_tree;

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.h
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.h
@@ -6,7 +6,6 @@ namespace DB
 {
 
 class MergeTreeData;
-struct MergeTreeProjectionRowPolicyFilter;
 
 /// A Storage that allows reading from a projection of MergeTree.
 class StorageFromMergeTreeProjection final : public IStorage
@@ -32,9 +31,6 @@ public:
     StorageSnapshotPtr getStorageSnapshot(const StorageMetadataPtr & metadata_snapshot, ContextPtr query_context) const override;
 
 private:
-    /// build the parent table's row policy filter against the projection columns, or throw if it can't be enforced
-    std::unique_ptr<MergeTreeProjectionRowPolicyFilter> buildRowPolicyFilter(const ContextPtr & context) const;
-
     StoragePtr parent_storage;
     const MergeTreeData & merge_tree;
     StorageMetadataPtr parent_metadata;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -1,0 +1,15 @@
+-- no policy: table function returns all rows
+Alice
+Bob
+Carol
+Dave
+-- base table honours the policy
+Alice
+Carol
+-- projection stores the policy column: filter is applied
+Alice
+Carol
+-- filter applied even when the policy column is selected explicitly
+Alice	engineering
+Carol	engineering
+-- projection lacks the policy column: read is refused

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -15,6 +15,9 @@ Carol	engineering
 -- projection lacks the policy column: read is refused
 -- policy on an ALIAS column is enforced via its physical dependency (expect a=3)
 3
+-- policy on a DEFAULT column filters the stored value, not b + 1 (expect 1, 2)
+1
+2
 -- user PREWHERE does not observe policy-hidden rows (expect 1, 3)
 1
 3

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -39,3 +39,6 @@ Carol	engineering
 3
 -- UDF-wrapped _part_offset policy is enforced with parent semantics (expect id=1)
 1
+-- LIMIT returns visible rows, not rows hidden by the policy (expect 1)
+1
+-- policy on a DEFAULT column with only its dependency stored: read is refused

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -13,3 +13,4 @@ Carol
 Alice	engineering
 Carol	engineering
 -- projection lacks the policy column: read is refused
+-- policy on an ALIAS column: read is refused

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -14,3 +14,6 @@ Alice	engineering
 Carol	engineering
 -- projection lacks the policy column: read is refused
 -- policy on an ALIAS column: read is refused
+-- user PREWHERE does not observe policy-hidden rows (expect 1, 3)
+1
+3

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -42,3 +42,4 @@ Carol	engineering
 -- LIMIT returns visible rows, not rows hidden by the policy (expect 1)
 1
 -- policy on a DEFAULT column with only its dependency stored: read is refused
+-- policy on a MATERIALIZED column with only its dependency stored: read is refused

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -43,3 +43,4 @@ Carol	engineering
 1
 -- policy on a DEFAULT column with only its dependency stored: read is refused
 -- policy on a MATERIALIZED column with only its dependency stored: read is refused
+-- policy on a column shadowed by a projection expression: read is refused

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -37,3 +37,5 @@ Carol	engineering
 -- policy on the _partition_id virtual is enforced (expect 1, 3)
 1
 3
+-- UDF-wrapped _part_offset policy is enforced with parent semantics (expect id=1)
+1

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -21,3 +21,13 @@ Carol	engineering
 -- policy on _part_offset enforced when the projection preserves the parent offset (expect id=1)
 1
 -- policy on _part_offset without a preserved parent offset: read is refused
+-- bare-column policy is enforced when the filter column is not selected (expect 1, 3)
+1
+3
+-- bare-column policy is enforced when the filter column is also selected (expect 1, 3)
+1	1
+3	1
+-- policy on global row index (_part_starting_offset + _part_offset < 3) enforced (expect 1, 2, 3)
+1
+2
+3

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -34,3 +34,6 @@ Carol	engineering
 1
 2
 3
+-- policy on the _partition_id virtual is enforced (expect 1, 3)
+1
+3

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -13,8 +13,11 @@ Carol
 Alice	engineering
 Carol	engineering
 -- projection lacks the policy column: read is refused
--- policy on an ALIAS column: read is refused
+-- policy on an ALIAS column is enforced via its physical dependency (expect a=3)
+3
 -- user PREWHERE does not observe policy-hidden rows (expect 1, 3)
 1
 3
--- policy on a virtual column: read is refused
+-- policy on _part_offset enforced when the projection preserves the parent offset (expect id=1)
+1
+-- policy on _part_offset without a preserved parent offset: read is refused

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -17,3 +17,4 @@ Carol	engineering
 -- user PREWHERE does not observe policy-hidden rows (expect 1, 3)
 1
 3
+-- policy on a virtual column: read is refused

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -37,3 +37,5 @@ Carol	engineering
 -- policy on a column shadowed by a projection expression: read is refused
 -- aggregate projection under a row policy: read is refused
 -- policy on the _block_number virtual: read is refused
+-- policy on the projection-only _parent_part_offset name: read is refused
+-- table-function row policy combined with a parent policy: read is refused

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -29,6 +29,9 @@ Carol	engineering
 1
 -- read-in-order + LIMIT skips the policy-hidden leading rows (expect 51)
 51
+-- row policy and additional_table_filters both apply (expect 1, 4)
+1
+4
 -- policy on an ALIAS column: read is refused
 -- policy on a DEFAULT column with only its dependency stored: read is refused
 -- policy on a MATERIALIZED column with only its dependency stored: read is refused

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -35,3 +35,5 @@ Carol	engineering
 -- policy on a position-relative virtual (_part_offset): read is refused
 -- same position-relative virtual wrapped in a SQL UDF: read is refused
 -- policy on a column shadowed by a projection expression: read is refused
+-- aggregate projection under a row policy: read is refused
+-- policy on the _block_number virtual: read is refused

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -42,3 +42,4 @@ Carol	engineering
 -- policy on the _block_number virtual: read is refused
 -- policy on the projection-only _parent_part_offset name: read is refused
 -- table-function row policy combined with a parent policy: read is refused
+-- pending on-the-fly mutation under a row policy: read is refused

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -27,6 +27,8 @@ Carol	engineering
 3
 -- LIMIT returns visible rows, not rows hidden by the policy (expect 1)
 1
+-- read-in-order + LIMIT skips the policy-hidden leading rows (expect 51)
+51
 -- policy on an ALIAS column: read is refused
 -- policy on a DEFAULT column with only its dependency stored: read is refused
 -- policy on a MATERIALIZED column with only its dependency stored: read is refused

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.reference
@@ -13,34 +13,23 @@ Carol
 Alice	engineering
 Carol	engineering
 -- projection lacks the policy column: read is refused
--- policy on an ALIAS column is enforced via its physical dependency (expect a=3)
+-- bare-column policy is enforced (expect 1, 3)
+1
 3
--- policy on a DEFAULT column filters the stored value, not b + 1 (expect 1, 2)
+-- policy on the _partition_id virtual is enforced (expect 1, 3)
+1
+3
+-- DEFAULT column stored: filtered on the stored value (expect 1, 2)
 1
 2
 -- user PREWHERE does not observe policy-hidden rows (expect 1, 3)
 1
 3
--- policy on _part_offset enforced when the projection preserves the parent offset (expect id=1)
-1
--- policy on _part_offset without a preserved parent offset: read is refused
--- bare-column policy is enforced when the filter column is not selected (expect 1, 3)
-1
-3
--- bare-column policy is enforced when the filter column is also selected (expect 1, 3)
-1	1
-3	1
--- policy on global row index (_part_starting_offset + _part_offset < 3) enforced (expect 1, 2, 3)
-1
-2
-3
--- policy on the _partition_id virtual is enforced (expect 1, 3)
-1
-3
--- UDF-wrapped _part_offset policy is enforced with parent semantics (expect id=1)
-1
 -- LIMIT returns visible rows, not rows hidden by the policy (expect 1)
 1
+-- policy on an ALIAS column: read is refused
 -- policy on a DEFAULT column with only its dependency stored: read is refused
 -- policy on a MATERIALIZED column with only its dependency stored: read is refused
+-- policy on a position-relative virtual (_part_offset): read is refused
+-- same position-relative virtual wrapped in a SQL UDF: read is refused
 -- policy on a column shadowed by a projection expression: read is refused

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -1,0 +1,38 @@
+-- Row policies are attached to the parent table, but the `mergeTreeProjection` table function used to
+-- read projection parts directly without applying them, leaking every row (clickhouse-private#53773).
+-- The read must honour the parent table's row policy: apply it when the projection stores every column
+-- the policy references, otherwise refuse the read.
+
+DROP TABLE IF EXISTS users_rls_proj;
+DROP ROW POLICY IF EXISTS rp_users_rls_proj ON users_rls_proj;
+
+CREATE TABLE users_rls_proj (id UInt64, name String, department String, salary UInt64)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO users_rls_proj VALUES (1, 'Alice', 'engineering', 100000), (2, 'Bob', 'finance', 120000), (3, 'Carol', 'engineering', 110000), (4, 'Dave', 'hr', 90000);
+
+-- proj_with_dept stores the policy column `department` (its ORDER BY key); proj_no_dept does not.
+ALTER TABLE users_rls_proj ADD PROJECTION proj_with_dept (SELECT id, name, salary ORDER BY department);
+ALTER TABLE users_rls_proj ADD PROJECTION proj_no_dept (SELECT id, name ORDER BY id);
+ALTER TABLE users_rls_proj MATERIALIZE PROJECTION proj_with_dept SETTINGS mutations_sync = 2;
+ALTER TABLE users_rls_proj MATERIALIZE PROJECTION proj_no_dept SETTINGS mutations_sync = 2;
+
+SELECT '-- no policy: table function returns all rows';
+SELECT name FROM mergeTreeProjection(currentDatabase(), 'users_rls_proj', 'proj_with_dept') ORDER BY name;
+
+CREATE ROW POLICY rp_users_rls_proj ON users_rls_proj FOR SELECT USING department = 'engineering' TO ALL;
+
+SELECT '-- base table honours the policy';
+SELECT name FROM users_rls_proj ORDER BY name;
+
+SELECT '-- projection stores the policy column: filter is applied';
+SELECT name FROM mergeTreeProjection(currentDatabase(), 'users_rls_proj', 'proj_with_dept') ORDER BY name;
+
+SELECT '-- filter applied even when the policy column is selected explicitly';
+SELECT name, department FROM mergeTreeProjection(currentDatabase(), 'users_rls_proj', 'proj_with_dept') ORDER BY name;
+
+SELECT '-- projection lacks the policy column: read is refused';
+SELECT name FROM mergeTreeProjection(currentDatabase(), 'users_rls_proj', 'proj_no_dept') ORDER BY name; -- { serverError ACCESS_DENIED }
+
+DROP ROW POLICY rp_users_rls_proj ON users_rls_proj;
+DROP TABLE users_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -113,3 +113,44 @@ SELECT id FROM mergeTreeProjection(currentDatabase(), 'virt_rls_proj', 'p') ORDE
 
 DROP ROW POLICY rp_virt_rls_proj ON virt_rls_proj;
 DROP TABLE virt_rls_proj;
+
+-- A bare-column policy (`USING flag`, where the predicate result is an existing column, not a new node).
+DROP TABLE IF EXISTS bare_rls_proj;
+DROP ROW POLICY IF EXISTS rp_bare_rls_proj ON bare_rls_proj;
+
+CREATE TABLE bare_rls_proj (id UInt64, visible UInt8) ENGINE = MergeTree ORDER BY id;
+INSERT INTO bare_rls_proj VALUES (1, 1), (2, 0), (3, 1);
+
+ALTER TABLE bare_rls_proj ADD PROJECTION p (SELECT id, visible ORDER BY id);
+ALTER TABLE bare_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_bare_rls_proj ON bare_rls_proj FOR SELECT USING visible TO ALL;
+
+SELECT '-- bare-column policy is enforced when the filter column is not selected (expect 1, 3)';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'bare_rls_proj', 'p') ORDER BY id;
+
+SELECT '-- bare-column policy is enforced when the filter column is also selected (expect 1, 3)';
+SELECT id, visible FROM mergeTreeProjection(currentDatabase(), 'bare_rls_proj', 'p') ORDER BY id;
+
+DROP ROW POLICY rp_bare_rls_proj ON bare_rls_proj;
+DROP TABLE bare_rls_proj;
+
+-- A policy on `_part_starting_offset + _part_offset` (the global row index) is enforced: the projection
+-- preserves both the parent offset and the part starting offset.
+DROP TABLE IF EXISTS pso_rls_proj;
+DROP ROW POLICY IF EXISTS rp_pso_rls_proj ON pso_rls_proj;
+
+CREATE TABLE pso_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO pso_rls_proj VALUES (1, 10), (2, 20);
+INSERT INTO pso_rls_proj VALUES (3, 30), (4, 40);
+
+ALTER TABLE pso_rls_proj ADD PROJECTION p (SELECT _part_offset, id, val ORDER BY val);
+ALTER TABLE pso_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_pso_rls_proj ON pso_rls_proj FOR SELECT USING _part_starting_offset + _part_offset < 3 TO ALL;
+
+SELECT '-- policy on global row index (_part_starting_offset + _part_offset < 3) enforced (expect 1, 2, 3)';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'pso_rls_proj', 'p') ORDER BY id;
+
+DROP ROW POLICY rp_pso_rls_proj ON pso_rls_proj;
+DROP TABLE pso_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -1,3 +1,5 @@
+-- Tags: no-parallel
+-- ^ the UDF case below creates a global SQL UDF (CREATE FUNCTION), which cannot run concurrently.
 -- Row policies are attached to the parent table, but the `mergeTreeProjection` table function used to
 -- read projection parts directly without applying them, leaking every row (clickhouse-private#53773).
 -- The read must honour the parent table's row policy: apply it when the projection stores every column
@@ -199,7 +201,7 @@ DROP TABLE pid_rls_proj;
 -- offset remap, so the parent offset semantics are preserved (reordered projection, expect id=1).
 DROP TABLE IF EXISTS udf_rls_proj;
 DROP ROW POLICY IF EXISTS rp_udf_rls_proj ON udf_rls_proj;
-DROP FUNCTION IF EXISTS rp_visible_{database};
+DROP FUNCTION IF EXISTS rp_visible_04368;
 
 CREATE TABLE udf_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
 INSERT INTO udf_rls_proj VALUES (1, 30), (2, 20), (3, 10);
@@ -207,12 +209,12 @@ INSERT INTO udf_rls_proj VALUES (1, 30), (2, 20), (3, 10);
 ALTER TABLE udf_rls_proj ADD PROJECTION p (SELECT _part_offset, id, val ORDER BY val);
 ALTER TABLE udf_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
 
-CREATE FUNCTION rp_visible_{database} AS (x) -> x < 1;
-CREATE ROW POLICY rp_udf_rls_proj ON udf_rls_proj FOR SELECT USING rp_visible_{database}(_part_offset) TO ALL;
+CREATE FUNCTION rp_visible_04368 AS (x) -> x < 1;
+CREATE ROW POLICY rp_udf_rls_proj ON udf_rls_proj FOR SELECT USING rp_visible_04368(_part_offset) TO ALL;
 
 SELECT '-- UDF-wrapped _part_offset policy is enforced with parent semantics (expect id=1)';
 SELECT id FROM mergeTreeProjection(currentDatabase(), 'udf_rls_proj', 'p') ORDER BY id;
 
 DROP ROW POLICY rp_udf_rls_proj ON udf_rls_proj;
-DROP FUNCTION rp_visible_{database};
+DROP FUNCTION rp_visible_04368;
 DROP TABLE udf_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -259,3 +259,23 @@ SELECT a FROM mergeTreeProjection(currentDatabase(), 'default_dep_rls_proj', 'p'
 
 DROP ROW POLICY rp_default_dep_rls_proj ON default_dep_rls_proj;
 DROP TABLE default_dep_rls_proj;
+
+-- Same for a MATERIALIZED column: although its value cannot be set explicitly, it is still stored and can
+-- diverge from the current expression (e.g. after ALTER MODIFY COLUMN, which does not re-materialize old
+-- parts). Reconstructing it from the stored dependency would filter the wrong value, so fail closed.
+DROP TABLE IF EXISTS materialized_dep_rls_proj;
+DROP ROW POLICY IF EXISTS rp_materialized_dep_rls_proj ON materialized_dep_rls_proj;
+
+CREATE TABLE materialized_dep_rls_proj (x UInt64, m UInt64 MATERIALIZED x + 1) ENGINE = MergeTree ORDER BY x;
+INSERT INTO materialized_dep_rls_proj (x) VALUES (1), (2), (3);
+
+ALTER TABLE materialized_dep_rls_proj ADD PROJECTION p (SELECT x ORDER BY x);
+ALTER TABLE materialized_dep_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_materialized_dep_rls_proj ON materialized_dep_rls_proj FOR SELECT USING m > 2 TO ALL;
+
+SELECT '-- policy on a MATERIALIZED column with only its dependency stored: read is refused';
+SELECT x FROM mergeTreeProjection(currentDatabase(), 'materialized_dep_rls_proj', 'p') ORDER BY x; -- { serverError ACCESS_DENIED }
+
+DROP ROW POLICY rp_materialized_dep_rls_proj ON materialized_dep_rls_proj;
+DROP TABLE materialized_dep_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -37,8 +37,8 @@ SELECT name FROM mergeTreeProjection(currentDatabase(), 'users_rls_proj', 'proj_
 DROP ROW POLICY rp_users_rls_proj ON users_rls_proj;
 DROP TABLE users_rls_proj;
 
--- A policy on an ALIAS column fails closed: the projection stores the alias's physical dependency
--- under a different name and does not expose the alias, so the policy cannot be evaluated here.
+-- A policy on an ALIAS column is enforced by expanding it to the physical dependency the projection
+-- stores (`c ALIAS b + 1` -> the filter reads `b`).
 DROP TABLE IF EXISTS alias_rls_proj;
 DROP ROW POLICY IF EXISTS rp_alias_rls_proj ON alias_rls_proj;
 
@@ -50,8 +50,8 @@ ALTER TABLE alias_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
 
 CREATE ROW POLICY rp_alias_rls_proj ON alias_rls_proj FOR SELECT USING c > 21 TO ALL;
 
-SELECT '-- policy on an ALIAS column: read is refused';
-SELECT a FROM mergeTreeProjection(currentDatabase(), 'alias_rls_proj', 'p') ORDER BY a; -- { serverError ACCESS_DENIED }
+SELECT '-- policy on an ALIAS column is enforced via its physical dependency (expect a=3)';
+SELECT a FROM mergeTreeProjection(currentDatabase(), 'alias_rls_proj', 'p') ORDER BY a;
 
 DROP ROW POLICY rp_alias_rls_proj ON alias_rls_proj;
 DROP TABLE alias_rls_proj;
@@ -76,8 +76,27 @@ PREWHERE throwIf(secret = 'private', 'row policy leak') = 0 ORDER BY id;
 DROP ROW POLICY rp_prewhere_rls_proj ON prewhere_rls_proj;
 DROP TABLE prewhere_rls_proj;
 
--- A policy on a virtual column fails closed: virtuals like `_part_offset` mean different rows on the
--- reordered projection, so they cannot be enforced there (a clean ACCESS_DENIED, not UNKNOWN_IDENTIFIER).
+-- A policy on `_part_offset` is enforced when the projection preserves the parent offset (it selects
+-- `_part_offset`, stored as `_parent_part_offset`), so parent-row semantics are kept.
+DROP TABLE IF EXISTS virt_ok_rls_proj;
+DROP ROW POLICY IF EXISTS rp_virt_ok_rls_proj ON virt_ok_rls_proj;
+
+CREATE TABLE virt_ok_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO virt_ok_rls_proj VALUES (1, 10), (2, 20), (3, 30);
+
+ALTER TABLE virt_ok_rls_proj ADD PROJECTION p (SELECT _part_offset, id, val ORDER BY val);
+ALTER TABLE virt_ok_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_virt_ok_rls_proj ON virt_ok_rls_proj FOR SELECT USING _part_offset < 1 TO ALL;
+
+SELECT '-- policy on _part_offset enforced when the projection preserves the parent offset (expect id=1)';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'virt_ok_rls_proj', 'p') ORDER BY id;
+
+DROP ROW POLICY rp_virt_ok_rls_proj ON virt_ok_rls_proj;
+DROP TABLE virt_ok_rls_proj;
+
+-- A policy on `_part_offset` fails closed when the projection does not preserve the parent offset:
+-- the projection's own offset means different rows, so it cannot be enforced (clean ACCESS_DENIED).
 DROP TABLE IF EXISTS virt_rls_proj;
 DROP ROW POLICY IF EXISTS rp_virt_rls_proj ON virt_rls_proj;
 
@@ -89,7 +108,7 @@ ALTER TABLE virt_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
 
 CREATE ROW POLICY rp_virt_rls_proj ON virt_rls_proj FOR SELECT USING _part_offset < 1 TO ALL;
 
-SELECT '-- policy on a virtual column: read is refused';
+SELECT '-- policy on _part_offset without a preserved parent offset: read is refused';
 SELECT id FROM mergeTreeProjection(currentDatabase(), 'virt_rls_proj', 'p') ORDER BY id; -- { serverError ACCESS_DENIED }
 
 DROP ROW POLICY rp_virt_rls_proj ON virt_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -175,3 +175,22 @@ SELECT id FROM mergeTreeProjection(currentDatabase(), 'pso_rls_proj', 'p') ORDER
 
 DROP ROW POLICY rp_pso_rls_proj ON pso_rls_proj;
 DROP TABLE pso_rls_proj;
+
+-- A policy on a part-identity virtual (`_partition_id`) is enforced: a projection part maps back to its
+-- parent part, so the virtual keeps parent-row semantics (unlike the projection-local `_part_offset`).
+DROP TABLE IF EXISTS pid_rls_proj;
+DROP ROW POLICY IF EXISTS rp_pid_rls_proj ON pid_rls_proj;
+
+CREATE TABLE pid_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree PARTITION BY (id % 2) ORDER BY id;
+INSERT INTO pid_rls_proj VALUES (1, 10), (2, 20), (3, 30), (4, 40);
+
+ALTER TABLE pid_rls_proj ADD PROJECTION p (SELECT id, val ORDER BY val);
+ALTER TABLE pid_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_pid_rls_proj ON pid_rls_proj FOR SELECT USING _partition_id = '1' TO ALL;
+
+SELECT '-- policy on the _partition_id virtual is enforced (expect 1, 3)';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'pid_rls_proj', 'p') ORDER BY id;
+
+DROP ROW POLICY rp_pid_rls_proj ON pid_rls_proj;
+DROP TABLE pid_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -218,3 +218,44 @@ SELECT id FROM mergeTreeProjection(currentDatabase(), 'udf_rls_proj', 'p') ORDER
 DROP ROW POLICY rp_udf_rls_proj ON udf_rls_proj;
 DROP FUNCTION rp_visible_04368;
 DROP TABLE udf_rls_proj;
+
+-- A LIMIT must not stop the read before the policy filters. The planner leaves trivial-LIMIT on (it checks
+-- this table function's own storage id, which has no policy), so hiding the first 50 rows and asking for 1
+-- must still return a visible row, not nothing.
+DROP TABLE IF EXISTS limit_rls_proj;
+DROP ROW POLICY IF EXISTS rp_limit_rls_proj ON limit_rls_proj;
+
+CREATE TABLE limit_rls_proj (id UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO limit_rls_proj SELECT number FROM numbers(1, 100);
+
+ALTER TABLE limit_rls_proj ADD PROJECTION p (SELECT id ORDER BY id);
+ALTER TABLE limit_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_limit_rls_proj ON limit_rls_proj FOR SELECT USING id > 50 TO ALL;
+
+SELECT '-- LIMIT returns visible rows, not rows hidden by the policy (expect 1)';
+SELECT count() FROM (SELECT id FROM mergeTreeProjection(currentDatabase(), 'limit_rls_proj', 'p') LIMIT 1);
+
+DROP ROW POLICY rp_limit_rls_proj ON limit_rls_proj;
+DROP TABLE limit_rls_proj;
+
+-- A policy on a DEFAULT column fails closed when the projection stores only the dependency, not the column:
+-- the stored value can differ from the default expression (explicit c = 5, not b + 1), so resolving `c` from
+-- `b` would filter the wrong value and could expose a hidden row. Enforcement needs the stored `c`.
+DROP TABLE IF EXISTS default_dep_rls_proj;
+DROP ROW POLICY IF EXISTS rp_default_dep_rls_proj ON default_dep_rls_proj;
+
+CREATE TABLE default_dep_rls_proj (a UInt64, b UInt64, c UInt64 DEFAULT b + 1) ENGINE = MergeTree ORDER BY a;
+INSERT INTO default_dep_rls_proj (a, b) VALUES (1, 10), (2, 20);
+INSERT INTO default_dep_rls_proj (a, b, c) VALUES (3, 30, 5);
+
+ALTER TABLE default_dep_rls_proj ADD PROJECTION p (SELECT a, b ORDER BY a);
+ALTER TABLE default_dep_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_default_dep_rls_proj ON default_dep_rls_proj FOR SELECT USING c > 20 TO ALL;
+
+SELECT '-- policy on a DEFAULT column with only its dependency stored: read is refused';
+SELECT a FROM mergeTreeProjection(currentDatabase(), 'default_dep_rls_proj', 'p') ORDER BY a; -- { serverError ACCESS_DENIED }
+
+DROP ROW POLICY rp_default_dep_rls_proj ON default_dep_rls_proj;
+DROP TABLE default_dep_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -194,3 +194,25 @@ SELECT id FROM mergeTreeProjection(currentDatabase(), 'pid_rls_proj', 'p') ORDER
 
 DROP ROW POLICY rp_pid_rls_proj ON pid_rls_proj;
 DROP TABLE pid_rls_proj;
+
+-- A policy that hides `_part_offset` inside a SQL UDF is still enforced: UDFs are expanded before the
+-- offset remap, so the parent offset semantics are preserved (reordered projection, expect id=1).
+DROP TABLE IF EXISTS udf_rls_proj;
+DROP ROW POLICY IF EXISTS rp_udf_rls_proj ON udf_rls_proj;
+DROP FUNCTION IF EXISTS rp_visible_04368;
+
+CREATE TABLE udf_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO udf_rls_proj VALUES (1, 30), (2, 20), (3, 10);
+
+ALTER TABLE udf_rls_proj ADD PROJECTION p (SELECT _part_offset, id, val ORDER BY val);
+ALTER TABLE udf_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE FUNCTION rp_visible_04368 AS (x) -> x < 1;
+CREATE ROW POLICY rp_udf_rls_proj ON udf_rls_proj FOR SELECT USING rp_visible_04368(_part_offset) TO ALL;
+
+SELECT '-- UDF-wrapped _part_offset policy is enforced with parent semantics (expect id=1)';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'udf_rls_proj', 'p') ORDER BY id;
+
+DROP ROW POLICY rp_udf_rls_proj ON udf_rls_proj;
+DROP FUNCTION rp_visible_04368;
+DROP TABLE udf_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -36,3 +36,22 @@ SELECT name FROM mergeTreeProjection(currentDatabase(), 'users_rls_proj', 'proj_
 
 DROP ROW POLICY rp_users_rls_proj ON users_rls_proj;
 DROP TABLE users_rls_proj;
+
+-- A policy on an ALIAS column fails closed: the projection stores the alias's physical dependency
+-- under a different name and does not expose the alias, so the policy cannot be evaluated here.
+DROP TABLE IF EXISTS alias_rls_proj;
+DROP ROW POLICY IF EXISTS rp_alias_rls_proj ON alias_rls_proj;
+
+CREATE TABLE alias_rls_proj (a UInt64, b UInt64, c UInt64 ALIAS b + 1) ENGINE = MergeTree ORDER BY a;
+INSERT INTO alias_rls_proj (a, b) VALUES (1, 10), (2, 20), (3, 30);
+
+ALTER TABLE alias_rls_proj ADD PROJECTION p (SELECT a, c ORDER BY a);
+ALTER TABLE alias_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_alias_rls_proj ON alias_rls_proj FOR SELECT USING c > 21 TO ALL;
+
+SELECT '-- policy on an ALIAS column: read is refused';
+SELECT a FROM mergeTreeProjection(currentDatabase(), 'alias_rls_proj', 'p') ORDER BY a; -- { serverError ACCESS_DENIED }
+
+DROP ROW POLICY rp_alias_rls_proj ON alias_rls_proj;
+DROP TABLE alias_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -75,3 +75,22 @@ PREWHERE throwIf(secret = 'private', 'row policy leak') = 0 ORDER BY id;
 
 DROP ROW POLICY rp_prewhere_rls_proj ON prewhere_rls_proj;
 DROP TABLE prewhere_rls_proj;
+
+-- A policy on a virtual column fails closed: virtuals like `_part_offset` mean different rows on the
+-- reordered projection, so they cannot be enforced there (a clean ACCESS_DENIED, not UNKNOWN_IDENTIFIER).
+DROP TABLE IF EXISTS virt_rls_proj;
+DROP ROW POLICY IF EXISTS rp_virt_rls_proj ON virt_rls_proj;
+
+CREATE TABLE virt_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO virt_rls_proj VALUES (1, 10), (2, 20), (3, 30);
+
+ALTER TABLE virt_rls_proj ADD PROJECTION p (SELECT id, val ORDER BY val);
+ALTER TABLE virt_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_virt_rls_proj ON virt_rls_proj FOR SELECT USING _part_offset < 1 TO ALL;
+
+SELECT '-- policy on a virtual column: read is refused';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'virt_rls_proj', 'p') ORDER BY id; -- { serverError ACCESS_DENIED }
+
+DROP ROW POLICY rp_virt_rls_proj ON virt_rls_proj;
+DROP TABLE virt_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -279,3 +279,23 @@ SELECT x FROM mergeTreeProjection(currentDatabase(), 'materialized_dep_rls_proj'
 
 DROP ROW POLICY rp_materialized_dep_rls_proj ON materialized_dep_rls_proj;
 DROP TABLE materialized_dep_rls_proj;
+
+-- A projection that binds a parent column name to a transformed expression does not expose that column
+-- under the parent name (only genuine parent columns are readable), so the policy cannot be evaluated on
+-- transformed data - it fails closed rather than filtering the wrong rows.
+DROP TABLE IF EXISTS shadow_rls_proj;
+DROP ROW POLICY IF EXISTS rp_shadow_rls_proj ON shadow_rls_proj;
+
+CREATE TABLE shadow_rls_proj (a UInt8, c UInt8) ENGINE = MergeTree ORDER BY a;
+INSERT INTO shadow_rls_proj VALUES (1, 0), (2, 1), (3, 0);
+
+ALTER TABLE shadow_rls_proj ADD PROJECTION p (SELECT a, (a = 1) AS c ORDER BY a);
+ALTER TABLE shadow_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_shadow_rls_proj ON shadow_rls_proj FOR SELECT USING c TO ALL;
+
+SELECT '-- policy on a column shadowed by a projection expression: read is refused';
+SELECT a FROM mergeTreeProjection(currentDatabase(), 'shadow_rls_proj', 'p') ORDER BY a; -- { serverError ACCESS_DENIED }
+
+DROP ROW POLICY rp_shadow_rls_proj ON shadow_rls_proj;
+DROP TABLE shadow_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -199,7 +199,7 @@ DROP TABLE pid_rls_proj;
 -- offset remap, so the parent offset semantics are preserved (reordered projection, expect id=1).
 DROP TABLE IF EXISTS udf_rls_proj;
 DROP ROW POLICY IF EXISTS rp_udf_rls_proj ON udf_rls_proj;
-DROP FUNCTION IF EXISTS rp_visible_04368;
+DROP FUNCTION IF EXISTS rp_visible_{database};
 
 CREATE TABLE udf_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
 INSERT INTO udf_rls_proj VALUES (1, 30), (2, 20), (3, 10);
@@ -207,12 +207,12 @@ INSERT INTO udf_rls_proj VALUES (1, 30), (2, 20), (3, 10);
 ALTER TABLE udf_rls_proj ADD PROJECTION p (SELECT _part_offset, id, val ORDER BY val);
 ALTER TABLE udf_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
 
-CREATE FUNCTION rp_visible_04368 AS (x) -> x < 1;
-CREATE ROW POLICY rp_udf_rls_proj ON udf_rls_proj FOR SELECT USING rp_visible_04368(_part_offset) TO ALL;
+CREATE FUNCTION rp_visible_{database} AS (x) -> x < 1;
+CREATE ROW POLICY rp_udf_rls_proj ON udf_rls_proj FOR SELECT USING rp_visible_{database}(_part_offset) TO ALL;
 
 SELECT '-- UDF-wrapped _part_offset policy is enforced with parent semantics (expect id=1)';
 SELECT id FROM mergeTreeProjection(currentDatabase(), 'udf_rls_proj', 'p') ORDER BY id;
 
 DROP ROW POLICY rp_udf_rls_proj ON udf_rls_proj;
-DROP FUNCTION rp_visible_04368;
+DROP FUNCTION rp_visible_{database};
 DROP TABLE udf_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -38,14 +38,15 @@ DROP ROW POLICY rp_users_rls_proj ON users_rls_proj;
 DROP TABLE users_rls_proj;
 
 -- A policy on an ALIAS column is enforced by expanding it to the physical dependency the projection
--- stores (`c ALIAS b + 1` -> the filter reads `b`).
+-- stores (`c ALIAS b + 1` -> the filter reads `b`). The projection selects `b`, not the alias itself
+-- (a projection cannot select an ALIAS column - it is not in the data block to materialize).
 DROP TABLE IF EXISTS alias_rls_proj;
 DROP ROW POLICY IF EXISTS rp_alias_rls_proj ON alias_rls_proj;
 
 CREATE TABLE alias_rls_proj (a UInt64, b UInt64, c UInt64 ALIAS b + 1) ENGINE = MergeTree ORDER BY a;
 INSERT INTO alias_rls_proj (a, b) VALUES (1, 10), (2, 20), (3, 30);
 
-ALTER TABLE alias_rls_proj ADD PROJECTION p (SELECT a, c ORDER BY a);
+ALTER TABLE alias_rls_proj ADD PROJECTION p (SELECT a, b ORDER BY a);
 ALTER TABLE alias_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
 
 CREATE ROW POLICY rp_alias_rls_proj ON alias_rls_proj FOR SELECT USING c > 21 TO ALL;
@@ -55,6 +56,26 @@ SELECT a FROM mergeTreeProjection(currentDatabase(), 'alias_rls_proj', 'p') ORDE
 
 DROP ROW POLICY rp_alias_rls_proj ON alias_rls_proj;
 DROP TABLE alias_rls_proj;
+
+-- A policy on a DEFAULT column uses the stored value, not the default expression: the projection stores
+-- the column, so an explicitly inserted value (c = 999, not b + 1) is filtered on directly.
+DROP TABLE IF EXISTS default_rls_proj;
+DROP ROW POLICY IF EXISTS rp_default_rls_proj ON default_rls_proj;
+
+CREATE TABLE default_rls_proj (a UInt64, b UInt64, c UInt64 DEFAULT b + 1) ENGINE = MergeTree ORDER BY a;
+INSERT INTO default_rls_proj (a, b) VALUES (1, 10), (2, 20);
+INSERT INTO default_rls_proj (a, b, c) VALUES (3, 30, 999);
+
+ALTER TABLE default_rls_proj ADD PROJECTION p (SELECT a, c ORDER BY a);
+ALTER TABLE default_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_default_rls_proj ON default_rls_proj FOR SELECT USING c < 100 TO ALL;
+
+SELECT '-- policy on a DEFAULT column filters the stored value, not b + 1 (expect 1, 2)';
+SELECT a FROM mergeTreeProjection(currentDatabase(), 'default_rls_proj', 'p') ORDER BY a;
+
+DROP ROW POLICY rp_default_rls_proj ON default_rls_proj;
+DROP TABLE default_rls_proj;
 
 -- A user PREWHERE must not observe rows the policy hides: the policy filter runs first, so throwIf
 -- never sees the hidden 'private' row.

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -55,3 +55,23 @@ SELECT a FROM mergeTreeProjection(currentDatabase(), 'alias_rls_proj', 'p') ORDE
 
 DROP ROW POLICY rp_alias_rls_proj ON alias_rls_proj;
 DROP TABLE alias_rls_proj;
+
+-- A user PREWHERE must not observe rows the policy hides: the policy filter runs first, so throwIf
+-- never sees the hidden 'private' row.
+DROP TABLE IF EXISTS prewhere_rls_proj;
+DROP ROW POLICY IF EXISTS rp_prewhere_rls_proj ON prewhere_rls_proj;
+
+CREATE TABLE prewhere_rls_proj (id UInt64, secret String, val UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO prewhere_rls_proj VALUES (1, 'public', 10), (2, 'private', 20), (3, 'public', 30);
+
+ALTER TABLE prewhere_rls_proj ADD PROJECTION p (SELECT id, secret, val ORDER BY secret);
+ALTER TABLE prewhere_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_prewhere_rls_proj ON prewhere_rls_proj FOR SELECT USING secret = 'public' TO ALL;
+
+SELECT '-- user PREWHERE does not observe policy-hidden rows (expect 1, 3)';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'prewhere_rls_proj', 'p')
+PREWHERE throwIf(secret = 'private', 'row policy leak') = 0 ORDER BY id;
+
+DROP ROW POLICY rp_prewhere_rls_proj ON prewhere_rls_proj;
+DROP TABLE prewhere_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -295,3 +295,44 @@ SELECT id FROM mergeTreeProjection(currentDatabase(), 'blocknum_rls_proj', 'p') 
 
 DROP ROW POLICY rp_blocknum_rls_proj ON blocknum_rls_proj;
 DROP TABLE blocknum_rls_proj;
+
+-- _parent_part_offset is a projection-only name absent on the parent, so a parent policy binding to it
+-- would diverge from the parent (where the read errors) - refused.
+DROP TABLE IF EXISTS pparent_rls_proj;
+DROP ROW POLICY IF EXISTS rp_pparent_rls_proj ON pparent_rls_proj;
+
+CREATE TABLE pparent_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO pparent_rls_proj VALUES (1, 10), (2, 20), (3, 30);
+
+ALTER TABLE pparent_rls_proj ADD PROJECTION p (SELECT _part_offset, id, val ORDER BY val);
+ALTER TABLE pparent_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_pparent_rls_proj ON pparent_rls_proj FOR SELECT USING _parent_part_offset = 0 TO ALL;
+
+SELECT '-- policy on the projection-only _parent_part_offset name: read is refused';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'pparent_rls_proj', 'p') ORDER BY id; -- { serverError ACCESS_DENIED }
+
+DROP ROW POLICY rp_pparent_rls_proj ON pparent_rls_proj;
+DROP TABLE pparent_rls_proj;
+
+-- A row policy on the table function itself (_table_function.*) must not be dropped by the parent policy;
+-- the two cannot be combined here, so the read is refused rather than losing the table-function restriction.
+DROP TABLE IF EXISTS tf_rls_proj;
+DROP ROW POLICY IF EXISTS rp_tf_rls_proj ON _table_function.*;
+DROP ROW POLICY IF EXISTS rp_tf_parent_rls_proj ON tf_rls_proj;
+
+CREATE TABLE tf_rls_proj (id UInt64, dept String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tf_rls_proj VALUES (1, 'eng'), (2, 'fin'), (3, 'eng');
+
+ALTER TABLE tf_rls_proj ADD PROJECTION p (SELECT id, dept ORDER BY dept);
+ALTER TABLE tf_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_tf_rls_proj ON _table_function.* FOR SELECT USING 0 TO ALL;
+CREATE ROW POLICY rp_tf_parent_rls_proj ON tf_rls_proj FOR SELECT USING dept = 'eng' TO ALL;
+
+SELECT '-- table-function row policy combined with a parent policy: read is refused';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'tf_rls_proj', 'p') ORDER BY id; -- { serverError ACCESS_DENIED }
+
+DROP ROW POLICY rp_tf_rls_proj ON _table_function.*;
+DROP ROW POLICY rp_tf_parent_rls_proj ON tf_rls_proj;
+DROP TABLE tf_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -151,6 +151,26 @@ SETTINGS optimize_read_in_order = 1;
 DROP ROW POLICY rp_order_limit_rls_proj ON order_limit_rls_proj;
 DROP TABLE order_limit_rls_proj;
 
+-- The row policy and an additional_table_filters entry must both apply, even when the filtered column is
+-- not selected (buildFilterInfo keeps the table-expression columns, so nothing is dropped mid-pipeline).
+DROP TABLE IF EXISTS addfilter_rls_proj;
+DROP ROW POLICY IF EXISTS rp_addfilter_rls_proj ON addfilter_rls_proj;
+
+CREATE TABLE addfilter_rls_proj (id UInt64, tenant String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO addfilter_rls_proj VALUES (1, 'a'), (2, 'x'), (3, 'y'), (4, 'a');
+
+ALTER TABLE addfilter_rls_proj ADD PROJECTION p (SELECT id, tenant ORDER BY tenant);
+ALTER TABLE addfilter_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_addfilter_rls_proj ON addfilter_rls_proj FOR SELECT USING tenant != 'x' TO ALL;
+
+SELECT '-- row policy and additional_table_filters both apply (expect 1, 4)';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'addfilter_rls_proj', 'p') AS p ORDER BY id
+SETTINGS additional_table_filters = {'p' : 'tenant != ''y'''};
+
+DROP ROW POLICY rp_addfilter_rls_proj ON addfilter_rls_proj;
+DROP TABLE addfilter_rls_proj;
+
 -- The remaining cases cannot be enforced against the projection, so the read is refused.
 
 -- ALIAS column: the projection stores the dependency `b`, not the alias `c`, and the analyzer resolves

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -1,19 +1,18 @@
 -- Tags: no-parallel
--- ^ the UDF case below creates a global SQL UDF (CREATE FUNCTION), which cannot run concurrently.
--- Row policies are attached to the parent table, but the `mergeTreeProjection` table function used to
--- read projection parts directly without applying them, leaking every row (clickhouse-private#53773).
--- The read must honour the parent table's row policy: apply it when the projection stores every column
--- the policy references, otherwise refuse the read.
+-- ^ the UDF case creates a global SQL UDF (CREATE FUNCTION), which cannot run concurrently.
+-- Row policies live on the parent table; mergeTreeProjection used to read projection parts without
+-- applying them (clickhouse-private#53773). The read now resolves the policy against the projection's
+-- own columns with the analyzer and refuses when it cannot be enforced there.
+
+SET enable_analyzer = 1;
 
 DROP TABLE IF EXISTS users_rls_proj;
 DROP ROW POLICY IF EXISTS rp_users_rls_proj ON users_rls_proj;
 
-CREATE TABLE users_rls_proj (id UInt64, name String, department String, salary UInt64)
-ENGINE = MergeTree ORDER BY id;
-
+CREATE TABLE users_rls_proj (id UInt64, name String, department String, salary UInt64) ENGINE = MergeTree ORDER BY id;
 INSERT INTO users_rls_proj VALUES (1, 'Alice', 'engineering', 100000), (2, 'Bob', 'finance', 120000), (3, 'Carol', 'engineering', 110000), (4, 'Dave', 'hr', 90000);
 
--- proj_with_dept stores the policy column `department` (its ORDER BY key); proj_no_dept does not.
+-- proj_with_dept stores the policy column `department`; proj_no_dept does not.
 ALTER TABLE users_rls_proj ADD PROJECTION proj_with_dept (SELECT id, name, salary ORDER BY department);
 ALTER TABLE users_rls_proj ADD PROJECTION proj_no_dept (SELECT id, name ORDER BY id);
 ALTER TABLE users_rls_proj MATERIALIZE PROJECTION proj_with_dept SETTINGS mutations_sync = 2;
@@ -39,28 +38,44 @@ SELECT name FROM mergeTreeProjection(currentDatabase(), 'users_rls_proj', 'proj_
 DROP ROW POLICY rp_users_rls_proj ON users_rls_proj;
 DROP TABLE users_rls_proj;
 
--- A policy on an ALIAS column is enforced by expanding it to the physical dependency the projection
--- stores (`c ALIAS b + 1` -> the filter reads `b`). The projection selects `b`, not the alias itself
--- (a projection cannot select an ALIAS column - it is not in the data block to materialize).
-DROP TABLE IF EXISTS alias_rls_proj;
-DROP ROW POLICY IF EXISTS rp_alias_rls_proj ON alias_rls_proj;
+-- A bare-column policy (`USING flag`).
+DROP TABLE IF EXISTS bare_rls_proj;
+DROP ROW POLICY IF EXISTS rp_bare_rls_proj ON bare_rls_proj;
 
-CREATE TABLE alias_rls_proj (a UInt64, b UInt64, c UInt64 ALIAS b + 1) ENGINE = MergeTree ORDER BY a;
-INSERT INTO alias_rls_proj (a, b) VALUES (1, 10), (2, 20), (3, 30);
+CREATE TABLE bare_rls_proj (id UInt64, visible UInt8) ENGINE = MergeTree ORDER BY id;
+INSERT INTO bare_rls_proj VALUES (1, 1), (2, 0), (3, 1);
 
-ALTER TABLE alias_rls_proj ADD PROJECTION p (SELECT a, b ORDER BY a);
-ALTER TABLE alias_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+ALTER TABLE bare_rls_proj ADD PROJECTION p (SELECT id, visible ORDER BY id);
+ALTER TABLE bare_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
 
-CREATE ROW POLICY rp_alias_rls_proj ON alias_rls_proj FOR SELECT USING c > 21 TO ALL;
+CREATE ROW POLICY rp_bare_rls_proj ON bare_rls_proj FOR SELECT USING visible TO ALL;
 
-SELECT '-- policy on an ALIAS column is enforced via its physical dependency (expect a=3)';
-SELECT a FROM mergeTreeProjection(currentDatabase(), 'alias_rls_proj', 'p') ORDER BY a;
+SELECT '-- bare-column policy is enforced (expect 1, 3)';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'bare_rls_proj', 'p') ORDER BY id;
 
-DROP ROW POLICY rp_alias_rls_proj ON alias_rls_proj;
-DROP TABLE alias_rls_proj;
+DROP ROW POLICY rp_bare_rls_proj ON bare_rls_proj;
+DROP TABLE bare_rls_proj;
 
--- A policy on a DEFAULT column uses the stored value, not the default expression: the projection stores
--- the column, so an explicitly inserted value (c = 999, not b + 1) is filtered on directly.
+-- A part-identity virtual (`_partition_id`) has the same value in the projection as in the parent.
+DROP TABLE IF EXISTS pid_rls_proj;
+DROP ROW POLICY IF EXISTS rp_pid_rls_proj ON pid_rls_proj;
+
+CREATE TABLE pid_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree PARTITION BY (id % 2) ORDER BY id;
+INSERT INTO pid_rls_proj VALUES (1, 10), (2, 20), (3, 30), (4, 40);
+
+ALTER TABLE pid_rls_proj ADD PROJECTION p (SELECT id, val ORDER BY val);
+ALTER TABLE pid_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_pid_rls_proj ON pid_rls_proj FOR SELECT USING _partition_id = '1' TO ALL;
+
+SELECT '-- policy on the _partition_id virtual is enforced (expect 1, 3)';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'pid_rls_proj', 'p') ORDER BY id;
+
+DROP ROW POLICY rp_pid_rls_proj ON pid_rls_proj;
+DROP TABLE pid_rls_proj;
+
+-- A DEFAULT column stored in the projection is filtered on its stored value, not the default expression
+-- (an explicitly inserted c = 999 stays hidden by `c < 100`).
 DROP TABLE IF EXISTS default_rls_proj;
 DROP ROW POLICY IF EXISTS rp_default_rls_proj ON default_rls_proj;
 
@@ -73,14 +88,13 @@ ALTER TABLE default_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 
 
 CREATE ROW POLICY rp_default_rls_proj ON default_rls_proj FOR SELECT USING c < 100 TO ALL;
 
-SELECT '-- policy on a DEFAULT column filters the stored value, not b + 1 (expect 1, 2)';
+SELECT '-- DEFAULT column stored: filtered on the stored value (expect 1, 2)';
 SELECT a FROM mergeTreeProjection(currentDatabase(), 'default_rls_proj', 'p') ORDER BY a;
 
 DROP ROW POLICY rp_default_rls_proj ON default_rls_proj;
 DROP TABLE default_rls_proj;
 
--- A user PREWHERE must not observe rows the policy hides: the policy filter runs first, so throwIf
--- never sees the hidden 'private' row.
+-- A user PREWHERE must not observe rows the policy hides: the policy filter runs first.
 DROP TABLE IF EXISTS prewhere_rls_proj;
 DROP ROW POLICY IF EXISTS rp_prewhere_rls_proj ON prewhere_rls_proj;
 
@@ -99,129 +113,7 @@ PREWHERE throwIf(secret = 'private', 'row policy leak') = 0 ORDER BY id;
 DROP ROW POLICY rp_prewhere_rls_proj ON prewhere_rls_proj;
 DROP TABLE prewhere_rls_proj;
 
--- A policy on `_part_offset` is enforced when the projection preserves the parent offset (it selects
--- `_part_offset`, stored as `_parent_part_offset`), so parent-row semantics are kept.
-DROP TABLE IF EXISTS virt_ok_rls_proj;
-DROP ROW POLICY IF EXISTS rp_virt_ok_rls_proj ON virt_ok_rls_proj;
-
-CREATE TABLE virt_ok_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
-INSERT INTO virt_ok_rls_proj VALUES (1, 10), (2, 20), (3, 30);
-
-ALTER TABLE virt_ok_rls_proj ADD PROJECTION p (SELECT _part_offset, id, val ORDER BY val);
-ALTER TABLE virt_ok_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
-
-CREATE ROW POLICY rp_virt_ok_rls_proj ON virt_ok_rls_proj FOR SELECT USING _part_offset < 1 TO ALL;
-
-SELECT '-- policy on _part_offset enforced when the projection preserves the parent offset (expect id=1)';
-SELECT id FROM mergeTreeProjection(currentDatabase(), 'virt_ok_rls_proj', 'p') ORDER BY id;
-
-DROP ROW POLICY rp_virt_ok_rls_proj ON virt_ok_rls_proj;
-DROP TABLE virt_ok_rls_proj;
-
--- A policy on `_part_offset` fails closed when the projection does not preserve the parent offset:
--- the projection's own offset means different rows, so it cannot be enforced (clean ACCESS_DENIED).
-DROP TABLE IF EXISTS virt_rls_proj;
-DROP ROW POLICY IF EXISTS rp_virt_rls_proj ON virt_rls_proj;
-
-CREATE TABLE virt_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
-INSERT INTO virt_rls_proj VALUES (1, 10), (2, 20), (3, 30);
-
-ALTER TABLE virt_rls_proj ADD PROJECTION p (SELECT id, val ORDER BY val);
-ALTER TABLE virt_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
-
-CREATE ROW POLICY rp_virt_rls_proj ON virt_rls_proj FOR SELECT USING _part_offset < 1 TO ALL;
-
-SELECT '-- policy on _part_offset without a preserved parent offset: read is refused';
-SELECT id FROM mergeTreeProjection(currentDatabase(), 'virt_rls_proj', 'p') ORDER BY id; -- { serverError ACCESS_DENIED }
-
-DROP ROW POLICY rp_virt_rls_proj ON virt_rls_proj;
-DROP TABLE virt_rls_proj;
-
--- A bare-column policy (`USING flag`, where the predicate result is an existing column, not a new node).
-DROP TABLE IF EXISTS bare_rls_proj;
-DROP ROW POLICY IF EXISTS rp_bare_rls_proj ON bare_rls_proj;
-
-CREATE TABLE bare_rls_proj (id UInt64, visible UInt8) ENGINE = MergeTree ORDER BY id;
-INSERT INTO bare_rls_proj VALUES (1, 1), (2, 0), (3, 1);
-
-ALTER TABLE bare_rls_proj ADD PROJECTION p (SELECT id, visible ORDER BY id);
-ALTER TABLE bare_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
-
-CREATE ROW POLICY rp_bare_rls_proj ON bare_rls_proj FOR SELECT USING visible TO ALL;
-
-SELECT '-- bare-column policy is enforced when the filter column is not selected (expect 1, 3)';
-SELECT id FROM mergeTreeProjection(currentDatabase(), 'bare_rls_proj', 'p') ORDER BY id;
-
-SELECT '-- bare-column policy is enforced when the filter column is also selected (expect 1, 3)';
-SELECT id, visible FROM mergeTreeProjection(currentDatabase(), 'bare_rls_proj', 'p') ORDER BY id;
-
-DROP ROW POLICY rp_bare_rls_proj ON bare_rls_proj;
-DROP TABLE bare_rls_proj;
-
--- A policy on `_part_starting_offset + _part_offset` (the global row index) is enforced: the projection
--- preserves both the parent offset and the part starting offset.
-DROP TABLE IF EXISTS pso_rls_proj;
-DROP ROW POLICY IF EXISTS rp_pso_rls_proj ON pso_rls_proj;
-
-CREATE TABLE pso_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
-INSERT INTO pso_rls_proj VALUES (1, 10), (2, 20);
-INSERT INTO pso_rls_proj VALUES (3, 30), (4, 40);
-
-ALTER TABLE pso_rls_proj ADD PROJECTION p (SELECT _part_offset, id, val ORDER BY val);
-ALTER TABLE pso_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
-
-CREATE ROW POLICY rp_pso_rls_proj ON pso_rls_proj FOR SELECT USING _part_starting_offset + _part_offset < 3 TO ALL;
-
-SELECT '-- policy on global row index (_part_starting_offset + _part_offset < 3) enforced (expect 1, 2, 3)';
-SELECT id FROM mergeTreeProjection(currentDatabase(), 'pso_rls_proj', 'p') ORDER BY id;
-
-DROP ROW POLICY rp_pso_rls_proj ON pso_rls_proj;
-DROP TABLE pso_rls_proj;
-
--- A policy on a part-identity virtual (`_partition_id`) is enforced: a projection part maps back to its
--- parent part, so the virtual keeps parent-row semantics (unlike the projection-local `_part_offset`).
-DROP TABLE IF EXISTS pid_rls_proj;
-DROP ROW POLICY IF EXISTS rp_pid_rls_proj ON pid_rls_proj;
-
-CREATE TABLE pid_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree PARTITION BY (id % 2) ORDER BY id;
-INSERT INTO pid_rls_proj VALUES (1, 10), (2, 20), (3, 30), (4, 40);
-
-ALTER TABLE pid_rls_proj ADD PROJECTION p (SELECT id, val ORDER BY val);
-ALTER TABLE pid_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
-
-CREATE ROW POLICY rp_pid_rls_proj ON pid_rls_proj FOR SELECT USING _partition_id = '1' TO ALL;
-
-SELECT '-- policy on the _partition_id virtual is enforced (expect 1, 3)';
-SELECT id FROM mergeTreeProjection(currentDatabase(), 'pid_rls_proj', 'p') ORDER BY id;
-
-DROP ROW POLICY rp_pid_rls_proj ON pid_rls_proj;
-DROP TABLE pid_rls_proj;
-
--- A policy that hides `_part_offset` inside a SQL UDF is still enforced: UDFs are expanded before the
--- offset remap, so the parent offset semantics are preserved (reordered projection, expect id=1).
-DROP TABLE IF EXISTS udf_rls_proj;
-DROP ROW POLICY IF EXISTS rp_udf_rls_proj ON udf_rls_proj;
-DROP FUNCTION IF EXISTS rp_visible_04368;
-
-CREATE TABLE udf_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
-INSERT INTO udf_rls_proj VALUES (1, 30), (2, 20), (3, 10);
-
-ALTER TABLE udf_rls_proj ADD PROJECTION p (SELECT _part_offset, id, val ORDER BY val);
-ALTER TABLE udf_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
-
-CREATE FUNCTION rp_visible_04368 AS (x) -> x < 1;
-CREATE ROW POLICY rp_udf_rls_proj ON udf_rls_proj FOR SELECT USING rp_visible_04368(_part_offset) TO ALL;
-
-SELECT '-- UDF-wrapped _part_offset policy is enforced with parent semantics (expect id=1)';
-SELECT id FROM mergeTreeProjection(currentDatabase(), 'udf_rls_proj', 'p') ORDER BY id;
-
-DROP ROW POLICY rp_udf_rls_proj ON udf_rls_proj;
-DROP FUNCTION rp_visible_04368;
-DROP TABLE udf_rls_proj;
-
--- A LIMIT must not stop the read before the policy filters. The planner leaves trivial-LIMIT on (it checks
--- this table function's own storage id, which has no policy), so hiding the first 50 rows and asking for 1
--- must still return a visible row, not nothing.
+-- A LIMIT must not stop the read before the policy filters (hiding the first 50 rows, asking for 1).
 DROP TABLE IF EXISTS limit_rls_proj;
 DROP ROW POLICY IF EXISTS rp_limit_rls_proj ON limit_rls_proj;
 
@@ -239,9 +131,29 @@ SELECT count() FROM (SELECT id FROM mergeTreeProjection(currentDatabase(), 'limi
 DROP ROW POLICY rp_limit_rls_proj ON limit_rls_proj;
 DROP TABLE limit_rls_proj;
 
--- A policy on a DEFAULT column fails closed when the projection stores only the dependency, not the column:
--- the stored value can differ from the default expression (explicit c = 5, not b + 1), so resolving `c` from
--- `b` would filter the wrong value and could expose a hidden row. Enforcement needs the stored `c`.
+-- The remaining cases cannot be enforced against the projection, so the read is refused.
+
+-- ALIAS column: the projection stores the dependency `b`, not the alias `c`, and the analyzer resolves
+-- the policy against the projection, where `c` is unknown.
+DROP TABLE IF EXISTS alias_rls_proj;
+DROP ROW POLICY IF EXISTS rp_alias_rls_proj ON alias_rls_proj;
+
+CREATE TABLE alias_rls_proj (a UInt64, b UInt64, c UInt64 ALIAS b + 1) ENGINE = MergeTree ORDER BY a;
+INSERT INTO alias_rls_proj (a, b) VALUES (1, 10), (2, 20), (3, 30);
+
+ALTER TABLE alias_rls_proj ADD PROJECTION p (SELECT a, b ORDER BY a);
+ALTER TABLE alias_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_alias_rls_proj ON alias_rls_proj FOR SELECT USING c > 21 TO ALL;
+
+SELECT '-- policy on an ALIAS column: read is refused';
+SELECT a FROM mergeTreeProjection(currentDatabase(), 'alias_rls_proj', 'p') ORDER BY a; -- { serverError ACCESS_DENIED }
+
+DROP ROW POLICY rp_alias_rls_proj ON alias_rls_proj;
+DROP TABLE alias_rls_proj;
+
+-- DEFAULT column with only its dependency stored: the stored value can differ from `b + 1`
+-- (an explicit c = 5), so it cannot be reconstructed from `b` - refused.
 DROP TABLE IF EXISTS default_dep_rls_proj;
 DROP ROW POLICY IF EXISTS rp_default_dep_rls_proj ON default_dep_rls_proj;
 
@@ -260,9 +172,8 @@ SELECT a FROM mergeTreeProjection(currentDatabase(), 'default_dep_rls_proj', 'p'
 DROP ROW POLICY rp_default_dep_rls_proj ON default_dep_rls_proj;
 DROP TABLE default_dep_rls_proj;
 
--- Same for a MATERIALIZED column: although its value cannot be set explicitly, it is still stored and can
--- diverge from the current expression (e.g. after ALTER MODIFY COLUMN, which does not re-materialize old
--- parts). Reconstructing it from the stored dependency would filter the wrong value, so fail closed.
+-- MATERIALIZED column with only its dependency stored: the stored value can diverge from the current
+-- expression (e.g. after ALTER MODIFY, which does not re-materialize old parts) - refused.
 DROP TABLE IF EXISTS materialized_dep_rls_proj;
 DROP ROW POLICY IF EXISTS rp_materialized_dep_rls_proj ON materialized_dep_rls_proj;
 
@@ -280,9 +191,36 @@ SELECT x FROM mergeTreeProjection(currentDatabase(), 'materialized_dep_rls_proj'
 DROP ROW POLICY rp_materialized_dep_rls_proj ON materialized_dep_rls_proj;
 DROP TABLE materialized_dep_rls_proj;
 
--- A projection that binds a parent column name to a transformed expression does not expose that column
--- under the parent name (only genuine parent columns are readable), so the policy cannot be evaluated on
--- transformed data - it fails closed rather than filtering the wrong rows.
+-- A position-relative virtual (`_part_offset`): the projection can reorder rows, so its value is not the
+-- parent's - refused, both directly and when hidden inside a SQL UDF.
+DROP TABLE IF EXISTS virt_rls_proj;
+DROP ROW POLICY IF EXISTS rp_virt_rls_proj ON virt_rls_proj;
+DROP FUNCTION IF EXISTS rp_visible_04368;
+
+CREATE TABLE virt_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO virt_rls_proj VALUES (1, 30), (2, 20), (3, 10);
+
+ALTER TABLE virt_rls_proj ADD PROJECTION p (SELECT _part_offset, id, val ORDER BY val);
+ALTER TABLE virt_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_virt_rls_proj ON virt_rls_proj FOR SELECT USING _part_offset < 1 TO ALL;
+
+SELECT '-- policy on a position-relative virtual (_part_offset): read is refused';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'virt_rls_proj', 'p') ORDER BY id; -- { serverError ACCESS_DENIED }
+
+CREATE FUNCTION rp_visible_04368 AS (x) -> x < 1;
+DROP ROW POLICY rp_virt_rls_proj ON virt_rls_proj;
+CREATE ROW POLICY rp_virt_rls_proj ON virt_rls_proj FOR SELECT USING rp_visible_04368(_part_offset) TO ALL;
+
+SELECT '-- same position-relative virtual wrapped in a SQL UDF: read is refused';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'virt_rls_proj', 'p') ORDER BY id; -- { serverError ACCESS_DENIED }
+
+DROP ROW POLICY rp_virt_rls_proj ON virt_rls_proj;
+DROP FUNCTION rp_visible_04368;
+DROP TABLE virt_rls_proj;
+
+-- A projection expression bound to a parent column name is not exposed under that name, so the policy
+-- cannot resolve it - refused (never filters on the transformed value).
 DROP TABLE IF EXISTS shadow_rls_proj;
 DROP ROW POLICY IF EXISTS rp_shadow_rls_proj ON shadow_rls_proj;
 

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -1,8 +1,7 @@
 -- Tags: no-parallel
 -- ^ the UDF case creates a global SQL UDF (CREATE FUNCTION), which cannot run concurrently.
--- Row policies live on the parent table; mergeTreeProjection used to read projection parts without
--- applying them (clickhouse-private#53773). The read now resolves the policy against the projection's
--- own columns with the analyzer and refuses when it cannot be enforced there.
+-- mergeTreeProjection used to ignore the parent table's row policy (clickhouse-private#53773). It now
+-- resolves the policy against the projection with the analyzer and refuses when it can't be enforced.
 
 SET enable_analyzer = 1;
 
@@ -74,8 +73,7 @@ SELECT id FROM mergeTreeProjection(currentDatabase(), 'pid_rls_proj', 'p') ORDER
 DROP ROW POLICY rp_pid_rls_proj ON pid_rls_proj;
 DROP TABLE pid_rls_proj;
 
--- A DEFAULT column stored in the projection is filtered on its stored value, not the default expression
--- (an explicitly inserted c = 999 stays hidden by `c < 100`).
+-- DEFAULT column stored in the projection: filtered on the stored value, not `b + 1` (c = 999 stays hidden).
 DROP TABLE IF EXISTS default_rls_proj;
 DROP ROW POLICY IF EXISTS rp_default_rls_proj ON default_rls_proj;
 
@@ -131,8 +129,7 @@ SELECT count() FROM (SELECT id FROM mergeTreeProjection(currentDatabase(), 'limi
 DROP ROW POLICY rp_limit_rls_proj ON limit_rls_proj;
 DROP TABLE limit_rls_proj;
 
--- ORDER BY the projection sort key + LIMIT (read-in-order): the in-order limit is a soft output limit,
--- so the read must skip the hidden leading rows and return the first visible one (expect 51, not empty).
+-- read-in-order + LIMIT: the in-order limit is soft, so hidden leading rows are skipped (expect 51, not empty).
 DROP TABLE IF EXISTS order_limit_rls_proj;
 DROP ROW POLICY IF EXISTS rp_order_limit_rls_proj ON order_limit_rls_proj;
 
@@ -151,8 +148,7 @@ SETTINGS optimize_read_in_order = 1;
 DROP ROW POLICY rp_order_limit_rls_proj ON order_limit_rls_proj;
 DROP TABLE order_limit_rls_proj;
 
--- The row policy and an additional_table_filters entry must both apply, even when the filtered column is
--- not selected (buildFilterInfo keeps the table-expression columns, so nothing is dropped mid-pipeline).
+-- row policy and additional_table_filters must both apply, even when the filtered column is not selected.
 DROP TABLE IF EXISTS addfilter_rls_proj;
 DROP ROW POLICY IF EXISTS rp_addfilter_rls_proj ON addfilter_rls_proj;
 
@@ -173,8 +169,7 @@ DROP TABLE addfilter_rls_proj;
 
 -- The remaining cases cannot be enforced against the projection, so the read is refused.
 
--- ALIAS column: the projection stores the dependency `b`, not the alias `c`, and the analyzer resolves
--- the policy against the projection, where `c` is unknown.
+-- ALIAS column: the projection stores `b`, not the alias `c`, so `c` is unknown when resolved there.
 DROP TABLE IF EXISTS alias_rls_proj;
 DROP ROW POLICY IF EXISTS rp_alias_rls_proj ON alias_rls_proj;
 
@@ -192,8 +187,7 @@ SELECT a FROM mergeTreeProjection(currentDatabase(), 'alias_rls_proj', 'p') ORDE
 DROP ROW POLICY rp_alias_rls_proj ON alias_rls_proj;
 DROP TABLE alias_rls_proj;
 
--- DEFAULT column with only its dependency stored: the stored value can differ from `b + 1`
--- (an explicit c = 5), so it cannot be reconstructed from `b` - refused.
+-- DEFAULT column, only its dependency stored: the stored value can differ from `b + 1`, so can't rebuild it.
 DROP TABLE IF EXISTS default_dep_rls_proj;
 DROP ROW POLICY IF EXISTS rp_default_dep_rls_proj ON default_dep_rls_proj;
 
@@ -212,8 +206,7 @@ SELECT a FROM mergeTreeProjection(currentDatabase(), 'default_dep_rls_proj', 'p'
 DROP ROW POLICY rp_default_dep_rls_proj ON default_dep_rls_proj;
 DROP TABLE default_dep_rls_proj;
 
--- MATERIALIZED column with only its dependency stored: the stored value can diverge from the current
--- expression (e.g. after ALTER MODIFY, which does not re-materialize old parts) - refused.
+-- MATERIALIZED column, only its dependency stored: stored value can diverge (e.g. after ALTER MODIFY).
 DROP TABLE IF EXISTS materialized_dep_rls_proj;
 DROP ROW POLICY IF EXISTS rp_materialized_dep_rls_proj ON materialized_dep_rls_proj;
 
@@ -231,8 +224,7 @@ SELECT x FROM mergeTreeProjection(currentDatabase(), 'materialized_dep_rls_proj'
 DROP ROW POLICY rp_materialized_dep_rls_proj ON materialized_dep_rls_proj;
 DROP TABLE materialized_dep_rls_proj;
 
--- A position-relative virtual (`_part_offset`): the projection can reorder rows, so its value is not the
--- parent's - refused, both directly and when hidden inside a SQL UDF.
+-- `_part_offset`: the projection reorders rows, so its value isn't the parent's - refused, direct and via UDF.
 DROP TABLE IF EXISTS virt_rls_proj;
 DROP ROW POLICY IF EXISTS rp_virt_rls_proj ON virt_rls_proj;
 DROP FUNCTION IF EXISTS rp_visible_04368;
@@ -259,8 +251,7 @@ DROP ROW POLICY rp_virt_rls_proj ON virt_rls_proj;
 DROP FUNCTION rp_visible_04368;
 DROP TABLE virt_rls_proj;
 
--- A projection expression bound to a parent column name is not exposed under that name, so the policy
--- cannot resolve it - refused (never filters on the transformed value).
+-- a projection expression bound to a parent column name isn't exposed under that name, so it can't resolve.
 DROP TABLE IF EXISTS shadow_rls_proj;
 DROP ROW POLICY IF EXISTS rp_shadow_rls_proj ON shadow_rls_proj;
 
@@ -278,8 +269,7 @@ SELECT a FROM mergeTreeProjection(currentDatabase(), 'shadow_rls_proj', 'p') ORD
 DROP ROW POLICY rp_shadow_rls_proj ON shadow_rls_proj;
 DROP TABLE shadow_rls_proj;
 
--- An aggregate projection stores states built from many parent rows, so a per-row policy cannot be
--- enforced after aggregation - refused, even when the policy only touches the GROUP BY key.
+-- aggregate projection: a per-row policy can't be enforced after aggregation, even on the GROUP BY key.
 DROP TABLE IF EXISTS agg_rls_proj;
 DROP ROW POLICY IF EXISTS rp_agg_rls_proj ON agg_rls_proj;
 
@@ -297,8 +287,7 @@ SELECT key FROM mergeTreeProjection(currentDatabase(), 'agg_rls_proj', 'p'); -- 
 DROP ROW POLICY rp_agg_rls_proj ON agg_rls_proj;
 DROP TABLE agg_rls_proj;
 
--- The _block_number virtual is not preserved by the projection (synthesized from the parent part), so
--- a policy on it cannot be enforced - refused.
+-- `_block_number` isn't preserved by the projection (synthesized from the parent part), so it can't be enforced.
 DROP TABLE IF EXISTS blocknum_rls_proj;
 DROP ROW POLICY IF EXISTS rp_blocknum_rls_proj ON blocknum_rls_proj;
 
@@ -316,8 +305,7 @@ SELECT id FROM mergeTreeProjection(currentDatabase(), 'blocknum_rls_proj', 'p') 
 DROP ROW POLICY rp_blocknum_rls_proj ON blocknum_rls_proj;
 DROP TABLE blocknum_rls_proj;
 
--- _parent_part_offset is a projection-only name absent on the parent, so a parent policy binding to it
--- would diverge from the parent (where the read errors) - refused.
+-- `_parent_part_offset` is a projection-only name absent on the parent, so a policy on it can't be enforced.
 DROP TABLE IF EXISTS pparent_rls_proj;
 DROP ROW POLICY IF EXISTS rp_pparent_rls_proj ON pparent_rls_proj;
 
@@ -335,8 +323,7 @@ SELECT id FROM mergeTreeProjection(currentDatabase(), 'pparent_rls_proj', 'p') O
 DROP ROW POLICY rp_pparent_rls_proj ON pparent_rls_proj;
 DROP TABLE pparent_rls_proj;
 
--- A row policy on the table function itself (_table_function.*) must not be dropped by the parent policy;
--- the two cannot be combined here, so the read is refused rather than losing the table-function restriction.
+-- a policy on the table function itself (_table_function.*) must not be dropped; can't combine, so refuse.
 DROP TABLE IF EXISTS tf_rls_proj;
 DROP ROW POLICY IF EXISTS rp_tf_rls_proj ON _table_function.*;
 DROP ROW POLICY IF EXISTS rp_tf_parent_rls_proj ON tf_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -257,3 +257,41 @@ SELECT a FROM mergeTreeProjection(currentDatabase(), 'shadow_rls_proj', 'p') ORD
 
 DROP ROW POLICY rp_shadow_rls_proj ON shadow_rls_proj;
 DROP TABLE shadow_rls_proj;
+
+-- An aggregate projection stores states built from many parent rows, so a per-row policy cannot be
+-- enforced after aggregation - refused, even when the policy only touches the GROUP BY key.
+DROP TABLE IF EXISTS agg_rls_proj;
+DROP ROW POLICY IF EXISTS rp_agg_rls_proj ON agg_rls_proj;
+
+CREATE TABLE agg_rls_proj (key UInt64, value UInt64) ENGINE = MergeTree ORDER BY key;
+INSERT INTO agg_rls_proj VALUES (1, 10), (1, 20), (2, 30);
+
+ALTER TABLE agg_rls_proj ADD PROJECTION p (SELECT key, sum(value) GROUP BY key);
+ALTER TABLE agg_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_agg_rls_proj ON agg_rls_proj FOR SELECT USING key = 1 TO ALL;
+
+SELECT '-- aggregate projection under a row policy: read is refused';
+SELECT key FROM mergeTreeProjection(currentDatabase(), 'agg_rls_proj', 'p'); -- { serverError ACCESS_DENIED }
+
+DROP ROW POLICY rp_agg_rls_proj ON agg_rls_proj;
+DROP TABLE agg_rls_proj;
+
+-- The _block_number virtual is not preserved by the projection (synthesized from the parent part), so
+-- a policy on it cannot be enforced - refused.
+DROP TABLE IF EXISTS blocknum_rls_proj;
+DROP ROW POLICY IF EXISTS rp_blocknum_rls_proj ON blocknum_rls_proj;
+
+CREATE TABLE blocknum_rls_proj (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO blocknum_rls_proj VALUES (1, 10), (2, 20), (3, 30);
+
+ALTER TABLE blocknum_rls_proj ADD PROJECTION p (SELECT id, val ORDER BY val);
+ALTER TABLE blocknum_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_blocknum_rls_proj ON blocknum_rls_proj FOR SELECT USING _block_number = 1 TO ALL;
+
+SELECT '-- policy on the _block_number virtual: read is refused';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'blocknum_rls_proj', 'p') ORDER BY id; -- { serverError ACCESS_DENIED }
+
+DROP ROW POLICY rp_blocknum_rls_proj ON blocknum_rls_proj;
+DROP TABLE blocknum_rls_proj;

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -131,6 +131,26 @@ SELECT count() FROM (SELECT id FROM mergeTreeProjection(currentDatabase(), 'limi
 DROP ROW POLICY rp_limit_rls_proj ON limit_rls_proj;
 DROP TABLE limit_rls_proj;
 
+-- ORDER BY the projection sort key + LIMIT (read-in-order): the in-order limit is a soft output limit,
+-- so the read must skip the hidden leading rows and return the first visible one (expect 51, not empty).
+DROP TABLE IF EXISTS order_limit_rls_proj;
+DROP ROW POLICY IF EXISTS rp_order_limit_rls_proj ON order_limit_rls_proj;
+
+CREATE TABLE order_limit_rls_proj (id UInt64, visible UInt8) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 2;
+INSERT INTO order_limit_rls_proj SELECT number + 1, number >= 50 FROM numbers(200);
+
+ALTER TABLE order_limit_rls_proj ADD PROJECTION p (SELECT id, visible ORDER BY id);
+ALTER TABLE order_limit_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+CREATE ROW POLICY rp_order_limit_rls_proj ON order_limit_rls_proj FOR SELECT USING visible TO ALL;
+
+SELECT '-- read-in-order + LIMIT skips the policy-hidden leading rows (expect 51)';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'order_limit_rls_proj', 'p') ORDER BY id LIMIT 1
+SETTINGS optimize_read_in_order = 1;
+
+DROP ROW POLICY rp_order_limit_rls_proj ON order_limit_rls_proj;
+DROP TABLE order_limit_rls_proj;
+
 -- The remaining cases cannot be enforced against the projection, so the read is refused.
 
 -- ALIAS column: the projection stores the dependency `b`, not the alias `c`, and the analyzer resolves

--- a/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
+++ b/tests/queries/0_stateless/04368_mergetree_projection_table_function_row_policy.sql
@@ -343,3 +343,26 @@ SELECT id FROM mergeTreeProjection(currentDatabase(), 'tf_rls_proj', 'p') ORDER 
 DROP ROW POLICY rp_tf_rls_proj ON _table_function.*;
 DROP ROW POLICY rp_tf_parent_rls_proj ON tf_rls_proj;
 DROP TABLE tf_rls_proj;
+
+-- an on-the-fly mutation applies to the parent read but not the projection, so the projection is stale - refused.
+DROP TABLE IF EXISTS onfly_rls_proj;
+DROP ROW POLICY IF EXISTS rp_onfly_rls_proj ON onfly_rls_proj;
+
+CREATE TABLE onfly_rls_proj (id UInt64, visible UInt8) ENGINE = MergeTree ORDER BY id;
+INSERT INTO onfly_rls_proj VALUES (1, 1), (2, 1), (3, 1);
+
+ALTER TABLE onfly_rls_proj ADD PROJECTION p (SELECT id, visible ORDER BY id);
+ALTER TABLE onfly_rls_proj MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2;
+
+SYSTEM STOP MERGES onfly_rls_proj;
+ALTER TABLE onfly_rls_proj UPDATE visible = 0 WHERE id = 1 SETTINGS mutations_sync = 0;
+
+CREATE ROW POLICY rp_onfly_rls_proj ON onfly_rls_proj FOR SELECT USING visible TO ALL;
+
+SELECT '-- pending on-the-fly mutation under a row policy: read is refused';
+SELECT id FROM mergeTreeProjection(currentDatabase(), 'onfly_rls_proj', 'p') ORDER BY id
+SETTINGS apply_mutations_on_fly = 1; -- { serverError ACCESS_DENIED }
+
+DROP ROW POLICY rp_onfly_rls_proj ON onfly_rls_proj;
+SYSTEM START MERGES onfly_rls_proj;
+DROP TABLE onfly_rls_proj;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes cases where row policy was not used for MergeTree Projections during query execution.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.4.52`, `26.6.3.53`, `26.5.8.3`, `26.3.20.7`, `25.8.34.10`
<!-- ch-version-info:end -->