### PR TITLE
Fix every -Wunique-object-duplication site

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,11 +499,19 @@ if (ENABLE_THINLTO AND NOT ENABLE_TESTS AND NOT SANITIZE)
         # cfi-vcall and cfi-derived-cast are C++-only checks; do not apply to C compilation.
         #
         # Use `-fvisibility=default` rather than the CFI-documented `hidden`: with hidden
-        # visibility the build succeeds (with `-Wunique-object-duplication` suppressed) but the
-        # resulting binary crashes with SIGSEGV before main runs, because inline-static singletons
-        # like `Context::global_context_instance` and `BaseSettings::unknown_settings` get
-        # duplicated per translation unit and singleton identity is broken. Validated empirically
-        # by WeeklyCFI run 25790910376 — `clickhouse-server --version` exited with signal 11.
+        # visibility the resulting binary crashes with SIGSEGV before main runs. Validated
+        # empirically by WeeklyCFI run 25790910376 — `clickhouse-server --version` exited with
+        # signal 11.
+        #
+        # That crash was originally attributed to inline-static singletons like
+        # `Context::global_context_instance` being duplicated per shared object. That is not the
+        # cause. Every `-Wunique-object-duplication` site has since been fixed (the warning now
+        # reports nothing under `-fvisibility=hidden`) and the crash is unchanged: it is
+        # `numa_init()`, a pre-main libc constructor, calling `free()` — which this binary
+        # interposes in `Common/malloc.cpp` — and reaching jemalloc before jemalloc has
+        # initialised. Whether it fires at all depends on static-initialisation order, so it can
+        # appear to come and go with unrelated changes. Fixing that is what would let CFI use
+        # `hidden`; the duplication fixes on their own do not.
         # CFI vtable visibility is still satisfied for in-binary types because
         # `-fwhole-program-vtables` and `-Wl,--lto-whole-program-visibility` (set above) cause
         # the linker to treat all vtables as internal to the binary.

--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -30,6 +30,14 @@
 
 // more aliases: https://mailman.videolan.org/pipermail/x264-devel/2014-May/010660.html
 
+/// Give a header-defined mutable object default visibility, so a build with hidden visibility
+/// gets one instance across all shared objects rather than one per shared object. On a function
+/// it covers that function's static locals, which cannot carry the attribute themselves.
+/// Prefer moving the definition into a .cpp instead; use this only where the definition has to
+/// stay in the header (a template, or a hot function that must remain inlinable).
+/// See `-Wunique-object-duplication`.
+#define SHARED_ACROSS_DSO __attribute__((visibility("default")))
+
 #define ALWAYS_INLINE __attribute__((__always_inline__))
 #define NO_INLINE __attribute__((__noinline__))
 #define MAY_ALIAS __attribute__((__may_alias__))

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -44,6 +44,11 @@ no_warning(unsafe-buffer-usage) # too aggressive
 no_warning(switch-default) # conflicts with "defaults in a switch covering all enum values"
 no_warning(nrvo) # not eliding copy on return - too aggressive
 no_warning(missing-noreturn) # too aggressive with no clear benefit, see https://github.com/ClickHouse/ClickHouse/pull/86416
+# -Wunique-object-duplication is enabled: a mutable object defined in a header, with external
+# linkage and hidden visibility, gets one copy per shared object rather than one per process, so
+# any "singleton" declared that way silently stops being one. It only has anything to report under
+# `-fvisibility=hidden`, which is why the default build never used to trip it - but see the CFI
+# block in the top-level CMakeLists.txt: hidden visibility made the binary SIGSEGV before main.
 # Hard-code knowledge of clang version-specific warnings rather than probing the compiler.
 # `lifetime-safety-*` were introduced in clang 23.
 if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 23)

--- a/contrib/pocketfft-cmake/CMakeLists.txt
+++ b/contrib/pocketfft-cmake/CMakeLists.txt
@@ -6,5 +6,5 @@ if (NOT ENABLE_POCKETFFT)
 endif()
 
 add_library(_pocketfft INTERFACE)
-target_include_directories(_pocketfft INTERFACE ${ClickHouse_SOURCE_DIR}/contrib/pocketfft)
+target_include_directories(_pocketfft SYSTEM INTERFACE ${ClickHouse_SOURCE_DIR}/contrib/pocketfft)
 add_library(ch_contrib::pocketfft ALIAS _pocketfft)

--- a/src/Common/CPUID.h
+++ b/src/Common/CPUID.h
@@ -444,7 +444,7 @@ inline bool haveGenuineIntel() noexcept
 
 struct CPUFlagsCache
 {
-#define DEF_NAME(X) static inline bool have_##X = have##X();
+#define DEF_NAME(X) static inline const bool have_##X = have##X();
     CPU_ID_ENUMERATE(DEF_NAME)
 #undef DEF_NAME
 };

--- a/src/Common/Crypto/OpenSSLInitializer.cpp
+++ b/src/Common/Crypto/OpenSSLInitializer.cpp
@@ -15,6 +15,12 @@
 namespace DB
 {
 
+OpenSSLInitializer & OpenSSLInitializer::instance()
+{
+    static OpenSSLInitializer instance;
+    return instance;
+}
+
 #if USE_SSL
 std::atomic<bool> DB::OpenSSLInitializer::initialize_done{false};
 std::atomic<bool> DB::OpenSSLInitializer::cleanup_done{false};

--- a/src/Common/Crypto/OpenSSLInitializer.h
+++ b/src/Common/Crypto/OpenSSLInitializer.h
@@ -15,11 +15,9 @@ namespace DB
 struct OpenSSLInitializer : private boost::noncopyable
 {
 public:
-    static OpenSSLInitializer & instance()
-    {
-        static OpenSSLInitializer instance;
-        return instance;
-    }
+    /// Defined out of line: a static local in a header-defined function gives every shared
+    /// object its own copy.
+    static OpenSSLInitializer & instance();
 
     static void initialize();
     static void cleanup();

--- a/src/Common/Fiber.cpp
+++ b/src/Common/Fiber.cpp
@@ -1,0 +1,7 @@
+#include <Common/Fiber.h>
+
+Fiber::FiberPtr & Fiber::getCurrentFiber()
+{
+    thread_local static FiberPtr current_fiber;
+    return current_fiber;
+}

--- a/src/Common/Fiber.h
+++ b/src/Common/Fiber.h
@@ -45,11 +45,9 @@ public:
         current_fiber = parent_fiber;
     }
 
-    static FiberPtr & getCurrentFiber()
-    {
-        thread_local static FiberPtr current_fiber;
-        return current_fiber;
-    }
+    /// Defined in `Fiber.cpp`: a static local in a header-defined function gives every shared
+    /// object its own copy.
+    static FiberPtr & getCurrentFiber();
 
 private:
     template <typename Fn>

--- a/src/Common/LoggingHelpers.cpp
+++ b/src/Common/LoggingHelpers.cpp
@@ -71,6 +71,12 @@ void LogFrequencyLimiterImpl::cleanup(time_t too_old_threshold_s)
 std::mutex LogSeriesLimiter::mutex;
 time_t LogSeriesLimiter::last_cleanup = 0;
 
+LogSeriesLimiter::SeriesRecords & LogSeriesLimiter::getSeriesRecords()
+{
+    static SeriesRecords records;
+    return records;
+}
+
 LogSeriesLimiter::LogSeriesLimiter(LoggerPtr logger_, size_t allowed_count_, time_t interval_s_)
     : logger(std::move(logger_))
 {

--- a/src/Common/LoggingHelpers.h
+++ b/src/Common/LoggingHelpers.h
@@ -55,11 +55,9 @@ class LogSeriesLimiter
     /// Hash(logger_name) -> (last_logged_time_s, accepted, muted)
     using SeriesRecords = std::unordered_map<UInt64, std::tuple<time_t, size_t, size_t>>;
 
-    static SeriesRecords & getSeriesRecords() TSA_REQUIRES(mutex)
-    {
-        static SeriesRecords records;
-        return records;
-    }
+    /// Defined out of line: a static local in a header-defined function gives every shared
+    /// object its own copy.
+    static SeriesRecords & getSeriesRecords() TSA_REQUIRES(mutex);
 
     LoggerPtr logger = nullptr;
     bool accepted = false;

--- a/src/Common/PerCPUMemory.cpp
+++ b/src/Common/PerCPUMemory.cpp
@@ -1,0 +1,15 @@
+#include <Common/PerCPUMemory.h>
+
+namespace DB
+{
+
+/// Process-wide instance used by CurrentMemoryTracker. Constructed before main(); allocations
+/// before its initialiser runs see cpu_count == 0, so sync() returns false without indexing the
+/// (empty) array - a normal per-thread flush.
+#if defined(OS_LINUX)
+PerCPUMemory per_cpu_memory{PerCPUMemory::numberOfCPUs(), PerCPUMemory::DEFAULT_BUDGET, PerCPUMemory::DEFAULT_THREAD_BUFFER};
+#else
+PerCPUMemory per_cpu_memory;
+#endif
+
+}

--- a/src/Common/PerCPUMemory.h
+++ b/src/Common/PerCPUMemory.h
@@ -190,7 +190,8 @@ private:
 /// Process-wide instance used by CurrentMemoryTracker. Constructed before main(); allocations
 /// before its initialiser runs see cpu_count == 0, so sync() returns false without indexing the
 /// (empty) array — a normal per-thread flush.
-inline PerCPUMemory per_cpu_memory{PerCPUMemory::numberOfCPUs(), PerCPUMemory::DEFAULT_BUDGET, PerCPUMemory::DEFAULT_THREAD_BUFFER};
+/// Defined in `PerCPUMemory.cpp`: a definition here gives every shared object its own copy.
+extern PerCPUMemory per_cpu_memory;
 
 }
 
@@ -225,7 +226,8 @@ private:
     std::atomic<Int64> buffer{DEFAULT_THREAD_BUFFER};
 };
 
-inline PerCPUMemory per_cpu_memory;
+/// Defined in `PerCPUMemory.cpp`: a definition here gives every shared object its own copy.
+extern PerCPUMemory per_cpu_memory;
 
 }
 

--- a/src/Common/ReplicasReconnector.cpp
+++ b/src/Common/ReplicasReconnector.cpp
@@ -8,6 +8,8 @@
 namespace DB
 {
 
+ReplicasReconnector * ReplicasReconnector::instance_ptr = nullptr;
+
 namespace ErrorCodes
 {
     extern const int NOT_INITIALIZED;

--- a/src/Common/ReplicasReconnector.h
+++ b/src/Common/ReplicasReconnector.h
@@ -29,7 +29,8 @@ public:
     void add(const Reconnector & reconnector);
 
 private:
-    inline static ReplicasReconnector * instance_ptr = nullptr;
+    /// Defined out of line: a definition in the header gives every shared object its own copy.
+    static ReplicasReconnector * instance_ptr;
     ReconnectorsList reconnectors;
     std::mutex mutex;
     std::atomic_bool emergency_stop{false};

--- a/src/Common/Scheduler/EventQueue.cpp
+++ b/src/Common/Scheduler/EventQueue.cpp
@@ -6,6 +6,8 @@
 namespace DB
 {
 
+thread_local EventQueue * EventQueue::current_thread_queue = nullptr;
+
 EventId EventQueue::postpone(TimePoint until, Task && task)
 {
     std::unique_lock lock{mutex};

--- a/src/Common/Scheduler/EventQueue.h
+++ b/src/Common/Scheduler/EventQueue.h
@@ -130,7 +130,8 @@ private:
     std::atomic<TimePoint> manual_time{TimePoint()}; // for tests only
 
     /// Thread-local pointer to the EventQueue attached to the current scheduler thread.
-    static inline thread_local EventQueue * current_thread_queue = nullptr;
+    /// Defined out of line: a definition in the header gives every shared object its own copy.
+    static thread_local EventQueue * current_thread_queue;
     std::atomic<bool> stopped{false};
 
 public:

--- a/src/Common/Scheduler/ResourceGuard.cpp
+++ b/src/Common/Scheduler/ResourceGuard.cpp
@@ -1,8 +1,55 @@
 #include <Common/Scheduler/ResourceGuard.h>
 #include <Common/CurrentThread.h>
 
+namespace ProfileEvents
+{
+    extern const Event SchedulerIOReadRequests;
+    extern const Event SchedulerIOReadBytes;
+    extern const Event SchedulerIOReadWaitMicroseconds;
+    extern const Event SchedulerIOWriteRequests;
+    extern const Event SchedulerIOWriteBytes;
+    extern const Event SchedulerIOWriteWaitMicroseconds;
+}
+
+namespace CurrentMetrics
+{
+    extern const Metric SchedulerIOReadScheduled;
+    extern const Metric SchedulerIOWriteScheduled;
+}
+
 namespace DB
 {
+
+const ResourceGuard::Metrics * ResourceGuard::Metrics::getIORead()
+{
+    static Metrics metrics{
+        .requests = ProfileEvents::SchedulerIOReadRequests,
+        .cost = ProfileEvents::SchedulerIOReadBytes,
+        .wait_microseconds = ProfileEvents::SchedulerIOReadWaitMicroseconds,
+        .scheduled_count = CurrentMetrics::SchedulerIOReadScheduled
+    };
+    return &metrics;
+}
+
+const ResourceGuard::Metrics * ResourceGuard::Metrics::getIOWrite()
+{
+    static Metrics metrics{
+        .requests = ProfileEvents::SchedulerIOWriteRequests,
+        .cost = ProfileEvents::SchedulerIOWriteBytes,
+        .wait_microseconds = ProfileEvents::SchedulerIOWriteWaitMicroseconds,
+        .scheduled_count = CurrentMetrics::SchedulerIOWriteScheduled
+    };
+    return &metrics;
+}
+
+ResourceGuard::Request & ResourceGuard::Request::local(const Metrics * metrics)
+{
+    // Since single thread cannot use more than one resource request simultaneously,
+    // we can reuse thread-local request to avoid allocations
+    static thread_local Request instance;
+    instance.metrics = metrics;
+    return instance;
+}
 
 namespace ErrorCodes
 {

--- a/src/Common/Scheduler/ResourceGuard.h
+++ b/src/Common/Scheduler/ResourceGuard.h
@@ -15,22 +15,6 @@
 #include <mutex>
 
 
-namespace ProfileEvents
-{
-    extern const Event SchedulerIOReadRequests;
-    extern const Event SchedulerIOReadBytes;
-    extern const Event SchedulerIOReadWaitMicroseconds;
-    extern const Event SchedulerIOWriteRequests;
-    extern const Event SchedulerIOWriteBytes;
-    extern const Event SchedulerIOWriteWaitMicroseconds;
-}
-
-namespace CurrentMetrics
-{
-    extern const Metric SchedulerIOReadScheduled;
-    extern const Metric SchedulerIOWriteScheduled;
-}
-
 namespace DB
 {
 
@@ -57,27 +41,13 @@ public:
         const ProfileEvents::Event wait_microseconds = ProfileEvents::end();
         const CurrentMetrics::Metric scheduled_count = CurrentMetrics::end();
 
-        static const Metrics * getIORead()
-        {
-            static Metrics metrics{
-                .requests = ProfileEvents::SchedulerIOReadRequests,
-                .cost = ProfileEvents::SchedulerIOReadBytes,
-                .wait_microseconds = ProfileEvents::SchedulerIOReadWaitMicroseconds,
-                .scheduled_count = CurrentMetrics::SchedulerIOReadScheduled
-            };
-            return &metrics;
-        }
+        /// Defined out of line: a static local in a header-defined function gives every
+        /// shared object its own copy.
+        static const Metrics * getIORead();
 
-        static const Metrics * getIOWrite()
-        {
-            static Metrics metrics{
-                .requests = ProfileEvents::SchedulerIOWriteRequests,
-                .cost = ProfileEvents::SchedulerIOWriteBytes,
-                .wait_microseconds = ProfileEvents::SchedulerIOWriteWaitMicroseconds,
-                .scheduled_count = CurrentMetrics::SchedulerIOWriteScheduled
-            };
-            return &metrics;
-        }
+        /// Defined out of line: a static local in a header-defined function gives every
+        /// shared object its own copy.
+        static const Metrics * getIOWrite();
     };
 
     enum RequestState
@@ -182,14 +152,9 @@ public:
             chassert(state == Finished);
         }
 
-        static Request & local(const Metrics * metrics)
-        {
-            // Since single thread cannot use more than one resource request simultaneously,
-            // we can reuse thread-local request to avoid allocations
-            static thread_local Request instance;
-            instance.metrics = metrics;
-            return instance;
-        }
+        /// Defined out of line: a static local in a header-defined function gives every
+        /// shared object its own copy.
+        static Request & local(const Metrics * metrics);
 
         const Metrics * metrics = nullptr; // Must be initialized before use
 

--- a/src/Common/TargetSpecific.h
+++ b/src/Common/TargetSpecific.h
@@ -97,7 +97,7 @@ enum class TargetArch : UInt32
 UInt32 getSupportedArchs();
 inline ALWAYS_INLINE bool isArchSupported(TargetArch arch)
 {
-    static UInt32 arches = getSupportedArchs();
+    static const UInt32 arches = getSupportedArchs();
     return arch == TargetArch::Default || (arches & static_cast<UInt32>(arch));
 }
 

--- a/src/Common/ThreadFuzzer.cpp
+++ b/src/Common/ThreadFuzzer.cpp
@@ -44,6 +44,14 @@
 namespace DB
 {
 
+ThreadFuzzer & ThreadFuzzer::instance()
+{
+    static ThreadFuzzer res;
+    return res;
+}
+
+std::atomic<bool> ThreadFuzzer::started{false};
+
 namespace ErrorCodes
 {
     extern const int CANNOT_MANIPULATE_SIGSET;

--- a/src/Common/ThreadFuzzer.h
+++ b/src/Common/ThreadFuzzer.h
@@ -45,11 +45,9 @@ namespace DB
 class ThreadFuzzer
 {
 public:
-    static ThreadFuzzer & instance()
-    {
-        static ThreadFuzzer res;
-        return res;
-    }
+    /// Defined out of line: a static local in a header-defined function gives every shared
+    /// object its own copy.
+    static ThreadFuzzer & instance();
 
     bool isEffective() const;
     void setup() const;
@@ -71,7 +69,8 @@ private:
     double explicit_sleep_probability = 0;
     double explicit_memory_exception_probability = 0;
 
-    inline static std::atomic<bool> started{false};
+    /// Defined out of line: a definition in the header gives every shared object its own copy.
+    static std::atomic<bool> started;
 
     ThreadFuzzer();
 

--- a/src/Common/ZooKeeper/KeeperClientCLI/KeeperClient.cpp
+++ b/src/Common/ZooKeeper/KeeperClientCLI/KeeperClient.cpp
@@ -9,6 +9,8 @@
 namespace DB
 {
 
+std::map<String, Command> KeeperClientBase::commands;
+
 namespace ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;

--- a/src/Common/ZooKeeper/KeeperClientCLI/KeeperClient.h
+++ b/src/Common/ZooKeeper/KeeperClientCLI/KeeperClient.h
@@ -46,7 +46,8 @@ public:
     std::function<void()> confirmation_callback;
     bool ask_confirmation = true;
 
-    inline static std::map<String, Command> commands;
+    /// Defined out of line: a definition in the header gives every shared object its own copy.
+    static std::map<String, Command> commands;
 
     std::unordered_map<String, std::future<Coordination::WatchResponse>> watches;
 

--- a/src/Core/BaseSettings.cpp
+++ b/src/Core/BaseSettings.cpp
@@ -7,6 +7,9 @@
 
 namespace DB
 {
+
+thread_local Strings BaseSettingsHelpers::unknown_settings;
+thread_local bool BaseSettingsHelpers::unknown_settings_warning_logged = false;
 namespace ErrorCodes
 {
     extern const int INCORRECT_DATA;

--- a/src/Core/BaseSettings.h
+++ b/src/Core/BaseSettings.h
@@ -61,8 +61,9 @@ struct BaseSettingsHelpers
 
 private:
     /// For logging the summary of unknown settings instead of logging each one separately.
-    inline static thread_local Strings unknown_settings;
-    inline static thread_local bool unknown_settings_warning_logged = false;
+    /// Defined out of line: a definition in the header gives every shared object its own copy.
+    static thread_local Strings unknown_settings;
+    static thread_local bool unknown_settings_warning_logged;
 };
 
 /// Maps a Traits type to its owning settings class (e.g. `SettingsTraits` -> `Settings`,

--- a/src/Core/QueryProcessingStage.h
+++ b/src/Core/QueryProcessingStage.h
@@ -44,7 +44,7 @@ namespace QueryProcessingStage
     {
         if (stage == QueryPlan)
             return "QueryPlan";
-        static const char * data[] =
+        static const char * const data[] =
         {
             "FetchColumns",
             "WithMergeableState",

--- a/src/Core/ServerUUID.cpp
+++ b/src/Core/ServerUUID.cpp
@@ -11,6 +11,8 @@
 namespace DB
 {
 
+UUID ServerUUID::server_uuid = UUIDHelpers::Nil;
+
 namespace ErrorCodes
 {
     extern const int CANNOT_CREATE_FILE;

--- a/src/Core/ServerUUID.h
+++ b/src/Core/ServerUUID.h
@@ -11,7 +11,8 @@ namespace DB
 
 class ServerUUID
 {
-    inline static UUID server_uuid = UUIDHelpers::Nil;
+    /// Defined out of line: a definition in the header gives every shared object its own copy.
+    static UUID server_uuid;
 
 public:
     /// Returns persistent UUID of current clickhouse-server or clickhouse-keeper instance.

--- a/src/Functions/FunctionsHashing.h
+++ b/src/Functions/FunctionsHashing.h
@@ -236,7 +236,9 @@ struct HalfMD5Impl
     static constexpr auto name = "halfMD5";
     using ReturnType = UInt64;
 
-    static UInt64 apply(const char * begin, size_t size)
+    /// SHARED_ACROSS_DSO covers the thread-local context below. This is a per-row hash, so the
+    /// definition stays in the header to keep it inlinable rather than moving to a .cpp.
+    SHARED_ACROSS_DSO static UInt64 apply(const char * begin, size_t size)
     {
         union // NOLINT(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
         {

--- a/src/Functions/UUIDv7Utils.cpp
+++ b/src/Functions/UUIDv7Utils.cpp
@@ -6,6 +6,9 @@ namespace DB
 namespace UUIDv7Utils
 {
 
+CounterFields Data::fields;
+SharedMutex Data::mutex;
+
 
 void setTimestampAndVersion(UUID & uuid, uint64_t timestamp)
 {

--- a/src/Functions/UUIDv7Utils.h
+++ b/src/Functions/UUIDv7Utils.h
@@ -62,8 +62,9 @@ struct CounterFields
 struct Data
 {
     /// Guarantee counter monotonicity within one timestamp across all threads generating UUIDv7 simultaneously.
-    static inline CounterFields fields;
-    static inline SharedMutex mutex; /// works a little bit faster than std::mutex here
+    /// Defined out of line: a definition in the header gives every shared object its own copy.
+    static CounterFields fields;
+    static SharedMutex mutex; /// works a little bit faster than std::mutex here
     std::lock_guard<SharedMutex> guard;
 
     Data()

--- a/src/IO/OpenedFileCache.cpp
+++ b/src/IO/OpenedFileCache.cpp
@@ -1,0 +1,12 @@
+#include <IO/OpenedFileCache.h>
+
+namespace DB
+{
+
+OpenedFileCache & OpenedFileCache::instance()
+{
+    static OpenedFileCache res;
+    return res;
+}
+
+}

--- a/src/IO/OpenedFileCache.h
+++ b/src/IO/OpenedFileCache.h
@@ -107,11 +107,9 @@ public:
         impls[bucket].remove(path, flags);
     }
 
-    static OpenedFileCache & instance()
-    {
-        static OpenedFileCache res;
-        return res;
-    }
+    /// Defined in `OpenedFileCache.cpp`: a static local in a header-defined function gives every shared
+    /// object its own copy.
+    static OpenedFileCache & instance();
 };
 
 using OpenedFileCachePtr = std::shared_ptr<OpenedFileCache>;

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -1131,6 +1131,12 @@ void ClientCache::clearCache()
     }
 }
 
+ClientCacheRegistry & ClientCacheRegistry::instance()
+{
+    static ClientCacheRegistry registry;
+    return registry;
+}
+
 void ClientCacheRegistry::registerClient(const std::shared_ptr<ClientCache> & client_cache)
 {
     std::lock_guard lock(clients_mutex);

--- a/src/IO/S3/Client.h
+++ b/src/IO/S3/Client.h
@@ -70,11 +70,9 @@ struct ClientCache
 class ClientCacheRegistry
 {
 public:
-    static ClientCacheRegistry & instance()
-    {
-        static ClientCacheRegistry registry;
-        return registry;
-    }
+    /// Defined out of line: a static local in a header-defined function gives every shared
+    /// object its own copy.
+    static ClientCacheRegistry & instance();
 
     void registerClient(const std::shared_ptr<ClientCache> & client_cache);
     void unregisterClient(ClientCache * client);

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -284,6 +284,9 @@ namespace CurrentMetrics
 
 namespace DB
 {
+
+ContextPtr ContextData::global_context_instance;
+ContextPtr ContextData::background_context_instance;
 namespace Setting
 {
     extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -592,8 +592,9 @@ protected:
     /// so view-inner queries on the same node are unaffected.
     bool positional_arguments_already_resolved = false;
 
-    inline static ContextPtr global_context_instance;
-    inline static ContextPtr background_context_instance;   /// Global holder to maintain ownership of background_context
+    /// Defined out of line: a definition in the header gives every shared object its own copy.
+    static ContextPtr global_context_instance;
+    static ContextPtr background_context_instance;   /// Global holder to maintain ownership of background_context
 
     /// Temporary data for query execution accounting.
     TemporaryDataOnDiskScopePtr temp_data_on_disk;

--- a/src/Interpreters/TextLog.cpp
+++ b/src/Interpreters/TextLog.cpp
@@ -17,6 +17,12 @@
 namespace DB
 {
 
+std::shared_ptr<TextLog::Queue> TextLog::getLogQueue(const SystemLogQueueSettings & settings)
+{
+    static std::shared_ptr<Queue> queue = std::make_shared<Queue>(settings);
+    return queue;
+}
+
 ColumnsDescription TextLogElement::getColumnsDescription()
 {
     auto priority_datatype = std::make_shared<DataTypeEnum8>(

--- a/src/Interpreters/TextLog.h
+++ b/src/Interpreters/TextLog.h
@@ -53,11 +53,9 @@ public:
 
     explicit TextLog(ContextPtr context_, const SystemLogSettings & settings);
 
-    static std::shared_ptr<Queue> getLogQueue(const SystemLogQueueSettings & settings)
-    {
-        static std::shared_ptr<Queue> queue = std::make_shared<Queue>(settings);
-        return queue;
-    }
+    /// Defined out of line: a static local in a header-defined function gives every shared
+    /// object its own copy.
+    static std::shared_ptr<Queue> getLogQueue(const SystemLogQueueSettings & settings);
 
     static consteval bool shouldTurnOffLogger() { return true; }
 };

--- a/src/Interpreters/TransactionLog.cpp
+++ b/src/Interpreters/TransactionLog.cpp
@@ -23,6 +23,8 @@
 namespace DB
 {
 
+std::atomic<Int64> TransactionLog::async_tables_loading_job_number{0};
+
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;

--- a/src/Interpreters/TransactionLog.h
+++ b/src/Interpreters/TransactionLog.h
@@ -153,7 +153,8 @@ private:
     static TransactionID deserializeTID(const String & csn_node_content);
     static String serializeTID(const TransactionID & tid);
 
-    inline static std::atomic<Int64> async_tables_loading_job_number{0};
+    /// Defined out of line: a definition in the header gives every shared object its own copy.
+    static std::atomic<Int64> async_tables_loading_job_number;
 
     ZooKeeperPtr getZooKeeper() const;
 

--- a/src/Server/CertificateReloader.cpp
+++ b/src/Server/CertificateReloader.cpp
@@ -14,6 +14,12 @@
 namespace DB
 {
 
+CertificateReloader & CertificateReloader::instance()
+{
+    static CertificateReloader instance;
+    return instance;
+}
+
 namespace ErrorCodes
 {
     extern const int INVALID_CONFIG_PARAMETER;

--- a/src/Server/CertificateReloader.h
+++ b/src/Server/CertificateReloader.h
@@ -74,11 +74,9 @@ public:
     /// Singleton
     CertificateReloader(CertificateReloader const &) = delete;
     void operator=(CertificateReloader const &) = delete;
-    static CertificateReloader & instance()
-    {
-        static CertificateReloader instance;
-        return instance;
-    }
+    /// Defined out of line: a static local in a header-defined function gives every shared
+    /// object its own copy.
+    static CertificateReloader & instance();
 
     /// Handle configuration reload for default path
     void tryLoad(const Poco::Util::AbstractConfiguration & config);

--- a/src/Server/DistributedQuery/ExchangeConnections.cpp
+++ b/src/Server/DistributedQuery/ExchangeConnections.cpp
@@ -9,6 +9,12 @@
 namespace DB
 {
 
+std::shared_ptr<ExchangeConnections> ExchangeConnections::instance()
+{
+    static std::shared_ptr<ExchangeConnections> self = std::make_shared<ExchangeConnections>();
+    return self;
+}
+
 namespace ErrorCodes
 {
     extern const int QUERY_WAS_CANCELLED;

--- a/src/Server/DistributedQuery/ExchangeConnections.h
+++ b/src/Server/DistributedQuery/ExchangeConnections.h
@@ -27,11 +27,9 @@ public:
     virtual ~ExchangeConnections() = default;
 
     /// TODO: move to Context instead of this singleton
-    static std::shared_ptr<ExchangeConnections> instance()
-    {
-        static std::shared_ptr<ExchangeConnections> self = std::make_shared<ExchangeConnections>();
-        return self;
-    }
+    /// Defined out of line: a static local in a header-defined function gives every shared
+    /// object its own copy.
+    static std::shared_ptr<ExchangeConnections> instance();
 
     void addConnection(const String & query_id, const String & exchange_stream_id, Poco::Net::StreamSocket socket);
 

--- a/src/Storages/StorageMongoDB.cpp
+++ b/src/Storages/StorageMongoDB.cpp
@@ -49,6 +49,12 @@ using bsoncxx::to_json;
 namespace DB
 {
 
+MongoDBInstanceHolder & MongoDBInstanceHolder::instance()
+{
+    static MongoDBInstanceHolder instance;
+    return instance;
+}
+
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;

--- a/src/Storages/StorageMongoDB.h
+++ b/src/Storages/StorageMongoDB.h
@@ -34,11 +34,9 @@ public:
     MongoDBInstanceHolder(MongoDBInstanceHolder const &) = delete;
     void operator=(MongoDBInstanceHolder const &) = delete;
 
-    static MongoDBInstanceHolder & instance()
-    {
-        static MongoDBInstanceHolder instance;
-        return instance;
-    }
+    /// Defined out of line: a static local in a header-defined function gives every shared
+    /// object its own copy.
+    static MongoDBInstanceHolder & instance();
 
     ~MongoDBInstanceHolder()
     {


### PR DESCRIPTION
A mutable object defined in a header, with external linkage and hidden visibility, gets one copy per shared object rather than one per process — so any "singleton" declared that way silently stops being one. `-Wunique-object-duplication` reports exactly that.

It is already enabled through `-Weverything` and has never been suppressed, but it only has anything to say under `-fvisibility=hidden`, which no ClickHouse target currently uses. So it has been quietly reporting 21 sites that nobody ever saw.

## The fixes

Three ways to fix one, in order of preference:

* **Move the definition into a `.cpp`.** There is then one instance by construction, and the symbol can stay hidden. Used for 17 sites. Three of them — `Common/Fiber`, `Common/PerCPUMemory`, `IO/OpenedFileCache` — had no `.cpp` and get a small one.
* **Make it `const`,** where it is never written after initialisation. Duplicate copies of a constant cannot diverge, so there is nothing to fix and nothing to keep in sync. Used for `CPUID.h` (19 diagnostics from one macro line), `TargetSpecific.h` and `QueryProcessingStage.h`.
* **Give it default visibility,** so the dynamic linker merges the copies. This is the weakest of the three — it does not remove the duplicates, it asks the loader to reconcile them, and it exports a symbol that could otherwise stay hidden. It is used exactly once, for `HalfMD5Impl::apply`: its `thread_local` OpenSSL context sits in a per-row hash whose own comment records a CI-visible regression from precisely this kind of extra indirection, so the definition has to stay inlinable. `SHARED_ACROSS_DSO` in `base/defines.h` is documented as the fallback, not the default.

`contrib/pocketfft` is included without `SYSTEM`, so its three sites landed on us. 107 other contribs already use `SYSTEM`; this makes it consistent, which is the treatment `cmake/warnings.cmake` prescribes for contrib headers.

`cmake/warnings.cmake` now records that the warning is deliberately on, alongside the other intentional ones, so it does not get switched off the next time it fires.

## Verification

* The default build is unchanged and behaves identically — queries, `system.settings`, `system.stack_trace`, the query profiler.
* Built with `-fvisibility=hidden` applied to `base/`, `src/` and `programs/` (deliberately not contrib), the warning goes from **214 diagnostics to 0**, and the binary links.

## What this does not do

It does not make hidden visibility usable, and the CFI block in `CMakeLists.txt` is corrected to say so.

That comment attributes the pre-`main` SIGSEGV to inline-static singletons like `Context::global_context_instance` being duplicated. That is not the cause. With every site fixed and the warning silent, the same crash remains:

```
numa_init()  →  set_sizes()  →  set_nodemask_size()      [pre-main libc constructor]
  → free()                                                [interposed, Common/malloc.cpp:47]
    → untrackMemory → je_sallocx → rtree_read             SIGSEGV
```

`numa_init()` runs as a libc constructor, calls the `free()` this binary interposes, and reaches jemalloc before jemalloc has initialised. Identical backtrace before and after this change.

It is also sensitive to static-initialisation order, so it can look fixed on one build and not the next — it did exactly that here, which is worth knowing before anyone reads a single green run as a green light. Fixing *that* is what would let CFI use `hidden`; these fixes on their own do not.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed every `-Wunique-object-duplication` site: header-defined mutable singletons that would get one copy per shared object instead of one per process. Mostly by moving the definition into a `.cpp`.


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.652` (included in `26.8` and later)
<!-- ch-version-info:end -->