### PR TITLE
Add docs team as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-
+/docs/ @ClickHouse/docs


### PR DESCRIPTION
Automatically request review from `@ClickHouse/docs` for pull requests that change files under `docs/` by adding the team to `.github/CODEOWNERS`. This uses GitHub's native path-based review routing and avoids label timing or a new workflow.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add `@ClickHouse/docs` as the code owner for documentation files.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.484` (included in `26.8` and later)
<!-- ch-version-info:end -->