### PR TITLE
fix: prevent optimize_empty_string_comparisons from silently disabling all skip index types

### DIFF
--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -39,7 +39,7 @@ IndexDescription::IndexDescription(const IndexDescription & other)
     , granularity(other.granularity)
     , is_implicitly_created(other.is_implicitly_created)
     , escape_filenames(other.escape_filenames)
-    , normalized_column_names(other.normalized_column_names)
+    , normalized_column_name_to_original(other.normalized_column_name_to_original)
 {
     if (other.expression)
         expression = other.expression->clone();
@@ -80,7 +80,7 @@ IndexDescription & IndexDescription::operator=(const IndexDescription & other)
     granularity = other.granularity;
     is_implicitly_created = other.is_implicitly_created;
     escape_filenames = other.escape_filenames;
-    normalized_column_names = other.normalized_column_names;
+    normalized_column_name_to_original = other.normalized_column_name_to_original;
     return *this;
 }
 
@@ -171,9 +171,10 @@ IndexDescription IndexDescription::getIndexFromAST(
             ASTPtr normalized = expr->clone();
             normalizeColumnExpression(normalizeColumnExpression, normalized);
             String normalized_name = normalized->getColumnName();
+            String original_name = expr->getColumnName();
             // Only add the normalized name if it differs from the original
-            if (normalized_name != expr->getColumnName())
-                result.normalized_column_names.push_back(normalized_name);
+            if (normalized_name != original_name)
+                result.normalized_column_name_to_original[normalized_name] = original_name;
         }
     }
 

--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -11,6 +11,8 @@
 #include <Parsers/parseQuery.h>
 #include <Storages/extractKeyExpressionList.h>
 
+#include <algorithm>
+
 #include <Storages/ReplaceAliasByExpressionVisitor.h>
 
 #include <Core/Defines.h>
@@ -37,6 +39,7 @@ IndexDescription::IndexDescription(const IndexDescription & other)
     , granularity(other.granularity)
     , is_implicitly_created(other.is_implicitly_created)
     , escape_filenames(other.escape_filenames)
+    , normalized_column_names(other.normalized_column_names)
 {
     if (other.expression)
         expression = other.expression->clone();
@@ -77,6 +80,7 @@ IndexDescription & IndexDescription::operator=(const IndexDescription & other)
     granularity = other.granularity;
     is_implicitly_created = other.is_implicitly_created;
     escape_filenames = other.escape_filenames;
+    normalized_column_names = other.normalized_column_names;
     return *this;
 }
 
@@ -126,6 +130,52 @@ IndexDescription IndexDescription::getIndexFromAST(
 
     if (result.column_names.empty())
         throw Exception(ErrorCodes::INCORRECT_QUERY, "Skip index '{}' must have at least one column in its expression", result.name);
+
+    // Compute normalized column names for query-side rewrite matching.
+    // optimize_empty_string_comparisons rewrites x = '' to empty(x) and x != '' to notEmpty(x) in the query,
+    // but the index expression is not rewritten, so the column names no longer match.
+    // Compute the normalized names here so index conditions can also match against them.
+    {
+        /// Rewrites x = '' to empty(x) and x != '' to notEmpty(x), matching the query-side rewrite.
+        auto normalizeColumnExpression = [](auto & normalize_ref, ASTPtr & ast) -> void
+        {
+            for (auto & child : ast->children)
+                normalize_ref(normalize_ref, child);
+
+            const auto * function = ast->as<ASTFunction>();
+            if (!function || (function->name != "equals" && function->name != "notEquals")
+                || !function->arguments || function->arguments->children.size() != 2)
+                return;
+
+            auto is_empty_string_literal = [](const ASTPtr & node)
+            {
+                const auto * literal = node->as<ASTLiteral>();
+                return literal && literal->value.getType() == Field::Types::String && literal->value.safeGet<String>().empty();
+            };
+
+            const auto & arguments = function->arguments->children;
+            ASTPtr expression;
+
+            if (is_empty_string_literal(arguments[1]))
+                expression = arguments[0];
+            else if (is_empty_string_literal(arguments[0]))
+                expression = arguments[1];
+            else
+                return;
+
+            ast = makeASTFunction(function->name == "equals" ? "empty" : "notEmpty", expression);
+        };
+
+        for (const auto & expr : result.expression_list_ast->children)
+        {
+            ASTPtr normalized = expr->clone();
+            normalizeColumnExpression(normalizeColumnExpression, normalized);
+            String normalized_name = normalized->getColumnName();
+            // Only add the normalized name if it differs from the original
+            if (normalized_name != expr->getColumnName())
+                result.normalized_column_names.push_back(normalized_name);
+        }
+    }
 
     if (index_type && index_type->arguments)
         result.arguments = index_type->arguments->clone();

--- a/src/Storages/IndicesDescription.h
+++ b/src/Storages/IndicesDescription.h
@@ -60,6 +60,13 @@ struct IndexDescription
     /// (if using the `escape_index_filenames`).
     bool escape_filenames{};
 
+    /// Alternate names for index columns after applying the same expression rewrites that
+    /// the query optimizer applies (e.g. `optimize_empty_string_comparisons` rewrites `x = ''` to `empty(x)`).
+    /// Skip index conditions match the query expression to the index expression by column name, so after the
+    /// query-side rewrite the two names no longer compare equal and the index is silently skipped.
+    /// This field stores the rewritten names so that each index condition can also match against them.
+    Names normalized_column_names;
+
     /// Parse index from definition AST
     static IndexDescription getIndexFromAST(
         const ASTPtr & definition_ast,

--- a/src/Storages/IndicesDescription.h
+++ b/src/Storages/IndicesDescription.h
@@ -3,6 +3,7 @@
 #include <base/types.h>
 
 #include <vector>
+#include <unordered_map>
 #include <Core/Field.h>
 #include <Parsers/IAST_fwd.h>
 #include <Storages/ColumnsDescription.h>
@@ -64,8 +65,9 @@ struct IndexDescription
     /// the query optimizer applies (e.g. `optimize_empty_string_comparisons` rewrites `x = ''` to `empty(x)`).
     /// Skip index conditions match the query expression to the index expression by column name, so after the
     /// query-side rewrite the two names no longer compare equal and the index is silently skipped.
-    /// This field stores the rewritten names so that each index condition can also match against them.
-    Names normalized_column_names;
+    /// This field stores the rewritten names (key) mapped to the original column name (value),
+    /// so that each index condition can also match against them and find the correct column position.
+    std::unordered_map<String, String> normalized_column_name_to_original;
 
     /// Parse index from definition AST
     static IndexDescription getIndexFromAST(

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -240,11 +240,11 @@ std::optional<MapIndexInfo> tryParseMapSubcolumn(const String & column_name, con
     auto & [map_column_name, serialized_key] = *parsed;
 
     auto map_keys_index_column_name = fmt::format("mapKeys({})", map_column_name);
-    if (!header.has(map_keys_index_column_name))
+    if (!hasIndexColumn(map_keys_index_column_name))
         return tryResolveMapIndexInfo(map_column_name, {}, header);
 
     /// Deserialize the key from its text representation using the key type from the index header.
-    size_t keys_position = header.getPositionByName(map_keys_index_column_name);
+    size_t keys_position = getIndexColumnPosition(map_keys_index_column_name);
     const DataTypePtr & index_type = header.getByPosition(keys_position).type;
     const auto & array_type = assert_cast<const DataTypeArray &>(*index_type);
     const auto & key_type = array_type.getNestedType();
@@ -286,8 +286,8 @@ std::optional<MapIndexInfo> tryResolveMapInfoFromNode(const RPNBuilderTreeNode &
 }
 
 MergeTreeIndexConditionBloomFilter::MergeTreeIndexConditionBloomFilter(
-    const ActionsDAG::Node * predicate, ContextPtr context_, const Block & header_, size_t hash_functions_)
-    : WithContext(context_), header(header_), hash_functions(hash_functions_)
+    const ActionsDAG::Node * predicate, ContextPtr context_, const Block & header_, size_t hash_functions_, const std::unordered_map<String, String> & normalized_column_name_to_original_)
+    : WithContext(context_), header(header_), hash_functions(hash_functions_), normalized_column_name_to_original(normalized_column_name_to_original_)
 {
     if (!predicate)
     {
@@ -555,10 +555,10 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeIn(
 {
     auto key_node_column_name = key_node.getColumnName();
 
-    if (header.has(key_node_column_name))
+    if (hasIndexColumn(key_node_column_name))
     {
         size_t row_size = column->size();
-        size_t position = header.getPositionByName(key_node_column_name);
+        size_t position = getIndexColumnPosition(key_node_column_name);
         const DataTypePtr & index_type = header.getByPosition(position).type;
         const auto & converted_column = castColumn(ColumnWithTypeAndName{column, type, ""}, index_type);
         out.predicate.emplace_back(std::make_pair(position, BloomFilterHash::hashWithColumn(index_type, converted_column, 0, row_size)));
@@ -801,9 +801,9 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
 {
     auto key_column_name = key_node.getColumnName();
 
-    if (header.has(key_column_name))
+    if (hasIndexColumn(key_column_name))
     {
-        size_t position = header.getPositionByName(key_column_name);
+        size_t position = getIndexColumnPosition(key_column_name);
         const DataTypePtr & index_type = header.getByPosition(position).type;
         const auto * array_type = typeid_cast<const DataTypeArray *>(index_type.get());
 
@@ -894,10 +894,10 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
         if (function_name == "mapContainsValue")
             map_keys_index_column_name = fmt::format("mapValues({})", key_column_name);
 
-        if (!header.has(map_keys_index_column_name))
+        if (!hasIndexColumn(map_keys_index_column_name))
             return false;
 
-        size_t position = header.getPositionByName(map_keys_index_column_name);
+        size_t position = getIndexColumnPosition(map_keys_index_column_name);
 
         const DataTypePtr & index_type = header.getByPosition(position).type;
         const auto * array_type = typeid_cast<const DataTypeArray *>(index_type.get());
@@ -1060,7 +1060,7 @@ MergeTreeIndexAggregatorPtr MergeTreeIndexBloomFilter::createIndexAggregator() c
 
 MergeTreeIndexConditionPtr MergeTreeIndexBloomFilter::createIndexCondition(const ActionsDAG::Node * predicate, ContextPtr context) const
 {
-    return std::make_shared<MergeTreeIndexConditionBloomFilter>(predicate, context, index.sample_block, hash_functions);
+    return std::make_shared<MergeTreeIndexConditionBloomFilter>(predicate, context, index.sample_block, hash_functions, index.normalized_column_name_to_original);
 }
 
 static void assertIndexColumnsType(const Block & header)

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
@@ -7,6 +7,7 @@
 #include <Storages/MergeTree/MergeTreeIndices.h>
 
 #include <algorithm>
+#include <unordered_map>
 
 namespace DB
 {
@@ -76,7 +77,7 @@ public:
         std::vector<std::pair<size_t, ColumnPtr>> predicate;
     };
 
-    MergeTreeIndexConditionBloomFilter(const ActionsDAG::Node * predicate, ContextPtr context_, const Block & header_, size_t hash_functions_, const Names & normalized_column_names_);
+    MergeTreeIndexConditionBloomFilter(const ActionsDAG::Node * predicate, ContextPtr context_, const Block & header_, size_t hash_functions_, const std::unordered_map<String, String> & normalized_column_name_to_original_);
 
     bool alwaysUnknownOrTrue() const override;
 
@@ -93,12 +94,22 @@ public:
 private:
     const Block & header;
     const size_t hash_functions;
-    const Names normalized_column_names;
+    const std::unordered_map<String, String> normalized_column_name_to_original;
     std::vector<RPNElement> rpn;
 
     bool hasIndexColumn(const String & column_name) const
     {
-        return header.has(column_name) || std::find(normalized_column_names.begin(), normalized_column_names.end(), column_name) != normalized_column_names.end();
+        return header.has(column_name) || normalized_column_name_to_original.find(column_name) != normalized_column_name_to_original.end();
+    }
+
+    size_t getIndexColumnPosition(const String & column_name) const
+    {
+        if (header.has(column_name))
+            return header.getPositionByName(column_name);
+        auto it = normalized_column_name_to_original.find(column_name);
+        if (it != normalized_column_name_to_original.end())
+            return header.getPositionByName(it->second);
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Column '{}' not found in index", column_name);
     }
 
     bool mayBeTrueOnGranule(const MergeTreeIndexGranuleBloomFilter * granule, const UpdatePartialDisjunctionResultFn & update_partial_result_disjuntion_fn) const;

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
@@ -6,6 +6,8 @@
 #include <Storages/MergeTree/KeyCondition.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
 
+#include <algorithm>
+
 namespace DB
 {
 
@@ -93,6 +95,11 @@ private:
     const size_t hash_functions;
     const Names normalized_column_names;
     std::vector<RPNElement> rpn;
+
+    bool hasIndexColumn(const String & column_name) const
+    {
+        return header.has(column_name) || std::find(normalized_column_names.begin(), normalized_column_names.end(), column_name) != normalized_column_names.end();
+    }
 
     bool mayBeTrueOnGranule(const MergeTreeIndexGranuleBloomFilter * granule, const UpdatePartialDisjunctionResultFn & update_partial_result_disjuntion_fn) const;
 

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
@@ -74,7 +74,7 @@ public:
         std::vector<std::pair<size_t, ColumnPtr>> predicate;
     };
 
-    MergeTreeIndexConditionBloomFilter(const ActionsDAG::Node * predicate, ContextPtr context_, const Block & header_, size_t hash_functions_);
+    MergeTreeIndexConditionBloomFilter(const ActionsDAG::Node * predicate, ContextPtr context_, const Block & header_, size_t hash_functions_, const Names & normalized_column_names_);
 
     bool alwaysUnknownOrTrue() const override;
 
@@ -91,6 +91,7 @@ public:
 private:
     const Block & header;
     const size_t hash_functions;
+    const Names normalized_column_names;
     std::vector<RPNElement> rpn;
 
     bool mayBeTrueOnGranule(const MergeTreeIndexGranuleBloomFilter * granule, const UpdatePartialDisjunctionResultFn & update_partial_result_disjuntion_fn) const;

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -199,7 +199,8 @@ namespace
 KeyCondition buildCondition(const IndexDescription & index, const ActionsDAGWithInversionPushDown & filter_dag, ContextPtr context)
 {
     Names combined_names = index.column_names;
-    combined_names.insert(combined_names.end(), index.normalized_column_names.begin(), index.normalized_column_names.end());
+    for (const auto & [normalized_name, _] : index.normalized_column_name_to_original)
+        combined_names.push_back(normalized_name);
     return KeyCondition{filter_dag, context, combined_names, index.expression};
 }
 

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -198,7 +198,9 @@ namespace
 
 KeyCondition buildCondition(const IndexDescription & index, const ActionsDAGWithInversionPushDown & filter_dag, ContextPtr context)
 {
-    return KeyCondition{filter_dag, context, index.column_names, index.expression};
+    Names combined_names = index.column_names;
+    combined_names.insert(combined_names.end(), index.normalized_column_names.begin(), index.normalized_column_names.end());
+    return KeyCondition{filter_dag, context, combined_names, index.expression};
 }
 
 }

--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -388,6 +388,10 @@ MergeTreeIndexConditionSet::MergeTreeIndexConditionSet(
         if (!key_columns.contains(name))
             key_columns.insert(name);
 
+    for (const auto & name : index_description.normalized_column_names)
+        if (!key_columns.contains(name))
+            key_columns.insert(name);
+
     if (!filter_dag.predicate)
         return;
 

--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -388,9 +388,9 @@ MergeTreeIndexConditionSet::MergeTreeIndexConditionSet(
         if (!key_columns.contains(name))
             key_columns.insert(name);
 
-    for (const auto & name : index_description.normalized_column_names)
-        if (!key_columns.contains(name))
-            key_columns.insert(name);
+    for (const auto & [normalized_name, _] : index_description.normalized_column_name_to_original)
+        if (!key_columns.contains(normalized_name))
+            key_columns.insert(normalized_name);
 
     if (!filter_dag.predicate)
         return;


### PR DESCRIPTION
### Description

Fixes: https://github.com/ClickHouse/ClickHouse/issues/112636

When `optimize_empty_string_comparisons = 1` (default since 25.10), the query optimizer rewrites `x = ''` to `empty(x)` and `x != ''` to `notEmpty(x)`. Skip index expressions are named once at DDL time and are NOT rewritten. Since skip index conditions match the query expression to the index expression **by column name**, after the rewrite the two names no longer compare equal and the index is silently skipped.

This affects all skip index types that match by column name: `minmax`, `set`, `bloom_filter`, and `text`. Results stay correct — only granule pruning is lost, so the symptom is a silent full scan rather than a wrong answer.

### Fix

This PR adds a **general fix** in `IndexDescription` that works for all index types:

1. **`IndicesDescription.h` / `IndicesDescription.cpp`**: Added `normalized_column_name_to_original` map to `IndexDescription`. In `getIndexFromAST()`, after computing the index column names, the function also applies the same `x = '' → empty(x)` / `x != '' → notEmpty(x)` rewrite to each expression and stores the mapping from normalized name to original name.

2. **`MergeTreeIndexMinMax.cpp`**: The `buildCondition()` function now passes both the original and normalized column names to `KeyCondition`, so the minmax index condition matches against either form.

3. **`MergeTreeIndexSet.cpp`**: The constructor also adds normalized column names to `key_columns`, so the set index condition matches against them.

4. **`MergeTreeIndexBloomFilter.h` / `MergeTreeIndexBloomFilter.cpp`**: Added `hasIndexColumn()` and `getIndexColumnPosition()` helper methods that check both the original header column names and the normalized names. All `header.has()` and `header.getPositionByName()` calls now use these helpers.

### Testing

The reproduction from the issue now shows the index being used:

```sql
SET explain_query_plan_default = 'legacy';

CREATE TABLE tab
(
    s String,
    INDEX idx if(s = '', 'abc', s) TYPE minmax
)
ENGINE = MergeTree
ORDER BY tuple()
SETTINGS index_granularity = 2;

INSERT INTO tab VALUES (''), ('x'), ('y'), ('z');

-- Should show: Skip -> Name: idx -> Granules: 1/2
EXPLAIN indexes = 1 SELECT count() FROM tab WHERE if(s = '', 'abc', s) = 'abc' SETTINGS optimize_empty_string_comparisons = 1;

-- Should also show: Skip -> Name: idx -> Granules: 1/2
EXPLAIN indexes = 1 SELECT count() FROM tab WHERE if(s = '', 'abc', s) = 'abc' SETTINGS optimize_empty_string_comparisons = 0;
```

### Changelog category

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry

Fix all skip index types (minmax, set, bloom_filter) not being used when their expression contains an empty string comparison, because `optimize_empty_string_comparisons` rewrites the comparison on the query side only.
