### PR TITLE
Revert "Use a lock-free queue for asynchronous logging"

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1299,14 +1299,6 @@ try
     if (server_settings[ServerSetting::remap_executable])
     {
         LOG_DEBUG(log, "Will remap executable in memory.");
-        /// remapExecutable rewrites the whole code segment in place; any other thread executing code during
-        /// the window faults (and the signal handler's code is unmapped too, so it dies silently). The async
-        /// logging threads poll rather than block, so join them for the duration and restart afterwards.
-        stopAsyncLoggingThreads();
-        /// Restart the async logging threads even if remapExecutable throws. Otherwise the logger would stay
-        /// stopped, and the exception unwinding through Server::main would be logged into a queue that no
-        /// consumer thread is draining, silently losing the startup exception and any queued diagnostics.
-        SCOPE_EXIT_SAFE(startAsyncLoggingThreads());
         size_t size = remapExecutable();
         LOG_DEBUG(log, "The code ({}) in memory has been successfully remapped.", ReadableSize(size));
     }

--- a/src/Common/NonblockingBoundedQueue.h
+++ b/src/Common/NonblockingBoundedQueue.h
@@ -4,7 +4,6 @@
 #include <vector>
 #include <base/defines.h>
 #include <Common/BitHelpers.h>
-#include <Common/CacheLine.h>
 
 /// Vyukov queue.
 /// https://web.archive.org/web/20170205113402/http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
@@ -164,12 +163,6 @@ public:
         size_t x = enqueue_pos.load(std::memory_order_relaxed);
         return x - std::min(x, y); // max(0, x - y)
     }
-
-    /// Number of pushes ever started. Acquire-ordered: a consumer observing this value also observes
-    /// every slot published before it, so it is an exact boundary for a full drain (unlike `size`).
-    size_t enqueuePosition() const { return enqueue_pos.load(std::memory_order_acquire); }
-    /// Number of pops ever completed. Only meaningful to the (single) consumer, which owns dequeue_pos.
-    size_t dequeuePosition() const { return dequeue_pos.load(std::memory_order_relaxed); }
 
 private:
     struct alignas(DB::CH_CACHE_LINE_SIZE) Slot

--- a/src/Common/remapExecutable.cpp
+++ b/src/Common/remapExecutable.cpp
@@ -59,22 +59,17 @@ __attribute__((__noinline__)) void remapToHugeStep3(void * scratch, size_t size,
 }
 
 
-__attribute__((__noinline__)) void remapToHugeStep2(void * begin, size_t size, void * scratch, void * syscall_in_scratch, void * step3_in_place)
+__attribute__((__noinline__)) void remapToHugeStep2(void * begin, size_t size, void * scratch)
 {
     /** Unmap old memory region with the code of our program.
       * Our instruction pointer is located inside scratch area and this function can execute after old code is unmapped.
       * But it cannot call any other functions because they are not available at usual addresses
       * - that's why we have to use "our_syscall" function and a substitution for memcpy.
       * (Relative addressing may continue to work but we should not assume that).
-      *
-      * The callee addresses (our_syscall in the scratch copy, and step3 in its original place) are captured by
-      * step1 while it still runs from the original mapping and passed in here. We must not recompute them here:
-      * in position-independent (PIE) builds a reference to our_syscall/step3 taken while running from scratch
-      * resolves into the scratch copy, so adding the offset again would double-count and jump into garbage.
       */
 
     int64_t offset = reinterpret_cast<intptr_t>(scratch) - reinterpret_cast<intptr_t>(begin);
-    int64_t (*syscall_func)(...) = reinterpret_cast<int64_t (*)(...)>(syscall_in_scratch);
+    int64_t (*syscall_func)(...) = reinterpret_cast<int64_t (*)(...)>(reinterpret_cast<intptr_t>(our_syscall) + offset);
 
     int64_t munmap_res = syscall_func(SYS_munmap, begin, size);
     if (munmap_res != 0)
@@ -115,7 +110,7 @@ __attribute__((__noinline__)) void remapToHugeStep2(void * begin, size_t size, v
       * To do it, we obtain its pointer and call by pointer.
       */
 
-    void(* volatile step3)(void*, size_t, size_t) = reinterpret_cast<void(*)(void*, size_t, size_t)>(step3_in_place);
+    void(* volatile step3)(void*, size_t, size_t) = remapToHugeStep3;
     step3(scratch, size, offset);
 }
 
@@ -134,17 +129,9 @@ __attribute__((__noinline__)) void remapToHugeStep1(void * begin, size_t size)
 
     int64_t offset = reinterpret_cast<intptr_t>(scratch) - reinterpret_cast<intptr_t>(begin);
 
-    /// Capture callee addresses here, while we still run from the original mapping, so they stay valid once
-    /// step2 executes from the scratch copy. our_syscall is relocated into scratch (+offset); step3 must be
-    /// called at its original place (the code is restored before step3 runs). In PIE builds these references
-    /// cannot be recomputed inside step2, hence we pass them as plain pointers.
-    void * syscall_in_scratch = reinterpret_cast<void *>(reinterpret_cast<intptr_t>(our_syscall) + offset);
-    void * step3_in_place = reinterpret_cast<void *>(remapToHugeStep3);
-
     /// Jump to the next function inside the scratch area.
 
-    reinterpret_cast<void(*)(void*, size_t, void*, void*, void*)>(reinterpret_cast<intptr_t>(remapToHugeStep2) + offset)(
-        begin, size, scratch, syscall_in_scratch, step3_in_place);
+    reinterpret_cast<void(*)(void*, size_t, void*)>(reinterpret_cast<intptr_t>(remapToHugeStep2) + offset)(begin, size, scratch);
 }
 
 }

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1793,7 +1793,7 @@ Configured as `named_collections_storage.type` (`<named_collections_storage><typ
     DECLARE(Bool, logger_use_syslog, false, R"(Also forward log output to syslog.)", 0, "logger.use_syslog") \
     DECLARE(String, logger_syslog_level, "trace", R"(Log level for logging to syslog.)", 0, "logger.syslog_level") \
     DECLARE(Bool, logger_async, true, R"(When `<true>` (default) logging will happen asynchronously (one background thread per output channel). Otherwise it will log inside the thread calling LOG.)", 0, "logger.async") \
-    DECLARE(UInt64, logger_async_queue_max_size, 65536, R"(When using async logging, the max amount of messages that will be kept in the the queue waiting for flushing. Extra messages will be dropped. Rounded up to the next power of two (e.g. `100000` becomes `131072`).)", 0, "logger.async_queye_max_size") \
+    DECLARE(UInt64, logger_async_queue_max_size, 65536, R"(When using async logging, the max amount of messages that will be kept in the the queue waiting for flushing. Extra messages will be dropped.)", 0, "logger.async_queye_max_size") \
     DECLARE(String, logger_startup_level, "", R"(Startup level is used to set the root logger level at server startup. After startup log level is reverted to the `<level>` setting.)", 0, "logger.startup_level") \
     DECLARE(String, logger_shutdown_level, "", R"(Shutdown level is used to set the root logger level at server Shutdown.)", 0, "logger.shutdown_level") \
     DECLARE(String, openssl_server_private_key_file, "", R"(Path to the file with the secret key of the PEM certificate. The file may contain a key and certificate at the same time.)", 0, "openSSL.server.privateKeyFile") \

--- a/src/Loggers/Loggers.cpp
+++ b/src/Loggers/Loggers.cpp
@@ -447,18 +447,6 @@ DB::AsyncLogQueueSizes Loggers::getAsynchronousMetricsFromAsyncLogs()
     return {};
 }
 
-void Loggers::stopAsyncLoggingThreads()
-{
-    if (auto * async = dynamic_cast<DB::OwnAsyncSplitChannel *>(split.get()))
-        async->close();
-}
-
-void Loggers::startAsyncLoggingThreads()
-{
-    if (auto * async = dynamic_cast<DB::OwnAsyncSplitChannel *>(split.get()))
-        async->open();
-}
-
 void Loggers::stopLogging()
 {
     if (split)

--- a/src/Loggers/Loggers.h
+++ b/src/Loggers/Loggers.h
@@ -34,12 +34,6 @@ public:
     DB::AsyncLogQueueSizes getAsynchronousMetricsFromAsyncLogs();
     void flushTextLogs();
 
-    /// Stop/restart the background logging threads. Used around remapExecutable, which rewrites the whole
-    /// code segment and requires that no other thread runs code meanwhile (the async threads poll, so they
-    /// must be joined for the duration). No-op for synchronous logging.
-    void stopAsyncLoggingThreads();
-    void startAsyncLoggingThreads();
-
     virtual ~Loggers() = default;
 
     void stopLogging();

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -13,8 +13,6 @@
 
 #include <Poco/Message.h>
 
-#include <base/sleep.h>
-
 #if defined(MEMORY_SANITIZER)
 #include <sanitizer/msan_interface.h>
 #endif
@@ -84,22 +82,6 @@ void OwnSplitChannel::log(Poco::Message && msg)
 
 namespace
 {
-
-/// Sleep between polls of an empty queue (consumers poll instead of futex-waiting, keeping pushes cheap).
-constexpr size_t sleep_on_empty_queue_ms = 10;
-
-/// Pops one message for a flush (null if empty), waiting out a head slot still being written so it isn't skipped.
-AsyncLogMessagePtr dequeueMessageForFlush(NonblockingBoundedQueue<AsyncLogMessagePtr> & messages)
-{
-    AsyncLogMessagePtr message;
-    while (!messages.tryPop(message))
-    {
-        if (messages.size() == 0)
-            return nullptr;
-        sleepForMilliseconds(10);
-    }
-    return message;
-}
 
 void pushExtendedMessageToInternalTCPTextLogQueue(
     const ExtendedLogMessage & msg_ext, const std::shared_ptr<InternalTextLogsQueue> & logs_queue)
@@ -283,17 +265,24 @@ void OwnAsyncSplitChannel::close()
     is_open = false;
     try
     {
-        /// The polling consumers see is_open == false on their own, flush what is left, and exit.
         if (text_log_thread)
         {
-            text_log_thread->join();
+            do
+            {
+                text_log_queue.wakeUp();
+            } while (!text_log_thread->tryJoin(100));
             text_log_thread.reset();
         }
 
         for (size_t i = 0; i < channels.size(); i++)
         {
             if (threads[i])
-                threads[i]->join();
+            {
+                do
+                {
+                    queues[i]->wakeUp();
+                } while (!threads[i]->tryJoin(100));
+            }
             threads[i].reset();
         }
     }
@@ -329,32 +318,86 @@ public:
 };
 
 
-namespace
+AsyncLogMessageQueue::AsyncLogMessageQueue(
+    size_t max_size_, const ProfileEvents::Event & event_on_passed_message_, const ProfileEvents::Event & event_on_drop_message_)
+    : event_on_passed_message(event_on_passed_message_)
+    , event_on_drop_message(event_on_drop_message_)
+    , max_size(max_size_)
 {
-
-/// Builds the "dropped N messages" warning, reported in the channel that dropped them.
-AsyncLogMessagePtr makeDroppedMessagesWarning(size_t dropped)
-{
-    auto warning = std::make_shared<AsyncLogMessage>(Poco::Message(
-        "AsyncLogger",
-        fmt::format("We've dropped {} log messages in this channel due to queue overflow", dropped),
-        Poco::Message::PRIO_WARNING));
-    warning->msg_ext.query_id.clear();
-    return warning;
+    if (max_size == 0)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Asynchronous log message queue cannot have zero size");
 }
 
-}
-
-void OwnAsyncSplitChannel::enqueueMessage(LogQueue & queue, AsyncLogMessagePtr message)
+void AsyncLogMessageQueue::enqueueMessage(AsyncLogMessagePtr message)
 {
-    ProfileEvents::incrementNoTrace(queue.event_on_passed_message);
-
-    if (unlikely(!queue.messages.tryPush(message)))
+    ProfileEvents::incrementNoTrace(event_on_passed_message);
+    std::unique_lock lock(mutex);
+    size_t current_size = message_queue.size();
+    if (unlikely(current_size >= max_size))
     {
-        /// Queue full: drop the message and count it; the consumer warns about drops once it catches up.
-        queue.dropped_messages.fetch_add(1, std::memory_order_relaxed);
-        ProfileEvents::incrementNoTrace(queue.event_on_dropped_message);
+        /// If the queue is full we start dropping messages until it's less than half of the max size
+        /// in order to give the thread a change to recover and to reduce the amount of warning messages (about dropped messages)
+        /// which would contribute to fill the queue even more
+        dropped_messages++;
+        lock.unlock();
+        ProfileEvents::incrementNoTrace(event_on_drop_message);
+        return;
     }
+
+    if (unlikely(dropped_messages))
+    {
+        String log = fmt::format("We've dropped {} log messages in this channel due to queue overflow", dropped_messages);
+        auto async_message = std::make_shared<AsyncLogMessage>(Poco::Message("AsyncLogMessageQueue", log, Poco::Message::PRIO_WARNING));
+        async_message->msg_ext.query_id.clear();
+        message_queue.push_back(async_message);
+        dropped_messages = 0;
+    }
+
+    message_queue.push_back(std::move(message));
+    /// Request the thread to flush as fast as possible (without acquiring the mutex every time)
+    if (current_size > max_size / 2)
+        request_flush = true;
+    if (unlikely(current_size == 0))
+        condition.notify_all();
+}
+
+AsyncLogMessagePtr AsyncLogMessageQueue::waitDequeueMessage()
+{
+    std::unique_lock lock(mutex);
+    if (!message_queue.empty())
+    {
+        auto notification = std::move(message_queue.front());
+        message_queue.pop_front();
+        return notification;
+    }
+
+    condition.wait(lock);
+    if (message_queue.empty())
+        return nullptr;
+
+    auto notification = std::move(message_queue.front());
+    message_queue.pop_front();
+    return notification;
+}
+
+AsyncLogMessageQueue::Queue AsyncLogMessageQueue::getCurrentQueueAndClear()
+{
+    std::unique_lock lock(mutex);
+    Queue new_queue;
+    std::swap(message_queue, new_queue);
+    return new_queue;
+}
+
+void AsyncLogMessageQueue::wakeUp()
+{
+    std::unique_lock lock(mutex);
+    condition.notify_one();
+}
+
+size_t AsyncLogMessageQueue::getCurrentMessageSize()
+{
+    std::unique_lock lock(mutex);
+    return message_queue.size();
 }
 
 void OwnAsyncSplitChannel::log(const Poco::Message & msg)
@@ -367,7 +410,8 @@ void OwnAsyncSplitChannel::log(Poco::Message && msg)
     try
     {
 #if defined(MEMORY_SANITIZER)
-        /// Catch which LOG call produces uninitialized format string bytes (STID 1478-2063: arm_msan use-of-uninitialized-value in TextLog).
+        /// Catch which LOG call produces a message with uninitialized format string bytes.
+        /// STID 1478-2063: arm_msan stress test reports use-of-uninitialized-value in TextLog
         {
             auto fmt = msg.getFormatString();
             __msan_check_mem_is_initialized(&fmt, sizeof(fmt));
@@ -375,7 +419,8 @@ void OwnAsyncSplitChannel::log(Poco::Message && msg)
                 __msan_check_mem_is_initialized(fmt.data(), fmt.size());
         }
 #endif
-        /// logger_useful.h skips this when the message isn't needed, so creating the AsyncLogMessage here is free.
+        /// Based on logger_useful.h this won't be called if the message is not needed
+        /// so we can create the AsyncLogMessage as it won't penalize performance by being unused
         auto msg_priority = msg.getPriority();
         auto notification = std::make_shared<AsyncLogMessage>(std::move(msg));
         if (const auto & logs_queue = CurrentThread::getInternalTextLogsQueue();
@@ -392,11 +437,11 @@ void OwnAsyncSplitChannel::log(Poco::Message && msg)
         for (size_t i = 0; i < queues.size(); i++)
         {
             if (channels[i]->getPriority() >= msg_priority)
-                enqueueMessage(*queues[i], notification);
+                queues[i]->enqueueMessage(notification);
         }
 
         if (text_log_max_priority_loaded >= msg_priority)
-            enqueueMessage(text_log_queue, std::move(notification));
+            text_log_queue.enqueueMessage(std::move(notification));
     }
     catch (...)
     {
@@ -415,21 +460,18 @@ void OwnAsyncSplitChannel::flushTextLogs()
     if (!text_log_locked)
         return;
 
-    /// The async text-log thread services this handshake. It is not running while logging is stopped around
-    /// remapExecutable (where the only caller is the fatal signal handler; the server accepts no connections
-    /// yet) nor after shutdown, so return instead of waiting forever for a flag nobody will clear. Anything
-    /// queued meanwhile is drained when the thread (re)starts.
-    if (!is_open)
-        return;
+    /// If there is a query flushing already we must wait until it's done. Otherwise we will receive the notification to wake up
+    /// once the previous flush is finished, which is not what we need
+    /// This is not ideal and we could use some kind of flush id to wait only until the point when you entered this function
+    /// But notice that even if you call in many threads, they will all wait and be processed together in the same block once this is unlocked
+    text_log_queue.request_flush.wait(true, std::memory_order_seq_cst);
 
-    /// Wait out any flush already in progress, else we'd wake when that one ends; concurrent callers flush together.
-    text_log_flush_requested.wait(true, std::memory_order_seq_cst);
-
-    /// The async thread checks this flag between messages and after each empty-queue sleep.
-    text_log_flush_requested = true;
+    /// We need to send an empty notification to wake up the thread if necessary
+    text_log_queue.request_flush = true;
+    text_log_queue.wakeUp();
 
     /// Now we simply wait for the async thread to notify it has finished flushing
-    text_log_flush_requested.wait(true, std::memory_order_seq_cst);
+    text_log_queue.request_flush.wait(true, std::memory_order_seq_cst);
 }
 
 AsyncLogQueueSizes OwnAsyncSplitChannel::getAsynchronousMetrics()
@@ -441,14 +483,14 @@ AsyncLogQueueSizes OwnAsyncSplitChannel::getAsynchronousMetrics()
         {
             if (channels[i] == channel.get())
             {
-                metrics.push_back({name, queues[i]->messages.size()});
+                metrics.push_back({name, queues[i]->getCurrentMessageSize()});
                 break;
             }
         }
     }
 
     if (text_log.lock())
-        metrics.push_back({"TextLog", text_log_queue.messages.size()});
+        metrics.push_back({"TextLog", text_log_queue.getCurrentMessageSize()});
 
     return metrics;
 }
@@ -457,39 +499,26 @@ void OwnAsyncSplitChannel::runChannel(size_t i)
 {
     DB::setThreadName(ThreadName::ASYNC_LOGGER);
     LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
-    LogQueue & queue = *queues[i];
+    auto notification = queues[i]->waitDequeueMessage();
     const auto & extended_channel = channels[i];
 
-    auto report_dropped_messages = [&]()
+    auto log_notification = [&](auto & async_message)
     {
-        if (likely(queue.dropped_messages.load(std::memory_order_relaxed) == 0))
+        if (!async_message)
             return;
-
-        size_t dropped = queue.dropped_messages.exchange(0, std::memory_order_relaxed);
-        try
-        {
-            extended_channel->logExtended(makeDroppedMessagesWarning(dropped)->msg_ext);
-        }
-        catch (...)
-        {
-            /// Don't lose the count if we failed to report it
-            queue.dropped_messages.fetch_add(dropped, std::memory_order_relaxed);
-            throw;
-        }
+        if (const auto * own_notification = dynamic_cast<const AsyncLogMessage *>(async_message.get()))
+            extended_channel->logExtended(own_notification->msg_ext);
     };
 
     auto flush_queue = [&]()
     {
-        /// Exact, bounded flush boundary: drain every message enqueued as of now (position captured with
-        /// acquire so we observe their published slots) and no later arrival, so producers can't prolong
-        /// the flush; dequeueMessageForFlush waits out any slot still being published.
-        const size_t target = queue.messages.enqueuePosition();
-        while (queue.messages.dequeuePosition() < target)
+        /// We want to process only what's currently in the queue and not block other logging
+        auto queue = queues[i]->getCurrentQueueAndClear();
+        while (!queue.empty())
         {
-            auto notif = dequeueMessageForFlush(queue.messages);
-            if (!notif)
-                break;
-            extended_channel->logExtended(notif->msg_ext);
+            auto notif = std::move(queue.front());
+            queue.pop_front();
+            log_notification(notif);
         }
     };
 
@@ -497,20 +526,14 @@ void OwnAsyncSplitChannel::runChannel(size_t i)
     {
         try
         {
-            AsyncLogMessagePtr message;
-            if (queue.messages.tryPop(message))
+            log_notification(notification);
+            if (queues[i]->request_flush)
             {
-                extended_channel->logExtended(message->msg_ext);
+                flush_queue();
+                queues[i]->request_flush = false;
             }
-            else
-            {
-                /// Empty queue: sleep, then report overflow drops here. tryPop can also fail while a producer
-                /// holds an unpublished slot, so only warn once the queue is truly drained (size()==0), else
-                /// the warning could overtake real messages still being enqueued.
-                sleepForMilliseconds(sleep_on_empty_queue_ms);
-                if (queue.messages.size() == 0)
-                    report_dropped_messages();
-            }
+
+            notification = queues[i]->waitDequeueMessage();
         }
         catch (...)
         {
@@ -523,9 +546,9 @@ void OwnAsyncSplitChannel::runChannel(size_t i)
 
     try
     {
-        /// Flush everything before closing and report the drops which were not reported yet
+        /// Flush everything before closing
+        log_notification(notification);
         flush_queue();
-        report_dropped_messages();
     }
     catch (...)
     {
@@ -540,74 +563,53 @@ void OwnAsyncSplitChannel::runTextLog()
 {
     DB::setThreadName(ThreadName::ASYNC_TEXT_LOG);
 
-    auto report_dropped_messages = [&](const std::shared_ptr<SystemLogQueue<TextLogElement>> & text_log_locked)
+    auto log_notification = [](auto & message, const std::shared_ptr<SystemLogQueue<TextLogElement>> & text_log_locked)
     {
-        if (likely(text_log_queue.dropped_messages.load(std::memory_order_relaxed) == 0))
-            return;
-
-        size_t dropped = text_log_queue.dropped_messages.exchange(0, std::memory_order_relaxed);
-        try
-        {
-            const auto warning = makeDroppedMessagesWarning(dropped);
-            logToSystemTextLogQueue(text_log_locked, warning->msg_ext, warning->msg_thread_name);
-        }
-        catch (...)
-        {
-            /// Don't lose the count if we failed to report it
-            text_log_queue.dropped_messages.fetch_add(dropped, std::memory_order_relaxed);
-            throw;
-        }
+        if (const auto * own_notification = dynamic_cast<const AsyncLogMessage *>(message.get()))
+            logToSystemTextLogQueue(text_log_locked, own_notification->msg_ext, own_notification->msg_thread_name);
     };
 
     auto flush_queue = [&](const std::shared_ptr<SystemLogQueue<TextLogElement>> & text_log_locked)
     {
-        /// Exact, bounded flush boundary: SYSTEM FLUSH LOGS relies on every record accepted before the
-        /// request reaching text_log before flushImpl samples the last index. Capture the enqueue position
-        /// with acquire (size() is imprecise while producers run) and drain up to it, waiting out any slot
-        /// still being published. Later arrivals aren't included, so producers can't prolong the flush.
-        const size_t target = text_log_queue.messages.enqueuePosition();
-        while (text_log_queue.messages.dequeuePosition() < target)
+        /// We want to process only what's currently in the queue and not block other logging
+        auto queue = text_log_queue.getCurrentQueueAndClear();
+        while (!queue.empty())
         {
-            auto notif = dequeueMessageForFlush(text_log_queue.messages);
-            if (!notif)
-                break;
-            logToSystemTextLogQueue(text_log_locked, notif->msg_ext, notif->msg_thread_name);
+            auto notif = std::move(queue.front());
+            queue.pop_front();
+            if (notif)
+                log_notification(notif, text_log_locked);
         }
     };
 
+    auto notification = text_log_queue.waitDequeueMessage();
     while (is_open)
     {
         try
         {
-            auto text_log_locked = text_log.lock();
-            if (!text_log_locked)
-                return;
-
-            if (text_log_flush_requested)
+            if (text_log_queue.request_flush)
             {
+                auto text_log_locked = text_log.lock();
+                if (!text_log_locked)
+                    return;
+
+                if (notification)
+                    log_notification(notification, text_log_locked);
+
                 flush_queue(text_log_locked);
-                /// Emit the drop warning as part of the flush, before releasing the waiter, so SYSTEM FLUSH
-                /// LOGS / shutdown can't miss the only record that tells users messages were dropped.
-                report_dropped_messages(text_log_locked);
-                text_log_flush_requested = false;
-                text_log_flush_requested.notify_all();
-                continue;
+
+                text_log_queue.request_flush = false;
+                text_log_queue.request_flush.notify_all();
+            }
+            else if (notification)
+            {
+                auto text_log_locked = text_log.lock();
+                if (!text_log_locked)
+                    return;
+                log_notification(notification, text_log_locked);
             }
 
-            AsyncLogMessagePtr message;
-            if (text_log_queue.messages.tryPop(message))
-            {
-                logToSystemTextLogQueue(text_log_locked, message->msg_ext, message->msg_thread_name);
-            }
-            else
-            {
-                /// Empty queue: sleep, then report overflow drops here. tryPop can also fail while a producer
-                /// holds an unpublished slot, so only warn once the queue is truly drained (size()==0), else
-                /// the warning could overtake real messages still being enqueued.
-                sleepForMilliseconds(sleep_on_empty_queue_ms);
-                if (text_log_queue.messages.size() == 0)
-                    report_dropped_messages(text_log_locked);
-            }
+            notification = text_log_queue.waitDequeueMessage();
         }
         catch (...)
         {
@@ -620,13 +622,14 @@ void OwnAsyncSplitChannel::runTextLog()
 
     try
     {
-        /// Flush everything still queued before closing, and report any drops not yet reported.
+        /// We want to flush everything already in the queue before closing so all messages are logged
         auto text_log_locked = text_log.lock();
         if (!text_log_locked)
             return;
 
+        if (notification)
+            log_notification(notification, text_log_locked);
         flush_queue(text_log_locked);
-        report_dropped_messages(text_log_locked);
     }
     catch (...)
     {
@@ -659,7 +662,7 @@ void OwnAsyncSplitChannel::addChannel(
     channel->setLevel(level);
 
     channels.emplace_back(element.first->second.get());
-    queues.emplace_back(std::make_unique<LogQueue>(async_queue_size, event_on_passed_message_, event_on_dropped_message_));
+    queues.emplace_back(std::make_unique<AsyncLogMessageQueue>(async_queue_size, event_on_passed_message_, event_on_dropped_message_));
     threads.emplace_back(nullptr);
     const size_t i = threads.size() - 1;
     runnables.emplace_back(new OwnRunnableForChannel(*this, i));

--- a/src/Loggers/OwnSplitChannel.h
+++ b/src/Loggers/OwnSplitChannel.h
@@ -3,10 +3,11 @@
 #include <base/strong_typedef.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <memory>
 
+#include <Common/DequeWithMemoryTracking.h>
 #include <Common/MapWithMemoryTracking.h>
-#include <Common/NonblockingBoundedQueue.h>
 #include <Common/VectorWithMemoryTracking.h>
 
 #include <boost/noncopyable.hpp>
@@ -99,7 +100,48 @@ struct OwnRunnableForTextLog;
 class AsyncLogMessage;
 using AsyncLogMessagePtr = std::shared_ptr<AsyncLogMessage>;
 
-/// Like OwnSplitChannel but logs on background threads — one per channel (plus text_log), to preserve order; internalTextLogsQueue (--send-logs-level) is still written synchronously.
+class AsyncLogMessageQueue
+{
+public:
+    explicit AsyncLogMessageQueue(
+        size_t max_size_, const ProfileEvents::Event & event_on_passed_message_, const ProfileEvents::Event & event_on_drop_message_);
+
+    using Queue = DequeWithMemoryTracking<AsyncLogMessagePtr>;
+
+    /// Enqueues a single message notification
+    void enqueueMessage(AsyncLogMessagePtr message);
+
+    /// Waits for a message notification to be dequeued and returns it. It might return an empty notification if wakeUp() was called
+    /// or a spurious wakeup occurs
+    AsyncLogMessagePtr waitDequeueMessage();
+
+    /// Gets the full queue including all pending notifications and clears it. It might return an empty queue if no messages were available
+    Queue getCurrentQueueAndClear();
+
+    /// Wakes up any threads waiting for a message notification.
+    void wakeUp();
+
+    /// Gets the current size of the queue.
+    size_t getCurrentMessageSize();
+
+    std::atomic<bool> request_flush = false;
+
+private:
+    Queue message_queue;
+    std::condition_variable condition;
+    const ProfileEvents::Event & event_on_passed_message;
+    const ProfileEvents::Event & event_on_drop_message;
+    /// Default queue limit, to prevent memory overflow
+    const size_t max_size = 10000;
+    size_t dropped_messages = 0;
+    std::mutex mutex;
+};
+
+
+/// Same as OwnSplitChannel but it uses separate threads for logging.
+/// Note that it uses a separate thread per each different channel (including one for text_log) instead of using a common thread pool
+/// to ensure the order is kept
+/// Currently logging to the internalTextLogsQueue (TCP queue for --send-logs-level) is done synchronously when log is called
 class OwnAsyncSplitChannel final : public OwnSplitChannelBase, public boost::noncopyable
 {
 public:
@@ -130,44 +172,18 @@ public:
     AsyncLogQueueSizes getAsynchronousMetrics();
 
 private:
-    /// One channel's queue: lock-free bounded MPSC with drop-on-overflow accounting; producers are `log` callers, the single consumer is the background thread feeding the channel (or text_log).
-    struct LogQueue : boost::noncopyable
-    {
-        LogQueue(
-            size_t max_size,
-            const ProfileEvents::Event & event_on_passed_message_,
-            const ProfileEvents::Event & event_on_dropped_message_)
-            : messages(max_size)
-            , event_on_passed_message(event_on_passed_message_)
-            , event_on_dropped_message(event_on_dropped_message_)
-        {
-        }
-
-        /// Fixed power-of-two capacity, slots preallocated; new messages are dropped on overflow.
-        NonblockingBoundedQueue<AsyncLogMessagePtr> messages;
-        const ProfileEvents::Event & event_on_passed_message;
-        const ProfileEvents::Event & event_on_dropped_message;
-        /// Overflow drops so far: incremented by producers, reported and reset by the consumer.
-        std::atomic<size_t> dropped_messages = 0;
-    };
-
-    /// Pushes the message into the queue. If the queue is full, drops the message and counts the drop.
-    static void enqueueMessage(LogQueue & queue, AsyncLogMessagePtr message);
-
     std::atomic<bool> is_open = false;
     const size_t async_queue_size;
 
     /// Each channel has a different queue, and each one a single thread handling it
     MapWithMemoryTracking<std::string, ChannelPtr> name_to_channels;
     VectorWithMemoryTracking<OwnFormattingChannel *> channels;
-    VectorWithMemoryTracking<std::unique_ptr<LogQueue>> queues;
+    VectorWithMemoryTracking<std::unique_ptr<AsyncLogMessageQueue>> queues;
     VectorWithMemoryTracking<std::unique_ptr<Poco::Thread>> threads;
     VectorWithMemoryTracking<std::unique_ptr<OwnRunnableForChannel>> runnables;
 
     /// system.text_log does not have a channel, but it's also async
-    LogQueue text_log_queue;
-    /// Set by flushTextLogs to request a full flush; the text log thread resets it and notifies waiters when done.
-    std::atomic<bool> text_log_flush_requested = false;
+    AsyncLogMessageQueue text_log_queue;
     std::unique_ptr<Poco::Thread> text_log_thread;
     std::unique_ptr<OwnRunnableForTextLog> text_log_runnable;
     std::weak_ptr<DB::TextLogQueue> text_log;


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#107363

```
  1. Scraping system tables — fix exists: PR #112753 (https://github.com/ClickHouse/ClickHouse/pull/112753)

  7 of the 9 system.*_log dumps aborted with:
  
  WARNING: ThreadSanitizer: thread leak (pid=460390)
    Thread T3 'AsyncLogger' (tid=460394, finished) created by main thread at:
      #3 DB::OwnAsyncSplitChannel::open() src/Loggers/OwnSplitChannel.cpp:276:25
      #5 DB::LocalServer::processConfig() programs/local/LocalServer.cpp:1321:9
  Aborted
      
  This is a regression from PR #107363 (https://github.com/ClickHouse/ClickHouse/pull/107363) ("Use a lock-free queue for asynchronous logging", merged 2026-07-29 13:05 UTC). CIDB confirms a clean step change — of
  all Scraping system tables failures on TSan jobs, 0/195 carried thread leak before 2026-07-29, and 67/67 after (13 on 07-29, 22 on 07-30, 32 on 07-31); the first one lands in the 14:00 UTC hour on the merge
  day.
  
  Mechanism: LocalServer never calls Loggers::stopLogging, so OwnAsyncSplitChannel::close never runs and the AsyncLogger threads are killed by exit_group. Before #107363 the consumers blocked in condition.wait
  forever, so TSan saw them as Running and skipped them (CollectThreadLeaks only reports threads in ThreadStatusFinished). The new polling while (is_open) loop lets them reach Finished, making the pre-existing
  missing join visible. base/base/sanitizer_options.h sets abort_on_error=1, so the report kills clickhouse-local — the .tsv is already on disk, but the nonzero exit is reported as a failed dump.
```


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.545` (included in `26.8` and later)
<!-- ch-version-info:end -->