### PR TITLE
Fix the ineffective TSAN suppression in `NonblockingBoundedQueue`

### DIFF
--- a/base/base/sanitizer_options.h
+++ b/base/base/sanitizer_options.h
@@ -56,6 +56,23 @@ const char * __tsan_default_options()
 {
     return "halt_on_error=1 abort_on_error=1 history_size=7 second_deadlock_stack=1 max_allocation_size_mb=32768 allocator_may_return_null=1";
 }
+const char * __tsan_default_suppressions()
+{
+    /// The release/acquire handoff on `slot.pos` orders every access to a slot payload, so the
+    /// reports these entries suppress are not real races (see the comment in
+    /// Common/NonblockingBoundedQueue.h). A function attribute cannot suppress them, because the
+    /// element type's implicitly generated move assignment is a separate, still-instrumented
+    /// function, and the attribute additionally prevents it from being inlined.
+    ///
+    /// Only `tryPush` is listed. Both Keeper queues have a single consumer thread, so two `tryPop`
+    /// calls never overlap and every reported pair therefore contains the `tryPush` write.
+    /// Patterns are matched against each frame's function, file and module name, so an unqualified
+    /// name would also match this header's file name and the unrelated asynchronous logging queue.
+    /// Keep them narrow: a `race:` entry also hides heap-use-after-free reports through the frame
+    /// it names.
+    return "race:^NonblockingBoundedQueue<DB::KeeperRequestForSession>::tryPush\n"
+           "race:^NonblockingBoundedQueue<DB::KeeperResponseForSession>::tryPush\n";
+}
 #endif
 
 #ifdef UNDEFINED_BEHAVIOR_SANITIZER

--- a/src/Common/NonblockingBoundedQueue.h
+++ b/src/Common/NonblockingBoundedQueue.h
@@ -90,10 +90,10 @@ public:
     /// here does not work: the reported access happens in the element type's move assignment,
     /// which is a separate function that stays instrumented.
     ///
-    /// The suppression lists only `tryPush`, because it names the only concurrent writer of a slot
-    /// payload for those queues: `tryPop` writes too (it moves out of `slot.value`), but each of
-    /// those queues has a single consumer thread, so two pops never overlap. Giving either of them
-    /// a second consumer makes a pop/pop report possible and requires a matching entry there.
+    /// The suppression lists only `tryPush`. `tryPop` writes the payload too (it moves out of
+    /// `slot.value`), but the `dequeue_pos` CAS gives one consumer sole ownership of a slot before
+    /// the move-out, so two pops never touch one payload concurrently, whatever the consumer count.
+    /// A `tryPop` entry would be dead, and would also hide heap-use-after-free through that frame.
     bool tryPush(T & value)
     {
         chassert(mask);

--- a/src/Common/NonblockingBoundedQueue.h
+++ b/src/Common/NonblockingBoundedQueue.h
@@ -85,12 +85,16 @@ public:
     /// TSAN very rarely reports a data race between the `slot.value` write in `tryPush` and the
     /// `slot.value` read in `tryPop`, even though the acquire/release operations on `slot.pos`
     /// make such a race impossible (the code is isomorphic to Vyukov's original implementation).
-    /// This appears to be a TSAN false positive, so we suppress it by excluding `tryPush` and
-    /// `tryPop` from instrumentation of plain memory accesses. Note that TSAN still instruments
-    /// atomic operations in such functions, so the happens-before edges through `slot.pos`
-    /// remain visible to it, and accesses to the contents of `T` in callers are still checked
-    /// correctly.
-    NO_SANITIZE_THREAD bool tryPush(T & value)
+    /// Those reports are suppressed at runtime, per instantiation, by
+    /// `__tsan_default_suppressions` in base/sanitizer_options.h. A `NO_SANITIZE_THREAD` attribute
+    /// here does not work: the reported access happens in the element type's move assignment,
+    /// which is a separate function that stays instrumented.
+    ///
+    /// The suppression lists only `tryPush`, because it names the only concurrent writer of a slot
+    /// payload for those queues: `tryPop` writes too (it moves out of `slot.value`), but each of
+    /// those queues has a single consumer thread, so two pops never overlap. Giving either of them
+    /// a second consumer makes a pop/pop report possible and requires a matching entry there.
+    bool tryPush(T & value)
     {
         chassert(mask);
         size_t pos = enqueue_pos.load(std::memory_order_relaxed);
@@ -122,7 +126,7 @@ public:
     }
 
     /// See the comment on `tryPush` about TSAN.
-    NO_SANITIZE_THREAD bool tryPop(T & out_value)
+    bool tryPop(T & out_value)
     {
         chassert(mask);
         size_t pos = dequeue_pos.load(std::memory_order_relaxed);


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/107083


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`Integration tests (amd_tsan, N/6)` fails in teardown with `Sanitizer assert found for instance zoo<N>`, from a TSAN data race between the `slot.value` write in `NonblockingBoundedQueue::tryPush` and the read in `tryPop`. #107083 added `NO_SANITIZE_THREAD` to both methods to silence it. That fix is merged and an ancestor of the failing branch, and the race still fires: 29 CIDB rows over 45 days across 27 pull requests, 4 of them after the merge.

The correctness analysis in #107083 is right: the release/acquire handoff on `slot.pos` orders every payload access, so the report is a false positive. Only the chosen mechanism is ineffective. `NO_SANITIZE_THREAD` covers just the annotated function's own body, and neither element type declares an `operator=`, so the racing access happens in the implicitly generated move assignment, a separate function that keeps `sanitize_thread`. The attribute also causes the frame split that defeats it, since an un-attributed callee cannot inline into an attributed caller.

This registers a `__tsan_default_suppressions` hook with two anchored patterns for the two Keeper instantiations, and removes the two attributes. Suppression applies to the report rather than to a function body, so one entry covers the whole nested move chain. Removing the attributes also restores plain-access instrumentation in the queue for all four element types, including the logging and `keeper-bench` queues that were being silenced for no reason, while atomics stay instrumented so the happens-before edges remain visible.

I have not identified the TSAN-internal path that produces the bogus shadow, so the suppression is scoped narrowly enough to drop if upstream fixes it. Only `tryPush` is listed, because `dequeue_pos` gives one consumer sole ownership of a slot before the move-out, so a concurrent pop cannot race on a payload. Each `race:` entry also hides heap-use-after-free through the named frame, which is why the set is kept at two.

<details>
<summary>Validation</summary>

A scratch harness drives the real queue header with the `slot.pos` handoff weakened to `relaxed`, linked against the real shipped hook, so a genuine race exists through the queue frames. It reproduces the CI signature exactly (`__tsan_memcpy` -> element `operator=` -> `tryPop`, read of size 8). The control arm omits the hook; every case below is confirmed non-vacuous there.

| case | control races | shipped races | matches | expected |
|---|---|---|---|---|
| `req_pushpop` (witnessed signature) | 8 | 0 | 4 | suppressed |
| `req_pushpush` | 14 | 0 | 4 | suppressed |
| `resp_pushpop` | 10 | 0 | 5 | suppressed |
| `resp_pushpush` | 20 | 0 | 5 | suppressed |
| `req_poppop` | 0 | 0 | 0 | no race possible |
| `log_pushpop`, `log_poppop` (logging queue) | 6 | 6 | 0 | reported |
| `bench_pushpop` (`keeper-bench`) | 6 | 6 | 0 | reported |
| `size`, `byref`, `unrelated` | 2 | 2 | 0 | reported |

Suppressed runs print `matched suppression` naming the shipped pattern, so the demangled-name match is empirical.

Why the attribute cannot work, measured on the real header. With it, `tryPush` and `tryPop` carry 0 plain-access hooks but each still calls the element move out of line, and that move body carries 11 hooks including `__tsan_memcpy`. Without it they carry 18 and 19 hooks and the move inlines; atomics are 8/8 in both arms.

On the real TSAN binary both patterns match exactly one live symbol each, so neither is a dead entry, and mangling only the suppression type makes the runtime fail to parse and die at startup, proving the list is consumed rather than merely present.

No test is added or changed, and no integration job applies setting randomization.

Witnessed failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107074&sha=e42b9c4c1c5cda0dc694c4150a195295639e4ca3&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%204%2F6%29
</details>