### PR TITLE
Use the primary key index for `pointInPolygon` with a `Point` key column

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -3883,22 +3883,47 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
 
             const auto atom_it = atom_map.find(func_name);
 
-            /// Analyze (x, y)
+            /// Analyze the point argument. It is either a `tuple` function of two key columns,
+            /// as in pointInPolygon((x, y), ...), or a single key column of type `Point`
+            /// (or another Tuple of two numeric elements), as in pointInPolygon(coord, ...).
 
-            /// TODO: support index analysis for first argument of Point/Tuple type.
-            if (!func.getArgumentAt(0).isFunction())
-                return false;
-
-            auto first_argument = func.getArgumentAt(0).toFunctionNode();
-            if (first_argument.getArgumentsSize() != 2 || first_argument.getFunctionName() != "tuple")
-                return false;
-
-            for (size_t i = 0; i < 2; ++i)
+            auto point_argument = func.getArgumentAt(0);
+            if (point_argument.isFunction()
+                && point_argument.toFunctionNode().getFunctionName() == "tuple"
+                && point_argument.toFunctionNode().getArgumentsSize() == 2)
             {
-                auto name = first_argument.getArgumentAt(i).getColumnName();
+                auto first_argument = point_argument.toFunctionNode();
+                for (size_t i = 0; i < 2; ++i)
+                {
+                    auto name = first_argument.getArgumentAt(i).getColumnName();
+                    auto it = key_columns.find(name);
+                    if (it == key_columns.end())
+                    {
+                        out.key_columns.clear();
+                        break;
+                    }
+                    out.key_columns.push_back(it->second);
+                }
+            }
+
+            if (out.key_columns.empty())
+            {
+                /// A whole key column (or key expression) of type Tuple of two coordinates,
+                /// e.g. a `Point` column. Tuple values are ordered lexicographically, so the range
+                /// of such key column constrains the coordinates of the point - see the evaluation
+                /// in `checkInHyperrectangle`.
+                auto name = point_argument.getColumnName();
                 auto it = key_columns.find(name);
                 if (it == key_columns.end())
                     return false;
+
+                const auto * tuple_type = typeid_cast<const DataTypeTuple *>(
+                    info.key_expr->getSampleBlock().getByName(name).type.get());
+                if (!tuple_type || tuple_type->getElements().size() != 2
+                    || !isNativeNumber(tuple_type->getElements()[0])
+                    || !isNativeNumber(tuple_type->getElements()[1]))
+                    return false;
+
                 out.key_columns.push_back(it->second);
             }
             out.point_in_polygon_function_name = func_name;
@@ -5706,6 +5731,42 @@ Ranges KeyCondition::extractBounds() const
     return std::move(bounds.ranges);
 }
 
+/// `FieldVisitorConvertToNumber` cannot handle if `Field` is `Null`
+/// (an unbounded side of a `Range` is represented by a null-like Field), so map it to infinity.
+static Float64 coordinateBoundToFloat64(const Field & field, bool is_left_bound)
+{
+    if (field.isNull())
+        return is_left_bound ? -std::numeric_limits<Float64>::infinity() : std::numeric_limits<Float64>::infinity();
+
+    return applyVisitor(FieldVisitorConvertToNumber<Float64>(), field);
+}
+
+/// For pointInPolygon over a single key column of type Tuple of two coordinates (e.g. `Point`):
+/// derive the bounding box of the coordinates from the range of tuple values. Tuples are ordered
+/// lexicographically: the range [(x1, y1), (x2, y2)] constrains the first coordinate to [x1, x2]
+/// and constrains the second coordinate only if the first coordinate is fixed (x1 = x2).
+static void tupleRangeToBoundingBox(const Range & tuple_range, Float64 & x_min, Float64 & x_max, Float64 & y_min, Float64 & y_max)
+{
+    x_min = -std::numeric_limits<Float64>::infinity();
+    x_max = std::numeric_limits<Float64>::infinity();
+    y_min = -std::numeric_limits<Float64>::infinity();
+    y_max = std::numeric_limits<Float64>::infinity();
+
+    const Tuple * left = tuple_range.left.getType() == Field::Types::Tuple ? &tuple_range.left.safeGet<Tuple>() : nullptr;
+    const Tuple * right = tuple_range.right.getType() == Field::Types::Tuple ? &tuple_range.right.safeGet<Tuple>() : nullptr;
+
+    if (left && !left->empty())
+        x_min = coordinateBoundToFloat64((*left)[0], /*is_left_bound*/ true);
+    if (right && !right->empty())
+        x_max = coordinateBoundToFloat64((*right)[0], /*is_left_bound*/ false);
+
+    if (left && right && left->size() == 2 && right->size() == 2 && (*left)[0] == (*right)[0])
+    {
+        y_min = coordinateBoundToFloat64((*left)[1], /*is_left_bound*/ true);
+        y_max = coordinateBoundToFloat64((*right)[1], /*is_left_bound*/ false);
+    }
+}
+
 BoolMask KeyCondition::checkInHyperrectangle(
     const Hyperrectangle & hyperrectangle,
     const DataTypes & data_types,
@@ -5942,30 +6003,38 @@ BoolMask KeyCondition::checkInHyperrectangle(
               *   Check whether there is any intersection of the 2 polygons. If true return {true, true}, else return {false, true}.
               */
 
-            /// `FieldVisitorConvertToNumber` cannot handle if `Field` is `Null`. So we need to separately handle `Null` case here.
-            auto convert_to_float64 = [](const FieldRef & ref, bool is_left_bound) -> Float64
+            Float64 x_min = std::numeric_limits<Float64>::quiet_NaN();
+            Float64 x_max = std::numeric_limits<Float64>::quiet_NaN();
+            Float64 y_min = std::numeric_limits<Float64>::quiet_NaN();
+            Float64 y_max = std::numeric_limits<Float64>::quiet_NaN();
+
+            if (element.key_columns.size() == 1)
             {
-                if (ref.isNull())
+                /// The point is a whole key column of type Tuple of two coordinates (e.g. `Point`).
+                if (element.key_columns[0] >= hyperrectangle.size())
                 {
-                    return is_left_bound ? -std::numeric_limits<Float64>::infinity() : std::numeric_limits<Float64>::infinity();
+                    rpn_stack.emplace_back(true, true);
+                    continue;
                 }
 
-                return applyVisitor(FieldVisitorConvertToNumber<Float64>(), static_cast<const Field &>(ref));
-            };
-
-            if (element.key_columns[0] >= hyperrectangle.size() || element.key_columns[1] >= hyperrectangle.size())
-            {
-                rpn_stack.emplace_back(true, true);
-                continue;
+                tupleRangeToBoundingBox(hyperrectangle[element.key_columns[0]], x_min, x_max, y_min, y_max);
             }
+            else
+            {
+                if (element.key_columns[0] >= hyperrectangle.size() || element.key_columns[1] >= hyperrectangle.size())
+                {
+                    rpn_stack.emplace_back(true, true);
+                    continue;
+                }
 
-            const auto & range_x = hyperrectangle[element.key_columns[0]];
-            const auto & range_y = hyperrectangle[element.key_columns[1]];
+                const auto & range_x = hyperrectangle[element.key_columns[0]];
+                const auto & range_y = hyperrectangle[element.key_columns[1]];
 
-            Float64 x_min = convert_to_float64(range_x.left, /*is_left_bound*/ true);
-            Float64 x_max = convert_to_float64(range_x.right, /*is_left_bound*/ false);
-            Float64 y_min = convert_to_float64(range_y.left, /*is_left_bound*/ true);
-            Float64 y_max = convert_to_float64(range_y.right, /*is_left_bound*/ false);
+                x_min = coordinateBoundToFloat64(range_x.left, /*is_left_bound*/ true);
+                x_max = coordinateBoundToFloat64(range_x.right, /*is_left_bound*/ false);
+                y_min = coordinateBoundToFloat64(range_y.left, /*is_left_bound*/ true);
+                y_max = coordinateBoundToFloat64(range_y.right, /*is_left_bound*/ false);
+            }
 
             if (unlikely(std::isnan(x_min) || std::isnan(x_max) || std::isnan(y_min) || std::isnan(y_max)))
             {
@@ -6402,59 +6471,62 @@ BoolMask KeyCondition::checkInHyperrectangle(
               *   Check whether there is any intersection of the 2 polygons. If true return {true, true}, else return {false, true}.
               */
 
-            if (element.key_columns.size() != 2)
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "Point-in-polygon requires 2 key columns.");
-
-            size_t x_key_column = element.key_columns[0];
-            size_t y_key_column = element.key_columns[1];
-
-            auto [is_x_key_col_present, x_sparse_pos] = get_sparse_info(x_key_column);
-            auto [is_y_key_col_present, y_sparse_pos] = get_sparse_info(y_key_column);
-
-            if (!is_x_key_col_present && !is_y_key_col_present)
-            {
-                /// Neither coordinate is available — nothing to prune on.
-                rpn_stack.emplace_back(true, true);
-                continue;
-            }
-
-            /// `FieldVisitorConvertToNumber` cannot handle if `Field` is `Null`. So we need to separately handle `Null` case here.
-            auto convert_to_float64 = [](const FieldRef & ref, bool is_left_bound) -> Float64
-            {
-                if (ref.isNull())
-                {
-                    return is_left_bound ? -std::numeric_limits<Float64>::infinity() : std::numeric_limits<Float64>::infinity();
-                }
-
-                return applyVisitor(FieldVisitorConvertToNumber<Float64>(), static_cast<const Field &>(ref));
-            };
-
-            /// For missing coordinates, assume (-inf, +inf) — we can still prune on the available coordinate.
             Float64 x_min = std::numeric_limits<Float64>::quiet_NaN();
             Float64 x_max = std::numeric_limits<Float64>::quiet_NaN();
             Float64 y_min = std::numeric_limits<Float64>::quiet_NaN();
             Float64 y_max = std::numeric_limits<Float64>::quiet_NaN();
-            if (is_x_key_col_present)
+
+            if (element.key_columns.size() == 1)
             {
-                const auto & range_x = sparse_hyperrectangle[x_sparse_pos];
-                x_min = convert_to_float64(range_x.left, /*is_left_bound*/ true);
-                x_max = convert_to_float64(range_x.right, /*is_left_bound*/ false);
+                /// The point is a whole key column of type Tuple of two coordinates (e.g. `Point`).
+                auto [is_key_col_present, sparse_pos] = get_sparse_info(element.key_columns[0]);
+
+                if (!is_key_col_present)
+                {
+                    rpn_stack.emplace_back(true, true);
+                    continue;
+                }
+
+                tupleRangeToBoundingBox(sparse_hyperrectangle[sparse_pos], x_min, x_max, y_min, y_max);
             }
             else
             {
-                x_min = -std::numeric_limits<Float64>::infinity();
-                x_max = std::numeric_limits<Float64>::infinity();
-            }
-            if (is_y_key_col_present)
-            {
-                const auto & range_y = sparse_hyperrectangle[y_sparse_pos];
-                y_min = convert_to_float64(range_y.left, /*is_left_bound*/ true);
-                y_max = convert_to_float64(range_y.right, /*is_left_bound*/ false);
-            }
-            else
-            {
-                y_min = -std::numeric_limits<Float64>::infinity();
-                y_max = std::numeric_limits<Float64>::infinity();
+                size_t x_key_column = element.key_columns[0];
+                size_t y_key_column = element.key_columns[1];
+
+                auto [is_x_key_col_present, x_sparse_pos] = get_sparse_info(x_key_column);
+                auto [is_y_key_col_present, y_sparse_pos] = get_sparse_info(y_key_column);
+
+                if (!is_x_key_col_present && !is_y_key_col_present)
+                {
+                    /// Neither coordinate is available — nothing to prune on.
+                    rpn_stack.emplace_back(true, true);
+                    continue;
+                }
+
+                /// For missing coordinates, assume (-inf, +inf) — we can still prune on the available coordinate.
+                if (is_x_key_col_present)
+                {
+                    const auto & range_x = sparse_hyperrectangle[x_sparse_pos];
+                    x_min = coordinateBoundToFloat64(range_x.left, /*is_left_bound*/ true);
+                    x_max = coordinateBoundToFloat64(range_x.right, /*is_left_bound*/ false);
+                }
+                else
+                {
+                    x_min = -std::numeric_limits<Float64>::infinity();
+                    x_max = std::numeric_limits<Float64>::infinity();
+                }
+                if (is_y_key_col_present)
+                {
+                    const auto & range_y = sparse_hyperrectangle[y_sparse_pos];
+                    y_min = coordinateBoundToFloat64(range_y.left, /*is_left_bound*/ true);
+                    y_max = coordinateBoundToFloat64(range_y.right, /*is_left_bound*/ false);
+                }
+                else
+                {
+                    y_min = -std::numeric_limits<Float64>::infinity();
+                    y_max = std::numeric_limits<Float64>::infinity();
+                }
             }
 
             if (unlikely(std::isnan(x_min) || std::isnan(x_max) || std::isnan(y_min) || std::isnan(y_max)))

--- a/src/Storages/MergeTree/KeyCondition.h
+++ b/src/Storages/MergeTree/KeyCondition.h
@@ -321,8 +321,10 @@ public:
             /// this expression will be analyzed and then represented by following:
             ///   args in hyperrectangle [10, 20] × [20, 30].
             FUNCTION_ARGS_IN_HYPERRECTANGLE,
-            /// Special for pointInPolygon to utilize minmax indices.
+            /// Special for pointInPolygon to utilize primary key and minmax indices.
             /// For example: pointInPolygon((x, y), [(0, 0), (0, 2), (2, 2), (2, 0)])
+            /// where x, y are key columns, or pointInPolygon(coord, [...])
+            /// where coord is a key column of type Point (Tuple of two coordinates).
             FUNCTION_POINT_IN_POLYGON,
             /// Can take any value.
             FUNCTION_UNKNOWN,
@@ -358,7 +360,8 @@ public:
         ///  * if FUNCTION[_NOT]_IN_SET: one or more elements in nondecreasing order, same as
         ///    set_index->getIndexesMapping()[..].key_index,
         ///  * if FUNCTION_POINT_IN_POLYGON: two elements (x, y) describing the point,
-        ///    as in pointInPolygon((x, y), ...).
+        ///    as in pointInPolygon((x, y), ...), or one element if the point is a whole
+        ///    key column of type Tuple of two coordinates, as in pointInPolygon(coord, ...).
         std::vector<size_t> key_columns;
 
         /// If a key column is a space filling curve, e.g. mortonEncode(x, y),
@@ -379,7 +382,8 @@ public:
 
         /// For FUNCTION_POINT_IN_POLYGON.
         /// Function name (e.g. 'pointInPolygon') and the polygon.
-        /// Additionally, `key_columns` has two elements for point coordinates (x, y).
+        /// Additionally, `key_columns` has two elements for point coordinates (x, y),
+        /// or one element if the point is a whole key column of Tuple type.
         std::optional<String> point_in_polygon_function_name;
         std::shared_ptr<Polygon> polygon;
 

--- a/tests/queries/0_stateless/04669_point_in_polygon_point_column_primary_key_index.reference
+++ b/tests/queries/0_stateless/04669_point_in_polygon_point_column_primary_key_index.reference
@@ -1,0 +1,17 @@
+25001
+25001
+Condition: pointInPolygon(coord, [(0, 0), (0, 25000), (25000, 25000), (25000, 0), (0, 0)])
+Parts: 1/1
+Granules: 26/100
+0
+Condition: pointInPolygon(coord, [(200000, 200000), (200000, 300000), (300000, 300000), (300000, 200000), (200000, 200000)])
+Parts: 0/1
+Granules: 0/100
+40001
+Condition: pointInPolygon(coord, [(0, 30000), (0, 70000), (10, 70000), (10, 30000), (0, 30000)])
+Parts: 1/1
+Granules: 42/100
+25001
+Condition: pointInPolygon(coord, [(0, 0), (0, 25000), (25000, 25000), (25000, 0), (0, 0)])
+Parts: 1/1
+Granules: 26/100

--- a/tests/queries/0_stateless/04669_point_in_polygon_point_column_primary_key_index.sql
+++ b/tests/queries/0_stateless/04669_point_in_polygon_point_column_primary_key_index.sql
@@ -1,0 +1,79 @@
+-- Tags: no-replicated-database, no-parallel-replicas, no-random-merge-tree-settings
+-- https://github.com/ClickHouse/ClickHouse/issues/54805
+
+-- EXPLAIN output may differ between old and new format
+SET explain_query_plan_default = 'legacy';
+
+DROP TABLE IF EXISTS points;
+CREATE TABLE points (coord Point) ENGINE = MergeTree ORDER BY coord SETTINGS index_granularity = 1000;
+
+INSERT INTO points SELECT (number, number) FROM numbers(100000);
+
+SELECT count()
+FROM points
+WHERE pointInPolygon(coord, [(0, 0), (0, 25000), (25000, 25000), (25000, 0)]);
+
+-- The primary key index must be used
+SELECT count()
+FROM points
+WHERE pointInPolygon(coord, [(0, 0), (0, 25000), (25000, 25000), (25000, 0)])
+SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT count()
+    FROM points
+    WHERE pointInPolygon(coord, [(0, 0), (0, 25000), (25000, 25000), (25000, 0)])
+) WHERE explain LIKE '%Condition%' OR explain LIKE '%Parts%' OR explain LIKE '%Granules%';
+
+-- A polygon that does not intersect the data at all
+SELECT count()
+FROM points
+WHERE pointInPolygon(coord, [(200000, 200000), (200000, 300000), (300000, 300000), (300000, 200000)]);
+
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT count()
+    FROM points
+    WHERE pointInPolygon(coord, [(200000, 200000), (200000, 300000), (300000, 300000), (300000, 200000)])
+) WHERE explain LIKE '%Condition%' OR explain LIKE '%Parts%' OR explain LIKE '%Granules%';
+
+DROP TABLE points;
+
+-- The second coordinate is used for pruning when the first coordinate is fixed
+DROP TABLE IF EXISTS points_fixed_x;
+CREATE TABLE points_fixed_x (coord Point) ENGINE = MergeTree ORDER BY coord SETTINGS index_granularity = 1000;
+
+INSERT INTO points_fixed_x SELECT (5, number) FROM numbers(100000);
+
+SELECT count()
+FROM points_fixed_x
+WHERE pointInPolygon(coord, [(0, 30000), (10, 30000), (10, 70000), (0, 70000)]);
+
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT count()
+    FROM points_fixed_x
+    WHERE pointInPolygon(coord, [(0, 30000), (10, 30000), (10, 70000), (0, 70000)])
+) WHERE explain LIKE '%Condition%' OR explain LIKE '%Parts%' OR explain LIKE '%Granules%';
+
+DROP TABLE points_fixed_x;
+
+-- The key column of type Tuple (not Point) works as well, and a composite key too
+DROP TABLE IF EXISTS points_tuple;
+CREATE TABLE points_tuple (id UInt64, coord Tuple(Float64, Float64)) ENGINE = MergeTree ORDER BY (coord, id) SETTINGS index_granularity = 1000;
+
+INSERT INTO points_tuple SELECT number, (number, number) FROM numbers(100000);
+
+SELECT count()
+FROM points_tuple
+WHERE pointInPolygon(coord, [(0, 0), (0, 25000), (25000, 25000), (25000, 0)]);
+
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT count()
+    FROM points_tuple
+    WHERE pointInPolygon(coord, [(0, 0), (0, 25000), (25000, 25000), (25000, 0)])
+) WHERE explain LIKE '%Condition%' OR explain LIKE '%Parts%' OR explain LIKE '%Granules%';
+
+DROP TABLE points_tuple;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/54805

`KeyCondition` could use the index for `pointInPolygon((x, y), [...])` where `x` and `y` are separate key columns, but not for `pointInPolygon(coord, [...])` where `coord` is a whole key column of type `Point` — such queries performed a full scan even when the table is ordered by the point column.

Now the first argument may also be a single key column (or key expression) of type `Point`, or another `Tuple` of two numeric elements. Tuple values are ordered lexicographically, so the range of such a key column in a granule constrains the first coordinate of the point, and also the second coordinate when the first one is fixed; the resulting bounding box is intersected with the polygon as before. Both the regular and the lightweight (`use_lightweight_primary_key_index_analysis`) analysis paths are covered.

```sql
CREATE TABLE points (coord Point) ENGINE = MergeTree ORDER BY coord;
INSERT INTO points SELECT (number, number) FROM numbers(100000);
SELECT count() FROM points WHERE pointInPolygon(coord, [(0, 0), (0, 25000), (25000, 25000), (25000, 0)]);
-- Before: 100000 rows read (full scan). After: ~26000 rows read (26/100 granules).
```

The `IN` part of the linked issue (`coord IN ((x, y), ...)`) already works on master.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use the primary key index for `pointInPolygon` when the point argument is a whole key column of type `Point` (or another `Tuple` of two numeric elements), e.g. `pointInPolygon(coord, [...])` for a table ordered by `coord`. Previously only the `pointInPolygon((x, y), [...])` form with two scalar key columns was analyzed. Closes [#54805](https://github.com/ClickHouse/ClickHouse/issues/54805).

### Documentation entry for user-facing changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.627` (included in `26.8` and later)
<!-- ch-version-info:end -->