### PR TITLE
Prevent DatabaseCatalog static destructor from destroying IStorage and IDatabase objects

### DIFF
--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -374,14 +374,14 @@ void DatabaseAtomic::renameTable(ContextPtr local_context, const String & table_
     else
         db_disk->moveFile(old_metadata_path, new_metadata_path);
 
+    table->renameInMemory(new_table_id);
+    if (exchange)
+        other_table->renameInMemory(other_table_new_id);
+
     /// After metadata was successfully moved, the following methods should not throw (if they do, it's a logical error)
     table_data_path = detach(*this, table_name, table->storesDataOnDisk());
     if (exchange)
         other_table_data_path = detach(other_db, to_table_name, other_table->storesDataOnDisk());
-
-    table->renameInMemory(new_table_id);
-    if (exchange)
-        other_table->renameInMemory(other_table_new_id);
 
     if (!inside_database)
     {

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -364,14 +364,14 @@ void DatabaseCatalog::shutdownImpl(std::function<void()> shutdown_system_logs)
         if (db_uuid != UUIDHelpers::Nil)
             removeUUIDMapping(db_uuid);
     }
-    chassert(std::find_if(uuid_map.begin(), uuid_map.end(), [](const auto & elem)
+    assert(std::find_if(uuid_map.begin(), uuid_map.end(), [](const auto & elem)
     {
         /// Ensure that all UUID mappings are empty (i.e. all mappings contain nullptr instead of a pointer to storage)
         const auto & not_empty_mapping = [] (const auto & mapping)
         {
             auto & db = mapping.second.first;
             auto & table = mapping.second.second;
-            return db || table;
+            return !db.expired() || !table.expired();
         };
         std::lock_guard map_lock{elem.mutex};
         auto it = std::find_if(elem.map.begin(), elem.map.end(), not_empty_mapping);
@@ -402,7 +402,7 @@ DatabaseAndTable DatabaseCatalog::tryGetByUUID(const UUID & uuid) const
     auto it = map_part.map.find(uuid);
     if (it == map_part.map.end())
         return {};
-    return it->second;
+    return {it->second.first.lock(), it->second.second.lock()};
 }
 
 
@@ -1001,9 +1001,9 @@ void DatabaseCatalog::addUUIDMapping(const UUID & uuid, const DatabasePtr & data
 
     auto & prev_database = it->second.first;
     auto & prev_table = it->second.second;
-    chassert(prev_database || !prev_table);
+    chassert(!prev_database.expired() || prev_table.expired());
 
-    if (!prev_database && database)
+    if (prev_database.expired() && database)
     {
         /// It's empty mapping, it was created to "lock" UUID and prevent collision. Just update it.
         prev_database = database;
@@ -1011,7 +1011,7 @@ void DatabaseCatalog::addUUIDMapping(const UUID & uuid, const DatabasePtr & data
         return;
     }
 
-    /// We are trying to replace existing mapping (prev_database != nullptr), it's logical error
+    /// We are trying to replace existing mapping (prev_database is still alive), it's logical error
     if (database || table)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Mapping for table with UUID={} already exists", uuid);
     /// Normally this should never happen, but it's possible when the same UUIDs are explicitly specified in different CREATE queries,
@@ -1028,7 +1028,7 @@ void DatabaseCatalog::removeUUIDMapping(const UUID & uuid)
     auto it = map_part.map.find(uuid);
     if (it == map_part.map.end())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Mapping for table with UUID={} doesn't exist", uuid);
-    it->second = {nullptr, nullptr};
+    it->second = {};
 }
 
 void DatabaseCatalog::removeUUIDMappingFinally(const UUID & uuid)
@@ -1051,9 +1051,9 @@ void DatabaseCatalog::updateUUIDMapping(const UUID & uuid, DatabasePtr database,
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Mapping for table with UUID={} doesn't exist", uuid);
     auto & prev_database = it->second.first;
     auto & prev_table = it->second.second;
-    chassert(prev_database && prev_table);
-    prev_database = std::move(database);
-    prev_table = std::move(table);
+    chassert(!prev_database.expired() && !prev_table.expired());
+    prev_database = database;
+    prev_table = table;
 }
 
 bool DatabaseCatalog::hasUUIDMapping(const UUID & uuid)

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -364,7 +364,7 @@ void DatabaseCatalog::shutdownImpl(std::function<void()> shutdown_system_logs)
         if (db_uuid != UUIDHelpers::Nil)
             removeUUIDMapping(db_uuid);
     }
-    assert(std::find_if(uuid_map.begin(), uuid_map.end(), [](const auto & elem)
+    chassert(std::find_if(uuid_map.begin(), uuid_map.end(), [](const auto & elem)
     {
         /// Ensure that all UUID mappings are empty (i.e. all mappings contain nullptr instead of a pointer to storage)
         const auto & not_empty_mapping = [] (const auto & mapping)

--- a/src/Interpreters/DatabaseCatalog.h
+++ b/src/Interpreters/DatabaseCatalog.h
@@ -37,6 +37,7 @@ class IDisk;
 
 using DatabasePtr = std::shared_ptr<IDatabase>;
 using DatabaseAndTable = std::pair<DatabasePtr, StoragePtr>;
+using DatabaseAndTableWeak = std::pair<std::weak_ptr<IDatabase>, std::weak_ptr<IStorage>>;
 using Databases = std::map<String, std::shared_ptr<IDatabase>, std::less<>>;
 using DiskPtr = std::shared_ptr<IDisk>;
 using TableNamesSet = std::unordered_set<QualifiedTableName>;
@@ -300,7 +301,7 @@ private:
 
     struct UUIDToStorageMapPart
     {
-        std::unordered_map<UUID, DatabaseAndTable> map TSA_GUARDED_BY(mutex);
+        std::unordered_map<UUID, DatabaseAndTableWeak> map TSA_GUARDED_BY(mutex);
         mutable std::mutex mutex;
     };
 

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -350,6 +350,11 @@ void StorageKafka::shutdown(bool)
     StreamingStorageRegistry::instance().unregisterTable(getStorageID(), /* if_exists */ true);
 }
 
+void StorageKafka::checkTableCanBeRenamed(const StorageID & /*new_name*/) const
+{
+    StreamingStorageRegistry::instance().checkTableCanBeRenamed(getStorageID());
+}
+
 void StorageKafka::renameInMemory(const StorageID & new_table_id)
 {
     const auto prev_storage_id = getStorageID();

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -61,6 +61,8 @@ public:
     void startup() override;
     void shutdown(bool is_drop) override;
 
+    void checkTableCanBeRenamed(const StorageID & new_name) const override;
+
     void renameInMemory(const StorageID & new_table_id) override;
 
     void read(

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -1822,6 +1822,8 @@ ObjectStorageQueueSettings StorageObjectStorageQueue::getSettings() const
 
 void StorageObjectStorageQueue::checkTableCanBeRenamed(const StorageID & new_name) const
 {
+    StreamingStorageRegistry::instance().checkTableCanBeRenamed(getStorageID());
+
     const bool move_between_databases = getStorageID().database_name != new_name.database_name;
     if (move_between_databases && !can_be_moved_between_databases)
     {

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -1036,6 +1036,11 @@ void StorageRabbitMQ::shutdown(bool)
     LOG_TRACE(log, "Shutdown finished");
 }
 
+void StorageRabbitMQ::checkTableCanBeRenamed(const StorageID & /*new_name*/) const
+{
+    StreamingStorageRegistry::instance().checkTableCanBeRenamed(getStorageID());
+}
+
 void StorageRabbitMQ::renameInMemory(const StorageID & new_table_id)
 {
     const auto prev_storage_id = getStorageID();

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.h
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.h
@@ -45,6 +45,8 @@ public:
 
     void cancelBackgroundActivity() override;
 
+    void checkTableCanBeRenamed(const StorageID & new_name) const override;
+
     void renameInMemory(const StorageID & new_table_id) override;
 
     /// This is a bad way to let storage know in shutdown() that table is going to be dropped. There are some actions which need

--- a/src/Storages/StreamingStorageRegistry.cpp
+++ b/src/Storages/StreamingStorageRegistry.cpp
@@ -30,6 +30,7 @@ std::string makeMetadataKey(const std::string & zookeeper_name, const std::strin
 
 namespace ErrorCodes
 {
+    extern const int ABORTED;
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
     extern const int TABLE_ALREADY_EXISTS;
@@ -116,6 +117,16 @@ void StreamingStorageRegistry::unregisterTable(const StorageID & storage, bool i
     }
     storages.erase(it);
     LOG_TRACE(log, "Unregistered table: {}", storage.getNameForLogs());
+}
+
+void StreamingStorageRegistry::checkTableCanBeRenamed(const StorageID & from)
+{
+    std::lock_guard lock(mutex);
+    if (shutdown_called)
+        throw Exception(ErrorCodes::ABORTED, "Cannot rename {}, the server is shutting down", from.getNameForLogs());
+
+    if (!storages.contains(from))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Table with storage id {} is not registered", from.getNameForLogs());
 }
 
 void StreamingStorageRegistry::renameTable(const StorageID & from, const StorageID & to)

--- a/src/Storages/StreamingStorageRegistry.h
+++ b/src/Storages/StreamingStorageRegistry.h
@@ -27,6 +27,9 @@ public:
 
     void renameTable(const StorageID & from, const StorageID & to);
 
+    /// Throws if a subsequent renameTable for this storage would fail.
+    void checkTableCanBeRenamed(const StorageID & from);
+
     void shutdown();
 
 private:


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):

- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Destroying IStorage or IDatabase objects in a static destructor can result in segfaults as their destructors access statics that may have been destroyed. This change is a defensive follow-up after a segfault investigation and fix.
