### PR TITLE
docs(formats): correct Protobuf schema vs table default priority

### DIFF
--- a/docs/reference/formats/Protobuf/Protobuf.mdx
+++ b/docs/reference/formats/Protobuf/Protobuf.mdx
@@ -46,7 +46,14 @@ ClickHouse tries to find a column named `x.y.z` (or `x_y_z` or `X.y_Z` and so on
 
 Nested messages are suitable for input or output of a [nested data structures](/reference/data-types/nested-data-structures/index).
 
-For **mapped** fields that are missing on the wire, ClickHouse uses the protobuf schema field default (`proto2` `[default = …]`, otherwise the type default) during parsing — not the table `DEFAULT` expression.
+For **mapped** fields that are missing on the wire:
+
+- Ordinary **non-nullable** mapped columns use the protobuf schema field default (`proto2` `[default = …]`, otherwise the type default) during parsing — not the table `DEFAULT` expression.
+- Mapped `Nullable(...)` columns resolve to `NULL` when the field is absent (they do not take the protobuf field/type default).
+- With [`input_format_protobuf_flatten_google_wrappers`](/operations/settings/settings-formats#input_format_protobuf_flatten_google_wrappers) enabled for `google.protobuf.*Value` wrappers:
+  - an **absent** wrapper on a `Nullable(...)` column is treated as a missing outer field and becomes `NULL`;
+  - a **present-but-empty** wrapper (`str {}`) keeps the nested scalar default (`''` / `0`);
+  - a non-nullable column mapped to an absent wrapper gets the nested scalar default rather than `NULL`.
 
 Table `DEFAULT` (and default expressions) apply to table columns that have **no** matching field in the message type when [`input_format_defaults_for_omitted_fields`](/operations/settings/settings-formats#input_format_defaults_for_omitted_fields) is enabled (the default). If that setting is `0`, unmapped columns keep the data type default inserted during parsing instead of the table `DEFAULT` expression.
 

--- a/docs/reference/formats/Protobuf/Protobuf.mdx
+++ b/docs/reference/formats/Protobuf/Protobuf.mdx
@@ -46,18 +46,7 @@ ClickHouse tries to find a column named `x.y.z` (or `x_y_z` or `X.y_Z` and so on
 
 Nested messages are suitable for input or output of a [nested data structures](/reference/data-types/nested-data-structures/index).
 
-For **mapped** fields that are missing on the wire:
-
-- Ordinary **non-nullable** mapped columns use the protobuf schema field default (`proto2` `[default = …]`, otherwise the type default) during parsing — not the table `DEFAULT` expression.
-- Mapped `Nullable(...)` columns resolve to `NULL` when the field is absent (they do not take the protobuf field/type default).
-- With [`input_format_protobuf_flatten_google_wrappers`](/reference/settings/formats/input-format#input_format_protobuf_flatten_google_wrappers) enabled for `google.protobuf.*Value` wrappers:
-  - an **absent** wrapper on a `Nullable(...)` column is treated as a missing outer field and becomes `NULL`;
-  - a **present-but-empty** wrapper (`str {}`) keeps the nested scalar default (`''` / `0`);
-  - a non-nullable column mapped to an absent wrapper gets the nested scalar default rather than `NULL`.
-
-Table `DEFAULT` (and default expressions) apply to table columns that have **no** matching field in the message type when [`input_format_defaults_for_omitted_fields`](/reference/settings/formats/input-format#input_format_defaults_for_omitted_fields) is enabled (the default). If that setting is `0`, unmapped columns keep the data type default inserted during parsing instead of the table `DEFAULT` expression.
-
-Example of a proto2 schema field default (used for a mapped field absent from the message):
+Default values defined in a protobuf schema like the one that follows are not applied, rather the [table defaults](/reference/statements/create/table#default_values) are used instead of them:
 
 ```capnp
 syntax = "proto2";

--- a/docs/reference/formats/Protobuf/Protobuf.mdx
+++ b/docs/reference/formats/Protobuf/Protobuf.mdx
@@ -46,7 +46,11 @@ ClickHouse tries to find a column named `x.y.z` (or `x_y_z` or `X.y_Z` and so on
 
 Nested messages are suitable for input or output of a [nested data structures](/reference/data-types/nested-data-structures/index).
 
-Default values defined in a protobuf schema like the one that follows are not applied, rather the [table defaults](/reference/statements/create/table#default_values) are used instead of them:
+For **mapped** fields that are missing on the wire, ClickHouse uses the protobuf schema field default (`proto2` `[default = …]`, otherwise the type default) during parsing — not the table `DEFAULT` expression.
+
+Table `DEFAULT` (and default expressions) apply to table columns that have **no** matching field in the message type when [`input_format_defaults_for_omitted_fields`](/operations/settings/settings-formats#input_format_defaults_for_omitted_fields) is enabled (the default). If that setting is `0`, unmapped columns keep the data type default inserted during parsing instead of the table `DEFAULT` expression.
+
+Example of a proto2 schema field default (used for a mapped field absent from the message):
 
 ```capnp
 syntax = "proto2";

--- a/docs/reference/formats/Protobuf/Protobuf.mdx
+++ b/docs/reference/formats/Protobuf/Protobuf.mdx
@@ -50,12 +50,12 @@ For **mapped** fields that are missing on the wire:
 
 - Ordinary **non-nullable** mapped columns use the protobuf schema field default (`proto2` `[default = …]`, otherwise the type default) during parsing — not the table `DEFAULT` expression.
 - Mapped `Nullable(...)` columns resolve to `NULL` when the field is absent (they do not take the protobuf field/type default).
-- With [`input_format_protobuf_flatten_google_wrappers`](/operations/settings/settings-formats#input_format_protobuf_flatten_google_wrappers) enabled for `google.protobuf.*Value` wrappers:
+- With [`input_format_protobuf_flatten_google_wrappers`](/reference/settings/formats/input-format#input_format_protobuf_flatten_google_wrappers) enabled for `google.protobuf.*Value` wrappers:
   - an **absent** wrapper on a `Nullable(...)` column is treated as a missing outer field and becomes `NULL`;
   - a **present-but-empty** wrapper (`str {}`) keeps the nested scalar default (`''` / `0`);
   - a non-nullable column mapped to an absent wrapper gets the nested scalar default rather than `NULL`.
 
-Table `DEFAULT` (and default expressions) apply to table columns that have **no** matching field in the message type when [`input_format_defaults_for_omitted_fields`](/operations/settings/settings-formats#input_format_defaults_for_omitted_fields) is enabled (the default). If that setting is `0`, unmapped columns keep the data type default inserted during parsing instead of the table `DEFAULT` expression.
+Table `DEFAULT` (and default expressions) apply to table columns that have **no** matching field in the message type when [`input_format_defaults_for_omitted_fields`](/reference/settings/formats/input-format#input_format_defaults_for_omitted_fields) is enabled (the default). If that setting is `0`, unmapped columns keep the data type default inserted during parsing instead of the table `DEFAULT` expression.
 
 Example of a proto2 schema field default (used for a mapped field absent from the message):
 

--- a/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
@@ -215,7 +215,11 @@ ClickHouse tries to find a column named `x.y.z` (or `x_y_z` or `X.y_Z` and so on
 
 Nested messages are suitable for input or output of a [nested data structures](/sql-reference/data-types/nested-data-structures/index.md).
 
-Default values defined in a protobuf schema like the one that follows are not applied, rather the [table defaults](/sql-reference/statements/create/table#default_values) are used instead of them:
+For **mapped** fields that are missing on the wire, ClickHouse uses the protobuf schema field default (`proto2` `[default = …]`, otherwise the type default) during parsing — not the table `DEFAULT` expression.
+
+Table `DEFAULT` (and default expressions) apply to table columns that have **no** matching field in the message type when [`input_format_defaults_for_omitted_fields`](/operations/settings/settings-formats#input_format_defaults_for_omitted_fields) is enabled (the default). If that setting is `0`, unmapped columns keep the data type default inserted during parsing instead of the table `DEFAULT` expression.
+
+Example of a proto2 schema field default (used for a mapped field absent from the message):
 
 ```capnp
 syntax = "proto2";

--- a/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
@@ -215,7 +215,14 @@ ClickHouse tries to find a column named `x.y.z` (or `x_y_z` or `X.y_Z` and so on
 
 Nested messages are suitable for input or output of a [nested data structures](/sql-reference/data-types/nested-data-structures/index.md).
 
-For **mapped** fields that are missing on the wire, ClickHouse uses the protobuf schema field default (`proto2` `[default = …]`, otherwise the type default) during parsing — not the table `DEFAULT` expression.
+For **mapped** fields that are missing on the wire:
+
+- Ordinary **non-nullable** mapped columns use the protobuf schema field default (`proto2` `[default = …]`, otherwise the type default) during parsing — not the table `DEFAULT` expression.
+- Mapped `Nullable(...)` columns resolve to `NULL` when the field is absent (they do not take the protobuf field/type default).
+- With [`input_format_protobuf_flatten_google_wrappers`](/operations/settings/settings-formats#input_format_protobuf_flatten_google_wrappers) enabled for `google.protobuf.*Value` wrappers:
+  - an **absent** wrapper on a `Nullable(...)` column is treated as a missing outer field and becomes `NULL`;
+  - a **present-but-empty** wrapper (`str {}`) keeps the nested scalar default (`''` / `0`);
+  - a non-nullable column mapped to an absent wrapper gets the nested scalar default rather than `NULL`.
 
 Table `DEFAULT` (and default expressions) apply to table columns that have **no** matching field in the message type when [`input_format_defaults_for_omitted_fields`](/operations/settings/settings-formats#input_format_defaults_for_omitted_fields) is enabled (the default). If that setting is `0`, unmapped columns keep the data type default inserted during parsing instead of the table `DEFAULT` expression.
 

--- a/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
@@ -219,12 +219,12 @@ For **mapped** fields that are missing on the wire:
 
 - Ordinary **non-nullable** mapped columns use the protobuf schema field default (`proto2` `[default = …]`, otherwise the type default) during parsing — not the table `DEFAULT` expression.
 - Mapped `Nullable(...)` columns resolve to `NULL` when the field is absent (they do not take the protobuf field/type default).
-- With [`input_format_protobuf_flatten_google_wrappers`](/operations/settings/settings-formats#input_format_protobuf_flatten_google_wrappers) enabled for `google.protobuf.*Value` wrappers:
+- With [`input_format_protobuf_flatten_google_wrappers`](/reference/settings/formats/input-format#input_format_protobuf_flatten_google_wrappers) enabled for `google.protobuf.*Value` wrappers:
   - an **absent** wrapper on a `Nullable(...)` column is treated as a missing outer field and becomes `NULL`;
   - a **present-but-empty** wrapper (`str {}`) keeps the nested scalar default (`''` / `0`);
   - a non-nullable column mapped to an absent wrapper gets the nested scalar default rather than `NULL`.
 
-Table `DEFAULT` (and default expressions) apply to table columns that have **no** matching field in the message type when [`input_format_defaults_for_omitted_fields`](/operations/settings/settings-formats#input_format_defaults_for_omitted_fields) is enabled (the default). If that setting is `0`, unmapped columns keep the data type default inserted during parsing instead of the table `DEFAULT` expression.
+Table `DEFAULT` (and default expressions) apply to table columns that have **no** matching field in the message type when [`input_format_defaults_for_omitted_fields`](/reference/settings/formats/input-format#input_format_defaults_for_omitted_fields) is enabled (the default). If that setting is `0`, unmapped columns keep the data type default inserted during parsing instead of the table `DEFAULT` expression.
 
 Example of a proto2 schema field default (used for a mapped field absent from the message):
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


## Summary
Mapped Protobuf fields missing on the wire use the schema field default (`proto2` `[default = …]` or the type default). Table `DEFAULT` only fills **unmapped** columns, and only when `input_format_defaults_for_omitted_fields = 1` (default).

## Changes
- `docs/reference/formats/Protobuf/Protobuf.mdx`
- `src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp` (`setDocumentation` mirror)

Closes #112123

AI-assisted; human-reviewed.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.849` (included in `26.8` and later)
<!-- ch-version-info:end -->