### PR TITLE
Pin max_insert_threads in 02354_distributed_with_external_aggregation_memory_usage

### DIFF
--- a/tests/queries/0_stateless/02354_distributed_with_external_aggregation_memory_usage.sql
+++ b/tests/queries/0_stateless/02354_distributed_with_external_aggregation_memory_usage.sql
@@ -6,7 +6,10 @@ DROP TABLE IF EXISTS t_2354_dist_with_external_aggr;
 
 create table t_2354_dist_with_external_aggr(a UInt64, b String, c FixedString(100)) engine = MergeTree order by tuple() SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
 
-insert into t_2354_dist_with_external_aggr select number, toString(number) as s, toFixedString(s, 100) from numbers_mt(5e7);
+-- the 5G budget below was measured with single-threaded insert, and `max_insert_threads` defaults to
+-- the number of CPU cores since 26.8, which multiplies the write-side peak past the profile limit
+insert into t_2354_dist_with_external_aggr select number, toString(number) as s, toFixedString(s, 100) from numbers_mt(5e7)
+settings max_insert_threads = 1;
 
 set max_bytes_before_external_group_by = '2G',
     max_bytes_ratio_before_external_group_by = 0,


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/109006
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`02354_distributed_with_external_aggregation_memory_usage` started failing on the INSERT, before it
reaches the external aggregation it exists to measure:

```
Code: 241. Query memory limit exceeded: would use 4.66 GiB
(attempt to allocate chunk of 105.54 MiB), maximum: 4.66 GiB.
(query: insert into t_2354_dist_with_external_aggr
        select number, toString(number) as s, toFixedString(s, 100) from numbers_mt(5e7);)
```

Master failure:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=86d92d6b4119f54ab6f5fad650502dd3531ef4d8&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

Root cause: #109006 changed the `max_insert_threads` default from `1` to auto (the number of CPU
cores). This INSERT had no `SETTINGS` clause, so it inherits the profile default, and the write
side's per-thread buffers now scale with the core count. The 5G budget in this test was measured
with single-threaded insert ("5G is just the actual value taken from the logs + delta"), so the
peak crosses the 4.66 GiB profile limit from `tests/config/users.d/limits.yaml`.

The fix pins `max_insert_threads = 1` on that INSERT, restoring the execution shape the budget was
calibrated for. This is the same adaptation #109006 applied in the same commit to the tests it
identified, for example `03217_primary_index_memory_leak.sql`, where `max_insert_threads = 1` sits
directly beside `max_memory_usage = '100M'`. This test needed the identical change and did not get
it. No limit is raised, no data volume is reduced, and every assertion is unchanged.

I deliberately did not make `getMaxThreadsForAvailableMemory` query-limit aware. It already runs
here and reduced the request from 192 to 134 threads, but its budget is server free memory rather
than the query's `max_memory_usage`, so it cannot help. Teaching it `getCurrentQueryHardLimit()`
would change read-side parallelism for every query that sets a memory limit, across its 19 call
sites, which is a separate discussion for #109006 rather than a test fix.

<details>
<summary>Validation</summary>

Reproduced with the CI-built binary at the base commit, on a server carrying
`tests/config/users.d/limits.yaml` (`max_memory_usage = 5000000000` asserted live,
`max_insert_threads` rendering `auto(192)`).

| arm | result | duration |
|---|---|---|
| before the fix | FAIL, `Code: 241` at 4.66 GiB | 0.35 - 0.47 s |
| with the fix | OK | 10.52 s |
| pin removed again (mutation) | FAIL, `Code: 241` | 0.34 s |

The duration split matches CI, where the 12 observed failures took 500-1860 ms and passing runs
take 10-26 s: the INSERT dies almost immediately instead of running to completion.

Peak memory for the same INSERT, from `system.query_log`:

| `max_insert_threads` | peak | share of the 5G budget |
|---|---|---|
| `1` (this fix) | 2.28 GiB | 48.9 % |
| default (auto, reduced to 134) | 4.65 GiB | 100 % |

So the pin leaves about 2.5 GiB of headroom rather than sitting just under the cap.

50 runs with randomization enabled: 50 OK, 0 FAIL. `--long-test-runs-ratio 1.0` is needed for the
count to be real, since the `long` tag otherwise scales `--test-runs` by 0.1.

Scope: of the 62 stateless tests that combine `INSERT ... SELECT` with `max_memory_usage`, 12
already pinned `max_insert_threads` before this change. Querying the `Query memory limit exceeded`
signature across the #109006 merge boundary, this test is the only one that regressed, going from 0 failures to 12
across 12 distinct pull requests plus one master run, against 0 failures in the 90 days before
that merge (24181 passing runs). Every other candidate has no failures after the merge.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.425` (included in `26.8` and later)
<!-- ch-version-info:end -->