### PR TITLE
Make the local object storage etag a real version token

### DIFF
--- a/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -2,8 +2,8 @@
 
 #include <array>
 #include <atomic>
-#include <compare>
 #include <filesystem>
+#include <tuple>
 #include <fcntl.h>
 #include <sys/file.h>
 #include <sys/stat.h>
@@ -68,11 +68,9 @@ struct timespec getMTime(const struct stat & file_stat)
 #endif
 }
 
-std::strong_ordering compareTimespec(const struct timespec & left, const struct timespec & right)
+bool isLaterThan(const struct timespec & left, const struct timespec & right)
 {
-    if (auto order = left.tv_sec <=> right.tv_sec; order != std::strong_ordering::equal)
-        return order;
-    return left.tv_nsec <=> right.tv_nsec;
+    return std::tie(left.tv_sec, left.tv_nsec) > std::tie(right.tv_sec, right.tv_nsec);
 }
 
 String makeETag(const struct stat & file_stat)
@@ -368,7 +366,7 @@ void stampMTimeAfterReplacedVersion(const String & temp_path, const struct stat 
 
     /// The payload was written after the replaced version had been published, so a
     /// clock of any usable resolution already separates the two on its own.
-    if (compareTimespec(getMTime(temp_stat), replaced_mtime) == std::strong_ordering::greater)
+    if (isLaterThan(getMTime(temp_stat), replaced_mtime))
         return;
 
     /// A nanosecond is enough on every filesystem that keeps sub-second inode times
@@ -402,7 +400,7 @@ void stampMTimeAfterReplacedVersion(const String & temp_path, const struct stat 
         if (0 != ::stat(temp_path.c_str(), &temp_stat))
             ErrnoException::throwFromPath(ErrorCodes::CANNOT_STAT, temp_path, "Cannot stat file {}", temp_path);
 
-        if (compareTimespec(getMTime(temp_stat), replaced_mtime) == std::strong_ordering::greater)
+        if (isLaterThan(getMTime(temp_stat), replaced_mtime))
             return;
     }
 

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -1,6 +1,8 @@
 #include <Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.h>
 
+#include <array>
 #include <atomic>
+#include <compare>
 #include <filesystem>
 #include <fcntl.h>
 #include <sys/file.h>
@@ -57,19 +59,29 @@ namespace ErrorCodes
 namespace
 {
 
-String makeETag(const struct stat & file_stat)
+struct timespec getMTime(const struct stat & file_stat)
 {
 #if defined(OS_DARWIN)
-    const auto mtim_sec = file_stat.st_mtimespec.tv_sec;
-    const auto mtim_nsec = file_stat.st_mtimespec.tv_nsec;
+    return file_stat.st_mtimespec;
 #else
-    const auto mtim_sec = file_stat.st_mtim.tv_sec;
-    const auto mtim_nsec = file_stat.st_mtim.tv_nsec;
+    return file_stat.st_mtim;
 #endif
+}
+
+std::strong_ordering compareTimespec(const struct timespec & left, const struct timespec & right)
+{
+    if (auto order = left.tv_sec <=> right.tv_sec; order != std::strong_ordering::equal)
+        return order;
+    return left.tv_nsec <=> right.tv_nsec;
+}
+
+String makeETag(const struct stat & file_stat)
+{
+    const auto mtime = getMTime(file_stat);
     return fmt::format(
         "{}.{:09}_{}_{}",
-        static_cast<Int64>(mtim_sec),
-        static_cast<Int64>(mtim_nsec),
+        static_cast<Int64>(mtime.tv_sec),
+        static_cast<Int64>(mtime.tv_nsec),
         static_cast<Int64>(file_stat.st_ino),
         static_cast<Int64>(file_stat.st_size));
 }
@@ -326,6 +338,84 @@ private:
     BlobStorageLogWriterPtr blob_log;
 };
 
+/// Give the version about to be published a modification time strictly later than
+/// the version it replaces, so that no two versions of a path can ever share an etag.
+///
+/// The etag is `(mtime, inode, size)`, and not one of the three is a version counter:
+///
+///   - `rename` unlinks the replaced version, which frees its inode number for
+///     immediate reuse - on ext4 the next file created in that directory typically
+///     lands on it, so version N+2 gets the inode number of version N;
+///   - two payloads of equal length share `st_size`;
+///   - a kernel that stamps inode times from the coarse per-tick clock gives every
+///     file written within one tick the same mtime down to the nanosecond.
+///
+/// When all three coincide, the etag of an older version compares equal to the etag
+/// of the current one, so a writer holding the older etag passes the If-Match check
+/// in `publishConditionally` and silently overwrites a newer version - a lost update,
+/// which is precisely what a compare-and-swap must never allow. Publication is
+/// serialized by the exclusive lock on the parent directory, so stamping every
+/// incoming version past the one it replaces makes the mtime - and therefore the
+/// etag - strictly increase across the whole version history of the path, which is
+/// exactly the uniqueness the compare-and-swap needs.
+void stampMTimeAfterReplacedVersion(const String & temp_path, const struct stat & replaced_stat)
+{
+    const struct timespec replaced_mtime = getMTime(replaced_stat);
+
+    struct stat temp_stat{};
+    if (0 != ::stat(temp_path.c_str(), &temp_stat))
+        ErrnoException::throwFromPath(ErrorCodes::CANNOT_STAT, temp_path, "Cannot stat file {}", temp_path);
+
+    /// The payload was written after the replaced version had been published, so a
+    /// clock of any usable resolution already separates the two on its own.
+    if (compareTimespec(getMTime(temp_stat), replaced_mtime) == std::strong_ordering::greater)
+        return;
+
+    /// A nanosecond is enough on every filesystem that keeps sub-second inode times
+    /// (ext4 with the default inode size, xfs, btrfs, tmpfs). One that keeps whole
+    /// seconds only truncates such a stamp back onto the replaced mtime, and is
+    /// served by the second candidate instead.
+    std::array<struct timespec, 2> candidates = {replaced_mtime, replaced_mtime};
+
+    if (++candidates[0].tv_nsec >= 1'000'000'000)
+    {
+        candidates[0].tv_nsec = 0;
+        ++candidates[0].tv_sec;
+    }
+
+    candidates[1].tv_nsec = 0;
+    ++candidates[1].tv_sec;
+
+    for (const auto & candidate : candidates)
+    {
+        struct timespec times[2];
+        times[0].tv_sec = 0;
+        times[0].tv_nsec = UTIME_OMIT; /// Leave the access time alone.
+        times[1] = candidate;
+
+        if (0 != ::utimensat(AT_FDCWD, temp_path.c_str(), times, 0))
+            ErrnoException::throwFromPath(
+                ErrorCodes::SYSTEM_ERROR, temp_path, "Cannot set the modification time of {}", temp_path);
+
+        /// The filesystem is free to store a coarser time than the one requested,
+        /// so read back what it actually kept instead of assuming the stamp landed.
+        if (0 != ::stat(temp_path.c_str(), &temp_stat))
+            ErrnoException::throwFromPath(ErrorCodes::CANNOT_STAT, temp_path, "Cannot stat file {}", temp_path);
+
+        if (compareTimespec(getMTime(temp_stat), replaced_mtime) == std::strong_ordering::greater)
+            return;
+    }
+
+    throw Exception(
+        ErrorCodes::SYSTEM_ERROR,
+        "Cannot advance the modification time of {} past {}.{:09} of the object it replaces: the filesystem does not keep "
+        "modification times precisely enough to tell two versions of an object apart, so a conditional write cannot be "
+        "performed safely on it",
+        temp_path,
+        static_cast<Int64>(replaced_mtime.tv_sec),
+        static_cast<Int64>(replaced_mtime.tv_nsec));
+}
+
 void publishConditionally(const String & temp_path, const String & target_path, const std::optional<String> & if_match_etag)
 {
     if (!if_match_etag.has_value())
@@ -369,6 +459,8 @@ void publishConditionally(const String & temp_path, const String & target_path, 
             ErrorCodes::STALE_VERSION,
             "Object {} was modified concurrently (etag {}, expected {}), PreconditionFailed for If-Match",
             target_path, etag, *if_match_etag);
+
+    stampMTimeAfterReplacedVersion(temp_path, file_stat);
 
     if (0 != ::rename(temp_path.c_str(), target_path.c_str()))
         ErrnoException::throwFromPath(ErrorCodes::SYSTEM_ERROR, target_path, "Cannot rename {} to {}", temp_path, target_path);
@@ -662,16 +754,18 @@ SmallObjectDataWithMetadata LocalObjectStorage::readSmallObjectAndGetObjectMetad
 ObjectMetadata LocalObjectStorage::getObjectMetadata(const std::string & path, bool) const
 {
     auto resolved_path = resolvePathRelativelyToKeyPrefix(path);
-    ObjectMetadata object_metadata;
     LOG_TEST(log, "Getting metadata for path: {}", resolved_path);
 
-    auto time = fs::last_write_time(resolved_path);
+    /// Every etag of this storage has to come out of `makeETag`: a caller feeds the
+    /// etag it read back into `If-Match`, and a token in any other shape can only
+    /// ever compare unequal there, turning a conditional write into an unconditional
+    /// `PreconditionFailed`.
+    struct stat file_stat{};
+    if (0 != ::stat(resolved_path.c_str(), &file_stat))
+        throw fs::filesystem_error(
+            "Got unexpected error while getting file metadata", resolved_path, std::error_code(errno, std::generic_category()));
 
-    object_metadata.size_bytes = fs::file_size(resolved_path);
-    object_metadata.etag = std::to_string(std::chrono::duration_cast<std::chrono::nanoseconds>(time.time_since_epoch()).count());
-    object_metadata.last_modified = Poco::Timestamp::fromEpochTime(
-        std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch()).count());
-    return object_metadata;
+    return makeObjectMetadata(file_stat);
 }
 
 void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t/* max_keys */) const

--- a/src/Disks/tests/gtest_local_object_storage.cpp
+++ b/src/Disks/tests/gtest_local_object_storage.cpp
@@ -715,6 +715,81 @@ TEST(LocalObjectStorage, ConditionalWriteIfMatchRejectsStaleEtag)
     EXPECT_THROW(writeObject(storage, root / "missing.text", "1", ifMatch(etag_seen_by_a)), DB::Exception);
 }
 
+/// The etag of this storage is `(mtime, inode, size)`, and none of the three
+/// distinguishes two versions of a path on its own: `rename` frees the replaced
+/// version's inode number for immediate reuse, equal-length payloads share the size,
+/// and a kernel that stamps inode times from the coarse per-tick clock gives every
+/// file written inside one tick the same mtime down to the nanosecond. If all three
+/// coincide, the etag of an older version compares equal to the current one and a
+/// writer holding that older etag silently overwrites a newer version.
+///
+/// What rules that out is a modification time that strictly increases with every
+/// published version. The clock hides a violation of that invariant whenever it
+/// happens to advance on its own, so this test removes the clock from the picture: it
+/// pushes the current version's mtime into the future and then publishes over it. The
+/// publication must still come out strictly later, which it can only do by stamping
+/// the mtime rather than by inheriting whatever the clock said.
+TEST(LocalObjectStorage, ConditionalWritePublishesStrictlyIncreasingMTime)
+{
+    ScopedTempDir tmp("ch_gtest_local_object_storage_monotonic_mtime");
+    const auto & root = tmp.path;
+
+    auto storage = makeLocalObjectStorage(root.string());
+    const auto path = root / "metadata" / "version-hint.text";
+
+    writeObject(storage, path, "1", ifNoneMatchAll());
+
+    /// Well past any tick of any clock, and past the runtime of this test.
+    std::error_code ec;
+    fs::last_write_time(path, fs::last_write_time(path) + std::chrono::hours(1), ec);
+    ASSERT_FALSE(ec) << "Failed to set the modification time: " << ec.message();
+
+    const auto mtime_before = fs::last_write_time(path);
+    const auto etag_before = readObject(storage, path).metadata.etag;
+    ASSERT_FALSE(etag_before.empty());
+
+    /// Same length as the payload it replaces, so `st_size` cannot tell them apart.
+    writeObject(storage, path, "2", ifMatch(etag_before));
+
+    EXPECT_GT(fs::last_write_time(path), mtime_before)
+        << "the published version must carry a modification time strictly later than the version it replaces, "
+           "otherwise its etag can repeat an earlier one and a stale writer passes the If-Match check";
+
+    const auto etag_after = readObject(storage, path).metadata.etag;
+    EXPECT_NE(etag_after, etag_before) << "two versions of an object must never share an etag";
+    EXPECT_EQ(readObject(storage, path).data, "2");
+
+    /// The stale etag must still be rejected, and the fresh one still accepted.
+    EXPECT_THROW(writeObject(storage, path, "3", ifMatch(etag_before)), DB::Exception);
+    EXPECT_EQ(readObject(storage, path).data, "2");
+    writeObject(storage, path, "4", ifMatch(etag_after));
+    EXPECT_EQ(readObject(storage, path).data, "4");
+
+    EXPECT_EQ(listDirectory(path.parent_path()), std::vector<std::string>{"version-hint.text"});
+}
+
+/// Every etag this storage hands out has to be the same kind of token, because a
+/// caller feeds the etag it read straight back into `If-Match`. `getObjectMetadata`
+/// used to build a differently shaped one, which could then only ever compare unequal
+/// and turned a conditional write into an unconditional `PreconditionFailed`.
+TEST(LocalObjectStorage, EtagFromGetObjectMetadataSatisfiesIfMatch)
+{
+    ScopedTempDir tmp("ch_gtest_local_object_storage_etag_shape");
+    const auto & root = tmp.path;
+
+    auto storage = makeLocalObjectStorage(root.string());
+    const auto path = root / "metadata" / "v1.metadata.json";
+
+    writeObject(storage, path, "first", ifNoneMatchAll());
+
+    const auto etag = storage->getObjectMetadata(path.string(), /*with_tags=*/ false).etag;
+    ASSERT_FALSE(etag.empty());
+    EXPECT_EQ(etag, readObject(storage, path).metadata.etag) << "all etag producers of this storage must agree";
+
+    writeObject(storage, path, "second", ifMatch(etag));
+    EXPECT_EQ(readObject(storage, path).data, "second");
+}
+
 TEST(LocalObjectStorage, ConcurrentConditionalWritesDoNotLoseUpdates)
 {
     ScopedTempDir tmp("ch_gtest_local_object_storage_cas");


### PR DESCRIPTION
`LocalObjectStorage` decides whether an `If-Match` conditional write may publish by comparing an etag built from `(mtime, inode, size)`. Not one of the three is a version counter:

- `rename` unlinks the replaced version, which frees its inode number for immediate reuse — on ext4 the next file created in that directory typically lands on it, so version N+2 gets the inode number of version N;
- two payloads of equal length share `st_size`;
- a kernel that stamps inode times from the coarse per-tick clock gives every file written within one tick the same mtime down to the nanosecond.

When all three coincide, the etag of an older version compares equal to the etag of the current one, so a writer holding that older etag passes the `If-Match` check and silently overwrites a newer version — the lost update a compare-and-swap exists to prevent.

The production consumer is the Iceberg `version-hint.text` compare-and-swap in `Iceberg::writeMessageToFile`: it reads the hint plus its etag and writes the next version back under `If-Match`. Because the hint holds just a version number, equal-length payloads are the norm, so concurrent writers could make the hint go *backwards* and readers with `iceberg_use_version_hint = 1` would observe stale data.

`LocalObjectStorage.ConcurrentConditionalWritesDoNotLoseUpdates` catches this on `master` and on unrelated pull requests, most visibly as a counter that finishes at 198 after 200 successful writes.

Publication is serialized by the exclusive `flock` on the parent directory, so it is enough to stamp every incoming version strictly past the version it replaces: the mtime — and therefore the etag — then increases strictly across the whole version history of a path, which is the uniqueness the compare-and-swap needs. A filesystem too coarse to keep two versions apart now fails the write loudly instead of losing an update.

This also routes `getObjectMetadata` through the same `makeETag` as every other producer. It built a differently shaped token, so an etag read through it could only ever compare unequal in `If-Match`, turning a conditional write into an unconditional `PreconditionFailed`.

Two regression tests are added. `ConditionalWritePublishesStrictlyIncreasingMTime` pins the invariant without depending on the host's clock resolution: it pushes the current version's mtime into the future and requires the publication over it to still come out strictly later. `EtagFromGetObjectMetadataSatisfiesIfMatch` pins that all etag producers agree.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=ca74af15c55453be1700b084389ce12061971855&name_0=MasterCI&name_1=Unit%20tests%20%28tsan%29&name_1=Unit%20tests%20%28tsan%29

Caused by: https://github.com/ClickHouse/ClickHouse/pull/110284

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed lost updates in conditional writes to a local object storage disk. The etag used for the compare-and-swap could repeat across versions of an object, which let a writer holding a stale etag overwrite a newer version — for Iceberg tables this could make `version-hint.text` go backwards.
