### PR TITLE
Add the `create_union_system_log_tables` configuration option to create and update `all_...` system log tables

### DIFF
--- a/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
+++ b/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
@@ -1587,6 +1587,34 @@ The default server configuration file `config.xml` contains the following settin
 </crash_log>
 ```
 
+## create_union_system_log_tables {#create_union_system_log_tables}
+
+Requests the creation of `all_...` tables next to the system log tables (`system.all_query_log` for `system.query_log`, `system.all_text_log` for `system.text_log`, and so on). Such a table is a union of the corresponding log table, its rotated versions (`query_log_0`, `query_log_1`, ...) and/or the same tables across all replicas of a cluster, and allows querying them all at once without remembering constructs like `clusterAllReplicas(default, merge(system, '^query_log'))`.
+
+The section is optional. If it is present, at least one of the following settings has to be specified:
+
+| Setting                | Description                                                                                                                                     |
+|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `merge_rotated_tables` | If `true`, the `all_...` table selects from the log table and its rotated versions with the `merge` table function.                            |
+| `cluster`              | If specified, the `all_...` table selects from all replicas of this cluster with the `clusterAllReplicas` table function (with `SETTINGS skip_unavailable_shards = 1`, so that unavailable replicas do not fail the queries). |
+
+If both settings are specified, the table is a union of the rotated tables across all replicas of the cluster.
+
+The option applies to all system log tables; it does not allow for a different configuration for different system logs. The tables are created in the same database as the system log tables at the first flush of each log and are automatically recreated when the structure of the log table changes (on rotation). They have no state, so it is safe to drop them at any time. The creation is supported only for the `Atomic`, `Replicated` and `Shared` database engines.
+
+:::note
+When the `cluster` setting is used, the table definition references the cluster, and the cluster has to exist for the table to be loaded. If you remove the cluster from the configuration, also drop the `all_...` tables (they will be recreated according to the new configuration at the next flush).
+:::
+
+**Example**
+
+```xml
+<create_union_system_log_tables>
+    <merge_rotated_tables>true</merge_rotated_tables>
+    <cluster>default</cluster>
+</create_union_system_log_tables>
+```
+
 ## custom_cached_disks_base_directory {#custom_cached_disks_base_directory}
 
 This setting specifies the cache path for custom (created from SQL) cached disks.

--- a/docs/en/sql-reference/table-functions/cluster.md
+++ b/docs/en/sql-reference/table-functions/cluster.md
@@ -19,10 +19,10 @@ All available clusters are listed in the [system.clusters](../../operations/syst
 ## Syntax {#syntax}
 
 ```sql
-cluster(['cluster_name', db.table, sharding_key])
-cluster(['cluster_name', db, table, sharding_key])
-clusterAllReplicas(['cluster_name', db.table, sharding_key])
-clusterAllReplicas(['cluster_name', db, table, sharding_key])
+cluster(['cluster_name', db.table, sharding_key][, SETTINGS name = value, ...])
+cluster(['cluster_name', db, table, sharding_key][, SETTINGS name = value, ...])
+clusterAllReplicas(['cluster_name', db.table, sharding_key][, SETTINGS name = value, ...])
+clusterAllReplicas(['cluster_name', db, table, sharding_key][, SETTINGS name = value, ...])
 ```
 ## Arguments {#arguments}
 
@@ -31,6 +31,7 @@ clusterAllReplicas(['cluster_name', db, table, sharding_key])
 | `cluster_name`              | Name of a cluster that is used to build a set of addresses and connection parameters to remote and local servers, set `default` if not specified. |
 | `db.table` or `db`, `table` | Name of a database and a table.                                                                                                                   |
 | `sharding_key`              | A sharding key. Optional. Needs to be specified if the cluster has more than one shard.                                                           |
+| `SETTINGS name = value, ...` | [Settings of the Distributed table](../../engines/table-engines/special/distributed.md#distributed-settings) created by the function, for example `skip_unavailable_shards`. Optional. A setting specified in the query has priority over it. |
 
 ## Returned value {#returned_value}
 

--- a/docs/en/sql-reference/table-functions/remote.md
+++ b/docs/en/sql-reference/table-functions/remote.md
@@ -16,12 +16,12 @@ Both functions can be used in `SELECT` and `INSERT` queries when the target is a
 ## Syntax {#syntax}
 
 ```sql
-remote(addresses_expr, [db, table, user [, password], sharding_key])
-remote(addresses_expr, [db.table, user [, password], sharding_key])
-remote(named_collection[, option=value [,..]])
-remoteSecure(addresses_expr, [db, table, user [, password], sharding_key])
-remoteSecure(addresses_expr, [db.table, user [, password], sharding_key])
-remoteSecure(named_collection[, option=value [,..]])
+remote(addresses_expr, [db, table, user [, password], sharding_key][, SETTINGS name = value, ...])
+remote(addresses_expr, [db.table, user [, password], sharding_key][, SETTINGS name = value, ...])
+remote(named_collection[, option=value [,..]][, SETTINGS name = value, ...])
+remoteSecure(addresses_expr, [db, table, user [, password], sharding_key][, SETTINGS name = value, ...])
+remoteSecure(addresses_expr, [db.table, user [, password], sharding_key][, SETTINGS name = value, ...])
+remoteSecure(named_collection[, option=value [,..]][, SETTINGS name = value, ...])
 ```
 
 ## Parameters {#parameters}
@@ -34,6 +34,7 @@ remoteSecure(named_collection[, option=value [,..]])
 | `user`         | User name. If not specified, `default` is used. Type: [String](../../sql-reference/data-types/string.md).                                                                                                                                                                                                                                                         |
 | `password`     | User password. If not specified, an empty password is used. Type: [String](../../sql-reference/data-types/string.md).                                                                                                                                                                                                                                             |
 | `sharding_key` | Sharding key to support distributing data across nodes. For example: `insert into remote('127.0.0.1:9000,127.0.0.2', db, table, 'default', rand())`. Type: [UInt32](../../sql-reference/data-types/int-uint.md).                                                                                                                                                 |
+| `SETTINGS name = value, ...` | [Settings of the Distributed table](../../engines/table-engines/special/distributed.md#distributed-settings) created by the function, for example `skip_unavailable_shards`. Optional. A setting specified in the query has priority over it. |
 
 Arguments also can be passed using [named collections](/operations/named-collections.md).
 

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -11,6 +11,7 @@
 #include <Common/logger_useful.h>
 #include <Common/quoteString.h>
 #include <Common/setThreadName.h>
+#include <Common/StringUtils.h>
 #include <Core/ServerSettings.h>
 #include <Core/UUID.h>
 #include <Interpreters/AsynchronousInsertLog.h>
@@ -55,6 +56,7 @@
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTInsertQuery.h>
+#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTRenameQuery.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/CommonParsers.h>
@@ -235,6 +237,21 @@ std::shared_ptr<TSystemLog> createSystemLog(
     if (!storage_with_comment.comment || storage_with_comment.comment->as<ASTLiteral &>().value.safeGet<String>().empty())
         log_settings.engine += fmt::format(" COMMENT {} ", quoteString(comment + comment_addendum));
 
+    /// The optional `create_union_system_log_tables` section requests the creation of `all_...`
+    /// tables querying the set of rotated tables (`query_log`, `query_log_0`, `query_log_1`, ...)
+    /// and/or the corresponding tables across all replicas of a cluster. It applies to all
+    /// system log tables and does not allow a different configuration for different logs.
+    if (config.has("create_union_system_log_tables"))
+    {
+        log_settings.union_table_merge_rotated_tables = config.getBool("create_union_system_log_tables.merge_rotated_tables", false);
+        log_settings.union_table_cluster = config.getString("create_union_system_log_tables.cluster", "");
+
+        if (!log_settings.union_table_merge_rotated_tables && log_settings.union_table_cluster.empty())
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                            "If the 'create_union_system_log_tables' section is present in the server configuration,"
+                            " at least one of 'merge_rotated_tables' and 'cluster' has to be specified");
+    }
+
     log_settings.queue_settings.flush_interval_milliseconds = config.getUInt64(config_prefix + ".flush_interval_milliseconds",
                                                                                TSystemLog::getDefaultFlushIntervalMilliseconds());
 
@@ -304,6 +321,21 @@ ASTPtr getCreateTableQueryClean(const StorageID & table_id, ContextPtr context)
     /// Reset UUID
     old_create_query_ast.uuid = UUIDHelpers::Nil;
     return old_ast;
+}
+
+/// Escapes a table name for use inside a regular expression
+/// (the argument of the `merge` table function).
+String escapeStringForRegexp(const String & s)
+{
+    String result;
+    result.reserve(s.size());
+    for (char c : s)
+    {
+        if (!isWordCharASCII(c))
+            result += '\\';
+        result += c;
+    }
+    return result;
 }
 
 }
@@ -593,10 +625,15 @@ SystemLog<LogElement>::SystemLog(
     , WithContext(context_)
     , log(getLogger("SystemLog (" + settings_.queue_settings.database + "." + settings_.queue_settings.table + ")"))
     , table_id(settings_.queue_settings.database, settings_.queue_settings.table)
+    , union_table_id(settings_.queue_settings.database, "all_" + settings_.queue_settings.table)
     , storage_def(settings_.engine)
+    , union_table_merge_rotated_tables(settings_.union_table_merge_rotated_tables)
+    , union_table_cluster(settings_.union_table_cluster)
     , flush_policy(std::make_unique<DefaultSystemLogFlushPolicy>(context_->getConfigRef()))
 {
     create_query = getCreateTableQuery()->formatWithSecretsOneLine();
+    if (union_table_merge_rotated_tables || !union_table_cluster.empty())
+        union_create_query = getCreateUnionTableQuery()->formatWithSecretsOneLine();
     chassert(settings_.queue_settings.database == DatabaseCatalog::SYSTEM_DATABASE);
 }
 
@@ -901,6 +938,11 @@ void SystemLog<LogElement>::prepareTable()
 
             /// The required table will be created.
             table = nullptr;
+
+            /// The union table (if configured) pins the structure of the current table,
+            /// so it has to be re-checked after the rotation.
+            union_table_check_pending = true;
+            union_table_broken = false;
         }
         else if (!is_prepared)
             LOG_DEBUG(log, "Will use existing table {} for {}", description, LogElement::name());
@@ -926,6 +968,95 @@ void SystemLog<LogElement>::prepareTable()
     }
 
     is_prepared = true;
+
+    prepareUnionTable();
+}
+
+template <typename LogElement>
+void SystemLog<LogElement>::prepareUnionTable()
+{
+    if (union_create_query.empty() || union_table_broken)
+        return;
+
+    try
+    {
+        auto union_table = DatabaseCatalog::instance().tryGetTable(union_table_id, getContext());
+
+        /// The definition is verified at the first flush and after each rotation of the log
+        /// table; on other flushes only recreate the union table if it was dropped by a user.
+        if (!union_table_check_pending && union_table)
+            return;
+
+        const auto & database_engine = DatabaseCatalog::instance().getDatabase(union_table_id.database_name)->getEngineName();
+        if (database_engine != "Atomic" && database_engine != "Replicated" && database_engine != "Shared")
+        {
+            LOG_INFO(
+                log,
+                "Not creating {}: it is only supported for the Atomic, Replicated and Shared database engines,"
+                " while the database {} has the engine {}",
+                union_table_id.getNameForLogs(),
+                backQuoteIfNeed(union_table_id.database_name),
+                database_engine);
+            union_table_broken = true;
+            return;
+        }
+
+        if (union_table)
+        {
+            String existing_create_query = getCreateTableQueryClean(union_table_id, getContext())->formatWithSecretsOneLine();
+            if (existing_create_query == union_create_query)
+            {
+                union_table_check_pending = false;
+                return;
+            }
+
+            LOG_DEBUG(
+                log,
+                "Existing table {} has an obsolete or different definition. Recreating it.\nOld: {}\nNew: {}\n.",
+                union_table_id.getNameForLogs(),
+                existing_create_query,
+                union_create_query);
+        }
+        else
+        {
+            LOG_DEBUG(log, "Creating new table {} for {}", union_table_id.getNameForLogs(), LogElement::name());
+        }
+
+        auto query_context = Context::createCopy(context);
+        query_context->makeQueryContext();
+        addSettingsForQuery(query_context, IAST::QueryKind::Create);
+        /// Replacing the union table drops the previous one, and users may have created
+        /// dependencies on it; as with the rotation of the log tables, this automatic
+        /// operation must not fail because of them.
+        query_context->setSetting("check_table_dependencies", Field{false});
+        query_context->setSetting("check_referential_table_dependencies", Field{false});
+
+        ASTPtr create_query_ast = getCreateUnionTableQuery();
+        auto & create = create_query_ast->as<ASTCreateQuery &>();
+        /// The union table has no state, so it is always possible to recreate it.
+        /// CREATE OR REPLACE swaps the old and the new table with an atomic exchange
+        /// and also works when the table does not exist.
+        create.create_or_replace = true;
+        create.replace_table = true;
+
+        InterpreterCreateQuery interpreter(create_query_ast, query_context);
+        interpreter.setInternal(true);
+        interpreter.execute();
+
+        union_table_check_pending = false;
+    }
+    catch (...)
+    {
+        /// The log table must keep flushing even if the union table cannot be created
+        /// (for example, the configured cluster does not exist).
+        union_table_broken = true;
+        tryLogCurrentException(
+            log,
+            fmt::format(
+                "Failed to prepare {}. The creation will not be retried until a restart of the server"
+                " or a rotation of the log table",
+                union_table_id.getNameForLogs()));
+    }
 }
 
 template <typename LogElement>
@@ -1040,6 +1171,85 @@ ASTPtr SystemLog<LogElement>::getCreateTableQuery()
         auto storage_settings = std::make_unique<MergeTreeSettings>(getContext()->getMergeTreeSettings());
         storage_settings->loadFromQuery(*create->storage, getContext(), false);
     }
+
+    return create;
+}
+
+template <typename LogElement>
+ASTPtr SystemLog<LogElement>::getCreateUnionTableQuery()
+{
+    auto create = make_intrusive<ASTCreateQuery>();
+
+    create->setDatabase(union_table_id.database_name);
+    create->setTable(union_table_id.table_name);
+
+    /// The columns are specified explicitly (instead of being derived from the table function),
+    /// so that the union table always pins the up-to-date structure of the log table: the
+    /// dynamically derived structure could include obsolete columns of the rotated tables.
+    /// Note: unlike the log table itself, no skipping indices - they are not supported for
+    /// tables created over a table function.
+    auto new_columns_list = make_intrusive<ASTColumns>();
+    auto ordinary_columns = LogElement::getColumnsDescription();
+    auto alias_columns = LogElement::getNamesAndAliases();
+    if (!flush_policy->shouldSkipAliasColumns())
+        ordinary_columns.setAliases(alias_columns);
+    new_columns_list->set(new_columns_list->columns, InterpreterCreateQuery::formatColumns(ordinary_columns));
+    create->set(create->columns_list, new_columns_list);
+
+    /// The `merge` table function selects the log table itself along with its rotated
+    /// versions (`query_log`, `query_log_0`, `query_log_1`, ...), but not the union table.
+    ASTPtr merge_table_function;
+    if (union_table_merge_rotated_tables)
+        merge_table_function = makeASTFunction(
+            "merge",
+            make_intrusive<ASTLiteral>(table_id.database_name),
+            make_intrusive<ASTLiteral>(fmt::format("^{}(_[0-9]+)?$", escapeStringForRegexp(table_id.table_name))));
+
+    String comment;
+    ASTPtr table_function;
+    if (!union_table_cluster.empty())
+    {
+        /// Reading from the union table should not fail because some of the replicas
+        /// are unavailable. The setting stored in the table definition is overridable:
+        /// it takes effect only when `skip_unavailable_shards` is not set for the query.
+        auto settings = make_intrusive<ASTSetQuery>();
+        settings->is_standalone = false;
+        settings->changes.emplace_back("skip_unavailable_shards", true);
+
+        if (merge_table_function)
+        {
+            table_function = makeASTFunction(
+                "clusterAllReplicas", make_intrusive<ASTLiteral>(union_table_cluster), merge_table_function, settings);
+            comment = fmt::format(
+                "Union of the {} tables (including the rotated versions) across all replicas of the cluster {}.",
+                backQuote(table_id.table_name),
+                backQuote(union_table_cluster));
+        }
+        else
+        {
+            table_function = makeASTFunction(
+                "clusterAllReplicas",
+                make_intrusive<ASTLiteral>(union_table_cluster),
+                make_intrusive<ASTLiteral>(table_id.database_name),
+                make_intrusive<ASTLiteral>(table_id.table_name),
+                settings);
+            comment = fmt::format(
+                "Union of the {} tables across all replicas of the cluster {}.",
+                backQuote(table_id.table_name),
+                backQuote(union_table_cluster));
+        }
+    }
+    else
+    {
+        table_function = merge_table_function;
+        comment = fmt::format(
+            "Union of the {} table and its rotated versions.", backQuote(table_id.table_name));
+    }
+
+    create->set(create->as_table_function, table_function);
+
+    comment += "\n\nIt is safe to drop this table at any time: it will be recreated automatically.";
+    create->set(create->comment, make_intrusive<ASTLiteral>(comment));
 
     return create;
 }

--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -184,6 +184,13 @@ struct SystemLogSettings
 
     String engine;
     bool symbolize_traces = false;
+
+    /// Settings of the `all_...` union table over the log table, its rotated versions and/or
+    /// the same tables across a cluster. See the `create_union_system_log_tables` section
+    /// of the server configuration. The union table is created when at least one of the
+    /// two fields below is set.
+    bool union_table_merge_rotated_tables = false;
+    String union_table_cluster;
 };
 
 template <typename LogElement>
@@ -247,17 +254,39 @@ protected:
 private:
     /* Saving thread data */
     const StorageID table_id;
+    /// The `all_...` table over the log table, its rotated versions and/or the same tables
+    /// across a cluster (see `create_union_system_log_tables` in the server config).
+    const StorageID union_table_id;
     const String storage_def;
+    const bool union_table_merge_rotated_tables;
+    const String union_table_cluster;
     std::unique_ptr<ISystemLogFlushPolicy> flush_policy;
     String create_query;
     String old_create_query;
+    /// Expected CREATE query of the union table. Empty when the union table is not configured.
+    String union_create_query;
     bool is_prepared = false;
+    /// Whether the definition of the union table has to be verified against the expected one.
+    /// This is done at the first flush and after each rotation of the log table; on other
+    /// flushes the union table is only recreated if it went missing (e.g. dropped by a user).
+    bool union_table_check_pending = true;
+    /// Set when the union table cannot be created (e.g. the configured cluster does not exist)
+    /// or the database engine does not support it, to avoid retrying the creation and polluting
+    /// the log on every flush. Reset on rotation of the log table.
+    bool union_table_broken = false;
 
     void savingThreadFunction() override;
 
     /// flushImpl can be executed only in saving_thread.
     void flushImpl(const std::vector<LogElement> & to_flush, uint64_t to_flush_end);
     ASTPtr getCreateTableQuery();
+    ASTPtr getCreateUnionTableQuery();
+
+    /// Creates or updates the `all_...` union table if it is configured.
+    /// The table is stateless (a proxy over the `merge`/`clusterAllReplicas` table functions),
+    /// so it is recreated with an atomic exchange whenever its definition differs from the
+    /// expected one. Failures are logged and never interfere with flushing the log itself.
+    void prepareUnionTable();
 };
 
 }

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -770,7 +770,9 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
     ParserIdentifier name_p;
     ParserTablePropertiesDeclarationList table_properties_p;
     ParserSelectWithUnionQuery select_p;
-    ParserFunction table_function_p;
+    /// Parse the table function after AS in the table-function mode, so that a trailing
+    /// SETTINGS clause is accepted: CREATE TABLE ... AS remote(..., SETTINGS skip_unavailable_shards = 1)
+    ParserFunction table_function_p{/*allow_function_parameters_=*/ true, /*is_table_function_=*/ true};
     ParserNameList names_p;
     ParserSQLSecurity sql_security_p;
 

--- a/src/Storages/Distributed/DistributedSettings.cpp
+++ b/src/Storages/Distributed/DistributedSettings.cpp
@@ -97,6 +97,11 @@ void DistributedSettings::loadFromQuery(ASTStorage & storage_def)
     }
 }
 
+void DistributedSettings::applyChanges(const SettingsChanges & changes)
+{
+    impl->applyChanges(changes);
+}
+
 bool DistributedSettings::hasBuiltin(std::string_view name)
 {
     return DistributedSettingsImpl::hasBuiltin(name);

--- a/src/Storages/Distributed/DistributedSettings.h
+++ b/src/Storages/Distributed/DistributedSettings.h
@@ -12,6 +12,7 @@ namespace Poco::Util
 namespace DB
 {
 class ASTStorage;
+class SettingsChanges;
 struct DistributedSettingsImpl;
 
 /// List of available types supported in DistributedSettings object
@@ -36,6 +37,7 @@ struct DistributedSettings
 
     void loadFromConfig(const String & config_elem, const Poco::Util::AbstractConfiguration & config);
     void loadFromQuery(ASTStorage & storage_def);
+    void applyChanges(const SettingsChanges & changes);
 
     static bool hasBuiltin(std::string_view name);
 

--- a/src/Storages/Distributed/parseRemoteFunctionArguments.cpp
+++ b/src/Storages/Distributed/parseRemoteFunctionArguments.cpp
@@ -5,6 +5,7 @@
 #include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTSetQuery.h>
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Interpreters/Cluster.h>
 #include <Interpreters/Context.h>
@@ -33,7 +34,7 @@ namespace ErrorCodes
 
 
 ParsedRemoteFunctionArguments parseRemoteFunctionArguments(
-    ASTs & args,
+    ASTs & all_args,
     ContextPtr context,
     const std::string & name,
     bool is_cluster_function,
@@ -45,6 +46,32 @@ ParsedRemoteFunctionArguments parseRemoteFunctionArguments(
     ClusterPtr & cluster = result.cluster;
     ASTPtr & sharding_key = result.sharding_key;
     ASTPtr & remote_table_function_ptr = result.remote_table_function_ptr;
+
+    /// A SETTINGS clause is parsed as an ASTSetQuery argument, e.g.
+    /// clusterAllReplicas('default', system.query_log, SETTINGS skip_unavailable_shards = 1).
+    /// Extract such arguments into `result.settings_changes` and parse the rest positionally.
+    /// The SETTINGS clause is intentionally left in the AST, so the definition of a table
+    /// created over the function (CREATE TABLE ... AS remote(...)) survives SHOW CREATE TABLE
+    /// and server restarts. The remaining arguments are processed through a copy that is
+    /// written back before returning, because parsing normalizes some of them in place
+    /// (e.g. evaluates constant expressions into literals) and callers persist that.
+    ASTs args;
+    std::vector<size_t> positional_arg_indexes;
+    args.reserve(all_args.size());
+    positional_arg_indexes.reserve(all_args.size());
+    for (size_t i = 0; i < all_args.size(); ++i)
+    {
+        if (const auto * settings_ast = all_args[i]->as<ASTSetQuery>())
+        {
+            result.settings_changes.insert(
+                result.settings_changes.end(), settings_ast->changes.begin(), settings_ast->changes.end());
+        }
+        else
+        {
+            args.push_back(all_args[i]);
+            positional_arg_indexes.push_back(i);
+        }
+    }
 
     String cluster_name;
     String cluster_description;
@@ -357,6 +384,9 @@ ParsedRemoteFunctionArguments parseRemoteFunctionArguments(
 
     result.remote_table_id.database_name = database;
     result.remote_table_id.table_name = table;
+
+    for (size_t i = 0; i < args.size(); ++i)
+        all_args[positional_arg_indexes[i]] = args[i];
 
     return result;
 }

--- a/src/Storages/Distributed/parseRemoteFunctionArguments.h
+++ b/src/Storages/Distributed/parseRemoteFunctionArguments.h
@@ -5,6 +5,7 @@
 #include <Interpreters/StorageID.h>
 #include <Parsers/IAST_fwd.h>
 #include <Common/LoggingFormatStringHelpers.h>
+#include <Common/SettingsChanges.h>
 
 
 namespace DB
@@ -19,6 +20,11 @@ struct ParsedRemoteFunctionArguments
     StorageID remote_table_id = StorageID::createEmpty();
     ASTPtr sharding_key;
     ASTPtr remote_table_function_ptr;
+
+    /// Changes from a SETTINGS clause among the arguments, e.g.
+    /// clusterAllReplicas('default', system.query_log, SETTINGS skip_unavailable_shards = 1).
+    /// They are applied to the `DistributedSettings` of the created `StorageDistributed`.
+    SettingsChanges settings_changes;
 };
 
 /// Parses the arguments shared by the `remote` family of table functions and the `Remote`/`RemoteSecure`

--- a/src/TableFunctions/TableFunctionRemote.cpp
+++ b/src/TableFunctions/TableFunctionRemote.cpp
@@ -32,6 +32,11 @@ void TableFunctionRemote::parseArguments(const ASTPtr & ast_function, ContextPtr
     remote_table_id = std::move(parsed.remote_table_id);
     sharding_key = std::move(parsed.sharding_key);
     remote_table_function_ptr = std::move(parsed.remote_table_function_ptr);
+    settings_changes = std::move(parsed.settings_changes);
+
+    /// Validate the settings early, so that a misspelled setting is reported during parsing
+    /// rather than at the first read from the storage.
+    DistributedSettings{}.applyChanges(settings_changes);
 }
 
 StoragePtr TableFunctionRemote::executeImpl(const ASTPtr & /*ast_function*/, ContextPtr context, const std::string & table_name, ColumnsDescription cached_columns, bool is_insert_query) const
@@ -58,6 +63,9 @@ StoragePtr TableFunctionRemote::executeImpl(const ASTPtr & /*ast_function*/, Con
     else if (has_local_shard)
         context->checkAccess(AccessType::INSERT, remote_table_id);
 
+    DistributedSettings distributed_settings;
+    distributed_settings.applyChanges(settings_changes);
+
     StoragePtr res = std::make_shared<StorageDistributed>(
             StorageID(getDatabaseName(), table_name),
             cached_columns,
@@ -70,7 +78,7 @@ StoragePtr TableFunctionRemote::executeImpl(const ASTPtr & /*ast_function*/, Con
             sharding_key,
             String{},
             String{},
-            DistributedSettings{},
+            distributed_settings,
             LoadingStrictnessLevel::CREATE,
             cluster,
             remote_table_function_ptr,
@@ -110,12 +118,12 @@ Both functions can be used in `SELECT` and `INSERT` queries when the target is a
 ## Syntax {#syntax}
 
 ```sql
-remote(addresses_expr, [db, table, user [, password], sharding_key])
-remote(addresses_expr, [db.table, user [, password], sharding_key])
-remote(named_collection[, option=value [,..]])
-remoteSecure(addresses_expr, [db, table, user [, password], sharding_key])
-remoteSecure(addresses_expr, [db.table, user [, password], sharding_key])
-remoteSecure(named_collection[, option=value [,..]])
+remote(addresses_expr, [db, table, user [, password], sharding_key][, SETTINGS name = value, ...])
+remote(addresses_expr, [db.table, user [, password], sharding_key][, SETTINGS name = value, ...])
+remote(named_collection[, option=value [,..]][, SETTINGS name = value, ...])
+remoteSecure(addresses_expr, [db, table, user [, password], sharding_key][, SETTINGS name = value, ...])
+remoteSecure(addresses_expr, [db.table, user [, password], sharding_key][, SETTINGS name = value, ...])
+remoteSecure(named_collection[, option=value [,..]][, SETTINGS name = value, ...])
 ```
 
 ## Parameters {#parameters}
@@ -128,6 +136,7 @@ remoteSecure(named_collection[, option=value [,..]])
 | `user`         | User name. If not specified, `default` is used. Type: [String](/reference/data-types/string).                                                                                                                                                                                                                                                         |
 | `password`     | User password. If not specified, an empty password is used. Type: [String](/reference/data-types/string).                                                                                                                                                                                                                                             |
 | `sharding_key` | Sharding key to support distributing data across nodes. For example: `insert into remote('127.0.0.1:9000,127.0.0.2', db, table, 'default', rand())`. Type: [UInt32](/reference/data-types/int-uint).                                                                                                                                                 |
+| `SETTINGS name = value, ...` | Settings of the Distributed table created by the function, for example `skip_unavailable_shards`. Optional. A setting specified in the query has priority over it. |
 
 Arguments also can be passed using [named collections](/concepts/features/configuration/server-config/named-collections).
 
@@ -284,10 +293,10 @@ All available clusters are listed in the [system.clusters](/reference/system-tab
 ## Syntax {#syntax}
 
 ```sql
-cluster(['cluster_name', db.table, sharding_key])
-cluster(['cluster_name', db, table, sharding_key])
-clusterAllReplicas(['cluster_name', db.table, sharding_key])
-clusterAllReplicas(['cluster_name', db, table, sharding_key])
+cluster(['cluster_name', db.table, sharding_key][, SETTINGS name = value, ...])
+cluster(['cluster_name', db, table, sharding_key][, SETTINGS name = value, ...])
+clusterAllReplicas(['cluster_name', db.table, sharding_key][, SETTINGS name = value, ...])
+clusterAllReplicas(['cluster_name', db, table, sharding_key][, SETTINGS name = value, ...])
 ```
 ## Arguments {#arguments}
 
@@ -296,6 +305,7 @@ clusterAllReplicas(['cluster_name', db, table, sharding_key])
 | `cluster_name`              | Name of a cluster that is used to build a set of addresses and connection parameters to remote and local servers, set `default` if not specified. |
 | `db.table` or `db`, `table` | Name of a database and a table.                                                                                                                   |
 | `sharding_key`              | A sharding key. Optional. Needs to be specified if the cluster has more than one shard.                                                           |
+| `SETTINGS name = value, ...` | Settings of the Distributed table created by the function, for example `skip_unavailable_shards`. Optional. A setting specified in the query has priority over it. |
 
 ## Returned value {#returned_value}
 

--- a/src/TableFunctions/TableFunctionRemote.h
+++ b/src/TableFunctions/TableFunctionRemote.h
@@ -43,6 +43,10 @@ private:
     StorageID remote_table_id = StorageID::createEmpty();
     ASTPtr remote_table_function_ptr;
     ASTPtr sharding_key = nullptr;
+
+    /// Changes from a SETTINGS clause among the arguments, applied to the `DistributedSettings`
+    /// of the created `StorageDistributed`, e.g. SETTINGS skip_unavailable_shards = 1.
+    SettingsChanges settings_changes;
 };
 
 }

--- a/tests/integration/test_create_union_system_log_tables/configs/clusters.xml
+++ b/tests/integration/test_create_union_system_log_tables/configs/clusters.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <remote_servers>
+        <system_logs_cluster>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </system_logs_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_create_union_system_log_tables/configs/union_cluster.xml
+++ b/tests/integration/test_create_union_system_log_tables/configs/union_cluster.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <create_union_system_log_tables>
+        <cluster>system_logs_cluster</cluster>
+    </create_union_system_log_tables>
+</clickhouse>

--- a/tests/integration/test_create_union_system_log_tables/configs/union_merge.xml
+++ b/tests/integration/test_create_union_system_log_tables/configs/union_merge.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <create_union_system_log_tables>
+        <merge_rotated_tables>true</merge_rotated_tables>
+    </create_union_system_log_tables>
+</clickhouse>

--- a/tests/integration/test_create_union_system_log_tables/configs/union_merge_and_cluster.xml
+++ b/tests/integration/test_create_union_system_log_tables/configs/union_merge_and_cluster.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <create_union_system_log_tables>
+        <merge_rotated_tables>true</merge_rotated_tables>
+        <cluster>system_logs_cluster</cluster>
+    </create_union_system_log_tables>
+</clickhouse>

--- a/tests/integration/test_create_union_system_log_tables/test.py
+++ b/tests/integration/test_create_union_system_log_tables/test.py
@@ -1,0 +1,223 @@
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+# The `all_...` union tables read both the rotated versions of the log tables
+# and the tables across the cluster.
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=[
+        "configs/clusters.xml",
+        "configs/union_merge_and_cluster.xml",
+    ],
+)
+
+# Only the tables across the cluster, without the rotated versions.
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=[
+        "configs/clusters.xml",
+        "configs/union_cluster.xml",
+    ],
+    stay_alive=True,
+)
+
+# Only the rotated versions of the local log tables.
+node3 = cluster.add_instance(
+    "node3",
+    main_configs=["configs/union_merge.xml"],
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_merge_rotated_tables(start_cluster):
+    node3.query("SELECT 'test_merge_marker_first'")
+    node3.query("SYSTEM FLUSH LOGS query_log")
+
+    create_query = node3.query("SHOW CREATE TABLE system.all_query_log FORMAT TSVRaw")
+    assert "AS merge('system', '^query_log(_[0-9]+)?$')" in create_query
+    assert "clusterAllReplicas" not in create_query
+
+    # The union table has the same structure as the log table.
+    assert node3.query("DESCRIBE TABLE system.all_query_log") == node3.query(
+        "DESCRIBE TABLE system.query_log"
+    )
+
+    assert (
+        int(
+            node3.query(
+                "SELECT count() > 0 FROM system.all_query_log WHERE query LIKE '%test_merge_marker_first%'"
+            )
+        )
+        == 1
+    )
+
+    # Union tables are created for all system logs configured on the server.
+    node3.query("SYSTEM FLUSH LOGS text_log, trace_log")
+    assert "AS merge" in node3.query(
+        "SHOW CREATE TABLE system.all_text_log FORMAT TSVRaw"
+    )
+    assert "AS merge" in node3.query(
+        "SHOW CREATE TABLE system.all_trace_log FORMAT TSVRaw"
+    )
+
+
+def test_recreated_after_drop(start_cluster):
+    node3.query("SYSTEM FLUSH LOGS query_log")
+    node3.query("DROP TABLE system.all_query_log SYNC")
+
+    node3.query("SELECT 'test_drop_marker'")
+    node3.query("SYSTEM FLUSH LOGS query_log")
+
+    assert "AS merge" in node3.query(
+        "SHOW CREATE TABLE system.all_query_log FORMAT TSVRaw"
+    )
+
+
+def test_recreated_on_rotation(start_cluster):
+    node3.query("SELECT 'test_rotation_marker_before'")
+    node3.query("SYSTEM FLUSH LOGS query_log")
+
+    # A user-modified union table is left intact until the next rotation of the log table
+    # (or a server restart).
+    node3.query("DROP TABLE system.all_query_log SYNC")
+    node3.query("CREATE TABLE system.all_query_log (x UInt8) ENGINE = Memory")
+    node3.query("SYSTEM FLUSH LOGS query_log")
+    assert "Memory" in node3.query(
+        "SHOW CREATE TABLE system.all_query_log FORMAT TSVRaw"
+    )
+
+    # Trigger a rotation: the structure of the log table no longer matches the expected
+    # one, so at the first flush after a restart it is renamed to `query_log_N` and
+    # created anew, and the union table is recreated as well.
+    node3.query("ALTER TABLE system.query_log ADD COLUMN test_rotation UInt8")
+    node3.restart_clickhouse()
+    node3.query("SYSTEM FLUSH LOGS query_log")
+
+    assert node3.query("EXISTS TABLE system.query_log_0").strip() == "1"
+    assert "AS merge" in node3.query(
+        "SHOW CREATE TABLE system.all_query_log FORMAT TSVRaw"
+    )
+
+    node3.query("SELECT 'test_rotation_marker_after'")
+    node3.query("SYSTEM FLUSH LOGS query_log")
+
+    # The union table sees both the rotated table and the new one.
+    assert (
+        int(
+            node3.query(
+                "SELECT count() > 0 FROM system.all_query_log WHERE query LIKE '%test_rotation_marker_before%'"
+            )
+        )
+        == 1
+    )
+    assert (
+        int(
+            node3.query(
+                "SELECT count() > 0 FROM system.all_query_log WHERE query LIKE '%test_rotation_marker_after%'"
+            )
+        )
+        == 1
+    )
+
+
+def test_stable_across_restarts(start_cluster):
+    node3.query("SYSTEM FLUSH LOGS query_log")
+    uuid_before = node3.query(
+        "SELECT uuid FROM system.tables WHERE database = 'system' AND name = 'all_query_log'"
+    )
+
+    node3.restart_clickhouse()
+
+    # The generated table definition must match the stored one, otherwise the table
+    # would be recreated at the first flush after every restart.
+    node3.query("SYSTEM FLUSH LOGS query_log")
+    uuid_after = node3.query(
+        "SELECT uuid FROM system.tables WHERE database = 'system' AND name = 'all_query_log'"
+    )
+    assert uuid_before == uuid_after
+
+
+def test_cluster(start_cluster):
+    node1.query("SELECT 'test_cluster_marker_node1'")
+    node1.query("SYSTEM FLUSH LOGS query_log")
+    node2.query("SELECT 'test_cluster_marker_node2'")
+    node2.query("SYSTEM FLUSH LOGS query_log")
+
+    create_query_node1 = node1.query(
+        "SHOW CREATE TABLE system.all_query_log FORMAT TSVRaw"
+    )
+    assert (
+        "AS clusterAllReplicas('system_logs_cluster', merge('system', '^query_log(_[0-9]+)?$'), SETTINGS skip_unavailable_shards = true)"
+        in create_query_node1
+    )
+
+    create_query_node2 = node2.query(
+        "SHOW CREATE TABLE system.all_query_log FORMAT TSVRaw"
+    )
+    assert (
+        "AS clusterAllReplicas('system_logs_cluster', 'system', 'query_log', SETTINGS skip_unavailable_shards = true)"
+        in create_query_node2
+    )
+
+    # The union table reads from all replicas of the cluster.
+    for marker in ["test_cluster_marker_node1", "test_cluster_marker_node2"]:
+        assert (
+            int(
+                node1.query(
+                    f"SELECT count() > 0 FROM system.all_query_log WHERE query LIKE '%{marker}%'"
+                )
+            )
+            == 1
+        )
+
+    assert (
+        node1.query(
+            "SELECT countDistinct(hostName()) FROM system.all_query_log"
+        ).strip()
+        == "2"
+    )
+
+
+def test_skip_unavailable_replicas(start_cluster):
+    node1.query("SELECT 'test_skip_unavailable_marker'")
+    node1.query("SYSTEM FLUSH LOGS query_log")
+
+    node2.stop_clickhouse()
+    try:
+        # Reading does not fail because of the unavailable replica.
+        assert (
+            int(
+                node1.query(
+                    "SELECT count() > 0 FROM system.all_query_log WHERE query LIKE '%test_skip_unavailable_marker%'"
+                )
+            )
+            == 1
+        )
+        assert (
+            node1.query(
+                "SELECT countDistinct(hostName()) FROM system.all_query_log"
+            ).strip()
+            == "1"
+        )
+
+        # The setting from the table definition can be overridden in the query.
+        assert "Exception" in node1.query_and_get_error(
+            "SELECT count() FROM system.all_query_log SETTINGS skip_unavailable_shards = 0"
+        )
+    finally:
+        node2.start_clickhouse()

--- a/tests/queries/0_stateless/04657_cluster_table_function_settings.reference
+++ b/tests/queries/0_stateless/04657_cluster_table_function_settings.reference
@@ -1,0 +1,7 @@
+1
+1
+1
+CREATE TABLE default.table_over_cluster_function\n(\n    `dummy` UInt8\n) AS clusterAllReplicas(\'test_unavailable_shard\', \'system.one\', SETTINGS skip_unavailable_shards = 1)
+1
+CREATE TABLE default.table_over_cluster_function\n(\n    `dummy` UInt8\n) AS clusterAllReplicas(\'test_unavailable_shard\', \'system.one\', SETTINGS skip_unavailable_shards = 1)
+1

--- a/tests/queries/0_stateless/04657_cluster_table_function_settings.sql
+++ b/tests/queries/0_stateless/04657_cluster_table_function_settings.sql
@@ -1,0 +1,33 @@
+-- Tags: shard, no-fasttest
+
+SET send_logs_level = 'fatal';
+
+-- The `remote`, `cluster` and `clusterAllReplicas` table functions accept a SETTINGS clause
+-- with the settings of the Distributed storage, e.g. `skip_unavailable_shards`.
+
+SELECT count() FROM clusterAllReplicas('test_unavailable_shard', system.one, SETTINGS skip_unavailable_shards = 1);
+SELECT count() FROM cluster('test_unavailable_shard', system.one, SETTINGS skip_unavailable_shards = 1);
+SELECT count() FROM remote('127.0.0.2|localhost:1', system.one, SETTINGS skip_unavailable_shards = 1);
+
+-- A setting specified in the query has priority over the setting from the table function.
+SELECT count() FROM clusterAllReplicas('test_unavailable_shard', system.one, SETTINGS skip_unavailable_shards = 1) SETTINGS skip_unavailable_shards = 0; -- { serverError ALL_CONNECTION_TRIES_FAILED }
+
+-- Only the settings of the Distributed storage are accepted.
+SELECT count() FROM clusterAllReplicas('test_shard_localhost', system.one, SETTINGS no_such_setting = 1); -- { serverError UNKNOWN_SETTING }
+SELECT count() FROM clusterAllReplicas('test_shard_localhost', system.one, SETTINGS max_threads = 1); -- { serverError UNKNOWN_SETTING }
+
+-- The SETTINGS clause is preserved in the definition of a table created over the table function.
+DROP TABLE IF EXISTS table_over_cluster_function;
+CREATE TABLE table_over_cluster_function AS clusterAllReplicas('test_unavailable_shard', system.one, SETTINGS skip_unavailable_shards = 1);
+SHOW CREATE TABLE table_over_cluster_function;
+
+SELECT count() FROM table_over_cluster_function;
+SELECT count() FROM table_over_cluster_function SETTINGS skip_unavailable_shards = 0; -- { serverError ALL_CONNECTION_TRIES_FAILED }
+
+DETACH TABLE table_over_cluster_function;
+ATTACH TABLE table_over_cluster_function;
+
+SHOW CREATE TABLE table_over_cluster_function;
+SELECT count() FROM table_over_cluster_function;
+
+DROP TABLE table_over_cluster_function;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/112653

A new optional server configuration section, `create_union_system_log_tables`, requests the creation of `all_...` tables next to the system log tables (`system.all_query_log` for `system.query_log` and so on). Such a table is a union of the corresponding log table, its rotated versions (`query_log_0`, `query_log_1`, ...) and/or the same tables across all replicas of a cluster — an equivalent of `clusterAllReplicas(default, merge(system, '^query_log')) SETTINGS skip_unavailable_shards = 1` that you don't have to remember, with the table structure automatically kept up to date with the structure of the latest table.

```xml
<create_union_system_log_tables>
    <merge_rotated_tables>true</merge_rotated_tables>
    <cluster>default</cluster>
</create_union_system_log_tables>
```

At least one of `merge_rotated_tables` and `cluster` has to be specified; they define whether the table is a merge of the rotated tables, a distributed table over all replicas of a cluster, or a combination of both. The option applies to all system log tables.

The union table is a `CREATE TABLE system.all_query_log (<columns of the log table>) AS merge('system', '^query_log(_[0-9]+)?$')` / `AS clusterAllReplicas('default', ..., SETTINGS skip_unavailable_shards = 1)` proxy table. `SystemLog` verifies it against the expected definition at the first flush and at every rotation of the log table and recreates it with an atomic exchange (`CREATE OR REPLACE`) when it differs; if the table is dropped by a user, it is recreated at the next flush. The tables have no state, so it is always safe to drop them. Creation is supported only in `Atomic`, `Replicated` and `Shared` databases and is skipped otherwise. Failures to create the union table (e.g. a misconfigured cluster) are logged and never interfere with flushing the log itself.

To support `skip_unavailable_shards` in the table definition, the `remote`, `remoteSecure`, `cluster` and `clusterAllReplicas` table functions now accept a trailing `SETTINGS` clause with the settings of the `Distributed` storage they create (previously such a clause was accepted by `mysql`, `postgresql` and other table functions, and the `Distributed` version of `skip_unavailable_shards` already existed for the `Distributed`/`Remote` engines):

```sql
SELECT count() FROM clusterAllReplicas('default', system.query_log, SETTINGS skip_unavailable_shards = 1);
CREATE TABLE t AS remote('127.0.0.{1,2}', system.one, SETTINGS skip_unavailable_shards = 1);
```

A setting specified in the query has priority over the setting from the table function. `CREATE TABLE ... AS table_function(...)` now parses the `SETTINGS` clause too (also required for loading the stored metadata of such tables).

Note: a table definition with a `SETTINGS` clause inside a table function cannot be loaded by servers of previous versions, so downgrading requires dropping such tables first (this applies to the `all_...` tables created with the `cluster` option).

### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A new server configuration section, `create_union_system_log_tables`, requests the creation and automatic maintenance of `all_...` tables (e.g. `system.all_query_log`) that query the union of a system log table, its rotated versions and/or the same tables across all replicas of a cluster. The `remote`, `remoteSecure`, `cluster` and `clusterAllReplicas` table functions now accept a trailing `SETTINGS` clause with the settings of the `Distributed` storage they create, e.g. `clusterAllReplicas('default', system.query_log, SETTINGS skip_unavailable_shards = 1)`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.564` (included in `26.8` and later)
<!-- ch-version-info:end -->