### PR TITLE
Stop the asynchronous logging threads at clickhouse-local exit

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -335,6 +335,15 @@ void LocalServer::processError(std::string_view) const
 }
 
 
+LocalServer::~LocalServer()
+{
+    /// Stop and join the asynchronous logging threads, like `BaseDaemon` does at shutdown.
+    /// They must not keep consuming the log queues while `exit` runs static destructors,
+    /// and ThreadSanitizer reports finished but unjoined threads as leaks at exit.
+    stopLogging();
+}
+
+
 void LocalServer::initialize(Poco::Util::Application & self)
 {
     Poco::Util::Application::initialize(self);

--- a/programs/local/LocalServer.h
+++ b/programs/local/LocalServer.h
@@ -33,6 +33,7 @@ class LocalServer : public ClientApplicationBase, public Loggers, public IServer
 {
 public:
     LocalServer() = default;
+    ~LocalServer() override;
 
     void initialize(Poco::Util::Application & self) override;
 


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/110816
Related: https://github.com/ClickHouse/ClickHouse/pull/110099
Related: https://github.com/ClickHouse/ClickHouse/pull/111979

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`clickhouse-local` never stopped the asynchronous logging threads (one `AsyncLogger` per log channel plus `AsyncTextLog`) started by `Loggers::buildLoggers`. Unlike the server, where `~BaseDaemon` calls `stopLogging`, `LocalServer` had no such call, so `OwnAsyncSplitChannel::close` never ran and the threads were still consuming the log queues while `exit` ran static destructors — verified with gdb breakpoints and strace: `close` is never called and the threads are terminated by `exit_group` instead of being joined.

In CI this intermittently fails the "Scraping system tables" step, which dumps every `system.*_log` table with a separate `clickhouse-local --config-file=/etc/clickhouse-server/config.xml` invocation. Under ThreadSanitizer the unjoined threads surface at exit as

```
WARNING: ThreadSanitizer: thread leak (pid=8365)
  Thread T3 'AsyncLogger' (tid=8369, finished) created by main thread at:
    ...
    #3 DB::OwnAsyncSplitChannel::open() src/Loggers/OwnSplitChannel.cpp:276:25
    #4 Loggers::buildLoggers(...) src/Loggers/Loggers.cpp:297:12
    #5 DB::LocalServer::processConfig() programs/local/LocalServer.cpp:1321:9
```

and since sanitizers run with `abort_on_error=1`, the report aborts `clickhouse-local`, so every table dump in an affected run is reported as failed (about 33 such failures across `amd_tsan` checks since 2026-07-21).

The MSan `use-of-uninitialized-value` failures of the same CI step on `amd_msan` are the same shutdown race, caught in the act. `OwnPatternFormatter::formatExtended` reads Poco's static priority-name strings (`writeString(getPriorityName(priority), wb)`), and the MSan origin shows they had already been destroyed by `exit` (with `poison_in_dtor=1`, destroyed objects are poisoned) while the `AsyncLogger` thread was still formatting a message:

```
  Member fields were destroyed
    #1 std::__1::basic_string<...>::~basic_string() contrib/llvm-project/libcxx/include/string:917:3
    #3 __cxx_global_array_dtor base/poco/Foundation/src/PatternFormatter.cpp
    #4 MSanCxaAtExitWrapper(void*) msan_interceptors.cpp
    #5 __run_exit_handlers stdlib/exit.c:113:8
```

The fix mirrors `BaseDaemon`: `~LocalServer` stops and joins the asynchronous logging threads (`OwnAsyncSplitChannel::close` flushes the queues before joining), so they never overlap with static destruction. Verified with strace that the `AsyncLogger`/`AsyncTextLog` threads now exit and are joined before the final `exit_group`, on both the success and the error path, with exit codes unchanged.

No test is added: every `clickhouse-local` invocation in the sanitizer stateless CI runs exercises this path.
