### PR TITLE
Fix wrong results reading a Nested sibling beside a re-added subcolumn

### DIFF
--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -140,7 +140,7 @@ void MergeTreeReaderWide::prefetchForAllColumns(
         {
             auto & cache = caches[columns_to_read[pos].getNameInStorage()];
             prefetchForColumn(
-                priority, columns_to_read[pos], serializations[pos], from_mark, continue_reading,
+                priority, pos, columns_to_read[pos], serializations[pos], from_mark, continue_reading,
                 current_task_last_mark, cache);
         }
         catch (Exception & e)
@@ -197,6 +197,7 @@ size_t MergeTreeReaderWide::readRows(
                 auto & deserialize_states_cache = deserialize_states_caches[column_to_read.getNameInStorage()];
 
                 readData(
+                    pos,
                     column_to_read,
                     serializations[pos],
                     column,
@@ -530,7 +531,7 @@ void MergeTreeReaderWide::deserializePrefixForAllColumnsImpl(size_t num_columns,
                     deserialize_state_map,
                     cache,
                     deserialize_states_cache,
-                    prefixes_prefetch_callback_getter ? prefixes_prefetch_callback_getter(columns_to_read[pos]) : ISerialization::StreamCallback{});
+                    prefixes_prefetch_callback_getter ? prefixes_prefetch_callback_getter(pos, columns_to_read[pos]) : ISerialization::StreamCallback{});
             }
             catch (Exception & e)
             {
@@ -557,9 +558,9 @@ void MergeTreeReaderWide::deserializePrefixForAllColumns(size_t num_columns, siz
 
 void MergeTreeReaderWide::deserializePrefixForAllColumnsWithPrefetch(size_t num_columns, size_t from_mark, size_t current_task_last_mark, Priority priority)
 {
-    auto prefixes_prefetch_callback_getter = [&](const NameAndTypePair & name_and_type)
+    auto prefixes_prefetch_callback_getter = [&](size_t pos, const NameAndTypePair & name_and_type)
     {
-        return [&](const ISerialization::SubstreamPath & substream_path)
+        return [&, pos](const ISerialization::SubstreamPath & substream_path)
         {
             auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(name_and_type, substream_path, ".bin", data_part_info_for_read->getChecksums(), storage_settings);
             if (stream_name && !prefetched_streams.contains(*stream_name))
@@ -567,7 +568,7 @@ void MergeTreeReaderWide::deserializePrefixForAllColumnsWithPrefetch(size_t num_
                 if (ReadBuffer * buf = getStream(/* seek_to_start = */true, substream_path, data_part_info_for_read->getChecksums(), name_and_type, 0, /* seek_to_mark = */false, current_task_last_mark, caches[name_and_type.getNameInStorage()]))
                 {
                     buf->prefetch(priority);
-                    prefetched_streams.insert(*stream_name);
+                    prefetched_streams.emplace(*stream_name, pos);
                 }
             }
         };
@@ -578,6 +579,7 @@ void MergeTreeReaderWide::deserializePrefixForAllColumnsWithPrefetch(size_t num_
 
 void MergeTreeReaderWide::prefetchForColumn(
     Priority priority,
+    size_t pos,
     const NameAndTypePair & name_and_type,
     const SerializationPtr & serialization,
     size_t from_mark,
@@ -599,7 +601,7 @@ void MergeTreeReaderWide::prefetchForColumn(
             if (ReadBuffer * buf = getStream(false, substream_path, data_part_info_for_read->getChecksums(), name_and_type, from_mark, seek_to_mark, current_task_last_mark, cache))
             {
                 buf->prefetch(priority);
-                prefetched_streams.insert(*stream_name);
+                prefetched_streams.emplace(*stream_name, pos);
             }
         }
     };
@@ -619,6 +621,7 @@ void MergeTreeReaderWide::prefetchForColumn(
 
 
 void MergeTreeReaderWide::readData(
+    size_t pos,
     const NameAndTypePair & name_and_type,
     const SerializationPtr & serialization,
     ColumnPtr & column,
@@ -638,7 +641,10 @@ void MergeTreeReaderWide::readData(
     deserialize_settings.getter = [&](const ISerialization::SubstreamPath & substream_path)
     {
         auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(name_and_type, substream_path, ".bin", data_part_info_for_read->getChecksums(), storage_settings);
-        bool was_prefetched = stream_name && prefetched_streams.contains(*stream_name);
+        /// A prefetch leaves the stream positioned for the column that issued it. Another column
+        /// sharing this stream must still seek, or it reads from where the first one stopped.
+        auto prefetched_it = stream_name ? prefetched_streams.find(*stream_name) : prefetched_streams.end();
+        bool was_prefetched = prefetched_it != prefetched_streams.end() && prefetched_it->second == pos;
         bool seek_to_mark = !was_prefetched && !continue_reading && !read_without_marks;
 
         return getStream(

--- a/src/Storages/MergeTree/MergeTreeReaderWide.h
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.h
@@ -76,6 +76,7 @@ private:
     FileStreams::iterator addStream(const ISerialization::SubstreamPath & substream_path, const String & stream_name);
 
     void readData(
+        size_t pos,
         const NameAndTypePair & name_and_type,
         const SerializationPtr & serialization,
         ColumnPtr & column,
@@ -90,6 +91,7 @@ private:
     /// Make next readData more simple by calling 'prefetch' of all related ReadBuffers (column streams).
     void prefetchForColumn(
         Priority priority,
+        size_t pos,
         const NameAndTypePair & name_and_type,
         const SerializationPtr & serialization,
         size_t from_mark,
@@ -110,13 +112,16 @@ private:
     void deserializePrefixForAllColumns(size_t num_columns, size_t from_mark, size_t current_task_last_mark);
     void deserializePrefixForAllColumnsWithPrefetch(size_t num_columns, size_t from_mark, size_t current_task_last_mark, Priority priority);
 
-    using StreamCallbackGetter = std::function<ISerialization::StreamCallback(const NameAndTypePair &)>;
+    using StreamCallbackGetter = std::function<ISerialization::StreamCallback(size_t, const NameAndTypePair &)>;
     void deserializePrefixForAllColumnsImpl(size_t num_columns, size_t from_mark, size_t current_task_last_mark, StreamCallbackGetter prefixes_prefetch_callback_getter);
 
     std::unordered_map<String, ISerialization::SubstreamsCache> caches;
     std::unordered_map<String, ISerialization::SubstreamsDeserializeStatesCache> deserialize_states_caches;
     DeserializationPrefixesCache * deserialization_prefixes_cache;
-    std::unordered_set<std::string> prefetched_streams;
+    /// Stream name -> position of the column that prefetched it. A prefetch positions the stream for
+    /// its own column only, so a stream shared by several requested columns (Nested offsets under
+    /// `share_nested_offsets`) must still be seeked by every other column that reads it.
+    std::unordered_map<std::string, size_t> prefetched_streams;
     ssize_t prefetched_from_mark = -1;
     ReadBufferFromFileBase::ProfileCallback profile_callback;
     clockid_t clock_type;

--- a/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.reference
+++ b/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.reference
@@ -1,0 +1,10 @@
+part type	Wide
+both columns in reader header	1
+missing subcolumn first	199	0	0
+sibling first	199	0	0
+sibling between	199	0	0
+prefetch off	199	0
+many granules	199	0
+wrapped element types	199	0	0
+compact part type	Compact
+compact control	199	0

--- a/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.reference
+++ b/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.reference
@@ -1,5 +1,6 @@
 part type	Wide
 both columns in reader header	1
+prefetch limit permits prefetching	1
 missing subcolumn first	199	0	0
 sibling first	199	0	0
 sibling between	199	0	0

--- a/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.sql
+++ b/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.sql
@@ -1,0 +1,127 @@
+-- Tags: no-random-merge-tree-settings
+
+DROP TABLE IF EXISTS t_shared_offsets_wide;
+DROP TABLE IF EXISTS t_shared_offsets_granules;
+DROP TABLE IF EXISTS t_shared_offsets_wrapped;
+DROP TABLE IF EXISTS t_shared_offsets_compact;
+
+-- A prefetch positions a stream for the column that issued it. Under `share_nested_offsets` several
+-- Nested siblings name one offsets stream, so every other column reading it must still seek.
+CREATE TABLE t_shared_offsets_wide
+(
+    `id` UInt64,
+    `arr.id` Array(UInt64),
+    `arr.s` Array(String),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS share_nested_offsets = 1, min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_shared_offsets_wide SELECT
+    number,
+    arrayMap(x -> x + 10, range(number % 3 + 1)),
+    arrayMap(x -> concat('s', toString(x)), range(number % 3 + 1)),
+    arrayMap(x -> (toString(x), x * 1.5), range(number % 3 + 1))
+FROM numbers(100);
+
+ALTER TABLE t_shared_offsets_wide DROP COLUMN `arr.nested`;
+ALTER TABLE t_shared_offsets_wide ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
+
+SELECT 'part type', any(part_type) FROM system.parts WHERE database = currentDatabase() AND table = 't_shared_offsets_wide' AND active;
+
+-- The reader must be asked for both columns, otherwise `query_plan_remove_unused_columns` prunes the
+-- subcolumn and the shared stream is read by a single column.
+SELECT 'both columns in reader header', countIf(explain LIKE '%arr.nested.b%') > 0 AND countIf(explain LIKE '%arr.id%') > 0
+FROM (EXPLAIN header = 1
+    SELECT sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1)))
+    FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_offsets_wide));
+
+SET local_filesystem_read_prefetch = 1;
+
+SELECT 'missing subcolumn first', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1))), countIf(s != arrayMap(x -> concat('s', toString(x)), range(id % 3 + 1)))
+FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid, `arr.s` AS s FROM t_shared_offsets_wide);
+
+SELECT 'sibling first', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1))), countIf(s != arrayMap(x -> concat('s', toString(x)), range(id % 3 + 1)))
+FROM (SELECT id, `arr.id` AS aid, `arr.s` AS s, `arr.nested`.b AS nb FROM t_shared_offsets_wide);
+
+SELECT 'sibling between', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1))), countIf(s != arrayMap(x -> concat('s', toString(x)), range(id % 3 + 1)))
+FROM (SELECT id, `arr.id` AS aid, `arr.nested`.b AS nb, `arr.s` AS s FROM t_shared_offsets_wide);
+
+SELECT 'prefetch off', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1)))
+FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_offsets_wide)
+SETTINGS local_filesystem_read_prefetch = 0;
+
+-- More than one granule, so the seek must be right for every mark, not only the first.
+CREATE TABLE t_shared_offsets_granules
+(
+    `id` UInt64,
+    `arr.id` Array(UInt64),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS share_nested_offsets = 1, min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 8;
+
+INSERT INTO t_shared_offsets_granules SELECT
+    number,
+    arrayMap(x -> x + 10, range(number % 3 + 1)),
+    arrayMap(x -> (toString(x), x * 1.5), range(number % 3 + 1))
+FROM numbers(100);
+
+ALTER TABLE t_shared_offsets_granules DROP COLUMN `arr.nested`;
+ALTER TABLE t_shared_offsets_granules ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
+
+SELECT 'many granules', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1)))
+FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_offsets_granules);
+
+-- Wrapped element types resolve to the same shared offsets stream.
+CREATE TABLE t_shared_offsets_wrapped
+(
+    `id` UInt64,
+    `arr.n` Array(Nullable(UInt64)),
+    `arr.lc` Array(LowCardinality(String)),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS share_nested_offsets = 1, min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_shared_offsets_wrapped SELECT
+    number,
+    arrayMap(x -> if(x % 2 = 0, NULL, x + 10), range(number % 3 + 1)),
+    arrayMap(x -> concat('l', toString(x)), range(number % 3 + 1)),
+    arrayMap(x -> (toString(x), x * 1.5), range(number % 3 + 1))
+FROM numbers(100);
+
+ALTER TABLE t_shared_offsets_wrapped DROP COLUMN `arr.nested`;
+ALTER TABLE t_shared_offsets_wrapped ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
+
+SELECT 'wrapped element types', sum(length(nb)), countIf(n != arrayMap(x -> if(x % 2 = 0, NULL, x + 10), range(id % 3 + 1))), countIf(lc != arrayMap(x -> concat('l', toString(x)), range(id % 3 + 1)))
+FROM (SELECT id, `arr.nested`.b AS nb, `arr.n` AS n, `arr.lc` AS lc FROM t_shared_offsets_wrapped);
+
+-- Compact parts keep per-column offsets and were never affected; a control against overfitting.
+CREATE TABLE t_shared_offsets_compact
+(
+    `id` UInt64,
+    `arr.id` Array(UInt64),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS share_nested_offsets = 1, min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000;
+
+INSERT INTO t_shared_offsets_compact SELECT
+    number,
+    arrayMap(x -> x + 10, range(number % 3 + 1)),
+    arrayMap(x -> (toString(x), x * 1.5), range(number % 3 + 1))
+FROM numbers(100);
+
+ALTER TABLE t_shared_offsets_compact DROP COLUMN `arr.nested`;
+ALTER TABLE t_shared_offsets_compact ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
+
+SELECT 'compact part type', any(part_type) FROM system.parts WHERE database = currentDatabase() AND table = 't_shared_offsets_compact' AND active;
+
+SELECT 'compact control', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1)))
+FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_offsets_compact);
+
+DROP TABLE t_shared_offsets_wide;
+DROP TABLE t_shared_offsets_granules;
+DROP TABLE t_shared_offsets_wrapped;
+DROP TABLE t_shared_offsets_compact;

--- a/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.sql
+++ b/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.sql
@@ -38,6 +38,12 @@ FROM (EXPLAIN header = 1
 
 SET local_filesystem_read_prefetch = 1;
 
+-- A nonzero `filesystem_prefetches_limit` below the number of columns read skips prefetching
+-- entirely, which would make every assertion below pass without taking the prefetch path. Read the
+-- effective value rather than pinning it, so such a limit fails this test instead of silencing it.
+-- No query below reads more than 8 columns; 0 means unlimited.
+SELECT 'prefetch limit permits prefetching', getSetting('filesystem_prefetches_limit') = 0 OR getSetting('filesystem_prefetches_limit') > 8;
+
 SELECT 'missing subcolumn first', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1))), countIf(s != arrayMap(x -> concat('s', toString(x)), range(id % 3 + 1)))
 FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid, `arr.s` AS s FROM t_shared_offsets_wide);
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/112769

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed wrong results when filesystem read prefetch is enabled and a `Nested` column is read beside a subcolumn that was dropped and re-added, on tables with `share_nested_offsets` enabled (the default). Such a query could return default values for a physically present column that the `ALTER`s never touched. This needs no non-default settings on object storage, where `remote_filesystem_read_prefetch` defaults to `1`; on local disks it needs `local_filesystem_read_prefetch = 1`. A separate, prefetch-independent defect still corrupts such reads when a range spans several blocks; that one is not covered here.

### Description

A physically present, never-altered column returned its default value when read beside a missing `Nested` subcolumn sharing its offsets stream.

```sql
CREATE TABLE t (`id` UInt64, `arr.id` Array(UInt64), `arr.nested` Array(Tuple(a String, b Float64)))
ENGINE = MergeTree ORDER BY id SETTINGS min_bytes_for_wide_part = 0;
INSERT INTO t SELECT number, [number + 10], [(toString(number), number * 1.5)] FROM numbers(100);
ALTER TABLE t DROP COLUMN `arr.nested`;
ALTER TABLE t ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));

SELECT `arr.nested`.b, `arr.id` FROM t SETTINGS local_filesystem_read_prefetch = 1;
-- every row returned [0] [0]; `arr.id` holds [10], [11], ...
```

Root cause: with `share_nested_offsets` every `arr.*` sibling names the same offsets stream, so the re-added subcolumn and the surviving sibling read one file. `MergeTreeReaderWide` recorded a prefetched stream by name only, and the data getter read that as "this stream is already positioned for the column about to read it". The first column's claim therefore suppressed the second column's mark seek; the second read from where the first stopped, got no usable offsets, came back empty, and was default-filled. The `readRows` comment already forbids skipping seeks.

The fix keys `prefetched_streams` from stream name to the position of the claiming column, so a skipped seek is authorized only for that column. Single-owner paths are unchanged, keeping the prefetch optimization; only a second column reading the same stream now seeks, as the invariant requires.

Scope: Wide parts, one reader call. The multi-block defect named in the changelog entry is prefetch-independent, so this diff is inert there (`prefetched_streams` is written only under the prefetch gate) and measures identically before and after; tracked separately. Compact parts were never affected and serve as a control. No new setting, no format change.

Pre-existing on master, reproduced on a pristine-master build, found while verifying #112769.

<details>
<summary>Validation matrix</summary>

Content oracles, not `length`, which the bad read preserves. `EXPLAIN header = 1` asserted to list both columns, since `query_plan_remove_unused_columns` otherwise prunes the subcolumn and the query stops triggering the bug. Verified in both directions, including a mutation check where reverting only the ownership comparison reproduces the original output byte for byte.

| arm | wrong rows before | after |
|---|---|---|
| Wide, local disk, `local_filesystem_read_prefetch = 1` | 100 / 100 | 0 |
| Wide, local disk, prefetch off | 0 | 0 |
| Wide, `type = s3` disk, no non-default settings | 100 / 100 | 0 |
| Wide, `type = local_blob_storage` disk, no non-default settings | 100 / 100 | 0 |
| Compact, any setting | 0 | 0 |
| Wide, `share_nested_offsets = 0` | 0 | 0 |

Also measured: 13-granule and 1250-granule fixtures; `Array(Nullable(UInt64))` and `Array(LowCardinality(String))` siblings; three siblings; both read orders (the subcolumn must be read first, otherwise the sibling's own prefetch positions the stream and the read is correct); `index_granularity` 1 to 65536 crossed with `max_block_size` 8000 to 100000; horizontal merge, vertical merge on a remote disk (`merge_algorithm = 'Vertical'` confirmed in `part_log`), mutation, and `apply_mutations_on_fly`. Merges and mutations write correct data; the defect is on the read path only.

New test run 50 times at 8 jobs and 50 times at 1 job with randomized settings. The `nested`, `share_nested_offsets`, `prefetch` and `subcolumn` suites ran on both arms: the failing sets differ only by tests that fail before the change, none after.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.750` (included in `26.8` and later)
<!-- ch-version-info:end -->