### PR TITLE
Fix `AccessRights::getFilters` writing to a shared grants tree

### DIFF
--- a/src/Access/AccessRights.cpp
+++ b/src/Access/AccessRights.cpp
@@ -692,10 +692,12 @@ public:
         }
     }
 
-    std::vector<Filter> getFilters(std::string_view parameter)
+    std::vector<Filter> getFilters(std::string_view parameter) const
     {
         std::vector<Filter> res;
-        auto & node = getLeaf(parameter, GLOBAL_WITH_PARAMETER);
+        /// `tryGetLeaf` returns by value and its light copy shares `children` with this tree,
+        /// so the node must outlive the loop: bind it to a named local, never to `auto &`.
+        const auto node = tryGetLeaf(parameter, GLOBAL_WITH_PARAMETER);
         for (auto it = node.begin(); it != node.end(); ++it)
             res.emplace_back(it->flags, it.getPath());
 

--- a/src/Access/tests/gtest_access_rights_ops.cpp
+++ b/src/Access/tests/gtest_access_rights_ops.cpp
@@ -571,6 +571,22 @@ TEST(AccessRights, FilterDoesNotMutate)
     ASSERT_EQ(root.dumpNodes(), nodes_before);
 }
 
+TEST(AccessRights, FilterDoesNotMutateOnPrefixSplit)
+{
+    AccessRights root;
+    root.grant(AccessType::READ, "S3", "s3://url1.*");
+
+    const AccessRights before = root;
+    const auto nodes_before = root.dumpNodes();
+
+    /// "SQLITE" shares its first character with the existing "S3" node but mismatches
+    /// after it, so a mutating find-or-create would rename "S3" in place and splice it
+    /// into a new "S" parent. Both are real source names.
+    root.getFilters("SQLITE");
+    ASSERT_EQ(root, before);
+    ASSERT_EQ(root.dumpNodes(), nodes_before);
+}
+
 TEST(AccessRights, RevokeWithParameters)
 {
     AccessRights root;

--- a/src/Access/tests/gtest_access_rights_ops.cpp
+++ b/src/Access/tests/gtest_access_rights_ops.cpp
@@ -545,6 +545,30 @@ TEST(AccessRights, Filter)
     root.revoke(AccessType::READ, "URL");
     res = root.getFilters("URL");
     ASSERT_EQ(res.size(), 0);
+
+    res = root.getFilters("NoSuchParam");
+    ASSERT_EQ(res.size(), 0);
+}
+
+TEST(AccessRights, FilterDoesNotMutate)
+{
+    AccessRights root;
+    root.grant(AccessType::READ, "S3", "s3://url1.*");
+
+    /// operator = is a deep copy, so `before` is an independent snapshot of the tree.
+    const AccessRights before = root;
+    const auto nodes_before = root.dumpNodes();
+
+    /// A parameter that is absent from the tree: "URL" shares no first character with
+    /// "S3", so the lookup misses and a mutating find-or-create would insert nodes.
+    root.getFilters("URL");
+    ASSERT_EQ(root, before);
+    ASSERT_EQ(root.dumpNodes(), nodes_before);
+
+    /// A parameter that is present must likewise leave the tree untouched.
+    root.getFilters("S3");
+    ASSERT_EQ(root, before);
+    ASSERT_EQ(root.dumpNodes(), nodes_before);
 }
 
 TEST(AccessRights, RevokeWithParameters)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes heap corruption, which could crash the server at shutdown, caused by the `const` method `AccessRights::getFilters` modifying an access-rights tree shared by concurrent queries.


### Description

`AccessRights::getFilters(std::string_view) const` reached the **non-const** `Node::getFilters`, because `std::unique_ptr::operator-> const` returns a non-const pointer, and `const` on the owning method does not propagate through it. `Node::getFilters` then called `getLeaf`, a find-or-create mutator that allocates the children container, appends nodes, splices `std::list` elements between containers and edits a live node's name in place.

The tree it writes to is shared and unlocked. `ContextAccess::getAccessRights` holds its mutex only long enough to copy the `shared_ptr` out, and `AccessControl::ContextAccessCache` hands the same cached `ContextAccess` to every query with equal `ContextAccessParams`. So two concurrent table-function queries by one user could run unsynchronized list splices and `shared_ptr` control-block stores on one tree. The corruption is only detected later, when the cache is destroyed and the damaged container is released, which is why it surfaced as a shutdown `SIGABRT` under ASan. It is reachable without a fuzzer through `ITableFunction::checkSourceAccess` for any storage declaring a `source_access_type`, on any denied source access.

The fix makes `Node::getFilters` `const` and routes it onto `tryGetLeaf`, the existing const twin already used by `isGranted` and `contains`. `AccessRights.h` already declared the method `const`; only the body violated that contract. `getFilters` was added on the mutating `getLeaf` in `9ee66f4256965a`, although a const leaf lookup already existed. No lock is added and no caller-visible behaviour changes: for a present parameter both helpers return the same node, and for an absent one both yield an empty result.

The bug is observable single-threaded, so the regression test needs no threads or sanitizer: a `const` call with a parameter absent from the tree permanently added a node. `getFilters` was the only `const` method reaching the tree that could write to it; `tryGetChildNode` has the same const-escape shape but is unreachable from any `const` method today, so it is left unchanged.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.512` (included in `26.8` and later)
<!-- ch-version-info:end -->