### PR TITLE
Remove the obsolete mysql_ssl_rsa_setup from the MySQL 8 test image

### DIFF
--- a/ci/docker/integration/mysql80/Dockerfile
+++ b/ci/docker/integration/mysql80/Dockerfile
@@ -6,7 +6,8 @@ USER root
 
 RUN apt-get update \
     && apt-get install -y iptables iproute2 curl \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /usr/bin/mysql_ssl_rsa_setup
 
 
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2907,6 +2907,7 @@ class ClickHouseCluster:
     def wait_mysql8_to_start(self, timeout=180):
         self.mysql8_ip = self.get_instance_ip("mysql80")
         start = time.time()
+        errors = []
         while time.time() - start < timeout:
             try:
                 conn = pymysql.connect(
@@ -2919,10 +2920,11 @@ class ClickHouseCluster:
                 logging.debug("Mysql 8 Started")
                 return
             except Exception as ex:
-                logging.debug("Can't connect to MySQL 8 " + str(ex))
+                errors += [str(ex)]
                 time.sleep(0.5)
 
         run_and_check(["docker", "ps", "--all"])
+        logging.error("Can't connect to MySQL 8:{}".format(errors))
         raise Exception("Cannot wait MySQL 8 container")
 
     def wait_mysql_cluster_to_start(self, timeout=180):


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/96252
Related: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112338&sha=6d6f6157b52d0580f7b793af3a6beec106675102&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%201%2F6%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Integration modules using `with_mysql8=True` sporadically fail their whole module with
`Exception: Cannot wait MySQL 8 container`. Seen on 6 unrelated PRs over the last 90 days
(0 on master), across 4 job flavours including `arm_binary`, most recently 2026-07-30.

The container's entrypoint runs `mysql_ssl_rsa_setup` under `set -e`, after the datadir
bootstrap but before the step that applies the `MYSQL_ROOT_HOST=%` grant. If that call exits
non-zero the entrypoint aborts, `restart: always` relaunches the container, and the second run
finds an initialized datadir and skips the whole init block, so the grant never runs. The server
then comes up healthy knowing only `root@localhost`, and every connection from the docker gateway
is refused with MySQL error 1130. That error precedes authentication and is permanent, so
`wait_mysql8_to_start` cannot recover and burns its full 180 s budget. In the linked report the
waiter logged 342 such refusals while the server had been ready for 171 s.

This finishes what #96252 started. That PR pre-generated all 11 cert/key files and disabled
server-side RSA generation, but left the entrypoint-side generator in place. It is dead work
here: every SSL/RSA path the server uses points at the bind-mounted `/etc/mysql/certs/`, and the
files this tool writes into the datadir are read by nothing. Removing it makes the entrypoint's
own `command -v` guard skip the step, so initialization reaches the grant.

Verified by injecting a failing `mysql_ssl_rsa_setup`: with it present, `RestartCount=1` and
only `root@localhost`; with the same binary removed, `RestartCount=0` and `root@%` present and
the waiter succeeds. 6 `with_mysql8` modules show an identical failure set before and after.

I also made `wait_mysql8_to_start` report the errors it collects, matching the other three MySQL
waiters. It was the only one discarding them, which is why this went undiagnosed for so long.