### PR TITLE
Make schema inference use the same float parser as deserialization

### DIFF
--- a/src/Formats/EscapingRuleUtils.cpp
+++ b/src/Formats/EscapingRuleUtils.cpp
@@ -340,13 +340,11 @@ DataTypePtr tryInferDataTypeByEscapingRule(const String & field, const FormatSet
 
             auto type = tryInferDataTypeForSingleField(field, format_settings);
 
-            /// A number starting with 0 must stay a String when the value parser cannot read the inferred type
-            /// back: an integer, because readIntTextUnsafe (see ReadHelpers.h) reads the leading '0' as the
-            /// whole value; or an exponent form, because inference accepts values such as `0.5e+` that
-            /// readFloatTextPrecise rejects. allow_number_leading_zeros (hive partitioning) opts out.
+            /// An integer starting with 0 must stay a String, because readIntTextUnsafe (see
+            /// ReadHelpers.h) reads the leading '0' as the whole value.
+            /// allow_number_leading_zeros (hive partitioning) opts out.
             if (type && field[0] == '0' && field.size() != 1 && !format_settings.allow_number_leading_zeros
-                && (isInteger(removeNullable(recursiveRemoveLowCardinality(type)))
-                    || field.find_first_of("eE") != String::npos))
+                && isInteger(removeNullable(recursiveRemoveLowCardinality(type))))
                 return std::make_shared<DataTypeString>();
 
             if (!type)

--- a/src/Formats/SchemaInferenceUtils.cpp
+++ b/src/Formats/SchemaInferenceUtils.cpp
@@ -1017,79 +1017,151 @@ namespace
         return tryReadFloatTextExtNoExponent(value, buf, has_fractional);
     }
 
-    template <bool is_json>
-    DataTypePtr tryInferNumber(ReadBuffer & buf, const FormatSettings & settings, JSONInferenceInfo * json_info)
+    /// A memory buffer forces this parser's strict no-copy path, so the verdict does not depend on
+    /// buffer geometry or on precise_float_parsing.
+    bool preciseParserAcceptsWholeSpan(std::string_view span)
     {
-        if (buf.eof())
-            return nullptr;
+        Float64 value = 0;
+        ReadBufferFromMemory span_buf(span);
+        return tryReadFloatTextPrecise(value, span_buf) && span_buf.eof();
+    }
 
-        Float64 tmp_float = 0;
-        bool has_fractional = false;
+    /// A complete String on the JSON path, because chooseResultColumnType discards a nullptr and a
+    /// later numeric row would resurrect the unreadable Float64. The CSV, Escaped and Raw rules
+    /// complete a nullptr to String per field before rows are merged; the Quoted rule keeps nullptr
+    /// but never receives such a token, because readQuotedFieldInto tokenizes it with this parser.
+    template <bool is_json>
+    DataTypePtr rejectedNumberType()
+    {
+        if constexpr (is_json)
+            return std::make_shared<DataTypeString>();
+        return nullptr;
+    }
+
+    /// The answer for a field that held no characters at all, which a trailing delimiter in a
+    /// collection leaves behind. The integer parsers accept a token with no digits, so this is the
+    /// type inference has always reported there, and the deserializers accept the same text.
+    DataTypePtr tryInferNumberFromEmptyField(const FormatSettings & settings)
+    {
+        /// The integer parsers read no sign either, so the type is never a negative integer and is not
+        /// registered in json_info->negative_integers.
+        if (settings.try_infer_integers)
+            return std::make_shared<DataTypeInt64>();
+        return std::make_shared<DataTypeFloat64>();
+    }
+
+    /// True when the span is written like a float rather than like an integer. Only reached after the
+    /// delimiting pass accepted the span and both integer arms declined it, so testing for a '.', an
+    /// exponent marker or an inf/nan lead character is enough to tell the two apart here.
+    bool spanHasFloatSyntax(std::string_view span)
+    {
+        for (char c : span)
+        {
+            if (c == '.' || c == 'e' || c == 'E' || c == 'i' || c == 'I' || c == 'n' || c == 'N')
+                return true;
+        }
+        return false;
+    }
+
+    /// Every parser must consume the whole span; the first that does wins. Re-parsing the span rather
+    /// than reusing the delimiting pass keeps the answer independent of buffer geometry.
+    template <bool is_json>
+    DataTypePtr classifyNumberSpan(
+        std::string_view span, bool field_was_untouched, const FormatSettings & settings, JSONInferenceInfo * json_info)
+    {
+        /// Nothing was delimited. A collection closing right after a delimiter read no characters at
+        /// all and keeps its previous answer; a failed `true`/`false`/`null` probe walked past what it
+        /// matched, and that leftover is refused.
+        if (span.empty())
+        {
+            if (field_was_untouched)
+                return tryInferNumberFromEmptyField(settings);
+            return rejectedNumberType<is_json>();
+        }
+
         if (settings.try_infer_integers)
         {
-            /// If we read from String, we can do it in a more efficient way.
-            if (auto * /*string_buf*/ _ = dynamic_cast<ReadBufferFromString *>(&buf))
-            {
-                /// Remember the pointer to the start of the number to rollback to it.
-                /// We can safely get back to the start of the number, because we read from a string and we didn't reach eof.
-                char * number_start = buf.position();
-
-                /// NOTE: it may break parsing of tryReadFloat() != tryReadIntText() + parsing of '.'/'e'
-                /// But, for now it is true
-                if (tryReadFloat<is_json>(tmp_float, buf, settings, has_fractional) && has_fractional)
-                    return std::make_shared<DataTypeFloat64>();
-
-                Int64 tmp_int = 0;
-                buf.position() = number_start;
-                if (tryReadIntText(tmp_int, buf))
-                {
-                    auto type = std::make_shared<DataTypeInt64>();
-                    if (json_info && tmp_int < 0)
-                        json_info->negative_integers.insert(type.get());
-                    return type;
-                }
-
-                /// In case of Int64 overflow we can try to infer UInt64.
-                UInt64 tmp_uint = 0;
-                buf.position() = number_start;
-                if (tryReadIntText(tmp_uint, buf))
-                    return std::make_shared<DataTypeUInt64>();
-
-                return nullptr;
-            }
-
-            /// We should use PeekableReadBuffer, because we need to
-            /// rollback to the start of number to parse it as integer first
-            /// and then as float.
-            PeekableReadBuffer peekable_buf(buf);
-            PeekableReadBufferCheckpoint checkpoint(peekable_buf);
-
-            if (tryReadFloat<is_json>(tmp_float, peekable_buf, settings, has_fractional) && has_fractional)
-                return std::make_shared<DataTypeFloat64>();
-            peekable_buf.rollbackToCheckpoint(/* drop= */ false);
-
             Int64 tmp_int = 0;
-            if (tryReadIntText(tmp_int, peekable_buf))
+            ReadBufferFromMemory int_buf(span);
+            if (tryReadIntText(tmp_int, int_buf) && int_buf.eof())
             {
                 auto type = std::make_shared<DataTypeInt64>();
                 if (json_info && tmp_int < 0)
                     json_info->negative_integers.insert(type.get());
                 return type;
             }
-            peekable_buf.rollbackToCheckpoint(/* drop= */ true);
 
             /// In case of Int64 overflow we can try to infer UInt64.
             UInt64 tmp_uint = 0;
-            if (tryReadIntText(tmp_uint, peekable_buf))
+            ReadBufferFromMemory uint_buf(span);
+            if (tryReadIntText(tmp_uint, uint_buf) && uint_buf.eof())
                 return std::make_shared<DataTypeUInt64>();
-        }
-        else if (tryReadFloat<is_json>(tmp_float, buf, settings, has_fractional))
-        {
-            return std::make_shared<DataTypeFloat64>();
+
+            /// Both integer types overflowed. Only a span written like a float may fall through to
+            /// Float64: a digit-only one keeps its exact digits as a String instead of rounding.
+            /// Where integers are not inferred at all there is nothing to preserve, so the check
+            /// applies here only.
+            if (!spanHasFloatSyntax(span))
+                return rejectedNumberType<is_json>();
         }
 
-        /// This is not a number.
-        return nullptr;
+        if (preciseParserAcceptsWholeSpan(span))
+            return std::make_shared<DataTypeFloat64>();
+
+        return rejectedNumberType<is_json>();
+    }
+
+    /// Extracts the number delimited between the checkpoint and the current position.
+    /// The span must come from makeContinuousMemoryFromCheckpointToPos(): a saved position()
+    /// dangles and count() carries no bytes once the working buffer refills (see 5246c56a2aae74).
+    /// Extraction cannot be undone, so the span stays consumed however it is then classified.
+    std::string_view extractDelimitedNumber(PeekableReadBuffer & buf)
+    {
+        buf.makeContinuousMemoryFromCheckpointToPos();
+        auto * end = buf.position();
+        buf.rollbackToCheckpoint();
+        std::string_view span(buf.position(), end - buf.position());
+        buf.position() = end;
+        return span;
+    }
+
+    /// field_start_count is buf.count() from before the field was probed at all, so that a number
+    /// delimited as empty can be told apart from a leftover a failed literal probe walked past.
+    template <bool is_json>
+    DataTypePtr tryInferNumber(
+        ReadBuffer & buf, size_t field_start_count, const FormatSettings & settings, JSONInferenceInfo * json_info)
+    {
+        if (buf.eof())
+            return nullptr;
+
+        const bool field_was_untouched = buf.count() == field_start_count;
+        Float64 tmp_float = 0;
+        bool has_fractional = false;
+
+        /// If we read from String, we can do it in a more efficient way.
+        if (auto * /*string_buf*/ _ = dynamic_cast<ReadBufferFromString *>(&buf))
+        {
+            /// Remember the pointer to the start of the number to delimit the span.
+            /// We can safely get back to the start of the number, because we read from a string and we didn't reach eof.
+            char * number_start = buf.position();
+            /// The verdict is discarded: what matters is the span the pass delimited. A failure may
+            /// still have consumed a partial token (a bare sign, or a partial inf/nan keyword), which
+            /// the classifier rejects, and a success may have consumed nothing at all, which leaves the
+            /// span empty so the integer arm below answers exactly as it did before this branch.
+            tryReadFloat<is_json>(tmp_float, buf, settings, has_fractional);
+
+            return classifyNumberSpan<is_json>(
+                std::string_view(number_start, buf.position() - number_start), field_was_untouched, settings, json_info);
+        }
+
+        /// Needs a checkpoint to extract the delimited number before classifying it.
+        PeekableReadBuffer peekable_buf(buf);
+        PeekableReadBufferCheckpoint checkpoint(peekable_buf);
+
+        tryReadFloat<is_json>(tmp_float, peekable_buf, settings, has_fractional);
+
+        return classifyNumberSpan<is_json>(
+            extractDelimitedNumber(peekable_buf), field_was_untouched, settings, json_info);
     }
 
     template <bool is_json>
@@ -1122,7 +1194,10 @@ namespace
 
         Float64 tmp = 0;
         bool has_fractional = false;
-        if (tryReadFloat<is_json>(tmp, buf, settings, has_fractional) && buf.eof())
+        /// The whole field is already in contiguous memory here, so validate it directly.
+        /// Keep returning nullptr on rejection: the caller falls through to String, and a String
+        /// returned from here would be registered in json_info->numbers_parsed_from_json_strings.
+        if (tryReadFloat<is_json>(tmp, buf, settings, has_fractional) && buf.eof() && preciseParserAcceptsWholeSpan(field))
             return std::make_shared<DataTypeFloat64>();
 
         return nullptr;
@@ -1356,6 +1431,10 @@ namespace
         if (buf.eof())
             return nullptr;
 
+        /// Remembered before any probe below can walk past characters it then fails to match, so that
+        /// number inference can tell a field that held nothing from one whose leftover was refused.
+        const size_t field_start_count = buf.count();
+
         /// Array [field1, field2, ...]
         if (*buf.position() == '[')
             return tryInferArray<is_json>(buf, settings, json_info, depth);
@@ -1402,7 +1481,7 @@ namespace
         }
 
         /// Number
-        return tryInferNumber<is_json>(buf, settings, json_info);
+        return tryInferNumber<is_json>(buf, field_start_count, settings, json_info);
     }
 }
 

--- a/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.reference
+++ b/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.reference
@@ -83,24 +83,29 @@ group 8: no row is lost
 group 9: type merge
 c1	Nullable(Float64)					
 c1	Nullable(Float64)					
-group 10: exponent forms stay String in TSV
+group 10: valid exponent forms infer Float64 in TSV, as in CSV
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					
+group 10: and they read back as numbers
+0
+5000000000
+group 10: malformed exponent forms stay String, now via inference itself
 c1	Nullable(String)					
 c1	Nullable(String)					
 c1	Nullable(String)					
-c1	Nullable(String)					
-c1	Nullable(String)					
-c1	Nullable(String)					
-c1	Nullable(String)					
-group 10: the malformed exponent is readable only because it stays String
+group 10: so they still read back verbatim
 0.5e+
 0e+
 0.5e-
 0.5e+	String
 0e+	String
-group 10: the CSV divergence that deliberately remains
+group 10: CSV agrees with TSV, and the malformed form is readable in both
 c1	Nullable(Float64)					
 c1	Nullable(Float64)					
-c1	Nullable(Float64)					
+c1	Nullable(String)					
+0.5e+
 group 11: try_infer_integers = 1 (the default)
 c1	Nullable(Float64)					
 c1	Nullable(String)					

--- a/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.sql
+++ b/tests/queries/0_stateless/04648_tsv_schema_inference_leading_zero_decimals.sql
@@ -108,29 +108,33 @@ SELECT 'group 9: type merge';
 DESC format(TSV, '0.0\n0.5');
 DESC format(TSV, '0.5\n1.5');
 
--- 10. Exponent forms deliberately keep inferring String in the TSV family. Do not remove this group:
--- schema inference accepts exponent values whose exponent has no digits, such as `0.5e+`, that the value
--- parser's precise float reader rejects, so admitting them here would turn a wrong type into a hard parse
--- error.
-SELECT 'group 10: exponent forms stay String in TSV';
+-- 10. A leading zero no longer forces exponent forms to String. Inference now validates the number it
+-- delimited with the same parser the value reader uses, so a malformed exponent such as `0.5e+` is
+-- declined by inference itself and a valid one such as `0e5` is admitted. The leading-zero check
+-- therefore covers integers only, and TSV agrees with CSV throughout this group.
+SELECT 'group 10: valid exponent forms infer Float64 in TSV, as in CSV';
 DESC format(TSV, '0e5') SETTINGS input_format_try_infer_exponent_floats = 1;
 DESC format(TSV, '0E5') SETTINGS input_format_try_infer_exponent_floats = 1;
 DESC format(TSV, '0e-5') SETTINGS input_format_try_infer_exponent_floats = 1;
 DESC format(TSV, '0.5e10') SETTINGS input_format_try_infer_exponent_floats = 1;
+SELECT 'group 10: and they read back as numbers';
+SELECT * FROM format(TSV, '0e5') SETTINGS input_format_try_infer_exponent_floats = 1;
+SELECT * FROM format(TSV, '0.5e10') SETTINGS input_format_try_infer_exponent_floats = 1;
+SELECT 'group 10: malformed exponent forms stay String, now via inference itself';
 DESC format(TSV, '0.5e+') SETTINGS input_format_try_infer_exponent_floats = 1;
 DESC format(TSV, '0e+') SETTINGS input_format_try_infer_exponent_floats = 1;
 DESC format(TSV, '0.5e-') SETTINGS input_format_try_infer_exponent_floats = 1;
-SELECT 'group 10: the malformed exponent is readable only because it stays String';
+SELECT 'group 10: so they still read back verbatim';
 SELECT * FROM format(TSV, '0.5e+') SETTINGS input_format_try_infer_exponent_floats = 1;
 SELECT * FROM format(TSV, '0e+') SETTINGS input_format_try_infer_exponent_floats = 1;
 SELECT * FROM format(TSV, '0.5e-') SETTINGS input_format_try_infer_exponent_floats = 1;
 SELECT d, dynamicType(d) FROM format(TSV, 'd Dynamic', '0.5e+') SETTINGS input_format_try_infer_exponent_floats = 1;
 SELECT d, dynamicType(d) FROM format(TSV, 'd Dynamic', '0e+') SETTINGS input_format_try_infer_exponent_floats = 1;
-SELECT 'group 10: the CSV divergence that deliberately remains';
+SELECT 'group 10: CSV agrees with TSV, and the malformed form is readable in both';
 DESC format(CSV, '0e5') SETTINGS input_format_try_infer_exponent_floats = 1;
 DESC format(CSV, '0.5e10') SETTINGS input_format_try_infer_exponent_floats = 1;
 DESC format(CSV, '0.5e+') SETTINGS input_format_try_infer_exponent_floats = 1;
-SELECT * FROM format(CSV, '0.5e+') SETTINGS input_format_try_infer_exponent_floats = 1; -- { serverError CANNOT_PARSE_NUMBER }
+SELECT * FROM format(CSV, '0.5e+') SETTINGS input_format_try_infer_exponent_floats = 1;
 
 -- 11. The integer part of the check is derived from the inferred type, so it follows
 -- input_format_try_infer_integers: with integer inference disabled, inference yields Float64, the value

--- a/tests/queries/0_stateless/04652_schema_inference_float_parser_parity.reference
+++ b/tests/queries/0_stateless/04652_schema_inference_float_parser_parity.reference
@@ -1,0 +1,50 @@
+-- 1. JSON rejects a malformed number as a complete String
+a	Nullable(String)					
+a	Nullable(String)					
+a	Nullable(String)					
+-- 2. a later numeric row must not resurrect the rejected type, in either order
+a	Nullable(String)					
+a	Nullable(String)					
+a	Nullable(String)					
+a	Array(Nullable(String))					
+c1	Nullable(String)					
+1.5
+['1.5']
+a	Nullable(Float64)					
+\N
+1.5
+-- 3. a digit-only value overflowing both integer types keeps its exact digits
+c1	Nullable(String)					
+a	Nullable(String)					
+12345678901234567890123
+12345678901234567890123
+c1	Nullable(UInt64)					
+c1	Nullable(UInt64)					
+c1	Nullable(Int64)					
+c1	Nullable(Int64)					
+-- 4. the same validation applies to a number inferred from a quoted string
+a	Nullable(String)					
+c1	Nullable(String)					
+a	Nullable(Float64)					
+c1	Nullable(Float64)					
+-- 5. default-reachable carriers in TSV and CSV, with a read-back
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+.
++
+.
+-- 6. on a Dynamic column the divergence was an error at INSERT time
+1e+	String
+.	String
+-- 7. a collection with a trailing delimiter keeps the type it always had
+Tuple(Int64, Int64, Int64)
+Array(Int64)
+(1,2,0)	[1]
+(false,false,'was',0)	Tuple(Bool, Bool, String, Int64)
+1	Int64
+a	Nullable(String)					
+a	Nullable(String)					

--- a/tests/queries/0_stateless/04652_schema_inference_float_parser_parity.sql
+++ b/tests/queries/0_stateless/04652_schema_inference_float_parser_parity.sql
@@ -1,0 +1,88 @@
+-- Inference must not propose a numeric type the value parser cannot read back.
+
+-- Group 2 merges a rejected number with a later numeric row, which only resolves while numbers are
+-- allowed to become strings. That default flipped in 23.9, so a randomized `compatibility` below it
+-- would turn those rows into Code 53 instead of the merge under test. At the real default this is a
+-- no-op, so the reference is unaffected.
+set input_format_json_read_numbers_as_strings = 1;
+
+SELECT '-- 1. JSON rejects a malformed number as a complete String';
+DESC format(JSONEachRow, '{"a":1e+}');
+DESC format(JSONEachRow, '{"a":+}');
+DESC format(JSONEachRow, '{"a":.}');
+
+SELECT '-- 2. a later numeric row must not resurrect the rejected type, in either order';
+DESC format(JSONEachRow, '{"a":1e+}\n{"a":1.5}');
+DESC format(JSONEachRow, '{"a":1.5}\n{"a":1e+}');
+DESC format(JSONEachRow, '{"a":+}\n{"a":1.5}');
+DESC format(JSONEachRow, '{"a":[1e+]}\n{"a":[1.5]}');
+DESC format(JSONCompactEachRow, '[1e+]\n[1.5]');
+-- the merged schema reads; the malformed row stays skippable, which an inference-time throw is not
+SELECT a FROM format(JSONEachRow, '{"a":1e+}\n{"a":1.5}') SETTINGS input_format_allow_errors_num = 1;
+SELECT a FROM format(JSONEachRow, '{"a":[1e+]}\n{"a":[1.5]}') SETTINGS input_format_allow_errors_num = 1;
+-- control: only the malformed token is rejected, not every non-numeric contribution
+DESC format(JSONEachRow, '{"a":null}\n{"a":1.5}');
+SELECT a FROM format(JSONEachRow, '{"a":null}\n{"a":1.5}') ORDER BY a NULLS FIRST;
+
+SELECT '-- 3. a digit-only value overflowing both integer types keeps its exact digits';
+DESC format(TSV, '12345678901234567890123');
+DESC format(JSONEachRow, '{"a":12345678901234567890123}');
+SELECT c1 FROM format(TSV, '12345678901234567890123');
+SELECT a FROM format(JSONEachRow, '{"a":12345678901234567890123}');
+-- must not move: these still fit an integer type
+DESC format(TSV, '12345678901234567890');
+DESC format(TSV, '9223372036854775808');
+DESC format(TSV, '1');
+DESC format(TSV, '-3');
+
+SELECT '-- 4. the same validation applies to a number inferred from a quoted string';
+DESC format(JSONEachRow, '{"a":"1e+"}') SETTINGS input_format_json_try_infer_numbers_from_strings = 1;
+-- `1e+` only reaches the permissive delimiter while the exponent setting is on, so the setting is
+-- part of this scenario; the JSON twin above needs no pin, because `is_json` forces the exponent
+-- grammar unconditionally.
+DESC format(CSV, '"1e+"') SETTINGS input_format_csv_try_infer_numbers_from_strings = 1, input_format_try_infer_exponent_floats = 1;
+DESC format(JSONEachRow, '{"a":"1.5"}') SETTINGS input_format_json_try_infer_numbers_from_strings = 1;
+DESC format(CSV, '"1.5"') SETTINGS input_format_csv_try_infer_numbers_from_strings = 1;
+
+SELECT '-- 5. default-reachable carriers in TSV and CSV, with a read-back';
+DESC format(TSV, '.');
+DESC format(TSV, '+');
+DESC format(TSV, '-');
+DESC format(CSV, '.');
+DESC format(CSV, '+');
+DESC format(CSV, '-');
+SELECT c1 FROM format(TSV, '.');
+SELECT c1 FROM format(TSV, '+');
+SELECT c1 FROM format(CSV, '.');
+
+SELECT '-- 6. on a Dynamic column the divergence was an error at INSERT time';
+-- `1e+` only reaches the permissive delimiter while the exponent setting is on, so the setting is
+-- part of this scenario and is pinned per statement rather than for the whole file.
+SELECT d, dynamicType(d) FROM format(TSV, 'd Dynamic', '1e+') SETTINGS input_format_try_infer_exponent_floats = 1;
+-- `.` carries the same divergence at stock settings, so the group keeps a live assertion either way.
+SELECT d, dynamicType(d) FROM format(TSV, 'd Dynamic', '.');
+
+SELECT '-- 7. a collection with a trailing delimiter keeps the type it always had';
+-- The delimiting pass reports success without consuming anything for the empty element a trailing
+-- delimiter leaves behind. Requiring the whole span to be consumed would refuse it, but the value
+-- parser accepts that text, so refusing it would be a new divergence in the opposite direction: on
+-- a Dynamic column an incomplete type here is absorbed by an existing integer variant, which
+-- replaces the whole field with a zero that was never in the input. So the empty element is left to
+-- the integer parsers, exactly as before this fix.
+-- CAST to Dynamic only runs inference while cast_string_to_dynamic_use_inference is on, so the
+-- setting is part of this scenario and is pinned per statement.
+SELECT dynamicType(CAST('(1, 2, )', 'Dynamic')) SETTINGS enable_dynamic_type = 1, cast_string_to_dynamic_use_inference = 1;
+SELECT dynamicType(CAST('[1, ]', 'Dynamic')) SETTINGS enable_dynamic_type = 1, cast_string_to_dynamic_use_inference = 1;
+-- the value parser reads back every type inferred above, which is the property under test
+SELECT CAST('(1, 2, )', 'Tuple(UInt8, UInt8, UInt8)'), CAST('[1, ]', 'Array(UInt8)');
+-- an existing integer variant must not swallow the whole tuple, which is what a rejection here costs
+DROP TABLE IF EXISTS t04652;
+CREATE TABLE t04652 (c0 Dynamic) ENGINE = Memory SETTINGS enable_dynamic_type = 1;
+INSERT INTO TABLE t04652 (c0) VALUES (1), ((FALSE, FALSE, 'was', ));
+SELECT c0, dynamicType(c0) FROM t04652 ORDER BY toString(c0);
+DROP TABLE t04652;
+-- A failed `true`/`false`/`null` probe also leaves nothing for the number parser, but it walked past
+-- the characters it matched, so that leftover is refused rather than preserved. This is the opposite
+-- answer to the empty element above, and the two are told apart by whether the field was read at all.
+DESC format(JSONEachRow, '{"a":tru}');
+DESC format(JSONEachRow, '{"a":nul}') SETTINGS input_format_try_infer_integers = 0;

--- a/tests/queries/0_stateless/04653_schema_inference_float_parser_parity_buffer_size.reference
+++ b/tests/queries/0_stateless/04653_schema_inference_float_parser_parity_buffer_size.reference
@@ -1,0 +1,11 @@
+inf: same type at both buffer sizes, and it reads
+Nullable(Float64)
+Nullable(Float64)
+inf
+inf
+a partial inf keyword: same type at both buffer sizes
+Nullable(String)
+Nullable(String)
+a later numeric row must not resurrect it, at either buffer size
+Nullable(String)
+Nullable(String)

--- a/tests/queries/0_stateless/04653_schema_inference_float_parser_parity_buffer_size.sh
+++ b/tests/queries/0_stateless/04653_schema_inference_float_parser_parity_buffer_size.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# The inferred type must not depend on how much of the number the working buffer held.
+# max_read_buffer_size is not settable per statement, so this needs clickhouse-local.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+SMALL=(--storage_file_read_method read --max_read_buffer_size 1 --input-format JSONEachRow)
+DEFAULT=(--storage_file_read_method read --input-format JSONEachRow)
+
+echo 'inf: same type at both buffer sizes, and it reads'
+$CLICKHOUSE_LOCAL "${SMALL[@]}" 'desc "table"' <<<'{"x" : inf}' | cut -f2
+$CLICKHOUSE_LOCAL "${DEFAULT[@]}" 'desc "table"' <<<'{"x" : inf}' | cut -f2
+$CLICKHOUSE_LOCAL "${SMALL[@]}" 'select x from "table"' <<<'{"x" : inf}'
+$CLICKHOUSE_LOCAL "${DEFAULT[@]}" 'select x from "table"' <<<'{"x" : inf}'
+
+echo 'a partial inf keyword: same type at both buffer sizes'
+$CLICKHOUSE_LOCAL "${SMALL[@]}" 'desc "table"' <<<'{"x" : i}' | cut -f2
+$CLICKHOUSE_LOCAL "${DEFAULT[@]}" 'desc "table"' <<<'{"x" : i}' | cut -f2
+
+echo 'a later numeric row must not resurrect it, at either buffer size'
+$CLICKHOUSE_LOCAL "${SMALL[@]}" 'desc "table"' <<<'{"x" : i}
+{"x" : 1.5}' | cut -f2
+$CLICKHOUSE_LOCAL "${DEFAULT[@]}" 'desc "table"' <<<'{"x" : i}
+{"x" : 1.5}' | cut -f2


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112226
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed schema inference proposing a numeric type for text values the value parser cannot read back. Inference accepted a dangling exponent (`1e+`), a missing mantissa (`.`) or a repeated sign (`++inf`), which `readFloatTextPrecise` then rejected with `CANNOT_PARSE_NUMBER` when reading the inferred schema; on a `Dynamic` column this was an error at INSERT time. Inference now validates the number with the parser the reader actually uses. This also removes a case where the inferred type depended on `max_read_buffer_size`, and lets valid leading-zero exponent forms such as `0e5` infer `Float64` in TSV as they already do in CSV. Follows #112226 and closes the exponent half of #112105.

### Description

Inference used `tryReadFloatTextExt` (`SchemaInferenceUtils.cpp`); deserialization uses `readFloatTextPrecise` (`SerializationNumber.cpp`, `precise_float_parsing` defaults `true`). What the first accepts and the second rejects became an unreadable schema.

With `input_format_try_infer_integers = 1` (the default) there was a second symptom: after the float attempt the code rolled back and re-parsed as an integer, and `tryReadIntText` could succeed on a *prefix*. Which exit was reached depended on how much of the token the buffer held, so `{"x" : inf}` inferred `Int64` at `--max_read_buffer_size 1` but raised `Code 636` by default.

The fix delimits the number once, then types it from that span alone on a memory buffer, each parser required to consume the whole span: `Int64`, then `UInt64`, then precise `Float64`. The last arm applies only when the span carries float or non-finite syntax, which preserves today's behaviour for a digit-only value overflowing both integer types (it keeps its exact digits as a `String` instead of rounding). The verdict never depends on parse-attempt order, buffer geometry, or `precise_float_parsing`, which is not in the schema-inference cache key. No parser in `src/IO/` is modified.

On the JSON path a rejected number becomes a complete `String`, not "no information": `chooseResultColumnType` discards a null contribution, so a later numeric row would resurrect the unreadable `Float64`. Such a column still reads numbers, nulls and quoted strings, and a malformed row stays skippable, which an inference-time throw is not.

Validated with a 2520-cell read-oracle sweep (0 violations), a 2156-token deserialization-oracle sweep, 50 randomized runs, and a mutation test per guard.

<details>
<summary>Buffer-geometry sweep: 227 tokens x <code>input_format_try_infer_integers</code> in {0,1}, each measured at <code>--max_read_buffer_size 1</code> and at the default</summary>

A cell is "divergent" when the same document infers different types at the two buffer sizes.

| build | divergent cells / 454 |
|---|---|
| `master` | 8 |
| `master` + this PR's other hunks, without the span classifier | 8 |
| **this PR** | **0** |

The eight pre-existing cells are `i`, `in`, `I`, `inf`, `Inf`, `INF`, `infi`, `infinit` at
`input_format_try_infer_integers = 1`: each infers `Nullable(Int64)` with a 1-byte buffer and fails
`Code 636` at the default. They are removed rather than merely left unchanged, so no token's inferred
type depends on the buffer size. `03170_float_schema_inference_small_block`, which guards this
property for ordinary numbers, is unchanged.

Behaviour intentionally changed beyond the tokens above: after a failed JSON `true`/`false`/`null`
probe the leftover span is now refused instead of being read as a zero-digit integer, so `tru`, `t`,
`nul`, `fals` and friends infer `String` rather than a numeric type that fails `Code 27` on read.
The remaining defect on that path (inference typing a suffix of a mistyped literal) is not addressed
here.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.496` (included in `26.8` and later)
<!-- ch-version-info:end -->