### PR TITLE
Azure: fix ranged copy corruption and harden the copy path

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -81,6 +81,7 @@ static struct InitFiu
     REGULAR(azure_inject_poco_timeout) \
     ONCE(azure_inject_poco_timeout_once) \
     REGULAR(azure_inject_bad_request) \
+    ONCE(azure_inject_forbidden_on_upload) \
     ONCE(distributed_cache_fail_request_in_the_middle_of_request) \
     ONCE(object_storage_queue_fail_commit_once) \
     ONCE(object_storage_queue_fail_commit_after_success) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -78,6 +78,7 @@ static struct InitFiu
     REGULAR(azure_inject_poco_timeout) \
     ONCE(azure_inject_poco_timeout_once) \
     REGULAR(azure_inject_bad_request) \
+    ONCE(azure_inject_forbidden_on_upload) \
     ONCE(distributed_cache_fail_request_in_the_middle_of_request) \
     ONCE(object_storage_queue_fail_commit_once) \
     ONCE(object_storage_queue_fail_commit_after_success) \

--- a/src/IO/AzureBlobStorage/copyAzureBlobStorageFile.cpp
+++ b/src/IO/AzureBlobStorage/copyAzureBlobStorageFile.cpp
@@ -14,11 +14,15 @@
 #include <IO/WriteBufferFromVector.h>
 #include <Disks/IO/ReadBufferFromAzureBlobStorage.h>
 #include <Disks/IO/WriteBufferFromAzureBlobStorage.h>
+#include <IO/AzureBlobStorage/retryAzureOperation.h>
 #include <Common/getRandomASCIIString.h>
+#include <Common/FailPoint.h>
 
 
 #include <azure/core/credentials/credentials.hpp>
+#include <azure/core/http/http.hpp>
 #include <azure/storage/common/storage_credential.hpp>
+#include <azure/storage/common/storage_exception.hpp>
 #include <azure/identity/managed_identity_credential.hpp>
 #include <azure/identity/workload_identity_credential.hpp>
 
@@ -44,8 +48,24 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
+namespace FailPoints
+{
+    extern const char azure_inject_forbidden_on_upload[];
+}
+
 namespace
 {
+    /// Test-only: make an UploadHelper write fail once with a retryable 403, so the
+    /// azure_inject_forbidden_on_upload failpoint exercises the write-side retry (retryAzureOperation).
+    [[noreturn, maybe_unused]] void injectForbiddenOnUpload()
+    {
+        throw Azure::Storage::StorageException::CreateFromResponse(
+            std::make_unique<Azure::Core::Http::RawResponse>(
+                1, 0,
+                Azure::Core::Http::HttpStatusCode::Forbidden,
+                "Forbidden (injected by failpoint)"));
+    }
+
     class UploadHelper
     {
     public:
@@ -165,7 +185,9 @@ namespace
         void performSinglepartUpload()
         {
             auto block_blob_client = client->GetBlockBlobClient(dest_blob);
-            auto read_buffer = create_read_buffer();
+            /// Skip the first `offset` bytes of the source, same as the multipart path
+            /// (processUploadPartRequest); otherwise a ranged copy reads from byte 0.
+            auto read_buffer = std::make_unique<LimitSeekableReadBuffer>(create_read_buffer(), offset, total_size);
 
             PODArray<char> memory;
             {
@@ -174,14 +196,21 @@ namespace
                 copyData(*read_buffer, wb, total_size);
             }
 
-            Azure::Core::IO::MemoryBodyStream stream(reinterpret_cast<const uint8_t *>(memory.data()), total_size);
-
             Stopwatch watch;
             Int32 error_code = 0;
             String error_message;
             try
             {
-                block_blob_client.Upload(stream);
+                retryAzureOperation(
+                    [&]
+                    {
+                        fiu_do_on(FailPoints::azure_inject_forbidden_on_upload, { injectForbiddenOnUpload(); });
+                        /// Rebuild the body stream on each attempt so a retry re-sends from the start.
+                        Azure::Core::IO::MemoryBodyStream stream(
+                            reinterpret_cast<const uint8_t *>(memory.data()), total_size);
+                        block_blob_client.Upload(stream);
+                    },
+                    settings->max_unexpected_write_error_retries, dest_blob, log);
             }
             catch (const Azure::Core::RequestFailedException & e)
             {
@@ -213,7 +242,13 @@ namespace
             String error_message;
             try
             {
-                block_blob_client.CommitBlockList(block_ids);
+                retryAzureOperation(
+                    [&]
+                    {
+                        fiu_do_on(FailPoints::azure_inject_forbidden_on_upload, { injectForbiddenOnUpload(); });
+                        block_blob_client.CommitBlockList(block_ids);
+                    },
+                    settings->max_unexpected_write_error_retries, dest_blob, log);
             }
             catch (const Azure::Core::RequestFailedException & e)
             {
@@ -309,8 +344,6 @@ namespace
                 copyData(*read_buffer, wb, size_to_stage);
             }
 
-            Azure::Core::IO::MemoryBodyStream stream(reinterpret_cast<const uint8_t *>(memory.data()), size_to_stage);
-
             auto block_id = getRandomASCIIString(64);
             block_ids[part_index] = block_id;
 
@@ -319,7 +352,16 @@ namespace
             String error_message;
             try
             {
-                block_blob_client.StageBlock(block_id, stream);
+                retryAzureOperation(
+                    [&]
+                    {
+                        fiu_do_on(FailPoints::azure_inject_forbidden_on_upload, { injectForbiddenOnUpload(); });
+                        /// Rebuild the body stream on each attempt so a retry re-sends from the start.
+                        Azure::Core::IO::MemoryBodyStream stream(
+                            reinterpret_cast<const uint8_t *>(memory.data()), size_to_stage);
+                        block_blob_client.StageBlock(block_id, stream);
+                    },
+                    settings->max_unexpected_write_error_retries, dest_blob, log);
             }
             catch (const Azure::Core::RequestFailedException & e)
             {
@@ -392,7 +434,9 @@ void copyAzureBlobStorageFile(
     auto log = getLogger("copyAzureBlobStorageFile");
     bool is_native_copy_done = false;
 
-    if (settings->use_native_copy)
+    /// Server-side CopyFromUri copies the whole source blob, so native copy is valid only for a
+    /// full-object copy; a ranged copy (offset > 0) must go via read+write.
+    if (settings->use_native_copy && offset == 0)
     {
         /// Do native copy
         LOG_TRACE(log, "Copying Blob: {} from Container: {} using native copy", src_blob, src_container_for_logging);
@@ -400,6 +444,7 @@ void copyAzureBlobStorageFile(
         if (dest_client->IsClientForDisk())
             ProfileEvents::increment(ProfileEvents::DiskAzureCopyObject);
 
+        std::optional<Azure::Storage::Blobs::StartBlobCopyOperation> async_operation;
         try
         {
             auto block_blob_client_src = src_client->GetBlockBlobClient(src_blob);
@@ -418,6 +463,7 @@ void copyAzureBlobStorageFile(
 
                 LOG_TRACE(log, "Copy blob sync {} -> {}", src_blob, dest_blob);
                 block_blob_client_dest.CopyFromUri(source_uri, copy_options);
+                is_native_copy_done = true;
             }
             else
             {
@@ -428,35 +474,13 @@ void copyAzureBlobStorageFile(
                         copy_options.Metadata[key] = value;
                 }
 
-                Azure::Storage::Blobs::StartBlobCopyOperation operation = block_blob_client_dest.StartCopyFromUri(source_uri, copy_options);
-
-                auto copy_response = operation.PollUntilDone(std::chrono::milliseconds(100));
-                auto properties_model = copy_response.Value;
-
-                auto copy_status = properties_model.CopyStatus;
-                auto copy_status_description = properties_model.CopyStatusDescription;
-
-
-                if (copy_status.HasValue() && copy_status.Value() == Azure::Storage::Blobs::Models::CopyStatus::Success)
-                {
-                    LOG_TRACE(log, "Copy of {} to {} finished", properties_model.CopySource.Value(), dest_blob);
-                }
-                else
-                {
-                    if (copy_status.HasValue())
-                        throw Exception(ErrorCodes::AZURE_BLOB_STORAGE_ERROR, "Copy from {} to {} failed with status {} description {} (operation is done {})",
-                                        src_blob, dest_blob, copy_status.Value().ToString(), copy_status_description.Value(), operation.IsDone());
-                    throw Exception(
-                        ErrorCodes::AZURE_BLOB_STORAGE_ERROR,
-                        "Copy from {} to {} didn't complete with success status (operation is done {})",
-                        src_blob,
-                        dest_blob,
-                        operation.IsDone());
-                }
+                /// Only *start* the server-side copy inside this try: a failure here happens before any copy
+                /// is in flight, so the catch below can still safely fall back to read+write. Polling is done
+                /// after the try, where a transient failure must not switch copy mechanisms mid-flight.
+                async_operation = block_blob_client_dest.StartCopyFromUri(source_uri, copy_options);
             }
-            is_native_copy_done = true;
         }
-        catch (const Azure::Storage::StorageException & e)
+        catch (const Azure::Core::RequestFailedException & e)
         {
             if (e.StatusCode == Azure::Core::Http::HttpStatusCode::Unauthorized)
             {
@@ -470,8 +494,49 @@ void copyAzureBlobStorageFile(
                                "Will attempt to copy using read & write. source container = {} blob = {} and destination container = {} blob = {}",
                           e.what(), src_container_for_logging, src_blob, dest_container_for_logging, dest_blob);
             }
+            else if (e.StatusCode == Azure::Core::Http::HttpStatusCode::Forbidden)
+            {
+                /// Transient RBAC-propagation 403: fall back to read+write, whose retry loops treat
+                /// 403 as retryable (isRetryableAzureException) instead of failing the copy.
+                LOG_TRACE(log, "Copy operation got 403 Forbidden; will retry using read & write. "
+                               "source container = {} blob = {} and destination container = {} blob = {}",
+                          src_container_for_logging, src_blob, dest_container_for_logging, dest_blob);
+            }
             else
                 throw;
+        }
+        catch (const Azure::Core::Credentials::AuthenticationException & e)
+        {
+            /// Credential/RBAC token failure while starting the copy: fall back to read+write.
+            LOG_TRACE(log, "Copy operation hit an authentication error ({}); will retry using read & write. "
+                           "source container = {} blob = {} and destination container = {} blob = {}",
+                      e.what(), src_container_for_logging, src_blob, dest_container_for_logging, dest_blob);
+        }
+
+        /// StartCopyFromUri succeeded, so a server-side copy is now in flight. Poll it to completion on the
+        /// SAME operation; a transient poll failure is retried here and never falls back to read+write --
+        /// that would start a second writer to dest_blob while the copy is still pending.
+        if (async_operation.has_value())
+        {
+            /// Polling copy status is a read, so it uses the read/download retry budget; the upload ops above use the write budget.
+            auto copy_response = retryAzureOperation(
+                [&] { return async_operation->PollUntilDone(std::chrono::milliseconds(100)); },
+                settings->max_single_download_retries, dest_blob, log);
+            auto properties_model = copy_response.Value;
+            auto copy_status = properties_model.CopyStatus;
+            auto copy_status_description = properties_model.CopyStatusDescription;
+
+            if (copy_status.HasValue() && copy_status.Value() == Azure::Storage::Blobs::Models::CopyStatus::Success)
+            {
+                LOG_TRACE(log, "Copy of {} to {} finished", properties_model.CopySource.Value(), dest_blob);
+                is_native_copy_done = true;
+            }
+            else if (copy_status.HasValue())
+                throw Exception(ErrorCodes::AZURE_BLOB_STORAGE_ERROR, "Copy from {} to {} failed with status {} description {} (operation is done {})",
+                                src_blob, dest_blob, copy_status.Value().ToString(), copy_status_description.Value(), async_operation->IsDone());
+            else
+                throw Exception(ErrorCodes::AZURE_BLOB_STORAGE_ERROR, "Copy from {} to {} didn't complete with success status (operation is done {})",
+                                src_blob, dest_blob, async_operation->IsDone());
         }
     }
     if (!is_native_copy_done)

--- a/src/IO/AzureBlobStorage/retryAzureOperation.h
+++ b/src/IO/AzureBlobStorage/retryAzureOperation.h
@@ -1,0 +1,49 @@
+#pragma once
+#include "config.h"
+
+#if USE_AZURE_BLOB_STORAGE
+#include <IO/AzureBlobStorage/isRetryableAzureException.h>
+#include <Common/Logger.h>
+#include <Common/logger_useful.h>
+#include <base/sleep.h>
+#include <base/types.h>
+#include <azure/core/credentials/credentials.hpp>
+
+namespace DB
+{
+
+/// Run an Azure SDK operation under the IO retry policy: retry a transient RBAC-propagation 403 / other
+/// retryable RequestFailedException (isRetryableAzureException) and a credential AuthenticationException
+/// with bounded exponential backoff, then rethrow. Shared by the GetProperties, delete and copy callers.
+template <typename Func>
+auto retryAzureOperation(Func && func, size_t max_retries, const String & path, const LoggerPtr & log)
+{
+    size_t sleep_time_with_backoff_milliseconds = 100;
+    for (size_t i = 0;; ++i)
+    {
+        try
+        {
+            return func();
+        }
+        catch (const Azure::Core::RequestFailedException & e)
+        {
+            if (i + 1 >= max_retries || !isRetryableAzureException(e))
+                throw;
+            LOG_TEST(log, "Azure operation on {} failed at attempt {}, retrying: {}", path, i + 1, e.Message);
+            sleepForMilliseconds(sleep_time_with_backoff_milliseconds);
+            sleep_time_with_backoff_milliseconds *= 2;
+        }
+        catch (const Azure::Core::Credentials::AuthenticationException & e)
+        {
+            if (i + 1 >= max_retries)
+                throw;
+            LOG_TEST(log, "Azure operation on {} failed at attempt {} (auth), retrying: {}", path, i + 1, e.what());
+            sleepForMilliseconds(sleep_time_with_backoff_milliseconds);
+            sleep_time_with_backoff_milliseconds *= 2;
+        }
+    }
+}
+
+}
+
+#endif

--- a/tests/integration/test_azure_403_handling/test.py
+++ b/tests/integration/test_azure_403_handling/test.py
@@ -48,7 +48,8 @@ ERROR_KINDS = {
 }
 
 ALL_FAILPOINTS = [fp for triple in ERROR_KINDS.values() for fp in triple[:2]] + [
-    "azure_inject_bad_request"
+    "azure_inject_bad_request",
+    "azure_inject_forbidden_on_upload",
 ]
 
 # The OSS-observable signal that reportBroken() was taken (part-check thread).
@@ -315,3 +316,50 @@ def test_transient_forbidden_on_write_succeeds(started_cluster):
         "Write at attempt"
     ), "the CH-level write retry loop was never exercised"
     assert not node.contains_in_log(BROKEN_PART_LOG)
+
+
+def test_azure_403_on_upload_read_write_copy_is_retried(started_cluster):
+    # The read+write copy fallback (UploadHelper in copyAzureBlobStorageFile) must retry a transient
+    # destination error on its write ops, the same way the read side already does. Force the
+    # read+write path with allow_azure_native_copy = 0 and inject one transient 403 on the upload;
+    # the backup must still succeed. Before the fix the first upload write threw and failed the copy.
+    connection_string = started_cluster.env_variables["AZURITE_CONNECTION_STRING"]
+
+    node.query("DROP TABLE IF EXISTS t_upload SYNC")
+    node.query("DROP TABLE IF EXISTS t_upload_restored SYNC")
+    node.query(
+        """
+        CREATE TABLE t_upload (k UInt64, v String)
+        ENGINE = MergeTree() ORDER BY k
+        SETTINGS storage_policy = 'azure_policy', min_bytes_for_wide_part = 0
+        """
+    )
+    node.query("INSERT INTO t_upload SELECT number, toString(number) FROM numbers(100)")
+
+    cont = "backupcont" + str(time.time_ns())
+    backup_dest = f"AzureBlobStorage('{connection_string}', '{cont}', 't_upload_backup')"
+
+    count_native = "SELECT sum(value) FROM system.events WHERE event = 'AzureCopyObject'"
+    native_before = int(node.query(count_native).strip() or 0)
+
+    node.query("SYSTEM ENABLE FAILPOINT azure_inject_forbidden_on_upload")
+    try:
+        node.query(
+            f"BACKUP TABLE t_upload TO {backup_dest} SETTINGS allow_azure_native_copy = 0"
+        )
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT azure_inject_forbidden_on_upload")
+
+    # Guard against a false pass: the copy must have gone through the read+write (UploadHelper) path,
+    # not a server-side native copy (which would never reach the injected write failpoint). Any
+    # native-copy attempt bumps AzureCopyObject before issuing the request.
+    assert int(node.query(count_native).strip() or 0) == native_before
+
+    node.query(
+        f"RESTORE TABLE t_upload AS t_upload_restored FROM {backup_dest} "
+        f"SETTINGS allow_azure_native_copy = 0"
+    )
+    assert node.query("SELECT count() FROM t_upload_restored").strip() == "100"
+
+    node.query("DROP TABLE IF EXISTS t_upload SYNC")
+    node.query("DROP TABLE IF EXISTS t_upload_restored SYNC")

--- a/tests/integration/test_backup_restore_azure_blob_storage/test.py
+++ b/tests/integration/test_backup_restore_azure_blob_storage/test.py
@@ -843,3 +843,60 @@ def test_reload_config_keeps_azure_endpoint_settings(cluster):
     azure_query(node, "DROP TABLE test_reload_native_copy")
     azure_query(node, "DROP TABLE test_reload_native_copy_r1")
     azure_query(node, "DROP TABLE test_reload_native_copy_r2")
+
+
+@pytest.mark.parametrize("allow_native_copy", [0, 1])
+def test_incremental_backup_for_log_family_native_copy(cluster, allow_native_copy):
+    # An Engine=Log .bin grows in place on INSERT, so an incremental backup copies a ranged suffix
+    # (offset = base .bin size > 0) through copyAzureBlobStorageFile. The delta is far below
+    # azure_max_single_part_upload_size (32 MiB), so it is a single-part copy that must copy bytes
+    # [offset, end); the exact-match assertion on restore catches a wrong-offset copy.
+    #
+    # Both copy mechanisms are exercised via allow_azure_native_copy; before the fix each corrupted
+    # a ranged copy for a different reason:
+    #   * allow_native_copy=1: server-side CopyFromUri copied the WHOLE source blob, ignoring
+    #     offset/size. The fix gates native copy on offset == 0, so a ranged copy now falls back to
+    #     read+write.
+    #   * allow_native_copy=0: the read+write single-part fallback read from byte 0 instead of
+    #     seeking to offset. The fix wraps the source in LimitSeekableReadBuffer(offset, size).
+    node = cluster.instances["node_native_copy"]
+    table = f"log_data_{allow_native_copy}"
+
+    azure_query(node, f"DROP TABLE IF EXISTS {table} SYNC")
+    azure_query(
+        node,
+        f"CREATE TABLE {table} (x UInt32, y String) Engine=Log "
+        "SETTINGS storage_policy='blob_storage_policy_native_copy'",
+    )
+    azure_query(
+        node, f"INSERT INTO {table} SELECT number, toString(number) FROM numbers(100)"
+    )
+    assert azure_query(node, f"SELECT count(), sum(x) FROM {table}") == "100\t4950\n"
+
+    backup_destination = f"AzureBlobStorage('{cluster.env_variables['AZURITE_CONNECTION_STRING']}', 'cont', '{new_backup_name()}')"
+    azure_query(
+        node,
+        f"BACKUP TABLE {table} TO {backup_destination} SETTINGS allow_azure_native_copy = {allow_native_copy}",
+    )
+
+    # Small append -> incremental backup copies [base_size, new_size), i.e. offset > 0.
+    azure_query(node, f"INSERT INTO {table} VALUES (1000, 'a'), (1001, 'b')")
+    assert azure_query(node, f"SELECT count(), sum(x) FROM {table}") == "102\t6951\n"
+
+    incremental_destination = f"AzureBlobStorage('{cluster.env_variables['AZURITE_CONNECTION_STRING']}', 'cont', '{new_backup_name()}')"
+    azure_query(
+        node,
+        f"BACKUP TABLE {table} TO {incremental_destination} "
+        f"SETTINGS base_backup = {backup_destination}, allow_azure_native_copy = {allow_native_copy}",
+    )
+
+    azure_query(node, f"DROP TABLE {table} SYNC")
+    azure_query(
+        node,
+        f"RESTORE TABLE {table} FROM {incremental_destination} SETTINGS allow_azure_native_copy = {allow_native_copy}",
+    )
+
+    # A wrong-offset ranged copy corrupts the restored delta; exact match catches it.
+    assert azure_query(node, f"SELECT count(), sum(x) FROM {table}") == "102\t6951\n"
+
+    azure_query(node, f"DROP TABLE {table} SYNC")


### PR DESCRIPTION
> **Series**: #112871 -> **#112876** (this), #112872, #112873, #112874, #112875

**Problem.** A ranged Azure copy corrupts the destination — native `CopyFromUri` copies the whole source blob (ignoring offset/size) and the single-part read+write fallback reads from byte 0 — and a transient 403/auth after the server-side copy starts spawns a second writer to the same blob. Failure scenario:

```
copyFile(src, offset=X>0, size=S):
  native CopyFromUri   -> copies the ENTIRE src (ignores X,S)  -> corrupt
  single-part fallback -> reads [0,S) not [X,X+S)             -> corrupt
  transient 403 after StartCopyFromUri -> read+write fallback -> 2 writers to dest
```

**Fix.** Gate native copy on `offset==0`; seek the fallback via `LimitSeekableReadBuffer(offset, total_size)`; only *start* the copy in the guarded block and poll the same operation on transient errors (no mechanism switch); retry the read+write upload writes through the shared retry helper.

**Changes.**
- `IO/AzureBlobStorage/copyAzureBlobStorageFile`: `offset==0` native-copy gate; seek the single-part fallback; poll-same-operation on transient errors; retry upload writes.
- `tests/integration/{test_backup_restore_azure_blob_storage,test_backup_restore_s3}`: incremental Log-family / ranged-copy regression tests.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a ranged Azure Blob Storage copy corrupting the destination during incremental backups: server-side native copy ignored the requested offset and size, and the single-part read-and-write fallback read from the start of the source. Native copy is now used only for a full-object copy, the fallback seeks to the correct offset, and a transient error after a server-side copy has started no longer starts a second writer to the destination.
