### PR TITLE
Add test: Adaptive codec selection firing on the vertical merge algorithm is untested

### DIFF
--- a/tests/queries/0_stateless/04669_adaptive_codec_vertical_merge.reference
+++ b/tests/queries/0_stateless/04669_adaptive_codec_vertical_merge.reference
@@ -1,0 +1,2 @@
+vertical	1	0
+roundtrip	200000	19999900000

--- a/tests/queries/0_stateless/04669_adaptive_codec_vertical_merge.reference
+++ b/tests/queries/0_stateless/04669_adaptive_codec_vertical_merge.reference
@@ -1,2 +1,3 @@
+merge_algorithm	Vertical
 vertical	1	0
 roundtrip	200000	19999900000

--- a/tests/queries/0_stateless/04669_adaptive_codec_vertical_merge.sql
+++ b/tests/queries/0_stateless/04669_adaptive_codec_vertical_merge.sql
@@ -17,7 +17,7 @@ OPTIMIZE TABLE t_vert_adaptive FINAL;
 SYSTEM FLUSH LOGS part_log;
 
 -- The merge actually used the vertical algorithm; otherwise `n` is written by the horizontal
--- call site (MergeTask.cpp:1053) and the vertical writer at MergeTask.cpp:1985 stays untested.
+-- call site and the vertical writer stays untested.
 SELECT 'merge_algorithm', merge_algorithm FROM system.part_log
 WHERE database = currentDatabase() AND table = 't_vert_adaptive' AND event_type = 'MergeParts'
 ORDER BY event_time_microseconds DESC LIMIT 1;

--- a/tests/queries/0_stateless/04669_adaptive_codec_vertical_merge.sql
+++ b/tests/queries/0_stateless/04669_adaptive_codec_vertical_merge.sql
@@ -1,0 +1,24 @@
+-- Tags: no-random-merge-tree-settings
+-- no-random-merge-tree-settings: reads mergeTreeCodecBlockCounts and depends on the vertical merge algorithm firing.
+
+-- Adaptive codec selection must apply on vertical merges too. The gathering (non-key) column `n`
+-- is written by the per-column vertical-merge stream, which is a different call site than horizontal merges.
+
+DROP TABLE IF EXISTS t_vert_adaptive;
+
+CREATE TABLE t_vert_adaptive (dt DateTime, n UInt64) ENGINE = MergeTree ORDER BY dt
+SETTINGS min_bytes_for_wide_part = 0, allow_experimental_adaptive_codec_selection = 1,
+         enable_vertical_merge_algorithm = 1,
+         vertical_merge_algorithm_min_columns_to_activate = 1, vertical_merge_algorithm_min_rows_to_activate = 1;
+
+INSERT INTO t_vert_adaptive SELECT toDateTime('2020-01-01'), number FROM numbers(100000);
+INSERT INTO t_vert_adaptive SELECT toDateTime('2020-01-01'), number FROM numbers(100000, 100000);
+OPTIMIZE TABLE t_vert_adaptive FINAL;
+
+-- `n` is gathered vertically and is monotonic, so T64 wins on every block.
+SELECT 'vertical', max(mapContains(codec_block_counts, 'T64')), max(mapContains(codec_block_counts, 'NONE'))
+FROM mergeTreeCodecBlockCounts(currentDatabase(), t_vert_adaptive) WHERE column = 'n';
+
+SELECT 'roundtrip', count(), sum(n) FROM t_vert_adaptive;
+
+DROP TABLE t_vert_adaptive;

--- a/tests/queries/0_stateless/04669_adaptive_codec_vertical_merge.sql
+++ b/tests/queries/0_stateless/04669_adaptive_codec_vertical_merge.sql
@@ -14,6 +14,13 @@ SETTINGS min_bytes_for_wide_part = 0, allow_experimental_adaptive_codec_selectio
 INSERT INTO t_vert_adaptive SELECT toDateTime('2020-01-01'), number FROM numbers(100000);
 INSERT INTO t_vert_adaptive SELECT toDateTime('2020-01-01'), number FROM numbers(100000, 100000);
 OPTIMIZE TABLE t_vert_adaptive FINAL;
+SYSTEM FLUSH LOGS part_log;
+
+-- The merge actually used the vertical algorithm; otherwise `n` is written by the horizontal
+-- call site (MergeTask.cpp:1053) and the vertical writer at MergeTask.cpp:1985 stays untested.
+SELECT 'merge_algorithm', merge_algorithm FROM system.part_log
+WHERE database = currentDatabase() AND table = 't_vert_adaptive' AND event_type = 'MergeParts'
+ORDER BY event_time_microseconds DESC LIMIT 1;
 
 -- `n` is gathered vertically and is monotonic, so T64 wins on every block.
 SELECT 'vertical', max(mapContains(codec_block_counts, 'T64')), max(mapContains(codec_block_counts, 'NONE'))


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #111834](https://github.com/ClickHouse/ClickHouse/pull/111834).
That PR The PR adds the experimental `MergeTree` setting `allow_experimental_adaptive_codec_selection`. When enabled, merges and mutations write each block of a default-codec (`CODEC(Default)` or no `CODEC`) column with whichever candidate codec (the table default, `NONE`, or a type-specialized codec) produ

**1. Adaptive codec selection firing on the vertical merge algorithm is untested**
  `src/Storages/MergeTree/MergeTask.cpp:1985`
  **Risk:** `MergeTask.cpp`:1985 passes `try_adaptive_codec = !global_ctx->is_explicit_recompression` to the per-column vertical-merge writer, a call site distinct from the horizontal writer (`MergeTask.cpp`:1052) and the mutation writers. The only test that forces the vertical algorithm (04403 `t_v`) uses `RECOMPRESS CODEC(NONE)`, so `is_explicit_recompression=true` and adaptivity is off there; every other adaptive test merges horizontally (<11 columns). Risk: if the vertical call site's …
  **What's unique vs PR tests:** The PR's tests fire adaptive selection only through the horizontal writer (04305 etc., all <11 columns) and through the column-only mutation writer (04305 ALTER UPDATE). The only test forcing the vertical algorithm (04403 `t_v`) uses `RECOMPRESS CODEC(NONE)`, which disables adaptivity. No PR test fires adaptive selection through the vertical merge writer; this test does.
  **Tags:** `-- Tags: no-random-merge-tree-settings` — `no-random-merge-tree-settings`: Randomized merge-tree settings can flip enable_vertical_merge_algorithm off or add block-number/offset columns to mergeTreeCodecBlockCounts output; the test must pin the vertical algorithm to exercise the intended call site.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/fdce30ae-4ec5-45c0-9f3c-feaa6a0cedd9)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.655` (included in `26.8` and later)
<!-- ch-version-info:end -->