### PR TITLE
Pin the JBOD least_used placement test to single-threaded inserts

### DIFF
--- a/tests/integration/test_jbod_load_balancing/test.py
+++ b/tests/integration/test_jbod_load_balancing/test.py
@@ -114,8 +114,11 @@ def test_jbod_load_balancing_least_used_next_disk(start_cluster):
 
             SYSTEM STOP MERGES data_least_used_next_disk;
 
-            -- 100MiB each part, 3 parts in total
-            INSERT INTO data_least_used_next_disk SELECT repeat('a', 100) FROM numbers(3e6) SETTINGS max_block_size='1Mi';
+            -- 100MiB each part, 3 parts in total.
+            -- max_insert_threads = 1 keeps the parts written one after another: with
+            -- concurrent writers a reserve can observe another part mid-write, and
+            -- which disk is least used at that moment is interleaving dependent.
+            INSERT INTO data_least_used_next_disk SELECT repeat('a', 100) FROM numbers(3e6) SETTINGS max_block_size='1Mi', max_insert_threads = 1;
         """
         )
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/109006
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

`test_jbod_load_balancing_least_used_next_disk` started failing on master and on unrelated PRs on
2026-07-29 (6 runs so far, 1 of them on master, against ~1500 passes that day). It asserts an exact
part-to-disk placement and got `jbod1` where it expects `jbod2`. Master run:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=e0e5e04a027ed740ab3756d4853fb6d21126c077&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%203%2F6%29

That assertion is only well posed for single-threaded inserts. `least_used` picks the disk with the
most unreserved space **at reserve time**; `getUnreservedSpace` is `statvfs f_bavail` minus the
**full** reservation size (`DiskLocal.cpp:308-313`), and a reservation lives only while its own part
is written (`MergeTreeTemporaryPart` holds no `ReservationPtr`). So an in-flight part has its bytes
charged twice, and with several insert threads the choice depends on whether a concurrently writing
part's reservation is still live. Reproduced locally, byte-identical to CI:

```
[ 211 ] Reserved 108.00 MiB on local disk `jbod3`, having unreserved 300.00 MiB.
[ 209 ] Reserved 108.00 MiB on local disk `jbod2`, having unreserved 200.00 MiB.
[ 209 ] Reserved  92.99 MiB on local disk `jbod1`, having unreserved 100.00 MiB.   <-- wrong disk
```

jbod3 reports `(300 - w) - 108`, so idle jbod1 wins once ~92 MiB of jbod3's part has reached the
filesystem. The test passed for years because `max_insert_threads` defaulted to 1; #109006 changed
that default to auto, which exposed it. That change is correct and is not at fault.

This pins `max_insert_threads = 1` on that one INSERT so the assertion runs in the mode where it is
deterministic. The assertion is unchanged and not weakened: with `least_used` deliberately broken to
always pick the first disk, the pinned test still fails.

The accounting error is conservative, so it cannot over-commit; separately it can refuse a
concurrent insert with `NOT_ENOUGH_SPACE` on tight disks. Neither is addressed here, both are filed
as follow-ups.

<details><summary>Validation</summary>

Pre-fix binary, arms alternated run by run so host load cannot bias either:

| arm | threads issuing the 3 reserves | 3rd reserve chose | diverged |
|---|---|---|---|
| default (auto) | 2 | 29x jbod3 (unreserved 191.96 MiB), 1x jbod1 (100.00 MiB) | 1/30 |
| `max_insert_threads = 1` | 1 | 30x jbod3 (unreserved 191.96 MiB) | 0/30 |

- Non-vacuity: mutating `VolumeJBOD.cpp:172` to always take `disks[0]` reddens the pinned test with
  a real placement assertion failure; `round_robin`, which ignores free space, stays green. Because
  the natural divergence rate is well under 1%, this mutation, not a revert of this diff, is what
  shows the pinned test still catches a real regression.
- Whole suite green post-fix (4 tests). 5 fresh clusters x 10 runs of the pinned test: 45 passed,
  0 assertion failures (5 runs lost to a container kill on a loaded host). Restoring the unfixed
  test file on the same host failed more often, also with 0 assertion failures, so those deaths are
  environmental.
- `GROUP BY disk_name` appears in exactly one integration test file, this suite, out of the 31 that
  reference `disk_name`; `test_jbod_balancer` and `test_ttl_move` assert sets, not exact placement.
  No sibling test needs the same pin.

</details>