### PR TITLE
Azure: log batch-delete events when SubmitBatch itself fails

### DIFF
--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -472,6 +472,10 @@ void AzureObjectStorage::removeObjectsBatchIfExists(
         for (const auto & object : object_batch)
             responses.push_back(requests.DeleteBlob(client_ptr->GetBlobPath(object.remote_path)));
 
+        ProfileEvents::increment(ProfileEvents::AzureDeleteObjects, object_batch.size());
+        if (is_disk)
+            ProfileEvents::increment(ProfileEvents::DiskAzureDeleteObjects, object_batch.size());
+
         try
         {
             client_ptr->SubmitBatch(requests);
@@ -495,10 +499,6 @@ void AzureObjectStorage::removeObjectsBatchIfExists(
                 add_log_entry(object, elapsed, -1, batch_error);
             throw;
         }
-
-        ProfileEvents::increment(ProfileEvents::AzureDeleteObjects, object_batch.size());
-        if (is_disk)
-            ProfileEvents::increment(ProfileEvents::DiskAzureDeleteObjects, object_batch.size());
 
         size_t avg_elapsed_us = watch.elapsedMicroseconds() / object_batch.size();
         std::exception_ptr throw_at_end;

--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -472,7 +472,29 @@ void AzureObjectStorage::removeObjectsBatchIfExists(
         for (const auto & object : object_batch)
             responses.push_back(requests.DeleteBlob(client_ptr->GetBlobPath(object.remote_path)));
 
-        client_ptr->SubmitBatch(requests);
+        try
+        {
+            client_ptr->SubmitBatch(requests);
+        }
+        catch (const Azure::Storage::StorageException & e)
+        {
+            /// A batch-level failure skips the per-object response loop below, so record one Delete attempt
+            /// per object before rethrowing. Preserve the real HTTP status (as the per-object path below
+            /// does) so these failures stay queryable by error_code.
+            const auto elapsed = watch.elapsedMicroseconds() / object_batch.size();
+            for (const auto & object : object_batch)
+                add_log_entry(object, elapsed, static_cast<Int32>(e.StatusCode), e.Message);
+            throw;
+        }
+        catch (...)
+        {
+            /// Non-Azure failure (e.g. a credential AuthenticationException) carries no HTTP status.
+            const auto elapsed = watch.elapsedMicroseconds() / object_batch.size();
+            const auto batch_error = getCurrentExceptionMessage(false);
+            for (const auto & object : object_batch)
+                add_log_entry(object, elapsed, -1, batch_error);
+            throw;
+        }
 
         ProfileEvents::increment(ProfileEvents::AzureDeleteObjects, object_batch.size());
         if (is_disk)

--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -465,7 +465,29 @@ void AzureObjectStorage::removeObjectsBatchIfExists(
         for (const auto & object : object_batch)
             responses.push_back(requests.DeleteBlob(client_ptr->GetBlobPath(object.remote_path)));
 
-        client_ptr->SubmitBatch(requests);
+        try
+        {
+            client_ptr->SubmitBatch(requests);
+        }
+        catch (const Azure::Storage::StorageException & e)
+        {
+            /// A batch-level failure skips the per-object response loop below, so record one Delete attempt
+            /// per object before rethrowing. Preserve the real HTTP status (as the per-object path below
+            /// does) so these failures stay queryable by error_code.
+            const auto elapsed = watch.elapsedMicroseconds() / object_batch.size();
+            for (const auto & object : object_batch)
+                add_log_entry(object, elapsed, static_cast<Int32>(e.StatusCode), e.Message);
+            throw;
+        }
+        catch (...)
+        {
+            /// Non-Azure failure (e.g. a credential AuthenticationException) carries no HTTP status.
+            const auto elapsed = watch.elapsedMicroseconds() / object_batch.size();
+            const auto batch_error = getCurrentExceptionMessage(false);
+            for (const auto & object : object_batch)
+                add_log_entry(object, elapsed, -1, batch_error);
+            throw;
+        }
 
         ProfileEvents::increment(ProfileEvents::AzureDeleteObjects, object_batch.size());
         if (is_disk)

--- a/tests/integration/test_azure_403_handling/configs/blob_log.xml
+++ b/tests/integration/test_azure_403_handling/configs/blob_log.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <blob_storage_log>
+        <database>system</database>
+        <table>blob_storage_log</table>
+        <flush_interval_milliseconds>1000</flush_interval_milliseconds>
+    </blob_storage_log>
+</clickhouse>

--- a/tests/integration/test_azure_403_handling/test.py
+++ b/tests/integration/test_azure_403_handling/test.py
@@ -408,3 +408,84 @@ def test_batch_delete_non_azure_failure_logs_every_object(started_cluster):
     assert "Authentication" in errors, f"expected the auth exception text in the log, got: {errors!r}"
 
     node.query("DROP TABLE IF EXISTS t_batch_del_auth SYNC")  # cleanup (failpoint disabled)
+
+
+def test_batch_delete_failure_counts_profile_events(started_cluster):
+    # Bot finding r3773675098: removeObjectsBatchIfExists must count the batch in system.events
+    # (AzureDeleteObjects) even when the batch SubmitBatch itself fails. The increment now runs before the
+    # submit — mirroring the single-object removeObjectImpl and the S3 delete path — so a failed batch is
+    # still reflected in system.events, not only in system.blob_storage_log. Pre-fix (increment after the
+    # try/catch) the rethrow skipped it, so this counter stayed flat while the blobs were still logged;
+    # assert the counter now grows by at least one per object on the failed batch.
+    node.query("DROP TABLE IF EXISTS t_batch_del_events SYNC")
+    node.query(
+        """
+        CREATE TABLE t_batch_del_events (k UInt64) ENGINE = MergeTree ORDER BY k
+        SETTINGS storage_policy = 'azure_policy', min_bytes_for_wide_part = 0
+        """
+    )
+    for i in range(3):
+        node.query(f"INSERT INTO t_batch_del_events SELECT number + {i * 100} FROM numbers(100)")
+
+    table_uuid = node.query(
+        "SELECT uuid FROM system.tables WHERE database = currentDatabase() AND name = 't_batch_del_events'"
+    ).strip()
+    expected_blobs = set(
+        node.query(
+            "SELECT remote_path FROM system.remote_data_paths "
+            f"WHERE disk_name = 'azure_disk' AND local_path LIKE '%{table_uuid}%'"
+        ).split()
+    )
+    assert expected_blobs, "the table must be backed by remote objects"
+
+    def azure_delete_objects():
+        # sum() so an absent event row reads as 0; system.events is a live global counter (no flush needed).
+        return int(
+            node.query(
+                "SELECT sum(value) FROM system.events WHERE event = 'AzureDeleteObjects'"
+            ).strip()
+        )
+
+    events_before = azure_delete_objects()
+
+    logged = set()
+    node.query("SYSTEM ENABLE FAILPOINT azure_inject_forbidden_response")
+    try:
+        try:
+            node.query("DROP TABLE t_batch_del_events SYNC")
+        except Exception:
+            pass
+
+        # Synchronize on the batch actually having been submitted: the increment now runs before the
+        # catch's blob_storage_log entries, so once every object's failed Delete row is visible the
+        # counter has definitely moved. Reuse the proven 403-batch poll for that barrier.
+        blob_list = ", ".join(f"'{p}'" for p in expected_blobs)
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            node.query("SYSTEM FLUSH LOGS")
+            logged = set(
+                node.query(
+                    "SELECT remote_path FROM system.blob_storage_log "
+                    "WHERE event_type = 'Delete' AND error_code = 403 "
+                    f"AND remote_path IN ({blob_list})"
+                ).split()
+            )
+            if logged >= expected_blobs:
+                break
+            time.sleep(0.5)
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT azure_inject_forbidden_response")
+
+    missing = expected_blobs - logged
+    assert not missing, (
+        f"batch delete did not run for every object; missing {len(missing)}/{len(expected_blobs)}: "
+        f"{sorted(missing)[:5]}"
+    )
+
+    delta = azure_delete_objects() - events_before
+    assert delta >= len(expected_blobs), (
+        f"expected system.events AzureDeleteObjects to grow by >= {len(expected_blobs)} "
+        f"on the failed batch delete, got delta {delta}"
+    )
+
+    node.query("DROP TABLE IF EXISTS t_batch_del_events SYNC")  # cleanup (failpoint disabled)

--- a/tests/integration/test_azure_403_handling/test.py
+++ b/tests/integration/test_azure_403_handling/test.py
@@ -23,7 +23,10 @@ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
     "node",
-    main_configs=[os.path.join(SCRIPT_DIR, "configs", "azure_disk.xml")],
+    main_configs=[
+        os.path.join(SCRIPT_DIR, "configs", "azure_disk.xml"),
+        os.path.join(SCRIPT_DIR, "configs", "blob_log.xml"),
+    ],
     with_azurite=True,
     with_zookeeper=True,
 )
@@ -271,3 +274,69 @@ def test_transient_forbidden_on_write_succeeds(started_cluster):
         "Write at attempt"
     ), "the CH-level write retry loop was never exercised"
     assert not node.contains_in_log(BROKEN_PART_LOG)
+
+
+def test_batch_delete_failure_logs_every_object(started_cluster):
+    # When the batch DELETE request itself fails (here a permanent 403), the per-object response loop is
+    # skipped, so removeObjectsBatchIfExists must still emit one system.blob_storage_log Delete event per
+    # object before rethrowing — otherwise those deletes vanish from the audit log. Assert exactly that:
+    # one failed Delete row per blob, scoped to this table's own objects, carrying the real Azure status
+    # code (403), not the placeholder -1.
+    node.query("DROP TABLE IF EXISTS t_batch_del SYNC")
+    node.query(
+        """
+        CREATE TABLE t_batch_del (k UInt64) ENGINE = MergeTree ORDER BY k
+        SETTINGS storage_policy = 'azure_policy', min_bytes_for_wide_part = 0
+        """
+    )
+    for i in range(3):
+        node.query(f"INSERT INTO t_batch_del SELECT number + {i * 100} FROM numbers(100)")
+
+    # The exact remote blobs backing this table, scoped by its UUID so residue from other tests in the
+    # module-scoped, append-only blob_storage_log cannot satisfy the assertion on its own.
+    table_uuid = node.query(
+        "SELECT uuid FROM system.tables WHERE database = currentDatabase() AND name = 't_batch_del'"
+    ).strip()
+    expected_blobs = set(
+        node.query(
+            "SELECT remote_path FROM system.remote_data_paths "
+            f"WHERE disk_name = 'azure_disk' AND local_path LIKE '%{table_uuid}%'"
+        ).split()
+    )
+    assert expected_blobs, "the table must be backed by remote objects"
+
+    logged = set()
+    node.query("SYSTEM ENABLE FAILPOINT azure_inject_forbidden_response")
+    try:
+        # Object removal on DROP is best-effort (and can run asynchronously), so the DROP itself may or
+        # may not surface the error. Keep the failpoint enabled and poll until every object's failed
+        # Delete event has been recorded, matching only this table's blobs and the injected 403.
+        try:
+            node.query("DROP TABLE t_batch_del SYNC")
+        except Exception:
+            pass
+
+        blob_list = ", ".join(f"'{p}'" for p in expected_blobs)
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            node.query("SYSTEM FLUSH LOGS")
+            logged = set(
+                node.query(
+                    "SELECT remote_path FROM system.blob_storage_log "
+                    "WHERE event_type = 'Delete' AND error_code = 403 "
+                    f"AND remote_path IN ({blob_list})"
+                ).split()
+            )
+            if logged >= expected_blobs:
+                break
+            time.sleep(0.5)
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT azure_inject_forbidden_response")
+
+    missing = expected_blobs - logged
+    assert not missing, (
+        f"expected one failed Delete event (error_code=403) per object, "
+        f"missing {len(missing)}/{len(expected_blobs)}: {sorted(missing)[:5]}"
+    )
+
+    node.query("DROP TABLE IF EXISTS t_batch_del SYNC")  # cleanup (failpoint disabled)

--- a/tests/integration/test_azure_403_handling/test.py
+++ b/tests/integration/test_azure_403_handling/test.py
@@ -340,3 +340,71 @@ def test_batch_delete_failure_logs_every_object(started_cluster):
     )
 
     node.query("DROP TABLE IF EXISTS t_batch_del SYNC")  # cleanup (failpoint disabled)
+
+
+def test_batch_delete_non_azure_failure_logs_every_object(started_cluster):
+    # Negative control for the catch(...) fallback in removeObjectsBatchIfExists: when SubmitBatch fails
+    # with a NON-Azure exception (an injected credential AuthenticationException, a std::exception that is
+    # NOT an Azure::Storage::StorageException), the batch path must still emit one Delete event per object
+    # before rethrowing, carrying the placeholder error_code = -1 (no HTTP status) plus the exception text.
+    node.query("DROP TABLE IF EXISTS t_batch_del_auth SYNC")
+    node.query(
+        """
+        CREATE TABLE t_batch_del_auth (k UInt64) ENGINE = MergeTree ORDER BY k
+        SETTINGS storage_policy = 'azure_policy', min_bytes_for_wide_part = 0
+        """
+    )
+    for i in range(3):
+        node.query(f"INSERT INTO t_batch_del_auth SELECT number + {i * 100} FROM numbers(100)")
+
+    table_uuid = node.query(
+        "SELECT uuid FROM system.tables WHERE database = currentDatabase() AND name = 't_batch_del_auth'"
+    ).strip()
+    expected_blobs = set(
+        node.query(
+            "SELECT remote_path FROM system.remote_data_paths "
+            f"WHERE disk_name = 'azure_disk' AND local_path LIKE '%{table_uuid}%'"
+        ).split()
+    )
+    assert expected_blobs, "the table must be backed by remote objects"
+
+    logged = set()
+    node.query("SYSTEM ENABLE FAILPOINT azure_inject_auth_failure_on_request")
+    try:
+        try:
+            node.query("DROP TABLE t_batch_del_auth SYNC")
+        except Exception:
+            pass
+
+        blob_list = ", ".join(f"'{p}'" for p in expected_blobs)
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            node.query("SYSTEM FLUSH LOGS")
+            logged = set(
+                node.query(
+                    "SELECT remote_path FROM system.blob_storage_log "
+                    "WHERE event_type = 'Delete' AND error_code = -1 "
+                    f"AND remote_path IN ({blob_list})"
+                ).split()
+            )
+            if logged >= expected_blobs:
+                break
+            time.sleep(0.5)
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT azure_inject_auth_failure_on_request")
+
+    missing = expected_blobs - logged
+    assert not missing, (
+        f"expected one failed Delete event (error_code=-1) per object, "
+        f"missing {len(missing)}/{len(expected_blobs)}: {sorted(missing)[:5]}"
+    )
+
+    blob_list = ", ".join(f"'{p}'" for p in expected_blobs)
+    errors = node.query(
+        "SELECT DISTINCT error FROM system.blob_storage_log "
+        "WHERE event_type = 'Delete' AND error_code = -1 "
+        f"AND remote_path IN ({blob_list})"
+    )
+    assert "Authentication" in errors, f"expected the auth exception text in the log, got: {errors!r}"
+
+    node.query("DROP TABLE IF EXISTS t_batch_del_auth SYNC")  # cleanup (failpoint disabled)


### PR DESCRIPTION
> **Series**: #112871 -> **#112873** (this), #112872, #112874, #112875, #112876

**Problem.** When the batch `SubmitBatch` delete request itself fails, the per-object response loop is skipped, so zero `system.blob_storage_log` Delete events are recorded for the whole batch. Failure scenario:

```
removeObjectsBatchIfExists: SubmitBatch() throws (e.g. 403 on the batch endpoint)
  -> per-object GetResponse() loop skipped -> 0 Delete events logged
```

**Fix.** Record a Delete event per object on batch-level failure before rethrowing.

**Changes.**
- `Disks/…/AzureBlobStorage/AzureObjectStorage::removeObjectsBatchIfExists`: emit per-object `blob_storage_log` Delete events on `SubmitBatch` failure.
- `tests/integration/test_azure_403_handling`: batch-delete-logging test + `configs/blob_log.xml`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed Azure batch object deletion recording no `system.blob_storage_log` Delete events when the batch request itself failed, leaving the whole batch unlogged. A Delete event is now recorded for each object on a batch-level failure.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1639` (included in `26.8` and later)
<!-- ch-version-info:end -->