### PR TITLE
Narrow docs code ownership scope

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,12 @@
 /docs/ @ClickHouse/docs
+
+# Reference documentation migrated from the legacy core repository
+/docs/reference/data-types/
+/docs/reference/engines/
+/docs/reference/formats/
+/docs/reference/functions/
+/docs/reference/interfaces/
+/docs/reference/operators/
+/docs/reference/settings/
+/docs/reference/statements/
+/docs/reference/system-tables/


### PR DESCRIPTION
Narrow automatic `@ClickHouse/docs` review requests by excluding the code-oriented `docs/reference/` subdirectories migrated from the legacy core repository. Narrative documentation, `docs/reference/navigation.json`, and future reference sections remain owned by the docs team.

GitHub's rendered ownership indicators confirm that an excluded function reference has no code owner while `docs/README.md` remains owned by `@ClickHouse/docs`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Exclude migrated code-reference directories from automatic docs-team review requests.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.687` (included in `26.8` and later)
<!-- ch-version-info:end -->