### PR TITLE
Automatically request docs team reviews

### DIFF
--- a/.github/workflows/request_docs_team_review.yml
+++ b/.github/workflows/request_docs_team_review.yml
@@ -1,0 +1,23 @@
+name: Request docs team review
+
+on:
+  pull_request_target:
+    types: [opened, labeled, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request_docs_team_review:
+    if: contains(github.event.pull_request.labels.*.name, 'pr-documentation')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review from the docs team
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh api --method POST \
+            "repos/${GH_REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
+            --field 'team_reviewers[]=docs'


### PR DESCRIPTION
Automatically request a review from `@ClickHouse/docs` whenever a pull request carries the `pr-documentation` label. A lightweight `pull_request_target` workflow handles labels present when a pull request is opened or reopened and labels added later, including by the existing changelog-category automation.

The workflow does not check out or execute pull request code. It grants only `pull-requests: write` and lets the review-request API error propagate. GitHub must allow that permission for `GITHUB_TOKEN`, and the `docs` team must remain visible to GitHub Actions and have read access to `ClickHouse/ClickHouse`; otherwise the workflow will fail visibly instead of silently using fallback reviewers.


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Automatically request a review from the docs team for pull requests labeled `pr-documentation`.