### PR TITLE
fix: accept materialized constant argument for ntile in distributed queries

### DIFF
--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -2214,8 +2214,6 @@ namespace
             const auto & current_block = transform->blockAt(transform->current_row);
             const auto & workspace = transform->workspaces[function_index];
             const auto & arg_col = *current_block.original_input_columns[workspace.argument_column_indices[0]];
-            if (!isColumnConst(arg_col))
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument of 'ntile' function must be a constant");
             auto type_id = argument_types[0]->getTypeId();
             if (type_id == TypeIndex::UInt8)
                 buckets = arg_col[transform->current_row.row].safeGet<UInt8>();


### PR DESCRIPTION
### Description

Fix #112401: `ntile(constant)` fails with `BAD_ARGUMENTS` when the query reads from a multi-shard `cluster()`/`Distributed` source because the constant argument loses its constness on the distributed two-stage path.

The `ntile` window function validates that its argument is a `ColumnConst` and throws `BAD_ARGUMENTS` ("Argument of ntile function must be a constant") when it is not. On the distributed query path, the argument column arrives materialized (all values equal to the original constant), so this check rejects a valid query.

**Fix:** Remove the `isColumnConst(arg_col)` check. The value is already read from `arg_col[current_row]` which works for both const and materialized columns. The `buckets` variable is cached after the first read, so subsequent rows are not affected.

Sibling constant-argument window functions (`nth_value(k, 2)`, `lagInFrame(k, 1)`) already work over multi-shard sources — only `ntile` had this overly strict validation.

### How to reproduce

```sql
CREATE TABLE br (k UInt32, w Int64) ENGINE = MergeTree ORDER BY k;
INSERT INTO br SELECT number, number * 2 FROM numbers(100);

-- Works locally
SELECT k, ntile(3) OVER (PARTITION BY w ORDER BY k) FROM br LIMIT 2;

-- Fails on distributed (was: BAD_ARGUMENTS, now: works)
SELECT k, ntile(3) OVER (PARTITION BY w ORDER BY k)
FROM cluster(two_loop, default, br) LIMIT 2;
```