### PR TITLE
Allow low cardinality types in iceberg and improve perfomance of low cardinality in parquet

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/Write.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Write.cpp
@@ -12,7 +12,9 @@
 #include <DataTypes/DataTypeObject.h>
 #include <Columns/MaskOperations.h>
 #include <Columns/ColumnFixedString.h>
+#include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnString.h>
+#include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnDecimal.h>
 #include <Columns/ColumnTuple.h>
@@ -737,6 +739,60 @@ void encodeRepDefLevelsRLE(const UInt8 * data, size_t size, UInt8 max_level, POD
     out.resize(offset + prefix_size + len);
 }
 
+struct DictionaryIndexes
+{
+    const UInt8 * u8 = nullptr;
+    const UInt16 * u16 = nullptr;
+    const UInt32 * u32 = nullptr;
+    const UInt64 * u64 = nullptr;
+
+    explicit DictionaryIndexes(const IColumn & column)
+    {
+        if (const auto * c8 = checkAndGetColumn<ColumnUInt8>(&column))
+            u8 = c8->getData().data();
+        else if (const auto * c16 = checkAndGetColumn<ColumnUInt16>(&column))
+            u16 = c16->getData().data();
+        else if (const auto * c32 = checkAndGetColumn<ColumnUInt32>(&column))
+            u32 = c32->getData().data();
+        else if (const auto * c64 = checkAndGetColumn<ColumnUInt64>(&column))
+            u64 = c64->getData().data();
+        else
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected LowCardinality index column: {}", column.getName());
+    }
+
+    ALWAYS_INLINE size_t operator[](size_t i) const
+    {
+        if (u8)
+            return u8[i];
+        if (u16)
+            return u16[i];
+        if (u32)
+            return u32[i];
+        return static_cast<size_t>(u64[i]);
+    }
+};
+
+void encodeDictionaryIndexesRLE(
+    const DictionaryIndexes & indexes, size_t offset, size_t count, int bit_width, PODArray<char> & out)
+{
+    using arrow::util::RleBitPackedEncoder;
+
+    size_t out_offset = out.size();
+    auto max_rle_size = RleBitPackedEncoder::MaxBufferSize(bit_width, static_cast<int>(count))
+        + RleBitPackedEncoder::MinBufferSize(bit_width);
+
+    out.resize(out_offset + 1 + max_rle_size);
+    out[out_offset] = static_cast<char>(bit_width);
+
+    RleBitPackedEncoder encoder(
+        reinterpret_cast<uint8_t *>(out.data() + out_offset + 1), static_cast<int>(max_rle_size), bit_width);
+    for (size_t i = 0; i < count; ++i)
+        encoder.Put(indexes[offset + i]);
+    encoder.Flush();
+
+    out.resize(out_offset + 1 + encoder.len());
+}
+
 void addToEncodingsUsed(ColumnChunkWriteState & s, parq::Encoding::type e)
 {
     if (!std::count(s.column_chunk.meta_data.encodings.begin(), s.column_chunk.meta_data.encodings.end(), e))
@@ -861,7 +917,13 @@ template <typename ParquetDType, typename Converter>
 void writeColumnImpl(
     ColumnChunkWriteState & s, const WriteOptions & options, WriteBuffer & out, Converter && converter)
 {
-    size_t num_values = s.max_def > 0 ? s.def.size() : s.primitive_column->size();
+    std::optional<DictionaryIndexes> reused_dictionary_indexes;
+    if (s.dictionary_indexes)
+        reused_dictionary_indexes.emplace(*s.dictionary_indexes);
+    const bool reuse_dictionary = reused_dictionary_indexes.has_value();
+
+    size_t num_rows = reuse_dictionary ? s.dictionary_indexes->size() : s.primitive_column->size();
+    size_t num_values = s.max_def > 0 ? s.def.size() : num_rows;
     auto encoding = options.encoding;
 
     typename Converter::Statistics page_statistics;
@@ -898,14 +960,21 @@ void writeColumnImpl(
         s.column_chunk.meta_data.size_statistics.__set_definition_level_histogram(std::vector<Int64>(s.max_def + 1));
 
     /// Could use an arena here (by passing a custom MemoryPool), to reuse memory across pages.
-    /// Alternatively, we could avoid using arrow's dictionary encoding code and leverage
-    /// ColumnLowCardinality instead. It would work basically the same way as what this function
-    /// currently does: add values to the ColumnRowCardinality (instead of `encoder`) in batches,
-    /// checking dictionary size after each batch. That might be faster.
     auto encoder = parquet::MakeTypedEncoder<ParquetDType>(
         // ignored if using dictionary
         static_cast<parquet::Encoding::type>(encoding),
-        use_dictionary, fixed_string_descr ? &*fixed_string_descr : nullptr);
+        use_dictionary && !reuse_dictionary, fixed_string_descr ? &*fixed_string_descr : nullptr);
+
+    const typename ParquetDType::c_type * dictionary_values = nullptr;
+    size_t dictionary_size = 0;
+    int dictionary_bit_width = 0;
+    std::vector<UInt64> dictionary_hashes;
+    if (reuse_dictionary)
+    {
+        dictionary_size = s.primitive_column->size();
+        dictionary_values = converter.getBatch(0, dictionary_size);
+        dictionary_bit_width = dictionary_size <= 1 ? 0 : bitScanReverse(dictionary_size - 1) + 1;
+    }
 
     struct PageData
     {
@@ -913,18 +982,43 @@ void writeColumnImpl(
         PODArray<char> data;
         size_t first_row_index = 0;
     };
-    std::vector<PageData> dict_encoded_pages; // can't write them out until we have full dictionary
+    std::vector<PageData> dict_encoded_pages;
 
     /// Reused across pages to reduce number of allocations and improve locality.
     PODArray<char> encoded;
     PODArray<char> compressed_maybe;
 
+/// With XXH_INLINE_ALL (from contrib/xxHash) every XXH function is marked as unused,
+/// so any actual use triggers this warning.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wused-but-marked-unused"
+    auto hash_value = [&](const typename ParquetDType::c_type & value) -> UInt64
+    {
+        constexpr UInt64 seed = 0;
+        if constexpr (std::is_same_v<ParquetDType, parquet::FLBAType>)
+            return XXH_INLINE_XXH64(value.ptr, converter.fixedStringSize(), seed);
+        else if constexpr (std::is_same_v<ParquetDType, parquet::ByteArrayType>)
+            return XXH_INLINE_XXH64(value.ptr, value.len, seed);
+        else
+        {
+            static_assert(sizeof(value) <= 12, "unexpected non-primitive type");
+            return XXH_INLINE_XXH64(reinterpret_cast<const void *>(&value), sizeof(value), seed);
+        }
+    };
+#pragma clang diagnostic pop
+
     /// Hash set to deduplicate the values before calculating bloom filter size.
-    /// Possible future optimization: if using dictionary encoding, take already-deduplicated values
-    /// from the dictionary instead.
     std::optional<HashSet<UInt64, TrivialHash>> hashes_for_bloom_filter;
     if (options.write_bloom_filter)
+    {
         hashes_for_bloom_filter.emplace(); // allocates memory for initial size
+        if (reuse_dictionary)
+        {
+            dictionary_hashes.resize(dictionary_size);
+            for (size_t i = 0; i < dictionary_size; ++i)
+                dictionary_hashes[i] = hash_value(dictionary_values[i]);
+        }
+    }
 
     /// Start of current page.
     size_t def_offset = 0; // index in def and rep
@@ -958,11 +1052,18 @@ void writeColumnImpl(
                 ++s.column_chunk.meta_data.size_statistics.definition_level_histogram[s.def[i]];
         }
 
-        std::shared_ptr<parquet::Buffer> values = encoder->FlushValues(); // resets it for next page
+        if (reuse_dictionary)
+        {
+            encodeDictionaryIndexesRLE(*reused_dictionary_indexes, data_offset, data_count, dictionary_bit_width, encoded);
+        }
+        else
+        {
+            std::shared_ptr<parquet::Buffer> values = encoder->FlushValues(); // resets it for next page
 
-        encoded.resize(encoded.size() + values->size());
-        memcpy(encoded.data() + encoded.size() - values->size(), values->data(), values->size());
-        values.reset();
+            encoded.resize(encoded.size() + values->size());
+            memcpy(encoded.data() + encoded.size() - values->size(), values->data(), values->size());
+            values.reset();
+        }
 
         if (encoded.size() > INT32_MAX)
             throw Exception(ErrorCodes::CANNOT_COMPRESS, "Uncompressed page is too big: {}", encoded.size());
@@ -1019,7 +1120,7 @@ void writeColumnImpl(
         total_statistics.merge(page_statistics);
         page_statistics.clear();
 
-        if (use_dictionary)
+        if (use_dictionary && !reuse_dictionary)
         {
             dict_encoded_pages.push_back({.header = std::move(header), .data = {}, .first_row_index = row_idx});
             std::swap(dict_encoded_pages.back().data, compressed);
@@ -1035,11 +1136,29 @@ void writeColumnImpl(
 
     auto flush_dict = [&] -> bool
     {
-        auto * dict_encoder = dynamic_cast<parquet::DictEncoder<ParquetDType> *>(encoder.get());
-        int dict_size = dict_encoder->dict_encoded_size();
+        int num_entries = 0;
+        if (reuse_dictionary)
+        {
+            auto dictionary_page_encoder = parquet::MakeTypedEncoder<ParquetDType>(
+                parquet::Encoding::PLAIN, /* use_dictionary */ false, fixed_string_descr ? &*fixed_string_descr : nullptr);
+            dictionary_page_encoder->Put(dictionary_values, static_cast<int>(dictionary_size));
+            std::shared_ptr<parquet::Buffer> values = dictionary_page_encoder->FlushValues();
 
-        encoded.resize(static_cast<size_t>(dict_size));
-        dict_encoder->WriteDict(reinterpret_cast<uint8_t *>(encoded.data()));
+            encoded.resize(static_cast<size_t>(values->size()));
+            memcpy(encoded.data(), values->data(), values->size());
+            num_entries = static_cast<int>(dictionary_size);
+        }
+        else
+        {
+            auto * dict_encoder = dynamic_cast<parquet::DictEncoder<ParquetDType> *>(encoder.get());
+            encoded.resize(static_cast<size_t>(dict_encoder->dict_encoded_size()));
+            dict_encoder->WriteDict(reinterpret_cast<uint8_t *>(encoded.data()));
+            num_entries = dict_encoder->num_entries();
+        }
+
+        if (encoded.size() > INT32_MAX)
+            throw Exception(ErrorCodes::CANNOT_COMPRESS, "Uncompressed dictionary page is too big: {}", encoded.size());
+        int dict_size = static_cast<int>(encoded.size());
 
         auto & compressed = compress(encoded, compressed_maybe, s.compression, s.compression_level);
 
@@ -1051,7 +1170,7 @@ void writeColumnImpl(
         header.__set_uncompressed_page_size(dict_size);
         header.__set_compressed_page_size(static_cast<int>(compressed.size()));
         header.__isset.dictionary_page_header = true;
-        header.dictionary_page_header.__set_num_values(dict_encoder->num_entries());
+        header.dictionary_page_header.__set_num_values(num_entries);
         header.dictionary_page_header.__set_encoding(parq::Encoding::PLAIN);
 
         if (options.write_checksums)
@@ -1076,6 +1195,9 @@ void writeColumnImpl(
         int dict_size = dict_encoder->dict_encoded_size();
         return static_cast<size_t>(dict_size) >= options.max_dictionary_size;
     };
+
+    if (reuse_dictionary)
+        flush_dict();
 
     while (def_offset < num_values)
     {
@@ -1103,53 +1225,54 @@ void writeColumnImpl(
                 }
             }
 
-            /// Encode the data (but not the levels yet), so that we can estimate its encoded size.
-            const typename ParquetDType::c_type * converted = converter.getBatch(next_data_offset, data_count);
+            if (reuse_dictionary)
+            {
+                const auto & indexes = *reused_dictionary_indexes;
 
-            if (options.write_page_statistics || options.write_column_chunk_statistics)
+                if (options.write_page_statistics || options.write_column_chunk_statistics)
+                    for (size_t i = 0; i < data_count; ++i)
+                        page_statistics.add(dictionary_values[indexes[next_data_offset + i]]);
+
+                if (hashes_for_bloom_filter.has_value())
+                    for (size_t i = 0; i < data_count; ++i)
+                        hashes_for_bloom_filter->insert(dictionary_hashes[indexes[next_data_offset + i]]);
+
+                if constexpr (std::is_same_v<ParquetDType, parquet::ByteArrayType>)
+                    for (size_t i = 0; i < data_count; ++i)
+                        s.column_chunk.meta_data.size_statistics.unencoded_byte_array_data_bytes
+                            += dictionary_values[indexes[next_data_offset + i]].len;
+            }
+            else
+            {
+                const typename ParquetDType::c_type * converted = converter.getBatch(next_data_offset, data_count);
+
+                if (options.write_page_statistics || options.write_column_chunk_statistics)
 /// Workaround for clang bug: https://github.com/llvm/llvm-project/issues/63630
 #ifdef MEMORY_SANITIZER
 #pragma clang loop vectorize(disable)
 #endif
-                for (size_t i = 0; i < data_count; ++i)
-                    page_statistics.add(converted[i]);
+                    for (size_t i = 0; i < data_count; ++i)
+                        page_statistics.add(converted[i]);
 
-            if (hashes_for_bloom_filter.has_value())
-            {
-/// With XXH_INLINE_ALL (from contrib/xxHash) every XXH function is marked as unused,
-/// so any actual use triggers this warning.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wused-but-marked-unused"
-                for (size_t i = 0; i < data_count; ++i)
+                if (hashes_for_bloom_filter.has_value())
                 {
-                    UInt64 h = 0;
-                    constexpr UInt64 seed = 0;
-                    if constexpr (std::is_same_v<ParquetDType, parquet::FLBAType>)
-                        h = XXH_INLINE_XXH64(converted[i].ptr, converter.fixedStringSize(), seed);
-                    else if constexpr (std::is_same_v<ParquetDType, parquet::ByteArrayType>)
-                        h = XXH_INLINE_XXH64(converted[i].ptr, converted[i].len, seed);
-                    else
-                    {
-                        static_assert(sizeof(converted[i]) <= 12, "unexpected non-primitive type");
-                        h = XXH_INLINE_XXH64(reinterpret_cast<const void*>(&converted[i]), sizeof(converted[i]), seed);
-                    }
-                    hashes_for_bloom_filter->insert(h);
+                    for (size_t i = 0; i < data_count; ++i)
+                        hashes_for_bloom_filter->insert(hash_value(converted[i]));
                 }
-#pragma clang diagnostic pop
-            }
 
-            if constexpr (std::is_same_v<ParquetDType, parquet::ByteArrayType>)
-            {
-                for (size_t i = 0; i < data_count; ++i)
-                    s.column_chunk.meta_data.size_statistics.unencoded_byte_array_data_bytes += converted[i].len;
-            }
+                if constexpr (std::is_same_v<ParquetDType, parquet::ByteArrayType>)
+                {
+                    for (size_t i = 0; i < data_count; ++i)
+                        s.column_chunk.meta_data.size_statistics.unencoded_byte_array_data_bytes += converted[i].len;
+                }
 
-            encoder->Put(converted, static_cast<int>(data_count));
+                encoder->Put(converted, static_cast<int>(data_count));
+            }
 
             next_def_offset += def_count;
             next_data_offset += data_count;
 
-            if (use_dictionary && is_dict_too_big())
+            if (use_dictionary && !reuse_dictionary && is_dict_too_big())
             {
                 /// Fallback to non-dictionary encoding.
                 ///
@@ -1182,8 +1305,11 @@ void writeColumnImpl(
                 break;
             }
 
-            if (next_def_offset == num_values ||
-                static_cast<size_t>(encoder->EstimatedDataEncodedSize()) >= options.data_page_size)
+            size_t estimated_page_size = reuse_dictionary
+                ? (next_data_offset - data_offset) * std::max(dictionary_bit_width, 1) / 8
+                : static_cast<size_t>(encoder->EstimatedDataEncodedSize());
+
+            if (next_def_offset == num_values || estimated_page_size >= options.data_page_size)
             {
                 flush_page(next_def_offset - def_offset, next_data_offset - data_offset);
                 break;
@@ -1191,10 +1317,10 @@ void writeColumnImpl(
         }
     }
 
-    if (use_dictionary)
+    if (use_dictionary && !reuse_dictionary)
         flush_dict();
 
-    chassert(data_offset == s.primitive_column->size());
+    chassert(data_offset == num_rows);
 
     if (options.write_column_chunk_statistics)
     {
@@ -1236,7 +1362,17 @@ void writeColumnChunkBody(
     s.column_chunk.meta_data.__set_total_uncompressed_size(0);
     s.column_chunk.meta_data.__set_data_page_offset(-1);
 
-    s.primitive_column = s.primitive_column->convertToFullColumnIfLowCardinality();
+    if (const auto * low_cardinality = checkAndGetColumn<ColumnLowCardinality>(s.primitive_column.get()))
+    {
+        const auto & dictionary = low_cardinality->getDictionary().getNestedColumn();
+        if (options.use_dictionary_encoding && !s.is_bool && dictionary->byteSize() < options.max_dictionary_size)
+        {
+            s.dictionary_indexes = low_cardinality->getIndexesPtr();
+            s.primitive_column = dictionary;
+        }
+        else
+            s.primitive_column = s.primitive_column->convertToFullColumnIfLowCardinality();
+    }
 
     switch (s.primitive_column->getDataType())
     {
@@ -1608,6 +1744,8 @@ size_t ColumnChunkWriteState::allocatedBytes() const
     size_t r = def.allocated_bytes() + rep.allocated_bytes();
     if (primitive_column)
         r += primitive_column->allocatedBytes();
+    if (dictionary_indexes)
+        r += dictionary_indexes->allocatedBytes();
     return r;
 }
 

--- a/src/Processors/Formats/Impl/Parquet/Write.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Write.cpp
@@ -12,7 +12,9 @@
 #include <DataTypes/DataTypeObject.h>
 #include <Columns/MaskOperations.h>
 #include <Columns/ColumnFixedString.h>
+#include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnString.h>
+#include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnDecimal.h>
 #include <Columns/ColumnTuple.h>
@@ -737,6 +739,60 @@ void encodeRepDefLevelsRLE(const UInt8 * data, size_t size, UInt8 max_level, POD
     out.resize(offset + prefix_size + len);
 }
 
+struct DictionaryIndexes
+{
+    const UInt8 * u8 = nullptr;
+    const UInt16 * u16 = nullptr;
+    const UInt32 * u32 = nullptr;
+    const UInt64 * u64 = nullptr;
+
+    explicit DictionaryIndexes(const IColumn & column)
+    {
+        if (const auto * c8 = checkAndGetColumn<ColumnUInt8>(&column))
+            u8 = c8->getData().data();
+        else if (const auto * c16 = checkAndGetColumn<ColumnUInt16>(&column))
+            u16 = c16->getData().data();
+        else if (const auto * c32 = checkAndGetColumn<ColumnUInt32>(&column))
+            u32 = c32->getData().data();
+        else if (const auto * c64 = checkAndGetColumn<ColumnUInt64>(&column))
+            u64 = c64->getData().data();
+        else
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected LowCardinality index column: {}", column.getName());
+    }
+
+    ALWAYS_INLINE size_t operator[](size_t i) const
+    {
+        if (u8)
+            return u8[i];
+        if (u16)
+            return u16[i];
+        if (u32)
+            return u32[i];
+        return static_cast<size_t>(u64[i]);
+    }
+};
+
+void encodeDictionaryIndexesRLE(
+    const DictionaryIndexes & indexes, size_t offset, size_t count, int bit_width, PODArray<char> & out)
+{
+    using arrow::util::RleBitPackedEncoder;
+
+    size_t out_offset = out.size();
+    auto max_rle_size = RleBitPackedEncoder::MaxBufferSize(bit_width, static_cast<int>(count))
+        + RleBitPackedEncoder::MinBufferSize(bit_width);
+
+    out.resize(out_offset + 1 + max_rle_size);
+    out[out_offset] = static_cast<char>(bit_width);
+
+    RleBitPackedEncoder encoder(
+        reinterpret_cast<uint8_t *>(out.data() + out_offset + 1), static_cast<int>(max_rle_size), bit_width);
+    for (size_t i = 0; i < count; ++i)
+        encoder.Put(indexes[offset + i]);
+    encoder.Flush();
+
+    out.resize(out_offset + 1 + encoder.len());
+}
+
 void addToEncodingsUsed(ColumnChunkWriteState & s, parq::Encoding::type e)
 {
     if (!std::count(s.column_chunk.meta_data.encodings.begin(), s.column_chunk.meta_data.encodings.end(), e))
@@ -861,7 +917,13 @@ template <typename ParquetDType, typename Converter>
 void writeColumnImpl(
     ColumnChunkWriteState & s, const WriteOptions & options, WriteBuffer & out, Converter && converter)
 {
-    size_t num_values = s.max_def > 0 ? s.def.size() : s.primitive_column->size();
+    std::optional<DictionaryIndexes> reused_dictionary_indexes;
+    if (s.dictionary_indexes)
+        reused_dictionary_indexes.emplace(*s.dictionary_indexes);
+    const bool reuse_dictionary = reused_dictionary_indexes.has_value();
+
+    size_t num_rows = reuse_dictionary ? s.dictionary_indexes->size() : s.primitive_column->size();
+    size_t num_values = s.max_def > 0 ? s.def.size() : num_rows;
     auto encoding = options.encoding;
 
     typename Converter::Statistics page_statistics;
@@ -898,14 +960,21 @@ void writeColumnImpl(
         s.column_chunk.meta_data.size_statistics.__set_definition_level_histogram(std::vector<Int64>(s.max_def + 1));
 
     /// Could use an arena here (by passing a custom MemoryPool), to reuse memory across pages.
-    /// Alternatively, we could avoid using arrow's dictionary encoding code and leverage
-    /// ColumnLowCardinality instead. It would work basically the same way as what this function
-    /// currently does: add values to the ColumnRowCardinality (instead of `encoder`) in batches,
-    /// checking dictionary size after each batch. That might be faster.
     auto encoder = parquet::MakeTypedEncoder<ParquetDType>(
         // ignored if using dictionary
         static_cast<parquet::Encoding::type>(encoding),
-        use_dictionary, fixed_string_descr ? &*fixed_string_descr : nullptr);
+        use_dictionary && !reuse_dictionary, fixed_string_descr ? &*fixed_string_descr : nullptr);
+
+    const typename ParquetDType::c_type * dictionary_values = nullptr;
+    size_t dictionary_size = 0;
+    int dictionary_bit_width = 0;
+    std::vector<UInt64> dictionary_hashes;
+    if (reuse_dictionary)
+    {
+        dictionary_size = s.primitive_column->size();
+        dictionary_values = converter.getBatch(0, dictionary_size);
+        dictionary_bit_width = dictionary_size <= 1 ? 0 : bitScanReverse(dictionary_size - 1) + 1;
+    }
 
     struct PageData
     {
@@ -913,18 +982,38 @@ void writeColumnImpl(
         PODArray<char> data;
         size_t first_row_index = 0;
     };
-    std::vector<PageData> dict_encoded_pages; // can't write them out until we have full dictionary
+    std::vector<PageData> dict_encoded_pages;
 
     /// Reused across pages to reduce number of allocations and improve locality.
     PODArray<char> encoded;
     PODArray<char> compressed_maybe;
 
+    auto hash_value = [&](const typename ParquetDType::c_type & value) -> UInt64
+    {
+        constexpr UInt64 seed = 0;
+        if constexpr (std::is_same_v<ParquetDType, parquet::FLBAType>)
+            return XXH64(value.ptr, converter.fixedStringSize(), seed);
+        else if constexpr (std::is_same_v<ParquetDType, parquet::ByteArrayType>)
+            return XXH64(value.ptr, value.len, seed);
+        else
+        {
+            static_assert(sizeof(value) <= 12, "unexpected non-primitive type");
+            return XXH64(reinterpret_cast<const void *>(&value), sizeof(value), seed);
+        }
+    };
+
     /// Hash set to deduplicate the values before calculating bloom filter size.
-    /// Possible future optimization: if using dictionary encoding, take already-deduplicated values
-    /// from the dictionary instead.
     std::optional<HashSet<UInt64, TrivialHash>> hashes_for_bloom_filter;
     if (options.write_bloom_filter)
+    {
         hashes_for_bloom_filter.emplace(); // allocates memory for initial size
+        if (reuse_dictionary)
+        {
+            dictionary_hashes.resize(dictionary_size);
+            for (size_t i = 0; i < dictionary_size; ++i)
+                dictionary_hashes[i] = hash_value(dictionary_values[i]);
+        }
+    }
 
     /// Start of current page.
     size_t def_offset = 0; // index in def and rep
@@ -958,11 +1047,18 @@ void writeColumnImpl(
                 ++s.column_chunk.meta_data.size_statistics.definition_level_histogram[s.def[i]];
         }
 
-        std::shared_ptr<parquet::Buffer> values = encoder->FlushValues(); // resets it for next page
+        if (reuse_dictionary)
+        {
+            encodeDictionaryIndexesRLE(*reused_dictionary_indexes, data_offset, data_count, dictionary_bit_width, encoded);
+        }
+        else
+        {
+            std::shared_ptr<parquet::Buffer> values = encoder->FlushValues(); // resets it for next page
 
-        encoded.resize(encoded.size() + values->size());
-        memcpy(encoded.data() + encoded.size() - values->size(), values->data(), values->size());
-        values.reset();
+            encoded.resize(encoded.size() + values->size());
+            memcpy(encoded.data() + encoded.size() - values->size(), values->data(), values->size());
+            values.reset();
+        }
 
         if (encoded.size() > INT32_MAX)
             throw Exception(ErrorCodes::CANNOT_COMPRESS, "Uncompressed page is too big: {}", encoded.size());
@@ -1019,7 +1115,7 @@ void writeColumnImpl(
         total_statistics.merge(page_statistics);
         page_statistics.clear();
 
-        if (use_dictionary)
+        if (use_dictionary && !reuse_dictionary)
         {
             dict_encoded_pages.push_back({.header = std::move(header), .data = {}, .first_row_index = row_idx});
             std::swap(dict_encoded_pages.back().data, compressed);
@@ -1035,11 +1131,29 @@ void writeColumnImpl(
 
     auto flush_dict = [&] -> bool
     {
-        auto * dict_encoder = dynamic_cast<parquet::DictEncoder<ParquetDType> *>(encoder.get());
-        int dict_size = dict_encoder->dict_encoded_size();
+        int num_entries = 0;
+        if (reuse_dictionary)
+        {
+            auto dictionary_page_encoder = parquet::MakeTypedEncoder<ParquetDType>(
+                parquet::Encoding::PLAIN, /* use_dictionary */ false, fixed_string_descr ? &*fixed_string_descr : nullptr);
+            dictionary_page_encoder->Put(dictionary_values, static_cast<int>(dictionary_size));
+            std::shared_ptr<parquet::Buffer> values = dictionary_page_encoder->FlushValues();
 
-        encoded.resize(static_cast<size_t>(dict_size));
-        dict_encoder->WriteDict(reinterpret_cast<uint8_t *>(encoded.data()));
+            encoded.resize(static_cast<size_t>(values->size()));
+            memcpy(encoded.data(), values->data(), values->size());
+            num_entries = static_cast<int>(dictionary_size);
+        }
+        else
+        {
+            auto * dict_encoder = dynamic_cast<parquet::DictEncoder<ParquetDType> *>(encoder.get());
+            encoded.resize(static_cast<size_t>(dict_encoder->dict_encoded_size()));
+            dict_encoder->WriteDict(reinterpret_cast<uint8_t *>(encoded.data()));
+            num_entries = dict_encoder->num_entries();
+        }
+
+        if (encoded.size() > INT32_MAX)
+            throw Exception(ErrorCodes::CANNOT_COMPRESS, "Uncompressed dictionary page is too big: {}", encoded.size());
+        int dict_size = static_cast<int>(encoded.size());
 
         auto & compressed = compress(encoded, compressed_maybe, s.compression, s.compression_level);
 
@@ -1051,7 +1165,7 @@ void writeColumnImpl(
         header.__set_uncompressed_page_size(dict_size);
         header.__set_compressed_page_size(static_cast<int>(compressed.size()));
         header.__isset.dictionary_page_header = true;
-        header.dictionary_page_header.__set_num_values(dict_encoder->num_entries());
+        header.dictionary_page_header.__set_num_values(num_entries);
         header.dictionary_page_header.__set_encoding(parq::Encoding::PLAIN);
 
         if (options.write_checksums)
@@ -1076,6 +1190,9 @@ void writeColumnImpl(
         int dict_size = dict_encoder->dict_encoded_size();
         return static_cast<size_t>(dict_size) >= options.max_dictionary_size;
     };
+
+    if (reuse_dictionary)
+        flush_dict();
 
     while (def_offset < num_values)
     {
@@ -1103,48 +1220,54 @@ void writeColumnImpl(
                 }
             }
 
-            /// Encode the data (but not the levels yet), so that we can estimate its encoded size.
-            const typename ParquetDType::c_type * converted = converter.getBatch(next_data_offset, data_count);
+            if (reuse_dictionary)
+            {
+                const auto & indexes = *reused_dictionary_indexes;
 
-            if (options.write_page_statistics || options.write_column_chunk_statistics)
+                if (options.write_page_statistics || options.write_column_chunk_statistics)
+                    for (size_t i = 0; i < data_count; ++i)
+                        page_statistics.add(dictionary_values[indexes[next_data_offset + i]]);
+
+                if (hashes_for_bloom_filter.has_value())
+                    for (size_t i = 0; i < data_count; ++i)
+                        hashes_for_bloom_filter->insert(dictionary_hashes[indexes[next_data_offset + i]]);
+
+                if constexpr (std::is_same_v<ParquetDType, parquet::ByteArrayType>)
+                    for (size_t i = 0; i < data_count; ++i)
+                        s.column_chunk.meta_data.size_statistics.unencoded_byte_array_data_bytes
+                            += dictionary_values[indexes[next_data_offset + i]].len;
+            }
+            else
+            {
+                const typename ParquetDType::c_type * converted = converter.getBatch(next_data_offset, data_count);
+
+                if (options.write_page_statistics || options.write_column_chunk_statistics)
 /// Workaround for clang bug: https://github.com/llvm/llvm-project/issues/63630
 #ifdef MEMORY_SANITIZER
 #pragma clang loop vectorize(disable)
 #endif
-                for (size_t i = 0; i < data_count; ++i)
-                    page_statistics.add(converted[i]);
+                    for (size_t i = 0; i < data_count; ++i)
+                        page_statistics.add(converted[i]);
 
-            if (hashes_for_bloom_filter.has_value())
-            {
-                for (size_t i = 0; i < data_count; ++i)
+                if (hashes_for_bloom_filter.has_value())
                 {
-                    UInt64 h = 0;
-                    constexpr UInt64 seed = 0;
-                    if constexpr (std::is_same_v<ParquetDType, parquet::FLBAType>)
-                        h = XXH64(converted[i].ptr, converter.fixedStringSize(), seed);
-                    else if constexpr (std::is_same_v<ParquetDType, parquet::ByteArrayType>)
-                        h = XXH64(converted[i].ptr, converted[i].len, seed);
-                    else
-                    {
-                        static_assert(sizeof(converted[i]) <= 12, "unexpected non-primitive type");
-                        h = XXH64(reinterpret_cast<const void*>(&converted[i]), sizeof(converted[i]), seed);
-                    }
-                    hashes_for_bloom_filter->insert(h);
+                    for (size_t i = 0; i < data_count; ++i)
+                        hashes_for_bloom_filter->insert(hash_value(converted[i]));
                 }
-            }
 
-            if constexpr (std::is_same_v<ParquetDType, parquet::ByteArrayType>)
-            {
-                for (size_t i = 0; i < data_count; ++i)
-                    s.column_chunk.meta_data.size_statistics.unencoded_byte_array_data_bytes += converted[i].len;
-            }
+                if constexpr (std::is_same_v<ParquetDType, parquet::ByteArrayType>)
+                {
+                    for (size_t i = 0; i < data_count; ++i)
+                        s.column_chunk.meta_data.size_statistics.unencoded_byte_array_data_bytes += converted[i].len;
+                }
 
-            encoder->Put(converted, static_cast<int>(data_count));
+                encoder->Put(converted, static_cast<int>(data_count));
+            }
 
             next_def_offset += def_count;
             next_data_offset += data_count;
 
-            if (use_dictionary && is_dict_too_big())
+            if (use_dictionary && !reuse_dictionary && is_dict_too_big())
             {
                 /// Fallback to non-dictionary encoding.
                 ///
@@ -1177,8 +1300,11 @@ void writeColumnImpl(
                 break;
             }
 
-            if (next_def_offset == num_values ||
-                static_cast<size_t>(encoder->EstimatedDataEncodedSize()) >= options.data_page_size)
+            size_t estimated_page_size = reuse_dictionary
+                ? (next_data_offset - data_offset) * std::max(dictionary_bit_width, 1) / 8
+                : static_cast<size_t>(encoder->EstimatedDataEncodedSize());
+
+            if (next_def_offset == num_values || estimated_page_size >= options.data_page_size)
             {
                 flush_page(next_def_offset - def_offset, next_data_offset - data_offset);
                 break;
@@ -1186,10 +1312,10 @@ void writeColumnImpl(
         }
     }
 
-    if (use_dictionary)
+    if (use_dictionary && !reuse_dictionary)
         flush_dict();
 
-    chassert(data_offset == s.primitive_column->size());
+    chassert(data_offset == num_rows);
 
     if (options.write_column_chunk_statistics)
     {
@@ -1231,7 +1357,17 @@ void writeColumnChunkBody(
     s.column_chunk.meta_data.__set_total_uncompressed_size(0);
     s.column_chunk.meta_data.__set_data_page_offset(-1);
 
-    s.primitive_column = s.primitive_column->convertToFullColumnIfLowCardinality();
+    if (const auto * low_cardinality = checkAndGetColumn<ColumnLowCardinality>(s.primitive_column.get()))
+    {
+        const auto & dictionary = low_cardinality->getDictionary().getNestedColumn();
+        if (options.use_dictionary_encoding && !s.is_bool && dictionary->byteSize() < options.max_dictionary_size)
+        {
+            s.dictionary_indexes = low_cardinality->getIndexesPtr();
+            s.primitive_column = dictionary;
+        }
+        else
+            s.primitive_column = s.primitive_column->convertToFullColumnIfLowCardinality();
+    }
 
     switch (s.primitive_column->getDataType())
     {
@@ -1603,6 +1739,8 @@ size_t ColumnChunkWriteState::allocatedBytes() const
     size_t r = def.allocated_bytes() + rep.allocated_bytes();
     if (primitive_column)
         r += primitive_column->allocatedBytes();
+    if (dictionary_indexes)
+        r += dictionary_indexes->allocatedBytes();
     return r;
 }
 

--- a/src/Processors/Formats/Impl/Parquet/Write.h
+++ b/src/Processors/Formats/Impl/Parquet/Write.h
@@ -107,6 +107,7 @@ struct ColumnChunkWriteState
     parq::ColumnChunk column_chunk;
 
     ColumnPtr primitive_column;
+    ColumnPtr dictionary_indexes;
     DataTypePtr type;
     CompressionMethod compression{}; // must match what's inside column_chunk
     int compression_level = 3;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.cpp
@@ -3,6 +3,7 @@
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Constant.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Utils.h>
 #include <Storages/MergeTree/MergeTreeDataWriter.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <Functions/FunctionFactory.h>
 #include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnConst.h>
@@ -23,6 +24,14 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+}
+
+static ColumnWithTypeAndName removeLowCardinalityFromPartitionSource(ColumnWithTypeAndName column)
+{
+    column.type = removeLowCardinality(column.type);
+    if (column.column)
+        column.column = column.column->convertToFullColumnIfLowCardinality();
+    return column;
 }
 
 ChunkPartitioner::ChunkPartitioner(
@@ -61,7 +70,7 @@ ChunkPartitioner::ChunkPartitioner(
         ColumnsWithTypeAndName columns_for_function;
         if (transform_and_argument->argument)
             columns_for_function.push_back(ColumnWithTypeAndName(nullptr, std::make_shared<DataTypeUInt64>(), ""));
-        columns_for_function.push_back(sample_block_->getByName(column_name));
+        columns_for_function.push_back(removeLowCardinalityFromPartitionSource(sample_block_->getByName(column_name)));
 
         result_data_types.push_back(function->getReturnType(columns_for_function));
         functions.push_back(function);
@@ -108,7 +117,7 @@ ChunkPartitioner::partitionChunk(const Chunk & chunk)
             auto const_column = ColumnConst::create(std::move(column_value), chunk.getNumRows());
             arguments.push_back(ColumnWithTypeAndName(const_column->clone(), type, "#"));
         }
-        arguments.push_back(name_to_column[columns_to_apply[transform_ind]]);
+        arguments.push_back(removeLowCardinalityFromPartitionSource(name_to_column[columns_to_apply[transform_ind]]));
         auto result
             = functions[transform_ind]->build(arguments)->execute(arguments, result_data_types[transform_ind], chunk.getNumRows(), false);
         functions_columns.push_back(result);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -530,6 +530,7 @@ static bool writeConsolidatedManifestFile(
         }
 
         /// Derive partition value types from a schema that defines every source column the spec references, preferring the current schema then any historical one; register all schemas first so they can be queried by id.
+        persistent_table_components.schema_processor->setLowCardinalityFieldIds(Iceberg::getLowCardinalityFieldIds(metadata_object));
         for (UInt32 i = 0; i < schemas->size(); ++i)
             persistent_table_components.schema_processor->addIcebergTableSchema(schemas->getObject(i));
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -505,6 +505,7 @@ static bool writeConsolidatedManifestFile(
         }
 
         /// Derive partition value types from a schema that defines every source column the spec references, preferring the current schema then any historical one; register all schemas first so they can be queried by id.
+        persistent_table_components.schema_processor->setLowCardinalityFieldIds(Iceberg::getLowCardinalityFieldIds(metadata_object));
         for (UInt32 i = 0; i < schemas->size(); ++i)
             persistent_table_components.schema_processor->addIcebergTableSchema(schemas->getObject(i));
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
@@ -81,6 +81,7 @@ DEFINE_ICEBERG_FIELD(file_sequence_number);
 DEFINE_ICEBERG_FIELD(snapshot_id);
 DEFINE_ICEBERG_FIELD(statistics);
 DEFINE_ICEBERG_FIELD(properties);
+DEFINE_ICEBERG_FIELD_ALIAS(low_cardinality_field_ids, clickhouse-low-cardinality-field-ids);
 DEFINE_ICEBERG_FIELD(owner);
 DEFINE_ICEBERG_FIELD(column_sizes);
 DEFINE_ICEBERG_FIELD(value_counts);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/DataFileStatistics.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/DataFileStatistics.cpp
@@ -1,6 +1,7 @@
 #include <Storages/ObjectStorage/DataLakes/Iceberg/DataFileStatistics.h>
 
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Constant.h>
+#include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnNullable.h>
 #include <Columns/IColumn.h>
 
@@ -53,6 +54,12 @@ void DataFileStatistics::update(const Chunk & chunk)
         {
             for (UInt8 v : nullable_col->getNullMapData())
                 null_counts[i] += v;
+        }
+        else if (const auto * low_cardinality_col = checkAndGetColumn<ColumnLowCardinality>(col.get());
+                 low_cardinality_col && low_cardinality_col->nestedIsNullable())
+        {
+            for (size_t row = 0; row < low_cardinality_col->size(); ++row)
+                null_counts[i] += low_cardinality_col->isNullAt(row);
         }
         ranges[i] = uniteRanges(ranges[i], getExtremeRangeFromColumn(col));
     }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -324,6 +324,8 @@ Int32 IcebergMetadata::parseTableSchema(
 {
     const auto format_version = metadata_object->getValue<Int32>(f_format_version);
 
+    schema_processor.setLowCardinalityFieldIds(Iceberg::getLowCardinalityFieldIds(metadata_object));
+
     if (format_version == 2)
     {
         auto [schema, current_schema_id] = parseTableSchemaV2Method(metadata_object);
@@ -373,6 +375,7 @@ static Poco::JSON::Object::Ptr traverseMetadataAndFindNecessarySnapshotObject(
 {
     if (!metadata_object->has(f_snapshots))
         throw Exception(ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "No snapshot set found in metadata for iceberg file");
+    schema_processor->setLowCardinalityFieldIds(Iceberg::getLowCardinalityFieldIds(metadata_object));
     auto schemas = metadata_object->get(f_schemas).extract<Poco::JSON::Array::Ptr>();
     for (UInt32 j = 0; j < schemas->size(); ++j)
     {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -323,6 +323,8 @@ Int32 IcebergMetadata::parseTableSchema(
 {
     const auto format_version = metadata_object->getValue<Int32>(f_format_version);
 
+    schema_processor.setLowCardinalityFieldIds(Iceberg::getLowCardinalityFieldIds(metadata_object));
+
     if (format_version == 2)
     {
         auto [schema, current_schema_id] = parseTableSchemaV2Method(metadata_object);
@@ -372,6 +374,7 @@ static Poco::JSON::Object::Ptr traverseMetadataAndFindNecessarySnapshotObject(
 {
     if (!metadata_object->has(f_snapshots))
         throw Exception(ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "No snapshot set found in metadata for iceberg file");
+    schema_processor->setLowCardinalityFieldIds(Iceberg::getLowCardinalityFieldIds(metadata_object));
     auto schemas = metadata_object->get(f_schemas).extract<Poco::JSON::Array::Ptr>();
     for (UInt32 j = 0; j < schemas->size(); ++j)
     {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -10,6 +10,7 @@
 #include <Core/Range.h>
 #include <Core/Settings.h>
 #include <Core/TypeId.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
@@ -121,6 +122,8 @@ bool canDumpIcebergStats(const Field & field, DataTypePtr type)
 {
     switch (type->getTypeId())
     {
+        case TypeIndex::LowCardinality:
+            return canDumpIcebergStats(field, removeLowCardinality(type));
         case TypeIndex::Nullable:
         {
             if (field.isNull())
@@ -167,6 +170,8 @@ std::vector<uint8_t> dumpFieldToBytes(const Field & field, DataTypePtr type)
 {
     switch (type->getTypeId())
     {
+        case TypeIndex::LowCardinality:
+            return dumpFieldToBytes(field, removeLowCardinality(type));
         case TypeIndex::Nullable:
             return dumpFieldToBytes(field, assert_cast<const DataTypeNullable *>(type.get())->getNestedType());
         case TypeIndex::Int32:

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.cpp
@@ -448,7 +448,7 @@ void MetadataGenerator::generateDropColumnMetadata(const String & column_name)
 
 void MetadataGenerator::generateAddColumnMetadata(const String & column_name, DataTypePtr type)
 {
-    if (!type->isNullable())
+    if (!type->isNullable() && !type->isLowCardinalityNullable())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Iceberg spec doesn't allow to add non-nullable columns");
     auto current_schema_id = metadata_object->getValue<Int32>(Iceberg::f_current_schema_id);
     metadata_object->set(Iceberg::f_current_schema_id, current_schema_id + 1);
@@ -482,7 +482,9 @@ void MetadataGenerator::generateAddColumnMetadata(const String & column_name, Da
     /// last-column-id must record so every added child gets a globally unique id.
     Int32 new_field_id = last_column_id + 1;
     Int32 iter = new_field_id;
-    auto new_type = Iceberg::getIcebergType(type, iter);
+    auto low_cardinality_field_ids = Iceberg::getLowCardinalityFieldIds(metadata_object);
+    auto new_type = Iceberg::getIcebergType(type, iter, new_field_id, low_cardinality_field_ids);
+    Iceberg::setLowCardinalityFieldIds(metadata_object, low_cardinality_field_ids);
     metadata_object->set(Iceberg::f_last_column_id, iter);
 
     Poco::JSON::Object::Ptr new_field = new Poco::JSON::Object;
@@ -517,7 +519,6 @@ void MetadataGenerator::generateModifyColumnMetadata(const String & column_name,
     current_schema = deepCopy(current_schema);
     auto last_column_id = metadata_object->getValue<Int32>(Iceberg::f_last_column_id);
 
-    auto new_type = Iceberg::getIcebergType(type, last_column_id);
     auto schema_fields = current_schema->getArray(Iceberg::f_fields);
 
     bool found = false;
@@ -526,15 +527,21 @@ void MetadataGenerator::generateModifyColumnMetadata(const String & column_name,
         auto current_field = schema_fields->getObject(i);
         if (current_field->getValue<String>(Iceberg::f_name) == column_name)
         {
+            Int32 field_id = current_field->getValue<Int32>(Iceberg::f_id);
+            auto low_cardinality_field_ids = Iceberg::getLowCardinalityFieldIds(metadata_object);
+            low_cardinality_field_ids.erase(field_id);
+            auto new_type = Iceberg::getIcebergType(type, last_column_id, field_id, low_cardinality_field_ids);
+
             if (!checkValidSchemaEvolution(current_field->get(Iceberg::f_type), new_type.first))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Iceberg spec doesn't allow schema evolution to type {}", type->getPrettyName());
 
             auto old_type = deepCopy(current_field);
             current_field->set(Iceberg::f_type, new_type.first);
-            if (!current_field->getValue<bool>(Iceberg::f_required) && !type->isNullable())
+            if (!current_field->getValue<bool>(Iceberg::f_required) && !type->isNullable() && !type->isLowCardinalityNullable())
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Iceberg spec doesn't allow change type from nullable to non-nullable {}", type->getPrettyName());
 
             current_field->set(Iceberg::f_required, new_type.second);
+            Iceberg::setLowCardinalityFieldIds(metadata_object, low_cardinality_field_ids);
             found = true;
             break;
         }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
@@ -27,6 +27,7 @@
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/DataTypeFixedString.h>
 #include <DataTypes/DataTypeMap.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeTuple.h>
@@ -422,6 +423,9 @@ void IcebergSchemaProcessor::addIcebergTableSchema(Poco::JSON::Object::Ptr schem
     }
     else
     {
+        active_low_cardinality_field_ids
+            = &low_cardinality_field_ids_by_schema_id.emplace(schema_id, low_cardinality_field_ids).first->second;
+        scope_guard low_cardinality_guard([&] { TSA_SUPPRESS_WARNING_FOR_WRITE(active_low_cardinality_field_ids) = nullptr; });
         auto fields = schema_ptr->get(f_fields).extract<Poco::JSON::Array::Ptr>();
         /// A field name is required per the Iceberg spec, and an empty column name is not representable in ClickHouse.
         for (size_t i = 0; i != fields->size(); ++i)
@@ -620,6 +624,42 @@ IcebergSchemaProcessor::getComplexTypeFromObject(const Poco::JSON::Object::Ptr &
     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown Iceberg type: {}", type_name);
 }
 
+void IcebergSchemaProcessor::setLowCardinalityFieldIds(std::set<Int32> field_ids)
+{
+    std::lock_guard lock(mutex);
+    low_cardinality_field_ids = std::move(field_ids);
+}
+
+DataTypePtr IcebergSchemaProcessor::wrapLowCardinalityIfNeeded(
+    const Poco::JSON::Object::Ptr & field, const String & type_key, DataTypePtr type) const
+{
+    const auto * active = TSA_SUPPRESS_WARNING_FOR_READ(active_low_cardinality_field_ids);
+    if (!active)
+        return type;
+
+    const auto & field_ids = *active;
+    if (field_ids.empty() || !type->canBeInsideLowCardinality())
+        return type;
+
+    const char * id_key = nullptr;
+    if (type_key == f_type)
+        id_key = f_id;
+    else if (type_key == f_element)
+        id_key = f_element_id;
+    else if (type_key == f_key)
+        id_key = f_key_id;
+    else if (type_key == f_value)
+        id_key = f_value_id;
+
+    if (!id_key || !field->has(id_key))
+        return type;
+
+    if (!field_ids.contains(field->getValue<Int32>(id_key)))
+        return type;
+
+    return std::make_shared<DataTypeLowCardinality>(type);
+}
+
 DataTypePtr IcebergSchemaProcessor::getFieldType(
     const Poco::JSON::Object::Ptr & field, const String & type_key, bool required, String & current_full_name, bool is_subfield_of_root)
 {
@@ -631,7 +671,9 @@ DataTypePtr IcebergSchemaProcessor::getFieldType(
     {
         const String & type_name = type.extract<String>();
         auto data_type = getSimpleType(type_name, allow_geo_parser);
-        return required || !data_type->canBeInsideNullable() ? data_type : makeNullable(data_type);
+        if (!required && data_type->canBeInsideNullable())
+            data_type = makeNullable(data_type);
+        return wrapLowCardinalityIfNeeded(field, type_key, data_type);
     }
 
     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected 'type' field: {}", type.toString());
@@ -671,6 +713,17 @@ std::shared_ptr<ActionsDAG> IcebergSchemaProcessor::getSchemaTransformationDag(
     auto old_schema_fields = old_schema->get(f_fields).extract<Poco::JSON::Array::Ptr>();
     std::shared_ptr<ActionsDAG> dag = std::make_shared<ActionsDAG>();
     auto & outputs = dag->getOutputs();
+
+    auto activate_low_cardinality_field_ids = [&](Int32 schema_id)
+    {
+        const auto & ids_by_schema_id = TSA_SUPPRESS_WARNING_FOR_READ(low_cardinality_field_ids_by_schema_id);
+        auto it = ids_by_schema_id.find(schema_id);
+        TSA_SUPPRESS_WARNING_FOR_WRITE(active_low_cardinality_field_ids)
+            = it == ids_by_schema_id.end() ? nullptr : &it->second;
+    };
+    scope_guard low_cardinality_guard([&] { TSA_SUPPRESS_WARNING_FOR_WRITE(active_low_cardinality_field_ids) = nullptr; });
+
+    activate_low_cardinality_field_ids(old_id);
     for (size_t i = 0; i != old_schema_fields->size(); ++i)
     {
         auto field = old_schema_fields->getObject(static_cast<UInt32>(i));
@@ -680,6 +733,7 @@ std::shared_ptr<ActionsDAG> IcebergSchemaProcessor::getSchemaTransformationDag(
         old_schema_entries[id] = {field, &dag->addInput(name, getFieldType(field, f_type, required))};
     }
     auto new_schema_fields = new_schema->get(f_fields).extract<Poco::JSON::Array::Ptr>();
+    activate_low_cardinality_field_ids(new_id);
     for (size_t i = 0; i != new_schema_fields->size(); ++i)
     {
         auto field = new_schema_fields->getObject(static_cast<UInt32>(i));
@@ -705,7 +759,9 @@ std::shared_ptr<ActionsDAG> IcebergSchemaProcessor::getSchemaTransformationDag(
                         old_id,
                         new_id);
                 }
+                activate_low_cardinality_field_ids(old_id);
                 auto old_type = getFieldType(old_json, "type", required);
+                activate_low_cardinality_field_ids(new_id);
                 auto transform = std::make_shared<EvolutionFunctionStruct>(DataTypes{type}, DataTypes{old_type}, old_json, field);
                 old_node = &dag->addFunction(transform, std::vector<const Node *>{old_node}, name);
 
@@ -745,7 +801,7 @@ std::shared_ptr<ActionsDAG> IcebergSchemaProcessor::getSchemaTransformationDag(
         }
         else
         {
-            if (!type->isNullable() && !field->isObject(f_type))
+            if (!type->isNullable() && !type->isLowCardinalityNullable() && !field->isObject(f_type))
             {
                 throw Exception(
                     ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
@@ -27,6 +27,7 @@
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/DataTypeFixedString.h>
 #include <DataTypes/DataTypeMap.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeTuple.h>
@@ -423,6 +424,9 @@ void IcebergSchemaProcessor::addIcebergTableSchema(Poco::JSON::Object::Ptr schem
     else
     {
         iceberg_table_schemas_by_ids[schema_id] = schema_ptr;
+        active_low_cardinality_field_ids
+            = &low_cardinality_field_ids_by_schema_id.emplace(schema_id, low_cardinality_field_ids).first->second;
+        scope_guard low_cardinality_guard([&] { TSA_SUPPRESS_WARNING_FOR_WRITE(active_low_cardinality_field_ids) = nullptr; });
         auto fields = schema_ptr->get(f_fields).extract<Poco::JSON::Array::Ptr>();
         auto clickhouse_schema = std::make_shared<NamesAndTypesList>();
         String current_full_name{};
@@ -608,6 +612,42 @@ IcebergSchemaProcessor::getComplexTypeFromObject(const Poco::JSON::Object::Ptr &
     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown Iceberg type: {}", type_name);
 }
 
+void IcebergSchemaProcessor::setLowCardinalityFieldIds(std::set<Int32> field_ids)
+{
+    std::lock_guard lock(mutex);
+    low_cardinality_field_ids = std::move(field_ids);
+}
+
+DataTypePtr IcebergSchemaProcessor::wrapLowCardinalityIfNeeded(
+    const Poco::JSON::Object::Ptr & field, const String & type_key, DataTypePtr type) const
+{
+    const auto * active = TSA_SUPPRESS_WARNING_FOR_READ(active_low_cardinality_field_ids);
+    if (!active)
+        return type;
+
+    const auto & field_ids = *active;
+    if (field_ids.empty() || !type->canBeInsideLowCardinality())
+        return type;
+
+    const char * id_key = nullptr;
+    if (type_key == f_type)
+        id_key = f_id;
+    else if (type_key == f_element)
+        id_key = f_element_id;
+    else if (type_key == f_key)
+        id_key = f_key_id;
+    else if (type_key == f_value)
+        id_key = f_value_id;
+
+    if (!id_key || !field->has(id_key))
+        return type;
+
+    if (!field_ids.contains(field->getValue<Int32>(id_key)))
+        return type;
+
+    return std::make_shared<DataTypeLowCardinality>(type);
+}
+
 DataTypePtr IcebergSchemaProcessor::getFieldType(
     const Poco::JSON::Object::Ptr & field, const String & type_key, bool required, String & current_full_name, bool is_subfield_of_root)
 {
@@ -619,7 +659,9 @@ DataTypePtr IcebergSchemaProcessor::getFieldType(
     {
         const String & type_name = type.extract<String>();
         auto data_type = getSimpleType(type_name, allow_geo_parser);
-        return required || !data_type->canBeInsideNullable() ? data_type : makeNullable(data_type);
+        if (!required && data_type->canBeInsideNullable())
+            data_type = makeNullable(data_type);
+        return wrapLowCardinalityIfNeeded(field, type_key, data_type);
     }
 
     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected 'type' field: {}", type.toString());
@@ -659,6 +701,17 @@ std::shared_ptr<ActionsDAG> IcebergSchemaProcessor::getSchemaTransformationDag(
     auto old_schema_fields = old_schema->get(f_fields).extract<Poco::JSON::Array::Ptr>();
     std::shared_ptr<ActionsDAG> dag = std::make_shared<ActionsDAG>();
     auto & outputs = dag->getOutputs();
+
+    auto activate_low_cardinality_field_ids = [&](Int32 schema_id)
+    {
+        const auto & ids_by_schema_id = TSA_SUPPRESS_WARNING_FOR_READ(low_cardinality_field_ids_by_schema_id);
+        auto it = ids_by_schema_id.find(schema_id);
+        TSA_SUPPRESS_WARNING_FOR_WRITE(active_low_cardinality_field_ids)
+            = it == ids_by_schema_id.end() ? nullptr : &it->second;
+    };
+    scope_guard low_cardinality_guard([&] { TSA_SUPPRESS_WARNING_FOR_WRITE(active_low_cardinality_field_ids) = nullptr; });
+
+    activate_low_cardinality_field_ids(old_id);
     for (size_t i = 0; i != old_schema_fields->size(); ++i)
     {
         auto field = old_schema_fields->getObject(static_cast<UInt32>(i));
@@ -668,6 +721,7 @@ std::shared_ptr<ActionsDAG> IcebergSchemaProcessor::getSchemaTransformationDag(
         old_schema_entries[id] = {field, &dag->addInput(name, getFieldType(field, f_type, required))};
     }
     auto new_schema_fields = new_schema->get(f_fields).extract<Poco::JSON::Array::Ptr>();
+    activate_low_cardinality_field_ids(new_id);
     for (size_t i = 0; i != new_schema_fields->size(); ++i)
     {
         auto field = new_schema_fields->getObject(static_cast<UInt32>(i));
@@ -684,7 +738,9 @@ std::shared_ptr<ActionsDAG> IcebergSchemaProcessor::getSchemaTransformationDag(
                     || field->getObject(f_type)->getValue<std::string>(f_type) == "list"
                     || field->getObject(f_type)->getValue<std::string>(f_type) == "map"))
             {
+                activate_low_cardinality_field_ids(old_id);
                 auto old_type = getFieldType(old_json, "type", required);
+                activate_low_cardinality_field_ids(new_id);
                 auto transform = std::make_shared<EvolutionFunctionStruct>(DataTypes{type}, DataTypes{old_type}, old_json, field);
                 old_node = &dag->addFunction(transform, std::vector<const Node *>{old_node}, name);
 
@@ -724,7 +780,7 @@ std::shared_ptr<ActionsDAG> IcebergSchemaProcessor::getSchemaTransformationDag(
         }
         else
         {
-            if (!type->isNullable() && !field->isObject(f_type))
+            if (!type->isNullable() && !type->isLowCardinalityNullable() && !field->isObject(f_type))
             {
                 throw Exception(
                     ErrorCodes::LOGICAL_ERROR,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.h
@@ -16,6 +16,7 @@
 #include <Poco/JSON/Parser.h>
 #include <Common/SharedMutex.h>
 
+#include <set>
 #include <unordered_map>
 #include <unordered_set>
 namespace DB::Iceberg
@@ -111,6 +112,8 @@ public:
     /// Nullable in the ClickHouse type, so a writer emitting Iceberg `required` must consult this.
     static std::unordered_set<String> collectIcebergOptionalPaths(Poco::JSON::Array::Ptr schema);
 
+    void setLowCardinalityFieldIds(std::set<Int32> field_ids);
+
     void registerSnapshotWithSchemaId(Int64 snapshot_id, Int32 schema_id);
     Int32 getSchemaIdForSnapshot(Int64 snapshot_id) const;
     std::optional<Int32> tryGetSchemaIdForSnapshot(Int64 snapshot_id) const;
@@ -125,6 +128,9 @@ private:
     mutable std::map<std::pair<Int32, std::string>, Int32> clickhouse_ids_by_source_names TSA_GUARDED_BY(mutex);
     std::optional<Int32> current_schema_id TSA_GUARDED_BY(mutex) = 0;
     std::unordered_map<Int64, Int32> schema_id_by_snapshot TSA_GUARDED_BY(mutex);
+    std::set<Int32> low_cardinality_field_ids TSA_GUARDED_BY(mutex);
+    std::unordered_map<Int32, std::set<Int32>> low_cardinality_field_ids_by_schema_id TSA_GUARDED_BY(mutex);
+    const std::set<Int32> * active_low_cardinality_field_ids TSA_GUARDED_BY(mutex) = nullptr;
 
     NamesAndTypesList getSchemaType(const Poco::JSON::Object::Ptr & schema);
     DataTypePtr getComplexTypeFromObject(const Poco::JSON::Object::Ptr & type, String & current_full_name, bool is_subfield_of_root);
@@ -134,6 +140,8 @@ private:
         bool required,
         String & current_full_name = default_link,
         bool is_subfield_of_root = false);
+
+    DataTypePtr wrapLowCardinalityIfNeeded(const Poco::JSON::Object::Ptr & field, const String & type_key, DataTypePtr type) const;
 
     bool allowPrimitiveTypeConversion(const String & old_type, const String & new_type);
     const Node * getDefaultNodeForField(const Poco::JSON::Object::Ptr & field);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -575,7 +575,7 @@ LowCardinalityFieldIds getLowCardinalityFieldIds(Poco::JSON::Object::Ptr metadat
     ReadBufferFromString buf(serialized_field_ids);
     while (!buf.eof())
     {
-        Int32 field_id;
+        Int32 field_id = 0;
         readIntText(field_id, buf);
         result.insert(field_id);
         if (!buf.eof())

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -10,6 +10,7 @@
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeCustom.h>
 #include <DataTypes/DataTypeDateTime64.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesDecimal.h>
@@ -49,7 +50,10 @@
 #include <Processors/Formats/Impl/AvroRowInputFormat.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Utils.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Constant.h>
+#include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
 #include <filesystem>
 #include <regex>
 
@@ -557,8 +561,53 @@ Poco::JSON::Object::Ptr getMetadataJSONObject(
     return json.extract<Poco::JSON::Object::Ptr>();
 }
 
+LowCardinalityFieldIds getLowCardinalityFieldIds(Poco::JSON::Object::Ptr metadata_object)
+{
+    LowCardinalityFieldIds result;
+    if (!metadata_object->has(Iceberg::f_properties))
+        return result;
+
+    auto properties = metadata_object->getObject(Iceberg::f_properties);
+    if (!properties || !properties->has(Iceberg::f_low_cardinality_field_ids))
+        return result;
+
+    const String serialized_field_ids = properties->getValue<String>(Iceberg::f_low_cardinality_field_ids);
+    ReadBufferFromString buf(serialized_field_ids);
+    while (!buf.eof())
+    {
+        Int32 field_id;
+        readIntText(field_id, buf);
+        result.insert(field_id);
+        if (!buf.eof())
+            assertChar(',', buf);
+    }
+    return result;
+}
+
+void setLowCardinalityFieldIds(Poco::JSON::Object::Ptr metadata_object, const LowCardinalityFieldIds & field_ids)
+{
+    if (field_ids.empty())
+    {
+        if (metadata_object->has(Iceberg::f_properties))
+            metadata_object->getObject(Iceberg::f_properties)->remove(Iceberg::f_low_cardinality_field_ids);
+        return;
+    }
+
+    if (!metadata_object->has(Iceberg::f_properties))
+        metadata_object->set(Iceberg::f_properties, Poco::JSON::Object::Ptr(new Poco::JSON::Object));
+
+    WriteBufferFromOwnString buf;
+    for (auto it = field_ids.begin(); it != field_ids.end(); ++it)
+    {
+        if (it != field_ids.begin())
+            writeChar(',', buf);
+        writeIntText(*it, buf);
+    }
+    metadata_object->getObject(Iceberg::f_properties)->set(Iceberg::f_low_cardinality_field_ids, buf.str());
+}
+
 /// Returns type and required
-std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & iter)
+std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & iter, Int32 field_id, LowCardinalityFieldIds & low_cardinality_field_ids)
 {
     switch (type->getTypeId())
     {
@@ -600,7 +649,7 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
                 field->set(Iceberg::f_name, type_tuple->getNameByPosition(iter_names));
                 /// Recurse on the element itself: `getNormalizedType` would rename a nested
                 /// tuple's elements to "1", "2", ... (`DataTypeTuple::getNormalizedType`).
-                auto child_type = getIcebergType(element, iter);
+                auto child_type = getIcebergType(element, iter, static_cast<Int32>(iter_fields), low_cardinality_field_ids);
                 field->set(Iceberg::f_required, child_type.second);
                 field->set(Iceberg::f_type, child_type.first);
                 fields->add(field);
@@ -614,9 +663,10 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
             auto type_array = std::static_pointer_cast<const DataTypeArray>(type);
             Poco::JSON::Object::Ptr field = new Poco::JSON::Object;
 
+            Int32 element_id = ++iter;
             field->set(Iceberg::f_type, "list");
-            field->set(Iceberg::f_element_id, ++iter);
-            auto child_type = getIcebergType(type_array->getNestedType(), iter);
+            field->set(Iceberg::f_element_id, element_id);
+            auto child_type = getIcebergType(type_array->getNestedType(), iter, element_id, low_cardinality_field_ids);
             field->set(Iceberg::f_required, false);
             field->set(Iceberg::f_element, child_type.first);
             field->set(Iceberg::f_element_required, child_type.second);
@@ -627,12 +677,14 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
             auto type_map = std::static_pointer_cast<const DataTypeMap>(type);
             Poco::JSON::Object::Ptr field = new Poco::JSON::Object;
 
+            Int32 key_id = ++iter;
+            Int32 value_id = ++iter;
             field->set(Iceberg::f_type, "map");
-            field->set(Iceberg::f_key_id, ++iter);
-            field->set(Iceberg::f_value_id, ++iter);
+            field->set(Iceberg::f_key_id, key_id);
+            field->set(Iceberg::f_value_id, value_id);
 
-            field->set(Iceberg::f_key, getIcebergType(type_map->getKeyType(), iter).first);
-            auto value_type = getIcebergType(type_map->getValueType(), iter);
+            field->set(Iceberg::f_key, getIcebergType(type_map->getKeyType(), iter, key_id, low_cardinality_field_ids).first);
+            auto value_type = getIcebergType(type_map->getValueType(), iter, value_id, low_cardinality_field_ids);
             field->set(Iceberg::f_value, value_type.first);
             field->set(Iceberg::f_value_required, value_type.second);
             return {field, true};
@@ -640,7 +692,13 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
         case TypeIndex::Nullable:
         {
             auto type_nullable = std::static_pointer_cast<const DataTypeNullable>(type);
-            return {getIcebergType(type_nullable->getNestedType(), iter).first, false};
+            return {getIcebergType(type_nullable->getNestedType(), iter, field_id, low_cardinality_field_ids).first, false};
+        }
+        case TypeIndex::LowCardinality:
+        {
+            auto type_low_cardinality = std::static_pointer_cast<const DataTypeLowCardinality>(type);
+            low_cardinality_field_ids.insert(field_id);
+            return getIcebergType(type_low_cardinality->getDictionaryType(), iter, field_id, low_cardinality_field_ids);
         }
         case TypeIndex::Variant:
         {
@@ -1034,17 +1092,19 @@ std::pair<Poco::JSON::Object::Ptr, String> createEmptyMetadataFile(
     /// column count) so a later ADD COLUMN does not reuse a nested field id.
     Int32 iter = static_cast<Int32>(columns.size());
     Int32 iter_for_initial_columns = 0;
+    LowCardinalityFieldIds low_cardinality_field_ids;
     for (const auto & column : columns)
     {
         Poco::JSON::Object::Ptr field = new Poco::JSON::Object;
         field->set(Iceberg::f_id, ++iter_for_initial_columns);
         field->set(Iceberg::f_name, column.name);
-        auto type = getIcebergType(column.type, iter);
+        auto type = getIcebergType(column.type, iter, iter_for_initial_columns, low_cardinality_field_ids);
         field->set(Iceberg::f_required, type.second);
         field->set(Iceberg::f_type, type.first);
         column_name_to_source_id[column.name] = iter_for_initial_columns;
         schema_fields->add(field);
     }
+    setLowCardinalityFieldIds(new_metadata_file_content, low_cardinality_field_ids);
     new_metadata_file_content->set(Iceberg::f_last_column_id, iter);
     schema_representation->set(Iceberg::f_fields, schema_fields);
     Poco::JSON::Array::Ptr schema_array = new Poco::JSON::Array;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -10,6 +10,7 @@
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeCustom.h>
 #include <DataTypes/DataTypeDateTime64.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesDecimal.h>
@@ -49,7 +50,10 @@
 #include <Processors/Formats/Impl/AvroRowInputFormat.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Utils.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Constant.h>
+#include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
 #include <filesystem>
 #include <regex>
 
@@ -546,8 +550,53 @@ Poco::JSON::Object::Ptr getMetadataJSONObject(
     return json.extract<Poco::JSON::Object::Ptr>();
 }
 
+LowCardinalityFieldIds getLowCardinalityFieldIds(Poco::JSON::Object::Ptr metadata_object)
+{
+    LowCardinalityFieldIds result;
+    if (!metadata_object->has(Iceberg::f_properties))
+        return result;
+
+    auto properties = metadata_object->getObject(Iceberg::f_properties);
+    if (!properties || !properties->has(Iceberg::f_low_cardinality_field_ids))
+        return result;
+
+    const String serialized_field_ids = properties->getValue<String>(Iceberg::f_low_cardinality_field_ids);
+    ReadBufferFromString buf(serialized_field_ids);
+    while (!buf.eof())
+    {
+        Int32 field_id;
+        readIntText(field_id, buf);
+        result.insert(field_id);
+        if (!buf.eof())
+            assertChar(',', buf);
+    }
+    return result;
+}
+
+void setLowCardinalityFieldIds(Poco::JSON::Object::Ptr metadata_object, const LowCardinalityFieldIds & field_ids)
+{
+    if (field_ids.empty())
+    {
+        if (metadata_object->has(Iceberg::f_properties))
+            metadata_object->getObject(Iceberg::f_properties)->remove(Iceberg::f_low_cardinality_field_ids);
+        return;
+    }
+
+    if (!metadata_object->has(Iceberg::f_properties))
+        metadata_object->set(Iceberg::f_properties, Poco::JSON::Object::Ptr(new Poco::JSON::Object));
+
+    WriteBufferFromOwnString buf;
+    for (auto it = field_ids.begin(); it != field_ids.end(); ++it)
+    {
+        if (it != field_ids.begin())
+            writeChar(',', buf);
+        writeIntText(*it, buf);
+    }
+    metadata_object->getObject(Iceberg::f_properties)->set(Iceberg::f_low_cardinality_field_ids, buf.str());
+}
+
 /// Returns type and required
-std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & iter)
+std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & iter, Int32 field_id, LowCardinalityFieldIds & low_cardinality_field_ids)
 {
     switch (type->getTypeId())
     {
@@ -589,7 +638,7 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
                 field->set(Iceberg::f_name, type_tuple->getNameByPosition(iter_names));
                 /// Recurse on the element itself: `getNormalizedType` would rename a nested
                 /// tuple's elements to "1", "2", ... (`DataTypeTuple::getNormalizedType`).
-                auto child_type = getIcebergType(element, iter);
+                auto child_type = getIcebergType(element, iter, static_cast<Int32>(iter_fields), low_cardinality_field_ids);
                 field->set(Iceberg::f_required, child_type.second);
                 field->set(Iceberg::f_type, child_type.first);
                 fields->add(field);
@@ -603,9 +652,10 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
             auto type_array = std::static_pointer_cast<const DataTypeArray>(type);
             Poco::JSON::Object::Ptr field = new Poco::JSON::Object;
 
+            Int32 element_id = ++iter;
             field->set(Iceberg::f_type, "list");
-            field->set(Iceberg::f_element_id, ++iter);
-            auto child_type = getIcebergType(type_array->getNestedType(), iter);
+            field->set(Iceberg::f_element_id, element_id);
+            auto child_type = getIcebergType(type_array->getNestedType(), iter, element_id, low_cardinality_field_ids);
             field->set(Iceberg::f_required, false);
             field->set(Iceberg::f_element, child_type.first);
             field->set(Iceberg::f_element_required, child_type.second);
@@ -616,12 +666,14 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
             auto type_map = std::static_pointer_cast<const DataTypeMap>(type);
             Poco::JSON::Object::Ptr field = new Poco::JSON::Object;
 
+            Int32 key_id = ++iter;
+            Int32 value_id = ++iter;
             field->set(Iceberg::f_type, "map");
-            field->set(Iceberg::f_key_id, ++iter);
-            field->set(Iceberg::f_value_id, ++iter);
+            field->set(Iceberg::f_key_id, key_id);
+            field->set(Iceberg::f_value_id, value_id);
 
-            field->set(Iceberg::f_key, getIcebergType(type_map->getKeyType(), iter).first);
-            auto value_type = getIcebergType(type_map->getValueType(), iter);
+            field->set(Iceberg::f_key, getIcebergType(type_map->getKeyType(), iter, key_id, low_cardinality_field_ids).first);
+            auto value_type = getIcebergType(type_map->getValueType(), iter, value_id, low_cardinality_field_ids);
             field->set(Iceberg::f_value, value_type.first);
             field->set(Iceberg::f_value_required, value_type.second);
             return {field, true};
@@ -629,7 +681,13 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
         case TypeIndex::Nullable:
         {
             auto type_nullable = std::static_pointer_cast<const DataTypeNullable>(type);
-            return {getIcebergType(type_nullable->getNestedType(), iter).first, false};
+            return {getIcebergType(type_nullable->getNestedType(), iter, field_id, low_cardinality_field_ids).first, false};
+        }
+        case TypeIndex::LowCardinality:
+        {
+            auto type_low_cardinality = std::static_pointer_cast<const DataTypeLowCardinality>(type);
+            low_cardinality_field_ids.insert(field_id);
+            return getIcebergType(type_low_cardinality->getDictionaryType(), iter, field_id, low_cardinality_field_ids);
         }
         case TypeIndex::Variant:
         {
@@ -1023,17 +1081,19 @@ std::pair<Poco::JSON::Object::Ptr, String> createEmptyMetadataFile(
     /// column count) so a later ADD COLUMN does not reuse a nested field id.
     Int32 iter = static_cast<Int32>(columns.size());
     Int32 iter_for_initial_columns = 0;
+    LowCardinalityFieldIds low_cardinality_field_ids;
     for (const auto & column : columns)
     {
         Poco::JSON::Object::Ptr field = new Poco::JSON::Object;
         field->set(Iceberg::f_id, ++iter_for_initial_columns);
         field->set(Iceberg::f_name, column.name);
-        auto type = getIcebergType(column.type, iter);
+        auto type = getIcebergType(column.type, iter, iter_for_initial_columns, low_cardinality_field_ids);
         field->set(Iceberg::f_required, type.second);
         field->set(Iceberg::f_type, type.first);
         column_name_to_source_id[column.name] = iter_for_initial_columns;
         schema_fields->add(field);
     }
+    setLowCardinalityFieldIds(new_metadata_file_content, low_cardinality_field_ids);
     new_metadata_file_content->set(Iceberg::f_last_column_id, iter);
     schema_representation->set(Iceberg::f_fields, schema_fields);
     Poco::JSON::Array::Ptr schema_array = new Poco::JSON::Array;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.h
@@ -5,6 +5,7 @@
 #if USE_AVRO
 
 #include <optional>
+#include <set>
 #include <string>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/FileNamesGenerator.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/PersistentTableComponents.h>
@@ -83,7 +84,12 @@ Poco::JSON::Object::Ptr getMetadataJSONObject(
     const std::optional<String> & table_uuid);
 
 
-std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & iter);
+using LowCardinalityFieldIds = std::set<Int32>;
+
+LowCardinalityFieldIds getLowCardinalityFieldIds(Poco::JSON::Object::Ptr metadata_object);
+void setLowCardinalityFieldIds(Poco::JSON::Object::Ptr metadata_object, const LowCardinalityFieldIds & field_ids);
+
+std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & iter, Int32 field_id, LowCardinalityFieldIds & low_cardinality_field_ids);
 Poco::Dynamic::Var getAvroType(DataTypePtr type);
 
 /// Spec: https://iceberg.apache.org/spec/?h=metadata.json#table-metadata-fields

--- a/tests/integration/test_storage_iceberg_with_spark/test_writes_low_cardinality.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_writes_low_cardinality.py
@@ -1,0 +1,81 @@
+import pytest
+
+from helpers.iceberg_utils import (
+    create_iceberg_table,
+    default_download_directory,
+    get_uuid_str,
+)
+
+
+@pytest.mark.parametrize("format_version", ["1", "2"])
+@pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
+def test_writes_low_cardinality(
+    started_cluster_iceberg_with_spark, format_version, storage_type
+):
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    spark = started_cluster_iceberg_with_spark.spark_session
+    TABLE_NAME = "test_writes_low_cardinality_" + storage_type + "_" + get_uuid_str()
+
+    schema = (
+        "(i Int32, "
+        "s LowCardinality(String), "
+        "n LowCardinality(Nullable(String)), "
+        "a Array(LowCardinality(String)))"
+    )
+    create_iceberg_table(
+        storage_type,
+        instance,
+        TABLE_NAME,
+        started_cluster_iceberg_with_spark,
+        schema,
+        format_version,
+    )
+
+    instance.query(
+        f"INSERT INTO {TABLE_NAME} VALUES (1, 'a', 'x', ['p', 'q']), (2, 'b', NULL, [])",
+        settings={"allow_experimental_insert_into_iceberg": 1},
+    )
+
+    assert (
+        instance.query(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL")
+        == "1\ta\tx\t['p','q']\n2\tb\t\\N\t[]\n"
+    )
+
+    instance.query(f"DETACH TABLE {TABLE_NAME}")
+    instance.query(f"ATTACH TABLE {TABLE_NAME}")
+    assert instance.query(
+        f"SELECT toTypeName(s), toTypeName(n), toTypeName(a) FROM {TABLE_NAME} LIMIT 1"
+    ) == "LowCardinality(String)\tLowCardinality(Nullable(String))\tArray(LowCardinality(String))\n"
+
+    assert (
+        instance.query(f"SELECT count() FROM {TABLE_NAME} WHERE s = 'a'").strip() == "1"
+    )
+
+    if storage_type == "azure":
+        return
+
+    default_download_directory(
+        started_cluster_iceberg_with_spark,
+        storage_type,
+        f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/",
+        f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/",
+    )
+
+    with open(
+        f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/metadata/version-hint.text",
+        "wb",
+    ) as f:
+        f.write(b"1")
+
+    df = (
+        spark.read.format("iceberg")
+        .load(
+            f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}"
+        )
+        .sort("i")
+        .collect()
+    )
+    assert len(df) == 2
+    assert [row["s"] for row in df] == ["a", "b"]
+    assert [row["n"] for row in df] == ["x", None]
+    assert [row["a"] for row in df] == [["p", "q"], []]


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
1) allow to use low cardinality types for iceberg. It will be converted to usual type + uses dictionary encoding of parquet. Also it will write special clickhouse field ids to the iceberg metadata json file.
2) Avoid arrow's encoding and use low cardinality column directly in parquet writer. It improves the speed of inserts for the query (0.80s -> 0.34s):

```
INSERT INTO FUNCTION file('bench.parquet', Parquet)
SELECT toLowCardinality(concat('value_', toString(number % 100))) AS s
FROM numbers(20000000)
SETTINGS engine_file_truncate_on_insert = 1,
         max_threads = 1,
         max_insert_threads = 1;
```
