### PR TITLE
CI: tighten functional and integration test failure allowance to 1

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -1352,7 +1352,7 @@ def main():
     force_ok_exit = False
     if test_result:
         failures_cnt = len([r for r in test_result.results if not r.is_ok()])
-        if failures_cnt > 0 and failures_cnt < 4:
+        if failures_cnt > 0 and failures_cnt < 2:
             print(
                 f"NOTE: Failed {failures_cnt} tests - do not block pipeline, exit with 0"
             )

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -1477,7 +1477,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
     force_ok_exit = False
     if R:
         failures_cnt = len([r for r in R.results if not r.is_ok()])
-        if failures_cnt > 0 and failures_cnt < 4:
+        if failures_cnt > 0 and failures_cnt < 2:
             print(
                 f"NOTE: Failed {failures_cnt} tests - do not block pipeline, exit with 0"
             )


### PR DESCRIPTION
Tighten the test-failure allowance in the functional and integration test jobs.

Previously both jobs did not block the pipeline when up to 3 tests failed (`failures_cnt < 4`). This change lowers the allowance so that only a single failure is tolerated (`failures_cnt < 2`) before the pipeline is blocked. The existing `ci-non-blocking` label override is unchanged.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.913` (included in `26.8` and later)
<!-- ch-version-info:end -->