### PR TITLE
Fix deadlock on concurrent resolution of one Filesystem or HDFS table

### DIFF
--- a/src/Databases/DatabaseFilesystem.cpp
+++ b/src/Databases/DatabaseFilesystem.cpp
@@ -32,7 +32,6 @@ namespace Setting
 
 namespace ErrorCodes
 {
-    extern const int LOGICAL_ERROR;
     extern const int UNKNOWN_TABLE;
     extern const int PATH_ACCESS_DENIED;
     extern const int BAD_ARGUMENTS;
@@ -68,15 +67,13 @@ std::string DatabaseFilesystem::getTablePath(const std::string & table_name) con
     return table_path.lexically_normal().string();
 }
 
-void DatabaseFilesystem::addTable(const std::string & table_name, StoragePtr table_storage) const
+StoragePtr DatabaseFilesystem::addTable(const std::string & table_name, StoragePtr table_storage) const
 {
     std::lock_guard lock(mutex);
-    auto [_, inserted] = loaded_tables.emplace(table_name, table_storage);
-    if (!inserted)
-        throw Exception(
-            ErrorCodes::LOGICAL_ERROR,
-            "Table with name `{}` already exists in database `{}` (engine {})",
-            table_name, getDatabaseName(), getEngineName());
+    /// `emplace` keeps the existing entry if the key is already there, so `first->second` is the storage
+    /// a concurrent call for the same name inserted first. Nothing that locks `mutex` again may be called
+    /// here: it is the non-recursive base `IDatabase::mutex`, shared with `getDatabaseName`.
+    return loaded_tables.emplace(table_name, table_storage).first->second;
 }
 
 bool DatabaseFilesystem::checkTableFilePath(const std::string & table_path, ContextPtr context_, bool throw_on_error) const
@@ -161,7 +158,7 @@ StoragePtr DatabaseFilesystem::getTableImpl(const String & name, ContextPtr cont
     /// TableFunctionFile throws exceptions, if table cannot be created.
     auto table_storage = table_function->execute(ast_function_ptr, context_, name);
     if (table_storage)
-        addTable(name, table_storage);
+        return addTable(name, table_storage);
 
     return table_storage;
 }

--- a/src/Databases/DatabaseFilesystem.h
+++ b/src/Databases/DatabaseFilesystem.h
@@ -53,7 +53,9 @@ protected:
 
     std::string getTablePath(const std::string & table_name) const;
 
-    void addTable(const std::string & table_name, StoragePtr table_storage) const;
+    /// Returns the storage that ended up in the cache: `table_storage`, or the one a concurrent call
+    /// for the same name inserted first.
+    StoragePtr addTable(const std::string & table_name, StoragePtr table_storage) const;
 
     bool checkTableFilePath(const std::string & table_path, ContextPtr context_, bool throw_on_error) const;
 

--- a/src/Databases/DatabaseHDFS.cpp
+++ b/src/Databases/DatabaseHDFS.cpp
@@ -36,7 +36,6 @@ namespace Setting
 
 namespace ErrorCodes
 {
-    extern const int LOGICAL_ERROR;
     extern const int UNKNOWN_TABLE;
     extern const int BAD_ARGUMENTS;
     extern const int FILE_DOESNT_EXIST;
@@ -66,15 +65,13 @@ DatabaseHDFS::DatabaseHDFS(const String & name_, const String & source_url, Cont
     }
 }
 
-void DatabaseHDFS::addTable(const std::string & table_name, StoragePtr table_storage) const
+StoragePtr DatabaseHDFS::addTable(const std::string & table_name, StoragePtr table_storage) const
 {
     std::lock_guard lock(mutex);
-    auto [_, inserted] = loaded_tables.emplace(table_name, table_storage);
-    if (!inserted)
-        throw Exception(
-            ErrorCodes::LOGICAL_ERROR,
-            "Table with name `{}` already exists in database `{}` (engine {})",
-            table_name, getDatabaseName(), getEngineName());
+    /// `emplace` keeps the existing entry if the key is already there, so `first->second` is the storage
+    /// a concurrent call for the same name inserted first. Nothing that locks `mutex` again may be called
+    /// here: it is the non-recursive base `IDatabase::mutex`, shared with `getDatabaseName`.
+    return loaded_tables.emplace(table_name, table_storage).first->second;
 }
 
 std::string DatabaseHDFS::getTablePath(const std::string & table_name) const
@@ -138,7 +135,7 @@ StoragePtr DatabaseHDFS::getTableImpl(const String & name, ContextPtr context_) 
     /// TableFunctionHDFS throws exceptions, if table cannot be created.
     auto table_storage = table_function->execute(args, context_, name);
     if (table_storage)
-        addTable(name, table_storage);
+        return addTable(name, table_storage);
 
     return table_storage;
 }

--- a/src/Databases/DatabaseHDFS.h
+++ b/src/Databases/DatabaseHDFS.h
@@ -49,7 +49,9 @@ protected:
     ASTPtr getCreateDatabaseQueryImpl() const override TSA_REQUIRES(mutex);
     StoragePtr getTableImpl(const String & name, ContextPtr context) const;
 
-    void addTable(const std::string & table_name, StoragePtr table_storage) const;
+    /// Returns the storage that ended up in the cache: `table_storage`, or the one a concurrent call
+    /// for the same name inserted first.
+    StoragePtr addTable(const std::string & table_name, StoragePtr table_storage) const;
 
     bool checkUrl(const std::string & url, ContextPtr context_, bool throw_on_error) const;
 

--- a/tests/queries/0_stateless/04653_database_filesystem_concurrent_resolve.reference
+++ b/tests/queries/0_stateless/04653_database_filesystem_concurrent_resolve.reference
@@ -1,4 +1,3 @@
-distinct results:
-4
-result count: 16
+Queries executed: 16
+exceptions: 0
 still usable: 10

--- a/tests/queries/0_stateless/04653_database_filesystem_concurrent_resolve.reference
+++ b/tests/queries/0_stateless/04653_database_filesystem_concurrent_resolve.reference
@@ -1,0 +1,4 @@
+distinct results:
+4
+result count: 16
+still usable: 10

--- a/tests/queries/0_stateless/04653_database_filesystem_concurrent_resolve.sh
+++ b/tests/queries/0_stateless/04653_database_filesystem_concurrent_resolve.sh
@@ -26,33 +26,36 @@ CREATE DATABASE ${DB} ENGINE = Filesystem;
 # `DatabaseFilesystem::getTableImpl`. The loser of that race used to reach a throw whose message
 # re-locked the already-held non-recursive `IDatabase::mutex`, wedging the database forever.
 #
-# The oracle is the deadlock itself: that all 16 clients return at all, and that the database is
-# still usable afterwards. Which of the racing storages a loser receives is deliberately not
-# asserted, because a `Filesystem` database exposes no table cache to SQL - `loaded_tables` has no
-# reference outside the engine and `getTablesIterator` returns an empty snapshot, so winner and
-# loser are indistinguishable from a query. The glob name is chosen for the width of the race
-# window, not for cache residency: `tryGetTableFromCache` invalidates an entry whenever
-# `fs::exists` fails on the table path, and that path is the literal glob pattern, so a glob
-# entry is dropped again on every lookup.
+# The oracle is the deadlock itself: that all 16 racing queries finish, that each returns the
+# expected count, and that the database is still usable afterwards. Which of the racing storages a
+# loser receives is deliberately not asserted, because a `Filesystem` database exposes no table
+# cache to SQL - `loaded_tables` has no reference outside the engine and `getTablesIterator`
+# returns an empty snapshot, so winner and loser are indistinguishable from a query. The glob name
+# is chosen for the width of the race window, not for cache residency: `tryGetTableFromCache`
+# invalidates an entry whenever `fs::exists` fails on the table path, and that path is the literal
+# glob pattern, so a glob entry is dropped again on every lookup.
 TABLE="${unique_name}/**/*.csv"
-QUERY="SELECT count(DISTINCT _path) FROM ${DB}.\`${TABLE}\` SETTINGS optimize_count_from_files = 1"
 
-out="${CLICKHOUSE_TMP}/${unique_name}_04653_out.txt"
-: > "${out}"
-for _ in {1..16}; do
-    ${CLICKHOUSE_CLIENT} --query "${QUERY}" >> "${out}" 2>&1 &
-done
-wait
+# Keep this to ONE driver process: the flaky check runs `nproc-1` copies of this test at once, so
+# a client per racing query multiplies into enough concurrent clients to exhaust the runner's
+# memory cgroup. Benchmark's `--concurrency` connections are independent, so they still race.
+#
+# `throwIf` is what asserts the count, because benchmark reads result blocks only for its
+# statistics and discards the values. Do not add `--ignore-error`, or a failing query stops
+# aborting the run.
+QUERY="SELECT throwIf(count(DISTINCT _path) != 4) FROM ${DB}.\`${TABLE}\` SETTINGS optimize_count_from_files = 1"
 
-# Every query must have returned the same count. A wedged database shows up as missing lines:
-# the clients never return and `clickhouse-test` kills the test on its own timeout.
-echo "distinct results:"
-sort -u "${out}"
-echo "result count: $(grep -c . "${out}")"
+# The report goes to stderr, and only after every query has finished, so a failed or wedged run
+# has no `Queries executed` line at all.
+log="${CLICKHOUSE_TMP}/${unique_name}_04653_bench.log"
+${CLICKHOUSE_BENCHMARK} --delay 0 --iterations 16 --concurrency 16 --query "${QUERY}" >/dev/null 2>"${log}"
+
+grep -o 'Queries executed: 16' "${log}"
+echo "exceptions: $(grep -c 'Exception' "${log}")"
 
 # The database must still be usable. With `mutex` held forever, this query never returns.
 echo "still usable: $(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${DB}.\`${TABLE}\`")"
 
 ${CLICKHOUSE_CLIENT} --query "DROP DATABASE ${DB}"
-rm -f "${out}"
+rm -f "${log}"
 rm -rd "${user_files_tmp_dir}"

--- a/tests/queries/0_stateless/04653_database_filesystem_concurrent_resolve.sh
+++ b/tests/queries/0_stateless/04653_database_filesystem_concurrent_resolve.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: needs the user_files directory, which clickhouse-local in Fast test does not provide.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+unique_name=${CLICKHOUSE_TEST_UNIQUE_NAME}
+user_files_tmp_dir=${USER_FILES_PATH}/${unique_name}
+mkdir -p "${user_files_tmp_dir}"/nested/
+
+# Several files, all with the same schema, some nested: `**/*.csv` then has real globbing and schema
+# inference to do, which is what widens the race window in getTableImpl. Keeping one schema across
+# every file is deliberate, so that reading the glob is deterministic under format randomization.
+printf '"id","str"\n1,"a"\n2,"b"\n' > "${user_files_tmp_dir}"/one.csv
+printf '"id","str"\n3,"c"\n4,"d"\n5,"e"\n' > "${user_files_tmp_dir}"/two.csv
+printf '"id","str"\n6,"f"\n' > "${user_files_tmp_dir}"/nested/three.csv
+printf '"id","str"\n7,"g"\n8,"h"\n9,"i"\n10,"j"\n' > "${user_files_tmp_dir}"/nested/four.csv
+
+DB="${CLICKHOUSE_DATABASE}_fs"
+${CLICKHOUSE_CLIENT} --multiline -q "
+DROP DATABASE IF EXISTS ${DB};
+CREATE DATABASE ${DB} ENGINE = Filesystem;
+"
+
+# Resolving one table name concurrently races the cache probe against the cache insert in
+# DatabaseFilesystem::getTableImpl. The loser of that race used to reach a throw whose message
+# re-locked the already-held non-recursive IDatabase::mutex, wedging the database forever.
+TABLE="${unique_name}/**/*.csv"
+QUERY="SELECT count(DISTINCT _path) FROM ${DB}.\`${TABLE}\` SETTINGS optimize_count_from_files = 1"
+
+out="${CLICKHOUSE_TMP}/${unique_name}_04653_out.txt"
+: > "${out}"
+for _ in {1..16}; do
+    ${CLICKHOUSE_CLIENT} --query "${QUERY}" >> "${out}" 2>&1 &
+done
+wait
+
+# Every query must have returned the same count. A wedged database shows up as missing lines:
+# the clients never return and clickhouse-test kills the test on its own timeout.
+echo "distinct results:"
+sort -u "${out}"
+echo "result count: $(grep -c . "${out}")"
+
+# The database must still be usable. With the mutex held forever, this query never returns.
+echo "still usable: $(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${DB}.\`${TABLE}\`")"
+
+${CLICKHOUSE_CLIENT} --query "DROP DATABASE ${DB}"
+rm -f "${out}"
+rm -rd "${user_files_tmp_dir}"

--- a/tests/queries/0_stateless/04653_database_filesystem_concurrent_resolve.sh
+++ b/tests/queries/0_stateless/04653_database_filesystem_concurrent_resolve.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
-# no-fasttest: needs the user_files directory, which clickhouse-local in Fast test does not provide.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -11,7 +9,7 @@ user_files_tmp_dir=${USER_FILES_PATH}/${unique_name}
 mkdir -p "${user_files_tmp_dir}"/nested/
 
 # Several files, all with the same schema, some nested: `**/*.csv` then has real globbing and schema
-# inference to do, which is what widens the race window in getTableImpl. Keeping one schema across
+# inference to do, which is what widens the race window in `getTableImpl`. Keeping one schema across
 # every file is deliberate, so that reading the glob is deterministic under format randomization.
 printf '"id","str"\n1,"a"\n2,"b"\n' > "${user_files_tmp_dir}"/one.csv
 printf '"id","str"\n3,"c"\n4,"d"\n5,"e"\n' > "${user_files_tmp_dir}"/two.csv
@@ -25,8 +23,17 @@ CREATE DATABASE ${DB} ENGINE = Filesystem;
 "
 
 # Resolving one table name concurrently races the cache probe against the cache insert in
-# DatabaseFilesystem::getTableImpl. The loser of that race used to reach a throw whose message
-# re-locked the already-held non-recursive IDatabase::mutex, wedging the database forever.
+# `DatabaseFilesystem::getTableImpl`. The loser of that race used to reach a throw whose message
+# re-locked the already-held non-recursive `IDatabase::mutex`, wedging the database forever.
+#
+# The oracle is the deadlock itself: that all 16 clients return at all, and that the database is
+# still usable afterwards. Which of the racing storages a loser receives is deliberately not
+# asserted, because a `Filesystem` database exposes no table cache to SQL - `loaded_tables` has no
+# reference outside the engine and `getTablesIterator` returns an empty snapshot, so winner and
+# loser are indistinguishable from a query. The glob name is chosen for the width of the race
+# window, not for cache residency: `tryGetTableFromCache` invalidates an entry whenever
+# `fs::exists` fails on the table path, and that path is the literal glob pattern, so a glob
+# entry is dropped again on every lookup.
 TABLE="${unique_name}/**/*.csv"
 QUERY="SELECT count(DISTINCT _path) FROM ${DB}.\`${TABLE}\` SETTINGS optimize_count_from_files = 1"
 
@@ -38,12 +45,12 @@ done
 wait
 
 # Every query must have returned the same count. A wedged database shows up as missing lines:
-# the clients never return and clickhouse-test kills the test on its own timeout.
+# the clients never return and `clickhouse-test` kills the test on its own timeout.
 echo "distinct results:"
 sort -u "${out}"
 echo "result count: $(grep -c . "${out}")"
 
-# The database must still be usable. With the mutex held forever, this query never returns.
+# The database must still be usable. With `mutex` held forever, this query never returns.
 echo "still usable: $(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${DB}.\`${TABLE}\`")"
 
 ${CLICKHOUSE_CLIENT} --query "DROP DATABASE ${DB}"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/107941


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a deadlock that permanently wedges a `Filesystem` or `HDFS` database when two queries resolve the same table name at the same time. Every later query against that database blocks forever and cannot be interrupted, so the server needs a restart to recover.

### Description

`DatabaseFilesystem::getTableImpl` probes the table cache and inserts into it under two separate mutex acquisitions, with schema inference between. Two same-name queries both miss, both build a storage, and the loser reaches a `throw` in `addTable` whose message calls `IDatabase::getDatabaseName`, which locks the non-recursive `IDatabase::mutex` `addTable` already holds, so the thread parks forever holding it.

Every later access blocks in `tryGetTableFromCache`, and a `std::mutex` wait has no cancellation point, so neither `KILL QUERY` nor the hung-check breaks it. `DatabaseHDFS` has a byte-identical `addTable`.

One mechanical change per engine: `addTable` returns `loaded_tables.emplace(...).first->second` and `getTableImpl` returns that, yielding the cached storage whether or not the insert happened. Losing the race becomes benign, and deleting the throw takes the accessor out from under the lock.

Found by `Stress test (arm_debug)` on an unrelated PR ([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111787&sha=51e1fb2b3f967df52a6eee66aedadb67f4d33889&name_0=PR&name_1=Stress%20test%20%28arm_debug%29)): 56 of 61 stuck queries queued behind one self-deadlocked thread. It recurred on 111990 (`amd_debug`), 62 of 74 stuck rows on this mutex.

A new stateless test hangs on unmodified master. Restoring the original `addTable` makes it hang in 20 of 20 runs, against 20 of 20 green with the fix. 50 randomized runs pass. Sweeping every `mutex` scope in `src/Databases/` for calls to the four `IDatabase` accessors that relock it finds these two.

It drives those 16 resolutions from one `clickhouse-benchmark` process, not 16 background clients: the flaky check runs `nproc-1` copies at once, so a client per racing query exhausted the runner's memory cgroup, reporting `Server died` with no results. Peak clients go 121 to 8; `--concurrency` connections are independent, so the race is unchanged and `throwIf` checks all 16.

Coverage boundary: the oracle is the deadlock, not which storage a loser gets, since a `Filesystem` database exposes no table cache to SQL. `DatabaseHDFS` has no test coverage, so its identical fix rests on that sweep.
