### PR TITLE
Record the pipeline column type when a mutation rewrites a whole part

### DIFF
--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -675,6 +675,11 @@ static bool isDeletedMaskUpdated(const MutationCommand & command, const NameSet 
 }
 
 /// Get the columns list of the resulting part in the same order as storage_columns.
+/// `rewrites_all_columns` tells whether the mutation will re-serialize every column of the part
+/// (MutateAllPartColumnsTask) rather than only the ones it updates. A re-serialized column is
+/// written from the mutation pipeline, which produces the storage type, so it must be recorded
+/// with the storage type; a column whose bytes are carried over unchanged keeps the source part's
+/// type, which may legitimately differ (e.g. after a metadata-only `T` -> `Nullable(T)` ALTER).
 static std::tuple<NamesAndTypesList, SerializationInfoByName, ColumnsSubstreams>
 getColumnsForNewDataPart(
     MergeTreeData::DataPartPtr source_part,
@@ -683,7 +688,8 @@ getColumnsForNewDataPart(
     NamesAndTypesList persistent_virtuals,
     const SerializationInfoByName & serialization_infos,
     const MutationCommands & commands_for_interpreter,
-    const MutationCommands & commands_for_removes)
+    const MutationCommands & commands_for_removes,
+    bool rewrites_all_columns)
 {
     MutationCommands all_commands;
     all_commands.insert(all_commands.end(), commands_for_interpreter.begin(), commands_for_interpreter.end());
@@ -900,6 +906,18 @@ getColumnsForNewDataPart(
                     source_col = source_columns_name_to_type.find(renamed_it->second);
                     if (source_col == source_columns_name_to_type.end())
                         it = storage_columns.erase(it);
+                    else if (rewrites_all_columns)
+                    {
+                        /// Keep the storage type. The source column's substream names carry the old
+                        /// name, so they cannot be reused either.
+                        if (fill_columns_substreams)
+                        {
+                            new_columns_substreams.addColumn(it->name);
+                            new_columns_substreams.addSubstreamToLastColumn(NOT_YET_WRITTEN_COLUMN_SUBSTREAM_PLACEHOLDER);
+                        }
+
+                        ++it;
+                    }
                     else
                     {
                         /// Take a type from source part column.
@@ -953,10 +971,33 @@ getColumnsForNewDataPart(
                                 "Got incorrect mutation commands, column {} was renamed from {}, but it doesn't exist in source columns {}",
                                 it->name, renamed_from, source_columns.toString());
 
-                        it->type = maybe_name_and_type->type;
+                        if (rewrites_all_columns)
+                        {
+                            /// Keep the storage type, as below.
+                            if (fill_columns_substreams)
+                            {
+                                new_columns_substreams.addColumn(it->name);
+                                new_columns_substreams.addSubstreamToLastColumn(NOT_YET_WRITTEN_COLUMN_SUBSTREAM_PLACEHOLDER);
+                            }
+                        }
+                        else
+                        {
+                            it->type = maybe_name_and_type->type;
 
+                            if (fill_columns_substreams)
+                                addRenamedColumnToColumnsSubstreams(new_columns_substreams, source_columns_substreams, it->name, renamed_from, *source_part->getColumnPosition(renamed_from));
+                        }
+                    }
+                    else if (rewrites_all_columns)
+                    {
+                        /// Keep the storage type `it->type` already holds. Its substreams follow that
+                        /// type and are only known once the writer has seen the first block, so
+                        /// record the placeholder as for any other not-yet-written column.
                         if (fill_columns_substreams)
-                            addRenamedColumnToColumnsSubstreams(new_columns_substreams, source_columns_substreams, it->name, renamed_from, *source_part->getColumnPosition(renamed_from));
+                        {
+                            new_columns_substreams.addColumn(it->name);
+                            new_columns_substreams.addSubstreamToLastColumn(NOT_YET_WRITTEN_COLUMN_SUBSTREAM_PLACEHOLDER);
+                        }
                     }
                     else
                     {
@@ -3603,9 +3644,22 @@ bool MutateTask::prepare()
     /// It shouldn't be changed by mutation.
     ctx->new_data_part->index_granularity_info = ctx->source_part->index_granularity_info;
 
+    /// Whether this mutation re-serializes every column of the part rather than updating only some
+    /// of them: all columns from part are changed and may be some more that were missing before in
+    /// part. Decided here rather than at the task instantiation below because the resulting part's
+    /// column types depend on it (see getColumnsForNewDataPart).
+    /// TODO We can materialize compact part without copying data
+    /// Also currently mutations of types with dynamic subcolumns in Wide part are possible only by
+    /// rewriting the whole part.
+    const bool rewrites_all_columns = MutationHelpers::haveMutationsOfDynamicColumns(ctx->source_part, ctx->commands_for_part)
+        || MutationHelpers::hasDynamicColumnsWithoutRecordedSubstreams(ctx->source_part)
+        || !isWidePart(ctx->source_part)
+        || !isFullPartStorage(ctx->source_part->getDataPartStorage())
+        || (ctx->interpreter && ctx->interpreter->isAffectingAllColumns());
+
     auto [new_columns, new_infos, new_columns_substreams] = MutationHelpers::getColumnsForNewDataPart(
         ctx->source_part, ctx->updated_header, ctx->storage_columns, ctx->metadata_snapshot->virtuals.getSampleBlock(VirtualsKind::Persistent, VirtualsMaterializationPlace::Reader).getNamesAndTypesList(),
-        ctx->source_part->getSerializationInfos(), ctx->for_interpreter, ctx->for_file_renames);
+        ctx->source_part->getSerializationInfos(), ctx->for_interpreter, ctx->for_file_renames, rewrites_all_columns);
 
     ctx->new_data_part->setColumns(new_columns, new_infos, ctx->metadata_snapshot->getMetadataVersion());
     if (!new_columns_substreams.empty())
@@ -3641,15 +3695,7 @@ bool MutateTask::prepare()
         ctx->new_data_part->existing_rows_count = ctx->source_part->existing_rows_count.value_or(ctx->source_part->rows_count);
     }
 
-    /// All columns from part are changed and may be some more that were missing before in part
-    /// TODO We can materialize compact part without copying data
-    /// Also currently mutations of types with dynamic subcolumns in Wide part are possible only by
-    /// rewriting the whole part.
-    if (MutationHelpers::haveMutationsOfDynamicColumns(ctx->source_part, ctx->commands_for_part)
-        || MutationHelpers::hasDynamicColumnsWithoutRecordedSubstreams(ctx->source_part)
-        || !isWidePart(ctx->source_part)
-        || !isFullPartStorage(ctx->source_part->getDataPartStorage())
-        || (ctx->interpreter && ctx->interpreter->isAffectingAllColumns()))
+    if (rewrites_all_columns)
     {
         /// In case of replicated merge tree with zero copy replication
         /// Here Clickhouse claims that this new part can be deleted in temporary state without unlocking the blobs

--- a/tests/queries/0_stateless/04653_mutation_full_rewrite_records_pipeline_column_type.reference
+++ b/tests/queries/0_stateless/04653_mutation_full_rewrite_records_pipeline_column_type.reference
@@ -1,0 +1,26 @@
+-- String, Wide: part type follows the full rewrite
+String	0
+Nullable(String)	1
+str	0
+1
+-- String, Compact: same rule
+Compact	String
+Nullable(String)
+str	0
+-- numeric T -> Nullable(T)
+UInt64	0
+Nullable(UInt64)	1
+7	0
+-- Variant extension
+Variant(String, UInt64)
+Variant(Float64, String, UInt64)
+1	7
+-- RENAME of a column whose part type lags
+String
+Nullable(String)	1
+1	str	0
+-- must not regress: a partial mutation still keeps the source part type
+part	String	0
+storage	Nullable(String)
+part-after-partial	String	0
+1	str	0	20

--- a/tests/queries/0_stateless/04653_mutation_full_rewrite_records_pipeline_column_type.sql
+++ b/tests/queries/0_stateless/04653_mutation_full_rewrite_records_pipeline_column_type.sql
@@ -1,0 +1,162 @@
+-- A part whose column type legitimately lags the storage type (metadata-only `T` -> `Nullable(T)`
+-- and Variant-extension ALTERs skip the data rewrite) must be recorded with the type the mutation
+-- actually writes: the pipeline/storage type when the mutation re-serializes every column, the
+-- source part's type when it carries the column's files over unchanged.
+--
+-- `enable_block_number_column` is what selects the full-rewrite mode here: it appends a
+-- `READ_COLUMN _block_number` command, which makes the interpreter's last stage cover every
+-- storage column, so `isAffectingAllColumns()` holds.
+--
+-- `has(substreams, ...)` rather than the whole list because `string_serialization_version` is
+-- randomized and decides whether a `.size` substream exists; the `.null` one is what the corrected
+-- type requires.
+
+SET allow_experimental_variant_type = 1;
+SET allow_suspicious_variant_types = 1;
+
+SELECT '-- String, Wide: part type follows the full rewrite';
+
+DROP TABLE IF EXISTS t_full_rewrite_str;
+CREATE TABLE t_full_rewrite_str (s String) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS min_bytes_for_wide_part = 0,
+         -- `tdigest` is not supported for String, so the column ends up with no statistics, which
+         -- is what lets `canSkipConversionToNullable` take the metadata-only path below.
+         auto_statistics_types = 'tdigest',
+         enable_block_number_column = true;
+
+INSERT INTO t_full_rewrite_str SELECT 'str' FROM numbers(1);
+
+ALTER TABLE t_full_rewrite_str MODIFY COLUMN s Nullable(String) SETTINGS mutations_sync = 2;
+-- Metadata-only: the part still holds non-nullable data.
+SELECT type, has(substreams, 's.null') FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_full_rewrite_str' AND active AND column = 's';
+
+ALTER TABLE t_full_rewrite_str ADD PROJECTION p1 (SELECT s ORDER BY s);
+ALTER TABLE t_full_rewrite_str MATERIALIZE PROJECTION p1 SETTINGS mutations_sync = 2;
+-- Every column was re-serialized from the storage-typed pipeline, so the part records
+-- Nullable(String) and grows the `.null` substream that type requires.
+SELECT type, has(substreams, 's.null') FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_full_rewrite_str' AND active AND column = 's';
+SELECT s, s.null FROM t_full_rewrite_str;
+CHECK TABLE t_full_rewrite_str SETTINGS check_query_single_value_result = 1;
+
+DROP TABLE t_full_rewrite_str;
+
+SELECT '-- String, Compact: same rule';
+
+DROP TABLE IF EXISTS t_full_rewrite_compact;
+CREATE TABLE t_full_rewrite_compact (s String) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000,
+         auto_statistics_types = 'tdigest',
+         enable_block_number_column = true;
+
+INSERT INTO t_full_rewrite_compact SELECT 'str' FROM numbers(1);
+ALTER TABLE t_full_rewrite_compact MODIFY COLUMN s Nullable(String) SETTINGS mutations_sync = 2;
+SELECT part_type, type FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_full_rewrite_compact' AND active AND column = 's';
+
+ALTER TABLE t_full_rewrite_compact ADD PROJECTION p1 (SELECT s ORDER BY s);
+ALTER TABLE t_full_rewrite_compact MATERIALIZE PROJECTION p1 SETTINGS mutations_sync = 2;
+SELECT type FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_full_rewrite_compact' AND active AND column = 's';
+SELECT s, s.null FROM t_full_rewrite_compact;
+
+DROP TABLE t_full_rewrite_compact;
+
+SELECT '-- numeric T -> Nullable(T)';
+
+DROP TABLE IF EXISTS t_full_rewrite_num;
+CREATE TABLE t_full_rewrite_num (n UInt64) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS min_bytes_for_wide_part = 0,
+         -- `tdigest` IS supported for UInt64, so statistics have to be disabled outright here.
+         auto_statistics_types = '',
+         enable_block_number_column = true;
+
+INSERT INTO t_full_rewrite_num SELECT 7 FROM numbers(1);
+ALTER TABLE t_full_rewrite_num MODIFY COLUMN n Nullable(UInt64) SETTINGS mutations_sync = 2;
+SELECT type, has(substreams, 'n.null') FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_full_rewrite_num' AND active AND column = 'n';
+
+ALTER TABLE t_full_rewrite_num ADD PROJECTION p1 (SELECT n ORDER BY n);
+ALTER TABLE t_full_rewrite_num MATERIALIZE PROJECTION p1 SETTINGS mutations_sync = 2;
+SELECT type, has(substreams, 'n.null') FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_full_rewrite_num' AND active AND column = 'n';
+SELECT n, n.null FROM t_full_rewrite_num;
+
+DROP TABLE t_full_rewrite_num;
+
+SELECT '-- Variant extension';
+
+DROP TABLE IF EXISTS t_full_rewrite_var;
+CREATE TABLE t_full_rewrite_var (k UInt8, v Variant(UInt64, String)) ENGINE = MergeTree ORDER BY k
+SETTINGS min_bytes_for_wide_part = 0,
+         auto_statistics_types = '',
+         enable_block_number_column = true;
+
+INSERT INTO t_full_rewrite_var SELECT 1, 7::UInt64::Variant(UInt64, String) FROM numbers(1);
+ALTER TABLE t_full_rewrite_var MODIFY COLUMN v Variant(UInt64, String, Float64) SETTINGS mutations_sync = 2;
+SELECT type FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_full_rewrite_var' AND active AND column = 'v';
+
+ALTER TABLE t_full_rewrite_var ADD PROJECTION p1 (SELECT k, v ORDER BY k);
+ALTER TABLE t_full_rewrite_var MATERIALIZE PROJECTION p1 SETTINGS mutations_sync = 2;
+SELECT type FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_full_rewrite_var' AND active AND column = 'v';
+SELECT k, v FROM t_full_rewrite_var;
+
+DROP TABLE t_full_rewrite_var;
+
+SELECT '-- RENAME of a column whose part type lags';
+
+DROP TABLE IF EXISTS t_full_rewrite_rename;
+CREATE TABLE t_full_rewrite_rename (k UInt8, s String) ENGINE = MergeTree ORDER BY k
+SETTINGS min_bytes_for_wide_part = 0,
+         auto_statistics_types = 'tdigest',
+         enable_block_number_column = true,
+         -- The RENAME below must stay a PARTIAL mutation for the next assertion to mean anything.
+         -- The randomizer raises `min_bytes_for_full_part_storage`, which makes the part packed and
+         -- thus takes the full-rewrite branch via `!isFullPartStorage`.
+         min_bytes_for_full_part_storage = 0;
+
+INSERT INTO t_full_rewrite_rename SELECT 1, 'str' FROM numbers(1);
+ALTER TABLE t_full_rewrite_rename MODIFY COLUMN s Nullable(String) SETTINGS mutations_sync = 2;
+ALTER TABLE t_full_rewrite_rename RENAME COLUMN s TO s2 SETTINGS mutations_sync = 2;
+-- A rename alone carries the column's files over, so the stale String survives the rename.
+SELECT type FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_full_rewrite_rename' AND active AND column = 's2';
+
+ALTER TABLE t_full_rewrite_rename ADD PROJECTION p1 (SELECT k, s2 ORDER BY k);
+ALTER TABLE t_full_rewrite_rename MATERIALIZE PROJECTION p1 SETTINGS mutations_sync = 2;
+SELECT type, has(substreams, 's2.null') FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_full_rewrite_rename' AND active AND column = 's2';
+SELECT k, s2, s2.null FROM t_full_rewrite_rename;
+
+DROP TABLE t_full_rewrite_rename;
+
+SELECT '-- must not regress: a partial mutation still keeps the source part type';
+
+DROP TABLE IF EXISTS t_partial_keeps_type;
+CREATE TABLE t_partial_keeps_type (k UInt8, s String, other UInt32) ENGINE = MergeTree ORDER BY k
+SETTINGS min_bytes_for_wide_part = 0, auto_statistics_types = 'tdigest',
+         -- Both a packed part (`min_bytes_for_full_part_storage`, raised by the randomizer) and
+         -- `enable_block_number_column` would turn the UPDATE below into a full rewrite, which is
+         -- the opposite of what this section asserts.
+         min_bytes_for_full_part_storage = 0, enable_block_number_column = false;
+
+INSERT INTO t_partial_keeps_type SELECT 1, 'str', 10 FROM numbers(1);
+ALTER TABLE t_partial_keeps_type MODIFY COLUMN s Nullable(String) SETTINGS mutations_sync = 2;
+-- The metadata-only skip fires: no data is rewritten, so the part keeps String while the storage
+-- type is Nullable(String). Breaking this would rewrite whole parts for every T -> Nullable(T).
+SELECT 'part', type, has(substreams, 's.null') FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_partial_keeps_type' AND active AND column = 's';
+SELECT 'storage', type FROM system.columns
+WHERE database = currentDatabase() AND table = 't_partial_keeps_type' AND name = 's';
+
+-- A partial mutation of the OTHER column must not disturb `s`: its files are carried over, so its
+-- recorded type stays the source part's String.
+ALTER TABLE t_partial_keeps_type UPDATE other = 20 WHERE 1 SETTINGS mutations_sync = 2;
+SELECT 'part-after-partial', type, has(substreams, 's.null') FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_partial_keeps_type' AND active AND column = 's';
+SELECT k, s, s.null, other FROM t_partial_keeps_type;
+
+DROP TABLE t_partial_keeps_type;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/112459
Related: https://github.com/ClickHouse/ClickHouse/issues/112417
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a logical error (`Bad cast from type DB::ColumnNullable to DB::ColumnString` and siblings) that makes a background mutation fail permanently when the mutation rewrites a whole data part and an earlier metadata-only `ALTER TABLE ... MODIFY COLUMN` has left that part's recorded column type behind. The same condition aborts debug and sanitizer builds.


### Description

`ALTER TABLE ... MODIFY COLUMN c Nullable(T)` (and a `Variant` extension) may skip the data rewrite and change metadata only, leaving the part legitimately storing `T` while the table stores `Nullable(T)`. Readers convert on the fly. This is by design, see `canSkipConversionToNullable`.

Root cause: `MutationHelpers::getColumnsForNewDataPart` picks each column's recorded type *before* `MutateTask::prepare` decides between a full-part rewrite and a partial one, so for a column that the mutation does not itself update it always keeps the source part's type. That is correct for a partial mutation, whose files are carried over unchanged, but wrong for a full rewrite: `MutateAllPartColumnsTask` re-serializes every column from the mutation pipeline, which is typed from the storage snapshot. The part then recorded `String` while the writer was handed a `ColumnNullable`, and `initColumnsSubstreamsIfNeeded` paired that column object with `SerializationString`, whose unconditional `typeid_cast` raised `LOGICAL_ERROR`.

The fix computes the full-versus-partial decision before the column list is built and passes it in: a re-serialized column is recorded with the pipeline type, a carried-over column keeps the source part's type. `columns_substreams` follows, so a column that becomes `Nullable` now also records its `.null` substream. The metadata-only skip is untouched. Type bookkeeping only, no on-disk format change and no new setting.

Reproduced against a real server (the failure needs the background mutation executor) and verified in both directions; a mutation that always takes the storage type instead fails with `Stream s2.null for column s2 with type Nullable(String) is not found`, which the new test also pins.

Known residual, deliberately not bundled: an `INSERT`-time projection writer reaches the same abort site with a `ColumnConst` through a different producer, and the part writers still accept a column whose class disagrees with its serialization. Both are tracked separately.