### PR TITLE
Backport the `NonblockingBoundedQueue` TSAN suppression to 26.6

### DIFF
--- a/base/base/sanitizer_options.h
+++ b/base/base/sanitizer_options.h
@@ -54,6 +54,23 @@ const char * __tsan_default_options()
 {
     return "halt_on_error=1 abort_on_error=1 history_size=7 second_deadlock_stack=1 max_allocation_size_mb=32768";
 }
+const char * __tsan_default_suppressions()
+{
+    /// The release/acquire handoff on `slot.pos` orders every access to a slot payload, so the
+    /// reports these entries suppress are not real races (see the comment in
+    /// Common/NonblockingBoundedQueue.h). A function attribute cannot suppress them, because the
+    /// element type's implicitly generated move assignment is a separate, still-instrumented
+    /// function, and the attribute additionally prevents it from being inlined.
+    ///
+    /// Only `tryPush` is listed: the `dequeue_pos` compare-exchange gives one consumer sole
+    /// ownership of a slot before the move-out in `tryPop`, so every reported pair contains the
+    /// `tryPush` write. Patterns are matched against each frame's function, file and module name,
+    /// so an unqualified name would also match the queue header's own file name, and with it the
+    /// unrelated `keeper-bench` queues. Keep them narrow: a `race:` entry also hides
+    /// heap-use-after-free reports through the frame it names.
+    return "race:^NonblockingBoundedQueue<DB::KeeperRequestForSession>::tryPush\n"
+           "race:^NonblockingBoundedQueue<DB::KeeperResponseForSession>::tryPush\n";
+}
 #endif
 
 #ifdef UNDEFINED_BEHAVIOR_SANITIZER

--- a/src/Common/NonblockingBoundedQueue.h
+++ b/src/Common/NonblockingBoundedQueue.h
@@ -79,6 +79,19 @@ public:
     }
 
     /// `value` is moved-out iff the return value is true.
+    ///
+    /// TSAN very rarely reports a data race between the `slot.value` write in `tryPush` and the
+    /// `slot.value` read in `tryPop`, even though the acquire/release operations on `slot.pos`
+    /// make such a race impossible (the code is isomorphic to Vyukov's original implementation).
+    /// Those reports are suppressed at runtime, per instantiation, by
+    /// `__tsan_default_suppressions` in base/sanitizer_options.h. A `NO_SANITIZE_THREAD` attribute
+    /// here does not work: the reported access happens in the element type's move assignment, which
+    /// is a separate function that stays instrumented.
+    ///
+    /// The suppression lists only `tryPush`. `tryPop` writes the payload too (it moves out of
+    /// `slot.value`), but the `dequeue_pos` CAS gives one consumer sole ownership of a slot before
+    /// the move-out, so two pops never touch one payload concurrently, whatever the consumer count.
+    /// A `tryPop` entry would be dead, and would also hide heap-use-after-free through that frame.
     bool tryPush(T & value)
     {
         chassert(mask);


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/112695
Related: https://github.com/ClickHouse/ClickHouse/pull/112722
Related: https://github.com/ClickHouse/ClickHouse/pull/112899

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Backport of #112695 to `26.6`, requested on #112722. `26.6` still carries the defect.

`Integration tests (amd_tsan, N/6)` fails in teardown with `Sanitizer assert found for instance zoo<N>`, from a TSAN data race report between the `slot.value` write in `NonblockingBoundedQueue::tryPush` and the read in `tryPop`. The report is a false positive: the release/acquire handoff on `slot.pos` orders every access to a slot payload, and the class has no non-protocol payload access. But `abort_on_error=1` aborts the Keeper node, so healthy runs turn red.

A `NO_SANITIZE_THREAD` attribute cannot suppress it. Neither element type declares an `operator=`, so the racing access happens in the implicitly generated move assignment, a separate function that stays instrumented. A runtime `__tsan_default_suppressions` entry is consulted for every frame of a report, so one entry covers the whole nested move chain.

This registers that hook with two anchored patterns for the two Keeper instantiations. Only `tryPush` is listed: the `dequeue_pos` CAS gives one consumer sole ownership of a slot before `tryPop`'s move-out, so a pop/pop payload race cannot occur at any consumer count, and a `race:` entry also hides heap-use-after-free through the frame it names. Anchoring keeps them off the unrelated `keeper-bench` queues in the same binary.

- **Purely additive**, and **sanitizer builds only** (no performance impact): #107083, whose attributes master's commit removes, was never backported here, and the hook is inside `#ifdef THREAD_SANITIZER`.
- **A cherry-pick does not apply** (`git apply --check` fails on both files). On `26.6` the hook goes in `base/base/sanitizer_options.h`, master's own placement; that header does not exist on `26.5`, which is why #112899 had to put the hook in `programs/main.cpp` instead.
- **No test**, matching #112695: the only oracle is a CI-side absence property over many runs.

- The label route was unavailable: #112695 has no `*-must-backport` label, and the robot cherry-picks.

<details>
<summary>Verification (26.6, TSAN build, clang-21)</summary>

Built `-DCMAKE_BUILD_TYPE=None -DSANITIZE=thread` (the `amd_tsan` shape). Both directions, on the real binary:

| | `nm -C` T count | W count | shipped patterns in binary |
|---|---|---|---|
| without the hook | 0 | 1 (compiler-rt weak fallback) | 0 |
| with the hook | 1 | 0 | 2 |

The weak fallback is why a bare `grep` for the symbol is not a valid check. `clickhouse-keeper` is a symlink to the `main.cpp`-built binary (`BUILD_STANDALONE_KEEPER` is off in the TSAN builds), so the hook is linked into the Keeper process, and the runtime loads the strings without a parse error.

A standalone TSAN probe, taking the hook from the real header, confirms behavior on three arms: `KeeperRequestForSession` suppressed, `KeeperResponseForSession` suppressed, `QueueItem` (the keeper-bench shape) still reported. Mangling the category to `bogusrace:` makes TSAN answer "failed to parse suppressions", proving the runtime consumes the string rather than ignoring it.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.5.48`
<!-- ch-version-info:end -->