### PR TITLE
Fix PostgreSQL startup payload bounds check

### DIFF
--- a/src/Core/PostgreSQLProtocol.h
+++ b/src/Core/PostgreSQLProtocol.h
@@ -40,7 +40,9 @@ namespace DB
 
 namespace ErrorCodes
 {
+    extern const int ATTEMPT_TO_READ_AFTER_EOF;
     extern const int BAD_ARGUMENTS;
+    extern const int CANNOT_READ_ALL_DATA;
     extern const int UNKNOWN_PACKET_FROM_CLIENT;
     extern const int UNEXPECTED_PACKET_FROM_CLIENT;
     extern const int NOT_IMPLEMENTED;
@@ -471,37 +473,55 @@ public:
 
     void deserialize(ReadBuffer & in) override
     {
-        Int32 ps = payload_size - 1;
-        while (ps > 0)
+        if (payload_size < 1)
+            throw Exception(ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT,
+                            "Wrong payload size {} for PostgreSQL startup message, it must include the terminating zero byte",
+                            payload_size);
+
+        LimitReadBuffer payload(in, {
+            .read_no_less = static_cast<size_t>(payload_size),
+            .read_no_more = static_cast<size_t>(payload_size),
+        });
+
+        size_t remaining = payload_size - 1;
+        try
         {
-            String parameter_name;
-            String parameter_value;
-            readNullTerminated(parameter_name, in);
-            readNullTerminated(parameter_value, in);
-            ps -= parameter_name.size() + 1;
-            ps -= parameter_value.size() + 1;
-
-            if (parameter_name == "user")
+            while (remaining > 0)
             {
-                user = parameter_value;
+                String parameter_name;
+                String parameter_value;
+                readNullTerminated(parameter_name, payload);
+                readNullTerminated(parameter_value, payload);
+
+                size_t parameter_size = parameter_name.size() + parameter_value.size() + 2;
+                if (parameter_size > remaining)
+                    throw Exception(ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT,
+                                    "Parameters exceed the declared PostgreSQL startup message payload size");
+                remaining -= parameter_size;
+
+                if (parameter_name == "user")
+                    user = parameter_value;
+                else if (parameter_name == "database")
+                    database = parameter_value;
+
+                parameters.insert({std::move(parameter_name), std::move(parameter_value)});
             }
-            else if (parameter_name == "database")
-            {
-                database = parameter_value;
-            }
 
-            parameters.insert({std::move(parameter_name), std::move(parameter_value)});
-
-            /// `payload_size` is the declared size of the message and never changes, so the check
-            /// has to be made against the remaining size instead.
-            if (ps < 0)
-            {
+            char terminator = 0;
+            payload.readStrict(terminator);
+            if (terminator != 0)
                 throw Exception(ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT,
-                                "Size of payload is larger than one declared in the message of type {}.",
-                                static_cast<UInt64>(getMessageType()));
-            }
+                                "PostgreSQL startup message is not terminated by a zero byte");
         }
-        in.ignore();
+        catch (const Exception & e)
+        {
+            if (e.code() == ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT)
+                throw;
+            if (e.code() == ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF || e.code() == ErrorCodes::CANNOT_READ_ALL_DATA)
+                throw Exception(ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT,
+                                "Cannot read the declared PostgreSQL startup message payload: {}", e.message());
+            throw;
+        }
     }
 
     MessageType getMessageType() const override

--- a/src/Core/tests/gtest_postgresql_protocol.cpp
+++ b/src/Core/tests/gtest_postgresql_protocol.cpp
@@ -136,6 +136,18 @@ void expectTrailingPayloadIsRejectedAndAligned(std::string payload)
     EXPECT_EQ(marker, 'X');
 }
 
+class FailingReadBuffer : public ReadBuffer
+{
+public:
+    FailingReadBuffer() : ReadBuffer(nullptr, 0) {}
+
+private:
+    bool nextImpl() override
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Synthetic read failure");
+    }
+};
+
 }
 
 TEST(PostgreSQLProtocol, DropMessageRejectsLengthBelowFour)
@@ -161,6 +173,95 @@ TEST(PostgreSQLProtocol, DropMessageRejectsLengthBelowFour)
     WriteBufferFromOwnString out;
     Messaging::MessageTransport mt(&in, &out);
     EXPECT_NO_THROW(mt.dropMessage());
+}
+
+TEST(PostgreSQLProtocol, StartupMessageRejectsParametersExceedingDeclaredPayload)
+{
+    std::string bytes("user\0default\0", 13);
+    bytes.push_back('\0');
+
+    {
+        ReadBufferFromMemory in(bytes.data(), bytes.size());
+        Messaging::StartupMessage msg(static_cast<Int32>(bytes.size()));
+        EXPECT_NO_THROW(msg.deserialize(in));
+        EXPECT_EQ(msg.user, "default");
+    }
+
+    ReadBufferFromMemory in(bytes.data(), bytes.size());
+    try
+    {
+        Messaging::StartupMessage msg(static_cast<Int32>(bytes.size() - 1));
+        msg.deserialize(in);
+        FAIL() << "Expected malformed startup message to be rejected";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT);
+    }
+    EXPECT_EQ(in.count(), bytes.size() - 1);
+}
+
+TEST(PostgreSQLProtocol, StartupMessageDoesNotReadPastDeclaredPayload)
+{
+    const std::string bytes("user\0default\0\0subsequent data", 29);
+
+    for (Int32 payload_size : {2, 7})
+    {
+        ReadBufferFromMemory in(bytes.data(), bytes.size());
+        try
+        {
+            Messaging::StartupMessage msg(payload_size);
+            msg.deserialize(in);
+            FAIL() << "Expected truncated startup message to be rejected";
+        }
+        catch (const Exception & e)
+        {
+            EXPECT_EQ(e.code(), ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT);
+        }
+        EXPECT_EQ(in.count(), payload_size);
+    }
+}
+
+TEST(PostgreSQLProtocol, StartupMessageValidatesPayloadAndTerminator)
+{
+    /// Total startup message lengths from 0 through 8 leave no room for the required final zero.
+    for (Int32 payload_size = -8; payload_size <= 0; ++payload_size)
+    {
+        EXPECT_TRUE(throwsUnknownPacket("", [&](ReadBuffer & in)
+        {
+            Messaging::StartupMessage msg(payload_size);
+            msg.deserialize(in);
+        })) << "payload_size = " << payload_size;
+    }
+
+    {
+        const std::string bytes(1, '\0');
+        ReadBufferFromMemory in(bytes.data(), bytes.size());
+        Messaging::StartupMessage msg(static_cast<Int32>(bytes.size()));
+        EXPECT_NO_THROW(msg.deserialize(in));
+        EXPECT_EQ(in.count(), bytes.size());
+    }
+
+    EXPECT_TRUE(throwsUnknownPacket("x", [&](ReadBuffer & in)
+    {
+        Messaging::StartupMessage msg(1);
+        msg.deserialize(in);
+    }));
+}
+
+TEST(PostgreSQLProtocol, StartupMessagePreservesUnrelatedReadErrors)
+{
+    FailingReadBuffer in;
+    Messaging::StartupMessage msg(1);
+    try
+    {
+        msg.deserialize(in);
+        FAIL() << "Expected synthetic read failure";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::BAD_ARGUMENTS);
+    }
 }
 
 TEST(PostgreSQLProtocol, SASLResponseRejectsLengthBelowFour)

--- a/src/Server/PostgreSQLHandler.cpp
+++ b/src/Server/PostgreSQLHandler.cpp
@@ -581,8 +581,16 @@ void PostgreSQLHandler::establishSecureConnection(Int32 & payload_size, Int32 & 
 {
     bool was_secure_connection = false;
     bool was_encryption_req = true;
-    readBinaryBigEndian(payload_size, *in);
-    readBinaryBigEndian(info, *in);
+    auto receive_first_message_header = [&]
+    {
+        readBinaryBigEndian(payload_size, *in);
+        if (payload_size < 8)
+            throw Exception(ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT,
+                            "Wrong PostgreSQL initial message length {}, it must be at least 8", payload_size);
+        readBinaryBigEndian(info, *in);
+    };
+
+    receive_first_message_header();
 
     switch (static_cast<PostgreSQLProtocol::Messaging::FrontMessageType>(info))
     {
@@ -604,10 +612,7 @@ void PostgreSQLHandler::establishSecureConnection(Int32 & payload_size, Int32 & 
             was_encryption_req = false;
     }
     if (was_encryption_req)
-    {
-        readBinaryBigEndian(payload_size, *in);
-        readBinaryBigEndian(info, *in);
-    }
+        receive_first_message_header();
 
     if (secure_required && !was_secure_connection)
     {
@@ -713,9 +718,9 @@ inline std::unique_ptr<PostgreSQLProtocol::Messaging::StartupMessage> PostgreSQL
     std::unique_ptr<PostgreSQLProtocol::Messaging::StartupMessage> message;
     try
     {
-        if (payload_size < 8 || payload_size > max_startup_message_size)
+        if (payload_size < 9 || payload_size > max_startup_message_size)
             throw Exception(ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT,
-                "Startup message declares a size of {} bytes, while it must be between 8 and {} bytes",
+                "Startup message declares a size of {} bytes, while it must be between 9 and {} bytes",
                 payload_size, max_startup_message_size);
 
         message = message_transport->receiveWithPayloadSize<PostgreSQLProtocol::Messaging::StartupMessage>(payload_size - 8);

--- a/tests/integration/test_postgresql_protocol/test.py
+++ b/tests/integration/test_postgresql_protocol/test.py
@@ -11,6 +11,7 @@ import socket
 import struct
 import threading
 import time
+import ssl
 import uuid
 from contextlib import closing
 from io import StringIO
@@ -71,6 +72,30 @@ server_port = 5433
 alt_server_port = 5435
 
 
+def _read_exact(sock, size):
+    data = b""
+    while len(data) < size:
+        chunk = sock.recv(size - len(data))
+        if not chunk:
+            raise AssertionError("Connection closed before the complete PostgreSQL message was received")
+        data += chunk
+    return data
+
+
+def _read_startup_error(sock):
+    assert _read_exact(sock, 1) == b"E"
+    message_size = struct.unpack("!I", _read_exact(sock, 4))[0]
+    message = _read_exact(sock, message_size - 4)
+    assert b"C08P01\x00" in message
+
+
+def _assert_connection_closed(sock):
+    try:
+        assert sock.recv(1) == b""
+    except ConnectionResetError:
+        pass
+
+
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
@@ -85,6 +110,33 @@ def started_cluster():
         raise ex
     finally:
         cluster.shutdown()
+
+
+def test_malformed_startup_messages_do_not_consume_following_bytes(started_cluster):
+    node = cluster.instances["node"]
+
+    with socket.create_connection((node.ip_address, server_port), timeout=5) as sock:
+        sock.sendall(struct.pack("!I", 7))
+        _assert_connection_closed(sock)
+
+    with socket.create_connection((node.ip_address, server_port), timeout=5) as sock:
+        sock.sendall(struct.pack("!II", 8, 80877103))
+        assert _read_exact(sock, 1) == b"S"
+
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        with context.wrap_socket(sock, server_hostname=node.ip_address) as tls_sock:
+            tls_sock.sendall(struct.pack("!II", 8, 196608))
+            _read_startup_error(tls_sock)
+
+    with socket.create_connection((node.ip_address, server_port), timeout=5) as sock:
+        sock.sendall(
+            struct.pack("!II", 13, 196608)
+            + b"user\x00default\x00\x00"
+            + b"following message bytes"
+        )
+        _read_startup_error(sock)
 
 
 def test_psql_client(started_cluster):


### PR DESCRIPTION
### Description

`StartupMessage::deserialize` tracked the remaining declared payload in `ps`, but checked the unchanged `payload_size` after reading each parameter pair. The check therefore could never reject parameter data that extended beyond the declared startup-message payload. The unbounded null-terminated reads could also consume subsequent stream bytes before detecting the mismatch.

Parse startup parameters through a `LimitReadBuffer` restricted to the declared payload, validate message lengths before subtraction, require the final zero terminator, and normalize only EOF and boundary failures to `UNKNOWN_PACKET_FROM_CLIENT` while preserving unrelated read errors.

Regression tests cover valid parameters, a valid empty parameter section, invalid lengths and terminators, parameters truncated inside both a name and a value, exact stream-boundary preservation, and preservation of unrelated exception codes.

### Documented behavior impact

No documented flow changes. This only rejects malformed PostgreSQL startup messages whose parameter data exceeds their declared payload size. Valid PostgreSQL clients require no migration, and no corresponding behavior is documented in either the ClickHouse repository or the current documentation repository.

### Changelog category (leave one):
- **Bug Fix (user-visible misbehavior in an official stable release)**

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
**Reject malformed PostgreSQL startup messages whose parameter data exceeds the declared payload size.**

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112780&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/112780](https://github.com/search?q=head%3Async-upstream%2Fpr%2F112780+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.210` (included in `26.10` and later)
<!-- ch-version-info:end -->