### PR TITLE
Carry enable_lazy_columns_replication in the serialized ArrayJoin step

### DIFF
--- a/src/Processors/QueryPlan/ArrayJoinStep.cpp
+++ b/src/Processors/QueryPlan/ArrayJoinStep.cpp
@@ -14,7 +14,6 @@ namespace DB
 namespace QueryPlanSerializationSetting
 {
     extern const QueryPlanSerializationSettingsUInt64 max_block_size;
-    extern const QueryPlanSerializationSettingsBool enable_lazy_columns_replication;
 }
 
 static ITransformingStep::Traits getTraits()
@@ -100,6 +99,11 @@ void ArrayJoinStep::serialize(Serialization & ctx) const
         flags |= 1;
     if (is_unaligned)
         flags |= 2;
+    /// Carried here rather than through serializeSettings: a step's settings object only ever holds
+    /// the names that same step writes, and readers that predate this bit ignore it and keep doing
+    /// eager replication, which is the correct fallback for a performance-only flag.
+    if (enable_lazy_columns_replication)
+        flags |= 4;
 
     writeIntBinary(flags, ctx.out);
 
@@ -120,6 +124,7 @@ QueryPlanStepPtr ArrayJoinStep::deserialize(Deserialization & ctx)
 
     bool is_left = bool(flags & 1);
     bool is_unaligned = bool(flags & 2);
+    bool enable_lazy_columns_replication = bool(flags & 4);
 
     UInt64 num_columns = 0;
     readVarUInt(num_columns, ctx.in);
@@ -136,7 +141,7 @@ QueryPlanStepPtr ArrayJoinStep::deserialize(Deserialization & ctx)
         std::move(array_join),
         is_unaligned,
         ctx.settings[QueryPlanSerializationSetting::max_block_size],
-        ctx.settings[QueryPlanSerializationSetting::enable_lazy_columns_replication]);
+        enable_lazy_columns_replication);
 }
 
 void registerArrayJoinStep(QueryPlanStepRegistry & registry);

--- a/src/Processors/QueryPlan/tests/gtest_array_join_step_serialization_roundtrip.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_array_join_step_serialization_roundtrip.cpp
@@ -1,0 +1,158 @@
+#include <gtest/gtest.h>
+
+#include <Core/Block.h>
+#include <Core/ProtocolDefines.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/VarInt.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/SetSerialization.h>
+#include <Processors/QueryPlan/ArrayJoinStep.h>
+#include <Processors/QueryPlan/QueryPlanSerializationSettings.h>
+#include <Processors/QueryPlan/Serialization.h>
+#include <Common/tests/gtest_global_context.h>
+
+using namespace DB;
+
+namespace
+{
+
+/// A header with one Array(UInt64) column, which is the only shape ArrayJoinStep accepts:
+/// its constructor runs ArrayJoinAction::prepare, which throws TYPE_MISMATCH for non-Array/Map.
+SharedHeader makeHeader()
+{
+    auto type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>());
+    return std::make_shared<const Block>(Block({ColumnWithTypeAndName(type->createColumn(), type, "arr")}));
+}
+
+/// Serialize a step through the production path and return its byte stream.
+String serializeStep(const IQueryPlanStep & step)
+{
+    WriteBufferFromOwnString out;
+    SerializedSetsRegistry registry;
+    IQueryPlanStep::Serialization ctx{out, registry};
+    ctx.version = DBMS_QUERY_PLAN_SERIALIZATION_VERSION;
+    step.serialize(ctx);
+    return out.str();
+}
+
+/// Deserialize a byte stream through the production path.
+///
+/// The QueryPlanSerializationSettings object is left at its DECLARE defaults on purpose: that is
+/// what QueryPlan::deserialize hands each step (it builds a fresh object per step and fills it only
+/// from the names that step's serializeSettings wrote). Since ArrayJoinStep::serializeSettings
+/// writes only max_block_size, a defaulted settings object is itself part of the assertion.
+QueryPlanStepPtr deserializeStep(const String & bytes, const SharedHeader & header)
+{
+    ReadBufferFromString in(bytes);
+    DeserializedSetsRegistry registry;
+    QueryPlanSerializationSettings settings;
+    SharedHeaders input_headers{header};
+    ContextPtr context = getContext().context;
+
+    IQueryPlanStep::Deserialization ctx{
+        in, registry, {}, context, input_headers, header, settings, 0, DBMS_QUERY_PLAN_SERIALIZATION_VERSION, false};
+
+    return ArrayJoinStep::deserialize(ctx);
+}
+
+struct RoundTrip
+{
+    String first;   /// bytes written by the original step
+    String second;  /// bytes written by re-serializing the restored step
+};
+
+/// serialize -> deserialize -> serialize.
+///
+/// enable_lazy_columns_replication is private and deliberately has no getter, so the restored
+/// step's value is observed by serializing it again: the second stream can carry the flag bit only
+/// if the restored member is true. That also pins the whole wire format, not just one accessor.
+RoundTrip roundTrip(bool is_left, bool is_unaligned, bool enable_lazy_columns_replication)
+{
+    auto header = makeHeader();
+    ArrayJoinStep step(
+        header,
+        ArrayJoin{Names{"arr"}, is_left},
+        is_unaligned,
+        /*max_block_size_=*/65536,
+        enable_lazy_columns_replication);
+
+    String first = serializeStep(step);
+    auto restored = deserializeStep(first, header);
+    return {first, serializeStep(*restored)};
+}
+
+UInt8 flagsByte(const String & bytes)
+{
+    return static_cast<UInt8>(bytes.at(0));
+}
+
+}
+
+/// Regression test for enable_lazy_columns_replication being lost when a query plan is serialized.
+///
+/// ArrayJoinStep::deserialize used to take the value from the per-step
+/// QueryPlanSerializationSettings object, which ArrayJoinStep::serializeSettings never populates,
+/// so a deserialized ArrayJoinStep always fell back to the plan DECLARE default (false) and the
+/// executing node did eager column replication no matter what the initiator ran with. The value now
+/// travels in the step's own flags byte.
+TEST(ArrayJoinStepSerializationRoundTrip, LazyColumnsReplicationTrueSurvives)
+{
+    auto result = roundTrip(/*is_left=*/false, /*is_unaligned=*/false, /*enable_lazy_columns_replication=*/true);
+
+    EXPECT_EQ(flagsByte(result.first) & 4, 4);
+    EXPECT_EQ(result.first, result.second);
+}
+
+TEST(ArrayJoinStepSerializationRoundTrip, LazyColumnsReplicationFalseSurvives)
+{
+    auto result = roundTrip(/*is_left=*/false, /*is_unaligned=*/false, /*enable_lazy_columns_replication=*/false);
+
+    EXPECT_EQ(flagsByte(result.first) & 4, 0);
+    EXPECT_EQ(result.first, result.second);
+}
+
+/// The new bit must collide with neither of the two bits already in the byte.
+TEST(ArrayJoinStepSerializationRoundTrip, FlagsBitsAreIndependent)
+{
+    for (bool is_left : {false, true})
+    {
+        for (bool is_unaligned : {false, true})
+        {
+            for (bool lazy : {false, true})
+            {
+                auto result = roundTrip(is_left, is_unaligned, lazy);
+                const UInt8 expected = static_cast<UInt8>((is_left ? 1 : 0) + (is_unaligned ? 2 : 0) + (lazy ? 4 : 0));
+
+                EXPECT_EQ(flagsByte(result.first), expected)
+                    << "is_left=" << is_left << " is_unaligned=" << is_unaligned << " lazy=" << lazy;
+                EXPECT_EQ(result.first, result.second)
+                    << "is_left=" << is_left << " is_unaligned=" << is_unaligned << " lazy=" << lazy;
+            }
+        }
+    }
+}
+
+/// Backward compatibility: a plan written by a server that predates the flag bit has bit 4 clear.
+/// Such a stream must still deserialize, and must yield eager replication (false), which is exactly
+/// what those servers do. This pins the graceful-degradation contract the whole approach rests on.
+TEST(ArrayJoinStepSerializationRoundTrip, OldFormatByteWithoutBit4YieldsFalse)
+{
+    auto header = makeHeader();
+
+    for (UInt8 old_flags : {UInt8(0), UInt8(1), UInt8(2), UInt8(3)})
+    {
+        /// The exact byte stream a pre-flag initiator emits: flags, then the column count, then the
+        /// column names.
+        WriteBufferFromOwnString out;
+        writeIntBinary(old_flags, out);
+        writeVarUInt(1, out);
+        writeStringBinary(String("arr"), out);
+
+        auto restored = deserializeStep(out.str(), header);
+        EXPECT_EQ(flagsByte(serializeStep(*restored)) & 4, 0) << "old_flags=" << static_cast<int>(old_flags);
+    }
+}

--- a/src/Processors/QueryPlan/tests/gtest_array_join_step_serialization_roundtrip.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_array_join_step_serialization_roundtrip.cpp
@@ -1,8 +1,12 @@
 #include <gtest/gtest.h>
 
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnsNumber.h>
 #include <Core/Block.h>
 #include <Core/ProtocolDefines.h>
 #include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/VarInt.h>
@@ -10,10 +14,20 @@
 #include <IO/WriteHelpers.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/SetSerialization.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Processors/QueryPlan/ArrayJoinStep.h>
+#include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
+#include <Processors/QueryPlan/ITransformingStep.h>
 #include <Processors/QueryPlan/QueryPlanSerializationSettings.h>
 #include <Processors/QueryPlan/Serialization.h>
+#include <Processors/Sources/SourceFromSingleChunk.h>
+#include <QueryPipeline/Pipe.h>
+#include <QueryPipeline/QueryPipeline.h>
+#include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Common/ThreadStatus.h>
+#include <Common/assert_cast.h>
 #include <Common/tests/gtest_global_context.h>
+#include <Common/tests/gtest_global_register.h>
 
 using namespace DB;
 
@@ -90,6 +104,71 @@ UInt8 flagsByte(const String & bytes)
     return static_cast<UInt8>(bytes.at(0));
 }
 
+/// The ARRAY JOIN column `arr` plus a non-array `payload` column, which is the one lazy replication
+/// can apply to (`arr` itself goes through the array-unnesting branch and is never replicated).
+///
+/// payload must be String. isLazyReplicationUseful declines any column that is fixed and contiguous
+/// with a value size <= 8, which is exactly what ColumnVector reports, so a numeric payload would
+/// take the eager branch in BOTH directions and the assertion below would be vacuous.
+SharedHeader makeExecutionHeader()
+{
+    auto arr_type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>());
+    auto payload_type = std::make_shared<DataTypeString>();
+    return std::make_shared<const Block>(Block{
+        ColumnWithTypeAndName(arr_type->createColumn(), arr_type, "arr"),
+        ColumnWithTypeAndName(payload_type->createColumn(), payload_type, "payload")});
+}
+
+/// Two rows whose arrays hold several elements each, so replication really expands `payload`.
+Chunk makeExecutionChunk(const Block & header)
+{
+    auto arr_column = header.getByName("arr").type->createColumn();
+    arr_column->insert(Array{UInt64(10), UInt64(11), UInt64(12)});
+    arr_column->insert(Array{UInt64(20), UInt64(21)});
+
+    auto payload_column = header.getByName("payload").type->createColumn();
+    payload_column->insert("first payload value");
+    payload_column->insert("second payload value");
+
+    return Chunk(Columns{std::move(arr_column), std::move(payload_column)}, 2);
+}
+
+/// Round-trip a step through the wire, then actually run the restored step and return what it
+/// produced. The object under test is deliberately the DESERIALIZED step, because the whole point is
+/// what the node executing a remote plan fragment does.
+Block roundTripAndExecute(bool enable_lazy_columns_replication, const ContextPtr & context)
+{
+    auto header = makeExecutionHeader();
+
+    ArrayJoinStep step(
+        header,
+        ArrayJoin{Names{"arr"}, /*is_left=*/false},
+        /*is_unaligned_=*/false,
+        /*max_block_size_=*/65536,
+        enable_lazy_columns_replication);
+
+    auto restored = deserializeStep(serializeStep(step), header);
+
+    QueryPipelineBuilder builder;
+    builder.init(Pipe(std::make_shared<SourceFromSingleChunk>(header, makeExecutionChunk(*header))));
+
+    BuildQueryPipelineSettings settings(context);
+    /// assert_cast compares typeid exactly, so the concrete type is the only thing it accepts here;
+    /// that also pins that the registry gave back an ArrayJoinStep.
+    assert_cast<ArrayJoinStep &>(*restored).transformPipeline(builder, settings);
+
+    auto pipeline = QueryPipelineBuilder::getPipeline(std::move(builder));
+    PullingPipelineExecutor executor(pipeline);
+
+    Block block;
+    while (executor.pull(block))
+    {
+        if (block.rows() != 0)
+            return block;
+    }
+    return block;
+}
+
 }
 
 /// Regression test for enable_lazy_columns_replication being lost when a query plan is serialized.
@@ -155,4 +234,44 @@ TEST(ArrayJoinStepSerializationRoundTrip, OldFormatByteWithoutBit4YieldsFalse)
         auto restored = deserializeStep(out.str(), header);
         EXPECT_EQ(flagsByte(serializeStep(*restored)) & 4, 0) << "old_flags=" << static_cast<int>(old_flags);
     }
+}
+
+/// The user-visible half of the contract: a deserialized step must actually replicate lazily.
+///
+/// The assertions above all inspect bytes, so they would stay green if the restored value stopped
+/// reaching ArrayJoinAction (for example if ArrayJoinStep::transformPipeline passed a literal false).
+/// This case runs the restored step and looks at the column it produced, so it is the one that fails
+/// in that situation.
+///
+/// Both arms must return identical data: the flag selects a column representation, never a result.
+TEST(ArrayJoinStepSerializationRoundTrip, DeserializedStepPerformsLazyReplication)
+{
+    MainThreadStatus::getInstance();
+    tryRegisterFunctions();
+
+    auto context = Context::createCopy(getContext().context);
+
+    Block lazy_block = roundTripAndExecute(/*enable_lazy_columns_replication=*/true, context);
+    Block eager_block = roundTripAndExecute(/*enable_lazy_columns_replication=*/false, context);
+
+    const auto & lazy_payload = lazy_block.getByName("payload").column;
+    const auto & eager_payload = eager_block.getByName("payload").column;
+
+    EXPECT_TRUE(lazy_payload->isReplicated());
+    EXPECT_FALSE(eager_payload->isReplicated());
+
+    /// 3 + 2 array elements, so the ARRAY JOIN produces 5 rows and each payload value repeats.
+    ASSERT_EQ(lazy_block.rows(), 5u);
+    ASSERT_EQ(eager_block.rows(), 5u);
+
+    auto lazy_payload_full = lazy_payload->convertToFullColumnIfReplicated();
+    ASSERT_EQ(lazy_payload_full->size(), eager_payload->size());
+    for (size_t row = 0; row < eager_payload->size(); ++row)
+        EXPECT_EQ((*lazy_payload_full)[row], (*eager_payload)[row]) << "row=" << row;
+
+    /// The ARRAY JOIN column itself is unnested, not replicated, in either direction.
+    EXPECT_FALSE(lazy_block.getByName("arr").column->isReplicated());
+    EXPECT_FALSE(eager_block.getByName("arr").column->isReplicated());
+    for (size_t row = 0; row < eager_block.rows(); ++row)
+        EXPECT_EQ((*lazy_block.getByName("arr").column)[row], (*eager_block.getByName("arr").column)[row]) << "row=" << row;
 }


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/112079
Related: https://github.com/ClickHouse/ClickHouse/pull/112131
-->


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Lazy column replication for `ARRAY JOIN` is no longer lost when a query plan is serialized. With `serialize_query_plan = 1`, the node executing a remote plan fragment used to ignore `enable_lazy_columns_replication` and always materialize every replicated copy, even though the setting defaults to enabled.


### Description

Related: #112079
Related: #112131

`ArrayJoinStep::deserialize` took `enable_lazy_columns_replication` from the per-step `QueryPlanSerializationSettings` object, but `ArrayJoinStep::serializeSettings` writes only `max_block_size`, so nothing ever put that name into an `ArrayJoinStep`'s settings block.

`QueryPlan::serialize` builds a **fresh** `QueryPlanSerializationSettings` for every step, calls that step's `serializeSettings`, then `writeChangedBinary`, which emits only the names the step assigned; on the other side `readBinary` leaves absent names at their `DECLARE` default. So a write performed by one step can never supply a read performed by another, and the only tree-wide writer of this name is `JoinSettings::updatePlanSettings`, reached only from `JoinStepLogical`. A deserialized `ArrayJoinStep` therefore always got the plan `DECLARE` default.

The defaults disagree, so this fires on an untouched configuration:

| | plan `DECLARE` default | core `Settings` default |
|---|---|---|
| `enable_lazy_columns_replication` | `false` (`QueryPlanSerializationSettings.cpp:111`) | `true` (`Settings.cpp:6551`) |

Effect: on a remote fragment of a serialized plan, `ArrayJoinAction` took the eager `replicate()` branch and copied every non-array column for each expanded row, instead of building a `ColumnReplicated`. Rows are identical either way, so this is lost memory and CPU savings, not a wrong result. It restores an optimization that already shipped, on a path that lost it; it does not introduce a new one.

The read was added in #88752, which introduced lazy replication and left `serializeSettings` untouched.

#### Why the flags byte and not the settings block

I carry the value in the step's existing `flags` byte (bit `4`) and drop the settings read, rather than adding the missing `serializeSettings` write.

Adding the write would newly emit a setting *name* that 25.8 does not declare, and `BaseSettings::readBinary` throws `UNKNOWN_SETTING` on an unknown name. A bare `ARRAY JOIN` plan works against 25.8 today, because `ReadFromMergeTree` and `ExpressionStep` write no plan settings at all and `max_block_size` (which 25.8 does declare) is the only name such a plan currently emits. So the settings channel would turn a working shape into a hard error.

Version-gating the settings write is not possible: `serializeSettings` receives no version, and the settings block is written before the `Serialization` context exists. `serialize` does get `ctx.version`.

The flags byte degrades gracefully instead. Measured over `master 26.7 26.6 26.5 26.4 26.3 26.2 26.1 25.8`: no branch uses bit `4`, and no branch validates the byte (no `flags != 0`, `flags & ~`, `CORRUPTED_DATA` or `INCORRECT_DATA` check), so every older reader ignores the bit and keeps doing eager replication, which is what it does today. A post-fix reader seeing a pre-fix plan finds the bit clear and also does eager replication; the initiator's real value is unknowable there and the conservative branch is the right fallback for a performance-only flag. No plan-version bump is needed, so no older peer starts rejecting plans wholesale.

No stream desynchronization is possible: `serialize` writes flags, then the column count, then the column names, and no byte is conditioned on a flag bit. This also matches the file's own convention, since the value already in that byte, `is_unaligned`, is likewise a per-step boolean derived from a core setting.

The sibling PR #112131 fixes the same class of defect for `serialize_string_in_memory_with_zero_byte` and correctly uses the **settings** channel: that setting changes the aggregation-key byte layout, so silently falling back is not acceptable, and every branch that has the read also declares the name. Different channel, for a different reason.

#### Completeness

I swept every file under `src/` that references `QueryPlanSerializationSetting` and classified each occurrence as a write or a read within that same file, since a cross-step write cannot help. Removing this read leaves `ArrayJoinStep.cpp` reading exactly the one plan setting it writes; the two remaining asymmetries (`AggregatingStep`, `MergingAggregatedStep`) are what #112131 fixes.

All `ArrayJoinStep` construction sites already pass the setting (`InterpreterSelectQuery.cpp:1979`, `PlannerJoinTree.cpp:2519`) and `clone()` copies the member; no optimizer pass rebuilds the step. Both plan transports and the distributed-plan executor funnel through `QueryPlan::serialize`, so the one bit covers all of them, and `LocalConnection` force-disables `serialize_query_plan`.

#### Test

A gtest, because nothing observable from SQL distinguishes the two branches. The representation is not surfaced by any function (`useDefaultImplementationForReplicatedColumns` defaults to true and no `src/` function overrides it to false, so a function either receives the unwrapped column or runs on the nested data and re-wraps the result), not by `EXPLAIN`, and there is no `ProfileEvent` for lazy replication. Both branches emit identical rows, so no `.sql`/`.reference` pair can tell them apart, and a peak-memory or timing assertion would be non-deterministic.

`gtest_array_join_step_serialization_roundtrip.cpp` round-trips through the real `serialize`/`deserialize` and observes the restored step by **re-serializing** it, so no getter is added and the whole wire format is pinned. Four cases cover the wire contract: the flag surviving in both directions, all eight combinations of the three flag bits (so the new bit collides with neither existing one), and an old-format byte with bit `4` clear still deserializing to eager replication, which is the graceful-degradation contract this approach rests on. A fifth case covers the user-visible effect: it hands the deserialized step to `transformPipeline`, drains the pipeline through a `PullingPipelineExecutor`, and asserts the non-array column comes back replicated with the flag set and materialized without it, with element-wise identical rows either way.

Three of the five cases fail on unmodified master and all five pass with the change. Each line is load-bearing: deleting `flags |= 4` and, separately, reading bit `8` instead of bit `4` in `deserialize` each fail the same three cases, and constructing `ArrayJoinAction` with a literal `false` in `transformPipeline`, which leaves the wire format untouched, fails only the fifth case.

#### Merge-order note: bit `4` is also claimed by #98868

The open #98868 assigns the same bit `4` of this same byte to `array_join_use_nulls`, and additionally bumps `DBMS_QUERY_PLAN_SERIALIZATION_VERSION` to 4. Bit `4` is free on `master` today, so both PRs are individually correct against it, but if both land unchanged the two booleans alias. Whichever lands second should move to bit `8`, which is unused on `master` and on every one of `26.7 26.6 26.5 26.4 26.3 26.2 26.1 25.8`; I am happy to be the one to move. The two new gtests have different filenames, so there is no test collision.

#### Three things worth flagging

This **activates** lazy `ARRAY JOIN` replication on the deserialized-plan path for the first time. `enable_lazy_columns_replication` is randomized per CI run and `serialize_query_plan = 1` is profile-wide in the distributed-plan flavour, so the `Stateless tests (*, distributed plan, *)` jobs will start exercising `ColumnReplicated` on remote fragments where they previously always took the eager branch. That surface has produced real bugs before (#109897, #110627, #109424), so newly-surfaced failures are possible; they would be unmasked by this change rather than caused by it.

Bit `4` enters `calculateHashFromStep`, which hashes `serialize()` output for hash-table-stats cache keys, so two plans differing only in this flag stop sharing a stats entry. That cache is for cardinality estimation and both branches emit identical rows, so ideally they would share it: this is a small unavoidable pessimisation, bounded to one cold estimate since the cache is per-server-run. It does not change the carrier choice, because a hard `UNKNOWN_SETTING` break against 25.8 is far worse.

One adjacent gap I deliberately leave alone: the `ExpressionActions` `ARRAY JOIN` path reads the flag from `ExpressionActionsSettings`, built from the executing node's query context. An explicitly set value does reach it, since per-query settings are sent before the plan packet and applied to the receiving context. Only an *unset* value diverges, and only across a mixed-version cluster whose defaults differ, because `Settings::write` emits changed settings only. It is a property of every `ExpressionStep` setting (`ExpressionStep` serializes no settings at all), and closing it is a design question about `ExpressionStep` and `BuildQueryPipelineSettings`.

No `SettingsChangesHistory.cpp` entry is owed: the core setting and its default are untouched, and that file tracks core `Settings` only. The plan `DECLARE` stays, because `JoinStepLogical` still uses it.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1650` (included in `26.8` and later)
<!-- ch-version-info:end -->