### PR TITLE
fix: make sorted DISTINCT use bitwise comparison for float columns to distinguish -0.0 from 0.0

### DIFF
--- a/src/Core/CompareHelper.h
+++ b/src/Core/CompareHelper.h
@@ -3,6 +3,7 @@
 #include <base/defines.h>
 #include <base/types.h>
 #include <Common/NaNUtils.h>
+#include <cstring>
 
 
 namespace DB
@@ -62,7 +63,17 @@ struct FloatCompareHelper
         return a > b;
     }
 
-    static constexpr bool equals(T a, T b, int nan_direction_hint) { return compare(a, b, nan_direction_hint) == 0; }
+    static bool equals(T a, T b, int nan_direction_hint)
+    {
+        /// Use bitwise comparison for float types to distinguish -0.0 from 0.0
+        /// and other bitwise-different values that compare equal.
+        /// This is consistent with GROUP BY and the hash-based DISTINCT variant.
+        if (isNaN(a) && isNaN(b))
+            return true;
+        if (isNaN(a) || isNaN(b))
+            return false;
+        return memcmp(&a, &b, sizeof(T)) == 0;
+    }
 
     static constexpr int compare(T a, T b, int nan_direction_hint)
     {

--- a/src/Processors/Transforms/DistinctSortedStreamTransform.cpp
+++ b/src/Processors/Transforms/DistinctSortedStreamTransform.cpp
@@ -1,6 +1,8 @@
 #include <Processors/Transforms/DistinctSortedStreamTransform.h>
 
 #include <Core/SortCursor.h>
+#include <cstring>
+#include <Common/NaNUtils.h>
 
 namespace DB
 {
@@ -129,9 +131,30 @@ bool DistinctSortedStreamTransform::isLatestKeyFromPrevChunk(const size_t row_po
                 i,
                 sorted_column.getFamilyName());
 
-        const int res = prev_chunk_latest_key[i]->compareAt(0, row_pos, sorted_column, sorted_columns_descr[i].nulls_direction);
-        if (res != 0)
-            return false;
+        /// For float columns, use bitwise comparison (via getFloat64 + memcmp) to
+        /// distinguish -0.0 from 0.0, consistent with the hash-based DISTINCT
+        /// variant and GROUP BY.
+        const char * family_name = sorted_column.getFamilyName();
+        if (family_name == "Float64" || family_name == "Float32")
+        {
+            const Float64 prev = prev_chunk_latest_key[i]->getFloat64(0);
+            const Float64 curr = sorted_column.getFloat64(row_pos);
+            /// Both NaN: equal (consistent with compareAt NaN handling).
+            if (isNaN(prev) && isNaN(curr))
+                continue;
+            /// One NaN, one not: not equal.
+            if (isNaN(prev) || isNaN(curr))
+                return false;
+            /// Bitwise comparison: memcmp on the float64 representation.
+            if (memcmp(&prev, &curr, sizeof(prev)) != 0)
+                return false;
+        }
+        else
+        {
+            const int res = prev_chunk_latest_key[i]->compareAt(0, row_pos, sorted_column, sorted_columns_descr[i].nulls_direction);
+            if (res != 0)
+                return false;
+        }
     }
     return true;
 }


### PR DESCRIPTION
### Bug

`SELECT DISTINCT` over a `Float64` column containing both `-0.0` and `0.0` returns a different number of rows depending on which `Distinct` transform the plan picks:
- With `optimize_distinct_in_order = 1` (default): the sorted variant deduplicates by *comparison* (`-0.0 == 0.0`, merged into one row)
- With `optimize_distinct_in_order = 0`: the hash variant deduplicates *bitwise* (kept as two rows)

`GROUP BY` over the same data also keeps both zeros, so the default sorted path contradicts the engine's own grouping/DISTINCT equality.

### Fix

Two changes:

1. **`FloatCompareHelper::equals`** (`src/Core/CompareHelper.h`): Changed from value comparison (`compare(a,b) == 0`) to bitwise comparison (`memcmp`). This `equals` function is used by `getEqualRangeEndAssumeSorted` for float columns, which is the in-chunk range detector for the sorted DISTINCT variant.

2. **`isLatestKeyFromPrevChunk`** (`src/Processors/Transforms/DistinctSortedStreamTransform.cpp`): For float sorted columns, use `getFloat64` + `memcmp` instead of `compareAt` for cross-chunk key comparison. This ensures consistent handling across chunk boundaries.

Both changes make the sorted DISTINCT variant consistent with the hash-based variant and GROUP BY: `-0.0` and `0.0` are kept as distinct values.

### Impact

- `SELECT DISTINCT` returns the same result regardless of which transform runs
- `GROUP BY` and `DISTINCT` are consistent on float columns
- Only `equals` is changed — `compare` (used for sorting/ordering) is unaffected
- NaN handling is preserved (all NaN bit patterns are equal)

Fixes #112396