### PR TITLE
Postpone mutation of a part ahead of the table metadata version

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1915,15 +1915,12 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
         }
     }
 
-    /// A part carries its own metadata version on disk and keeps it when it is fetched from another
-    /// replica, while this replica's table metadata version only advances when it executes its own
-    /// ALTER_METADATA entry. So a fetched part can be ahead of the table, and mutating it against a
-    /// snapshot that does not know its columns yet is not a state the mutation code can represent.
-    /// Wait until the pending ALTER_METADATA is applied, which is what resolves the mismatch.
-    /// This mirrors MergeFromLogEntryTask::prepare, which already refuses to merge in this state.
+    /// A fetched part keeps its own metadata version, so it can be ahead of this replica's table until
+    /// this replica applies its own ALTER_METADATA. MergeFromLogEntryTask::prepare has the same rule.
     if (entry.type == LogEntry::MUTATE_PART && !entry.source_parts.empty())
     {
-        if (auto part = data.getPartIfExists(entry.source_parts[0], {MergeTreeDataPartState::PreActive, MergeTreeDataPartState::Active, MergeTreeDataPartState::Outdated}))
+        if (auto part = data.getPartIfExists(entry.source_parts[0],
+            {MergeTreeDataPartState::PreActive, MergeTreeDataPartState::Active, MergeTreeDataPartState::Outdated}))
         {
             const auto metadata_snapshot = storage.getInMemoryMetadataPtr(storage.getContext(), false);
             int32_t part_metadata_version = part->getMetadataVersion();

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1915,6 +1915,30 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
         }
     }
 
+    /// A part carries its own metadata version on disk and keeps it when it is fetched from another
+    /// replica, while this replica's table metadata version only advances when it executes its own
+    /// ALTER_METADATA entry. So a fetched part can be ahead of the table, and mutating it against a
+    /// snapshot that does not know its columns yet is not a state the mutation code can represent.
+    /// Wait until the pending ALTER_METADATA is applied, which is what resolves the mismatch.
+    /// This mirrors MergeFromLogEntryTask::prepare, which already refuses to merge in this state.
+    if (entry.type == LogEntry::MUTATE_PART && !entry.source_parts.empty())
+    {
+        if (auto part = data.getPartIfExists(entry.source_parts[0], {MergeTreeDataPartState::PreActive, MergeTreeDataPartState::Active, MergeTreeDataPartState::Outdated}))
+        {
+            const auto metadata_snapshot = storage.getInMemoryMetadataPtr(storage.getContext(), false);
+            int32_t part_metadata_version = part->getMetadataVersion();
+            int32_t table_metadata_version = metadata_snapshot->getMetadataVersion();
+            if (part_metadata_version > table_metadata_version)
+            {
+                constexpr auto fmt_string = "Not executing log entry {} of type {} for part {} because source part {} metadata version {} "
+                                            "is newer than the table metadata version {}. ALTER_METADATA is still in progress.";
+                LOG_TRACE(LogToStr(out_postpone_reason, log), fmt_string, entry.znode_name, entry.typeToString(),
+                          entry.new_part_name, part->name, part_metadata_version, table_metadata_version);
+                return false;
+            }
+        }
+    }
+
     /// DROP_RANGE, DROP_PART and REPLACE_RANGE entries remove other entries, which produce parts in the range.
     /// If such part producing operations are currently executing, then DROP/REPLACE RANGE wait them to finish.
     /// Deadlock is possible if multiple DROP/REPLACE RANGE entries are executing in parallel and wait each other.

--- a/tests/queries/0_stateless/04652_mutate_part_ahead_of_table_metadata_version.reference
+++ b/tests/queries/0_stateless/04652_mutate_part_ahead_of_table_metadata_version.reference
@@ -1,0 +1,13 @@
+held replica still at metadata version 0: 1
+other replica advanced to metadata version 1: 1
+ALTER_METADATA still queued on the held replica: 1
+held replica fetched the part containing h: 1
+MUTATE_PART postponed because the source part is ahead of the table: 1
+both replicas reached metadata version 1: 1
+mutation finished without a failure: 1
+data on data_r1:
+1	10	7
+3	30	98
+data on data_r2:
+1	10	7
+3	30	98

--- a/tests/queries/0_stateless/04652_mutate_part_ahead_of_table_metadata_version.sh
+++ b/tests/queries/0_stateless/04652_mutate_part_ahead_of_table_metadata_version.sh
@@ -17,9 +17,6 @@ function restore_failpoints()
         return
     fi
 
-    # In case we failed inside the stopped-merges window below
-    $CLICKHOUSE_CLIENT -q "system start merges $advanced_replica" ||:
-
     # Let the failed ALTER_METADATA succeed again, to avoid endless errors in logs
     $CLICKHOUSE_CLIENT -q "system enable failpoint replicated_queue_unfail_entries" ||:
     $CLICKHOUSE_CLIENT -q "system sync replica $held_replica" ||:
@@ -31,8 +28,10 @@ $CLICKHOUSE_CLIENT -m --insert_keeper_fault_injection_probability=0 -q "
     drop table if exists data_r1;
     drop table if exists data_r2;
 
-    create table data_r1 (key Int, value Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/data', 'r1') order by key;
-    create table data_r2 (key Int, value Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/data', 'r2') order by key;
+    -- Merges disabled on both replicas: the pre-ALTER and post-ALTER parts are mutually mergeable,
+    -- and a covering part would make the exact-name assertions below vacuous.
+    create table data_r1 (key Int, value Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/data', 'r1') order by key settings max_bytes_to_merge_at_max_space_in_pool = 0;
+    create table data_r2 (key Int, value Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/data', 'r2') order by key settings max_bytes_to_merge_at_max_space_in_pool = 0;
 
     insert into data_r1 (key, value) values (1, 10);
 
@@ -72,13 +71,6 @@ if [[ -z $held_replica ]]; then
     echo "Table metadata version did not diverge between the replicas" >&2 && exit 1
 fi
 
-# Stop merges on the advanced replica only, which is the one that assigns merges here. The pre-ALTER
-# part and the post-ALTER one are mutually mergeable (a metadata-only ALTER creates no mutation, so
-# both are at mutation version 0), so otherwise the held replica could fetch a covering part instead
-# and the exact-name assertions below would become vacuous. Not stopped on the held replica: the same
-# blocker gates MUTATE_PART, which would postpone our mutation for the wrong reason.
-$CLICKHOUSE_CLIENT -q "system stop merges $advanced_replica"
-
 # Write a part at metadata version 1 containing `h` and let the held-back replica fetch it.
 # metadata_version.txt travels with the part, so the fetched part is ahead of that replica's table.
 # Two rows, so the DELETE below touches some but not all of them: a mutation that affects no row
@@ -95,8 +87,6 @@ for ((i = 0; i < 300; ++i)); do
     fi
     sleep 0.1
 done
-
-$CLICKHOUSE_CLIENT -q "system start merges $advanced_replica"
 
 # Assert the fixture really built the state, otherwise the test below proves nothing.
 echo -n 'held replica still at metadata version 0: '

--- a/tests/queries/0_stateless/04652_mutate_part_ahead_of_table_metadata_version.sh
+++ b/tests/queries/0_stateless/04652_mutate_part_ahead_of_table_metadata_version.sh
@@ -17,6 +17,9 @@ function restore_failpoints()
         return
     fi
 
+    # In case we failed inside the stopped-merges window below
+    $CLICKHOUSE_CLIENT -q "system start merges $advanced_replica" ||:
+
     # Let the failed ALTER_METADATA succeed again, to avoid endless errors in logs
     $CLICKHOUSE_CLIENT -q "system enable failpoint replicated_queue_unfail_entries" ||:
     $CLICKHOUSE_CLIENT -q "system sync replica $held_replica" ||:
@@ -69,6 +72,13 @@ if [[ -z $held_replica ]]; then
     echo "Table metadata version did not diverge between the replicas" >&2 && exit 1
 fi
 
+# Stop merges on the advanced replica only, which is the one that assigns merges here. The pre-ALTER
+# part and the post-ALTER one are mutually mergeable (a metadata-only ALTER creates no mutation, so
+# both are at mutation version 0), so otherwise the held replica could fetch a covering part instead
+# and the exact-name assertions below would become vacuous. Not stopped on the held replica: the same
+# blocker gates MUTATE_PART, which would postpone our mutation for the wrong reason.
+$CLICKHOUSE_CLIENT -q "system stop merges $advanced_replica"
+
 # Write a part at metadata version 1 containing `h` and let the held-back replica fetch it.
 # metadata_version.txt travels with the part, so the fetched part is ahead of that replica's table.
 # Two rows, so the DELETE below touches some but not all of them: a mutation that affects no row
@@ -85,6 +95,8 @@ for ((i = 0; i < 300; ++i)); do
     fi
     sleep 0.1
 done
+
+$CLICKHOUSE_CLIENT -q "system start merges $advanced_replica"
 
 # Assert the fixture really built the state, otherwise the test below proves nothing.
 echo -n 'held replica still at metadata version 0: '

--- a/tests/queries/0_stateless/04652_mutate_part_ahead_of_table_metadata_version.sh
+++ b/tests/queries/0_stateless/04652_mutate_part_ahead_of_table_metadata_version.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Tags: zookeeper, no-parallel, no-shared-merge-tree, no-replicated-database
+# Tag no-parallel: replicated_queue_fail_next_entry is a server-global ONCE failpoint, so a
+#                  concurrent copy of this test would consume it instead of our ALTER_METADATA
+# Tag no-shared-merge-tree: tests ReplicatedMergeTree queue behaviour with failpoints
+# Tag no-replicated-database: the test drives ALTER_METADATA on individual replicas
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+set -e
+
+function restore_failpoints()
+{
+    if [ -z "${held_replica:-}" ]; then
+        return
+    fi
+
+    # Let the failed ALTER_METADATA succeed again, to avoid endless errors in logs
+    $CLICKHOUSE_CLIENT -q "system enable failpoint replicated_queue_unfail_entries" ||:
+    $CLICKHOUSE_CLIENT -q "system sync replica $held_replica" ||:
+    $CLICKHOUSE_CLIENT -q "system disable failpoint replicated_queue_unfail_entries" ||:
+}
+trap restore_failpoints EXIT
+
+$CLICKHOUSE_CLIENT -m --insert_keeper_fault_injection_probability=0 -q "
+    drop table if exists data_r1;
+    drop table if exists data_r2;
+
+    create table data_r1 (key Int, value Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/data', 'r1') order by key;
+    create table data_r2 (key Int, value Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/data', 'r2') order by key;
+
+    insert into data_r1 (key, value) values (1, 10);
+
+    -- Sync both replicas before enabling the failpoint, so no pending queue entry
+    -- (e.g. GET_PART for data_r2) can consume the ONCE failpoint instead of ALTER_METADATA.
+    system sync replica data_r1;
+    system sync replica data_r2;
+"
+
+# Fail ALTER_METADATA on one of the replicas. That replica keeps the entry in its queue and stays
+# at metadata version 0, while the other one advances to metadata version 1.
+$CLICKHOUSE_CLIENT -m -q "
+    system enable failpoint replicated_queue_fail_next_entry;
+    alter table data_r1 add column h Int default 7 settings alter_sync = 0;
+
+    system sync replica data_r1 pull;
+    system sync replica data_r2 pull;
+"
+
+# Which replica consumes the ONCE failpoint is not fixed, so measure it. ADD COLUMN is
+# metadata-only and creates no mutation, so system.mutations cannot tell the replicas apart --
+# system.tables.metadata_version is the quantity that actually differs.
+held_replica=
+advanced_replica=
+for ((i = 0; i < 300; ++i)); do
+    mv1=$($CLICKHOUSE_CLIENT -q "select metadata_version from system.tables where database = currentDatabase() and name = 'data_r1'")
+    mv2=$($CLICKHOUSE_CLIENT -q "select metadata_version from system.tables where database = currentDatabase() and name = 'data_r2'")
+    if [[ $mv1 -gt $mv2 ]]; then
+        held_replica=data_r2 && advanced_replica=data_r1 && break
+    fi
+    if [[ $mv2 -gt $mv1 ]]; then
+        held_replica=data_r1 && advanced_replica=data_r2 && break
+    fi
+    sleep 0.1
+done
+if [[ -z $held_replica ]]; then
+    echo "Table metadata version did not diverge between the replicas" >&2 && exit 1
+fi
+
+# Write a part at metadata version 1 containing `h` and let the held-back replica fetch it.
+# metadata_version.txt travels with the part, so the fetched part is ahead of that replica's table.
+# Two rows, so the DELETE below touches some but not all of them: a mutation that affects no row
+# (or every row) is short-circuited before the mutation commands are computed at all.
+$CLICKHOUSE_CLIENT -m --insert_keeper_fault_injection_probability=0 -q "
+    insert into $advanced_replica (key, value, h) values (2, 20, 99), (3, 30, 98);
+    system sync replica $advanced_replica pull;
+"
+
+for ((i = 0; i < 300; ++i)); do
+    fetched=$($CLICKHOUSE_CLIENT -q "select count() from system.parts where database = currentDatabase() and table = '$held_replica' and active and name = 'all_1_1_0'")
+    if [[ $fetched -eq 1 ]]; then
+        break
+    fi
+    sleep 0.1
+done
+
+# Assert the fixture really built the state, otherwise the test below proves nothing.
+echo -n 'held replica still at metadata version 0: '
+$CLICKHOUSE_CLIENT -q "select metadata_version = 0 from system.tables where database = currentDatabase() and name = '$held_replica'"
+echo -n 'other replica advanced to metadata version 1: '
+$CLICKHOUSE_CLIENT -q "select metadata_version = 1 from system.tables where database = currentDatabase() and name = '$advanced_replica'"
+echo -n 'ALTER_METADATA still queued on the held replica: '
+$CLICKHOUSE_CLIENT -q "select count() = 1 from system.replication_queue where database = currentDatabase() and table = '$held_replica' and type = 'ALTER_METADATA' and num_tries > 0"
+echo -n 'held replica fetched the part containing h: '
+$CLICKHOUSE_CLIENT -q "select count() = 1 from system.parts_columns where database = currentDatabase() and table = '$held_replica' and name = 'all_1_1_0' and column = 'h'"
+
+# A plain data mutation carries alter_version = -1, so the existing alter sequencing does not
+# apply to it. Before the fix this mutated the fetched part against a table snapshot that does not
+# know `h` and threw LOGICAL_ERROR "Part ... contains column h that is absent in table ...".
+$CLICKHOUSE_CLIENT -q "alter table $held_replica delete where key = 2 settings mutations_sync = 0"
+
+# The MUTATE_PART entry has to be postponed instead. Asserting the postpone reason (and not just
+# the absence of an error) is what proves the guard fired.
+postponed=0
+for ((i = 0; i < 300; ++i)); do
+    postponed=$($CLICKHOUSE_CLIENT -q "select count() from system.replication_queue where database = currentDatabase() and table = '$held_replica' and type = 'MUTATE_PART' and postpone_reason like '%metadata version 1 is newer than the table metadata version 0%'")
+    if [[ $postponed -eq 1 ]]; then
+        break
+    fi
+    sleep 0.1
+done
+echo -n 'MUTATE_PART postponed because the source part is ahead of the table: '
+echo "$postponed"
+
+# Applying the pending ALTER_METADATA resolves the mismatch and the mutation goes through.
+restore_failpoints
+trap '' EXIT
+held_replica=
+
+$CLICKHOUSE_CLIENT -m -q "
+    system sync replica data_r1;
+    system sync replica data_r2;
+"
+
+echo -n 'both replicas reached metadata version 1: '
+$CLICKHOUSE_CLIENT -q "select countIf(metadata_version = 1) = 2 from system.tables where database = currentDatabase() and name in ('data_r1', 'data_r2')"
+echo -n 'mutation finished without a failure: '
+$CLICKHOUSE_CLIENT -q "select countIf(is_done and latest_fail_reason = '') = 2 from system.mutations where database = currentDatabase() and table in ('data_r1', 'data_r2')"
+echo 'data on data_r1:'
+$CLICKHOUSE_CLIENT -q "select key, value, h from data_r1 order by key"
+echo 'data on data_r2:'
+$CLICKHOUSE_CLIENT -q "select key, value, h from data_r2 order by key"
+
+$CLICKHOUSE_CLIENT -m -q "
+    drop table data_r1;
+    drop table data_r2;
+"


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/91015
Related: https://github.com/ClickHouse/ClickHouse/issues/102153
Related: https://github.com/ClickHouse/ClickHouse/pull/102349
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/91015
Related: https://github.com/ClickHouse/ClickHouse/issues/102153
Related: https://github.com/ClickHouse/ClickHouse/pull/102349

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a `LOGICAL_ERROR` ("Part ... contains column ... that is absent in table ...") when a `ReplicatedMergeTree` replica mutates a part it fetched from another replica before applying its own pending `ALTER ... ADD COLUMN`. Such a mutation is now postponed until the metadata change is applied.

### Description

A part stores its metadata version on disk and keeps it when it is fetched, while a replica's
table metadata version only advances when that replica executes its own `ALTER_METADATA` entry.
So a replica can hold a fetched part at metadata version 1, containing a column it does not know
yet, while its own snapshot is still at version 0. A plain `ALTER ... DELETE` carries
`alter_version = -1`, so the existing alter sequencing does not apply, and mutating that part
throws `LOGICAL_ERROR` at `MutateTask.cpp:510`, aborting the server in debug and sanitizer
builds.

This is a gap between the two subclasses of `ReplicatedMergeMutateTaskBase`.
`MergeFromLogEntryTask::prepare` already refuses to run in this state ("ALTER_METADATA is still
in progress"); the mutation path had no equivalent. This adds the same rule for `MUTATE_PART` in
`ReplicatedMergeTreeQueue::shouldExecuteLogEntry`, so the entry waits for the pending
`ALTER_METADATA` and the mutation then completes normally. The queue predicate is used rather
than `prepare` so nothing is reserved or locked before bailing out, and the reason surfaces in
`system.replication_queue.postpone_reason`.

`MutateTask.cpp` is unchanged, so the assertion keeps its meaning and the equal-versions case
still throws. This is not the soft-keep direction of #96008, reverted in #97301 as a
data-loss risk. Like the merge-side guard, the postpone is unconditional, inheriting its
assumption that some `ALTER_METADATA` eventually applies; recovery synthesizes a `dummy_alter`
and a restart reads the version from Keeper. The added metadata read is the same
`MultiVersion::get` shape as this predicate's existing `getSettings()` calls.

A new stateless test builds the state with `replicated_queue_fail_next_entry`:
without the fix the server aborts with the reported message; with it the entry is postponed and
the mutation completes once the metadata change lands. 50/50 randomized runs pass, as does
`00992_system_parts_race_condition_zookeeper_long`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.482` (included in `26.8` and later)
<!-- ch-version-info:end -->