### PR TITLE
MergeTree: rethrow retryable errors from checkDataPart instead of returning empty checksums

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -81,6 +81,7 @@ static struct InitFiu
     REGULAR(azure_inject_poco_timeout) \
     ONCE(azure_inject_poco_timeout_once) \
     REGULAR(azure_inject_bad_request) \
+    REGULAR(check_data_part_retryable_error) \
     ONCE(distributed_cache_fail_request_in_the_middle_of_request) \
     ONCE(object_storage_queue_fail_commit_once) \
     ONCE(object_storage_queue_fail_commit_after_success) \

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -964,20 +964,9 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
             /// entries from the expected checksums when throw_on_broken_projection is false. Genuine
             /// base-file corruption still fails checkEqual, so it is left to propagate.
             bool is_broken_projection = false;
-            auto computed_checksums = checkDataPart(new_data_part, /*require_checksums=*/ true, is_broken_projection);
-
-            /// checkDataPart returns an empty result (instead of throwing) when it hits a retryable error
-            /// such as a transient read or memory-limit exception, expecting the check to be retried
-            /// later. On the fetch path there is no later check before the part is published, so an empty
-            /// result means the archive contents were never verified. Fail the fetch so it is retried
-            /// rather than accepting a possibly-corrupted packed part. (A real part always has files, so a
-            /// genuine part never yields empty checksums here.)
-            if (computed_checksums.empty())
-                throw Exception(
-                    ErrorCodes::ABORTED,
-                    "Could not verify packed part {} on fetch (checksum computation was skipped because of a "
-                    "transient error); the fetch will be retried",
-                    part_name);
+            /// checkDataPart rethrows a retryable error (transient read / memory limit / Azure 403),
+            /// which fails the fetch so it is retried instead of publishing an unverified part.
+            checkDataPart(new_data_part, /*require_checksums=*/ true, is_broken_projection);
         }
         LOG_DEBUG(log, "Download of part {} onto disk {} finished.", part_name, disk->getName());
     }

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -966,20 +966,8 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
             /// entries from the expected checksums when throw_on_broken_projection is false. Genuine
             /// base-file corruption still fails checkEqual, so it is left to propagate.
             bool is_broken_projection = false;
-            auto computed_checksums = checkDataPart(new_data_part, /*require_checksums=*/ true, is_broken_projection);
-
-            /// checkDataPart returns an empty result (instead of throwing) when it hits a retryable error
-            /// such as a transient read or memory-limit exception, expecting the check to be retried
-            /// later. On the fetch path there is no later check before the part is published, so an empty
-            /// result means the archive contents were never verified. Fail the fetch so it is retried
-            /// rather than accepting a possibly-corrupted packed part. (A real part always has files, so a
-            /// genuine part never yields empty checksums here.)
-            if (computed_checksums.empty())
-                throw Exception(
-                    ErrorCodes::ABORTED,
-                    "Could not verify packed part {} on fetch (checksum computation was skipped because of a "
-                    "transient error); the fetch will be retried",
-                    part_name);
+            /// checkDataPart rethrows a retryable error (transient read / memory limit / Azure 403), failing the fetch so it retries instead of publishing an unverified part.
+            checkDataPart(new_data_part, /*require_checksums=*/ true, is_broken_projection);
         }
         LOG_DEBUG(log, "Download of part {} onto disk {} finished.", part_name, disk->getName());
     }

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -18,6 +18,7 @@
 #include <Common/SipHash.h>
 #include <Common/ZooKeeper/IKeeper.h>
 #include <Common/ErrnoException.h>
+#include <Common/FailPoint.h>
 #include <IO/AzureBlobStorage/isRetryableAzureException.h>
 #if USE_AZURE_BLOB_STORAGE
 #include <azure/core/credentials/credentials.hpp>
@@ -56,6 +57,11 @@ namespace ErrorCodes
     extern const int ABORTED;
     extern const int CANNOT_WRITE_TO_OSTREAM;
     extern const int CACHE_CANNOT_WRITE_TO_CACHE_DISK;
+}
+
+namespace FailPoints
+{
+    extern const char check_data_part_retryable_error[];
 }
 
 
@@ -174,6 +180,12 @@ static IMergeTreeDataPart::Checksums checkDataPart(
 
     CurrentMetrics::Increment metric_increment{CurrentMetrics::ReplicatedChecks};
     Poco::Logger * log = &Poco::Logger::get("checkDataPart");
+
+    /// Test-only: make checkDataPart's read raise a retryable error, after the part is on disk.
+    fiu_do_on(FailPoints::check_data_part_retryable_error,
+    {
+        throw Poco::TimeoutException("Injected transient error into checkDataPart");
+    });
 
     NamesAndTypesList columns_txt;
 
@@ -551,12 +563,10 @@ IMergeTreeDataPart::Checksums checkDataPart(
             {
                 LOG_DEBUG(
                     getLogger("checkDataPart"),
-                    "Got retriable error {} checking data part {}, will return empty", data_part->name, getCurrentExceptionMessage(false));
+                    "Got retriable error {} checking data part {}, will rethrow", getCurrentExceptionMessage(false), data_part->name);
 
-                /// We were unable to check data part because of some temporary exception
-                /// like Memory limit exceeded. If part is actually broken we will retry check
-                /// with the next read attempt of this data part.
-                return IMergeTreeDataPart::Checksums{};
+                /// Transient error (memory limit, retryable Azure 403/timeout): rethrow so the caller retries later instead of treating the part as verified; a genuinely broken part still surfaces on retry.
+                throw;
             }
             throw;
         }
@@ -584,12 +594,10 @@ IMergeTreeDataPart::Checksums checkDataPart(
         {
             LOG_DEBUG(
                 getLogger("checkDataPart"),
-                "Got retriable error {} checking data part {}, will return empty", data_part->name, getCurrentExceptionMessage(false));
+                "Got retriable error {} checking data part {}, will rethrow", getCurrentExceptionMessage(false), data_part->name);
 
-            /// We were unable to check data part because of some temporary exception
-            /// like Memory limit exceeded. If part is actually broken we will retry check
-            /// with the next read attempt of this data part.
-            return {};
+            /// Transient error (memory limit, retryable Azure 403/timeout): rethrow so the caller retries later instead of treating the part as verified; a genuinely broken part still surfaces on retry.
+            throw;
         }
         return drop_cache_and_check();
     }

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -551,12 +551,12 @@ IMergeTreeDataPart::Checksums checkDataPart(
             {
                 LOG_DEBUG(
                     getLogger("checkDataPart"),
-                    "Got retriable error {} checking data part {}, will return empty", data_part->name, getCurrentExceptionMessage(false));
+                    "Got retriable error {} checking data part {}, will rethrow", getCurrentExceptionMessage(false), data_part->name);
 
-                /// We were unable to check data part because of some temporary exception
-                /// like Memory limit exceeded. If part is actually broken we will retry check
-                /// with the next read attempt of this data part.
-                return IMergeTreeDataPart::Checksums{};
+                /// We were unable to check the data part because of a transient error (e.g. a memory
+                /// limit, or a retryable Azure 403/timeout). Rethrow it so the caller retries later
+                /// instead of treating the part as verified; a real broken part surfaces on retry.
+                throw;
             }
             throw;
         }
@@ -584,12 +584,12 @@ IMergeTreeDataPart::Checksums checkDataPart(
         {
             LOG_DEBUG(
                 getLogger("checkDataPart"),
-                "Got retriable error {} checking data part {}, will return empty", data_part->name, getCurrentExceptionMessage(false));
+                "Got retriable error {} checking data part {}, will rethrow", getCurrentExceptionMessage(false), data_part->name);
 
-            /// We were unable to check data part because of some temporary exception
-            /// like Memory limit exceeded. If part is actually broken we will retry check
-            /// with the next read attempt of this data part.
-            return {};
+            /// We were unable to check the data part because of a transient error (e.g. a memory
+            /// limit, or a retryable Azure 403/timeout). Rethrow it so the caller retries later
+            /// instead of treating the part as verified; a real broken part surfaces on retry.
+            throw;
         }
         return drop_cache_and_check();
     }

--- a/tests/integration/test_azure_403_handling/test.py
+++ b/tests/integration/test_azure_403_handling/test.py
@@ -14,6 +14,7 @@ import time
 import pytest
 
 from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
 
 AZURITE_ACCOUNT = "devstoreaccount1"
 AZURITE_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
@@ -23,6 +24,13 @@ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
     "node",
+    main_configs=[os.path.join(SCRIPT_DIR, "configs", "azure_disk.xml")],
+    with_azurite=True,
+    with_zookeeper=True,
+)
+# Second replica for the packed-fetch verification test (DataPartsExchange downloadPartToDisk).
+node2 = cluster.add_instance(
+    "node2",
     main_configs=[os.path.join(SCRIPT_DIR, "configs", "azure_disk.xml")],
     with_azurite=True,
     with_zookeeper=True,
@@ -48,7 +56,8 @@ ERROR_KINDS = {
 }
 
 ALL_FAILPOINTS = [fp for triple in ERROR_KINDS.values() for fp in triple[:2]] + [
-    "azure_inject_bad_request"
+    "azure_inject_bad_request",
+    "check_data_part_retryable_error",
 ]
 
 # The OSS-observable signal that reportBroken() was taken (part-check thread).
@@ -271,3 +280,91 @@ def test_transient_forbidden_on_write_succeeds(started_cluster):
         "Write at attempt"
     ), "the CH-level write retry loop was never exercised"
     assert not node.contains_in_log(BROKEN_PART_LOG)
+
+
+def test_check_table_surfaces_transient_not_verified(started_cluster):
+    # checkDataPart now rethrows a retryable error instead of returning empty checksums, so a
+    # verification caller surfaces the transient failure rather than masquerading it as verified.
+    # This pins the StorageMergeTree::checkDataNext caller (StorageMergeTree.cpp:3417/3438): plain
+    # MergeTree on purpose, because the rest of the suite is ReplicatedMergeTree, whose CHECK TABLE
+    # routes through the part-check thread instead. Before the fix checkDataPart returned empty on
+    # the retryable 403 and checkDataNext reported the part as a verified "OK" (is_passed=true) — a
+    # silent false pass; with the fix the 403 is rethrown and CHECK TABLE fails with the real error.
+    node.query("DROP TABLE IF EXISTS t_check_mt SYNC")
+    node.query(
+        """
+        CREATE TABLE t_check_mt (k UInt64, v String)
+        ENGINE = MergeTree() ORDER BY k
+        SETTINGS storage_policy = 'azure_policy', min_bytes_for_wide_part = 0
+        """
+    )
+    node.query("INSERT INTO t_check_mt SELECT number, toString(number) FROM numbers(100)")
+    assert node.query("SELECT count() FROM t_check_mt").strip() == "100"
+
+    # Force the check to read the part data from Azure (not a local cache) so the failpoint fires.
+    node.query("SYSTEM DROP FILESYSTEM CACHE")
+    node.query("SYSTEM DROP MARK CACHE")
+
+    node.query("SYSTEM ENABLE FAILPOINT azure_inject_forbidden_response")
+    try:
+        err = node.query_and_get_error("CHECK TABLE t_check_mt")
+        assert "403" in err or "Forbidden" in err, f"expected surfaced transient error, got:\n{err}"
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT azure_inject_forbidden_response")
+
+    node.query("DROP TABLE IF EXISTS t_check_mt SYNC")
+
+
+def test_packed_fetch_checkdatapart_retryable_not_published(started_cluster):
+    # Regression for DataPartsExchange.cpp:971: on a packed replica-fetch, checkDataPart must rethrow a
+    # retryable error (not return empty) so the receiver retries instead of publishing an unverified part.
+    # A code failpoint injects the error at checkDataPart itself, since a wire 403 can't isolate that read.
+    def create(n, replica):
+        n.query("DROP TABLE IF EXISTS t_cdp SYNC")
+        n.query(
+            f"""
+            CREATE TABLE t_cdp (k UInt64, v String)
+            ENGINE = ReplicatedMergeTree('/clickhouse/t_cdp', '{replica}')
+            ORDER BY k
+            SETTINGS storage_policy = 'azure_policy',
+                     min_bytes_for_wide_part = 0,
+                     min_bytes_for_full_part_storage = 1073741824,
+                     max_postpone_time_for_failed_replicated_fetches_ms = 1000
+            """
+        )
+
+    try:
+        create(node, "r1")
+        create(node2, "r2")
+
+        node2.query("SYSTEM STOP FETCHES t_cdp")
+        node.query("INSERT INTO t_cdp SELECT number, toString(number) FROM numbers(100)")
+        assert node.query("SELECT count() FROM t_cdp").strip() == "100"
+
+        node2.query("SYSTEM DROP FILESYSTEM CACHE")
+        node2.query("SYSTEM DROP MARK CACHE")
+        node2.query("SYSTEM ENABLE FAILPOINT check_data_part_retryable_error")
+        node2.query("SYSTEM START FETCHES t_cdp")
+
+        # Wait for the injected marker on node2's replication_queue: proves the fetch reached checkDataPart's retryable path (a stalled queue alone would also keep count()==0).
+        INJECTED = "Injected transient error into checkDataPart"
+        assert_eq_with_retry(
+            node2,
+            "SELECT count() > 0 FROM system.replication_queue "
+            "WHERE database = currentDatabase() AND table = 't_cdp' AND type = 'GET_PART' "
+            f"AND num_tries >= 1 AND last_exception LIKE '%{INJECTED}%'",
+            "1",
+            retry_count=120,
+        )
+        # Failpoint is persistent, so the unverified part cannot be published while it is enabled.
+        assert node2.query("SELECT count() FROM t_cdp").strip() == "0"
+        assert not node2.contains_in_log(BROKEN_PART_LOG)
+
+        # Clear the injected error: the fetch retries, checkDataPart passes, and the part is published.
+        node2.query("SYSTEM DISABLE FAILPOINT check_data_part_retryable_error")
+        node2.query("SYSTEM SYNC REPLICA t_cdp", timeout=90)
+        assert node2.query("SELECT count() FROM t_cdp").strip() == "100"
+    finally:
+        node2.query("SYSTEM DISABLE FAILPOINT check_data_part_retryable_error")
+        node.query("DROP TABLE IF EXISTS t_cdp SYNC")
+        node2.query("DROP TABLE IF EXISTS t_cdp SYNC")

--- a/tests/integration/test_azure_403_handling/test.py
+++ b/tests/integration/test_azure_403_handling/test.py
@@ -271,3 +271,36 @@ def test_transient_forbidden_on_write_succeeds(started_cluster):
         "Write at attempt"
     ), "the CH-level write retry loop was never exercised"
     assert not node.contains_in_log(BROKEN_PART_LOG)
+
+
+def test_check_table_surfaces_transient_not_verified(started_cluster):
+    # checkDataPart now rethrows a retryable error instead of returning empty checksums, so a
+    # verification caller surfaces the transient failure rather than masquerading it as verified.
+    # This pins the StorageMergeTree::checkDataNext caller (StorageMergeTree.cpp:3417/3438): plain
+    # MergeTree on purpose, because the rest of the suite is ReplicatedMergeTree, whose CHECK TABLE
+    # routes through the part-check thread instead. Before the fix checkDataPart returned empty on
+    # the retryable 403 and checkDataNext reported the part as a verified "OK" (is_passed=true) — a
+    # silent false pass; with the fix the 403 is rethrown and CHECK TABLE fails with the real error.
+    node.query("DROP TABLE IF EXISTS t_check_mt SYNC")
+    node.query(
+        """
+        CREATE TABLE t_check_mt (k UInt64, v String)
+        ENGINE = MergeTree() ORDER BY k
+        SETTINGS storage_policy = 'azure_policy', min_bytes_for_wide_part = 0
+        """
+    )
+    node.query("INSERT INTO t_check_mt SELECT number, toString(number) FROM numbers(100)")
+    assert node.query("SELECT count() FROM t_check_mt").strip() == "100"
+
+    # Force the check to read the part data from Azure (not a local cache) so the failpoint fires.
+    node.query("SYSTEM DROP FILESYSTEM CACHE")
+    node.query("SYSTEM DROP MARK CACHE")
+
+    node.query("SYSTEM ENABLE FAILPOINT azure_inject_forbidden_response")
+    try:
+        err = node.query_and_get_error("CHECK TABLE t_check_mt")
+        assert "403" in err or "Forbidden" in err, f"expected surfaced transient error, got:\n{err}"
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT azure_inject_forbidden_response")
+
+    node.query("DROP TABLE IF EXISTS t_check_mt SYNC")


### PR DESCRIPTION
> **Series**: #112871 -> **#112874** (this), #112872, #112873, #112875, #112876

**Problem.** `checkDataPart` swallows a retryable error and returns empty checksums, so `CHECK TABLE` and the fetch path treat a transient failure as "verified" and can persist an empty integrity baseline. Failure scenario:

```
checkDataPart(): catch retryable -> return {}
  CHECK TABLE       : empty -> reports OK
  downloadPartToDisk: empty -> accepts an unverified packed part
```

**Fix.** Rethrow retryable errors so callers' retry/skip guards fire; remove the now-dead empty-checksums guard on the fetch path.

**Changes.**
- `Storages/MergeTree/checkDataPart`: `return {}` -> `throw` on a retryable error.
- `Storages/MergeTree/DataPartsExchange`: delete the now-dead empty-checksums fetch guard.
- `tests/integration/test_azure_403_handling`: CHECK-TABLE-surfaces-transient test.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `checkDataPart` swallowing a retryable error and returning empty checksums, so `CHECK TABLE` could report a part as OK and a fetch could accept an unverified part after a transient failure. Retryable errors are now rethrown so the check is retried later instead of masking a transient failure as verified.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112874&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/112874](https://github.com/search?q=head%3Async-upstream%2Fpr%2F112874+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
