### PR TITLE
Capture connection_id at construction in connectionId()

### DIFF
--- a/src/Functions/connectionId.cpp
+++ b/src/Functions/connectionId.cpp
@@ -9,12 +9,16 @@ namespace DB
 {
 
 /// Get the connection Id. It's used for MySQL handler only.
-class FunctionConnectionId final : public IFunction, WithContext
+class FunctionConnectionId final : public IFunction
 {
 public:
     static constexpr auto name = "connectionId";
 
-    explicit FunctionConnectionId(ContextPtr context_) : WithContext(context_) {}
+    /// The connection id is a property of the query, so capture it here instead of keeping a reference to
+    /// the context. A function built while analyzing a subquery can be executed after the context that
+    /// built it is gone - e.g. a scalar subquery whose expression actions are reused by the outer query -
+    /// and looking the context up at execution time throws `Context has expired`.
+    explicit FunctionConnectionId(const ContextPtr & context_) : connection_id(context_->getClientInfo().connection_id) {}
 
     static FunctionPtr create(ContextPtr context_) { return std::make_shared<FunctionConnectionId>(context_); }
 
@@ -30,8 +34,11 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName &, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
-        return result_type->createColumnConst(input_rows_count, getContext()->getClientInfo().connection_id);
+        return result_type->createColumnConst(input_rows_count, connection_id);
     }
+
+private:
+    const UInt64 connection_id;
 };
 
 REGISTER_FUNCTION(ConnectionId)

--- a/src/Functions/tests/gtest_connection_id_expired_context.cpp
+++ b/src/Functions/tests/gtest_connection_id_expired_context.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+
+#include <Common/tests/gtest_global_context.h>
+#include <Common/tests/gtest_global_register.h>
+
+#include <Functions/FunctionFactory.h>
+#include <Interpreters/Context.h>
+#include <Core/ColumnsWithTypeAndName.h>
+#include <Columns/IColumn.h>
+
+using namespace DB;
+
+/// `connectionId()` used to inherit from `WithContext` and dereference a weak reference to the query
+/// context in `executeImpl`. A function built while analyzing a subquery can be executed after the
+/// context that built it is gone - e.g. a scalar subquery whose expression actions are reused by the
+/// outer query - and the weak reference then threw the logical error `Context has expired`.
+///
+/// After capturing the connection id at construction time, executing the function must still succeed
+/// (and return the captured value) once the building context has been released.
+TEST(ConnectionIdFunction, SurvivesExpiredBuildContext)
+{
+    tryRegisterFunctions();
+
+    ContextMutablePtr query_context = Context::createCopy(getContext().context);
+    query_context->makeQueryContext();
+    query_context->setClientConnectionId(4242);
+
+    /// Building the function captures the connection id (before the fix it captured a weak context ref).
+    ColumnsWithTypeAndName no_arguments;
+    auto resolver = FunctionFactory::instance().get("connectionId", query_context);
+    auto function = resolver->build(no_arguments);
+
+    /// Release the context that built the function, mimicking a subquery whose context is gone by the
+    /// time the outer query's expression actions run.
+    query_context.reset();
+
+    ColumnPtr result;
+    ASSERT_NO_THROW(result = function->execute(no_arguments, function->getResultType(), 1, /*dry_run=*/ false));
+    ASSERT_EQ(result->getUInt(0), 4242u);
+}


### PR DESCRIPTION
_Found via ClickGap automated review._

Fixes #112533

**Implements fix for [issue #112533](https://github.com/ClickHouse/ClickHouse/issues/112533) found during review of [PR #112533](https://github.com/ClickHouse/ClickHouse/pull/112533).**

Requested by @alexey-milovidov.

### What this fixes
What: `FunctionConnectionId` no longer inherits from `WithContext`. It captures the client's `connection_id` (a `UInt64`) in its constructor and returns it directly from `executeImpl`, instead of holding a weak reference to the query context and dereferencing it at execution time. This applies the same capture-at-construction pattern PR #112533 used for `getClientHTTPHeader`.

Why: `src/Functions/connectionId.cpp:12,17,33` — the function inherited `WithContext` (a `std::weak_ptr<const Context>`) and called `getContext()->getClientInfo().connection_id` inside `executeImpl`. When the function is built while analyzing a subquery, the building context can be gone by the time the expression actions run (e.g. a scalar subquery whose actions are reused by the outer query). `WithContextImpl::getContext()` then throws the logical error `Context has expired` (`src/Interpreters/Context_fwd.cpp:18`). The connection id is a property of the query and is known at build time, so it is safe to capture in the constructor.

Files changed:
- src/Functions/connectionId.cpp — drop `WithContext`, capture `connection_id` in the ctor, read the captured member in `executeImpl`.
- src/Functions/tests/gtest_connection_id_expired_context.cpp — new gtest.

Test: `ConnectionIdFunction.SurvivesExpiredBuildContext` builds `connectionId()` with a query context whose `connection_id` is set to 4242, releases that context, then executes the function. Before the fix execution throws `Context has expired`; after the fix it succeeds and returns 4242. A gtest is used because the natural SQL reproducer relied on the column-matcher machinery of `getClientHTTPHeader`'s argument, which the zero-argument `connectionId()` cannot exercise; the gtest deterministically pins the exact invariant (execute after the build context expires).

### Changelog category (leave one):
- Bug Fix

### Changelog entry
What: `FunctionConnectionId` no longer inherits from `WithContext`. It captures the client's `connection_id` (a `UInt64`) in its constructor and returns it directly from `executeImpl`, instead of holding a weak reference to the query context and dereferencing it at execution time. This applies the same capture-at-construction pattern PR #112533 used for `getClientHTTPHeader`.

---
_ClickGapAI · Fix for PR #112533_


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.605` (included in `26.8` and later)
<!-- ch-version-info:end -->