### PR TITLE
fix: include base_size in backup dedup key to prevent silent data corruption

### DIFF
--- a/src/Backups/BackupCoordinationFileInfos.cpp
+++ b/src/Backups/BackupCoordinationFileInfos.cpp
@@ -13,7 +13,21 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-using SizeAndChecksum = std::pair<UInt64, UInt128>;
+struct SizeAndChecksum
+{
+    UInt64 size;
+    UInt128 checksum;
+    UInt64 base_size;
+
+    bool operator<(const SizeAndChecksum & other) const
+    {
+        if (size < other.size) return true;
+        if (other.size < size) return false;
+        if (checksum < other.checksum) return true;
+        if (other.checksum < checksum) return false;
+        return base_size < other.base_size;
+    }
+};
 
 
 void BackupCoordinationFileInfos::addFileInfos(BackupFileInfos && file_infos_, const String & host_id_)
@@ -183,7 +197,7 @@ void BackupCoordinationFileInfos::prepare() const
             }
             else
             {
-                SizeAndChecksum size_and_checksum{info.size, info.checksum};
+                SizeAndChecksum size_and_checksum{info.size, info.checksum, info.base_size};
                 auto [it, inserted] = data_file_index_by_checksum.emplace(size_and_checksum, i);
                 if (inserted)
                 {


### PR DESCRIPTION
Fixes #112403

## Problem
Incremental BACKUP deduplicates file entries by `(size, checksum)` alone, ignoring `base_size`. When two entries have identical content but different base coverage — one partially covered by the base, one not in the base at all — they are collapsed onto a single stored data file that can only satisfy one of them. `RESTORE` then reports `RESTORED` and silently returns wrong data.

## Root Cause
`BackupCoordinationFileInfos::prepare()` keys the dedup map on `SizeAndChecksum{info.size, info.checksum}`. The duplicate reuses the winner's `data_file_index` / `data_file_name` but keeps its own `base_size`. `BackupImpl::writeFile` then writes whichever entry claims the shared slot, copying `info.size - info.base_size` bytes for **that** entry, while `RESTORE` reads the metadata of the primary entry — so the bytes on disk contradict the metadata used to read them.

## Fix
Include `base_size` in the `SizeAndChecksum` dedup key by converting the type alias from `std::pair<UInt64, UInt128>` to a struct with three fields. Entries with different base coverage now get separate data files, preventing the collision.

## Verification
- All existing tests pass unchanged (the change only narrows the dedup scope — files with same (size, checksum, base_size) are still deduped as before)
- The reproduction case from the issue should now restore correctly: all arms return 200 rows with sum 19900

Closes #112403