### PR TITLE
Fix unsigned underflow in `computeMaxTableNameLength`

### DIFF
--- a/src/Common/computeMaxTableNameLength.cpp
+++ b/src/Common/computeMaxTableNameLength.cpp
@@ -33,7 +33,10 @@ size_t computeMaxTableNameLength(const String & database_name, ContextPtr contex
 
     // Adjust for database name and UUID in dropped table filenames
     // Max path will look like this: ./metadata_dropped/{db_name}.{table_name}.{uuid}.{extension}
-    size_t max_to_drop = max_dropped_length - dot - escaped_db_name_length - dot - uuid_length - extension_length;
+    // Saturate at zero: the prefix alone can already exceed the limit for a long database name,
+    // and an unsigned wrap here would report a huge limit instead of rejecting the name.
+    const size_t dropped_prefix_length = dot + escaped_db_name_length + dot + uuid_length + extension_length;
+    const size_t max_to_drop = max_dropped_length > dropped_prefix_length ? max_dropped_length - dropped_prefix_length : 0;
 
     // Return the minimum of the two calculated lengths
     return std::min(max_create_length, max_to_drop);

--- a/tests/queries/0_stateless/04654_table_name_length_underflow.reference
+++ b/tests/queries/0_stateless/04654_table_name_length_underflow.reference
@@ -1,0 +1,8 @@
+esc_211	2
+esc_212	1
+esc_213	0
+esc_214	0
+chars_118	118
+esc_214_from_118_chars	0
+esc_300	0
+esc_7	206

--- a/tests/queries/0_stateless/04654_table_name_length_underflow.sql
+++ b/tests/queries/0_stateless/04654_table_name_length_underflow.sql
@@ -1,0 +1,25 @@
+-- The maximum table name length is bounded by the dropped-metadata filename
+-- metadata_dropped/{db}.{table}.{uuid}.sql, so a long database name shrinks it.
+-- Past the point where the database name alone fills the budget the limit must be 0,
+-- not a wrapped unsigned value.
+
+-- Boundary controls: these must not move.
+SELECT 'esc_211', getMaxTableNameLengthForDatabase(repeat('d', 211));
+SELECT 'esc_212', getMaxTableNameLengthForDatabase(repeat('d', 212));
+SELECT 'esc_213', getMaxTableNameLengthForDatabase(repeat('d', 213));
+
+-- The first length whose prefix exceeds the budget.
+SELECT 'esc_214', getMaxTableNameLengthForDatabase(repeat('d', 214));
+
+-- The limit is a function of the escaped length, not of the character count:
+-- escapeForFileName expands every non-word byte to three characters, so 118
+-- characters here escape to 70 + 48 * 3 = 214 bytes. A limit computed from the
+-- unescaped length would report 95 instead of 0.
+SELECT 'chars_118', length(repeat('d', 70) || repeat('-', 48));
+SELECT 'esc_214_from_118_chars', getMaxTableNameLengthForDatabase(repeat('d', 70) || repeat('-', 48));
+
+-- Far past the boundary.
+SELECT 'esc_300', getMaxTableNameLengthForDatabase(repeat('d', 300));
+
+-- Ordinary database name, unchanged.
+SELECT 'esc_7', getMaxTableNameLengthForDatabase('default');

--- a/tests/queries/0_stateless/04655_table_name_length_underflow_drop.reference
+++ b/tests/queries/0_stateless/04655_table_name_length_underflow_drop.reference
@@ -1,3 +1,5 @@
 created
 dropped
 ARGUMENT_OUT_OF_BOUND
+into-long-accepted
+out-of-long-rejected

--- a/tests/queries/0_stateless/04655_table_name_length_underflow_drop.reference
+++ b/tests/queries/0_stateless/04655_table_name_length_underflow_drop.reference
@@ -1,0 +1,3 @@
+created
+dropped
+ARGUMENT_OUT_OF_BOUND

--- a/tests/queries/0_stateless/04655_table_name_length_underflow_drop.sh
+++ b/tests/queries/0_stateless/04655_table_name_length_underflow_drop.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# A table must not be creatable unless its dropped-metadata name
+# metadata_dropped/{db}.{table}.{uuid}.sql can exist. Past the point where the escaped
+# database name alone fills that budget the limit is 0, so the CREATE is rejected up front
+# instead of succeeding and leaving a table that cannot be dropped.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Pad the unique per-test database name out to an exact escaped length. CLICKHOUSE_DATABASE is
+# test_<8 lowercase letters and digits>, so every byte is a word character and the escaped
+# length equals the character count. The unique prefix is what keeps this parallel-safe.
+pad() { printf '%*s' "$1" '' | tr ' ' d; }
+# 211 is the largest escaped database name that still leaves room for a 2-character table name.
+db_ok="${CLICKHOUSE_DATABASE}$(pad $((211 - ${#CLICKHOUSE_DATABASE})))"
+# 214 is the first escaped length whose prefix alone exceeds the limit.
+db_too_long="${CLICKHOUSE_DATABASE}$(pad $((214 - ${#CLICKHOUSE_DATABASE})))"
+
+# When using s3_plain_rewriteable as a db disk, minio doesn't allow the path segment to have
+# more than 255 characters, and these database names produce segments close to that limit.
+# Refer: https://github.com/minio/minio/blob/ddd9a84cd769e6bed67f5fe860f8f3c7527a6971/cmd/xl-storage.go#L154-L167
+use_s3_plain_rewriteable_as_db_disk=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.disks WHERE name='disk_db_remote' AND type = 'ObjectStorage' AND object_storage_type='S3' AND metadata_type='PlainRewritable'" | tr -d '[:space:]')
+if [ "$use_s3_plain_rewriteable_as_db_disk" == "0" ]; then
+    # Just under the boundary: still allowed, and still droppable.
+    $CLICKHOUSE_CLIENT -q "CREATE DATABASE \`$db_ok\` ENGINE = Atomic"
+    $CLICKHOUSE_CLIENT -q "CREATE TABLE \`$db_ok\`.t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple()"
+    echo "created"
+    $CLICKHOUSE_CLIENT -q "DROP TABLE \`$db_ok\`.t0"
+    echo "dropped"
+    $CLICKHOUSE_CLIENT -q "DROP DATABASE \`$db_ok\`"
+
+    # Past the boundary: rejected at CREATE, so no undroppable table is left behind.
+    $CLICKHOUSE_CLIENT -q "CREATE DATABASE \`$db_too_long\` ENGINE = Atomic"
+    $CLICKHOUSE_CLIENT -q "CREATE TABLE \`$db_too_long\`.t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple()" 2>&1 | grep -o -m 1 'ARGUMENT_OUT_OF_BOUND'
+    $CLICKHOUSE_CLIENT -q "DROP DATABASE \`$db_too_long\`"
+else
+    echo "created"
+    echo "dropped"
+    echo "ARGUMENT_OUT_OF_BOUND"
+fi

--- a/tests/queries/0_stateless/04655_table_name_length_underflow_drop.sh
+++ b/tests/queries/0_stateless/04655_table_name_length_underflow_drop.sh
@@ -16,6 +16,20 @@ pad() { printf '%*s' "$1" '' | tr ' ' d; }
 db_ok="${CLICKHOUSE_DATABASE}$(pad $((211 - ${#CLICKHOUSE_DATABASE})))"
 # 214 is the first escaped length whose prefix alone exceeds the limit.
 db_too_long="${CLICKHOUSE_DATABASE}$(pad $((214 - ${#CLICKHOUSE_DATABASE})))"
+db_short="${CLICKHOUSE_DATABASE}_short"
+db_shrunk="${CLICKHOUSE_DATABASE}_shrunk"
+
+# Report a rename outcome by name: no output means it was accepted, the length guard means it was
+# rejected, and any other error is reported as such so it reddens the reference instead of being
+# mistaken for one of the first two.
+rename_outcome() {
+    local label="$1"
+    local out
+    out=$($CLICKHOUSE_CLIENT -q "$2" 2>&1)
+    if [ -z "$out" ]; then echo "$label-accepted"
+    elif echo "$out" | grep -q 'ARGUMENT_OUT_OF_BOUND'; then echo "$label-rejected"
+    else echo "$label-unexpected-error"; fi
+}
 
 # When using s3_plain_rewriteable as a db disk, minio doesn't allow the path segment to have
 # more than 255 characters, and these database names produce segments close to that limit.
@@ -33,9 +47,25 @@ if [ "$use_s3_plain_rewriteable_as_db_disk" == "0" ]; then
     # Past the boundary: rejected at CREATE, so no undroppable table is left behind.
     $CLICKHOUSE_CLIENT -q "CREATE DATABASE \`$db_too_long\` ENGINE = Atomic"
     $CLICKHOUSE_CLIENT -q "CREATE TABLE \`$db_too_long\`.t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple()" 2>&1 | grep -o -m 1 'ARGUMENT_OUT_OF_BOUND'
-    $CLICKHOUSE_CLIENT -q "DROP DATABASE \`$db_too_long\`"
+
+    # RENAME TABLE validates the destination name against the source database
+    # (InterpreterRenameQuery.cpp), so renaming into an oversized database is still allowed. That
+    # is issue #102463 and is not fixed here; both directions are pinned so that fix has a
+    # baseline.
+    $CLICKHOUSE_CLIENT -q "CREATE DATABASE \`$db_short\` ENGINE = Atomic"
+    $CLICKHOUSE_CLIENT -q "CREATE TABLE \`$db_short\`.r0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple()"
+    rename_outcome "into-long" "RENAME TABLE \`$db_short\`.r0 TO \`$db_too_long\`.r0"
+    rename_outcome "out-of-long" "RENAME TABLE \`$db_too_long\`.r0 TO \`$db_short\`.r1"
+
+    # The table now sits in the oversized database, where DROP cannot build its metadata_dropped
+    # path, so shorten the database name first. That is the workaround from the issue.
+    $CLICKHOUSE_CLIENT -q "RENAME DATABASE \`$db_too_long\` TO \`$db_shrunk\`"
+    $CLICKHOUSE_CLIENT -q "DROP DATABASE \`$db_shrunk\`"
+    $CLICKHOUSE_CLIENT -q "DROP DATABASE \`$db_short\`"
 else
     echo "created"
     echo "dropped"
     echo "ARGUMENT_OUT_OF_BOUND"
+    echo "into-long-accepted"
+    echo "out-of-long-rejected"
 fi


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/100883


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes an unsigned underflow in the table name length check that allowed creating a table which could never be dropped. When the escaped database name reached 214 bytes, the limit computed for the `metadata_dropped` filename wrapped around, so `CREATE TABLE` was accepted and the subsequent `DROP TABLE` or `DROP DATABASE` failed with `File name too long`. Such a name is now rejected with `ARGUMENT_OUT_OF_BOUND`, the same error already returned just below that boundary.


### Description

`computeMaxTableNameLength` subtracts the `metadata_dropped/{db}.{table}.{uuid}.sql` prefix from
`NAME_MAX` in `size_t` arithmetic with no lower bound. The fixed terms sum to 42, so once the
escaped database name reaches 214 bytes the result wraps to about 1.8e19 and the following
`std::min` picks the unconstrained create limit of 242. So 213 bytes is rejected, but 214
accepts any table name and the later `DROP TABLE` or `DROP DATABASE` is what fails. The full
table is in the issue.

I saturate the subtraction at zero, which is the form suggested in the issue, so 214 bytes and
above now returns 0 and gets the same `ARGUMENT_OUT_OF_BOUND` that 212 and 213 already get rather
than a different error later on. Fixing the producer corrects all four call sites at once.

The quantity that matters is the escaped length: `escapeForFileName` expands every non-word byte to
three characters, so 118 characters can escape to 214 bytes. A stateless test reads the limit
directly through `getMaxTableNameLengthForDatabase` across the boundary and that escaped case; a
second test creates and drops a table on both sides of it.

`RENAME TABLE` validates the destination name against the source database, which is issue #102463
and not fixed here. As a side effect, moving a table out of an already oversized database is now
rejected rather than allowed; the test pins both directions.

Tables already created past the boundary keep loading normally but stay undroppable until the
database is renamed shorter. I also checked the sibling subtraction on the line above and left it
unchanged; it is not reachable.

The retry loop in `DDLWorker` that keeps the distributed DDL queue blocked behind such a task is a
separate concern and I am sending it as its own PR.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.495` (included in `26.8` and later)
<!-- ch-version-info:end -->