### PR TITLE
Fix a query being cancelled up to 1 ms before its `max_execution_time`

### DIFF
--- a/src/Interpreters/CancellationChecker.cpp
+++ b/src/Interpreters/CancellationChecker.cpp
@@ -10,13 +10,9 @@
 namespace DB
 {
 
-/// Align all timeouts to a grid to allow batching of timeout processing.
-/// Tasks may be cancelled slightly later than their exact timeout, but never before.
-static constexpr UInt64 CANCELLATION_GRID_MS = 100;
-
-/// Maximum allowed timeout is 1 year in milliseconds.
+/// Maximum allowed timeout is 1 year in microseconds.
 /// This prevents overflow in chrono calculations and ensures reasonable behavior.
-static constexpr Int64 MAX_TIMEOUT_MS = 365LL * 24 * 60 * 60 * 1000;
+static constexpr Int64 MAX_TIMEOUT_US = 365LL * 24 * 60 * 60 * 1000 * 1000;
 
 struct CancellationChecker::QueryToTrack
 {
@@ -80,27 +76,36 @@ void CancellationChecker::terminateThread()
     cond_var.notify_all();
 }
 
-bool CancellationChecker::appendTask(const QueryStatusPtr & query, const Int64 timeout, OverflowMode overflow_mode)
+UInt64 CancellationChecker::alignedDeadlineMs(UInt64 now_ns, UInt64 timeout_us)
 {
-    if (timeout <= 0) // Avoid cases when the timeout is less or equal zero
+    /// Round the exact deadline UP to whole milliseconds: truncating either operand would discard
+    /// up to 1 ms and place the deadline before `now + timeout_us`.
+    const UInt64 deadline_ms = (now_ns + timeout_us * 1000 + 999'999) / 1'000'000;
+    /// Round up to the next grid boundary to enable batching of timeout checks.
+    return ((deadline_ms + CANCELLATION_GRID_MS - 1) / CANCELLATION_GRID_MS) * CANCELLATION_GRID_MS;
+}
+
+bool CancellationChecker::appendTask(const QueryStatusPtr & query, const Int64 timeout_us, OverflowMode overflow_mode)
+{
+    /// The worker resolves deadlines at millisecond granularity, so a timeout below 1 ms cannot be
+    /// tracked here; such a query is bounded by the executor's own time-limit checks instead.
+    if (timeout_us < 1000)
     {
-        LOG_TEST(log, "Did not add the task because the timeout is 0, query_id: {}", query->getClientInfo().current_query_id);
+        LOG_TEST(log, "Did not add the task because the timeout is below 1 ms ({} us), query_id: {}", timeout_us, query->getClientInfo().current_query_id);
         return false;
     }
 
     /// Cap timeout to 1 year to prevent overflow in chrono calculations.
     /// std::condition_variable::wait_for converts milliseconds to nanoseconds internally
     /// (multiplying by 1,000,000), which overflows for values close to INT64_MAX.
-    const Int64 capped_timeout = std::min(timeout, MAX_TIMEOUT_MS);
+    const Int64 capped_timeout_us = std::min(timeout_us, MAX_TIMEOUT_US);
 
     std::unique_lock<std::mutex> lock(m);
-    LOG_TEST(log, "Added to set. query: {}, timeout: {} milliseconds", query->getInfo().query, capped_timeout);
-    const auto now = std::chrono::steady_clock::now();
-    const UInt64 now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
-    /// Round up to the next grid boundary to enable batching of timeout checks.
-    /// This ensures tasks are never cancelled before their timeout, only slightly after.
-    const UInt64 end_time = ((now_ms + capped_timeout + CANCELLATION_GRID_MS - 1) / CANCELLATION_GRID_MS) * CANCELLATION_GRID_MS;
-    auto iter = query_set.emplace(query, capped_timeout, end_time, overflow_mode);
+    LOG_TEST(log, "Added to set. query: {}, timeout: {} microseconds", query->getInfo().query, capped_timeout_us);
+    const auto now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+    const UInt64 end_time = alignedDeadlineMs(now_ns, capped_timeout_us);
+    auto iter = query_set.emplace(query, capped_timeout_us / 1000, end_time, overflow_mode);
     if (iter == query_set.begin()) // Only notify if the new task is the earliest one
         cond_var.notify_all();
     return true;

--- a/src/Interpreters/CancellationChecker.h
+++ b/src/Interpreters/CancellationChecker.h
@@ -51,6 +51,10 @@ private:
     const LoggerPtr log;
 
 public:
+    /// Deadlines are aligned to this grid to allow batching of timeout processing.
+    /// Tasks may be cancelled slightly later than their exact timeout, but never before.
+    static constexpr UInt64 CANCELLATION_GRID_MS = 100;
+
     // Singleton instance retrieval
     static CancellationChecker & getInstance();
 
@@ -61,7 +65,9 @@ public:
     void terminateThread();
 
     // Method to add a new task to the multiset. Returns true if the task was added.
-    [[nodiscard]] bool appendTask(const QueryStatusPtr & query, Int64 timeout, OverflowMode overflow_mode);
+    /// The timeout is in microseconds: flooring it to milliseconds first would arm the deadline
+    /// before the timeout the setting names.
+    [[nodiscard]] bool appendTask(const QueryStatusPtr & query, Int64 timeout_us, OverflowMode overflow_mode);
 
     // Used when some task is done
     void appendDoneTasks(const QueryStatusPtr & query);
@@ -71,5 +77,9 @@ public:
 
     // The deadline the worker is currently sleeping toward, 0 when it is not. For tests.
     UInt64 getArmedDeadline();
+
+    /// Grid-aligned deadline, in whole milliseconds since the steady_clock epoch, for a task
+    /// started at `now_ns` with a timeout of `timeout_us`. Never earlier than the exact deadline.
+    static UInt64 alignedDeadlineMs(UInt64 now_ns, UInt64 timeout_us);
 };
 }

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -378,7 +378,7 @@ ProcessList::EntryPtr ProcessList::insert(
             increaseQueryKindAmount(query_kind);
         }
 
-        bool registered_in_cancellation_checker = CancellationChecker::getInstance().appendTask(query, query_context->getSettingsRef()[Setting::max_execution_time].totalMilliseconds(), query_context->getSettingsRef()[Setting::timeout_overflow_mode]);
+        bool registered_in_cancellation_checker = CancellationChecker::getInstance().appendTask(query, query_context->getSettingsRef()[Setting::max_execution_time].totalMicroseconds(), query_context->getSettingsRef()[Setting::timeout_overflow_mode]);
 
         res = std::make_shared<Entry>(*this, process_it, registered_in_cancellation_checker);
 

--- a/src/Interpreters/tests/gtest_cancellation_checker.cpp
+++ b/src/Interpreters/tests/gtest_cancellation_checker.cpp
@@ -288,13 +288,29 @@ TEST(CancellationChecker, ProcessListPreservesFractionalTimeout)
                 if (deadline_ms == 0)
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
-            ASSERT_NE(deadline_ms, 0u) << "ProcessList::insert did not register the query";
+
+            if (deadline_ms == 0)
+            {
+                /// Nothing was armed. Only inconclusive if the timeout has passed, in which case the
+                /// worker has already cancelled and removed the query and there is no deadline left
+                /// to read: retry rather than judge the arithmetic. Raising the timeout instead would
+                /// break the retry path above, which waits for a drain that `appendDoneTasks` never
+                /// notifies.
+                ASSERT_GE(steadyNowNs(), now_ns + timeout_us * 1000)
+                    << "the query was not registered with the checker while it was still running";
+                entry.reset();
+                continue;
+            }
 
             EXPECT_GE(deadline_ms * NS_PER_MS, now_ns + timeout_us * 1000)
                 << "the deadline was armed before the exact timeout the setting names";
             measured = true;
         }
-        EXPECT_TRUE(measured) << "could not observe ProcessList::insert within a single millisecond";
+        /// Every attempt was inconclusive, which needs the machine to have starved this thread for
+        /// longer than the timeout 20 times over. Skipping keeps that from reading as a violation of
+        /// the arithmetic, which was never observed.
+        if (!measured)
+            GTEST_SKIP() << "never observed a deadline before the query timed out";
     });
     body.join();
 }

--- a/src/Interpreters/tests/gtest_cancellation_checker.cpp
+++ b/src/Interpreters/tests/gtest_cancellation_checker.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <string>
 #include <thread>
 
 #include <base/scope_guard.h>
@@ -12,10 +13,17 @@
 #include <Interpreters/ProcessList.h>
 #include <Parsers/IAST.h>
 #include <QueryPipeline/SizeLimits.h>
+#include <Common/CurrentThread.h>
 #include <Common/Scheduler/MemoryReservation.h>
+#include <Common/ThreadStatus.h>
 #include <Common/tests/gtest_global_context.h>
 
 using namespace DB;
+
+namespace DB::Setting
+{
+extern const SettingsSeconds max_execution_time;
+}
 
 namespace
 {
@@ -40,6 +48,253 @@ QueryStatusPtr makeQueryStatus(const String & query_id)
         /*is_internal*/ false);
 }
 
+UInt64 steadyNowNs()
+{
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+}
+
+/// A grid-aligned deadline must never land before the exact one. Truncating either operand to whole
+/// milliseconds broke this whenever the truncated deadline was already grid-aligned, because the
+/// alignment then had no rounding left with which to absorb the discarded sub-millisecond.
+TEST(CancellationChecker, NeverCancelsBeforeTimeout)
+{
+    static constexpr UInt64 NS_PER_MS = 1'000'000;
+    const UInt64 grid = CancellationChecker::CANCELLATION_GRID_MS;
+
+    size_t early_cases = 0;
+    /// `max_execution_time` is a `SettingsSeconds`, which keeps microsecond resolution, so the
+    /// timeouts that are not a whole number of milliseconds are as reachable as the ones that are.
+    for (UInt64 timeout_us : {1'000UL, 1'999UL, 37'400UL, 100'000UL, 100'001UL, 1'000'500UL})
+    {
+        /// Every position on the alignment grid, combined with sub-millisecond residues that
+        /// bracket both ends of the truncation window.
+        for (UInt64 grid_offset_ms = 0; grid_offset_ms < grid; ++grid_offset_ms)
+        {
+            for (UInt64 residue_ns : {0UL, 1UL, 500'000UL, 999'998UL, 999'999UL})
+            {
+                const UInt64 now_ns = grid_offset_ms * NS_PER_MS + residue_ns;
+                const UInt64 deadline_ms = CancellationChecker::alignedDeadlineMs(now_ns, timeout_us);
+
+                if (deadline_ms * NS_PER_MS < now_ns + timeout_us * 1000)
+                    ++early_cases;
+
+                EXPECT_EQ(deadline_ms % grid, 0u) << "deadline is not grid-aligned";
+                /// Not gratuitously late either: at most one grid step past the exact deadline.
+                EXPECT_LT(deadline_ms * NS_PER_MS, now_ns + timeout_us * 1000 + grid * NS_PER_MS);
+            }
+        }
+    }
+    EXPECT_EQ(early_cases, 0u) << "deadline placed before the exact timeout";
+}
+
+/// The same contract, asserted on the deadline `appendTask` arms rather than on the helper alone.
+/// The timeout is solved so that the truncated deadline is already grid-aligned, leaving the
+/// alignment no rounding with which to absorb a discarded fraction: truncation is then always one
+/// grid step early and correct arithmetic never is, so no waiting or tolerance is involved.
+TEST(CancellationChecker, AppendTaskUsesAlignedDeadline)
+{
+    static constexpr UInt64 NS_PER_MS = 1'000'000;
+    /// Enough clock reads to span several milliseconds, so exhausting them means the clock never
+    /// exposes a sub-millisecond residue rather than that this attempt was unlucky.
+    static constexpr int max_boundary_samples = 1'000'000;
+    const UInt64 grid = CancellationChecker::CANCELLATION_GRID_MS;
+
+    auto & checker = CancellationChecker::getInstance();
+    std::vector<QueryStatusPtr> queries;
+
+    std::thread worker([&] { checker.workerFunction(); });
+    /// Runs on every exit path (including early ASSERT returns, which would otherwise destroy a
+    /// joinable thread and terminate); also drains leftover tasks from the singleton.
+    SCOPE_EXIT({
+        for (const auto & query : queries)
+            checker.appendDoneTasks(query);
+        checker.terminateThread();
+        worker.join();
+    });
+
+    /// The singleton is shared with the other tests in this binary; start from an empty queue so
+    /// `getArmedDeadline` below can only report the task appended here.
+    for (int i = 0; i < 2000 && checker.getArmedDeadline() != 0; ++i)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    ASSERT_EQ(checker.getArmedDeadline(), 0u);
+
+    bool measured = false;
+    for (int attempt = 0; attempt < 20 && !measured; ++attempt)
+    {
+        /// Constructed before the timed window below, so that only `appendTask` runs inside it: a
+        /// `QueryStatus` carries a whole default-constructed `Settings`, which on an instrumented
+        /// build can outlast the sub-millisecond budget the window depends on. A fresh one per
+        /// attempt, since `QueryStatus::is_killed` is sticky.
+        auto query = makeQueryStatus("gtest_cancellation_checker_aligned_" + std::to_string(attempt));
+        queries.push_back(query);
+
+        /// Sync to just after a millisecond boundary: the residue must be non-zero for truncation
+        /// to discard anything, and small so that `appendTask` reads the same millisecond.
+        UInt64 now_ns = steadyNowNs();
+        int samples = 0;
+        while (now_ns % NS_PER_MS == 0 || now_ns % NS_PER_MS > NS_PER_MS / 10)
+        {
+            ASSERT_LT(++samples, max_boundary_samples)
+                << "steady_clock never reported a sub-100us residue; the clock source lacks the "
+                   "resolution this test needs";
+            now_ns = steadyNowNs();
+        }
+
+        /// `(now_ms + timeout) % grid == 0`, plus whole grid steps of headroom so the deadline does
+        /// not fire before it is read. The addend must be a multiple of the grid to preserve the
+        /// alignment this test depends on. The fractional half-millisecond makes the timeout itself
+        /// lossy under truncation, so the case also covers flooring the timeout rather than `now`.
+        const UInt64 now_ms = now_ns / NS_PER_MS;
+        const UInt64 aligning_timeout = (grid - now_ms % grid) % grid;
+        const UInt64 timeout_us = ((aligning_timeout == 0 ? grid : aligning_timeout) + 5 * grid) * 1000 + 500;
+
+        ASSERT_TRUE(checker.appendTask(query, static_cast<Int64>(timeout_us), OverflowMode::THROW));
+
+        if (steadyNowNs() / NS_PER_MS != now_ms)
+        {
+            /// `appendTask` read a later millisecond, so the solved timeout is no longer aligned for
+            /// it and the grid would mask the truncation. Retire this task and retry.
+            checker.appendDoneTasks(query);
+            for (int i = 0; i < 2000 && checker.getArmedDeadline() != 0; ++i)
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            /// Same guarantee the first attempt gets above: an unemptied queue would let the next
+            /// attempt read this retired task's deadline and assert against the wrong task.
+            ASSERT_EQ(checker.getArmedDeadline(), 0u) << "retired task is still armed";
+            continue;
+        }
+
+        UInt64 deadline_ms = 0;
+        for (int i = 0; i < 2000 && deadline_ms == 0; ++i)
+        {
+            deadline_ms = checker.getArmedDeadline();
+            if (deadline_ms == 0)
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        ASSERT_NE(deadline_ms, 0u);
+
+        /// Valid whether or not `appendTask` read the same nanosecond: it ran no earlier than
+        /// `now_ns`, so its exact deadline is no earlier than `now_ns + timeout_us`.
+        EXPECT_GE(deadline_ms * NS_PER_MS, now_ns + timeout_us * 1000)
+            << "appendTask armed a deadline before the exact timeout";
+        measured = true;
+    }
+    EXPECT_TRUE(measured) << "could not observe appendTask within a single millisecond";
+}
+
+/// `appendTask` receives microseconds, so its own test stays green if the conversion at the sole
+/// production caller floors the setting to whole milliseconds. The timeout is solved as above, with
+/// a fraction large enough that the floored deadline lands a whole millisecond short of the exact
+/// one: flooring is then always caught and correct arithmetic never is.
+TEST(CancellationChecker, ProcessListPreservesFractionalTimeout)
+{
+    static constexpr UInt64 NS_PER_MS = 1'000'000;
+    static constexpr int max_boundary_samples = 1'000'000;
+    const UInt64 grid = CancellationChecker::CANCELLATION_GRID_MS;
+
+    auto & checker = CancellationChecker::getInstance();
+
+    /// `insert` calls `CurrentThread::attachQueryForLog`, which throws unless this thread either has
+    /// no `ThreadStatus` at all or has one with a group attached. Run in a dedicated thread and set
+    /// up both, so the state matches a real query rather than whatever other tests left behind.
+    std::thread body([&]
+    {
+        ThreadStatus thread_status;
+        auto group_context = Context::createCopy(getContext().context);
+        group_context->makeQueryContext();
+        CurrentThread::attachToGroup(std::make_shared<ThreadGroup>(group_context, 0));
+        /// Declared after `thread_status`, so it detaches before that is destroyed: `~ThreadStatus`
+        /// requires the group's counters to be finalized from this same thread.
+        SCOPE_EXIT({ CurrentThread::detachFromGroupIfNotDetached(); });
+
+        std::thread worker([&] { checker.workerFunction(); });
+        SCOPE_EXIT({
+            checker.terminateThread();
+            worker.join();
+        });
+
+        for (int i = 0; i < 2000 && checker.getArmedDeadline() != 0; ++i)
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        ASSERT_EQ(checker.getArmedDeadline(), 0u);
+
+        ProcessList process_list;
+
+        /// Pays the process-wide lazy initialization of the first insertion, which is far slower
+        /// than the window below tolerates. The timeout must clear `appendTask`'s 1 ms guard to warm
+        /// the registration too, and stay small because removal leaves an armed deadline armed.
+        {
+            auto warmup_context = Context::createCopy(getContext().context);
+            warmup_context->makeQueryContext();
+            warmup_context->setCurrentQueryId("gtest_cancellation_checker_fractional_warmup");
+            warmup_context->setSetting("max_execution_time", 0.002);
+            process_list.insert(
+                "SELECT 1", /*normalized_query_hash*/ 0, /*ast*/ nullptr, warmup_context, steadyNowNs(), /*is_internal*/ false);
+        }
+        for (int i = 0; i < 2000 && checker.getArmedDeadline() != 0; ++i)
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        ASSERT_EQ(checker.getArmedDeadline(), 0u) << "warm-up query is still armed";
+
+        bool measured = false;
+        for (int attempt = 0; attempt < 20 && !measured; ++attempt)
+        {
+            /// Built before the window below, leaving only the setting and the insertion inside it:
+            /// copying a `Context` deep-copies a whole `Settings`, which an instrumented build can
+            /// stretch past the budget the window depends on.
+            auto context = Context::createCopy(getContext().context);
+            context->makeQueryContext();
+            context->setCurrentQueryId("gtest_cancellation_checker_fractional_" + std::to_string(attempt));
+
+            /// The residue must exceed 1 us, so that adding the 999 us fraction crosses into the next
+            /// millisecond and a floored timeout is observably short.
+            UInt64 now_ns = steadyNowNs();
+            int samples = 0;
+            while (now_ns % NS_PER_MS <= 1000 || now_ns % NS_PER_MS > NS_PER_MS / 10)
+            {
+                ASSERT_LT(++samples, max_boundary_samples)
+                    << "steady_clock never reported a residue between 1us and 100us";
+                now_ns = steadyNowNs();
+            }
+
+            const UInt64 deadline_ms_exact = (now_ns + 999'999) / NS_PER_MS;
+            const UInt64 aligning = (grid - deadline_ms_exact % grid) % grid;
+            const UInt64 timeout_us = ((aligning == 0 ? grid : aligning) + 5 * grid) * 1000 + 999;
+
+            context->setSetting("max_execution_time", static_cast<double>(timeout_us) / 1'000'000);
+            ASSERT_EQ(context->getSettingsRef()[Setting::max_execution_time].totalMicroseconds(),
+                      static_cast<Int64>(timeout_us));
+
+            auto entry = process_list.insert(
+                "SELECT 1", /*normalized_query_hash*/ 0, /*ast*/ nullptr, context, now_ns, /*is_internal*/ false);
+
+            if (steadyNowNs() / NS_PER_MS != now_ns / NS_PER_MS)
+            {
+                /// `insert` read a later millisecond, so the solved timeout is no longer aligned for it.
+                /// Retire the query and wait for the queue to drain: a still-armed deadline from this
+                /// attempt would be read by the next one, which would then assert against the wrong task.
+                entry.reset();
+                for (int i = 0; i < 2000 && checker.getArmedDeadline() != 0; ++i)
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                ASSERT_EQ(checker.getArmedDeadline(), 0u) << "retired query is still armed";
+                continue;
+            }
+
+            UInt64 deadline_ms = 0;
+            for (int i = 0; i < 2000 && deadline_ms == 0; ++i)
+            {
+                deadline_ms = checker.getArmedDeadline();
+                if (deadline_ms == 0)
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            ASSERT_NE(deadline_ms, 0u) << "ProcessList::insert did not register the query";
+
+            EXPECT_GE(deadline_ms * NS_PER_MS, now_ns + timeout_us * 1000)
+                << "the deadline was armed before the exact timeout the setting names";
+            measured = true;
+        }
+        EXPECT_TRUE(measured) << "could not observe ProcessList::insert within a single millisecond";
+    });
+    body.join();
 }
 
 /// The worker arms its wait for the earliest deadline present at wait entry. A deadline appended
@@ -64,7 +319,7 @@ TEST(CancellationChecker, RearmsWaitOnEarlierDeadline)
 
     /// Arm the worker's wait toward a deadline 10 minutes away and wait until the worker has
     /// actually parked on it, so the buggy interleaving is reproduced deterministically.
-    ASSERT_TRUE(checker.appendTask(long_query, /*timeout=*/600'000, OverflowMode::THROW));
+    ASSERT_TRUE(checker.appendTask(long_query, /*timeout_us=*/600'000'000, OverflowMode::THROW));
     for (int i = 0; i < 2000 && checker.getArmedDeadline() == 0; ++i)
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
     ASSERT_NE(checker.getArmedDeadline(), 0u);
@@ -74,7 +329,7 @@ TEST(CancellationChecker, RearmsWaitOnEarlierDeadline)
     checker.appendDoneTasks(long_query);
 
     /// A short deadline appended while the worker is armed for the (already removed) long one.
-    ASSERT_TRUE(checker.appendTask(short_query, /*timeout=*/100, OverflowMode::THROW));
+    ASSERT_TRUE(checker.appendTask(short_query, /*timeout_us=*/100'000, OverflowMode::THROW));
 
     /// 100 ms deadline + 100 ms cancellation grid; poll with a generous bound for sanitizer builds.
     bool killed = false;

--- a/src/Interpreters/tests/gtest_cancellation_checker.cpp
+++ b/src/Interpreters/tests/gtest_cancellation_checker.cpp
@@ -200,6 +200,11 @@ TEST(CancellationChecker, ProcessListPreservesFractionalTimeout)
     /// up both, so the state matches a real query rather than whatever other tests left behind.
     std::thread body([&]
     {
+        /// Declared before the group, because `insert` points the group's counters and memory tracker
+        /// into an entry of `user_to_queries` that is never erased: the group must be detached while
+        /// this is still alive.
+        ProcessList process_list;
+
         ThreadStatus thread_status;
         auto group_context = Context::createCopy(getContext().context);
         group_context->makeQueryContext();
@@ -217,8 +222,6 @@ TEST(CancellationChecker, ProcessListPreservesFractionalTimeout)
         for (int i = 0; i < 2000 && checker.getArmedDeadline() != 0; ++i)
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         ASSERT_EQ(checker.getArmedDeadline(), 0u);
-
-        ProcessList process_list;
 
         /// Pays the process-wide lazy initialization of the first insertion, which is far slower
         /// than the window below tolerates. The timeout must clear `appendTask`'s 1 ms guard to warm

--- a/src/Interpreters/tests/gtest_cancellation_checker.cpp
+++ b/src/Interpreters/tests/gtest_cancellation_checker.cpp
@@ -292,12 +292,8 @@ TEST(CancellationChecker, ProcessListPreservesFractionalTimeout)
 
             if (deadline_ms == 0)
             {
-                /// Nothing left to read. Inconclusive only if the checker had tracked this query and
-                /// already cancelled it for exceeding its timeout, which needs this thread to have
-                /// lost the CPU for that long: retry rather than judge the arithmetic. A query that
-                /// is still running was never tracked, which is a real defect at the caller. Raising
-                /// the timeout instead would break the retry path above, which waits for a drain that
-                /// `appendDoneTasks` never notifies.
+                /// A killed query was tracked and timed out, so there is legitimately no deadline
+                /// left to read; one still running was never registered, which is the defect.
                 ASSERT_TRUE(entry->getQueryStatus()->isKilled())
                     << "the query was not registered with the checker while it was still running";
                 ASSERT_GE(steadyNowNs(), now_ns + timeout_us * 1000);
@@ -310,10 +306,7 @@ TEST(CancellationChecker, ProcessListPreservesFractionalTimeout)
                 << "the deadline was armed before the exact timeout the setting names";
             measured = true;
         }
-        /// Skip only when the deadline was genuinely unobservable, which needs this thread to have
-        /// been starved for longer than the timeout: judging the arithmetic on that would report a
-        /// violation nothing observed. Attempts lost to the millisecond window still fail, so losing
-        /// every one of those keeps reporting a test that can no longer prove anything.
+        /// Only a starved thread skips; attempts lost to the millisecond window still fail below.
         if (!measured && timed_out_before_read)
             GTEST_SKIP() << "never observed a deadline before the query timed out";
         EXPECT_TRUE(measured) << "could not observe ProcessList::insert within a single millisecond";

--- a/src/Interpreters/tests/gtest_cancellation_checker.cpp
+++ b/src/Interpreters/tests/gtest_cancellation_checker.cpp
@@ -200,9 +200,8 @@ TEST(CancellationChecker, ProcessListPreservesFractionalTimeout)
     /// up both, so the state matches a real query rather than whatever other tests left behind.
     std::thread body([&]
     {
-        /// Declared before the group, because `insert` points the group's counters and memory tracker
-        /// into an entry of `user_to_queries` that is never erased: the group must be detached while
-        /// this is still alive.
+        /// Declared before the group: `insert` points the group's counters into a `user_to_queries`
+        /// entry that is never erased, so the detach below must run while this is still alive.
         ProcessList process_list;
 
         ThreadStatus thread_status;

--- a/src/Interpreters/tests/gtest_cancellation_checker.cpp
+++ b/src/Interpreters/tests/gtest_cancellation_checker.cpp
@@ -238,6 +238,7 @@ TEST(CancellationChecker, ProcessListPreservesFractionalTimeout)
         ASSERT_EQ(checker.getArmedDeadline(), 0u) << "warm-up query is still armed";
 
         bool measured = false;
+        bool timed_out_before_read = false;
         for (int attempt = 0; attempt < 20 && !measured; ++attempt)
         {
             /// Built before the window below, leaving only the setting and the insertion inside it:
@@ -298,6 +299,7 @@ TEST(CancellationChecker, ProcessListPreservesFractionalTimeout)
                 /// notifies.
                 ASSERT_GE(steadyNowNs(), now_ns + timeout_us * 1000)
                     << "the query was not registered with the checker while it was still running";
+                timed_out_before_read = true;
                 entry.reset();
                 continue;
             }
@@ -306,11 +308,13 @@ TEST(CancellationChecker, ProcessListPreservesFractionalTimeout)
                 << "the deadline was armed before the exact timeout the setting names";
             measured = true;
         }
-        /// Every attempt was inconclusive, which needs the machine to have starved this thread for
-        /// longer than the timeout 20 times over. Skipping keeps that from reading as a violation of
-        /// the arithmetic, which was never observed.
-        if (!measured)
+        /// Skip only when the deadline was genuinely unobservable, which needs this thread to have
+        /// been starved for longer than the timeout: judging the arithmetic on that would report a
+        /// violation nothing observed. Attempts lost to the millisecond window still fail, so losing
+        /// every one of those keeps reporting a test that can no longer prove anything.
+        if (!measured && timed_out_before_read)
             GTEST_SKIP() << "never observed a deadline before the query timed out";
+        EXPECT_TRUE(measured) << "could not observe ProcessList::insert within a single millisecond";
     });
     body.join();
 }

--- a/src/Interpreters/tests/gtest_cancellation_checker.cpp
+++ b/src/Interpreters/tests/gtest_cancellation_checker.cpp
@@ -292,13 +292,15 @@ TEST(CancellationChecker, ProcessListPreservesFractionalTimeout)
 
             if (deadline_ms == 0)
             {
-                /// Nothing was armed. Only inconclusive if the timeout has passed, in which case the
-                /// worker has already cancelled and removed the query and there is no deadline left
-                /// to read: retry rather than judge the arithmetic. Raising the timeout instead would
-                /// break the retry path above, which waits for a drain that `appendDoneTasks` never
-                /// notifies.
-                ASSERT_GE(steadyNowNs(), now_ns + timeout_us * 1000)
+                /// Nothing left to read. Inconclusive only if the checker had tracked this query and
+                /// already cancelled it for exceeding its timeout, which needs this thread to have
+                /// lost the CPU for that long: retry rather than judge the arithmetic. A query that
+                /// is still running was never tracked, which is a real defect at the caller. Raising
+                /// the timeout instead would break the retry path above, which waits for a drain that
+                /// `appendDoneTasks` never notifies.
+                ASSERT_TRUE(entry->getQueryStatus()->isKilled())
                     << "the query was not registered with the checker while it was still running";
+                ASSERT_GE(steadyNowNs(), now_ns + timeout_us * 1000);
                 timed_out_before_read = true;
                 entry.reset();
                 continue;


### PR DESCRIPTION
Fix a query being cancelled up to 1 ms before its `max_execution_time`

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a query being cancelled up to 1 ms before its `max_execution_time` had elapsed, which also produced a self-contradictory error message such as `Timeout exceeded: elapsed 999.630 ms, maximum: 1000 ms`. Fractional values of the setting are now honoured to microsecond precision.

### Description

`CancellationChecker::appendTask` built the deadline as `((now_ms + timeout_ms + GRID - 1) / GRID) * GRID` from two operands already floored to whole milliseconds: `now_ms` from a `duration_cast`, and the timeout from `max_execution_time.totalMilliseconds()` even though the setting is a `SettingsSeconds` holding microseconds. The grid ceiling normally absorbs the discarded fraction, but when the floored sum is already grid-aligned the ceiling is a no-op and the deadline lands before `now + timeout`, contradicting the guarantee the comment there promised. With `max_execution_time = 0.001999` at 98.800 ms the deadline was armed for 100 ms; the exact one is 100.799 ms.

The fix passes the timeout in microseconds and rounds the whole deadline up once instead of rounding either operand, in a static function `CancellationChecker::alignedDeadlineMs` so the unit tests exercise shipped code rather than a copy. Grid alignment is unchanged, as is the set of tracked queries: a timeout below 1 ms was already dropped, and those queries stay bounded by the executor's own microsecond-precise check. Only `timeout_overflow_mode = 'throw'` was affected; `'break'` re-measures against the query's own stopwatch and cannot fire early.

A deadline that was previously early now fires up to one grid step (100 ms) later, inside the window the grid establishes by design. Of the stateless tests bounding such a query's duration, the tightest leaves 1 s of headroom.

Validation: the unit tests sweep the production function over 6 timeouts x 100 grid offsets x 5 sub-millisecond residues, and separately assert the deadline `appendTask` arms for a fractional-millisecond timeout. Restoring either truncation fails 27 of those 3000 cases and reddens the production-path test in all 20 runs; with the fix, 0.

Surfaced by `02122_join_group_by_timeout`, whose HTTP arm read a sub-second duration ([CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=gh-readonly-queue/master/pr-110451-2f02abe52a79c02fb554728f14d8fa847dcbc1e6&sha=2eba84a8a12a21c36516158d4fbe9530d3f0af8c&name_0=MergeQueueCI&name_1=Fast%20test)); it is unchanged here. Both defects are present on 25.8 and every 26.x branch.

Related: https://github.com/ClickHouse/ClickHouse/pull/109792
