### PR TITLE
Fix PromQL error positions

### DIFF
--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
@@ -43,6 +43,12 @@ namespace
     using ResultType = PrometheusQueryResultType;
     using Node = PrometheusQueryTree::Node;
 
+    size_t convertCodePointPositionToByteOffset(std::string_view query, size_t position)
+    {
+        return UTF8::computeBytesBeforeCodePoint(
+            reinterpret_cast<const UInt8 *>(query.data()), query.size(), position);
+    }
+
     /// Handles errors while a promql query is parsed.
     class ErrorListener : public antlr4::BaseErrorListener
     {
@@ -71,7 +77,7 @@ namespace
 
             size_t pos = 0;
             if (offending_symbol)
-                pos = convertCodePointPositionToByteOffset(offending_symbol->getStartIndex());
+                pos = convertCodePointPositionToByteOffset(promql_query, offending_symbol->getStartIndex());
             else  /// `offending_symbol` can be null if `recognizer` is a lexer.
                 pos = convertLineAndPositionInLine(line, position_in_line);
 
@@ -100,12 +106,6 @@ namespace
             auto line_suffix = promql_query.substr(char_index);
             return char_index + UTF8::computeBytesBeforeCodePoint(
                 reinterpret_cast<const UInt8 *>(line_suffix.data()), line_suffix.size(), position_in_line);
-        }
-
-        size_t convertCodePointPositionToByteOffset(size_t position) const
-        {
-            return UTF8::computeBytesBeforeCodePoint(
-                reinterpret_cast<const UInt8 *>(promql_query.data()), promql_query.size(), position);
         }
 
     private:
@@ -158,7 +158,10 @@ namespace
 
         static String getText(const antlr4::tree::TerminalNode * ctx) { return ctx->getSymbol()->getText(); }
 
-        static size_t getStartPos(const antlr4::tree::TerminalNode * ctx) { return ctx->getSymbol()->getStartIndex(); }
+        size_t getStartPos(const antlr4::tree::TerminalNode * ctx) const
+        {
+            return convertCodePointPositionToByteOffset(promql_query, ctx->getSymbol()->getStartIndex());
+        }
 
         bool parseStringLiteral(const antlr4::tree::TerminalNode * ctx, String & result)
         {

--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
@@ -71,7 +71,7 @@ namespace
 
             size_t pos = 0;
             if (offending_symbol)
-                pos = offending_symbol->getStartIndex();
+                pos = convertCodePointPositionToByteOffset(offending_symbol->getStartIndex());
             else  /// `offending_symbol` can be null if `recognizer` is a lexer.
                 pos = convertLineAndPositionInLine(line, position_in_line);
 
@@ -79,7 +79,7 @@ namespace
         }
 
         /// ANTLR4's lexer returns the position of an error as a line number and a position in that line;
-        /// we need to convert them to a char index.
+        /// we need to convert them to a byte offset.
         size_t convertLineAndPositionInLine(size_t line, size_t position_in_line) const
         {
             size_t char_index = 0;
@@ -100,6 +100,12 @@ namespace
             auto line_suffix = promql_query.substr(char_index);
             return char_index + UTF8::computeBytesBeforeCodePoint(
                 reinterpret_cast<const UInt8 *>(line_suffix.data()), line_suffix.size(), position_in_line);
+        }
+
+        size_t convertCodePointPositionToByteOffset(size_t position) const
+        {
+            return UTF8::computeBytesBeforeCodePoint(
+                reinterpret_cast<const UInt8 *>(promql_query.data()), promql_query.size(), position);
         }
 
     private:

--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
@@ -96,7 +96,7 @@ namespace
                     }
                 }
             }
-            return std::max(char_index + position_in_line, promql_query.length());
+            return std::min(char_index + position_in_line, promql_query.length());
         }
 
     private:

--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
@@ -97,9 +97,9 @@ namespace
                     }
                 }
             }
-            auto line = promql_query.substr(char_index);
+            auto line_suffix = promql_query.substr(char_index);
             return char_index + UTF8::computeBytesBeforeCodePoint(
-                reinterpret_cast<const UInt8 *>(line.data()), line.size(), position_in_line);
+                reinterpret_cast<const UInt8 *>(line_suffix.data()), line_suffix.size(), position_in_line);
         }
 
     private:

--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
@@ -1,6 +1,7 @@
 #include <Parsers/Prometheus/PrometheusQueryParsingUtil.h>
 
 #include <Common/Exception.h>
+#include <Common/UTF8Helpers.h>
 
 #include "config.h"
 
@@ -96,7 +97,9 @@ namespace
                     }
                 }
             }
-            return std::min(char_index + position_in_line, promql_query.length());
+            auto line = promql_query.substr(char_index);
+            return char_index + UTF8::computeBytesBeforeCodePoint(
+                reinterpret_cast<const UInt8 *>(line.data()), line.size(), position_in_line);
         }
 
     private:

--- a/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
+++ b/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
@@ -1187,6 +1187,7 @@ TEST(PromQLParser, ErrorPosition)
              {"up\n$down", 3},
              {R"("é"$)", 4},
              {R"("é" "x")", 5},
+             {R"(label_join(up, "dst", "é", "src", "\q"))", 36},
          })
     {
         PrometheusQueryTree query_tree;

--- a/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
+++ b/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
@@ -1185,6 +1185,7 @@ TEST(PromQLParser, LexerErrorPosition)
     for (const auto & [query, expected_error_pos] : std::initializer_list<std::pair<std::string_view, size_t>>{
              {"$metric", 0},
              {"up\n$down", 3},
+             {R"("é"$)", 4},
          })
     {
         PrometheusQueryTree query_tree;

--- a/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
+++ b/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
@@ -1180,12 +1180,13 @@ PrometheusQueryTree(INSTANT_VECTOR):
 }
 
 
-TEST(PromQLParser, LexerErrorPosition)
+TEST(PromQLParser, ErrorPosition)
 {
     for (const auto & [query, expected_error_pos] : std::initializer_list<std::pair<std::string_view, size_t>>{
              {"$metric", 0},
              {"up\n$down", 3},
              {R"("é"$)", 4},
+             {R"("é" "x")", 5},
          })
     {
         PrometheusQueryTree query_tree;

--- a/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
+++ b/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
@@ -1180,6 +1180,23 @@ PrometheusQueryTree(INSTANT_VECTOR):
 }
 
 
+TEST(PromQLParser, LexerErrorPosition)
+{
+    for (const auto & [query, expected_error_pos] : std::initializer_list<std::pair<std::string_view, size_t>>{
+             {"$metric", 0},
+             {"up\n$down", 3},
+         })
+    {
+        PrometheusQueryTree query_tree;
+        String error_message;
+        size_t error_pos = String::npos;
+
+        EXPECT_FALSE(query_tree.tryParse(query, 3, &error_message, &error_pos));
+        EXPECT_EQ(error_pos, expected_error_pos);
+    }
+}
+
+
 TEST(PromQLParser, ParseStringLiterals)
 {
     EXPECT_EQ(parse(R"(


### PR DESCRIPTION
Fix incorrect error positions reported for invalid PromQL queries.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Report the correct position for errors in PromQL queries.

### Description

ANTLR reports lexer errors as a line number and a Unicode code-point column, and parser errors with a token index in the same code-point coordinate space. ClickHouse exposes both error positions as byte offsets into the original UTF-8 query.

The lexer conversion used `std::max(calculated_position, query_length)`, which moved every in-bounds lexer error to the end of the query. In addition, both error paths treated ANTLR's code-point positions as byte offsets, producing incorrect results when a multibyte character appeared earlier in the query.

Convert lexer and parser error positions to UTF-8 byte offsets and clamp them to the available input. The regression test covers lexer errors at the beginning of a query, after a newline, and after a multibyte character, plus a parser error after a multibyte character.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.504` (included in `26.8` and later)
<!-- ch-version-info:end -->