### PR TITLE
Docs: Remove duplicate BYOC sidebar entry

### DIFF
--- a/docs/products/cloud/navigation.json
+++ b/docs/products/cloud/navigation.json
@@ -258,8 +258,7 @@
                   "group": "Deployment modes",
                   "pages": [
                     "products/cloud/guides/infrastructure/deployment-options/clickhouse-private",
-                    "products/cloud/guides/infrastructure/deployment-options/clickhouse-government",
-                    "products/cloud/guides/infrastructure/deployment-options/byoc/overview"
+                    "products/cloud/guides/infrastructure/deployment-options/clickhouse-government"
                   ]
                 }
               ]


### PR DESCRIPTION
Remove the duplicate BYOC overview entry from **ClickHouse Cloud → Infrastructure → Deployment modes**. The same page remains available in its dedicated **Bring Your Own Cloud → Overview** section.

This is strictly a sidebar cleanup. It does not move, delete, or edit the overview page, and it does not change links, slugs, or redirects.

Root cause: consolidation commit https://github.com/ClickHouse/ClickHouse/commit/584a98097122bb6366ecb55444f4709b13ade90e from https://github.com/ClickHouse/ClickHouse/pull/109260 introduced separate Cloud and dedicated-BYOC overview entries. Cleanup commit https://github.com/ClickHouse/ClickHouse/commit/c2e063f994d884d283d76f4fbf4dc9cde644dfd1 from https://github.com/ClickHouse/ClickHouse/pull/112512 removed the stale duplicate page and pointed the dedicated BYOC entry at the surviving page, but left its original Cloud-sidebar entry in place.

Validated that both navigation files remain valid JSON, the overview remains present exactly once in the dedicated BYOC navigation, and the diff contains only `docs/products/cloud/navigation.json`.

Related public page:
https://clickhouse.com/docs/products/cloud/guides/infrastructure/deployment-options/byoc/overview

Related: https://github.com/ClickHouse/ClickHouse/pull/109260
Related: https://github.com/ClickHouse/ClickHouse/pull/112512

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable (documentation).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.486` (included in `26.8` and later)
<!-- ch-version-info:end -->