### PR TITLE
Set keeper component in StorageMergeTree::startup

### DIFF
--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -239,9 +239,6 @@ void StorageMergeTree::startup()
     /// Do not schedule any background jobs if the table is read-only.
     if (isTableReadonly())
         return;
-
-    /// The table may be located on a disk with metadata in Keeper (e.g. system tables in some cloud configurations),
-    /// and the cleanups below access the disk metadata, so the Keeper requests need a component for tracking.
     auto component_guard = Coordination::setCurrentComponent("StorageMergeTree::startup");
 
     clearEmptyParts();

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -240,6 +240,10 @@ void StorageMergeTree::startup()
     if (isTableReadonly())
         return;
 
+    /// The table may be located on a disk with metadata in Keeper (e.g. system tables in some cloud configurations),
+    /// and the cleanups below access the disk metadata, so the Keeper requests need a component for tracking.
+    auto component_guard = Coordination::setCurrentComponent("StorageMergeTree::startup");
+
     clearEmptyParts();
 
     /// Temporary directories contain incomplete results of merges (after forced restart)


### PR DESCRIPTION

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.505` (included in `26.8` and later)
<!-- ch-version-info:end -->