### PR TITLE
Add a test for the per-part minmax index over block columns during mutations

### DIFF
--- a/tests/queries/0_stateless/04652_part_minmax_block_columns_mutation.reference
+++ b/tests/queries/0_stateless/04652_part_minmax_block_columns_mutation.reference
@@ -1,0 +1,12 @@
+-- after insert --
+all_1_1_0	(1,1)	(0,8)
+-- ALTER UPDATE --
+all_1_1_0_2	(1,1)	(0,8)
+-- ALTER RENAME COLUMN --
+all_1_1_0_3	(1,1)	(0,8)
+-- ALTER DROP COLUMN --
+all_1_1_0_4	(1,1)	(0,8)
+-- ALTER DELETE --
+all_1_1_0_5	(1,1)	(1,8)
+-- surviving rows --
+6	1	1	1	8

--- a/tests/queries/0_stateless/04652_part_minmax_block_columns_mutation.sql
+++ b/tests/queries/0_stateless/04652_part_minmax_block_columns_mutation.sql
@@ -1,0 +1,43 @@
+-- Tags: no-shared-merge-tree
+-- Tag no-shared-merge-tree: RMT/SMT allocate block numbers starting from 0
+
+-- Mutations that rewrite a part must materialize `_block_number` / `_block_offset`
+-- so the per-part minmax index over them can be rebuilt.
+
+DROP TABLE IF EXISTS t_mut;
+
+CREATE TABLE t_mut (date1 Date, value1 String, value2 UInt64) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         part_minmax_index_columns = 'with_block_number_offset';
+
+INSERT INTO t_mut SELECT toDate('2018-10-01') + number % 3, toString(number), number FROM numbers(9);
+
+SELECT '-- after insert --';
+SELECT DISTINCT part_name, minmax__block_number, minmax__block_offset
+FROM mergeTreeIndex(currentDatabase(), 't_mut', with_minmax = 1) ORDER BY part_name;
+
+SELECT '-- ALTER UPDATE --';
+ALTER TABLE t_mut UPDATE value1 = 'x' WHERE 1 SETTINGS mutations_sync = 2;
+SELECT DISTINCT part_name, minmax__block_number, minmax__block_offset
+FROM mergeTreeIndex(currentDatabase(), 't_mut', with_minmax = 1) ORDER BY part_name;
+
+SELECT '-- ALTER RENAME COLUMN --';
+ALTER TABLE t_mut RENAME COLUMN date1 TO renamed_date1 SETTINGS mutations_sync = 2;
+SELECT DISTINCT part_name, minmax__block_number, minmax__block_offset
+FROM mergeTreeIndex(currentDatabase(), 't_mut', with_minmax = 1) ORDER BY part_name;
+
+SELECT '-- ALTER DROP COLUMN --';
+ALTER TABLE t_mut DROP COLUMN value2 SETTINGS mutations_sync = 2;
+SELECT DISTINCT part_name, minmax__block_number, minmax__block_offset
+FROM mergeTreeIndex(currentDatabase(), 't_mut', with_minmax = 1) ORDER BY part_name;
+
+-- Deleting the rows at offsets 0, 3 and 6 narrows the `_block_offset` range.
+SELECT '-- ALTER DELETE --';
+ALTER TABLE t_mut DELETE WHERE renamed_date1 = toDate('2018-10-01') SETTINGS mutations_sync = 2;
+SELECT DISTINCT part_name, minmax__block_number, minmax__block_offset
+FROM mergeTreeIndex(currentDatabase(), 't_mut', with_minmax = 1) ORDER BY part_name;
+
+SELECT '-- surviving rows --';
+SELECT count(), min(_block_number), max(_block_number), min(_block_offset), max(_block_offset) FROM t_mut;
+
+DROP TABLE t_mut;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/106780
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/106780

Test only, no engine change.

With `part_minmax_index_columns = 'with_block_number_offset'`, `_block_number` and `_block_offset` are part of the per-part minmax index, but the mutation read pipeline did not materialize them, so any mutation that rewrites a part failed with `Code: 341 ... Not found column or subcolumn _block_number in block. (NOT_FOUND_COLUMN_IN_BLOCK)`.

The engine side was fixed by #109281. That PR ships `04501_mutation_materialize_block_number_offset`, which covers merges and `ALTER TABLE ... REWRITE PARTS`. This test pins the interpreter-driven mutation shapes that were reported and are not covered there: `ALTER UPDATE` (the shape in the issue), `RENAME COLUMN`, `DROP COLUMN` and `DELETE`.

Besides checking the mutations succeed, it asserts the resulting minmax ranges, so it also fails if a mutation silently drops them: a rewritten part keeps `(1,1)` / `(0,8)`, and `DELETE` narrows `_block_offset` to `(1,8)`.

Verified both directions against prebuilt master binaries: the test fails on `1125231165b1` (the commit right before the #109281 merge) with the exact `NOT_FOUND_COLUMN_IN_BLOCK` message from the issue, and passes on `8990a8b4426e` (right after). 15 runs with the default randomization are green, and it is parallel-safe (no `no-parallel`).

One residual issue found while writing this test, deliberately left out of scope because it is a separate engine defect rather than the one this issue reports: for a **Wide** part, `UPDATE` / `RENAME COLUMN` / `DROP COLUMN` produce the correct ranges in memory, but after `DETACH` + `ATTACH` they read back as `(NULL,NULL)`. Merged Wide parts and mutated Compact parts both survive reattachment, so it is specific to the mutated-Wide path. Query results stay correct (only the pruning ranges are lost), so it is not a correctness bug. I will report it separately.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.335` (included in `26.8` and later)
<!-- ch-version-info:end -->