### PR TITLE
Automatically size initial `GraceHashJoin` buckets

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -429,6 +429,7 @@
     M(JoinNonJoinedTransformRowCount, "Number of non-joined rows emitted by NonJoinedBlocksTransform.", ValueType::Number) \
     M(JoinDelayedJoinedTransformBlockCount, "Number of blocks emitted by DelayedJoinedBlocksWorkerTransform.", ValueType::Number) \
     M(JoinDelayedJoinedTransformRowCount, "Number of rows emitted by DelayedJoinedBlocksWorkerTransform.", ValueType::Number) \
+    M(JoinGraceHashJoinInitialBuckets, "Total number of buckets created when initializing `GraceHashJoin`.", ValueType::Number) \
     M(JoinSpillingHashJoinSwitchedToGraceJoin, "Number of times a (Concurrent)HashJoin was switched to GraceHashJoin due to memory limit in SpillingHashJoin.", ValueType::Number) \
     M(JoinReorderMicroseconds, "Total time spent executing JOIN reordering algorithm.", ValueType::Microseconds) \
     M(JoinOptimizeMicroseconds, "Total time spent executing JOIN plan optimizations.", ValueType::Microseconds) \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8321,7 +8321,7 @@ Wait for committed changes to become actually visible in the latest snapshot
 If enabled and not already inside a transaction, wraps the query inside a full transaction (begin + commit or rollback)
 )", EXPERIMENTAL) \
     DECLARE(UInt64, grace_hash_join_initial_buckets, 0, R"(
-Initial number of grace hash join buckets. If set to `0`, ClickHouse chooses the number automatically based on the estimated or actual size of the right table. The effective value is always a power of two. ClickHouse rounds a positive value up when possible; otherwise it uses the largest power of two that does not exceed `grace_hash_join_max_buckets`.
+Initial number of grace hash join buckets. If set to `0`, a standalone `grace_hash` join chooses the number based on the planner's right-table row estimate and `max_rows_in_join`. `SpillingHashJoin` also combines the observed row width with the external JOIN threshold. A standalone join configured only with `max_bytes_in_join` relies on runtime bucket expansion. The effective value is always a power of two. ClickHouse rounds a positive value up when possible; otherwise it uses the largest power of two that does not exceed `grace_hash_join_max_buckets`.
 )", EXPERIMENTAL) \
     DECLARE(NonZeroUInt64, grace_hash_join_max_buckets, 1024, R"(
 Limit on the number of grace hash join buckets

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8321,7 +8321,7 @@ Wait for committed changes to become actually visible in the latest snapshot
 If enabled and not already inside a transaction, wraps the query inside a full transaction (begin + commit or rollback)
 )", EXPERIMENTAL) \
     DECLARE(UInt64, grace_hash_join_initial_buckets, 0, R"(
-Initial number of grace hash join buckets. If set to `0`, ClickHouse chooses the number automatically based on the estimated or actual size of the right table. Positive values preserve the explicitly configured number of initial buckets.
+Initial number of grace hash join buckets. If set to `0`, ClickHouse chooses the number automatically based on the estimated or actual size of the right table. The effective value is always a power of two. ClickHouse rounds a positive value up when possible; otherwise it uses the largest power of two that does not exceed `grace_hash_join_max_buckets`.
 )", EXPERIMENTAL) \
     DECLARE(NonZeroUInt64, grace_hash_join_max_buckets, 1024, R"(
 Limit on the number of grace hash join buckets

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8320,8 +8320,8 @@ Wait for committed changes to become actually visible in the latest snapshot
     DECLARE(Bool, implicit_transaction, false, R"(
 If enabled and not already inside a transaction, wraps the query inside a full transaction (begin + commit or rollback)
 )", EXPERIMENTAL) \
-    DECLARE(NonZeroUInt64, grace_hash_join_initial_buckets, 1, R"(
-Initial number of grace hash join buckets
+    DECLARE(UInt64, grace_hash_join_initial_buckets, 0, R"(
+Initial number of grace hash join buckets. If set to `0`, ClickHouse chooses the number automatically based on the estimated or actual size of the right table. Positive values preserve the explicitly configured number of initial buckets.
 )", EXPERIMENTAL) \
     DECLARE(NonZeroUInt64, grace_hash_join_max_buckets, 1024, R"(
 Limit on the number of grace hash join buckets

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -43,6 +43,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// Note: please check if the key already exists to prevent duplicate entries.
         addSettingsChanges(settings_changes_history, "26.8",
         {
+            {"grace_hash_join_initial_buckets", 1, 0, "Changed the default from one bucket to automatic sizing. Set to `1` to restore the previous behavior."},
             {"max_insert_threads", 1, 0, "Changed the default from 1 (no parallel execution) to auto (0), which resolves to the number of CPU cores available to the server, reduced under memory pressure via `max_insert_threads_min_free_memory_per_thread`. This parallelizes `INSERT SELECT` by default. Set to 1 to restore the previous single-threaded behavior."},
             {"unique_key_probe_implementation", "auto", "auto", "New setting: selects the UNIQUE KEY probe implementation (currently only the simple baseline exists)"},
             {"use_projection_index_in_read_pools", false, false, "New setting to drop mark ranges fully filtered out by a projection index before read tasks are created in MergeTree read pools."},

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -65,6 +65,7 @@
 #include <Parsers/QueryParameterVisitor.h>
 #include <Processors/QueryPlan/AggregatingStep.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
+#include <Processors/QueryPlan/Optimizations/Optimizations.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <QueryPipeline/SizeLimits.h>
 #include <Storages/StorageDictionary.h>
@@ -1029,6 +1030,13 @@ static std::shared_ptr<IJoin> tryCreateJoin(
         || (!isCrossOrComma(analyzed_join->kind()) && analyzed_join->getClauses().empty() && analyzed_join->strictness() != JoinStrictness::Asof))
         return std::make_shared<ConstantJoin>(analyzed_join, right_sample_block);
 
+    const auto get_rhs_size_estimation = [&]() -> std::optional<size_t>
+    {
+        if (!joined_plan || !joined_plan->isInitialized())
+            return std::nullopt;
+        return QueryPlanOptimizations::estimateReadRowsCountForJoin(*joined_plan->getRootNode());
+    };
+
     if (algorithm == JoinAlgorithm::PARTIAL_MERGE ||
         algorithm == JoinAlgorithm::PREFER_PARTIAL_MERGE)
     {
@@ -1050,6 +1058,7 @@ static std::shared_ptr<IJoin> tryCreateJoin(
             Block left_sample_block(left_sample_columns);
             if (sanitizeBlock(left_sample_block, false))
             {
+                const auto rhs_size_estimation = get_rhs_size_estimation();
                 if (analyzed_join->allowParallelHashJoin())
                     return std::make_shared<SpillingHashJoin>(
                         analyzed_join,
@@ -1059,7 +1068,9 @@ static std::shared_ptr<IJoin> tryCreateJoin(
                         settings[Setting::grace_hash_join_initial_buckets],
                         settings[Setting::grace_hash_join_max_buckets],
                         settings[Setting::max_threads],
-                        StatsCollectingParams{});
+                        StatsCollectingParams{},
+                        /*any_take_last_row_=*/false,
+                        rhs_size_estimation);
                 else
                     return std::make_shared<SpillingHashJoin>(
                         analyzed_join,
@@ -1067,7 +1078,10 @@ static std::shared_ptr<IJoin> tryCreateJoin(
                         right_sample_block,
                         context->getTempDataOnDisk(),
                         settings[Setting::grace_hash_join_initial_buckets],
-                        settings[Setting::grace_hash_join_max_buckets]);
+                        settings[Setting::grace_hash_join_max_buckets],
+                        StatsCollectingParams{},
+                        /*any_take_last_row_=*/false,
+                        rhs_size_estimation);
             }
         }
 
@@ -1093,10 +1107,19 @@ static std::shared_ptr<IJoin> tryCreateJoin(
         // Grace hash join requires that columns exist in left_sample_block.
         Block left_sample_block(left_sample_columns);
         if (sanitizeBlock(left_sample_block, false) && GraceHashJoin::isSupported(analyzed_join))
+        {
+            const auto rhs_size_estimation = get_rhs_size_estimation();
             return std::make_shared<GraceHashJoin>(
                 context->getSettingsRef()[Setting::grace_hash_join_initial_buckets],
                 context->getSettingsRef()[Setting::grace_hash_join_max_buckets],
-                analyzed_join, std::make_shared<const Block>(std::move(left_sample_block)), right_sample_block, context->getTempDataOnDisk());
+                analyzed_join,
+                std::make_shared<const Block>(std::move(left_sample_block)),
+                right_sample_block,
+                context->getTempDataOnDisk(),
+                /*any_take_last_row_=*/false,
+                /*external_join_threshold_=*/0,
+                GraceHashJoin::InitialBucketsParams{.total_rows_estimation = rhs_size_estimation});
+        }
     }
 
     if (algorithm == JoinAlgorithm::AUTO)
@@ -1109,6 +1132,7 @@ static std::shared_ptr<IJoin> tryCreateJoin(
             Block left_sample_block(left_sample_columns);
             if (sanitizeBlock(left_sample_block, false))
             {
+                const auto rhs_size_estimation = get_rhs_size_estimation();
                 if (analyzed_join->allowParallelHashJoin())
                     return std::make_shared<SpillingHashJoin>(
                         analyzed_join,
@@ -1118,7 +1142,9 @@ static std::shared_ptr<IJoin> tryCreateJoin(
                         settings[Setting::grace_hash_join_initial_buckets],
                         settings[Setting::grace_hash_join_max_buckets],
                         settings[Setting::max_threads],
-                        StatsCollectingParams{});
+                        StatsCollectingParams{},
+                        /*any_take_last_row_=*/false,
+                        rhs_size_estimation);
                 else
                     return std::make_shared<SpillingHashJoin>(
                         analyzed_join,
@@ -1126,7 +1152,10 @@ static std::shared_ptr<IJoin> tryCreateJoin(
                         right_sample_block,
                         context->getTempDataOnDisk(),
                         settings[Setting::grace_hash_join_initial_buckets],
-                        settings[Setting::grace_hash_join_max_buckets]);
+                        settings[Setting::grace_hash_join_max_buckets],
+                        StatsCollectingParams{},
+                        /*any_take_last_row_=*/false,
+                        rhs_size_estimation);
             }
         }
 

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -101,7 +101,7 @@ namespace Setting
     extern const SettingsUInt64 use_index_for_in_with_subqueries_max_values;
     extern const SettingsBool allow_suspicious_types_in_group_by;
     extern const SettingsBool allow_suspicious_types_in_order_by;
-    extern const SettingsNonZeroUInt64 grace_hash_join_initial_buckets;
+    extern const SettingsUInt64 grace_hash_join_initial_buckets;
     extern const SettingsNonZeroUInt64 grace_hash_join_max_buckets;
 }
 

--- a/src/Interpreters/GraceHashJoin.cpp
+++ b/src/Interpreters/GraceHashJoin.cpp
@@ -285,7 +285,7 @@ GraceHashJoin::GraceHashJoin(
             .num_files = ProfileEvents::ExternalJoinWritePart,
         },
         initial_num_buckets_ == 0
-            ? getTemporaryFilesBufferSize(table_join->temporaryFilesBufferSize(), initial_num_buckets, external_join_threshold_)
+            ? getTemporaryFilesBufferSize(table_join->temporaryFilesBufferSize(), max_num_buckets, external_join_threshold_)
             : table_join->temporaryFilesBufferSize(),
         table_join->temporaryFilesCodec()))
     , hash_join(makeInMemoryJoin("grace0"))
@@ -372,19 +372,21 @@ size_t GraceHashJoin::getInitialNumBuckets(
 
 size_t GraceHashJoin::getTemporaryFilesBufferSize(
     size_t configured_buffer_size,
-    size_t initial_num_buckets,
+    size_t max_num_buckets,
     size_t max_bytes_before_external_join)
 {
     chassert(configured_buffer_size > 0);
-    chassert(initial_num_buckets > 0);
-
-    if (max_bytes_before_external_join == 0)
-        return configured_buffer_size;
+    chassert(max_num_buckets > 0);
 
     /// Every bucket owns two temporary streams. Each stream has an uncompressed buffer and
-    /// a compressed buffer, so reserve at most half of the external JOIN threshold for all
-    /// four buffers. Divide one factor at a time to avoid overflowing on a large bucket count.
-    size_t buffer_size = max_bytes_before_external_join / initial_num_buckets / 4 / 2;
+    /// a compressed buffer. Standalone automatic `GraceHashJoin` has no external JOIN threshold,
+    /// so divide the configured buffer size by the maximum bucket count to target an aggregate
+    /// allocation of four configured buffers even after rehashing. For spilling joins, target half
+    /// of the external JOIN threshold for all four buffers. The result is clamped to at least one
+    /// byte, and factors are divided one at a time to avoid overflow.
+    size_t buffer_size = max_bytes_before_external_join == 0
+        ? configured_buffer_size / max_num_buckets
+        : max_bytes_before_external_join / max_num_buckets / 4 / 2;
     return std::clamp(buffer_size, 1uz, configured_buffer_size);
 }
 

--- a/src/Interpreters/GraceHashJoin.cpp
+++ b/src/Interpreters/GraceHashJoin.cpp
@@ -276,18 +276,10 @@ GraceHashJoin::GraceHashJoin(
           external_join_threshold_))
     , max_num_buckets(max_num_buckets_)
     , external_join_threshold(external_join_threshold_)
+    , automatic_num_buckets(initial_num_buckets_ == 0)
     , left_key_names(table_join->getOnlyClause().key_names_left)
     , right_key_names(table_join->getOnlyClause().key_names_right)
-    , tmp_data(tmp_data_->childScope({
-            .current_metric = CurrentMetrics::TemporaryFilesForJoin,
-            .bytes_compressed = ProfileEvents::ExternalJoinCompressedBytes,
-            .bytes_uncompressed = ProfileEvents::ExternalJoinUncompressedBytes,
-            .num_files = ProfileEvents::ExternalJoinWritePart,
-        },
-        initial_num_buckets_ == 0
-            ? getTemporaryFilesBufferSize(table_join->temporaryFilesBufferSize(), max_num_buckets, external_join_threshold_)
-            : table_join->temporaryFilesBufferSize(),
-        table_join->temporaryFilesCodec()))
+    , tmp_data(std::move(tmp_data_))
     , hash_join(makeInMemoryJoin("grace0"))
     , hash_join_sample_block(hash_join->savedBlockSample())
 {
@@ -372,20 +364,22 @@ size_t GraceHashJoin::getInitialNumBuckets(
 
 size_t GraceHashJoin::getTemporaryFilesBufferSize(
     size_t configured_buffer_size,
+    size_t num_buckets,
     size_t max_num_buckets,
     size_t max_bytes_before_external_join)
 {
     chassert(configured_buffer_size > 0);
+    chassert(num_buckets > 0);
     chassert(max_num_buckets > 0);
+    chassert(num_buckets <= max_num_buckets);
 
     /// Every bucket owns two temporary streams. Each stream has an uncompressed buffer and
     /// a compressed buffer. Standalone automatic `GraceHashJoin` has no external JOIN threshold,
-    /// so divide the configured buffer size by the maximum bucket count to target an aggregate
-    /// allocation of four configured buffers even after rehashing. For spilling joins, target half
-    /// of the external JOIN threshold for all four buffers. The result is clamped to at least one
-    /// byte, and factors are divided one at a time to avoid overflow.
+    /// so divide the configured buffer size by the current bucket count. For spilling joins, target
+    /// half of the external JOIN threshold for all four buffers at the maximum bucket count. The
+    /// result is clamped to at least one byte, and factors are divided one at a time to avoid overflow.
     size_t buffer_size = max_bytes_before_external_join == 0
-        ? configured_buffer_size / max_num_buckets
+        ? configured_buffer_size / num_buckets
         : max_bytes_before_external_join / max_num_buckets / 4 / 2;
     return std::clamp(buffer_size, 1uz, configured_buffer_size);
 }
@@ -497,13 +491,31 @@ void GraceHashJoin::addBuckets(const size_t bucket_count)
     // otherwise we can end up having unexpected number of buckets
 
     const size_t current_size = buckets.size();
+    chassert(bucket_count > 0);
+    chassert(bucket_count <= max_num_buckets);
+    chassert(current_size <= max_num_buckets - bucket_count);
+
+    const size_t num_buckets = current_size + bucket_count;
+    const size_t buffer_size = automatic_num_buckets
+        ? getTemporaryFilesBufferSize(
+            table_join->temporaryFilesBufferSize(), num_buckets, max_num_buckets, external_join_threshold)
+        : table_join->temporaryFilesBufferSize();
+    auto batch_tmp_data = tmp_data->childScope({
+            .current_metric = CurrentMetrics::TemporaryFilesForJoin,
+            .bytes_compressed = ProfileEvents::ExternalJoinCompressedBytes,
+            .bytes_uncompressed = ProfileEvents::ExternalJoinUncompressedBytes,
+            .num_files = ProfileEvents::ExternalJoinWritePart,
+        },
+        buffer_size,
+        table_join->temporaryFilesCodec());
+
     Buckets tmp_buckets;
     tmp_buckets.reserve(bucket_count);
     for (size_t i = 0; i < bucket_count; ++i)
         try
         {
-            TemporaryBlockStreamHolder left_file(left_sample_block, tmp_data);
-            TemporaryBlockStreamHolder right_file(std::make_shared<const Block>(prepareRightBlock(*right_sample_block)), tmp_data);
+            TemporaryBlockStreamHolder left_file(left_sample_block, batch_tmp_data);
+            TemporaryBlockStreamHolder right_file(std::make_shared<const Block>(prepareRightBlock(*right_sample_block)), batch_tmp_data);
 
             BucketPtr new_bucket = std::make_shared<FileBucket>(current_size + i, std::move(left_file), std::move(right_file), log);
             tmp_buckets.emplace_back(std::move(new_bucket));

--- a/src/Interpreters/GraceHashJoin.cpp
+++ b/src/Interpreters/GraceHashJoin.cpp
@@ -355,7 +355,7 @@ size_t GraceHashJoin::getInitialNumBuckets(
     }
 
     const size_t rounded_num_buckets = roundUpToPowerOfTwoOrZero(std::clamp(initial_num_buckets, 1uz, max_num_buckets));
-    if (rounded_num_buckets <= max_num_buckets)
+    if (isPowerOf2(rounded_num_buckets) && rounded_num_buckets <= max_num_buckets)
         return rounded_num_buckets;
 
     /// The maximum may not be a power of two. Keep the result both valid and within the limit.

--- a/src/Interpreters/GraceHashJoin.cpp
+++ b/src/Interpreters/GraceHashJoin.cpp
@@ -1,21 +1,22 @@
 #include <Compression/CompressedWriteBuffer.h>
+#include <Core/Settings.h>
 #include <Formats/NativeWriter.h>
 #include <Formats/formatBlock.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/GraceHashJoin.h>
 #include <Interpreters/HashJoin/HashJoin.h>
+#include <Interpreters/IJoin.h>
 #include <Interpreters/TableJoin.h>
 #include <Interpreters/TemporaryDataOnDisk.h>
 #include <base/FnTraits.h>
+#include <Common/BitHelpers.h>
 #include <Common/SharedMutex.h>
 #include <Common/formatReadable.h>
 #include <Common/logger_useful.h>
 #include <Common/thread_local_rng.h>
-#include <Interpreters/IJoin.h>
-#include <Core/Settings.h>
 
-#include <numeric>
 #include <fmt/format.h>
+#include <numeric>
 
 
 namespace CurrentMetrics
@@ -28,6 +29,7 @@ namespace ProfileEvents
     extern const Event ExternalJoinCompressedBytes;
     extern const Event ExternalJoinUncompressedBytes;
     extern const Event ExternalJoinWritePart;
+    extern const Event JoinGraceHashJoinInitialBuckets;
 }
 
 namespace DB
@@ -286,10 +288,10 @@ void GraceHashJoin::initBuckets()
     if (!buckets.empty())
         return;
 
-    size_t initial_rounded_num_buckets = roundUpToPowerOfTwoOrZero(
-        std::clamp<size_t>(initial_num_buckets, 1, max_num_buckets));
+    size_t initial_rounded_num_buckets = getInitialNumBuckets(initial_num_buckets, max_num_buckets);
 
     addBuckets(initial_rounded_num_buckets);
+    ProfileEvents::increment(ProfileEvents::JoinGraceHashJoinInitialBuckets, initial_rounded_num_buckets);
 
     if (buckets.empty())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "No buckets created");
@@ -298,6 +300,36 @@ void GraceHashJoin::initBuckets()
 
     current_bucket = buckets.front().get();
     current_bucket->startJoining();
+}
+
+size_t GraceHashJoin::getInitialNumBuckets(
+    size_t configured_num_buckets,
+    size_t max_num_buckets,
+    std::optional<size_t> total_size_estimation,
+    size_t max_bucket_size)
+{
+    chassert(max_num_buckets > 0);
+
+    size_t initial_num_buckets = configured_num_buckets;
+    if (initial_num_buckets == 0)
+    {
+        initial_num_buckets = 1;
+        if (total_size_estimation && max_bucket_size > 0)
+        {
+            /// `SizeLimits::softCheck` treats equality as an overflow. Add one bucket after
+            /// integer division so the estimated size of every evenly distributed bucket is
+            /// strictly below the limit. Saturate before adding to avoid overflow.
+            const size_t full_buckets = *total_size_estimation / max_bucket_size;
+            initial_num_buckets = full_buckets >= max_num_buckets ? max_num_buckets : full_buckets + 1;
+        }
+    }
+
+    const size_t rounded_num_buckets = roundUpToPowerOfTwoOrZero(std::clamp(initial_num_buckets, 1uz, max_num_buckets));
+    if (rounded_num_buckets <= max_num_buckets)
+        return rounded_num_buckets;
+
+    /// The maximum may not be a power of two. Keep the result both valid and within the limit.
+    return 1uz << bitScanReverse(max_num_buckets);
 }
 
 bool GraceHashJoin::isSupported(const std::shared_ptr<TableJoin> & table_join)

--- a/src/Interpreters/GraceHashJoin.cpp
+++ b/src/Interpreters/GraceHashJoin.cpp
@@ -283,7 +283,11 @@ GraceHashJoin::GraceHashJoin(
             .bytes_compressed = ProfileEvents::ExternalJoinCompressedBytes,
             .bytes_uncompressed = ProfileEvents::ExternalJoinUncompressedBytes,
             .num_files = ProfileEvents::ExternalJoinWritePart,
-        }, table_join->temporaryFilesBufferSize(), table_join->temporaryFilesCodec()))
+        },
+        initial_num_buckets_ == 0
+            ? getTemporaryFilesBufferSize(table_join->temporaryFilesBufferSize(), initial_num_buckets, external_join_threshold_)
+            : table_join->temporaryFilesBufferSize(),
+        table_join->temporaryFilesCodec()))
     , hash_join(makeInMemoryJoin("grace0"))
     , hash_join_sample_block(hash_join->savedBlockSample())
 {
@@ -364,6 +368,24 @@ size_t GraceHashJoin::getInitialNumBuckets(
 
     /// The maximum may not be a power of two. Keep the result both valid and within the limit.
     return 1uz << bitScanReverse(max_num_buckets);
+}
+
+size_t GraceHashJoin::getTemporaryFilesBufferSize(
+    size_t configured_buffer_size,
+    size_t initial_num_buckets,
+    size_t max_bytes_before_external_join)
+{
+    chassert(configured_buffer_size > 0);
+    chassert(initial_num_buckets > 0);
+
+    if (max_bytes_before_external_join == 0)
+        return configured_buffer_size;
+
+    /// Every bucket owns two temporary streams. Each stream has an uncompressed buffer and
+    /// a compressed buffer, so reserve at most half of the external JOIN threshold for all
+    /// four buffers. Divide one factor at a time to avoid overflowing on a large bucket count.
+    size_t buffer_size = max_bytes_before_external_join / initial_num_buckets / 4 / 2;
+    return std::clamp(buffer_size, 1uz, configured_buffer_size);
 }
 
 bool GraceHashJoin::isSupported(const std::shared_ptr<TableJoin> & table_join)

--- a/src/Interpreters/GraceHashJoin.cpp
+++ b/src/Interpreters/GraceHashJoin.cpp
@@ -16,6 +16,8 @@
 #include <Common/thread_local_rng.h>
 
 #include <fmt/format.h>
+#include <algorithm>
+#include <limits>
 #include <numeric>
 
 
@@ -259,13 +261,19 @@ GraceHashJoin::GraceHashJoin(
     SharedHeader right_sample_block_,
     TemporaryDataOnDiskScopePtr tmp_data_,
     bool any_take_last_row_,
-    size_t external_join_threshold_)
+    size_t external_join_threshold_,
+    const InitialBucketsParams & initial_buckets_params_)
     : log{getLogger("GraceHashJoin")}
     , table_join{std::move(table_join_)}
     , left_sample_block{left_sample_block_}
     , right_sample_block{right_sample_block_}
     , any_take_last_row{any_take_last_row_}
-    , initial_num_buckets(initial_num_buckets_)
+    , initial_num_buckets(getInitialNumBuckets(
+          initial_num_buckets_,
+          max_num_buckets_,
+          initial_buckets_params_,
+          table_join->sizeLimits().max_rows,
+          external_join_threshold_))
     , max_num_buckets(max_num_buckets_)
     , external_join_threshold(external_join_threshold_)
     , left_key_names(table_join->getOnlyClause().key_names_left)
@@ -288,10 +296,8 @@ void GraceHashJoin::initBuckets()
     if (!buckets.empty())
         return;
 
-    size_t initial_rounded_num_buckets = getInitialNumBuckets(initial_num_buckets, max_num_buckets);
-
-    addBuckets(initial_rounded_num_buckets);
-    ProfileEvents::increment(ProfileEvents::JoinGraceHashJoinInitialBuckets, initial_rounded_num_buckets);
+    addBuckets(initial_num_buckets);
+    ProfileEvents::increment(ProfileEvents::JoinGraceHashJoinInitialBuckets, initial_num_buckets);
 
     if (buckets.empty())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "No buckets created");
@@ -305,8 +311,9 @@ void GraceHashJoin::initBuckets()
 size_t GraceHashJoin::getInitialNumBuckets(
     size_t configured_num_buckets,
     size_t max_num_buckets,
-    std::optional<size_t> total_size_estimation,
-    size_t max_bucket_size)
+    const InitialBucketsParams & initial_buckets_params,
+    size_t max_rows,
+    size_t max_bytes_before_external_join)
 {
     chassert(max_num_buckets > 0);
 
@@ -314,13 +321,42 @@ size_t GraceHashJoin::getInitialNumBuckets(
     if (initial_num_buckets == 0)
     {
         initial_num_buckets = 1;
-        if (total_size_estimation && max_bucket_size > 0)
+
+        const auto get_num_buckets_for_size = [max_num_buckets](size_t total_size, size_t max_bucket_size)
         {
+            if (max_bucket_size == 0)
+                return 1uz;
+
             /// `SizeLimits::softCheck` treats equality as an overflow. Add one bucket after
             /// integer division so the estimated size of every evenly distributed bucket is
             /// strictly below the limit. Saturate before adding to avoid overflow.
-            const size_t full_buckets = *total_size_estimation / max_bucket_size;
-            initial_num_buckets = full_buckets >= max_num_buckets ? max_num_buckets : full_buckets + 1;
+            const size_t full_buckets = total_size / max_bucket_size;
+            return full_buckets >= max_num_buckets ? max_num_buckets : full_buckets + 1;
+        };
+
+        const size_t estimated_total_rows
+            = std::max(initial_buckets_params.current_rows, initial_buckets_params.total_rows_estimation.value_or(0));
+        initial_num_buckets = get_num_buckets_for_size(estimated_total_rows, max_rows);
+
+        if (max_bytes_before_external_join > 0)
+        {
+            size_t estimated_total_bytes = initial_buckets_params.current_bytes;
+            if (initial_buckets_params.current_rows > 0 && estimated_total_rows > initial_buckets_params.current_rows)
+            {
+                const UInt128 numerator = static_cast<UInt128>(initial_buckets_params.current_bytes) * estimated_total_rows;
+                const UInt128 estimate
+                    = numerator / initial_buckets_params.current_rows + (numerator % initial_buckets_params.current_rows != 0);
+                estimated_total_bytes = static_cast<size_t>(
+                    std::min<UInt128>(estimate, std::numeric_limits<size_t>::max()));
+            }
+
+            /// `GraceHashJoin` spills when twice the in-memory bucket size reaches the external
+            /// join threshold. Express the same boundary without multiplication to avoid overflow.
+            const size_t max_bucket_bytes
+                = max_bytes_before_external_join / 2 + max_bytes_before_external_join % 2;
+            initial_num_buckets = std::max(
+                initial_num_buckets,
+                get_num_buckets_for_size(estimated_total_bytes, max_bucket_bytes));
         }
     }
 

--- a/src/Interpreters/GraceHashJoin.cpp
+++ b/src/Interpreters/GraceHashJoin.cpp
@@ -320,8 +320,6 @@ size_t GraceHashJoin::getInitialNumBuckets(
     size_t initial_num_buckets = configured_num_buckets;
     if (initial_num_buckets == 0)
     {
-        initial_num_buckets = 1;
-
         const auto get_num_buckets_for_size = [max_num_buckets](size_t total_size, size_t max_bucket_size)
         {
             if (max_bucket_size == 0)

--- a/src/Interpreters/GraceHashJoin.h
+++ b/src/Interpreters/GraceHashJoin.h
@@ -121,7 +121,7 @@ public:
 
     static size_t getTemporaryFilesBufferSize(
         size_t configured_buffer_size,
-        size_t initial_num_buckets,
+        size_t max_num_buckets,
         size_t max_bytes_before_external_join);
 
     void forceSpill() { force_spill = true; }

--- a/src/Interpreters/GraceHashJoin.h
+++ b/src/Interpreters/GraceHashJoin.h
@@ -121,6 +121,7 @@ public:
 
     static size_t getTemporaryFilesBufferSize(
         size_t configured_buffer_size,
+        size_t num_buckets,
         size_t max_num_buckets,
         size_t max_bytes_before_external_join);
 
@@ -168,6 +169,7 @@ private:
     const size_t initial_num_buckets;
     const size_t max_num_buckets;
     const size_t external_join_threshold;
+    const bool automatic_num_buckets;
 
     Names left_key_names;
     Names right_key_names;

--- a/src/Interpreters/GraceHashJoin.h
+++ b/src/Interpreters/GraceHashJoin.h
@@ -119,6 +119,11 @@ public:
         size_t max_rows,
         size_t max_bytes_before_external_join);
 
+    static size_t getTemporaryFilesBufferSize(
+        size_t configured_buffer_size,
+        size_t initial_num_buckets,
+        size_t max_bytes_before_external_join);
+
     void forceSpill() { force_spill = true; }
 
 private:

--- a/src/Interpreters/GraceHashJoin.h
+++ b/src/Interpreters/GraceHashJoin.h
@@ -11,6 +11,7 @@
 #include <Common/SharedMutex.h>
 
 #include <mutex>
+#include <optional>
 
 namespace DB
 {
@@ -99,6 +100,15 @@ public:
     void onBuildPhaseFinish() override;
 
     static bool isSupported(const std::shared_ptr<TableJoin> & table_join);
+
+    /// Resolve the configured initial bucket count. Zero means automatic: when an estimate and
+    /// a per-bucket limit are available, create enough buckets that an evenly distributed bucket
+    /// stays below the limit. Otherwise, start with one bucket.
+    static size_t getInitialNumBuckets(
+        size_t configured_num_buckets,
+        size_t max_num_buckets,
+        std::optional<size_t> total_size_estimation = std::nullopt,
+        size_t max_bucket_size = 0);
 
     void forceSpill() { force_spill = true; }
 

--- a/src/Interpreters/GraceHashJoin.h
+++ b/src/Interpreters/GraceHashJoin.h
@@ -53,6 +53,13 @@ public:
     using BucketPtr = std::shared_ptr<FileBucket>;
     using Buckets = std::vector<BucketPtr>;
 
+    struct InitialBucketsParams
+    {
+        std::optional<size_t> total_rows_estimation;
+        size_t current_rows = 0;
+        size_t current_bytes = 0;
+    };
+
     /// `external_join_threshold_` is the auto-spill memory cap supplied by `SpillingHashJoin`
     /// when this instance is wrapped. It triggers in-bucket rehashing whenever the in-memory
     /// hash table approaches half of the cap, so the configured spill ceiling is honored.
@@ -67,7 +74,8 @@ public:
         SharedHeader left_sample_block_, SharedHeader right_sample_block_,
         TemporaryDataOnDiskScopePtr tmp_data_,
         bool any_take_last_row_ = false,
-        size_t external_join_threshold_ = 0);
+        size_t external_join_threshold_ = 0,
+        const InitialBucketsParams & initial_buckets_params_ = {});
 
     ~GraceHashJoin() override;
 
@@ -101,14 +109,15 @@ public:
 
     static bool isSupported(const std::shared_ptr<TableJoin> & table_join);
 
-    /// Resolve the configured initial bucket count. Zero means automatic: when an estimate and
-    /// a per-bucket limit are available, create enough buckets that an evenly distributed bucket
-    /// stays below the limit. Otherwise, start with one bucket.
+    /// Resolve the configured initial bucket count. Zero means automatic: combine the planner's
+    /// row estimate with the rows and bytes already observed at runtime, then create enough
+    /// buckets that an evenly distributed bucket stays below every available limit.
     static size_t getInitialNumBuckets(
         size_t configured_num_buckets,
         size_t max_num_buckets,
-        std::optional<size_t> total_size_estimation = std::nullopt,
-        size_t max_bucket_size = 0);
+        const InitialBucketsParams & initial_buckets_params,
+        size_t max_rows,
+        size_t max_bytes_before_external_join);
 
     void forceSpill() { force_spill = true; }
 

--- a/src/Interpreters/GraceHashJoin.h
+++ b/src/Interpreters/GraceHashJoin.h
@@ -75,7 +75,7 @@ public:
         TemporaryDataOnDiskScopePtr tmp_data_,
         bool any_take_last_row_ = false,
         size_t external_join_threshold_ = 0,
-        const InitialBucketsParams & initial_buckets_params_ = {});
+        const InitialBucketsParams & initial_buckets_params_ = {std::nullopt, 0, 0});
 
     ~GraceHashJoin() override;
 

--- a/src/Interpreters/JoinOperator.cpp
+++ b/src/Interpreters/JoinOperator.cpp
@@ -92,7 +92,7 @@ namespace QueryPlanSerializationSetting
     extern const QueryPlanSerializationSettingsUInt64 partial_merge_join_rows_in_right_blocks;
     extern const QueryPlanSerializationSettingsUInt64 join_on_disk_max_files_to_merge;
 
-    extern const QueryPlanSerializationSettingsNonZeroUInt64 grace_hash_join_initial_buckets;
+    extern const QueryPlanSerializationSettingsUInt64 grace_hash_join_initial_buckets;
     extern const QueryPlanSerializationSettingsNonZeroUInt64 grace_hash_join_max_buckets;
 
     extern const QueryPlanSerializationSettingsUInt64 max_bytes_before_external_join;

--- a/src/Interpreters/JoinOperator.cpp
+++ b/src/Interpreters/JoinOperator.cpp
@@ -92,7 +92,7 @@ namespace QueryPlanSerializationSetting
     extern const QueryPlanSerializationSettingsUInt64 partial_merge_join_rows_in_right_blocks;
     extern const QueryPlanSerializationSettingsUInt64 join_on_disk_max_files_to_merge;
 
-    extern const QueryPlanSerializationSettingsUInt64 grace_hash_join_initial_buckets;
+    extern const QueryPlanSerializationSettingsNonZeroUInt64 grace_hash_join_initial_buckets;
     extern const QueryPlanSerializationSettingsNonZeroUInt64 grace_hash_join_max_buckets;
 
     extern const QueryPlanSerializationSettingsUInt64 max_bytes_before_external_join;

--- a/src/Interpreters/JoinOperator.cpp
+++ b/src/Interpreters/JoinOperator.cpp
@@ -206,10 +206,7 @@ JoinSettings::JoinSettings(const QueryPlanSerializationSettings & settings)
     partial_merge_join_rows_in_right_blocks = settings[QueryPlanSerializationSetting::partial_merge_join_rows_in_right_blocks];
     join_on_disk_max_files_to_merge = settings[QueryPlanSerializationSetting::join_on_disk_max_files_to_merge];
 
-    grace_hash_join_initial_buckets
-        = settings.isChanged("grace_hash_join_initial_buckets")
-        ? settings[QueryPlanSerializationSetting::grace_hash_join_initial_buckets]
-        : 0;
+    grace_hash_join_initial_buckets = settings[QueryPlanSerializationSetting::grace_hash_join_initial_buckets];
     grace_hash_join_max_buckets = settings[QueryPlanSerializationSetting::grace_hash_join_max_buckets];
 
     max_bytes_before_external_join = settings[QueryPlanSerializationSetting::max_bytes_before_external_join];
@@ -264,6 +261,8 @@ void JoinSettings::updatePlanSettings(QueryPlanSerializationSettings & settings)
     settings[QueryPlanSerializationSetting::partial_merge_join_rows_in_right_blocks] = partial_merge_join_rows_in_right_blocks;
     settings[QueryPlanSerializationSetting::join_on_disk_max_files_to_merge] = join_on_disk_max_files_to_merge;
 
+    /// `JoinStepLogical` carries automatic mode in its reserved flags byte. Keep zero out of
+    /// the settings payload so old readers retain their valid legacy default of one bucket.
     if (grace_hash_join_initial_buckets > 0)
         settings[QueryPlanSerializationSetting::grace_hash_join_initial_buckets] = grace_hash_join_initial_buckets;
     settings[QueryPlanSerializationSetting::grace_hash_join_max_buckets] = grace_hash_join_max_buckets;

--- a/src/Interpreters/JoinOperator.cpp
+++ b/src/Interpreters/JoinOperator.cpp
@@ -41,7 +41,7 @@ namespace Setting
     extern const SettingsUInt64 partial_merge_join_rows_in_right_blocks;
     extern const SettingsUInt64 join_on_disk_max_files_to_merge;
 
-    extern const SettingsNonZeroUInt64 grace_hash_join_initial_buckets;
+    extern const SettingsUInt64 grace_hash_join_initial_buckets;
     extern const SettingsNonZeroUInt64 grace_hash_join_max_buckets;
 
     extern const SettingsUInt64 max_rows_in_set_to_optimize_join;
@@ -92,7 +92,7 @@ namespace QueryPlanSerializationSetting
     extern const QueryPlanSerializationSettingsUInt64 partial_merge_join_rows_in_right_blocks;
     extern const QueryPlanSerializationSettingsUInt64 join_on_disk_max_files_to_merge;
 
-    extern const QueryPlanSerializationSettingsNonZeroUInt64 grace_hash_join_initial_buckets;
+    extern const QueryPlanSerializationSettingsUInt64 grace_hash_join_initial_buckets;
     extern const QueryPlanSerializationSettingsNonZeroUInt64 grace_hash_join_max_buckets;
 
     extern const QueryPlanSerializationSettingsUInt64 max_bytes_before_external_join;

--- a/src/Interpreters/JoinOperator.cpp
+++ b/src/Interpreters/JoinOperator.cpp
@@ -206,7 +206,10 @@ JoinSettings::JoinSettings(const QueryPlanSerializationSettings & settings)
     partial_merge_join_rows_in_right_blocks = settings[QueryPlanSerializationSetting::partial_merge_join_rows_in_right_blocks];
     join_on_disk_max_files_to_merge = settings[QueryPlanSerializationSetting::join_on_disk_max_files_to_merge];
 
-    grace_hash_join_initial_buckets = settings[QueryPlanSerializationSetting::grace_hash_join_initial_buckets];
+    grace_hash_join_initial_buckets
+        = settings.isChanged("grace_hash_join_initial_buckets")
+        ? settings[QueryPlanSerializationSetting::grace_hash_join_initial_buckets]
+        : 0;
     grace_hash_join_max_buckets = settings[QueryPlanSerializationSetting::grace_hash_join_max_buckets];
 
     max_bytes_before_external_join = settings[QueryPlanSerializationSetting::max_bytes_before_external_join];
@@ -261,7 +264,8 @@ void JoinSettings::updatePlanSettings(QueryPlanSerializationSettings & settings)
     settings[QueryPlanSerializationSetting::partial_merge_join_rows_in_right_blocks] = partial_merge_join_rows_in_right_blocks;
     settings[QueryPlanSerializationSetting::join_on_disk_max_files_to_merge] = join_on_disk_max_files_to_merge;
 
-    settings[QueryPlanSerializationSetting::grace_hash_join_initial_buckets] = grace_hash_join_initial_buckets;
+    if (grace_hash_join_initial_buckets > 0)
+        settings[QueryPlanSerializationSetting::grace_hash_join_initial_buckets] = grace_hash_join_initial_buckets;
     settings[QueryPlanSerializationSetting::grace_hash_join_max_buckets] = grace_hash_join_max_buckets;
 
     settings[QueryPlanSerializationSetting::max_bytes_before_external_join] = max_bytes_before_external_join;

--- a/src/Interpreters/SpillingHashJoin.cpp
+++ b/src/Interpreters/SpillingHashJoin.cpp
@@ -4,11 +4,9 @@
 #include <Interpreters/GraceHashJoin.h>
 #include <Interpreters/HashJoin/HashJoin.h>
 #include <Interpreters/TableJoin.h>
+#include <Common/Exception.h>
 #include <Common/ProfileEvents.h>
 #include <Common/logger_useful.h>
-
-#include <algorithm>
-#include <limits>
 
 namespace ProfileEvents
 {
@@ -17,6 +15,24 @@ extern const Event JoinSpillingHashJoinSwitchedToGraceJoin;
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+
+void checkExternalJoinThreshold(size_t max_bytes_before_external_join)
+{
+    if (max_bytes_before_external_join == 0)
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "`SpillingHashJoin` requires the external JOIN threshold to be greater than 0");
+}
+
+}
 
 SpillingHashJoin::SpillingHashJoin(
     std::shared_ptr<TableJoin> table_join_,
@@ -39,6 +55,7 @@ SpillingHashJoin::SpillingHashJoin(
     , max_bytes_before_external_join(table_join->maxBytesBeforeExternalJoin())
     , rhs_size_estimation(rhs_size_estimation_)
 {
+    checkExternalJoinThreshold(max_bytes_before_external_join);
     hash_join = std::make_shared<HashJoin>(
         table_join, right_sample_block_, any_take_last_row, /*reserve_num_=*/0, /*instance_id_=*/"",
         /*use_two_level_maps_=*/false, stats_collecting_params_);
@@ -66,6 +83,7 @@ SpillingHashJoin::SpillingHashJoin(
     , max_bytes_before_external_join(table_join->maxBytesBeforeExternalJoin())
     , rhs_size_estimation(rhs_size_estimation_)
 {
+    checkExternalJoinThreshold(max_bytes_before_external_join);
     concurrent_join = std::make_shared<ConcurrentHashJoin>(
         table_join,
         concurrent_slots_,
@@ -102,44 +120,6 @@ void SpillingHashJoin::tryConvertSlots()
             blocks.pop_front();
         }
     }
-}
-
-size_t SpillingHashJoin::getInitialNumBucketsForGraceJoin(size_t total_rows, size_t total_bytes) const
-{
-    if (initial_num_buckets > 0)
-        return GraceHashJoin::getInitialNumBuckets(initial_num_buckets, max_num_buckets);
-
-    const size_t estimated_total_rows = std::max(total_rows, rhs_size_estimation.value_or(0));
-    size_t result = GraceHashJoin::getInitialNumBuckets(
-        /*configured_num_buckets=*/0,
-        max_num_buckets,
-        estimated_total_rows,
-        table_join->sizeLimits().max_rows);
-
-    if (max_bytes_before_external_join > 0)
-    {
-        size_t estimated_total_bytes = total_bytes;
-        if (total_rows > 0 && estimated_total_rows > total_rows)
-        {
-            const UInt128 numerator = static_cast<UInt128>(total_bytes) * estimated_total_rows;
-            const UInt128 estimate = numerator / total_rows + (numerator % total_rows != 0);
-            estimated_total_bytes = static_cast<size_t>(
-                std::min<UInt128>(estimate, std::numeric_limits<size_t>::max()));
-        }
-
-        /// `GraceHashJoin` spills when twice the in-memory bucket size reaches the external
-        /// join threshold. Express the same boundary without multiplication to avoid overflow.
-        const size_t max_bucket_bytes = max_bytes_before_external_join / 2 + max_bytes_before_external_join % 2;
-        result = std::max(
-            result,
-            GraceHashJoin::getInitialNumBuckets(
-                /*configured_num_buckets=*/0,
-                max_num_buckets,
-                estimated_total_bytes,
-                max_bucket_bytes));
-    }
-
-    return result;
 }
 
 std::string SpillingHashJoin::getName() const
@@ -231,19 +211,21 @@ void SpillingHashJoin::switchToGraceHashJoin()
 
             print_threshold_reached_log(concurrent_join, "ConcurrentHashJoin");
 
-            const size_t grace_initial_num_buckets = getInitialNumBucketsForGraceJoin(
-                concurrent_join->getTotalRowCount(), concurrent_join->getTotalByteCount());
-
             /// Create GraceHashJoin.
             grace_join = std::make_shared<GraceHashJoin>(
-                grace_initial_num_buckets,
+                initial_num_buckets,
                 max_num_buckets,
                 table_join,
                 left_sample_block,
                 std::make_shared<const Block>(right_sample_block),
                 tmp_data,
                 any_take_last_row,
-                max_bytes_before_external_join);
+                max_bytes_before_external_join,
+                GraceHashJoin::InitialBucketsParams{
+                    .total_rows_estimation = rhs_size_estimation,
+                    .current_rows = concurrent_join->getTotalRowCount(),
+                    .current_bytes = concurrent_join->getTotalByteCount(),
+                });
             grace_join->initialize(*left_sample_block);
             chosen_join = grace_join;
 
@@ -260,19 +242,23 @@ void SpillingHashJoin::switchToGraceHashJoin()
     print_threshold_reached_log(hash_join, "HashJoin");
     /// Single-thread path: extract from HashJoin, feed to GraceHashJoin.
     ProfileEvents::increment(ProfileEvents::JoinSpillingHashJoinSwitchedToGraceJoin);
-    const size_t grace_initial_num_buckets = getInitialNumBucketsForGraceJoin(
-        hash_join->getTotalRowCount(), hash_join->getTotalByteCount());
+    const auto initial_buckets_params = GraceHashJoin::InitialBucketsParams{
+        .total_rows_estimation = rhs_size_estimation,
+        .current_rows = hash_join->getTotalRowCount(),
+        .current_bytes = hash_join->getTotalByteCount(),
+    };
     BlocksList right_blocks = hash_join->releaseJoinedBlocks(/*restructure=*/false);
 
     chosen_join = std::make_shared<GraceHashJoin>(
-        grace_initial_num_buckets,
+        initial_num_buckets,
         max_num_buckets,
         table_join,
         left_sample_block,
         std::make_shared<const Block>(right_sample_block),
         tmp_data,
         any_take_last_row,
-        max_bytes_before_external_join);
+        max_bytes_before_external_join,
+        initial_buckets_params);
 
     chosen_join->initialize(*left_sample_block);
 

--- a/src/Interpreters/SpillingHashJoin.cpp
+++ b/src/Interpreters/SpillingHashJoin.cpp
@@ -7,6 +7,9 @@
 #include <Common/ProfileEvents.h>
 #include <Common/logger_useful.h>
 
+#include <algorithm>
+#include <limits>
+
 namespace ProfileEvents
 {
 extern const Event JoinSpillingHashJoinSwitchedToGraceJoin;
@@ -23,7 +26,8 @@ SpillingHashJoin::SpillingHashJoin(
     size_t initial_num_buckets_,
     size_t max_num_buckets_,
     const StatsCollectingParams & stats_collecting_params_,
-    bool any_take_last_row_)
+    bool any_take_last_row_,
+    std::optional<size_t> rhs_size_estimation_)
     : log(getLogger("SpillingHashJoin"))
     , table_join(std::move(table_join_))
     , left_sample_block(std::move(left_sample_block_))
@@ -33,6 +37,7 @@ SpillingHashJoin::SpillingHashJoin(
     , max_num_buckets(max_num_buckets_)
     , any_take_last_row(any_take_last_row_)
     , max_bytes_before_external_join(table_join->maxBytesBeforeExternalJoin())
+    , rhs_size_estimation(rhs_size_estimation_)
 {
     hash_join = std::make_shared<HashJoin>(
         table_join, right_sample_block_, any_take_last_row, /*reserve_num_=*/0, /*instance_id_=*/"",
@@ -48,7 +53,8 @@ SpillingHashJoin::SpillingHashJoin(
     size_t max_num_buckets_,
     size_t concurrent_slots_,
     const StatsCollectingParams & stats_collecting_params_,
-    bool any_take_last_row_)
+    bool any_take_last_row_,
+    std::optional<size_t> rhs_size_estimation_)
     : log(getLogger("SpillingHashJoin"))
     , table_join(std::move(table_join_))
     , left_sample_block(std::move(left_sample_block_))
@@ -58,6 +64,7 @@ SpillingHashJoin::SpillingHashJoin(
     , max_num_buckets(max_num_buckets_)
     , any_take_last_row(any_take_last_row_)
     , max_bytes_before_external_join(table_join->maxBytesBeforeExternalJoin())
+    , rhs_size_estimation(rhs_size_estimation_)
 {
     concurrent_join = std::make_shared<ConcurrentHashJoin>(
         table_join,
@@ -95,6 +102,44 @@ void SpillingHashJoin::tryConvertSlots()
             blocks.pop_front();
         }
     }
+}
+
+size_t SpillingHashJoin::getInitialNumBucketsForGraceJoin(size_t total_rows, size_t total_bytes) const
+{
+    if (initial_num_buckets > 0)
+        return GraceHashJoin::getInitialNumBuckets(initial_num_buckets, max_num_buckets);
+
+    const size_t estimated_total_rows = std::max(total_rows, rhs_size_estimation.value_or(0));
+    size_t result = GraceHashJoin::getInitialNumBuckets(
+        /*configured_num_buckets=*/0,
+        max_num_buckets,
+        estimated_total_rows,
+        table_join->sizeLimits().max_rows);
+
+    if (max_bytes_before_external_join > 0)
+    {
+        size_t estimated_total_bytes = total_bytes;
+        if (total_rows > 0 && estimated_total_rows > total_rows)
+        {
+            const UInt128 numerator = static_cast<UInt128>(total_bytes) * estimated_total_rows;
+            const UInt128 estimate = numerator / total_rows + (numerator % total_rows != 0);
+            estimated_total_bytes = static_cast<size_t>(
+                std::min<UInt128>(estimate, std::numeric_limits<size_t>::max()));
+        }
+
+        /// `GraceHashJoin` spills when twice the in-memory bucket size reaches the external
+        /// join threshold. Express the same boundary without multiplication to avoid overflow.
+        const size_t max_bucket_bytes = max_bytes_before_external_join / 2 + max_bytes_before_external_join % 2;
+        result = std::max(
+            result,
+            GraceHashJoin::getInitialNumBuckets(
+                /*configured_num_buckets=*/0,
+                max_num_buckets,
+                estimated_total_bytes,
+                max_bucket_bytes));
+    }
+
+    return result;
 }
 
 std::string SpillingHashJoin::getName() const
@@ -186,9 +231,12 @@ void SpillingHashJoin::switchToGraceHashJoin()
 
             print_threshold_reached_log(concurrent_join, "ConcurrentHashJoin");
 
+            const size_t grace_initial_num_buckets = getInitialNumBucketsForGraceJoin(
+                concurrent_join->getTotalRowCount(), concurrent_join->getTotalByteCount());
+
             /// Create GraceHashJoin.
             grace_join = std::make_shared<GraceHashJoin>(
-                initial_num_buckets,
+                grace_initial_num_buckets,
                 max_num_buckets,
                 table_join,
                 left_sample_block,
@@ -212,10 +260,12 @@ void SpillingHashJoin::switchToGraceHashJoin()
     print_threshold_reached_log(hash_join, "HashJoin");
     /// Single-thread path: extract from HashJoin, feed to GraceHashJoin.
     ProfileEvents::increment(ProfileEvents::JoinSpillingHashJoinSwitchedToGraceJoin);
+    const size_t grace_initial_num_buckets = getInitialNumBucketsForGraceJoin(
+        hash_join->getTotalRowCount(), hash_join->getTotalByteCount());
     BlocksList right_blocks = hash_join->releaseJoinedBlocks(/*restructure=*/false);
 
     chosen_join = std::make_shared<GraceHashJoin>(
-        initial_num_buckets,
+        grace_initial_num_buckets,
         max_num_buckets,
         table_join,
         left_sample_block,

--- a/src/Interpreters/SpillingHashJoin.h
+++ b/src/Interpreters/SpillingHashJoin.h
@@ -120,7 +120,6 @@ private:
 
     void switchToGraceHashJoin();
     void tryConvertSlots();
-    size_t getInitialNumBucketsForGraceJoin(size_t total_rows, size_t total_bytes) const;
 
     LoggerPtr log;
     std::shared_ptr<TableJoin> table_join;

--- a/src/Interpreters/SpillingHashJoin.h
+++ b/src/Interpreters/SpillingHashJoin.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <optional>
 
 #include <Core/Block.h>
 #include <Core/Block_fwd.h>
@@ -55,7 +56,8 @@ public:
         size_t initial_num_buckets_,
         size_t max_num_buckets_,
         const StatsCollectingParams & stats_collecting_params_ = {},
-        bool any_take_last_row_ = false);
+        bool any_take_last_row_ = false,
+        std::optional<size_t> rhs_size_estimation_ = std::nullopt);
 
     /// Concurrent mode: wraps a ConcurrentHashJoin.
     SpillingHashJoin(
@@ -67,7 +69,8 @@ public:
         size_t max_num_buckets_,
         size_t concurrent_slots_,
         const StatsCollectingParams & stats_collecting_params_ = {},
-        bool any_take_last_row_ = false);
+        bool any_take_last_row_ = false,
+        std::optional<size_t> rhs_size_estimation_ = std::nullopt);
 
     ~SpillingHashJoin() override;
 
@@ -117,6 +120,7 @@ private:
 
     void switchToGraceHashJoin();
     void tryConvertSlots();
+    size_t getInitialNumBucketsForGraceJoin(size_t total_rows, size_t total_bytes) const;
 
     LoggerPtr log;
     std::shared_ptr<TableJoin> table_join;
@@ -127,6 +131,7 @@ private:
     size_t max_num_buckets;
     bool any_take_last_row;
     size_t max_bytes_before_external_join;
+    std::optional<size_t> rhs_size_estimation;
 
     SharedMutex switch_mutex;
     std::atomic<size_t> next_slot_to_convert{0};

--- a/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
+++ b/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
@@ -222,6 +222,7 @@ TEST(GraceHashJoinBuckets, UsesSizeEstimateInAutoMode)
     using Params = GraceHashJoin::InitialBucketsParams;
 
     EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, Params{}, 0, 0), 1);
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, Params{.total_rows_estimation = 4000}, 0, 0), 1);
     EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, Params{.total_rows_estimation = 999}, 1000, 0), 1);
     EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, Params{.total_rows_estimation = 1000}, 1000, 0), 2);
     EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, Params{.total_rows_estimation = 4000}, 1000, 0), 8);
@@ -275,14 +276,14 @@ TEST(GraceHashJoinBuckets, LimitsAutomaticTemporaryFileBufferMemory)
 {
     constexpr size_t configured_buffer_size = 1uz << 20;
 
-    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1, 0), configured_buffer_size);
-    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 128, 0), 1uz << 13);
-    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1024, 0), 1uz << 10);
-    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 128, 1uz << 30), configured_buffer_size);
-    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 256, 1uz << 30), 1uz << 19);
-    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1024, 1uz << 30), 1uz << 17);
-    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 256, 100uz << 10), 50);
-    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1024, 1), 1);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1, 1024, 0), configured_buffer_size);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 8, 1024, 0), 1uz << 17);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1024, 1024, 0), 1uz << 10);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1, 1, 1uz << 30), configured_buffer_size);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1, 1024, 1uz << 30), 1uz << 17);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 256, 256, 1uz << 30), 1uz << 19);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 256, 256, 100uz << 10), 50);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1024, 1024, 1), 1);
 }
 
 TEST(SpillingHashJoin, RejectsZeroExternalJoinThreshold)

--- a/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
+++ b/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
@@ -261,6 +261,7 @@ TEST(GraceHashJoinBuckets, CombinesPlannerAndRuntimeInformation)
 TEST(GraceHashJoinBuckets, ClampsAutoValueWithoutOverflow)
 {
     using Params = GraceHashJoin::InitialBucketsParams;
+    constexpr size_t highest_power_of_two = 1uz << (std::numeric_limits<size_t>::digits - 1);
 
     EXPECT_EQ(
         GraceHashJoin::getInitialNumBuckets(
@@ -270,6 +271,22 @@ TEST(GraceHashJoinBuckets, ClampsAutoValueWithoutOverflow)
             1,
             0),
         8);
+    EXPECT_EQ(
+        GraceHashJoin::getInitialNumBuckets(
+            0,
+            std::numeric_limits<size_t>::max(),
+            Params{.total_rows_estimation = std::numeric_limits<size_t>::max()},
+            1,
+            0),
+        highest_power_of_two);
+    EXPECT_EQ(
+        GraceHashJoin::getInitialNumBuckets(
+            std::numeric_limits<size_t>::max(),
+            std::numeric_limits<size_t>::max(),
+            Params{},
+            0,
+            0),
+        highest_power_of_two);
 }
 
 TEST(GraceHashJoinBuckets, LimitsAutomaticTemporaryFileBufferMemory)

--- a/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
+++ b/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
@@ -276,8 +276,11 @@ TEST(GraceHashJoinBuckets, LimitsAutomaticTemporaryFileBufferMemory)
     constexpr size_t configured_buffer_size = 1uz << 20;
 
     EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1, 0), configured_buffer_size);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 128, 0), 1uz << 13);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1024, 0), 1uz << 10);
     EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 128, 1uz << 30), configured_buffer_size);
     EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 256, 1uz << 30), 1uz << 19);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1024, 1uz << 30), 1uz << 17);
     EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 256, 100uz << 10), 50);
     EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1024, 1), 1);
 }

--- a/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
+++ b/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
@@ -70,8 +70,6 @@ String serializeJoinStep(const JoinStepLogical & step)
     IQueryPlanStep::Serialization ctx{
         .out = out,
         .registry = registry,
-        .skip_final_flag = false,
-        .skip_cache_key = false,
         .version = 0,
     };
     step.serialize(ctx);

--- a/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
+++ b/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
@@ -3,11 +3,15 @@
 #include <Core/Settings.h>
 #include <Interpreters/GraceHashJoin.h>
 #include <Interpreters/JoinOperator.h>
+#include <Interpreters/SetSerialization.h>
 #include <Interpreters/SpillingHashJoin.h>
 #include <Interpreters/TableJoin.h>
+#include <Processors/QueryPlan/JoinStepLogical.h>
 #include <Processors/QueryPlan/QueryPlanSerializationSettings.h>
+#include <Processors/QueryPlan/Serialization.h>
 #include <Common/Exception.h>
 #include <IO/ReadBufferFromString.h>
+#include <IO/ReadHelpers.h>
 #include <IO/WriteBufferFromString.h>
 
 #include <limits>
@@ -18,11 +22,6 @@ using namespace DB;
 namespace DB::Setting
 {
     extern const SettingsUInt64 grace_hash_join_initial_buckets;
-}
-
-namespace DB::QueryPlanSerializationSetting
-{
-    extern const QueryPlanSerializationSettingsUInt64 grace_hash_join_initial_buckets;
 }
 
 namespace DB::ErrorCodes
@@ -46,6 +45,71 @@ QueryPlanSerializationSettings roundTrip(const JoinSettings & source)
     QueryPlanSerializationSettings result;
     result.readBinary(in);
     return result;
+}
+
+std::unique_ptr<JoinStepLogical> makeJoinStep(UInt64 initial_buckets)
+{
+    Settings query_settings;
+    query_settings[Setting::grace_hash_join_initial_buckets] = initial_buckets;
+
+    auto empty_header = std::make_shared<const Block>();
+    return std::make_unique<JoinStepLogical>(
+        empty_header,
+        empty_header,
+        JoinOperator{},
+        JoinExpressionActions{},
+        std::vector<const ActionsDAG::Node *>{},
+        JoinSettings(query_settings),
+        SortingStep::Settings(query_settings));
+}
+
+String serializeJoinStep(const JoinStepLogical & step)
+{
+    SerializedSetsRegistry registry;
+    WriteBufferFromOwnString out;
+    IQueryPlanStep::Serialization ctx{
+        .out = out,
+        .registry = registry,
+        .skip_final_flag = false,
+        .skip_cache_key = false,
+        .version = 0,
+    };
+    step.serialize(ctx);
+    return out.str();
+}
+
+UInt8 readJoinStepFlags(const String & serialized_data)
+{
+    ReadBufferFromString in(serialized_data);
+    UInt8 flags = 0;
+    readIntBinary(flags, in);
+    return flags;
+}
+
+UInt64 roundTripJoinStep(const JoinStepLogical & source, const String & serialized_data)
+{
+    auto serialized_settings = roundTrip(source.getJoinSettings());
+
+    ReadBufferFromString in(serialized_data);
+    DeserializedSetsRegistry registry;
+    ContextPtr context;
+    const auto & input_headers = source.getInputHeaders();
+    const auto & output_header = source.getOutputHeader();
+    IQueryPlanStep::Deserialization ctx{
+        .in = in,
+        .registry = registry,
+        .storage_holders = {},
+        .context = context,
+        .input_headers = input_headers,
+        .output_header = output_header,
+        .settings = serialized_settings,
+        .max_type_complexity = 0,
+        .version = 0,
+        .skipping = false,
+    };
+
+    auto restored = JoinStepLogical::deserialize(ctx);
+    return static_cast<JoinStepLogical &>(*restored).getJoinSettings().grace_hash_join_initial_buckets;
 }
 
 void expectZeroExternalJoinThresholdRejected(bool concurrent)
@@ -78,15 +142,13 @@ void expectZeroExternalJoinThresholdRejected(bool concurrent)
 }
 
 
-TEST(QueryPlanSerializationSettings, EncodesAutomaticGraceBucketsByFieldAbsence)
+TEST(QueryPlanSerializationSettings, PreservesLegacyGraceBucketsWhenWireFieldIsMissing)
 {
     Settings query_settings;
     query_settings[Setting::grace_hash_join_initial_buckets] = 0;
     const auto serialized = roundTrip(JoinSettings(query_settings));
 
-    EXPECT_FALSE(serialized.isChanged("grace_hash_join_initial_buckets"));
-    EXPECT_EQ(serialized[QueryPlanSerializationSetting::grace_hash_join_initial_buckets], 1);
-    EXPECT_EQ(JoinSettings(serialized).grace_hash_join_initial_buckets, 0);
+    EXPECT_EQ(JoinSettings(serialized).grace_hash_join_initial_buckets, 1);
 }
 
 TEST(QueryPlanSerializationSettings, PreservesExplicitGraceBuckets)
@@ -97,8 +159,37 @@ TEST(QueryPlanSerializationSettings, PreservesExplicitGraceBuckets)
         query_settings[Setting::grace_hash_join_initial_buckets] = explicit_value;
         const auto serialized = roundTrip(JoinSettings(query_settings));
 
-        EXPECT_TRUE(serialized.isChanged("grace_hash_join_initial_buckets"));
         EXPECT_EQ(JoinSettings(serialized).grace_hash_join_initial_buckets, explicit_value);
+    }
+}
+
+TEST(QueryPlanSerializationSettings, RoundTripsAutomaticGraceBucketsThroughJoinStepFlag)
+{
+    const auto source = makeJoinStep(0);
+    const auto serialized_data = serializeJoinStep(*source);
+
+    EXPECT_EQ(readJoinStepFlags(serialized_data), 1);
+    EXPECT_EQ(roundTripJoinStep(*source, serialized_data), 0);
+}
+
+TEST(QueryPlanSerializationSettings, ReadsLegacyMissingGraceBucketsAsOne)
+{
+    const auto source = makeJoinStep(0);
+    auto serialized_data = serializeJoinStep(*source);
+    serialized_data.front() = 0;
+
+    EXPECT_EQ(roundTripJoinStep(*source, serialized_data), 1);
+}
+
+TEST(QueryPlanSerializationSettings, RoundTripsExplicitGraceBucketsWithoutAutoFlag)
+{
+    for (UInt64 explicit_value : {1, 8})
+    {
+        const auto source = makeJoinStep(explicit_value);
+        const auto serialized_data = serializeJoinStep(*source);
+
+        EXPECT_EQ(readJoinStepFlags(serialized_data), 0);
+        EXPECT_EQ(roundTripJoinStep(*source, serialized_data), explicit_value);
     }
 }
 
@@ -136,10 +227,20 @@ TEST(GraceHashJoinBuckets, CombinesPlannerAndRuntimeInformation)
     using Params = GraceHashJoin::InitialBucketsParams;
 
     EXPECT_EQ(
-        GraceHashJoin::getInitialNumBuckets(0, 1024, Params{.current_rows = 999, .current_bytes = 99900}, 0, 100000),
+        GraceHashJoin::getInitialNumBuckets(
+            0,
+            1024,
+            Params{.total_rows_estimation = std::nullopt, .current_rows = 999, .current_bytes = 99900},
+            0,
+            100000),
         2);
     EXPECT_EQ(
-        GraceHashJoin::getInitialNumBuckets(0, 1024, Params{.current_rows = 1000, .current_bytes = 100000}, 0, 100000),
+        GraceHashJoin::getInitialNumBuckets(
+            0,
+            1024,
+            Params{.total_rows_estimation = std::nullopt, .current_rows = 1000, .current_bytes = 100000},
+            0,
+            100000),
         4);
     EXPECT_EQ(
         GraceHashJoin::getInitialNumBuckets(

--- a/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
+++ b/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+
+#include <Interpreters/GraceHashJoin.h>
+
+#include <limits>
+
+using namespace DB;
+
+
+TEST(GraceHashJoinBuckets, PreservesExplicitValues)
+{
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(1, 1024), 1);
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(3, 1024), 4);
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(3, 3), 2);
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(2048, 1024), 1024);
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(2, 1024, 1000000, 1), 2);
+}
+
+TEST(GraceHashJoinBuckets, UsesSizeEstimateInAutoMode)
+{
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024), 1);
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, 999, 1000), 1);
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, 1000, 1000), 2);
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, 4000, 1000), 8);
+}
+
+TEST(GraceHashJoinBuckets, ClampsAutoValueWithoutOverflow)
+{
+    EXPECT_EQ(
+        GraceHashJoin::getInitialNumBuckets(0, 8, std::numeric_limits<size_t>::max(), 1),
+        8);
+}

--- a/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
+++ b/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
@@ -1,32 +1,172 @@
 #include <gtest/gtest.h>
 
+#include <Core/Settings.h>
 #include <Interpreters/GraceHashJoin.h>
+#include <Interpreters/JoinOperator.h>
+#include <Interpreters/SpillingHashJoin.h>
+#include <Interpreters/TableJoin.h>
+#include <Processors/QueryPlan/QueryPlanSerializationSettings.h>
+#include <Common/Exception.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromString.h>
 
 #include <limits>
+#include <memory>
 
 using namespace DB;
+
+namespace DB::Setting
+{
+    extern const SettingsUInt64 grace_hash_join_initial_buckets;
+}
+
+namespace DB::QueryPlanSerializationSetting
+{
+    extern const QueryPlanSerializationSettingsUInt64 grace_hash_join_initial_buckets;
+}
+
+namespace DB::ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+
+QueryPlanSerializationSettings roundTrip(const JoinSettings & source)
+{
+    QueryPlanSerializationSettings serialized;
+    source.updatePlanSettings(serialized);
+
+    WriteBufferFromOwnString out;
+    serialized.writeChangedBinary(out);
+    const String serialized_data = out.str();
+    ReadBufferFromString in(serialized_data);
+
+    QueryPlanSerializationSettings result;
+    result.readBinary(in);
+    return result;
+}
+
+void expectZeroExternalJoinThresholdRejected(bool concurrent)
+{
+    auto table_join = std::make_shared<TableJoin>(
+        SizeLimits{},
+        /*use_nulls=*/false,
+        JoinKind::Inner,
+        JoinStrictness::All,
+        Names{});
+    auto header = std::make_shared<const Block>();
+
+    try
+    {
+        std::unique_ptr<SpillingHashJoin> join;
+        if (concurrent)
+            join = std::make_unique<SpillingHashJoin>(table_join, header, header, nullptr, 1, 1024, 2);
+        else
+            join = std::make_unique<SpillingHashJoin>(table_join, header, header, nullptr, 1, 1024);
+        FAIL() << "Expected an exception";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::LOGICAL_ERROR);
+        EXPECT_TRUE(e.message().contains("SpillingHashJoin"));
+        EXPECT_TRUE(e.message().contains("greater than 0"));
+    }
+}
+
+}
+
+
+TEST(QueryPlanSerializationSettings, EncodesAutomaticGraceBucketsByFieldAbsence)
+{
+    Settings query_settings;
+    query_settings[Setting::grace_hash_join_initial_buckets] = 0;
+    const auto serialized = roundTrip(JoinSettings(query_settings));
+
+    EXPECT_FALSE(serialized.isChanged("grace_hash_join_initial_buckets"));
+    EXPECT_EQ(serialized[QueryPlanSerializationSetting::grace_hash_join_initial_buckets], 1);
+    EXPECT_EQ(JoinSettings(serialized).grace_hash_join_initial_buckets, 0);
+}
+
+TEST(QueryPlanSerializationSettings, PreservesExplicitGraceBuckets)
+{
+    for (UInt64 explicit_value : {1, 8})
+    {
+        Settings query_settings;
+        query_settings[Setting::grace_hash_join_initial_buckets] = explicit_value;
+        const auto serialized = roundTrip(JoinSettings(query_settings));
+
+        EXPECT_TRUE(serialized.isChanged("grace_hash_join_initial_buckets"));
+        EXPECT_EQ(JoinSettings(serialized).grace_hash_join_initial_buckets, explicit_value);
+    }
+}
 
 
 TEST(GraceHashJoinBuckets, PreservesExplicitValues)
 {
-    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(1, 1024), 1);
-    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(3, 1024), 4);
-    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(3, 3), 2);
-    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(2048, 1024), 1024);
-    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(2, 1024, 1000000, 1), 2);
+    using Params = GraceHashJoin::InitialBucketsParams;
+
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(1, 1024, Params{}, 0, 0), 1);
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(3, 1024, Params{}, 0, 0), 4);
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(3, 3, Params{}, 0, 0), 2);
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(2048, 1024, Params{}, 0, 0), 1024);
+    EXPECT_EQ(
+        GraceHashJoin::getInitialNumBuckets(
+            2,
+            1024,
+            Params{.total_rows_estimation = 1000000, .current_rows = 1000, .current_bytes = 1000000},
+            1,
+            1),
+        2);
 }
 
 TEST(GraceHashJoinBuckets, UsesSizeEstimateInAutoMode)
 {
-    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024), 1);
-    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, 999, 1000), 1);
-    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, 1000, 1000), 2);
-    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, 4000, 1000), 8);
+    using Params = GraceHashJoin::InitialBucketsParams;
+
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, Params{}, 0, 0), 1);
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, Params{.total_rows_estimation = 999}, 1000, 0), 1);
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, Params{.total_rows_estimation = 1000}, 1000, 0), 2);
+    EXPECT_EQ(GraceHashJoin::getInitialNumBuckets(0, 1024, Params{.total_rows_estimation = 4000}, 1000, 0), 8);
+}
+
+TEST(GraceHashJoinBuckets, CombinesPlannerAndRuntimeInformation)
+{
+    using Params = GraceHashJoin::InitialBucketsParams;
+
+    EXPECT_EQ(
+        GraceHashJoin::getInitialNumBuckets(0, 1024, Params{.current_rows = 999, .current_bytes = 99900}, 0, 100000),
+        2);
+    EXPECT_EQ(
+        GraceHashJoin::getInitialNumBuckets(0, 1024, Params{.current_rows = 1000, .current_bytes = 100000}, 0, 100000),
+        4);
+    EXPECT_EQ(
+        GraceHashJoin::getInitialNumBuckets(
+            0,
+            1024,
+            Params{.total_rows_estimation = 4000, .current_rows = 1000, .current_bytes = 100000},
+            0,
+            100000),
+        16);
 }
 
 TEST(GraceHashJoinBuckets, ClampsAutoValueWithoutOverflow)
 {
+    using Params = GraceHashJoin::InitialBucketsParams;
+
     EXPECT_EQ(
-        GraceHashJoin::getInitialNumBuckets(0, 8, std::numeric_limits<size_t>::max(), 1),
+        GraceHashJoin::getInitialNumBuckets(
+            0,
+            8,
+            Params{.total_rows_estimation = std::numeric_limits<size_t>::max()},
+            1,
+            0),
         8);
+}
+
+TEST(SpillingHashJoin, RejectsZeroExternalJoinThreshold)
+{
+    expectZeroExternalJoinThresholdRejected(/*concurrent=*/false);
+    expectZeroExternalJoinThresholdRejected(/*concurrent=*/true);
 }

--- a/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
+++ b/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
@@ -115,6 +115,7 @@ UInt64 roundTripJoinStep(const JoinStepLogical & source, const String & serializ
     return static_cast<JoinStepLogical &>(*restored).getJoinSettings().grace_hash_join_initial_buckets;
 }
 
+#ifndef DEBUG_OR_SANITIZER_BUILD
 void expectZeroExternalJoinThresholdRejected(bool concurrent)
 {
     auto table_join = std::make_shared<TableJoin>(
@@ -141,6 +142,7 @@ void expectZeroExternalJoinThresholdRejected(bool concurrent)
         EXPECT_TRUE(e.message().contains("greater than 0"));
     }
 }
+#endif
 
 }
 
@@ -282,6 +284,10 @@ TEST(GraceHashJoinBuckets, LimitsAutomaticTemporaryFileBufferMemory)
 
 TEST(SpillingHashJoin, RejectsZeroExternalJoinThreshold)
 {
+#ifdef DEBUG_OR_SANITIZER_BUILD
+    GTEST_SKIP() << "`LOGICAL_ERROR` aborts in debug and sanitizer builds";
+#else
     expectZeroExternalJoinThresholdRejected(/*concurrent=*/false);
     expectZeroExternalJoinThresholdRejected(/*concurrent=*/true);
+#endif
 }

--- a/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
+++ b/src/Interpreters/tests/gtest_grace_hash_join_buckets.cpp
@@ -10,6 +10,7 @@
 #include <Processors/QueryPlan/QueryPlanSerializationSettings.h>
 #include <Processors/QueryPlan/Serialization.h>
 #include <Common/Exception.h>
+#include <Common/tests/gtest_global_register.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteBufferFromString.h>
@@ -49,6 +50,8 @@ QueryPlanSerializationSettings roundTrip(const JoinSettings & source)
 
 std::unique_ptr<JoinStepLogical> makeJoinStep(UInt64 initial_buckets)
 {
+    tryRegisterFunctions();
+
     Settings query_settings;
     query_settings[Setting::grace_hash_join_initial_buckets] = initial_buckets;
 
@@ -58,7 +61,9 @@ std::unique_ptr<JoinStepLogical> makeJoinStep(UInt64 initial_buckets)
         empty_header,
         JoinOperator{},
         JoinExpressionActions{},
-        std::vector<const ActionsDAG::Node *>{},
+        NameSet{},
+        std::unordered_map<String, const ActionsDAG::Node *>{},
+        false,
         JoinSettings(query_settings),
         SortingStep::Settings(query_settings));
 }
@@ -262,6 +267,17 @@ TEST(GraceHashJoinBuckets, ClampsAutoValueWithoutOverflow)
             1,
             0),
         8);
+}
+
+TEST(GraceHashJoinBuckets, LimitsAutomaticTemporaryFileBufferMemory)
+{
+    constexpr size_t configured_buffer_size = 1uz << 20;
+
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1, 0), configured_buffer_size);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 128, 1uz << 30), configured_buffer_size);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 256, 1uz << 30), 1uz << 19);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 256, 100uz << 10), 50);
+    EXPECT_EQ(GraceHashJoin::getTemporaryFilesBufferSize(configured_buffer_size, 1024, 1), 1);
 }
 
 TEST(SpillingHashJoin, RejectsZeroExternalJoinThreshold)

--- a/src/Planner/PlannerJoins.cpp
+++ b/src/Planner/PlannerJoins.cpp
@@ -1272,19 +1272,16 @@ static std::shared_ptr<IJoin> tryCreateJoin(
             std::optional<size_t> rhs_size_estimation;
             if (params.rhs_size_estimation)
                 rhs_size_estimation = static_cast<size_t>(*params.rhs_size_estimation);
-            const size_t initial_num_buckets = GraceHashJoin::getInitialNumBuckets(
-                params.grace_hash_join_initial_buckets,
-                params.grace_hash_join_max_buckets,
-                rhs_size_estimation,
-                table_join->sizeLimits().max_rows);
             return std::make_shared<GraceHashJoin>(
-                initial_num_buckets,
+                params.grace_hash_join_initial_buckets,
                 params.grace_hash_join_max_buckets,
                 table_join,
                 left_table_expression_header,
                 right_table_expression_header,
                 table_join->getTempDataOnDisk(),
-                params.join_any_take_last_row);
+                params.join_any_take_last_row,
+                /*external_join_threshold_=*/0,
+                GraceHashJoin::InitialBucketsParams{.total_rows_estimation = rhs_size_estimation});
         }
     }
 

--- a/src/Planner/PlannerJoins.cpp
+++ b/src/Planner/PlannerJoins.cpp
@@ -70,7 +70,7 @@ namespace Setting
     extern const SettingsJoinAlgorithm join_algorithm;
     extern const SettingsUInt64 parallel_hash_join_threshold;
     extern const SettingsSeconds lock_acquire_timeout;
-    extern const SettingsNonZeroUInt64 grace_hash_join_initial_buckets;
+    extern const SettingsUInt64 grace_hash_join_initial_buckets;
     extern const SettingsNonZeroUInt64 grace_hash_join_max_buckets;
     extern const SettingsBool allow_dynamic_type_in_join_keys;
     extern const SettingsUInt64 max_bytes_before_external_join;
@@ -1217,7 +1217,8 @@ static std::shared_ptr<IJoin> tryCreateJoin(
                         params.grace_hash_join_max_buckets,
                         params.max_threads,
                         stats_collecting_params,
-                        params.join_any_take_last_row);
+                        params.join_any_take_last_row,
+                        params.rhs_size_estimation);
                 }
             }
 
@@ -1229,7 +1230,8 @@ static std::shared_ptr<IJoin> tryCreateJoin(
                 params.grace_hash_join_initial_buckets,
                 params.grace_hash_join_max_buckets,
                 stats_collecting_params,
-                params.join_any_take_last_row);
+                params.join_any_take_last_row,
+                params.rhs_size_estimation);
         }
 
         if (table_join->allowParallelHashJoin())
@@ -1267,8 +1269,16 @@ static std::shared_ptr<IJoin> tryCreateJoin(
 
         if (GraceHashJoin::isSupported(table_join))
         {
-            return std::make_shared<GraceHashJoin>(
+            std::optional<size_t> rhs_size_estimation;
+            if (params.rhs_size_estimation)
+                rhs_size_estimation = static_cast<size_t>(*params.rhs_size_estimation);
+            const size_t initial_num_buckets = GraceHashJoin::getInitialNumBuckets(
                 params.grace_hash_join_initial_buckets,
+                params.grace_hash_join_max_buckets,
+                rhs_size_estimation,
+                table_join->sizeLimits().max_rows);
+            return std::make_shared<GraceHashJoin>(
+                initial_num_buckets,
                 params.grace_hash_join_max_buckets,
                 table_join,
                 left_table_expression_header,
@@ -1299,7 +1309,8 @@ static std::shared_ptr<IJoin> tryCreateJoin(
                     params.grace_hash_join_max_buckets,
                     params.max_threads,
                     stats_collecting_params,
-                    params.join_any_take_last_row);
+                    params.join_any_take_last_row,
+                    params.rhs_size_estimation);
             }
 
             return std::make_shared<SpillingHashJoin>(
@@ -1310,7 +1321,8 @@ static std::shared_ptr<IJoin> tryCreateJoin(
                 params.grace_hash_join_initial_buckets,
                 params.grace_hash_join_max_buckets,
                 stats_collecting_params,
-                params.join_any_take_last_row);
+                params.join_any_take_last_row,
+                params.rhs_size_estimation);
         }
 
         if (MergeJoin::isSupported(table_join))

--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -71,6 +71,9 @@
 namespace
 {
 constexpr std::string_view join_dummy_result_name = "__join_result_dummy";
+/// Old readers already consume and ignore this reserved flags byte, so they safely keep the
+/// legacy serialized setting default of one bucket when a new writer requests automatic sizing.
+constexpr UInt8 grace_hash_join_initial_buckets_auto_flag = 1;
 }
 namespace DB
 {
@@ -1677,6 +1680,8 @@ static void serializeNodeList(
 void JoinStepLogical::serialize(Serialization & ctx) const
 {
     UInt8 flags = 0;
+    if (join_settings.grace_hash_join_initial_buckets == 0)
+        flags |= grace_hash_join_initial_buckets_auto_flag;
     writeIntBinary(flags, ctx.out);
 
     writeVarUInt(1, ctx.out);
@@ -1714,6 +1719,11 @@ QueryPlanStepPtr JoinStepLogical::deserialize(Deserialization & ctx)
 
     UInt8 flags = 0;
     readIntBinary(flags, ctx.in);
+    if (flags & ~grace_hash_join_initial_buckets_auto_flag)
+        throw Exception(
+            ErrorCodes::INCORRECT_DATA,
+            "Unknown `JoinStepLogical` serialization flags: {}",
+            static_cast<UInt64>(flags));
 
     ActionsDAG actions_dag;
     {
@@ -1736,6 +1746,8 @@ QueryPlanStepPtr JoinStepLogical::deserialize(Deserialization & ctx)
 
     SortingStep::Settings sort_settings(ctx.settings);
     JoinSettings join_settings(ctx.settings);
+    if (flags & grace_hash_join_initial_buckets_auto_flag)
+        join_settings.grace_hash_join_initial_buckets = 0;
 
     return std::make_unique<JoinStepLogical>(
         std::move(left_header),

--- a/src/Processors/QueryPlan/Optimizations/Optimizations.h
+++ b/src/Processors/QueryPlan/Optimizations/Optimizations.h
@@ -3,6 +3,7 @@
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
 #include <array>
+#include <optional>
 
 class SipHash;
 
@@ -262,6 +263,9 @@ bool convertLogicalJoinToPhysical(
     const QueryPlanOptimizationSettings & optimization_settings);
 
 void optimizeJoinLogical(QueryPlan::Node & node, QueryPlan::Nodes &, const QueryPlanOptimizationSettings &);
+
+/// Estimate rows produced by a completed right-side plan before constructing a legacy-analyzer JOIN.
+std::optional<size_t> estimateReadRowsCountForJoin(QueryPlan::Node & node);
 
 /// A separate tree traverse to apply sorting properties after *InOrder optimizations.
 void applyOrder(const QueryPlanOptimizationSettings & optimization_settings, QueryPlan::Node & root);

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -512,6 +512,11 @@ RelationStats estimateReadRowsCount(QueryPlan::Node & node, const ActionsDAG::No
     return {};
 }
 
+std::optional<size_t> estimateReadRowsCountForJoin(QueryPlan::Node & node)
+{
+    return estimateReadRowsCount(node).estimated_rows;
+}
+
 
 bool optimizeJoinLegacy(QueryPlan::Node & node, QueryPlan::Nodes & /*nodes*/, const QueryPlanOptimizationSettings &)
 {

--- a/src/Processors/QueryPlan/QueryPlanSerializationSettings.cpp
+++ b/src/Processors/QueryPlan/QueryPlanSerializationSettings.cpp
@@ -84,7 +84,7 @@ namespace DB
     DECLARE(UInt64, partial_merge_join_rows_in_right_blocks, 65536, "Limits sizes of right-hand join data blocks in partial merge join algorithm for [JOIN](/reference/statements/select/join) queries.", 0) \
     DECLARE(UInt64, join_on_disk_max_files_to_merge, 64, "Limits the number of files allowed for parallel sorting in MergeJoin operations when they are executed on disk.", 0) \
     \
-    DECLARE(UInt64, grace_hash_join_initial_buckets, 1, "Initial number of grace hash join buckets", 0) \
+    DECLARE(NonZeroUInt64, grace_hash_join_initial_buckets, 1, "Initial number of grace hash join buckets", 0) \
     DECLARE(NonZeroUInt64, grace_hash_join_max_buckets, 1024, "Limit on the number of grace hash join buckets", 0) \
     \
     DECLARE(UInt64, max_bytes_before_external_join, 0, "If set to a non-zero value and `join_algorithm` is `hash`, `parallel_hash`, `default`, or `auto`, the hash join will automatically be converted to grace hash join to enable spilling to disk when the right-side data exceeds this many bytes. When set to 0 (default), automatic spilling is disabled.", 0) \

--- a/src/Processors/QueryPlan/QueryPlanSerializationSettings.cpp
+++ b/src/Processors/QueryPlan/QueryPlanSerializationSettings.cpp
@@ -84,7 +84,7 @@ namespace DB
     DECLARE(UInt64, partial_merge_join_rows_in_right_blocks, 65536, "Limits sizes of right-hand join data blocks in partial merge join algorithm for [JOIN](/reference/statements/select/join) queries.", 0) \
     DECLARE(UInt64, join_on_disk_max_files_to_merge, 64, "Limits the number of files allowed for parallel sorting in MergeJoin operations when they are executed on disk.", 0) \
     \
-    DECLARE(NonZeroUInt64, grace_hash_join_initial_buckets, 1, "Initial number of grace hash join buckets", 0) \
+    DECLARE(UInt64, grace_hash_join_initial_buckets, 1, "Initial number of grace hash join buckets", 0) \
     DECLARE(NonZeroUInt64, grace_hash_join_max_buckets, 1024, "Limit on the number of grace hash join buckets", 0) \
     \
     DECLARE(UInt64, max_bytes_before_external_join, 0, "If set to a non-zero value and `join_algorithm` is `hash`, `parallel_hash`, `default`, or `auto`, the hash join will automatically be converted to grace hash join to enable spilling to disk when the right-side data exceeds this many bytes. When set to 0 (default), automatic spilling is disabled.", 0) \

--- a/src/Processors/QueryPlan/QueryPlanSerializationSettings.cpp
+++ b/src/Processors/QueryPlan/QueryPlanSerializationSettings.cpp
@@ -142,11 +142,6 @@ void QueryPlanSerializationSettings::readBinary(ReadBuffer & in)
     impl->readBinary(in);
 }
 
-bool QueryPlanSerializationSettings::isChanged(std::string_view name) const
-{
-    return impl->isChanged(name);
-}
-
 QUERY_PLAN_SERIALIZATION_SETTINGS_SUPPORTED_TYPES(QueryPlanSerializationSettings, IMPLEMENT_SETTING_SUBSCRIPT_OPERATOR)
 
 }

--- a/src/Processors/QueryPlan/QueryPlanSerializationSettings.cpp
+++ b/src/Processors/QueryPlan/QueryPlanSerializationSettings.cpp
@@ -84,7 +84,7 @@ namespace DB
     DECLARE(UInt64, partial_merge_join_rows_in_right_blocks, 65536, "Limits sizes of right-hand join data blocks in partial merge join algorithm for [JOIN](/reference/statements/select/join) queries.", 0) \
     DECLARE(UInt64, join_on_disk_max_files_to_merge, 64, "Limits the number of files allowed for parallel sorting in MergeJoin operations when they are executed on disk.", 0) \
     \
-    DECLARE(NonZeroUInt64, grace_hash_join_initial_buckets, 1, "Initial number of grace hash join buckets", 0) \
+    DECLARE(UInt64, grace_hash_join_initial_buckets, 0, "Initial number of grace hash join buckets. Zero means automatic", 0) \
     DECLARE(NonZeroUInt64, grace_hash_join_max_buckets, 1024, "Limit on the number of grace hash join buckets", 0) \
     \
     DECLARE(UInt64, max_bytes_before_external_join, 0, "If set to a non-zero value and `join_algorithm` is `hash`, `parallel_hash`, `default`, or `auto`, the hash join will automatically be converted to grace hash join to enable spilling to disk when the right-side data exceeds this many bytes. When set to 0 (default), automatic spilling is disabled.", 0) \

--- a/src/Processors/QueryPlan/QueryPlanSerializationSettings.cpp
+++ b/src/Processors/QueryPlan/QueryPlanSerializationSettings.cpp
@@ -84,7 +84,7 @@ namespace DB
     DECLARE(UInt64, partial_merge_join_rows_in_right_blocks, 65536, "Limits sizes of right-hand join data blocks in partial merge join algorithm for [JOIN](/reference/statements/select/join) queries.", 0) \
     DECLARE(UInt64, join_on_disk_max_files_to_merge, 64, "Limits the number of files allowed for parallel sorting in MergeJoin operations when they are executed on disk.", 0) \
     \
-    DECLARE(UInt64, grace_hash_join_initial_buckets, 0, "Initial number of grace hash join buckets. Zero means automatic", 0) \
+    DECLARE(UInt64, grace_hash_join_initial_buckets, 1, "Initial number of grace hash join buckets", 0) \
     DECLARE(NonZeroUInt64, grace_hash_join_max_buckets, 1024, "Limit on the number of grace hash join buckets", 0) \
     \
     DECLARE(UInt64, max_bytes_before_external_join, 0, "If set to a non-zero value and `join_algorithm` is `hash`, `parallel_hash`, `default`, or `auto`, the hash join will automatically be converted to grace hash join to enable spilling to disk when the right-side data exceeds this many bytes. When set to 0 (default), automatic spilling is disabled.", 0) \
@@ -140,6 +140,11 @@ void QueryPlanSerializationSettings::writeChangedBinary(WriteBuffer & out) const
 void QueryPlanSerializationSettings::readBinary(ReadBuffer & in)
 {
     impl->readBinary(in);
+}
+
+bool QueryPlanSerializationSettings::isChanged(std::string_view name) const
+{
+    return impl->isChanged(name);
 }
 
 QUERY_PLAN_SERIALIZATION_SETTINGS_SUPPORTED_TYPES(QueryPlanSerializationSettings, IMPLEMENT_SETTING_SUBSCRIPT_OPERATOR)

--- a/src/Processors/QueryPlan/QueryPlanSerializationSettings.h
+++ b/src/Processors/QueryPlan/QueryPlanSerializationSettings.h
@@ -4,6 +4,8 @@
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
 
+#include <string_view>
+
 namespace DB
 {
 
@@ -55,6 +57,8 @@ struct QueryPlanSerializationSettings
     void writeChangedBinary(WriteBuffer & out) const;
     /// Read settings updating only those present in the stream; missing ones keep defaults.
     void readBinary(ReadBuffer & in);
+    /// Return whether the setting was explicitly set or read from the serialized representation.
+    bool isChanged(std::string_view name) const;
 
     /// Generated operator[] overloads for each supported type category.
     QUERY_PLAN_SERIALIZATION_SETTINGS_SUPPORTED_TYPES(QueryPlanSerializationSettings, DECLARE_SETTING_SUBSCRIPT_OPERATOR)

--- a/src/Processors/QueryPlan/QueryPlanSerializationSettings.h
+++ b/src/Processors/QueryPlan/QueryPlanSerializationSettings.h
@@ -4,8 +4,6 @@
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
 
-#include <string_view>
-
 namespace DB
 {
 
@@ -57,9 +55,6 @@ struct QueryPlanSerializationSettings
     void writeChangedBinary(WriteBuffer & out) const;
     /// Read settings updating only those present in the stream; missing ones keep defaults.
     void readBinary(ReadBuffer & in);
-    /// Return whether the setting was explicitly set or read from the serialized representation.
-    bool isChanged(std::string_view name) const;
-
     /// Generated operator[] overloads for each supported type category.
     QUERY_PLAN_SERIALIZATION_SETTINGS_SUPPORTED_TYPES(QueryPlanSerializationSettings, DECLARE_SETTING_SUBSCRIPT_OPERATOR)
 

--- a/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.reference
+++ b/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.reference
@@ -1,10 +1,13 @@
 0	UInt64
 planner auto
 10
+legacy planner auto
+10
 explicit value
 10
 runtime auto
 10000
 04665_explicit	2
+04665_legacy_planner_auto	1
 04665_planner_auto	1
 04665_runtime_auto	1

--- a/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.reference
+++ b/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.reference
@@ -1,0 +1,10 @@
+0	UInt64
+planner auto
+10
+explicit value
+10
+runtime auto
+10000
+04665_explicit	2
+04665_planner_auto	8
+04665_runtime_auto	1

--- a/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.reference
+++ b/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.reference
@@ -6,5 +6,5 @@ explicit value
 runtime auto
 10000
 04665_explicit	2
-04665_planner_auto	8
+04665_planner_auto	1
 04665_runtime_auto	1

--- a/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.sql
+++ b/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.sql
@@ -1,3 +1,7 @@
+DROP TABLE IF EXISTS grace_hash_join_auto_initial_buckets_rhs;
+CREATE TABLE grace_hash_join_auto_initial_buckets_rhs (number UInt64) ENGINE = MergeTree ORDER BY number;
+INSERT INTO grace_hash_join_auto_initial_buckets_rhs SELECT number FROM numbers(4000);
+
 SELECT default, type
 FROM system.settings
 WHERE name = 'grace_hash_join_initial_buckets';
@@ -13,7 +17,7 @@ SET join_overflow_mode = 'throw';
 SELECT 'planner auto';
 SELECT count()
 FROM numbers(10) AS lhs
-INNER JOIN numbers(4000) AS rhs USING number
+INNER JOIN grace_hash_join_auto_initial_buckets_rhs AS rhs USING number
 SETTINGS
     grace_hash_join_initial_buckets = 0,
     max_rows_in_join = 1000,
@@ -55,3 +59,5 @@ WHERE
     AND type = 'QueryFinish'
 GROUP BY log_comment
 ORDER BY log_comment;
+
+DROP TABLE grace_hash_join_auto_initial_buckets_rhs;

--- a/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.sql
+++ b/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.sql
@@ -21,7 +21,18 @@ INNER JOIN grace_hash_join_auto_initial_buckets_rhs AS rhs USING number
 SETTINGS
     grace_hash_join_initial_buckets = 0,
     max_rows_in_join = 1000,
+    query_plan_optimize_join_order_limit = 10,
     log_comment = '04665_planner_auto';
+
+SELECT 'legacy planner auto';
+SELECT count()
+FROM numbers(10) AS lhs
+INNER JOIN grace_hash_join_auto_initial_buckets_rhs AS rhs USING number
+SETTINGS
+    allow_experimental_analyzer = 0,
+    grace_hash_join_initial_buckets = 0,
+    max_rows_in_join = 1000,
+    log_comment = '04665_legacy_planner_auto';
 
 SELECT 'explicit value';
 SELECT count()
@@ -49,13 +60,13 @@ SYSTEM FLUSH LOGS query_log;
 
 SELECT
     log_comment,
-    if(log_comment IN ('04665_planner_auto', '04665_runtime_auto'),
+    if(log_comment IN ('04665_planner_auto', '04665_legacy_planner_auto', '04665_runtime_auto'),
         max(ProfileEvents['JoinGraceHashJoinInitialBuckets']) > 1,
         max(ProfileEvents['JoinGraceHashJoinInitialBuckets'])) AS initial_buckets
 FROM system.query_log
 WHERE
     current_database = currentDatabase()
-    AND log_comment IN ('04665_planner_auto', '04665_explicit', '04665_runtime_auto')
+    AND log_comment IN ('04665_planner_auto', '04665_legacy_planner_auto', '04665_explicit', '04665_runtime_auto')
     AND type = 'QueryFinish'
 GROUP BY log_comment
 ORDER BY log_comment;

--- a/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.sql
+++ b/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.sql
@@ -1,0 +1,56 @@
+SELECT default, type
+FROM system.settings
+WHERE name = 'grace_hash_join_initial_buckets';
+
+SET enable_parallel_replicas = 0;
+SET query_plan_join_swap_table = 0;
+SET join_algorithm = 'grace_hash';
+SET grace_hash_join_max_buckets = 64;
+SET max_bytes_in_join = 0;
+SET join_overflow_mode = 'throw';
+
+SELECT 'planner auto';
+SELECT count()
+FROM numbers(10) AS lhs
+INNER JOIN numbers(4000) AS rhs USING number
+SETTINGS
+    grace_hash_join_initial_buckets = 0,
+    max_rows_in_join = 1000,
+    log_comment = '04665_planner_auto';
+
+SELECT 'explicit value';
+SELECT count()
+FROM numbers(10) AS lhs
+INNER JOIN numbers(4000) AS rhs USING number
+SETTINGS
+    grace_hash_join_initial_buckets = 2,
+    max_rows_in_join = 1000,
+    log_comment = '04665_explicit';
+
+SELECT 'runtime auto';
+SELECT count()
+FROM numbers(10000) AS lhs
+INNER JOIN numbers(10000) AS rhs USING number
+SETTINGS
+    join_algorithm = 'hash',
+    max_threads = 1,
+    max_block_size = 1000,
+    grace_hash_join_initial_buckets = 0,
+    max_rows_in_join = 0,
+    max_bytes_before_external_join = 100000,
+    log_comment = '04665_runtime_auto';
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT
+    log_comment,
+    if(log_comment = '04665_runtime_auto',
+        max(ProfileEvents['JoinGraceHashJoinInitialBuckets']) > 1,
+        max(ProfileEvents['JoinGraceHashJoinInitialBuckets'])) AS initial_buckets
+FROM system.query_log
+WHERE
+    current_database = currentDatabase()
+    AND log_comment LIKE '04665_%'
+    AND type = 'QueryFinish'
+GROUP BY log_comment
+ORDER BY log_comment;

--- a/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.sql
+++ b/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.sql
@@ -55,7 +55,7 @@ SELECT
 FROM system.query_log
 WHERE
     current_database = currentDatabase()
-    AND log_comment LIKE '04665_%'
+    AND log_comment IN ('04665_planner_auto', '04665_explicit', '04665_runtime_auto')
     AND type = 'QueryFinish'
 GROUP BY log_comment
 ORDER BY log_comment;

--- a/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.sql
+++ b/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.sql
@@ -49,7 +49,7 @@ SYSTEM FLUSH LOGS query_log;
 
 SELECT
     log_comment,
-    if(log_comment = '04665_runtime_auto',
+    if(log_comment IN ('04665_planner_auto', '04665_runtime_auto'),
         max(ProfileEvents['JoinGraceHashJoinInitialBuckets']) > 1,
         max(ProfileEvents['JoinGraceHashJoinInitialBuckets'])) AS initial_buckets
 FROM system.query_log

--- a/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.sql
+++ b/tests/queries/0_stateless/04665_grace_hash_join_auto_initial_buckets.sql
@@ -4,6 +4,7 @@ WHERE name = 'grace_hash_join_initial_buckets';
 
 SET enable_parallel_replicas = 0;
 SET query_plan_join_swap_table = 0;
+SET collect_hash_table_stats_during_joins = 0;
 SET join_algorithm = 'grace_hash';
 SET grace_hash_join_max_buckets = 64;
 SET max_bytes_in_join = 0;

--- a/tests/queries/0_stateless/04666_grace_hash_join_auto_buffer_budget.reference
+++ b/tests/queries/0_stateless/04666_grace_hash_join_auto_buffer_budget.reference
@@ -1,0 +1,4 @@
+32768
+32768
+04666_planner_auto_buffer_budget	1024
+04666_runtime_rehash_buffer_budget	1

--- a/tests/queries/0_stateless/04666_grace_hash_join_auto_buffer_budget.sql
+++ b/tests/queries/0_stateless/04666_grace_hash_join_auto_buffer_budget.sql
@@ -1,0 +1,52 @@
+DROP TABLE IF EXISTS grace_hash_join_auto_buffer_budget_rhs;
+CREATE TABLE grace_hash_join_auto_buffer_budget_rhs (number UInt64) ENGINE = MergeTree ORDER BY number;
+INSERT INTO grace_hash_join_auto_buffer_budget_rhs SELECT number FROM numbers(32768);
+
+SELECT count()
+FROM numbers(32768) AS lhs
+INNER JOIN grace_hash_join_auto_buffer_budget_rhs AS rhs USING number
+SETTINGS
+    join_algorithm = 'grace_hash',
+    grace_hash_join_initial_buckets = 0,
+    grace_hash_join_max_buckets = 1024,
+    max_rows_in_join = 64,
+    max_bytes_in_join = 0,
+    max_memory_usage = 268435456,
+    max_threads = 1,
+    query_plan_optimize_join_order_limit = 10,
+    query_plan_join_swap_table = 0,
+    collect_hash_table_stats_during_joins = 0,
+    enable_parallel_replicas = 0,
+    log_comment = '04666_planner_auto_buffer_budget';
+
+SELECT count()
+FROM numbers(32768) AS lhs
+INNER JOIN numbers(32768) AS rhs USING number
+SETTINGS
+    join_algorithm = 'grace_hash',
+    grace_hash_join_initial_buckets = 0,
+    grace_hash_join_max_buckets = 1024,
+    max_rows_in_join = 64,
+    max_bytes_in_join = 0,
+    max_memory_usage = 268435456,
+    max_threads = 1,
+    query_plan_optimize_join_order_limit = 10,
+    query_plan_join_swap_table = 0,
+    collect_hash_table_stats_during_joins = 0,
+    enable_parallel_replicas = 0,
+    log_comment = '04666_runtime_rehash_buffer_budget';
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT
+    log_comment,
+    max(ProfileEvents['JoinGraceHashJoinInitialBuckets'])
+FROM system.query_log
+WHERE
+    current_database = currentDatabase()
+    AND log_comment IN ('04666_planner_auto_buffer_budget', '04666_runtime_rehash_buffer_budget')
+    AND type = 'QueryFinish'
+GROUP BY log_comment
+ORDER BY log_comment;
+
+DROP TABLE grace_hash_join_auto_buffer_budget_rhs;

--- a/tests/queries/0_stateless/04666_grace_hash_join_auto_buffer_budget.sql
+++ b/tests/queries/0_stateless/04666_grace_hash_join_auto_buffer_budget.sql
@@ -14,6 +14,7 @@ SETTINGS
     max_memory_usage = 268435456,
     max_threads = 1,
     query_plan_optimize_join_order_limit = 10,
+    query_plan_optimize_join_order_randomize = 0,
     query_plan_join_swap_table = 0,
     collect_hash_table_stats_during_joins = 0,
     enable_parallel_replicas = 0,
@@ -21,7 +22,10 @@ SETTINGS
 
 SELECT count()
 FROM numbers(32768) AS lhs
-INNER JOIN numbers(32768) AS rhs USING number
+INNER JOIN
+(
+    SELECT toUInt64(arrayJoin(range(32768))) AS number
+) AS rhs USING number
 SETTINGS
     join_algorithm = 'grace_hash',
     grace_hash_join_initial_buckets = 0,
@@ -31,6 +35,7 @@ SETTINGS
     max_memory_usage = 268435456,
     max_threads = 1,
     query_plan_optimize_join_order_limit = 10,
+    query_plan_optimize_join_order_randomize = 0,
     query_plan_join_swap_table = 0,
     collect_hash_table_stats_during_joins = 0,
     enable_parallel_replicas = 0,


### PR DESCRIPTION
Use `0` as the automatic value for `grace_hash_join_initial_buckets`. For standalone `GraceHashJoin`, derive the initial power-of-two bucket count from the planner right-side row estimate and `max_rows_in_join`. When `SpillingHashJoin` switches algorithms, combine that row estimate with observed row width and the external-join byte threshold. Explicit positive settings remain unchanged, and the result is clamped by `grace_hash_join_max_buckets`.

This avoids the guaranteed first rehash and reduces repeated right-side re-scattering for large joins.

Closes: https://github.com/ClickHouse/ClickHouse/issues/110522

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Automatically choose the initial number of grace hash join buckets from right-side size estimates, reducing avoidable rehashing and re-scattering during external joins.