### PR TITLE
Docs: align Entra SCIM guide with setup template

### DIFF
--- a/docs/products/cloud/guides/security/cloud-access-management/scim-setup-entra.mdx
+++ b/docs/products/cloud/guides/security/cloud-access-management/scim-setup-entra.mdx
@@ -240,7 +240,7 @@ Entra ID syncs on a recurring cycle (roughly every 40 minutes), so routine chang
 
 <AccordionGroup>
 
-<Accordion title='"Test connection" fails in Entra ID'>
+<Accordion title='"Test connection" fails in Entra ID' id="test-credentials-fails">
 
 - Confirm SCIM is **enabled** in the ClickHouse Cloud Console.
 - Confirm the **Tenant URL** in Entra ID exactly matches the SCIM endpoint URL shown in the Cloud Console — the organization id must be correct.
@@ -249,7 +249,7 @@ Entra ID syncs on a recurring cycle (roughly every 40 minutes), so routine chang
 
 </Accordion>
 
-<Accordion title="Users get created but have no permissions">
+<Accordion title="Users get created but have no permissions" id="users-no-permissions">
 
 - Check that you've added a row under **Map roles in "Users and roles"** for the role you expect.
 - Check that the Entra ID group name **exactly** matches the SCIM group name in the mapping, including capitalisation and hyphens.
@@ -257,7 +257,7 @@ Entra ID syncs on a recurring cycle (roughly every 40 minutes), so routine chang
 
 </Accordion>
 
-<Accordion title="Users or groups aren't provisioning at all">
+<Accordion title="Users or groups aren't provisioning at all" id="nothing-provisioning">
 
 - Confirm **Provisioning Status** is `On`.
 - Confirm **Scope** is set to `Sync only assigned users and groups` and that the users/groups are actually assigned to the application under **Users and groups**.
@@ -266,31 +266,31 @@ Entra ID syncs on a recurring cycle (roughly every 40 minutes), so routine chang
 
 </Accordion>
 
-<Accordion title="Duplicate user in the member list">
+<Accordion title="Duplicate user in the member list" id="duplicate-user">
 
 Usually caused by inconsistent email casing between Entra ID and an earlier manual invite. Remove the duplicate from the Members list, then unassign and reassign the user in Entra ID (or re-run **Provision on demand**) to provision fresh.
 
 </Accordion>
 
-<Accordion title="Group provisioning fails with a name mismatch">
+<Accordion title="Group provisioning fails with a name mismatch" id="group-display-name">
 
 The group display name in Entra ID doesn't match a configured mapping in ClickHouse Cloud. Either rename the Entra ID group or add a mapping under **Map roles in "Users and roles"** from the SCIM Configuration panel (or via **Users and roles → Roles**).
 
 </Accordion>
 
-<Accordion title="Deactivated users still show as members">
+<Accordion title="Deactivated users still show as members" id="deactivated-users-remaining">
 
 Deactivation propagates on the next provisioning cycle. To force it immediately, use **Provision on demand** for that user. If the user is still a member afterwards, check **Provisioning → View provisioning logs** for an error on the disable operation.
 
 </Accordion>
 
-<Accordion title="I rotated the SCIM token and now Entra ID is failing">
+<Accordion title="I rotated the SCIM token and now Entra ID is failing" id="token-rotation-issue">
 
 Check that you updated the **Secret Token** on the correct enterprise application in Entra ID, in the form `<scim-key>:<scim-secret>`. After updating, click `Test Connection` to confirm. Once provisioning is back to healthy, revoke the old token in the ClickHouse Cloud Console.
 
 </Accordion>
 
-<Accordion title="I lost the SCIM token">
+<Accordion title="I lost the SCIM token" id="lost-token">
 
 Tokens can't be recovered. In **Organization settings → SAML and SCIM settings → SCIM Configuration** in the ClickHouse Cloud Console, revoke the lost token and generate a new one, then update the **Secret Token** in Entra ID.
 

--- a/docs/products/cloud/guides/security/cloud-access-management/scim-setup-entra.mdx
+++ b/docs/products/cloud/guides/security/cloud-access-management/scim-setup-entra.mdx
@@ -212,82 +212,128 @@ SCIM errors surface in the application's **Provisioning → View provisioning lo
 
 ## Best practices for production {#best-practices}
 
-**Rotate tokens regularly.** Set a calendar reminder for SCIM token rotation. Recommended cadence: every 12 months, or immediately whenever an admin who knew the token leaves the company. ClickHouse Cloud allows two active tokens per organization specifically so you can rotate without breaking provisioning — generate the new token, update the **Secret Token** in Entra ID, confirm with **Test Connection**, then revoke the old token.
+### Rotate tokens regularly {#rotate-tokens}
 
-**Use groups, not direct assignments.** Direct user assignment to the application works, but quickly becomes hard to audit. Driving assignment through Entra ID groups means access reviews and role changes happen in one place.
+Set a calendar reminder for SCIM token rotation. Recommended cadence: every 12 months, or immediately whenever an admin who knew the token leaves the company. ClickHouse Cloud allows two active tokens per organization specifically so you can rotate without breaking provisioning — generate the new token, update the **Secret Token** in Entra ID, confirm with **Test Connection**, then revoke the old token.
 
-**Review the audit log.** Every SCIM action — user created, user deactivated, profile updated — is recorded in the ClickHouse Cloud audit log. See [Audit logging](/products/cloud/reference/security/audit-logging). Check the log periodically, especially after large provisioning bursts.
+### Use groups, not direct assignments {#use-groups}
 
-**Set a sensible default role.** If an Entra ID user gets assigned to the application but isn't in any assigned group, they're created with the **Default role**. Pick the most restrictive role that still lets the user accomplish *something*, so misconfigurations fail safely.
+Direct user assignment to the application works, but quickly becomes hard to audit. Driving assignment through Entra ID groups means access reviews and role changes happen in one place.
 
-**Avoid SCIM and manual invites at the same time.** Once SCIM is on, manage membership through Entra ID — don't also send manual invites for the same users. Mixing the two paths leads to confusion about who is the source of truth and can produce duplicates.
+### Review the audit log {#review-audit-log}
 
-**Account for the provisioning cycle.** Entra ID syncs on a recurring cycle (roughly every 40 minutes), so routine changes aren't instant. Use **Provision on demand** when you need a change to land immediately, and monitor **Provisioning logs** for persistent failures.
+Every SCIM action — user created, user deactivated, profile updated — is recorded in the ClickHouse Cloud audit log. See [Audit logging](/products/cloud/reference/security/audit-logging). Check the log periodically, especially after large provisioning bursts.
+
+### Set a sensible default role {#default-role}
+
+If an Entra ID user gets assigned to the application but isn't in any assigned group, they're created with the **Default role**. Pick the most restrictive role that still lets the user accomplish *something*, so misconfigurations fail safely.
+
+### Avoid SCIM and manual invites at the same time {#avoid-manual-invites}
+
+Once SCIM is on, manage membership through Entra ID — don't also send manual invites for the same users. Mixing the two paths leads to confusion about who is the source of truth and can produce duplicates.
+
+### Account for the provisioning cycle {#account-for-provisioning-cycle}
+
+Entra ID syncs on a recurring cycle (roughly every 40 minutes), so routine changes aren't instant. Use **Provision on demand** when you need a change to land immediately, and monitor **Provisioning logs** for persistent failures.
 
 ## Troubleshooting {#troubleshooting}
 
-### "Test connection" fails in Entra ID {#test-credentials-fails}
+<AccordionGroup>
+
+<Accordion title='"Test connection" fails in Entra ID'>
 
 - Confirm SCIM is **enabled** in the ClickHouse Cloud Console.
 - Confirm the **Tenant URL** in Entra ID exactly matches the SCIM endpoint URL shown in the Cloud Console — the organization id must be correct.
 - Confirm the **Secret Token** is in the form `<scim-key>:<scim-secret>` — the key (starting with `scim_`), a colon, and then the secret. Include no leading or trailing whitespace, and no `Bearer` prefix (Entra ID adds that automatically).
 - If you've rotated tokens, make sure you're using the **new** key and secret, not the previous pair.
 
-### Users get created but have no permissions {#users-no-permissions}
+</Accordion>
+
+<Accordion title="Users get created but have no permissions">
 
 - Check that you've added a row under **Map roles in "Users and roles"** for the role you expect.
 - Check that the Entra ID group name **exactly** matches the SCIM group name in the mapping, including capitalisation and hyphens.
 - If your design intentionally provisions some users without a group, confirm the **Default role** is set.
 
-### Users or groups aren't provisioning at all {#nothing-provisioning}
+</Accordion>
+
+<Accordion title="Users or groups aren't provisioning at all">
 
 - Confirm **Provisioning Status** is `On`.
 - Confirm **Scope** is set to `Sync only assigned users and groups` and that the users/groups are actually assigned to the application under **Users and groups**.
 - Remember the cycle runs roughly every 40 minutes — use **Provision on demand** to test a single user immediately.
 - Provisioning groups (rather than just their members) requires Microsoft Entra ID P1 or higher.
 
-### Duplicate user in the member list {#duplicate-user}
+</Accordion>
+
+<Accordion title="Duplicate user in the member list">
 
 Usually caused by inconsistent email casing between Entra ID and an earlier manual invite. Remove the duplicate from the Members list, then unassign and reassign the user in Entra ID (or re-run **Provision on demand**) to provision fresh.
 
-### Group provisioning fails with a name mismatch {#group-display-name}
+</Accordion>
+
+<Accordion title="Group provisioning fails with a name mismatch">
 
 The group display name in Entra ID doesn't match a configured mapping in ClickHouse Cloud. Either rename the Entra ID group or add a mapping under **Map roles in "Users and roles"** from the SCIM Configuration panel (or via **Users and roles → Roles**).
 
-### Deactivated users still show as members {#deactivated-users-remaining}
+</Accordion>
+
+<Accordion title="Deactivated users still show as members">
 
 Deactivation propagates on the next provisioning cycle. To force it immediately, use **Provision on demand** for that user. If the user is still a member afterwards, check **Provisioning → View provisioning logs** for an error on the disable operation.
 
-### I rotated the SCIM token and now Entra ID is failing {#token-rotation-issue}
+</Accordion>
+
+<Accordion title="I rotated the SCIM token and now Entra ID is failing">
 
 Check that you updated the **Secret Token** on the correct enterprise application in Entra ID, in the form `<scim-key>:<scim-secret>`. After updating, click `Test Connection` to confirm. Once provisioning is back to healthy, revoke the old token in the ClickHouse Cloud Console.
 
-### I lost the SCIM token {#lost-token}
+</Accordion>
+
+<Accordion title="I lost the SCIM token">
 
 Tokens can't be recovered. In **Organization settings → SAML and SCIM settings → SCIM Configuration** in the ClickHouse Cloud Console, revoke the lost token and generate a new one, then update the **Secret Token** in Entra ID.
 
+</Accordion>
+
+</AccordionGroup>
+
 ## Frequently asked questions {#faq}
 
+<AccordionGroup>
+
 <Accordion title="Do I need SAML SSO before I can use SCIM?">
+
 Yes. SCIM creates the user accounts, but ClickHouse Cloud authenticates them through SAML. Set up [SAML SSO](/products/cloud/guides/security/cloud-access-management/saml-sso-setup) first.
+
 </Accordion>
 
 <Accordion title="Can I use the same enterprise application for SAML and SCIM?">
+
 Yes. With SAML-based SSO, a single Entra ID enterprise application handles both single sign-on and SCIM provisioning.
+
 </Accordion>
 
 <Accordion title="Why is the Secret Token formatted as key:secret?">
+
 Entra ID authenticates by sending the Secret Token as an `Authorization: Bearer` header. The ClickHouse Cloud SCIM endpoint expects the bearer value to be your token key and secret joined by a colon.
+
 </Accordion>
 
 <Accordion title="How quickly do changes in Entra ID show up in ClickHouse Cloud?">
+
 Entra ID provisions on a recurring cycle of roughly 40 minutes. For an immediate update, use **Provision on demand** for the specific user.
+
 </Accordion>
 
 <Accordion title="Where do I get help if I'm stuck?">
+
 Open a support ticket from the ClickHouse Cloud Console (**Help → Contact support**) and include:
 
 - your organization id,
 - the name (and object id) of your Entra ID enterprise application, and
 - a screenshot of the failing entry from **Provisioning → View provisioning logs**.
+
 </Accordion>
+
+</AccordionGroup>


### PR DESCRIPTION
Bring the restored Microsoft Entra ID SCIM guide into the setup-guide structure already used by its Okta and SAML sibling pages. This splits best practices into anchored subsections and presents troubleshooting and frequently asked questions as grouped accordions, without changing the technical setup instructions.

Scoped Mintlify validation passed across all 11 cloud access-management pages, their navigation entries, and imported components.

Related: https://github.com/ClickHouse/ClickHouse/pull/109929

Related: https://github.com/ClickHouse/ClickHouse/pull/112307

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.685` (included in `26.8` and later)
<!-- ch-version-info:end -->