### PR TITLE
Speed up the slowest tests in the fast test check

### DIFF
--- a/tests/queries/0_stateless/00156_max_execution_speed_sample_merge.sql
+++ b/tests/queries/0_stateless/00156_max_execution_speed_sample_merge.sql
@@ -1,14 +1,15 @@
--- Tags: no-random-settings, no-random-merge-tree-settings, no-parallel
+-- Tags: no-random-settings, no-random-merge-tree-settings
 -- This test validates that max_execution_speed & timeout_before_checking_execution_speed works with:
 --      a) regular query
 --      b) merge query
 -- NOTE: This test uses simple synthetic data to validate the fact throttling was applied.
 -- If throttling works as expected - each execution will take >= 1 second, as we allow not more than {max_execution_speed} records/sec
+--      (30 records are read at 15 records/sec, so ~2 seconds per query; without throttling it finishes in milliseconds)
 -- If it doesn't - each select will finish immediately, and the test will fail
--- NOTE: randomizer and parallelism are disabled as they can fiddle behaviour of merge and cause flakiness - we're checking functional correctness here
+-- NOTE: randomizer is disabled as it can fiddle the settings under test and cause flakiness - we're checking functional correctness here
 -- NOTE: sleep(0.001) per block ensures CLOCK_MONOTONIC_COARSE (ReadProgressCallback) ticks between reads - otherwise entire data can be read within a single ~10ms clock tick and skipping throttling
 
-SET max_execution_speed = 2;                      -- this is the parameter we're testing - execution to be throttled down to 2 records/sec
+SET max_execution_speed = 15;                     -- this is the parameter we're testing - execution to be throttled down to 15 records/sec
 SET timeout_before_checking_execution_speed = 0;  -- and to apply it immediately
 SET max_block_size = 1;                           -- this one needs to be tweaked to ensure only 1 record per block is read; otherwise we'll read everything at once, and throttling won't work
 

--- a/tests/queries/0_stateless/02293_part_log_has_merge_reason.sh
+++ b/tests/queries/0_stateless/02293_part_log_has_merge_reason.sh
@@ -23,41 +23,39 @@ ${CLICKHOUSE_CLIENT} -q '
 ${CLICKHOUSE_CLIENT} -q "INSERT INTO t_part_log_has_merge_type_table VALUES (now(), 1, 'username1');"
 ${CLICKHOUSE_CLIENT} -q "INSERT INTO t_part_log_has_merge_type_table VALUES (now() - INTERVAL 4 MONTH, 2, 'username2');"
 
-function get_parts_count() {
-    table_name=$1
-    ${CLICKHOUSE_CLIENT} -q '
-        SELECT
-            count(*)
-        FROM
-            system.parts
-        WHERE
-            table = '"'${table_name}'"'
-        AND
-            active = 1
-        AND
-            database = '"'${CLICKHOUSE_DATABASE}'"'
-    '
-}
-
-function wait_table_parts_are_merged_into_one_part() {
+# Wait for the merge itself to be logged. Waiting for the parts to be merged into a single active part would
+# take much longer: the TTL merge produces an empty part, which stays active until the cleanup thread drops it.
+function wait_for_merge_in_part_log() {
     table_name=$1
     local TIMELIMIT=$((SECONDS+60)) # 60 second timeout
 
     while [ $SECONDS -lt "$TIMELIMIT" ]
     do
-        count=$(get_parts_count $table_name)
-        if [[ count -gt 1 ]]
+        ${CLICKHOUSE_CLIENT} -q 'SYSTEM FLUSH LOGS part_log'
+        count=$(${CLICKHOUSE_CLIENT} -q '
+            SELECT
+                count(*)
+            FROM
+                system.part_log
+            WHERE
+                event_date >= yesterday() AND event_time >= now() - 600
+            AND
+                event_type = '"'MergeParts'"'
+            AND
+                table = '"'${table_name}'"'
+            AND
+                database = '"'${CLICKHOUSE_DATABASE}'"'
+        ')
+        if [[ count -eq 0 ]]
         then
-            sleep 1
+            sleep 0.2
         else
             break
         fi
     done
 }
 
-wait_table_parts_are_merged_into_one_part t_part_log_has_merge_type_table
-
-${CLICKHOUSE_CLIENT} -q 'SYSTEM FLUSH LOGS part_log'
+wait_for_merge_in_part_log t_part_log_has_merge_type_table
 
 ${CLICKHOUSE_CLIENT} -q '
   SELECT

--- a/tests/queries/0_stateless/02790_async_queries_in_query_log.sh
+++ b/tests/queries/0_stateless/02790_async_queries_in_query_log.sh
@@ -4,6 +4,10 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+# Pin the busy wait: the test checks what asynchronous inserts write to the logs, not how long they are
+# batched. These go on the command line, because the reference prints the SETTINGS clause of every insert.
+async_insert_opts=(--async_insert_use_adaptive_busy_timeout 0 --async_insert_busy_timeout_ms 1)
+
 function print_flush_query_logs()
 {
     ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS asynchronous_insert_log, query_log, query_views_log, part_log"
@@ -74,7 +78,7 @@ function print_flush_query_logs()
 ${CLICKHOUSE_CLIENT} -q "CREATE TABLE async_insert_landing (id UInt32) ENGINE = MergeTree ORDER BY id"
 
 query_id="$(random_str 10)"
-${CLICKHOUSE_CLIENT} --query_id="${query_id}" -q "INSERT INTO async_insert_landing SETTINGS wait_for_async_insert=1, async_insert=1 values (1), (2), (3), (4);"
+${CLICKHOUSE_CLIENT} --query_id="${query_id}" "${async_insert_opts[@]}" -q "INSERT INTO async_insert_landing SETTINGS wait_for_async_insert=1, async_insert=1 values (1), (2), (3), (4);"
 print_flush_query_logs ${query_id}
 
 
@@ -82,11 +86,11 @@ ${CLICKHOUSE_CLIENT} -q "CREATE TABLE async_insert_target (id UInt32) ENGINE = M
 ${CLICKHOUSE_CLIENT} -q "CREATE MATERIALIZED VIEW async_insert_mv TO async_insert_target AS SELECT id + throwIf(id = 42) AS id FROM async_insert_landing"
 
 query_id="$(random_str 10)"
-${CLICKHOUSE_CLIENT} --query_id="${query_id}" -q "INSERT INTO async_insert_landing SETTINGS wait_for_async_insert=1, async_insert=1 values (11), (12), (13);"
+${CLICKHOUSE_CLIENT} --query_id="${query_id}" "${async_insert_opts[@]}" -q "INSERT INTO async_insert_landing SETTINGS wait_for_async_insert=1, async_insert=1 values (11), (12), (13);"
 print_flush_query_logs ${query_id}
 
 
 query_id="$(random_str 10)"
 # Use materialized_views_ignore_errors to guarantee it lands in the landing table, making the test stable
-${CLICKHOUSE_CLIENT} --query_id="${query_id}" -q "INSERT INTO async_insert_landing SETTINGS wait_for_async_insert=1, async_insert=1, materialized_views_ignore_errors=1 values (42), (12), (13)" 2>/dev/null || true
+${CLICKHOUSE_CLIENT} --query_id="${query_id}" "${async_insert_opts[@]}" -q "INSERT INTO async_insert_landing SETTINGS wait_for_async_insert=1, async_insert=1, materialized_views_ignore_errors=1 values (42), (12), (13)" 2>/dev/null || true
 print_flush_query_logs ${query_id}

--- a/tests/queries/0_stateless/03748_async_insert_reset_setting.sh
+++ b/tests/queries/0_stateless/03748_async_insert_reset_setting.sh
@@ -7,7 +7,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 SYNC_USER="${CLICKHOUSE_DATABASE}_sync_user"
 ASYNC_USER="${CLICKHOUSE_DATABASE}_async_user"
 
-${CLICKHOUSE_CLIENT} --multiquery <<EOF
+# Pin the busy wait: the test checks which inserts end up asynchronous, not how long they are batched.
+${CLICKHOUSE_CLIENT} --async_insert_use_adaptive_busy_timeout 0 --async_insert_busy_timeout_ms 1 --multiquery <<EOF
 DROP TABLE IF EXISTS source_table, target_table, target_table_remote_sync, target_table_remote_async, async_insert_mv, sync_insert_mv;
 DROP USER IF EXISTS ${SYNC_USER}, ${ASYNC_USER};
 

--- a/tests/queries/0_stateless/04000_mutation_sync_replica_removed_race.sh
+++ b/tests/queries/0_stateless/04000_mutation_sync_replica_removed_race.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Tags: zookeeper, no-parallel, no-shared-merge-tree, no-replicated-database
+# Tags: zookeeper, no-parallel, no-shared-merge-tree, no-replicated-database, no-fasttest
+# no-fasttest: the fast test binary is built as RelWithDebInfo, where `chassert` is a no-op, so this test
+#              cannot detect the regression there. It keeps running in the debug and sanitizer builds.
 
 # Regression test for https://github.com/ClickHouse/ClickHouse/issues/97309
 #

--- a/tests/queries/0_stateless/04403_normalized_query_hash_quota_async_insert.sh
+++ b/tests/queries/0_stateless/04403_normalized_query_hash_quota_async_insert.sh
@@ -22,9 +22,7 @@ user="u_04403_${CLICKHOUSE_DATABASE}"
 quota="q_04403_${CLICKHOUSE_DATABASE}"
 table="t_04403_${CLICKHOUSE_DATABASE}"
 
-# The quota accounting does not depend on how long inserts are batched, so the busy wait is pinned to the
-# smallest possible value. Otherwise every insert waits for the adaptive busy timeout, whose upper bound is
-# raised to 5 seconds by the CI test config, and whose value is shared by all queries on the same queue shard.
+# Pin the busy wait: the quota accounting does not depend on how long inserts are batched.
 async_insert_opts="--async_insert 1 --wait_for_async_insert 1 --async_insert_use_adaptive_busy_timeout 0 --async_insert_busy_timeout_ms 1"
 
 # shellcheck disable=SC2086  # CLICKHOUSE_CLIENT and the options must be word-split.

--- a/tests/queries/0_stateless/04403_normalized_query_hash_quota_async_insert.sh
+++ b/tests/queries/0_stateless/04403_normalized_query_hash_quota_async_insert.sh
@@ -22,8 +22,13 @@ user="u_04403_${CLICKHOUSE_DATABASE}"
 quota="q_04403_${CLICKHOUSE_DATABASE}"
 table="t_04403_${CLICKHOUSE_DATABASE}"
 
-# shellcheck disable=SC2086  # CLICKHOUSE_CLIENT must be word-split.
-check_exceeded() { ${CLICKHOUSE_CLIENT} --user "${user}" --async_insert 1 --wait_for_async_insert 1 --send_logs_level=none -q "$1" 2>&1 | grep -m1 -o QUOTA_EXCEEDED || echo allowed; }
+# The quota accounting does not depend on how long inserts are batched, so the busy wait is pinned to the
+# smallest possible value. Otherwise every insert waits for the adaptive busy timeout, whose upper bound is
+# raised to 5 seconds by the CI test config, and whose value is shared by all queries on the same queue shard.
+async_insert_opts="--async_insert 1 --wait_for_async_insert 1 --async_insert_use_adaptive_busy_timeout 0 --async_insert_busy_timeout_ms 1"
+
+# shellcheck disable=SC2086  # CLICKHOUSE_CLIENT and the options must be word-split.
+check_exceeded() { ${CLICKHOUSE_CLIENT} --user "${user}" ${async_insert_opts} --send_logs_level=none -q "$1" 2>&1 | grep -m1 -o QUOTA_EXCEEDED || echo allowed; }
 
 ${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS ${user}"
 ${CLICKHOUSE_CLIENT} -q "DROP QUOTA IF EXISTS ${quota}"


### PR DESCRIPTION
Six of the slowest tests in the fast test check, one commit each, with the reason it was slow.

- `00156_max_execution_speed_sample_merge` (45s, now ~5s): `SAMPLE 1/2` does not reduce the number of read rows, so both queries read all 30 rows at `max_execution_speed = 2`, taking 15 seconds each. Raised to 15 records/sec, still two orders of magnitude slower than the unthrottled query, so the assertion keeps its margin. Also dropped `no-parallel`, a leftover from when this test was `stateful` and read the shared `test.hits`.
- `02293_part_log_has_merge_reason` (36s, now ~1.2s): the test waited until the table had a single active part, but the `TTLDropMerge` it asserts is logged one millisecond after the inserts. The wait was spent on the empty part left behind by the TTL merge, which stays active until the cleanup thread drops it ~37 seconds later. It now polls `system.part_log` for the event it actually checks.
- `04403_normalized_query_hash_quota_async_insert` (18s), `03748_async_insert_reset_setting` (15s), `02790_async_queries_in_query_log` (14s): every asynchronous insert waited for the adaptive busy timeout. `tests/config/users.d/timeouts.xml` raises its upper bound to 5 seconds, and the adaptive value is kept per queue shard and shared by all queries on the server, so concurrent inserts from other tests ratchet it up. None of these tests check how long inserts are batched, so the busy wait is pinned to 1 ms. Measured per test by pinning the timeout: 20-30 seconds at the CI value against 0.4-1.1 seconds at 1 ms, with identical output.
- `04000_mutation_sync_replica_removed_race` (15s): tagged `no-fasttest`. It cannot be made fast, because its runtime is the race window it stresses. It also cannot catch anything in the fast test, which passes no `CMAKE_BUILD_TYPE` and so builds `RelWithDebInfo`, where the `chassert` this test guards compiles to a no-op. It keeps running in the debug and sanitizer builds.

`02932_refreshable_materialized_views_1` (11s) is not addressed here.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.411` (included in `26.8` and later)
<!-- ch-version-info:end -->