### PR TITLE
Fix `bloom_filter` index skipping granules for a `FixedString` constant

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -754,8 +754,9 @@ static bool castConstantToIndexDomain(
     }
     catch (const Exception & e)
     {
-        /// The constant does not fit the element width. The function raises the same error on the
-        /// same input, so there is no value the index could hash that it would ever compare.
+        /// The constant does not fit the element width, so it has no representation in the index
+        /// domain and the index must decline. Depending on the element wrapper the function either
+        /// rejects the same constant or simply finds no match; neither is a value the index can hash.
         if (e.code() == ErrorCodes::TOO_LARGE_STRING_SIZE)
             return false;
         throw;
@@ -798,6 +799,10 @@ static ColumnPtr createColumnFromConstantArray(const Field & value_field, const 
 /// Like createColumnFromConstantArray, but hashes what hasAny/hasAll compare. Kept separate because
 /// createColumnFromConstantArray is shared with the has(<const array>, <indexed scalar>) arm, whose
 /// runtime is a Field-level accurateEquals and therefore needs the padded form.
+///
+/// Performs the same two hops as castConstantToIndexDomain, batched over the whole array: the common
+/// type and both cast functions are loop-invariant, and hasAllAny.h likewise casts whole argument
+/// columns rather than one element at a time.
 static ColumnPtr createColumnFromConstantArrayCastAware(
     const Field & value_field, const DataTypePtr & value_type, const DataTypePtr & actual_type)
 {
@@ -814,22 +819,63 @@ static ColumnPtr createColumnFromConstantArrayCastAware(
     if (!constantCastAppliesToIndexDomain(element_type, actual_type))
         return createColumnFromConstantArray(value_field, actual_type);
 
+    const Array & elements = value_field.safeGet<Array>();
     const bool is_nullable = actual_type->isNullable();
+    const DataTypePtr from_type = removeLowCardinalityAndNullable(element_type);
+
     auto mutable_column = actual_type->createColumn();
+    if (elements.empty())
+        return std::move(mutable_column);
 
-    for (const auto & f : value_field.safeGet<Array>())
+    try
     {
-        if ((f.isNull() && !is_nullable) || f.isDecimal(f.getType())) /// NOLINT(readability-static-accessed-through-instance)
+        auto source_column = from_type->createColumn();
+        source_column->reserve(elements.size());
+
+        for (const auto & f : elements)
+        {
+            if ((f.isNull() && !is_nullable) || f.isDecimal(f.getType())) /// NOLINT(readability-static-accessed-through-instance)
+                return nullptr;
+
+            /// from_type has the wrappers stripped, so a NULL has no representation in it. Declining
+            /// matches the scalar path, which refuses a NULL constant for the same reason.
+            if (f.isNull())
+                return nullptr;
+
+            source_column->insert(f);
+        }
+
+        ColumnWithTypeAndName arg{std::move(source_column), from_type, ""};
+
+        /// Two hops, matching the runtime: strip the padding via the common type, then re-encode into
+        /// the element width. A direct cast would reject a constant wider than the element before the
+        /// padding is stripped, losing pruning the function does perform.
+        const DataTypePtr common_type = getLeastSupertype(DataTypes{actual_type, from_type});
+        arg = ColumnWithTypeAndName{castColumn(arg, common_type), common_type, ""};
+
+        ColumnPtr casted = castColumn(arg, actual_type);
+        if (casted->size() != elements.size())
             return nullptr;
 
-        Field converted;
-        if (!castConstantToIndexDomain(f, element_type, actual_type, ConstantCoercion::Supertype, converted))
-            return nullptr;
+        /// One unrepresentable element declines the whole predicate, as the per-element form did.
+        for (size_t i = 0; i < casted->size(); ++i)
+        {
+            if (casted->isNullAt(i))
+                return nullptr;
 
-        mutable_column->insert(converted);
+            mutable_column->insert((*casted)[i]);
+        }
+
+        return std::move(mutable_column);
     }
-
-    return std::move(mutable_column);
+    catch (const Exception & e)
+    {
+        /// The batched cast throws on the first element that does not fit the element width, which
+        /// declines the whole predicate exactly as one unrepresentable element did before.
+        if (e.code() == ErrorCodes::TOO_LARGE_STRING_SIZE)
+            return nullptr;
+        throw;
+    }
 }
 
 

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -5,8 +5,10 @@
 #include <Columns/ColumnsNumber.h>
 #include <Common/FieldAccurateComparison.h>
 #include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeMapHelpers.h>
 #include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/getLeastSupertype.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/BloomFilterHash.h>
@@ -33,6 +35,7 @@ namespace ErrorCodes
     extern const int INCORRECT_QUERY;
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
     extern const int LOGICAL_ERROR;
+    extern const int TOO_LARGE_STRING_SIZE;
 }
 
 MergeTreeIndexGranuleBloomFilter::MergeTreeIndexGranuleBloomFilter(size_t bits_per_row_, size_t hash_functions_, size_t index_columns_)
@@ -689,6 +692,79 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeIn(
 }
 
 
+/// How the executing function coerces the constant before comparing it.
+enum class ConstantCoercion : uint8_t
+{
+    /// hasAny/hasAll and has/indexOf over a FixedString element: the function casts both sides to
+    /// getLeastSupertype (hasAllAny.h, arrayIndex.h executeGeneric).
+    Supertype,
+    /// has/indexOf over a LowCardinality element: the function casts the constant straight to the
+    /// dictionary value type (LowCardinalityExecutionHelpers.h dictionaryIndexForConstant).
+    Direct,
+};
+
+/// The index must hash the value the executing function actually compares.
+///
+/// convertFieldToType is a Field-level conversion: it pads a String shorter than FixedString(N) and
+/// passes an oversized one through unchanged. The array-search functions instead coerce with
+/// castColumn, and a FixedString -> String cast strips trailing zero bytes. So for a FixedString
+/// constant the index hashed a padded value the function never compares, and the granule was dropped.
+///
+/// Returns false when the constant has no representation in the index domain, which means the caller
+/// must decline the index rather than hash a value that can never match.
+static bool castConstantToIndexDomain(
+    const Field & value_field,
+    const DataTypePtr & value_type,
+    const DataTypePtr & actual_type,
+    ConstantCoercion coercion,
+    Field & out_field)
+{
+    if (!value_type)
+        return false;
+
+    const DataTypePtr from_type = removeLowCardinalityAndNullable(value_type);
+
+    try
+    {
+        auto column = from_type->createColumn();
+        column->insert(value_field);
+        ColumnWithTypeAndName arg{std::move(column), from_type, ""};
+
+        if (coercion == ConstantCoercion::Supertype)
+        {
+            /// Two hops, matching the runtime: strip the padding via the common type, then re-encode
+            /// into the element width. A direct cast would reject a constant wider than the element
+            /// before the padding is stripped, losing pruning the function does perform.
+            const DataTypePtr common_type = getLeastSupertype(DataTypes{actual_type, from_type});
+            arg = ColumnWithTypeAndName{castColumn(arg, common_type), common_type, ""};
+        }
+
+        ColumnPtr casted = castColumn(arg, actual_type);
+        if (casted->empty() || casted->isNullAt(0))
+            return false;
+
+        out_field = (*casted)[0];
+        return !out_field.isNull();
+    }
+    catch (const Exception & e)
+    {
+        /// The constant does not fit the element width. The function raises the same error on the
+        /// same input, so there is no value the index could hash that it would ever compare.
+        if (e.code() == ErrorCodes::TOO_LARGE_STRING_SIZE)
+            return false;
+        throw;
+    }
+}
+
+/// True for the element/constant types whose coercion castConstantToIndexDomain reproduces. Numeric
+/// elements take executeIntegral, which runs before executeGeneric and does not coerce this way.
+static bool constantCastAppliesToIndexDomain(const DataTypePtr & value_type, const DataTypePtr & actual_type)
+{
+    return value_type
+        && isStringOrFixedString(removeLowCardinalityAndNullable(value_type))
+        && isStringOrFixedString(actual_type);
+}
+
 static ColumnPtr createColumnFromConstantArray(const Field & value_field, const DataTypePtr & actual_type)
 {
     if (value_field.getType() != Field::Types::Array)
@@ -704,6 +780,44 @@ static ColumnPtr createColumnFromConstantArray(const Field & value_field, const 
 
         auto converted = convertFieldToType(f, *actual_type);
         if (converted.isNull())
+            return nullptr;
+
+        mutable_column->insert(converted);
+    }
+
+    return std::move(mutable_column);
+}
+
+
+/// Like createColumnFromConstantArray, but hashes what hasAny/hasAll compare. Kept separate because
+/// createColumnFromConstantArray is shared with the has(<const array>, <indexed scalar>) arm, whose
+/// runtime is a Field-level accurateEquals and therefore needs the padded form.
+static ColumnPtr createColumnFromConstantArrayCastAware(
+    const Field & value_field, const DataTypePtr & value_type, const DataTypePtr & actual_type)
+{
+    if (value_field.getType() != Field::Types::Array)
+        return nullptr;
+
+    DataTypePtr element_type;
+    if (value_type)
+    {
+        if (const auto * value_array_type = typeid_cast<const DataTypeArray *>(removeLowCardinalityAndNullable(value_type).get()))
+            element_type = value_array_type->getNestedType();
+    }
+
+    if (!constantCastAppliesToIndexDomain(element_type, actual_type))
+        return createColumnFromConstantArray(value_field, actual_type);
+
+    const bool is_nullable = actual_type->isNullable();
+    auto mutable_column = actual_type->createColumn();
+
+    for (const auto & f : value_field.safeGet<Array>())
+    {
+        if ((f.isNull() && !is_nullable) || f.isDecimal(f.getType())) /// NOLINT(readability-static-accessed-through-instance)
+            return nullptr;
+
+        Field converted;
+        if (!castConstantToIndexDomain(f, element_type, actual_type, ConstantCoercion::Supertype, converted))
             return nullptr;
 
         mutable_column->insert(converted);
@@ -817,10 +931,30 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
                 if (function_name == "has" || indexOfCanUseBloomFilter(parent))
                 {
                     out.function = RPNElement::FUNCTION_HAS;
-                    const DataTypePtr actual_type = BloomFilter::getPrimitiveType(array_type->getNestedType());
-                    auto converted_field = convertFieldToType(value_field, *actual_type, value_type.get());
-                    if (converted_field.isNull())
-                        return false;
+                    const DataTypePtr & raw_nested_type = array_type->getNestedType();
+                    const DataTypePtr actual_type = BloomFilter::getPrimitiveType(raw_nested_type);
+
+                    Field converted_field;
+                    /// A bare String element takes executeString, which compares the raw padded bytes
+                    /// without coercing, so there the unconverted field is already the right value. The
+                    /// test must read the raw type: getPrimitiveType strips LowCardinality, and a
+                    /// LowCardinality element does coerce (executeArrayLowCardinality runs before the
+                    /// wrapper is removed).
+                    if (WhichDataType(raw_nested_type).isString()
+                        || !constantCastAppliesToIndexDomain(value_type, actual_type))
+                    {
+                        converted_field = convertFieldToType(value_field, *actual_type, value_type.get());
+                        if (converted_field.isNull())
+                            return false;
+                    }
+                    else
+                    {
+                        const auto coercion = raw_nested_type->lowCardinality()
+                            ? ConstantCoercion::Direct
+                            : ConstantCoercion::Supertype;
+                        if (!castConstantToIndexDomain(value_field, value_type, actual_type, coercion, converted_field))
+                            return false;
+                    }
 
                     out.predicate.emplace_back(std::make_pair(position, BloomFilterHash::hashWithField(actual_type.get(), converted_field)));
                 }
@@ -843,7 +977,7 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
                 return false;
 
             const DataTypePtr actual_type = BloomFilter::getPrimitiveType(array_type->getNestedType());
-            ColumnPtr column = createColumnFromConstantArray(value_field, actual_type);
+            ColumnPtr column = createColumnFromConstantArrayCastAware(value_field, value_type, actual_type);
 
             if (!column)
                 return false;

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -695,20 +695,21 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeIn(
 /// How the executing function coerces the constant before comparing it.
 enum class ConstantCoercion : uint8_t
 {
-    /// hasAny/hasAll and has/indexOf over a FixedString element: the function casts both sides to
-    /// getLeastSupertype (hasAllAny.h, arrayIndex.h executeGeneric).
+    /// `hasAny`/`hasAll` and `has`/`indexOf` over a `FixedString` element: the function casts both
+    /// sides to `getLeastSupertype` (hasAllAny.h, arrayIndex.h `executeGeneric`).
     Supertype,
-    /// has/indexOf over a LowCardinality element: the function casts the constant straight to the
-    /// dictionary value type (LowCardinalityExecutionHelpers.h dictionaryIndexForConstant).
+    /// `has`/`indexOf` over a `LowCardinality` element: the function casts the constant straight to
+    /// the dictionary value type (LowCardinalityExecutionHelpers.h `dictionaryIndexForConstant`).
     Direct,
 };
 
 /// The index must hash the value the executing function actually compares.
 ///
-/// convertFieldToType is a Field-level conversion: it pads a String shorter than FixedString(N) and
-/// passes an oversized one through unchanged. The array-search functions instead coerce with
-/// castColumn, and a FixedString -> String cast strips trailing zero bytes. So for a FixedString
-/// constant the index hashed a padded value the function never compares, and the granule was dropped.
+/// `convertFieldToType` is a `Field`-level conversion: it pads a `String` shorter than
+/// `FixedString(N)` and passes an oversized one through unchanged. The array-search functions instead
+/// coerce with `castColumn`, and a `FixedString` -> `String` cast strips trailing zero bytes. So for a
+/// `FixedString` constant the index hashed a padded value the function never compares, and the granule
+/// was dropped.
 ///
 /// Returns false when the constant has no representation in the index domain, which means the caller
 /// must decline the index rather than hash a value that can never match.
@@ -722,9 +723,9 @@ static bool castConstantToIndexDomain(
     if (!value_type)
         return false;
 
-    /// A NULL constant has no representation in the index domain, and the wrapper strip below would
-    /// otherwise insert it into a non-nullable column, which throws BAD_GET. Declining matches what
-    /// convertFieldToType did here before.
+    /// A `NULL` constant has no representation in the index domain, and the wrapper strip below would
+    /// otherwise insert it into a non-nullable column, which throws `BAD_GET`. Declining matches what
+    /// `convertFieldToType` did here before.
     if (value_field.isNull())
         return false;
 
@@ -763,8 +764,8 @@ static bool castConstantToIndexDomain(
     }
 }
 
-/// True for the element/constant types whose coercion castConstantToIndexDomain reproduces. Numeric
-/// elements take executeIntegral, which runs before executeGeneric and does not coerce this way.
+/// True for the element/constant types whose coercion `castConstantToIndexDomain` reproduces. Numeric
+/// elements take `executeIntegral`, which runs before `executeGeneric` and does not coerce this way.
 static bool constantCastAppliesToIndexDomain(const DataTypePtr & value_type, const DataTypePtr & actual_type)
 {
     return value_type
@@ -796,11 +797,11 @@ static ColumnPtr createColumnFromConstantArray(const Field & value_field, const 
 }
 
 
-/// Like createColumnFromConstantArray, but hashes what hasAny/hasAll compare. Kept separate because
-/// createColumnFromConstantArray is shared with the has(<const array>, <indexed scalar>) arm, whose
-/// runtime is a Field-level accurateEquals and therefore needs the padded form.
+/// Like `createColumnFromConstantArray`, but hashes what `hasAny`/`hasAll` compare. Kept separate
+/// because `createColumnFromConstantArray` is shared with the `has(<const array>, <indexed scalar>)`
+/// arm, whose runtime is a `Field`-level `accurateEquals` and therefore needs the padded form.
 ///
-/// Performs the same two hops as castConstantToIndexDomain, batched over the whole array: the common
+/// Performs the same two hops as `castConstantToIndexDomain`, batched over the whole array: the common
 /// type and both cast functions are loop-invariant, and hasAllAny.h likewise casts whole argument
 /// columns rather than one element at a time.
 static ColumnPtr createColumnFromConstantArrayCastAware(
@@ -837,8 +838,8 @@ static ColumnPtr createColumnFromConstantArrayCastAware(
             if ((f.isNull() && !is_nullable) || f.isDecimal(f.getType())) /// NOLINT(readability-static-accessed-through-instance)
                 return nullptr;
 
-            /// from_type has the wrappers stripped, so a NULL has no representation in it. Declining
-            /// matches the scalar path, which refuses a NULL constant for the same reason.
+            /// `from_type` has the wrappers stripped, so a `NULL` has no representation in it.
+            /// Declining matches the scalar path, which refuses a `NULL` constant for the same reason.
             if (f.isNull())
                 return nullptr;
 
@@ -987,11 +988,11 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
                     const DataTypePtr actual_type = BloomFilter::getPrimitiveType(raw_nested_type);
 
                     Field converted_field;
-                    /// A bare String element takes executeString, which compares the raw padded bytes
-                    /// without coercing, so there the unconverted field is already the right value. The
-                    /// test must read the raw type: getPrimitiveType strips LowCardinality, and a
-                    /// LowCardinality element does coerce (executeArrayLowCardinality runs before the
-                    /// wrapper is removed).
+                    /// A bare `String` element takes `executeString`, which compares the raw padded
+                    /// bytes without coercing, so there the unconverted field is already the right
+                    /// value. The test must read the raw type: `getPrimitiveType` strips
+                    /// `LowCardinality`, and a `LowCardinality` element does coerce
+                    /// (`executeArrayLowCardinality` runs before the wrapper is removed).
                     if (WhichDataType(raw_nested_type).isString()
                         || !constantCastAppliesToIndexDomain(value_type, actual_type))
                     {

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -722,6 +722,12 @@ static bool castConstantToIndexDomain(
     if (!value_type)
         return false;
 
+    /// A NULL constant has no representation in the index domain, and the wrapper strip below would
+    /// otherwise insert it into a non-nullable column, which throws BAD_GET. Declining matches what
+    /// convertFieldToType did here before.
+    if (value_field.isNull())
+        return false;
+
     const DataTypePtr from_type = removeLowCardinalityAndNullable(value_type);
 
     try

--- a/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.reference
+++ b/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.reference
@@ -20,6 +20,8 @@ DROP TABLE IF EXISTS p_num;
 DROP TABLE IF EXISTS q_str;
 DROP TABLE IF EXISTS o_sc;
 DROP TABLE IF EXISTS k_sc;
+DROP TABLE IF EXISTS o_fs3m;
+DROP TABLE IF EXISTS k_fs3m;
 CREATE TABLE o_str (id UInt64, v Array(String)) ENGINE = Log;
 CREATE TABLE k_str (id UInt64, v Array(String), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO o_str VALUES (0,['V0']),(1,['V0\0']),(2,['V0\0\0']),(3,['X']);
@@ -268,6 +270,20 @@ SELECT 'const-array has FS3 id', (SELECT groupArray(id) FROM (SELECT id FROM k_s
 const-array has FS3 id	1
 SELECT 'prune const-array has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM k_sc WHERE has([toFixedString('V0',3)], s)) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune const-array has FS3	1
+-- Multi-element constant arrays: the coercion is batched over the whole array, so a non-first
+-- element must survive both hops in its own position. Rows carry two elements so hasAll genuinely
+-- needs both. Every constant shares one width: a mixed-width literal array types as Array(String),
+-- which would reach the helper with a different element type and probe another path.
+CREATE TABLE o_fs3m (id UInt64, v Array(FixedString(3))) ENGINE = Log;
+CREATE TABLE k_fs3m (id UInt64, v Array(FixedString(3)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_fs3m VALUES (0,['V0','V0A']),(1,['V0']),(2,['XYZ','ZZZ']);
+INSERT INTO k_fs3m VALUES (0,['V0','V0A']),(1,['V0']),(2,['XYZ','ZZZ']);
+SELECT 'fs3m hasAny nonfirst FS5', (SELECT count() FROM o_fs3m WHERE hasAny(v,[toFixedString('QQQ',5),toFixedString('V0A',5)])) = (SELECT count() FROM k_fs3m WHERE hasAny(v,[toFixedString('QQQ',5),toFixedString('V0A',5)]));
+fs3m hasAny nonfirst FS5	1
+SELECT 'fs3m hasAll both FS5', (SELECT count() FROM o_fs3m WHERE hasAll(v,[toFixedString('V0',5),toFixedString('V0A',5)])) = (SELECT count() FROM k_fs3m WHERE hasAll(v,[toFixedString('V0',5),toFixedString('V0A',5)]));
+fs3m hasAll both FS5	1
+SELECT 'fs3m hasAny later unrepresentable', (SELECT count() FROM o_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('WXYZ',5)])) = (SELECT count() FROM k_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('WXYZ',5)]));
+fs3m hasAny later unrepresentable	1
 DROP TABLE o_str;
 DROP TABLE k_str;
 DROP TABLE o_fs3;
@@ -284,3 +300,5 @@ DROP TABLE p_num;
 DROP TABLE q_str;
 DROP TABLE o_sc;
 DROP TABLE k_sc;
+DROP TABLE o_fs3m;
+DROP TABLE k_fs3m;

--- a/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.reference
+++ b/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.reference
@@ -17,6 +17,7 @@ DROP TABLE IF EXISTS p_fs3;
 DROP TABLE IF EXISTS p_lcstr;
 DROP TABLE IF EXISTS p_lcfs3;
 DROP TABLE IF EXISTS p_num;
+DROP TABLE IF EXISTS p_fs3m;
 DROP TABLE IF EXISTS q_str;
 DROP TABLE IF EXISTS o_sc;
 DROP TABLE IF EXISTS k_sc;
@@ -38,7 +39,8 @@ CREATE TABLE o_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3)))) ENGINE
 CREATE TABLE k_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO o_lcfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
 INSERT INTO k_lcfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
--- Array(String): hasAny/hasAll cast both arrays to the common type, so they compare the unpadded value.
+-- `Array(String)`: `hasAny`/`hasAll` cast both arrays to the common type, so they compare the
+-- unpadded value.
 SELECT 'str hasAny FS3', (SELECT count() FROM o_str WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_str WHERE hasAny(v,[toFixedString('V0',3)]));
 str hasAny FS3	1
 SELECT 'str hasAny FS5', (SELECT count() FROM o_str WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_str WHERE hasAny(v,[toFixedString('V0',5)]));
@@ -47,7 +49,8 @@ SELECT 'str hasAll FS3', (SELECT count() FROM o_str WHERE hasAll(v,[toFixedStrin
 str hasAll FS3	1
 SELECT 'str hasAll FS5', (SELECT count() FROM o_str WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_str WHERE hasAll(v,[toFixedString('V0',5)]));
 str hasAll FS5	1
--- Array(String): has/indexOf take executeString, which compares the raw padded bytes. Must not change.
+-- `Array(String)`: `has`/`indexOf` take `executeString`, which compares the raw padded bytes. Must
+-- not change.
 SELECT 'str has Str', (SELECT count() FROM o_str WHERE has(v,'V0')) = (SELECT count() FROM k_str WHERE has(v,'V0'));
 str has Str	1
 SELECT 'str has FS2', (SELECT count() FROM o_str WHERE has(v,toFixedString('V0',2))) = (SELECT count() FROM k_str WHERE has(v,toFixedString('V0',2)));
@@ -66,8 +69,8 @@ SELECT 'str hasAny FS2', (SELECT count() FROM o_str WHERE hasAny(v,[toFixedStrin
 str hasAny FS2	1
 SELECT 'str hasAll Str', (SELECT count() FROM o_str WHERE hasAll(v,['V0'])) = (SELECT count() FROM k_str WHERE hasAll(v,['V0']));
 str hasAll Str	1
--- Array(FixedString(3)): a wider constant is stripped then re-encoded into the element width, so it
--- matches exactly. Before the fix has/indexOf answered 0 and hasAny/hasAll raised Code 131.
+-- `Array(FixedString(3))`: a wider constant is stripped then re-encoded into the element width, so it
+-- matches exactly. Before the fix `has`/`indexOf` answered 0 and `hasAny`/`hasAll` raised `Code 131`.
 SELECT 'fs3 has FS5', (SELECT count() FROM o_fs3 WHERE has(v,toFixedString('V0',5))) = (SELECT count() FROM k_fs3 WHERE has(v,toFixedString('V0',5)));
 fs3 has FS5	1
 SELECT 'fs3 indexOf FS5', (SELECT count() FROM o_fs3 WHERE indexOf(v,toFixedString('V0',5)) = 1) = (SELECT count() FROM k_fs3 WHERE indexOf(v,toFixedString('V0',5)) = 1);
@@ -88,7 +91,8 @@ SELECT 'fs3 hasAny FS3', (SELECT count() FROM o_fs3 WHERE hasAny(v,[toFixedStrin
 fs3 hasAny FS3	1
 SELECT 'fs3 hasAll FS3', (SELECT count() FROM o_fs3 WHERE hasAll(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_fs3 WHERE hasAll(v,[toFixedString('V0',3)]));
 fs3 hasAll FS3	1
--- Array(LowCardinality(String)): every predicate coerces here, so every FixedString constant was wrong.
+-- `Array(LowCardinality(String))`: every predicate coerces here, so every `FixedString` constant was
+-- wrong.
 SELECT 'lcstr has FS3', (SELECT count() FROM o_lcstr WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcstr WHERE has(v,toFixedString('V0',3)));
 lcstr has FS3	1
 SELECT 'lcstr has FS5', (SELECT count() FROM o_lcstr WHERE has(v,toFixedString('V0',5))) = (SELECT count() FROM k_lcstr WHERE has(v,toFixedString('V0',5)));
@@ -111,7 +115,8 @@ SELECT 'lcstr has FS2', (SELECT count() FROM o_lcstr WHERE has(v,toFixedString('
 lcstr has FS2	1
 SELECT 'lcstr hasAny Str', (SELECT count() FROM o_lcstr WHERE hasAny(v,['V0'])) = (SELECT count() FROM k_lcstr WHERE hasAny(v,['V0']));
 lcstr hasAny Str	1
--- Array(LowCardinality(FixedString(3))): hasAny/hasAll cast to the supertype and legitimately match.
+-- `Array(LowCardinality(FixedString(3)))`: `hasAny`/`hasAll` cast to the supertype and legitimately
+-- match.
 SELECT 'lcfs3 hasAny FS5', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcfs3 WHERE hasAny(v,[toFixedString('V0',5)]));
 lcfs3 hasAny FS5	1
 SELECT 'lcfs3 hasAll FS5', (SELECT count() FROM o_lcfs3 WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcfs3 WHERE hasAll(v,[toFixedString('V0',5)]));
@@ -120,18 +125,18 @@ SELECT 'lcfs3 has FS3', (SELECT count() FROM o_lcfs3 WHERE has(v,toFixedString('
 lcfs3 has FS3	1
 SELECT 'lcfs3 hasAny FS3', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)]));
 lcfs3 hasAny FS3	1
--- has/indexOf over a LowCardinality element cast the constant straight to the dictionary type, which
--- overflows for a wider constant. The engine raises this with no index at all, so the index must
+-- `has`/`indexOf` over a `LowCardinality` element cast the constant straight to the dictionary type,
+-- which overflows for a wider constant. The engine raises this with no index at all, so the index must
 -- decline rather than answer 0.
 SELECT count() FROM o_lcfs3 WHERE has(v,toFixedString('V0',5)); -- { serverError TOO_LARGE_STRING_SIZE }
 SELECT count() FROM k_lcfs3 WHERE has(v,toFixedString('V0',5)); -- { serverError TOO_LARGE_STRING_SIZE }
 SELECT count() FROM o_lcfs3 WHERE indexOf(v,toFixedString('V0',5)) = 1; -- { serverError TOO_LARGE_STRING_SIZE }
 SELECT count() FROM k_lcfs3 WHERE indexOf(v,toFixedString('V0',5)) = 1; -- { serverError TOO_LARGE_STRING_SIZE }
--- A NULL constant has no representation in the index domain, so analysis must decline instead of
--- materializing it. The constant must be a TYPED null: a bare NULL is Nullable(Nothing), which fails
--- the string test and declines earlier, so a bare-literal cell would not reach the coercion at all.
--- RPNBuilder keeps the constant type Nullable only when the value IS Null, so this is the exact pair
--- that arrives. Every cell answers 0; asserting keyed == oracle is what catches a throw.
+-- A `NULL` constant has no representation in the index domain, so analysis must decline instead of
+-- materializing it. The constant must be a TYPED null: a bare `NULL` is `Nullable(Nothing)`, which
+-- fails the string test and declines earlier, so a bare-literal cell would not reach the coercion at
+-- all. `RPNBuilder` keeps the constant type `Nullable` only when the value IS Null, so this is the
+-- exact pair that arrives. Every cell answers 0; asserting keyed == oracle is what catches a throw.
 SELECT 'null str has NStr', (SELECT count() FROM o_str WHERE has(v,CAST(NULL AS Nullable(String)))) = (SELECT count() FROM k_str WHERE has(v,CAST(NULL AS Nullable(String))));
 null str has NStr	1
 SELECT 'null str indexOf NStr', (SELECT count() FROM o_str WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1) = (SELECT count() FROM k_str WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1);
@@ -189,17 +194,18 @@ SELECT 'prune str has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count()
 prune str has Str	1
 SELECT 'prune str hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune str hasAny FS3	1
--- has over a bare String element keeps hashing the padded form, so a FixedString(3) constant selects
--- the granule holding 'V0\0' and not the one holding 'V0'. Asserting the exact granule the index picks
--- pins the representation: a >0-reduction test would also pass if the index pruned everything away.
+-- `has` over a bare `String` element keeps hashing the padded form, so a `FixedString(3)` constant
+-- selects the granule holding 'V0\0' and not the one holding 'V0'. Asserting the exact granule the
+-- index picks pins the representation: a >0-reduction test would also pass if the index pruned
+-- everything away.
 CREATE TABLE q_str (id UInt64, v Array(String), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO q_str SELECT number, [multiIf(number = 7, 'V0', number = 11, 'V0\0', concat('z', toString(number)))] FROM numbers(64);
 SELECT 'padded str has FS3', (SELECT count() FROM q_str WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM q_str WHERE has(v,toFixedString('V0',3)) SETTINGS use_skip_indexes=0);
 padded str has FS3	1
 SELECT 'padded str has FS3 id', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE has(v,toFixedString('V0',3)) ORDER BY id SETTINGS use_skip_indexes=0));
 padded str has FS3 id	1
--- On byte-identical data has matches the padded row and hasAny matches the unpadded one. Pinning the
--- absolute ids is what proves each predicate keeps its own representation: a keyed-vs-unkeyed
+-- On byte-identical data `has` matches the padded row and `hasAny` matches the unpadded one. Pinning
+-- the absolute ids is what proves each predicate keeps its own representation: a keyed-vs-unkeyed
 -- comparison alone stays green if a change moves both sides together.
 SELECT 'padded str has FS3 is 11', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = [11];
 padded str has FS3 is 11	1
@@ -225,10 +231,10 @@ SELECT 'prune lcstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT co
 prune lcstr hasAny FS3	1
 SELECT 'prune lcstr has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune lcstr has Str	1
--- LowCardinality(FixedString(N)) is the one element type where the two coercion modes could differ,
+-- `LowCardinality(FixedString(N))` is the one element type where the two coercion modes could differ,
 -- and the whole case for coercing rather than declining is that pruning survives. The four cells
 -- above that use this wrapper are result comparisons, which would also pass if analysis declined
--- entirely, so pin both modes here: has/indexOf take Direct, hasAny/hasAll take Supertype.
+-- entirely, so pin both modes here: `has`/`indexOf` take Direct, `hasAny`/`hasAll` take Supertype.
 SELECT 'prune lcfs3 has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcfs3 WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune lcfs3 has FS3	1
 SELECT 'prune lcfs3 indexOf FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcfs3 WHERE indexOf(v,toFixedString('V0',3)) = 1) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
@@ -242,8 +248,8 @@ SELECT 'prune lcfs3 has FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM p
 prune lcfs3 has FS3 is 7	1
 SELECT 'prune lcfs3 hasAny FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id)) = [7];
 prune lcfs3 hasAny FS3 is 7	1
--- A numeric element takes executeIntegral, a coercion the helper does not emulate, so it stays on the
--- original path. Answer and pruning must both be unaffected.
+-- A numeric element takes `executeIntegral`, a coercion the helper does not emulate, so it stays on
+-- the original path. Answer and pruning must both be unaffected.
 CREATE TABLE p_num (id UInt64, v Array(UInt64), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO p_num SELECT number, [if(number = 7, 999, number)] FROM numbers(64);
 SELECT 'num has', (SELECT count() FROM p_num WHERE has(v,999)) = (SELECT count() FROM p_num WHERE has(v,999) SETTINGS use_skip_indexes=0);
@@ -252,8 +258,8 @@ SELECT 'num hasAny', (SELECT count() FROM p_num WHERE hasAny(v,[999])) = (SELECT
 num hasAny	1
 SELECT 'prune num has', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_num WHERE has(v,999)) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune num has	1
--- has(<const array>, <indexed scalar>) shares createColumnFromConstantArray, whose runtime is a
--- Field-level accurateEquals and therefore needs the padded form. Deliberately left untouched.
+-- `has(<const array>, <indexed scalar>)` shares `createColumnFromConstantArray`, whose runtime is a
+-- `Field`-level `accurateEquals` and therefore needs the padded form. Deliberately left untouched.
 -- The indexed column must be a SCALAR: with an array column this form does not use the index at all,
 -- which would make every assertion below vacuous.
 CREATE TABLE o_sc (id UInt64, s String) ENGINE = Log;
@@ -271,8 +277,8 @@ const-array has FS3 id	1
 SELECT 'prune const-array has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM k_sc WHERE has([toFixedString('V0',3)], s)) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune const-array has FS3	1
 -- Multi-element constant arrays: the coercion is batched over the whole array, so a non-first
--- element must survive both hops in its own position. Rows carry two elements so hasAll genuinely
--- needs both. Every constant shares one width: a mixed-width literal array types as Array(String),
+-- element must survive both hops in its own position. Rows carry two elements so `hasAll` genuinely
+-- needs both. Every constant shares one width: a mixed-width literal array types as `Array(String)`,
 -- which would reach the helper with a different element type and probe another path.
 CREATE TABLE o_fs3m (id UInt64, v Array(FixedString(3))) ENGINE = Log;
 CREATE TABLE k_fs3m (id UInt64, v Array(FixedString(3)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
@@ -284,6 +290,17 @@ SELECT 'fs3m hasAll both FS5', (SELECT count() FROM o_fs3m WHERE hasAll(v,[toFix
 fs3m hasAll both FS5	1
 SELECT 'fs3m hasAny later unrepresentable', (SELECT count() FROM o_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('WXYZ',5)])) = (SELECT count() FROM k_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('WXYZ',5)]));
 fs3m hasAny later unrepresentable	1
+-- A decline only changes the plan, not the answer, so the result cells above cannot see it. These
+-- pin the granule reduction for a multi-element constant array, which is what the PR claims to
+-- preserve by coercing rather than declining.
+CREATE TABLE p_fs3m (id UInt64, v Array(FixedString(3)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO p_fs3m SELECT number, if(number = 7, [toFixedString('V0',3), toFixedString('V0A',3)], [toFixedString(concat('z', leftPad(toString(number),2,'0')),3)]) FROM numbers(64);
+SELECT 'prune fs3m hasAny nonfirst FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3m WHERE hasAny(v,[toFixedString('QQQ',5),toFixedString('V0A',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune fs3m hasAny nonfirst FS5	1
+SELECT 'prune fs3m hasAll both FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3m WHERE hasAll(v,[toFixedString('V0',5),toFixedString('V0A',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune fs3m hasAll both FS5	1
+SELECT 'prune fs3m hasAny id is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_fs3m WHERE hasAny(v,[toFixedString('QQQ',5),toFixedString('V0A',5)]) ORDER BY id)) = [7];
+prune fs3m hasAny id is 7	1
 DROP TABLE o_str;
 DROP TABLE k_str;
 DROP TABLE o_fs3;
@@ -297,6 +314,7 @@ DROP TABLE p_fs3;
 DROP TABLE p_lcstr;
 DROP TABLE p_lcfs3;
 DROP TABLE p_num;
+DROP TABLE p_fs3m;
 DROP TABLE q_str;
 DROP TABLE o_sc;
 DROP TABLE k_sc;

--- a/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.reference
+++ b/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.reference
@@ -1,0 +1,215 @@
+-- { echo }
+
+-- The index must hash the value the array-search function actually compares. Every cell asserts
+-- keyed == oracle, so no expected answer is baked into the reference.
+
+DROP TABLE IF EXISTS o_str;
+DROP TABLE IF EXISTS k_str;
+DROP TABLE IF EXISTS o_fs3;
+DROP TABLE IF EXISTS k_fs3;
+DROP TABLE IF EXISTS o_lcstr;
+DROP TABLE IF EXISTS k_lcstr;
+DROP TABLE IF EXISTS o_lcfs3;
+DROP TABLE IF EXISTS k_lcfs3;
+DROP TABLE IF EXISTS p_str;
+DROP TABLE IF EXISTS p_fs3;
+DROP TABLE IF EXISTS p_lcstr;
+DROP TABLE IF EXISTS p_num;
+DROP TABLE IF EXISTS q_str;
+DROP TABLE IF EXISTS o_sc;
+DROP TABLE IF EXISTS k_sc;
+CREATE TABLE o_str (id UInt64, v Array(String)) ENGINE = Log;
+CREATE TABLE k_str (id UInt64, v Array(String), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_str VALUES (0,['V0']),(1,['V0\0']),(2,['V0\0\0']),(3,['X']);
+INSERT INTO k_str VALUES (0,['V0']),(1,['V0\0']),(2,['V0\0\0']),(3,['X']);
+CREATE TABLE o_fs3 (id UInt64, v Array(FixedString(3))) ENGINE = Log;
+CREATE TABLE k_fs3 (id UInt64, v Array(FixedString(3)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_fs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
+INSERT INTO k_fs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
+CREATE TABLE o_lcstr (id UInt64, v Array(LowCardinality(String))) ENGINE = Log;
+CREATE TABLE k_lcstr (id UInt64, v Array(LowCardinality(String)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_lcstr VALUES (0,['V0']),(1,['V0\0']),(2,['V0\0\0']),(3,['X']);
+INSERT INTO k_lcstr VALUES (0,['V0']),(1,['V0\0']),(2,['V0\0\0']),(3,['X']);
+CREATE TABLE o_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3)))) ENGINE = Log;
+CREATE TABLE k_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_lcfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
+INSERT INTO k_lcfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
+-- Array(String): hasAny/hasAll cast both arrays to the common type, so they compare the unpadded value.
+SELECT 'str hasAny FS3', (SELECT count() FROM o_str WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_str WHERE hasAny(v,[toFixedString('V0',3)]));
+str hasAny FS3	1
+SELECT 'str hasAny FS5', (SELECT count() FROM o_str WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_str WHERE hasAny(v,[toFixedString('V0',5)]));
+str hasAny FS5	1
+SELECT 'str hasAll FS3', (SELECT count() FROM o_str WHERE hasAll(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_str WHERE hasAll(v,[toFixedString('V0',3)]));
+str hasAll FS3	1
+SELECT 'str hasAll FS5', (SELECT count() FROM o_str WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_str WHERE hasAll(v,[toFixedString('V0',5)]));
+str hasAll FS5	1
+-- Array(String): has/indexOf take executeString, which compares the raw padded bytes. Must not change.
+SELECT 'str has Str', (SELECT count() FROM o_str WHERE has(v,'V0')) = (SELECT count() FROM k_str WHERE has(v,'V0'));
+str has Str	1
+SELECT 'str has FS2', (SELECT count() FROM o_str WHERE has(v,toFixedString('V0',2))) = (SELECT count() FROM k_str WHERE has(v,toFixedString('V0',2)));
+str has FS2	1
+SELECT 'str has FS3', (SELECT count() FROM o_str WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_str WHERE has(v,toFixedString('V0',3)));
+str has FS3	1
+SELECT 'str has FS5', (SELECT count() FROM o_str WHERE has(v,toFixedString('V0',5))) = (SELECT count() FROM k_str WHERE has(v,toFixedString('V0',5)));
+str has FS5	1
+SELECT 'str indexOf Str', (SELECT count() FROM o_str WHERE indexOf(v,'V0') = 1) = (SELECT count() FROM k_str WHERE indexOf(v,'V0') = 1);
+str indexOf Str	1
+SELECT 'str indexOf FS3', (SELECT count() FROM o_str WHERE indexOf(v,toFixedString('V0',3)) = 1) = (SELECT count() FROM k_str WHERE indexOf(v,toFixedString('V0',3)) = 1);
+str indexOf FS3	1
+SELECT 'str hasAny Str', (SELECT count() FROM o_str WHERE hasAny(v,['V0'])) = (SELECT count() FROM k_str WHERE hasAny(v,['V0']));
+str hasAny Str	1
+SELECT 'str hasAny FS2', (SELECT count() FROM o_str WHERE hasAny(v,[toFixedString('V0',2)])) = (SELECT count() FROM k_str WHERE hasAny(v,[toFixedString('V0',2)]));
+str hasAny FS2	1
+SELECT 'str hasAll Str', (SELECT count() FROM o_str WHERE hasAll(v,['V0'])) = (SELECT count() FROM k_str WHERE hasAll(v,['V0']));
+str hasAll Str	1
+-- Array(FixedString(3)): a wider constant is stripped then re-encoded into the element width, so it
+-- matches exactly. Before the fix has/indexOf answered 0 and hasAny/hasAll raised Code 131.
+SELECT 'fs3 has FS5', (SELECT count() FROM o_fs3 WHERE has(v,toFixedString('V0',5))) = (SELECT count() FROM k_fs3 WHERE has(v,toFixedString('V0',5)));
+fs3 has FS5	1
+SELECT 'fs3 indexOf FS5', (SELECT count() FROM o_fs3 WHERE indexOf(v,toFixedString('V0',5)) = 1) = (SELECT count() FROM k_fs3 WHERE indexOf(v,toFixedString('V0',5)) = 1);
+fs3 indexOf FS5	1
+SELECT 'fs3 hasAny FS5', (SELECT count() FROM o_fs3 WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_fs3 WHERE hasAny(v,[toFixedString('V0',5)]));
+fs3 hasAny FS5	1
+SELECT 'fs3 hasAll FS5', (SELECT count() FROM o_fs3 WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_fs3 WHERE hasAll(v,[toFixedString('V0',5)]));
+fs3 hasAll FS5	1
+SELECT 'fs3 has Str', (SELECT count() FROM o_fs3 WHERE has(v,'V0')) = (SELECT count() FROM k_fs3 WHERE has(v,'V0'));
+fs3 has Str	1
+SELECT 'fs3 has FS2', (SELECT count() FROM o_fs3 WHERE has(v,toFixedString('V0',2))) = (SELECT count() FROM k_fs3 WHERE has(v,toFixedString('V0',2)));
+fs3 has FS2	1
+SELECT 'fs3 has FS3', (SELECT count() FROM o_fs3 WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_fs3 WHERE has(v,toFixedString('V0',3)));
+fs3 has FS3	1
+SELECT 'fs3 indexOf FS3', (SELECT count() FROM o_fs3 WHERE indexOf(v,toFixedString('V0',3)) = 1) = (SELECT count() FROM k_fs3 WHERE indexOf(v,toFixedString('V0',3)) = 1);
+fs3 indexOf FS3	1
+SELECT 'fs3 hasAny FS3', (SELECT count() FROM o_fs3 WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_fs3 WHERE hasAny(v,[toFixedString('V0',3)]));
+fs3 hasAny FS3	1
+SELECT 'fs3 hasAll FS3', (SELECT count() FROM o_fs3 WHERE hasAll(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_fs3 WHERE hasAll(v,[toFixedString('V0',3)]));
+fs3 hasAll FS3	1
+-- Array(LowCardinality(String)): every predicate coerces here, so every FixedString constant was wrong.
+SELECT 'lcstr has FS3', (SELECT count() FROM o_lcstr WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcstr WHERE has(v,toFixedString('V0',3)));
+lcstr has FS3	1
+SELECT 'lcstr has FS5', (SELECT count() FROM o_lcstr WHERE has(v,toFixedString('V0',5))) = (SELECT count() FROM k_lcstr WHERE has(v,toFixedString('V0',5)));
+lcstr has FS5	1
+SELECT 'lcstr indexOf FS3', (SELECT count() FROM o_lcstr WHERE indexOf(v,toFixedString('V0',3)) = 1) = (SELECT count() FROM k_lcstr WHERE indexOf(v,toFixedString('V0',3)) = 1);
+lcstr indexOf FS3	1
+SELECT 'lcstr indexOf FS5', (SELECT count() FROM o_lcstr WHERE indexOf(v,toFixedString('V0',5)) = 1) = (SELECT count() FROM k_lcstr WHERE indexOf(v,toFixedString('V0',5)) = 1);
+lcstr indexOf FS5	1
+SELECT 'lcstr hasAny FS3', (SELECT count() FROM o_lcstr WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcstr WHERE hasAny(v,[toFixedString('V0',3)]));
+lcstr hasAny FS3	1
+SELECT 'lcstr hasAny FS5', (SELECT count() FROM o_lcstr WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcstr WHERE hasAny(v,[toFixedString('V0',5)]));
+lcstr hasAny FS5	1
+SELECT 'lcstr hasAll FS3', (SELECT count() FROM o_lcstr WHERE hasAll(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcstr WHERE hasAll(v,[toFixedString('V0',3)]));
+lcstr hasAll FS3	1
+SELECT 'lcstr hasAll FS5', (SELECT count() FROM o_lcstr WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcstr WHERE hasAll(v,[toFixedString('V0',5)]));
+lcstr hasAll FS5	1
+SELECT 'lcstr has Str', (SELECT count() FROM o_lcstr WHERE has(v,'V0')) = (SELECT count() FROM k_lcstr WHERE has(v,'V0'));
+lcstr has Str	1
+SELECT 'lcstr has FS2', (SELECT count() FROM o_lcstr WHERE has(v,toFixedString('V0',2))) = (SELECT count() FROM k_lcstr WHERE has(v,toFixedString('V0',2)));
+lcstr has FS2	1
+SELECT 'lcstr hasAny Str', (SELECT count() FROM o_lcstr WHERE hasAny(v,['V0'])) = (SELECT count() FROM k_lcstr WHERE hasAny(v,['V0']));
+lcstr hasAny Str	1
+-- Array(LowCardinality(FixedString(3))): hasAny/hasAll cast to the supertype and legitimately match.
+SELECT 'lcfs3 hasAny FS5', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcfs3 WHERE hasAny(v,[toFixedString('V0',5)]));
+lcfs3 hasAny FS5	1
+SELECT 'lcfs3 hasAll FS5', (SELECT count() FROM o_lcfs3 WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcfs3 WHERE hasAll(v,[toFixedString('V0',5)]));
+lcfs3 hasAll FS5	1
+SELECT 'lcfs3 has FS3', (SELECT count() FROM o_lcfs3 WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcfs3 WHERE has(v,toFixedString('V0',3)));
+lcfs3 has FS3	1
+SELECT 'lcfs3 hasAny FS3', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)]));
+lcfs3 hasAny FS3	1
+-- has/indexOf over a LowCardinality element cast the constant straight to the dictionary type, which
+-- overflows for a wider constant. The engine raises this with no index at all, so the index must
+-- decline rather than answer 0.
+SELECT count() FROM o_lcfs3 WHERE has(v,toFixedString('V0',5)); -- { serverError TOO_LARGE_STRING_SIZE }
+SELECT count() FROM k_lcfs3 WHERE has(v,toFixedString('V0',5)); -- { serverError TOO_LARGE_STRING_SIZE }
+SELECT count() FROM o_lcfs3 WHERE indexOf(v,toFixedString('V0',5)) = 1; -- { serverError TOO_LARGE_STRING_SIZE }
+SELECT count() FROM k_lcfs3 WHERE indexOf(v,toFixedString('V0',5)) = 1; -- { serverError TOO_LARGE_STRING_SIZE }
+-- Pruning must not be lost. 64 granules, needle in exactly one, so the reduction is real.
+CREATE TABLE p_str (id UInt64, v Array(String), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO p_str SELECT number, [if(number = 7, 'V0', concat('z', toString(number)))] FROM numbers(64);
+CREATE TABLE p_fs3 (id UInt64, v Array(FixedString(3)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO p_fs3 SELECT number, [if(number = 7, toFixedString('V0',3), toFixedString(concat('z', leftPad(toString(number),2,'0')),3))] FROM numbers(64);
+CREATE TABLE p_lcstr (id UInt64, v Array(LowCardinality(String)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO p_lcstr SELECT number, [if(number = 7, 'V0', concat('z', toString(number)))] FROM numbers(64);
+SELECT 'prune str has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune str has Str	1
+SELECT 'prune str hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune str hasAny FS3	1
+-- has over a bare String element keeps hashing the padded form, so a FixedString(3) constant selects
+-- the granule holding 'V0\0' and not the one holding 'V0'. Asserting the exact granule the index picks
+-- pins the representation: a >0-reduction test would also pass if the index pruned everything away.
+CREATE TABLE q_str (id UInt64, v Array(String), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO q_str SELECT number, [multiIf(number = 7, 'V0', number = 11, 'V0\0', concat('z', toString(number)))] FROM numbers(64);
+SELECT 'padded str has FS3', (SELECT count() FROM q_str WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM q_str WHERE has(v,toFixedString('V0',3)) SETTINGS use_skip_indexes=0);
+padded str has FS3	1
+SELECT 'padded str has FS3 id', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE has(v,toFixedString('V0',3)) ORDER BY id SETTINGS use_skip_indexes=0));
+padded str has FS3 id	1
+-- On byte-identical data has matches the padded row and hasAny matches the unpadded one. Pinning the
+-- absolute ids is what proves each predicate keeps its own representation: a keyed-vs-unkeyed
+-- comparison alone stays green if a change moves both sides together.
+SELECT 'padded str has FS3 is 11', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = [11];
+padded str has FS3 is 11	1
+SELECT 'unpadded str hasAny FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id)) = [7];
+unpadded str hasAny FS3 is 7	1
+SELECT 'prune str has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM q_str WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune str has FS3	1
+SELECT 'padded str hasAny FS3 id', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id)) = (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id SETTINGS use_skip_indexes=0));
+padded str hasAny FS3 id	1
+SELECT 'prune fs3 has FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('V0',5))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune fs3 has FS5	1
+SELECT 'prune fs3 indexOf FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE indexOf(v,toFixedString('V0',5)) = 1) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune fs3 indexOf FS5	1
+SELECT 'prune fs3 hasAny FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE hasAny(v,[toFixedString('V0',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune fs3 hasAny FS5	1
+SELECT 'prune fs3 hasAll FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE hasAll(v,[toFixedString('V0',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune fs3 hasAll FS5	1
+SELECT 'prune fs3 has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune fs3 has FS3	1
+SELECT 'prune lcstr has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune lcstr has FS3	1
+SELECT 'prune lcstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune lcstr hasAny FS3	1
+SELECT 'prune lcstr has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune lcstr has Str	1
+-- A numeric element takes executeIntegral, a coercion the helper does not emulate, so it stays on the
+-- original path. Answer and pruning must both be unaffected.
+CREATE TABLE p_num (id UInt64, v Array(UInt64), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO p_num SELECT number, [if(number = 7, 999, number)] FROM numbers(64);
+SELECT 'num has', (SELECT count() FROM p_num WHERE has(v,999)) = (SELECT count() FROM p_num WHERE has(v,999) SETTINGS use_skip_indexes=0);
+num has	1
+SELECT 'num hasAny', (SELECT count() FROM p_num WHERE hasAny(v,[999])) = (SELECT count() FROM p_num WHERE hasAny(v,[999]) SETTINGS use_skip_indexes=0);
+num hasAny	1
+SELECT 'prune num has', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_num WHERE has(v,999)) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune num has	1
+-- has(<const array>, <indexed scalar>) shares createColumnFromConstantArray, whose runtime is a
+-- Field-level accurateEquals and therefore needs the padded form. Deliberately left untouched.
+-- The indexed column must be a SCALAR: with an array column this form does not use the index at all,
+-- which would make every assertion below vacuous.
+CREATE TABLE o_sc (id UInt64, s String) ENGINE = Log;
+CREATE TABLE k_sc (id UInt64, s String, INDEX idx s TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_sc VALUES (0,'V0'),(1,'V0\0'),(2,'V0\0\0'),(3,'X');
+INSERT INTO k_sc VALUES (0,'V0'),(1,'V0\0'),(2,'V0\0\0'),(3,'X');
+SELECT 'const-array has FS3', (SELECT count() FROM o_sc WHERE has([toFixedString('V0',3)], s)) = (SELECT count() FROM k_sc WHERE has([toFixedString('V0',3)], s));
+const-array has FS3	1
+SELECT 'const-array has FS5', (SELECT count() FROM o_sc WHERE has([toFixedString('V0',5)], s)) = (SELECT count() FROM k_sc WHERE has([toFixedString('V0',5)], s));
+const-array has FS5	1
+SELECT 'const-array has Str', (SELECT count() FROM o_sc WHERE has(['V0'], s)) = (SELECT count() FROM k_sc WHERE has(['V0'], s));
+const-array has Str	1
+SELECT 'const-array has FS3 id', (SELECT groupArray(id) FROM (SELECT id FROM k_sc WHERE has([toFixedString('V0',3)], s) ORDER BY id)) = [1];
+const-array has FS3 id	1
+SELECT 'prune const-array has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM k_sc WHERE has([toFixedString('V0',3)], s)) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune const-array has FS3	1
+DROP TABLE o_str;
+DROP TABLE k_str;
+DROP TABLE o_fs3;
+DROP TABLE k_fs3;
+DROP TABLE o_lcstr;
+DROP TABLE k_lcstr;
+DROP TABLE o_lcfs3;
+DROP TABLE k_lcfs3;
+DROP TABLE p_str;
+DROP TABLE p_fs3;
+DROP TABLE p_lcstr;
+DROP TABLE p_num;
+DROP TABLE q_str;
+DROP TABLE o_sc;
+DROP TABLE k_sc;

--- a/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.reference
+++ b/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.reference
@@ -12,6 +12,11 @@ DROP TABLE IF EXISTS o_lcstr;
 DROP TABLE IF EXISTS k_lcstr;
 DROP TABLE IF EXISTS o_lcfs3;
 DROP TABLE IF EXISTS k_lcfs3;
+DROP TABLE IF EXISTS o_lcnstr;
+DROP TABLE IF EXISTS k_lcnstr;
+DROP TABLE IF EXISTS o_lcnfs3;
+DROP TABLE IF EXISTS k_lcnfs3;
+DROP TABLE IF EXISTS p_lcnstr;
 DROP TABLE IF EXISTS p_str;
 DROP TABLE IF EXISTS p_fs3;
 DROP TABLE IF EXISTS p_lcstr;
@@ -39,6 +44,14 @@ CREATE TABLE o_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3)))) ENGINE
 CREATE TABLE k_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO o_lcfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
 INSERT INTO k_lcfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
+CREATE TABLE o_lcnstr (id UInt64, v Array(LowCardinality(Nullable(String)))) ENGINE = Log;
+CREATE TABLE k_lcnstr (id UInt64, v Array(LowCardinality(Nullable(String))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_lcnstr VALUES (0,['V0']),(1,['V0\0']),(2,['V0\0\0']),(3,['X']);
+INSERT INTO k_lcnstr VALUES (0,['V0']),(1,['V0\0']),(2,['V0\0\0']),(3,['X']);
+CREATE TABLE o_lcnfs3 (id UInt64, v Array(LowCardinality(Nullable(FixedString(3))))) ENGINE = Log;
+CREATE TABLE k_lcnfs3 (id UInt64, v Array(LowCardinality(Nullable(FixedString(3)))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_lcnfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']);
+INSERT INTO k_lcnfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']);
 -- `Array(String)`: `hasAny`/`hasAll` cast both arrays to the common type, so they compare the
 -- unpadded value.
 SELECT 'str hasAny FS3', (SELECT count() FROM o_str WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_str WHERE hasAny(v,[toFixedString('V0',3)]));
@@ -91,6 +104,16 @@ SELECT 'fs3 hasAny FS3', (SELECT count() FROM o_fs3 WHERE hasAny(v,[toFixedStrin
 fs3 hasAny FS3	1
 SELECT 'fs3 hasAll FS3', (SELECT count() FROM o_fs3 WHERE hasAll(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_fs3 WHERE hasAll(v,[toFixedString('V0',3)]));
 fs3 hasAll FS3	1
+-- A constant that does not fit the element width even after the padding is stripped: `WXYZ` is 4
+-- bytes against `FixedString(3)`, so the second hop throws and analysis must decline. The engine has
+-- an answer here without any index, so a decline must leave that answer intact rather than
+-- propagating the error. This is the scalar twin of the batched case pinned further down.
+SELECT 'fs3 has unrepresentable FS5', (SELECT count() FROM o_fs3 WHERE has(v,toFixedString('WXYZ',5))) = (SELECT count() FROM k_fs3 WHERE has(v,toFixedString('WXYZ',5)));
+fs3 has unrepresentable FS5	1
+SELECT 'fs3 indexOf unrepresentable FS5', (SELECT count() FROM o_fs3 WHERE indexOf(v,toFixedString('WXYZ',5)) = 1) = (SELECT count() FROM k_fs3 WHERE indexOf(v,toFixedString('WXYZ',5)) = 1);
+fs3 indexOf unrepresentable FS5	1
+SELECT 'fs3 has unrepresentable FS5 is 0', (SELECT count() FROM k_fs3 WHERE has(v,toFixedString('WXYZ',5))) = 0;
+fs3 has unrepresentable FS5 is 0	1
 -- `Array(LowCardinality(String))`: every predicate coerces here, so every `FixedString` constant was
 -- wrong.
 SELECT 'lcstr has FS3', (SELECT count() FROM o_lcstr WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcstr WHERE has(v,toFixedString('V0',3)));
@@ -125,6 +148,33 @@ SELECT 'lcfs3 has FS3', (SELECT count() FROM o_lcfs3 WHERE has(v,toFixedString('
 lcfs3 has FS3	1
 SELECT 'lcfs3 hasAny FS3', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)]));
 lcfs3 hasAny FS3	1
+-- `LowCardinality(Nullable(...))` is the one element type carrying both wrappers, so
+-- `getPrimitiveType` strips both and the raw type is neither `String` nor bare `LowCardinality`:
+-- it takes the Direct mode. `bloom_filter` accepts it because the array's data column is a
+-- `ColumnLowCardinality`, not a `ColumnNullable`, and two existing tests already index this type.
+SELECT 'lcnstr has FS3', (SELECT count() FROM o_lcnstr WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcnstr WHERE has(v,toFixedString('V0',3)));
+lcnstr has FS3	1
+SELECT 'lcnstr indexOf FS3', (SELECT count() FROM o_lcnstr WHERE indexOf(v,toFixedString('V0',3)) = 1) = (SELECT count() FROM k_lcnstr WHERE indexOf(v,toFixedString('V0',3)) = 1);
+lcnstr indexOf FS3	1
+SELECT 'lcnstr hasAny FS3', (SELECT count() FROM o_lcnstr WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcnstr WHERE hasAny(v,[toFixedString('V0',3)]));
+lcnstr hasAny FS3	1
+SELECT 'lcnstr hasAll FS3', (SELECT count() FROM o_lcnstr WHERE hasAll(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcnstr WHERE hasAll(v,[toFixedString('V0',3)]));
+lcnstr hasAll FS3	1
+SELECT 'lcnstr hasAny FS5', (SELECT count() FROM o_lcnstr WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcnstr WHERE hasAny(v,[toFixedString('V0',5)]));
+lcnstr hasAny FS5	1
+SELECT 'lcnstr has Str', (SELECT count() FROM o_lcnstr WHERE has(v,'V0')) = (SELECT count() FROM k_lcnstr WHERE has(v,'V0'));
+lcnstr has Str	1
+SELECT 'lcnfs3 hasAny FS5', (SELECT count() FROM o_lcnfs3 WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcnfs3 WHERE hasAny(v,[toFixedString('V0',5)]));
+lcnfs3 hasAny FS5	1
+SELECT 'lcnfs3 hasAll FS5', (SELECT count() FROM o_lcnfs3 WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcnfs3 WHERE hasAll(v,[toFixedString('V0',5)]));
+lcnfs3 hasAll FS5	1
+SELECT 'lcnfs3 has FS3', (SELECT count() FROM o_lcnfs3 WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcnfs3 WHERE has(v,toFixedString('V0',3)));
+lcnfs3 has FS3	1
+-- Adding `Nullable` inside `LowCardinality` changes the wider-constant outcome: `Array(LowCardinality(FixedString(3)))`
+-- raises `Code 131` at `has(v, toFixedString('V0',5))` (pinned at the `serverError` cells below), while the
+-- nullable element absorbs the failed cast and answers 0 on both arms. Must not change.
+SELECT 'lcnfs3 has FS5', (SELECT count() FROM o_lcnfs3 WHERE has(v,toFixedString('V0',5))) = (SELECT count() FROM k_lcnfs3 WHERE has(v,toFixedString('V0',5)));
+lcnfs3 has FS5	1
 -- `has`/`indexOf` over a `LowCardinality` element cast the constant straight to the dictionary type,
 -- which overflows for a wider constant. The engine raises this with no index at all, so the index must
 -- decline rather than answer 0.
@@ -190,6 +240,8 @@ CREATE TABLE p_lcstr (id UInt64, v Array(LowCardinality(String)), INDEX idx v TY
 INSERT INTO p_lcstr SELECT number, [if(number = 7, 'V0', concat('z', toString(number)))] FROM numbers(64);
 CREATE TABLE p_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO p_lcfs3 SELECT number, [if(number = 7, toFixedString('V0',3), toFixedString(concat('z', leftPad(toString(number),2,'0')),3))] FROM numbers(64);
+CREATE TABLE p_lcnstr (id UInt64, v Array(LowCardinality(Nullable(String))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO p_lcnstr SELECT number, [if(number = 7, 'V0', concat('z', toString(number)))] FROM numbers(64);
 SELECT 'prune str has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune str has Str	1
 SELECT 'prune str hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
@@ -231,6 +283,17 @@ SELECT 'prune lcstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT co
 prune lcstr hasAny FS3	1
 SELECT 'prune lcstr has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune lcstr has Str	1
+SELECT 'prune lcnstr has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcnstr WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune lcnstr has FS3	1
+SELECT 'prune lcnstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcnstr WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune lcnstr hasAny FS3	1
+SELECT 'prune lcnstr has FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_lcnstr WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = [7];
+prune lcnstr has FS3 is 7	1
+-- The unrepresentable-constant query must still PLAN, so analysis has to swallow the failed cast
+-- rather than propagate it. This reads the plan rather than the answer, which is what makes it fail
+-- loudly if the scalar coercion ever rethrows.
+SELECT 'decline fs3 has unrepresentable FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('WXYZ',5))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) = toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+decline fs3 has unrepresentable FS5	1
 -- `LowCardinality(FixedString(N))` is the one element type where the two coercion modes could differ,
 -- and the whole case for coercing rather than declining is that pruning survives. The four cells
 -- above that use this wrapper are result comparisons, which would also pass if analysis declined
@@ -294,13 +357,22 @@ fs3m hasAny later unrepresentable	1
 -- pin the granule reduction for a multi-element constant array, which is what the PR claims to
 -- preserve by coercing rather than declining.
 CREATE TABLE p_fs3m (id UInt64, v Array(FixedString(3)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
-INSERT INTO p_fs3m SELECT number, if(number = 7, [toFixedString('V0',3), toFixedString('V0A',3)], [toFixedString(concat('z', leftPad(toString(number),2,'0')),3)]) FROM numbers(64);
-SELECT 'prune fs3m hasAny nonfirst FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3m WHERE hasAny(v,[toFixedString('QQQ',5),toFixedString('V0A',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+INSERT INTO p_fs3m SELECT number, multiIf(number = 5, [toFixedString('V0',3)], number = 7, [toFixedString('V0',3), toFixedString('V0A',3)], number = 11, [toFixedString('V0A',3)], [toFixedString(concat('z', leftPad(toString(number),2,'0')),3)]) FROM numbers(64);
+SELECT 'prune fs3m hasAny nonfirst FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('V0A',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune fs3m hasAny nonfirst FS5	1
 SELECT 'prune fs3m hasAll both FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3m WHERE hasAll(v,[toFixedString('V0',5),toFixedString('V0A',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune fs3m hasAll both FS5	1
-SELECT 'prune fs3m hasAny id is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_fs3m WHERE hasAny(v,[toFixedString('QQQ',5),toFixedString('V0A',5)]) ORDER BY id)) = [7];
-prune fs3m hasAny id is 7	1
+-- Two needles across three granules: one row has only the first, one only the second, one both. So
+-- dropping EITHER hash changes the selected ROW SET, which a result cell can see; with both needles
+-- on a single row it does not, and only the granule count moves. `hasAny` is the cell that sees it:
+-- the index ORs the hashes, so a missing hash prunes a granule the runtime can never bring back.
+-- `hasAll` ANDs them, so a missing hash only ADDS granules and the runtime `hasAll` removes the
+-- extra rows again, which is why the cell below it is a must-not-change control rather than a
+-- dropped-hash detector.
+SELECT 'prune fs3m hasAny ids are 5 7 11', (SELECT groupArray(id) FROM (SELECT id FROM p_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('V0A',5)]) ORDER BY id)) = [5,7,11];
+prune fs3m hasAny ids are 5 7 11	1
+SELECT 'prune fs3m hasAll ids are 7', (SELECT groupArray(id) FROM (SELECT id FROM p_fs3m WHERE hasAll(v,[toFixedString('V0',5),toFixedString('V0A',5)]) ORDER BY id)) = [7];
+prune fs3m hasAll ids are 7	1
 DROP TABLE o_str;
 DROP TABLE k_str;
 DROP TABLE o_fs3;
@@ -309,6 +381,11 @@ DROP TABLE o_lcstr;
 DROP TABLE k_lcstr;
 DROP TABLE o_lcfs3;
 DROP TABLE k_lcfs3;
+DROP TABLE o_lcnstr;
+DROP TABLE k_lcnstr;
+DROP TABLE o_lcnfs3;
+DROP TABLE k_lcnfs3;
+DROP TABLE p_lcnstr;
 DROP TABLE p_str;
 DROP TABLE p_fs3;
 DROP TABLE p_lcstr;

--- a/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.reference
+++ b/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.reference
@@ -149,9 +149,10 @@ lcfs3 has FS3	1
 SELECT 'lcfs3 hasAny FS3', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)]));
 lcfs3 hasAny FS3	1
 -- `LowCardinality(Nullable(...))` is the one element type carrying both wrappers, so
--- `getPrimitiveType` strips both and the raw type is neither `String` nor bare `LowCardinality`:
--- it takes the Direct mode. `bloom_filter` accepts it because the array's data column is a
--- `ColumnLowCardinality`, not a `ColumnNullable`, and two existing tests already index this type.
+-- `getPrimitiveType` strips both. The mode is per-PREDICATE, not per-type: `has`/`indexOf` see the raw
+-- `LowCardinality` and take the Direct mode, while `hasAny`/`hasAll` route through the batched helper,
+-- whose two hops are always Supertype. `bloom_filter` accepts this type because the array's data column
+-- is a `ColumnLowCardinality`, not a `ColumnNullable`, and two existing tests already index it.
 SELECT 'lcnstr has FS3', (SELECT count() FROM o_lcnstr WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcnstr WHERE has(v,toFixedString('V0',3)));
 lcnstr has FS3	1
 SELECT 'lcnstr indexOf FS3', (SELECT count() FROM o_lcnstr WHERE indexOf(v,toFixedString('V0',3)) = 1) = (SELECT count() FROM k_lcnstr WHERE indexOf(v,toFixedString('V0',3)) = 1);
@@ -289,10 +290,12 @@ SELECT 'prune lcnstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT c
 prune lcnstr hasAny FS3	1
 SELECT 'prune lcnstr has FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_lcnstr WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = [7];
 prune lcnstr has FS3 is 7	1
--- The unrepresentable-constant query must still PLAN, so analysis has to swallow the failed cast
--- rather than propagate it. This reads the plan rather than the answer, which is what makes it fail
--- loudly if the scalar coercion ever rethrows.
-SELECT 'decline fs3 has unrepresentable FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('WXYZ',5))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) = toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+-- Two properties in one cell. The query must still PLAN, so analysis has to swallow the failed cast
+-- rather than propagate it: a rethrow errors the whole statement. And the `idx` block must be ABSENT,
+-- so the decline is real rather than a successful prune of a value the function can never match. The
+-- `Name:` line is emitted only for a named index, and the always-present `PrimaryKey` entry carries no
+-- name, so a granule-count predicate cannot stand in for this.
+SELECT 'decline fs3 has unrepresentable FS5', countIf(explain LIKE '%Name: idx%') = 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('WXYZ',5)));
 decline fs3 has unrepresentable FS5	1
 -- `LowCardinality(FixedString(N))` is the one element type where the two coercion modes could differ,
 -- and the whole case for coercing rather than declining is that pruning survives. The four cells
@@ -373,6 +376,12 @@ SELECT 'prune fs3m hasAny ids are 5 7 11', (SELECT groupArray(id) FROM (SELECT i
 prune fs3m hasAny ids are 5 7 11	1
 SELECT 'prune fs3m hasAll ids are 7', (SELECT groupArray(id) FROM (SELECT id FROM p_fs3m WHERE hasAll(v,[toFixedString('V0',5),toFixedString('V0A',5)]) ORDER BY id)) = [7];
 prune fs3m hasAll ids are 7	1
+-- One unrepresentable element declines the WHOLE predicate, so the index must not be applied even
+-- though the other element is representable and present in the data. The result cell above cannot see
+-- this: hashing only the valid `V0` and dropping `WXYZ` selects exactly the rows `hasAny` returns, so
+-- the answer stays right while the contract is broken. Only the plan shows it.
+SELECT 'decline fs3m hasAny later unrepresentable', countIf(explain LIKE '%Name: idx%') = 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('WXYZ',5)]));
+decline fs3m hasAny later unrepresentable	1
 DROP TABLE o_str;
 DROP TABLE k_str;
 DROP TABLE o_fs3;

--- a/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.reference
+++ b/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.reference
@@ -14,6 +14,7 @@ DROP TABLE IF EXISTS k_lcfs3;
 DROP TABLE IF EXISTS p_str;
 DROP TABLE IF EXISTS p_fs3;
 DROP TABLE IF EXISTS p_lcstr;
+DROP TABLE IF EXISTS p_lcfs3;
 DROP TABLE IF EXISTS p_num;
 DROP TABLE IF EXISTS q_str;
 DROP TABLE IF EXISTS o_sc;
@@ -123,6 +124,55 @@ SELECT count() FROM o_lcfs3 WHERE has(v,toFixedString('V0',5)); -- { serverError
 SELECT count() FROM k_lcfs3 WHERE has(v,toFixedString('V0',5)); -- { serverError TOO_LARGE_STRING_SIZE }
 SELECT count() FROM o_lcfs3 WHERE indexOf(v,toFixedString('V0',5)) = 1; -- { serverError TOO_LARGE_STRING_SIZE }
 SELECT count() FROM k_lcfs3 WHERE indexOf(v,toFixedString('V0',5)) = 1; -- { serverError TOO_LARGE_STRING_SIZE }
+-- A NULL constant has no representation in the index domain, so analysis must decline instead of
+-- materializing it. The constant must be a TYPED null: a bare NULL is Nullable(Nothing), which fails
+-- the string test and declines earlier, so a bare-literal cell would not reach the coercion at all.
+-- RPNBuilder keeps the constant type Nullable only when the value IS Null, so this is the exact pair
+-- that arrives. Every cell answers 0; asserting keyed == oracle is what catches a throw.
+SELECT 'null str has NStr', (SELECT count() FROM o_str WHERE has(v,CAST(NULL AS Nullable(String)))) = (SELECT count() FROM k_str WHERE has(v,CAST(NULL AS Nullable(String))));
+null str has NStr	1
+SELECT 'null str indexOf NStr', (SELECT count() FROM o_str WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1) = (SELECT count() FROM k_str WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1);
+null str indexOf NStr	1
+SELECT 'null str hasAny NStr', (SELECT count() FROM o_str WHERE hasAny(v,[CAST(NULL AS Nullable(String))])) = (SELECT count() FROM k_str WHERE hasAny(v,[CAST(NULL AS Nullable(String))]));
+null str hasAny NStr	1
+SELECT 'null str hasAll NStr', (SELECT count() FROM o_str WHERE hasAll(v,[CAST(NULL AS Nullable(String))])) = (SELECT count() FROM k_str WHERE hasAll(v,[CAST(NULL AS Nullable(String))]));
+null str hasAll NStr	1
+SELECT 'null fs3 has NStr', (SELECT count() FROM o_fs3 WHERE has(v,CAST(NULL AS Nullable(String)))) = (SELECT count() FROM k_fs3 WHERE has(v,CAST(NULL AS Nullable(String))));
+null fs3 has NStr	1
+SELECT 'null fs3 has NFS3', (SELECT count() FROM o_fs3 WHERE has(v,CAST(NULL AS Nullable(FixedString(3))))) = (SELECT count() FROM k_fs3 WHERE has(v,CAST(NULL AS Nullable(FixedString(3)))));
+null fs3 has NFS3	1
+SELECT 'null fs3 indexOf NStr', (SELECT count() FROM o_fs3 WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1) = (SELECT count() FROM k_fs3 WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1);
+null fs3 indexOf NStr	1
+SELECT 'null fs3 indexOf NFS3', (SELECT count() FROM o_fs3 WHERE indexOf(v,CAST(NULL AS Nullable(FixedString(3)))) = 1) = (SELECT count() FROM k_fs3 WHERE indexOf(v,CAST(NULL AS Nullable(FixedString(3)))) = 1);
+null fs3 indexOf NFS3	1
+SELECT 'null fs3 hasAny NFS3', (SELECT count() FROM o_fs3 WHERE hasAny(v,[CAST(NULL AS Nullable(FixedString(3)))])) = (SELECT count() FROM k_fs3 WHERE hasAny(v,[CAST(NULL AS Nullable(FixedString(3)))]));
+null fs3 hasAny NFS3	1
+SELECT 'null fs3 hasAll NFS3', (SELECT count() FROM o_fs3 WHERE hasAll(v,[CAST(NULL AS Nullable(FixedString(3)))])) = (SELECT count() FROM k_fs3 WHERE hasAll(v,[CAST(NULL AS Nullable(FixedString(3)))]));
+null fs3 hasAll NFS3	1
+SELECT 'null lcstr has NStr', (SELECT count() FROM o_lcstr WHERE has(v,CAST(NULL AS Nullable(String)))) = (SELECT count() FROM k_lcstr WHERE has(v,CAST(NULL AS Nullable(String))));
+null lcstr has NStr	1
+SELECT 'null lcstr has NFS3', (SELECT count() FROM o_lcstr WHERE has(v,CAST(NULL AS Nullable(FixedString(3))))) = (SELECT count() FROM k_lcstr WHERE has(v,CAST(NULL AS Nullable(FixedString(3)))));
+null lcstr has NFS3	1
+SELECT 'null lcstr indexOf NStr', (SELECT count() FROM o_lcstr WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1) = (SELECT count() FROM k_lcstr WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1);
+null lcstr indexOf NStr	1
+SELECT 'null lcstr indexOf NFS3', (SELECT count() FROM o_lcstr WHERE indexOf(v,CAST(NULL AS Nullable(FixedString(3)))) = 1) = (SELECT count() FROM k_lcstr WHERE indexOf(v,CAST(NULL AS Nullable(FixedString(3)))) = 1);
+null lcstr indexOf NFS3	1
+SELECT 'null lcstr hasAny NStr', (SELECT count() FROM o_lcstr WHERE hasAny(v,[CAST(NULL AS Nullable(String))])) = (SELECT count() FROM k_lcstr WHERE hasAny(v,[CAST(NULL AS Nullable(String))]));
+null lcstr hasAny NStr	1
+SELECT 'null lcstr hasAll NStr', (SELECT count() FROM o_lcstr WHERE hasAll(v,[CAST(NULL AS Nullable(String))])) = (SELECT count() FROM k_lcstr WHERE hasAll(v,[CAST(NULL AS Nullable(String))]));
+null lcstr hasAll NStr	1
+SELECT 'null lcfs3 has NStr', (SELECT count() FROM o_lcfs3 WHERE has(v,CAST(NULL AS Nullable(String)))) = (SELECT count() FROM k_lcfs3 WHERE has(v,CAST(NULL AS Nullable(String))));
+null lcfs3 has NStr	1
+SELECT 'null lcfs3 has NFS3', (SELECT count() FROM o_lcfs3 WHERE has(v,CAST(NULL AS Nullable(FixedString(3))))) = (SELECT count() FROM k_lcfs3 WHERE has(v,CAST(NULL AS Nullable(FixedString(3)))));
+null lcfs3 has NFS3	1
+SELECT 'null lcfs3 indexOf NStr', (SELECT count() FROM o_lcfs3 WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1) = (SELECT count() FROM k_lcfs3 WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1);
+null lcfs3 indexOf NStr	1
+SELECT 'null lcfs3 indexOf NFS3', (SELECT count() FROM o_lcfs3 WHERE indexOf(v,CAST(NULL AS Nullable(FixedString(3)))) = 1) = (SELECT count() FROM k_lcfs3 WHERE indexOf(v,CAST(NULL AS Nullable(FixedString(3)))) = 1);
+null lcfs3 indexOf NFS3	1
+SELECT 'null lcfs3 hasAny NFS3', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[CAST(NULL AS Nullable(FixedString(3)))])) = (SELECT count() FROM k_lcfs3 WHERE hasAny(v,[CAST(NULL AS Nullable(FixedString(3)))]));
+null lcfs3 hasAny NFS3	1
+SELECT 'null lcfs3 hasAll NFS3', (SELECT count() FROM o_lcfs3 WHERE hasAll(v,[CAST(NULL AS Nullable(FixedString(3)))])) = (SELECT count() FROM k_lcfs3 WHERE hasAll(v,[CAST(NULL AS Nullable(FixedString(3)))]));
+null lcfs3 hasAll NFS3	1
 -- Pruning must not be lost. 64 granules, needle in exactly one, so the reduction is real.
 CREATE TABLE p_str (id UInt64, v Array(String), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO p_str SELECT number, [if(number = 7, 'V0', concat('z', toString(number)))] FROM numbers(64);
@@ -130,6 +180,8 @@ CREATE TABLE p_fs3 (id UInt64, v Array(FixedString(3)), INDEX idx v TYPE bloom_f
 INSERT INTO p_fs3 SELECT number, [if(number = 7, toFixedString('V0',3), toFixedString(concat('z', leftPad(toString(number),2,'0')),3))] FROM numbers(64);
 CREATE TABLE p_lcstr (id UInt64, v Array(LowCardinality(String)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO p_lcstr SELECT number, [if(number = 7, 'V0', concat('z', toString(number)))] FROM numbers(64);
+CREATE TABLE p_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO p_lcfs3 SELECT number, [if(number = 7, toFixedString('V0',3), toFixedString(concat('z', leftPad(toString(number),2,'0')),3))] FROM numbers(64);
 SELECT 'prune str has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune str has Str	1
 SELECT 'prune str hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
@@ -170,6 +222,23 @@ SELECT 'prune lcstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT co
 prune lcstr hasAny FS3	1
 SELECT 'prune lcstr has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune lcstr has Str	1
+-- LowCardinality(FixedString(N)) is the one element type where the two coercion modes could differ,
+-- and the whole case for coercing rather than declining is that pruning survives. The four cells
+-- above that use this wrapper are result comparisons, which would also pass if analysis declined
+-- entirely, so pin both modes here: has/indexOf take Direct, hasAny/hasAll take Supertype.
+SELECT 'prune lcfs3 has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcfs3 WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune lcfs3 has FS3	1
+SELECT 'prune lcfs3 indexOf FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcfs3 WHERE indexOf(v,toFixedString('V0',3)) = 1) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune lcfs3 indexOf FS3	1
+SELECT 'prune lcfs3 hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune lcfs3 hasAny FS3	1
+SELECT 'prune lcfs3 hasAll FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcfs3 WHERE hasAll(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+prune lcfs3 hasAll FS3	1
+-- The reduction is real and both modes agree on it: all four select exactly the granule holding row 7.
+SELECT 'prune lcfs3 has FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_lcfs3 WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = [7];
+prune lcfs3 has FS3 is 7	1
+SELECT 'prune lcfs3 hasAny FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id)) = [7];
+prune lcfs3 hasAny FS3 is 7	1
 -- A numeric element takes executeIntegral, a coercion the helper does not emulate, so it stays on the
 -- original path. Answer and pruning must both be unaffected.
 CREATE TABLE p_num (id UInt64, v Array(UInt64), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
@@ -209,6 +278,7 @@ DROP TABLE k_lcfs3;
 DROP TABLE p_str;
 DROP TABLE p_fs3;
 DROP TABLE p_lcstr;
+DROP TABLE p_lcfs3;
 DROP TABLE p_num;
 DROP TABLE q_str;
 DROP TABLE o_sc;

--- a/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.reference
+++ b/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.reference
@@ -1,7 +1,8 @@
 -- { echo }
 
--- The index must hash the value the array-search function actually compares. Every cell asserts
--- keyed == oracle, so no expected answer is baked into the reference.
+-- The index must hash the value the array-search function actually compares. Cells either compare
+-- the keyed answer against an unindexed oracle, assert a granule reduction, or pin the rows the
+-- index selects; every reference row answers 1, so no expected value is baked in.
 
 DROP TABLE IF EXISTS o_str;
 DROP TABLE IF EXISTS k_str;
@@ -182,9 +183,9 @@ CREATE TABLE p_lcstr (id UInt64, v Array(LowCardinality(String)), INDEX idx v TY
 INSERT INTO p_lcstr SELECT number, [if(number = 7, 'V0', concat('z', toString(number)))] FROM numbers(64);
 CREATE TABLE p_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO p_lcfs3 SELECT number, [if(number = 7, toFixedString('V0',3), toFixedString(concat('z', leftPad(toString(number),2,'0')),3))] FROM numbers(64);
-SELECT 'prune str has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune str has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune str has Str	1
-SELECT 'prune str hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune str hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune str hasAny FS3	1
 -- has over a bare String element keeps hashing the padded form, so a FixedString(3) constant selects
 -- the granule holding 'V0\0' and not the one holding 'V0'. Asserting the exact granule the index picks
@@ -206,21 +207,21 @@ SELECT 'prune str has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count()
 prune str has FS3	1
 SELECT 'padded str hasAny FS3 id', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id)) = (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id SETTINGS use_skip_indexes=0));
 padded str hasAny FS3 id	1
-SELECT 'prune fs3 has FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('V0',5))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3 has FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('V0',5))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune fs3 has FS5	1
-SELECT 'prune fs3 indexOf FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE indexOf(v,toFixedString('V0',5)) = 1) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3 indexOf FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE indexOf(v,toFixedString('V0',5)) = 1) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune fs3 indexOf FS5	1
-SELECT 'prune fs3 hasAny FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE hasAny(v,[toFixedString('V0',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3 hasAny FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE hasAny(v,[toFixedString('V0',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune fs3 hasAny FS5	1
-SELECT 'prune fs3 hasAll FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE hasAll(v,[toFixedString('V0',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3 hasAll FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE hasAll(v,[toFixedString('V0',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune fs3 hasAll FS5	1
-SELECT 'prune fs3 has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3 has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune fs3 has FS3	1
-SELECT 'prune lcstr has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcstr has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune lcstr has FS3	1
-SELECT 'prune lcstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune lcstr hasAny FS3	1
-SELECT 'prune lcstr has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcstr has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 prune lcstr has Str	1
 -- LowCardinality(FixedString(N)) is the one element type where the two coercion modes could differ,
 -- and the whole case for coercing rather than declining is that pruning survives. The four cells

--- a/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.sql
+++ b/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.sql
@@ -12,6 +12,11 @@ DROP TABLE IF EXISTS o_lcstr;
 DROP TABLE IF EXISTS k_lcstr;
 DROP TABLE IF EXISTS o_lcfs3;
 DROP TABLE IF EXISTS k_lcfs3;
+DROP TABLE IF EXISTS o_lcnstr;
+DROP TABLE IF EXISTS k_lcnstr;
+DROP TABLE IF EXISTS o_lcnfs3;
+DROP TABLE IF EXISTS k_lcnfs3;
+DROP TABLE IF EXISTS p_lcnstr;
 DROP TABLE IF EXISTS p_str;
 DROP TABLE IF EXISTS p_fs3;
 DROP TABLE IF EXISTS p_lcstr;
@@ -43,6 +48,16 @@ CREATE TABLE o_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3)))) ENGINE
 CREATE TABLE k_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO o_lcfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
 INSERT INTO k_lcfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
+
+CREATE TABLE o_lcnstr (id UInt64, v Array(LowCardinality(Nullable(String)))) ENGINE = Log;
+CREATE TABLE k_lcnstr (id UInt64, v Array(LowCardinality(Nullable(String))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_lcnstr VALUES (0,['V0']),(1,['V0\0']),(2,['V0\0\0']),(3,['X']);
+INSERT INTO k_lcnstr VALUES (0,['V0']),(1,['V0\0']),(2,['V0\0\0']),(3,['X']);
+
+CREATE TABLE o_lcnfs3 (id UInt64, v Array(LowCardinality(Nullable(FixedString(3))))) ENGINE = Log;
+CREATE TABLE k_lcnfs3 (id UInt64, v Array(LowCardinality(Nullable(FixedString(3)))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_lcnfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']);
+INSERT INTO k_lcnfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']);
 
 -- `Array(String)`: `hasAny`/`hasAll` cast both arrays to the common type, so they compare the
 -- unpadded value.
@@ -76,6 +91,14 @@ SELECT 'fs3 indexOf FS3', (SELECT count() FROM o_fs3 WHERE indexOf(v,toFixedStri
 SELECT 'fs3 hasAny FS3', (SELECT count() FROM o_fs3 WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_fs3 WHERE hasAny(v,[toFixedString('V0',3)]));
 SELECT 'fs3 hasAll FS3', (SELECT count() FROM o_fs3 WHERE hasAll(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_fs3 WHERE hasAll(v,[toFixedString('V0',3)]));
 
+-- A constant that does not fit the element width even after the padding is stripped: `WXYZ` is 4
+-- bytes against `FixedString(3)`, so the second hop throws and analysis must decline. The engine has
+-- an answer here without any index, so a decline must leave that answer intact rather than
+-- propagating the error. This is the scalar twin of the batched case pinned further down.
+SELECT 'fs3 has unrepresentable FS5', (SELECT count() FROM o_fs3 WHERE has(v,toFixedString('WXYZ',5))) = (SELECT count() FROM k_fs3 WHERE has(v,toFixedString('WXYZ',5)));
+SELECT 'fs3 indexOf unrepresentable FS5', (SELECT count() FROM o_fs3 WHERE indexOf(v,toFixedString('WXYZ',5)) = 1) = (SELECT count() FROM k_fs3 WHERE indexOf(v,toFixedString('WXYZ',5)) = 1);
+SELECT 'fs3 has unrepresentable FS5 is 0', (SELECT count() FROM k_fs3 WHERE has(v,toFixedString('WXYZ',5))) = 0;
+
 -- `Array(LowCardinality(String))`: every predicate coerces here, so every `FixedString` constant was
 -- wrong.
 SELECT 'lcstr has FS3', (SELECT count() FROM o_lcstr WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcstr WHERE has(v,toFixedString('V0',3)));
@@ -96,6 +119,24 @@ SELECT 'lcfs3 hasAny FS5', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[toFixedS
 SELECT 'lcfs3 hasAll FS5', (SELECT count() FROM o_lcfs3 WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcfs3 WHERE hasAll(v,[toFixedString('V0',5)]));
 SELECT 'lcfs3 has FS3', (SELECT count() FROM o_lcfs3 WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcfs3 WHERE has(v,toFixedString('V0',3)));
 SELECT 'lcfs3 hasAny FS3', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)]));
+
+-- `LowCardinality(Nullable(...))` is the one element type carrying both wrappers, so
+-- `getPrimitiveType` strips both and the raw type is neither `String` nor bare `LowCardinality`:
+-- it takes the Direct mode. `bloom_filter` accepts it because the array's data column is a
+-- `ColumnLowCardinality`, not a `ColumnNullable`, and two existing tests already index this type.
+SELECT 'lcnstr has FS3', (SELECT count() FROM o_lcnstr WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcnstr WHERE has(v,toFixedString('V0',3)));
+SELECT 'lcnstr indexOf FS3', (SELECT count() FROM o_lcnstr WHERE indexOf(v,toFixedString('V0',3)) = 1) = (SELECT count() FROM k_lcnstr WHERE indexOf(v,toFixedString('V0',3)) = 1);
+SELECT 'lcnstr hasAny FS3', (SELECT count() FROM o_lcnstr WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcnstr WHERE hasAny(v,[toFixedString('V0',3)]));
+SELECT 'lcnstr hasAll FS3', (SELECT count() FROM o_lcnstr WHERE hasAll(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcnstr WHERE hasAll(v,[toFixedString('V0',3)]));
+SELECT 'lcnstr hasAny FS5', (SELECT count() FROM o_lcnstr WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcnstr WHERE hasAny(v,[toFixedString('V0',5)]));
+SELECT 'lcnstr has Str', (SELECT count() FROM o_lcnstr WHERE has(v,'V0')) = (SELECT count() FROM k_lcnstr WHERE has(v,'V0'));
+SELECT 'lcnfs3 hasAny FS5', (SELECT count() FROM o_lcnfs3 WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcnfs3 WHERE hasAny(v,[toFixedString('V0',5)]));
+SELECT 'lcnfs3 hasAll FS5', (SELECT count() FROM o_lcnfs3 WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcnfs3 WHERE hasAll(v,[toFixedString('V0',5)]));
+SELECT 'lcnfs3 has FS3', (SELECT count() FROM o_lcnfs3 WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcnfs3 WHERE has(v,toFixedString('V0',3)));
+-- Adding `Nullable` inside `LowCardinality` changes the wider-constant outcome: `Array(LowCardinality(FixedString(3)))`
+-- raises `Code 131` at `has(v, toFixedString('V0',5))` (pinned at the `serverError` cells below), while the
+-- nullable element absorbs the failed cast and answers 0 on both arms. Must not change.
+SELECT 'lcnfs3 has FS5', (SELECT count() FROM o_lcnfs3 WHERE has(v,toFixedString('V0',5))) = (SELECT count() FROM k_lcnfs3 WHERE has(v,toFixedString('V0',5)));
 
 -- `has`/`indexOf` over a `LowCardinality` element cast the constant straight to the dictionary type,
 -- which overflows for a wider constant. The engine raises this with no index at all, so the index must
@@ -142,6 +183,8 @@ CREATE TABLE p_lcstr (id UInt64, v Array(LowCardinality(String)), INDEX idx v TY
 INSERT INTO p_lcstr SELECT number, [if(number = 7, 'V0', concat('z', toString(number)))] FROM numbers(64);
 CREATE TABLE p_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO p_lcfs3 SELECT number, [if(number = 7, toFixedString('V0',3), toFixedString(concat('z', leftPad(toString(number),2,'0')),3))] FROM numbers(64);
+CREATE TABLE p_lcnstr (id UInt64, v Array(LowCardinality(Nullable(String))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO p_lcnstr SELECT number, [if(number = 7, 'V0', concat('z', toString(number)))] FROM numbers(64);
 
 SELECT 'prune str has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 SELECT 'prune str hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
@@ -169,6 +212,14 @@ SELECT 'prune fs3 has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count()
 SELECT 'prune lcstr has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 SELECT 'prune lcstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 SELECT 'prune lcstr has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcnstr has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcnstr WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcnstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcnstr WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcnstr has FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_lcnstr WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = [7];
+
+-- The unrepresentable-constant query must still PLAN, so analysis has to swallow the failed cast
+-- rather than propagate it. This reads the plan rather than the answer, which is what makes it fail
+-- loudly if the scalar coercion ever rethrows.
+SELECT 'decline fs3 has unrepresentable FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('WXYZ',5))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) = toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 
 -- `LowCardinality(FixedString(N))` is the one element type where the two coercion modes could differ,
 -- and the whole case for coercing rather than declining is that pruning survives. The four cells
@@ -220,10 +271,18 @@ SELECT 'fs3m hasAny later unrepresentable', (SELECT count() FROM o_fs3m WHERE ha
 -- pin the granule reduction for a multi-element constant array, which is what the PR claims to
 -- preserve by coercing rather than declining.
 CREATE TABLE p_fs3m (id UInt64, v Array(FixedString(3)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
-INSERT INTO p_fs3m SELECT number, if(number = 7, [toFixedString('V0',3), toFixedString('V0A',3)], [toFixedString(concat('z', leftPad(toString(number),2,'0')),3)]) FROM numbers(64);
-SELECT 'prune fs3m hasAny nonfirst FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3m WHERE hasAny(v,[toFixedString('QQQ',5),toFixedString('V0A',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+INSERT INTO p_fs3m SELECT number, multiIf(number = 5, [toFixedString('V0',3)], number = 7, [toFixedString('V0',3), toFixedString('V0A',3)], number = 11, [toFixedString('V0A',3)], [toFixedString(concat('z', leftPad(toString(number),2,'0')),3)]) FROM numbers(64);
+SELECT 'prune fs3m hasAny nonfirst FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('V0A',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 SELECT 'prune fs3m hasAll both FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3m WHERE hasAll(v,[toFixedString('V0',5),toFixedString('V0A',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
-SELECT 'prune fs3m hasAny id is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_fs3m WHERE hasAny(v,[toFixedString('QQQ',5),toFixedString('V0A',5)]) ORDER BY id)) = [7];
+-- Two needles across three granules: one row has only the first, one only the second, one both. So
+-- dropping EITHER hash changes the selected ROW SET, which a result cell can see; with both needles
+-- on a single row it does not, and only the granule count moves. `hasAny` is the cell that sees it:
+-- the index ORs the hashes, so a missing hash prunes a granule the runtime can never bring back.
+-- `hasAll` ANDs them, so a missing hash only ADDS granules and the runtime `hasAll` removes the
+-- extra rows again, which is why the cell below it is a must-not-change control rather than a
+-- dropped-hash detector.
+SELECT 'prune fs3m hasAny ids are 5 7 11', (SELECT groupArray(id) FROM (SELECT id FROM p_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('V0A',5)]) ORDER BY id)) = [5,7,11];
+SELECT 'prune fs3m hasAll ids are 7', (SELECT groupArray(id) FROM (SELECT id FROM p_fs3m WHERE hasAll(v,[toFixedString('V0',5),toFixedString('V0A',5)]) ORDER BY id)) = [7];
 
 DROP TABLE o_str;
 DROP TABLE k_str;
@@ -233,6 +292,11 @@ DROP TABLE o_lcstr;
 DROP TABLE k_lcstr;
 DROP TABLE o_lcfs3;
 DROP TABLE k_lcfs3;
+DROP TABLE o_lcnstr;
+DROP TABLE k_lcnstr;
+DROP TABLE o_lcnfs3;
+DROP TABLE k_lcnfs3;
+DROP TABLE p_lcnstr;
 DROP TABLE p_str;
 DROP TABLE p_fs3;
 DROP TABLE p_lcstr;

--- a/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.sql
+++ b/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.sql
@@ -20,6 +20,8 @@ DROP TABLE IF EXISTS p_num;
 DROP TABLE IF EXISTS q_str;
 DROP TABLE IF EXISTS o_sc;
 DROP TABLE IF EXISTS k_sc;
+DROP TABLE IF EXISTS o_fs3m;
+DROP TABLE IF EXISTS k_fs3m;
 
 CREATE TABLE o_str (id UInt64, v Array(String)) ENGINE = Log;
 CREATE TABLE k_str (id UInt64, v Array(String), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
@@ -196,6 +198,18 @@ SELECT 'const-array has Str', (SELECT count() FROM o_sc WHERE has(['V0'], s)) = 
 SELECT 'const-array has FS3 id', (SELECT groupArray(id) FROM (SELECT id FROM k_sc WHERE has([toFixedString('V0',3)], s) ORDER BY id)) = [1];
 SELECT 'prune const-array has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM k_sc WHERE has([toFixedString('V0',3)], s)) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 
+-- Multi-element constant arrays: the coercion is batched over the whole array, so a non-first
+-- element must survive both hops in its own position. Rows carry two elements so hasAll genuinely
+-- needs both. Every constant shares one width: a mixed-width literal array types as Array(String),
+-- which would reach the helper with a different element type and probe another path.
+CREATE TABLE o_fs3m (id UInt64, v Array(FixedString(3))) ENGINE = Log;
+CREATE TABLE k_fs3m (id UInt64, v Array(FixedString(3)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_fs3m VALUES (0,['V0','V0A']),(1,['V0']),(2,['XYZ','ZZZ']);
+INSERT INTO k_fs3m VALUES (0,['V0','V0A']),(1,['V0']),(2,['XYZ','ZZZ']);
+SELECT 'fs3m hasAny nonfirst FS5', (SELECT count() FROM o_fs3m WHERE hasAny(v,[toFixedString('QQQ',5),toFixedString('V0A',5)])) = (SELECT count() FROM k_fs3m WHERE hasAny(v,[toFixedString('QQQ',5),toFixedString('V0A',5)]));
+SELECT 'fs3m hasAll both FS5', (SELECT count() FROM o_fs3m WHERE hasAll(v,[toFixedString('V0',5),toFixedString('V0A',5)])) = (SELECT count() FROM k_fs3m WHERE hasAll(v,[toFixedString('V0',5),toFixedString('V0A',5)]));
+SELECT 'fs3m hasAny later unrepresentable', (SELECT count() FROM o_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('WXYZ',5)])) = (SELECT count() FROM k_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('WXYZ',5)]));
+
 DROP TABLE o_str;
 DROP TABLE k_str;
 DROP TABLE o_fs3;
@@ -212,3 +226,5 @@ DROP TABLE p_num;
 DROP TABLE q_str;
 DROP TABLE o_sc;
 DROP TABLE k_sc;
+DROP TABLE o_fs3m;
+DROP TABLE k_fs3m;

--- a/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.sql
+++ b/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.sql
@@ -1,7 +1,8 @@
 -- { echo }
 
--- The index must hash the value the array-search function actually compares. Every cell asserts
--- keyed == oracle, so no expected answer is baked into the reference.
+-- The index must hash the value the array-search function actually compares. Cells either compare
+-- the keyed answer against an unindexed oracle, assert a granule reduction, or pin the rows the
+-- index selects; every reference row answers 1, so no expected value is baked in.
 
 DROP TABLE IF EXISTS o_str;
 DROP TABLE IF EXISTS k_str;
@@ -135,8 +136,8 @@ INSERT INTO p_lcstr SELECT number, [if(number = 7, 'V0', concat('z', toString(nu
 CREATE TABLE p_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO p_lcfs3 SELECT number, [if(number = 7, toFixedString('V0',3), toFixedString(concat('z', leftPad(toString(number),2,'0')),3))] FROM numbers(64);
 
-SELECT 'prune str has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
-SELECT 'prune str hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune str has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune str hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 
 -- has over a bare String element keeps hashing the padded form, so a FixedString(3) constant selects
 -- the granule holding 'V0\0' and not the one holding 'V0'. Asserting the exact granule the index picks
@@ -152,14 +153,14 @@ SELECT 'padded str has FS3 is 11', (SELECT groupArray(id) FROM (SELECT id FROM q
 SELECT 'unpadded str hasAny FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id)) = [7];
 SELECT 'prune str has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM q_str WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 SELECT 'padded str hasAny FS3 id', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id)) = (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id SETTINGS use_skip_indexes=0));
-SELECT 'prune fs3 has FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('V0',5))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
-SELECT 'prune fs3 indexOf FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE indexOf(v,toFixedString('V0',5)) = 1) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
-SELECT 'prune fs3 hasAny FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE hasAny(v,[toFixedString('V0',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
-SELECT 'prune fs3 hasAll FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE hasAll(v,[toFixedString('V0',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
-SELECT 'prune fs3 has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
-SELECT 'prune lcstr has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
-SELECT 'prune lcstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
-SELECT 'prune lcstr has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3 has FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('V0',5))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3 indexOf FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE indexOf(v,toFixedString('V0',5)) = 1) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3 hasAny FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE hasAny(v,[toFixedString('V0',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3 hasAll FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE hasAll(v,[toFixedString('V0',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3 has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcstr has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcstr has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 
 -- LowCardinality(FixedString(N)) is the one element type where the two coercion modes could differ,
 -- and the whole case for coercing rather than declining is that pruning survives. The four cells

--- a/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.sql
+++ b/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.sql
@@ -17,6 +17,7 @@ DROP TABLE IF EXISTS p_fs3;
 DROP TABLE IF EXISTS p_lcstr;
 DROP TABLE IF EXISTS p_lcfs3;
 DROP TABLE IF EXISTS p_num;
+DROP TABLE IF EXISTS p_fs3m;
 DROP TABLE IF EXISTS q_str;
 DROP TABLE IF EXISTS o_sc;
 DROP TABLE IF EXISTS k_sc;
@@ -43,13 +44,15 @@ CREATE TABLE k_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3))), INDEX 
 INSERT INTO o_lcfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
 INSERT INTO k_lcfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
 
--- Array(String): hasAny/hasAll cast both arrays to the common type, so they compare the unpadded value.
+-- `Array(String)`: `hasAny`/`hasAll` cast both arrays to the common type, so they compare the
+-- unpadded value.
 SELECT 'str hasAny FS3', (SELECT count() FROM o_str WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_str WHERE hasAny(v,[toFixedString('V0',3)]));
 SELECT 'str hasAny FS5', (SELECT count() FROM o_str WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_str WHERE hasAny(v,[toFixedString('V0',5)]));
 SELECT 'str hasAll FS3', (SELECT count() FROM o_str WHERE hasAll(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_str WHERE hasAll(v,[toFixedString('V0',3)]));
 SELECT 'str hasAll FS5', (SELECT count() FROM o_str WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_str WHERE hasAll(v,[toFixedString('V0',5)]));
 
--- Array(String): has/indexOf take executeString, which compares the raw padded bytes. Must not change.
+-- `Array(String)`: `has`/`indexOf` take `executeString`, which compares the raw padded bytes. Must
+-- not change.
 SELECT 'str has Str', (SELECT count() FROM o_str WHERE has(v,'V0')) = (SELECT count() FROM k_str WHERE has(v,'V0'));
 SELECT 'str has FS2', (SELECT count() FROM o_str WHERE has(v,toFixedString('V0',2))) = (SELECT count() FROM k_str WHERE has(v,toFixedString('V0',2)));
 SELECT 'str has FS3', (SELECT count() FROM o_str WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_str WHERE has(v,toFixedString('V0',3)));
@@ -60,8 +63,8 @@ SELECT 'str hasAny Str', (SELECT count() FROM o_str WHERE hasAny(v,['V0'])) = (S
 SELECT 'str hasAny FS2', (SELECT count() FROM o_str WHERE hasAny(v,[toFixedString('V0',2)])) = (SELECT count() FROM k_str WHERE hasAny(v,[toFixedString('V0',2)]));
 SELECT 'str hasAll Str', (SELECT count() FROM o_str WHERE hasAll(v,['V0'])) = (SELECT count() FROM k_str WHERE hasAll(v,['V0']));
 
--- Array(FixedString(3)): a wider constant is stripped then re-encoded into the element width, so it
--- matches exactly. Before the fix has/indexOf answered 0 and hasAny/hasAll raised Code 131.
+-- `Array(FixedString(3))`: a wider constant is stripped then re-encoded into the element width, so it
+-- matches exactly. Before the fix `has`/`indexOf` answered 0 and `hasAny`/`hasAll` raised `Code 131`.
 SELECT 'fs3 has FS5', (SELECT count() FROM o_fs3 WHERE has(v,toFixedString('V0',5))) = (SELECT count() FROM k_fs3 WHERE has(v,toFixedString('V0',5)));
 SELECT 'fs3 indexOf FS5', (SELECT count() FROM o_fs3 WHERE indexOf(v,toFixedString('V0',5)) = 1) = (SELECT count() FROM k_fs3 WHERE indexOf(v,toFixedString('V0',5)) = 1);
 SELECT 'fs3 hasAny FS5', (SELECT count() FROM o_fs3 WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_fs3 WHERE hasAny(v,[toFixedString('V0',5)]));
@@ -73,7 +76,8 @@ SELECT 'fs3 indexOf FS3', (SELECT count() FROM o_fs3 WHERE indexOf(v,toFixedStri
 SELECT 'fs3 hasAny FS3', (SELECT count() FROM o_fs3 WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_fs3 WHERE hasAny(v,[toFixedString('V0',3)]));
 SELECT 'fs3 hasAll FS3', (SELECT count() FROM o_fs3 WHERE hasAll(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_fs3 WHERE hasAll(v,[toFixedString('V0',3)]));
 
--- Array(LowCardinality(String)): every predicate coerces here, so every FixedString constant was wrong.
+-- `Array(LowCardinality(String))`: every predicate coerces here, so every `FixedString` constant was
+-- wrong.
 SELECT 'lcstr has FS3', (SELECT count() FROM o_lcstr WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcstr WHERE has(v,toFixedString('V0',3)));
 SELECT 'lcstr has FS5', (SELECT count() FROM o_lcstr WHERE has(v,toFixedString('V0',5))) = (SELECT count() FROM k_lcstr WHERE has(v,toFixedString('V0',5)));
 SELECT 'lcstr indexOf FS3', (SELECT count() FROM o_lcstr WHERE indexOf(v,toFixedString('V0',3)) = 1) = (SELECT count() FROM k_lcstr WHERE indexOf(v,toFixedString('V0',3)) = 1);
@@ -86,25 +90,26 @@ SELECT 'lcstr has Str', (SELECT count() FROM o_lcstr WHERE has(v,'V0')) = (SELEC
 SELECT 'lcstr has FS2', (SELECT count() FROM o_lcstr WHERE has(v,toFixedString('V0',2))) = (SELECT count() FROM k_lcstr WHERE has(v,toFixedString('V0',2)));
 SELECT 'lcstr hasAny Str', (SELECT count() FROM o_lcstr WHERE hasAny(v,['V0'])) = (SELECT count() FROM k_lcstr WHERE hasAny(v,['V0']));
 
--- Array(LowCardinality(FixedString(3))): hasAny/hasAll cast to the supertype and legitimately match.
+-- `Array(LowCardinality(FixedString(3)))`: `hasAny`/`hasAll` cast to the supertype and legitimately
+-- match.
 SELECT 'lcfs3 hasAny FS5', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcfs3 WHERE hasAny(v,[toFixedString('V0',5)]));
 SELECT 'lcfs3 hasAll FS5', (SELECT count() FROM o_lcfs3 WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcfs3 WHERE hasAll(v,[toFixedString('V0',5)]));
 SELECT 'lcfs3 has FS3', (SELECT count() FROM o_lcfs3 WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcfs3 WHERE has(v,toFixedString('V0',3)));
 SELECT 'lcfs3 hasAny FS3', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)]));
 
--- has/indexOf over a LowCardinality element cast the constant straight to the dictionary type, which
--- overflows for a wider constant. The engine raises this with no index at all, so the index must
+-- `has`/`indexOf` over a `LowCardinality` element cast the constant straight to the dictionary type,
+-- which overflows for a wider constant. The engine raises this with no index at all, so the index must
 -- decline rather than answer 0.
 SELECT count() FROM o_lcfs3 WHERE has(v,toFixedString('V0',5)); -- { serverError TOO_LARGE_STRING_SIZE }
 SELECT count() FROM k_lcfs3 WHERE has(v,toFixedString('V0',5)); -- { serverError TOO_LARGE_STRING_SIZE }
 SELECT count() FROM o_lcfs3 WHERE indexOf(v,toFixedString('V0',5)) = 1; -- { serverError TOO_LARGE_STRING_SIZE }
 SELECT count() FROM k_lcfs3 WHERE indexOf(v,toFixedString('V0',5)) = 1; -- { serverError TOO_LARGE_STRING_SIZE }
 
--- A NULL constant has no representation in the index domain, so analysis must decline instead of
--- materializing it. The constant must be a TYPED null: a bare NULL is Nullable(Nothing), which fails
--- the string test and declines earlier, so a bare-literal cell would not reach the coercion at all.
--- RPNBuilder keeps the constant type Nullable only when the value IS Null, so this is the exact pair
--- that arrives. Every cell answers 0; asserting keyed == oracle is what catches a throw.
+-- A `NULL` constant has no representation in the index domain, so analysis must decline instead of
+-- materializing it. The constant must be a TYPED null: a bare `NULL` is `Nullable(Nothing)`, which
+-- fails the string test and declines earlier, so a bare-literal cell would not reach the coercion at
+-- all. `RPNBuilder` keeps the constant type `Nullable` only when the value IS Null, so this is the
+-- exact pair that arrives. Every cell answers 0; asserting keyed == oracle is what catches a throw.
 SELECT 'null str has NStr', (SELECT count() FROM o_str WHERE has(v,CAST(NULL AS Nullable(String)))) = (SELECT count() FROM k_str WHERE has(v,CAST(NULL AS Nullable(String))));
 SELECT 'null str indexOf NStr', (SELECT count() FROM o_str WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1) = (SELECT count() FROM k_str WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1);
 SELECT 'null str hasAny NStr', (SELECT count() FROM o_str WHERE hasAny(v,[CAST(NULL AS Nullable(String))])) = (SELECT count() FROM k_str WHERE hasAny(v,[CAST(NULL AS Nullable(String))]));
@@ -141,15 +146,16 @@ INSERT INTO p_lcfs3 SELECT number, [if(number = 7, toFixedString('V0',3), toFixe
 SELECT 'prune str has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 SELECT 'prune str hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 
--- has over a bare String element keeps hashing the padded form, so a FixedString(3) constant selects
--- the granule holding 'V0\0' and not the one holding 'V0'. Asserting the exact granule the index picks
--- pins the representation: a >0-reduction test would also pass if the index pruned everything away.
+-- `has` over a bare `String` element keeps hashing the padded form, so a `FixedString(3)` constant
+-- selects the granule holding 'V0\0' and not the one holding 'V0'. Asserting the exact granule the
+-- index picks pins the representation: a >0-reduction test would also pass if the index pruned
+-- everything away.
 CREATE TABLE q_str (id UInt64, v Array(String), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO q_str SELECT number, [multiIf(number = 7, 'V0', number = 11, 'V0\0', concat('z', toString(number)))] FROM numbers(64);
 SELECT 'padded str has FS3', (SELECT count() FROM q_str WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM q_str WHERE has(v,toFixedString('V0',3)) SETTINGS use_skip_indexes=0);
 SELECT 'padded str has FS3 id', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE has(v,toFixedString('V0',3)) ORDER BY id SETTINGS use_skip_indexes=0));
--- On byte-identical data has matches the padded row and hasAny matches the unpadded one. Pinning the
--- absolute ids is what proves each predicate keeps its own representation: a keyed-vs-unkeyed
+-- On byte-identical data `has` matches the padded row and `hasAny` matches the unpadded one. Pinning
+-- the absolute ids is what proves each predicate keeps its own representation: a keyed-vs-unkeyed
 -- comparison alone stays green if a change moves both sides together.
 SELECT 'padded str has FS3 is 11', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = [11];
 SELECT 'unpadded str hasAny FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id)) = [7];
@@ -164,10 +170,10 @@ SELECT 'prune lcstr has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count
 SELECT 'prune lcstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 SELECT 'prune lcstr has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 
--- LowCardinality(FixedString(N)) is the one element type where the two coercion modes could differ,
+-- `LowCardinality(FixedString(N))` is the one element type where the two coercion modes could differ,
 -- and the whole case for coercing rather than declining is that pruning survives. The four cells
 -- above that use this wrapper are result comparisons, which would also pass if analysis declined
--- entirely, so pin both modes here: has/indexOf take Direct, hasAny/hasAll take Supertype.
+-- entirely, so pin both modes here: `has`/`indexOf` take Direct, `hasAny`/`hasAll` take Supertype.
 SELECT 'prune lcfs3 has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcfs3 WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 SELECT 'prune lcfs3 indexOf FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcfs3 WHERE indexOf(v,toFixedString('V0',3)) = 1) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 SELECT 'prune lcfs3 hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
@@ -176,16 +182,16 @@ SELECT 'prune lcfs3 hasAll FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT co
 SELECT 'prune lcfs3 has FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_lcfs3 WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = [7];
 SELECT 'prune lcfs3 hasAny FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id)) = [7];
 
--- A numeric element takes executeIntegral, a coercion the helper does not emulate, so it stays on the
--- original path. Answer and pruning must both be unaffected.
+-- A numeric element takes `executeIntegral`, a coercion the helper does not emulate, so it stays on
+-- the original path. Answer and pruning must both be unaffected.
 CREATE TABLE p_num (id UInt64, v Array(UInt64), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO p_num SELECT number, [if(number = 7, 999, number)] FROM numbers(64);
 SELECT 'num has', (SELECT count() FROM p_num WHERE has(v,999)) = (SELECT count() FROM p_num WHERE has(v,999) SETTINGS use_skip_indexes=0);
 SELECT 'num hasAny', (SELECT count() FROM p_num WHERE hasAny(v,[999])) = (SELECT count() FROM p_num WHERE hasAny(v,[999]) SETTINGS use_skip_indexes=0);
 SELECT 'prune num has', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_num WHERE has(v,999)) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 
--- has(<const array>, <indexed scalar>) shares createColumnFromConstantArray, whose runtime is a
--- Field-level accurateEquals and therefore needs the padded form. Deliberately left untouched.
+-- `has(<const array>, <indexed scalar>)` shares `createColumnFromConstantArray`, whose runtime is a
+-- `Field`-level `accurateEquals` and therefore needs the padded form. Deliberately left untouched.
 -- The indexed column must be a SCALAR: with an array column this form does not use the index at all,
 -- which would make every assertion below vacuous.
 CREATE TABLE o_sc (id UInt64, s String) ENGINE = Log;
@@ -199,8 +205,8 @@ SELECT 'const-array has FS3 id', (SELECT groupArray(id) FROM (SELECT id FROM k_s
 SELECT 'prune const-array has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM k_sc WHERE has([toFixedString('V0',3)], s)) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 
 -- Multi-element constant arrays: the coercion is batched over the whole array, so a non-first
--- element must survive both hops in its own position. Rows carry two elements so hasAll genuinely
--- needs both. Every constant shares one width: a mixed-width literal array types as Array(String),
+-- element must survive both hops in its own position. Rows carry two elements so `hasAll` genuinely
+-- needs both. Every constant shares one width: a mixed-width literal array types as `Array(String)`,
 -- which would reach the helper with a different element type and probe another path.
 CREATE TABLE o_fs3m (id UInt64, v Array(FixedString(3))) ENGINE = Log;
 CREATE TABLE k_fs3m (id UInt64, v Array(FixedString(3)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
@@ -209,6 +215,15 @@ INSERT INTO k_fs3m VALUES (0,['V0','V0A']),(1,['V0']),(2,['XYZ','ZZZ']);
 SELECT 'fs3m hasAny nonfirst FS5', (SELECT count() FROM o_fs3m WHERE hasAny(v,[toFixedString('QQQ',5),toFixedString('V0A',5)])) = (SELECT count() FROM k_fs3m WHERE hasAny(v,[toFixedString('QQQ',5),toFixedString('V0A',5)]));
 SELECT 'fs3m hasAll both FS5', (SELECT count() FROM o_fs3m WHERE hasAll(v,[toFixedString('V0',5),toFixedString('V0A',5)])) = (SELECT count() FROM k_fs3m WHERE hasAll(v,[toFixedString('V0',5),toFixedString('V0A',5)]));
 SELECT 'fs3m hasAny later unrepresentable', (SELECT count() FROM o_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('WXYZ',5)])) = (SELECT count() FROM k_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('WXYZ',5)]));
+
+-- A decline only changes the plan, not the answer, so the result cells above cannot see it. These
+-- pin the granule reduction for a multi-element constant array, which is what the PR claims to
+-- preserve by coercing rather than declining.
+CREATE TABLE p_fs3m (id UInt64, v Array(FixedString(3)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO p_fs3m SELECT number, if(number = 7, [toFixedString('V0',3), toFixedString('V0A',3)], [toFixedString(concat('z', leftPad(toString(number),2,'0')),3)]) FROM numbers(64);
+SELECT 'prune fs3m hasAny nonfirst FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3m WHERE hasAny(v,[toFixedString('QQQ',5),toFixedString('V0A',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3m hasAll both FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3m WHERE hasAll(v,[toFixedString('V0',5),toFixedString('V0A',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3m hasAny id is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_fs3m WHERE hasAny(v,[toFixedString('QQQ',5),toFixedString('V0A',5)]) ORDER BY id)) = [7];
 
 DROP TABLE o_str;
 DROP TABLE k_str;
@@ -223,6 +238,7 @@ DROP TABLE p_fs3;
 DROP TABLE p_lcstr;
 DROP TABLE p_lcfs3;
 DROP TABLE p_num;
+DROP TABLE p_fs3m;
 DROP TABLE q_str;
 DROP TABLE o_sc;
 DROP TABLE k_sc;

--- a/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.sql
+++ b/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.sql
@@ -14,6 +14,7 @@ DROP TABLE IF EXISTS k_lcfs3;
 DROP TABLE IF EXISTS p_str;
 DROP TABLE IF EXISTS p_fs3;
 DROP TABLE IF EXISTS p_lcstr;
+DROP TABLE IF EXISTS p_lcfs3;
 DROP TABLE IF EXISTS p_num;
 DROP TABLE IF EXISTS q_str;
 DROP TABLE IF EXISTS o_sc;
@@ -96,6 +97,34 @@ SELECT count() FROM k_lcfs3 WHERE has(v,toFixedString('V0',5)); -- { serverError
 SELECT count() FROM o_lcfs3 WHERE indexOf(v,toFixedString('V0',5)) = 1; -- { serverError TOO_LARGE_STRING_SIZE }
 SELECT count() FROM k_lcfs3 WHERE indexOf(v,toFixedString('V0',5)) = 1; -- { serverError TOO_LARGE_STRING_SIZE }
 
+-- A NULL constant has no representation in the index domain, so analysis must decline instead of
+-- materializing it. The constant must be a TYPED null: a bare NULL is Nullable(Nothing), which fails
+-- the string test and declines earlier, so a bare-literal cell would not reach the coercion at all.
+-- RPNBuilder keeps the constant type Nullable only when the value IS Null, so this is the exact pair
+-- that arrives. Every cell answers 0; asserting keyed == oracle is what catches a throw.
+SELECT 'null str has NStr', (SELECT count() FROM o_str WHERE has(v,CAST(NULL AS Nullable(String)))) = (SELECT count() FROM k_str WHERE has(v,CAST(NULL AS Nullable(String))));
+SELECT 'null str indexOf NStr', (SELECT count() FROM o_str WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1) = (SELECT count() FROM k_str WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1);
+SELECT 'null str hasAny NStr', (SELECT count() FROM o_str WHERE hasAny(v,[CAST(NULL AS Nullable(String))])) = (SELECT count() FROM k_str WHERE hasAny(v,[CAST(NULL AS Nullable(String))]));
+SELECT 'null str hasAll NStr', (SELECT count() FROM o_str WHERE hasAll(v,[CAST(NULL AS Nullable(String))])) = (SELECT count() FROM k_str WHERE hasAll(v,[CAST(NULL AS Nullable(String))]));
+SELECT 'null fs3 has NStr', (SELECT count() FROM o_fs3 WHERE has(v,CAST(NULL AS Nullable(String)))) = (SELECT count() FROM k_fs3 WHERE has(v,CAST(NULL AS Nullable(String))));
+SELECT 'null fs3 has NFS3', (SELECT count() FROM o_fs3 WHERE has(v,CAST(NULL AS Nullable(FixedString(3))))) = (SELECT count() FROM k_fs3 WHERE has(v,CAST(NULL AS Nullable(FixedString(3)))));
+SELECT 'null fs3 indexOf NStr', (SELECT count() FROM o_fs3 WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1) = (SELECT count() FROM k_fs3 WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1);
+SELECT 'null fs3 indexOf NFS3', (SELECT count() FROM o_fs3 WHERE indexOf(v,CAST(NULL AS Nullable(FixedString(3)))) = 1) = (SELECT count() FROM k_fs3 WHERE indexOf(v,CAST(NULL AS Nullable(FixedString(3)))) = 1);
+SELECT 'null fs3 hasAny NFS3', (SELECT count() FROM o_fs3 WHERE hasAny(v,[CAST(NULL AS Nullable(FixedString(3)))])) = (SELECT count() FROM k_fs3 WHERE hasAny(v,[CAST(NULL AS Nullable(FixedString(3)))]));
+SELECT 'null fs3 hasAll NFS3', (SELECT count() FROM o_fs3 WHERE hasAll(v,[CAST(NULL AS Nullable(FixedString(3)))])) = (SELECT count() FROM k_fs3 WHERE hasAll(v,[CAST(NULL AS Nullable(FixedString(3)))]));
+SELECT 'null lcstr has NStr', (SELECT count() FROM o_lcstr WHERE has(v,CAST(NULL AS Nullable(String)))) = (SELECT count() FROM k_lcstr WHERE has(v,CAST(NULL AS Nullable(String))));
+SELECT 'null lcstr has NFS3', (SELECT count() FROM o_lcstr WHERE has(v,CAST(NULL AS Nullable(FixedString(3))))) = (SELECT count() FROM k_lcstr WHERE has(v,CAST(NULL AS Nullable(FixedString(3)))));
+SELECT 'null lcstr indexOf NStr', (SELECT count() FROM o_lcstr WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1) = (SELECT count() FROM k_lcstr WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1);
+SELECT 'null lcstr indexOf NFS3', (SELECT count() FROM o_lcstr WHERE indexOf(v,CAST(NULL AS Nullable(FixedString(3)))) = 1) = (SELECT count() FROM k_lcstr WHERE indexOf(v,CAST(NULL AS Nullable(FixedString(3)))) = 1);
+SELECT 'null lcstr hasAny NStr', (SELECT count() FROM o_lcstr WHERE hasAny(v,[CAST(NULL AS Nullable(String))])) = (SELECT count() FROM k_lcstr WHERE hasAny(v,[CAST(NULL AS Nullable(String))]));
+SELECT 'null lcstr hasAll NStr', (SELECT count() FROM o_lcstr WHERE hasAll(v,[CAST(NULL AS Nullable(String))])) = (SELECT count() FROM k_lcstr WHERE hasAll(v,[CAST(NULL AS Nullable(String))]));
+SELECT 'null lcfs3 has NStr', (SELECT count() FROM o_lcfs3 WHERE has(v,CAST(NULL AS Nullable(String)))) = (SELECT count() FROM k_lcfs3 WHERE has(v,CAST(NULL AS Nullable(String))));
+SELECT 'null lcfs3 has NFS3', (SELECT count() FROM o_lcfs3 WHERE has(v,CAST(NULL AS Nullable(FixedString(3))))) = (SELECT count() FROM k_lcfs3 WHERE has(v,CAST(NULL AS Nullable(FixedString(3)))));
+SELECT 'null lcfs3 indexOf NStr', (SELECT count() FROM o_lcfs3 WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1) = (SELECT count() FROM k_lcfs3 WHERE indexOf(v,CAST(NULL AS Nullable(String))) = 1);
+SELECT 'null lcfs3 indexOf NFS3', (SELECT count() FROM o_lcfs3 WHERE indexOf(v,CAST(NULL AS Nullable(FixedString(3)))) = 1) = (SELECT count() FROM k_lcfs3 WHERE indexOf(v,CAST(NULL AS Nullable(FixedString(3)))) = 1);
+SELECT 'null lcfs3 hasAny NFS3', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[CAST(NULL AS Nullable(FixedString(3)))])) = (SELECT count() FROM k_lcfs3 WHERE hasAny(v,[CAST(NULL AS Nullable(FixedString(3)))]));
+SELECT 'null lcfs3 hasAll NFS3', (SELECT count() FROM o_lcfs3 WHERE hasAll(v,[CAST(NULL AS Nullable(FixedString(3)))])) = (SELECT count() FROM k_lcfs3 WHERE hasAll(v,[CAST(NULL AS Nullable(FixedString(3)))]));
+
 -- Pruning must not be lost. 64 granules, needle in exactly one, so the reduction is real.
 CREATE TABLE p_str (id UInt64, v Array(String), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO p_str SELECT number, [if(number = 7, 'V0', concat('z', toString(number)))] FROM numbers(64);
@@ -103,6 +132,8 @@ CREATE TABLE p_fs3 (id UInt64, v Array(FixedString(3)), INDEX idx v TYPE bloom_f
 INSERT INTO p_fs3 SELECT number, [if(number = 7, toFixedString('V0',3), toFixedString(concat('z', leftPad(toString(number),2,'0')),3))] FROM numbers(64);
 CREATE TABLE p_lcstr (id UInt64, v Array(LowCardinality(String)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
 INSERT INTO p_lcstr SELECT number, [if(number = 7, 'V0', concat('z', toString(number)))] FROM numbers(64);
+CREATE TABLE p_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO p_lcfs3 SELECT number, [if(number = 7, toFixedString('V0',3), toFixedString(concat('z', leftPad(toString(number),2,'0')),3))] FROM numbers(64);
 
 SELECT 'prune str has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 SELECT 'prune str hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
@@ -129,6 +160,18 @@ SELECT 'prune fs3 has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count()
 SELECT 'prune lcstr has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 SELECT 'prune lcstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 SELECT 'prune lcstr has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+
+-- LowCardinality(FixedString(N)) is the one element type where the two coercion modes could differ,
+-- and the whole case for coercing rather than declining is that pruning survives. The four cells
+-- above that use this wrapper are result comparisons, which would also pass if analysis declined
+-- entirely, so pin both modes here: has/indexOf take Direct, hasAny/hasAll take Supertype.
+SELECT 'prune lcfs3 has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcfs3 WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcfs3 indexOf FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcfs3 WHERE indexOf(v,toFixedString('V0',3)) = 1) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcfs3 hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcfs3 hasAll FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcfs3 WHERE hasAll(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+-- The reduction is real and both modes agree on it: all four select exactly the granule holding row 7.
+SELECT 'prune lcfs3 has FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_lcfs3 WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = [7];
+SELECT 'prune lcfs3 hasAny FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id)) = [7];
 
 -- A numeric element takes executeIntegral, a coercion the helper does not emulate, so it stays on the
 -- original path. Answer and pruning must both be unaffected.
@@ -163,6 +206,7 @@ DROP TABLE k_lcfs3;
 DROP TABLE p_str;
 DROP TABLE p_fs3;
 DROP TABLE p_lcstr;
+DROP TABLE p_lcfs3;
 DROP TABLE p_num;
 DROP TABLE q_str;
 DROP TABLE o_sc;

--- a/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.sql
+++ b/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.sql
@@ -1,0 +1,169 @@
+-- { echo }
+
+-- The index must hash the value the array-search function actually compares. Every cell asserts
+-- keyed == oracle, so no expected answer is baked into the reference.
+
+DROP TABLE IF EXISTS o_str;
+DROP TABLE IF EXISTS k_str;
+DROP TABLE IF EXISTS o_fs3;
+DROP TABLE IF EXISTS k_fs3;
+DROP TABLE IF EXISTS o_lcstr;
+DROP TABLE IF EXISTS k_lcstr;
+DROP TABLE IF EXISTS o_lcfs3;
+DROP TABLE IF EXISTS k_lcfs3;
+DROP TABLE IF EXISTS p_str;
+DROP TABLE IF EXISTS p_fs3;
+DROP TABLE IF EXISTS p_lcstr;
+DROP TABLE IF EXISTS p_num;
+DROP TABLE IF EXISTS q_str;
+DROP TABLE IF EXISTS o_sc;
+DROP TABLE IF EXISTS k_sc;
+
+CREATE TABLE o_str (id UInt64, v Array(String)) ENGINE = Log;
+CREATE TABLE k_str (id UInt64, v Array(String), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_str VALUES (0,['V0']),(1,['V0\0']),(2,['V0\0\0']),(3,['X']);
+INSERT INTO k_str VALUES (0,['V0']),(1,['V0\0']),(2,['V0\0\0']),(3,['X']);
+
+CREATE TABLE o_fs3 (id UInt64, v Array(FixedString(3))) ENGINE = Log;
+CREATE TABLE k_fs3 (id UInt64, v Array(FixedString(3)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_fs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
+INSERT INTO k_fs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
+
+CREATE TABLE o_lcstr (id UInt64, v Array(LowCardinality(String))) ENGINE = Log;
+CREATE TABLE k_lcstr (id UInt64, v Array(LowCardinality(String)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_lcstr VALUES (0,['V0']),(1,['V0\0']),(2,['V0\0\0']),(3,['X']);
+INSERT INTO k_lcstr VALUES (0,['V0']),(1,['V0\0']),(2,['V0\0\0']),(3,['X']);
+
+CREATE TABLE o_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3)))) ENGINE = Log;
+CREATE TABLE k_lcfs3 (id UInt64, v Array(LowCardinality(FixedString(3))), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_lcfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
+INSERT INTO k_lcfs3 VALUES (0,['V0']),(1,['V0A']),(2,['XYZ']),(3,['ZZZ']);
+
+-- Array(String): hasAny/hasAll cast both arrays to the common type, so they compare the unpadded value.
+SELECT 'str hasAny FS3', (SELECT count() FROM o_str WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_str WHERE hasAny(v,[toFixedString('V0',3)]));
+SELECT 'str hasAny FS5', (SELECT count() FROM o_str WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_str WHERE hasAny(v,[toFixedString('V0',5)]));
+SELECT 'str hasAll FS3', (SELECT count() FROM o_str WHERE hasAll(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_str WHERE hasAll(v,[toFixedString('V0',3)]));
+SELECT 'str hasAll FS5', (SELECT count() FROM o_str WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_str WHERE hasAll(v,[toFixedString('V0',5)]));
+
+-- Array(String): has/indexOf take executeString, which compares the raw padded bytes. Must not change.
+SELECT 'str has Str', (SELECT count() FROM o_str WHERE has(v,'V0')) = (SELECT count() FROM k_str WHERE has(v,'V0'));
+SELECT 'str has FS2', (SELECT count() FROM o_str WHERE has(v,toFixedString('V0',2))) = (SELECT count() FROM k_str WHERE has(v,toFixedString('V0',2)));
+SELECT 'str has FS3', (SELECT count() FROM o_str WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_str WHERE has(v,toFixedString('V0',3)));
+SELECT 'str has FS5', (SELECT count() FROM o_str WHERE has(v,toFixedString('V0',5))) = (SELECT count() FROM k_str WHERE has(v,toFixedString('V0',5)));
+SELECT 'str indexOf Str', (SELECT count() FROM o_str WHERE indexOf(v,'V0') = 1) = (SELECT count() FROM k_str WHERE indexOf(v,'V0') = 1);
+SELECT 'str indexOf FS3', (SELECT count() FROM o_str WHERE indexOf(v,toFixedString('V0',3)) = 1) = (SELECT count() FROM k_str WHERE indexOf(v,toFixedString('V0',3)) = 1);
+SELECT 'str hasAny Str', (SELECT count() FROM o_str WHERE hasAny(v,['V0'])) = (SELECT count() FROM k_str WHERE hasAny(v,['V0']));
+SELECT 'str hasAny FS2', (SELECT count() FROM o_str WHERE hasAny(v,[toFixedString('V0',2)])) = (SELECT count() FROM k_str WHERE hasAny(v,[toFixedString('V0',2)]));
+SELECT 'str hasAll Str', (SELECT count() FROM o_str WHERE hasAll(v,['V0'])) = (SELECT count() FROM k_str WHERE hasAll(v,['V0']));
+
+-- Array(FixedString(3)): a wider constant is stripped then re-encoded into the element width, so it
+-- matches exactly. Before the fix has/indexOf answered 0 and hasAny/hasAll raised Code 131.
+SELECT 'fs3 has FS5', (SELECT count() FROM o_fs3 WHERE has(v,toFixedString('V0',5))) = (SELECT count() FROM k_fs3 WHERE has(v,toFixedString('V0',5)));
+SELECT 'fs3 indexOf FS5', (SELECT count() FROM o_fs3 WHERE indexOf(v,toFixedString('V0',5)) = 1) = (SELECT count() FROM k_fs3 WHERE indexOf(v,toFixedString('V0',5)) = 1);
+SELECT 'fs3 hasAny FS5', (SELECT count() FROM o_fs3 WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_fs3 WHERE hasAny(v,[toFixedString('V0',5)]));
+SELECT 'fs3 hasAll FS5', (SELECT count() FROM o_fs3 WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_fs3 WHERE hasAll(v,[toFixedString('V0',5)]));
+SELECT 'fs3 has Str', (SELECT count() FROM o_fs3 WHERE has(v,'V0')) = (SELECT count() FROM k_fs3 WHERE has(v,'V0'));
+SELECT 'fs3 has FS2', (SELECT count() FROM o_fs3 WHERE has(v,toFixedString('V0',2))) = (SELECT count() FROM k_fs3 WHERE has(v,toFixedString('V0',2)));
+SELECT 'fs3 has FS3', (SELECT count() FROM o_fs3 WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_fs3 WHERE has(v,toFixedString('V0',3)));
+SELECT 'fs3 indexOf FS3', (SELECT count() FROM o_fs3 WHERE indexOf(v,toFixedString('V0',3)) = 1) = (SELECT count() FROM k_fs3 WHERE indexOf(v,toFixedString('V0',3)) = 1);
+SELECT 'fs3 hasAny FS3', (SELECT count() FROM o_fs3 WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_fs3 WHERE hasAny(v,[toFixedString('V0',3)]));
+SELECT 'fs3 hasAll FS3', (SELECT count() FROM o_fs3 WHERE hasAll(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_fs3 WHERE hasAll(v,[toFixedString('V0',3)]));
+
+-- Array(LowCardinality(String)): every predicate coerces here, so every FixedString constant was wrong.
+SELECT 'lcstr has FS3', (SELECT count() FROM o_lcstr WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcstr WHERE has(v,toFixedString('V0',3)));
+SELECT 'lcstr has FS5', (SELECT count() FROM o_lcstr WHERE has(v,toFixedString('V0',5))) = (SELECT count() FROM k_lcstr WHERE has(v,toFixedString('V0',5)));
+SELECT 'lcstr indexOf FS3', (SELECT count() FROM o_lcstr WHERE indexOf(v,toFixedString('V0',3)) = 1) = (SELECT count() FROM k_lcstr WHERE indexOf(v,toFixedString('V0',3)) = 1);
+SELECT 'lcstr indexOf FS5', (SELECT count() FROM o_lcstr WHERE indexOf(v,toFixedString('V0',5)) = 1) = (SELECT count() FROM k_lcstr WHERE indexOf(v,toFixedString('V0',5)) = 1);
+SELECT 'lcstr hasAny FS3', (SELECT count() FROM o_lcstr WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcstr WHERE hasAny(v,[toFixedString('V0',3)]));
+SELECT 'lcstr hasAny FS5', (SELECT count() FROM o_lcstr WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcstr WHERE hasAny(v,[toFixedString('V0',5)]));
+SELECT 'lcstr hasAll FS3', (SELECT count() FROM o_lcstr WHERE hasAll(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcstr WHERE hasAll(v,[toFixedString('V0',3)]));
+SELECT 'lcstr hasAll FS5', (SELECT count() FROM o_lcstr WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcstr WHERE hasAll(v,[toFixedString('V0',5)]));
+SELECT 'lcstr has Str', (SELECT count() FROM o_lcstr WHERE has(v,'V0')) = (SELECT count() FROM k_lcstr WHERE has(v,'V0'));
+SELECT 'lcstr has FS2', (SELECT count() FROM o_lcstr WHERE has(v,toFixedString('V0',2))) = (SELECT count() FROM k_lcstr WHERE has(v,toFixedString('V0',2)));
+SELECT 'lcstr hasAny Str', (SELECT count() FROM o_lcstr WHERE hasAny(v,['V0'])) = (SELECT count() FROM k_lcstr WHERE hasAny(v,['V0']));
+
+-- Array(LowCardinality(FixedString(3))): hasAny/hasAll cast to the supertype and legitimately match.
+SELECT 'lcfs3 hasAny FS5', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcfs3 WHERE hasAny(v,[toFixedString('V0',5)]));
+SELECT 'lcfs3 hasAll FS5', (SELECT count() FROM o_lcfs3 WHERE hasAll(v,[toFixedString('V0',5)])) = (SELECT count() FROM k_lcfs3 WHERE hasAll(v,[toFixedString('V0',5)]));
+SELECT 'lcfs3 has FS3', (SELECT count() FROM o_lcfs3 WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcfs3 WHERE has(v,toFixedString('V0',3)));
+SELECT 'lcfs3 hasAny FS3', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)]));
+
+-- has/indexOf over a LowCardinality element cast the constant straight to the dictionary type, which
+-- overflows for a wider constant. The engine raises this with no index at all, so the index must
+-- decline rather than answer 0.
+SELECT count() FROM o_lcfs3 WHERE has(v,toFixedString('V0',5)); -- { serverError TOO_LARGE_STRING_SIZE }
+SELECT count() FROM k_lcfs3 WHERE has(v,toFixedString('V0',5)); -- { serverError TOO_LARGE_STRING_SIZE }
+SELECT count() FROM o_lcfs3 WHERE indexOf(v,toFixedString('V0',5)) = 1; -- { serverError TOO_LARGE_STRING_SIZE }
+SELECT count() FROM k_lcfs3 WHERE indexOf(v,toFixedString('V0',5)) = 1; -- { serverError TOO_LARGE_STRING_SIZE }
+
+-- Pruning must not be lost. 64 granules, needle in exactly one, so the reduction is real.
+CREATE TABLE p_str (id UInt64, v Array(String), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO p_str SELECT number, [if(number = 7, 'V0', concat('z', toString(number)))] FROM numbers(64);
+CREATE TABLE p_fs3 (id UInt64, v Array(FixedString(3)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO p_fs3 SELECT number, [if(number = 7, toFixedString('V0',3), toFixedString(concat('z', leftPad(toString(number),2,'0')),3))] FROM numbers(64);
+CREATE TABLE p_lcstr (id UInt64, v Array(LowCardinality(String)), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO p_lcstr SELECT number, [if(number = 7, 'V0', concat('z', toString(number)))] FROM numbers(64);
+
+SELECT 'prune str has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune str hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_str WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+
+-- has over a bare String element keeps hashing the padded form, so a FixedString(3) constant selects
+-- the granule holding 'V0\0' and not the one holding 'V0'. Asserting the exact granule the index picks
+-- pins the representation: a >0-reduction test would also pass if the index pruned everything away.
+CREATE TABLE q_str (id UInt64, v Array(String), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO q_str SELECT number, [multiIf(number = 7, 'V0', number = 11, 'V0\0', concat('z', toString(number)))] FROM numbers(64);
+SELECT 'padded str has FS3', (SELECT count() FROM q_str WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM q_str WHERE has(v,toFixedString('V0',3)) SETTINGS use_skip_indexes=0);
+SELECT 'padded str has FS3 id', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE has(v,toFixedString('V0',3)) ORDER BY id SETTINGS use_skip_indexes=0));
+-- On byte-identical data has matches the padded row and hasAny matches the unpadded one. Pinning the
+-- absolute ids is what proves each predicate keeps its own representation: a keyed-vs-unkeyed
+-- comparison alone stays green if a change moves both sides together.
+SELECT 'padded str has FS3 is 11', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = [11];
+SELECT 'unpadded str hasAny FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id)) = [7];
+SELECT 'prune str has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM q_str WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'padded str hasAny FS3 id', (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id)) = (SELECT groupArray(id) FROM (SELECT id FROM q_str WHERE hasAny(v,[toFixedString('V0',3)]) ORDER BY id SETTINGS use_skip_indexes=0));
+SELECT 'prune fs3 has FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('V0',5))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3 indexOf FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE indexOf(v,toFixedString('V0',5)) = 1) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3 hasAny FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE hasAny(v,[toFixedString('V0',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3 hasAll FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE hasAll(v,[toFixedString('V0',5)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune fs3 has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcstr has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,toFixedString('V0',3))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+SELECT 'prune lcstr has Str', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcstr WHERE has(v,'V0')) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+
+-- A numeric element takes executeIntegral, a coercion the helper does not emulate, so it stays on the
+-- original path. Answer and pruning must both be unaffected.
+CREATE TABLE p_num (id UInt64, v Array(UInt64), INDEX idx v TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO p_num SELECT number, [if(number = 7, 999, number)] FROM numbers(64);
+SELECT 'num has', (SELECT count() FROM p_num WHERE has(v,999)) = (SELECT count() FROM p_num WHERE has(v,999) SETTINGS use_skip_indexes=0);
+SELECT 'num hasAny', (SELECT count() FROM p_num WHERE hasAny(v,[999])) = (SELECT count() FROM p_num WHERE hasAny(v,[999]) SETTINGS use_skip_indexes=0);
+SELECT 'prune num has', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_num WHERE has(v,999)) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+
+-- has(<const array>, <indexed scalar>) shares createColumnFromConstantArray, whose runtime is a
+-- Field-level accurateEquals and therefore needs the padded form. Deliberately left untouched.
+-- The indexed column must be a SCALAR: with an array column this form does not use the index at all,
+-- which would make every assertion below vacuous.
+CREATE TABLE o_sc (id UInt64, s String) ENGINE = Log;
+CREATE TABLE k_sc (id UInt64, s String, INDEX idx s TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+INSERT INTO o_sc VALUES (0,'V0'),(1,'V0\0'),(2,'V0\0\0'),(3,'X');
+INSERT INTO k_sc VALUES (0,'V0'),(1,'V0\0'),(2,'V0\0\0'),(3,'X');
+SELECT 'const-array has FS3', (SELECT count() FROM o_sc WHERE has([toFixedString('V0',3)], s)) = (SELECT count() FROM k_sc WHERE has([toFixedString('V0',3)], s));
+SELECT 'const-array has FS5', (SELECT count() FROM o_sc WHERE has([toFixedString('V0',5)], s)) = (SELECT count() FROM k_sc WHERE has([toFixedString('V0',5)], s));
+SELECT 'const-array has Str', (SELECT count() FROM o_sc WHERE has(['V0'], s)) = (SELECT count() FROM k_sc WHERE has(['V0'], s));
+SELECT 'const-array has FS3 id', (SELECT groupArray(id) FROM (SELECT id FROM k_sc WHERE has([toFixedString('V0',3)], s) ORDER BY id)) = [1];
+SELECT 'prune const-array has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM k_sc WHERE has([toFixedString('V0',3)], s)) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+
+DROP TABLE o_str;
+DROP TABLE k_str;
+DROP TABLE o_fs3;
+DROP TABLE k_fs3;
+DROP TABLE o_lcstr;
+DROP TABLE k_lcstr;
+DROP TABLE o_lcfs3;
+DROP TABLE k_lcfs3;
+DROP TABLE p_str;
+DROP TABLE p_fs3;
+DROP TABLE p_lcstr;
+DROP TABLE p_num;
+DROP TABLE q_str;
+DROP TABLE o_sc;
+DROP TABLE k_sc;

--- a/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.sql
+++ b/tests/queries/0_stateless/04654_bloom_filter_array_fixed_string_constant.sql
@@ -121,9 +121,10 @@ SELECT 'lcfs3 has FS3', (SELECT count() FROM o_lcfs3 WHERE has(v,toFixedString('
 SELECT 'lcfs3 hasAny FS3', (SELECT count() FROM o_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcfs3 WHERE hasAny(v,[toFixedString('V0',3)]));
 
 -- `LowCardinality(Nullable(...))` is the one element type carrying both wrappers, so
--- `getPrimitiveType` strips both and the raw type is neither `String` nor bare `LowCardinality`:
--- it takes the Direct mode. `bloom_filter` accepts it because the array's data column is a
--- `ColumnLowCardinality`, not a `ColumnNullable`, and two existing tests already index this type.
+-- `getPrimitiveType` strips both. The mode is per-PREDICATE, not per-type: `has`/`indexOf` see the raw
+-- `LowCardinality` and take the Direct mode, while `hasAny`/`hasAll` route through the batched helper,
+-- whose two hops are always Supertype. `bloom_filter` accepts this type because the array's data column
+-- is a `ColumnLowCardinality`, not a `ColumnNullable`, and two existing tests already index it.
 SELECT 'lcnstr has FS3', (SELECT count() FROM o_lcnstr WHERE has(v,toFixedString('V0',3))) = (SELECT count() FROM k_lcnstr WHERE has(v,toFixedString('V0',3)));
 SELECT 'lcnstr indexOf FS3', (SELECT count() FROM o_lcnstr WHERE indexOf(v,toFixedString('V0',3)) = 1) = (SELECT count() FROM k_lcnstr WHERE indexOf(v,toFixedString('V0',3)) = 1);
 SELECT 'lcnstr hasAny FS3', (SELECT count() FROM o_lcnstr WHERE hasAny(v,[toFixedString('V0',3)])) = (SELECT count() FROM k_lcnstr WHERE hasAny(v,[toFixedString('V0',3)]));
@@ -216,10 +217,12 @@ SELECT 'prune lcnstr has FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT coun
 SELECT 'prune lcnstr hasAny FS3', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_lcnstr WHERE hasAny(v,[toFixedString('V0',3)])) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) > 0 AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) < toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
 SELECT 'prune lcnstr has FS3 is 7', (SELECT groupArray(id) FROM (SELECT id FROM p_lcnstr WHERE has(v,toFixedString('V0',3)) ORDER BY id)) = [7];
 
--- The unrepresentable-constant query must still PLAN, so analysis has to swallow the failed cast
--- rather than propagate it. This reads the plan rather than the answer, which is what makes it fail
--- loudly if the scalar coercion ever rethrows.
-SELECT 'decline fs3 has unrepresentable FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('WXYZ',5))) WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain,'Granules: (\d+)/')) = toUInt64OrZero(extract(explain,'Granules: \d+/(\d+)'));
+-- Two properties in one cell. The query must still PLAN, so analysis has to swallow the failed cast
+-- rather than propagate it: a rethrow errors the whole statement. And the `idx` block must be ABSENT,
+-- so the decline is real rather than a successful prune of a value the function can never match. The
+-- `Name:` line is emitted only for a named index, and the always-present `PrimaryKey` entry carries no
+-- name, so a granule-count predicate cannot stand in for this.
+SELECT 'decline fs3 has unrepresentable FS5', countIf(explain LIKE '%Name: idx%') = 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3 WHERE has(v,toFixedString('WXYZ',5)));
 
 -- `LowCardinality(FixedString(N))` is the one element type where the two coercion modes could differ,
 -- and the whole case for coercing rather than declining is that pruning survives. The four cells
@@ -283,6 +286,11 @@ SELECT 'prune fs3m hasAll both FS5', count() > 0 FROM (EXPLAIN indexes = 1 SELEC
 -- dropped-hash detector.
 SELECT 'prune fs3m hasAny ids are 5 7 11', (SELECT groupArray(id) FROM (SELECT id FROM p_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('V0A',5)]) ORDER BY id)) = [5,7,11];
 SELECT 'prune fs3m hasAll ids are 7', (SELECT groupArray(id) FROM (SELECT id FROM p_fs3m WHERE hasAll(v,[toFixedString('V0',5),toFixedString('V0A',5)]) ORDER BY id)) = [7];
+-- One unrepresentable element declines the WHOLE predicate, so the index must not be applied even
+-- though the other element is representable and present in the data. The result cell above cannot see
+-- this: hashing only the valid `V0` and dropping `WXYZ` selects exactly the rows `hasAny` returns, so
+-- the answer stays right while the contract is broken. Only the plan shows it.
+SELECT 'decline fs3m hasAny later unrepresentable', countIf(explain LIKE '%Name: idx%') = 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM p_fs3m WHERE hasAny(v,[toFixedString('V0',5),toFixedString('WXYZ',5)]));
 
 DROP TABLE o_str;
 DROP TABLE k_str;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/107076
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes `hasAny`, `hasAll`, `has` and `indexOf` returning too few rows, or failing with `TOO_LARGE_STRING_SIZE`, when a `bloom_filter` index is queried with a `FixedString` constant. The index hashed the padded form of the constant while the function compares the unpadded one, so a matching granule was skipped.


### Description

A `bloom_filter` skip index silently returns too few rows for a plain `SELECT` when the constant is a
`FixedString`, and in four cases raises `Code: 131 TOO_LARGE_STRING_SIZE` on a query that succeeds
without the index. No unusual setting is required.

```sql
CREATE TABLE k (id UInt64, v Array(String), INDEX idx v TYPE bloom_filter GRANULARITY 1)
ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
INSERT INTO k VALUES (0,['V0']),(1,['V0\0']),(2,['X']);

SELECT count() FROM k WHERE hasAny(v, [toFixedString('V0',3)]);                        -- 0, wrong
SELECT count() FROM k WHERE hasAny(v, [toFixedString('V0',3)]) SETTINGS use_skip_indexes=0; -- 1
```

Root cause: `traverseTreeEquals` converts the constant with `convertFieldToType`, a `Field`-level
conversion that pads a `String` shorter than `FixedString(N)` and passes an oversized one through
unchanged. The array-search functions instead coerce with `castColumn`, and a `FixedString` to
`String` cast strips trailing zero bytes. The index therefore hashed a value the function never
compares, the hash missed, and the granule was pruned. The `TOO_LARGE_STRING_SIZE` cases are the same
cause: an oversized `Field` reaches `insert` inside index analysis.

This teaches the index to coerce the way the executing function coerces, so it stays exact rather than
declining. The mode comes from the raw element type, because the predicates genuinely compare
different representations: `has` and `indexOf` over a bare `String` element compare the padded bytes
and are left untouched, a `LowCardinality` element casts straight to the dictionary type, and
everything else routes through `getLeastSupertype`. Where a constant has no representation in the
element domain the index declines, so a runtime `TOO_LARGE_STRING_SIZE` stays reachable instead of
becoming a silent `0`. The shared `createColumnFromConstantArray` is deliberately unchanged: the
`has(<const array>, <indexed scalar>)` arm needs the padded form.

<details>
<summary>Validation</summary>

New test `04654_bloom_filter_array_fixed_string_constant`, 115 assertions: 83 compare the keyed answer
against an unindexed oracle so no expected value is baked into the reference, 23 assert the plan the
index produces, 8 pin the exact rows it selects, and 1 pins a count directly. Eight cover
multi-element constant arrays, where an element must survive both hops in its own position. Every
reference row answers `1`.

An 18-cell defect matrix over `Array(String)`, `Array(FixedString(N))`,
`Array(LowCardinality(String))` and `Array(LowCardinality(FixedString(N)))` times `has`, `indexOf`,
`hasAny`, `hasAll` times four constant widths is measured wrong before and correct after, on two
independent binaries. Both directions through the test runner: the fixed build passes, the
`origin/master` build fails.

Pruning is preserved, which is the point of coercing rather than declining: on a 64-granule fixture
there are zero pruning regressions, 46 cells are byte-identical, and all 18 fixed cells still prune to
`1/64` or `3/64`. Twenty-eight mutation arms each redden a disjoint predicted subset; three reddened
nothing and are documented rather than presented as passes. A 139-test bloom-filter and skip-index
sweep against two live servers shows zero regressions, and a tag-free 50-run randomized pass is clean.

</details>