### PR TITLE
Support workload identity in delta-kernel Azure path

### DIFF
--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.h
@@ -154,6 +154,11 @@ struct ConnectionParams
     AuthMethod auth_method;
     BlobClientOptions client_options;
 
+    /// Explicit workload identity IDs (e.g. from extra_credentials). The SDK credential
+    /// does not expose them back, so they are kept here for the delta-kernel path.
+    String workload_identity_client_id;
+    String workload_identity_tenant_id;
+
     String getContainer() const { return endpoint.container_name; }
     String getConnectionURL() const;
 

--- a/src/Disks/DiskObjectStorage/ObjectStorages/ObjectStorageFactory.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/ObjectStorageFactory.cpp
@@ -199,7 +199,9 @@ static void registerAzureObjectStorage(ObjectStorageFactory & factory)
         {
             .endpoint = AzureBlobStorage::processEndpoint(config, config_prefix),
             .auth_method = AzureBlobStorage::getAuthMethod(config, config_prefix),
-            .client_options = AzureBlobStorage::getClientOptions(context, context->getSettingsRef(), *azure_settings, /*for_disk=*/ true)
+            .client_options = AzureBlobStorage::getClientOptions(context, context->getSettingsRef(), *azure_settings, /*for_disk=*/ true),
+            .workload_identity_client_id = "",
+            .workload_identity_tenant_id = ""
         };
 
         return std::make_shared<AzureObjectStorage>(

--- a/src/Storages/ObjectStorage/Azure/Configuration.cpp
+++ b/src/Storages/ObjectStorage/Azure/Configuration.cpp
@@ -124,6 +124,12 @@ AzureBlobStorage::ConnectionParams getAzureConnectionParams(
         if (!client_id || !tenant_id)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Both 'client_id' and 'tenant_id' need to be provided, but '{}' is missing", client_id ? "tenant_id" : "client_id");
 
+        /// Same heuristic as AzureBlobStorage::isConnectionString: a URL starts with http.
+        if (!connection_url.empty() && !connection_url.starts_with("http") && !connection_url.starts_with("abfss"))
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Azure workload identity cannot be used with a connection_string; pass storage_account_url instead");
+
         connection_params.endpoint.storage_account_url = connection_url;
         connection_params.endpoint.container_name = container_name;
         Azure::Identity::WorkloadIdentityCredentialOptions options;

--- a/src/Storages/ObjectStorage/Azure/Configuration.cpp
+++ b/src/Storages/ObjectStorage/Azure/Configuration.cpp
@@ -130,6 +130,8 @@ AzureBlobStorage::ConnectionParams getAzureConnectionParams(
         options.ClientId = *client_id;
         options.TenantId = *tenant_id;
         connection_params.auth_method = std::make_shared<Azure::Identity::WorkloadIdentityCredential>(options);
+        connection_params.workload_identity_client_id = *client_id;
+        connection_params.workload_identity_tenant_id = *tenant_id;
     }
 
     if (account_name || account_key)

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -385,8 +385,7 @@ std::vector<std::pair<std::string, std::string>> getAzureBuilderOptions(
     /// private endpoints). The builder still requires the storage account name, so
     /// hosts that do not encode it in the first label (custom domains) only work when
     /// endpoint.account_name is set, which the credential-based SQL paths cannot do
-    /// yet. For a parsed connection string, azure_endpoint is already set above and
-    /// storage_account_url holds the connection string, not a URL.
+    /// yet.
     if (endpoint.storage_account_url.starts_with("http://"))
     {
         set_option("azure_endpoint", connection_params.getConnectionURL());

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -337,8 +337,15 @@ std::vector<std::pair<std::string, std::string>> getAzureBuilderOptions(
                 if (const char * value = std::getenv(env_var); value && *value) // NOLINT(concurrency-mt-unsafe)
                     set_option(option, value);
             };
-            set_option_from_env("azure_tenant_id", "AZURE_TENANT_ID");
-            set_option_from_env("azure_client_id", "AZURE_CLIENT_ID");
+            /// Explicit IDs (extra_credentials / named collection) win over the environment.
+            if (!connection_params.workload_identity_tenant_id.empty())
+                set_option("azure_tenant_id", connection_params.workload_identity_tenant_id);
+            else
+                set_option_from_env("azure_tenant_id", "AZURE_TENANT_ID");
+            if (!connection_params.workload_identity_client_id.empty())
+                set_option("azure_client_id", connection_params.workload_identity_client_id);
+            else
+                set_option_from_env("azure_client_id", "AZURE_CLIENT_ID");
             set_option_from_env("azure_federated_token_file", "AZURE_FEDERATED_TOKEN_FILE");
             set_option_from_env("azure_authority_host", "AZURE_AUTHORITY_HOST");
             break;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -10,6 +10,8 @@
 #include <Common/isValidUTF8.h>
 #include <Common/logger_useful.h>
 
+#include <cstdlib>
+
 #if USE_AZURE_BLOB_STORAGE
 #include <Storages/ObjectStorage/Azure/Configuration.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.h>
@@ -323,8 +325,25 @@ std::vector<std::pair<std::string, std::string>> getAzureBuilderOptions(
                 set_option("azure_storage_account_key", connection_params.endpoint.account_key);
             break;
         }
-        case 1: /// ClientSecretCredential
         case 3: /// WorkloadIdentityCredential
+        {
+            const auto & name = endpoint.account_name.empty() ? get_account_name() : endpoint.account_name;
+            if (!name.empty())
+                set_option("azure_storage_account_name", name);
+
+            /// The object_store builder does not read the workload identity environment variables on its own.
+            auto set_option_from_env = [&](const std::string & option, const char * env_var)
+            {
+                if (const char * value = std::getenv(env_var); value && *value) // NOLINT(concurrency-mt-unsafe)
+                    set_option(option, value);
+            };
+            set_option_from_env("azure_tenant_id", "AZURE_TENANT_ID");
+            set_option_from_env("azure_client_id", "AZURE_CLIENT_ID");
+            set_option_from_env("azure_federated_token_file", "AZURE_FEDERATED_TOKEN_FILE");
+            set_option_from_env("azure_authority_host", "AZURE_AUTHORITY_HOST");
+            break;
+        }
+        case 1: /// ClientSecretCredential
         case 5: /// StaticCredential
         case 6: /// TokenProviderCredential
         default:

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -362,13 +362,30 @@ std::vector<std::pair<std::string, std::string>> getAzureBuilderOptions(
     if (!endpoint.sas_auth.empty())
         set_option("azure_storage_sas_key", endpoint.sas_auth);
 
-    /// For non-standard endpoints (e.g., Azurite emulator), set the endpoint explicitly.
-    /// Also allow plain HTTP connections when the endpoint uses http://, since the object-store
-    /// Azure builder defaults to https_only=true and would reject plain HTTP requests.
-    if (!endpoint.storage_account_url.empty() && endpoint.storage_account_url.starts_with("http://"))
+    /// The builder derives <account>.blob.core.windows.net from the account name.
+    auto is_default_azure_host = [](const std::string & url)
+    {
+        auto scheme_end = url.find("://");
+        if (scheme_end == std::string::npos)
+            return false;
+        auto host_start = scheme_end + 3;
+        auto host_end = url.find_first_of(":/", host_start);
+        std::string_view host(url.data() + host_start, (host_end == std::string::npos ? url.size() : host_end) - host_start);
+        return host.ends_with(".blob.core.windows.net");
+    };
+
+    /// Non-default endpoints must be set explicitly: plain HTTP (Azurite; the builder
+    /// defaults to https_only=true) and non-default HTTPS hosts (sovereign clouds,
+    /// custom domains). For a parsed connection string, azure_endpoint is already set
+    /// above and storage_account_url holds the connection string, not a URL.
+    if (endpoint.storage_account_url.starts_with("http://"))
     {
         set_option("azure_endpoint", connection_params.getConnectionURL());
         set_option("azure_allow_http", "true");
+    }
+    else if (endpoint.storage_account_url.starts_with("https://") && !is_default_azure_host(endpoint.storage_account_url))
+    {
+        set_option("azure_endpoint", connection_params.getConnectionURL());
     }
 
     return options;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -375,9 +375,12 @@ std::vector<std::pair<std::string, std::string>> getAzureBuilderOptions(
     };
 
     /// Non-default endpoints must be set explicitly: plain HTTP (Azurite; the builder
-    /// defaults to https_only=true) and non-default HTTPS hosts (sovereign clouds,
-    /// custom domains). For a parsed connection string, azure_endpoint is already set
-    /// above and storage_account_url holds the connection string, not a URL.
+    /// defaults to https_only=true) and non-default HTTPS hosts (sovereign clouds).
+    /// The builder still requires the storage account name, so hosts that do not encode
+    /// it in the first label (custom domains) only work when endpoint.account_name is
+    /// set, which the credential-based SQL paths cannot do yet. For a parsed connection
+    /// string, azure_endpoint is already set above and storage_account_url holds the
+    /// connection string, not a URL.
     if (endpoint.storage_account_url.starts_with("http://"))
     {
         set_option("azure_endpoint", connection_params.getConnectionURL());

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -332,22 +332,34 @@ std::vector<std::pair<std::string, std::string>> getAzureBuilderOptions(
                 set_option("azure_storage_account_name", name);
 
             /// The object_store builder does not read the workload identity environment variables on its own.
-            auto set_option_from_env = [&](const std::string & option, const char * env_var)
+            auto env_value = [](const char * env_var) -> const char *
             {
                 if (const char * value = std::getenv(env_var); value && *value) // NOLINT(concurrency-mt-unsafe)
-                    set_option(option, value);
+                    return value;
+                return nullptr;
             };
+
             /// Explicit IDs (extra_credentials / named collection) win over the environment.
-            if (!connection_params.workload_identity_tenant_id.empty())
-                set_option("azure_tenant_id", connection_params.workload_identity_tenant_id);
-            else
-                set_option_from_env("azure_tenant_id", "AZURE_TENANT_ID");
-            if (!connection_params.workload_identity_client_id.empty())
-                set_option("azure_client_id", connection_params.workload_identity_client_id);
-            else
-                set_option_from_env("azure_client_id", "AZURE_CLIENT_ID");
-            set_option_from_env("azure_federated_token_file", "AZURE_FEDERATED_TOKEN_FILE");
-            set_option_from_env("azure_authority_host", "AZURE_AUTHORITY_HOST");
+            const char * tenant = !connection_params.workload_identity_tenant_id.empty()
+                ? connection_params.workload_identity_tenant_id.c_str()
+                : env_value("AZURE_TENANT_ID");
+            const char * client = !connection_params.workload_identity_client_id.empty()
+                ? connection_params.workload_identity_client_id.c_str()
+                : env_value("AZURE_CLIENT_ID");
+            const char * token_file = env_value("AZURE_FEDERATED_TOKEN_FILE");
+
+            if (!tenant || !client || !token_file)
+                throw DB::Exception(
+                    DB::ErrorCodes::NOT_IMPLEMENTED,
+                    "Azure workload identity is not configured for the delta-kernel path: "
+                    "AZURE_TENANT_ID, AZURE_CLIENT_ID and AZURE_FEDERATED_TOKEN_FILE must be set "
+                    "(tenant/client id may instead be passed via extra_credentials)");
+
+            set_option("azure_tenant_id", tenant);
+            set_option("azure_client_id", client);
+            set_option("azure_federated_token_file", token_file);
+            if (const char * authority = env_value("AZURE_AUTHORITY_HOST"))
+                set_option("azure_authority_host", authority);
             break;
         }
         case 1: /// ClientSecretCredential
@@ -362,31 +374,25 @@ std::vector<std::pair<std::string, std::string>> getAzureBuilderOptions(
     if (!endpoint.sas_auth.empty())
         set_option("azure_storage_sas_key", endpoint.sas_auth);
 
-    /// The builder derives <account>.blob.core.windows.net from the account name.
-    auto is_default_azure_host = [](const std::string & url)
-    {
-        auto scheme_end = url.find("://");
-        if (scheme_end == std::string::npos)
-            return false;
-        auto host_start = scheme_end + 3;
-        auto host_end = url.find_first_of(":/", host_start);
-        std::string_view host(url.data() + host_start, (host_end == std::string::npos ? url.size() : host_end) - host_start);
-        return host.ends_with(".blob.core.windows.net");
-    };
+    /// The builder derives exactly this URL from the account name; anything else must be explicit.
+    /// Value, not a reference: get_account_name() returns a temporary.
+    const std::string account_for_endpoint = endpoint.account_name.empty() ? get_account_name() : endpoint.account_name;
+    const bool endpoint_is_derivable = !account_for_endpoint.empty()
+        && endpoint.storage_account_url == "https://" + account_for_endpoint + ".blob.core.windows.net";
 
     /// Non-default endpoints must be set explicitly: plain HTTP (Azurite; the builder
-    /// defaults to https_only=true) and non-default HTTPS hosts (sovereign clouds).
-    /// The builder still requires the storage account name, so hosts that do not encode
-    /// it in the first label (custom domains) only work when endpoint.account_name is
-    /// set, which the credential-based SQL paths cannot do yet. For a parsed connection
-    /// string, azure_endpoint is already set above and storage_account_url holds the
-    /// connection string, not a URL.
+    /// defaults to https_only=true) and non-default HTTPS hosts (sovereign clouds,
+    /// private endpoints). The builder still requires the storage account name, so
+    /// hosts that do not encode it in the first label (custom domains) only work when
+    /// endpoint.account_name is set, which the credential-based SQL paths cannot do
+    /// yet. For a parsed connection string, azure_endpoint is already set above and
+    /// storage_account_url holds the connection string, not a URL.
     if (endpoint.storage_account_url.starts_with("http://"))
     {
         set_option("azure_endpoint", connection_params.getConnectionURL());
         set_option("azure_allow_http", "true");
     }
-    else if (endpoint.storage_account_url.starts_with("https://") && !is_default_azure_host(endpoint.storage_account_url))
+    else if (endpoint.storage_account_url.starts_with("https://") && !endpoint_is_derivable)
     {
         set_option("azure_endpoint", connection_params.getConnectionURL());
     }

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -2321,8 +2321,13 @@ ENGINE = DeltaLake(gcs_creds, url = 'https://storage.googleapis.com/<bucket>/<pa
 **Syntax**
 
 ```sql
+-- Account key
 CREATE TABLE table_name
-ENGINE = DeltaLake(connection_string|storage_account_url, container_name, blobpath, [account_name, account_key, format, compression, extra_credentials(client_id=, tenant_id=)])
+ENGINE = DeltaLake(connection_string|storage_account_url, container_name, blobpath, [account_name, account_key, format, compression])
+
+-- Workload identity (mutually exclusive with account_name / account_key)
+CREATE TABLE table_name
+ENGINE = DeltaLake(storage_account_url, container_name, blobpath, extra_credentials(client_id=, tenant_id=) [, format, compression])
 ```
 
 **Arguments**
@@ -2333,7 +2338,7 @@ ENGINE = DeltaLake(connection_string|storage_account_url, container_name, blobpa
 - `blobpath` — Path to the Delta Lake table within the container
 - `account_name` — Azure storage account name
 - `account_key` — Azure storage account key
-- `extra_credentials` — Optional. Use `client_id` and `tenant_id` for Azure workload identity authentication. Takes priority over `account_name` and `account_key`. This is not the S3 `role_arn` form of `extra_credentials`.
+- `extra_credentials` — Optional alternative to `account_name` / `account_key`. Use `client_id` and `tenant_id` for Azure workload identity authentication. Cannot be combined with account credentials. This is not the S3 `role_arn` form of `extra_credentials`.
 
 Engine parameters can be specified using [Named Collections](/operations/named-collections.md). Named collections accept the same `client_id` and `tenant_id` keys.
 
@@ -2463,7 +2468,7 @@ The `DeltaLake` table engine and table function support data caching, the same a
         },
         Documentation{
             .description = "Provides a read-only integration with existing Delta Lake tables stored in Microsoft Azure Blob Storage.",
-            .syntax = "ENGINE = DeltaLakeAzure(connection_string | storage_account_url, container_name, blobpath [, extra_credentials(client_id=, tenant_id=)])",
+            .syntax = "ENGINE = DeltaLakeAzure(connection_string | storage_account_url, container_name, blobpath) | ENGINE = DeltaLakeAzure(storage_account_url, container_name, blobpath, extra_credentials(client_id=, tenant_id=))",
             .related = {"DeltaLake"}});
 #    endif
     factory.registerStorage(

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -169,7 +169,7 @@ CREATE TABLE azure_blob_storage_table (name String, value UInt32)
 - `compression` — Supported values: `none`, `gzip/gz`, `brotli/br`, `xz/LZMA`, `zstd/zst`. By default, it will autodetect compression by file extension. (same as setting to `auto`).
 - `partition_strategy` – Options: `wildcard` or `hive`. `wildcard` requires a `{_partition_id}` in the path, which is replaced with the partition key. `hive` does not allow wildcards, assumes the path is the table root, and generates Hive-style partitioned directories with Snowflake IDs as filenames and the file format as the extension. Without an explicit strategy, a path with `{_partition_id}` uses `wildcard`. A path with another glob uses no partition strategy and ignores `PARTITION BY`. A path without a glob uses `hive` when `file_like_engine_default_partition_strategy` is `hive`; otherwise it uses no partition strategy.
 - `partition_columns_in_data_file` - Only used with `hive` partition strategy. Tells ClickHouse whether to expect partition columns to be written in the data file. Defaults `false`.
-- `extra_credentials` - Use `client_id` and `tenant_id` for authentication. If extra_credentials are provided, they are given priority over `account_name` and `account_key`.
+- `extra_credentials` - Use `client_id` and `tenant_id` for Azure workload identity authentication. Mutually exclusive with `account_name` / `account_key`, and requires `storage_account_url` (not `connection_string`).
 
 **Example**
 

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -2322,7 +2322,7 @@ ENGINE = DeltaLake(gcs_creds, url = 'https://storage.googleapis.com/<bucket>/<pa
 
 ```sql
 CREATE TABLE table_name
-ENGINE = DeltaLake(connection_string|storage_account_url, container_name, blobpath, [account_name, account_key, format, compression])
+ENGINE = DeltaLake(connection_string|storage_account_url, container_name, blobpath, [account_name, account_key, format, compression, extra_credentials(client_id=, tenant_id=)])
 ```
 
 **Arguments**
@@ -2333,6 +2333,29 @@ ENGINE = DeltaLake(connection_string|storage_account_url, container_name, blobpa
 - `blobpath` — Path to the Delta Lake table within the container
 - `account_name` — Azure storage account name
 - `account_key` — Azure storage account key
+- `extra_credentials` — Optional. Use `client_id` and `tenant_id` for Azure workload identity authentication. Takes priority over `account_name` and `account_key`. This is not the S3 `role_arn` form of `extra_credentials`.
+
+Engine parameters can be specified using [Named Collections](/operations/named-collections.md). Named collections accept the same `client_id` and `tenant_id` keys.
+
+**Workload identity**
+
+The delta-kernel Azure path also requires environment variables:
+
+- `AZURE_FEDERATED_TOKEN_FILE` — required (the projected token file, e.g. on AKS)
+- `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` — required unless passed via `extra_credentials` or a named collection
+- `AZURE_AUTHORITY_HOST` — optional
+
+```sql
+CREATE NAMED COLLECTION azure_wi AS
+    storage_account_url = 'https://account.blob.core.windows.net',
+    container = 'mycontainer',
+    blob_path = 'path/to/table',
+    client_id = '<client-id>',
+    tenant_id = '<tenant-id>';
+
+CREATE TABLE azureDeltaLake
+ENGINE = DeltaLake(azure_wi)
+```
 
 </TabItem>
 </Tabs>
@@ -2440,7 +2463,7 @@ The `DeltaLake` table engine and table function support data caching, the same a
         },
         Documentation{
             .description = "Provides a read-only integration with existing Delta Lake tables stored in Microsoft Azure Blob Storage.",
-            .syntax = "ENGINE = DeltaLakeAzure(connection_string | storage_account_url, container_name, blobpath)",
+            .syntax = "ENGINE = DeltaLakeAzure(connection_string | storage_account_url, container_name, blobpath [, extra_credentials(client_id=, tenant_id=)])",
             .related = {"DeltaLake"}});
 #    endif
     factory.registerStorage(

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -150,8 +150,15 @@ This engine provides an integration with [Azure Blob Storage](https://azure.micr
 ## Create table {#create-table}
 
 ```sql
+-- Account key
 CREATE TABLE azure_blob_storage_table (name String, value UInt32)
-    ENGINE = AzureBlobStorage(connection_string|storage_account_url, container_name, blobpath, [account_name, account_key, format, compression, partition_strategy, partition_columns_in_data_file, extra_credentials(client_id=, tenant_id=)])
+    ENGINE = AzureBlobStorage(connection_string|storage_account_url, container_name, blobpath, [account_name, account_key, format, compression, partition_strategy, partition_columns_in_data_file])
+    [PARTITION BY expr]
+    [SETTINGS ...]
+
+-- Workload identity (mutually exclusive with account_name / account_key)
+CREATE TABLE azure_blob_storage_table (name String, value UInt32)
+    ENGINE = AzureBlobStorage(storage_account_url, container_name, blobpath, extra_credentials(client_id=, tenant_id=) [, format, compression, partition_strategy, partition_columns_in_data_file])
     [PARTITION BY expr]
     [SETTINGS ...]
 ```

--- a/src/Storages/tests/gtest_azure_configuration.cpp
+++ b/src/Storages/tests/gtest_azure_configuration.cpp
@@ -178,6 +178,32 @@ TEST(StorageAzureConfiguration, FromNamedCollectionWithExtraCredentialsAndAccoun
     ASSERT_THROW_ERROR_CODE(conf.fromNamedCollection(*collection, Context::getGlobalContextInstance()), Exception, ErrorCodes::BAD_ARGUMENTS, "Choose only one");
 }
 
+TEST(StorageAzureConfiguration, FromNamedCollectionWithConnectionStringAndExtraCredentials)
+{
+    std::string xml(R"CONFIG(<clickhouse>
+    <named_collections>
+        <FromNamedCollectionWithConnectionStringAndExtraCredentials>
+            <container>test_container</container>
+            <blob_path>test_blob.csv</blob_path>
+            <connection_string>DefaultEndpointsProtocol=https;AccountName=testaccount;AccountKey=dGVzdGtleQ==;EndpointSuffix=core.windows.net</connection_string>
+            <client_id>test_client_id</client_id>
+            <tenant_id>test_tenant_id</tenant_id>
+        </FromNamedCollectionWithConnectionStringAndExtraCredentials>
+    </named_collections>
+    </clickhouse>)CONFIG");
+
+    loadNamedCollectionConfig(xml);
+
+    StorageAzureConfigurationFriend conf;
+    auto collection = NamedCollectionFactoryFriend::instance().get("FromNamedCollectionWithConnectionStringAndExtraCredentials");
+
+    ASSERT_THROW_ERROR_CODE(
+        conf.fromNamedCollection(*collection, Context::getGlobalContextInstance()),
+        Exception,
+        ErrorCodes::BAD_ARGUMENTS,
+        "connection_string");
+}
+
 TEST(StorageAzureConfiguration, FromNamedCollectionWithPartialExtraCredentials)
 {
     std::string xml(R"CONFIG(<clickhouse>

--- a/src/Storages/tests/gtest_delta_kernel.cpp
+++ b/src/Storages/tests/gtest_delta_kernel.cpp
@@ -111,7 +111,9 @@ TEST(DeltaLakeMetadata, GetSimpleTypeByNameChar)
 
 #include <Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.h>
+#include <azure/identity/workload_identity_credential.hpp>
 
+#include <cstdlib>
 #include <optional>
 
 namespace
@@ -174,6 +176,47 @@ TEST(DeltaLakeAzureKernelHelper, ConnectionStringSetsAccountName)
     const auto key = findBuilderOption(options, "azure_storage_account_key");
     ASSERT_TRUE(key.has_value());
     ASSERT_EQ(*key, "dGVzdGtleQ==");
+}
+
+/// Workload identity credentials must be forwarded as builder options because
+/// object_store does not read the environment on its own.
+TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityForwardsEnvironment)
+{
+    setenv("AZURE_TENANT_ID", "11111111-1111-1111-1111-111111111111", 1); // NOLINT(concurrency-mt-unsafe)
+    setenv("AZURE_CLIENT_ID", "22222222-2222-2222-2222-222222222222", 1); // NOLINT(concurrency-mt-unsafe)
+    setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token", 1); // NOLINT(concurrency-mt-unsafe)
+    unsetenv("AZURE_AUTHORITY_HOST"); // NOLINT(concurrency-mt-unsafe)
+    SCOPE_EXIT({
+        unsetenv("AZURE_TENANT_ID"); // NOLINT(concurrency-mt-unsafe)
+        unsetenv("AZURE_CLIENT_ID"); // NOLINT(concurrency-mt-unsafe)
+        unsetenv("AZURE_FEDERATED_TOKEN_FILE"); // NOLINT(concurrency-mt-unsafe)
+    });
+
+    DB::AzureBlobStorage::ConnectionParams params;
+    params.endpoint.storage_account_url = "https://testaccount.blob.core.windows.net";
+    params.endpoint.container_name = "testcontainer";
+    params.auth_method = std::make_shared<Azure::Identity::WorkloadIdentityCredential>();
+    ASSERT_EQ(params.auth_method.index(), 3u);
+
+    const auto options = DeltaLake::getAzureBuilderOptions(params);
+
+    const auto account = findBuilderOption(options, "azure_storage_account_name");
+    ASSERT_TRUE(account.has_value());
+    ASSERT_EQ(*account, "testaccount");
+
+    const auto tenant = findBuilderOption(options, "azure_tenant_id");
+    ASSERT_TRUE(tenant.has_value());
+    ASSERT_EQ(*tenant, "11111111-1111-1111-1111-111111111111");
+
+    const auto client = findBuilderOption(options, "azure_client_id");
+    ASSERT_TRUE(client.has_value());
+    ASSERT_EQ(*client, "22222222-2222-2222-2222-222222222222");
+
+    const auto token_file = findBuilderOption(options, "azure_federated_token_file");
+    ASSERT_TRUE(token_file.has_value());
+    ASSERT_EQ(*token_file, "/var/run/secrets/azure/tokens/azure-identity-token");
+
+    ASSERT_FALSE(findBuilderOption(options, "azure_authority_host").has_value());
 }
 
 #endif

--- a/src/Storages/tests/gtest_delta_kernel.cpp
+++ b/src/Storages/tests/gtest_delta_kernel.cpp
@@ -127,6 +127,39 @@ std::optional<std::string> findBuilderOption(
             return v;
     return std::nullopt;
 }
+
+/// Snapshot and restore process-global AZURE_* env vars so tests do not wipe
+/// values that were already set in the environment.
+class ScopedEnv
+{
+public:
+    ScopedEnv(const char * name_, const char * value)
+        : name(name_)
+    {
+        if (const char * previous_value = std::getenv(name)) // NOLINT(concurrency-mt-unsafe)
+            previous = previous_value;
+
+        if (value)
+            setenv(name, value, 1); // NOLINT(concurrency-mt-unsafe)
+        else
+            unsetenv(name); // NOLINT(concurrency-mt-unsafe)
+    }
+
+    ~ScopedEnv()
+    {
+        if (previous)
+            setenv(name, previous->c_str(), 1); // NOLINT(concurrency-mt-unsafe)
+        else
+            unsetenv(name); // NOLINT(concurrency-mt-unsafe)
+    }
+
+    ScopedEnv(const ScopedEnv &) = delete;
+    ScopedEnv & operator=(const ScopedEnv &) = delete;
+
+private:
+    const char * name;
+    std::optional<std::string> previous;
+};
 }
 
 /// Empty connection string
@@ -183,15 +216,10 @@ TEST(DeltaLakeAzureKernelHelper, ConnectionStringSetsAccountName)
 /// object_store does not read the environment on its own.
 TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityForwardsEnvironment)
 {
-    setenv("AZURE_TENANT_ID", "11111111-1111-1111-1111-111111111111", 1); // NOLINT(concurrency-mt-unsafe)
-    setenv("AZURE_CLIENT_ID", "22222222-2222-2222-2222-222222222222", 1); // NOLINT(concurrency-mt-unsafe)
-    setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token", 1); // NOLINT(concurrency-mt-unsafe)
-    unsetenv("AZURE_AUTHORITY_HOST"); // NOLINT(concurrency-mt-unsafe)
-    SCOPE_EXIT({
-        unsetenv("AZURE_TENANT_ID"); // NOLINT(concurrency-mt-unsafe)
-        unsetenv("AZURE_CLIENT_ID"); // NOLINT(concurrency-mt-unsafe)
-        unsetenv("AZURE_FEDERATED_TOKEN_FILE"); // NOLINT(concurrency-mt-unsafe)
-    });
+    ScopedEnv env_tenant("AZURE_TENANT_ID", "11111111-1111-1111-1111-111111111111");
+    ScopedEnv env_client("AZURE_CLIENT_ID", "22222222-2222-2222-2222-222222222222");
+    ScopedEnv env_token_file("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token");
+    ScopedEnv env_authority("AZURE_AUTHORITY_HOST", nullptr);
 
     DB::AzureBlobStorage::ConnectionParams params;
     params.endpoint.storage_account_url = "https://testaccount.blob.core.windows.net";
@@ -227,14 +255,9 @@ TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityForwardsEnvironment)
 /// azure_endpoint, or the builder falls back to the default public host.
 TEST(DeltaLakeAzureKernelHelper, WorkloadIdentitySetsEndpointForNonDefaultHost)
 {
-    setenv("AZURE_TENANT_ID", "11111111-1111-1111-1111-111111111111", 1); // NOLINT(concurrency-mt-unsafe)
-    setenv("AZURE_CLIENT_ID", "22222222-2222-2222-2222-222222222222", 1); // NOLINT(concurrency-mt-unsafe)
-    setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token", 1); // NOLINT(concurrency-mt-unsafe)
-    SCOPE_EXIT({
-        unsetenv("AZURE_TENANT_ID"); // NOLINT(concurrency-mt-unsafe)
-        unsetenv("AZURE_CLIENT_ID"); // NOLINT(concurrency-mt-unsafe)
-        unsetenv("AZURE_FEDERATED_TOKEN_FILE"); // NOLINT(concurrency-mt-unsafe)
-    });
+    ScopedEnv env_tenant("AZURE_TENANT_ID", "11111111-1111-1111-1111-111111111111");
+    ScopedEnv env_client("AZURE_CLIENT_ID", "22222222-2222-2222-2222-222222222222");
+    ScopedEnv env_token_file("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token");
 
     DB::AzureBlobStorage::ConnectionParams params;
     params.endpoint.storage_account_url = "https://testaccount.blob.core.usgovcloudapi.net";
@@ -257,13 +280,9 @@ TEST(DeltaLakeAzureKernelHelper, WorkloadIdentitySetsEndpointForNonDefaultHost)
 /// the IDs on ConnectionParams, not just the builder plumbing.
 TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityForwardsExplicitIds)
 {
-    unsetenv("AZURE_TENANT_ID"); // NOLINT(concurrency-mt-unsafe)
-    setenv("AZURE_CLIENT_ID", "99999999-9999-9999-9999-999999999999", 1); // NOLINT(concurrency-mt-unsafe)
-    setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token", 1); // NOLINT(concurrency-mt-unsafe)
-    SCOPE_EXIT({
-        unsetenv("AZURE_CLIENT_ID"); // NOLINT(concurrency-mt-unsafe)
-        unsetenv("AZURE_FEDERATED_TOKEN_FILE"); // NOLINT(concurrency-mt-unsafe)
-    });
+    ScopedEnv env_tenant("AZURE_TENANT_ID", nullptr);
+    ScopedEnv env_client("AZURE_CLIENT_ID", "99999999-9999-9999-9999-999999999999");
+    ScopedEnv env_token_file("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token");
 
     const auto params = DB::getAzureConnectionParams(
         "https://testaccount.blob.core.windows.net",
@@ -295,10 +314,10 @@ TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityForwardsExplicitIds)
 /// Missing tenant / client / token-file must fail here, not later inside object_store.
 TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityRequiresConfiguration)
 {
-    unsetenv("AZURE_TENANT_ID"); // NOLINT(concurrency-mt-unsafe)
-    unsetenv("AZURE_CLIENT_ID"); // NOLINT(concurrency-mt-unsafe)
-    unsetenv("AZURE_FEDERATED_TOKEN_FILE"); // NOLINT(concurrency-mt-unsafe)
-    unsetenv("AZURE_AUTHORITY_HOST"); // NOLINT(concurrency-mt-unsafe)
+    ScopedEnv env_tenant("AZURE_TENANT_ID", nullptr);
+    ScopedEnv env_client("AZURE_CLIENT_ID", nullptr);
+    ScopedEnv env_token_file("AZURE_FEDERATED_TOKEN_FILE", nullptr);
+    ScopedEnv env_authority("AZURE_AUTHORITY_HOST", nullptr);
 
     DB::AzureBlobStorage::ConnectionParams params;
     params.endpoint.storage_account_url = "https://testaccount.blob.core.windows.net";
@@ -321,9 +340,9 @@ TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityRequiresConfiguration)
 /// extra_credentials can supply tenant/client, but the projected token file is still required.
 TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityRequiresTokenFileWithExplicitIds)
 {
-    unsetenv("AZURE_TENANT_ID"); // NOLINT(concurrency-mt-unsafe)
-    unsetenv("AZURE_CLIENT_ID"); // NOLINT(concurrency-mt-unsafe)
-    unsetenv("AZURE_FEDERATED_TOKEN_FILE"); // NOLINT(concurrency-mt-unsafe)
+    ScopedEnv env_tenant("AZURE_TENANT_ID", nullptr);
+    ScopedEnv env_client("AZURE_CLIENT_ID", nullptr);
+    ScopedEnv env_token_file("AZURE_FEDERATED_TOKEN_FILE", nullptr);
 
     const auto params = DB::getAzureConnectionParams(
         "https://testaccount.blob.core.windows.net",
@@ -351,14 +370,9 @@ TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityRequiresTokenFileWithExplicitId
 /// derives from the account name, so azure_endpoint must still be forwarded.
 TEST(DeltaLakeAzureKernelHelper, WorkloadIdentitySetsEndpointForPrivateLinkHost)
 {
-    setenv("AZURE_TENANT_ID", "11111111-1111-1111-1111-111111111111", 1); // NOLINT(concurrency-mt-unsafe)
-    setenv("AZURE_CLIENT_ID", "22222222-2222-2222-2222-222222222222", 1); // NOLINT(concurrency-mt-unsafe)
-    setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token", 1); // NOLINT(concurrency-mt-unsafe)
-    SCOPE_EXIT({
-        unsetenv("AZURE_TENANT_ID"); // NOLINT(concurrency-mt-unsafe)
-        unsetenv("AZURE_CLIENT_ID"); // NOLINT(concurrency-mt-unsafe)
-        unsetenv("AZURE_FEDERATED_TOKEN_FILE"); // NOLINT(concurrency-mt-unsafe)
-    });
+    ScopedEnv env_tenant("AZURE_TENANT_ID", "11111111-1111-1111-1111-111111111111");
+    ScopedEnv env_client("AZURE_CLIENT_ID", "22222222-2222-2222-2222-222222222222");
+    ScopedEnv env_token_file("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token");
 
     DB::AzureBlobStorage::ConnectionParams params;
     params.endpoint.storage_account_url = "https://testaccount.privatelink.blob.core.windows.net";

--- a/src/Storages/tests/gtest_delta_kernel.cpp
+++ b/src/Storages/tests/gtest_delta_kernel.cpp
@@ -218,6 +218,37 @@ TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityForwardsEnvironment)
     ASSERT_EQ(*token_file, "/var/run/secrets/azure/tokens/azure-identity-token");
 
     ASSERT_FALSE(findBuilderOption(options, "azure_authority_host").has_value());
+
+    /// Default host: the builder derives the endpoint from the account name.
+    ASSERT_FALSE(findBuilderOption(options, "azure_endpoint").has_value());
+}
+
+/// Non-default HTTPS hosts (sovereign clouds, custom domains) must be forwarded as
+/// azure_endpoint, or the builder falls back to the default public host.
+TEST(DeltaLakeAzureKernelHelper, WorkloadIdentitySetsEndpointForNonDefaultHost)
+{
+    setenv("AZURE_TENANT_ID", "11111111-1111-1111-1111-111111111111", 1); // NOLINT(concurrency-mt-unsafe)
+    setenv("AZURE_CLIENT_ID", "22222222-2222-2222-2222-222222222222", 1); // NOLINT(concurrency-mt-unsafe)
+    setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token", 1); // NOLINT(concurrency-mt-unsafe)
+    SCOPE_EXIT({
+        unsetenv("AZURE_TENANT_ID"); // NOLINT(concurrency-mt-unsafe)
+        unsetenv("AZURE_CLIENT_ID"); // NOLINT(concurrency-mt-unsafe)
+        unsetenv("AZURE_FEDERATED_TOKEN_FILE"); // NOLINT(concurrency-mt-unsafe)
+    });
+
+    DB::AzureBlobStorage::ConnectionParams params;
+    params.endpoint.storage_account_url = "https://testaccount.blob.core.usgovcloudapi.net";
+    params.endpoint.container_name = "testcontainer";
+    params.auth_method = std::make_shared<Azure::Identity::WorkloadIdentityCredential>();
+    ASSERT_EQ(params.auth_method.index(), 3u);
+
+    const auto options = DeltaLake::getAzureBuilderOptions(params);
+
+    const auto azure_endpoint = findBuilderOption(options, "azure_endpoint");
+    ASSERT_TRUE(azure_endpoint.has_value());
+    ASSERT_EQ(*azure_endpoint, "https://testaccount.blob.core.usgovcloudapi.net");
+
+    ASSERT_FALSE(findBuilderOption(options, "azure_allow_http").has_value());
 }
 
 /// Explicit client_id / tenant_id (extra_credentials, named collections) must be

--- a/src/Storages/tests/gtest_delta_kernel.cpp
+++ b/src/Storages/tests/gtest_delta_kernel.cpp
@@ -219,4 +219,44 @@ TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityForwardsEnvironment)
     ASSERT_FALSE(findBuilderOption(options, "azure_authority_host").has_value());
 }
 
+/// Explicit client_id / tenant_id (extra_credentials, named collections) must be
+/// forwarded even when the environment variables are absent, and win over them.
+TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityForwardsExplicitIds)
+{
+    unsetenv("AZURE_TENANT_ID"); // NOLINT(concurrency-mt-unsafe)
+    setenv("AZURE_CLIENT_ID", "99999999-9999-9999-9999-999999999999", 1); // NOLINT(concurrency-mt-unsafe)
+    setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token", 1); // NOLINT(concurrency-mt-unsafe)
+    SCOPE_EXIT({
+        unsetenv("AZURE_CLIENT_ID"); // NOLINT(concurrency-mt-unsafe)
+        unsetenv("AZURE_FEDERATED_TOKEN_FILE"); // NOLINT(concurrency-mt-unsafe)
+    });
+
+    DB::AzureBlobStorage::ConnectionParams params;
+    params.endpoint.storage_account_url = "https://testaccount.blob.core.windows.net";
+    params.endpoint.container_name = "testcontainer";
+    Azure::Identity::WorkloadIdentityCredentialOptions credential_options;
+    credential_options.ClientId = "22222222-2222-2222-2222-222222222222";
+    credential_options.TenantId = "11111111-1111-1111-1111-111111111111";
+    params.auth_method = std::make_shared<Azure::Identity::WorkloadIdentityCredential>(credential_options);
+    params.workload_identity_client_id = "22222222-2222-2222-2222-222222222222";
+    params.workload_identity_tenant_id = "11111111-1111-1111-1111-111111111111";
+    ASSERT_EQ(params.auth_method.index(), 3u);
+
+    const auto options = DeltaLake::getAzureBuilderOptions(params);
+
+    /// Explicit tenant id, despite no AZURE_TENANT_ID in the environment.
+    const auto tenant = findBuilderOption(options, "azure_tenant_id");
+    ASSERT_TRUE(tenant.has_value());
+    ASSERT_EQ(*tenant, "11111111-1111-1111-1111-111111111111");
+
+    /// Explicit client id wins over the conflicting AZURE_CLIENT_ID.
+    const auto client = findBuilderOption(options, "azure_client_id");
+    ASSERT_TRUE(client.has_value());
+    ASSERT_EQ(*client, "22222222-2222-2222-2222-222222222222");
+
+    const auto token_file = findBuilderOption(options, "azure_federated_token_file");
+    ASSERT_TRUE(token_file.has_value());
+    ASSERT_EQ(*token_file, "/var/run/secrets/azure/tokens/azure-identity-token");
+}
+
 #endif

--- a/src/Storages/tests/gtest_delta_kernel.cpp
+++ b/src/Storages/tests/gtest_delta_kernel.cpp
@@ -110,6 +110,7 @@ TEST(DeltaLakeMetadata, GetSimpleTypeByNameChar)
 #if USE_DELTA_KERNEL_RS && USE_AZURE_BLOB_STORAGE
 
 #include <Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h>
+#include <Storages/ObjectStorage/Azure/Configuration.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.h>
 #include <azure/identity/workload_identity_credential.hpp>
 
@@ -221,6 +222,8 @@ TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityForwardsEnvironment)
 
 /// Explicit client_id / tenant_id (extra_credentials, named collections) must be
 /// forwarded even when the environment variables are absent, and win over them.
+/// Built through getAzureConnectionParams so the test covers the persistence of
+/// the IDs on ConnectionParams, not just the builder plumbing.
 TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityForwardsExplicitIds)
 {
     unsetenv("AZURE_TENANT_ID"); // NOLINT(concurrency-mt-unsafe)
@@ -231,15 +234,14 @@ TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityForwardsExplicitIds)
         unsetenv("AZURE_FEDERATED_TOKEN_FILE"); // NOLINT(concurrency-mt-unsafe)
     });
 
-    DB::AzureBlobStorage::ConnectionParams params;
-    params.endpoint.storage_account_url = "https://testaccount.blob.core.windows.net";
-    params.endpoint.container_name = "testcontainer";
-    Azure::Identity::WorkloadIdentityCredentialOptions credential_options;
-    credential_options.ClientId = "22222222-2222-2222-2222-222222222222";
-    credential_options.TenantId = "11111111-1111-1111-1111-111111111111";
-    params.auth_method = std::make_shared<Azure::Identity::WorkloadIdentityCredential>(credential_options);
-    params.workload_identity_client_id = "22222222-2222-2222-2222-222222222222";
-    params.workload_identity_tenant_id = "11111111-1111-1111-1111-111111111111";
+    const auto params = DB::getAzureConnectionParams(
+        "https://testaccount.blob.core.windows.net",
+        "testcontainer",
+        /*account_name*/ std::nullopt,
+        /*account_key*/ std::nullopt,
+        "22222222-2222-2222-2222-222222222222",
+        "11111111-1111-1111-1111-111111111111",
+        getContext().context);
     ASSERT_EQ(params.auth_method.index(), 3u);
 
     const auto options = DeltaLake::getAzureBuilderOptions(params);

--- a/src/Storages/tests/gtest_delta_kernel.cpp
+++ b/src/Storages/tests/gtest_delta_kernel.cpp
@@ -292,4 +292,85 @@ TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityForwardsExplicitIds)
     ASSERT_EQ(*token_file, "/var/run/secrets/azure/tokens/azure-identity-token");
 }
 
+/// Missing tenant / client / token-file must fail here, not later inside object_store.
+TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityRequiresConfiguration)
+{
+    unsetenv("AZURE_TENANT_ID"); // NOLINT(concurrency-mt-unsafe)
+    unsetenv("AZURE_CLIENT_ID"); // NOLINT(concurrency-mt-unsafe)
+    unsetenv("AZURE_FEDERATED_TOKEN_FILE"); // NOLINT(concurrency-mt-unsafe)
+    unsetenv("AZURE_AUTHORITY_HOST"); // NOLINT(concurrency-mt-unsafe)
+
+    DB::AzureBlobStorage::ConnectionParams params;
+    params.endpoint.storage_account_url = "https://testaccount.blob.core.windows.net";
+    params.endpoint.container_name = "testcontainer";
+    params.auth_method = std::make_shared<Azure::Identity::WorkloadIdentityCredential>();
+    ASSERT_EQ(params.auth_method.index(), 3u);
+
+    try
+    {
+        (void)DeltaLake::getAzureBuilderOptions(params);
+        FAIL() << "expected NOT_IMPLEMENTED when workload identity env is missing";
+    }
+    catch (const DB::Exception & e)
+    {
+        EXPECT_EQ(e.code(), DB::ErrorCodes::NOT_IMPLEMENTED);
+        EXPECT_NE(std::string(e.message()).find("AZURE_FEDERATED_TOKEN_FILE"), std::string::npos);
+    }
+}
+
+/// extra_credentials can supply tenant/client, but the projected token file is still required.
+TEST(DeltaLakeAzureKernelHelper, WorkloadIdentityRequiresTokenFileWithExplicitIds)
+{
+    unsetenv("AZURE_TENANT_ID"); // NOLINT(concurrency-mt-unsafe)
+    unsetenv("AZURE_CLIENT_ID"); // NOLINT(concurrency-mt-unsafe)
+    unsetenv("AZURE_FEDERATED_TOKEN_FILE"); // NOLINT(concurrency-mt-unsafe)
+
+    const auto params = DB::getAzureConnectionParams(
+        "https://testaccount.blob.core.windows.net",
+        "testcontainer",
+        /*account_name*/ std::nullopt,
+        /*account_key*/ std::nullopt,
+        "22222222-2222-2222-2222-222222222222",
+        "11111111-1111-1111-1111-111111111111",
+        getContext().context);
+    ASSERT_EQ(params.auth_method.index(), 3u);
+
+    try
+    {
+        (void)DeltaLake::getAzureBuilderOptions(params);
+        FAIL() << "expected NOT_IMPLEMENTED when AZURE_FEDERATED_TOKEN_FILE is missing";
+    }
+    catch (const DB::Exception & e)
+    {
+        EXPECT_EQ(e.code(), DB::ErrorCodes::NOT_IMPLEMENTED);
+        EXPECT_NE(std::string(e.message()).find("AZURE_FEDERATED_TOKEN_FILE"), std::string::npos);
+    }
+}
+
+/// Private-link hosts end with .blob.core.windows.net but are not the URL the builder
+/// derives from the account name, so azure_endpoint must still be forwarded.
+TEST(DeltaLakeAzureKernelHelper, WorkloadIdentitySetsEndpointForPrivateLinkHost)
+{
+    setenv("AZURE_TENANT_ID", "11111111-1111-1111-1111-111111111111", 1); // NOLINT(concurrency-mt-unsafe)
+    setenv("AZURE_CLIENT_ID", "22222222-2222-2222-2222-222222222222", 1); // NOLINT(concurrency-mt-unsafe)
+    setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token", 1); // NOLINT(concurrency-mt-unsafe)
+    SCOPE_EXIT({
+        unsetenv("AZURE_TENANT_ID"); // NOLINT(concurrency-mt-unsafe)
+        unsetenv("AZURE_CLIENT_ID"); // NOLINT(concurrency-mt-unsafe)
+        unsetenv("AZURE_FEDERATED_TOKEN_FILE"); // NOLINT(concurrency-mt-unsafe)
+    });
+
+    DB::AzureBlobStorage::ConnectionParams params;
+    params.endpoint.storage_account_url = "https://testaccount.privatelink.blob.core.windows.net";
+    params.endpoint.container_name = "testcontainer";
+    params.auth_method = std::make_shared<Azure::Identity::WorkloadIdentityCredential>();
+    ASSERT_EQ(params.auth_method.index(), 3u);
+
+    const auto options = DeltaLake::getAzureBuilderOptions(params);
+
+    const auto azure_endpoint = findBuilderOption(options, "azure_endpoint");
+    ASSERT_TRUE(azure_endpoint.has_value());
+    ASSERT_EQ(*azure_endpoint, "https://testaccount.privatelink.blob.core.windows.net");
+}
+
 #endif

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -2384,7 +2384,8 @@ deltaLake(url [,aws_access_key_id, aws_secret_access_key] [,format] [,structure]
 
 deltaLakeS3(url [,aws_access_key_id, aws_secret_access_key] [,format] [,structure] [,compression] [,extra_credentials])
 
-deltaLakeAzure(connection_string|storage_account_url, container_name, blobpath, [,account_name], [,account_key] [,format] [,compression_method] [,extra_credentials(client_id=, tenant_id=)])
+deltaLakeAzure(connection_string|storage_account_url, container_name, blobpath, [,account_name], [,account_key] [,format] [,compression_method])
+deltaLakeAzure(storage_account_url, container_name, blobpath, extra_credentials(client_id=, tenant_id=) [,format] [,compression_method])
 
 deltaLakeLocal(path, [,format])
 ```
@@ -2396,7 +2397,7 @@ The `format` argument stands for the format of data files in the Delta lake tabl
 
 An optional `extra_credentials` parameter can be used to pass a `role_arn` for role-based access in ClickHouse Cloud. See [Secure S3](/products/cloud/guides/data-sources/accessing-s3-data-securely) for configuration steps.
 
-For Azure (`deltaLakeAzure`), `extra_credentials` takes `client_id` and `tenant_id` for workload identity. The process must also have `AZURE_FEDERATED_TOKEN_FILE` set (`AZURE_TENANT_ID` / `AZURE_CLIENT_ID` if not passed explicitly; `AZURE_AUTHORITY_HOST` is optional).
+For Azure (`deltaLakeAzure`), `extra_credentials` takes `client_id` and `tenant_id` for workload identity and cannot be combined with `account_name` / `account_key`. The process must also have `AZURE_FEDERATED_TOKEN_FILE` set (`AZURE_TENANT_ID` / `AZURE_CLIENT_ID` if not passed explicitly; `AZURE_AUTHORITY_HOST` is optional).
 
 ## Returned value {#returned-value}
 
@@ -2489,7 +2490,8 @@ Query id: 65032944-bed6-4d45-86b3-a71205a2b659
 #if USE_AZURE_BLOB_STORAGE
     factory.registerFunction<TableFunctionDeltaLakeAzure>(
          {.description = R"(The table function can be used to read the DeltaLake table stored on Azure object store.)",
-            .syntax = "deltaLakeAzure(connection_string|storage_account_url, container_name, blobpath, [account_name, account_key, format, compression, structure])",
+            .syntax = "deltaLakeAzure(connection_string|storage_account_url, container_name, blobpath, [account_name, account_key, format, compression, structure])\n"
+                      "deltaLakeAzure(storage_account_url, container_name, blobpath, extra_credentials(client_id=, tenant_id=))",
             .category = FunctionDocumentation::Category::TableFunction},
          {.allow_readonly = false});
 #endif

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -2384,7 +2384,7 @@ deltaLake(url [,aws_access_key_id, aws_secret_access_key] [,format] [,structure]
 
 deltaLakeS3(url [,aws_access_key_id, aws_secret_access_key] [,format] [,structure] [,compression] [,extra_credentials])
 
-deltaLakeAzure(connection_string|storage_account_url, container_name, blobpath, [,account_name], [,account_key] [,format] [,compression_method])
+deltaLakeAzure(connection_string|storage_account_url, container_name, blobpath, [,account_name], [,account_key] [,format] [,compression_method] [,extra_credentials(client_id=, tenant_id=)])
 
 deltaLakeLocal(path, [,format])
 ```
@@ -2395,6 +2395,8 @@ The arguments for this table function are the same as for the `s3`, `azureBlobSt
 The `format` argument stands for the format of data files in the Delta lake table.
 
 An optional `extra_credentials` parameter can be used to pass a `role_arn` for role-based access in ClickHouse Cloud. See [Secure S3](/products/cloud/guides/data-sources/accessing-s3-data-securely) for configuration steps.
+
+For Azure (`deltaLakeAzure`), `extra_credentials` takes `client_id` and `tenant_id` for workload identity. The process must also have `AZURE_FEDERATED_TOKEN_FILE` set (`AZURE_TENANT_ID` / `AZURE_CLIENT_ID` if not passed explicitly; `AZURE_AUTHORITY_HOST` is optional).
 
 ## Returned value {#returned-value}
 

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -1057,7 +1057,7 @@ azureBlobStorage(named_collection[, option=value [,..]])
 | `structure`                      | Structure of the table. Format `'column1_name column1_type, column2_name column2_type, ...'`.                                                                                                                                                                                                                                                             |
 | `partition_strategy`             | Optional. Supported values: `WILDCARD` or `HIVE`. `WILDCARD` requires a `{_partition_id}` in the path, which is replaced with the partition key. `HIVE` does not allow wildcards, assumes the path is the table root, and generates Hive-style partitioned directories with Snowflake IDs as filenames and the file format as the extension. Without an explicit strategy, a path with `{_partition_id}` uses `WILDCARD`. A path with another glob uses no partition strategy and ignores `PARTITION BY`. A path without a glob uses `HIVE` when `file_like_engine_default_partition_strategy` is `HIVE`; otherwise it uses no partition strategy. |
 | `partition_columns_in_data_file` | Optional. Only used with `HIVE` partition strategy. Tells ClickHouse whether to expect partition columns to be written in the data file. Defaults `false`.                                                                                                                                                                                                 |
-| `extra_credentials`              | Use `client_id` and `tenant_id` for authentication. If extra_credentials are provided, they are given priority over `account_name` and `account_key`.                                                                                                                                                                                                     |
+| `extra_credentials`              | Use `client_id` and `tenant_id` for Azure workload identity authentication. Mutually exclusive with `account_name` / `account_key`, and requires `storage_account_url` (not `connection_string`).                                                                                                                                                          |
 
 ## Named Collections {#named-collections}
 
@@ -2491,7 +2491,7 @@ Query id: 65032944-bed6-4d45-86b3-a71205a2b659
     factory.registerFunction<TableFunctionDeltaLakeAzure>(
          {.description = R"(The table function can be used to read the DeltaLake table stored on Azure object store.)",
             .syntax = "deltaLakeAzure(connection_string|storage_account_url, container_name, blobpath, [account_name, account_key, format, compression, structure])\n"
-                      "deltaLakeAzure(storage_account_url, container_name, blobpath, extra_credentials(client_id=, tenant_id=))",
+                      "deltaLakeAzure(storage_account_url, container_name, blobpath, extra_credentials(client_id=, tenant_id=) [,format] [,compression] [,structure])",
             .category = FunctionDocumentation::Category::TableFunction},
          {.allow_readonly = false});
 #endif

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -1031,6 +1031,15 @@ azureBlobStorage(storage_account_url, container_name, blobpath, account_name, ac
 ```
 
 </Tab>
+<Tab title="Workload identity">
+
+Uses Azure workload identity via `extra_credentials`; mutually exclusive with `account_name` / `account_key` and requires `storage_account_url` (not `connection_string`):
+
+```sql
+azureBlobStorage(storage_account_url, container_name, blobpath, extra_credentials(client_id=, tenant_id=) [, format, compression, partition_strategy, structure])
+```
+
+</Tab>
 <Tab title="Named collection">
 
 See [Named Collections](#named-collections) below for the full list of supported keys:
@@ -1047,7 +1056,7 @@ azureBlobStorage(named_collection[, option=value [,..]])
 | Argument                         | Description                                                                                                                                                                                                                                                                                                                                               |
 |----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `connection_string`              | A connection string that includes embedded credentials (account name + account key or SAS token). When using this form, `account_name` and `account_key` should **not** be passed separately. See [Configure a connection string](https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&bc=%2Fazure%2Fstorage%2Fblobs%2Fbreadcrumb%2Ftoc.json#configure-a-connection-string-for-an-azure-storage-account). |
-| `storage_account_url`            | The storage account endpoint URL, e.g. `https://myaccount.blob.core.windows.net/`. When using this form, you **must** also pass `account_name` and `account_key`.                                                                                                                                                                                         |
+| `storage_account_url`            | The storage account endpoint URL, e.g. `https://myaccount.blob.core.windows.net/`. When using this form, pass either `account_name` and `account_key`, or `extra_credentials(client_id=, tenant_id=)` for workload identity.                                                                                                                              |
 | `container_name`                 | Container name.                                                                                                                                                                                                                                                                                                                                           |
 | `blobpath`                       | File path. Supports the following wildcards in read-only mode: `*`, `**`, `?`, `{abc,def}` and `{N..M}` where `N`, `M` — numbers, `'abc'`, `'def'` — strings.                                                                                                                                                                                            |
 | `account_name`                   | Storage account name. **Required** when using `storage_account_url` without SAS; must **not** be passed when using `connection_string`.                                                                                                                                                                                                                               |

--- a/src/TableFunctions/TableFunctionObjectStorageCluster.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorageCluster.cpp
@@ -511,7 +511,8 @@ deltaLakeCluster(cluster_name, named_collection[, option=value [,..]])
 deltaLakeS3Cluster(cluster_name, url [,aws_access_key_id, aws_secret_access_key] [,format] [,structure] [,compression] [,extra_credentials])
 deltaLakeS3Cluster(cluster_name, named_collection[, option=value [,..]])
 
-deltaLakeAzureCluster(cluster_name, connection_string|storage_account_url, container_name, blobpath, [,account_name], [,account_key] [,format] [,compression_method] [,extra_credentials(client_id=, tenant_id=)])
+deltaLakeAzureCluster(cluster_name, connection_string|storage_account_url, container_name, blobpath, [,account_name], [,account_key] [,format] [,compression_method])
+deltaLakeAzureCluster(cluster_name, storage_account_url, container_name, blobpath, extra_credentials(client_id=, tenant_id=) [,format] [,compression_method])
 deltaLakeAzureCluster(cluster_name, named_collection[, option=value [,..]])
 ```
 `deltaLakeS3Cluster` is an alias to `deltaLakeCluster`, both are for S3. 
@@ -521,7 +522,7 @@ deltaLakeAzureCluster(cluster_name, named_collection[, option=value [,..]])
 - `cluster_name` — Name of a cluster that is used to build a set of addresses and connection parameters to remote and local servers.
 - Description of all other arguments coincides with description of arguments in equivalent [deltaLake](/reference/functions/table-functions/deltalake) table function.
 - An optional `extra_credentials` parameter can be used to pass a `role_arn` for role-based access in ClickHouse Cloud. See [Secure S3](/products/cloud/guides/data-sources/accessing-s3-data-securely) for configuration steps.
-- For Azure (`deltaLakeAzureCluster`), `extra_credentials` takes `client_id` and `tenant_id` for workload identity. The process must also have `AZURE_FEDERATED_TOKEN_FILE` set (`AZURE_TENANT_ID` / `AZURE_CLIENT_ID` if not passed explicitly; `AZURE_AUTHORITY_HOST` is optional).
+- For Azure (`deltaLakeAzureCluster`), `extra_credentials` takes `client_id` and `tenant_id` for workload identity and cannot be combined with `account_name` / `account_key`. The process must also have `AZURE_FEDERATED_TOKEN_FILE` set (`AZURE_TENANT_ID` / `AZURE_CLIENT_ID` if not passed explicitly; `AZURE_AUTHORITY_HOST` is optional).
 
 ## Returned value {#returned-value}
 
@@ -556,7 +557,8 @@ A table with the specified structure for reading data from cluster in the specif
     factory.registerFunction<TableFunctionDeltaLakeAzureCluster>(
         {
             .description = R"(The table function can be used to read the DeltaLake table stored on Azure object store in parallel for many nodes in a specified cluster.)",
-            .syntax = "deltaLakeAzureCluster(cluster, connection_string|storage_account_url, container_name, blobpath, [account_name, account_key, format, compression])",
+            .syntax = "deltaLakeAzureCluster(cluster, connection_string|storage_account_url, container_name, blobpath, [account_name, account_key, format, compression])\n"
+                      "deltaLakeAzureCluster(cluster, storage_account_url, container_name, blobpath, extra_credentials(client_id=, tenant_id=))",
             .category = FunctionDocumentation::Category::TableFunction
         },
         {.allow_readonly = false}

--- a/src/TableFunctions/TableFunctionObjectStorageCluster.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorageCluster.cpp
@@ -511,7 +511,7 @@ deltaLakeCluster(cluster_name, named_collection[, option=value [,..]])
 deltaLakeS3Cluster(cluster_name, url [,aws_access_key_id, aws_secret_access_key] [,format] [,structure] [,compression] [,extra_credentials])
 deltaLakeS3Cluster(cluster_name, named_collection[, option=value [,..]])
 
-deltaLakeAzureCluster(cluster_name, connection_string|storage_account_url, container_name, blobpath, [,account_name], [,account_key] [,format] [,compression_method])
+deltaLakeAzureCluster(cluster_name, connection_string|storage_account_url, container_name, blobpath, [,account_name], [,account_key] [,format] [,compression_method] [,extra_credentials(client_id=, tenant_id=)])
 deltaLakeAzureCluster(cluster_name, named_collection[, option=value [,..]])
 ```
 `deltaLakeS3Cluster` is an alias to `deltaLakeCluster`, both are for S3. 
@@ -521,6 +521,7 @@ deltaLakeAzureCluster(cluster_name, named_collection[, option=value [,..]])
 - `cluster_name` — Name of a cluster that is used to build a set of addresses and connection parameters to remote and local servers.
 - Description of all other arguments coincides with description of arguments in equivalent [deltaLake](/reference/functions/table-functions/deltalake) table function.
 - An optional `extra_credentials` parameter can be used to pass a `role_arn` for role-based access in ClickHouse Cloud. See [Secure S3](/products/cloud/guides/data-sources/accessing-s3-data-securely) for configuration steps.
+- For Azure (`deltaLakeAzureCluster`), `extra_credentials` takes `client_id` and `tenant_id` for workload identity. The process must also have `AZURE_FEDERATED_TOKEN_FILE` set (`AZURE_TENANT_ID` / `AZURE_CLIENT_ID` if not passed explicitly; `AZURE_AUTHORITY_HOST` is optional).
 
 ## Returned value {#returned-value}
 

--- a/src/TableFunctions/TableFunctionObjectStorageCluster.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorageCluster.cpp
@@ -558,7 +558,7 @@ A table with the specified structure for reading data from cluster in the specif
         {
             .description = R"(The table function can be used to read the DeltaLake table stored on Azure object store in parallel for many nodes in a specified cluster.)",
             .syntax = "deltaLakeAzureCluster(cluster, connection_string|storage_account_url, container_name, blobpath, [account_name, account_key, format, compression])\n"
-                      "deltaLakeAzureCluster(cluster, storage_account_url, container_name, blobpath, extra_credentials(client_id=, tenant_id=))",
+                      "deltaLakeAzureCluster(cluster, storage_account_url, container_name, blobpath, extra_credentials(client_id=, tenant_id=) [,format] [,compression])",
             .category = FunctionDocumentation::Category::TableFunction
         },
         {.allow_readonly = false}


### PR DESCRIPTION
Previously, reading a Delta table on Azure with `allow_experimental_delta_kernel_rs = 1` and workload identity authentication (`use_workload_identity`) failed with:

    Code: 48. DB::Exception: Unsupported authentication type for azure: 3. (NOT_IMPLEMENTED)

The Azure SDK's `WorkloadIdentityCredential` configures itself from the standard environment variables (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_FEDERATED_TOKEN_FILE`), but the delta-kernel path builds its object store from an explicit option list and never reads the environment. The credentials were silently unavailable and the auth type was rejected.

This PR forwards those environment variables (plus `AZURE_AUTHORITY_HOST`, used by the existing workload identity integration test) as `object_store` builder options (`azure_tenant_id`, `azure_client_id`, `azure_federated_token_file`, `azure_authority_host`). The Rust side already supports these keys and handles the token exchange and refresh, including re-reading the projected token file on rotation (e.g. AKS workload identity). `ClientSecretCredential` and `StaticCredential` remain unsupported.

Added a unit test in `gtest_delta_kernel.cpp` verifying the builder options, following the existing `getAzureBuilderOptions` tests.

Closes: https://github.com/ClickHouse/ClickHouse/issues/113267
Related: https://github.com/ClickHouse/ClickHouse/issues/53850
Related: https://github.com/ClickHouse/ClickHouse/issues/78963
Related: https://github.com/ClickHouse/ClickHouse/pull/102202

### Changelog category (leave one):
- Improvement

### Changelog entry:
Support Azure workload identity authentication in the delta-kernel implementation of the DeltaLake engine.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112637&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/112637](https://github.com/search?q=head%3Async-upstream%2Fpr%2F112637+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
