### PR TITLE
Fix ClickBench server start racing self-extraction

### DIFF
--- a/ci/jobs/scripts/clickhouse_service.py
+++ b/ci/jobs/scripts/clickhouse_service.py
@@ -76,6 +76,17 @@ class ClickHouseService:
                 if not link_path.exists():
                     Utils.link(clickhouse_bin, link_path)
 
+            # The build artifacts are self-extracting: the first invocation
+            # decompresses the real ELF in place. An unstripped release build
+            # expands to over 4 GB, which on its own can outlast the pid-file
+            # wait in `_wait_ready`, so the server gets killed mid-extraction
+            # before it ever runs and the job fails with `Failed to get PID`.
+            # Extract synchronously here - the same thing the install stage in
+            # `functional_tests.py` does - so that wait covers server startup
+            # only. Decompression is a no-op once the binary is extracted, so
+            # this is cheap on repeat starts within a job.
+            Shell.run(f"{clickhouse_bin} --version", verbose=True, strict=True)
+
             # Run config hooks in order, passing the config and data dirs so a
             # hook can build paths into either. Typically the first is
             # `install_base`, then per-job tune-ups that customize it.


### PR DESCRIPTION
The `ClickBench (amd_release)` job on master failed at `Start ClickHouse`:

```
RuntimeError: Failed to get PID from [.../ci/tmp/etc/clickhouse-server/clickhouse-server.pid]
```

and the captured server log contained nothing but the self-extracting decompressor's progress:

```
Decompressing the binary................................
```

`ClickHouseService` launches `clickhouse-server` straight from the downloaded build artifact. That artifact is a self-extracting executable, so the first invocation decompresses the real ELF in place before any server code runs. The unstripped release build expands to over 4 GB (32 blocks of 128 MiB, one dot per block — matching the 32 dots in the log), and that extraction outlasted the 30-second pid-file wait in `_wait_ready`. The wait expired, the process group was killed mid-extraction, and the job failed before the server ever started.

The fix extracts the binary synchronously before launching the server, so the pid-file wait covers server startup only. This is the same thing the install stage in `functional_tests.py` already does, for the same reason. Extraction is a no-op once the binary is unpacked, so repeat starts within a job are unaffected.

The change is in the shared start path, so it also covers the stress, AST fuzzer, CI tests and vector search stress jobs.

Verified locally that the added call behaves as intended: on a fresh self-extracting master binary `Shell.run("<binary> --version", strict=True)` returns 0 after completing the extraction and streams the decompressor output into the job log; a second call takes 0.0s.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d4f94c252b9b49b349494e81a57532db1829296c&name_0=MasterCI&name_1=ClickBench%20%28amd_release%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
