### PR TITLE
Fix the LLVM Coverage gate failing a drop equal to its own tolerance

### DIFF
--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -70,6 +70,24 @@ def get_lcov_summary(
     )
 
 
+COVERAGE_DROP_TOLERANCE = 0.3
+
+
+def coverage_drop(baseline_cov: float, current_cov: float) -> float:
+    """Return the line coverage drop in pp, rounded to lcov's reporting precision.
+
+    lcov reports percentages with one decimal, so subtracting two of them can
+    land just above the tolerance: `84.4 - 84.1 == 0.30000000000001137`, which
+    made a drop exactly equal to the tolerance fail the check below.
+    """
+    return round(baseline_cov - current_cov, 2)
+
+
+def coverage_degraded(drop: float) -> bool:
+    """A drop equal to the tolerance is allowed, as the gate's message states."""
+    return drop > COVERAGE_DROP_TOLERANCE
+
+
 def collect_html_report_files(
     folder_path: str, entry_point: str = "index.html"
 ) -> tuple[list[str], list[str]]:
@@ -240,11 +258,11 @@ if __name__ == "__main__":
             print(f"Current coverage  : {c_line_cov:.2f}%")
             print(f"Delta             : {delta:+.2f}%")
 
-            TOLERANCE = 0.3
-            if b_line_cov - c_line_cov > TOLERANCE:
+            _drop = coverage_drop(b_line_cov, c_line_cov)
+            if coverage_degraded(_drop):
                 _failure_msg = (
                     f"Coverage degraded: master {b_line_cov:.2f}% → PR {c_line_cov:.2f}%"
-                    f" (dropped {b_line_cov - c_line_cov:.2f} pp, tolerance {TOLERANCE} pp)"
+                    f" (dropped {_drop:.2f} pp, tolerance {COVERAGE_DROP_TOLERANCE} pp)"
                 )
                 print(_failure_msg)
                 diff_res.info = _failure_msg

--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -74,11 +74,13 @@ COVERAGE_DROP_TOLERANCE = 0.3
 
 
 def coverage_drop(baseline_cov: float, current_cov: float) -> float:
-    """Return the line coverage drop in pp, rounded to lcov's reporting precision.
+    """Return the line coverage drop in pp, rounded to two decimals.
 
-    lcov reports percentages with one decimal, so subtracting two of them can
-    land just above the tolerance: `84.4 - 84.1 == 0.30000000000001137`, which
-    made a drop exactly equal to the tolerance fail the check below.
+    In practice lcov reports these percentages with one decimal, so subtracting
+    two of them can land just above the tolerance:
+    `84.4 - 84.1 == 0.30000000000001137`, which made a drop exactly equal to the
+    tolerance fail the check below. Rounding to two decimals is finer than the
+    reported precision, so a drop lcov can actually express is never masked.
     """
     return round(baseline_cov - current_cov, 2)
 

--- a/ci/tests/test_llvm_coverage_gate.py
+++ b/ci/tests/test_llvm_coverage_gate.py
@@ -1,27 +1,14 @@
 """
 Regression tests for the LLVM Coverage diff gate tolerance check.
 
-Background
-----------
-`llvm_coverage_job.py` fails a PR when line coverage drops by more than
-0.3 pp. `get_lcov_summary` parses lcov's one-decimal percentages, so the
-drop was a binary float subtraction of two decimal values, and for many
-pairs the result lands just above the tolerance:
-
-    84.4 - 84.1 == 0.30000000000001137   ->  > 0.3 is True
-
-A drop exactly equal to the tolerance therefore failed the gate, contrary
-to the message it prints ("dropped 0.30 pp, tolerance 0.3 pp"). Observed on
-21 of 80 `Coverage degraded` rows over 90 days, across 21 distinct PRs.
-
-Fix
----
-`coverage_drop` rounds the difference to two decimals, which is finer than
-lcov's own one-decimal reporting, so no drop lcov can distinguish is masked.
+A drop exactly equal to the 0.3 pp tolerance must pass, as the gate's own
+message states. `coverage_drop` rounds the difference so the binary-float
+representation of a decimal subtraction cannot push it over the threshold.
 """
 
 import os
 import sys
+import textwrap
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
@@ -31,10 +18,64 @@ from ci.jobs.llvm_coverage_job import (
     coverage_drop,
 )
 
+_JOB = os.path.join(os.path.dirname(__file__), "..", "jobs", "llvm_coverage_job.py")
+
 
 def _degraded(baseline: float, current: float) -> bool:
     """The gate's verdict, driving both production helpers rather than a copy."""
     return coverage_degraded(coverage_drop(baseline, current))
+
+
+def _gate_snippet() -> str:
+    """The verdict block from llvm_coverage_job.py, verbatim.
+
+    The gate lives inside `if __name__ == "__main__":`, so it cannot be imported;
+    exec'ing its own source keeps this test honest about what the job really does.
+    """
+    lines = open(_JOB, encoding="utf-8").read().splitlines(True)
+    start = next(i for i, l in enumerate(lines) if "_drop = coverage_drop(" in l)
+    end = next(i for i, l in enumerate(lines) if "diff_res.set_failed()" in l)
+    return textwrap.dedent("".join(lines[start : end + 1]))
+
+
+class _ResultStub:
+    """Captures the three side effects the gate has on its Result."""
+
+    def __init__(self):
+        self.info = None
+        self.comment = None
+        self.failed = False
+
+    def set_comment(self, msg):
+        self.comment = msg
+
+    def set_failed(self):
+        self.failed = True
+
+
+def _run_gate(baseline: float, current: float) -> _ResultStub:
+    """Execute the job's own verdict block and report what it did to the Result."""
+    res = _ResultStub()
+    ns = {
+        "coverage_drop": coverage_drop,
+        "coverage_degraded": coverage_degraded,
+        "COVERAGE_DROP_TOLERANCE": COVERAGE_DROP_TOLERANCE,
+        "b_line_cov": baseline,
+        "c_line_cov": current,
+        "diff_res": res,
+        "print": lambda *a, **k: None,
+    }
+    exec(_gate_snippet(), ns)  # noqa: S102 - trusted first-party source
+    return res
+
+
+def test_gate_snippet_is_the_real_verdict_block():
+    # Without this the extraction could silently degenerate and make every
+    # _run_gate assertion below vacuous.
+    src = _gate_snippet()
+    assert "coverage_drop(" in src
+    assert "coverage_degraded(" in src
+    assert "diff_res.set_failed()" in src
 
 
 def test_tolerance_is_unchanged():
@@ -89,3 +130,25 @@ def test_message_reports_the_value_it_compared():
     # The gate interpolates this same value, so the printed number cannot
     # disagree with the number judged.
     assert f"{drop:.2f}" == "0.31"
+
+
+def test_gate_passes_a_drop_equal_to_tolerance():
+    # Drives the production call site, not just the helpers it wires together.
+    assert _run_gate(84.4, 84.1).failed is False
+    assert _run_gate(85.4, 85.1).failed is False
+
+
+def test_gate_fails_a_drop_above_tolerance_with_the_value_it_judged():
+    res = _run_gate(86.30, 85.99)
+    assert res.failed is True
+    assert res.comment == (
+        "Coverage degraded: master 86.30% \u2192 PR 85.99%"
+        " (dropped 0.31 pp, tolerance 0.3 pp)"
+    )
+    assert res.info == res.comment
+
+
+def test_gate_still_fails_the_large_drop():
+    res = _run_gate(86.20, 28.60)
+    assert res.failed is True
+    assert "dropped 57.60 pp" in res.comment

--- a/ci/tests/test_llvm_coverage_gate.py
+++ b/ci/tests/test_llvm_coverage_gate.py
@@ -1,0 +1,91 @@
+"""
+Regression tests for the LLVM Coverage diff gate tolerance check.
+
+Background
+----------
+`llvm_coverage_job.py` fails a PR when line coverage drops by more than
+0.3 pp. `get_lcov_summary` parses lcov's one-decimal percentages, so the
+drop was a binary float subtraction of two decimal values, and for many
+pairs the result lands just above the tolerance:
+
+    84.4 - 84.1 == 0.30000000000001137   ->  > 0.3 is True
+
+A drop exactly equal to the tolerance therefore failed the gate, contrary
+to the message it prints ("dropped 0.30 pp, tolerance 0.3 pp"). Observed on
+21 of 80 `Coverage degraded` rows over 90 days, across 21 distinct PRs.
+
+Fix
+---
+`coverage_drop` rounds the difference to two decimals, which is finer than
+lcov's own one-decimal reporting, so no drop lcov can distinguish is masked.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.llvm_coverage_job import (
+    COVERAGE_DROP_TOLERANCE,
+    coverage_degraded,
+    coverage_drop,
+)
+
+
+def _degraded(baseline: float, current: float) -> bool:
+    """The gate's verdict, driving both production helpers rather than a copy."""
+    return coverage_degraded(coverage_drop(baseline, current))
+
+
+def test_tolerance_is_unchanged():
+    assert COVERAGE_DROP_TOLERANCE == 0.3
+
+
+def test_drop_equal_to_tolerance_passes():
+    # The only two value pairs behind all 21 observed failures.
+    assert not _degraded(84.4, 84.1)
+    assert not _degraded(85.4, 85.1)
+
+
+def test_old_expression_did_fire_on_those_pairs():
+    # Without this the suite cannot tell the fixed and broken versions apart.
+    assert 84.4 - 84.1 > COVERAGE_DROP_TOLERANCE
+    assert 85.4 - 85.1 > COVERAGE_DROP_TOLERANCE
+
+
+def test_drop_above_tolerance_still_fails():
+    assert _degraded(86.30, 85.99)
+    assert _degraded(86.3, 85.8)
+
+
+def test_large_drop_still_fails():
+    # The shape reported on PR #105684; the gate must not be disabled.
+    assert _degraded(86.20, 28.60)
+
+
+def test_coverage_increase_passes():
+    assert not _degraded(86.53, 86.54)
+
+
+def test_contract_over_full_range():
+    # For every one-decimal baseline, the verdict must be `drop > 0.3`.
+    mismatches = []
+    for step in range(0, 1001):
+        baseline = step / 10.0
+        for drop in ("0.29", "0.30", "0.31", "0.35", "0.40"):
+            current = round(baseline - float(drop), 2)
+            if current < 0:
+                continue
+            expected = float(drop) > COVERAGE_DROP_TOLERANCE
+            if _degraded(baseline, current) != expected:
+                mismatches.append((baseline, current, drop))
+    assert mismatches == [], f"{len(mismatches)} mismatches, first: {mismatches[:5]}"
+
+
+def test_message_reports_the_value_it_compared():
+    baseline, current = 86.30, 85.99
+    drop = coverage_drop(baseline, current)
+    assert _degraded(baseline, current)
+    # The gate interpolates this same value, so the printed number cannot
+    # disagree with the number judged.
+    assert f"{drop:.2f}" == "0.31"


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/105684
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes the `LLVM Coverage` diff gate rejecting a line coverage drop that is exactly equal to its 0.3 pp tolerance.

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/105684

The gate reports `dropped 0.30 pp, tolerance 0.3 pp` while failing the check. `get_lcov_summary` parses lcov's one-decimal percentages, so the drop was a binary float subtraction of two decimals, and for many pairs it lands just above the tolerance:

```
84.4 - 84.1 == 0.30000000000001137   ->  > 0.3 is True
85.5 - 85.2 == 0.29999999999999716   ->  > 0.3 is False
```

It is value-dependent, which is why it looks intermittent. Of the one-decimal pairs whose exact decimal drop is 0.3, 404 of 998 (40.5%) wrongly fail.

The change rounds the drop to two decimals before comparing, and prints the same rounded value it judged so the message cannot disagree with the verdict. Two decimals is strictly finer than lcov's one-decimal reporting, so no drop lcov can distinguish is masked. The 0.3 pp tolerance is unchanged deliberately: the bug is that `0.30` was not `0.30`, not that the threshold is wrong.

Measured on CIDB over 90 days: 21 of 80 `Coverage degraded` rows, across 21 distinct pull requests, report exactly `dropped 0.30 pp`, and they reduce to two value pairs, `84.4/84.1` and `85.4/85.1`. Both wrongly fail today and both pass with this change.

Scope: this fixes the exactly-at-tolerance class only, not every `Coverage degraded` failure. The other cause, the gate scoring a pull request against an incomplete set of coverage profiles (the 57.60 pp failure on #105684, already fixed for that shape by #111808), needs a cross-job artifact-completeness protocol. It is tracked separately and will get its own pull request.

New `ci/tests/test_llvm_coverage_gate.py` imports the production helpers rather than copying the predicate: both real failing pairs pass, a 0.31 pp drop and the 57.60 pp shape still fail, and a sweep over every one-decimal baseline with drops of 0.29/0.30/0.31/0.35/0.40 has zero mismatches against `drop > 0.3`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.479` (included in `26.8` and later)
<!-- ch-version-info:end -->