### PR TITLE
fix: use conditional write (SetIfNoneMatch) to prevent concurrent INSERT data loss

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -721,7 +721,8 @@ SinkToStoragePtr StorageObjectStorage::write(
         sample_block,
         local_context,
         configuration->format,
-        configuration->compression_method);
+        configuration->compression_method,
+        !settings.truncate_on_insert);
 }
 
 bool StorageObjectStorage::optimize(

--- a/src/Storages/ObjectStorage/StorageObjectStorageSink.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSink.cpp
@@ -1,7 +1,7 @@
 #include <Storages/ObjectStorage/StorageObjectStorageSink.h>
 #include <Formats/FormatFactory.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h>
-#include <Common/isValidUTF8.H>
+#include <Common/isValidUTF8.h>
 #include <Core/Settings.h>
 #include <Storages/ObjectStorage/Utils.h>
 #include <base/defines.h>
@@ -29,12 +29,12 @@ namespace
     {
         /// See:
         /// - https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
-        /// - https://cloud.ibm.com/apidocs/cos/co-compatibility#basicoperations#putobject
+        /// - https://cloud.ibm.com/apidocs/cos/cos-compatibility#putobject
 
         if (str.empty() || str.size() > 1024)
-            throw Exception(ErrorCodes:BAD_ARGUMENTS, "Incorrect key length (not empty, max 1023 characters), got: { }", str.size());
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Incorrect key length (not empty, max 1023 characters), got: {}", str.size());
 
-        if (!UTF8(isValidUTF8(reinterpret_cast<const UInt8 *>(str.data()), str.size())))
+        if (!UTF8::isValidUTF8(reinterpret_cast<const UInt8 *>(str.data()), str.size()))
             throw Exception(ErrorCodes::CANNOT_PARSE_TEXT, "Incorrect non-UTF8 sequence in key");
 
         PartitionedSink::validatePartitionKey(str, true);
@@ -44,7 +44,7 @@ namespace
     {
         configuration->validateNamespace(str);
 
-        if (!UTF8(isValidUTF8(reinterpret_cast<const UInt8 >*(str.data()), str.size())))
+        if (!UTF8::isValidUTF8(reinterpret_cast<const UInt8 *>(str.data()), str.size()))
             throw Exception(ErrorCodes::CANNOT_PARSE_TEXT, "Incorrect non-UTF8 sequence in bucket name");
 
         PartitionedSink::validatePartitionKey(str, false);

--- a/src/Storages/ObjectStorage/StorageObjectStorageSink.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSink.cpp
@@ -1,7 +1,7 @@
 #include <Storages/ObjectStorage/StorageObjectStorageSink.h>
 #include <Formats/FormatFactory.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h>
-#include <Common/isValidUTF8.h>
+#include <Common/isValidUTF8.H>
 #include <Core/Settings.h>
 #include <Storages/ObjectStorage/Utils.h>
 #include <base/defines.h>
@@ -29,12 +29,12 @@ namespace
     {
         /// See:
         /// - https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
-        /// - https://cloud.ibm.com/apidocs/cos/cos-compatibility#putobject
+        /// - https://cloud.ibm.com/apidocs/cos/co-compatibility#basicoperations#putobject
 
         if (str.empty() || str.size() > 1024)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Incorrect key length (not empty, max 1023 characters), got: {}", str.size());
+            throw Exception(ErrorCodes:BAD_ARGUMENTS, "Incorrect key length (not empty, max 1023 characters), got: { }", str.size());
 
-        if (!UTF8::isValidUTF8(reinterpret_cast<const UInt8 *>(str.data()), str.size()))
+        if (!UTF8(isValidUTF8(reinterpret_cast<const UInt8 *>(str.data()), str.size())))
             throw Exception(ErrorCodes::CANNOT_PARSE_TEXT, "Incorrect non-UTF8 sequence in key");
 
         PartitionedSink::validatePartitionKey(str, true);
@@ -44,7 +44,7 @@ namespace
     {
         configuration->validateNamespace(str);
 
-        if (!UTF8::isValidUTF8(reinterpret_cast<const UInt8 *>(str.data()), str.size()))
+        if (!UTF8(isValidUTF8(reinterpret_cast<const UInt8 >*(str.data()), str.size())))
             throw Exception(ErrorCodes::CANNOT_PARSE_TEXT, "Incorrect non-UTF8 sequence in bucket name");
 
         PartitionedSink::validatePartitionKey(str, false);
@@ -58,7 +58,8 @@ StorageObjectStorageSink::StorageObjectStorageSink(
     SharedHeader sample_block_,
     ContextPtr context,
     const String & format,
-    const String & compression_method)
+    const String & compression_method,
+    bool use_conditional_write)
     : SinkToStorage(sample_block_)
     , path(path_)
     , sample_block(sample_block_)
@@ -66,8 +67,12 @@ StorageObjectStorageSink::StorageObjectStorageSink(
     const auto & settings = context->getSettingsRef();
     const auto chosen_compression_method = chooseCompressionMethod(path, compression_method);
 
+    auto write_settings = context->getWriteSettings();
+    if (use_conditional_write)
+        write_settings.object_storage_write_if_none_match = "*";
+
     auto buffer = object_storage->writeObject(
-        StoredObject(path), WriteMode::Rewrite, std::nullopt, DBMS_DEFAULT_BUFFER_SIZE, context->getWriteSettings());
+        StoredObject(path), WriteMode::Rewrite, std::nullopt, DBMS_DEFAULT_BUFFER_SIZE, write_settings);
 
     write_buf = wrapWriteBufferWithCompressionMethod(
         std::move(buffer),
@@ -182,7 +187,8 @@ SinkPtr PartitionedStorageObjectStorageSink::createSinkForPartition(const String
         std::make_shared<Block>(partition_strategy->getFormatHeader()),
         context,
         configuration->format,
-        configuration->compression_method);
+        configuration->compression_method,
+        !query_settings.truncate_on_insert);
 }
 
 }

--- a/src/Storages/ObjectStorage/StorageObjectStorageSink.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSink.h
@@ -16,11 +16,12 @@ public:
         SharedHeader sample_block_,
         ContextPtr context,
         const String & format,
-        const String & compression_method);
+        const String & compression_method,
+        bool use_conditional_write = false);
 
     ~StorageObjectStorageSink() override;
 
-    String getName() const override { return "StorageObjectStorageSink"; }
+    String GetName() const override { return "StorageObjectStorageSink"; }
 
     void consume(Chunk & chunk) override;
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageSink.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSink.h
@@ -21,7 +21,7 @@ public:
 
     ~StorageObjectStorageSink() override;
 
-    String GetName() const override { return "StorageObjectStorageSink"; }
+    String getName() const override { return "StorageObjectStorageSink"; }
 
     void consume(Chunk & chunk) override;
 


### PR DESCRIPTION
Fixes #112419

## Problem
Two concurrent INSERT INTO FUNCTION s3(...) to the same object-storage key are both acked BACKUP_CREATED, and one writer's rows are silently lost. The exists-check in checkAndGetNewFileOnInsertIfNeeded is not atomic with the unconditional PUT.

## Root cause
The exists-check (Utils.cpp:45-47) checks whether the key exists, then StorageObjectStorageSink calls writeObject with WriteMode::Rewrite unconditionally. Between the check and the PUT, a concurrent writer can create the same key, and the second PUT overwrites the first writer's data.

The s3_create_new_file_on_insert path has the same problem: the while(object_storage.exists(...)) probe is not atomic with the write, so two concurrent writers can settle on the same free key.N.

## Fix
- Add a use_conditional_write parameter to StorageObjectStorageSink constructor
- When truncate_on_insert is false, set object_storage_write_if_none_match = "*" on the write settings before calling writeObject
- This makes the S3 PUT use SetIfNoneMatch: *, so the second writer's PUT fails with 412 Precondition Failed instead of silently overwriting the first writer's data
- The plumbing already exists in WriteBufferFromS3.cpp:643-644 and WriteBufferFromAzureBlobStorage.cpp:192-193

## Changes
1. StorageObjectStorageSink.h: add use_conditional_write parameter (default false)
2. StorageObjectStorageSink.cpp: modify writeObject call to use conditional write when flag is set
3. StorageObjectStorage.cpp: pass !settings.truncate_on_insert to the sink

## Verification
The existing ClickFawkes test tests/clickfawkes/objectstorage_insert_claim_check_durability.py should flip from BUG to HELD with this fix.