### PR TITLE
Fix `ATTEMPT_TO_READ_AFTER_EOF` on merge of text index with an empty part

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -2353,6 +2353,10 @@ bool MergeTask::MergeTextIndexStage::prepare() const
             {
                 const auto & part = global_ctx->future_part->parts[part_idx];
 
+                /// An empty part contributes nothing to the merged index and its files are empty.
+                if (part->rows_count == 0)
+                    continue;
+
                 if (index_ptr->getDeserializedFormat(*part, index_ptr->getFileName()))
                 {
                     /// If text index exists in the source part, take it as is.

--- a/tests/queries/0_stateless/04654_text_index_merge_with_empty_part.reference
+++ b/tests/queries/0_stateless/04654_text_index_merge_with_empty_part.reference
@@ -1,0 +1,8 @@
+parts before optimize
+1
+0
+parts after optimize
+1
+1
+0
+0

--- a/tests/queries/0_stateless/04654_text_index_merge_with_empty_part.sql
+++ b/tests/queries/0_stateless/04654_text_index_merge_with_empty_part.sql
@@ -1,0 +1,51 @@
+-- Regression test: merging a text index with an empty source part threw `ATTEMPT_TO_READ_AFTER_EOF`.
+-- A mutation that deletes all rows of a part leaves the text index files empty (no granules are
+-- serialized, so not even the header is written) but still listed in the part's checksums, and
+-- `MergeTextIndexesTask` tried to read the header of such a file.
+
+DROP TABLE IF EXISTS t_text_index_merge_with_empty_part;
+
+CREATE TABLE t_text_index_merge_with_empty_part
+(
+    ts DateTime,
+    body String,
+    INDEX idx lower(body) TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY ts
+SETTINGS
+    remove_empty_parts = 0, -- keep the empty part until OPTIMIZE
+    max_bytes_to_merge_at_max_space_in_pool = 1; -- no background merges before OPTIMIZE
+
+INSERT INTO t_text_index_merge_with_empty_part VALUES ('2026-01-01 00:00:00', 'keeper row timeout');
+INSERT INTO t_text_index_merge_with_empty_part VALUES ('2026-01-01 00:00:01', 'doomed row');
+
+-- Turn the second part into an empty part that still carries the (empty) text index files.
+ALTER TABLE t_text_index_merge_with_empty_part DELETE WHERE body = 'doomed row' SETTINGS mutations_sync = 2;
+
+SELECT 'parts before optimize';
+SELECT rows FROM system.parts
+WHERE database = currentDatabase() AND table = 't_text_index_merge_with_empty_part' AND active
+ORDER BY name;
+
+OPTIMIZE TABLE t_text_index_merge_with_empty_part FINAL;
+
+SELECT 'parts after optimize';
+SELECT rows FROM system.parts
+WHERE database = currentDatabase() AND table = 't_text_index_merge_with_empty_part' AND active
+ORDER BY name;
+
+SELECT count() FROM t_text_index_merge_with_empty_part
+WHERE hasToken(lower(body), 'keeper')
+SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT count() FROM t_text_index_merge_with_empty_part
+WHERE hasToken(lower(body), 'doomed')
+SETTINGS force_data_skipping_indices = 'idx';
+
+-- A merge where every source part is empty.
+ALTER TABLE t_text_index_merge_with_empty_part DELETE WHERE 1 SETTINGS mutations_sync = 2;
+OPTIMIZE TABLE t_text_index_merge_with_empty_part FINAL;
+SELECT count() FROM t_text_index_merge_with_empty_part;
+
+DROP TABLE t_text_index_merge_with_empty_part;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `ATTEMPT_TO_READ_AFTER_EOF` error when merging parts with a text index if one of the merged parts was empty, for example after a mutation that deleted all rows of the part.

Fixes #112451.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.412` (included in `26.8` and later)
- Backported to: `26.7.2.50`, `26.6.2.136`
<!-- ch-version-info:end -->