### PR TITLE
Azure: fix listObjects dropping the endpoint prefix on pages after the first

### DIFF
--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -196,15 +196,17 @@ void AzureObjectStorage::listObjects(const std::string & path, RelativePathsWith
     else
         options.PageSizeHint = settings.get()->list_object_keys_size;
 
-    for (auto blob_list_response = client_ptr->ListBlobs(options); blob_list_response.HasPage(); blob_list_response.MoveToNextPage())
+    /// Re-issue ListBlobs per page through the client wrapper (which strips the endpoint prefix); the SDK's
+    /// MoveToNextPage refetches pages 2..N directly and would leave the raw Azure prefix on their blob names.
+    while (true)
     {
+        auto blob_list_response = client_ptr->ListBlobs(options);
+
         ProfileEvents::increment(ProfileEvents::AzureListObjects);
         if (client_ptr->IsClientForDisk())
             ProfileEvents::increment(ProfileEvents::DiskAzureListObjects);
 
-        const auto & blobs_list = blob_list_response.Blobs;
-
-        for (const auto & blob : blobs_list)
+        for (const auto & blob : blob_list_response.Blobs)
         {
             children.emplace_back(std::make_shared<RelativePathWithMetadata>(
                 blob.Name,
@@ -221,6 +223,11 @@ void AzureObjectStorage::listObjects(const std::string & path, RelativePathsWith
 
         if (max_keys && children.size() >= max_keys)
             break;
+
+        if (!blob_list_response.NextPageToken.HasValue() || blob_list_response.NextPageToken.Value().empty())
+            break;
+
+        options.ContinuationToken = blob_list_response.NextPageToken;
     }
 }
 

--- a/tests/integration/test_azure_blob_storage_listobjects_prefix/test.py
+++ b/tests/integration/test_azure_blob_storage_listobjects_prefix/test.py
@@ -1,0 +1,174 @@
+"""Regression test for the Azure ``listObjects`` endpoint-prefix bug (PR #112872).
+
+On a prefixed-endpoint Azure Blob Storage disk, ``AzureObjectStorage::listObjects``
+used to fetch pages 2..N with the SDK's ``MoveToNextPage()``, which bypasses
+``ContainerClientWrapper``'s endpoint-prefix stripping, so every blob name after the
+first page kept the raw Azure prefix (wrong paths).
+
+The batched ``listObjects`` is reachable only through
+``MetadataStorageFromPlainObjectStorage::listDirectory`` -- Azure overrides
+``iterate()`` (``AzureIteratorAsync``, already correct), so plain_rewritable and
+ordinary MergeTree disks never exercise the buggy path. This test therefore:
+
+  * builds a MergeTree table with several wide parts on the default (local) disk,
+  * uploads its ``store/<uuid>/`` tree into Azurite under a prefixed endpoint,
+  * ATTACHes it read-only from a ``metadata_type=plain`` Azure disk with
+    ``list_object_keys_size=1`` so every directory listing crosses page 1,
+  * reads it back.
+
+Pre-fix, pages 2..N come back with the raw endpoint prefix, so the parts are
+garbled/broken and the read returns the wrong rows (or throws). Post-fix, every
+page is stripped and the read returns all rows. Switching the code back to
+``MoveToNextPage()`` makes this test fail again.
+"""
+
+import os
+
+import pytest
+from azure.storage.blob import BlobServiceClient
+
+from helpers.cluster import ClickHouseCluster
+from helpers.s3_tools import AzureUploader
+
+NODE_NAME = "node"
+ACCOUNT_NAME = "devstoreaccount1"
+ACCOUNT_KEY = (
+    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/"
+    "K1SZFPTOtr/KBHBeksoGMGw=="
+)
+CONTAINER_NAME = "cont"
+# A non-empty path after the container name is what gives ContainerClientWrapper a
+# prefix to strip -- without it there is nothing to reproduce.
+DISK_PREFIX = "data/disks/disk_azure_plain/"
+NUM_PARTS = 8
+
+
+def generate_cluster_def(port):
+    path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "./_gen/disk_storage_conf.xml",
+    )
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(f"""<clickhouse>
+    <storage_configuration>
+        <disks>
+            <disk_azure_plain_readonly>
+                <type>object_storage</type>
+                <object_storage_type>azure_blob_storage</object_storage_type>
+                <metadata_type>plain</metadata_type>
+                <endpoint>http://azurite1:{port}/{ACCOUNT_NAME}/{CONTAINER_NAME}/{DISK_PREFIX}</endpoint>
+                <account_name>{ACCOUNT_NAME}</account_name>
+                <account_key>{ACCOUNT_KEY}</account_key>
+                <!-- One blob per page, so every listing crosses page 1. -->
+                <list_object_keys_size>1</list_object_keys_size>
+                <readonly>true</readonly>
+            </disk_azure_plain_readonly>
+        </disks>
+        <policies>
+            <azure_plain_readonly>
+                <volumes>
+                    <main>
+                        <disk>disk_azure_plain_readonly</disk>
+                    </main>
+                </volumes>
+            </azure_plain_readonly>
+        </policies>
+    </storage_configuration>
+</clickhouse>
+""")
+    return path
+
+
+@pytest.fixture(scope="module")
+def cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        port = cluster.azurite_port
+        path = generate_cluster_def(port)
+        cluster.add_instance(
+            NODE_NAME,
+            main_configs=[path],
+            with_azurite=True,
+            stay_alive=True,
+        )
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def _blob_service_client(cluster):
+    port = cluster.env_variables["AZURITE_PORT"]
+    connection_string = (
+        f"DefaultEndpointsProtocol=http;AccountName={ACCOUNT_NAME};"
+        f"AccountKey={ACCOUNT_KEY};"
+        f"BlobEndpoint=http://127.0.0.1:{port}/{ACCOUNT_NAME};"
+    )
+    return BlobServiceClient.from_connection_string(connection_string)
+
+
+def test_listobjects_prefix_crosses_page(cluster):
+    node = cluster.instances[NODE_NAME]
+
+    # 1. Build a MergeTree table with several separate wide parts on the local disk.
+    node.query("CREATE DATABASE IF NOT EXISTS local_db")
+    node.query(
+        "CREATE TABLE local_db.src (num UInt32, data String) "
+        "ENGINE=MergeTree ORDER BY num SETTINGS min_bytes_for_wide_part=0"
+    )
+    node.query("SYSTEM STOP MERGES local_db.src")
+    for i in range(NUM_PARTS):
+        node.query(f"INSERT INTO local_db.src VALUES ({i}, 'row{i}')")
+
+    expected_count = NUM_PARTS
+    expected_sum = sum(range(NUM_PARTS))
+    assert int(node.query("SELECT count() FROM local_db.src")) == expected_count
+    assert (
+        int(
+            node.query(
+                "SELECT count() FROM system.parts "
+                "WHERE database='local_db' AND table='src' AND active"
+            )
+        )
+        == NUM_PARTS
+    ), "each INSERT must stay a separate part so the directory listing crosses a page"
+
+    table_uuid = node.query(
+        "SELECT uuid FROM system.tables WHERE database='local_db' AND name='src'"
+    ).strip()
+
+    # 2. Upload the table's store/<uuid>/ tree into Azurite under the prefixed endpoint.
+    #    Creating the container here is enough; the read-only disk never creates it.
+    blob_service_client = _blob_service_client(cluster)
+    try:
+        blob_service_client.create_container(CONTAINER_NAME)
+    except Exception:
+        # Already exists on a re-run of the module -- fine.
+        pass
+
+    store_rel = os.path.join("store", table_uuid[:3], table_uuid)
+    local_store_path = os.path.join(node.path, "database", store_rel)
+    AzureUploader(
+        blob_service_client, CONTAINER_NAME, use_relpath=True
+    ).upload_directory(local_store_path, DISK_PREFIX + store_rel)
+
+    # 3. Drop the local table; the data now lives only in Azurite.
+    node.query("DROP TABLE local_db.src SYNC")
+
+    # 4. Attach the same UUID read-only from the plain-metadata Azure disk.
+    node.query("CREATE DATABASE IF NOT EXISTS azure_db")
+    node.query(
+        f"ATTACH TABLE azure_db.dst UUID '{table_uuid}' (num UInt32, data String) "
+        "ENGINE=MergeTree ORDER BY num "
+        "SETTINGS storage_policy='azure_plain_readonly'"
+    )
+
+    # 5. Reading loads the parts via MetadataStorageFromPlainObjectStorage::listDirectory
+    #    -> AzureObjectStorage::listObjects, which paginates. Pre-fix, pages 2..N keep the
+    #    raw endpoint prefix, so the parts are garbled/broken and the read is wrong (or throws).
+    assert int(node.query("SELECT count() FROM azure_db.dst")) == expected_count
+    assert int(node.query("SELECT sum(num) FROM azure_db.dst")) == expected_sum
+    assert node.query(
+        "SELECT num, data FROM azure_db.dst ORDER BY num FORMAT Values"
+    ) == ",".join(f"({i},'row{i}')" for i in range(NUM_PARTS))

--- a/tests/integration/test_azure_blob_storage_listobjects_prefix/test.py
+++ b/tests/integration/test_azure_blob_storage_listobjects_prefix/test.py
@@ -29,6 +29,7 @@ from azure.storage.blob import BlobServiceClient
 
 from helpers.cluster import ClickHouseCluster
 from helpers.s3_tools import AzureUploader
+from test_storage_azure_blob_storage.test import azure_query
 
 NODE_NAME = "node"
 ACCOUNT_NAME = "devstoreaccount1"
@@ -44,9 +45,12 @@ NUM_PARTS = 8
 
 
 def generate_cluster_def(port):
+    # Per-worker suffix so parallel xdist workers don't race on the generated file.
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "")
+    suffix = f"_{worker_id}" if worker_id else ""
     path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
-        "./_gen/disk_storage_conf.xml",
+        f"./_gen/disk_storage_conf{suffix}.xml",
     )
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w") as f:
@@ -158,17 +162,19 @@ def test_listobjects_prefix_crosses_page(cluster):
 
     # 4. Attach the same UUID read-only from the plain-metadata Azure disk.
     node.query("CREATE DATABASE IF NOT EXISTS azure_db")
-    node.query(
+    azure_query(
+        node,
         f"ATTACH TABLE azure_db.dst UUID '{table_uuid}' (num UInt32, data String) "
         "ENGINE=MergeTree ORDER BY num "
-        "SETTINGS storage_policy='azure_plain_readonly'"
+        "SETTINGS storage_policy='azure_plain_readonly'",
+        query_on_retry="DROP TABLE IF EXISTS azure_db.dst SYNC",
     )
 
     # 5. Reading loads the parts via MetadataStorageFromPlainObjectStorage::listDirectory
     #    -> AzureObjectStorage::listObjects, which paginates. Pre-fix, pages 2..N keep the
     #    raw endpoint prefix, so the parts are garbled/broken and the read is wrong (or throws).
-    assert int(node.query("SELECT count() FROM azure_db.dst")) == expected_count
-    assert int(node.query("SELECT sum(num) FROM azure_db.dst")) == expected_sum
-    assert node.query(
-        "SELECT num, data FROM azure_db.dst ORDER BY num FORMAT Values"
+    assert int(azure_query(node, "SELECT count() FROM azure_db.dst")) == expected_count
+    assert int(azure_query(node, "SELECT sum(num) FROM azure_db.dst")) == expected_sum
+    assert azure_query(
+        node, "SELECT num, data FROM azure_db.dst ORDER BY num FORMAT Values"
     ) == ",".join(f"({i},'row{i}')" for i in range(NUM_PARTS))


### PR DESCRIPTION
> **Series**: **#112872** (this), #112871, #112873, #112874, #112875, #112876

**Problem.** On a prefixed-endpoint Azure disk, `listObjects` returns wrong blob names on every page after the first: the client wrapper strips the endpoint prefix, but the SDK's `MoveToNextPage()` refetches pages 2..N directly and leaves the raw Azure prefix on their names. Failure scenario:

```
listObjects(prefixed endpoint, >1 page):
  page 1  = client wrapper ListBlobs()  -> names prefix-stripped (correct)
  page 2+ = response.MoveToNextPage()    -> names keep the raw prefix (wrong paths)
```

**Fix.** Paginate with the continuation token, re-entering the wrapper each page so every page's names are stripped.

**Changes.**
- `Disks/…/AzureBlobStorage/AzureObjectStorage::listObjects`: drive pagination via `ContinuationToken` instead of `MoveToNextPage`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `listObjects` on a prefixed-endpoint Azure Blob Storage disk returning wrong blob names on every page after the first, because pagination bypassed the client wrapper that strips the endpoint prefix. Pagination now re-enters the wrapper via the continuation token so every page's blob names are correct.
