### PR TITLE
tidy: assorted `clang-tidy` fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,9 +23,11 @@ Checks: [
 
   '-bugprone-assignment-in-if-condition',
   '-bugprone-branch-clone',
+  '-bugprone-derived-method-shadowing-base-method',
   '-bugprone-easily-swappable-parameters',
   '-bugprone-exception-escape',
   '-bugprone-implicit-widening-of-multiplication-result',
+  '-bugprone-invalid-enum-default-initialization',
   '-bugprone-multi-level-implicit-pointer-conversion',
   '-bugprone-narrowing-conversions',
   '-bugprone-unchecked-optional-access',
@@ -34,6 +36,7 @@ Checks: [
   '-bugprone-forward-declaration-namespace',
   '-bugprone-nondeterministic-pointer-iteration-order',
   '-bugprone-sizeof-expression', # too aggressive
+  '-bugprone-throwing-static-initialization',
 
   '-cert-dcl16-c',
   '-cert-arr39-c', # alias of bugprone-sizeof-expression
@@ -41,10 +44,13 @@ Checks: [
 
   '-clang-analyzer-core.BitwiseShift', # false positive on boost::dynamic_bitset::to_ulong
 
+  '-clang-analyzer-core.NullPointerArithm',
+
   '-clang-analyzer-optin.performance.Padding',
 
   '-clang-analyzer-security.ArrayBound', # only false positives
 
+  '-clang-analyzer-cplusplus.NewDelete', # false positive on boost::split/is_any_of, reported inside the header so NOLINT at the call site cannot suppress it
   '-clang-analyzer-cplusplus.NewDeleteLeaks', # false positives, slow
   '-clang-analyzer-unix.Malloc', # fixme, false positive in contrib somehow
 
@@ -133,11 +139,14 @@ Checks: [
   '-misc-const-correctness',
   '-misc-include-cleaner', # useful but far too many occurrences
   '-misc-no-recursion',
+  '-misc-multiple-inheritance',
   '-misc-non-private-member-variables-in-classes',
+  '-misc-override-with-different-visibility',
   '-misc-use-anonymous-namespace',
   '-misc-use-internal-linkage',
 
   '-modernize-avoid-c-arrays',
+  '-modernize-avoid-c-style-cast',
   '-modernize-concat-nested-namespaces',
   '-modernize-pass-by-value',
   '-modernize-return-braced-init-list',
@@ -170,11 +179,14 @@ Checks: [
   '-readability-function-cognitive-complexity',
   '-readability-function-size',
   '-readability-identifier-length',
+  '-readability-inconsistent-declaration-parameter-name',
   '-readability-identifier-naming', # useful but too slow
   '-readability-implicit-bool-conversion',
+  '-readability-inconsistent-ifelse-braces',
   '-readability-magic-numbers',
   '-readability-named-parameter',
   '-readability-redundant-declaration',
+  '-readability-redundant-typename',
   '-readability-redundant-inline-specifier', # useful but incompatible with __attribute((always_inline))__ (aka. ALWAYS_INLINE, base/base/defines.h).
         # ALWAYS_INLINE only has an effect if combined with `inline`: https://godbolt.org/z/Eefd74qdM
   '-readability-redundant-member-init', # Useful but triggers another problem. Imagine a struct S with multiple String members. Structs are often instantiated via designated

--- a/base/base/DecomposedFloat.h
+++ b/base/base/DecomposedFloat.h
@@ -83,7 +83,7 @@ struct DecomposedFloat
 
     uint16_t exponent() const
     {
-        return (x_uint >> (Traits::mantissa_bits)) & ((1ull << Traits::exponent_bits) - 1);
+        return (x_uint >> Traits::mantissa_bits) & ((1ull << Traits::exponent_bits) - 1);
     }
 
     int16_t normalizedExponent() const

--- a/base/pcg-random/pcg_extras.hpp
+++ b/base/pcg-random/pcg_extras.hpp
@@ -466,7 +466,7 @@ template <typename Iter, typename RandType>
 void shuffle(Iter from, Iter to, RandType&& rng) // NOLINT(cppcoreguidelines-missing-std-forward)
 {
     typedef typename std::iterator_traits<Iter>::difference_type delta_t;
-    typedef typename std::remove_reference<RandType>::type::result_type result_t;
+    typedef typename std::remove_reference_t<RandType>::result_type result_t;
     auto count = to - from;
     while (count > 1) {
         delta_t chosen = delta_t(bounded_rand(rng, result_t(count)));

--- a/src/Access/Authentication.h
+++ b/src/Access/Authentication.h
@@ -47,7 +47,7 @@ struct Authentication
         const String & getRealm() const;
 
         Require * clone() const override { return new Require(*this); }
-        void rethrow() const override { throw *this; } /// NOLINT(cert-err60-cpp)
+        void rethrow() const override { throw *this; } /// NOLINT(bugprone-exception-copy-constructor-throws,cert-err60-cpp)
 
     private:
         const String realm;

--- a/src/AggregateFunctions/AggregateFunctionGroupNumericIndexedVectorDataBSI.h
+++ b/src/AggregateFunctions/AggregateFunctionGroupNumericIndexedVectorDataBSI.h
@@ -764,7 +764,7 @@ public:
         UInt64 mask = 0xFFFFFFFFFFFFFFFFULL;
         if (total_bit_num < 64)
         {
-            mask = (1ULL << (total_bit_num)) - 1;
+            mask = (1ULL << total_bit_num) - 1;
         }
         Float64 ratio = static_cast<Float64>(1ULL << vector.fraction_bit_num);
         for (size_t i = 0; i < length; ++i)
@@ -820,7 +820,7 @@ public:
         UInt64 mask = 0xFFFFFFFFFFFFFFFFULL;
         if (total_bit_num < 64)
         {
-            mask = (1ULL << (total_bit_num)) - 1;
+            mask = (1ULL << total_bit_num) - 1;
         }
         Float64 ratio = static_cast<Float64>(1ULL << fraction_bit_num);
         UInt32 number_of_1s = 0;

--- a/src/AggregateFunctions/AggregateFunctionQuantile.h
+++ b/src/AggregateFunctions/AggregateFunctionQuantile.h
@@ -58,7 +58,7 @@ class AggregateFunctionQuantile final
 private:
     using ColVecType = ColumnVectorOrDecimal<Value>;
 
-    static constexpr bool returns_float = !(std::is_same_v<FloatReturnType, void>);
+    static constexpr bool returns_float = !std::is_same_v<FloatReturnType, void>;
     static constexpr bool is_quantile_ddsketch = std::is_same_v<Data, QuantileDD<Value>>;
     static_assert(!is_decimal<Value> || !returns_float);
 

--- a/src/AggregateFunctions/AggregateFunctionQuantileExactWeighted.cpp
+++ b/src/AggregateFunctions/AggregateFunctionQuantileExactWeighted.cpp
@@ -260,7 +260,7 @@ private:
 
     /// get implementation with interpolation
     Value getInterpolatedImpl(Float64 level) const
-    requires(interpolated)
+    requires interpolated
     {
         size_t size = map.size();
         if (0 == size)
@@ -275,7 +275,7 @@ private:
 
     /// getMany implementation with interpolation
     void getManyInterpolatedImpl(const Float64 * levels, const size_t * indices, size_t num_levels, Value * result) const
-    requires(interpolated)
+    requires interpolated
     {
         size_t size = map.size();
         if (0 == size)
@@ -299,7 +299,7 @@ private:
 
     /// getFloat implementation with interpolation
     Float64 getFloatInterpolatedImpl(Float64 level) const
-    requires(interpolated)
+    requires interpolated
     {
         size_t size = map.size();
 
@@ -326,7 +326,7 @@ private:
 
     /// getManyFloat implementation with interpolation
     void getManyFloatInterpolatedImpl(const Float64 * levels, const size_t * indices, size_t num_levels, Float64 * result) const
-    requires(interpolated)
+    requires interpolated
     {
         size_t size = map.size();
         if (0 == size)
@@ -360,7 +360,7 @@ private:
 
     /// Calculate quantile, using linear interpolation between two closest values
     Float64 NO_SANITIZE_UNDEFINED quantileInterpolated(const Pair * array, size_t size, Float64 position) const
-    requires(interpolated)
+    requires interpolated
     {
         size_t lower = static_cast<size_t>(std::floor(position));
         size_t higher = static_cast<size_t>(std::ceil(position));

--- a/src/AggregateFunctions/examples/group_array_sorted.cpp
+++ b/src/AggregateFunctions/examples/group_array_sorted.cpp
@@ -177,8 +177,8 @@ NO_INLINE void benchmark(size_t elements, size_t max_elements)
 
 int mainEntryExampleGroupArraySorted(int argc, char ** argv)
 {
-    (void)(argc);
-    (void)(argv);
+    (void)argc;
+    (void)argv;
 
     if (argc != 4)
     {

--- a/src/Backups/BackupCoordinationStageSync.cpp
+++ b/src/Backups/BackupCoordinationStageSync.cpp
@@ -769,7 +769,7 @@ void BackupCoordinationStageSync::cancelQueryIfDisconnectedTooLong()
 
     {
         std::lock_guard lock{mutex};
-        if (state.host_with_error || ((failure_after_host_disconnected_for_seconds.count() == 0)))
+        if (state.host_with_error || (failure_after_host_disconnected_for_seconds.count() == 0))
             return;
 
         auto monotonic_now = std::chrono::steady_clock::now();

--- a/src/Client/BuzzHouse/Generator/SQLExpression.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLExpression.cpp
@@ -106,7 +106,7 @@ void StatementGenerator::addColNestedAccess(RandomGenerator & rg, ExprColumn * e
                 uint32_t col_counter = 0;
 
                 const uint64_t type_mask_backup = this->next_type_mask;
-                this->next_type_mask = fc.type_mask & ~(allow_nested);
+                this->next_type_mask = fc.type_mask & ~allow_nested;
                 auto tp = randomNextType(rg, this->next_type_mask, col_counter, tpn->mutable_type());
                 this->next_type_mask = type_mask_backup;
             }
@@ -116,7 +116,7 @@ void StatementGenerator::addColNestedAccess(RandomGenerator & rg, ExprColumn * e
             uint32_t col_counter = 0;
 
             const uint64_t type_mask_backup = this->next_type_mask;
-            this->next_type_mask = fc.type_mask & ~(allow_nested);
+            this->next_type_mask = fc.type_mask & ~allow_nested;
             auto tp = randomNextType(rg, this->next_type_mask, col_counter, expr->mutable_dynamic_subtype()->mutable_type());
             this->next_type_mask = type_mask_backup;
         }
@@ -1217,7 +1217,7 @@ void StatementGenerator::generateExpression(RandomGenerator & rg, Expr * expr)
 
             casexpr->set_simple(rg.nextMediumNumber() < 16);
             this->depth++;
-            this->next_type_mask = fc.type_mask & ~(allow_nested);
+            this->next_type_mask = fc.type_mask & ~allow_nested;
             auto tp = randomNextType(rg, this->next_type_mask, col_counter, casexpr->mutable_type_name()->mutable_type());
             this->next_type_mask = type_mask_backup;
             this->generateExpression(rg, casexpr->mutable_expr());

--- a/src/Client/BuzzHouse/Generator/SQLQuery.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLQuery.cpp
@@ -2501,7 +2501,7 @@ void StatementGenerator::generateSelect(
             force_group_by |= nopt > 3 && nopt < 7;
             if (force_global_agg || force_group_by)
             {
-                allowed_clauses &= ~(allow_orderby);
+                allowed_clauses &= ~allow_orderby;
             }
             else
             {

--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -1743,7 +1743,7 @@ String StatementGenerator::addTableColumn(
         if (t.hasPostgreSQLPeer())
         {
             /// Datetime must have 6 digits precision
-            this->next_type_mask &= ~(set_any_datetime_precision);
+            this->next_type_mask &= ~set_any_datetime_precision;
         }
     }
     if ((t.isSQLiteEngine() && (t.isDeterministic() || rg.nextSmallNumber() < 8)) || t.hasSQLitePeer())
@@ -1766,7 +1766,7 @@ String StatementGenerator::addTableColumn(
     if (t.hasDatabasePeer())
     {
         /// ClickHouse's UUID sorting order is different from other databases
-        this->next_type_mask &= ~(allow_uuid);
+        this->next_type_mask &= ~allow_uuid;
     }
     addTableColumnInternal(rg, t, modify, is_pk, special, col, cd);
 

--- a/src/Client/BuzzHouse/Generator/SQLTypes.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTypes.cpp
@@ -1821,7 +1821,7 @@ std::unique_ptr<SQLType> StatementGenerator::randomAggregateType(RandomGenerator
     {
         this->depth++;
         subtypes.emplace_back(
-            this->randomNextType(rg, this->next_type_mask & ~(allow_nested), col_counter2, tp ? af->add_types() : nullptr));
+            this->randomNextType(rg, this->next_type_mask & ~allow_nested, col_counter2, tp ? af->add_types() : nullptr));
         this->depth--;
     }
     if (tp)
@@ -1932,7 +1932,7 @@ StatementGenerator::bottomType(RandomGenerator & rg, const uint64_t allowed_type
           {
               DateTimeTp * dtp = tp ? tp->mutable_datetimes() : nullptr;
 
-              res = randomDateTimeType(rg, low_card ? (allowed_types & ~(allow_datetime64)) : allowed_types, dtp);
+              res = randomDateTimeType(rg, low_card ? (allowed_types & ~allow_datetime64) : allowed_types, dtp);
           }},
          {string_type,
           [&]
@@ -2114,7 +2114,7 @@ StatementGenerator::bottomType(RandomGenerator & rg, const uint64_t allowed_type
           {
               TimeTp * tt = tp ? tp->mutable_times() : nullptr;
 
-              res = randomTimeType(rg, low_card ? (allowed_types & ~(allow_time64)) : allowed_types, tt);
+              res = randomTimeType(rg, low_card ? (allowed_types & ~allow_time64) : allowed_types, tt);
           }},
          {qbit_type,
           [&]
@@ -2220,7 +2220,7 @@ StatementGenerator::randomNextType(RandomGenerator & rg, const uint64_t allowed_
               TopTypeName * arr = tp ? tp->mutable_array() : nullptr;
 
               this->depth++;
-              auto k = this->randomNextType(rg, this->next_type_mask & ~(allow_nested), col_counter, arr);
+              auto k = this->randomNextType(rg, this->next_type_mask & ~allow_nested, col_counter, arr);
               this->depth--;
               result = std::make_unique<ArrayType>(std::move(k));
           }},
@@ -2234,7 +2234,7 @@ StatementGenerator::randomNextType(RandomGenerator & rg, const uint64_t allowed_
               auto k = this->randomNextType(
                   rg, this->next_type_mask & ~(allow_nullable | allow_nested), col_counter, mt ? mt->mutable_key() : nullptr);
               this->width++;
-              auto v = this->randomNextType(rg, this->next_type_mask & ~(allow_nested), col_counter, mt ? mt->mutable_value() : nullptr);
+              auto v = this->randomNextType(rg, this->next_type_mask & ~allow_nested, col_counter, mt ? mt->mutable_value() : nullptr);
               this->depth--;
               this->width--;
               result = std::make_unique<MapType>(std::move(k), std::move(v));
@@ -2272,7 +2272,7 @@ StatementGenerator::randomNextType(RandomGenerator & rg, const uint64_t allowed_
                       opt_cname = std::optional<uint32_t>(ncname);
                   }
                   auto k
-                      = this->randomNextType(rg, this->next_type_mask & ~(allow_nested), col_counter, tcd ? tcd->mutable_type_name() : ttn);
+                      = this->randomNextType(rg, this->next_type_mask & ~allow_nested, col_counter, tcd ? tcd->mutable_type_name() : ttn);
                   subtypes.emplace_back(SubType(opt_cname, std::move(k)));
               }
               this->depth--;
@@ -2319,7 +2319,7 @@ StatementGenerator::randomNextType(RandomGenerator & rg, const uint64_t allowed_
                       tcd->mutable_col()->set_column(cname);
                   }
                   auto k = this->randomNextType(
-                      rg, this->next_type_mask & ~(allow_nested), col_counter, tcd ? tcd->mutable_type_name() : nullptr);
+                      rg, this->next_type_mask & ~allow_nested, col_counter, tcd ? tcd->mutable_type_name() : nullptr);
                   subtypes.emplace_back(NestedSubType(cname, std::move(k)));
               }
               this->depth--;

--- a/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
+++ b/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
@@ -1788,7 +1788,7 @@ std::optional<String> StatementGenerator::alterSingleTable(
                          if (val.tp->getTypeClass() == SQLTypeClass::NESTED)
                              nested_ids.emplace_back(key);
                      }
-                     this->next_type_mask = fc.type_mask & ~(allow_nested);
+                     this->next_type_mask = fc.type_mask & ~allow_nested;
                  }
 
                  const String ncname_key = addTableColumn(rg, t, ncname, true, false, rg.nextMediumNumber() < 6, ColumnSpecial::NONE, def);
@@ -1885,7 +1885,7 @@ std::optional<String> StatementGenerator::alterSingleTable(
                          if (val.tp->getTypeClass() == SQLTypeClass::NESTED)
                              nested_ids.emplace_back(key);
                      }
-                     this->next_type_mask = fc.type_mask & ~(allow_nested);
+                     this->next_type_mask = fc.type_mask & ~allow_nested;
                  }
 
                  const String ncol_key

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -402,7 +402,7 @@ public:
     using Exception::Exception;
 
     LocalFormatError * clone() const override { return new LocalFormatError(*this); }
-    void rethrow() const override { throw *this; } /// NOLINT(cert-err60-cpp)
+    void rethrow() const override { throw *this; } /// NOLINT(bugprone-exception-copy-constructor-throws,cert-err60-cpp)
 };
 
 /// Wrapper for write buffer to execute callback before flush.

--- a/src/Columns/tests/gtest_column_stable_permutation.cpp
+++ b/src/Columns/tests/gtest_column_stable_permutation.cpp
@@ -28,7 +28,7 @@ static void stableGetColumnPermutation(
     int nan_direction_hint,
     IColumn::Permutation & out_permutation)
 {
-    (void)(limit);
+    (void)limit;
 
     size_t size = column.size();
     out_permutation.resize(size);

--- a/src/Common/ColumnsHashing.h
+++ b/src/Common/ColumnsHashing.h
@@ -487,7 +487,7 @@ struct HashMethodSerialized
     /// `Aggregator::executeImpl`'s `prefetch` gate.
     template <typename Data>
     NO_INLINE void initPrecomputedHashes(const Data & data, size_t first_row)
-        requires(prealloc)
+        requires prealloc
     {
         precomputed_hashes_initialized = true;
         calibration_row = first_row + PrefetchingHelper::iterationsToMeasure();
@@ -521,7 +521,7 @@ struct HashMethodSerialized
     friend class columns_hashing_impl::HashMethodBase<Self, Value, Mapped, false>;
 
     ALWAYS_INLINE ArenaKeyHolder getKeyHolder(size_t row, Arena & pool) const
-    requires(prealloc)
+    requires prealloc
     {
         if (use_batch_serialize)
             return ArenaKeyHolder{serialized_keys[row], pool};

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -441,7 +441,7 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool enforce_memory_limit, 
 
             /// If that wasn't enough, try to stop some query.
             OvercommitTracker * overcommit_tracker_ptr = nullptr;
-            if (overcommit_result == OvercommitResult::NONE && ((overcommit_tracker_ptr = overcommit_tracker.load(std::memory_order_relaxed))) && query_tracker != nullptr)
+            if (overcommit_result == OvercommitResult::NONE && (overcommit_tracker_ptr = overcommit_tracker.load(std::memory_order_relaxed)) && query_tracker != nullptr)
                 overcommit_result = overcommit_tracker_ptr->needToStopQuery(query_tracker, size);
 
             if (overcommit_result != OvercommitResult::MEMORY_FREED)

--- a/src/Common/NetException.h
+++ b/src/Common/NetException.h
@@ -29,7 +29,7 @@ public:
     }
 
     NetException * clone() const override { return new NetException(*this); }
-    void rethrow() const override { throw *this; } /// NOLINT(cert-err60-cpp)
+    void rethrow() const override { throw *this; } /// NOLINT(bugprone-exception-copy-constructor-throws,cert-err60-cpp)
 
 private:
     const char * name() const noexcept override { return "DB::NetException"; }

--- a/src/Common/UTF8Helpers.cpp
+++ b/src/Common/UTF8Helpers.cpp
@@ -57,7 +57,7 @@ struct UTF8Decoder
     UInt32 decode(UInt8 byte)
     {
         UInt32 type = TABLE[byte];
-        codepoint = (state != ACCEPT) ? (byte & 0x3fu) | (codepoint << 6) : (0xff >> type) & (byte);
+        codepoint = (state != ACCEPT) ? (byte & 0x3fu) | (codepoint << 6) : (0xff >> type) & byte;
         state = TABLE[256 + state * 16 + type];
         return state;
     }

--- a/src/Common/examples/executable_udf.cpp
+++ b/src/Common/examples/executable_udf.cpp
@@ -15,8 +15,8 @@ using namespace DB;
 
 int mainEntryExampleExecutableUdf(int argc, char **argv)
 {
-    (void)(argc);
-    (void)(argv);
+    (void)argc;
+    (void)argv;
 
     std::string buffer;
 

--- a/src/Common/mysqlxx/mysqlxx/Exception.h
+++ b/src/Common/mysqlxx/mysqlxx/Exception.h
@@ -16,7 +16,7 @@ struct Exception : public Poco::Exception
     const char * className() const noexcept override { return "mysqlxx::Exception"; }
 
     Exception * clone() const override { return new Exception(*this); }
-    void rethrow() const override { throw *this; } /// NOLINT(cert-err60-cpp)
+    void rethrow() const override { throw *this; } /// NOLINT(bugprone-exception-copy-constructor-throws,cert-err60-cpp)
 };
 
 
@@ -28,7 +28,7 @@ struct ConnectionFailed : public Exception
     const char * className() const noexcept override { return "mysqlxx::ConnectionFailed"; }
 
     ConnectionFailed * clone() const override { return new ConnectionFailed(*this); }
-    void rethrow() const override { throw *this; } /// NOLINT(cert-err60-cpp)
+    void rethrow() const override { throw *this; } /// NOLINT(bugprone-exception-copy-constructor-throws,cert-err60-cpp)
 };
 
 
@@ -40,7 +40,7 @@ struct ConnectionLost : public Exception
     const char * className() const noexcept override { return "mysqlxx::ConnectionLost"; }
 
     ConnectionLost * clone() const override { return new ConnectionLost(*this); }
-    void rethrow() const override { throw *this; } /// NOLINT(cert-err60-cpp)
+    void rethrow() const override { throw *this; } /// NOLINT(bugprone-exception-copy-constructor-throws,cert-err60-cpp)
 };
 
 
@@ -52,7 +52,7 @@ struct BadQuery : public Exception
     const char * className() const noexcept override { return "mysqlxx::BadQuery"; }
 
     BadQuery * clone() const override { return new BadQuery(*this); }
-    void rethrow() const override { throw *this; } /// NOLINT(cert-err60-cpp)
+    void rethrow() const override { throw *this; } /// NOLINT(bugprone-exception-copy-constructor-throws,cert-err60-cpp)
 };
 
 
@@ -64,7 +64,7 @@ struct CannotParseValue : public Exception
     const char * className() const noexcept override { return "mysqlxx::CannotParseValue"; }
 
     CannotParseValue * clone() const override { return new CannotParseValue(*this); }
-    void rethrow() const override { throw *this; } /// NOLINT(cert-err60-cpp)
+    void rethrow() const override { throw *this; } /// NOLINT(bugprone-exception-copy-constructor-throws,cert-err60-cpp)
 };
 
 

--- a/src/Common/tests/gtest_bit_packed_string_array.cpp
+++ b/src/Common/tests/gtest_bit_packed_string_array.cpp
@@ -94,7 +94,7 @@ TEST(BitPackedStringArray, BlockBoundaries)
 
 TEST(BitPackedStringArray, RandomStrings)
 {
-    std::mt19937_64 rng(42); // NOLINT(cert-msc32-c,cert-msc51-cpp): deterministic seed for reproducible test
+    std::mt19937_64 rng(42); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp): deterministic seed for reproducible test
     std::vector<std::string> strings;
 
     for (size_t i = 0; i < 10000; ++i)

--- a/src/Common/tests/gtest_bit_packed_uint64_array.cpp
+++ b/src/Common/tests/gtest_bit_packed_uint64_array.cpp
@@ -67,7 +67,7 @@ TEST(BitPackedUInt64Array, BlockBoundaries)
 TEST(BitPackedUInt64Array, IncreasingOffsets)
 {
     /// Emulates offsets in a file: steadily increasing with variable steps.
-    std::mt19937_64 rng(42); // NOLINT(cert-msc32-c,cert-msc51-cpp): deterministic seed for reproducible test
+    std::mt19937_64 rng(42); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp): deterministic seed for reproducible test
     std::vector<UInt64> values;
     UInt64 current = 0;
 
@@ -82,7 +82,7 @@ TEST(BitPackedUInt64Array, IncreasingOffsets)
 
 TEST(BitPackedUInt64Array, RandomValues)
 {
-    std::mt19937_64 rng(42); // NOLINT(cert-msc32-c,cert-msc51-cpp): deterministic seed for reproducible test
+    std::mt19937_64 rng(42); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp): deterministic seed for reproducible test
     std::vector<UInt64> values;
 
     for (size_t i = 0; i < 10000; ++i)

--- a/src/Common/tests/gtest_sort.cpp
+++ b/src/Common/tests/gtest_sort.cpp
@@ -72,7 +72,7 @@ std::vector<int> makeKeys(size_t n, Pattern pattern, std::mt19937_64 & rng)
 
 TEST(Sort, MatchesStdSortTriviallyCopyable)
 {
-    std::mt19937_64 rng(12345); // NOLINT(cert-msc51-cpp,cert-msc32-c): deterministic seed for reproducible test failures
+    std::mt19937_64 rng(12345); // NOLINT(bugprone-random-generator-seed,cert-msc51-cpp,cert-msc32-c): deterministic seed for reproducible test failures
     for (size_t n : test_sizes)
     {
         for (Pattern pattern : test_patterns)
@@ -108,7 +108,7 @@ TEST(Sort, StableSortMatchesStdAndIsStable)
 
     auto less = [](const Item & x, const Item & y) { return x.key < y.key; };
 
-    std::mt19937_64 rng(67890); // NOLINT(cert-msc51-cpp,cert-msc32-c): deterministic seed for reproducible test failures
+    std::mt19937_64 rng(67890); // NOLINT(bugprone-random-generator-seed,cert-msc51-cpp,cert-msc32-c): deterministic seed for reproducible test failures
     for (size_t n : test_sizes)
     {
         for (Pattern pattern : test_patterns)
@@ -153,7 +153,7 @@ TEST(Sort, NonDefaultConstructibleTriviallyCopyable)
 
     auto less = [](const NoDefault & x, const NoDefault & y) { return x.key < y.key; };
 
-    std::mt19937_64 rng(11111); // NOLINT(cert-msc51-cpp,cert-msc32-c): deterministic seed for reproducible test failures
+    std::mt19937_64 rng(11111); // NOLINT(bugprone-random-generator-seed,cert-msc51-cpp,cert-msc32-c): deterministic seed for reproducible test failures
     for (size_t n : test_sizes)
     {
         std::vector<int> keys = makeKeys(n, Pattern::Random, rng);
@@ -195,7 +195,7 @@ TEST(Sort, OverAlignedType)
         return x.key < y.key;
     };
 
-    std::mt19937_64 rng(22222); // NOLINT(cert-msc51-cpp,cert-msc32-c): deterministic seed for reproducible test failures
+    std::mt19937_64 rng(22222); // NOLINT(bugprone-random-generator-seed,cert-msc51-cpp,cert-msc32-c): deterministic seed for reproducible test failures
     for (size_t n : {65u, 128u, 300u, 5000u})
     {
         std::vector<Aligned> a(n);
@@ -226,7 +226,7 @@ TEST(Sort, NonTriviallyCopyableFallback)
 
     auto less = [](const Item & x, const Item & y) { return x.key < y.key; };
 
-    std::mt19937_64 rng(33333); // NOLINT(cert-msc51-cpp,cert-msc32-c): deterministic seed for reproducible test failures
+    std::mt19937_64 rng(33333); // NOLINT(bugprone-random-generator-seed,cert-msc51-cpp,cert-msc32-c): deterministic seed for reproducible test failures
     for (size_t n : test_sizes)
     {
         std::vector<Item> a(n);
@@ -279,7 +279,7 @@ TEST(Sort, MoveBasedPartitionExceptionSafety)
     /// vector is destroyed.
     const size_t n = 512;
 
-    std::mt19937_64 rng(44444); // NOLINT(cert-msc51-cpp,cert-msc32-c): deterministic seed for reproducible test failures
+    std::mt19937_64 rng(44444); // NOLINT(bugprone-random-generator-seed,cert-msc51-cpp,cert-msc32-c): deterministic seed for reproducible test failures
 
     for (size_t limit = 1; limit <= 400; ++limit)
     {

--- a/src/Core/tests/gtest_DecimalFunctions.cpp
+++ b/src/Core/tests/gtest_DecimalFunctions.cpp
@@ -145,10 +145,10 @@ TEST_P(DecimalUtilsSplitAndCombineForDateTime64Test, getFractionalPartDateTime64
 
 }
 
-namespace std // NOLINT(cert-dcl58-cpp)
+namespace std // NOLINT(bugprone-std-namespace-modification,cert-dcl58-cpp)
 {
 
-std::ostream & operator << (std::ostream & ostr, const DecimalUtilsSplitAndCombineTestParam & param) // NOLINT(cert-dcl58-cpp)
+std::ostream & operator << (std::ostream & ostr, const DecimalUtilsSplitAndCombineTestParam & param) // NOLINT(bugprone-std-namespace-modification,cert-dcl58-cpp)
 {
     return ostr << param.description;
 }

--- a/src/Dictionaries/HashedArrayDictionary.cpp
+++ b/src/Dictionaries/HashedArrayDictionary.cpp
@@ -1068,7 +1068,7 @@ void HashedArrayDictionary<dictionary_key_type, sharded>::loadData()
                     break;
 
                 ++total_blocks;
-                total_rows += block.rows();
+                total_rows += block.rows(); // NOLINT(clang-analyzer-cplusplus.Move)
 
                 Stopwatch watch_process;
                 resize(total_rows);

--- a/src/Functions/AI/IAIProvider.h
+++ b/src/Functions/AI/IAIProvider.h
@@ -17,7 +17,7 @@ public:
     AIProviderHTTPException(Poco::Net::HTTPResponse::HTTPStatus http_status_, PreformattedMessage msg);
 
     AIProviderHTTPException * clone() const override { return new AIProviderHTTPException(*this); }
-    void rethrow() const override { throw *this; } /// NOLINT(cert-err60-cpp)
+    void rethrow() const override { throw *this; } /// NOLINT(bugprone-exception-copy-constructor-throws,cert-err60-cpp)
 
     Poco::Net::HTTPResponse::HTTPStatus getHTTPStatus() const { return http_status; }
 

--- a/src/Functions/FunctionsCharsetClassification.cpp
+++ b/src/Functions/FunctionsCharsetClassification.cpp
@@ -105,7 +105,7 @@ struct CharsetClassificationImpl
             std::string_view result_value;
 
             /// Go through the dictionary and find the charset with the highest weight
-            Float64 max_result = zero_frequency_log * (max_string_size);
+            Float64 max_result = zero_frequency_log * max_string_size;
             for (const auto & item : encodings_freq)
             {
                 Float64 score = naiveBayes(item.map, model, max_result);

--- a/src/Functions/FunctionsCodingIP.h
+++ b/src/Functions/FunctionsCodingIP.h
@@ -108,13 +108,13 @@ namespace detail
             {
                 auto & vec_res = col_res->getChars();
                 vec_res.resize(col_size * IPV6_BINARY_LENGTH);
-                return (vec_res);
+                return vec_res;
             }
             else
             {
                 auto & vec_res = col_res->getData();
                 vec_res.resize(col_size);
-                return (vec_res);
+                return vec_res;
             }
         };
 

--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -4223,10 +4223,10 @@ struct ToDateMonotonicity
              && ((left.isNull() || left.safeGet<UInt64>() <= max_day_num) && (right.isNull() || right.safeGet<UInt64>() > max_day_num)))
             || ((left.getType() == Field::Types::Int64 || left.isNull()) && (right.getType() == Field::Types::Int64 || right.isNull())
                 && ((left.isNull() || left.safeGet<Int64>() <= static_cast<Int64>(max_day_num)) && (right.isNull() || right.safeGet<Int64>() > static_cast<Int64>(max_day_num))))
-            || ((
+            || (
                 (left.getType() == Field::Types::Float64 || left.isNull())
                 && (right.getType() == Field::Types::Float64 || right.isNull())
-                && ((left.isNull() || left.safeGet<Float64>() <= static_cast<Float64>(max_day_num)) && (right.isNull() || right.safeGet<Float64>() > static_cast<Float64>(max_day_num)))))
+                && ((left.isNull() || left.safeGet<Float64>() <= static_cast<Float64>(max_day_num)) && (right.isNull() || right.safeGet<Float64>() > static_cast<Float64>(max_day_num))))
             || !isNativeNumber(type))
         {
             return {};

--- a/src/Functions/FunctionsStringSimilarity.cpp
+++ b/src/Functions/FunctionsStringSimilarity.cpp
@@ -176,7 +176,7 @@ struct NgramDistanceImpl
                         res &= ~(1u << (5 + 2 * CHAR_BIT));
                         [[fallthrough]];
                     case 2:
-                        res &= ~(1u);
+                        res &= ~1u;
                         res &= ~(1u << (5 + CHAR_BIT));
                         [[fallthrough]];
                     default:

--- a/src/Functions/MatchImpl.h
+++ b/src/Functions/MatchImpl.h
@@ -271,7 +271,7 @@ struct MatchImpl
                           *  so that it can match when `required_substring` occurs into the string several times,
                           *  and at the first occurrence, the regexp is not a match.
                           */
-                        const size_t start_pos = (required_substring_is_prefix) ? (reinterpret_cast<const char *>(pos) - str_data) : 0;
+                        const size_t start_pos = required_substring_is_prefix ? (reinterpret_cast<const char *>(pos) - str_data) : 0;
                         const size_t end_pos = str_size;
 
                         const bool match = regexp.getRE2()->Match(
@@ -442,7 +442,7 @@ struct MatchImpl
                             *  so that it can match when `required_substring` occurs into the string several times,
                             *  and at the first occurrence, the regexp is not a match.
                             */
-                            const size_t start_pos = (required_substring_is_prefix) ? (reinterpret_cast<const char *>(pos) - str_data) : 0;
+                            const size_t start_pos = required_substring_is_prefix ? (reinterpret_cast<const char *>(pos) - str_data) : 0;
                             const size_t end_pos = N;
 
                             const bool match = regexp.getRE2()->Match(

--- a/src/Functions/URL/cutWWW.cpp
+++ b/src/Functions/URL/cutWWW.cpp
@@ -30,7 +30,7 @@ struct ExtractWWW
                     return;
             }
 
-            if (end - pos < 2 || *(pos) != '/' || *(pos + 1) != '/')
+            if (end - pos < 2 || *pos != '/' || *(pos + 1) != '/')
                 return;
 
             const char *start_of_host = (pos += 2);

--- a/src/Functions/array/arraySort.h
+++ b/src/Functions/array/arraySort.h
@@ -32,7 +32,7 @@ struct ArraySortImpl
     static void checkArguments(
         const String & name,
         const ColumnWithTypeAndName * fixed_arguments)
-        requires(num_fixed_params)
+        requires num_fixed_params
     {
         if (!fixed_arguments)
             throw Exception(

--- a/src/Functions/bitShiftLeft.cpp
+++ b/src/Functions/bitShiftLeft.cpp
@@ -79,7 +79,7 @@ struct BitShiftLeftImpl
                 if (shift_left_bits)
                 {
                     /// The left b bit of the right byte is moved to the right b bit of this byte
-                    *out = static_cast<UInt8>(static_cast<UInt8>(*(op_pointer) >> (8 - shift_left_bits)) | previous);
+                    *out = static_cast<UInt8>(static_cast<UInt8>(*op_pointer >> (8 - shift_left_bits)) | previous);
                     previous = static_cast<UInt8>(*op_pointer << shift_left_bits);
                 }
                 else

--- a/src/Functions/generateSnowflakeID.cpp
+++ b/src/Functions/generateSnowflakeID.cpp
@@ -83,7 +83,7 @@ SnowflakeId toSnowflakeId(uint64_t snowflake)
 uint64_t fromSnowflakeId(SnowflakeId components)
 {
     return (components.timestamp << (machine_id_bits_count + machine_seq_num_bits_count) |
-            components.machine_id << (machine_seq_num_bits_count) |
+            components.machine_id << machine_seq_num_bits_count |
             components.machine_seq_num);
 }
 

--- a/src/IO/HTTPCommon.h
+++ b/src/IO/HTTPCommon.h
@@ -35,7 +35,7 @@ public:
     {}
 
     HTTPException * clone() const override { return new HTTPException(*this); }
-    void rethrow() const override { throw *this; } /// NOLINT(cert-err60-cpp)
+    void rethrow() const override { throw *this; } /// NOLINT(bugprone-exception-copy-constructor-throws,cert-err60-cpp)
 
     Poco::Net::HTTPResponse::HTTPStatus getHTTPStatus() const { return http_status; }
 

--- a/src/IO/S3/URI.cpp
+++ b/src/IO/S3/URI.cpp
@@ -186,7 +186,7 @@ bool URI::tryInitVirtualHostedStyle(bool is_using_aws_private_link_interface, bo
     String name;
     String endpoint_authority_from_uri;
 
-    if (!re2::RE2::FullMatch(uri.getAuthority(), (use_strict_pattern) ? virtual_hosted_style_pattern_strict : virtual_hosted_style_pattern_light, &bucket, &name, &endpoint_authority_from_uri))
+    if (!re2::RE2::FullMatch(uri.getAuthority(), use_strict_pattern ? virtual_hosted_style_pattern_strict : virtual_hosted_style_pattern_light, &bucket, &name, &endpoint_authority_from_uri))
         return false;
 
     is_virtual_hosted_style = true;

--- a/src/IO/S3Common.h
+++ b/src/IO/S3Common.h
@@ -60,7 +60,7 @@ public:
     bool isAccessTokenExpiredError() const;
 
     S3Exception * clone() const override { return new S3Exception(*this); }
-    void rethrow() const override { throw *this; } /// NOLINT(cert-err60-cpp)
+    void rethrow() const override { throw *this; } /// NOLINT(bugprone-exception-copy-constructor-throws,cert-err60-cpp)
 
 private:
     Aws::S3::S3Errors code;

--- a/src/IO/tests/gtest_libdeflate.cpp
+++ b/src/IO/tests/gtest_libdeflate.cpp
@@ -27,7 +27,7 @@ std::string makeData(size_t size)
 {
     std::string out;
     out.reserve(size);
-    std::mt19937 rng(12345); /// NOLINT(cert-msc32-c,cert-msc51-cpp) deterministic test data on purpose
+    std::mt19937 rng(12345); /// NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp) deterministic test data on purpose
     while (out.size() < size)
     {
         if (rng() % 3 == 0)

--- a/src/IO/tests/gtest_libdeflate_streaming.cpp
+++ b/src/IO/tests/gtest_libdeflate_streaming.cpp
@@ -25,7 +25,7 @@ std::string makeData(size_t size)
 {
     std::string out;
     out.reserve(size);
-    std::mt19937 rng(777); /// NOLINT(cert-msc32-c,cert-msc51-cpp) deterministic test data on purpose
+    std::mt19937 rng(777); /// NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp) deterministic test data on purpose
     while (out.size() < size)
     {
         if (rng() % 2)

--- a/src/Interpreters/Access/InterpreterShowGrantsQuery.cpp
+++ b/src/Interpreters/Access/InterpreterShowGrantsQuery.cpp
@@ -196,8 +196,8 @@ std::vector<AccessEntityPtr> InterpreterShowGrantsQuery::getEntities() const
         bool is_enabled_or_granted_role = entity->isTypeOf<Role>()
             && (current_user->granted_roles.isGranted(id) || roles_info->enabled_roles.contains(id));
 
-        if ((is_current_user /* Any user can see his own grants */)
-            || (is_enabled_or_granted_role /* and grants from the granted roles */)
+        if (is_current_user /* Any user can see his own grants */
+            || is_enabled_or_granted_role /* and grants from the granted roles */
             || (entity->isTypeOf<User>() && show_users.checkAccess(throw_if_access_denied))
             || (entity->isTypeOf<Role>() && show_roles.checkAccess(throw_if_access_denied)))
             entities.push_back(entity);

--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -476,7 +476,7 @@ Cluster::Cluster(const Poco::Util::AbstractConfiguration & config,
         if (!shard_with_replicas && !shard_without_replicas)
             throw Exception(ErrorCodes::UNKNOWN_ELEMENT_IN_CONFIG, "Unknown element in config: {}", key);
 
-        const auto & prefix = config_prefix + key + ((shard_with_replicas) ? ".":  "");
+        const auto & prefix = config_prefix + key + (shard_with_replicas ? ".":  "");
         const auto weight = config.getInt(prefix + ".weight", default_weight);
         auto shard_name = use_shards_names ? config.getString(prefix + ".name") : "";
         if (use_shards_names)

--- a/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
+++ b/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
@@ -220,7 +220,7 @@ IndexAnalysisPartsRanges getIndexAnalysisFromReplicaSync(const LoggerPtr & logge
     IndexAnalysisPartsRanges res;
     Block block;
     while (executor.pull(block))
-        parseIndexAnalysisBlock(std::move(block), res);
+        parseIndexAnalysisBlock(std::move(block), res); // NOLINT(clang-analyzer-cplusplus.Move)
 
     return res;
 }

--- a/src/Interpreters/FileCache/FileSegment.cpp
+++ b/src/Interpreters/FileCache/FileSegment.cpp
@@ -97,13 +97,13 @@ FileSegment::FileSegment(
     {
         /// EMPTY is used when file segment is not in cache and
         /// someone will _potentially_ want to download it (after calling getOrSetDownloader()).
-        case (State::EMPTY):
+        case State::EMPTY:
         {
             chassert(key_metadata.lock());
             break;
         }
         /// DOWNLOADED is used either on initial cache metadata load into memory on server startup
-        case (State::DOWNLOADED):
+        case State::DOWNLOADED:
         {
             reserved_size = downloaded_size = size_;
             /// When the size was read from the file name (`<offset>_<size>`), we deliberately trust it
@@ -118,7 +118,7 @@ FileSegment::FileSegment(
             chassert(key_metadata.lock());
             break;
         }
-        case (State::DETACHED):
+        case State::DETACHED:
         {
             break;
         }

--- a/src/Interpreters/IJoin.h
+++ b/src/Interpreters/IJoin.h
@@ -86,9 +86,9 @@ public:
         SharedHeader left_sample_block_,
         SharedHeader right_sample_block_) const
     {
-        (void)(table_join_);
-        (void)(left_sample_block_);
-        (void)(right_sample_block_);
+        (void)table_join_;
+        (void)left_sample_block_;
+        (void)right_sample_block_;
         throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Clone method is not supported for {}", getName());
     }
 

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -684,7 +684,7 @@ void MergeJoin::mergeInMemoryRightBlocks()
     Block block;
     while (executor.pull(block))
     {
-        if (!block.rows())
+        if (!block.rows()) // NOLINT(clang-analyzer-cplusplus.Move)
             continue;
 
         if (skip_not_intersected)

--- a/src/Parsers/IAST_erase.h
+++ b/src/Parsers/IAST_erase.h
@@ -7,7 +7,7 @@
 namespace std
 {
 
-inline typename DB::ASTs::size_type erase(DB::ASTs & asts, const DB::ASTPtr & element) /// NOLINT(cert-dcl58-cpp)
+inline typename DB::ASTs::size_type erase(DB::ASTs & asts, const DB::ASTPtr & element) /// NOLINT(bugprone-std-namespace-modification,cert-dcl58-cpp)
 {
     auto old_size = asts.size();
     asts.erase(std::remove(asts.begin(), asts.end(), element), asts.end());
@@ -15,7 +15,7 @@ inline typename DB::ASTs::size_type erase(DB::ASTs & asts, const DB::ASTPtr & el
 }
 
 template <class Predicate>
-inline typename DB::ASTs::size_type erase_if(DB::ASTs & asts, Predicate pred) /// NOLINT(cert-dcl58-cpp)
+inline typename DB::ASTs::size_type erase_if(DB::ASTs & asts, Predicate pred) /// NOLINT(bugprone-std-namespace-modification,cert-dcl58-cpp)
 {
     auto old_size = asts.size();
     asts.erase(std::remove_if(asts.begin(), asts.end(), pred), asts.end());

--- a/src/Parsers/Kusto/ParserKQLOperators.cpp
+++ b/src/Parsers/Kusto/ParserKQLOperators.cpp
@@ -317,14 +317,14 @@ String KQLOperators::genHaystackOpExpr(
     String needle;
     String raw_needle; /// needle without wildcards for position-based fallback
     bool needle_is_literal = false;
-    if ((token_pos)->type == TokenType::StringLiteral || token_pos->type == TokenType::QuotedIdentifier)
+    if (token_pos->type == TokenType::StringLiteral || token_pos->type == TokenType::QuotedIdentifier)
     {
         raw_needle = "'" + IParserKQLFunction::escapeSingleQuotes(String(token_pos->begin + 1, token_pos->end - 1)) + "'";
         needle = "'" + left_wildcards + left_space + String(token_pos->begin + 1, token_pos->end - 1)
             + right_space + right_wildcards + "'";
         needle_is_literal = true;
     }
-    else if ((token_pos)->type == TokenType::BareWord)
+    else if (token_pos->type == TokenType::BareWord)
     {
         auto tmp_arg = IParserKQLFunction::getExpression(token_pos);
         raw_needle = tmp_arg;

--- a/src/Processors/Sources/YTsaurusSource.cpp
+++ b/src/Processors/Sources/YTsaurusSource.cpp
@@ -146,7 +146,7 @@ Pipe YTsaurusSourceFactory::createPipe(
         {
             size_t row_from = i * rows_batch_count;
             size_t row_to = (i + 1 == pipes_num) ? rows_count :  (i + 1) * rows_batch_count;
-            YTsaurusClientPtr client_for_source(new YTsaurusClient(*client));
+            auto client_for_source = std::make_shared<YTsaurusClient>(*client);
             pipes.emplace_back(std::make_shared<YTsaurusTableSourceStaticTable>(
                   client_for_source
                 , cypress_path

--- a/src/Server/HTTP/HTTPServerRequest.cpp
+++ b/src/Server/HTTP/HTTPServerRequest.cpp
@@ -203,7 +203,7 @@ std::string HTTPServerRequest::toStringForLogging() const
         getMethod(),
         clientAddress().toString(),
         get("User-Agent", "(none)"),
-        (hasContentLength() ? fmt::format(", Length: {}", getContentLength()) : ("")),
+        (hasContentLength() ? fmt::format(", Length: {}", getContentLength()) : ""),
         getContentType(),
         getTransferEncoding(),
         get("X-Forwarded-For", "(none)"));

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -1399,7 +1399,7 @@ static const ActionsDAG::Node & cloneDAGWithInversionPushDown(
 
     switch (node.type)
     {
-        case (ActionsDAG::ActionType::INPUT):
+        case ActionsDAG::ActionType::INPUT:
         {
             auto & input = inputs_mapping[&node];
             if (input == nullptr)
@@ -1409,7 +1409,7 @@ static const ActionsDAG::Node & cloneDAGWithInversionPushDown(
             res = input;
             break;
         }
-        case (ActionsDAG::ActionType::COLUMN):
+        case ActionsDAG::ActionType::COLUMN:
         {
             String name;
             if (node.column && node.column->getDataType() != TypeIndex::Function)
@@ -1426,20 +1426,20 @@ static const ActionsDAG::Node & cloneDAGWithInversionPushDown(
             res = &inverted_dag.addColumn(node.column, node.result_type, name);
             break;
         }
-        case (ActionsDAG::ActionType::ALIAS):
+        case ActionsDAG::ActionType::ALIAS:
         {
             /// Ignore aliases
             res = &cloneDAGWithInversionPushDown(*node.children.front(), inverted_dag, inputs_mapping, context, need_inversion, boolean_context);
             handled_inversion = true;
             break;
         }
-        case (ActionsDAG::ActionType::ARRAY_JOIN):
+        case ActionsDAG::ActionType::ARRAY_JOIN:
         {
             const auto & arg = cloneDAGWithInversionPushDown(*node.children.front(), inverted_dag, inputs_mapping, context, false, /* boolean_context */ false);
             res = &inverted_dag.addArrayJoin(arg, {});
             break;
         }
-        case (ActionsDAG::ActionType::FUNCTION):
+        case ActionsDAG::ActionType::FUNCTION:
         {
             auto name = node.function_base->getName();
             if (name == "not")

--- a/src/Storages/MergeTree/UniqueKey/tests/gtest_delete_bitmap.cpp
+++ b/src/Storages/MergeTree/UniqueKey/tests/gtest_delete_bitmap.cpp
@@ -122,7 +122,7 @@ TEST(DeleteBitmapTest, ContainsBulkMatchesScalar)
     }
 
     /// Randomised cross-check: 10k random probes against a sparse bitmap.
-    std::mt19937 rng(424242); // NOLINT(cert-msc32-c, cert-msc51-cpp)
+    std::mt19937 rng(424242); // NOLINT(bugprone-random-generator-seed,cert-msc32-c, cert-msc51-cpp)
     std::uniform_int_distribution<UInt32> dist(0, 10'000'000);
     std::vector<UInt64> many(10'000);
     for (auto & r : many)
@@ -275,7 +275,7 @@ TEST(DeleteBitmapTest, RoundtripSingleRow)
 TEST(DeleteBitmapTest, RoundtripSparse1M)
 {
     DeleteBitmap in;
-    std::mt19937 rng(12345); // NOLINT(cert-msc32-c, cert-msc51-cpp)
+    std::mt19937 rng(12345); // NOLINT(bugprone-random-generator-seed,cert-msc32-c, cert-msc51-cpp)
     std::uniform_int_distribution<UInt32> dist(0, 100'000'000);
     std::vector<UInt64> samples;
     samples.reserve(1'000'000);
@@ -286,7 +286,7 @@ TEST(DeleteBitmapTest, RoundtripSparse1M)
     auto out = roundtrip(in);
     EXPECT_EQ(out->cardinality(), in.cardinality());
     /// Spot-check 1000 random samples.
-    std::mt19937 rng2(9999); // NOLINT(cert-msc32-c, cert-msc51-cpp)
+    std::mt19937 rng2(9999); // NOLINT(bugprone-random-generator-seed,cert-msc32-c, cert-msc51-cpp)
     std::uniform_int_distribution<size_t> idx_dist(0, samples.size() - 1);
     for (size_t i = 0; i < 1000; ++i)
     {

--- a/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
@@ -116,7 +116,7 @@ bool agrees(const Columns & cols, size_t ra, size_t rb, size_t max_size = 4096)
 TEST(UniqueKeyEncoding, UInt64Ordering)
 {
     // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
-    std::mt19937_64 rng(0xDEADBEEF);
+    std::mt19937_64 rng(0xDEADBEEF); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
 
     auto col = ColumnUInt64::create();
     /// Boundary values first.
@@ -155,7 +155,7 @@ TEST(UniqueKeyEncoding, AllUnsignedWidths)
 TEST(UniqueKeyEncoding, SignedIntOrdering)
 {
     // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
-    std::mt19937_64 rng(0xCAFEBABE);
+    std::mt19937_64 rng(0xCAFEBABE); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
 
     auto col = ColumnInt64::create();
     for (Int64 v : {std::numeric_limits<Int64>::min(), Int64(-1), Int64(0), Int64(1), std::numeric_limits<Int64>::max()})
@@ -506,7 +506,7 @@ TEST(UniqueKeyEncoding, StringEncoderByteEquivalent)
     /// No-NUL widths spanning cache-line boundaries — fast path.
     {
         // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
-        std::mt19937_64 rng(0xA5A5A5A5);
+        std::mt19937_64 rng(0xA5A5A5A5); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
         for (size_t width : {size_t(0), size_t(1), size_t(7), size_t(8), size_t(15),
                               size_t(16), size_t(17), size_t(31), size_t(32),
                               size_t(33), size_t(63), size_t(64), size_t(65),
@@ -535,7 +535,7 @@ TEST(UniqueKeyEncoding, StringEncoderByteEquivalent)
 
     /// Fuzz — 500 random widths, ~25% '\0' density.
     // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
-    std::mt19937_64 rng(0x1234567890ABCDEFULL);
+    std::mt19937_64 rng(0x1234567890ABCDEFULL); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
     for (size_t trial = 0; trial < 500; ++trial)
     {
         String s(rng() % 257, 0);
@@ -553,7 +553,7 @@ TEST(UniqueKeyEncoding, StringBlockEncoderByteEquivalent)
     /// Block-level path: `encodeBlock` → `appendStringColumn`. Mix of edge
     /// cases and varying widths in a single block.
     // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
-    std::mt19937_64 rng(0xB10C);
+    std::mt19937_64 rng(0xB10C); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
     std::vector<String> rows = {
         String(),
         String("hello", 5),
@@ -620,7 +620,7 @@ TEST(UniqueKeyEncoding, FixedStringEncoderByteEquivalent)
     /// bytes (no escape — width-prefixed). Verify direct memcpy for widths
     /// 8 / 16 / 24 / 32 / 64.
     // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
-    std::mt19937_64 rng(0xFEEDFACE);
+    std::mt19937_64 rng(0xFEEDFACE); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
     for (size_t width : {size_t(8), size_t(16), size_t(24), size_t(32), size_t(64)})
     {
         auto col = ColumnFixedString::create(width);
@@ -940,7 +940,7 @@ TEST(UniqueKeyEncoding, NullableBatchPermutationAlignsFlagAndNested)
 TEST(UniqueKeyEncoding, CompoundKeyShuffleSort)
 {
     // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
-    std::mt19937_64 rng(0x12345678);
+    std::mt19937_64 rng(0x12345678); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
 
     auto col_u = ColumnUInt32::create();
     auto col_s = ColumnString::create();
@@ -1109,7 +1109,7 @@ TEST(UniqueKeyEncoding, DISABLED_MicrobenchUInt641M)
     constexpr size_t N = 1'000'000;
     auto col = ColumnUInt64::create();
     // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
-    std::mt19937_64 rng(42);
+    std::mt19937_64 rng(42); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
     for (size_t i = 0; i < N; ++i)
         col->insert(Field(rng()));
     Columns cols{std::move(col)};
@@ -1128,7 +1128,7 @@ TEST(UniqueKeyEncoding, DISABLED_MicrobenchString321M)
     constexpr size_t N = 1'000'000;
     auto col = ColumnString::create();
     // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
-    std::mt19937_64 rng(43);
+    std::mt19937_64 rng(43); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
     for (size_t i = 0; i < N; ++i)
     {
         String s(32, 0);
@@ -1153,7 +1153,7 @@ TEST(UniqueKeyEncoding, DISABLED_MicrobenchCompoundUInt64String1M)
     auto col_u = ColumnUInt64::create();
     auto col_s = ColumnString::create();
     // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
-    std::mt19937_64 rng(44);
+    std::mt19937_64 rng(44); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
     for (size_t i = 0; i < N; ++i)
     {
         col_u->insert(Field(rng()));

--- a/src/Storages/MergeTree/tests/gtest_generic_exclusion_search.cpp
+++ b/src/Storages/MergeTree/tests/gtest_generic_exclusion_search.cpp
@@ -81,7 +81,7 @@ TEST(GenericExclusionSearch, UnlimitedMatchesBruteForce)
 {
     /// The exhaustive search must reproduce the brute-force expectation for arbitrary patterns,
     /// split factors, and seek thresholds.
-    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
+    // NOLINTNEXTLINE(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
     std::mt19937 rng(42);
 
     for (size_t coarse_index_granularity : {2, 3, 8})
@@ -313,7 +313,7 @@ TEST(GenericExclusionSearch, StepLimitInvariantsWithMultipleInitialRanges)
     /// The budget and multiple initial input ranges (the query condition cache scenario) interact:
     /// whatever the budget, the invariants of the outputs must hold, and marks outside the initial
     /// ranges must not reappear unless the seek merging deliberately bridges a gap.
-    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
+    // NOLINTNEXTLINE(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
     std::mt19937 rng(13);
     auto matching = randomFlags(300, 0.3, rng);
     auto oracle = oracleFromFlags(matching);
@@ -394,7 +394,7 @@ TEST(GenericExclusionSearch, LimitedIsAlwaysCoarserThanUnlimited)
     /// For any budget, truncation may only coarsen the result: everything the exhaustive search
     /// selects stays selected, exact ranges may only shrink, and the limited search never spends
     /// more checks than the exhaustive one, because it visits a subset of the same recursion tree.
-    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
+    // NOLINTNEXTLINE(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
     std::mt19937 rng(37);
 
     for (double density : {0.2, 0.7})
@@ -430,7 +430,7 @@ TEST(GenericExclusionSearch, StepLimitProducesSupersetAndValidExactRanges)
 {
     /// Whatever the budget, the outputs must keep their contracts: sorted and non-intersecting, all
     /// matching marks covered, exact ranges contained in the result and fully matching.
-    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
+    // NOLINTNEXTLINE(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
     std::mt19937 rng(7);
     auto matching = randomFlags(300, 0.3, rng);
     auto oracle = oracleFromFlags(matching);
@@ -520,7 +520,7 @@ TEST(GenericExclusionSearch, LargestRangeSplitFirst)
 
 TEST(GenericExclusionSearch, HugeLimitEqualsUnlimited)
 {
-    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
+    // NOLINTNEXTLINE(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
     std::mt19937 rng(2026);
 
     for (double density : {0.1, 0.6})
@@ -591,7 +591,7 @@ TEST(GenericExclusionSearch, NeverExactOracle)
     /// An oracle that never proves a range fully matching, modelling a key condition that cannot
     /// establish exactness. The result then comes entirely from single-mark accepts: the ranges to
     /// read must still be found, and the exact ranges must stay empty.
-    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
+    // NOLINTNEXTLINE(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
     std::mt19937 rng(29);
     auto matching = randomFlags(150, 0.4, rng);
     auto precise = oracleFromFlags(matching);
@@ -624,7 +624,7 @@ TEST(GenericExclusionSearch, ConservativeOracle)
 {
     /// An over-approximating oracle that never allows exclusion, modelling an imprecise key
     /// condition. The output invariants must hold regardless of the oracle's precision.
-    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
+    // NOLINTNEXTLINE(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp) — deterministic test fixture
     std::mt19937 rng(11);
     auto matching = randomFlags(128, 0.4, rng);
     auto precise = oracleFromFlags(matching);

--- a/src/Storages/MergeTree/tests/gtest_posting_list_codec.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_codec.cpp
@@ -393,7 +393,7 @@ TEST(PostingListCodecTest, LargeDataWithTail)
 
 TEST(PostingListCodecTest, StressRandomSizes)
 {
-    std::mt19937 rng(12345); // NOLINT(cert-msc32-c, cert-msc51-cpp)
+    std::mt19937 rng(12345); // NOLINT(bugprone-random-generator-seed,cert-msc32-c, cert-msc51-cpp)
     std::uniform_int_distribution<size_t> size_dist(1, 500);
     std::uniform_int_distribution<uint32_t> bits_dist(0, 32);
 
@@ -462,7 +462,7 @@ TEST(PostingListCodecTest, Bit32TightTailNoPadding)
 
 TEST(PostingListCodecTest, SmallBitsRandomMonotonicManySizes)
 {
-    std::mt19937 rng(12345); // NOLINT(cert-msc32-c, cert-msc51-cpp)
+    std::mt19937 rng(12345); // NOLINT(bugprone-random-generator-seed,cert-msc32-c, cert-msc51-cpp)
     std::uniform_int_distribution<uint32_t> delta_dist(0, 15);
 
     auto gen = [&](size_t n)
@@ -487,7 +487,7 @@ TEST(PostingListCodecTest, SmallBitsRandomMonotonicManySizes)
 
 TEST(PostingListCodecTest, MixedRandomMonotonicLarger)
 {
-    std::mt19937 rng(20240601); // NOLINT(cert-msc32-c, cert-msc51-cpp)
+    std::mt19937 rng(20240601); // NOLINT(bugprone-random-generator-seed,cert-msc32-c, cert-msc51-cpp)
     std::uniform_int_distribution<uint32_t> delta_dist(0, 100000);
 
     for (int t = 0; t < 20; ++t)

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -1012,7 +1012,7 @@ TEST(PostingListCursorTest, BruteForceIntersectThree)
 
 TEST(PostingListCursorTest, BruteForceVsLeapfrogConsistency)
 {
-    std::mt19937 rng(42); // NOLINT(cert-msc32-c,cert-msc51-cpp)
+    std::mt19937 rng(42); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
     std::uniform_int_distribution<uint32_t> dist(0, 999);
 
     for (int trial = 0; trial < 10; ++trial)
@@ -1238,7 +1238,7 @@ TEST(PostingListCursorTest, UnionZeroCursors)
 
 TEST(PostingListCursorTest, StressRandomIntersectTwo)
 {
-    std::mt19937 rng(12345); // NOLINT(cert-msc32-c,cert-msc51-cpp)
+    std::mt19937 rng(12345); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
 
     for (int trial = 0; trial < 20; ++trial)
     {
@@ -1272,7 +1272,7 @@ TEST(PostingListCursorTest, StressRandomIntersectTwo)
 
 TEST(PostingListCursorTest, StressRandomIntersectFour)
 {
-    std::mt19937 rng(54321); // NOLINT(cert-msc32-c,cert-msc51-cpp)
+    std::mt19937 rng(54321); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
 
     for (int trial = 0; trial < 10; ++trial)
     {
@@ -1312,7 +1312,7 @@ TEST(PostingListCursorTest, StressRandomIntersectFour)
 
 TEST(PostingListCursorTest, StressRandomUnion)
 {
-    std::mt19937 rng(99999); // NOLINT(cert-msc32-c,cert-msc51-cpp)
+    std::mt19937 rng(99999); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
 
     for (int trial = 0; trial < 10; ++trial)
     {
@@ -3102,7 +3102,7 @@ TEST(PostingListCursorTest, ArithmeticMixedNonArithThenArith)
 
     /// Block 0: 128 docs with variable gaps (non-constant delta).
     uint32_t prev = 0;
-    std::mt19937 rng(42); // NOLINT(cert-msc32-c,cert-msc51-cpp)
+    std::mt19937 rng(42); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
     for (int i = 0; i < 128; ++i)
     {
         prev += 1 + (rng() % 5);  // gap 1-5 (variable → non-constant delta)
@@ -3130,7 +3130,7 @@ TEST(PostingListCursorTest, ArithmeticSeekFromNonArithToArith)
     docs.push_back(0);
 
     uint32_t prev = 0;
-    std::mt19937 rng(123); // NOLINT(cert-msc32-c,cert-msc51-cpp)
+    std::mt19937 rng(123); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp)
     for (int i = 0; i < 128; ++i)
     {
         prev += 1 + (rng() % 10);

--- a/src/Storages/ObjectStorage/DataLakes/Paimon/PaimonClient.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Paimon/PaimonClient.cpp
@@ -231,7 +231,7 @@ std::optional<std::pair<Int64, String>> PaimonTableClient::getLatestTableSnapsho
         Int64 next_snapshot_version = snapshot_version + 1;
         StoredObject snapshot_object(latest_snapshot_path);
         StoredObject next_snapshot_object(
-            std::filesystem::path(table_location) / (PAIMON_SNAPSHOT_DIR)
+            std::filesystem::path(table_location) / PAIMON_SNAPSHOT_DIR
             / (PAIMON_SNAPSHOT_PREFIX + std::to_string(next_snapshot_version)));
         if (object_storage->exists(snapshot_object) && !object_storage->exists(next_snapshot_object))
         {
@@ -299,7 +299,7 @@ std::pair<std::vector<PaimonManifestFileMeta>, size_t> PaimonTableClient::getMan
 {
     /// read manifest list file
     auto context = getContext();
-    RelativePathWithMetadata relative_path(std::filesystem::path(table_location) / (PAIMON_MANIFEST_DIR) / manifest_list_path);
+    RelativePathWithMetadata relative_path(std::filesystem::path(table_location) / PAIMON_MANIFEST_DIR / manifest_list_path);
     auto read_settings = getPaimonMetadataReadSettings(disable_filesystem_cache);
     auto manifest_list_buf = createReadBuffer(relative_path, object_storage, context, log, read_settings);
     /// createReadBuffer fills relative_path.metadata->size_bytes via a HEAD request.
@@ -325,7 +325,7 @@ PaimonTableClient::getDataManifest(String manifest_path, const PaimonTableSchema
         return {};
 
     auto context = getContext();
-    RelativePathWithMetadata object_info(std::filesystem::path(table_location) / (PAIMON_MANIFEST_DIR) / manifest_path);
+    RelativePathWithMetadata object_info(std::filesystem::path(table_location) / PAIMON_MANIFEST_DIR / manifest_path);
     auto read_settings = getPaimonMetadataReadSettings(disable_filesystem_cache);
     auto manifest_buf = createReadBuffer(object_info, object_storage, context, log, read_settings);
     /// createReadBuffer fills object_info.metadata->size_bytes via a HEAD request.

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -501,11 +501,11 @@ public:
             std::array<char, 1024> stack; // NOLINT(cppcoreguidelines-pro-type-member-init,hicpp-member-init) - written by `vsnprintf` before read
             if (vsnprintf(stack.data(), stack.size(), format, backup_ap) < static_cast<int>(stack.size()))
             {
-                va_end(backup_ap);
+                va_end(backup_ap); // NOLINT(clang-analyzer-security.VAList)
                 LOG_IMPL(log, level.first, level.second, "{}", stack.data());
                 return;
             }
-            va_end(backup_ap);
+            va_end(backup_ap); // NOLINT(clang-analyzer-security.VAList)
         }
 
         /// let's try with a bigger dynamic buffer (but not too huge, since

--- a/src/Storages/Statistics/StatisticsUniq.cpp
+++ b/src/Storages/Statistics/StatisticsUniq.cpp
@@ -44,7 +44,7 @@ void StatisticsUniq::build(const ColumnPtr & column)
         raw_column_ptr = column.get();
     }
 
-    collector->addBatchSinglePlace(0, raw_column_ptr->size(), data, &(raw_column_ptr), nullptr);
+    collector->addBatchSinglePlace(0, raw_column_ptr->size(), data, &raw_column_ptr, nullptr);
 }
 
 void StatisticsUniq::merge(const StatisticsPtr & other_stats)

--- a/src/Storages/Statistics/StatisticsUniqV2.cpp
+++ b/src/Storages/Statistics/StatisticsUniqV2.cpp
@@ -54,7 +54,7 @@ void StatisticsUniqV2::build(const ColumnPtr & column)
         raw_column_ptr = column.get();
     }
 
-    collector->addBatchSinglePlace(0, raw_column_ptr->size(), data, &(raw_column_ptr), nullptr);
+    collector->addBatchSinglePlace(0, raw_column_ptr->size(), data, &raw_column_ptr, nullptr);
 }
 
 void StatisticsUniqV2::merge(const StatisticsPtr & other_stats)

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -390,7 +390,7 @@ private:
                             : retry_count(0ull)
                             , latest_fail_time_us(static_cast<size_t>(Poco::Timestamp().epochMicroseconds()))
                             , max_postpone_time_ms(max_postpone_time_ms_)
-                            , max_postpone_power((max_postpone_time_ms_) ? (static_cast<size_t>(std::log2(max_postpone_time_ms_))) : (0ull))
+                            , max_postpone_power(max_postpone_time_ms_ ? static_cast<size_t>(std::log2(max_postpone_time_ms_)) : 0ull)
             {}
 
 

--- a/src/Storages/System/StorageSystemCompletions.cpp
+++ b/src/Storages/System/StorageSystemCompletions.cpp
@@ -224,7 +224,7 @@ static void fillDataWithTableFunctions(MutableColumns & res_columns, const Conte
     for (const auto & function_name : table_functions)
     {
         auto properties = table_functions_factory.tryGetProperties(function_name);
-        if ((non_readonly_allowed) || (properties && properties->allow_readonly))
+        if (non_readonly_allowed || (properties && properties->allow_readonly))
         {
             res_columns[0]->insert(function_name);
             res_columns[1]->insert(TABLE_FUNCTION_CONTEXT);


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/108400

Assorted `clang-tidy` fixes split out of #108400 so they can be merged
independently of the toolchain bump. One commit per check.

- `readability-redundant-parentheses` — remove redundant parentheses around
  `requires` clauses, `switch` case labels, unary operands, `(void)` casts and
  ternary conditions.
- `bugprone-random-generator-seed` — these tests seed `std::mt19937` with a
  constant on purpose so that failures reproduce; extends the existing
  `cert-msc32-c`/`cert-msc51-cpp` NOLINT comments.
- `bugprone-exception-copy-constructor-throws` — `rethrow` does `throw *this`
  and our exception classes hold a `String`, so the copy constructor can throw;
  extends the existing `cert-err60-cpp` NOLINT comments.
- `modernize-type-traits`, `modernize-make-shared` and
  `bugprone-std-namespace-modification` — use the `_t`/`_v` trait aliases
  instead of `::type`/`::value`, construct `YTsaurusClientPtr` with
  `std::make_shared` instead of `new`, and extend the `cert-dcl58-cpp` NOLINT
  comments on the deliberate `namespace std` additions.
- `.clang-tidy` — disable checks that duplicate ones we already run or that we
  do not want to enforce codebase-wide, and suppress the `clang-22` analyzer
  false positives. `clang-analyzer-cplusplus.NewDelete` is disabled globally
  rather than per call site: it false-positives on `boost::split`/`is_any_of`
  and reports inside the Boost header, so a NOLINT at the call site cannot
  suppress it.

No behaviour change — every change is a comment, a redundant-token removal, or a
`.clang-tidy` entry. The `.clang-tidy` part is inert until #108400 lands, since
those checks only exist in `clang-22`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
