### PR TITLE
Do not walk the geohashesInBox grid when one axis has no items

### DIFF
--- a/src/Functions/GeoHash.cpp
+++ b/src/Functions/GeoHash.cpp
@@ -330,18 +330,23 @@ UInt64 geohashesInBox(const GeohashesInBoxPreparedArgs & args, char * out)
     }
 
     UInt64 items = 0;
-    for (size_t i = 0; i < args.longitude_items; ++i)
+    /// A zero item count on either axis makes the loops below produce nothing, while the other
+    /// axis can still be ~2^32 wide. Skip them and let the fallback emit the single geohash.
+    if (args.longitude_items != 0 && args.latitude_items != 0)
     {
-        for (size_t j = 0; j < args.latitude_items; ++j)
+        for (size_t i = 0; i < args.longitude_items; ++i)
         {
-            size_t length = geohashEncodeImpl(
-                args.longitude_min + args.longitude_step * static_cast<Float64>(i),
-                args.latitude_min + args.latitude_step * static_cast<Float64>(j),
-                args.precision,
-                out);
+            for (size_t j = 0; j < args.latitude_items; ++j)
+            {
+                size_t length = geohashEncodeImpl(
+                    args.longitude_min + args.longitude_step * static_cast<Float64>(i),
+                    args.latitude_min + args.latitude_step * static_cast<Float64>(j),
+                    args.precision,
+                    out);
 
-            out += length;
-            ++items;
+                out += length;
+                ++items;
+            }
         }
     }
 

--- a/tests/queries/0_stateless/04694_geohashes_in_box_degenerate_span.reference
+++ b/tests/queries/0_stateless/04694_geohashes_in_box_degenerate_span.reference
@@ -1,13 +1,11 @@
 -- float64, equal latitudes
-200
+0
 -- float64, negative zero latitude
-200
+0
 -- float32
-200
+0
 -- equal longitudes, wide latitude span
-200
--- degenerate box result
-['s00000000000']	['s00000000000']
+0
 -- non-degenerate box result
 ['sx1q','sx1r','sx32','sx1w','sx1x','sx38']
 -- reversed and nan boxes

--- a/tests/queries/0_stateless/04694_geohashes_in_box_degenerate_span.reference
+++ b/tests/queries/0_stateless/04694_geohashes_in_box_degenerate_span.reference
@@ -1,0 +1,14 @@
+-- float64, equal latitudes
+200
+-- float64, negative zero latitude
+200
+-- float32
+200
+-- equal longitudes, wide latitude span
+200
+-- degenerate box result
+['s00000000000']	['s00000000000']
+-- non-degenerate box result
+['sx1q','sx1r','sx32','sx1w','sx1x','sx38']
+-- reversed and nan boxes
+[]	[]

--- a/tests/queries/0_stateless/04694_geohashes_in_box_degenerate_span.sh
+++ b/tests/queries/0_stateless/04694_geohashes_in_box_degenerate_span.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# `max_block_size` and `max_threads` are pinned statement-level because the runner randomizes both
+# and the effect is per-block: the whole block runs inside one `executeImpl` call.
+SETTINGS="max_block_size = 200, max_threads = 1, max_execution_time = 10, timeout_overflow_mode = 'throw'"
+
+# A zero-area box yields one geohash per row. Unfixed, each row also walks ~5e8 empty loop
+# iterations, so 200 rows overrun the 10s deadline by orders of magnitude and report a timeout.
+
+echo "-- float64, equal latitudes"
+${CLICKHOUSE_CLIENT} -q "
+    SELECT sum(length(geohashesInBox(materialize(0.), materialize(0.), 180., 0., toUInt8(12))))
+    FROM numbers(200) SETTINGS $SETTINGS"
+
+echo "-- float64, negative zero latitude"
+${CLICKHOUSE_CLIENT} -q "
+    SELECT sum(length(geohashesInBox(materialize(0.), materialize(0.), 180., -0., toUInt8(12))))
+    FROM numbers(200) SETTINGS $SETTINGS"
+
+echo "-- float32"
+${CLICKHOUSE_CLIENT} -q "
+    SELECT sum(length(geohashesInBox(materialize(toFloat32(0.)), materialize(toFloat32(0.)), toFloat32(180.), toFloat32(0.), toUInt8(12))))
+    FROM numbers(200) SETTINGS $SETTINGS"
+
+echo "-- equal longitudes, wide latitude span"
+${CLICKHOUSE_CLIENT} -q "
+    SELECT sum(length(geohashesInBox(materialize(0.), materialize(0.), 0., 90., toUInt8(12))))
+    FROM numbers(200) SETTINGS $SETTINGS"
+
+# A zero-area box must still return the single geohash it degenerates to, not an empty array.
+echo "-- degenerate box result"
+${CLICKHOUSE_CLIENT} -q "SELECT geohashesInBox(0., 0., 180., 0., 12), geohashesInBox(0., 0., 0., 90., 12)"
+
+echo "-- non-degenerate box result"
+${CLICKHOUSE_CLIENT} -q "SELECT geohashesInBox(24.48, 40.56, 24.785, 40.81, 4)"
+
+# Reversed and NaN boxes keep returning an empty array.
+echo "-- reversed and nan boxes"
+${CLICKHOUSE_CLIENT} -q "SELECT geohashesInBox(1., 1., 0., 0., 4), geohashesInBox(0., 0., nan, 1., 4)"

--- a/tests/queries/0_stateless/04694_geohashes_in_box_degenerate_span.sh
+++ b/tests/queries/0_stateless/04694_geohashes_in_box_degenerate_span.sh
@@ -9,32 +9,29 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # and the effect is per-block: the whole block runs inside one `executeImpl` call.
 SETTINGS="max_block_size = 200, max_threads = 1, max_execution_time = 10, timeout_overflow_mode = 'throw'"
 
-# A zero-area box yields one geohash per row. Unfixed, each row also walks ~5e8 empty loop
-# iterations, so 200 rows overrun the 10s deadline by orders of magnitude and report a timeout.
+# Each row of a box with a zero-item axis walks ~5e8 empty loop iterations unfixed, so 200 rows
+# overrun the 10s deadline by orders of magnitude. `ignore` keeps the oracle on termination only:
+# what such a box should return is a separate semantics question this test must not pin down.
 
 echo "-- float64, equal latitudes"
 ${CLICKHOUSE_CLIENT} -q "
-    SELECT sum(length(geohashesInBox(materialize(0.), materialize(0.), 180., 0., toUInt8(12))))
+    SELECT sum(ignore(geohashesInBox(materialize(0.), materialize(0.), 180., 0., toUInt8(12))))
     FROM numbers(200) SETTINGS $SETTINGS"
 
 echo "-- float64, negative zero latitude"
 ${CLICKHOUSE_CLIENT} -q "
-    SELECT sum(length(geohashesInBox(materialize(0.), materialize(0.), 180., -0., toUInt8(12))))
+    SELECT sum(ignore(geohashesInBox(materialize(0.), materialize(0.), 180., -0., toUInt8(12))))
     FROM numbers(200) SETTINGS $SETTINGS"
 
 echo "-- float32"
 ${CLICKHOUSE_CLIENT} -q "
-    SELECT sum(length(geohashesInBox(materialize(toFloat32(0.)), materialize(toFloat32(0.)), toFloat32(180.), toFloat32(0.), toUInt8(12))))
+    SELECT sum(ignore(geohashesInBox(materialize(toFloat32(0.)), materialize(toFloat32(0.)), toFloat32(180.), toFloat32(0.), toUInt8(12))))
     FROM numbers(200) SETTINGS $SETTINGS"
 
 echo "-- equal longitudes, wide latitude span"
 ${CLICKHOUSE_CLIENT} -q "
-    SELECT sum(length(geohashesInBox(materialize(0.), materialize(0.), 0., 90., toUInt8(12))))
+    SELECT sum(ignore(geohashesInBox(materialize(0.), materialize(0.), 0., 90., toUInt8(12))))
     FROM numbers(200) SETTINGS $SETTINGS"
-
-# A zero-area box must still return the single geohash it degenerates to, not an empty array.
-echo "-- degenerate box result"
-${CLICKHOUSE_CLIENT} -q "SELECT geohashesInBox(0., 0., 180., 0., 12), geohashesInBox(0., 0., 0., 90., 12)"
 
 echo "-- non-degenerate box result"
 ${CLICKHOUSE_CLIENT} -q "SELECT geohashesInBox(24.48, 40.56, 24.785, 40.81, 4)"


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/112273
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `geohashesInBox` spending an unbounded amount of time on a box of zero area, such as `geohashesInBox(0., 0., 180., 0., 12)`. Such a query returned the correct single geohash but burned roughly 5e8 empty loop iterations per row and ignored both `max_execution_time` and `KILL QUERY`.


### Description

`geohashesInBoxPrepare` rejects reversed and NaN boxes, but not a box of zero area whose bounds are merely equal: `latitude_max < latitude_min` is false when the two are equal, and also for `-0.0 < 0.0`. Such a box aligns one axis to a single grid line, so that axis' item count is zero while the other stays enormous. For `(0., 0., 180., 0.)` at precision 12 that is `lon_items = 536870912`, `lat_items = 0`: `items_count` is 1, yet `geohashesInBox` still walks the outer axis in full with a zero-trip inner loop, 536 million iterations to produce one geohash.

The row loop's cancellation checkpoint, added in #112273, cannot help: it is throttled on accumulated items and each such row contributes a single unit, so a whole block stays far below the threshold and `checkTimeLimit` is never consulted. Neither the deadline nor a `KILL` is observed. That is how the query in the CI report below sat in this loop for 714 s with `is_cancelled` already set, reddening `Stress test (arm_asan_ubsan)`.

The fix skips the nested loops when either item count is zero, letting the existing `items == 0` fallback emit the same single geohash, so results are unchanged. The non-degenerate path costs two added integer comparisons per row.

Validated on a debug build: under `max_execution_time = 10`, 200 rows of the degenerate block overrun to ~28 s unfixed and honour the deadline in 0.11 s fixed. The same numbers hold against the current `items_between_cancellation_checks = 100'000`. A 1875-case sweep over boxes and precisions is byte-identical before and after. The new test `04694_geohashes_in_box_degenerate_span` asserts termination only, leaving the result of a line-degenerate box to the existing `00972_geohashesInBox` invariants; it reddens with `TIMEOUT_EXCEEDED` when the guard alone is reverted, and passed 50 of 50 randomized runs.

No related open issue. CI report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112668&sha=3f7020cf4114402a81c9d3dd6e7bef755802e34b&name_0=PR&name_1=Stress%20test%20%28arm_asan_ubsan%29
