### PR TITLE
Reject invalid PromQL duration unit order

### DIFF
--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil.cpp
@@ -434,6 +434,7 @@ namespace
         bool has_time_units = false;
         Int64 seconds = 0;
         Int64 milliseconds = 0;
+        size_t last_unit_order = 0;
 
         /// Iterate through all {number, time unit} pairs.
         size_t pos = 0;
@@ -472,21 +473,43 @@ namespace
 
             Int64 seconds_per_unit = 0;
             Int64 ms_per_unit = 0;
+            size_t unit_order = 0;
 
             if (unit_name == "y")
+            {
+                unit_order = 1;
                 seconds_per_unit = 365ULL * 24 * 60 * 60;  /// 1y equals 365d (ignoring leap days)
+            }
             else if (unit_name == "w")
+            {
+                unit_order = 2;
                 seconds_per_unit = 7 * 24 * 60 * 60;  /// 1w equals 7d
+            }
             else if (unit_name == "d")
+            {
+                unit_order = 3;
                 seconds_per_unit = 24 * 60 * 60;  /// 1d equals 24h
+            }
             else if (unit_name == "h")
+            {
+                unit_order = 4;
                 seconds_per_unit = 60 * 60;  /// 1h equals 60m
+            }
             else if (unit_name == "m")
+            {
+                unit_order = 5;
                 seconds_per_unit = 60;  /// 1m equals 60s
+            }
             else if (unit_name == "s")
+            {
+                unit_order = 6;
                 seconds_per_unit = 1;  /// 1s equals 1000ms
+            }
             else if (unit_name == "ms")
+            {
+                unit_order = 7;
                 ms_per_unit = 1;
+            }
             else
             {
                 setErrorMessage(error_message,
@@ -495,6 +518,16 @@ namespace
                 setErrorPos(error_pos, unit_start_pos);
                 return false;
             }
+
+            if (unit_order <= last_unit_order)
+            {
+                setErrorMessage(error_message,
+                                "Cannot parse {} {} in duration format: Time units must be ordered from longest to shortest and must not be repeated",
+                                getTypeName<T>(), quoteString(input));
+                setErrorPos(error_pos, unit_start_pos);
+                return false;
+            }
+            last_unit_order = unit_order;
 
             if (seconds_per_unit)
             {

--- a/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
+++ b/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
@@ -1180,6 +1180,27 @@ PrometheusQueryTree(INSTANT_VECTOR):
 }
 
 
+TEST(PromQLParser, DurationUnitOrder)
+{
+    for (const auto & [query, expected_error_pos] : std::initializer_list<std::pair<std::string_view, size_t>>{
+             {"up[1m1d]", 6},
+             {"up[1h2h]", 6},
+             {"up offset 1ms1s", 14},
+         })
+    {
+        PrometheusQueryTree query_tree;
+        String error_message;
+        size_t error_pos = String::npos;
+
+        EXPECT_FALSE(query_tree.tryParse(query, 3, &error_message, &error_pos)) << query;
+        EXPECT_EQ(error_pos, expected_error_pos) << query;
+    }
+
+    EXPECT_NO_THROW(PrometheusQueryTree{"up[1y2w3d4h5m6s7ms]"});
+    EXPECT_NO_THROW(PrometheusQueryTree{"up[1d2h5ms]"});
+}
+
+
 TEST(PromQLParser, ErrorPosition)
 {
     for (const auto & [query, expected_error_pos] : std::initializer_list<std::pair<std::string_view, size_t>>{


### PR DESCRIPTION
PromQL duration components must appear from longest to shortest, and each unit may appear at most once. The duration parser stopped enforcing this invariant after the parser refactor in #95223, so malformed durations such as `1m1d`, `1h2h`, and `1ms1s` were accepted.

Restore the validation while preserving valid durations that omit intermediate units, such as `1d2h5ms`. Parser tests cover reversed units, repeated units, the `offset` path, and valid ordered durations.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reject PromQL durations whose units are repeated or not ordered from longest to shortest.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.758` (included in `26.8` and later)
<!-- ch-version-info:end -->