### PR TITLE
fix: validate base backup data files exist before creating incremental backup

### DIFF
--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -339,6 +339,43 @@ std::shared_ptr<const IBackup> BackupImpl::getBaseBackupUnlocked() const
         BackupFactory::CreateParams base_params = params.getCreateParamsForBaseBackup(std::move(effective_base_backup_info), archive_params.password);
         base_backup = BackupFactory::instance().createBackup(base_params);
 
+        if (open_mode == OpenMode::WRITE)
+        {
+            /// Verify the base backup is actually usable — check that data files
+            /// exist on the storage. The .backup metadata file was already verified
+            /// to exist (readBackupMetadata would have thrown otherwise), but the
+            /// data files might have been removed (e.g., by an S3 lifecycle rule,
+            /// partial cleanup, or operator rm).
+            /// Without this check, an incremental backup would report BACKUP_CREATED
+            /// against a base that is already unrestorable, and the failure would
+            /// only surface at restore time.
+            auto * base_impl = dynamic_cast<const BackupImpl *>(base_backup.get());
+            if (base_impl && base_impl->reader)
+            {
+                bool has_data_files = false;
+                for (const auto & [name, _] : base_impl->file_names)
+                {
+                    if (name != ".backup")
+                    {
+                        if (base_impl->reader->fileExists(name))
+                        {
+                            has_data_files = true;
+                            break;
+                        }
+                    }
+                }
+                if (!has_data_files)
+                {
+                    throw Exception(
+                        ErrorCodes::NO_BASE_BACKUP,
+                        "Backup {}: The base backup {} has no data files on the storage. "
+                        "The backup is unusable as a base backup.",
+                        backup_name_for_logging,
+                        base_backup->getNameForLogging());
+                }
+            }
+        }
+
         if ((open_mode == OpenMode::READ) && (base_backup_uuid != base_backup->getUUID()))
         {
             throw Exception(


### PR DESCRIPTION
### Changes

When creating an incremental `BACKUP` with a `base_backup`, the base backup's `.backup` metadata file is read and parsed, but the actual data files are never verified to exist on the storage. If the base's data files have been removed (e.g., by an S3 lifecycle rule, partial cleanup, or operator `rm`), the incremental backup reports `BACKUP_CREATED` even though the chain is already unrestorable from the moment it is created. The failure only surfaces at restore time, with a raw `std::filesystem` error.

This fix adds a storage-probe check in `getBaseBackupUnlocked()` when the open mode is `WRITE` (i.e., during an incremental backup). After the base backup is opened, we iterate through its file entries and verify that at least one non-`.backup` data file exists on the storage by calling `reader->fileExists()` directly — which probes the storage, not just the in-memory metadata map. If no data files are found, `NO_BASE_BACKUP` is thrown with a descriptive error message.

### Why this approach

- The `fileExists()` method on `BackupImpl` checks the in-memory `file_names` map, which was populated from the `.backup` metadata. This map is correct even when the data files are missing, so it wouldn't catch the issue.
- The `reader->fileExists()` method on `IBackupReader` probes the storage directly (e.g., S3 `HEAD` request, filesystem `stat`), which catches missing data files.
- The check is scoped to `OpenMode::WRITE` (incremental backup creation) because the read path (RESTORE) already fails — it just fails with a poor error message.

### Testing

The reproducer from the issue should now fail at `BACKUP` time instead of `RESTORE` time:

```sql
BACKUP TABLE t TO File('b');
-- (delete data files from 'b' manually)
BACKUP TABLE t TO File('i') SETTINGS base_backup = File('b');
-- Before: BACKUP_CREATED
-- After:  NO_BASE_BACKUP with descriptive message
```

Fixes #112395
