### PR TITLE
Pin `packed_skip_index_max_bytes` in three skip-index surgery tests

### DIFF
--- a/tests/queries/0_stateless/04402_mutate_all_columns_preserve_legacy_idx_minmax.sh
+++ b/tests/queries/0_stateless/04402_mutate_all_columns_preserve_legacy_idx_minmax.sh
@@ -37,9 +37,12 @@ ENGINE = MergeTree ORDER BY k
 -- merge-tree settings cannot break it: index_granularity fixes the granule
 -- count (2000 rows / 100 = 20 granules), replace_long_file_name_to_hash = 0
 -- keeps the index file at its logical name (skp_idx_mm_v.idx2) that we rename,
--- and min_bytes_for_wide_part = 0 forces the Wide layout.
+-- min_bytes_for_wide_part = 0 forces the Wide layout, and
+-- packed_skip_index_max_bytes = 0 keeps that file standalone rather than a
+-- member of skp_idx.packed, which the rename cannot reach.
 SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
          index_granularity = 100, replace_long_file_name_to_hash = 0,
+         packed_skip_index_max_bytes = 0,
          columns_and_secondary_indices_sizes_lazy_calculation = 0"
 
 ${CLICKHOUSE_CLIENT} -q "INSERT INTO t_legacy_minmax (k, v) SELECT number, number FROM numbers(2000)"

--- a/tests/queries/0_stateless/04426_mutate_repair_corrupted_missing_idx_checksums.sh
+++ b/tests/queries/0_stateless/04426_mutate_repair_corrupted_missing_idx_checksums.sh
@@ -16,7 +16,9 @@
 # no-fasttest: local-disk part-file surgery (see 04402/04404).
 # no-object-storage/-shared/-replicated: relies on local on-disk file layout.
 # no-random-merge-tree-settings: depends on a fixed granule count and the
-# standalone (non-packed) index file that the surgery injects.
+# standalone (non-packed) index file that the surgery injects; the CREATE below
+# pins `packed_skip_index_max_bytes` = 0 because the tag does not cover a
+# non-zero server default.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=none
@@ -40,6 +42,7 @@ CREATE TABLE t_corrupt_minmax
 ENGINE = MergeTree ORDER BY k
 SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
          index_granularity = 100, replace_long_file_name_to_hash = 0,
+         packed_skip_index_max_bytes = 0,
          columns_and_secondary_indices_sizes_lazy_calculation = 0"
 
 ${CLICKHOUSE_CLIENT} -q "INSERT INTO t_corrupt_minmax (k, v) SELECT number, number FROM numbers(2000)"

--- a/tests/queries/0_stateless/04427_mutate_some_columns_drop_index_corrupted_idx.sh
+++ b/tests/queries/0_stateless/04427_mutate_some_columns_drop_index_corrupted_idx.sh
@@ -19,7 +19,9 @@
 # no-fasttest: local-disk part-file surgery (see 04402/04404/04426).
 # no-object-storage/-shared/-replicated: relies on local on-disk file layout.
 # no-random-merge-tree-settings: depends on a fixed granule count and the
-# standalone (non-packed) index file that the surgery injects.
+# standalone (non-packed) index file that the surgery injects; both CREATEs below
+# pin `packed_skip_index_max_bytes` = 0 because the tag does not cover a non-zero
+# server default.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=none
@@ -43,6 +45,7 @@ make_corrupted_part () {
     ENGINE = MergeTree ORDER BY k
     SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
              index_granularity = 100, replace_long_file_name_to_hash = 0,
+             packed_skip_index_max_bytes = 0,
              columns_and_secondary_indices_sizes_lazy_calculation = 0"
 
     ${CLICKHOUSE_CLIENT} -q "INSERT INTO ${tbl} (k, v, w) SELECT number, number, number FROM numbers(2000)"
@@ -94,12 +97,16 @@ ${CLICKHOUSE_CLIENT} -q "CHECK TABLE t_drop SETTINGS check_query_single_value_re
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_drop SYNC"
 
 # --- Path C (no regression): a healthy part keeps its index through a some-columns mutation ---
+# `packed_skip_index_max_bytes` = 0 keeps this control on the standalone
+# (non-packed) preserve path that paths A and B exercise; without it the control
+# would assert over packed-archive preservation instead (covered by 04403).
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_ok SYNC"
 ${CLICKHOUSE_CLIENT} -q "
 CREATE TABLE t_ok (k UInt64, v UInt64, w UInt64, INDEX mm_v v TYPE minmax GRANULARITY 1)
 ENGINE = MergeTree ORDER BY k
 SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
-         index_granularity = 100, replace_long_file_name_to_hash = 0"
+         index_granularity = 100, replace_long_file_name_to_hash = 0,
+         packed_skip_index_max_bytes = 0"
 ${CLICKHOUSE_CLIENT} -q "INSERT INTO t_ok (k, v, w) SELECT number, number, number FROM numbers(2000)"
 ${CLICKHOUSE_CLIENT} -q "ALTER TABLE t_ok UPDATE w = w + 1 WHERE 1 SETTINGS mutations_sync = 2"
 echo "C_healthy_prunes_after_update:"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/111816
-->

Related: #111816


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04402_mutate_all_columns_preserve_legacy_idx_minmax`,
`04426_mutate_repair_corrupted_missing_idx_checksums` and
`04427_mutate_some_columns_drop_index_corrupted_idx` perform raw file surgery on
standalone `skp_idx_mm_v.idx2` / `.cmrk2` part files, but none of them pins
`packed_skip_index_max_bytes`. With a non-zero value the tiny `minmax` substream
becomes a member of one `skp_idx.packed` archive per part, the standalone files
never exist, and the surgery has no inputs. Six of their surgery siblings
already pin it (`04404`, `04425`, `04428`, `04429`, `04431` at `0`; `04403` at
`1000000` because it exercises packing on purpose), and `04431` documents the
mechanism in-tree, so this is a per-test omission rather than a missing
convention.

The `no-random-merge-tree-settings` tag all three already carry does not help:
the value comes from the server default, not the randomizer.

The failure is not only a red. Verified locally on `04402`: with a 1 MiB
threshold its stdout still matches its `.reference` byte for byte, because the
`mv` that fabricates the legacy `.idx` shape silently does nothing and the
assertions then run against an ordinary healthy part. It reddens only through
the runner's stderr rule. So the pin is what keeps these three regression tests
actually testing their regressions.

The change is additive: one setting clause per `CREATE TABLE` (four in total,
`04427` has two) plus comment text. No `.reference` changes, no source changes.

Validated against both values of the setting, per test:

| | threshold `0` | threshold `1048576` |
|---|---|---|
| without the pin | pass | **fail** (`mv`/`cp: cannot stat ... skp_idx_mm_v.idx2`) |
| with the pin | pass | pass |

50 runs per test in each of three arms (randomization on, off, and off with the
1 MiB threshold): 450/450 pass.