### PR TITLE
Use a scalar subquery's value for an always-constant argument

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -191,6 +191,36 @@ bool isConstantFromScalarSubquery(const ActionsDAG::Node * node)
     return true;
 }
 
+/// Returns the constant a `__scalarSubqueryResult` chain stands for, or nullptr if unavailable.
+/// Unwraps only value-preserving nodes and takes that node's own already-folded constant: never
+/// searches the subtree (an enclosing expression's value is not its descendant's), never executes
+/// (a non-foldable child has no folded column) and never casts (a type mismatch rejects).
+ColumnPtr tryGetScalarSubqueryPayload(const ActionsDAG::Node * node, const DataTypePtr & expected_type)
+{
+    bool unwrapped_scalar_subquery = false;
+    while (true)
+    {
+        while (node->type == ActionsDAG::ActionType::ALIAS)
+            node = node->children.at(0);
+
+        if (node->type != ActionsDAG::ActionType::FUNCTION || node->function_base->getName() != "__scalarSubqueryResult")
+            break;
+
+        unwrapped_scalar_subquery = true;
+        node = node->children.at(0);
+    }
+
+    /// Requiring the wrapper keeps this a no-op for every chain the check above does not already
+    /// accept, in particular a plain `identity`, which is not whitelisted there.
+    if (!unwrapped_scalar_subquery || !node->column || !isColumnConst(*node->column))
+        return nullptr;
+
+    if (!node->result_type->equals(*expected_type))
+        return nullptr;
+
+    return node->column;
+}
+
 }
 
 ActionsDAG::ActionsDAG() = default;
@@ -437,7 +467,12 @@ const ActionsDAG::Node & ActionsDAG::addFunction(
         if (arguments[pos].column && isColumnConst(*arguments[pos].column))
             continue;
 
-        if (isConstantFromScalarSubquery(children[pos]))
+        /// Prefer the value the scalar subquery stands for: `build` below derives the result type
+        /// from this column, so a default here declares a type that disagrees with the value
+        /// execution will use (wrong scale/timezone, or a LOGICAL_ERROR on the type mismatch).
+        if (auto column = tryGetScalarSubqueryPayload(children[pos], arguments[pos].type))
+            arguments[pos].column = std::move(column);
+        else if (isConstantFromScalarSubquery(children[pos]))
             arguments[pos].column = arguments[pos].type->createColumnConstWithDefaultValue(0);
     }
 

--- a/tests/queries/0_stateless/04653_scalar_subquery_result_const_arg_type.reference
+++ b/tests/queries/0_stateless/04653_scalar_subquery_result_const_arg_type.reference
@@ -1,0 +1,39 @@
+-- scale argument: declared type must match the folded value
+DateTime64(1)	1970-01-01 00:00:00.0
+1	1
+1	1
+1970-01-01 00:00:00.0
+12:00:00.0	12:00:00.000
+0.333
+3
+-- timezone argument
+2020-09-13 21:26:40
+2020-09-13 21:26:40.000
+DateTime(\'Asia/Tokyo\')
+2020-09-13 00:00:00
+-- the new analyzer rejects a directly typed wrapper instead of folding it, and still does
+-- a literal in the same position gives the same answers
+DateTime64(1)	1970-01-01 00:00:00.0
+1	1
+12:00:00.000	0.333
+2020-09-13 21:26:40	3
+-- non-foldable children are never executed: still rejected, and no sleep/throwIf runs
+-- only __scalarSubqueryResult is looked through, and only genuine constants are accepted
+1970-01-01 00:00:00
+-- ordinary path unchanged
+1	1
+2020-09-13 21:26:40
+1
+6
+1.234
+2020-09-13 21:26:40
+-- an expression above the wrapper keeps the previous behaviour: the wrapper payload is not the argument value
+Decimal(9, 0)
+-- persisted view/MV column types
+mv_datadep_tz	Nullable(DateTime)
+mv_foldable_tz	Nullable(DateTime(\'Asia/Tokyo\'))
+v_datadep_scale	Nullable(Decimal(9, 0))
+v_foldable_scale	Nullable(Decimal(9, 2))
+v_nested_expr	Nullable(Decimal(9, 0))
+mv_foldable_tz	2020-09-13 21:26:40
+mv_datadep_tz	2020-09-13 12:26:40

--- a/tests/queries/0_stateless/04653_scalar_subquery_result_const_arg_type.reference
+++ b/tests/queries/0_stateless/04653_scalar_subquery_result_const_arg_type.reference
@@ -11,7 +11,7 @@ DateTime64(1)	1970-01-01 00:00:00.0
 2020-09-13 21:26:40.000
 DateTime(\'Asia/Tokyo\')
 2020-09-13 00:00:00
--- the new analyzer rejects a directly typed wrapper instead of folding it, and still does
+-- the analyzer rejects a directly typed wrapper instead of folding it, and still does
 -- a literal in the same position gives the same answers
 DateTime64(1)	1970-01-01 00:00:00.0
 1	1

--- a/tests/queries/0_stateless/04653_scalar_subquery_result_const_arg_type.sql
+++ b/tests/queries/0_stateless/04653_scalar_subquery_result_const_arg_type.sql
@@ -1,0 +1,104 @@
+-- The old analyzer used to install a type-default constant for an always-constant argument hiding
+-- behind `__scalarSubqueryResult`, so the declared result type was derived from a zero/empty value
+-- while execution used the real one. Pinned explicitly because `compatibility` randomization can
+-- flip `enable_analyzer` and silently stop testing the old analyzer.
+SET enable_analyzer = 0;
+-- Results carrying a timezone-less DateTime are rendered in the session timezone, which the test
+-- runner randomizes. The timezone-argument rows below name a timezone explicitly and are unaffected.
+SET session_timezone = 'UTC';
+
+SELECT '-- scale argument: declared type must match the folded value';
+SELECT toTypeName(toDateTime(0, __scalarSubqueryResult(toUInt64(1)))), toDateTime(0, __scalarSubqueryResult(toUInt64(1)))::String;
+SELECT toDecimal32(1, __scalarSubqueryResult(toUInt64(1)))::String, toDecimal64(1, __scalarSubqueryResult(toUInt64(3)))::String;
+SELECT toDecimal128(1, __scalarSubqueryResult(toUInt64(1)))::String, toDecimal256(1, __scalarSubqueryResult(toUInt64(1)))::String;
+SELECT toDateTime64(0, __scalarSubqueryResult(toUInt64(1)))::String;
+SELECT toTime64('12:00:00', __scalarSubqueryResult(toUInt64(1)))::String, toTime64('12:00:00', __scalarSubqueryResult(toUInt64(3)))::String;
+SELECT divideDecimal(toDecimal64(1, 2), toDecimal64(3, 2), __scalarSubqueryResult(toUInt8(3)))::String;
+SELECT length(toFixedString('ab', __scalarSubqueryResult(toUInt8(3))));
+
+SELECT '-- timezone argument';
+SELECT toDateTime(1600000000, __scalarSubqueryResult('Asia/Tokyo'))::String;
+SELECT toDateTime64(1600000000, 3, __scalarSubqueryResult('Asia/Tokyo'))::String;
+SELECT toTypeName(toDateTime('2020-01-01 00:00:00', __scalarSubqueryResult('Asia/Tokyo')));
+SELECT toStartOfDay(toDateTime(1600000000), __scalarSubqueryResult('Asia/Tokyo'))::String;
+
+SELECT '-- the new analyzer rejects a directly typed wrapper instead of folding it, and still does';
+SET enable_analyzer = 1;
+SELECT toStartOfDay(toDateTime(1600000000), __scalarSubqueryResult('Asia/Tokyo'))::String; -- { serverError ILLEGAL_COLUMN }
+SELECT toDateTime(0, __scalarSubqueryResult(toUInt64(1))); -- { serverError ILLEGAL_COLUMN }
+SET enable_analyzer = 0;
+
+SELECT '-- a literal in the same position gives the same answers';
+SELECT toTypeName(toDateTime(0, 1)), toDateTime(0, 1)::String;
+SELECT toDecimal32(1, 1)::String, toDecimal64(1, 3)::String;
+SELECT toTime64('12:00:00', 3)::String, divideDecimal(toDecimal64(1, 2), toDecimal64(3, 2), 3)::String;
+SELECT toDateTime(1600000000, 'Asia/Tokyo')::String, length(toFixedString('ab', 3));
+
+SELECT '-- non-foldable children are never executed: still rejected, and no sleep/throwIf runs';
+SELECT toDecimal32(1, __scalarSubqueryResult(toUInt64(sleep(0.1)))); -- { serverError ILLEGAL_COLUMN }
+SELECT toDecimal32(1, __scalarSubqueryResult(sleep(0.1))); -- { serverError ILLEGAL_COLUMN }
+SELECT toDecimal32(1, __scalarSubqueryResult(toUInt64(rand() % 3))); -- { serverError ILLEGAL_COLUMN }
+SELECT toDecimal32(1, __scalarSubqueryResult(toUInt64(throwIf(1, 'boom')))); -- { serverError ILLEGAL_COLUMN }
+
+SELECT '-- only __scalarSubqueryResult is looked through, and only genuine constants are accepted';
+SELECT toDateTime(0, identity(toUInt64(1))); -- { serverError ILLEGAL_COLUMN }
+SELECT toDecimal32(1, materialize(toUInt64(1))); -- { serverError ILLEGAL_COLUMN }
+SELECT toDateTime(0, __scalarSubqueryResult(toUInt64(0)))::String;
+
+SELECT '-- ordinary path unchanged';
+SELECT toDecimal32(1, 2)::String, toDecimal32(1, (SELECT 2))::String;
+SELECT toDateTime(1600000000, (SELECT 'Asia/Tokyo'))::String;
+SELECT toDecimal32OrZero('1', __scalarSubqueryResult(toUInt64(1)))::String;
+SELECT multiplyDecimal(toDecimal64(2, 2), toDecimal64(3, 2), __scalarSubqueryResult(toUInt8(3)))::String;
+SELECT round(1.2345, __scalarSubqueryResult(toUInt64(3)))::String;
+SELECT toString(toDateTime(1600000000), __scalarSubqueryResult('Asia/Tokyo'));
+
+SELECT '-- an expression above the wrapper keeps the previous behaviour: the wrapper payload is not the argument value';
+-- Only the declared type is asserted here: this shape has a pre-existing value divergence of its own
+-- (the result depends on whether the expression is JIT-compiled), which is out of scope.
+SELECT toTypeName(toDecimal32(1, __scalarSubqueryResult(toUInt64(1)) + 2));
+
+SELECT '-- persisted view/MV column types';
+DROP TABLE IF EXISTS src;
+DROP TABLE IF EXISTS tz;
+DROP TABLE IF EXISTS sc;
+DROP VIEW IF EXISTS v_foldable_scale;
+DROP VIEW IF EXISTS v_datadep_scale;
+DROP VIEW IF EXISTS v_nested_expr;
+DROP TABLE IF EXISTS mv_foldable_tz;
+DROP TABLE IF EXISTS mv_datadep_tz;
+
+CREATE TABLE src (x Int64) ENGINE = Log;
+CREATE TABLE tz (z String) ENGINE = Log;
+CREATE TABLE sc (s UInt8) ENGINE = Log;
+INSERT INTO tz VALUES ('Asia/Tokyo');
+INSERT INTO sc VALUES (2);
+
+-- (a) foldable timezone: type and stored value now match the new analyzer
+CREATE MATERIALIZED VIEW mv_foldable_tz ENGINE = Log AS SELECT toDateTime(x, (SELECT 'Asia/Tokyo')) AS d FROM src;
+-- (b) data-dependent timezone: the scalar is not known while the view is analyzed, so it stays as it was
+CREATE MATERIALIZED VIEW mv_datadep_tz ENGINE = Log AS SELECT toDateTime(x, (SELECT z FROM tz)) AS d FROM src;
+-- (c) foldable scale
+CREATE VIEW v_foldable_scale AS SELECT toDecimal32(1, (SELECT 2)) AS d FROM src;
+-- (d) data-dependent scale
+CREATE VIEW v_datadep_scale AS SELECT toDecimal32(1, (SELECT s FROM sc)) AS d FROM src;
+-- (e) expression above the wrapper: falls back, so unchanged
+CREATE VIEW v_nested_expr AS SELECT toDecimal32(1, (SELECT 2) + 1) AS d FROM src;
+
+SELECT table, type FROM system.columns
+WHERE database = currentDatabase() AND name = 'd'
+  AND table IN ('mv_foldable_tz', 'mv_datadep_tz', 'v_foldable_scale', 'v_datadep_scale', 'v_nested_expr')
+ORDER BY table;
+
+INSERT INTO src VALUES (1600000000);
+SELECT 'mv_foldable_tz', d::String FROM mv_foldable_tz;
+SELECT 'mv_datadep_tz', d::String FROM mv_datadep_tz;
+
+DROP VIEW v_nested_expr;
+DROP VIEW v_datadep_scale;
+DROP VIEW v_foldable_scale;
+DROP TABLE mv_datadep_tz;
+DROP TABLE mv_foldable_tz;
+DROP TABLE sc;
+DROP TABLE tz;
+DROP TABLE src;

--- a/tests/queries/0_stateless/04653_scalar_subquery_result_const_arg_type.sql
+++ b/tests/queries/0_stateless/04653_scalar_subquery_result_const_arg_type.sql
@@ -22,7 +22,7 @@ SELECT toDateTime64(1600000000, 3, __scalarSubqueryResult('Asia/Tokyo'))::String
 SELECT toTypeName(toDateTime('2020-01-01 00:00:00', __scalarSubqueryResult('Asia/Tokyo')));
 SELECT toStartOfDay(toDateTime(1600000000), __scalarSubqueryResult('Asia/Tokyo'))::String;
 
-SELECT '-- the new analyzer rejects a directly typed wrapper instead of folding it, and still does';
+SELECT '-- the analyzer rejects a directly typed wrapper instead of folding it, and still does';
 SET enable_analyzer = 1;
 SELECT toStartOfDay(toDateTime(1600000000), __scalarSubqueryResult('Asia/Tokyo'))::String; -- { serverError ILLEGAL_COLUMN }
 SELECT toDateTime(0, __scalarSubqueryResult(toUInt64(1))); -- { serverError ILLEGAL_COLUMN }
@@ -74,7 +74,7 @@ CREATE TABLE sc (s UInt8) ENGINE = Log;
 INSERT INTO tz VALUES ('Asia/Tokyo');
 INSERT INTO sc VALUES (2);
 
--- (a) foldable timezone: type and stored value now match the new analyzer
+-- (a) foldable timezone: type and stored value now match the analyzer
 CREATE MATERIALIZED VIEW mv_foldable_tz ENGINE = Log AS SELECT toDateTime(x, (SELECT 'Asia/Tokyo')) AS d FROM src;
 -- (b) data-dependent timezone: the scalar is not known while the view is analyzed, so it stays as it was
 CREATE MATERIALIZED VIEW mv_datadep_tz ENGINE = Log AS SELECT toDateTime(x, (SELECT z FROM tz)) AS d FROM src;

--- a/tests/queries/0_stateless/04653_scalar_subquery_result_const_arg_type.sql
+++ b/tests/queries/0_stateless/04653_scalar_subquery_result_const_arg_type.sql
@@ -3,7 +3,7 @@
 -- while execution used the real one. Pinned explicitly because `compatibility` randomization can
 -- flip `enable_analyzer` and silently stop testing the old analyzer.
 SET enable_analyzer = 0;
--- Results carrying a timezone-less DateTime are rendered in the session timezone, which the test
+-- Results carrying a timezone-less `DateTime` are rendered in the session timezone, which the test
 -- runner randomizes. The timezone-argument rows below name a timezone explicitly and are unaffected.
 SET session_timezone = 'UTC';
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/57855


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes wrong results and a logical error when an argument that must be constant, such as the scale of `toDecimal32` or the timezone of `toDateTime`, comes from a scalar subquery and the old analyzer is used. Such an argument was analyzed as if its value were zero or empty, so the declared result type disagreed with the computed value, and `CREATE VIEW` and `CREATE MATERIALIZED VIEW` persisted a wrong column type.


### Description

`ActionsDAG::addFunction` needs a constant column for every argument the callee lists in `getArgumentsThatAreAlwaysConstant`. An argument coming from a scalar subquery is wrapped in `__scalarSubqueryResult`, which suppresses constant folding, so that node carries no column. To satisfy the callee, `addFunction` installed a **type-default** constant instead: zero, or an empty string.

`function->build` then derives the declared result type from that fake zero while execution uses the real value. What breaks depends on which of the two a code path reads:

* Wrong values: `toDecimal32(1, ssr(toUInt64(1)))` returns `10` instead of `1`, and `toDateTime(1600000000, ssr('Asia/Tokyo'))` is 9 hours off (`ssr` is `__scalarSubqueryResult`).
* `toDateTime(0, ssr(toUInt64(1)))` declares `DateTime` but folds to `Const(DateTime64(1))`, tripping the `columnMatchesType` check in `evaluatePartialResult` and aborting a debug or sanitizer build.
* From ordinary SQL, `CREATE MATERIALIZED VIEW mv AS SELECT toDecimal32(x, (SELECT 2)) FROM src` persists `Decimal(9, 0)` where the new analyzer gives `Decimal(9, 2)`. Views created earlier keep their wrong type; only new ones are affected.

The value is available one node down: the wrapper's argument is a foldable `_CAST` of a literal whose column is already materialised. This uses it, so the declared type comes from the value execution will use. The resolver reads only that one node's constant, and only when its type is identical to the argument's. It never searches the subtree (for `__scalarSubqueryResult(1) + 2` the value is 3, not the payload 1), never executes anything (a non-foldable child such as `sleep` has no folded column) and never casts. Without a payload - an expression above the wrapper, or a scalar not known during analysis - the previous default is kept, which is what `CREATE VIEW` has relied on since #57855. The new analyzer already derives the correct type and is untouched.

<details>
<summary>Validation</summary>

Old analyzer, measured against the same expression written with a literal:

| probe | before | after | literal |
|---|---|---|---|
| `toDateTime(0, ssr(toUInt64(1)))` | abort | `1970-01-01 00:00:00.0`, `DateTime64(1)` | same |
| `toDecimal32/64/128/256(1, ssr(toUInt64(1)))` | `10`, `1000`, `10`, `10` | `1`, `1`, `1`, `1` | same |
| `toTime64('12:00:00', ssr(toUInt64(3)))` | `999:59:59` | `12:00:00.000` | same |
| `divideDecimal(..., ssr(toUInt8(3)))` | `0` | `0.333` | same |
| `toDateTime(1600000000, ssr('Asia/Tokyo'))` | `12:26:40` | `21:26:40` | same |
| `CREATE MV ... toDateTime(x, (SELECT 'Asia/Tokyo'))` | `Nullable(DateTime)` | `Nullable(DateTime('Asia/Tokyo'))` | new analyzer's answer |
| `CREATE VIEW ... toDecimal32(1, (SELECT 2))` | `Nullable(Decimal(9,0))` | `Nullable(Decimal(9,2))` | new analyzer's answer |

Two expressions that used to fail on the invalid fabricated value now succeed with the real one:
`toFixedString('ab', ssr(toUInt8(3)))` and `toStartOfDay(dt, ssr('Asia/Tokyo'))`.

Unchanged, and asserted in the test: a data-dependent scalar subquery in `CREATE VIEW`, an expression
above the wrapper, `sleep`, `rand` and `throwIf` children (still `ILLEGAL_COLUMN`, and measurably not
executed), `identity` and `materialize` arguments, scale 0, and the ordinary literal and plain
subquery paths.

`02999_scalar_subqueries_bug_1`, `02999_scalar_subqueries_bug_2`, `01611_constant_folding_subqueries`
and `01029_early_constant_folding` pass, and no reference file in the tree moved. All 79 stateless
tests that create a view whose body contains a scalar subquery were run against both this build and
an unmodified one: identical results. The new test passes 50 out of 50 randomized runs.

A follow-up could carry proven values from `ExecuteScalarSubqueriesVisitor` so a data-dependent scalar
subquery also gets the right type; that is a larger producer-side change, not done here.

</details>