### PR TITLE
Backport the runtime TSan suppression for `NonblockingBoundedQueue` to 26.7

### DIFF
--- a/base/base/sanitizer_options.h
+++ b/base/base/sanitizer_options.h
@@ -56,6 +56,22 @@ const char * __tsan_default_options()
 {
     return "halt_on_error=1 abort_on_error=1 history_size=7 second_deadlock_stack=1 max_allocation_size_mb=32768 allocator_may_return_null=1";
 }
+const char * __tsan_default_suppressions()
+{
+    /// The release/acquire handoff on `slot.pos` orders every access to a slot payload, so the
+    /// reports these entries suppress are not real races (see the comment in
+    /// Common/NonblockingBoundedQueue.h). A function attribute cannot suppress them, because the
+    /// element type's implicitly generated move assignment is a separate, still-instrumented
+    /// function, and the attribute additionally prevents it from being inlined.
+    ///
+    /// Only `tryPush` is listed: the `dequeue_pos` compare-exchange gives one consumer sole
+    /// ownership of a slot before the move-out in `tryPop`, so every reported pair contains the
+    /// `tryPush` write. Patterns are matched against each frame's function, file and module name,
+    /// so an unqualified name would also match the queue header's own file name. Keep them narrow:
+    /// a `race:` entry also hides heap-use-after-free reports through the frame it names.
+    return "race:^NonblockingBoundedQueue<DB::KeeperRequestForSession>::tryPush\n"
+           "race:^NonblockingBoundedQueue<DB::KeeperResponseForSession>::tryPush\n";
+}
 #endif
 
 #ifdef UNDEFINED_BEHAVIOR_SANITIZER

--- a/src/Common/NonblockingBoundedQueue.h
+++ b/src/Common/NonblockingBoundedQueue.h
@@ -79,6 +79,19 @@ public:
     }
 
     /// `value` is moved-out iff the return value is true.
+    ///
+    /// TSan very rarely reports a data race between the `slot.value` write in `tryPush` and the
+    /// `slot.value` read in `tryPop`, even though the acquire/release operations on `slot.pos`
+    /// make such a race impossible (the code is isomorphic to Vyukov's original implementation).
+    /// Those reports are suppressed at runtime, per instantiation, by
+    /// `__tsan_default_suppressions` in base/sanitizer_options.h. A `NO_SANITIZE_THREAD` attribute
+    /// here does not work: the reported access happens in the element type's move assignment, which
+    /// is a separate function that stays instrumented.
+    ///
+    /// The suppression lists only `tryPush`. `tryPop` writes the payload too (it moves out of
+    /// `slot.value`), but the `dequeue_pos` CAS gives one consumer sole ownership of a slot before
+    /// the move-out, so two pops never touch one payload concurrently, whatever the consumer count.
+    /// A `tryPop` entry would be dead, and would also hide heap-use-after-free through that frame.
     bool tryPush(T & value)
     {
         chassert(mask);


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

Related: https://github.com/ClickHouse/ClickHouse/pull/112695
Related: https://github.com/ClickHouse/ClickHouse/pull/112722

### Description

The TSan integration shards abort in teardown with `Sanitizer assert found for instance zoo<N>`. The Keeper container log carries a data race between the slot payload write in `NonblockingBoundedQueue<DB::KeeperResponseForSession>::tryPush` and the read in `tryPop`. The release/acquire handoff on `slot.pos` orders every access to a slot payload, so the report is a false positive. Example on a 26.5 backport branch: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112722&sha=21ba2dbcf7a5d9e1a4f1e1357677f5429f121040&name_0=BackportPR&name_1=Integration%20tests%20%28amd_tsan%2C%203%2F6%29

master fixed this in #112695 with two anchored `tryPush` patterns in `__tsan_default_suppressions`. A function attribute cannot suppress the reports: the access happens in the element type's implicitly generated move assignment, a separate function that stays instrumented, which the attribute also keeps from being inlined. A runtime suppression is consulted for every frame.

I authored this by hand because the cherry-pick does not apply and the label route is unavailable: #112695 carries no `*-must-backport` label and I cannot apply one. @alexey-milovidov asked for it in #112722; 26.5 is #112899.

The hook goes beside the existing `__tsan_default_options` in `base/base/sanitizer_options.h`, master's placement (26.5 lacks that header, so #112899 used `programs/main.cpp`). Purely additive: #107083, whose attributes #112695 removed as ineffective, was never backported here.

Only `tryPush` is listed. `tryPop` writes the payload too, but the `dequeue_pos` compare-exchange gives one consumer sole ownership of a slot before the move-out, so two pops never touch one payload concurrently, whatever the consumer count. A `tryPop` entry would be dead, and a `race:` entry also hides heap-use-after-free through that frame.

Sanitizer builds only, no performance impact: outside `THREAD_SANITIZER` the hook is preprocessed away, and inside it returns a fixed string read once at sanitizer init. The queue header change is a comment. No new test, matching #112695: the only end-to-end oracle is the TSan shards going quiet over many runs. The comment says `TSan` rather than master's `TSAN`, per `.claude/CLAUDE.md`; happy to unify across the three branches.

<details>
<summary>Why 26.7 is affected although the signature has not been observed on it</summary>

Over the last 45 days the signature appears four times on master, plus once on a robot backport branch targeting 26.6 and once on one targeting 26.5. It never appears with `26.5`, `26.6` or `26.7` as the head ref, so the zero on 26.7 is not distinctive. Worth flagging for anyone re-running this: two of the master occurrences escape the obvious query, because the TSan banner overwrites the instance name and the harness line reads `Sanitizer assert found for instance ==================` rather than naming a `zoo` container.

That zero is sample size, not immunity. At master's observed rate the probability of seeing zero occurrences is about 84 percent on 26.7's TSan integration build volume, and about 64 percent on each of 26.5's and 26.6's. So no release branch can be shown immune from this data, and I am not claiming the data shows 26.7 susceptible either.

The case for 26.7 is structural. Both carrier files are present, `src/Common/NonblockingBoundedQueue.h` and `src/Coordination/KeeperRequestDispatcher.cpp`, with both explicit instantiations. Its copy of the queue header is md5-identical to 26.6's, which did see the failure. 26.4 and older lack the files entirely and are immune for that reason.

One detail on scope: `keeper-bench` also instantiates the queue, but its element type is a private nested struct of `StorageRunner`, so it demangles as `NonblockingBoundedQueue<StorageRunner::QueueItem>` and matches neither anchored pattern. Verified in the built binary, where each pattern names exactly one live symbol and that one names none.

</details>