### PR TITLE
fix: use ARGUMENT_OUT_OF_BOUND for long distributed path, add missing check for non-internal_replication branch

### DIFF
--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -950,7 +950,7 @@ std::vector<const Cluster::Address *> Cluster::filterAddressesByShardOrReplica(s
 const std::string & Cluster::ShardInfo::insertPathForInternalReplication(bool prefer_localhost_replica, bool use_compact_format) const
 {
     if (!has_internal_replication)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "internal_replication is not set");
+        throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "internal_replication is not set");
 
     const auto & paths = insert_path_for_internal_replication;
     if (!use_compact_format)
@@ -958,7 +958,7 @@ const std::string & Cluster::ShardInfo::insertPathForInternalReplication(bool pr
         const auto & path = prefer_localhost_replica ? paths.prefer_localhost_replica : paths.no_prefer_localhost_replica;
         if (path.size() > NAME_MAX)
         {
-            throw Exception(ErrorCodes::LOGICAL_ERROR,
+            throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND,
                 "Path '{}' for async distributed INSERT is too long (exceed {} limit)", path, NAME_MAX);
         }
         return path;

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -28,6 +28,7 @@
 #include <Common/setThreadName.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/Exception.h>
+#include <climits>
 #include <Common/ProfileEvents.h>
 #include <Common/CurrentThread.h>
 #include <Common/ThreadGroupSwitcher.h>
@@ -797,7 +798,13 @@ void DistributedSink::writeAsyncImpl(const Block & block, size_t shard_id)
         std::vector<std::string> dir_names;
         for (const auto & address : cluster->getShardsAddresses()[shard_id])
             if (!address.is_local || !settings[Setting::prefer_localhost_replica])
-                dir_names.push_back(address.toFullString(settings[Setting::use_compact_format_in_distributed_parts_names]));
+            {
+                const auto & dir_name = address.toFullString(settings[Setting::use_compact_format_in_distributed_parts_names]);
+                if (dir_name.size() > NAME_MAX)
+                    throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND,
+                        "Path '{}' for async distributed INSERT is too long (exceed {} limit)", dir_name, NAME_MAX);
+                dir_names.push_back(dir_name);
+            }
 
         if (!dir_names.empty())
             writeToShard(shard_info, block_to_send, dir_names);


### PR DESCRIPTION
Fixes #112719

### Changes

1. **src/Interpreters/Cluster.cpp**: Changed  to  in  for the path-too-long check.  causes the server to abort in debug/sanitizer builds even though the condition is purely input-driven.

2. **src/Storages/Distributed/DistributedSink.cpp**: Added a missing path length check for the  branch. Previously, a long directory name would fail with an opaque  (ENAMETOOLONG from mkdir). Now it throws  with a descriptive message.