### PR TITLE
Fix Iceberg write publishing positional names for nested tuple fields

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -587,8 +587,8 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
                 Poco::JSON::Object::Ptr field = new Poco::JSON::Object;
                 field->set(Iceberg::f_id, ++iter_fields);
                 field->set(Iceberg::f_name, type_tuple->getNameByPosition(iter_names));
-                /// Recurse on the element itself: getNormalizedType() would rename a nested
-                /// tuple's elements to "1", "2", ... (DataTypeTuple::getNormalizedType).
+                /// Recurse on the element itself: `getNormalizedType` would rename a nested
+                /// tuple's elements to "1", "2", ... (`DataTypeTuple::getNormalizedType`).
                 auto child_type = getIcebergType(element, iter);
                 field->set(Iceberg::f_required, child_type.second);
                 field->set(Iceberg::f_type, child_type.first);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -587,7 +587,9 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
                 Poco::JSON::Object::Ptr field = new Poco::JSON::Object;
                 field->set(Iceberg::f_id, ++iter_fields);
                 field->set(Iceberg::f_name, type_tuple->getNameByPosition(iter_names));
-                auto child_type = getIcebergType(element->getNormalizedType(), iter);
+                /// Recurse on the element itself: getNormalizedType() would rename a nested
+                /// tuple's elements to "1", "2", ... (DataTypeTuple::getNormalizedType).
+                auto child_type = getIcebergType(element, iter);
                 field->set(Iceberg::f_required, child_type.second);
                 field->set(Iceberg::f_type, child_type.first);
                 fields->add(field);

--- a/tests/queries/0_stateless/04561_iceberg_nested_tuple_field_names.reference
+++ b/tests/queries/0_stateless/04561_iceberg_nested_tuple_field_names.reference
@@ -1,0 +1,12 @@
+parquet	((7))
+avro	((7))
+depth3	(((7)))
+multi	((7,8),9)
+array	([(7)])
+map	({\'k\':(7)})
+unnamed	((7))
+avro innermost name: inner
+unnamed innermost name: 1
+added	1	((0))
+added	2	((7))
+added innermost name: i

--- a/tests/queries/0_stateless/04561_iceberg_nested_tuple_field_names.sh
+++ b/tests/queries/0_stateless/04561_iceberg_nested_tuple_field_names.sh
@@ -2,7 +2,7 @@
 # Tags: no-fasttest
 # - no-fasttest: requires IcebergLocal (USE_AVRO build option)
 
-# getIcebergType recursed into tuple elements through getNormalizedType(), which
+# `getIcebergType` recursed into tuple elements through `getNormalizedType`, which
 # renames a named tuple's elements to "1", "2", ... So a tuple nested inside a
 # tuple was published in the Iceberg schema with its inner field names replaced
 # by positions. With the default Parquet format the INSERT then failed with
@@ -19,6 +19,10 @@ BASE_DIR="${USER_FILES_PATH}/t_${CLICKHOUSE_DATABASE}_${RANDOM}"
 rm -rf "${BASE_DIR}"
 mkdir -p "${BASE_DIR}"
 trap 'rm -rf "${BASE_DIR}"' EXIT
+
+# Object names are database-scoped too: the stress job runs part of its threads
+# against one shared database, where a repeat would otherwise hit TABLE_ALREADY_EXISTS.
+PFX="t_${CLICKHOUSE_DATABASE}"
 
 CH="${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --enable_nullable_tuple_type=1"
 
@@ -45,18 +49,21 @@ print(deepest(json.load(open(sys.argv[1]))['schemas'][-1]['fields'])[1])
 
 # Write each shape through a materialized view (the write path that publishes the
 # Iceberg schema) and read the value back, so the round trip is asserted end to end.
+# The DROPs pin ignore_drop_queries_probability: the stress job injects 0.2 for it,
+# and an ignored DROP would leave the table behind and fail the next CREATE.
 roundtrip() {
     local tag="$1" type="$2" insert="$3" format="$4"
     local engine="IcebergLocal('${BASE_DIR}/${tag}/'"
     [ -n "${format}" ] && engine="${engine}, '${format}'"
-    ${CH} --multiquery -q "
-DROP TABLE IF EXISTS src_${tag};
-DROP TABLE IF EXISTS dst_${tag};
-CREATE TABLE src_${tag} (c0 ${type}) ENGINE = MergeTree ORDER BY tuple();
-CREATE TABLE dst_${tag} (c0 ${type}) ENGINE = ${engine});
-CREATE MATERIALIZED VIEW mv_${tag} TO dst_${tag} AS SELECT c0 FROM src_${tag};
-INSERT INTO src_${tag} ${insert};
-SELECT '${tag}', toString(c0) FROM dst_${tag};
+    ${CH} -q "
+DROP TABLE IF EXISTS mv_${PFX}_${tag} SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS src_${PFX}_${tag} SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS dst_${PFX}_${tag} SETTINGS ignore_drop_queries_probability = 0;
+CREATE TABLE src_${PFX}_${tag} (c0 ${type}) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE dst_${PFX}_${tag} (c0 ${type}) ENGINE = ${engine});
+CREATE MATERIALIZED VIEW mv_${PFX}_${tag} TO dst_${PFX}_${tag} AS SELECT c0 FROM src_${PFX}_${tag};
+INSERT INTO src_${PFX}_${tag} ${insert};
+SELECT '${tag}', toString(c0) FROM dst_${PFX}_${tag};
 "
 }
 
@@ -84,11 +91,12 @@ echo "unnamed innermost name: $(innermost_name unnamed)"
 # ALTER ... ADD COLUMN publishes a schema through generateAddColumnMetadata, a
 # second call site that a CREATE-only test would miss. Iceberg refuses adding a
 # non-nullable column, hence Nullable.
-${CH} --multiquery -q "
-CREATE TABLE added (id Int64) ENGINE = IcebergLocal('${BASE_DIR}/added/', 'Avro');
-INSERT INTO added VALUES (1);
-ALTER TABLE added ADD COLUMN c1 Nullable(Tuple(o Tuple(i UInt32)));
-INSERT INTO added VALUES (2, ((7)));
-SELECT 'added', id, toString(c1) FROM added ORDER BY id;
+${CH} -q "
+DROP TABLE IF EXISTS added_${PFX} SETTINGS ignore_drop_queries_probability = 0;
+CREATE TABLE added_${PFX} (id Int64) ENGINE = IcebergLocal('${BASE_DIR}/added/', 'Avro');
+INSERT INTO added_${PFX} VALUES (1);
+ALTER TABLE added_${PFX} ADD COLUMN c1 Nullable(Tuple(o Tuple(i UInt32)));
+INSERT INTO added_${PFX} VALUES (2, ((7)));
+SELECT 'added', id, toString(c1) FROM added_${PFX} ORDER BY id;
 "
 echo "added innermost name: $(innermost_name added)"

--- a/tests/queries/0_stateless/04561_iceberg_nested_tuple_field_names.sh
+++ b/tests/queries/0_stateless/04561_iceberg_nested_tuple_field_names.sh
@@ -18,13 +18,32 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 BASE_DIR="${USER_FILES_PATH}/t_${CLICKHOUSE_DATABASE}_${RANDOM}"
 rm -rf "${BASE_DIR}"
 mkdir -p "${BASE_DIR}"
-trap 'rm -rf "${BASE_DIR}"' EXIT
 
 # Object names are database-scoped too: the stress job runs part of its threads
 # against one shared database, where a repeat would otherwise hit TABLE_ALREADY_EXISTS.
 PFX="t_${CLICKHOUSE_DATABASE}"
 
 CH="${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --enable_nullable_tuple_type=1"
+
+# The tags of the shapes exercised below, in one place so `cleanup` follows them.
+TAGS="parquet avro depth3 multi array map unnamed"
+
+# Drop the objects before removing their directories (a surviving table is re-attached
+# with its data gone), pinning `ignore_drop_queries_probability` as `roundtrip` does.
+cleanup() {
+    local query="" tag
+    for tag in ${TAGS}; do
+        query="${query} DROP TABLE IF EXISTS mv_${PFX}_${tag} SETTINGS ignore_drop_queries_probability = 0;"
+    done
+    for tag in ${TAGS}; do
+        query="${query} DROP TABLE IF EXISTS src_${PFX}_${tag} SETTINGS ignore_drop_queries_probability = 0;"
+        query="${query} DROP TABLE IF EXISTS dst_${PFX}_${tag} SETTINGS ignore_drop_queries_probability = 0;"
+    done
+    query="${query} DROP TABLE IF EXISTS added_${PFX} SETTINGS ignore_drop_queries_probability = 0;"
+    ${CH} -q "${query}" > /dev/null 2>&1 || true
+    rm -rf "${BASE_DIR}"
+}
+trap cleanup EXIT
 
 # Innermost field name of the deepest struct in the latest metadata version.
 innermost_name() {

--- a/tests/queries/0_stateless/04561_iceberg_nested_tuple_field_names.sh
+++ b/tests/queries/0_stateless/04561_iceberg_nested_tuple_field_names.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# - no-fasttest: requires IcebergLocal (USE_AVRO build option)
+
+# getIcebergType recursed into tuple elements through getNormalizedType(), which
+# renames a named tuple's elements to "1", "2", ... So a tuple nested inside a
+# tuple was published in the Iceberg schema with its inner field names replaced
+# by positions. With the default Parquet format the INSERT then failed with
+# `Code: 117 ... Column 'c0.outer.inner' has no field id in the Iceberg schema
+# being written`; with 'Avro' the INSERT succeeded and the read failed with
+# `Code: 10 ... Tuple doesn't have element with name 'inner'`.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Unique on-disk path so the test is parallel-safe.
+BASE_DIR="${USER_FILES_PATH}/t_${CLICKHOUSE_DATABASE}_${RANDOM}"
+rm -rf "${BASE_DIR}"
+mkdir -p "${BASE_DIR}"
+trap 'rm -rf "${BASE_DIR}"' EXIT
+
+CH="${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --enable_nullable_tuple_type=1"
+
+# Innermost field name of the deepest struct in the latest metadata version.
+innermost_name() {
+    local latest
+    latest=$(find "${BASE_DIR}/$1/metadata" -name 'v*.metadata.json' | sort -V | tail -1)
+    python3 -c "
+import json,sys
+def deepest(fields, depth=0):
+    best = (depth, None)
+    for f in fields:
+        t = f.get('type')
+        if isinstance(t, dict) and t.get('type') == 'struct':
+            cand = deepest(t['fields'], depth + 1)
+        else:
+            cand = (depth, f['name'])
+        if cand[0] >= best[0]:
+            best = cand
+    return best
+print(deepest(json.load(open(sys.argv[1]))['schemas'][-1]['fields'])[1])
+" "${latest}"
+}
+
+# Write each shape through a materialized view (the write path that publishes the
+# Iceberg schema) and read the value back, so the round trip is asserted end to end.
+roundtrip() {
+    local tag="$1" type="$2" insert="$3" format="$4"
+    local engine="IcebergLocal('${BASE_DIR}/${tag}/'"
+    [ -n "${format}" ] && engine="${engine}, '${format}'"
+    ${CH} --multiquery -q "
+DROP TABLE IF EXISTS src_${tag};
+DROP TABLE IF EXISTS dst_${tag};
+CREATE TABLE src_${tag} (c0 ${type}) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE dst_${tag} (c0 ${type}) ENGINE = ${engine});
+CREATE MATERIALIZED VIEW mv_${tag} TO dst_${tag} AS SELECT c0 FROM src_${tag};
+INSERT INTO src_${tag} ${insert};
+SELECT '${tag}', toString(c0) FROM dst_${tag};
+"
+}
+
+# 1-2. The reported shape, on both formats: Parquet fails at INSERT (Code 117),
+#      Avro at read (Code 10).
+roundtrip parquet  'Tuple(outer Tuple(inner UInt32))' 'VALUES (((7)))' ''
+roundtrip avro     'Tuple(outer Tuple(inner UInt32))' 'VALUES (((7)))' 'Avro'
+# 3. Depth 3: every level below the top one was renamed, not just the second.
+roundtrip depth3   'Tuple(l1 Tuple(l2 Tuple(l3 UInt32)))' 'VALUES ((((7))))' 'Avro'
+# 4. Several elements, so positional and real names disagree beyond the first.
+roundtrip multi    'Tuple(o Tuple(i UInt32, j UInt32), p UInt32)' 'VALUES (((7,8),9))' 'Avro'
+# 5-6. Array and Map recurse through the same tuple branch.
+roundtrip array    'Tuple(x Array(Tuple(a UInt32)))' 'VALUES (([(7)]))' 'Avro'
+roundtrip map      'Tuple(m Map(String, Tuple(a UInt32)))' \
+    "SELECT tuple(map('k', tuple(7::UInt32)))::Tuple(m Map(String, Tuple(a UInt32)))" 'Avro'
+# 7. Negative control: an unnamed inner tuple is already positional, so the
+#    published names must stay "1", "2", ... and the round trip must keep working.
+roundtrip unnamed  'Tuple(o Tuple(UInt32))' 'VALUES (((7)))' 'Avro'
+
+# The invariant itself, not just its symptom: the innermost published field name
+# must be the ClickHouse element name. Master wrote "1" here.
+echo "avro innermost name: $(innermost_name avro)"
+echo "unnamed innermost name: $(innermost_name unnamed)"
+
+# ALTER ... ADD COLUMN publishes a schema through generateAddColumnMetadata, a
+# second call site that a CREATE-only test would miss. Iceberg refuses adding a
+# non-nullable column, hence Nullable.
+${CH} --multiquery -q "
+CREATE TABLE added (id Int64) ENGINE = IcebergLocal('${BASE_DIR}/added/', 'Avro');
+INSERT INTO added VALUES (1);
+ALTER TABLE added ADD COLUMN c1 Nullable(Tuple(o Tuple(i UInt32)));
+INSERT INTO added VALUES (2, ((7)));
+SELECT 'added', id, toString(c1) FROM added ORDER BY id;
+"
+echo "added innermost name: $(innermost_name added)"

--- a/tests/queries/0_stateless/04561_iceberg_nested_tuple_field_names.sh
+++ b/tests/queries/0_stateless/04561_iceberg_nested_tuple_field_names.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Tags: no-fasttest
-# - no-fasttest: requires IcebergLocal (USE_AVRO build option)
+# - no-fasttest: requires `IcebergLocal` (USE_AVRO build option)
 
 # `getIcebergType` recursed into tuple elements through `getNormalizedType`, which
 # renames a named tuple's elements to "1", "2", ... So a tuple nested inside a
@@ -88,7 +88,7 @@ roundtrip unnamed  'Tuple(o Tuple(UInt32))' 'VALUES (((7)))' 'Avro'
 echo "avro innermost name: $(innermost_name avro)"
 echo "unnamed innermost name: $(innermost_name unnamed)"
 
-# ALTER ... ADD COLUMN publishes a schema through generateAddColumnMetadata, a
+# ALTER ... ADD COLUMN publishes a schema through `generateAddColumnMetadata`, a
 # second call site that a CREATE-only test would miss. Iceberg refuses adding a
 # non-nullable column, hence Nullable.
 ${CH} -q "


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/109838
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/109838

Found in that pull request as pre-existing and [deferred out](https://github.com/ClickHouse/ClickHouse/pull/109838#discussion_r3662399031). No related open issue found.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes writing Iceberg tables whose schema contains a tuple nested inside a tuple. The published table metadata replaced the inner tuple's field names with positional names `1`, `2`, ..., so with the default `Parquet` format the `INSERT` failed with `INCORRECT_DATA` and with `Avro` the column could not be read back.


### Description

Writing an Iceberg table whose schema nests a tuple inside a tuple (directly or through `Array`/`Map`, at any depth) published metadata replacing the inner tuple's field names with `1`, `2`, ... The column was then unusable:

| write format | symptom |
|---|---|
| `Parquet` (default) | `INSERT` fails, `Code: 117 INCORRECT_DATA: Column 'c0.outer.inner' has no field id in the Iceberg schema being written` (its advice to retry can never succeed) |
| `'Avro'` | read fails, `Code: 10 NOT_FOUND_COLUMN_IN_BLOCK: Tuple doesn't have element with name 'inner'` |

`CREATE TABLE` accepted the schema, so this surfaced only on the first `INSERT` or `SELECT`. The Avro data file carried the correct name while the metadata carried `"1"`, violating the Iceberg spec and so affecting external readers too.

`getIcebergType` wrote each tuple element's real name, then recursed through `element->getNormalizedType()`. `DataTypeTuple::getNormalizedType` rebuilds a tuple through the names-less constructor, so the next level down saw positional names and published those. That normalization exists for aggregate-function state types and is not needed here: none of its four implementations strips `Nullable` or `LowCardinality`. The fix recurses on the element. Since the function is recursive and its `Array`/`Map`/`Nullable` branches never normalized, the single hunk covers every depth, every composite path, and both publishing call sites (`CREATE TABLE`, `ADD COLUMN`; `MODIFY COLUMN` rejects complex types earlier).

Validated on a 14-shape matrix, failing before and passing after, including two must-stay-unchanged controls: an unnamed inner tuple keeps its positional names, and `Tuple(o Nullable(Tuple(i UInt32)))` already worked, the interposed `Nullable` bypassing the normalization.

Metadata already published with `"name": "1"` is **not** migrated, since rewriting historical versions would break Iceberg's immutable-metadata contract. Such `Avro` tables stay unreadable; `Parquet` tables have no data files, so they can be recreated.