### PR TITLE
fix: re-check dependencies in S3Queue streaming loop to prevent data loss on MV detach

### DIFF
--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -966,14 +966,16 @@ bool StorageObjectStorageQueue::streamToViews(size_t streaming_tasks_index, UInt
 
     while (!shutdown_called && !file_iterator->isFinished() && !stream_control.isCancelRequested(cycle_epoch))
     {
+        /// Re-check dependencies inside the loop — if the MV was detached
+        /// mid-batch, stop processing and leave remaining files unprocessed
+        /// so re-attaching the view can resume ingestion with no gap.
+        /// Same pattern as Kafka engines (StorageKafka.cpp:619).
+        if (!getDependencies())
+            break;
+
         /// All tasks share a single batch size override so that the halving
         /// converges regardless of which task encounters the bad file.
         auto effective_max_files = max_files_override.load();
-
-        /// FIXME:
-        /// it is possible that MV is dropped just before we start the insert,
-        /// but in this case we would not throw any exception, so
-        /// data will not be inserted anywhere.
         InterpreterInsertQuery interpreter(
             insert,
             queue_context,


### PR DESCRIPTION
Fixes #112341

S3Queue marks files as `Processed` in Keeper — permanently and for every replica — while discarding their rows to a `NullSinkToStorage`, when the attached materialized view is detached (or dropped) while the engine is mid-way through a bucket.

**Root cause:** `StorageObjectStorageQueue::threadFunc` checks the dependency count exactly once at the start, then enters `streamToViews` whose batch loop never re-checks it. When the MV disappears mid-batch, the pipeline completes successfully, the processed-mark is committed to Keeper, and the files are unreprocessable for every replica.

**Fix:** Re-check dependencies inside the streaming loop, matching the pattern both Kafka engines already use (`StorageKafka.cpp:619`). When `getDependencies()` returns 0, break out of the loop so the remaining files are left unprocessed — re-attaching the view resumes ingestion with no gap.

Also removes the `FIXME` comment that documented this exact gap.