### PR TITLE
sync private

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.cpp
@@ -175,7 +175,8 @@ MetadataGenerator::NextMetadataResult MetadataGenerator::generateNextMetadata(
     Int64 added_delete_files,
     Int64 num_deleted_rows,
     std::optional<Int64> user_defined_snapshot_id,
-    std::optional<Int64> user_defined_timestamp)
+    std::optional<Int64> user_defined_timestamp,
+    SnapshotOperation operation)
 {
     int format_version = metadata_object->getValue<Int32>(Iceberg::f_format_version);
 
@@ -219,7 +220,14 @@ MetadataGenerator::NextMetadataResult MetadataGenerator::generateNextMetadata(
 
     auto parent_snapshot = getParentSnapshot(parent_snapshot_id);
     Poco::JSON::Object::Ptr summary = new Poco::JSON::Object;
-    summary->set(Iceberg::f_operation, num_deleted_rows == 0 ? Iceberg::f_append : Iceberg::f_overwrite);
+    /// A merge-on-read DELETE writes position-delete files (num_deleted_rows != 0): per the Iceberg
+    /// spec that snapshot is an `overwrite`, not an `append`. Compaction passes `Replace` explicitly.
+    const char * operation_name = Iceberg::f_append;
+    if (operation == SnapshotOperation::Replace)
+        operation_name = Iceberg::f_replace;
+    else if (num_deleted_rows != 0)
+        operation_name = Iceberg::f_overwrite;
+    summary->set(Iceberg::f_operation, operation_name);
     summary->set(Iceberg::f_added_data_files, std::to_string(added_files));
     summary->set(Iceberg::f_added_records, std::to_string(added_records));
     summary->set(Iceberg::f_added_files_size, std::to_string(added_files_size));

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.h
@@ -26,6 +26,12 @@ public:
         Iceberg::IcebergPathFromMetadata manifest_list_path;
     };
 
+    enum class SnapshotOperation
+    {
+        Append,
+        Replace,
+    };
+
     NextMetadataResult generateNextMetadata(
         FileNamesGenerator & generator,
         const Iceberg::IcebergPathFromMetadata & metadata_file_path,
@@ -37,7 +43,8 @@ public:
         Int64 added_delete_files,
         Int64 num_deleted_rows,
         std::optional<Int64> user_defined_snapshot_id = std::nullopt,
-        std::optional<Int64> user_defined_timestamp = std::nullopt);
+        std::optional<Int64> user_defined_timestamp = std::nullopt,
+        SnapshotOperation operation = SnapshotOperation::Append);
 
     /// Create a manifest-only rewrite snapshot (`replace` operation) carrying `total-*` counters forward so `OPTIMIZE ... MANIFEST` is idempotent.
     NextMetadataResult generateManifestOnlySnapshot(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_metadata_generator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_metadata_generator.cpp
@@ -61,6 +61,57 @@ void appendSnapshot(Poco::JSON::Object::Ptr metadata, Int64 parent_snapshot_id =
         /*num_deleted_rows=*/ 0);
 }
 
+/// Generate one snapshot with explicit delete-file / operation parameters and return its `operation` summary field.
+String snapshotOperation(
+    Poco::JSON::Object::Ptr metadata,
+    Int64 added_delete_files,
+    Int64 num_deleted_rows,
+    MetadataGenerator::SnapshotOperation operation = MetadataGenerator::SnapshotOperation::Append)
+{
+    FileNamesGenerator generator("s3://bucket/table", /*use_uuid_in_metadata=*/ false, CompressionMethod::None, "Parquet");
+    generator.setVersion(1);
+    auto metadata_info = generator.generateMetadataPathWithInfo();
+    auto result = MetadataGenerator(metadata).generateNextMetadata(
+        generator,
+        metadata_info.path,
+        /*parent_snapshot_id=*/ -1,
+        /*added_files=*/ 1,
+        /*added_records=*/ 1,
+        /*added_files_size=*/ 100,
+        /*num_partitions=*/ 1,
+        added_delete_files,
+        num_deleted_rows,
+        /*user_defined_snapshot_id=*/ std::nullopt,
+        /*user_defined_timestamp=*/ std::nullopt,
+        operation);
+    return result.snapshot->getObject(Iceberg::f_summary)->getValue<String>(Iceberg::f_operation);
+}
+
+}
+
+/// A plain data append (no deleted rows) must be labelled `append`.
+TEST(IcebergMetadataGenerator, AppendOperationForInsert)
+{
+    auto metadata = makeMinimalV2Metadata();
+    EXPECT_EQ(snapshotOperation(metadata, /*added_delete_files=*/ 0, /*num_deleted_rows=*/ 0), Iceberg::f_append);
+}
+
+/// A merge-on-read DELETE writes position-delete files, so its snapshot must be labelled `overwrite`
+/// (Iceberg spec). This is what system.iceberg_history reports and what expire_snapshots relies on.
+TEST(IcebergMetadataGenerator, OverwriteOperationForDelete)
+{
+    auto metadata = makeMinimalV2Metadata();
+    EXPECT_EQ(snapshotOperation(metadata, /*added_delete_files=*/ 1, /*num_deleted_rows=*/ 5), Iceberg::f_overwrite);
+}
+
+/// An explicit `Replace` (manifest rewrite / compaction) stays `replace` regardless of delete counters.
+TEST(IcebergMetadataGenerator, ReplaceOperationIsPreserved)
+{
+    auto metadata = makeMinimalV2Metadata();
+    EXPECT_EQ(
+        snapshotOperation(
+            metadata, /*added_delete_files=*/ 1, /*num_deleted_rows=*/ 5, MetadataGenerator::SnapshotOperation::Replace),
+        Iceberg::f_replace);
 }
 
 /// snapshots / metadata-log / snapshot-log are optional per the Iceberg spec, so external


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
sync private


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.490` (included in `26.8` and later)
<!-- ch-version-info:end -->