### PR TITLE
Fix DeltaLake losing rows for `NOT` over an untranslatable predicate

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/EnginePredicate.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/EnginePredicate.cpp
@@ -130,6 +130,36 @@ public:
     }
 
 private:
+    /// Name of the `Unknown` predicate handed to delta-kernel for a sub-expression we could not
+    /// translate. It must be a fixed ASCII literal: visit_predicate_unknown validates the name as
+    /// UTF-8 and reports failure for anything else, while a DAG node's result_name may hold
+    /// arbitrary bytes (e.g. a binary string literal appearing in the filter).
+    static constexpr std::string_view UNTRANSLATED_PREDICATE_NAME = "clickhouse_untranslated";
+
+    /// Represent "this node could not be translated" to delta-kernel.
+    ///
+    /// Returning nullptr instead would mean *the iterator is exhausted*, which truncates the
+    /// enclosing junction rather than dropping one child. That is only harmless in monotone
+    /// position: an empty conjunction normalizes to TRUE, so under NOT it becomes FALSE and every
+    /// data file gets skipped; a partially consumed conjunction under NOT yields a predicate
+    /// narrower than the truth. An explicit Unknown is "cannot decide" in the kernel's
+    /// three-valued logic and never skips a file on its own account, in any polarity.
+    static uintptr_t visitUntranslated(EngineIteratorData & iterator_data)
+    {
+        const std::string name{UNTRANSLATED_PREDICATE_NAME};
+        auto unknown = ffi::visit_predicate_unknown(iterator_data.state, KernelUtils::toDeltaString(name));
+        if (!unknown)
+        {
+            /// Unreachable with a compile-time ASCII name unless an invariant broke: 0 is the
+            /// kernel's reserved "no id" sentinel, and handing it on would reintroduce the very
+            /// truncation this function exists to prevent.
+            throw DB::Exception(
+                DB::ErrorCodes::LOGICAL_ERROR,
+                "delta-kernel rejected the `{}` predicate name", name);
+        }
+        return unknown;
+    }
+
     static const void * getNext(void * data_)
     {
         auto * iterator_data = static_cast<EngineIteratorData *>(data_);
@@ -144,6 +174,7 @@ private:
             const auto * node = iterator_data->next();
             if (!node)
             {
+                /// Real exhaustion, which is what nullptr means to the kernel.
                 LOG_TEST(iterator_data->log(), "Iterator finished");
                 return nullptr;
             }
@@ -160,13 +191,27 @@ private:
             {
                 return reinterpret_cast<const void *>(result);
             }
+
+            LOG_TEST(iterator_data->log(), "Node could not be translated, visiting it as unknown");
         }
         catch (...)
         {
             iterator_data->setException(std::current_exception());
         }
 
-        return nullptr;
+        /// Reached when the node was not translated, either because the visitor reported
+        /// failure or because it threw (the exception stays recorded on the shared predicate).
+        /// This function is invoked from Rust through an `extern "C"` pointer, so an exception
+        /// must not leave it.
+        try
+        {
+            return reinterpret_cast<const void *>(visitUntranslated(*iterator_data));
+        }
+        catch (...)
+        {
+            iterator_data->setException(std::current_exception());
+            return nullptr;
+        }
     }
 
     static uintptr_t getNextImpl(EngineIteratorData & iterator_data, const DB::ActionsDAG::Node * node);

--- a/tests/queries/0_stateless/04654_delta_lake_predicate_untranslatable_under_not.reference
+++ b/tests/queries/0_stateless/04654_delta_lake_predicate_untranslatable_under_not.reference
@@ -1,0 +1,55 @@
+-- wrong before the fix: the untranslatable child was dropped and the NOT inverted
+NOT (c0 NOT BETWEEN c0 AND 100): ok
+NOT (c0 > 100 OR c0 < 0): ok
+NOT (c0 < c0): ok
+NOT (c0 >= c0 AND c0 < 100): ok
+-- wrong before the fix: the conjunction was truncated, so a narrower predicate was pushed
+NOT (c0 >= 100 AND c0 < c0): ok
+NOT (c0 < c0 AND c0 >= 100): ok
+NOT (c0 >= 100 AND c0 < c0) AND c0 >= 0: ok
+NOT (c0 < 100 AND c0 < c0): ok
+-- wrong before the fix for any operand type, not just plain integers
+NOT (toNullable(c0) < toNullable(c0)): ok
+NOT (toString(c0) < toString(c0) AND c0 >= 100): ok
+NOT ([c0] = [c0] AND c0 >= 100): ok
+-- the Unknown predicate name must not be derived from the filter, which may hold non-UTF-8 bytes
+NOT (c0 < c0 AND non-utf8 literal): ok
+-- unchanged: predicates that already translated fully
+c0 >= 100: ok
+NOT (c0 < 100): ok
+NOT (c0 > 100): ok
+NOT (c0 > 100 AND c0 > 100): ok
+NOT (c0 >= 100 AND c0 >= 100): ok
+NOT (NOT (c0 >= 100)): ok
+c0 >= 100::Int16: ok
+NOT (c0 >= 100::Int16): ok
+NOT (c0 >= 100::Int64): ok
+-- unchanged: dropping an untranslatable child stays correct in monotone position
+c0 < c0: ok
+c0 >= c0: ok
+c0 > 200 OR c0 < 0: ok
+c0 >= 100 AND c0 < c0: ok
+c0 >= 100 AND (c0 > 1 OR c0 < 0): ok
+c0 >= 100 AND c0 != 105: ok
+c0 < 50 AND NOT (c0 >= 100 AND c0 < c0): ok
+NOT (NOT (c0 < c0)): ok
+c0 NOT BETWEEN c0 AND 100: ok
+-- file pruning must be preserved: these skip one of the two files
+c0 >= 100: ok
+NOT (c0 < 100): ok
+NOT (c0 >= 100 AND c0 >= 100): ok
+NOT (NOT (c0 >= 100)): ok
+c0 >= 100 AND c0 < c0: ok
+c0 >= 100 AND (c0 > 1 OR c0 < 0): ok
+c0 >= 100 AND c0 != 105: ok
+c0 >= 100::Int16: ok
+NOT (c0 >= 100::Int16): ok
+-- and these legitimately read both files
+NOT (c0 < c0): ok
+NOT (c0 > 100): ok
+c0 < c0: ok
+NOT (c0 >= 100 AND c0 < c0): ok
+-- a visitor exception is the same class: it must not skip files either
+failpoint NOT (c0 >= 100): ok
+-- but delta_lake_throw_on_engine_predicate_error still reports it
+1

--- a/tests/queries/0_stateless/04654_delta_lake_predicate_untranslatable_under_not.sh
+++ b/tests/queries/0_stateless/04654_delta_lake_predicate_untranslatable_under_not.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-msan
+# Tag no-fasttest: delta-kernel pulls in extra dependencies.
+# Tag no-msan: delta-kernel-rs (Rust) is not built under MSan, so DeltaLakeLocal is absent.
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/87390
+# A sub-expression the delta-kernel predicate translator cannot handle was reported to the
+# kernel as "the iterator is exhausted", which truncates the enclosing conjunction instead of
+# dropping one child. In monotone position that is harmless, but under NOT it changes the
+# answer: an empty conjunction normalizes to TRUE, so NOT(TRUE) skipped every data file, and a
+# partially consumed conjunction produced a predicate narrower than the truth. Both returned
+# too few rows with no error. The translator now emits an explicit `Unknown` predicate, which
+# the kernel treats as "cannot decide" in any polarity.
+#
+# Every answer is asserted against the same query over the same bytes read as plain Parquet, so
+# the expected values are derived rather than hand-copied. File counts are asserted too: losing
+# pruning would be a silent performance regression that a correct-answers test cannot see.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+ROOT="${CLICKHOUSE_TMP}/${CLICKHOUSE_DATABASE}_delta_not"
+trap 'rm -rf "${ROOT}" 2>/dev/null' EXIT
+rm -rf "${ROOT}"
+mkdir -p "${ROOT}/t/_delta_log"
+
+# Two data files with disjoint ranges, written by plain file() so no experimental Delta write
+# path is involved. ClickHouse's own Delta writer emits stats containing only numRecords, and a
+# statsless table can never prune, which would make every pruning assertion below vacuous. So
+# the transaction log is hand-written with real per-column stats.
+${CLICKHOUSE_LOCAL} --query "
+    INSERT INTO FUNCTION file('${ROOT}/t/lo.parquet', Parquet, 'c0 Int8') SELECT toInt8(number) FROM numbers(50);
+    INSERT INTO FUNCTION file('${ROOT}/t/hi.parquet', Parquet, 'c0 Int8') SELECT toInt8(100 + number) FROM numbers(27);
+"
+
+cat > "${ROOT}/t/_delta_log/00000000000000000000.json" <<EOF
+{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
+{"metaData":{"id":"${CLICKHOUSE_DATABASE}-t","format":{"provider":"parquet","options":{}},"schemaString":"{\\"type\\":\\"struct\\",\\"fields\\":[{\\"name\\":\\"c0\\",\\"type\\":\\"byte\\",\\"nullable\\":false,\\"metadata\\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1700000000000}}
+{"add":{"path":"lo.parquet","partitionValues":{},"size":685,"modificationTime":1700000000000,"dataChange":true,"stats":"{\\"numRecords\\":50,\\"minValues\\":{\\"c0\\":0},\\"maxValues\\":{\\"c0\\":49},\\"nullCount\\":{\\"c0\\":0}}"}}
+{"add":{"path":"hi.parquet","partitionValues":{},"size":576,"modificationTime":1700000000000,"dataChange":true,"stats":"{\\"numRecords\\":27,\\"minValues\\":{\\"c0\\":100},\\"maxValues\\":{\\"c0\\":126},\\"nullCount\\":{\\"c0\\":0}}"}}
+EOF
+
+# Compare the Delta answer with the plain-Parquet answer over the identical bytes. Prints only
+# the predicate and "ok"/the two counts, so the reference stays stable.
+check() {
+    local where="$1"
+    local label="${2:-$1}"
+    ${CLICKHOUSE_LOCAL} --query "
+        SELECT '${label//\'/\'\'}: ' || if(d = o, 'ok', 'MISMATCH delta=' || toString(d) || ' parquet=' || toString(o))
+        FROM (
+            SELECT
+                (SELECT count() FROM deltaLakeLocal('${ROOT}/t') WHERE ${where}) AS d,
+                (SELECT count() FROM file('${ROOT}/t/{lo,hi}.parquet', Parquet, 'c0 Int8') WHERE ${where}) AS o
+        );
+    "
+}
+
+# How many data files the Delta reader actually opened for this predicate, read from the
+# DeltaLakeScannedFiles profile event in the same session right after the query. 1 means the
+# pushed-down predicate skipped one of the two files; 2 means nothing was pruned. Answers alone
+# cannot detect lost pruning, which is why this is asserted separately.
+#
+# The count is aggregated over the whole table rather than filtered to the event's own row: when a
+# predicate skips every file the event is never incremented, so no row exists and a filtered query
+# would print nothing at all instead of reporting a mismatch.
+check_files() {
+    local where="$1"
+    local expected="$2"
+    ${CLICKHOUSE_LOCAL} --query "
+        SELECT count() FROM deltaLakeLocal('${ROOT}/t') WHERE ${where} FORMAT Null;
+        SELECT '${where//\'/\'\'}: ' || if(files = ${expected}, 'ok', 'files=' || toString(files) || ' expected ${expected}')
+        FROM (SELECT sumIf(value, event = 'DeltaLakeScannedFiles') AS files FROM system.events);
+    "
+}
+
+echo "-- wrong before the fix: the untranslatable child was dropped and the NOT inverted"
+# c0 < c0 and c0 >= c0 are untranslatable because a comparison needs one side to be a literal;
+# OR has no case in the translator at all. BETWEEN expands to a conjunction containing c0 >= c0,
+# which is the shape reported in the issue.
+check "NOT (c0 NOT BETWEEN c0 AND 100)"
+check "NOT (c0 > 100 OR c0 < 0)"
+check "NOT (c0 < c0)"
+# A bare NOT (c0 >= c0) would be useless here: c0 >= c0 always holds, so the correct answer is 0
+# and the wrong one is 0 too. Pairing it with a translatable conjunct makes it discriminating.
+check "NOT (c0 >= c0 AND c0 < 100)"
+
+echo "-- wrong before the fix: the conjunction was truncated, so a narrower predicate was pushed"
+# Only the child after the untranslatable one is lost, so the answer depended on operand order:
+# these two returned 50 and 0 respectively before the fix.
+check "NOT (c0 >= 100 AND c0 < c0)"
+check "NOT (c0 < c0 AND c0 >= 100)"
+check "NOT (c0 >= 100 AND c0 < c0) AND c0 >= 0"
+check "NOT (c0 < 100 AND c0 < c0)"
+
+echo "-- wrong before the fix for any operand type, not just plain integers"
+# The defect is in how the translator reports an untranslatable node, so it is independent of the
+# operand type: Nullable, String and Array operands all reach the same path.
+check "NOT (toNullable(c0) < toNullable(c0))"
+check "NOT (toString(c0) < toString(c0) AND c0 >= 100)"
+check "NOT ([c0] = [c0] AND c0 >= 100)"
+
+echo "-- the Unknown predicate name must not be derived from the filter, which may hold non-UTF-8 bytes"
+check "NOT (c0 < c0 AND toString(c0) > unhex('fffe'))" "NOT (c0 < c0 AND non-utf8 literal)"
+
+echo "-- unchanged: predicates that already translated fully"
+check "c0 >= 100"
+check "NOT (c0 < 100)"
+check "NOT (c0 > 100)"
+check "NOT (c0 > 100 AND c0 > 100)"
+check "NOT (c0 >= 100 AND c0 >= 100)"
+check "NOT (NOT (c0 >= 100))"
+check "c0 >= 100::Int16"
+check "NOT (c0 >= 100::Int16)"
+check "NOT (c0 >= 100::Int64)"
+
+echo "-- unchanged: dropping an untranslatable child stays correct in monotone position"
+check "c0 < c0"
+check "c0 >= c0"
+check "c0 > 200 OR c0 < 0"
+check "c0 >= 100 AND c0 < c0"
+check "c0 >= 100 AND (c0 > 1 OR c0 < 0)"
+check "c0 >= 100 AND c0 != 105"
+check "c0 < 50 AND NOT (c0 >= 100 AND c0 < c0)"
+check "NOT (NOT (c0 < c0))"
+check "c0 NOT BETWEEN c0 AND 100"
+
+echo "-- file pruning must be preserved: these skip one of the two files"
+check_files "c0 >= 100" 1
+check_files "NOT (c0 < 100)" 1
+check_files "NOT (c0 >= 100 AND c0 >= 100)" 1
+check_files "NOT (NOT (c0 >= 100))" 1
+check_files "c0 >= 100 AND c0 < c0" 1
+check_files "c0 >= 100 AND (c0 > 1 OR c0 < 0)" 1
+check_files "c0 >= 100 AND c0 != 105" 1
+check_files "c0 >= 100::Int16" 1
+check_files "NOT (c0 >= 100::Int16)" 1
+
+echo "-- and these legitimately read both files"
+check_files "NOT (c0 < c0)" 2
+check_files "NOT (c0 > 100)" 2
+check_files "c0 < c0" 2
+check_files "NOT (c0 >= 100 AND c0 < c0)" 2
+
+echo "-- a visitor exception is the same class: it must not skip files either"
+# The failpoint makes the literal visitor throw. It is ONCE, so it self-disarms after one hit;
+# a separate invocation keeps that hit on the intended query.
+${CLICKHOUSE_LOCAL} --query "
+    SYSTEM ENABLE FAILPOINT delta_kernel_fail_literal_visitor;
+    SELECT 'failpoint NOT (c0 >= 100): ' || if(count() = 50, 'ok', 'got ' || toString(count())) FROM deltaLakeLocal('${ROOT}/t') WHERE NOT (c0 >= 100);
+"
+
+echo "-- but delta_lake_throw_on_engine_predicate_error still reports it"
+${CLICKHOUSE_LOCAL} --query "
+    SYSTEM ENABLE FAILPOINT delta_kernel_fail_literal_visitor;
+    SELECT count() FROM deltaLakeLocal('${ROOT}/t') WHERE NOT (c0 >= 100) SETTINGS delta_lake_throw_on_engine_predicate_error = 1;
+" 2>&1 | grep -c "FAULT_INJECTED"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/87390
-->
Closes: https://github.com/ClickHouse/ClickHouse/issues/87390


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes `DeltaLake` tables returning too few rows when the `WHERE` predicate contains a sub-expression the delta-kernel predicate translator cannot handle, positioned under a `NOT`. Such a sub-expression is now reported to delta-kernel as an explicit unknown predicate instead of as the end of the child iterator, which used to silently truncate the enclosing conjunction.


### Description

`SELECT count() FROM t0 WHERE NOT (c0 NOT BETWEEN c0 AND 100)` returns 0 on a `DeltaLake` table holding 256 matching rows, with no error, while the complement is right, so the two do not add up. Reading the same bytes as plain Parquet is correct, so the defect is in the Delta reader.

Root cause: `EngineIterator::getNext` reported an untranslatable node by returning `nullptr`, which on the FFI side means *the child iterator is exhausted*, not *this child failed*, so the surrounding junction is truncated rather than losing one child. That is harmless in monotone position, where it only widens the file set and the exact filter is re-applied afterwards, but not under `NOT`:

- an empty conjunction normalizes to `TRUE`, so `NOT(TRUE)` is `FALSE` and every file is skipped;
- a partially consumed conjunction gives `NOT A` where the truth is `NOT A OR NOT B`, so files that only satisfy `NOT B` are skipped too. That second shape is not in the issue, is order sensitive, and is closed by the same change.

A node becomes untranslatable because `OR` has no case in the translator, or because a comparison needs one side to be a literal, so `c0 >= c0` never binds; `BETWEEN` expands to a conjunction containing it. A visitor exception took the same path and is fixed too.

The change makes `getNext` emit `Predicate::Unknown` for such a node. delta-kernel treats it as "cannot decide" and never skips a file on its account in any polarity, because negation flips an inversion flag rather than negating a value. Genuine exhaustion keeps returning `nullptr`, and sibling conjuncts that did translate remain usable for skipping, so no shape that prunes today loses pruning. `OR` support is out of scope: predicates containing `OR` stop returning wrong answers but still lose pushdown.

<details>
<summary>Validation</summary>

Every answer in the new test is asserted against the same query over the same bytes read as plain Parquet, so the expected values are derived rather than hand-copied. Scanned-file counts are asserted separately, because losing pruning is a silent performance regression that a correct-answers test cannot see. The fixture writes two Parquet files with disjoint ranges via `file()` and a hand-written transaction log carrying real per-column statistics; a table written by `INSERT INTO FUNCTION deltaLakeLocal(...)` carries only `numRecords`, so it can never prune and every pruning assertion on it would be vacuous.

15 assertion rows fail on unpatched master and pass with the change; 26 rows that are already correct, 9 of them asserting a skipped file, are unchanged in both directions. Wrong answers were confirmed for `Nullable`, `String`, `Bool` and `Array` operands, in both operand orders, so the fix is not specific to plain integers.

Mutation testing, each mutation reddening a predicted set: reverting the change reddens all 15 rows; emitting the unknown predicate on only one of the two paths reddens exactly the other path's rows in each direction; emitting it for genuine exhaustion makes every pushdown query hang; deriving the predicate name from the filter instead of a fixed ASCII literal reddens only the row whose filter carries non-UTF-8 bytes. The minimal variant of returning failure when the negated child is falsy is a no-op here, byte identical to unpatched master, because the kernel's conjunction visitor always returns a valid id, including for an empty conjunction.

50 randomized runs of the new test pass with 0 failures. The 14 other DeltaLake stateless tests produce an identical result with and without the change.
</details>