### PR TITLE
iceberg v2 without seq_num

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Common/AvroForIcebergDeserializer.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Common/AvroForIcebergDeserializer.cpp
@@ -114,7 +114,7 @@ ParsedManifestFileEntryPtr AvroForIcebergDeserializer::createParsedManifestFileE
 {
     const auto format_version = getFormatVersionFromManifestFileMetadata();
     FileContentType content_type = FileContentType::DATA;
-    if (format_version > 1)
+    if (format_version > 1 && hasPath(c_data_file_content))
         content_type = FileContentType(getValueFromRowByName(row_index, c_data_file_content, TypeIndex::Int32).safeGet<UInt64>());
     const auto status = ManifestEntryStatus(getValueFromRowByName(row_index, f_status, TypeIndex::Int32).safeGet<UInt64>());
 
@@ -140,20 +140,27 @@ ParsedManifestFileEntryPtr AvroForIcebergDeserializer::createParsedManifestFileE
 
     if (format_version > 1)
     {
-        const auto sequence_number_value = getValueFromRowByName(row_index, f_sequence_number);
-        if (sequence_number_value.isNull())
+        if (!hasPath(f_sequence_number))
         {
-            if (status == ManifestEntryStatus::EXISTING)
-            {
-                throw Exception(
-                    ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
-                    "Cannot read Iceberg table: manifest file '{}' has entry with status 'EXISTING' without sequence number",
-                    manifest_file_path);
-            }
+            sequence_number = 0;
         }
         else
         {
-            sequence_number = sequence_number_value.safeGet<Int64>();
+            const auto sequence_number_value = getValueFromRowByName(row_index, f_sequence_number);
+            if (sequence_number_value.isNull())
+            {
+                if (status == ManifestEntryStatus::EXISTING)
+                {
+                    throw Exception(
+                        ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
+                        "Cannot read Iceberg table: manifest file '{}' has entry with status 'EXISTING' without sequence number",
+                        manifest_file_path);
+                }
+            }
+            else
+            {
+                sequence_number = sequence_number_value.safeGet<Int64>();
+            }
         }
     }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
@@ -254,10 +254,6 @@ std::shared_ptr<ManifestFileIterator> ManifestFileIterator::create(
                 DB::ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "Required columns are not found in manifest file: {}", column_name);
     }
 
-    if (manifest_format_version > 1 && !manifest_file_deserializer_->hasPath(f_sequence_number))
-        throw Exception(
-            ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "Required columns are not found in manifest file: {}", f_sequence_number);
-
     Poco::JSON::Parser parser;
 
     auto partition_spec_json_string = manifest_file_deserializer_->tryGetAvroMetadataValue("partition-spec");

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.cpp
@@ -213,13 +213,12 @@ ManifestFileCacheKeys getManifestList(
                     i,
                     f_manifest_length);
             }
-            if (manifest_list_format_version > 1)
-            {
+            if (manifest_list_format_version > 1 && manifest_list_deserializer.hasPath(f_sequence_number))
                 added_sequence_number
                     = manifest_list_deserializer.getValueFromRowByName(i, f_sequence_number, TypeIndex::Int64).safeGet<Int64>();
+            if (manifest_list_format_version > 1 && manifest_list_deserializer.hasPath(f_content))
                 content_type = Iceberg::ManifestFileContentType(
                     manifest_list_deserializer.getValueFromRowByName(i, f_content, TypeIndex::Int32).safeGet<Int32>());
-            }
             if (!manifest_list_deserializer.hasPath(f_partition_spec_id))
                 throw Exception(
                     ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -8,10 +8,13 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 
+import avro.schema as avro_schema
 import pyarrow as pa
 import pytest
 import requests
 import pytz
+from avro.datafile import DataFileReader, DataFileWriter
+from avro.io import DatumReader, DatumWriter
 from pyiceberg.catalog import load_catalog
 from pyiceberg.partitioning import PartitionField, PartitionSpec
 from pyiceberg.schema import Schema
@@ -977,6 +980,108 @@ def test_insert_into_table_without_optional_metadata_arrays(started_cluster, fie
         settings={"allow_insert_into_iceberg": 1, "write_full_path_in_iceberg_metadata": 1},
     )
     assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`") == "\\N\tAAPL\t193.24\t193.31\t('bot')\n"
+
+
+def _get_s3_object_bytes(minio_client, bucket, key):
+    response = minio_client.get_object(bucket, key)
+    data = b""
+    for chunk in response.stream():
+        data += chunk
+    return data
+
+
+def _put_s3_object_bytes(minio_client, bucket, key, data):
+    minio_client.put_object(bucket, key, io.BytesIO(data), len(data))
+
+
+def _rewrite_avro_without_fields(raw_avro, fields_to_drop, nested_fields_to_drop=None):
+    nested_fields_to_drop = nested_fields_to_drop or {}
+    reader = DataFileReader(io.BytesIO(raw_avro), DatumReader())
+    schema = json.loads(reader.meta["avro.schema"].decode())
+    codec = reader.meta.get("avro.codec", b"null").decode()
+    user_meta = {k: v for k, v in reader.meta.items() if not k.startswith("avro.")}
+    records = list(reader)
+    reader.close()
+
+    assert user_meta["format-version"] == b"2"
+    assert set(fields_to_drop).issubset({f["name"] for f in schema["fields"]})
+
+    schema["fields"] = [f for f in schema["fields"] if f["name"] not in fields_to_drop]
+    for field in schema["fields"]:
+        if field["name"] in nested_fields_to_drop:
+            dropped = nested_fields_to_drop[field["name"]]
+            assert set(dropped).issubset({f["name"] for f in field["type"]["fields"]})
+            field["type"]["fields"] = [f for f in field["type"]["fields"] if f["name"] not in dropped]
+
+    for record in records:
+        for name in fields_to_drop:
+            del record[name]
+        for name, dropped in nested_fields_to_drop.items():
+            for nested_name in dropped:
+                del record[name][nested_name]
+
+    out = io.BytesIO()
+    writer = DataFileWriter(out, DatumWriter(), avro_schema.parse(json.dumps(schema)), codec=codec)
+    for key, value in user_meta.items():
+        writer.set_meta(key, value)
+    for record in records:
+        writer.append(record)
+    writer.flush()
+    return out.getvalue()
+
+
+def _rewrite_s3_avro_without_fields(minio_client, path, fields_to_drop, nested_fields_to_drop=None):
+    assert path.startswith("s3://")
+    bucket, key = path[len("s3://") :].split("/", 1)
+    raw_avro = _get_s3_object_bytes(minio_client, bucket, key)
+    rewritten = _rewrite_avro_without_fields(raw_avro, fields_to_drop, nested_fields_to_drop)
+    _put_s3_object_bytes(minio_client, bucket, key, rewritten)
+
+
+@pytest.mark.parametrize("rewrite_manifest_list", [False, True])
+def test_select_manifest_without_sequence_number(started_cluster, rewrite_manifest_list):
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_manifest_without_sequence_number_{uuid.uuid4()}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+
+    catalog = load_catalog_impl(started_cluster)
+    catalog.create_namespace(root_namespace)
+    create_table(catalog, root_namespace, table_name)
+
+    num_rows = 10
+    table = catalog.load_table(f"{root_namespace}.{table_name}")
+    table.append(pa.Table.from_pylist([generate_record() for _ in range(num_rows)]))
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+    table_ref = f"{CATALOG_NAME}.`{root_namespace}.{table_name}`"
+
+    assert num_rows == int(node.query(f"SELECT count() FROM (SELECT * FROM {table_ref})"))
+
+    snapshot = catalog.load_table(f"{root_namespace}.{table_name}").current_snapshot()
+    manifests = snapshot.manifests(table.io)
+    assert len(manifests) > 0
+
+    for manifest in manifests:
+        _rewrite_s3_avro_without_fields(
+            started_cluster.minio_client,
+            manifest.manifest_path,
+            ["sequence_number", "file_sequence_number"],
+            {"data_file": ["content"]},
+        )
+
+    if rewrite_manifest_list:
+        _rewrite_s3_avro_without_fields(
+            started_cluster.minio_client,
+            snapshot.manifest_list,
+            ["sequence_number", "min_sequence_number", "content"],
+        )
+
+    node.query("SYSTEM DROP ICEBERG METADATA CACHE")
+
+    assert num_rows == int(node.query(f"SELECT count() FROM (SELECT * FROM {table_ref})"))
+    assert num_rows == int(node.query(f"SELECT count() FROM {table_ref} WHERE symbol = 'kek'"))
 
 
 def test_create(started_cluster):


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Iceberg v2 spec requires sequence_number in manifest files. However, other engines such as BigQuery could write those files without this field. This PR allow to read those non-spec tables


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.440` (included in `26.8` and later)
- Backported to: `26.7.2.45`
<!-- ch-version-info:end -->