### PR TITLE
Do not require the patched libc++ to compile Common/Exception.cpp

### DIFF
--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -21,6 +21,19 @@
 #    define SIZE_T_IS_A_DISTINCT_TYPE 1
 #endif
 
+/// Whether every `std::exception` carries the stack trace of the throw that created it.
+/// ClickHouse's patched libc++ records it (`contrib/libcxx-cmake` defines this to 1), and every
+/// supported platform links that libc++. A port that has to use a foreign C++ standard library -
+/// the standalone parser build in `utils/wasm-parser`, for one - gets no trace, and there is no
+/// `std::exception::get_stack_trace_frames` to call at all. `Common/StackTrace.h` is where the
+/// difference is handled; nothing else should test this macro.
+/// Only the absence is defaulted here: a supported platform that somehow lost the definition must
+/// not silently start throwing exceptions without stack traces, so `Common/Exception.cpp` asserts
+/// that it is 1 there.
+#if !defined(STD_EXCEPTION_HAS_STACK_TRACE)
+#    define STD_EXCEPTION_HAS_STACK_TRACE 0
+#endif
+
 #if !defined(likely)
 #    define likely(x)   (__builtin_expect(!!(x), 1))
 #endif

--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -29,7 +29,13 @@
 
 #include <Poco/String.h>
 
-static_assert(STD_EXCEPTION_HAS_STACK_TRACE == 1);
+/// Every supported platform builds `contrib/libcxx-cmake` (see `cmake/cxx.cmake`, which every
+/// `cmake/*/default_libs.cmake` includes), so losing this would silently strip the throw-site
+/// stack trace from every exception. Only a port linking a foreign C++ standard library - the
+/// standalone parser in `utils/wasm-parser`, for one - is allowed to be without it.
+#if defined(OS_LINUX) || defined(OS_DARWIN) || defined(OS_FREEBSD) || defined(OS_SUNOS)
+static_assert(STD_EXCEPTION_HAS_STACK_TRACE == 1, "ClickHouse's patched libc++ is not being linked");
+#endif
 
 namespace fs = std::filesystem;
 
@@ -177,10 +183,7 @@ Exception::Exception(CreateFromPocoTag, const Poco::Exception & exc)
     if (terminate_on_any_exception)
         std::_Exit(terminate_status_code);
     capture_thread_frame_pointers = getThreadFramePointers();
-    auto * stack_trace_frames = exc.get_stack_trace_frames();
-    auto stack_trace_size = exc.get_stack_trace_size();
-    __msan_unpoison(stack_trace_frames, stack_trace_size * sizeof(stack_trace_frames[0]));
-    set_stack_trace(stack_trace_frames, stack_trace_size);
+    copyStackTraceOfThrow(exc, *this);
 }
 
 static int getCodeForSTDException(const std::exception & exc)
@@ -198,10 +201,7 @@ Exception::Exception(CreateFromSTDTag, const std::exception & exc)
     if (terminate_on_any_exception)
         std::_Exit(terminate_status_code);
     capture_thread_frame_pointers = getThreadFramePointers();
-    auto * stack_trace_frames = exc.get_stack_trace_frames();
-    auto stack_trace_size = exc.get_stack_trace_size();
-    __msan_unpoison(stack_trace_frames, stack_trace_size * sizeof(stack_trace_frames[0]));
-    set_stack_trace(stack_trace_frames, stack_trace_size);
+    copyStackTraceOfThrow(exc, *this);
 }
 
 void Exception::addMessage(const MessageMasked & msg_masked)
@@ -218,10 +218,8 @@ std::string getExceptionStackTraceString(const std::exception & e)
     /// Explicitly block MEMORY_LIMIT_EXCEEDED
     LockMemoryExceptionInThread lock(VariableContext::Global);
 
-    auto * stack_trace_frames = e.get_stack_trace_frames();
-    auto stack_trace_size = e.get_stack_trace_size();
-    __msan_unpoison(stack_trace_frames, stack_trace_size * sizeof(stack_trace_frames[0]));
-    return StackTrace::toString(stack_trace_frames, 0, stack_trace_size);
+    const auto trace = getStackTraceOfThrow(e);
+    return StackTrace::toString(trace.data(), 0, trace.size());
 }
 
 std::string getExceptionStackTraceString(std::exception_ptr e)
@@ -243,9 +241,7 @@ std::string getExceptionStackTraceString(std::exception_ptr e)
 
 std::string Exception::getStackTraceString() const
 {
-    auto * stack_trace_frames = get_stack_trace_frames();
-    auto stack_trace_size = get_stack_trace_size();
-    __msan_unpoison(stack_trace_frames, stack_trace_size * sizeof(stack_trace_frames[0]));
+    const auto trace = getStackTraceOfThrow(*this);
     String thread_stack_trace;
     std::for_each(capture_thread_frame_pointers.rbegin(), capture_thread_frame_pointers.rend(),
         [&thread_stack_trace](FramePointers & frame_pointers)
@@ -256,19 +252,13 @@ std::string Exception::getStackTraceString() const
         }
     );
 
-    return StackTrace::toString(stack_trace_frames, 0, stack_trace_size) + thread_stack_trace;
+    return StackTrace::toString(trace.data(), 0, trace.size()) + thread_stack_trace;
 }
 
 Exception::Trace Exception::getStackFramePointers() const
 {
-    Trace frame_pointers;
-    frame_pointers.resize(get_stack_trace_size());
-    for (size_t i = 0; i < frame_pointers.size(); ++i)
-    {
-        frame_pointers[i] = get_stack_trace_frames()[i];
-    }
-    __msan_unpoison(frame_pointers.data(), frame_pointers.size() * sizeof(frame_pointers[0]));
-    return frame_pointers;
+    const auto trace = getStackTraceOfThrow(*this);
+    return Trace(trace.begin(), trace.end());
 }
 
 thread_local bool Exception::enable_job_stack_trace = false;

--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -204,12 +204,10 @@ static void signalHandler(int sig, siginfo_t * info, void * context)
         }
         catch (const std::exception & e)
         {
-            const auto * stack_trace_frames = e.get_stack_trace_frames();
-            const size_t stack_trace_size = e.get_stack_trace_size();
-            __msan_unpoison(stack_trace_frames, stack_trace_size * sizeof(stack_trace_frames[0]));
-            terminate_current_exception_trace_size = std::min(stack_trace_size, FRAMEPOINTER_CAPACITY);
+            const auto trace = getStackTraceOfThrow(e);
+            terminate_current_exception_trace_size = std::min(trace.size(), FRAMEPOINTER_CAPACITY);
             for (size_t i = 0; i < terminate_current_exception_trace_size; ++i)
-                terminate_current_exception_trace[i] = stack_trace_frames[i];
+                terminate_current_exception_trace[i] = trace[i];
         }
         catch (...) {} // NOLINT(bugprone-empty-catch) Ok: best-effort in terminate handler
     }

--- a/src/Common/StackTrace.h
+++ b/src/Common/StackTrace.h
@@ -2,12 +2,15 @@
 
 #include <base/defines.h>
 #include <base/types.h>
+#include <base/MemorySanitizer.h>
 #include <Common/FramePointers.h>
 
 #include <string>
 #include <array>
+#include <exception>
 #include <optional>
 #include <functional>
+#include <span>
 /** A standalone build of the parser (see `utils/wasm-parser`) has no signals, no `setjmp` and no
   * way to walk its own stack, and it does not link `StackTrace.cpp`. Everything below that needs
   * those is left out rather than making the whole header unavailable, since `Common/Exception.h`
@@ -26,6 +29,34 @@
 #endif
 #include <ucontext.h>
 #endif
+
+/** The stack trace of the throw that created an exception, recorded inside the `std::exception`
+  * itself by ClickHouse's patched libc++. See `STD_EXCEPTION_HAS_STACK_TRACE` in `base/defines.h`:
+  * these two functions are the only place that copes with a C++ standard library which records
+  * nothing, where they report an empty trace and do nothing respectively.
+  *
+  * The frames are un-poisoned for MSan, which does not see libc++ writing them.
+  */
+inline std::span<void *> getStackTraceOfThrow([[maybe_unused]] const std::exception & e)
+{
+#if STD_EXCEPTION_HAS_STACK_TRACE
+    void ** frames = e.get_stack_trace_frames();
+    const size_t size = e.get_stack_trace_size();
+    __msan_unpoison(frames, size * sizeof(frames[0]));
+    return {frames, size};
+#else
+    return {};
+#endif
+}
+
+/// Make the throw-site stack trace of `from` the throw-site stack trace of `to`.
+inline void copyStackTraceOfThrow([[maybe_unused]] const std::exception & from, [[maybe_unused]] std::exception & to)
+{
+#if STD_EXCEPTION_HAS_STACK_TRACE
+    const auto trace = getStackTraceOfThrow(from);
+    to.set_stack_trace(trace.data(), static_cast<int>(trace.size()));
+#endif
+}
 
 struct NoCapture
 {

--- a/utils/wasm-parser/README.md
+++ b/utils/wasm-parser/README.md
@@ -99,9 +99,10 @@ measure.
 `wasm_runtime.cpp` replaces a handful of chokepoints rather than building the real ones. Each is
 something a browser has no use for, and each would otherwise dominate the bundle:
 
-* **Stack traces.** `Common/Exception.cpp` cannot even compile here - it `static_assert`s on
-  `STD_EXCEPTION_HAS_STACK_TRACE`, which comes from ClickHouse's patched libc++ in
-  `contrib/libcxx-cmake`. WebAssembly cannot walk its own call stack from user code anyway.
+* **Stack traces.** They need libunwind and DWARF parsing, and the trace recorded at the throw
+  needs ClickHouse's patched libc++ in `contrib/libcxx-cmake` (`STD_EXCEPTION_HAS_STACK_TRACE`),
+  which is not the libc++ a wasi-sdk build gets. WebAssembly cannot walk its own call stack from
+  user code anyway.
 * **Memory tracking and thread status.** Server bookkeeping; `malloc` is the only budget here.
 * **`Core/Settings.cpp`.** `ParserSetQuery` calls `Settings::castValueUtil` once, only to ask
   whether a bare `SET x` names a `Bool` setting. That single call pulls in the whole settings

--- a/utils/wasm-parser/wasm_runtime.cpp
+++ b/utils/wasm-parser/wasm_runtime.cpp
@@ -4,7 +4,7 @@
 /// `Common/MemoryTracker.cpp` and friends. They are deliberately NOT built here:
 ///
 ///   * stack traces need libunwind, DWARF parsing and a patched libc++
-///     (`Common/Exception.cpp` static_asserts on `STD_EXCEPTION_HAS_STACK_TRACE`),
+///     (`STD_EXCEPTION_HAS_STACK_TRACE`, which is 0 here),
 ///   * memory tracking and thread status need thread-local server bookkeeping,
 ///   * logging needs Poco's channel/formatter machinery.
 ///


### PR DESCRIPTION
`Exception.cpp` opens with `static_assert(STD_EXCEPTION_HAS_STACK_TRACE == 1)`, and that macro comes from ClickHouse's patched libc++ in `contrib/libcxx-cmake`. A build linking any other C++ standard library cannot compile the file at all - and it is not only the assert: six places call `std::exception::get_stack_trace_frames`, which only the patched libc++ has. `utils/wasm-parser` works around this today by leaving `Exception.cpp` out of its build entirely and substituting stubs.

This moves the two operations - reading the throw-site trace, and adopting one exception's trace as another's - behind `getStackTraceOfThrow` and `copyStackTraceOfThrow` in `Common/StackTrace.h`, so exactly one place has to know whether the standard library records a trace at all. `base/defines.h` defaults `STD_EXCEPTION_HAS_STACK_TRACE` to 0 when it is absent.

It stays fail-closed. Every currently supported platform builds `contrib/libcxx-cmake` - `cmake/cxx.cmake` is included by every `cmake/*/default_libs.cmake` - so `Exception.cpp` still hard-asserts the macro is 1 on Linux, Darwin, FreeBSD and SunOS. Losing the definition there would silently strip the stack trace from every exception, and it still cannot happen.

As a side effect this removes six copies of the same `get_stack_trace_frames`/`get_stack_trace_size`/`__msan_unpoison` incantation.

No behaviour change. Checked against a build of the same commit without the change: identical symbolized stack traces for a thrown `DB::Exception`, for the `Poco::Exception` conversion path and for the `std::exception` conversion path, and `system.errors.last_error_trace` populated the same way.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`Common/Exception.cpp` no longer requires ClickHouse's patched libc++ to compile, so a build linking a different C++ standard library gets exceptions without a throw-site stack trace rather than not compiling.


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)
