### PR TITLE
Look for empty replacements in regex

### DIFF
--- a/src/Functions/ReplaceRegexpImpl.h
+++ b/src/Functions/ReplaceRegexpImpl.h
@@ -205,7 +205,11 @@ struct ReplaceRegexpImpl
                     else
                         replacement = instr.literal;
                     res_data.resize(res_data.size() + replacement.size());
-                    memcpy(&res_data[res_offset], replacement.data(), replacement.size());
+                    /// A capture group that did not participate in the match comes back from re2 as
+                    /// an empty piece with a null `data()`, and `memcpy` is declared `nonnull` even
+                    /// for a zero length. Guarded like the JIT path below.
+                    if (!replacement.empty())
+                        memcpy(&res_data[res_offset], replacement.data(), replacement.size());
                     res_offset += replacement.size();
                     units_since_charge += 1 + replacement.size() / ReplaceCancellationBudget::bytes_per_unit;
                     if (units_since_charge >= ReplaceCancellationBudget::units_per_instruction_charge)

--- a/tests/queries/0_stateless/04670_replace_regexp_unmatched_capture_group.reference
+++ b/tests/queries/0_stateless/04670_replace_regexp_unmatched_capture_group.reference
@@ -1,0 +1,71 @@
+-- an optional group that never participates --
+a[]c
+a[]c
+-- the group is in the branch of an alternation that was not taken --
+<a><a><a>
+<a>aa
+-- the replacement is nothing but the unmatched group --
+ac
+ac
+-- the same unmatched group substituted several times --
+ac
+-- matched and unmatched groups mixed, with literals in between --
+[a||b]c
+-- the whole match next to an unmatched group --
+a<b|>c
+-- five groups, none of which participate (the pattern from 04650) --
+[][][]
+-- nested optional groups --
+[||]y
+-- an empty haystack, and an empty match at the end of the string --
+[]
+ab[]
+[]a[]b[]
+-- a trailing group that matches only sometimes, over several rows --
+[a|]
+[a|b]
+[a|][a|b]
+b[a|]
+
+-- non-constant haystack (the vector path) --
+a[]c
+a[]c
+-- non-constant needle --
+a[]c
+a[]c
+-- non-constant replacement --
+a[]c
+a[]c
+-- non-constant haystack, needle and replacement --
+a[]c
+a[]c
+-- FixedString haystack (a constant FixedString is not accepted by the function) --
+a[]c
+a[]c
+-- forced through the re2 path --
+a[]c
+a[]c
+a[]c
+a[]c
+a[]c
+a[]c
+a[]c
+a[]c
+-- forced through the JIT path, which compiles after one use --
+a[]c
+a[]c
+a[]c
+a[]c
+a[]c
+a[]c
+a[]c
+a[]c
+-- and the same for replaceRegexpOne on both paths --
+a[]cb
+a[]cb
+a[]cb
+a[]cb
+a[]cb
+a[]cb
+a[]cb
+a[]cb

--- a/tests/queries/0_stateless/04670_replace_regexp_unmatched_capture_group.sql
+++ b/tests/queries/0_stateless/04670_replace_regexp_unmatched_capture_group.sql
@@ -1,0 +1,70 @@
+-- A capture group that does not participate in the match is returned by re2 as an empty piece
+-- with a null `data()`. Substituting it reached `memcpy(dst, nullptr, 0)` in `ReplaceRegexpImpl`,
+-- which UBSan reports as "null pointer passed as argument 2, which is declared to never be null"
+-- (memcpy's pointers are `nonnull` even for a zero length). The JIT path already guarded this;
+-- the re2 path did not. The results below are unchanged by the fix - only the UB is gone.
+
+SELECT '-- an optional group that never participates --';
+SELECT replaceRegexpAll('abc', '(x)?b', '[\\1]');
+SELECT replaceRegexpOne('abc', '(x)?b', '[\\1]');
+
+SELECT '-- the group is in the branch of an alternation that was not taken --';
+SELECT replaceRegexpAll('aaa', '(a)|(z)', '<\\1\\2>');
+SELECT replaceRegexpOne('aaa', '(a)|(z)', '<\\1\\2>');
+
+SELECT '-- the replacement is nothing but the unmatched group --';
+SELECT replaceRegexpAll('abc', '(x)?b', '\\1');
+SELECT replaceRegexpAll('abc', 'b', '');
+
+SELECT '-- the same unmatched group substituted several times --';
+SELECT replaceRegexpAll('abc', '(x)?b', '\\1\\1\\1');
+
+SELECT '-- matched and unmatched groups mixed, with literals in between --';
+SELECT replaceRegexpAll('abc', '(a)(x)?(b)', '[\\1|\\2|\\3]');
+
+SELECT '-- the whole match next to an unmatched group --';
+SELECT replaceRegexpAll('abc', '(x)?b', '<\\0|\\1>');
+
+SELECT '-- five groups, none of which participate (the pattern from 04650) --';
+SELECT replaceRegexpAll('123', '[0-9]((a|b)(c|d)|(e|f)(g|h))?', '[\\1\\2\\3\\4\\5]');
+
+SELECT '-- nested optional groups --';
+SELECT replaceRegexpAll('xy', '((p)(q))?x', '[\\1|\\2|\\3]');
+
+SELECT '-- an empty haystack, and an empty match at the end of the string --';
+SELECT replaceRegexpAll('', '(x)?', '[\\1]');
+SELECT replaceRegexpAll('ab', '(x)?$', '[\\1]');
+SELECT replaceRegexpAll('ab', '(x)?', '[\\1]');
+
+SELECT '-- a trailing group that matches only sometimes, over several rows --';
+SELECT replaceRegexpAll(s, '(a)(b)?', '[\\1|\\2]')
+FROM (SELECT arrayJoin(['a', 'ab', 'aab', 'ba', '']) AS s);
+
+SELECT '-- non-constant haystack (the vector path) --';
+SELECT replaceRegexpAll(materialize('abc'), '(x)?b', '[\\1]') FROM numbers(2);
+
+SELECT '-- non-constant needle --';
+SELECT replaceRegexpAll(materialize('abc'), materialize('(x)?b'), '[\\1]') FROM numbers(2);
+
+SELECT '-- non-constant replacement --';
+SELECT replaceRegexpAll(materialize('abc'), '(x)?b', materialize('[\\1]')) FROM numbers(2);
+
+SELECT '-- non-constant haystack, needle and replacement --';
+SELECT replaceRegexpAll(materialize('abc'), materialize('(x)?b'), materialize('[\\1]')) FROM numbers(2);
+
+SELECT '-- FixedString haystack (a constant FixedString is not accepted by the function) --';
+SELECT replaceRegexpAll(materialize(toFixedString('abc', 3)), '(x)?b', '[\\1]') FROM numbers(2);
+
+SELECT '-- forced through the re2 path --';
+SELECT replaceRegexpAll(materialize('abc'), '(x)?b', '[\\1]')
+FROM numbers(8) SETTINGS compile_regular_expressions = 0;
+
+SELECT '-- forced through the JIT path, which compiles after one use --';
+SELECT replaceRegexpAll(materialize('abc'), '(x)?b', '[\\1]')
+FROM numbers(8) SETTINGS compile_regular_expressions = 1, min_count_to_compile_regular_expression = 1;
+
+SELECT '-- and the same for replaceRegexpOne on both paths --';
+SELECT replaceRegexpOne(materialize('abcb'), '(x)?b', '[\\1]')
+FROM numbers(4) SETTINGS compile_regular_expressions = 0;
+SELECT replaceRegexpOne(materialize('abcb'), '(x)?b', '[\\1]')
+FROM numbers(4) SETTINGS compile_regular_expressions = 1, min_count_to_compile_regular_expression = 1;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Do not memcpy from a null pointer for a non-participating capture group

re2 returns an empty piece with a null `data()` for a capture group that did
not participate in the match. Substituting it called `memcpy(dst, nullptr, 0)`,
which is undefined behaviour because `memcpy`'s pointers are declared `nonnull`
even for a zero length, and UBSan reports it. The JIT substitution path in the
same file already guards this; the re2 path now does too.

Fixes CI failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=4c8a7fd995e084bcaea0da4a2c21282f550a4261&name_0=MasterCI&name_1=Stress%20test%20%28arm_asan_ubsan%2C%20s3%29