### PR TITLE
Resolve an unqualified matcher inside a lambda from the query scope in PREWHERE

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -1902,8 +1902,12 @@ void QueryAnalyzer::updateMatchedColumnsFromJoinUsing(
 
                 matched_column_node->as<ColumnNode &>().setColumnType(using_column_type);
                 correctColumnExpressionType(matched_column_node->as<ColumnNode &>(), scope.context);
+                /// Register the undo entry on the query scope whose join tree the type came from, the same
+                /// scope every join-state read above already uses. A matcher in a lambda body resolves
+                /// through a fresh child scope, and the PREWHERE rollback only consults the query scope,
+                /// so an entry left on the child scope would never be applied.
                 if (!matched_column_node->isEqual(*join_using_column_nodes.at(0)))
-                    scope.join_columns_with_changed_types[matched_column_node] = join_using_column_nodes.at(0);
+                    nearest_query_scope->join_columns_with_changed_types[matched_column_node] = join_using_column_nodes.at(0);
             }
         }
     }
@@ -2228,7 +2232,12 @@ QueryAnalyzer::QueryTreeNodesWithNames QueryAnalyzer::resolveUnqualifiedMatcher(
               *
               * Example: SELECT id FROM test_table_1 AS t1 INNER JOIN test_table_2 AS t2 USING (id);
               */
-            if (scope.allow_resolve_from_using && !table_expression_in_resolve_process && join_node->isUsingJoinExpression())
+            /// The flag lives on the query scope whose join tree is expanded here, not on the current
+            /// scope: a matcher in a lambda body (`arrayMap(x -> *, ...)`) resolves through a fresh
+            /// child scope that does not inherit the flag, so it would see the default `true` and
+            /// substitute the merged USING key even inside PREWHERE, where the physical read still
+            /// supplies the table's own column.
+            if (nearest_query_scope->allow_resolve_from_using && !table_expression_in_resolve_process && join_node->isUsingJoinExpression())
             {
                 auto & join_using_list = join_node->getJoinExpression()->as<ListNode &>();
 

--- a/src/Analyzer/Resolve/ReplaceColumnsVisitor.h
+++ b/src/Analyzer/Resolve/ReplaceColumnsVisitor.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <Analyzer/InDepthQueryTreeVisitor.h>
+#include <Analyzer/LambdaNode.h>
 #include <Analyzer/Utils.h>
+#include <DataTypes/DataTypeFunction.h>
 #include <fmt/ranges.h>
 
 namespace DB
@@ -49,7 +51,22 @@ public:
             node = replacement_node;
 
         if (auto * function_node = node->as<FunctionNode>(); function_node && function_node->isResolved())
+        {
             rerunFunctionResolve(function_node, context);
+        }
+        else if (auto * lambda_node = node->as<LambdaNode>())
+        {
+            /// The lambda caches its own result type, so replacing a column inside its body leaves that
+            /// cache stale and the mismatch resurfaces later as a header type mismatch. Recompute it from
+            /// the rewritten body, keeping the argument types.
+            const auto * lambda_type = typeid_cast<const DataTypeFunction *>(lambda_node->getResultType().get());
+            if (!lambda_type)
+                throw Exception(ErrorCodes::LOGICAL_ERROR,
+                    "Lambda node {} result type is not a function type",
+                    lambda_node->formatASTForErrorMessage());
+
+            lambda_node->resolve(std::make_shared<DataTypeFunction>(lambda_type->getArgumentTypes(), lambda_node->getExpression()->getResultType()));
+        }
     }
 
     /// We want to re-run resolve for function _after_ its arguments are replaced
@@ -57,11 +74,15 @@ public:
 
     bool needChildVisit(QueryTreeNodePtr & /* parent */, QueryTreeNodePtr & child)
     {
-        /// Visit only expressions, but not subqueries
+        /// Visit only expressions, but not subqueries.
+        /// LAMBDA is an expression too: a matcher inside a lambda body (`arrayMap(x -> *, ...)`) is
+        /// rewritten by the same JOIN type corrections as one outside it, so the replacement must reach
+        /// it, otherwise the registered entry is never applied.
         return child->getNodeType() == QueryTreeNodeType::IDENTIFIER
             || child->getNodeType() == QueryTreeNodeType::LIST
             || child->getNodeType() == QueryTreeNodeType::FUNCTION
-            || child->getNodeType() == QueryTreeNodeType::COLUMN;
+            || child->getNodeType() == QueryTreeNodeType::COLUMN
+            || child->getNodeType() == QueryTreeNodeType::LAMBDA;
     }
 
 private:

--- a/tests/queries/0_stateless/04683_matcher_in_lambda_join_using_supertype.reference
+++ b/tests/queries/0_stateless/04683_matcher_in_lambda_join_using_supertype.reference
@@ -1,0 +1,74 @@
+int inner
+11	1	10
+int inner direct oracle
+11	1	10
+int lambda expansion equals direct expansion	1
+int direct expansion	1
+int left
+11	1	10
+int right
+11	1	10
+int full lambda expansion equals direct expansion	1
+int full direct expansion	1
+arrayFilter
+1
+arrayExists
+1
+arraySort
+11	1	10
+nested lambda
+11	1	10
+using alias
+11	1	10
+COLUMNS matcher
+11	1	10
+natural join
+1	10
+multi column matcher in one argument lambda
+WHERE keeps the supertype
+Array(Tuple(UInt64, Int16))
+qualified matcher
+11	1	10
+explicit columns
+Array(Tuple(UInt64, Int16))
+bare key column
+11	1	10
+matcher excluding the key
+Array(Tuple(Int16))
+APPLY transformer
+Array(Tuple(String, String))
+matcher in the select list
+Array(Tuple(UInt64, Int16))
+top level identifier compatibility	1
+join_use_nulls with USING
+1
+join_use_nulls with ON, bare column
+1
+lambda argument is not replaced
+1
+lambda argument beside a matcher
+1
+subquery in PREWHERE keeps its own supertype
+Array(Tuple(UInt64, Int16))
+subquery inside a lambda is not visited
+1
+LowCardinality(String) against String
+11	1	10
+LowCardinality lambda expansion equals direct expansion	1
+LowCardinality direct expansion	1
+LowCardinality(Nullable(String)) against String
+11	1	10
+String against Nullable(String)
+11	1	10
+multi key USING
+11	1	2	10
+no join
+1	10
+cross join
+1
+three tables qualified matcher
+Array(Tuple(Int8, Int16))
+three tables unqualified matcher
+Array(Tuple(UInt64, Int8))
+three tables unqualified matcher direct oracle
+Tuple(UInt64, Int8)

--- a/tests/queries/0_stateless/04683_matcher_in_lambda_join_using_supertype.reference
+++ b/tests/queries/0_stateless/04683_matcher_in_lambda_join_using_supertype.reference
@@ -42,6 +42,12 @@ Array(Tuple(UInt64, Int16))
 top level identifier compatibility	1
 join_use_nulls with USING
 1
+join_use_nulls widens the lambda body, right	1
+join_use_nulls widens the lambda body, right direct oracle	1
+join_use_nulls widens the lambda body, right value
+1
+join_use_nulls widens the lambda body, full value
+1
 join_use_nulls with ON, bare column
 1
 lambda argument is not replaced

--- a/tests/queries/0_stateless/04683_matcher_in_lambda_join_using_supertype.sql
+++ b/tests/queries/0_stateless/04683_matcher_in_lambda_join_using_supertype.sql
@@ -1,0 +1,237 @@
+-- An unqualified matcher inside a lambda body in PREWHERE over JOIN USING must expand to each
+-- table's own columns, exactly like the same matcher written directly in PREWHERE. Before the fix
+-- it expanded to the merged USING key instead, so the header declared the supertype while the read
+-- supplied the table's own column, and the server aborted with a LOGICAL_ERROR.
+--
+-- The oracle is the DIRECT (non-lambda) matcher in PREWHERE, which is correct on master. It is read
+-- through EXPLAIN QUERY TREE, never through toTypeName: toTypeName constant-folds during analysis,
+-- before the PREWHERE type rollback runs, so it reports the pre-rollback type for both forms.
+
+SET enable_analyzer = 1;
+
+-- 1. The wrapper-free carrier: UInt32 vs UInt64. No LowCardinality, no Nullable.
+
+DROP TABLE IF EXISTS r1;
+DROP TABLE IF EXISTS r2;
+CREATE TABLE r1 (`a` UInt32, `v` Int16) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+CREATE TABLE r2 (`a` UInt64, `w` UInt64) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+INSERT INTO r1 VALUES (1, 10);
+INSERT INTO r2 VALUES (1, 11);
+
+SELECT 'int inner';
+SELECT w, a, v FROM r1 INNER JOIN r2 USING (a) PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).2) != 0;
+SELECT 'int inner direct oracle';
+SELECT w, a, v FROM r1 INNER JOIN r2 USING (a) PREWHERE ((tuple(* EXCEPT w)).2) != 0;
+
+-- The load-bearing assertion: the lambda expansion must have the SAME type as the direct one.
+-- Both must print 1.
+SELECT 'int lambda expansion equals direct expansion', countIf(explain LIKE '%function_name: tuple, function_type: ordinary, result_type: Tuple(UInt32, Int16, UInt32)%')
+FROM (EXPLAIN QUERY TREE run_passes = 1
+    SELECT w, a, v FROM r1 INNER JOIN r2 USING (a) PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).2) != 0);
+SELECT 'int direct expansion', countIf(explain LIKE '%function_name: tuple, function_type: ordinary, result_type: Tuple(UInt32, Int16, UInt32)%')
+FROM (EXPLAIN QUERY TREE run_passes = 1
+    SELECT w, a, v FROM r1 INNER JOIN r2 USING (a) PREWHERE ((tuple(* EXCEPT w)).2) != 0);
+
+SELECT 'int left';
+SELECT w, a, v FROM r1 LEFT JOIN r2 USING (a) PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).2) != 0;
+SELECT 'int right';
+SELECT w, a, v FROM r1 RIGHT JOIN r2 USING (a) PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).2) != 0;
+
+-- FULL JOIN did not abort before the fix, but the lambda body expanded to the merged key while the
+-- direct form kept the table's own column. Pin the type-level agreement only; the values agree on
+-- both sides, so there is no wrong-answer claim here.
+SELECT 'int full lambda expansion equals direct expansion', countIf(explain LIKE '%function_name: tuple, function_type: ordinary, result_type: Tuple(UInt32, Int16, UInt32)%')
+FROM (EXPLAIN QUERY TREE run_passes = 1
+    SELECT w, a, v FROM r1 FULL JOIN r2 USING (a) PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).2) != 0);
+SELECT 'int full direct expansion', countIf(explain LIKE '%function_name: tuple, function_type: ordinary, result_type: Tuple(UInt32, Int16, UInt32)%')
+FROM (EXPLAIN QUERY TREE run_passes = 1
+    SELECT w, a, v FROM r1 FULL JOIN r2 USING (a) PREWHERE ((tuple(* EXCEPT w)).2) != 0);
+
+-- 5. Every higher-order function reaches this through the one shared lambda resolution path.
+SELECT 'arrayFilter';
+SELECT length(arrayFilter(z -> ((tuple(* EXCEPT w).2) != 0), [1])) FROM r1 INNER JOIN r2 USING (a)
+PREWHERE (arrayFilter(z -> ((tuple(* EXCEPT w).2) != 0), [1])[1]) = 1;
+SELECT 'arrayExists';
+SELECT 1 FROM r1 INNER JOIN r2 USING (a) PREWHERE arrayExists(z -> ((tuple(* EXCEPT w).2) != 0), [1]);
+SELECT 'arraySort';
+SELECT w, a, v FROM r1 INNER JOIN r2 USING (a) PREWHERE (arraySort(z -> (tuple(* EXCEPT w).2), [1])[1]) = 1;
+SELECT 'nested lambda';
+SELECT w, a, v FROM r1 INNER JOIN r2 USING (a)
+PREWHERE ((arrayMap(y -> (arrayMap(z -> tuple(* EXCEPT w), [1])[1]), [1])[1]).2) != 0;
+
+-- 6. Matcher spellings and USING shapes.
+SELECT 'using alias';
+SELECT w, a, v FROM r1 INNER JOIN r2 USING (a AS a) PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).2) != 0;
+SELECT 'COLUMNS matcher';
+SELECT w, a, v FROM r1 INNER JOIN r2 USING (a) PREWHERE ((arrayMap(z -> tuple(COLUMNS('a|v')), [1])[1]).2) != 0;
+SELECT 'natural join';
+SELECT a, v FROM r1 NATURAL INNER JOIN r2 PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).2) != 0;
+
+-- A bare multi-column matcher in a single-argument lambda position is a user error, the same one a
+-- join-free query reports. Before the fix it aborted the server instead.
+SELECT 'multi column matcher in one argument lambda';
+SELECT w, a, v FROM r1 INNER JOIN r2 USING (a)
+PREWHERE ((arrayMap(z -> (* EXCEPT (v, w)), [1])[1]).2) != 0; -- { serverError UNSUPPORTED_METHOD }
+
+-- 8. Already correct before the fix, must stay unchanged.
+SELECT 'WHERE keeps the supertype';
+SELECT toTypeName(arrayMap(z -> tuple(* EXCEPT w), [1])) FROM r1 INNER JOIN r2 USING (a) WHERE v != 0;
+SELECT 'qualified matcher';
+SELECT w, r1.a, v FROM r1 INNER JOIN r2 USING (a) PREWHERE ((arrayMap(z -> tuple(r1.*), [1])[1]).1) != 0;
+SELECT 'explicit columns';
+SELECT toTypeName(arrayMap(z -> tuple(a, v), [1])) FROM r1 INNER JOIN r2 USING (a) PREWHERE v != 0;
+SELECT 'bare key column';
+SELECT w, a, v FROM r1 INNER JOIN r2 USING (a) PREWHERE (arrayMap(z -> a, [1])[1]) = 1;
+SELECT 'matcher excluding the key';
+SELECT toTypeName(arrayMap(z -> tuple(* EXCEPT (a, w)), [1])) FROM r1 INNER JOIN r2 USING (a) PREWHERE v != 0;
+SELECT 'APPLY transformer';
+SELECT toTypeName(arrayMap(z -> tuple(* EXCEPT w APPLY toString), [1])) FROM r1 INNER JOIN r2 USING (a) PREWHERE v != 0;
+SELECT 'matcher in the select list';
+SELECT toTypeName(arrayMap(z -> tuple(* EXCEPT w), [1])) FROM r1 INNER JOIN r2 USING (a);
+-- With analyzer_compatibility_join_using_top_level_identifier the USING key comes from the SELECT
+-- projection, so the helper returns before touching the matched column's type. Read the resolved
+-- expansion directly: it must stay at the projection's type on both sides of the fix.
+SELECT 'top level identifier compatibility', countIf(explain LIKE '%function_name: tuple, function_type: ordinary, result_type: Tuple(UInt64, Int16)%')
+FROM (EXPLAIN QUERY TREE run_passes = 1
+    SELECT a + 1 AS a, arrayMap(z -> tuple(* EXCEPT w), [1]) FROM r1 INNER JOIN r2 USING (a)
+    SETTINGS analyzer_compatibility_join_using_top_level_identifier = 1);
+
+-- 9. The rollback now descends into lambda bodies for every writer of the replacement map, so cover
+-- the other channels too: join_use_nulls, an empty map, a lambda argument, and a lambda subquery.
+SELECT 'join_use_nulls with USING';
+SELECT count() FROM r1 LEFT JOIN r2 USING (a)
+PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).2) != 0 SETTINGS join_use_nulls = 1;
+SELECT 'join_use_nulls with ON, bare column';
+SELECT count() FROM r1 LEFT JOIN r2 ON r1.a = r2.a
+PREWHERE (arrayMap(z -> v, [1])[1]) != 0 SETTINGS join_use_nulls = 1;
+SELECT 'lambda argument is not replaced';
+SELECT count() FROM r1 INNER JOIN r2 USING (a) PREWHERE (arrayMap(z -> z + v, [1])[1]) != 0;
+SELECT 'lambda argument beside a matcher';
+SELECT count() FROM r1 INNER JOIN r2 USING (a)
+PREWHERE ((arrayMap(z -> tuple(z, * EXCEPT w), [1])[1]).3) != 0;
+
+DROP TABLE IF EXISTS s1;
+CREATE TABLE s1 (`k` UInt32, `p` Int16) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+DROP TABLE IF EXISTS s2;
+CREATE TABLE s2 (`k` UInt64, `q` UInt64) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+INSERT INTO s1 VALUES (1, 10);
+INSERT INTO s2 VALUES (1, 11);
+
+-- A subquery in PREWHERE keeps its own USING supertype: the flag is read from the nearest query
+-- scope, which for the inner matcher is the subquery, not the outer PREWHERE.
+SELECT 'subquery in PREWHERE keeps its own supertype';
+SELECT (SELECT toTypeName(arrayMap(z -> tuple(* EXCEPT q), [1])) FROM s1 INNER JOIN s2 USING (k))
+FROM r1 INNER JOIN r2 USING (a) PREWHERE v != 0;
+SELECT 'subquery inside a lambda is not visited';
+SELECT count() FROM r1 INNER JOIN r2 USING (a) PREWHERE (arrayMap(z -> (SELECT max(p) FROM s1), [1])[1]) != 0;
+
+DROP TABLE s1;
+DROP TABLE s2;
+DROP TABLE r1;
+DROP TABLE r2;
+
+-- 3. Wrapper carriers, including the original CI signature and the inverted mismatch.
+
+DROP TABLE IF EXISTS lc1;
+DROP TABLE IF EXISTS lc2;
+CREATE TABLE lc1 (`a` LowCardinality(String), `v` Int16) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+CREATE TABLE lc2 (`a` String, `w` UInt64) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+INSERT INTO lc1 VALUES ('1', 10);
+INSERT INTO lc2 VALUES ('1', 11);
+
+SELECT 'LowCardinality(String) against String';
+SELECT w, a, v FROM lc1 INNER JOIN lc2 USING (a) PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).1) != '';
+SELECT 'LowCardinality lambda expansion equals direct expansion', countIf(explain LIKE '%function_name: tuple, function_type: ordinary, result_type: Tuple(LowCardinality(String), Int16, LowCardinality(String))%')
+FROM (EXPLAIN QUERY TREE run_passes = 1
+    SELECT w, a, v FROM lc1 INNER JOIN lc2 USING (a) PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).1) != '');
+SELECT 'LowCardinality direct expansion', countIf(explain LIKE '%function_name: tuple, function_type: ordinary, result_type: Tuple(LowCardinality(String), Int16, LowCardinality(String))%')
+FROM (EXPLAIN QUERY TREE run_passes = 1
+    SELECT w, a, v FROM lc1 INNER JOIN lc2 USING (a) PREWHERE ((tuple(* EXCEPT w)).1) != '');
+
+DROP TABLE lc1;
+DROP TABLE lc2;
+
+DROP TABLE IF EXISTS lcn1;
+DROP TABLE IF EXISTS lcn2;
+CREATE TABLE lcn1 (`a` LowCardinality(Nullable(String)), `v` Int16) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+CREATE TABLE lcn2 (`a` String, `w` UInt64) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+INSERT INTO lcn1 VALUES ('1', 10);
+INSERT INTO lcn2 VALUES ('1', 11);
+SELECT 'LowCardinality(Nullable(String)) against String';
+SELECT w, a, v FROM lcn1 INNER JOIN lcn2 USING (a) PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).2) != 0;
+DROP TABLE lcn1;
+DROP TABLE lcn2;
+
+DROP TABLE IF EXISTS inv1;
+DROP TABLE IF EXISTS inv2;
+CREATE TABLE inv1 (`a` String, `v` Int16) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+CREATE TABLE inv2 (`a` Nullable(String), `w` UInt64) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+INSERT INTO inv1 VALUES ('1', 10);
+INSERT INTO inv2 VALUES ('1', 11);
+-- Here the supertype is WIDER than the left column, so the mismatch is inverted.
+SELECT 'String against Nullable(String)';
+SELECT w, a, v FROM inv1 INNER JOIN inv2 USING (a) PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).2) != 0;
+DROP TABLE inv1;
+DROP TABLE inv2;
+
+-- 6. Multi key USING.
+
+DROP TABLE IF EXISTS m1;
+DROP TABLE IF EXISTS m2;
+CREATE TABLE m1 (`a` UInt32, `b` UInt32, `v` Int16) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+CREATE TABLE m2 (`a` UInt64, `b` UInt64, `w` UInt64) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+INSERT INTO m1 VALUES (1, 2, 10);
+INSERT INTO m2 VALUES (1, 2, 11);
+SELECT 'multi key USING';
+SELECT w, a, b, v FROM m1 INNER JOIN m2 USING (a, b) PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).3) != 0;
+DROP TABLE m1;
+DROP TABLE m2;
+
+-- 9. A CROSS JOIN and a join-free query leave the replacement map empty, so the wider descent must
+-- be a no-op there.
+
+DROP TABLE IF EXISTS n1;
+CREATE TABLE n1 (`a` UInt32, `v` Int16) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+INSERT INTO n1 VALUES (1, 10);
+SELECT 'no join';
+SELECT a, v FROM n1 PREWHERE ((arrayMap(z -> tuple(*), [1])[1]).2) != 0;
+
+DROP TABLE IF EXISTS c1;
+CREATE TABLE c1 (`id` Int8, `z` Int16) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+INSERT INTO c1 VALUES (1, 3);
+SELECT 'cross join';
+SELECT count() FROM n1 CROSS JOIN c1 PREWHERE ((arrayMap(w -> tuple(n1.*), [1])[1]).2) != 0;
+
+-- Three tables, a USING join beside a CROSS JOIN: the qualified matcher path is untouched, and an
+-- unqualified matcher there keeps expanding to each table's own columns.
+DROP TABLE IF EXISTS n2;
+CREATE TABLE n2 (`a` UInt64, `y` Int16) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+INSERT INTO n2 VALUES (1, 2);
+SELECT 'three tables qualified matcher';
+SELECT toTypeName(arrayMap(w -> tuple(c1.*), [1])) FROM n1 INNER JOIN n2 USING (a) CROSS JOIN c1
+PREWHERE c1.z != 0;
+SELECT 'three tables unqualified matcher';
+SELECT toTypeName(arrayMap(w -> tuple(* EXCEPT (v, y, z)), [1])) FROM n1 INNER JOIN n2 USING (a) CROSS JOIN c1
+PREWHERE c1.z != 0;
+SELECT 'three tables unqualified matcher direct oracle';
+SELECT toTypeName(tuple(* EXCEPT (v, y, z))) FROM n1 INNER JOIN n2 USING (a) CROSS JOIN c1
+PREWHERE c1.z != 0;
+
+DROP TABLE n1;
+DROP TABLE n2;
+DROP TABLE c1;

--- a/tests/queries/0_stateless/04683_matcher_in_lambda_join_using_supertype.sql
+++ b/tests/queries/0_stateless/04683_matcher_in_lambda_join_using_supertype.sql
@@ -99,10 +99,30 @@ FROM (EXPLAIN QUERY TREE run_passes = 1
     SETTINGS analyzer_compatibility_join_using_top_level_identifier = 1);
 
 -- 9. The rollback now descends into lambda bodies for every writer of the replacement map, so cover
--- the other channels too: join_use_nulls, an empty map, a lambda argument, and a lambda subquery.
+-- the other channels too: the nullability writer, an empty map, a lambda argument, and a lambda
+-- subquery. The nullability cases need a NON-PRESERVED side, so the lambda body reads a column the
+-- join actually widens: under LEFT JOIN both `a` and `v` come from the preserved left table and stay
+-- non-Nullable, which is why the supertype carrier below is the only thing a LEFT shape can assert.
 SELECT 'join_use_nulls with USING';
 SELECT count() FROM r1 LEFT JOIN r2 USING (a)
 PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).2) != 0 SETTINGS join_use_nulls = 1;
+-- RIGHT/FULL make the LEFT table's `v` the non-preserved one, so the map really carries a
+-- Nullable(Int16) entry for it. Assert the resolved type, not just the row count: the lambda body
+-- must converge on the direct form's Int16 after the rollback, and print 1 twice.
+SELECT 'join_use_nulls widens the lambda body, right', countIf(explain LIKE '%column_name: v, result_type: Int16%')
+FROM (EXPLAIN QUERY TREE run_passes = 1
+    SELECT count() FROM r1 RIGHT JOIN r2 USING (a)
+    PREWHERE (arrayMap(z -> v, [1])[1]) != 0 SETTINGS join_use_nulls = 1);
+SELECT 'join_use_nulls widens the lambda body, right direct oracle', countIf(explain LIKE '%column_name: v, result_type: Int16%')
+FROM (EXPLAIN QUERY TREE run_passes = 1
+    SELECT count() FROM r1 RIGHT JOIN r2 USING (a)
+    PREWHERE v != 0 SETTINGS join_use_nulls = 1);
+SELECT 'join_use_nulls widens the lambda body, right value';
+SELECT count() FROM r1 RIGHT JOIN r2 USING (a)
+PREWHERE (arrayMap(z -> v, [1])[1]) != 0 SETTINGS join_use_nulls = 1;
+SELECT 'join_use_nulls widens the lambda body, full value';
+SELECT count() FROM r1 FULL JOIN r2 USING (a)
+PREWHERE (arrayMap(z -> v, [1])[1]) != 0 SETTINGS join_use_nulls = 1;
 SELECT 'join_use_nulls with ON, bare column';
 SELECT count() FROM r1 LEFT JOIN r2 ON r1.a = r2.a
 PREWHERE (arrayMap(z -> v, [1])[1]) != 0 SETTINGS join_use_nulls = 1;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/111993


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a `LOGICAL_ERROR` (`Unexpected return type from tuple`) when an unqualified matcher such as `*` or `* EXCEPT c` appears inside a lambda body in `PREWHERE` over a `JOIN ... USING (k)` whose merged key type differs from the left table's own `k`. The query failed, and the server aborted in debug and sanitizer builds.


### Description

`SELECT w, a, v FROM r1 INNER JOIN r2 USING (a) PREWHERE ((arrayMap(z -> tuple(* EXCEPT w), [1])[1]).2) != 0` fails with `Unexpected return type from tuple. Expected Tuple(UInt64, Int16). Got Tuple(UInt32, Int16)` when `r1.a` is `UInt32` and `r2.a` is `UInt64`, and aborts the server in debug and sanitizer builds. Any MergeTree read with that shape is hit. It is not `LowCardinality`-specific: the only condition is that the `USING` supertype differs from the left column's own type, and with `String` against `Nullable(String)` the mismatch is inverted.

Found by `AST fuzzer (amd_debug, targeted, old_compatibility)`, STID `3262-472c`, on #111993 ([CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111993&sha=d3ec18e7b0303191d03f9e3b29cbaf05a16843db&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%2C%20old_compatibility%29)); it reproduces on pristine master, so that PR did not cause it.

The flag meaning "you are inside `PREWHERE`, do not rewrite a matched column to the merged `USING` key" is set on the query scope, and `IdentifierResolveScope`'s constructor does not propagate it, so a lambda body resolved in a fresh child scope saw its default and both `resolveUnqualifiedMatcher` rewrite sites fired. This reads the flag, and registers the retype's undo entry, on the join-owning scope the helper's other join-state accesses already use. An undo entry only helps if something applies it, so `ReplaceColumnsVisitor` now descends into a lambda body and refreshes the lambda's cached result type, mirroring `convertNestedGroupByKeysToNullable`.

#111993 suppresses `PREWHERE` promotion instead of rolling it back; that is unavailable here, since the merged key is how a bare `k` resolves under `USING` and suppressing the retype breaks the non-lambda matcher in `PREWHERE`, which works today. The `ON`-join sibling reporting `Cannot capture column` is promoted at a third site and is not fixed here.

Validated on a debug build: 15 carriers fail before and pass after, the lambda expansion now matches the direct matcher node for node, three mutations each redden the new test, and a 219-test sweep is clean.