### PR TITLE
Document that a float NaN JOIN key can match NaN

### DIFF
--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -275,10 +275,10 @@ SELECT A.name, B.score FROM A LEFT JOIN B ON isNotDistinctFrom(A.id, B.id)
 └─────────┴───────┘
 ```
 
-`NaN` values in a float JOIN keys do not follow the `NULL` rule above.
+`NaN` values in float JOIN keys do not follow the `NULL` rule above.
 A scalar comparison of two NaN values (`NaN = NaN`) is `0`, however, `JOIN` keys are not compared using scalar semantics - `NaN` keys may match.
-If they actually do is an implementation detail and depends on the join algorithm, the key type, and the session settings.
-Do do not rely on a specific behavior.
+Whether they actually do is an implementation detail and depends on the join algorithm, the key type, and the session settings.
+Do not rely on a specific behavior.
 If you require that `NaN` rows do not match, map them to `NULL` values: `ON if(isNaN(A.id), NULL, A.id) = B.id`.
 In an `ASOF JOIN`, the closest-match column is compared by ordering, which `NaN` does not support — filter such rows out on both sides.
 

--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -221,7 +221,7 @@ key2    a2    1    1    1            0    0    \N
 key4    f    2    3    4            0    0    \N
 ```
 
-## NULL values in JOIN keys {#null-values-in-join-keys}
+## NULL and NaN values in JOIN keys {#null-values-in-join-keys}
 
 `NULL` is not equal to any value, including itself. This means that if a `JOIN` key has a `NULL` value in one table, it won't match a `NULL` value in the other table.
 
@@ -275,14 +275,12 @@ SELECT A.name, B.score FROM A LEFT JOIN B ON isNotDistinctFrom(A.id, B.id)
 └─────────┴───────┘
 ```
 
-<Warning>
-`NaN` in a `Float` `JOIN` key does not follow the `NULL` rule above. The scalar comparison
-`NaN = NaN` is `0`, but `JOIN` keys are not compared with scalar semantics, so `NaN` keys can match
-each other. Whether they do is not specified: it varies with the join algorithm, the key type, and
-the settings in effect, so do not rely on either outcome. When `NaN` rows must not match, map them
-to `NULL` in the key: `ON if(isNaN(A.id), NULL, A.id) = B.id`. In an `ASOF JOIN`, the closest-match
-column is compared by ordering, which `NaN` does not support — filter such rows out on both sides.
-</Warning>
+`NaN` values in a float JOIN keys do not follow the `NULL` rule above.
+A scalar comparison of two NaN values (`NaN = NaN`) is `0`, however, `JOIN` keys are not compared using scalar semantics - `NaN` keys may match.
+If they actually do is an implementation detail and depends on the join algorithm, the key type, and the session settings.
+Do do not rely on a specific behavior.
+If you require that `NaN` rows do not match, map them to `NULL` values: `ON if(isNaN(A.id), NULL, A.id) = B.id`.
+In an `ASOF JOIN`, the closest-match column is compared by ordering, which `NaN` does not support — filter such rows out on both sides.
 
 ## ASOF JOIN usage {#asof-join-usage}
 

--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -275,22 +275,14 @@ SELECT A.name, B.score FROM A LEFT JOIN B ON isNotDistinctFrom(A.id, B.id)
 └─────────┴───────┘
 ```
 
+<Warning>
 `NaN` in a `Float` `JOIN` key does not follow the `NULL` rule above. The scalar comparison
-`NaN = NaN` is `0`, but an equality `JOIN` key is not compared with those scalar semantics, so `NaN`
-keys can match each other. Do not rely on either outcome: whether two `NaN` keys match is not
-specified, and it varies with the join implementation that ClickHouse chooses, with the key type, and
-with the settings in effect. The merge algorithms, for instance, use the column comparator, which
-reports any two `NaN` values as equal, while the hash algorithms compare the key bytes and so treat
-`NaN` values with different bit patterns as different keys. `isNotDistinctFrom` does not reliably
-separate them either. On a key that is not `Nullable`, use `ON if(isNaN(A.id), NULL, A.id) = B.id`
-when `NaN` rows must not match. On a `Nullable(Float)` key that form also stops `NULL` keys from
-matching each other, because `isNaN(NULL)` is `NULL`. To drop only the `NaN` matches and keep the
-`NULL = NULL` matches of the section above, write
-`ON isNotDistinctFrom(A.id, B.id) AND NOT ifNull(isNaN(A.id), 0)` instead. That
-predicate adds a condition besides the key equality, which not every join algorithm accepts, so
-`join_algorithm = 'full_sorting_merge'` on its own may reject it depending on the `JOIN` kind. The
-closest match key of an `ASOF JOIN` is searched by ordering, so exclude `NaN` from that key on both
-sides when it can occur.
+`NaN = NaN` is `0`, but `JOIN` keys are not compared with scalar semantics, so `NaN` keys can match
+each other. Whether they do is not specified: it varies with the join algorithm, the key type, and
+the settings in effect, so do not rely on either outcome. When `NaN` rows must not match, map them
+to `NULL` in the key: `ON if(isNaN(A.id), NULL, A.id) = B.id`. In an `ASOF JOIN`, the closest-match
+column is compared by ordering, which `NaN` does not support — filter such rows out on both sides.
+</Warning>
 
 ## ASOF JOIN usage {#asof-join-usage}
 

--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -275,8 +275,8 @@ SELECT A.name, B.score FROM A LEFT JOIN B ON isNotDistinctFrom(A.id, B.id)
 └─────────┴───────┘
 ```
 
-`NaN` in a [Float](/reference/data-types/float) `JOIN` key does not follow the `NULL` rule above. The
-scalar comparison `NaN = NaN` is `0`, but an equality `JOIN` key is compared by key identity, so `NaN`
+`NaN` in a `Float` `JOIN` key does not follow the `NULL` rule above. The scalar comparison
+`NaN = NaN` is `0`, but an equality `JOIN` key is compared by key identity, so `NaN`
 keys can match each other. Whether they do depends on their bit patterns and on the join
 implementation that ClickHouse chooses, and `isNotDistinctFrom` does not reliably separate them. On a
 key that is not `Nullable`, use `ON if(isNaN(A.id), NULL, A.id) = B.id` when `NaN` rows must not

--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -275,6 +275,19 @@ SELECT A.name, B.score FROM A LEFT JOIN B ON isNotDistinctFrom(A.id, B.id)
 └─────────┴───────┘
 ```
 
+`NaN` in a [Float](/reference/data-types/float) `JOIN` key does not follow the `NULL` rule above. The
+scalar comparison `NaN = NaN` is `0`, but an equality `JOIN` key is compared by key identity, so `NaN`
+keys can match each other. Whether they do depends on their bit patterns and on the join
+implementation that ClickHouse chooses, and `isNotDistinctFrom` does not reliably separate them. On a
+key that is not `Nullable`, use `ON if(isNaN(A.id), NULL, A.id) = B.id` when `NaN` rows must not
+match. On a `Nullable(Float)` key that form also stops `NULL` keys from matching each other, because
+`isNaN(NULL)` is `NULL`. To drop only the `NaN` matches and keep the `NULL = NULL` matches of the
+section above, write `ON isNotDistinctFrom(A.id, B.id) AND NOT ifNull(isNaN(A.id), 0)` instead. That
+predicate adds a condition besides the key equality, which not every join algorithm accepts, so
+`join_algorithm = 'full_sorting_merge'` on its own may reject it depending on the `JOIN` kind. The
+closest match key of an `ASOF JOIN` is searched by ordering rather than by key identity, so exclude
+`NaN` from that key on both sides when it can occur.
+
 ## ASOF JOIN usage {#asof-join-usage}
 
 `ASOF JOIN` is useful when you need to join records that have no exact match.

--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -275,8 +275,8 @@ SELECT A.name, B.score FROM A LEFT JOIN B ON isNotDistinctFrom(A.id, B.id)
 └─────────┴───────┘
 ```
 
-`NaN` values in float JOIN keys do not follow the `NULL` rule above.
-A scalar comparison of two NaN values (`NaN = NaN`) is `0`, however, `JOIN` keys are not compared using scalar semantics - `NaN` keys may match.
+`NaN` values in float `JOIN` keys do not follow the `NULL` rule above.
+A scalar comparison of two `NaN` values (`NaN = NaN`) is `0`, however, `JOIN` keys are not compared using scalar semantics - `NaN` keys may match.
 Whether they actually do is an implementation detail and depends on the join algorithm, the key type, and the session settings.
 Do not rely on a specific behavior.
 If you require that `NaN` rows do not match, map them to `NULL` values: `ON if(isNaN(A.id), NULL, A.id) = B.id`.

--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -276,17 +276,21 @@ SELECT A.name, B.score FROM A LEFT JOIN B ON isNotDistinctFrom(A.id, B.id)
 ```
 
 `NaN` in a `Float` `JOIN` key does not follow the `NULL` rule above. The scalar comparison
-`NaN = NaN` is `0`, but an equality `JOIN` key is compared by key identity, so `NaN`
-keys can match each other. Whether they do depends on their bit patterns and on the join
-implementation that ClickHouse chooses, and `isNotDistinctFrom` does not reliably separate them. On a
-key that is not `Nullable`, use `ON if(isNaN(A.id), NULL, A.id) = B.id` when `NaN` rows must not
-match. On a `Nullable(Float)` key that form also stops `NULL` keys from matching each other, because
-`isNaN(NULL)` is `NULL`. To drop only the `NaN` matches and keep the `NULL = NULL` matches of the
-section above, write `ON isNotDistinctFrom(A.id, B.id) AND NOT ifNull(isNaN(A.id), 0)` instead. That
+`NaN = NaN` is `0`, but an equality `JOIN` key is not compared with those scalar semantics, so `NaN`
+keys can match each other. Do not rely on either outcome: whether two `NaN` keys match is not
+specified, and it varies with the join implementation that ClickHouse chooses, with the key type, and
+with the settings in effect. The merge algorithms, for instance, use the column comparator, which
+reports any two `NaN` values as equal, while the hash algorithms compare the key bytes and so treat
+`NaN` values with different bit patterns as different keys. `isNotDistinctFrom` does not reliably
+separate them either. On a key that is not `Nullable`, use `ON if(isNaN(A.id), NULL, A.id) = B.id`
+when `NaN` rows must not match. On a `Nullable(Float)` key that form also stops `NULL` keys from
+matching each other, because `isNaN(NULL)` is `NULL`. To drop only the `NaN` matches and keep the
+`NULL = NULL` matches of the section above, write
+`ON isNotDistinctFrom(A.id, B.id) AND NOT ifNull(isNaN(A.id), 0)` instead. That
 predicate adds a condition besides the key equality, which not every join algorithm accepts, so
 `join_algorithm = 'full_sorting_merge'` on its own may reject it depending on the `JOIN` kind. The
-closest match key of an `ASOF JOIN` is searched by ordering rather than by key identity, so exclude
-`NaN` from that key on both sides when it can occur.
+closest match key of an `ASOF JOIN` is searched by ordering, so exclude `NaN` from that key on both
+sides when it can occur.
 
 ## ASOF JOIN usage {#asof-join-usage}
 


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/106531
Related: https://github.com/ClickHouse/ClickHouse/pull/106540
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/106540
Closes: https://github.com/ClickHouse/ClickHouse/issues/106531

@ PedroTadim asked for a docs PR after #106540 was closed. This adds one paragraph to the
`NULL values in JOIN keys` section of `join.mdx`, which a reader would read as covering `NaN`.

An equality `JOIN` key is not compared with the scalar `=` semantics, so `NaN = NaN` is `0` while a
`Float` `JOIN` key holding `NaN` can still match on the other side. The paragraph states that the
outcome is unspecified and varies with the join implementation, the key type and the settings, and
gives the two comparators as illustrations: the merge algorithms use `FloatCompareHelper::compare`,
which reports any two `NaN` values equal, while the hash algorithms compare key bytes via `bitEquals`.
It promises no per-algorithm outcome, because further layers change it: a `LowCardinality(Float)` key
can arrive with its `NaN` payloads already collapsed to one dictionary entry, and the default-enabled
join runtime filter drops matching `NaN` probe rows when the build side has one distinct key (a
separate defect). `isNotDistinctFrom` does not separate `NaN` either; the
paragraph gives a form that does, and scopes itself away from `ASOF`.

Per review this is docs-only: the `Float`-page correction and a stale test comment were removed at
@ PedroTadim's request. The paragraph no longer points at the `Float` page, because that page states
the byte-wise rule as a blanket fact. Measured on master with runtime filters off:

| right-side `NaN` | hash / parallel_hash / grace_hash / direct | full_sorting_merge / partial_merge |
|---|---|---|
| same bit pattern (`7FF8000000000000` both sides) | matches | matches |
| different bit pattern (`nan` vs `0./0.`) | no match | matches |

I have asked in the review thread how you would like that page handled rather than opening a follow-up
you did not ask for. The `docs/en` copies are untouched.




<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.676` (included in `26.8` and later)
<!-- ch-version-info:end -->