### PR TITLE
fix: validate projection name length at DDL time to prevent unwritable tables

### DIFF
--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -53,6 +53,7 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
     extern const int NO_SUCH_PROJECTION_IN_TABLE;
     extern const int BAD_ARGUMENTS;
+    extern const int ARGUMENT_OUT_OF_BOUND;
     extern const int SUPPORT_IS_DISABLED;
 }
 
@@ -858,6 +859,17 @@ void ProjectionsDescription::add(ProjectionDescription && projection, const Stri
             return;
         throw Exception(
             ErrorCodes::ILLEGAL_PROJECTION, "Cannot add projection {}: projection with this name already exists", projection.name);
+    }
+
+    /// Validate projection name length: the directory name is <name>.proj,
+    /// so the name must fit in NAME_MAX - strlen(".proj") = 255 - 5 = 250.
+    constexpr size_t max_projection_name_length = 250;
+    if (projection.name.length() > max_projection_name_length)
+    {
+        throw Exception(
+            ErrorCodes::ARGUMENT_OUT_OF_BOUND,
+            "The max length of projection name is {}, current length is {}",
+            max_projection_name_length, projection.name.length());
     }
 
     auto insert_it = projections.cend();


### PR DESCRIPTION
Closes #112714

A projection whose name is longer than 250 characters is accepted by `CREATE TABLE`
and `ALTER TABLE ... ADD PROJECTION`, but every `INSERT` into that table then fails
with `Code: 1001, STD_EXCEPTION` (ENAMETOOLONG). The directory name is `<name>.proj`,
so the raw name must fit in `NAME_MAX - strlen(".proj") = 255 - 5 = 250`.

**Changes:**
1. Added `extern const int ARGUMENT_OUT_OF_BOUND` error code declaration
2. Added name length validation in `ProjectionsDescription::add()` that throws
   `ARGUMENT_OUT_OF_BOUND` at DDL time, consistent with how
   `DatabaseOnDisk::checkTableNameLength` validates table names

**Verification boundary:**
| projection name length | `<name>.proj` | Before fix | After fix |
|---|---|---|---|
| 249 | 254 | OK | OK |
| 250 | 255 | OK | OK |
| 251 | 256 | `Code: 1001, STD_EXCEPTION` | `Code: 69, ARGUMENT_OUT_OF_BOUND` |