### PR TITLE
Do not apply the lazy `FINAL` rewrite to a bucketed distributed read

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyFinal.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyFinal.cpp
@@ -389,6 +389,16 @@ void optimizeLazyFinal(const Stack & stack, QueryPlan & query_plan, QueryPlan::N
     if (!reading_step->isQueryWithFinal())
         return;
 
+    /// A distributed read (make_distributed_plan) was already pinned to the coordinator's per-bucket
+    /// mark ranges by an earlier optimization pass. Those ranges are chosen so that a deduplication
+    /// group stays inside one bucket, they travel in the `read_bucket` task parameter rather than
+    /// inside the step, and initializePipeline only consumes them while distributed_read_bucket_count
+    /// is non-zero. The replacement reads built below carry no bucket state, so every task would read
+    /// all parts and return the whole deduplicated result. Keep the read whole; the same reasoning
+    /// already disables the projection optimizations for distributed reads.
+    if (reading_step->getDistributedReadBucketCount() > 0)
+        return;
+
     /// Only ReplacingMergeTree is supported.
     const auto & data = reading_step->getMergeTreeData();
     if (data.merging_params.mode != MergeTreeData::MergingParams::Replacing)

--- a/tests/queries/0_stateless/04359_distributed_final_modifiers.reference
+++ b/tests/queries/0_stateless/04359_distributed_final_modifiers.reference
@@ -7,3 +7,15 @@ PREWHERE read distributes	1
 delete local	64000	2560320000
 delete distributed	64000	2560320000
 delete read distributes	1
+lazy WHERE local	133334	26667400003
+lazy WHERE distributed buckets 2	133334	26667400003
+lazy WHERE distributed buckets 4	133334	26667400003
+lazy WHERE distributed buckets 8	133334	26667400003
+lazy WHERE read distributes	1
+lazy PREWHERE distributed	133334	26667400003
+lazy PREWHERE read distributes	1
+lazy no filter local	400000	80001800000
+lazy no filter distributed	400000	80001800000
+lazy off distributed	133334	26667400003
+lazy local still rewrites	1
+lazy local result	26667	1066786668

--- a/tests/queries/0_stateless/04359_distributed_final_modifiers.sql
+++ b/tests/queries/0_stateless/04359_distributed_final_modifiers.sql
@@ -37,3 +37,65 @@ SELECT 'delete read distributes', countIf(explain LIKE '%ReadFromDistributedPlan
 FROM (EXPLAIN PIPELINE SELECT k, v FROM t_del FINAL SETTINGS make_distributed_plan = 1);
 
 DROP TABLE t_del;
+
+-- The lazy FINAL rewrite replaces the reading step with reads that carry no per-bucket mark state, so
+-- it must decline on a bucketed distributed read or every reader task returns the whole deduplicated
+-- result. A larger table is needed here: on 80000 rows the FINAL read is not split into buckets, so
+-- the arms below would pass without exercising the interaction at all.
+-- `optimize_aggregation_in_order` is randomized by the test runner and makes the lazy FINAL rewrite
+-- roughly two orders of magnitude slower on this shape (about 39s versus 0.2s here) without changing
+-- any result. That is pre-existing behaviour of the rewrite and reproduces on master with
+-- `make_distributed_plan = 0`, so pin it here to keep this file fast rather than assert around it.
+SET optimize_aggregation_in_order = 0;
+
+DROP TABLE IF EXISTS t_lazy;
+CREATE TABLE t_lazy (k UInt64, v UInt64, ver UInt64) ENGINE = ReplacingMergeTree(ver) ORDER BY k SETTINGS index_granularity = 256;
+SYSTEM STOP MERGES t_lazy;
+INSERT INTO t_lazy SELECT number, number, 1 FROM numbers(400000);
+INSERT INTO t_lazy SELECT number, number + 5, 2 FROM numbers(400000);
+
+SELECT 'lazy WHERE local', count(), sum(v) FROM t_lazy FINAL WHERE k % 3 = 0 SETTINGS make_distributed_plan = 0;
+SELECT 'lazy WHERE distributed buckets 2', count(), sum(v) FROM t_lazy FINAL WHERE k % 3 = 0
+SETTINGS make_distributed_plan = 1, distributed_plan_default_reader_bucket_count = 2, query_plan_optimize_lazy_final = 1, min_filtered_ratio_for_lazy_final = 0.0;
+SELECT 'lazy WHERE distributed buckets 4', count(), sum(v) FROM t_lazy FINAL WHERE k % 3 = 0
+SETTINGS make_distributed_plan = 1, distributed_plan_default_reader_bucket_count = 4, query_plan_optimize_lazy_final = 1, min_filtered_ratio_for_lazy_final = 0.0;
+SELECT 'lazy WHERE distributed buckets 8', count(), sum(v) FROM t_lazy FINAL WHERE k % 3 = 0
+SETTINGS make_distributed_plan = 1, distributed_plan_default_reader_bucket_count = 8, query_plan_optimize_lazy_final = 1, min_filtered_ratio_for_lazy_final = 0.0;
+SELECT 'lazy WHERE read distributes', countIf(explain LIKE '%ReadFromDistributedPlanSource%') > 0
+FROM (EXPLAIN PIPELINE SELECT k, v FROM t_lazy FINAL WHERE k % 3 = 0
+SETTINGS make_distributed_plan = 1, query_plan_optimize_lazy_final = 1, min_filtered_ratio_for_lazy_final = 0.0);
+
+SELECT 'lazy PREWHERE distributed', count(), sum(v) FROM t_lazy FINAL PREWHERE k % 3 = 0
+SETTINGS make_distributed_plan = 1, query_plan_optimize_lazy_final = 1, min_filtered_ratio_for_lazy_final = 0.0;
+SELECT 'lazy PREWHERE read distributes', countIf(explain LIKE '%ReadFromDistributedPlanSource%') > 0
+FROM (EXPLAIN PIPELINE SELECT k, v FROM t_lazy FINAL PREWHERE k % 3 = 0
+SETTINGS make_distributed_plan = 1, query_plan_optimize_lazy_final = 1, min_filtered_ratio_for_lazy_final = 0.0);
+
+-- Without a filter the rewrite declines on its own, so this arm must be unaffected by the guard.
+SELECT 'lazy no filter local', count(), sum(v) FROM t_lazy FINAL SETTINGS make_distributed_plan = 0;
+SELECT 'lazy no filter distributed', count(), sum(v) FROM t_lazy FINAL
+SETTINGS make_distributed_plan = 1, query_plan_optimize_lazy_final = 1, min_filtered_ratio_for_lazy_final = 0.0;
+
+-- The non-lazy distributed path must keep working: bucketing itself is correct.
+SELECT 'lazy off distributed', count(), sum(v) FROM t_lazy FINAL WHERE k % 3 = 0
+SETTINGS make_distributed_plan = 1, query_plan_optimize_lazy_final = 0;
+
+DROP TABLE t_lazy;
+
+-- The guard keys on the bucket count and not on the setting, so a local FINAL must still be rewritten
+-- by lazy FINAL. A small table is enough and is used deliberately: the rewrite reads every part twice
+-- (once to build the primary-key set, once to read the surviving rows), so running it over the larger
+-- table above would multiply this file's runtime for no extra coverage.
+DROP TABLE IF EXISTS t_lazy_local;
+CREATE TABLE t_lazy_local (k UInt64, v UInt64, ver UInt64) ENGINE = ReplacingMergeTree(ver) ORDER BY k SETTINGS index_granularity = 256;
+SYSTEM STOP MERGES t_lazy_local;
+INSERT INTO t_lazy_local SELECT number, number, 1 FROM numbers(80000);
+INSERT INTO t_lazy_local SELECT number, number + 5, 2 FROM numbers(80000);
+
+SELECT 'lazy local still rewrites', countIf(explain LIKE '%LazyFinalKeyAnalysis%' OR explain LIKE '%LazyReadReplacingFinal%' OR explain LIKE '%LazilyUnordered%') > 0
+FROM (EXPLAIN PLAN SELECT count() FROM t_lazy_local FINAL WHERE k % 3 = 0
+SETTINGS make_distributed_plan = 0, query_plan_optimize_lazy_final = 1, min_filtered_ratio_for_lazy_final = 0.0);
+SELECT 'lazy local result', count(), sum(v) FROM t_lazy_local FINAL WHERE k % 3 = 0
+SETTINGS make_distributed_plan = 0, query_plan_optimize_lazy_final = 1, min_filtered_ratio_for_lazy_final = 0.0;
+
+DROP TABLE t_lazy_local;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/112332


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes wrong results when `make_distributed_plan` and `query_plan_optimize_lazy_final` are both enabled and a `FINAL` query on a `ReplacingMergeTree` also carries a `WHERE` or `PREWHERE`. Each reader task returned the whole deduplicated result, so aggregates were inflated by the number of reader tasks.


### Description

With `make_distributed_plan = 1` and `query_plan_optimize_lazy_final = 1`, a filtered `FINAL` query on a `ReplacingMergeTree` returned each row once per distributed reader task. Against a local oracle of `count() = 133334`: `266668`, `400002` and `666670` at 2, 4 and 8 buckets. `count()` and `sum(v)` inflate by the same factor, so the result is duplicated rather than mis-merged.

Root cause. `tryMakeDistributedRead` bucketizes the read early in `optimizeTree`, building primary-key-range layers so a deduplication group stays inside one bucket. Those mark ranges reach the worker in the `read_bucket` task parameter, which `initializePipeline` only consumes while `distributed_read_bucket_count` is non-zero. The worker re-runs the pass list, where `optimizeLazyFinal` fires and replaces the reading step with fresh reads carrying no bucket state. With the count back at zero, `read_bucket` is ignored and every task merges the whole table, while the exchange still unions them.

This declines the rewrite when the read is bucketed, as `canUseProjectionForReadingStep` already does for the projection passes. Propagating the bucket state instead would be a new distributed-`FINAL` algorithm: a lane's marks are resolved on the worker against a part set the rewrite re-partitions, and the set-building replacement has no notion of a primary-key interval.

Validation. The failure is deterministic but needs a fixture large enough to be bucketed; the reporter's 80000-row table never distributes the `FINAL` read, which is why this never reddened `04359_distributed_final_modifiers`. The new arms assert distribution per arm and compare against the local oracle rather than a bucket multiplier, since the observed factor is the effective task count. Removing the guard reddens exactly the four correctness arms and leaves the five controls green. Lazy `FINAL` is unchanged for local and non-bucketed reads, because the guard keys on the bucket count and not the setting. The `CLICKHOUSE_CLOUD` relaxation in `supportsBucketedRead` is untested here.