### PR TITLE
Fix flaky test_partial_auth cleanup after widening the parent ACL

### DIFF
--- a/tests/integration/test_keeper_auth/test.py
+++ b/tests/integration/test_keeper_auth/test.py
@@ -61,6 +61,22 @@ def zk_stop_and_close(zk):
         zk.close()
 
 
+# ZooKeeper checks delete against the PARENT's ACL, and its setACL leaves the
+# outstanding change record carrying the old ACL (duplicate() copies acl verbatim
+# and updates only stat.aversion), so a delete issued right after a widening
+# setACL can still be authorized against the pre-setACL ACL and get NoAuthError.
+def zk_delete_after_acl_change(zk, path, timeout=30.0):
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            zk.delete(path)
+            return
+        except NoAuthError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.1)
+
+
 @pytest.mark.parametrize(("get_zk"), [get_genuine_zk, get_fake_zk])
 def test_remove_acl(started_cluster, get_zk):
     auth_connection = None
@@ -412,7 +428,9 @@ def test_partial_auth(started_cluster, get_zk):
         )
         auth_connection.set_acls("/test_partial_acl_delete", acls=[acl])
         auth_connection.set_acls("/test_partial_acl_delete/subnode", acls=[acl])
-        auth_connection.delete("/test_partial_acl_delete/subnode")
+        zk_delete_after_acl_change(auth_connection, "/test_partial_acl_delete/subnode")
+        # Authorized against "/", whose ACL this test never touches, so a
+        # NoAuthError here would be a real problem: do not retry it.
         auth_connection.delete("/test_partial_acl_delete")
         zk_stop_and_close(auth_connection)
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/78981 (closed, same test, earlier remedy did not hold)
Observed on: https://github.com/ClickHouse/ClickHouse/pull/100377

`test_keeper_auth/test.py::test_partial_auth[get_genuine_zk]` can fail in its
`finally` cleanup, never in an assertion:

```
test_keeper_auth/test.py:415: in test_partial_auth
    auth_connection.delete("/test_partial_acl_delete/subnode")
E   kazoo.exceptions.NoAuthError
```

Seen on `Integration tests (amd_tsan, 2/6)`
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100377&sha=73a75d7bec0160a487b7aff7139350c59ee71503&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%202%2F6%29)).
Only the Apache ZooKeeper parametrization is affected; the Keeper one passes the
identical sequence. This exact signature fired once in 400 days and on no master
run, so it is cheap to decline if you would rather leave it.

Root cause is upstream ZooKeeper, not ClickHouse. ZooKeeper authorizes a delete
against the **parent's** ACL, and its `setACL` publishes an outstanding
`ChangeRecord` still carrying the *old* ACL: the new ACL goes only into the
`SetACLTxn`, then `duplicate` copies `acl` verbatim and updates only
`stat.aversion`. A delete prepped after the client's `setACL` reply but before
that txn is applied is checked against the pre-`setACL` ACL, which this test
deliberately created with `delete=False`, and gets `NoAuthError`. Keeper is
read-your-own-writes here, which is the asymmetry. It also explains why #79104's
remedy did not hold: it added the two `setACL` calls that already succeed right
before the delete that still fails. The problem is the permission's visibility,
not the permission.

The fix retries only that one cleanup delete, only on `NoAuthError`, on a
wall-clock deadline. The parent delete is authorized against `/`, whose ACL this
test never touches, so it stays un-retried and still fails loudly. No assertion
is touched.

Validation: the race opens on demand by issuing the child delete before the
parent `setACL` is acknowledged (10/40 iterations, 3-node ZK 3.6.2). With the
helper at `timeout=0` it still fails (2 of 32 opened windows); at the shipped
`timeout=30` it does not (0 of 85). The test's own `pytest.raises(NoAuthError)`
oracle was confirmed non-vacuous. 50 runs x both parametrizations pass, and the
whole 26-test file passes.