### PR TITLE
Backport the runtime TSAN suppression for `NonblockingBoundedQueue` to 26.5

### DIFF
--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -64,6 +64,22 @@ const char * __tsan_default_options()
 {
     return "halt_on_error=1 abort_on_error=1 history_size=7 second_deadlock_stack=1 max_allocation_size_mb=32768";
 }
+const char * __tsan_default_suppressions()
+{
+    /// The release/acquire handoff on `slot.pos` orders every access to a slot payload, so the
+    /// reports these entries suppress are not real races (see the comment in
+    /// Common/NonblockingBoundedQueue.h). A function attribute cannot suppress them, because the
+    /// element type's implicitly generated move assignment is a separate, still-instrumented
+    /// function, and the attribute additionally prevents it from being inlined.
+    ///
+    /// Only `tryPush` is listed: the `dequeue_pos` compare-exchange gives one consumer sole
+    /// ownership of a slot before the move-out in `tryPop`, so every reported pair contains the
+    /// `tryPush` write. Patterns are matched against each frame's function, file and module name,
+    /// so an unqualified name would also match the queue header's own file name. Keep them narrow:
+    /// a `race:` entry also hides heap-use-after-free reports through the frame it names.
+    return "race:^NonblockingBoundedQueue<DB::KeeperRequestForSession>::tryPush\n"
+           "race:^NonblockingBoundedQueue<DB::KeeperResponseForSession>::tryPush\n";
+}
 #endif
 
 #ifdef UNDEFINED_BEHAVIOR_SANITIZER

--- a/src/Common/NonblockingBoundedQueue.h
+++ b/src/Common/NonblockingBoundedQueue.h
@@ -79,6 +79,19 @@ public:
     }
 
     /// `value` is moved-out iff the return value is true.
+    ///
+    /// TSAN very rarely reports a data race between the `slot.value` write in `tryPush` and the
+    /// `slot.value` read in `tryPop`, even though the acquire/release operations on `slot.pos`
+    /// make such a race impossible (the code is isomorphic to Vyukov's original implementation).
+    /// Those reports are suppressed at runtime, per instantiation, by
+    /// `__tsan_default_suppressions` in programs/main.cpp. A `NO_SANITIZE_THREAD` attribute here
+    /// does not work: the reported access happens in the element type's move assignment, which is
+    /// a separate function that stays instrumented.
+    ///
+    /// The suppression lists only `tryPush`. `tryPop` writes the payload too (it moves out of
+    /// `slot.value`), but the `dequeue_pos` CAS gives one consumer sole ownership of a slot before
+    /// the move-out, so two pops never touch one payload concurrently, whatever the consumer count.
+    /// A `tryPop` entry would be dead, and would also hide heap-use-after-free through that frame.
     bool tryPush(T && value)
     {
         chassert(mask);


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

Related: https://github.com/ClickHouse/ClickHouse/pull/112695
Related: https://github.com/ClickHouse/ClickHouse/pull/112722

### Description

Every `26.5` pull request keeps failing the TSan integration shards with `Sanitizer assert found for instance zoo3-1`. The Keeper container log carries a ThreadSanitizer data race between the slot payload write in `NonblockingBoundedQueue<DB::KeeperResponseForSession>::tryPush` and the read in `tryPop`. The release/acquire handoff on `slot.pos` orders every access to a slot payload, so the report is a false positive. Most recent instance: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112722&sha=21ba2dbcf7a5d9e1a4f1e1357677f5429f121040&name_0=BackportPR&name_1=Integration%20tests%20%28amd_tsan%2C%203%2F6%29

master fixed this in #112695 by registering the two anchored `tryPush` patterns through `__tsan_default_suppressions`. A function attribute cannot suppress these reports: the reported access happens in the element type's implicitly generated move assignment, a separate function that stays instrumented.

That fix cannot be cherry-picked here, which is why I authored the backport by hand: `base/base/sanitizer_options.h` does not exist on this branch, so the hook goes beside the existing `__tsan_default_options` in `programs/main.cpp`, inside the same `#ifdef THREAD_SANITIZER` block. The change is purely additive: #107083, which added the attributes #112695 removed as ineffective, was never backported either, so there is nothing to delete.

Only `tryPush` is listed. `tryPop` writes the payload too, but the `dequeue_pos` compare-exchange gives one consumer sole ownership of a slot before the move-out, so two pops never touch one payload concurrently, whatever the consumer count. A `tryPop` entry would be dead, and a `race:` entry also hides heap-use-after-free reports through the frame it names. `26.5` has exactly two instantiations of the queue, both in `KeeperRequestDispatcher`, so the two patterns cover it completely.

Sanitizer builds only: outside `THREAD_SANITIZER` the hook is preprocessed away, and inside it is one `const char *` return read once at sanitizer init. The queue header change is a comment. There is no new test, matching #112695: the only end-to-end oracle is the TSan integration shards going quiet, which is a CI-side property over many runs.