### PR TITLE
Add a test for a matcher in a column DEFAULT expression

### DIFF
--- a/tests/queries/0_stateless/04654_matcher_in_default_expression.reference
+++ b/tests/queries/0_stateless/04654_matcher_in_default_expression.reference
@@ -1,0 +1,7 @@
+asterisk
+qualified asterisk
+columns regexp
+columns list
+qualified columns regexp
+qualified columns list
+no matcher

--- a/tests/queries/0_stateless/04654_matcher_in_default_expression.reference
+++ b/tests/queries/0_stateless/04654_matcher_in_default_expression.reference
@@ -1,7 +1,2 @@
-asterisk
-qualified asterisk
-columns regexp
-columns list
-qualified columns regexp
-qualified columns list
+matcher in default expression
 no matcher

--- a/tests/queries/0_stateless/04654_matcher_in_default_expression.sql
+++ b/tests/queries/0_stateless/04654_matcher_in_default_expression.sql
@@ -1,29 +1,13 @@
--- The matcher guard lives on the analyzer path only, so this SET is load-bearing:
--- without it the old analyzer reports MULTIPLE_EXPRESSIONS_FOR_ALIAS instead. A session
--- SET also holds under the stress `compatibility` randomization, which a tag would not.
+-- A matcher in a column DEFAULT expression is rejected up front: assertNoMatcherNodes runs
+-- before the analyzer resolves the expression, so the matcher is reported rather than the
+-- duplicate alias. Closes #81194.
+-- The guard is on the analyzer path only, so this SET is load-bearing: without it the old
+-- analyzer resolves the expression and reports the alias collision instead. A session SET
+-- also holds under the stress `compatibility` randomization, which a tag would not.
 SET enable_analyzer = 1;
 
--- Every cell wraps the matcher in the duplicate-alias shape from the issue, so a build
--- without the guard reports MULTIPLE_EXPRESSIONS_FOR_ALIAS while a build with it reports
--- UNKNOWN_IDENTIFIER. A plain matcher reports UNKNOWN_IDENTIFIER either way.
-
-SELECT 'asterisk';
-CREATE TABLE t_asterisk (c0 Int DEFAULT tuple(1 AS a0, * + 2 AS a0)) ENGINE = Memory; -- { serverError UNKNOWN_IDENTIFIER }
-
-SELECT 'qualified asterisk';
-CREATE TABLE t_qualified_asterisk (c0 Int DEFAULT tuple(1 AS a0, c2.* + 2 AS a0)) ENGINE = Memory; -- { serverError UNKNOWN_IDENTIFIER }
-
-SELECT 'columns regexp';
-CREATE TABLE t_columns_regexp (c0 Int DEFAULT tuple(1 AS a0, COLUMNS('x.*') + 2 AS a0)) ENGINE = Memory; -- { serverError UNKNOWN_IDENTIFIER }
-
-SELECT 'columns list';
-CREATE TABLE t_columns_list (a Int, b Int, c0 Int DEFAULT tuple(1 AS a0, COLUMNS(a, b) + 2 AS a0)) ENGINE = Memory; -- { serverError UNKNOWN_IDENTIFIER }
-
-SELECT 'qualified columns regexp';
-CREATE TABLE t_qualified_columns_regexp (c0 Int DEFAULT tuple(1 AS a0, c2.COLUMNS('x.*') + 2 AS a0)) ENGINE = Memory; -- { serverError UNKNOWN_IDENTIFIER }
-
-SELECT 'qualified columns list';
-CREATE TABLE t_qualified_columns_list (a Int, b Int, c0 Int DEFAULT tuple(1 AS a0, c2.COLUMNS(a, b) + 2 AS a0)) ENGINE = Memory; -- { serverError UNKNOWN_IDENTIFIER }
+SELECT 'matcher in default expression';
+CREATE TABLE t_matcher_default (c0 Int DEFAULT tuple(1 AS a0, * + 2 AS a0)) ENGINE = Memory; -- { serverError UNKNOWN_IDENTIFIER }
 
 -- A matcher-free default must still be accepted, so that a change rejecting every default
 -- expression reddens differently from the guard firing.

--- a/tests/queries/0_stateless/04654_matcher_in_default_expression.sql
+++ b/tests/queries/0_stateless/04654_matcher_in_default_expression.sql
@@ -1,0 +1,31 @@
+-- The matcher guard lives on the analyzer path only, so this SET is load-bearing:
+-- without it the old analyzer reports MULTIPLE_EXPRESSIONS_FOR_ALIAS instead. A session
+-- SET also holds under the stress `compatibility` randomization, which a tag would not.
+SET enable_analyzer = 1;
+
+-- Every cell wraps the matcher in the duplicate-alias shape from the issue, so a build
+-- without the guard reports MULTIPLE_EXPRESSIONS_FOR_ALIAS while a build with it reports
+-- UNKNOWN_IDENTIFIER. A plain matcher reports UNKNOWN_IDENTIFIER either way.
+
+SELECT 'asterisk';
+CREATE TABLE t_asterisk (c0 Int DEFAULT tuple(1 AS a0, * + 2 AS a0)) ENGINE = Memory; -- { serverError UNKNOWN_IDENTIFIER }
+
+SELECT 'qualified asterisk';
+CREATE TABLE t_qualified_asterisk (c0 Int DEFAULT tuple(1 AS a0, c2.* + 2 AS a0)) ENGINE = Memory; -- { serverError UNKNOWN_IDENTIFIER }
+
+SELECT 'columns regexp';
+CREATE TABLE t_columns_regexp (c0 Int DEFAULT tuple(1 AS a0, COLUMNS('x.*') + 2 AS a0)) ENGINE = Memory; -- { serverError UNKNOWN_IDENTIFIER }
+
+SELECT 'columns list';
+CREATE TABLE t_columns_list (a Int, b Int, c0 Int DEFAULT tuple(1 AS a0, COLUMNS(a, b) + 2 AS a0)) ENGINE = Memory; -- { serverError UNKNOWN_IDENTIFIER }
+
+SELECT 'qualified columns regexp';
+CREATE TABLE t_qualified_columns_regexp (c0 Int DEFAULT tuple(1 AS a0, c2.COLUMNS('x.*') + 2 AS a0)) ENGINE = Memory; -- { serverError UNKNOWN_IDENTIFIER }
+
+SELECT 'qualified columns list';
+CREATE TABLE t_qualified_columns_list (a Int, b Int, c0 Int DEFAULT tuple(1 AS a0, c2.COLUMNS(a, b) + 2 AS a0)) ENGINE = Memory; -- { serverError UNKNOWN_IDENTIFIER }
+
+-- A matcher-free default must still be accepted, so that a change rejecting every default
+-- expression reddens differently from the guard firing.
+SELECT 'no matcher';
+CREATE TABLE t_no_matcher (a Int, c0 Int DEFAULT a + 2) ENGINE = Memory;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/81194
Related: https://github.com/ClickHouse/ClickHouse/pull/105045
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/81194

Test only, no source change, as requested in the issue.

The behaviour pinned is that a matcher in a column DEFAULT expression is rejected up front:
`assertNoMatcherNodes` runs before the analyzer resolves the expression, so the matcher is reported
rather than the duplicate alias in the issue's reproducer. I checked with the guard body neutered
locally, where the same statement returns `MULTIPLE_EXPRESSIONS_FOR_ALIAS` instead, and the matcher
visibly expands first.

Two things worth stating plainly. The assertion is code-level, not message-level, because
`TestHint` compares error codes and not text. And `MULTIPLE_EXPRESSIONS_FOR_ALIAS` was never wrong:
it is still what an actual alias collision returns, for example
`DEFAULT tuple(1 AS a0, a + 2 AS a0)` with no matcher. Only the ordering changed.

`SET enable_analyzer = 1` is load-bearing rather than stylistic, since the guard exists on the
analyzer path only. Without it, the same statement returns 179 under
`compatibility = '23.8'`, which the stress runner injects, so a tag would not cover this.

The test uses one assertion cell. The guard is a plain node-type check with no per-matcher-kind
branch, so extra cells for `COLUMNS(...)` or qualified forms add no coverage, and the qualified ones
are not even distinguishable here because an unresolvable qualifier reaches a second
`UNKNOWN_IDENTIFIER` throw in `QueryAnalyzer`.

Two disclosures. https://github.com/ClickHouse/ClickHouse/pull/105045 makes bare `*` and `COLUMNS`
legal in DEFAULT expressions and would change this assertion; it already updates the sibling
rejection test `03443_alias_with_asterisk.sql` in the same way, so the cost there is one line.
And `03443_alias_with_asterisk.sql` already hits this guard incidentally, but it was written five
months earlier for a different bug, it cannot close this issue, and it returns 47 at both values of
`enable_analyzer`, so it does not pin the ordering.