### PR TITLE
Iterate ColumnObject subcolumns in sorted path order

### DIFF
--- a/src/Columns/ColumnObject.cpp
+++ b/src/Columns/ColumnObject.cpp
@@ -1537,28 +1537,31 @@ void ColumnObject::protect()
 
 void ColumnObject::forEachMutableSubcolumn(DB::IColumn::MutableColumnCallback callback)
 {
-    for (auto & [_, column] : typed_paths)
-        callback(column);
-    for (auto & [path, column] : dynamic_paths)
+    for (const auto & path : sorted_typed_paths)
+        callback(typed_paths.find(path)->second);
+    for (const auto & path : sorted_dynamic_paths)
     {
-        callback(column);
-        dynamic_paths_ptrs[path] = assert_cast<ColumnDynamic *>(column.get());
+        auto it = dynamic_paths.find(path);
+        callback(it->second);
+        dynamic_paths_ptrs[it->first] = assert_cast<ColumnDynamic *>(it->second.get());
     }
     callback(shared_data);
 }
 
 void ColumnObject::forEachMutableSubcolumnRecursively(DB::IColumn::RecursiveMutableColumnCallback callback)
 {
-    for (auto & [_, column] : typed_paths)
+    for (const auto & path : sorted_typed_paths)
     {
+        auto & column = typed_paths.find(path)->second;
         callback(*column);
         column->forEachMutableSubcolumnRecursively(callback);
     }
-    for (auto & [path, column] : dynamic_paths)
+    for (const auto & path : sorted_dynamic_paths)
     {
-        callback(*column);
-        column->forEachMutableSubcolumnRecursively(callback);
-        dynamic_paths_ptrs[path] = assert_cast<ColumnDynamic *>(column.get());
+        auto it = dynamic_paths.find(path);
+        callback(*it->second);
+        it->second->forEachMutableSubcolumnRecursively(callback);
+        dynamic_paths_ptrs[it->first] = assert_cast<ColumnDynamic *>(it->second.get());
     }
     callback(*shared_data);
     shared_data->forEachMutableSubcolumnRecursively(callback);
@@ -1566,23 +1569,25 @@ void ColumnObject::forEachMutableSubcolumnRecursively(DB::IColumn::RecursiveMuta
 
 void ColumnObject::forEachSubcolumn(DB::IColumn::ColumnCallback callback) const
 {
-    for (const auto & [_, column] : typed_paths)
-        callback(column);
-    for (const auto & [path, column] : dynamic_paths)
-        callback(column);
+    for (const auto & path : sorted_typed_paths)
+        callback(typed_paths.find(path)->second);
+    for (const auto & path : sorted_dynamic_paths)
+        callback(dynamic_paths.find(path)->second);
 
     callback(shared_data);
 }
 
 void ColumnObject::forEachSubcolumnRecursively(DB::IColumn::RecursiveColumnCallback callback) const
 {
-    for (const auto & [_, column] : typed_paths)
+    for (const auto & path : sorted_typed_paths)
     {
+        const auto & column = typed_paths.find(path)->second;
         callback(*column);
         column->forEachSubcolumnRecursively(callback);
     }
-    for (const auto & [path, column] : dynamic_paths)
+    for (const auto & path : sorted_dynamic_paths)
     {
+        const auto & column = dynamic_paths.find(path)->second;
         callback(*column);
         column->forEachSubcolumnRecursively(callback);
     }


### PR DESCRIPTION
Make `ColumnObject::forEachSubcolumn`, `forEachMutableSubcolumn` and their recursive variants iterate over the already-maintained `sorted_typed_paths`/`sorted_dynamic_paths` lists instead of the raw `typed_paths`/`dynamic_paths` `unordered_map`s.

Motivation: the iteration order of an `unordered_map` is not guaranteed to be preserved by its copy constructor, and `IColumn::mutate` clones the column (copy-constructing those maps) when it is shared. `IColumn::convertToFullIfWrapped` collects the unwrapped subcolumns while iterating the source column and then reassigns them positionally while iterating the mutated (possibly cloned) column, so both passes must visit subcolumns in the same order. If the cloned maps iterated in a different order, converted subcolumns would be assigned to the wrong paths.

Iterating the sorted path lists makes the visiting order deterministic and stable across cloning, removing the reliance on unspecified `unordered_map` copy-order behavior. This is currently latent — the bundled `libc++` happens to preserve copy order — so it is a safety change with no user-visible effect.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1131` (included in `26.8` and later)
- Backported to: `26.7.4.17`, `26.6.3.32`, `26.5.7.40`, `26.3.18.22`, `25.8.30.14`
<!-- ch-version-info:end -->