### PR TITLE
Azure: retry transient authentication failures on the remaining object-storage call sites

### DIFF
--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
@@ -12,6 +12,7 @@
 #include <Core/ServerSettings.h>
 #include <Common/ProxyConfigurationResolverProvider.h>
 #include <IO/AzureBlobStorage/PocoHTTPClient.h>
+#include <IO/AzureBlobStorage/retryAzureOnAuthError.h>
 #include <Common/Exception.h>
 #include <Common/ProfileEvents.h>
 #include <Common/re2.h>
@@ -310,7 +311,9 @@ static bool containerExists(const ContainerClient & client)
 
     try
     {
-        client.GetProperties();
+        /// No RequestSettings are available at client-factory time; mirror the default retry count.
+        retryAzureOnAuthError([&] { return client.GetProperties(); },
+            /*max_retries*/ 3, "containerExists", getLogger("AzureBlobStorageCommon"));
         return true;
     }
     catch (const Azure::Storage::StorageException & e)

--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -18,6 +18,7 @@
 #include <Disks/IO/ReadBufferFromRemoteFSGather.h>
 #include <Disks/IO/AsynchronousBoundedReadBuffer.h>
 #include <IO/AzureBlobStorage/copyAzureBlobStorageFile.h>
+#include <IO/AzureBlobStorage/retryAzureOnAuthError.h>
 
 #include <azure/storage/files/datalake/datalake_file_client.hpp>
 #include <azure/storage/files/datalake/datalake_options.hpp>
@@ -162,10 +163,12 @@ bool AzureObjectStorage::exists(const StoredObject & object) const
     try
     {
         auto blob_client = client_ptr->GetBlobClient(object.remote_path);
-        blob_client.GetProperties();
+        /// A transient credential failure must not be mistaken for absence; only a real NotFound
+        /// (handled below) means the object is absent.
+        getBlobPropertiesWithRetry(blob_client, settings.get()->max_single_download_retries, object.remote_path, log);
         return true;
     }
-    catch (const Azure::Storage::StorageException & e)
+    catch (const Azure::Core::RequestFailedException & e)
     {
         if (e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound)
             return false;
@@ -359,12 +362,14 @@ void AzureObjectStorage::removeObjectImpl(
     {
         if (isAdlsGen2Endpoint(connection_params.endpoint))
         {
-            buildDataLakeFileClient(path)->Delete();
+            retryAzureOnAuthError([&] { buildDataLakeFileClient(path)->Delete(); },
+                settings.get()->max_single_download_retries, path, log);
             success = true;
         }
         else
         {
-            auto delete_info = client_ptr->GetBlobClient(path).Delete();
+            auto delete_info = retryAzureOnAuthError([&] { return client_ptr->GetBlobClient(path).Delete(); },
+                settings.get()->max_single_download_retries, path, log);
             success = delete_info.Value.Deleted;
             if (!if_exists && !delete_info.Value.Deleted)
                 throw Exception(
@@ -372,7 +377,7 @@ void AzureObjectStorage::removeObjectImpl(
                     path, delete_info.RawResponse ? delete_info.RawResponse->GetReasonPhrase() : "Unknown");
         }
     }
-    catch (const Azure::Storage::StorageException & e)
+    catch (const Azure::Core::RequestFailedException & e)
     {
         error_code = static_cast<Int32>(e.StatusCode);
         error_message = e.Message;
@@ -472,7 +477,20 @@ void AzureObjectStorage::removeObjectsBatchIfExists(
         for (const auto & object : object_batch)
             responses.push_back(requests.DeleteBlob(client_ptr->GetBlobPath(object.remote_path)));
 
-        client_ptr->SubmitBatch(requests);
+        try
+        {
+            /// Retry a transient batch-level credential failure before giving up.
+            retryAzureOnAuthError([&] { client_ptr->SubmitBatch(requests); },
+                settings.get()->max_single_download_retries, container, log);
+        }
+        catch (...)
+        {
+            /// A batch-level failure skips the per-object loop below, so record the delete attempts before rethrowing.
+            const auto batch_error = getCurrentExceptionMessage(false);
+            for (const auto & object : object_batch)
+                add_log_entry(object, watch.elapsedMicroseconds() / object_batch.size(), -1, batch_error);
+            throw;
+        }
 
         ProfileEvents::increment(ProfileEvents::AzureDeleteObjects, object_batch.size());
         if (is_disk)
@@ -487,7 +505,7 @@ void AzureObjectStorage::removeObjectsBatchIfExists(
                 deferred_response.GetResponse();
                 add_log_entry(object, avg_elapsed_us);
             }
-            catch (const Azure::Storage::StorageException & e)
+            catch (const Azure::Core::RequestFailedException & e)
             {
                 if (e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound)
                 {
@@ -564,7 +582,7 @@ ObjectMetadata AzureObjectStorage::getObjectMetadata(const std::string & path, b
 {
     auto client_ptr = client.get();
     auto blob_client = client_ptr->GetBlobClient(path);
-    auto properties = blob_client.GetProperties().Value;
+    auto properties = getBlobPropertiesWithRetry(blob_client, settings.get()->max_single_download_retries, path, log);
 
     ProfileEvents::increment(ProfileEvents::AzureGetProperties);
     if (client_ptr->IsClientForDisk())
@@ -588,7 +606,7 @@ try
 {
     return getObjectMetadata(path, with_tags);
 }
-catch (const Azure::Storage::StorageException & e)
+catch (const Azure::Core::RequestFailedException & e)
 {
     if (e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound)
         return {};

--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -18,6 +18,7 @@
 #include <Disks/IO/ReadBufferFromRemoteFSGather.h>
 #include <Disks/IO/AsynchronousBoundedReadBuffer.h>
 #include <IO/AzureBlobStorage/copyAzureBlobStorageFile.h>
+#include <IO/AzureBlobStorage/retryAzureOnAuthError.h>
 
 #include <azure/storage/files/datalake/datalake_file_client.hpp>
 #include <azure/storage/files/datalake/datalake_options.hpp>
@@ -162,10 +163,12 @@ bool AzureObjectStorage::exists(const StoredObject & object) const
     try
     {
         auto blob_client = client_ptr->GetBlobClient(object.remote_path);
-        blob_client.GetProperties();
+        /// A transient credential failure must not be mistaken for absence; only a real NotFound
+        /// (handled below) means the object is absent.
+        getBlobPropertiesWithRetry(blob_client, settings.get()->max_single_download_retries, object.remote_path, log);
         return true;
     }
-    catch (const Azure::Storage::StorageException & e)
+    catch (const Azure::Core::RequestFailedException & e)
     {
         if (e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound)
             return false;
@@ -352,12 +355,14 @@ void AzureObjectStorage::removeObjectImpl(
     {
         if (isAdlsGen2Endpoint(connection_params.endpoint))
         {
-            buildDataLakeFileClient(path)->Delete();
+            retryAzureOnAuthError([&] { buildDataLakeFileClient(path)->Delete(); },
+                settings.get()->max_single_download_retries, path, log);
             success = true;
         }
         else
         {
-            auto delete_info = client_ptr->GetBlobClient(path).Delete();
+            auto delete_info = retryAzureOnAuthError([&] { return client_ptr->GetBlobClient(path).Delete(); },
+                settings.get()->max_single_download_retries, path, log);
             success = delete_info.Value.Deleted;
             if (!if_exists && !delete_info.Value.Deleted)
                 throw Exception(
@@ -365,7 +370,7 @@ void AzureObjectStorage::removeObjectImpl(
                     path, delete_info.RawResponse ? delete_info.RawResponse->GetReasonPhrase() : "Unknown");
         }
     }
-    catch (const Azure::Storage::StorageException & e)
+    catch (const Azure::Core::RequestFailedException & e)
     {
         error_code = static_cast<Int32>(e.StatusCode);
         error_message = e.Message;
@@ -465,7 +470,20 @@ void AzureObjectStorage::removeObjectsBatchIfExists(
         for (const auto & object : object_batch)
             responses.push_back(requests.DeleteBlob(client_ptr->GetBlobPath(object.remote_path)));
 
-        client_ptr->SubmitBatch(requests);
+        try
+        {
+            /// Retry a transient batch-level credential failure before giving up.
+            retryAzureOnAuthError([&] { client_ptr->SubmitBatch(requests); },
+                settings.get()->max_single_download_retries, container, log);
+        }
+        catch (...)
+        {
+            /// A batch-level failure skips the per-object loop below, so record the delete attempts before rethrowing.
+            const auto batch_error = getCurrentExceptionMessage(false);
+            for (const auto & object : object_batch)
+                add_log_entry(object, watch.elapsedMicroseconds() / object_batch.size(), -1, batch_error);
+            throw;
+        }
 
         ProfileEvents::increment(ProfileEvents::AzureDeleteObjects, object_batch.size());
         if (is_disk)
@@ -480,7 +498,7 @@ void AzureObjectStorage::removeObjectsBatchIfExists(
                 deferred_response.GetResponse();
                 add_log_entry(object, avg_elapsed_us);
             }
-            catch (const Azure::Storage::StorageException & e)
+            catch (const Azure::Core::RequestFailedException & e)
             {
                 if (e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound)
                 {
@@ -557,7 +575,7 @@ ObjectMetadata AzureObjectStorage::getObjectMetadata(const std::string & path, b
 {
     auto client_ptr = client.get();
     auto blob_client = client_ptr->GetBlobClient(path);
-    auto properties = blob_client.GetProperties().Value;
+    auto properties = getBlobPropertiesWithRetry(blob_client, settings.get()->max_single_download_retries, path, log);
 
     ProfileEvents::increment(ProfileEvents::AzureGetProperties);
     if (client_ptr->IsClientForDisk())
@@ -581,7 +599,7 @@ try
 {
     return getObjectMetadata(path, with_tags);
 }
-catch (const Azure::Storage::StorageException & e)
+catch (const Azure::Core::RequestFailedException & e)
 {
     if (e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound)
         return {};

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -6,6 +6,7 @@
 #include <Common/BlobStorageLogWriter.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <IO/AzureBlobStorage/isRetryableAzureException.h>
+#include <IO/AzureBlobStorage/retryAzureOnAuthError.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/AzureBlobStorage/PocoHTTPClient.h>
 #include <Common/logger_useful.h>
@@ -339,14 +340,15 @@ std::optional<size_t> ReadBufferFromAzureBlobStorage::tryGetFileSize()
         blob_client = std::make_unique<Azure::Storage::Blobs::BlobClient>(blob_container_client->GetBlobClient(path));
 
     if (!file_size)
-        file_size = blob_client->GetProperties().Value.BlobSize;
+        file_size = getBlobPropertiesWithRetry(*blob_client, max_single_download_retries, path, log).BlobSize;
 
     return file_size;
 }
 
 std::optional<RemoteFileMetadata> ReadBufferFromAzureBlobStorage::getRemoteFileMetadata() const
 {
-    const auto properties = blob_container_client->GetBlobClient(path).GetProperties().Value;
+    const auto properties = getBlobPropertiesWithRetry(
+        blob_container_client->GetBlobClient(path), max_single_download_retries, path, log);
     const auto last_modification_time = std::chrono::duration_cast<std::chrono::seconds>(
         static_cast<std::chrono::system_clock::time_point>(properties.LastModified).time_since_epoch())
         .count();
@@ -391,6 +393,8 @@ size_t ReadBufferFromAzureBlobStorage::readBigAt(char * to, size_t n, size_t ran
             setMetadataFromResponse(download_response.Value.Details, download_response.Value.BlobSize);
 
             std::unique_ptr<Azure::Core::IO::BodyStream> body_stream = std::move(download_response.Value.BodyStream);
+            if (body_stream == nullptr)
+                throw Exception(ErrorCodes::RECEIVED_EMPTY_DATA, "Null body stream in Azure download response for {}", path);
             bytes_copied = body_stream->ReadToCount(reinterpret_cast<uint8_t *>(to), body_stream->Length(), azure_context);
 
             LOG_TEST(log, "AzureBlobStorage readBigAt read bytes {}", bytes_copied);

--- a/src/Disks/IO/WriteBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/WriteBufferFromAzureBlobStorage.cpp
@@ -4,6 +4,7 @@
 
 #include <Disks/IO/WriteBufferFromAzureBlobStorage.h>
 #include <IO/AzureBlobStorage/isRetryableAzureException.h>
+#include <IO/AzureBlobStorage/retryAzureOnAuthError.h>
 #include <IO/AzureBlobStorage/PocoHTTPClient.h>
 #include <Common/getRandomASCIIString.h>
 #include <Common/logger_useful.h>
@@ -383,9 +384,11 @@ void WriteBufferFromAzureBlobStorage::finalizeImpl()
         try
         {
             auto blob_client = blob_container_client->GetBlobClient(blob_path);
-            blob_client.GetProperties();
+            /// The upload already succeeded; a transient credential failure on this verification must not
+            /// turn a good write into a final failure.
+            getBlobPropertiesWithRetry(blob_client, max_unexpected_write_error_retries, blob_path, log);
         }
-        catch (const Azure::Storage::StorageException & e)
+        catch (const Azure::Core::RequestFailedException & e)
         {
             if (e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound)
                 throw Exception(

--- a/src/Disks/IO/WriteBufferFromAzureDataLakeStorage.cpp
+++ b/src/Disks/IO/WriteBufferFromAzureDataLakeStorage.cpp
@@ -14,6 +14,7 @@
 
 #include <azure/core/io/body_stream.hpp>
 #include <azure/storage/files/datalake/datalake_options.hpp>
+#include <azure/core/credentials/credentials.hpp>
 
 
 namespace ProfileEvents
@@ -167,7 +168,28 @@ void WriteBufferFromAzureDataLakeStorage::runWithRetries(
 
     Stopwatch watch;
     size_t backoff_ms = 100;
-    for (size_t attempt = 1; attempt < ADLFS_MAX_RETRIES; ++attempt)
+    size_t attempt = 1;
+
+    /// Shared budget/backoff tail for both failure kinds: give up (log + throw) once the retry
+    /// budget is spent, otherwise warn and sleep before the next attempt.
+    auto retry_or_throw = [&](Int32 code, const String & msg, const char * kind)
+    {
+        if (attempt >= max_unexpected_write_error_retries)
+        {
+            log_event(code, msg, watch.elapsedMicroseconds());
+            throw Exception(
+                ErrorCodes::AZURE_BLOB_STORAGE_ERROR,
+                "ADLS Gen2 {} failed for `{}`: {}: {}", what, blob_path, kind, msg);
+        }
+
+        LOG_WARNING(log, "ADLS Gen2 {} attempt {} for `{}` failed: {}: {}. Retrying after {} ms.",
+            what, attempt, blob_path, kind, msg, backoff_ms);
+
+        sleepForMilliseconds(backoff_ms);
+        backoff_ms *= 2;
+    };
+
+    for (; attempt < ADLFS_MAX_RETRIES; ++attempt)
     {
         LOG_TRACE(log, "ADLS Gen2 {} attempt {} for `{}`", what, attempt, blob_path);
         try
@@ -179,8 +201,9 @@ void WriteBufferFromAzureDataLakeStorage::runWithRetries(
         }
         catch (const Azure::Core::RequestFailedException & e)
         {
-            const bool retryable = isRetryableAzureException(e);
-            if (!retryable || attempt >= max_unexpected_write_error_retries)
+            /// A non-retryable HTTP error fails immediately (keeping the numeric status in the
+            /// message); a retryable one goes through the shared budget/backoff tail.
+            if (!isRetryableAzureException(e))
             {
                 log_event(static_cast<Int32>(e.StatusCode), e.Message, watch.elapsedMicroseconds());
                 throw Exception(
@@ -192,11 +215,13 @@ void WriteBufferFromAzureDataLakeStorage::runWithRetries(
                     e.Message);
             }
 
-            LOG_WARNING(log, "ADLS Gen2 {} attempt {} for `{}` failed: HTTP {}: {}. Retrying after {} ms.",
-                what, attempt, blob_path, static_cast<int>(e.StatusCode), e.Message, backoff_ms);
-
-            sleepForMilliseconds(backoff_ms);
-            backoff_ms *= 2;
+            retry_or_throw(static_cast<Int32>(e.StatusCode), e.Message, "HTTP error");
+        }
+        catch (const Azure::Core::Credentials::AuthenticationException & e)
+        {
+            /// Credential/RBAC token-acquisition failures are transient during the auth-propagation
+            /// window (same rationale as 403 in isRetryableAzureException), so retry within budget.
+            retry_or_throw(static_cast<Int32>(ErrorCodes::AZURE_BLOB_STORAGE_ERROR), e.what(), "authentication error");
         }
     }
     log_event(static_cast<Int32>(ErrorCodes::AZURE_BLOB_STORAGE_ERROR), "retries exhausted", watch.elapsedMicroseconds());

--- a/src/IO/AzureBlobStorage/retryAzureOnAuthError.h
+++ b/src/IO/AzureBlobStorage/retryAzureOnAuthError.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "config.h"
+
+#if USE_AZURE_BLOB_STORAGE
+#include <Common/Logger.h>
+#include <Common/logger_useful.h>
+#include <base/sleep.h>
+#include <base/types.h>
+#include <azure/core/credentials/credentials.hpp>
+#include <azure/storage/blobs/blob_client.hpp>
+
+namespace DB
+{
+
+/// A credential AuthenticationException is thrown by the token layer around the transport, so the SDK
+/// RetryPolicy (which retries transient HTTP responses and transport errors) never sees it; retry it
+/// here with bounded exponential backoff for call sites without a ClickHouse-level retry loop.
+template <typename Func>
+auto retryAzureOnAuthError(Func && func, size_t max_retries, const String & path, const LoggerPtr & log)
+{
+    size_t sleep_time_with_backoff_milliseconds = 100;
+    for (size_t i = 0;; ++i)
+    {
+        try
+        {
+            return func();
+        }
+        catch (const Azure::Core::Credentials::AuthenticationException & e)
+        {
+            if (i + 1 >= max_retries)
+                throw;
+            LOG_DEBUG(log, "Azure operation on {} failed at attempt {}/{} (auth), retrying: {}", path, i + 1, max_retries, e.what());
+            sleepForMilliseconds(sleep_time_with_backoff_milliseconds);
+            sleep_time_with_backoff_milliseconds *= 2;
+        }
+    }
+}
+
+/// GetProperties() issued outside the IO retry loops (existence/metadata/size probes, upload verification).
+inline Azure::Storage::Blobs::Models::BlobProperties getBlobPropertiesWithRetry(
+    const Azure::Storage::Blobs::BlobClient & client, size_t max_retries, const String & path, const LoggerPtr & log)
+{
+    return retryAzureOnAuthError([&] { return client.GetProperties().Value; }, max_retries, path, log);
+}
+
+}
+
+#endif

--- a/tests/integration/test_azure_403_handling/test.py
+++ b/tests/integration/test_azure_403_handling/test.py
@@ -157,6 +157,50 @@ def test_sdk_retry_isolates_forbidden_on_direct_call(started_cluster):
         node.query("SYSTEM DISABLE FAILPOINT azure_inject_forbidden_response_once")
 
 
+def test_auth_retry_isolates_on_direct_call(started_cluster):
+    # Companion to the SDK-403 isolation test above, for the auth half: an AuthenticationException is
+    # thrown by the credential layer around the transport, so the SDK RetryPolicy never sees it — the
+    # only thing that can absorb a one-shot auth failure on this INSERT's direct metadata calls (the
+    # container existence check, then exists() for the blob) is the ClickHouse-level
+    # retryAzureOnAuthError wrapper. Without it this INSERT fails with the injected auth error.
+    # Runs early, while the node is otherwise Azure-quiet, like the test above.
+    endpoint = started_cluster.env_variables["AZURITE_STORAGE_ACCOUNT_URL"]
+
+    node.query("SYSTEM ENABLE FAILPOINT azure_inject_auth_failure_on_request_once")
+    try:
+        node.query(
+            f"""
+            INSERT INTO TABLE FUNCTION azureBlobStorage(
+                '{endpoint}', '{CONTAINER}', 'auth_direct_probe.csv',
+                '{AZURITE_ACCOUNT}', '{AZURITE_KEY}', 'CSV', 'auto', 'k UInt64')
+            VALUES (1)
+            """
+        )
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT azure_inject_auth_failure_on_request_once")
+
+
+def test_permanent_auth_failure_on_direct_call_fails_bounded(started_cluster):
+    # The auth retry must stay bounded: a never-clearing AuthenticationException still fails the query
+    # with the real auth error after the small retry budget instead of looping forever.
+    endpoint = started_cluster.env_variables["AZURITE_STORAGE_ACCOUNT_URL"]
+
+    node.query("SYSTEM ENABLE FAILPOINT azure_inject_auth_failure_on_request")
+    try:
+        err = node.query_and_get_error(
+            f"""
+            INSERT INTO TABLE FUNCTION azureBlobStorage(
+                '{endpoint}', '{CONTAINER}', 'auth_direct_probe_permanent.csv',
+                '{AZURITE_ACCOUNT}', '{AZURITE_KEY}', 'CSV', 'auto', 'k UInt64')
+            VALUES (1)
+            """
+        )
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT azure_inject_auth_failure_on_request")
+
+    assert "AuthenticationException" in err, f"expected an auth error, got:\n{err}"
+
+
 @pytest.mark.parametrize("kind", list(ERROR_KINDS))
 def test_transient_error_read_succeeds(started_cluster, kind):
     # One transient failure must be absorbed by the retry budget: data still returned, part never broken.


### PR DESCRIPTION
> **Series:** **#112871** → #112875 (this), #112872, #112873, #112874, #112876

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Retry a transient Azure `AuthenticationException` (credential/token-acquisition failure, e.g. during the managed-identity/RBAC propagation window) on object-storage call sites that previously had no retry at all: blob existence/metadata/size probes, single and batch deletes, the post-upload verification, the container existence check, and ADLS Gen2 writes. Previously a single transient credential failure at any of these points failed the whole query or background job.

---

Follow-up to #112871, which handles the HTTP half of the problem: the Azure SDK `RetryPolicy` now retries a transient 403 for every client (`retry_options.StatusCodes.insert(Forbidden)` in `AzureBlobStorageCommon.cpp`).

What the SDK cannot retry is `Azure::Core::Credentials::AuthenticationException`: it is thrown by the credential/token layer *around* the transport, so the retry policy — which only sees HTTP responses and `TransportException` — never observes it. The read/download/write buffer loops already absorb it via their `catch (...)` retry, but these call sites had no retry of any kind:

- `AzureObjectStorage::exists` and `getObjectMetadata` / `getObjectMetadataIfExists` — one-shot `GetProperties()`
- `AzureObjectStorage::removeObjectImpl` (blob and ADLS) and the batch `SubmitBatch`
- `ReadBufferFromAzureBlobStorage::tryGetFileSize` / `getRemoteFileMetadata`
- `WriteBufferFromAzureBlobStorage::finalizeImpl` post-upload verification — the upload already succeeded, a transient credential failure must not turn a good write into a failure
- `containerExists` in the client factory — the first request many flows issue
- `WriteBufferFromAzureDataLakeStorage::runWithRetries` — retried HTTP errors but let `AuthenticationException` escape on the first attempt

A single transient credential failure at any of them surfaced as a query/job failure.

Changes:
- New `retryAzureOnAuthError()` (`src/IO/AzureBlobStorage/retryAzureOnAuthError.h`): bounded exponential backoff around `AuthenticationException` **only**. HTTP-status retries deliberately stay in the SDK retry policy (#112871), so retry layers don't stack multiplicatively. `getBlobPropertiesWithRetry()` lives in the same header for the `GetProperties()` sites.
- Route the call sites above through it; widen their `Azure::Storage::StorageException` catches to the base `Azure::Core::RequestFailedException` (a behavior-preserving superset; NotFound handling unchanged).
- ADLS Gen2 `runWithRetries` additionally retries `AuthenticationException` within the same budget (shared give-up/backoff tail for both failure kinds).
- `readBigAt`: guard against a null body stream in the download response (mirrors the existing guard in `initialize()`).
- Tests (`test_azure_403_handling`): a one-shot injected `AuthenticationException` on the direct metadata path (no ClickHouse-level retry loop anywhere) must be absorbed — this test fails without this PR; a permanent one must still fail with the real auth error after the bounded budget.

Compared to the previous revision of this PR: all 403/HTTP retrying has been removed from the helper. After #112871 that is the SDK retry policy's job; doing it here as well would stack a second retry loop on top of the SDK's (up to 3 × 11 attempts on a permanent 403). This PR is now strictly about the auth exception the SDK cannot see. The per-object batch re-issue loop is gone for the same reason (an RBAC 403/auth failure is per-principal, i.e. all-or-nothing across a batch; batch-level retry covers it).

Not covered by tests: the ADLS Gen2 write path (azurite cannot emulate ADLS/OneLake endpoints).

Stacked on #112871 (branch base); to be merged after it.
