### PR TITLE
fix: throw on queue-full in synchronous QueryRunner mode instead of silently counting down the latch (#112534)

### DIFF
--- a/src/Storages/StorageQueryRunner.cpp
+++ b/src/Storages/StorageQueryRunner.cpp
@@ -351,6 +351,22 @@ public:
             LOG_WARNING(log, "The table is shutting down, discarding the query");
         else
             LOG_ERROR(LogFrequencyLimiter(log, 5), "The queue is full (max_queue_size = {}), discarding the query", max_queue_size);
+
+        if (batch)
+        {
+            /// In synchronous mode, discarding a query is a user-visible error:
+            /// the INSERT must fail so the caller knows that not all queries were
+            /// executed. Retire the seq (so PrefixLatch does not wedge) but do NOT
+            /// count down the latch — that would make the INSERT appear successful.
+            pending.retire(seq);
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Synchronous mode: the queue is full (max_queue_size = {}), "
+                "discarding the query. Use 'asynchronous' mode, "
+                "increase 'max_queue_size', or reduce the batch size",
+                max_queue_size);
+        }
+
         finishJob(batch, seq);
     }
 


### PR DESCRIPTION
### Problem

When a `QueryRunner` table with `mode = 'synchronous'` receives more queries than `max_queue_size`, the excess queries are discarded silently. The `CountDownLatch` is counted down for every discarded query (via `finishJob`), so it reaches zero when all rows have been "accounted for" — including discarded ones. The `INSERT` returns exit code 0, and the caller has no way to learn that most of its queries were never executed.

### Root cause

`QueryRunnerDispatcher::submit()` calls `finishJob(batch, seq)` on every exit path, including the queue-full and shutdown-discard paths. `finishJob` counts down the `CountDownLatch`, which is the mechanism that signals completion to the synchronous `INSERT`. The latch has no error channel — "all jobs retired" is indistinguishable from "all queries finished".

### Fix

When the queue is full and a `batch` is present (synchronous mode), instead of counting down the latch:

1. Retire the `PrefixLatch` seq so the pending-issue tracker does not wedge.
2. Throw `BAD_ARGUMENTS` with a descriptive message pointing the user to `asynchronous` mode, a larger `max_queue_size`, or a smaller batch.

The exception propagates through `QueryRunnerSink::consume()` and the `INSERT` fails with a clear error. Asynchronous mode is unaffected — the existing silent-discard behaviour is retained.

### Testing

```sql
CREATE TABLE runner (query String) ENGINE = QueryRunner SETTINGS mode = 'synchronous';
CREATE TABLE sink (x UInt64) ENGINE = Memory;

-- default max_queue_size = 1000, threads = 4
INSERT INTO runner SELECT 'INSERT INTO sink SELECT 1' FROM numbers(5000);
-- Before: exit code 0, 1004 executed, 3996 silently discarded
-- After: BAD_ARGUMENTS: Synchronous mode: the queue is full (max_queue_size = 1000), discarding the query
```

Fixes #112534