### PR TITLE
fix: RANK/DENSE_RANK with ROWS frame should use ORDER BY peer groups

### DIFF
--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -795,14 +795,12 @@ bool WindowTransform::arePeers(const RowNumber & x, const RowNumber & y) const
         return true;
     }
 
-    if (window_description.frame.type == WindowFrame::FrameType::ROWS)
-    {
-        // For ROWS frame, row is only peers with itself (checked above);
-        return false;
-    }
-
-    // For RANGE and GROUPS frames, rows that compare equal w/ORDER BY are peers.
-    chassert(window_description.frame.type == WindowFrame::FrameType::RANGE);
+    // RANK, DENSE_RANK, PERCENT_RANK, and CUME_DIST use peer group semantics
+    // regardless of the frame type per the SQL standard. ROWS frames should
+    // not treat every row as its own peer -- ORDER BY values determine peers.
+    // The frame boundaries (not peer groups) control which rows are included
+    // in aggregate calculations, so removing the ROWS short-circuit is safe
+    // for all window function types.
     const size_t n = order_by_indices.size();
     if (n == 0)
     {


### PR DESCRIPTION
### Description
`RANK()` and `DENSE_RANK()` with an explicit `ROWS` frame silently degenerate into `ROW_NUMBER()` because the `arePeers()` function returns `false` for every row when the frame type is `ROWS`. This makes every row its own peer, so all rows get distinct ranks.

### Root cause
`WindowTransform::arePeers()` has a short-circuit for `ROWS` frames that returns `false` for all rows except the row compared with itself:

```cpp
if (window_description.frame.type == WindowFrame::FrameType::ROWS)
{
    // For ROWS frame, row is only peers with itself (checked above);
    return false;
}
```

The SQL standard requires RANK, DENSE_RANK, PERCENT_RANK, and CUME_DIST to use peer group semantics regardless of the frame type. The frame type only affects which rows are included in aggregate window function calculations (via `frame_start` / `frame_end`), not how peer groups are determined for ranking functions.

### Fix
Remove the `ROWS` frame short-circuit. Peer groups are now determined by ORDER BY column values for all frame types, which is the correct behavior per the SQL standard. The frame boundaries (not peer groups) control which rows are included in aggregate calculations, so this change is safe for all window function types.

### How to reproduce
```sql
-- Expected [1,1,3] (the two 'a' rows are ORDER BY peers); actual [1,2,3]
SELECT groupArray(r) FROM (
  SELECT RANK() OVER (ORDER BY v ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS r
  FROM (SELECT arrayJoin(['a','a','b']) AS v));

-- Expected [1,1,2]; actual [1,2,3]
SELECT groupArray(r) FROM (
  SELECT DENSE_RANK() OVER (ORDER BY v ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS r
  FROM (SELECT arrayJoin(['a','a','b']) AS v));
```
