### PR TITLE
fix: KeeperMap DELETE exits after first block instead of continuing loop

### DIFF
--- a/src/Storages/StorageKeeperMap.cpp
+++ b/src/Storages/StorageKeeperMap.cpp
@@ -1693,7 +1693,7 @@ void StorageKeeperMap::mutate(const MutationCommands & commands, ContextPtr loca
             });
 
             if (status == Coordination::Error::ZOK)
-                return;
+                continue;
 
             if (status != Coordination::Error::ZNONODE)
                 throw zkutil::KeeperMultiException(status, delete_requests, responses);


### PR DESCRIPTION
Fixes #112244

## Summary

In `StorageKeeperMap::mutate()`, the DELETE branch uses `return;` after successfully deleting the first block of matched rows. This causes the function to exit the `while (executor.pull(block))` loop after processing only the first block, silently leaving all remaining matched rows undeleted.

## Fix

Changed `return;` to `continue;` at line 1696 so that `mutate()` processes every block of matched rows, not just the first one.

## Impact

Without this fix, a `DELETE FROM KeeperMap WHERE <predicate>` that matches more than `max_block_size` (default 65409) rows will silently delete only the first block and report success. The remaining rows are left in the table, and `system.mutations` shows `is_done = 1` with no error.