### PR TITLE
tidy: fix `readability-container-contains`

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -891,7 +891,7 @@ void sanityChecks(Server & server, const ServerSettings & server_settings)
     try
     {
         const char * filename = "/sys/kernel/mm/transparent_hugepage/enabled";
-        if (readLine(filename).find("[always]") != std::string::npos)
+        if (readLine(filename).contains("[always]"))
             server.context()->addOrUpdateWarningMessage(
                 Context::WarningType::LINUX_TRANSPARENT_HUGEPAGES_SET_TO_ALWAYS,
                 PreformattedMessage::create("Linux transparent hugepages are set to \"always\". Check {}", String(filename)));

--- a/src/Analyzer/Passes/ConvertOrLikeChainPass.cpp
+++ b/src/Analyzer/Passes/ConvertOrLikeChainPass.cpp
@@ -225,7 +225,7 @@ struct PatternInfo
     bool allRegexpsHaveNoEmbeddedNul() const
     {
         for (const auto & p : patterns)
-            if (p.regexp.find('\0') != String::npos)
+            if (p.regexp.contains('\0'))
                 return false;
         return true;
     }

--- a/src/Analyzer/Passes/RegexpFunctionRewritePass.cpp
+++ b/src/Analyzer/Passes/RegexpFunctionRewritePass.cpp
@@ -119,7 +119,7 @@ private:
         /// prefix can match at more than one offset (greedy `^.*` selects the last occurrence, while
         /// the stripped pattern selects the first). Be conservative and skip the rewrite for patterns
         /// containing a NUL, so this fix does not change `extract` results for such patterns.
-        if (regexp.find('\0') != String::npos)
+        if (regexp.contains('\0'))
             return;
 
         RegexpAnalysisResult result = OptimizedRegularExpression::analyze(regexp);

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -5275,7 +5275,7 @@ void QueryAnalyzer::resolveJoin(QueryTreeNodePtr & join_node, IdentifierResolveS
         for (const auto & col_name : left_cols)
         {
             /// Skip sub-columns (e.g. name.size) — NATURAL JOIN only matches top-level columns.
-            if (col_name.find('.') != std::string::npos)
+            if (col_name.contains('.'))
                 continue;
 
             if (right_cols.contains(col_name) && !seen.contains(col_name))

--- a/src/Backups/BackupInfo.cpp
+++ b/src/Backups/BackupInfo.cpp
@@ -129,7 +129,7 @@ namespace
     /// Returns the URL unchanged if there is nothing to remove.
     String removeCredentialsFromS3URL(const String & url)
     {
-        if (url.find('@') == String::npos && url.find('?') == String::npos)
+        if (!url.contains('@') && !url.contains('?'))
             return url;
 
         Poco::URI uri(url);

--- a/src/Backups/tests/gtest_backup_data_file_name_generator.cpp
+++ b/src/Backups/tests/gtest_backup_data_file_name_generator.cpp
@@ -69,7 +69,7 @@ TEST(BackupDataFileNameGeneratorTest, ChecksumGeneratorWithMaxPrefixLength32)
     auto suffix = hex.substr(prefix_length);
     EXPECT_TRUE(suffix.empty());
 
-    EXPECT_TRUE(path.find('/') == std::string::npos) << "Should not contain slash";
+    EXPECT_TRUE(!path.contains('/')) << "Should not contain slash";
 }
 
 TEST(BackupDataFileNameGeneratorTest, ThrowsWhenChecksumPrefixOutOfBound)
@@ -80,7 +80,7 @@ TEST(BackupDataFileNameGeneratorTest, ThrowsWhenChecksumPrefixOutOfBound)
     auto prefix_length = 33;
     std::string path = getBackupDataFileName(info, BackupDataFileNameGeneratorType::Checksum, prefix_length);
 
-    EXPECT_TRUE(path.find('/') == std::string::npos) << "Should not contain slash";
+    EXPECT_TRUE(!path.contains('/')) << "Should not contain slash";
 }
 
 TEST(BackupDataFileNameGeneratorTest, ThrowsOnZeroChecksum)

--- a/src/Backups/tests/gtest_backup_info.cpp
+++ b/src/Backups/tests/gtest_backup_info.cpp
@@ -50,7 +50,7 @@ namespace
 
     void requireContains(const String & str, const String & expected)
     {
-        if (str.find(expected) == String::npos)
+        if (!str.contains(expected))
         {
             std::cerr << "Expected to find " << expected << " in " << str << '\n';
             std::_Exit(1);
@@ -59,7 +59,7 @@ namespace
 
     void requireNotContains(const String & str, const String & unexpected)
     {
-        if (str.find(unexpected) != String::npos)
+        if (str.contains(unexpected))
         {
             std::cerr << "Did not expect to find " << unexpected << " in " << str << '\n';
             std::_Exit(1);

--- a/src/Client/AI/tests/gtest_ai_client_factory.cpp
+++ b/src/Client/AI/tests/gtest_ai_client_factory.cpp
@@ -303,7 +303,7 @@ TEST(AIClientFactory, ProviderCaseSensitivity)
     catch (const Exception & e)
     {
         // Should not contain "Unknown AI provider" if lowercase is correct
-        if (e.message().find("Unknown AI provider") != std::string::npos)
+        if (e.message().contains("Unknown AI provider"))
         {
             FAIL() << "Lowercase provider name should be recognized";
         }

--- a/src/Client/AI/tests/gtest_ai_sql_generator.cpp
+++ b/src/Client/AI/tests/gtest_ai_sql_generator.cpp
@@ -33,15 +33,15 @@ QueryExecutor createMockQueryExecutor()
 {
     return [](const std::string & query) -> std::string
     {
-        if (query.find("SHOW DATABASES") != std::string::npos)
+        if (query.contains("SHOW DATABASES"))
         {
             return "default\nsystem";
         }
-        else if (query.find("SHOW TABLES FROM") != std::string::npos)
+        else if (query.contains("SHOW TABLES FROM"))
         {
             return "users\norders";
         }
-        else if (query.find("SHOW CREATE TABLE") != std::string::npos)
+        else if (query.contains("SHOW CREATE TABLE"))
         {
             return "CREATE TABLE users (id UInt64, name String) ENGINE = MergeTree ORDER BY id";
         }
@@ -80,14 +80,14 @@ std::string toLower(const std::string & str)
 /// Helper to check if result contains SQL keywords
 bool containsSQLKeywords(const std::string & result)
 {
-    return result.find("SELECT") != std::string::npos ||
-           result.find("SHOW") != std::string::npos ||
-           result.find("COUNT") != std::string::npos ||
-           result.find("DESCRIBE") != std::string::npos ||
-           result.find("CREATE") != std::string::npos ||
-           result.find("INSERT") != std::string::npos ||
-           result.find("UPDATE") != std::string::npos ||
-           result.find("DELETE") != std::string::npos;
+    return result.contains("SELECT") ||
+           result.contains("SHOW") ||
+           result.contains("COUNT") ||
+           result.contains("DESCRIBE") ||
+           result.contains("CREATE") ||
+           result.contains("INSERT") ||
+           result.contains("UPDATE") ||
+           result.contains("DELETE");
 }
 
 
@@ -137,19 +137,19 @@ QueryExecutor createRealQueryExecutor()
     return [](const std::string & query) -> std::string
     {
         // Simulate a real database schema
-        if (query.find("SHOW DATABASES") != std::string::npos)
+        if (query.contains("SHOW DATABASES"))
         {
             return "default\nsystem\ntest_db";
         }
-        else if (query.find("SHOW TABLES FROM default") != std::string::npos)
+        else if (query.contains("SHOW TABLES FROM default"))
         {
             return "customers\norders\nproducts";
         }
-        else if (query.find("SHOW TABLES FROM test_db") != std::string::npos)
+        else if (query.contains("SHOW TABLES FROM test_db"))
         {
             return "analytics\nmetrics";
         }
-        else if (query.find("SHOW CREATE TABLE default.customers") != std::string::npos)
+        else if (query.contains("SHOW CREATE TABLE default.customers"))
         {
             return "CREATE TABLE default.customers (\n"
                    "    customer_id UInt64,\n"
@@ -159,7 +159,7 @@ QueryExecutor createRealQueryExecutor()
                    ") ENGINE = MergeTree()\n"
                    "ORDER BY customer_id";
         }
-        else if (query.find("SHOW CREATE TABLE default.orders") != std::string::npos)
+        else if (query.contains("SHOW CREATE TABLE default.orders"))
         {
             return "CREATE TABLE default.orders (\n"
                    "    order_id UInt64,\n"
@@ -170,7 +170,7 @@ QueryExecutor createRealQueryExecutor()
                    ") ENGINE = MergeTree()\n"
                    "ORDER BY (customer_id, order_date)";
         }
-        else if (query.find("SHOW CREATE TABLE default.products") != std::string::npos)
+        else if (query.contains("SHOW CREATE TABLE default.products"))
         {
             return "CREATE TABLE default.products (\n"
                    "    product_id UInt64,\n"
@@ -190,23 +190,23 @@ QueryExecutor createSQLInjectionTestExecutor()
     return [](const std::string & query) -> std::string
     {
         // Detect obvious SQL injection patterns
-        if (query.find("'; DROP TABLE") != std::string::npos ||
-            query.find("--") != std::string::npos ||
-            query.find("/*") != std::string::npos ||
-            query.find("UNION SELECT") != std::string::npos)
+        if (query.contains("'; DROP TABLE") ||
+            query.contains("--") ||
+            query.contains("/*") ||
+            query.contains("UNION SELECT"))
         {
             throw std::runtime_error("Potential SQL injection detected");
         }
         
-        if (query.find("SHOW DATABASES") != std::string::npos)
+        if (query.contains("SHOW DATABASES"))
         {
             return "default\n`test-db`\n\"quoted.db\"";
         }
-        else if (query.find("SHOW TABLES FROM") != std::string::npos)
+        else if (query.contains("SHOW TABLES FROM"))
         {
             return "`user-accounts`\n\"order.items\"\nproduct_catalog";
         }
-        else if (query.find("SHOW CREATE TABLE") != std::string::npos)
+        else if (query.contains("SHOW CREATE TABLE"))
         {
             return "CREATE TABLE `user-accounts` (\n"
                    "    `user-id` UInt64,\n"
@@ -341,8 +341,8 @@ TEST_F(AITestFixture, RealAIGeneration)
     std::string output_str = output.str();
     EXPECT_NE(output_str.find("Starting AI SQL generation"), std::string::npos);
     // SQL generation might succeed or fail, but we should see some status
-    EXPECT_TRUE(output_str.find("SQL query generated successfully") != std::string::npos ||
-                output_str.find("No SQL query was generated") != std::string::npos);
+    EXPECT_TRUE(output_str.contains("SQL query generated successfully") ||
+                output_str.contains("No SQL query was generated"));
 }
 
 /// Test AI with complex query requiring joins
@@ -361,22 +361,22 @@ TEST_F(AITestFixture, ComplexQueryGeneration)
     EXPECT_FALSE(result.empty());
     
     // For a revenue query, we expect certain patterns
-    if (result.find("SELECT") != std::string::npos)
+    if (result.contains("SELECT"))
     {
         std::string result_lower = toLower(result);
         
         // Should have aggregation (SUM, GROUP BY) or JOIN for this complex query
-        bool has_aggregation = result_lower.find("sum") != std::string::npos || 
-                               result_lower.find("group by") != std::string::npos;
-        bool has_join = result_lower.find("join") != std::string::npos;
+        bool has_aggregation = result_lower.contains("sum") ||
+                               result_lower.contains("group by");
+        bool has_join = result_lower.contains("join");
         
         EXPECT_TRUE(has_aggregation || has_join) 
             << "Complex query should use aggregation or joins";
         
         // Should reference relevant tables (customers, orders, or products)
-        bool references_tables = result_lower.find("customer") != std::string::npos || 
-                                result_lower.find("order") != std::string::npos || 
-                                result_lower.find("product") != std::string::npos;
+        bool references_tables = result_lower.contains("customer") ||
+                                 result_lower.contains("order") ||
+                                 result_lower.contains("product");
         
         EXPECT_TRUE(references_tables)
             << "Query should reference relevant tables";
@@ -415,8 +415,8 @@ TEST_F(AITestFixture, SchemaExploration)
     std::string output_str = output.str();
     
     // Check that schema exploration tools were used
-    EXPECT_TRUE(output_str.find("list_databases") != std::string::npos ||
-                output_str.find("list_tables_in_database") != std::string::npos)
+    EXPECT_TRUE(output_str.contains("list_databases") ||
+                output_str.contains("list_tables_in_database"))
         << "AI should use schema exploration tools";
 }
 
@@ -438,9 +438,9 @@ TEST_F(AITestFixture, SQLCleaningWithRealAI)
     
     // Should generate some SQL-like content
     std::string result_lower = toLower(result);
-    bool has_sql_keywords = result_lower.find("select") != std::string::npos ||
-                           result_lower.find("from") != std::string::npos ||
-                           result_lower.find("create") != std::string::npos;
+    bool has_sql_keywords = result_lower.contains("select") ||
+                           result_lower.contains("from") ||
+                           result_lower.contains("create");
     EXPECT_TRUE(has_sql_keywords) << "Should contain SQL keywords";
 }
 
@@ -498,12 +498,12 @@ TEST_F(AITestFixture, SpecialCharacterHandling)
     // 4. Use the exact schema discovered name
     
     // Just verify the result doesn't have unquoted special chars that would break SQL
-    if (result.find("user-accounts") != std::string::npos)
+    if (result.contains("user-accounts"))
     {
         // If the hyphenated name appears, it should be quoted
-        bool is_quoted = (result.find("`user-accounts`") != std::string::npos) ||
-                        (result.find("\"user-accounts\"") != std::string::npos) ||
-                        (result.find("'user-accounts'") != std::string::npos);
+        bool is_quoted = (result.contains("`user-accounts`")) ||
+                        (result.contains("\"user-accounts\"")) ||
+                        (result.contains("'user-accounts'"));
         EXPECT_TRUE(is_quoted) 
             << "Table names with special characters should be properly quoted";
     }

--- a/src/Client/ClientApplicationBase.cpp
+++ b/src/Client/ClientApplicationBase.cpp
@@ -167,7 +167,7 @@ void ClientApplicationBase::init(int argc, char ** argv)
     /// Set application name for help messages based on how the binary was invoked
     std::string_view argv0_view(argv0 ? argv0 : "");
     std::string name_with_dash = "clickhouse-" + getName();
-    if (argv0_view.find(name_with_dash) != std::string_view::npos)
+    if (argv0_view.contains(name_with_dash))
         app_name = name_with_dash;
     else
         app_name = "clickhouse " + getName();

--- a/src/Client/TerminalMarkdownRenderer.cpp
+++ b/src/Client/TerminalMarkdownRenderer.cpp
@@ -90,7 +90,7 @@ bool isMdxImport(std::string_view line)
     line = trimView(line);
     if (!line.starts_with("import "))
         return false;
-    return line.find(" from '") != std::string_view::npos || line.find(" from \"") != std::string_view::npos || line.starts_with("import '")
+    return line.contains(" from '") || line.contains(" from \"") || line.starts_with("import '")
         || line.starts_with("import \"");
 }
 
@@ -1418,12 +1418,12 @@ private:
             }
 
             /// Table: a row of cells followed by a separator row.
-            if (line.find('|') != std::string_view::npos && i + 1 < lines.size() && isTableSeparator(lines[i + 1]))
+            if (line.contains('|') && i + 1 < lines.size() && isTableSeparator(lines[i + 1]))
             {
                 std::vector<std::string_view> rows;
                 rows.push_back(line);
                 i += 2; /// skip the header and the separator
-                while (i < lines.size() && !isBlank(lines[i]) && lines[i].find('|') != std::string_view::npos
+                while (i < lines.size() && !isBlank(lines[i]) && lines[i].contains('|')
                        && !stripCR(lines[i]).substr(leadingSpaces(lines[i])).starts_with("```"))
                 {
                     rows.push_back(stripCR(lines[i]));
@@ -1499,7 +1499,7 @@ private:
                     std::string_view pl = stripCR(lines[i]);
                     if (startsNewBlock(pl))
                         break;
-                    if (pl.find('|') != std::string_view::npos && i + 1 < lines.size() && isTableSeparator(lines[i + 1]))
+                    if (pl.contains('|') && i + 1 < lines.size() && isTableSeparator(lines[i + 1]))
                         break;
                     if (!paragraph.empty())
                         paragraph += ' ';

--- a/src/Common/FieldVisitorToCastedLiteral.cpp
+++ b/src/Common/FieldVisitorToCastedLiteral.cpp
@@ -48,7 +48,7 @@ String FieldVisitorToCastedLiteral::operator() (const Float64 & x) const
     /// FieldVisitorToString should emit a decimal point or exponent for finite Float64,
     /// it's important here because the trailing decimal point keeps the SQL parser from re-parsing
     /// the literal as an integer.
-    chassert(!std::isfinite(x) || out.find('.') != String::npos || out.find('e') != String::npos || out.find('E') != String::npos);
+    chassert(!std::isfinite(x) || out.contains('.') || out.contains('e') || out.contains('E'));
     if (!skip_unambiguous_cast)
         out += "::Float64";
     return out;

--- a/src/Common/logger_useful.h
+++ b/src/Common/logger_useful.h
@@ -68,7 +68,7 @@ namespace impl
 
 constexpr bool constexprContains(std::string_view haystack, std::string_view needle)
 {
-    return haystack.find(needle) != std::string_view::npos;
+    return haystack.contains(needle);
 }
 
 #define LOG_IMPL(logger, priority, PRIORITY, ...) do                                                                \

--- a/src/Common/maskSensitiveQueryParameters.cpp
+++ b/src/Common/maskSensitiveQueryParameters.cpp
@@ -83,7 +83,7 @@ bool isSensitiveParameterName(std::string_view raw_name)
 
     for (auto needle : sensitive_name_substrings)
     {
-        if (lower.find(needle) != std::string::npos)
+        if (lower.contains(needle))
             return true;
     }
     return false;

--- a/src/Common/tests/gtest_async_loader.cpp
+++ b/src/Common/tests/gtest_async_loader.cpp
@@ -238,7 +238,7 @@ TEST(AsyncLoader, CycleDetection)
     {
         int present[] = { 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0 };
         for (int i = 0; i < std::size(present); i++)
-            ASSERT_EQ(e.message().find(fmt::format("job{}", i)) != String::npos, present[i]);
+            ASSERT_EQ(e.message().contains(fmt::format("job{}", i)), present[i]);
     }
 
     const_cast<LoadJobSet &>(cycle_breaker->dependencies).clear();

--- a/src/Common/tests/gtest_connection_pool.cpp
+++ b/src/Common/tests/gtest_connection_pool.cpp
@@ -743,8 +743,8 @@ TEST_F(ConnectionPoolTest, ProxyConnectSkipsTargetResolution)
         /// address, so the proxy address text is not a reliable marker - match on the error kind,
         /// and accept the address too for the synchronous-failure path.
         const std::string text = e.displayText();
-        reached_proxy_connect = text.find("Connection refused") != std::string::npos
-            || text.find("127.0.0.1:1") != std::string::npos;
+        reached_proxy_connect = text.contains("Connection refused")
+            || text.contains("127.0.0.1:1");
         ASSERT_EQ(std::string::npos, text.find("proxy-only-target.invalid"))
             << "Target host was resolved locally: " << text;
     }

--- a/src/Compression/tests/gtest_compressionCodec.cpp
+++ b/src/Compression/tests/gtest_compressionCodec.cpp
@@ -1635,7 +1635,7 @@ TEST(SZ3Test, DecompressRejectsOversizedInnerLosslessSize)
     }
     catch (const Exception & e)
     {
-        rejected_before_allocation = e.message().find("exceeds the allowed capacity") != std::string::npos;
+        rejected_before_allocation = e.message().contains("exceeds the allowed capacity");
     }
     ASSERT_TRUE(rejected_before_allocation)
         << "Decompression must reject the oversized inner lossless size before allocating it";
@@ -1761,7 +1761,7 @@ TEST(SZ3Test, DecompressRejectsTamperedInterpolationDimensions)
     }
     catch (const Exception & e)
     {
-        rejected_dimensions = e.message().find("stored dimensions do not match") != std::string::npos;
+        rejected_dimensions = e.message().contains("stored dimensions do not match");
     }
     ASSERT_TRUE(rejected_dimensions)
         << "Decompression must reject tampered interpolation dimensions before any out-of-bounds access";

--- a/src/Databases/DataLake/ICatalog.cpp
+++ b/src/Databases/DataLake/ICatalog.cpp
@@ -177,7 +177,7 @@ std::string TableMetadata::constructLocation(const std::string & endpoint_, DB::
     /// The bucket variable contains the container name for Azure.
     if (!azure_account_with_suffix.empty())
     {
-        if (!force_add_bucket && location.find("/" + bucket) != std::string::npos)
+        if (!force_add_bucket && location.contains("/" + bucket))
             return std::filesystem::path(location) / path / "";
         return std::filesystem::path(location) / bucket / path / "";
     }

--- a/src/Databases/SQLite/fetchSQLiteTableStructure.cpp
+++ b/src/Databases/SQLite/fetchSQLiteTableStructure.cpp
@@ -36,7 +36,7 @@ DataTypePtr convertSQLiteDataType(String type)
     /// particular width, even though it's not enforced in any way by SQLite itself.
     /// Docs: https://www.sqlite.org/datatype3.html
     /// The most insane quote from there: Note that a declared type of "FLOATING POINT" would give INTEGER affinity, not REAL affinity, due to the "INT" at the end of "POINT".
-    if (type.find("int") != std::string::npos)
+    if (type.contains("int"))
         res = std::make_shared<DataTypeInt64>();
     else if (type == "float" || type.starts_with("double") || type == "real")
         res = std::make_shared<DataTypeFloat64>();

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Web/MetadataStorageFromIndexPages.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Web/MetadataStorageFromIndexPages.cpp
@@ -57,7 +57,7 @@ namespace
     /// references; unrecognized entities are left untouched.
     std::string decodeHTMLEntities(const std::string & input)
     {
-        if (input.find('&') == std::string::npos)
+        if (!input.contains('&'))
             return input;
 
         std::string result;

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -477,7 +477,7 @@ void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWith
     /// unbounded loop for a directory that holds only subdirectories). A
     /// `readdir` entry name never contains a NUL, so this single up-front check
     /// guarantees no path derived during traversal can reintroduce one.
-    if (path.find('\0') != std::string::npos)
+    if (path.contains('\0'))
         throw fs::filesystem_error(
             "Path contains an embedded NUL byte", path,
             std::make_error_code(std::errc::invalid_argument));

--- a/src/Functions/prettyPrintJSON.cpp
+++ b/src/Functions/prettyPrintJSON.cpp
@@ -94,7 +94,7 @@ public:
             /// Since RapidJSON uses '\0' as end-of-stream char in its stream abstraction,
             /// we have to default to this check to prevent silent truncation of the input
             /// unescaped '\0' is not valid in JSON strings anyway
-            if (str_view.find('\0') != std::string_view::npos)
+            if (str_view.contains('\0'))
                 throw Exception(
                     ErrorCodes::BAD_ARGUMENTS,
                     "Invalid JSON string in function {}: embedded NULL byte",

--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -1383,7 +1383,7 @@ struct FunctionsStressTestThread
                     /// guards we set up ourselves.
                     stats.add(S_QUERY_CANCELLED, 1);
                 }
-                else if (e.code() == ErrorCodes::LOGICAL_ERROR && e.message().find("incorrect data types") != String::npos)
+                else if (e.code() == ErrorCodes::LOGICAL_ERROR && e.message().contains("incorrect data types"))
                 {
                     /// Known issue: some arithmetic functions (plus, minus, etc.) accept types in
                     /// getReturnTypeImpl but fail in executeImpl with LowCardinality arguments.

--- a/src/IO/tests/gtest_archive_reader_and_writer.cpp
+++ b/src/IO/tests/gtest_archive_reader_and_writer.cpp
@@ -95,7 +95,7 @@ public:
         }
         catch (Exception & e)
         {
-            if ((e.code() != code) || (e.message().find(message) == String::npos))
+            if ((e.code() != code) || !e.message().contains(message))
                 throw;
         }
     }

--- a/src/Interpreters/ITokenizer.cpp
+++ b/src/Interpreters/ITokenizer.cpp
@@ -435,7 +435,7 @@ VectorWithMemoryTracking<String> SparseGramsTokenizer::compactTokens(const Vecto
 
         for (const auto & existing_token : result)
         {
-            if (existing_token.find(token) != std::string::npos)
+            if (existing_token.contains(token))
             {
                 is_covered = true;
                 break;

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -3114,7 +3114,7 @@ void InterpreterCreateQuery::convertMergeTreeTableIfPossible(ASTCreateQuery & cr
         throw Exception(ErrorCodes::NOT_IMPLEMENTED,
             "Table engine conversion to replicated is supported only for Atomic databases");
 
-    if (!create.storage || !create.storage->engine || create.storage->engine->name.find("MergeTree") == std::string::npos)
+    if (!create.storage || !create.storage->engine || !create.storage->engine->name.contains("MergeTree"))
         throw Exception(ErrorCodes::NOT_IMPLEMENTED,
             "Table engine conversion is supported only for MergeTree family engines");
 

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -702,7 +702,7 @@ void resolveNaturalJoin(ASTTableJoin & table_join, const TablesWithColumns & tab
     for (const auto & col : tables[0].columns)
     {
         /// Skip sub-columns (e.g. name.size) — NATURAL JOIN only matches top-level columns.
-        if (col.name.find('.') != std::string::npos)
+        if (col.name.contains('.'))
             continue;
         if (right_col_names.contains(col.name) && seen.insert(col.name).second)
             using_list->children.push_back(make_intrusive<ASTIdentifier>(col.name));

--- a/src/Parsers/Kusto/ParserKQLJoin.cpp
+++ b/src/Parsers/Kusto/ParserKQLJoin.cpp
@@ -137,7 +137,7 @@ bool ParserKQLJoin::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     /// In KQL "on col1, col2" means "on left.col1 = right.col1 AND left.col2 = right.col2"
     /// We add suffix "1" for the right table columns (ClickHouse join convention)
     String sql_on;
-    if (on_conditions.find("==") == String::npos && on_conditions.find('=') == String::npos)
+    if (!on_conditions.contains("==") && !on_conditions.contains('='))
     {
         /// Simple column name(s) - KQL convention: on col means left.col = right.col
         /// Handle comma-separated keys: on a, b -> a = a1 AND b = b1

--- a/src/Parsers/Kusto/ParserKQLOperators.cpp
+++ b/src/Parsers/Kusto/ParserKQLOperators.cpp
@@ -375,12 +375,12 @@ String KQLOperators::genHaystackOpExpr(
         }
         else if (ch_op == "startsWith" || ch_op == "not startsWith")
         {
-            bool negated = ch_op.find("not") != String::npos;
+            bool negated = ch_op.contains("not");
             new_expr = fmt::format("toBool({}startsWith({}, {}))", negated ? "not " : "", haystack, safe_needle);
         }
         else if (ch_op == "endsWith" || ch_op == "not endsWith")
         {
-            bool negated = ch_op.find("not") != String::npos;
+            bool negated = ch_op.contains("not");
             new_expr = fmt::format("toBool({}endsWith({}, {}))", negated ? "not " : "", haystack, safe_needle);
         }
         else if (ch_op == "match")

--- a/src/Parsers/Kusto/ParserKQLQuery.cpp
+++ b/src/Parsers/Kusto/ParserKQLQuery.cpp
@@ -471,7 +471,7 @@ static bool preprocessUnionJoin(IParser::Pos & pos, ASTPtr & node, Expected & ex
         else return false;
 
         String on_clause;
-        if (join_on.find("==") == String::npos && join_on.find('=') == String::npos)
+        if (!join_on.contains("==") && !join_on.contains('='))
         {
             /// Handle comma-separated join keys: on a, b -> a = a1 AND b = b1
             std::vector<String> keys;

--- a/src/Parsers/tests/gtest_play_highlight_query_error.cpp
+++ b/src/Parsers/tests/gtest_play_highlight_query_error.cpp
@@ -120,7 +120,7 @@ QueryErrorPos computeQueryErrorPos(
     const size_t byte_offset = value - 1;
 
     /// The server writes " (end of query)" for both an unexpected end of stream and a `;`.
-    result.at_end = error_text.find(" (end of query)") != std::string::npos;
+    result.at_end = error_text.contains(" (end of query)");
 
     /// Locate the sent query within the textarea. Prefer the exact captured start offset so
     /// duplicate statements map to the one that failed; otherwise fall back to its first

--- a/src/Processors/Merges/Algorithms/Graphite.cpp
+++ b/src/Processors/Merges/Algorithms/Graphite.cpp
@@ -304,7 +304,7 @@ std::string buildTaggedRegex(std::string regexp_str)
     /* remove empty elements */
     using namespace std::string_literals;
     std::erase(tags, ""s);
-    if (tags[0].find('=') == tags[0].npos)  /// NOLINT(readability-static-accessed-through-instance)
+    if (!tags[0].contains('='))  /// NOLINT(readability-static-accessed-through-instance)
     {
         if (tags.size() == 1) /* only name */
             return "^" + tags[0] + "\\?";

--- a/src/Processors/QueryPlan/QueryPlanFormat.cpp
+++ b/src/Processors/QueryPlan/QueryPlanFormat.cpp
@@ -55,7 +55,7 @@ namespace QueryPlanFormat
 
     String trimColumnIdentifier(std::string_view name)
     {
-        if (name.find(TABLE_PREFIX) == std::string_view::npos)
+        if (!name.contains(TABLE_PREFIX))
             return String(name);
 
         String result;

--- a/src/Server/WebUIRequestHandler.cpp
+++ b/src/Server/WebUIRequestHandler.cpp
@@ -254,7 +254,7 @@ std::optional<std::string> ClickStackUIRequestHandler::getResourcePath(const std
     if (decoded.empty())
         return std::string("index.html");
 
-    if (decoded.find('.') != std::string::npos)
+    if (decoded.contains('.'))
         return decoded;
 
     // assuming a path with no "." is an html page
@@ -307,7 +307,7 @@ const ClickStack::EmbeddedResource * resolveDynamicRoute(const std::string & res
             continue;
         if (!tail.ends_with(dynamic_tail_suffix))
             continue;
-        if (tail.find('/') != std::string_view::npos)
+        if (tail.contains('/'))
             continue;
 
         return &candidate;

--- a/src/Storages/Kafka/KafkaConfigLoader.cpp
+++ b/src/Storages/Kafka/KafkaConfigLoader.cpp
@@ -580,7 +580,7 @@ cppkafka::Configuration KafkaConfigLoader::getConsumerConfiguration(TKafkaStorag
 
     for (auto & property : conf.get_all())
     {
-        if (property.first.find("password") != std::string::npos)
+        if (property.first.contains("password"))
             continue;
         LOG_TRACE(params.log, "Consumer set property {}:{}", property.first, property.second);
     }

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -117,7 +117,7 @@ struct ReplicatedFetchReadCallback
 bool isProjectionNameSafe(const std::string & projection_name)
 {
     return !projection_name.empty()
-        && projection_name.find('/') == std::string::npos;
+        && !projection_name.contains('/');
 }
 
 }

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -653,7 +653,7 @@ const KeyCondition::AtomMap KeyCondition::atom_map
 
                 /// ClickHouse `match` patterns must not contain NUL bytes.
                 /// Do not attempt to optimize such patterns.
-                if (expression.find('\0') != String::npos)
+                if (expression.contains('\0'))
                     return false;
 
                 String prefix;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -214,9 +214,9 @@ public:
             return false;
         const auto & msg = e.message();
         const bool stale_credentials_error =
-            msg.find("ExpiredToken") != std::string::npos
-            || msg.find("InvalidToken") != std::string::npos
-            || msg.find("TokenRefreshRequired") != std::string::npos;
+            msg.contains("ExpiredToken")
+            || msg.contains("InvalidToken")
+            || msg.contains("TokenRefreshRequired");
         if (!stale_credentials_error)
             return false;
 
@@ -864,9 +864,9 @@ bool TableSnapshot::tryRefreshAfterStaleTokenError(
         return false;
     const auto & msg = e.message();
     const bool stale_credentials_error =
-        msg.find("ExpiredToken") != std::string::npos
-        || msg.find("InvalidToken") != std::string::npos
-        || msg.find("TokenRefreshRequired") != std::string::npos;
+        msg.contains("ExpiredToken")
+        || msg.contains("InvalidToken")
+        || msg.contains("TokenRefreshRequired");
     if (!stale_credentials_error)
         return false;
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -809,7 +809,7 @@ void IcebergMetadata::createInitial(
     }
 
     String location_path = configuration_ptr->getRawPath().path;
-    if (location_path.find("://") == String::npos && !location_path.starts_with('/'))
+    if (!location_path.contains("://") && !location_path.starts_with('/'))
         location_path = "/" + location_path;
     if (local_context->getSettingsRef()[Setting::write_full_path_in_iceberg_metadata].value)
         location_path
@@ -836,7 +836,7 @@ void IcebergMetadata::createInitial(
         /// already exists (e.g. leftover data after `DROP TABLE` with `iceberg_delete_data_on_drop` off,
         /// or a concurrent creation). When `IF NOT EXISTS` was specified, this is expected.
         if (if_not_exists && e.code() == ErrorCodes::S3_ERROR
-            && e.message().find("PreconditionFailed") != String::npos)
+            && e.message().contains("PreconditionFailed"))
             return;
         throw;
     }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergPath.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergPath.h
@@ -74,7 +74,7 @@ public:
         trim_backward_slashes(table_location);
 
         /// Normalize: non-URI table_location should start with '/'
-        if (!table_location.empty() && table_location.find("://") == String::npos && table_location[0] != '/')
+        if (!table_location.empty() && !table_location.contains("://") && table_location[0] != '/')
             table_location = "/" + table_location;
     }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/RemoveOrphanFilesExecute.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/RemoveOrphanFilesExecute.cpp
@@ -96,7 +96,7 @@ String resolveScanPath(const String & table_path, const RemoveOrphanFilesParams 
     if (params.location.has_value())
     {
         String loc = *params.location;
-        if (loc.find("..") != String::npos || loc.starts_with('/'))
+        if (loc.contains("..") || loc.starts_with('/'))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "location must be a relative path under the table root, got '{}'", loc);
 
         while (loc.starts_with("./"))

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -119,13 +119,13 @@ using namespace DB;
 /// reporting metrics, not deletion safety.
 FileCategory inspectFileCategory(const String & relative_path)
 {
-    if (relative_path.find("/metadata/") != String::npos || relative_path.starts_with("metadata/"))
+    if (relative_path.contains("/metadata/") || relative_path.starts_with("metadata/"))
     {
-        if (relative_path.find(".metadata.json") != String::npos)
+        if (relative_path.contains(".metadata.json"))
             return FileCategory::METADATA_JSON;
         if (relative_path.ends_with(".avro"))
         {
-            if (relative_path.find("snap-") != String::npos)
+            if (relative_path.contains("snap-"))
                 return FileCategory::MANIFEST_LIST;
             return FileCategory::MANIFEST_FILE;
         }
@@ -133,10 +133,10 @@ FileCategory inspectFileCategory(const String & relative_path)
             return FileCategory::STATISTICS_FILE;
     }
 
-    if (relative_path.find("eq-del") != String::npos)
+    if (relative_path.contains("eq-del"))
         return FileCategory::EQUALITY_DELETE_FILE;
 
-    if (relative_path.find("-deletes.parquet") != String::npos || relative_path.find("-delete-") != String::npos)
+    if (relative_path.contains("-deletes.parquet") || relative_path.contains("-delete-"))
         return FileCategory::POSITION_DELETE_FILE;
 
     return FileCategory::DATA_FILE;
@@ -1269,7 +1269,7 @@ MetadataFileWithInfo getLatestOrExplicitMetadataFileAndVersion(
     if (data_lake_settings[DataLakeStorageSetting::iceberg_metadata_file_path].changed && !ignore_explicit_metadata_file_path)
     {
         auto explicit_metadata_path = data_lake_settings[DataLakeStorageSetting::iceberg_metadata_file_path].value;
-        if (explicit_metadata_path.find('\0') != String::npos)
+        if (explicit_metadata_path.contains('\0'))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Iceberg metadata file path contains a null byte");
         LOG_TEST(log, "Explicit metadata file path is specified {}, will read from this metadata file", explicit_metadata_path);
         std::filesystem::path p(explicit_metadata_path);

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp
@@ -280,12 +280,12 @@ StorageObjectStorageConfiguration::Path StorageObjectStorageConfiguration::getPa
 bool StorageObjectStorageConfiguration::Path::hasPartitionWildcard() const
 {
     static const String PARTITION_ID_WILDCARD = "{_partition_id}";
-    return path.find(PARTITION_ID_WILDCARD) != String::npos;
+    return path.contains(PARTITION_ID_WILDCARD);
 }
 
 bool StorageObjectStorageConfiguration::Path::hasSchemaHashWildcard() const
 {
-    return path.find(StorageObjectStorageConfiguration::SCHEMA_HASH_WILDCARD) != String::npos;
+    return path.contains(StorageObjectStorageConfiguration::SCHEMA_HASH_WILDCARD);
 }
 
 bool StorageObjectStorageConfiguration::Path::hasGlobsIgnorePlaceholders() const

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -1887,7 +1887,7 @@ String StorageObjectStorageQueue::chooseZooKeeperPath(
         result_zk_path = fs::path(zk_path_prefix) / toString(database_uuid) / toString(table_id.uuid);
     }
 
-    if (context_ && result_zk_path.find('{') != String::npos)
+    if (context_ && result_zk_path.contains('{'))
     {
         Macros::MacroExpansionInfo info;
         info.table_id = table_id;

--- a/src/Storages/StorageMongoDB.cpp
+++ b/src/Storages/StorageMongoDB.cpp
@@ -76,7 +76,7 @@ void MongoDBConfiguration::checkCollection() const
     /// The C driver builds the namespace as "<db>.<collection>" and asserts that the collection part is non-empty.
     /// It treats the name as a NUL-terminated C string, so any embedded NUL truncates it and can produce an
     /// effectively empty collection name, which aborts the process inside the driver.
-    if (collection.empty() || collection.find('\0') != String::npos)
+    if (collection.empty() || collection.contains('\0'))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "MongoDB collection name must be non-empty and must not contain NUL characters");
 }
 

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -1745,7 +1745,7 @@ void StorageURL::processNamedCollectionResult(Configuration & configuration, con
 static String removeDotSegments(const String & path)
 {
     /// Fast path: no dot segments present.
-    if (path.find("/.") == String::npos)
+    if (!path.contains("/."))
         return path;
 
     /// Split the path into segments and process each one.
@@ -1815,7 +1815,7 @@ static String normalizeDotSegmentsInURL(const String & url, size_t authority_sta
     String path = url.substr(path_start, path_end - path_start);
 
     /// Fast check: no dot segments.
-    if (path.find("/.") == String::npos)
+    if (!path.contains("/."))
         return url;
 
     String normalized = removeDotSegments(path);
@@ -2071,7 +2071,7 @@ AzureURLParts parseAzureURL(const String & url)
     const String host = (slash_pos == String::npos) ? rest : rest.substr(0, slash_pos);
     const String path = (slash_pos == String::npos) ? "" : rest.substr(slash_pos + 1);
 
-    if (host.find('.') == String::npos)
+    if (!host.contains('.'))
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,
             "Azure `{}` URL must include the storage account host, e.g. "

--- a/src/Storages/System/StorageSystemDocumentation.cpp
+++ b/src/Storages/System/StorageSystemDocumentation.cpp
@@ -168,7 +168,7 @@ bool isFullPageDescription(std::string_view description)
         else if (!in_code_block)
         {
             const size_t hashes = line.find_first_not_of('#');
-            if (hashes >= 1 && hashes <= 6 && line[hashes] == ' ' && line.find("{#") != std::string_view::npos)
+            if (hashes >= 1 && hashes <= 6 && line[hashes] == ' ' && line.contains("{#"))
                 return true;
         }
 

--- a/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
+++ b/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
@@ -719,7 +719,7 @@ namespace
     /// engine — both when we generate it and when the user specifies an aggregating engine explicitly.
     void allowOffKeyDimensionsForAggregatingTagsEngine(ASTStorage & storage)
     {
-        if (!storage.engine || storage.engine->name.find("Aggregating") == std::string::npos)
+        if (!storage.engine || !storage.engine->name.contains("Aggregating"))
             return;
 
         if (storage.settings)


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/108400

Mechanical replacement of `find(...) == end()` / `find(...) == npos` membership
checks with `contains` across 48 files. No behaviour change. Split out of #108400
so it can be merged on its own.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.538` (included in `26.8` and later)
<!-- ch-version-info:end -->