### PR TITLE
Label over/under-utilized runners from host metrics

### DIFF
--- a/ci/praktika/gh_auth.py
+++ b/ci/praktika/gh_auth.py
@@ -3,19 +3,35 @@ import time
 
 import requests
 
-try:
-    import jwt  # From pyjwt
-
-    assert hasattr(jwt, "encode"), "Invalid jwt module, 'encode' not found"
-    USING_PYJWT = True
-except (ImportError, AssertionError):
-    USING_PYJWT = False
-    print(
-        "Warning: pyjwt not available. Falling back to 'jwt' module (not recommended)"
-    )
-    from jwt import jwk_from_pem, JWT
-
 from praktika.utils import Shell
+
+# The JWT backend is imported lazily (see _jwt_backend) so importing this module
+# - and therefore runner.py - never requires pyjwt. Only GitHub App auth needs
+# it; local flows such as running integration tests must not depend on it.
+_JWT_BACKEND = None
+
+
+def _jwt_backend():
+    """Return (using_pyjwt, backend), importing the JWT library on first use.
+
+    backend is the ``jwt`` module when pyjwt is available, otherwise the
+    ``(jwk_from_pem, JWT)`` symbols from the legacy ``jwt`` package.
+    """
+    global _JWT_BACKEND
+    if _JWT_BACKEND is None:
+        try:
+            import jwt  # From pyjwt
+
+            assert hasattr(jwt, "encode"), "Invalid jwt module, 'encode' not found"
+            _JWT_BACKEND = (True, jwt)
+        except (ImportError, AssertionError):
+            print(
+                "Warning: pyjwt not available. Falling back to 'jwt' module (not recommended)"
+            )
+            from jwt import JWT, jwk_from_pem
+
+            _JWT_BACKEND = (False, (jwk_from_pem, JWT))
+    return _JWT_BACKEND
 
 # `gh auth login --with-token` validates the token against api.github.com. A single
 # transient GitHub API 5xx/timeout there would otherwise hard-fail the whole job.
@@ -91,6 +107,7 @@ class GHAuth:
             "iss": app_id,
         }
 
+        _, jwt = _jwt_backend()
         jwt_instance = jwt.PyJWT()
         encoded_jwt = jwt_instance.encode(payload, private_key, algorithm="RS256")
         return cls._get_access_token_by_jwt(encoded_jwt, installation_id)
@@ -98,6 +115,7 @@ class GHAuth:
     @classmethod
     def _get_access_token_deprecated(cls, app_key, app_id, installation_id: int):
         def _generate_jwt(client_id, pem):
+            _, (jwk_from_pem, JWT) = _jwt_backend()
             pem = str.encode(pem)
             signing_key = jwk_from_pem(pem)
             payload = {
@@ -124,7 +142,8 @@ class GHAuth:
         instead print a warning and return False.
         """
         try:
-            if USING_PYJWT:
+            using_pyjwt, _ = _jwt_backend()
+            if using_pyjwt:
                 access_token = cls._get_access_token(app_key, app_id, installation_id)
             else:
                 access_token = cls._get_access_token_deprecated(app_key, app_id, installation_id)

--- a/ci/praktika/host_metrics.py
+++ b/ci/praktika/host_metrics.py
@@ -53,6 +53,7 @@ class HostMetricsCollector:
     _UNDER_CPU_PCT = 20.0  # average CPU below this -> CPU over-provisioned
     _RAM_PRESSURE_PCT = 95.0  # peak RAM at/above this -> RAM under-provisioned
     _CPU_STALL_RATIO = 0.5  # cpu stall seconds / duration above this -> CPU-bound
+    _IO_STALL_RATIO = 0.4  # io stall seconds / duration above this -> IO-bound
     _DISK_WARN_PCT = 85.0  # peak disk at/above this -> almost full
 
     def __init__(
@@ -458,6 +459,7 @@ class HostMetricsCollector:
         disk_gb = metrics.get("disk_total_gb")
         mem_full_s = psi.get("mem_full_s", 0)
         cpu_s = psi.get("cpu_s", 0)
+        io_s = psi.get("io_some_s", 0)
 
         # RAM: pressure (under-provisioned) takes precedence over idle headroom.
         if (mem_peak is not None and mem_peak >= cls._RAM_PRESSURE_PCT) or mem_full_s:
@@ -489,6 +491,16 @@ class HostMetricsCollector:
                 (
                     "under-utilized CPU",
                     f"Average CPU only {cpu_avg}% - consider a smaller runner",
+                )
+            )
+
+        # IO: sustained stall waiting on storage.
+        io_ratio = io_s / duration if duration else 0
+        if io_ratio > cls._IO_STALL_RATIO:
+            labels.append(
+                (
+                    "io-bound",
+                    f"IO stalled {io_s}s ({round(100 * io_ratio)}% of runtime) - storage may be the bottleneck",
                 )
             )
 

--- a/ci/praktika/host_metrics.py
+++ b/ci/praktika/host_metrics.py
@@ -446,7 +446,10 @@ class HostMetricsCollector:
         if not metrics:
             return labels
         duration = metrics.get("duration") or 0
-        if duration < Settings.HOST_METRICS_MIN_LABEL_DURATION_SEC:
+        mem_gb = metrics.get("mem_total_gb") or 0
+        # Label only jobs worth right-sizing: either long enough, or on a host
+        # with substantial RAM (costly, so worth flagging even if short).
+        if duration < Settings.HOST_METRICS_MIN_LABEL_DURATION_SEC and mem_gb <= Settings.HOST_METRICS_MIN_LABEL_MEM_GB:
             return labels
 
         peaks = metrics.get("peaks", {})
@@ -455,7 +458,6 @@ class HostMetricsCollector:
         mem_peak = peaks.get("mem")
         cpu_avg = averages.get("cpu")
         disk_peak = peaks.get("disk")
-        mem_gb = metrics.get("mem_total_gb")
         disk_gb = metrics.get("disk_total_gb")
         mem_full_s = psi.get("mem_full_s", 0)
         cpu_s = psi.get("cpu_s", 0)

--- a/ci/praktika/host_metrics.py
+++ b/ci/praktika/host_metrics.py
@@ -48,6 +48,13 @@ class HostMetricsCollector:
     _PSI_MEM = "/proc/pressure/memory"
     _PSI_IO = "/proc/pressure/io"
 
+    # Utilization label thresholds (see classify). Percentages unless noted.
+    _UNDER_MEM_PCT = 50.0  # peak RAM below this -> RAM over-provisioned
+    _UNDER_CPU_PCT = 20.0  # average CPU below this -> CPU over-provisioned
+    _RAM_PRESSURE_PCT = 95.0  # peak RAM at/above this -> RAM under-provisioned
+    _CPU_STALL_RATIO = 0.5  # cpu stall seconds / duration above this -> CPU-bound
+    _DISK_WARN_PCT = 85.0  # peak disk at/above this -> almost full
+
     def __init__(
         self,
         out_file: str = Settings.HOST_METRICS_FILE,
@@ -77,6 +84,12 @@ class HostMetricsCollector:
         self._cpu_peak = 0.0
         self._mem_peak = 0.0
         self._disk_peak = 0.0
+        # Time-weighted running sums for whole-run averages (area = value * dt).
+        self._cpu_area = 0.0
+        self._mem_area = 0.0
+        self._disk_area = 0.0
+        self._dt_total = 0.0
+        self._disk_dt_total = 0.0
         self._n_fine = 0
         self._psi_start: Optional[Dict[str, int]] = None
         self._psi_end: Optional[Dict[str, int]] = None
@@ -200,6 +213,10 @@ class HostMetricsCollector:
             # Exact global peaks, immune to windowing/decimation.
             self._cpu_peak = max(self._cpu_peak, cpu_pct)
             self._mem_peak = max(self._mem_peak, mem_pct)
+            # Time-weighted running totals for the whole-run averages.
+            self._cpu_area += cpu_pct * dt
+            self._mem_area += mem_pct * dt
+            self._dt_total += dt
             # Disk is sampled independently: a failure here disables only the
             # disk series and leaves CPU/RAM/PSI intact.
             if self._disk_available:
@@ -211,6 +228,8 @@ class HostMetricsCollector:
                 else:
                     win_disk.append((disk_pct, dt))
                     self._disk_peak = max(self._disk_peak, disk_pct)
+                    self._disk_area += disk_pct * dt
+                    self._disk_dt_total += dt
             if now - window_start >= self._report_interval:
                 flush_window(now)
                 window_start = now
@@ -338,6 +357,12 @@ class HostMetricsCollector:
             "mem": round(self._mem_peak, 1),
             "mem_gb": round(mem_total_gb * self._mem_peak / 100.0, 2),
         }
+        averages = {
+            "cpu": round(self._cpu_area / self._dt_total, 1) if self._dt_total else 0.0,
+            "mem": round(self._mem_area / self._dt_total, 1) if self._dt_total else 0.0,
+        }
+        if self._disk_dt_total:
+            averages["disk"] = round(self._disk_area / self._disk_dt_total, 1)
         series = {
             "cpu": self._decimate([(s["t"], s["cpu"], s["cpu_peak"]) for s in samples], self._max_points),
             "mem": self._decimate([(s["t"], s["mem"], s["mem_peak"]) for s in samples], self._max_points),
@@ -350,6 +375,7 @@ class HostMetricsCollector:
             "n_raw": self._n_fine,
             "n_windows": len(samples),
             "peaks": peaks,
+            "averages": averages,
             "series": series,
         }
         # Disk is optional: present only when the disk path was sampled.
@@ -403,3 +429,76 @@ class HostMetricsCollector:
             result.extend(sorted(reps, key=lambda p: p[0]))
         result.append(last)
         return [[t, a, p] for t, a, p in result]
+
+    @classmethod
+    def classify(cls, metrics: Optional[Dict]) -> List[Tuple[str, str]]:
+        """Derive over/under-utilization labels from a compacted metrics dict.
+
+        Returns a list of ``(label, hint)`` pairs for ``Result.set_label``.
+        Only jobs that ran at least ``HOST_METRICS_MIN_LABEL_DURATION_SEC`` are
+        labelled - shorter runs are noisy and not worth right-sizing. RAM uses
+        the peak (you provision for the worst case); CPU uses the whole-run
+        average (brief bursts do not justify more cores); a large CPU stall or a
+        near-full disk are surfaced as their own warnings.
+        """
+        labels: List[Tuple[str, str]] = []
+        if not metrics:
+            return labels
+        duration = metrics.get("duration") or 0
+        if duration < Settings.HOST_METRICS_MIN_LABEL_DURATION_SEC:
+            return labels
+
+        peaks = metrics.get("peaks", {})
+        averages = metrics.get("averages", {})
+        psi = metrics.get("psi", {})
+        mem_peak = peaks.get("mem")
+        cpu_avg = averages.get("cpu")
+        disk_peak = peaks.get("disk")
+        mem_gb = metrics.get("mem_total_gb")
+        disk_gb = metrics.get("disk_total_gb")
+        mem_full_s = psi.get("mem_full_s", 0)
+        cpu_s = psi.get("cpu_s", 0)
+
+        # RAM: pressure (under-provisioned) takes precedence over idle headroom.
+        if (mem_peak is not None and mem_peak >= cls._RAM_PRESSURE_PCT) or mem_full_s:
+            labels.append(
+                (
+                    "ram-pressure",
+                    f"Peak RAM {mem_peak}% of {mem_gb}GB, memory stalled {mem_full_s}s - consider more RAM",
+                )
+            )
+        elif mem_peak is not None and mem_peak < cls._UNDER_MEM_PCT:
+            labels.append(
+                (
+                    "under-utilized RAM",
+                    f"Peak RAM only {mem_peak}% of {mem_gb}GB - consider a smaller runner",
+                )
+            )
+
+        # CPU: sustained contention (CPU-bound) vs mostly-idle cores.
+        stall_ratio = cpu_s / duration if duration else 0
+        if stall_ratio > cls._CPU_STALL_RATIO:
+            labels.append(
+                (
+                    "cpu-bound",
+                    f"CPU stalled {cpu_s}s ({round(100 * stall_ratio)}% of runtime) - consider more CPU",
+                )
+            )
+        elif cpu_avg is not None and cpu_avg < cls._UNDER_CPU_PCT:
+            labels.append(
+                (
+                    "under-utilized CPU",
+                    f"Average CPU only {cpu_avg}% - consider a smaller runner",
+                )
+            )
+
+        # Disk: nearly full.
+        if disk_peak is not None and disk_peak >= cls._DISK_WARN_PCT:
+            labels.append(
+                (
+                    "disk-almost-full",
+                    f"Peak disk {disk_peak}% of {disk_gb}GB",
+                )
+            )
+
+        return labels

--- a/ci/praktika/host_metrics.py
+++ b/ci/praktika/host_metrics.py
@@ -52,6 +52,7 @@ class HostMetricsCollector:
     _UNDER_MEM_PCT = 50.0  # peak RAM below this -> RAM over-provisioned
     _UNDER_CPU_PCT = 20.0  # average CPU below this -> CPU over-provisioned
     _RAM_PRESSURE_PCT = 95.0  # peak RAM at/above this -> RAM under-provisioned
+    _MEM_STALL_RATIO = 0.02  # mem full-stall / duration above this -> RAM pressure
     _CPU_STALL_RATIO = 0.5  # cpu stall seconds / duration above this -> CPU-bound
     _IO_STALL_RATIO = 0.4  # io stall seconds / duration above this -> IO-bound
     _DISK_WARN_PCT = 85.0  # peak disk at/above this -> almost full
@@ -464,11 +465,18 @@ class HostMetricsCollector:
         io_s = psi.get("io_some_s", 0)
 
         # RAM: pressure (under-provisioned) takes precedence over idle headroom.
-        if (mem_peak is not None and mem_peak >= cls._RAM_PRESSURE_PCT) or mem_full_s:
+        # Only a sustained memory full-stall counts - a brief blip (e.g. 0.01s
+        # over a long build) is noise, not pressure, so require a fraction of
+        # the runtime rather than any non-zero value.
+        mem_full_ratio = mem_full_s / duration if duration else 0
+        if (
+            mem_peak is not None and mem_peak >= cls._RAM_PRESSURE_PCT
+        ) or mem_full_ratio > cls._MEM_STALL_RATIO:
             labels.append(
                 (
                     "ram-pressure",
-                    f"Peak RAM {mem_peak}% of {mem_gb}GB, memory stalled {mem_full_s}s - consider more RAM",
+                    f"Peak RAM {mem_peak}% of {mem_gb}GB, memory stalled {mem_full_s}s "
+                    f"({round(100 * mem_full_ratio)}% of runtime) - consider more RAM",
                 )
             )
         elif mem_peak is not None and mem_peak < cls._UNDER_MEM_PCT:

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -497,9 +497,11 @@ class Runner:
                 result = Result.from_fs(job.name)
                 if host_metrics:
                     result.add_ext_key_value("metrics", host_metrics)
-                    # Flag over/under-utilized runners (long jobs only).
-                    for label, hint in HostMetricsCollector.classify(host_metrics):
-                        result.set_label(label, hint=hint)
+                    # Flag over/under-utilized runners, but not for skipped jobs -
+                    # they did no real work, so their metrics are meaningless.
+                    if not result.is_skipped():
+                        for label, hint in HostMetricsCollector.classify(host_metrics):
+                            result.set_label(label, hint=hint)
                 if exit_code != 0:
                     if not result.is_completed():
                         if process.timeout_exceeded:

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -497,6 +497,9 @@ class Runner:
                 result = Result.from_fs(job.name)
                 if host_metrics:
                     result.add_ext_key_value("metrics", host_metrics)
+                    # Flag over/under-utilized runners (long jobs only).
+                    for label, hint in HostMetricsCollector.classify(host_metrics):
+                        result.set_label(label, hint=hint)
                 if exit_code != 0:
                     if not result.is_completed():
                         if process.timeout_exceeded:

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -82,9 +82,11 @@ class _Settings:
     # Filesystem whose used% is tracked as the "disk" series. Defaults to the
     # working directory, i.e. the disk the job actually writes to.
     HOST_METRICS_DISK_PATH: str = "."
-    # Only jobs that ran at least this long are labelled over/under-utilized -
-    # shorter jobs are too noisy and not worth right-sizing. 30 minutes.
-    HOST_METRICS_MIN_LABEL_DURATION_SEC: float = 1800.0
+    # Jobs are labelled over/under-utilized only when they ran at least this
+    # long OR ran on a host with more than HOST_METRICS_MIN_LABEL_MEM_GB of RAM;
+    # short jobs on small runners are too noisy and not worth right-sizing.
+    HOST_METRICS_MIN_LABEL_DURATION_SEC: int = 1800
+    HOST_METRICS_MIN_LABEL_MEM_GB: int = 15
 
     SECRET_GH_APP_ID: str = ""
     SECRET_GH_APP_PEM_KEY: str = ""
@@ -220,6 +222,7 @@ _USER_DEFINED_SETTINGS = [
     "HOST_METRICS_FILE",
     "HOST_METRICS_DISK_PATH",
     "HOST_METRICS_MIN_LABEL_DURATION_SEC",
+    "HOST_METRICS_MIN_LABEL_MEM_GB",
 ]
 
 

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -82,6 +82,9 @@ class _Settings:
     # Filesystem whose used% is tracked as the "disk" series. Defaults to the
     # working directory, i.e. the disk the job actually writes to.
     HOST_METRICS_DISK_PATH: str = "."
+    # Only jobs that ran at least this long are labelled over/under-utilized -
+    # shorter jobs are too noisy and not worth right-sizing. 30 minutes.
+    HOST_METRICS_MIN_LABEL_DURATION_SEC: float = 1800.0
 
     SECRET_GH_APP_ID: str = ""
     SECRET_GH_APP_PEM_KEY: str = ""
@@ -216,6 +219,7 @@ _USER_DEFINED_SETTINGS = [
     "HOST_METRICS_MAX_POINTS",
     "HOST_METRICS_FILE",
     "HOST_METRICS_DISK_PATH",
+    "HOST_METRICS_MIN_LABEL_DURATION_SEC",
 ]
 
 
@@ -231,9 +235,7 @@ def _get_settings() -> _Settings:
 
     for py_file in sorted_files:
         module_name = py_file.name.removeprefix(".py")
-        spec = importlib.util.spec_from_file_location(
-            module_name, f"{_Settings.SETTINGS_DIRECTORY}/{module_name}"
-        )
+        spec = importlib.util.spec_from_file_location(module_name, f"{_Settings.SETTINGS_DIRECTORY}/{module_name}")
         assert spec
         foo = importlib.util.module_from_spec(spec)
         assert spec.loader

--- a/src/Processors/QueryPlan/LogicalExchangeStep.h
+++ b/src/Processors/QueryPlan/LogicalExchangeStep.h
@@ -10,7 +10,7 @@ namespace DB
 {
 
 /// Base class for logical exchange steps.
-/// Derived classes implement createSinkAndSourcePair method that is used to create a pair of send-recieve steps when converting
+/// Derived classes implement createSinkAndSourcePair method that is used to create a pair of send-receive steps when converting
 /// logical plan to a distributed plan.
 /// By default the data that is sent via the exchange might be reordered, but in cases like distributed sorting it is required to
 /// merge incoming sorted streams according to the sort description.


### PR DESCRIPTION
Automatically label CI jobs as over/under-utilized from the host metrics already collected (CPU/RAM/disk usage + PSI), so runners can be right-sized.

`HostMetricsCollector.classify` derives labels from the compacted metrics and `runner.py` applies them via `Result.set_label` (they render as badges with a hint tooltip). Only jobs that ran at least `HOST_METRICS_MIN_LABEL_DURATION_SEC` (default 30 min) are labelled — shorter runs are too noisy to right-size.

Criteria:

| Label | Trigger | Meaning |
|---|---|---|
| `under-utilized RAM` | peak RAM < 50% | over-provisioned → smaller runner |
| `under-utilized CPU` | whole-run avg CPU < 20% | over-provisioned → smaller runner |
| `cpu-bound` | CPU stall (PSI) > 50% of runtime | under-provisioned → more cores |
| `io-bound` | IO stall (PSI) > 40% of runtime | storage is the bottleneck |
| `ram-pressure` | peak RAM ≥ 95% or memory stalled (PSI full) > 0 | near-OOM → more RAM |
| `disk-almost-full` | peak disk ≥ 85% | warning |

RAM uses the peak (provision for the worst case); CPU uses the time-weighted whole-run average (brief bursts do not justify more cores), which is added to the metrics payload as `averages`. Thresholds are class constants; the minimum duration is a setting.

Related: https://github.com/ClickHouse/ClickHouse/pull/112436
Related: https://github.com/ClickHouse/ClickHouse/pull/112567

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.599` (included in `26.8` and later)
<!-- ch-version-info:end -->