### PR TITLE
Track host CPU/RAM usage in praktika jobs

### DIFF
--- a/ci/praktika/host_metrics.py
+++ b/ci/praktika/host_metrics.py
@@ -1,0 +1,195 @@
+import json
+import threading
+import time
+import traceback
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from .settings import Settings
+
+
+class HostMetricsCollector:
+    """Samples whole-VM CPU and RAM usage in a background thread.
+
+    Dependency-free: reads ``/proc/stat`` and ``/proc/meminfo`` directly, so it
+    reflects the load of the whole host (not just this process) regardless of
+    whether the job itself runs inside Docker. Each sample is appended to a
+    ``jsonl`` file so partial data survives if the runner is killed (e.g. on an
+    OOM or a hard timeout). On ``stop`` the samples are decimated with a
+    min/max-per-bucket pass that preserves peaks and troughs, and returned as a
+    plain dict ready to be stored in ``Result.ext["metrics"]``.
+
+    On a non-Linux host (no ``/proc``) the collector is a no-op and ``stop``
+    returns ``None``.
+    """
+
+    _CPU_STAT = "/proc/stat"
+    _MEMINFO = "/proc/meminfo"
+
+    def __init__(
+        self,
+        out_file: str = Settings.HOST_METRICS_FILE,
+        interval: float = Settings.HOST_METRICS_SAMPLE_INTERVAL_SEC,
+        max_points: int = Settings.HOST_METRICS_MAX_POINTS,
+    ):
+        self._out_file = out_file
+        self._interval = max(0.1, float(interval))
+        self._max_points = max(2, int(max_points))
+        self._available = Path(self._CPU_STAT).exists() and Path(self._MEMINFO).exists()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._samples: List[Dict[str, float]] = []
+        self._mem_total_kb = 0
+        self._started = False
+        self._stopped = False
+
+    def start(self) -> "HostMetricsCollector":
+        if not Settings.HOST_METRICS_ENABLED:
+            return self
+        if not self._available:
+            print("NOTE: Host metrics collection is not available on this platform (no /proc) - skipping")
+            return self
+        if self._started:
+            return self
+        self._started = True
+        # Truncate any stale file from a previous run in the same workspace.
+        try:
+            Path(self._out_file).parent.mkdir(parents=True, exist_ok=True)
+            open(self._out_file, "w", encoding="utf8").close()
+        except OSError as e:
+            print(f"WARNING: Failed to init host metrics file [{self._out_file}]: {e}")
+            self._available = False
+            return self
+        self._thread = threading.Thread(target=self._run, name="host-metrics", daemon=True)
+        self._thread.start()
+        print(f"NOTE: Host metrics collection started (interval {self._interval}s, file [{self._out_file}])")
+        return self
+
+    def stop(self) -> Optional[Dict]:
+        """Stop sampling and return the compacted metrics, or None if disabled."""
+        if not self._started or self._stopped:
+            return None
+        self._stopped = True
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self._interval * 2 + 5)
+        if not self._samples:
+            return None
+        return self._compact(self._samples)
+
+    def _run(self):
+        # The first /proc/stat read only establishes a baseline; CPU% needs a
+        # delta between two reads, so no sample is emitted for it.
+        prev_cpu = self._read_cpu_times()
+        start = time.monotonic()
+        while not self._stop_event.is_set():
+            # Sleep first so the first emitted sample already has a valid CPU
+            # delta over one interval.
+            self._stop_event.wait(self._interval)
+            try:
+                cur_cpu = self._read_cpu_times()
+                cpu_pct = self._cpu_percent(prev_cpu, cur_cpu)
+                prev_cpu = cur_cpu
+                mem_pct = self._mem_percent()
+                sample = {
+                    "t": round(time.monotonic() - start, 1),
+                    "cpu": cpu_pct,
+                    "mem": mem_pct,
+                }
+            except Exception as e:
+                # A transient /proc read failure must not kill the collector.
+                print(f"WARNING: Host metrics sample failed: {e}")
+                traceback.print_exc()
+                continue
+            self._samples.append(sample)
+            self._append_to_fs(sample)
+
+    def _append_to_fs(self, sample: Dict[str, float]):
+        try:
+            with open(self._out_file, "a", encoding="utf8") as f:
+                f.write(json.dumps(sample) + "\n")
+        except OSError as e:
+            print(f"WARNING: Failed to append host metrics sample: {e}")
+
+    def _read_cpu_times(self) -> Tuple[int, int]:
+        """Return (idle_all, total) jiffies from the aggregate ``cpu`` line."""
+        with open(self._CPU_STAT, "r", encoding="utf8") as f:
+            line = f.readline()
+        # cpu  user nice system idle iowait irq softirq steal guest guest_nice
+        fields = [int(x) for x in line.split()[1:]]
+        idle = fields[3] + (fields[4] if len(fields) > 4 else 0)  # idle + iowait
+        total = sum(fields)
+        return idle, total
+
+    @staticmethod
+    def _cpu_percent(prev: Tuple[int, int], cur: Tuple[int, int]) -> float:
+        idle_delta = cur[0] - prev[0]
+        total_delta = cur[1] - prev[1]
+        if total_delta <= 0:
+            return 0.0
+        busy = 100.0 * (total_delta - idle_delta) / total_delta
+        return round(max(0.0, min(100.0, busy)), 1)
+
+    def _mem_percent(self) -> float:
+        total_kb = 0
+        available_kb = 0
+        with open(self._MEMINFO, "r", encoding="utf8") as f:
+            for line in f:
+                if line.startswith("MemTotal:"):
+                    total_kb = int(line.split()[1])
+                elif line.startswith("MemAvailable:"):
+                    available_kb = int(line.split()[1])
+                if total_kb and available_kb:
+                    break
+        if not total_kb:
+            return 0.0
+        self._mem_total_kb = total_kb
+        used = total_kb - available_kb
+        return round(max(0.0, min(100.0, 100.0 * used / total_kb)), 1)
+
+    def _compact(self, samples: List[Dict[str, float]]) -> Dict:
+        cpu_points = [(s["t"], s["cpu"]) for s in samples]
+        mem_points = [(s["t"], s["mem"]) for s in samples]
+        return {
+            "interval": self._interval,
+            "duration": samples[-1]["t"] if samples else 0,
+            "mem_total_gb": round(self._mem_total_kb / 1024.0 / 1024.0, 2),
+            "n_raw": len(samples),
+            "series": {
+                "cpu": self._decimate(cpu_points, self._max_points),
+                "mem": self._decimate(mem_points, self._max_points),
+            },
+        }
+
+    @staticmethod
+    def _decimate(points: List[Tuple[float, float]], max_points: int) -> List[List[float]]:
+        """Downsample preserving the envelope (per-bucket min and max).
+
+        The first and last samples are always kept. The middle is split into
+        buckets; from each bucket the minimum and maximum values are emitted in
+        time order, so spikes and dips are never smoothed away.
+        """
+        n = len(points)
+        if n <= max_points:
+            return [[t, v] for t, v in points]
+
+        first, last = points[0], points[-1]
+        middle = points[1:-1]
+        # Two points (min, max) per bucket, plus the fixed first/last.
+        n_buckets = max(1, (max_points - 2) // 2)
+        bucket_size = len(middle) / n_buckets
+
+        result: List[Tuple[float, float]] = [first]
+        for b in range(n_buckets):
+            lo = int(b * bucket_size)
+            hi = int((b + 1) * bucket_size) if b < n_buckets - 1 else len(middle)
+            chunk = middle[lo:hi]
+            if not chunk:
+                continue
+            min_p = min(chunk, key=lambda p: p[1])
+            max_p = max(chunk, key=lambda p: p[1])
+            # Emit the two extrema in their original time order (dedup if equal).
+            pair = sorted({min_p, max_p}, key=lambda p: p[0])
+            result.extend(pair)
+        result.append(last)
+        return [[t, v] for t, v in result]

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1112,6 +1112,183 @@
         }
     }
 
+    // Renders the whole-VM CPU/RAM timeline collected by praktika's
+    // HostMetricsCollector and stored in a job Result's ext.metrics.
+    // Shape: { interval, duration, mem_total_gb, n_raw,
+    //          series: { cpu: [[t,pct],...], mem: [[t,pct],...] } }
+    function addHostMetricsChart(metrics) {
+        if (!metrics || !metrics.series) return;
+        const cpu = metrics.series.cpu || [];
+        const mem = metrics.series.mem || [];
+        if (cpu.length < 2 && mem.length < 2) return;
+
+        const statusContainer = document.getElementById("status-container");
+        const wrapper = document.createElement("div");
+        wrapper.className = "status-widget";
+        wrapper.style.position = "relative";
+
+        const CPU_COLOR = "#4e79a7";
+        const MEM_COLOR = "#e15759";
+
+        const peak = (s) => s.reduce((m, p) => Math.max(m, p[1]), 0);
+        const cpuPeak = peak(cpu), memPeak = peak(mem);
+        const duration = Math.max(
+            metrics.duration || 0,
+            cpu.length ? cpu[cpu.length - 1][0] : 0,
+            mem.length ? mem[mem.length - 1][0] : 0,
+            1
+        );
+
+        const fmtT = (sec) => {
+            sec = Math.round(sec);
+            const h = Math.floor(sec / 3600);
+            const m = Math.floor((sec % 3600) / 60);
+            const s = sec % 60;
+            if (h > 0) return `${h}h${String(m).padStart(2, "0")}m`;
+            if (m > 0) return `${m}m${String(s).padStart(2, "0")}s`;
+            return `${s}s`;
+        };
+
+        // Header: title + legend with peak values.
+        const header = document.createElement("div");
+        header.style.display = "flex";
+        header.style.justifyContent = "space-between";
+        header.style.alignItems = "baseline";
+        header.style.fontSize = "0.8em";
+        header.style.marginBottom = "4px";
+        const title = document.createElement("div");
+        title.textContent = "host usage";
+        const legend = document.createElement("div");
+        legend.style.fontSize = "0.85em";
+        legend.innerHTML =
+            `<span style="color:${CPU_COLOR}">■</span> cpu ${cpuPeak.toFixed(0)}% peak &nbsp;` +
+            `<span style="color:${MEM_COLOR}">■</span> ram ${memPeak.toFixed(0)}%` +
+            (metrics.mem_total_gb ? ` of ${metrics.mem_total_gb}GB` : "");
+        header.appendChild(title);
+        header.appendChild(legend);
+        wrapper.appendChild(header);
+
+        // Responsive SVG (scales to the widget width via viewBox).
+        const W = 320, H = 130, ML = 26, MR = 6, TP = 6, BP = 16;
+        const plotW = W - ML - MR, plotH = H - TP - BP;
+        const svgNS = "http://www.w3.org/2000/svg";
+        const svg = document.createElementNS(svgNS, "svg");
+        svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
+        svg.setAttribute("preserveAspectRatio", "none");
+        svg.style.width = "100%";
+        svg.style.height = `${H}px`;
+        svg.style.display = "block";
+        svg.style.cursor = "crosshair";
+
+        const gridColor =
+            getComputedStyle(document.body).getPropertyValue("--table-border-color").trim() || "#ccc";
+        const textColor =
+            getComputedStyle(document.body).getPropertyValue("--text-color").trim() || "#555";
+
+        const xScale = (t) => ML + (t / duration) * plotW;
+        const yScale = (v) => TP + (1 - Math.max(0, Math.min(100, v)) / 100) * plotH;
+
+        const mkLine = (x1, y1, x2, y2, color, opacity) => {
+            const l = document.createElementNS(svgNS, "line");
+            l.setAttribute("x1", x1); l.setAttribute("y1", y1);
+            l.setAttribute("x2", x2); l.setAttribute("y2", y2);
+            l.setAttribute("stroke", color);
+            if (opacity != null) l.setAttribute("stroke-opacity", opacity);
+            svg.appendChild(l);
+            return l;
+        };
+        const mkText = (x, y, str, anchor) => {
+            const t = document.createElementNS(svgNS, "text");
+            t.setAttribute("x", x); t.setAttribute("y", y);
+            t.setAttribute("font-size", "8");
+            t.setAttribute("fill", textColor);
+            t.setAttribute("text-anchor", anchor || "start");
+            t.textContent = str;
+            svg.appendChild(t);
+        };
+
+        // Horizontal gridlines + y labels at 0/50/100%.
+        [0, 50, 100].forEach((v) => {
+            const y = yScale(v);
+            mkLine(ML, y, W - MR, y, gridColor, 0.5);
+            mkText(ML - 3, y + 3, `${v}`, "end");
+        });
+        // X axis time labels.
+        mkText(ML, H - 4, "0s", "start");
+        mkText(W - MR, H - 4, fmtT(duration), "end");
+
+        const mkPath = (series, color) => {
+            if (series.length < 2) return;
+            const d = series
+                .map((p, i) => `${i === 0 ? "M" : "L"}${xScale(p[0]).toFixed(1)} ${yScale(p[1]).toFixed(1)}`)
+                .join(" ");
+            const path = document.createElementNS(svgNS, "path");
+            path.setAttribute("d", d);
+            path.setAttribute("fill", "none");
+            path.setAttribute("stroke", color);
+            path.setAttribute("stroke-width", "1.2");
+            path.setAttribute("vector-effect", "non-scaling-stroke");
+            svg.appendChild(path);
+        };
+        mkPath(mem, MEM_COLOR);
+        mkPath(cpu, CPU_COLOR);
+
+        // Hover cursor + tooltip.
+        const cursor = mkLine(ML, TP, ML, TP + plotH, textColor, 0);
+        const tip = document.createElement("div");
+        tip.style.position = "absolute";
+        tip.style.pointerEvents = "none";
+        tip.style.padding = "2px 5px";
+        tip.style.font = "11px monospace";
+        tip.style.background = "var(--info-background, rgba(0,0,0,0.8))";
+        tip.style.color = "var(--text-color, #fff)";
+        tip.style.border = `1px solid ${gridColor}`;
+        tip.style.borderRadius = "3px";
+        tip.style.whiteSpace = "nowrap";
+        tip.style.display = "none";
+        tip.style.zIndex = "10";
+        wrapper.appendChild(tip);
+
+        const nearest = (series, t) => {
+            if (!series.length) return null;
+            let best = series[0];
+            for (const p of series) {
+                if (Math.abs(p[0] - t) < Math.abs(best[0] - t)) best = p;
+            }
+            return best;
+        };
+
+        activeListeners.add(svg, "mousemove", (e) => {
+            const rect = svg.getBoundingClientRect();
+            // Map pixel x back to viewBox coordinates (svg is width-scaled).
+            const vx = ((e.clientX - rect.left) / rect.width) * W;
+            const t = ((vx - ML) / plotW) * duration;
+            if (t < 0 || t > duration) { cursor.setAttribute("stroke-opacity", 0); tip.style.display = "none"; return; }
+            const cx = xScale(t);
+            cursor.setAttribute("x1", cx); cursor.setAttribute("x2", cx);
+            cursor.setAttribute("stroke-opacity", 0.4);
+            const c = nearest(cpu, t), m = nearest(mem, t);
+            tip.innerHTML =
+                `${fmtT(t)}<br>` +
+                (c ? `<span style="color:${CPU_COLOR}">cpu</span> ${c[1].toFixed(0)}%<br>` : "") +
+                (m ? `<span style="color:${MEM_COLOR}">ram</span> ${m[1].toFixed(0)}%` : "");
+            tip.style.display = "block";
+            const left = Math.min(
+                (e.clientX - rect.left) + 8,
+                wrapper.clientWidth - tip.offsetWidth - 4
+            );
+            tip.style.left = `${Math.max(0, left)}px`;
+            tip.style.top = "20px";
+        });
+        activeListeners.add(svg, "mouseleave", () => {
+            cursor.setAttribute("stroke-opacity", 0);
+            tip.style.display = "none";
+        });
+
+        wrapper.appendChild(svg);
+        statusContainer.appendChild(wrapper);
+    }
+
     function addStorageUsageChartToStatus(usage_data) {
         const statusContainer = document.getElementById("status-container");
 
@@ -2079,6 +2256,7 @@
             addTimeTraceWidget(result.results, statusWidget, originalWorkflowDetails);
         }
         addStorageUsageChartToStatus(result.ext?.storage_usage)
+        addHostMetricsChart(result.ext?.metrics)
     }
 
     const persistentStorage = {

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -18,6 +18,7 @@ from .gh import GH
 from .gh_auth import GHAuth
 from .hook_cache import CacheRunnerHooks
 from .hook_html import HtmlRunnerHooks
+from .host_metrics import HostMetricsCollector
 from .info import Info
 from .native_jobs import _check_and_link_open_issues, _is_praktika_job
 from .result import Result, ResultInfo
@@ -466,48 +467,58 @@ class Runner:
             cmd += f" --workers {workers}"
         print(f"--- Run command [{cmd}]")
 
-        with TeePopen(
-            cmd,
-            timeout=job.timeout,
-            preserve_stdio=preserve_stdio,
-            timeout_shell_cleanup=job.timeout_shell_cleanup,
-        ) as process:
-            Utils.timestamp()
+        # Sample whole-VM CPU/RAM usage in the background for the duration of the
+        # job (see HostMetricsCollector). Runs on the host, so metrics cover the
+        # whole VM even when the job itself runs inside Docker.
+        host_metrics_collector = HostMetricsCollector().start()
+        try:
+            with TeePopen(
+                cmd,
+                timeout=job.timeout,
+                preserve_stdio=preserve_stdio,
+                timeout_shell_cleanup=job.timeout_shell_cleanup,
+            ) as process:
+                Utils.timestamp()
 
-            exit_code = process.wait()
+                exit_code = process.wait()
+                host_metrics = host_metrics_collector.stop()
 
-            # When running Docker containers as root (non-rootless mode), any files
-            # created by the job will be owned by root.  Fix ownership here, before
-            # reading the result file or writing the host-side result, so that the
-            # host user can open them without a PermissionError.
-            if job.run_in_docker and not no_docker and from_root:
-                print("--- Fixing file ownership after running docker as root")
-                uid = os.getuid()
-                gid = os.getgid()
-                chown_cmd = f"docker run --rm --user root --volume {host_dir_q}:{current_dir} --workdir={current_dir} {docker} chown -R {uid}:{gid} {Settings.TEMP_DIR}"
-                Shell.run(chown_cmd)
+                # When running Docker containers as root (non-rootless mode), any files
+                # created by the job will be owned by root.  Fix ownership here, before
+                # reading the result file or writing the host-side result, so that the
+                # host user can open them without a PermissionError.
+                if job.run_in_docker and not no_docker and from_root:
+                    print("--- Fixing file ownership after running docker as root")
+                    uid = os.getuid()
+                    gid = os.getgid()
+                    chown_cmd = f"docker run --rm --user root --volume {host_dir_q}:{current_dir} --workdir={current_dir} {docker} chown -R {uid}:{gid} {Settings.TEMP_DIR}"
+                    Shell.run(chown_cmd)
 
-            result = Result.from_fs(job.name)
-            if exit_code != 0:
-                if not result.is_completed():
-                    if process.timeout_exceeded:
-                        print(
-                            f"WARNING: Job timed out: [{job.name}], timeout [{job.timeout}], exit code [{exit_code}]"
-                        )
-                        result.add_error(ResultInfo.TIMEOUT)
-                    elif result.is_running():
-                        info = f"Job killed, exit code [{exit_code}]"
-                        print(f"ERROR: {info}")
-                        result.add_error(info)
-                    else:
-                        info = f"Invalid status [{result.status}] for exit code [{exit_code}]"
-                        print(f"ERROR: {info}")
-                        result.add_error(info)
-                    result.set_status(Result.Status.ERROR)
-                    result.set_info(
-                        process.get_latest_log(max_lines=20)
-                    )
-            result.dump()
+                result = Result.from_fs(job.name)
+                if host_metrics:
+                    result.add_ext_key_value("metrics", host_metrics)
+                if exit_code != 0:
+                    if not result.is_completed():
+                        if process.timeout_exceeded:
+                            print(
+                                f"WARNING: Job timed out: [{job.name}], timeout [{job.timeout}], exit code [{exit_code}]"
+                            )
+                            result.add_error(ResultInfo.TIMEOUT)
+                        elif result.is_running():
+                            info = f"Job killed, exit code [{exit_code}]"
+                            print(f"ERROR: {info}")
+                            result.add_error(info)
+                        else:
+                            info = f"Invalid status [{result.status}] for exit code [{exit_code}]"
+                            print(f"ERROR: {info}")
+                            result.add_error(info)
+                        result.set_status(Result.Status.ERROR)
+                        result.set_info(process.get_latest_log(max_lines=20))
+                result.dump()
+        finally:
+            # Idempotent: a no-op if stop() already ran above; guarantees the
+            # sampling thread is always joined even if TeePopen raised.
+            host_metrics_collector.stop()
 
         print("INFO: disk status after running a job:")
         Shell.run("df -h")

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -62,6 +62,18 @@ class _Settings:
     ENVIRONMENT_VAR_FILE: str = f"{TEMP_DIR}/environment.json"
     RUN_LOG: str = f"{TEMP_DIR}/job.log"
 
+    ######################################
+    #      Host metrics (CPU/RAM)        #
+    ######################################
+    # Sample whole-VM CPU and RAM usage in the background while a job runs and
+    # store a decimated timeline in Result.ext["metrics"] (rendered in json.html).
+    HOST_METRICS_ENABLED: bool = True
+    HOST_METRICS_SAMPLE_INTERVAL_SEC: float = 1.0
+    # Upper bound on points kept per series after min/max decimation, so the
+    # payload injected into the Result stays small regardless of job duration.
+    HOST_METRICS_MAX_POINTS: int = 400
+    HOST_METRICS_FILE: str = f"{TEMP_DIR}/host_metrics.jsonl"
+
     SECRET_GH_APP_ID: str = ""
     SECRET_GH_APP_PEM_KEY: str = ""
     SECRET_GH_APP_INSTALLATION_ID: str = ""


### PR DESCRIPTION
Adds whole-VM CPU and RAM usage tracking to praktika jobs, so CI reports show how much CPU/memory a job actually used over its lifetime — useful for spotting memory pressure / OOM risk, CPU-starved stages, and mis-provisioned runners.

- `HostMetricsCollector`: a dependency-free background sampler started by `runner.py` for the duration of each job. Reads `/proc/stat` and `/proc/meminfo` once per second, so it measures the whole VM even when the job runs inside Docker, and appends raw samples to `ci/tmp/host_metrics.jsonl` so partial data survives a runner kill.
- On job teardown the series is decimated with a min/max-per-bucket pass (preserves peaks and troughs) down to a bounded number of points per series and stored in the job's `Result.ext["metrics"]`. The payload stays small (~10 KB) regardless of job length; the raw 1s stream is not uploaded.
- `json.html` renders a theme-aware CPU/RAM timeline SVG chart with a hover readout in the job status panel.
- Configurable via new `Settings.HOST_METRICS_*` keys (enable, interval, max points, file). A no-op on non-Linux hosts (no `/proc`).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.367` (included in `26.8` and later)
<!-- ch-version-info:end -->