### PR TITLE
Add a test for a set operation in a scalar mutation predicate

### DIFF
--- a/tests/queries/0_stateless/04654_union_scalar_subquery_in_mutation_predicate.reference
+++ b/tests/queries/0_stateless/04654_union_scalar_subquery_in_mutation_predicate.reference
@@ -1,0 +1,2 @@
+delete scalar subquery union distinct	[]
+delete scalar subquery union distinct, validated	[]

--- a/tests/queries/0_stateless/04654_union_scalar_subquery_in_mutation_predicate.sql
+++ b/tests/queries/0_stateless/04654_union_scalar_subquery_in_mutation_predicate.sql
@@ -1,0 +1,26 @@
+-- A set operation inside a scalar subquery used directly as a mutation predicate must be normalized
+-- when the mutation command is re-parsed on execution.
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/81135
+
+DROP TABLE IF EXISTS t_union_scalar_pred;
+CREATE TABLE t_union_scalar_pred (c0 Int) ENGINE = MergeTree ORDER BY tuple();
+
+-- `DELETE FROM` overwrites `mutations_sync` from `lightweight_deletes_sync`, so that is the setting
+-- which decides whether anything waits for the mutation. The failure surfaced only while the
+-- mutation executed on the part, so pin it rather than relying on the default.
+SET lightweight_deletes_sync = 1;
+
+-- With mutation validation disabled the mutation was accepted and then failed on the part.
+SET validate_mutation_query = 0;
+INSERT INTO t_union_scalar_pred VALUES (0), (1), (2);
+DELETE FROM t_union_scalar_pred WHERE (SELECT true UNION DISTINCT SELECT true);
+SELECT 'delete scalar subquery union distinct', arraySort(groupArray(c0)) FROM t_union_scalar_pred;
+TRUNCATE TABLE t_union_scalar_pred;
+
+-- With validation enabled the same query was rejected earlier, at validation time.
+SET validate_mutation_query = 1;
+INSERT INTO t_union_scalar_pred VALUES (0), (1), (2);
+DELETE FROM t_union_scalar_pred WHERE (SELECT true UNION DISTINCT SELECT true);
+SELECT 'delete scalar subquery union distinct, validated', arraySort(groupArray(c0)) FROM t_union_scalar_pred;
+
+DROP TABLE t_union_scalar_pred;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/81135
Related: https://github.com/ClickHouse/ClickHouse/pull/110196
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/81135
Related: https://github.com/ClickHouse/ClickHouse/pull/110196

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Issue #81135 reports that `DELETE FROM t0 WHERE (SELECT true UNION DISTINCT SELECT true)` with
`validate_mutation_query = 0` fails with `UNION mode UNION_DEFAULT must be normalized`. It no longer
reproduces, so this adds a test only.

Root cause: mutation commands are stored as serialized SQL text and re-parsed when the mutation executes on a
part. Re-parsing reset set-operation nodes to `UNION_DEFAULT` and lost the normalized flag, so the exception
surfaced asynchronously through `waitForMutation`. Fixed by #110196, which closed #72853. @ PedroTadim
suspected that relationship in the issue thread, and it was correct.

I verified the test is a real regression test rather than a tautology. On 25.8.29.39 it fails with
`Code: 341` wrapping `Code: 36 ... UNION mode UNION_DEFAULT must be normalized`, at the same
`checkMutationStatus` and `waitForMutation` frames the issue reports; on master it passes with output matching
the reference. The `lightweight_deletes_sync = 1` pin is load-bearing: with `0` the mutation is not waited for
and the exception is hidden. Note that `DELETE FROM` overwrites `mutations_sync` from
`lightweight_deletes_sync`, so pinning `mutations_sync` here has no effect.

Both `validate_mutation_query` arms are covered, because they failed differently before the fix: `0` failed
during execution on the part, and the default failed earlier at validation.

`04560_union_subqueries_in_mutations` already pins this root cause, but only for the `IN` position; nothing in
the suite covered a set operation in a bare scalar-subquery predicate. All such predicate positions share one
normalization call site, so this is position coverage rather than a new code path.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.421` (included in `26.8` and later)
<!-- ch-version-info:end -->