### PR TITLE
Deflake 04648_geohashes_in_box_cancellation

### DIFF
--- a/src/Functions/geohashesInBox.cpp
+++ b/src/Functions/geohashesInBox.cpp
@@ -81,7 +81,12 @@ public:
         size_t input_rows_count) const
     {
         static constexpr size_t max_array_size = 10'000'000;
-        static constexpr UInt64 items_between_cancellation_checks = 1'000'000;
+        /// The span between two checkpoints is the work a cancelled query still has to finish, so it
+        /// is what the caller waits for. 100k items are ~1.2 MB of geohashes: tens of milliseconds
+        /// of work against a check that costs a clock read and an uncontended lock. A million items,
+        /// the first choice here, was over three seconds of uninterruptible work on a loaded
+        /// sanitizer build, which is not what "cancelled promptly" should mean.
+        static constexpr UInt64 items_between_cancellation_checks = 100'000;
 
         const auto * lon_min_const = typeid_cast<const ColumnConst *>(lon_min_column);
         const auto * lat_min_const = typeid_cast<const ColumnConst *>(lat_min_column);

--- a/tests/queries/0_stateless/04648_geohashes_in_box_cancellation.reference
+++ b/tests/queries/0_stateless/04648_geohashes_in_box_cancellation.reference
@@ -5,8 +5,7 @@ float64 break stopped promptly
 TIMEOUT_EXCEEDED
 float32 throw stopped promptly
 expanding kill returned promptly
-degenerate kill returned promptly
-nan kill returned promptly
 ['sx1q','sx1r','sx32','sx1w','sx1x','sx38']
 2048000
+2000000	0
 2000000	0

--- a/tests/queries/0_stateless/04648_geohashes_in_box_cancellation.sh
+++ b/tests/queries/0_stateless/04648_geohashes_in_box_cancellation.sh
@@ -8,27 +8,24 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# Every case below expands one box over a whole block, and such a block runs for ten seconds or more
+# against a one second deadline, so the cancellation lands inside the row loop however the load moves
+# the absolute numbers. Rows that expand to nothing are the opposite shape: they cost a few hundred
+# milliseconds per gigabyte of block, so a block of them can only outlast a deadline by outgrowing
+# the memory the job has, and a deadline that fits in memory lands before or after the row loop as
+# often as inside it. That is what made the two `KILL` cases on reversed and NaN bounds flaky, so
+# their promptness is no longer asserted; those boxes are kept in the liveness checks at the end.
+#
 # `max_block_size` and `max_threads` are pinned statement-level because the runner randomizes both and
 # the effect size is a function of rows-per-block: at one row per block the limit is honoured even
 # unfixed. `max_execution_time` and `timeout_overflow_mode` are the oracle and are not randomized.
 SETTINGS="max_block_size = 60000, max_threads = 1"
 BOX="materialize(0.0), materialize(0.0), 0.0000106, 0.0000053, toUInt8(12)"
 BOX_F32="materialize(toFloat32(0.0)), materialize(toFloat32(0.0)), toFloat32(0.0000106), toFloat32(0.0000053), toUInt8(12)"
-
-# A degenerate box yields documented empty arrays, so those rows are cheap and fit in one block. 60M
-# is the smallest count whose ratio below still separates from the unfixed one: cancelling costs a
-# fixed ~100ms while the uncancelled cost is proportional to the block, so a smaller block only
-# shrinks the denominator. Loaded, 60M measures 0.121 against 0.660 unfixed, where 10M is 0.556
-# against 0.550. It also holds peak memory to 1.25GiB rather than 4.26GiB, which would be 91% of the
-# limit set below. The precision is materialized rather than a coordinate to keep the block one byte
-# per row, and two fixed limits from `limits.yaml` are lifted: `max_rows_to_read` (20M) and
-# `max_result_bytes` (1G).
-ROWS_DEGENERATE=60000000
 BOX_DEGENERATE="1.0, 1.0, 0.0, 0.0, materialize(toUInt8(12))"
 BOX_NAN="nan, 1.0, 0.0, 0.0, materialize(toUInt8(12))"
-SETTINGS_DEGENERATE="max_block_size = $ROWS_DEGENERATE, max_threads = 1, max_memory_usage = 5000000000, max_rows_to_read = 0, max_result_bytes = 0"
 
-# 4x the 1s limit absorbs clock granularity, a busy runner and the row in flight when the check
+# 4x the 1s limit absorbs clock granularity, a busy runner and the work in flight when the check
 # fires; the unfixed path lands far above that.
 check_duration() {
     local query_id="$1" label="$2"
@@ -67,23 +64,14 @@ run_case break "$BOX" "float64"
 # carrying the check is shared, so this pins that both are covered.
 run_case throw "$BOX_F32" "float32"
 
-# `KILL` takes the same in-thread path (`checkTimeLimit` consults `is_killed`) and is the half the report
-# showed. The oracle is how long `KILL ... SYNC` blocks, so no time limit is involved. Each bound is
-# per case because the unfixed cost differs by almost an order of magnitude between them.
+# `KILL` takes the same in-thread path (`checkTimeLimit` consults `is_killed`) and is the half the
+# report showed. The oracle is how long `KILL ... SYNC` blocks, so no time limit is involved.
 run_kill_case() {
     # $1 = label, $2 = argument expression, $3 = rows, $4 = settings, $5 = readiness predicate,
-    # $6 = bound in ms for how long `KILL ... SYNC` may block, or the word 'calibrated' to compare that
-    #      same blocking time against the block run to completion rather than against a fixed bound
+    # $6 = bound in ms for how long `KILL ... SYNC` may block
     local label="$1" box="$2" rows="$3" settings="$4" ready="$5" bound="$6"
     local query_id="04648_kill_${label}_${CLICKHOUSE_DATABASE}"
     local err="${CLICKHOUSE_TMP}/04648_${label}_${CLICKHOUSE_DATABASE}_err.txt"
-
-    # The calibration run is the identical block with no limit and no kill, kept in the same run as
-    # the killed query so that whatever the load does to one it does to the other.
-    if [ "$bound" = "calibrated" ]; then
-        ${CLICKHOUSE_CLIENT} --query_id "${query_id}_full" \
-            -q "SELECT geohashesInBox($box) FROM numbers($rows) FORMAT Null SETTINGS $settings" > /dev/null
-    fi
 
     ${CLICKHOUSE_CLIENT} --query_id "$query_id" \
         -q "SELECT geohashesInBox($box) FROM numbers($rows) FORMAT Null SETTINGS $settings" > /dev/null 2>"$err" &
@@ -114,49 +102,17 @@ run_kill_case() {
     rm -f "$err"
 
     ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS query_log"
-
-    if [ "$bound" = "calibrated" ]; then
-        # Halving is the threshold: a checkpoint reached inside the loop cuts the work short, while a
-        # cancel seen only at the block boundary leaves the same work to do either way. Both
-        # durations are reported on failure so a regression is diagnosable from the diff alone.
-        # The numerator is how long `KILL ... SYNC` blocked, not how long the killed query lived: the
-        # readiness poll runs before the kill is issued, so its cost is outside this measurement.
-        # `QUERY_WAS_CANCELLED` is asserted first, because a kill that arrived after the block had
-        # already finished leaves nothing for the ratio to measure and would otherwise pass.
-        ${CLICKHOUSE_CLIENT} -q "
-            WITH
-                (SELECT max(query_duration_ms) FROM system.query_log
-                 WHERE query_id = '${query_id}_full' AND current_database = currentDatabase() AND type != 'QueryStart') AS full_ms,
-                (SELECT max(query_duration_ms) FROM system.query_log
-                 WHERE query_id = '${query_id}_sync' AND current_database = currentDatabase() AND type != 'QueryStart') AS sync_ms,
-                (SELECT max(exception_code) FROM system.query_log
-                 WHERE query_id = '$query_id' AND current_database = currentDatabase() AND type != 'QueryStart') AS killed_code
-            SELECT multiIf(killed_code != 394,
-                           '$label kill: query ended with code ' || toString(killed_code) || ' instead of being cancelled',
-                      sync_ms * 2 < full_ms,
-                           '$label kill returned promptly',
-                           '$label kill blocked ' || toString(sync_ms) || 'ms of a ' || toString(full_ms) || 'ms block')"
-    else
-        ${CLICKHOUSE_CLIENT} -q "
-            SELECT if(max(query_duration_ms) < $bound, '$label kill returned promptly', '$label kill blocked ' || toString(max(query_duration_ms)) || 'ms')
-            FROM system.query_log
-            WHERE query_id = '${query_id}_sync' AND current_database = currentDatabase() AND type != 'QueryStart'"
-    fi
+    ${CLICKHOUSE_CLIENT} -q "
+        SELECT if(max(query_duration_ms) < $bound, '$label kill returned promptly', '$label kill blocked ' || toString(max(query_duration_ms)) || 'ms')
+        FROM system.query_log
+        WHERE query_id = '${query_id}_sync' AND current_database = currentDatabase() AND type != 'QueryStart'"
 }
 
 # Readiness waits for the query to have been running rather than merely being visible: `ProcessList`
 # makes it visible before the executor is attached, and `addPipelineExecutor` raises a pending
-# cancellation itself, so a kill winning that race would pass even unfixed. 4000ms as above.
+# cancellation itself, so a kill winning that race would pass even unfixed. One second of the block's
+# tens leaves the rest of it as the window in which the kill has to land. 4000ms as above.
 run_kill_case "expanding" "$BOX" 60000 "$SETTINGS" "max(elapsed) > 1" 4000
-
-# Zero-item rows would never fire a checkpoint throttled only on accumulated items. Readiness waits
-# for the source to be drained so the kill lands inside the row loop. These blocks are an order of
-# magnitude cheaper than the expanding one, so the ranges a fixed bound would have to separate are
-# only about 1.5x apart and overlap on a loaded runner; a ratio against their own block does not.
-run_kill_case "degenerate" "$BOX_DEGENERATE" "$ROWS_DEGENERATE" "$SETTINGS_DEGENERATE" "max(read_rows) >= $ROWS_DEGENERATE" calibrated
-
-# NaN bounds reach the same zero-item early return as reversed bounds.
-run_kill_case "nan" "$BOX_NAN" "$ROWS_DEGENERATE" "$SETTINGS_DEGENERATE" "max(read_rows) >= $ROWS_DEGENERATE" calibrated
 
 # Liveness control: with no time limit the function must still return the documented result, so a
 # "fix" that simply always threw would fail here rather than pass.
@@ -166,6 +122,7 @@ ${CLICKHOUSE_CLIENT} -q "SELECT geohashesInBox(24.48, 40.56, 24.785, 40.81, 4)"
 # no deadline set and must return cleanly.
 ${CLICKHOUSE_CLIENT} -q "SELECT sum(length(geohashesInBox($BOX))) FROM numbers(2000) SETTINGS max_block_size = 2000, max_threads = 1"
 
-# Degenerate rows cross the same checkpoint once every row counts as a work unit, and must still
-# return their documented empty arrays.
+# Reversed and NaN bounds return no items at all, so they cross the same checkpoint only because a
+# row counts as a work unit on its own, and they must still return their documented empty arrays.
 ${CLICKHOUSE_CLIENT} -q "SELECT count(), sum(length(geohashesInBox($BOX_DEGENERATE))) FROM numbers(2000000) SETTINGS max_block_size = 2000000, max_threads = 1"
+${CLICKHOUSE_CLIENT} -q "SELECT count(), sum(length(geohashesInBox($BOX_NAN))) FROM numbers(2000000) SETTINGS max_block_size = 2000000, max_threads = 1"


### PR DESCRIPTION
`04648_geohashes_in_box_cancellation` has failed 11 times on master and in pull requests over the last four days, in three distinct ways. All of them come from its two `KILL` cases on reversed and NaN bounds, plus the fixed millisecond bound the other cases use.

Rows whose box expands to nothing cost about 11ns each, so the row loop a kill has to land in lasts 650ms for the 60M-row block those cases use on a debug build and around 200ms on a release one — and the block cannot be made longer without being made bigger, as it already holds 1.25GiB. Against that window the readiness poll runs `curl` and then `clickhouse-client` per iteration, and one fork stall on a loaded runner steps over it: in the report below the killed query lived from 18.394 to 19.005 while the poll slept between its first iteration at 18.233 and its second at 20.251, so `KILL` was issued 32 seconds after the query had finished (`nan kill: query never reached the row loop`, then `ended with code 0 instead of being cancelled`, the dominant mode with 5 of the 11).

Their oracle was unsound as well. It compared how long `KILL ... SYNC` blocked against the same block run to completion, but that numerator also covers tearing 1.25GiB down, which on a fast release build is most of it — hence `nan kill ran 1190ms of a 1436ms block` on a build that has the fix.

So the assertion is removed rather than retuned: an interruptible zero-item row loop is not observable from a stateless test at a block size that fits in a CI job. Those boxes stay in the liveness checks, where they exercise counting a row as a work unit at all. The cases that expand a box keep their assertions — such a block runs for ten seconds or more against a one second deadline, so the cancellation lands inside the row loop whatever the load does. Verified against a pre-fix binary: they still fail, by 11x (`ran 11423ms past a 1000ms limit`) rather than by the 1.2x the zero-item cases had.

The remaining bound was the third failure mode, `float64 throw ran 4419ms past a 1000ms limit` on a loaded sanitizer build: with a cancellation checkpoint every million items, over three seconds of that was work already started and not yet interruptible. The checkpoint now runs every 100k items — ~1.2MB of geohashes against a clock read — which is what "cancelled promptly" should mean and keeps the measurement an order of magnitude inside the bound.

The test also drops from 47s to 6s and from 1.25GiB peak to a few tens of MB.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8aad759007771032aa94d7f4eee3e18103dd63c3&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29

Related: https://github.com/ClickHouse/ClickHouse/pull/112273

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)