### PR TITLE
Fix referring to a parameterized view by its own name

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -1629,6 +1629,18 @@ void QueryAnalyzer::qualifyColumnNodesWithProjectionNames(const QueryTreeNodes &
         if (!table_node->getTemporaryTableName().empty())
             additional_column_qualification_parts = {table_node->getTemporaryTableName()};
     }
+    else if (auto * table_function_node = table_expression_node->as<TableFunctionNode>())
+    {
+        /// A parameterized view is resolved as a `TableFunctionNode` but has a name of its own,
+        /// so its columns are qualified with it exactly like a `TableNode`'s. A regular table
+        /// function has no name and contributes no qualification parts.
+        const auto & storage = table_function_node->getStorage();
+        if (const auto * storage_view = storage ? storage->as<StorageView>() : nullptr; storage_view && storage_view->isParameterizedView())
+        {
+            const auto & table_storage_id = table_function_node->getStorageID();
+            additional_column_qualification_parts = {table_storage_id.getDatabaseName(), table_storage_id.getTableName()};
+        }
+    }
     else if (auto * query_node = table_expression_node->as<QueryNode>(); query_node && query_node->isCTE())
         additional_column_qualification_parts = {query_node->getCTEName()};
     else if (auto * union_node = table_expression_node->as<UnionNode>(); union_node && union_node->isCTE())

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -880,6 +880,16 @@ void QueryAnalyzer::validateJoinTableExpressionWithoutAlias(const QueryTreeNodeP
     if ((query_node && !query_node->getCTEName().empty()) || (union_node && !union_node->getCTEName().empty()))
         return;
 
+    /// The restriction exists because a subquery or a table function has no name to qualify its columns with.
+    /// A parameterized view does have one, even though it is resolved as a `TableFunctionNode`, so it is exempt
+    /// exactly like the plain table below.
+    if (const auto * table_function_node = table_expression_node->as<TableFunctionNode>())
+    {
+        const auto & storage = table_function_node->getStorage();
+        if (const auto * storage_view = storage ? storage->as<StorageView>() : nullptr; storage_view && storage_view->isParameterizedView())
+            return;
+    }
+
     auto table_expression_node_type = table_expression_node->getNodeType();
 
     if (table_expression_node_type == QueryTreeNodeType::TABLE_FUNCTION ||
@@ -4312,6 +4322,18 @@ void QueryAnalyzer::initializeTableExpressionData(const QueryTreeNodePtr & table
     else if (table_function_node)
     {
         table_expression_data.table_expression_description = "table_function";
+
+        /// A parameterized view is resolved as a `TableFunctionNode` wrapping a real `StorageView`, but unlike a
+        /// regular table function it has a name of its own, so expose the same table identity a `TableNode` does.
+        /// Without it nothing binds `view_name.column` and the alias check below has no name to qualify with.
+        const auto & storage = table_function_node->getStorage();
+        if (const auto * storage_view = storage ? storage->as<StorageView>() : nullptr; storage_view && storage_view->isParameterizedView())
+        {
+            const auto & table_storage_id = table_function_node->getStorageID();
+            table_expression_data.database_name = table_storage_id.database_name;
+            table_expression_data.table_name = table_storage_id.table_name;
+            table_expression_data.table_expression_name = table_storage_id.getFullNameNotQuoted();
+        }
     }
 
     if (table_expression_node->hasAlias())

--- a/tests/queries/0_stateless/04653_parameterized_view_own_name.reference
+++ b/tests/queries/0_stateless/04653_parameterized_view_own_name.reference
@@ -10,6 +10,18 @@ t1
 1
 1
 1
+-- matcher-expanded columns are qualified with the view name
+tenant_id	String					
+host_id	UInt64					
+pv.tenant_id	String					
+pv.host_id	UInt64					
+tenant_id	String					
+host_id	UInt64					
+pv.host_id	UInt64					
+-- control: a real table function contributes no qualifier
+tenant_id	String					
+host_id	UInt64					
+number	UInt64					
 -- the parameter type is irrelevant
 1
 -- controls: an alias or no qualifier always worked

--- a/tests/queries/0_stateless/04653_parameterized_view_own_name.reference
+++ b/tests/queries/0_stateless/04653_parameterized_view_own_name.reference
@@ -28,6 +28,7 @@ number	UInt64
 1
 1
 -- controls: a real table function must not gain a bindable name
--- a database-qualified call binds by the view name too
+-- a view in another database binds by the view name too
 1
 1
+-- control: qualifying with a database that does not hold the view does not bind

--- a/tests/queries/0_stateless/04653_parameterized_view_own_name.reference
+++ b/tests/queries/0_stateless/04653_parameterized_view_own_name.reference
@@ -1,0 +1,21 @@
+-- a parameterized view may be joined without an alias
+1
+1
+1
+1
+-- its columns may be qualified with the view name
+1
+1
+t1
+1
+1
+1
+-- the parameter type is irrelevant
+1
+-- controls: an alias or no qualifier always worked
+1
+1
+-- controls: a real table function must not gain a bindable name
+-- a database-qualified call binds by the view name too
+1
+1

--- a/tests/queries/0_stateless/04653_parameterized_view_own_name.reference
+++ b/tests/queries/0_stateless/04653_parameterized_view_own_name.reference
@@ -27,7 +27,10 @@ number	UInt64
 -- controls: an alias or no qualifier always worked
 1
 1
--- controls: a real table function must not gain a bindable name
+-- controls: a regular table function and an ordinary view must not gain a bindable name
+tenant_id	String					
+host_id	UInt64					
+tenant_id	String					
 -- a view in another database binds by the view name too
 1
 1

--- a/tests/queries/0_stateless/04653_parameterized_view_own_name.sql
+++ b/tests/queries/0_stateless/04653_parameterized_view_own_name.sql
@@ -45,9 +45,14 @@ SELECT '-- controls: an alias or no qualifier always worked';
 SELECT p.host_id FROM pv(tenants = ['t1']) AS p;
 SELECT host_id FROM pv(tenants = ['t1']);
 
-SELECT '-- controls: a real table function must not gain a bindable name';
+SELECT '-- controls: a regular table function and an ordinary view must not gain a bindable name';
 SELECT numbers.number FROM numbers(3); -- { serverError UNKNOWN_IDENTIFIER }
 SELECT count() FROM local_data JOIN numbers(3) ON 1 = 1; -- { serverError ALIAS_REQUIRED }
+SELECT view.dummy FROM view(SELECT 1 AS dummy); -- { serverError UNKNOWN_IDENTIFIER }
+SELECT count() FROM local_data JOIN view(SELECT 1 AS dummy) ON 1 = 1; -- { serverError ALIAS_REQUIRED }
+-- `tenant_id` collides with `local_data`'s, so the matcher must decide whether to qualify it;
+-- an ordinary view contributes no qualification parts, so the second one stays bare.
+DESCRIBE (SELECT * FROM local_data, view(SELECT 't1' AS tenant_id)) SETTINGS joined_subquery_requires_alias = 0;
 
 DROP VIEW pv2;
 DROP VIEW pv;
@@ -56,6 +61,7 @@ DROP TABLE local_data;
 -- The view also binds by its own name when it lives outside the session's current database.
 -- The call itself stays unqualified: a query parameter is not accepted in the database
 -- position of a table function, and a literal database name would not be parallel-safe.
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
 CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
 USE {CLICKHOUSE_DATABASE_1:Identifier};
 CREATE TABLE local_data (tenant_id String, host_id UInt64) ENGINE = MergeTree ORDER BY tenant_id;

--- a/tests/queries/0_stateless/04653_parameterized_view_own_name.sql
+++ b/tests/queries/0_stateless/04653_parameterized_view_own_name.sql
@@ -1,0 +1,55 @@
+-- Tags: need-query-parameters
+
+DROP TABLE IF EXISTS local_data;
+DROP VIEW IF EXISTS pv;
+DROP VIEW IF EXISTS pv2;
+
+CREATE TABLE local_data (tenant_id String, host_id UInt64) ENGINE = MergeTree ORDER BY tenant_id;
+INSERT INTO local_data SELECT 't1', 1;
+
+CREATE VIEW pv AS SELECT tenant_id, host_id FROM local_data WHERE tenant_id IN ({tenants:Array(String)});
+CREATE VIEW pv2 AS SELECT tenant_id, host_id FROM local_data WHERE tenant_id = {tenant:String};
+
+SELECT '-- a parameterized view may be joined without an alias';
+SELECT count() FROM local_data JOIN pv(tenants = ['t1']) USING (tenant_id);
+SELECT count() FROM local_data AS t JOIN pv(tenants = ['t1']) ON t.tenant_id = pv.tenant_id;
+SELECT count() FROM local_data, pv(tenants = ['t1']);
+SELECT count() FROM pv(tenants = ['t1']) JOIN local_data AS t USING (tenant_id);
+
+SELECT '-- its columns may be qualified with the view name';
+SELECT pv.host_id FROM pv(tenants = ['t1']);
+SELECT host_id FROM pv(tenants = ['t1']) WHERE pv.host_id = 1;
+SELECT pv.tenant_id FROM pv(tenants = ['t1']) GROUP BY pv.tenant_id;
+SELECT pv.host_id FROM pv(tenants = ['t1']) ORDER BY pv.host_id;
+SELECT {CLICKHOUSE_DATABASE:Identifier}.pv.host_id FROM pv(tenants = ['t1']);
+SELECT count() FROM local_data AS t JOIN pv(tenants = ['t1']) ON t.tenant_id = pv.tenant_id SETTINGS joined_subquery_requires_alias = 0;
+
+SELECT '-- the parameter type is irrelevant';
+SELECT pv2.host_id FROM pv2(tenant = 't1');
+
+SELECT '-- controls: an alias or no qualifier always worked';
+SELECT p.host_id FROM pv(tenants = ['t1']) AS p;
+SELECT host_id FROM pv(tenants = ['t1']);
+
+SELECT '-- controls: a real table function must not gain a bindable name';
+SELECT numbers.number FROM numbers(3); -- { serverError UNKNOWN_IDENTIFIER }
+SELECT count() FROM local_data JOIN numbers(3) ON 1 = 1; -- { serverError ALIAS_REQUIRED }
+
+DROP VIEW pv2;
+DROP VIEW pv;
+DROP TABLE local_data;
+
+-- A call qualified with an explicit database name binds by the view name too.
+-- The database must be spelled literally: a query parameter is not accepted in the
+-- database position of any table function (a pre-existing parser limitation).
+DROP DATABASE IF EXISTS test_04653;
+CREATE DATABASE test_04653;
+CREATE TABLE test_04653.local_data (tenant_id String, host_id UInt64) ENGINE = MergeTree ORDER BY tenant_id;
+INSERT INTO test_04653.local_data SELECT 't1', 1;
+CREATE VIEW test_04653.pv AS SELECT tenant_id, host_id FROM test_04653.local_data WHERE tenant_id IN ({tenants:Array(String)});
+
+SELECT '-- a database-qualified call binds by the view name too';
+SELECT pv.host_id FROM test_04653.pv(tenants = ['t1']);
+SELECT test_04653.pv.host_id FROM test_04653.pv(tenants = ['t1']);
+
+DROP DATABASE test_04653;

--- a/tests/queries/0_stateless/04653_parameterized_view_own_name.sql
+++ b/tests/queries/0_stateless/04653_parameterized_view_own_name.sql
@@ -1,5 +1,12 @@
 -- Tags: need-query-parameters
 
+-- The fix is in the query-tree analyzer, so pin it: the `old analyzer` CI jobs link
+-- `users.d/analyzer.xml` and the randomized `compatibility='<24.3'` setting also reverts
+-- `allow_experimental_analyzer`, and on the legacy path a JOINed parameterized view is not
+-- expanded at all (only the left table storage is), so these rows would assert a different
+-- code path's behaviour.
+SET enable_analyzer = 1;
+
 DROP TABLE IF EXISTS local_data;
 DROP VIEW IF EXISTS pv;
 DROP VIEW IF EXISTS pv2;
@@ -23,6 +30,13 @@ SELECT pv.tenant_id FROM pv(tenants = ['t1']) GROUP BY pv.tenant_id;
 SELECT pv.host_id FROM pv(tenants = ['t1']) ORDER BY pv.host_id;
 SELECT {CLICKHOUSE_DATABASE:Identifier}.pv.host_id FROM pv(tenants = ['t1']);
 SELECT count() FROM local_data AS t JOIN pv(tenants = ['t1']) ON t.tenant_id = pv.tenant_id SETTINGS joined_subquery_requires_alias = 0;
+
+SELECT '-- matcher-expanded columns are qualified with the view name';
+DESCRIBE (SELECT * FROM local_data, pv(tenants = ['t1']));
+DESCRIBE (SELECT * FROM local_data JOIN pv(tenants = ['t1']) USING (tenant_id));
+
+SELECT '-- control: a real table function contributes no qualifier';
+DESCRIBE (SELECT * FROM local_data AS t JOIN numbers(3) AS n ON 1 = 1);
 
 SELECT '-- the parameter type is irrelevant';
 SELECT pv2.host_id FROM pv2(tenant = 't1');

--- a/tests/queries/0_stateless/04653_parameterized_view_own_name.sql
+++ b/tests/queries/0_stateless/04653_parameterized_view_own_name.sql
@@ -53,17 +53,20 @@ DROP VIEW pv2;
 DROP VIEW pv;
 DROP TABLE local_data;
 
--- A call qualified with an explicit database name binds by the view name too.
--- The database must be spelled literally: a query parameter is not accepted in the
--- database position of any table function (a pre-existing parser limitation).
-DROP DATABASE IF EXISTS test_04653;
-CREATE DATABASE test_04653;
-CREATE TABLE test_04653.local_data (tenant_id String, host_id UInt64) ENGINE = MergeTree ORDER BY tenant_id;
-INSERT INTO test_04653.local_data SELECT 't1', 1;
-CREATE VIEW test_04653.pv AS SELECT tenant_id, host_id FROM test_04653.local_data WHERE tenant_id IN ({tenants:Array(String)});
+-- The view also binds by its own name when it lives outside the session's current database.
+-- The call itself stays unqualified: a query parameter is not accepted in the database
+-- position of a table function, and a literal database name would not be parallel-safe.
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+USE {CLICKHOUSE_DATABASE_1:Identifier};
+CREATE TABLE local_data (tenant_id String, host_id UInt64) ENGINE = MergeTree ORDER BY tenant_id;
+INSERT INTO local_data SELECT 't1', 1;
+CREATE VIEW pv AS SELECT tenant_id, host_id FROM local_data WHERE tenant_id IN ({tenants:Array(String)});
 
-SELECT '-- a database-qualified call binds by the view name too';
-SELECT pv.host_id FROM test_04653.pv(tenants = ['t1']);
-SELECT test_04653.pv.host_id FROM test_04653.pv(tenants = ['t1']);
+SELECT '-- a view in another database binds by the view name too';
+SELECT pv.host_id FROM pv(tenants = ['t1']);
+SELECT {CLICKHOUSE_DATABASE_1:Identifier}.pv.host_id FROM pv(tenants = ['t1']);
 
-DROP DATABASE test_04653;
+SELECT '-- control: qualifying with a database that does not hold the view does not bind';
+SELECT {CLICKHOUSE_DATABASE:Identifier}.pv.host_id FROM pv(tenants = ['t1']); -- { serverError UNKNOWN_IDENTIFIER }
+
+DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier};


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/68978
Related: https://github.com/ClickHouse/ClickHouse/issues/112148

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...

### Description

Referring to a parameterized view by its own name stopped working on master:

```sql
SELECT pv.host_id FROM pv(tenants = ['t1']);
-- Code: 47. Unknown expression or function identifier `pv.host_id`

SELECT count() FROM local_data JOIN pv(tenants = ['t1']) USING (tenant_id);
-- Code: 206. no alias for subquery or table function pv(tenants = ['t1'])
```

Both are correct in 26.6.2.122 and 26.7.2.33: unreleased 26.8 only, no backport.
Categorized `Not for changelog` because the broken behaviour never shipped in a stable release;
the per-arch Bugfix Validation gate is satisfiable either way.

**Root cause.** #68978 stopped replacing a parameterized-view call with an argument-less
`TableNode` and keeps it as a resolved `TableFunctionNode`. That flip is not behaviour-preserving:
three places in the analyzer key on the node type rather than on whether the table expression has
a name (right for `numbers(3)`, wrong for a view). `initializeTableExpressionData` leaves
`database_name`/`table_name` empty, and identifier binding reads exactly those fields, hence
`UNKNOWN_IDENTIFIER`; `validateJoinTableExpressionWithoutAlias` throws for `TABLE_FUNCTION` but
returns for `TABLE`, hence `ALIAS_REQUIRED`.

**The change.** Three hunks in `QueryAnalyzer.cpp`, each restoring what a `TableNode` already
does: populate the table identity from `getStorageID()`, exempt the node from the
un-aliased-join check, and contribute the view name as a matcher qualification part. The
discriminator is the one #68978 itself added in `PlannerJoinTree.cpp`, so a regular table
function cannot match.

**Validation.** New test `04653_parameterized_view_own_name` covers 15 previously working
spellings, each verified to fail on a #68978 build and pass here, plus must-not-change
controls over a regular table function and an ordinary `view()`, pinning that neither gains a
bindable name, an alias exemption, nor a qualifier. Deleting any one hunk reddens a disjoint row set. 50
randomized plus 50 plain runs green; no reference moved across the parameterized-view and
matcher families.

Tracked separately: `TableFunctionNode::toASTImpl` drops the database qualifier.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.281` (included in `26.10` and later)
<!-- ch-version-info:end -->