### PR TITLE
Bump `simdjson` from v4.2.4 to v4.6.5

### DIFF
--- a/contrib/simdjson-cmake/CMakeLists.txt
+++ b/contrib/simdjson-cmake/CMakeLists.txt
@@ -29,6 +29,17 @@ if (NOT (ARCH_AMD64 AND X86_ARCH_LEVEL VERSION_GREATER_EQUAL 3))
     target_compile_options(_simdjson PRIVATE -DSIMDJSON_IMPLEMENTATION_FALLBACK=1)
 endif()
 
+# On LoongArch, simdjson's CPU dispatch reads the HWCAP_LOONGARCH_LSX / HWCAP_LOONGARCH_LASX
+# bits (see contrib/simdjson/src/internal/isadetection.h). These are kernel UAPI macros defined
+# in <asm/hwcap.h>, but simdjson only includes <sys/auxv.h>, which pulls in glibc's <bits/hwcap.h>.
+# The glibc in our LoongArch sysroot is old enough that its <bits/hwcap.h> defines no bits for this
+# architecture ("No bits defined for this architecture."), so the macros are unreachable and the
+# build fails. Force-include the kernel header so the macros are always available. The header has an
+# include guard and its values match glibc's, so this is a benign no-op once the sysroot is updated.
+if(ARCH_LOONGARCH64)
+    target_compile_options(_simdjson PRIVATE -include asm/hwcap.h)
+endif()
+
 # On ppc64le, ClickHouse globally defines __SSE2__ to enable SSE-to-AltiVec emulation.
 # This causes simdjson's experimental json_string_builder to activate its SSE2 code path,
 # which fails to compile due to __m128i vs __m128i_u type mismatch in the PPC SSE wrappers.

--- a/src/Common/JSONParsers/SimdJSONParser.h
+++ b/src/Common/JSONParsers/SimdJSONParser.h
@@ -208,6 +208,14 @@ public:
                 format.nullAtom();
                 break;
             }
+            /// `simdjson` only produces `BIGINT` when the parser is configured to store integers
+            /// that do not fit in 64 bits as raw digit strings. We do not enable that option, so
+            /// `simdjson` reports `BIGINT_ERROR` for such numbers instead and this case is
+            /// unreachable; it is handled to keep the switch exhaustive.
+            case simdjson::dom::element_type::BIGINT: {
+                format.string(value.get_bigint().value_unsafe());
+                break;
+            }
             case simdjson::dom::element_type::ARRAY: {
                 append(value.get_array().value_unsafe());
                 break;
@@ -289,6 +297,10 @@ struct SimdJSONParser
                 case simdjson::dom::element_type::OBJECT: return ElementType::OBJECT;
                 case simdjson::dom::element_type::BOOL: return ElementType::BOOL;
                 case simdjson::dom::element_type::NULL_VALUE: return ElementType::NULL_VALUE;
+                /// Unreachable unless the parser is told to store big integers as raw digit
+                /// strings, which we do not do. Reported as a string because that is how
+                /// `simdjson` exposes the value (`element::get_bigint`).
+                case simdjson::dom::element_type::BIGINT: return ElementType::STRING;
             }
         }
 


### PR DESCRIPTION
Contains the fix for CVE-2026-8295 (integer overflow) plus upstream fuzzing fixes. `simdjson` sits directly on the untrusted JSON parsing path (`JSONExtract*`, the `JSON` data type, `FunctionSQLJSON`), so it is worth keeping close to upstream.

v4.6.5 adds `simdjson::dom::element_type::BIGINT`, so the exhaustive switches over the element type in `SimdJSONParser.h` have to handle it. That type is only produced when the parser is configured to store integers exceeding 64 bits as raw digit strings, which we do not enable - `simdjson` returns `BIGINT_ERROR` for such numbers, exactly as it did in v4.2.4. Big integer handling is therefore unchanged.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update `simdjson` to v4.6.5.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.3.5`, `26.6.2.155`, `26.5.6.113`, `26.3.18.2`, `25.8.30.5`
<!-- ch-version-info:end -->