### PR TITLE
Support Nullable(Tuple) in parquet, along with Nullable(Tuple(X, Nullable(Y)))

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -1410,6 +1410,11 @@ void Reader::decodePrimitiveColumn(ColumnChunk & column, const PrimitiveColumnIn
     {
         subchunk.null_map = ColumnUInt8::create();
         subchunk.null_map->reserve(output_num_values_estimate);
+        if (column_info.nullable_group_def)
+        {
+            subchunk.group_null_map = ColumnUInt8::create();
+            subchunk.group_null_map->reserve(output_num_values_estimate);
+        }
     }
 
     subchunk.column = column_info.decoded_type->createColumn();
@@ -1517,7 +1522,7 @@ void Reader::decodePrimitiveColumn(ColumnChunk & column, const PrimitiveColumnIn
             throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid repetition/definition levels for arrays in column {}", column_info.name);
     }
 
-    if (subchunk.null_map && !column_info.output_nullable && !column_info.group_nullable && !options.format.null_as_default)
+    if (subchunk.null_map && !column_info.output_nullable && !column_info.nullable_group_def && !options.format.null_as_default)
     {
         const auto & null_map = assert_cast<const ColumnUInt8 &>(*subchunk.null_map).getData();
         /// null_map uses standard ClickHouse convention: 1 = NULL, 0 = NOT NULL.
@@ -1530,21 +1535,28 @@ void Reader::decodePrimitiveColumn(ColumnChunk & column, const PrimitiveColumnIn
     if (subchunk.null_map)
     {
         const auto & null_map = assert_cast<const ColumnUInt8 &>(*subchunk.null_map).getData();
-        /// Fill defaults at null rows so the column reaches full size. For a group_nullable leaf,
-        /// the null map is the group null map: defaults fill the struct-null rows.
+        /// Fill defaults before splitting group and descendant null maps
         subchunk.column->expand(null_map, /*inverted*/ true);
     }
 
-    if (column_info.group_nullable && subchunk.null_map)
+    if (column_info.nullable_group_def && subchunk.null_map)
     {
-        /// Leaf of a physically-nullable struct read as Nullable(Tuple(...)): its def-level null map
-        /// is the group null map. Move it aside now, before the output_nullable block below can
-        /// consume `null_map` into a leaf-level ColumnNullable. formOutputColumn reads it from the
-        /// group's first leaf to wrap the assembled ColumnTuple in ColumnNullable. If the leaf is
-        /// itself Nullable, it gets a fresh all-non-null map below (the file leaf is REQUIRED, so it
-        /// has no element-level nulls; the struct nulls are represented by the outer ColumnNullable).
-        subchunk.group_null_map = std::move(subchunk.null_map);
-        subchunk.null_map.reset();
+        chassert(subchunk.group_null_map);
+        auto & null_map = assert_cast<ColumnUInt8 &>(*subchunk.null_map).getData();
+        const auto & group_null_map = assert_cast<const ColumnUInt8 &>(*subchunk.group_null_map).getData();
+        chassert(null_map.size() == group_null_map.size());
+        for (size_t i = 0; i < null_map.size(); ++i)
+            null_map[i] &= !group_null_map[i];
+
+        if (!column_info.output_nullable)
+        {
+            if (!options.format.null_as_default && memchr(null_map.data(), 1, null_map.size()) != nullptr)
+                throw Exception(
+                    ErrorCodes::CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN,
+                    "Cannot convert NULL value to non-Nullable type for column {}",
+                    column_info.name);
+            subchunk.null_map.reset();
+        }
     }
 
     if (subchunk.arrays_offsets.empty() && subchunk.column->size() != row_subgroup.filter.rows_pass)
@@ -1982,6 +1994,8 @@ bool Reader::skipRowsInPage(size_t target_row_idx, PageState & page, ColumnChunk
 ///  * Null element of innermost array: max_array_def <= def[i] < max_def.
 ///    No encoded value. A default value needs to be inserted into IColumn.
 ///    null_map->push_back(1).
+///    If nullable group is active, def[i] < nullable_group_def is group null;
+///    higher levels are nullable descendant nulls.
 ///  * Empty array or null array: def[i] < max_array_def.
 ///    No encoded value, no IColumn or null_map element.
 ///
@@ -1996,9 +2010,10 @@ bool Reader::skipRowsInPage(size_t target_row_idx, PageState & page, ColumnChunk
 ///  * Array offsets for each array level (rep = 1..max_rep).
 ///    (Array may have elements in multiple pages.)
 ///  * Advance value_idx and next_row_idx by correct amounts, keeping them in sync.
-template <bool has_arrays, bool has_nulls>
+template <bool has_arrays, bool has_nulls, bool has_nullable_group>
 static void processDefLevelsForInnermostColumn(
-    size_t num_values, const UInt8 * def, UInt8 max_def, UInt8 max_array_def, size_t & out_num_encoded_values, ColumnUInt8::Container * out_null_map)
+    size_t num_values, const UInt8 * def, UInt8 max_def, UInt8 max_array_def, UInt8 nullable_group_def,
+    size_t & out_num_encoded_values, ColumnUInt8::Container * out_null_map, ColumnUInt8::Container * out_group_null_map)
 {
     size_t num_encoded_values = 0;
     for (size_t i = 0; i < num_values; ++i)
@@ -2006,6 +2021,9 @@ static void processDefLevelsForInnermostColumn(
         if constexpr (has_arrays)
             if (def[i] < max_array_def)
                 continue; // empty array
+
+        if constexpr (has_nullable_group)
+            out_group_null_map->push_back(def[i] < nullable_group_def);
 
         bool is_null = false;
         if constexpr (has_nulls)
@@ -2106,25 +2124,33 @@ void Reader::readRowsInPage(size_t end_row_idx, ColumnSubchunk & subchunk, Colum
     else
     {
         /// Dispatch to a version of the hot loop with unneeded features disabled.
-#define X(has_arrays, has_nulls, null_map) \
-            processDefLevelsForInnermostColumn<has_arrays, has_nulls>( \
+#define X(has_arrays, has_nulls, has_nullable_group, null_map, group_null_map) \
+            processDefLevelsForInnermostColumn<has_arrays, has_nulls, has_nullable_group>( \
                 page.value_idx - prev_value_idx, page.def.data() + prev_value_idx, \
-                column_info.levels.back().def, column_info.max_array_def, encoded_values_to_read, \
-                null_map)
+                column_info.levels.back().def, column_info.max_array_def, column_info.nullable_group_def.value_or(0), \
+                encoded_values_to_read, null_map, group_null_map)
         if (subchunk.null_map)
         {
             auto & null_map = assert_cast<ColumnUInt8 &>(*subchunk.null_map).getData();
-            if (column_info.max_array_def)
-                X(true, true, &null_map);
+            if (subchunk.group_null_map)
+            {
+                auto & group_null_map = assert_cast<ColumnUInt8 &>(*subchunk.group_null_map).getData();
+                if (column_info.max_array_def)
+                    X(true, true, true, &null_map, &group_null_map);
+                else
+                    X(false, true, true, &null_map, &group_null_map);
+            }
+            else if (column_info.max_array_def)
+                X(true, true, false, &null_map, nullptr);
             else
-                X(false, true, &null_map);
+                X(false, true, false, &null_map, nullptr);
         }
         else
         {
             if (column_info.max_array_def)
-                X(true, false, nullptr);
+                X(true, false, false, nullptr, nullptr);
             else
-                X(false, false, nullptr);
+                X(false, false, false, nullptr, nullptr);
         }
     }
 
@@ -2218,12 +2244,7 @@ MutableColumnPtr Reader::formOutputColumn(RowSubgroup & row_subgroup, size_t out
         return res;
     }
 
-    /// Physically-nullable struct read as Nullable(Tuple(...)). input_type is Nullable(Tuple), but
-    /// we assemble the inner ColumnTuple from the leaves and then wrap it in ColumnNullable using
-    /// the group null map. Every leaf shares the same def-level null map (the subtree is
-    /// all-REQUIRED), which decodePrimitiveColumn moved into `group_null_map` on each leaf before
-    /// any leaf-level Nullable wrapping could consume it. Take it from the first leaf. Dispatch on
-    /// the unwrapped type.
+    /// Assemble inner `ColumnTuple`, then wrap it using struct null map from first leaf
     MutableColumnPtr nullable_group_null_map;
     if (output_info.nullable_group)
     {

--- a/src/Processors/Formats/Impl/Parquet/Reader.h
+++ b/src/Processors/Formats/Impl/Parquet/Reader.h
@@ -161,13 +161,9 @@ struct Reader
         DataTypePtr decoded_type; // what decoder outputs, not Nullable
         DataTypePtr output_type; // maybe Nullable
         bool output_nullable = false;
-        /// This leaf is inside a Tuple group that is requested as Nullable(Tuple(...)) and is
-        /// eligible for it (the OPTIONAL group has no optional/nullable ancestor and an all-REQUIRED,
-        /// non-array subtree). Then this leaf's definition-level null map is exactly the group's null
-        /// map. We keep that null map (instead of throwing CANNOT_INSERT_NULL) and fill defaults at
-        /// the null rows; the group null map is later used to wrap the assembled ColumnTuple in
-        /// ColumnNullable. See OutputColumnInfo::nullable_group.
-        bool group_nullable = false;
+        /// Definition level of enclosing `Nullable(Tuple(...))` group
+        /// Split lower levels into group nulls and higher levels into nullable descendant nulls
+        std::optional<UInt8> nullable_group_def;
         /// TODO [parquet]: Consider also adding output_low_cardinality to allow producing LowCardinality
         ///       column directly from parquet dictionary+indices. This is not straightforward
         ///       because ColumnLowCardinality requires values to be unique and the first value to
@@ -209,11 +205,9 @@ struct Reader
         bool is_missing_column = false;
         bool needs_cast = false; // if output_type is different from input_type
 
-        /// If set, the assembled column (a ColumnTuple) is wrapped in ColumnNullable using the group
-        /// null map reconstructed from the leaves' definition levels. Used to read a physically
-        /// nullable parquet struct (OPTIONAL group) as Nullable(Tuple(...)). Only set when the group
-        /// has no optional/nullable ancestor and an all-REQUIRED, non-array subtree, so every leaf's
-        /// null map equals the group null map. `needs_cast` (if any) is applied after wrapping.
+        /// Wrap assembled `ColumnTuple` in `ColumnNullable` using group null map reconstructed
+        /// from leaf definition levels. Repeated descendants are unsupported because their null maps
+        /// have different cardinality. Apply `needs_cast` after wrapping
         bool nullable_group = false;
 
         /// If type is Array, this is the repetition level of that array.
@@ -363,12 +357,8 @@ struct Reader
 
         MutableColumnPtr null_map;
 
-        /// For a leaf of a physically-nullable struct read as Nullable(Tuple(...)) (see
-        /// PrimitiveColumnInfo::group_nullable): the group's definition-level null map, moved here
-        /// in decodePrimitiveColumn before any leaf-level Nullable wrapping can consume `null_map`.
-        /// formOutputColumn reads it from the group's first leaf to wrap the assembled ColumnTuple
-        /// in ColumnNullable. Kept separate from `null_map` so it survives even when the leaf itself
-        /// is materialized as Nullable(...) (which moves `null_map` into the leaf's ColumnNullable).
+        /// Group null map for leaf under `Nullable(Tuple(...))`
+        /// `formOutputColumn` reads it from first leaf to wrap assembled `ColumnTuple`
         MutableColumnPtr group_null_map;
 
         /// If this primitive column is inside an array, this is the offsets for `ColumnArray`s at

--- a/src/Processors/Formats/Impl/Parquet/SchemaConverter.cpp
+++ b/src/Processors/Formats/Impl/Parquet/SchemaConverter.cpp
@@ -376,9 +376,10 @@ bool SchemaConverter::processSubtreePrimitive(TraversalNode & node)
     /// Force map key to be non-nullable because clickhouse Map doesn't support nullable map key.
     else if (!options.schema_inference_force_not_nullable && node.schema_context != SchemaContext::MapKey)
     {
-        if (levels.back().is_array == false)
+        if (levels.back().is_array == false
+            && (!nullable_tuple_group_def || levels.back().def > *nullable_tuple_group_def))
         {
-            /// This schema element is OPTIONAL or inside an OPTIONAL tuple.
+            /// This schema element is `OPTIONAL` or inside an `OPTIONAL` descendant group
             output_nullable = true;
         }
         else if (options.schema_inference_force_nullable)
@@ -434,10 +435,7 @@ bool SchemaConverter::processSubtreePrimitive(TraversalNode & node)
     primitive.name = node.name;
     primitive.levels = levels;
     primitive.output_nullable = output_nullable || (output_nullable_if_not_json && !typeid_cast<const DataTypeObject *>(inferred_type.get()));
-    /// Leaf of a physically-nullable struct read as Nullable(Tuple(...)): its def-level null map is
-    /// the group null map. Keep that null map (don't throw on the group-null rows) and fill defaults
-    /// there; the group null map wraps the ColumnTuple in Reader::formOutputColumn.
-    primitive.group_nullable = nullable_tuple_group_depth > 0;
+    primitive.nullable_group_def = nullable_tuple_group_def;
     primitive.decoder = std::move(decoder);
     primitive.decoded_type = decoded_type;
     for (const auto & level : levels)
@@ -623,12 +621,8 @@ bool SchemaConverter::processSubtreeArrayInner(TraversalNode & node)
     return true;
 }
 
-/// Whether the subtree rooted at `schema[root_idx]` (a group) contains only REQUIRED, non-repeated
-/// elements below the root. If so, none of its descendants add a definition level, so every leaf's
-/// definition-level null map is exactly the root group's null map. This lets us reconstruct the
-/// group null map from any leaf and read a physically nullable struct (OPTIONAL group) as
-/// Nullable(Tuple(...)) losslessly. Returns false for any OPTIONAL/REPEATED descendant.
-static bool tupleSubtreeIsAllRequired(const std::vector<parq::SchemaElement> & schema, size_t root_idx)
+/// Optional descendants add splittable definition levels, repeated descendants change cardinality
+static bool tupleSubtreeHasNoRepeated(const std::vector<parq::SchemaElement> & schema, size_t root_idx)
 {
     /// schema is a flattened pre-order tree; num_children counts direct children, laid out
     /// contiguously in pre-order. Walk the root's subtree with an explicit stack of
@@ -649,7 +643,7 @@ static bool tupleSubtreeIsAllRequired(const std::vector<parq::SchemaElement> & s
             return false; // malformed schema; caller handles elsewhere
         stack.back() -= 1;
         const parq::SchemaElement & elem = schema.at(idx);
-        if (elem.repetition_type != parq::FieldRepetitionType::REQUIRED)
+        if (elem.repetition_type == parq::FieldRepetitionType::REPEATED)
             return false;
         idx += 1;
         if (elem.__isset.num_children && elem.num_children > 0)
@@ -675,10 +669,8 @@ void SchemaConverter::processSubtreeTuple(TraversalNode & node)
     /// processRepDefLevelsForArray and never reach the inner tuple null-map.
     ///  1. REQUIRED group: always defined, so the outer Nullable is always-non-null. Restored via
     ///     outer_type_hint (needs_cast) as an all-non-null wrapper.
-    ///  2. OPTIONAL group with an all-REQUIRED, non-array subtree: physically nullable struct. No
-    ///     descendant adds a definition level, so every leaf's def-level null map equals the group
-    ///     null map. We mark the leaves and the output so the assembled ColumnTuple is wrapped in
-    ///     ColumnNullable using that reconstructed null map (see OutputColumnInfo::nullable_group).
+    ///  2. OPTIONAL group without repeated descendants: physically nullable struct. Group and
+    ///     nullable-descendant null maps are split using their definition-level thresholds.
     /// Otherwise keep the hint wrapped and let the check below reject it with TYPE_MISMATCH rather
     /// than lose nulls. For an OPTIONAL group, processSubtree has already pushed this group's own
     /// (non-array) level as levels.back(); exclude it when scanning for an ancestor.
@@ -696,16 +688,24 @@ void SchemaConverter::processSubtreeTuple(TraversalNode & node)
     {
         if (node.element->repetition_type == parq::FieldRepetitionType::REQUIRED)
             node.type_hint = assert_cast<const DataTypeNullable &>(*node.type_hint).getNestedType();
-        else if (group_is_optional && tupleSubtreeIsAllRequired(file_metadata.schema, schema_idx - 1))
+        else if (group_is_optional && tupleSubtreeHasNoRepeated(file_metadata.schema, schema_idx - 1))
         {
             node.type_hint = assert_cast<const DataTypeNullable &>(*node.type_hint).getNestedType();
             nullable_group = true;
         }
     }
+    /// Infer case 2 as `Nullable(Tuple(...))` when enabled
+    else if (!sample_block && options.format.schema_inference_allow_nullable_tuple_type
+        && !options.schema_inference_force_not_nullable && !has_optional_ancestor
+        && group_is_optional && tupleSubtreeHasNoRepeated(file_metadata.schema, schema_idx - 1))
+    {
+        nullable_group = true;
+    }
 
-    /// Mark leaves recursed below as belonging to a physically-nullable group (case 2 above).
-    nullable_tuple_group_depth += nullable_group ? 1 : 0;
-    SCOPE_EXIT({ nullable_tuple_group_depth -= nullable_group ? 1 : 0; });
+    const auto previous_nullable_tuple_group_def = nullable_tuple_group_def;
+    if (nullable_group)
+        nullable_tuple_group_def = levels.back().def;
+    SCOPE_EXIT({ nullable_tuple_group_def = previous_nullable_tuple_group_def; });
 
     const DataTypeTuple * tuple_type_hint = typeid_cast<const DataTypeTuple *>(node.type_hint.get());
     if (node.type_hint && !tuple_type_hint && !typeid_cast<const DataTypeObject *>(node.type_hint.get()))
@@ -849,19 +849,17 @@ void SchemaConverter::processSubtreeTuple(TraversalNode & node)
         output_type = std::make_shared<DataTypeTuple>(types, names);
     }
 
-    /// Physically-nullable struct (OPTIONAL group, case 2 above): the assembled ColumnTuple must be
-    /// wrapped in ColumnNullable using the group null map. Make input_type Nullable(Tuple(...)) so
-    /// the outer restore in processSubtree sees no type change (needs_cast stays off); the wrapping
-    /// is done in Reader::formOutputColumn keyed by OutputColumnInfo::nullable_group.
-    /// The group null map is reconstructed from a physical leaf's definition levels, so at least one
-    /// leaf must actually be read. With allow_missing_columns, every requested element can be a
-    /// synthetic default (no physical leaf); then the null map is unrecoverable, so reject rather
-    /// than fabricate an all-non-null map that silently drops the struct nulls.
+    /// `formOutputColumn` wraps assembled tuple using group null map from physical leaf
     if (nullable_group && primitive_start == primitive_columns.size())
-        throw Exception(ErrorCodes::TYPE_MISMATCH,
-            "Requested type of column {} doesn't match parquet schema: physically nullable Tuple has no "
-            "physical elements to read (all requested elements are missing), so its null map cannot be "
-            "reconstructed; requested type is {}", node.getNameForLogging(), node.type_hint->getName());
+    {
+        if (node.type_hint)
+            throw Exception(ErrorCodes::TYPE_MISMATCH,
+                "Requested type of column {} doesn't match parquet schema: physically nullable Tuple has no "
+                "physical elements to read (all requested elements are missing), so its null map cannot be "
+                "reconstructed; requested type is {}", node.getNameForLogging(), node.type_hint->getName());
+        /// Infer plain `Tuple` when unsupported elements remove every physical leaf
+        nullable_group = false;
+    }
     if (nullable_group)
         output_type = makeNullable(output_type);
 

--- a/src/Processors/Formats/Impl/Parquet/SchemaConverter.h
+++ b/src/Processors/Formats/Impl/Parquet/SchemaConverter.h
@@ -35,11 +35,8 @@ struct SchemaConverter
     /// Actual recursion depth of processSubtree. Tracked unconditionally because the def-level
     /// counter only advances for OPTIONAL/REPEATED nodes, so REQUIRED-group nesting would bypass it.
     size_t recursion_depth = 0;
-    /// >0 while recursing inside a physically-nullable Tuple group (OPTIONAL group requested as
-    /// Nullable(Tuple(...)) and eligible for lossless reading). Leaves under it get
-    /// PrimitiveColumnInfo::group_nullable set: their definition-level null map equals the group
-    /// null map, so we keep it and later wrap the assembled ColumnTuple in ColumnNullable.
-    size_t nullable_tuple_group_depth = 0;
+    /// Definition level of active physically nullable tuple group
+    std::optional<UInt8> nullable_tuple_group_def;
 
     /// The key is the parquet column name, without ColumnMapper.
     std::unordered_map<String, GeoColumnMetadata> geo_columns;

--- a/src/Processors/Formats/Impl/ParquetV3BlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetV3BlockInputFormat.cpp
@@ -584,8 +584,10 @@ void registerParquetSchemaReader(FormatFactory & factory)
         [](const FormatSettings & settings)
         {
             return fmt::format(
-                "schema_inference_make_columns_nullable={};enable_json_parsing={}",
+                "schema_inference_make_columns_nullable={};schema_inference_allow_nullable_tuple_type={};"
+                "enable_json_parsing={}",
                 settings.schema_inference_make_columns_nullable,
+                settings.schema_inference_allow_nullable_tuple_type,
                 settings.parquet.enable_json_parsing);
         });
 }

--- a/tests/queries/0_stateless/04065_parquet_optional_list_map_wrapper_nullable_tuple.reference
+++ b/tests/queries/0_stateless/04065_parquet_optional_list_map_wrapper_nullable_tuple.reference
@@ -5,5 +5,7 @@
 {'k1':(1),'k2':(2)}	Map(String, Nullable(Tuple(x UInt32)))
 -- optional element group with all-REQUIRED subtree under a list: struct nulls reconstructed losslessly, accepted
 [((1)),NULL,((3))]	Array(Nullable(Tuple(inner Tuple(x UInt32))))
--- optional element group with a NULLABLE leaf under a list: leaf null map != struct null map, still rejected
-TYPE_MISMATCH
+-- optional element group with a NULLABLE leaf under a list: split struct and leaf null maps
+[((1)),NULL,((NULL))]	Array(Nullable(Tuple(inner Tuple(x Nullable(UInt32)))))
+-- optional element group with a NULLABLE leaf requested as non-nullable: reject leaf null
+CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN

--- a/tests/queries/0_stateless/04065_parquet_optional_list_map_wrapper_nullable_tuple.sh
+++ b/tests/queries/0_stateless/04065_parquet_optional_list_map_wrapper_nullable_tuple.sh
@@ -14,11 +14,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # the inner tuple null-map, so an always-defined REQUIRED element/value read as Nullable(Tuple)
 # is lossless and must be accepted (issue #109605 follow-up).
 #
-# An OPTIONAL element/struct group whose own subtree is all-REQUIRED carries genuine struct-level
-# nulls, but every leaf's definition-level null map then equals the group null map, so it can be
-# reconstructed and the tuple wrapped in Nullable losslessly (#109898) -- accepted. Only when the
-# subtree adds another definition level (e.g. a nullable leaf) is the group null map no longer
-# recoverable from a leaf, so that case must still be rejected.
+# Split struct and nullable-leaf null maps at their definition levels. Repeated descendants remain
+# unsupported because their null maps have different cardinality.
 
 DATA="$CURDIR/data_parquet"
 
@@ -33,5 +30,8 @@ $CLICKHOUSE_LOCAL $opts -q "SELECT m, toTypeName(m) FROM file('$DATA/04065_optio
 echo "-- optional element group with all-REQUIRED subtree under a list: struct nulls reconstructed losslessly, accepted"
 $CLICKHOUSE_LOCAL $opts -q "SELECT a, toTypeName(a) FROM file('$DATA/04065_optional_struct_under_list.parquet', 'Parquet', 'a Array(Nullable(Tuple(inner Tuple(x UInt32))))')"
 
-echo "-- optional element group with a NULLABLE leaf under a list: leaf null map != struct null map, still rejected"
-$CLICKHOUSE_LOCAL $opts -q "SELECT a FROM file('$DATA/04065_optional_struct_nullable_leaf_under_list.parquet', 'Parquet', 'a Array(Nullable(Tuple(inner Tuple(x UInt32))))')" 2>&1 | grep -o "TYPE_MISMATCH" | head -1
+echo "-- optional element group with a NULLABLE leaf under a list: split struct and leaf null maps"
+$CLICKHOUSE_LOCAL $opts -q "SELECT a, toTypeName(a) FROM file('$DATA/04065_optional_struct_nullable_leaf_under_list.parquet', 'Parquet', 'a Array(Nullable(Tuple(inner Tuple(x Nullable(UInt32)))))')"
+
+echo "-- optional element group with a NULLABLE leaf requested as non-nullable: reject leaf null"
+$CLICKHOUSE_LOCAL $opts -q "SELECT a FROM file('$DATA/04065_optional_struct_nullable_leaf_under_list.parquet', 'Parquet', 'a Array(Nullable(Tuple(inner Tuple(x UInt32))))')" 2>&1 | grep -o "CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN" | head -1

--- a/tests/queries/0_stateless/04065_tuple_inside_nullable_parquet_roundtrip.reference
+++ b/tests/queries/0_stateless/04065_tuple_inside_nullable_parquet_roundtrip.reference
@@ -19,14 +19,14 @@ DROP TABLE IF EXISTS test_nullable_tuple_both;
 CREATE TABLE test_nullable_tuple_both (c0 Nullable(Tuple(Nullable(UInt32), String))) ENGINE = Memory;
 INSERT INTO test_nullable_tuple_both VALUES ((1, 'a')), (NULL), ((NULL, 'c')), ((4, 'd'));
 INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04065_both.parquet', 'Parquet') SELECT c0 FROM test_nullable_tuple_both;
--- Parquet V3 native reader: nullable element makes the subtree not all-REQUIRED, so the group
--- null map cannot be separated from the element null map. Reject rather than lose data.
-SELECT c0 FROM file(currentDatabase() || '_04065_both.parquet', 'Parquet', 'c0 Nullable(Tuple(Nullable(UInt32), String))'); -- { serverError TYPE_MISMATCH }
+-- Split struct and element null maps by definition level
+SELECT c0 FROM file(currentDatabase() || '_04065_both.parquet', 'Parquet', 'c0 Nullable(Tuple(Nullable(UInt32), String))');
+(1,'a')
+\N
+(NULL,'c')
+(4,'d')
 DROP TABLE test_nullable_tuple_both;
--- Physically-nullable struct (all-REQUIRED leaves) read as Nullable(Tuple) with a leaf hint that
--- materializes the first leaf as Nullable. decodePrimitiveColumn moves the shared group null map
--- into the leaf's ColumnNullable, so the group null map must be preserved separately or the middle
--- (struct-level NULL) row would be silently returned as a non-null tuple. Middle row must stay NULL.
+-- Required physical leaf requested as `Nullable` gets all-zero leaf map after struct-map split
 DROP TABLE IF EXISTS test_nullable_tuple_leaf_nullable;
 CREATE TABLE test_nullable_tuple_leaf_nullable (c0 Nullable(Tuple(UInt32, String))) ENGINE = Memory;
 INSERT INTO test_nullable_tuple_leaf_nullable VALUES ((1, 'a')), (NULL), ((3, 'c'));
@@ -109,8 +109,7 @@ DROP TABLE IF EXISTS test_nullable_tuple_deep;
 CREATE TABLE test_nullable_tuple_deep (c0 Nullable(Tuple(Nullable(Tuple(UInt32, String)), UInt64))) ENGINE = Memory;
 INSERT INTO test_nullable_tuple_deep VALUES (((1, 'a'), 10)), (NULL), ((NULL, 20)), (((4, 'd'), 40));
 INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04065_deep.parquet', 'Parquet') SELECT c0 FROM test_nullable_tuple_deep;
--- Parquet V3 native reader deep nested: inner Nullable(Tuple) is an OPTIONAL inner group, so the
--- subtree is not all-REQUIRED. Reject rather than lose the inner struct nulls.
+-- Nested nullable tuple needs a second struct null map, reject rather than lose inner nulls
 SELECT c0 FROM file(currentDatabase() || '_04065_deep.parquet', 'Parquet', 'c0 Nullable(Tuple(Nullable(Tuple(UInt32, String)), UInt64))'); -- { serverError TYPE_MISMATCH }
 DROP TABLE test_nullable_tuple_deep;
 -- Nullable tuple with Array element
@@ -118,8 +117,7 @@ DROP TABLE IF EXISTS test_nullable_tuple_arr;
 CREATE TABLE test_nullable_tuple_arr (c0 Nullable(Tuple(Array(UInt32), String))) ENGINE = Memory;
 INSERT INTO test_nullable_tuple_arr VALUES (([1, 2], 'a')), (NULL), (([3], 'c'));
 INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04065_arr.parquet', 'Parquet') SELECT c0 FROM test_nullable_tuple_arr;
--- Parquet V3 native reader array elem: the Array element adds a repetition level, so the subtree
--- is not all-REQUIRED and the leaf null maps no longer equal the group null map. Reject.
+-- Repeated descendant changes null-map cardinality, reject
 SELECT c0 FROM file(currentDatabase() || '_04065_arr.parquet', 'Parquet', 'c0 Nullable(Tuple(Array(UInt32), String))'); -- { serverError TYPE_MISMATCH }
 DROP TABLE test_nullable_tuple_arr;
 -- Multiple nullable tuple columns
@@ -165,11 +163,11 @@ DROP TABLE IF EXISTS test_nullable_tuple_describe;
 CREATE TABLE test_nullable_tuple_describe (c0 Nullable(Tuple(UInt32, String))) ENGINE = Memory;
 INSERT INTO test_nullable_tuple_describe VALUES ((1, 'a')), (NULL), ((3, 'c'));
 INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04065_describe.parquet', 'Parquet') SELECT c0 FROM test_nullable_tuple_describe;
--- Parquet V3 native reader: inferred type (struct-level NULL not supported, becomes (NULL,NULL))
+-- Schema inference preserves struct null map
 SELECT c0, toTypeName(c0) FROM file(currentDatabase() || '_04065_describe.parquet', 'Parquet');
-(1,'a')	Tuple(\n    `1` Nullable(UInt32),\n    `2` Nullable(String))
-(NULL,NULL)	Tuple(\n    `1` Nullable(UInt32),\n    `2` Nullable(String))
-(3,'c')	Tuple(\n    `1` Nullable(UInt32),\n    `2` Nullable(String))
+(1,'a')	Nullable(Tuple(`1` UInt32, `2` String))
+\N	Nullable(Tuple(`1` UInt32, `2` String))
+(3,'c')	Nullable(Tuple(`1` UInt32, `2` String))
 DROP TABLE test_nullable_tuple_describe;
 -- Array(Nullable(Tuple)) flattened via import_nested
 DROP TABLE IF EXISTS test_nullable_tuple_import_nested;

--- a/tests/queries/0_stateless/04065_tuple_inside_nullable_parquet_roundtrip.sql
+++ b/tests/queries/0_stateless/04065_tuple_inside_nullable_parquet_roundtrip.sql
@@ -26,16 +26,12 @@ INSERT INTO test_nullable_tuple_both VALUES ((1, 'a')), (NULL), ((NULL, 'c')), (
 
 INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04065_both.parquet', 'Parquet') SELECT c0 FROM test_nullable_tuple_both;
 
--- Parquet V3 native reader: nullable element makes the subtree not all-REQUIRED, so the group
--- null map cannot be separated from the element null map. Reject rather than lose data.
-SELECT c0 FROM file(currentDatabase() || '_04065_both.parquet', 'Parquet', 'c0 Nullable(Tuple(Nullable(UInt32), String))'); -- { serverError TYPE_MISMATCH }
+-- Split struct and element null maps by definition level
+SELECT c0 FROM file(currentDatabase() || '_04065_both.parquet', 'Parquet', 'c0 Nullable(Tuple(Nullable(UInt32), String))');
 
 DROP TABLE test_nullable_tuple_both;
 
--- Physically-nullable struct (all-REQUIRED leaves) read as Nullable(Tuple) with a leaf hint that
--- materializes the first leaf as Nullable. decodePrimitiveColumn moves the shared group null map
--- into the leaf's ColumnNullable, so the group null map must be preserved separately or the middle
--- (struct-level NULL) row would be silently returned as a non-null tuple. Middle row must stay NULL.
+-- Required physical leaf requested as `Nullable` gets all-zero leaf map after struct-map split
 DROP TABLE IF EXISTS test_nullable_tuple_leaf_nullable;
 CREATE TABLE test_nullable_tuple_leaf_nullable (c0 Nullable(Tuple(UInt32, String))) ENGINE = Memory;
 INSERT INTO test_nullable_tuple_leaf_nullable VALUES ((1, 'a')), (NULL), ((3, 'c'));
@@ -126,8 +122,7 @@ INSERT INTO test_nullable_tuple_deep VALUES (((1, 'a'), 10)), (NULL), ((NULL, 20
 
 INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04065_deep.parquet', 'Parquet') SELECT c0 FROM test_nullable_tuple_deep;
 
--- Parquet V3 native reader deep nested: inner Nullable(Tuple) is an OPTIONAL inner group, so the
--- subtree is not all-REQUIRED. Reject rather than lose the inner struct nulls.
+-- Nested nullable tuple needs a second struct null map, reject rather than lose inner nulls
 SELECT c0 FROM file(currentDatabase() || '_04065_deep.parquet', 'Parquet', 'c0 Nullable(Tuple(Nullable(Tuple(UInt32, String)), UInt64))'); -- { serverError TYPE_MISMATCH }
 
 DROP TABLE test_nullable_tuple_deep;
@@ -139,8 +134,7 @@ INSERT INTO test_nullable_tuple_arr VALUES (([1, 2], 'a')), (NULL), (([3], 'c'))
 
 INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04065_arr.parquet', 'Parquet') SELECT c0 FROM test_nullable_tuple_arr;
 
--- Parquet V3 native reader array elem: the Array element adds a repetition level, so the subtree
--- is not all-REQUIRED and the leaf null maps no longer equal the group null map. Reject.
+-- Repeated descendant changes null-map cardinality, reject
 SELECT c0 FROM file(currentDatabase() || '_04065_arr.parquet', 'Parquet', 'c0 Nullable(Tuple(Array(UInt32), String))'); -- { serverError TYPE_MISMATCH }
 
 DROP TABLE test_nullable_tuple_arr;
@@ -193,7 +187,7 @@ INSERT INTO test_nullable_tuple_describe VALUES ((1, 'a')), (NULL), ((3, 'c'));
 
 INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04065_describe.parquet', 'Parquet') SELECT c0 FROM test_nullable_tuple_describe;
 
--- Parquet V3 native reader: inferred type (struct-level NULL not supported, becomes (NULL,NULL))
+-- Schema inference preserves struct null map
 SELECT c0, toTypeName(c0) FROM file(currentDatabase() || '_04065_describe.parquet', 'Parquet');
 
 DROP TABLE test_nullable_tuple_describe;

--- a/tests/queries/0_stateless/04653_parquet_nullable_tuple_schema_inference.reference
+++ b/tests/queries/0_stateless/04653_parquet_nullable_tuple_schema_inference.reference
@@ -1,0 +1,32 @@
+p	Nullable(Tuple(a UInt8, b String))					
+(1,'x')
+\N
+(3,'z')
+p	Nullable(Tuple(a Nullable(UInt8), b String))					
+(1,'x')
+\N
+(NULL,'z')
+p	Nullable(Tuple(`1` Float64, `2` Float64))					
+(1,2)
+\N
+p	Array(Nullable(Tuple(`1` Float64, `2` Float64)))					
+[(1,2),NULL]
+[]
+n	Nullable(Tuple(x Int64, t Tuple(y Int64, z String)))					
+(0,(0,'y'))
+\N
+(2,(20,'y'))
+m	Map(String, Nullable(Tuple(x UInt32)))					
+{'a':(0)}
+{'a':NULL}
+p	Tuple(a Nullable(UInt8))					
+(1)
+(NULL)
+p	Tuple(a Nullable(UInt8), b Nullable(String))					
+(1,'x')
+(NULL,NULL)
+(3,'z')
+p	Tuple(a Nullable(UInt8), b Nullable(String))					
+(1,'x')
+(NULL,NULL)
+(NULL,'z')

--- a/tests/queries/0_stateless/04653_parquet_nullable_tuple_schema_inference.sql
+++ b/tests/queries/0_stateless/04653_parquet_nullable_tuple_schema_inference.sql
@@ -1,0 +1,70 @@
+-- Tags: no-fasttest
+-- no-fasttest: needs Parquet
+
+SET allow_experimental_nullable_tuple_type = 1;
+SET engine_file_truncate_on_insert = 1;
+SET print_pretty_type_names = 0;
+
+-- Infer `OPTIONAL` Parquet group as `Nullable(Tuple(...))`
+
+INSERT INTO FUNCTION file(currentDatabase() || '_04653.parquet', Parquet, 'p Nullable(Tuple(a UInt8, b String))')
+    SELECT * FROM values('p Nullable(Tuple(a UInt8, b String))', ((1, 'x')), (NULL), ((3, 'z')));
+
+DESCRIBE file(currentDatabase() || '_04653.parquet', Parquet);
+SELECT * FROM file(currentDatabase() || '_04653.parquet', Parquet);
+
+INSERT INTO FUNCTION file(
+    currentDatabase() || '_04653_nullable_element.parquet',
+    Parquet,
+    'p Nullable(Tuple(a Nullable(UInt8), b String))')
+SELECT *
+FROM values(
+    'p Nullable(Tuple(a Nullable(UInt8), b String))',
+    ((1, 'x')),
+    (NULL),
+    ((NULL, 'z')));
+
+DESCRIBE file(currentDatabase() || '_04653_nullable_element.parquet', Parquet);
+SELECT * FROM file(currentDatabase() || '_04653_nullable_element.parquet', Parquet);
+
+INSERT INTO FUNCTION file(currentDatabase() || '_04653_point.parquet', Parquet, 'p Nullable(Point)')
+    SELECT * FROM values('p Nullable(Point)', ((1, 2)), (NULL));
+
+DESCRIBE file(currentDatabase() || '_04653_point.parquet', Parquet);
+SELECT * FROM file(currentDatabase() || '_04653_point.parquet', Parquet);
+
+INSERT INTO FUNCTION file(currentDatabase() || '_04653_array.parquet', Parquet, 'p Array(Nullable(Point))')
+    SELECT * FROM values('p Array(Nullable(Point))', ([(1, 2), NULL]), ([]));
+
+DESCRIBE file(currentDatabase() || '_04653_array.parquet', Parquet);
+SELECT * FROM file(currentDatabase() || '_04653_array.parquet', Parquet);
+
+INSERT INTO FUNCTION file(currentDatabase() || '_04653_nested.parquet', Parquet, 'n Nullable(Tuple(x Int64, t Tuple(y Int64, z String)))')
+    SELECT if(number = 1, NULL, (number, (number * 10, 'y'))) FROM numbers(3);
+
+DESCRIBE file(currentDatabase() || '_04653_nested.parquet', Parquet);
+SELECT * FROM file(currentDatabase() || '_04653_nested.parquet', Parquet);
+
+INSERT INTO FUNCTION file(currentDatabase() || '_04653_map.parquet', Parquet, 'm Map(String, Nullable(Tuple(x UInt32)))')
+    SELECT map('a', if(number = 1, NULL, tuple(toUInt32(number)))) FROM numbers(2);
+
+DESCRIBE file(currentDatabase() || '_04653_map.parquet', Parquet);
+SELECT * FROM file(currentDatabase() || '_04653_map.parquet', Parquet);
+
+-- Nullable element without optional parent group stays inside `Tuple`
+
+INSERT INTO FUNCTION file(currentDatabase() || '_04653_inner.parquet', Parquet, 'p Tuple(a Nullable(UInt8))')
+    SELECT * FROM values('p Tuple(a Nullable(UInt8))', (tuple(1)), (tuple(NULL)));
+
+DESCRIBE file(currentDatabase() || '_04653_inner.parquet', Parquet);
+SELECT * FROM file(currentDatabase() || '_04653_inner.parquet', Parquet);
+
+-- Without `allow_experimental_nullable_tuple_type`, push group null map onto leaves
+
+SET allow_experimental_nullable_tuple_type = 0;
+
+DESCRIBE file(currentDatabase() || '_04653.parquet', Parquet);
+SELECT * FROM file(currentDatabase() || '_04653.parquet', Parquet);
+
+DESCRIBE file(currentDatabase() || '_04653_nullable_element.parquet', Parquet);
+SELECT * FROM file(currentDatabase() || '_04653_nullable_element.parquet', Parquet);


### PR DESCRIPTION
Closes #112427


### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed Parquet schema inference and round trips for Nullable(Tuple(...)), preserving tuple-level NULL values separately from nullable tuple elements, including tuple values nested in arrays and maps.