### PR TITLE
Do not disable the query condition cache for materialized lightweight deletes

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1552,9 +1552,8 @@ void MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache(
     const auto & settings = context->getSettingsRef();
     if (!settings[Setting::use_query_condition_cache]
             || !settings[Setting::allow_experimental_analyzer]
-            /// `apply_deleted_mask = 0` sees rows that a normal read does not, so it must not consume
-            /// entries written by normal reads - they may exclude a granule whose only matching rows
-            /// are deleted. Mirrored on the write side in MergeTreeIOSettings.
+            /// `apply_deleted_mask = 0` must return deleted rows, so it cannot reuse entries written
+            /// by normal reads: those may exclude a granule whose only matching rows are deleted.
             || !settings[Setting::apply_deleted_mask]
             || (!select_query_info.prewhere_info && !select_query_info.filter_actions_dag)
             || (vector_search_parameters.has_value()) /// vector search has filter in the ORDER BY

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -92,6 +92,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsBool per_part_index_stats;
+    extern const SettingsBool apply_deleted_mask;
     extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
     extern const SettingsString force_data_skipping_indices;
     extern const SettingsBool force_index_by_date;
@@ -1551,6 +1552,10 @@ void MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache(
     const auto & settings = context->getSettingsRef();
     if (!settings[Setting::use_query_condition_cache]
             || !settings[Setting::allow_experimental_analyzer]
+            /// `apply_deleted_mask = 0` sees rows that a normal read does not, so it must not consume
+            /// entries written by normal reads - they may exclude a granule whose only matching rows
+            /// are deleted. Mirrored on the write side in MergeTreeIOSettings.
+            || !settings[Setting::apply_deleted_mask]
             || (!select_query_info.prewhere_info && !select_query_info.filter_actions_dag)
             || (vector_search_parameters.has_value()) /// vector search has filter in the ORDER BY
             || select_query_info.isFinal()

--- a/src/Storages/MergeTree/MergeTreeIOSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.cpp
@@ -127,11 +127,9 @@ MergeTreeReaderSettings MergeTreeReaderSettings::createFromContext(const Context
         && (settings[Setting::max_streams_to_max_threads_ratio] > 1 || settings[Setting::max_streams_for_merge_tree_reading] > 1);
     result.enable_multiple_prewhere_read_steps = settings[Setting::enable_multiple_prewhere_read_steps];
     result.force_short_circuit_execution = settings[Setting::query_plan_merge_filters];
-    /// `apply_deleted_mask = 0` reads rows that a normal query does not see, so its verdicts are not
-    /// interchangeable with those of a normal read of the same part. Only one direction is actually
-    /// unsound (an `apply_deleted_mask = 1` entry consumed by an `apply_deleted_mask = 0` query,
-    /// which would then miss deleted rows it is supposed to return), but the setting is a debugging
-    /// aid, so simply keeping such queries out of the cache is cheaper than splitting the key space.
+    /// `apply_deleted_mask = 0` reads deleted rows, so its entries and those of normal reads are not
+    /// interchangeable. The setting is a debugging aid, so such queries skip the cache instead of
+    /// getting a key space of their own. Mirrored on the read side in MergeTreeDataSelectExecutor.
     result.use_query_condition_cache = settings[Setting::use_query_condition_cache]
         && settings[Setting::allow_experimental_analyzer]
         && settings[Setting::apply_deleted_mask];

--- a/src/Storages/MergeTree/MergeTreeIOSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.cpp
@@ -127,7 +127,14 @@ MergeTreeReaderSettings MergeTreeReaderSettings::createFromContext(const Context
         && (settings[Setting::max_streams_to_max_threads_ratio] > 1 || settings[Setting::max_streams_for_merge_tree_reading] > 1);
     result.enable_multiple_prewhere_read_steps = settings[Setting::enable_multiple_prewhere_read_steps];
     result.force_short_circuit_execution = settings[Setting::query_plan_merge_filters];
-    result.use_query_condition_cache = settings[Setting::use_query_condition_cache] && settings[Setting::allow_experimental_analyzer];
+    /// `apply_deleted_mask = 0` reads rows that a normal query does not see, so its verdicts are not
+    /// interchangeable with those of a normal read of the same part. Only one direction is actually
+    /// unsound (an `apply_deleted_mask = 1` entry consumed by an `apply_deleted_mask = 0` query,
+    /// which would then miss deleted rows it is supposed to return), but the setting is a debugging
+    /// aid, so simply keeping such queries out of the cache is cheaper than splitting the key space.
+    result.use_query_condition_cache = settings[Setting::use_query_condition_cache]
+        && settings[Setting::allow_experimental_analyzer]
+        && settings[Setting::apply_deleted_mask];
     result.use_deserialization_prefixes_cache = settings[Setting::merge_tree_use_deserialization_prefixes_cache];
     result.use_prefixes_deserialization_thread_pool = settings[Setting::merge_tree_use_prefixes_deserialization_thread_pool];
     result.secondary_indices_enable_bulk_filtering = settings[Setting::secondary_indices_enable_bulk_filtering];

--- a/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
@@ -242,6 +242,7 @@ MergeTreeReadPoolBase::buildReadTaskInfo(const RangesInDataPart & part_with_rang
         auto columns_list = storage_snapshot->getColumnsByNames(options, column_names);
         auto mutation_steps
             = read_task_info.alter_conversions->getMutationSteps(part_info, columns_list, storage_snapshot->metadata, getContext());
+        read_task_info.has_on_fly_mutation_steps = !mutation_steps.empty();
         std::move(mutation_steps.begin(), mutation_steps.end(), std::back_inserter(read_task_info.mutation_steps));
     }
 

--- a/src/Storages/MergeTree/MergeTreeReadTask.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadTask.cpp
@@ -494,30 +494,20 @@ bool MergeTreeReadTask::appliesMutationsBeforePrewhere() const
     /// them. The read path already bypasses the cache in this case; this keeps the write path
     /// symmetric.
     ///
-    /// Only filters whose effect varies between queries are disqualifying. `mutation_steps` cannot
-    /// be used as the criterion because it also holds the step that applies an already materialized
-    /// lightweight-delete mask (`_row_exists`, added in MergeTreeReadPoolBase). That mask is
-    /// committed part data, not a pending mutation: every query reading the part observes exactly
-    /// the same rows, so a mark it empties is attributable to the predicate just like any other.
-    /// Treating it as disqualifying disabled the cache for every table that ever had a lightweight
-    /// delete. The read path draws the same line - it bypasses on `hasDataMutations()` and
-    /// `hasPatchParts()` but not on `hasLightweightDeletedMask()` - so keying off the source of the
-    /// filter (rather than the resulting step list) is what actually makes the two sides symmetric.
-    ///
-    /// The one way the mask can vary is `apply_deleted_mask = 0`; that is handled by not using the
-    /// cache at all for such queries (see MergeTreeIOSettings and MergeTreeDataSelectExecutor).
+    /// Only filters that vary between queries count. A materialized lightweight delete does not:
+    /// `_row_exists` is committed part data, so every query reading the part sees the same rows.
+    /// Its step lands in `mutation_steps` too, hence the checks below instead of testing that list.
+    /// (`apply_deleted_mask = 0` is the exception and skips the cache entirely, see
+    /// MergeTreeReaderSettings::createFromContext.)
     if (!info->patch_parts.empty())
         return true;
 
-    /// Only the steps that actually made it into `mutation_steps` count: a pending mutation whose
-    /// commands touch none of the columns this query reads is filtered out entirely (see
-    /// `AlterConversions::filterMutationCommands`), so it rewrites nothing this query observes and
-    /// must not disable the cache. `hasMutations()` would be too broad here.
+    /// Not `alter_conversions->hasMutations()`: a pending mutation that touches no column this
+    /// query reads produces no step and rewrites nothing the query observes.
     if (info->has_on_fly_mutation_steps)
         return true;
 
-    /// An unmaterialized lightweight delete is applied from the mutations snapshot at read time and
-    /// therefore does vary between queries, so it stays disqualifying.
+    /// An unmaterialized lightweight delete is applied from the mutations snapshot at read time.
     return info->alter_conversions && info->alter_conversions->hasLightweightDelete();
 }
 

--- a/src/Storages/MergeTree/MergeTreeReadTask.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadTask.cpp
@@ -509,10 +509,16 @@ bool MergeTreeReadTask::appliesMutationsBeforePrewhere() const
     if (!info->patch_parts.empty())
         return true;
 
+    /// Only the steps that actually made it into `mutation_steps` count: a pending mutation whose
+    /// commands touch none of the columns this query reads is filtered out entirely (see
+    /// `AlterConversions::filterMutationCommands`), so it rewrites nothing this query observes and
+    /// must not disable the cache. `hasMutations()` would be too broad here.
+    if (info->has_on_fly_mutation_steps)
+        return true;
+
     /// An unmaterialized lightweight delete is applied from the mutations snapshot at read time and
     /// therefore does vary between queries, so it stays disqualifying.
-    return info->alter_conversions
-        && (info->alter_conversions->hasMutations() || info->alter_conversions->hasLightweightDelete());
+    return info->alter_conversions && info->alter_conversions->hasLightweightDelete();
 }
 
 }

--- a/src/Storages/MergeTree/MergeTreeReadTask.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadTask.cpp
@@ -493,7 +493,26 @@ bool MergeTreeReadTask::appliesMutationsBeforePrewhere() const
     /// predicate but does not apply the mutations (apply_mutations_on_fly = 0) would wrongly skip
     /// them. The read path already bypasses the cache in this case; this keeps the write path
     /// symmetric.
-    return !info->mutation_steps.empty() || !info->patch_parts.empty();
+    ///
+    /// Only filters whose effect varies between queries are disqualifying. `mutation_steps` cannot
+    /// be used as the criterion because it also holds the step that applies an already materialized
+    /// lightweight-delete mask (`_row_exists`, added in MergeTreeReadPoolBase). That mask is
+    /// committed part data, not a pending mutation: every query reading the part observes exactly
+    /// the same rows, so a mark it empties is attributable to the predicate just like any other.
+    /// Treating it as disqualifying disabled the cache for every table that ever had a lightweight
+    /// delete. The read path draws the same line - it bypasses on `hasDataMutations()` and
+    /// `hasPatchParts()` but not on `hasLightweightDeletedMask()` - so keying off the source of the
+    /// filter (rather than the resulting step list) is what actually makes the two sides symmetric.
+    ///
+    /// The one way the mask can vary is `apply_deleted_mask = 0`; that is handled by not using the
+    /// cache at all for such queries (see MergeTreeIOSettings and MergeTreeDataSelectExecutor).
+    if (!info->patch_parts.empty())
+        return true;
+
+    /// An unmaterialized lightweight delete is applied from the mutations snapshot at read time and
+    /// therefore does vary between queries, so it stays disqualifying.
+    return info->alter_conversions
+        && (info->alter_conversions->hasMutations() || info->alter_conversions->hasLightweightDelete());
 }
 
 }

--- a/src/Storages/MergeTree/MergeTreeReadTask.h
+++ b/src/Storages/MergeTree/MergeTreeReadTask.h
@@ -110,6 +110,11 @@ struct MergeTreeReadTaskInfo
     MergedPartOffsetsPtr merged_part_offsets;
     /// Prewhere steps that should be applied to execute on-fly mutations for part.
     PrewhereExprSteps mutation_steps;
+    /// Whether `mutation_steps` contains steps produced from the mutations snapshot (on-fly
+    /// mutations). Distinguishes them from the step applying a materialized lightweight-delete
+    /// mask, which also lives in `mutation_steps` but is committed part data (see
+    /// appliesMutationsBeforePrewhere).
+    bool has_on_fly_mutation_steps = false;
     /// Patches that should be applied for part.
     PatchPartsForReader patch_parts;
     /// Column names to read during PREWHERE and WHERE

--- a/src/Storages/MergeTree/MergeTreeReadTask.h
+++ b/src/Storages/MergeTree/MergeTreeReadTask.h
@@ -110,10 +110,8 @@ struct MergeTreeReadTaskInfo
     MergedPartOffsetsPtr merged_part_offsets;
     /// Prewhere steps that should be applied to execute on-fly mutations for part.
     PrewhereExprSteps mutation_steps;
-    /// Whether `mutation_steps` contains steps produced from the mutations snapshot (on-fly
-    /// mutations). Distinguishes them from the step applying a materialized lightweight-delete
-    /// mask, which also lives in `mutation_steps` but is committed part data (see
-    /// appliesMutationsBeforePrewhere).
+    /// Whether `mutation_steps` holds steps for on-fly mutations, as opposed to only the step that
+    /// applies an already materialized lightweight-delete mask.
     bool has_on_fly_mutation_steps = false;
     /// Patches that should be applied for part.
     PatchPartsForReader patch_parts;

--- a/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.reference
+++ b/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.reference
@@ -11,6 +11,9 @@
 --- and the reverse direction is also unaffected
 1
 0
+--- apply_deleted_mask = 0 neither writes nor consumes the cache
+04669_lwd_mask0_prime	0	0
+04669_lwd_mask0_reuse	0	0
 --- results stay correct with the cache warm
 999999
 9

--- a/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.reference
+++ b/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.reference
@@ -1,0 +1,16 @@
+--- the delete is materialized, nothing pending
+0
+0
+0
+--- prime reads everything, reuse prunes
+04669_lwd_prime	0	0
+04669_lwd_reuse	1	1
+--- apply_deleted_mask = 0 must not consume entries written by a normal read
+0
+1
+--- and the reverse direction is also unaffected
+1
+0
+--- results stay correct with the cache warm
+999999
+9

--- a/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.reference
+++ b/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.reference
@@ -12,6 +12,8 @@
 1
 0
 --- apply_deleted_mask = 0 neither writes nor consumes the cache
+0
+0
 04669_lwd_mask0_prime	0	0
 04669_lwd_mask0_reuse	0	0
 --- results stay correct with the cache warm

--- a/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.reference
+++ b/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.reference
@@ -14,3 +14,9 @@
 --- results stay correct with the cache warm
 999999
 9
+--- a pending mutation on an unread column must not disable the cache
+0
+0
+--- pending-mutation prime reads everything, reuse prunes
+04669_lwd_pending_prime	0	0
+04669_lwd_pending_reuse	1	1

--- a/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.sql
+++ b/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.sql
@@ -12,6 +12,10 @@
 -- had ever been touched by a lightweight delete - a single deleted row was enough.
 
 SET use_query_condition_cache = 1;
+-- The query condition cache requires the analyzer, on both the write and the read side; without
+-- this the cache never functions in the old-analyzer CI configuration and the effectiveness
+-- assertions below cannot hold.
+SET enable_analyzer = 1;
 
 DROP TABLE IF EXISTS t_qcc_lwd;
 

--- a/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.sql
+++ b/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.sql
@@ -30,19 +30,21 @@ WHERE database = currentDatabase() AND table = 't_qcc_lwd' AND NOT is_done;
 
 SYSTEM DROP QUERY CONDITION CACHE;
 
--- `v = 123456789` matches no row, so after the first (priming) run every granule is known not to
--- match and the second run must read strictly fewer marks.
+-- `v = 123456789` matches no row, so after the first (priming) run every granule of every part is
+-- known not to match and the second run must read no marks at all. Asserting zero rather than
+-- "fewer" matters: only the part holding `id = 0` carries the mask, so if the insert ever lands in
+-- more than one part, a weaker assertion would be satisfied by the other parts pruning.
 SELECT count() FROM t_qcc_lwd WHERE v = 123456789 SETTINGS log_comment = '04669_lwd_prime';
 SELECT count() FROM t_qcc_lwd WHERE v = 123456789 SETTINGS log_comment = '04669_lwd_reuse';
 
 SYSTEM FLUSH LOGS query_log;
 
 SELECT '--- prime reads everything, reuse prunes';
--- Columns: (any QCC hit), (granules skipped). Expected: prime = 0 0, reuse = 1 1.
+-- Columns: (any QCC hit), (read no marks at all). Expected: prime = 0 0, reuse = 1 1.
 SELECT
     log_comment,
     ProfileEvents['QueryConditionCacheHits'] > 0,
-    toInt32(ProfileEvents['SelectedMarks']) < toInt32(ProfileEvents['SelectedMarksTotal'])
+    ProfileEvents['SelectedMarks'] = 0
 FROM system.query_log
 WHERE event_date >= yesterday() AND event_time >= now() - 600
     AND type = 'QueryFinish'
@@ -64,6 +66,30 @@ SELECT '--- and the reverse direction is also unaffected';
 SYSTEM DROP QUERY CONDITION CACHE;
 SELECT count() FROM t_qcc_lwd WHERE id = 0 SETTINGS apply_deleted_mask = 0;
 SELECT count() FROM t_qcc_lwd WHERE id = 0;
+
+SELECT '--- apply_deleted_mask = 0 neither writes nor consumes the cache';
+-- Such queries are kept out of the cache entirely instead of getting their own key space, so a
+-- repeated `apply_deleted_mask = 0` query does not prune. Both runs must miss and read every mark.
+-- Pinned here because it is the one behaviour this change gives up; a follow-up that keys entries by
+-- `apply_deleted_mask` instead of disabling them has to update this block deliberately.
+SYSTEM DROP QUERY CONDITION CACHE;
+SELECT count() FROM t_qcc_lwd WHERE v = 123456789
+SETTINGS apply_deleted_mask = 0, log_comment = '04669_lwd_mask0_prime';
+SELECT count() FROM t_qcc_lwd WHERE v = 123456789
+SETTINGS apply_deleted_mask = 0, log_comment = '04669_lwd_mask0_reuse';
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT
+    log_comment,
+    ProfileEvents['QueryConditionCacheHits'] > 0,
+    ProfileEvents['SelectedMarks'] = 0
+FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600
+    AND type = 'QueryFinish'
+    AND current_database = currentDatabase()
+    AND log_comment IN ('04669_lwd_mask0_prime', '04669_lwd_mask0_reuse')
+ORDER BY event_time_microseconds;
 
 SELECT '--- results stay correct with the cache warm';
 SELECT count() FROM t_qcc_lwd;
@@ -105,7 +131,7 @@ SELECT '--- pending-mutation prime reads everything, reuse prunes';
 SELECT
     log_comment,
     ProfileEvents['QueryConditionCacheHits'] > 0,
-    toInt32(ProfileEvents['SelectedMarks']) < toInt32(ProfileEvents['SelectedMarksTotal'])
+    ProfileEvents['SelectedMarks'] = 0
 FROM system.query_log
 WHERE event_date >= yesterday() AND event_time >= now() - 600
     AND type = 'QueryFinish'

--- a/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.sql
+++ b/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.sql
@@ -3,26 +3,18 @@
 -- no-parallel-replicas: the query condition cache is populated per replica, so the granule
 --                       accounting below is deterministic only on a single replica
 
--- A materialized lightweight delete must not disable the query condition cache.
---
--- The step that applies the `_row_exists` mask is appended to the read task's `mutation_steps`,
--- and the cache write path used to treat a non-empty `mutation_steps` as "a mutation filtered rows
--- before PREWHERE, do not attribute anything to the predicate". A materialized mask is committed
--- part data rather than a pending mutation, so that check disabled the cache for every table that
--- had ever been touched by a lightweight delete - a single deleted row was enough.
+-- A materialized lightweight delete must not disable the query condition cache. The cache write
+-- path used to skip any part with a non-empty `mutation_steps`, which also holds the step applying
+-- the committed `_row_exists` mask - so one deleted row disabled the cache for the whole table.
 
 SET use_query_condition_cache = 1;
--- The query condition cache requires the analyzer, on both the write and the read side; without
--- this the cache never functions in the old-analyzer CI configuration and the effectiveness
--- assertions below cannot hold.
+-- The cache needs the analyzer on both the write and the read side.
 SET enable_analyzer = 1;
 
 DROP TABLE IF EXISTS t_qcc_lwd;
 
 -- auto_statistics_types = '': randomized auto statistics would prune the whole part for the
--- never-matching predicates below (`Part ... pruned by statistics`), so nothing would be read,
--- nothing would be written to the query condition cache, and the granule accounting would be
--- vacuous.
+-- never-matching predicates below, leaving nothing to read and the granule counts below vacuous.
 CREATE TABLE t_qcc_lwd (id UInt64, v UInt64)
 ENGINE = MergeTree ORDER BY id
 SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 0, auto_statistics_types = '';
@@ -58,13 +50,12 @@ WHERE event_date >= yesterday() AND event_time >= now() - 600
     AND log_comment IN ('04669_lwd_prime', '04669_lwd_reuse')
 ORDER BY event_time_microseconds;
 
--- An unmaterialized (on-fly) lightweight delete still varies per query, so it must keep the cache
--- write disabled. That direction is covered by 03229_query_condition_cache_on_fly_mutations.
+-- The unmaterialized (on-fly) direction, which must keep the cache write disabled, is covered by
+-- 03229_query_condition_cache_on_fly_mutations.
 
 SELECT '--- apply_deleted_mask = 0 must not consume entries written by a normal read';
--- Prime with a predicate that only the deleted row satisfies. A normal read sees no match and may
--- record the granule as non-matching; a later `apply_deleted_mask = 0` read must still return the
--- deleted row rather than reuse that verdict.
+-- `id = 0` matches only the deleted row, so a normal read may record the granule as non-matching.
+-- An `apply_deleted_mask = 0` read must still return that row instead of reusing the verdict.
 SYSTEM DROP QUERY CONDITION CACHE;
 SELECT count() FROM t_qcc_lwd WHERE id = 0;
 SELECT count() FROM t_qcc_lwd WHERE id = 0 SETTINGS apply_deleted_mask = 0;
@@ -80,11 +71,9 @@ SELECT count() FROM t_qcc_lwd WHERE v < 10;
 
 DROP TABLE t_qcc_lwd;
 
--- A pending on-fly mutation that touches none of the columns the query reads is filtered out of
--- the read chain entirely (`AlterConversions::filterMutationCommands`), rewrites nothing the query
--- observes, and therefore must not disable the cache write. The entry it writes is consumable by
--- an `apply_mutations_on_fly = 0` query (the read path skips the cache while a data mutation is
--- pending, so the `= 0` side is the one that can actually hit).
+-- A pending on-fly mutation of a column the query does not read produces no read step, so it must
+-- not disable the cache write either. Only an `apply_mutations_on_fly = 0` query can consume the
+-- entry: the read path skips the cache while a data mutation is pending.
 
 SELECT '--- a pending mutation on an unread column must not disable the cache';
 

--- a/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.sql
+++ b/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.sql
@@ -75,3 +75,49 @@ SELECT count() FROM t_qcc_lwd;
 SELECT count() FROM t_qcc_lwd WHERE v < 10;
 
 DROP TABLE t_qcc_lwd;
+
+-- A pending on-fly mutation that touches none of the columns the query reads is filtered out of
+-- the read chain entirely (`AlterConversions::filterMutationCommands`), rewrites nothing the query
+-- observes, and therefore must not disable the cache write. The entry it writes is consumable by
+-- an `apply_mutations_on_fly = 0` query (the read path skips the cache while a data mutation is
+-- pending, so the `= 0` side is the one that can actually hit).
+
+SELECT '--- a pending mutation on an unread column must not disable the cache';
+
+DROP TABLE IF EXISTS t_qcc_lwd_pending;
+
+CREATE TABLE t_qcc_lwd_pending (id UInt64, v UInt64, w UInt64)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 0, auto_statistics_types = '';
+
+INSERT INTO t_qcc_lwd_pending SELECT number, number, number FROM numbers(1000000);
+
+DELETE FROM t_qcc_lwd_pending WHERE id = 0 SETTINGS mutations_sync = 2;
+
+SYSTEM STOP MERGES t_qcc_lwd_pending;
+ALTER TABLE t_qcc_lwd_pending UPDATE w = 0 WHERE id = 1 SETTINGS mutations_sync = 0;
+
+SYSTEM DROP QUERY CONDITION CACHE;
+
+-- The prime reads only `v`, so the pending `UPDATE` of `w` is irrelevant to it and the write must
+-- still happen; the reuse with `apply_mutations_on_fly = 0` must consume it and prune.
+SELECT count() FROM t_qcc_lwd_pending WHERE v = 123456789
+SETTINGS apply_mutations_on_fly = 1, log_comment = '04669_lwd_pending_prime';
+SELECT count() FROM t_qcc_lwd_pending WHERE v = 123456789
+SETTINGS apply_mutations_on_fly = 0, log_comment = '04669_lwd_pending_reuse';
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT '--- pending-mutation prime reads everything, reuse prunes';
+SELECT
+    log_comment,
+    ProfileEvents['QueryConditionCacheHits'] > 0,
+    toInt32(ProfileEvents['SelectedMarks']) < toInt32(ProfileEvents['SelectedMarksTotal'])
+FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600
+    AND type = 'QueryFinish'
+    AND current_database = currentDatabase()
+    AND log_comment IN ('04669_lwd_pending_prime', '04669_lwd_pending_reuse')
+ORDER BY event_time_microseconds;
+
+DROP TABLE t_qcc_lwd_pending;

--- a/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.sql
+++ b/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.sql
@@ -1,0 +1,73 @@
+-- Tags: no-parallel, no-parallel-replicas
+-- no-parallel: drops the (instance-wide) query condition cache
+-- no-parallel-replicas: the query condition cache is populated per replica, so the granule
+--                       accounting below is deterministic only on a single replica
+
+-- A materialized lightweight delete must not disable the query condition cache.
+--
+-- The step that applies the `_row_exists` mask is appended to the read task's `mutation_steps`,
+-- and the cache write path used to treat a non-empty `mutation_steps` as "a mutation filtered rows
+-- before PREWHERE, do not attribute anything to the predicate". A materialized mask is committed
+-- part data rather than a pending mutation, so that check disabled the cache for every table that
+-- had ever been touched by a lightweight delete - a single deleted row was enough.
+
+SET use_query_condition_cache = 1;
+
+DROP TABLE IF EXISTS t_qcc_lwd;
+
+CREATE TABLE t_qcc_lwd (id UInt64, v UInt64)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 0;
+
+INSERT INTO t_qcc_lwd SELECT number, number FROM numbers(1000000);
+
+-- Materialize the delete so the part carries `_row_exists` and no mutation is left pending.
+DELETE FROM t_qcc_lwd WHERE id = 0 SETTINGS mutations_sync = 2;
+
+SELECT '--- the delete is materialized, nothing pending';
+SELECT count() FROM system.mutations
+WHERE database = currentDatabase() AND table = 't_qcc_lwd' AND NOT is_done;
+
+SYSTEM DROP QUERY CONDITION CACHE;
+
+-- `v = 123456789` matches no row, so after the first (priming) run every granule is known not to
+-- match and the second run must read strictly fewer marks.
+SELECT count() FROM t_qcc_lwd WHERE v = 123456789 SETTINGS log_comment = '04669_lwd_prime';
+SELECT count() FROM t_qcc_lwd WHERE v = 123456789 SETTINGS log_comment = '04669_lwd_reuse';
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT '--- prime reads everything, reuse prunes';
+-- Columns: (any QCC hit), (granules skipped). Expected: prime = 0 0, reuse = 1 1.
+SELECT
+    log_comment,
+    ProfileEvents['QueryConditionCacheHits'] > 0,
+    toInt32(ProfileEvents['SelectedMarks']) < toInt32(ProfileEvents['SelectedMarksTotal'])
+FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600
+    AND type = 'QueryFinish'
+    AND current_database = currentDatabase()
+    AND log_comment IN ('04669_lwd_prime', '04669_lwd_reuse')
+ORDER BY event_time_microseconds;
+
+-- An unmaterialized (on-fly) lightweight delete still varies per query, so it must keep the cache
+-- write disabled. That direction is covered by 03229_query_condition_cache_on_fly_mutations.
+
+SELECT '--- apply_deleted_mask = 0 must not consume entries written by a normal read';
+-- Prime with a predicate that only the deleted row satisfies. A normal read sees no match and may
+-- record the granule as non-matching; a later `apply_deleted_mask = 0` read must still return the
+-- deleted row rather than reuse that verdict.
+SYSTEM DROP QUERY CONDITION CACHE;
+SELECT count() FROM t_qcc_lwd WHERE id = 0;
+SELECT count() FROM t_qcc_lwd WHERE id = 0 SETTINGS apply_deleted_mask = 0;
+
+SELECT '--- and the reverse direction is also unaffected';
+SYSTEM DROP QUERY CONDITION CACHE;
+SELECT count() FROM t_qcc_lwd WHERE id = 0 SETTINGS apply_deleted_mask = 0;
+SELECT count() FROM t_qcc_lwd WHERE id = 0;
+
+SELECT '--- results stay correct with the cache warm';
+SELECT count() FROM t_qcc_lwd;
+SELECT count() FROM t_qcc_lwd WHERE v < 10;
+
+DROP TABLE t_qcc_lwd;

--- a/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.sql
+++ b/tests/queries/0_stateless/04669_query_condition_cache_lightweight_delete.sql
@@ -15,9 +15,13 @@ SET use_query_condition_cache = 1;
 
 DROP TABLE IF EXISTS t_qcc_lwd;
 
+-- auto_statistics_types = '': randomized auto statistics would prune the whole part for the
+-- never-matching predicates below (`Part ... pruned by statistics`), so nothing would be read,
+-- nothing would be written to the query condition cache, and the granule accounting would be
+-- vacuous.
 CREATE TABLE t_qcc_lwd (id UInt64, v UInt64)
 ENGINE = MergeTree ORDER BY id
-SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 0;
+SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 0, auto_statistics_types = '';
 
 INSERT INTO t_qcc_lwd SELECT number, number FROM numbers(1000000);
 

--- a/tests/queries/0_stateless/04670_query_condition_cache_unique_key.reference
+++ b/tests/queries/0_stateless/04670_query_condition_cache_unique_key.reference
@@ -1,0 +1,8 @@
+--- a UNIQUE KEY part cannot carry a materialized _row_exists mask
+0
+--- the cache still prunes for ordinary queries
+04670_uk_prime	0	0
+04670_uk_reuse	1	1
+--- results stay correct with the cache warm
+100000
+10

--- a/tests/queries/0_stateless/04670_query_condition_cache_unique_key.reference
+++ b/tests/queries/0_stateless/04670_query_condition_cache_unique_key.reference
@@ -1,8 +1,10 @@
 --- a UNIQUE KEY part cannot carry a materialized _row_exists mask
 0
---- the cache still prunes for ordinary queries
+--- and a UNIQUE KEY read does not use the cache at all
+0
+0
 04670_uk_prime	0	0
-04670_uk_reuse	1	1
---- results stay correct with the cache warm
+04670_uk_reuse	0	0
+--- results are correct
 100000
 10

--- a/tests/queries/0_stateless/04670_query_condition_cache_unique_key.sql
+++ b/tests/queries/0_stateless/04670_query_condition_cache_unique_key.sql
@@ -7,12 +7,21 @@
 -- no-ordinary-database, no-replicated-database, no-shared-merge-tree: UNIQUE KEY is only supported
 --                       on plain MergeTree in an Atomic database
 
--- UNIQUE KEY tables and the query condition cache.
+-- Why the query condition cache and UNIQUE KEY tables do not interact, pinned so that changing
+-- either half is deliberate.
 --
--- Building a part's dense index reads the part's UNIQUE KEY columns with `apply_deleted_mask = 0`
--- (`UniqueKeyDenseIndexOps::readUniqueKeyColumns`), which is the one internal reader that turns the
--- mask off. That read carries no predicate, so it neither writes nor consults the cache, and user
--- queries on the same table must keep pruning normally.
+-- 1. A UNIQUE KEY read never uses the cache. `ReadFromMergeTree` turns it off for both the write and
+--    the consult side, because the cache is CSN-oblivious while the delete bitmap is not: a mark
+--    recorded as non-matching after a bitmap drop could be skipped by a reader pinned at an older
+--    snapshot whose rows are still live.
+-- 2. No UNIQUE KEY part can carry a materialized `_row_exists` mask, because mutation-class commands
+--    are rejected on such tables - `DELETE FROM` included, as it is executed as an
+--    `UPDATE _row_exists`.
+--
+-- Either one on its own is enough to keep such tables away from the materialized-mask handling in
+-- `appliesMutationsBeforePrewhere`. Re-enabling the cache for UNIQUE KEY reads (there is a TODO for
+-- a snapshot-aware cache) makes this test fail, which is the point: that work has to look at the
+-- mask and bitmap interaction rather than just flipping the flag.
 
 SET allow_experimental_unique_key = 1;
 SET async_insert = 0;
@@ -21,8 +30,6 @@ SET enable_analyzer = 1;
 
 DROP TABLE IF EXISTS t_qcc_uk;
 
--- auto_statistics_types = '': randomized auto statistics would prune the whole part for the
--- never-matching predicate below, leaving nothing to read and the mark counts vacuous.
 CREATE TABLE t_qcc_uk (id UInt64, v UInt64)
 ENGINE = MergeTree ORDER BY id UNIQUE KEY (id)
 SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 0, auto_statistics_types = '';
@@ -30,22 +37,22 @@ SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 0, auto_statistics_
 INSERT INTO t_qcc_uk SELECT number, number FROM numbers(100000);
 
 SELECT '--- a UNIQUE KEY part cannot carry a materialized _row_exists mask';
--- Mutation-class commands are rejected on a UNIQUE KEY table, `DELETE FROM` included (it is
--- executed as an `UPDATE _row_exists`), so the materialized-mask case cannot arise here at all.
 DELETE FROM t_qcc_uk WHERE id = 0; -- { serverError SUPPORT_IS_DISABLED }
 
 SELECT sum(has_lightweight_delete) FROM system.parts
 WHERE database = currentDatabase() AND table = 't_qcc_uk' AND active;
 
-SELECT '--- the cache still prunes for ordinary queries';
+SELECT '--- and a UNIQUE KEY read does not use the cache at all';
 SYSTEM DROP QUERY CONDITION CACHE;
 
+-- `v = 123456789` matches no row. On a plain MergeTree table the second run would hit the cache and
+-- read no marks (see 04669_query_condition_cache_lightweight_delete); here neither run may.
 SELECT count() FROM t_qcc_uk WHERE v = 123456789 SETTINGS log_comment = '04670_uk_prime';
 SELECT count() FROM t_qcc_uk WHERE v = 123456789 SETTINGS log_comment = '04670_uk_reuse';
 
 SYSTEM FLUSH LOGS query_log;
 
--- Columns: (any QCC hit), (read no marks at all). Expected: prime = 0 0, reuse = 1 1.
+-- Columns: (any QCC hit), (read no marks at all). Expected: both runs = 0 0.
 SELECT
     log_comment,
     ProfileEvents['QueryConditionCacheHits'] > 0,
@@ -57,7 +64,7 @@ WHERE event_date >= yesterday() AND event_time >= now() - 600
     AND log_comment IN ('04670_uk_prime', '04670_uk_reuse')
 ORDER BY event_time_microseconds;
 
-SELECT '--- results stay correct with the cache warm';
+SELECT '--- results are correct';
 SELECT count() FROM t_qcc_uk;
 SELECT count() FROM t_qcc_uk WHERE v < 10;
 

--- a/tests/queries/0_stateless/04670_query_condition_cache_unique_key.sql
+++ b/tests/queries/0_stateless/04670_query_condition_cache_unique_key.sql
@@ -1,0 +1,64 @@
+-- Tags: no-parallel, no-parallel-replicas, no-fasttest, no-ordinary-database, no-replicated-database, no-shared-merge-tree, no-object-storage, no-s3-storage, no-async-insert
+-- no-parallel: drops the (instance-wide) query condition cache
+-- no-parallel-replicas: the cache is populated per replica, so the mark counts below are
+--                       deterministic only on a single replica
+-- no-fasttest: a UNIQUE KEY insert writes the dense-index SST, which needs RocksDB
+-- no-object-storage, no-s3-storage: UNIQUE KEY requires a storage policy of local disks
+-- no-ordinary-database, no-replicated-database, no-shared-merge-tree: UNIQUE KEY is only supported
+--                       on plain MergeTree in an Atomic database
+
+-- UNIQUE KEY tables and the query condition cache.
+--
+-- Building a part's dense index reads the part's UNIQUE KEY columns with `apply_deleted_mask = 0`
+-- (`UniqueKeyDenseIndexOps::readUniqueKeyColumns`), which is the one internal reader that turns the
+-- mask off. That read carries no predicate, so it neither writes nor consults the cache, and user
+-- queries on the same table must keep pruning normally.
+
+SET allow_experimental_unique_key = 1;
+SET async_insert = 0;
+SET use_query_condition_cache = 1;
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS t_qcc_uk;
+
+-- auto_statistics_types = '': randomized auto statistics would prune the whole part for the
+-- never-matching predicate below, leaving nothing to read and the mark counts vacuous.
+CREATE TABLE t_qcc_uk (id UInt64, v UInt64)
+ENGINE = MergeTree ORDER BY id UNIQUE KEY (id)
+SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 0, auto_statistics_types = '';
+
+INSERT INTO t_qcc_uk SELECT number, number FROM numbers(100000);
+
+SELECT '--- a UNIQUE KEY part cannot carry a materialized _row_exists mask';
+-- Mutation-class commands are rejected on a UNIQUE KEY table, `DELETE FROM` included (it is
+-- executed as an `UPDATE _row_exists`), so the materialized-mask case cannot arise here at all.
+DELETE FROM t_qcc_uk WHERE id = 0; -- { serverError SUPPORT_IS_DISABLED }
+
+SELECT sum(has_lightweight_delete) FROM system.parts
+WHERE database = currentDatabase() AND table = 't_qcc_uk' AND active;
+
+SELECT '--- the cache still prunes for ordinary queries';
+SYSTEM DROP QUERY CONDITION CACHE;
+
+SELECT count() FROM t_qcc_uk WHERE v = 123456789 SETTINGS log_comment = '04670_uk_prime';
+SELECT count() FROM t_qcc_uk WHERE v = 123456789 SETTINGS log_comment = '04670_uk_reuse';
+
+SYSTEM FLUSH LOGS query_log;
+
+-- Columns: (any QCC hit), (read no marks at all). Expected: prime = 0 0, reuse = 1 1.
+SELECT
+    log_comment,
+    ProfileEvents['QueryConditionCacheHits'] > 0,
+    ProfileEvents['SelectedMarks'] = 0
+FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600
+    AND type = 'QueryFinish'
+    AND current_database = currentDatabase()
+    AND log_comment IN ('04670_uk_prime', '04670_uk_reuse')
+ORDER BY event_time_microseconds;
+
+SELECT '--- results stay correct with the cache warm';
+SELECT count() FROM t_qcc_uk;
+SELECT count() FROM t_qcc_uk WHERE v < 10;
+
+DROP TABLE t_qcc_uk;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/107145
Related: https://github.com/ClickHouse/ClickHouse/pull/113239
Related: https://github.com/ClickHouse/ClickHouse/issues/83259
Related: https://github.com/ClickHouse/ClickHouse/issues/104985

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a performance regression where a single lightweight `DELETE` disabled the query condition cache for the whole table. Repeated selective queries over a table that had ever been touched by a lightweight delete stopped pruning granules and fell back to reading every mark.

### Description

#### The regression

Deleting **one row** stops the query condition cache from pruning anything, for the entire table, permanently.

```sql
CREATE TABLE t (id UInt64, val String) ENGINE = MergeTree ORDER BY id;
INSERT INTO t SELECT number, toString(number % 97) FROM numbers(1000000);

DELETE FROM t WHERE id = 0;          -- the whole trigger

SYSTEM DROP QUERY CONDITION CACHE;
SELECT count() FROM t WHERE val = 'nope_nope';   -- run this 3 times
```

`ProfileEvents['SelectedMarks']` per run:

| version | run 1 | run 2 | run 3 |
|---|---|---|---|
| 26.3 (before the backport) | 122 | **0** | **0** |
| 26.4 / 26.6 / master | 122 | **122** | **122** |

Same behaviour with `mutations_sync = 2`, so this is not a pending-mutation window: it persists after the delete is fully materialized.

This was found on a production table (24M rows, 5 parts) where exactly one part carried `has_lightweight_delete = 1`. That part has 4318 marks; the four small parts have 6 between them. The affected version pruned the four small parts and read all 4318 marks of the big one on every repetition, turning a **0.03 s** query into **0.8-2.0 s**. An `INSERT ... SELECT *` copy of the same table into a fresh table did not reproduce, which is what pointed at `_row_exists` rather than the schema or the data.

Bisected to https://github.com/ClickHouse/ClickHouse/pull/107145.

#### Root cause

`MergeTreeReadPoolBase` appends two different kinds of thing to the same `mutation_steps` list:

```cpp
if (reader_settings.apply_deleted_mask && has_lightweight_delete)
    read_task_info.mutation_steps.push_back(createLightweightDeleteStep(...)); // committed part data
if (read_task_info.alter_conversions->hasMutations())
    ...append...                                                              // pending, per-query
```

and `appliesMutationsBeforePrewhere()` was `!info->mutation_steps.empty() || !info->patch_parts.empty()`.

The reasoning in #107145 is correct for anything whose effect varies between queries: a mark emptied by an on-fly mutation must not be attributed to the predicate, or a later `apply_mutations_on_fly = 0` query reusing that entry loses rows. A **materialized** `_row_exists` mask is not that. It is committed part data, every query reading the part observes exactly the same rows, and a mark it empties is attributable to the predicate like any other.

The read path already draws this line correctly - it bypasses on `hasDataMutations()` and `hasPatchParts()`, but not on `hasLightweightDeletedMask()`. So the write side was not actually made symmetric with the read side; it was made stricter.

#### The fix

**Part 1 - key the check off the source of the filter, not the resulting step list** (`MergeTreeReadTask.cpp`).

Patch parts and mutations coming from the mutations snapshot stay disqualifying. `alter_conversions->hasLightweightDelete()` keeps an *unmaterialized* lightweight delete disqualifying, because that one really is applied from the snapshot at read time and varies with `apply_mutations_on_fly`. A materialized mask no longer disables the cache. This is a narrowing of an over-broad condition; every case #107145 set out to cover is still covered.

**Part 2 - keep `apply_deleted_mask = 0` out of the cache** (`MergeTreeIOSettings.cpp`, `MergeTreeDataSelectExecutor.cpp`).

Part 1 leaves exactly one way for the mask to vary between queries. Only one direction is unsound:

- `apply_deleted_mask = 1` writes, `= 0` reads: **unsound**. The writer saw fewer rows and may record "no match" for a granule whose only matching rows are deleted; the reader must return those rows.
- `= 0` writes, `= 1` reads: sound. The writer saw a superset, so its verdict is conservative.

`apply_deleted_mask` is a debugging aid, so such queries simply do not read or write the cache. That is cheaper and easier to reason about than splitting the key space, and it costs nothing on the default path.

#### Tests

New `04669_query_condition_cache_lightweight_delete`:

- a materialized lightweight delete still prunes on a repeat query (fails before this change: the second run reads every mark)
- an `apply_deleted_mask = 0` read does not consume an entry written by a normal read, and the reverse order is also correct
- results stay correct with the cache warm

- a repeated `apply_deleted_mask = 0` query does not prune, which is the one behaviour Part 2 gives up. Pinned deliberately: keying entries by `apply_deleted_mask` instead of excluding them (https://github.com/ClickHouse/ClickHouse/pull/113239) has to update that block.

The effectiveness assertions demand that the repeat reads *no* marks rather than fewer marks than the first run. Only the part holding the deleted row carries the mask, so with a weaker assertion a multi-part table would satisfy it through the other parts pruning and the test would pass with the bug present.

New `04670_query_condition_cache_unique_key` covers `UNIQUE KEY` tables, which is where the one internal reader that turns the mask off lives (building a part's dense index reads its `UNIQUE KEY` columns with `apply_deleted_mask = 0`, in `UniqueKeyDenseIndexOps::readUniqueKeyColumns`). Two independent reasons keep such tables away from anything this PR changes, and the test pins both:

- a `UNIQUE KEY` read never uses the cache. `ReadFromMergeTree` disables it for both the write and the consult side, because the cache is CSN-oblivious while the delete bitmap is not; there is a `TODO(unique-key)` to revisit it with a snapshot-aware cache.
- no `UNIQUE KEY` part can carry a materialized mask, because mutation-class commands are rejected on such tables, `DELETE FROM` included.

Re-enabling the cache for `UNIQUE KEY` reads now has to come past this test, which is the point: that work has to look at the mask and bitmap interaction rather than only flipping the flag.

The unmaterialized/on-fly direction is already covered by `03229_query_condition_cache_on_fly_mutations`, added by #107145, which must keep passing.

#### Backports

#107145 was backported to `26.5.6.46`, `26.4.5.134` and `26.3.17.50`, so every one of those lines is affected and needs this fix. Note `26.3` is LTS and is affected from `26.3.17.50` onward.




<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.3.13`, `26.6.3.2`
<!-- ch-version-info:end -->