### PR TITLE
Fix reading a re-added `Nested` subcolumn with its parent column

### DIFF
--- a/src/Interpreters/inplaceBlockConversions.cpp
+++ b/src/Interpreters/inplaceBlockConversions.cpp
@@ -404,6 +404,32 @@ static bool hasDefault(const StorageSnapshotPtr & storage_snapshot, const NameAn
     return storage_snapshot->getDefault(name_in_storage).has_value();
 }
 
+/// True if `column` is a subcolumn whose parent column is going to be present in the block.
+/// `column` may come from `Nested::convertToSubcolumns`, which moves the subcolumn delimiter
+/// (`arr.nested.b` becomes `{name_in_storage = "arr", subcolumn = "nested.b"}`), so its own
+/// `getNameInStorage` is not the parent to look for. The metadata knows where the delimiter
+/// really belongs, and both availability sets are keyed by full column name.
+static bool isSubcolumnOfAvailableColumn(
+    const StorageSnapshotPtr & storage_snapshot,
+    const NameAndTypePair & column,
+    const NamesAndTypesList & available_columns,
+    const NameSet & additional_available_columns)
+{
+    if (!storage_snapshot || !column.isSubcolumn())
+        return false;
+
+    auto options = GetColumnsOptions(GetColumnsOptions::AllPhysical).withSubcolumns();
+    auto column_in_storage = storage_snapshot->tryGetColumn(options, column.name);
+
+    /// Not a subcolumn according to the metadata: a plain column missing from the part,
+    /// which the offsets branch below legitimately owns.
+    if (!column_in_storage || !column_in_storage->isSubcolumn())
+        return false;
+
+    auto parent_name = column_in_storage->getNameInStorage();
+    return available_columns.contains(parent_name) || additional_available_columns.contains(parent_name);
+}
+
 static String removeTupleElementsFromSubcolumn(String subcolumn_name, const Names & tuple_elements)
 {
     /// Add a dot to the end of name for convenience.
@@ -461,10 +487,7 @@ void fillMissingColumns(
         /// Subcolumn missing from the part's (older) type but whose parent is available (read here
         /// or produced by an earlier step): defer to evaluateMissingDefaults instead of default-
         /// filling. Needs a storage_snapshot, i.e. a caller that runs that pass (not Memory engine).
-        if (storage_snapshot
-            && requested_column->isSubcolumn()
-            && (available_columns.contains(requested_column->getNameInStorage())
-                || additional_available_columns.contains(requested_column->getNameInStorage())))
+        if (isSubcolumnOfAvailableColumn(storage_snapshot, *requested_column, available_columns, additional_available_columns))
             continue;
 
         std::vector<ColumnPtr> current_offsets;

--- a/src/Interpreters/inplaceBlockConversions.cpp
+++ b/src/Interpreters/inplaceBlockConversions.cpp
@@ -404,11 +404,8 @@ static bool hasDefault(const StorageSnapshotPtr & storage_snapshot, const NameAn
     return storage_snapshot->getDefault(name_in_storage).has_value();
 }
 
-/// True if `column` is a subcolumn whose parent column is going to be present in the block.
-/// `column` may come from `Nested::convertToSubcolumns`, which moves the subcolumn delimiter
-/// (`arr.nested.b` becomes `{name_in_storage = "arr", subcolumn = "nested.b"}`), so its own
-/// `getNameInStorage` is not the parent to look for. The metadata knows where the delimiter
-/// really belongs, and both availability sets are keyed by full column name.
+/// `column` may have come from `Nested::convertToSubcolumns`, which moves the subcolumn delimiter,
+/// so its own `getNameInStorage` is not necessarily the parent. Resolve the parent from metadata.
 static bool isSubcolumnOfAvailableColumn(
     const StorageSnapshotPtr & storage_snapshot,
     const NameAndTypePair & column,

--- a/tests/queries/0_stateless/03742_test_flattened_crash.reference
+++ b/tests/queries/0_stateless/03742_test_flattened_crash.reference
@@ -17,3 +17,8 @@ wide read	[0]	[('',0)]
 compact part	Compact
 compact read	[0]	[('',0)]
 null subcolumn	[1]	[NULL]
+default subcolumn alone	[42.5]
+default subcolumn and parent	[42.5]	[('dflt',42.5)]
+default parent alone	[('dflt',42.5)]
+default string element	['dflt']	[('dflt',42.5)]
+sibling default subcolumn	[7]	[('sib',7)]

--- a/tests/queries/0_stateless/03742_test_flattened_crash.reference
+++ b/tests/queries/0_stateless/03742_test_flattened_crash.reference
@@ -2,7 +2,6 @@
 subcolumn and parent	[0,0,0,0,0,0,0,0,0,0]	[('',0),('',0),('',0),('',0),('',0),('',0),('',0),('',0),('',0),('',0)]
 float element	[0]	[('',0)]
 string element	['']	[('',0)]
-declared type	Array(Float64)
 ordered by parent	[0]
 array element	0	[('',0)]
 array sum	0	[('',0)]

--- a/tests/queries/0_stateless/03742_test_flattened_crash.reference
+++ b/tests/queries/0_stateless/03742_test_flattened_crash.reference
@@ -1,1 +1,19 @@
 [('',0),('',0),('',0),('',0),('',0),('',0),('',0),('',0),('',0),('',0)]
+subcolumn and parent	[0,0,0,0,0,0,0,0,0,0]	[('',0),('',0),('',0),('',0),('',0),('',0),('',0),('',0),('',0),('',0)]
+float element	[0]	[('',0)]
+string element	['']	[('',0)]
+declared type	Array(Float64)
+ordered by parent	[0]
+array element	0	[('',0)]
+array sum	0	[('',0)]
+subcolumn alone	[0]
+parent alone	[('',0)]
+two subcolumns	[0]	['']
+size0 and parent	1	[('',0)]
+two parts	1	[0]	[('',0)]
+two parts	2	[7.5]	[('z',7.5)]
+wide part	Wide
+wide read	[0]	[('',0)]
+compact part	Compact
+compact read	[0]	[('',0)]
+null subcolumn	[1]	[NULL]

--- a/tests/queries/0_stateless/03742_test_flattened_crash.sql
+++ b/tests/queries/0_stateless/03742_test_flattened_crash.sql
@@ -108,3 +108,38 @@ ALTER TABLE test_nested_subcolumn_refill_null DROP COLUMN `arr.nested`;
 ALTER TABLE test_nested_subcolumn_refill_null ADD COLUMN `arr.nested` Array(Nullable(Float64));
 SELECT 'null subcolumn', arr.nested.null, arr.nested FROM test_nested_subcolumn_refill_null;
 DROP TABLE test_nested_subcolumn_refill_null;
+
+-- Same shape with a DDL DEFAULT on the re-added column, read on the old part. The DDL default
+-- must win here, and reading the element beside its parent hit the same wrongly-typed slot.
+DROP TABLE IF EXISTS test_nested_subcolumn_refill_default;
+CREATE TABLE test_nested_subcolumn_refill_default
+(
+    `id` UInt64,
+    `arr.id` Array(UInt64),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY (id) SETTINGS share_nested_offsets = 1;
+INSERT INTO test_nested_subcolumn_refill_default VALUES (1, [1], [('y', 2.5)]);
+ALTER TABLE test_nested_subcolumn_refill_default DROP COLUMN `arr.nested`;
+ALTER TABLE test_nested_subcolumn_refill_default ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64)) DEFAULT [('dflt', 42.5)];
+SELECT 'default subcolumn alone', arr.nested.b FROM test_nested_subcolumn_refill_default;
+SELECT 'default subcolumn and parent', arr.nested.b, arr.nested FROM test_nested_subcolumn_refill_default;
+SELECT 'default parent alone', arr.nested FROM test_nested_subcolumn_refill_default;
+SELECT 'default string element', arr.nested.a, arr.nested FROM test_nested_subcolumn_refill_default;
+DROP TABLE test_nested_subcolumn_refill_default;
+
+-- A DEFAULT that reads a sibling column proves the expression is evaluated rather than the
+-- element being synthesized from the shared offsets, which would yield the type default.
+DROP TABLE IF EXISTS test_nested_subcolumn_refill_default_sibling;
+CREATE TABLE test_nested_subcolumn_refill_default_sibling
+(
+    `id` UInt64,
+    `arr.id` Array(UInt64),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY (id) SETTINGS share_nested_offsets = 1;
+INSERT INTO test_nested_subcolumn_refill_default_sibling VALUES (7, [1], [('y', 2.5)]);
+ALTER TABLE test_nested_subcolumn_refill_default_sibling DROP COLUMN `arr.nested`;
+ALTER TABLE test_nested_subcolumn_refill_default_sibling ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64)) DEFAULT arrayMap(x -> ('sib', toFloat64(id)), `arr.id`);
+SELECT 'sibling default subcolumn', arr.nested.b, arr.nested FROM test_nested_subcolumn_refill_default_sibling;
+DROP TABLE test_nested_subcolumn_refill_default_sibling;

--- a/tests/queries/0_stateless/03742_test_flattened_crash.sql
+++ b/tests/queries/0_stateless/03742_test_flattened_crash.sql
@@ -44,7 +44,6 @@ ALTER TABLE test_nested_subcolumn_refill ADD COLUMN `arr.nested` Array(Tuple(a S
 -- The subcolumn must read the default, consistently with the parent.
 SELECT 'float element', arr.nested.b, arr.nested FROM test_nested_subcolumn_refill;
 SELECT 'string element', arr.nested.a, arr.nested FROM test_nested_subcolumn_refill;
-SELECT 'declared type', toTypeName(arr.nested.b) FROM test_nested_subcolumn_refill;
 -- ORDER BY hands the same block to the merging consumer.
 SELECT 'ordered by parent', arr.nested.b FROM test_nested_subcolumn_refill ORDER BY arr.nested;
 -- Function execution over the subcolumn is a third consumer of the same block.

--- a/tests/queries/0_stateless/03742_test_flattened_crash.sql
+++ b/tests/queries/0_stateless/03742_test_flattened_crash.sql
@@ -21,4 +21,90 @@ SELECT * FROM generateRandom(
 ALTER TABLE test_flatten_nested_crash DROP COLUMN `arr.nested`;
 ALTER TABLE test_flatten_nested_crash ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
 SELECT arr.nested FROM test_flatten_nested_crash ORDER BY arr.nested LIMIT 1;
+SELECT 'subcolumn and parent', arr.nested.b, arr.nested FROM test_flatten_nested_crash ORDER BY arr.nested LIMIT 1;
 DROP TABLE test_flatten_nested_crash;
+
+-- Reading a re-added Nested element subcolumn together with its own parent column used to put the
+-- whole Tuple in the subcolumn's slot while the block kept declaring the element type: a logical
+-- error in debug builds, and a wrongly-typed read of unrelated memory in release builds.
+-- share_nested_offsets (default on) is load-bearing, so pin it instead of disabling randomization.
+
+DROP TABLE IF EXISTS test_nested_subcolumn_refill;
+CREATE TABLE test_nested_subcolumn_refill
+(
+    `id` UInt64,
+    `arr.id` Array(UInt64),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY (id) SETTINGS share_nested_offsets = 1;
+INSERT INTO test_nested_subcolumn_refill VALUES (1, [1], [('y', 2.5)]);
+ALTER TABLE test_nested_subcolumn_refill DROP COLUMN `arr.nested`;
+ALTER TABLE test_nested_subcolumn_refill ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
+
+-- The subcolumn must read the default, consistently with the parent.
+SELECT 'float element', arr.nested.b, arr.nested FROM test_nested_subcolumn_refill;
+SELECT 'string element', arr.nested.a, arr.nested FROM test_nested_subcolumn_refill;
+SELECT 'declared type', toTypeName(arr.nested.b) FROM test_nested_subcolumn_refill;
+-- ORDER BY hands the same block to the merging consumer.
+SELECT 'ordered by parent', arr.nested.b FROM test_nested_subcolumn_refill ORDER BY arr.nested;
+-- Function execution over the subcolumn is a third consumer of the same block.
+SELECT 'array element', arr.nested.b[1], arr.nested FROM test_nested_subcolumn_refill;
+SELECT 'array sum', arraySum(arr.nested.b), arr.nested FROM test_nested_subcolumn_refill;
+
+-- Reads that were already correct and must stay so.
+SELECT 'subcolumn alone', arr.nested.b FROM test_nested_subcolumn_refill;
+SELECT 'parent alone', arr.nested FROM test_nested_subcolumn_refill;
+SELECT 'two subcolumns', arr.nested.b, arr.nested.a FROM test_nested_subcolumn_refill;
+SELECT 'size0 and parent', arr.nested.size0, arr.nested FROM test_nested_subcolumn_refill;
+
+-- One part missing the column, one part having it.
+INSERT INTO test_nested_subcolumn_refill VALUES (2, [2], [('z', 7.5)]);
+SELECT 'two parts', id, arr.nested.b, arr.nested FROM test_nested_subcolumn_refill ORDER BY id;
+DROP TABLE test_nested_subcolumn_refill;
+
+-- Wide and Compact parts reach the same code, so pin min_bytes_for_wide_part to cover each.
+DROP TABLE IF EXISTS test_nested_subcolumn_refill_wide;
+CREATE TABLE test_nested_subcolumn_refill_wide
+(
+    `id` UInt64,
+    `arr.id` Array(UInt64),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY (id) SETTINGS min_bytes_for_wide_part = 0, share_nested_offsets = 1;
+INSERT INTO test_nested_subcolumn_refill_wide VALUES (1, [1], [('y', 2.5)]);
+ALTER TABLE test_nested_subcolumn_refill_wide DROP COLUMN `arr.nested`;
+ALTER TABLE test_nested_subcolumn_refill_wide ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
+SELECT 'wide part', part_type FROM system.parts WHERE database = currentDatabase() AND table = 'test_nested_subcolumn_refill_wide' AND active;
+SELECT 'wide read', arr.nested.b, arr.nested FROM test_nested_subcolumn_refill_wide;
+DROP TABLE test_nested_subcolumn_refill_wide;
+
+DROP TABLE IF EXISTS test_nested_subcolumn_refill_compact;
+CREATE TABLE test_nested_subcolumn_refill_compact
+(
+    `id` UInt64,
+    `arr.id` Array(UInt64),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY (id) SETTINGS min_bytes_for_wide_part = 1000000000, share_nested_offsets = 1;
+INSERT INTO test_nested_subcolumn_refill_compact VALUES (1, [1], [('y', 2.5)]);
+ALTER TABLE test_nested_subcolumn_refill_compact DROP COLUMN `arr.nested`;
+ALTER TABLE test_nested_subcolumn_refill_compact ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
+SELECT 'compact part', part_type FROM system.parts WHERE database = currentDatabase() AND table = 'test_nested_subcolumn_refill_compact' AND active;
+SELECT 'compact read', arr.nested.b, arr.nested FROM test_nested_subcolumn_refill_compact;
+DROP TABLE test_nested_subcolumn_refill_compact;
+
+-- Subcolumns served from the shared offsets rather than derived from the parent were already
+-- correct and must not change.
+DROP TABLE IF EXISTS test_nested_subcolumn_refill_null;
+CREATE TABLE test_nested_subcolumn_refill_null
+(
+    `id` UInt64,
+    `arr.id` Array(UInt64),
+    `arr.nested` Array(Nullable(Float64))
+)
+ENGINE = MergeTree ORDER BY (id) SETTINGS share_nested_offsets = 1;
+INSERT INTO test_nested_subcolumn_refill_null VALUES (1, [1], [2.5]);
+ALTER TABLE test_nested_subcolumn_refill_null DROP COLUMN `arr.nested`;
+ALTER TABLE test_nested_subcolumn_refill_null ADD COLUMN `arr.nested` Array(Nullable(Float64));
+SELECT 'null subcolumn', arr.nested.null, arr.nested FROM test_nested_subcolumn_refill_null;
+DROP TABLE test_nested_subcolumn_refill_null;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/112668


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a wrongly typed read of a `Nested` element subcolumn whose column was dropped and re-added. Selecting such a subcolumn together with its own parent column returned the whole element in the subcolumn's slot while the block still declared the element type, which produced arbitrary values in release builds and a logical error in debug and sanitizer builds.

### Description

`SELECT` of a `Nested` element subcolumn together with its own parent column, after the column was
`DROP`ped and re-`ADD`ed, returned a column of the wrong type:

```sql
CREATE TABLE t (`id` UInt64, `arr.id` Array(UInt64), `arr.nested` Array(Tuple(a String, b Float64)))
ENGINE = MergeTree ORDER BY (id);
INSERT INTO t VALUES (1, [1], [('y', 2.5)]);
ALTER TABLE t DROP COLUMN `arr.nested`;
ALTER TABLE t ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
SELECT arr.nested.b, arr.nested FROM t;   -- expected [0] [('',0)]
```

On a release build this returned a different value on every run while the parent
column read correctly, so nothing indicated the subcolumn value was fabricated. Debug and sanitizer
builds raised `Logical error: 'Bad cast from type DB::ColumnTuple to DB::ColumnVector<double>'`.

Root cause: `fillMissingColumns` decides between deferring to `evaluateMissingDefaults` and synthesizing a default from a `Nested` sibling's shared
offsets. `IMergeTreeReader` first runs its column lists through `Nested::convertToSubcolumns`, which
moves the subcolumn delimiter, so `arr.nested.b` becomes `{name_in_storage = "arr", subcolumn =
"nested.b"}`. The deferral compared that `name_in_storage` against lists keyed by full name, never
matched, and the offsets branch then produced the whole `Tuple` under a declared element type.

The fix resolves the requested column through the storage snapshot, which is authoritative about
where the subcolumn delimiter belongs, and matches the resolved parent's full name against the
availability sets. Three consumers were observed reading the wrongly typed column (output
formatting, merging via `ORDER BY`, and function execution), and all three are repaired by this
single change at the point where the block is built. Reads that were already correct are covered as
controls in the test.

Found by the AST fuzzer, which mutated the existing `03742_test_flattened_crash` test to read the
element subcolumn instead of the whole column (`AST fuzzer (amd_debug)`, STID 2508-368d):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112668&sha=3f7020cf4114402a81c9d3dd6e7bef755802e34b&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.598` (included in `26.8` and later)
<!-- ch-version-info:end -->