### PR TITLE
Fix signed integer overflow in refreshable materialized view retry backoff

### DIFF
--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <limits>
 #include <thread>
 #include <Storages/MaterializedView/RefreshTask.h>
 

--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -22,6 +22,7 @@
 #include <QueryPipeline/ReadProgressCallback.h>
 #include <Storages/StorageMaterializedView.h>
 #include <base/EnumReflection.h>
+#include <base/arithmeticOverflow.h>
 #include <base/scope_guard.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/QueryScope.h>
@@ -1532,6 +1533,19 @@ void RefreshTask::syncDependenciesForRefresh(const std::vector<StorageID> & deps
     }
 }
 
+/// Bounds for the retry arithmetic below, named in their own units: the retry instant is widened by
+/// x1000 three times over (seconds -> milliseconds -> microseconds -> nanoseconds), so a value has
+/// to be bounded in each unit before the conversion that widens it.
+static constexpr std::chrono::seconds::rep max_last_attempt_seconds = 900'000'000'000;
+static constexpr std::chrono::milliseconds::rep max_delay_ms = 3'000'000'000'000;
+static constexpr std::chrono::milliseconds::rep max_when_ms = max_last_attempt_seconds * 1000 + max_delay_ms;
+static_assert(max_when_ms <= std::numeric_limits<std::chrono::milliseconds::rep>::max() / 1000);
+static_assert(max_when_ms * 1000 <= std::numeric_limits<std::chrono::system_clock::rep>::max());
+static_assert(max_delay_ms * 1'000'000 <= std::numeric_limits<std::chrono::nanoseconds::rep>::max());
+/// max_last_attempt_seconds must also be calendar-valid: CalendarTimeInterval::floor builds a
+/// std::chrono::year_month_day from it, and std::chrono::year holds a short, so a year outside
+/// [year::min(), year::max()] wraps silently with ok() still true. 9e11 s is year ~30489.
+
 static std::chrono::milliseconds backoff(Int64 retry_idx, const RefreshSettings & refresh_settings)
 {
     UInt64 delay_ms = 0;
@@ -1541,7 +1555,9 @@ static std::chrono::milliseconds backoff(Int64 retry_idx, const RefreshSettings 
         delay_ms = refresh_settings[RefreshSetting::refresh_retry_initial_backoff_ms] * multiplier;
     else
         delay_ms = refresh_settings[RefreshSetting::refresh_retry_max_backoff_ms];
-    return std::chrono::milliseconds(delay_ms);
+    /// The check above bounds only the product, so both branches can still yield an arbitrary
+    /// setting value. Clamp while unsigned: milliseconds(UInt64 above INT64_MAX) is negative.
+    return std::chrono::milliseconds(std::min(delay_ms, UInt64(max_delay_ms)));
 }
 
 std::tuple<std::chrono::system_clock::time_point, bool /*waiting_for_dependencies*/, RefreshTask::CoordinationZnode>
@@ -1549,6 +1565,11 @@ RefreshTask::determineNextRefreshTime(std::chrono::system_clock::time_point now,
 {
     chassert(lock.owns_lock());
     auto znode = coordination.root_znode;
+    /// last_attempt_time comes from Keeper unvalidated. Clamp it here, where it enters the
+    /// function, so every consumer below is covered: the retry addition promotes seconds to
+    /// milliseconds, and CalendarTimeInterval::floor adds an epoch offset to it.
+    znode.last_attempt_time = std::chrono::sys_seconds(std::chrono::seconds(std::clamp(
+        znode.last_attempt_time.time_since_epoch().count(), -max_last_attempt_seconds, max_last_attempt_seconds)));
     if (refresh_settings[RefreshSetting::refresh_retries] >= 0 && znode.attempt_number > refresh_settings[RefreshSetting::refresh_retries])
     {
         /// Skip to the next scheduled refresh, as if a refresh succeeded.
@@ -1561,7 +1582,17 @@ RefreshTask::determineNextRefreshTime(std::chrono::system_clock::time_point now,
     if (znode.attempt_number != 0)
     {
         /// Retrying refresh. Ignore schedule and dependencies.
-        when = znode.last_attempt_time + backoff(znode.attempt_number - 1, refresh_settings);
+        /// sys_seconds + milliseconds is evaluated in milliseconds, so do that addition explicitly
+        /// with overflow detection. Both operands are bounded above, so this cannot trip, but the
+        /// check keeps the property local instead of resting on the bounds alone.
+        const std::chrono::milliseconds::rep last_attempt_ms
+            = std::chrono::milliseconds(znode.last_attempt_time.time_since_epoch()).count();
+        const std::chrono::milliseconds::rep delay_ms = backoff(znode.attempt_number - 1, refresh_settings).count();
+        std::chrono::milliseconds::rep when_ms = 0;
+        if (common::addOverflow(last_attempt_ms, delay_ms, when_ms))
+            when_ms = max_when_ms;
+        when = std::chrono::system_clock::time_point(
+            std::chrono::milliseconds(std::clamp(when_ms, -max_when_ms, max_when_ms)));
     }
     else if (dependencies.tables.empty())
     {

--- a/tests/queries/0_stateless/04707_refreshable_mv_backoff_int64_max.reference
+++ b/tests/queries/0_stateless/04707_refreshable_mv_backoff_int64_max.reference
@@ -1,9 +1,6 @@
 refresh_failed 1
 retry_within_budget 1
 retry_state	Scheduled	1
-clamped_failed 1
-clamped_retried 1
-clamped_state	Scheduled	1
 sched_state	Scheduled	1
 longsched_state	Scheduled	1
 spread_alive	1

--- a/tests/queries/0_stateless/04707_refreshable_mv_backoff_int64_max.reference
+++ b/tests/queries/0_stateless/04707_refreshable_mv_backoff_int64_max.reference
@@ -1,6 +1,9 @@
 refresh_failed 1
 retry_within_budget 1
 retry_state	Scheduled	1
+clamped_failed 1
+clamped_retried 1
+clamped_state	Scheduled	1
 sched_state	Scheduled	1
 longsched_state	Scheduled	1
 spread_alive	1

--- a/tests/queries/0_stateless/04707_refreshable_mv_backoff_int64_max.reference
+++ b/tests/queries/0_stateless/04707_refreshable_mv_backoff_int64_max.reference
@@ -1,0 +1,6 @@
+refresh_failed 1
+retry_within_budget 1
+retry_state	Scheduled	1
+sched_state	Scheduled	1
+longsched_state	Scheduled	1
+spread_alive	1

--- a/tests/queries/0_stateless/04707_refreshable_mv_backoff_int64_max.sh
+++ b/tests/queries/0_stateless/04707_refreshable_mv_backoff_int64_max.sh
@@ -5,10 +5,6 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-# SET FAKE TIME parses its literal in the session timezone; refresh scheduling is UTC.
-CLICKHOUSE_CLIENT="$(echo "$CLICKHOUSE_CLIENT" | sed 's/--session_timezone[= ][^ ]*//g')"
-CLICKHOUSE_CLIENT="$CLICKHOUSE_CLIENT --session_timezone Etc/UTC"
-
 # system.view_refreshes briefly reports the transient internal state 'Scheduling' between state
 # transitions of the refresh task, so a status read taken right after a DDL can catch it. Same
 # helper as 02932_refreshable_materialized_views_1.sh, bounded so a hang is not reported as a pass.
@@ -45,10 +41,13 @@ wait_first_refresh() {
 # backoff() returns a delay that used to overflow the retry instant.
 # Pinning refresh_retry_initial_backoff_ms too is required: with the default 100
 # and refresh_retries = 10 the multiplier stays under 512 and nothing overflows.
-# Only backoff()'s IF branch is exercised (retry_idx = 0, initial * 1): the 95-year clamped delay
+# Only backoff()'s IF branch is exercised (retry_idx = 0, initial * 1): the 95-year bounded delay
 # stops a second retry from happening, so the ELSE branch that returns refresh_retry_max_backoff_ms
-# verbatim is unreachable here. That is why the clamp sits after the if/else rather than in a branch.
+# verbatim is unreachable here. That is why the bound sits after the if/else rather than in a branch.
 # all_replicas = 1 keeps the refresh uncoordinated so this client's replica runs it.
+# Coverage boundary: this arm constrains backoff()'s bound and the checked addition jointly. The
+# bound on last_attempt_time has no oracle here, since its consumer fails as a silent calendar wrap
+# rather than an observable value; static_assert and the corner sweep cover it instead.
 $CLICKHOUSE_CLIENT -q "
     create materialized view rmv refresh after 1 year
         settings refresh_retries = 10,
@@ -84,34 +83,6 @@ after=$(retry_of rmv)
 query_no_scheduling "
     select 'retry_state', status, $before = $after
     from system.view_refreshes where view = 'rmv' and database = currentDatabase()"
-
-# Liveness under a far-future clock, which no real clock reaches: 2e12 seconds is year ~65340, past
-# both the bound on last_attempt_time and what std::chrono::year's short can hold. The server must
-# stay up and keep reporting a non-sentinel instant. This arm does not distinguish a clamped
-# last_attempt_time from an unclamped one - that difference is a silent calendar wrap, and asserting
-# it would mean hard-coding a truncated UInt32 DateTime. Unset the clock to stop the retries.
-$CLICKHOUSE_CLIENT -q "
-    create materialized view clamped refresh after 1 hour
-        settings refresh_retries = 1000000,
-                 refresh_retry_initial_backoff_ms = 9223372036854775807,
-                 refresh_retry_max_backoff_ms = 9223372036854775807,
-                 all_replicas = 1
-        append (x Int64) engine Memory as select throwIf(number = 0) as x from numbers(1);"
-$CLICKHOUSE_CLIENT -q "system wait view clamped" 2>&1 | grep -qF REFRESH_FAILED && echo "clamped_failed 1"
-$CLICKHOUSE_CLIENT -q "system test view clamped set fake time '2000000000000'"
-retried=0
-for _ in {1..100}; do
-    if [ "$(retry_of clamped)" -ge 3 ] 2>/dev/null; then
-        retried=1
-        break
-    fi
-    sleep 0.2
-done
-$CLICKHOUSE_CLIENT -q "system test view clamped unset fake time"
-echo "clamped_retried $retried"
-query_no_scheduling "
-    select 'clamped_state', status, next_refresh_time is not null
-    from system.view_refreshes where view = 'clamped' and database = currentDatabase()"
 
 # Non-regression: a plain near-future schedule still gets an exact, readable
 # instant. 04707 does not bound any schedule period.
@@ -154,5 +125,4 @@ $CLICKHOUSE_CLIENT -q "
 $CLICKHOUSE_CLIENT -q "drop table spread"
 $CLICKHOUSE_CLIENT -q "drop table longsched"
 $CLICKHOUSE_CLIENT -q "drop table sched"
-$CLICKHOUSE_CLIENT -q "drop table clamped"
 $CLICKHOUSE_CLIENT -q "drop table rmv"

--- a/tests/queries/0_stateless/04707_refreshable_mv_backoff_int64_max.sh
+++ b/tests/queries/0_stateless/04707_refreshable_mv_backoff_int64_max.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Tags: memory-engine
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# A refresh that always fails, with both retry-backoff settings at INT64_MAX, so
+# backoff() returns a delay that used to overflow the retry instant.
+# Pinning refresh_retry_initial_backoff_ms too is required: with the default 100
+# and refresh_retries = 10 the multiplier stays under 512 and nothing overflows.
+# all_replicas = 1 keeps the refresh uncoordinated so this client's replica runs it.
+$CLICKHOUSE_CLIENT -q "
+    create materialized view rmv refresh after 1 year
+        settings refresh_retries = 10,
+                 refresh_retry_initial_backoff_ms = 9223372036854775807,
+                 refresh_retry_max_backoff_ms = 9223372036854775807,
+                 all_replicas = 1
+        append (x Int64) engine Memory as select throwIf(number = 0) as x from numbers(1);"
+
+$CLICKHOUSE_CLIENT -q "system wait view rmv" 2>&1 | grep -qF REFRESH_FAILED && echo "refresh_failed 1"
+
+# The retry instant must stay far in the future, so the view sits on attempt 1
+# instead of racing through the whole retry budget. With the overflow the wrapped
+# instant landed in the past, so all 11 attempts burned within ~0.1s.
+progressed=0
+for _ in {1..40}; do
+    retry=$($CLICKHOUSE_CLIENT -q "select retry from system.view_refreshes where view = 'rmv' and database = currentDatabase()" | xargs)
+    if ! [ "$retry" -ge 1 ] 2>/dev/null || [ "$retry" -ge 10 ]; then
+        progressed=1
+        break
+    fi
+    sleep 0.2
+done
+echo "retry_within_budget $((1 - progressed))"
+
+# Scheduled (not WaitingForDependencies) proves the saturated instant stayed
+# strictly below time_point::max(), which is the "no refresh scheduled" sentinel.
+$CLICKHOUSE_CLIENT -q "
+    select 'retry_state', status, next_refresh_time is not null
+    from system.view_refreshes where view = 'rmv' and database = currentDatabase()"
+
+# Non-regression: a plain near-future schedule still gets an exact, readable
+# instant. 04707 does not bound any schedule period.
+$CLICKHOUSE_CLIENT -q "
+    create materialized view sched refresh every 1 year
+        settings all_replicas = 1
+        append (x Int64) engine Memory as select 1 as x;"
+$CLICKHOUSE_CLIENT -q "
+    select 'sched_state', status, next_refresh_time > now()
+    from system.view_refreshes where view = 'sched' and database = currentDatabase()"
+
+# Non-regression: a long-but-representable schedule period is not truncated.
+# 1e9 seconds is 31.7 years, which keeps the resulting delay nanosecond-safe with
+# a 9x margin and stays inside the UInt32 range next_refresh_time is read through.
+$CLICKHOUSE_CLIENT -q "
+    create materialized view longsched refresh after 1000000000 second
+        settings all_replicas = 1
+        append (x Int64) engine Memory as select 1 as x;"
+$CLICKHOUSE_CLIENT -q "
+    select 'longsched_state', status, next_refresh_time > now()
+    from system.view_refreshes where view = 'longsched' and database = currentDatabase()"
+
+# Non-regression smoke for the random-spread path, which this fix does not touch.
+# The oracle is deliberately sign-independent: randomness is drawn uniformly from
+# both signs, so a negative draw legitimately yields a past-due instant and any
+# status assertion here would be a coin flip on master already.
+$CLICKHOUSE_CLIENT -q "
+    create materialized view spread refresh after 1 hour randomize for 1 hour
+        settings refresh_retries = 10,
+                 refresh_retry_initial_backoff_ms = 9223372036854775807,
+                 refresh_retry_max_backoff_ms = 9223372036854775807,
+                 all_replicas = 1
+        append (x Int64) engine Memory as select throwIf(number = 0) as x from numbers(1);"
+$CLICKHOUSE_CLIENT -q "
+    select 'spread_alive', count() from system.view_refreshes
+    where view = 'spread' and database = currentDatabase()"
+
+$CLICKHOUSE_CLIENT -q "drop table spread"
+$CLICKHOUSE_CLIENT -q "drop table longsched"
+$CLICKHOUSE_CLIENT -q "drop table sched"
+$CLICKHOUSE_CLIENT -q "drop table rmv"

--- a/tests/queries/0_stateless/04707_refreshable_mv_backoff_int64_max.sh
+++ b/tests/queries/0_stateless/04707_refreshable_mv_backoff_int64_max.sh
@@ -5,10 +5,49 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+# SET FAKE TIME parses its literal in the session timezone; refresh scheduling is UTC.
+CLICKHOUSE_CLIENT="$(echo "$CLICKHOUSE_CLIENT" | sed 's/--session_timezone[= ][^ ]*//g')"
+CLICKHOUSE_CLIENT="$CLICKHOUSE_CLIENT --session_timezone Etc/UTC"
+
+# system.view_refreshes briefly reports the transient internal state 'Scheduling' between state
+# transitions of the refresh task, so a status read taken right after a DDL can catch it. Same
+# helper as 02932_refreshable_materialized_views_1.sh, bounded so a hang is not reported as a pass.
+query_no_scheduling() {
+    for _ in {1..100}; do
+        out=$($CLICKHOUSE_CLIENT -q "$1")
+        if ! grep -qE $'(^|\t)Scheduling(\t|$)' <<< "$out"; then
+            echo "$out"
+            return
+        fi
+        sleep 0.2
+    done
+    echo "still_scheduling"
+}
+
+retry_of() {
+    $CLICKHOUSE_CLIENT -q "select retry from system.view_refreshes
+        where view = '$1' and database = currentDatabase()" | xargs
+}
+
+# Wait for the view's first refresh to finish. Views without EMPTY start at last_completed_timeslot
+# = epoch, so their first refresh is already overdue at CREATE and runs immediately instead of being
+# scheduled; until it lands, status is Scheduling/Running and next_refresh_time is the epoch.
+wait_first_refresh() {
+    for _ in {1..100}; do
+        [ "$($CLICKHOUSE_CLIENT -q "select last_success_time is not null from system.view_refreshes
+              where view = '$1' and database = currentDatabase()" | xargs)" = "1" ] && return
+        sleep 0.2
+    done
+    echo "no_first_refresh_$1"
+}
+
 # A refresh that always fails, with both retry-backoff settings at INT64_MAX, so
 # backoff() returns a delay that used to overflow the retry instant.
 # Pinning refresh_retry_initial_backoff_ms too is required: with the default 100
 # and refresh_retries = 10 the multiplier stays under 512 and nothing overflows.
+# Only backoff()'s IF branch is exercised (retry_idx = 0, initial * 1): the 95-year clamped delay
+# stops a second retry from happening, so the ELSE branch that returns refresh_retry_max_backoff_ms
+# verbatim is unreachable here. That is why the clamp sits after the if/else rather than in a branch.
 # all_replicas = 1 keeps the refresh uncoordinated so this client's replica runs it.
 $CLICKHOUSE_CLIENT -q "
     create materialized view rmv refresh after 1 year
@@ -25,7 +64,7 @@ $CLICKHOUSE_CLIENT -q "system wait view rmv" 2>&1 | grep -qF REFRESH_FAILED && e
 # instant landed in the past, so all 11 attempts burned within ~0.1s.
 progressed=0
 for _ in {1..40}; do
-    retry=$($CLICKHOUSE_CLIENT -q "select retry from system.view_refreshes where view = 'rmv' and database = currentDatabase()" | xargs)
+    retry=$(retry_of rmv)
     if ! [ "$retry" -ge 1 ] 2>/dev/null || [ "$retry" -ge 10 ]; then
         progressed=1
         break
@@ -34,11 +73,45 @@ for _ in {1..40}; do
 done
 echo "retry_within_budget $((1 - progressed))"
 
-# Scheduled (not WaitingForDependencies) proves the saturated instant stayed
-# strictly below time_point::max(), which is the "no refresh scheduled" sentinel.
-$CLICKHOUSE_CLIENT -q "
-    select 'retry_state', status, next_refresh_time is not null
+# Scheduled (not WaitingForDependencies) proves the saturated instant stayed strictly below
+# time_point::max(), which is the "no refresh scheduled" sentinel. The attempt counter must also
+# hold still: a wrapped or past-due instant makes doScheduling start a refresh on every pass.
+# next_refresh_time cannot be read by value here - the instant is year 2121, and the column is a
+# UInt32 DateTime.
+before=$(retry_of rmv)
+sleep 2
+after=$(retry_of rmv)
+query_no_scheduling "
+    select 'retry_state', status, $before = $after
     from system.view_refreshes where view = 'rmv' and database = currentDatabase()"
+
+# Liveness under a far-future clock, which no real clock reaches: 2e12 seconds is year ~65340, past
+# both the bound on last_attempt_time and what std::chrono::year's short can hold. The server must
+# stay up and keep reporting a non-sentinel instant. This arm does not distinguish a clamped
+# last_attempt_time from an unclamped one - that difference is a silent calendar wrap, and asserting
+# it would mean hard-coding a truncated UInt32 DateTime. Unset the clock to stop the retries.
+$CLICKHOUSE_CLIENT -q "
+    create materialized view clamped refresh after 1 hour
+        settings refresh_retries = 1000000,
+                 refresh_retry_initial_backoff_ms = 9223372036854775807,
+                 refresh_retry_max_backoff_ms = 9223372036854775807,
+                 all_replicas = 1
+        append (x Int64) engine Memory as select throwIf(number = 0) as x from numbers(1);"
+$CLICKHOUSE_CLIENT -q "system wait view clamped" 2>&1 | grep -qF REFRESH_FAILED && echo "clamped_failed 1"
+$CLICKHOUSE_CLIENT -q "system test view clamped set fake time '2000000000000'"
+retried=0
+for _ in {1..100}; do
+    if [ "$(retry_of clamped)" -ge 3 ] 2>/dev/null; then
+        retried=1
+        break
+    fi
+    sleep 0.2
+done
+$CLICKHOUSE_CLIENT -q "system test view clamped unset fake time"
+echo "clamped_retried $retried"
+query_no_scheduling "
+    select 'clamped_state', status, next_refresh_time is not null
+    from system.view_refreshes where view = 'clamped' and database = currentDatabase()"
 
 # Non-regression: a plain near-future schedule still gets an exact, readable
 # instant. 04707 does not bound any schedule period.
@@ -46,7 +119,8 @@ $CLICKHOUSE_CLIENT -q "
     create materialized view sched refresh every 1 year
         settings all_replicas = 1
         append (x Int64) engine Memory as select 1 as x;"
-$CLICKHOUSE_CLIENT -q "
+wait_first_refresh sched
+query_no_scheduling "
     select 'sched_state', status, next_refresh_time > now()
     from system.view_refreshes where view = 'sched' and database = currentDatabase()"
 
@@ -57,7 +131,8 @@ $CLICKHOUSE_CLIENT -q "
     create materialized view longsched refresh after 1000000000 second
         settings all_replicas = 1
         append (x Int64) engine Memory as select 1 as x;"
-$CLICKHOUSE_CLIENT -q "
+wait_first_refresh longsched
+query_no_scheduling "
     select 'longsched_state', status, next_refresh_time > now()
     from system.view_refreshes where view = 'longsched' and database = currentDatabase()"
 
@@ -79,4 +154,5 @@ $CLICKHOUSE_CLIENT -q "
 $CLICKHOUSE_CLIENT -q "drop table spread"
 $CLICKHOUSE_CLIENT -q "drop table longsched"
 $CLICKHOUSE_CLIENT -q "drop table sched"
+$CLICKHOUSE_CLIENT -q "drop table clamped"
 $CLICKHOUSE_CLIENT -q "drop table rmv"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108005
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a signed integer overflow when computing the next retry time of a refreshable materialized view with a very large `refresh_retry_max_backoff_ms` or `refresh_retry_initial_backoff_ms`. The overflowed instant landed in the past, so the view refreshed on every pass rather than waiting.

### Description

Found by `BuzzHouse (arm_asan_ubsan)`, STID 3978-3a6d ([CI](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110493&sha=2c074ea29f3150a13a9ff1bf954538f73332ba5a&name_0=PR&name_1=BuzzHouse%20%28arm_asan_ubsan%29)). Trunk bug, not PR-caused.

```
duration.h:403: signed integer overflow: 1785593651000 + 9223372036854775807
  #2 DB::RefreshTask::determineNextRefreshTime(...)
```

**Root cause.** `backoff` bounds only the product `refresh_retry_initial_backoff_ms * multiplier`,
never the value it returns, so both branches can return an arbitrary setting value. The retry site
then does `znode.last_attempt_time + backoff(...)`, whose common type is milliseconds, so the seconds
operand is multiplied by 1000 and the addition overflows. `last_attempt_time` is itself read from
Keeper unvalidated. In a release build the wrapped instant lands just before `start_time`, so the
"not arrived yet" branch is skipped and the view refreshes every pass.

**The change.** One file. `backoff`'s result and the untrusted `last_attempt_time` are bounded in
their own units before the conversions that widen them, and the retry addition uses
`common::addOverflow`. Three `static_assert`s pin the units the instant and the delay must survive,
down to the nanoseconds `condition_variable::wait_for` widens to. The seconds bound must also be
calendar-valid: `CalendarTimeInterval::floor` builds a `year_month_day` and `std::chrono::year` holds
a `short` that wraps silently with `ok()` true; that one is a comment.

Neither bound is clock-reachable (year ~30489, and a 95-year retry delay), so no legitimate schedule
or retry changes and no setting period is bounded. No perf impact. Verified both directions
under ASAN+UBSAN with a deterministic reproducer, plus the refreshable MV suite (incl. `02932`,
which drives the fake clock to 2070).

**Limitation:** a *corrupt* `last_attempt_time` at its bound can still overflow inside
`src/Core/BackgroundSchedulePool.cpp`, a pre-existing bug reachable from a plain
`REFRESH AFTER 20000000000 SECOND` and shared with ~100 other `scheduleAfter` callers, tracked
separately.

Related: #108005 (sibling overflow in this file; its closing note asked for this sweep)