### PR TITLE
Add test: Lightweight `UPDATE`/`DELETE` materialization of `_block_number`/`_block_offset` on an upgraded table (`MutateSomePartColumns` path) is untested

### DIFF
--- a/tests/queries/0_stateless/04652_mutation_materialize_block_columns_some.reference
+++ b/tests/queries/0_stateless/04652_mutation_materialize_block_columns_some.reference
@@ -1,0 +1,10 @@
+all_1_1_0_3	_block_number
+all_1_1_0_3	_block_offset
+all_2_2_0_3	_block_number
+all_2_2_0_3	_block_offset
+1	101	1	0
+2	102	1	1
+3	103	1	2
+4	104	2	0
+5	105	2	1
+6	106	2	2

--- a/tests/queries/0_stateless/04652_mutation_materialize_block_columns_some.sql
+++ b/tests/queries/0_stateless/04652_mutation_materialize_block_columns_some.sql
@@ -1,0 +1,27 @@
+-- Tags: no-random-settings, no-random-merge-tree-settings, no-shared-merge-tree
+
+-- A lightweight UPDATE mutation materializes `_block_number` / `_block_offset` in parts
+-- created before the columns were enabled (MutateSomePartColumns path, not REWRITE PARTS).
+
+DROP TABLE IF EXISTS t_mut_block_columns;
+
+CREATE TABLE t_mut_block_columns (id UInt32, a UInt32) ENGINE = MergeTree ORDER BY id
+SETTINGS enable_block_number_column = 0, enable_block_offset_column = 0, min_bytes_for_wide_part = 1;
+
+INSERT INTO t_mut_block_columns VALUES (1, 1), (2, 2), (3, 3);
+INSERT INTO t_mut_block_columns VALUES (4, 4), (5, 5), (6, 6);
+
+ALTER TABLE t_mut_block_columns MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;
+
+SET mutations_sync = 1;
+ALTER TABLE t_mut_block_columns UPDATE a = a + 100 WHERE 1;
+
+-- Both mutated parts now physically store the block columns.
+SELECT name, column FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_mut_block_columns' AND active
+  AND column IN ('_block_number', '_block_offset')
+ORDER BY name, column;
+
+SELECT id, a, _block_number, _block_offset FROM t_mut_block_columns ORDER BY id;
+
+DROP TABLE t_mut_block_columns;

--- a/tests/queries/0_stateless/04652_mutation_materialize_block_columns_some.sql
+++ b/tests/queries/0_stateless/04652_mutation_materialize_block_columns_some.sql
@@ -5,8 +5,14 @@
 
 DROP TABLE IF EXISTS t_mut_block_columns;
 
+-- Pin the two legacy level-0 parts against background merges: max_bytes_to_merge_at_max_space_in_pool = 1
+-- caps the merge selector so no two parts are ever merged, which keeps the all_1_1_0_3 / all_2_2_0_3
+-- part set stable and prevents the block columns from being materialized through the merge path.
+-- SYSTEM STOP MERGES is unusable here: StorageMergeTree::selectPartsToMutate gates on the same
+-- merges_blocker, so stopping merges would also block the UPDATE mutation this test needs.
 CREATE TABLE t_mut_block_columns (id UInt32, a UInt32) ENGINE = MergeTree ORDER BY id
-SETTINGS enable_block_number_column = 0, enable_block_offset_column = 0, min_bytes_for_wide_part = 1;
+SETTINGS enable_block_number_column = 0, enable_block_offset_column = 0, min_bytes_for_wide_part = 1,
+         max_bytes_to_merge_at_max_space_in_pool = 1;
 
 INSERT INTO t_mut_block_columns VALUES (1, 1), (2, 2), (3, 3);
 INSERT INTO t_mut_block_columns VALUES (4, 4), (5, 5), (6, 6);


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #109281](https://github.com/ClickHouse/ClickHouse/pull/109281).
That PR The PR fixes materialization of `_block_number` / `_block_offset` columns and their part-level min-max index across merges and mutations. (1) `MergeTask::ExecuteAndFinalizeHorizontalPart::prepare` now passes `WITH_BLOCK_NUMBER_OFFSET` to `getMinMaxColumns` only when both block columns are enabled (`

**1. Lightweight `UPDATE`/`DELETE` materialization of `_block_number`/`_block_offset` on an upgraded table (`MutateSomePartColumns` path) is untested**
  `src/Storages/MergeTree/MutateTask.cpp:753`, `src/Storages/MergeTree/MutateTask.cpp:630`
  **Risk:** `splitAndModifyMutationCommands` (MutateTask.cpp:630-640) appends `READ_COLUMN` commands for the block columns when `!for_interpreter.empty()` and the part lacks them, and `getColumnsForNewDataPart` (MutateTask.cpp:753-754) keeps them when `updated_header.has(name)`. The PR's own tests only reach these branches through `REWRITE PARTS`, which forces the `MutateAllPartColumnsTask` path; a plain `UPDATE`/`DELETE` of a non-key column on a wide part takes the `else` branch at MutateTask.cpp:3667 …
  **What's unique vs PR tests:** The PR's 04501 reaches block-column materialization only through `REWRITE PARTS`, which forces `MutateAllPartColumnsTask`, and asserts existence only. Existing block-column mutation tests (02668, 03001, 03275) enable the settings AT CREATE, so the part always already has the columns and the new `!part_columns.has(...)` materialization branch never fires. This test is the only one that upgrades an existing table (`MODIFY SETTING`) and then runs a lightweight `UPDATE` (non-key column, wide part …
  **Tags:** `-- Tags: no-random-settings, no-random-merge-tree-settings, no-shared-merge-tree` — `no-random-settings`: test pins mutation version in generated part names (all_1_1_0_3); randomized settings can add extra mutations and shift versions; `no-random-merge-tree-settings`: test explicitly sets enable_block_number_column/enable_block_offset_column/min_bytes_for_wide_part; randomization would override them; `no-shared-merge-tree`: part naming and materialization differ under shared-merge-tree, breaking the parts_columns assertion

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.365` (included in `26.8` and later)
<!-- ch-version-info:end -->