### PR TITLE
Fix transient Azure errors misreported as broken data parts

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -74,6 +74,13 @@ static struct InitFiu
     ONCE(s3_read_buffer_throw_expired_token) \
     ONCE(s3_send_request_throw_expired_token) \
     REGULAR(s3_read_inject_etag_mismatch) \
+    REGULAR(azure_inject_forbidden_response) \
+    ONCE(azure_inject_forbidden_response_once) \
+    REGULAR(azure_inject_auth_failure_on_request) \
+    ONCE(azure_inject_auth_failure_on_request_once) \
+    REGULAR(azure_inject_poco_timeout) \
+    ONCE(azure_inject_poco_timeout_once) \
+    REGULAR(azure_inject_bad_request) \
     ONCE(distributed_cache_fail_request_in_the_middle_of_request) \
     ONCE(object_storage_queue_fail_commit_once) \
     ONCE(object_storage_queue_fail_commit_after_success) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -71,6 +71,13 @@ static struct InitFiu
     ONCE(s3_read_buffer_throw_expired_token) \
     ONCE(s3_send_request_throw_expired_token) \
     REGULAR(s3_read_inject_etag_mismatch) \
+    REGULAR(azure_inject_forbidden_response) \
+    ONCE(azure_inject_forbidden_response_once) \
+    REGULAR(azure_inject_auth_failure_on_request) \
+    ONCE(azure_inject_auth_failure_on_request_once) \
+    REGULAR(azure_inject_poco_timeout) \
+    ONCE(azure_inject_poco_timeout_once) \
+    REGULAR(azure_inject_bad_request) \
     ONCE(distributed_cache_fail_request_in_the_middle_of_request) \
     ONCE(object_storage_queue_fail_commit_once) \
     ONCE(object_storage_queue_fail_commit_after_success) \

--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
@@ -401,6 +401,8 @@ BlobClientOptions getClientOptions(
     retry_options.MaxRetries = static_cast<Int32>(request_settings.sdk_max_retries);
     retry_options.RetryDelay = std::chrono::milliseconds(request_settings.sdk_retry_initial_backoff_ms);
     retry_options.MaxRetryDelay = std::chrono::milliseconds(request_settings.sdk_retry_max_backoff_ms);
+    /// Add 403 to the SDK retry set — RBAC propagation returns a transient 403 the SDK won't otherwise retry.
+    retry_options.StatusCodes.insert(Azure::Core::Http::HttpStatusCode::Forbidden);
     Azure::Storage::Blobs::BlobClientOptions client_options;
     client_options.Retry = retry_options;
     client_options.ClickhouseOptions = Azure::Storage::Blobs::ClickhouseClientOptions{.IsClientForDisk=for_disk};

--- a/src/Disks/IO/WriteBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/WriteBufferFromAzureBlobStorage.cpp
@@ -126,7 +126,7 @@ void WriteBufferFromAzureBlobStorage::execWithRetry(std::function<void(size_t)> 
         }
         catch (const Azure::Core::RequestFailedException & e)
         {
-            if (i == num_tries - 1 || !isRetryableAzureException(e, /* may_be_provisioning_access */ write_settings.is_initial_access_check))
+            if (i == num_tries - 1 || !isRetryableAzureException(e))
                 throw;
 
             LOG_DEBUG(log, "Write at attempt {} for blob `{}` failed: {} {}", i + 1, blob_path, e.what(), e.Message);

--- a/src/Disks/IO/WriteBufferFromAzureDataLakeStorage.cpp
+++ b/src/Disks/IO/WriteBufferFromAzureDataLakeStorage.cpp
@@ -179,7 +179,7 @@ void WriteBufferFromAzureDataLakeStorage::runWithRetries(
         }
         catch (const Azure::Core::RequestFailedException & e)
         {
-            const bool retryable = isRetryableAzureException(e, write_settings.is_initial_access_check);
+            const bool retryable = isRetryableAzureException(e);
             if (!retryable || attempt >= max_unexpected_write_error_retries)
             {
                 log_event(static_cast<Int32>(e.StatusCode), e.Message, watch.elapsedMicroseconds());

--- a/src/IO/AzureBlobStorage/PocoHTTPClient.cpp
+++ b/src/IO/AzureBlobStorage/PocoHTTPClient.cpp
@@ -9,6 +9,7 @@
 #include <Common/Throttler.h>
 #include <Common/VectorWithMemoryTracking.h>
 #include <Common/logger_useful.h>
+#include <Common/FailPoint.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/Operators.h>
 #include <IO/ConnectionTimeouts.h>
@@ -17,7 +18,10 @@
 #include <Poco/Net/HTTPClientSession.h>
 #include <Poco/String.h>
 #include <Poco/URI.h>
+#include <azure/core/http/http.hpp>
 #include <azure/core/http/policies/policy.hpp>
+#include <azure/storage/common/storage_exception.hpp>
+#include <azure/core/credentials/credentials.hpp>
 
 
 namespace DB::ErrorCodes
@@ -25,6 +29,17 @@ namespace DB::ErrorCodes
     extern const int TOO_MANY_REDIRECTS;
     extern const int NOT_IMPLEMENTED;
     extern const int BAD_ARGUMENTS;
+}
+
+namespace DB::FailPoints
+{
+    extern const char azure_inject_forbidden_response[];
+    extern const char azure_inject_forbidden_response_once[];
+    extern const char azure_inject_auth_failure_on_request[];
+    extern const char azure_inject_auth_failure_on_request_once[];
+    extern const char azure_inject_poco_timeout[];
+    extern const char azure_inject_poco_timeout_once[];
+    extern const char azure_inject_bad_request[];
 }
 
 namespace ProfileEvents
@@ -137,6 +152,44 @@ std::unique_ptr<Azure::Core::Http::RawResponse> PocoAzureHTTPClient::Send(
     Azure::Core::Http::Request & request,
     Azure::Core::Context const & context)
 {
+    /// Test-only: inject a 403 by returning it like the real transport. Returned (not thrown) so it goes
+    /// through the SDK RetryPolicy — a thrown exception would bypass it and test only the ClickHouse loops.
+    fiu_do_on(DB::FailPoints::azure_inject_forbidden_response,
+    {
+        auto injected = std::make_unique<Azure::Core::Http::RawResponse>(
+            1, 1, Azure::Core::Http::HttpStatusCode::Forbidden, "Forbidden (injected by failpoint)");
+        injected->SetBodyStream(std::make_unique<EmptyBodyStream>());
+        return injected;
+    });
+
+    /// Test-only: transient 403 — returned once, so the SDK retry recovers on the next attempt.
+    fiu_do_on(DB::FailPoints::azure_inject_forbidden_response_once,
+    {
+        auto injected = std::make_unique<Azure::Core::Http::RawResponse>(
+            1, 1, Azure::Core::Http::HttpStatusCode::Forbidden, "Forbidden (injected by failpoint)");
+        injected->SetBodyStream(std::make_unique<EmptyBodyStream>());
+        return injected;
+    });
+
+    /// Test-only: throw AuthenticationException on the read path (production throws it from the SDK token policy).
+    fiu_do_on(DB::FailPoints::azure_inject_auth_failure_on_request,
+    {
+        throw Azure::Core::Credentials::AuthenticationException("Authentication failed (injected by failpoint)");
+    });
+    fiu_do_on(DB::FailPoints::azure_inject_auth_failure_on_request_once,
+    {
+        throw Azure::Core::Credentials::AuthenticationException("Authentication failed (injected by failpoint)");
+    });
+
+    /// Test-only: non-retryable 400 (negative control) — a real failure must still report the part broken.
+    fiu_do_on(DB::FailPoints::azure_inject_bad_request,
+    {
+        auto injected = std::make_unique<Azure::Core::Http::RawResponse>(
+            1, 1, Azure::Core::Http::HttpStatusCode::BadRequest, "Bad request (injected by failpoint)");
+        injected->SetBodyStream(std::make_unique<EmptyBodyStream>());
+        return injected;
+    });
+
     CurrentMetrics::Increment metric_increment{CurrentMetrics::AzureRequests};
 
     size_t redirects_left = max_redirects;
@@ -326,6 +379,12 @@ std::unique_ptr<Azure::Core::Http::RawResponse> PocoAzureHTTPClient::makeRequest
 
     try
     {
+        /// Test-only: raise a real Poco timeout so the TimeoutException -> TransportException path is what's tested.
+        fiu_do_on(DB::FailPoints::azure_inject_poco_timeout,
+            { throw Poco::TimeoutException("connect timed out (injected by failpoint)"); });
+        fiu_do_on(DB::FailPoints::azure_inject_poco_timeout_once,
+            { throw Poco::TimeoutException("connect timed out (injected by failpoint)"); });
+
         Poco::Net::HTTPRequest poco_request(Poco::Net::HTTPRequest::HTTP_1_1);
 
         poco_request.setMethod(method);
@@ -502,15 +561,10 @@ std::unique_ptr<Azure::Core::Http::RawResponse> PocoAzureHTTPClient::makeRequest
             observeLatency(method, first_byte_latency_type, static_cast<HistogramMetrics::Value>(first_byte_time));
         }
 
-        auto error_message = getCurrentExceptionMessageAndPattern(/* with_stacktrace */ true);
-        auto response = std::make_unique<Azure::Core::Http::RawResponse>(
-            1, 1, // HTTP/1.1
-            Azure::Core::Http::HttpStatusCode::RequestTimeout,
-            error_message.text);
-
-        response->SetBodyStream(std::make_unique<EmptyBodyStream>());
         addMetric(method, AzureMetricType::Errors);
-        return response;
+
+        /// Throw TransportException (retryable) for a timeout instead of a synthetic 408 that read as a broken part.
+        throw Azure::Core::Http::TransportException(getCurrentExceptionMessageAndPattern(true).text);
     }
     catch (...)
     {

--- a/src/IO/AzureBlobStorage/isRetryableAzureException.cpp
+++ b/src/IO/AzureBlobStorage/isRetryableAzureException.cpp
@@ -12,8 +12,12 @@ bool isRetryableAzureException(const Azure::Core::RequestFailedException & e)
     if (dynamic_cast<const Azure::Core::Http::TransportException *>(&e))
         return true;
 
-    /// 403 is always retryable so a transient RBAC-propagation 403 isn't misreported as POTENTIALLY_BROKEN_DATA_PART.
+    /// Always retry 403 (RBAC-propagation lag); never treat it as data corruption.
     if (e.StatusCode == Azure::Core::Http::HttpStatusCode::Forbidden)
+        return true;
+
+    /// 408 request-timeout is transient; retry it.
+    if (e.StatusCode == Azure::Core::Http::HttpStatusCode::RequestTimeout)
         return true;
 
     /// Retry other 5xx errors just in case.

--- a/src/IO/AzureBlobStorage/isRetryableAzureException.cpp
+++ b/src/IO/AzureBlobStorage/isRetryableAzureException.cpp
@@ -6,15 +6,14 @@
 namespace DB
 {
 
-bool isRetryableAzureException(const Azure::Core::RequestFailedException & e, bool may_be_provisioning_access)
+bool isRetryableAzureException(const Azure::Core::RequestFailedException & e)
 {
     /// Always retry transport errors.
     if (dynamic_cast<const Azure::Core::Http::TransportException *>(&e))
         return true;
 
-    /// Azure may be provisioning access for quite a long time, so 403 is retriable in some cases
-    /// It makes sense for IDisk::checkAccess() which is called early on startup and terminates the server/keeper if the check fails
-    if (may_be_provisioning_access && e.StatusCode == Azure::Core::Http::HttpStatusCode::Forbidden)
+    /// 403 is always retryable so a transient RBAC-propagation 403 isn't misreported as POTENTIALLY_BROKEN_DATA_PART.
+    if (e.StatusCode == Azure::Core::Http::HttpStatusCode::Forbidden)
         return true;
 
     /// Retry other 5xx errors just in case.

--- a/src/IO/AzureBlobStorage/isRetryableAzureException.h
+++ b/src/IO/AzureBlobStorage/isRetryableAzureException.h
@@ -7,7 +7,7 @@
 namespace DB
 {
 
-bool isRetryableAzureException(const Azure::Core::RequestFailedException & e, bool may_be_provisioning_access = false);
+bool isRetryableAzureException(const Azure::Core::RequestFailedException & e);
 
 }
 

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -19,6 +19,9 @@
 #include <Common/ZooKeeper/IKeeper.h>
 #include <Common/ErrnoException.h>
 #include <IO/AzureBlobStorage/isRetryableAzureException.h>
+#if USE_AZURE_BLOB_STORAGE
+#include <azure/core/credentials/credentials.hpp>
+#endif
 #include <Poco/Net/NetException.h>
 
 
@@ -83,6 +86,11 @@ bool isRetryableException(std::exception_ptr exception_ptr)
     catch (const Azure::Core::RequestFailedException & e)
     {
         return isRetryableAzureException(e);
+    }
+    catch (const Azure::Core::Credentials::AuthenticationException &)
+    {
+        /// AuthenticationException (token/RBAC not ready) is transient; separate catch — it isn't a RequestFailedException.
+        return true;
     }
 #endif
     catch (const ErrnoException & e)

--- a/tests/integration/test_azure_403_handling/configs/azure_disk.xml
+++ b/tests/integration/test_azure_403_handling/configs/azure_disk.xml
@@ -1,0 +1,44 @@
+<clickhouse>
+    <logger><level>debug</level></logger>
+    <storage_configuration>
+        <disks>
+            <azure_disk>
+                <type>azure_blob_storage</type>
+                <storage_account_url from_env="AZURITE_STORAGE_ACCOUNT_URL"/>
+                <container_name>cont</container_name>
+                <skip_access_check>false</skip_access_check>
+                <account_name>devstoreaccount1</account_name>
+                <account_key>Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==</account_key>
+                <max_single_read_retries>2</max_single_read_retries>
+                <max_single_download_retries>2</max_single_download_retries>
+                <max_unexpected_write_error_retries>2</max_unexpected_write_error_retries>
+                <max_tries>2</max_tries>
+                <retry_initial_backoff_ms>10</retry_initial_backoff_ms>
+                <retry_max_backoff_ms>50</retry_max_backoff_ms>
+            </azure_disk>
+            <!-- Like azure_disk but SDK retry off (max_tries=0), so the write test sees the CH loop retry, not the SDK. -->
+            <azure_disk_nosdk>
+                <type>azure_blob_storage</type>
+                <storage_account_url from_env="AZURITE_STORAGE_ACCOUNT_URL"/>
+                <container_name>cont</container_name>
+                <skip_access_check>false</skip_access_check>
+                <account_name>devstoreaccount1</account_name>
+                <account_key>Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==</account_key>
+                <max_single_read_retries>2</max_single_read_retries>
+                <max_single_download_retries>2</max_single_download_retries>
+                <max_unexpected_write_error_retries>2</max_unexpected_write_error_retries>
+                <max_tries>0</max_tries>
+                <retry_initial_backoff_ms>10</retry_initial_backoff_ms>
+                <retry_max_backoff_ms>50</retry_max_backoff_ms>
+            </azure_disk_nosdk>
+        </disks>
+        <policies>
+            <azure_policy>
+                <volumes><main><disk>azure_disk</disk></main></volumes>
+            </azure_policy>
+            <azure_policy_nosdk>
+                <volumes><main><disk>azure_disk_nosdk</disk></main></volumes>
+            </azure_policy_nosdk>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_azure_403_handling/test.py
+++ b/tests/integration/test_azure_403_handling/test.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Azure transient-vs-permanent error handling on the MergeTree read/merge path.
+
+Covers #106298, #110724 and private #53656: a transient Azure 403, credential failure or connect
+timeout must be retried and must never be attributed to a broken data part; a permanent one must
+fail with the real Azure error and still not accuse the part. A genuinely non-retryable error must
+still mark the part broken.
+
+ReplicatedMergeTree so reportBroken() is observable (plain MergeTree's callback is a no-op).
+"""
+import os
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+AZURITE_ACCOUNT = "devstoreaccount1"
+AZURITE_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+CONTAINER = "cont"
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=[os.path.join(SCRIPT_DIR, "configs", "azure_disk.xml")],
+    with_azurite=True,
+    with_zookeeper=True,
+)
+
+# kind -> (one-shot fp, permanent fp, expected error text)
+ERROR_KINDS = {
+    "forbidden": (
+        "azure_inject_forbidden_response_once",
+        "azure_inject_forbidden_response",
+        "403",
+    ),
+    "auth": (
+        "azure_inject_auth_failure_on_request_once",
+        "azure_inject_auth_failure_on_request",
+        "AuthenticationException",
+    ),
+    "timeout": (
+        "azure_inject_poco_timeout_once",
+        "azure_inject_poco_timeout",
+        "TransportException",
+    ),
+}
+
+ALL_FAILPOINTS = [fp for triple in ERROR_KINDS.values() for fp in triple[:2]] + [
+    "azure_inject_bad_request"
+]
+
+# The OSS-observable signal that reportBroken() was taken (part-check thread).
+BROKEN_PART_LOG = "looks broken. Removing it and will try to fetch"
+# One line per failed Azure read attempt; substring matches both Read and Download variants.
+RETRY_LOG = "Exception caught during Azure"
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True, scope="function")
+def clean_state(started_cluster):
+    def _disable_all():
+        for fp in ALL_FAILPOINTS:
+            try:
+                node.query(f"SYSTEM DISABLE FAILPOINT {fp}")
+            except Exception:
+                pass
+
+    _disable_all()
+    node.rotate_logs()
+    yield
+    _disable_all()
+
+
+def _create_table(name, wide=True, stop_merges=False, policy="azure_policy"):
+    node.query(f"DROP TABLE IF EXISTS {name} SYNC")
+    part_setting = (
+        "min_bytes_for_wide_part = 0" if wide else "min_bytes_for_wide_part = 1073741824"
+    )
+    node.query(
+        f"""
+        CREATE TABLE {name} (k UInt64, v String)
+        ENGINE = ReplicatedMergeTree('/clickhouse/tables/{name}', 'r1')
+        ORDER BY k
+        SETTINGS storage_policy = '{policy}', {part_setting}
+        """
+    )
+    # Three distinct parts so OPTIMIZE has real merge work that reaches the read (the reportBroken() decision).
+    if stop_merges:
+        node.query(f"SYSTEM STOP MERGES {name}")
+    for i in range(3):
+        node.query(
+            f"INSERT INTO {name} SELECT number + {i * 100}, toString(number) FROM numbers(100)"
+        )
+    assert node.query(f"SELECT count() FROM {name}").strip() == "300"
+    node.query("SYSTEM DROP FILESYSTEM CACHE")
+    node.query("SYSTEM DROP MARK CACHE")
+
+
+def _wait_for_merge_failure(table, expected_in_err, timeout=90):
+    # A retryable merge failure retries indefinitely — the only terminal signal is last_exception on the
+    # replication queue; wait for it (failpoint still on) so the no-broken-part check is meaningful.
+    deadline = time.monotonic() + timeout
+    last = ""
+    while time.monotonic() < deadline:
+        last = node.query(
+            f"SELECT last_exception FROM system.replication_queue "
+            f"WHERE database = currentDatabase() AND table = '{table}'"
+        )
+        if expected_in_err in last:
+            return
+        time.sleep(0.5)
+    raise AssertionError(
+        f"merge for {table} never recorded a failure containing {expected_in_err!r}; "
+        f"last_exception=\n{last}"
+    )
+
+
+def test_sanity_check(started_cluster):
+    endpoint = started_cluster.env_variables["AZURITE_STORAGE_ACCOUNT_URL"]
+    node.query(
+        f"""
+        CREATE TABLE t_sanity (k UInt64, v String)
+        ENGINE = AzureBlobStorage('{endpoint}', '{CONTAINER}', 'sanity.csv',
+                                  '{AZURITE_ACCOUNT}', '{AZURITE_KEY}', 'CSV')
+        """
+    )
+    node.query("INSERT INTO t_sanity VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+    assert node.query("SELECT count() FROM t_sanity").strip() == "3"
+
+
+def test_sdk_retry_isolates_forbidden_on_direct_call(started_cluster):
+    # Isolation test for the SDK 403 retry (StatusCodes.insert(Forbidden)): an INSERT's direct GetProperties/
+    # exists() calls have no CH retry loop, so this one-shot 403 succeeds only if the SDK retried it — drop the line, it fails.
+    endpoint = started_cluster.env_variables["AZURITE_STORAGE_ACCOUNT_URL"]
+
+    node.query("SYSTEM ENABLE FAILPOINT azure_inject_forbidden_response_once")
+    try:
+        node.query(
+            f"""
+            INSERT INTO TABLE FUNCTION azureBlobStorage(
+                '{endpoint}', '{CONTAINER}', 'b1_direct_probe.csv',
+                '{AZURITE_ACCOUNT}', '{AZURITE_KEY}', 'CSV', 'auto', 'k UInt64')
+            VALUES (1)
+            """
+        )
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT azure_inject_forbidden_response_once")
+
+
+@pytest.mark.parametrize("kind", list(ERROR_KINDS))
+def test_transient_error_read_succeeds(started_cluster, kind):
+    # One transient failure must be absorbed by the retry budget: data still returned, part never broken.
+    # No RETRY_LOG assert — the SDK may absorb the one-shot below the ClickHouse loop.
+    once_fp, _, _ = ERROR_KINDS[kind]
+    table = f"t_transient_{kind}"
+    _create_table(table)
+
+    node.query(f"SYSTEM ENABLE FAILPOINT {once_fp}")
+    try:
+        assert node.query(f"SELECT sum(k) FROM {table}").strip() == "44850"
+    finally:
+        node.query(f"SYSTEM DISABLE FAILPOINT {once_fp}")
+
+    assert not node.contains_in_log(BROKEN_PART_LOG)
+
+
+@pytest.mark.parametrize("kind", list(ERROR_KINDS))
+def test_permanent_error_read_fails_without_accusing_part(started_cluster, kind):
+    # A permanent error fails with the real Azure error after the budget, and still never accuses the part.
+    _, perm_fp, expected_in_err = ERROR_KINDS[kind]
+    table = f"t_permanent_{kind}"
+    _create_table(table)
+
+    node.query(f"SYSTEM ENABLE FAILPOINT {perm_fp}")
+    try:
+        err = node.query_and_get_error(f"SELECT sum(k) FROM {table}")
+    finally:
+        node.query(f"SYSTEM DISABLE FAILPOINT {perm_fp}")
+
+    assert expected_in_err in err, f"expected {expected_in_err} in error, got:\n{err}"
+    # Load-bearing: the healthy part must never be reported broken. 740 is private-only, so we assert on
+    # BROKEN_PART_LOG (ReplicatedMergeTreePartCheckThread) — the OSS-observable reportBroken() signal.
+    assert not node.contains_in_log(BROKEN_PART_LOG)
+    assert node.contains_in_log(RETRY_LOG), "the read retry budget was never used"
+
+
+@pytest.mark.parametrize("kind", list(ERROR_KINDS))
+def test_permanent_error_at_merge_does_not_mark_part_broken(started_cluster, kind):
+    # Permanent error at merge -> merge reschedules (async, alter_sync=0), part never marked broken.
+    _, perm_fp, expected_in_err = ERROR_KINDS[kind]
+    table = f"t_merge_{kind}"
+    _create_table(table, stop_merges=True)
+
+    node.query(f"SYSTEM ENABLE FAILPOINT {perm_fp}")
+    try:
+        node.query(f"SYSTEM START MERGES {table}")
+        node.query(f"OPTIMIZE TABLE {table} FINAL SETTINGS alter_sync = 0")
+        # Keep the failpoint on until the merge's terminal failure: a false reportBroken() on the final attempt
+        # would slip past an early RETRY_LOG check (and past count()==300, since refetch restores the rows).
+        _wait_for_merge_failure(table, expected_in_err, timeout=90)
+        assert not node.contains_in_log(BROKEN_PART_LOG)
+    finally:
+        node.query(f"SYSTEM DISABLE FAILPOINT {perm_fp}")
+
+
+def test_transient_forbidden_compact_part_read_succeeds(started_cluster):
+    # Cover a compact part too — #106298's stack is the compact reader, a different reportBroken() site.
+    once_fp, _, _ = ERROR_KINDS["forbidden"]
+    _create_table("t_compact", wide=False)
+
+    node.query(f"SYSTEM ENABLE FAILPOINT {once_fp}")
+    try:
+        assert node.query("SELECT sum(k) FROM t_compact").strip() == "44850"
+    finally:
+        node.query(f"SYSTEM DISABLE FAILPOINT {once_fp}")
+
+    assert not node.contains_in_log(BROKEN_PART_LOG)
+
+
+def test_non_retryable_error_still_marks_part_broken(started_cluster):
+    # Negative control: a non-retryable 400 must still reportBroken(), else real corruption is missed.
+    _create_table("t_negative")
+
+    node.query("SYSTEM ENABLE FAILPOINT azure_inject_bad_request")
+    try:
+        node.query_and_get_error("SELECT sum(k) FROM t_negative")
+        node.wait_for_log_line(BROKEN_PART_LOG, timeout=60)
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT azure_inject_bad_request")
+
+
+def test_permanent_forbidden_on_write_fails(started_cluster):
+    # 403 is retryable on writes now too; a permanent one must still fail on the bounded budget, not hang.
+    _create_table("t_write")
+
+    node.query("SYSTEM ENABLE FAILPOINT azure_inject_forbidden_response")
+    try:
+        err = node.query_and_get_error(
+            "INSERT INTO t_write SELECT number, toString(number) FROM numbers(100)"
+        )
+        assert "403" in err or "Forbidden" in err
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT azure_inject_forbidden_response")
+
+
+def test_transient_forbidden_on_write_succeeds(started_cluster):
+    # nosdk (SDK retry off) so the one-shot 403 must reach execWithRetry; the "Write at attempt" log proves the
+    # CH write loop recovered. stop_merges keeps the upload PUT the only in-flight Azure traffic.
+    _create_table("t_write_transient", stop_merges=True, policy="azure_policy_nosdk")
+
+    node.query("SYSTEM ENABLE FAILPOINT azure_inject_forbidden_response_once")
+    try:
+        node.query(
+            "INSERT INTO t_write_transient SELECT number + 300, toString(number) FROM numbers(100)"
+        )
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT azure_inject_forbidden_response_once")
+
+    assert node.query("SELECT count() FROM t_write_transient").strip() == "400"
+    assert node.contains_in_log(
+        "Write at attempt"
+    ), "the CH-level write retry loop was never exercised"
+    assert not node.contains_in_log(BROKEN_PART_LOG)


### PR DESCRIPTION
> **Series:** **#112871** (this), #112872, #112873, #112874, #112875, #112876

**Problem.** Transient Azure errors — a `403` (Forbidden), a credential `AuthenticationException`, and connect timeouts (surfaced as a synthetic `408`) — were previously classified as non-retryable, which caused healthy data parts to be flagged as corrupt: `POTENTIALLY_BROKEN_DATA_PART` (code 740). Due to Azure RBAC propagation lag, these 403s are possible within minutes after service provisioning. They are not always caught by `IDisk::checkAccess()`, because that startup probe and the later data requests can be served by different Azure storage frontends holding different (stale) RBAC caches.

**Fix.** Treat 403/408 as retryable and throw a real `TransportException` for connect timeouts (instead of fabricating a 408), so the read path retries in-budget and a transient failure is never attributed to data corruption.

**Changes.**
- `IO/AzureBlobStorage/isRetryableAzureException`: 403 + 408 retryable; drop the `may_be_provisioning_access` arg.
- `IO/AzureBlobStorage/PocoHTTPClient`: throw `Azure::Core::Http::TransportException` on `Poco::TimeoutException` instead of a synthetic 408.
- `Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon`: add `403` to the Azure SDK's retryable status codes — its default set omits it — so call sites without a ClickHouse-level retry loop are covered too.
- `Storages/MergeTree/checkDataPart` (`isRetryableException`): treat `AuthenticationException` as retryable.
- `Common/FailPoint` + `tests/integration/test_azure_403_handling`: failpoints and regression tests for transient vs permanent 403 / auth / timeout, plus a non-retryable error as a negative control.

**Scope note.** `isRetryableAzureException` no longer takes `may_be_provisioning_access`, so 403 is retryable at every call site, including writes; previously it was retryable only for `IDisk::checkAccess()` (#86419). Budgets stay bounded, so a permanent 403 still fails — now after the full budget (~18s on a read) instead of immediately. This also fixes the read half of `checkAccess`, which had no 403 tolerance at all. @tavplubix @alesapin — asking you to confirm this widening, as owners of the 403 gate and of the Poco HTTP client respectively.

Supersedes #111179 (same 408 fix), closed in favour of this — thanks @qiuyanjun888.

Closes #106298, #110724.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a transient Azure Blob Storage error on the read or merge path — an RBAC permission-propagation `403 Forbidden`, a credential authentication failure, or a connect timeout surfaced as `408` — being misclassified as non-retryable and reported as `POTENTIALLY_BROKEN_DATA_PART` (Code 740), raising a false critical alert for a healthy part. These transient failures are now treated as retryable, and a genuinely persistent one surfaces as a plain Azure error instead of a phantom broken data part.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1265` (included in `26.8` and later)
<!-- ch-version-info:end -->