### PR TITLE
Fix code block font and line height

### DIFF
--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -825,25 +825,12 @@ html:not(.dark) .pagination-prev:hover {
     max-width: none !important;
 }
 
-/* Fix code block text alignment: JetBrains Mono renders box-drawing characters
-   (─, ┌, ┐, │, etc.) at ~13.6px vs ASCII at ~8.6px because it falls back to a
-   system font for box-drawing. Monaco renders both at equal width. Target the
-   pre.shiki and code elements directly since Mintlify overrides .font-mono. */
-[data-component-part="code-block-root"] pre.shiki,
-[data-component-part="code-block-root"] code,
-[data-component-part="code-block-root"] .line,
-[data-component-part="code-block-root"] .line span {
-    font-family: "Monaco", "Menlo", "Consolas", "Ubuntu Mono", monospace !important;
+/* Use Mintlify's configured Paper Mono face throughout code blocks. */
+[data-component-part="code-block-root"] .font-mono {
     font-variant-ligatures: none !important;
     font-feature-settings: "kern" 0 !important;
-}
-
-/* Slightly reduce the code-block font size to limit horizontal scrolling.
-   Tighten line-height to match monospace table output while ensuring
-   box-drawing characters render fully. */
-[data-component-part="code-block-root"] .font-mono {
     font-size: 0.8125rem !important;
-    line-height: 1.5 !important;
+    line-height: 1.25 !important;
 }
 
 

--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -825,7 +825,14 @@ html:not(.dark) .pagination-prev:hover {
     max-width: none !important;
 }
 
-/* Use Mintlify's configured Paper Mono face throughout code blocks. */
+/* Match the monospace stack used by the server's built-in documentation. */
+[data-component-part="code-block-root"] pre.shiki,
+[data-component-part="code-block-root"] code,
+[data-component-part="code-block-root"] .line,
+[data-component-part="code-block-root"] .line span {
+    font-family: "DejaVu Sans Mono", "Liberation Mono", "MonoLisa", "Consolas", monospace !important;
+}
+
 [data-component-part="code-block-root"] .font-mono {
     font-variant-ligatures: none !important;
     font-feature-settings: "kern" 0 !important;


### PR DESCRIPTION
Mintlify code blocks used a 1.5 line height and a font that rendered ASCII and box-drawing characters with different advances. This pins the monospace stack used by the server's built-in documentation on the rendered Shiki tree and tightens the line height to 1.25.

Verified using the isolated `mint-preview` container on the HTTP `Pretty` output example. Chromium, Firefox, and WebKit render all five table rows at equal widths with 13px text and a 16.25px line height.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.364` (included in `26.8` and later)
<!-- ch-version-info:end -->