### PR TITLE
Fix enterprise feature banner in dark mode

### DIFF
--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -2220,12 +2220,14 @@ html.dark .prose a.experimentalBadge:not(.card):not(.card *),
     font-size: 0.875rem;
 }
 
-.dark .scalePlanFeatureContainer {
+.dark .scalePlanFeatureContainer,
+[data-theme='dark'] .scalePlanFeatureContainer {
     background-color: #1F1F1C;
     border: 1px solid #414141;
 }
 
-.dark .scalePlanFeatureBadge {
+.dark .scalePlanFeatureBadge,
+[data-theme='dark'] .scalePlanFeatureBadge {
     background-color: #1D64EC;
     color: #FFFFFF;
 }

--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -2040,7 +2040,6 @@ html.dark .prose a.betaBadge:not(.card):not(.card *),
     background-color: #F6F7FA;
     border-radius: 4px;
     border: 1px solid #E6E7E9;
-    color: #1F1F1C;
     padding: 12px 16px;
     margin-bottom: 8px;
     font-size: 0.875rem;
@@ -2070,7 +2069,6 @@ html.dark .prose a.betaBadge:not(.card):not(.card *),
 [data-theme='dark'] .enterprisePlanFeatureContainer {
     background-color: #1F1F1C;
     border: 1px solid #414141;
-    color: #E6E7E9;
 }
 
 .dark .enterprisePlanFeatureBadge,

--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -2040,6 +2040,7 @@ html.dark .prose a.betaBadge:not(.card):not(.card *),
     background-color: #F6F7FA;
     border-radius: 4px;
     border: 1px solid #E6E7E9;
+    color: #1F1F1C;
     padding: 12px 16px;
     margin-bottom: 8px;
     font-size: 0.875rem;
@@ -2065,12 +2066,15 @@ html.dark .prose a.betaBadge:not(.card):not(.card *),
     font-size: 0.875rem;
 }
 
-.dark .enterprisePlanFeatureContainer {
+.dark .enterprisePlanFeatureContainer,
+[data-theme='dark'] .enterprisePlanFeatureContainer {
     background-color: #1F1F1C;
     border: 1px solid #414141;
+    color: #E6E7E9;
 }
 
-.dark .enterprisePlanFeatureBadge {
+.dark .enterprisePlanFeatureBadge,
+[data-theme='dark'] .enterprisePlanFeatureBadge {
     background-color: #99FFA1;
     color: #1F1F1C;
 }

--- a/docs/snippets/components/Badges/badges_styles.css
+++ b/docs/snippets/components/Badges/badges_styles.css
@@ -220,6 +220,7 @@ a.betaBadge {
     background-color: #F6F7FA;
     border-radius: 4px;
     border: 1px solid #E6E7E9;
+    color: #1F1F1C;
     padding: 12px 16px;
     margin-bottom: 8px;
     font-size: 0.875rem;
@@ -245,12 +246,15 @@ a.betaBadge {
     font-size: 0.875rem;
 }
 
-.dark .enterprisePlanFeatureContainer {
+.dark .enterprisePlanFeatureContainer,
+[data-theme='dark'] .enterprisePlanFeatureContainer {
     background-color: #1F1F1C;
     border: 1px solid #414141;
+    color: #E6E7E9;
 }
 
-.dark .enterprisePlanFeatureBadge {
+.dark .enterprisePlanFeatureBadge,
+[data-theme='dark'] .enterprisePlanFeatureBadge {
     background-color: #99FFA1;
     color: #1F1F1C;
 }

--- a/docs/snippets/components/Badges/badges_styles.css
+++ b/docs/snippets/components/Badges/badges_styles.css
@@ -220,7 +220,6 @@ a.betaBadge {
     background-color: #F6F7FA;
     border-radius: 4px;
     border: 1px solid #E6E7E9;
-    color: #1F1F1C;
     padding: 12px 16px;
     margin-bottom: 8px;
     font-size: 0.875rem;
@@ -250,7 +249,6 @@ a.betaBadge {
 [data-theme='dark'] .enterprisePlanFeatureContainer {
     background-color: #1F1F1C;
     border: 1px solid #414141;
-    color: #E6E7E9;
 }
 
 .dark .enterprisePlanFeatureBadge,

--- a/docs/snippets/components/Badges/badges_styles.css
+++ b/docs/snippets/components/Badges/badges_styles.css
@@ -398,12 +398,14 @@ a.experimentalBadge {
     font-size: 0.875rem;
 }
 
-.dark .scalePlanFeatureContainer {
+.dark .scalePlanFeatureContainer,
+[data-theme='dark'] .scalePlanFeatureContainer {
     background-color: #1F1F1C;
     border: 1px solid #414141;
 }
 
-.dark .scalePlanFeatureBadge {
+.dark .scalePlanFeatureBadge,
+[data-theme='dark'] .scalePlanFeatureBadge {
     background-color: #1D64EC;
     color: #FFFFFF;
 }


### PR DESCRIPTION
Fix the `EnterprisePlanFeatureBadge` banner contrast in dark mode.

The banner depended on inherited text color and only recognized the `.dark` theme marker. Documentation surfaces that use `[data-theme='dark']` could therefore render dark text and background styles inconsistently. This change supports both theme markers, sets explicit accessible text colors for the outer banner, and keeps the generated site stylesheet synchronized with the component stylesheet.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the `EnterprisePlanFeatureBadge` banner contrast in dark mode.