### PR TITLE
Retain core dumps of crashed clients in stateless CI jobs

### DIFF
--- a/ci/decrypt-cores.md
+++ b/ci/decrypt-cores.md
@@ -25,10 +25,13 @@ When a job collects core dumps, it attaches the following files to the run:
 
 - `aes.key.rsa` - the RSA-OAEP-wrapped AES key. There is exactly one per job, and
   it decrypts every core that job attached.
-- One or more `<origin>.core.<comm>.<pid>.zst.enc` files. `<origin>` says where the
-  core came from: `run_r0`/`run_r1`/`run_r2` for a server replica, `client` for a
-  `clickhouse-client` or `clickhouse-local` process that a test spawned. At most
-  three cores are taken per origin.
+- One or more encrypted cores, at most three per directory collected from. The
+  stateless and fast-test jobs collect from several directories, so each core is
+  prefixed with its origin: `<origin>.core.<comm>.<pid>.zst.enc`, where `<origin>`
+  is `run_r0`/`run_r1`/`run_r2` for a server replica and `client` for a
+  `clickhouse-client` or `clickhouse-local` process that a test spawned. The
+  AST-fuzzer and stress jobs collect from a single directory and keep the
+  unprefixed `core.<comm>.<pid>.zst.enc` form.
 
 Client cores are collected only for jobs that declare the directory their
 `clickhouse-test` runs from (`ClickHouseProc.client_core_path`). A relative
@@ -63,16 +66,19 @@ openssl pkeyutl -decrypt \
 
 # 2. Decrypt the compressed core.
 openssl enc -d -aes-256-cbc \
-    -in core.<pid>.zst.enc \
-    -out core.<pid>.zst \
+    -in <core>.zst.enc \
+    -out <core>.zst \
     -pbkdf2 \
     -pass file:aes.key
 
 # 3. Decompress to obtain the raw core file.
-zstd -d core.<pid>.zst -o core.<pid>
+zstd -d <core>.zst -o <core>
 ```
 
-Repeat steps 2 and 3 for each `core.<pid>.zst.enc` artifact. The same
+`<core>` is whatever the downloaded file is called:
+`run_r0.core.MergeMutate.654-5182` for a stateless server core,
+`client.core.clickhouse-clie.138694` for a client core, `core.Fuzzer.7` for a
+fuzzer core. Repeat steps 2 and 3 for each `.zst.enc` artifact. The same
 `aes.key` works for every core file in the same job.
 
 ## Loading the Core in gdb
@@ -85,7 +91,7 @@ with the helper in `.claude/skills/decompress-binary`:
 
 ```bash
 python3 .claude/skills/decompress-binary/extract_self_extracting.py clickhouse clickhouse.elf
-gdb clickhouse.elf core.<pid>      # or: lldb clickhouse.elf -c core.<pid>
+gdb clickhouse.elf <core>          # or: lldb clickhouse.elf -c <core>
 ```
 
 The binary must come from the exact build that produced the core (matching

--- a/ci/decrypt-cores.md
+++ b/ci/decrypt-cores.md
@@ -23,14 +23,23 @@ maintainers and is required for decryption.
 
 When a job collects core dumps, it attaches the following files to the run:
 
-- `aes.key.rsa` — the RSA-OAEP-wrapped AES key for that job.
-- One or more `core.<pid>.zst.enc` files — at most three, taken from
-  `ci/tmp/run_r*/core.*`.
+- `aes.key.rsa` - the RSA-OAEP-wrapped AES key. There is exactly one per job, and
+  it decrypts every core that job attached.
+- One or more `<origin>.core.<comm>.<pid>.zst.enc` files. `<origin>` says where the
+  core came from: `run_r0`/`run_r1`/`run_r2` for a server replica, `client` for a
+  `clickhouse-client` or `clickhouse-local` process that a test spawned. At most
+  three cores are taken per origin.
+
+Client cores are collected only for jobs that declare the directory their
+`clickhouse-test` runs from (`ClickHouseProc.client_core_path`). A relative
+`kernel.core_pattern`, which is what CI runners use, writes a core into the
+working directory of the dumping process, and that directory differs between jobs.
 
 You will also need the matching `clickhouse` binary (download it from the build
 job for the same commit) to actually analyze the core in `gdb`. That binary is
 self-extracting; to get the inner ELF with symbols, see "Loading the Core in
-gdb" below.
+gdb" below. A job that runs several build types, such as bugfix validation,
+replaces the binary between runs, so pick the build the core came from.
 
 ## Prerequisites
 

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -344,6 +344,10 @@ def main():
         ch_config_dir=f"{temp_dir}/etc/clickhouse-server",
         ch_var_lib_dir=f"{temp_dir}/var/lib/clickhouse",
     )
+    # `fast_test_command` below prefixes `cd {temp_dir}`, so clients spawned by
+    # tests inherit that directory rather than the repository root this job runs
+    # from, and dump their cores there.
+    CH.client_core_path = str(temp_dir)
     CH.install_configs()
 
     attach_debug = False

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -742,8 +742,8 @@ def main():
         is_shared_catalog=is_shared_catalog,
         is_per_test_coverage=is_per_test_coverage,
     )
-    # `run_stateless_test` runs `clickhouse-test` without changing directory, so
-    # clients it spawns inherit the repository root and dump their cores there.
+    # `run_tests` runs `clickhouse-test` without changing directory, so clients
+    # it spawns inherit the repository root and dump their cores there.
     # Declaring it lets `prepare_logs` retain the core of a client that died on a
     # fatal signal; without it such a crash leaves no core and no stack anywhere.
     CH.client_core_path = Utils.cwd()
@@ -1314,6 +1314,13 @@ def main():
         test_result.extend_sub_results(results[-1].results)
         results[-1].results = []
 
+    # `invert_bugfix_validation_status` below rewrites a reproduced failure to
+    # `OK` (and a no-repro to `SKIPPED`), both of which `Result.is_ok` accepts.
+    # The collect-logs gate must see the run's real outcome, or a bugfix
+    # validation job that reproduced a crash would attach neither its cores nor
+    # its full logs.
+    test_run_failed = bool(test_result) and not test_result.is_ok()
+
     # invert result status for bugfix validation
     bugfix_validation_no_repro = False
     if is_labeled_bugfix_validation and test_result:
@@ -1330,7 +1337,7 @@ def main():
         print("Collect logs")
 
         def collect_logs():
-            CH.prepare_logs(all=test_result and not test_result.is_ok(), info=info)
+            CH.prepare_logs(all=test_run_failed, info=info)
 
         results.append(
             Result.from_commands_run(

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -742,6 +742,11 @@ def main():
         is_shared_catalog=is_shared_catalog,
         is_per_test_coverage=is_per_test_coverage,
     )
+    # `run_stateless_test` runs `clickhouse-test` without changing directory, so
+    # clients it spawns inherit the repository root and dump their cores there.
+    # Declaring it lets `prepare_logs` retain the core of a client that died on a
+    # fatal signal; without it such a crash leaves no core and no stack anywhere.
+    CH.client_core_path = Utils.cwd()
 
     job_info = ""
 

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -71,6 +71,14 @@ class ClickHouseProc:
         self.run_path0 = f"{temp_dir}/run_r0"
         self.run_path1 = f"{temp_dir}/run_r1"
         self.run_path2 = f"{temp_dir}/run_r2"
+        # Directory the job runs `clickhouse-test` from, if it wants cores of
+        # crashed client processes collected. A client started by a `.sh` test
+        # inherits this directory, and a relative `kernel.core_pattern` (the one
+        # CI runners use) writes the core into the dumping process's cwd, so this
+        # is where a client core lands. Jobs differ - `functional_tests.py` runs
+        # from the repository root while `fast_test.py` prefixes `cd {temp_dir}` -
+        # so the job declares it instead of it being guessed here.
+        self.client_core_path = None
         self.log_dir = f"{temp_dir}/var/log/clickhouse-server"
         self.pid_file = f"{self.ch_config_dir}/clickhouse-server.pid"
         self.config_file = f"{self.ch_config_dir}/config.xml"
@@ -832,9 +840,37 @@ clickhouse-client --query "SELECT count() FROM test.visits"
         return res
 
     def _collect_core_dumps(self) -> List[str]:
+        # Server cores land in `run_r*` because each server is started with
+        # `cwd=run_path` (see `_start_server`) and is not a daemon, so
+        # `BaseDaemon`'s `chdir` into a `core_path` directory is skipped. Setting
+        # `--daemon` or a `core_path` would move them into `run_rN/cores/` and this
+        # glob would stop finding them.
         result = []
+        # One AES key for the whole job. Artifacts are uploaded under their
+        # basename alone, so a key per directory would emit several different
+        # `aes.key.rsa` files that overwrite each other in the report, leaving the
+        # cores of every directory but the last one undecryptable.
+        aes_key_path = f"{temp_dir}/aes.key"
         for run_dir in sorted(p_temp_dir.glob("run_r*")):
-            result.extend(ClickHouseService.collect_cores(run_dir))
+            result.extend(
+                ClickHouseService.collect_cores(
+                    run_dir,
+                    aes_key_path=aes_key_path,
+                    # `core.<comm>.<pid>` collides across replicas running the
+                    # same thread; keep the basenames distinct.
+                    name_prefix=f"{Path(run_dir).name}.",
+                )
+            )
+        # `Path.glob` yields nothing for a missing directory, so a declared path
+        # that does not exist needs no separate guard.
+        if self.client_core_path:
+            result.extend(
+                ClickHouseService.collect_cores(
+                    self.client_core_path,
+                    aes_key_path=aes_key_path,
+                    name_prefix="client.",
+                )
+            )
         return result
 
     @staticmethod

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -73,11 +73,12 @@ class ClickHouseProc:
         self.run_path2 = f"{temp_dir}/run_r2"
         # Directory the job runs `clickhouse-test` from, if it wants cores of
         # crashed client processes collected. A client started by a `.sh` test
-        # inherits this directory, and a relative `kernel.core_pattern` (the one
-        # CI runners use) writes the core into the dumping process's cwd, so this
-        # is where a client core lands. Jobs differ - `functional_tests.py` runs
-        # from the repository root while `fast_test.py` prefixes `cd {temp_dir}` -
-        # so the job declares it instead of it being guessed here.
+        # inherits this directory unless the test changes directory itself, and a
+        # relative `kernel.core_pattern` (the one CI runners use) writes the core
+        # into the dumping process's cwd, so this is where a client core lands.
+        # Jobs differ - `functional_tests.py` runs from the repository root while
+        # `fast_test.py` prefixes `cd {temp_dir}` - so the job declares it instead
+        # of it being guessed here.
         self.client_core_path = None
         self.log_dir = f"{temp_dir}/var/log/clickhouse-server"
         self.pid_file = f"{self.ch_config_dir}/clickhouse-server.pid"
@@ -841,7 +842,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
 
     def _collect_core_dumps(self) -> List[str]:
         # Server cores land in `run_r*` because each server is started with
-        # `cwd=run_path` (see `_start_server`) and is not a daemon, so
+        # `cwd=run_path` (see `start`) and is not a daemon, so
         # `BaseDaemon`'s `chdir` into a `core_path` directory is skipped. Setting
         # `--daemon` or a `core_path` would move them into `run_rN/cores/` and this
         # glob would stop finding them.

--- a/ci/jobs/scripts/clickhouse_service.py
+++ b/ci/jobs/scripts/clickhouse_service.py
@@ -205,14 +205,36 @@ class ClickHouseService:
         raise RuntimeError(f"Server not ready after {attempts * delay}s")
 
     @staticmethod
-    def collect_cores(directory) -> list:
+    def collect_cores(directory, aes_key_path=None, name_prefix="") -> list:
+        """Compress and encrypt up to three `core.*` files from a single directory.
+
+        Artifacts are uploaded under their basename alone
+        (`S3.copy_file_to_s3` appends `Path(local_path).name`), so a caller that
+        collects from more than one directory must keep both the AES key and the
+        core names unique across those directories or the later upload silently
+        overwrites the earlier one:
+
+        `aes_key_path` overrides the default per-directory key location. Pass one
+        shared path for all directories of a job: `Utils.encrypt` only generates a
+        key when `<aes_key_path>.rsa` is absent, so every core is then wrapped with
+        the same key and a single `aes.key.rsa` is emitted. Without it each
+        directory gets its own key under the same basename, and the surviving
+        upload cannot decrypt the other directory's cores.
+
+        `name_prefix` disambiguates core basenames, which are `core.<comm>.<pid>`
+        and thus collide across replicas running the same thread.
+        """
         key_path = f"{repo_dir}/ci/defs/public.pem"
         assert Path(key_path).exists(), f"RSA public key not found: {key_path}"
-        aes_key_path = str(Path(directory) / "aes.key")
+        if aes_key_path is None:
+            aes_key_path = str(Path(directory) / "aes.key")
+        aes_key_path = str(aes_key_path)
         encrypted = []
         for core in sorted(Path(directory).glob("core.*"))[:3]:
             if not core.name.endswith(".zst") and not core.name.endswith(".enc"):
-                zst_path = Utils.compress_zst(core)
+                zst_path = Utils.compress_zst(
+                    core, dest_path=str(core.parent / f"{name_prefix}{core.name}.zst")
+                )
                 encrypted.append(Utils.encrypt(str(zst_path), key_path, aes_key_path))
         if encrypted and Path(f"{aes_key_path}.rsa").exists():
             encrypted.append(f"{aes_key_path}.rsa")

--- a/ci/tests/test_collect_core_dumps.py
+++ b/ci/tests/test_collect_core_dumps.py
@@ -199,6 +199,13 @@ def test_one_aes_key_for_the_whole_job(monkeypatch, tmp_path):
     if not shutil.which("openssl") or not shutil.which("zstd"):
         pytest.skip("openssl and zstd are needed to decrypt a collected core")
 
+    # The client directory must differ from `temp_dir`: the shared key is
+    # `{temp_dir}/aes.key` and `collect_cores` defaults to
+    # `{directory}/aes.key`, so if the two are the same directory the paths
+    # alias and dropping the shared key from the client call is undetectable.
+    # They differ in the stateless job too, where `client_core_path` is the
+    # repository root and `temp_dir` is `<repo>/ci/tmp`.
+    client_dir = tmp_path / "workdir"
     payloads = {
         "run_r0.core.MergeMutate.654-5182.zst.enc": _write_core(
             tmp_path / "run_r0", "core.MergeMutate.654-5182"
@@ -207,11 +214,11 @@ def test_one_aes_key_for_the_whole_job(monkeypatch, tmp_path):
             tmp_path / "run_r1", "core.MergeMutate.654-5182"
         ),
         "client.core.clickhouse-clie.138694.zst.enc": _write_core(
-            tmp_path, "core.clickhouse-clie.138694"
+            client_dir, "core.clickhouse-clie.138694"
         ),
     }
     collected = _collector(
-        monkeypatch, tmp_path, client_core_path=tmp_path
+        monkeypatch, tmp_path, client_core_path=client_dir
     )._collect_core_dumps()
 
     keys = {str(Path(f).resolve()) for f in collected if f.endswith("aes.key.rsa")}

--- a/ci/tests/test_collect_core_dumps.py
+++ b/ci/tests/test_collect_core_dumps.py
@@ -2,7 +2,7 @@
 Tests for the core-dump collection built by `ClickHouseProc._collect_core_dumps`
 and `ClickHouseService.collect_cores`.
 
-Two properties are covered.
+Three properties are covered.
 
 1. A core left by a `clickhouse-client` / `clickhouse-local` process that died on a
    fatal signal is retained. Only server cores used to be collected, because the
@@ -11,40 +11,60 @@ Two properties are covered.
    with `return code: 139` therefore left no core and no stack anywhere, and the
    crash could not be root-caused (`00900_long_parquet`, 2026-07-29).
 
-2. Collected artifacts do not overwrite each other. Every artifact is uploaded
-   under its basename alone (`S3.copy_file_to_s3` appends `Path(local_path).name`)
-   and the per-result deduplication keys on the resolved absolute path, so two
+2. Collected artifacts do not overwrite each other, and every core actually
+   decrypts with the single key the job emits. Every artifact is uploaded under
+   its basename alone (`S3.copy_file_to_s3` appends `Path(local_path).name`) and
+   the per-result deduplication keys on the resolved absolute path, so two
    distinct files sharing a basename become one object and the later upload wins.
    With a key derived per directory that silently produced several different
    `aes.key.rsa` files, leaving the cores of every directory but the last one
    permanently undecryptable, and `core.<comm>.<pid>` collides across replicas
    running the same thread.
+
+3. The collector only runs when the job actually failed, and the jobs that want
+   client cores really declare their directory. Both are properties of code the
+   unit tests above cannot reach without starting servers, so they are asserted
+   statically from the job modules' source.
 """
 
+import ast
 import os
+import shutil
+import subprocess
 import sys
 from collections import Counter
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
+from ci.jobs.functional_tests import invert_bugfix_validation_status
 from ci.jobs.scripts import clickhouse_proc as clickhouse_proc_module
 from ci.jobs.scripts.clickhouse_proc import ClickHouseProc
 from ci.jobs.scripts.clickhouse_service import ClickHouseService
+from ci.praktika.result import Result
+
+# Read at import time so the restore of the redirected module globals can be
+# asserted rather than assumed.
+IMPORT_TIME_TEMP_DIR = clickhouse_proc_module.temp_dir
+IMPORT_TIME_P_TEMP_DIR = clickhouse_proc_module.p_temp_dir
+
+JOBS_DIR = Path(__file__).resolve().parent.parent / "jobs"
 
 
-def _collector(tmp_path, client_core_path=None):
+def _collector(monkeypatch, tmp_path, client_core_path=None):
     """A `ClickHouseProc` whose temp dir is `tmp_path`.
 
-    The module-level `temp_dir` / `p_temp_dir` are derived from the repository at
-    import time, so they are redirected for the duration of the test.
+    `temp_dir` / `p_temp_dir` are module globals derived from the repository at
+    import time; `monkeypatch` restores them after the test.
     """
     proc = ClickHouseProc.__new__(ClickHouseProc)
     proc.client_core_path = (
         str(client_core_path) if client_core_path is not None else None
     )
-    clickhouse_proc_module.temp_dir = str(tmp_path)
-    clickhouse_proc_module.p_temp_dir = Path(tmp_path)
+    monkeypatch.setattr(clickhouse_proc_module, "temp_dir", str(tmp_path))
+    monkeypatch.setattr(clickhouse_proc_module, "p_temp_dir", Path(tmp_path))
     return proc
 
 
@@ -58,8 +78,8 @@ def _write_core(directory: Path, name: str, size: int = 2048) -> bytes:
 def _upload(files):
     """Model the upload of `result.files`, in the two stages CI performs.
 
-    `Result.upload_files` deduplicates by resolved absolute path, then
-    `S3.copy_file_to_s3` keys the object by basename. Returns the resulting
+    `Result.upload_result_files_to_s3` deduplicates by resolved absolute path,
+    then `S3.copy_file_to_s3` keys the object by basename. Returns the resulting
     objects and the basenames for which two *different* files collided, i.e. the
     ones where an upload destroys another upload's data.
     """
@@ -77,71 +97,184 @@ def _upload(files):
     return objects, overwritten
 
 
-def test_client_core_is_collected(tmp_path):
+def _job_source(name):
+    """Source text and parsed tree of a job module.
+
+    The modules are read, not imported: importing `fast_test` has import-time
+    side effects, and running either `main` would start servers.
+    """
+    text = (JOBS_DIR / name).read_text()
+    return text, ast.parse(text)
+
+
+def _assignments_to(tree, attribute):
+    """Every `x = ...` / `o.x = ...` statement in `tree` that assigns `attribute`."""
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Attribute):
+                name = target.attr
+            elif isinstance(target, ast.Name):
+                name = target.id
+            else:
+                name = None
+            if name == attribute:
+                found.append(node)
+    return found
+
+
+def _function(tree, name):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"function {name} not found")
+
+
+def _calls_to(tree, attribute, of=None):
+    """Every call of `attribute` (optionally as `of.attribute`) inside `tree`."""
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == attribute:
+            if of is None or (isinstance(func.value, ast.Name) and func.value.id == of):
+                found.append(node)
+        elif isinstance(func, ast.Name) and func.id == attribute and of is None:
+            found.append(node)
+    return found
+
+
+def _keyword(call, name):
+    for keyword in call.keywords:
+        if keyword.arg == name:
+            return keyword
+    return None
+
+
+def _run(command):
+    return subprocess.run(command, capture_output=True)
+
+
+def test_client_core_is_collected(monkeypatch, tmp_path):
     _write_core(tmp_path, "core.clickhouse-clie.138694")
-    collected = _collector(tmp_path, client_core_path=tmp_path)._collect_core_dumps()
+    collected = _collector(
+        monkeypatch, tmp_path, client_core_path=tmp_path
+    )._collect_core_dumps()
 
     cores = [Path(f).name for f in collected if f.endswith(".zst.enc")]
     assert cores == ["client.core.clickhouse-clie.138694.zst.enc"], cores
 
 
-def test_clickhouse_local_core_is_collected(tmp_path):
+def test_clickhouse_local_core_is_collected(monkeypatch, tmp_path):
     _write_core(tmp_path, "core.clickhouse-loca.99001")
-    collected = _collector(tmp_path, client_core_path=tmp_path)._collect_core_dumps()
+    collected = _collector(
+        monkeypatch, tmp_path, client_core_path=tmp_path
+    )._collect_core_dumps()
 
     cores = [Path(f).name for f in collected if f.endswith(".zst.enc")]
     assert cores == ["client.core.clickhouse-loca.99001.zst.enc"], cores
 
 
-def test_client_core_not_collected_when_directory_not_declared(tmp_path):
+def test_client_core_not_collected_when_directory_not_declared(monkeypatch, tmp_path):
     """A job that does not declare its client directory keeps today's behaviour."""
     _write_core(tmp_path, "core.clickhouse-clie.138694")
     _write_core(tmp_path / "run_r0", "core.Server.1")
-    collected = _collector(tmp_path)._collect_core_dumps()
+    collected = _collector(monkeypatch, tmp_path)._collect_core_dumps()
 
     cores = [Path(f).name for f in collected if f.endswith(".zst.enc")]
     assert cores == ["run_r0.core.Server.1.zst.enc"], cores
 
 
-def test_one_aes_key_for_the_whole_job(tmp_path):
-    """Several directories must share one key, or all but one become unreadable."""
-    _write_core(tmp_path / "run_r0", "core.MergeMutate.654-5182")
-    _write_core(tmp_path / "run_r1", "core.MergeMutate.654-5182")
-    _write_core(tmp_path, "core.clickhouse-clie.138694")
-    collected = _collector(tmp_path, client_core_path=tmp_path)._collect_core_dumps()
+def test_one_aes_key_for_the_whole_job(monkeypatch, tmp_path):
+    """Several directories must share one key, or all but one become unreadable.
+
+    Asserted end to end: exactly one wrapped key is emitted, and every collected
+    core decrypts with it back to the bytes that were dumped. A key count alone
+    would still pass if a refactor emitted one key *path* while encrypting with
+    different key *material*.
+    """
+    if not shutil.which("openssl") or not shutil.which("zstd"):
+        pytest.skip("openssl and zstd are needed to decrypt a collected core")
+
+    payloads = {
+        "run_r0.core.MergeMutate.654-5182.zst.enc": _write_core(
+            tmp_path / "run_r0", "core.MergeMutate.654-5182"
+        ),
+        "run_r1.core.MergeMutate.654-5182.zst.enc": _write_core(
+            tmp_path / "run_r1", "core.MergeMutate.654-5182"
+        ),
+        "client.core.clickhouse-clie.138694.zst.enc": _write_core(
+            tmp_path, "core.clickhouse-clie.138694"
+        ),
+    }
+    collected = _collector(
+        monkeypatch, tmp_path, client_core_path=tmp_path
+    )._collect_core_dumps()
 
     keys = {str(Path(f).resolve()) for f in collected if f.endswith("aes.key.rsa")}
     assert len(keys) == 1, keys
 
+    # Unwrapping `aes.key.rsa` needs the off-repo private key; the plaintext key
+    # `Utils.encrypt` wrote beside it is the same material, so the round trip
+    # runs without `private-cores.pem`.
+    aes_key = Path(clickhouse_proc_module.temp_dir) / "aes.key"
+    assert aes_key.exists(), aes_key
 
-def test_core_names_do_not_collide_across_directories(tmp_path):
+    cores = [f for f in collected if f.endswith(".zst.enc")]
+    assert sorted(Path(f).name for f in cores) == sorted(payloads), cores
+
+    decrypted_dir = tmp_path / "decrypted"
+    decrypted_dir.mkdir()
+    for core in cores:
+        name = Path(core).name
+        compressed = decrypted_dir / name[: -len(".enc")]
+        plain = decrypted_dir / name[: -len(".zst.enc")]
+        decrypt = _run(
+            [
+                "openssl", "enc", "-d", "-aes-256-cbc",
+                "-in", core, "-out", str(compressed),
+                "-pbkdf2", "-pass", f"file:{aes_key}",
+            ]
+        )
+        assert decrypt.returncode == 0, f"{name}: {decrypt.stderr.decode()}"
+        decompress = _run(["zstd", "-d", "-f", str(compressed), "-o", str(plain)])
+        assert decompress.returncode == 0, f"{name}: {decompress.stderr.decode()}"
+        assert plain.read_bytes() == payloads[name], name
+
+
+def test_core_names_do_not_collide_across_directories(monkeypatch, tmp_path):
     """`core.<comm>.<pid>` repeats across replicas running the same thread."""
     _write_core(tmp_path / "run_r0", "core.MergeMutate.654-5182")
     _write_core(tmp_path / "run_r1", "core.MergeMutate.654-5182")
-    collected = _collector(tmp_path)._collect_core_dumps()
+    collected = _collector(monkeypatch, tmp_path)._collect_core_dumps()
 
     cores = [Path(f).name for f in collected if f.endswith(".zst.enc")]
     duplicated = [name for name, count in Counter(cores).items() if count > 1]
     assert not duplicated, cores
 
 
-def test_no_artifact_overwrites_another(tmp_path):
+def test_no_artifact_overwrites_another(monkeypatch, tmp_path):
     """The end-to-end property: every collected file survives the upload."""
     _write_core(tmp_path / "run_r0", "core.MergeMutate.654-5182")
     _write_core(tmp_path / "run_r1", "core.MergeMutate.654-5182")
     _write_core(tmp_path, "core.clickhouse-clie.138694")
-    collected = _collector(tmp_path, client_core_path=tmp_path)._collect_core_dumps()
+    collected = _collector(
+        monkeypatch, tmp_path, client_core_path=tmp_path
+    )._collect_core_dumps()
 
     _, overwritten = _upload(collected)
     assert not overwritten, overwritten
 
 
-def test_three_cores_kept_per_directory(tmp_path):
+def test_three_cores_kept_per_directory(monkeypatch, tmp_path):
     """The per-directory cap is unchanged: three each, so up to nine servers."""
     for replica in ("run_r0", "run_r1"):
         for i in range(5):
             _write_core(tmp_path / replica, f"core.Thread{i}.{1000 + i}", size=256)
-    collected = _collector(tmp_path)._collect_core_dumps()
+    collected = _collector(monkeypatch, tmp_path)._collect_core_dumps()
 
     per_directory = Counter(
         Path(f).parent.name for f in collected if f.endswith(".zst.enc")
@@ -149,21 +282,23 @@ def test_three_cores_kept_per_directory(tmp_path):
     assert per_directory == {"run_r0": 3, "run_r1": 3}, per_directory
 
 
-def test_already_compressed_cores_are_skipped(tmp_path):
+def test_already_compressed_cores_are_skipped(monkeypatch, tmp_path):
     run_dir = tmp_path / "run_r0"
     _write_core(run_dir, "core.Fresh.1", size=256)
     (run_dir / "core.Done.2.zst").write_bytes(b"compressed")
     (run_dir / "core.Done.3.zst.enc").write_bytes(b"encrypted")
-    collected = _collector(tmp_path)._collect_core_dumps()
+    collected = _collector(monkeypatch, tmp_path)._collect_core_dumps()
 
     cores = [Path(f).name for f in collected if f.endswith(".zst.enc")]
     assert cores == ["run_r0.core.Fresh.1.zst.enc"], cores
 
 
-def test_nothing_collected_when_no_core_present(tmp_path):
+def test_nothing_collected_when_no_core_present(monkeypatch, tmp_path):
     """A passing job must not gain artifacts."""
     (tmp_path / "run_r0").mkdir(parents=True)
-    collected = _collector(tmp_path, client_core_path=tmp_path)._collect_core_dumps()
+    collected = _collector(
+        monkeypatch, tmp_path, client_core_path=tmp_path
+    )._collect_core_dumps()
 
     assert collected == [], collected
     assert not (tmp_path / "aes.key.rsa").exists()
@@ -179,3 +314,98 @@ def test_collect_cores_defaults_are_unchanged(tmp_path):
         "core.Fuzzer.7.zst.enc",
     ], collected
     assert (tmp_path / "aes.key.rsa").exists()
+
+
+def test_module_globals_are_restored():
+    """The redirection above must not leak into the rest of the session.
+
+    `ci/jobs/ci_tests_job.py` runs all of `ci/tests` in one process, so a
+    permanent rebind would leave every later test with a `temp_dir` pointing at
+    a deleted pytest directory.
+    """
+    assert clickhouse_proc_module.temp_dir == IMPORT_TIME_TEMP_DIR
+    assert clickhouse_proc_module.p_temp_dir == IMPORT_TIME_P_TEMP_DIR
+
+
+def test_collect_logs_gate_sees_the_pre_inversion_verdict():
+    """Bugfix validation rewrites a reproduced failure to `OK` before the gate.
+
+    `Result.is_ok` accepts `OK` and `SKIPPED`, so reading the verdict after the
+    inversion makes `prepare_logs(all=...)` False on exactly the jobs where a
+    crash was expected, and `_collect_core_dumps` never runs.
+    """
+    test_result = Result.create_from(
+        name="Tests",
+        results=[Result(name="00900_long_parquet", status=Result.Status.FAIL)],
+    )
+
+    assert not test_result.is_ok()
+    captured = bool(test_result) and not test_result.is_ok()
+    assert captured
+
+    assert invert_bugfix_validation_status(test_result) is False
+    # The trap: the run failed, yet the result now reports itself as ok.
+    assert test_result.is_ok()
+    assert captured
+
+    # And the module must read the verdict before the inversion, not after.
+    source, tree = _job_source("functional_tests.py")
+    main = _function(tree, "main")
+    captures = _assignments_to(main, "test_run_failed")
+    assert len(captures) == 1, ast.dump(main)[:200]
+    inversions = _calls_to(main, "invert_bugfix_validation_status")
+    assert len(inversions) == 1
+    assert captures[0].lineno < inversions[0].lineno, (
+        captures[0].lineno,
+        inversions[0].lineno,
+    )
+
+    prepare_logs = _calls_to(main, "prepare_logs", of="CH")
+    assert len(prepare_logs) == 1
+    gate = _keyword(prepare_logs[0], "all")
+    assert gate is not None and ast.get_source_segment(source, gate.value) == (
+        "test_run_failed"
+    ), ast.get_source_segment(source, prepare_logs[0])
+
+
+def test_functional_tests_declares_its_client_core_directory():
+    """`run_tests` does not change directory, so cwd is the repository root."""
+    source, tree = _job_source("functional_tests.py")
+
+    assigns = _assignments_to(tree, "client_core_path")
+    assert len(assigns) == 1, [a.lineno for a in assigns]
+    assert (
+        ast.get_source_segment(source, assigns[0].value) == "Utils.cwd()"
+    ), ast.get_source_segment(source, assigns[0])
+
+    # The premise that makes `Utils.cwd()` the right directory.
+    assert "os.chdir" not in source
+    runner = _function(tree, "run_tests")
+    commands = _assignments_to(runner, "command")
+    assert len(commands) == 1
+    command = ast.get_source_segment(source, commands[0])
+    assert "clickhouse-test" in command
+    assert "cd " not in command, command
+
+    shell_runs = _calls_to(runner, "run", of="Shell")
+    assert len(shell_runs) == 1
+    assert _keyword(shell_runs[0], "cwd") is None, ast.get_source_segment(
+        source, shell_runs[0]
+    )
+
+
+def test_fast_test_declares_its_client_core_directory():
+    """`fast_test_command` prefixes `cd {temp_dir}`, so cwd is the temp dir."""
+    source, tree = _job_source("fast_test.py")
+
+    assigns = _assignments_to(tree, "client_core_path")
+    assert len(assigns) == 1, [a.lineno for a in assigns]
+    assert (
+        ast.get_source_segment(source, assigns[0].value) == "str(temp_dir)"
+    ), ast.get_source_segment(source, assigns[0])
+
+    commands = _assignments_to(tree, "fast_test_command")
+    assert len(commands) == 1
+    command = ast.get_source_segment(source, commands[0])
+    assert "clickhouse-test" in command
+    assert "cd {temp_dir} &&" in command, command

--- a/ci/tests/test_collect_core_dumps.py
+++ b/ci/tests/test_collect_core_dumps.py
@@ -7,9 +7,10 @@ Three properties are covered.
 1. A core left by a `clickhouse-client` / `clickhouse-local` process that died on a
    fatal signal is retained. Only server cores used to be collected, because the
    collector globbed `ci/tmp/run_r*` alone, while a client spawned by a `.sh` test
-   dumps into the directory `clickhouse-test` runs from. A stateless test failing
-   with `return code: 139` therefore left no core and no stack anywhere, and the
-   crash could not be root-caused (`00900_long_parquet`, 2026-07-29).
+   dumps into the directory `clickhouse-test` runs from, unless the test changes
+   directory itself. A stateless test failing with `return code: 139` therefore
+   left no core and no stack anywhere, and the crash could not be root-caused
+   (`00900_long_parquet`, 2026-07-29).
 
 2. Collected artifacts do not overwrite each other, and every core actually
    decrypts with the single key the job emits. Every artifact is uploaded under
@@ -51,6 +52,16 @@ IMPORT_TIME_TEMP_DIR = clickhouse_proc_module.temp_dir
 IMPORT_TIME_P_TEMP_DIR = clickhouse_proc_module.p_temp_dir
 
 JOBS_DIR = Path(__file__).resolve().parent.parent / "jobs"
+
+# The expression `functional_tests.py` must use to capture the run's verdict
+# before bugfix validation rewrites it. Pinned as text against the production
+# source and exercised as an expression below, so the two halves of
+# `test_collect_logs_gate_sees_the_pre_inversion_verdict` cannot drift apart:
+# a rewrite of production has to update this literal, which the truth table
+# then re-checks. A string pin also rejects a semantically equivalent rewrite;
+# that is the accepted trade and the convention this module already follows for
+# `prepare_logs(all=...)` and both `client_core_path` values.
+GATE_EXPR = "bool(test_result) and not test_result.is_ok()"
 
 
 def _collector(monkeypatch, tmp_path, client_core_path=None):
@@ -152,6 +163,11 @@ def _keyword(call, name):
         if keyword.arg == name:
             return keyword
     return None
+
+
+def _gate(test_result):
+    """Evaluate `GATE_EXPR`, the pinned collect-logs gate, for one result."""
+    return eval(GATE_EXPR, {"test_result": test_result})  # noqa: S307
 
 
 def _run(command):
@@ -347,7 +363,7 @@ def test_collect_logs_gate_sees_the_pre_inversion_verdict():
     )
 
     assert not test_result.is_ok()
-    captured = bool(test_result) and not test_result.is_ok()
+    captured = _gate(test_result)
     assert captured
 
     assert invert_bugfix_validation_status(test_result) is False
@@ -355,11 +371,31 @@ def test_collect_logs_gate_sees_the_pre_inversion_verdict():
     assert test_result.is_ok()
     assert captured
 
-    # And the module must read the verdict before the inversion, not after.
+    # The verdict of every status the gate can see. `is_ok` accepts SKIPPED, so
+    # a no-repro validation run is correctly treated as not-failed; ERROR is
+    # neither FAIL nor OK, and reading it before the inversion is what makes an
+    # environment-setup failure collect its logs at all.
+    assert _gate(None) is False
+    assert (
+        _gate(
+            Result.create_from(
+                name="Tests", results=[Result(name="t", status=Result.Status.OK)]
+            )
+        )
+        is False
+    )
+    assert _gate(Result(name="Tests", status=Result.Status.SKIPPED)) is False
+    assert _gate(Result(name="Tests", status=Result.Status.ERROR)) is True
+
+    # And the module must read the verdict before the inversion, not after, with
+    # exactly the expression the truth table above exercises.
     source, tree = _job_source("functional_tests.py")
     main = _function(tree, "main")
     captures = _assignments_to(main, "test_run_failed")
     assert len(captures) == 1, ast.dump(main)[:200]
+    assert (
+        ast.get_source_segment(source, captures[0].value) == GATE_EXPR
+    ), ast.get_source_segment(source, captures[0])
     inversions = _calls_to(main, "invert_bugfix_validation_status")
     assert len(inversions) == 1
     assert captures[0].lineno < inversions[0].lineno, (

--- a/ci/tests/test_collect_core_dumps.py
+++ b/ci/tests/test_collect_core_dumps.py
@@ -1,0 +1,181 @@
+"""
+Tests for the core-dump collection built by `ClickHouseProc._collect_core_dumps`
+and `ClickHouseService.collect_cores`.
+
+Two properties are covered.
+
+1. A core left by a `clickhouse-client` / `clickhouse-local` process that died on a
+   fatal signal is retained. Only server cores used to be collected, because the
+   collector globbed `ci/tmp/run_r*` alone, while a client spawned by a `.sh` test
+   dumps into the directory `clickhouse-test` runs from. A stateless test failing
+   with `return code: 139` therefore left no core and no stack anywhere, and the
+   crash could not be root-caused (`00900_long_parquet`, 2026-07-29).
+
+2. Collected artifacts do not overwrite each other. Every artifact is uploaded
+   under its basename alone (`S3.copy_file_to_s3` appends `Path(local_path).name`)
+   and the per-result deduplication keys on the resolved absolute path, so two
+   distinct files sharing a basename become one object and the later upload wins.
+   With a key derived per directory that silently produced several different
+   `aes.key.rsa` files, leaving the cores of every directory but the last one
+   permanently undecryptable, and `core.<comm>.<pid>` collides across replicas
+   running the same thread.
+"""
+
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.scripts import clickhouse_proc as clickhouse_proc_module
+from ci.jobs.scripts.clickhouse_proc import ClickHouseProc
+from ci.jobs.scripts.clickhouse_service import ClickHouseService
+
+
+def _collector(tmp_path, client_core_path=None):
+    """A `ClickHouseProc` whose temp dir is `tmp_path`.
+
+    The module-level `temp_dir` / `p_temp_dir` are derived from the repository at
+    import time, so they are redirected for the duration of the test.
+    """
+    proc = ClickHouseProc.__new__(ClickHouseProc)
+    proc.client_core_path = (
+        str(client_core_path) if client_core_path is not None else None
+    )
+    clickhouse_proc_module.temp_dir = str(tmp_path)
+    clickhouse_proc_module.p_temp_dir = Path(tmp_path)
+    return proc
+
+
+def _write_core(directory: Path, name: str, size: int = 2048) -> bytes:
+    directory.mkdir(parents=True, exist_ok=True)
+    payload = os.urandom(size)
+    (directory / name).write_bytes(payload)
+    return payload
+
+
+def _upload(files):
+    """Model the upload of `result.files`, in the two stages CI performs.
+
+    `Result.upload_files` deduplicates by resolved absolute path, then
+    `S3.copy_file_to_s3` keys the object by basename. Returns the resulting
+    objects and the basenames for which two *different* files collided, i.e. the
+    ones where an upload destroys another upload's data.
+    """
+    deduplicated = {}
+    for file in files:
+        deduplicated.setdefault(str(Path(file).resolve()), file)
+
+    objects = {}
+    overwritten = []
+    for file in deduplicated.values():
+        name = Path(file).name
+        if name in objects and Path(objects[name]).resolve() != Path(file).resolve():
+            overwritten.append(name)
+        objects[name] = file
+    return objects, overwritten
+
+
+def test_client_core_is_collected(tmp_path):
+    _write_core(tmp_path, "core.clickhouse-clie.138694")
+    collected = _collector(tmp_path, client_core_path=tmp_path)._collect_core_dumps()
+
+    cores = [Path(f).name for f in collected if f.endswith(".zst.enc")]
+    assert cores == ["client.core.clickhouse-clie.138694.zst.enc"], cores
+
+
+def test_clickhouse_local_core_is_collected(tmp_path):
+    _write_core(tmp_path, "core.clickhouse-loca.99001")
+    collected = _collector(tmp_path, client_core_path=tmp_path)._collect_core_dumps()
+
+    cores = [Path(f).name for f in collected if f.endswith(".zst.enc")]
+    assert cores == ["client.core.clickhouse-loca.99001.zst.enc"], cores
+
+
+def test_client_core_not_collected_when_directory_not_declared(tmp_path):
+    """A job that does not declare its client directory keeps today's behaviour."""
+    _write_core(tmp_path, "core.clickhouse-clie.138694")
+    _write_core(tmp_path / "run_r0", "core.Server.1")
+    collected = _collector(tmp_path)._collect_core_dumps()
+
+    cores = [Path(f).name for f in collected if f.endswith(".zst.enc")]
+    assert cores == ["run_r0.core.Server.1.zst.enc"], cores
+
+
+def test_one_aes_key_for_the_whole_job(tmp_path):
+    """Several directories must share one key, or all but one become unreadable."""
+    _write_core(tmp_path / "run_r0", "core.MergeMutate.654-5182")
+    _write_core(tmp_path / "run_r1", "core.MergeMutate.654-5182")
+    _write_core(tmp_path, "core.clickhouse-clie.138694")
+    collected = _collector(tmp_path, client_core_path=tmp_path)._collect_core_dumps()
+
+    keys = {str(Path(f).resolve()) for f in collected if f.endswith("aes.key.rsa")}
+    assert len(keys) == 1, keys
+
+
+def test_core_names_do_not_collide_across_directories(tmp_path):
+    """`core.<comm>.<pid>` repeats across replicas running the same thread."""
+    _write_core(tmp_path / "run_r0", "core.MergeMutate.654-5182")
+    _write_core(tmp_path / "run_r1", "core.MergeMutate.654-5182")
+    collected = _collector(tmp_path)._collect_core_dumps()
+
+    cores = [Path(f).name for f in collected if f.endswith(".zst.enc")]
+    duplicated = [name for name, count in Counter(cores).items() if count > 1]
+    assert not duplicated, cores
+
+
+def test_no_artifact_overwrites_another(tmp_path):
+    """The end-to-end property: every collected file survives the upload."""
+    _write_core(tmp_path / "run_r0", "core.MergeMutate.654-5182")
+    _write_core(tmp_path / "run_r1", "core.MergeMutate.654-5182")
+    _write_core(tmp_path, "core.clickhouse-clie.138694")
+    collected = _collector(tmp_path, client_core_path=tmp_path)._collect_core_dumps()
+
+    _, overwritten = _upload(collected)
+    assert not overwritten, overwritten
+
+
+def test_three_cores_kept_per_directory(tmp_path):
+    """The per-directory cap is unchanged: three each, so up to nine servers."""
+    for replica in ("run_r0", "run_r1"):
+        for i in range(5):
+            _write_core(tmp_path / replica, f"core.Thread{i}.{1000 + i}", size=256)
+    collected = _collector(tmp_path)._collect_core_dumps()
+
+    per_directory = Counter(
+        Path(f).parent.name for f in collected if f.endswith(".zst.enc")
+    )
+    assert per_directory == {"run_r0": 3, "run_r1": 3}, per_directory
+
+
+def test_already_compressed_cores_are_skipped(tmp_path):
+    run_dir = tmp_path / "run_r0"
+    _write_core(run_dir, "core.Fresh.1", size=256)
+    (run_dir / "core.Done.2.zst").write_bytes(b"compressed")
+    (run_dir / "core.Done.3.zst.enc").write_bytes(b"encrypted")
+    collected = _collector(tmp_path)._collect_core_dumps()
+
+    cores = [Path(f).name for f in collected if f.endswith(".zst.enc")]
+    assert cores == ["run_r0.core.Fresh.1.zst.enc"], cores
+
+
+def test_nothing_collected_when_no_core_present(tmp_path):
+    """A passing job must not gain artifacts."""
+    (tmp_path / "run_r0").mkdir(parents=True)
+    collected = _collector(tmp_path, client_core_path=tmp_path)._collect_core_dumps()
+
+    assert collected == [], collected
+    assert not (tmp_path / "aes.key.rsa").exists()
+
+
+def test_collect_cores_defaults_are_unchanged(tmp_path):
+    """`ast_fuzzer_job` and `stress_job` call this with one directory and no key."""
+    _write_core(tmp_path, "core.Fuzzer.7", size=256)
+    collected = ClickHouseService.collect_cores(tmp_path)
+
+    assert sorted(Path(f).name for f in collected) == [
+        "aes.key.rsa",
+        "core.Fuzzer.7.zst.enc",
+    ], collected
+    assert (tmp_path / "aes.key.rsa").exists()


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`00900_long_parquet` failed on `Stateless tests (arm_binary, parallel)` with
`return code: 139`: a `clickhouse-client` process spawned by the test died on `SIGSEGV`.
The shell reported `(core dumped)`, so the kernel did write a core, yet the job retained
neither a core nor a stack, leaving the crash unroot-causable. This PR makes that evidence
exist. It does not fix the faulting frame, which remains unknown.

`_collect_core_dumps` globbed `ci/tmp/run_r*/core.*` only. That finds server cores because
each server runs with `cwd=run_rN` and is not a daemon, so `BaseDaemon` never `chdir`s into
a `core_path` and a relative `kernel.core_pattern` writes the core there. A client dumps
into the directory `clickhouse-test` runs from, which no glob covered. Jobs differ
(`functional_tests.py` runs from the repository root, `fast_test.py` prefixes
`cd {temp_dir}`), so the job now declares that directory and the collector consumes it.

Measuring this surfaced a second, pre-existing bug. Artifacts upload under their basename
alone, but `collect_cores` derived the AES key per directory, so a job where two replicas
both dumped emitted two different `aes.key.rsa` files and the later upload silently replaced
the earlier one, leaving one server core permanently undecryptable (`openssl` reports
`bad decrypt`; the correct key round-trips). `core.<comm>.<pid>` collides the same way. Both
are fixed: one AES key per job, and core names prefixed with their origin.

Validated on a real 962 MB core from a real ClickHouse process: collected, decrypted per
`ci/decrypt-cores.md`, byte-identical to the original, and loaded in `gdb` with real
symbolized frames. New `ci/tests/test_collect_core_dumps.py` fails on master source (10 of
its 14 cases) and passes with the fix; every added line was mutation-tested. Server retention is
unchanged at three cores per replica, and the other `collect_cores` callers are unaffected
on defaults. No core-size bound is added, deliberately (rationale below).

<details>
<summary>Measured evidence</summary>

No size bound is added because none is coherent: with up to nine server cores of up to
100 GiB each, any budget low enough to matter would discard cores retained today, anything
above bounds nothing, and truncated cores were proven unusable in `534b8fab3a59f7`.

That runners use a relative `core_pattern` was established from artifacts CI already
uploads (`kernel.core_pattern` is a host-wide non-namespaced sysctl, so it cannot be probed
from inside the test image). PRs 110230 and 110284 uploaded server cores, which are only
reachable from inside a `run_rN`; the server's cwd is `run_rN`, and a pattern with no `/`
writes into the dumping process's cwd.

The pre-existing key collision, driving the real `collect_cores` over two `run_r*`
directories on unmodified master:

```
BASENAME COUNTS: {'core.QueryPullPipeEx.617-3599.zst.enc': 2, 'aes.key.rsa': 2}
NUM aes.key.rsa: 2      aes keys IDENTICAL? False

SURVIVING aes.key.rsa came from: .../run_r1/aes.key.rsa
DECRYPT r0-core WITH r1-key -> rc: 1   stderr: bad decrypt
CONTROL decrypt r0-core WITH r0-key -> rc: 0
   CONTROL roundtrip matches original: True
```

End-to-end acceptance with a real core:

```
COLLECTED:  run_r0.core.SrvThread.4242.zst.enc
            aes.key.rsa
            client.core.clickhouse-loca.2136580.zst.enc   (203.2 MB from 962.7 MB)
DISTINCT aes.key.rsa PATHS: 1
DECRYPT rc: 0 | ZSTD rc: 0 | BYTE-IDENTICAL to original core: True

#11 std::condition_variable::wait_for<..., ConcurrentBoundedQueue<DB::Chunk>::popImpl<true>(...)>
```

`ci/tests` suite, run back to back with and without the new module: the same failures in
both arms, all in `test_print_stacktraces` / `test_cleanup_test_groups` /
`test_max_failures_exit_code`, which need a live server and are order-dependent
independently of this change (any unrelated module loaded first produces the same or more of
them). No failure is introduced. `ruff check` is clean.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.569` (included in `26.8` and later)
<!-- ch-version-info:end -->