### PR TITLE
Fix a short read of the product quantization codebook

### DIFF
--- a/src/DataTypes/Serializations/ISerialization.cpp
+++ b/src/DataTypes/Serializations/ISerialization.cpp
@@ -732,6 +732,18 @@ bool ISerialization::isMetadataStream(const DB::ISerialization::SubstreamPath & 
         || path[path.size() - 1].type == SubstreamType::MapBucketsInfo;
 }
 
+bool ISerialization::isSingleValuePerPartStream(const DB::ISerialization::SubstreamPath & path)
+{
+    /// The whole path is scanned rather than only its last element, because the codebook substream is terminal
+    /// only when the column itself is enumerated; when the subcolumn is read on its own, the path of its stream
+    /// is `ProductQuantizationCodebook` followed by the `Regular` substream of the underlying `FixedString`.
+    for (const auto & elem : path)
+        if (elem.type == SubstreamType::ProductQuantizationCodebook)
+            return true;
+
+    return false;
+}
+
 bool ISerialization::hasPrefix(const DB::ISerialization::SubstreamPath & path, bool use_specialized_prefixes_and_suffixes_substreams)
 {
     if (path.empty())

--- a/src/DataTypes/Serializations/ISerialization.h
+++ b/src/DataTypes/Serializations/ISerialization.h
@@ -715,6 +715,11 @@ public:
     static bool isLowCardinalityDictionarySubcolumn(const SubstreamPath & path);
     static bool isMetadataStream(const SubstreamPath & path);
 
+    /// Returns true if the stream holds a single value for the whole part, which every granule reads
+    /// (the product quantization codebook). Such a value is written once, after the data of all granules,
+    /// so the marks do not delimit it and it has to be read as a whole file.
+    static bool isSingleValuePerPartStream(const SubstreamPath & path);
+
     /// Returns true if stream with specified path corresponds to Variant subcolumn.
     static bool isVariantSubcolumn(const SubstreamPath & path);
 

--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -45,6 +45,8 @@ struct MergeTreeReaderSettings
     bool is_low_cardinality_dictionary = false;
     /// True if we read stream that contains some metadata and will be read as a whole at once.
     bool is_metadata_file = false;
+    /// True if we read a stream that holds a single value for the whole part, which every granule reads.
+    bool is_single_value_per_part = false;
     /// Deleted mask is applied to all reads except internal select from mutate some part columns.
     bool apply_deleted_mask = true;
     /// Put reading task in a common I/O pool, return Async state on prepare()

--- a/src/Storages/MergeTree/MergeTreeReaderStream.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderStream.cpp
@@ -326,6 +326,13 @@ size_t MergeTreeReaderStreamSingleColumn::getRightOffset(size_t right_mark)
     if (settings.is_metadata_file)
         return file_size;
 
+    /// Special case for a stream that holds a single value for the whole part (the product quantization codebook).
+    /// The value is written after the data of all granules, so every granule's mark points at its start and no mark
+    /// delimits its end. In particular, when the value spans several compressed blocks, the final mark points into
+    /// the middle of it, and bounding the read by that mark truncates the value (`CANNOT_READ_ALL_DATA`).
+    if (settings.is_single_value_per_part)
+        return file_size;
+
     /// This is a good scenario. The compressed block is finished within the right mark,
     /// and previous mark was different.
     if (marks_getter->getMark(right_mark, 0).offset_in_decompressed_block == 0

--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -333,6 +333,7 @@ MergeTreeReaderWide::FileStreams::iterator MergeTreeReaderWide::addStream(const 
     auto stream_settings = settings;
     stream_settings.is_low_cardinality_dictionary = ISerialization::isLowCardinalityDictionarySubcolumn(substream_path);
     stream_settings.is_metadata_file = ISerialization::isMetadataStream(substream_path);
+    stream_settings.is_single_value_per_part = ISerialization::isSingleValuePerPartStream(substream_path);
 
     auto create_stream = [&]<typename Stream>()
     {

--- a/tests/queries/0_stateless/04661_vector_search_quantize_pq_codebook_mark_range.reference
+++ b/tests/queries/0_stateless/04661_vector_search_quantize_pq_codebook_mark_range.reference
@@ -1,0 +1,4 @@
+part_type	Wide
+partial_range	3000	3000
+full_scan	10000	10000
+same_codebook	1	1	1

--- a/tests/queries/0_stateless/04661_vector_search_quantize_pq_codebook_mark_range.sh
+++ b/tests/queries/0_stateless/04661_vector_search_quantize_pq_codebook_mark_range.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Tags: no-distributed-cache
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# The codebook of the `product` quantization method is a single value for the whole part, written after the data of
+# all granules, so every granule's mark points at its start and no mark delimits its end. With an adaptive write
+# buffer the 65536-byte codebook spans several compressed blocks and the part's final mark points into the middle of
+# it, so a read whose mark range ends before the final mark used to be bounded by that mark and read the codebook
+# short: `Cannot read all data of type FixedString. Bytes read:49152. String size:65536`.
+#
+# The bound is only enforced by read buffers that implement `setReadUntilPosition` (object storage, encrypted or
+# cached disks) - a plain local disk ignores it - hence the `local_blob_storage` disk. The compression settings are
+# pinned because the codebook must span more than one compressed block, and the granularity settings because the
+# read must stop before the part's final mark.
+
+$CLICKHOUSE_CLIENT --allow_experimental_codecs 1 -m -q "
+DROP TABLE IF EXISTS quantize_pq_codebook_mark_range;
+
+CREATE TABLE quantize_pq_codebook_mark_range
+(
+    id UInt32,
+    vec Array(Float32) CODEC(Quantized('product', 64, 8, 8))
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 1024, index_granularity_bytes = '10Mi', min_bytes_for_wide_part = 0,
+    min_compress_block_size = 65536, max_compress_block_size = 1048576,
+    min_columns_to_activate_adaptive_write_buffer = 1, adaptive_write_buffer_initial_size = 16384,
+    disk = disk(type = 'local_blob_storage', path = '${CLICKHOUSE_TEST_UNIQUE_NAME}/');
+
+-- ~10 granules in a single wide part.
+INSERT INTO quantize_pq_codebook_mark_range
+SELECT number, arrayMap(j -> toFloat32(sipHash64(number, j) % 2000 / 1000.0 - 1.0), range(64))
+FROM numbers(10000);
+
+SELECT 'part_type', part_type FROM system.parts
+WHERE database = currentDatabase() AND table = 'quantize_pq_codebook_mark_range' AND active;
+
+-- A read of the first three granules only: its mark range ends long before the part's final mark.
+SELECT 'partial_range', countIf(length(vec.product_quantization_codebook) = 65536), count()
+FROM quantize_pq_codebook_mark_range WHERE id < 3000 SETTINGS max_block_size = 1024;
+
+SELECT 'full_scan', countIf(length(vec.product_quantization_codebook) = 65536), count()
+FROM quantize_pq_codebook_mark_range SETTINGS max_block_size = 1024;
+
+-- Every granule must see the very same codebook, whatever the mark range of the read is. Hashing it keeps the
+-- broadcast blob from being materialized: the subcolumn is a \`ColumnConst\`, so the hash is computed once per block.
+SELECT 'same_codebook',
+    (SELECT uniqExact(cityHash64(vec.product_quantization_codebook)) FROM quantize_pq_codebook_mark_range WHERE id < 3000),
+    (SELECT uniqExact(cityHash64(vec.product_quantization_codebook)) FROM quantize_pq_codebook_mark_range),
+    (SELECT any(cityHash64(vec.product_quantization_codebook)) FROM quantize_pq_codebook_mark_range WHERE id < 3000)
+        = (SELECT any(cityHash64(vec.product_quantization_codebook)) FROM quantize_pq_codebook_mark_range);
+
+DROP TABLE quantize_pq_codebook_mark_range SYNC;
+"


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/112804
Related: https://github.com/ClickHouse/ClickHouse/pull/110926

The `product` method of the `Quantized` codec stores one codebook value for the whole part. It is written once, in `serializeBinaryBulkStateSuffix`, after the data of all granules, so every granule's mark in the `product_quantization_codebook` stream points at its start and no mark delimits its end.

`MergeTreeReaderStreamSingleColumn::getRightOffset` assumed the opposite. For a read whose mark range ends before the end of the part it bounds the read at the offset of the first following mark with a greater compressed offset. For the codebook stream that mark is the part's final mark, which is written right after the suffix - and with an adaptive write buffer (starting at `adaptive_write_buffer_initial_size`, 16 KiB, and doubling) the codebook spans several compressed blocks, so the final mark points into the middle of it. For a 64 KiB codebook the marks look like this:

```
mark 0..9  (0, 0)          <- the data granules
mark 10    (49202, 16384)  <- the final mark, inside the codebook
```

so the read was cut at compressed offset 49202 and threw:

```
Cannot read all data of type FixedString. Bytes read:49152. String size:65536:
(while reading column vec.product_quantization_codebook)
```

The bound is only enforced by read buffers that implement `setReadUntilPosition` - object storage, encrypted or cached disks - which is why this only showed up on the s3 CI runs, and only with a write-side `min_columns_to_activate_adaptive_write_buffer` small enough to activate the adaptive buffer. That matches the two culprit settings the randomized-settings minimizer found in the issue.

The codebook stream holds exactly one value for the whole part, so it must be read as a whole file, like the metadata streams of `Dynamic` and `JSON`. This also repairs reads of parts that are already written.

The failing test is a plain `SELECT` of the subcolumn, so this was not specific to it: any read of the codebook subcolumn whose mark range stops before the part's final mark could hit it. The new test reproduces that deterministically with a `WHERE` on the primary key, without the range-splitting injection - on a `local_blob_storage` disk, because a plain local `ReadBufferFromFileDescriptor` ignores `setReadUntilPosition` and hides the bug.

CI report from the issue: [Stateless tests (amd_tsan, s3 storage, parallel, 3/3)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111093&sha=d9fd5a7700ea97bde7122ce954ca2dfe07e7ee6a&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%203%2F3%29) (https://github.com/ClickHouse/ClickHouse/pull/111093)

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `Cannot read all data of type FixedString` when reading the `product_quantization_codebook` subcolumn of a column with a `Quantized('product', ...)` codec. The per-part codebook is written after the data of all granules, so it is not delimited by marks, and a read whose mark range ended before the part's final mark could read it short.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.572` (included in `26.8` and later)
<!-- ch-version-info:end -->