### PR TITLE
Fix flaky 03568_udf_memory_tracking: raise the UDF pipe read timeout

### DIFF
--- a/tests/config/test_function.xml
+++ b/tests/config/test_function.xml
@@ -11,6 +11,7 @@
         </argument>
         <format>TabSeparated</format>
         <command>awk -F'\t' '{print $1 + $2}'</command>
+        <command_read_timeout>60000</command_read_timeout>
         <execute_direct>0</execute_direct>
     </function>
     <function>


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/112994
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/112994

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`03568_udf_memory_tracking` fails sporadically on `Stateless tests (amd_msan, WasmEdge, parallel, 2/2)`:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110615&sha=f9e1693ebf232cbb3042616f6917a4d4e2b3e5f6&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F2%29

**It is not a test timeout:** the failing runs die in 13.7 s / 16.3 s / 27.3 s against the 600 s limit. The error is exit code 242 (`UDF_EXECUTION_FAILED`) wrapping `Code: 159 Pipe read timeout exceeded 10000 milliseconds` at `ShellCommandSource.cpp:174`.

Root cause: `test_function` has `execute_direct=0` and no `command_read_timeout`, so it gets the 10000 ms default, and each call `vfork`+`exec`s `/bin/sh -c "awk ..."` on a fresh pipe (it is not an `executable_pool`). `max_block_size = 1` over `numbers(40)` and `numbers(60)` makes 100 such round-trips, which is the per-block coverage the test exists for. The read clock is armed independently of the writer's progress: each `SendDataTask` runs on a separate thread while the input format is built over the pipe immediately, so the 10 s budget also covers `vfork`, `exec`, `sh` and `awk` startup plus the writer thread's scheduling delay. Under MSan in a loaded parallel bucket one round-trip can exceed that, and one slow read fails the query.

#107699 cut the round-trips 300 -> 100, reducing the attempts but leaving the per-attempt ceiling untouched -- hence the move from TSan to MSan. So I raise the bound rather than trim again.

Every assertion is unchanged: both memory checks, `count() = 2`, the 100-block workload and the `.reference`. Nothing is masked either: all 100 round-trips take 0.43 s locally, and 60 s is finite so a real hang still fails. The same knob at the same value fixed this signature for executable dictionaries in #108933.

Validation: at `command_read_timeout=1` the exact CI error reproduces on demand, at `60000` it passes, and reverting to `1` brings it back. A green 50-run is not evidence here, since the unpatched control is also 50/50 green locally; the acceptance criterion is CIDB silence.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.654` (included in `26.8` and later)
<!-- ch-version-info:end -->