### PR TITLE
Backport #111506 to 26.7: Fix flaky test_s3_table_functions_timeouts

### DIFF
--- a/tests/integration/test_s3_table_functions/test.py
+++ b/tests/integration/test_s3_table_functions/test.py
@@ -78,14 +78,25 @@ def test_s3_table_functions(started_cluster):
 
 def test_s3_table_functions_timeouts(started_cluster):
     """
-    Test with timeout limit of 1200ms.
-    This should raise an Exception and pass.
+    A 1200ms network delay must make the S3 write time out and raise.
     """
+
+    # Make the S3 request timeout (not the connect timeout) the single failure mechanism:
+    # disable adaptive timeouts and keep the connect timeout above the delay, so the write
+    # can only fail via s3_request_timeout_ms. This exercises the send/receive idleness
+    # timeout that applies to every attempt on both fresh and reused (pooled keep-alive)
+    # connections, which is the path that was silently not timing out before.
+    timeout_settings = {
+        **settings,
+        "s3_use_adaptive_timeouts": "0",
+        "s3_connect_timeout_ms": "10000",
+        "s3_request_timeout_ms": "500",
+    }
 
     with PartitionManager() as pm:
         pm.add_network_delay(node, 1200)
 
-        with pytest.raises(QueryRuntimeException):
+        with pytest.raises(QueryRuntimeException, match="Timeout"):
             node.query(
                 """
                 INSERT INTO FUNCTION s3
@@ -98,5 +109,5 @@ def test_s3_table_functions_timeouts(started_cluster):
                     )
                 SELECT * FROM numbers(1000000)
             """,
-                settings=settings,
+                settings=timeout_settings,
             )


### PR DESCRIPTION
Backport of #111506 to the `26.7` release branch.

`test_s3_table_functions/test.py::test_s3_table_functions_timeouts` is flaky on `26.7`: the test injects a 1200ms network delay and expects the S3 `INSERT` to time out, but when the request reuses a pooled keep-alive connection there is no fresh TCP connect, so the connect timeout does not apply and the write completes — `DID NOT RAISE`. The fix (already on `master`) makes `s3_request_timeout_ms` the single failure mechanism and asserts the error is a timeout.

The fix was never backported, so the flake still hits CI of `26.7` backport pull requests, e.g. https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112365&sha=dd3a3d84d1e2b05319bf27d88dbefeeb1403ed1b&name_0=BackportPR&name_1=Integration%20tests%20%28amd_tsan%2C%203%2F6%29 (https://github.com/ClickHouse/ClickHouse/pull/112365).

Test-only change.

Related: https://github.com/ClickHouse/ClickHouse/pull/111506
Related: https://github.com/ClickHouse/ClickHouse/pull/112365

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)
