### PR TITLE
BuzzHouse: do not enable the thread-group fault injections

### DIFF
--- a/src/Client/BuzzHouse/Generator/FuzzConfig.cpp
+++ b/src/Client/BuzzHouse/Generator/FuzzConfig.cpp
@@ -942,13 +942,19 @@ void FuzzConfig::loadServerConfigurations()
     /// terminate_with_exception, terminate_with_std_exception - Terminates the server
     /// tcp_handler_fail_connection_setup - Fails every new TCP connection setup, so once enabled the fuzzer can neither
     ///     reconnect nor disable it again over its TCP connection (it would deadlock; the test controls it over HTTP)
+    /// attach_to_group_failure, thread_group_switcher_post_attach_failure - Break the "a query thread has a thread
+    ///     group" invariant on whatever thread happens to hit them next. `ThreadGroupSwitcher` is `noexcept` and only
+    ///     logs the injected failure, so the thread continues with no group and the next `executeQuery` on it fails
+    ///     with the `No thread group attached to the thread` logical error. They are meant for the in-process unit
+    ///     test `gtest_thread_group_switcher`, which enables them around a single controlled switch.
     loadServerSettings<String>(
         this->failpoints,
         "failpoints",
         "SELECT \"name\" FROM \"system\".\"fail_points\""
         " WHERE \"name\" NOT IN ('keeper_leader_sets_invalid_digest', 'terminate_with_exception', "
         "'terminate_with_std_exception', 'libcxx_hardening_out_of_bounds_assertion', "
-        "'trigger_sanitizer_error', 'tcp_handler_fail_connection_setup')");
+        "'trigger_sanitizer_error', 'tcp_handler_fail_connection_setup', 'attach_to_group_failure', "
+        "'thread_group_switcher_post_attach_failure')");
     loadServerSettings<String>(this->tokenizers, "tokenizers", R"(SELECT "name" FROM "system"."tokenizers")");
     /// Probe which function_implementation values the server supports. They depend on how the binary
     /// was compiled and on the host CPU (e.g. no x86-64 tag is available on aarch64 builds), and an


### PR DESCRIPTION
BuzzHouse enables a random failpoint from `system.fail_points`. Two of them — `attach_to_group_failure` and `thread_group_switcher_post_attach_failure` — deliberately break the invariant that a query thread is attached to a thread group. `ThreadGroupSwitcher` is `noexcept` and only logs the injected failure, so the thread carries on with no group and the next `executeQuery` that runs on it fails with the `No thread group attached to the thread` logical error:

```
2026.08.01 16:02:41 [ 138 ] executeQuery: SYSTEM ENABLE FAILPOINT attach_to_group_failure
2026.08.01 16:02:42 [ 138 ] DB::ThreadGroupSwitcher::ThreadGroupSwitcher(...): Code: 710. DB::Exception: Injected failure in attachToGroupImpl. (FAULT_INJECTED)
2026.08.01 16:02:42 [ 138 ] <Fatal> : Logical error: 'No thread group attached to the thread 138'.
```

Seen in https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112766&sha=25a457c530e81c122d764503aa913d2d04eedbb1&name_0=PR&name_1=BuzzHouse%20%28amd_msan%29 and, on the same day, in `BuzzHouse (amd_debug)` on an unrelated pull request.

Both failpoints exist for the in-process unit test `gtest_thread_group_switcher`, which enables them around a single controlled switch; they are not meaningful to inject from SQL. Exclude them from the list the fuzzer picks from, like the other failpoints that legitimately take the server down.

Related: https://github.com/ClickHouse/ClickHouse/pull/112766
Related: https://github.com/ClickHouse/ClickHouse/pull/110514

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.651` (included in `26.8` and later)
<!-- ch-version-info:end -->