### PR TITLE
Do not read part sizes while committing under the parts lock

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Common/UniqueLock.h>
+
 #include <atomic>
 #include <filesystem>
 #include <mutex>
@@ -564,6 +566,15 @@ public:
     /// If checksums.txt exists, reads file's checksums (and sizes) from it
     void loadChecksums(bool require);
     bool areChecksumsLoaded() const { return !checksums.empty(); }
+
+    /// Whether this part's column and secondary index sizes are already computed.
+    /// Never triggers the lazy computation: that reads from the part storage, and callers
+    /// use this to decide whether reading is safe here.
+    bool areColumnAndSecondaryIndexSizesCalculated() const
+    {
+        UniqueLock lock(columns_and_secondary_indices_sizes_mutex);
+        return are_columns_and_secondary_indices_sizes_calculated;
+    }
 
     void setBrokenReason(const String & message, int code) const;
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7331,6 +7331,7 @@ void MergeTreeData::calculateColumnAndSecondaryIndexSizesImpl(DataPartsLock & /*
 
     column_sizes.clear();
     secondary_index_sizes.clear();
+    primary_index_size = {};
 
     /// Take into account only committed parts
     auto committed_parts_range = getDataPartsStateRange(DataPartState::Active);
@@ -7347,6 +7348,7 @@ void MergeTreeData::calculateColumnAndSecondaryIndexSizesLazily(DataPartsSharedL
 
     column_sizes.clear();
     secondary_index_sizes.clear();
+    primary_index_size = {};
 
     auto committed_parts_range = getDataPartsStateRange(DataPartState::Active);
 
@@ -7375,12 +7377,30 @@ void MergeTreeData::calculateColumnAndSecondaryIndexSizesLazily(DataPartsSharedL
     are_columns_and_secondary_indices_sizes_calculated = true;
 }
 
+/// A part whose sizes are not computed yet cannot be accounted for without reading them from its
+/// storage. Callers hold the parts lock, and `Transaction::commit` calls them from inside a
+/// NOEXCEPT_SCOPE, where a read that fails to schedule a thread would terminate the server. So drop
+/// the aggregates instead and let the next reader rebuild them from the active parts.
+void MergeTreeData::invalidateColumnAndSecondaryIndexSizesUnlocked() const
+{
+    column_sizes.clear();
+    secondary_index_sizes.clear();
+    primary_index_size = {};
+    are_columns_and_secondary_indices_sizes_calculated = false;
+}
+
 void MergeTreeData::addPartContributionToColumnAndSecondaryIndexSizes(const DataPartPtr & part) const
 {
     /// If sizes are calculated lazily, don't add part contribution. All sizes from all active parts will be calculated later.
     std::unique_lock lock(columns_and_secondary_indices_sizes_mutex);
     if (!are_columns_and_secondary_indices_sizes_calculated)
         return;
+
+    if (!part->areColumnAndSecondaryIndexSizesCalculated())
+    {
+        invalidateColumnAndSecondaryIndexSizesUnlocked();
+        return;
+    }
 
     addPartContributionToColumnAndSecondaryIndexSizesUnlocked(part);
 }
@@ -7448,6 +7468,12 @@ void MergeTreeData::removePartContributionToColumnAndSecondaryIndexSizes(const D
     if (!are_columns_and_secondary_indices_sizes_calculated)
         return;
 
+    if (!part->areColumnAndSecondaryIndexSizesCalculated())
+    {
+        invalidateColumnAndSecondaryIndexSizesUnlocked();
+        return;
+    }
+
     for (const auto & column : part->getColumns())
     {
         ColumnSize & total_column_size = column_sizes[column.name];
@@ -7467,12 +7493,11 @@ void MergeTreeData::removePartContributionToColumnAndSecondaryIndexSizes(const D
         log_subtract(total_column_size.marks, part_column_size.marks, ".marks");
     }
 
-    const auto metadata_ptr = getInMemoryMetadataPtr(getContext(), false);
     for (auto & [secondary_index_name, total_secondary_index_size] : secondary_index_sizes)
     {
-        if (!part->hasSecondaryIndex(secondary_index_name, metadata_ptr))
-            continue;
-
+        /// No hasSecondaryIndex() check: it resolves the index file through the part storage, which
+        /// reads on packed storage, and getSecondaryIndexSize() already returns an empty size for an
+        /// index the part does not have, so subtracting it is a no-op.
         IndexSize part_secondary_index_size = part->getSecondaryIndexSize(secondary_index_name);
 
         auto log_subtract = [&](size_t & from, size_t value, const char * field)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7495,8 +7495,8 @@ void MergeTreeData::removePartContributionToColumnAndSecondaryIndexSizes(const D
 
     for (auto & [secondary_index_name, total_secondary_index_size] : secondary_index_sizes)
     {
-        /// No hasSecondaryIndex() check: it resolves the index file through the part storage, which
-        /// reads on packed storage, and getSecondaryIndexSize() already returns an empty size for an
+        /// No `hasSecondaryIndex` check: it resolves the index file through the part storage, which
+        /// reads on packed storage, and `getSecondaryIndexSize` already returns an empty size for an
         /// index the part does not have, so subtracting it is a no-op.
         IndexSize part_secondary_index_size = part->getSecondaryIndexSize(secondary_index_name);
 

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1542,6 +1542,8 @@ protected:
 
     void unregisterFromMergeSelection(const MergeTreeSettingsPtr & settings);
 
+    void invalidateColumnAndSecondaryIndexSizesUnlocked() const;
+
     void resetColumnSizes()
     {
         column_sizes.clear();

--- a/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.reference
+++ b/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.reference
@@ -1,0 +1,9 @@
+packed	1	Packed
+accounted	1
+untouched	1
+rows	1
+fewer_file_open	1
+fewer_pool_read	1
+sizes_correct	m_a	1
+sizes_correct	m_b	1
+rows_intact	2000

--- a/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.reference
+++ b/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.reference
@@ -1,7 +1,7 @@
 packed	1	Packed
 accounted	1
-untouched	1
 rows	1
+untouched	1
 fewer_file_open	1
 fewer_pool_read	1
 sizes_index_equal	1	1	1

--- a/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.reference
+++ b/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.reference
@@ -4,6 +4,6 @@ untouched	1
 rows	1
 fewer_file_open	1
 fewer_pool_read	1
-sizes_correct	m_a	1
-sizes_correct	m_b	1
+sizes_index_equal	1	1	1
+sizes_column_equal	1	1	1
 rows_intact	2000

--- a/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.sql
+++ b/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.sql
@@ -3,23 +3,23 @@
 -- tests/config/install.sh, which clears EXPORT_S3_STORAGE_POLICIES, so the s3 policies are not
 -- installed there at all.
 
--- MergeTreeData::Transaction::commit updates the table's per-column and per-secondary-index size
--- aggregates inside a NOEXCEPT_SCOPE. For a part whose sizes are not computed yet, that update used
--- to call the size getters, which lazily read the part storage. On packed storage that read resolves
--- the skip-index archive index, and on object storage it is scheduled onto a thread pool. A thread
--- pool that cannot schedule throws CANNOT_SCHEDULE_TASK, which is not a memory-tracker exception, so
--- LockMemoryExceptionInThread does not suppress it, it reaches the NOEXCEPT_SCOPE catch-all, and the
--- server terminates.
+-- `MergeTreeData::Transaction::commit` updates the table's per-column and per-secondary-index size
+-- aggregates inside a `NOEXCEPT_SCOPE`. For a part whose sizes are not computed yet, that update
+-- used to call the size getters, which lazily read the part storage. On packed storage that read
+-- resolves the skip-index archive index, and on object storage it is scheduled onto a thread pool. A
+-- thread pool that cannot schedule throws `CANNOT_SCHEDULE_TASK`, which is not a memory-tracker
+-- exception, so `LockMemoryExceptionInThread` does not suppress it, it reaches the `NOEXCEPT_SCOPE`
+-- catch-all, and the server terminates.
 --
 -- The commit path must therefore perform no storage read at all. This test measures that through
--- the MutatePart row of system.part_log: ProfileEventsScope in MutatePlainMergeTreeTask::executeStep
--- covers transaction.commit, and write_part_log runs after it on the same thread, so a read taken
--- inside the commit is counted there.
+-- the `MutatePart` row of `system.part_log`: `ProfileEventsScope` in
+-- `MutatePlainMergeTreeTask::executeStep` covers `transaction.commit`, and `write_part_log` runs
+-- after it on the same thread, so a read taken inside the commit is counted there.
 --
 -- The cold arm is compared against a warm control rather than against an absolute count: with
--- lazy_calculation = 0 the part is warmed when it is loaded, so that arm always contains exactly one
--- archive read and never needs another one in the commit. Absolute counts would depend on the
--- fixture, the control makes the assertion self-normalizing.
+-- `columns_and_secondary_indices_sizes_lazy_calculation = 0` the part is warmed when it is loaded,
+-- so that arm always contains exactly one archive read and never needs another one in the commit.
+-- Absolute counts would depend on the fixture, the control makes the assertion self-normalizing.
 
 DROP TABLE IF EXISTS packed_commit_cold SYNC;
 DROP TABLE IF EXISTS packed_commit_warm SYNC;
@@ -59,23 +59,25 @@ SETTINGS storage_policy = 's3_no_fake_transaction',
          min_bytes_for_full_part_storage = 1000000000,
          columns_and_secondary_indices_sizes_lazy_calculation = 0;
 
--- String columns on purpose: loadRowsCount computes on-disk sizes for numeric columns in debug and
+-- String columns on purpose: `loadRowsCount` computes on-disk sizes for numeric columns in debug and
 -- sanitizer builds, which would warm the cloned part and hide the read.
 INSERT INTO packed_commit_cold SELECT toString(number), toString(number * 7), toString(number * 11) FROM numbers(2000);
 INSERT INTO packed_commit_warm SELECT toString(number), toString(number * 7), toString(number * 11) FROM numbers(2000);
 
--- Both parts must be Packed, otherwise there is no archive to read and the test is vacuous.
+-- Both parts must be `Packed`, otherwise there is no archive to read and the test is vacuous.
 SELECT 'packed', countDistinct(part_storage_type) = 1, any(part_storage_type)
 FROM system.parts
 WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND active;
 
--- Reading a size sets the table level flag, which is what makes commit update the aggregates at all.
+-- Reading a size sets the table level flag, which is what makes the commit update the aggregates at
+-- all.
 SELECT 'accounted', sum(data_compressed_bytes) > 0
 FROM system.data_skipping_indices
 WHERE database = currentDatabase() AND table LIKE 'packed_commit_%';
 
 -- A predicate matching no rows takes the untouched-part shortcut, which clones the part and keeps
 -- its block range, so the source part is covered and both accounting paths run in the commit.
+-- `MutationUntouchedParts` below asserts that shortcut was taken.
 ALTER TABLE packed_commit_cold UPDATE a = concat(a, 'x') WHERE s = 'no_such_key' SETTINGS mutations_sync = 2;
 ALTER TABLE packed_commit_warm UPDATE a = concat(a, 'x') WHERE s = 'no_such_key' SETTINGS mutations_sync = 2;
 
@@ -87,7 +89,7 @@ SELECT 'rows', count() = 2
 FROM system.part_log
 WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
 
--- The warm control computes the sizes when it loads the cloned part, so its MutatePart row always
+-- The warm control computes the sizes when it loads the cloned part, so its `MutatePart` row always
 -- contains that one archive read. The cold arm must contain strictly fewer file opens, because
 -- after the fix it does not read the archive at all: not when loading (the sizes stay lazy) and not
 -- in the commit (the aggregates are dropped instead of updated). Before the fix it read in the
@@ -96,8 +98,8 @@ WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_ty
 -- Strictly fewer, not "no more than": the unfixed build reads exactly as much as the control, so a
 -- "no more than" assertion would hold on both builds and the test would prove nothing.
 --
--- FileOpen is the counter because it does not depend on which reader implementation serves the
--- read, so the assertion survives local_filesystem_read_method and remote_filesystem_read_method
+-- `FileOpen` is the counter because it does not depend on which reader implementation serves the
+-- read, so the assertion survives `local_filesystem_read_method` and `remote_filesystem_read_method`
 -- randomization.
 SELECT 'fewer_file_open',
     maxIf(ProfileEvents['FileOpen'], table = 'packed_commit_cold')
@@ -105,9 +107,14 @@ SELECT 'fewer_file_open',
 FROM system.part_log
 WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
 
--- The same statement in bytes read through the asynchronous reader. This is the counter that ties
--- the test to the abort: on object storage the archive read is handed to a thread pool, and a pool
--- that cannot schedule is where CANNOT_SCHEDULE_TASK comes from.
+-- The same statement in bytes moved through `ThreadPoolRemoteFSReader::execute` for this read. On
+-- this path that runs synchronously on the mutation thread, via
+-- `AsynchronousBoundedReadBuffer::readSync`, so the `MutatePart` counter scope collects it.
+--
+-- It is a second read-volume signal beside `FileOpen`, not the scheduling observable: on the
+-- scheduled path the same increment happens on a pool worker under its own thread group, which the
+-- part-log snapshot cannot collect. The claim that the read is handed to a pool, and so can raise
+-- `CANNOT_SCHEDULE_TASK`, is carried by the fix's rationale and by the boundary probe instead.
 SELECT 'fewer_pool_read',
     maxIf(ProfileEvents['ThreadpoolReaderReadBytes'], table = 'packed_commit_cold')
    < maxIf(ProfileEvents['ThreadpoolReaderReadBytes'], table = 'packed_commit_warm')
@@ -115,11 +122,71 @@ FROM system.part_log
 WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
 
 -- The aggregates must stay correct: dropping them and rebuilding on the next read has to give the
--- same answer the incremental update gave.
-SELECT 'sizes_correct', name, data_compressed_bytes > 0
-FROM system.data_skipping_indices
-WHERE database = currentDatabase() AND table = 'packed_commit_cold'
-ORDER BY name;
+-- same answer the incremental update gave. The warm control is that answer, because it never takes
+-- the invalidation branch, and the two tables are identical in schema and data. So the two rows below
+-- compare the rebuilt aggregate against the incrementally updated one exactly, on every size field
+-- the system tables expose: a "greater than zero" assertion would also pass for a double-counted or a
+-- truncated aggregate. The `count` and the positivity flag keep the row from passing on an empty join
+-- or on an all-zero answer.
+--
+-- Both aggregates the fix clears are covered: `system.data_skipping_indices` reads
+-- `getSecondaryIndexSizes` and `system.columns` reads `getColumnSizes`. Reading them is also what
+-- forces the cold arm's rebuild.
+SELECT 'sizes_index_equal', count() = 2, min(sizes_equal), min(sizes_positive)
+FROM
+(
+    SELECT
+        (cold_compressed, cold_uncompressed, cold_marks) = (warm_compressed, warm_uncompressed, warm_marks) AS sizes_equal,
+        cold_compressed > 0 AND cold_uncompressed > 0 AND cold_marks > 0 AS sizes_positive
+    FROM
+    (
+        SELECT
+            name,
+            data_compressed_bytes AS cold_compressed,
+            data_uncompressed_bytes AS cold_uncompressed,
+            marks_bytes AS cold_marks
+        FROM system.data_skipping_indices
+        WHERE database = currentDatabase() AND table = 'packed_commit_cold'
+    ) AS cold
+    INNER JOIN
+    (
+        SELECT
+            name,
+            data_compressed_bytes AS warm_compressed,
+            data_uncompressed_bytes AS warm_uncompressed,
+            marks_bytes AS warm_marks
+        FROM system.data_skipping_indices
+        WHERE database = currentDatabase() AND table = 'packed_commit_warm'
+    ) AS warm USING (name)
+) AS index_sizes;
+
+SELECT 'sizes_column_equal', count() = 3, min(sizes_equal), min(sizes_positive)
+FROM
+(
+    SELECT
+        (cold_compressed, cold_uncompressed, cold_marks) = (warm_compressed, warm_uncompressed, warm_marks) AS sizes_equal,
+        cold_compressed > 0 AND cold_uncompressed > 0 AND cold_marks > 0 AS sizes_positive
+    FROM
+    (
+        SELECT
+            name,
+            data_compressed_bytes AS cold_compressed,
+            data_uncompressed_bytes AS cold_uncompressed,
+            marks_bytes AS cold_marks
+        FROM system.columns
+        WHERE database = currentDatabase() AND table = 'packed_commit_cold'
+    ) AS cold
+    INNER JOIN
+    (
+        SELECT
+            name,
+            data_compressed_bytes AS warm_compressed,
+            data_uncompressed_bytes AS warm_uncompressed,
+            marks_bytes AS warm_marks
+        FROM system.columns
+        WHERE database = currentDatabase() AND table = 'packed_commit_warm'
+    ) AS warm USING (name)
+) AS column_sizes;
 
 SELECT 'rows_intact', count() FROM packed_commit_cold;
 

--- a/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.sql
+++ b/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.sql
@@ -1,0 +1,127 @@
+-- Tags: no-fasttest
+-- no-fasttest: needs an object-storage disk (minio). Fast test passes --fast-test to
+-- tests/config/install.sh, which clears EXPORT_S3_STORAGE_POLICIES, so the s3 policies are not
+-- installed there at all.
+
+-- MergeTreeData::Transaction::commit updates the table's per-column and per-secondary-index size
+-- aggregates inside a NOEXCEPT_SCOPE. For a part whose sizes are not computed yet, that update used
+-- to call the size getters, which lazily read the part storage. On packed storage that read resolves
+-- the skip-index archive index, and on object storage it is scheduled onto a thread pool. A thread
+-- pool that cannot schedule throws CANNOT_SCHEDULE_TASK, which is not a memory-tracker exception, so
+-- LockMemoryExceptionInThread does not suppress it, it reaches the NOEXCEPT_SCOPE catch-all, and the
+-- server terminates.
+--
+-- The commit path must therefore perform no storage read at all. This test measures that through
+-- the MutatePart row of system.part_log: ProfileEventsScope in MutatePlainMergeTreeTask::executeStep
+-- covers transaction.commit, and write_part_log runs after it on the same thread, so a read taken
+-- inside the commit is counted there.
+--
+-- The cold arm is compared against a warm control rather than against an absolute count: with
+-- lazy_calculation = 0 the part is warmed when it is loaded, so that arm always contains exactly one
+-- archive read and never needs another one in the commit. Absolute counts would depend on the
+-- fixture, the control makes the assertion self-normalizing.
+
+DROP TABLE IF EXISTS packed_commit_cold SYNC;
+DROP TABLE IF EXISTS packed_commit_warm SYNC;
+
+-- Cold arm: the mutation's cloned part arrives with its sizes not yet computed.
+CREATE TABLE packed_commit_cold
+(
+    s String,
+    a String,
+    b String,
+    INDEX m_a a TYPE minmax GRANULARITY 1,
+    INDEX m_b b TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY s
+SETTINGS storage_policy = 's3_no_fake_transaction',
+         min_bytes_for_wide_part = 0,
+         packed_skip_index_max_bytes = '1M',
+         index_granularity = 1024,
+         min_bytes_for_full_part_storage = 1000000000,
+         columns_and_secondary_indices_sizes_lazy_calculation = 1;
+
+-- Warm control: identical except that the sizes are computed when the part is loaded, so the
+-- commit has no reason to read even before the fix.
+CREATE TABLE packed_commit_warm
+(
+    s String,
+    a String,
+    b String,
+    INDEX m_a a TYPE minmax GRANULARITY 1,
+    INDEX m_b b TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY s
+SETTINGS storage_policy = 's3_no_fake_transaction',
+         min_bytes_for_wide_part = 0,
+         packed_skip_index_max_bytes = '1M',
+         index_granularity = 1024,
+         min_bytes_for_full_part_storage = 1000000000,
+         columns_and_secondary_indices_sizes_lazy_calculation = 0;
+
+-- String columns on purpose: loadRowsCount computes on-disk sizes for numeric columns in debug and
+-- sanitizer builds, which would warm the cloned part and hide the read.
+INSERT INTO packed_commit_cold SELECT toString(number), toString(number * 7), toString(number * 11) FROM numbers(2000);
+INSERT INTO packed_commit_warm SELECT toString(number), toString(number * 7), toString(number * 11) FROM numbers(2000);
+
+-- Both parts must be Packed, otherwise there is no archive to read and the test is vacuous.
+SELECT 'packed', countDistinct(part_storage_type) = 1, any(part_storage_type)
+FROM system.parts
+WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND active;
+
+-- Reading a size sets the table level flag, which is what makes commit update the aggregates at all.
+SELECT 'accounted', sum(data_compressed_bytes) > 0
+FROM system.data_skipping_indices
+WHERE database = currentDatabase() AND table LIKE 'packed_commit_%';
+
+-- A predicate matching no rows takes the untouched-part shortcut, which clones the part and keeps
+-- its block range, so the source part is covered and both accounting paths run in the commit.
+ALTER TABLE packed_commit_cold UPDATE a = concat(a, 'x') WHERE s = 'no_such_key' SETTINGS mutations_sync = 2;
+ALTER TABLE packed_commit_warm UPDATE a = concat(a, 'x') WHERE s = 'no_such_key' SETTINGS mutations_sync = 2;
+
+SELECT 'untouched', value > 0 FROM system.events WHERE event = 'MutationUntouchedParts';
+
+SYSTEM FLUSH LOGS part_log;
+
+SELECT 'rows', count() = 2
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
+
+-- The warm control computes the sizes when it loads the cloned part, so its MutatePart row always
+-- contains that one archive read. The cold arm must contain strictly fewer file opens, because
+-- after the fix it does not read the archive at all: not when loading (the sizes stay lazy) and not
+-- in the commit (the aggregates are dropped instead of updated). Before the fix it read in the
+-- commit, so it opened the same number of files as the control.
+--
+-- Strictly fewer, not "no more than": the unfixed build reads exactly as much as the control, so a
+-- "no more than" assertion would hold on both builds and the test would prove nothing.
+--
+-- FileOpen is the counter because it does not depend on which reader implementation serves the
+-- read, so the assertion survives local_filesystem_read_method and remote_filesystem_read_method
+-- randomization.
+SELECT 'fewer_file_open',
+    maxIf(ProfileEvents['FileOpen'], table = 'packed_commit_cold')
+   < maxIf(ProfileEvents['FileOpen'], table = 'packed_commit_warm')
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
+
+-- The same statement in bytes read through the asynchronous reader. This is the counter that ties
+-- the test to the abort: on object storage the archive read is handed to a thread pool, and a pool
+-- that cannot schedule is where CANNOT_SCHEDULE_TASK comes from.
+SELECT 'fewer_pool_read',
+    maxIf(ProfileEvents['ThreadpoolReaderReadBytes'], table = 'packed_commit_cold')
+   < maxIf(ProfileEvents['ThreadpoolReaderReadBytes'], table = 'packed_commit_warm')
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
+
+-- The aggregates must stay correct: dropping them and rebuilding on the next read has to give the
+-- same answer the incremental update gave.
+SELECT 'sizes_correct', name, data_compressed_bytes > 0
+FROM system.data_skipping_indices
+WHERE database = currentDatabase() AND table = 'packed_commit_cold'
+ORDER BY name;
+
+SELECT 'rows_intact', count() FROM packed_commit_cold;
+
+DROP TABLE packed_commit_cold SYNC;
+DROP TABLE packed_commit_warm SYNC;

--- a/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.sql
+++ b/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.sql
@@ -4,17 +4,20 @@
 -- installed there at all.
 
 -- `MergeTreeData::Transaction::commit` updates the table's per-column and per-secondary-index size
--- aggregates inside a `NOEXCEPT_SCOPE`. For a part whose sizes are not computed yet, that update
--- used to call the size getters, which lazily read the part storage. On packed storage that read
--- resolves the skip-index archive index, and on object storage it is scheduled onto a thread pool. A
--- thread pool that cannot schedule throws `CANNOT_SCHEDULE_TASK`, which is not a memory-tracker
--- exception, so `LockMemoryExceptionInThread` does not suppress it, it reaches the `NOEXCEPT_SCOPE`
--- catch-all, and the server terminates.
+-- aggregates inside a `NOEXCEPT_SCOPE` whose catch-all terminates the server. For a part whose sizes
+-- are not computed yet, that update called the size getters, which lazily read the part storage, and
+-- on packed storage that read resolves the skip-index archive index. Under the default
+-- `local_filesystem_read_method = 'pread_threadpool'` it is submitted to a thread pool, which is where
+-- the reproduced abort came from (`AsynchronousReadBufferFromFileDescriptor::asyncReadInto` ->
+-- `ThreadPoolImpl::scheduleImpl`): a pool that cannot schedule throws `CANNOT_SCHEDULE_TASK`, not a
+-- memory-tracker exception, so `LockMemoryExceptionInThread` does not suppress it and it escapes.
 --
--- The commit path must therefore perform no storage read at all. This test measures that through
--- the `MutatePart` row of `system.part_log`: `ProfileEventsScope` in
--- `MutatePlainMergeTreeTask::executeStep` covers `transaction.commit`, and `write_part_log` runs
--- after it on the same thread, so a read taken inside the commit is counted there.
+-- The commit must therefore read nothing. The oracle is the `MutatePart` row of `system.part_log`:
+-- `ProfileEventsScope` in `MutatePlainMergeTreeTask::executeStep` covers `transaction.commit`, and
+-- `write_part_log` runs after it on the same thread. An object-storage disk is used not because the
+-- scheduling happens there, but because it makes the extra access deterministically measurable as
+-- read volume: on it the read runs synchronously (`AsynchronousBoundedReadBuffer::readSync` ->
+-- `ThreadPoolRemoteFSReader::execute`), so the test observes the access, not the scheduling.
 --
 -- The cold arm is compared against a warm control rather than against an absolute count: with
 -- `columns_and_secondary_indices_sizes_lazy_calculation = 0` the part is warmed when it is loaded,
@@ -77,15 +80,22 @@ WHERE database = currentDatabase() AND table LIKE 'packed_commit_%';
 
 -- A predicate matching no rows takes the untouched-part shortcut, which clones the part and keeps
 -- its block range, so the source part is covered and both accounting paths run in the commit.
--- `MutationUntouchedParts` below asserts that shortcut was taken.
+-- `untouched` below asserts that shortcut was taken.
 ALTER TABLE packed_commit_cold UPDATE a = concat(a, 'x') WHERE s = 'no_such_key' SETTINGS mutations_sync = 2;
 ALTER TABLE packed_commit_warm UPDATE a = concat(a, 'x') WHERE s = 'no_such_key' SETTINGS mutations_sync = 2;
-
-SELECT 'untouched', value > 0 FROM system.events WHERE event = 'MutationUntouchedParts';
 
 SYSTEM FLUSH LOGS part_log;
 
 SELECT 'rows', count() = 2
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
+
+-- `MutationUntouchedParts` is read per table from the `MutatePart` row rather than from
+-- `system.events`, whose counters are process-wide and lifetime-cumulative, so a concurrent test
+-- taking the same shortcut would satisfy the assertion for us and it would fail open.
+SELECT 'untouched',
+    minIf(ProfileEvents['MutationUntouchedParts'], table = 'packed_commit_cold') > 0
+  AND minIf(ProfileEvents['MutationUntouchedParts'], table = 'packed_commit_warm') > 0
 FROM system.part_log
 WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
 
@@ -107,9 +117,8 @@ SELECT 'fewer_file_open',
 FROM system.part_log
 WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
 
--- The same statement in bytes moved through `ThreadPoolRemoteFSReader::execute` for this read. On
--- this path that runs synchronously on the mutation thread, via
--- `AsynchronousBoundedReadBuffer::readSync`, so the `MutatePart` counter scope collects it.
+-- The same statement in bytes moved through `ThreadPoolRemoteFSReader::execute`, which as noted above
+-- runs synchronously on the mutation thread here, so the `MutatePart` counter scope collects it.
 --
 -- It is a second read-volume signal beside `FileOpen`, not the scheduling observable: on the
 -- scheduled path the same increment happens on a pool worker under its own thread group, which the


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a server abort while committing a mutated part. Accounting for a part whose column and secondary index sizes were not computed yet read them from the part storage inside a critical section documented as non-throwing, so a failure to start a thread for that read terminated the server instead of being reported.

### Description

`MergeTreeData::Transaction::commit` updates the table-level column and secondary index size aggregates from inside a `NOEXCEPT_SCOPE`, whose catch-all calls `std::terminate`. Accounting for a part whose own sizes were not computed yet called the part's size getters, which compute them from the part storage; on packed storage that reads the skip-indices archive. Under the default `local_filesystem_read_method = 'pread_threadpool'` that read is submitted to a thread pool, so a failure to schedule it raises `CANNOT_SCHEDULE_TASK`. That is not a memory-tracker exception, so `LockMemoryExceptionInThread` does not hold it back and it escapes the scope.

Such a part now invalidates the table aggregates instead of having its sizes read, and the next reader rebuilds them from the active parts. That is already the state before the first size query on the default `columns_and_secondary_indices_sizes_lazy_calculation = 1`, and the consumers are advisory statistics. A part whose sizes are known keeps the existing arithmetic. This also drops a `hasSecondaryIndex` check that resolved an index file through the part storage, while `getSecondaryIndexSize` already returns an empty size for an absent index. Separately, both recompute paths cleared only the two size maps, so `primary_index_size` was double counted on every rebuild; it is now cleared too. The change is in `MergeTreeData`, so it covers plain and replicated tables and every `Transaction::commit` call site.

Observed on `master` (`Stress test (amd_msan)`, commit 27b5773b9c452e59eb5b2b0cf3ae8929d4b6a42e, `Received signal 6 (internal) (STID: 3563-40df)`, [CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=27b5773b9c452e59eb5b2b0cf3ae8929d4b6a42e&name_0=MasterCI&name_1=Stress%20test%20%28amd_msan%29)).

The new test measures the extra storage access itself, through the `MutatePart` row of `system.part_log`, against a warm control; the scheduling step is established by the stack above rather than by the test. It pins the lazy size calculation. A sweep of related stateless tests found no failure that is unique to the fixed build.