### PR TITLE
Fix wrong results in JOIN on float keys from the join runtime filter

### DIFF
--- a/src/Processors/QueryPlan/RuntimeFilterLookup.cpp
+++ b/src/Processors/QueryPlan/RuntimeFilterLookup.cpp
@@ -57,13 +57,24 @@ bool typeSupportsMinMaxRange(const DataTypePtr & type)
 }
 }
 
+namespace
+{
+/// `Object` (JSON) does not statically enumerate its dynamic paths, so "contains a float" is
+/// undecidable for it: forEachChild only visits typed_paths. Answer yes so the fast path is declined.
+bool typeIsFloatOrUndecidable(const IDataType & type)
+{
+    WhichDataType which(type);
+    /// isFloat() also covers BFloat16, unlike isNativeFloat().
+    return which.isFloat() || which.isObject();
+}
+}
+
 bool runtimeFilterTypeContainsFloat(const DataTypePtr & type)
 {
     if (!type)
         return false;
 
-    /// isFloat() also covers BFloat16, unlike isNativeFloat().
-    if (WhichDataType(*type).isFloat())
+    if (typeIsFloatOrUndecidable(*type))
         return true;
 
     /// forEachChild walks the whole type tree, not only the immediate children, so a float nested at any
@@ -71,7 +82,7 @@ bool runtimeFilterTypeContainsFloat(const DataTypePtr & type)
     bool contains_float = false;
     type->forEachChild([&contains_float](const IDataType & child)
     {
-        if (!contains_float && WhichDataType(child).isFloat())
+        if (!contains_float && typeIsFloatOrUndecidable(child))
             contains_float = true;
     });
     return contains_float;

--- a/src/Processors/QueryPlan/RuntimeFilterLookup.cpp
+++ b/src/Processors/QueryPlan/RuntimeFilterLookup.cpp
@@ -57,6 +57,26 @@ bool typeSupportsMinMaxRange(const DataTypePtr & type)
 }
 }
 
+bool runtimeFilterTypeContainsFloat(const DataTypePtr & type)
+{
+    if (!type)
+        return false;
+
+    /// isFloat() also covers BFloat16, unlike isNativeFloat().
+    if (WhichDataType(*type).isFloat())
+        return true;
+
+    /// forEachChild walks the whole type tree, not only the immediate children, so a float nested at any
+    /// depth is found here: Array(Tuple(Float64, Int64)), Map(String, Float64), LowCardinality(Float32), ...
+    bool contains_float = false;
+    type->forEachChild([&contains_float](const IDataType & child)
+    {
+        if (!contains_float && WhichDataType(child).isFloat())
+            contains_float = true;
+    });
+    return contains_float;
+}
+
 IRuntimeFilter::IRuntimeFilter(
     size_t filters_to_merge_,
     const DataTypePtr & filter_column_target_type_,

--- a/src/Processors/QueryPlan/RuntimeFilterLookup.h
+++ b/src/Processors/QueryPlan/RuntimeFilterLookup.h
@@ -25,7 +25,8 @@ extern const int LOGICAL_ERROR;
 
 }
 
-/// True if `type` is a float or contains one at any nesting depth.
+/// True if `type` is a float or contains one at any nesting depth, and also for `JSON`, whose dynamic
+/// paths are not part of the static type so a float in one cannot be ruled out.
 bool runtimeFilterTypeContainsFloat(const DataTypePtr & type);
 
 class IRuntimeFilter;

--- a/src/Processors/QueryPlan/RuntimeFilterLookup.h
+++ b/src/Processors/QueryPlan/RuntimeFilterLookup.h
@@ -25,6 +25,9 @@ extern const int LOGICAL_ERROR;
 
 }
 
+/// True if `type` is a float or contains one at any nesting depth.
+bool runtimeFilterTypeContainsFloat(const DataTypePtr & type);
+
 class IRuntimeFilter;
 using UniqueRuntimeFilterPtr = std::unique_ptr<IRuntimeFilter>;
 using SharedRuntimeFilterPtr = std::shared_ptr<IRuntimeFilter>;
@@ -168,7 +171,10 @@ public:
 
         /// If only 1 element in the set then use " == const" instead of set lookup
         /// But if the argument is Nullable we cannot use "==" so fallback to Set because it can handle NULLs
-        if (exact_values->getTotalRowCount() == 1 && !argument_can_have_nulls)
+        /// Floats are excluded for the same reason: the JOIN compares keys bitwise (HashTable.h bitEquals),
+        /// so "==" and "!=" disagree with it on NaN and on signed zero, while the Set path matches the JOIN.
+        if (exact_values->getTotalRowCount() == 1 && !argument_can_have_nulls
+            && !runtimeFilterTypeContainsFloat(filter_column_target_type))
         {
             values_count = ValuesCount::ONE;
             single_element_column = exact_values->getSetElements().front();

--- a/src/Processors/tests/gtest_runtime_filter_contains_float.cpp
+++ b/src/Processors/tests/gtest_runtime_filter_contains_float.cpp
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+
+#include <DataTypes/DataTypeFactory.h>
+#include <Processors/QueryPlan/RuntimeFilterLookup.h>
+
+using namespace DB;
+
+/// Pins both branches of `runtimeFilterTypeContainsFloat`, which decides whether the join runtime
+/// filter may take its single-distinct-value `== const` fast path. The FALSE branch is what keeps the
+/// optimization for types where `=` is key identity; it is not observable from SQL, because
+/// `ValuesCount::ONE` and `ValuesCount::MANY` produce the same rows for such a type and update the same
+/// stats, so an over-broad helper would silently cost the optimization while every SQL assertion still
+/// passed.
+
+namespace
+{
+bool containsFloat(const String & type_name)
+{
+    return runtimeFilterTypeContainsFloat(DataTypeFactory::instance().get(type_name));
+}
+}
+
+TEST(RuntimeFilterContainsFloat, FloatBearingTypesDeclineTheFastPath)
+{
+    EXPECT_TRUE(containsFloat("Float64"));
+    EXPECT_TRUE(containsFloat("Float32"));
+    EXPECT_TRUE(containsFloat("BFloat16"));
+    EXPECT_TRUE(containsFloat("LowCardinality(Float64)"));
+    EXPECT_TRUE(containsFloat("Nullable(Float64)"));
+    EXPECT_TRUE(containsFloat("Tuple(Float64, Int64)"));
+    EXPECT_TRUE(containsFloat("Array(Float64)"));
+    EXPECT_TRUE(containsFloat("Map(String, Float64)"));
+    /// Two levels deep, so the type walk has to be transitive.
+    EXPECT_TRUE(containsFloat("Array(Tuple(Float64, Int64))"));
+    /// A declared JSON path is part of the static type and is found by the walk.
+    EXPECT_TRUE(containsFloat("JSON(a Float64)"));
+    /// A JSON without declared float paths still declines: its dynamic paths are not in the type.
+    EXPECT_TRUE(containsFloat("JSON"));
+    EXPECT_TRUE(containsFloat("Tuple(JSON)"));
+}
+
+TEST(RuntimeFilterContainsFloat, FloatFreeTypesKeepTheFastPath)
+{
+    EXPECT_FALSE(containsFloat("Int64"));
+    EXPECT_FALSE(containsFloat("UInt8"));
+    EXPECT_FALSE(containsFloat("Decimal64(2)"));
+    EXPECT_FALSE(containsFloat("String"));
+    EXPECT_FALSE(containsFloat("Date"));
+    EXPECT_FALSE(containsFloat("DateTime64(3)"));
+    EXPECT_FALSE(containsFloat("Tuple(Int64, String)"));
+    EXPECT_FALSE(containsFloat("Array(Int64)"));
+    EXPECT_FALSE(containsFloat("Map(String, Int64)"));
+    EXPECT_FALSE(containsFloat("LowCardinality(String)"));
+}
+
+TEST(RuntimeFilterContainsFloat, NullTypeIsFloatFree)
+{
+    EXPECT_FALSE(runtimeFilterTypeContainsFloat(nullptr));
+}

--- a/tests/queries/0_stateless/04653_join_runtime_filter_float_key_identity.reference
+++ b/tests/queries/0_stateless/04653_join_runtime_filter_float_key_identity.reference
@@ -1,0 +1,23 @@
+f64 inner nan	1
+f32 inner nan	1
+bf16 inner nan	1
+lc f64 inner nan	1
+mixed f32 f64 inner nan	1
+f64 anti negzero	1
+f32 anti negzero	1
+bf16 anti negzero	1
+tuple anti negzero	1
+multikey inner nan	1
+array anti negzero	1
+map anti negzero	1
+array tuple anti negzero	1
+control array inner nan	1
+control map inner nan	1
+alg parallel_hash	1
+alg grace_hash	1
+control nullable inner nan	1
+control decimal inner	1
+control int inner	1
+control negzero inner	0
+control nan anti	0
+has-filter	1

--- a/tests/queries/0_stateless/04653_join_runtime_filter_float_key_identity.reference
+++ b/tests/queries/0_stateless/04653_join_runtime_filter_float_key_identity.reference
@@ -20,4 +20,12 @@ control decimal inner	1
 control int inner	1
 control negzero inner	0
 control nan anti	0
+json anti negzero	1
+tuple json anti negzero	1
+json declared path anti negzero	1
 has-filter	1
+has-filter anti	1
+has-filter tuple	1
+has-filter parallel_hash	1
+has-filter grace_hash	1
+has-filter json	1

--- a/tests/queries/0_stateless/04653_join_runtime_filter_float_key_identity.reference
+++ b/tests/queries/0_stateless/04653_join_runtime_filter_float_key_identity.reference
@@ -29,3 +29,9 @@ has-filter tuple	1
 has-filter parallel_hash	1
 has-filter grace_hash	1
 has-filter json	1
+ran-filter	1
+ran-filter anti	1
+ran-filter tuple	1
+ran-filter parallel_hash	1
+ran-filter grace_hash	1
+ran-filter json	1

--- a/tests/queries/0_stateless/04653_join_runtime_filter_float_key_identity.sql
+++ b/tests/queries/0_stateless/04653_join_runtime_filter_float_key_identity.sql
@@ -1,0 +1,111 @@
+-- The JOIN compares keys bitwise, so two NaNs are one key and 0.0 / -0.0 are two keys. The runtime
+-- filter must agree. Its single-distinct-value fast path used `equals`/`notEquals` instead, which
+-- disagrees on NaN (too strict for IN) and on signed zero (too strict for NOT IN), so matching rows
+-- were dropped above the JOIN.
+
+-- Pinned as a session SET, not per statement: a SET survives both the `old analyzer` jobs and the
+-- stress `compatibility='NN.N'` randomization (applyCompatibilitySetting skips manually changed
+-- settings), and the runner randomizes enable_join_runtime_filters to false 5% of the time.
+SET enable_analyzer = 1;
+SET enable_join_runtime_filters = 1;
+-- Log reports no row estimate, so the probe-size cutoff cannot suppress the filter today. Pinned
+-- anyway so the test keeps its filter if Log ever gains an estimate or the default changes.
+SET join_runtime_filter_min_probe_rows = 0;
+SET allow_suspicious_low_cardinality_types = 1;
+
+-- Log, not MergeTree: the plan inserts no runtime filter for a MergeTree source at this size, which
+-- would make every assertion below vacuous. Row `has-filter` guards that.
+-- Every build side holds exactly ONE distinct value; with two or more the filter takes the Set path,
+-- which was already correct.
+
+CREATE TABLE l_f64 (k Float64) ENGINE = Log;  INSERT INTO l_f64 VALUES (nan);
+CREATE TABLE r_f64 (k Float64) ENGINE = Log;  INSERT INTO r_f64 VALUES (nan);
+CREATE TABLE l_f32 (k Float32) ENGINE = Log;  INSERT INTO l_f32 VALUES (nan);
+CREATE TABLE r_f32 (k Float32) ENGINE = Log;  INSERT INTO r_f32 VALUES (nan);
+CREATE TABLE l_bf16 (k BFloat16) ENGINE = Log; INSERT INTO l_bf16 VALUES (nan);
+CREATE TABLE r_bf16 (k BFloat16) ENGINE = Log; INSERT INTO r_bf16 VALUES (nan);
+CREATE TABLE l_lc (k LowCardinality(Float64)) ENGINE = Log; INSERT INTO l_lc VALUES (nan);
+CREATE TABLE r_lc (k LowCardinality(Float64)) ENGINE = Log; INSERT INTO r_lc VALUES (nan);
+
+-- 1. NaN INNER JOIN NaN: the JOIN matches the identical bit patterns, `nan = nan` does not.
+SELECT 'f64 inner nan', count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'hash';
+SELECT 'f32 inner nan', count() FROM l_f32 JOIN r_f32 ON l_f32.k = r_f32.k SETTINGS join_algorithm = 'hash';
+SELECT 'bf16 inner nan', count() FROM l_bf16 JOIN r_bf16 ON l_bf16.k = r_bf16.k SETTINGS join_algorithm = 'hash';
+SELECT 'lc f64 inner nan', count() FROM l_lc JOIN r_lc ON l_lc.k = r_lc.k SETTINGS join_algorithm = 'hash';
+-- mixed widths: the filter target type is the Float64 supertype
+SELECT 'mixed f32 f64 inner nan', count() FROM l_f32 JOIN r_f64 ON l_f32.k = r_f64.k SETTINGS join_algorithm = 'hash';
+
+CREATE TABLE l_negzero_f64 (k Float64) ENGINE = Log;  INSERT INTO l_negzero_f64 VALUES (-0.0);
+CREATE TABLE r_zero_f64 (k Float64) ENGINE = Log;     INSERT INTO r_zero_f64 VALUES (0.0);
+CREATE TABLE l_negzero_f32 (k Float32) ENGINE = Log;  INSERT INTO l_negzero_f32 VALUES (-0.0);
+CREATE TABLE r_zero_f32 (k Float32) ENGINE = Log;     INSERT INTO r_zero_f32 VALUES (0.0);
+CREATE TABLE l_negzero_bf16 (k BFloat16) ENGINE = Log; INSERT INTO l_negzero_bf16 VALUES (-0.0);
+CREATE TABLE r_zero_bf16 (k BFloat16) ENGINE = Log;    INSERT INTO r_zero_bf16 VALUES (0.0);
+
+-- 2. -0.0 LEFT ANTI JOIN 0.0: distinct keys for the JOIN, so the row belongs in the ANTI output,
+-- but `0.0 != -0.0` is false so the negated filter dropped it. No NaN involved.
+SELECT 'f64 anti negzero', count() FROM l_negzero_f64 LEFT ANTI JOIN r_zero_f64 ON l_negzero_f64.k = r_zero_f64.k SETTINGS join_algorithm = 'hash';
+SELECT 'f32 anti negzero', count() FROM l_negzero_f32 LEFT ANTI JOIN r_zero_f32 ON l_negzero_f32.k = r_zero_f32.k SETTINGS join_algorithm = 'hash';
+SELECT 'bf16 anti negzero', count() FROM l_negzero_bf16 LEFT ANTI JOIN r_zero_bf16 ON l_negzero_bf16.k = r_zero_bf16.k SETTINGS join_algorithm = 'hash';
+
+CREATE TABLE l_multi_negzero (k Float64, j Int64) ENGINE = Log; INSERT INTO l_multi_negzero VALUES (-0.0, 1);
+CREATE TABLE r_multi_zero (k Float64, j Int64) ENGINE = Log;    INSERT INTO r_multi_zero VALUES (0.0, 1);
+CREATE TABLE l_multi_nan (k Float64, j Int64) ENGINE = Log;     INSERT INTO l_multi_nan VALUES (nan, 1);
+CREATE TABLE r_multi_nan (k Float64, j Int64) ENGINE = Log;     INSERT INTO r_multi_nan VALUES (nan, 1);
+
+-- 3. Multi-key LEFT ANTI builds one filter over Tuple(Float64, Int64), so the float is nested and a
+-- top-level type test would miss it.
+SELECT 'tuple anti negzero', count() FROM l_multi_negzero LEFT ANTI JOIN r_multi_zero ON l_multi_negzero.k = r_multi_zero.k AND l_multi_negzero.j = r_multi_zero.j SETTINGS join_algorithm = 'hash';
+-- 4. Multi-key INNER builds one filter per column.
+SELECT 'multikey inner nan', count() FROM l_multi_nan JOIN r_multi_nan ON l_multi_nan.k = r_multi_nan.k AND l_multi_nan.j = r_multi_nan.j SETTINGS join_algorithm = 'hash';
+
+CREATE TABLE l_arr_negzero (k Array(Float64)) ENGINE = Log; INSERT INTO l_arr_negzero VALUES ([-0.0]);
+CREATE TABLE r_arr_zero (k Array(Float64)) ENGINE = Log;    INSERT INTO r_arr_zero VALUES ([0.0]);
+CREATE TABLE l_map_negzero (k Map(String, Float64)) ENGINE = Log; INSERT INTO l_map_negzero VALUES (map('a', -0.0));
+CREATE TABLE r_map_zero (k Map(String, Float64)) ENGINE = Log;    INSERT INTO r_map_zero VALUES (map('a', 0.0));
+CREATE TABLE l_arrtup_negzero (k Array(Tuple(Float64, Int64))) ENGINE = Log; INSERT INTO l_arrtup_negzero VALUES ([(-0.0, 1)]);
+CREATE TABLE r_arrtup_zero (k Array(Tuple(Float64, Int64))) ENGINE = Log;    INSERT INTO r_arrtup_zero VALUES ([(0.0, 1)]);
+
+-- 5. Composite keys break only in the ANTI direction: `[0.0] = [-0.0]` is true while the JOIN keys
+-- differ. Array(Tuple(...)) nests the float two levels deep, so the type walk must be transitive.
+SELECT 'array anti negzero', count() FROM l_arr_negzero LEFT ANTI JOIN r_arr_zero ON l_arr_negzero.k = r_arr_zero.k SETTINGS join_algorithm = 'hash';
+SELECT 'map anti negzero', count() FROM l_map_negzero LEFT ANTI JOIN r_map_zero ON l_map_negzero.k = r_map_zero.k SETTINGS join_algorithm = 'hash';
+SELECT 'array tuple anti negzero', count() FROM l_arrtup_negzero LEFT ANTI JOIN r_arrtup_zero ON l_arrtup_negzero.k = r_arrtup_zero.k SETTINGS join_algorithm = 'hash';
+
+CREATE TABLE l_arr_nan (k Array(Float64)) ENGINE = Log; INSERT INTO l_arr_nan VALUES ([nan]);
+CREATE TABLE r_arr_nan (k Array(Float64)) ENGINE = Log; INSERT INTO r_arr_nan VALUES ([nan]);
+CREATE TABLE l_map_nan (k Map(String, Float64)) ENGINE = Log; INSERT INTO l_map_nan VALUES (map('a', nan));
+CREATE TABLE r_map_nan (k Map(String, Float64)) ENGINE = Log; INSERT INTO r_map_nan VALUES (map('a', nan));
+
+-- Controls, correct before the fix: `equals` on a composite compares float elements bitwise, so it
+-- already agreed with the JOIN on NaN. These are not regressions being fixed.
+SELECT 'control array inner nan', count() FROM l_arr_nan JOIN r_arr_nan ON l_arr_nan.k = r_arr_nan.k SETTINGS join_algorithm = 'hash';
+SELECT 'control map inner nan', count() FROM l_map_nan JOIN r_map_nan ON l_map_nan.k = r_map_nan.k SETTINGS join_algorithm = 'hash';
+
+-- 6. The fast path lives in the shared filter base, so every hash algorithm was affected.
+SELECT 'alg parallel_hash', count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'parallel_hash';
+SELECT 'alg grace_hash', count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'grace_hash';
+
+CREATE TABLE l_nullable (k Nullable(Float64)) ENGINE = Log; INSERT INTO l_nullable VALUES (nan);
+CREATE TABLE r_nullable (k Nullable(Float64)) ENGINE = Log; INSERT INTO r_nullable VALUES (nan);
+CREATE TABLE l_dec (k Decimal64(2)) ENGINE = Log; INSERT INTO l_dec VALUES (1.25);
+CREATE TABLE r_dec (k Decimal64(2)) ENGINE = Log; INSERT INTO r_dec VALUES (1.25);
+CREATE TABLE l_int (k Int64) ENGINE = Log; INSERT INTO l_int VALUES (7);
+CREATE TABLE r_int (k Int64) ENGINE = Log; INSERT INTO r_int VALUES (7);
+
+-- 7. Types that were already correct and must keep the fast path. Nullable was excluded by the
+-- existing NULL clause; Decimal and Int have no NaN and no signed zero, so `=` is key identity.
+SELECT 'control nullable inner nan', count() FROM l_nullable JOIN r_nullable ON l_nullable.k = r_nullable.k SETTINGS join_algorithm = 'hash';
+SELECT 'control decimal inner', count() FROM l_dec JOIN r_dec ON l_dec.k = r_dec.k SETTINGS join_algorithm = 'hash';
+SELECT 'control int inner', count() FROM l_int JOIN r_int ON l_int.k = r_int.k SETTINGS join_algorithm = 'hash';
+
+-- 8. The other direction of each disagreement, where the filter was too permissive rather than too
+-- strict. The JOIN rejects these rows itself, so they were and stay empty.
+SELECT 'control negzero inner', count() FROM l_negzero_f64 JOIN r_zero_f64 ON l_negzero_f64.k = r_zero_f64.k SETTINGS join_algorithm = 'hash';
+SELECT 'control nan anti', count() FROM l_f64 LEFT ANTI JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'hash';
+
+-- 9. Anti-vacuity: everything above only tests something while the plan actually installs a runtime
+-- filter for this shape. EXPLAIN PLAN checks the whole subtree, so it is insensitive to the plan
+-- output format.
+SELECT 'has-filter', countIf(explain ILIKE '%RuntimeFilter%') > 0
+FROM (EXPLAIN PLAN SELECT count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'hash');

--- a/tests/queries/0_stateless/04653_join_runtime_filter_float_key_identity.sql
+++ b/tests/queries/0_stateless/04653_join_runtime_filter_float_key_identity.sql
@@ -11,10 +11,18 @@ SET enable_join_runtime_filters = 1;
 -- Log reports no row estimate, so the probe-size cutoff cannot suppress the filter today. Pinned
 -- anyway so the test keeps its filter if Log ever gains an estimate or the default changes.
 SET join_runtime_filter_min_probe_rows = 0;
+-- LEFT ANTI is a swap-only strictness (isSwapOnlyJoinStrictness), so query_plan_join_swap_table=true
+-- reverses it to RIGHT ANTI. The negated filter is built only for LEFT ANTI
+-- (check_left_does_not_contain), so a swapped plan would exercise ExactContains instead of
+-- ExactNotContains: the results, the plan rows and the ran-filter rows would all still pass while the
+-- notEquals path this test covers never ran. stress.py randomizes this setting to 'true'.
+SET query_plan_join_swap_table = 0;
 SET allow_suspicious_low_cardinality_types = 1;
 
--- Log, not MergeTree: the plan inserts no runtime filter for a MergeTree source at this size, which
--- would make every assertion below vacuous. Row `has-filter` guards that.
+-- Log, not MergeTree: with join_runtime_filter_min_probe_rows pinned to 0 above, either engine keeps
+-- the filter, but at the default 1000 a MergeTree source of this size reports an estimate of 1 row and
+-- the cutoff would suppress it, whereas Log reports no estimate at all. Log therefore keeps the test
+-- meaningful even if that pin is ever dropped. Row `has-filter` guards the property directly.
 -- Every build side holds exactly ONE distinct value; with two or more the filter takes the Set path,
 -- which was already correct.
 

--- a/tests/queries/0_stateless/04653_join_runtime_filter_float_key_identity.sql
+++ b/tests/queries/0_stateless/04653_join_runtime_filter_float_key_identity.sql
@@ -24,14 +24,14 @@ CREATE TABLE l_f32 (k Float32) ENGINE = Log;  INSERT INTO l_f32 VALUES (nan);
 CREATE TABLE r_f32 (k Float32) ENGINE = Log;  INSERT INTO r_f32 VALUES (nan);
 CREATE TABLE l_bf16 (k BFloat16) ENGINE = Log; INSERT INTO l_bf16 VALUES (nan);
 CREATE TABLE r_bf16 (k BFloat16) ENGINE = Log; INSERT INTO r_bf16 VALUES (nan);
-CREATE TABLE l_lc (k LowCardinality(Float64)) ENGINE = Log; INSERT INTO l_lc VALUES (nan);
-CREATE TABLE r_lc (k LowCardinality(Float64)) ENGINE = Log; INSERT INTO r_lc VALUES (nan);
+CREATE TABLE l_lc_f64 (k LowCardinality(Float64)) ENGINE = Log; INSERT INTO l_lc_f64 VALUES (nan);
+CREATE TABLE r_lc_f64 (k LowCardinality(Float64)) ENGINE = Log; INSERT INTO r_lc_f64 VALUES (nan);
 
 -- 1. NaN INNER JOIN NaN: the JOIN matches the identical bit patterns, `nan = nan` does not.
 SELECT 'f64 inner nan', count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'hash';
 SELECT 'f32 inner nan', count() FROM l_f32 JOIN r_f32 ON l_f32.k = r_f32.k SETTINGS join_algorithm = 'hash';
 SELECT 'bf16 inner nan', count() FROM l_bf16 JOIN r_bf16 ON l_bf16.k = r_bf16.k SETTINGS join_algorithm = 'hash';
-SELECT 'lc f64 inner nan', count() FROM l_lc JOIN r_lc ON l_lc.k = r_lc.k SETTINGS join_algorithm = 'hash';
+SELECT 'lc f64 inner nan', count() FROM l_lc_f64 JOIN r_lc_f64 ON l_lc_f64.k = r_lc_f64.k SETTINGS join_algorithm = 'hash';
 -- mixed widths: the filter target type is the Float64 supertype
 SELECT 'mixed f32 f64 inner nan', count() FROM l_f32 JOIN r_f64 ON l_f32.k = r_f64.k SETTINGS join_algorithm = 'hash';
 
@@ -104,8 +104,31 @@ SELECT 'control int inner', count() FROM l_int JOIN r_int ON l_int.k = r_int.k S
 SELECT 'control negzero inner', count() FROM l_negzero_f64 JOIN r_zero_f64 ON l_negzero_f64.k = r_zero_f64.k SETTINGS join_algorithm = 'hash';
 SELECT 'control nan anti', count() FROM l_f64 LEFT ANTI JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'hash';
 
--- 9. Anti-vacuity: everything above only tests something while the plan actually installs a runtime
--- filter for this shape. EXPLAIN PLAN checks the whole subtree, so it is insensitive to the plan
--- output format.
+-- 9. A JSON key keeps its floats in dynamic paths, which are not part of the static type, so the type
+-- cannot say whether a float is present and the fast path must be declined. Subquery sources because
+-- Log rejects columns with dynamic structure.
+SELECT 'json anti negzero', count() FROM (SELECT '{"a":-0.0}'::JSON AS k) AS t1
+LEFT ANTI JOIN (SELECT '{"a":0.0}'::JSON AS k) AS t2 USING (k) SETTINGS join_algorithm = 'hash';
+SELECT 'tuple json anti negzero', count() FROM (SELECT tuple('{"a":-0.0}'::JSON) AS k) AS t1
+LEFT ANTI JOIN (SELECT tuple('{"a":0.0}'::JSON) AS k) AS t2 USING (k) SETTINGS join_algorithm = 'hash';
+-- A DECLARED path is part of the static type, so the plain type walk already covered this one.
+SELECT 'json declared path anti negzero', count() FROM (SELECT '{"a":-0.0}'::JSON(a Float64) AS k) AS t1
+LEFT ANTI JOIN (SELECT '{"a":0.0}'::JSON(a Float64) AS k) AS t2 USING (k) SETTINGS join_algorithm = 'hash';
+
+-- 10. Anti-vacuity: every assertion above only tests something while the plan actually installs a
+-- runtime filter for that shape. EXPLAIN PLAN checks the whole subtree, so it is insensitive to the
+-- plan output format. One row per planner branch, since they are selected separately: per-column
+-- filters for INNER, one tuple filter for multi-key ANTI, and the two other hash algorithms.
 SELECT 'has-filter', countIf(explain ILIKE '%RuntimeFilter%') > 0
 FROM (EXPLAIN PLAN SELECT count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'hash');
+SELECT 'has-filter anti', countIf(explain ILIKE '%RuntimeFilter%') > 0
+FROM (EXPLAIN PLAN SELECT count() FROM l_negzero_f64 LEFT ANTI JOIN r_zero_f64 ON l_negzero_f64.k = r_zero_f64.k SETTINGS join_algorithm = 'hash');
+SELECT 'has-filter tuple', countIf(explain ILIKE '%RuntimeFilter%') > 0
+FROM (EXPLAIN PLAN SELECT count() FROM l_multi_negzero LEFT ANTI JOIN r_multi_zero ON l_multi_negzero.k = r_multi_zero.k AND l_multi_negzero.j = r_multi_zero.j SETTINGS join_algorithm = 'hash');
+SELECT 'has-filter parallel_hash', countIf(explain ILIKE '%RuntimeFilter%') > 0
+FROM (EXPLAIN PLAN SELECT count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'parallel_hash');
+SELECT 'has-filter grace_hash', countIf(explain ILIKE '%RuntimeFilter%') > 0
+FROM (EXPLAIN PLAN SELECT count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'grace_hash');
+SELECT 'has-filter json', countIf(explain ILIKE '%RuntimeFilter%') > 0
+FROM (EXPLAIN PLAN SELECT count() FROM (SELECT '{"a":-0.0}'::JSON AS k) AS t1
+LEFT ANTI JOIN (SELECT '{"a":0.0}'::JSON AS k) AS t2 USING (k) SETTINGS join_algorithm = 'hash');

--- a/tests/queries/0_stateless/04653_join_runtime_filter_float_key_identity.sql
+++ b/tests/queries/0_stateless/04653_join_runtime_filter_float_key_identity.sql
@@ -28,7 +28,8 @@ CREATE TABLE l_lc_f64 (k LowCardinality(Float64)) ENGINE = Log; INSERT INTO l_lc
 CREATE TABLE r_lc_f64 (k LowCardinality(Float64)) ENGINE = Log; INSERT INTO r_lc_f64 VALUES (nan);
 
 -- 1. NaN INNER JOIN NaN: the JOIN matches the identical bit patterns, `nan = nan` does not.
-SELECT 'f64 inner nan', count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'hash';
+-- The log_comment on six of the statements below is read back in section 11.
+SELECT 'f64 inner nan', count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'hash', log_comment = '04653_inner';
 SELECT 'f32 inner nan', count() FROM l_f32 JOIN r_f32 ON l_f32.k = r_f32.k SETTINGS join_algorithm = 'hash';
 SELECT 'bf16 inner nan', count() FROM l_bf16 JOIN r_bf16 ON l_bf16.k = r_bf16.k SETTINGS join_algorithm = 'hash';
 SELECT 'lc f64 inner nan', count() FROM l_lc_f64 JOIN r_lc_f64 ON l_lc_f64.k = r_lc_f64.k SETTINGS join_algorithm = 'hash';
@@ -44,7 +45,7 @@ CREATE TABLE r_zero_bf16 (k BFloat16) ENGINE = Log;    INSERT INTO r_zero_bf16 V
 
 -- 2. -0.0 LEFT ANTI JOIN 0.0: distinct keys for the JOIN, so the row belongs in the ANTI output,
 -- but `0.0 != -0.0` is false so the negated filter dropped it. No NaN involved.
-SELECT 'f64 anti negzero', count() FROM l_negzero_f64 LEFT ANTI JOIN r_zero_f64 ON l_negzero_f64.k = r_zero_f64.k SETTINGS join_algorithm = 'hash';
+SELECT 'f64 anti negzero', count() FROM l_negzero_f64 LEFT ANTI JOIN r_zero_f64 ON l_negzero_f64.k = r_zero_f64.k SETTINGS join_algorithm = 'hash', log_comment = '04653_anti';
 SELECT 'f32 anti negzero', count() FROM l_negzero_f32 LEFT ANTI JOIN r_zero_f32 ON l_negzero_f32.k = r_zero_f32.k SETTINGS join_algorithm = 'hash';
 SELECT 'bf16 anti negzero', count() FROM l_negzero_bf16 LEFT ANTI JOIN r_zero_bf16 ON l_negzero_bf16.k = r_zero_bf16.k SETTINGS join_algorithm = 'hash';
 
@@ -55,7 +56,7 @@ CREATE TABLE r_multi_nan (k Float64, j Int64) ENGINE = Log;     INSERT INTO r_mu
 
 -- 3. Multi-key LEFT ANTI builds one filter over Tuple(Float64, Int64), so the float is nested and a
 -- top-level type test would miss it.
-SELECT 'tuple anti negzero', count() FROM l_multi_negzero LEFT ANTI JOIN r_multi_zero ON l_multi_negzero.k = r_multi_zero.k AND l_multi_negzero.j = r_multi_zero.j SETTINGS join_algorithm = 'hash';
+SELECT 'tuple anti negzero', count() FROM l_multi_negzero LEFT ANTI JOIN r_multi_zero ON l_multi_negzero.k = r_multi_zero.k AND l_multi_negzero.j = r_multi_zero.j SETTINGS join_algorithm = 'hash', log_comment = '04653_tuple';
 -- 4. Multi-key INNER builds one filter per column.
 SELECT 'multikey inner nan', count() FROM l_multi_nan JOIN r_multi_nan ON l_multi_nan.k = r_multi_nan.k AND l_multi_nan.j = r_multi_nan.j SETTINGS join_algorithm = 'hash';
 
@@ -83,8 +84,8 @@ SELECT 'control array inner nan', count() FROM l_arr_nan JOIN r_arr_nan ON l_arr
 SELECT 'control map inner nan', count() FROM l_map_nan JOIN r_map_nan ON l_map_nan.k = r_map_nan.k SETTINGS join_algorithm = 'hash';
 
 -- 6. The fast path lives in the shared filter base, so every hash algorithm was affected.
-SELECT 'alg parallel_hash', count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'parallel_hash';
-SELECT 'alg grace_hash', count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'grace_hash';
+SELECT 'alg parallel_hash', count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'parallel_hash', log_comment = '04653_parallel_hash';
+SELECT 'alg grace_hash', count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SETTINGS join_algorithm = 'grace_hash', log_comment = '04653_grace_hash';
 
 CREATE TABLE l_nullable (k Nullable(Float64)) ENGINE = Log; INSERT INTO l_nullable VALUES (nan);
 CREATE TABLE r_nullable (k Nullable(Float64)) ENGINE = Log; INSERT INTO r_nullable VALUES (nan);
@@ -108,7 +109,7 @@ SELECT 'control nan anti', count() FROM l_f64 LEFT ANTI JOIN r_f64 ON l_f64.k = 
 -- cannot say whether a float is present and the fast path must be declined. Subquery sources because
 -- Log rejects columns with dynamic structure.
 SELECT 'json anti negzero', count() FROM (SELECT '{"a":-0.0}'::JSON AS k) AS t1
-LEFT ANTI JOIN (SELECT '{"a":0.0}'::JSON AS k) AS t2 USING (k) SETTINGS join_algorithm = 'hash';
+LEFT ANTI JOIN (SELECT '{"a":0.0}'::JSON AS k) AS t2 USING (k) SETTINGS join_algorithm = 'hash', log_comment = '04653_json';
 SELECT 'tuple json anti negzero', count() FROM (SELECT tuple('{"a":-0.0}'::JSON) AS k) AS t1
 LEFT ANTI JOIN (SELECT tuple('{"a":0.0}'::JSON) AS k) AS t2 USING (k) SETTINGS join_algorithm = 'hash';
 -- A DECLARED path is part of the static type, so the plain type walk already covered this one.
@@ -132,3 +133,31 @@ FROM (EXPLAIN PLAN SELECT count() FROM l_f64 JOIN r_f64 ON l_f64.k = r_f64.k SET
 SELECT 'has-filter json', countIf(explain ILIKE '%RuntimeFilter%') > 0
 FROM (EXPLAIN PLAN SELECT count() FROM (SELECT '{"a":-0.0}'::JSON AS k) AS t1
 LEFT ANTI JOIN (SELECT '{"a":0.0}'::JSON AS k) AS t2 USING (k) SETTINGS join_algorithm = 'hash');
+
+-- 11. The rows above check that the PLAN contains a runtime filter, which the build-side
+-- BuildRuntimeFilter step satisfies on its own. The probe side is a separate mechanism and it fails
+-- open: FunctionApplyFilter returns an all-true constant when the rendezvous lookup misses, so a
+-- broken probe side would leave every result correct and every assertion above green while the code
+-- this test covers never runs. RuntimeFilterRowsChecked is incremented only from IRuntimeFilter
+-- ::updateStats, reached only from the ZERO/ONE/MANY arms of the lookup, so it moves if and only if
+-- the probe-side filter actually ran. One row per planner branch, paired with the rows above.
+SYSTEM FLUSH LOGS system.query_log;
+
+SELECT 'ran-filter', ProfileEvents['RuntimeFilterRowsChecked'] > 0 FROM system.query_log
+WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND event_date >= yesterday()
+AND log_comment = '04653_inner' ORDER BY event_time DESC LIMIT 1;
+SELECT 'ran-filter anti', ProfileEvents['RuntimeFilterRowsChecked'] > 0 FROM system.query_log
+WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND event_date >= yesterday()
+AND log_comment = '04653_anti' ORDER BY event_time DESC LIMIT 1;
+SELECT 'ran-filter tuple', ProfileEvents['RuntimeFilterRowsChecked'] > 0 FROM system.query_log
+WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND event_date >= yesterday()
+AND log_comment = '04653_tuple' ORDER BY event_time DESC LIMIT 1;
+SELECT 'ran-filter parallel_hash', ProfileEvents['RuntimeFilterRowsChecked'] > 0 FROM system.query_log
+WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND event_date >= yesterday()
+AND log_comment = '04653_parallel_hash' ORDER BY event_time DESC LIMIT 1;
+SELECT 'ran-filter grace_hash', ProfileEvents['RuntimeFilterRowsChecked'] > 0 FROM system.query_log
+WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND event_date >= yesterday()
+AND log_comment = '04653_grace_hash' ORDER BY event_time DESC LIMIT 1;
+SELECT 'ran-filter json', ProfileEvents['RuntimeFilterRowsChecked'] > 0 FROM system.query_log
+WHERE type = 'QueryFinish' AND current_database = currentDatabase() AND event_date >= yesterday()
+AND log_comment = '04653_json' ORDER BY event_time DESC LIMIT 1;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/106531
Related: https://github.com/ClickHouse/ClickHouse/pull/96779
Related: https://github.com/ClickHouse/ClickHouse/pull/112409
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes wrong results in `JOIN` on floating-point keys when the join runtime filter's build side has exactly one distinct value. The single-value fast path compared keys with `equals`/`notEquals` instead of the bitwise key identity the `JOIN` itself uses, so rows with `NaN` keys were dropped from `INNER JOIN` results and rows with `-0.0` keys were dropped from `LEFT ANTI JOIN` results.


### Description

The join runtime filter pre-filters the probe side above the join, so it must never reject a row the join could match. When the build side collects exactly one distinct value, `finishInsertImpl` takes a fast path evaluating the filter as `value == const`, or `value != const` for ANTI, instead of a set lookup. The `JOIN` compares keys bitwise via `bitEquals` in `HashTable.h`, and SQL comparison disagrees with that on floats in both directions:

- `nan = nan` is false while the two bit patterns are the same key, so the positive filter drops a row the `JOIN` would have matched.
- `0.0 = -0.0` is true while the keys differ, so the negated filter drops a row belonging in the `LEFT ANTI JOIN` output. No `NaN` is involved in this one.

Both return silently wrong results on default settings:

```sql
CREATE TABLE l (k Float64) ENGINE = Log; INSERT INTO l VALUES (nan);
CREATE TABLE r (k Float64) ENGINE = Log; INSERT INTO r VALUES (nan);
SELECT count() FROM l JOIN r ON l.k = r.k;  -- returns 0, must be 1
```

The fix skips the fast path when the filter's target type contains a float at any nesting depth, so those filters fall back to the existing `Set` path, which is byte-wise and already agrees with the `JOIN`. This mirrors the `!argument_can_have_nulls` clause on the same line, and keeps the optimization for every type where it is sound. The type test uses `isFloat`, not `isNativeFloat`, which would exclude `BFloat16`, and walks the type tree with `IDataType::forEachChild`, covering `Tuple`, `Array`, `Map` and `Array(Tuple(...))` keys. A `JSON` key declines outright: its dynamic paths are not in the static type, so a float in one cannot be ruled out. `Nullable` keys were already excluded by the NULL clause.

<details>
<summary>Validation and merge-order notes</summary>

With this fix the fixture in https://github.com/ClickHouse/ClickHouse/issues/106531 returns 2 rather than the 0 seen on 26.x. 2 is the correct key-identity answer, so a reviewer who recalls that report should not expect 0. Documented in https://github.com/ClickHouse/ClickHouse/pull/112409.

https://github.com/ClickHouse/ClickHouse/pull/96779 carries an equivalent guard inside a much larger change, but it uses `isNativeFloat` and covers neither signed zero nor `JSON`.

New test `04653_join_runtime_filter_float_key_identity`: 37 rows, of which 18 return `0` before the fix and `1` after; the other 19 are unchanged controls. Carriers: `Float64`, `Float32`, `BFloat16`, `LowCardinality(Float64)`, mixed widths, multi-key `INNER` and `LEFT ANTI` over `Tuple(Float64, Int64)`, `Array(Float64)`, `Map(String, Float64)`, `Array(Tuple(Float64, Int64))`, `JSON` and `Tuple(JSON)`, and the three hash algorithms. Controls: `Nullable(Float64)`, `Decimal64(2)` and `Int64` keys keep the fast path, and `-0.0 INNER JOIN 0.0` and `nan LEFT ANTI JOIN nan` stay empty, since there the filter was too permissive rather than too strict and the `JOIN` rejects those rows itself.

Eight mutations confirm every clause of the guard is load-bearing, each reddening only the rows it should. A unit test pins the predicate directly, since a guard answering yes for every type would silently cost the optimization on `Int64` and `Decimal64` keys while every SQL row still passed.

Liveness: `Log` tables so the probe-size cutoff cannot suppress the filter even at its default; `EXPLAIN PLAN` and `RuntimeFilterRowsChecked` assertions per planner branch that the filter is present and actually ran; and `query_plan_join_swap_table` pinned, without which a swapped plan builds a positive filter and the signed-zero rows stop reproducing the bug while still passing. 50 of 50 repeated runs pass, 20 of 20 randomized, 20 of 20 at `-j 8`.

</details>