### PR TITLE
Make std::string_view comparison operators constexpr

### DIFF
--- a/base/base/StringViewHash.h
+++ b/base/base/StringViewHash.h
@@ -174,7 +174,8 @@ constexpr bool operator== (std::string_view lhs, std::string_view rhs)
 {
     if consteval
     {
-        return lhs.compare(rhs) == 0;
+        /// Cannot use `==`: that is this operator. The standard defines it as exactly this.
+        return lhs.compare(rhs) == 0; // NOLINT(readability-string-compare)
     }
 
     if (lhs.size() != rhs.size())

--- a/base/base/StringViewHash.h
+++ b/base/base/StringViewHash.h
@@ -170,8 +170,13 @@ inline bool memequalWide(const char * p1, const char * p2, size_t size)
 
 #endif
 
-inline bool operator== (std::string_view lhs, std::string_view rhs)
+constexpr bool operator== (std::string_view lhs, std::string_view rhs)
 {
+    if consteval
+    {
+        return lhs.compare(rhs) == 0;
+    }
+
     if (lhs.size() != rhs.size())
         return false;
 
@@ -185,7 +190,7 @@ inline bool operator== (std::string_view lhs, std::string_view rhs)
 #endif
 }
 
-inline bool operator!= (std::string_view lhs, std::string_view rhs)
+constexpr bool operator!= (std::string_view lhs, std::string_view rhs)
 {
     return !(lhs == rhs);
 }

--- a/base/base/StringViewHash.h
+++ b/base/base/StringViewHash.h
@@ -196,14 +196,24 @@ constexpr bool operator!= (std::string_view lhs, std::string_view rhs)
     return !(lhs == rhs);
 }
 
-inline bool operator< (std::string_view lhs, std::string_view rhs)
+constexpr bool operator< (std::string_view lhs, std::string_view rhs)
 {
+    if consteval
+    {
+        return lhs.compare(rhs) < 0;
+    }
+
     int cmp = memcmp(lhs.data(), rhs.data(), std::min(lhs.size(), rhs.size()));
     return cmp < 0 || (cmp == 0 && lhs.size() < rhs.size());
 }
 
-inline bool operator> (std::string_view lhs, std::string_view rhs)
+constexpr bool operator> (std::string_view lhs, std::string_view rhs)
 {
+    if consteval
+    {
+        return lhs.compare(rhs) > 0;
+    }
+
     int cmp = memcmp(lhs.data(), rhs.data(), std::min(lhs.size(), rhs.size()));
     return cmp > 0 || (cmp == 0 && lhs.size() > rhs.size());
 }

--- a/base/base/StringViewHash.h
+++ b/base/base/StringViewHash.h
@@ -174,7 +174,7 @@ constexpr bool operator== (std::string_view lhs, std::string_view rhs)
 {
     if consteval
     {
-        /// Cannot use `==`: that is this operator. The standard defines it as exactly this.
+        /// `==` would recurse into the operator being defined; the standard specifies `compare` as its result.
         return lhs.compare(rhs) == 0; // NOLINT(readability-string-compare)
     }
 

--- a/src/Common/tests/gtest_string_view_hash.cpp
+++ b/src/Common/tests/gtest_string_view_hash.cpp
@@ -1,0 +1,27 @@
+#include <string_view>
+
+#include <base/StringViewHash.h>
+
+#include <gtest/gtest.h>
+
+using std::string_view_literals::operator""sv;
+
+/// The operators from `StringViewHash.h` take separate paths at run time and under constant
+/// evaluation, so check every case both ways.
+#define CHECK(expression) \
+    static_assert(expression); \
+    ASSERT_TRUE(expression)
+
+TEST(StringViewComparison, ConstantEvaluatedAndRunTimePathsAgree)
+{
+    CHECK("a"sv == "a"sv);
+    CHECK("a"sv != "b"sv);
+    CHECK("a"sv < "b"sv);
+    CHECK("b"sv > "a"sv);
+
+    /// One view a prefix of the other, so only the size breaks the tie.
+    CHECK("abc"sv < "abcd"sv);
+    CHECK("abcd"sv > "abc"sv);
+}
+
+#undef CHECK


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

---

The comparison operators for `std::string_view` are `constexpr` in the standard — see [[string.view.comparison]](https://eel.is/c++draft/string.view.comparison) and [cppreference](https://en.cppreference.com/w/cpp/string/basic_string_view/operator_cmp).

`base/base/StringViewHash.h` defines its own `==`, `!=`, `<` and `>` for `std::string_view`. They are non-template and therefore take precedence over the standard library's in every translation unit that includes the header. Being non-`constexpr`, they made any comparison of two `std::string_view` values unusable in a constant expression, which is limiting in `consteval` contexts — comparing string views inside a `static_assert` is a natural thing to want, and it failed with `non-constexpr function 'operator==' cannot be used in a constant expression`, an error that gives no hint as to where the offending overload comes from.

All four are now `constexpr`. The vectorised and `memcmp`-based implementations are not constant-evaluable, so constant evaluation delegates to `std::string_view::compare`. That is what the standard specifies these operators to return:

> `constexpr bool operator==(basic_string_view<charT, traits> lhs, type_identity_t<basic_string_view<charT, traits>> rhs) noexcept;`
> *Returns:* `lhs.compare(rhs) == 0`.

and the ordering likewise, via `operator<=>` returning `static_cast<R>(lhs.compare(rhs) <=> 0)`.

Note that the signature quoted above is also `noexcept`, and these overloads are not, so `noexcept(a == b)` is `false` here where the standard says it should be `true`. That divergence is left out of scope deliberately. It is orthogonal to this change — an exception specification has no bearing on whether an expression can appear in a `static_assert`, which is what this PR is after — and closing it is a much wider change than adding a keyword: every template that computes its own `noexcept` specification from a `std::string_view` comparison would have that specification flip, so it needs an audit of its own rather than riding along here.

`if consteval` keeps the run-time branch, and hence the generated code, unchanged. The existing run-time bodies for `<` and `>` already agree with `compare`: they compare `min(size)` bytes and then tie-break on size, which is `compare`'s specified behaviour. I checked that equivalence exhaustively over a set of inputs covering prefixes, equal lengths, size tie-breaks and embedded NULs.

After this, all of the following compile:

```cpp
static_assert(std::string_view("a") == std::string_view("a"));
static_assert(std::string_view("a") != std::string_view("b"));
static_assert(std::string_view("a") <  std::string_view("b"));
static_assert(std::string_view("b") >  std::string_view("a"));
```

One `NOLINT(readability-string-compare)` is needed on the equality operator's constant-evaluated branch. The check advises using the equality operator instead of `compare`, which here is the operator being defined. It does not fire on the ordered operators, since it only flags `compare(...) == 0` and `!= 0`.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.492` (included in `26.8` and later)
<!-- ch-version-info:end -->