### PR TITLE
Make the `query_id` of `03652_threads_count_insert` unique

### DIFF
--- a/tests/queries/0_stateless/03652_threads_count_insert.sh
+++ b/tests/queries/0_stateless/03652_threads_count_insert.sh
@@ -24,7 +24,7 @@ for max_threads in 1 7; do
     for max_insert_threads in 1 4; do
         echo "max_threads: $max_threads max_insert_threads: $max_insert_threads"
 
-        QUERY_ID="03652_query_id_$RANDOM"
+        QUERY_ID="${CLICKHOUSE_DATABASE}_03652_${max_threads}_${max_insert_threads}_$($CLICKHOUSE_CLIENT -q 'SELECT lower(hex(generateUUIDv4()))')"
         SETTINGS="--query_id=$QUERY_ID "
         SETTINGS="$SETTINGS --max_threads=$max_threads "
         SETTINGS="$SETTINGS --max_insert_threads=$max_insert_threads "


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/106671


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`03652_threads_count_insert.sh` built its `query_id` as `03652_query_id_$RANDOM`, drawing 4
times per run from bash's 15-bit `$RANDOM` (0..32767). When two of the 4 loop iterations draw
the same number they share one `query_id`, and every predicate of the test's `system.query_log`
filter is true of both INSERTs, so the later `SELECT` returns two rows instead of one. `order by
ALL` prints the smaller first, which is the extra `1` above a `7` seen in CI. This is a test bug,
not a `query_log` defect: `query_id` uniqueness is enforced only among concurrently running
queries and the log is append-only history, so several rows per `query_id` are by design.

There is a second collision axis: `current_database = currentDatabase()` isolates executions
only when each gets a fresh database, while the stress arms pass a fixed `--database`. The fix
composes the id from the per-iteration loop variables (closing the within-run axis by
construction, with no randomness) plus a server `generateUUIDv4` (closing the across-execution
axis).

Validation. The natural failure is roughly 1 in 11,000, so it was proven by forcing the
collision rather than by repetition: replacing `$RANDOM` with a constant makes the test fail
deterministically with the same diff class in maximal form, and adding only the loop-variable
component makes it pass again with zero randomness involved. The second axis reproduces with a
fixed `--database` and passes 5/5 with the fix. Randomized 50/50 run: 50 OK, 0 FAIL. No blanket
`no-random-settings` tag was added, since the mechanism is independent of the randomizer.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112680&sha=fa21e1fb571139f9ca1c573fd38bd6232eb50aa5&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20sequential%29

Of the 13 CI failures in the last 90 days, 11 have this collision shape. One (#110015) is a
thread-count shortfall (`7` becoming `4`, not an extra line) and one is a `server died` during
cleanup, so the residual rate should fall to about 1 per 90 days rather than to zero.