### PR TITLE
CI log parser: find the `Format string` line despite interleaved log lines

### DIFF
--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -22,6 +22,38 @@ class FuzzerLogParser:
         r".*[a-zA-Z]+Sanitizer: CHECK failed:.*"
     )
     RUNTIME_ERROR_PATTERN = r".*runtime error: .*|.*is located.*"
+    # (name, flag_name, pattern) triples checked in this order by `parse_failure`;
+    # also used to bound the thread-less `Format string:` search by the next failure
+    # of any kind, so keep every failure-carrying pattern listed here.
+    ERROR_PATTERNS = [
+        (
+            "Sanitizer",
+            "is_sanitizer_error",
+            SANITIZER_ERROR_PATTERN,
+        ),
+        ("Logical error", "is_logical_error", r"Logical error.*"),
+        (
+            "Assertion",
+            "is_logical_error",
+            r"Assertion.*failed|Failed assertion.*|.*_LIBCPP_ASSERT.*",
+        ),
+        (
+            "Runtime error",
+            "is_sanitizer_error",
+            RUNTIME_ERROR_PATTERN,
+        ),
+        ("SegFault", "is_segfault", r"Segmentation fault.*"),
+        (
+            "Signal",
+            "is_killed_by_signal",
+            r"Received signal.*|.*Child process was terminated by signal 9.*",
+        ),
+        (
+            "Memory limit exceeded",
+            "is_memory_limit_exceeded",
+            r".*\(total\) memory limit exceeded.*",
+        ),
+    ]
     SQL_COMMANDS = [
         "SELECT",
         "INSERT",
@@ -114,10 +146,15 @@ class FuzzerLogParser:
             # The input has no thread ids (e.g. a bare stack trace string), so bound
             # the search by the failure block instead: the format string belongs to
             # this failure only if it appears before the next fatal / failure line.
+            # The next failure may be carried by any pattern (e.g. an assertion
+            # following a logical error), so check all of them, not just the matched
+            # one.
             for line in lines[match_index + 1 :]:
                 if "Format string: " in line:
                     return self.extract_format_string(line)
-                if "<Fatal>" in line or re.search(matched_pattern, line):
+                if "<Fatal>" in line or any(
+                    re.search(pattern, line) for _, _, pattern in self.ERROR_PATTERNS
+                ):
                     return ""
             return ""
 
@@ -142,40 +179,11 @@ class FuzzerLogParser:
         is_killed_by_signal = False
         is_segfault = False
         is_memory_limit_exceeded = False
-        error_patterns = [
-            (
-                "Sanitizer",
-                "is_sanitizer_error",
-                self.SANITIZER_ERROR_PATTERN,
-            ),
-            ("Logical error", "is_logical_error", r"Logical error.*"),
-            (
-                "Assertion",
-                "is_logical_error",
-                r"Assertion.*failed|Failed assertion.*|.*_LIBCPP_ASSERT.*",
-            ),
-            (
-                "Runtime error",
-                "is_sanitizer_error",
-                self.RUNTIME_ERROR_PATTERN,
-            ),
-            ("SegFault", "is_segfault", r"Segmentation fault.*"),
-            (
-                "Signal",
-                "is_killed_by_signal",
-                r"Received signal.*|.*Child process was terminated by signal 9.*",
-            ),
-            (
-                "Memory limit exceeded",
-                "is_memory_limit_exceeded",
-                r".*\(total\) memory limit exceeded.*",
-            ),
-        ]
 
         error_output = None
         matched_pattern = None
         matched_log_file = None
-        for name, flag_name, pattern in error_patterns:
+        for name, flag_name, pattern in self.ERROR_PATTERNS:
             output = ""
             file = None
             if self.stack_trace_str:

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -65,6 +65,17 @@ class FuzzerLogParser:
         self.stderr_log = stderr_log
         self.stack_trace_str = stack_trace_str
 
+    @staticmethod
+    def extract_format_string(line):
+        # Extract the format string content between quotes
+        # Example: "... <Fatal> : Format string: 'Unknown numeric column of type: {}'."
+        start_idx = line.find("Format string: ")
+        if start_idx == -1:
+            return ""
+        substring = line[start_idx + len("Format string: ") :]
+        # Remove quotes and trailing period
+        return substring.strip().rstrip(".").strip("'\"")
+
     def parse_failure(self):
         files = []
         is_logical_error = False
@@ -103,8 +114,11 @@ class FuzzerLogParser:
         ]
 
         error_output = None
+        matched_pattern = None
+        matched_log_file = None
         for name, flag_name, pattern in error_patterns:
             output = ""
+            file = None
             if self.stack_trace_str:
                 output = Shell.get_output(
                     f"echo '{self.stack_trace_str}' | rg --text -A 10 -o '{pattern}' | head -n10",
@@ -127,6 +141,8 @@ class FuzzerLogParser:
 
             if output:
                 error_output = output
+                matched_pattern = pattern
+                matched_log_file = file
                 if flag_name == "is_sanitizer_error":
                     is_sanitizer_error = True
                 elif flag_name == "is_logical_error":
@@ -155,17 +171,31 @@ class FuzzerLogParser:
         if marker_pos != -1:
             result_name = result_name[:marker_pos].rstrip().removesuffix(".")
         format_message = ""
-        for i, line in enumerate(error_lines):
+        for line in error_lines:
             if "Format string: " in line:
-                # Extract the format string content between quotes
-                # Example: "... <Fatal> : Format string: 'Unknown numeric column of type: {}'."
-                start_idx = line.find("Format string: ")
-                if start_idx != -1:
-                    substring = line[start_idx + len("Format string: ") :]
-                    # Remove quotes and trailing period
-                    substring = substring.strip().rstrip(".").strip("'\"")
-                    format_message = substring
+                format_message = self.extract_format_string(line)
                 break
+        if not format_message and is_logical_error:
+            # `abortOnFailedAssertion` logs the `Format string:` line right after the
+            # `Logical error:` line, but messages from other threads (together with
+            # their multi-line stack traces) may interleave between the two and push
+            # it out of the 10-line window captured above. Search for it separately,
+            # starting from the matched error line, so the failure name stays
+            # normalized regardless of log interleaving.
+            format_line = ""
+            if self.stack_trace_str:
+                format_line = Shell.get_output(
+                    f"echo '{self.stack_trace_str}' | rg --text -m1 'Format string: '"
+                )
+            elif matched_log_file:
+                match_position = Shell.get_output(
+                    f"rg --text -n -m1 '{matched_pattern}' {matched_log_file} | cut -d: -f1"
+                )
+                if match_position.isdigit():
+                    format_line = Shell.get_output(
+                        f"tail -n +{match_position} {matched_log_file} | rg --text -m1 'Format string: '"
+                    )
+            format_message = self.extract_format_string(format_line)
         is_check_failed = bool(
             error_lines and re.search(r"\w+Sanitizer: CHECK failed:", error_lines[0])
         )

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -89,8 +89,9 @@ class FuzzerLogParser:
         # when the format string is empty. So it belongs to this failure only if it is
         # the next fatal message of the same thread; otherwise this failure has none
         # and "" is returned, so that an unrelated later failure never renames it.
-        # `None` means the search could not be bounded to the failure, because the
-        # thread that logged it is unknown - e.g. the input has no server log lines.
+        # When the input has no thread ids, the search is bounded by the failure
+        # block instead. `None` means the search could not be bounded to the failure
+        # - e.g. the matched line could not be located in the input.
         if self.stack_trace_str:
             lines = self.stack_trace_str.splitlines()
             match_index = next(
@@ -100,17 +101,25 @@ class FuzzerLogParser:
             if match_index == -1:
                 return None
             thread = self.thread_id(lines[match_index])
-            if not thread:
-                return None
-            next_fatal_line = next(
-                (
-                    line
-                    for line in lines[match_index + 1 :]
-                    if f"[ {thread} ] {{" in line and "<Fatal>" in line
-                ),
-                "",
-            )
-            return self.extract_format_string(next_fatal_line)
+            if thread:
+                next_fatal_line = next(
+                    (
+                        line
+                        for line in lines[match_index + 1 :]
+                        if f"[ {thread} ] {{" in line and "<Fatal>" in line
+                    ),
+                    "",
+                )
+                return self.extract_format_string(next_fatal_line)
+            # The input has no thread ids (e.g. a bare stack trace string), so bound
+            # the search by the failure block instead: the format string belongs to
+            # this failure only if it appears before the next fatal / failure line.
+            for line in lines[match_index + 1 :]:
+                if "Format string: " in line:
+                    return self.extract_format_string(line)
+                if "<Fatal>" in line or re.search(matched_pattern, line):
+                    return ""
+            return ""
 
         if not matched_log_file:
             return None
@@ -611,6 +620,9 @@ class FuzzerLogParser:
         # TODO: Fetch the failed query from fuzzer.log instead of server.log to ensure exact matching.
         # The server.log may normalize whitespace or format queries differently, making it difficult
         # to locate the corresponding query and its dependencies in fuzzer.log.
+        if not self.server_log:
+            # Without a file argument `rg` would search the working directory.
+            return None
         failure_output = Shell.get_output(
             f"rg --text -A10 'Logical error.*|Assertion.*failed|Failed assertion.*|.*runtime error: .*|.*is located.*|(SUMMARY|ERROR|WARNING): [a-zA-Z]+Sanitizer:.*|.*_LIBCPP_ASSERT.*' {self.server_log}",
             verbose=True,

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -76,6 +76,56 @@ class FuzzerLogParser:
         # Remove quotes and trailing period
         return substring.strip().rstrip(".").strip("'\"")
 
+    @staticmethod
+    def thread_id(line):
+        # The thread id of a server log line: "... [ 4353 ] {} <Fatal> : ...".
+        match = re.search(r"\[ (\d+) \] \{", line)
+        return match.group(1) if match else ""
+
+    def find_format_string(self, matched_pattern, matched_log_file):
+        # Find the `Format string:` message belonging to the failure matched by
+        # `matched_pattern`. `abortOnFailedAssertion` logs it immediately after the
+        # `Logical error:` message, from the same thread, but does not log it at all
+        # when the format string is empty. So it belongs to this failure only if it is
+        # the next fatal message of the same thread; otherwise this failure has none
+        # and "" is returned, so that an unrelated later failure never renames it.
+        # `None` means the search could not be bounded to the failure, because the
+        # thread that logged it is unknown - e.g. the input has no server log lines.
+        if self.stack_trace_str:
+            lines = self.stack_trace_str.splitlines()
+            match_index = next(
+                (i for i, line in enumerate(lines) if re.search(matched_pattern, line)),
+                -1,
+            )
+            if match_index == -1:
+                return None
+            thread = self.thread_id(lines[match_index])
+            if not thread:
+                return None
+            next_fatal_line = next(
+                (
+                    line
+                    for line in lines[match_index + 1 :]
+                    if f"[ {thread} ] {{" in line and "<Fatal>" in line
+                ),
+                "",
+            )
+            return self.extract_format_string(next_fatal_line)
+
+        if not matched_log_file:
+            return None
+        match_position, _, match_line = Shell.get_output(
+            f"rg --text -n -m1 '{matched_pattern}' {matched_log_file}"
+        ).partition(":")
+        thread = self.thread_id(match_line)
+        if not match_position.isdigit() or not thread:
+            return None
+        next_fatal_line = Shell.get_output(
+            f"tail -n +{int(match_position) + 1} {matched_log_file}"
+            f" | rg --text -m1 '\\[ {thread} \\] \\{{.*<Fatal>'"
+        )
+        return self.extract_format_string(next_fatal_line)
+
     def parse_failure(self):
         files = []
         is_logical_error = False
@@ -171,31 +221,25 @@ class FuzzerLogParser:
         if marker_pos != -1:
             result_name = result_name[:marker_pos].rstrip().removesuffix(".")
         format_message = ""
-        for line in error_lines:
-            if "Format string: " in line:
-                format_message = self.extract_format_string(line)
-                break
-        if not format_message and is_logical_error:
-            # `abortOnFailedAssertion` logs the `Format string:` line right after the
-            # `Logical error:` line, but messages from other threads (together with
-            # their multi-line stack traces) may interleave between the two and push
-            # it out of the 10-line window captured above. Search for it separately,
-            # starting from the matched error line, so the failure name stays
-            # normalized regardless of log interleaving.
-            format_line = ""
-            if self.stack_trace_str:
-                format_line = Shell.get_output(
-                    f"echo '{self.stack_trace_str}' | rg --text -m1 'Format string: '"
-                )
-            elif matched_log_file:
-                match_position = Shell.get_output(
-                    f"rg --text -n -m1 '{matched_pattern}' {matched_log_file} | cut -d: -f1"
-                )
-                if match_position.isdigit():
-                    format_line = Shell.get_output(
-                        f"tail -n +{match_position} {matched_log_file} | rg --text -m1 'Format string: '"
-                    )
-            format_message = self.extract_format_string(format_line)
+        # `abortOnFailedAssertion` logs the `Format string:` line right after the
+        # `Logical error:` line, but messages from other threads (together with their
+        # multi-line stack traces) may interleave between the two and push it out of
+        # the 10-line window captured above, while the window may as well reach into a
+        # later unrelated failure. So, for a logical error, take the format string from
+        # the matched failure itself - the next fatal message of the same thread.
+        bounded_format_message = (
+            self.find_format_string(matched_pattern, matched_log_file)
+            if is_logical_error
+            else None
+        )
+        if bounded_format_message is not None:
+            format_message = bounded_format_message
+        else:
+            # The thread that logged the failure is unknown - scan the window.
+            for line in error_lines:
+                if "Format string: " in line:
+                    format_message = self.extract_format_string(line)
+                    break
         is_check_failed = bool(
             error_lines and re.search(r"\w+Sanitizer: CHECK failed:", error_lines[0])
         )

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -1,3 +1,4 @@
+import itertools
 import re
 import string
 import sys
@@ -144,33 +145,46 @@ class FuzzerLogParser:
                 )
                 return self.extract_format_string(next_fatal_line)
             # The input has no thread ids (e.g. a bare stack trace string), so bound
-            # the search by the failure block instead: the format string belongs to
-            # this failure only if it appears before the next fatal / failure line.
-            # The next failure may be carried by any pattern (e.g. an assertion
-            # following a logical error), so check all of them, not just the matched
-            # one.
-            for line in lines[match_index + 1 :]:
-                if "Format string: " in line:
-                    return self.extract_format_string(line)
-                if "<Fatal>" in line or any(
-                    re.search(pattern, line) for _, _, pattern in self.ERROR_PATTERNS
-                ):
-                    return ""
-            return ""
+            # the search by the failure block instead.
+            return self.format_string_within_failure_block(lines[match_index + 1 :])
 
         if not matched_log_file:
             return None
         match_position, _, match_line = Shell.get_output(
             f"rg --text -n -m1 '{matched_pattern}' {matched_log_file}"
         ).partition(":")
-        thread = self.thread_id(match_line)
-        if not match_position.isdigit() or not thread:
+        if not match_position.isdigit():
             return None
-        next_fatal_line = Shell.get_output(
-            f"tail -n +{int(match_position) + 1} {matched_log_file}"
-            f" | rg --text -m1 '\\[ {thread} \\] \\{{.*<Fatal>'"
-        )
-        return self.extract_format_string(next_fatal_line)
+        thread = self.thread_id(match_line)
+        if thread:
+            next_fatal_line = Shell.get_output(
+                f"tail -n +{int(match_position) + 1} {matched_log_file}"
+                f" | rg --text -m1 '\\[ {thread} \\] \\{{.*<Fatal>'"
+            )
+            return self.extract_format_string(next_fatal_line)
+        # The file has no thread ids either (e.g. stderr.log standing in for an
+        # absent server log), so bound the search by the failure block, same as for
+        # the string input above. Stream the lines instead of loading the file.
+        with open(matched_log_file, errors="replace") as f:
+            return self.format_string_within_failure_block(
+                itertools.islice(f, int(match_position), None)
+            )
+
+    def format_string_within_failure_block(self, lines):
+        # Find the `Format string:` line within the failure block that starts right
+        # after the matched failure line, for inputs without thread ids: the format
+        # string belongs to the matched failure only if it appears before the next
+        # fatal / failure line. The next failure may be carried by any pattern (e.g.
+        # an assertion following a logical error), so check all of them, not just
+        # the matched one.
+        for line in lines:
+            if "Format string: " in line:
+                return self.extract_format_string(line)
+            if "<Fatal>" in line or any(
+                re.search(pattern, line) for _, _, pattern in self.ERROR_PATTERNS
+            ):
+                return ""
+        return ""
 
     def parse_failure(self):
         files = []

--- a/ci/tests/test_log_parser.py
+++ b/ci/tests/test_log_parser.py
@@ -227,3 +227,28 @@ def test_parse_failure_logical_error_stack_trace_str_without_thread_ids():
 
     assert result_name.startswith("Logical error: first error without format (STID:")
     assert "second error normalized" not in result_name
+
+
+def test_parse_failure_logical_error_stack_trace_str_next_failure_other_pattern():
+    # Same as above, but the later failure is carried by a different pattern variant
+    # (an assertion instead of another `Logical error:`). The thread-less search must
+    # stop at the next failure line of any kind, so the assertion's `Format string:`
+    # must not rename the first failure.
+    parser = FuzzerLogParser(
+        server_log="",
+        stack_trace_str=(
+            "Logical error: 'first error without format'.\n"
+            "Stack trace (when copying this message, always include the lines "
+            "below):\n"
+            "\n"
+            "0. ./src/Common/Exception.cpp:66:5: DB::abortOnFailedAssertion() "
+            "@ 0x00000000139d383c\n"
+            "Assertion `count == 0` failed.\n"
+            "Format string: 'second assertion normalized {}'.\n"
+        ),
+    )
+
+    result_name, _, _ = parser.parse_failure()
+
+    assert result_name.startswith("Logical error: first error without format (STID:")
+    assert "second assertion normalized" not in result_name

--- a/ci/tests/test_log_parser.py
+++ b/ci/tests/test_log_parser.py
@@ -116,3 +116,54 @@ def test_parse_failure_logical_error_name_drops_dangling_stack_trace_marker(tmp_
     assert "(STID:" in result_name
     # The frames are still preserved in the separate stack-trace section of the info.
     assert "abortOnFailedAssertion" in info
+
+
+def test_parse_failure_logical_error_finds_format_string_despite_interleaving(
+    tmp_path,
+):
+    server_log = tmp_path / "clickhouse-server.err.log"
+
+    # A message from another thread (with its multi-line stack trace) lands between
+    # the `Logical error:` and `Format string:` fatal lines, pushing the format
+    # string out of the 10-line window around the match. The failure name must
+    # still be built from the format string (without the raw line's quotes).
+    interleaved_message = (
+        "2026.08.01 18:35:11.673118 [ 4327 ] {} <Error> TCPHandler: Code: 210. "
+        "DB::NetException: Connection reset by peer, while writing to socket. "
+        "(NETWORK_ERROR), Stack trace (when copying this message, always include "
+        "the lines below):\n"
+        "\n"
+        + "".join(
+            f"{i}. src/Server/TCPHandler.cpp:{i}: DB::someFunction() @ 0x{i:016x}\n"
+            for i in range(14)
+        )
+        + "\n"
+    )
+    server_log.write_text(
+        "2026.08.01 18:35:11.672071 [ 4353 ] {} <Fatal> : Logical error: "
+        "'Query context must be created after authentication'.\n"
+        + interleaved_message
+        + "2026.08.01 18:35:11.675219 [ 4353 ] {} <Fatal> : Format string: "
+        "'Query context must be created after authentication'.\n"
+        "2026.08.01 18:35:11.694220 [ 4353 ] {} <Fatal> : Stack trace (when "
+        "copying this message, always include the lines below):\n"
+        "\n"
+        "0. ./src/Common/Exception.cpp:66:5: DB::abortOnFailedAssertion() "
+        "@ 0x00000000139d383c\n"
+        "1. ./src/Interpreters/Session.cpp:690:15: "
+        "DB::Session::makeQueryContextImpl() @ 0x0000000018143638\n",
+        encoding="utf-8",
+    )
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log),
+        stderr_log="",
+        fuzzer_log="",
+    )
+
+    result_name, info, files = parser.parse_failure()
+
+    assert result_name.startswith(
+        "Logical error: Query context must be created after authentication (STID:"
+    )
+    assert "'" not in result_name

--- a/ci/tests/test_log_parser.py
+++ b/ci/tests/test_log_parser.py
@@ -167,3 +167,37 @@ def test_parse_failure_logical_error_finds_format_string_despite_interleaving(
         "Logical error: Query context must be created after authentication (STID:"
     )
     assert "'" not in result_name
+
+
+def test_parse_failure_logical_error_without_own_format_string(tmp_path):
+    server_log = tmp_path / "clickhouse-server.err.log"
+
+    # `abortOnFailedAssertion(description)` logs no `Format string:` line when the
+    # format string is empty. The search for it must stay inside the matched failure
+    # (the next fatal message of the same thread), so that a later unrelated logical
+    # error does not rename the first one with its own format string.
+    server_log.write_text(
+        "2026.08.01 18:35:11.672071 [ 4353 ] {} <Fatal> : Logical error: "
+        "'first error without format'.\n"
+        "2026.08.01 18:35:11.694220 [ 4353 ] {} <Fatal> : Stack trace (when "
+        "copying this message, always include the lines below):\n"
+        "\n"
+        "0. ./src/Common/Exception.cpp:66:5: DB::abortOnFailedAssertion() "
+        "@ 0x00000000139d383c\n"
+        "2026.08.01 18:36:00.000000 [ 4400 ] {} <Fatal> : Logical error: "
+        "'second error normalized A'.\n"
+        "2026.08.01 18:36:00.000001 [ 4400 ] {} <Fatal> : Format string: "
+        "'second error normalized {}'.\n",
+        encoding="utf-8",
+    )
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log),
+        stderr_log="",
+        fuzzer_log="",
+    )
+
+    result_name, _, _ = parser.parse_failure()
+
+    assert result_name.startswith("Logical error: 'first error without format' (STID:")
+    assert "second error normalized" not in result_name

--- a/ci/tests/test_log_parser.py
+++ b/ci/tests/test_log_parser.py
@@ -201,3 +201,29 @@ def test_parse_failure_logical_error_without_own_format_string(tmp_path):
 
     assert result_name.startswith("Logical error: 'first error without format' (STID:")
     assert "second error normalized" not in result_name
+
+
+def test_parse_failure_logical_error_stack_trace_str_without_thread_ids():
+    # Same scenario as above, but with the `stack_trace_str` input, whose lines have
+    # no server-log `[ thread_id ] {}` prefixes. The search for the `Format string:`
+    # line cannot be bounded by the thread there, so it must be bounded by the
+    # failure block instead: a `Format string:` that appears after the next failure
+    # line belongs to that failure, not to the matched one.
+    parser = FuzzerLogParser(
+        server_log="",
+        stack_trace_str=(
+            "Logical error: 'first error without format'.\n"
+            "Stack trace (when copying this message, always include the lines "
+            "below):\n"
+            "\n"
+            "0. ./src/Common/Exception.cpp:66:5: DB::abortOnFailedAssertion() "
+            "@ 0x00000000139d383c\n"
+            "Logical error: 'second error normalized A'.\n"
+            "Format string: 'second error normalized {}'.\n"
+        ),
+    )
+
+    result_name, _, _ = parser.parse_failure()
+
+    assert result_name.startswith("Logical error: first error without format (STID:")
+    assert "second error normalized" not in result_name

--- a/ci/tests/test_log_parser.py
+++ b/ci/tests/test_log_parser.py
@@ -252,3 +252,69 @@ def test_parse_failure_logical_error_stack_trace_str_next_failure_other_pattern(
 
     assert result_name.startswith("Logical error: first error without format (STID:")
     assert "second assertion normalized" not in result_name
+
+
+def test_parse_failure_logical_error_file_without_thread_ids(tmp_path):
+    # A plain file input whose lines carry no server-log `[ thread_id ] {}`
+    # prefixes - e.g. stderr.log standing in for an absent server log. The search
+    # for the `Format string:` line cannot be bounded by the thread, so it must be
+    # bounded by the failure block, exactly as for the `stack_trace_str` input: a
+    # `Format string:` that appears after the next failure line of any kind (here
+    # an assertion) belongs to that failure and must not rename the matched one.
+    server_log = tmp_path / "stderr.log"
+    server_log.write_text(
+        "Logical error: 'first error without format'.\n"
+        "Stack trace (when copying this message, always include the lines "
+        "below):\n"
+        "\n"
+        "0. ./src/Common/Exception.cpp:66:5: DB::abortOnFailedAssertion() "
+        "@ 0x00000000139d383c\n"
+        "Assertion `count == 0` failed.\n"
+        "Format string: 'second assertion normalized {}'.\n",
+        encoding="utf-8",
+    )
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log),
+        stderr_log="",
+        fuzzer_log="",
+    )
+
+    result_name, _, _ = parser.parse_failure()
+
+    assert result_name.startswith("Logical error: 'first error without format' (STID:")
+    assert "second assertion normalized" not in result_name
+
+
+def test_parse_failure_logical_error_file_without_thread_ids_own_format_string(
+    tmp_path,
+):
+    # The positive counterpart: on a thread-less file input, a `Format string:`
+    # line that belongs to the matched failure (before any other failure line)
+    # must still normalize the name.
+    server_log = tmp_path / "stderr.log"
+    server_log.write_text(
+        "Logical error: 'Cannot parse element A: expected B'.\n"
+        "Format string: 'Cannot parse element {}: expected {}'.\n"
+        "Stack trace (when copying this message, always include the lines "
+        "below):\n"
+        "\n"
+        "0. ./src/Common/Exception.cpp:66:5: DB::abortOnFailedAssertion() "
+        "@ 0x00000000139d383c\n",
+        encoding="utf-8",
+    )
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log),
+        stderr_log="",
+        fuzzer_log="",
+    )
+
+    result_name, _, _ = parser.parse_failure()
+
+    assert result_name.startswith(
+        "Logical error: Cannot parse element A: expected B (STID:"
+    )
+    assert "'" not in result_name.partition(" (STID:")[0].removeprefix(
+        "Logical error: "
+    )


### PR DESCRIPTION
The failure name for a logical error is normalized from the `Format string:` fatal line (quotes stripped, `{}` placeholders replaced with letters), which `abortOnFailedAssertion` logs right after the `Logical error:` line. The log parser looked for it only within a 10-line window around the matched error line (`rg -A 10 ... | head -n10`), so when a message from another thread (together with its multi-line stack trace) interleaved between the two fatal lines, the format string fell out of the window and the parser fell back to the raw log line. The same crash then got two different names in the checks database, e.g. `Logical error: 'Query context must be created after authentication'` (quoted) vs `Logical error: Query context must be created after authentication` (normalized), breaking failure grouping.

An occurrence of the quoted variant, where a concurrent `TCPHandler` `NetException` with a 14-frame stack trace landed between the two fatal lines: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8cf92ff61e921d2c62c911412012f1bb94d2faaa&name_0=MasterCI&name_1=Stress%20test%20%28arm_release%29

Now, if the window scan misses, the parser searches for the `Format string:` line separately, anchored at the matched error line (`rg -n -m1` for the line number, then `tail -n +N | rg -m1 'Format string: '`), so the name stays normalized regardless of log interleaving. Added a unit test reproducing the interleaving; also verified the fixed parser on the actual server log from the report above — it now yields the normalized name.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.879` (included in `26.8` and later)
<!-- ch-version-info:end -->