### PR TITLE
Add a test pinning the deferred-PREWHERE sync from #109703

### DIFF
--- a/tests/queries/0_stateless/04653_text_index_prewhere_deferred_after_final.reference
+++ b/tests/queries/0_stateless/04653_text_index_prewhere_deferred_after_final.reference
@@ -3,3 +3,7 @@
 1
 = the filter sees post-FINAL rows only =
 2
+= a later text-index rewrite reaches the deferred prewhere =
+1
+1
+1

--- a/tests/queries/0_stateless/04653_text_index_prewhere_deferred_after_final.sql
+++ b/tests/queries/0_stateless/04653_text_index_prewhere_deferred_after_final.sql
@@ -31,3 +31,35 @@ SELECT k FROM t_text_defer_final FINAL PREWHERE hasPhrase(text, 'hello');
 SELECT k FROM t_text_defer_final FINAL PREWHERE hasPhrase(text, 'goodbye');
 
 DROP TABLE t_text_defer_final;
+
+SELECT '= a later text-index rewrite reaches the deferred prewhere =';
+
+DROP TABLE IF EXISTS t_text_defer_final_pp;
+
+CREATE TABLE t_text_defer_final_pp
+(
+    k Int32,
+    text String,
+    v UInt64,
+    INDEX idx(text) TYPE text(tokenizer = ngrams(3), preprocessor = lower(text))
+)
+ENGINE = ReplacingMergeTree(v)
+ORDER BY k;
+
+-- k = 1 keeps the matching mixed-case row as the FINAL winner (v = 2 beats v = 1);
+-- k = 2 never matches, so the deduplication stays meaningful
+INSERT INTO t_text_defer_final_pp VALUES (1, 'Nothing Here', 1), (2, 'Goodbye World', 1);
+INSERT INTO t_text_defer_final_pp VALUES (1, 'Hello World', 2);
+
+-- The predicate must also appear in WHERE: a deferred PREWHERE is excluded from index analysis and
+-- `text` is not a sorting-key column, so the WHERE copy is the only thing that registers the text
+-- index and lets a later rewrite fire. Mixed case on disk plus a lower-case needle means only the
+-- preprocessor-rewritten predicate matches, so a stale deferred filter would return nothing.
+-- `use_skip_indexes_if_final` is randomized by the runner and unregisters the index when false.
+SELECT k FROM t_text_defer_final_pp FINAL PREWHERE hasPhrase(text, 'hello world') WHERE hasPhrase(text, 'hello world')
+SETTINGS use_skip_indexes = 1, use_skip_indexes_if_final = 1;
+
+SELECT count() FROM (EXPLAIN actions=1 SELECT k FROM t_text_defer_final_pp FINAL PREWHERE hasPhrase(text, 'hello world') WHERE hasPhrase(text, 'hello world') SETTINGS use_skip_indexes = 1, use_skip_indexes_if_final = 1) WHERE explain LIKE '%Deferred prewhere filter column%';
+SELECT count() FROM (EXPLAIN indexes = 1 SELECT k FROM t_text_defer_final_pp FINAL PREWHERE hasPhrase(text, 'hello world') WHERE hasPhrase(text, 'hello world') SETTINGS use_skip_indexes = 1, use_skip_indexes_if_final = 1) WHERE explain LIKE '%Name: idx%';
+
+DROP TABLE t_text_defer_final_pp;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/109703
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/109703

Follow-up requested by @ yariks5s in https://github.com/ClickHouse/ClickHouse/pull/109703#issuecomment-5123981915. Test-only, no source change.

#109703 added a sync in `ReadFromMergeTree::updatePrewhereInfo` that carries a later PREWHERE rewrite into `deferred_prewhere_info`. Neither test it shipped pins that line: deleting it leaves both green. `04653` says so itself, that the deferred filter runs without the tokenizer rewrite so its results must not depend on it, which is exactly the property the sync controls.

`deferFiltersAfterFinalIfNeeded` snapshots `deferred_prewhere_info`, and only afterwards does the text-index pass rewrite the PREWHERE and call `updatePrewhereInfo`. The `isPrewhereDeferredAfterFinal` gate there suppresses only the direct-read half, so the preprocessor rewrite still fires on a deferred PREWHERE and the sync is what makes the post-FINAL filter use it.

The new case uses `preprocessor = lower(text)` with mixed-case data and a lower-case needle, so only the rewritten predicate matches. The predicate is duplicated in `WHERE` because a deferred PREWHERE is excluded from index analysis, making the `WHERE` copy the only registrant of the text index; without it the rewrite never fires. `use_skip_indexes` and `use_skip_indexes_if_final` are pinned because the runner randomizes the latter 50/50 and a false draw unregisters the index and makes the case vacuous.

Validation: with the sync reverted the new query returns nothing instead of one row, while both controls and every pre-existing assertion in `04653` and `04652` stay green. Tag-free 50 of 50 runs pass.

One note on the request: asserting the rewritten deferred filter in `EXPLAIN` is not achievable. The deferred block prints only the filter's column name, and the rewrite preserves that name, so `EXPLAIN actions=1` is byte-identical with and without the sync. The result-based case is shipped instead.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.420` (included in `26.8` and later)
<!-- ch-version-info:end -->