### PR TITLE
Build OpenSSL from portable C sources where there is no assembly

### DIFF
--- a/contrib/openssl-cmake/CMakeLists.txt
+++ b/contrib/openssl-cmake/CMakeLists.txt
@@ -35,7 +35,28 @@ set(OPENSSL_MODULESDIR "/usr/local/lib/ossl-modules" CACHE PATH "Set the default
 
 add_definitions(-DOPENSSL_NO_KTLS -DOPENSSLDIR="${OPENSSLDIR}" -DENGINESDIR="${OPENSSL_ENGINESDIR}" -DMODULESDIR="${OPENSSL_MODULESDIR}" -DOPENSSL_USE_NODELETE -DOPENSSL_PIC)
 
-if(ARCH_AMD64)
+# Not every architecture has a build description here: generating one means running OpenSSL's
+# `Configure` for that target and transcribing the result, and some targets - WebAssembly, for one
+# - have no assembler at all. `OPENSSL_NO_ASM` builds the portable C implementations instead.
+#
+# An architecture this file does not know about turns it on by itself. Without that, neither
+# `PLATFORM_DIRECTORY` nor a single one of the AES/BN/SHA/... cores below is set, and the build
+# gets all the way to the final link before failing on undefined `OPENSSL_cleanse` and friends.
+option(OPENSSL_NO_ASM "Build OpenSSL from the portable C sources instead of the hand-written assembly" OFF)
+
+if(NOT (ARCH_AMD64 OR ARCH_AARCH64 OR ARCH_PPC64LE OR ARCH_S390X OR ARCH_RISCV64 OR ARCH_LOONGARCH64))
+    message(STATUS "OpenSSL: no assembly for ${CMAKE_SYSTEM_PROCESSOR}, building the portable C sources")
+    set(OPENSSL_NO_ASM ON)
+endif()
+
+if(OPENSSL_NO_ASM)
+    set(PLATFORM_DIRECTORY generic)
+    if(CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+        add_definitions(-DB_ENDIAN)
+    else()
+        add_definitions(-DL_ENDIAN)
+    endif()
+elseif(ARCH_AMD64)
     if(OS_DARWIN)
         set(PLATFORM_DIRECTORY darwin_x86_64)
         add_definitions(-DL_ENDIAN)
@@ -1085,7 +1106,23 @@ set(CRYPTO_SRC ${CRYPTO_SRC}
 )
 
 
-if(ARCH_AMD64)
+if(OPENSSL_NO_ASM)
+    # The C implementations of everything the assembly would otherwise provide. This is the same
+    # set as the Darwin arms below, which are also no-asm builds.
+    set(CRYPTO_SRC ${CRYPTO_SRC}
+        ${OPENSSL_SOURCE_DIR}/crypto/aes/aes_cbc.c
+        ${OPENSSL_SOURCE_DIR}/crypto/aes/aes_core.c
+        ${OPENSSL_SOURCE_DIR}/crypto/bn/bn_asm.c
+        ${OPENSSL_SOURCE_DIR}/crypto/camellia/camellia.c
+        ${OPENSSL_SOURCE_DIR}/crypto/camellia/cmll_cbc.c
+        ${OPENSSL_SOURCE_DIR}/crypto/chacha/chacha_enc.c
+        ${OPENSSL_SOURCE_DIR}/crypto/mem_clr.c
+        ${OPENSSL_SOURCE_DIR}/crypto/rc4/rc4_enc.c
+        ${OPENSSL_SOURCE_DIR}/crypto/rc4/rc4_skey.c
+        ${OPENSSL_SOURCE_DIR}/crypto/sha/keccak1600.c
+        ${OPENSSL_SOURCE_DIR}/crypto/whrlpool/wp_block.c
+    )
+elseif(ARCH_AMD64)
     if (OS_DARWIN)
         set(CRYPTO_SRC ${CRYPTO_SRC}
             ${OPENSSL_SOURCE_DIR}/crypto/aes/aes_cbc.c

--- a/contrib/openssl-cmake/generic/include_private/buildinf.h
+++ b/contrib/openssl-cmake/generic/include_private/buildinf.h
@@ -1,0 +1,20 @@
+/*
+ * Unlike its siblings in the other platform directories, this one is not the output of
+ * util/mkbuildinf.pl: there is no OpenSSL `Configure` target for "whatever architecture this
+ * is", so this is the hand-written equivalent for the portable no-asm build (OPENSSL_NO_ASM).
+ *
+ * crypto/cversion.c and crypto/info.c are the only consumers; they surface these strings
+ * through OpenSSL_version(). Keeping them constant also keeps the build reproducible.
+ *
+ * Copyright 2014-2025 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#define PLATFORM "platform: generic-no-asm"
+#define DATE "built on: unknown"
+
+static const char compiler_flags[] = "compiler: unknown";


### PR DESCRIPTION
`contrib/openssl-cmake` picks a `PLATFORM_DIRECTORY` and the AES/BN/SHA/... implementations from a per-architecture `if/elseif` chain. An architecture the chain does not know about matches nothing: no `buildinf.h` include directory, and not one of the crypto cores gets compiled. The build then runs all the way to the final link before failing on undefined `OPENSSL_cleanse` and friends, which says nothing about what is actually wrong.

This adds a no-asm arm that builds the portable C implementations - the same source set the Darwin arms already use, since those are no-asm builds too - against a hand-written generic `buildinf.h`, with the endianness taken from `CMAKE_CXX_BYTE_ORDER`. An unrecognized architecture now selects it by itself, so a new port gets a working (if slower) libcrypto instead of a link failure. Some targets, WebAssembly for one, have no assembler at all and can only build this way.

The same arm can be selected explicitly with `-DOPENSSL_NO_ASM=1`, which is how it was tested: an x86_64 build with that flag links no `.s` object at all, and `SHA1`/`SHA256`/`SHA512`/`MD5`/`keccak256`, AES-GCM and AES-CBC round trips and an HTTPS fetch through `url()` all give the same answers as the assembly build.

Default builds are unaffected - every architecture with a build description here takes the same arm as before.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
OpenSSL can now be built from its portable C sources on architectures that have no hand-written assembly in the build description, instead of failing at the final link with undefined symbols. The new `OPENSSL_NO_ASM` CMake option selects the same path explicitly.


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)
