### PR TITLE
Reject a valueless `SETTINGS` form that carries a value other than `true`

### DIFF
--- a/src/Core/BaseSettings.cpp
+++ b/src/Core/BaseSettings.cpp
@@ -9,6 +9,7 @@ namespace DB
 {
 namespace ErrorCodes
 {
+    extern const int BAD_ARGUMENTS;
     extern const int INCORRECT_DATA;
     extern const int TYPE_MISMATCH;
     extern const int UNKNOWN_SETTING;
@@ -72,6 +73,14 @@ void BaseSettingsHelpers::throwValuelessSettingIsNotBool(std::string_view name)
         ErrorCodes::TYPE_MISMATCH,
         "Setting '{}' is not Bool, so it cannot be set without a value. Write '{} = <value>'",
         String{name}, String{name});
+}
+
+void BaseSettingsHelpers::throwValuelessSettingHasValue(std::string_view name)
+{
+    throw Exception(
+        ErrorCodes::BAD_ARGUMENTS,
+        "Setting '{}' is marked as written without a value, which stands for `{} = true`, "
+        "but it carries a different value", String{name}, String{name});
 }
 
 /// Log the summary of unknown settings as a warning instead of warning for each one separately.

--- a/src/Core/BaseSettings.h
+++ b/src/Core/BaseSettings.h
@@ -37,6 +37,7 @@ struct BaseSettingsHelpers
     [[noreturn]] static void throwSettingNotFound(std::string_view name);
     [[noreturn]] static void throwValuelessSettingIsNotBool(std::string_view name, std::string_view type);
     [[noreturn]] static void throwValuelessSettingIsNotBool(std::string_view name);
+    [[noreturn]] static void throwValuelessSettingHasValue(std::string_view name);
     static void warningSettingNotFound(std::string_view name);
     static void flushWarnings();
 
@@ -450,6 +451,16 @@ void BaseSettings<TTraits>::checkShorthandChange(const SettingChange & change) c
 
     if (std::string_view type = getTypeName(change.name); type != "Bool")
         BaseSettingsHelpers::throwValuelessSettingIsNotBool(change.name, type);
+
+    /// The type alone is not enough. The parser writes Bool `true` for the valueless form, but a
+    /// `SettingChange` can also arrive from the AST JSON dialect, which is free to pair the flag
+    /// with any other value - and for a `Bool` setting the check above lets that through. Such a
+    /// change would execute with the carried value while `ASTSetQuery::formatImpl` renders the bare
+    /// name, so `system.query_log` and every other formatter would under-report what ran. This is
+    /// the first point after deserialization where an exception is logged with the AST masked
+    /// rather than with the raw JSON text, so this is where it is rejected.
+    if (change.value != Field(true))
+        BaseSettingsHelpers::throwValuelessSettingHasValue(change.name);
 }
 
 template <typename TTraits>

--- a/src/Parsers/ASTSetQuery.cpp
+++ b/src/Parsers/ASTSetQuery.cpp
@@ -103,7 +103,12 @@ void ASTSetQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & format, 
         /// The valueless form has to survive a format/parse round trip: written back as
         /// `name = true` it would be accepted for a setting of any type, which is exactly what the
         /// shorthand check exists to prevent. The value is Bool `true` and never secret.
-        if (change.shorthand)
+        ///
+        /// Only elide the value when it really is `true`. The AST JSON dialect can pair the
+        /// shorthand flag with any other value, and such a change is rejected by
+        /// `BaseSettings::checkShorthandChange` - but that happens after the query is logged, so the
+        /// formatter must not print a bare name for a change that carries something else.
+        if (change.shorthand && change.value == Field(true))
             continue;
 
         auto format_if_secret = [&]() -> bool

--- a/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.reference
+++ b/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.reference
@@ -6,9 +6,9 @@ SELECT 1 SETTINGS optimize_move_to_prewhere
 1
 TYPE_MISMATCH
 1
-SELECT 1 SETTINGS format_avro_schema_registry_url
+SELECT 1 SETTINGS format_avro_schema_registry_url = \'http://user:pass@localhost\'
 TYPE_MISMATCH
-SELECT 1 SETTINGS format_avro_schema_registry_url	1
+SELECT 1 SETTINGS format_avro_schema_registry_url = \'http://user:[HIDDEN]@localhost\'	1
 TYPE_MISMATCH
 TYPE_MISMATCH
 SELECT 1 SETTINGS format_avro_schema_registry_url = \'http://user:pass@localhost\'

--- a/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.sh
+++ b/tests/queries/0_stateless/04665_valueless_setting_ast_json_and_secret_parts.sh
@@ -32,7 +32,10 @@ $CLICKHOUSE_CLIENT --dialect clickhouse_json --allow_experimental_json_ast_diale
 # A payload may pair the flag with a value the parser would never produce. Deserialization must not
 # reject it: that runs before `executeQueryImpl` has an AST to mask with, so the raw JSON text -
 # the value included - would go down the unmasked logging path. The value is kept, so the query is
-# rejected by the setting's own check, and the value stays hidden when the query is formatted.
+# rejected by the setting's own check, and the formatter still prints it - a valueless setting only
+# has its value elided when the value really is `true`, so a formatter can never under-report what a
+# query carries. `formatQueryFromJSON` shows secrets, exactly like `formatQuerySingleLine` below;
+# what matters is that the masking path used for logging hides the password.
 CRAFTED="replaceAll(parseQueryToJSON(\$\$SELECT 1 SETTINGS format_avro_schema_registry_url = 'http://user:pass@localhost'\$\$), '{\"name\":\"format_avro_schema_registry_url\"', '{\"name\":\"format_avro_schema_registry_url\",\"shorthand\":true')"
 $CLICKHOUSE_CLIENT -q "SELECT formatQueryFromJSON($CRAFTED)"
 CRAFTED_JSON=$($CLICKHOUSE_CLIENT -q "SELECT $CRAFTED FORMAT TSVRaw")

--- a/tests/queries/0_stateless/04691_shorthand_setting_value_mismatch.reference
+++ b/tests/queries/0_stateless/04691_shorthand_setting_value_mismatch.reference
@@ -1,0 +1,7 @@
+SELECT 1 SETTINGS optimize_move_to_prewhere = false
+BAD_ARGUMENTS
+SELECT 1 SETTINGS optimize_move_to_prewhere = \'x\'
+BAD_ARGUMENTS
+SELECT 1 SETTINGS optimize_move_to_prewhere
+1
+1

--- a/tests/queries/0_stateless/04691_shorthand_setting_value_mismatch.sh
+++ b/tests/queries/0_stateless/04691_shorthand_setting_value_mismatch.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# The valueless `SETTINGS name` form stands for `name = true`, and the parser always writes Bool
+# `true` for it. The AST JSON dialect can pair the `shorthand` flag with any other value, and for a
+# `Bool` setting the type check alone accepted that: the query executed with the carried value while
+# every formatter rendered the bare name, so `system.query_log` under-reported what ran.
+
+# Craft a payload for a `Bool` setting whose shorthand flag carries `false`.
+CRAFTED="replaceAll(parseQueryToJSON(\$\$SELECT 1 SETTINGS optimize_move_to_prewhere = false\$\$), '{\"name\":\"optimize_move_to_prewhere\"', '{\"name\":\"optimize_move_to_prewhere\",\"shorthand\":true')"
+
+# The formatter must not claim the setting was written without a value when it carries `false`.
+$CLICKHOUSE_CLIENT -q "SELECT formatQueryFromJSON($CRAFTED)"
+
+# And executing it must be rejected instead of silently running with `false`.
+CRAFTED_JSON=$($CLICKHOUSE_CLIENT -q "SELECT $CRAFTED FORMAT TSVRaw")
+$CLICKHOUSE_CLIENT --dialect clickhouse_json --allow_experimental_json_ast_dialect 1 -q "$CRAFTED_JSON" 2>&1 | grep -o "BAD_ARGUMENTS" | head -n 1
+
+# The same for a value of another type smuggled in under the flag: rejected for carrying a value,
+# before the type of the setting is even considered.
+CRAFTED_STR="replaceAll(parseQueryToJSON(\$\$SELECT 1 SETTINGS optimize_move_to_prewhere = false\$\$), '\"value\":{\"field_type\":\"Bool\",\"value\":false}', '\"shorthand\":true,\"value\":{\"field_type\":\"String\",\"value\":\"x\"}')"
+$CLICKHOUSE_CLIENT -q "SELECT formatQueryFromJSON($CRAFTED_STR)"
+CRAFTED_STR_JSON=$($CLICKHOUSE_CLIENT -q "SELECT $CRAFTED_STR FORMAT TSVRaw")
+$CLICKHOUSE_CLIENT --dialect clickhouse_json --allow_experimental_json_ast_dialect 1 -q "$CRAFTED_STR_JSON" 2>&1 | grep -o "BAD_ARGUMENTS" | head -n 1
+
+# The genuine valueless form is untouched: it still formats without a value and still executes.
+$CLICKHOUSE_CLIENT -q "SELECT formatQueryFromJSON(parseQueryToJSON(\$\$SELECT 1 SETTINGS optimize_move_to_prewhere\$\$))"
+$CLICKHOUSE_CLIENT -q "SELECT 1 SETTINGS optimize_move_to_prewhere"
+$CLICKHOUSE_CLIENT -q "SELECT * FROM (SELECT 1 SETTINGS optimize_move_to_prewhere)"

--- a/tests/queries/0_stateless/04691_shorthand_setting_value_mismatch.sh
+++ b/tests/queries/0_stateless/04691_shorthand_setting_value_mismatch.sh
@@ -7,7 +7,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # The valueless `SETTINGS name` form stands for `name = true`, and the parser always writes Bool
 # `true` for it. The AST JSON dialect can pair the `shorthand` flag with any other value, and for a
 # `Bool` setting the type check alone accepted that: the query executed with the carried value while
-# every formatter rendered the bare name, so `system.query_log` under-reported what ran.
+# every formatter rendered the bare name, so the logged query under-reported what ran.
 
 # Craft a payload for a `Bool` setting whose shorthand flag carries `false`.
 CRAFTED="replaceAll(parseQueryToJSON(\$\$SELECT 1 SETTINGS optimize_move_to_prewhere = false\$\$), '{\"name\":\"optimize_move_to_prewhere\"', '{\"name\":\"optimize_move_to_prewhere\",\"shorthand\":true')"


### PR DESCRIPTION
The valueless `SETTINGS name` form stands for `name = true`. `SettingChange::shorthand` records that it was written without a value, and the parser always pairs the flag with Bool `true` — but the AST JSON dialect can pair it with any other value, and `BaseSettings::checkShorthandChange` only verified that the setting's type is `Bool`.

So a payload like

```json
{"name":"optimize_move_to_prewhere","shorthand":true,"value":{"field_type":"Bool","value":false}}
```

was accepted and executed with `false`, while `ASTSetQuery::formatImpl` elided the value for every shorthand change — `formatQueryFromJSON`, `system.query_log` and every other formatter rendered `SETTINGS optimize_move_to_prewhere`, under-reporting what actually ran.

Two changes:

- `checkShorthandChange` now also requires the carried value to be Bool `true`. It runs after the settings type check, so a non-`Bool` setting still reports `TYPE_MISMATCH`, and it is the first point after deserialization where an exception is logged with the AST masked rather than with the raw JSON text.
- `formatImpl` elides the value only when it really is `true`, so a formatter can never print a bare setting name for a change that carries something else. In the window before the change is rejected, the value of a crafted payload is printed through the secret-masking path, so a password is still hidden in `system.query_log`.

The reference of `04665_valueless_setting_ast_json_and_secret_parts` is updated for the second change: the crafted payload now formats with its value, masked (`http://user:[HIDDEN]@localhost`) on the logging path and shown by `formatQueryFromJSON`, which formats with `show_secrets = true` exactly like `formatQuerySingleLine` in the line below it.

Follow-up to the AI review finding on https://github.com/ClickHouse/ClickHouse/pull/112902.

Related: https://github.com/ClickHouse/ClickHouse/pull/112902

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Reject a `SETTINGS` change marked as written without a value when it carries a value other than `true`, and never elide the value of such a change when formatting a query. Previously a crafted AST JSON payload could execute a `Bool` setting with `false` while `system.query_log` and `formatQueryFromJSON` showed the valueless form.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.708` (included in `26.8` and later)
<!-- ch-version-info:end -->