### PR TITLE
Support legacy documentation anchor casing

### DIFF
--- a/docs/_site/customizations/scroll-reset.js
+++ b/docs/_site/customizations/scroll-reset.js
@@ -26,13 +26,34 @@
     }
   });
 
+  function findAnchor(id) {
+    var exact = document.getElementById(id);
+    if (exact) return exact;
+
+    // Legacy Docusaurus anchors were lowercase, while some Mintlify anchors
+    // preserve identifier casing. Accept casing-only changes in page content,
+    // but fail closed if more than one element could be the intended target.
+    var main = document.querySelector('main');
+    if (!main) return null;
+
+    var normalizedId = id.toLowerCase();
+    var elements = main.querySelectorAll('[id]');
+    var match = null;
+    for (var index = 0; index < elements.length; index += 1) {
+      if (elements[index].id.toLowerCase() !== normalizedId) continue;
+      if (match) return null;
+      match = elements[index];
+    }
+    return match;
+  }
+
   // The new page renders some frames after the path changes, so poll for the
   // anchor target before scrolling to it; if it never appears (bad anchor),
   // fall back to the top rather than keeping the old page's position.
   function scrollToAnchor(hash, framesLeft) {
     var id;
     try { id = decodeURIComponent(hash.slice(1)); } catch (e) { id = hash.slice(1); }
-    var el = document.getElementById(id);
+    var el = findAnchor(id);
     if (el) {
       el.scrollIntoView();
       return;
@@ -57,6 +78,10 @@
       }
     }
     window.requestAnimationFrame(watch);
+  }
+
+  if (window.location.hash) {
+    scrollToAnchor(window.location.hash, 180);
   }
   window.requestAnimationFrame(watch);
 })();

--- a/docs/_site/customizations/scroll-reset.js
+++ b/docs/_site/customizations/scroll-reset.js
@@ -65,9 +65,26 @@
     }
   }
 
+  // Let the browser handle exact anchors on initial load and same-page hash
+  // changes. Only intervene when a legacy casing variant needs compatibility.
+  function scrollToLegacyAnchor(hash, framesLeft) {
+    var id;
+    try { id = decodeURIComponent(hash.slice(1)); } catch (e) { id = hash.slice(1); }
+    if (document.getElementById(id)) return;
+
+    var el = findAnchor(id);
+    if (el) {
+      el.scrollIntoView();
+      return;
+    }
+    if (framesLeft > 0 && window.location.hash === hash) {
+      window.requestAnimationFrame(function () { scrollToLegacyAnchor(hash, framesLeft - 1); });
+    }
+  }
+
   window.addEventListener('hashchange', function () {
     if (window.location.hash) {
-      scrollToAnchor(window.location.hash, 180);
+      scrollToLegacyAnchor(window.location.hash, 180);
     }
   });
 
@@ -87,7 +104,7 @@
   }
 
   if (window.location.hash) {
-    scrollToAnchor(window.location.hash, 180);
+    scrollToLegacyAnchor(window.location.hash, 180);
   }
   window.requestAnimationFrame(watch);
 })();

--- a/docs/_site/customizations/scroll-reset.js
+++ b/docs/_site/customizations/scroll-reset.js
@@ -65,6 +65,12 @@
     }
   }
 
+  window.addEventListener('hashchange', function () {
+    if (window.location.hash) {
+      scrollToAnchor(window.location.hash, 180);
+    }
+  });
+
   function watch() {
     var path = window.location.pathname;
     if (path !== lastPath) {


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/112503

Lowercase documentation fragments such as `#jsonextractarrayraw` can reach a page whose explicit anchor is `#JSONExtractArrayRaw`, leaving the browser unable to find the target. This adds a narrow compatibility lookup to the existing documentation navigation script so legacy inbound links continue to work without changing canonical anchors or regenerating documentation.

The lookup keeps the browser's normal behavior on the fast path: an exact `document.getElementById` match always wins. Only when that fails does it compare IDs case-insensitively, and only among elements inside the page's `<main>` content. If casing produces more than one possible match, it fails closed instead of choosing an ambiguous target.

The investigation found that these links did not all break at one time. Docusaurus lowercased automatically generated heading slugs but preserved explicit heading IDs verbatim. As individual function categories moved from manually authored headings to generated documentation, the generator began supplying explicit, case-preserving IDs for that category:

- JSON functions entered autogeneration on September 19, 2025: https://github.com/ClickHouse/clickhouse-docs/commit/e84be4428aaaef0f4cfd3bc8da5930561841c823
- String functions entered autogeneration on October 18, 2025: https://github.com/ClickHouse/clickhouse-docs/commit/4b4f96253fad22cc0997f5accf97479e25a25d5c
- Type conversion functions entered autogeneration on December 12, 2025: https://github.com/ClickHouse/clickhouse-docs/commit/a924035aa70e294fe85a8d57f87f2940ae469927

This explains why some lowercase links were valid when written and broke later. For example, `pg_clickhouse` added its lowercase `#trimboth` link on October 15, three days before the String category switched to generated, case-preserving anchors: https://github.com/ClickHouse/pg_clickhouse/commit/bc1bd4ee2cfed1f7ede7a2ddddff3050ee04ae3d. Its lowercase `toUInt*` fragments were added on December 8, four days before the Type Conversion category switched: https://github.com/ClickHouse/pg_clickhouse/commit/ca940d0c09fddbb471cf5f34f4a41c8e58a27f76.

The old site was case-sensitive for explicit IDs. Its repository updated lowercase links to their case-preserving targets in October 2025: https://github.com/ClickHouse/clickhouse-docs/commit/1836b91ca86424fcb85106750cc77e34a0d0dd21. The ClickHouse-hosted copy of the `pg_clickhouse` reference similarly corrected these fragments in May 2026, while the upstream `pg_clickhouse.md` retained them: https://github.com/ClickHouse/clickhouse-docs/commit/dca1392a4ce0eda524ff5d8e4d7262cfdccedaaf.

The new documentation launch therefore did not introduce the anchor casing itself, but its redirects made the accumulated compatibility breakage visible again. A runtime compatibility path is preferable to changing canonical IDs because the current documentation corpus also contains many links to the case-preserving fragments.

An audit of https://github.com/ClickHouse/pg_clickhouse/blob/main/doc/pg_clickhouse.md found 14 ClickHouse documentation links whose pages exist but whose fragments differ only by case; this compatibility path repairs those links. Six additional links point to stale or moved headings and are outside the scope of a casing fallback.

Validation covered exact-case targets, lowercase compatibility targets, ambiguous case-insensitive matches, initial hash navigation, and router-managed cross-page navigation. `node --check docs/_site/customizations/scroll-reset.js` also passes.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.394` (included in `26.8` and later)
<!-- ch-version-info:end -->