### PR TITLE
Fix 04516_quantile_tdigest test timing out under coverage

### DIFF
--- a/tests/queries/0_stateless/04516_quantile_tdigest_serialize_shared_state.sh
+++ b/tests/queries/0_stateless/04516_quantile_tdigest_serialize_shared_state.sh
@@ -4,8 +4,9 @@
 # used to mutate the shared state via compress() (data race -> heap-buffer-overflow in RadixSort).
 # The race is probabilistic per query run; the pre-fix binary trips ASan within the first 1-2
 # iterations of this loop, so a short loop is enough for a reliable failure. The fixed serialize()
-# is const and never touches the shared centroids buffer. Tagged `long` so the flaky check does
-# not FAIL it on the 180s soft ceiling (the query is heavy on slow sanitizer builds).
+# is const and never touches the shared centroids buffer. Tagged `long` for the flaky check's 180s
+# soft ceiling (the query is heavy on slow sanitizer builds); the tag does not raise the runner's
+# 600s hard --timeout.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -13,6 +14,9 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # A single tdigest state (const, one row) broadcast across many rows and grouped by, so the
 # Aggregator serializes the SAME shared state pointer from several threads concurrently.
+# optimize_group_by_constant_keys is pinned: with it off the state is serialized once per row
+# instead of once per block, an order of magnitude slower, which hit the 600s hard timeout under
+# coverage. Threads still serialize the same shared state, so the race stays covered.
 query="SELECT count()
 FROM
 (
@@ -23,7 +27,7 @@ FROM
         FROM numbers_mt(200000)
     )
     GROUP BY k
-) SETTINGS max_threads = 16"
+) SETTINGS max_threads = 16, optimize_group_by_constant_keys = 1"
 
 for _ in {1..10}; do
     ${CLICKHOUSE_CLIENT} --query "$query"


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/110263

`04516_quantile_tdigest_serialize_shared_state` hits the runner's 600s hard `--timeout`: 3 FAIL of
18 master runs of `Stateless tests (amd_llvm_coverage_per_test, per_test_coverage, 7/8)` since the
test landed, strictly bimodal (600120/600130/600660 ms against 5530-8790 ms), and 20 such hard kills
on 5 distinct checks overall.

The cause is the randomized `optimize_group_by_constant_keys`, drawn `false` with p = 0.05
(`tests/clickhouse-test:1569`). `Aggregator::executeOnBlock` gates const-key detection on it
(`Aggregator.cpp:1643-1648`): on, `emplaceKey` runs once per block (`:1059-1062`); off, the const
column is materialized (`:1660`) and it runs once per row (`:1066-1081`). The method is `serialized`,
so the test's single broadcast `quantileTDigestState` is serialized 200000 times per iteration
instead of about four, and the cost becomes linear in rows (0.99 / 1.89 / 3.68 / 7.24 CPU-sec at
50k / 100k / 200k / 400k) where pinned stays flat at 0.12.

All 20 hard kills drew `false`; none drew `true`. CI pairs the arms directly: on one commit,
`amd_asan_ubsan, flaky check` killed the `false` runs at 600430-600510 ms while `true` runs in the
same job finished at 180790-183440 ms.

This pins that one setting in the test's own `SETTINGS` clause. With the bad value forced through
`--client-option` the median over 3 runs is 2.19s pinned against 14.76s unpinned, so the query-level
pin overrides runner injection; over 50 randomized runs its slowest run is 2.28s against an 8.00s
unpinned tail.

The pin does not weaken the test: on an ASan build with `QuantileTDigest::serialize` reverted to its
pre-#110263 form, the pinned test still detects the heap-buffer-overflow in 20 of 20 runs (unpinned
control: 4 of 5). Threads still serialize the same shared state once per block, which is the race
being pinned; only the per-row repetition goes away. The `long` tag is kept and its comment
corrected: it covers the 180s soft ceiling, not the 600s hard `--timeout`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.865` (included in `26.8` and later)
<!-- ch-version-info:end -->