### PR TITLE
Keep or skip five stateless tests that a Replicated database refuses to run

### DIFF
--- a/tests/queries/0_stateless/03981_refreshable_mv_retries_int64_max.reference
+++ b/tests/queries/0_stateless/03981_refreshable_mv_retries_int64_max.reference
@@ -1,1 +1,2 @@
 ok	1
+formatted	1

--- a/tests/queries/0_stateless/03981_refreshable_mv_retries_int64_max.sh
+++ b/tests/queries/0_stateless/03981_refreshable_mv_retries_int64_max.sh
@@ -9,8 +9,12 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # keeps retrying and reaches attempt_number > 1 (the formatting branch in
 # RefreshTask::executeRefresh). throwIf reads a column so it throws at refresh
 # execution, not at view creation.
+# APPEND keeps the view creatable on a Replicated database: a non-APPEND
+# refreshable view over a non-replicated inner table is refused there. The retry
+# machinery does not read the append flag, so the formatting branch is reached
+# either way.
 $CLICKHOUSE_CLIENT -q "
-    create materialized view rmv refresh after 1 year settings refresh_retries = 9223372036854775807
+    create materialized view rmv refresh after 1 year settings refresh_retries = 9223372036854775807 append
         (x Int64) engine Memory as select throwIf(number = 0) as x from numbers(1);"
 
 # Wait until the second attempt has started (retry counter advanced past the

--- a/tests/queries/0_stateless/03981_refreshable_mv_retries_int64_max.sh
+++ b/tests/queries/0_stateless/03981_refreshable_mv_retries_int64_max.sh
@@ -17,18 +17,26 @@ $CLICKHOUSE_CLIENT -q "
     create materialized view rmv refresh after 1 year settings refresh_retries = 9223372036854775807 append
         (x Int64) engine Memory as select throwIf(number = 0) as x from numbers(1);"
 
-# Wait until the second attempt has started (retry counter advanced past the
-# first attempt). This is exactly when executeRefresh formats the
-# '(attempt N/total)' comment.
+# Wait until a third attempt has been scheduled. system.view_refreshes.retry is
+# attempt_number minus one while a refresh is in flight, so retry = 1 is also
+# reached before the second attempt starts; retry >= 2 is reachable only once
+# attempt 2 has entered executeRefresh, which is where the '(attempt N/total)'
+# comment is formatted.
 for _ in {1..200}; do
     retry=$($CLICKHOUSE_CLIENT -q "select retry from system.view_refreshes where view = 'rmv' and database = currentDatabase()" | xargs)
-    if [ "$retry" -ge 1 ] 2>/dev/null; then
+    if [ "$retry" -ge 2 ] 2>/dev/null; then
         break
     fi
     sleep 0.2
 done
 
 # Server is alive and the second attempt ran without UB.
-$CLICKHOUSE_CLIENT -q "select 'ok', retry >= 1 from system.view_refreshes where view = 'rmv' and database = currentDatabase()"
+$CLICKHOUSE_CLIENT -q "select 'ok', retry >= 2 from system.view_refreshes where view = 'rmv' and database = currentDatabase()"
+
+# The comment the guarded branch produced. 9223372036854775808 is
+# static_cast<UInt64>(INT64_MAX) + 1, i.e. the value the guard computes; a signed
+# overflow there would print something else.
+$CLICKHOUSE_CLIENT -q "system flush logs query_log"
+$CLICKHOUSE_CLIENT -q "select 'formatted', count() > 0 from system.query_log where current_database = currentDatabase() and log_comment like 'refresh of %rmv (attempt %/9223372036854775808)'"
 
 $CLICKHOUSE_CLIENT -q "drop table rmv"

--- a/tests/queries/0_stateless/03981_refreshable_mv_retries_int64_max.sh
+++ b/tests/queries/0_stateless/03981_refreshable_mv_retries_int64_max.sh
@@ -13,11 +13,17 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # refreshable view over a non-replicated inner table is refused there. The retry
 # machinery does not read the append flag, so the formatting branch is reached
 # either way.
+# all_replicas = 1 keeps refresh uncoordinated, so the replica this client is
+# connected to runs its own refresh. Without it, an APPEND view on a Replicated
+# database refreshes on one arbitrarily chosen same-shard replica: the retry
+# counter would still be visible here because it lives in shared Keeper state,
+# but query_log is replica-local, so the formatted comment below could be written
+# on another replica and never observed by this client.
 $CLICKHOUSE_CLIENT -q "
-    create materialized view rmv refresh after 1 year settings refresh_retries = 9223372036854775807 append
+    create materialized view rmv refresh after 1 year settings refresh_retries = 9223372036854775807, all_replicas = 1 append
         (x Int64) engine Memory as select throwIf(number = 0) as x from numbers(1);"
 
-# Wait until a third attempt has been scheduled. system.view_refreshes.retry is
+# Wait until attempt 2 has entered executeRefresh. system.view_refreshes.retry is
 # attempt_number minus one while a refresh is in flight, so retry = 1 is also
 # reached before the second attempt starts; retry >= 2 is reachable only once
 # attempt 2 has entered executeRefresh, which is where the '(attempt N/total)'

--- a/tests/queries/0_stateless/04062_table_readonly_replicated.sh
+++ b/tests/queries/0_stateless/04062_table_readonly_replicated.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# Tags: zookeeper, no-shared-merge-tree
+# Tags: zookeeper, no-shared-merge-tree, no-replicated-database
 # no-shared-merge-tree: the test checks that `table_readonly` is rejected specifically for
 # `ReplicatedMergeTree` (in its constructor); with the engine substituted by `SharedMergeTree`,
 # the `CREATE` succeeds and the subsequent queries fail with `TABLE_ALREADY_EXISTS`.
+# no-replicated-database: one assertion combines `ADD COLUMN` with `MODIFY SETTING` in a single
+# ALTER; a Replicated database rejects that in segment validation (InterpreterAlterQuery,
+# QUERY_IS_PROHIBITED) before the storage can return the expected `NOT_IMPLEMENTED`.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
+++ b/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
@@ -143,7 +143,11 @@ DROP TABLE IF EXISTS t_mv_104791_other_target;
 
 CREATE TABLE t_mv_104791_target (id UInt32, x UInt32) ENGINE = MergeTree ORDER BY id;
 CREATE TABLE t_mv_104791_other_target (id UInt32, x UInt32) ENGINE = MergeTree ORDER BY id;
-CREATE MATERIALIZED VIEW t_mv_104791 REFRESH EVERY 1 HOUR TO t_mv_104791_target AS SELECT 1 AS id, 2 AS x;
+-- APPEND keeps this fixture creatable on a Replicated database, which refuses a
+-- non-APPEND refreshable view over a non-replicated target; EMPTY suppresses the
+-- initial refresh so the ATTACH cases see an untouched target. Neither reaches the
+-- ATTACH rejection surface under test, which is decided before storage construction.
+CREATE MATERIALIZED VIEW t_mv_104791 REFRESH EVERY 1 HOUR APPEND TO t_mv_104791_target EMPTY AS SELECT 1 AS id, 2 AS x;
 DETACH TABLE t_mv_104791;
 
 -- 18. ATTACH MV with a different REFRESH schedule: silently dropped before this

--- a/tests/queries/0_stateless/04278_json_minmax_index_mixed_type_array.sql
+++ b/tests/queries/0_stateless/04278_json_minmax_index_mixed_type_array.sql
@@ -1,3 +1,8 @@
+-- Tags: no-replicated-database
+-- Tag no-replicated-database: one assertion drops the index and resets the escape-hatch
+-- setting in a single ALTER, which a Replicated database refuses (InterpreterAlterQuery
+-- rejects ALTERs mixing replicated and non-replicated actions, QUERY_IS_PROHIBITED).
+
 -- Test for https://github.com/ClickHouse/ClickHouse/issues/106088
 -- JSON (Object) column should be forbidden in minmax skip index by default.
 -- The MergeTree setting or query-level setting allow_minmax_index_for_json can suppress

--- a/tests/queries/0_stateless/04617_pr_plan_based_materialized_view.sql
+++ b/tests/queries/0_stateless/04617_pr_plan_based_materialized_view.sql
@@ -1,3 +1,8 @@
+-- Tags: no-replicated-database
+-- Tag no-replicated-database: the test asserts the APPEND/non-APPEND distinction, and a
+-- Replicated database refuses to create the non-APPEND refreshable view over a plain
+-- MergeTree target (StorageMaterializedView.cpp, BAD_ARGUMENTS), so that arm cannot exist.
+
 -- Plan-based parallel replicas expands a MaterializedView into a plain read of its target table, so
 -- eligibility is governed by the target storage: a MaterializedView over a ReplicatedMergeTree is
 -- distributed, over a plain MergeTree it needs parallel_replicas_for_non_replicated_merge_tree.


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/112247


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

On the `DBReplicated` coverage flavours the runner puts stateless tests on a Replicated
database, and five of them execute a statement the server refuses there by design. Those
failures were hidden: the diagnostics rerun drops the job's `--replicated-database` flag, so
they were labelled `flaky` and force-set `OK` (over 94,000 such rows in the last 21 days). #112247
fixes the visibility; this makes the five stop failing.

Two refusals are involved, both unconditional throws with no relaxing setting:
`StorageMaterializedView.cpp` rejects a refreshable materialized view with no `APPEND` over a
non-replicated target on a Replicated database, and `InterpreterAlterQuery` rejects an `ALTER`
mixing replicated and non-replicated actions in one statement.

The engine sanity-check block holding the first refusal is skipped when `APPEND` is set, so two
tests keep running on every flavour via an `APPEND` fixture instead of losing that coverage:
`03981_refreshable_mv_retries_int64_max` and
`04247_attach_table_storage_clauses_without_engine_error`. `04247`'s assertions are unchanged.
`03981` also raises its retry threshold, so the wait can no longer be satisfied before the second
attempt starts, and asserts the comment that attempt formats; its reference gains one row.

The remaining three get `no-replicated-database`, because for them the refused statement *is*
the assertion: `04617_pr_plan_based_materialized_view` asserts the `APPEND`/non-`APPEND`
distinction in both arms, and `04278_json_minmax_index_mixed_type_array` plus
`04062_table_readonly_replicated` each assert a single mixed `ALTER`. This records a
server-enforced engine incompatibility, not a randomization silencer: no `no-random-*` tag is
added and randomization stays green on its own. Note the tag also skips Cloud and
shared-catalog runs, where the same refusals apply.

Validation: each rewrite verified to keep its assertion on a plain server and to newly pass with
`--replicated-database`; each tag verified to skip rather than fail. Reverting the `APPEND` or
removing a tag reddens exactly the affected tests with the refusal above. 50 randomized runs of
all five: 250 OK, 0 failures.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.596` (included in `26.8` and later)
<!-- ch-version-info:end -->