### PR TITLE
Bump `libcotp` from v3.1.1 to v4.2.1

### DIFF
--- a/contrib/libcotp-cmake/CMakeLists.txt
+++ b/contrib/libcotp-cmake/CMakeLists.txt
@@ -10,10 +10,20 @@ endif()
 set (LIBCOTP_SOURCE_DIR "${ClickHouse_SOURCE_DIR}/contrib/libcotp")
 set (LIBCOTP_BINARY_DIR "${ClickHouse_BINARY_DIR}/contrib/libcotp")
 
+# Mirrors the upstream source list for the OpenSSL HMAC/hash backend, without
+# the optional validation helpers (`COTP_ENABLE_VALIDATION`), which we do not use.
 set(SRCS
+    "${LIBCOTP_SOURCE_DIR}/src/ctx.c"
     "${LIBCOTP_SOURCE_DIR}/src/otp.c"
+    "${LIBCOTP_SOURCE_DIR}/src/strerror.c"
+    "${LIBCOTP_SOURCE_DIR}/src/yaotp.c"
     "${LIBCOTP_SOURCE_DIR}/src/utils/base32.c"
+    "${LIBCOTP_SOURCE_DIR}/src/utils/otpauth_uri.c"
+    "${LIBCOTP_SOURCE_DIR}/src/utils/pct.c"
+    "${LIBCOTP_SOURCE_DIR}/src/utils/secure_zero.c"
+    "${LIBCOTP_SOURCE_DIR}/src/utils/whash_openssl.c"
     "${LIBCOTP_SOURCE_DIR}/src/utils/whmac_openssl.c"
+    "${LIBCOTP_SOURCE_DIR}/src/utils/yaotp_uri.c"
 )
 
 add_library (_libcotp ${SRCS})

--- a/src/Access/Common/OneTimePassword.cpp
+++ b/src/Access/Common/OneTimePassword.cpp
@@ -12,12 +12,9 @@
 
 #include <cotp.h>
 
-constexpr int TOTP_SHA512 = SHA512;
-constexpr int TOTP_SHA256 = SHA256;
-constexpr int TOTP_SHA1 = SHA1;
-#undef SHA512
-#undef SHA256
-#undef SHA1
+constexpr int TOTP_SHA512 = COTP_SHA512;
+constexpr int TOTP_SHA256 = COTP_SHA256;
+constexpr int TOTP_SHA1 = COTP_SHA1;
 
 #endif
 


### PR DESCRIPTION
v4 renames the hashing algorithm constants from bare `SHA1`/`SHA256`/`SHA512` to `COTP_SHA1`/`COTP_SHA256`/`COTP_SHA512`. The bare names collided with OpenSSL, which is why `OneTimePassword.cpp` aliased them into `TOTP_SHA*` and undefined them; the `#undef` is no longer needed. The values are unchanged (0/1/2), and `get_totp_at` and the `cotp_error_t` enumerators are unchanged, so the call site stays as it was.

v4 splits the implementation across more translation units. The source list now mirrors upstream for the OpenSSL HMAC/hash backend, without the optional validation helpers (`COTP_ENABLE_VALIDATION`), which we do not use.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update `libcotp` to v4.2.1.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.501` (included in `26.8` and later)
- Backported to: `26.7.3.14`, `26.6.3.3`, `26.5.7.4`, `26.3.17.105`
<!-- ch-version-info:end -->