### PR TITLE
Derive the join order randomization seed from the initial query id

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -2573,10 +2573,10 @@ Set to 0 to disable the limit. Has no effect on the default `query_plan_optimize
 DECLARE(UInt64, query_plan_optimize_join_order_randomize, 0, R"(
 When non-zero, the join order optimizer uses randomly generated cardinalities and NDVs instead of real statistics.
 When set to 1, the seed is derived from the initial query id, so every plan built for one query, including the plans
-built by remote replicas, uses the same seed and therefore the same join order. Rerunning the same query text still
-explores a different ordering, because each query gets a new id; pass an explicit query id to make the choice
-reproducible. An empty initial query id, which is what an internal or background plan carries, falls back to a random
-seed. When set to a value > 1, that value is used as the seed directly.
+built by remote replicas, uses the same seed and therefore the same join order. Rerunning the same query text gets a new
+id and therefore a new seed, which may select a different ordering; pass an explicit query id to keep the seed stable.
+An empty initial query id, which is what an internal or background plan carries, falls back to a random seed.
+When set to a value > 1, that value is used as the seed directly.
 This is intended for testing to find errors caused by different join orderings.
 )", EXPERIMENTAL) \
     \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -2572,9 +2572,11 @@ Set to 0 to disable the limit. Has no effect on the default `query_plan_optimize
 )", EXPERIMENTAL) \
 DECLARE(UInt64, query_plan_optimize_join_order_randomize, 0, R"(
 When non-zero, the join order optimizer uses randomly generated cardinalities and NDVs instead of real statistics.
-When set to 1, the seed is derived from the initial query id, so every query plan built for that query uses the same
-seed, including the plans built by remote replicas. That keeps a run reproducible and stops two replicas from picking
-different join orders for one query. When set to a value > 1, that value is used as the seed directly.
+When set to 1, the seed is derived from the initial query id, so every plan built for one query, including the plans
+built by remote replicas, uses the same seed and therefore the same join order. Rerunning the same query text still
+explores a different ordering, because each query gets a new id; pass an explicit query id to make the choice
+reproducible. An empty initial query id, which is what an internal or background plan carries, falls back to a random
+seed. When set to a value > 1, that value is used as the seed directly.
 This is intended for testing to find errors caused by different join orderings.
 )", EXPERIMENTAL) \
     \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -2572,7 +2572,9 @@ Set to 0 to disable the limit. Has no effect on the default `query_plan_optimize
 )", EXPERIMENTAL) \
 DECLARE(UInt64, query_plan_optimize_join_order_randomize, 0, R"(
 When non-zero, the join order optimizer uses randomly generated cardinalities and NDVs instead of real statistics.
-When set to 1, a random seed is generated, when set to a value > 1, that value is used as the seed directly.
+When set to 1, the seed is derived from the initial query id, so every query plan built for that query uses the same
+seed, including the plans built by remote replicas. That keeps a run reproducible and stops two replicas from picking
+different join orders for one query. When set to a value > 1, that value is used as the seed directly.
 This is intended for testing to find errors caused by different join orderings.
 )", EXPERIMENTAL) \
     \

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
@@ -185,13 +185,9 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
     query_plan_optimize_join_order_randomize = from[Setting::query_plan_optimize_join_order_randomize];
     if (query_plan_optimize_join_order_randomize == 1)
     {
-        /// One query must get one seed. This constructor runs once per query plan construction, and a query builds
-        /// several plans (scalar subqueries, `Merge` children, and, under parallel replicas, one per replica because
-        /// `serialize_query_plan` is off by default and every replica re-plans the query text it receives). Rolling a
-        /// fresh seed here would let those plans pick different join orders, which makes the run irreproducible and can
-        /// make two replicas announce different read modes for one stream. `initial_query_id` is stable for the whole
-        /// query and is propagated to remote replicas in `ClientInfo`, so deriving the seed from it keeps every plan of
-        /// one query consistent while different queries still explore different orderings.
+        /// One query must get one seed, but this constructor runs once per plan construction and one query builds
+        /// several plans, including one per replica. `initial_query_id` is stable for the query and reaches remote
+        /// replicas in `ClientInfo`, so deriving the seed from it keeps those plans consistent.
         /// The value is forced above 1 so it can never read back as the sentinel (1) or as disabled (0).
         if (initial_query_id_.empty())
             query_plan_optimize_join_order_randomize = randomSeed(); /// No query to be consistent with (internal or background plan).

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
@@ -8,6 +8,7 @@
 #include <Interpreters/Cluster.h>
 #include <Interpreters/Context.h>
 
+#include <Common/SipHash.h>
 #include <Common/logger_useful.h>
 #include <Common/randomSeed.h>
 
@@ -184,7 +185,20 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
     query_plan_optimize_join_order_randomize = from[Setting::query_plan_optimize_join_order_randomize];
     if (query_plan_optimize_join_order_randomize == 1)
     {
-        query_plan_optimize_join_order_randomize = randomSeed();
+        /// One query must get one seed. This constructor runs once per query plan construction, and a query builds
+        /// several plans (scalar subqueries, `Merge` children, and, under parallel replicas, one per replica because
+        /// `serialize_query_plan` is off by default and every replica re-plans the query text it receives). Rolling a
+        /// fresh seed here would let those plans pick different join orders, which makes the run irreproducible and can
+        /// make two replicas announce different read modes for one stream. `initial_query_id` is stable for the whole
+        /// query and is propagated to remote replicas in `ClientInfo`, so deriving the seed from it keeps every plan of
+        /// one query consistent while different queries still explore different orderings.
+        /// The value is forced above 1 so it can never read back as the sentinel (1) or as disabled (0).
+        if (initial_query_id_.empty())
+            query_plan_optimize_join_order_randomize = randomSeed(); /// No query to be consistent with (internal or background plan).
+        else
+            query_plan_optimize_join_order_randomize = sipHash64(initial_query_id_);
+        if (query_plan_optimize_join_order_randomize <= 1)
+            query_plan_optimize_join_order_randomize = 2;
     }
     if (query_plan_optimize_join_order_randomize)
     {

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.reference
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.reference
@@ -12,3 +12,4 @@ cell C one seed across replicas	1
 cell C seed equals hash of initial query id	1
 cell C saw several plan constructions	1
 cell C several plans carried the derived seed	1
+cell C fanned out to three replicas	1

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.reference
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.reference
@@ -11,4 +11,4 @@ cell B2 randomize=0 derives no seed	1
 cell C one seed across replicas	1
 cell C seed equals hash of initial query id	1
 cell C saw several plan constructions	1
-cell C fanned out to three replicas	1
+cell C several plans carried the derived seed	1

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.reference
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.reference
@@ -1,0 +1,11 @@
+200	200	200
+cell A one seed per query	1
+cell A saw several plan constructions	1
+200
+cell B explicit seed used verbatim	1
+cell B distinct seeds still reorder	1
+200
+cell B2 randomize=0 derives no seed	1
+200
+cell C one seed across replicas	1
+cell C fanned out to several replicas	1

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.reference
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.reference
@@ -10,4 +10,5 @@ cell B2 randomize=0 derives no seed	1
 200
 cell C one seed across replicas	1
 cell C seed equals hash of initial query id	1
-cell C fanned out to several replicas	1
+cell C saw several plan constructions	1
+cell C fanned out to three replicas	1

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.reference
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.reference
@@ -15,3 +15,4 @@ cell C several plans carried the derived seed	1
 cell C fanned out to three replicas	1
 200
 cell C2 serialized plan derives the same seed	1
+cell C2 replicas received a serialized plan	1

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.reference
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.reference
@@ -1,5 +1,6 @@
 200	200	200
 cell A one seed per query	1
+cell A seed equals hash of initial query id	1
 cell A saw several plan constructions	1
 200
 cell B explicit seed used verbatim	1
@@ -8,4 +9,5 @@ cell B distinct seeds still reorder	1
 cell B2 randomize=0 derives no seed	1
 200
 cell C one seed across replicas	1
+cell C seed equals hash of initial query id	1
 cell C fanned out to several replicas	1

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.reference
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.reference
@@ -13,3 +13,5 @@ cell C seed equals hash of initial query id	1
 cell C saw several plan constructions	1
 cell C several plans carried the derived seed	1
 cell C fanned out to three replicas	1
+200
+cell C2 serialized plan derives the same seed	1

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
@@ -53,6 +53,9 @@ WHERE logger_name = 'QueryPlanOptimizationSettings'
 
 -- The seed must be the DERIVED value, not merely one value: a constant seed would also be unique within a
 -- query and across replicas.
+-- `system.query_log` is server-global and append-only, so every expected-seed lookup below is ordered and takes
+-- the NEWEST matching row: a stress thread runs with a fixed `--database`, so the same test can appear there
+-- repeatedly and an unordered single-row pick could hash a previous run's query id.
 SELECT 'cell A seed equals hash of initial query id', (
     SELECT groupUniqArray(extract(message, 'seed (\\d+)'))
     FROM system.text_log
@@ -69,6 +72,7 @@ SELECT 'cell A seed equals hash of initial query id', (
     FROM system.query_log
     WHERE current_database = currentDatabase() AND log_comment = '04653_cell_a'
       AND is_initial_query AND type != 'QueryStart'
+    ORDER BY event_time_microseconds DESC
     LIMIT 1);
 
 -- Cell A must be non-vacuous: the query really did construct more than one plan.
@@ -105,14 +109,16 @@ WHERE logger_name = 'QueryPlanOptimizationSettings'
 -- feature off. Seeds 2 and 3 are used because the chosen order is a hash of (seed, relation index, table name),
 -- so two arbitrary seeds can legitimately land on the same order for one particular set of table names: seeds
 -- 12345 and 54321 do exactly that here. Seeds 2 and 3 are verified to differ for these table names.
+-- The join-swap pin is required because both the functional runner and the stress runner randomize the setting,
+-- and a forced swap changes the read order independently of the seed, which is what this row measures.
 SELECT 'cell B distinct seeds still reorder', (
     SELECT groupArray(explain) FROM (
         EXPLAIN PLAN SELECT count() FROM t1_04653 LEFT JOIN t2_04653 ON t1_04653.x = t2_04653.x JOIN t3_04653 ON t2_04653.y = t3_04653.y AND t1_04653.z = t3_04653.z
-        SETTINGS query_plan_optimize_join_order_randomize = 2, query_plan_optimize_join_order_limit = 3)
+        SETTINGS query_plan_optimize_join_order_randomize = 2, query_plan_optimize_join_order_limit = 3, query_plan_join_swap_table = 'auto')
     WHERE explain ILIKE '%ReadFromMergeTree%') != (
     SELECT groupArray(explain) FROM (
         EXPLAIN PLAN SELECT count() FROM t1_04653 LEFT JOIN t2_04653 ON t1_04653.x = t2_04653.x JOIN t3_04653 ON t2_04653.y = t3_04653.y AND t1_04653.z = t3_04653.z
-        SETTINGS query_plan_optimize_join_order_randomize = 3, query_plan_optimize_join_order_limit = 3)
+        SETTINGS query_plan_optimize_join_order_randomize = 3, query_plan_optimize_join_order_limit = 3, query_plan_join_swap_table = 'auto')
     WHERE explain ILIKE '%ReadFromMergeTree%');
 
 -- Cell B2 (must-not-change control): the default value 0 disables randomization entirely and is untouched.
@@ -178,6 +184,7 @@ SELECT 'cell C seed equals hash of initial query id', (
     FROM system.query_log
     WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c'
       AND is_initial_query AND type != 'QueryStart'
+    ORDER BY event_time_microseconds DESC
     LIMIT 1);
 
 -- Cell C must be non-vacuous: the query really did construct more than one plan.
@@ -192,9 +199,9 @@ WHERE logger_name = 'QueryPlanOptimizationSettings'
             SELECT query_id FROM system.query_log
             WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c' AND is_initial_query));
 
--- Cell C must be non-vacuous in the way that matters: at least two DISTINCT plan constructions carried this
--- query's derived seed. The scope is the seed value itself, computed from the initiator's own `query_log` row,
--- which is always locally visible; joining the replicas' rows instead would race their `query_log` flush
+-- Cell C non-vacuity, part 1: more than one plan construction carried this query's derived seed.
+-- The scope is the seed value itself, computed from the initiator's own `query_log` row, which is
+-- always locally visible; joining the replicas' rows instead would race their `query_log` flush
 -- (`SYSTEM FLUSH LOGS` has no cross-replica barrier).
 SELECT 'cell C several plans carried the derived seed', uniqExact(query_id) >= 2
 FROM system.text_log
@@ -205,6 +212,24 @@ WHERE logger_name = 'QueryPlanOptimizationSettings'
       FROM system.query_log
       WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c'
         AND is_initial_query AND type != 'QueryStart'
+      ORDER BY event_time_microseconds DESC
+      LIMIT 1);
+
+-- Cell C non-vacuity, part 2: the configured fan-out really happened, so the multi-replica half of
+-- the coordination contract is exercised rather than assumed. The population that carries the
+-- derived seed is one initiator plan construction plus one per replica, so at
+-- `max_parallel_replicas = 3` the count is 4. This row is deliberately coupled to that setting: if
+-- the fixture's replica count is ever changed, this row must be updated with it.
+SELECT 'cell C fanned out to three replicas', uniqExact(query_id) = 4
+FROM system.text_log
+WHERE logger_name = 'QueryPlanOptimizationSettings'
+  AND message LIKE '%random seed%'
+  AND extract(message, 'seed (\\d+)') = (
+      SELECT toString(greatest(sipHash64(query_id), 2))
+      FROM system.query_log
+      WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c'
+        AND is_initial_query AND type != 'QueryStart'
+      ORDER BY event_time_microseconds DESC
       LIMIT 1);
 
 DROP TABLE t1_04653;

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
@@ -292,6 +292,39 @@ SELECT 'cell C2 serialized plan derives the same seed', (
     ORDER BY event_time_microseconds DESC
     LIMIT 1);
 
+-- The replicas must really have received a serialized plan rather than the query text: that is what
+-- distinguishes this cell from cell C. Without this row the cell stays green on the query-text
+-- fallback, because a re-planning replica derives the SAME seed from the same propagated
+-- `initial_query_id`, so the row above cannot tell the two paths apart. The discriminator is the
+-- number of plan constructions: the deserialize path constructs `QueryPlanOptimizationSettings`
+-- twice per receiver (`executeQuery.cpp:1980` and `:1987`; the second passes `do_optimize = false`,
+-- but the object is built at the call site, so both log the seed), while a replica re-planning the
+-- query text constructs it once (`InterpreterSelectQueryAnalyzer.cpp:403`). The initiator is
+-- excluded because it constructs twice on both arms whenever `parallel_replicas_local_plan = 1`
+-- (`InterpreterSelectQueryAnalyzer.cpp:192`, reached only by the initiator: `:184` returns early for
+-- a secondary query), so its id is exactly the one participant that can double without
+-- deserializing. Both subqueries read the initiator's own always-visible `query_log` row, so this
+-- needs no replica `query_log` join, whose flush this test cannot force (`SYSTEM FLUSH LOGS` has no
+-- cross-replica barrier).
+SELECT 'cell C2 replicas received a serialized plan', count() > uniqExact(query_id)
+FROM system.text_log
+WHERE logger_name = 'QueryPlanOptimizationSettings'
+  AND message LIKE '%random seed%'
+  AND extract(message, 'seed (\\d+)') = (
+      SELECT toString(greatest(sipHash64(query_id), 2))
+      FROM system.query_log
+      WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c2'
+        AND is_initial_query AND type != 'QueryStart'
+      ORDER BY event_time_microseconds DESC
+      LIMIT 1)
+  AND query_id != (
+      SELECT query_id
+      FROM system.query_log
+      WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c2'
+        AND is_initial_query AND type != 'QueryStart'
+      ORDER BY event_time_microseconds DESC
+      LIMIT 1);
+
 DROP TABLE t1_04653;
 DROP TABLE t2_04653;
 DROP TABLE t3_04653;

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
@@ -3,8 +3,9 @@
 -- `query_plan_optimize_join_order_randomize = 1` means "derive a seed", and the seed feeds
 -- `getRandomizedStats`, which replaces the real relation statistics and therefore decides the join order.
 -- The seed must be a function of the query, not of the individual plan construction: a query builds several
--- plans (one per scalar subquery, and under parallel replicas one per replica, because `serialize_query_plan`
--- is off by default and every replica re-plans the query text it receives). When those plans disagree on the
+-- plans (one per scalar subquery, and under parallel replicas one per replica: a replica re-plans whether it
+-- receives the query text or a serialized plan, because `JoinStepLogical::serialize` does not encode the
+-- `optimized` flag, so the join-order rewrite runs again on the replica). When those plans disagree on the
 -- join order, the leftmost relation differs, so a different table gets `requestReadingInOrder` and two
 -- replicas announce different coordination modes for one stream, throwing `Coordination mode mismatch for
 -- stream`.
@@ -191,15 +192,20 @@ WHERE logger_name = 'QueryPlanOptimizationSettings'
             SELECT query_id FROM system.query_log
             WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c' AND is_initial_query));
 
--- The configured fan-out really happened, read from the initiator's own accumulated counters so the assertion
--- does not depend on when the replicas' own `query_log` rows become visible. `ParallelReplicasAvailableCount` is
--- incremented once per replica that actually joined the query.
-SELECT 'cell C fanned out to three replicas', ProfileEvents['ParallelReplicasAvailableCount'] = 3
-FROM system.query_log
-WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c'
-  AND is_initial_query AND type = 'QueryFinish'
-LIMIT 1
-SETTINGS enable_parallel_replicas = 0;
+-- Cell C must be non-vacuous in the way that matters: at least two DISTINCT plan constructions carried this
+-- query's derived seed. The scope is the seed value itself, computed from the initiator's own `query_log` row,
+-- which is always locally visible; joining the replicas' rows instead would race their `query_log` flush
+-- (`SYSTEM FLUSH LOGS` has no cross-replica barrier).
+SELECT 'cell C several plans carried the derived seed', uniqExact(query_id) >= 2
+FROM system.text_log
+WHERE logger_name = 'QueryPlanOptimizationSettings'
+  AND message LIKE '%random seed%'
+  AND extract(message, 'seed (\\d+)') = (
+      SELECT toString(greatest(sipHash64(query_id), 2))
+      FROM system.query_log
+      WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c'
+        AND is_initial_query AND type != 'QueryStart'
+      LIMIT 1);
 
 DROP TABLE t1_04653;
 DROP TABLE t2_04653;

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
@@ -50,6 +50,26 @@ WHERE logger_name = 'QueryPlanOptimizationSettings'
             SELECT query_id FROM system.query_log
             WHERE current_database = currentDatabase() AND log_comment = '04653_cell_a' AND is_initial_query));
 
+-- The seed must be the DERIVED value, not merely one value: a constant seed would also be unique within a
+-- query and across replicas.
+SELECT 'cell A seed equals hash of initial query id', (
+    SELECT groupUniqArray(extract(message, 'seed (\\d+)'))
+    FROM system.text_log
+    WHERE logger_name = 'QueryPlanOptimizationSettings'
+      AND message LIKE '%random seed%'
+      AND query_id IN (
+          SELECT query_id FROM system.query_log
+          WHERE log_comment = '04653_cell_a' AND type != 'QueryStart'
+            AND initial_query_id IN (
+                SELECT query_id FROM system.query_log
+                WHERE current_database = currentDatabase() AND log_comment = '04653_cell_a' AND is_initial_query))
+) = (
+    SELECT [toString(greatest(sipHash64(query_id), 2))]
+    FROM system.query_log
+    WHERE current_database = currentDatabase() AND log_comment = '04653_cell_a'
+      AND is_initial_query AND type != 'QueryStart'
+    LIMIT 1);
+
 -- Cell A must be non-vacuous: the query really did construct more than one plan.
 SELECT 'cell A saw several plan constructions', count() > 1
 FROM system.text_log
@@ -138,6 +158,26 @@ WHERE logger_name = 'QueryPlanOptimizationSettings'
         AND initial_query_id IN (
             SELECT query_id FROM system.query_log
             WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c' AND is_initial_query));
+
+-- The replicas must have agreed on the DERIVED value, not merely on some value. Each replica has its own
+-- `query_id`, so hashing the initial one is what makes them agree.
+SELECT 'cell C seed equals hash of initial query id', (
+    SELECT groupUniqArray(extract(message, 'seed (\\d+)'))
+    FROM system.text_log
+    WHERE logger_name = 'QueryPlanOptimizationSettings'
+      AND message LIKE '%random seed%'
+      AND query_id IN (
+          SELECT query_id FROM system.query_log
+          WHERE log_comment = '04653_cell_c' AND type != 'QueryStart'
+            AND initial_query_id IN (
+                SELECT query_id FROM system.query_log
+                WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c' AND is_initial_query))
+) = (
+    SELECT [toString(greatest(sipHash64(query_id), 2))]
+    FROM system.query_log
+    WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c'
+      AND is_initial_query AND type != 'QueryStart'
+    LIMIT 1);
 
 -- Cell C must be non-vacuous: the query really did fan out to several replicas, each re-planning.
 SELECT 'cell C fanned out to several replicas', uniqExact(query_id) > 1

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
@@ -252,6 +252,32 @@ WHERE logger_name = 'QueryPlanOptimizationSettings'
       ORDER BY event_time_microseconds DESC
       LIMIT 1);
 
+-- Cell C2: the serialized-plan replica path. With a local plan the initiator ships a serialized
+-- plan to the replicas (`ClusterProxy/executeQuery.cpp:893-897`), and the receiver re-optimizes it
+-- (`executeQuery.cpp:1980`) because `JoinStepLogical::serialize` does not encode the `optimized`
+-- flag, so the join-order rewrite runs again there and must derive the same seed.
+SELECT count() FROM (
+    SELECT t1_04653.x, t1_04653.z, t2_04653.x, t2_04653.y, t3_04653.y, t3_04653.z
+    FROM t1_04653 LEFT JOIN t2_04653 ON t1_04653.x = t2_04653.x
+    JOIN t3_04653 ON t2_04653.y = t3_04653.y AND t1_04653.z = t3_04653.z
+    ORDER BY ALL)
+SETTINGS query_plan_optimize_join_order_randomize = 1, query_plan_optimize_join_order_limit = 3,
+    parallel_replicas_local_plan = 1, serialize_query_plan = 1, log_comment = '04653_cell_c2';
+
+SYSTEM FLUSH LOGS query_log, text_log;
+
+SELECT 'cell C2 serialized plan derives the same seed', uniqExact(query_id) >= 2
+FROM system.text_log
+WHERE logger_name = 'QueryPlanOptimizationSettings'
+  AND message LIKE '%random seed%'
+  AND extract(message, 'seed (\\d+)') = (
+      SELECT toString(greatest(sipHash64(query_id), 2))
+      FROM system.query_log
+      WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c2'
+        AND is_initial_query AND type != 'QueryStart'
+      ORDER BY event_time_microseconds DESC
+      LIMIT 1);
+
 DROP TABLE t1_04653;
 DROP TABLE t2_04653;
 DROP TABLE t3_04653;

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
@@ -1,0 +1,156 @@
+-- Tags: no-parallel, no-random-settings
+--
+-- `query_plan_optimize_join_order_randomize = 1` means "derive a seed", and the seed feeds
+-- `getRandomizedStats`, which replaces the real relation statistics and therefore decides the join order.
+-- The seed must be a function of the query, not of the individual plan construction: a query builds several
+-- plans (one per scalar subquery, and under parallel replicas one per replica, because `serialize_query_plan`
+-- is off by default and every replica re-plans the query text it receives). When those plans disagree on the
+-- join order, the leftmost relation differs, so a different table gets `requestReadingInOrder` and two
+-- replicas announce different coordination modes for one stream, throwing `Coordination mode mismatch for
+-- stream`.
+--
+-- `no-parallel` is required because the assertions read `system.text_log`, which is server-global.
+-- `no-random-settings` is required because the runner randomizes `query_plan_optimize_join_order_randomize`
+-- itself (`tests/clickhouse-test`), which would overwrite the value under test.
+
+DROP TABLE IF EXISTS t1_04653;
+DROP TABLE IF EXISTS t2_04653;
+DROP TABLE IF EXISTS t3_04653;
+
+CREATE TABLE t1_04653 (x UInt64, z UInt64) ENGINE = MergeTree ORDER BY x;
+CREATE TABLE t2_04653 (x UInt64, y UInt64) ENGINE = MergeTree ORDER BY x;
+CREATE TABLE t3_04653 (y UInt64, z UInt64) ENGINE = MergeTree ORDER BY y;
+
+INSERT INTO t1_04653 SELECT number, number FROM numbers(1000);
+INSERT INTO t2_04653 SELECT number, number FROM numbers(500);
+INSERT INTO t3_04653 SELECT number, number FROM numbers(200);
+
+SET enable_analyzer = 1;
+SET max_rows_to_read = 0; -- system.text_log can be really big
+SET max_execution_time = 0;
+
+-- Cell A: one query builds three plans (three scalar subqueries over the same join, each constructing its own
+-- `QueryPlanOptimizationSettings`). All of them must use the same derived seed.
+SELECT
+    (SELECT count() FROM t1_04653 LEFT JOIN t2_04653 ON t1_04653.x = t2_04653.x JOIN t3_04653 ON t2_04653.y = t3_04653.y AND t1_04653.z = t3_04653.z) AS a,
+    (SELECT count() FROM t1_04653 LEFT JOIN t2_04653 ON t1_04653.x = t2_04653.x JOIN t3_04653 ON t2_04653.y = t3_04653.y AND t1_04653.z = t3_04653.z) AS b,
+    (SELECT count() FROM t1_04653 LEFT JOIN t2_04653 ON t1_04653.x = t2_04653.x JOIN t3_04653 ON t2_04653.y = t3_04653.y AND t1_04653.z = t3_04653.z) AS c
+SETTINGS query_plan_optimize_join_order_randomize = 1, query_plan_optimize_join_order_limit = 3, log_comment = '04653_cell_a';
+
+SYSTEM FLUSH LOGS query_log, text_log;
+
+SELECT 'cell A one seed per query', uniqExact(extract(message, 'seed (\\d+)')) = 1
+FROM system.text_log
+WHERE logger_name = 'QueryPlanOptimizationSettings'
+  AND message LIKE '%random seed%'
+  AND query_id IN (
+      SELECT query_id FROM system.query_log
+      WHERE log_comment = '04653_cell_a' AND type != 'QueryStart'
+        AND initial_query_id IN (
+            SELECT query_id FROM system.query_log
+            WHERE current_database = currentDatabase() AND log_comment = '04653_cell_a' AND is_initial_query));
+
+-- Cell A must be non-vacuous: the query really did construct more than one plan.
+SELECT 'cell A saw several plan constructions', count() > 1
+FROM system.text_log
+WHERE logger_name = 'QueryPlanOptimizationSettings'
+  AND message LIKE '%random seed%'
+  AND query_id IN (
+      SELECT query_id FROM system.query_log
+      WHERE log_comment = '04653_cell_a' AND type != 'QueryStart'
+        AND initial_query_id IN (
+            SELECT query_id FROM system.query_log
+            WHERE current_database = currentDatabase() AND log_comment = '04653_cell_a' AND is_initial_query));
+
+-- Cell B (must-not-change control): an explicit seed above 1 is still used verbatim, and different explicit
+-- seeds still produce different join orders, so the randomization keeps its coverage.
+SELECT count() FROM t1_04653 LEFT JOIN t2_04653 ON t1_04653.x = t2_04653.x JOIN t3_04653 ON t2_04653.y = t3_04653.y AND t1_04653.z = t3_04653.z
+SETTINGS query_plan_optimize_join_order_randomize = 12345, query_plan_optimize_join_order_limit = 3, log_comment = '04653_cell_b';
+
+SYSTEM FLUSH LOGS query_log, text_log;
+
+SELECT 'cell B explicit seed used verbatim', groupUniqArray(extract(message, 'seed (\\d+)')) = ['12345']
+FROM system.text_log
+WHERE logger_name = 'QueryPlanOptimizationSettings'
+  AND message LIKE '%random seed%'
+  AND query_id IN (
+      SELECT query_id FROM system.query_log
+      WHERE log_comment = '04653_cell_b' AND type != 'QueryStart'
+        AND initial_query_id IN (
+            SELECT query_id FROM system.query_log
+            WHERE current_database = currentDatabase() AND log_comment = '04653_cell_b' AND is_initial_query));
+
+-- The randomization must still explore different join orders, otherwise the fix would have silently turned the
+-- feature off. Seeds 2 and 3 are used because the chosen order is a hash of (seed, relation index, table name),
+-- so two arbitrary seeds can legitimately land on the same order for one particular set of table names: seeds
+-- 12345 and 54321 do exactly that here. Seeds 2 and 3 are verified to differ for these table names.
+SELECT 'cell B distinct seeds still reorder', (
+    SELECT groupArray(explain) FROM (
+        EXPLAIN PLAN SELECT count() FROM t1_04653 LEFT JOIN t2_04653 ON t1_04653.x = t2_04653.x JOIN t3_04653 ON t2_04653.y = t3_04653.y AND t1_04653.z = t3_04653.z
+        SETTINGS query_plan_optimize_join_order_randomize = 2, query_plan_optimize_join_order_limit = 3)
+    WHERE explain ILIKE '%ReadFromMergeTree%') != (
+    SELECT groupArray(explain) FROM (
+        EXPLAIN PLAN SELECT count() FROM t1_04653 LEFT JOIN t2_04653 ON t1_04653.x = t2_04653.x JOIN t3_04653 ON t2_04653.y = t3_04653.y AND t1_04653.z = t3_04653.z
+        SETTINGS query_plan_optimize_join_order_randomize = 3, query_plan_optimize_join_order_limit = 3)
+    WHERE explain ILIKE '%ReadFromMergeTree%');
+
+-- Cell B2 (must-not-change control): the default value 0 disables randomization entirely and is untouched.
+SELECT count() FROM t1_04653 LEFT JOIN t2_04653 ON t1_04653.x = t2_04653.x JOIN t3_04653 ON t2_04653.y = t3_04653.y AND t1_04653.z = t3_04653.z
+SETTINGS query_plan_optimize_join_order_randomize = 0, query_plan_optimize_join_order_limit = 3, log_comment = '04653_cell_b2';
+
+SYSTEM FLUSH LOGS query_log, text_log;
+
+SELECT 'cell B2 randomize=0 derives no seed', count() = 0
+FROM system.text_log
+WHERE logger_name = 'QueryPlanOptimizationSettings'
+  AND message LIKE '%random seed%'
+  AND query_id IN (
+      SELECT query_id FROM system.query_log
+      WHERE log_comment = '04653_cell_b2' AND type != 'QueryStart'
+        AND initial_query_id IN (
+            SELECT query_id FROM system.query_log
+            WHERE current_database = currentDatabase() AND log_comment = '04653_cell_b2' AND is_initial_query));
+
+-- Cell C: the parallel-replicas path this fixes. Every replica re-plans the query and must derive the same
+-- seed, so all of them choose the same join order and announce the same coordination mode.
+SET automatic_parallel_replicas_mode = 0;
+SET enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1;
+SET parallel_replicas_local_plan = 0;
+
+SELECT count() FROM (
+    SELECT t1_04653.x, t1_04653.z, t2_04653.x, t2_04653.y, t3_04653.y, t3_04653.z
+    FROM t1_04653 LEFT JOIN t2_04653 ON t1_04653.x = t2_04653.x
+    JOIN t3_04653 ON t2_04653.y = t3_04653.y AND t1_04653.z = t3_04653.z
+    ORDER BY ALL)
+SETTINGS query_plan_optimize_join_order_randomize = 1, query_plan_optimize_join_order_limit = 3, log_comment = '04653_cell_c';
+
+SYSTEM FLUSH LOGS query_log, text_log;
+
+SELECT 'cell C one seed across replicas', uniqExact(extract(message, 'seed (\\d+)')) = 1
+FROM system.text_log
+WHERE logger_name = 'QueryPlanOptimizationSettings'
+  AND message LIKE '%random seed%'
+  AND query_id IN (
+      SELECT query_id FROM system.query_log
+      WHERE log_comment = '04653_cell_c' AND type != 'QueryStart'
+        AND initial_query_id IN (
+            SELECT query_id FROM system.query_log
+            WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c' AND is_initial_query));
+
+-- Cell C must be non-vacuous: the query really did fan out to several replicas, each re-planning.
+SELECT 'cell C fanned out to several replicas', uniqExact(query_id) > 1
+FROM system.text_log
+WHERE logger_name = 'QueryPlanOptimizationSettings'
+  AND message LIKE '%random seed%'
+  AND query_id IN (
+      SELECT query_id FROM system.query_log
+      WHERE log_comment = '04653_cell_c' AND type != 'QueryStart'
+        AND initial_query_id IN (
+            SELECT query_id FROM system.query_log
+            WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c' AND is_initial_query));
+
+DROP TABLE t1_04653;
+DROP TABLE t2_04653;
+DROP TABLE t3_04653;

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
@@ -266,17 +266,31 @@ SETTINGS query_plan_optimize_join_order_randomize = 1, query_plan_optimize_join_
 
 SYSTEM FLUSH LOGS query_log, text_log;
 
-SELECT 'cell C2 serialized plan derives the same seed', uniqExact(query_id) >= 2
-FROM system.text_log
-WHERE logger_name = 'QueryPlanOptimizationSettings'
-  AND message LIKE '%random seed%'
-  AND extract(message, 'seed (\\d+)') = (
-      SELECT toString(greatest(sipHash64(query_id), 2))
-      FROM system.query_log
-      WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c2'
-        AND is_initial_query AND type != 'QueryStart'
-      ORDER BY event_time_microseconds DESC
-      LIMIT 1);
+-- The scope is the query, not the seed value: a seed-filtered population cannot observe a plan
+-- construction that derived a DIFFERENT seed, so it could never fail on the disagreement this change is
+-- about. Scoping by `initial_query_id` and comparing the whole set against the single derived value
+-- asserts both halves at once: the constructions agreed, and they agreed on the derived value.
+SELECT 'cell C2 serialized plan derives the same seed', (
+    SELECT groupUniqArray(extract(message, 'seed (\\d+)'))
+    FROM system.text_log
+    WHERE logger_name = 'QueryPlanOptimizationSettings'
+      AND message LIKE '%random seed%'
+      AND query_id IN (
+          SELECT query_id FROM system.query_log
+          WHERE log_comment = '04653_cell_c2' AND type != 'QueryStart'
+            AND initial_query_id = (
+                SELECT query_id FROM system.query_log
+                WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c2'
+                  AND is_initial_query AND type != 'QueryStart'
+                ORDER BY event_time_microseconds DESC
+                LIMIT 1))
+) = (
+    SELECT [toString(greatest(sipHash64(query_id), 2))]
+    FROM system.query_log
+    WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c2'
+      AND is_initial_query AND type != 'QueryStart'
+    ORDER BY event_time_microseconds DESC
+    LIMIT 1);
 
 DROP TABLE t1_04653;
 DROP TABLE t2_04653;

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
@@ -47,15 +47,20 @@ WHERE logger_name = 'QueryPlanOptimizationSettings'
   AND query_id IN (
       SELECT query_id FROM system.query_log
       WHERE log_comment = '04653_cell_a' AND type != 'QueryStart'
-        AND initial_query_id IN (
+        AND initial_query_id = (
             SELECT query_id FROM system.query_log
-            WHERE current_database = currentDatabase() AND log_comment = '04653_cell_a' AND is_initial_query));
+            WHERE current_database = currentDatabase() AND log_comment = '04653_cell_a'
+              AND is_initial_query AND type != 'QueryStart'
+            ORDER BY event_time_microseconds DESC
+            LIMIT 1));
 
 -- The seed must be the DERIVED value, not merely one value: a constant seed would also be unique within a
 -- query and across replicas.
--- `system.query_log` is server-global and append-only, so every expected-seed lookup below is ordered and takes
--- the NEWEST matching row: a stress thread runs with a fixed `--database`, so the same test can appear there
--- repeatedly and an unordered single-row pick could hash a previous run's query id.
+-- `system.query_log` is server-global and append-only, and the runner re-runs a failed test in the supplied
+-- database without cleaning it (a transient failure such as the global memory tracker firing is retried), so one
+-- database can hold several attempts of this test. Both the expected side and the observed side below are
+-- therefore scoped to the NEWEST initiator: an unscoped observed side would see one derived seed per attempt, and
+-- an unordered single-row pick on the expected side could hash a previous attempt's query id.
 SELECT 'cell A seed equals hash of initial query id', (
     SELECT groupUniqArray(extract(message, 'seed (\\d+)'))
     FROM system.text_log
@@ -64,9 +69,12 @@ SELECT 'cell A seed equals hash of initial query id', (
       AND query_id IN (
           SELECT query_id FROM system.query_log
           WHERE log_comment = '04653_cell_a' AND type != 'QueryStart'
-            AND initial_query_id IN (
+            AND initial_query_id = (
                 SELECT query_id FROM system.query_log
-                WHERE current_database = currentDatabase() AND log_comment = '04653_cell_a' AND is_initial_query))
+                WHERE current_database = currentDatabase() AND log_comment = '04653_cell_a'
+                  AND is_initial_query AND type != 'QueryStart'
+                ORDER BY event_time_microseconds DESC
+                LIMIT 1))
 ) = (
     SELECT [toString(greatest(sipHash64(query_id), 2))]
     FROM system.query_log
@@ -83,9 +91,12 @@ WHERE logger_name = 'QueryPlanOptimizationSettings'
   AND query_id IN (
       SELECT query_id FROM system.query_log
       WHERE log_comment = '04653_cell_a' AND type != 'QueryStart'
-        AND initial_query_id IN (
+        AND initial_query_id = (
             SELECT query_id FROM system.query_log
-            WHERE current_database = currentDatabase() AND log_comment = '04653_cell_a' AND is_initial_query));
+            WHERE current_database = currentDatabase() AND log_comment = '04653_cell_a'
+              AND is_initial_query AND type != 'QueryStart'
+            ORDER BY event_time_microseconds DESC
+            LIMIT 1));
 
 -- Cell B (must-not-change control): an explicit seed above 1 is still used verbatim, and different explicit
 -- seeds still produce different join orders, so the randomization keeps its coverage.
@@ -162,9 +173,12 @@ WHERE logger_name = 'QueryPlanOptimizationSettings'
   AND query_id IN (
       SELECT query_id FROM system.query_log
       WHERE log_comment = '04653_cell_c' AND type != 'QueryStart'
-        AND initial_query_id IN (
+        AND initial_query_id = (
             SELECT query_id FROM system.query_log
-            WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c' AND is_initial_query));
+            WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c'
+              AND is_initial_query AND type != 'QueryStart'
+            ORDER BY event_time_microseconds DESC
+            LIMIT 1));
 
 -- The replicas must have agreed on the DERIVED value, not merely on some value. Each replica has its own
 -- `query_id`, so hashing the initial one is what makes them agree.
@@ -176,9 +190,12 @@ SELECT 'cell C seed equals hash of initial query id', (
       AND query_id IN (
           SELECT query_id FROM system.query_log
           WHERE log_comment = '04653_cell_c' AND type != 'QueryStart'
-            AND initial_query_id IN (
+            AND initial_query_id = (
                 SELECT query_id FROM system.query_log
-                WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c' AND is_initial_query))
+                WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c'
+                  AND is_initial_query AND type != 'QueryStart'
+                ORDER BY event_time_microseconds DESC
+                LIMIT 1))
 ) = (
     SELECT [toString(greatest(sipHash64(query_id), 2))]
     FROM system.query_log
@@ -195,9 +212,12 @@ WHERE logger_name = 'QueryPlanOptimizationSettings'
   AND query_id IN (
       SELECT query_id FROM system.query_log
       WHERE log_comment = '04653_cell_c' AND type != 'QueryStart'
-        AND initial_query_id IN (
+        AND initial_query_id = (
             SELECT query_id FROM system.query_log
-            WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c' AND is_initial_query));
+            WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c'
+              AND is_initial_query AND type != 'QueryStart'
+            ORDER BY event_time_microseconds DESC
+            LIMIT 1));
 
 -- Cell C non-vacuity, part 1: more than one plan construction carried this query's derived seed.
 -- The scope is the seed value itself, computed from the initiator's own `query_log` row, which is

--- a/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
+++ b/tests/queries/0_stateless/04653_join_order_randomize_seed_stable.sql
@@ -179,8 +179,8 @@ SELECT 'cell C seed equals hash of initial query id', (
       AND is_initial_query AND type != 'QueryStart'
     LIMIT 1);
 
--- Cell C must be non-vacuous: the query really did fan out to several replicas, each re-planning.
-SELECT 'cell C fanned out to several replicas', uniqExact(query_id) > 1
+-- Cell C must be non-vacuous: the query really did construct more than one plan.
+SELECT 'cell C saw several plan constructions', uniqExact(query_id) > 1
 FROM system.text_log
 WHERE logger_name = 'QueryPlanOptimizationSettings'
   AND message LIKE '%random seed%'
@@ -190,6 +190,16 @@ WHERE logger_name = 'QueryPlanOptimizationSettings'
         AND initial_query_id IN (
             SELECT query_id FROM system.query_log
             WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c' AND is_initial_query));
+
+-- The configured fan-out really happened, read from the initiator's own accumulated counters so the assertion
+-- does not depend on when the replicas' own `query_log` rows become visible. `ParallelReplicasAvailableCount` is
+-- incremented once per replica that actually joined the query.
+SELECT 'cell C fanned out to three replicas', ProfileEvents['ParallelReplicasAvailableCount'] = 3
+FROM system.query_log
+WHERE current_database = currentDatabase() AND log_comment = '04653_cell_c'
+  AND is_initial_query AND type = 'QueryFinish'
+LIMIT 1
+SETTINGS enable_parallel_replicas = 0;
 
 DROP TABLE t1_04653;
 DROP TABLE t2_04653;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/106039
Related: https://github.com/ClickHouse/ClickHouse/pull/107567
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes `LOGICAL_ERROR: Coordination mode mismatch for stream` when a multi-way join runs under parallel replicas with `query_plan_optimize_join_order_randomize = 1`. The seed is now derived from the initial query id, so every query plan of one query, including the plans built by remote replicas, picks the same join order.


### Description

Reported on https://github.com/ClickHouse/ClickHouse/pull/107567 as STID `6117-68e9`, tracked by https://github.com/ClickHouse/ClickHouse/issues/106039: [CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107567&sha=8efcf363191f726c098a4952a3ceafeedb23daef&name_0=PR&name_1=Stress%20test%20%28arm_asan_ubsan%29).

`query_plan_optimize_join_order_randomize = 1` means "derive a random seed", but the substitution happened in the `QueryPlanOptimizationSettings` constructor while the session value stayed `1`. That constructor runs once per plan construction, and one query builds several plans: one per scalar subquery and, under parallel replicas, one per replica. A replica re-plans the query text it receives, and also re-optimizes a serialized plan, since `JoinStepLogical::serialize` does not encode the `optimized` flag. Each plan rolled its own seed.

The seed feeds `getRandomizedStats`, which replaces the relation statistics, so a different seed picks a different leftmost relation. `findReadingStep` descends only `children.front()`, so a different table receives `requestReadingInOrder` and announces a different `CoordinationMode` for one stream; `stream_to_coordinator` is keyed by table name alone, so the second announcement throws. The abort dump contains both preconditions.

The fix derives the seed from `initial_query_id`, which is stable for one query and reaches remote replicas in `ClientInfo`, so every plan of one query agrees on the seed. `0` (the default) and explicit seeds above `1` are untouched; an empty `initial_query_id`, which an internal or background plan carries, keeps the old random seed. The trade is deliberate: a query building several plans now explores one ordering instead of one per plan. Coverage across queries is retained because each gets a fresh id and so a fresh seed.

On a three-replica cluster one initial query id yields 3 distinct seeds before the fix and 1 after. The new test carries 13 assertions, of which 8 fail on unmodified master.

<details>
<summary>Validation matrix and remaining carriers</summary>

This removes one carrier of the class, not all: the process-global hash-table statistics cache and per-replica real statistics can also diverge join order without this setting. Both were inactive for the reported abort. Followed up separately.

The pre-fix binary is a pristine master build whose copy of the modified file is byte-identical to `origin/master`.

| measurement | pre-fix | post-fix |
|---|---|---|
| distinct seeds within one query id (2 plan constructions) | 2 (5 of 5 runs) | 1 (5 of 5 runs) |
| distinct seeds across 3 replica query ids of one initial query id | 3 (3 of 3 runs) | 1 |
| `count()` result, 3-way join under parallel replicas | 200 | 200 |
| new test via `clickhouse-test` | FAIL on 8 of its 13 assertions | pass |
| new test, repeated runs | n/a | 50 passed, 0 failed; 20 passed, 0 failed |

Mutation tests: reverting the derivation to `randomSeed` reddens 8 assertions; replacing the hash with a constant reddens 6 of those 8, leaving green only the two that assert a single seed rather than the derived one, so no assertion is satisfiable by an arbitrary constant. Lowering the fixture's replica count reddens the fan-out assertion alone; removing the join-swap pin reddens the reorder control alone; dropping the plan-serialization pin reddens the serialized-plan assertion alone. Removing the clamp that forces the derived value above 1 reddens nothing, as expected: it fires only when the hash is 0 or 1 (probability 2/2^64).

Must-not-change controls stay green in both arms: an explicit seed is still used verbatim, two distinct explicit seeds still produce different join orders, and `= 0` derives no seed.

The neighbouring parallel-replicas coordination tests, the carrier `04305_dpsub_outer_join`, and the join-order-reordering tests all pass. Every other failure in a wider local sweep reproduces byte-identically on the pristine binary and is a sandbox gap.

</details>