### PR TITLE
Fix flaky 04490_join_runtime_filters_index_analysis

### DIFF
--- a/tests/queries/0_stateless/04490_join_runtime_filters_index_analysis.sql
+++ b/tests/queries/0_stateless/04490_join_runtime_filters_index_analysis.sql
@@ -35,6 +35,7 @@ SET query_plan_join_swap_table = 'false';
 -- Left-side join pruning is intentionally disabled under parallel replicas, so pin PR off to
 -- exercise the feature (the ParallelReplicas CI job otherwise forces it on).
 SET enable_parallel_replicas = 0;
+SET join_runtime_filter_min_probe_rows = 0;
 
 -- PK join
 SELECT s1.id, s1.country, s1.amount


### PR DESCRIPTION
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107666&sha=df23e1d1e81fab78c6c717fdf63b6928f95461a5&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.415` (included in `26.8` and later)
<!-- ch-version-info:end -->