### PR TITLE
Docs: redirect 2026 release changelog URLs

### DIFF
--- a/docs/_site/redirects.json
+++ b/docs/_site/redirects.json
@@ -1192,7 +1192,7 @@
     "source": "/changelogs/26.1"
   },
   {
-    "destination": "/resources/changelogs/oss/2026#262",
+    "destination": "/resources/changelogs/cloud/release-notes/26_02",
     "source": "/changelogs/26.2"
   },
   {
@@ -1200,7 +1200,7 @@
     "source": "/changelogs/26.3"
   },
   {
-    "destination": "/resources/changelogs/oss/2026#264",
+    "destination": "/resources/changelogs/cloud/release-notes/26_4",
     "source": "/changelogs/26.4"
   },
   {

--- a/docs/_site/redirects.json
+++ b/docs/_site/redirects.json
@@ -1188,12 +1188,32 @@
     "source": "/changelogs/25.8"
   },
   {
-    "destination": "/resources/changelogs/cloud/release-notes/26_02",
+    "destination": "/resources/changelogs/oss/2026#261",
+    "source": "/changelogs/26.1"
+  },
+  {
+    "destination": "/resources/changelogs/oss/2026#262",
     "source": "/changelogs/26.2"
   },
   {
-    "destination": "/resources/changelogs/cloud/release-notes/26_4",
+    "destination": "/resources/changelogs/oss/2026#263",
+    "source": "/changelogs/26.3"
+  },
+  {
+    "destination": "/resources/changelogs/oss/2026#264",
     "source": "/changelogs/26.4"
+  },
+  {
+    "destination": "/resources/changelogs/oss/2026#265",
+    "source": "/changelogs/26.5"
+  },
+  {
+    "destination": "/resources/changelogs/oss/2026#266",
+    "source": "/changelogs/26.6"
+  },
+  {
+    "destination": "/resources/changelogs/oss/2026#267",
+    "source": "/changelogs/26.7"
   },
   {
     "destination": "/chdb/reference/data-formats",


### PR DESCRIPTION
Redirect the missing legacy `/changelogs/26.1`, `/changelogs/26.3`, and `/changelogs/26.5` through `/changelogs/26.7` URLs to the matching anchors in the 2026 OSS changelog. The existing `/changelogs/26.2` and `/changelogs/26.4` Cloud routes remain unchanged. This fixes 404 responses for OSS release changelog links and keeps existing Cloud rollout links working after the documentation migration.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.575` (included in `26.8` and later)
<!-- ch-version-info:end -->