### PR TITLE
Fix `RENAME TABLE` checking the new name against the source database

### DIFF
--- a/src/Interpreters/InterpreterRenameQuery.cpp
+++ b/src/Interpreters/InterpreterRenameQuery.cpp
@@ -160,9 +160,7 @@ BlockIO InterpreterRenameQuery::executeToTables(const ASTRenameQuery & rename, c
         {
             /// The limit is derived from the receiver's own name, so the destination database
             /// is the one that has to be able to hold the new name.
-            DatabasePtr to_database = elem.to_database_name == elem.from_database_name
-                ? database
-                : database_catalog.getDatabase(elem.to_database_name);
+            DatabasePtr to_database = database_catalog.getDatabase(elem.to_database_name);
             to_database->checkTableNameLength(to_table_id.table_name);
 
             DatabaseCatalog::instance().checkTableCanBeRenamedWithNoCyclicDependencies(from_table_id, to_table_id);

--- a/src/Interpreters/InterpreterRenameQuery.cpp
+++ b/src/Interpreters/InterpreterRenameQuery.cpp
@@ -158,7 +158,12 @@ BlockIO InterpreterRenameQuery::executeToTables(const ASTRenameQuery & rename, c
         }
         else
         {
-            database->checkTableNameLength(to_table_id.table_name);
+            /// The limit is derived from the receiver's own name, so the destination database
+            /// is the one that has to be able to hold the new name.
+            DatabasePtr to_database = elem.to_database_name == elem.from_database_name
+                ? database
+                : database_catalog.getDatabase(elem.to_database_name);
+            to_database->checkTableNameLength(to_table_id.table_name);
 
             DatabaseCatalog::instance().checkTableCanBeRenamedWithNoCyclicDependencies(from_table_id, to_table_id);
             bool check_ref_deps = getContext()->getSettingsRef()[Setting::check_referential_table_dependencies];

--- a/tests/queries/0_stateless/04655_table_name_length_underflow_drop.reference
+++ b/tests/queries/0_stateless/04655_table_name_length_underflow_drop.reference
@@ -6,3 +6,7 @@ into-long-escaped-rejected
 out-of-long-accepted
 rescued-dropped
 unknown-db-reported
+view-into-long-rejected
+matview-into-long-rejected
+refreshable-matview-into-long-rejected
+dictionary-into-long-rejected

--- a/tests/queries/0_stateless/04655_table_name_length_underflow_drop.reference
+++ b/tests/queries/0_stateless/04655_table_name_length_underflow_drop.reference
@@ -1,5 +1,8 @@
 created
 dropped
 ARGUMENT_OUT_OF_BOUND
-into-long-accepted
-out-of-long-rejected
+into-long-rejected
+into-long-escaped-rejected
+out-of-long-accepted
+rescued-dropped
+unknown-db-reported

--- a/tests/queries/0_stateless/04655_table_name_length_underflow_drop.sh
+++ b/tests/queries/0_stateless/04655_table_name_length_underflow_drop.sh
@@ -11,23 +11,31 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # Pad the unique per-test database name out to an exact escaped length. CLICKHOUSE_DATABASE is
 # test_<8 lowercase letters and digits>, so every byte is a word character and the escaped
 # length equals the character count. The unique prefix is what keeps this parallel-safe.
-pad() { printf '%*s' "$1" '' | tr ' ' d; }
+pad() { printf '%*s' "$1" '' | tr ' ' "${2:-d}"; }
 # 211 is the largest escaped database name that still leaves room for a 2-character table name.
 db_ok="${CLICKHOUSE_DATABASE}$(pad $((211 - ${#CLICKHOUSE_DATABASE})))"
 # 214 is the first escaped length whose prefix alone exceeds the limit.
 db_too_long="${CLICKHOUSE_DATABASE}$(pad $((214 - ${#CLICKHOUSE_DATABASE})))"
+# Same 214 escaped bytes, but from only 118 characters: escapeForFileName expands every non-word
+# byte to three, so a limit computed from the character count would be 95 instead of 0.
+db_esc="${CLICKHOUSE_DATABASE}$(pad $((70 - ${#CLICKHOUSE_DATABASE})))$(pad 48 -)"
+# 211 escaped bytes again, so its own limit is 2: long enough to hold t0, short enough that any
+# longer destination name is rejected while it is the receiver.
+db_rescue="${CLICKHOUSE_DATABASE}_r$(pad $((209 - ${#CLICKHOUSE_DATABASE})))"
 db_short="${CLICKHOUSE_DATABASE}_short"
 db_shrunk="${CLICKHOUSE_DATABASE}_shrunk"
+db_absent="${CLICKHOUSE_DATABASE}_absent"
 
 # Report a rename outcome by name: no output means it was accepted, the length guard means it was
-# rejected, and any other error is reported as such so it reddens the reference instead of being
-# mistaken for one of the first two.
+# rejected, an unknown target database is reported as such, and any other error reddens the
+# reference instead of being mistaken for one of the first three.
 rename_outcome() {
     local label="$1"
     local out
     out=$($CLICKHOUSE_CLIENT -q "$2" 2>&1)
     if [ -z "$out" ]; then echo "$label-accepted"
     elif echo "$out" | grep -q 'ARGUMENT_OUT_OF_BOUND'; then echo "$label-rejected"
+    elif echo "$out" | grep -q 'UNKNOWN_DATABASE'; then echo "$label-reported"
     else echo "$label-unexpected-error"; fi
 }
 
@@ -48,24 +56,50 @@ if [ "$use_s3_plain_rewriteable_as_db_disk" == "0" ]; then
     $CLICKHOUSE_CLIENT -q "CREATE DATABASE \`$db_too_long\` ENGINE = Atomic"
     $CLICKHOUSE_CLIENT -q "CREATE TABLE \`$db_too_long\`.t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple()" 2>&1 | grep -o -m 1 'ARGUMENT_OUT_OF_BOUND'
 
-    # RENAME TABLE validates the destination name against the source database
-    # (InterpreterRenameQuery.cpp), so renaming into an oversized database is still allowed. That
-    # is issue #102463 and is not fixed here; both directions are pinned so that fix has a
-    # baseline.
+    # RENAME TABLE must validate the destination name against the database the table lands in,
+    # not against the one it leaves (issue #102463). Each rename below is independent, so no
+    # assertion depends on an earlier one having been accepted.
+    $CLICKHOUSE_CLIENT -q "CREATE DATABASE \`$db_esc\` ENGINE = Atomic"
+    $CLICKHOUSE_CLIENT -q "CREATE DATABASE \`$db_rescue\` ENGINE = Atomic"
     $CLICKHOUSE_CLIENT -q "CREATE DATABASE \`$db_short\` ENGINE = Atomic"
     $CLICKHOUSE_CLIENT -q "CREATE TABLE \`$db_short\`.r0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple()"
-    rename_outcome "into-long" "RENAME TABLE \`$db_short\`.r0 TO \`$db_too_long\`.r0"
-    rename_outcome "out-of-long" "RENAME TABLE \`$db_too_long\`.r0 TO \`$db_short\`.r1"
+    $CLICKHOUSE_CLIENT -q "CREATE TABLE \`$db_short\`.r1 (c0 Int) ENGINE = MergeTree() ORDER BY tuple()"
+    $CLICKHOUSE_CLIENT -q "CREATE TABLE \`$db_short\`.r2 (c0 Int) ENGINE = MergeTree() ORDER BY tuple()"
+    $CLICKHOUSE_CLIENT -q "CREATE TABLE \`$db_rescue\`.t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple()"
 
-    # The table now sits in the oversized database, where DROP cannot build its metadata_dropped
-    # path, so shorten the database name first. That is the workaround from the issue.
+    # Into an oversized database: must be rejected, or the table cannot be dropped afterwards.
+    rename_outcome "into-long" "RENAME TABLE \`$db_short\`.r0 TO \`$db_too_long\`.r0"
+    rename_outcome "into-long-escaped" "RENAME TABLE \`$db_short\`.r1 TO \`$db_esc\`.r1"
+
+    # Out of an oversized database into a short one: must be accepted, and the table must then
+    # drop. This is the per-table escape hatch out of an already-oversized database.
+    rename_outcome "out-of-long" "RENAME TABLE \`$db_rescue\`.t0 TO \`$db_short\`.rescued_table"
+    if $CLICKHOUSE_CLIENT -q "DROP TABLE \`$db_short\`.rescued_table" 2>/dev/null; then
+        echo "rescued-dropped"
+    else
+        echo "rescued-drop-failed"
+    fi
+
+    # An unknown target database is reported as such, rather than as a length violation measured
+    # against the source database.
+    src_limit=$($CLICKHOUSE_CLIENT -q "SELECT getMaxTableNameLengthForDatabase('$db_short')")
+    over_limit_name=$(pad $((src_limit + 1)) a)
+    rename_outcome "unknown-db" "RENAME TABLE \`$db_short\`.r2 TO \`$db_absent\`.\`$over_limit_name\`"
+
+    # db_too_long and db_esc are empty, but their own escaped names already fill the dropped
+    # metadata budget, so shorten one of them first. That is the workaround from the issue.
     $CLICKHOUSE_CLIENT -q "RENAME DATABASE \`$db_too_long\` TO \`$db_shrunk\`"
     $CLICKHOUSE_CLIENT -q "DROP DATABASE \`$db_shrunk\`"
+    $CLICKHOUSE_CLIENT -q "DROP DATABASE \`$db_esc\`"
+    $CLICKHOUSE_CLIENT -q "DROP DATABASE \`$db_rescue\`"
     $CLICKHOUSE_CLIENT -q "DROP DATABASE \`$db_short\`"
 else
     echo "created"
     echo "dropped"
     echo "ARGUMENT_OUT_OF_BOUND"
-    echo "into-long-accepted"
-    echo "out-of-long-rejected"
+    echo "into-long-rejected"
+    echo "into-long-escaped-rejected"
+    echo "out-of-long-accepted"
+    echo "rescued-dropped"
+    echo "unknown-db-reported"
 fi

--- a/tests/queries/0_stateless/04655_table_name_length_underflow_drop.sh
+++ b/tests/queries/0_stateless/04655_table_name_length_underflow_drop.sh
@@ -67,6 +67,17 @@ if [ "$use_s3_plain_rewriteable_as_db_disk" == "0" ]; then
     $CLICKHOUSE_CLIENT -q "CREATE TABLE \`$db_short\`.r2 (c0 Int) ENGINE = MergeTree() ORDER BY tuple()"
     $CLICKHOUSE_CLIENT -q "CREATE TABLE \`$db_rescue\`.t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple()"
 
+    # Views, materialized views, refreshable materialized views and dictionaries are renamed by the
+    # same statement, so the destination length is checked against the same database for all of
+    # them. They read `vsrc`, which no assertion renames, so each case below stands alone.
+    $CLICKHOUSE_CLIENT -q "CREATE TABLE \`$db_short\`.vsrc (c0 Int) ENGINE = MergeTree() ORDER BY tuple()"
+    $CLICKHOUSE_CLIENT -q "CREATE TABLE \`$db_short\`.mv_target (c0 Int) ENGINE = MergeTree() ORDER BY tuple()"
+    $CLICKHOUSE_CLIENT -q "CREATE TABLE \`$db_short\`.rmv_target (c0 Int) ENGINE = MergeTree() ORDER BY tuple()"
+    $CLICKHOUSE_CLIENT -q "CREATE VIEW \`$db_short\`.v0 AS SELECT * FROM \`$db_short\`.vsrc"
+    $CLICKHOUSE_CLIENT -q "CREATE MATERIALIZED VIEW \`$db_short\`.mv0 TO \`$db_short\`.mv_target AS SELECT * FROM \`$db_short\`.vsrc"
+    $CLICKHOUSE_CLIENT -q "CREATE MATERIALIZED VIEW \`$db_short\`.rmv0 REFRESH EVERY 1 YEAR TO \`$db_short\`.rmv_target AS SELECT * FROM \`$db_short\`.vsrc"
+    $CLICKHOUSE_CLIENT -q "CREATE DICTIONARY \`$db_short\`.d0 (c0 Int DEFAULT 0) PRIMARY KEY c0 SOURCE(CLICKHOUSE(TABLE 'vsrc' DB '$db_short')) LAYOUT(FLAT()) LIFETIME(0)"
+
     # Into an oversized database: must be rejected, or the table cannot be dropped afterwards.
     rename_outcome "into-long" "RENAME TABLE \`$db_short\`.r0 TO \`$db_too_long\`.r0"
     rename_outcome "into-long-escaped" "RENAME TABLE \`$db_short\`.r1 TO \`$db_esc\`.r1"
@@ -86,6 +97,11 @@ if [ "$use_s3_plain_rewriteable_as_db_disk" == "0" ]; then
     over_limit_name=$(pad $((src_limit + 1)) a)
     rename_outcome "unknown-db" "RENAME TABLE \`$db_short\`.r2 TO \`$db_absent\`.\`$over_limit_name\`"
 
+    rename_outcome "view-into-long" "RENAME TABLE \`$db_short\`.v0 TO \`$db_too_long\`.v0"
+    rename_outcome "matview-into-long" "RENAME TABLE \`$db_short\`.mv0 TO \`$db_too_long\`.mv0"
+    rename_outcome "refreshable-matview-into-long" "RENAME TABLE \`$db_short\`.rmv0 TO \`$db_too_long\`.rmv0"
+    rename_outcome "dictionary-into-long" "RENAME DICTIONARY \`$db_short\`.d0 TO \`$db_too_long\`.d0"
+
     # db_too_long and db_esc are empty, but their own escaped names already fill the dropped
     # metadata budget, so shorten one of them first. That is the workaround from the issue.
     $CLICKHOUSE_CLIENT -q "RENAME DATABASE \`$db_too_long\` TO \`$db_shrunk\`"
@@ -102,4 +118,8 @@ else
     echo "out-of-long-accepted"
     echo "rescued-dropped"
     echo "unknown-db-reported"
+    echo "view-into-long-rejected"
+    echo "matview-into-long-rejected"
+    echo "refreshable-matview-into-long-rejected"
+    echo "dictionary-into-long-rejected"
 fi


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/102463
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `RENAME TABLE` checking the maximum table name length against the source database instead of the destination one. Renaming a table into a database with a long name could produce a table that `DROP TABLE` could not remove, and renaming a table out of such a database was wrongly rejected.


### Description

Closes: #102463

The maximum table name length is bounded by the dropped-metadata filename
`metadata_dropped/{db}.{table}.{uuid}.sql`, so it is a function of the database the table
lives in. `InterpreterRenameQuery::executeToTables` bound the source database and validated
the destination name against it, so a cross-database rename used the limit of the wrong
database.

Two effects, both reproduced on master:

- `RENAME TABLE short_db.t TO long_db.t` was accepted, and the table then could not be
  dropped: `DROP` fails with `Code: 1001 ... in rename: File name too long`.
- `RENAME TABLE long_db.t TO short_db.t` was rejected with `Code: 69`, although it is valid
  and is the only per-table way out of an oversized database.

I resolve the destination database and validate against it, reusing the already-bound source
object when both sides are the same database so the common path takes no extra
`databases_mutex` acquisition. `RENAME DATABASE` and both `CREATE`-side call sites already
use the target as the receiver, so this makes `RENAME TABLE` consistent.

Two notes for review:

- Renaming into an oversized database is now rejected. That operation is exactly the one
  that leaves a table `DROP` cannot remove, so there is no working use to preserve. No
  setting defaults change, so no `SettingsChangesHistory.cpp` entry.
- `RENAME TABLE a.t TO nonexistent_db.<over-long name>` now reports `UNKNOWN_DATABASE`
  instead of `ARGUMENT_OUT_OF_BOUND`, before the dependency bookkeeping it used to run
  after. The new test pins it.

`EXCHANGE TABLES` checks no length at all and can reach the same state, but adding a check
there would newly reject exchanges that succeed today, and its `CREATE OR REPLACE` route is
already covered against the correct database. Out of scope here, as is #101747.

Test: `04655_table_name_length_underflow_drop` gains both directions as independent renames
plus a drop assertion, a case whose escaped length differs from its character count, and the
ordering case.

<details>
<summary>Validation</summary>

Debug build, single node. Pre-fix binary `944e794b2dcd`, fixed binary `e046128414920ceb`
(server `buildId()` checked against `readelf` on every run).

| check | pre-fix | with fix |
|---|---|---|
| `04655` reference | 5 of 8 lines differ | pass |
| into-long (`RENAME short -> long`) | accepted | rejected `ARGUMENT_OUT_OF_BOUND` |
| into-long, escaped 118 chars -> 214 bytes | accepted | rejected |
| out-of-long (rescue) | rejected `Code: 69` | accepted |
| `DROP` of the rescued table | fails | succeeds |
| unknown target database | `ARGUMENT_OUT_OF_BOUND` | `UNKNOWN_DATABASE` |

Mutation test: reverting only the receiver line rebuilds to the byte-identical pre-fix build
id and turns exactly those five assertions red, the three unrelated lines staying green.

Also green with the fix: `03167_improvement_table_name_too_long`,
`03253_getMaxTableNameLength`, `04654_table_name_length_underflow`,
`01155_rename_move_materialized_view`, `01114_database_atomic`, and
`tests/integration/test_check_table_name_length_2` (its `rename ... to atomic.<long>`
expectation is unchanged, since `atomic` and `replic` escape to the same length).
150 of 150 randomized runs of `04655` and the `0465*` family passed.

</details>