### PR TITLE
Fix two `distributed_index_analysis` tests on an unavailable replica

### DIFF
--- a/tests/queries/0_stateless/03622_distributed_index_analysis_additional_table_filters.reference
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_additional_table_filters.reference
@@ -2,7 +2,7 @@
 -- { echo }
 select count() from (select * from test_1m);
 989999
--- The `Distributed:` block lists one row per replica of test_cluster_one_shard_two_replicas.
+-- The `Distributed:` block lists one row per replica of `test_cluster_one_shard_two_replicas`.
 -- 127.0.0.2 is not guaranteed to be up, and when it is down its row degenerates to an empty
 -- `Address:` with zero counters while the local replica absorbs its parts. Assert the
 -- aggregate `Parts:`/`Granules:` and the pushed-down `Condition:` instead.
@@ -23,3 +23,4 @@ Expression ((Project names + (Projection + (Change column names to column identi
         Granules: 99/100
         Distributed:
       Ranges: 99
+DistributedIndexAnalysisMicroseconds>0=1, DistributedIndexAnalysisReplicaFallback=0, DistributedIndexAnalysisMissingParts=0

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_additional_table_filters.reference
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_additional_table_filters.reference
@@ -2,7 +2,15 @@
 -- { echo }
 select count() from (select * from test_1m);
 989999
-explain indexes=1 select key from (select * from test_1m);
+-- The `Distributed:` block lists one row per replica of test_cluster_one_shard_two_replicas.
+-- 127.0.0.2 is not guaranteed to be up, and when it is down its row degenerates to an empty
+-- `Address:` with zero counters while the local replica absorbs its parts. Assert the
+-- aggregate `Parts:`/`Granules:` and the pushed-down `Condition:` instead.
+select * from (
+    explain indexes=1 select key from (select * from test_1m)
+) where explain not like '%Address:%'
+    and explain not like '%Parts send:%' and explain not like '%Parts received:%'
+    and explain not like '%Granules send:%' and explain not like '%Granules received:%';
 Expression ((Project names + (Projection + (Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))))
   Filter (additional filter)
     ReadFromMergeTree (default.test_1m)
@@ -14,14 +22,4 @@ Expression ((Project names + (Projection + (Change column names to column identi
         Parts: 99/100
         Granules: 99/100
         Distributed:
-          Address: 127.0.0.2:9000
-          Parts send: 44
-          Parts received: 43
-          Granules send: 44
-          Granules received: 43
-          Address: 127.0.0.1:9000
-          Parts send: 56
-          Parts received: 56
-          Granules send: 56
-          Granules received: 56
       Ranges: 99

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_additional_table_filters.sql
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_additional_table_filters.sql
@@ -21,7 +21,17 @@ set allow_experimental_analyzer=1;
 set allow_experimental_parallel_reading_from_replicas=0;
 -- disable statistics-based part pruning to keep EXPLAIN output stable
 SET use_statistics_for_part_pruning = 0;
+-- Ignore "Cannot connect to {}. It will not participate in distributed index analysis"
+set send_logs_level='error';
 
 -- { echo }
 select count() from (select * from test_1m);
-explain indexes=1 select key from (select * from test_1m);
+-- The `Distributed:` block lists one row per replica of test_cluster_one_shard_two_replicas.
+-- 127.0.0.2 is not guaranteed to be up, and when it is down its row degenerates to an empty
+-- `Address:` with zero counters while the local replica absorbs its parts. Assert the
+-- aggregate `Parts:`/`Granules:` and the pushed-down `Condition:` instead.
+select * from (
+    explain indexes=1 select key from (select * from test_1m)
+) where explain not like '%Address:%'
+    and explain not like '%Parts send:%' and explain not like '%Parts received:%'
+    and explain not like '%Granules send:%' and explain not like '%Granules received:%';

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_additional_table_filters.sql
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_additional_table_filters.sql
@@ -21,12 +21,12 @@ set allow_experimental_analyzer=1;
 set allow_experimental_parallel_reading_from_replicas=0;
 -- disable statistics-based part pruning to keep EXPLAIN output stable
 SET use_statistics_for_part_pruning = 0;
--- Ignore "Cannot connect to {}. It will not participate in distributed index analysis"
+-- Ignore `Cannot connect to {}. It will not participate in distributed index analysis`
 set send_logs_level='error';
 
 -- { echo }
 select count() from (select * from test_1m);
--- The `Distributed:` block lists one row per replica of test_cluster_one_shard_two_replicas.
+-- The `Distributed:` block lists one row per replica of `test_cluster_one_shard_two_replicas`.
 -- 127.0.0.2 is not guaranteed to be up, and when it is down its row degenerates to an empty
 -- `Address:` with zero counters while the local replica absorbs its parts. Assert the
 -- aggregate `Parts:`/`Granules:` and the pushed-down `Condition:` instead.
@@ -35,3 +35,35 @@ select * from (
 ) where explain not like '%Address:%'
     and explain not like '%Parts send:%' and explain not like '%Parts received:%'
     and explain not like '%Granules send:%' and explain not like '%Granules received:%';
+
+-- { echoOff }
+-- The filtered plan above no longer names the replica that answered, so assert separately that the
+-- remote replica analyzed its own parts rather than silently falling back to the initiator. Both
+-- `DistributedIndexAnalysisReplicaFallback` and `DistributedIndexAnalysisMissingParts` are
+-- incremented only once a replica has connected and its analysis then failed, so they read 0
+-- whether or not 127.0.0.2 is up. `DistributedIndexAnalysisScheduledReplicas` and
+-- `DistributedIndexAnalysisReplicaUnavailable` are deliberately not asserted: they depend on
+-- replica availability and would reintroduce the flakiness this test avoids.
+system flush logs query_log;
+select format(
+  'DistributedIndexAnalysisMicroseconds>0={}, DistributedIndexAnalysisReplicaFallback={}, DistributedIndexAnalysisMissingParts={}',
+  ProfileEvents['DistributedIndexAnalysisMicroseconds'] > 0,
+  ProfileEvents['DistributedIndexAnalysisReplicaFallback'],
+  ProfileEvents['DistributedIndexAnalysisMissingParts']
+)
+from system.query_log
+where
+  current_database = currentDatabase()
+  and event_date >= yesterday() and event_time >= now() - 600
+  and type = 'QueryFinish'
+  and is_initial_query
+  and endsWith(log_comment, '-' || currentDatabase())
+  -- The statement above is a `select` over a subquery, not an `explain`, so its kind is `Select`.
+  and query_kind = 'Select'
+  and position(query, 'explain indexes=1') > 0
+  -- This observing statement also contains that literal, so exclude it by the fact that it is the
+  -- only statement here reading `system`.
+  and not has(databases, 'system')
+-- Newest match only, so a rerun in a fixed database cannot add a second line.
+order by event_time_microseconds desc
+limit 1;

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_applies_skip_indexes.reference
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_applies_skip_indexes.reference
@@ -16,7 +16,17 @@ Expression ((Project names + Projection))
         Parts: 20/100
         Granules: 20/100
       Ranges: 20
-explain indexes=1 select * from test_1m where value > 800_000*100 settings distributed_index_analysis=1;
+-- The `Distributed:` block lists one row per replica of test_cluster_one_shard_two_replicas.
+-- 127.0.0.2 is not guaranteed to be up, and when it is down its row degenerates to an empty
+-- `Address:` with zero counters while the local replica absorbs its parts. Assert the
+-- aggregate `Parts:`/`Granules:` instead: under distributed_index_analysis=1 those come from
+-- the ranges the replicas returned, so they still prove the skip index was applied remotely.
+select * from (
+    explain indexes=1 select * from test_1m where value > 800_000*100
+    settings distributed_index_analysis=1
+) where explain not like '%Address:%'
+    and explain not like '%Parts send:%' and explain not like '%Parts received:%'
+    and explain not like '%Granules send:%' and explain not like '%Granules received:%';
 Expression ((Project names + Projection))
   Expression ((WHERE + Change column names to column identifiers))
     ReadFromMergeTree (default.test_1m)
@@ -26,14 +36,4 @@ Expression ((Project names + Projection))
         Parts: 20/100
         Granules: 20/100
         Distributed:
-          Address: 127.0.0.2:9000
-          Parts send: 44
-          Parts received: 12
-          Granules send: 44
-          Granules received: 12
-          Address: 127.0.0.1:9000
-          Parts send: 56
-          Parts received: 8
-          Granules send: 56
-          Granules received: 8
       Ranges: 20

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_applies_skip_indexes.reference
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_applies_skip_indexes.reference
@@ -16,10 +16,10 @@ Expression ((Project names + Projection))
         Parts: 20/100
         Granules: 20/100
       Ranges: 20
--- The `Distributed:` block lists one row per replica of test_cluster_one_shard_two_replicas.
+-- The `Distributed:` block lists one row per replica of `test_cluster_one_shard_two_replicas`.
 -- 127.0.0.2 is not guaranteed to be up, and when it is down its row degenerates to an empty
 -- `Address:` with zero counters while the local replica absorbs its parts. Assert the
--- aggregate `Parts:`/`Granules:` instead: under distributed_index_analysis=1 those come from
+-- aggregate `Parts:`/`Granules:` instead: under `distributed_index_analysis=1` those come from
 -- the ranges the replicas returned, so they still prove the skip index was applied remotely.
 select * from (
     explain indexes=1 select * from test_1m where value > 800_000*100
@@ -37,3 +37,4 @@ Expression ((Project names + Projection))
         Granules: 20/100
         Distributed:
       Ranges: 20
+DistributedIndexAnalysisMicroseconds>0=1, DistributedIndexAnalysisReplicaFallback=0, DistributedIndexAnalysisMissingParts=0

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_applies_skip_indexes.sql
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_applies_skip_indexes.sql
@@ -20,15 +20,15 @@ set allow_experimental_parallel_reading_from_replicas=0;
 set allow_experimental_analyzer=1;
 set query_plan_optimize_prewhere=1;
 set optimize_move_to_prewhere=1;
--- Ignore "Cannot connect to {}. It will not participate in distributed index analysis"
+-- Ignore `Cannot connect to {}. It will not participate in distributed index analysis`
 set send_logs_level='error';
 
 -- { echo }
 explain indexes=1 select * from test_1m where value > 800_000*100 settings distributed_index_analysis=0;
--- The `Distributed:` block lists one row per replica of test_cluster_one_shard_two_replicas.
+-- The `Distributed:` block lists one row per replica of `test_cluster_one_shard_two_replicas`.
 -- 127.0.0.2 is not guaranteed to be up, and when it is down its row degenerates to an empty
 -- `Address:` with zero counters while the local replica absorbs its parts. Assert the
--- aggregate `Parts:`/`Granules:` instead: under distributed_index_analysis=1 those come from
+-- aggregate `Parts:`/`Granules:` instead: under `distributed_index_analysis=1` those come from
 -- the ranges the replicas returned, so they still prove the skip index was applied remotely.
 select * from (
     explain indexes=1 select * from test_1m where value > 800_000*100
@@ -36,3 +36,35 @@ select * from (
 ) where explain not like '%Address:%'
     and explain not like '%Parts send:%' and explain not like '%Parts received:%'
     and explain not like '%Granules send:%' and explain not like '%Granules received:%';
+
+-- { echoOff }
+-- The filtered plan above no longer names the replica that answered, so assert separately that the
+-- remote replica analyzed its own parts rather than silently falling back to the initiator. Both
+-- `DistributedIndexAnalysisReplicaFallback` and `DistributedIndexAnalysisMissingParts` are
+-- incremented only once a replica has connected and its analysis then failed, so they read 0
+-- whether or not 127.0.0.2 is up. `DistributedIndexAnalysisScheduledReplicas` and
+-- `DistributedIndexAnalysisReplicaUnavailable` are deliberately not asserted: they depend on
+-- replica availability and would reintroduce the flakiness this test avoids.
+system flush logs query_log;
+select format(
+  'DistributedIndexAnalysisMicroseconds>0={}, DistributedIndexAnalysisReplicaFallback={}, DistributedIndexAnalysisMissingParts={}',
+  ProfileEvents['DistributedIndexAnalysisMicroseconds'] > 0,
+  ProfileEvents['DistributedIndexAnalysisReplicaFallback'],
+  ProfileEvents['DistributedIndexAnalysisMissingParts']
+)
+from system.query_log
+where
+  current_database = currentDatabase()
+  and event_date >= yesterday() and event_time >= now() - 600
+  and type = 'QueryFinish'
+  and is_initial_query
+  and endsWith(log_comment, '-' || currentDatabase())
+  -- The statement above is a `select` over a subquery, not an `explain`, so its kind is `Select`.
+  and query_kind = 'Select'
+  and position(query, 'explain indexes=1') > 0
+  -- This observing statement also contains that literal, so exclude it by the fact that it is the
+  -- only statement here reading `system`.
+  and not has(databases, 'system')
+-- Newest match only, so a rerun in a fixed database cannot add a second line.
+order by event_time_microseconds desc
+limit 1;

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_applies_skip_indexes.sql
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_applies_skip_indexes.sql
@@ -20,7 +20,19 @@ set allow_experimental_parallel_reading_from_replicas=0;
 set allow_experimental_analyzer=1;
 set query_plan_optimize_prewhere=1;
 set optimize_move_to_prewhere=1;
+-- Ignore "Cannot connect to {}. It will not participate in distributed index analysis"
+set send_logs_level='error';
 
 -- { echo }
 explain indexes=1 select * from test_1m where value > 800_000*100 settings distributed_index_analysis=0;
-explain indexes=1 select * from test_1m where value > 800_000*100 settings distributed_index_analysis=1;
+-- The `Distributed:` block lists one row per replica of test_cluster_one_shard_two_replicas.
+-- 127.0.0.2 is not guaranteed to be up, and when it is down its row degenerates to an empty
+-- `Address:` with zero counters while the local replica absorbs its parts. Assert the
+-- aggregate `Parts:`/`Granules:` instead: under distributed_index_analysis=1 those come from
+-- the ranges the replicas returned, so they still prove the skip index was applied remotely.
+select * from (
+    explain indexes=1 select * from test_1m where value > 800_000*100
+    settings distributed_index_analysis=1
+) where explain not like '%Address:%'
+    and explain not like '%Parts send:%' and explain not like '%Parts received:%'
+    and explain not like '%Granules send:%' and explain not like '%Granules received:%';


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/111492
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`03622_distributed_index_analysis_applies_skip_indexes` and
`03622_distributed_index_analysis_additional_table_filters` both fail whenever `127.0.0.2:9000`,
the second replica of `test_cluster_one_shard_two_replicas`, is unreachable.

The server warns that the replica dropped out at `LogsLevel::warning`, the stateless runner ships
`--send_logs_level=warning` for every `.sql` test, and any non-empty stderr fails the test.
Separately, `DistributedIndexAnalyzer::run` fills the result address only for replicas that
connected, so the dead replica's entry keeps an empty address with zero counters while the local
replica absorbs its parts. Both tests pin the healthy two-replica split, so they also fail on
stdout.

The empty-address entry is correct behaviour and is already a pinned expectation elsewhere in this
family, so this change is test-only.

Each test now sets `send_logs_level='error'` (as most tests in the family already do) and
asserts the plan through
`select * from (explain indexes=1 ...) where explain not like '%Address:%' and ...`, which drops
only the per-replica rows, leaving the aggregate `Parts:`/`Granules:` on the `PrimaryKey` entry.
Because the plan no longer names the replica that answered, each test also asserts from
`system.query_log` that
`DistributedIndexAnalysisReplicaFallback` and `DistributedIndexAnalysisMissingParts` are zero. Both
are incremented only after a replica connects, so they are unaffected by its availability and still
fail if the remote analysis silently falls back to the initiator.

Validated by binding a server to `127.0.0.1` only so the second replica genuinely refuses: both
tests fail before the change and pass after it, in that arm and with both replicas up. Mutations
redden them, including forcing distributed index analysis off and forcing the remote analysis to
throw while the replica is up, so no assertion became a tautology. 50 randomized runs per test per
arm pass, and a 22-test sweep over the family shows no regressions.

Four more tests carry half of the same latent exposure; they are tracked separately.

Related: https://github.com/ClickHouse/ClickHouse/pull/111492