### PR TITLE
Revert "Fix stale and deleted rows when reading a MaterializedPostgreSQL database through Merge"

### DIFF
--- a/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
@@ -533,33 +533,8 @@ void DatabaseMaterializedPostgreSQL::drop(ContextPtr local_context)
 DatabaseTablesIteratorPtr DatabaseMaterializedPostgreSQL::getTablesIterator(
     ContextPtr local_context, const DatabaseOnDisk::FilterByNameFunction & filter_by_table_name, bool skip_not_loaded) const
 {
-    /// Internal queries (replication machinery, DDL, backups) work on the nested ReplacingMergeTree
-    /// tables directly. If materialized_tables is empty, all access goes to the nested tables as
-    /// well - it is the case after replication_handler was shutdown (see tryGetTable).
-    if (local_context->isInternalQuery() || materialized_tables.empty())
-        return DatabaseAtomic::getTablesIterator(StorageMaterializedPostgreSQL::makeNestedTableContext(local_context), filter_by_table_name, skip_not_loaded);
-
-    /// For user-facing enumeration return the StorageMaterializedPostgreSQL wrappers, consistently
-    /// with tryGetTable. Otherwise consumers reading data through the iterator (e.g. StorageMerge)
-    /// would read the nested tables directly - without the `_sign = 1` filter and the forced
-    /// `FINAL` - exposing stale and deleted row versions.
-    Tables tables;
-    {
-        std::lock_guard lock(tables_mutex);
-        for (const auto & [table_name, storage] : materialized_tables)
-        {
-            if (filter_by_table_name && !filter_by_table_name(table_name))
-                continue;
-
-            /// A table is considered to exist once its nested table was created (see tryGetTable).
-            if (!storage->as<StorageMaterializedPostgreSQL>()->hasNested())
-                continue;
-
-            tables.emplace(table_name, storage);
-        }
-    }
-
-    return std::make_unique<DatabaseTablesSnapshotIterator>(std::move(tables), getDatabaseName());
+    /// Modify context into nested_context and pass query to Atomic database.
+    return DatabaseAtomic::getTablesIterator(StorageMaterializedPostgreSQL::makeNestedTableContext(local_context), filter_by_table_name, skip_not_loaded);
 }
 
 
@@ -611,11 +586,7 @@ DatabaseMaterializedPostgreSQL::getTablesForBackup(const FilterByNameFunction & 
         }
     }
 
-    /// Enumerate through the nested context: the base implementation lists tables via
-    /// `getTablesIterator`, which for user-facing (non-internal) contexts returns the
-    /// `StorageMaterializedPostgreSQL` wrappers, while backups must keep backing up the nested
-    /// ReplacingMergeTree tables directly.
-    return DatabaseAtomic::getTablesForBackup(filter, StorageMaterializedPostgreSQL::makeNestedTableContext(local_context));
+    return DatabaseAtomic::getTablesForBackup(filter, local_context);
 }
 
 void registerDatabaseMaterializedPostgreSQL(DatabaseFactory & factory);

--- a/tests/integration/test_postgresql_replica_database_engine/test_1.py
+++ b/tests/integration/test_postgresql_replica_database_engine/test_1.py
@@ -546,46 +546,6 @@ def test_merge_table_over_materialized_postgresql(started_cluster):
         instance.query(f"DROP TABLE IF EXISTS {table_name} SYNC")
 
 
-def test_merge_table_over_materialized_postgresql_database(started_cluster):
-    """
-    Reading a MaterializedPostgreSQL database through Merge forces FINAL on the child read:
-    getTablesIterator must return StorageMaterializedPostgreSQL wrappers instead of the
-    nested ReplacingMergeTree tables, so that Merge over the database reads with the
-    forced FINAL and the `_sign = 1` filter (otherwise stale and deleted row versions
-    would be exposed).
-    """
-    table_name = "postgresql_replica_final_db"
-    pg_manager.create_postgres_table(table_name)
-    instance.query(
-        f"INSERT INTO postgres_database.{table_name} SELECT number, number FROM numbers(3)"
-    )
-
-    pg_manager.create_materialized_db(
-        ip=started_cluster.postgres_ip, port=started_cluster.postgres_port
-    )
-    check_tables_are_synchronized(instance, table_name)
-
-    pg_manager.execute(f"UPDATE {table_name} SET value = 42 WHERE key = 1")
-    pg_manager.execute(f"DELETE FROM {table_name} WHERE key = 2")
-    check_tables_are_synchronized(instance, table_name)
-
-    expected = "0\t0\n1\t42\n"
-    direct_query = (
-        f"SELECT key, value FROM test_database.{table_name} ORDER BY key, value"
-    )
-    merge_query = (
-        f"SELECT key, value FROM merge('test_database', '^{table_name}$')"
-        " ORDER BY key, value"
-    )
-
-    for query in [direct_query, merge_query]:
-        explain = instance.query(f"EXPLAIN actions=1 {query}")
-        assert "FINAL: 1" in explain, explain
-
-    assert instance.query(direct_query) == expected
-    assert instance.query(merge_query) == expected
-
-
 if __name__ == "__main__":
     cluster.start()
     input("Cluster created, press any key to destroy...")


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#109339


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.332` (included in `26.8` and later)
<!-- ch-version-info:end -->