### PR TITLE
Restore docs search query parameters

### DIFF
--- a/docs/_site/customizations/inkeep-init.js
+++ b/docs/_site/customizations/inkeep-init.js
@@ -155,11 +155,17 @@
       return;
     }
 
+    var initialQuery = new URLSearchParams(window.location.search).get('q') || '';
     var settings = {
       // Open straight to the search view. (canToggleView is honored by
       // SearchBar/ChatButton but NOT by ModalSearchAndChat, so we hide the
       // chat affordances via CSS below instead.)
       defaultView: 'search',
+      // A URL such as /docs/?q=MergeTree opens the modal and runs the search
+      // immediately, matching the old Docusaurus search-page behavior.
+      modalSettings: {
+        isOpen: Boolean(initialQuery),
+      },
       baseSettings: {
         apiKey: INKEEP_API_KEY,
         primaryBrandColor: '#fdff75',
@@ -243,6 +249,7 @@
       },
       searchSettings: {
         placeholder: 'Search ClickHouse docs...',
+        defaultQuery: initialQuery,
         // Wait 300ms after the last keystroke before firing a search request,
         // so fast typing issues one query instead of one per character.
         debounceTimeMs: 300,


### PR DESCRIPTION
Allow docs URLs with a `q` query parameter to open the Inkeep search modal and execute the supplied query immediately. This restores shareable search links that were supported by the previous Docusaurus site.


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.445` (included in `26.8` and later)
<!-- ch-version-info:end -->