### PR TITLE
Pass `--allow_repeated_settings` when collecting server stacktraces

### DIFF
--- a/ci/tests/test_print_stacktraces.py
+++ b/ci/tests/test_print_stacktraces.py
@@ -26,6 +26,7 @@ import argparse
 import io
 import os
 import runpy
+from collections import Counter
 from contextlib import redirect_stdout
 from pathlib import Path
 
@@ -101,6 +102,52 @@ def test_print_sql_stacktraces_against_live_server():
     # output confirms the round-trip succeeded.
     assert "Collecting stacktraces from system.stack_trace table" in output, output
     assert "trace_str" in output or "thread_name" in output, output
+
+
+def test_get_stacktraces_tolerates_repeated_client_options():
+    # A setting passed via --client-option is also copied into
+    # CLICKHOUSE_CLIENT_OPT at startup, so get_additional_client_options returns
+    # it twice.  add_effective_settings adds --allow_repeated_settings for the
+    # duration of a test and remove_settings_from_env drops it again, so at
+    # hung-check time the collector must supply the flag itself or
+    # clickhouse-client exits 36 with "cannot be specified more than once".
+    ct = _load_clickhouse_test()
+    args = _make_args()
+    args.client_option = [
+        "max_untracked_memory=1Gi",
+        "max_memory_usage_for_user=0",
+        "memory_profiler_step=1Gi",
+        "ast_fuzzer_runs=0",
+    ]
+
+    saved = os.environ.get("CLICKHOUSE_CLIENT_OPT")
+    try:
+        os.environ["CLICKHOUSE_CLIENT_OPT"] = " ".join(
+            "--" + option for option in args.client_option
+        )
+
+        # Premise: without this the test would pass trivially if the duplication
+        # ever stopped happening, and would no longer cover the fix.
+        options = ct["get_additional_client_options"](args).split()
+        names = [o.split("=")[0] for o in options if o.startswith("--")]
+        repeated = sorted(n for n, count in Counter(names).items() if count > 1)
+        assert repeated == [
+            "--ast_fuzzer_runs",
+            "--max_memory_usage_for_user",
+            "--max_untracked_memory",
+            "--memory_profiler_step",
+        ], repeated
+        assert "--allow_repeated_settings" not in options, options
+
+        dump = ct["get_stacktraces_from_clickhouse"](args)
+    finally:
+        if saved is None:
+            os.environ.pop("CLICKHOUSE_CLIENT_OPT", None)
+        else:
+            os.environ["CLICKHOUSE_CLIENT_OPT"] = saved
+
+    assert dump, "no stacktraces collected: the client rejected the command line"
+    assert "thread_name" in dump, dump[:2000]
 
 
 def test_is_asan_build_uses_collected_flags():

--- a/ci/tests/test_print_stacktraces.py
+++ b/ci/tests/test_print_stacktraces.py
@@ -105,12 +105,13 @@ def test_print_sql_stacktraces_against_live_server():
 
 
 def test_get_stacktraces_tolerates_repeated_client_options():
-    # A setting passed via --client-option is also copied into
-    # CLICKHOUSE_CLIENT_OPT at startup, so get_additional_client_options returns
-    # it twice.  add_effective_settings adds --allow_repeated_settings for the
-    # duration of a test and remove_settings_from_env drops it again, so at
-    # hung-check time the collector must supply the flag itself or
-    # clickhouse-client exits 36 with "cannot be specified more than once".
+    # A setting passed via `--client-option` is also copied into
+    # `CLICKHOUSE_CLIENT_OPT` at startup, so `get_additional_client_options`
+    # returns it twice.  `add_effective_settings` adds
+    # `--allow_repeated_settings` while a test runs and
+    # `remove_settings_from_env` drops it again, so the collector must supply
+    # the flag itself or `clickhouse-client` exits 36 with
+    # `cannot be specified more than once`.
     ct = _load_clickhouse_test()
     args = _make_args()
     args.client_option = [

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1079,8 +1079,9 @@ def get_stacktraces_from_clickhouse(args, timeout: float = 30):
         [
             get_additional_client_options(args),
             # The options above can repeat: they come from both the environment
-            # and --client-option. add_effective_settings adds this flag only for
-            # the duration of a test, and this collector runs outside one.
+            # and `--client-option`. `add_effective_settings` adds this flag only
+            # while a test runs, and this collector runs from the hung check and
+            # the per-test timeout handler, where it may not be set.
             "--allow_repeated_settings",
             "--allow_introspection_functions=1",
             "--skip_unavailable_shards=1",

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1078,6 +1078,10 @@ def get_stacktraces_from_clickhouse(args, timeout: float = 30):
     settings_str = " ".join(
         [
             get_additional_client_options(args),
+            # The options above can repeat: they come from both the environment
+            # and --client-option. add_effective_settings adds this flag only for
+            # the duration of a test, and this collector runs outside one.
+            "--allow_repeated_settings",
             "--allow_introspection_functions=1",
             "--skip_unavailable_shards=1",
         ]


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/109368
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`get_stacktraces_from_clickhouse` in `tests/clickhouse-test` builds a `clickhouse-client` command
line that can carry the same setting twice, and then dies before querying anything:

```
Bad arguments: option '--max_untracked_memory' cannot be specified more than once
```

The duplication is intended. `get_additional_client_options` concatenates the
`CLICKHOUSE_CLIENT_OPT` copy of `--client-option` with `--client-option` itself, so that
user-supplied values come last and win; that is the documented last-occurrence-wins override.
`add_effective_settings` makes it safe by appending `--allow_repeated_settings` to the environment
while a test runs, but `remove_settings_from_env` resets the variable to the flagless startup
snapshot in a `finally` block after every test. This collector is reached from the end-of-run hung
check and from the per-test timeout handler, where the flag may not be set, so it assembles the
command with the duplicates and without the flag, and `clickhouse-client` exits 36.

The consequence is a diagnostics loss: a hung-check report loses its `system.stack_trace` dump
entirely, which is the only view that maps a stuck thread to the query it was running. The
`Hung check failed` verdict itself is decided elsewhere, so no CI result changes. It has been
observed on `master` as well as on pull requests.

This adds the flag where the command line is assembled, matching what `add_effective_settings`
already does for the ordinary test path. All three query branches share the single `settings_str`,
so one line covers them.

An observed failure: [`Stress test (arm_tsan)` on #109368](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109368&sha=cc445a8b9100dad9d25b5abeeb001fbf7df0ee1d&name_0=PR&name_1=Stress%20test%20%28arm_tsan%29).

Validation: driving the real function against a live server returns 0 bytes with `exit status 36`
before the change and a 332 KB dump containing `thread_name` after it. The new test in
`ci/tests/test_print_stacktraces.py` asserts both that the assembled options really are duplicated
and that a dump comes back; reverting the one-line change reddens it with the message above.

Related: https://github.com/ClickHouse/ClickHouse/pull/109368


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.871` (included in `26.8` and later)
<!-- ch-version-info:end -->