### PR TITLE
Fix `No space left on device` in the `Install packages` job

### DIFF
--- a/ci/jobs/install_check.py
+++ b/ci/jobs/install_check.py
@@ -144,6 +144,11 @@ bash -ex /packages/keeper_test.sh""",
 def test_install_tgz(image: DockerImage) -> List[Result]:
     # FIXME: I couldn't find why Type=notify is broken in centos:8
     # systemd just ignores the watchdog completely
+
+    # `doinst.sh` copies the unpacked tree into the system instead of moving it, so a
+    # package occupies twice its size - 6.8 GiB for `clickhouse-common-static-dbg` -
+    # until the tree is removed. These are by far the most disk hungry tests of the
+    # job, and they used to fail with `No space left on device`.
     tests = {
         f"Install server tgz in {image}": r"""#!/bin/bash -ex
 [ -f /etc/debian_version ] && CONFIGURE=configure || CONFIGURE=
@@ -152,6 +157,7 @@ for pkg in /packages/clickhouse-{common,client,server}*tgz; do
     package=${package##*/}
     tar xf "$pkg"
     "/$package/install/doinst.sh" $CONFIGURE
+    rm -rf "/${package:?}"
 done
 [ -f /etc/yum.conf ] && echo CLICKHOUSE_WATCHDOG_ENABLE=0 > /etc/default/clickhouse-server
 bash -ex /packages/server_test.sh""",
@@ -162,6 +168,7 @@ for pkg in /packages/clickhouse-keeper*tgz; do
     package=${package##*/}
     tar xf "$pkg"
     "/$package/install/doinst.sh" $CONFIGURE
+    rm -rf "/${package:?}"
 done
 bash -ex /packages/keeper_test.sh""",
     }
@@ -189,6 +196,18 @@ def test_install(image: DockerImage, tests: Dict[str, str]) -> List[Result]:
         )
         Shell.check(f"docker kill -s 9 {container_id}", verbose=True)
     return test_results
+
+
+def free_packages(pattern: str) -> None:
+    """Delete the packages that have already been tested.
+
+    All the package flavours are downloaded into the same directory, which is mounted
+    into every container, and together they take more than 6 GiB - as much as a single
+    container needs to install them. Nothing reads a package once its own tests are
+    done, so drop it to leave room for the tests that follow.
+    """
+    Shell.check(f"rm -f {TEMP_PATH}/{pattern}", verbose=True)
+    Shell.check("df -h /", verbose=True)
 
 
 def parse_args() -> argparse.Namespace:
@@ -241,9 +260,11 @@ def main():
     if args.deb:
         print("Test debian")
         test_results.extend(test_install_deb(deb_image))
+        free_packages("*.deb")
     if args.rpm:
         print("Test rpm")
         test_results.extend(test_install_rpm(rpm_image))
+        free_packages("*.rpm")
     if args.tgz:
         print("Test tgz")
         test_results.extend(test_install_tgz(deb_image))


### PR DESCRIPTION
The tgz tests of the `Install packages` job keep failing on the AMD runners with

```
cp: error writing '/usr/lib/debug/usr/bin/clickhouse.debug': No space left on device
```

It is not a one-off: master and the release branches hit it on 2026-07-23, 07-25, 07-26 and 07-30, always in `Install server tgz`, always in both the deb and the rpm image.

The tgz tests run last and are by far the most disk hungry tests of the job. `doinst.sh` copies the unpacked tarball into the system instead of moving it, so a package occupies twice its size until the unpacked tree is removed - 6.8 GiB for `clickhouse-common-static-dbg` alone. At that moment the deb, rpm and tgz packages of the same build, over 6 GiB together, are all still sitting in `ci/tmp`, which is mounted into the container.

This removes the unpacked tree once `doinst.sh` has installed it, and deletes the deb and the rpm packages once their own tests are done, which frees about 5 GiB. It also prints `df -h /` between the phases, since nothing in the report told us how tight the disk was.

The `--rm` plus `docker kill` container teardown was left alone on purpose: making it synchronous with `docker rm -f` would serialize the removal of multi-gigabyte writable layers into the critical path, and this job already times out against its 900s limit from time to time.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3bb7f633cfc4794a68bd724a8060b472fd6ec5d5&name_0=MasterCI&name_1=Install%20packages%20%28amd_release%29
