### PR TITLE
Fix `JoinResultRowCount` under-reporting for joins that spill to disk

### DIFF
--- a/src/Processors/Transforms/JoiningTransform.cpp
+++ b/src/Processors/Transforms/JoiningTransform.cpp
@@ -504,6 +504,8 @@ void DelayedJoinedBlocksWorkerTransform::work()
 
     // Add block to the output
     const auto rows = block.rows();
+    /// This port is a first-class member of the join result stream, so these rows belong to the total.
+    ProfileEvents::increment(ProfileEvents::JoinResultRowCount, rows);
     ProfileEvents::increment(ProfileEvents::JoinDelayedJoinedTransformBlockCount);
     ProfileEvents::increment(ProfileEvents::JoinDelayedJoinedTransformRowCount, rows);
     output_chunk.setColumns(block.getColumns(), rows);

--- a/tests/queries/0_stateless/04657_join_result_row_count_delayed_buckets.reference
+++ b/tests/queries/0_stateless/04657_join_result_row_count_delayed_buckets.reference
@@ -1,0 +1,8 @@
+04657_grace_inner	1	1
+04657_mem_inner	1	0
+04657_ph_full	1	1
+04657_ph_right	1	1
+04657_spill_full	1	1
+04657_spill_inner	1	1
+04657_spill_left	1	1
+04657_spill_right	1	1

--- a/tests/queries/0_stateless/04657_join_result_row_count_delayed_buckets.sql
+++ b/tests/queries/0_stateless/04657_join_result_row_count_delayed_buckets.sql
@@ -1,0 +1,125 @@
+-- Regression test for issue #112422: JoinResultRowCount omitted the rows emitted by
+-- `DelayedJoinedBlocksWorkerTransform`, so any join that spilled to disk under-reported its
+-- result size. Results were always correct; only the ProfileEvent was wrong.
+--
+-- Each cell asserts JoinResultRowCount against result_rows, the number of rows the query
+-- actually returned, so a fix that double-counts is just as visible as the original undercount.
+-- The cells stream their rows and are read with FORMAT Null: an aggregate such as `count` would
+-- log result_rows = 1 and the comparison would be meaningless.
+-- The in-memory cell is a control that was already correct before the fix and must not change.
+
+SET enable_analyzer = 1;
+SET enable_parallel_replicas = 0;
+-- Pin the join orientation: side swapping decides which side emits non-joined rows.
+SET query_plan_optimize_join_order_randomize = 0;
+SET query_plan_join_swap_table = 0;
+-- The runner randomizes max_bytes_before_external_join and grace_hash_join_initial_buckets, so
+-- every cell pins both explicitly. max_bytes_ratio_before_external_join is not randomized, but its
+-- 0.5 default makes the resolved threshold non-zero, which would put the in-memory control on the
+-- spill-capable `SpillingHashJoin` path; pinning it to 0 keeps that control a plain `HashJoin`.
+SET max_bytes_ratio_before_external_join = 0;
+-- The stress profile sets ast_fuzzer_runs=5; a fuzzed re-run inherits log_comment and would win
+-- the lookup against system.query_log below.
+SET ast_fuzzer_runs = 0;
+SET max_threads = 4;
+
+-- In-memory control, INNER: no delayed output, counter already correct before the fix.
+SELECT t1.k
+FROM (SELECT number AS k FROM numbers(50000)) AS t1
+INNER JOIN (SELECT number AS k FROM numbers(50000)) AS t2 ON t1.k = t2.k
+SETTINGS log_comment = '04657_mem_inner', join_algorithm = 'hash',
+    max_bytes_before_external_join = 0, grace_hash_join_initial_buckets = 1
+FORMAT Null;
+
+-- Spilling INNER via `SpillingHashJoin`: 50000 matched rows.
+SELECT t1.k
+FROM (SELECT number AS k FROM numbers(50000)) AS t1
+INNER JOIN (SELECT number AS k FROM numbers(50000)) AS t2 ON t1.k = t2.k
+SETTINGS log_comment = '04657_spill_inner', join_algorithm = 'hash',
+    max_bytes_before_external_join = 100000, grace_hash_join_initial_buckets = 1
+FORMAT Null;
+
+-- Spilling LEFT: 25000 matched plus 25000 left rows with no match.
+SELECT t1.k
+FROM (SELECT number AS k FROM numbers(50000)) AS t1
+LEFT JOIN (SELECT number + 25000 AS k FROM numbers(50000)) AS t2 ON t1.k = t2.k
+SETTINGS log_comment = '04657_spill_left', join_algorithm = 'hash',
+    max_bytes_before_external_join = 100000, grace_hash_join_initial_buckets = 1
+FORMAT Null;
+
+-- Spilling RIGHT: right non-joined rows travel through `nextNonJoinedBlock` inside the delayed
+-- worker, so this covers a different sub-path than the INNER cell.
+SELECT t2.k
+FROM (SELECT number + 25000 AS k FROM numbers(50000)) AS t1
+RIGHT JOIN (SELECT number AS k FROM numbers(50000)) AS t2 ON t1.k = t2.k
+SETTINGS log_comment = '04657_spill_right', join_algorithm = 'hash',
+    max_bytes_before_external_join = 100000, grace_hash_join_initial_buckets = 1
+FORMAT Null;
+
+-- Spilling FULL: 25000 matched, 25000 left-only, 25000 right-only. Non-joined rows from both
+-- sides travel through the delayed worker, so this is the widest emitter mix reachable with
+-- `join_algorithm = 'hash'`. The runner randomizes parallel_non_joined_rows_processing, so pin
+-- it; note it cannot take effect here, because a single-thread `SpillingHashJoin` reports
+-- `supportParallelNonJoinedBlocksProcessing` as false and no `NonJoinedBlocksTransform` is
+-- built. The parallel_hash cells below are the ones that wire that separate emitter.
+SELECT t1.k, t2.k
+FROM (SELECT number + 1 AS k FROM numbers(50000)) AS t1
+FULL JOIN (SELECT number + 25001 AS k FROM numbers(50000)) AS t2 ON t1.k = t2.k
+SETTINGS log_comment = '04657_spill_full', join_algorithm = 'hash',
+    max_bytes_before_external_join = 100000, grace_hash_join_initial_buckets = 1,
+    parallel_non_joined_rows_processing = 1
+FORMAT Null;
+
+-- Explicit grace_hash: a carrier the issue does not mention. It needs at least two initial
+-- buckets, because with grace_hash_join_initial_buckets = 1 nothing is delayed and the cell
+-- would be vacuous.
+SELECT t1.k
+FROM (SELECT number AS k FROM numbers(50000)) AS t1
+INNER JOIN (SELECT number AS k FROM numbers(50000)) AS t2 ON t1.k = t2.k
+SETTINGS log_comment = '04657_grace_inner', join_algorithm = 'grace_hash',
+    max_bytes_before_external_join = 100000, grace_hash_join_initial_buckets = 4
+FORMAT Null;
+
+-- The two parallel_hash cells below take the concurrent `SpillingHashJoin` constructor, a
+-- different code path from the single-thread one every cell above uses, and they are the only
+-- cells here that build the second `DelayedPortsProcessor` of `QueryPipelineBuilder`. They pin
+-- that the total stays exact through that extra port layer. The `NonJoinedBlocksTransform`
+-- sources this shape also wires stay silent while the join is spilled, because
+-- `SpillingHashJoin::isParallelNonJoinedProcessingEnabled` requires the in-memory state, so the
+-- delayed worker is still the only emitter of the non-joined rows.
+
+-- parallel_hash RIGHT, spilling: same rows as the 04657_spill_right cell, 50000 in total.
+SELECT t2.k
+FROM (SELECT number + 25000 AS k FROM numbers(50000)) AS t1
+RIGHT JOIN (SELECT number AS k FROM numbers(50000)) AS t2 ON t1.k = t2.k
+SETTINGS log_comment = '04657_ph_right', join_algorithm = 'parallel_hash',
+    max_bytes_before_external_join = 100000, grace_hash_join_initial_buckets = 1,
+    parallel_non_joined_rows_processing = 1
+FORMAT Null;
+
+-- parallel_hash FULL, spilling: same rows as the 04657_spill_full cell, 75000 in total.
+SELECT t1.k, t2.k
+FROM (SELECT number + 1 AS k FROM numbers(50000)) AS t1
+FULL JOIN (SELECT number + 25001 AS k FROM numbers(50000)) AS t2 ON t1.k = t2.k
+SETTINGS log_comment = '04657_ph_full', join_algorithm = 'parallel_hash',
+    max_bytes_before_external_join = 100000, grace_hash_join_initial_buckets = 1,
+    parallel_non_joined_rows_processing = 1
+FORMAT Null;
+
+SYSTEM FLUSH LOGS query_log;
+
+-- total_equals_result is an equality against ground truth rather than a hardcoded number.
+-- has_delayed_rows proves the delayed path was really exercised: without it, a cell that stops
+-- spilling would pass while covering nothing.
+SELECT
+    log_comment,
+    ProfileEvents['JoinResultRowCount'] = result_rows AS total_equals_result,
+    ProfileEvents['JoinDelayedJoinedTransformRowCount'] > 0 AS has_delayed_rows
+FROM system.query_log
+WHERE log_comment IN ('04657_mem_inner', '04657_spill_inner', '04657_spill_left',
+                      '04657_spill_right', '04657_spill_full', '04657_grace_inner',
+                      '04657_ph_right', '04657_ph_full')
+    AND current_database = currentDatabase()
+    AND type = 'QueryFinish'
+    AND event_date >= yesterday()
+ORDER BY log_comment;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/112422
Related: https://github.com/ClickHouse/ClickHouse/pull/112645
Related: https://github.com/ClickHouse/ClickHouse/pull/105630
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes `ProfileEvents['JoinResultRowCount']` under-reporting the result size of a `JOIN` that spills to disk. Rows emitted from delayed buckets were counted only in `JoinDelayedJoinedTransformRowCount` and were missing from the total. Query results were always correct; only the profile event was wrong.


### Description

`JoinResultRowCount` is documented as "Total number of rows in the result of a JOIN operation", but a join whose output flows through `DelayedJoinedBlocksWorkerTransform` lost those rows from the total.

Root cause: `src/Processors/Transforms/JoiningTransform.cpp` has four processors that emit join result rows. Three increment the total; `DelayedJoinedBlocksWorkerTransform::work` incremented only its own block/row pair. Its output port is pushed into `joined_output_ports` next to the `JoiningTransform` port (`QueryPipeline/QueryPipelineBuilder.cpp:617-618`), so every row it emits is a result row and belongs in the total. The change adds the missing increment at that emitter, giving it the same trio `NonJoinedBlocksTransform::generate` already uses.

This is reachable on the default configuration: `max_bytes_before_external_join` defaults to 0, but `max_bytes_ratio_before_external_join` defaults to `0.5`, so a large enough build side spills automatically. One hunk covers both join classes that reach the path, `GraceHashJoin` and `SpillingHashJoin`, since they share a single construction site.

Validation: a new stateless test asserts, per cell, that `JoinResultRowCount` equals the number of rows the query actually returned, so a double-count is as visible as the original undercount. It passes on this branch and fails on unmodified master with the in-memory control still green. Pre-fix versus post-fix totals: spilling `INNER`/`LEFT`/`RIGHT` 25000 to 50000, `FULL` 37500 to 75000, explicit `grace_hash` 12500 to 50000.

The change also repairs three existing tests that assert `JoinResultRowCount` and fail once the runner's spill randomization actually spills (both `03279_join_choose_build_table*` files and `03759_join_filterpushdown_granules_read`). That failure is the one #105630 recorded when it deferred randomizing `max_bytes_ratio_before_external_join`; enabling that randomization is left as separate work.

This issue also reports a sorting-side overcount, fixed separately in #112645. `full_sorting_merge`, `partial_merge` and `paste` never increment this event at all, which is a different mechanism in a different file and is tracked separately.

Related: https://github.com/ClickHouse/ClickHouse/issues/112422