### PR TITLE
finalizeAggregation: throw a clean error on incompatible combined states

### DIFF
--- a/src/Functions/checkAggregateStateCanBeFinalized.h
+++ b/src/Functions/checkAggregateStateCanBeFinalized.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <AggregateFunctions/IAggregateFunction.h>
+#include <Columns/ColumnAggregateFunction.h>
+#include <DataTypes/IDataType.h>
+#include <Common/Exception.h>
+
+#include <string_view>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+}
+
+/// A column of aggregate states can hold states of a *different* function that shares the same state
+/// representation (e.g. `quantileState` vs `quantilesState`) but finalizes to another type. Report that
+/// as a normal error instead of tripping a logical error downstream when the column is finalized.
+inline void checkAggregateStateCanBeFinalized(
+    const ColumnAggregateFunction & column,
+    const DataTypePtr & expected_result_type,
+    std::string_view function_name)
+{
+    const auto & actual_result_type = column.getAggregateFunction()->getResultType();
+    if (!actual_result_type->equals(*expected_result_type))
+        throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+            "Cannot finalize state of function '{}': it finalizes to {}, but function '{}' is declared to "
+            "return {}. States of different aggregate functions that share a state representation cannot "
+            "be finalized together.",
+            column.getAggregateFunction()->getName(), actual_result_type->getName(),
+            function_name, expected_result_type->getName());
+}
+
+}

--- a/src/Functions/finalizeAggregation.cpp
+++ b/src/Functions/finalizeAggregation.cpp
@@ -1,7 +1,7 @@
 #include <Functions/IFunction.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
-#include <AggregateFunctions/IAggregateFunction.h>
+#include <Functions/checkAggregateStateCanBeFinalized.h>
 #include <DataTypes/DataTypeAggregateFunction.h>
 #include <Columns/ColumnAggregateFunction.h>
 #include <Common/typeid_cast.h>
@@ -65,17 +65,7 @@ public:
             throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of first argument of function {}",
                     arguments.at(0).column->getName(), getName());
 
-        /// The column can hold states of a *different* aggregate function that shares the same state
-        /// representation (e.g. 'quantileState' vs 'quantilesState', combined via UNION or arrayReduce)
-        /// but finalizes to a different type than declared. Report that rather than failing downstream.
-        const auto & actual_result_type = column_aggregate_function->getAggregateFunction()->getResultType();
-        if (!actual_result_type->equals(*result_type))
-            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                "Cannot finalize state of function '{}': the column holds a state finalizing to {}, "
-                "but the declared result type of '{}' is {}. This happens when states of different "
-                "aggregate functions that share a state representation are combined.",
-                column_aggregate_function->getAggregateFunction()->getName(),
-                actual_result_type->getName(), getName(), result_type->getName());
+        checkAggregateStateCanBeFinalized(*column_aggregate_function, result_type, getName());
 
         /// Column is copied here, because there is no guarantee that we own it.
         auto mut_column = IColumn::mutate(std::move(column));

--- a/src/Functions/finalizeAggregation.cpp
+++ b/src/Functions/finalizeAggregation.cpp
@@ -1,6 +1,7 @@
 #include <Functions/IFunction.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
+#include <AggregateFunctions/IAggregateFunction.h>
 #include <DataTypes/DataTypeAggregateFunction.h>
 #include <Columns/ColumnAggregateFunction.h>
 #include <Common/typeid_cast.h>
@@ -56,12 +57,25 @@ public:
         return type->getReturnType();
     }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t /*input_rows_count*/) const override
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t /*input_rows_count*/) const override
     {
         auto column = arguments.at(0).column;
-        if (!typeid_cast<const ColumnAggregateFunction *>(column.get()))
+        const auto * column_aggregate_function = typeid_cast<const ColumnAggregateFunction *>(column.get());
+        if (!column_aggregate_function)
             throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of first argument of function {}",
                     arguments.at(0).column->getName(), getName());
+
+        /// The column can hold states of a *different* aggregate function that shares the same state
+        /// representation (e.g. 'quantileState' vs 'quantilesState', combined via UNION or arrayReduce)
+        /// but finalizes to a different type than declared. Report that rather than failing downstream.
+        const auto & actual_result_type = column_aggregate_function->getAggregateFunction()->getResultType();
+        if (!actual_result_type->equals(*result_type))
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Cannot finalize state of function '{}': the column holds a state finalizing to {}, "
+                "but the declared result type of '{}' is {}. This happens when states of different "
+                "aggregate functions that share a state representation are combined.",
+                column_aggregate_function->getAggregateFunction()->getName(),
+                actual_result_type->getName(), getName(), result_type->getName());
 
         /// Column is copied here, because there is no guarantee that we own it.
         auto mut_column = IColumn::mutate(std::move(column));

--- a/src/Functions/runningAccumulate.cpp
+++ b/src/Functions/runningAccumulate.cpp
@@ -5,6 +5,7 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
 #include <Functions/IFunction.h>
+#include <Functions/checkAggregateStateCanBeFinalized.h>
 #include <Interpreters/Context.h>
 #include <Common/AlignedBuffer.h>
 #include <Common/Arena.h>
@@ -96,7 +97,7 @@ public:
         return type->getReturnType();
     }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t /*input_rows_count*/) const override
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t /*input_rows_count*/) const override
     {
         const ColumnAggregateFunction * column_with_states
             = typeid_cast<const ColumnAggregateFunction *>(&*arguments.at(0).column);
@@ -104,6 +105,8 @@ public:
         if (!column_with_states)
             throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of first argument of function {}",
                     arguments.at(0).column->getName(), getName());
+
+        checkAggregateStateCanBeFinalized(*column_with_states, result_type, getName());
 
         ColumnPtr column_with_groups;
 

--- a/tests/queries/0_stateless/04629_finalize_aggregation_mismatched_state.reference
+++ b/tests/queries/0_stateless/04629_finalize_aggregation_mismatched_state.reference
@@ -1,0 +1,9 @@
+-- single homogeneous state
+5
+-- UNION of the same function finalizes fine
+2
+3
+-- arrayReduce of a single function
+2
+-- a non-quantile state (sum) still finalizes
+6

--- a/tests/queries/0_stateless/04629_finalize_aggregation_mismatched_state.reference
+++ b/tests/queries/0_stateless/04629_finalize_aggregation_mismatched_state.reference
@@ -7,3 +7,5 @@
 2
 -- a non-quantile state (sum) still finalizes
 6
+-- runningAccumulate over a homogeneous state column still works
+5

--- a/tests/queries/0_stateless/04629_finalize_aggregation_mismatched_state.sql
+++ b/tests/queries/0_stateless/04629_finalize_aggregation_mismatched_state.sql
@@ -3,7 +3,8 @@
 -- representation) must raise a normal error, not an internal logical error / abort.
 -- https://github.com/ClickHouse/ClickHouse/issues/111193
 
--- Repro 1: brought together by a UNION.
+-- Repro 1: states of different functions brought together by a UNION (materialized branch).
+-- Reproduces under both the analyzer and `enable_analyzer = 0`.
 SELECT finalizeAggregation(s) FROM
 (
     SELECT quantileState(number) AS s FROM numbers(7)
@@ -11,13 +12,16 @@ SELECT finalizeAggregation(s) FROM
     SELECT quantilesState(0.9)(number) FROM numbers(5)
 ); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
--- Repro 2: without any UNION, via arrayReduce (from the issue).
+-- Repro 2 (from the issue): the non-UNION `arrayReduce`/`DISTINCT` path, which exercises different
+-- plumbing (the const aggregate-state / header path). It only reproduces with the analyzer, so it is
+-- pinned to `enable_analyzer = 1` to stay deterministic under the old-analyzer and random-settings jobs.
 SELECT DISTINCT finalizeAggregation(s) FROM
 (
     SELECT DISTINCT *, arrayReduce('quantilesState(0.9)', [65537]) AS s
     FROM (SELECT DISTINCT arrayReduce('quantileState(0.5)', [1048577]) AS s, 5e-324)
     LIMIT 1
-); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+)
+SETTINGS enable_analyzer = 1; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
 -- Positive cases: legitimate finalization still works.
 SELECT '-- single homogeneous state';
@@ -37,3 +41,19 @@ SELECT finalizeAggregation(arrayReduce('quantileState(0.5)', [1, 2, 3]));
 
 SELECT '-- a non-quantile state (sum) still finalizes';
 SELECT finalizeAggregation(arrayReduce('sumState', [1, 2, 3]));
+
+-- runningAccumulate shares the same header/runtime split and must reject the mismatch too.
+SET allow_deprecated_error_prone_window_functions = 1;
+
+SELECT runningAccumulate(s) FROM
+(
+    SELECT quantileState(number) AS s FROM numbers(7)
+    UNION ALL
+    SELECT quantilesState(0.9)(number) FROM numbers(5)
+); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- runningAccumulate is order-dependent, so assert only that a homogeneous state column still
+-- finalizes without error (row count), not the exact accumulated values, to stay deterministic
+-- under randomized settings.
+SELECT '-- runningAccumulate over a homogeneous state column still works';
+SELECT count() FROM (SELECT runningAccumulate(s) FROM (SELECT sumState(number) AS s FROM numbers(5) GROUP BY number));

--- a/tests/queries/0_stateless/04629_finalize_aggregation_mismatched_state.sql
+++ b/tests/queries/0_stateless/04629_finalize_aggregation_mismatched_state.sql
@@ -1,0 +1,39 @@
+-- Finalizing a column of aggregate states whose *actual* function finalizes to a different type
+-- than the column's declared type (e.g. `quantileState` vs `quantilesState`, which share a state
+-- representation) must raise a normal error, not an internal logical error / abort.
+-- https://github.com/ClickHouse/ClickHouse/issues/111193
+
+-- Repro 1: brought together by a UNION.
+SELECT finalizeAggregation(s) FROM
+(
+    SELECT quantileState(number) AS s FROM numbers(7)
+    UNION ALL
+    SELECT quantilesState(0.9)(number) FROM numbers(5)
+); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- Repro 2: without any UNION, via arrayReduce (from the issue).
+SELECT DISTINCT finalizeAggregation(s) FROM
+(
+    SELECT DISTINCT *, arrayReduce('quantilesState(0.9)', [65537]) AS s
+    FROM (SELECT DISTINCT arrayReduce('quantileState(0.5)', [1048577]) AS s, 5e-324)
+    LIMIT 1
+); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- Positive cases: legitimate finalization still works.
+SELECT '-- single homogeneous state';
+SELECT finalizeAggregation(quantileState(0.5)(number)) FROM numbers(11);
+
+SELECT '-- UNION of the same function finalizes fine';
+SELECT finalizeAggregation(s) FROM
+(
+    SELECT quantileState(0.5)(number) AS s FROM numbers(7)
+    UNION ALL
+    SELECT quantileState(0.5)(number) FROM numbers(5)
+)
+ORDER BY 1;
+
+SELECT '-- arrayReduce of a single function';
+SELECT finalizeAggregation(arrayReduce('quantileState(0.5)', [1, 2, 3]));
+
+SELECT '-- a non-quantile state (sum) still finalizes';
+SELECT finalizeAggregation(arrayReduce('sumState', [1, 2, 3]));


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/111193

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a logical error (which aborts in debug and sanitizer builds) when `finalizeAggregation` is applied to a column whose aggregate states come from different functions that share a state representation but finalize to different types — for example `quantileState` and `quantilesState(0.9)` brought together by a `UNION` or produced via `arrayReduce`. Such queries now raise a normal error instead of crashing.

---

### Root cause (for reviewers)

`finalizeAggregation` derives its return type from the argument column's **declared**
`DataTypeAggregateFunction` (e.g. `quantile` → `Float64`). But `ColumnAggregateFunction::convertToValues`
finalizes each row using the state's **actual** stored aggregate function. When a column holds states of
a *different* function that happens to share the same state representation (`quantileState` vs
`quantilesState`, unified by a `UNION` or produced by `arrayReduce`), the actual finalization type
(`Array(Float64)`) differs from the declared one (`Float64`). The produced column then failed the
return-type check in the pipeline with a `LOGICAL_ERROR`, aborting in debug/sanitizer builds.

### Fix

In `FunctionFinalizeAggregation::executeImpl`, compare the column's actual
`getAggregateFunction()->getResultType()` against the declared `result_type` and, on mismatch, throw a
normal `ILLEGAL_TYPE_OF_ARGUMENT` error naming both types — instead of returning a column that trips the
downstream logical error. This is confined to `finalizeAggregation` and does **not** touch type
unification (`getLeastSupertype`) or `DataTypeAggregateFunction::equals`, so it does not affect the
related `#111185` behaviour where such states are legitimately combined without finalization.

Both repros from the issue (the `UNION` one and the `arrayReduce`/`DISTINCT` one) now return a clean
error. Covered by `tests/queries/0_stateless/04629_finalize_aggregation_mismatched_state.sql`, which also
checks that legitimate finalization (single state, same-function UNION, `arrayReduce` of one function,
non-quantile states) still works.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.632` (included in `26.8` and later)
<!-- ch-version-info:end -->