### PR TITLE
Check for cancellation while replacing substrings

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -397,6 +397,7 @@
     M(CompiledFunctionExecute, "Number of times a compiled function was executed.", ValueType::Number) \
     M(CompileExpressionsMicroseconds, "Total time spent for compilation of expressions to LLVM code.", ValueType::Microseconds) \
     M(CompileExpressionsBytes, "Number of bytes used for expressions compilation.", ValueType::Bytes) \
+    M(CompileRegexpFunction, "Number of times a regular expression was JIT-compiled to machine code.", ValueType::Number) \
     \
     M(ExecuteShellCommand, "Number of shell command executions.", ValueType::Number) \
     \

--- a/src/Functions/FunctionStringReplace.h
+++ b/src/Functions/FunctionStringReplace.h
@@ -8,7 +8,10 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
+#include <Common/CurrentThread.h>
 
+#include <functional>
 #include <limits>
 
 
@@ -18,6 +21,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
+    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace Setting
@@ -68,8 +72,32 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
+        /// Resolved from the executing thread rather than captured: this instance can be stored in table
+        /// metadata and then run by any later query.
+        QueryStatusPtr process_list_element;
+        if (auto query_context = CurrentThread::tryGetQueryContext())
+            process_list_element = query_context->getProcessListElementSafe();
+
+        /// `checkTimeLimit` returns false rather than throwing under the `break` overflow mode, but a
+        /// partially rewritten string is a wrong value rather than a shorter one, so it becomes a throw.
+        std::function<void()> check_cancellation;
+        if (process_list_element)
+            check_cancellation = [&process_list_element]
+            {
+                if (!process_list_element->checkTimeLimit())
+                    throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", name);
+            };
+
+        /// Before materialization: expanding a constant into a full column is itself unbounded.
+        if (check_cancellation)
+            check_cancellation();
+
         ColumnPtr column_haystack = arguments[0].column;
         column_haystack = column_haystack->convertToFullColumnIfConst();
+
+        /// After materialization, so that a deadline crossed by the expansion above is observed too.
+        if (check_cancellation)
+            check_cancellation();
 
         const ColumnPtr column_needle = arguments[1].column;
         const ColumnPtr column_replacement = arguments[2].column;
@@ -92,17 +120,16 @@ public:
             auto & res_chars = col_res->getChars();
             auto & res_offsets = col_res->getOffsets();
             /// Only impls that opt in (currently `ReplaceRegexpImpl`) take the JIT compile-count threshold.
-            if constexpr (requires { Impl::vectorConstantConstant(col_haystack->getChars(), col_haystack->getOffsets(), needle, replacement, res_chars, res_offsets, input_rows_count, regexp_jit_min_count); })
+            if constexpr (requires { Impl::vectorConstantConstant(col_haystack->getChars(), col_haystack->getOffsets(), needle, replacement, res_chars, res_offsets, input_rows_count, regexp_jit_min_count, check_cancellation); })
                 Impl::vectorConstantConstant(
                     col_haystack->getChars(), col_haystack->getOffsets(), needle, replacement,
-                    res_chars, res_offsets, input_rows_count, regexp_jit_min_count);
+                    res_chars, res_offsets, input_rows_count, regexp_jit_min_count, check_cancellation);
             else
                 Impl::vectorConstantConstant(
                     col_haystack->getChars(), col_haystack->getOffsets(), needle, replacement,
-                    res_chars, res_offsets, input_rows_count);
-            return col_res;
+                    res_chars, res_offsets, input_rows_count, check_cancellation);
         }
-        if (col_haystack && col_needle_vector && col_replacement_const)
+        else if (col_haystack && col_needle_vector && col_replacement_const)
         {
             Impl::vectorVectorConstant(
                 col_haystack->getChars(),
@@ -112,10 +139,10 @@ public:
                 col_replacement_const->getValue<String>(),
                 col_res->getChars(),
                 col_res->getOffsets(),
-                input_rows_count);
-            return col_res;
+                input_rows_count,
+                check_cancellation);
         }
-        if (col_haystack && col_needle_const && col_replacement_vector)
+        else if (col_haystack && col_needle_const && col_replacement_vector)
         {
             Impl::vectorConstantVector(
                 col_haystack->getChars(),
@@ -125,10 +152,10 @@ public:
                 col_replacement_vector->getOffsets(),
                 col_res->getChars(),
                 col_res->getOffsets(),
-                input_rows_count);
-            return col_res;
+                input_rows_count,
+                check_cancellation);
         }
-        if (col_haystack && col_needle_vector && col_replacement_vector)
+        else if (col_haystack && col_needle_vector && col_replacement_vector)
         {
             Impl::vectorVectorVector(
                 col_haystack->getChars(),
@@ -139,10 +166,10 @@ public:
                 col_replacement_vector->getOffsets(),
                 col_res->getChars(),
                 col_res->getOffsets(),
-                input_rows_count);
-            return col_res;
+                input_rows_count,
+                check_cancellation);
         }
-        if (col_haystack_fixed && col_needle_const && col_replacement_const)
+        else if (col_haystack_fixed && col_needle_const && col_replacement_const)
         {
             Impl::vectorFixedConstantConstant(
                 col_haystack_fixed->getChars(),
@@ -151,11 +178,19 @@ public:
                 col_replacement_const->getValue<String>(),
                 col_res->getChars(),
                 col_res->getOffsets(),
-                input_rows_count);
-            return col_res;
+                input_rows_count,
+                check_cancellation);
         }
-        throw Exception(
-            ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of first argument of function {}", arguments[0].column->getName(), getName());
+        else
+            throw Exception(
+                ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of first argument of function {}", arguments[0].column->getName(), getName());
+
+        /// One check on the single exit path, covering every fast path that copies the column in one bulk
+        /// operation and returns without reaching a throttled loop, including any added later.
+        if (check_cancellation)
+            check_cancellation();
+
+        return col_res;
     }
 
 private:

--- a/src/Functions/ReplaceRegexpImpl.h
+++ b/src/Functions/ReplaceRegexpImpl.h
@@ -9,6 +9,7 @@
 #include <Interpreters/JIT/CompileRegexp.h>
 #include <base/types.h>
 
+#include <functional>
 #include <limits>
 #include <vector>
 
@@ -88,10 +89,11 @@ struct ReplaceRegexpImpl
     }
 
     /// The replacement string references must not contain non-existing capturing groups.
-    static void checkSubstitutions(std::string_view replacement, int num_captures)
+    static void checkSubstitutions(std::string_view replacement, int num_captures, ReplaceCancellationBudget & budget)
     {
         for (size_t i = 0; i < replacement.size(); ++i)
         {
+            budget.charge(1);
             if (replacement[i] == '\\' && i + 1 < replacement.size())
             {
                 if (isNumericASCII(replacement[i + 1])) /// substitution
@@ -104,9 +106,9 @@ struct ReplaceRegexpImpl
         }
     }
 
-    static Instructions createInstructions(std::string_view replacement, int num_captures)
+    static Instructions createInstructions(std::string_view replacement, int num_captures, ReplaceCancellationBudget & budget)
     {
-        checkSubstitutions(replacement, num_captures);
+        checkSubstitutions(replacement, num_captures, budget);
 
         Instructions instructions;
 
@@ -115,6 +117,7 @@ struct ReplaceRegexpImpl
 
         for (size_t i = 0; i < replacement.size(); ++i)
         {
+            budget.charge(1);
             if (replacement[i] == '\\' && i + 1 < replacement.size())
             {
                 if (isNumericASCII(replacement[i + 1])) /// substitution
@@ -141,12 +144,17 @@ struct ReplaceRegexpImpl
         return instructions;
     }
 
-    static bool canFallbackToStringReplacement(const String & needle, const String & replacement, const re2::RE2 & searcher, int num_captures)
+    /// `budget` is mandatory: this helper scans the whole replacement, and `analyze` the whole needle.
+    static bool canFallbackToStringReplacement(
+        const String & needle, const String & replacement, const re2::RE2 & searcher, int num_captures,
+        ReplaceCancellationBudget & budget)
     {
         if (searcher.NumberOfCapturingGroups())
             return false;
 
-        checkSubstitutions(replacement, num_captures);
+        checkSubstitutions(replacement, num_captures, budget);
+        /// The needle's length is independent of the replacement charged above.
+        budget.charge(needle.size());
         RegexpAnalysisResult result = OptimizedRegularExpression::analyze(needle);
         return result.is_trivial && result.required_substring_is_prefix && result.required_substring == needle;
     }
@@ -158,7 +166,8 @@ struct ReplaceRegexpImpl
         ColumnString::Offset & res_offset,
         const re2::RE2 & searcher,
         int num_captures,
-        const Instructions & instructions)
+        const Instructions & instructions,
+        ReplaceCancellationBudget & budget)
     {
         std::string_view haystack(haystack_data, haystack_length);
         std::string_view matches[max_captures];
@@ -185,6 +194,9 @@ struct ReplaceRegexpImpl
                 match_pos = copy_pos;
 
                 /// Substitute inside current match using instructions
+                /// Charged from INSIDE the loop: the list runs in full for every match and is itself
+                /// unbounded, so a single match can carry the whole list. Flushed in chunks.
+                size_t units_since_charge = 0;
                 for (const auto & instr : instructions)
                 {
                     std::string_view replacement;
@@ -195,7 +207,16 @@ struct ReplaceRegexpImpl
                     res_data.resize(res_data.size() + replacement.size());
                     memcpy(&res_data[res_offset], replacement.data(), replacement.size());
                     res_offset += replacement.size();
+                    units_since_charge += 1 + replacement.size() / budget.bytes_per_unit;
+                    if (units_since_charge >= budget.units_per_instruction_charge)
+                    {
+                        budget.chargeUnits(units_since_charge);
+                        units_since_charge = 0;
+                    }
                 }
+
+                /// This iteration, whatever the loop has not flushed, plus the prefix bytes copied.
+                budget.chargeUnits(1 + units_since_charge + bytes_to_copy / budget.bytes_per_unit);
 
                 if constexpr (replace == ReplaceRegexpTraits::First)
                     can_finish_current_string = true;
@@ -216,7 +237,10 @@ struct ReplaceRegexpImpl
                 }
             }
             else
+            {
                 can_finish_current_string = true;
+                budget.charge();
+            }
 
             /// If ready, append suffix after match to end of string.
             if (can_finish_current_string)
@@ -224,6 +248,7 @@ struct ReplaceRegexpImpl
                 res_data.resize(res_data.size() + haystack_length - copy_pos);
                 memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], haystack.data() + copy_pos, haystack_length - copy_pos);
                 res_offset += haystack_length - copy_pos;
+                budget.charge(haystack_length - copy_pos);
                 copy_pos = haystack_length;
                 match_pos = copy_pos;
                 break;
@@ -242,7 +267,8 @@ struct ReplaceRegexpImpl
         const RegexpJITMatcher & matcher,
         const uint8_t ** capture_starts,
         const uint8_t ** capture_ends,
-        const Instructions & instructions)
+        const Instructions & instructions,
+        ReplaceCancellationBudget & budget)
     {
         const auto * begin = reinterpret_cast<const uint8_t *>(haystack_data);
         const auto * end = begin + haystack_length;
@@ -267,6 +293,8 @@ struct ReplaceRegexpImpl
                 copy_pos += bytes_to_copy + match_length;
                 match_pos = copy_pos;
 
+                /// Charged from inside the loop in chunks, see `processString`.
+                size_t units_since_charge = 0;
                 for (const auto & instr : instructions)
                 {
                     std::string_view replacement;
@@ -284,7 +312,16 @@ struct ReplaceRegexpImpl
                     if (!replacement.empty())
                         memcpy(&res_data[res_offset], replacement.data(), replacement.size());
                     res_offset += replacement.size();
+                    units_since_charge += 1 + replacement.size() / budget.bytes_per_unit;
+                    if (units_since_charge >= budget.units_per_instruction_charge)
+                    {
+                        budget.chargeUnits(units_since_charge);
+                        units_since_charge = 0;
+                    }
                 }
+
+                /// See `processString`.
+                budget.chargeUnits(1 + units_since_charge + bytes_to_copy / budget.bytes_per_unit);
 
                 if constexpr (replace == ReplaceRegexpTraits::First)
                     can_finish_current_string = true;
@@ -302,13 +339,17 @@ struct ReplaceRegexpImpl
                 }
             }
             else
+            {
                 can_finish_current_string = true;
+                budget.charge();
+            }
 
             if (can_finish_current_string)
             {
                 res_data.resize(res_data.size() + haystack_length - copy_pos);
                 memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], haystack_data + copy_pos, haystack_length - copy_pos);
                 res_offset += haystack_length - copy_pos;
+                budget.charge(haystack_length - copy_pos);
                 copy_pos = haystack_length;
                 match_pos = copy_pos;
                 break;
@@ -324,8 +365,11 @@ struct ReplaceRegexpImpl
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
         size_t input_rows_count,
-        size_t regexp_jit_min_count = std::numeric_limits<size_t>::max())
+        size_t regexp_jit_min_count = std::numeric_limits<size_t>::max(),
+        const std::function<void()> & check_cancellation = {})
     {
+        ReplaceCancellationBudget budget(check_cancellation);
+
         if (needle.empty())
         {
             res_data.assign(haystack_data);
@@ -347,7 +391,7 @@ struct ReplaceRegexpImpl
 
         /// Try to use non-regexp string replacement. This shortcut is implemented only for const-needles + const-replacement as
         /// pattern analysis incurs some cost too.
-        if (canFallbackToStringReplacement(needle, replacement, searcher, num_captures))
+        if (canFallbackToStringReplacement(needle, replacement, searcher, num_captures, budget))
         {
             auto convert_trait = [](ReplaceRegexpTraits first_or_all)
             {
@@ -357,12 +401,14 @@ struct ReplaceRegexpImpl
                     case ReplaceRegexpTraits::All:   return ReplaceStringTraits::Replace::All;
                 }
             };
+            /// The delegated call starts its own budget, which covers the traversal it performs.
             ReplaceStringImpl<Name, convert_trait(replace)>::vectorConstantConstant(
-                haystack_data, haystack_offsets, needle, replacement, res_data, res_offsets, input_rows_count);
+                haystack_data, haystack_offsets, needle, replacement, res_data, res_offsets, input_rows_count,
+                check_cancellation);
             return;
         }
 
-        Instructions instructions = createInstructions(replacement, num_captures);
+        Instructions instructions = createInstructions(replacement, num_captures, budget);
 
         /// `replace` builds RE2 with `dot_nl` enabled (see `createRegexpOptions`), so `.` matches newline (dot_all = true).
         RegexpJITMatcher matcher = getRegexpJITMatcher(needle, /* case_insensitive */ false, /* dot_all */ true, regexp_jit_min_count);
@@ -378,15 +424,17 @@ struct ReplaceRegexpImpl
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
+            budget.charge();
+
             size_t from = haystack_offsets[i - 1];
 
             const char * hs_data = reinterpret_cast<const char *>(haystack_data.data() + from);
             const size_t hs_length = static_cast<size_t>(haystack_offsets[i] - from);
 
             if (matcher)
-                processStringJIT(hs_data, hs_length, res_data, res_offset, matcher, capture_starts.data(), capture_ends.data(), instructions);
+                processStringJIT(hs_data, hs_length, res_data, res_offset, matcher, capture_starts.data(), capture_ends.data(), instructions, budget);
             else
-                processString(hs_data, hs_length, res_data, res_offset, searcher, num_captures, instructions);
+                processString(hs_data, hs_length, res_data, res_offset, searcher, num_captures, instructions, budget);
             res_offsets[i] = res_offset;
         }
     }
@@ -399,9 +447,12 @@ struct ReplaceRegexpImpl
         const String & replacement,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
-        size_t input_rows_count)
+        size_t input_rows_count,
+        const std::function<void()> & check_cancellation = {})
     {
         chassert(haystack_offsets.size() == needle_offsets.size());
+
+        ReplaceCancellationBudget budget(check_cancellation);
 
         ColumnString::Offset res_offset = 0;
         res_data.reserve(haystack_data.size());
@@ -411,6 +462,8 @@ struct ReplaceRegexpImpl
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
+            budget.charge();
+
             size_t hs_from = haystack_offsets[i - 1];
             const char * hs_data = reinterpret_cast<const char *>(haystack_data.data() + hs_from);
             const size_t hs_length = static_cast<size_t>(haystack_offsets[i] - hs_from);
@@ -425,17 +478,22 @@ struct ReplaceRegexpImpl
                 res_data.insert(res_data.end(), hs_data, hs_data + hs_length);
                 res_offset += hs_length;
                 res_offsets[i] = res_offset;
+                /// This branch skips every other checkpoint, so the copied row must be charged here.
+                budget.charge(hs_length);
                 continue;
             }
+
+            /// Matcher and instruction list are rebuilt per row, and scale with the pattern.
+            budget.charge(needle.size());
 
             re2::RE2 searcher(needle, regexp_options);
             if (!searcher.ok())
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "The pattern argument is not a valid re2 pattern: {}", searcher.error());
 
             int num_captures = std::min(searcher.NumberOfCapturingGroups() + 1, max_captures);
-            Instructions instructions = createInstructions(replacement, num_captures);
+            Instructions instructions = createInstructions(replacement, num_captures, budget);
 
-            processString(hs_data, hs_length, res_data, res_offset, searcher, num_captures, instructions);
+            processString(hs_data, hs_length, res_data, res_offset, searcher, num_captures, instructions, budget);
             res_offsets[i] = res_offset;
         }
     }
@@ -448,9 +506,12 @@ struct ReplaceRegexpImpl
         const ColumnString::Offsets & replacement_offsets,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
-        size_t input_rows_count)
+        size_t input_rows_count,
+        const std::function<void()> & check_cancellation = {})
     {
         chassert(haystack_offsets.size() == replacement_offsets.size());
+
+        ReplaceCancellationBudget budget(check_cancellation);
 
         if (needle.empty())
         {
@@ -473,6 +534,8 @@ struct ReplaceRegexpImpl
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
+            budget.charge();
+
             size_t hs_from = haystack_offsets[i - 1];
             const char * hs_data = reinterpret_cast<const char *>(haystack_data.data() + hs_from);
             const size_t hs_length = static_cast<size_t>(haystack_offsets[i] - hs_from);
@@ -482,9 +545,10 @@ struct ReplaceRegexpImpl
             const size_t repl_length = static_cast<size_t>(replacement_offsets[i] - repl_from);
             std::string_view replacement(repl_data, repl_length);
 
-            Instructions instructions = createInstructions(replacement, num_captures);
+            /// The instruction list is rebuilt for every row from that row's replacement.
+            Instructions instructions = createInstructions(replacement, num_captures, budget);
 
-            processString(hs_data, hs_length, res_data, res_offset, searcher, num_captures, instructions);
+            processString(hs_data, hs_length, res_data, res_offset, searcher, num_captures, instructions, budget);
             res_offsets[i] = res_offset;
         }
     }
@@ -498,10 +562,13 @@ struct ReplaceRegexpImpl
         const ColumnString::Offsets & replacement_offsets,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
-        size_t input_rows_count)
+        size_t input_rows_count,
+        const std::function<void()> & check_cancellation = {})
     {
         chassert(haystack_offsets.size() == needle_offsets.size());
         chassert(needle_offsets.size() == replacement_offsets.size());
+
+        ReplaceCancellationBudget budget(check_cancellation);
 
         ColumnString::Offset res_offset = 0;
         res_data.reserve(haystack_data.size());
@@ -511,6 +578,8 @@ struct ReplaceRegexpImpl
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
+            budget.charge();
+
             size_t hs_from = haystack_offsets[i - 1];
             const char * hs_data = reinterpret_cast<const char *>(haystack_data.data() + hs_from);
             const size_t hs_length = static_cast<size_t>(haystack_offsets[i] - hs_from);
@@ -525,6 +594,8 @@ struct ReplaceRegexpImpl
                 res_data.insert(res_data.end(), hs_data, hs_data + hs_length);
                 res_offsets[i] = res_offsets[i - 1] + hs_length;
                 res_offset = res_offsets[i];
+                /// This branch skips every other checkpoint, so the copied row must be charged here.
+                budget.charge(hs_length);
                 continue;
             }
 
@@ -533,14 +604,17 @@ struct ReplaceRegexpImpl
             const size_t repl_length = static_cast<size_t>(replacement_offsets[i] - repl_from);
             std::string_view replacement(repl_data, repl_length);
 
+            /// Per-row matcher construction, its cost scales with the pattern rather than the haystack.
+            budget.charge(needle.size());
+
             re2::RE2 searcher(needle, regexp_options);
             if (!searcher.ok())
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "The pattern argument is not a valid re2 pattern: {}", searcher.error());
 
             int num_captures = std::min(searcher.NumberOfCapturingGroups() + 1, max_captures);
-            Instructions instructions = createInstructions(replacement, num_captures);
+            Instructions instructions = createInstructions(replacement, num_captures, budget);
 
-            processString(hs_data, hs_length, res_data, res_offset, searcher, num_captures, instructions);
+            processString(hs_data, hs_length, res_data, res_offset, searcher, num_captures, instructions, budget);
             res_offsets[i] = res_offset;
         }
     }
@@ -552,15 +626,22 @@ struct ReplaceRegexpImpl
         const String & replacement,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
-        size_t input_rows_count)
+        size_t input_rows_count,
+        const std::function<void()> & check_cancellation = {})
     {
+        ReplaceCancellationBudget budget(check_cancellation);
+
         if (needle.empty())
         {
             chassert(input_rows_count == haystack_data.size() / n);
             res_data.assign(haystack_data.begin(), haystack_data.end());
             res_offsets.resize(input_rows_count);
+            /// Per-row loop over an unbounded row count, see the same charge in `ReplaceStringImpl`.
             for (size_t i = 0; i < input_rows_count; ++i)
+            {
                 res_offsets[i] = (i + 1) * n;
+                budget.charge();
+            }
             return;
         }
 
@@ -575,15 +656,17 @@ struct ReplaceRegexpImpl
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "The pattern argument is not a valid re2 pattern: {}", searcher.error());
 
         int num_captures = std::min(searcher.NumberOfCapturingGroups() + 1, max_captures);
-        Instructions instructions = createInstructions(replacement, num_captures);
+        Instructions instructions = createInstructions(replacement, num_captures, budget);
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
+            budget.charge();
+
             size_t from = i * n;
             const char * hs_data = reinterpret_cast<const char *>(haystack_data.data() + from);
             const size_t hs_length = n;
 
-            processString(hs_data, hs_length, res_data, res_offset, searcher, num_captures, instructions);
+            processString(hs_data, hs_length, res_data, res_offset, searcher, num_captures, instructions, budget);
             res_offsets[i] = res_offset;
         }
     }

--- a/src/Functions/ReplaceRegexpImpl.h
+++ b/src/Functions/ReplaceRegexpImpl.h
@@ -207,8 +207,8 @@ struct ReplaceRegexpImpl
                     res_data.resize(res_data.size() + replacement.size());
                     memcpy(&res_data[res_offset], replacement.data(), replacement.size());
                     res_offset += replacement.size();
-                    units_since_charge += 1 + replacement.size() / budget.bytes_per_unit;
-                    if (units_since_charge >= budget.units_per_instruction_charge)
+                    units_since_charge += 1 + replacement.size() / ReplaceCancellationBudget::bytes_per_unit;
+                    if (units_since_charge >= ReplaceCancellationBudget::units_per_instruction_charge)
                     {
                         budget.chargeUnits(units_since_charge);
                         units_since_charge = 0;
@@ -216,7 +216,7 @@ struct ReplaceRegexpImpl
                 }
 
                 /// This iteration, whatever the loop has not flushed, plus the prefix bytes copied.
-                budget.chargeUnits(1 + units_since_charge + bytes_to_copy / budget.bytes_per_unit);
+                budget.chargeUnits(1 + units_since_charge + bytes_to_copy / ReplaceCancellationBudget::bytes_per_unit);
 
                 if constexpr (replace == ReplaceRegexpTraits::First)
                     can_finish_current_string = true;
@@ -312,8 +312,8 @@ struct ReplaceRegexpImpl
                     if (!replacement.empty())
                         memcpy(&res_data[res_offset], replacement.data(), replacement.size());
                     res_offset += replacement.size();
-                    units_since_charge += 1 + replacement.size() / budget.bytes_per_unit;
-                    if (units_since_charge >= budget.units_per_instruction_charge)
+                    units_since_charge += 1 + replacement.size() / ReplaceCancellationBudget::bytes_per_unit;
+                    if (units_since_charge >= ReplaceCancellationBudget::units_per_instruction_charge)
                     {
                         budget.chargeUnits(units_since_charge);
                         units_since_charge = 0;
@@ -321,7 +321,7 @@ struct ReplaceRegexpImpl
                 }
 
                 /// See `processString`.
-                budget.chargeUnits(1 + units_since_charge + bytes_to_copy / budget.bytes_per_unit);
+                budget.chargeUnits(1 + units_since_charge + bytes_to_copy / ReplaceCancellationBudget::bytes_per_unit);
 
                 if constexpr (replace == ReplaceRegexpTraits::First)
                     can_finish_current_string = true;

--- a/src/Functions/ReplaceStringImpl.h
+++ b/src/Functions/ReplaceStringImpl.h
@@ -4,6 +4,8 @@
 #include <Common/Volnitsky.h>
 #include <Columns/ColumnString.h>
 
+#include <functional>
+
 
 namespace DB
 {
@@ -15,6 +17,43 @@ struct ReplaceStringTraits
         First,
         All
     };
+};
+
+/// Throttled cancellation checkpoint for the `replace*` functions. Lives on the stack of a single vector
+/// call, so it is never shared between threads. Counted in loop ITERATIONS, not bytes: an empty regexp
+/// match advances one byte and may copy nothing, yet costs a full `RE2::Match`. Bytes are charged on top,
+/// scaled down, because one iteration can copy megabytes.
+struct ReplaceCancellationBudget
+{
+    /// About 30ms of granularity on the cheapest loop.
+    static constexpr size_t units_per_check = 1ULL << 16;
+    /// Bytes of data read or written that count as one unit of work.
+    static constexpr size_t bytes_per_unit = 16;
+    /// Accumulated inside a substitution loop before being charged, so the loop body stays short.
+    static constexpr size_t units_per_instruction_charge = 4096;
+
+    explicit ReplaceCancellationBudget(const std::function<void()> & check_)
+        : check(check_ ? &check_ : nullptr) {}
+
+    /// One iteration of an unbounded loop, plus the bytes of data that iteration touched.
+    void charge(size_t bytes = 0) { chargeUnits(1 + bytes / bytes_per_unit); }
+
+    /// Work that is not proportional to the amount of data, e.g. constructing a matcher from a pattern.
+    void chargeUnits(size_t units)
+    {
+        if (units_left > units)
+        {
+            units_left -= units;
+            return;
+        }
+        units_left = units_per_check;
+        if (check)
+            (*check)();
+    }
+
+private:
+    const std::function<void()> * check;
+    size_t units_left = units_per_check;
 };
 
 /** Replace one or all occurencies of substring 'needle' to 'replacement'.
@@ -31,8 +70,11 @@ struct ReplaceStringImpl
         const String & replacement,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
-        size_t input_rows_count)
+        size_t input_rows_count,
+        const std::function<void()> & check_cancellation = {})
     {
+        ReplaceCancellationBudget budget(check_cancellation);
+
         if (needle.empty())
         {
             res_data.assign(haystack_data.begin(), haystack_data.end());
@@ -61,9 +103,19 @@ struct ReplaceStringImpl
                 res_offsets.assign(haystack_offsets.begin(), haystack_offsets.end());
                 const auto from = static_cast<UInt8>(needle[0]);
                 const auto to = static_cast<UInt8>(replacement[0]);
-                for (auto & c : res_data)
-                    if (c == from)
-                        c = to;
+                /// Chunked so the time limit is observed inside this single whole-column loop. Chunking
+                /// measurably perturbs how the scan is compiled, so the chunk is kept large.
+                static constexpr size_t chunk_size = 64 * 1024 * 1024;
+                UInt8 * const data = res_data.data();
+                const size_t size = res_data.size();
+                for (size_t chunk_begin = 0; chunk_begin < size; chunk_begin += chunk_size)
+                {
+                    const size_t chunk_end = std::min(chunk_begin + chunk_size, size);
+                    for (UInt8 * p = data + chunk_begin, * const chunk_last = data + chunk_end; p != chunk_last; ++p)
+                        if (*p == from)
+                            *p = to;
+                    budget.charge(chunk_end - chunk_begin);
+                }
                 return;
             }
         }
@@ -90,11 +142,14 @@ struct ReplaceStringImpl
             res_data.resize(res_data.size() + (match - pos));
             memcpy(&res_data[res_offset], pos, match - pos);
 
+            budget.charge(match - pos);
+
             /// Determine which index the match belongs to.
             while (i < input_rows_count && begin + haystack_offsets[i] <= match)
             {
                 res_offsets[i] = res_offset + ((begin + haystack_offsets[i]) - pos);
                 ++i;
+                budget.charge();
             }
             res_offset += (match - pos);
 
@@ -111,6 +166,8 @@ struct ReplaceStringImpl
                 res_data.resize(res_data.size() + replacement.size());
                 memcpy(&res_data[res_offset], replacement.data(), replacement.size());
                 res_offset += replacement.size();
+                /// The output is work too: a large replacement writes far more than it reads.
+                budget.charge(replacement.size());
                 pos = match + needle.size();
                 if constexpr (replace == ReplaceStringTraits::Replace::First)
                     can_finish_current_string = true;
@@ -125,12 +182,15 @@ struct ReplaceStringImpl
 
             if (can_finish_current_string)
             {
-                res_data.resize(res_data.size() + (begin + haystack_offsets[i] - pos));
-                memcpy(&res_data[res_offset], pos, (begin + haystack_offsets[i] - pos));
-                res_offset += (begin + haystack_offsets[i] - pos);
+                const size_t rest_of_string = begin + haystack_offsets[i] - pos;
+                res_data.resize(res_data.size() + rest_of_string);
+                memcpy(&res_data[res_offset], pos, rest_of_string);
+                res_offset += rest_of_string;
                 res_offsets[i] = res_offset;
                 pos = begin + haystack_offsets[i];
                 ++i;
+                /// Unconditional, and the whole rest of the row.
+                budget.charge(rest_of_string);
             }
         }
     }
@@ -154,9 +214,12 @@ struct ReplaceStringImpl
         const String & replacement,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
-        size_t input_rows_count)
+        size_t input_rows_count,
+        const std::function<void()> & check_cancellation = {})
     {
         chassert(haystack_offsets.size() == needle_offsets.size());
+
+        ReplaceCancellationBudget budget(check_cancellation);
 
         res_data.reserve(haystack_data.size());
         res_offsets.resize(input_rows_count);
@@ -168,6 +231,7 @@ struct ReplaceStringImpl
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
+            budget.charge();
             const auto * const cur_haystack_data = &haystack_data[prev_haystack_offset];
             const size_t cur_haystack_length = haystack_offsets[i] - prev_haystack_offset;
 
@@ -193,6 +257,8 @@ struct ReplaceStringImpl
                         /// Insert replacement for match
                         copyToOutput(replacement.data(), replacement.size(), res_data, res_offset);
 
+                        budget.charge((match - start_pos) + replacement.size());
+
                         last_match = match;
                         start_pos = match + cur_needle_length;
 
@@ -208,6 +274,8 @@ struct ReplaceStringImpl
             size_t bytes = (last_match == nullptr) ? (cur_haystack_end - cur_haystack_data)
                                                    : (cur_haystack_end - last_match - cur_needle_length);
             copyToOutput(start_pos, bytes, res_data, res_offset);
+            /// Unconditional, and the whole row when it never matches.
+            budget.charge(bytes);
 
             res_offsets[i] = res_offset;
 
@@ -224,9 +292,12 @@ struct ReplaceStringImpl
         const ColumnString::Offsets & replacement_offsets,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
-        size_t input_rows_count)
+        size_t input_rows_count,
+        const std::function<void()> & check_cancellation = {})
     {
         chassert(haystack_offsets.size() == replacement_offsets.size());
+
+        ReplaceCancellationBudget budget(check_cancellation);
 
         if (needle.empty())
         {
@@ -247,6 +318,8 @@ struct ReplaceStringImpl
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
+            budget.charge();
+
             const auto * const cur_haystack_data = &haystack_data[prev_haystack_offset];
             const size_t cur_haystack_length = haystack_offsets[i] - prev_haystack_offset;
 
@@ -267,6 +340,8 @@ struct ReplaceStringImpl
                     /// Insert replacement for match
                     copyToOutput(cur_replacement_data, cur_replacement_length, res_data, res_offset);
 
+                    budget.charge((match - start_pos) + cur_replacement_length);
+
                     last_match = match;
                     start_pos = match + needle.size();
 
@@ -281,6 +356,8 @@ struct ReplaceStringImpl
             size_t bytes = (last_match == nullptr) ? (cur_haystack_end - cur_haystack_data)
                                                    : (cur_haystack_end - last_match - needle.size());
             copyToOutput(start_pos, bytes, res_data, res_offset);
+            /// See `vectorVectorConstant`: unconditional, and the whole row when it never matches.
+            budget.charge(bytes);
 
             res_offsets[i] = res_offset;
 
@@ -298,10 +375,13 @@ struct ReplaceStringImpl
         const ColumnString::Offsets & replacement_offsets,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
-        size_t input_rows_count)
+        size_t input_rows_count,
+        const std::function<void()> & check_cancellation = {})
     {
         chassert(haystack_offsets.size() == needle_offsets.size());
         chassert(needle_offsets.size() == replacement_offsets.size());
+
+        ReplaceCancellationBudget budget(check_cancellation);
 
         res_data.reserve(haystack_data.size());
         res_offsets.resize(input_rows_count);
@@ -314,6 +394,8 @@ struct ReplaceStringImpl
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
+            budget.charge();
+
             const auto * const cur_haystack_data = &haystack_data[prev_haystack_offset];
             const size_t cur_haystack_length = haystack_offsets[i] - prev_haystack_offset;
 
@@ -342,6 +424,8 @@ struct ReplaceStringImpl
                         /// Insert replacement for match
                         copyToOutput(cur_replacement_data, cur_replacement_length, res_data, res_offset);
 
+                        budget.charge((match - start_pos) + cur_replacement_length);
+
                         last_match = match;
                         start_pos = match + cur_needle_length;
 
@@ -356,6 +440,8 @@ struct ReplaceStringImpl
             size_t bytes = (last_match == nullptr) ? (cur_haystack_end - cur_haystack_data)
                                                    : (cur_haystack_end - last_match - cur_needle_length);
             copyToOutput(start_pos, bytes, res_data, res_offset);
+            /// See `vectorVectorConstant`: unconditional, and the whole row when it never matches.
+            budget.charge(bytes);
 
             res_offsets[i] = res_offset;
 
@@ -373,15 +459,22 @@ struct ReplaceStringImpl
         const String & replacement,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
-        size_t input_rows_count)
+        size_t input_rows_count,
+        const std::function<void()> & check_cancellation = {})
     {
+        ReplaceCancellationBudget budget(check_cancellation);
+
         if (needle.empty() || needle == replacement)
         {
             chassert(input_rows_count == haystack_data.size() / n);
             res_data.assign(haystack_data.begin(), haystack_data.end());
             res_offsets.resize(input_rows_count);
+            /// The copy above is one bulk operation, but filling the offsets is an unbounded per-row loop.
             for (size_t i = 1; i <= input_rows_count; ++i)
+            {
                 res_offsets[i - 1] = i * n;
+                budget.charge();
+            }
             return;
         }
 
@@ -403,6 +496,8 @@ struct ReplaceStringImpl
         {
             const UInt8 * match = searcher.search(pos, end - pos);
 
+            budget.charge(match - pos);
+
 #define COPY_REST_OF_CURRENT_STRING() \
     do \
     { \
@@ -413,6 +508,7 @@ struct ReplaceStringImpl
         res_offsets[i] = res_offset; \
         pos = begin + n * (i + 1); \
         ++i; \
+        budget.charge(len); \
     } while (false)
 
             /// Copy skipped strings without any changes.
@@ -439,6 +535,8 @@ struct ReplaceStringImpl
                 res_data.resize(res_data.size() + replacement.size());
                 memcpy(&res_data[res_offset], replacement.data(), replacement.size());
                 res_offset += replacement.size();
+                /// See the same charge in `vectorConstantConstant`: the written bytes are work as well.
+                budget.charge(replacement.size());
                 pos = match + needle.size();
                 if constexpr (replace == ReplaceStringTraits::Replace::First)
                     can_finish_current_string = true;

--- a/src/Interpreters/JIT/CompileRegexp.cpp
+++ b/src/Interpreters/JIT/CompileRegexp.cpp
@@ -758,11 +758,7 @@ RegexpJITMatcher getRegexpJITMatcher(
         return {};
     }
 
-    /// Charged here rather than next to the compilation itself: every throw between the two, including
-    /// the cache insertion, is swallowed above and leaves the caller on the interpreted loop, so an
-    /// earlier increment would report a matcher the caller never received. Only this function reaches the
-    /// regexp JIT, and `compiled_here` keeps it a compile rather than a cache hit. The other writers of
-    /// the shared cache charge `CompileFunction` instead.
+    /// Must stay below the catch above: every throw it swallows leaves the caller on the interpreted loop.
     if (compiled_here)
         ProfileEvents::increment(ProfileEvents::CompileRegexpFunction);
 

--- a/src/Interpreters/JIT/CompileRegexp.cpp
+++ b/src/Interpreters/JIT/CompileRegexp.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <Common/Exception.h>
+#include <Common/ProfileEvents.h>
 #include <Common/RegexpJIT/RegexpProgram.h>
 #include <Common/SipHash.h>
 #include <Common/logger_useful.h>
@@ -26,6 +27,11 @@
 #include <llvm/IR/Intrinsics.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Verifier.h>
+
+namespace ProfileEvents
+{
+    extern const Event CompileRegexpFunction;
+}
 
 namespace DB
 {
@@ -671,6 +677,10 @@ std::shared_ptr<CompiledRegexpHolder> compileMatcher(const RegexpProgram & progr
     }
 
     auto func = reinterpret_cast<JITRegexpMatcherFunc>(it->second);
+
+    /// Only this function reaches the regexp JIT, and only on a compile rather than on a cache hit. The
+    /// other writers of the shared cache charge `CompileFunction` instead.
+    ProfileEvents::increment(ProfileEvents::CompileRegexpFunction);
 
     /// `compileModule` has already registered the module in the JIT instance; it is released only by
     /// `deleteCompiledModule` (called from `~CompiledRegexpHolder`). Until the holder is constructed and

--- a/src/Interpreters/JIT/CompileRegexp.cpp
+++ b/src/Interpreters/JIT/CompileRegexp.cpp
@@ -678,10 +678,6 @@ std::shared_ptr<CompiledRegexpHolder> compileMatcher(const RegexpProgram & progr
 
     auto func = reinterpret_cast<JITRegexpMatcherFunc>(it->second);
 
-    /// Only this function reaches the regexp JIT, and only on a compile rather than on a cache hit. The
-    /// other writers of the shared cache charge `CompileFunction` instead.
-    ProfileEvents::increment(ProfileEvents::CompileRegexpFunction);
-
     /// `compileModule` has already registered the module in the JIT instance; it is released only by
     /// `deleteCompiledModule` (called from `~CompiledRegexpHolder`). Until the holder is constructed and
     /// takes ownership, there is an unmanaged gap: if `make_shared` throws (e.g. `bad_alloc`), the module
@@ -689,15 +685,18 @@ std::shared_ptr<CompiledRegexpHolder> compileMatcher(const RegexpProgram & progr
     /// The raw pointer stays valid even after `jit` is moved from, because `regexp_jit_instance` keeps the
     /// `CHJIT` alive.
     CHJIT * jit_ptr = jit.get();
+    std::shared_ptr<CompiledRegexpHolder> holder;
     try
     {
-        return std::make_shared<CompiledRegexpHolder>(compiled_module, std::move(jit), func, program.num_captures);
+        holder = std::make_shared<CompiledRegexpHolder>(compiled_module, std::move(jit), func, program.num_captures);
     }
     catch (...)
     {
         jit_ptr->deleteCompiledModule(compiled_module);
         throw;
     }
+
+    return holder;
 }
 
 }
@@ -731,6 +730,8 @@ RegexpJITMatcher getRegexpJITMatcher(
             return {};
     }
 
+    /// Set inside the loader, so it stays false on a cache hit, where nothing is compiled.
+    bool compiled_here = false;
     std::shared_ptr<CompiledRegexpHolder> holder;
     try
     {
@@ -738,13 +739,16 @@ RegexpJITMatcher getRegexpJITMatcher(
         {
             auto [entry, _] = cache->getOrSet(key, [&]() -> std::shared_ptr<CompiledExpressionCacheEntry>
             {
-                return compileMatcher(*program);
+                auto compiled = compileMatcher(*program);
+                compiled_here = true;
+                return compiled;
             });
             holder = std::static_pointer_cast<CompiledRegexpHolder>(entry);
         }
         else
         {
             holder = compileMatcher(*program);
+            compiled_here = true;
         }
     }
     catch (...)
@@ -753,6 +757,14 @@ RegexpJITMatcher getRegexpJITMatcher(
         tryLogCurrentException(getLogger("CompileRegexp"), "Failed to JIT-compile a regular expression, falling back to RE2");
         return {};
     }
+
+    /// Charged here rather than next to the compilation itself: every throw between the two, including
+    /// the cache insertion, is swallowed above and leaves the caller on the interpreted loop, so an
+    /// earlier increment would report a matcher the caller never received. Only this function reaches the
+    /// regexp JIT, and `compiled_here` keeps it a compile rather than a cache hit. The other writers of
+    /// the shared cache charge `CompileFunction` instead.
+    if (compiled_here)
+        ProfileEvents::increment(ProfileEvents::CompileRegexpFunction);
 
     RegexpJITMatcher result;
     result.func = holder->func;

--- a/tests/queries/0_stateless/04650_replace_cancellation.reference
+++ b/tests/queries/0_stateless/04650_replace_cancellation.reference
@@ -1,0 +1,24 @@
+fold regexp: stopped within bound
+pipe regexp: stopped within bound
+many rows: stopped within bound
+many folds: stopped within bound
+expanding replacement: stopped within bound
+regexp fallback to literal: stopped within bound
+replaceAll: stopped within bound
+per-row matcher setup: stopped within bound
+one-byte in place: stopped within bound
+instruction list: stopped within bound
+empty matches: stopped within bound
+replacement parsing: stopped within bound
+fixed string haystack: stopped within bound
+per-row replacement: stopped within bound
+one match, long instruction list: stopped within bound
+replaceRegexpOne: stopped within bound
+break pipeline: stopped within bound
+TIMEOUT_EXCEEDED
+kill query: killed within bound
+stored expression: stopped within bound
+stored expression leak: no query state retained
+jit matcher: stopped within bound
+jit matcher: compiled
+fixed string literal: stopped within bound

--- a/tests/queries/0_stateless/04650_replace_cancellation.sh
+++ b/tests/queries/0_stateless/04650_replace_cancellation.sh
@@ -105,8 +105,13 @@ run "expanding replacement" "SELECT $EXPAND FORMAT Null" throw "" fold
 # 6. The literal-search implementation reached through the regexp function's trivial-pattern shortcut,
 #    whose delegated call re-traverses the whole value. The needle must be a plain literal, or the
 #    shortcut is not taken and the case duplicates case 2.
+#    Materializing the argument happens before the call and is not interruptible by this fix, while the
+#    deadline runs from when the query was registered. That part therefore has to stay well inside the
+#    deadline on the slowest build, or the query is stopped before the function is entered and the case
+#    passes whatever the function does. The value is kept small and the cost carried by the replacement
+#    length instead, which is charged inside the loop.
 run "regexp fallback to literal" \
-    "SELECT length(replaceRegexpAll(materialize(repeat(repeat('ab', 1000000), 300)), 'ab', 'YZ')) FROM numbers(1) FORMAT Null"
+    "SELECT length(replaceRegexpAll(materialize(repeat(repeat('ab', 1000000), 60)), 'ab', 'YZYZYZYZYZYZYZYZYZYZYZYZYZYZYZYZ')) FROM numbers(1) FORMAT Null"
 
 # 7. The same work reached directly through replaceAll rather than through that shortcut.
 run "replaceAll" \
@@ -309,9 +314,12 @@ esac
 #     per-row offset loop and its own search loop over the whole block. The haystack has to be
 #     materialized: constant arguments are unwrapped to their nested data column before the dispatcher
 #     runs, which leaves the needle no longer constant so no branch matches. A prologue is therefore
-#     unavoidable, so the work per byte is large rather than the data - a needle matching every second byte
-#     - while the replacement stays short so the output cannot outgrow the input.
+#     unavoidable, so the work per byte is large rather than the data - every byte matches - while the
+#     replacement stays bounded so the output cannot outgrow the test's memory profile.
 #     Sizing this case by its written bytes instead does not work, which is what two earlier versions got
 #     wrong: the output is then what bounds the call, and no single size satisfies a fast and a slow build.
+#     The row count bounds that unavoidable prologue, which the deadline covers but this fix cannot
+#     interrupt: at 400000 rows it alone outlasted the deadline on a thread-sanitizer build, so the query
+#     was stopped before the function was entered and the case reported the same time either way.
 run "fixed string literal" \
-    "SELECT sum(length(replaceAll(toFixedString(materialize(repeat('ab', 800)), 1600), 'b', 'YY'))) FROM numbers(400000) SETTINGS max_block_size = 400000"
+    "SELECT sum(length(replaceAll(toFixedString(materialize(repeat('b', 1600)), 1600), 'b', 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'))) FROM numbers(50000) SETTINGS max_block_size = 50000"

--- a/tests/queries/0_stateless/04650_replace_cancellation.sh
+++ b/tests/queries/0_stateless/04650_replace_cancellation.sh
@@ -21,17 +21,23 @@ SCALE=1
 case "$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'WITH_COVERAGE'")" in ON|1) SCALE=2 ;; esac
 BOUND=$((SCALE * 2000))
 
-# $1 = label, $2 = query, $3 = overflow mode (default "throw"), $4 = query id (default none)
+# $1 = label, $2 = query, $3 = overflow mode (default "throw"), $4 = query id (default none),
+# $5 = "fold" if the call is constant-folded (no pipeline), empty for a pipeline case
 #
 # Regexp compilation is pinned off for every case but the one that is about the compiled matcher: the
 # compiled-regexp cache is server-global with a compile threshold of 3, and this test runs up to 5 times,
 # so an earlier run's pattern would already be compiled and the query would finish inside the deadline.
 #
 # Two messages report the same enforced deadline and only one carries a number: `CancellationChecker`
-# can win the race against this function's own check, and its error has no elapsed part. Both are
-# correct stops, so without a number the wall clock is bounded instead, as cases 19 and 20 do.
+# can win the race against this function's own check, and its error then has no elapsed part to read.
+# For a folded call that is still this function's stop to make, since the fold runs during analysis and
+# there is no pipeline to cancel, so the wall clock is bounded instead - as cases 19 and 20 do. For a
+# pipeline case it is not: `addPipelineExecutor` throws on the killed flag before the executor is
+# registered, so the query can end without ever entering the function, and accepting it on wall time
+# would assert query-level cancellation instead of the in-function checkpoint. That is reported as
+# inconclusive rather than passed.
 run() {
-    local label="$1" query="$2" mode="${3:-throw}" query_id="${4:-}"
+    local label="$1" query="$2" mode="${3:-throw}" query_id="${4:-}" shape="${5:-}"
     local output start_ms elapsed_ms wall_ms
     start_ms=$(date +%s%N)
     # shellcheck disable=SC2086
@@ -48,7 +54,9 @@ run() {
         else
             echo "$label: OVERSHOT ${elapsed_ms} ms"
         fi
-    elif printf '%s' "$output" | grep -q TIMEOUT_EXCEEDED; then
+    elif ! printf '%s' "$output" | grep -q TIMEOUT_EXCEEDED; then
+        echo "$label: no timeout"
+    elif [ "$shape" = fold ]; then
         # Wall clock covers the whole client call, not server time alone, hence case 19's allowance.
         if [ "$wall_ms" -lt "$((BOUND * 2))" ]; then
             echo "$label: stopped within bound"
@@ -56,14 +64,14 @@ run() {
             echo "$label: OVERSHOT ${wall_ms} ms"
         fi
     else
-        echo "$label: no timeout"
+        echo "$label: cancelled before the pipeline started"
     fi
 }
 
 # 1. Constant folding: no pipeline exists while this runs, which is what the original hung-check reports
 #    showed.
 run "fold regexp" \
-    "SELECT length(replaceRegexpAll(repeat(repeat('1', 1000000), 200), '[0-9]{1,3}', 'x')) FORMAT Null"
+    "SELECT length(replaceRegexpAll(repeat(repeat('1', 1000000), 200), '[0-9]{1,3}', 'x')) FORMAT Null" throw "" fold
 
 # 2. The same work in the pipeline, which makes case 1 non-vacuous: the defect is the missing in-function
 #    checkpoint, not something specific to constant folding. All three arguments must be materialized -
@@ -83,14 +91,14 @@ run "many rows" \
 #    version got wrong. The folds go in one array rather than a '+' chain: a chain nests one node per
 #    fold and formatting it recurses, which overruns the stack allowance a TSan build gives a query thread.
 FOLDS=$(python3 -c "print('arraySum([' + ', '.join(\"length(replaceRegexpAll('zzz%d', repeat('[a-z0-9]{1,2}', 10000), 'x'))\" % i for i in range(60)) + '])')")
-run "many folds" "SELECT $FOLDS FORMAT Null"
+run "many folds" "SELECT $FOLDS FORMAT Null" throw "" fold
 
 # 5. One match per iteration with a replacement much larger than the match: the whole cost is in the
 #    generated output, which accounting that looked only at the searched input would price at zero.
 #    Split across independent folds because a single fold large enough to matter races the 5GiB test
 #    profile; each fold's output is released before the next starts.
 EXPAND=$(python3 -c "print(' + '.join(\"length(replaceAll(repeat('%s', 500), '%s', repeat('Y', 1000000)))\" % (c, c) for c in 'qwertyuiopas'))")
-run "expanding replacement" "SELECT $EXPAND FORMAT Null"
+run "expanding replacement" "SELECT $EXPAND FORMAT Null" throw "" fold
 
 # 6. The literal-search implementation reached through the regexp function's trivial-pattern shortcut,
 #    whose delegated call re-traverses the whole value. The needle must be a plain literal, or the
@@ -100,7 +108,7 @@ run "regexp fallback to literal" \
 
 # 7. The same work reached directly through replaceAll rather than through that shortcut.
 run "replaceAll" \
-    "SELECT length(replaceAll(repeat(repeat('ab', 1000000), 300), 'ab', 'YZ')) FORMAT Null"
+    "SELECT length(replaceAll(repeat(repeat('ab', 1000000), 300), 'ab', 'YZ')) FORMAT Null" throw "" fold
 
 # 8. Empty haystacks with a different pattern per row: nothing is scanned or written, so all the work is
 #    building one matcher per row. The needle must vary, otherwise the matcher is built once outside the
@@ -111,18 +119,18 @@ run "per-row matcher setup" \
 # 9. A one-byte needle and replacement on the per-row entry point. It has to be a fold: in the pipeline
 #    the executor's own between-block check bounds the query whatever the function does.
 run "one-byte in place" \
-    "SELECT length(replaceAll(repeat(repeat('ab', 1000000), 300), 'b', 'c')) FORMAT Null"
+    "SELECT length(replaceAll(repeat(repeat('ab', 1000000), 300), 'b', 'c')) FORMAT Null" throw "" fold
 
 # 10. Many capture references against an empty capture group: every match executes the whole list while
 #     producing no output, so one checkpoint per match is not enough. The group must be empty and the
 #     references must be substitutions rather than literal bytes.
 run "instruction list" \
-    "SELECT length(replaceRegexpAll(repeat('a', 200000), '()', repeat('\\\\1', 20000))) FORMAT Null"
+    "SELECT length(replaceRegexpAll(repeat('a', 200000), '()', repeat('\\\\1', 20000))) FORMAT Null" throw "" fold
 
 # 11. A pattern that matches the empty string at every position: each iteration advances one byte, runs no
 #     instructions and writes nothing, which is why the budget counts iterations rather than bytes.
 run "empty matches" \
-    "SELECT length(replaceRegexpAll(repeat(repeat('a', 1000000), 20), '()', '')) FORMAT Null"
+    "SELECT length(replaceRegexpAll(repeat(repeat('a', 1000000), 20), '()', '')) FORMAT Null" throw "" fold
 
 # 12. A replacement of 200000 capture references parsed per row against a needle that never matches: the
 #     whole list is built before any processing loop runs. The haystack must not match, or the case
@@ -142,7 +150,7 @@ run "per-row replacement" \
 #     finished would leave one match uninterruptible. Case 10's list is short enough that the per-match
 #     charge alone fires.
 run "one match, long instruction list" \
-    "SELECT length(replaceRegexpAll(repeat('a', 1000000), '(.*)', repeat('\\\\1', 2000))) FORMAT Null"
+    "SELECT length(replaceRegexpAll(repeat('a', 1000000), '(.*)', repeat('\\\\1', 2000))) FORMAT Null" throw "" fold
 
 # 16. The "replace first" specialization, which leaves the per-row loop at the first match - a different
 #     loop exit from "replace all". Empty haystacks with a per-row pattern make the matcher setup the whole

--- a/tests/queries/0_stateless/04650_replace_cancellation.sh
+++ b/tests/queries/0_stateless/04650_replace_cancellation.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Tags: long, no-fasttest, no-msan, no-parallel, no-coverage
+# Tags: long, no-fasttest, no-msan, no-parallel, no-coverage, no-flaky-check
 # no-msan: that build has no embedded compiler, so case 22 would assert nothing.
 # no-parallel: case 21 samples the process-wide `CurrentMetrics::QueryNonInternal`.
 # no-coverage: per-test coverage instrumentation makes the fixed side of cases 8 and 16 unstable.
+# no-flaky-check: The test verifies a timeout-based behavior and is not suitable for rerun-based flakiness detection.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -25,18 +26,38 @@ BOUND=$((SCALE * 2000))
 # Regexp compilation is pinned off for every case but the one that is about the compiled matcher: the
 # compiled-regexp cache is server-global with a compile threshold of 3, and this test runs up to 5 times,
 # so an earlier run's pattern would already be compiled and the query would finish inside the deadline.
+#
+# Two messages report the same enforced deadline and only one carries a number: `CancellationChecker`
+# can win the race against this function's own check, and its error has no elapsed part. Both are
+# correct stops, so without a number the wall clock is bounded instead, as cases 19 and 20 do.
 run() {
     local label="$1" query="$2" mode="${3:-throw}" query_id="${4:-}"
-    # A verdict rather than the number itself keeps the reference stable across machine speeds.
+    local output start_ms elapsed_ms wall_ms
+    start_ms=$(date +%s%N)
     # shellcheck disable=SC2086
-    timeout 600 ${CLICKHOUSE_CLIENT} --max_execution_time "$DEADLINE" --timeout_overflow_mode "$mode" \
+    output=$(timeout 600 ${CLICKHOUSE_CLIENT} --max_execution_time "$DEADLINE" --timeout_overflow_mode "$mode" \
         --compile_regular_expressions 0 \
         ${query_id:+--query_id "$query_id"} \
-        --query "$query" 2>&1 \
-        | grep -oP 'elapsed \K[0-9]+(?=\.)' \
-        | head -1 \
-        | awk -v l="$label" -v b="$BOUND" '{ print l ": " ($1 < b ? "stopped within bound" : "OVERSHOT " $1 " ms") }' \
-        | grep . || echo "$label: no timeout"
+        --query "$query" 2>&1)
+    wall_ms=$(( ($(date +%s%N) - start_ms) / 1000000 ))
+    elapsed_ms=$(printf '%s' "$output" | grep -oP 'elapsed \K[0-9]+(?=\.)' | head -1)
+    # A verdict rather than the number itself keeps the reference stable across machine speeds.
+    if [ -n "$elapsed_ms" ]; then
+        if [ "$elapsed_ms" -lt "$BOUND" ]; then
+            echo "$label: stopped within bound"
+        else
+            echo "$label: OVERSHOT ${elapsed_ms} ms"
+        fi
+    elif printf '%s' "$output" | grep -q TIMEOUT_EXCEEDED; then
+        # Wall clock covers the whole client call, not server time alone, hence case 19's allowance.
+        if [ "$wall_ms" -lt "$((BOUND * 2))" ]; then
+            echo "$label: stopped within bound"
+        else
+            echo "$label: OVERSHOT ${wall_ms} ms"
+        fi
+    else
+        echo "$label: no timeout"
+    fi
 }
 
 # 1. Constant folding: no pipeline exists while this runs, which is what the original hung-check reports

--- a/tests/queries/0_stateless/04650_replace_cancellation.sh
+++ b/tests/queries/0_stateless/04650_replace_cancellation.sh
@@ -197,9 +197,7 @@ fi
 #     leak. Asserted from both sides. The rows must arrive in one block, or the pipeline's own check bounds
 #     the INSERT whatever the function does.
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS t_replace_stored SYNC"
-# Pinned off here too: the instance built for a stored expression snapshots the compile threshold from the
-# defining statement's context.
-${CLICKHOUSE_CLIENT} --compile_regular_expressions 0 --query "
+${CLICKHOUSE_CLIENT} --query "
     CREATE TABLE t_replace_stored (k String) ENGINE = MergeTree
     PARTITION BY substring(replaceRegexpAll(k, '[0-9]((a|b)(c|d)|(e|f)(g|h))?', 'x'), 1, 1) ORDER BY tuple()"
 run "stored expression" \
@@ -228,7 +226,7 @@ for i in 1 2 3 4 5 6; do
     ${CLICKHOUSE_CLIENT} --query "CREATE TABLE t_replace_stored_$i (k String, v String) ENGINE = MergeTree ORDER BY k"
     # ALTER, not CREATE: a CREATE analyses the expression on a context carrying no query state, so nothing
     # could be captured there and the case would be vacuous.
-    ${CLICKHOUSE_CLIENT} --compile_regular_expressions 0 --max_execution_time "$DEADLINE" --query "
+    ${CLICKHOUSE_CLIENT} --max_execution_time "$DEADLINE" --query "
         ALTER TABLE t_replace_stored_$i ADD INDEX ix replaceRegexpAll(v, '[0-9]', 'x') TYPE set(10) GRANULARITY 1"
 done
 queries_after=$(sample_queries)

--- a/tests/queries/0_stateless/04650_replace_cancellation.sh
+++ b/tests/queries/0_stateless/04650_replace_cancellation.sh
@@ -80,8 +80,10 @@ run "pipe regexp" \
     "SELECT length(replaceRegexpAll(materialize(repeat(repeat('1', 1000000), 60)), materialize('[0-9]((a|b)(c|d)|(e|f)(g|h))?'), materialize('x'))) FROM numbers(1) FORMAT Null"
 
 # 3. Many small rows: the per-row loops, which a checkpoint scoped to a single value would never reach.
+#    max_block_size is pinned like the other per-row cases: the runner randomizes it down to 8000, and a
+#    split block would let the unconditional end-of-call check bound the query on its own.
 run "many rows" \
-    "SELECT sum(length(replaceRegexpAll(materialize(repeat('1', 20000)), materialize('[0-9]{1,3}'), materialize('x')))) FROM numbers(10000)"
+    "SELECT sum(length(replaceRegexpAll(materialize(repeat('1', 20000)), materialize('[0-9]{1,3}'), materialize('x')))) FROM numbers(10000) SETTINGS max_block_size = 10000"
 
 # 4. Many folds, each provably too small to reach a throttled checkpoint, so the three unconditional
 #    per-call checks are the only thing that can stop this query - and the only cover for the bulk-copy

--- a/tests/queries/0_stateless/04650_replace_cancellation.sh
+++ b/tests/queries/0_stateless/04650_replace_cancellation.sh
@@ -245,12 +245,14 @@ done
 #     with a non-constant haystack, a constant non-trivial pattern and a constant replacement, and only
 #     once the pattern has been compiled - hence the two settings and the many short rows.
 #     That the pattern really was compiled is asserted rather than argued, by the `CompileRegexpFunction`
-#     event this PR adds: it is incremented only in `compileMatcher`, and is read back for this query's own
-#     `query_id`. `argMax` over `event_time_microseconds` rather than `sum`, because the stress runner gives
-#     some threads one fixed database for every test, so across repeats the same id accumulates rows and a
-#     sum would answer with an earlier run's compile. The cache must be dropped first for the same reason:
-#     `CacheBase::getOrSet` returns early on a hit without invoking the load lambda, so the increment is
-#     skipped entirely when the pattern is already cached.
+#     event this PR adds: `getRegexpJITMatcher` charges it once the matcher has survived both the holder
+#     construction and the cache insertion, so it cannot claim a compile the query then fell back from, and
+#     it is read back for this query's own `query_id`. `argMax` over `event_time_microseconds` rather than
+#     `sum`, because the stress runner gives some threads one fixed database for every test, so across
+#     repeats the same id accumulates rows and a sum would answer with an earlier run's compile. The cache
+#     must be dropped first for the same reason:
+#     `CacheBase::getOrSet` returns early on a hit without invoking the load lambda, so nothing is compiled
+#     and the event is not charged when the pattern is already cached.
 #     A failed compile is silent by design, and a build with no embedded compiler can never obtain the
 #     matcher, so that is asserted directly: `USE_EMBEDDED_COMPILER` is substituted unconditionally, so on
 #     such a build the row is empty and anything that is not `ON` takes the fail-loud branch.

--- a/tests/queries/0_stateless/04650_replace_cancellation.sh
+++ b/tests/queries/0_stateless/04650_replace_cancellation.sh
@@ -59,9 +59,9 @@ run "many rows" \
 #    fast paths, which return without entering any loop. Each fold's cost is building the matcher, charged
 #    as the pattern's byte count: 130000 bytes is about 8100 units against a 65536-unit budget.
 #    Sizing the folds by their MATCH count instead lets the in-loop check fire, which is what an earlier
-#    version got wrong. The count stays at 60: the folds are chained with '+', and a longer chain is
-#    rejected as too deeply nested on builds with a smaller usable stack.
-FOLDS=$(python3 -c "print(' + '.join(\"length(replaceRegexpAll('zzz%d', repeat('[a-z0-9]{1,2}', 10000), 'x'))\" % i for i in range(60)))")
+#    version got wrong. The folds go in one array rather than a '+' chain: a chain nests one node per
+#    fold and formatting it recurses, which overruns the stack allowance a TSan build gives a query thread.
+FOLDS=$(python3 -c "print('arraySum([' + ', '.join(\"length(replaceRegexpAll('zzz%d', repeat('[a-z0-9]{1,2}', 10000), 'x'))\" % i for i in range(60)) + '])')")
 run "many folds" "SELECT $FOLDS FORMAT Null"
 
 # 5. One match per iteration with a replacement much larger than the match: the whole cost is in the

--- a/tests/queries/0_stateless/04650_replace_cancellation.sh
+++ b/tests/queries/0_stateless/04650_replace_cancellation.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# Tags: long, no-fasttest, no-msan, no-parallel, no-coverage
+# no-msan: that build has no embedded compiler, so case 22 would assert nothing.
+# no-parallel: case 21 samples the process-wide `CurrentMetrics::QueryNonInternal`.
+# no-coverage: per-test coverage instrumentation makes the fixed side of cases 8 and 16 unstable.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Every case bounds the elapsed time the server itself reports in its `TIMEOUT_EXCEEDED` message: the fix
+# bounds it, the unfixed code does not. Each one is sized to keep its prologue - materializing an
+# argument, reading rows, building a block - small and put the cost inside the function, because the
+# prologue is not interruptible by this fix and scales the other way on an optimized build.
+# A sanitizer or coverage build stretches both sides, so the bound scales; coverage never reaches
+# CXX_FLAGS and has to be read from its own `system.build_options` row.
+DEADLINE=1
+SCALE=1
+[ -n "$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS' AND value LIKE '%sanitize=%'")" ] && SCALE=2
+case "$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'WITH_COVERAGE'")" in ON|1) SCALE=2 ;; esac
+BOUND=$((SCALE * 2000))
+
+# $1 = label, $2 = query, $3 = overflow mode (default "throw"), $4 = query id (default none)
+#
+# Regexp compilation is pinned off for every case but the one that is about the compiled matcher: the
+# compiled-regexp cache is server-global with a compile threshold of 3, and this test runs up to 5 times,
+# so an earlier run's pattern would already be compiled and the query would finish inside the deadline.
+run() {
+    local label="$1" query="$2" mode="${3:-throw}" query_id="${4:-}"
+    # A verdict rather than the number itself keeps the reference stable across machine speeds.
+    # shellcheck disable=SC2086
+    timeout 600 ${CLICKHOUSE_CLIENT} --max_execution_time "$DEADLINE" --timeout_overflow_mode "$mode" \
+        --compile_regular_expressions 0 \
+        ${query_id:+--query_id "$query_id"} \
+        --query "$query" 2>&1 \
+        | grep -oP 'elapsed \K[0-9]+(?=\.)' \
+        | head -1 \
+        | awk -v l="$label" -v b="$BOUND" '{ print l ": " ($1 < b ? "stopped within bound" : "OVERSHOT " $1 " ms") }' \
+        | grep . || echo "$label: no timeout"
+}
+
+# 1. Constant folding: no pipeline exists while this runs, which is what the original hung-check reports
+#    showed.
+run "fold regexp" \
+    "SELECT length(replaceRegexpAll(repeat(repeat('1', 1000000), 200), '[0-9]{1,3}', 'x')) FORMAT Null"
+
+# 2. The same work in the pipeline, which makes case 1 non-vacuous: the defect is the missing in-function
+#    checkpoint, not something specific to constant folding. All three arguments must be materialized -
+#    materializing only the haystack selects the JIT-accelerated implementation (case 22).
+run "pipe regexp" \
+    "SELECT length(replaceRegexpAll(materialize(repeat(repeat('1', 1000000), 60)), materialize('[0-9]((a|b)(c|d)|(e|f)(g|h))?'), materialize('x'))) FROM numbers(1) FORMAT Null"
+
+# 3. Many small rows: the per-row loops, which a checkpoint scoped to a single value would never reach.
+run "many rows" \
+    "SELECT sum(length(replaceRegexpAll(materialize(repeat('1', 20000)), materialize('[0-9]{1,3}'), materialize('x')))) FROM numbers(10000)"
+
+# 4. Many folds, each provably too small to reach a throttled checkpoint, so the three unconditional
+#    per-call checks are the only thing that can stop this query - and the only cover for the bulk-copy
+#    fast paths, which return without entering any loop. Each fold's cost is building the matcher, charged
+#    as the pattern's byte count: 130000 bytes is about 8100 units against a 65536-unit budget.
+#    Sizing the folds by their MATCH count instead lets the in-loop check fire, which is what an earlier
+#    version got wrong. The count stays at 60: the folds are chained with '+', and a longer chain is
+#    rejected as too deeply nested on builds with a smaller usable stack.
+FOLDS=$(python3 -c "print(' + '.join(\"length(replaceRegexpAll('zzz%d', repeat('[a-z0-9]{1,2}', 10000), 'x'))\" % i for i in range(60)))")
+run "many folds" "SELECT $FOLDS FORMAT Null"
+
+# 5. One match per iteration with a replacement much larger than the match: the whole cost is in the
+#    generated output, which accounting that looked only at the searched input would price at zero.
+#    Split across independent folds because a single fold large enough to matter races the 5GiB test
+#    profile; each fold's output is released before the next starts.
+EXPAND=$(python3 -c "print(' + '.join(\"length(replaceAll(repeat('%s', 500), '%s', repeat('Y', 1000000)))\" % (c, c) for c in 'qwertyuiopas'))")
+run "expanding replacement" "SELECT $EXPAND FORMAT Null"
+
+# 6. The literal-search implementation reached through the regexp function's trivial-pattern shortcut,
+#    whose delegated call re-traverses the whole value. The needle must be a plain literal, or the
+#    shortcut is not taken and the case duplicates case 2.
+run "regexp fallback to literal" \
+    "SELECT length(replaceRegexpAll(materialize(repeat(repeat('ab', 1000000), 300)), 'ab', 'YZ')) FROM numbers(1) FORMAT Null"
+
+# 7. The same work reached directly through replaceAll rather than through that shortcut.
+run "replaceAll" \
+    "SELECT length(replaceAll(repeat(repeat('ab', 1000000), 300), 'ab', 'YZ')) FORMAT Null"
+
+# 8. Empty haystacks with a different pattern per row: nothing is scanned or written, so all the work is
+#    building one matcher per row. The needle must vary, otherwise the matcher is built once outside the
+#    loop and the case measures nothing. max_block_size is pinned so the whole row set arrives in one call.
+run "per-row matcher setup" \
+    "SELECT sum(length(replaceRegexpAll(materialize(''), toString(number)||'[0-9]{1,3}(a|b|c)+x?', 'y'))) FROM numbers(1000000) SETTINGS max_block_size = 1000000"
+
+# 9. A one-byte needle and replacement on the per-row entry point. It has to be a fold: in the pipeline
+#    the executor's own between-block check bounds the query whatever the function does.
+run "one-byte in place" \
+    "SELECT length(replaceAll(repeat(repeat('ab', 1000000), 300), 'b', 'c')) FORMAT Null"
+
+# 10. Many capture references against an empty capture group: every match executes the whole list while
+#     producing no output, so one checkpoint per match is not enough. The group must be empty and the
+#     references must be substitutions rather than literal bytes.
+run "instruction list" \
+    "SELECT length(replaceRegexpAll(repeat('a', 200000), '()', repeat('\\\\1', 20000))) FORMAT Null"
+
+# 11. A pattern that matches the empty string at every position: each iteration advances one byte, runs no
+#     instructions and writes nothing, which is why the budget counts iterations rather than bytes.
+run "empty matches" \
+    "SELECT length(replaceRegexpAll(repeat(repeat('a', 1000000), 20), '()', '')) FORMAT Null"
+
+# 12. A replacement of 200000 capture references parsed per row against a needle that never matches: the
+#     whole list is built before any processing loop runs. The haystack must not match, or the case
+#     degenerates into case 10; only the needle varies per row, so nothing large has to be materialized.
+run "replacement parsing" \
+    "SELECT sum(length(replaceRegexpAll(materialize(''), toString(number)||'(q)', repeat('\\\\1', 200000)))) FROM numbers(1500) SETTINGS max_block_size = 1500"
+
+# 13. A FixedString haystack, which reaches the regexp loop through its own entry point.
+run "fixed string haystack" \
+    "SELECT sum(length(replaceRegexpAll(toFixedString(materialize(repeat('1', 20000)), 20000), '[0-9]((a|b)(c|d)|(e|f)(g|h))?', 'x'))) FROM numbers(2000) SETTINGS max_block_size = 2000"
+
+# 14. A different replacement per row, which rebuilds the instruction list per row.
+run "per-row replacement" \
+    "SELECT sum(length(replaceRegexpAll(materialize(repeat('1', 20000)), '[0-9]{1,3}', toString(number)))) FROM numbers(10000) SETTINGS max_block_size = 10000"
+
+# 15. A SINGLE match whose instruction list is itself over budget, so charging the list only after the loop
+#     finished would leave one match uninterruptible. Case 10's list is short enough that the per-match
+#     charge alone fires.
+run "one match, long instruction list" \
+    "SELECT length(replaceRegexpAll(repeat('a', 1000000), '(.*)', repeat('\\\\1', 2000))) FORMAT Null"
+
+# 16. The "replace first" specialization, which leaves the per-row loop at the first match - a different
+#     loop exit from "replace all". Empty haystacks with a per-row pattern make the matcher setup the whole
+#     cost, which is the part the early exit does not skip.
+run "replaceRegexpOne" \
+    "SELECT sum(length(replaceRegexpOne(materialize(''), toString(number)||'[0-9]{1,3}(a|b|c)+x?', 'y'))) FROM numbers(1000000) SETTINGS max_block_size = 1000000"
+
+# NOTE. Four charged sites have no case of their own, because under the 5GiB test memory profile none of
+#     them can be made to run past the deadline: the unconditional suffix and remainder copies, the two
+#     FixedString offset loops that follow a bulk copy, and the JIT implementation's output-byte charge and
+#     one-byte in-place fast path. Their charges are verified by inspection. This is why the case numbering
+#     below has gaps.
+
+# 19. The "break" overflow mode, where checkTimeLimit() returns false instead of throwing, so a path that
+#     never calls it ignores the deadline entirely. What is asserted is the wall time, not the presence of
+#     an error: in the pipeline the executor's soft check and this function's check race, and both are
+#     correct stops.
+break_start=$(date +%s%N)
+timeout 600 ${CLICKHOUSE_CLIENT} --max_execution_time "$DEADLINE" --timeout_overflow_mode break \
+    --compile_regular_expressions 0 \
+    --query "SELECT length(replaceRegexpAll(materialize(repeat(repeat('1', 1000000), 60)), materialize('[0-9]((a|b)(c|d)|(e|f)(g|h))?'), materialize('x'))) FROM numbers(1) FORMAT Null" \
+    > /dev/null 2>&1
+break_ms=$(( ($(date +%s%N) - break_start) / 1000000 ))
+if [ "$break_ms" -lt "$((BOUND * 2))" ]; then
+    echo "break pipeline: stopped within bound"
+else
+    echo "break pipeline: OVERSHOT ${break_ms} ms"
+fi
+
+#     A folded call has no way to report a partial result, so there the timeout always surfaces as an
+#     error, as master already does for base58Decode.
+timeout 600 ${CLICKHOUSE_CLIENT} --max_execution_time "$DEADLINE" --timeout_overflow_mode break \
+    --compile_regular_expressions 0 \
+    --query "SELECT length(replaceRegexpAll(repeat(repeat('1', 1000000), 200), '[0-9]{1,3}', 'x')) FORMAT Null" 2>&1 \
+    | grep -o -m1 "TIMEOUT_EXCEEDED" || echo "break fold: no timeout"
+
+# 20. KILL QUERY, a different channel from the elapsed-time limit: it sets the killed flag and surfaces
+#     through a separate branch of the same check. No time limit is set, so only the kill can stop the
+#     query, and what is asserted is how long the synchronous kill waits. Both halves are needed - that
+#     the target was really running, and that KILL reported killing it - otherwise a query that never
+#     started would be "killed" instantly.
+kill_id="${CLICKHOUSE_DATABASE}_replace_kill"
+${CLICKHOUSE_CLIENT} --query_id "$kill_id" --compile_regular_expressions 0 \
+    --query "SELECT length(replaceRegexpAll(repeat(repeat('1', 1000000), 400), '[0-9]{1,3}', 'x')) FORMAT Null" \
+    > /dev/null 2>&1 &
+kill_bg=$!
+kill_seen=0
+for _ in $(seq 1 100); do
+    if [ "$(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.processes WHERE query_id = '$kill_id'")" = 1 ]; then
+        kill_seen=1
+        break
+    fi
+    sleep 0.1
+done
+kill_start=$(date +%s%N)
+kill_rows=$(${CLICKHOUSE_CLIENT} --query "KILL QUERY WHERE query_id = '$kill_id' SYNC FORMAT TSV" 2>/dev/null | grep -c "$kill_id")
+kill_ms=$(( ($(date +%s%N) - kill_start) / 1000000 ))
+wait $kill_bg 2>/dev/null
+if [ "$kill_seen" != 1 ]; then
+    echo "kill query: TARGET NEVER RAN"
+elif [ "$kill_rows" != 1 ]; then
+    echo "kill query: KILL DID NOT REPORT THE TARGET"
+elif [ "$kill_ms" -lt "$((BOUND * 2))" ]; then
+    echo "kill query: killed within bound"
+else
+    echo "kill query: OVERSHOT ${kill_ms} ms"
+fi
+
+# 21. A `replace*` call inside a stored expression (a key, a skip index or a TTL). The instance built while
+#     that expression is analysed is kept for the table's lifetime and executed by unrelated later queries,
+#     so the query to check is the one running the call, not the one that defined it: a definition-time
+#     query would be the wrong deadline and, held alive, a permanent `CurrentMetrics::QueryNonInternal`
+#     leak. Asserted from both sides. The rows must arrive in one block, or the pipeline's own check bounds
+#     the INSERT whatever the function does.
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS t_replace_stored SYNC"
+# Pinned off here too: the instance built for a stored expression snapshots the compile threshold from the
+# defining statement's context.
+${CLICKHOUSE_CLIENT} --compile_regular_expressions 0 --query "
+    CREATE TABLE t_replace_stored (k String) ENGINE = MergeTree
+    PARTITION BY substring(replaceRegexpAll(k, '[0-9]((a|b)(c|d)|(e|f)(g|h))?', 'x'), 1, 1) ORDER BY tuple()"
+run "stored expression" \
+    "INSERT INTO t_replace_stored SELECT repeat('1', 1000000) FROM numbers(40) SETTINGS max_insert_block_size = 40, min_insert_block_size_rows = 40"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE t_replace_stored SYNC"
+
+#     The leak side: a retained QueryStatus keeps the `CurrentMetrics::QueryNonInternal` increment it owns,
+#     so the count never returns to where it was. The assertion is a zero delta rather than a tolerance,
+#     which a drop in either direction would mask: the metric excludes internal queries, so background work
+#     cannot move it, and the test is no-parallel, so every non-internal query in the window is one of this
+#     test's own and cancels in the difference.
+sample_queries() {
+    local m=999999 v
+    for _ in 1 2 3 4 5; do
+        v=$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.metrics WHERE metric = 'QueryNonInternal'")
+        [ "$v" -lt "$m" ] && m=$v
+    done
+    echo "$m"
+}
+
+for i in 1 2 3 4 5 6; do
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS t_replace_stored_$i SYNC"
+done
+queries_before=$(sample_queries)
+for i in 1 2 3 4 5 6; do
+    ${CLICKHOUSE_CLIENT} --query "CREATE TABLE t_replace_stored_$i (k String, v String) ENGINE = MergeTree ORDER BY k"
+    # ALTER, not CREATE: a CREATE analyses the expression on a context carrying no query state, so nothing
+    # could be captured there and the case would be vacuous.
+    ${CLICKHOUSE_CLIENT} --compile_regular_expressions 0 --max_execution_time "$DEADLINE" --query "
+        ALTER TABLE t_replace_stored_$i ADD INDEX ix replaceRegexpAll(v, '[0-9]', 'x') TYPE set(10) GRANULARITY 1"
+done
+queries_after=$(sample_queries)
+if [ "$((queries_after - queries_before))" = 0 ]; then
+    echo "stored expression leak: no query state retained"
+else
+    echo "stored expression leak: RETAINED $((queries_after - queries_before)) query states"
+fi
+for i in 1 2 3 4 5 6; do
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE t_replace_stored_$i SYNC"
+done
+
+# 22. The JIT-compiled regexp matcher, which has its own copy of the substitution loop. It is reached only
+#     with a non-constant haystack, a constant non-trivial pattern and a constant replacement, and only
+#     once the pattern has been compiled - hence the two settings and the many short rows.
+#     That the pattern really was compiled is asserted rather than argued, by the `CompileRegexpFunction`
+#     event this PR adds: it is incremented only in `compileMatcher`, and is read back for this query's own
+#     `query_id`. `argMax` over `event_time_microseconds` rather than `sum`, because the stress runner gives
+#     some threads one fixed database for every test, so across repeats the same id accumulates rows and a
+#     sum would answer with an earlier run's compile. The cache must be dropped first for the same reason:
+#     `CacheBase::getOrSet` returns early on a hit without invoking the load lambda, so the increment is
+#     skipped entirely when the pattern is already cached.
+#     A failed compile is silent by design, and a build with no embedded compiler can never obtain the
+#     matcher, so that is asserted directly: `USE_EMBEDDED_COMPILER` is substituted unconditionally, so on
+#     such a build the row is empty and anything that is not `ON` takes the fail-loud branch.
+JIT_PINS="--compile_expressions 0 --compile_aggregate_expressions 0 --compile_sort_description 0"
+jit_id="${CLICKHOUSE_DATABASE}_replace_jit"
+${CLICKHOUSE_CLIENT} --query "SYSTEM DROP COMPILED EXPRESSION CACHE"
+run "jit matcher" \
+    "SELECT sum(length(replaceRegexpAll(materialize(repeat('1', 10000)), '[0-9]{1,3}', repeat('y', 20)))) FROM numbers(40000) SETTINGS max_block_size = 40000, compile_regular_expressions = 1, min_count_to_compile_regular_expression = 0, compile_expressions = 0, compile_aggregate_expressions = 0, compile_sort_description = 0" \
+    throw "$jit_id"
+${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS query_log"
+# shellcheck disable=SC2086
+jit_regexp_compiles=$(${CLICKHOUSE_CLIENT} $JIT_PINS --query "SELECT argMax(ProfileEvents['CompileRegexpFunction'], event_time_microseconds) FROM system.query_log WHERE query_id = '$jit_id' AND current_database = currentDatabase() AND type IN ('QueryFinish', 'ExceptionWhileProcessing')")
+# shellcheck disable=SC2086
+jit_embedded=$(${CLICKHOUSE_CLIENT} $JIT_PINS --query "SELECT value FROM system.build_options WHERE name = 'USE_EMBEDDED_COMPILER'")
+case "$jit_embedded" in
+    ON|1) if [ "$jit_regexp_compiles" -ge 1 ]; then
+              echo "jit matcher: compiled"
+          else
+              echo "jit matcher: NOT COMPILED, the case ran the interpreted loop"
+          fi ;;
+    *)    echo "jit matcher: NO EMBEDDED COMPILER, the case ran the interpreted loop" ;;
+esac
+
+# 25. A FixedString haystack on the literal implementation, which has its own entry point with its own
+#     per-row offset loop and its own search loop over the whole block. The haystack has to be
+#     materialized: constant arguments are unwrapped to their nested data column before the dispatcher
+#     runs, which leaves the needle no longer constant so no branch matches. A prologue is therefore
+#     unavoidable, so the work per byte is large rather than the data - a needle matching every second byte
+#     - while the replacement stays short so the output cannot outgrow the input.
+#     Sizing this case by its written bytes instead does not work, which is what two earlier versions got
+#     wrong: the output is then what bounds the call, and no single size satisfies a fast and a slow build.
+run "fixed string literal" \
+    "SELECT sum(length(replaceAll(toFixedString(materialize(repeat('ab', 800)), 1600), 'b', 'YY'))) FROM numbers(400000) SETTINGS max_block_size = 400000"

--- a/tests/queries/0_stateless/04650_replace_cancellation.sh
+++ b/tests/queries/0_stateless/04650_replace_cancellation.sh
@@ -88,11 +88,16 @@ run "many rows" \
 # 4. Many folds, each provably too small to reach a throttled checkpoint, so the three unconditional
 #    per-call checks are the only thing that can stop this query - and the only cover for the bulk-copy
 #    fast paths, which return without entering any loop. Each fold's cost is building the matcher, charged
-#    as the pattern's byte count: 130000 bytes is about 8100 units against a 65536-unit budget.
+#    as the pattern's byte count: 32500 bytes is about 2000 units against a 65536-unit budget.
 #    Sizing the folds by their MATCH count instead lets the in-loop check fire, which is what an earlier
 #    version got wrong. The folds go in one array rather than a '+' chain: a chain nests one node per
 #    fold and formatting it recurses, which overruns the stack allowance a TSan build gives a query thread.
-FOLDS=$(python3 -c "print('arraySum([' + ', '.join(\"length(replaceRegexpAll('zzz%d', repeat('[a-z0-9]{1,2}', 10000), 'x'))\" % i for i in range(60)) + '])')")
+#    One fold is the smallest amount of work this can interrupt, because the budget is only consulted
+#    between folds, so the reported time comes out a multiple of a single fold's cost. Many cheap folds
+#    rather than few expensive ones keep that step well inside the deadline: at a pattern of 10000 one
+#    fold cost about a whole deadline on a thread-sanitizer build, leaving the case no room under the
+#    bound. Total pattern bytes are unchanged, so the unfixed side is bounded by nothing as before.
+FOLDS=$(python3 -c "print('arraySum([' + ', '.join(\"length(replaceRegexpAll('zzz%d', repeat('[a-z0-9]{1,2}', 2500), 'x'))\" % i for i in range(240)) + '])')")
 run "many folds" "SELECT $FOLDS FORMAT Null" throw "" fold
 
 # 5. One match per iteration with a replacement much larger than the match: the whole cost is in the
@@ -114,8 +119,12 @@ run "regexp fallback to literal" \
     "SELECT length(replaceRegexpAll(materialize(repeat(repeat('ab', 1000000), 60)), 'ab', 'YZYZYZYZYZYZYZYZYZYZYZYZYZYZYZYZ')) FROM numbers(1) FORMAT Null"
 
 # 7. The same work reached directly through replaceAll rather than through that shortcut.
-run "replaceAll" \
-    "SELECT length(replaceAll(repeat(repeat('ab', 1000000), 300), 'ab', 'YZ')) FORMAT Null" throw "" fold
+#    Split across independent folds like case 5, and for the same two reasons: building one 600MB constant
+#    is not interruptible by this fix and cost about a whole deadline on a thread-sanitizer build, which
+#    left the case no room under the bound, and one value that large also doubled what the query needs
+#    against the test memory profile. Each fold gets its own value so none of them is shared.
+SPLIT_ALL=$(python3 -c "print('arraySum([' + ', '.join(\"length(replaceAll(repeat(repeat('%s', 1000000), 30), '%s', 'YZ'))\" % (p, p) for p in ['ab','cd','ef','gh','ij','kl','mn','op','qr','st']) + '])')")
+run "replaceAll" "SELECT $SPLIT_ALL FORMAT Null" throw "" fold
 
 # 8. Empty haystacks with a different pattern per row: nothing is scanned or written, so all the work is
 #    building one matcher per row. The needle must vary, otherwise the matcher is built once outside the
@@ -124,9 +133,10 @@ run "per-row matcher setup" \
     "SELECT sum(length(replaceRegexpAll(materialize(''), toString(number)||'[0-9]{1,3}(a|b|c)+x?', 'y'))) FROM numbers(1000000) SETTINGS max_block_size = 1000000"
 
 # 9. A one-byte needle and replacement on the per-row entry point. It has to be a fold: in the pipeline
-#    the executor's own between-block check bounds the query whatever the function does.
-run "one-byte in place" \
-    "SELECT length(replaceAll(repeat(repeat('ab', 1000000), 300), 'b', 'c')) FORMAT Null" throw "" fold
+#    the executor's own between-block check bounds the query whatever the function does. Split for the
+#    same reasons as case 7, with a needle that is one byte of each fold's own value.
+SPLIT_ONE=$(python3 -c "print('arraySum([' + ', '.join(\"length(replaceAll(repeat(repeat('%s', 1000000), 30), '%s', '%s'))\" % (h, h[1], r) for (h, r) in [('ab','c'),('cd','e'),('ef','g'),('gh','i'),('ij','k'),('kl','m'),('mn','o'),('op','q'),('qr','s'),('st','u')]) + '])')")
+run "one-byte in place" "SELECT $SPLIT_ONE FORMAT Null" throw "" fold
 
 # 10. Many capture references against an empty capture group: every match executes the whole list while
 #     producing no output, so one checkpoint per match is not enough. The group must be empty and the


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/107941
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes `replaceOne`, `replaceAll`, `replaceRegexpOne` and `replaceRegexpAll` ignoring `max_execution_time` and `KILL QUERY`. A single call now checks for cancellation while it works, so a long-running replacement over a large value or a large number of rows stops instead of holding a server thread until it finishes. Such a call has no partial result to return, so under `timeout_overflow_mode = 'break'` it raises the deadline as an error: always when constant-folded, and in the pipeline whenever this checkpoint is reached before the executor's between-block check, which still stops the query silently.


### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/107941

The four `replace*` functions had no cancellation checkpoint, so one call ran to completion however
long it took. The time limit is only tested between pipeline blocks, and with constant arguments the
function runs during query analysis, before any pipeline exists. On master a debug build runs
`replaceRegexpAll` over a folded 200 MB value with `max_execution_time = 1` to completion, then reports
`Code: 159` with no elapsed time at all because the deadline was never observed. The overshoot is
unbounded in the input, and the same shape is equally unstoppable in the pipeline (70 s over on 200k
rows), so this is a missing in-function check rather than anything specific to constant folding. Same
defect class as the merged #111909, fixed the same way.

`FunctionStringReplace` now builds one cancellation callback per call, and every unboundedly-iterating
loop in both implementations charges a throttled budget against it. One `RE2::Match` or `memcpy` still
runs to completion, so no absolute bound is claimed; what is removed is the unbounded accumulation.

Under `timeout_overflow_mode = 'break'` an uninterruptible `replace*` in the pipeline used to be
stopped by the executor's soft check with no client-visible error. This checkpoint cannot return a
partially rewritten string, so it raises `TIMEOUT_EXCEEDED` instead, as `arrayFold` and `base58Decode`
already do. Which checkpoint wins depends on build speed, so such a query may now report the deadline
where it used to end quietly; both are correct stops.

This addresses 2 of the 30 hung-check artifacts of #107941, so it stays referenced, not closed.

<details>
<summary>Mechanism and validation</summary>

Three unconditional checks bracket the dispatch: before and after expanding a constant argument, and on
the single exit path, covering the seven bulk-copy fast paths that return without searching. The budget
counts iterations rather than bytes, since one iteration can cost a full match attempt while touching
almost no data. Resolving the query per call, rather than capturing it, means a `replace*` stored in a
key, index or TTL is bounded by the query that runs it.

New test `04650_replace_cancellation.sh`: 24 assertions bounding the elapsed time the server reports,
over folded and pipeline calls, both haystack types, constant and per-row needles and replacements,
empty needles, `First` and `All`, interpreted and JIT matchers, `throw` and `break` modes, `KILL QUERY`,
and a stored `PARTITION BY` run by an INSERT. Unfixed these report 2.4 s to 21 s, or nothing at all.

With the five files reverted, **23 of the 24 reference lines differ** on Debug and on an unsanitized
`-O3` build, 20 under TSan; the only line that cannot differ is the leak guard, and each is proven live
by its own mutation. Four further mutations each delete one mechanism's charges and redden that case
only. 50/50 passes on Debug and `-O3`; every flavour matches the reference; 0 TSan reports.

Release build, interleaved per shape, 12 iterations, best/mean ms, master -> fix: 1-byte `replaceAll`
283/305 -> 288/303; literal fallback 1433/1471 -> 1423/1467; regexp fallback 1663/1713 -> 1667/1759;
7-byte `replaceAll` 426/476 -> 407/438.

Five charged sites are documented as not asserted rather than implied covered, each bounded by what one
call may hold under the 5 GiB profile. Tags: `no-msan` (that build has no embedded compiler, so the JIT
case asserts nothing there), `no-parallel` (the leak case reads a global metric), `no-coverage` (per-test
coverage only, whose cost is bursty; the 21 of 24 lines it covered are covered elsewhere).
</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.581` (included in `26.8` and later)
<!-- ch-version-info:end -->