### PR TITLE
Add ClickHouse metadata to MongoDB driver handshake

### DIFF
--- a/src/Processors/Sources/MongoDBSource.cpp
+++ b/src/Processors/Sources/MongoDBSource.cpp
@@ -22,6 +22,7 @@
 
 #include <mongoc/mongoc-client.h>
 #include <mongocxx/client.hpp>
+#include <mongocxx/lib/mongocxx/v_noabi/mongocxx/client.hh>
 
 namespace DB
 {

--- a/src/Processors/Sources/MongoDBSource.cpp
+++ b/src/Processors/Sources/MongoDBSource.cpp
@@ -3,6 +3,7 @@
 #if USE_MONGODB
 #include <Processors/Sources/MongoDBSource.h>
 
+#include <Common/config_version.h>
 #include <vector>
 
 #include <Columns/ColumnArray.h>
@@ -19,6 +20,9 @@
 #include <Common/logger_useful.h>
 #include <base/range.h>
 
+#include <mongoc/mongoc-client.h>
+#include <mongocxx/client.hpp>
+
 namespace DB
 {
 
@@ -26,6 +30,34 @@ namespace ErrorCodes
 {
 extern const int TYPE_MISMATCH;
 extern const int NOT_IMPLEMENTED;
+}
+
+namespace
+{
+
+mongocxx::client createMongoDBClient(const mongocxx::uri & uri)
+{
+    mongocxx::client client{uri};
+
+    /// Access the underlying mongoc_client_t through the internal bridge
+    /// to append ClickHouse metadata to the MongoDB driver handshake.
+    /// The C++ driver's public metadata API is not yet available in the pinned version.
+    mongoc_client_t * mongoc_client = mongocxx::v_noabi::client::internal::as_mongoc(client);
+
+    if (!mongoc_client_append_metadata(
+            mongoc_client,
+            "ClickHouse",
+            VERSION_STRING,
+            nullptr))
+    {
+        LOG_WARNING(
+            getLogger("MongoDBSource"),
+            "Failed to append ClickHouse metadata to the MongoDB client handshake");
+    }
+
+    return client;
+}
+
 }
 
 using BSONCXXHelper::BSONElementAsNumber;
@@ -161,7 +193,7 @@ MongoDBSource::MongoDBSource(
     SharedHeader sample_block_,
     const UInt64 & max_block_size_)
     : ISource{sample_block_}
-    , client{uri}
+    , client{createMongoDBClient(uri)}
     , database{client.database(uri.database())}
     , collection{database.collection(collection_name)}
     , cursor{collection.find(query, options)}


### PR DESCRIPTION
Add ClickHouse identification to the MongoDB driver handshake metadata. This allows MongoDB server operators to identify connections originating from ClickHouse and track which ClickHouse version is being used.

The implementation uses `mongoc_client_append_metadata` from the C driver (available since mongo-c-driver 2.3.0, added in [CDRIVER-5993](https://github.com/mongodb/mongo-c-driver/commit/d0b080e2fa973480f4c2f025416ec4ca91b6c8ef)) through the internal bridge available in `mongocxx::v_noabi::client::internal::as_mongoc`, avoiding the need to modify either driver submodule while the C++ driver's public metadata API remains on the master branch.

After this change, mongos/d server logs will be able to differentiate ClickHouse connections from other connections:

```json
{
  "client": {
    "driver": {
      "name": "mongoc / mongocxx / ClickHouse",
      "version": "2.3.0 / 4.3.0 / 25.8.1.2345"
    },
    "os": {
      "type": "Linux",
      "name": "Ubuntu",
      "version": "22.04",
      "architecture": "x86_64"
    }
  }
}
```

This implements the [MongoDB Handshake Protocol](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md#wrapping-libraries) for wrapping libraries. Having this differentiation in the logs facilitates troubleshooting in dashboards or static log analysis (ex: tracing a slow query to the MongoDB engine).

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
MongoDB connections from ClickHouse now identify themselves with ClickHouse name and version in the driver handshake metadata, improving observability for MongoDB server operators.