### PR TITLE
Revert "Iceberg local concurrent"

### DIFF
--- a/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -2,22 +2,15 @@
 
 #include <atomic>
 #include <filesystem>
-#include <fcntl.h>
-#include <sys/file.h>
-#include <sys/stat.h>
-#include <unistd.h>
 #include <Disks/IO/AsynchronousBoundedReadBuffer.h>
 #include <Disks/IO/ReadBufferFromRemoteFSGather.h>
 #include <Disks/IO/createReadBufferFromFileBase.h>
-#include <IO/ReadBufferFromFile.h>
 #include <IO/ReadBufferFromFileDecorator.h>
 #include <IO/WriteBufferFromFile.h>
 #include <IO/WriteBufferFromFileDecorator.h>
-#include <IO/WriteBufferFromString.h>
 #include <IO/copyData.h>
 #include <Interpreters/BlobStorageLog.h>
 #include <Interpreters/Context.h>
-#include <base/scope_guard.h>
 #include <Common/BlobStorageLogWriter.h>
 #include <Common/ObjectStorageKeyGenerator.h>
 #include <Common/StackTrace.h>
@@ -45,72 +38,7 @@ namespace ErrorCodes
     extern const int CANNOT_RMDIR;
     extern const int READONLY;
     extern const int FAULT_INJECTED;
-    extern const int FILE_ALREADY_EXISTS;
-    extern const int CANNOT_OPEN_FILE;
-    extern const int CANNOT_LINK;
-    extern const int CANNOT_STAT;
-    extern const int STALE_VERSION;
-    extern const int SYSTEM_ERROR;
     extern const int PATH_ACCESS_DENIED;
-}
-
-namespace
-{
-
-String makeETag(const struct stat & file_stat)
-{
-#if defined(OS_DARWIN)
-    const auto mtim_sec = file_stat.st_mtimespec.tv_sec;
-    const auto mtim_nsec = file_stat.st_mtimespec.tv_nsec;
-#else
-    const auto mtim_sec = file_stat.st_mtim.tv_sec;
-    const auto mtim_nsec = file_stat.st_mtim.tv_nsec;
-#endif
-    return fmt::format(
-        "{}.{:09}_{}_{}",
-        static_cast<Int64>(mtim_sec),
-        static_cast<Int64>(mtim_nsec),
-        static_cast<Int64>(file_stat.st_ino),
-        static_cast<Int64>(file_stat.st_size));
-}
-
-ObjectMetadata makeObjectMetadata(const struct stat & file_stat)
-{
-    ObjectMetadata object_metadata;
-    object_metadata.size_bytes = file_stat.st_size;
-    object_metadata.etag = makeETag(file_stat);
-    object_metadata.last_modified = Poco::Timestamp::fromEpochTime(file_stat.st_mtime);
-    return object_metadata;
-}
-
-/// The concurrent-disappearance class for a best-effort local listing: an entry
-/// removed mid-stat (ENOENT) or whose parent path component was concurrently
-/// replaced by a non-directory (ENOTDIR). Mirrors libc++'s own `__is_dne_error`.
-/// Every other error (EACCES, EIO, ...) is a real failure and must propagate.
-bool isVanishedEntryError(const std::error_code & error)
-{
-    return error == std::errc::no_such_file_or_directory || error == std::errc::not_a_directory;
-}
-
-/// Best-effort metadata stat for a path that has ALREADY been validated against
-/// the key prefix. Uses the non-throwing `error_code` overloads and tolerates the
-/// concurrent-disappearance class (see `isVanishedEntryError`), returning an empty
-/// optional for a vanished entry. Every other error is propagated.
-std::optional<ObjectMetadata> tryStatResolvedPath(const std::string & resolved_path)
-{
-    struct stat file_stat{};
-    if (0 != ::stat(resolved_path.c_str(), &file_stat))
-    {
-        std::error_code error(errno, std::generic_category());
-        if (isVanishedEntryError(error))
-            return {};
-        throw fs::filesystem_error("Got unexpected error while getting file metadata", resolved_path, error);
-    }
-
-    return makeObjectMetadata(file_stat);
-}
-
-
 }
 
 LocalObjectStorage::LocalObjectStorage(LocalObjectStorageSettings settings_)
@@ -326,124 +254,6 @@ private:
     BlobStorageLogWriterPtr blob_log;
 };
 
-void publishConditionally(const String & temp_path, const String & target_path, const std::optional<String> & if_match_etag)
-{
-    if (!if_match_etag.has_value())
-    {
-        if (0 == ::link(temp_path.c_str(), target_path.c_str()))
-            return;
-
-        if (errno == EEXIST)
-            throw Exception(
-                ErrorCodes::FILE_ALREADY_EXISTS,
-                "Object {} already exists, PreconditionFailed for If-None-Match",
-                target_path);
-
-        ErrnoException::throwFromPath(ErrorCodes::CANNOT_LINK, target_path, "Cannot link {} to {}", temp_path, target_path);
-    }
-
-    const String parent_path = fs::path(target_path).parent_path();
-    int dir_fd = ::open(parent_path.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
-    if (dir_fd < 0)
-        ErrnoException::throwFromPath(ErrorCodes::CANNOT_OPEN_FILE, parent_path, "Cannot open directory {}", parent_path);
-
-    SCOPE_EXIT({ [[maybe_unused]] int err = ::close(dir_fd); });
-
-    if (0 != ::flock(dir_fd, LOCK_EX))
-        ErrnoException::throwFromPath(ErrorCodes::SYSTEM_ERROR, parent_path, "Cannot lock directory {}", parent_path);
-
-    struct stat file_stat{};
-    if (0 != ::stat(target_path.c_str(), &file_stat))
-    {
-        if (errno == ENOENT)
-            throw Exception(
-                ErrorCodes::STALE_VERSION,
-                "Object {} does not exist, PreconditionFailed for If-Match: {}",
-                target_path, *if_match_etag);
-
-        ErrnoException::throwFromPath(ErrorCodes::CANNOT_STAT, target_path, "Cannot stat file {}", target_path);
-    }
-
-    if (auto etag = makeETag(file_stat); etag != *if_match_etag)
-        throw Exception(
-            ErrorCodes::STALE_VERSION,
-            "Object {} was modified concurrently (etag {}, expected {}), PreconditionFailed for If-Match",
-            target_path, etag, *if_match_etag);
-
-    if (0 != ::rename(temp_path.c_str(), target_path.c_str()))
-        ErrnoException::throwFromPath(ErrorCodes::SYSTEM_ERROR, target_path, "Cannot rename {} to {}", temp_path, target_path);
-}
-
-class WriteBufferToConditionallyPublishedFile final : public WriteBufferFromFileDecorator
-{
-public:
-    WriteBufferToConditionallyPublishedFile(
-        const String & target_path_,
-        const String & temp_path_,
-        size_t buf_size,
-        std::optional<String> if_match_etag_,
-        const String & bucket_,
-        BlobStorageLogWriterPtr blob_log_)
-        : WriteBufferFromFileDecorator(std::make_unique<WriteBufferFromFile>(temp_path_, buf_size, O_WRONLY | O_CREAT | O_EXCL))
-        , target_path(target_path_)
-        , temp_path(temp_path_)
-        , if_match_etag(std::move(if_match_etag_))
-        , bucket(bucket_)
-        , blob_log(std::move(blob_log_))
-    {
-    }
-
-    ~WriteBufferToConditionallyPublishedFile() override
-    {
-        removeTemporaryFile();
-    }
-
-    std::string getFileName() const override { return target_path; }
-
-private:
-    void finalizeImpl() override
-    {
-        WriteBufferFromFileDecorator::finalizeImpl();
-
-        const size_t data_size = count();
-        publishConditionally(temp_path, target_path, if_match_etag);
-        removeTemporaryFile();
-
-        if (blob_log)
-        {
-            blob_log->addEvent(
-                BlobStorageLogElement::EventType::Upload,
-                /* bucket */ bucket,
-                /* remote_path */ target_path,
-                /* local_path */ {},
-                /* data_size */ data_size,
-                /* elapsed_microseconds */ 0,
-                /* error_code */ 0,
-                /* error_message */ {});
-        }
-    }
-
-    void cancelImpl() noexcept override
-    {
-        WriteBufferFromFileDecorator::cancelImpl();
-        removeTemporaryFile();
-    }
-
-    void removeTemporaryFile() noexcept
-    {
-        if (std::exchange(temporary_file_removed, true))
-            return;
-        [[maybe_unused]] int err = ::unlink(temp_path.c_str());
-    }
-
-    const String target_path;
-    const String temp_path;
-    const std::optional<String> if_match_etag;
-    const String bucket;
-    BlobStorageLogWriterPtr blob_log;
-    bool temporary_file_removed = false;
-};
-
 }
 
 std::unique_ptr<ReadBufferFromFileBase> LocalObjectStorage::readObject( /// NOLINT
@@ -476,7 +286,7 @@ std::unique_ptr<WriteBufferFromFileBase> LocalObjectStorage::writeObject( /// NO
     WriteMode mode,
     std::optional<ObjectAttributes> /* attributes */,
     size_t buf_size,
-    const WriteSettings & write_settings)
+    const WriteSettings & /* write_settings */)
 {
     throwIfReadonly();
 
@@ -493,36 +303,6 @@ std::unique_ptr<WriteBufferFromFileBase> LocalObjectStorage::writeObject( /// NO
     auto blob_storage_log = BlobStorageLogWriter::create(settings.disk_name);
     if (blob_storage_log)
         blob_storage_log->local_path = object.local_path;
-
-    const auto & if_none_match = write_settings.object_storage_write_if_none_match;
-    const auto & if_match = write_settings.object_storage_write_if_match;
-
-    if (!if_none_match.empty() && !if_match.empty())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "If-None-Match and If-Match cannot be used together for object {}", object.remote_path);
-
-    if (!if_none_match.empty() || !if_match.empty())
-    {
-        if (!if_none_match.empty() && if_none_match != "*")
-            throw Exception(
-                ErrorCodes::BAD_ARGUMENTS,
-                "Local object storage supports only `*` for If-None-Match, got `{}`",
-                if_none_match);
-
-        std::optional<String> if_match_etag;
-        if (!if_match.empty())
-            if_match_etag = if_match;
-
-        auto target_path = fs::path(object.remote_path);
-        auto temp_path = target_path.parent_path() / fmt::format(".tmp_{}_{}", target_path.filename().string(), getRandomASCIIString(8));
-
-        return std::make_unique<WriteBufferToConditionallyPublishedFile>(
-            object.remote_path,
-            temp_path,
-            buf_size,
-            std::move(if_match_etag),
-            settings.key_prefix,
-            std::move(blob_storage_log));
-    }
 
     return std::make_unique<WriteBufferFromFileWithLogging>(
         resolved_path,
@@ -621,43 +401,50 @@ void LocalObjectStorage::removeObjectsIfExist(const StoredObjects & objects)
         removeObjectIfExists(object);
 }
 
-std::optional<ObjectMetadata> LocalObjectStorage::tryGetObjectMetadata(const std::string & path, bool) const
+namespace
 {
-    LOG_TEST(log, "Getting metadata for path: {}", path);
+/// The concurrent-disappearance class for a best-effort local listing: an entry
+/// removed mid-stat (ENOENT) or whose parent path component was concurrently
+/// replaced by a non-directory (ENOTDIR). Mirrors libc++'s own `__is_dne_error`.
+/// Every other error (EACCES, EIO, ...) is a real failure and must propagate.
+bool isVanishedEntryError(const std::error_code & error)
+{
+    return error == std::errc::no_such_file_or_directory || error == std::errc::not_a_directory;
+}
 
-    struct stat file_stat{};
-    if (0 != ::stat(path.c_str(), &file_stat))
+/// Best-effort metadata stat for a path that has ALREADY been validated against
+/// the key prefix. Uses the non-throwing `error_code` overloads and tolerates the
+/// concurrent-disappearance class (see `isVanishedEntryError`), returning an empty
+/// optional for a vanished entry. Every other error is propagated.
+std::optional<ObjectMetadata> tryStatResolvedPath(const std::string & resolved_path)
+{
+    ObjectMetadata object_metadata;
+
+    std::error_code error;
+    auto time = fs::last_write_time(resolved_path, error);
+    if (error)
     {
-        std::error_code error(errno, std::generic_category());
         if (isVanishedEntryError(error))
             return {};
-        throw fs::filesystem_error("Got unexpected error while getting file metadata", path, error);
+        throw fs::filesystem_error("Got unexpected error while getting last write time", resolved_path, error);
     }
 
-    return makeObjectMetadata(file_stat);
+    object_metadata.size_bytes = fs::file_size(resolved_path, error);
+    if (error)
+    {
+        /// The entry may vanish between the two stat calls (concurrent removal),
+        /// or a parent path component may be concurrently replaced by a file.
+        if (isVanishedEntryError(error))
+            return {};
+        throw fs::filesystem_error("Got unexpected error while getting file size", resolved_path, error);
+    }
+
+    object_metadata.etag = std::to_string(std::chrono::duration_cast<std::chrono::nanoseconds>(time.time_since_epoch()).count());
+    object_metadata.last_modified = Poco::Timestamp::fromEpochTime(
+        std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch()).count());
+    return object_metadata;
 }
-
-SmallObjectDataWithMetadata LocalObjectStorage::readSmallObjectAndGetObjectMetadata( /// NOLINT
-    const StoredObject & object,
-    const ReadSettings &,
-    size_t max_size_bytes,
-    std::optional<size_t>) const
-{
-    ReadBufferFromFile in(object.remote_path, std::clamp<size_t>(max_size_bytes, 1, DBMS_DEFAULT_BUFFER_SIZE));
-
-    struct stat file_stat{};
-    if (0 != ::fstat(in.getFD(), &file_stat))
-        ErrnoException::throwFromPath(ErrorCodes::CANNOT_STAT, object.remote_path, "Cannot stat file {}", object.remote_path);
-
-    SmallObjectDataWithMetadata result;
-    WriteBufferFromString out(result.data);
-    copyDataMaxBytes(in, out, max_size_bytes);
-    out.finalize();
-
-    result.metadata = makeObjectMetadata(file_stat);
-    return result;
 }
-
 
 ObjectMetadata LocalObjectStorage::getObjectMetadata(const std::string & path, bool) const
 {
@@ -672,6 +459,13 @@ ObjectMetadata LocalObjectStorage::getObjectMetadata(const std::string & path, b
     object_metadata.last_modified = Poco::Timestamp::fromEpochTime(
         std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch()).count());
     return object_metadata;
+}
+
+std::optional<ObjectMetadata> LocalObjectStorage::tryGetObjectMetadata(const std::string & path, bool) const
+{
+    auto resolved_path = resolvePathRelativelyToKeyPrefix(path);
+    LOG_TEST(log, "Getting metadata for path: {}", resolved_path);
+    return tryStatResolvedPath(resolved_path);
 }
 
 void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t/* max_keys */) const

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.h
@@ -51,12 +51,6 @@ public:
         bool use_external_buffer = false,
         bool restrict_seek = false) const override;
 
-    SmallObjectDataWithMetadata readSmallObjectAndGetObjectMetadata( /// NOLINT
-        const StoredObject & object,
-        const ReadSettings & read_settings,
-        size_t max_size_bytes,
-        std::optional<size_t> read_hint = {}) const override;
-
     /// Open the file for write and return WriteBufferFromFileBase object.
     std::unique_ptr<WriteBufferFromFileBase> writeObject( /// NOLINT
         const StoredObject & object,

--- a/src/Disks/tests/gtest_local_object_storage.cpp
+++ b/src/Disks/tests/gtest_local_object_storage.cpp
@@ -1,9 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.h>
-#include <Core/Defines.h>
-#include <IO/ReadSettings.h>
-#include <IO/WriteSettings.h>
 
 #include <unistd.h> /// for ::getpid
 
@@ -11,7 +8,6 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
-#include <exception>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -53,42 +49,6 @@ struct ScopedTempDir
         fs::remove_all(path, ec);
     }
 };
-
-void writeObject(const DB::ObjectStoragePtr & storage, const fs::path & path, const std::string & data, const DB::WriteSettings & write_settings)
-{
-    auto buffer = storage->writeObject(
-        DB::StoredObject(path.string()), DB::WriteMode::Rewrite, /*attributes=*/ {}, DB::DBMS_DEFAULT_BUFFER_SIZE, write_settings);
-    buffer->write(data.data(), data.size());
-    buffer->finalize();
-}
-
-DB::WriteSettings ifNoneMatchAll()
-{
-    DB::WriteSettings write_settings;
-    write_settings.object_storage_write_if_none_match = "*";
-    return write_settings;
-}
-
-DB::WriteSettings ifMatch(const std::string & etag)
-{
-    DB::WriteSettings write_settings;
-    write_settings.object_storage_write_if_match = etag;
-    return write_settings;
-}
-
-DB::SmallObjectDataWithMetadata readObject(const DB::ObjectStoragePtr & storage, const fs::path & path)
-{
-    return storage->readSmallObjectAndGetObjectMetadata(DB::StoredObject(path.string()), DB::ReadSettings{}, /*max_size_bytes=*/ 4096);
-}
-
-std::vector<std::string> listDirectory(const fs::path & directory)
-{
-    std::vector<std::string> names;
-    for (const auto & entry : fs::directory_iterator(directory))
-        names.push_back(entry.path().filename().string());
-    std::sort(names.begin(), names.end());
-    return names;
-}
 
 }
 
@@ -668,111 +628,4 @@ TEST(LocalObjectStorage, ListObjectsHandlesMissingAndNonDirectoryPaths)
         storage->listObjects(file_path.string(), children, /* max_keys */ 0);
         EXPECT_TRUE(children.empty());
     }
-}
-
-TEST(LocalObjectStorage, ConditionalWriteIfNoneMatchIsExclusive)
-{
-    ScopedTempDir tmp("ch_gtest_local_object_storage_if_none_match");
-    const auto & root = tmp.path;
-
-    auto storage = makeLocalObjectStorage(root.string());
-    const auto path = root / "metadata" / "v1.metadata.json";
-
-    writeObject(storage, path, "first", ifNoneMatchAll());
-    EXPECT_EQ(readObject(storage, path).data, "first");
-
-    EXPECT_THROW(writeObject(storage, path, "second", ifNoneMatchAll()), DB::Exception);
-    EXPECT_EQ(readObject(storage, path).data, "first") << "a failed If-None-Match write must not touch the object";
-
-    EXPECT_EQ(listDirectory(path.parent_path()), std::vector<std::string>{"v1.metadata.json"})
-        << "the staging file of the failed write must be cleaned up";
-}
-
-TEST(LocalObjectStorage, ConditionalWriteIfMatchRejectsStaleEtag)
-{
-    ScopedTempDir tmp("ch_gtest_local_object_storage_if_match");
-    const auto & root = tmp.path;
-
-    auto storage = makeLocalObjectStorage(root.string());
-    const auto path = root / "metadata" / "version-hint.text";
-
-    writeObject(storage, path, "1", ifNoneMatchAll());
-
-    const auto etag_seen_by_a = readObject(storage, path).metadata.etag;
-    ASSERT_FALSE(etag_seen_by_a.empty()) << "an etag is required for the compare-and-swap to work at all";
-
-    writeObject(storage, path, "3", ifMatch(etag_seen_by_a));
-    ASSERT_EQ(readObject(storage, path).data, "3");
-
-    EXPECT_THROW(writeObject(storage, path, "2", ifMatch(etag_seen_by_a)), DB::Exception);
-    EXPECT_EQ(readObject(storage, path).data, "3") << "the hint must not go backwards";
-
-    writeObject(storage, path, "4", ifMatch(readObject(storage, path).metadata.etag));
-    EXPECT_EQ(readObject(storage, path).data, "4");
-
-    EXPECT_EQ(listDirectory(path.parent_path()), std::vector<std::string>{"version-hint.text"});
-
-    EXPECT_THROW(writeObject(storage, root / "missing.text", "1", ifMatch(etag_seen_by_a)), DB::Exception);
-}
-
-TEST(LocalObjectStorage, ConcurrentConditionalWritesDoNotLoseUpdates)
-{
-    ScopedTempDir tmp("ch_gtest_local_object_storage_cas");
-    const auto & root = tmp.path;
-
-    auto storage = makeLocalObjectStorage(root.string());
-    const auto path = root / "metadata" / "counter.text";
-
-    writeObject(storage, path, "0", ifNoneMatchAll());
-
-    constexpr size_t num_threads = 8;
-    constexpr size_t increments_per_thread = 25;
-
-    std::atomic<size_t> successful_writes{0};
-    std::mutex writer_failure_mutex;
-    std::exception_ptr writer_failure;
-
-    auto writer_loop = [&]
-    {
-        for (size_t i = 0; i < increments_per_thread; ++i)
-        {
-            while (true)
-            {
-                auto current = readObject(storage, path);
-                const auto next_value = std::to_string(std::stoull(current.data) + 1);
-                try
-                {
-                    writeObject(storage, path, next_value, ifMatch(current.metadata.etag));
-                }
-                catch (const DB::Exception &)
-                {
-                    continue;
-                }
-                catch (...)
-                {
-                    std::lock_guard lock(writer_failure_mutex);
-                    if (!writer_failure)
-                        writer_failure = std::current_exception();
-                    return;
-                }
-                successful_writes.fetch_add(1, std::memory_order_relaxed);
-                break;
-            }
-        }
-    };
-
-    std::vector<std::thread> threads;
-    for (size_t t = 0; t < num_threads; ++t)
-        threads.emplace_back(writer_loop);
-    for (auto & thread : threads)
-        thread.join();
-
-    if (writer_failure)
-        std::rethrow_exception(writer_failure);
-
-    EXPECT_EQ(successful_writes.load(), num_threads * increments_per_thread);
-    EXPECT_EQ(readObject(storage, path).data, std::to_string(num_threads * increments_per_thread))
-        << "concurrent compare-and-swap writers lost an update";
-
-    EXPECT_EQ(listDirectory(path.parent_path()), std::vector<std::string>{"counter.text"});
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -120,7 +120,6 @@ extern const int ICEBERG_SPECIFICATION_VIOLATION;
 extern const int S3_ERROR;
 extern const int TABLE_ALREADY_EXISTS;
 extern const int SUPPORT_IS_DISABLED;
-extern const int FILE_ALREADY_EXISTS;
 }
 
 namespace Setting
@@ -836,10 +835,8 @@ void IcebergMetadata::createInitial(
         /// The write uses `If-None-Match: *`, so S3 returns PreconditionFailed when the metadata file
         /// already exists (e.g. leftover data after `DROP TABLE` with `iceberg_delete_data_on_drop` off,
         /// or a concurrent creation). When `IF NOT EXISTS` was specified, this is expected.
-        const bool precondition_failed
-            = (e.code() == ErrorCodes::S3_ERROR && e.message().find("PreconditionFailed") != String::npos)
-            || e.code() == ErrorCodes::FILE_ALREADY_EXISTS;
-        if (if_not_exists && precondition_failed)
+        if (if_not_exists && e.code() == ErrorCodes::S3_ERROR
+            && e.message().find("PreconditionFailed") != String::npos)
             return;
         throw;
     }

--- a/src/Storages/ObjectStorage/DataLakes/Paimon/tests/gtest_paimon_latest_hint.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Paimon/tests/gtest_paimon_latest_hint.cpp
@@ -90,7 +90,7 @@ public:
         last_local_buffer_size.store(read_settings.local_fs_settings.buffer_size, std::memory_order_relaxed);
         last_remote_buffer_size.store(read_settings.remote_fs_settings.buffer_size, std::memory_order_relaxed);
         last_max_size_bytes.store(max_size_bytes, std::memory_order_relaxed);
-        return LocalObjectStorage::readSmallObjectAndGetObjectMetadata(object, read_settings, max_size_bytes, read_hint);
+        return IObjectStorage::readSmallObjectAndGetObjectMetadata(object, read_settings, max_size_bytes, read_hint);
     }
 
     size_t getSmallObjectReads() const { return small_object_reads.load(std::memory_order_relaxed); }

--- a/tests/integration/test_storage_iceberg_no_spark/test_writes_multiple_threads.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_writes_multiple_threads.py
@@ -8,7 +8,7 @@ from helpers.iceberg_utils import (
 )
 
 @pytest.mark.parametrize("format_version", [1, 2])
-@pytest.mark.parametrize("storage_type", ["s3", "local",])
+@pytest.mark.parametrize("storage_type", ["s3",])
 def test_writes_multiple_threads(started_cluster_iceberg_no_spark, format_version, storage_type):
     instance = started_cluster_iceberg_no_spark.instances["node1"]
     r1 = instance.is_built_with_llvm_coverage()

--- a/tests/queries/0_stateless/04230_iceberg_optimize_metadata_not_initialized_104711.reference
+++ b/tests/queries/0_stateless/04230_iceberg_optimize_metadata_not_initialized_104711.reference
@@ -1,4 +1,4 @@
-metadata corrupted
+INSERT failed as expected
 OPTIMIZE did not crash with Logical error
 ALTER did not crash with Logical error
 ALTER ADD COLUMN did not crash with Logical error

--- a/tests/queries/0_stateless/04230_iceberg_optimize_metadata_not_initialized_104711.sh
+++ b/tests/queries/0_stateless/04230_iceberg_optimize_metadata_not_initialized_104711.sh
@@ -10,16 +10,14 @@
 # user-facing exception describing the underlying load failure.
 #
 # We reproduce the "could not load metadata" state by:
-#   1. creating an Iceberg table,
-#   2. overwriting its metadata file on disk with a non-JSON payload,
+#   1. creating an Iceberg table with `iceberg_metadata_compression_method='deflate'`,
+#   2. issuing an `INSERT` with an out-of-range `output_format_compression_level=13`
+#      (above the max supported deflate level - 9 for zlib, 12 for libdeflate)
+#      so the second metadata file lands on disk corrupted,
 #   3. `DETACH ... SYNC` + `ATTACH` (equivalent to a server restart from the
 #      perspective of `DataLakeConfiguration::current_metadata`),
 #   4. then issuing `OPTIMIZE TABLE` / `ALTER TABLE` / `SELECT` which previously
 #      crashed.
-#
-# The metadata is corrupted directly rather than by provoking a failed write:
-# writes to `IcebergLocal` go through a temporary file and `rename`, so a failed
-# write leaves no partial file at the target path.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -30,20 +28,19 @@ TABLE_PATH="${USER_FILES_PATH}/${TABLE}/"
 
 trap 'rm -rf "${TABLE_PATH}" 2>/dev/null' EXIT
 
-# Step 1: create the table. This writes the initial metadata file.
+# Step 1: create the table with the deflate metadata format.
 ${CLICKHOUSE_CLIENT} --query "
     CREATE TABLE ${TABLE} (c0 Int32)
     ENGINE = IcebergLocal('${TABLE_PATH}')
+    SETTINGS iceberg_metadata_compression_method = 'deflate'
 "
 
-# Step 2: corrupt every metadata file on disk.
-corrupted=0
-for metadata_file in "${TABLE_PATH}"metadata/*.metadata.json; do
-    [ -f "${metadata_file}" ] || continue
-    echo 'not a json' > "${metadata_file}"
-    corrupted=1
-done
-[ "${corrupted}" = 1 ] && echo "metadata corrupted"
+# Step 2: provoke the corrupt-metadata-on-disk state via an INSERT with an
+# out-of-range compression level (13 exceeds the deflate max of 9 for zlib and
+# 12 for libdeflate). The INSERT itself must fail.
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --output_format_compression_level=13 \
+    --query "INSERT INTO ${TABLE} VALUES (2)" 2>&1 \
+    | grep -F 'INCORRECT_DATA' > /dev/null && echo "INSERT failed as expected"
 
 # Step 3: detach + attach to clear the in-memory `current_metadata` cache,
 # the way a server restart would. The corrupted metadata produces a server-side

--- a/tests/queries/0_stateless/04240_iceberg_supports_parallel_insert_mv_104891.reference
+++ b/tests/queries/0_stateless/04240_iceberg_supports_parallel_insert_mv_104891.reference
@@ -1,3 +1,3 @@
-[mv_to_datalake] target metadata corrupted
+[mv_to_datalake] target INSERT failed as expected
 [mv_to_datalake] client did not receive Logical error
 [mv_to_datalake] server alive after dependent-sink INSERT

--- a/tests/queries/0_stateless/04240_iceberg_supports_parallel_insert_mv_104891.sh
+++ b/tests/queries/0_stateless/04240_iceberg_supports_parallel_insert_mv_104891.sh
@@ -43,22 +43,22 @@ SOURCE="mv_source_${RANDOM}"
 MV="mv_${RANDOM}"
 TARGET_PATH="${BASE_DIR}/${TARGET}/"
 
-# Step 1: create the data lake target. This writes the initial metadata file.
+# Step 1: create the data lake target with the deflate metadata format so the
+# next step can corrupt it.
 ${CLICKHOUSE_CLIENT} --query "
     CREATE TABLE ${TARGET} (c0 Int32)
     ENGINE = IcebergLocal('${TARGET_PATH}')
+    SETTINGS iceberg_metadata_compression_method = 'deflate'
 "
 
-# Step 2: corrupt every metadata file on disk. This is done directly rather than
-# by provoking a failed write: writes to `IcebergLocal` go through a temporary
-# file and `rename`, so a failed write leaves no partial file at the target path.
-corrupted=0
-for metadata_file in "${TARGET_PATH}"metadata/*.metadata.json; do
-    [ -f "${metadata_file}" ] || continue
-    echo 'not a json' > "${metadata_file}"
-    corrupted=1
-done
-[ "${corrupted}" = 1 ] && echo "[mv_to_datalake] target metadata corrupted"
+# Step 2: corrupt the on-disk metadata via an INSERT with an out-of-range
+# compression level (13 exceeds the deflate max of 9 for zlib and 12 for
+# libdeflate). The INSERT itself must fail.
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 \
+                     --output_format_compression_level=13 \
+    --query "INSERT INTO ${TARGET} VALUES (2)" 2>&1 \
+    | grep -F 'INCORRECT_DATA' > /dev/null \
+    && echo "[mv_to_datalake] target INSERT failed as expected"
 
 # Step 3: build the dependency chain - a plain `MergeTree` source plus a
 # `MATERIALIZED VIEW` that routes rows to the corrupted data lake target.


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#110284

> What broke: LocalObjectStorage.ConcurrentConditionalWritesDoNotLoseUpdates — a unit test added by PR #110284 (https://github.com/ClickHouse/ClickHouse/pull/110284) ("Iceberg local concurrent", merged 2026-07-29
  22:52 UTC). The report you gave is the first master run containing it, and it has since failed on unrelated PRs too (7 failures / ~289 runs across tsan, asan_ubsan and coverage). No existing issue or fix — I
  searched.
  
>  Root cause: the test is right; the code is wrong. LocalObjectStorage gates If-Match conditional writes on an etag built from (mtime, inode, size), and none of the three is a version counter:
  
>  - rename frees the replaced version's inode number for immediate reuse — I measured ext4 handing the same inode number back on every create;
>  - equal-length payloads share st_size;
>  - a kernel that stamps inode times from the coarse per-tick clock gives every file written inside one tick the same mtime down to the nanosecond.
  
>  All three coinciding makes an older version's etag compare equal to the current one, so a writer holding the stale etag passes the check and overwrites a newer version. I reproduced it with a standalone program
  mirroring the exact protocol: with a 1 ms clock tick it produces the CI signature exactly — final=198, expected=200, successful_writes=200. At 1 ns granularity (this box's kernel) it never fires, which is why
  the failure is machine-dependent.
  
>  This is not just a test problem. The production consumer is the Iceberg version-hint.text compare-and-swap in Iceberg::writeMessageToFile — the hint holds a bare version number, so equal-length payloads are the
  norm, and a lost update makes the hint go backwards.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.406` (included in `26.8` and later)
<!-- ch-version-info:end -->