### PR TITLE
Fix data loss when a ReplicatedMergeTree INSERT is cancelled during ambiguous-commit recovery

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeperRetries.h
+++ b/src/Common/ZooKeeper/ZooKeeperRetries.h
@@ -68,6 +68,7 @@ public:
     {
         current_iteration = 0;
         current_backoff_ms = retries_info.initial_backoff_ms;
+        gave_up = false;
 
         while (current_iteration == 0 || canTry())
         {
@@ -90,6 +91,9 @@ public:
             catch (...)
             {
                 iteration_cleanup();
+                /// Non-retryable non-Keeper errors (e.g. `MEMORY_LIMIT_EXCEEDED`) are a give-up:
+                /// run the finalizer before leaving the loop.
+                giveUpOnceWhileHandlingException("giving up after non-retryable error");
                 throw;
             }
             current_iteration++;
@@ -162,10 +166,15 @@ public:
 
     const std::string & getLastKeeperErrorMessage() const { return keeper_error.message; }
 
-    /// action will be called only once and only after latest failed retry
-    /// NOTE: this one will be called only in case when retries finishes with Keeper exception
-    /// if it will be some other exception this function will not be called.
-    void actionAfterLastFailedRetry(std::function<void()> f) { action_after_last_failed_retry = std::move(f); }
+    /// Finalizer for give-up paths: retry limit, explicit stop, query cancel/timeout (when
+    /// `checkTimeLimit` throws), and non-Keeper exceptions from the loop body. Not invoked on
+    /// success, and not on non-hardware `KeeperException` rethrows (those are treated as a known
+    /// Keeper outcome, not an ambiguous give-up).
+    /// On the retry-limit and explicit-stop paths an error recorded via `setUserError` becomes the
+    /// reported outcome. On the cancel/timeout and non-Keeper paths an exception is already in flight
+    /// and is kept, so a finalizer that must replace the outcome there has to throw (callers often
+    /// throw `UNKNOWN_STATUS_OF_INSERT` from here).
+    void onGiveUp(std::function<void()> f) { on_give_up = std::move(f); }
 
     const std::string & getName() const { return name; }
 
@@ -186,6 +195,53 @@ private:
         std::string message;
         std::exception_ptr exception;
     };
+
+    /// Runs on_give_up at most once per `retryLoop` invocation.
+    void giveUpOnce()
+    {
+        if (gave_up)
+            return;
+        gave_up = true;
+        if (on_give_up)
+            on_give_up();
+    }
+
+    /// Runs the give-up finalizer while an exception is in flight. The exception in flight is the more
+    /// specific outcome, so it is kept: a finalizer that needs to replace it does so by throwing (see
+    /// `onGiveUp`), and errors it merely records via setUserError are not surfaced here. When it does
+    /// throw, log the triggering exception first, otherwise the cancellation or memory-limit error that
+    /// actually caused the give-up leaves no trace.
+    void giveUpOnceWhileHandlingException(std::string_view reason)
+    {
+        auto triggering_exception = std::current_exception();
+        try
+        {
+            giveUpOnce();
+        }
+        catch (...)
+        {
+            if (logger && triggering_exception)
+                tryLogException(triggering_exception, logger, fmt::format("ZooKeeperRetriesControl: {}: {}", name, reason));
+            throw;
+        }
+    }
+
+    /// If the query was cancelled or hit a throwing time limit, run the give-up finalizer then rethrow.
+    void checkQueryTimeLimitOrGiveUp()
+    {
+        if (!retries_info.query_status)
+            return;
+
+        try
+        {
+            retries_info.query_status->checkTimeLimit();
+        }
+        catch (...)
+        {
+            giveUpOnceWhileHandlingException("giving up after query cancellation or timeout");
+            throw;
+        }
+    }
 
     bool canTry()
     {
@@ -210,7 +266,7 @@ private:
 
         if (stop_retries)
         {
-            action_after_last_failed_retry();
+            giveUpOnce();
             logLastError("stop retries on request");
             throwIfError();
             return false;
@@ -218,15 +274,14 @@ private:
 
         if (total_failures > retries_info.max_retries)
         {
-            action_after_last_failed_retry();
+            giveUpOnce();
             logLastError("retry limit is reached");
             throwIfError();
             return false;
         }
 
         /// Check if the query was cancelled.
-        if (retries_info.query_status)
-            retries_info.query_status->checkTimeLimit();
+        checkQueryTimeLimitOrGiveUp();
 
         /// retries
         logLastError("will retry due to error");
@@ -234,8 +289,7 @@ private:
         current_backoff_ms = std::min(current_backoff_ms * 2, retries_info.max_backoff_ms);
 
         /// Check if the query was cancelled again after sleeping.
-        if (retries_info.query_status)
-            retries_info.query_status->checkTimeLimit();
+        checkQueryTimeLimitOrGiveUp();
 
         return true;
     }
@@ -288,7 +342,8 @@ private:
     UInt64 total_failures = 0;
     UserError user_error;
     KeeperError keeper_error;
-    std::function<void()> action_after_last_failed_retry = []() {};
+    std::function<void()> on_give_up;
+    bool gave_up = false;
     bool iteration_succeeded = true;
     bool stop_retries = false;
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -1012,7 +1012,7 @@ std::vector<DeduplicationHash> ReplicatedMergeTreeSink::commitPart(
             /// If we fail to do so (keeper unavailable) then we don't know if the changes were applied or not so
             /// we can't delete the local part, as if the changes were applied then inserted block appeared in
             /// `/blocks/`, and it can not be inserted again.
-            new_retry_controller.actionAfterLastFailedRetry([&]
+            new_retry_controller.onGiveUp([&]
             {
                 {
                     /// While we could not verify in keeper whether the part was committed, the failed-quorum
@@ -1022,7 +1022,12 @@ std::vector<DeduplicationHash> ReplicatedMergeTreeSink::commitPart(
                     /// so we check the state under the parts lock to make the decision free of a race with the cleanup.
                     auto parts_lock = storage.lockParts();
                     if (part->getState() == MergeTreeDataPartState::PreActive)
+                    {
+                        /// Suppress writeExistingPart's try_rollback_part_rename after we keep the part.
+                        /// Keeper status may still be unknown; enqueuePartForCheck reconciles that later.
+                        part->new_part_was_committed_to_zookeeper_after_rename_on_disk = true;
                         transaction.commit(parts_lock);
+                    }
                     else
                     {
                         /// The cleanup already committed the part storage transaction and moved the part
@@ -1390,7 +1395,7 @@ void ReplicatedMergeTreeSink::resolveQuorum(const ZooKeeperWithFaultInjectionPtr
             context->getProcessListElement()
         });
 
-    quorum_retries_ctl.actionAfterLastFailedRetry([&]
+    quorum_retries_ctl.onGiveUp([&]
     {
         ProfileEvents::increment(ProfileEvents::QuorumFailedInserts);
         /// We do not know whether or not data has been inserted in other replicas

--- a/tests/integration/test_quorum_inserts/test.py
+++ b/tests/integration/test_quorum_inserts/test.py
@@ -561,6 +561,92 @@ def test_insert_quorum_with_keeper_loss_connection(started_cluster):
             )
 
 
+def test_cancel_during_ambiguous_commit_recovery(started_cluster):
+    # The part commit reaches Keeper, but its response is lost. Cancel the `INSERT` while
+    # its recovery probe is paused, then make that probe fail with a hardware error.
+    # The recovery must preserve the committed local part instead of allowing the
+    # transaction destructor to roll it back.
+    table_name = "test_cancel_ambiguous_commit_" + uuid.uuid4().hex
+    query_id = "cancel_ambiguous_commit_" + uuid.uuid4().hex
+    part_name = "all_0_0_0"
+    create_query = (
+        f"CREATE TABLE {table_name} "
+        "(a Int8, d Date) "
+        "Engine = ReplicatedMergeTree('/clickhouse/tables/{table}', '{replica}') "
+        "ORDER BY a "
+    )
+
+    zero.query(create_query)
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        # Enabled inside the `try` so that a failure here still disables the failpoints already
+        # enabled. `replicated_merge_tree_commit_zk_fail_when_recovering_from_hw_fault` is a regular
+        # failpoint, so leaking it would break the tests that follow.
+        zero.query(
+            "SYSTEM ENABLE FAILPOINT replicated_merge_tree_commit_zk_fail_after_op"
+        )
+        zero.query("SYSTEM ENABLE FAILPOINT replicated_merge_tree_insert_retry_pause")
+        zero.query(
+            "SYSTEM ENABLE FAILPOINT replicated_merge_tree_commit_zk_fail_when_recovering_from_hw_fault"
+        )
+
+        insert_future = executor.submit(
+            zero.query,
+            f"INSERT INTO {table_name}(a,d) VALUES(1, '2011-01-01')",
+            query_id=query_id,
+            settings={
+                # Module default profile sets insert_quorum=2; this repro is single-replica.
+                "insert_quorum": 0,
+                "insert_keeper_max_retries": 20,
+                "insert_keeper_retry_max_backoff_ms": 10,
+            },
+        )
+
+        zero.query(
+            "SYSTEM WAIT FAILPOINT replicated_merge_tree_insert_retry_pause PAUSE",
+            timeout=60,
+        )
+
+        zk = cluster.get_kazoo_client("zoo1")
+        part_path = f"/clickhouse/tables/{table_name}/replicas/zero/parts/{part_name}"
+        assert zk.exists(part_path) is not None
+
+        # `ASYNC` marks the blocked query as cancelled without waiting for it to leave
+        # the failpoint. Verify the cancellation before releasing recovery so the
+        # test deterministically exercises the cancellation check between retries.
+        zero.query(f"KILL QUERY WHERE query_id = '{query_id}' ASYNC")
+        assert (
+            zero.query(
+                f"SELECT is_cancelled FROM system.processes WHERE query_id = '{query_id}'"
+            ).strip()
+            == "1"
+        )
+        zero.query("SYSTEM DISABLE FAILPOINT replicated_merge_tree_insert_retry_pause")
+
+        insert_exception = insert_future.exception(timeout=60)
+        assert insert_exception is not None
+        assert "UNKNOWN_STATUS_OF_INSERT" in str(insert_exception), str(
+            insert_exception
+        )
+
+        assert zk.exists(part_path) is not None
+        assert "1" == zero.query(f"SELECT count() FROM {table_name}").strip()
+    finally:
+        zero.query(
+            "SYSTEM DISABLE FAILPOINT replicated_merge_tree_commit_zk_fail_when_recovering_from_hw_fault"
+        )
+        zero.query("SYSTEM DISABLE FAILPOINT replicated_merge_tree_insert_retry_pause")
+        zero.query(
+            "SYSTEM DISABLE FAILPOINT replicated_merge_tree_commit_zk_fail_after_op"
+        )
+        # The failpoints are disabled above, so a paused insert is already released and joining it
+        # cannot hang. Join before dropping the table, otherwise `DROP TABLE ... SYNC` races an
+        # insert that is still in flight after an assertion above failed.
+        executor.shutdown(wait=True)
+        zero.query(f"DROP TABLE IF EXISTS {table_name} SYNC")
+
+
 def test_insert_quorum_with_keeper_fail_during_unknown_status(started_cluster):
     # Regression for a logical error ("Part ... doesn't exist") / server abort:
     # a quorum insert commits the part to keeper but the client gets a hardware error,


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/112149

## Problem

An `INSERT` into a `ReplicatedMergeTree` table can silently lose rows.

When the sink commits a part to Keeper and the connection breaks, the outcome is unknown: the commit may or may not have been applied. `ReplicatedMergeTreeSink::commitPart` handles this by registering a recovery callback on its Keeper retry loop, `ZooKeeperRetriesControl`, via `actionAfterLastFailedRetry`. The callback keeps the local part, schedules it for verification and reports `UNKNOWN_STATUS_OF_INSERT`, because a part that might already be in Keeper must not be deleted from disk.

Problem is, `ZooKeeperRetriesControl` only ran that callback when the retry loop hit its retry limit or was stopped explicitly. If the query was cancelled instead, by `KILL QUERY`, by `max_execution_time` or by a client disconnect, or if the loop body threw a non-Keeper exception such as `MEMORY_LIMIT_EXCEEDED`, the loop threw straight out and the callback never ran. `~Transaction` then rolled the part back and deleted it from disk even though its commit may already have reached Keeper. The block hash stays in `/blocks/`, so deduplication rejects a re-insert, other replicas try to fetch a part nobody has, and reads report no error at all.

## Fix

1. `actionAfterLastFailedRetry` is renamed to `onGiveUp` which better reflects its duty, since the callback no longer runs only after a failed retry. This is source-breaking for out-of-tree code including `ZooKeeperRetries.h`; all in-tree callers are updated.

2. `onGiveUp` becomes the single hook for "the retry loop is giving up", covering every way out of the loop rather than just the two failure branches: retry limit, explicit stop, query cancellation or timeout, and non-Keeper exceptions. It runs at most once per `retryLoop` call, so a caller can put all of its give-up handling there and know it runs exactly once, whatever ended the loop. Where an exception is already in flight, that exception is kept as the outcome and a callback that needs to replace it throws, which is what the sink does to surface `UNKNOWN_STATUS_OF_INSERT`.

3. The sink's callback also sets `new_part_was_committed_to_zookeeper_after_rename_on_disk` when it keeps the part, otherwise `writeExistingPart` renames the data directory of the now-active part back to `detached/`.



## Testing

`test_quorum_inserts/test.py::test_cancel_during_ambiguous_commit_recovery` reproduces the loss with failpoints: the commit reaches Keeper but its response is dropped, the `INSERT` is cancelled while the recovery probe is paused, and the probe then fails with a hardware error. Before the fix the query failed with `QUERY_WAS_CANCELLED` and the table was empty; now it fails with `UNKNOWN_STATUS_OF_INSERT` and the row is there.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed silent data loss on `INSERT` into a `ReplicatedMergeTree` table. If the part commit to Keeper failed with a connection error, leaving its outcome unknown, and the query was then cancelled by `KILL QUERY`, by `max_execution_time` or by a client disconnect while the sink was retrying to determine that outcome, the part was removed from local disk even though it could already be committed in Keeper. Deduplication then rejected a re-insert of the same block, and other replicas tried to fetch a part that no longer existed anywhere. Such an `INSERT` now keeps the part, schedules it for verification and fails with `UNKNOWN_STATUS_OF_INSERT` instead of `QUERY_WAS_CANCELLED` or `TIMEOUT_EXCEEDED`. Closes #112149
