### PR TITLE
Whole-pipeline utilization KPI from host metrics

### DIFF
--- a/ci/praktika/gh_auth.py
+++ b/ci/praktika/gh_auth.py
@@ -3,19 +3,35 @@ import time
 
 import requests
 
-try:
-    import jwt  # From pyjwt
-
-    assert hasattr(jwt, "encode"), "Invalid jwt module, 'encode' not found"
-    USING_PYJWT = True
-except (ImportError, AssertionError):
-    USING_PYJWT = False
-    print(
-        "Warning: pyjwt not available. Falling back to 'jwt' module (not recommended)"
-    )
-    from jwt import jwk_from_pem, JWT
-
 from praktika.utils import Shell
+
+# The JWT backend is imported lazily (see _jwt_backend) so importing this module
+# - and therefore runner.py - never requires pyjwt. Only GitHub App auth needs
+# it; local flows such as running integration tests must not depend on it.
+_JWT_BACKEND = None
+
+
+def _jwt_backend():
+    """Return (using_pyjwt, backend), importing the JWT library on first use.
+
+    backend is the ``jwt`` module when pyjwt is available, otherwise the
+    ``(jwk_from_pem, JWT)`` symbols from the legacy ``jwt`` package.
+    """
+    global _JWT_BACKEND
+    if _JWT_BACKEND is None:
+        try:
+            import jwt  # From pyjwt
+
+            assert hasattr(jwt, "encode"), "Invalid jwt module, 'encode' not found"
+            _JWT_BACKEND = (True, jwt)
+        except (ImportError, AssertionError):
+            print(
+                "Warning: pyjwt not available. Falling back to 'jwt' module (not recommended)"
+            )
+            from jwt import JWT, jwk_from_pem
+
+            _JWT_BACKEND = (False, (jwk_from_pem, JWT))
+    return _JWT_BACKEND
 
 # `gh auth login --with-token` validates the token against api.github.com. A single
 # transient GitHub API 5xx/timeout there would otherwise hard-fail the whole job.
@@ -91,6 +107,7 @@ class GHAuth:
             "iss": app_id,
         }
 
+        _, jwt = _jwt_backend()
         jwt_instance = jwt.PyJWT()
         encoded_jwt = jwt_instance.encode(payload, private_key, algorithm="RS256")
         return cls._get_access_token_by_jwt(encoded_jwt, installation_id)
@@ -98,6 +115,7 @@ class GHAuth:
     @classmethod
     def _get_access_token_deprecated(cls, app_key, app_id, installation_id: int):
         def _generate_jwt(client_id, pem):
+            _, (jwk_from_pem, JWT) = _jwt_backend()
             pem = str.encode(pem)
             signing_key = jwk_from_pem(pem)
             payload = {
@@ -124,7 +142,8 @@ class GHAuth:
         instead print a warning and return False.
         """
         try:
-            if USING_PYJWT:
+            using_pyjwt, _ = _jwt_backend()
+            if using_pyjwt:
                 access_token = cls._get_access_token(app_key, app_id, installation_id)
             else:
                 access_token = cls._get_access_token_deprecated(app_key, app_id, installation_id)

--- a/ci/praktika/hook_html.py
+++ b/ci/praktika/hook_html.py
@@ -10,7 +10,8 @@ from .result import Result, ResultInfo, _ResultS3
 from .runtime import RunConfig
 from .s3 import S3
 from .settings import Settings
-from .usage import ComputeUsage, StorageUsage
+from .host_metrics import HostMetricsCollector
+from .usage import ComputeUsage, PipelineUtilization, StorageUsage
 from .utils import Utils
 
 
@@ -36,9 +37,7 @@ class GitCommit:
                 for commit in json_data
             ]
         except Exception as e:
-            print(
-                f"ERROR: Failed to deserialize commit's data [{json_data}], ex: [{e}]"
-            )
+            print(f"ERROR: Failed to deserialize commit's data [{json_data}], ex: [{e}]")
 
         return commits
 
@@ -52,14 +51,10 @@ class GitCommit:
         commits = cls.pull_from_s3()
         for commit in commits:
             if sha == commit.sha:
-                print(
-                    f"INFO: Sha already present in commits data [{sha}] - skip data update"
-                )
+                print(f"INFO: Sha already present in commits data [{sha}] - skip data update")
                 return
         commits.append(GitCommit(sha=sha, message=env.COMMIT_MESSAGE))
-        commits = commits[
-            -20:
-        ]  # limit maximum number of commits from the past to show in the report
+        commits = commits[-20:]  # limit maximum number of commits from the past to show in the report
         cls.push_to_s3(commits)
         return
 
@@ -86,9 +81,7 @@ class GitCommit:
         local_path = Path(cls.file_name())
         file_name = local_path.name
         s3_path = f"{cls.get_s3_path()}/{file_name}"
-        if not S3.copy_file_from_s3(
-            s3_path=s3_path, local_path=local_path, no_strict=True
-        ):
+        if not S3.copy_file_from_s3(s3_path=s3_path, local_path=local_path, no_strict=True):
             print(f"WARNING: failed to cp file [{s3_path}] from s3")
             return []
         return cls.from_json(local_path)
@@ -100,9 +93,7 @@ class GitCommit:
         local_path = Path(cls.file_name())
         file_name = local_path.name
         s3_path = f"{cls.get_s3_path()}/{file_name}"
-        if not S3.copy_file_to_s3(
-            s3_path=s3_path, local_path=local_path, text=True, no_strict=True
-        ):
+        if not S3.copy_file_to_s3(s3_path=s3_path, local_path=local_path, text=True, no_strict=True):
             print(f"WARNING: failed to cp file [{local_path}] to s3")
 
     @classmethod
@@ -132,31 +123,15 @@ class HtmlRunnerHooks:
             else:
                 result = Result.create_new(job.name, Result.Status.PENDING)
             results.append(result)
-        summary_result = Result.create_new(
-            _workflow.name, Result.Status.RUNNING, results=results
-        )
+        summary_result = Result.create_new(_workflow.name, Result.Status.RUNNING, results=results)
         summary_result.start_time = Utils.timestamp()
         info = Info()
         report_url_current_sha = info.get_report_url(latest=False)
-        summary_result.add_ext_key_value("pr_title", info.pr_title).add_ext_key_value(
-            "git_branch", info.git_branch
-        ).add_ext_key_value("report_url", report_url_current_sha).add_ext_key_value(
+        summary_result.add_ext_key_value("pr_title", info.pr_title).add_ext_key_value("git_branch", info.git_branch).add_ext_key_value("report_url", report_url_current_sha).add_ext_key_value(
             "commit_sha", env.SHA
-        ).add_ext_key_value(
-            "commit_message", env.COMMIT_MESSAGE
-        ).add_ext_key_value(
-            "repo_name", env.REPOSITORY
-        ).add_ext_key_value(
-            "pr_number", env.PR_NUMBER
-        ).add_ext_key_value(
+        ).add_ext_key_value("commit_message", env.COMMIT_MESSAGE).add_ext_key_value("repo_name", env.REPOSITORY).add_ext_key_value("pr_number", env.PR_NUMBER).add_ext_key_value(
             "run_url", env.RUN_URL
-        ).add_ext_key_value(
-            "change_url", env.CHANGE_URL
-        ).add_ext_key_value(
-            "workflow_name", env.WORKFLOW_NAME
-        ).add_ext_key_value(
-            "base_branch", env.BASE_BRANCH
-        )
+        ).add_ext_key_value("change_url", env.CHANGE_URL).add_ext_key_value("workflow_name", env.WORKFLOW_NAME).add_ext_key_value("base_branch", env.BASE_BRANCH)
 
         summary_result.dump()
         # Use version 0 for initial workflow report creation (destructive reset)
@@ -200,12 +175,7 @@ class HtmlRunnerHooks:
                     )
                 results.append(result)
             if results:
-                assert (
-                    _ResultS3.update_workflow_results(
-                        _workflow.name, new_sub_results=results
-                    )
-                    is None
-                ), "Workflow status supposed to remain 'running'"
+                assert _ResultS3.update_workflow_results(_workflow.name, new_sub_results=results) is None, "Workflow status supposed to remain 'running'"
 
     @classmethod
     def pre_run(cls, _workflow, _job):
@@ -234,12 +204,17 @@ class HtmlRunnerHooks:
         _ResultS3.upload_result_files_to_s3(result).dump()
         storage_usage = None
         if StorageUsage.exist():
-            StorageUsage.add_uploaded(
-                result.file_name()
-            )  # add Result file beforehand to upload actual storage usage data
+            StorageUsage.add_uploaded(result.file_name())  # add Result file beforehand to upload actual storage usage data
             print("Storage usage data found - add to Result")
             storage_usage = StorageUsage.from_fs()
             result.ext["storage_usage"] = storage_usage
+        # Accumulate the whole-pipeline utilization KPI from this job's host
+        # metrics, but only for jobs substantial enough to be worth right-sizing.
+        pipeline_utilization = None
+        job_metrics = result.ext.get("metrics")
+        if job_metrics and HostMetricsCollector.qualifies(job_metrics):
+            pipeline_utilization = PipelineUtilization.from_job_metrics(job_metrics)
+
         report_messages = env.REPORT_MESSAGES
         _ResultS3.append_report_messages(result, report_messages)
         _ResultS3.copy_result_to_s3(result)
@@ -247,9 +222,7 @@ class HtmlRunnerHooks:
         new_sub_results = [result]
 
         if not result.is_ok() and not result.do_not_block_pipeline_on_failure():
-            print(
-                "Current job failed - find dependee jobs in the workflow and set their statuses to dropped"
-            )
+            print("Current job failed - find dependee jobs in the workflow and set their statuses to dropped")
             workflow_config_parsed = WorkflowConfigParser(_workflow).parse()
 
             dependees = set()
@@ -258,28 +231,21 @@ class HtmlRunnerHooks:
                 for dependee_job in workflow_config_parsed.workflow_yaml_config.jobs:
                     if dependee_job.run_unless_cancelled:
                         continue
-                    if (
-                        job_name in dependee_job.needs
-                        and dependee_job.name not in dependees
-                    ):
+                    if job_name in dependee_job.needs and dependee_job.name not in dependees:
                         dependees.add(dependee_job.name)
                         add_dependees(dependee_job.name)
 
             add_dependees(_job.name)
 
             for dependee in dependees:
-                print(
-                    f"NOTE: Set job [{dependee}] status to [{Result.Status.DROPPED}] due to current failure"
-                )
+                print(f"NOTE: Set job [{dependee}] status to [{Result.Status.DROPPED}] due to current failure")
                 dropped_result = Result(
                     name=dependee,
                     status=Result.Status.DROPPED,
                     start_time=Utils.timestamp(),
                     duration=0,
                 )
-                dropped_result.add_note(
-                    ResultInfo.DROPPED_DUE_TO_PREVIOUS_FAILURE + f" [{_job.name}]"
-                )
+                dropped_result.add_note(ResultInfo.DROPPED_DUE_TO_PREVIOUS_FAILURE + f" [{_job.name}]")
                 new_sub_results.append(dropped_result)
 
         updated_status = _ResultS3.update_workflow_results(
@@ -291,6 +257,7 @@ class HtmlRunnerHooks:
                 duration=result.duration,
                 job_name=_job.name,
             ),
+            pipeline_utilization=pipeline_utilization,
             report_messages=report_messages,
         )
         return updated_status

--- a/ci/praktika/host_metrics.md
+++ b/ci/praktika/host_metrics.md
@@ -41,7 +41,7 @@ than `HOST_METRICS_MIN_LABEL_MEM_GB` (15 GB) of RAM — and never to skipped job
 
 | Label | Trigger |
 |---|---|
-| `under-utilized RAM` | peak RAM < 50% (provision for the peak) |
+| `under-utilized RAM` | peak RAM < 40% (provision for the peak) |
 | `under-utilized CPU` | whole-run avg CPU < 20% (bursts don't justify more cores) |
 | `ram-pressure` | peak RAM ≥ 95% **or** memory full-stall > 2% of runtime |
 | `cpu-bound` | CPU stall > 50% of runtime |

--- a/ci/praktika/host_metrics.md
+++ b/ci/praktika/host_metrics.md
@@ -52,8 +52,12 @@ than `HOST_METRICS_MIN_LABEL_MEM_GB` (15 GB) of RAM — and never to skipped job
 
 Every qualifying job's metrics are accumulated into the workflow `Result` (same
 plumbing as `storage_usage` / `compute_usage`), giving one KPI to monitor and be
-motivated to improve a whole pipeline. Stored as running sums (exact merge);
-percentages are derived by `PipelineUtilization.to_summary`:
+motivated to improve a whole pipeline. Stored as running sums (associative
+merge); percentages are derived by `PipelineUtilization.to_summary`. Stall
+percentages are the duration-weighted **average share of qualifying job-time**
+under pressure — not a single elapsed-workflow fraction (jobs run in parallel on
+different runners). Per-job contributions are reconstructed from rounded,
+sampled-window averages, so they are estimates rather than bit-exact:
 
 | Summary field | Meaning & weighting |
 |---|---|

--- a/ci/praktika/host_metrics.md
+++ b/ci/praktika/host_metrics.md
@@ -58,7 +58,9 @@ percentages are derived by `PipelineUtilization.to_summary`:
 | Summary field | Meaning & weighting |
 |---|---|
 | `jobs`, `wall_time_s` | Qualifying jobs counted and their total runtime. |
-| `cpu_util_pct` / `mem_util_pct` | Utilization, weighted by **provisioned resource-time** — core-seconds (`cpu_count × duration`) for CPU, GB-seconds (`mem_total_gb × duration`) for RAM. A true efficiency ratio: used ÷ provisioned. A bigger runner and/or longer job impacts it more. |
+| `cpu_hours` / `mem_gb_hours` / `disk_gb_hours` | Provisioned capacity-time (cores/GB × duration), in hours. |
+| `cpu_util_pct` / `mem_util_pct` | Utilization, weighted by **provisioned resource-time** — core-seconds (`cpu_count × duration`) for CPU, GB-seconds (`mem_total_gb × duration`) for RAM. A true efficiency ratio: used ÷ provisioned. A bigger runner and/or longer job impacts it more. Uses the whole-run averages. |
+| `disk_util_pct` | Disk uses the **peak** footprint (you size a disk for its high-water mark), weighted by disk-GB × duration. |
 | `cpu_stall_pct` / `mem_stall_pct` / `io_stall_pct` | `some`-stall, a wall-clock pressure fraction → **duration-weighted** ("% of pipeline runtime under pressure"). |
 | `mem_full_pct` / `io_full_pct` | `full`-stall wastes every core, so weighted by **core-seconds** — the share of provisioned CPU wasted while the box made no progress. |
 

--- a/ci/praktika/host_metrics.md
+++ b/ci/praktika/host_metrics.md
@@ -1,0 +1,75 @@
+# Host metrics
+
+Praktika samples whole-VM resource usage while each job runs and stores it in the
+job's `Result.ext["metrics"]`, renders it in `json.html`, labels over/under-utilized
+runners, and accumulates a pipeline-wide KPI into the workflow `Result`.
+
+Collection is dependency-free (`/proc/stat`, `/proc/meminfo`, `os.statvfs`,
+`/proc/pressure/*`), runs on the host so it covers the whole VM even for
+dockerized jobs, and is a no-op on non-Linux. See `host_metrics.py`. Sampling
+covers the job command only (not praktika pre/post-run).
+
+## Job level — `Result.ext["metrics"]`
+
+`/proc` is read at a fine cadence (`HOST_METRICS_FINE_INTERVAL_SEC`, default
+`0.25s`) and one aggregated point is emitted per reporting window
+(`HOST_METRICS_SAMPLE_INTERVAL_SEC`, default `1s`), so short bursts survive as
+the window's peak instead of being averaged away.
+
+| Field | Meaning |
+|---|---|
+| `duration` | Sampled command runtime, seconds. |
+| `cpu_count` | Logical CPUs (whole-VM `cpu%` denominator). |
+| `mem_total_gb` / `disk_total_gb` | Total RAM / workspace-filesystem size. |
+| `series.cpu` / `series.mem` / `series.disk` | Timelines of `[t, avg, peak]` (percent), decimated to `HOST_METRICS_MAX_POINTS` while preserving the envelope. |
+| `averages.{cpu,mem,disk}` | Whole-run **time-weighted** average utilization %. |
+| `peaks.{cpu,mem,disk}` | Exact max utilization % over every fine sample (never decimated away); `mem_gb` / `disk_gb` are the same in absolute units. |
+| `psi.cpu_s` | Seconds at least one task stalled waiting for CPU (PSI `some`). |
+| `psi.mem_some_s` / `psi.mem_full_s` | Seconds ≥1 task / **all** tasks stalled on memory. |
+| `psi.io_some_s` / `psi.io_full_s` | Seconds ≥1 task / **all** tasks stalled on I/O. |
+| `n_raw` / `n_windows` | Fine-sample count / emitted window count. |
+
+`disk` and `psi` are omitted when unavailable (bad `HOST_METRICS_DISK_PATH`,
+kernel without PSI). `peaks` are rate-independent; PSI totals are accumulated by
+the kernel continuously, so they capture contention even between samples.
+
+### Utilization labels
+
+Applied via `Result.set_label` to jobs worth right-sizing — those that ran at
+least `HOST_METRICS_MIN_LABEL_DURATION_SEC` (30 min) **or** on a runner with more
+than `HOST_METRICS_MIN_LABEL_MEM_GB` (15 GB) of RAM — and never to skipped jobs.
+
+| Label | Trigger |
+|---|---|
+| `under-utilized RAM` | peak RAM < 50% (provision for the peak) |
+| `under-utilized CPU` | whole-run avg CPU < 20% (bursts don't justify more cores) |
+| `ram-pressure` | peak RAM ≥ 95% **or** memory full-stall > 2% of runtime |
+| `cpu-bound` | CPU stall > 50% of runtime |
+| `io-bound` | I/O stall > 40% of runtime |
+| `disk-almost-full` | peak disk ≥ 85% |
+
+## Workflow level — `Result.ext["pipeline_utilization"]`
+
+Every qualifying job's metrics are accumulated into the workflow `Result` (same
+plumbing as `storage_usage` / `compute_usage`), giving one KPI to monitor and be
+motivated to improve a whole pipeline. Stored as running sums (exact merge);
+percentages are derived by `PipelineUtilization.to_summary`:
+
+| Summary field | Meaning & weighting |
+|---|---|
+| `jobs`, `wall_time_s` | Qualifying jobs counted and their total runtime. |
+| `cpu_util_pct` / `mem_util_pct` | Utilization, weighted by **provisioned resource-time** — core-seconds (`cpu_count × duration`) for CPU, GB-seconds (`mem_total_gb × duration`) for RAM. A true efficiency ratio: used ÷ provisioned. A bigger runner and/or longer job impacts it more. |
+| `cpu_stall_pct` / `mem_stall_pct` / `io_stall_pct` | `some`-stall, a wall-clock pressure fraction → **duration-weighted** ("% of pipeline runtime under pressure"). |
+| `mem_full_pct` / `io_full_pct` | `full`-stall wastes every core, so weighted by **core-seconds** — the share of provisioned CPU wasted while the box made no progress. |
+
+Low utilization ⇒ over-provisioned pipeline (wasted spend); high stall ⇒
+contention / under-provisioning. The weighting normalizes across
+differently-sized runners so the numbers are comparable pipeline-wide.
+
+## Settings
+
+All knobs live in `settings.py` (overridable via the settings directory):
+`HOST_METRICS_ENABLED`, `HOST_METRICS_SAMPLE_INTERVAL_SEC`,
+`HOST_METRICS_FINE_INTERVAL_SEC`, `HOST_METRICS_MAX_POINTS`,
+`HOST_METRICS_FILE`, `HOST_METRICS_DISK_PATH`,
+`HOST_METRICS_MIN_LABEL_DURATION_SEC`, `HOST_METRICS_MIN_LABEL_MEM_GB`.

--- a/ci/praktika/host_metrics.md
+++ b/ci/praktika/host_metrics.md
@@ -12,8 +12,8 @@ covers the job command only (not praktika pre/post-run).
 ## Job level — `Result.ext["metrics"]`
 
 `/proc` is read at a fine cadence (`HOST_METRICS_FINE_INTERVAL_SEC`, default
-`0.25s`) and one aggregated point is emitted per reporting window
-(`HOST_METRICS_SAMPLE_INTERVAL_SEC`, default `1s`), so short bursts survive as
+`1s`) and one aggregated point is emitted (and written) per reporting window
+(`HOST_METRICS_SAMPLE_INTERVAL_SEC`, default `5s`), so short bursts survive as
 the window's peak instead of being averaged away.
 
 | Field | Meaning |

--- a/ci/praktika/host_metrics.py
+++ b/ci/praktika/host_metrics.py
@@ -53,6 +53,7 @@ class HostMetricsCollector:
     _UNDER_CPU_PCT = 20.0  # average CPU below this -> CPU over-provisioned
     _RAM_PRESSURE_PCT = 95.0  # peak RAM at/above this -> RAM under-provisioned
     _CPU_STALL_RATIO = 0.5  # cpu stall seconds / duration above this -> CPU-bound
+    _IO_STALL_RATIO = 0.4  # io stall seconds / duration above this -> IO-bound
     _DISK_WARN_PCT = 85.0  # peak disk at/above this -> almost full
 
     def __init__(
@@ -458,6 +459,7 @@ class HostMetricsCollector:
         disk_gb = metrics.get("disk_total_gb")
         mem_full_s = psi.get("mem_full_s", 0)
         cpu_s = psi.get("cpu_s", 0)
+        io_s = psi.get("io_some_s", 0)
 
         # RAM: pressure (under-provisioned) takes precedence over idle headroom.
         if (mem_peak is not None and mem_peak >= cls._RAM_PRESSURE_PCT) or mem_full_s:
@@ -489,6 +491,16 @@ class HostMetricsCollector:
                 (
                     "under-utilized CPU",
                     f"Average CPU only {cpu_avg}% - consider a smaller runner",
+                )
+            )
+
+        # IO: sustained stall waiting on storage.
+        io_ratio = io_s / duration if duration else 0
+        if io_ratio > cls._IO_STALL_RATIO:
+            labels.append(
+                (
+                    "io-bound",
+                    f"IO stalled {io_s}s ({round(100 * io_ratio)}% of runtime) - storage may be the bottleneck",
                 )
             )
 

--- a/ci/praktika/host_metrics.py
+++ b/ci/praktika/host_metrics.py
@@ -446,7 +446,10 @@ class HostMetricsCollector:
         if not metrics:
             return labels
         duration = metrics.get("duration") or 0
-        if duration < Settings.HOST_METRICS_MIN_LABEL_DURATION_SEC:
+        mem_gb = metrics.get("mem_total_gb") or 0
+        # Label only jobs worth right-sizing: either long enough, or on a host
+        # with substantial RAM (costly, so worth flagging even if short).
+        if duration < Settings.HOST_METRICS_MIN_LABEL_DURATION_SEC and mem_gb <= Settings.HOST_METRICS_MIN_LABEL_MEM_GB:
             return labels
 
         peaks = metrics.get("peaks", {})
@@ -455,7 +458,6 @@ class HostMetricsCollector:
         mem_peak = peaks.get("mem")
         cpu_avg = averages.get("cpu")
         disk_peak = peaks.get("disk")
-        mem_gb = metrics.get("mem_total_gb")
         disk_gb = metrics.get("disk_total_gb")
         mem_full_s = psi.get("mem_full_s", 0)
         cpu_s = psi.get("cpu_s", 0)

--- a/ci/praktika/host_metrics.py
+++ b/ci/praktika/host_metrics.py
@@ -48,6 +48,13 @@ class HostMetricsCollector:
     _PSI_MEM = "/proc/pressure/memory"
     _PSI_IO = "/proc/pressure/io"
 
+    # Utilization label thresholds (see classify). Percentages unless noted.
+    _UNDER_MEM_PCT = 50.0  # peak RAM below this -> RAM over-provisioned
+    _UNDER_CPU_PCT = 20.0  # average CPU below this -> CPU over-provisioned
+    _RAM_PRESSURE_PCT = 95.0  # peak RAM at/above this -> RAM under-provisioned
+    _CPU_STALL_RATIO = 0.5  # cpu stall seconds / duration above this -> CPU-bound
+    _DISK_WARN_PCT = 85.0  # peak disk at/above this -> almost full
+
     def __init__(
         self,
         out_file: str = Settings.HOST_METRICS_FILE,
@@ -77,6 +84,12 @@ class HostMetricsCollector:
         self._cpu_peak = 0.0
         self._mem_peak = 0.0
         self._disk_peak = 0.0
+        # Time-weighted running sums for whole-run averages (area = value * dt).
+        self._cpu_area = 0.0
+        self._mem_area = 0.0
+        self._disk_area = 0.0
+        self._dt_total = 0.0
+        self._disk_dt_total = 0.0
         self._n_fine = 0
         self._psi_start: Optional[Dict[str, int]] = None
         self._psi_end: Optional[Dict[str, int]] = None
@@ -200,6 +213,10 @@ class HostMetricsCollector:
             # Exact global peaks, immune to windowing/decimation.
             self._cpu_peak = max(self._cpu_peak, cpu_pct)
             self._mem_peak = max(self._mem_peak, mem_pct)
+            # Time-weighted running totals for the whole-run averages.
+            self._cpu_area += cpu_pct * dt
+            self._mem_area += mem_pct * dt
+            self._dt_total += dt
             # Disk is sampled independently: a failure here disables only the
             # disk series and leaves CPU/RAM/PSI intact.
             if self._disk_available:
@@ -211,6 +228,8 @@ class HostMetricsCollector:
                 else:
                     win_disk.append((disk_pct, dt))
                     self._disk_peak = max(self._disk_peak, disk_pct)
+                    self._disk_area += disk_pct * dt
+                    self._disk_dt_total += dt
             if now - window_start >= self._report_interval:
                 flush_window(now)
                 window_start = now
@@ -338,6 +357,12 @@ class HostMetricsCollector:
             "mem": round(self._mem_peak, 1),
             "mem_gb": round(mem_total_gb * self._mem_peak / 100.0, 2),
         }
+        averages = {
+            "cpu": round(self._cpu_area / self._dt_total, 1) if self._dt_total else 0.0,
+            "mem": round(self._mem_area / self._dt_total, 1) if self._dt_total else 0.0,
+        }
+        if self._disk_dt_total:
+            averages["disk"] = round(self._disk_area / self._disk_dt_total, 1)
         series = {
             "cpu": self._decimate([(s["t"], s["cpu"], s["cpu_peak"]) for s in samples], self._max_points),
             "mem": self._decimate([(s["t"], s["mem"], s["mem_peak"]) for s in samples], self._max_points),
@@ -350,6 +375,7 @@ class HostMetricsCollector:
             "n_raw": self._n_fine,
             "n_windows": len(samples),
             "peaks": peaks,
+            "averages": averages,
             "series": series,
         }
         # Disk is optional: present only when the disk path was sampled.
@@ -403,3 +429,76 @@ class HostMetricsCollector:
             result.extend(sorted(reps, key=lambda p: p[0]))
         result.append(last)
         return [[t, a, p] for t, a, p in result]
+
+    @classmethod
+    def classify(cls, metrics: Optional[Dict]) -> List[Tuple[str, str]]:
+        """Derive over/under-utilization labels from a compacted metrics dict.
+
+        Returns a list of ``(label, hint)`` pairs for ``Result.set_label``.
+        Only jobs that ran at least ``HOST_METRICS_MIN_LABEL_DURATION_SEC`` are
+        labelled - shorter runs are noisy and not worth right-sizing. RAM uses
+        the peak (you provision for the worst case); CPU uses the whole-run
+        average (brief bursts do not justify more cores); a large CPU stall or a
+        near-full disk are surfaced as their own warnings.
+        """
+        labels: List[Tuple[str, str]] = []
+        if not metrics:
+            return labels
+        duration = metrics.get("duration") or 0
+        if duration < Settings.HOST_METRICS_MIN_LABEL_DURATION_SEC:
+            return labels
+
+        peaks = metrics.get("peaks", {})
+        averages = metrics.get("averages", {})
+        psi = metrics.get("psi", {})
+        mem_peak = peaks.get("mem")
+        cpu_avg = averages.get("cpu")
+        disk_peak = peaks.get("disk")
+        mem_gb = metrics.get("mem_total_gb")
+        disk_gb = metrics.get("disk_total_gb")
+        mem_full_s = psi.get("mem_full_s", 0)
+        cpu_s = psi.get("cpu_s", 0)
+
+        # RAM: pressure (under-provisioned) takes precedence over idle headroom.
+        if (mem_peak is not None and mem_peak >= cls._RAM_PRESSURE_PCT) or mem_full_s:
+            labels.append(
+                (
+                    "ram-pressure",
+                    f"Peak RAM {mem_peak}% of {mem_gb}GB, memory stalled {mem_full_s}s - consider more RAM",
+                )
+            )
+        elif mem_peak is not None and mem_peak < cls._UNDER_MEM_PCT:
+            labels.append(
+                (
+                    "under-utilized RAM",
+                    f"Peak RAM only {mem_peak}% of {mem_gb}GB - consider a smaller runner",
+                )
+            )
+
+        # CPU: sustained contention (CPU-bound) vs mostly-idle cores.
+        stall_ratio = cpu_s / duration if duration else 0
+        if stall_ratio > cls._CPU_STALL_RATIO:
+            labels.append(
+                (
+                    "cpu-bound",
+                    f"CPU stalled {cpu_s}s ({round(100 * stall_ratio)}% of runtime) - consider more CPU",
+                )
+            )
+        elif cpu_avg is not None and cpu_avg < cls._UNDER_CPU_PCT:
+            labels.append(
+                (
+                    "under-utilized CPU",
+                    f"Average CPU only {cpu_avg}% - consider a smaller runner",
+                )
+            )
+
+        # Disk: nearly full.
+        if disk_peak is not None and disk_peak >= cls._DISK_WARN_PCT:
+            labels.append(
+                (
+                    "disk-almost-full",
+                    f"Peak disk {disk_peak}% of {disk_gb}GB",
+                )
+            )
+
+        return labels

--- a/ci/praktika/host_metrics.py
+++ b/ci/praktika/host_metrics.py
@@ -79,6 +79,7 @@ class HostMetricsCollector:
         self._samples: List[Dict[str, float]] = []
         self._mem_total_kb = 0
         self._disk_total_kb = 0
+        self._cpu_count = 0
         # Set in start() by probing disk_path; a bad path disables only the disk
         # series, never CPU/RAM/PSI.
         self._disk_available = False
@@ -107,6 +108,7 @@ class HostMetricsCollector:
         if self._started:
             return self
         self._started = True
+        self._cpu_count = self._read_cpu_count()
         # Truncate any stale file from a previous run in the same workspace.
         try:
             Path(self._out_file).parent.mkdir(parents=True, exist_ok=True)
@@ -250,6 +252,22 @@ class HostMetricsCollector:
         except OSError as e:
             print(f"WARNING: Failed to append host metrics sample: {e}")
 
+    def _read_cpu_count(self) -> int:
+        """Number of logical CPUs from the per-cpu lines in ``/proc/stat``.
+
+        Matches the whole-VM denominator of the aggregate ``cpu`` line, so it is
+        the right capacity for weighting CPU utilization by "core-seconds".
+        """
+        try:
+            count = 0
+            with open(self._CPU_STAT, "r", encoding="utf8") as f:
+                for line in f:
+                    if line.startswith("cpu") and len(line) > 3 and line[3].isdigit():
+                        count += 1
+            return count or 1
+        except OSError:
+            return 1
+
     def _read_cpu_times(self) -> Tuple[int, int]:
         """Return (idle_all, total) jiffies from the aggregate ``cpu`` line."""
         with open(self._CPU_STAT, "r", encoding="utf8") as f:
@@ -374,6 +392,7 @@ class HostMetricsCollector:
             "fine_interval": self._fine_interval,
             "duration": samples[-1]["t"] if samples else 0,
             "mem_total_gb": mem_total_gb,
+            "cpu_count": self._cpu_count,
             "n_raw": self._n_fine,
             "n_windows": len(samples),
             "peaks": peaks,
@@ -432,6 +451,18 @@ class HostMetricsCollector:
         result.append(last)
         return [[t, a, p] for t, a, p in result]
 
+    @staticmethod
+    def qualifies(metrics: Optional[Dict]) -> bool:
+        """Whether a job is substantial enough to label / count for the pipeline
+        utilization KPI: it ran long enough OR on a host with enough RAM. Short
+        jobs on small runners are too noisy and not worth right-sizing.
+        """
+        if not metrics:
+            return False
+        duration = metrics.get("duration") or 0
+        mem_gb = metrics.get("mem_total_gb") or 0
+        return duration >= Settings.HOST_METRICS_MIN_LABEL_DURATION_SEC or mem_gb > Settings.HOST_METRICS_MIN_LABEL_MEM_GB
+
     @classmethod
     def classify(cls, metrics: Optional[Dict]) -> List[Tuple[str, str]]:
         """Derive over/under-utilization labels from a compacted metrics dict.
@@ -444,15 +475,11 @@ class HostMetricsCollector:
         near-full disk are surfaced as their own warnings.
         """
         labels: List[Tuple[str, str]] = []
-        if not metrics:
-            return labels
-        duration = metrics.get("duration") or 0
-        mem_gb = metrics.get("mem_total_gb") or 0
-        # Label only jobs worth right-sizing: either long enough, or on a host
-        # with substantial RAM (costly, so worth flagging even if short).
-        if duration < Settings.HOST_METRICS_MIN_LABEL_DURATION_SEC and mem_gb <= Settings.HOST_METRICS_MIN_LABEL_MEM_GB:
+        if not cls.qualifies(metrics):
             return labels
 
+        duration = metrics.get("duration") or 0
+        mem_gb = metrics.get("mem_total_gb") or 0
         peaks = metrics.get("peaks", {})
         averages = metrics.get("averages", {})
         psi = metrics.get("psi", {})
@@ -469,14 +496,11 @@ class HostMetricsCollector:
         # over a long build) is noise, not pressure, so require a fraction of
         # the runtime rather than any non-zero value.
         mem_full_ratio = mem_full_s / duration if duration else 0
-        if (
-            mem_peak is not None and mem_peak >= cls._RAM_PRESSURE_PCT
-        ) or mem_full_ratio > cls._MEM_STALL_RATIO:
+        if (mem_peak is not None and mem_peak >= cls._RAM_PRESSURE_PCT) or mem_full_ratio > cls._MEM_STALL_RATIO:
             labels.append(
                 (
                     "ram-pressure",
-                    f"Peak RAM {mem_peak}% of {mem_gb}GB, memory stalled {mem_full_s}s "
-                    f"({round(100 * mem_full_ratio)}% of runtime) - consider more RAM",
+                    f"Peak RAM {mem_peak}% of {mem_gb}GB, memory stalled {mem_full_s}s ({round(100 * mem_full_ratio)}% of runtime) - consider more RAM",
                 )
             )
         elif mem_peak is not None and mem_peak < cls._UNDER_MEM_PCT:

--- a/ci/praktika/host_metrics.py
+++ b/ci/praktika/host_metrics.py
@@ -52,6 +52,7 @@ class HostMetricsCollector:
     _UNDER_MEM_PCT = 50.0  # peak RAM below this -> RAM over-provisioned
     _UNDER_CPU_PCT = 20.0  # average CPU below this -> CPU over-provisioned
     _RAM_PRESSURE_PCT = 95.0  # peak RAM at/above this -> RAM under-provisioned
+    _MEM_STALL_RATIO = 0.02  # mem full-stall / duration above this -> RAM pressure
     _CPU_STALL_RATIO = 0.5  # cpu stall seconds / duration above this -> CPU-bound
     _IO_STALL_RATIO = 0.4  # io stall seconds / duration above this -> IO-bound
     _DISK_WARN_PCT = 85.0  # peak disk at/above this -> almost full
@@ -464,11 +465,18 @@ class HostMetricsCollector:
         io_s = psi.get("io_some_s", 0)
 
         # RAM: pressure (under-provisioned) takes precedence over idle headroom.
-        if (mem_peak is not None and mem_peak >= cls._RAM_PRESSURE_PCT) or mem_full_s:
+        # Only a sustained memory full-stall counts - a brief blip (e.g. 0.01s
+        # over a long build) is noise, not pressure, so require a fraction of
+        # the runtime rather than any non-zero value.
+        mem_full_ratio = mem_full_s / duration if duration else 0
+        if (
+            mem_peak is not None and mem_peak >= cls._RAM_PRESSURE_PCT
+        ) or mem_full_ratio > cls._MEM_STALL_RATIO:
             labels.append(
                 (
                     "ram-pressure",
-                    f"Peak RAM {mem_peak}% of {mem_gb}GB, memory stalled {mem_full_s}s - consider more RAM",
+                    f"Peak RAM {mem_peak}% of {mem_gb}GB, memory stalled {mem_full_s}s "
+                    f"({round(100 * mem_full_ratio)}% of runtime) - consider more RAM",
                 )
             )
         elif mem_peak is not None and mem_peak < cls._UNDER_MEM_PCT:

--- a/ci/praktika/host_metrics.py
+++ b/ci/praktika/host_metrics.py
@@ -96,6 +96,11 @@ class HostMetricsCollector:
         self._n_fine = 0
         self._psi_start: Optional[Dict[str, int]] = None
         self._psi_end: Optional[Dict[str, int]] = None
+        # Monotonic start reference and the true elapsed span, used as the job
+        # duration so stall% is normalized by real wall time (not by the last
+        # sample timestamp, which lags when the sampler is starved under load).
+        self._t0 = 0.0
+        self._elapsed_s = 0.0
         self._started = False
         self._stopped = False
 
@@ -126,6 +131,7 @@ class HostMetricsCollector:
         except OSError as e:
             print(f"WARNING: disk path [{self._disk_path}] is not accessible ({e}) - disk series disabled")
             self._disk_available = False
+        self._t0 = time.monotonic()
         self._psi_start = self._read_psi()
         self._thread = threading.Thread(target=self._run, name="host-metrics", daemon=True)
         self._thread.start()
@@ -142,9 +148,13 @@ class HostMetricsCollector:
         self._stop_event.set()
         if self._thread is not None:
             self._thread.join(timeout=self._report_interval * 2 + 5)
-        # Fallback in case the thread was killed / timed out before recording it.
+        # Fallback if the thread was starved / timed out before recording these.
+        # Capturing the real elapsed span here (not the last sample timestamp) is
+        # what keeps stall% <= 100%: a starved sampler emits stale sample times,
+        # but the PSI delta always spans the true wall-clock interval.
         if self._psi_end is None:
             self._psi_end = self._read_psi()
+            self._elapsed_s = time.monotonic() - self._t0
         if not self._samples:
             return None
         return self._compact(self._samples)
@@ -153,7 +163,7 @@ class HostMetricsCollector:
         # The first /proc/stat read only establishes a baseline; CPU% needs a
         # delta between two reads, so no sample is emitted for it.
         prev_cpu = self._read_cpu_times()
-        start = time.monotonic()
+        start = self._t0
         window_start = start
         last_time = start
         # Each entry is (value, dt) so the window average can be time-weighted:
@@ -241,9 +251,11 @@ class HostMetricsCollector:
                 break
 
         # Emit the trailing partial window and capture PSI as close to the real
-        # end of the job as possible.
+        # end of the job as possible. Record the true elapsed span (>= the PSI
+        # delta interval) so stall percentages stay bounded by 100%.
         flush_window(time.monotonic())
         self._psi_end = self._read_psi()
+        self._elapsed_s = time.monotonic() - self._t0
 
     def _append_to_fs(self, sample: Dict[str, float]):
         try:
@@ -390,7 +402,9 @@ class HostMetricsCollector:
         result = {
             "interval": self._report_interval,
             "fine_interval": self._fine_interval,
-            "duration": samples[-1]["t"] if samples else 0,
+            "duration": round(self._elapsed_s, 1)
+            if self._elapsed_s
+            else (samples[-1]["t"] if samples else 0),
             "mem_total_gb": mem_total_gb,
             "cpu_count": self._cpu_count,
             "n_raw": self._n_fine,

--- a/ci/praktika/host_metrics.py
+++ b/ci/praktika/host_metrics.py
@@ -49,7 +49,7 @@ class HostMetricsCollector:
     _PSI_IO = "/proc/pressure/io"
 
     # Utilization label thresholds (see classify). Percentages unless noted.
-    _UNDER_MEM_PCT = 50.0  # peak RAM below this -> RAM over-provisioned
+    _UNDER_MEM_PCT = 40.0  # peak RAM below this -> RAM over-provisioned
     _UNDER_CPU_PCT = 20.0  # average CPU below this -> CPU over-provisioned
     _RAM_PRESSURE_PCT = 95.0  # peak RAM at/above this -> RAM under-provisioned
     _MEM_STALL_RATIO = 0.02  # mem full-stall / duration above this -> RAM pressure

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1380,9 +1380,11 @@
         if (!u || !u.cpu_core_s) return;
         const CPU_COLOR = "#4e79a7";
         const MEM_COLOR = "#e15759";
+        const DISK_COLOR = "#59a14f";
         const pct = (area, weight) => (weight ? area / weight : 0);
         const cpuUtil = pct(u.cpu_used_area, u.cpu_core_s);
         const memUtil = pct(u.mem_used_area, u.mem_gb_s);
+        const diskUtil = pct(u.disk_used_area, u.disk_gb_s);
         // "some" stalls are wall-clock pressure fractions -> weighted by runtime;
         // "full" stalls waste every core -> weighted by provisioned core-seconds.
         const cpuStall = pct(u.cpu_stall_area, u.wall_time_s);
@@ -1390,6 +1392,10 @@
         const ioStall = pct(u.io_stall_area, u.wall_time_s);
         const memFull = pct(u.mem_full_area, u.cpu_core_s);
         const ioFull = pct(u.io_full_area, u.cpu_core_s);
+        // Provisioned capacity-time, in hours (cores/GB * duration).
+        const cpuHours = u.cpu_core_s / 3600;
+        const memHours = u.mem_gb_s / 3600;
+        const diskHours = u.disk_gb_s / 3600;
 
         const statusContainer = document.getElementById("status-container");
         const wrapper = document.createElement("div");
@@ -1397,9 +1403,19 @@
 
         const title = document.createElement("div");
         title.style.fontSize = "0.8em";
-        title.style.marginBottom = "2px";
-        title.textContent = `pipeline utilization (${u.jobs} job${u.jobs === 1 ? "" : "s"})`;
+        title.textContent = "pipeline utilization";
         wrapper.appendChild(title);
+
+        // Faded sub-line: job count and provisioned capacity-time.
+        const sub = document.createElement("div");
+        sub.style.fontSize = "0.7em";
+        sub.style.opacity = "0.55";
+        sub.style.marginBottom = "4px";
+        const fmtH = (h) => (h >= 100 ? Math.round(h) : h.toFixed(1));
+        sub.textContent =
+            `${u.jobs} job${u.jobs === 1 ? "" : "s"} · ${fmtH(cpuHours)} cpu-h · ${fmtH(memHours)} GiB-h` +
+            (u.disk_gb_s ? ` · ${fmtH(diskHours)} disk-GiB-h` : "");
+        wrapper.appendChild(sub);
 
         const cols = document.createElement("div");
         cols.style.display = "flex";
@@ -1423,6 +1439,9 @@
         const utilCol = mkCol("left");
         addRow(utilCol, `<span style="color:${CPU_COLOR}">■</span> cpu ${cpuUtil.toFixed(0)}%`);
         addRow(utilCol, `<span style="color:${MEM_COLOR}">■</span> ram ${memUtil.toFixed(0)}%`);
+        if (u.disk_gb_s) {
+            addRow(utilCol, `<span style="color:${DISK_COLOR}">■</span> disk ${diskUtil.toFixed(0)}%`);
+        }
         cols.appendChild(utilCol);
 
         const stallCol = mkCol("right");
@@ -1813,7 +1832,7 @@
             nameLine.style.whiteSpace = "normal";
             nameLine.style.overflow = "hidden";
             nameLine.style.maxWidth = "100%";
-            nameLine.style.height = "2.6em"; // Reserve space for 2 lines
+            nameLine.style.height = "3.9em"; // Reserve space for 3 lines
             nameLine.style.lineHeight = "1.3em";
             nameLine.style.textAlign = "left";
             widget.appendChild(nameLine);

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1383,9 +1383,13 @@
         const pct = (area, weight) => (weight ? area / weight : 0);
         const cpuUtil = pct(u.cpu_used_area, u.cpu_core_s);
         const memUtil = pct(u.mem_used_area, u.mem_gb_s);
-        const cpuStall = pct(u.cpu_stall_area, u.cpu_core_s);
-        const memStall = pct(u.mem_stall_area, u.mem_gb_s);
-        const ioStall = pct(u.io_stall_area, u.cpu_core_s);
+        // "some" stalls are wall-clock pressure fractions -> weighted by runtime;
+        // "full" stalls waste every core -> weighted by provisioned core-seconds.
+        const cpuStall = pct(u.cpu_stall_area, u.wall_time_s);
+        const memStall = pct(u.mem_stall_area, u.wall_time_s);
+        const ioStall = pct(u.io_stall_area, u.wall_time_s);
+        const memFull = pct(u.mem_full_area, u.cpu_core_s);
+        const ioFull = pct(u.io_full_area, u.cpu_core_s);
 
         const statusContainer = document.getElementById("status-container");
         const wrapper = document.createElement("div");
@@ -1424,8 +1428,8 @@
         const stallCol = mkCol("right");
         stallCol.style.opacity = "0.7";
         addRow(stallCol, `cpu stalled ${cpuStall.toFixed(0)}%`);
-        addRow(stallCol, `mem stalled ${memStall.toFixed(0)}%`);
-        addRow(stallCol, `io stalled ${ioStall.toFixed(0)}%`);
+        addRow(stallCol, `mem stalled ${memStall.toFixed(0)}%` + (memFull >= 1 ? ` (full ${memFull.toFixed(0)}%)` : ""));
+        addRow(stallCol, `io stalled ${ioStall.toFixed(0)}%` + (ioFull >= 1 ? ` (full ${ioFull.toFixed(0)}%)` : ""));
         cols.appendChild(stallCol);
 
         wrapper.appendChild(cols);

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1381,7 +1381,7 @@
         const CPU_COLOR = "#4e79a7";
         const MEM_COLOR = "#e15759";
         const DISK_COLOR = "#59a14f";
-        const pct = (area, weight) => (weight ? area / weight : 0);
+        const pct = (area, weight) => (weight ? Math.min(100, area / weight) : 0);
         const cpuUtil = pct(u.cpu_used_area, u.cpu_core_s);
         const memUtil = pct(u.mem_used_area, u.mem_gb_s);
         const diskUtil = pct(u.disk_used_area, u.disk_gb_s);

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1372,6 +1372,66 @@
         statusContainer.appendChild(wrapper);
     }
 
+    // Whole-pipeline utilization KPI, accumulated across qualifying jobs into
+    // the workflow Result (see PipelineUtilization). Only present on the
+    // workflow-level result; values are capacity-time-weighted running sums, so
+    // the percentages are derived here as area / provisioned-resource-seconds.
+    function addPipelineUtilizationWidget(u) {
+        if (!u || !u.cpu_core_s) return;
+        const CPU_COLOR = "#4e79a7";
+        const MEM_COLOR = "#e15759";
+        const pct = (area, weight) => (weight ? area / weight : 0);
+        const cpuUtil = pct(u.cpu_used_area, u.cpu_core_s);
+        const memUtil = pct(u.mem_used_area, u.mem_gb_s);
+        const cpuStall = pct(u.cpu_stall_area, u.cpu_core_s);
+        const memStall = pct(u.mem_stall_area, u.mem_gb_s);
+        const ioStall = pct(u.io_stall_area, u.cpu_core_s);
+
+        const statusContainer = document.getElementById("status-container");
+        const wrapper = document.createElement("div");
+        wrapper.className = "status-widget";
+
+        const title = document.createElement("div");
+        title.style.fontSize = "0.8em";
+        title.style.marginBottom = "2px";
+        title.textContent = `pipeline utilization (${u.jobs} job${u.jobs === 1 ? "" : "s"})`;
+        wrapper.appendChild(title);
+
+        const cols = document.createElement("div");
+        cols.style.display = "flex";
+        cols.style.justifyContent = "space-between";
+        cols.style.gap = "10px";
+        cols.style.fontSize = "0.75em";
+        const mkCol = (align) => {
+            const c = document.createElement("div");
+            c.style.display = "flex";
+            c.style.flexDirection = "column";
+            c.style.whiteSpace = "nowrap";
+            c.style.textAlign = align;
+            return c;
+        };
+        const addRow = (col, html) => {
+            const d = document.createElement("div");
+            d.innerHTML = html;
+            col.appendChild(d);
+        };
+
+        const utilCol = mkCol("left");
+        addRow(utilCol, `<span style="color:${CPU_COLOR}">■</span> cpu ${cpuUtil.toFixed(0)}%`);
+        addRow(utilCol, `<span style="color:${MEM_COLOR}">■</span> ram ${memUtil.toFixed(0)}%`);
+        cols.appendChild(utilCol);
+
+        const stallCol = mkCol("right");
+        stallCol.style.opacity = "0.7";
+        addRow(stallCol, `cpu stalled ${cpuStall.toFixed(0)}%`);
+        addRow(stallCol, `mem stalled ${memStall.toFixed(0)}%`);
+        addRow(stallCol, `io stalled ${ioStall.toFixed(0)}%`);
+        cols.appendChild(stallCol);
+
+        wrapper.appendChild(cols);
+        statusContainer.appendChild(wrapper);
+    }
+
     function addStorageUsageChartToStatus(usage_data) {
         const statusContainer = document.getElementById("status-container");
 
@@ -2346,6 +2406,7 @@
             addTimeTraceWidget(result.results, statusWidget, originalWorkflowDetails);
         }
         addStorageUsageChartToStatus(result.ext?.storage_usage)
+        addPipelineUtilizationWidget(result.ext?.pipeline_utilization)
         addHostMetricsChart(result.ext?.metrics)
     }
 

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1400,6 +1400,10 @@ class _ResultS3:
                 workflow_result.ext["compute_usage"] = workflow_compute_usage
 
             if pipeline_utilization:
+                # TODO: like storage_usage/compute_usage above, this only adds -
+                # a job rerun double-counts its contribution (jobs, *_area, ...).
+                # Reruns are rare and this is a monitoring aggregate; make it
+                # rerun-safe (recompute from the workflow sub-results) if needed.
                 workflow_pipeline_utilization = PipelineUtilization.from_dict(workflow_result.ext.get("pipeline_utilization", {})).merge_with(pipeline_utilization)
                 workflow_result.ext["pipeline_utilization"] = workflow_pipeline_utilization
 

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -17,7 +17,7 @@ from ._environment import _Environment
 from .event import Event
 from .s3 import S3
 from .settings import Settings
-from .usage import ComputeUsage, StorageUsage
+from .usage import ComputeUsage, PipelineUtilization, StorageUsage
 from .utils import ContextManager, MetaClasses, Shell, Utils
 
 from .info import Info
@@ -134,9 +134,7 @@ class Result(MetaClasses.Serializable):
         if isinstance(status, bool):
             status = Result.Status.OK if status else Result.Status.FAIL
         if not results and not status:
-            print(
-                "WARNING: No results and no status provided - setting status to error"
-            )
+            print("WARNING: No results and no status provided - setting status to error")
             status = Result.Status.ERROR
         if not name:
             name = _Environment.get().JOB_NAME
@@ -148,9 +146,7 @@ class Result(MetaClasses.Serializable):
                 start_time = preresult.start_time
                 duration = datetime.datetime.now().timestamp() - preresult.start_time
             except Exception:
-                print(
-                    f"WARNING: Failed to get start time for [{name}] - start time and duration won't be set"
-                )
+                print(f"WARNING: Failed to get start time for [{name}] - start time and duration won't be set")
         else:
             start_time = stopwatch.start_time
             duration = stopwatch.duration
@@ -170,9 +166,7 @@ class Result(MetaClasses.Serializable):
                     Result.Status.XFAIL,
                 ):
                     continue
-                elif result.status in (
-                    Result.Status.ERROR,
-                ):
+                elif result.status in (Result.Status.ERROR,):
                     result_status = Result.Status.ERROR
                     break
                 elif result.status in (
@@ -182,9 +176,7 @@ class Result(MetaClasses.Serializable):
                 ):
                     result_status = Result.Status.FAIL
                 else:
-                    Utils.raise_with_error(
-                        f"Unexpected result status [{result.status}] for [{result.name}]"
-                    )
+                    Utils.raise_with_error(f"Unexpected result status [{result.status}] for [{result.name}]")
         if results and with_info_from_results:
             for result in results:
                 if result.info:
@@ -291,16 +283,12 @@ class Result(MetaClasses.Serializable):
             files = [files]
         if strict:
             for file in files:
-                assert Path(
-                    file
-                ).is_file(), f"Not valid file [{file}] from file list [{files}]"
+                assert Path(file).is_file(), f"Not valid file [{file}] from file list [{files}]"
         if not self.files:
             self.files = []
         for file in self.files:
             if file in files:
-                print(
-                    f"WARNING: File [{file}] is already present in Result [{self.name}] - skip"
-                )
+                print(f"WARNING: File [{file}] is already present in Result [{self.name}] - skip")
                 files.remove(file)
         self.files += files
         self._dump_if_persisted()
@@ -348,9 +336,7 @@ class Result(MetaClasses.Serializable):
         ``Info.add_workflow_warning`` when the message should appear on the job
         level and be propagated to the top (workflow) level.
         """
-        self.ext.setdefault("warnings", []).append(
-            {"message": message, "from": self.name}
-        )
+        self.ext.setdefault("warnings", []).append({"message": message, "from": self.name})
         self._dump_if_persisted()
         return self
 
@@ -360,9 +346,7 @@ class Result(MetaClasses.Serializable):
 
         See ``add_warning`` for propagation semantics.
         """
-        self.ext.setdefault("errors", []).append(
-            {"message": message, "from": self.name}
-        )
+        self.ext.setdefault("errors", []).append({"message": message, "from": self.name})
         self._dump_if_persisted()
         return self
 
@@ -372,9 +356,7 @@ class Result(MetaClasses.Serializable):
 
         See ``add_warning`` for propagation semantics.
         """
-        self.ext.setdefault("notes", []).append(
-            {"message": message, "from": self.name}
-        )
+        self.ext.setdefault("notes", []).append({"message": message, "from": self.name})
         self._dump_if_persisted()
         return self
 
@@ -414,9 +396,7 @@ class Result(MetaClasses.Serializable):
         if self.start_time:
             self.duration = datetime.datetime.now().timestamp() - self.start_time
         else:
-            print(
-                f"NOTE: start_time is not set for job [{self.name}] Result - do not update duration"
-            )
+            print(f"NOTE: start_time is not set for job [{self.name}] Result - do not update duration")
         return self
 
     def set_timing(self, stopwatch: Utils.Stopwatch):
@@ -440,9 +420,7 @@ class Result(MetaClasses.Serializable):
           falls back to Result.LABEL_HINTS[label] when registered. On an existing
           label, omitting link/hint preserves the current value.
         """
-        assert isinstance(label, str), (
-            f"label must be a string, got {type(label).__name__}"
-        )
+        assert isinstance(label, str), f"label must be a string, got {type(label).__name__}"
 
         labels = self.ext.setdefault("labels", [])
         for i, existing in enumerate(labels):
@@ -482,9 +460,7 @@ class Result(MetaClasses.Serializable):
     def remove_label(self, label):
         if not self.ext.get("labels", None):
             return self
-        self.ext["labels"] = [
-            l for l in self.ext["labels"] if self._label_name(l) != label
-        ]
+        self.ext["labels"] = [l for l in self.ext["labels"] if self._label_name(l) != label]
         return self
 
     def get_labels(self):
@@ -569,9 +545,7 @@ class Result(MetaClasses.Serializable):
 
             # Run pytest
             Shell.run(full_command, log_file=logfile, timeout=timeout)
-            test_result = ResultTranslator.from_pytest_jsonl(
-                pytest_report_file=pytest_report_file
-            )
+            test_result = ResultTranslator.from_pytest_jsonl(pytest_report_file=pytest_report_file)
 
         return Result.create_from(
             name=name,
@@ -624,9 +598,7 @@ class Result(MetaClasses.Serializable):
                 # This is a leaf - add the path to its ext
                 if not hasattr(r, "ext") or r.ext is None:
                     r.ext = {}
-                r.ext["result_tree_path"] = path + [
-                    r.name
-                ]  # store hierarchical path to the leaf so that report can build a navigation link to it
+                r.ext["result_tree_path"] = path + [r.name]  # store hierarchical path to the leaf so that report can build a navigation link to it
                 leaves.append(r)
             else:
                 # Recursively process children with updated path
@@ -653,16 +625,12 @@ class Result(MetaClasses.Serializable):
             if result_.name == result.name:
                 if result_.is_skipped() and result.is_dropped():
                     # job was skipped in workflow configuration by a user' hook
-                    print(
-                        f"NOTE: Job [{result.name}] has completed status [{result_.status}] - do not switch status to [{result.status}]"
-                    )
+                    print(f"NOTE: Job [{result.name}] has completed status [{result_.status}] - do not switch status to [{result.status}]")
                     continue
                 if drop_nested_results:
                     # self.results[i] = self._filter_out_ok_results(result)
                     self.results[i] = copy.deepcopy(result)
-                    self.results[i].results = self._flat_failed_leaves(
-                        result, path=[self.name]
-                    )
+                    self.results[i].results = self._flat_failed_leaves(result, path=[self.name])
                 else:
                     self.results[i] = result
         self._update_status()
@@ -825,10 +793,7 @@ class Result(MetaClasses.Serializable):
                     last_run_idx = idx
                     crashed_test = line[bracket_end + 1 :].strip()
                 for line in log_lines[last_run_idx + 1 :]:
-                    if not crash_info and (
-                        any(line.startswith(p) for p in _ERROR_PREFIXES)
-                        or any(s in line for s in _ERROR_SUBSTRINGS)
-                    ):
+                    if not crash_info and (any(line.startswith(p) for p in _ERROR_PREFIXES) or any(s in line for s in _ERROR_SUBSTRINGS)):
                         crash_info = line.strip()
                     if not repro_info and line.startswith("(while ") and "SELECT " in line:
                         repro_info = line
@@ -842,9 +807,7 @@ class Result(MetaClasses.Serializable):
             # was running when the binary died; fall back to the filter expression only when the
             # log had no "[ RUN      ]" marker at all.
             crashed_test = crashed_test or gtest_filter.rstrip(".*") or "unknown"
-            result.set_results(
-                [Result(name=crashed_test, status=Result.Status.FAIL, info=crash_info or info)]
-            )
+            result.set_results([Result(name=crashed_test, status=Result.Status.FAIL, info=crash_info or info)])
             result.set_status(Result.Status.FAIL)
         return result
 
@@ -905,9 +868,7 @@ class Result(MetaClasses.Serializable):
         with ContextManager.cd(workdir):
             for command_ in command:
                 if callable(command_):
-                    assert (
-                        retries == 1
-                    ), "FIXME: retry not supported for python callables"
+                    assert retries == 1, "FIXME: retry not supported for python callables"
                     # If command is a Python function, call it with provided arguments
                     if with_info or with_info_on_failure:
                         buffer = io.StringIO()
@@ -926,18 +887,12 @@ class Result(MetaClasses.Serializable):
                         )
                     res = result if isinstance(result, bool) else not bool(result)
                     if (with_info_on_failure and not res) or with_info:
-                        output = (
-                            buffer.getvalue()
-                            if isinstance(result, bool)
-                            else str(result)
-                        )
+                        output = buffer.getvalue() if isinstance(result, bool) else str(result)
                         info_lines.extend(output.splitlines())
                         # Write callable output to log file for consistency with shell commands
                         if log_file and output:
                             with open(log_file, "a") as f:
-                                f.write(
-                                    output if output.endswith("\n") else output + "\n"
-                                )
+                                f.write(output if output.endswith("\n") else output + "\n")
                 else:
                     # Run shell command in a specified directory with logging and verbosity
                     exit_code = Shell.run(
@@ -994,21 +949,15 @@ class Result(MetaClasses.Serializable):
 
                 new_info_lines = []
                 if truncated_before > 0:
-                    new_info_lines.append(
-                        f"~~~~~ truncated {truncated_before} lines at the beginning ~~~~~"
-                    )
+                    new_info_lines.append(f"~~~~~ truncated {truncated_before} lines at the beginning ~~~~~")
                 new_info_lines.extend(info_lines[start_idx:end_idx])
                 if truncated_after > 0:
-                    new_info_lines.append(
-                        f"~~~~~ truncated {truncated_after} lines at the end ~~~~~"
-                    )
+                    new_info_lines.append(f"~~~~~ truncated {truncated_after} lines at the end ~~~~~")
                 info_lines = new_info_lines
             else:
                 # Default behavior: keep the last MAX_LINES_IN_INFO lines
                 truncated_count = len(info_lines) - MAX_LINES_IN_INFO
-                info_lines = [
-                    f"~~~~~ truncated {truncated_count} lines ~~~~~"
-                ] + info_lines[-MAX_LINES_IN_INFO:]
+                info_lines = [f"~~~~~ truncated {truncated_count} lines ~~~~~"] + info_lines[-MAX_LINES_IN_INFO:]
             truncated = True
 
         # Create and return the result object with status and log file (if any)
@@ -1069,20 +1018,13 @@ class Result(MetaClasses.Serializable):
         if len(info_lines) > max_info_lines_cnt:
             truncated_count = len(info_lines) - max_info_lines_cnt
             if truncate_from_top:
-                info_lines = [
-                    f"~~~~~ truncated {truncated_count} lines ~~~~~"
-                ] + info_lines[-max_info_lines_cnt:]
+                info_lines = [f"~~~~~ truncated {truncated_count} lines ~~~~~"] + info_lines[-max_info_lines_cnt:]
             else:
-                info_lines = info_lines[:max_info_lines_cnt] + [
-                    f"~~~~~ truncated {truncated_count} lines ~~~~~"
-                ]
+                info_lines = info_lines[:max_info_lines_cnt] + [f"~~~~~ truncated {truncated_count} lines ~~~~~"]
 
         # Truncate individual lines if too long
         if max_line_length > 0:
-            info_lines = [
-                line[:max_line_length] + "..." if len(line) > max_line_length else line
-                for line in info_lines
-            ]
+            info_lines = [line[:max_line_length] + "..." if len(line) > max_line_length else line for line in info_lines]
 
         return "\n".join(info_lines)
 
@@ -1111,11 +1053,7 @@ class Result(MetaClasses.Serializable):
         sub_indent = indent + "  "
 
         # Check if colors should be used: local run + TTY + terminal supports colors
-        use_colors = (
-            Info().is_local_run
-            and sys.stdout.isatty()
-            and os.environ.get("TERM", "").lower() != "dumb"
-        )
+        use_colors = Info().is_local_run and sys.stdout.isatty() and os.environ.get("TERM", "").lower() != "dumb"
 
         # Define color variables once to avoid repetition
         status_color = ""
@@ -1135,7 +1073,7 @@ class Result(MetaClasses.Serializable):
                 frame_color = _Colors.YELLOW
 
         if add_frame:
-            output = f"{indent}{frame_color}{'+'*80}{reset_color}\n"
+            output = f"{indent}{frame_color}{'+' * 80}{reset_color}\n"
 
         if add_frame or not self.is_ok():
             # Capitalize status and only show name if it's not empty
@@ -1162,7 +1100,7 @@ class Result(MetaClasses.Serializable):
                 )
 
         if add_frame:
-            output += f"{indent}{frame_color}{'+'*80}{reset_color}\n"
+            output += f"{indent}{frame_color}{'+' * 80}{reset_color}\n"
 
         return output
 
@@ -1211,11 +1149,7 @@ class Result(MetaClasses.Serializable):
 
             results = result.get("results")
             if isinstance(results, list):
-                result["results"] = [
-                    {"name": r.get("name", ""), "status": r.get("status", "")}
-                    for r in results
-                    if isinstance(r, dict)
-                ]
+                result["results"] = [{"name": r.get("name", ""), "status": r.get("status", "")} for r in results if isinstance(r, dict)]
 
             # Keep only report_url from ext
             ext = result.get("ext")
@@ -1252,31 +1186,22 @@ class Result(MetaClasses.Serializable):
 
 
 class ResultInfo:
-    SETUP_ENV_JOB_FAILED = (
-        "Failed to set up job env, it is praktika bug or misconfiguration"
-    )
-    PRE_JOB_FAILED = (
-        "Failed to do a job pre-run step, it is praktika bug or misconfiguration"
-    )
+    SETUP_ENV_JOB_FAILED = "Failed to set up job env, it is praktika bug or misconfiguration"
+    PRE_JOB_FAILED = "Failed to do a job pre-run step, it is praktika bug or misconfiguration"
     KILLED = "Job killed or terminated, no Result provided"
-    NOT_FOUND_IMPOSSIBLE = (
-        "No Result file (bug, or job misbehaviour, must not ever happen)"
-    )
+    NOT_FOUND_IMPOSSIBLE = "No Result file (bug, or job misbehaviour, must not ever happen)"
     DROPPED_DUE_TO_PREVIOUS_FAILURE = "Dropped due to previous failure"
     TIMEOUT = "Timeout"
 
     GH_STATUS_ERROR = "Failed to set GH commit status"
     OPEN_ISSUES_CHECK_ERROR = "Failed to check open issues"
 
-    NOT_FINALIZED = (
-        "Job failed to produce Result due to a script error or CI runner issue"
-    )
+    NOT_FINALIZED = "Job failed to produce Result due to a script error or CI runner issue"
 
     S3_ERROR = "S3 call failure"
 
 
 class _ResultS3:
-
     # Map the ``kind`` field used in ``_Environment.REPORT_MESSAGES`` to the
     # ``ext`` bucket rendered by ``json.html``. Unknown kinds fall into notes.
     _REPORT_MESSAGE_KIND_TO_EXT_KEY = {
@@ -1294,9 +1219,7 @@ class _ResultS3:
         """
         for msg in messages:
             key = cls._REPORT_MESSAGE_KIND_TO_EXT_KEY.get(msg.get("kind"), "notes")
-            result.ext.setdefault(key, []).append(
-                {"message": msg["message"], "from": msg["from"]}
-            )
+            result.ext.setdefault(key, []).append({"message": msg["message"], "from": msg["from"]})
 
     @classmethod
     def copy_result_to_s3(cls, result, clean=False):
@@ -1357,9 +1280,7 @@ class _ResultS3:
         )
 
     @classmethod
-    def upload_result_files_to_s3(
-        cls, result: Result, s3_subprefix="", _uploaded_file_link=None
-    ):
+    def upload_result_files_to_s3(cls, result: Result, s3_subprefix="", _uploaded_file_link=None):
         parts = [
             s3_subprefix.strip("/"),
             Utils.normalize_string(result.name).strip("/"),
@@ -1380,9 +1301,7 @@ class _ResultS3:
         for file_str, file in unique_files.items():
             try:
                 if not Path(file).is_file():
-                    print(
-                        f"ERROR: Invalid file [{file}] in [{result.name}] - skip upload"
-                    )
+                    print(f"ERROR: Invalid file [{file}] in [{result.name}] - skip upload")
                     result.set_info(f"WARNING: File [{file}] was not found")
                     file_link = S3._upload_file_to_s3(file, upload_to_s3=False)
                 elif file in _uploaded_file_link:
@@ -1392,9 +1311,7 @@ class _ResultS3:
                     is_text = False
                     for text_file_suffix in Settings.TEXT_CONTENT_EXTENSIONS:
                         if file.endswith(text_file_suffix):
-                            print(
-                                f"File [{file}] matches Settings.TEXT_CONTENT_EXTENSIONS [{Settings.TEXT_CONTENT_EXTENSIONS}] - add text attribute for s3 object"
-                            )
+                            print(f"File [{file}] matches Settings.TEXT_CONTENT_EXTENSIONS [{Settings.TEXT_CONTENT_EXTENSIONS}] - add text attribute for s3 object")
                             is_text = True
                             break
                     file_link = S3._upload_file_to_s3(
@@ -1408,27 +1325,19 @@ class _ResultS3:
                 result.links.append(file_link)
             except Exception as e:
                 traceback.print_exc()
-                print(
-                    f"ERROR: Failed to upload file [{file}] for result [{result.name}]"
-                )
+                print(f"ERROR: Failed to upload file [{file}] for result [{result.name}]")
                 result.set_info(f"ERROR: Failed to upload file [{file}]: {e}")
         result.files = []
 
         # Upload assets in parallel (preserving relative paths for HTML interlinking)
         if result.assets:
-            asset_paths = [
-                Path(a).resolve() for a in result.assets if Path(a).is_file()
-            ]
+            asset_paths = [Path(a).resolve() for a in result.assets if Path(a).is_file()]
             if asset_paths:
                 common_root = os.path.commonpath([p.parent for p in asset_paths])
                 env = _Environment.get()
-                base_s3_prefix = f"{Settings.S3_REPORT_BUCKET}/{env.get_s3_prefix()}/{s3_subprefix}".replace(
-                    "//", "/"
-                )
+                base_s3_prefix = f"{Settings.S3_REPORT_BUCKET}/{env.get_s3_prefix()}/{s3_subprefix}".replace("//", "/")
 
-                print(
-                    f"INFO: Uploading {len(asset_paths)} assets to {base_s3_prefix} in parallel"
-                )
+                print(f"INFO: Uploading {len(asset_paths)} assets to {base_s3_prefix} in parallel")
                 with ThreadPoolExecutor(max_workers=50) as executor:
                     futures = {
                         executor.submit(
@@ -1461,6 +1370,7 @@ class _ResultS3:
         new_sub_results=None,
         storage_usage=None,
         compute_usage=None,
+        pipeline_utilization=None,
         report_messages=None,
         clear_report_sources=None,
     ):
@@ -1472,38 +1382,31 @@ class _ResultS3:
         MAX_ATTEMPTS = 50
 
         while attempt < MAX_ATTEMPTS:
-            version = cls.copy_result_from_s3_with_version(
-                Result.file_name_static(workflow_name)
-            )
+            version = cls.copy_result_from_s3_with_version(Result.file_name_static(workflow_name))
             workflow_result = Result.from_fs(workflow_name)
             prev_status = workflow_result.status
             if new_sub_results:
                 if isinstance(new_sub_results, Result):
                     new_sub_results = [new_sub_results]
                 for result_ in new_sub_results:
-                    workflow_result.update_sub_result(
-                        result_, drop_nested_results=True
-                    ).dump()
+                    workflow_result.update_sub_result(result_, drop_nested_results=True).dump()
             # TODO: consider not accumulating these 2 for reruns:
             if storage_usage:
-                workflow_storage_usage = StorageUsage.from_dict(
-                    workflow_result.ext.get("storage_usage", {})
-                ).merge_with(storage_usage)
+                workflow_storage_usage = StorageUsage.from_dict(workflow_result.ext.get("storage_usage", {})).merge_with(storage_usage)
                 workflow_result.ext["storage_usage"] = workflow_storage_usage
 
             if compute_usage:
-                workflow_compute_usage = ComputeUsage.from_dict(
-                    workflow_result.ext.get("compute_usage", {})
-                ).merge_with(compute_usage)
+                workflow_compute_usage = ComputeUsage.from_dict(workflow_result.ext.get("compute_usage", {})).merge_with(compute_usage)
                 workflow_result.ext["compute_usage"] = workflow_compute_usage
+
+            if pipeline_utilization:
+                workflow_pipeline_utilization = PipelineUtilization.from_dict(workflow_result.ext.get("pipeline_utilization", {})).merge_with(pipeline_utilization)
+                workflow_result.ext["pipeline_utilization"] = workflow_pipeline_utilization
 
             if clear_report_sources:
                 for key in cls._REPORT_MESSAGE_KIND_TO_EXT_KEY.values():
                     if key in workflow_result.ext:
-                        workflow_result.ext[key] = [
-                            e for e in workflow_result.ext[key]
-                            if e.get("from") not in clear_report_sources
-                        ]
+                        workflow_result.ext[key] = [e for e in workflow_result.ext[key] if e.get("from") not in clear_report_sources]
 
             if report_messages:
                 cls.append_report_messages(workflow_result, report_messages)
@@ -1595,9 +1498,7 @@ class ResultTranslator:
             )
 
         try:
-            with open(
-                cls.GTEST_RESULT_FILE, "r", encoding="utf-8", errors="ignore"
-            ) as j:
+            with open(cls.GTEST_RESULT_FILE, "r", encoding="utf-8", errors="ignore") as j:
                 report = json.load(j)
         except Exception as e:
             print(f"ERROR: failed to read json [{e}]")
@@ -1669,10 +1570,7 @@ class ResultTranslator:
         test_results.append(Result(report["name"], test_status, duration=tests_time))
 
         if not description:
-            description += (
-                f"fail: {failed_counter + error_counter}, "
-                f"passed: {total_counter - failed_counter - error_counter}"
-            )
+            description += f"fail: {failed_counter + error_counter}, passed: {total_counter - failed_counter - error_counter}"
 
         return (
             check_status,
@@ -1734,11 +1632,7 @@ class ResultTranslator:
                                     # Best-effort: mirror traceback builder from TestReport for dict shape
                                     try:
                                         lr_txt = ""
-                                        crash = (
-                                            longrepr.get("reprcrash")
-                                            if isinstance(longrepr, dict)
-                                            else None
-                                        )
+                                        crash = longrepr.get("reprcrash") if isinstance(longrepr, dict) else None
                                         if isinstance(crash, dict):
                                             p = crash.get("path")
                                             ln = crash.get("lineno")
@@ -1750,40 +1644,23 @@ class ResultTranslator:
                                                 seg.append(str(msg))
                                             if seg:
                                                 lr_txt += "\n".join(seg)
-                                        rt = (
-                                            longrepr.get("reprtraceback")
-                                            if isinstance(longrepr, dict)
-                                            else None
-                                        )
+                                        rt = longrepr.get("reprtraceback") if isinstance(longrepr, dict) else None
                                         if isinstance(rt, dict) and "reprentries" in rt:
                                             composed = []
                                             for re_entry in rt.get("reprentries", []):
                                                 dd = re_entry.get("data", {})
-                                                fileloc = (
-                                                    dd.get("reprfileloc", {})
-                                                    if isinstance(dd, dict)
-                                                    else {}
-                                                )
+                                                fileloc = dd.get("reprfileloc", {}) if isinstance(dd, dict) else {}
                                                 fpath = fileloc.get("path")
                                                 flineno = fileloc.get("lineno")
                                                 fmsg = fileloc.get("message")
                                                 header_parts = []
-                                                if (
-                                                    fpath is not None
-                                                    and flineno is not None
-                                                ):
-                                                    header_parts.append(
-                                                        f"File: {fpath}:{flineno}"
-                                                    )
+                                                if fpath is not None and flineno is not None:
+                                                    header_parts.append(f"File: {fpath}:{flineno}")
                                                 if fmsg:
                                                     header_parts.append(str(fmsg))
                                                 if header_parts:
-                                                    composed.append(
-                                                        " - ".join(header_parts)
-                                                    )
-                                                if isinstance(dd, dict) and dd.get(
-                                                    "lines"
-                                                ):
+                                                    composed.append(" - ".join(header_parts))
+                                                if isinstance(dd, dict) and dd.get("lines"):
                                                     composed.extend(dd["lines"])
                                             if composed:
                                                 if lr_txt:
@@ -1802,9 +1679,7 @@ class ResultTranslator:
                                             if isinstance(sec, list) and len(sec) == 2:
                                                 title, content = sec
                                                 if content:
-                                                    sec_chunks.append(
-                                                        f"===== {title} =====\n{content}"
-                                                    )
+                                                    sec_chunks.append(f"===== {title} =====\n{content}")
                                         if sec_chunks:
                                             info_parts.append("\n".join(sec_chunks))
                                     except Exception:
@@ -1832,11 +1707,7 @@ class ResultTranslator:
                             if "longrepr" in entry:
                                 data = entry["longrepr"]
                                 # reprcrash: include file:line and message if present
-                                if (
-                                    data
-                                    and isinstance(data, dict)
-                                    and "reprcrash" in data
-                                ):
+                                if data and isinstance(data, dict) and "reprcrash" in data:
                                     crash = data.get("reprcrash", {})
                                     path = crash.get("path")
                                     lineno = crash.get("lineno")
@@ -1851,39 +1722,24 @@ class ResultTranslator:
                                         if parts:
                                             traceback_str += "\n".join(parts)
                                 # reprtraceback: collect lines
-                                if (
-                                    data
-                                    and isinstance(data, dict)
-                                    and "reprtraceback" in data
-                                ):
+                                if data and isinstance(data, dict) and "reprtraceback" in data:
                                     rt = data.get("reprtraceback", {})
                                     if isinstance(rt, dict) and "reprentries" in rt:
                                         composed = []
                                         for re_entry in rt.get("reprentries", []):
                                             dd = re_entry.get("data", {})
                                             # include per-frame file location for full stack context
-                                            fileloc = (
-                                                dd.get("reprfileloc", {})
-                                                if isinstance(dd, dict)
-                                                else {}
-                                            )
+                                            fileloc = dd.get("reprfileloc", {}) if isinstance(dd, dict) else {}
                                             fpath = fileloc.get("path")
                                             flineno = fileloc.get("lineno")
                                             fmsg = fileloc.get("message")
                                             header_parts = []
-                                            if (
-                                                fpath is not None
-                                                and flineno is not None
-                                            ):
-                                                header_parts.append(
-                                                    f"File: {fpath}:{flineno}"
-                                                )
+                                            if fpath is not None and flineno is not None:
+                                                header_parts.append(f"File: {fpath}:{flineno}")
                                             if fmsg:
                                                 header_parts.append(str(fmsg))
                                             if header_parts:
-                                                composed.append(
-                                                    " - ".join(header_parts)
-                                                )
+                                                composed.append(" - ".join(header_parts))
                                             if isinstance(dd, dict) and dd.get("lines"):
                                                 composed.extend(dd["lines"])
                                         if composed:
@@ -1891,63 +1747,36 @@ class ResultTranslator:
                                                 traceback_str += "\n"
                                             traceback_str += "\n".join(composed)
                                 # chain: fallback/additional entries (only if no reprtraceback)
-                                elif (
-                                    data and isinstance(data, dict) and "chain" in data
-                                ):
+                                elif data and isinstance(data, dict) and "chain" in data:
                                     try:
                                         chain = data.get("chain", [])
                                         for pair in chain:
                                             # pair typically is [reprtraceback, reprcrash, context]
                                             if not isinstance(pair, list):
                                                 continue
-                                            if len(pair) >= 1 and isinstance(
-                                                pair[0], dict
-                                            ):
+                                            if len(pair) >= 1 and isinstance(pair[0], dict):
                                                 rt = pair[0]
                                                 if "reprentries" in rt:
-                                                    for re_entry in rt.get(
-                                                        "reprentries", []
-                                                    ):
+                                                    for re_entry in rt.get("reprentries", []):
                                                         dd = re_entry.get("data", {})
-                                                        fileloc = (
-                                                            dd.get("reprfileloc", {})
-                                                            if isinstance(dd, dict)
-                                                            else {}
-                                                        )
+                                                        fileloc = dd.get("reprfileloc", {}) if isinstance(dd, dict) else {}
                                                         fpath = fileloc.get("path")
                                                         flineno = fileloc.get("lineno")
                                                         fmsg = fileloc.get("message")
                                                         header_parts = []
-                                                        if (
-                                                            fpath is not None
-                                                            and flineno is not None
-                                                        ):
-                                                            header_parts.append(
-                                                                f"File: {fpath}:{flineno}"
-                                                            )
+                                                        if fpath is not None and flineno is not None:
+                                                            header_parts.append(f"File: {fpath}:{flineno}")
                                                         if fmsg:
-                                                            header_parts.append(
-                                                                str(fmsg)
-                                                            )
+                                                            header_parts.append(str(fmsg))
                                                         if header_parts:
                                                             if traceback_str:
                                                                 traceback_str += "\n"
-                                                            traceback_str += " - ".join(
-                                                                header_parts
-                                                            )
-                                                        if (
-                                                            isinstance(dd, dict)
-                                                            and "lines" in dd
-                                                            and dd["lines"]
-                                                        ):
+                                                            traceback_str += " - ".join(header_parts)
+                                                        if isinstance(dd, dict) and "lines" in dd and dd["lines"]:
                                                             if traceback_str:
                                                                 traceback_str += "\n"
-                                                            traceback_str += "\n".join(
-                                                                dd["lines"]
-                                                            )
-                                            if len(pair) >= 2 and isinstance(
-                                                pair[1], dict
-                                            ):
+                                                            traceback_str += "\n".join(dd["lines"])
+                                            if len(pair) >= 2 and isinstance(pair[1], dict):
                                                 crash = pair[1]
                                                 p = crash.get("path")
                                                 ln = crash.get("lineno")
@@ -1998,20 +1827,14 @@ class ResultTranslator:
                                 test_failures[node_id][when] = status
 
                             # Include captured sections (stdout/stderr) for failures to help debugging
-                            if (
-                                outcome in ("failed", "error")
-                                and entry.get("sections")
-                                and enable_capture_output_to_info
-                            ):
+                            if outcome in ("failed", "error") and entry.get("sections") and enable_capture_output_to_info:
                                 try:
                                     sec_chunks = []
                                     for sec in entry.get("sections", []):
                                         if isinstance(sec, list) and len(sec) == 2:
                                             title, content = sec
                                             if content:
-                                                sec_chunks.append(
-                                                    f"===== {title} =====\n{content}"
-                                                )
+                                                sec_chunks.append(f"===== {title} =====\n{content}")
                                     if sec_chunks:
                                         sec_text = "\n".join(sec_chunks)
                                         if traceback_str:
@@ -2039,21 +1862,14 @@ class ResultTranslator:
                                     Result.Status.FAIL,
                                     Result.Status.XPASS,
                                 )
-                                if (
-                                    status in _failure_statuses
-                                    or test_results[node_id].status in _failure_statuses
-                                ):
+                                if status in _failure_statuses or test_results[node_id].status in _failure_statuses:
                                     test_results[node_id].status = status
                                 # Update info if we now have traceback
                                 if traceback_str:
                                     if not test_results[node_id].info:
                                         test_results[node_id].info = traceback_str
-                                    elif (
-                                        traceback_str not in test_results[node_id].info
-                                    ):
-                                        test_results[node_id].info += (
-                                            f"\n[{when}]\n" + traceback_str
-                                        )
+                                    elif traceback_str not in test_results[node_id].info:
+                                        test_results[node_id].info += f"\n[{when}]\n" + traceback_str
                                 # Only update with non-failure if there's no existing failure
                                 elif test_results[node_id].status not in (
                                     Result.Status.FAIL,
@@ -2093,9 +1909,7 @@ class ResultTranslator:
 
             if session_exitstatus == 1:
                 if R.status == Result.Status.OK:
-                    print(
-                        f"WARNING: Tests are all OK, but exit code is 1; timeout or other runner issue - reset overall status to [{Result.Status.ERROR}]"
-                    )
+                    print(f"WARNING: Tests are all OK, but exit code is 1; timeout or other runner issue - reset overall status to [{Result.Status.ERROR}]")
                     R.status = Result.Status.ERROR
                 return R
 

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -497,9 +497,11 @@ class Runner:
                 result = Result.from_fs(job.name)
                 if host_metrics:
                     result.add_ext_key_value("metrics", host_metrics)
-                    # Flag over/under-utilized runners (long jobs only).
-                    for label, hint in HostMetricsCollector.classify(host_metrics):
-                        result.set_label(label, hint=hint)
+                    # Flag over/under-utilized runners, but not for skipped jobs -
+                    # they did no real work, so their metrics are meaningless.
+                    if not result.is_skipped():
+                        for label, hint in HostMetricsCollector.classify(host_metrics):
+                            result.set_label(label, hint=hint)
                 if exit_code != 0:
                     if not result.is_completed():
                         if process.timeout_exceeded:

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -497,6 +497,9 @@ class Runner:
                 result = Result.from_fs(job.name)
                 if host_metrics:
                     result.add_ext_key_value("metrics", host_metrics)
+                    # Flag over/under-utilized runners (long jobs only).
+                    for label, hint in HostMetricsCollector.classify(host_metrics):
+                        result.set_label(label, hint=hint)
                 if exit_code != 0:
                     if not result.is_completed():
                         if process.timeout_exceeded:

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -82,9 +82,11 @@ class _Settings:
     # Filesystem whose used% is tracked as the "disk" series. Defaults to the
     # working directory, i.e. the disk the job actually writes to.
     HOST_METRICS_DISK_PATH: str = "."
-    # Only jobs that ran at least this long are labelled over/under-utilized -
-    # shorter jobs are too noisy and not worth right-sizing. 30 minutes.
-    HOST_METRICS_MIN_LABEL_DURATION_SEC: float = 1800.0
+    # Jobs are labelled over/under-utilized only when they ran at least this
+    # long OR ran on a host with more than HOST_METRICS_MIN_LABEL_MEM_GB of RAM;
+    # short jobs on small runners are too noisy and not worth right-sizing.
+    HOST_METRICS_MIN_LABEL_DURATION_SEC: int = 1800
+    HOST_METRICS_MIN_LABEL_MEM_GB: int = 15
 
     SECRET_GH_APP_ID: str = ""
     SECRET_GH_APP_PEM_KEY: str = ""
@@ -220,6 +222,7 @@ _USER_DEFINED_SETTINGS = [
     "HOST_METRICS_FILE",
     "HOST_METRICS_DISK_PATH",
     "HOST_METRICS_MIN_LABEL_DURATION_SEC",
+    "HOST_METRICS_MIN_LABEL_MEM_GB",
 ]
 
 

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -68,13 +68,14 @@ class _Settings:
     # Sample whole-VM CPU and RAM usage in the background while a job runs and
     # store a decimated timeline in Result.ext["metrics"] (rendered in json.html).
     HOST_METRICS_ENABLED: bool = True
-    # Reporting/window interval: one aggregated point (avg + peak) is emitted per
-    # window, so the timeline stays ~1 point/sec regardless of the fine cadence.
-    HOST_METRICS_SAMPLE_INTERVAL_SEC: float = 1.0
+    # Reporting/window interval: one aggregated point (avg + peak) is emitted and
+    # written per window, so the timeline stays ~1 point / this-many-seconds
+    # regardless of the fine cadence.
+    HOST_METRICS_SAMPLE_INTERVAL_SEC: float = 5.0
     # Fine sampling cadence: /proc is read this often within each reporting window
     # so short bursts are captured as the window's peak instead of being averaged
     # away. Must be <= the reporting interval.
-    HOST_METRICS_FINE_INTERVAL_SEC: float = 0.25
+    HOST_METRICS_FINE_INTERVAL_SEC: float = 1.0
     # Upper bound on points kept per series after min/max decimation, so the
     # payload injected into the Result stays small regardless of job duration.
     HOST_METRICS_MAX_POINTS: int = 400

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -82,6 +82,9 @@ class _Settings:
     # Filesystem whose used% is tracked as the "disk" series. Defaults to the
     # working directory, i.e. the disk the job actually writes to.
     HOST_METRICS_DISK_PATH: str = "."
+    # Only jobs that ran at least this long are labelled over/under-utilized -
+    # shorter jobs are too noisy and not worth right-sizing. 30 minutes.
+    HOST_METRICS_MIN_LABEL_DURATION_SEC: float = 1800.0
 
     SECRET_GH_APP_ID: str = ""
     SECRET_GH_APP_PEM_KEY: str = ""
@@ -216,6 +219,7 @@ _USER_DEFINED_SETTINGS = [
     "HOST_METRICS_MAX_POINTS",
     "HOST_METRICS_FILE",
     "HOST_METRICS_DISK_PATH",
+    "HOST_METRICS_MIN_LABEL_DURATION_SEC",
 ]
 
 
@@ -231,9 +235,7 @@ def _get_settings() -> _Settings:
 
     for py_file in sorted_files:
         module_name = py_file.name.removeprefix(".py")
-        spec = importlib.util.spec_from_file_location(
-            module_name, f"{_Settings.SETTINGS_DIRECTORY}/{module_name}"
-        )
+        spec = importlib.util.spec_from_file_location(module_name, f"{_Settings.SETTINGS_DIRECTORY}/{module_name}")
         assert spec
         foo = importlib.util.module_from_spec(spec)
         assert spec.loader

--- a/ci/praktika/usage.py
+++ b/ci/praktika/usage.py
@@ -141,8 +141,10 @@ class PipelineUtilization(MetaClasses.SerializableSingleton):
     wall_time_s: float = 0.0  # sum(duration) - the "some"-stall weight/denominator
     cpu_core_s: float = 0.0  # sum(cpu_count * duration) - provisioned core-seconds
     mem_gb_s: float = 0.0  # sum(mem_total_gb * duration) - provisioned GB-seconds
+    disk_gb_s: float = 0.0  # sum(disk_total_gb * duration) - provisioned disk GB-seconds
     cpu_used_area: float = 0.0  # sum(avg_cpu% * cpu_count * duration)
     mem_used_area: float = 0.0  # sum(avg_mem% * mem_total_gb * duration)
+    disk_used_area: float = 0.0  # sum(peak_disk% * disk_total_gb * duration)
     cpu_stall_area: float = 0.0  # sum(cpu_some_s * 100)  (duration-weighted)
     mem_stall_area: float = 0.0  # sum(mem_some_s * 100)
     io_stall_area: float = 0.0  # sum(io_some_s * 100)
@@ -155,8 +157,10 @@ class PipelineUtilization(MetaClasses.SerializableSingleton):
         self.wall_time_s += other.wall_time_s
         self.cpu_core_s += other.cpu_core_s
         self.mem_gb_s += other.mem_gb_s
+        self.disk_gb_s += other.disk_gb_s
         self.cpu_used_area += other.cpu_used_area
         self.mem_used_area += other.mem_used_area
+        self.disk_used_area += other.disk_used_area
         self.cpu_stall_area += other.cpu_stall_area
         self.mem_stall_area += other.mem_stall_area
         self.io_stall_area += other.io_stall_area
@@ -182,6 +186,10 @@ class PipelineUtilization(MetaClasses.SerializableSingleton):
         psi = metrics.get("psi", {})
         cpu_avg = averages.get("cpu") or 0
         mem_avg = averages.get("mem") or 0
+        # Disk uses the peak footprint (you size a disk for its high-water mark),
+        # weighted like RAM by GB-time.
+        disk_gb = metrics.get("disk_total_gb") or 0
+        disk_peak = (metrics.get("peaks") or {}).get("disk") or 0
         # Stalls are wall-clock PSI fractions; the duration-weighted numerator is
         # stall% * duration = (stall_s / duration * 100) * duration = stall_s * 100,
         # divided by wall_time_s on read.
@@ -196,8 +204,10 @@ class PipelineUtilization(MetaClasses.SerializableSingleton):
             wall_time_s=duration,
             cpu_core_s=cores * duration,
             mem_gb_s=gb * duration,
+            disk_gb_s=disk_gb * duration,
             cpu_used_area=cpu_avg * cores * duration,
             mem_used_area=mem_avg * gb * duration,
+            disk_used_area=disk_peak * disk_gb * duration,
             cpu_stall_area=cpu_stall_s * 100.0,
             mem_stall_area=mem_stall_s * 100.0,
             io_stall_area=io_stall_s * 100.0,
@@ -214,8 +224,13 @@ class PipelineUtilization(MetaClasses.SerializableSingleton):
         return {
             "jobs": self.jobs,
             "wall_time_s": round(self.wall_time_s, 1),
+            # Provisioned capacity-time (cores/GB * duration), in hours.
+            "cpu_hours": round(self.cpu_core_s / 3600.0, 1),
+            "mem_gb_hours": round(self.mem_gb_s / 3600.0, 1),
+            "disk_gb_hours": round(self.disk_gb_s / 3600.0, 1),
             "cpu_util_pct": pct(self.cpu_used_area, self.cpu_core_s),
             "mem_util_pct": pct(self.mem_used_area, self.mem_gb_s),
+            "disk_util_pct": pct(self.disk_used_area, self.disk_gb_s),
             "cpu_stall_pct": pct(self.cpu_stall_area, self.wall_time_s),
             "mem_stall_pct": pct(self.mem_stall_area, self.wall_time_s),
             "io_stall_pct": pct(self.io_stall_area, self.wall_time_s),

--- a/ci/praktika/usage.py
+++ b/ci/praktika/usage.py
@@ -219,7 +219,9 @@ class PipelineUtilization(MetaClasses.SerializableSingleton):
         """Derive the human-facing utilization/stall percentages."""
 
         def pct(area, weight):
-            return round(area / weight, 1) if weight else 0.0
+            # A utilization/stall percentage is a fraction of time, so clamp to
+            # 100 - guards against any residual sampling jitter.
+            return round(min(100.0, area / weight), 1) if weight else 0.0
 
         return {
             "jobs": self.jobs,

--- a/ci/praktika/usage.py
+++ b/ci/praktika/usage.py
@@ -128,13 +128,18 @@ class PipelineUtilization(MetaClasses.SerializableSingleton):
 
     Stalls come in two PSI flavours. ``some`` (time at least one task was
     stalled) is a wall-clock pressure fraction independent of machine size, so
-    it is duration-weighted - "what % of pipeline runtime was under pressure".
-    ``full`` (all tasks stalled at once, so the box made zero progress; exists
-    for mem and io, not cpu) wastes the whole machine, so it is weighted by
-    core-seconds - the wasted-compute share of provisioned CPU.
+    it is duration-weighted - the average share of qualifying job-time spent
+    under pressure. Note this is NOT a single elapsed-workflow fraction: jobs
+    run in parallel on different runners, so two 10s jobs where only one stalls
+    the whole time read as 50%, not 100%. ``full`` (all tasks stalled at once,
+    so the box made zero progress; exists for mem and io, not cpu) wastes the
+    whole machine, so it is weighted by core-seconds - the wasted-compute share
+    of provisioned CPU.
 
-    Values are kept as running sums so merging across jobs is exact; the
-    percentages are derived on read (see to_summary).
+    Values are kept as running sums so merging across jobs is associative. The
+    per-job utilization contributions are reconstructed from the rounded,
+    sampled-window averages, so they are estimates (not bit-exact). Percentages
+    are derived on read (see to_summary).
     """
 
     jobs: int = 0

--- a/ci/praktika/usage.py
+++ b/ci/praktika/usage.py
@@ -38,9 +38,7 @@ class StorageUsage(MetaClasses.SerializableSingleton):
     def _init(cls):
         if not StorageUsage.exist():
             print("NOTE: UsageStorage data will be initialized")
-            StorageUsage(
-                downloaded=0, uploaded=0, downloaded_details={}, uploaded_details={}
-            ).dump()
+            StorageUsage(downloaded=0, uploaded=0, downloaded_details={}, uploaded_details={}).dump()
 
     @classmethod
     def add_downloaded(cls, file_path):
@@ -115,3 +113,92 @@ class ComputeUsage(MetaClasses.SerializableSingleton):
         else:
             self.set_usage(runner_str, duration, job_name)
         return self
+
+
+@dataclasses.dataclass
+class PipelineUtilization(MetaClasses.SerializableSingleton):
+    """Whole-pipeline CPU/RAM utilization and CPU/mem/io stall, accumulated over
+    all jobs that qualified for host-metrics labelling.
+
+    Each job is weighted by its provisioned resource-time - core-seconds
+    (cpu_count * duration) for CPU/io, GB-seconds (mem_total_gb * duration) for
+    RAM - so a bigger runner and/or a longer job impacts the KPI more. Values
+    are kept as running sums so merging across jobs is exact; the percentages
+    are derived on read (see to_summary). Lets a whole pipeline be monitored for
+    over-provisioning (low utilization) or contention (high stall) and be
+    normalized across differently-sized runners.
+    """
+
+    jobs: int = 0
+    wall_time_s: float = 0.0  # sum of qualifying job durations (context only)
+    cpu_core_s: float = 0.0  # sum(cpu_count * duration) - provisioned core-seconds
+    mem_gb_s: float = 0.0  # sum(mem_total_gb * duration) - provisioned GB-seconds
+    cpu_used_area: float = 0.0  # sum(avg_cpu% * cpu_count * duration)
+    mem_used_area: float = 0.0  # sum(avg_mem% * mem_total_gb * duration)
+    cpu_stall_area: float = 0.0  # sum(cpu_stall% * cpu_count * duration)
+    mem_stall_area: float = 0.0  # sum(mem_stall% * mem_total_gb * duration)
+    io_stall_area: float = 0.0  # sum(io_stall% * cpu_count * duration)
+    ext: Dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    def merge_with(self, other: "PipelineUtilization"):
+        self.jobs += other.jobs
+        self.wall_time_s += other.wall_time_s
+        self.cpu_core_s += other.cpu_core_s
+        self.mem_gb_s += other.mem_gb_s
+        self.cpu_used_area += other.cpu_used_area
+        self.mem_used_area += other.mem_used_area
+        self.cpu_stall_area += other.cpu_stall_area
+        self.mem_stall_area += other.mem_stall_area
+        self.io_stall_area += other.io_stall_area
+        return self
+
+    @classmethod
+    def file_name_static(cls):
+        return f"{Settings.TEMP_DIR}/pipeline_utilization.json"
+
+    @classmethod
+    def from_job_metrics(cls, metrics: Dict[str, Any]) -> "PipelineUtilization":
+        """Build the single-job contribution from a compacted metrics dict.
+
+        A short job contributes small resource-time weight even when it
+        qualified via runner size, so it naturally impacts the KPI less.
+        """
+        duration = metrics.get("duration") or 0
+        cores = metrics.get("cpu_count") or 1
+        gb = metrics.get("mem_total_gb") or 0
+        averages = metrics.get("averages", {})
+        psi = metrics.get("psi", {})
+        cpu_avg = averages.get("cpu") or 0
+        mem_avg = averages.get("mem") or 0
+        # stall% over the run = stall_seconds / duration * 100; multiplied by the
+        # resource-time weight (cores*duration) the duration cancels out.
+        cpu_stall_s = psi.get("cpu_s", 0) or 0
+        mem_stall_s = psi.get("mem_some_s", 0) or 0
+        io_stall_s = psi.get("io_some_s", 0) or 0
+        return cls(
+            jobs=1,
+            wall_time_s=duration,
+            cpu_core_s=cores * duration,
+            mem_gb_s=gb * duration,
+            cpu_used_area=cpu_avg * cores * duration,
+            mem_used_area=mem_avg * gb * duration,
+            cpu_stall_area=cpu_stall_s * cores * 100.0,
+            mem_stall_area=mem_stall_s * gb * 100.0,
+            io_stall_area=io_stall_s * cores * 100.0,
+        )
+
+    def to_summary(self) -> Dict[str, Any]:
+        """Derive the human-facing utilization/stall percentages."""
+
+        def pct(area, weight):
+            return round(area / weight, 1) if weight else 0.0
+
+        return {
+            "jobs": self.jobs,
+            "wall_time_s": round(self.wall_time_s, 1),
+            "cpu_util_pct": pct(self.cpu_used_area, self.cpu_core_s),
+            "mem_util_pct": pct(self.mem_used_area, self.mem_gb_s),
+            "cpu_stall_pct": pct(self.cpu_stall_area, self.cpu_core_s),
+            "mem_stall_pct": pct(self.mem_stall_area, self.mem_gb_s),
+            "io_stall_pct": pct(self.io_stall_area, self.cpu_core_s),
+        }

--- a/ci/praktika/usage.py
+++ b/ci/praktika/usage.py
@@ -120,24 +120,34 @@ class PipelineUtilization(MetaClasses.SerializableSingleton):
     """Whole-pipeline CPU/RAM utilization and CPU/mem/io stall, accumulated over
     all jobs that qualified for host-metrics labelling.
 
-    Each job is weighted by its provisioned resource-time - core-seconds
-    (cpu_count * duration) for CPU/io, GB-seconds (mem_total_gb * duration) for
-    RAM - so a bigger runner and/or a longer job impacts the KPI more. Values
-    are kept as running sums so merging across jobs is exact; the percentages
-    are derived on read (see to_summary). Lets a whole pipeline be monitored for
-    over-provisioning (low utilization) or contention (high stall) and be
-    normalized across differently-sized runners.
+    Utilization (cpu, mem) is weighted by provisioned resource-time -
+    core-seconds (cpu_count * duration) for CPU, GB-seconds
+    (mem_total_gb * duration) for RAM - so it is a true efficiency ratio
+    (used resource-time / provisioned resource-time) and a bigger runner and/or
+    a longer job impacts it more.
+
+    Stalls come in two PSI flavours. ``some`` (time at least one task was
+    stalled) is a wall-clock pressure fraction independent of machine size, so
+    it is duration-weighted - "what % of pipeline runtime was under pressure".
+    ``full`` (all tasks stalled at once, so the box made zero progress; exists
+    for mem and io, not cpu) wastes the whole machine, so it is weighted by
+    core-seconds - the wasted-compute share of provisioned CPU.
+
+    Values are kept as running sums so merging across jobs is exact; the
+    percentages are derived on read (see to_summary).
     """
 
     jobs: int = 0
-    wall_time_s: float = 0.0  # sum of qualifying job durations (context only)
+    wall_time_s: float = 0.0  # sum(duration) - the "some"-stall weight/denominator
     cpu_core_s: float = 0.0  # sum(cpu_count * duration) - provisioned core-seconds
     mem_gb_s: float = 0.0  # sum(mem_total_gb * duration) - provisioned GB-seconds
     cpu_used_area: float = 0.0  # sum(avg_cpu% * cpu_count * duration)
     mem_used_area: float = 0.0  # sum(avg_mem% * mem_total_gb * duration)
-    cpu_stall_area: float = 0.0  # sum(cpu_stall% * cpu_count * duration)
-    mem_stall_area: float = 0.0  # sum(mem_stall% * mem_total_gb * duration)
-    io_stall_area: float = 0.0  # sum(io_stall% * cpu_count * duration)
+    cpu_stall_area: float = 0.0  # sum(cpu_some_s * 100)  (duration-weighted)
+    mem_stall_area: float = 0.0  # sum(mem_some_s * 100)
+    io_stall_area: float = 0.0  # sum(io_some_s * 100)
+    mem_full_area: float = 0.0  # sum(mem_full_s * cpu_count * 100)  (core-weighted)
+    io_full_area: float = 0.0  # sum(io_full_s * cpu_count * 100)
     ext: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def merge_with(self, other: "PipelineUtilization"):
@@ -150,6 +160,8 @@ class PipelineUtilization(MetaClasses.SerializableSingleton):
         self.cpu_stall_area += other.cpu_stall_area
         self.mem_stall_area += other.mem_stall_area
         self.io_stall_area += other.io_stall_area
+        self.mem_full_area += other.mem_full_area
+        self.io_full_area += other.io_full_area
         return self
 
     @classmethod
@@ -170,11 +182,15 @@ class PipelineUtilization(MetaClasses.SerializableSingleton):
         psi = metrics.get("psi", {})
         cpu_avg = averages.get("cpu") or 0
         mem_avg = averages.get("mem") or 0
-        # stall% over the run = stall_seconds / duration * 100; multiplied by the
-        # resource-time weight (cores*duration) the duration cancels out.
+        # Stalls are wall-clock PSI fractions; the duration-weighted numerator is
+        # stall% * duration = (stall_s / duration * 100) * duration = stall_s * 100,
+        # divided by wall_time_s on read.
         cpu_stall_s = psi.get("cpu_s", 0) or 0
         mem_stall_s = psi.get("mem_some_s", 0) or 0
         io_stall_s = psi.get("io_some_s", 0) or 0
+        # full stall wastes every core -> weighted by cpu_count.
+        mem_full_s = psi.get("mem_full_s", 0) or 0
+        io_full_s = psi.get("io_full_s", 0) or 0
         return cls(
             jobs=1,
             wall_time_s=duration,
@@ -182,9 +198,11 @@ class PipelineUtilization(MetaClasses.SerializableSingleton):
             mem_gb_s=gb * duration,
             cpu_used_area=cpu_avg * cores * duration,
             mem_used_area=mem_avg * gb * duration,
-            cpu_stall_area=cpu_stall_s * cores * 100.0,
-            mem_stall_area=mem_stall_s * gb * 100.0,
-            io_stall_area=io_stall_s * cores * 100.0,
+            cpu_stall_area=cpu_stall_s * 100.0,
+            mem_stall_area=mem_stall_s * 100.0,
+            io_stall_area=io_stall_s * 100.0,
+            mem_full_area=mem_full_s * cores * 100.0,
+            io_full_area=io_full_s * cores * 100.0,
         )
 
     def to_summary(self) -> Dict[str, Any]:
@@ -198,7 +216,9 @@ class PipelineUtilization(MetaClasses.SerializableSingleton):
             "wall_time_s": round(self.wall_time_s, 1),
             "cpu_util_pct": pct(self.cpu_used_area, self.cpu_core_s),
             "mem_util_pct": pct(self.mem_used_area, self.mem_gb_s),
-            "cpu_stall_pct": pct(self.cpu_stall_area, self.cpu_core_s),
-            "mem_stall_pct": pct(self.mem_stall_area, self.mem_gb_s),
-            "io_stall_pct": pct(self.io_stall_area, self.cpu_core_s),
+            "cpu_stall_pct": pct(self.cpu_stall_area, self.wall_time_s),
+            "mem_stall_pct": pct(self.mem_stall_area, self.wall_time_s),
+            "io_stall_pct": pct(self.io_stall_area, self.wall_time_s),
+            "mem_full_pct": pct(self.mem_full_area, self.cpu_core_s),
+            "io_full_pct": pct(self.io_full_area, self.cpu_core_s),
         }

--- a/src/Processors/QueryPlan/LogicalExchangeStep.h
+++ b/src/Processors/QueryPlan/LogicalExchangeStep.h
@@ -10,7 +10,7 @@ namespace DB
 {
 
 /// Base class for logical exchange steps.
-/// Derived classes implement createSinkAndSourcePair method that is used to create a pair of send-recieve steps when converting
+/// Derived classes implement createSinkAndSourcePair method that is used to create a pair of send-receive steps when converting
 /// logical plan to a distributed plan.
 /// By default the data that is sent via the exchange might be reordered, but in cases like distributed sorting it is required to
 /// merge incoming sorted streams according to the sort description.


### PR DESCRIPTION
Accumulate a whole-pipeline resource-utilization KPI from the host metrics, so an entire CI pipeline can be monitored for over-provisioning (low utilization) or contention (high stall) and right-sized.

Builds on the per-job host metrics + utilization labels. `PipelineUtilization` accumulates, across every job that qualifies for labelling (ran long enough OR on a >15 GB runner), into the workflow `Result.ext["pipeline_utilization"]` (same plumbing as `storage_usage`/`compute_usage`):

- **CPU / RAM utilization** and **CPU / mem / io stall**, each a percentage.
- Every job is weighted by its **provisioned resource-time** — core-seconds (`cpu_count × duration`) for CPU/io, GB-seconds (`mem_total_gb × duration`) for RAM — so a **bigger runner and/or longer job impacts the KPI more**, and the numbers are normalized across differently-sized runners. Values are stored as running sums (exact merge); percentages are derived on read.

Supporting changes: the collector records `cpu_count` and exposes `qualifies()` (the label gate, reused for aggregation); `json.html` renders the KPI as a workflow-level widget.

This branch also carries the host-metrics utilization labelling it depends on (from #112602): `under-utilized RAM/CPU`, `cpu-bound`, `io-bound`, `ram-pressure`, `disk-almost-full`, the duration-OR-RAM gate, skip-for-skipped-jobs, and a couple of unrelated praktika fixes (lazy `jwt` import; a comment typo).

Related: https://github.com/ClickHouse/ClickHouse/pull/112602
Related: https://github.com/ClickHouse/ClickHouse/pull/112436
Related: https://github.com/ClickHouse/ClickHouse/pull/112567

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.599` (included in `26.8` and later)
<!-- ch-version-info:end -->