### PR TITLE
Pin five stateless tests a Replicated database cannot enforce

### DIFF
--- a/tests/queries/0_stateless/02440_mutations_finalization.sh
+++ b/tests/queries/0_stateless/02440_mutations_finalization.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-# Tags: no-shared-merge-tree, no-parallel
+# Tags: no-shared-merge-tree, no-parallel, no-replicated-database
 # no-shared-merge-tree -- SMT doesn't assign mutations when merges are stopped.
 # no-parallel -- uses server-wide failpoints that affect all RMT tables.
+# no-replicated-database -- SYSTEM ENABLE FAILPOINT is process-local, but on a replicated /
+# shared-catalog database the table is created once per shard, so the untouched shard's
+# scheduler is never paused and finishes the mutation the test expects to stay pending.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02440_mutations_finalization.sh
+++ b/tests/queries/0_stateless/02440_mutations_finalization.sh
@@ -2,9 +2,9 @@
 # Tags: no-shared-merge-tree, no-parallel, no-replicated-database
 # no-shared-merge-tree -- SMT doesn't assign mutations when merges are stopped.
 # no-parallel -- uses server-wide failpoints that affect all RMT tables.
-# no-replicated-database -- SYSTEM ENABLE FAILPOINT is process-local, but on a replicated /
-# shared-catalog database the table is created once per shard, so the untouched shard's
-# scheduler is never paused and finishes the mutation the test expects to stay pending.
+# no-replicated-database -- SYSTEM ENABLE FAILPOINT is process-local, but the test cluster gives
+# this shard a second replica of the same table, whose merge-selecting task is not paused and
+# assigns the mutation the test expects to stay pending.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04318_remote_storage_engine_access.sh
+++ b/tests/queries/0_stateless/04318_remote_storage_engine_access.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Tags: shard
+# Tags: shard, no-replicated-database
+# no-replicated-database: on a replicated / shared-catalog database the DDL runs with no user, so the
+# in-storage access check asserted here is a no-op and the deny path silently allows.
+# Blocked on https://github.com/ClickHouse/ClickHouse/issues/111561 - re-enable when fixed.
 
 # Regression coverage for the security and lifecycle guarantees of the persistent `Remote` engine:
 #   1. Creating `Remote('127.0.0.1', ...)` that resolves to a local shard requires the creator to

--- a/tests/queries/0_stateless/04401_remote_storage_engine_restore_access.sh
+++ b/tests/queries/0_stateless/04401_remote_storage_engine_restore_access.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Tags: shard
+# Tags: shard, no-replicated-database
+# no-replicated-database: on a replicated / shared-catalog database the DDL runs with no user, so the
+# in-storage access check asserted here is a no-op and the deny path silently allows.
+# Blocked on https://github.com/ClickHouse/ClickHouse/issues/111561 - re-enable when fixed.
 
 # Regression: a backup `RESTORE` of a `Remote` storage engine that resolves to a local shard must
 # enforce the same local-target `SELECT`/`INSERT` access check that a direct `CREATE` does. A backup

--- a/tests/queries/0_stateless/04401_url_engine_s3_dispatch.reference
+++ b/tests/queries/0_stateless/04401_url_engine_s3_dispatch.reference
@@ -5,11 +5,5 @@ URL
 1
 --- TRUNCATE on ENGINE = URL('s3://...') is rejected (URL semantics preserved, no object removed) ---
 truncate-rejected
---- TABLE ENGINE ON URL grant alone: ENGINE = URL('http://...') is allowed (URL engine) ---
-http-allowed
---- TABLE ENGINE ON URL grant alone: ENGINE = URL('s3://...') is denied (dispatches to S3) ---
-s3-engine-denied
---- TABLE ENGINE ON URL grant alone: ENGINE = URL('az://...') is denied (dispatches to AzureBlobStorage) ---
-azure-engine-denied
 --- url('s3://...') table function requires the S3 source grant (dispatches to S3) ---
 s3-source-required

--- a/tests/queries/0_stateless/04401_url_engine_s3_dispatch.sh
+++ b/tests/queries/0_stateless/04401_url_engine_s3_dispatch.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-replicated-database
 # no-fasttest: dispatches to the S3/Azure object-storage backends (not built in the fast-test image)
 # and relies on the `table_engines_require_grant` access-control improvement enabled for the
 # stateless test server.
+# no-replicated-database: on a replicated / shared-catalog database the DDL runs with no user, so the
+# in-storage access check the engine-denial assertions rely on is a no-op and they silently allow.
+# Blocked on https://github.com/ClickHouse/ClickHouse/issues/111561 - re-enable when fixed.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04401_url_engine_s3_dispatch.sh
+++ b/tests/queries/0_stateless/04401_url_engine_s3_dispatch.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-replicated-database
+# Tags: no-fasttest
 # no-fasttest: dispatches to the S3/Azure object-storage backends (not built in the fast-test image)
 # and relies on the `table_engines_require_grant` access-control improvement enabled for the
 # stateless test server.
-# no-replicated-database: on a replicated / shared-catalog database the DDL runs with no user, so the
-# in-storage access check the engine-denial assertions rely on is a no-op and they silently allow.
-# Blocked on https://github.com/ClickHouse/ClickHouse/issues/111561 - re-enable when fixed.
+# The two CREATE-time engine-grant denials live in 04401_url_engine_s3_dispatch_engine_grant, which is
+# pinned to non-replicated databases; everything here runs in every flavour.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -36,30 +35,11 @@ ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_s3" 2>&1 
     | grep -qiE "not supported|NOT_IMPLEMENTED" && echo "truncate-rejected" || echo "NOT REJECTED"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_s3"
 
-# The dispatch re-checks `TABLE ENGINE` on the *target* backend on CREATE: a user granted only
-# `TABLE ENGINE ON URL` can create http(s) URL tables (served by the URL engine itself) but is denied
-# `s3://`/`az://` tables, which dispatch to `S3`/`AzureBlobStorage` and require those engine grants.
-# The denial naming the target engine proves the dispatched backend (not the plain URL engine) is the
-# one created.
 USER="url_only_${CLICKHOUSE_TEST_UNIQUE_NAME}"
 ${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS ${USER}"
 ${CLICKHOUSE_CLIENT} -q "CREATE USER ${USER} IDENTIFIED WITH no_password"
 ${CLICKHOUSE_CLIENT} -q "GRANT CREATE TABLE, DROP TABLE ON ${CLICKHOUSE_DATABASE}.* TO ${USER}"
 ${CLICKHOUSE_CLIENT} -q "GRANT TABLE ENGINE ON URL TO ${USER}"
-
-echo "--- TABLE ENGINE ON URL grant alone: ENGINE = URL('http://...') is allowed (URL engine) ---"
-${CLICKHOUSE_CLIENT} --user "${USER}" -q "DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.${CLICKHOUSE_TEST_UNIQUE_NAME}_http"
-${CLICKHOUSE_CLIENT} --user "${USER}" -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.${CLICKHOUSE_TEST_UNIQUE_NAME}_http (a UInt32) ENGINE = URL('http://example.com/data.csv', 'CSV')" 2>&1 \
-    | grep -qiE "Not enough privileges|ACCESS_DENIED" && echo "http-DENIED (unexpected)" || echo "http-allowed"
-${CLICKHOUSE_CLIENT} --user "${USER}" -q "DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.${CLICKHOUSE_TEST_UNIQUE_NAME}_http"
-
-echo "--- TABLE ENGINE ON URL grant alone: ENGINE = URL('s3://...') is denied (dispatches to S3) ---"
-${CLICKHOUSE_CLIENT} --user "${USER}" -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.${CLICKHOUSE_TEST_UNIQUE_NAME}_d_s3 (a UInt32) ENGINE = URL('${S3_URL}', 'CSV')" 2>&1 \
-    | grep -qiE "TABLE ENGINE ON S3|grant.*\bS3\b" && echo "s3-engine-denied" || echo "NOT DENIED"
-
-echo "--- TABLE ENGINE ON URL grant alone: ENGINE = URL('az://...') is denied (dispatches to AzureBlobStorage) ---"
-${CLICKHOUSE_CLIENT} --user "${USER}" -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.${CLICKHOUSE_TEST_UNIQUE_NAME}_d_az (a UInt32) ENGINE = URL('az://account.blob.core.windows.net/container/blob.csv', 'CSV')" 2>&1 \
-    | grep -qiE "TABLE ENGINE ON AzureBlobStorage|grant.*AzureBlobStorage" && echo "azure-engine-denied" || echo "NOT DENIED"
 
 # The `url(...)` table function forwards the *delegate's* engine name to source-access control, so a
 # user lacking the `S3` source grant is denied `url('s3://...')` with an `S3` (not `URL`) source

--- a/tests/queries/0_stateless/04401_url_engine_s3_dispatch_engine_grant.reference
+++ b/tests/queries/0_stateless/04401_url_engine_s3_dispatch_engine_grant.reference
@@ -1,0 +1,6 @@
+--- TABLE ENGINE ON URL grant alone: ENGINE = URL('http://...') is allowed (URL engine) ---
+http-allowed
+--- TABLE ENGINE ON URL grant alone: ENGINE = URL('s3://...') is denied (dispatches to S3) ---
+s3-engine-denied
+--- TABLE ENGINE ON URL grant alone: ENGINE = URL('az://...') is denied (dispatches to AzureBlobStorage) ---
+azure-engine-denied

--- a/tests/queries/0_stateless/04401_url_engine_s3_dispatch_engine_grant.sh
+++ b/tests/queries/0_stateless/04401_url_engine_s3_dispatch_engine_grant.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-replicated-database
+# no-fasttest: dispatches to the S3/Azure object-storage backends (not built in the fast-test image)
+# and relies on the `table_engines_require_grant` access-control improvement enabled for the
+# stateless test server.
+# no-replicated-database: on a replicated / shared-catalog database the DDL runs with no user, so the
+# in-storage access check these engine-denial assertions rely on is a no-op and they silently allow.
+# Blocked on https://github.com/ClickHouse/ClickHouse/issues/111561 - re-enable when fixed.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# The dispatch re-checks `TABLE ENGINE` on the *target* backend on CREATE: a user granted only
+# `TABLE ENGINE ON URL` can create http(s) URL tables (served by the URL engine itself) but is denied
+# `s3://`/`az://` tables, which dispatch to `S3`/`AzureBlobStorage` and require those engine grants.
+# The denial naming the target engine proves the dispatched backend (not the plain URL engine) is the
+# one created. The http case is asserted here too, so a denial cannot pass merely because the user
+# holds no engine grant at all.
+
+S3_URL="s3://my-bucket/my-key.csv"
+
+USER="url_only_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS ${USER}"
+${CLICKHOUSE_CLIENT} -q "CREATE USER ${USER} IDENTIFIED WITH no_password"
+${CLICKHOUSE_CLIENT} -q "GRANT CREATE TABLE, DROP TABLE ON ${CLICKHOUSE_DATABASE}.* TO ${USER}"
+${CLICKHOUSE_CLIENT} -q "GRANT TABLE ENGINE ON URL TO ${USER}"
+
+echo "--- TABLE ENGINE ON URL grant alone: ENGINE = URL('http://...') is allowed (URL engine) ---"
+${CLICKHOUSE_CLIENT} --user "${USER}" -q "DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.${CLICKHOUSE_TEST_UNIQUE_NAME}_http"
+${CLICKHOUSE_CLIENT} --user "${USER}" -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.${CLICKHOUSE_TEST_UNIQUE_NAME}_http (a UInt32) ENGINE = URL('http://example.com/data.csv', 'CSV')" 2>&1 \
+    | grep -qiE "Not enough privileges|ACCESS_DENIED" && echo "http-DENIED (unexpected)" || echo "http-allowed"
+${CLICKHOUSE_CLIENT} --user "${USER}" -q "DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.${CLICKHOUSE_TEST_UNIQUE_NAME}_http"
+
+echo "--- TABLE ENGINE ON URL grant alone: ENGINE = URL('s3://...') is denied (dispatches to S3) ---"
+${CLICKHOUSE_CLIENT} --user "${USER}" -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.${CLICKHOUSE_TEST_UNIQUE_NAME}_d_s3 (a UInt32) ENGINE = URL('${S3_URL}', 'CSV')" 2>&1 \
+    | grep -qiE "TABLE ENGINE ON S3|grant.*\bS3\b" && echo "s3-engine-denied" || echo "NOT DENIED"
+
+echo "--- TABLE ENGINE ON URL grant alone: ENGINE = URL('az://...') is denied (dispatches to AzureBlobStorage) ---"
+${CLICKHOUSE_CLIENT} --user "${USER}" -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.${CLICKHOUSE_TEST_UNIQUE_NAME}_d_az (a UInt32) ENGINE = URL('az://account.blob.core.windows.net/container/blob.csv', 'CSV')" 2>&1 \
+    | grep -qiE "TABLE ENGINE ON AzureBlobStorage|grant.*AzureBlobStorage" && echo "azure-engine-denied" || echo "NOT DENIED"
+
+${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS ${USER}"

--- a/tests/queries/0_stateless/04489_remote_storage_engine_restore_tf_access.sh
+++ b/tests/queries/0_stateless/04489_remote_storage_engine_restore_tf_access.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Tags: shard
+# Tags: shard, no-replicated-database
+# no-replicated-database: on a replicated / shared-catalog database the DDL runs with no user, so the
+# in-storage access check asserted here is a no-op and the deny path silently allows.
+# Blocked on https://github.com/ClickHouse/ClickHouse/issues/111561 - re-enable when fixed.
 
 # Regression: a backup `RESTORE` of a `Remote` storage engine over a *table-function* target that
 # resolves to a local shard must enforce the same access check that a direct `CREATE` does. A backup


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/111561
Related: https://github.com/ClickHouse/ClickHouse/pull/112862
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Five stateless tests diverge on the DBReplicated coverage flavours, then get force-set to `OK` by
the llvm-coverage whitewash, so they catch nothing. Over 21 days the divergence (`result differs`,
or `having stderror` for `04318`) hits 100% of the four access tests' runs and 96.4% of `02440`'s
(6449 of 6687); 26686 rows carry the whitewash (`Failed 0 out of 3 reruns`).

Two causes, verified locally:

- Four access tests (`04318_remote_storage_engine_access`,
  `04401_remote_storage_engine_restore_access`, `04401_url_engine_s3_dispatch`,
  `04489_remote_storage_engine_restore_tf_access`) assert deny paths implemented *inside*
  storage construction (`StorageDistributed.cpp`, `StorageURL.cpp`). On a Replicated database
  `tryEnqueueReplicatedDDL` enqueues the statement and a userless worker runs it, so
  `full_access` no-ops those checks and the deny path silently allows: open issue #111561.
- `02440_mutations_finalization` pauses merge selection with the process-local
  `SYSTEM ENABLE FAILPOINT`, but the test cluster gives this shard a second replica of the same
  table, whose unpaused merge-selecting task assigns the mutation that must stay pending.
  A harness assumption, not a defect.

Each pin gets a `no-replicated-database` tag and a comment naming its mechanism; the access pins
also name #111561, so `git grep 111561 tests/` finds every pin when it resolves. No assertion is
weakened or deleted.

`04401_url_engine_s3_dispatch` is pinned per subcase, not per file: only its two CREATE-time
engine-grant denials are invalidated, so a file-level tag would also have dropped five live
assertions, including the only stateless coverage of S3 source-grant dispatch. Those two subcases
move to `04401_url_engine_s3_dispatch_engine_grant`, which carries the pin; the rest of the file
now runs in every flavour.

The tag reaches three configurations (replicated-database, cloud, shared-catalog), all subject to
the same gap. Over 50 randomized runs: 250/250 green on the default flavour, 250/250 skipped on
the affected one.

I am not fixing the engine here: #111561 is parked on an owner-level decision, with a write-up and
three options there. Same instrument as merged #112862.

<details><summary>Per-test validation (before / after, both directions)</summary>

Reproduced with `tests/clickhouse-test --replicated-database --no-stateful <test>` on a 3-host,
2-shard cluster matching `tests/config/config.d/database_replicated.xml`.

| test | with `--replicated-database`, before | after | default flavour, after |
|---|---|---|---|
| `04318_remote_storage_engine_access` | FAIL, `TABLE_ALREADY_EXISTS` on the 3rd create (first two not rejected) | SKIP | OK |
| `04401_remote_storage_engine_restore_access` | FAIL, deny count `1` -> `0` and table-absent `0` -> `1` | SKIP | OK |
| `04401_url_engine_s3_dispatch` | FAIL, `s3-engine-denied` / `azure-engine-denied` -> `NOT DENIED`, `s3-source-required` still passed | OK (engine subcases moved out) | OK |
| `04401_url_engine_s3_dispatch_engine_grant` (new) | FAIL, same two lines, pin removed | SKIP | OK |
| `04489_remote_storage_engine_restore_tf_access` | FAIL, same inversion as 04401 | SKIP | OK |
| `02440_mutations_finalization` | FAIL, `['all_0_0_0'] 0` -> `[] 1` (pause had no effect) | SKIP | OK |

Mechanism corroborated in the server log: the `RESTORE` arrives as `user: user_04401_...`, but the
`CREATE TABLE ... ENGINE = Remote(...)` it produces runs as
`(from 0.0.0.0:0, user: , ...) /* ddl_entry=query-0000000007 */` and succeeds, where the test
requires it to be rejected.

`04541_create_as_select_table_scoped_insert_grant` and
`04418_create_table_as_select_subquery_access` are left failing on purpose, as the live evidence
for #111561, and are not touched here.

Why `04401_url_engine_s3_dispatch` splits: its `url('s3://...')` source-grant check is a plain
`SELECT` analyzed on the initiator, which has a user, and its engine-name, reload-safety and
TRUNCATE-rejection checks never touch access control, so only the two CREATE-time engine denials
are invalidated. The `http` allow case moves with them because it stops a denial from passing
merely because the user holds no engine grant at all.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.646` (included in `26.8` and later)
<!-- ch-version-info:end -->