### PR TITLE
Improve `use_const_adaptive_granularity` documenation

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -1714,9 +1714,25 @@ To provide a safeguard against accidentally creating tables with very low
 `index_granularity_bytes`.
 )", 1024) \
     DECLARE(Bool, use_const_adaptive_granularity, false, R"(
-Always use constant granularity for whole part. It allows to compress in
-memory values of index granularity. It can be useful in extremely large
-workloads with thin tables.
+Adaptive granularity (the default, `index_granularity_bytes` is not `0`) keeps
+granules at a constant size in bytes, so their row count varies: for every
+written block, rows per granule is `index_granularity_bytes` divided by the
+average size of a row in that block, capped at `index_granularity`. Because it differs
+from granule to granule, the row count of every granule in the part has to be kept in
+memory, 8 bytes each, which on large tables adds up to tens of gigabytes.
+
+This setting keeps granules at a constant number of rows instead, so their
+size in bytes varies. The number is computed once from the average size of a
+row in the part being written, and a part stores that single value
+instead of one value per granule.
+
+The amount of memory currently spent on these values is reported by the
+`TotalIndexGranularityBytesInMemory` metric in `system.asynchronous_metrics`,
+and per part in `system.parts.index_granularity_bytes_in_memory`.
+
+The setting is applied only to parts written after it was changed. Use
+[ALTER TABLE ... REWRITE PARTS](/sql-reference/statements/alter/partition#rewrite-parts)
+to apply it to existing parts. `Compact` parts always use adaptive granularity.
 )", 0) \
     DECLARE(Bool, enable_index_granularity_compression, true, R"(
 Compress in memory values of index granularity if it is possible

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -1714,17 +1714,18 @@ To provide a safeguard against accidentally creating tables with very low
 `index_granularity_bytes`.
 )", 1024) \
     DECLARE(Bool, use_const_adaptive_granularity, false, R"(
-Adaptive granularity (the default, `index_granularity_bytes` is not `0`) keeps
+Non-const adaptive granularity (the default, `index_granularity_bytes` is not `0`) keeps
 granules at a constant size in bytes, so their row count varies: for every
 written block, rows per granule is `index_granularity_bytes` divided by the
 average size of a row in that block, capped at `index_granularity`. Because it differs
 from granule to granule, the row count of every granule in the part has to be kept in
 memory, 8 bytes each, which on large tables adds up to tens of gigabytes.
 
-This setting keeps granules at a constant number of rows instead, so their
-size in bytes varies. The number is computed once from the average size of a
+Enabling constant adaptive granularity (this setting) keeps granules at a constant number of rows instead,
+so their size in bytes varies. The number is computed once from the average size of a
 row in the part being written, and a part stores that single value
-instead of one value per granule.
+instead of one value per granule. Because all granules contain the same number of rows,
+no additional row count per granule needs to be stored.
 
 The amount of memory currently spent on these values is reported by the
 `TotalIndexGranularityBytesInMemory` metric in `system.asynchronous_metrics`,


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.459` (included in `26.8` and later)
<!-- ch-version-info:end -->