### PR TITLE
Stop `test_refreshable_mv_no_multi_read` from clamping its Keeper sessions to 10 s

### DIFF
--- a/tests/integration/test_refreshable_mv_no_multi_read/configs/enable_keeper_multi_read.xml
+++ b/tests/integration/test_refreshable_mv_no_multi_read/configs/enable_keeper_multi_read.xml
@@ -7,7 +7,9 @@
 
         <coordination_settings>
             <operation_timeout_ms>5000</operation_timeout_ms>
-            <session_timeout_ms>10000</session_timeout_ms>
+            <!-- Server's MAX session timeout. Keep it >= the client default (30000), otherwise
+                 every session is silently clamped down to this value. -->
+            <session_timeout_ms>30000</session_timeout_ms>
             <heart_beat_interval_ms>0</heart_beat_interval_ms>
             <election_timeout_lower_bound_ms>0</election_timeout_lower_bound_ms>
             <election_timeout_upper_bound_ms>0</election_timeout_upper_bound_ms>

--- a/tests/integration/test_refreshable_mv_no_multi_read/configs/enable_keeper_no_multi_read.xml
+++ b/tests/integration/test_refreshable_mv_no_multi_read/configs/enable_keeper_no_multi_read.xml
@@ -7,7 +7,9 @@
 
         <coordination_settings>
             <operation_timeout_ms>5000</operation_timeout_ms>
-            <session_timeout_ms>10000</session_timeout_ms>
+            <!-- Server's MAX session timeout. Keep it >= the client default (30000), otherwise
+                 every session is silently clamped down to this value. -->
+            <session_timeout_ms>30000</session_timeout_ms>
             <heart_beat_interval_ms>0</heart_beat_interval_ms>
             <election_timeout_lower_bound_ms>0</election_timeout_lower_bound_ms>
             <election_timeout_upper_bound_ms>0</election_timeout_upper_bound_ms>

--- a/tests/integration/test_refreshable_mv_no_multi_read/configs/enable_keeper_no_multi_read_simulate_attach_race.xml
+++ b/tests/integration/test_refreshable_mv_no_multi_read/configs/enable_keeper_no_multi_read_simulate_attach_race.xml
@@ -7,7 +7,9 @@
 
         <coordination_settings>
             <operation_timeout_ms>5000</operation_timeout_ms>
-            <session_timeout_ms>10000</session_timeout_ms>
+            <!-- Server's MAX session timeout. Keep it >= the client default (30000), otherwise
+                 every session is silently clamped down to this value. -->
+            <session_timeout_ms>30000</session_timeout_ms>
             <heart_beat_interval_ms>0</heart_beat_interval_ms>
             <election_timeout_lower_bound_ms>0</election_timeout_lower_bound_ms>
             <election_timeout_upper_bound_ms>0</election_timeout_upper_bound_ms>

--- a/tests/integration/test_refreshable_mv_no_multi_read/test.py
+++ b/tests/integration/test_refreshable_mv_no_multi_read/test.py
@@ -11,10 +11,12 @@
 # gracefully and leave the server running.
 
 import os
+import re
 import time
 
 import pytest
 
+import helpers.keeper_utils as keeper_utils
 from helpers.cluster import ClickHouseCluster
 
 CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -48,9 +50,33 @@ def use_keeper_config(config_name):
     )
 
 
+def assert_negotiated_session_timeout(expected_ms):
+    """Assert the server enforces expected_ms for the server's own Keeper session.
+
+    The configs here set the server's *max* session timeout; if that cap drops to or below the
+    client's default request the handshake silently clamps every session, and a stall longer than
+    the clamped value then kills the session under whatever Keeper call is in flight.
+    """
+    data = keeper_utils.send_4lw_cmd(cluster, node, cmd="cons")
+    # 'cons' answers on its own connection too, and that connection never completed a handshake:
+    # its session_id is the -1 initializer, which still passes the 'session_id != 0' guard in
+    # dumpStats, and session_timeout is never assigned for it, so it reports
+    # sid=0xffffffffffffffff with to=0. Skip it and read the real sessions.
+    timeouts = [
+        int(m.group(1))
+        for line in data.split("\n")
+        if line.strip() and "sid=0xffffffffffffffff" not in line
+        for m in [re.search(r"\bto=(\d+)", line)]
+        if m
+    ]
+    assert timeouts, f"no established Keeper session found in cons output:\n{data}"
+    assert all(t == expected_ms for t in timeouts), (expected_ms, timeouts, data)
+
+
 def test_refreshable_mv_attach_without_multi_read(started_cluster):
     use_keeper_config("enable_keeper_multi_read.xml")
     node.restart_clickhouse()
+    assert_negotiated_session_timeout(30000)
 
     node.query(
         "CREATE DATABASE rdb ENGINE = Replicated('/clickhouse/rdb', '{shard}', '{replica}')"
@@ -76,6 +102,7 @@ def test_refreshable_mv_attach_without_multi_read(started_cluster):
     # re-attaches rdb.mv (attach=true), which is exactly the path that used to crash.
     use_keeper_config("enable_keeper_no_multi_read.xml")
     node.restart_clickhouse()
+    assert_negotiated_session_timeout(30000)
 
     # The server must be up and answering queries (no crash, no crash-loop).
     assert node.query("SELECT 1").strip() == "1"
@@ -159,6 +186,7 @@ def test_refreshable_mv_attach_feature_flag_propagation_race(started_cluster):
     # Downgrade Keeper AND make the constructor miss the downgrade (simulating the race).
     use_keeper_config("enable_keeper_no_multi_read_simulate_attach_race.xml")
     node.restart_clickhouse()
+    assert_negotiated_session_timeout(30000)
 
     # The server must be up and answering queries (no crash, no crash-loop).
     assert node.query("SELECT 1").strip() == "1"

--- a/tests/integration/test_refreshable_mv_no_multi_read/test.py
+++ b/tests/integration/test_refreshable_mv_no_multi_read/test.py
@@ -56,19 +56,29 @@ def assert_negotiated_session_timeout(expected_ms):
     The configs here set the server's *max* session timeout; if that cap drops to or below the
     client's default request the handshake silently clamps every session, and a stall longer than
     the clamped value then kills the session under whatever Keeper call is in flight.
+
+    Only the session's *existence* is polled: with no Replicated database yet, the server's own
+    session is opened by DDLWorker startup, which is an AsyncLoader job that restart_clickhouse()
+    does not wait for. The timeout value itself is never retried, so a clamped session fails on
+    the first read.
     """
-    data = keeper_utils.send_4lw_cmd(cluster, node, cmd="cons")
-    # 'cons' answers on its own connection too, and that connection never completed a handshake:
-    # its session_id is the -1 initializer, which still passes the 'session_id != 0' guard in
-    # dumpStats, and session_timeout is never assigned for it, so it reports
-    # sid=0xffffffffffffffff with to=0. Skip it and read the real sessions.
-    timeouts = [
-        int(m.group(1))
-        for line in data.split("\n")
-        if line.strip() and "sid=0xffffffffffffffff" not in line
-        for m in [re.search(r"\bto=(\d+)", line)]
-        if m
-    ]
+    deadline = time.monotonic() + 30
+    while True:
+        data = keeper_utils.send_4lw_cmd(cluster, node, cmd="cons")
+        # 'cons' answers on its own connection too, and that connection never completed a
+        # handshake: its session_id is the -1 initializer, which still passes the
+        # 'session_id != 0' guard in dumpStats, and session_timeout is never assigned for it, so
+        # it reports sid=0xffffffffffffffff with to=0. Skip it and read the real sessions.
+        timeouts = [
+            int(m.group(1))
+            for line in data.split("\n")
+            if line.strip() and "sid=0xffffffffffffffff" not in line
+            for m in [re.search(r"\bto=(\d+)", line)]
+            if m
+        ]
+        if timeouts or time.monotonic() >= deadline:
+            break
+        time.sleep(0.5)
     assert timeouts, f"no established Keeper session found in cons output:\n{data}"
     assert all(t == expected_ms for t in timeouts), (expected_ms, timeouts, data)
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/107042


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Cleanup DDL in `test_refreshable_mv_no_multi_read` fails with a raw `Code: 999. Coordination error: Connection loss, path /clickhouse/rdbN/max_log_ptr` on `Integration tests (amd_tsan, 4/6)`: 6 rows over 4 tests and 4 unrelated PRs plus a master hit, all on 2026-07-29. In `..._missing_flags_shutdown_clears_running_lock` that statement is the load-bearing `DETACH TABLE ... PERMANENTLY SYNC`, so the run aborts before the assertions and the coverage is silently lost.

Root cause: the suite pinned the server's **maximum** session timeout to the same value as its **minimum**, clamping every session to 10 s. `session_timeout_ms` is read as `max_session_timeout` while `min_session_timeout` defaults to 10000 (`KeeperTCPHandler.cpp:253-254`); the `<zookeeper>` blocks set no client timeout, so the client requests 30000 and negotiation yields `min(max(30000, 10000), 10000)` (`:436-439`). This node's Keeper is embedded in the same process and the file restarts it 13 times, so on a loaded TSAN host a quiet period past 10 s drops the session mid-DDL.

Raising that cap to 30000 in all three keeper configs makes sessions negotiate the client default instead, buying stall tolerance of 10 s to 30 s. It is not extra heartbeats: the interval is `session_timeout_ms / 3`, so the budget is 3 either way. No existing assertion or failpoint changes. Only 9 of the 235 `coordination_settings` blocks under `tests/integration` that set it share this shape; elsewhere a co-located client mirrors the cap.

The invariant is pinned in-tree rather than measured by hand: after each config swap the suite reads the server-side `cons` four-letter command and asserts the negotiated timeout is 30000, once per edited config file. Reverting any single config to 10000 fails that assertion with the observed value, so a partial fix or a future re-lowering is caught by CI. The module passes 9/9.

Tracked separately: `DatabaseReplicatedDDLWorker::enqueueQuery` discards its `ZooKeeperRetriesInfo` (`DatabaseReplicatedWorker.cpp:337-341`) where the base honours it.

Master run: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=e0e5e04a027ed740ab3756d4853fb6d21126c077&name_0=MasterCI&name_1=Integration%20tests%20%28amd_tsan%2C%204%2F6%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.481` (included in `26.8` and later)
<!-- ch-version-info:end -->