### PR TITLE
Fix data race on `FsNode` in `plain_rewritable` metadata

### DIFF
--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Metadata/FsSnapshot.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Metadata/FsSnapshot.cpp
@@ -33,14 +33,6 @@ bool isVirtual(const FsNodePtr & node)
     return !node->info.has_value();
 }
 
-FsNodePtr cloneFsNodeIfNotExclusive(const FsNodePtr & node)
-{
-    if (node.use_count() > 1)
-        return std::make_shared<FsNode>(*node);
-
-    return node;
-}
-
 template <class Ptr>
 Ptr walk(Ptr node, const NormalizedPath & path)
 {
@@ -93,16 +85,25 @@ bool hasFileOnPath(const FsNodePtr & root, const NormalizedPath & path)
     return false;
 }
 
+/// Copies every node on the path, so that the nodes of the previous version of the tree are never modified.
+/// This is what makes a tree that was already published (via `FsSnapshot::getRoot`) immutable, and therefore
+/// safe to read from other threads without holding the mutex of the snapshot that is being modified here.
+///
+/// Do not try to skip the copy for nodes that look exclusively owned, e.g. by testing `use_count() == 1`.
+/// A node is reachable through the `subdirectories` map of its parent, and a thread that reads the node -
+/// including a thread that copies it here - does not take a reference of its own. The reference count can
+/// therefore drop to one while another thread is still reading the node, and modifying it in place at that
+/// moment is a data race.
 std::pair<FsNodePtr, FsNodePtr> clonePath(const FsNodePtr & start, const NormalizedPath & path)
 {
-    FsNodePtr cloned_start = cloneFsNodeIfNotExclusive(start);
+    FsNodePtr cloned_start = std::make_shared<FsNode>(*start);
     FsNodePtr node = cloned_start;
 
     for (const auto & step : path)
     {
         FsNodePtr cloned_child;
         if (auto it = node->subdirectories.find(step); it != node->subdirectories.end())
-            cloned_child = cloneFsNodeIfNotExclusive(it->second);
+            cloned_child = std::make_shared<FsNode>(*it->second);
         else
             cloned_child = std::make_shared<FsNode>();
 


### PR DESCRIPTION
Caused by: https://github.com/ClickHouse/ClickHouse/pull/111883

`clonePath` in the `plain_rewritable` metadata storage stopped copying `FsNode`s whose reference count was one, and modified them in place instead:

```cpp
FsNodePtr cloneFsNodeIfNotExclusive(const FsNodePtr & node)
{
    if (node.use_count() > 1)
        return std::make_shared<FsNode>(*node);

    return node;
}
```

The reference count is not a proof of exclusive ownership here. An `FsNode` is reachable through the `subdirectories` map of its parent, and a thread that reads the node takes no reference of its own - including `cloneFsNodeIfNotExclusive` itself, which receives the node as a `const std::shared_ptr<FsNode> &` aliasing the parent's map slot. The count can therefore drop to one while another thread is still reading the node, and modifying it in place at that moment is a data race.

`FsNode`s are shared between independent `FsSnapshot` objects, each guarded by its own mutex, and a root handed out by `FsSnapshot::getRoot` is traversed without holding the mutex of the snapshot that is being modified. Nothing serialises the two threads: ThreadSanitizer reported the write from `clonePath` against a read of the same map in `FsNode`'s copy constructor, with disjoint sets of held mutexes.

This restores unconditional copying of the nodes on the path, and therefore the invariant that a tree which was already published is immutable. `clonePath` is now identical to what it was before #111883. The comment above it records why the reference-count shortcut is not sound, so it is not reintroduced. The optimisation can be brought back later on top of explicit ownership tracking rather than a `use_count` test.

### How it showed up in CI

The ThreadSanitizer report aborts the server, so the test fails on its next query with a connection error rather than with anything that points at the metadata storage:

```
File: test_s3_plain_rewritable/test.py:92 - in test
    node.query("SELECT * FROM test ORDER BY id FORMAT Values")
E   helpers.client.QueryRuntimeException: Client failed! Return code: 210, stderr:
    Code: 210. DB::NetException: Connection refused (172.16.4.10:9000). (NETWORK_ERROR)
```

```
E   WARNING: ThreadSanitizer: data race (pid=566)
E     Write of size 8 at 0x721000315d28 by thread T9 (mutexes: write M0, write M1):
E       #3 DB::(anonymous namespace)::clonePath(...) FsSnapshot.cpp:109:36
E       #4 DB::(anonymous namespace)::updateInfo(...) FsSnapshot.cpp:137:45
E       #5 DB::FsSnapshot::recordDirectoryPath(...) FsSnapshot.cpp:197:12
E
E     Previous read of size 8 at 0x721000315d28 by thread T8 (mutexes: write M2, write M3, write M4):
E       #12 DB::FsNode::FsNode(DB::FsNode const&) FsSnapshot.h:33:8
E       #19 DB::(anonymous namespace)::cloneFsNodeIfNotExclusive(...) FsSnapshot.cpp:39:16
E       #20 DB::(anonymous namespace)::clonePath(...) FsSnapshot.cpp:105:36
E       #22 DB::FsSnapshot::recordFile(...) FsSnapshot.cpp:...
```

All of the failures since 2026-07-29 12:21 UTC are in `Integration tests (amd_tsan, 2/6)`, and they span four unrelated pull requests as well as master, so they are not caused by the branches under test. On master:

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=0&sha=ca74af15c55453be1700b084389ce12061971855&name_0=MasterCI&name_1=Integration%20tests%20%28amd_tsan%2C%202%2F6%29

`test_s3_plain_rewritable` was the only test that failed in that run. The failing tests are `test[s3_plain_rewritable_with_metadata_cache-data_with_cache/]`, `test_projections[s3_plain_rewritable]`, `test_projections[cache_s3_plain_rewritable]` and `test_projections[s3_plain_rewritable_with_metadata_cache]`. There were no failures of this test in the three days before #111883 was merged.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
