### PR TITLE
Fix HDFS storage type parsing in data lake catalogs

### DIFF
--- a/src/Databases/DataLake/ICatalog.cpp
+++ b/src/Databases/DataLake/ICatalog.cpp
@@ -66,6 +66,9 @@ StorageType parseStorageTypeFromString(const std::string & type)
         // convert s3://, file://, etc. to s3, file etc.
         storage_type_str = storage_type_str.substr(0,pos);
     }
+    if (storage_type_str == "hdfs")
+        return StorageType::HDFS;
+
     if (capitalize_first_letter(storage_type_str) == "File")
         storage_type_str = "Local";
     else if (capitalize_first_letter(storage_type_str) == "S3a" || storage_type_str == "oss" || storage_type_str == "gs")

--- a/src/Databases/DataLake/tests/gtest_storage_type_parsing.cpp
+++ b/src/Databases/DataLake/tests/gtest_storage_type_parsing.cpp
@@ -1,6 +1,5 @@
 #include <Databases/DataLake/ICatalog.h>
 #include <gtest/gtest.h>
-#include <Common/Exception.h>
 
 namespace DataLake::Test
 {
@@ -9,38 +8,6 @@ TEST(StorageTypeParsingTest, ParsesHDFS)
 {
     EXPECT_EQ(parseStorageTypeFromString("hdfs"), StorageType::HDFS);
     EXPECT_EQ(parseStorageTypeFromString("hdfs://"), StorageType::HDFS);
-}
-
-TEST(StorageTypeParsingTest, RejectsUppercaseHDFS)
-{
-    EXPECT_THROW(parseStorageTypeFromString("HDFS"), DB::Exception);
-    EXPECT_THROW(parseStorageTypeFromString("HDFS://"), DB::Exception);
-    EXPECT_THROW(parseStorageTypeFromLocation("HDFS://namenode/warehouse/table"), DB::Exception);
-}
-
-TEST(StorageTypeParsingTest, ParsesHDFSLocation)
-{
-    EXPECT_EQ(parseStorageTypeFromLocation("hdfs://namenode/warehouse/table"), StorageType::HDFS);
-}
-
-TEST(StorageTypeParsingTest, PreservesExistingStorageSchemes)
-{
-    EXPECT_EQ(parseStorageTypeFromString("s3"), StorageType::S3);
-    EXPECT_EQ(parseStorageTypeFromString("s3a"), StorageType::S3);
-    EXPECT_EQ(parseStorageTypeFromString("azure"), StorageType::Azure);
-    EXPECT_EQ(parseStorageTypeFromString("abfss"), StorageType::Azure);
-    EXPECT_EQ(parseStorageTypeFromString("file"), StorageType::Local);
-    EXPECT_EQ(parseStorageTypeFromString("local"), StorageType::Local);
-}
-
-TEST(StorageTypeParsingTest, TableMetadataAcceptsHDFSLocation)
-{
-    TableMetadata metadata;
-    metadata.withLocation();
-    metadata.setLocation("hdfs://namenode/warehouse/table");
-
-    EXPECT_EQ(metadata.getStorageType(), StorageType::HDFS);
-    EXPECT_EQ(metadata.getLocation(), "hdfs://namenode/warehouse/table");
 }
 
 }

--- a/src/Databases/DataLake/tests/gtest_storage_type_parsing.cpp
+++ b/src/Databases/DataLake/tests/gtest_storage_type_parsing.cpp
@@ -1,0 +1,46 @@
+#include <Databases/DataLake/ICatalog.h>
+#include <gtest/gtest.h>
+#include <Common/Exception.h>
+
+namespace DataLake::Test
+{
+
+TEST(StorageTypeParsingTest, ParsesHDFS)
+{
+    EXPECT_EQ(parseStorageTypeFromString("hdfs"), StorageType::HDFS);
+    EXPECT_EQ(parseStorageTypeFromString("hdfs://"), StorageType::HDFS);
+}
+
+TEST(StorageTypeParsingTest, RejectsUppercaseHDFS)
+{
+    EXPECT_THROW(parseStorageTypeFromString("HDFS"), DB::Exception);
+    EXPECT_THROW(parseStorageTypeFromString("HDFS://"), DB::Exception);
+    EXPECT_THROW(parseStorageTypeFromLocation("HDFS://namenode/warehouse/table"), DB::Exception);
+}
+
+TEST(StorageTypeParsingTest, ParsesHDFSLocation)
+{
+    EXPECT_EQ(parseStorageTypeFromLocation("hdfs://namenode/warehouse/table"), StorageType::HDFS);
+}
+
+TEST(StorageTypeParsingTest, PreservesExistingStorageSchemes)
+{
+    EXPECT_EQ(parseStorageTypeFromString("s3"), StorageType::S3);
+    EXPECT_EQ(parseStorageTypeFromString("s3a"), StorageType::S3);
+    EXPECT_EQ(parseStorageTypeFromString("azure"), StorageType::Azure);
+    EXPECT_EQ(parseStorageTypeFromString("abfss"), StorageType::Azure);
+    EXPECT_EQ(parseStorageTypeFromString("file"), StorageType::Local);
+    EXPECT_EQ(parseStorageTypeFromString("local"), StorageType::Local);
+}
+
+TEST(StorageTypeParsingTest, TableMetadataAcceptsHDFSLocation)
+{
+    TableMetadata metadata;
+    metadata.withLocation();
+    metadata.setLocation("hdfs://namenode/warehouse/table");
+
+    EXPECT_EQ(metadata.getStorageType(), StorageType::HDFS);
+    EXPECT_EQ(metadata.getLocation(), "hdfs://namenode/warehouse/table");
+}
+
+}


### PR DESCRIPTION
### Description

Data lake catalogs report HDFS table locations using the `hdfs` URI scheme. Storage type parsing previously capitalized only the first character, producing `Hdfs`, which did not match the `HDFS` enum value.

Recognize the lowercase `hdfs` scheme explicitly as `StorageType::HDFS`, while preserving the existing parsing behavior for other storage types.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`DataLakeCatalog` databases can now read tables stored on HDFS when the catalog returns an `hdfs://` location.