### PR TITLE
Restore `unicode_word` tokenizer alias

### DIFF
--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -1957,7 +1957,7 @@ void StatementGenerator::addTableIndex(RandomGenerator & rg, SQLTable & t, const
             String buf;
             bool has_paren = rg.nextSmallNumber() < 8;
             static const DB::Strings tokenizerVals
-                = {"splitByNonAlpha", "splitByString", "ngrams", "array", "sparseGrams", "asciiCJK", "unicodeWord"};
+                = {"splitByNonAlpha", "splitByString", "ngrams", "array", "sparseGrams", "asciiCJK", "unicodeWord", "unicode_word"};
             const auto & nt = rg.pickRandomly(fc.tokenizers.empty() ? tokenizerVals : fc.tokenizers);
 
             buf += fmt::format("tokenizer = {}", nt);

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -2205,7 +2205,7 @@ void QueryFuzzer::fuzzIndexDeclaration(ASTIndexDeclaration & index)
     /// BF index types: require positional arguments — swap name only, keep args.
     static const std::unordered_set<String> bf_index_types = {"ngrambf_v1", "tokenbf_v1", "sparse_grams"};
     /// Simple no-arg tokenizers valid as text index tokenizer values.
-    static const Strings simple_tokenizers = {"splitByNonAlpha", "splitByString", "array", "asciiCJK", "unicodeWord"};
+    static const Strings simple_tokenizers = {"splitByNonAlpha", "splitByString", "array", "asciiCJK", "unicodeWord", "unicode_word"};
     /// Non-empty separators for the splitByString tokenizer (empty ones are rejected).
     static const Strings tokenizer_separators = {" ", ",", ";", ".", "\t", "\n", "ab", "叫", "😉"};
     static const Strings posting_list_codecs = {"none", "bitpacking"};

--- a/src/Interpreters/TokenizerFactory.cpp
+++ b/src/Interpreters/TokenizerFactory.cpp
@@ -283,7 +283,9 @@ static void registerTokenizers(TokenizerFactory & factory)
     };
 
     factory.registerTokenizer(AsciiCJKTokenizer::getName(), ITokenizer::Type::AsciiCJK, ascii_cjk_creator);
+    /// Backward-compatible aliases for names used before this tokenizer was renamed to `asciiCJK`.
     factory.registerTokenizer("unicodeWord", ITokenizer::Type::AsciiCJK, ascii_cjk_creator);
+    factory.registerTokenizer("unicode_word", ITokenizer::Type::AsciiCJK, ascii_cjk_creator);
 
 #if USE_MECAB
     auto japanese_creator = [](const FieldVector & args) -> std::unique_ptr<ITokenizer>

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -360,9 +360,6 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       `MergeTreeBackgroundExecutor` line of the replicated case in a single entry.
 # `NO_SUCH_INTERSERVER_IO_ENDPOINT` is expected during upgrades because replicated tables try to fetch parts
 # from replicas that are being restarted and whose interserver endpoints are temporarily unavailable.
-# `Unknown tokenizer: 'unicode_word'` appears because the `unicode_word` tokenizer was renamed to `asciiCJK`
-#       (with `unicodeWord` as a transitional alias). Tables from old versions using `unicode_word` trigger this
-#       on attach. Narrowed to the exact legacy name so genuinely unsupported tokenizer names are not masked.
 # `Azure::Storage::StorageException.*Not found address of host` is a transient Azure blob DNS resolution failure
 #       for `openbucketforpublicci.blob.core.windows.net`. Filtered via regex in the secondary pipe below to match
 #       both the Azure SDK exception type AND the DNS error together, so non-Azure DNS errors are not masked.
@@ -536,7 +533,6 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Cannot parse projection test_projection" \
            -e "Key expressions cannot contain subqueries" \
            -e "Expression must be deterministic but it contains non-deterministic part" \
-           -e "Unknown tokenizer: 'unicode_word'" \
            -e "This engine is deprecated and is not supported in transactions" \
            -e "Prevent converting Nullable type to non-Nullable type inside mutation" \
            -e "e.what() = failed to parse response body" \

--- a/tests/queries/0_stateless/02346_system_tokenizers.reference
+++ b/tests/queries/0_stateless/02346_system_tokenizers.reference
@@ -8,3 +8,4 @@ splitByNonAlpha
 splitByString
 tokenbf_v1
 unicodeWord
+unicode_word

--- a/tests/queries/0_stateless/04691_unicode_word_tokenizer_alias.reference
+++ b/tests/queries/0_stateless/04691_unicode_word_tokenizer_alias.reference
@@ -1,0 +1,24 @@
+-- { echoOn }
+-- The `asciiCJK` tokenizer was named `unicode_word` throughout the 26.3 LTS line. That name is persisted in the
+-- metadata of tables created there and is re-validated when they are attached, so it has to keep resolving.
+select name from system.tokenizers where name in ('asciiCJK', 'unicodeWord', 'unicode_word') order by name;
+asciiCJK
+unicodeWord
+unicode_word
+select tokens('taichi张三丰in the house', 'unicode_word');
+['taichi','张','三','丰','in','the','house']
+select tokens('taichi张三丰in the house', 'unicode_word') = tokens('taichi张三丰in the house', 'asciiCJK');
+1
+drop table if exists tab;
+create table tab (key UInt64, str String, index text_idx(str) type text(tokenizer = unicode_word)) engine MergeTree order by key;
+insert into tab values (1, 'hello错误502需要处理kitty');
+explain estimate select * from tab where str like '%错误502需要%';
+default	tab	1	1	1
+-- Attaching is the path on which such tables used to fail after an upgrade.
+detach table tab;
+attach table tab;
+select count() from tab;
+1
+explain estimate select * from tab where str like '%错误502需要%';
+default	tab	1	1	1
+drop table tab;

--- a/tests/queries/0_stateless/04691_unicode_word_tokenizer_alias.sql
+++ b/tests/queries/0_stateless/04691_unicode_word_tokenizer_alias.sql
@@ -1,0 +1,20 @@
+-- { echoOn }
+-- The `asciiCJK` tokenizer was named `unicode_word` throughout the 26.3 LTS line. That name is persisted in the
+-- metadata of tables created there and is re-validated when they are attached, so it has to keep resolving.
+select name from system.tokenizers where name in ('asciiCJK', 'unicodeWord', 'unicode_word') order by name;
+
+select tokens('taichi张三丰in the house', 'unicode_word');
+select tokens('taichi张三丰in the house', 'unicode_word') = tokens('taichi张三丰in the house', 'asciiCJK');
+
+drop table if exists tab;
+create table tab (key UInt64, str String, index text_idx(str) type text(tokenizer = unicode_word)) engine MergeTree order by key;
+insert into tab values (1, 'hello错误502需要处理kitty');
+explain estimate select * from tab where str like '%错误502需要%';
+
+-- Attaching is the path on which such tables used to fail after an upgrade.
+detach table tab;
+attach table tab;
+select count() from tab;
+explain estimate select * from tab where str like '%错误502需要%';
+
+drop table tab;


### PR DESCRIPTION
Restore `unicode_word` as a backward-compatible alias for the `asciiCJK` tokenizer.

  The `unicode_word` name shipped throughout the 26.3 LTS release line and can be persisted in table metadata. Without this alias,
  affected tables cannot be attached after upgrading to later releases.

  This change also adds regression coverage for `DETACH` and `ATTACH`, updates tokenizer lists used by fuzzers, and removes the
  corresponding upgrade-test error suppression.

  Related: https://github.com/ClickHouse/ClickHouse/issues/112711


  ### Changelog category (leave one):
  - Bug Fix (user-visible misbehavior in an official stable release)


  ### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/
  changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
  Restored the `unicode_word` tokenizer alias, allowing tables created with this tokenizer on 26.3 LTS to remain attachable after
  upgrading.