### PR TITLE
Fix Iceberg Avro writer emitting optional complex fields as required

### DIFF
--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
@@ -334,7 +334,7 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
         case TypeIndex::Array:
         {
             const auto & array_type = assert_cast<const DataTypeArray &>(*data_type);
-            auto nested_mapping = createSchemaWithSerializeFn(array_type.getNestedType(), type_name_increment, column_name, Nested::concatenateName(column_path, "element"));
+            auto nested_mapping = createFieldSchemaWithSerializeFn(array_type.getNestedType(), type_name_increment, column_name, Nested::concatenateName(column_path, "element"));
             auto schema = avro::ArraySchema(nested_mapping.schema);
             return {
                 schema,
@@ -452,7 +452,7 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
             auto schema = avro::RecordSchema(column_name + "_" + std::to_string(type_name_increment));
             for (size_t i = 0; i != nested_types.size(); ++i)
             {
-                auto nested_mapping = createSchemaWithSerializeFn(nested_types[i], type_name_increment, nested_names[i], Nested::concatenateName(column_path, nested_names[i]));
+                auto nested_mapping = createFieldSchemaWithSerializeFn(nested_types[i], type_name_increment, nested_names[i], Nested::concatenateName(column_path, nested_names[i]));
                 schema.addField(nested_names[i], nested_mapping.schema);
                 nested_serializers.push_back(nested_mapping.serialize);
             }
@@ -479,7 +479,7 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
             };
 
             const auto & values_type = map_type.getValueType();
-            auto values_mapping = createSchemaWithSerializeFn(values_type, type_name_increment, column_name + ".value", Nested::concatenateName(column_path, "value"));
+            auto values_mapping = createFieldSchemaWithSerializeFn(values_type, type_name_increment, column_name + ".value", Nested::concatenateName(column_path, "value"));
             auto schema = avro::MapSchema(values_mapping.schema);
 
             return {schema, [keys_serializer, values_mapping](const IColumn & column, size_t row_num, avro::Encoder & encoder)
@@ -512,6 +512,32 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
     throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Type {} is not supported for Avro output", data_type->getName());
 }
 
+AvroSerializer::SchemaWithSerializeFn AvroSerializer::createFieldSchemaWithSerializeFn(const DataTypePtr & data_type, size_t & type_name_increment, const String & column_name, const String & column_path)
+{
+    auto mapping = createSchemaWithSerializeFn(data_type, type_name_increment, column_name, column_path);
+
+    if (!column_mapper || !column_mapper->hasIcebergRequiredInfo() || !column_mapper->isIcebergOptionalPath(column_path))
+        return mapping;
+
+    /// A union already encodes the null branch (Nullable, Variant), and Avro forbids a union of
+    /// unions; a null schema would give the duplicate `["null", "null"]`. Both already express
+    /// optionality, so wrapping them would be wrong rather than redundant.
+    const auto schema_type = mapping.schema.type();
+    if (schema_type == avro::AVRO_UNION || schema_type == avro::AVRO_NULL)
+        return mapping;
+
+    avro::UnionSchema union_schema;
+    union_schema.addType(avro::NullSchema());
+    union_schema.addType(mapping.schema);
+    /// The ClickHouse column at an optional path is not Nullable (that is why the type cannot carry
+    /// the flag), so it is never null and only the non-null branch is ever encoded.
+    return {union_schema, [nested_serialize = mapping.serialize](const IColumn & column, size_t row_num, avro::Encoder & encoder)
+    {
+        encoder.encodeUnionIndex(1);
+        nested_serialize(column, row_num, encoder);
+    }};
+}
+
 AvroSerializer::AvroSerializer(const ColumnsWithTypeAndName & columns, std::unique_ptr<AvroSerializerTraits> traits_, const FormatSettings & settings_, ColumnMapperPtr column_mapper_)
     : traits(std::move(traits_)), settings(settings_), column_mapper(std::move(column_mapper_))
 {
@@ -522,7 +548,7 @@ AvroSerializer::AvroSerializer(const ColumnsWithTypeAndName & columns, std::uniq
     {
         try
         {
-            auto field_mapping = createSchemaWithSerializeFn(column.type, type_name_increment, column.name, /*column_path=*/column.name);
+            auto field_mapping = createFieldSchemaWithSerializeFn(column.type, type_name_increment, column.name, /*column_path=*/column.name);
             serialize_fns.push_back(field_mapping.serialize);
             //TODO: verify name starts with A-Za-z_
             record_schema.addField(column.name, field_mapping.schema);

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.h
@@ -60,6 +60,13 @@ private:
     /// path it picks Avro `string` vs `bytes` for a String column from the source logical type.
     SchemaWithSerializeFn createSchemaWithSerializeFn(const DataTypePtr & data_type, size_t & type_name_increment, const String & column_name, const String & column_path);
 
+    /// Same, but for a site that owns a field (top-level column, tuple field, array element, map
+    /// value). A complex container is never wrapped in Nullable, so its Iceberg optionality is not
+    /// recoverable from the type: consult the per-path metadata and add the `["null", T]` union an
+    /// optional field needs. A schema that is already a union or null carries its own optionality,
+    /// so the union is added exactly once per path.
+    SchemaWithSerializeFn createFieldSchemaWithSerializeFn(const DataTypePtr & data_type, size_t & type_name_increment, const String & column_name, const String & column_path);
+
     /// Sets the Iceberg `field-id` on every Avro record field, descending through union
     /// (Nullable/Variant), array and map wrappers so nested records also get ids. No-op without a mapper.
     void setIcebergFieldIds(const avro::NodePtr & node, const String & path);

--- a/tests/queries/0_stateless/04653_iceberg_avro_optional_complex_union.reference
+++ b/tests/queries/0_stateless/04653_iceberg_avro_optional_complex_union.reference
@@ -1,0 +1,15 @@
+req_int	required int
+opt_int	optional int
+opt_list	optional array
+opt_map	optional map
+opt_struct	optional record
+req_list	required array
+req_map	required map
+req_struct	required record
+list_opt_elem	required array
+map_opt_val	required map
+list_opt_elem.element	optional int
+map_opt_val.value	optional int
+opt_struct.sy	optional long
+field_ids	1,2,3,4,5,6,7,8,9,20
+1	2	[10,20]	{'k':5}	(7,8)	[99]	{'r':1}	(3)	[NULL,4]	{'z':NULL}

--- a/tests/queries/0_stateless/04653_iceberg_avro_optional_complex_union.reference
+++ b/tests/queries/0_stateless/04653_iceberg_avro_optional_complex_union.reference
@@ -8,8 +8,36 @@ req_map	required map
 req_struct	required record
 list_opt_elem	required array
 map_opt_val	required map
+list_opt_struct_elem	required array
+struct_opt_list_field	required record
+map_opt_struct_val	required map
 list_opt_elem.element	optional int
 map_opt_val.value	optional int
 opt_struct.sy	optional long
-field_ids	1,2,3,4,5,6,7,8,9,20
-1	2	[10,20]	{'k':5}	(7,8)	[99]	{'r':1}	(3)	[NULL,4]	{'z':NULL}
+list_opt_struct_elem.element	optional record
+struct_opt_list_field.inner	optional array
+map_opt_struct_val.value	optional record
+field_ids	1,2,3,4,5,6,7,8,9,20,23,26,29
+id	list_opt_elem	9
+id	list_opt_struct_elem	23
+id	list_opt_struct_elem.element.ex	25
+id	map_opt_struct_val	29
+id	map_opt_struct_val.value.vx	32
+id	map_opt_val	20
+id	opt_int	2
+id	opt_list	3
+id	opt_map	4
+id	opt_struct	5
+id	opt_struct.sx	13
+id	opt_struct.sy	14
+id	req_int	1
+id	req_list	6
+id	req_map	7
+id	req_struct	8
+id	req_struct.rx	18
+id	struct_opt_list_field	26
+id	struct_opt_list_field.inner	27
+1	2	[10,20]	{'k':5}	(7,8)	[99]	{'r':1}	(3)	[NULL,4]	{'z':NULL}	[(41)]	([51,52])	{'m':(61)}
+1
+[10,20]
+0

--- a/tests/queries/0_stateless/04653_iceberg_avro_optional_complex_union.sh
+++ b/tests/queries/0_stateless/04653_iceberg_avro_optional_complex_union.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: IcebergLocal and the Avro output format need USE_AVRO.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# An Iceberg field carries an explicit `required` bit. A complex container (list/map/struct) is never
+# wrapped in Nullable in the ClickHouse type, so an optional container used to be written as a bare
+# Avro `array`/`map`/`record` -- indistinguishable from a required one. Assert on the schema the Avro
+# file itself embeds: an optional field must be a `["null", T]` union, a required one must not be.
+# The schema is hand-written because ClickHouse DDL cannot express an optional container (getIcebergType
+# publishes required=true for Array/Map/Tuple), so this is the externally-authored-schema case.
+
+TEST_DIR="${CLICKHOUSE_USER_FILES}/${CLICKHOUSE_TEST_UNIQUE_NAME}"
+TABLE="t_${CLICKHOUSE_DATABASE}"
+
+function cleanup()
+{
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE}"
+    rm -rf "${TEST_DIR}"
+}
+trap cleanup EXIT
+
+rm -rf "${TEST_DIR}"
+mkdir -p "${TEST_DIR}/metadata" "${TEST_DIR}/data"
+
+cat > "${TEST_DIR}/metadata/v1.metadata.json" << EOF
+{
+  "format-version": 2,
+  "table-uuid": "8f2a1c34-5b6d-4e7f-9a0b-1c2d3e4f5a6b",
+  "location": "${TEST_DIR}",
+  "last-updated-ms": 1700000000000,
+  "last-column-id": 30,
+  "current-schema-id": 0,
+  "schemas": [
+    {
+      "type": "struct",
+      "schema-id": 0,
+      "fields": [
+        {"id": 1, "name": "req_int", "required": true, "type": "int"},
+        {"id": 2, "name": "opt_int", "required": false, "type": "int"},
+        {"id": 3, "name": "opt_list", "required": false,
+         "type": {"type": "list", "element-id": 10, "element": "int", "element-required": true}},
+        {"id": 4, "name": "opt_map", "required": false,
+         "type": {"type": "map", "key-id": 11, "key": "string", "value-id": 12, "value": "int", "value-required": true}},
+        {"id": 5, "name": "opt_struct", "required": false,
+         "type": {"type": "struct", "fields": [
+            {"id": 13, "name": "sx", "required": true, "type": "long"},
+            {"id": 14, "name": "sy", "required": false, "type": "long"}]}},
+        {"id": 6, "name": "req_list", "required": true,
+         "type": {"type": "list", "element-id": 15, "element": "int", "element-required": true}},
+        {"id": 7, "name": "req_map", "required": true,
+         "type": {"type": "map", "key-id": 16, "key": "string", "value-id": 17, "value": "int", "value-required": true}},
+        {"id": 8, "name": "req_struct", "required": true,
+         "type": {"type": "struct", "fields": [
+            {"id": 18, "name": "rx", "required": true, "type": "long"}]}},
+        {"id": 9, "name": "list_opt_elem", "required": true,
+         "type": {"type": "list", "element-id": 19, "element": "int", "element-required": false}},
+        {"id": 20, "name": "map_opt_val", "required": true,
+         "type": {"type": "map", "key-id": 21, "key": "string", "value-id": 22, "value": "int", "value-required": false}}
+      ]
+    }
+  ],
+  "default-spec-id": 0,
+  "partition-specs": [{"spec-id": 0, "fields": []}],
+  "last-partition-id": 0,
+  "default-sort-order-id": 0,
+  "sort-orders": [{"order-id": 0, "fields": []}],
+  "properties": {},
+  "current-snapshot-id": -1,
+  "snapshots": [],
+  "snapshot-log": [],
+  "metadata-log": []
+}
+EOF
+
+# IF NOT EXISTS attaches to the metadata already on disk instead of generating a new one, which is
+# what keeps the hand-written optional-container schema in force.
+${CLICKHOUSE_CLIENT} --query "
+    SET allow_experimental_insert_into_iceberg = 1;
+    CREATE TABLE IF NOT EXISTS ${TABLE}
+    (
+        req_int Int32,
+        opt_int Nullable(Int32),
+        opt_list Array(Int32),
+        opt_map Map(String, Int32),
+        opt_struct Tuple(sx Int64, sy Nullable(Int64)),
+        req_list Array(Int32),
+        req_map Map(String, Int32),
+        req_struct Tuple(rx Int64),
+        list_opt_elem Array(Nullable(Int32)),
+        map_opt_val Map(String, Nullable(Int32))
+    ) ENGINE = IcebergLocal('${TEST_DIR}/', 'Avro');
+    INSERT INTO ${TABLE} VALUES (1, 2, [10, 20], map('k', 5), (7, 8), [99], map('r', 1), (3), [NULL, 4], map('z', NULL));
+"
+
+# Nullability per field, straight out of the written file's `avro.schema` header entry. The reader
+# maps union[NULL, array] back to Array(...), so DESCRIBE cannot tell the two apart -- the embedded
+# schema is the only unambiguous witness.
+python3 - "${TEST_DIR}" << 'PY'
+import glob, json, re, sys
+
+files = sorted(glob.glob(sys.argv[1] + '/data/*.avro'))
+if not files:
+    sys.exit('no Avro data file was written')
+
+raw = open(files[0], 'rb').read()
+start = raw.index(b'{', re.search(rb'avro\.schema', raw).end())
+depth, end = 0, start
+while True:
+    char = raw[end:end + 1]
+    if char == b'{':
+        depth += 1
+    elif char == b'}':
+        depth -= 1
+        if depth == 0:
+            end += 1
+            break
+    end += 1
+schema = json.loads(raw[start:end].decode())
+
+
+def describe(avro_type):
+    """'optional' for a ["null", T] union, else the bare type name."""
+    if isinstance(avro_type, list):
+        assert not any(isinstance(branch, list) for branch in avro_type), 'nested union'
+        inner = [b for b in avro_type if b != 'null'][0]
+        name = inner if isinstance(inner, str) else inner['type']
+        return 'optional ' + name
+    if isinstance(avro_type, str):
+        return 'required ' + avro_type
+    return 'required ' + avro_type['type']
+
+
+def unwrap(avro_type):
+    """The wrapped type of a ["null", T] union, or the type itself."""
+    if isinstance(avro_type, list):
+        return [b for b in avro_type if b != 'null'][0]
+    return avro_type
+
+
+for field in schema['fields']:
+    print(field['name'], describe(field['type']), sep='\t')
+
+# An optional element/value nested inside a required container keeps its own union.
+by_name = {f['name']: f['type'] for f in schema['fields']}
+print('list_opt_elem.element', describe(unwrap(by_name['list_opt_elem'])['items']), sep='\t')
+print('map_opt_val.value', describe(unwrap(by_name['map_opt_val'])['values']), sep='\t')
+print('opt_struct.sy', describe(unwrap(by_name['opt_struct'])['fields'][1]['type']), sep='\t')
+
+# Iceberg field ids must survive the extra union level.
+print('field_ids', ','.join(str(f['field-id']) for f in schema['fields']), sep='\t')
+PY
+
+# Values round-trip unchanged.
+${CLICKHOUSE_CLIENT} --query "SELECT * FROM ${TABLE} FORMAT TSV"

--- a/tests/queries/0_stateless/04653_iceberg_avro_optional_complex_union.sh
+++ b/tests/queries/0_stateless/04653_iceberg_avro_optional_complex_union.sh
@@ -32,7 +32,7 @@ cat > "${TEST_DIR}/metadata/v1.metadata.json" << EOF
   "table-uuid": "8f2a1c34-5b6d-4e7f-9a0b-1c2d3e4f5a6b",
   "location": "${TEST_DIR}",
   "last-updated-ms": 1700000000000,
-  "last-column-id": 30,
+  "last-column-id": 40,
   "current-schema-id": 0,
   "schemas": [
     {
@@ -59,7 +59,19 @@ cat > "${TEST_DIR}/metadata/v1.metadata.json" << EOF
         {"id": 9, "name": "list_opt_elem", "required": true,
          "type": {"type": "list", "element-id": 19, "element": "int", "element-required": false}},
         {"id": 20, "name": "map_opt_val", "required": true,
-         "type": {"type": "map", "key-id": 21, "key": "string", "value-id": 22, "value": "int", "value-required": false}}
+         "type": {"type": "map", "key-id": 21, "key": "string", "value-id": 22, "value": "int", "value-required": false}},
+        {"id": 23, "name": "list_opt_struct_elem", "required": true,
+         "type": {"type": "list", "element-id": 24, "element-required": false,
+                  "element": {"type": "struct", "fields": [
+                     {"id": 25, "name": "ex", "required": true, "type": "long"}]}}},
+        {"id": 26, "name": "struct_opt_list_field", "required": true,
+         "type": {"type": "struct", "fields": [
+            {"id": 27, "name": "inner", "required": false,
+             "type": {"type": "list", "element-id": 28, "element": "int", "element-required": true}}]}},
+        {"id": 29, "name": "map_opt_struct_val", "required": true,
+         "type": {"type": "map", "key-id": 30, "key": "string", "value-id": 31, "value-required": false,
+                  "value": {"type": "struct", "fields": [
+                     {"id": 32, "name": "vx", "required": true, "type": "long"}]}}}
       ]
     }
   ],
@@ -78,6 +90,12 @@ EOF
 
 # IF NOT EXISTS attaches to the metadata already on disk instead of generating a new one, which is
 # what keeps the hand-written optional-container schema in force.
+# The `SETTINGS input_format_null_as_default = 1` clause pins the setting the read-back below needs.
+# It belongs on the CREATE and not on the SELECT: a table engine freezes its format settings when it
+# is created and ignores the session ones afterwards, so a per-statement pin on the SELECT would not
+# reach the reader. Without it, stress runs that inject an old `compatibility` value get the pre-21.1
+# default of `false`, under which a `["null", array]` union has no legal target (Array cannot be
+# Nullable in ClickHouse) and the read-back throws.
 ${CLICKHOUSE_CLIENT} --query "
     SET allow_experimental_insert_into_iceberg = 1;
     CREATE TABLE IF NOT EXISTS ${TABLE}
@@ -91,9 +109,12 @@ ${CLICKHOUSE_CLIENT} --query "
         req_map Map(String, Int32),
         req_struct Tuple(rx Int64),
         list_opt_elem Array(Nullable(Int32)),
-        map_opt_val Map(String, Nullable(Int32))
-    ) ENGINE = IcebergLocal('${TEST_DIR}/', 'Avro');
-    INSERT INTO ${TABLE} VALUES (1, 2, [10, 20], map('k', 5), (7, 8), [99], map('r', 1), (3), [NULL, 4], map('z', NULL));
+        map_opt_val Map(String, Nullable(Int32)),
+        list_opt_struct_elem Array(Tuple(ex Int64)),
+        struct_opt_list_field Tuple(inner Array(Int32)),
+        map_opt_struct_val Map(String, Tuple(vx Int64))
+    ) ENGINE = IcebergLocal('${TEST_DIR}/', 'Avro') SETTINGS input_format_null_as_default = 1;
+    INSERT INTO ${TABLE} VALUES (1, 2, [10, 20], map('k', 5), (7, 8), [99], map('r', 1), (3), [NULL, 4], map('z', NULL), [(41)], ([51, 52]), map('m', tuple(61)));
 "
 
 # Nullability per field, straight out of the written file's `avro.schema` header entry. The reader
@@ -123,10 +144,16 @@ schema = json.loads(raw[start:end].decode())
 
 
 def describe(avro_type):
-    """'optional' for a ["null", T] union, else the bare type name."""
+    """'optional' for a ["null", T] union, else the bare type name.
+
+    A union must be exactly the 2-branch null-first form Iceberg optionality uses, so that a
+    wrong arity or a swapped branch order is a failure rather than another 'optional' line.
+    """
     if isinstance(avro_type, list):
         assert not any(isinstance(branch, list) for branch in avro_type), 'nested union'
-        inner = [b for b in avro_type if b != 'null'][0]
+        assert len(avro_type) == 2, 'expected 2 union branches, got %d' % len(avro_type)
+        assert avro_type[0] == 'null', 'expected null-first union, got %r' % (avro_type[0],)
+        inner = avro_type[1]
         name = inner if isinstance(inner, str) else inner['type']
         return 'optional ' + name
     if isinstance(avro_type, str):
@@ -144,15 +171,61 @@ def unwrap(avro_type):
 for field in schema['fields']:
     print(field['name'], describe(field['type']), sep='\t')
 
-# An optional element/value nested inside a required container keeps its own union.
+# An optional element/value/field nested inside a required container keeps its own union. Each of
+# these paths is produced by exactly one call site in the writer, so one line moves per site.
 by_name = {f['name']: f['type'] for f in schema['fields']}
 print('list_opt_elem.element', describe(unwrap(by_name['list_opt_elem'])['items']), sep='\t')
 print('map_opt_val.value', describe(unwrap(by_name['map_opt_val'])['values']), sep='\t')
 print('opt_struct.sy', describe(unwrap(by_name['opt_struct'])['fields'][1]['type']), sep='\t')
+print('list_opt_struct_elem.element', describe(unwrap(by_name['list_opt_struct_elem'])['items']), sep='\t')
+print('struct_opt_list_field.inner', describe(unwrap(by_name['struct_opt_list_field'])['fields'][0]['type']), sep='\t')
+print('map_opt_struct_val.value', describe(unwrap(by_name['map_opt_struct_val'])['values']), sep='\t')
 
-# Iceberg field ids must survive the extra union level.
+# Iceberg field ids must survive the extra union level, at every depth.
 print('field_ids', ','.join(str(f['field-id']) for f in schema['fields']), sep='\t')
+
+
+def walk_ids(avro_type, path, out):
+    """Collect `path=field-id` for every id-carrying record field, through every wrapper."""
+    if isinstance(avro_type, list):
+        for branch in avro_type:
+            walk_ids(branch, path, out)
+        return
+    if not isinstance(avro_type, dict):
+        return
+    kind = avro_type['type']
+    if kind == 'record':
+        for field in avro_type['fields']:
+            child = path + '.' + field['name'] if path else field['name']
+            if 'field-id' in field:
+                out.append((child, field['field-id']))
+            walk_ids(field['type'], child, out)
+    elif kind == 'array':
+        walk_ids(avro_type['items'], path + '.element', out)
+    elif kind == 'map':
+        walk_ids(avro_type['values'], path + '.value', out)
+
+
+nested_ids = []
+walk_ids(schema, '', nested_ids)
+for path, field_id in sorted(nested_ids):
+    print('id', path, field_id, sep='\t')
 PY
 
 # Values round-trip unchanged.
 ${CLICKHOUSE_CLIENT} --query "SELECT * FROM ${TABLE} FORMAT TSV"
+
+# The union an optional container now carries needs input_format_null_as_default to land on a bare
+# Array/Map, which cannot be Nullable in ClickHouse. Read the same file through `file()`, whose
+# format settings do come from the query, to pin that behaviour instead of only describing it.
+# `grep -c -m1` and not `grep -c`: the message arrives twice whenever the client asks the server for
+# logs at `error` or a lower level (once as a log line, once as the exception), and that level comes
+# from CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL, which is `warning` normally and `fatal` under stress.
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/data/*.avro', 'Avro', 'opt_list Array(Int32)') SETTINGS input_format_null_as_default = 0" 2>&1 \
+    | grep -c -m1 "Cannot insert Avro Union"
+${CLICKHOUSE_CLIENT} --query "SELECT opt_list FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/data/*.avro', 'Avro', 'opt_list Array(Int32)') SETTINGS input_format_null_as_default = 1"
+# A required container is a bare Avro array, so it reads at either value of the setting. A `grep`
+# that matches nothing exits 1, and the runner fails a `.sh` test on any nonzero exit code, so the
+# count has to be taken without letting that status become the script's own.
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/data/*.avro', 'Avro', 'req_list Array(Int32)') SETTINGS input_format_null_as_default = 0" 2>&1 \
+    | grep -c -m1 "Cannot insert Avro Union" || true


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/111775
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes an Iceberg table whose write format is `Avro` serializing a field declared `"required": false` whose type is a `list`, `map` or `struct` as required, with no `["null", T]` union, so that the data file's own schema disagreed with the table metadata and other Iceberg readers saw a required field. Such a field is now written as the `["null", T]` union the Iceberg spec uses for an optional one.


### Description

`AvroSerializer::createSchemaWithSerializeFn` emits a `["null", T]` union only for `Nullable` and `Variant`, so Avro nullability came purely from the type carrying a `Nullable` wrapper. The Iceberg read layer never puts that wrapper on a container: `IcebergSchemaProcessor::getFieldType` calls `makeNullable` only on the scalar branch, while the complex branch returns a bare `Array`/`Map`/`Tuple` regardless of the field's own `required` bit. An optional container's optionality is therefore unrecoverable from the type.

This is the Avro half of #111775, which fixed the same defect for ORC and added the per-path metadata this consumes.

The fix adds `createFieldSchemaWithSerializeFn`, used at the four sites that own a field (top-level column, tuple field, array element, map value). It consults that metadata and wraps the built schema in `["null", T]`, unless the schema is already a union or null, so the union is added exactly once per path.

`getIcebergType` publishes `required: true` for ClickHouse-authored containers, so the carrier is normally an externally authored schema written by ClickHouse with `'Avro'`. The one exception is `Nullable(Tuple)`, the only container ClickHouse DDL can declare optional. Field ids are unchanged and plain `FORMAT Avro` output is byte-identical.

At the default `input_format_null_as_default = 1` such a file reads back unchanged. With the setting off the read throws `Cannot insert Avro Union(Null, T) into non-nullable type T`, because `getFieldType` derives a bare container for an optional complex field, the standing reader limitation Spark-written files already hit. For a `Nullable(Tuple)` column it is a change: master wrote a bare record, readable at either value, so with `enable_nullable_tuple_type = 1` (default off) and the setting persisted off at `CREATE`, a read that worked now errors. Optional element, value and field positions are unaffected, their targets being `Nullable`. The reader derivation is the root cause and is tracked separately.

<details>
<summary>Validation: per-field nullability in the written file's schema, master vs fix</summary>

Fixture: hand-written `v1.metadata.json` with optional and required containers, `CREATE TABLE IF NOT EXISTS ... ENGINE = IcebergLocal(dir, 'Avro')`, one INSERT. Values read out of the written file's `avro.schema` header entry.

| field (Iceberg) | master | with fix |
|---|---|---|
| `req_int` required int | required int | required int |
| `opt_int` optional int | optional int | optional int |
| **`opt_list` optional list** | **required array** | **optional array** |
| **`opt_map` optional map** | **required map** | **optional map** |
| **`opt_struct` optional struct** | **required record** | **optional record** |
| `req_list` / `req_map` / `req_struct` required | required | required |
| `list_opt_elem.element`, `map_opt_val.value`, `opt_struct.sy` optional | optional | optional |
| **`list_opt_struct_elem.element` optional struct** | **required record** | **optional record** |
| **`struct_opt_list_field.inner` optional list** | **required array** | **optional array** |
| **`map_opt_struct_val.value` optional struct** | **required record** | **optional record** |

Each of the four call sites is pinned separately: reverting one at a time to `createSchemaWithSerializeFn` moves a disjoint set of reference lines, the top-level site moving `opt_list`/`opt_map`/`opt_struct`, and the array-element, tuple-field and map-value sites moving one nested line each. All 13 Iceberg field ids are byte-identical between the arms, and the test also pins them at depth: not descending through the union drops four nested-id lines. 50/50 green, and 20/20 green under `compatibility='20.1'`, the regime whose pre-21.1 `input_format_null_as_default` default the read-back pin defends.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.487` (included in `26.8` and later)
<!-- ch-version-info:end -->