### PR TITLE
Remove a dead store hiding an inverted clamp on the Keeper auto-forwarding timeout

### DIFF
--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -568,9 +568,6 @@ void KeeperServer::launchRaftServer(const Poco::Util::AbstractConfiguration & co
     params.client_req_timeout_
         = getValueOrMaxInt32AndLogWarning(coordination_settings[CoordinationSetting::operation_timeout_ms].totalMilliseconds(), "operation_timeout_ms", log);
     params.auto_forwarding_ = coordination_settings[CoordinationSetting::auto_forwarding];
-    params.auto_forwarding_req_timeout_ = std::max<int32_t>(
-        static_cast<int32_t>(coordination_settings[CoordinationSetting::operation_timeout_ms].totalMilliseconds() * 2),
-        std::numeric_limits<int32_t>::max());
     params.auto_forwarding_req_timeout_
         = getValueOrMaxInt32AndLogWarning(coordination_settings[CoordinationSetting::operation_timeout_ms].totalMilliseconds() * 2, "operation_timeout_ms", log);
     params.max_append_size_


### PR DESCRIPTION
## Problem

`KeeperServer::launchRaftServer` assigns `params.auto_forwarding_req_timeout_` twice in a row:

```cpp
params.auto_forwarding_req_timeout_ = std::max<int32_t>(
    static_cast<int32_t>(coordination_settings[...operation_timeout_ms].totalMilliseconds() * 2),
    std::numeric_limits<int32_t>::max());
params.auto_forwarding_req_timeout_
    = getValueOrMaxInt32AndLogWarning(...operation_timeout_ms...* 2, "operation_timeout_ms", log);
```

Nothing reads the field in between, so the first assignment is dead and the compiler discards it. Behaviour today is correct. But the dead line contains two mistakes, and dead code with a mistake in it is a trap rather than merely noise:

- `std::max(x, std::numeric_limits<int32_t>::max())` is unconditionally `INT32_MAX` for every `x`. The intent was plainly `min` — "do not exceed the int32 this field is".
- The `static_cast<int32_t>` narrows `totalMilliseconds() * 2` **before** any clamping, so a large `operation_timeout_ms` would wrap to a negative value first. Preventing precisely that is why `getValueOrMaxInt32AndLogWarning` exists.

Why it matters despite being dead: `auto_forwarding_req_timeout_` is how long a follower waits for the leader's response after forwarding a client write, and `0` means no timeout at all (`raft_params.hxx`, consumed in `handle_user_cmd.cxx`). The correct value is `2 * operation_timeout_ms` — 20 s with the default `operation_timeout_ms` of 10000. The dead value was `INT32_MAX` milliseconds, about **24.9 days**. Two adjacent assignments to the same field invite a future reader to delete "the redundant one"; deleting the *second* would silently turn a 20 s timeout into effectively none, and no test would notice.

## Root cause

Introduced by 8bb6205293b ("Fix keeper log messages", 2021-12-27), and it looks like a draft left next to its own replacement. That commit *introduced* `getValueOrMaxInt32AndLogWarning` and converted every settings-to-`params` assignment to use it — `heart_beat_interval_`, both `election_timeout_*`, `reserved_log_items_`, `snapshot_distance_`, `stale_log_gap_`, `fresh_log_gap_`, `client_req_timeout_`, `max_append_size_`. For `auto_forwarding_req_timeout_` alone it added *both* forms:

```diff
+    params.auto_forwarding_req_timeout_ = std::max<uint64_t>(...* 2, std::numeric_limits<int32_t>::max());
+    params.auto_forwarding_req_timeout_ = getValueOrMaxInt32AndLogWarning(...* 2, "operation_timeout_ms", log);
```

So the inline clamp was presumably written first, then generalised into the helper and applied here too, without the first attempt being deleted. The store has therefore been dead since the moment it was written — the helper call has always been the next line — and the inverted comparison has never had an observable effect.

Note the original was wrong for every input, not only for small ones: `std::max<uint64_t>(x, INT32_MAX)` yields `INT32_MAX` when `x <= INT32_MAX`, and yields `x` when `x > INT32_MAX`, which then narrows into an `int32` field.

Two later commits maintained the dead line without noticing:

- 4e76629aafc ("Fixes for `-Wshorten-64-to-32`", 2022-10-07) retyped it as `std::max<int32_t>` with an explicit `static_cast<int32_t>` to silence a narrowing warning — on a line that had been dead for ten months.
- 786c2bc5758 ("Move CoordinationSettings to pImpl", 2024-10-16) ported its settings accessor to the new syntax.

That is the argument for deleting rather than keeping it: dead code with a mistake in it does not stay inert, it consumes maintenance attention and misleads each person who touches it.

## Fix

Delete the three dead lines. The surviving assignment is already correct — it computes in 64 bits, narrows afterwards via `getValueOrMaxInt32AndLogWarning`, and logs a warning when it has to clamp — so repairing the dead line as `min` would only duplicate it.

No test is added: removing a provably dead store changes no observable behaviour, so there is no new behaviour to assert. The existing `Storage/CoordinationTest`, `Storage/CoordinationTestWithCompression`, `TestKeeperTest`, `ZooKeeperTest` and Keeper metrics suites pass unchanged — 180/180 locally.

Found while reading this function for https://github.com/ClickHouse/ClickHouse/pull/112405, which relocates this block into a `buildRaftParams` helper and carries the dead store over verbatim. Split out here so that pull request stays focused; whichever merges second will need a trivial conflict resolution in this hunk.

Related: https://github.com/ClickHouse/ClickHouse/pull/112405

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.423` (included in `26.8` and later)
<!-- ch-version-info:end -->