### PR TITLE
Fold the LLVM coverage report into the main CI comment

### DIFF
--- a/ci/jobs/scripts/job_hooks/llvm_coverage_hook.py
+++ b/ci/jobs/scripts/job_hooks/llvm_coverage_hook.py
@@ -64,7 +64,9 @@ def check():
                 links.append(f"[Uncovered code]({uncovered_code_url})")
             if links:
                 body += "\n" + " · ".join(links)
-            GH.post_fresh_comment(tag="llvm-coverage", body=body)
+            GH.post_updateable_comment(
+                comment_tags_and_bodies={"coverage": body}, only_update=True
+            )
         else:
             print("Not a PR run, skipping GitHub coverage comment")
 

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -605,6 +605,7 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
                 "param_1": "",
                 "summary": "",
                 "review": "",
+                "coverage": "",
             },
         )
         res1 = GH.post_commit_status(


### PR DESCRIPTION
The coverage post-hook used GH.post_fresh_comment, which deletes and recreates its own comment at the bottom of the PR on every commit, producing a separate GitHub notification each time in addition to the main CI summary comment. Switch it to GH.post_updateable_comment so the coverage section is merged into the single main CI comment instead, under a "coverage" tag reserved up front alongside "report", "summary", and "review".

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.630` (included in `26.8` and later)
<!-- ch-version-info:end -->