### PR TITLE
Allow multi-component identifiers in TimeSeries tables

### DIFF
--- a/docs/en/engines/table-engines/integrations/time-series.md
+++ b/docs/en/engines/table-engines/integrations/time-series.md
@@ -133,7 +133,7 @@ The _samples_ table must have columns:
 
 | Name | Mandatory? | Default type | Possible types | Description |
 |---|---|---|---|---|
-| `id` | [x] | `UUID` | any | Identifies a combination of a metric names and tags |
+| `id` | [x] | `Tuple(UInt64, UUID)` | any | Identifies a combination of a metric names and tags |
 | `timestamp` | [x] | `DateTime64(3)` | `DateTime64(X)` | A time point |
 | `value` | [x] | `Float64` | `Float32` or `Float64` | A value associated with the `timestamp` |
 
@@ -150,7 +150,7 @@ The _tags_ table must have columns:
 
 | Name | Mandatory? | Default type | Possible types | Description |
 |---|---|---|---|---|
-| `id` | [x] | `UUID` | any (must match the type of `id` in the [samples](#samples-table) table) | An `id` identifies a combination of a metric name and tags. The DEFAULT expression specifies how to calculate such an identifier |
+| `id` | [x] | `Tuple(UInt64, UUID)` | any (must match the type of `id` in the [samples](#samples-table) table) | An `id` identifies a combination of a metric name and tags. The DEFAULT expression specifies how to calculate such an identifier |
 | `metric_name` | [x] | `LowCardinality(String)` | `String` or `LowCardinality(String)` | The name of a metric |
 | `<tag_value_column>` | [ ] | `String` | `String` or `LowCardinality(String)` or `LowCardinality(Nullable(String))` | The value of a specific tag, the tag's name and the name of a corresponding column are specified in the [tags_to_columns](#settings) setting |
 | `tags` | [x] | `Map(LowCardinality(String), String)` | `Map(String, String)` or `Map(LowCardinality(String), String)` or `Map(LowCardinality(String), LowCardinality(String))` | Map of tags excluding the tag `__name__` containing the name of a metric and excluding tags with names enumerated in the [tags_to_columns](#settings) setting |
@@ -196,14 +196,14 @@ CREATE TABLE my_table
 ENGINE = TimeSeries
 SAMPLES INNER COLUMNS
 (
-    `id` UUID,
+    `id` Tuple(UInt64, UUID),
     `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
     `value` Float64 CODEC(Gorilla, ZSTD(1))
 )
 SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp)
 TAGS INNER COLUMNS
 (
-    `id` UUID DEFAULT reinterpretAsUUID(sipHash128(metric_name, all_tags)),
+    `id` Tuple(UInt64, UUID) DEFAULT tuple(sipHash64(metric_name), reinterpretAsUUID(sipHash128(metric_name, all_tags))),
     `metric_name` LowCardinality(String),
     `tags` Map(LowCardinality(String), String),
     `all_tags` Map(String, String) EPHEMERAL,
@@ -231,7 +231,7 @@ and each target table has its own set of columns:
 ```sql
 CREATE TABLE default.`.inner_id.samples.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 (
-    `id` UUID,
+    `id` Tuple(UInt64, UUID),
     `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
     `value` Float64 CODEC(Gorilla(8), ZSTD(1))
 )
@@ -242,7 +242,7 @@ ORDER BY (id, timestamp)
 ```sql
 CREATE TABLE default.`.inner_id.tags.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 (
-    `id` UUID DEFAULT reinterpretAsUUID(sipHash128(metric_name, all_tags)),
+    `id` Tuple(UInt64, UUID) DEFAULT tuple(sipHash64(metric_name), reinterpretAsUUID(sipHash128(metric_name, all_tags))),
     `metric_name` LowCardinality(String),
     `tags` Map(LowCardinality(String), String),
     `all_tags` Map(String, String) EPHEMERAL,

--- a/docs/en/engines/table-engines/integrations/time-series.md
+++ b/docs/en/engines/table-engines/integrations/time-series.md
@@ -304,7 +304,9 @@ CREATE TABLE my_table ENGINE=TimeSeries
 TAGS INNER COLUMNS (id UInt64 DEFAULT sipHash64(metric_name, all_tags))
 ```
 
-The `id` column can be of any comparable non-Nullable type. If no `DEFAULT` expression is given and the `id_generator` setting is not set, ClickHouse will choose the expression automatically based on the `id` type (only if the `id` type is one of `UUID`, `UInt64`, `UInt128`, or `FixedString(16)`). The `id` types declared in the samples and tags inner tables must match.
+The `id` column can be of any comparable non-Nullable type. The `id` types declared in the samples and tags inner tables must match.
+
+If no `DEFAULT` expression is given for the `id` column and the `id_generator` setting is not set, ClickHouse will choose the `DEFAULT` expression automatically based on the `id` type, but only if the `id` type is one of `UUID`, `UInt64`, `UInt128`, `FixedString(16)`, or a tuple of two of those types. For such a tuple the automatically chosen expression calculates a hash of the metric name in the first component and a hash of all the tags in the second component.
 
 The `id_generator` setting offers the same customization without using the `INNER COLUMNS` clause:
 

--- a/docs/en/engines/table-engines/integrations/time-series.md
+++ b/docs/en/engines/table-engines/integrations/time-series.md
@@ -304,7 +304,7 @@ CREATE TABLE my_table ENGINE=TimeSeries
 TAGS INNER COLUMNS (id UInt64 DEFAULT sipHash64(metric_name, all_tags))
 ```
 
-The `id` column type must be one of `UUID`, `UInt64`, `UInt128`, or `FixedString(16)`. If no `DEFAULT` expression is given, ClickHouse will choose it automatically based on the `id` type. The `id` types declared in the samples and tags inner tables must match.
+The `id` column can be of any comparable non-Nullable type. If no `DEFAULT` expression is given and the `id_generator` setting is not set, ClickHouse will choose the expression automatically based on the `id` type (only if the `id` type is one of `UUID`, `UInt64`, `UInt128`, or `FixedString(16)`). The `id` types declared in the samples and tags inner tables must match.
 
 The `id_generator` setting offers the same customization without using the `INNER COLUMNS` clause:
 

--- a/src/Functions/TimeSeries/TimeSeriesTagsFunctionHelpers.cpp
+++ b/src/Functions/TimeSeries/TimeSeriesTagsFunctionHelpers.cpp
@@ -1,7 +1,6 @@
 #include <Functions/TimeSeries/TimeSeriesTagsFunctionHelpers.h>
 
 #include <Columns/ColumnArray.h>
-#include <Columns/ColumnFixedString.h>
 #include <Columns/ColumnMap.h>
 #include <Columns/ColumnNothing.h>
 #include <Columns/ColumnNullable.h>
@@ -11,7 +10,6 @@
 #include <Common/quoteString.h>
 #include <Core/ColumnsWithTypeAndName.h>
 #include <DataTypes/DataTypeArray.h>
-#include <DataTypes/DataTypeFixedString.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeTuple.h>
@@ -278,72 +276,6 @@ namespace
             column.getName(), argument_index + 1, function_name, "UInt64");
     }
 
-    /// Extracts an identifier of time series from a column.
-    template <typename IDType>
-    void extractIDFromColumn(std::string_view function_name, size_t argument_index, const IColumn & column, VectorWithMemoryTracking<IDType> & out_ids)
-    {
-        size_t num_rows = out_ids.size();
-
-        /// Identifier can be UInt64.
-        if constexpr (std::is_convertible_v<UInt64, IDType>)
-        {
-            if (checkColumn<ColumnUInt64>(&column))
-            {
-                std::string_view data = column.getRawData();
-                chassert(data.size() == num_rows * sizeof(UInt64));
-                const UInt64 * begin = reinterpret_cast<const UInt64 *>(data.data());
-                out_ids.assign(begin, begin + num_rows);
-                return;
-            }
-        }
-
-        /// Identifier can be UInt128 or UUID or FixedString(16).
-        if constexpr (std::is_convertible_v<UInt128, IDType>)
-        {
-            const auto * fixed_string_column = checkAndGetColumn<ColumnFixedString>(&column);
-            if (checkColumn<ColumnUInt128>(&column) || checkColumn<ColumnUUID>(&column) || (fixed_string_column && (fixed_string_column->getN() == 16)))
-            {
-                /// We can handle UUID and FixedString(16) as UInt128 as they have the same size.
-                std::string_view data = column.getRawData();
-                chassert(data.size() == num_rows * sizeof(UInt128));
-                const UInt128 * begin = reinterpret_cast<const UInt128 *>(data.data());
-                out_ids.assign(begin, begin + num_rows);
-                return;
-            }
-        }
-
-        /// The argument can be nullable.
-        if (const auto * nullable_column = checkAndGetColumn<ColumnNullable>(&column))
-        {
-            const auto & nested_column = nullable_column->getNestedColumn();
-            /// The argument can be literal NULL.
-            if (checkColumn<ColumnNothing>(&nested_column))
-            {
-                std::fill(out_ids.begin(), out_ids.end(), IDType{});
-                return;
-            }
-            const auto & null_map = nullable_column->getNullMapData();
-            extractIDFromColumn(function_name, argument_index, nested_column, out_ids);
-            for (size_t i = 0; i != num_rows; ++i)
-            {
-                if (null_map[i])
-                    out_ids[i] = IDType{};
-            }
-            return;
-        }
-
-        /// The argument can be wrapped in ColumnConst or ColumnLowCardinality.
-        if (auto full_column = column.convertToFullIfWrapped()->convertToFullColumnIfLowCardinality(); full_column.get() != &column)
-        {
-            extractIDFromColumn(function_name, argument_index, *full_column, out_ids);
-            return;
-        }
-
-        throw Exception(
-            ErrorCodes::ILLEGAL_COLUMN,
-            "Illegal column {} of argument #{} of function {}, it must be {}",
-            column.getName(), argument_index + 1, function_name, "UInt64 or UInt128 or UUID");
-    }
 }
 
 
@@ -533,52 +465,23 @@ Strings extractConstTagNamesFromArgument(std::string_view function_name, const C
 }
 
 
-const std::type_info & checkArgumentTypeForID(std::string_view function_name, const ColumnsWithTypeAndName & arguments, size_t argument_index, bool allow_nullable)
+void checkArgumentTypeForID(std::string_view function_name, const ColumnsWithTypeAndName & arguments, size_t argument_index, bool allow_nullable)
 {
     if (argument_index >= arguments.size())
         throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} can't be called with {} arguments", function_name, arguments.size());
 
     auto type = removeLowCardinality(arguments[argument_index].type);
-    bool is_nullable = false;
 
     if (allow_nullable)
-    {
-        is_nullable = type->isNullable();
-        type = removeLowCardinalityAndNullable(type);
-    }
+        type = removeNullable(type);
 
-    if (isUInt64(type))
-        return is_nullable ? typeid(std::optional<UInt64>) : typeid(UInt64);
-
-    const auto * fixed_string_type = typeid_cast<const DataTypeFixedString *>(type.get());
-
-    if (isUInt128(type) || isUUID(type) || (fixed_string_type && (fixed_string_type->getN() == 16)))
-        return is_nullable ? typeid(std::optional<UInt128>) : typeid(UInt128);
-
-    throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Argument #{} of function {} has wrong type {}, it must be {}",
-                    argument_index + 1, function_name, type, "UInt64 or UInt128 or UUID");
+    bool id_ok = !type->isNullable() && !isNothing(*type) && type->isComparable()
+        && !isVariant(*type) && !type->hasDynamicSubcolumns();
+    if (!id_ok)
+        throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                        "Argument #{} of function {} has wrong type {}, it must be a comparable non-Nullable type",
+                        argument_index + 1, function_name, arguments[argument_index].type);
 }
-
-
-template <typename IDType>
-VectorWithMemoryTracking<IDType> extractIDFromArgument(std::string_view function_name, const ColumnsWithTypeAndName & arguments, size_t argument_index)
-{
-    chassert(argument_index < arguments.size());
-    const auto & column = *arguments[argument_index].column;
-
-    size_t num_rows = column.size();
-    VectorWithMemoryTracking<IDType> ids;
-    ids.resize(num_rows);
-
-    extractIDFromColumn(function_name, argument_index, column, ids);
-    return ids;
-}
-
-
-template VectorWithMemoryTracking<UInt64> extractIDFromArgument<UInt64>(std::string_view function_name, const ColumnsWithTypeAndName & arguments, size_t argument_index);
-template VectorWithMemoryTracking<std::optional<UInt64>> extractIDFromArgument<std::optional<UInt64>>(std::string_view function_name, const ColumnsWithTypeAndName & arguments, size_t argument_index);
-template VectorWithMemoryTracking<UInt128> extractIDFromArgument<UInt128>(std::string_view function_name, const ColumnsWithTypeAndName & arguments, size_t argument_index);
-template VectorWithMemoryTracking<std::optional<UInt128>> extractIDFromArgument<std::optional<UInt128>>(std::string_view function_name, const ColumnsWithTypeAndName & arguments, size_t argument_index);
 
 
 ColumnPtr makeColumnForGroup(const VectorWithMemoryTracking<Group> & groups)

--- a/src/Functions/TimeSeries/TimeSeriesTagsFunctionHelpers.h
+++ b/src/Functions/TimeSeries/TimeSeriesTagsFunctionHelpers.h
@@ -62,11 +62,10 @@ Strings extractConstTagNamesFromArgument(std::string_view function_name, const C
 Strings extractConstStringsFromArgument(std::string_view function_name, const ColumnsWithTypeAndName & arguments, size_t argument_index);
 
 /// Checks the type of a function argument containing an identifier of time series.
-const std::type_info & checkArgumentTypeForID(std::string_view function_name, const ColumnsWithTypeAndName & arguments, size_t argument_index, bool allow_nullable = false);
-
-/// Extracts an identifier of time series from a function argument.
-template <typename IDType>
-VectorWithMemoryTracking<IDType> extractIDFromArgument(std::string_view function_name, const ColumnsWithTypeAndName & arguments, size_t argument_index);
+/// Identifiers can be of any comparable non-Nullable type.
+/// If `allow_nullable` is set, the argument can also be wrapped in Nullable:
+/// NULL means a row without an identifier (`timeSeriesStoreTags` skips such rows), not a nullable identifier.
+void checkArgumentTypeForID(std::string_view function_name, const ColumnsWithTypeAndName & arguments, size_t argument_index, bool allow_nullable = false);
 
 /// Converts a vector of groups to a column.
 ColumnPtr makeColumnForGroup(const VectorWithMemoryTracking<Group> & groups);

--- a/src/Functions/TimeSeries/timeSeriesIdToGroup.cpp
+++ b/src/Functions/TimeSeries/timeSeriesIdToGroup.cpp
@@ -57,22 +57,9 @@ public:
         TimeSeriesTagsFunctionHelpers::checkArgumentTypeForID(name, arguments, 0);
     }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /* result_type */, size_t input_rows_count) const override
     {
-        const auto & id_type = TimeSeriesTagsFunctionHelpers::checkArgumentTypeForID(name, arguments, 0);
-        if (id_type == typeid(UInt64))
-            return executeForIDType<UInt64>(arguments, result_type, input_rows_count);
-        if (id_type == typeid(UInt128))
-            return executeForIDType<UInt128>(arguments, result_type, input_rows_count);
-        UNREACHABLE();
-    }
-
-    template <typename IDType>
-    ColumnPtr executeForIDType(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /* result_type */, size_t input_rows_count) const
-    {
-        auto ids = TimeSeriesTagsFunctionHelpers::extractIDFromArgument<IDType>(name, arguments, 0);
-
-        auto groups = tags_collector->getGroupByID(ids);
+        auto groups = tags_collector->getGroupByID(arguments[0].column);
         chassert(groups.size() == input_rows_count);
 
         return TimeSeriesTagsFunctionHelpers::makeColumnForGroup(groups);
@@ -91,7 +78,7 @@ See also function [timeSeriesStoreTags()](/sql-reference/functions/time-series-f
     )";
     FunctionDocumentation::Syntax syntax = "timeSeriesIdToGroup(id)";
     FunctionDocumentation::Arguments arguments = {
-        {"id", "Identifier of a time series.", {"UInt64", "UInt128", "UUID", "FixedString(16)"}}
+        {"id", "Identifier of a time series. Must be of the same type which was used when calling [timeSeriesStoreTags()](/sql-reference/functions/time-series-functions#timeSeriesStoreTags).", {"Any"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {
         "Returns a group of tags associated with the identifier `id` of a time series.", {"UInt64"}

--- a/src/Functions/TimeSeries/timeSeriesIdToTags.cpp
+++ b/src/Functions/TimeSeries/timeSeriesIdToTags.cpp
@@ -59,22 +59,9 @@ public:
         TimeSeriesTagsFunctionHelpers::checkArgumentTypeForID(name, arguments, 0);
     }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /* result_type */, size_t input_rows_count) const override
     {
-        const auto & id_type = TimeSeriesTagsFunctionHelpers::checkArgumentTypeForID(name, arguments, 0);
-        if (id_type == typeid(UInt64))
-            return executeForIDType<UInt64>(arguments, result_type, input_rows_count);
-        if (id_type == typeid(UInt128))
-            return executeForIDType<UInt128>(arguments, result_type, input_rows_count);
-        UNREACHABLE();
-    }
-
-    template <typename IDType>
-    ColumnPtr executeForIDType(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /* result_type */, size_t input_rows_count) const
-    {
-        auto ids = TimeSeriesTagsFunctionHelpers::extractIDFromArgument<IDType>(name, arguments, 0);
-
-        auto tags = tags_collector->getTagsByID(ids);
+        auto tags = tags_collector->getTagsByID(arguments[0].column);
         chassert(tags.size() == input_rows_count);
 
         return TimeSeriesTagsFunctionHelpers::makeColumnForTagNamesAndValues(tags);
@@ -93,7 +80,7 @@ See also function [timeSeriesStoreTags()](/sql-reference/functions/time-series-f
     )";
     FunctionDocumentation::Syntax syntax = "timeSeriesIdToTags(id)";
     FunctionDocumentation::Arguments arguments = {
-        {"id", "Identifier of a time series.", {"UInt64", "UInt128", "UUID", "FixedString(16)"}}
+        {"id", "Identifier of a time series. Must be of the same type which was used when calling [timeSeriesStoreTags()](/sql-reference/functions/time-series-functions#timeSeriesStoreTags).", {"Any"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {
         R"(

--- a/src/Functions/TimeSeries/timeSeriesStoreTags.cpp
+++ b/src/Functions/TimeSeries/timeSeriesStoreTags.cpp
@@ -63,48 +63,10 @@ public:
         TimeSeriesTagsFunctionHelpers::checkArgumentTypesForTagNamesAndValues(name, arguments, 1);
     }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
-    {
-        const auto & id_type = TimeSeriesTagsFunctionHelpers::checkArgumentTypeForID(name, arguments, 0, /* allow_nullable = */ true);
-        if (id_type == typeid(UInt64))
-            return executeForIDType<UInt64, false>(arguments, result_type, input_rows_count);
-        if (id_type == typeid(std::optional<UInt64>))
-            return executeForIDType<UInt64, true>(arguments, result_type, input_rows_count);
-        if (id_type == typeid(UInt128))
-            return executeForIDType<UInt128, false>(arguments, result_type, input_rows_count);
-        if (id_type == typeid(std::optional<UInt128>))
-            return executeForIDType<UInt128, true>(arguments, result_type, input_rows_count);
-        UNREACHABLE();
-    }
-
-    template <typename IDType, bool id_is_nullable>
-    ColumnPtr executeForIDType(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /* result_type */, size_t /* input_rows_count */) const
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /* result_type */, size_t /* input_rows_count */) const override
     {
         auto tags_vector = TimeSeriesTagsFunctionHelpers::extractTagNamesAndValuesFromArguments(name, arguments, 1);
-
-        if constexpr (id_is_nullable)
-        {
-            auto ids = TimeSeriesTagsFunctionHelpers::extractIDFromArgument<std::optional<IDType>>(name, arguments, 0);
-            VectorWithMemoryTracking<IDType> valid_ids;
-            valid_ids.reserve(ids.size());
-            for (size_t i = 0; i != ids.size(); ++i)
-            {
-                if (ids[i])
-                {
-                    size_t offset = valid_ids.size();
-                    valid_ids.emplace_back(*ids[i]);
-                    tags_vector[offset] = tags_vector[i];
-                }
-            }
-            tags_vector.resize(valid_ids.size());
-            tags_collector->storeTags(valid_ids, tags_vector);
-        }
-        else
-        {
-            auto ids = TimeSeriesTagsFunctionHelpers::extractIDFromArgument<IDType>(name, arguments, 0);
-            tags_collector->storeTags(ids, tags_vector);
-        }
-
+        tags_collector->storeTags(arguments[0].column, tags_vector);
         return arguments[0].column;
     }
 
@@ -123,7 +85,7 @@ can be used to access this mapping later during the query execution.
     )";
     FunctionDocumentation::Syntax syntax = "timeSeriesStoreTags(id, tags_array, separate_tag_name_1, separate_tag_value_1, ...)";
     FunctionDocumentation::Arguments arguments = {
-        {"id", "Identifier of a time series.", {"UInt64", "UInt128", "UUID", "FixedString(16)"}},
+        {"id", "Identifier of a time series. Can be of any comparable type. Rows with NULL identifiers are skipped.", {"Any"}},
         {"tags_array", "Array of pairs (tag_name, tag_value).", {"Array(Tuple(String, String))", "NULL"}},
         {"separate_tag_name_i", "The name of a tag.", {"String", "FixedString"}},
         {"separate_tag_value_i", "The value of a tag.", {"String", "FixedString", "Nullable(String)"}}\

--- a/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
@@ -1,10 +1,16 @@
 #include <Interpreters/ContextTimeSeriesTagsCollector.h>
 
+#include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
+#include <Columns/ColumnsCommon.h>
 #include <Common/Exception.h>
+#include <Common/FieldVisitorToString.h>
+#include <Common/FieldVisitors.h>
+#include <Common/HashTable/HashTableKeyHolder.h>
 #include <Common/SharedLockGuard.h>
 #include <Common/re2.h>
 #include <Common/quoteString.h>
+#include <Common/typeid_cast.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <IO/Operators.h>
@@ -20,6 +26,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+    extern const int ILLEGAL_COLUMN;
 }
 
 namespace
@@ -38,20 +45,57 @@ namespace
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "No groups exist");
     }
 
-    template <typename IDType>
-    [[noreturn]] void throwIDWasAddedWithOtherTags(const IDType & id, const TagNamesAndValuesPtr & tags, const TagNamesAndValuesPtr & existing_tags)
+    [[noreturn]] void throwIDWasAddedWithOtherTags(const IColumn & id_column, size_t row, const TagNamesAndValuesPtr & tags, const TagNamesAndValuesPtr & existing_tags)
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
                         "Cannot add identifier {} with tags {} because it was added before with tags {}",
-                        toString(id),
+                        applyVisitor(FieldVisitorToString{}, id_column[row]),
                         ContextTimeSeriesTagsCollector::toString(*tags),
                         ContextTimeSeriesTagsCollector::toString(*existing_tags));
     }
 
-    template <typename IDType>
-    [[noreturn]] void throwUnknownID(const IDType & id)
+    [[noreturn]] void throwUnknownID(const IColumn & id_column, size_t row)
     {
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown identifier {}", toString(id));
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown identifier {}", applyVisitor(FieldVisitorToString{}, id_column[row]));
+    }
+
+    /// Represents an identifier column with Const/Sparse/LowCardinality/Nullable wrappers removed.
+    struct UnwrappedIDColumn
+    {
+        ColumnPtr column;                   /// The full column, it keeps `data` and `null_map` alive.
+        const IColumn * data = nullptr;     /// The column containing values of identifiers (not Nullable).
+        const NullMap * null_map = nullptr; /// The null map if the original column was Nullable.
+    };
+
+    UnwrappedIDColumn unwrapIDColumn(const ColumnPtr & id_column)
+    {
+        UnwrappedIDColumn res;
+        res.column = id_column->convertToFullIfWrapped()->convertToFullColumnIfLowCardinality();
+        res.data = res.column.get();
+        res.null_map = nullptr;
+        if (const auto * nullable_column = typeid_cast<const ColumnNullable *>(res.data))
+        {
+            res.null_map = &nullable_column->getNullMapData();
+            res.data = &nullable_column->getNestedColumn();
+        }
+        return res;
+    }
+
+    /// Serializes identifiers from a column to be used as keys in the mapping.
+    /// Identifiers which are NULLs are skipped (their keys are left empty).
+    VectorWithMemoryTracking<std::string_view> serializeIDs(const IColumn & id_data, const NullMap * null_map, Arena & arena)
+    {
+        size_t num_rows = id_data.size();
+        VectorWithMemoryTracking<std::string_view> keys;
+        keys.resize(num_rows);
+        for (size_t i = 0; i != num_rows; ++i)
+        {
+            if (null_map && (*null_map)[i])
+                continue;
+            const char * begin = nullptr;
+            keys[i] = id_data.serializeValueIntoArena(i, arena, begin, /* settings = */ nullptr);
+        }
+        return keys;
     }
 
     template <typename TransformFunc2>
@@ -886,157 +930,124 @@ void ContextTimeSeriesTagsCollector::extractTag(const VectorWithMemoryTracking<G
 }
 
 
-template <typename IDType>
-void ContextTimeSeriesTagsCollector::storeTags(const IDType & id, const TagNamesAndValuesPtr & tags)
+void ContextTimeSeriesTagsCollector::storeTags(const ColumnPtr & id_column, const VectorWithMemoryTracking<TagNamesAndValuesPtr> & tags_vector)
 {
-    {
-        SharedLockGuard lock{mutex};
+    auto unwrapped = unwrapIDColumn(id_column);
+    const NullMap * null_map = unwrapped.null_map;
+    size_t num_rows = unwrapped.data->size();
+    chassert(num_rows == tags_vector.size());
 
-        const auto & groups_by_id = getConstIDMap<IDType>().groups_by_id;
-        auto it = groups_by_id.find(id);
+    size_t num_rows_to_store = num_rows;
+    if (null_map)
+        num_rows_to_store -= countBytesInFilter(*null_map);
+    if (!num_rows_to_store)
+        return;
 
-        if (it != groups_by_id.end())
-        {
-            Group existing_group = it->second;
-            if (*tags != *groups.at(existing_group))
-                throwIDWasAddedWithOtherTags(id, tags, groups.at(existing_group));
-            return;
-        }
-    }
-
-    {
-        std::lock_guard lock{mutex};
-
-        Group group = tryAddGroupUnlocked(tags);
-        auto & groups_by_id = getIDMap<IDType>().groups_by_id;
-        auto it = groups_by_id.try_emplace(id, group).first;
-
-        if (it->second != group)
-            throwIDWasAddedWithOtherTags(id, tags, groups.at(it->second));
-    }
-}
-
-
-template <typename IDType>
-void ContextTimeSeriesTagsCollector::storeTags(const VectorWithMemoryTracking<IDType> & ids, const VectorWithMemoryTracking<TagNamesAndValuesPtr> & tags_vector)
-{
-    chassert(ids.size() == tags_vector.size());
+    Arena temp_arena;
+    auto keys = serializeIDs(*unwrapped.data, null_map, temp_arena);
 
     VectorWithMemoryTracking<Group> found_groups;
-    found_groups.resize(tags_vector.size(), INVALID_GROUP);
+    found_groups.resize(num_rows, INVALID_GROUP);
     size_t num_found_groups = 0;
 
     {
         SharedLockGuard lock{mutex};
-        const auto & groups_by_id = getConstIDMap<IDType>().groups_by_id;
 
-        for (size_t i = 0; i != tags_vector.size(); ++i)
+        for (size_t i = 0; i != num_rows; ++i)
         {
-            const auto & id = ids[i];
-            const auto & tags = tags_vector[i];
-            auto it = groups_by_id.find(id);
-            if (it != groups_by_id.end())
+            const auto & key = keys[i];
+            if (!key.empty())
             {
-                Group existing_group = it->second;
-                if (*tags != *groups.at(existing_group))
-                    throwIDWasAddedWithOtherTags(id, tags, groups.at(existing_group));
-                found_groups[i] = existing_group;
-                ++num_found_groups;
+                if (const auto * it = groups_by_id.find(key))
+                {
+                    Group existing_group = it->getMapped();
+                    if (*tags_vector[i] != *groups.at(existing_group))
+                        throwIDWasAddedWithOtherTags(*unwrapped.data, i, tags_vector[i], groups.at(existing_group));
+                    found_groups[i] = existing_group;
+                    ++num_found_groups;
+                }
             }
         }
     }
 
-    if (num_found_groups == tags_vector.size())
+    if (num_found_groups == num_rows_to_store)
         return;
 
     {
         std::lock_guard lock{mutex};
-        auto & groups_by_id = getIDMap<IDType>().groups_by_id;
 
-        for (size_t i = 0; i != tags_vector.size(); ++i)
+        for (size_t i = 0; i != num_rows; ++i)
         {
+            const auto key = keys[i];
+            if (key.empty())
+                continue;
+
             if (found_groups[i] != INVALID_GROUP)
                 continue;
-            const auto & id = ids[i];
-            const auto & tags = tags_vector[i];
 
-            Group group = tryAddGroupUnlocked(tags);
-            auto it = groups_by_id.try_emplace(id, group).first;
+            Group group = tryAddGroupUnlocked(tags_vector[i]);
 
-            if (it->second != group)
-                throwIDWasAddedWithOtherTags(id, tags, groups.at(it->second));
+            GroupsByID::LookupResult it = nullptr;
+            bool inserted = false;
+            groups_by_id.emplace(ArenaKeyHolder{key, ids_arena}, it, inserted);
 
-            found_groups[i] = group;
-            if (++num_found_groups == tags_vector.size())
-                break;
+            if (inserted)
+                it->getMapped() = group;
+            else if (it->getMapped() != group)
+                throwIDWasAddedWithOtherTags(*unwrapped.data, i, tags_vector[i], groups.at(it->getMapped()));
         }
     }
 }
 
 
-template <typename IDType>
-Group ContextTimeSeriesTagsCollector::getGroupByID(const IDType & id) const
+VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::getGroupByID(const ColumnPtr & id_column) const
 {
-    SharedLockGuard lock{mutex};
-    const auto & groups_by_id = getConstIDMap<IDType>().groups_by_id;
+    auto unwrapped = unwrapIDColumn(id_column);
+    if (unwrapped.null_map)
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Unexpected Nullable column {} of identifiers", id_column->getName());
+    size_t num_rows = unwrapped.data->size();
 
-    auto it = groups_by_id.find(id);
-    if (it == groups_by_id.end())
-        throwUnknownID(id);
+    Arena temp_arena;
+    auto keys = serializeIDs(*unwrapped.data, nullptr, temp_arena);
 
-    return it->second;
-}
-
-
-template <typename IDType>
-VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::getGroupByID(const VectorWithMemoryTracking<IDType> & ids) const
-{
     VectorWithMemoryTracking<Group> res;
-    res.reserve(ids.size());
+    res.reserve(num_rows);
 
     SharedLockGuard lock{mutex};
-    const auto & groups_by_id = getConstIDMap<IDType>().groups_by_id;
 
-    for (const auto & id : ids)
+    for (size_t i = 0; i != num_rows; ++i)
     {
-        auto it = groups_by_id.find(id);
-        if (it == groups_by_id.end())
-            throwUnknownID(id);
-        res.push_back(it->second);
+        const auto * it = groups_by_id.find(keys[i]);
+        if (!it)
+            throwUnknownID(*unwrapped.column, i);
+        res.push_back(it->getMapped());
     }
 
     return res;
 }
 
 
-template <typename IDType>
-TagNamesAndValuesPtr ContextTimeSeriesTagsCollector::getTagsByID(const IDType & id) const
+VectorWithMemoryTracking<TagNamesAndValuesPtr> ContextTimeSeriesTagsCollector::getTagsByID(const ColumnPtr & id_column) const
 {
-    SharedLockGuard lock{mutex};
-    const auto & groups_by_id = getConstIDMap<IDType>().groups_by_id;
+    auto unwrapped = unwrapIDColumn(id_column);
+    if (unwrapped.null_map)
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Unexpected Nullable column {} of identifiers", id_column->getName());
+    size_t num_rows = unwrapped.data->size();
 
-    auto it = groups_by_id.find(id);
-    if (it == groups_by_id.end())
-        throwUnknownID(id);
+    Arena temp_arena;
+    auto keys = serializeIDs(*unwrapped.data, nullptr, temp_arena);
 
-    return groups[it->second];
-}
-
-template <typename IDType>
-VectorWithMemoryTracking<TagNamesAndValuesPtr> ContextTimeSeriesTagsCollector::getTagsByID(const VectorWithMemoryTracking<IDType> & ids) const
-{
     VectorWithMemoryTracking<TagNamesAndValuesPtr> res;
-    res.reserve(ids.size());
+    res.reserve(num_rows);
 
     SharedLockGuard lock{mutex};
-    const auto & groups_by_id = getConstIDMap<IDType>().groups_by_id;
 
-    for (const auto & id : ids)
+    for (size_t i = 0; i != num_rows; ++i)
     {
-        auto it = groups_by_id.find(id);
-        if (it == groups_by_id.end())
-            throwUnknownID(id);
-        res.push_back(groups[it->second]);
+        const auto * it = groups_by_id.find(keys[i]);
+        if (!it)
+            throwUnknownID(*unwrapped.column, i);
+        res.push_back(groups[it->getMapped()]);
     }
 
     return res;
@@ -1287,39 +1298,5 @@ VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::replaceTag(const
     return transformTags(groups_, ReplaceTagTransformFunc{dest_tag, replacement, src_tag, regex});
 }
 
-
-template <typename IDType>
-ContextTimeSeriesTagsCollector::IDMap<IDType> & ContextTimeSeriesTagsCollector::getIDMap()
-{
-    if constexpr (std::is_same_v<IDType, UInt64>)
-    {
-        return uint64_id_map;
-    }
-    else
-    {
-        static_assert(std::is_same_v<IDType, UInt128>);
-        return uint128_id_map;
-    }
-}
-
-template <typename IDType>
-const ContextTimeSeriesTagsCollector::IDMap<IDType> & ContextTimeSeriesTagsCollector::getConstIDMap() const
-{
-    return TSA_SUPPRESS_WARNING_FOR_READ(const_cast<ContextTimeSeriesTagsCollector *>(this)->getIDMap<IDType>());
-}
-
-
-#define TIME_SERIES_ID_TO_TAGS_MAP_INSTANTIATE(IDType) \
-    template void ContextTimeSeriesTagsCollector::storeTags<IDType>(const IDType & id, const TagNamesAndValuesPtr & tags); \
-    template void ContextTimeSeriesTagsCollector::storeTags<IDType>(const VectorWithMemoryTracking<IDType> & ids, const VectorWithMemoryTracking<TagNamesAndValuesPtr> & tags_vector); \
-    template Group ContextTimeSeriesTagsCollector::getGroupByID<IDType>(const IDType & id) const; \
-    template VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::getGroupByID<IDType>(const VectorWithMemoryTracking<IDType> & ids) const; \
-    template ContextTimeSeriesTagsCollector::TagNamesAndValuesPtr ContextTimeSeriesTagsCollector::getTagsByID<IDType>(const IDType & id) const; \
-    template VectorWithMemoryTracking<ContextTimeSeriesTagsCollector::TagNamesAndValuesPtr> ContextTimeSeriesTagsCollector::getTagsByID<IDType>(const VectorWithMemoryTracking<IDType> & ids) const; \
-
-TIME_SERIES_ID_TO_TAGS_MAP_INSTANTIATE(UInt64)
-TIME_SERIES_ID_TO_TAGS_MAP_INSTANTIATE(UInt128)
-
-#undef TIME_SERIES_ID_TO_TAGS_MAP_INSTANTIATE
 
 }

--- a/src/Interpreters/ContextTimeSeriesTagsCollector.h
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <Columns/IColumn_fwd.h>
+#include <Common/Arena.h>
+#include <Common/HashTable/HashMap.h>
 #include <Common/SharedMutex.h>
 #include <Common/VectorWithMemoryTracking.h>
 #include <Core/Types.h>
@@ -10,6 +13,12 @@ namespace DB
 class ColumnString;
 
 /// Mapping between identifiers and tags which are collected in the context of the currently executed query.
+///
+/// Identifiers can be of any type: they are stored in serialized form,
+/// so lookups must use the same type of identifiers which was used to store them.
+/// Identifiers of all types share the same map, so identifiers of different types are treated as the same
+/// identifier if their serialized forms are identical (for example, UInt64 and Int64 with the same bit pattern,
+/// or UUID and FixedString(16) with the same bytes).
 ///
 /// Set of tags are always sorted.
 ///
@@ -46,13 +55,10 @@ public:
     /// A group is just an integer.
     using Group = UInt64;
 
-    /// Adds mapping between a specified identifier and a set of tags to the collector.
-    /// The function assigns a group to that set of tags and returns it.
-    template <typename IDType>
-    void storeTags(const IDType & id, const TagNamesAndValuesPtr & tags);
-
-    template <typename IDType>
-    void storeTags(const VectorWithMemoryTracking<IDType> & ids, const VectorWithMemoryTracking<TagNamesAndValuesPtr> & tags_vector);
+    /// Adds mapping between identifiers from a column and sets of tags to the collector.
+    /// `id_column` is allowed to be Nullable, in that case rows with NULL identifiers are skipped.
+    /// `tags_vector` must contain one element per row of `id_column`.
+    void storeTags(const ColumnPtr & id_column, const VectorWithMemoryTracking<TagNamesAndValuesPtr> & tags_vector);
 
     /// Returns the group assigned to a specified set of tags.
     /// If that set of tags hasn't been added to the collector yet then this functions adds it.
@@ -77,20 +83,15 @@ public:
     VectorWithMemoryTracking<String> extractTag(const VectorWithMemoryTracking<Group> & groups_, const String & tag_to_extract) const;
     void extractTag(const VectorWithMemoryTracking<Group> & groups_, const String & tag_to_extract, ColumnString & out_column) const;
 
-    /// Returns the group assigned to the set of tags which was added to the collector
-    /// with a specified identifier.
-    template <typename IDType>
-    Group getGroupByID(const IDType & id) const;
+    /// Returns the groups assigned to the sets of tags which were added to the collector
+    /// with identifiers from a column. Throws an exception if some identifier is unknown.
+    /// `id_column` must not be Nullable.
+    VectorWithMemoryTracking<Group> getGroupByID(const ColumnPtr & id_column) const;
 
-    template <typename IDType>
-    VectorWithMemoryTracking<Group> getGroupByID(const VectorWithMemoryTracking<IDType> & ids) const;
-
-    /// Returns the set of tags which was added to the collector with a specified identifier.
-    template <typename IDType>
-    TagNamesAndValuesPtr getTagsByID(const IDType & id) const;
-
-    template <typename IDType>
-    VectorWithMemoryTracking<TagNamesAndValuesPtr> getTagsByID(const VectorWithMemoryTracking<IDType> & ids) const;
+    /// Returns the sets of tags which were added to the collector with identifiers from a column.
+    /// Throws an exception if some identifier is unknown.
+    /// `id_column` must not be Nullable.
+    VectorWithMemoryTracking<TagNamesAndValuesPtr> getTagsByID(const ColumnPtr & id_column) const;
 
     /// Removes a tag from a group and returns the result group.
     /// If the result set of tags hasn't been added to the collector yet then this functions adds it and assigns a group to it.
@@ -193,20 +194,10 @@ private:
 
     std::unordered_map<TagsKey, Group, Hash, Equal> groups_for_tags TSA_GUARDED_BY(mutex);
 
-    template <typename IDType>
-    struct IDMap
-    {
-        std::unordered_map<IDType, Group> groups_by_id;
-    };
-
-    template <typename IDType>
-    IDMap<IDType> & getIDMap() TSA_REQUIRES(mutex);
-
-    template <typename IDType>
-    const IDMap<IDType> & getConstIDMap() const TSA_REQUIRES_SHARED(mutex);
-
-    IDMap<UInt64> uint64_id_map TSA_GUARDED_BY(mutex);
-    IDMap<UInt128> uint128_id_map TSA_GUARDED_BY(mutex);
+    /// Identifiers are stored in serialized form, the keys of `groups_by_id` point to memory owned by `ids_arena`.
+    using GroupsByID = HashMapWithSavedHash<std::string_view, Group>;
+    Arena ids_arena TSA_GUARDED_BY(mutex);
+    GroupsByID groups_by_id TSA_GUARDED_BY(mutex);
 };
 
 }

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -964,7 +964,9 @@ CREATE TABLE my_table ENGINE=TimeSeries
 TAGS INNER COLUMNS (id UInt64 DEFAULT sipHash64(metric_name, all_tags))
 ```
 
-The `id` column can be of any comparable non-Nullable type. If no `DEFAULT` expression is given and the `id_generator` setting is not set, ClickHouse will choose the expression automatically based on the `id` type (only if the `id` type is one of `UUID`, `UInt64`, `UInt128`, or `FixedString(16)`). The `id` types declared in the samples and tags inner tables must match.
+The `id` column can be of any comparable non-Nullable type. The `id` types declared in the samples and tags inner tables must match.
+
+If no `DEFAULT` expression is given for the `id` column and the `id_generator` setting is not set, ClickHouse will choose the `DEFAULT` expression automatically based on the `id` type, but only if the `id` type is one of `UUID`, `UInt64`, `UInt128`, `FixedString(16)`, or a tuple of two of those types. For such a tuple the automatically chosen expression calculates a hash of the metric name in the first component and a hash of all the tags in the second component.
 
 The `id_generator` setting offers the same customization without using the `INNER COLUMNS` clause:
 

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -964,7 +964,7 @@ CREATE TABLE my_table ENGINE=TimeSeries
 TAGS INNER COLUMNS (id UInt64 DEFAULT sipHash64(metric_name, all_tags))
 ```
 
-The `id` column type must be one of `UUID`, `UInt64`, `UInt128`, or `FixedString(16)`. If no `DEFAULT` expression is given, ClickHouse will choose it automatically based on the `id` type. The `id` types declared in the samples and tags inner tables must match.
+The `id` column can be of any comparable non-Nullable type. If no `DEFAULT` expression is given and the `id_generator` setting is not set, ClickHouse will choose the expression automatically based on the `id` type (only if the `id` type is one of `UUID`, `UInt64`, `UInt128`, or `FixedString(16)`). The `id` types declared in the samples and tags inner tables must match.
 
 The `id_generator` setting offers the same customization without using the `INNER COLUMNS` clause:
 

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -793,7 +793,7 @@ The _samples_ table must have columns:
 
 | Name | Mandatory? | Default type | Possible types | Description |
 |---|---|---|---|---|
-| `id` | [x] | `UUID` | any | Identifies a combination of a metric names and tags |
+| `id` | [x] | `Tuple(UInt64, UUID)` | any | Identifies a combination of a metric names and tags |
 | `timestamp` | [x] | `DateTime64(3)` | `DateTime64(X)` | A time point |
 | `value` | [x] | `Float64` | `Float32` or `Float64` | A value associated with the `timestamp` |
 
@@ -810,7 +810,7 @@ The _tags_ table must have columns:
 
 | Name | Mandatory? | Default type | Possible types | Description |
 |---|---|---|---|---|
-| `id` | [x] | `UUID` | any (must match the type of `id` in the [samples](#samples-table) table) | An `id` identifies a combination of a metric name and tags. The DEFAULT expression specifies how to calculate such an identifier |
+| `id` | [x] | `Tuple(UInt64, UUID)` | any (must match the type of `id` in the [samples](#samples-table) table) | An `id` identifies a combination of a metric name and tags. The DEFAULT expression specifies how to calculate such an identifier |
 | `metric_name` | [x] | `LowCardinality(String)` | `String` or `LowCardinality(String)` | The name of a metric |
 | `<tag_value_column>` | [ ] | `String` | `String` or `LowCardinality(String)` or `LowCardinality(Nullable(String))` | The value of a specific tag, the tag's name and the name of a corresponding column are specified in the [tags_to_columns](#settings) setting |
 | `tags` | [x] | `Map(LowCardinality(String), String)` | `Map(String, String)` or `Map(LowCardinality(String), String)` or `Map(LowCardinality(String), LowCardinality(String))` | Map of tags excluding the tag `__name__` containing the name of a metric and excluding tags with names enumerated in the [tags_to_columns](#settings) setting |
@@ -856,14 +856,14 @@ CREATE TABLE my_table
 ENGINE = TimeSeries
 SAMPLES INNER COLUMNS
 (
-    `id` UUID,
+    `id` Tuple(UInt64, UUID),
     `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
     `value` Float64 CODEC(Gorilla, ZSTD(1))
 )
 SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp)
 TAGS INNER COLUMNS
 (
-    `id` UUID DEFAULT reinterpretAsUUID(sipHash128(metric_name, all_tags)),
+    `id` Tuple(UInt64, UUID) DEFAULT tuple(sipHash64(metric_name), reinterpretAsUUID(sipHash128(metric_name, all_tags))),
     `metric_name` LowCardinality(String),
     `tags` Map(LowCardinality(String), String),
     `all_tags` Map(String, String) EPHEMERAL,
@@ -891,7 +891,7 @@ and each target table has its own set of columns:
 ```sql
 CREATE TABLE default.`.inner_id.samples.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 (
-    `id` UUID,
+    `id` Tuple(UInt64, UUID),
     `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
     `value` Float64 CODEC(Gorilla(8), ZSTD(1))
 )
@@ -902,7 +902,7 @@ ORDER BY (id, timestamp)
 ```sql
 CREATE TABLE default.`.inner_id.tags.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 (
-    `id` UUID DEFAULT reinterpretAsUUID(sipHash128(metric_name, all_tags)),
+    `id` Tuple(UInt64, UUID) DEFAULT tuple(sipHash64(metric_name), reinterpretAsUUID(sipHash128(metric_name, all_tags))),
     `metric_name` LowCardinality(String),
     `tags` Map(LowCardinality(String), String),
     `all_tags` Map(String, String) EPHEMERAL,

--- a/src/Storages/TimeSeries/TimeSeriesIDGenerator.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesIDGenerator.cpp
@@ -21,7 +21,7 @@ namespace TimeSeriesSetting
 
 namespace ErrorCodes
 {
-    extern const int BAD_TYPE_OF_FIELD;
+    extern const int INCORRECT_QUERY;
 }
 
 namespace
@@ -87,8 +87,11 @@ ASTPtr TimeSeriesIDGenerator::getDefault(
     if (id_which.isUInt128())
         return makeASTFunction("reinterpretAsUInt128", make_hash_function("sipHash128"));
 
-    throw Exception(ErrorCodes::BAD_TYPE_OF_FIELD, "{}: Unexpected type {} of the {} column",
-        table_id.getNameForLogs(), id_type->getName(), TimeSeriesColumnNames::ID);
+    throw Exception(ErrorCodes::INCORRECT_QUERY,
+        "{}: An expression generating identifiers must be specified explicitly for the {} column of type {} - "
+        "either as a DEFAULT expression of that column or in the 'id_generator' setting. "
+        "An expression can be chosen automatically only for types UInt64, UInt128, UUID, and FixedString(16)",
+        table_id.getNameForLogs(), TimeSeriesColumnNames::ID, id_type->getName());
 }
 
 

--- a/src/Storages/TimeSeries/TimeSeriesIDGenerator.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesIDGenerator.cpp
@@ -2,6 +2,7 @@
 
 #include <Common/typeid_cast.h>
 #include <DataTypes/DataTypeFixedString.h>
+#include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/IDataType.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTFunction.h>
@@ -63,34 +64,60 @@ ASTPtr TimeSeriesIDGenerator::getDefault(
         arguments_for_hash_function.push_back(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Tags));
     }
 
-    auto make_hash_function = [&](const String & function_name) -> boost::intrusive_ptr<ASTFunction>
+    auto make_hash_function = [](const String & function_name, ASTs arguments) -> boost::intrusive_ptr<ASTFunction>
     {
         auto function = make_intrusive<ASTFunction>();
         function->name = function_name;
         function->arguments = make_intrusive<ASTExpressionList>();
         function->children.push_back(function->arguments);
-        function->arguments->children = std::move(arguments_for_hash_function);
+        function->arguments->children = std::move(arguments);
         return function;
     };
 
-    WhichDataType id_which(*id_type);
+    /// Makes an expression calculating a hash of `arguments` represented as a value of type `type`,
+    /// returns null if `type` is not one of the plain identifier types supported by the generator.
+    auto make_hash_expression = [&](const IDataType & type, ASTs arguments) -> ASTPtr
+    {
+        WhichDataType which(type);
 
-    if (id_which.isUInt64())
-        return make_hash_function("sipHash64");
+        if (which.isUInt64())
+            return make_hash_function("sipHash64", std::move(arguments));
 
-    if (id_which.isFixedString() && typeid_cast<const DataTypeFixedString &>(*id_type).getN() == 16)
-        return make_hash_function("sipHash128");
+        if (which.isFixedString() && typeid_cast<const DataTypeFixedString &>(type).getN() == 16)
+            return make_hash_function("sipHash128", std::move(arguments));
 
-    if (id_which.isUUID())
-        return makeASTFunction("reinterpretAsUUID", make_hash_function("sipHash128"));
+        if (which.isUUID())
+            return makeASTFunction("reinterpretAsUUID", make_hash_function("sipHash128", std::move(arguments)));
 
-    if (id_which.isUInt128())
-        return makeASTFunction("reinterpretAsUInt128", make_hash_function("sipHash128"));
+        if (which.isUInt128())
+            return makeASTFunction("reinterpretAsUInt128", make_hash_function("sipHash128", std::move(arguments)));
+
+        return nullptr;
+    };
+
+    /// An identifier of a plain type is a hash of the metric name and the tags.
+    if (auto expression = make_hash_expression(*id_type, arguments_for_hash_function))
+        return expression;
+
+    /// For a two-component identifier Tuple(F, S) the first component is a hash of the metric name only,
+    /// and the second component is a hash of the metric name and the tags.
+    if (const auto * tuple_type = typeid_cast<const DataTypeTuple *>(id_type.get()))
+    {
+        const auto & element_types = tuple_type->getElements();
+        if (element_types.size() == 2)
+        {
+            ASTPtr first = make_hash_expression(*element_types[0], ASTs{make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::MetricName)});
+            ASTPtr second = first ? make_hash_expression(*element_types[1], arguments_for_hash_function) : nullptr;
+            if (first && second)
+                return makeASTFunction("tuple", std::move(first), std::move(second));
+        }
+    }
 
     throw Exception(ErrorCodes::INCORRECT_QUERY,
         "{}: An expression generating identifiers must be specified explicitly for the {} column of type {} - "
         "either as a DEFAULT expression of that column or in the 'id_generator' setting. "
-        "An expression can be chosen automatically only for types UInt64, UInt128, UUID, and FixedString(16)",
+        "An expression can be chosen automatically only for types UInt64, UInt128, UUID, FixedString(16), "
+        "and tuples of two of those types",
         table_id.getNameForLogs(), TimeSeriesColumnNames::ID, id_type->getName());
 }
 

--- a/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
+++ b/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
@@ -328,13 +328,13 @@ namespace
                     table_id.getNameForLogs(), scalar_type->getName(), TimeSeriesColumnNames::Value);
         }
         {
-            WhichDataType id_which{*id_type};
-            bool id_ok = id_which.isUInt64()
-                || (id_which.isFixedString() && typeid_cast<const DataTypeFixedString &>(*id_type).getN() == 16)
-                || id_which.isUUID()
-                || id_which.isUInt128();
+            /// Identifiers can be of any comparable type: the id column is used in the sorting keys of the inner tables
+            /// and in JOINs between them.
+            bool id_ok = id_type->isComparable() && !id_type->isNullable() && !id_type->isLowCardinalityNullable()
+                && !isNothing(*id_type) && !isVariant(*id_type) && !id_type->hasDynamicSubcolumns();
             if (!id_ok)
-                throw Exception(ErrorCodes::BAD_TYPE_OF_FIELD, "{}: Unexpected type {} of the {} column",
+                throw Exception(ErrorCodes::BAD_TYPE_OF_FIELD,
+                    "{}: Unexpected type {} of the {} column, it must be a comparable non-Nullable type",
                     table_id.getNameForLogs(), id_type->getName(), TimeSeriesColumnNames::ID);
         }
 

--- a/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
+++ b/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
@@ -312,7 +312,7 @@ namespace
         if (!scalar_type)
             scalar_type = std::make_shared<DataTypeFloat64>();
         if (!id_type)
-            id_type = std::make_shared<DataTypeUUID>();
+            id_type = std::make_shared<DataTypeTuple>(DataTypes{std::make_shared<DataTypeUInt64>(), std::make_shared<DataTypeUUID>()});
 
         /// Validate types.
         {

--- a/tests/integration/test_prometheus_protocols/test_different_table_engines.py
+++ b/tests/integration/test_prometheus_protocols/test_different_table_engines.py
@@ -229,6 +229,32 @@ def test_custom_id_algorithm():
     ) == TSV([["FixedString(16)", ""]])
 
 
+# Checks that a multi-component identifier `Tuple(F, S)` can be used.
+def test_multi_component_id():
+    # Case 1: the identifier expression is specified as a DEFAULT expression of the `id` column.
+    node.query(
+        "CREATE TABLE prometheus ENGINE=TimeSeries "
+        "TAGS INNER COLUMNS (id Tuple(UInt64, UInt64) DEFAULT tuple(xxHash64(metric_name), xxHash64(all_tags)))"
+    )
+    check()
+
+    assert re.search(r"\bid\s+Tuple\(UInt64, UInt64\)", node.query("DESCRIBE timeSeriesTags(prometheus)"))
+    assert re.search(r"\bid\s+Tuple\(UInt64, UInt64\)", node.query("DESCRIBE timeSeriesSamples(prometheus)"))
+
+    drop_prometheus_table()
+
+    # Case 2: the identifier expression is specified in the `id_generator` setting.
+    node.query(
+        "CREATE TABLE prometheus ENGINE=TimeSeries "
+        "SETTINGS id_generator = 'tuple(xxHash64(metric_name), xxHash64(all_tags))' "
+        "TAGS INNER COLUMNS (id Tuple(UInt64, UInt64))"
+    )
+    check()
+
+    assert re.search(r"\bid\s+Tuple\(UInt64, UInt64\)", node.query("DESCRIBE timeSeriesTags(prometheus)"))
+    assert re.search(r"\bid\s+Tuple\(UInt64, UInt64\)", node.query("DESCRIBE timeSeriesSamples(prometheus)"))
+
+
 # Checks that timestamps can be stored with microsecond precision (`DateTime64(6)`).
 def test_microsecond_precision():
     node.query("CREATE TABLE prometheus (time_series Array(Tuple(DateTime64(6), Float64))) ENGINE=TimeSeries")

--- a/tests/queries/0_stateless/04600_timeseries_column_validation.reference
+++ b/tests/queries/0_stateless/04600_timeseries_column_validation.reference
@@ -1,6 +1,6 @@
 ok
 Array(Tuple(UInt32, Float32))
-`id` UUID, `timestamp` UInt32 CODEC(DoubleDelta, ZSTD(1)), `value` Float32 CODEC(Gorilla, ZSTD(1))
+`id` Tuple(UInt64, UUID), `timestamp` UInt32 CODEC(DoubleDelta, ZSTD(1)), `value` Float32 CODEC(Gorilla, ZSTD(1))
 metric_name	String
 tags	Map(String, String)
 time_series	Array(Tuple(DateTime64(3), Float64))

--- a/tests/queries/0_stateless/04648_timeseries_samples_codecs.reference
+++ b/tests/queries/0_stateless/04648_timeseries_samples_codecs.reference
@@ -1,9 +1,9 @@
 default codecs:
-id	UUID	
+id	Tuple(UInt64, UUID)	
 timestamp	DateTime64(3)	CODEC(DoubleDelta, ZSTD(1))
 value	Float64	CODEC(Gorilla(8), ZSTD(1))
 after detach/attach:
-id	UUID	
+id	Tuple(UInt64, UUID)	
 timestamp	DateTime64(3)	CODEC(DoubleDelta, ZSTD(1))
 value	Float64	CODEC(Gorilla(8), ZSTD(1))
 explicit columns keep user codecs:

--- a/tests/queries/0_stateless/04651_timeseries_recover_lost_replica.sh
+++ b/tests/queries/0_stateless/04651_timeseries_recover_lost_replica.sh
@@ -183,7 +183,7 @@ ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.tables WHERE database = '${D
 # and re-create leaves the inner tables empty, so a regression that made the eager inner drop a
 # silent no-op would leave these rows in place.
 SAMPLES_TABLE=$(${CLICKHOUSE_CLIENT} -q "SELECT name FROM system.tables WHERE database = '${DB}' AND name LIKE '.inner_id.samples.%'")
-${CLICKHOUSE_CLIENT} -q "INSERT INTO ${DB}.\`${SAMPLES_TABLE}\` SELECT generateUUIDv4(), now64(3), number FROM numbers(50)"
+${CLICKHOUSE_CLIENT} -q "INSERT INTO ${DB}.\`${SAMPLES_TABLE}\` (timestamp, value) SELECT now64(3), number FROM numbers(50)"
 ${CLICKHOUSE_CLIENT} -q "SELECT sum(total_rows) FROM system.tables WHERE database = '${DB}' AND name LIKE '.inner_id.%'"
 
 RECOVERIES_BEFORE=$(count_recovery_completions)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow multi-component identifiers in TimeSeries tables.

For example, the following command will create a table with two-component identifier:
```
CREATE TABLE mytable ENGINE=TimeSeries 
TAGS INNER COLUMNS (id Tuple(UInt64, UInt64) DEFAULT tuple(xxHash64(metric_name), xxHash64(all_tags)))
```


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.694` (included in `26.8` and later)
<!-- ch-version-info:end -->