### PR TITLE
CI: validate that the two LLVM coverage measurements are comparable

### DIFF
--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -629,7 +629,20 @@ class ArtifactConfigs:
     llvm_coverage_info_file = Artifact.Config(
         name=ArtifactNames.LLVM_COVERAGE_INFO_FILE,
         type=Artifact.Type.S3,
-        path=f"{TEMP_DIR}/llvm_coverage.info",
+        # llvm_coverage.meta.json rides along on the same artifact so that the
+        # completeness of a published measurement is fetchable next to it, without
+        # introducing a new artifact name (which would have to be registered in
+        # every workflow that uses it).
+        path=[
+            f"{TEMP_DIR}/llvm_coverage.info",
+            f"{TEMP_DIR}/llvm_coverage.meta.json",
+        ],
+        # The aggregate merge is all-or-nothing: on a corrupt input it produces no
+        # .info at all, and the job then reports SKIPPED rather than comparing a
+        # partial measurement. The runner re-checks artifact paths after the job
+        # exits, so without this it would override that verdict with ERROR. The
+        # consumer treats a missing .info as "measurement incomplete".
+        optional=True,
     )
     clickhouse_debians = Artifact.Config(
         name="*",

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1758,6 +1758,7 @@ class JobConfigs:
                 "./ci/jobs/llvm_coverage_job.py",
                 "./ci/jobs/scripts/merge_llvm_coverage.sh",
                 "./ci/jobs/scripts/generate_diff_coverage_report.sh",
+                "./ci/jobs/scripts/llvm_coverage_completeness.py",
                 "./ci/jobs/scripts/print_uncovered_code.py",
                 "./ci/jobs/scripts/dedup_lcov_instantiations.py",
                 "./ci/jobs/scripts/job_hooks/llvm_coverage_hook.py",

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -1403,6 +1403,53 @@ def main():
         )
         profraw_files = [f.strip() for f in profraw_files if f.strip()]
 
+        # Name the profile after this job's own coverage artifact, so the
+        # aggregation can tell which shards arrived from the filenames alone.
+        # JOB_CONFIG has been through dump()/get() by the time a job body runs, so
+        # it is a plain dict here and attribute access on it raises AttributeError.
+        _job_config = info.job_config
+        assert (
+            _job_config is not None
+        ), "JOB_CONFIG is not set, cannot derive the coverage profile name"
+        _provides = _job_config["provides"]
+        assert (
+            isinstance(_provides, list)
+            and len(_provides) == 1
+            and isinstance(_provides[0], str)
+            and _provides[0]
+        ), f"expected exactly one provided artifact name, got {_provides!r}"
+        merged_file = f"./{_provides[0]}.profdata"
+
+        # Drop any pre-existing profile at our target name before deciding whether
+        # to merge at all. llvm-profdata truncates its -o target in place instead
+        # of replacing it, and the completion gate below can skip the merge
+        # entirely, so a stale valid profile would otherwise be published as this
+        # shard's contribution. On CI the pre-run `git clean` already removes it;
+        # this covers a bare local run, where that clean is skipped.
+        if os.path.exists(merged_file):
+            print(f"Removing pre-existing {merged_file}")
+            os.unlink(merged_file)
+
+        # A shard that did not execute what it planned must publish no profile: a
+        # short-but-valid profile is indistinguishable from a complete one
+        # downstream and silently drags the coverage total down. The fact comes
+        # from the runner's own marker, not from its exit code (exit 1 also
+        # follows a complete run with failing tests) and not from
+        # `success_finish` (also true for "no tests were run", and for a run that
+        # lost a worker).
+        # `test_result` is None when the test stage did not run at all, which is
+        # itself "did not execute what we planned".
+        _coverage_run_complete = bool(
+            test_result is not None
+            and test_result.ext.get("coverage_run_complete", False)
+        )
+        if not _coverage_run_complete:
+            print(
+                "The test runner did not report completing every selected test, so this "
+                "shard's coverage is incomplete; publishing no profile."
+            )
+            profraw_files = []
+
         if profraw_files:
             print(f"Found {len(profraw_files)} .profraw files:")
             for f in profraw_files:
@@ -1412,6 +1459,22 @@ def main():
                 except OSError:
                     continue
 
+            # A zero-length .profraw is silently ignored by llvm-profdata at every
+            # --failure-mode, so it would drop one process's coverage with no
+            # signal at all. Treat it as an incomplete shard.
+            empty_files = [
+                f
+                for f in profraw_files
+                if os.path.exists(f) and os.path.getsize(f) == 0
+            ]
+            if empty_files:
+                print(
+                    f"ERROR: {len(empty_files)} .profraw files are empty, so this shard's "
+                    f"coverage is incomplete; publishing no profile: {', '.join(empty_files)}"
+                )
+                profraw_files = []
+
+        if profraw_files:
             # Auto-detect available LLVM profdata tool
             llvm_profdata = None
             for ver in ["21", "20", "18", "19", "17", "16", ""]:
@@ -1425,34 +1488,22 @@ def main():
             else:
                 print(f"Using {llvm_profdata} to merge coverage files")
 
-                # Merge all profraw files to current directory
-                joined_test_options = "_".join(test_options) if test_options else "all"
-                joined_test_options = joined_test_options.replace(" ", "_").replace("/", "_")
-                merged_file = f"./ft-{joined_test_options}.profdata"
-                merge_cmd = f"{llvm_profdata} merge -sparse -failure-mode=warn {' '.join(profraw_files)} -o {merged_file} 2>&1"
+                # --failure-mode=any makes the merge all-or-nothing: on any
+                # invalid input it exits non-zero and writes no file, so the shard
+                # is simply absent instead of contributing a silently short
+                # profile. The clean path is byte-identical to =warn.
+                merge_cmd = f"{llvm_profdata} merge -sparse -failure-mode=any {' '.join(profraw_files)} -o {merged_file} 2>&1"
                 merge_output = Shell.get_output(merge_cmd, verbose=True)
-
-                # Check for corrupted files in the output
-                corrupted_files = [
-                    line
-                    for line in merge_output.split("\n")
-                    if "invalid instrumentation profile" in line
-                    or "file header is corrupt" in line
-                ]
-                if corrupted_files:
-                    print(
-                        f"WARNING: Found {len(corrupted_files)} corrupted profraw files:"
-                    )
-                    for corrupted in corrupted_files:
-                        print(f"  {corrupted}")
 
                 # Attach profdata file to the result report so it is uploaded
                 # unconditionally (even when tests fail) and visible in the CI report.
                 if os.path.exists(merged_file):
                     R.files.append(merged_file)
+                else:
+                    print(f"ERROR: coverage merge produced no profile:\n{merge_output}")
 
         else:
-            print("No .profraw files found for coverage")
+            print("No usable .profraw files for coverage")
 
     if reset_success:
         # coverage job ignores test failures

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -336,6 +336,42 @@ def parse_args():
     return parser.parse_args()
 
 
+def coverage_profile_target() -> str:
+    """Filename this shard must publish its coverage profile under.
+
+    Named after the job's own coverage artifact, so the aggregation can tell which
+    shards arrived from the filenames alone. JOB_CONFIG has been through
+    dump()/get() by the time a job body runs, so it is a plain dict here and
+    attribute access on it raises AttributeError.
+    """
+    job_config = Info().job_config
+    assert (
+        job_config is not None
+    ), "JOB_CONFIG is not set, cannot derive the coverage profile name"
+    provides = job_config["provides"]
+    assert (
+        isinstance(provides, list)
+        and len(provides) == 1
+        and isinstance(provides[0], str)
+        and provides[0]
+    ), f"expected exactly one provided artifact name, got {provides!r}"
+    return f"./{provides[0]}.profdata"
+
+
+def remove_stale_coverage_profile(final_file: str) -> None:
+    """Drop any pre-existing profile at our target name.
+
+    llvm-profdata truncates its -o target in place instead of replacing it, and
+    the completion gate can skip the merge entirely, so a stale valid profile
+    would otherwise be published as this shard's contribution. On CI the pre-run
+    `git clean` already removes it; this covers a bare local run, where that clean
+    is skipped.
+    """
+    if os.path.exists(final_file):
+        print(f"Removing pre-existing {final_file}", flush=True)
+        os.unlink(final_file)
+
+
 def merge_profraw_files(llvm_profdata_cmd: str, job_params: list):
     """Merge all profraw files into final profdata file.
 
@@ -346,6 +382,8 @@ def merge_profraw_files(llvm_profdata_cmd: str, job_params: list):
     import subprocess
     from pathlib import Path
 
+    final_file = coverage_profile_target()
+
     # Find all profraw files
     profraw_files = [str(p) for p in Path(".").rglob("*.profraw")]
 
@@ -353,42 +391,31 @@ def merge_profraw_files(llvm_profdata_cmd: str, job_params: list):
         print("No profraw files found", flush=True)
         return
 
-    joined_job_params = "_".join(job_params) if job_params else "all"
-    joined_job_params = joined_job_params.replace(" ", "_").replace("/", "_")
-    final_file = f"./it-{joined_job_params}.profdata"
+    # A zero-length .profraw is silently ignored by llvm-profdata at every
+    # --failure-mode, so it would drop one process's coverage with no signal at
+    # all. Treat it as an incomplete shard and publish no profile.
+    empty_files = [f for f in profraw_files if os.path.getsize(f) == 0]
+    if empty_files:
+        print(
+            f"ERROR: {len(empty_files)} .profraw files are empty, so this shard's coverage "
+            f"is incomplete; publishing no profile: {', '.join(empty_files)}",
+            flush=True,
+        )
+        return None
+
     print(f"Merging {len(profraw_files)} profraw files into {final_file}", flush=True)
 
+    # --failure-mode=any makes the merge all-or-nothing: on any invalid input it
+    # exits non-zero and writes no file, so the shard is simply absent instead of
+    # contributing a silently short profile. The clean path is byte-identical
+    # to =warn.
     result = subprocess.run(
-        [llvm_profdata_cmd, "merge", "-sparse", "-failure-mode=warn"]
+        [llvm_profdata_cmd, "merge", "-sparse", "-failure-mode=any"]
         + profraw_files
         + ["-o", final_file],
         capture_output=True,
         text=True,
     )
-
-    # Check for corrupted files in stderr
-    corrupted_count = result.stderr.count(
-        "invalid instrumentation profile"
-    ) + result.stderr.count("file header is corrupt")
-    if corrupted_count > 0:
-        print(f"  WARNING: Found {corrupted_count} corrupted profraw files", flush=True)
-        # Extract and display corrupted filenames from stderr
-        corrupted_files = set()
-        for line in result.stderr.split("\n"):
-            if (
-                "invalid instrumentation profile" in line
-                or "file header is corrupt" in line
-                or "error:" in line.lower()
-            ):
-                print(f"    {line.strip()}", flush=True)
-                # Extract filename from error message (format: "error: file.profraw: ..." or "warning: file.profraw: ...")
-                parts = line.split(":")
-                if len(parts) >= 2:
-                    potential_file = parts[1].strip()
-                    if potential_file.endswith(".profraw"):
-                        corrupted_files.add(potential_file)
-        if corrupted_files:
-            print(f"  Corrupted files: {', '.join(corrupted_files)}", flush=True)
 
     if result.returncode == 0:
         print(f"Successfully created final coverage file: {final_file}", flush=True)
@@ -1017,6 +1044,10 @@ tar -czf ./ci/tmp/logs.tar.gz \
     failed_tests_files = []
 
     has_error = False
+    # Cleared when a test phase is dropped before it runs. Such a drop sets no
+    # termination status of its own, so it must be RECORDED where the decision is
+    # made rather than derived afterwards.
+    coverage_phases_complete = True
     # Set when a pytest run was cut short by a timeout (graceful session-timeout or the
     # hard subprocess backstop). Used below to keep an empty flaky/targeted result a
     # best-effort SKIPPED only when a timeout actually exhausted the budget.
@@ -1156,6 +1187,26 @@ tar -czf ./ci/tmp/logs.tar.gz \
                     f"Flaky/targeted check: sequential test run fails after attempt [{attempt+1}/{sequential_repeat_cnt}] - break"
                 )
                 break
+    elif sequential_test_modules:
+        # There were sequential tests to run and we chose not to run them, because
+        # too many tests had already failed or because of an infrastructure error.
+        # That skip is silent and sets nothing, so record it here.
+        print(
+            "Sequential test phase was dropped before it ran; this run did not execute "
+            "everything it planned"
+        )
+        coverage_phases_complete = False
+
+    # Whether this run executed what it planned, snapshotted HERE: both accumulators
+    # already reflect the sequential phase being dropped before it started (the
+    # admission test above is silent, it sets nothing) and the phase timing out
+    # after it started, and the LLVM-coverage block further down resets `has_error`,
+    # so reading them later would answer a different question. A coverage shard that
+    # did not complete must publish no profile: its short-but-valid profile is
+    # indistinguishable from a complete one downstream. Note this is deliberately
+    # NOT "no test failed" - a completed run with ordinary test failures still
+    # publishes its profile.
+    coverage_run_complete = coverage_phases_complete and not has_error and not timed_out
 
     # Run additional build types for bugfix validation.
     # Exit early on first failure to avoid duplicate test names and workspace pollution.
@@ -1507,8 +1558,20 @@ tar -czf ./ci/tmp/logs.tar.gz \
     if is_llvm_coverage and llvm_profdata_cmd:
         print("Collecting and merging LLVM coverage files...")
 
-        # Merge all profraw files into final profdata file
-        merged_profdata = merge_profraw_files(llvm_profdata_cmd, job_params)
+        # Unconditionally, and before deciding whether to merge: the gate below
+        # skips the merge entirely, so nothing would otherwise open the target
+        # name and a stale profile would be published as this shard's result.
+        remove_stale_coverage_profile(coverage_profile_target())
+
+        merged_profdata = None
+        if not coverage_run_complete:
+            print(
+                "This run did not execute everything it planned, so its coverage would be "
+                "incomplete; publishing no profile."
+            )
+        else:
+            # Merge all profraw files into final profdata file
+            merged_profdata = merge_profraw_files(llvm_profdata_cmd, job_params)
 
         # Attach profdata file to the result report so it is uploaded
         # unconditionally (even when tests fail) and visible in the CI report.

--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -396,27 +396,17 @@ if __name__ == "__main__":
 
                 _drop = coverage_drop(b_line_cov, c_line_cov)
 
-            if not _measurement_comparable:
-                # SKIPPED counts as OK, so the job stays green while stating that it
-                # did not judge. Reddening instead would turn a tool crash the PR
-                # author cannot act on into a blocking failure, and would relitigate
-                # the deliberate decision to let a shard's profile go missing.
-                _skip_msg = f"Coverage comparison skipped: {_incomparable_reason}"
-                print(_skip_msg)
-                diff_res.info = _skip_msg
-                diff_res.set_comment(_skip_msg)
-                diff_res.set_status(Result.Status.SKIPPED)
-            elif coverage_degraded(_drop):
-                _failure_msg = (
-                    f"Coverage degraded: master {b_line_cov:.2f}% → PR {c_line_cov:.2f}%"
-                    f" (dropped {_drop:.2f} pp, tolerance {COVERAGE_DROP_TOLERANCE} pp)"
-                )
-                print(_failure_msg)
-                diff_res.info = _failure_msg
-                diff_res.set_comment(_failure_msg)
-                diff_res.set_failed()
-            else:
-                print(f"Coverage did not degrade beyond tolerance (delta {delta:+.2f}%).")
+                if coverage_degraded(_drop):
+                    _failure_msg = (
+                        f"Coverage degraded: master {b_line_cov:.2f}% → PR {c_line_cov:.2f}%"
+                        f" (dropped {_drop:.2f} pp, tolerance {COVERAGE_DROP_TOLERANCE} pp)"
+                    )
+                    print(_failure_msg)
+                    diff_res.info = _failure_msg
+                    diff_res.set_comment(_failure_msg)
+                    diff_res.set_failed()
+                else:
+                    print(f"Coverage did not degrade beyond tolerance (delta {delta:+.2f}%).")
 
             # Compress and attach the diff HTML report archive + files to the diff result.
             # Unlike the full report, the DIFFERENTIAL report renders per-line deltas
@@ -445,6 +435,21 @@ if __name__ == "__main__":
             # When it is not comparable the reason was already printed above, and
             # repeating this sentence would name a cause that was never established.
             print("No C/C++ source files changed — differential coverage report was not generated.")
+
+        # Deliberately NOT an arm of the _diff_ran chain above: _diff_ran is False
+        # for three different reasons and only one of them (nothing coverable
+        # changed on a comparable run) licenses an OK, so reaching the abstention
+        # through it left a green sub-result on a run that did not judge. Placing
+        # it after the whole construct also keeps the verdict arm from being
+        # clobbered. SKIPPED counts as OK, so the job stays green while stating
+        # that it did not judge; reddening would turn a tool problem the PR author
+        # cannot act on into a blocking failure.
+        if not _measurement_comparable:
+            _skip_msg = f"Coverage comparison skipped: {_incomparable_reason}"
+            print(_skip_msg)
+            diff_res.info = _skip_msg
+            diff_res.set_comment(_skip_msg)
+            diff_res.set_status(Result.Status.SKIPPED)
 
         results.append(diff_res)
 
@@ -534,7 +539,13 @@ if __name__ == "__main__":
             # and therefore coverage, cannot have moved.
             _has_coverage_data = _diff_ran and _measurement_comparable
             if not _has_coverage_data:
-                if _diff_ran:
+                # Comparability is tested FIRST, as at the two sibling sites above,
+                # because a current-side cause short-circuits the differential
+                # script entirely: _diff_ran is then False for a reason that has
+                # nothing to do with C/C++ files, so selecting the message on it
+                # states something about the PR's contents that was never
+                # established - immediately after the real reason was printed.
+                if not _measurement_comparable:
                     print(f"Skipping coverage comment and CI DB row: {_incomparable_reason}")
                 else:
                     print("No coverage-relevant changes detected (no C/C++ source changes), skipping coverage comment.")
@@ -655,9 +666,17 @@ if __name__ == "__main__":
             else f"REFs/{branch}/{current_commit_sha}"
         )
         _s3_base = f"https://{S3_REPORT_BUCKET_HTTP_ENDPOINT}/{_s3_prefix}"
-        report_links.append(
-            f"{_s3_base}/llvm_coverage/generate_llvm_coverage_report/index.html"
-        )
+        # Only publish the link when the artifact it addresses exists: the merge
+        # phase now legitimately produces no report at all (it exits 0 without
+        # generating HTML when merged.profdata is absent), so an unconditional
+        # append points the intended green SKIPPED result at a 404. The entry
+        # point rather than the directory is tested, because that is what the URL
+        # addresses and what collect_html_report_files requires before it attaches
+        # anything.
+        if Path(f"{TEMP_DIR}/llvm_coverage_html_report/index.html").exists():
+            report_links.append(
+                f"{_s3_base}/llvm_coverage/generate_llvm_coverage_report/index.html"
+            )
         if _diff_ran and _measurement_comparable:
             report_links.append(
                 f"{_s3_base}/llvm_coverage/generate_llvm_coverage_diff_report/index_diff.html"

--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -439,12 +439,21 @@ if __name__ == "__main__":
         # Deliberately NOT an arm of the _diff_ran chain above: _diff_ran is False
         # for three different reasons and only one of them (nothing coverable
         # changed on a comparable run) licenses an OK, so reaching the abstention
-        # through it left a green sub-result on a run that did not judge. Placing
-        # it after the whole construct also keeps the verdict arm from being
-        # clobbered. SKIPPED counts as OK, so the job stays green while stating
-        # that it did not judge; reddening would turn a tool problem the PR author
-        # cannot act on into a blocking failure.
-        if not _measurement_comparable:
+        # through it left a green sub-result on a run that did not judge.
+        #
+        # Guarded on is_ok() as well, because this MUTATES a result rather than
+        # constructing one, unlike the two sibling abstentions above: on this path
+        # diff_res is what from_commands_run returned for the differential script,
+        # so it is already FAIL when that script exited non-zero. The script writes
+        # its baseline sidecar and selected-base marker before several later
+        # failure paths, so "the tool broke" and "we cannot judge" genuinely
+        # co-occur - and a failed REPORT must stay RED, per the contract this job
+        # states above. Only a result that is not already a failure may be
+        # downgraded; SKIPPED then counts as OK, so the job stays green while
+        # stating that it did not judge, and reddening a run that merely could not
+        # be compared would turn a tool problem the PR author cannot act on into a
+        # blocking failure.
+        if not _measurement_comparable and diff_res.is_ok():
             _skip_msg = f"Coverage comparison skipped: {_incomparable_reason}"
             print(_skip_msg)
             diff_res.info = _skip_msg

--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -285,11 +285,6 @@ if __name__ == "__main__":
     _incomparable_reason = ""
 
     if not is_master_branch:
-        diff_res = Result.from_commands_run(
-            name="Generate LLVM Coverage Diff Report",
-            command=["bash ci/jobs/scripts/generate_diff_coverage_report.sh"],
-        )
-
         # Both sides must be complete measurements of the same artifact manifest
         # before any number derived from them may be published. Computed here, ahead
         # of every consumer of those numbers.
@@ -302,12 +297,29 @@ if __name__ == "__main__":
             if _selected_base_file.exists()
             else ""
         )
-        if not Path(f"{TEMP_DIR}/llvm_coverage.info").exists():
+        # This test comes before the differential script runs, not after: that
+        # script's own precondition exits 1 when llvm_coverage.info is absent, and
+        # a non-zero command turns the sub-result FAIL. Its output directory is
+        # then missing too, so the SKIPPED override further down is never reached
+        # and the whole job reddens - exactly the outcome a failed aggregate merge
+        # is meant to report as SKIPPED.
+        _have_own_info = Path(f"{TEMP_DIR}/llvm_coverage.info").exists()
+        if not _have_own_info:
             _measurement_comparable = False
             _incomparable_reason = (
                 "this run published no coverage data, so there is nothing to compare"
             )
+            diff_res = Result.create_from(
+                name="Generate LLVM Coverage Diff Report",
+                status=Result.Status.SKIPPED,
+                info=f"Coverage comparison skipped: {_incomparable_reason}",
+            )
+            diff_res.set_comment(f"Coverage comparison skipped: {_incomparable_reason}")
         else:
+            diff_res = Result.from_commands_run(
+                name="Generate LLVM Coverage Diff Report",
+                command=["bash ci/jobs/scripts/generate_diff_coverage_report.sh"],
+            )
             _measurement_comparable, _incomparable_reason = completeness.comparable(
                 _sidecar,
                 _baseline_sidecar,

--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -8,7 +8,8 @@ from pathlib import Path
 from ci.praktika.info import Info
 from ci.praktika.result import Result
 from ci.praktika.utils import Shell, Utils
-from ci.defs.defs import S3_REPORT_BUCKET_HTTP_ENDPOINT
+from ci.defs.defs import LLVM_ARTIFACTS_LIST, S3_REPORT_BUCKET_HTTP_ENDPOINT
+from ci.jobs.scripts import llvm_coverage_completeness as completeness
 
 CURRENT_DIR = Utils.cwd()
 TEMP_DIR = f"{CURRENT_DIR}/ci/tmp/"
@@ -206,29 +207,116 @@ if __name__ == "__main__":
 
     results = []
 
+    # Which shard profiles this run expects, and which actually arrived. Snapshot
+    # the present set BEFORE the merge runs: the merge writes merged.profdata into
+    # the very directory being listed.
+    _expected_artifacts = list(LLVM_ARTIFACTS_LIST)
+    _present_profiles = completeness.present_profiles(TEMP_DIR)
+    _merge_inputs = completeness.merge_inputs(_expected_artifacts, _present_profiles)
+    print(f"Coverage shard profiles expected: {len(_expected_artifacts)}, present: {len(_present_profiles)}")
+
+    # Merge and report are separate steps. A failed MERGE means "no complete
+    # measurement", which is reported as SKIPPED further down; a failed REPORT is a
+    # tooling failure and must stay RED. praktika collapses a step's exit code to a
+    # boolean, so the merge status is passed back in a marker file instead.
+    _merge_env = f"MERGE_PROFDATA_FILES={shlex.quote(' '.join(_merge_inputs))}"
+    merge_res = Result.from_commands_run(
+        name="Merge LLVM Coverage Profiles",
+        command=[f"{_merge_env} bash ci/jobs/scripts/merge_llvm_coverage.sh merge"],
+    )
+    results.append(merge_res)
+
+    _merge_status_file = Path(TEMP_DIR) / "merge_profdata.status"
+    _merge_ok = (
+        merge_res.is_ok()
+        and _merge_status_file.exists()
+        and _merge_status_file.read_text().strip() == "ok"
+    )
+    if not _merge_ok:
+        print("The aggregate coverage merge did not produce a usable profile.")
+
     gen_report_res = Result.from_commands_run(
         name="Generate LLVM Coverage Report",
-        command=["bash ci/jobs/scripts/merge_llvm_coverage.sh"],
+        command=["bash ci/jobs/scripts/merge_llvm_coverage.sh report"],
     )
+
+    # Our own completeness metadata, published beside llvm_coverage.info so that a
+    # later PR comparing against this commit can tell whether this measurement was
+    # complete. Written even when incomplete - "incomplete" is exactly the fact the
+    # consumer needs.
+    _sidecar = completeness.build_sidecar(
+        _expected_artifacts,
+        _present_profiles,
+        info_path=f"{TEMP_DIR}/llvm_coverage.info",
+        merge_ok=_merge_ok,
+    )
+    completeness.write_sidecar(f"{TEMP_DIR}/{completeness.SIDECAR_BASENAME}", _sidecar)
+    if not _sidecar["complete"]:
+        print(
+            "This run's coverage measurement is INCOMPLETE: "
+            f"missing={_sidecar['missing']} unexpected={_sidecar['unexpected']} merge_ok={_merge_ok}"
+        )
 
     # Compress and attach the full HTML report archive + files to the generate result.
     # Keeping files/assets inside the same sub-Result ensures upload_result_files_to_s3
     # computes common_root = llvm_coverage_html_report/, so relative links stay intact.
-    Utils.compress_gz(
-        f"{TEMP_DIR}/llvm_coverage_html_report",
-        f"{TEMP_DIR}/llvm_coverage_html_report.tar.gz",
-    )
-    gen_report_res.files.append(f"{TEMP_DIR}/llvm_coverage_html_report.tar.gz")
-    _html_files, _html_assets = collect_html_report_files("llvm_coverage_html_report")
-    gen_report_res.files.extend(_html_files)
-    gen_report_res.assets.extend(_html_assets)
+    # The report directory is absent when the merge produced no profile.
+    if Path(f"{TEMP_DIR}/llvm_coverage_html_report").exists():
+        Utils.compress_gz(
+            f"{TEMP_DIR}/llvm_coverage_html_report",
+            f"{TEMP_DIR}/llvm_coverage_html_report.tar.gz",
+        )
+        gen_report_res.files.append(f"{TEMP_DIR}/llvm_coverage_html_report.tar.gz")
+        _html_files, _html_assets = collect_html_report_files("llvm_coverage_html_report")
+        gen_report_res.files.extend(_html_files)
+        gen_report_res.assets.extend(_html_assets)
+    if not _sidecar["complete"]:
+        # The full report is still published: it is a genuine measurement of what
+        # DID run and the best artifact for finding out which shard went missing.
+        # It is labelled so it cannot be read as a complete measurement.
+        _n_present = len(_expected_artifacts) - len(_sidecar["missing"])
+        _banner = (
+            f"partial measurement: {_n_present} of {len(_expected_artifacts)} shards"
+        )
+        gen_report_res.info = f"{gen_report_res.info}\n{_banner}" if gen_report_res.info else _banner
     results.append(gen_report_res)
+
+    _measurement_comparable = True
+    _incomparable_reason = ""
 
     if not is_master_branch:
         diff_res = Result.from_commands_run(
             name="Generate LLVM Coverage Diff Report",
             command=["bash ci/jobs/scripts/generate_diff_coverage_report.sh"],
         )
+
+        # Both sides must be complete measurements of the same artifact manifest
+        # before any number derived from them may be published. Computed here, ahead
+        # of every consumer of those numbers.
+        _baseline_sidecar = completeness.read_sidecar(
+            f"{TEMP_DIR}/base_llvm_coverage.meta.json"
+        )
+        _selected_base_file = Path(TEMP_DIR) / "selected_base_commit.txt"
+        _selected_base_commit = (
+            _selected_base_file.read_text().strip()
+            if _selected_base_file.exists()
+            else ""
+        )
+        if not Path(f"{TEMP_DIR}/llvm_coverage.info").exists():
+            _measurement_comparable = False
+            _incomparable_reason = (
+                "this run published no coverage data, so there is nothing to compare"
+            )
+        else:
+            _measurement_comparable, _incomparable_reason = completeness.comparable(
+                _sidecar,
+                _baseline_sidecar,
+                baseline_info_path=f"{TEMP_DIR}/base_llvm_coverage.info",
+            )
+        if not _measurement_comparable:
+            print(f"Coverage comparison skipped: {_incomparable_reason}")
+        elif _selected_base_commit:
+            print(f"Comparing against baseline commit {_selected_base_commit}")
 
         # The diff script exits 0 without running genhtml when no C/C++ files changed.
         # Use the presence of its output directory as the authoritative indicator.
@@ -261,7 +349,17 @@ if __name__ == "__main__":
             print(f"Delta             : {delta:+.2f}%")
 
             _drop = coverage_drop(b_line_cov, c_line_cov)
-            if coverage_degraded(_drop):
+            if not _measurement_comparable:
+                # SKIPPED counts as OK, so the job stays green while stating that it
+                # did not judge. Reddening instead would turn a tool crash the PR
+                # author cannot act on into a blocking failure, and would relitigate
+                # the deliberate decision to let a shard's profile go missing.
+                _skip_msg = f"Coverage comparison skipped: {_incomparable_reason}"
+                print(_skip_msg)
+                diff_res.info = _skip_msg
+                diff_res.set_comment(_skip_msg)
+                diff_res.set_status(Result.Status.SKIPPED)
+            elif coverage_degraded(_drop):
                 _failure_msg = (
                     f"Coverage degraded: master {b_line_cov:.2f}% → PR {c_line_cov:.2f}%"
                     f" (dropped {_drop:.2f} pp, tolerance {COVERAGE_DROP_TOLERANCE} pp)"
@@ -274,23 +372,27 @@ if __name__ == "__main__":
                 print(f"Coverage did not degrade beyond tolerance (delta {delta:+.2f}%).")
 
             # Compress and attach the diff HTML report archive + files to the diff result.
-            Utils.compress_gz(
-                f"{TEMP_DIR}/llvm_coverage_diff_html_report",
-                f"{TEMP_DIR}/llvm_coverage_diff_html_report.tar.gz",
-            )
-            diff_res.files.append(f"{TEMP_DIR}/llvm_coverage_diff_html_report.tar.gz")
-            # Copy index.html → index_diff.html so the diff entry-point has a unique
-            # name in S3 links. The original index.html is kept as an asset so that
-            # relative links inside the report continue to work.
-            _diff_index = Path(TEMP_DIR) / "llvm_coverage_diff_html_report" / "index.html"
-            _diff_index_copy = _diff_index.parent / "index_diff.html"
-            if _diff_index.exists():
-                shutil.copy2(_diff_index, _diff_index_copy)
-            _diff_files, _diff_assets = collect_html_report_files(
-                "llvm_coverage_diff_html_report", entry_point="index_diff.html"
-            )
-            diff_res.files.extend(_diff_files)
-            diff_res.assets.extend(_diff_assets)
+            # Unlike the full report, the DIFFERENTIAL report renders per-line deltas
+            # against the baseline, so it belongs with the numbers: when the two sides
+            # are not comparable its content is as fabricated as the verdict would be.
+            if _measurement_comparable:
+                Utils.compress_gz(
+                    f"{TEMP_DIR}/llvm_coverage_diff_html_report",
+                    f"{TEMP_DIR}/llvm_coverage_diff_html_report.tar.gz",
+                )
+                diff_res.files.append(f"{TEMP_DIR}/llvm_coverage_diff_html_report.tar.gz")
+                # Copy index.html to index_diff.html so the diff entry-point has a
+                # unique name in S3 links. The original index.html is kept as an asset
+                # so that relative links inside the report continue to work.
+                _diff_index = Path(TEMP_DIR) / "llvm_coverage_diff_html_report" / "index.html"
+                _diff_index_copy = _diff_index.parent / "index_diff.html"
+                if _diff_index.exists():
+                    shutil.copy2(_diff_index, _diff_index_copy)
+                _diff_files, _diff_assets = collect_html_report_files(
+                    "llvm_coverage_diff_html_report", entry_point="index_diff.html"
+                )
+                diff_res.files.extend(_diff_files)
+                diff_res.assets.extend(_diff_assets)
         else:
             print("No C/C++ source files changed — differential coverage report was not generated.")
 
@@ -302,7 +404,20 @@ if __name__ == "__main__":
             Path(TEMP_DIR + "changes.diff").exists()
             and Path(TEMP_DIR + "current.changed.info").exists()
         )
-        if _diff_inputs_exist:
+        if _diff_inputs_exist and not _measurement_comparable:
+            # The uncovered-code analysis compares the changed-line slice of the two
+            # measurements, extracted from the same merged data as the totals, so its
+            # output is fabricated for exactly the same reason.
+            msg = f"Skipping uncovered code analysis: {_incomparable_reason}"
+            print(msg)
+            print_res = Result.create_from(
+                name="Print Uncovered Code",
+                status=Result.Status.SKIPPED,
+                info=msg,
+            )
+            print_res.set_comment(msg)
+            _diff_inputs_exist = False
+        elif _diff_inputs_exist:
             Shell.run(
                 f"python3 ci/jobs/scripts/print_uncovered_code.py 2>&1 | tee {_print_log}",
                 verbose=True,
@@ -319,7 +434,7 @@ if __name__ == "__main__":
             print_res.set_comment(msg)
         # Append high-precision hit/total counts to the log so they are visible
         # in the artifact without cluttering the GitHub comment.
-        if _diff_ran:
+        if _diff_ran and _measurement_comparable:
             with open(_print_log, "a") as _f:
                 _f.write(
                     f"\n--- Coverage counts ---\n"
@@ -361,9 +476,12 @@ if __name__ == "__main__":
             # Tests-only PRs never reach this job at all - the coverage family is
             # auto-skipped for them (see filter_job.py) since the compiled binary,
             # and therefore coverage, cannot have moved.
-            _has_coverage_data = _diff_ran
+            _has_coverage_data = _diff_ran and _measurement_comparable
             if not _has_coverage_data:
-                print("No coverage-relevant changes detected (no C/C++ source changes) — skipping coverage comment.")
+                if _diff_ran:
+                    print(f"Skipping coverage comment and CI DB row: {_incomparable_reason}")
+                else:
+                    print("No coverage-relevant changes detected (no C/C++ source changes), skipping coverage comment.")
             else:
                 _comment_data = {
                     # GitHub comment fields
@@ -414,7 +532,15 @@ if __name__ == "__main__":
             print("Local run, skipping CI DB update with coverage results")
     else:
         print("On master branch, skipping diff coverage generation")
-        if not is_local_run:
+        if not is_local_run and not _sidecar["complete"]:
+            # The post-hook's non-PR branch inserts this row into the coverage CI DB
+            # table, which is the series every later baseline and trend reads. An
+            # incomplete master measurement must not enter it.
+            print(
+                "This master run's coverage measurement is incomplete, "
+                "skipping the CI DB row so it cannot poison the baseline series."
+            )
+        elif not is_local_run:
             try:
                 (m_line_cov, m_line_hit, m_line_total), \
                 (m_function_cov, m_func_hit, m_func_total), \
@@ -476,14 +602,21 @@ if __name__ == "__main__":
         report_links.append(
             f"{_s3_base}/llvm_coverage/generate_llvm_coverage_report/index.html"
         )
-        if _diff_ran:
+        if _diff_ran and _measurement_comparable:
             report_links.append(
                 f"{_s3_base}/llvm_coverage/generate_llvm_coverage_diff_report/index_diff.html"
             )
 
-    archives = [f"{TEMP_DIR}/llvm_coverage_html_report.tar.gz"]
-    if _diff_ran:
-        archives.append(f"{TEMP_DIR}/llvm_coverage_diff_html_report.tar.gz")
+    archives = [
+        a
+        for a in [
+            f"{TEMP_DIR}/llvm_coverage_html_report.tar.gz",
+            f"{TEMP_DIR}/llvm_coverage_diff_html_report.tar.gz"
+            if (_diff_ran and _measurement_comparable)
+            else None,
+        ]
+        if a and Path(a).exists()
+    ]
 
     Result.create_from(
         results=results,

--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -219,19 +219,34 @@ if __name__ == "__main__":
     # measurement", which is reported as SKIPPED further down; a failed REPORT is a
     # tooling failure and must stay RED. praktika collapses a step's exit code to a
     # boolean, so the merge status is passed back in a marker file instead.
-    _merge_env = f"MERGE_PROFDATA_FILES={shlex.quote(' '.join(_merge_inputs))}"
-    merge_res = Result.from_commands_run(
-        name="Merge LLVM Coverage Profiles",
-        command=[f"{_merge_env} bash ci/jobs/scripts/merge_llvm_coverage.sh merge"],
-    )
+    if not _merge_inputs:
+        # An empty input set is the limit of the same tolerated case as one absent
+        # shard, so it reports SKIPPED instead of reddening. The script is not
+        # invoked: its guard cannot tell an empty value from an omitted one, and it
+        # must keep refusing the latter to stay safe against an unbounded glob. It
+        # writes no marker either, so the marker read is skipped rather than
+        # satisfied with a fabricated one.
+        _merge_msg = "no shard coverage profile arrived, so there is nothing to merge"
+        merge_res = Result.create_from(
+            name="Merge LLVM Coverage Profiles",
+            status=Result.Status.SKIPPED,
+            info=_merge_msg,
+        )
+        merge_res.set_comment(_merge_msg)
+        _merge_ok = False
+    else:
+        _merge_env = f"MERGE_PROFDATA_FILES={shlex.quote(' '.join(_merge_inputs))}"
+        merge_res = Result.from_commands_run(
+            name="Merge LLVM Coverage Profiles",
+            command=[f"{_merge_env} bash ci/jobs/scripts/merge_llvm_coverage.sh merge"],
+        )
+        _merge_status_file = Path(TEMP_DIR) / "merge_profdata.status"
+        _merge_ok = (
+            merge_res.is_ok()
+            and _merge_status_file.exists()
+            and _merge_status_file.read_text().strip() == "ok"
+        )
     results.append(merge_res)
-
-    _merge_status_file = Path(TEMP_DIR) / "merge_profdata.status"
-    _merge_ok = (
-        merge_res.is_ok()
-        and _merge_status_file.exists()
-        and _merge_status_file.read_text().strip() == "ok"
-    )
     if not _merge_ok:
         print("The aggregate coverage merge did not produce a usable profile.")
 
@@ -286,29 +301,32 @@ if __name__ == "__main__":
 
     if not is_master_branch:
         # Both sides must be complete measurements of the same artifact manifest
-        # before any number derived from them may be published. Computed here, ahead
-        # of every consumer of those numbers.
-        _baseline_sidecar = completeness.read_sidecar(
-            f"{TEMP_DIR}/base_llvm_coverage.meta.json"
-        )
-        _selected_base_file = Path(TEMP_DIR) / "selected_base_commit.txt"
-        _selected_base_commit = (
-            _selected_base_file.read_text().strip()
-            if _selected_base_file.exists()
-            else ""
-        )
-        # This test comes before the differential script runs, not after: that
-        # script's own precondition exits 1 when llvm_coverage.info is absent, and
-        # a non-zero command turns the sub-result FAIL. Its output directory is
-        # then missing too, so the SKIPPED override further down is never reached
-        # and the whole job reddens - exactly the outcome a failed aggregate merge
-        # is meant to report as SKIPPED.
+        # before any number derived from them may be published.
+        #
+        # The baseline sidecar and the selected-base marker are produced BY the
+        # differential script, so they may only be read after it has run.
+        #
+        # The current side is decided BEFORE it. An absent llvm_coverage.info trips
+        # that script's own precondition, which exits 1 and turns the sub-result
+        # FAIL; its output directory is then missing too, so the SKIPPED override
+        # further down is never reached and the whole job reddens - exactly the
+        # outcome a failed aggregate merge is meant to report as SKIPPED. The
+        # sidecar's own causes are short-circuited here for a different reason:
+        # running the script on a measurement already known incomparable spends
+        # genhtml on it and prints a delta the very next line says was not judged.
+        # Baseline-side causes cannot be known yet, because that script is what
+        # fetches the baseline, so they stay with the override.
         _have_own_info = Path(f"{TEMP_DIR}/llvm_coverage.info").exists()
-        if not _have_own_info:
+        _own_side_reason = completeness.current_side_reason(_sidecar)
+        if not _have_own_info or _own_side_reason:
             _measurement_comparable = False
             _incomparable_reason = (
-                "this run published no coverage data, so there is nothing to compare"
+                _own_side_reason
+                if _have_own_info
+                else "this run published no coverage data, so there is nothing to compare"
             )
+            # The script never ran, so it wrote no marker and there is nothing to read.
+            _selected_base_commit = ""
             diff_res = Result.create_from(
                 name="Generate LLVM Coverage Diff Report",
                 status=Result.Status.SKIPPED,
@@ -319,6 +337,15 @@ if __name__ == "__main__":
             diff_res = Result.from_commands_run(
                 name="Generate LLVM Coverage Diff Report",
                 command=["bash ci/jobs/scripts/generate_diff_coverage_report.sh"],
+            )
+            _baseline_sidecar = completeness.read_sidecar(
+                f"{TEMP_DIR}/base_llvm_coverage.meta.json"
+            )
+            _selected_base_file = Path(TEMP_DIR) / "selected_base_commit.txt"
+            _selected_base_commit = (
+                _selected_base_file.read_text().strip()
+                if _selected_base_file.exists()
+                else ""
             )
             _measurement_comparable, _incomparable_reason = completeness.comparable(
                 _sidecar,

--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -368,26 +368,34 @@ if __name__ == "__main__":
         b_branch_hit = b_branch_total = c_branch_hit = c_branch_total = 0
 
         if _diff_ran:
-            # Baseline coverage from the primary master run.
-            (b_line_cov, b_line_hit, b_line_total), \
-            (b_function_cov, b_func_hit, b_func_total), \
-            (b_branch_cov, b_branch_hit, b_branch_total) = get_lcov_summary(
-                f"{TEMP_DIR}/base_llvm_coverage.info"
-            )
+            # A baseline-side cause is only knowable after the script has run, so the
+            # script legitimately ran and this block is reached with the measurement
+            # already known incomparable. Parsing the two summaries and printing a
+            # delta here would put three numbers between two abstention notices,
+            # which is the reading confusion this gate exists to remove. The
+            # zero-initialisations above keep the unparsed variables safe.
+            if _measurement_comparable:
+                # Baseline coverage from the primary master run.
+                (b_line_cov, b_line_hit, b_line_total), \
+                (b_function_cov, b_func_hit, b_func_total), \
+                (b_branch_cov, b_branch_hit, b_branch_total) = get_lcov_summary(
+                    f"{TEMP_DIR}/base_llvm_coverage.info"
+                )
 
-            # Current coverage for the current branch
-            (c_line_cov, c_line_hit, c_line_total), \
-            (c_function_cov, c_func_hit, c_func_total), \
-            (c_branch_cov, c_branch_hit, c_branch_total) = get_lcov_summary(
-                f"{TEMP_DIR}/llvm_coverage.info"
-            )
+                # Current coverage for the current branch
+                (c_line_cov, c_line_hit, c_line_total), \
+                (c_function_cov, c_func_hit, c_func_total), \
+                (c_branch_cov, c_branch_hit, c_branch_total) = get_lcov_summary(
+                    f"{TEMP_DIR}/llvm_coverage.info"
+                )
 
-            delta = c_line_cov - b_line_cov
-            print(f"Baseline coverage : {b_line_cov:.2f}%")
-            print(f"Current coverage  : {c_line_cov:.2f}%")
-            print(f"Delta             : {delta:+.2f}%")
+                delta = c_line_cov - b_line_cov
+                print(f"Baseline coverage : {b_line_cov:.2f}%")
+                print(f"Current coverage  : {c_line_cov:.2f}%")
+                print(f"Delta             : {delta:+.2f}%")
 
-            _drop = coverage_drop(b_line_cov, c_line_cov)
+                _drop = coverage_drop(b_line_cov, c_line_cov)
+
             if not _measurement_comparable:
                 # SKIPPED counts as OK, so the job stays green while stating that it
                 # did not judge. Reddening instead would turn a tool crash the PR
@@ -432,7 +440,10 @@ if __name__ == "__main__":
                 )
                 diff_res.files.extend(_diff_files)
                 diff_res.assets.extend(_diff_assets)
-        else:
+        elif _measurement_comparable:
+            # Only a comparable run can conclude that nothing coverable changed.
+            # When it is not comparable the reason was already printed above, and
+            # repeating this sentence would name a cause that was never established.
             print("No C/C++ source files changed — differential coverage report was not generated.")
 
         results.append(diff_res)
@@ -443,7 +454,13 @@ if __name__ == "__main__":
             Path(TEMP_DIR + "changes.diff").exists()
             and Path(TEMP_DIR + "current.changed.info").exists()
         )
-        if _diff_inputs_exist and not _measurement_comparable:
+        # Comparability is tested FIRST because the two conditions are not
+        # independent: a current-side cause short-circuits the differential script,
+        # which is the sole writer of both diff inputs, so their absence there means
+        # "the script never ran", not "nothing coverable changed". Testing
+        # _diff_inputs_exist first would therefore report the no-C++-changes reason
+        # on the very paths this gate exists to abstain on.
+        if not _measurement_comparable:
             # The uncovered-code analysis compares the changed-line slice of the two
             # measurements, extracted from the same merged data as the totals, so its
             # output is fabricated for exactly the same reason.

--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -594,7 +594,12 @@ if __name__ == "__main__":
                     ),
                     "pull_request_number": pr_number,
                     "commit_sha": current_commit_sha,
-                    "base_commit_sha": base_commit_sha,
+                    # The ancestor the report was actually generated against, which
+                    # is generally NOT base_commit_sha: that is the NEAREST master
+                    # ancestor, while the selector walks past any that is unusable.
+                    # Storing the nearest one would attribute the delta to a
+                    # revision that was never measured.
+                    "base_commit_sha": _selected_base_commit or base_commit_sha,
                     "branch": branch,
                     "base_branch": base_branch,
                     "status": diff_res.status,

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -61,6 +61,12 @@ ABORTED_RUN_EXIT_CODES = frozenset(
 
 SUCCESS_FINISH_SIGNS = ["All tests have finished", "No tests were run"]
 
+# Emitted by tests/clickhouse-test only when the scheduler ran to the end AND no
+# worker was killed. Deliberately separate from SUCCESS_FINISH_SIGNS, which is
+# also true for "No tests were run" and for a run that lost a worker - both would
+# let an under-executed coverage shard publish a short profile.
+COVERAGE_RUN_COMPLETE_SIGN = "Coverage run completed all selected tests."
+
 RETRIES_SIGN = "Some tests were restarted"
 
 # Regex pattern to match test result lines.
@@ -87,6 +93,10 @@ class FTResultsProcessor:
         hung: bool = False
         retries: bool = False
         success_finish: bool = False
+        # True only when tests/clickhouse-test reported that it executed every
+        # selected test. Used to decide whether a coverage shard may publish its
+        # profile; success_finish is NOT a substitute (see the sign definitions).
+        coverage_run_complete: bool = False
         test_end: bool = True
 
     def __init__(self, wd):
@@ -102,6 +112,7 @@ class FTResultsProcessor:
         hung = False
         retries = False
         success_finish = False
+        coverage_run_complete = False
         test_results = []
         test_end = True
 
@@ -112,6 +123,8 @@ class FTResultsProcessor:
 
                 if any(s in line for s in SUCCESS_FINISH_SIGNS):
                     success_finish = True
+                if COVERAGE_RUN_COMPLETE_SIGN in line:
+                    coverage_run_complete = True
                 # Ignore hung check report, since it may be quite large.
                 # (and may break python parser which has limit of 128KiB for each row).
                 if HUNG_SIGN in line:
@@ -208,6 +221,7 @@ class FTResultsProcessor:
             test_results=test_results,
             hung=hung,
             success_finish=success_finish,
+            coverage_run_complete=coverage_run_complete,
             retries=retries,
         )
 
@@ -335,6 +349,11 @@ class FTResultsProcessor:
             info=info,
             with_info_from_results=False,
         )
+
+        # Expose the coverage-completion fact additively, for the coverage merge
+        # in functional_tests.py. Status, info and results are untouched, so no
+        # non-coverage job changes behaviour.
+        result.ext["coverage_run_complete"] = s.coverage_run_complete
 
         if not result.is_ok():
             order = {

--- a/ci/jobs/scripts/generate_diff_coverage_report.sh
+++ b/ci/jobs/scripts/generate_diff_coverage_report.sh
@@ -21,24 +21,82 @@ fi
 # Try to find .info file from S3, checking up to 30 ancestor commits
 IFS=',' read -ra COMMITS <<< "${PREV_30_COMMITS}"
 
+BASE_S3_PREFIX="https://clickhouse-builds.s3.amazonaws.com/REFs/master"
+
+# Our own completeness metadata, written by the job before this script runs. Used
+# to prefer a baseline that measured the same artifact manifest.
+OUR_MANIFEST_FP=""
+if [ -f "llvm_coverage.meta.json" ]; then
+  OUR_MANIFEST_FP=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('manifest_fp',''))" llvm_coverage.meta.json 2>/dev/null || true)
+fi
+
+# Two passes over the same ancestor list.
+#
+# Pass 1 prefers an ancestor that published a COMPLETE measurement of the same
+# artifact manifest. Most master runs are not complete, so selecting the first
+# ancestor that merely has an .info would make the gate abstain on the majority of
+# runs rather than judge them.
+#
+# Pass 2 is byte-for-byte the previous behaviour, and it is what keeps this
+# backward compatible: no master commit published before this change carries
+# completeness metadata, so until master republishes, pass 1 finds nothing, pass 2
+# selects exactly as before, and the job reports SKIPPED with a reason instead of
+# failing.
 FOUND=0
 FIRST_BASE_COMMIT=""
-for TEST_COMMIT in "${COMMITS[@]}"; do
-COVERAGE_URL="https://clickhouse-builds.s3.amazonaws.com/REFs/master/${TEST_COMMIT}/llvm_coverage/llvm_coverage.info"
-echo "Checking coverage file for commit ${TEST_COMMIT}..."
-if wget --spider "${COVERAGE_URL}" 2>&1 | grep -q '200 OK'; then
-echo "Found coverage file at ${COVERAGE_URL}"
-wget --quiet "${COVERAGE_URL}" -O base_llvm_coverage.info
-FIRST_BASE_COMMIT="${TEST_COMMIT}"
-FOUND=1
-break
-fi
+for PASS in prefer_complete any_info; do
+  if [ "$PASS" = "prefer_complete" ] && [ -z "$OUR_MANIFEST_FP" ]; then
+    echo "No local completeness metadata; skipping the complete-baseline pass"
+    continue
+  fi
+  echo "Baseline selection pass: ${PASS}"
+  for TEST_COMMIT in "${COMMITS[@]}"; do
+    COVERAGE_URL="${BASE_S3_PREFIX}/${TEST_COMMIT}/llvm_coverage/llvm_coverage.info"
+    META_URL="${BASE_S3_PREFIX}/${TEST_COMMIT}/llvm_coverage/llvm_coverage.meta.json"
+    echo "Checking coverage file for commit ${TEST_COMMIT}..."
+    if ! wget --spider "${COVERAGE_URL}" 2>&1 | grep -q '200 OK'; then
+      continue
+    fi
+    rm -f base_llvm_coverage.meta.json
+    # Fetch the sidecar when it exists; the job validates the pair either way.
+    wget --quiet "${META_URL}" -O base_llvm_coverage.meta.json || rm -f base_llvm_coverage.meta.json
+    if [ "$PASS" = "prefer_complete" ]; then
+      if [ ! -f base_llvm_coverage.meta.json ]; then
+        echo "  no completeness metadata for ${TEST_COMMIT}"
+        continue
+      fi
+      if ! python3 -c "
+import json, sys
+d = json.load(open('base_llvm_coverage.meta.json'))
+sys.exit(0 if d.get('complete') and d.get('manifest_fp') == sys.argv[1] else 1)
+" "${OUR_MANIFEST_FP}" 2>/dev/null; then
+        rm -f base_llvm_coverage.meta.json
+        echo "  ${TEST_COMMIT} is not a complete measurement of our artifact manifest"
+        continue
+      fi
+      echo "  ${TEST_COMMIT} reports a complete measurement of our artifact manifest"
+    fi
+    echo "Found coverage file at ${COVERAGE_URL}"
+    wget --quiet "${COVERAGE_URL}" -O base_llvm_coverage.info
+    FIRST_BASE_COMMIT="${TEST_COMMIT}"
+    FOUND=1
+    break
+  done
+  if [ $FOUND -eq 1 ]; then
+    break
+  fi
 done
 
 if [ $FOUND -eq 0 ]; then
   echo "ERROR: Could not find baseline coverage file after checking ${#COMMITS[@]} commits"
   exit 1
 fi
+
+# Record which ancestor was actually selected. The job cannot re-derive it: its
+# own base_commit_sha is the NEAREST ancestor, generally not this one, and
+# re-walking S3 from Python could select a different commit than the .info that
+# ended up on disk.
+echo "${FIRST_BASE_COMMIT}" > selected_base_commit.txt
 
 # Note: base_llvm_coverage_{2..6}.info (extra older master baselines) are not
 # downloaded anywhere. The slot loop below is a no-op unless something else

--- a/ci/jobs/scripts/generate_diff_coverage_report.sh
+++ b/ci/jobs/scripts/generate_diff_coverage_report.sh
@@ -23,19 +23,20 @@ IFS=',' read -ra COMMITS <<< "${PREV_30_COMMITS}"
 
 BASE_S3_PREFIX="https://clickhouse-builds.s3.amazonaws.com/REFs/master"
 
-# Our own completeness metadata, written by the job before this script runs. Used
-# to prefer a baseline that measured the same artifact manifest.
-OUR_MANIFEST_FP=""
-if [ -f "llvm_coverage.meta.json" ]; then
-  OUR_MANIFEST_FP=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('manifest_fp',''))" llvm_coverage.meta.json 2>/dev/null || true)
-fi
-
 # Two passes over the same ancestor list.
 #
-# Pass 1 prefers an ancestor that published a COMPLETE measurement of the same
-# artifact manifest. Most master runs are not complete, so selecting the first
-# ancestor that merely has an .info would make the gate abstain on the majority of
-# runs rather than judge them.
+# Pass 1 prefers an ancestor the job will actually be able to compare against.
+# Most master runs are not complete, so selecting the first ancestor that merely
+# has an .info would make the gate abstain on the majority of runs rather than
+# judge them.
+#
+# Its predicate is llvm_coverage_completeness.comparable itself, not a local
+# approximation of it. A selection test weaker than the usability test lets a
+# candidate win here that the job then rejects, which turns "walk on to the next
+# usable baseline" into a whole-job abstention. Reusing the one function keeps the
+# two from drifting apart again, and it is why the candidate .info is downloaded
+# before the decision: the torn-pair check digests the very bytes that would be
+# compared.
 #
 # Pass 2 is byte-for-byte the previous behaviour, and it is what keeps this
 # backward compatible: no master commit published before this change carries
@@ -45,7 +46,7 @@ fi
 FOUND=0
 FIRST_BASE_COMMIT=""
 for PASS in prefer_complete any_info; do
-  if [ "$PASS" = "prefer_complete" ] && [ -z "$OUR_MANIFEST_FP" ]; then
+  if [ "$PASS" = "prefer_complete" ] && [ ! -f llvm_coverage.meta.json ]; then
     echo "No local completeness metadata; skipping the complete-baseline pass"
     continue
   fi
@@ -65,19 +66,30 @@ for PASS in prefer_complete any_info; do
         echo "  no completeness metadata for ${TEST_COMMIT}"
         continue
       fi
-      if ! python3 -c "
-import json, sys
-d = json.load(open('base_llvm_coverage.meta.json'))
-sys.exit(0 if d.get('complete') and d.get('manifest_fp') == sys.argv[1] else 1)
-" "${OUR_MANIFEST_FP}" 2>/dev/null; then
-        rm -f base_llvm_coverage.meta.json
-        echo "  ${TEST_COMMIT} is not a complete measurement of our artifact manifest"
+      wget --quiet "${COVERAGE_URL}" -O base_llvm_coverage.info
+      if ! REASON=$(PYTHONPATH="${WORKSPACE_PATH}" python3 -c "
+import sys
+from ci.jobs.scripts import llvm_coverage_completeness as completeness
+
+ok, reason = completeness.comparable(
+    completeness.read_sidecar('llvm_coverage.meta.json'),
+    completeness.read_sidecar('base_llvm_coverage.meta.json'),
+    baseline_info_path='base_llvm_coverage.info',
+)
+if ok:
+    sys.exit(0)
+sys.stdout.write(reason)
+sys.exit(1)
+"); then
+        rm -f base_llvm_coverage.meta.json base_llvm_coverage.info
+        echo "  ${TEST_COMMIT} is not usable as a baseline: ${REASON}"
         continue
       fi
-      echo "  ${TEST_COMMIT} reports a complete measurement of our artifact manifest"
+      echo "  ${TEST_COMMIT} is a usable baseline for this measurement"
+    else
+      wget --quiet "${COVERAGE_URL}" -O base_llvm_coverage.info
     fi
     echo "Found coverage file at ${COVERAGE_URL}"
-    wget --quiet "${COVERAGE_URL}" -O base_llvm_coverage.info
     FIRST_BASE_COMMIT="${TEST_COMMIT}"
     FOUND=1
     break

--- a/ci/jobs/scripts/llvm_coverage_completeness.py
+++ b/ci/jobs/scripts/llvm_coverage_completeness.py
@@ -1,0 +1,234 @@
+"""Completeness metadata for the LLVM coverage diff gate.
+
+The gate compares a baseline coverage percentage against the current one. Both
+percentages are merged from per-shard `.profdata` artifacts that are declared
+`optional=True`, so either side can silently be short a shard and still produce
+a number. This module carries the fact "the measurement was complete" next to
+the measurement so the consumer can refuse to compare two things that are not
+comparable.
+
+`manifest_fp` fingerprints the ARTIFACT MANIFEST only. It detects a change to
+the set of coverage artifacts (the list has really grown 18 -> 20 -> 21), which
+makes two otherwise-complete measurements incomparable. It deliberately does
+NOT claim that the two runs exercised the same code: coverage test selection
+also depends on the test tree, on per-test tags and on hash-based sharding, none
+of which is expressible here. See the PR description for that residual.
+
+Consumer-only by design: the producers derive their profile filename inline
+from their own artifact identity, so no producer cache digest depends on this
+file.
+"""
+
+import hashlib
+import json
+import os
+from typing import Iterable, List, Optional, Tuple
+
+# Bump when the on-disk shape changes. A reader that meets a higher version must
+# treat the sidecar as unknown rather than misinterpret it.
+SCHEMA_VERSION = 1
+
+SIDECAR_BASENAME = "llvm_coverage.meta.json"
+
+# Shard profiles are named "<artifact name>.profdata" by their producer, so the
+# filename carries the shard identity and completeness is exact set equality.
+PROFDATA_SUFFIX = ".profdata"
+
+
+def profile_basename(artifact_name: str) -> str:
+    """Profile filename for one coverage artifact.
+
+    Both sides must derive the name the same way: the producers call this shape
+    inline (they must not import this module, so their cache digests stay
+    independent of it) and the consumer builds its expected set from it.
+    """
+    assert isinstance(artifact_name, str) and artifact_name, (
+        f"coverage artifact name must be a non-empty str, got {artifact_name!r}"
+    )
+    return f"{artifact_name}{PROFDATA_SUFFIX}"
+
+
+def manifest_fingerprint(artifact_names: Iterable[str]) -> str:
+    """Digest of the sorted artifact-name list.
+
+    Detects manifest drift only. Two runs with different fingerprints measured
+    different artifact sets and must not be compared.
+    """
+    names = sorted(str(n) for n in artifact_names)
+    payload = "\n".join(names).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:16]
+
+
+def file_digest(path: str) -> str:
+    """Content digest of a coverage `.info`, or "" when it does not exist.
+
+    Uploads of the `.info` and of this sidecar are separate S3 objects written
+    sequentially into a commit-keyed prefix, so a re-run of the same commit can
+    replace one before the other. Recording the digest of the `.info` the
+    sidecar describes lets the consumer detect such a torn pair.
+    """
+    if not path or not os.path.exists(path):
+        return ""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()[:16]
+
+
+def present_profiles(directory: str) -> List[str]:
+    """Profile filenames present in `directory`.
+
+    Snapshot this BEFORE the aggregate merge runs: the merge writes its own
+    output into the same directory and would otherwise appear as an extra input.
+    """
+    if not os.path.isdir(directory):
+        return []
+    return sorted(
+        name
+        for name in os.listdir(directory)
+        if name.endswith(PROFDATA_SUFFIX)
+        and os.path.isfile(os.path.join(directory, name))
+    )
+
+
+def classify(expected_names: Iterable[str], present_files: Iterable[str]):
+    """Compare the expected profile set against what is on disk.
+
+    Returns (complete, missing, unexpected).
+
+    Completeness is exact set EQUALITY, never a difference: `expected - present`
+    is empty whenever every expected file is there, so it silently accepts a
+    foreign or stale profile that the merge would then fold into the total.
+    """
+    expected = {profile_basename(n) for n in expected_names}
+    present = set(present_files)
+    missing = sorted(expected - present)
+    unexpected = sorted(present - expected)
+    return (not missing and not unexpected), missing, unexpected
+
+
+def merge_inputs(expected_names: Iterable[str], present_files: Iterable[str]) -> List[str]:
+    """Files to hand the aggregate merge: `expected` INTERSECT `present`.
+
+    Two different sets are in play and confusing them turns an incomplete run
+    into a hard failure: the merge gets the shards that actually arrived (so a
+    legitimately absent optional shard still merges the rest), while the
+    completeness VERDICT is the equality above.
+    """
+    expected = {profile_basename(n) for n in expected_names}
+    return sorted(expected & set(present_files))
+
+
+def build_sidecar(
+    artifact_names: Iterable[str],
+    present_files: Iterable[str],
+    info_path: str = "",
+    merge_ok: bool = True,
+) -> dict:
+    names = sorted(str(n) for n in artifact_names)
+    complete, missing, unexpected = classify(names, present_files)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "manifest_fp": manifest_fingerprint(names),
+        "complete": bool(complete and merge_ok),
+        "merge_ok": bool(merge_ok),
+        "expected": [profile_basename(n) for n in names],
+        "present": sorted(present_files),
+        "missing": missing,
+        "unexpected": unexpected,
+        "info_digest": file_digest(info_path),
+    }
+
+
+def write_sidecar(path: str, sidecar: dict) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(sidecar, f, indent=2, sort_keys=True)
+
+
+def read_sidecar(path: str) -> Optional[dict]:
+    """Read a sidecar, or None when it is absent or unusable.
+
+    None means "unknown", which the consumer turns into SKIPPED. No master
+    commit published before this change has a sidecar, so absence must never be
+    a hard failure or every PR would be blocked until master republishes.
+    """
+    if not path or not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (ValueError, OSError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def comparable(
+    current: dict,
+    baseline: Optional[dict],
+    baseline_info_path: str = "",
+) -> Tuple[bool, str]:
+    """Whether a verdict may be produced from these two measurements.
+
+    Returns (comparable, reason). `reason` is empty when comparable and
+    otherwise names which side was short and what was missing, so the SKIPPED
+    sub-result explains itself.
+    """
+    if not isinstance(current, dict):
+        return False, "current-side completeness metadata is missing"
+
+    if current.get("schema_version") != SCHEMA_VERSION:
+        return False, (
+            f"current-side sidecar schema version {current.get('schema_version')!r}"
+            f" is not {SCHEMA_VERSION}"
+        )
+
+    if not current.get("merge_ok", True):
+        return False, "the aggregate coverage merge failed, so this run has no complete measurement"
+
+    if not current.get("complete"):
+        missing = current.get("missing") or []
+        unexpected = current.get("unexpected") or []
+        detail = []
+        if missing:
+            detail.append(f"missing {len(missing)}: {', '.join(missing)}")
+        if unexpected:
+            detail.append(f"unexpected {len(unexpected)}: {', '.join(unexpected)}")
+        return False, "PR-side measurement is incomplete (" + "; ".join(detail) + ")"
+
+    if baseline is None:
+        return False, (
+            "baseline commit published no completeness metadata, so its measurement"
+            " cannot be confirmed complete"
+        )
+
+    if baseline.get("schema_version") != SCHEMA_VERSION:
+        return False, (
+            f"baseline sidecar schema version {baseline.get('schema_version')!r}"
+            f" is not {SCHEMA_VERSION}"
+        )
+
+    if not baseline.get("complete"):
+        missing = baseline.get("missing") or []
+        detail = f"missing {len(missing)}: {', '.join(missing)}" if missing else "reason unrecorded"
+        return False, f"baseline measurement is incomplete ({detail})"
+
+    if baseline.get("manifest_fp") != current.get("manifest_fp"):
+        return False, (
+            "coverage artifact manifest changed between the baseline and this run"
+            f" (baseline {baseline.get('manifest_fp')!r} vs current {current.get('manifest_fp')!r}),"
+            " so the two totals cover different artifact sets"
+        )
+
+    recorded = baseline.get("info_digest") or ""
+    if recorded and baseline_info_path:
+        actual = file_digest(baseline_info_path)
+        if actual and actual != recorded:
+            return False, (
+                "baseline sidecar does not describe the baseline coverage data it was"
+                f" fetched with (recorded {recorded!r} vs actual {actual!r})"
+            )
+
+    return True, ""

--- a/ci/jobs/scripts/llvm_coverage_completeness.py
+++ b/ci/jobs/scripts/llvm_coverage_completeness.py
@@ -165,6 +165,39 @@ def read_sidecar(path: str) -> Optional[dict]:
     return data
 
 
+def current_side_reason(current: dict) -> str:
+    """Why the CURRENT side alone cannot support a verdict, "" when it can.
+
+    These causes depend only on the current sidecar, so they are knowable before
+    the differential script runs. `comparable` delegates to this function, which
+    keeps a single producer of these strings: a caller short-circuiting on a
+    current-side cause cannot drift from the verdict `comparable` would give.
+    """
+    if not isinstance(current, dict):
+        return "current-side completeness metadata is missing"
+
+    if current.get("schema_version") != SCHEMA_VERSION:
+        return (
+            f"current-side sidecar schema version {current.get('schema_version')!r}"
+            f" is not {SCHEMA_VERSION}"
+        )
+
+    if not current.get("merge_ok", True):
+        return "the aggregate coverage merge failed, so this run has no complete measurement"
+
+    if not current.get("complete"):
+        missing = current.get("missing") or []
+        unexpected = current.get("unexpected") or []
+        detail = []
+        if missing:
+            detail.append(f"missing {len(missing)}: {', '.join(missing)}")
+        if unexpected:
+            detail.append(f"unexpected {len(unexpected)}: {', '.join(unexpected)}")
+        return "PR-side measurement is incomplete (" + "; ".join(detail) + ")"
+
+    return ""
+
+
 def comparable(
     current: dict,
     baseline: Optional[dict],
@@ -176,27 +209,9 @@ def comparable(
     otherwise names which side was short and what was missing, so the SKIPPED
     sub-result explains itself.
     """
-    if not isinstance(current, dict):
-        return False, "current-side completeness metadata is missing"
-
-    if current.get("schema_version") != SCHEMA_VERSION:
-        return False, (
-            f"current-side sidecar schema version {current.get('schema_version')!r}"
-            f" is not {SCHEMA_VERSION}"
-        )
-
-    if not current.get("merge_ok", True):
-        return False, "the aggregate coverage merge failed, so this run has no complete measurement"
-
-    if not current.get("complete"):
-        missing = current.get("missing") or []
-        unexpected = current.get("unexpected") or []
-        detail = []
-        if missing:
-            detail.append(f"missing {len(missing)}: {', '.join(missing)}")
-        if unexpected:
-            detail.append(f"unexpected {len(unexpected)}: {', '.join(unexpected)}")
-        return False, "PR-side measurement is incomplete (" + "; ".join(detail) + ")"
+    current_reason = current_side_reason(current)
+    if current_reason:
+        return False, current_reason
 
     if baseline is None:
         return False, (

--- a/ci/jobs/scripts/merge_llvm_coverage.sh
+++ b/ci/jobs/scripts/merge_llvm_coverage.sh
@@ -43,38 +43,86 @@ if [ -z "$LLVM_COV" ]; then
   exit 1
 fi
 
-# Merge profdata files from all jobs (skip corrupted files with -failure-mode=warn)
-echo "Merging profdata files..."
+# This script runs in two phases, invoked as separate job steps:
+#
+#   merge  - merge the per-shard profiles. A failure here means "this run has no
+#            complete measurement", which the job reports as SKIPPED, so the
+#            status is passed back in a marker file rather than as an exit code
+#            (praktika collapses a step's exit code to a boolean, which cannot
+#            distinguish this from a genuine tooling failure).
+#   report - llvm-cov export + genhtml. A failure here IS a tooling failure and
+#            must stay RED, so this phase keeps `set -e` and a non-zero exit.
+#
+# Both phases are accepted in one invocation ("all") for local use.
+PHASE="${1:-all}"
+case "$PHASE" in
+  merge|report|all) ;;
+  *) echo "ERROR: unknown phase '$PHASE' (expected merge, report or all)"; exit 1 ;;
+esac
 
 # Artifacts are downloaded to ci/tmp by the CI framework
 cd ci/tmp || { echo "ERROR: ci/tmp directory not found"; exit 1; }
 
-# List available profdata files for debugging
-echo "Available profdata files in $(pwd):"
-ls -lh *.profdata 2>/dev/null || echo "No profdata files found"
+MERGE_STATUS_FILE="merge_profdata.status"
+
+if [ "$PHASE" = "merge" ] || [ "$PHASE" = "all" ]; then
+  echo "Merging profdata files..."
+
+  # List available profdata files for debugging
+  echo "Available profdata files in $(pwd):"
+  ls -lh *.profdata 2>/dev/null || echo "No profdata files found"
+
+  # The files to merge are named after their coverage artifacts and passed in
+  # explicitly. An unrestricted `*.profdata` glob would also pick up this
+  # script's own merged.profdata from an earlier invocation, or a profile left
+  # under a stale name, and fold it into the total with nothing to notice it.
+  if [ -z "${MERGE_PROFDATA_FILES:-}" ]; then
+    echo "ERROR: MERGE_PROFDATA_FILES is not set, refusing to merge an unbounded glob"
+    exit 1
+  fi
+  read -ra PROFDATA_FILES <<< "${MERGE_PROFDATA_FILES}"
+  echo "Merging ${#PROFDATA_FILES[@]} profdata file(s): ${PROFDATA_FILES[*]}"
+
+  # --failure-mode=any makes the merge all-or-nothing: on any invalid input it
+  # exits non-zero and writes no file, instead of silently dropping that input
+  # and producing a total that is short by a whole shard. The clean path is
+  # byte-identical to =warn.
+  #
+  # `set -e` is lifted around the merge deliberately - the point is to observe
+  # its status, not to abort on it.
+  rm -f "$MERGE_STATUS_FILE" merged.profdata
+  set +e
+  "$LLVM_PROFDATA" merge -sparse -failure-mode=any "${PROFDATA_FILES[@]}" -o merged.profdata 2>&1
+  MERGE_EXIT_CODE=$?
+  set -e
+
+  if [ $MERGE_EXIT_CODE -eq 0 ] && [ -f merged.profdata ]; then
+      echo "Successfully merged coverage data to merged.profdata"
+      echo "ok" > "$MERGE_STATUS_FILE"
+  else
+      echo "ERROR: Failed to merge coverage files (exit code $MERGE_EXIT_CODE)"
+      echo "failed" > "$MERGE_STATUS_FILE"
+      # Deliberately exit 0 and produce no llvm_coverage.info: publishing nothing
+      # is what lets the job report SKIPPED with a reason instead of comparing a
+      # partial measurement. Never fabricate an .info to keep the job green.
+      exit 0
+  fi
+fi
+
+if [ "$PHASE" = "merge" ]; then
+  exit 0
+fi
+
+if [ ! -f merged.profdata ]; then
+  echo "merged.profdata is absent (the merge phase reported an incomplete measurement); nothing to report on"
+  exit 0
+fi
 
 echo "Checking for binaries..."
 ls -lh clickhouse unit_tests_dbms 2>/dev/null || echo "Warning: Some binaries not found"
 
 # Make binaries executable
 chmod +x clickhouse unit_tests_dbms 2>/dev/null || true
-
-MERGE_OUTPUT=$("$LLVM_PROFDATA" merge -sparse -failure-mode=warn *.profdata -o merged.profdata 2>&1)
-MERGE_EXIT_CODE=$?
-
-# Log corrupted files
-CORRUPTED_COUNT=$(echo "$MERGE_OUTPUT" | grep -c "invalid instrumentation profile\|file header is corrupt" || true)
-if [ "$CORRUPTED_COUNT" -gt 0 ]; then
-    echo "WARNING: Found $CORRUPTED_COUNT corrupted profdata files:"
-    echo "$MERGE_OUTPUT" | grep "invalid instrumentation profile\|file header is corrupt" || true
-fi
-
-if [ $MERGE_EXIT_CODE -eq 0 ] && [ -f merged.profdata ]; then
-    echo "Successfully merged coverage data to merged.profdata"
-else
-    echo "ERROR: Failed to merge coverage files"
-    exit 1
-fi
 
 ./clickhouse --version
 

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -111,6 +111,10 @@ _COVERAGE_PIPELINE_PATHS = (
     "ci/jobs/scripts/integration_tests_configs.py",
     "ci/jobs/scripts/merge_llvm_coverage.sh",
     "ci/jobs/scripts/generate_diff_coverage_report.sh",
+    "ci/jobs/scripts/llvm_coverage_completeness.py",
+    # Parses the marker that decides whether a functional coverage shard publishes
+    # its profile at all (functional_tests.py).
+    "ci/jobs/scripts/functional_tests_results.py",
     "ci/jobs/scripts/print_uncovered_code.py",
     "ci/jobs/scripts/dedup_lcov_instantiations.py",
     "ci/jobs/scripts/job_hooks/llvm_coverage_hook.py",

--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -33,34 +33,38 @@ if __name__ == "__main__":
     )
     profraw_files = [f.strip() for f in profraw_files if f.strip()]
 
-    # Name the profile after this job's own coverage artifact, so the aggregation
-    # can tell which shards arrived from the filenames alone. JOB_CONFIG has been
-    # through dump()/get() by the time a job body runs, so it is a plain dict
-    # here and attribute access on it raises AttributeError.
-    _job_config = Info().job_config
-    assert (
-        _job_config is not None
-    ), "JOB_CONFIG is not set, cannot derive the coverage profile name"
-    _provides = _job_config["provides"]
-    assert (
-        isinstance(_provides, list)
-        and len(_provides) == 1
-        and isinstance(_provides[0], str)
-        and _provides[0]
-    ), f"expected exactly one provided artifact name, got {_provides!r}"
-    merged_file = f"./{_provides[0]}.profdata"
-
-    # Drop any pre-existing profile at our target name before deciding whether to
-    # merge at all. llvm-profdata truncates its -o target in place instead of
-    # replacing it, so a failed merge would otherwise leave an older valid
-    # profile for the uploader to publish as this shard's contribution. On CI the
-    # pre-run `git clean` already removes it; this covers a bare local run, where
-    # that clean is skipped.
-    if os.path.exists(merged_file):
-        print(f"Removing pre-existing {merged_file}")
-        os.unlink(merged_file)
-
+    # All of the coverage bookkeeping below stays inside this guard. Only the one
+    # instrumented job declares a coverage artifact; the six sanitizer jobs emit no
+    # .profraw and declare none, and deriving a name there would assert between
+    # from_gtest_run() above and complete_job() below, losing the gtest result.
     if profraw_files:
+        # Name the profile after this job's own coverage artifact, so the aggregation
+        # can tell which shards arrived from the filenames alone. JOB_CONFIG has been
+        # through dump()/get() by the time a job body runs, so it is a plain dict
+        # here and attribute access on it raises AttributeError.
+        _job_config = Info().job_config
+        assert (
+            _job_config is not None
+        ), "JOB_CONFIG is not set, cannot derive the coverage profile name"
+        _provides = _job_config["provides"]
+        assert (
+            isinstance(_provides, list)
+            and len(_provides) == 1
+            and isinstance(_provides[0], str)
+            and _provides[0]
+        ), f"expected exactly one provided artifact name, got {_provides!r}"
+        merged_file = f"./{_provides[0]}.profdata"
+
+        # Drop any pre-existing profile at our target name before deciding whether to
+        # merge at all. llvm-profdata truncates its -o target in place instead of
+        # replacing it, so a failed merge would otherwise leave an older valid
+        # profile for the uploader to publish as this shard's contribution. On CI the
+        # pre-run `git clean` already removes it; this covers a bare local run, where
+        # that clean is skipped.
+        if os.path.exists(merged_file):
+            print(f"Removing pre-existing {merged_file}")
+            os.unlink(merged_file)
+
         # A zero-length .profraw is silently ignored by llvm-profdata at every
         # --failure-mode, so it would drop one process's coverage with no signal
         # at all. Treat it as an incomplete shard and publish no profile.

--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -33,6 +33,45 @@ if __name__ == "__main__":
     )
     profraw_files = [f.strip() for f in profraw_files if f.strip()]
 
+    # Name the profile after this job's own coverage artifact, so the aggregation
+    # can tell which shards arrived from the filenames alone. JOB_CONFIG has been
+    # through dump()/get() by the time a job body runs, so it is a plain dict
+    # here and attribute access on it raises AttributeError.
+    _job_config = Info().job_config
+    assert (
+        _job_config is not None
+    ), "JOB_CONFIG is not set, cannot derive the coverage profile name"
+    _provides = _job_config["provides"]
+    assert (
+        isinstance(_provides, list)
+        and len(_provides) == 1
+        and isinstance(_provides[0], str)
+        and _provides[0]
+    ), f"expected exactly one provided artifact name, got {_provides!r}"
+    merged_file = f"./{_provides[0]}.profdata"
+
+    # Drop any pre-existing profile at our target name before deciding whether to
+    # merge at all. llvm-profdata truncates its -o target in place instead of
+    # replacing it, so a failed merge would otherwise leave an older valid
+    # profile for the uploader to publish as this shard's contribution. On CI the
+    # pre-run `git clean` already removes it; this covers a bare local run, where
+    # that clean is skipped.
+    if os.path.exists(merged_file):
+        print(f"Removing pre-existing {merged_file}")
+        os.unlink(merged_file)
+
+    if profraw_files:
+        # A zero-length .profraw is silently ignored by llvm-profdata at every
+        # --failure-mode, so it would drop one process's coverage with no signal
+        # at all. Treat it as an incomplete shard and publish no profile.
+        empty_files = [f for f in profraw_files if os.path.getsize(f) == 0]
+        if empty_files:
+            print(
+                f"ERROR: {len(empty_files)} .profraw files are empty, so this shard's coverage "
+                f"is incomplete; publishing no profile: {', '.join(empty_files)}"
+            )
+            profraw_files = []
+
     if profraw_files:
         # Merge profraw files into profdata
         print("Collecting and merging LLVM coverage files...")
@@ -51,21 +90,13 @@ if __name__ == "__main__":
         else:
             print(f"Using {llvm_profdata} to merge coverage files")
 
-            # Merge all profraw files to current directory
-            merged_file = "./unit-tests.profdata"
-            merge_cmd = f"{llvm_profdata} merge -sparse -failure-mode=warn {' '.join(profraw_files)} -o {merged_file} 2>&1"
+            # --failure-mode=any makes the merge all-or-nothing: on any invalid
+            # input it exits non-zero and writes no file, so the shard is simply
+            # absent instead of contributing a silently short profile that drags
+            # the total down. The clean path is byte-identical to =warn.
+            merge_cmd = f"{llvm_profdata} merge -sparse -failure-mode=any {' '.join(profraw_files)} -o {merged_file} 2>&1"
             merge_output = Shell.get_output(merge_cmd, verbose=True)
-
-            # Check for corrupted files in the output
-            corrupted_files = [
-                line
-                for line in merge_output.split("\n")
-                if "invalid instrumentation profile" in line
-                or "file header is corrupt" in line
-            ]
-            if corrupted_files:
-                print(f"WARNING: Found {len(corrupted_files)} corrupted profraw files:")
-                for corrupted in corrupted_files:
-                    print(f"  {corrupted}")
+            if not os.path.exists(merged_file):
+                print(f"ERROR: coverage merge produced no profile:\n{merge_output}")
 
     R.complete_job()

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -95,6 +95,9 @@ class Runner:
             PR_LABELS=[],
             EVENT_TIME="",
             WORKFLOW_CONFIG=workflow_config,
+            # Mirror _setup_env: a job body may read its own configuration (e.g. to
+            # derive an output filename from `provides`), which is None here otherwise.
+            JOB_CONFIG=job,
         ).dump()
 
         if pr and pr > 0:

--- a/ci/tests/test_llvm_coverage_completeness.py
+++ b/ci/tests/test_llvm_coverage_completeness.py
@@ -1,0 +1,1035 @@
+"""
+Regression tests for the LLVM coverage completeness protocol.
+
+Background
+----------
+The coverage diff gate compares a baseline coverage percentage against the
+current one. Both are merged from per-shard `.profdata` artifacts that are
+deliberately `optional=True`, and nothing validated that either side had all of
+them. That is wrong in two directions:
+
+* the PR side is short a shard, the total drops, and an unrelated PR is failed
+  for a coverage regression it did not cause;
+* the BASELINE is short a shard, its total is low, and a real regression passes.
+
+The second direction is the worse one and produces a PASS, so it leaves no trace
+in the failure counts at all.
+
+These tests pin the contract: a verdict, and every number derived from it, is
+produced only from two complete measurements of the same artifact manifest;
+otherwise the job reports SKIPPED with a reason and stays green.
+
+Every row drives the production module, never a copy of its logic.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+# ci.praktika must be imported first: its __init__ puts ci/ on sys.path, which
+# ci.defs.defs needs for its bare `from praktika import ...`.
+from ci.praktika.job import Job
+from ci.praktika.result import Result
+from ci.defs.defs import LLVM_ARTIFACTS_LIST, ArtifactConfigs
+from ci.jobs.scripts import llvm_coverage_completeness as completeness
+
+_CI_ROOT = os.path.join(os.path.dirname(__file__), "..")
+_REPO_ROOT = os.path.join(_CI_ROOT, "..")
+_JOB = os.path.join(_CI_ROOT, "jobs", "llvm_coverage_job.py")
+_MERGE_SH = os.path.join(_CI_ROOT, "jobs", "scripts", "merge_llvm_coverage.sh")
+_SELECT_SH = os.path.join(
+    _CI_ROOT, "jobs", "scripts", "generate_diff_coverage_report.sh"
+)
+_UT_JOB = os.path.join(_CI_ROOT, "jobs", "unit_tests_job.py")
+_FT_JOB = os.path.join(_CI_ROOT, "jobs", "functional_tests.py")
+_IT_JOB = os.path.join(_CI_ROOT, "jobs", "integration_test_job.py")
+_FT_RESULTS = os.path.join(_CI_ROOT, "jobs", "scripts", "functional_tests_results.py")
+_CH_TEST = os.path.join(_REPO_ROOT, "tests", "clickhouse-test")
+_FILTER_JOB = os.path.join(
+    _CI_ROOT, "jobs", "scripts", "workflow_hooks", "filter_job.py"
+)
+_JOB_CONFIGS = os.path.join(_CI_ROOT, "defs", "job_configs.py")
+
+# A representative manifest. The real one has 21 entries today and has grown
+# 18 -> 20 -> 21, which is exactly the drift `manifest_fp` exists to catch.
+_NAMES = [f"LLVM_COVERAGE_FILE_shard_{i}" for i in range(1, 22)]
+_ALL_PRESENT = [completeness.profile_basename(n) for n in _NAMES]
+
+
+def _sidecar(names=None, present=None, merge_ok=True, info_path=""):
+    return completeness.build_sidecar(
+        names if names is not None else _NAMES,
+        present if present is not None else _ALL_PRESENT,
+        info_path=info_path,
+        merge_ok=merge_ok,
+    )
+
+
+# --------------------------------------------------------------------------
+# Row 1: both sides complete and matching -> a verdict is produced
+# --------------------------------------------------------------------------
+
+
+def test_two_complete_matching_measurements_are_comparable():
+    ok, reason = completeness.comparable(_sidecar(), _sidecar())
+    assert ok is True
+    assert reason == ""
+
+
+# --------------------------------------------------------------------------
+# Row 2: PR side short -> SKIPPED, and the reason names the missing shard
+# --------------------------------------------------------------------------
+
+
+def test_short_pr_side_is_not_comparable():
+    short = _ALL_PRESENT[:-1]
+    ok, reason = completeness.comparable(_sidecar(present=short), _sidecar())
+    assert ok is False
+    assert "PR-side" in reason
+    assert _ALL_PRESENT[-1] in reason
+
+
+# --------------------------------------------------------------------------
+# Row 3: BASELINE short while our side is complete -> SKIPPED, not PASS.
+# The masked-regression direction; the most important assertion in this file.
+# --------------------------------------------------------------------------
+
+
+def test_short_baseline_is_not_comparable():
+    baseline = _sidecar(present=_ALL_PRESENT[:1])  # the measured 1-of-21 shape
+    ok, reason = completeness.comparable(_sidecar(), baseline)
+    assert ok is False
+    assert "baseline" in reason
+    assert "incomplete" in reason
+
+
+def test_short_baseline_would_otherwise_look_like_an_improvement():
+    # Why row 3 matters: a 1-of-21 baseline reads far LOWER than a complete
+    # current side, so the raw comparison is a coverage *increase* and any real
+    # regression inside it passes unnoticed.
+    from ci.jobs.llvm_coverage_job import coverage_degraded, coverage_drop
+
+    assert not coverage_degraded(coverage_drop(28.6, 86.4))
+
+
+# --------------------------------------------------------------------------
+# Row 4: manifest drift -> SKIPPED even though both sides are internally complete
+# --------------------------------------------------------------------------
+
+
+def test_manifest_change_is_not_comparable():
+    old_names = _NAMES[:18]  # the real 18 -> 21 growth
+    baseline = _sidecar(
+        names=old_names,
+        present=[completeness.profile_basename(n) for n in old_names],
+    )
+    assert baseline["complete"] is True
+    ok, reason = completeness.comparable(_sidecar(), baseline)
+    assert ok is False
+    assert "manifest" in reason
+
+
+def test_manifest_fingerprint_is_order_independent_and_content_sensitive():
+    assert completeness.manifest_fingerprint(_NAMES) == completeness.manifest_fingerprint(
+        list(reversed(_NAMES))
+    )
+    assert completeness.manifest_fingerprint(_NAMES) != completeness.manifest_fingerprint(
+        _NAMES[:-1]
+    )
+
+
+# --------------------------------------------------------------------------
+# Row 5: no baseline sidecar at all -> SKIPPED, never an exception.
+# Back-compat: no master commit published before this change has one.
+# --------------------------------------------------------------------------
+
+
+def test_missing_baseline_sidecar_is_not_comparable_and_does_not_raise():
+    ok, reason = completeness.comparable(_sidecar(), None)
+    assert ok is False
+    assert "no completeness metadata" in reason
+
+
+def test_reading_an_absent_sidecar_returns_none():
+    with tempfile.TemporaryDirectory() as d:
+        assert completeness.read_sidecar(os.path.join(d, "nope.json")) is None
+
+
+def test_reading_a_corrupt_sidecar_returns_none_instead_of_raising():
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, "llvm_coverage.meta.json")
+        with open(p, "w") as f:
+            f.write("{not json")
+        assert completeness.read_sidecar(p) is None
+
+
+# --------------------------------------------------------------------------
+# Row 6: unknown/newer schema version -> SKIPPED, not an exception
+# --------------------------------------------------------------------------
+
+
+def test_newer_baseline_schema_version_is_not_comparable():
+    baseline = _sidecar()
+    baseline["schema_version"] = completeness.SCHEMA_VERSION + 1
+    ok, reason = completeness.comparable(_sidecar(), baseline)
+    assert ok is False
+    assert "schema version" in reason
+
+
+# --------------------------------------------------------------------------
+# Row 7: an EXTRA/foreign profile makes the measurement INCOMPLETE.
+# Passes only under set EQUALITY; a set difference accepts extras.
+# --------------------------------------------------------------------------
+
+
+def test_extra_foreign_profile_makes_the_measurement_incomplete():
+    with_extra = _ALL_PRESENT + ["merged.profdata"]
+    s = _sidecar(present=with_extra)
+    assert s["complete"] is False
+    assert s["missing"] == []
+    assert s["unexpected"] == ["merged.profdata"]
+    ok, reason = completeness.comparable(s, _sidecar())
+    assert ok is False
+    assert "unexpected" in reason
+
+
+def test_a_set_difference_would_accept_the_extra():
+    # Pins WHY equality is required: `expected - present` is empty here, so a
+    # difference-based predicate would call this complete.
+    expected = set(_ALL_PRESENT)
+    present = set(_ALL_PRESENT + ["merged.profdata"])
+    assert expected - present == set()
+    assert expected != present
+
+
+# --------------------------------------------------------------------------
+# Row 7b: the merge is given an explicit list, never a glob
+# --------------------------------------------------------------------------
+
+
+def test_merge_inputs_are_manifest_derived_and_exclude_foreign_files():
+    inputs = completeness.merge_inputs(
+        _NAMES, _ALL_PRESENT + ["merged.profdata", "stale-name.profdata"]
+    )
+    assert inputs == sorted(_ALL_PRESENT)
+    assert "merged.profdata" not in inputs
+    assert "stale-name.profdata" not in inputs
+
+
+def test_merge_script_refuses_an_unbounded_glob():
+    src = open(_MERGE_SH, encoding="utf-8").read()
+    assert "MERGE_PROFDATA_FILES" in src
+    assert "refusing to merge an unbounded glob" in src
+    # The old unrestricted glob must be gone from the merge invocation.
+    assert "-failure-mode=any" in src
+    assert "*.profdata -o merged.profdata" not in src
+
+
+def test_job_passes_the_intersection_to_the_merge_step():
+    src = open(_JOB, encoding="utf-8").read()
+    assert "completeness.merge_inputs(" in src
+    assert "MERGE_PROFDATA_FILES=" in src
+
+
+# --------------------------------------------------------------------------
+# Row 7c: a legitimately absent optional shard still merges the rest
+# --------------------------------------------------------------------------
+
+
+def test_twenty_of_twenty_one_still_merges_those_twenty_but_skips_the_verdict():
+    present = _ALL_PRESENT[:-1]
+    inputs = completeness.merge_inputs(_NAMES, present)
+    assert len(inputs) == 20  # the merge is not starved
+    ok, _ = completeness.comparable(_sidecar(present=present), _sidecar())
+    assert ok is False  # but no verdict is produced
+
+
+# --------------------------------------------------------------------------
+# Row 8: a producer with no profile at all is "absent", not "complete with zero"
+# --------------------------------------------------------------------------
+
+
+def test_no_profiles_at_all_is_incomplete_not_complete_with_zero():
+    s = _sidecar(present=[])
+    assert s["complete"] is False
+    assert len(s["missing"]) == len(_NAMES)
+
+
+def test_present_profiles_snapshot_ignores_non_profdata_files():
+    with tempfile.TemporaryDirectory() as d:
+        for name in ("a.profdata", "b.profdata", "notes.txt", "clickhouse"):
+            with open(os.path.join(d, name), "w") as f:
+                f.write("x")
+        os.mkdir(os.path.join(d, "dir.profdata"))
+        assert completeness.present_profiles(d) == ["a.profdata", "b.profdata"]
+
+
+# --------------------------------------------------------------------------
+# Rows 8b / 8c / 8d / 15: a shard that did not complete publishes NO profile,
+# while a completed run WITH failing tests still publishes its profile.
+# --------------------------------------------------------------------------
+
+
+def _ft_completion(runner_output: str) -> bool:
+    """Drive the real FT parser over a runner transcript."""
+    sys.path.insert(0, _CI_ROOT)
+    from ci.jobs.scripts.functional_tests_results import FTResultsProcessor
+
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "test_result.txt"), "w") as f:
+            f.write(runner_output)
+        return FTResultsProcessor(wd=d)._process_test_output().coverage_run_complete
+
+
+def _ft_success_finish(runner_output: str) -> bool:
+    sys.path.insert(0, _CI_ROOT)
+    from ci.jobs.scripts.functional_tests_results import FTResultsProcessor
+
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "test_result.txt"), "w") as f:
+            f.write(runner_output)
+        return FTResultsProcessor(wd=d)._process_test_output().success_finish
+
+
+_OK_LINE = "00001_test: [ OK ] 0.10 sec.\n"
+_FAIL_LINE = "00002_test: [ FAIL ] 0.10 sec.\n"
+_COMPLETE = "Coverage run completed all selected tests.\n"
+
+
+def test_completed_run_with_failing_tests_still_publishes_its_profile():
+    # 8c: the discriminating row. A gate keyed on "no test failed" would pass
+    # every other cell here while silently DELETING coverage on the common path.
+    out = _OK_LINE + _FAIL_LINE + _COMPLETE + "All tests have finished.\n"
+    assert _ft_completion(out) is True
+
+
+def test_zero_test_run_publishes_no_profile():
+    # 8d: `No tests were run.` sets success_finish True and exits 1, and the
+    # instrumented server still wrote .profraw files, so a predicate keyed on
+    # success_finish would publish a startup-only profile.
+    out = "No tests were run.\n"
+    assert _ft_completion(out) is False
+    assert _ft_success_finish(out) is True
+
+
+def test_run_that_died_mid_way_publishes_no_profile():
+    out = _OK_LINE + _OK_LINE
+    assert _ft_completion(out) is False
+    assert _ft_success_finish(out) is False
+
+
+def test_killed_worker_run_publishes_no_profile_even_though_the_legacy_marker_printed():
+    # 15: the r19 regression test. A worker that dies abnormally only sets
+    # runner_process_killed, while the counter tested at the end is the SELECTED
+    # test count, so `All tests have finished.` is printed anyway.
+    out = _OK_LINE + "All tests have finished.\n"
+    assert _ft_success_finish(out) is True
+    assert _ft_completion(out) is False
+
+
+def test_success_finish_semantics_are_unchanged():
+    # The new field is additive: success_finish keeps its own contract, which
+    # three unrelated call sites depend on.
+    from ci.jobs.scripts.functional_tests_results import SUCCESS_FINISH_SIGNS
+
+    assert SUCCESS_FINISH_SIGNS == ["All tests have finished", "No tests were run"]
+
+
+def test_runner_emits_the_marker_only_when_it_completed_and_kept_its_workers():
+    src = open(_CH_TEST, encoding="utf-8").read()
+    assert "Coverage run completed all selected tests." in src
+    # Both halves of the predicate must be present, and the existing marker text
+    # and exit contract untouched.
+    idx = src.index("Coverage run completed all selected tests.")
+    window = src[idx - 400 : idx]
+    assert "total_tests_run != 0" in window
+    assert "runner_process_killed.is_set()" in window
+    assert 'print("All tests have finished.")' in src
+    assert 'print("No tests were run.")' in src
+
+
+def test_ft_job_gates_profile_creation_not_attachment():
+    # The r5 no-op: skipping `R.files.append` leaves the file on disk, where the
+    # runner's own glob still uploads it. The gate must sit on the merge.
+    src = open(_FT_JOB, encoding="utf-8").read()
+    assert 'coverage_run_complete' in src
+    gate = src.index('_coverage_run_complete = bool(')
+    merge = src.index('merge -sparse -failure-mode=any')
+    append = src.index('R.files.append(merged_file)')
+    assert gate < merge < append
+
+
+def test_integration_job_snapshots_completion_before_the_coverage_block():
+    src = open(_IT_JOB, encoding="utf-8").read()
+    snapshot = src.index("coverage_run_complete = coverage_phases_complete")
+    coverage_block = src.index("    if is_llvm_coverage:\n        assert (")
+    merge_call = src.index("merged_profdata = merge_profraw_files(")
+    # The coverage block resets has_error, so a later read answers a different
+    # question; and the merge site must consult the snapshot, not re-derive it.
+    assert snapshot < coverage_block < merge_call
+    assert "if not coverage_run_complete:" in src
+
+
+def test_integration_job_records_the_silent_phase_drop():
+    # Route 5a: the MAX_FAILS_BEFORE_DROP skip sets no termination status of its
+    # own, so it must be recorded where the decision is made.
+    src = open(_IT_JOB, encoding="utf-8").read()
+    assert "coverage_phases_complete = False" in src
+    assert "MAX_FAILS_BEFORE_DROP and not has_error" in src
+
+
+# --------------------------------------------------------------------------
+# Rows 9b / route 6: a zero-length raw makes the shard incomplete, and the
+# premise (the tool ignores it silently) is asserted by measurement.
+# --------------------------------------------------------------------------
+
+
+def _find_tool(base):
+    """First available versioned spelling of an LLVM tool, mirroring the jobs."""
+    for ver in ["21", "20", "19", "18", "17", "16", ""]:
+        cmd = f"{base}{'-' + ver if ver else ''}"
+        found = shutil.which(cmd)
+        if found:
+            return found
+    return None
+
+
+def test_zero_length_raw_is_silently_ignored_by_the_tool():
+    # The PREMISE behind the explicit zero-length filter: --failure-mode=any does
+    # NOT cover this, so the producers must reject it themselves.
+    tool = _find_tool("llvm-profdata")
+    clang = _find_tool("clang")
+    if not tool or not clang:
+        return  # no LLVM toolchain in this environment
+    with tempfile.TemporaryDirectory() as d:
+        src = os.path.join(d, "t.c")
+        with open(src, "w") as f:
+            f.write("int main(){return 0;}\n")
+        exe = os.path.join(d, "t")
+        if subprocess.run(
+            [clang, "-fprofile-instr-generate", "-fcoverage-mapping", src, "-o", exe],
+            capture_output=True,
+        ).returncode != 0:
+            return
+        good = os.path.join(d, "good.profraw")
+        env = dict(os.environ, LLVM_PROFILE_FILE=good)
+        subprocess.run([exe], env=env, capture_output=True)
+        if not os.path.exists(good):
+            return
+        empty = os.path.join(d, "empty.profraw")
+        open(empty, "w").close()
+
+        only_good = os.path.join(d, "a.profdata")
+        with_empty = os.path.join(d, "b.profdata")
+        r1 = subprocess.run(
+            [tool, "merge", "-sparse", "-failure-mode=any", good, "-o", only_good],
+            capture_output=True,
+        )
+        r2 = subprocess.run(
+            [tool, "merge", "-sparse", "-failure-mode=any", good, empty, "-o", with_empty],
+            capture_output=True,
+        )
+        assert r1.returncode == 0
+        # The tool accepts the empty input and produces the same merge: no signal.
+        assert r2.returncode == 0
+        assert open(only_good, "rb").read() == open(with_empty, "rb").read()
+
+
+def test_every_producer_rejects_zero_length_raw_inputs():
+    for path in (_UT_JOB, _FT_JOB, _IT_JOB):
+        src = open(path, encoding="utf-8").read()
+        assert "getsize(f) == 0" in src, path
+        assert "are empty" in src, path
+
+
+def test_every_producer_merge_is_all_or_nothing():
+    for path in (_UT_JOB, _FT_JOB, _IT_JOB):
+        src = open(path, encoding="utf-8").read()
+        assert "-failure-mode=any" in src, path
+        assert "-failure-mode=warn" not in src, path
+
+
+def test_producers_no_longer_parse_corrupt_strings():
+    # Obsolete once the merge is all-or-nothing: a corrupt input produces no
+    # file, so there is nothing to classify by message text.
+    for path in (_UT_JOB, _FT_JOB, _IT_JOB):
+        src = open(path, encoding="utf-8").read()
+        assert "invalid instrumentation profile" not in src, path
+        assert "file header is corrupt" not in src, path
+
+
+# --------------------------------------------------------------------------
+# Row 9c: the UT producer needs no completion gate - the runner already
+# prevents the upload. Asserted structurally.
+# --------------------------------------------------------------------------
+
+
+def test_unit_test_job_relies_on_the_runner_to_withhold_a_failed_shards_profile():
+    src = open(_UT_JOB, encoding="utf-8").read()
+    # No do_not_block_pipeline_on_failure, so a non-OK result exits 1 ...
+    assert "R.complete_job()" in src
+    assert "do_not_block_pipeline_on_failure" not in src
+    runner = open(
+        os.path.join(_CI_ROOT, "praktika", "runner.py"), encoding="utf-8"
+    ).read()
+    # ... and the runner then skips artifact upload entirely.
+    assert "run_exit_code == 0 or result.do_not_block_pipeline_on_failure()" in runner
+
+
+# --------------------------------------------------------------------------
+# Rows 10b / 10c / 10d: the fabricated numbers are withheld on every surface
+# --------------------------------------------------------------------------
+
+
+def test_no_coverage_comment_or_cidb_row_when_incomparable():
+    src = open(_JOB, encoding="utf-8").read()
+    assert "_has_coverage_data = _diff_ran and _measurement_comparable" in src
+
+
+def test_master_path_writes_no_cidb_row_for_an_incomplete_measurement():
+    # The post-hook's non-PR branch still inserts, so gating only the comment
+    # would keep poisoning the baseline series every later PR compares against.
+    src = open(_JOB, encoding="utf-8").read()
+    assert 'if not is_local_run and not _sidecar["complete"]:' in src
+
+
+def test_uncovered_code_analysis_is_skipped_when_incomparable():
+    src = open(_JOB, encoding="utf-8").read()
+    assert "if _diff_inputs_exist and not _measurement_comparable:" in src
+    # ... and its counts block is withheld too.
+    assert "if _diff_ran and _measurement_comparable:" in src
+
+
+def test_differential_report_is_withheld_but_the_full_report_is_only_labelled():
+    src = open(_JOB, encoding="utf-8").read()
+    # differential: attachment and link both gated
+    assert "llvm_coverage_diff_html_report.tar.gz" in src
+    assert "if _diff_ran and _measurement_comparable:" in src
+    # full report: still attached, with an explicit partial banner. It is the
+    # best artifact for finding out WHICH shard went missing.
+    assert "partial measurement:" in src
+
+
+def test_baseline_info_digest_detects_a_torn_pair():
+    with tempfile.TemporaryDirectory() as d:
+        info = os.path.join(d, "base_llvm_coverage.info")
+        with open(info, "w") as f:
+            f.write("SF:/a.cpp\nDA:1,1\nend_of_record\n")
+        baseline = _sidecar(info_path=info)
+        assert baseline["info_digest"]
+        # Same-SHA rerun replaced the .info but not the sidecar.
+        with open(info, "w") as f:
+            f.write("SF:/a.cpp\nDA:1,0\nend_of_record\n")
+        ok, reason = completeness.comparable(
+            _sidecar(), baseline, baseline_info_path=info
+        )
+        assert ok is False
+        assert "does not describe" in reason
+
+
+def test_absent_info_digest_does_not_block_a_complete_baseline():
+    baseline = _sidecar()  # no info_path -> digest ""
+    ok, _ = completeness.comparable(_sidecar(), baseline, baseline_info_path="")
+    assert ok is True
+
+
+# --------------------------------------------------------------------------
+# Rows 12 / 13: an aggregate MERGE failure is SKIPPED and green; a genuine
+# REPORT failure stays RED. One cell cannot distinguish them.
+# --------------------------------------------------------------------------
+
+
+def test_failed_aggregate_merge_is_not_comparable():
+    ok, reason = completeness.comparable(_sidecar(merge_ok=False), _sidecar())
+    assert ok is False
+    assert "merge failed" in reason
+
+
+def test_merge_and_report_are_separate_job_steps():
+    src = open(_JOB, encoding="utf-8").read()
+    assert 'name="Merge LLVM Coverage Profiles"' in src
+    assert "merge_llvm_coverage.sh merge" in src
+    assert "merge_llvm_coverage.sh report" in src
+    # The merge status is read from a marker, because a step's exit code is
+    # collapsed to a boolean and could not distinguish the two failures.
+    assert "merge_profdata.status" in src
+
+
+def _run_merge_phase(profdata_ok: bool, files="a.profdata"):
+    """Drive the real merge phase against a synthetic llvm-profdata.
+
+    Returns (exit_code, marker_contents, info_exists). A shim is used because the
+    property under test is how the script REACTS to a failing merge, not what
+    llvm-profdata does (that is measured separately).
+    """
+    with tempfile.TemporaryDirectory() as d:
+        bin_dir = os.path.join(d, "bin")
+        os.makedirs(bin_dir)
+        shim = os.path.join(bin_dir, "llvm-profdata")
+        with open(shim, "w") as f:
+            if profdata_ok:
+                # Honour -o like the real tool does.
+                f.write(
+                    "#!/bin/bash\nwhile [ $# -gt 0 ]; do"
+                    ' if [ "$1" = "-o" ]; then echo data > "$2"; fi; shift; done\nexit 0\n'
+                )
+            else:
+                f.write('#!/bin/bash\necho "error: no profile can be merged" >&2\nexit 1\n')
+        os.chmod(shim, 0o755)
+        with open(os.path.join(bin_dir, "llvm-cov"), "w") as f:
+            f.write("#!/bin/bash\nexit 0\n")
+        os.chmod(os.path.join(bin_dir, "llvm-cov"), 0o755)
+
+        work = os.path.join(d, "work")
+        os.makedirs(os.path.join(work, "ci", "tmp"))
+        for name in files.split():
+            open(os.path.join(work, "ci", "tmp", name), "w").close()
+        shutil.copy2(_MERGE_SH, os.path.join(work, "merge.sh"))
+
+        env = dict(
+            os.environ,
+            PATH=bin_dir + os.pathsep + os.environ["PATH"],
+            MERGE_PROFDATA_FILES=files,
+            LLVM_PROFDATA=shim,
+            LLVM_COV=os.path.join(bin_dir, "llvm-cov"),
+        )
+        r = subprocess.run(
+            ["bash", "merge.sh", "merge"], cwd=work, env=env, capture_output=True, text=True
+        )
+        marker = os.path.join(work, "ci", "tmp", "merge_profdata.status")
+        return (
+            r.returncode,
+            open(marker).read().strip() if os.path.exists(marker) else None,
+            os.path.exists(os.path.join(work, "ci", "tmp", "llvm_coverage.info")),
+        )
+
+
+def test_merge_phase_reports_failure_without_reddening_and_without_faking_an_info():
+    # 12: a failed aggregate merge must leave the job GREEN with an explicit
+    # reason, not RED, and must fabricate no .info to get there.
+    rc, marker, info_exists = _run_merge_phase(profdata_ok=False)
+    assert rc == 0, "a merge failure must not redden the step"
+    assert marker == "failed"
+    assert info_exists is False
+
+
+def test_merge_phase_reports_success_through_the_same_marker():
+    rc, marker, _ = _run_merge_phase(profdata_ok=True)
+    assert rc == 0
+    assert marker == "ok"
+
+
+def test_merge_phase_refuses_an_unset_file_list():
+    # Without the explicit list the script would fall back to a glob, which is
+    # route 3; it must refuse instead.
+    with tempfile.TemporaryDirectory() as d:
+        work = os.path.join(d, "work")
+        os.makedirs(os.path.join(work, "ci", "tmp"))
+        shutil.copy2(_MERGE_SH, os.path.join(work, "merge.sh"))
+        env = {k: v for k, v in os.environ.items() if k != "MERGE_PROFDATA_FILES"}
+        env["LLVM_PROFDATA"] = "/bin/true"
+        env["LLVM_COV"] = "/bin/true"
+        r = subprocess.run(
+            ["bash", "merge.sh", "merge"], cwd=work, env=env, capture_output=True, text=True
+        )
+        assert r.returncode != 0
+        assert "unbounded glob" in r.stdout + r.stderr
+
+
+def test_report_phase_still_fails_hard():
+    # 13: the counterpart to row 12. A genuine report-generation failure is a
+    # tooling failure and must stay RED; one cell cannot show both.
+    with tempfile.TemporaryDirectory() as d:
+        bin_dir = os.path.join(d, "bin")
+        os.makedirs(bin_dir)
+        for name, body in (
+            ("llvm-profdata", "#!/bin/bash\nexit 0\n"),
+            # llvm-cov export fails: this is NOT an incompleteness signal.
+            ("llvm-cov", '#!/bin/bash\nif [ "$1" = "export" ]; then exit 3; fi\nexit 0\n'),
+        ):
+            p_ = os.path.join(bin_dir, name)
+            with open(p_, "w") as f:
+                f.write(body)
+            os.chmod(p_, 0o755)
+        work = os.path.join(d, "work")
+        os.makedirs(os.path.join(work, "ci", "tmp"))
+        # merged.profdata present, so the report phase proceeds past its guard.
+        open(os.path.join(work, "ci", "tmp", "merged.profdata"), "w").close()
+        open(os.path.join(work, "ci", "tmp", "clickhouse"), "w").close()
+        shutil.copy2(_MERGE_SH, os.path.join(work, "merge.sh"))
+        env = dict(
+            os.environ,
+            PATH=bin_dir + os.pathsep + os.environ["PATH"],
+            LLVM_PROFDATA=os.path.join(bin_dir, "llvm-profdata"),
+            LLVM_COV=os.path.join(bin_dir, "llvm-cov"),
+            WORKSPACE_PATH=work,
+        )
+        r = subprocess.run(
+            ["bash", "merge.sh", "report"], cwd=work, env=env, capture_output=True, text=True
+        )
+        assert r.returncode != 0, "a report-generation failure must stay RED"
+
+
+def test_report_phase_does_nothing_when_the_merge_produced_no_profile():
+    # The merge phase legitimately leaves no merged.profdata; the report phase must
+    # then exit cleanly rather than throwing on the absent input.
+    with tempfile.TemporaryDirectory() as d:
+        work = os.path.join(d, "work")
+        os.makedirs(os.path.join(work, "ci", "tmp"))
+        shutil.copy2(_MERGE_SH, os.path.join(work, "merge.sh"))
+        env = dict(os.environ, LLVM_PROFDATA="/bin/true", LLVM_COV="/bin/true")
+        r = subprocess.run(
+            ["bash", "merge.sh", "report"], cwd=work, env=env, capture_output=True, text=True
+        )
+        assert r.returncode == 0
+        assert "nothing to report on" in r.stdout
+
+
+def test_the_scripts_are_syntactically_valid():
+    for path in (_MERGE_SH, _SELECT_SH):
+        assert (
+            subprocess.run(["bash", "-n", path], capture_output=True).returncode == 0
+        ), path
+
+
+# --------------------------------------------------------------------------
+# Row 14: a missing llvm_coverage.info must not turn the JOB into ERROR
+# --------------------------------------------------------------------------
+
+
+def test_coverage_info_artifact_is_optional_so_a_skipped_verdict_survives():
+    # runner.py re-checks artifact paths AFTER the job exits and raises
+    # FileNotFoundError -> ERROR for a missing non-optional path, which would
+    # override the job's own SKIPPED.
+    assert ArtifactConfigs.llvm_coverage_info_file.optional is True
+
+
+def test_the_sidecar_rides_on_the_existing_artifact_so_no_new_name_is_introduced():
+    paths = ArtifactConfigs.llvm_coverage_info_file.path
+    assert isinstance(paths, list)
+    assert any(p.endswith("llvm_coverage.info") for p in paths)
+    assert any(p.endswith(completeness.SIDECAR_BASENAME) for p in paths)
+
+
+def test_job_treats_an_absent_info_as_incomplete_rather_than_comparing_nothing():
+    src = open(_JOB, encoding="utf-8").read()
+    assert 'if not Path(f"{TEMP_DIR}/llvm_coverage.info").exists():' in src
+    assert "nothing to compare" in src
+
+
+# --------------------------------------------------------------------------
+# Row 11: the producer-side filename and the consumer-side expected name agree,
+# driven through a real dump()/get() round-trip.
+# --------------------------------------------------------------------------
+
+
+def _round_trip_job_config(provides):
+    """Return Info().job_config as a job body really sees it."""
+    from ci.praktika._environment import _Environment
+
+    os.makedirs("ci/tmp", exist_ok=True)
+    jc = Job.Config(name="ut", runs_on=["x"], command="c", provides=provides)
+    _Environment(
+        WORKFLOW_NAME="w",
+        JOB_NAME="ut",
+        REPOSITORY="a/b",
+        BRANCH="master",
+        SHA="deadbeef",
+        PR_NUMBER=0,
+        EVENT_TYPE="push",
+        JOB_OUTPUT_STREAM="",
+        EVENT_FILE_PATH="",
+        CHANGE_URL="",
+        COMMIT_URL="",
+        BASE_BRANCH="",
+        RUN_URL="",
+        RUN_ID="",
+        INSTANCE_ID="",
+        INSTANCE_TYPE="",
+        INSTANCE_LIFE_CYCLE="",
+        LOCAL_RUN=False,
+        PR_BODY="",
+        PR_TITLE="",
+        USER_LOGIN="",
+        FORK_NAME="",
+        PR_LABELS=[],
+        EVENT_TIME="",
+        JOB_CONFIG=jc,
+    ).dump()
+    return _Environment.get().JOB_CONFIG
+
+
+def test_job_config_survives_serialization_only_as_a_dict():
+    # An in-memory Job.Config passes under BOTH the attribute and the subscript
+    # spelling, so an in-memory cell here would be vacuous. This drives the real
+    # round-trip, which is where the attribute spelling breaks.
+    cwd = os.getcwd()
+    try:
+        os.chdir(_REPO_ROOT)
+        got = _round_trip_job_config(["LLVM_COVERAGE_FILE_ut"])
+    finally:
+        os.chdir(cwd)
+    assert isinstance(got, dict)
+    assert got["provides"][0] == "LLVM_COVERAGE_FILE_ut"
+    try:
+        got.provides
+        raise AssertionError("attribute access unexpectedly worked")
+    except AttributeError:
+        pass
+
+
+def test_producer_and_consumer_agree_on_the_profile_name():
+    name = "LLVM_COVERAGE_FILE_ut"
+    cwd = os.getcwd()
+    try:
+        os.chdir(_REPO_ROOT)
+        got = _round_trip_job_config([name])
+    finally:
+        os.chdir(cwd)
+    producer_side = f"./{got['provides'][0]}.profdata"
+    consumer_side = completeness.profile_basename(name)
+    assert os.path.basename(producer_side) == consumer_side
+
+
+def test_every_producer_reads_provides_as_a_dict_key():
+    for path in (_UT_JOB, _FT_JOB, _IT_JOB):
+        src = open(path, encoding="utf-8").read()
+        assert '["provides"]' in src, path
+        assert ".job_config.provides" not in src, path
+
+
+def test_local_runs_get_a_job_config_too():
+    # Without this a locally-run coverage shard dies with TypeError before
+    # merging, on praktika's own supported local path.
+    src = open(
+        os.path.join(_CI_ROOT, "praktika", "runner.py"), encoding="utf-8"
+    ).read()
+    local = src[src.index("def generate_local_run_environment") :]
+    local = local[: local.index("\n    @")] if "\n    @" in local else local
+    assert "JOB_CONFIG=job" in local
+
+
+def test_every_llvm_producer_paramset_provides_exactly_one_artifact():
+    # `provides[0]` is only well defined because of this.
+    assert len(LLVM_ARTIFACTS_LIST) >= 18
+    assert len(set(LLVM_ARTIFACTS_LIST)) == len(LLVM_ARTIFACTS_LIST)
+
+
+# --------------------------------------------------------------------------
+# Baseline selection: prefer a complete, manifest-matching ancestor, but keep
+# today's first-match walk as the back-compat fallback.
+# --------------------------------------------------------------------------
+
+
+def _run_selector(ancestors):
+    """Drive the real selector loop against a synthetic S3.
+
+    `ancestors` is an ordered list of (sha, has_info, sidecar_or_None); the wget
+    shim serves them. Returns the sha the script selected, or None.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        bin_dir = os.path.join(d, "bin")
+        os.makedirs(bin_dir)
+        s3 = os.path.join(d, "s3")
+        os.makedirs(s3)
+        our = _sidecar()
+        for sha, has_info, sidecar in ancestors:
+            if has_info:
+                with open(os.path.join(s3, f"{sha}.info"), "w") as f:
+                    f.write("SF:/a.cpp\nDA:1,1\nend_of_record\n")
+            if sidecar is not None:
+                with open(os.path.join(s3, f"{sha}.meta.json"), "w") as f:
+                    json.dump(sidecar, f)
+
+        # A wget shim that maps the selector's URLs onto that directory.
+        with open(os.path.join(bin_dir, "wget"), "w") as f:
+            f.write(
+                "#!/usr/bin/env python3\n"
+                "import os, shutil, sys\n"
+                f"S3 = {s3!r}\n"
+                "args = sys.argv[1:]\n"
+                "spider = '--spider' in args\n"
+                "out = None\n"
+                "if '-O' in args: out = args[args.index('-O') + 1]\n"
+                "url = [a for a in args if a.startswith('http')][0]\n"
+                "sha = url.split('/REFs/master/')[1].split('/')[0]\n"
+                "kind = '.info' if url.endswith('llvm_coverage.info') else '.meta.json'\n"
+                "src = os.path.join(S3, sha + kind)\n"
+                "if not os.path.exists(src):\n"
+                "    sys.stderr.write('404 Not Found\\n'); sys.exit(8)\n"
+                "if spider:\n"
+                "    sys.stderr.write('200 OK\\n'); sys.exit(0)\n"
+                "shutil.copy2(src, out)\n"
+            )
+        os.chmod(os.path.join(bin_dir, "wget"), 0o755)
+
+        work = os.path.join(d, "work")
+        os.makedirs(os.path.join(work, "ci", "tmp"))
+        tmp = os.path.join(work, "ci", "tmp")
+        with open(os.path.join(tmp, "llvm_coverage.info"), "w") as f:
+            f.write("SF:/a.cpp\nDA:1,1\nend_of_record\n")
+        completeness.write_sidecar(
+            os.path.join(tmp, completeness.SIDECAR_BASENAME), our
+        )
+        # Stop after selection: the rest of the script needs a git tree.
+        lines = open(_SELECT_SH, encoding="utf-8").read().splitlines(True)
+        end = next(
+            i for i, l in enumerate(lines) if "selected_base_commit.txt" in l
+        )
+        with open(os.path.join(work, "select.sh"), "w") as f:
+            f.writelines(lines[: end + 1])
+
+        env = dict(
+            os.environ,
+            PATH=bin_dir + os.pathsep + os.environ["PATH"],
+            PREV_30_COMMITS=",".join(a[0] for a in ancestors),
+            CURRENT_COMMIT="cur",
+            BASE_COMMIT=ancestors[0][0],
+            BRANCH="pr",
+            BASE_BRANCH="master",
+            WORKSPACE_PATH=work,
+        )
+        r = subprocess.run(
+            ["bash", "select.sh"], cwd=work, env=env, capture_output=True, text=True
+        )
+        sel = os.path.join(tmp, "selected_base_commit.txt")
+        return (
+            open(sel).read().strip() if os.path.exists(sel) else None,
+            r.returncode,
+            r.stdout,
+        )
+
+
+def test_selector_prefers_a_complete_manifest_matching_ancestor_over_a_nearer_one():
+    # Pass 1. Most master runs are incomplete, so taking the first ancestor with
+    # an .info would make the gate abstain on the majority of runs.
+    complete = _sidecar()
+    incomplete = _sidecar(present=_ALL_PRESENT[:-1])
+    sel, rc, _ = _run_selector(
+        [("near", True, incomplete), ("far", True, complete)]
+    )
+    assert rc == 0
+    assert sel == "far"
+
+
+def test_selector_falls_back_to_the_first_info_when_no_ancestor_is_complete():
+    # Pass 2, byte-for-byte the old behaviour. This is what keeps the change
+    # backward compatible: no master commit published before it has a sidecar, so
+    # until master republishes pass 1 finds nothing and the job reports SKIPPED
+    # rather than failing every PR.
+    sel, rc, _ = _run_selector([("near", True, None), ("far", True, None)])
+    assert rc == 0
+    assert sel == "near"
+
+
+def test_selector_pass_one_rejects_a_mismatched_manifest():
+    old_names = _NAMES[:18]
+    other_manifest = _sidecar(
+        names=old_names,
+        present=[completeness.profile_basename(n) for n in old_names],
+    )
+    assert other_manifest["complete"] is True
+    complete = _sidecar()
+    # The nearer ancestor is complete but measured a DIFFERENT manifest.
+    sel, rc, _ = _run_selector(
+        [("near", True, other_manifest), ("far", True, complete)]
+    )
+    assert rc == 0
+    assert sel == "far"
+
+
+def test_selector_records_the_commit_it_actually_chose():
+    # The job cannot re-derive it: its own base_commit_sha is the NEAREST
+    # ancestor, generally not the selected one.
+    sel, rc, _ = _run_selector([("a", False, None), ("b", True, None)])
+    assert rc == 0
+    assert sel == "b"
+
+
+def test_job_reads_the_selected_commit_rather_than_rewalking_s3():
+    src = open(_JOB, encoding="utf-8").read()
+    assert "selected_base_commit.txt" in src
+    assert "base_llvm_coverage.meta.json" in src
+
+
+# --------------------------------------------------------------------------
+# Registration: both job-filter layers, and the one that fires first
+# --------------------------------------------------------------------------
+
+
+def test_the_shared_module_is_registered_in_both_filter_layers():
+    layer1 = open(_FILTER_JOB, encoding="utf-8").read()
+    layer2 = open(_JOB_CONFIGS, encoding="utf-8").read()
+    # Layer 1 decides whether the coverage FAMILY runs at all, and it is
+    # consulted BEFORE any digest, so registering only the digest is not enough.
+    assert "ci/jobs/scripts/llvm_coverage_completeness.py" in layer1
+    assert "./ci/jobs/scripts/llvm_coverage_completeness.py" in layer2
+
+
+def test_the_ft_completion_parser_is_registered_in_layer_one():
+    layer1 = open(_FILTER_JOB, encoding="utf-8").read()
+    assert "ci/jobs/scripts/functional_tests_results.py" in layer1
+
+
+def test_the_runner_local_parity_fix_is_deliberately_not_registered():
+    # CI always takes the _setup_env branch (local_run = not args.ci), so CI never
+    # executes the changed code; digesting it would schedule every coverage shard
+    # on each runner.py edit for no signal.
+    layer1 = open(_FILTER_JOB, encoding="utf-8").read()
+    layer2 = open(_JOB_CONFIGS, encoding="utf-8").read()
+    assert "ci/praktika/runner.py" not in layer1
+    assert "./ci/praktika/runner.py" not in layer2
+    main = open(os.path.join(_CI_ROOT, "praktika", "__main__.py"), encoding="utf-8").read()
+    assert "local_run=not args.ci" in main
+
+
+# --------------------------------------------------------------------------
+# Sidecar shape
+# --------------------------------------------------------------------------
+
+
+def test_sidecar_round_trips_through_disk():
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, completeness.SIDECAR_BASENAME)
+        original = _sidecar()
+        completeness.write_sidecar(p, original)
+        assert completeness.read_sidecar(p) == original
+        # It must be plain JSON so the selector can read it with a one-liner.
+        json.loads(open(p).read())
+
+
+def test_sidecar_records_which_shards_were_missing():
+    s = _sidecar(present=_ALL_PRESENT[:-2])
+    assert s["missing"] == sorted(_ALL_PRESENT[-2:])
+    assert s["complete"] is False
+
+
+def test_a_complete_sidecar_says_so():
+    s = _sidecar()
+    assert s["complete"] is True
+    assert s["missing"] == []
+    assert s["unexpected"] == []
+    assert s["schema_version"] == completeness.SCHEMA_VERSION
+
+
+def test_profile_basename_rejects_a_missing_artifact_name():
+    # A silent None here would name the profile "None.profdata" and turn a naming
+    # bug into a phantom incompleteness verdict on every run.
+    for bad in (None, "", 0, []):
+        try:
+            completeness.profile_basename(bad)
+            raise AssertionError(f"accepted {bad!r}")
+        except AssertionError as e:
+            if "accepted" in str(e):
+                raise
+
+
+def test_skipped_status_counts_as_ok_so_the_job_stays_green():
+    # The whole SKIPPED-not-FAIL design rests on this.
+    r = Result(name="x", status=Result.Status.SKIPPED)
+    assert r.is_ok() is True

--- a/ci/tests/test_llvm_coverage_completeness.py
+++ b/ci/tests/test_llvm_coverage_completeness.py
@@ -32,6 +32,7 @@ import subprocess
 import sys
 import tempfile
 import types
+from datetime import datetime, timezone
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
@@ -954,6 +955,7 @@ def _drive_diff_gate(
     baseline_complete=True,
     sidecar_override=None,
     diff_inputs=True,
+    pr_number=4242,
 ):
     """Drive the real diff-gate out of the job source.
 
@@ -975,15 +977,16 @@ def _drive_diff_gate(
         for s in main_if.body
         if isinstance(s, ast.If) and ast.unparse(s.test) == "not is_master_branch"
     ][0]
-    # Slice through `results.append(print_res)`, not merely to the comparability
-    # verdict: the "Baseline coverage / Current coverage / Delta" prints and the
-    # whole Print Uncovered Code branch live below it, and a cell asserting on
-    # either is VACUOUS unless they are in the executed region at all.
+    # Slice through the `if not is_local_run:` block, not merely to the
+    # comparability verdict: the "Baseline coverage / Current coverage / Delta"
+    # prints, the whole Print Uncovered Code branch AND the coverage-comment /
+    # CI-DB-row branch all live below it, and a cell asserting on any of them is
+    # VACUOUS unless they are in the executed region at all.
     keep = []
     for st in block.body:
         keep.append(st)
         txt = ast.get_source_segment(src, st) or ""
-        if txt.startswith("results.append(print_res)"):
+        if txt.startswith("if not is_local_run:"):
             break
     _sliced = "\n".join((ast.get_source_segment(src, s) or "") for s in keep)
     assert (
@@ -992,6 +995,9 @@ def _drive_diff_gate(
     assert (
         "No C/C++ source files changed" in _sliced
     ), "harness slice no longer contains the no-C++-changes messages it asserts on"
+    assert (
+        "No coverage-relevant changes detected" in _sliced
+    ), "harness slice no longer contains the coverage-comment branch it asserts on"
     mod = ast.Module(body=keep, type_ignores=[])
     ast.fix_missing_locations(mod)
     code = compile(mod, job_path or _JOB, "exec")
@@ -1070,6 +1076,20 @@ def _drive_diff_gate(
         "_measurement_comparable": True,
         "_incomparable_reason": "",
         "results": [],
+        # The coverage-comment / CI-DB-row branch. is_local_run is False so the
+        # branch actually EXECUTES: on a local run the job prints one line and
+        # writes nothing, which would make every cell below it vacuous.
+        "is_local_run": False,
+        "pr_number": pr_number,
+        "current_commit_sha": "c" * 40,
+        "branch": "some-branch",
+        "base_commit_sha": "b" * 40,
+        "base_branch": "master",
+        "datetime": datetime,
+        "timezone": timezone,
+        "json": json,
+        "open": open,
+        "S3_REPORT_BUCKET_HTTP_ENDPOINT": "s3.example.invalid",
     }
     exec(code, ns)
     return types.SimpleNamespace(
@@ -1082,6 +1102,12 @@ def _drive_diff_gate(
         selected_base=ns.get("_selected_base_commit"),
         printed=printed,
         sidecar=sidecar,
+        # Whether the job decided it had coverage data worth publishing. The file
+        # is the artifact the post-hook reads to post the GitHub comment and to
+        # insert the CI DB row, so its absence is the observable that the
+        # abstention really withheld both.
+        comment_written=os.path.exists(os.path.join(tmpdir, "coverage_comment.json")),
+        report_links=ns.get("report_links"),
     )
 
 
@@ -1234,6 +1260,43 @@ def test_two_complete_sides_reach_a_real_comparable_verdict():
     assert any("Baseline coverage : 84.10%" in l for l in got.printed), got.printed
     assert any("Current coverage  : 84.40%" in l for l in got.printed), got.printed
     assert any("Delta             : +0.30%" in l for l in got.printed), got.printed
+    # Reverse direction of the abstention below: a comparable diff-ran verdict must
+    # keep the OK sub-result, so the abstention cannot be widened into "always
+    # SKIPPED".
+    assert got.diff_res.status == Result.Status.OK, got.diff_res.status
+
+
+def test_baseline_incomplete_with_no_coverable_changes_still_abstains():
+    # The one cell in the matrix nobody had driven, and the reason the abstention
+    # cannot live inside `if _diff_ran:`.
+    #
+    # The differential script DOES run here (a baseline-side cause is unknowable
+    # before it fetches the baseline), it selects an INCOMPLETE baseline, and it
+    # then takes its own `${#patterns[@]} -eq 0` exit because nothing coverable
+    # changed - so it never runs genhtml and the report directory is absent. With
+    # the abstention nested under `if _diff_ran:`, that made _diff_ran False, the
+    # override was skipped, and the sub-result kept the OK from_commands_run gave
+    # it: a green verdict for a run that did not judge, which is the exact outcome
+    # this gate exists to prevent.
+    #
+    # _diff_ran is False for three materially different reasons and only one of
+    # them - nothing coverable changed on a COMPARABLE run - licenses an OK, so
+    # the abstention is guarded on comparability alone and placed after the whole
+    # _diff_ran construct, where the degraded arm cannot clobber it either.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_diff_gate(True, d, baseline_complete=False, diff_inputs=False)
+    assert got.comparable is False
+    assert "baseline measurement is incomplete" in got.reason, got.reason
+    # The script ran: that is what makes this a BASELINE-side cause rather than
+    # the current-side short-circuit, and it is why _diff_ran cannot stand in for
+    # "this run produced a verdict".
+    assert len(got.invocations) == 1, f"expected one invocation, got {got.invocations}"
+    assert got.diff_res.status == Result.Status.SKIPPED, got.diff_res.status
+    assert got.reason in got.diff_res.info, (got.reason, got.diff_res.info)
+    # A SKIPPED child must keep the JOB green: the abstention states that the gate
+    # did not judge, it does not fail the PR author for a tool problem.
+    parent = Result.create_from(name="LLVM Coverage", results=got.results)
+    assert parent.is_ok(), f"job is not green: {parent.status}"
 
 
 _NO_CPP = "No C/C++ source files changed"
@@ -1284,8 +1347,215 @@ def test_a_comparable_run_with_no_coverable_changes_still_reports_no_cpp_changes
     assert got.print_res.status == Result.Status.OK, got.print_res.status
     assert _NO_CPP in got.print_res.info, got.print_res.info
     assert any(_NO_CPP in line for line in got.printed), got.printed
+    # The diff sub-result too: this cell and the baseline-incomplete one above
+    # differ ONLY in comparability, so together they pin that the abstention is
+    # keyed on comparability rather than on the absent report directory the two
+    # states share.
+    assert got.diff_res.status == Result.Status.OK, got.diff_res.status
     parent = Result.create_from(name="LLVM Coverage", results=got.results)
     assert parent.is_ok(), f"job is not green: {parent.status}"
+
+
+_NO_COV_DATA = "No coverage-relevant changes detected"
+_SKIP_COMMENT = "Skipping coverage comment and CI DB row"
+
+
+def test_current_side_abstention_does_not_report_no_cpp_changes_in_the_comment_branch():
+    # The THIRD site of the same ordering defect, in the branch that decides
+    # whether to publish the GitHub comment and the CI DB row.
+    #
+    # The gate on _has_coverage_data is correct - neither is published - but the
+    # MESSAGE was selected on _diff_ran alone. On a current-side cause the
+    # differential script is deliberately never invoked, so _diff_ran is False for
+    # a reason that has nothing to do with C/C++ files, and the run made a claim
+    # about the PR's contents that was never established, immediately after having
+    # printed the real incompleteness reason.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_diff_gate(
+            True, d, present_names=[completeness.profile_basename(_GATE_ARTIFACTS[0])]
+        )
+    assert got.comparable is False
+    assert any(_SKIP_COMMENT in line for line in got.printed), got.printed
+    assert got.reason in " ".join(got.printed), (got.reason, got.printed)
+    assert not any(_NO_COV_DATA in line for line in got.printed), got.printed
+    # And the artifact the post-hook reads really was withheld, so no comment is
+    # posted and no CI DB row is inserted from an unjudged run.
+    assert got.comment_written is False
+
+
+def test_baseline_side_abstention_does_not_report_no_cpp_changes_in_the_comment_branch():
+    # The baseline-side route to the same branch. Here the script DID run, so the
+    # pre-fix _diff_ran test happened to pick the right message when it also
+    # produced a report - but not when it took its own no-coverable-files exit,
+    # which is the state driven here.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_diff_gate(True, d, baseline_complete=False, diff_inputs=False)
+    assert got.comparable is False
+    assert "baseline measurement is incomplete" in got.reason, got.reason
+    assert any(_SKIP_COMMENT in line for line in got.printed), got.printed
+    assert not any(_NO_COV_DATA in line for line in got.printed), got.printed
+    assert got.comment_written is False
+
+
+def test_a_comparable_run_with_nothing_coverable_does_report_no_coverage_data():
+    # The reverse direction, and the cell that keeps the one-token fix from being
+    # widened into "always print the reason": both sides are complete, the script
+    # ran, and nothing coverable changed. That is the ONE state in which this
+    # sentence is true, so it must survive.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_diff_gate(True, d, diff_inputs=False)
+    assert got.comparable is True, f"gate abstained: {got.reason}"
+    assert any(_NO_COV_DATA in line for line in got.printed), got.printed
+    assert not any(_SKIP_COMMENT in line for line in got.printed), got.printed
+    # Still nothing to publish: there is no delta to report.
+    assert got.comment_written is False
+
+
+def test_a_healthy_comparable_run_publishes_the_comment_and_neither_skip_message():
+    # The path the whole branch exists to serve. Without this cell the two skip
+    # messages could both be suppressed and every assertion above would still
+    # pass while the job never published a comment at all.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_diff_gate(True, d)
+    assert got.comparable is True, f"gate abstained: {got.reason}"
+    assert got.comment_written is True
+    assert not any(_NO_COV_DATA in line for line in got.printed), got.printed
+    assert not any(_SKIP_COMMENT in line for line in got.printed), got.printed
+
+
+# --------------------------------------------------------------------------
+# The job's report_links block: a published URL must address an artifact that
+# exists. The merge phase now legitimately produces no report at all, which is a
+# state that did not exist on the merge base (a failed merge exited 1 there and
+# reddened the job), so the previously-unconditional append can now point the
+# intended green SKIPPED result at a 404.
+# --------------------------------------------------------------------------
+
+_FULL_REPORT_URL_TAIL = "generate_llvm_coverage_report/index.html"
+
+
+def _report_links_nodes():
+    """The job's `report_links = []` and the `not is_local_run` block that fills it."""
+    src = open(_JOB, encoding="utf-8").read()
+    tree = ast.parse(src)
+    main_if = [n for n in tree.body if isinstance(n, ast.If)][-1]
+    return [
+        st
+        for st in main_if.body
+        if (ast.get_source_segment(src, st) or "").startswith("report_links = []")
+        or (
+            isinstance(st, ast.If)
+            and ast.unparse(st.test) == "not is_local_run"
+            and "report_links.append" in ast.unparse(st)
+        )
+    ]
+
+
+def _drive_report_links(tmpdir, report_exists, pr_number=4242, branch="some-branch"):
+    """Drive the job's own report_links block out of its source.
+
+    Extracted by AST rather than by line range, like the other harnesses here:
+    the two statements sit at different nesting depths from anything a single
+    dedent could express, and node extraction cannot silently degenerate into an
+    IndentationError when either is re-nested.
+    """
+    keep = _report_links_nodes()
+    src = open(_JOB, encoding="utf-8").read()
+    assert len(keep) == 2, f"expected the two report_links statements, got {len(keep)}"
+    _sliced = "\n".join((ast.get_source_segment(src, s) or "") for s in keep)
+    assert (
+        _FULL_REPORT_URL_TAIL in _sliced
+    ), "harness slice no longer contains the full-report link it asserts on"
+    mod = ast.Module(body=keep, type_ignores=[])
+    ast.fix_missing_locations(mod)
+
+    if report_exists:
+        os.makedirs(os.path.join(tmpdir, "llvm_coverage_html_report"), exist_ok=True)
+        with open(
+            os.path.join(tmpdir, "llvm_coverage_html_report", "index.html"),
+            "w",
+            encoding="utf-8",
+        ) as f:
+            f.write("<html></html>")
+
+    ns = {
+        "Path": pathlib.Path,
+        "TEMP_DIR": tmpdir,
+        "is_local_run": False,
+        "pr_number": pr_number,
+        "current_commit_sha": "c" * 40,
+        "branch": branch,
+        "S3_REPORT_BUCKET_HTTP_ENDPOINT": "s3.example.invalid",
+        # The diff link's own guard is not under test here; keep it False so the
+        # assertions below see the full-report link alone.
+        "_diff_ran": False,
+        "_measurement_comparable": False,
+    }
+    exec(compile(mod, _JOB, "exec"), ns)  # noqa: S102 - trusted first-party source
+    return ns["report_links"]
+
+
+def test_no_full_report_link_when_the_merge_produced_no_report():
+    # merge_llvm_coverage.sh exits 0 without generating any HTML when
+    # merged.profdata is absent, so the intended green SKIPPED result would
+    # otherwise advertise a URL that 404s.
+    with tempfile.TemporaryDirectory() as d:
+        assert _drive_report_links(d, report_exists=False) == []
+
+
+def test_full_report_link_is_published_when_the_report_exists():
+    # The reverse direction, so the guard cannot be widened into "never publish".
+    # The URL's shape is asserted verbatim: it is deterministic from the upload
+    # path structure, so a change here means a dead link on every healthy run.
+    with tempfile.TemporaryDirectory() as d:
+        links = _drive_report_links(d, report_exists=True)
+    assert links == [
+        f"https://s3.example.invalid/PRs/4242/{'c' * 40}/llvm_coverage/{_FULL_REPORT_URL_TAIL}"
+    ], links
+
+
+def test_the_master_branch_link_is_gated_on_the_report_too():
+    # The report_links block sits OUTSIDE `if not is_master_branch:`, so a master
+    # run with an incomplete measurement publishes the same dead URL. This path
+    # uses the REFs/<branch>/<sha> prefix and was untested.
+    with tempfile.TemporaryDirectory() as d:
+        assert _drive_report_links(d, report_exists=False, pr_number=0) == []
+    with tempfile.TemporaryDirectory() as d:
+        links = _drive_report_links(d, report_exists=True, pr_number=0, branch="master")
+    assert links == [
+        f"https://s3.example.invalid/REFs/master/{'c' * 40}/llvm_coverage/{_FULL_REPORT_URL_TAIL}"
+    ], links
+
+
+def test_the_diff_link_still_rides_behind_its_own_guard():
+    # The diff link's guard is unchanged; this pins that a comparable diff-ran run
+    # still gets BOTH URLs, in the same order.
+    mod = ast.Module(body=_report_links_nodes(), type_ignores=[])
+    ast.fix_missing_locations(mod)
+    with tempfile.TemporaryDirectory() as d:
+        os.makedirs(os.path.join(d, "llvm_coverage_html_report"), exist_ok=True)
+        with open(
+            os.path.join(d, "llvm_coverage_html_report", "index.html"),
+            "w",
+            encoding="utf-8",
+        ) as f:
+            f.write("<html></html>")
+        ns = {
+            "Path": pathlib.Path,
+            "TEMP_DIR": d,
+            "is_local_run": False,
+            "pr_number": 4242,
+            "current_commit_sha": "c" * 40,
+            "branch": "some-branch",
+            "S3_REPORT_BUCKET_HTTP_ENDPOINT": "s3.example.invalid",
+            "_diff_ran": True,
+            "_measurement_comparable": True,
+        }
+        exec(compile(mod, _JOB, "exec"), ns)  # noqa: S102 - trusted first-party source
+    assert [link.rsplit("/llvm_coverage/", 1)[1] for link in ns["report_links"]] == [
+        _FULL_REPORT_URL_TAIL,
+        "generate_llvm_coverage_diff_report/index_diff.html",
+    ], ns["report_links"]
 
 
 # --------------------------------------------------------------------------

--- a/ci/tests/test_llvm_coverage_completeness.py
+++ b/ci/tests/test_llvm_coverage_completeness.py
@@ -344,15 +344,78 @@ def test_success_finish_semantics_are_unchanged():
     assert SUCCESS_FINISH_SIGNS == ["All tests have finished", "No tests were run"]
 
 
-def test_runner_emits_the_marker_only_when_it_completed_and_kept_its_workers():
+_MARKER = "Coverage run completed all selected tests."
+
+
+def _marker_predicate_node():
+    """The real `if` statement in tests/clickhouse-test that prints the marker.
+
+    Selected as the INNERMOST enclosing ast.If by smallest line span:
+    ast.walk yields outer nodes first, so its first match could be an enclosing
+    `if` whose span covers most of main.
+    """
     src = open(_CH_TEST, encoding="utf-8").read()
-    assert "Coverage run completed all selected tests." in src
-    # Both halves of the predicate must be present, and the existing marker text
-    # and exit contract untouched.
-    idx = src.index("Coverage run completed all selected tests.")
-    window = src[idx - 400 : idx]
-    assert "total_tests_run != 0" in window
-    assert "runner_process_killed.is_set()" in window
+    tree = ast.parse(src)
+    enclosing = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.If) and _MARKER in (ast.get_source_segment(src, n) or "")
+    ]
+    assert enclosing, "no if statement encloses the coverage marker"
+    return min(enclosing, key=lambda n: n.end_lineno - n.lineno)
+
+
+def test_runner_emits_the_marker_only_when_it_completed_and_kept_its_workers():
+    # EXECUTES the real predicate rather than asserting that both operand
+    # substrings appear somewhere near it: replaying two such `in` checks against
+    # a window whose `and` has been swapped for `or` passes, so a substring pair
+    # is blind to the operator by construction - and `or` admits exactly the two
+    # states this marker exists to exclude (a killed worker and a zero-test run),
+    # each of which then lets a short profile be merged.
+    src = open(_CH_TEST, encoding="utf-8").read()
+    assert _MARKER in src
+    node = _marker_predicate_node()
+
+    # Exact, not two independent `in` checks: an operator swap must fail
+    # structurally as well as behaviourally.
+    assert (
+        ast.unparse(node.test)
+        == "total_tests_run != 0 and (not runner_process_killed.is_set())"
+    ), ast.unparse(node.test)
+
+    mod = ast.Module(body=[node], type_ignores=[])
+    ast.fix_missing_locations(mod)
+    code = compile(mod, _CH_TEST, "exec")
+
+    class _Event:
+        def __init__(self, state):
+            self._state = state
+
+        def is_set(self):
+            return self._state
+
+    emitted = {}
+    for total_tests_run in (0, 7):
+        for killed in (False, True):
+            out = []
+            exec(
+                code,
+                {
+                    "total_tests_run": total_tests_run,
+                    "runner_process_killed": _Event(killed),
+                    "print": lambda *a, **k: out.append(" ".join(str(x) for x in a)),
+                },
+            )
+            emitted[(total_tests_run, killed)] = any(_MARKER in line for line in out)
+
+    assert emitted == {
+        (7, False): True,  # completed and kept its workers: the only publishing state
+        (7, True): False,  # the r19 case: a worker was killed mid-run
+        (0, False): False,  # zero tests ran, so nothing was measured
+        (0, True): False,
+    }, emitted
+
+    # The existing marker text and exit contract stay untouched.
     assert 'print("All tests have finished.")' in src
     assert 'print("No tests were run.")' in src
 
@@ -503,8 +566,15 @@ def test_master_path_writes_no_cidb_row_for_an_incomplete_measurement():
 
 
 def test_uncovered_code_analysis_is_skipped_when_incomparable():
+    # Comparability is tested FIRST, unconjoined: on a current-side cause the
+    # differential script never runs, so its two output files are absent and a
+    # guard conjoined with _diff_inputs_exist could not fire at all. The
+    # behavioural counterparts are the three
+    # test_incomparable_*_uncovered_analysis / test_a_comparable_run_with_no_*
+    # cells below, which observe print_res rather than the source text.
     src = open(_JOB, encoding="utf-8").read()
-    assert "if _diff_inputs_exist and not _measurement_comparable:" in src
+    assert "if not _measurement_comparable:" in src
+    assert "if _diff_inputs_exist and not _measurement_comparable:" not in src
     # ... and its counts block is withheld too.
     assert "if _diff_ran and _measurement_comparable:" in src
 
@@ -835,7 +905,7 @@ def _load_job_module_namespace():
     return ns
 
 
-def _write_baseline_outputs(tmpdir, artifact_names, complete=True):
+def _write_baseline_outputs(tmpdir, artifact_names, complete=True, diff_inputs=True):
     """Reproduce what generate_diff_coverage_report.sh leaves in TEMP_DIR.
 
     The script is the SOLE writer of base_llvm_coverage.meta.json (its wget) and
@@ -844,6 +914,13 @@ def _write_baseline_outputs(tmpdir, artifact_names, complete=True):
     the reads that consume them. Every field is produced by the real module
     functions rather than a literal dict, so a schema change cannot leave this
     stub silently describing something the production reader no longer accepts.
+
+    diff_inputs=False reproduces the script's `${#patterns[@]} -eq 0` exit: it
+    has already fetched and selected the baseline, but nothing coverable changed,
+    so it never extracts current.changed.info and never runs genhtml - hence no
+    report directory either. That is the only state in which the job may
+    legitimately conclude "No C/C++ source files changed", so it is the reverse
+    direction of the comparability-first ordering below.
     """
     base_info = os.path.join(tmpdir, "base_llvm_coverage.info")
     with open(base_info, "w", encoding="utf-8") as f:
@@ -857,7 +934,14 @@ def _write_baseline_outputs(tmpdir, artifact_names, complete=True):
     )
     with open(os.path.join(tmpdir, "selected_base_commit.txt"), "w", encoding="utf-8") as f:
         f.write("a" * 40 + "\n")
+    if not diff_inputs:
+        return
     os.makedirs(os.path.join(tmpdir, "llvm_coverage_diff_html_report"), exist_ok=True)
+    # genhtml's --diff-file and print_uncovered_code.py's two inputs.
+    with open(os.path.join(tmpdir, "changes.diff"), "w", encoding="utf-8") as f:
+        f.write("diff --git a/src/a.cpp b/src/a.cpp\n")
+    with open(os.path.join(tmpdir, "current.changed.info"), "w", encoding="utf-8") as f:
+        f.write("SF:/src/a.cpp\nDA:1,1\nend_of_record\n")
 
 
 def _drive_diff_gate(
@@ -869,6 +953,7 @@ def _drive_diff_gate(
     merge_ok=True,
     baseline_complete=True,
     sidecar_override=None,
+    diff_inputs=True,
 ):
     """Drive the real diff-gate out of the job source.
 
@@ -890,19 +975,23 @@ def _drive_diff_gate(
         for s in main_if.body
         if isinstance(s, ast.If) and ast.unparse(s.test) == "not is_master_branch"
     ][0]
-    # Slice through the `if _diff_ran:` statement, not merely to the comparability
-    # verdict: the "Baseline coverage / Current coverage / Delta" prints live inside
-    # it, and a cell asserting that they are absent is VACUOUS unless they are in
-    # the executed region at all.
+    # Slice through `results.append(print_res)`, not merely to the comparability
+    # verdict: the "Baseline coverage / Current coverage / Delta" prints and the
+    # whole Print Uncovered Code branch live below it, and a cell asserting on
+    # either is VACUOUS unless they are in the executed region at all.
     keep = []
     for st in block.body:
         keep.append(st)
         txt = ast.get_source_segment(src, st) or ""
-        if txt.startswith("if _diff_ran:"):
+        if txt.startswith("results.append(print_res)"):
             break
-    assert any(
-        "Baseline coverage" in (ast.get_source_segment(src, s) or "") for s in keep
+    _sliced = "\n".join((ast.get_source_segment(src, s) or "") for s in keep)
+    assert (
+        "Baseline coverage" in _sliced
     ), "harness slice no longer contains the delta prints it asserts on"
+    assert (
+        "No C/C++ source files changed" in _sliced
+    ), "harness slice no longer contains the no-C++-changes messages it asserts on"
     mod = ast.Module(body=keep, type_ignores=[])
     ast.fix_missing_locations(mod)
     code = compile(mod, job_path or _JOB, "exec")
@@ -928,13 +1017,18 @@ def _drive_diff_gate(
         invocations.append(command)
         ok = os.path.exists(info_path)
         if ok:
-            _write_baseline_outputs(tmpdir, names, complete=baseline_complete)
+            _write_baseline_outputs(
+                tmpdir, names, complete=baseline_complete, diff_inputs=diff_inputs
+            )
         return Result.create_from(name=name, status=ok)
 
     class _ResultShim:
         Status = Result.Status
         create_from = staticmethod(Result.create_from)
         from_commands_run = staticmethod(_from_commands_run)
+        from_fs = staticmethod(
+            lambda name: Result.create_from(name=name, status=Result.Status.OK)
+        )
 
     printed = []
     sidecar = (
@@ -946,17 +1040,28 @@ def _drive_diff_gate(
     )
     # lcov is not required to be installed here, so the only summary values the
     # slice needs are stubbed - but the two verdict helpers are the REAL ones, so
-    # the tolerance semantics under test cannot drift from production.
+    # the tolerance semantics under test cannot drift from production. The two
+    # sides return DISTINCT percentages keyed on the path, so the printed numbers
+    # are distinguishable and a swapped-argument regression is visible; the 0.30
+    # pp gap is an improvement, which keeps the healthy arm's verdict green.
+    def _stub_lcov_summary(path):
+        pct = 84.10 if "base_" in os.path.basename(path) else 84.40
+        return ((pct, 1, 2), (pct, 1, 2), (pct, 1, 2))
+
     job_ns = _load_job_module_namespace()
     ns = {
         "Path": pathlib.Path,
         "TEMP_DIR": tmpdir,
         "Result": _ResultShim,
-        "Utils": types.SimpleNamespace(compress_gz=lambda *a, **k: None),
+        "Shell": types.SimpleNamespace(run=lambda *a, **k: None),
+        "Utils": types.SimpleNamespace(
+            compress_gz=lambda *a, **k: None,
+            normalize_string=lambda s: s.lower().replace(" ", "_"),
+        ),
         "completeness": completeness,
         "print": lambda *a, **k: printed.append(" ".join(str(x) for x in a)),
         "shutil": shutil,
-        "get_lcov_summary": lambda path: ((50.0, 1, 2), (50.0, 1, 2), (50.0, 1, 2)),
+        "get_lcov_summary": _stub_lcov_summary,
         "coverage_drop": job_ns["coverage_drop"],
         "coverage_degraded": job_ns["coverage_degraded"],
         "collect_html_report_files": lambda *a, **k: ([], []),
@@ -964,11 +1069,14 @@ def _drive_diff_gate(
         "_sidecar": sidecar,
         "_measurement_comparable": True,
         "_incomparable_reason": "",
+        "results": [],
     }
     exec(code, ns)
     return types.SimpleNamespace(
         invocations=invocations,
         diff_res=ns.get("diff_res"),
+        print_res=ns.get("print_res"),
+        results=ns.get("results"),
         comparable=ns.get("_measurement_comparable"),
         reason=ns.get("_incomparable_reason"),
         selected_base=ns.get("_selected_base_commit"),
@@ -1068,6 +1176,16 @@ def test_a_baseline_side_cause_still_runs_the_script_and_uses_the_override():
     assert "generate_diff_coverage_report.sh" in " ".join(got.invocations[0])
     assert got.comparable is False
     assert "baseline measurement is incomplete" in got.reason, got.reason
+    # The override still fires: it is the ONLY thing that turns the OK sub-result
+    # from_commands_run produced into SKIPPED on this path.
+    assert got.diff_res.status == Result.Status.SKIPPED, got.diff_res.status
+    # ... and no delta is printed. The script legitimately ran, so this block IS
+    # reached with the measurement already known incomparable; parsing the two
+    # summaries here would print three numbers between two abstention notices,
+    # which is the reading confusion this gate exists to remove.
+    assert not any(
+        "Baseline coverage" in line or "Delta" in line for line in got.printed
+    ), got.printed
 
 
 def test_the_short_circuit_reason_cannot_drift_from_the_verdict_function():
@@ -1109,6 +1227,65 @@ def test_two_complete_sides_reach_a_real_comparable_verdict():
     assert got.reason == "", got.reason
     assert got.selected_base == "a" * 40, repr(got.selected_base)
     assert any("Comparing against baseline commit" in line for line in got.printed), got.printed
+    # Reverse direction of the delta suppression above: a comparable run MUST
+    # still print all three numbers, so that suppression cannot be widened into
+    # "never print a delta". The two stubbed sides differ (84.10 / 84.40), so a
+    # swapped-argument regression is visible in the printed values too.
+    assert any("Baseline coverage : 84.10%" in l for l in got.printed), got.printed
+    assert any("Current coverage  : 84.40%" in l for l in got.printed), got.printed
+    assert any("Delta             : +0.30%" in l for l in got.printed), got.printed
+
+
+_NO_CPP = "No C/C++ source files changed"
+
+
+def test_incomparable_pr_side_does_not_report_no_cpp_changes():
+    # The short-circuit is the SOLE reason the two diff inputs are absent on this
+    # path, because the differential script that writes them never ran. Testing
+    # _diff_inputs_exist before comparability therefore reported "No C/C++ source
+    # files changed" twice on a run whose C++ files may well have changed - the
+    # job log contradicting itself on the very path this gate exists to serve.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_diff_gate(
+            True, d, present_names=[completeness.profile_basename(_GATE_ARTIFACTS[0])]
+        )
+    assert got.comparable is False
+    assert got.print_res.status == Result.Status.SKIPPED, got.print_res.status
+    assert got.reason in got.print_res.info, (got.reason, got.print_res.info)
+    assert not any(_NO_CPP in line for line in got.printed), got.printed
+    # The abstention must not redden anything: SKIPPED counts as OK.
+    parent = Result.create_from(name="LLVM Coverage", results=got.results)
+    assert parent.is_ok(), f"job is not green: {parent.status}"
+
+
+def test_an_empty_measurement_does_not_report_no_cpp_changes():
+    # Same ordering defect reached by the other current-side cause: the aggregate
+    # merge published no llvm_coverage.info at all, so there is nothing to compare
+    # - which is emphatically not the same statement as "nothing changed".
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_diff_gate(False, d)
+    assert got.comparable is False
+    assert got.print_res.status == Result.Status.SKIPPED, got.print_res.status
+    assert got.reason in got.print_res.info, (got.reason, got.print_res.info)
+    assert not any(_NO_CPP in line for line in got.printed), got.printed
+    parent = Result.create_from(name="LLVM Coverage", results=got.results)
+    assert parent.is_ok(), f"job is not green: {parent.status}"
+
+
+def test_a_comparable_run_with_no_coverable_changes_still_reports_no_cpp_changes():
+    # The reverse direction, and the cell that keeps the fix from being widened
+    # into "always report SKIPPED": both sides are complete and comparable, the
+    # script ran and selected a baseline, but nothing coverable changed, so it
+    # took its own `${#patterns[@]} -eq 0` exit and wrote neither diff input.
+    # That is the one state in which this sentence is TRUE, and it must survive.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_diff_gate(True, d, diff_inputs=False)
+    assert got.comparable is True, f"gate abstained: {got.reason}"
+    assert got.print_res.status == Result.Status.OK, got.print_res.status
+    assert _NO_CPP in got.print_res.info, got.print_res.info
+    assert any(_NO_CPP in line for line in got.printed), got.printed
+    parent = Result.create_from(name="LLVM Coverage", results=got.results)
+    assert parent.is_ok(), f"job is not green: {parent.status}"
 
 
 # --------------------------------------------------------------------------

--- a/ci/tests/test_llvm_coverage_completeness.py
+++ b/ci/tests/test_llvm_coverage_completeness.py
@@ -1886,6 +1886,15 @@ def _run_selector(ancestors):
         work = os.path.join(d, "work")
         os.makedirs(os.path.join(work, "ci", "tmp"))
         tmp = os.path.join(work, "ci", "tmp")
+        # Production sets WORKSPACE_PATH to the repo root, and the selector puts it
+        # on PYTHONPATH to import the completeness module. `ci` and `ci.jobs` are
+        # namespace packages, so linking jobs/ makes the REAL module importable from
+        # this synthetic workspace - the selector's predicate under test is then the
+        # production function, not a copy of it.
+        os.symlink(
+            os.path.abspath(os.path.join(_CI_ROOT, "jobs")),
+            os.path.join(work, "ci", "jobs"),
+        )
         with open(os.path.join(tmp, "llvm_coverage.info"), "w") as f:
             f.write("SF:/a.cpp\nDA:1,1\nend_of_record\n")
         completeness.write_sidecar(
@@ -1970,6 +1979,68 @@ def test_job_reads_the_selected_commit_rather_than_rewalking_s3():
     src = open(_JOB, encoding="utf-8").read()
     assert "selected_base_commit.txt" in src
     assert "base_llvm_coverage.meta.json" in src
+
+
+def test_selector_walks_past_a_newer_schema_version_to_the_next_usable_one():
+    # The selection predicate must be the USABILITY predicate. A candidate the
+    # job will later reject must not win selection here: doing so converts "pick
+    # an older usable baseline" into a whole-job abstention, which is the exact
+    # self-disabling failure this protocol exists to avoid.
+    newer = _sidecar()
+    newer["schema_version"] = completeness.SCHEMA_VERSION + 1
+    # Confirm the premise: the job's own verdict function rejects this candidate.
+    assert completeness.comparable(_sidecar(), newer)[0] is False
+    sel, rc, _ = _run_selector([("near", True, newer), ("far", True, _sidecar())])
+    assert rc == 0
+    assert sel == "far"
+
+
+def test_selector_walks_past_a_torn_sidecar_info_pair_to_the_next_usable_one():
+    # The other cause `comparable` rejects after download. Detecting it requires
+    # the candidate's .info bytes, so the selector must fetch before deciding.
+    torn = _sidecar()
+    torn["info_digest"] = "0" * 16  # describes an .info that is not the one served
+    assert completeness.comparable(_sidecar(), torn)[0] is True, (
+        "digest mismatch is only detectable with the .info in hand"
+    )
+    sel, rc, out = _run_selector([("near", True, torn), ("far", True, _sidecar())])
+    assert rc == 0
+    assert sel == "far"
+    assert "does not describe" in out, out
+
+
+def test_a_selected_baseline_is_actually_usable_by_the_job():
+    # The reverse direction of the two rows above: pass 1 must still SELECT a
+    # candidate that is usable, so the tightened predicate cannot pass by
+    # rejecting everything.
+    sel, rc, _ = _run_selector([("near", True, _sidecar())])
+    assert rc == 0
+    assert sel == "near"
+
+
+def test_emitted_metadata_names_the_baseline_that_was_measured():
+    # A silent data-integrity defect in the STORED row: coverage_ci.coverage_data
+    # is keyed on base_commit_sha, so serializing the NEAREST ancestor while the
+    # report was generated against an older one attributes the delta to a
+    # revision that was never measured, with nothing in the payload revealing it.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_diff_gate(True, d)
+        assert got.comparable is True
+        assert got.comment_written
+        with open(os.path.join(d, "coverage_comment.json")) as f:
+            payload = json.load(f)
+        # _write_baseline_outputs writes "a" * 40 as the selected commit; the
+        # harness passes "b" * 40 as the job's own nearest-ancestor base.
+        assert got.selected_base == "a" * 40
+        assert payload["base_commit_sha"] == "a" * 40, payload["base_commit_sha"]
+
+
+def test_emitted_metadata_falls_back_to_the_nearest_ancestor():
+    # Back-compat: when no marker exists (an older script, or a run that never
+    # reached it) the payload keeps today's value rather than an empty string,
+    # so the stored row never loses its baseline key entirely.
+    src = open(_JOB, encoding="utf-8").read()
+    assert '"base_commit_sha": _selected_base_commit or base_commit_sha,' in src
 
 
 # --------------------------------------------------------------------------

--- a/ci/tests/test_llvm_coverage_completeness.py
+++ b/ci/tests/test_llvm_coverage_completeness.py
@@ -956,6 +956,7 @@ def _drive_diff_gate(
     sidecar_override=None,
     diff_inputs=True,
     pr_number=4242,
+    script_fails=False,
 ):
     """Drive the real diff-gate out of the job source.
 
@@ -1026,6 +1027,17 @@ def _drive_diff_gate(
             _write_baseline_outputs(
                 tmpdir, names, complete=baseline_complete, diff_inputs=diff_inputs
             )
+        # script_fails reproduces a LATER failure of the differential script: it
+        # has already written the baseline sidecar and the selected-base marker
+        # (its wget at :64 and its echo at :100) and only then hits `exit 1` on an
+        # empty GitHub compare, or a set -euo pipefail failure of a gh api call,
+        # of either lcov --extract, or of genhtml. Writing those outputs FIRST is
+        # exactly what makes the mixed "the tool broke AND we cannot judge" state
+        # real, so the write above is deliberately not skipped. The existing
+        # os.path.exists(info_path) term is kept so the absent-.info precondition
+        # cell is unaffected.
+        if script_fails:
+            ok = False
         return Result.create_from(name=name, status=ok)
 
     class _ResultShim:
@@ -1297,6 +1309,61 @@ def test_baseline_incomplete_with_no_coverable_changes_still_abstains():
     # did not judge, it does not fail the PR author for a tool problem.
     parent = Result.create_from(name="LLVM Coverage", results=got.results)
     assert parent.is_ok(), f"job is not green: {parent.status}"
+
+
+def test_a_failing_differential_script_stays_red_even_when_incomparable():
+    # "The tool broke" and "we cannot judge" genuinely CO-OCCUR, and this is the
+    # cell where the abstention must lose. generate_diff_coverage_report.sh writes
+    # base_llvm_coverage.meta.json (:64) and selected_base_commit.txt (:100)
+    # BEFORE several of its own failure paths - `exit 1` on an empty GitHub
+    # compare (:138), and under set -euo pipefail any failure of the two gh api
+    # calls (:125-131), of either lcov --extract (:156, :161) or of genhtml
+    # (:203). In every one of those the report directory is absent, so _diff_ran
+    # is False; and the baseline side is incomparable for EVERY baseline
+    # published before this change, because those commits carry no sidecar. Old
+    # baseline plus a late script failure is therefore the ordinary post-merge
+    # run, not a corner.
+    #
+    # The asymmetry that makes this reachable at all: the two sibling abstentions
+    # (the current-side short-circuit and Print Uncovered Code) CONSTRUCT a fresh
+    # Result via create_from, so they cannot destroy a status. This one MUTATES a
+    # result that from_commands_run may already have set to FAIL, and SKIPPED is
+    # inside is_ok() - so an unguarded set_status turns a real tooling failure
+    # green. A failed REPORT must stay RED: merge_llvm_coverage.sh:50-52 says so
+    # verbatim, echoed at llvm_coverage_job.py:216-218.
+    #
+    # Do not delete this as redundant with the sibling SKIPPED cells: all five of
+    # those reach the block with diff_res in SKIPPED or OK, so none of them can
+    # observe the overwrite.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_diff_gate(
+            True, d, baseline_complete=False, diff_inputs=False, script_fails=True
+        )
+    # The abstention branch really was entered - without this the cell could pass
+    # for the trivial reason that comparability never came into question.
+    assert got.comparable is False
+    assert "baseline measurement is incomplete" in got.reason, got.reason
+    # The property under test: the script's own FAIL survives the abstention.
+    assert got.diff_res.status == Result.Status.FAIL, got.diff_res.status
+    # The assertion that actually pins the invariant, mirroring how the sibling
+    # cells assert the composite IS ok.
+    assert not Result.create_from(
+        name="LLVM Coverage", results=got.results
+    ).is_ok(), "a failed differential script must not leave the job green"
+    # ...and the ABSTENTION's own print must not have run, so a future refactor
+    # cannot satisfy the status assertion while still telling the PR author in the
+    # log that the gate merely abstained.
+    #
+    # Counted rather than asserted absent, because the identical sentence has a
+    # SECOND and older producer: llvm_coverage_job.py:355-356 prints it once for
+    # every incomparable run, which is what production's own comment at :434-436
+    # means by "the reason was already printed above". So one occurrence is the
+    # pre-existing report of the cause and is expected here; two would mean the
+    # abstention block itself also ran. Measured across three arms: this one
+    # prints it ONCE, while the two arms whose script SUCCEEDS print it TWICE, so
+    # the count is discriminating.
+    _skips = [line for line in got.printed if "Coverage comparison skipped" in line]
+    assert len(_skips) == 1, _skips
 
 
 _NO_CPP = "No C/C++ source files changed"

--- a/ci/tests/test_llvm_coverage_completeness.py
+++ b/ci/tests/test_llvm_coverage_completeness.py
@@ -22,12 +22,15 @@ otherwise the job reports SKIPPED with a reason and stays green.
 Every row drives the production module, never a copy of its logic.
 """
 
+import ast
 import json
 import os
+import pathlib
 import shutil
 import subprocess
 import sys
 import tempfile
+import types
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
@@ -716,10 +719,93 @@ def test_the_sidecar_rides_on_the_existing_artifact_so_no_new_name_is_introduced
     assert any(p.endswith(completeness.SIDECAR_BASENAME) for p in paths)
 
 
-def test_job_treats_an_absent_info_as_incomplete_rather_than_comparing_nothing():
-    src = open(_JOB, encoding="utf-8").read()
-    assert 'if not Path(f"{TEMP_DIR}/llvm_coverage.info").exists():' in src
-    assert "nothing to compare" in src
+def _drive_diff_gate(info_present, tmpdir, job_path=None):
+    """Drive the real diff-gate ordering out of the job source.
+
+    Returns (script_invocations, diff_res, measurement_comparable). The statement
+    ORDER is the property under test - whether the absent-.info verdict is reached
+    before or after the differential script runs - so the real statements are
+    executed in their real order rather than a copy of the logic. Only the leaf
+    calls that need a workspace (from_commands_run) are stubbed, and that stub
+    reproduces the script's own precondition: it exits non-zero when
+    llvm_coverage.info is absent (measured separately).
+    """
+    src = open(job_path or _JOB, encoding="utf-8").read()
+    tree = ast.parse(src)
+    main_if = [n for n in tree.body if isinstance(n, ast.If)][-1]
+    block = [
+        s
+        for s in main_if.body
+        if isinstance(s, ast.If) and ast.unparse(s.test) == "not is_master_branch"
+    ][0]
+    keep = []
+    for st in block.body:
+        keep.append(st)
+        txt = ast.get_source_segment(src, st) or ""
+        if txt.startswith("if not _measurement_comparable:"):
+            break
+    mod = ast.Module(body=keep, type_ignores=[])
+    ast.fix_missing_locations(mod)
+    code = compile(mod, job_path or _JOB, "exec")
+
+    if info_present:
+        with open(os.path.join(tmpdir, "llvm_coverage.info"), "w") as f:
+            f.write("TN:\nend_of_record\n")
+
+    invocations = []
+
+    def _from_commands_run(name, command, **kwargs):
+        invocations.append(command)
+        ok = os.path.exists(os.path.join(tmpdir, "llvm_coverage.info"))
+        return Result.create_from(name=name, status=ok)
+
+    class _ResultShim:
+        Status = Result.Status
+        create_from = staticmethod(Result.create_from)
+        from_commands_run = staticmethod(_from_commands_run)
+
+    ns = {
+        "Path": pathlib.Path,
+        "TEMP_DIR": tmpdir,
+        "Result": _ResultShim,
+        "completeness": completeness,
+        "_sidecar": {
+            "complete": True,
+            "missing": [],
+            "names": [],
+            "manifest_fp": "fp",
+        },
+        "_measurement_comparable": True,
+        "_incomparable_reason": "",
+    }
+    exec(code, ns)
+    return invocations, ns.get("diff_res"), ns.get("_measurement_comparable")
+
+
+def test_absent_info_skips_the_diff_script_and_keeps_the_job_green():
+    # The differential script's own precondition exits 1 when llvm_coverage.info
+    # is absent, which is exactly the state a failed aggregate merge leaves. If
+    # the script is invoked anyway the sub-result is FAIL and its output directory
+    # is missing, so the SKIPPED override that reads _measurement_comparable is
+    # never reached and the job reddens on a run it promised to report as SKIPPED.
+    with tempfile.TemporaryDirectory() as d:
+        invocations, diff_res, comparable = _drive_diff_gate(False, d)
+    assert invocations == [], f"differential script was invoked: {invocations}"
+    assert diff_res.status == Result.Status.SKIPPED, diff_res.status
+    assert comparable is False
+    # The assertion that actually pins the invariant: the composite job result.
+    parent = Result.create_from(name="LLVM Coverage", results=[diff_res])
+    assert parent.is_ok(), f"job is not green: {parent.status}"
+
+
+def test_a_present_info_still_runs_the_diff_script():
+    # Reverse direction. Without this the guard above could be widened to always
+    # skip and every other cell would still pass.
+    with tempfile.TemporaryDirectory() as d:
+        invocations, diff_res, _ = _drive_diff_gate(True, d)
+    assert len(invocations) == 1, f"expected one invocation, got {invocations}"
+    assert "generate_diff_coverage_report.sh" in " ".join(invocations[0])
+    assert diff_res.status != Result.Status.SKIPPED
 
 
 # --------------------------------------------------------------------------
@@ -801,6 +887,118 @@ def test_every_producer_reads_provides_as_a_dict_key():
         src = open(path, encoding="utf-8").read()
         assert '["provides"]' in src, path
         assert ".job_config.provides" not in src, path
+
+
+def _drive_ut_naming(provides, profraw_files, tmpdir, job_path=None):
+    """Execute the real coverage bookkeeping of unit_tests_job.py.
+
+    Returns the derived `merged_file`, or None when the job never derives one.
+    The statements are taken from the job source and run in their real order, so
+    the nesting under the `.profraw` guard is exercised rather than described.
+    from_gtest_run/complete_job are dropped because they need a built gtest
+    binary; everything the naming path touches is real.
+    """
+    src = open(job_path or _UT_JOB, encoding="utf-8").read()
+    tree = ast.parse(src)
+    main_if = [n for n in tree.body if isinstance(n, ast.If)][-1]
+    keep = []
+    for st in main_if.body:
+        txt = ast.get_source_segment(src, st) or ""
+        if txt.startswith(
+            (
+                "R = Result.from_gtest_run",
+                "R.complete_job",
+                "parser",
+                "args =",
+                "os.environ",
+                "job_name =",
+                'if "asan"',
+                "profraw_files",
+            )
+        ):
+            continue
+        keep.append(st)
+    mod = ast.Module(body=keep, type_ignores=[])
+    ast.fix_missing_locations(mod)
+    code = compile(mod, job_path or _UT_JOB, "exec")
+
+    class _Info:
+        job_config = {"provides": provides}
+
+    ns = {
+        "os": os,
+        "Info": lambda: _Info(),
+        "Shell": types.SimpleNamespace(
+            get_output=lambda *a, **k: "", check=lambda *a, **k: False
+        ),
+        "profraw_files": list(profraw_files),
+    }
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmpdir)
+        exec(code, ns)
+    finally:
+        os.chdir(cwd)
+    return ns.get("merged_file")
+
+
+def test_unit_test_job_names_no_profile_when_there_is_no_coverage_to_name():
+    # The six sanitizer Unit tests ParamSets declare no artifact and emit no
+    # .profraw. The naming asserts sit between from_gtest_run() and
+    # complete_job(), so raising here does not merely mis-report - it loses the
+    # gtest result entirely.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_ut_naming([], [], d)
+    assert got is None
+
+
+def test_unit_test_job_still_names_the_profile_after_its_own_artifact():
+    # Reverse direction: the one instrumented ParamSet must keep deriving exactly
+    # the name the consumer side expects, so moving the block cannot silently stop
+    # naming the profile at all.
+    name = "LLVM_COVERAGE_FILE"
+    with tempfile.TemporaryDirectory() as d:
+        raw = os.path.join(d, "one.profraw")
+        with open(raw, "w") as f:
+            f.write("data")
+        got = _drive_ut_naming([name], [raw], d)
+    assert got == f"./{name}.profdata"
+    assert os.path.basename(got) == completeness.profile_basename(name)
+
+
+def test_unit_test_job_naming_is_nested_under_the_profraw_guard():
+    # Structural companion to the two cells above: catches a re-hoist to the
+    # top level of __main__, where the asserts run unconditionally.
+    src = open(_UT_JOB, encoding="utf-8").read()
+    tree = ast.parse(src)
+    main_if = [n for n in tree.body if isinstance(n, ast.If)][-1]
+    assert not [
+        s for s in main_if.body if isinstance(s, ast.Assert)
+    ], "coverage asserts must not be direct children of __main__"
+    guards = [
+        s
+        for s in main_if.body
+        if isinstance(s, ast.If) and ast.unparse(s.test) == "profraw_files"
+    ]
+    assert guards, "expected an `if profraw_files:` guard"
+    nested = [n for g in guards for n in ast.walk(g) if isinstance(n, ast.Assert)]
+    assert (
+        len(nested) == 2
+    ), f"expected both asserts inside the guard, got {len(nested)}"
+
+
+def test_the_six_non_coverage_unit_test_jobs_declare_no_artifact():
+    # The premise behind the cells above, read off the real job configs rather
+    # than assumed: only the instrumented ParamSet provides an artifact.
+    sys.path.insert(0, _REPO_ROOT)
+    from ci.defs.job_configs import JobConfigs
+
+    plain = list(JobConfigs.unittest_jobs)
+    assert len(plain) == 6, [j.name for j in plain]
+    assert all(j.provides == [] for j in plain), [(j.name, j.provides) for j in plain]
+    coverage = list(JobConfigs.unittest_llvm_coverage_job)
+    assert len(coverage) == 1, [j.name for j in coverage]
+    assert coverage[0].provides == ["LLVM_COVERAGE_FILE"], coverage[0].provides
 
 
 def test_local_runs_get_a_job_config_too():

--- a/ci/tests/test_llvm_coverage_completeness.py
+++ b/ci/tests/test_llvm_coverage_completeness.py
@@ -26,6 +26,7 @@ import ast
 import json
 import os
 import pathlib
+import shlex
 import shutil
 import subprocess
 import sys
@@ -693,6 +694,106 @@ def test_report_phase_does_nothing_when_the_merge_produced_no_profile():
         assert "nothing to report on" in r.stdout
 
 
+def _drive_merge_gate(present_profiles, tmpdir, artifact_names=None, marker=None):
+    """Drive the real merge-invocation decision out of the job source.
+
+    Returns a namespace with the merge-script invocations, merge_res and _merge_ok.
+    The real statements are executed in their real order; only from_commands_run is
+    stubbed, and that stub reproduces the script's observable behaviour (it writes
+    the status marker) so the marker read is exercised rather than bypassed.
+    """
+    src = open(_JOB, encoding="utf-8").read()
+    tree = ast.parse(src)
+    main_if = [n for n in tree.body if isinstance(n, ast.If)][-1]
+    keep = []
+    started = False
+    for st in main_if.body:
+        txt = ast.get_source_segment(src, st) or ""
+        if txt.startswith("_expected_artifacts = "):
+            started = True
+        if not started:
+            continue
+        keep.append(st)
+        if txt.startswith("if not _merge_ok:"):
+            break
+    mod = ast.Module(body=keep, type_ignores=[])
+    ast.fix_missing_locations(mod)
+    code = compile(mod, _JOB, "exec")
+
+    for profile in present_profiles:
+        with open(os.path.join(tmpdir, profile), "wb") as f:
+            f.write(b"\x00profdata\x00")
+
+    invocations = []
+
+    def _from_commands_run(name, command, **kwargs):
+        invocations.append(command)
+        if marker is not None:
+            with open(os.path.join(tmpdir, "merge_profdata.status"), "w") as f:
+                f.write(marker)
+        return Result.create_from(name=name, status=True)
+
+    class _ResultShim:
+        Status = Result.Status
+        create_from = staticmethod(Result.create_from)
+        from_commands_run = staticmethod(_from_commands_run)
+
+    ns = {
+        "Path": pathlib.Path,
+        "TEMP_DIR": tmpdir,
+        "Result": _ResultShim,
+        "completeness": completeness,
+        "shlex": shlex,
+        "print": lambda *a, **k: None,
+        "LLVM_ARTIFACTS_LIST": list(
+            _GATE_ARTIFACTS if artifact_names is None else artifact_names
+        ),
+        "results": [],
+    }
+    exec(code, ns)
+    return types.SimpleNamespace(
+        invocations=invocations,
+        merge_res=ns.get("merge_res"),
+        merge_ok=ns.get("_merge_ok"),
+        results=ns["results"],
+        sidecar_inputs=ns.get("_merge_inputs"),
+    )
+
+
+def test_zero_arriving_profiles_reports_skipped_instead_of_reddening():
+    # Every shard profile is optional=True, so "none arrived" is the limit of the
+    # case the job promises to report as a green SKIPPED. Invoking the merge script
+    # with an empty file list instead exits 1 on its unbounded-glob guard, which
+    # cannot distinguish an empty value from an omitted one, so the FAIL child
+    # reddens the whole job BEFORE the marker mechanism the SKIPPED verdict is
+    # built on is ever reached.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_merge_gate([], d)
+    assert got.invocations == [], f"merge script was invoked: {got.invocations}"
+    assert got.merge_res.status == Result.Status.SKIPPED, got.merge_res.status
+    assert got.merge_ok is False
+    # The assertion that pins the invariant: the composite job result stays green.
+    parent = Result.create_from(name="LLVM Coverage", results=[got.merge_res])
+    assert parent.is_ok(), f"job is not green: {parent.status}"
+    # And the sidecar must record the measurement as unusable, not as complete.
+    sidecar = completeness.build_sidecar(
+        _GATE_ARTIFACTS, [], info_path="", merge_ok=got.merge_ok
+    )
+    assert sidecar["complete"] is False
+
+
+def test_at_least_one_arriving_profile_still_invokes_the_merge_script():
+    # Reverse direction. Without this the new branch could be widened to always
+    # skip and the aggregate merge would silently stop running.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_merge_gate(["COV_A.profdata"], d, marker="ok")
+    assert len(got.invocations) == 1, f"expected one invocation, got {got.invocations}"
+    joined = " ".join(got.invocations[0])
+    assert "merge_llvm_coverage.sh merge" in joined
+    assert "MERGE_PROFDATA_FILES=COV_A.profdata" in joined, joined
+    assert got.merge_ok is True
+
+
 def test_the_scripts_are_syntactically_valid():
     for path in (_MERGE_SH, _SELECT_SH):
         assert (
@@ -719,16 +820,67 @@ def test_the_sidecar_rides_on_the_existing_artifact_so_no_new_name_is_introduced
     assert any(p.endswith(completeness.SIDECAR_BASENAME) for p in paths)
 
 
-def _drive_diff_gate(info_present, tmpdir, job_path=None):
-    """Drive the real diff-gate ordering out of the job source.
+_GATE_ARTIFACTS = ["COV_A", "COV_B"]
 
-    Returns (script_invocations, diff_res, measurement_comparable). The statement
-    ORDER is the property under test - whether the absent-.info verdict is reached
-    before or after the differential script runs - so the real statements are
-    executed in their real order rather than a copy of the logic. Only the leaf
-    calls that need a workspace (from_commands_run) are stubbed, and that stub
-    reproduces the script's own precondition: it exits non-zero when
-    llvm_coverage.info is absent (measured separately).
+
+def _load_job_module_namespace():
+    """The job's module-level definitions, without running its __main__ block."""
+    src = open(_JOB, encoding="utf-8").read()
+    tree = ast.parse(src)
+    body = [n for n in tree.body if not isinstance(n, ast.If)]
+    mod = ast.Module(body=body, type_ignores=[])
+    ast.fix_missing_locations(mod)
+    ns = {"__name__": "_job_defs"}
+    exec(compile(mod, _JOB, "exec"), ns)
+    return ns
+
+
+def _write_baseline_outputs(tmpdir, artifact_names, complete=True):
+    """Reproduce what generate_diff_coverage_report.sh leaves in TEMP_DIR.
+
+    The script is the SOLE writer of base_llvm_coverage.meta.json (its wget) and
+    of selected_base_commit.txt (its echo), so a stub that writes neither makes
+    the whole baseline side unobservable and the harness blind to the order of
+    the reads that consume them. Every field is produced by the real module
+    functions rather than a literal dict, so a schema change cannot leave this
+    stub silently describing something the production reader no longer accepts.
+    """
+    base_info = os.path.join(tmpdir, "base_llvm_coverage.info")
+    with open(base_info, "w", encoding="utf-8") as f:
+        f.write("TN:\nSF:/src/a.cpp\nDA:1,1\nend_of_record\n")
+    present = [completeness.profile_basename(n) for n in artifact_names]
+    if not complete:
+        present = present[:-1]
+    completeness.write_sidecar(
+        os.path.join(tmpdir, "base_llvm_coverage.meta.json"),
+        completeness.build_sidecar(artifact_names, present, info_path=base_info),
+    )
+    with open(os.path.join(tmpdir, "selected_base_commit.txt"), "w", encoding="utf-8") as f:
+        f.write("a" * 40 + "\n")
+    os.makedirs(os.path.join(tmpdir, "llvm_coverage_diff_html_report"), exist_ok=True)
+
+
+def _drive_diff_gate(
+    info_present,
+    tmpdir,
+    job_path=None,
+    artifact_names=None,
+    present_names=None,
+    merge_ok=True,
+    baseline_complete=True,
+    sidecar_override=None,
+):
+    """Drive the real diff-gate out of the job source.
+
+    Returns a namespace with the script invocations, diff_res, the comparability
+    verdict and reason, the selected base commit and every printed line.
+
+    The statement ORDER is a property under test: the baseline sidecar and the
+    selected-base marker are written BY the differential script, so a read placed
+    above it can only ever see nothing. The real statements therefore run in
+    their real order; only from_commands_run is stubbed, and that stub both
+    reproduces the script's precondition (non-zero when llvm_coverage.info is
+    absent, measured separately) and writes the files the real script writes.
     """
     src = open(job_path or _JOB, encoding="utf-8").read()
     tree = ast.parse(src)
@@ -738,25 +890,45 @@ def _drive_diff_gate(info_present, tmpdir, job_path=None):
         for s in main_if.body
         if isinstance(s, ast.If) and ast.unparse(s.test) == "not is_master_branch"
     ][0]
+    # Slice through the `if _diff_ran:` statement, not merely to the comparability
+    # verdict: the "Baseline coverage / Current coverage / Delta" prints live inside
+    # it, and a cell asserting that they are absent is VACUOUS unless they are in
+    # the executed region at all.
     keep = []
     for st in block.body:
         keep.append(st)
         txt = ast.get_source_segment(src, st) or ""
-        if txt.startswith("if not _measurement_comparable:"):
+        if txt.startswith("if _diff_ran:"):
             break
+    assert any(
+        "Baseline coverage" in (ast.get_source_segment(src, s) or "") for s in keep
+    ), "harness slice no longer contains the delta prints it asserts on"
     mod = ast.Module(body=keep, type_ignores=[])
     ast.fix_missing_locations(mod)
     code = compile(mod, job_path or _JOB, "exec")
 
+    names = list(_GATE_ARTIFACTS if artifact_names is None else artifact_names)
+    present = (
+        [completeness.profile_basename(n) for n in names]
+        if present_names is None
+        else list(present_names)
+    )
+    for profile in present:
+        with open(os.path.join(tmpdir, profile), "wb") as f:
+            f.write(b"\x00profdata\x00")
+
+    info_path = os.path.join(tmpdir, "llvm_coverage.info")
     if info_present:
-        with open(os.path.join(tmpdir, "llvm_coverage.info"), "w") as f:
-            f.write("TN:\nend_of_record\n")
+        with open(info_path, "w", encoding="utf-8") as f:
+            f.write("TN:\nSF:/src/a.cpp\nDA:1,1\nend_of_record\n")
 
     invocations = []
 
     def _from_commands_run(name, command, **kwargs):
         invocations.append(command)
-        ok = os.path.exists(os.path.join(tmpdir, "llvm_coverage.info"))
+        ok = os.path.exists(info_path)
+        if ok:
+            _write_baseline_outputs(tmpdir, names, complete=baseline_complete)
         return Result.create_from(name=name, status=ok)
 
     class _ResultShim:
@@ -764,22 +936,45 @@ def _drive_diff_gate(info_present, tmpdir, job_path=None):
         create_from = staticmethod(Result.create_from)
         from_commands_run = staticmethod(_from_commands_run)
 
+    printed = []
+    sidecar = (
+        completeness.build_sidecar(
+            names, present, info_path=info_path, merge_ok=merge_ok
+        )
+        if sidecar_override is None
+        else sidecar_override
+    )
+    # lcov is not required to be installed here, so the only summary values the
+    # slice needs are stubbed - but the two verdict helpers are the REAL ones, so
+    # the tolerance semantics under test cannot drift from production.
+    job_ns = _load_job_module_namespace()
     ns = {
         "Path": pathlib.Path,
         "TEMP_DIR": tmpdir,
         "Result": _ResultShim,
+        "Utils": types.SimpleNamespace(compress_gz=lambda *a, **k: None),
         "completeness": completeness,
-        "_sidecar": {
-            "complete": True,
-            "missing": [],
-            "names": [],
-            "manifest_fp": "fp",
-        },
+        "print": lambda *a, **k: printed.append(" ".join(str(x) for x in a)),
+        "shutil": shutil,
+        "get_lcov_summary": lambda path: ((50.0, 1, 2), (50.0, 1, 2), (50.0, 1, 2)),
+        "coverage_drop": job_ns["coverage_drop"],
+        "coverage_degraded": job_ns["coverage_degraded"],
+        "collect_html_report_files": lambda *a, **k: ([], []),
+        "COVERAGE_DROP_TOLERANCE": job_ns["COVERAGE_DROP_TOLERANCE"],
+        "_sidecar": sidecar,
         "_measurement_comparable": True,
         "_incomparable_reason": "",
     }
     exec(code, ns)
-    return invocations, ns.get("diff_res"), ns.get("_measurement_comparable")
+    return types.SimpleNamespace(
+        invocations=invocations,
+        diff_res=ns.get("diff_res"),
+        comparable=ns.get("_measurement_comparable"),
+        reason=ns.get("_incomparable_reason"),
+        selected_base=ns.get("_selected_base_commit"),
+        printed=printed,
+        sidecar=sidecar,
+    )
 
 
 def test_absent_info_skips_the_diff_script_and_keeps_the_job_green():
@@ -789,23 +984,131 @@ def test_absent_info_skips_the_diff_script_and_keeps_the_job_green():
     # is missing, so the SKIPPED override that reads _measurement_comparable is
     # never reached and the job reddens on a run it promised to report as SKIPPED.
     with tempfile.TemporaryDirectory() as d:
-        invocations, diff_res, comparable = _drive_diff_gate(False, d)
-    assert invocations == [], f"differential script was invoked: {invocations}"
-    assert diff_res.status == Result.Status.SKIPPED, diff_res.status
-    assert comparable is False
+        got = _drive_diff_gate(False, d)
+    assert got.invocations == [], f"differential script was invoked: {got.invocations}"
+    assert got.diff_res.status == Result.Status.SKIPPED, got.diff_res.status
+    assert got.comparable is False
+    # The script never ran, so there is no marker to read and nothing to select.
+    assert got.selected_base == "", repr(got.selected_base)
     # The assertion that actually pins the invariant: the composite job result.
-    parent = Result.create_from(name="LLVM Coverage", results=[diff_res])
+    parent = Result.create_from(name="LLVM Coverage", results=[got.diff_res])
     assert parent.is_ok(), f"job is not green: {parent.status}"
 
 
-def test_a_present_info_still_runs_the_diff_script():
-    # Reverse direction. Without this the guard above could be widened to always
-    # skip and every other cell would still pass.
+def test_the_baseline_reads_are_below_the_script_that_writes_their_files():
+    # Structural guard, secondary to the behavioural cell below: the differential
+    # script is the sole writer of base_llvm_coverage.meta.json and of
+    # selected_base_commit.txt, so a read placed above its invocation can only ever
+    # observe nothing.
+    src = open(_JOB, encoding="utf-8").read()
+    tree = ast.parse(src)
+    main_if = [n for n in tree.body if isinstance(n, ast.If)][-1]
+    block = [
+        s
+        for s in main_if.body
+        if isinstance(s, ast.If) and ast.unparse(s.test) == "not is_master_branch"
+    ][0]
+    script_lines, read_lines = [], []
+    for node in ast.walk(block):
+        if not isinstance(node, ast.Call):
+            continue
+        rendered = ast.unparse(node)
+        if "from_commands_run" in rendered and "generate_diff_coverage_report" in rendered:
+            script_lines.append(node.lineno)
+        if "read_sidecar" in rendered or "selected_base_commit.txt" in rendered:
+            read_lines.append(node.lineno)
+    assert len(script_lines) == 1, script_lines
+    assert read_lines, "neither baseline read was found"
+    assert min(read_lines) > script_lines[0], (
+        f"a baseline read at line {min(read_lines)} sits above its only writer"
+        f" at line {script_lines[0]}"
+    )
+
+
+def test_a_known_incomplete_pr_side_never_runs_the_script_or_prints_a_delta():
+    # The PR side being short a shard is knowable from the sidecar before the
+    # script runs. Running it anyway spends genhtml on a measurement already known
+    # incomparable and prints "Baseline coverage / Current coverage / Delta"
+    # between two skip notices, which is how a reader mistakes an abstention for a
+    # verdict - the exact confusion this gate exists to remove.
     with tempfile.TemporaryDirectory() as d:
-        invocations, diff_res, _ = _drive_diff_gate(True, d)
-    assert len(invocations) == 1, f"expected one invocation, got {invocations}"
-    assert "generate_diff_coverage_report.sh" in " ".join(invocations[0])
-    assert diff_res.status != Result.Status.SKIPPED
+        got = _drive_diff_gate(
+            True, d, present_names=[completeness.profile_basename(_GATE_ARTIFACTS[0])]
+        )
+    assert got.sidecar["complete"] is False, got.sidecar
+    assert got.invocations == [], f"differential script was invoked: {got.invocations}"
+    assert got.diff_res.status == Result.Status.SKIPPED, got.diff_res.status
+    assert got.comparable is False
+    assert "COV_B.profdata" in got.reason, got.reason
+    assert not any(
+        "Baseline coverage" in line or "Delta" in line for line in got.printed
+    ), got.printed
+    parent = Result.create_from(name="LLVM Coverage", results=[got.diff_res])
+    assert parent.is_ok(), f"job is not green: {parent.status}"
+
+
+def test_a_failed_merge_also_short_circuits_the_script():
+    # Same branch, same class: merge_ok=False is a current-side cause too.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_diff_gate(True, d, merge_ok=False)
+    assert got.invocations == [], f"differential script was invoked: {got.invocations}"
+    assert got.diff_res.status == Result.Status.SKIPPED, got.diff_res.status
+    assert "aggregate coverage merge failed" in got.reason, got.reason
+
+
+def test_a_baseline_side_cause_still_runs_the_script_and_uses_the_override():
+    # The counterpart that keeps the short-circuit from being over-fixed into
+    # "skip every incomparable case", which would make the later override dead
+    # code. A baseline-side cause is NOT knowable before the script runs, because
+    # that script is what fetches the baseline: so the script MUST run here, and
+    # the verdict must come out incomparable afterwards.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_diff_gate(True, d, baseline_complete=False)
+    assert len(got.invocations) == 1, f"expected one invocation, got {got.invocations}"
+    assert "generate_diff_coverage_report.sh" in " ".join(got.invocations[0])
+    assert got.comparable is False
+    assert "baseline measurement is incomplete" in got.reason, got.reason
+
+
+def test_the_short_circuit_reason_cannot_drift_from_the_verdict_function():
+    # The job short-circuits on a current-side cause and must report the SAME
+    # reason comparable() would. Both read one producer, so this cell pins that
+    # they stay one producer.
+    incomplete = completeness.build_sidecar(_GATE_ARTIFACTS, ["COV_A.profdata"])
+    assert (
+        completeness.current_side_reason(incomplete)
+        == completeness.comparable(incomplete, None)[1]
+    )
+    complete = completeness.build_sidecar(
+        _GATE_ARTIFACTS, [completeness.profile_basename(n) for n in _GATE_ARTIFACTS]
+    )
+    # A complete current side yields no current-side reason, while comparable()
+    # still rejects on the absent baseline - so the two must NOT be equal here.
+    assert completeness.current_side_reason(complete) == ""
+    assert completeness.comparable(complete, None)[0] is False
+
+
+def test_two_complete_sides_reach_a_real_comparable_verdict():
+    # The healthy path, asserted on the RUNTIME verdict rather than on the
+    # pre-override sub-result status.
+    #
+    # The property under test is the ORDER of the two baseline reads relative to
+    # the differential script that writes their files: the script is the sole
+    # writer of base_llvm_coverage.meta.json and selected_base_commit.txt, so a
+    # read hoisted above it sees nothing, comparable() takes its absent-baseline
+    # branch and the gate abstains on every single run - while emitting exactly
+    # the reason string that correct back-compat behaviour also emits, so the CI
+    # log of the broken state is indistinguishable from the healthy one. Only a
+    # verdict assertion can see that. Do not weaken this cell to a status or
+    # invocation-count check.
+    with tempfile.TemporaryDirectory() as d:
+        got = _drive_diff_gate(True, d)
+    assert len(got.invocations) == 1, f"expected one invocation, got {got.invocations}"
+    assert "generate_diff_coverage_report.sh" in " ".join(got.invocations[0])
+    assert got.comparable is True, f"gate abstained: {got.reason}"
+    assert got.reason == "", got.reason
+    assert got.selected_base == "a" * 40, repr(got.selected_base)
+    assert any("Comparing against baseline commit" in line for line in got.printed), got.printed
 
 
 # --------------------------------------------------------------------------

--- a/ci/tests/test_llvm_coverage_gate.py
+++ b/ci/tests/test_llvm_coverage_gate.py
@@ -17,6 +17,7 @@ from ci.jobs.llvm_coverage_job import (
     coverage_degraded,
     coverage_drop,
 )
+from ci.praktika.result import Result
 
 _JOB = os.path.join(os.path.dirname(__file__), "..", "jobs", "llvm_coverage_job.py")
 
@@ -39,12 +40,13 @@ def _gate_snippet() -> str:
 
 
 class _ResultStub:
-    """Captures the three side effects the gate has on its Result."""
+    """Captures the side effects the gate has on its Result."""
 
     def __init__(self):
         self.info = None
         self.comment = None
         self.failed = False
+        self.status = None
 
     def set_comment(self, msg):
         self.comment = msg
@@ -52,8 +54,14 @@ class _ResultStub:
     def set_failed(self):
         self.failed = True
 
+    def set_status(self, status):
+        self.status = status
+        return self
 
-def _run_gate(baseline: float, current: float) -> _ResultStub:
+
+def _run_gate(
+    baseline: float, current: float, comparable: bool = True
+) -> _ResultStub:
     """Execute the job's own verdict block and report what it did to the Result."""
     res = _ResultStub()
     ns = {
@@ -62,6 +70,11 @@ def _run_gate(baseline: float, current: float) -> _ResultStub:
         "COVERAGE_DROP_TOLERANCE": COVERAGE_DROP_TOLERANCE,
         "b_line_cov": baseline,
         "c_line_cov": current,
+        # The gate only reaches a tolerance verdict for two comparable
+        # measurements; these tests are about the tolerance, so they say so.
+        "_measurement_comparable": comparable,
+        "_incomparable_reason": "" if comparable else "test-supplied reason",
+        "Result": Result,
         "diff_res": res,
         "print": lambda *a, **k: None,
     }
@@ -76,6 +89,9 @@ def test_gate_snippet_is_the_real_verdict_block():
     assert "coverage_drop(" in src
     assert "coverage_degraded(" in src
     assert "diff_res.set_failed()" in src
+    # The verdict is reached only for two comparable measurements; if this guard
+    # ever leaves the block, the comparable=False assertions below go vacuous.
+    assert "_measurement_comparable" in src
 
 
 def test_tolerance_is_unchanged():
@@ -152,3 +168,12 @@ def test_gate_still_fails_the_large_drop():
     res = _run_gate(86.20, 28.60)
     assert res.failed is True
     assert "dropped 57.60 pp" in res.comment
+
+
+def test_gate_produces_no_verdict_for_two_incomparable_measurements():
+    # The same over-tolerance drop that fails above must NOT fail when the two
+    # measurements are not comparable: the number itself is then meaningless.
+    res = _run_gate(86.20, 28.60, comparable=False)
+    assert res.failed is False
+    assert res.status == Result.Status.SKIPPED
+    assert "test-supplied reason" in res.comment

--- a/ci/tests/test_llvm_coverage_gate.py
+++ b/ci/tests/test_llvm_coverage_gate.py
@@ -33,14 +33,22 @@ def _gate_snippet() -> str:
     The gate lives inside `if __name__ == "__main__":`, so it cannot be imported;
     exec'ing its own source keeps this test honest about what the job really does.
 
-    The two statements are collected as AST NODES and re-emitted at top level.
-    A line-range slice plus textwrap.dedent cannot express this: the drop
-    assignment and the verdict chain sit at DIFFERENT nesting depths (the
-    assignment is under `if _measurement_comparable:`, which is what keeps a
-    fabricated drop from being computed for two unparsed measurements), so the
-    raw slice is not a valid suite at any single indent. Extracting nodes makes
-    the extraction indentation-independent, so a future re-nesting of either
-    statement cannot silently degenerate this into an IndentationError.
+    The statements are collected as AST NODES and re-emitted. A line-range slice
+    plus textwrap.dedent cannot express this: the drop assignment, the verdict
+    chain and the abstention sit at DIFFERENT nesting depths, so the raw slice is
+    not a valid suite at any single indent. Extracting nodes makes the extraction
+    indentation-independent, so a future re-nesting cannot silently degenerate
+    this into an IndentationError.
+
+    The abstention and the tolerance verdict are two SEPARATE production
+    statements, mutually exclusive on comparability rather than arms of one
+    chain: the abstention must stay reachable when the differential script ran,
+    selected an incomplete baseline and then found nothing coverable, which is a
+    state the verdict's own `if _diff_ran:` enclosure does not reach. Their guard
+    relationship is what these tests assert on, so it is reproduced from
+    production's OWN `_measurement_comparable` test node rather than rebuilt
+    here: the drop and the verdict are re-emitted under it, and the abstention
+    follows as the independent statement it is in production.
     """
     src = open(_JOB, encoding="utf-8").read()
     tree = ast.parse(src)
@@ -54,12 +62,32 @@ def _gate_snippet() -> str:
         n
         for n in ast.walk(tree)
         if isinstance(n, ast.If)
-        and ast.unparse(n.test) == "not _measurement_comparable"
+        and ast.unparse(n.test) == "coverage_degraded(_drop)"
         and "diff_res.set_failed()" in ast.unparse(n)
+    ]
+    abstain = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.If)
+        and ast.unparse(n.test) == "not _measurement_comparable"
+        and "diff_res.set_status(Result.Status.SKIPPED)" in ast.unparse(n)
+    ]
+    # The guard that keeps a fabricated drop from being computed for two
+    # unparsed measurements. Taken from production so this cannot describe a
+    # nesting the job no longer has.
+    guard = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.If)
+        and ast.unparse(n.test) == "_measurement_comparable"
+        and any(a is assign[0] for a in ast.walk(n))
     ]
     assert len(assign) == 1, f"expected one drop assignment, found {len(assign)}"
     assert len(verdict) == 1, f"expected one verdict chain, found {len(verdict)}"
-    mod = ast.Module(body=[assign[0], verdict[0]], type_ignores=[])
+    assert len(abstain) == 1, f"expected one abstention block, found {len(abstain)}"
+    assert len(guard) == 1, f"expected one comparability guard, found {len(guard)}"
+    guarded = ast.If(test=guard[0].test, body=[assign[0], verdict[0]], orelse=[])
+    mod = ast.Module(body=[guarded, abstain[0]], type_ignores=[])
     ast.fix_missing_locations(mod)
     return ast.unparse(mod)
 
@@ -123,10 +151,26 @@ def test_gate_snippet_is_the_real_verdict_block():
     # The verdict is reached only for two comparable measurements; if this guard
     # ever leaves the block, the comparable=False assertions below go vacuous.
     assert "_measurement_comparable" in src
-    # All THREE arms, so the pass path below is executed rather than merely
-    # not-failed. The previous line-range extraction stopped at set_failed() and
-    # so never carried this arm.
+    # BOTH arms of the tolerance verdict, so the pass path below is executed
+    # rather than merely not-failed. The previous line-range extraction stopped
+    # at set_failed() and so never carried this arm.
     assert "did not degrade beyond tolerance" in src
+    # The abstention is a SEPARATE statement guarded on the negation, not an arm
+    # of the verdict chain. Both halves are asserted because the two failure
+    # directions are different bugs: were the abstention folded back INTO the
+    # verdict chain it would stop being reachable when the differential script
+    # ran and only the baseline turned out incomplete (a green sub-result for a
+    # run that did not judge), and were the guard dropped entirely every
+    # comparable run would abstain.
+    tree = ast.parse(src)
+    assert [ast.unparse(n.test) for n in tree.body] == [
+        "_measurement_comparable",
+        "not _measurement_comparable",
+    ], f"snippet no longer reproduces the two guarded statements: {ast.unparse(tree)}"
+    assert "diff_res.set_status(Result.Status.SKIPPED)" in src
+    # ...and it must NOT be nested inside the comparable branch, or a
+    # baseline-side abstention could never reach it.
+    assert "set_status(Result.Status.SKIPPED)" not in ast.unparse(tree.body[0])
 
 
 def test_tolerance_is_unchanged():

--- a/ci/tests/test_llvm_coverage_gate.py
+++ b/ci/tests/test_llvm_coverage_gate.py
@@ -65,11 +65,17 @@ def _gate_snippet() -> str:
         and ast.unparse(n.test) == "coverage_degraded(_drop)"
         and "diff_res.set_failed()" in ast.unparse(n)
     ]
+    # Matched on the SKIPPED body plus a test that CONTAINS the comparability
+    # negation rather than equals it: the abstention is also guarded on
+    # diff_res.is_ok(), because it MUTATES a result that may already carry the
+    # differential script's own FAIL. An exact-unparse match here stopped finding
+    # the node the moment that second term was added, and this helper's own
+    # self-assert below then fired loudly.
     abstain = [
         n
         for n in ast.walk(tree)
         if isinstance(n, ast.If)
-        and ast.unparse(n.test) == "not _measurement_comparable"
+        and "not _measurement_comparable" in ast.unparse(n.test)
         and "diff_res.set_status(Result.Status.SKIPPED)" in ast.unparse(n)
     ]
     # The guard that keeps a fabricated drop from being computed for two
@@ -110,6 +116,16 @@ class _ResultStub:
     def set_status(self, status):
         self.status = status
         return self
+
+    def is_ok(self):
+        # The abstention is guarded on this as well as on comparability, because
+        # it mutates a result that may already carry the differential script's
+        # FAIL. Delegating to the REAL predicate keeps that semantics from
+        # drifting: a status of None means from_commands_run has not been
+        # modelled here (these tests drive the tolerance verdict, where the
+        # script succeeded), so it reports ok, which is the state that lets the
+        # abstention run.
+        return self.status is None or Result.is_ok(self)
 
 
 def _run_gate(
@@ -165,7 +181,7 @@ def test_gate_snippet_is_the_real_verdict_block():
     tree = ast.parse(src)
     assert [ast.unparse(n.test) for n in tree.body] == [
         "_measurement_comparable",
-        "not _measurement_comparable",
+        "not _measurement_comparable and diff_res.is_ok()",
     ], f"snippet no longer reproduces the two guarded statements: {ast.unparse(tree)}"
     assert "diff_res.set_status(Result.Status.SKIPPED)" in src
     # ...and it must NOT be nested inside the comparable branch, or a

--- a/ci/tests/test_llvm_coverage_gate.py
+++ b/ci/tests/test_llvm_coverage_gate.py
@@ -6,9 +6,9 @@ message states. `coverage_drop` rounds the difference so the binary-float
 representation of a decimal subtraction cannot push it over the threshold.
 """
 
+import ast
 import os
 import sys
-import textwrap
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
@@ -32,11 +32,36 @@ def _gate_snippet() -> str:
 
     The gate lives inside `if __name__ == "__main__":`, so it cannot be imported;
     exec'ing its own source keeps this test honest about what the job really does.
+
+    The two statements are collected as AST NODES and re-emitted at top level.
+    A line-range slice plus textwrap.dedent cannot express this: the drop
+    assignment and the verdict chain sit at DIFFERENT nesting depths (the
+    assignment is under `if _measurement_comparable:`, which is what keeps a
+    fabricated drop from being computed for two unparsed measurements), so the
+    raw slice is not a valid suite at any single indent. Extracting nodes makes
+    the extraction indentation-independent, so a future re-nesting of either
+    statement cannot silently degenerate this into an IndentationError.
     """
-    lines = open(_JOB, encoding="utf-8").read().splitlines(True)
-    start = next(i for i, l in enumerate(lines) if "_drop = coverage_drop(" in l)
-    end = next(i for i, l in enumerate(lines) if "diff_res.set_failed()" in l)
-    return textwrap.dedent("".join(lines[start : end + 1]))
+    src = open(_JOB, encoding="utf-8").read()
+    tree = ast.parse(src)
+    assign = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Assign)
+        and ast.unparse(n).startswith("_drop = coverage_drop(")
+    ]
+    verdict = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.If)
+        and ast.unparse(n.test) == "not _measurement_comparable"
+        and "diff_res.set_failed()" in ast.unparse(n)
+    ]
+    assert len(assign) == 1, f"expected one drop assignment, found {len(assign)}"
+    assert len(verdict) == 1, f"expected one verdict chain, found {len(verdict)}"
+    mod = ast.Module(body=[assign[0], verdict[0]], type_ignores=[])
+    ast.fix_missing_locations(mod)
+    return ast.unparse(mod)
 
 
 class _ResultStub:
@@ -70,6 +95,12 @@ def _run_gate(
         "COVERAGE_DROP_TOLERANCE": COVERAGE_DROP_TOLERANCE,
         "b_line_cov": baseline,
         "c_line_cov": current,
+        # Node extraction carries the whole three-arm chain, including the
+        # did-not-degrade arm that the previous line-range slice stopped short
+        # of. That arm reports the delta, computed here exactly as production
+        # computes it, so the pass path is now executed rather than merely
+        # not-failed.
+        "delta": current - baseline,
         # The gate only reaches a tolerance verdict for two comparable
         # measurements; these tests are about the tolerance, so they say so.
         "_measurement_comparable": comparable,
@@ -92,6 +123,10 @@ def test_gate_snippet_is_the_real_verdict_block():
     # The verdict is reached only for two comparable measurements; if this guard
     # ever leaves the block, the comparable=False assertions below go vacuous.
     assert "_measurement_comparable" in src
+    # All THREE arms, so the pass path below is executed rather than merely
+    # not-failed. The previous line-range extraction stopped at set_failed() and
+    # so never carried this arm.
+    assert "did not degrade beyond tolerance" in src
 
 
 def test_tolerance_is_unchanged():

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -5994,6 +5994,16 @@ ORDER BY (test_name, callee_offset)
                 )
             print(test_result.description)
 
+    # An authoritative marker for coverage: the scheduler ran to the end AND no
+    # worker was killed on the way. `All tests have finished.` below cannot carry
+    # this - it is also printed when a worker died mid-run, because the counter it
+    # tests is the SELECTED test count, not a completed one - and it is printed
+    # for a zero-test run too. A coverage shard that did not execute what it
+    # planned must publish no profile, so the fact is emitted here, where both the
+    # worker state and the scheduler state are known.
+    if total_tests_run != 0 and not runner_process_killed.is_set():
+        print("Coverage run completed all selected tests.")
+
     if total_tests_run == 0:
         print("No tests were run.")
         sys.exit(1)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/105684
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

The `LLVM Coverage` gate fails a PR when line coverage drops more than 0.3 pp below the baseline.
Both percentages are merged from per-shard `.profdata` artifacts that are deliberately
`optional=True`, and nothing checked that either side had all of them. Five routes drop a shard
while every check-run stays green, from a producer merge that crashes to an aggregate merge that
discards a corrupt input under `-failure-mode=warn`.

Both directions are wrong. A short PR side fails an unrelated PR for a regression it did not cause
([example](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110708&sha=1489754354cc3aef1e4c053cdbeef8d6b1a04ea6&name_0=PR&name_1=LLVM%20Coverage)).
A short baseline has a low total, so a real regression passes; that case produces a PASS, emits no
failure row, and is invisible in any failure count.

Rather than raise the tolerance, which would paper over the measurement, the invariant is that a
verdict comes only from two complete measurements of the same artifact manifest. Each merge becomes all-or-nothing via
`--failure-mode=any`; each producer publishes no profile unless it ran what it planned; each shard
names its profile after its own coverage artifact, so completeness is exact set equality. That
fact travels beside the measurement in a sidecar riding on the existing
`llvm_coverage.info` artifact, so no new artifact name and no workflow file change is needed.
Otherwise the job reports `SKIPPED` with the reason, which counts as OK, and withholds every
comparative output, including the CI DB row that later baselines read. No master commit has a
sidecar yet, so a missing one means "unknown" and the fallback selector pass reproduces today's
behaviour until master republishes.

One residual is not covered: two runs can both be complete over the same 21 artifacts yet exercise
different code, for example when a commit changes which integration suites are selected. The
fingerprint detects artifact-list drift only, and is not a claim that the measured code matched.

<details>
<summary>Why <code>tests/clickhouse-test</code> gains a marker, and validation</summary>

`All tests have finished.` cannot carry the "this run executed what it planned" fact, because a
worker that dies abnormally still reaches it: the counter tested there is the number of tests
selected. Suppressing that marker would be the tidier layer, but such a run already exits non-zero
and is already reported as a failure, so suppression would only reclassify it from `FAIL` to `ERROR`
across every functional-test job. The new line is additive and leaves `success_finish` and its three
consumers untouched. If you would rather have the suppression, that is a deliberate CI semantics
change and I would send it separately.

92 new pytest cases plus one on the existing gate test, all pure and deterministic. Each of 51
mutations, one per behaviour introduced here, reddens its intended case. `ci/tests/` run per arm
against a baseline exported from this branch's merge base: 607 collected here against 514 there,
0 new failures and 0 tests deleted by set difference, and the same pre-existing host-flaky rows in
both arms. Workflow config generation succeeds, which confirms no new artifact name was introduced.
The `llvm-profdata` behaviour relied on here was measured: `-failure-mode=any` on a corrupt input exits
1 and writes no file, while the clean path is byte-identical to `-failure-mode=warn`; a zero-length
input is accepted silently at both modes, which is why it is filtered explicitly.

The other three routes are an unbounded `*.profdata` glob, a run that stopped early yet still
publishes a valid but under-covered profile, and that zero-length `.profraw`. When a measurement is
incomplete the full report is still published, labelled `partial measurement: N of M shards`, as the
best artifact for identifying the missing shard.

</details>