### PR TITLE
Keep the valueless `SETTINGS` form out of the AST JSON round trip and secret detection

### DIFF
--- a/src/Parsers/ASTSetQuery.cpp
+++ b/src/Parsers/ASTSetQuery.cpp
@@ -117,8 +117,10 @@ void ASTSetQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & format, 
 
             if (change.name == format_avro_schema_registry_url)
             {
-                auto uri_string = change.value.safeGet<String>();
-                if (!maskURIPassword(&uri_string))
+                /// Matches `hasSecretParts`: a non-String value cannot embed a URI password, and the
+                /// AST JSON path can carry any `Field` type here.
+                String uri_string;
+                if (!change.value.tryGet<String>(uri_string) || !maskURIPassword(&uri_string))
                     return false;
 
                 ostr << " = '" << uri_string << "'";
@@ -308,16 +310,12 @@ void ASTSetQuery::readJSON(const Poco::JSON::Object & json)
             if (!value_obj)
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Missing 'value' object at index {} in 'changes' array during AST JSON deserialization", i);
             change.value = JSONObjectReader::readFieldFromObject(*value_obj);
-            /// The parser only ever pairs the flag with Bool `true`, and both `formatImpl` and
-            /// `hasSecretParts` skip the value of a valueless setting on that basis. Reject any other
-            /// pairing here so a crafted payload cannot hide a real value (a secret one, in
-            /// particular) from formatting and from the query log behind the flag.
-            if (change.shorthand && change.value != Field(true))
-                throw Exception(
-                    ErrorCodes::BAD_ARGUMENTS,
-                    "Setting '{}' is marked as valueless but its value is not `true` "
-                    "during AST JSON deserialization",
-                    change.name);
+            /// A payload may pair the flag with a value the parser would never produce. That is not
+            /// rejected here: deserialization runs before `executeQueryImpl` has an AST to mask with,
+            /// so throwing would send the raw JSON text - the value included - down the unmasked
+            /// `wipeSensitiveDataAndCutToLength` logging path. The value is kept instead, so
+            /// `hasSecretParts` can still see it and `formatImpl` can still hide it, and
+            /// `checkShorthandChange` then rejects the setting itself once logging is safe.
             changes.push_back(std::move(change));
         }
     }
@@ -353,12 +351,6 @@ bool ASTSetQuery::hasSecretParts() const
 {
     for (const auto & change : changes)
     {
-        /// A valueless setting carries Bool `true` and can never be secret, but this runs before any
-        /// settings validation (`executeQueryImpl` masks the query for logging first), so reading the
-        /// value as a String below would report `BAD_GET` instead of the intended `TYPE_MISMATCH`.
-        if (change.shorthand)
-            continue;
-
         CustomType custom;
         if (change.value.tryGet<CustomType>(custom) && custom.isSecret())
             return true;
@@ -377,9 +369,13 @@ bool ASTSetQuery::hasSecretParts() const
 
         if (change.name == format_avro_schema_registry_url)
         {
-            /// Secret only if there is actually a password embedded in it.
-            String uri_string = change.value.safeGet<String>();
-            if (maskURIPassword(&uri_string))
+            /// Secret only if there is actually a password embedded in it. The value need not be a
+            /// String: a valueless `SETTINGS format_avro_schema_registry_url` carries Bool `true`,
+            /// and the AST JSON path can carry any `Field` type. This runs before any settings
+            /// validation - `executeQueryImpl` masks the query for logging first - so demanding a
+            /// String here would report `BAD_GET` instead of the setting's own `TYPE_MISMATCH`.
+            String uri_string;
+            if (change.value.tryGet<String>(uri_string) && maskURIPassword(&uri_string))
                 return true;
         }
     }

--- a/src/Parsers/ASTSetQuery.cpp
+++ b/src/Parsers/ASTSetQuery.cpp
@@ -232,6 +232,12 @@ void ASTSetQuery::writeJSON(WriteBuffer & out) const
             if (i > 0) o << ',';
             o << "{\"name\":";
             writeJSONString(changes[i].name, o, fs);
+            /// The valueless form has to survive the JSON round trip for the same reason it has to
+            /// survive the SQL one (see `formatImpl`): reconstructed as an explicit `name = true` it
+            /// would be accepted for a setting of any type, which is what the shorthand check exists
+            /// to prevent. The value is Bool `true`, so it carries no information beyond the flag.
+            if (changes[i].shorthand)
+                o << ",\"shorthand\":true";
             /// Write "value" key and the field as a JSON object via writeFieldValue.
             /// We use a trick: writeFieldValue writes, "key":{field_json},
             /// but since we just wrote {"name":"..." the comma is exactly what we need.
@@ -295,10 +301,23 @@ void ASTSetQuery::readJSON(const Poco::JSON::Object & json)
             /// `BAD_ARGUMENTS` instead of being coerced (e.g. a number stringified into a setting name).
             JSONObjectReader change_reader(*change_obj);
             change.name = change_reader.getString("name");
+            /// Restore the valueless form so `checkShorthandChange` still rejects a non-`Bool`
+            /// setting written without a value; otherwise the JSON dialect is a way around it.
+            change.shorthand = change_reader.getBool("shorthand");
             auto value_obj = change_obj->getObject("value");
             if (!value_obj)
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Missing 'value' object at index {} in 'changes' array during AST JSON deserialization", i);
             change.value = JSONObjectReader::readFieldFromObject(*value_obj);
+            /// The parser only ever pairs the flag with Bool `true`, and both `formatImpl` and
+            /// `hasSecretParts` skip the value of a valueless setting on that basis. Reject any other
+            /// pairing here so a crafted payload cannot hide a real value (a secret one, in
+            /// particular) from formatting and from the query log behind the flag.
+            if (change.shorthand && change.value != Field(true))
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Setting '{}' is marked as valueless but its value is not `true` "
+                    "during AST JSON deserialization",
+                    change.name);
             changes.push_back(std::move(change));
         }
     }
@@ -334,6 +353,12 @@ bool ASTSetQuery::hasSecretParts() const
 {
     for (const auto & change : changes)
     {
+        /// A valueless setting carries Bool `true` and can never be secret, but this runs before any
+        /// settings validation (`executeQueryImpl` masks the query for logging first), so reading the
+        /// value as a String below would report `BAD_GET` instead of the intended `TYPE_MISMATCH`.
+        if (change.shorthand)
+            continue;
+
         CustomType custom;
         if (change.value.tryGet<CustomType>(custom) && custom.isSecret())
             return true;

--- a/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.reference
+++ b/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.reference
@@ -1,0 +1,12 @@
+1
+SELECT 1 SETTINGS max_threads
+1
+SELECT 1 SETTINGS max_threads = 4
+SELECT 1 SETTINGS optimize_move_to_prewhere
+1
+TYPE_MISMATCH
+1
+BAD_ARGUMENTS
+TYPE_MISMATCH
+TYPE_MISMATCH
+SELECT 1 SETTINGS format_avro_schema_registry_url = \'http://user:pass@localhost\'

--- a/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.reference
+++ b/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.reference
@@ -8,6 +8,7 @@ TYPE_MISMATCH
 1
 SELECT 1 SETTINGS format_avro_schema_registry_url
 TYPE_MISMATCH
+SELECT 1 SETTINGS format_avro_schema_registry_url	1
 TYPE_MISMATCH
 TYPE_MISMATCH
 SELECT 1 SETTINGS format_avro_schema_registry_url = \'http://user:pass@localhost\'

--- a/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.reference
+++ b/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.reference
@@ -6,7 +6,9 @@ SELECT 1 SETTINGS optimize_move_to_prewhere
 1
 TYPE_MISMATCH
 1
-BAD_ARGUMENTS
+SELECT 1 SETTINGS format_avro_schema_registry_url
+TYPE_MISMATCH
 TYPE_MISMATCH
 TYPE_MISMATCH
 SELECT 1 SETTINGS format_avro_schema_registry_url = \'http://user:pass@localhost\'
+SELECT 1 SETTINGS format_avro_schema_registry_url = 1

--- a/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.sh
+++ b/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.sh
@@ -42,9 +42,14 @@ CRAFTED_JSON=$($CLICKHOUSE_CLIENT -q "SELECT $CRAFTED FORMAT TSVRaw")
 QUERY_ID="04665_crafted_$CLICKHOUSE_DATABASE"
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&dialect=clickhouse_json&allow_experimental_json_ast_dialect=1&log_queries=1&query_id=$QUERY_ID" \
     --data-binary "$CRAFTED_JSON" 2>&1 | grep -o "TYPE_MISMATCH" | head -n 1
-$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log"
-$CLICKHOUSE_CLIENT -q "SELECT query, position(query, 'pass') = 0 AS no_password FROM system.query_log
-    WHERE query_id = '$QUERY_ID' AND type = 'ExceptionBeforeStart'"
+for _ in {1..60}; do
+    $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log"
+    LOGGED=$($CLICKHOUSE_CLIENT -q "SELECT query, position(query, 'pass') = 0 AS no_password FROM system.query_log
+        WHERE current_database = currentDatabase() AND query_id = '$QUERY_ID' AND type = 'ExceptionBeforeStart'")
+    [ -n "$LOGGED" ] && break
+    sleep 0.5
+done
+echo "$LOGGED"
 
 # 2. `ASTSetQuery::hasSecretParts` read the value of `format_avro_schema_registry_url` as a String.
 # `executeQueryImpl` masks the query for logging before any settings validation runs, so a valueless

--- a/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.sh
+++ b/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.sh
@@ -29,9 +29,14 @@ $CLICKHOUSE_CLIENT --dialect clickhouse_json --allow_experimental_json_ast_diale
 JSON_BOOL=$($CLICKHOUSE_CLIENT -q "SELECT parseQueryToJSON(\$\$SELECT 1 SETTINGS optimize_move_to_prewhere\$\$)")
 $CLICKHOUSE_CLIENT --dialect clickhouse_json --allow_experimental_json_ast_dialect 1 -q "$JSON_BOOL"
 
-# The flag is only ever paired with `true`. A payload pairing it with a real value is rejected, so it
-# cannot be used to hide that value from formatting and from the query log.
-$CLICKHOUSE_CLIENT -q "SELECT formatQueryFromJSON(replaceAll(parseQueryToJSON(\$\$SELECT 1 SETTINGS format_avro_schema_registry_url = 'http://user:pass@localhost'\$\$), '{\"name\":\"format_avro_schema_registry_url\"', '{\"name\":\"format_avro_schema_registry_url\",\"shorthand\":true'))" 2>&1 | grep -o "BAD_ARGUMENTS" | head -n 1
+# A payload may pair the flag with a value the parser would never produce. Deserialization must not
+# reject it: that runs before `executeQueryImpl` has an AST to mask with, so the raw JSON text -
+# the value included - would go down the unmasked logging path. The value is kept, so the query is
+# rejected by the setting's own check, and the value stays hidden when the query is formatted.
+CRAFTED="replaceAll(parseQueryToJSON(\$\$SELECT 1 SETTINGS format_avro_schema_registry_url = 'http://user:pass@localhost'\$\$), '{\"name\":\"format_avro_schema_registry_url\"', '{\"name\":\"format_avro_schema_registry_url\",\"shorthand\":true')"
+$CLICKHOUSE_CLIENT -q "SELECT formatQueryFromJSON($CRAFTED)"
+CRAFTED_JSON=$($CLICKHOUSE_CLIENT -q "SELECT $CRAFTED")
+$CLICKHOUSE_CLIENT --dialect clickhouse_json --allow_experimental_json_ast_dialect 1 -q "$CRAFTED_JSON" 2>&1 | grep -o "TYPE_MISMATCH" | head -n 1
 
 # 2. `ASTSetQuery::hasSecretParts` read the value of `format_avro_schema_registry_url` as a String.
 # `executeQueryImpl` masks the query for logging before any settings validation runs, so a valueless
@@ -40,5 +45,7 @@ $CLICKHOUSE_CLIENT -q "SELECT formatQueryFromJSON(replaceAll(parseQueryToJSON(\$
 $CLICKHOUSE_CLIENT -q "SELECT * FROM (SELECT 1 SETTINGS format_avro_schema_registry_url)" 2>&1 | grep -o "TYPE_MISMATCH" | head -n 1
 $CLICKHOUSE_CLIENT -q "SELECT 1 SETTINGS format_avro_schema_registry_url" 2>&1 | grep -o "TYPE_MISMATCH" | head -n 1
 
-# A setting that really carries a secret is still detected and formatted through the masking path.
+# A setting that really carries a secret is still detected and formatted through the masking path,
+# and a value of a type that cannot embed a URI password is not read as a String either.
 $CLICKHOUSE_CLIENT -q "SELECT formatQuerySingleLine(\$\$SELECT 1 SETTINGS format_avro_schema_registry_url = 'http://user:pass@localhost'\$\$)"
+$CLICKHOUSE_CLIENT -q "SELECT formatQueryFromJSON(replaceAll(parseQueryToJSON(\$\$SELECT 1 SETTINGS format_avro_schema_registry_url = 'x'\$\$), '{\"field_type\":\"String\",\"value\":\"x\"}', '{\"field_type\":\"UInt64\",\"value\":1}'))"

--- a/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.sh
+++ b/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.sh
@@ -23,10 +23,10 @@ $CLICKHOUSE_CLIENT -q "SELECT position(parseQueryToJSON(\$\$SELECT 1 SETTINGS ma
 
 # Executing the JSON payload must be rejected exactly like the SQL form, instead of silently running
 # with the setting equal to 1.
-JSON=$($CLICKHOUSE_CLIENT -q "SELECT parseQueryToJSON(\$\$SELECT 1 SETTINGS max_threads\$\$)")
+JSON=$($CLICKHOUSE_CLIENT -q "SELECT parseQueryToJSON(\$\$SELECT 1 SETTINGS max_threads\$\$) FORMAT TSVRaw")
 $CLICKHOUSE_CLIENT --dialect clickhouse_json --allow_experimental_json_ast_dialect 1 -q "$JSON" 2>&1 | grep -o "TYPE_MISMATCH" | head -n 1
 # The valueless form of a `Bool` setting still executes.
-JSON_BOOL=$($CLICKHOUSE_CLIENT -q "SELECT parseQueryToJSON(\$\$SELECT 1 SETTINGS optimize_move_to_prewhere\$\$)")
+JSON_BOOL=$($CLICKHOUSE_CLIENT -q "SELECT parseQueryToJSON(\$\$SELECT 1 SETTINGS optimize_move_to_prewhere\$\$) FORMAT TSVRaw")
 $CLICKHOUSE_CLIENT --dialect clickhouse_json --allow_experimental_json_ast_dialect 1 -q "$JSON_BOOL"
 
 # A payload may pair the flag with a value the parser would never produce. Deserialization must not
@@ -35,8 +35,16 @@ $CLICKHOUSE_CLIENT --dialect clickhouse_json --allow_experimental_json_ast_diale
 # rejected by the setting's own check, and the value stays hidden when the query is formatted.
 CRAFTED="replaceAll(parseQueryToJSON(\$\$SELECT 1 SETTINGS format_avro_schema_registry_url = 'http://user:pass@localhost'\$\$), '{\"name\":\"format_avro_schema_registry_url\"', '{\"name\":\"format_avro_schema_registry_url\",\"shorthand\":true')"
 $CLICKHOUSE_CLIENT -q "SELECT formatQueryFromJSON($CRAFTED)"
-CRAFTED_JSON=$($CLICKHOUSE_CLIENT -q "SELECT $CRAFTED")
-$CLICKHOUSE_CLIENT --dialect clickhouse_json --allow_experimental_json_ast_dialect 1 -q "$CRAFTED_JSON" 2>&1 | grep -o "TYPE_MISMATCH" | head -n 1
+CRAFTED_JSON=$($CLICKHOUSE_CLIENT -q "SELECT $CRAFTED FORMAT TSVRaw")
+# Over HTTP, so the rejection happens server-side and the query reaches `system.query_log`. Rejecting
+# the payload while deserializing would have logged the raw JSON text there, password included; what
+# must be logged is the masked AST, which omits the value of a valueless setting entirely.
+QUERY_ID="04665_crafted_$CLICKHOUSE_DATABASE"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&dialect=clickhouse_json&allow_experimental_json_ast_dialect=1&log_queries=1&query_id=$QUERY_ID" \
+    --data-binary "$CRAFTED_JSON" 2>&1 | grep -o "TYPE_MISMATCH" | head -n 1
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log"
+$CLICKHOUSE_CLIENT -q "SELECT query, position(query, 'pass') = 0 AS no_password FROM system.query_log
+    WHERE query_id = '$QUERY_ID' AND type = 'ExceptionBeforeStart'"
 
 # 2. `ASTSetQuery::hasSecretParts` read the value of `format_avro_schema_registry_url` as a String.
 # `executeQueryImpl` masks the query for logging before any settings validation runs, so a valueless

--- a/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.sh
+++ b/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# `SETTINGS name` with no value is a shorthand for `= true`, and is rejected for a setting whose type
+# is not `Bool`. Two paths used to sidestep that rule.
+
+# 1. The AST JSON round trip dropped `SettingChange::shorthand`, so the `clickhouse_json` dialect
+# reconstructed the valueless form as an explicit `name = true`, which is accepted for a setting of
+# any type. The formatted round trip must keep the valueless form.
+$CLICKHOUSE_CLIENT -q "SELECT formatQueryFromJSON(parseQueryToJSON(\$\$SELECT 1 SETTINGS max_threads\$\$))
+    = formatQuerySingleLine(\$\$SELECT 1 SETTINGS max_threads\$\$)"
+$CLICKHOUSE_CLIENT -q "SELECT formatQueryFromJSON(parseQueryToJSON(\$\$SELECT 1 SETTINGS max_threads\$\$))"
+$CLICKHOUSE_CLIENT -q "SELECT position(parseQueryToJSON(\$\$SELECT 1 SETTINGS max_threads\$\$), '\"shorthand\":true') > 0"
+
+# A setting given an explicit value is unaffected, and a genuine `Bool` setting still round-trips
+# in either form.
+$CLICKHOUSE_CLIENT -q "SELECT formatQueryFromJSON(parseQueryToJSON(\$\$SELECT 1 SETTINGS max_threads = 4\$\$))"
+$CLICKHOUSE_CLIENT -q "SELECT formatQueryFromJSON(parseQueryToJSON(\$\$SELECT 1 SETTINGS optimize_move_to_prewhere\$\$))"
+$CLICKHOUSE_CLIENT -q "SELECT position(parseQueryToJSON(\$\$SELECT 1 SETTINGS max_threads = 4\$\$), 'shorthand') = 0"
+
+# Executing the JSON payload must be rejected exactly like the SQL form, instead of silently running
+# with the setting equal to 1.
+JSON=$($CLICKHOUSE_CLIENT -q "SELECT parseQueryToJSON(\$\$SELECT 1 SETTINGS max_threads\$\$)")
+$CLICKHOUSE_CLIENT --dialect clickhouse_json --allow_experimental_json_ast_dialect 1 -q "$JSON" 2>&1 | grep -o "TYPE_MISMATCH" | head -n 1
+# The valueless form of a `Bool` setting still executes.
+JSON_BOOL=$($CLICKHOUSE_CLIENT -q "SELECT parseQueryToJSON(\$\$SELECT 1 SETTINGS optimize_move_to_prewhere\$\$)")
+$CLICKHOUSE_CLIENT --dialect clickhouse_json --allow_experimental_json_ast_dialect 1 -q "$JSON_BOOL"
+
+# The flag is only ever paired with `true`. A payload pairing it with a real value is rejected, so it
+# cannot be used to hide that value from formatting and from the query log.
+$CLICKHOUSE_CLIENT -q "SELECT formatQueryFromJSON(replaceAll(parseQueryToJSON(\$\$SELECT 1 SETTINGS format_avro_schema_registry_url = 'http://user:pass@localhost'\$\$), '{\"name\":\"format_avro_schema_registry_url\"', '{\"name\":\"format_avro_schema_registry_url\",\"shorthand\":true'))" 2>&1 | grep -o "BAD_ARGUMENTS" | head -n 1
+
+# 2. `ASTSetQuery::hasSecretParts` read the value of `format_avro_schema_registry_url` as a String.
+# `executeQueryImpl` masks the query for logging before any settings validation runs, so a valueless
+# setting reached it as Bool `true` and reported `BAD_GET` instead of the intended `TYPE_MISMATCH`.
+# The top-level form is validated before that; a subquery reaches the masking path first.
+$CLICKHOUSE_CLIENT -q "SELECT * FROM (SELECT 1 SETTINGS format_avro_schema_registry_url)" 2>&1 | grep -o "TYPE_MISMATCH" | head -n 1
+$CLICKHOUSE_CLIENT -q "SELECT 1 SETTINGS format_avro_schema_registry_url" 2>&1 | grep -o "TYPE_MISMATCH" | head -n 1
+
+# A setting that really carries a secret is still detected and formatted through the masking path.
+$CLICKHOUSE_CLIENT -q "SELECT formatQuerySingleLine(\$\$SELECT 1 SETTINGS format_avro_schema_registry_url = 'http://user:pass@localhost'\$\$)"


### PR DESCRIPTION
Follow-up to the two unresolved review comments on https://github.com/ClickHouse/ClickHouse/pull/112067 (merged as `a208bbb94ab`).

`SETTINGS name` with no value is a shorthand for `= true`, and #112067 made it an error for a setting whose type is not `Bool`. Two paths sidestepped that rule.

**The AST JSON round trip dropped the flag.** `ASTSetQuery::writeJSON` did not serialize `SettingChange::shorthand` and `readJSON` did not restore it, so the `clickhouse_json` dialect reconstructed the valueless form as an explicit `name = true`, which is accepted for a setting of any type:

```
$ clickhouse local -q "SELECT parseQueryToJSON('SELECT 1 SETTINGS max_threads')"
... "changes":[{"name":"max_threads","value":{"field_type":"Bool","value":true}}] ...
$ clickhouse local --dialect clickhouse_json --allow_experimental_json_ast_dialect 1 --queries-file q.json
1                       -- runs with max_threads = 1
$ clickhouse local -q "SELECT 1 SETTINGS max_threads"
Code: 53. ... Setting 'max_threads' has type MaxThreads, so it cannot be set without a value. (TYPE_MISMATCH)
```

The flag is now written and read back. A payload pairing it with anything other than `true` is rejected with `BAD_ARGUMENTS`: both `formatImpl` and `hasSecretParts` skip the value of a valueless setting, so without that check the flag could be used to hide a real value - a secret one in particular - from formatting and from the query log.

**`hasSecretParts` read the value as a String.** `executeQueryImpl` masks the query for logging before any settings validation runs, so a valueless `format_avro_schema_registry_url` reached `safeGet<String>` as Bool `true`:

```
$ clickhouse local -q "SELECT * FROM (SELECT 1 SETTINGS format_avro_schema_registry_url)"
Code: 170. DB::Exception: Bad get: has Bool, requested String. (BAD_GET)
```

It now reports the intended `TYPE_MISMATCH`. A valueless setting carries Bool `true` and can never be secret.

New test `04665_valueless_setting_ast_json_and_secret_parts`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Related: https://github.com/ClickHouse/ClickHouse/pull/112067
