### PR TITLE
Write Iceberg `optional` lists, maps and structs as OPTIONAL in the Parquet footer

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/PrepareForWrite.cpp
+++ b/src/Processors/Formats/Impl/Parquet/PrepareForWrite.cpp
@@ -11,6 +11,8 @@
 #include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnMap.h>
 #include <Core/Block.h>
+#include <DataTypes/NestedUtils.h>
+#include <Formats/FormatFilterInfo.h>
 #include <Common/Exception.h>
 #include <Common/WKB.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -124,6 +126,29 @@ void updateRepDefLevelsAndFilterColumnForNullable(ColumnChunkWriteState & s, con
     s.primitive_column = s.primitive_column->filter(filter, /*result_size_hint*/ -1);
 }
 
+/// Adds the definition level of a container group that is OPTIONAL in the Parquet schema but whose
+/// ClickHouse column cannot be null, so every value below it is present.
+///
+/// Must run AFTER updateRepDefLevelsForArray for array/map groups: that function encodes an empty
+/// container as definition level 0, and level 0 under an OPTIONAL ancestor means "container is null"
+/// to a reader. Incrementing afterwards shifts empty-but-present to 1 and leaves 0 free for null.
+void updateDefLevelsForAlwaysPresentOptionalGroup(ColumnChunkWriteState & s)
+{
+    assertNoDefOverflow(s);
+    ++s.max_def;
+
+    /// def is empty iff max_def was 0, so the 0 -> 1 transition has to materialize it.
+    if (s.max_def == 1)
+    {
+        chassert(s.def.empty());
+        s.def.resize_fill(s.primitive_column->size(), 1);
+        return;
+    }
+
+    for (auto & x : s.def)
+        ++x;
+}
+
 void updateRepDefLevelsForArray(ColumnChunkWriteState & s, const IColumn::Offsets & offsets)
 {
     /// Increment all definition levels.
@@ -228,9 +253,12 @@ parq::CompressionCodec::type compressionMethodToParquet(CompressionMethod c)
 }
 
 /// Depth-first traversal of the schema tree for this column.
+/// `column_path` is the dotted Iceberg field path of this node (t.x / arr.element / m.value), built
+/// with the same convention as ColumnMapper's producer; only the Iceberg optionality lookup uses it.
 void prepareColumnRecursive(
     ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
-    ColumnChunkWriteStates & states, SchemaElements & schemas, const std::optional<std::unordered_map<String, Int64>> & column_field_ids);
+    ColumnChunkWriteStates & states, SchemaElements & schemas, const std::optional<std::unordered_map<String, Int64>> & column_field_ids,
+    const String & column_path, const IcebergOptionality & iceberg_optionality);
 
 void preparePrimitiveColumn(ColumnPtr column, DataTypePtr type, const std::string & name,
     const WriteOptions & options, ColumnChunkWriteStates & states, SchemaElements & schemas, std::optional<Int64> field_id)
@@ -485,7 +513,8 @@ void preparePrimitiveColumn(ColumnPtr column, DataTypePtr type, const std::strin
 
 void prepareColumnNullable(
     ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
-    ColumnChunkWriteStates & states, SchemaElements & schemas, const std::optional<std::unordered_map<String, Int64>> & field_ids)
+    ColumnChunkWriteStates & states, SchemaElements & schemas, const std::optional<std::unordered_map<String, Int64>> & field_ids,
+    const String & column_path, const IcebergOptionality & iceberg_optionality)
 {
     const ColumnNullable * column_nullable = assert_cast<const ColumnNullable *>(column.get());
     ColumnPtr nested_column = column_nullable->getNestedColumnPtr();
@@ -495,7 +524,13 @@ void prepareColumnNullable(
     size_t child_states_begin = states.size();
     size_t child_schema_idx = schemas.size();
 
-    prepareColumnRecursive(nested_column, nested_type, name, options, states, schemas, field_ids);
+    /// Nullable is transparent in Iceberg field naming, so the nested node keeps the same dotted
+    /// path. Tell it that this Nullable already owns the OPTIONAL level for that path, so a container
+    /// below does not add a second one (which would also push us into the "nullable" wrapper branch
+    /// below and rewrite path_in_schema).
+    IcebergOptionality nested_optionality = iceberg_optionality;
+    nested_optionality.owned_by_enclosing_nullable = true;
+    prepareColumnRecursive(nested_column, nested_type, name, options, states, schemas, field_ids, column_path, nested_optionality);
 
     if (schemas[child_schema_idx].repetition_type == parq::FieldRepetitionType::REQUIRED)
     {
@@ -546,7 +581,8 @@ std::optional<std::unordered_map<String, Int64>> buildSubFieldIds(
 
 void prepareColumnTuple(
     ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
-    ColumnChunkWriteStates & states, SchemaElements & schemas, const std::optional<std::unordered_map<String, Int64>> & column_field_ids = std::nullopt)
+    ColumnChunkWriteStates & states, SchemaElements & schemas, const std::optional<std::unordered_map<String, Int64>> & column_field_ids,
+    const String & column_path, const IcebergOptionality & iceberg_optionality)
 {
     const auto * column_tuple = assert_cast<const ColumnTuple *>(column.get());
     const auto * type_tuple = assert_cast<const DataTypeTuple *>(type.get());
@@ -558,8 +594,10 @@ void prepareColumnTuple(
     if (num_elements == 0)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parquet doesn't support empty tuples");
 
+    const bool optional = iceberg_optionality.isOptional(column_path);
+
     auto & tuple_schema = schemas.emplace_back();
-    tuple_schema.__set_repetition_type(parq::FieldRepetitionType::REQUIRED);
+    tuple_schema.__set_repetition_type(optional ? parq::FieldRepetitionType::OPTIONAL : parq::FieldRepetitionType::REQUIRED);
     tuple_schema.__set_name(name);
     tuple_schema.__set_num_children(static_cast<Int32>(num_elements));
     if (column_field_ids)
@@ -572,20 +610,32 @@ void prepareColumnTuple(
     size_t child_states_begin = states.size();
 
     auto sub_field_ids = buildSubFieldIds(column_field_ids, name);
+    /// Children sit at their own dotted paths, which no enclosing Nullable owns.
+    IcebergOptionality child_optionality = iceberg_optionality;
+    child_optionality.owned_by_enclosing_nullable = false;
     for (size_t i = 0; i < num_elements; ++i)
-        prepareColumnRecursive(column_tuple->getColumnPtr(i), type_tuple->getElement(i), type_tuple->getNameByPosition(i + 1), options, states, schemas, sub_field_ids);
+    {
+        const auto & element_name = type_tuple->getNameByPosition(i + 1);
+        prepareColumnRecursive(
+            column_tuple->getColumnPtr(i), type_tuple->getElement(i), element_name, options, states, schemas, sub_field_ids,
+            Nested::concatenateName(column_path, element_name), child_optionality);
+    }
 
     for (size_t i = child_states_begin; i < states.size(); ++i)
     {
         Strings & path = states[i].column_chunk.meta_data.path_in_schema;
         /// O(nesting_depth^2), but who cares.
         path.insert(path.begin(), name);
+
+        if (optional)
+            updateDefLevelsForAlwaysPresentOptionalGroup(states[i]);
     }
 }
 
 void prepareColumnArray(
     ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
-    ColumnChunkWriteStates & states, SchemaElements & schemas, const std::optional<std::unordered_map<String, Int64>> & column_field_ids = std::nullopt)
+    ColumnChunkWriteStates & states, SchemaElements & schemas, const std::optional<std::unordered_map<String, Int64>> & column_field_ids,
+    const String & column_path, const IcebergOptionality & iceberg_optionality)
 {
     const auto * column_array = assert_cast<const ColumnArray *>(column.get());
     ColumnPtr nested_column = column_array->getDataPtr();
@@ -605,7 +655,9 @@ void prepareColumnArray(
     auto & list_schema = schemas[schemas.size() - 2];
     auto & item_schema = schemas[schemas.size() - 1];
 
-    list_schema.__set_repetition_type(parq::FieldRepetitionType::REQUIRED);
+    const bool optional = iceberg_optionality.isOptional(column_path);
+
+    list_schema.__set_repetition_type(optional ? parq::FieldRepetitionType::OPTIONAL : parq::FieldRepetitionType::REQUIRED);
     list_schema.__set_name(name);
     list_schema.__set_num_children(1);
     list_schema.__set_converted_type(parq::ConvertedType::LIST);
@@ -625,8 +677,12 @@ void prepareColumnArray(
     std::array<std::string, 2> path_prefix = {list_schema.name, item_schema.name};
     size_t child_states_begin = states.size();
 
-    /// Recurse.
-    prepareColumnRecursive(nested_column, nested_type, "element", options, states, schemas, buildSubFieldIds(column_field_ids, name));
+    /// Recurse. The element sits at its own dotted path, which no enclosing Nullable owns.
+    IcebergOptionality child_optionality = iceberg_optionality;
+    child_optionality.owned_by_enclosing_nullable = false;
+    prepareColumnRecursive(
+        nested_column, nested_type, "element", options, states, schemas, buildSubFieldIds(column_field_ids, name),
+        Nested::concatenateName(column_path, "element"), child_optionality);
 
     /// Update repetition+definition levels and fully-qualified column names (x -> myarray.list.x).
     for (size_t i = child_states_begin; i < states.size(); ++i)
@@ -635,12 +691,18 @@ void prepareColumnArray(
         path.insert(path.begin(), path_prefix.begin(), path_prefix.end());
 
         updateRepDefLevelsForArray(states[i], offsets);
+
+        /// Strictly after updateRepDefLevelsForArray: it encodes an empty array as level 0, which
+        /// under an OPTIONAL group would read back as a null array instead of an empty one.
+        if (optional)
+            updateDefLevelsForAlwaysPresentOptionalGroup(states[i]);
     }
 }
 
 void prepareColumnMap(
     ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
-    ColumnChunkWriteStates & states, SchemaElements & schemas, const std::optional<std::unordered_map<String, Int64>> & column_field_ids = std::nullopt)
+    ColumnChunkWriteStates & states, SchemaElements & schemas, const std::optional<std::unordered_map<String, Int64>> & column_field_ids,
+    const String & column_path, const IcebergOptionality & iceberg_optionality)
 {
     const auto * column_map = assert_cast<const ColumnMap *>(column.get());
     const auto * column_array = &column_map->getNestedColumn();
@@ -657,8 +719,10 @@ void prepareColumnMap(
     ///     reqiured <...> "key"
     ///     <...> "value"
 
+    const bool optional = iceberg_optionality.isOptional(column_path);
+
     auto & map_schema = schemas.emplace_back();
-    map_schema.__set_repetition_type(parq::FieldRepetitionType::REQUIRED);
+    map_schema.__set_repetition_type(optional ? parq::FieldRepetitionType::OPTIONAL : parq::FieldRepetitionType::REQUIRED);
     map_schema.__set_name(name);
     map_schema.__set_num_children(1);
     map_schema.__set_converted_type(parq::ConvertedType::MAP);
@@ -680,8 +744,16 @@ void prepareColumnMap(
     size_t child_states_begin = states.size();
     auto child_field_ids = buildSubFieldIds(column_field_ids, name);
     const auto * column_tuple_typed = assert_cast<const ColumnTuple *>(column_tuple.get());
-    prepareColumnRecursive(column_tuple_typed->getColumnPtr(0), map_type->getKeyType(), "key", options, states, schemas, child_field_ids);
-    prepareColumnRecursive(column_tuple_typed->getColumnPtr(1), map_type->getValueType(), "value", options, states, schemas, child_field_ids);
+    /// Key/value sit at their own dotted paths, which no enclosing Nullable owns. A map key is
+    /// always required per the Iceberg spec, and the producer forces that, so the lookup declines it.
+    IcebergOptionality child_optionality = iceberg_optionality;
+    child_optionality.owned_by_enclosing_nullable = false;
+    prepareColumnRecursive(
+        column_tuple_typed->getColumnPtr(0), map_type->getKeyType(), "key", options, states, schemas, child_field_ids,
+        Nested::concatenateName(column_path, "key"), child_optionality);
+    prepareColumnRecursive(
+        column_tuple_typed->getColumnPtr(1), map_type->getValueType(), "value", options, states, schemas, child_field_ids,
+        Nested::concatenateName(column_path, "value"), child_optionality);
 
     for (size_t i = child_states_begin; i < states.size(); ++i)
     {
@@ -690,6 +762,10 @@ void prepareColumnMap(
         path.insert(path.begin(), name);
 
         updateRepDefLevelsForArray(states[i], offsets);
+
+        /// Strictly after updateRepDefLevelsForArray, for the same reason as in prepareColumnArray.
+        if (optional)
+            updateDefLevelsForAlwaysPresentOptionalGroup(states[i]);
     }
 }
 
@@ -762,7 +838,8 @@ void validateIcebergFieldIds(
 
 void prepareColumnRecursive(
     ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
-    ColumnChunkWriteStates & states, SchemaElements & schemas, const std::optional<std::unordered_map<String, Int64>> & column_field_ids)
+    ColumnChunkWriteStates & states, SchemaElements & schemas, const std::optional<std::unordered_map<String, Int64>> & column_field_ids,
+    const String & column_path, const IcebergOptionality & iceberg_optionality)
 {
     /// Remove const and sparse but leave LowCardinality as the encoder can directly use it for
     /// parquet dictionary-encoding.
@@ -770,16 +847,16 @@ void prepareColumnRecursive(
 
     switch (type->getTypeId())
     {
-        case TypeIndex::Nullable: prepareColumnNullable(column, type, name, options, states, schemas, column_field_ids); break;
-        case TypeIndex::Array: prepareColumnArray(column, type, name, options, states, schemas, column_field_ids); break;
-        case TypeIndex::Tuple: prepareColumnTuple(column, type, name, options, states, schemas, column_field_ids); break;
-        case TypeIndex::Map: prepareColumnMap(column, type, name, options, states, schemas, column_field_ids); break;
+        case TypeIndex::Nullable: prepareColumnNullable(column, type, name, options, states, schemas, column_field_ids, column_path, iceberg_optionality); break;
+        case TypeIndex::Array: prepareColumnArray(column, type, name, options, states, schemas, column_field_ids, column_path, iceberg_optionality); break;
+        case TypeIndex::Tuple: prepareColumnTuple(column, type, name, options, states, schemas, column_field_ids, column_path, iceberg_optionality); break;
+        case TypeIndex::Map: prepareColumnMap(column, type, name, options, states, schemas, column_field_ids, column_path, iceberg_optionality); break;
         case TypeIndex::LowCardinality:
         {
             auto nested_type = assert_cast<const DataTypeLowCardinality &>(*type).getDictionaryType();
             if (nested_type->isNullable())
                 prepareColumnNullable(
-                    column->convertToFullColumnIfLowCardinality(), nested_type, name, options, states, schemas, column_field_ids);
+                    column->convertToFullColumnIfLowCardinality(), nested_type, name, options, states, schemas, column_field_ids, column_path, iceberg_optionality);
             else
                 /// Use nested data type, but keep ColumnLowCardinality. The encoder can deal with it.
                 preparePrimitiveColumn(column, nested_type, name, options, states, schemas, lookupLeafFieldId(column_field_ids, name));
@@ -793,7 +870,20 @@ void prepareColumnRecursive(
 
 }
 
-SchemaElements convertSchema(const Block & sample, const WriteOptions & options, const std::optional<std::unordered_map<String, Int64>> & column_field_ids)
+bool IcebergOptionality::isOptional(const String & path) const
+{
+    /// No mapper, or a mapper that carries only field ids / string paths: keep today's behavior.
+    /// This fallback is load-bearing, not defensive: Iceberg position-delete writes build such a
+    /// mapper (Mutations.cpp) and must keep emitting required containers.
+    if (!mapper || !mapper->hasIcebergRequiredInfo())
+        return false;
+    /// An enclosing Nullable already supplies the OPTIONAL level for this same path.
+    if (owned_by_enclosing_nullable)
+        return false;
+    return mapper->isIcebergOptionalPath(path);
+}
+
+SchemaElements convertSchema(const Block & sample, const WriteOptions & options, const std::optional<std::unordered_map<String, Int64>> & column_field_ids, const IcebergOptionality & iceberg_optionality)
 {
     SchemaElements schema;
     auto & root = schema.emplace_back();
@@ -808,7 +898,7 @@ SchemaElements convertSchema(const Block & sample, const WriteOptions & options,
         if (column_field_ids)
             validateIcebergFieldIds(c.type, c.name, *column_field_ids);
 
-        prepareColumnForWrite(c.column, c.type, c.name, options, nullptr, &schema, column_field_ids);
+        prepareColumnForWrite(c.column, c.type, c.name, options, nullptr, &schema, column_field_ids, iceberg_optionality);
     }
 
     return schema;
@@ -904,7 +994,8 @@ static void prepareGeoColumn(ColumnPtr & column, DataTypePtr & type)
 
 void prepareColumnForWrite(
     ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
-    ColumnChunkWriteStates * out_columns_to_write, SchemaElements * out_schema, const std::optional<std::unordered_map<String, Int64>> & column_field_ids)
+    ColumnChunkWriteStates * out_columns_to_write, SchemaElements * out_schema, const std::optional<std::unordered_map<String, Int64>> & column_field_ids,
+    const IcebergOptionality & iceberg_optionality)
 {
     if (column->empty() && out_columns_to_write != nullptr)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty column passed to Parquet encoder");
@@ -913,7 +1004,7 @@ void prepareColumnForWrite(
     SchemaElements schemas;
     if (options.write_geometadata)
         prepareGeoColumn(column, type);
-    prepareColumnRecursive(column, type, name, options, states, schemas, column_field_ids);
+    prepareColumnRecursive(column, type, name, options, states, schemas, column_field_ids, name, iceberg_optionality);
 
     if (out_columns_to_write)
         for (auto & s : states)

--- a/src/Processors/Formats/Impl/Parquet/Write.h
+++ b/src/Processors/Formats/Impl/Parquet/Write.h
@@ -10,6 +10,7 @@
 namespace DB
 {
 class Block;
+class ColumnMapper;
 }
 
 namespace DB::Parquet
@@ -70,6 +71,21 @@ struct WriteOptions
     size_t bloom_filter_flush_threshold_bytes = 1024 * 1024 * 128;
 
     bool write_geometadata = true;
+};
+
+/// Iceberg optionality of complex containers, which is not recoverable from the ClickHouse type:
+/// Array/Map are never wrapped in Nullable, so an Iceberg `optional` list/map/struct arrives here as
+/// a plain container. `mapper == nullptr` (or a mapper without this info) means "no Iceberg info",
+/// in which case the writer keeps its type-derived behavior.
+struct IcebergOptionality
+{
+    const ColumnMapper * mapper = nullptr;
+    /// True while an enclosing Nullable already supplies the OPTIONAL level for this exact path.
+    /// Nullable is transparent in Iceberg field naming, so the container below it sees the same
+    /// dotted path and must not add a second OPTIONAL level.
+    bool owned_by_enclosing_nullable = false;
+
+    bool isOptional(const String & path) const;
 };
 
 struct ColumnChunkIndexes
@@ -168,11 +184,15 @@ using ColumnChunkWriteStates = std::vector<ColumnChunkWriteState>;
 /// Parquet schema is a tree of SchemaElements, flattened into a list in depth-first order.
 /// Leaf nodes correspond to physical columns of primitive types. Inner nodes describe logical
 /// groupings of those columns, e.g. tuples or structs.
-SchemaElements convertSchema(const Block & sample, const WriteOptions & options, const std::optional<std::unordered_map<String, Int64>> & column_field_ids);
+SchemaElements convertSchema(const Block & sample, const WriteOptions & options, const std::optional<std::unordered_map<String, Int64>> & column_field_ids, const IcebergOptionality & iceberg_optionality = {});
 
+/// `iceberg_optionality` must be passed identically on the schema and the data path: the reader
+/// derives its max definition level from the schema while the writer derives the level bit width
+/// from the state produced here, so a schema-only change would desynchronize them.
 void prepareColumnForWrite(
     ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
-    ColumnChunkWriteStates * out_columns_to_write, SchemaElements * out_schema = nullptr, const std::optional<std::unordered_map<String, Int64>> & column_field_ids = std::nullopt);
+    ColumnChunkWriteStates * out_columns_to_write, SchemaElements * out_schema = nullptr, const std::optional<std::unordered_map<String, Int64>> & column_field_ids = std::nullopt,
+    const IcebergOptionality & iceberg_optionality = {});
 
 void writeFileHeader(FileWriteState & file, WriteBuffer & out);
 

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
@@ -61,9 +61,16 @@ ParquetBlockOutputFormat::ParquetBlockOutputFormat(WriteBuffer & out_, SharedHea
     options.use_dictionary_encoding = options.max_dictionary_size > 0;
 
     if (format_filter_info_ && format_filter_info_->column_mapper)
-        schema = convertSchema(*header_, options, format_filter_info_->column_mapper->getStorageColumnEncoding());
+    {
+        /// The mapper outlives this format (and the encoder threads) via format_filter_info.
+        /// It has to be consulted identically here and on the data paths below: the reader takes its
+        /// max definition level from the schema, while the writer takes the level bit width from the
+        /// state the data path builds, so the two would desynchronize.
+        iceberg_optionality.mapper = format_filter_info_->column_mapper.get();
+        schema = convertSchema(*header_, options, format_filter_info_->column_mapper->getStorageColumnEncoding(), iceberg_optionality);
+    }
     else
-        schema = convertSchema(*header_, options, std::nullopt);
+        schema = convertSchema(*header_, options, std::nullopt, iceberg_optionality);
 }
 
 ParquetBlockOutputFormat::~ParquetBlockOutputFormat()
@@ -254,7 +261,7 @@ void ParquetBlockOutputFormat::writeRowGroupInOneThread(Chunk chunk)
     for (size_t i = 0; i < header.columns(); ++i)
         prepareColumnForWrite(
             chunk.getColumns()[i], header.getByPosition(i).type, header.getByPosition(i).name,
-            options, &columns_to_write);
+            options, &columns_to_write, /*out_schema*/ nullptr, /*column_field_ids*/ std::nullopt, iceberg_optionality);
 
     if (file_state.offset == 0)
     {
@@ -412,7 +419,8 @@ void ParquetBlockOutputFormat::threadFunction()
 
             std::vector<ColumnChunkWriteState> subcolumns;
             prepareColumnForWrite(
-                std::move(concatenated), task.column_type, task.column_name, options, &subcolumns);
+                std::move(concatenated), task.column_type, task.column_name, options, &subcolumns,
+                /*out_schema*/ nullptr, /*column_field_ids*/ std::nullopt, iceberg_optionality);
 
             lock.lock();
 

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.h
@@ -115,6 +115,8 @@ private:
     size_t staging_bytes = 0;
 
     Parquet::WriteOptions options;
+    /// Filled in by the ctor and read-only afterwards, so the encoder threads can share it.
+    Parquet::IcebergOptionality iceberg_optionality;
     Parquet::SchemaElements schema;
     Parquet::FileWriteState file_state;
     size_t base_offset = 0; // initial out.count(), just for assert

--- a/tests/queries/0_stateless/04653_iceberg_parquet_optional_complex.reference
+++ b/tests/queries/0_stateless/04653_iceberg_parquet_optional_complex.reference
@@ -1,0 +1,70 @@
+--- half A: containers required in the Iceberg schema stay REQUIRED (parallel_encoding=0) ---
+leaf arr.list.element         maxdef=1 maxrep=1
+leaf m.key_value.key          maxdef=1 maxrep=1
+leaf m.key_value.value        maxdef=1 maxrep=1
+leaf st.a                     maxdef=0 maxrep=0
+leaf nst.list.element.b       maxdef=1 maxrep=1
+leaf ns.c                     maxdef=1 maxrep=0
+leaf nq.inner.list.element    maxdef=2 maxrep=1
+leaf sc                       maxdef=1 maxrep=0
+data arr  [[1, 2], []]
+data m    [[('k', 1)], []]
+data st   [{'a': 7}, {'a': 8}]
+data nst  [[{'b': 3}], []]
+data ns   [{'c': 9}, {'c': 0}]
+data nq   [{'inner': [4]}, {'inner': []}]
+data sc   [5, None]
+--- half B: optional containers become OPTIONAL (parallel_encoding=0) ---
+leaf arr.list.element         maxdef=2 maxrep=1
+leaf m.key_value.key          maxdef=2 maxrep=1
+leaf m.key_value.value        maxdef=2 maxrep=1
+leaf st.a                     maxdef=1 maxrep=0
+leaf nst.list.element.b       maxdef=2 maxrep=1
+leaf ns.c                     maxdef=1 maxrep=0
+leaf nq.inner.list.element    maxdef=3 maxrep=1
+leaf sc                       maxdef=1 maxrep=0
+data arr  [[1, 2], []]
+data m    [[('k', 1)], []]
+data st   [{'a': 7}, {'a': 8}]
+data nst  [[{'b': 3}], []]
+data ns   [{'c': 9}, {'c': 0}]
+data nq   [{'inner': [4]}, {'inner': []}]
+data sc   [5, None]
+--- half B: values round-trip through ClickHouse (parallel_encoding=0) ---
+[1,2]	{'k':1}	(7)	[(3)]	(9)	([4])	5
+[]	{}	(8)	[]	(0)	([])	\N
+--- half A: containers required in the Iceberg schema stay REQUIRED (parallel_encoding=1) ---
+leaf arr.list.element         maxdef=1 maxrep=1
+leaf m.key_value.key          maxdef=1 maxrep=1
+leaf m.key_value.value        maxdef=1 maxrep=1
+leaf st.a                     maxdef=0 maxrep=0
+leaf nst.list.element.b       maxdef=1 maxrep=1
+leaf ns.c                     maxdef=1 maxrep=0
+leaf nq.inner.list.element    maxdef=2 maxrep=1
+leaf sc                       maxdef=1 maxrep=0
+data arr  [[1, 2], []]
+data m    [[('k', 1)], []]
+data st   [{'a': 7}, {'a': 8}]
+data nst  [[{'b': 3}], []]
+data ns   [{'c': 9}, {'c': 0}]
+data nq   [{'inner': [4]}, {'inner': []}]
+data sc   [5, None]
+--- half B: optional containers become OPTIONAL (parallel_encoding=1) ---
+leaf arr.list.element         maxdef=2 maxrep=1
+leaf m.key_value.key          maxdef=2 maxrep=1
+leaf m.key_value.value        maxdef=2 maxrep=1
+leaf st.a                     maxdef=1 maxrep=0
+leaf nst.list.element.b       maxdef=2 maxrep=1
+leaf ns.c                     maxdef=1 maxrep=0
+leaf nq.inner.list.element    maxdef=3 maxrep=1
+leaf sc                       maxdef=1 maxrep=0
+data arr  [[1, 2], []]
+data m    [[('k', 1)], []]
+data st   [{'a': 7}, {'a': 8}]
+data nst  [[{'b': 3}], []]
+data ns   [{'c': 9}, {'c': 0}]
+data nq   [{'inner': [4]}, {'inner': []}]
+data sc   [5, None]
+--- half B: values round-trip through ClickHouse (parallel_encoding=1) ---
+[1,2]	{'k':1}	(7)	[(3)]	(9)	([4])	5
+[]	{}	(8)	[]	(0)	([])	\N

--- a/tests/queries/0_stateless/04653_iceberg_parquet_optional_complex.reference
+++ b/tests/queries/0_stateless/04653_iceberg_parquet_optional_complex.reference
@@ -7,6 +7,17 @@ leaf nst.list.element.b       maxdef=1 maxrep=1
 leaf ns.c                     maxdef=1 maxrep=0
 leaf nq.inner.list.element    maxdef=2 maxrep=1
 leaf sc                       maxdef=1 maxrep=0
+node arr              optional=False
+node arr.element      optional=False
+node m                optional=False
+node m.key            optional=False
+node m.value          optional=False
+node st               optional=False
+node nst              optional=False
+node nst.element      optional=False
+node nq               optional=True
+node nq.inner         optional=False
+node sc               optional=True
 data arr  [[1, 2], []]
 data m    [[('k', 1)], []]
 data st   [{'a': 7}, {'a': 8}]
@@ -23,6 +34,17 @@ leaf nst.list.element.b       maxdef=2 maxrep=1
 leaf ns.c                     maxdef=1 maxrep=0
 leaf nq.inner.list.element    maxdef=3 maxrep=1
 leaf sc                       maxdef=1 maxrep=0
+node arr              optional=True
+node arr.element      optional=False
+node m                optional=True
+node m.key            optional=False
+node m.value          optional=False
+node st               optional=True
+node nst              optional=False
+node nst.element      optional=True
+node nq               optional=True
+node nq.inner         optional=True
+node sc               optional=True
 data arr  [[1, 2], []]
 data m    [[('k', 1)], []]
 data st   [{'a': 7}, {'a': 8}]
@@ -42,6 +64,17 @@ leaf nst.list.element.b       maxdef=1 maxrep=1
 leaf ns.c                     maxdef=1 maxrep=0
 leaf nq.inner.list.element    maxdef=2 maxrep=1
 leaf sc                       maxdef=1 maxrep=0
+node arr              optional=False
+node arr.element      optional=False
+node m                optional=False
+node m.key            optional=False
+node m.value          optional=False
+node st               optional=False
+node nst              optional=False
+node nst.element      optional=False
+node nq               optional=True
+node nq.inner         optional=False
+node sc               optional=True
 data arr  [[1, 2], []]
 data m    [[('k', 1)], []]
 data st   [{'a': 7}, {'a': 8}]
@@ -58,6 +91,17 @@ leaf nst.list.element.b       maxdef=2 maxrep=1
 leaf ns.c                     maxdef=1 maxrep=0
 leaf nq.inner.list.element    maxdef=3 maxrep=1
 leaf sc                       maxdef=1 maxrep=0
+node arr              optional=True
+node arr.element      optional=False
+node m                optional=True
+node m.key            optional=False
+node m.value          optional=False
+node st               optional=True
+node nst              optional=False
+node nst.element      optional=True
+node nq               optional=True
+node nq.inner         optional=True
+node sc               optional=True
 data arr  [[1, 2], []]
 data m    [[('k', 1)], []]
 data st   [{'a': 7}, {'a': 8}]

--- a/tests/queries/0_stateless/04653_iceberg_parquet_optional_complex.sh
+++ b/tests/queries/0_stateless/04653_iceberg_parquet_optional_complex.sh
@@ -6,9 +6,9 @@
 # (list/map/struct) was written to Parquet with `FieldRepetitionType::REQUIRED`, because
 # Array/Map are never wrapped in `Nullable` in the ClickHouse type, so the optionality is
 # not recoverable from the type and the Parquet writer never consulted the per-path Iceberg
-# metadata the ORC writer already uses. The footer then contradicted the Iceberg schema
-# published by the same commit, which spec-compliant external readers (Spark, Trino,
-# pyiceberg) reject.
+# metadata the ORC writer already uses. A `REQUIRED` group cannot encode a null container, so a
+# null list/map/struct was silently read back as an empty one, and the footer contradicted the
+# Iceberg schema published by the same commit.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -27,7 +27,7 @@ trap 'rm -rf "${USER_FILES_PATH}/${BASE}"* 2>/dev/null' EXIT
 # The `node` lines are what localize the level: a leaf's `maxdef` counts the nullable ancestors
 # along its whole chain and therefore cannot say WHICH ancestor contributed, so it reads the same
 # whether the container group or a node beneath it carries the OPTIONAL. Which node carries it is
-# the property an external Iceberg reader validates against the published schema.
+# what has to match the published Iceberg schema.
 read -r -d '' PROBE <<'PY'
 import glob, sys
 import pyarrow.parquet as pq

--- a/tests/queries/0_stateless/04653_iceberg_parquet_optional_complex.sh
+++ b/tests/queries/0_stateless/04653_iceberg_parquet_optional_complex.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# - no-fasttest: requires `IcebergLocal` (USE_AVRO build option) and python3 pyarrow.
+#
+# An Iceberg field marked `"required": false` whose type is a complex container
+# (list/map/struct) was written to Parquet with `FieldRepetitionType::REQUIRED`, because
+# Array/Map are never wrapped in `Nullable` in the ClickHouse type, so the optionality is
+# not recoverable from the type and the Parquet writer never consulted the per-path Iceberg
+# metadata the ORC writer already uses. The footer then contradicted the Iceberg schema
+# published by the same commit, which spec-compliant external readers (Spark, Trino,
+# pyiceberg) reject.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+BASE="t_${CLICKHOUSE_DATABASE}_${RANDOM}_pq_opt"
+
+trap 'rm -rf "${USER_FILES_PATH}/${BASE}"* 2>/dev/null' EXIT
+
+# Reports the repetition type per leaf, plus the values as an external reader sees them.
+# pyarrow is the oracle for the definition levels: unlike ParquetMetadata's per-column
+# `max_definition_level`, it distinguishes a present-but-empty container (`[]`) from a null
+# one (`None`), which is what pins the definition level of the new OPTIONAL group relative
+# to the array's own level. ClickHouse's own reader normalizes a null container to an empty
+# one, so a round-trip through ClickHouse cannot see that distinction.
+read -r -d '' PROBE <<'PY'
+import glob, sys
+import pyarrow.parquet as pq
+for fn in sorted(glob.glob(sys.argv[1] + '/data/*.parquet')):
+    f = pq.ParquetFile(fn)
+    schema = f.schema
+    for i in range(len(schema)):
+        c = schema.column(i)
+        print('leaf %-24s maxdef=%d maxrep=%d' % (c.path, c.max_definition_level, c.max_repetition_level))
+    table = f.read()
+    for name in table.column_names:
+        print('data %-4s %s' % (name, table.column(name).to_pylist()))
+PY
+
+# Marks the complex fields optional in a new schema version, the way another engine would.
+# An optional top-level list/map is not producible by our own CREATE (getIcebergType returns
+# required=true for Array/Map), so the metadata has to be authored externally. `nst` stays a
+# required list whose *element* becomes optional: that nested case is what proves the dotted
+# path is accumulated correctly rather than only matched at the top level.
+read -r -d '' MARK_OPTIONAL <<'PY'
+import glob, json, os, sys
+md = sys.argv[1]
+versions = sorted(glob.glob(os.path.join(md, 'v*.metadata.json')),
+                  key=lambda p: int(os.path.basename(p)[1:].split('.')[0]))
+current = versions[-1]
+n = int(os.path.basename(current)[1:].split('.')[0])
+m = json.load(open(current))
+schema = json.loads(json.dumps(m['schemas'][-1]))
+schema['schema-id'] = len(m['schemas'])
+for field in schema['fields']:
+    if field['name'] in ('arr', 'm', 'st'):
+        field['required'] = False
+    if field['name'] == 'nst':
+        field['type']['element-required'] = False
+    if field['name'] == 'nq':
+        # An optional container nested under a Nullable-owned struct: the struct's own path is
+        # owned by the Nullable, but `nq.inner` is a distinct path that must be consulted.
+        field['type']['fields'][0]['required'] = False
+m['schemas'].append(schema)
+m['current-schema-id'] = schema['schema-id']
+m['metadata-log'] = m.get('metadata-log', []) + [
+    {'timestamp-ms': m['last-updated-ms'], 'metadata-file': current}]
+m['last-updated-ms'] += 1
+json.dump(m, open(os.path.join(md, 'v%d.metadata.json' % (n + 1)), 'w'), indent=1)
+open(os.path.join(md, 'version-hint.text'), 'w').write(str(n + 1))
+PY
+
+# `ns`/`nq` are declared `Nullable(Tuple(...))`, which is the one optional container a plain
+# CREATE TABLE can express (getIcebergType maps Nullable(T) to required=false). They are
+# carriers, not controls: the sink's header comes from the Iceberg schema, whose builder never
+# wraps a container in Nullable (canBeInsideNullable() is false for Array/Map, and
+# getComplexTypeFromObject returns a bare Tuple), so the writer receives a plain `Tuple` and
+# the container reaches prepareColumnTuple rather than prepareColumnNullable. `nq.inner` also
+# covers the nested case where a container sits below a struct that is itself optional.
+create_and_fill() {
+    local table="$1" path="$2" parallel="$3"
+    ${CLICKHOUSE_CLIENT} --enable_nullable_tuple_type 1 --query "
+        CREATE TABLE ${table} (
+            arr Array(Int32),
+            m Map(String, Int32),
+            st Tuple(a Int32),
+            nst Array(Tuple(b Int32)),
+            ns Nullable(Tuple(c Int32)),
+            nq Nullable(Tuple(inner Array(Int32))),
+            sc Nullable(Int32)
+        ) ENGINE = IcebergLocal('${path}')
+    " < /dev/null
+    ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg 1 --async_insert 0 \
+        --output_format_parquet_parallel_encoding "${parallel}" --max_threads 4 --query "
+        INSERT INTO ${table} VALUES
+            ([1, 2], {'k': 1}, (7), [(3)], (9), ([4]), 5),
+            ([],     {},       (8), [],    NULL, NULL,  NULL)
+    " < /dev/null
+}
+
+# Both encoders have to agree with the footer: the reader takes its max definition level from
+# the schema while the writer takes the level bit width from the state it builds, so a fix
+# applied to only one of the two data paths silently produces unreadable files.
+for parallel in 0 1
+do
+    # --- half A: every container required in the Iceberg schema stays REQUIRED -------------
+    TABLE_A="${BASE}_a${parallel}"
+    PATH_A="${USER_FILES_PATH}/${TABLE_A}/"
+    rm -rf "${PATH_A}" 2>/dev/null
+    create_and_fill "${TABLE_A}" "${PATH_A}" "${parallel}"
+
+    echo "--- half A: containers required in the Iceberg schema stay REQUIRED (parallel_encoding=${parallel}) ---"
+    python3 -c "${PROBE}" "${PATH_A}"
+
+    # --- half B: containers marked optional become OPTIONAL --------------------------------
+    TABLE_B="${BASE}_b${parallel}"
+    PATH_B="${USER_FILES_PATH}/${TABLE_B}/"
+    rm -rf "${PATH_B}" 2>/dev/null
+    ${CLICKHOUSE_CLIENT} --enable_nullable_tuple_type 1 --query "
+        CREATE TABLE ${TABLE_B} (
+            arr Array(Int32),
+            m Map(String, Int32),
+            st Tuple(a Int32),
+            nst Array(Tuple(b Int32)),
+            ns Nullable(Tuple(c Int32)),
+            nq Nullable(Tuple(inner Array(Int32))),
+            sc Nullable(Int32)
+        ) ENGINE = IcebergLocal('${PATH_B}')
+    " < /dev/null
+    python3 -c "${MARK_OPTIONAL}" "${PATH_B}metadata"
+    ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg 1 --async_insert 0 \
+        --output_format_parquet_parallel_encoding "${parallel}" --max_threads 4 --query "
+        INSERT INTO TABLE FUNCTION icebergLocal('${PATH_B}') VALUES
+            ([1, 2], {'k': 1}, (7), [(3)], (9), ([4]), 5),
+            ([],     {},       (8), [],    NULL, NULL,  NULL)
+    " < /dev/null
+
+    # Expected against half A: arr/m gain a definition level, st.a goes 0 -> 1, the optional
+    # struct element lifts nst.list.element.b, and nq.inner rises again because its own path is
+    # marked optional too. Untouched: every repeated list/key_value level (maxrep), the map key
+    # (always required per the Iceberg spec), and the optional scalar. The second row's [] / {}
+    # must read back as empty containers rather than NULL, which is what pins the new group's
+    # definition level against the array's own.
+    echo "--- half B: optional containers become OPTIONAL (parallel_encoding=${parallel}) ---"
+    python3 -c "${PROBE}" "${PATH_B}"
+
+    echo "--- half B: values round-trip through ClickHouse (parallel_encoding=${parallel}) ---"
+    ${CLICKHOUSE_CLIENT} --query "
+        SELECT arr, m, st, nst, ns, nq, sc FROM icebergLocal('${PATH_B}') ORDER BY sc NULLS LAST
+    " < /dev/null
+
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE ${TABLE_A}; DROP TABLE ${TABLE_B}" < /dev/null
+done

--- a/tests/queries/0_stateless/04653_iceberg_parquet_optional_complex.sh
+++ b/tests/queries/0_stateless/04653_iceberg_parquet_optional_complex.sh
@@ -24,6 +24,10 @@ trap 'rm -rf "${USER_FILES_PATH}/${BASE}"* 2>/dev/null' EXIT
 # one (`None`), which is what pins the definition level of the new OPTIONAL group relative
 # to the array's own level. ClickHouse's own reader normalizes a null container to an empty
 # one, so a round-trip through ClickHouse cannot see that distinction.
+# The `node` lines are what localize the level: a leaf's `maxdef` counts the nullable ancestors
+# along its whole chain and therefore cannot say WHICH ancestor contributed, so it reads the same
+# whether the container group or a node beneath it carries the OPTIONAL. Which node carries it is
+# the property an external Iceberg reader validates against the published schema.
 read -r -d '' PROBE <<'PY'
 import glob, sys
 import pyarrow.parquet as pq
@@ -33,6 +37,20 @@ for fn in sorted(glob.glob(sys.argv[1] + '/data/*.parquet')):
     for i in range(len(schema)):
         c = schema.column(i)
         print('leaf %-24s maxdef=%d maxrep=%d' % (c.path, c.max_definition_level, c.max_repetition_level))
+    sa = f.schema_arrow
+    for name, get in (
+            ('arr',           lambda: sa.field('arr')),
+            ('arr.element',   lambda: sa.field('arr').type.field(0)),
+            ('m',             lambda: sa.field('m')),
+            ('m.key',         lambda: sa.field('m').type.key_field),
+            ('m.value',       lambda: sa.field('m').type.item_field),
+            ('st',            lambda: sa.field('st')),
+            ('nst',           lambda: sa.field('nst')),
+            ('nst.element',   lambda: sa.field('nst').type.field(0)),
+            ('nq',            lambda: sa.field('nq')),
+            ('nq.inner',      lambda: sa.field('nq').type.field('inner')),
+            ('sc',            lambda: sa.field('sc'))):
+        print('node %-16s optional=%s' % (name, get().nullable))
     table = f.read()
     for name in table.column_names:
         print('data %-4s %s' % (name, table.column(name).to_pylist()))

--- a/tests/queries/0_stateless/04653_iceberg_parquet_optional_complex.sh
+++ b/tests/queries/0_stateless/04653_iceberg_parquet_optional_complex.sh
@@ -6,9 +6,8 @@
 # (list/map/struct) was written to Parquet with `FieldRepetitionType::REQUIRED`, because
 # Array/Map are never wrapped in `Nullable` in the ClickHouse type, so the optionality is
 # not recoverable from the type and the Parquet writer never consulted the per-path Iceberg
-# metadata the ORC writer already uses. A `REQUIRED` group cannot encode a null container, so a
-# null list/map/struct was silently read back as an empty one, and the footer contradicted the
-# Iceberg schema published by the same commit.
+# metadata the ORC writer already uses. The footer then contradicted the Iceberg schema published
+# by the same commit, which is the mismatch this test pins.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/111775
Related: https://github.com/ClickHouse/ClickHouse/pull/109994
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/111775
Related: https://github.com/ClickHouse/ClickHouse/pull/109994


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

An Iceberg field declared `"required": false` whose type is a container was written to Parquet as
`REQUIRED`, so the footer contradicted the Iceberg schema published by the same commit. The
optionality is not recoverable from the ClickHouse type: `Array` and `Map` are never wrapped in
`Nullable` (`canBeInsideNullable()` is false for both) and the Iceberg schema builder returns a
bare container, so `prepareColumnArray` / `prepareColumnTuple` / `prepareColumnMap` each
hard-coded their group `REQUIRED`. `ColumnMapper` already carries the recovered bit
(`iceberg_optional_paths`) and the ORC writer already consumes it; the Parquet writer threaded only
the field-id map.

This is deliberately not a schema-only flip: the reader takes its max definition level from the
schema while the writer takes the level bit width from the state built on the data path, so the two
have to move together or the file becomes unreadable. Both now receive the same `IcebergOptionality`
(`convertSchema`, plus the serial and parallel encoder paths). When a container's dotted Iceberg path
is marked optional, the group becomes `OPTIONAL` and one definition level is added below it, strictly
after `updateRepDefLevelsForArray` so a present-but-empty container keeps level 1 and level 0 stays
free to mean "null container". With no mapper, or a mapper carrying only field ids, the writer keeps
its current behaviour, which is what Iceberg position-delete writes rely on.

Validation: a new stateless test asserts, through pyarrow across both encoders, the per-leaf
definition levels and which schema node carries the OPTIONAL, with a required-container half as the
control. Without the fix its reference differs by 64 lines. Map keys, every `repeated` level and
optional scalars are asserted unchanged, and values round-trip identically, so this only corrects
metadata. No new or changed setting, so no `SettingsChangesHistory.cpp` entry; files written by
older versions keep their `REQUIRED` groups and stay readable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.491` (included in `26.8` and later)
<!-- ch-version-info:end -->