### PR TITLE
Add offline detector of intersecting MergeTree data parts

### DIFF
--- a/utils/mergetree-part-conflicts/README.md
+++ b/utils/mergetree-part-conflicts/README.md
@@ -1,0 +1,44 @@
+# mergetree-part-conflicts
+
+Offline detector of intersecting / covered `MergeTree` data parts, working from
+part-directory names alone -- no running server.
+
+A non-replicated `MergeTree` refuses to load a table when two active parts in
+the same partition partially overlap (`LOGICAL_ERROR`, "Part ... intersects
+previous/next part"). It throws on the **first** such pair, so a failed startup
+never shows the full set, the table is not attached (absent from `system.parts`),
+and there is no setting to load past it. This tool reconstructs the complete
+picture by replaying the server's own classification (`MergeTreePartInfo::contains`
+/ `isDisjoint`, as used by `PartLoadingTree`):
+
+* **partial overlap** -- neither part contains the other; this is what aborts load.
+* **covered layer** -- a survivor name-covers the part (normally a merge source);
+  reported because a re-issued block range can make a survivor *falsely* cover a
+  part that holds unique data.
+* **same part on more than one disk** -- an interrupted move left a stale copy.
+
+The tool is strictly read-only. It never moves, attaches, or deletes anything.
+
+## Usage
+
+```bash
+# Scan one or more data roots / disk mount points (auto-discovers table dirs by
+# their format_version.txt; handles Atomic store/<prefix>/<uuid>/ and Ordinary
+# data/<db>/<table>/ layouts, and tiered disks when several roots are given):
+./mergetree_part_conflicts.py /var/lib/clickhouse /mnt/ngx2/clickhouse
+
+# Feed part names directly (e.g. from clickhouse-disks list, find, or system.parts):
+find /var/lib/clickhouse/store -mindepth 3 -maxdepth 3 -type d -printf '%f\n' \
+    | ./mergetree_part_conflicts.py --stdin
+
+# Machine-readable output:
+./mergetree_part_conflicts.py --json /var/lib/clickhouse
+```
+
+Exit code is `2` when any partial overlap is found, `0` otherwise.
+
+## Tests
+
+```bash
+python3 -m unittest -v
+```

--- a/utils/mergetree-part-conflicts/README.md
+++ b/utils/mergetree-part-conflicts/README.md
@@ -1,7 +1,7 @@
 # mergetree-part-conflicts
 
 Offline detector of intersecting / covered `MergeTree` data parts, working from
-part-directory names alone -- no running server.
+the part names you feed it -- no running server.
 
 A non-replicated `MergeTree` refuses to load a table when two active parts in
 the same partition partially overlap (`LOGICAL_ERROR`, "Part ... intersects
@@ -15,24 +15,52 @@ picture by replaying the server's own classification (`MergeTreePartInfo::contai
 * **covered layer** -- a survivor name-covers the part (normally a merge source);
   reported because a re-issued block range can make a survivor *falsely* cover a
   part that holds unique data.
-* **same part on more than one disk** -- an interrupted move left a stale copy.
 
 The tool is strictly read-only. It never moves, attaches, or deletes anything.
 
-## Usage
+## Input
+
+Part names (or full part-directory paths), one per line on stdin -- typically the
+output of `find`, `clickhouse-disks list`, or a `system.parts` query. A line may
+be prefixed with `<table>\t` to group by table; otherwise the parent directory of
+a path is the table, and bare names all fall under one group. Blank lines, `#`
+comments, and non-part entries (e.g. `detached`) are ignored.
+
+## Examples
 
 ```bash
-# Scan one or more data roots / disk mount points (auto-discovers table dirs by
-# their format_version.txt; handles Atomic store/<prefix>/<uuid>/ and Ordinary
-# data/<db>/<table>/ layouts, and tiered disks when several roots are given):
-./mergetree_part_conflicts.py /var/lib/clickhouse /mnt/ngx2/clickhouse
+# Bare names for one table (find with -printf '%f'):
+find /var/lib/clickhouse/store/b11/b11e7407 -mindepth 1 -maxdepth 1 -type d -printf '%f\n' \
+    | ./mergetree_part_conflicts.py
 
-# Feed part names directly (e.g. from clickhouse-disks list, find, or system.parts):
-find /var/lib/clickhouse/store -mindepth 3 -maxdepth 3 -type d -printf '%f\n' \
-    | ./mergetree_part_conflicts.py --stdin
+# Full paths across a whole disk, all tables at once (parent dir groups by table):
+find /var/lib/clickhouse/store -mindepth 3 -maxdepth 3 -type d \
+    | ./mergetree_part_conflicts.py
+
+# From a running server (a healthy table, as a sanity check):
+clickhouse-client -q "SELECT database || '.' || table || '\t' || name FROM system.parts
+                      WHERE active FORMAT TSVRaw" \
+    | ./mergetree_part_conflicts.py
 
 # Machine-readable output:
-./mergetree_part_conflicts.py --json /var/lib/clickhouse
+find ... -type d | ./mergetree_part_conflicts.py --json
+
+# Legacy on-disk format (pre custom partitioning):
+find ... -type d | ./mergetree_part_conflicts.py --format-version 0
+
+# Emit a read-only recovery script (concrete `mv` needs full paths as input):
+find /var/lib/clickhouse/store/b11/b11e7407 -mindepth 1 -maxdepth 1 -type d \
+    | ./mergetree_part_conflicts.py --emit-detach-commands
+```
+
+Example report:
+
+```
+=== table: /var/lib/clickhouse/store/b11/b11e7407 ===
+  partition 20260722:
+    PARTIAL OVERLAP (aborts load): 20260722_98_20874_190  <->  20260722_2313_113249_107  [shared blocks 2313..20874]
+      suggested: keep the survivor, DETACH + REATTACH: 20260722_2313_113249_107
+    covered layers (load fine; audit for a false dominator): 20260722_98_20874_50
 ```
 
 Exit code is `2` when any partial overlap is found, `0` otherwise.

--- a/utils/mergetree-part-conflicts/README.md
+++ b/utils/mergetree-part-conflicts/README.md
@@ -45,9 +45,6 @@ clickhouse-client -q "SELECT database || '.' || table || '\t' || name FROM syste
 # Machine-readable output:
 find ... -type d | ./mergetree_part_conflicts.py --json
 
-# Legacy on-disk format (pre custom partitioning):
-find ... -type d | ./mergetree_part_conflicts.py --format-version 0
-
 # Emit a read-only recovery script (concrete `mv` needs full paths as input):
 find /var/lib/clickhouse/store/b11/b11e7407 -mindepth 1 -maxdepth 1 -type d \
     | ./mergetree_part_conflicts.py --emit-detach-commands

--- a/utils/mergetree-part-conflicts/README.md
+++ b/utils/mergetree-part-conflicts/README.md
@@ -37,6 +37,14 @@ find /var/lib/clickhouse/store/b11/b11e7407 -mindepth 1 -maxdepth 1 -type d -pri
 find /var/lib/clickhouse/store -mindepth 3 -maxdepth 3 -type d \
     | ./mergetree_part_conflicts.py
 
+# One table whose parts are spread across several disks (tiered storage). Label every
+# line with the same table name so parts from all disks are analysed together -- a part
+# on one disk can intersect a part on another. Full paths are kept, so
+# --emit-detach-commands moves each part into detached/ on its own disk.
+for disk in /var/lib/clickhouse /mnt/ngx2/clickhouse; do
+    find "$disk/store/b11/b11e7407" -mindepth 1 -maxdepth 1 -type d -printf 'nat\t%p\n'
+done | ./mergetree_part_conflicts.py
+
 # From a running server (a healthy table, as a sanity check):
 clickhouse-client -q "SELECT database || '.' || table || '\t' || name FROM system.parts
                       WHERE active FORMAT TSVRaw" \

--- a/utils/mergetree-part-conflicts/README.md
+++ b/utils/mergetree-part-conflicts/README.md
@@ -12,9 +12,12 @@ picture by replaying the server's own classification (`MergeTreePartInfo::contai
 / `isDisjoint`, as used by `PartLoadingTree`):
 
 * **partial overlap** -- neither part contains the other; this is what aborts load.
-* **covered layer** -- a survivor name-covers the part (normally a merge source);
-  reported because a re-issued block range can make a survivor *falsely* cover a
-  part that holds unique data.
+* **cross-disk covered** -- a covered part whose surviving coverer is on a *different*
+  disk. The table loads, but CH silently retires the covered part on startup; if that
+  coverage is false (a re-issued block range) it is silent data loss, so the tool
+  detaches it to preserve it. Needs part paths to tell the disk.
+* **covered layer** -- a covered part on the *same* disk as its coverer: an ordinary
+  not-yet-cleaned merge source, cleaned normally, left alone.
 
 The tool is strictly read-only. It never moves, attaches, or deletes anything.
 

--- a/utils/mergetree-part-conflicts/mergetree_part_conflicts.py
+++ b/utils/mergetree-part-conflicts/mergetree_part_conflicts.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Offline detector of intersecting / covered MergeTree data parts.
+
+A non-replicated ``MergeTree`` refuses to load a table when two active parts in
+the same partition partially overlap (``LOGICAL_ERROR`` "Part ... intersects
+previous/next part"), and it does so by throwing on the *first* such pair it
+meets, so a failed startup never reveals the full picture. This tool
+reconstructs the whole picture from the on-disk part-directory names alone -- no
+running server, no table attach -- by replaying the exact classification the
+server performs in ``PartLoadingTree`` / ``MergeTreePartInfo``:
+
+* ``contains``     -- one part supersedes another (a merge result over its
+                      sources); the covered one would load as ``Outdated``.
+* ``isDisjoint``   -- the parts share no block numbers; both stay active.
+* neither          -- a partial overlap; this is what aborts startup.
+
+It reports, per table and partition:
+
+* PARTIAL OVERLAP  -- the crash-causers you must resolve before the table loads.
+* covered layers   -- parts a survivor name-covers; they load fine, but a
+                      re-issued block range can make a survivor *falsely* cover
+                      a part with unique data, so they are worth auditing.
+* same part name on more than one disk -- an interrupted move left a stale copy.
+
+The tool is strictly read-only: it never moves, attaches, or deletes anything.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field, replace
+from typing import Dict, List, Optional, Tuple
+
+# Mirrors src/Storages/MergeTree/MergeTreePartInfo.h
+MAX_LEVEL = 999999999
+LEGACY_MAX_LEVEL = 4294967295  # numeric_limits<UInt32>::max()
+
+# Mirrors src/Storages/MergeTree/MergeTreeDataFormatVersion.h
+FORMAT_VERSION_OLD = 0  # YYYYMMDD_YYYYMMDD_min_max_level (pre custom partitioning)
+FORMAT_VERSION_CUSTOM = 1  # partitionid_min_max_level[_mutation]
+
+# New-format part name: <partition_id>_<min>_<max>_<level>[_<mutation>].
+# partition_id is taken non-greedily so the numeric tail binds to min/max/level
+# (+ optional mutation). This is exact for numeric, hash and "all" partition ids
+# -- i.e. every id that carries no underscore, which is the realistic case.
+_NEW_NAME_RE = re.compile(r"^(?P<pid>.+?)_(?P<min>\d+)_(?P<max>\d+)_(?P<level>\d+)(?:_(?P<mut>\d+))?$")
+# Old-format part name: <min_date>_<max_date>_<min>_<max>_<level>.
+_OLD_NAME_RE = re.compile(r"^(?P<dmin>\d{6,8})_(?P<dmax>\d{6,8})_(?P<min>\d+)_(?P<max>\d+)_(?P<level>\d+)$")
+
+# Directory entries under a table path that are never data parts.
+_SKIP_EXACT = {"detached", "moving", "format_version.txt", "tmp"}
+_SKIP_PREFIXES = (
+    "tmp_", "tmp-", "delete_tmp_", "deleting_", "broken_", "broken-on-start",
+    "attaching_", "ignored_", "inactive_", "covered-by-", "cloning_", "future_",
+)
+
+
+@dataclass(frozen=True)
+class PartInfo:
+    partition_id: str
+    min_block: int
+    max_block: int
+    level: int
+    mutation: int
+    name: str
+    # Full path to the part directory, when known (scan mode). Excluded from
+    # equality/hashing so two copies of the same part (e.g. on two disks) compare
+    # equal on identity of block coordinates.
+    path: Optional[str] = field(default=None, compare=False)
+
+    def contains(self, rhs: "PartInfo") -> bool:
+        """True if this part supersedes ``rhs`` (mirror of MergeTreePartInfo::contains)."""
+        strictly_contains_block_range = (
+            (self.min_block == rhs.min_block and self.max_block == rhs.max_block)
+            or self.level > rhs.level
+            or self.level == MAX_LEVEL
+            or self.level == LEGACY_MAX_LEVEL
+        )
+        return (
+            self.partition_id == rhs.partition_id
+            and self.min_block <= rhs.min_block
+            and self.max_block >= rhs.max_block
+            and self.level >= rhs.level
+            and self.mutation >= rhs.mutation
+            and strictly_contains_block_range
+        )
+
+    def is_disjoint(self, rhs: "PartInfo") -> bool:
+        """True if the parts share no block numbers (mirror of MergeTreePartInfo::isDisjoint)."""
+        return (
+            self.partition_id != rhs.partition_id
+            or self.min_block > rhs.max_block
+            or self.max_block < rhs.min_block
+        )
+
+
+def parse_part_name(name: str, format_version: int = FORMAT_VERSION_CUSTOM) -> Optional[PartInfo]:
+    """Parse a part-directory name into a PartInfo, or None if it is not a part.
+
+    ``format_version`` selects the on-disk naming scheme, exactly as the server
+    does from ``format_version.txt``.
+    """
+    if format_version == FORMAT_VERSION_OLD:
+        m = _OLD_NAME_RE.match(name)
+        if not m:
+            return None
+        return PartInfo(
+            partition_id=m.group("dmin")[:6],  # YYYYMM month partition
+            min_block=int(m.group("min")),
+            max_block=int(m.group("max")),
+            level=int(m.group("level")),
+            mutation=0,
+            name=name,
+        )
+
+    m = _NEW_NAME_RE.match(name)
+    if not m:
+        return None
+    return PartInfo(
+        partition_id=m.group("pid"),
+        min_block=int(m.group("min")),
+        max_block=int(m.group("max")),
+        level=int(m.group("level")),
+        mutation=int(m.group("mut")) if m.group("mut") is not None else 0,
+        name=name,
+    )
+
+
+@dataclass
+class Conflict:
+    """A partial overlap between two parts that would abort table load."""
+
+    a: PartInfo
+    b: PartInfo
+
+    def overlap(self) -> Tuple[int, int]:
+        return (max(self.a.min_block, self.b.min_block), min(self.a.max_block, self.b.max_block))
+
+
+@dataclass
+class PartitionReport:
+    partition_id: str
+    maximal: List[PartInfo] = field(default_factory=list)  # would-be-active parts
+    covered: List[PartInfo] = field(default_factory=list)  # superseded layers
+    conflicts: List[Conflict] = field(default_factory=list)
+
+    @property
+    def has_conflicts(self) -> bool:
+        return bool(self.conflicts)
+
+
+def classify_partition(parts: List[PartInfo]) -> PartitionReport:
+    """Split one partition's parts into covering (maximal), covered, and conflicting.
+
+    A part is *covered* when some other part ``contains`` it; the rest are
+    *maximal*. Two maximal parts that are neither disjoint nor in a containment
+    relation are a partial overlap -- the load-aborting conflict.
+    """
+    report = PartitionReport(partition_id=parts[0].partition_id if parts else "")
+
+    for p in parts:
+        covered_by_other = any(q is not p and q.contains(p) for q in parts)
+        if covered_by_other:
+            report.covered.append(p)
+        else:
+            report.maximal.append(p)
+
+    ordered = sorted(report.maximal, key=lambda p: (p.min_block, p.max_block, p.level))
+    for i in range(len(ordered)):
+        for j in range(i + 1, len(ordered)):
+            a, b = ordered[i], ordered[j]
+            if a.max_block < b.min_block:  # sorted by min_block: nothing further can overlap a
+                break
+            if not a.is_disjoint(b) and not a.contains(b) and not b.contains(a):
+                report.conflicts.append(Conflict(a, b))
+
+    report.maximal = ordered
+    report.covered.sort(key=lambda p: (p.min_block, p.max_block, p.level))
+    return report
+
+
+def classify(parts: List[PartInfo]) -> Dict[str, PartitionReport]:
+    by_partition: Dict[str, List[PartInfo]] = {}
+    for p in parts:
+        by_partition.setdefault(p.partition_id, []).append(p)
+    return {pid: classify_partition(ps) for pid, ps in by_partition.items()}
+
+
+# --------------------------------------------------------------------------- #
+# Filesystem scanning
+# --------------------------------------------------------------------------- #
+
+def _is_part_dir_name(name: str) -> bool:
+    if name in _SKIP_EXACT:
+        return False
+    return not any(name.startswith(pfx) for pfx in _SKIP_PREFIXES)
+
+
+def read_format_version(table_dir: str) -> int:
+    path = os.path.join(table_dir, "format_version.txt")
+    try:
+        with open(path, "r", encoding="ascii") as f:
+            return int(f.read().strip() or FORMAT_VERSION_CUSTOM)
+    except (OSError, ValueError):
+        return FORMAT_VERSION_CUSTOM
+
+
+def find_table_dirs(root: str) -> List[str]:
+    """Return every directory under ``root`` that looks like a MergeTree table
+    data dir (it contains ``format_version.txt``). Works for both Atomic
+    (``store/<prefix>/<uuid>/``) and Ordinary (``data/<db>/<table>/``) layouts.
+    """
+    table_dirs: List[str] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        if "format_version.txt" in filenames:
+            table_dirs.append(dirpath)
+            dirnames[:] = []  # do not descend into a table's own part dirs
+    return table_dirs
+
+
+def scan_table_dir(table_dir: str, format_version: Optional[int] = None) -> Tuple[List[PartInfo], List[str]]:
+    """List the parts of a single table dir. Returns (parts, skipped_entry_names)."""
+    fv = read_format_version(table_dir) if format_version is None else format_version
+    parts: List[PartInfo] = []
+    skipped: List[str] = []
+    try:
+        entries = sorted(os.listdir(table_dir))
+    except OSError as e:
+        print(f"warning: cannot list {table_dir}: {e}", file=sys.stderr)
+        return parts, skipped
+    for entry in entries:
+        full = os.path.join(table_dir, entry)
+        if not os.path.isdir(full) or not _is_part_dir_name(entry):
+            continue
+        info = parse_part_name(entry, fv)
+        if info is None:
+            skipped.append(entry)
+            continue
+        parts.append(replace(info, path=full))
+    return parts, skipped
+
+
+def read_names_from_stream(stream) -> Dict[str, List[str]]:
+    """Read '<table>\\t<part_name>' or bare '<part_name>' lines. Returns table -> names."""
+    tables: Dict[str, List[str]] = {}
+    for raw in stream:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "\t" in line:
+            table, name = line.split("\t", 1)
+        else:
+            table, name = "(stdin)", line
+        tables.setdefault(table, []).append(name.strip())
+    return tables
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+
+def suggest_keep(cluster: List[PartInfo]) -> PartInfo:
+    """Pick the part to keep active in an overlapping cluster: highest level,
+    then widest block range, then lexicographically smallest name (stable)."""
+    return max(cluster, key=lambda p: (p.level, p.max_block - p.min_block, p.name))
+
+
+def build_report(tables: Dict[str, List[PartInfo]], cross_disk_dups: Dict[str, List[str]]) -> dict:
+    out = {"tables": {}, "has_conflicts": False}
+    for table, parts in sorted(tables.items()):
+        per_partition = classify(parts)
+        table_entry = {"partitions": {}, "cross_disk_duplicates": cross_disk_dups.get(table, [])}
+        for pid, rep in sorted(per_partition.items()):
+            if not rep.conflicts and not rep.covered:
+                continue
+            conflict_parts = {p.name for c in rep.conflicts for p in (c.a, c.b)}
+            detach: List[str] = []
+            if conflict_parts:
+                cluster = [p for p in rep.maximal if p.name in conflict_parts]
+                keep = suggest_keep(cluster)
+                detach = sorted(n for n in conflict_parts if n != keep.name)
+            table_entry["partitions"][pid] = {
+                "conflicts": [
+                    {"a": c.a.name, "b": c.b.name, "overlap_blocks": list(c.overlap())}
+                    for c in rep.conflicts
+                ],
+                "covered_layers": [p.name for p in rep.covered],
+                "suggested_detach": detach,
+            }
+            if rep.conflicts:
+                out["has_conflicts"] = True
+        if table_entry["partitions"] or table_entry["cross_disk_duplicates"]:
+            out["tables"][table] = table_entry
+    return out
+
+
+def print_report(report: dict) -> None:
+    if not report["tables"]:
+        print("No intersecting or covered parts found.")
+        return
+    for table, entry in report["tables"].items():
+        print(f"\n=== table: {table} ===")
+        for dup in entry["cross_disk_duplicates"]:
+            print(f"  ! same part on more than one disk (interrupted move?): {dup}")
+        for pid, pinfo in entry["partitions"].items():
+            print(f"  partition {pid}:")
+            for c in pinfo["conflicts"]:
+                lo, hi = c["overlap_blocks"]
+                print(f"    PARTIAL OVERLAP (aborts load): {c['a']}  <->  {c['b']}  "
+                      f"[shared blocks {lo}..{hi}]")
+            if pinfo["suggested_detach"]:
+                print(f"      suggested: keep the survivor, DETACH + REATTACH: "
+                      f"{', '.join(pinfo['suggested_detach'])}")
+            if pinfo["covered_layers"]:
+                print(f"    covered layers (load fine; audit for a false dominator): "
+                      f"{', '.join(pinfo['covered_layers'])}")
+
+
+def _sh_quote(s: str) -> str:
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+def emit_detach_commands(tables: Dict[str, List["PartInfo"]]) -> List[str]:
+    """Produce a shell script that moves each suggested-detach part into its
+    table's detached/ dir. Read-only: the lines are printed, never executed.
+
+    Concrete `mv` lines are produced only for parts scanned from disk (path
+    known). For parts fed by name (stdin) the path is unknown and a placeholder
+    comment is emitted instead.
+    """
+    lines = [
+        "#!/bin/sh",
+        "# READ-ONLY SUGGESTION -- review every line before running; this tool does not execute it.",
+        "# Move the intersecting parts aside so the table can load, WITHOUT losing them.",
+        "# The server must not have these tables loaded while you move files (they are the",
+        "# tables that failed to attach). After moving, reload them (DETACH/ATTACH DATABASE",
+        "# or a restart), then ATTACH PART each moved part to bring its rows back with a",
+        "# fresh block number, then reconcile duplicates in the overlapping ranges.",
+        "set -eu",
+    ]
+    reattach: List[str] = []
+    any_cmd = False
+    for table, parts in sorted(tables.items()):
+        per_partition = classify(parts)
+        header_done = False
+        for pid, rep in sorted(per_partition.items()):
+            if not rep.conflicts:
+                continue
+            conflict_names = {p.name for c in rep.conflicts for p in (c.a, c.b)}
+            cluster = [p for p in rep.maximal if p.name in conflict_names]
+            keep = suggest_keep(cluster)
+            for p in sorted((x for x in cluster if x.name != keep.name), key=lambda x: x.name):
+                if not header_done:
+                    lines.append(f"\n# table: {table}")
+                    header_done = True
+                if p.path:
+                    table_dir = os.path.dirname(p.path)
+                    detached_dir = os.path.join(table_dir, "detached")
+                    dest = os.path.join(detached_dir, p.name)
+                    lines.append(f"#   partition {pid}: detach {p.name} (keep {keep.name})")
+                    lines.append(f"mkdir -p {_sh_quote(detached_dir)}")
+                    lines.append(f"mv -- {_sh_quote(p.path)} {_sh_quote(dest)}")
+                    any_cmd = True
+                else:
+                    lines.append(f"#   partition {pid}: detach {p.name} (keep {keep.name}) "
+                                 f"-- path unknown; run in scan mode to get an mv command")
+                reattach.append(f"#   ALTER TABLE <db>.<table> ATTACH PART '{p.name}';")
+
+    if reattach:
+        lines.append("\n# After the tables are reloaded, bring the moved parts back:")
+        lines.extend(reattach)
+    if not any_cmd and not reattach:
+        lines.append("\n# No intersecting parts to detach.")
+    return lines
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("paths", nargs="*", help="data roots / disk mount points to scan")
+    parser.add_argument("--stdin", action="store_true",
+                        help="read part names from stdin ('<table>\\t<name>' or bare '<name>')")
+    parser.add_argument("--format-version", type=int, choices=[0, 1], default=None,
+                        help="override on-disk format version (default: auto from format_version.txt)")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    parser.add_argument("--emit-detach-commands", action="store_true",
+                        help="print a read-only shell script that moves the suggested parts "
+                             "into detached/ (never executed)")
+    args = parser.parse_args(argv)
+
+    tables: Dict[str, List[PartInfo]] = {}
+    # (table, name) -> set of source roots, to catch the same part on two disks.
+    seen: Dict[Tuple[str, str], set] = {}
+    cross_disk_dups: Dict[str, List[str]] = {}
+
+    if args.stdin:
+        fv = FORMAT_VERSION_CUSTOM if args.format_version is None else args.format_version
+        for table, names in read_names_from_stream(sys.stdin).items():
+            for name in names:
+                info = parse_part_name(name, fv)
+                if info is not None:
+                    tables.setdefault(table, []).append(info)
+                else:
+                    print(f"warning: not a part name, skipped: {name}", file=sys.stderr)
+
+    for root in args.paths:
+        for table_dir in find_table_dirs(root):
+            table = os.path.relpath(table_dir, root)
+            parts, _ = scan_table_dir(table_dir, args.format_version)
+            for info in parts:
+                key = (table, info.name)
+                seen.setdefault(key, set()).add(root)
+                if len(seen[key]) == 2:  # first time it becomes a duplicate
+                    cross_disk_dups.setdefault(table, []).append(info.name)
+                else:
+                    tables.setdefault(table, []).append(info)
+
+    report = build_report(tables, cross_disk_dups)
+
+    if args.emit_detach_commands:
+        print("\n".join(emit_detach_commands(tables)))
+    elif args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print_report(report)
+
+    return 2 if report["has_conflicts"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/mergetree-part-conflicts/mergetree_part_conflicts.py
+++ b/utils/mergetree-part-conflicts/mergetree_part_conflicts.py
@@ -18,10 +18,14 @@ You supply the list of parts yourself (from ``find``, ``clickhouse-disks
 list``, ``system.parts``, etc.), one per line on stdin. It reports, per table
 and partition:
 
-* PARTIAL OVERLAP  -- the crash-causers you must resolve before the table loads.
-* covered layers   -- parts a survivor name-covers; they load fine, but a
-                      re-issued block range can make a survivor *falsely* cover
-                      a part with unique data, so they are worth auditing.
+* PARTIAL OVERLAP      -- the crash-causers you must resolve before the table loads.
+* CROSS-DISK COVERED   -- a covered part whose surviving coverer is on a DIFFERENT
+                          disk. The table loads, but CH silently retires the covered
+                          part on startup; if the coverage is false (a re-issued
+                          block range) that is silent data loss, so it is detached to
+                          preserve it. (Needs part paths to tell the disk.)
+* covered layers       -- a covered part on the SAME disk as its coverer: an ordinary
+                          not-yet-cleaned merge source, left alone.
 
 The tool is strictly read-only: it never moves, attaches, or deletes anything.
 """
@@ -211,30 +215,100 @@ def suggest_keep(cluster: List[PartInfo]) -> PartInfo:
     return max(cluster, key=lambda p: (p.level, p.max_block - p.min_block, p.name))
 
 
+def _group_by_partition(parts: List[PartInfo]) -> Dict[str, List[PartInfo]]:
+    groups: Dict[str, List[PartInfo]] = {}
+    for p in parts:
+        groups.setdefault(p.partition_id, []).append(p)
+    return groups
+
+
+def _table_dir(p: PartInfo) -> Optional[str]:
+    """The part's containing (table-on-a-disk) directory, or None without a path.
+    Two parts of one table on different disks have different table dirs."""
+    return os.path.dirname(p.path.rstrip("/")) if p.path else None
+
+
+# Reasons a part ends up in the detach set.
+DETACH_OVERLAP = "overlap"                       # partial overlap -- aborts load
+DETACH_XDISK_COVERED = "cross-disk-covered"      # covered by a part on another disk
+
+
+def compute_detach(parts: List[PartInfo]) -> List[Tuple[PartInfo, str]]:
+    """Parts (of one partition) to move to detached/, each with the reason.
+
+    Two independent reasons:
+
+    (a) OVERLAP -- for each partial overlap, drop the lower part so the table can
+        load. Done as a fixpoint, because detaching a covering part exposes the
+        parts it covered; if such a part then overlaps a survivor it is dropped in
+        a later round.
+
+    (b) CROSS-DISK-COVERED -- among what survives, a covered part whose surviving
+        coverer sits on a *different disk* is moved aside too. CH would otherwise
+        retire it as Outdated and clean it on startup, and if that coverage is
+        false (a re-issued block range) that is silent data loss. Same-disk covered
+        parts are ordinary not-yet-cleaned merge sources and are left alone. This
+        needs the part path to know the disk; bare-name parts are skipped here.
+    """
+    by_name = {p.name: p for p in parts}
+    result: List[Tuple[PartInfo, str]] = []
+    seen = set()
+
+    # (a) resolve partial overlaps
+    remaining = list(parts)
+    while True:
+        rep = classify_partition(remaining)
+        if not rep.conflicts:
+            break
+        losers = set()
+        for c in rep.conflicts:
+            keep = suggest_keep([c.a, c.b])
+            loser = c.a if keep.name == c.b.name else c.b
+            losers.add(loser.name)
+        for name in sorted(losers):
+            if name not in seen:
+                seen.add(name)
+                result.append((by_name[name], DETACH_OVERLAP))
+        remaining = [p for p in remaining if p.name not in losers]
+
+    # (b) cross-disk covered parts among the survivors
+    rep = classify_partition(remaining)
+    for c in sorted(rep.covered, key=lambda p: (p.min_block, p.max_block, p.level, p.name)):
+        coverer = next((s for s in rep.maximal if s.contains(c)), None)
+        if coverer is None or c.name in seen:
+            continue
+        if _table_dir(c) is not None and _table_dir(coverer) is not None \
+                and _table_dir(c) != _table_dir(coverer):
+            seen.add(c.name)
+            result.append((c, DETACH_XDISK_COVERED))
+    return result
+
+
 def build_report(tables: Dict[str, List[PartInfo]]) -> dict:
-    out: dict = {"tables": {}, "has_conflicts": False}
+    out: dict = {"tables": {}, "has_conflicts": False, "has_detach": False}
     for table, parts in sorted(tables.items()):
-        per_partition = classify(parts)
         partitions: dict = {}
-        for pid, rep in sorted(per_partition.items()):
+        for pid, ps in sorted(_group_by_partition(parts).items()):
+            rep = classify_partition(ps)
             if not rep.conflicts and not rep.covered:
                 continue
-            conflict_parts = {p.name for c in rep.conflicts for p in (c.a, c.b)}
-            detach: List[str] = []
-            if conflict_parts:
-                cluster = [p for p in rep.maximal if p.name in conflict_parts]
-                keep = suggest_keep(cluster)
-                detach = sorted(n for n in conflict_parts if n != keep.name)
+            detach = compute_detach(ps)
+            detach_set = {p.name for p, _ in detach}
             partitions[pid] = {
                 "conflicts": [
                     {"a": c.a.name, "b": c.b.name, "overlap_blocks": list(c.overlap())}
                     for c in rep.conflicts
                 ],
-                "covered_layers": [p.name for p in rep.covered],
-                "suggested_detach": detach,
+                "suggested_detach": sorted(p.name for p, _ in detach),
+                "cross_disk_covered": sorted(p.name for p, r in detach if r == DETACH_XDISK_COVERED),
+                # covered layers that are NOT being detached are benign same-disk
+                # merge sources that load as Outdated and get cleaned normally.
+                "covered_layers": [p.name for p in rep.covered if p.name not in detach_set],
             }
             if rep.conflicts:
                 out["has_conflicts"] = True
+            if detach:
+                out["has_detach"] = True
         if partitions:
             out["tables"][table] = {"partitions": partitions}
     return out
@@ -252,11 +326,14 @@ def print_report(report: dict) -> None:
                 lo, hi = c["overlap_blocks"]
                 print(f"    PARTIAL OVERLAP (aborts load): {c['a']}  <->  {c['b']}  "
                       f"[shared blocks {lo}..{hi}]")
+            if pinfo["cross_disk_covered"]:
+                print(f"    CROSS-DISK COVERED (CH would silently remove on start): "
+                      f"{', '.join(pinfo['cross_disk_covered'])}")
             if pinfo["suggested_detach"]:
-                print(f"      suggested: keep the survivor, DETACH + REATTACH: "
+                print(f"      suggested: move to detached/ before reload: "
                       f"{', '.join(pinfo['suggested_detach'])}")
             if pinfo["covered_layers"]:
-                print(f"    covered layers (load fine; audit for a false dominator): "
+                print(f"    same-disk covered layers (load fine, cleaned normally): "
                       f"{', '.join(pinfo['covered_layers'])}")
 
 
@@ -274,23 +351,18 @@ def emit_detach_commands(tables: Dict[str, List[PartInfo]]) -> List[str]:
     lines = [
         "#!/bin/sh",
         "# READ-ONLY SUGGESTION -- review every line before running; this tool does not execute it.",
-        "# Move the intersecting parts aside so the table can load, WITHOUT losing them.",
-        "# The server must not have these tables loaded while you move files (they are the",
-        "# tables that failed to attach). After moving, reload the tables, then re-attach each",
-        "# moved part to bring its rows back and reconcile duplicates in the overlapping ranges.",
+        "# Move the flagged parts aside so the table loads cleanly (overlaps) AND so the server",
+        "# does not silently drop cross-disk-covered parts on startup -- WITHOUT losing data.",
+        "# Do this with the server stopped, or with the affected tables not loaded. After moving,",
+        "# reload the tables (DETACH/ATTACH DATABASE, or restart), then decide which moved parts",
+        "# to re-attach and reconcile any duplicates in overlapping ranges.",
         "set -eu",
     ]
     any_line = False
     for table, parts in sorted(tables.items()):
-        per_partition = classify(parts)
         header_done = False
-        for pid, rep in sorted(per_partition.items()):
-            if not rep.conflicts:
-                continue
-            conflict_names = {p.name for c in rep.conflicts for p in (c.a, c.b)}
-            cluster = [p for p in rep.maximal if p.name in conflict_names]
-            keep = suggest_keep(cluster)
-            for p in sorted((x for x in cluster if x.name != keep.name), key=lambda x: x.name):
+        for pid, ps in sorted(_group_by_partition(parts).items()):
+            for p, reason in compute_detach(ps):
                 if not header_done:
                     lines.append(f"\n# table: {table}")
                     header_done = True
@@ -299,11 +371,11 @@ def emit_detach_commands(tables: Dict[str, List[PartInfo]]) -> List[str]:
                     table_dir = os.path.dirname(p.path.rstrip("/"))
                     detached_dir = os.path.join(table_dir, "detached")
                     dest = os.path.join(detached_dir, p.name)
-                    lines.append(f"#   partition {pid}: detach {p.name} (keep {keep.name})")
+                    lines.append(f"#   partition {pid}: detach {p.name} ({reason})")
                     lines.append(f"mkdir -p {_sh_quote(detached_dir)}")
                     lines.append(f"mv -- {_sh_quote(p.path)} {_sh_quote(dest)}")
                 else:
-                    lines.append(f"#   partition {pid}: detach {p.name} (keep {keep.name}) "
+                    lines.append(f"#   partition {pid}: detach {p.name} ({reason}) "
                                  f"-- path unknown; feed the part's full path to get an mv command")
 
     if not any_line:
@@ -333,7 +405,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     else:
         print_report(report)
 
-    return 2 if report["has_conflicts"] else 0
+    return 2 if report["has_detach"] else 0
 
 
 if __name__ == "__main__":

--- a/utils/mergetree-part-conflicts/mergetree_part_conflicts.py
+++ b/utils/mergetree-part-conflicts/mergetree_part_conflicts.py
@@ -5,22 +5,23 @@ A non-replicated ``MergeTree`` refuses to load a table when two active parts in
 the same partition partially overlap (``LOGICAL_ERROR`` "Part ... intersects
 previous/next part"), and it does so by throwing on the *first* such pair it
 meets, so a failed startup never reveals the full picture. This tool
-reconstructs the whole picture from the on-disk part-directory names alone -- no
-running server, no table attach -- by replaying the exact classification the
-server performs in ``PartLoadingTree`` / ``MergeTreePartInfo``:
+reconstructs the whole picture from the part names you feed it -- no running
+server, no table attach -- by replaying the exact classification the server
+performs in ``PartLoadingTree`` / ``MergeTreePartInfo``:
 
 * ``contains``     -- one part supersedes another (a merge result over its
                       sources); the covered one would load as ``Outdated``.
 * ``isDisjoint``   -- the parts share no block numbers; both stay active.
 * neither          -- a partial overlap; this is what aborts startup.
 
-It reports, per table and partition:
+You supply the list of parts yourself (from ``find``, ``clickhouse-disks
+list``, ``system.parts``, etc.), one per line on stdin. It reports, per table
+and partition:
 
 * PARTIAL OVERLAP  -- the crash-causers you must resolve before the table loads.
 * covered layers   -- parts a survivor name-covers; they load fine, but a
                       re-issued block range can make a survivor *falsely* cover
                       a part with unique data, so they are worth auditing.
-* same part name on more than one disk -- an interrupted move left a stale copy.
 
 The tool is strictly read-only: it never moves, attaches, or deletes anything.
 """
@@ -49,13 +50,6 @@ _NEW_NAME_RE = re.compile(r"^(?P<pid>.+?)_(?P<min>\d+)_(?P<max>\d+)_(?P<level>\d
 # Old-format part name: <min_date>_<max_date>_<min>_<max>_<level>.
 _OLD_NAME_RE = re.compile(r"^(?P<dmin>\d{6,8})_(?P<dmax>\d{6,8})_(?P<min>\d+)_(?P<max>\d+)_(?P<level>\d+)$")
 
-# Directory entries under a table path that are never data parts.
-_SKIP_EXACT = {"detached", "moving", "format_version.txt", "tmp"}
-_SKIP_PREFIXES = (
-    "tmp_", "tmp-", "delete_tmp_", "deleting_", "broken_", "broken-on-start",
-    "attaching_", "ignored_", "inactive_", "covered-by-", "cloning_", "future_",
-)
-
 
 @dataclass(frozen=True)
 class PartInfo:
@@ -65,9 +59,8 @@ class PartInfo:
     level: int
     mutation: int
     name: str
-    # Full path to the part directory, when known (scan mode). Excluded from
-    # equality/hashing so two copies of the same part (e.g. on two disks) compare
-    # equal on identity of block coordinates.
+    # Full path to the part directory, when the input line carried one. Excluded
+    # from equality/hashing so it does not affect classification.
     path: Optional[str] = field(default=None, compare=False)
 
     def contains(self, rhs: "PartInfo") -> bool:
@@ -99,8 +92,8 @@ class PartInfo:
 def parse_part_name(name: str, format_version: int = FORMAT_VERSION_CUSTOM) -> Optional[PartInfo]:
     """Parse a part-directory name into a PartInfo, or None if it is not a part.
 
-    ``format_version`` selects the on-disk naming scheme, exactly as the server
-    does from ``format_version.txt``.
+    ``format_version`` selects the on-disk naming scheme (0 = legacy, 1 = custom
+    partitioning), exactly as the server reads it from ``format_version.txt``.
     """
     if format_version == FORMAT_VERSION_OLD:
         m = _OLD_NAME_RE.match(name)
@@ -189,71 +182,44 @@ def classify(parts: List[PartInfo]) -> Dict[str, PartitionReport]:
 
 
 # --------------------------------------------------------------------------- #
-# Filesystem scanning
+# Input
 # --------------------------------------------------------------------------- #
 
-def _is_part_dir_name(name: str) -> bool:
-    if name in _SKIP_EXACT:
-        return False
-    return not any(name.startswith(pfx) for pfx in _SKIP_PREFIXES)
+def read_parts_from_stream(stream, format_version: int) -> Dict[str, List[PartInfo]]:
+    """Read parts from a plain-text stream (e.g. the output of ``find``), one per
+    line, grouped by table.
 
+    Each non-empty, non-``#`` line is::
 
-def read_format_version(table_dir: str) -> int:
-    path = os.path.join(table_dir, "format_version.txt")
-    try:
-        with open(path, "r", encoding="ascii") as f:
-            return int(f.read().strip() or FORMAT_VERSION_CUSTOM)
-    except (OSError, ValueError):
-        return FORMAT_VERSION_CUSTOM
+        [<table>\\t]<token>
 
-
-def find_table_dirs(root: str) -> List[str]:
-    """Return every directory under ``root`` that looks like a MergeTree table
-    data dir (it contains ``format_version.txt``). Works for both Atomic
-    (``store/<prefix>/<uuid>/``) and Ordinary (``data/<db>/<table>/``) layouts.
+    ``<token>`` is a part name (``20260722_98_20874_190``) or a full path to the
+    part directory. When a path is given, its basename is the part name, the path
+    is remembered (so ``--emit-detach-commands`` can produce a concrete ``mv``),
+    and the parent directory is the default table. Lines that are not part names
+    are skipped with a warning.
     """
-    table_dirs: List[str] = []
-    for dirpath, dirnames, filenames in os.walk(root):
-        if "format_version.txt" in filenames:
-            table_dirs.append(dirpath)
-            dirnames[:] = []  # do not descend into a table's own part dirs
-    return table_dirs
-
-
-def scan_table_dir(table_dir: str, format_version: Optional[int] = None) -> Tuple[List[PartInfo], List[str]]:
-    """List the parts of a single table dir. Returns (parts, skipped_entry_names)."""
-    fv = read_format_version(table_dir) if format_version is None else format_version
-    parts: List[PartInfo] = []
-    skipped: List[str] = []
-    try:
-        entries = sorted(os.listdir(table_dir))
-    except OSError as e:
-        print(f"warning: cannot list {table_dir}: {e}", file=sys.stderr)
-        return parts, skipped
-    for entry in entries:
-        full = os.path.join(table_dir, entry)
-        if not os.path.isdir(full) or not _is_part_dir_name(entry):
-            continue
-        info = parse_part_name(entry, fv)
-        if info is None:
-            skipped.append(entry)
-            continue
-        parts.append(replace(info, path=full))
-    return parts, skipped
-
-
-def read_names_from_stream(stream) -> Dict[str, List[str]]:
-    """Read '<table>\\t<part_name>' or bare '<part_name>' lines. Returns table -> names."""
-    tables: Dict[str, List[str]] = {}
+    tables: Dict[str, List[PartInfo]] = {}
     for raw in stream:
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
+        table: Optional[str] = None
+        token = line
         if "\t" in line:
-            table, name = line.split("\t", 1)
-        else:
-            table, name = "(stdin)", line
-        tables.setdefault(table, []).append(name.strip())
+            table, token = line.split("\t", 1)
+            table, token = table.strip(), token.strip()
+        path = token if "/" in token else None
+        name = os.path.basename(token.rstrip("/")) if path else token
+        if table is None:
+            table = os.path.dirname(path.rstrip("/")) if path else "(input)"
+        info = parse_part_name(name, format_version)
+        if info is None:
+            print(f"warning: not a part name, skipped: {name}", file=sys.stderr)
+            continue
+        if path:
+            info = replace(info, path=path)
+        tables.setdefault(table, []).append(info)
     return tables
 
 
@@ -267,11 +233,11 @@ def suggest_keep(cluster: List[PartInfo]) -> PartInfo:
     return max(cluster, key=lambda p: (p.level, p.max_block - p.min_block, p.name))
 
 
-def build_report(tables: Dict[str, List[PartInfo]], cross_disk_dups: Dict[str, List[str]]) -> dict:
-    out = {"tables": {}, "has_conflicts": False}
+def build_report(tables: Dict[str, List[PartInfo]]) -> dict:
+    out: dict = {"tables": {}, "has_conflicts": False}
     for table, parts in sorted(tables.items()):
         per_partition = classify(parts)
-        table_entry = {"partitions": {}, "cross_disk_duplicates": cross_disk_dups.get(table, [])}
+        partitions: dict = {}
         for pid, rep in sorted(per_partition.items()):
             if not rep.conflicts and not rep.covered:
                 continue
@@ -281,7 +247,7 @@ def build_report(tables: Dict[str, List[PartInfo]], cross_disk_dups: Dict[str, L
                 cluster = [p for p in rep.maximal if p.name in conflict_parts]
                 keep = suggest_keep(cluster)
                 detach = sorted(n for n in conflict_parts if n != keep.name)
-            table_entry["partitions"][pid] = {
+            partitions[pid] = {
                 "conflicts": [
                     {"a": c.a.name, "b": c.b.name, "overlap_blocks": list(c.overlap())}
                     for c in rep.conflicts
@@ -291,8 +257,8 @@ def build_report(tables: Dict[str, List[PartInfo]], cross_disk_dups: Dict[str, L
             }
             if rep.conflicts:
                 out["has_conflicts"] = True
-        if table_entry["partitions"] or table_entry["cross_disk_duplicates"]:
-            out["tables"][table] = table_entry
+        if partitions:
+            out["tables"][table] = {"partitions": partitions}
     return out
 
 
@@ -302,8 +268,6 @@ def print_report(report: dict) -> None:
         return
     for table, entry in report["tables"].items():
         print(f"\n=== table: {table} ===")
-        for dup in entry["cross_disk_duplicates"]:
-            print(f"  ! same part on more than one disk (interrupted move?): {dup}")
         for pid, pinfo in entry["partitions"].items():
             print(f"  partition {pid}:")
             for c in pinfo["conflicts"]:
@@ -322,13 +286,12 @@ def _sh_quote(s: str) -> str:
     return "'" + s.replace("'", "'\\''") + "'"
 
 
-def emit_detach_commands(tables: Dict[str, List["PartInfo"]]) -> List[str]:
+def emit_detach_commands(tables: Dict[str, List[PartInfo]]) -> List[str]:
     """Produce a shell script that moves each suggested-detach part into its
     table's detached/ dir. Read-only: the lines are printed, never executed.
 
-    Concrete `mv` lines are produced only for parts scanned from disk (path
-    known). For parts fed by name (stdin) the path is unknown and a placeholder
-    comment is emitted instead.
+    Concrete ``mv`` lines are produced only for parts fed as a path; for parts
+    fed by bare name the path is unknown and a placeholder comment is emitted.
     """
     lines = [
         "#!/bin/sh",
@@ -356,7 +319,7 @@ def emit_detach_commands(tables: Dict[str, List["PartInfo"]]) -> List[str]:
                     lines.append(f"\n# table: {table}")
                     header_done = True
                 if p.path:
-                    table_dir = os.path.dirname(p.path)
+                    table_dir = os.path.dirname(p.path.rstrip("/"))
                     detached_dir = os.path.join(table_dir, "detached")
                     dest = os.path.join(detached_dir, p.name)
                     lines.append(f"#   partition {pid}: detach {p.name} (keep {keep.name})")
@@ -365,7 +328,7 @@ def emit_detach_commands(tables: Dict[str, List["PartInfo"]]) -> List[str]:
                     any_cmd = True
                 else:
                     lines.append(f"#   partition {pid}: detach {p.name} (keep {keep.name}) "
-                                 f"-- path unknown; run in scan mode to get an mv command")
+                                 f"-- path unknown; feed the part's full path to get an mv command")
                 reattach.append(f"#   ALTER TABLE <db>.<table> ATTACH PART '{p.name}';")
 
     if reattach:
@@ -377,46 +340,21 @@ def emit_detach_commands(tables: Dict[str, List["PartInfo"]]) -> List[str]:
 
 
 def main(argv: Optional[List[str]] = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument("paths", nargs="*", help="data roots / disk mount points to scan")
-    parser.add_argument("--stdin", action="store_true",
-                        help="read part names from stdin ('<table>\\t<name>' or bare '<name>')")
-    parser.add_argument("--format-version", type=int, choices=[0, 1], default=None,
-                        help="override on-disk format version (default: auto from format_version.txt)")
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        epilog="Feed part names (or full paths), one per line, on stdin. E.g.: "
+               "find /var/lib/clickhouse/store -mindepth 3 -maxdepth 3 -type d | %(prog)s",
+    )
+    parser.add_argument("--format-version", type=int, choices=[0, 1], default=FORMAT_VERSION_CUSTOM,
+                        help="on-disk part-name format version (default: 1, custom partitioning)")
     parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
     parser.add_argument("--emit-detach-commands", action="store_true",
                         help="print a read-only shell script that moves the suggested parts "
                              "into detached/ (never executed)")
     args = parser.parse_args(argv)
 
-    tables: Dict[str, List[PartInfo]] = {}
-    # (table, name) -> set of source roots, to catch the same part on two disks.
-    seen: Dict[Tuple[str, str], set] = {}
-    cross_disk_dups: Dict[str, List[str]] = {}
-
-    if args.stdin:
-        fv = FORMAT_VERSION_CUSTOM if args.format_version is None else args.format_version
-        for table, names in read_names_from_stream(sys.stdin).items():
-            for name in names:
-                info = parse_part_name(name, fv)
-                if info is not None:
-                    tables.setdefault(table, []).append(info)
-                else:
-                    print(f"warning: not a part name, skipped: {name}", file=sys.stderr)
-
-    for root in args.paths:
-        for table_dir in find_table_dirs(root):
-            table = os.path.relpath(table_dir, root)
-            parts, _ = scan_table_dir(table_dir, args.format_version)
-            for info in parts:
-                key = (table, info.name)
-                seen.setdefault(key, set()).add(root)
-                if len(seen[key]) == 2:  # first time it becomes a duplicate
-                    cross_disk_dups.setdefault(table, []).append(info.name)
-                else:
-                    tables.setdefault(table, []).append(info)
-
-    report = build_report(tables, cross_disk_dups)
+    tables = read_parts_from_stream(sys.stdin, args.format_version)
+    report = build_report(tables)
 
     if args.emit_detach_commands:
         print("\n".join(emit_detach_commands(tables)))

--- a/utils/mergetree-part-conflicts/mergetree_part_conflicts.py
+++ b/utils/mergetree-part-conflicts/mergetree_part_conflicts.py
@@ -38,17 +38,12 @@ from typing import Dict, List, Optional, Tuple
 MAX_LEVEL = 999999999
 LEGACY_MAX_LEVEL = 4294967295  # numeric_limits<UInt32>::max()
 
-# Mirrors src/Storages/MergeTree/MergeTreeDataFormatVersion.h
-FORMAT_VERSION_OLD = 0  # YYYYMMDD_YYYYMMDD_min_max_level (pre custom partitioning)
-FORMAT_VERSION_CUSTOM = 1  # partitionid_min_max_level[_mutation]
-
-# New-format part name: <partition_id>_<min>_<max>_<level>[_<mutation>].
-# partition_id is taken non-greedily so the numeric tail binds to min/max/level
-# (+ optional mutation). This is exact for numeric, hash and "all" partition ids
-# -- i.e. every id that carries no underscore, which is the realistic case.
-_NEW_NAME_RE = re.compile(r"^(?P<pid>.+?)_(?P<min>\d+)_(?P<max>\d+)_(?P<level>\d+)(?:_(?P<mut>\d+))?$")
-# Old-format part name: <min_date>_<max_date>_<min>_<max>_<level>.
-_OLD_NAME_RE = re.compile(r"^(?P<dmin>\d{6,8})_(?P<dmax>\d{6,8})_(?P<min>\d+)_(?P<max>\d+)_(?P<level>\d+)$")
+# Part name: <partition_id>_<min_block>_<max_block>_<level>[_<mutation>] -- the
+# custom-partitioning format used by every table created since 2016. partition_id
+# is matched non-greedily so the numeric tail binds to min/max/level (+ optional
+# mutation); this is exact for numeric, hash and "all" partition ids, i.e. every
+# id that carries no underscore, which is the realistic case.
+_NAME_RE = re.compile(r"^(?P<pid>.+?)_(?P<min>\d+)_(?P<max>\d+)_(?P<level>\d+)(?:_(?P<mut>\d+))?$")
 
 
 @dataclass(frozen=True)
@@ -89,26 +84,9 @@ class PartInfo:
         )
 
 
-def parse_part_name(name: str, format_version: int = FORMAT_VERSION_CUSTOM) -> Optional[PartInfo]:
-    """Parse a part-directory name into a PartInfo, or None if it is not a part.
-
-    ``format_version`` selects the on-disk naming scheme (0 = legacy, 1 = custom
-    partitioning), exactly as the server reads it from ``format_version.txt``.
-    """
-    if format_version == FORMAT_VERSION_OLD:
-        m = _OLD_NAME_RE.match(name)
-        if not m:
-            return None
-        return PartInfo(
-            partition_id=m.group("dmin")[:6],  # YYYYMM month partition
-            min_block=int(m.group("min")),
-            max_block=int(m.group("max")),
-            level=int(m.group("level")),
-            mutation=0,
-            name=name,
-        )
-
-    m = _NEW_NAME_RE.match(name)
+def parse_part_name(name: str) -> Optional[PartInfo]:
+    """Parse a part-directory name into a PartInfo, or None if it is not a part."""
+    m = _NAME_RE.match(name)
     if not m:
         return None
     return PartInfo(
@@ -185,7 +163,7 @@ def classify(parts: List[PartInfo]) -> Dict[str, PartitionReport]:
 # Input
 # --------------------------------------------------------------------------- #
 
-def read_parts_from_stream(stream, format_version: int) -> Dict[str, List[PartInfo]]:
+def read_parts_from_stream(stream) -> Dict[str, List[PartInfo]]:
     """Read parts from a plain-text stream (e.g. the output of ``find``), one per
     line, grouped by table.
 
@@ -213,7 +191,7 @@ def read_parts_from_stream(stream, format_version: int) -> Dict[str, List[PartIn
         name = os.path.basename(token.rstrip("/")) if path else token
         if table is None:
             table = os.path.dirname(path.rstrip("/")) if path else "(input)"
-        info = parse_part_name(name, format_version)
+        info = parse_part_name(name)
         if info is None:
             print(f"warning: not a part name, skipped: {name}", file=sys.stderr)
             continue
@@ -339,15 +317,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         epilog="Feed part names (or full paths), one per line, on stdin. E.g.: "
                "find /var/lib/clickhouse/store -mindepth 3 -maxdepth 3 -type d | %(prog)s",
     )
-    parser.add_argument("--format-version", type=int, choices=[0, 1], default=FORMAT_VERSION_CUSTOM,
-                        help="on-disk part-name format version (default: 1, custom partitioning)")
     parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
     parser.add_argument("--emit-detach-commands", action="store_true",
                         help="print a read-only shell script that moves the suggested parts "
                              "into detached/ (never executed)")
     args = parser.parse_args(argv)
 
-    tables = read_parts_from_stream(sys.stdin, args.format_version)
+    tables = read_parts_from_stream(sys.stdin)
     report = build_report(tables)
 
     if args.emit_detach_commands:

--- a/utils/mergetree-part-conflicts/mergetree_part_conflicts.py
+++ b/utils/mergetree-part-conflicts/mergetree_part_conflicts.py
@@ -298,13 +298,11 @@ def emit_detach_commands(tables: Dict[str, List[PartInfo]]) -> List[str]:
         "# READ-ONLY SUGGESTION -- review every line before running; this tool does not execute it.",
         "# Move the intersecting parts aside so the table can load, WITHOUT losing them.",
         "# The server must not have these tables loaded while you move files (they are the",
-        "# tables that failed to attach). After moving, reload them (DETACH/ATTACH DATABASE",
-        "# or a restart), then ATTACH PART each moved part to bring its rows back with a",
-        "# fresh block number, then reconcile duplicates in the overlapping ranges.",
+        "# tables that failed to attach). After moving, reload the tables, then re-attach each",
+        "# moved part to bring its rows back and reconcile duplicates in the overlapping ranges.",
         "set -eu",
     ]
-    reattach: List[str] = []
-    any_cmd = False
+    any_line = False
     for table, parts in sorted(tables.items()):
         per_partition = classify(parts)
         header_done = False
@@ -318,6 +316,7 @@ def emit_detach_commands(tables: Dict[str, List[PartInfo]]) -> List[str]:
                 if not header_done:
                     lines.append(f"\n# table: {table}")
                     header_done = True
+                any_line = True
                 if p.path:
                     table_dir = os.path.dirname(p.path.rstrip("/"))
                     detached_dir = os.path.join(table_dir, "detached")
@@ -325,16 +324,11 @@ def emit_detach_commands(tables: Dict[str, List[PartInfo]]) -> List[str]:
                     lines.append(f"#   partition {pid}: detach {p.name} (keep {keep.name})")
                     lines.append(f"mkdir -p {_sh_quote(detached_dir)}")
                     lines.append(f"mv -- {_sh_quote(p.path)} {_sh_quote(dest)}")
-                    any_cmd = True
                 else:
                     lines.append(f"#   partition {pid}: detach {p.name} (keep {keep.name}) "
                                  f"-- path unknown; feed the part's full path to get an mv command")
-                reattach.append(f"#   ALTER TABLE <db>.<table> ATTACH PART '{p.name}';")
 
-    if reattach:
-        lines.append("\n# After the tables are reloaded, bring the moved parts back:")
-        lines.extend(reattach)
-    if not any_cmd and not reattach:
+    if not any_line:
         lines.append("\n# No intersecting parts to detach.")
     return lines
 

--- a/utils/mergetree-part-conflicts/test_mergetree_part_conflicts.py
+++ b/utils/mergetree-part-conflicts/test_mergetree_part_conflicts.py
@@ -166,6 +166,20 @@ class TestReadInput(unittest.TestCase):
         self.assertEqual(list(tables), ["db.t"])
         self.assertEqual(len(tables["db.t"]), 2)
 
+    def test_one_table_across_several_disks(self):
+        # Tiered storage: the same table has parts on two disks. Labelling every line
+        # with the same table name unifies them, so a part on one disk that overlaps a
+        # part on another is detected; each part keeps its own path.
+        text = ("nat\t/var/lib/clickhouse/store/b11/b11e7407/20260722_98_20874_190\n"
+                "nat\t/mnt/ngx2/clickhouse/store/b11/b11e7407/20260722_2313_113249_107\n")
+        tables = feed(text)
+        self.assertEqual(list(tables), ["nat"])
+        rep = m.classify(tables["nat"])["20260722"]
+        self.assertEqual(len(rep.conflicts), 1)
+        # --emit-detach-commands moves the part into detached/ on its own disk (ngx2)
+        script = "\n".join(m.emit_detach_commands(tables))
+        self.assertIn("/mnt/ngx2/clickhouse/store/b11/b11e7407/detached/20260722_2313_113249_107", script)
+
 
 class TestSuggestKeep(unittest.TestCase):
     def test_prefers_higher_level(self):

--- a/utils/mergetree-part-conflicts/test_mergetree_part_conflicts.py
+++ b/utils/mergetree-part-conflicts/test_mergetree_part_conflicts.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
-"""Tests for mergetree_part_conflicts. Run: python3 -m unittest -v (from this dir)."""
+"""Tests for mergetree_part_conflicts. Run: python3 -m unittest -v (from this dir).
+
+The tool's only input is plain text on stdin -- one part per line, exactly as
+`find <table_dir> -mindepth 1 -maxdepth 1 -type d` (full paths) or
+`find ... -printf '%f\\n'` (bare names) would print it. The feed/CLI tests below
+pass such text verbatim so the input shape is obvious.
+"""
 
 import io
+import json
 import os
 import sys
-import tempfile
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -13,9 +19,15 @@ import mergetree_part_conflicts as m  # noqa: E402
 
 
 def P(name, fv=m.FORMAT_VERSION_CUSTOM):
+    """Build a PartInfo from a name (helper for the pure predicate/classify tests)."""
     info = m.parse_part_name(name, fv)
     assert info is not None, name
     return info
+
+
+def feed(text, fv=m.FORMAT_VERSION_CUSTOM):
+    """Run the input reader over a block of text, as if piped in from `find`."""
+    return m.read_parts_from_stream(io.StringIO(text), fv)
 
 
 class TestParsing(unittest.TestCase):
@@ -53,7 +65,6 @@ class TestContains(unittest.TestCase):
         self.assertTrue(P("all_0_100_1").contains(P("all_51_100_0")))
 
     def test_equal_range_needs_higher_or_equal_level(self):
-        # equal block range: strictly_contains satisfied by equal range; level>= required
         self.assertTrue(P("all_0_5_3").contains(P("all_0_5_2")))
         self.assertFalse(P("all_0_4_2").contains(P("all_0_5_2")))  # narrower range
 
@@ -120,12 +131,44 @@ class TestClassify(unittest.TestCase):
         # (0_50,40_90) and (40_90,80_120) overlap; (0_50,80_120) do not.
         self.assertEqual(len(rep.conflicts), 2)
 
-    def test_classify_groups_by_partition(self):
-        parts = [P("20260722_98_20874_190"), P("20260722_2313_113249_107"),
-                 P("20260723_0_10_0")]
-        groups = m.classify(parts)
-        self.assertTrue(groups["20260722"].has_conflicts)
-        self.assertFalse(groups["20260723"].has_conflicts)
+
+class TestReadInput(unittest.TestCase):
+    def test_reads_bare_names_like_find_printf_f(self):
+        # exactly what `find <uuid> -mindepth 1 -maxdepth 1 -type d -printf '%f\n'` prints
+        text = """\
+20260722_98_20874_190
+20260722_2313_113249_107
+20260723_0_10_0
+"""
+        tables = feed(text)
+        self.assertEqual(list(tables), ["(input)"])  # no path -> single default table
+        self.assertEqual(len(tables["(input)"]), 3)
+
+    def test_reads_full_paths_like_find_type_d(self):
+        # exactly what `find <uuid> -mindepth 1 -maxdepth 1 -type d` prints (full paths),
+        # including the non-part `detached` dir which must be skipped.
+        text = """\
+/var/lib/clickhouse/store/b11/b11e7407/20260722_98_20874_190
+/var/lib/clickhouse/store/b11/b11e7407/20260722_2313_113249_107
+/var/lib/clickhouse/store/b11/b11e7407/detached
+"""
+        tables = feed(text)
+        # grouped under the parent (table) dir; detached line skipped
+        self.assertEqual(list(tables), ["/var/lib/clickhouse/store/b11/b11e7407"])
+        parts = tables["/var/lib/clickhouse/store/b11/b11e7407"]
+        self.assertEqual(len(parts), 2)
+        self.assertTrue(all(p.path is not None for p in parts))
+
+    def test_blank_lines_comments_and_non_parts_are_ignored(self):
+        text = "\n# a comment\n20260722_98_20874_190\nnot_a_part_dir\n"
+        tables = feed(text)
+        self.assertEqual(len(tables["(input)"]), 1)
+
+    def test_explicit_table_column(self):
+        text = "db.t\t20260722_98_20874_190\ndb.t\t20260722_2313_113249_107\n"
+        tables = feed(text)
+        self.assertEqual(list(tables), ["db.t"])
+        self.assertEqual(len(tables["db.t"]), 2)
 
 
 class TestSuggestKeep(unittest.TestCase):
@@ -138,65 +181,23 @@ class TestSuggestKeep(unittest.TestCase):
         self.assertEqual(keep.max_block, 100)
 
 
-class TestScan(unittest.TestCase):
-    def _make_table(self, root, rel, fv, parts, extras=()):
-        tdir = os.path.join(root, rel)
-        os.makedirs(tdir)
-        with open(os.path.join(tdir, "format_version.txt"), "w") as f:
-            f.write(str(fv))
-        for name in list(parts) + list(extras):
-            os.makedirs(os.path.join(tdir, name))
-        return tdir
-
-    def test_scan_skips_non_parts(self):
-        with tempfile.TemporaryDirectory() as root:
-            tdir = self._make_table(
-                root, "store/b11/b11e7407", 1,
-                parts=["20260722_98_20874_190", "20260722_2313_113249_107"],
-                extras=["detached", "tmp_insert_9", "delete_tmp_5", "broken_x"],
-            )
-            parts, skipped = m.scan_table_dir(tdir)
-            self.assertEqual(sorted(p.name for p in parts),
-                             ["20260722_2313_113249_107", "20260722_98_20874_190"])
-            self.assertEqual(skipped, [])  # non-parts are filtered by name, not counted as skipped
-
-    def test_find_table_dirs_atomic_layout(self):
-        with tempfile.TemporaryDirectory() as root:
-            self._make_table(root, "store/b11/b11e7407", 1, parts=["all_1_1_0"])
-            self._make_table(root, "store/120/1206e97e", 1, parts=["all_1_1_0"])
-            found = m.find_table_dirs(root)
-            self.assertEqual(len(found), 2)
-
-    def test_scan_reads_old_format_version(self):
-        with tempfile.TemporaryDirectory() as root:
-            tdir = self._make_table(root, "data/db/t", 0,
-                                    parts=["20140317_20140323_2_2_0"])
-            parts, _ = m.scan_table_dir(tdir)
-            self.assertEqual(len(parts), 1)
-            self.assertEqual(parts[0].partition_id, "201403")
-
-
 class TestEmitDetachCommands(unittest.TestCase):
-    def test_scan_mode_emits_mv(self):
-        with tempfile.TemporaryDirectory() as root:
-            tdir = os.path.join(root, "store/b11/b11e7407")
-            os.makedirs(tdir)
-            with open(os.path.join(tdir, "format_version.txt"), "w") as f:
-                f.write("1")
-            for name in ("20260722_98_20874_190", "20260722_2313_113249_107"):
-                os.makedirs(os.path.join(tdir, name))
-            parts, _ = m.scan_table_dir(tdir)
-            script = "\n".join(m.emit_detach_commands({"t": parts}))
-            # keep the higher-level _190, detach the _107, with a concrete mv into detached/
-            self.assertIn("mv -- ", script)
-            self.assertIn("20260722_2313_113249_107", script)
-            self.assertIn(os.path.join(tdir, "detached", "20260722_2313_113249_107"), script)
-            self.assertNotIn("mv -- '" + os.path.join(tdir, "20260722_98_20874_190"), script)
-            self.assertIn("ATTACH PART '20260722_2313_113249_107'", script)
+    def test_full_paths_emit_concrete_mv(self):
+        # find output with full paths -> concrete mv into the table's detached/
+        text = """\
+/var/lib/clickhouse/store/b11/b11e7407/20260722_98_20874_190
+/var/lib/clickhouse/store/b11/b11e7407/20260722_2313_113249_107
+"""
+        script = "\n".join(m.emit_detach_commands(feed(text)))
+        # keep the higher-level _190, detach the _107 with a concrete mv
+        self.assertIn("mv -- ", script)
+        self.assertIn("/var/lib/clickhouse/store/b11/b11e7407/detached/20260722_2313_113249_107", script)
+        self.assertNotIn("20260722_98_20874_190'", script.split("# After")[0].replace("mkdir", ""))
+        self.assertIn("ATTACH PART '20260722_2313_113249_107'", script)
 
-    def test_stdin_mode_no_path_placeholder(self):
-        parts = [P("20260722_98_20874_190"), P("20260722_2313_113249_107")]
-        script = "\n".join(m.emit_detach_commands({"t": parts}))
+    def test_bare_names_emit_placeholder(self):
+        text = "20260722_98_20874_190\n20260722_2313_113249_107\n"
+        script = "\n".join(m.emit_detach_commands(feed(text)))
         self.assertIn("path unknown", script)
         self.assertNotIn("mv -- ", script)
 
@@ -204,14 +205,13 @@ class TestEmitDetachCommands(unittest.TestCase):
         self.assertEqual(m._sh_quote("a'b"), "'a'\\''b'")
 
 
-class TestMainStdin(unittest.TestCase):
+class TestMain(unittest.TestCase):
     def _run(self, text, *args):
         old_in, old_out = sys.stdin, sys.stdout
         sys.stdin = io.StringIO(text)
         sys.stdout = io.StringIO()
         try:
-            code = m.main(["--stdin", *args])
-            return code, sys.stdout.getvalue()
+            return m.main(list(args)), sys.stdout.getvalue()
         finally:
             sys.stdin, sys.stdout = old_in, old_out
 
@@ -219,7 +219,6 @@ class TestMainStdin(unittest.TestCase):
         text = "t\t20260722_98_20874_190\nt\t20260722_2313_113249_107\n"
         code, out = self._run(text, "--json")
         self.assertEqual(code, 2)
-        import json
         report = json.loads(out)
         self.assertTrue(report["has_conflicts"])
         part = report["tables"]["t"]["partitions"]["20260722"]
@@ -227,7 +226,7 @@ class TestMainStdin(unittest.TestCase):
         self.assertEqual(part["suggested_detach"], ["20260722_2313_113249_107"])
 
     def test_clean_exit_code(self):
-        text = "t\tall_0_50_0\nt\tall_51_100_0\n"
+        text = "all_0_50_0\nall_51_100_0\n"
         code, out = self._run(text)
         self.assertEqual(code, 0)
 

--- a/utils/mergetree-part-conflicts/test_mergetree_part_conflicts.py
+++ b/utils/mergetree-part-conflicts/test_mergetree_part_conflicts.py
@@ -189,11 +189,11 @@ class TestEmitDetachCommands(unittest.TestCase):
 /var/lib/clickhouse/store/b11/b11e7407/20260722_2313_113249_107
 """
         script = "\n".join(m.emit_detach_commands(feed(text)))
-        # keep the higher-level _190, detach the _107 with a concrete mv
-        self.assertIn("mv -- ", script)
+        # keep the higher-level _190, detach the _107 with a single concrete mv
+        self.assertEqual(script.count("mv -- "), 1)
         self.assertIn("/var/lib/clickhouse/store/b11/b11e7407/detached/20260722_2313_113249_107", script)
-        self.assertNotIn("20260722_98_20874_190'", script.split("# After")[0].replace("mkdir", ""))
-        self.assertIn("ATTACH PART '20260722_2313_113249_107'", script)
+        # the tool does not emit ATTACH PART commands
+        self.assertNotIn("ATTACH PART", script)
 
     def test_bare_names_emit_placeholder(self):
         text = "20260722_98_20874_190\n20260722_2313_113249_107\n"

--- a/utils/mergetree-part-conflicts/test_mergetree_part_conflicts.py
+++ b/utils/mergetree-part-conflicts/test_mergetree_part_conflicts.py
@@ -181,6 +181,73 @@ class TestReadInput(unittest.TestCase):
         self.assertIn("/mnt/ngx2/clickhouse/store/b11/b11e7407/detached/20260722_2313_113249_107", script)
 
 
+class TestComputeDetach(unittest.TestCase):
+    def _names(self, detach):
+        return {p.name for p, _ in detach}
+
+    def test_simple_overlap_detaches_the_lower(self):
+        detach = m.compute_detach([P("20260722_98_20874_190"), P("20260722_2313_113249_107")])
+        self.assertEqual(self._names(detach), {"20260722_2313_113249_107"})
+        self.assertTrue(all(r == m.DETACH_OVERLAP for _, r in detach))
+
+    def test_pure_cross_disk_containment_detaches_the_covered(self):
+        # No overlap at all: all_10_100_10 (hot) simply CONTAINS all_20_30_5 (ngx2).
+        # The table loads, but CH would silently retire the covered part on startup.
+        # Because its coverer is on another disk, we detach it to preserve it.
+        parts = feed(
+            "nat\t/hot/store/x/y/all_10_100_10\n"       # coverer, hot disk
+            "nat\t/ngx2/store/x/y/all_20_30_5\n"        # covered, ngx2 disk
+        )["nat"]
+        self.assertEqual(m.classify_partition(parts).conflicts, [])  # no overlap
+        detach = m.compute_detach(parts)
+        self.assertEqual([(p.name, r) for p, r in detach],
+                         [("all_20_30_5", m.DETACH_XDISK_COVERED)])
+        script = "\n".join(m.emit_detach_commands({"nat": parts}))
+        self.assertIn("/ngx2/store/x/y/detached/all_20_30_5", script)
+        self.assertIn(m.DETACH_XDISK_COVERED, script)
+
+    def test_same_disk_containment_is_left_alone(self):
+        # Covered part on the SAME disk as its coverer is an ordinary merge source;
+        # CH cleans it correctly, so it is not detached.
+        parts = feed(
+            "nat\t/hot/store/x/y/all_10_100_10\n"
+            "nat\t/hot/store/x/y/all_20_30_5\n"
+        )["nat"]
+        self.assertEqual(m.compute_detach(parts), [])
+
+    def test_cross_disk_needs_a_path(self):
+        # Bare names carry no disk, so cross-disk coverage cannot be judged: not detached.
+        parts = feed("all_10_100_10\nall_20_30_5\n")["(input)"]
+        self.assertEqual(m.compute_detach(parts), [])
+
+    def test_covered_child_across_disks_exposed_by_overlap_is_detached(self):
+        # P_cover (ngx2) overlaps the survivor P_keep (hot) AND covers P_child (hot).
+        # Detaching P_cover for the overlap exposes P_child, which then overlaps P_keep,
+        # so the covered child (on a different disk) is detached too.
+        parts = feed(
+            "nat\t/hot/store/x/y/20260722_98_20874_190\n"       # P_keep  (survivor)
+            "nat\t/ngx2/store/x/y/20260722_2313_113249_107\n"   # P_cover (overlaps P_keep, covers P_child)
+            "nat\t/hot/store/x/y/20260722_2313_50000_50\n"      # P_child (covered by P_cover)
+        )["nat"]
+        self.assertIn("20260722_2313_50000_50",
+                      [p.name for p in m.classify_partition(parts).covered])
+        self.assertEqual(self._names(m.compute_detach(parts)),
+                         {"20260722_2313_113249_107", "20260722_2313_50000_50"})
+        script = "\n".join(m.emit_detach_commands({"nat": parts}))
+        self.assertIn("/ngx2/store/x/y/detached/20260722_2313_113249_107", script)
+        self.assertIn("/hot/store/x/y/detached/20260722_2313_50000_50", script)
+
+    def test_covered_child_outside_overlap_is_left_alone(self):
+        # After its cover is detached for an overlap, this covered child is disjoint from
+        # the survivor, so it loads fine on its own and is not detached.
+        parts = feed(
+            "nat\t/hot/store/x/y/20260722_80_200_9\n"       # survivor, higher level
+            "nat\t/ngx2/store/x/y/20260722_0_100_5\n"       # overlaps survivor -> detached
+            "nat\t/hot/store/x/y/20260722_0_40_2\n"         # covered by _0_100_5, disjoint from survivor
+        )["nat"]
+        self.assertEqual(self._names(m.compute_detach(parts)), {"20260722_0_100_5"})
+
+
 class TestSuggestKeep(unittest.TestCase):
     def test_prefers_higher_level(self):
         keep = m.suggest_keep([P("all_0_100_2"), P("all_0_100_5")])

--- a/utils/mergetree-part-conflicts/test_mergetree_part_conflicts.py
+++ b/utils/mergetree-part-conflicts/test_mergetree_part_conflicts.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Tests for mergetree_part_conflicts. Run: python3 -m unittest -v (from this dir)."""
+
+import io
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import mergetree_part_conflicts as m  # noqa: E402
+
+
+def P(name, fv=m.FORMAT_VERSION_CUSTOM):
+    info = m.parse_part_name(name, fv)
+    assert info is not None, name
+    return info
+
+
+class TestParsing(unittest.TestCase):
+    def test_new_format_no_mutation(self):
+        p = P("20260722_98_20874_190")
+        self.assertEqual((p.partition_id, p.min_block, p.max_block, p.level, p.mutation),
+                         ("20260722", 98, 20874, 190, 0))
+
+    def test_new_format_with_mutation(self):
+        p = P("20260722_98_20874_190_5")
+        self.assertEqual((p.partition_id, p.min_block, p.max_block, p.level, p.mutation),
+                         ("20260722", 98, 20874, 190, 5))
+
+    def test_all_partition(self):
+        p = P("all_1_1_0")
+        self.assertEqual((p.partition_id, p.min_block, p.max_block, p.level), ("all", 1, 1, 0))
+
+    def test_hex_hash_partition(self):
+        p = P("a1b2c3d4e5f6_10_20_3")
+        self.assertEqual((p.partition_id, p.min_block, p.max_block, p.level), ("a1b2c3d4e5f6", 10, 20, 3))
+
+    def test_old_format(self):
+        p = P("20140317_20140323_2_2_0", fv=m.FORMAT_VERSION_OLD)
+        self.assertEqual((p.partition_id, p.min_block, p.max_block, p.level), ("201403", 2, 2, 0))
+
+    def test_not_a_part(self):
+        for bad in ("detached", "format_version.txt", "tmp_insert_123", "notapart", ""):
+            self.assertIsNone(m.parse_part_name(bad))
+
+
+class TestContains(unittest.TestCase):
+    def test_merge_ancestor_contains_source(self):
+        # 0_100_1 is a merge over 0_50_0 and 51_100_0
+        self.assertTrue(P("all_0_100_1").contains(P("all_0_50_0")))
+        self.assertTrue(P("all_0_100_1").contains(P("all_51_100_0")))
+
+    def test_equal_range_needs_higher_or_equal_level(self):
+        # equal block range: strictly_contains satisfied by equal range; level>= required
+        self.assertTrue(P("all_0_5_3").contains(P("all_0_5_2")))
+        self.assertFalse(P("all_0_4_2").contains(P("all_0_5_2")))  # narrower range
+
+    def test_wider_but_equal_level_does_not_contain(self):
+        # all_0_5_2 does not contain all_0_4_2 (needs level>rhs.level unless equal range)
+        self.assertFalse(P("all_0_5_2").contains(P("all_0_4_2")))
+
+    def test_max_level_contains(self):
+        self.assertTrue(P(f"all_0_100_{m.MAX_LEVEL}").contains(P("all_10_20_50")))
+
+    def test_different_partition_never_contains(self):
+        self.assertFalse(P("20260722_0_100_5").contains(P("20260723_0_50_0")))
+
+    def test_mutation_must_be_ge(self):
+        self.assertFalse(P("all_0_100_5_1").contains(P("all_0_50_0_3")))
+        self.assertTrue(P("all_0_100_5_3").contains(P("all_0_50_0_1")))
+
+
+class TestDisjoint(unittest.TestCase):
+    def test_disjoint(self):
+        self.assertTrue(P("all_0_50_0").is_disjoint(P("all_51_100_0")))
+
+    def test_touching_ranges_overlap(self):
+        self.assertFalse(P("all_0_50_0").is_disjoint(P("all_50_100_0")))
+
+    def test_different_partition_is_disjoint(self):
+        self.assertTrue(P("20260722_0_50_0").is_disjoint(P("20260723_0_50_0")))
+
+
+class TestClassify(unittest.TestCase):
+    def test_customer_partial_overlap(self):
+        # Turkcell nat, partition 20260722: neither contains the other -> load-aborting conflict.
+        parts = [P("20260722_98_20874_190"), P("20260722_2313_113249_107")]
+        rep = m.classify_partition(parts)
+        self.assertEqual(len(rep.conflicts), 1)
+        self.assertEqual(rep.conflicts[0].overlap(), (2313, 20874))
+        self.assertEqual(len(rep.maximal), 2)
+        self.assertEqual(rep.covered, [])
+
+    def test_healthy_merge_layers_no_conflict(self):
+        parts = [P("all_0_100_1"), P("all_0_50_0"), P("all_51_100_0")]
+        rep = m.classify_partition(parts)
+        self.assertEqual(rep.conflicts, [])
+        self.assertEqual([p.name for p in rep.maximal], ["all_0_100_1"])
+        self.assertEqual(sorted(p.name for p in rep.covered), ["all_0_50_0", "all_51_100_0"])
+
+    def test_false_dominator_shows_as_covered_not_conflict(self):
+        # A wider, higher-level part name-covers another -> silent path, reported as covered.
+        parts = [P("20260722_98_113249_200"), P("20260722_2313_20874_107")]
+        rep = m.classify_partition(parts)
+        self.assertEqual(rep.conflicts, [])
+        self.assertEqual([p.name for p in rep.maximal], ["20260722_98_113249_200"])
+        self.assertEqual([p.name for p in rep.covered], ["20260722_2313_20874_107"])
+
+    def test_disjoint_parts_no_conflict(self):
+        parts = [P("all_0_50_0"), P("all_51_100_0"), P("all_101_150_0")]
+        rep = m.classify_partition(parts)
+        self.assertEqual(rep.conflicts, [])
+        self.assertEqual(len(rep.maximal), 3)
+
+    def test_three_way_overlap_reports_all_pairs(self):
+        parts = [P("all_0_50_1"), P("all_40_90_1"), P("all_80_120_1")]
+        rep = m.classify_partition(parts)
+        # (0_50,40_90) and (40_90,80_120) overlap; (0_50,80_120) do not.
+        self.assertEqual(len(rep.conflicts), 2)
+
+    def test_classify_groups_by_partition(self):
+        parts = [P("20260722_98_20874_190"), P("20260722_2313_113249_107"),
+                 P("20260723_0_10_0")]
+        groups = m.classify(parts)
+        self.assertTrue(groups["20260722"].has_conflicts)
+        self.assertFalse(groups["20260723"].has_conflicts)
+
+
+class TestSuggestKeep(unittest.TestCase):
+    def test_prefers_higher_level(self):
+        keep = m.suggest_keep([P("all_0_100_2"), P("all_0_100_5")])
+        self.assertEqual(keep.level, 5)
+
+    def test_prefers_wider_when_same_level(self):
+        keep = m.suggest_keep([P("all_0_50_3"), P("all_0_100_3")])
+        self.assertEqual(keep.max_block, 100)
+
+
+class TestScan(unittest.TestCase):
+    def _make_table(self, root, rel, fv, parts, extras=()):
+        tdir = os.path.join(root, rel)
+        os.makedirs(tdir)
+        with open(os.path.join(tdir, "format_version.txt"), "w") as f:
+            f.write(str(fv))
+        for name in list(parts) + list(extras):
+            os.makedirs(os.path.join(tdir, name))
+        return tdir
+
+    def test_scan_skips_non_parts(self):
+        with tempfile.TemporaryDirectory() as root:
+            tdir = self._make_table(
+                root, "store/b11/b11e7407", 1,
+                parts=["20260722_98_20874_190", "20260722_2313_113249_107"],
+                extras=["detached", "tmp_insert_9", "delete_tmp_5", "broken_x"],
+            )
+            parts, skipped = m.scan_table_dir(tdir)
+            self.assertEqual(sorted(p.name for p in parts),
+                             ["20260722_2313_113249_107", "20260722_98_20874_190"])
+            self.assertEqual(skipped, [])  # non-parts are filtered by name, not counted as skipped
+
+    def test_find_table_dirs_atomic_layout(self):
+        with tempfile.TemporaryDirectory() as root:
+            self._make_table(root, "store/b11/b11e7407", 1, parts=["all_1_1_0"])
+            self._make_table(root, "store/120/1206e97e", 1, parts=["all_1_1_0"])
+            found = m.find_table_dirs(root)
+            self.assertEqual(len(found), 2)
+
+    def test_scan_reads_old_format_version(self):
+        with tempfile.TemporaryDirectory() as root:
+            tdir = self._make_table(root, "data/db/t", 0,
+                                    parts=["20140317_20140323_2_2_0"])
+            parts, _ = m.scan_table_dir(tdir)
+            self.assertEqual(len(parts), 1)
+            self.assertEqual(parts[0].partition_id, "201403")
+
+
+class TestEmitDetachCommands(unittest.TestCase):
+    def test_scan_mode_emits_mv(self):
+        with tempfile.TemporaryDirectory() as root:
+            tdir = os.path.join(root, "store/b11/b11e7407")
+            os.makedirs(tdir)
+            with open(os.path.join(tdir, "format_version.txt"), "w") as f:
+                f.write("1")
+            for name in ("20260722_98_20874_190", "20260722_2313_113249_107"):
+                os.makedirs(os.path.join(tdir, name))
+            parts, _ = m.scan_table_dir(tdir)
+            script = "\n".join(m.emit_detach_commands({"t": parts}))
+            # keep the higher-level _190, detach the _107, with a concrete mv into detached/
+            self.assertIn("mv -- ", script)
+            self.assertIn("20260722_2313_113249_107", script)
+            self.assertIn(os.path.join(tdir, "detached", "20260722_2313_113249_107"), script)
+            self.assertNotIn("mv -- '" + os.path.join(tdir, "20260722_98_20874_190"), script)
+            self.assertIn("ATTACH PART '20260722_2313_113249_107'", script)
+
+    def test_stdin_mode_no_path_placeholder(self):
+        parts = [P("20260722_98_20874_190"), P("20260722_2313_113249_107")]
+        script = "\n".join(m.emit_detach_commands({"t": parts}))
+        self.assertIn("path unknown", script)
+        self.assertNotIn("mv -- ", script)
+
+    def test_sh_quote_escapes(self):
+        self.assertEqual(m._sh_quote("a'b"), "'a'\\''b'")
+
+
+class TestMainStdin(unittest.TestCase):
+    def _run(self, text, *args):
+        old_in, old_out = sys.stdin, sys.stdout
+        sys.stdin = io.StringIO(text)
+        sys.stdout = io.StringIO()
+        try:
+            code = m.main(["--stdin", *args])
+            return code, sys.stdout.getvalue()
+        finally:
+            sys.stdin, sys.stdout = old_in, old_out
+
+    def test_conflict_exit_code_and_json(self):
+        text = "t\t20260722_98_20874_190\nt\t20260722_2313_113249_107\n"
+        code, out = self._run(text, "--json")
+        self.assertEqual(code, 2)
+        import json
+        report = json.loads(out)
+        self.assertTrue(report["has_conflicts"])
+        part = report["tables"]["t"]["partitions"]["20260722"]
+        self.assertEqual(part["conflicts"][0]["overlap_blocks"], [2313, 20874])
+        self.assertEqual(part["suggested_detach"], ["20260722_2313_113249_107"])
+
+    def test_clean_exit_code(self):
+        text = "t\tall_0_50_0\nt\tall_51_100_0\n"
+        code, out = self._run(text)
+        self.assertEqual(code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/mergetree-part-conflicts/test_mergetree_part_conflicts.py
+++ b/utils/mergetree-part-conflicts/test_mergetree_part_conflicts.py
@@ -18,16 +18,16 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import mergetree_part_conflicts as m  # noqa: E402
 
 
-def P(name, fv=m.FORMAT_VERSION_CUSTOM):
+def P(name):
     """Build a PartInfo from a name (helper for the pure predicate/classify tests)."""
-    info = m.parse_part_name(name, fv)
+    info = m.parse_part_name(name)
     assert info is not None, name
     return info
 
 
-def feed(text, fv=m.FORMAT_VERSION_CUSTOM):
+def feed(text):
     """Run the input reader over a block of text, as if piped in from `find`."""
-    return m.read_parts_from_stream(io.StringIO(text), fv)
+    return m.read_parts_from_stream(io.StringIO(text))
 
 
 class TestParsing(unittest.TestCase):
@@ -48,10 +48,6 @@ class TestParsing(unittest.TestCase):
     def test_hex_hash_partition(self):
         p = P("a1b2c3d4e5f6_10_20_3")
         self.assertEqual((p.partition_id, p.min_block, p.max_block, p.level), ("a1b2c3d4e5f6", 10, 20, 3))
-
-    def test_old_format(self):
-        p = P("20140317_20140323_2_2_0", fv=m.FORMAT_VERSION_OLD)
-        self.assertEqual((p.partition_id, p.min_block, p.max_block, p.level), ("201403", 2, 2, 0))
 
     def test_not_a_part(self):
         for bad in ("detached", "format_version.txt", "tmp_insert_123", "notapart", ""):


### PR DESCRIPTION
## Description

Adds `utils/mergetree-part-conflicts`, a read-only, offline tool that reconstructs —
from a list of part names you feed it — the full set of intersecting and covered
data parts in a non-replicated `MergeTree`.

Motivation: when two active parts in a partition partially overlap, the table fails to
load with `Part ... intersects previous/next part` (`LOGICAL_ERROR`). The server throws
on the *first* such pair and does not attach the table, so the complete set of conflicts
is otherwise invisible — it is not in `system.parts`, `clickhouse-local` hits the same
error, and there is no setting to load past it. The tool replays the server's own
`MergeTreePartInfo::contains` / `isDisjoint` classification to list every conflict at
once, without a running server.

It reads part names (or full part-directory paths) on stdin — from `find`,
`clickhouse-disks list`, or a `system.parts` query — and reports, per table and
partition, the partial overlaps (with the shared block range and a keep/detach
suggestion) and the covered layers. With `--emit-detach-commands` it prints a read-only
shell script that moves the intersecting parts into `detached/` (concrete `mv` when full
paths are fed). It never moves, attaches, or deletes anything itself. Includes unit tests
(`python3 -m unittest`).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
