### PR TITLE
Tag 04296_alter_rename_column_in_memory_rollback as no-replicated-database and cover the Replicated-database path

### DIFF
--- a/tests/queries/0_stateless/04296_alter_rename_column_in_memory_rollback.sh
+++ b/tests/queries/0_stateless/04296_alter_rename_column_in_memory_rollback.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-replicated-database
 # Tag no-parallel: uses fail points which affect the whole server.
+# Tag no-replicated-database: this test asserts the non-replicated rollback
+# contract. Inside a `Replicated` database the durable metadata commit lives in
+# ZooKeeper and cannot be rolled back, so `StorageMergeTree::alter` deliberately
+# converges forward to `new_metadata` instead of reverting; column `d` is then
+# gone by design. 04352 covers that path.
 #
 # Regression test for https://github.com/ClickHouse/ClickHouse/pull/104822
 # inline review (error-path rollback gap).

--- a/tests/queries/0_stateless/04352_alter_rename_column_replicated_db_start_mutation_rollback.reference
+++ b/tests/queries/0_stateless/04352_alter_rename_column_replicated_db_start_mutation_rollback.reference
@@ -1,0 +1,7 @@
+1	(RENAME COLUMN d TO d1)
+d1
+id
+1	hello
+2	world
+1	hello
+2	world

--- a/tests/queries/0_stateless/04352_alter_rename_column_replicated_db_start_mutation_rollback.sh
+++ b/tests/queries/0_stateless/04352_alter_rename_column_replicated_db_start_mutation_rollback.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Tags: no-parallel, zookeeper, no-replicated-database
+# Tag no-parallel: uses fail points which affect the whole server.
+# Tag no-replicated-database: this test creates its own `Replicated` database
+# explicitly, so it must not also run under the implicit replicated-database
+# test wrapper (which would nest databases and rename the engine).
+#
+# Companion of 04311 for the pre-registration failure point on
+# https://github.com/ClickHouse/ClickHouse/pull/104822. `mt_alter_throw_in_start_mutation`
+# throws before the rename mutation is registered, so the rollback handler enters with
+# `mutation_registered == false` and must register the prepared mutation itself (its
+# `mutation_*.txt` is already durable) before publishing `new_metadata`. 04311 enters the
+# same handler with the mutation already registered; 04296 covers this failure point on a
+# non-replicated database, where the durable metadata is reverted instead.
+#
+# A `Replicated` database commits table metadata to ZooKeeper, which cannot be rolled back,
+# so the handler must converge forward. Reverting in memory while the rename mutation stays
+# registered would let a merge run the rename against the old schema and reopen the #80648
+# data loss.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+set -e
+
+REP_DB="${CLICKHOUSE_DATABASE}_rep"
+ZK_PATH="/test/${CLICKHOUSE_DATABASE}/04352"
+
+# Silence the distributed-DDL status rows so the reference only contains the
+# query results asserted on.
+CLICKHOUSE_CLIENT="${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode=none"
+
+$CLICKHOUSE_CLIENT --query="DROP DATABASE IF EXISTS ${REP_DB} SYNC"
+$CLICKHOUSE_CLIENT --query="CREATE DATABASE ${REP_DB} ENGINE = Replicated('${ZK_PATH}', 'shard1', 'replica1')"
+
+$CLICKHOUSE_CLIENT --query="
+    CREATE TABLE ${REP_DB}.t (id UInt64, d String DEFAULT '')
+    ENGINE = MergeTree() ORDER BY id
+    SETTINGS min_bytes_for_wide_part = 0;
+
+    INSERT INTO ${REP_DB}.t VALUES (1, 'hello'), (2, 'world');
+
+    SYSTEM ENABLE FAILPOINT mt_alter_throw_in_start_mutation;
+"
+
+# The ALTER must throw. `alter_sync = 0` so the test does not block on the
+# (now harmless) registered mutation.
+set +e
+$CLICKHOUSE_CLIENT --query="ALTER TABLE ${REP_DB}.t RENAME COLUMN d TO d1 SETTINGS alter_sync = 0" 2>/dev/null
+alter_status=$?
+set -e
+
+$CLICKHOUSE_CLIENT --query="SYSTEM DISABLE FAILPOINT mt_alter_throw_in_start_mutation"
+
+if [ "$alter_status" -eq 0 ]; then
+    echo "FAIL: ALTER unexpectedly succeeded; failpoint did not fire"
+    $CLICKHOUSE_CLIENT --query="DROP DATABASE IF EXISTS ${REP_DB} SYNC"
+    exit 1
+fi
+
+# The handler entered with the mutation unregistered, so it must have registered
+# the prepared entry itself. `system.mutations` reads the in-memory mutation map,
+# so this pins that step before any reload could re-read the durable file. On the
+# non-replicated path the same failure point leaves no mutation registered.
+$CLICKHOUSE_CLIENT --query="SELECT count(), any(command) FROM system.mutations WHERE database = '${REP_DB}' AND table = 't'"
+
+# The durable metadata commit (column `d1`) could not be rolled back, so the
+# in-memory metadata must converge to it: column `d1` is visible and `d` is not.
+$CLICKHOUSE_CLIENT --query="SELECT name FROM system.columns WHERE database = '${REP_DB}' AND table = 't' ORDER BY name"
+
+# The data of the renamed column must be preserved (not replaced by defaults).
+# A concurrent merge would have reopened #80648; force one and re-check.
+$CLICKHOUSE_CLIENT --query="OPTIMIZE TABLE ${REP_DB}.t FINAL"
+$CLICKHOUSE_CLIENT --query="SELECT id, d1 FROM ${REP_DB}.t ORDER BY id"
+
+# Reload the table from the durable metadata and confirm the data is still
+# intact after the registered rename mutation has had a chance to run.
+$CLICKHOUSE_CLIENT --query="DETACH TABLE ${REP_DB}.t PERMANENTLY"
+$CLICKHOUSE_CLIENT --query="ATTACH TABLE ${REP_DB}.t"
+$CLICKHOUSE_CLIENT --query="SELECT id, d1 FROM ${REP_DB}.t ORDER BY id"
+
+$CLICKHOUSE_CLIENT --query="DROP DATABASE ${REP_DB} SYNC"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/104822
-->

Related: #104822


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04296_alter_rename_column_in_memory_rollback` fails on **every** run of the two
`DBReplicated` `llvm_coverage` job flavours: over the 20 days to 2026-08-02, all **~6,200**
rows of those flavours carry `Code: 47 ... Missing columns: 'd'` (including all ~550 master
runs), against **0** of the ~94,100 runs on every other flavour. Deterministic, not
flaky. It is invisible because the diagnostics rerun drops the job's
`--replicated-database` flag: the rerun passes, the test is labelled flaky, and the
`llvm_coverage` job force-sets `OK`. Once #112247 lands, these two jobs start failing for real.

Root cause is the test's scope, not the engine. `--replicated-database` makes the test
database `ENGINE=Replicated`, so `StorageMergeTree::alter`'s in-memory-commit error handler
takes the deliberate converge-forward branch (`StorageMergeTree.cpp:638-661`): the durable
commit is already in ZooKeeper and unrollbackable, so it publishes `new_metadata` rather than
reverting. Reverting while the rename mutation stays registered would let a merge run it
against the old schema and reopen the #80648 data loss (see `:640` and commit
`467604032169269`). Column `d` is gone by design and `SELECT id, d` correctly raises
`UNKNOWN_IDENTIFIER`. 04296 is the only one of the seven tests added by #104822 lacking
`no-replicated-database`; it predates that branch.

This PR tags 04296 with a reason comment, matching its six siblings, and adds
`04352_alter_rename_column_replicated_db_start_mutation_rollback` covering the cell the tag
excludes: `mt_alter_throw_in_start_mutation` on an explicitly created `Replicated` database.
That cell is uncovered today, and is the only way to reach the
`if (!mutation_registered && prepared)` sub-branch at `:647`.

Validation: the failure reproduces deterministically with the flag and passes without it on
the same binary; after the change 04296 is SKIPPED under `--replicated-database` and still
passes plainly. 50/50 randomized runs green for both files, no `no-random-*` tag. 04352
reddens under three independent mutations: removing its failpoint, flipping the
converge-forward line to revert, and deleting the handler's mutation self-registration.

[Failing CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=0fffcd7de88bcefa39912ed1a624e59d79e9479d&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20old%20analyzer%2C%20s3%20storage%2C%20DBReplicated%2C%20WasmEdge%2C%20sequential%2C%202%2F2%29)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.662` (included in `26.8` and later)
<!-- ch-version-info:end -->