### PR TITLE
CI: Retry S3 result upload when a competing write is in flight

### DIFF
--- a/ci/praktika/event.py
+++ b/ci/praktika/event.py
@@ -345,7 +345,7 @@ class EventFeed:
             max_retries: Maximum retry attempts on conflicts (default: 3)
 
         Implements exponential backoff retry logic for handling concurrent updates.
-        On PreconditionFailed (ETag mismatch), retries with exponentially increasing delays.
+        On a lost race (PreconditionFailed / ConditionalRequestConflict), retries with exponentially increasing delays.
         """
         from botocore.exceptions import ClientError
 
@@ -357,7 +357,10 @@ class EventFeed:
                 break
             except ClientError as e:
                 error_code = e.response.get("Error", {}).get("Code")
-                if error_code == "PreconditionFailed" and attempt < max_retries - 1:
+                if (
+                    error_code in ("PreconditionFailed", "ConditionalRequestConflict")
+                    and attempt < max_retries - 1
+                ):
                     time.sleep(0.1 * (2**attempt))
                     continue
                 raise

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1520,8 +1520,6 @@ class _ResultS3:
             # random delay (0-2s) to reduce contention and minimize race conditions
             # when multiple concurrent jobs attempt to update the workflow report
             time.sleep(random.uniform(0, 2))
-        else:
-            raise RuntimeError(f"Failed to upload workflow result after {MAX_ATTEMPTS} attempts")
 
         print(f"Workflow status changed: [{prev_status}] -> [{new_status}]")
         if prev_status != new_status:

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1520,6 +1520,8 @@ class _ResultS3:
             # random delay (0-2s) to reduce contention and minimize race conditions
             # when multiple concurrent jobs attempt to update the workflow report
             time.sleep(random.uniform(0, 2))
+        else:
+            raise RuntimeError(f"Failed to upload workflow result after {MAX_ATTEMPTS} attempts")
 
         print(f"Workflow status changed: [{prev_status}] -> [{new_status}]")
         if prev_status != new_status:

--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -275,8 +275,13 @@ class S3:
                 print("ERROR: Invalid AWS CLI command or CLI client version:")
                 print(f"  | awc error: {stderr}")
                 break
-            elif "PreconditionFailed" in stderr:
-                print("ERROR: AWS API Call Precondition Failed")
+            elif (
+                "PreconditionFailed" in stderr
+                or "ConditionalRequestConflict" in stderr
+            ):
+                # Lost optimistic-lock race. Set to true s.t. the caller re-reads the current version and retries.
+                no_strict = True
+                print("ERROR: AWS API conditional request failed (concurrent write)")
                 print(f"  | awc error: {stderr}")
                 break
             if ret_code != 0:

--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -670,8 +670,8 @@ class S3:
 
             except ClientError as e:
                 error_code = e.response.get("Error", {}).get("Code", "")
-                if error_code == "PreconditionFailed":
-                    print("Precondition failed (concurrent write detected)")
+                if error_code in ("PreconditionFailed", "ConditionalRequestConflict"):
+                    print(f"{error_code} (concurrent write detected)")
                     return False
                 print(f"ERROR: Failed to upload file using boto3: {error_code}")
                 if not no_strict:

--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -281,7 +281,7 @@ class S3:
             ):
                 # Lost optimistic-lock race. Set to true s.t. the caller re-reads the current version and retries.
                 no_strict = True
-                print("ERROR: AWS API conditional request failed (concurrent write)")
+                print("AWS API conditional request failed (concurrent write detected)")
                 print(f"  | awc error: {stderr}")
                 break
             if ret_code != 0:

--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -273,7 +273,7 @@ class S3:
                 break
             elif "Unknown options" in stderr:
                 print("ERROR: Invalid AWS CLI command or CLI client version:")
-                print(f"  | awc error: {stderr}")
+                print(f"  | aws error: {stderr}")
                 break
             elif (
                 "PreconditionFailed" in stderr
@@ -282,7 +282,7 @@ class S3:
                 # Lost optimistic-lock race. Set to true s.t. the caller re-reads the current version and retries.
                 no_strict = True
                 print("AWS API conditional request failed (concurrent write detected)")
-                print(f"  | awc error: {stderr}")
+                print(f"  | aws error: {stderr}")
                 break
             if ret_code != 0:
                 print(

--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -279,7 +279,7 @@ class S3:
                 "PreconditionFailed" in stderr
                 or "ConditionalRequestConflict" in stderr
             ):
-                # Lost optimistic-lock race. Set to true s.t. the caller re-reads the current version and retries.
+                # Lost optimistic-lock race. Suppress the raise and return False so the caller retries.
                 no_strict = True
                 print("AWS API conditional request failed (concurrent write detected)")
                 print(f"  | aws error: {stderr}")

--- a/ci/tests/test_event.py
+++ b/ci/tests/test_event.py
@@ -78,7 +78,7 @@ def test_sanitize_completed_untouched():
 
 
 def test_update_retries_conditional_request_conflict(monkeypatch):
-    """The 409 lost-race code must be retried like PreconditionFailed (#112786)."""
+    """A lost race (ConditionalRequestConflict) must be retried, not raised."""
     boto3 = pytest.importorskip("boto3")
     from botocore.exceptions import ClientError
 

--- a/ci/tests/test_event.py
+++ b/ci/tests/test_event.py
@@ -6,6 +6,7 @@ The EventFeed sanitizer must handle both old (lowercase) and new (uppercase) for
 """
 
 import os
+import pytest
 import sys
 import time
 
@@ -71,3 +72,28 @@ def test_sanitize_completed_untouched():
     old_ts = int(time.time()) - 13 * 3600
     e = _sanitize_via_feed(_make_event("OK", timestamp=old_ts))
     assert e.ci_status == "OK"
+
+
+def test_update_retries_conditional_request_conflict(monkeypatch):
+    """The 409 lost-race code must be retried like PreconditionFailed (#112786)."""
+    boto3 = pytest.importorskip("boto3")
+    from botocore.exceptions import ClientError
+
+    class _Client:
+        put_calls = 0
+
+        def get_object(self, **kwargs):
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+
+        def put_object(self, **kwargs):
+            self.put_calls += 1
+            if self.put_calls == 1:
+                raise ClientError(
+                    {"Error": {"Code": "ConditionalRequestConflict"}}, "PutObject"
+                )
+            return {"ETag": '"etag"'}
+
+    client = _Client()
+    monkeypatch.setattr(boto3, "client", lambda service, **kwargs: client)
+    EventFeed.update("user", _make_event("OK"), s3_path="bucket/prefix")
+    assert client.put_calls == 2

--- a/ci/tests/test_event.py
+++ b/ci/tests/test_event.py
@@ -5,6 +5,9 @@ The Event.ci_status field stores Result.Status values directly.
 The EventFeed sanitizer must handle both old (lowercase) and new (uppercase) formats.
 """
 
+import gzip
+import io
+import json
 import os
 import pytest
 import sys
@@ -83,9 +86,11 @@ def test_update_retries_conditional_request_conflict(monkeypatch):
         put_calls = 0
 
         def get_object(self, **kwargs):
-            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+            body = gzip.compress(json.dumps(EventFeed().to_dict()).encode())
+            return {"Body": io.BytesIO(body), "ETag": '"etag"'}
 
         def put_object(self, **kwargs):
+            assert kwargs.get("IfMatch") == '"etag"', "write must be conditional"
             self.put_calls += 1
             if self.put_calls == 1:
                 raise ClientError(

--- a/ci/tests/test_s3_versioned_upload_conflict.py
+++ b/ci/tests/test_s3_versioned_upload_conflict.py
@@ -1,0 +1,57 @@
+"""
+S3.copy_file_to_s3_with_version is praktika's optimistic-locking write. 
+update_workflow_results retries the read-merge-write cycle whenever it returns False. 
+S3 signals a lost race with PreconditionFailed (theother write committed) or ConditionalRequestConflict (the other writeis in flight).
+Treating the latter as fatal kills jobs in pre_run whenever two jobs updated the workflow result concurrently.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+pytest.importorskip("boto3")
+from botocore.exceptions import ClientError
+
+from ci.praktika.s3 import S3
+
+
+class _FakeS3Client:
+    def __init__(self, put_error_code):
+        self.put_error_code = put_error_code
+
+    def head_object(self, Bucket, Key):
+        return {"ETag": '"etag"', "Metadata": {"version": "0"}}
+
+    def put_object(self, **kwargs):
+        if self.put_error_code:
+            raise ClientError({"Error": {"Code": self.put_error_code}}, "PutObject")
+
+
+def _upload(tmp_path, put_error_code):
+    local_file = tmp_path / "result.json"
+    local_file.write_text("{}")
+    S3._boto3_client = _FakeS3Client(put_error_code)
+    try:
+        return S3.copy_file_to_s3_with_version("bucket/key", str(local_file), version=1)
+    finally:
+        S3._boto3_client = None
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        (None, True),
+        ("PreconditionFailed", False),
+        ("ConditionalRequestConflict", False),
+    ],
+)
+def test_lost_race_returns_false_for_retry(tmp_path, code, expected):
+    assert _upload(tmp_path, code) is expected
+
+
+def test_unexpected_error_raises(tmp_path):
+    with pytest.raises(ClientError):
+        _upload(tmp_path, "AccessDenied")

--- a/ci/tests/test_s3_versioned_upload_conflict.py
+++ b/ci/tests/test_s3_versioned_upload_conflict.py
@@ -1,10 +1,10 @@
 """
-S3.copy_file_to_s3_with_version is praktika's optimistic-locking write. 
-update_workflow_results retries the read-merge-write cycle whenever it returns False. 
-S3 signals a lost race with PreconditionFailed (theother write committed) or ConditionalRequestConflict (the other writeis in flight).
-Treating the latter as fatal kills jobs in pre_run whenever two jobs updated the workflow result concurrently.
+S3.copy_file_to_s3_with_version is praktika's optimistic-locking write.
+update_workflow_results retries the read-merge-write cycle whenever it returns False.
+Verify S3 signals a lost race with PreconditionFailed (other write committed) or ConditionalRequestConflict (other write in flight).
 """
 
+import json
 import os
 import sys
 
@@ -15,7 +15,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 pytest.importorskip("boto3")
 from botocore.exceptions import ClientError
 
+from ci.praktika import s3 as s3_module
 from ci.praktika.s3 import S3
+
+HEAD_OBJECT = {"ETag": '"etag"', "Metadata": {"version": "0"}}
 
 
 class _FakeS3Client:
@@ -23,23 +26,35 @@ class _FakeS3Client:
         self.put_error_code = put_error_code
 
     def head_object(self, Bucket, Key):
-        return {"ETag": '"etag"', "Metadata": {"version": "0"}}
+        return HEAD_OBJECT
 
     def put_object(self, **kwargs):
         if self.put_error_code:
             raise ClientError({"Error": {"Code": self.put_error_code}}, "PutObject")
 
 
-def _upload(tmp_path, put_error_code):
+def _upload(tmp_path, monkeypatch, cli, code):
+    """Run the versioned upload against a fake S3 backend that fails with `code`."""
     local_file = tmp_path / "result.json"
     local_file.write_text("{}")
-    S3._boto3_client = _FakeS3Client(put_error_code)
-    try:
-        return S3.copy_file_to_s3_with_version("bucket/key", str(local_file), version=1)
-    finally:
-        S3._boto3_client = None
+    if cli:
+        monkeypatch.setattr(s3_module, "BOTO3_AVAILABLE", False)
+        monkeypatch.setattr(
+            s3_module.Shell, "get_output", lambda *a, **kw: json.dumps(HEAD_OBJECT)
+        )
+        monkeypatch.setattr(
+            s3_module.Shell,
+            "get_res_stdout_stderr",
+            lambda cmd, **kw: (
+                (255, "", f"An error occurred ({code})") if code else (0, "", "")
+            ),
+        )
+    else:
+        monkeypatch.setattr(S3, "_boto3_client", _FakeS3Client(code))
+    return S3.copy_file_to_s3_with_version("bucket/key", str(local_file), version=1)
 
 
+@pytest.mark.parametrize("cli", [False, True], ids=["boto3", "cli"])
 @pytest.mark.parametrize(
     "code,expected",
     [
@@ -48,10 +63,15 @@ def _upload(tmp_path, put_error_code):
         ("ConditionalRequestConflict", False),
     ],
 )
-def test_lost_race_returns_false_for_retry(tmp_path, code, expected):
-    assert _upload(tmp_path, code) is expected
+def test_lost_race_returns_false_for_retry(tmp_path, monkeypatch, cli, code, expected):
+    assert _upload(tmp_path, monkeypatch, cli, code) is expected
 
 
-def test_unexpected_error_raises(tmp_path):
-    with pytest.raises(ClientError):
-        _upload(tmp_path, "AccessDenied")
+@pytest.mark.parametrize(
+    "cli,expected_error",
+    [(False, ClientError), (True, RuntimeError)],
+    ids=["boto3", "cli"],
+)
+def test_unexpected_error_raises(tmp_path, monkeypatch, cli, expected_error):
+    with pytest.raises(expected_error):
+        _upload(tmp_path, monkeypatch, cli, "AccessDenied")


### PR DESCRIPTION
`copy_file_to_s3_with_version` retries a lost race only on `PreconditionFailed` (the competing write already committed, so our read is stale). But S3 rejects a conditional write with `ConditionalRequestConflict` when the competing write is still in flight (same lost race, caught one moment earlier). Map it to the same retry path instead of killing the job.

[Example of this firing.](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109920&sha=facaa5af52e4014049504c8c877f01379c925bc7&name_0=PR&name_1=Integration+tests+%28arm_binary%2C+distributed+plan%2C+3%2F4%29)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.696` (included in `26.8` and later)
<!-- ch-version-info:end -->