### PR TITLE
Speed up 03300_merge_parts_metric to stop it timing out

### DIFF
--- a/tests/queries/0_stateless/03300_merge_parts_metric.sh
+++ b/tests/queries/0_stateless/03300_merge_parts_metric.sh
@@ -18,7 +18,10 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 #
 # We sample the metric before and after reading system.merges, and check if the sum
 # falls within that range. This should significantly reduce false negatives.
+#
+# The threshold below must stay at 10% of the iteration count: both numbers describe
+# one ratio, so changing either alone would silently alter what is asserted.
 
-yes "WITH metric_before AS (SELECT value FROM system.metrics WHERE name = 'MergeParts'), merges_sum AS (SELECT sum(length(source_part_names)) AS total FROM system.merges), metric_after AS (SELECT value FROM system.metrics WHERE name = 'MergeParts') SELECT merges_sum.total BETWEEN least(metric_before.value, metric_after.value) AND greatest(metric_before.value, metric_after.value) FROM metric_before, merges_sum, metric_after;" | head -n1000 | $CLICKHOUSE_CLIENT | {
-  sort | uniq -cd | awk '$1 > 100 && $NF == "1" { print $NF }'
+yes "WITH metric_before AS (SELECT value FROM system.metrics WHERE name = 'MergeParts'), merges_sum AS (SELECT sum(length(source_part_names)) AS total FROM system.merges), metric_after AS (SELECT value FROM system.metrics WHERE name = 'MergeParts') SELECT merges_sum.total BETWEEN least(metric_before.value, metric_after.value) AND greatest(metric_before.value, metric_after.value) FROM metric_before, merges_sum, metric_after;" | head -n300 | $CLICKHOUSE_CLIENT | {
+  sort | uniq -cd | awk '$1 > 30 && $NF == "1" { print $NF }'
 }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/36933
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`03300_merge_parts_metric` intermittently fails with `Timeout!` at the 600s per-test cap. The
test does a fixed 1000 sequential client round-trips, and its normal runtime already sits close
to that cap on the slowest jobs: over 14 days on `Stateless tests (amd_tsan, parallel)` the p50
is 140.8s and the observed max 303.2s, leaving only about 2x headroom.

Over 365 days the family has 18 timeout rows, and **every one is on a sanitizer build** (asan 8,
msan 8, tsan 2; non-sanitizer 0), including one on master. No single setting explains them: the
common factor is a fixed iteration count against a build where each round-trip is several times
slower. Adding
`no-msan` in de069e3b508e stopped the msan rows; this generalizes that without removing asan
and tsan coverage.

This reduces the iteration count from 1000 to 300 and the pass threshold from 100 to 30. Both
numbers describe one ratio, so the assertion is unchanged: the metric and `system.merges` must
agree in more than 10% of samples. The before/after `BETWEEN` sandwich, the `long` and `no-msan`
tags and the reference file are untouched, and `head -n1000` has never been modified since the
test was added, so no previous flakiness fix is reverted.

Measured on a real server kept under continuous merge activity, the margin over the threshold is
10x and is the same at both 1000 and 300 iterations, the median runtime drops from 13.83s to
7.16s over 50 runs per arm, three mutations each make the test fail, and 50 out of 50 randomized
runs pass. Details are in the collapsed section below.

This addresses the `Timeout!` signature only. The same test name also carries `result differs
with reference`, `having stderror` and internal-query failures, which have separate causes and
are out of scope here.

Related: https://github.com/ClickHouse/ClickHouse/pull/36933
Reported failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=36933&sha=ecc923adbb0e5eb10bfd395e1b9a09394f4535c6&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%29

<details>
<summary>Measured runtime and margin detail</summary>

Runtime, 50 runs per arm, same server, randomization enabled:

| arm | min | median | p95 | max |
|---|---|---|---|---|
| 1000 iterations (before) | 12.06s | 13.83s | 15.48s | 19.47s |
| 300 iterations (after) | 5.99s | 7.16s | 8.20s | 8.26s |

The whole-test speedup is 1.93x rather than 3.33x because a fixed per-test overhead does not
scale with the iteration count. That overhead measures 4.75s directly at 1 iteration, and a
two-point fit over the two arms gives 9.53 ms per iteration plus 4.30s fixed. The iteration
component itself scales 9.53s to 2.86s, exactly 1000/300. In CI, where the test takes 140.8s at
p50, that component dominates, so scaling only it projects p50 to about 73s and the observed max
from 303.2s to about 157s, taking headroom to the cap from 1.98x to about 3.8x and bringing the
projected max under the 180s that `TEST_MAX_RUN_TIME_IN_SECONDS` describes as too long.

Ratio margin, on a real server with merges continuously in flight (under `clickhouse local` both
`MergeParts` and `system.merges` are 0, so the query is degenerate and cannot be measured there):

| arm | reps | min passing count | threshold | margin |
|---|---|---|---|---|
| 300 iterations, moderate load | 25 | 300 / 300 | 30 | 10.0x |
| 300 iterations, 30 concurrent merges | 30 | 299 / 300 | 30 | 10.0x |
| 1000 iterations, same load | 12 | 998 / 1000 | 100 | 10.0x |

Sampling 300 raw values under that load: 0% were degenerate, 100% had a non-zero merge sum, the
metric moved between the before and after reads in 5% of samples, and in 1% the sum differed
from the first metric read, which is the race the sandwich absorbs.

Per `max_threads`, 300 iterations under the same load: 8.26 ms per query at 1, 9.69 at 2, 9.95 at
3, 9.19 at 32. The spread is 1.20x and 32 is not the slowest, consistent with the timeout
population showing no `max_threads` correlation.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.593` (included in `26.8` and later)
<!-- ch-version-info:end -->