### PR TITLE
Fix 01666_merge_tree_max_query_limit under parallel replicas

### DIFF
--- a/tests/queries/0_stateless/01666_merge_tree_max_query_limit.sh
+++ b/tests/queries/0_stateless/01666_merge_tree_max_query_limit.sh
@@ -5,6 +5,12 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# The throttle asserted below is a per-table counter keyed on query id. Under parallel replicas one
+# statement becomes several reads of the same table on the same server, each carrying a different
+# query id, so the long running query competes against itself for the single max_concurrent_queries
+# slot and is rejected instead of holding it.
+CLICKHOUSE_CLIENT="${CLICKHOUSE_CLIENT} --automatic_parallel_replicas_mode 0 --enable_parallel_replicas 0"
+
 function wait_for_query_to_start() {
     while [[ $($CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "SELECT sum(read_rows) FROM system.processes WHERE query_id = '$1'") == 0 ]]; do sleep 0.1; done
 }


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/111230
Related: https://github.com/ClickHouse/ClickHouse/pull/108091
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #111230. Found by CI triage on #108091.

`01666_merge_tree_max_query_limit` fails on `Stateless tests (amd_llvm_coverage, ParallelReplicas, s3 storage, parallel)`, including on master (`86d92d6b4119f54a`, `71ec9afe6fed1be8`, both `Failed 3 out of 3 reruns`), with `Expected error code: 202 but got: 0`. It became reachable on that lane when #111230 removed its entry from `tests/parallel_replicas_blacklist.txt`; the entry dated from January 2025 with the reason `!!!Reason: Timeout!`.

Root cause: the throttle the test asserts is a per-table counter keyed on query id (`checkLimits` -> `getQueryIdHolder` -> `insertQueryIdOrThrowNoLock`). `ReadFromParallelRemoteReplicasStep::createPipeForSingeReplica` builds each secondary `RemoteQueryExecutor` without calling `setQueryId`, so the query id is sent empty and `Context::setCurrentQueryId` turns it into a random UUID. With `max_concurrent_queries = 1` the long running query that should hold the single slot becomes several differently-keyed reads of the same table on the same server, so it competes against itself and is rejected instead of holding the slot, and the last assertion gets code 0. `system.query_log` shows two secondary reads of the holder's own statement rejected with 202, then the holder itself, within 204 ms. If that lands before `read_rows` is visible, `wait_for_query_to_start` instead spins on `sum(read_rows)` over zero rows, which is the recorded timeout mode. `ReadFromParallelReplicasStep` omits `setQueryId` the same way.

The fix pins parallel replicas off for the test's client, so all three 202 assertions keep running on every lane. It neither restores the blacklist entry nor undoes #111230, which was right for the other 13 tests it removed. A parallel-replicas-coherent engine throttle would be a separate change.

Validation, one server, both directions: unpinned 0/30 runs match the reference (4 `202 but got: 0`, 21 hang, 5 other); pinned 30/30. With randomization on, 50/50 pass on local disk and 50/50 on S3, 0 skipped in either. `--enable_parallel_replicas 0` alone suffices; `--automatic_parallel_replicas_mode 0` is redundant here, kept to match `03164_selects_with_pk_usage_profile_event.sh` and `03518_key_condition_binary_search.sh`.