### PR TITLE
Write custom min/max stats for UInt128/UInt256 in Parquet

### DIFF
--- a/docs/en/interfaces/formats/Parquet/Parquet.md
+++ b/docs/en/interfaces/formats/Parquet/Parquet.md
@@ -73,10 +73,13 @@ When writing Parquet file, data types that don't have a matching Parquet type ar
 
 For `UInt128` and `UInt256`, ClickHouse also writes versioned numeric minimum and maximum values to
 the `clickhouse.wide_integer_statistics` key in each non-empty column chunk's key-value metadata.
-The standard Parquet statistics remain ordered by the raw little-endian byte representation, as
-required for an unannotated `FIXED_LEN_BYTE_ARRAY`. ClickHouse uses the additional numeric bounds to
-skip row groups for predicates on columns explicitly read as `UInt128` or `UInt256`. Other Parquet
-clients and older ClickHouse versions ignore this metadata and continue to read the same payload.
+When the page index is enabled, the `clickhouse.wide_integer_page_statistics` key contains the same
+kind of bounds for every data page. Its value is `1;<type>;<page-0-min>;<page-0-max>;...`, with an
+empty minimum and maximum for an all-null page. The standard Parquet row-group and page statistics
+remain ordered by the raw little-endian byte representation, as required for an unannotated
+`FIXED_LEN_BYTE_ARRAY`. ClickHouse uses the additional numeric bounds to skip row groups and pages
+for predicates on columns explicitly read as `UInt128` or `UInt256`. Other Parquet clients and
+older ClickHouse versions ignore this metadata and continue to read the same payload.
 
 Arrays can be nested and can have a value of `Nullable` type as an argument. `Tuple` and `Map` types can also be nested.
 

--- a/docs/en/interfaces/formats/Parquet/Parquet.md
+++ b/docs/en/interfaces/formats/Parquet/Parquet.md
@@ -71,6 +71,13 @@ When writing Parquet file, data types that don't have a matching Parquet type ar
 | [MultiLineString](/sql-reference/data-types/geo.md#multilinestring) | `BYTE_ARRAY` (WKB) + GeoParquet metadata |
 | [MultiPolygon](/sql-reference/data-types/geo.md#multipolygon) | `BYTE_ARRAY` (WKB) + GeoParquet metadata |
 
+For `UInt128` and `UInt256`, ClickHouse also writes versioned numeric minimum and maximum values to
+the `clickhouse.wide_integer_statistics` key in each non-empty column chunk's key-value metadata.
+The standard Parquet statistics remain ordered by the raw little-endian byte representation, as
+required for an unannotated `FIXED_LEN_BYTE_ARRAY`. ClickHouse uses the additional numeric bounds to
+skip row groups for predicates on columns explicitly read as `UInt128` or `UInt256`. Other Parquet
+clients and older ClickHouse versions ignore this metadata and continue to read the same payload.
+
 Arrays can be nested and can have a value of `Nullable` type as an argument. `Tuple` and `Map` types can also be nested.
 
 Data types of ClickHouse table columns can differ from the corresponding fields of the Parquet data inserted. When inserting data, ClickHouse interprets data types according to the table above and then [casts](/sql-reference/functions/type-conversion-functions#CAST) the data to that data type which is set for the ClickHouse table column. E.g. a `UINT_32` Parquet column can be read into an [IPv4](/sql-reference/data-types/ipv4.md) ClickHouse column.

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1487,6 +1487,7 @@ The server successfully detected this situation and will download merged part fr
     \
     M(ParquetReadRowGroups, "The total number of row groups read from parquet data", ValueType::Number) \
     M(ParquetPrunedRowGroups, "The total number of row groups pruned from parquet data", ValueType::Number) \
+    M(ParquetPrunedPages, "The total number of data pages pruned using parquet column indexes", ValueType::Number) \
     M(ParquetDecodingTasks, "Tasks issued by parquet reader", ValueType::Number) \
     M(ParquetDecodingTaskBatches, "Task groups sent to a thread pool by parquet reader", ValueType::Number) \
     M(ParquetPrefetcherReadRandomRead, "The total number of reads with ReadMode::RandomRead by DB::Parquet::Prefetcher", ValueType::Number) \

--- a/src/Processors/Formats/Impl/Parquet/Decoding.h
+++ b/src/Processors/Formats/Impl/Parquet/Decoding.h
@@ -168,8 +168,8 @@ struct PageDecoderInfo
     bool allow_stats = false;
 
     /// ClickHouse writes wide integers as little-endian `FIXED_LEN_BYTE_ARRAY`, whose numeric
-    /// order differs from the physical Parquet byte order. Numeric row-group bounds are therefore
-    /// stored separately in column-chunk key/value metadata.
+    /// order differs from the physical Parquet byte order. Numeric row-group and page bounds are
+    /// therefore stored separately in column-chunk key/value metadata.
     WideIntegerStatisticsType wide_integer_statistics_type = WideIntegerStatisticsType::None;
 
     /// True if we can decompress the whole page directly into IColumn's memory.

--- a/src/Processors/Formats/Impl/Parquet/Decoding.h
+++ b/src/Processors/Formats/Impl/Parquet/Decoding.h
@@ -142,6 +142,13 @@ struct StringConverter
 ///  2. after reading page header, the Encoding becomes known, and we create a PageDecoder.
 struct PageDecoderInfo
 {
+    enum class WideIntegerStatisticsType : uint8_t
+    {
+        None,
+        UInt128,
+        UInt256,
+    };
+
     parq::Type::type physical_type{};
 
     /// Postprocessing of decoded values. Exactly one of these is set, depending on physical_type.
@@ -159,6 +166,11 @@ struct PageDecoderInfo
     /// In particular we don't call something like convertFieldToType because working through all
     /// the cases would be a nightmare.
     bool allow_stats = false;
+
+    /// ClickHouse writes wide integers as little-endian `FIXED_LEN_BYTE_ARRAY`, whose numeric
+    /// order differs from the physical Parquet byte order. Numeric row-group bounds are therefore
+    /// stored separately in column-chunk key/value metadata.
+    WideIntegerStatisticsType wide_integer_statistics_type = WideIntegerStatisticsType::None;
 
     /// True if we can decompress the whole page directly into IColumn's memory.
     bool canReadDirectlyIntoColumn(parq::Encoding::type, size_t /*num_values*/, IColumn &, std::span<char> & out) const;

--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -15,6 +15,7 @@
 #include <Interpreters/castColumn.h>
 #include <IO/CompressionMethod.h>
 #include <IO/Libdeflate.h>
+#include <IO/ReadHelpers.h>
 #include <Processors/Formats/Impl/Parquet/Decoding.h>
 #include <Processors/Formats/Impl/Parquet/parquetBloomFilterHash.h>
 #include <Processors/Formats/Impl/Parquet/Reader.h>
@@ -24,6 +25,7 @@
 #include <Storages/MergeTree/MergeTreeRangeReader.h>
 #include <Storages/MergeTree/MergeTreeSplitPrewhereIntoReadSteps.h>
 
+#include <array>
 #include <mutex>
 #include <lz4.h>
 #include <arrow/util/crc32.h>
@@ -50,6 +52,99 @@ namespace ProfileEvents
 
 namespace DB::Parquet
 {
+
+inline constexpr std::string_view WIDE_INTEGER_STATISTICS_KEY = "clickhouse.wide_integer_statistics";
+
+using WideIntegerStatisticsType = PageDecoderInfo::WideIntegerStatisticsType;
+
+static std::optional<std::pair<Field, Field>> getWideIntegerStatistics(
+    const parq::ColumnMetaData & column_meta, WideIntegerStatisticsType expected_type)
+{
+    if (expected_type == WideIntegerStatisticsType::None || !column_meta.__isset.key_value_metadata)
+        return std::nullopt;
+
+    const parq::KeyValue * metadata = nullptr;
+    for (const auto & key_value : column_meta.key_value_metadata)
+    {
+        if (key_value.key != WIDE_INTEGER_STATISTICS_KEY)
+            continue;
+        if (metadata)
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Duplicate `{}` metadata", WIDE_INTEGER_STATISTICS_KEY);
+        metadata = &key_value;
+    }
+
+    if (!metadata)
+        return std::nullopt;
+    if (!metadata->__isset.value)
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Metadata `{}` has no value", WIDE_INTEGER_STATISTICS_KEY);
+
+    std::string_view value = metadata->value;
+    std::array<std::string_view, 4> fields;
+    size_t begin = 0;
+    for (size_t i = 0; i < fields.size(); ++i)
+    {
+        size_t end = value.find(';', begin);
+        if (i + 1 == fields.size())
+        {
+            if (end != std::string_view::npos)
+                throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid `{}` metadata value", WIDE_INTEGER_STATISTICS_KEY);
+            end = value.size();
+        }
+        else if (end == std::string_view::npos)
+        {
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid `{}` metadata value", WIDE_INTEGER_STATISTICS_KEY);
+        }
+
+        fields[i] = value.substr(begin, end - begin);
+        begin = end + 1;
+    }
+
+    if (fields[0] != "1")
+        throw Exception(
+            ErrorCodes::INCORRECT_DATA,
+            "Unsupported `{}` metadata version `{}`",
+            WIDE_INTEGER_STATISTICS_KEY,
+            fields[0]);
+
+    auto parse = [&]<typename T>(std::string_view expected_name) -> std::pair<Field, Field>
+    {
+        if (fields[1] != expected_name)
+            throw Exception(
+                ErrorCodes::INCORRECT_DATA,
+                "Metadata `{}` has type `{}`, expected `{}`",
+                WIDE_INTEGER_STATISTICS_KEY,
+                fields[1],
+                expected_name);
+
+        T min = parseFromString<T>(fields[2]);
+        T max = parseFromString<T>(fields[3]);
+        if (min > max)
+            throw Exception(
+                ErrorCodes::INCORRECT_DATA,
+                "Metadata `{}` has minimum greater than maximum",
+                WIDE_INTEGER_STATISTICS_KEY);
+        return {Field(min), Field(max)};
+    };
+
+    switch (expected_type)
+    {
+        case WideIntegerStatisticsType::UInt128: return parse.template operator()<UInt128>("UInt128");
+        case WideIntegerStatisticsType::UInt256: return parse.template operator()<UInt256>("UInt256");
+        case WideIntegerStatisticsType::None: break;
+    }
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected wide integer statistics type");
+}
+
+static Field getStatisticsDefault(const Reader::PrimitiveColumnInfo & column_info)
+{
+    switch (column_info.decoder.wide_integer_statistics_type)
+    {
+        case WideIntegerStatisticsType::UInt128: return Field(UInt128(0));
+        case WideIntegerStatisticsType::UInt256: return Field(UInt256(0));
+        case WideIntegerStatisticsType::None: return column_info.output_type->getDefault();
+    }
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected wide integer statistics type");
+}
 
 /// Thrift deserialization can store an out-of-range value into an unscoped enum field when the
 /// input file is malformed. Loading such an enum directly is undefined behavior (caught by
@@ -300,37 +395,51 @@ void Reader::getHyperrectangleForRowGroup(const parq::RowGroup * meta, Hyperrect
     {
         if (!column_info.used_by_key_condition)
             continue;
-        if (!column_info.decoder.allow_stats)
-            continue;
         try
         {
             const auto & column_meta = meta->columns.at(column_info.column_idx).meta_data;
-            if (!column_meta.__isset.statistics)
+            auto wide_integer_statistics = getWideIntegerStatistics(
+                column_meta, column_info.decoder.wide_integer_statistics_type);
+            bool can_use_standard_statistics = column_info.decoder.allow_stats && column_meta.__isset.statistics;
+
+            bool always_null = column_meta.__isset.statistics
+                && column_meta.statistics.__isset.null_count
+                && column_meta.statistics.null_count == column_meta.num_values;
+            bool can_use_wide_integer_null_count
+                = column_info.decoder.wide_integer_statistics_type != WideIntegerStatisticsType::None && always_null;
+            if (!can_use_standard_statistics && !wide_integer_statistics && !can_use_wide_integer_null_count)
                 continue;
 
             Range & range = hyperrectangle[column_info.idx_in_output_block];
 
             bool nullable = column_info.levels.back().def > 0;
-            bool always_null = column_meta.statistics.__isset.null_count &&
-                            column_meta.statistics.null_count == column_meta.num_values;
-            bool can_be_null = !column_meta.statistics.__isset.null_count ||
-                            column_meta.statistics.null_count != 0;
+            bool can_be_null = !column_meta.__isset.statistics
+                || !column_meta.statistics.__isset.null_count
+                || column_meta.statistics.null_count != 0;
             bool null_as_default = options.format.null_as_default && !column_info.output_nullable;
 
             if (nullable && always_null)
             {
                 /// Single-point range containing either the default value or one of the infinities.
                 if (null_as_default)
-                    range.right = range.left = column_info.output_type->getDefault();
+                    range.right = range.left = getStatisticsDefault(column_info);
                 else
                     range.right = range.left;
                 continue;
             }
 
-            if (column_meta.statistics.__isset.min_value)
-                column_info.decoder.decodeField(column_meta.statistics.min_value, /*is_max=*/ false, range.left);
-            if (column_meta.statistics.__isset.max_value)
-                column_info.decoder.decodeField(column_meta.statistics.max_value, /*is_max=*/ true, range.right);
+            if (wide_integer_statistics)
+            {
+                range.left = wide_integer_statistics->first;
+                range.right = wide_integer_statistics->second;
+            }
+            else
+            {
+                if (column_meta.statistics.__isset.min_value)
+                    column_info.decoder.decodeField(column_meta.statistics.min_value, /*is_max=*/ false, range.left);
+                if (column_meta.statistics.__isset.max_value)
+                    column_info.decoder.decodeField(column_meta.statistics.max_value, /*is_max=*/ true, range.right);
+            }
 
             adjustRangeFromIndexIfNeeded(range, column_info, can_be_null);
         }
@@ -1593,7 +1702,7 @@ void Reader::adjustRangeFromIndexIfNeeded(Range & range, const PrimitiveColumnIn
     {
         if (null_as_default)
         {
-            Field default_value = column_info.output_type->getDefault();
+            Field default_value = getStatisticsDefault(column_info);
             /// Make sure the range contains the default value.
             if (!range.left.isNull() && accurateLess(default_value, range.left))
                 range.left = default_value;

--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -25,7 +25,7 @@
 #include <Storages/MergeTree/MergeTreeRangeReader.h>
 #include <Storages/MergeTree/MergeTreeSplitPrewhereIntoReadSteps.h>
 
-#include <array>
+#include <limits>
 #include <mutex>
 #include <lz4.h>
 #include <arrow/util/crc32.h>
@@ -48,17 +48,24 @@ namespace ProfileEvents
 {
     extern const Event ParquetRowsFilterExpression;
     extern const Event ParquetColumnsFilterExpression;
+    extern const Event ParquetPrunedPages;
 }
 
 namespace DB::Parquet
 {
 
 inline constexpr std::string_view WIDE_INTEGER_STATISTICS_KEY = "clickhouse.wide_integer_statistics";
+inline constexpr std::string_view WIDE_INTEGER_PAGE_STATISTICS_KEY = "clickhouse.wide_integer_page_statistics";
 
 using WideIntegerStatisticsType = PageDecoderInfo::WideIntegerStatisticsType;
+using WideIntegerStatistics = std::vector<std::optional<std::pair<Field, Field>>>;
 
-static std::optional<std::pair<Field, Field>> getWideIntegerStatistics(
-    const parq::ColumnMetaData & column_meta, WideIntegerStatisticsType expected_type)
+static std::optional<WideIntegerStatistics> parseWideIntegerStatistics(
+    const parq::ColumnMetaData & column_meta,
+    std::string_view metadata_key,
+    WideIntegerStatisticsType expected_type,
+    size_t num_ranges,
+    bool allow_empty_ranges)
 {
     if (expected_type == WideIntegerStatisticsType::None || !column_meta.__isset.key_value_metadata)
         return std::nullopt;
@@ -66,20 +73,22 @@ static std::optional<std::pair<Field, Field>> getWideIntegerStatistics(
     const parq::KeyValue * metadata = nullptr;
     for (const auto & key_value : column_meta.key_value_metadata)
     {
-        if (key_value.key != WIDE_INTEGER_STATISTICS_KEY)
+        if (key_value.key != metadata_key)
             continue;
         if (metadata)
-            throw Exception(ErrorCodes::INCORRECT_DATA, "Duplicate `{}` metadata", WIDE_INTEGER_STATISTICS_KEY);
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Duplicate `{}` metadata", metadata_key);
         metadata = &key_value;
     }
 
     if (!metadata)
         return std::nullopt;
     if (!metadata->__isset.value)
-        throw Exception(ErrorCodes::INCORRECT_DATA, "Metadata `{}` has no value", WIDE_INTEGER_STATISTICS_KEY);
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Metadata `{}` has no value", metadata_key);
+    if (num_ranges > (std::numeric_limits<size_t>::max() - 2) / 2)
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Too many ranges in `{}` metadata", metadata_key);
 
     std::string_view value = metadata->value;
-    std::array<std::string_view, 4> fields;
+    std::vector<std::string_view> fields(num_ranges * 2 + 2);
     size_t begin = 0;
     for (size_t i = 0; i < fields.size(); ++i)
     {
@@ -87,12 +96,12 @@ static std::optional<std::pair<Field, Field>> getWideIntegerStatistics(
         if (i + 1 == fields.size())
         {
             if (end != std::string_view::npos)
-                throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid `{}` metadata value", WIDE_INTEGER_STATISTICS_KEY);
+                throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid `{}` metadata value", metadata_key);
             end = value.size();
         }
         else if (end == std::string_view::npos)
         {
-            throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid `{}` metadata value", WIDE_INTEGER_STATISTICS_KEY);
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid `{}` metadata value", metadata_key);
         }
 
         fields[i] = value.substr(begin, end - begin);
@@ -103,27 +112,50 @@ static std::optional<std::pair<Field, Field>> getWideIntegerStatistics(
         throw Exception(
             ErrorCodes::INCORRECT_DATA,
             "Unsupported `{}` metadata version `{}`",
-            WIDE_INTEGER_STATISTICS_KEY,
+            metadata_key,
             fields[0]);
 
-    auto parse = [&]<typename T>(std::string_view expected_name) -> std::pair<Field, Field>
+    auto parse = [&]<typename T>(std::string_view expected_name) -> WideIntegerStatistics
     {
         if (fields[1] != expected_name)
             throw Exception(
                 ErrorCodes::INCORRECT_DATA,
                 "Metadata `{}` has type `{}`, expected `{}`",
-                WIDE_INTEGER_STATISTICS_KEY,
+                metadata_key,
                 fields[1],
                 expected_name);
 
-        T min = parseFromString<T>(fields[2]);
-        T max = parseFromString<T>(fields[3]);
-        if (min > max)
-            throw Exception(
-                ErrorCodes::INCORRECT_DATA,
-                "Metadata `{}` has minimum greater than maximum",
-                WIDE_INTEGER_STATISTICS_KEY);
-        return {Field(min), Field(max)};
+        WideIntegerStatistics result;
+        result.reserve(num_ranges);
+        for (size_t range_idx = 0; range_idx < num_ranges; ++range_idx)
+        {
+            std::string_view min_string = fields[range_idx * 2 + 2];
+            std::string_view max_string = fields[range_idx * 2 + 3];
+            if (min_string.empty() || max_string.empty())
+            {
+                if (allow_empty_ranges && min_string.empty() && max_string.empty())
+                {
+                    result.emplace_back(std::nullopt);
+                    continue;
+                }
+                throw Exception(
+                    ErrorCodes::INCORRECT_DATA,
+                    "Metadata `{}` has an incomplete range {}",
+                    metadata_key,
+                    range_idx);
+            }
+
+            T min = parseFromString<T>(min_string);
+            T max = parseFromString<T>(max_string);
+            if (min > max)
+                throw Exception(
+                    ErrorCodes::INCORRECT_DATA,
+                    "Metadata `{}` has minimum greater than maximum for range {}",
+                    metadata_key,
+                    range_idx);
+            result.emplace_back(std::pair<Field, Field>{Field(min), Field(max)});
+        }
+        return result;
     };
 
     switch (expected_type)
@@ -133,6 +165,39 @@ static std::optional<std::pair<Field, Field>> getWideIntegerStatistics(
         case WideIntegerStatisticsType::None: break;
     }
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected wide integer statistics type");
+}
+
+static std::optional<std::pair<Field, Field>> getWideIntegerStatistics(
+    const parq::ColumnMetaData & column_meta, WideIntegerStatisticsType expected_type)
+{
+    auto statistics = parseWideIntegerStatistics(
+        column_meta, WIDE_INTEGER_STATISTICS_KEY, expected_type, 1, /*allow_empty_ranges=*/ false);
+    if (!statistics)
+        return std::nullopt;
+    return std::move(statistics->front());
+}
+
+static bool hasWideIntegerPageStatistics(
+    const parq::ColumnMetaData & column_meta, WideIntegerStatisticsType expected_type)
+{
+    if (expected_type == WideIntegerStatisticsType::None || !column_meta.__isset.key_value_metadata)
+        return false;
+
+    return std::any_of(
+        column_meta.key_value_metadata.begin(),
+        column_meta.key_value_metadata.end(),
+        [](const parq::KeyValue & key_value) { return key_value.key == WIDE_INTEGER_PAGE_STATISTICS_KEY; });
+}
+
+static std::optional<WideIntegerStatistics> getWideIntegerPageStatistics(
+    const parq::ColumnMetaData & column_meta, WideIntegerStatisticsType expected_type, size_t num_pages)
+{
+    return parseWideIntegerStatistics(
+        column_meta,
+        WIDE_INTEGER_PAGE_STATISTICS_KEY,
+        expected_type,
+        num_pages,
+        /*allow_empty_ranges=*/ true);
 }
 
 static Field getStatisticsDefault(const Reader::PrimitiveColumnInfo & column_info)
@@ -579,9 +644,24 @@ void Reader::prefilterAndInitRowGroups(const std::optional<std::unordered_set<UI
                 continue;
             const OutputColumnInfo & output_info = output_columns[output_idx.value()];
 
-            if (!output_info.is_primitive || !primitive_columns[output_info.primitive_start].decoder.allow_stats)
+            if (!output_info.is_primitive)
                 continue;
-            primitive_columns[output_info.primitive_start].column_index_condition = key_condition.get();
+
+            size_t primitive_idx = output_info.primitive_start;
+            PrimitiveColumnInfo & column_info = primitive_columns[primitive_idx];
+            bool has_usable_statistics = column_info.decoder.allow_stats
+                || std::any_of(
+                    row_groups.begin(),
+                    row_groups.end(),
+                    [&](const RowGroup & row_group)
+                    {
+                        return hasWideIntegerPageStatistics(
+                            row_group.columns.at(primitive_idx).meta->meta_data,
+                            column_info.decoder.wide_integer_statistics_type);
+                    });
+            if (!has_usable_statistics)
+                continue;
+            column_info.column_index_condition = key_condition.get();
         }
     }
 
@@ -817,7 +897,12 @@ void Reader::initializePrefetches()
             }
 
             /// Column index.
-            column.use_column_index = primitive_columns[column_idx].column_index_condition
+            const PrimitiveColumnInfo & column_info = primitive_columns[column_idx];
+            bool has_usable_statistics = column_info.decoder.allow_stats
+                || hasWideIntegerPageStatistics(
+                    column.meta->meta_data, column_info.decoder.wide_integer_statistics_type);
+            column.use_column_index = column_info.column_index_condition
+                && has_usable_statistics
                 && column.offset_index_prefetch
                 && column.meta->__isset.column_index_offset && column.meta->__isset.column_index_length;
             if (column.use_column_index)
@@ -1640,8 +1725,12 @@ void Reader::applyColumnIndex(ColumnChunk & column, const PrimitiveColumnInfo & 
             (column_index.__isset.null_counts && column_index.null_counts.size() != num_pages))
             throw Exception(ErrorCodes::INCORRECT_DATA, "Unexpected number of pages: {} null_pages, {} null_counts, {} min_values, {} max_values, {} pages in offset index", column_index.null_pages.size(), column_index.null_counts.size(), column_index.min_values.size(), column_index.max_values.size(), num_pages);
 
+        auto wide_integer_page_statistics = getWideIntegerPageStatistics(
+            column.meta->meta_data, column_info.decoder.wide_integer_statistics_type, num_pages);
+
         Hyperrectangle hyperrectangle(extended_sample_block.columns(), Range::createWholeUniverse());
         size_t prev_row_idx = 0; // start of the latest range of rows that pass filter
+        size_t num_pruned_pages = 0;
         for (size_t page_idx = 0; page_idx < num_pages; ++page_idx)
         {
             Range & range = hyperrectangle[column_info.idx_in_output_block];
@@ -1649,6 +1738,15 @@ void Reader::applyColumnIndex(ColumnChunk & column, const PrimitiveColumnInfo & 
 
             bool always_null = !column_index.null_pages.empty() && column_index.null_pages[page_idx];
             bool can_be_null = !column_index.__isset.null_counts || column_index.null_counts[page_idx] != 0;
+            const std::optional<std::pair<Field, Field>> * wide_integer_page_range
+                = wide_integer_page_statistics ? &wide_integer_page_statistics->at(page_idx) : nullptr;
+
+            if (wide_integer_page_range && always_null != !wide_integer_page_range->has_value())
+                throw Exception(
+                    ErrorCodes::INCORRECT_DATA,
+                    "Metadata `{}` disagrees with null_pages for page {}",
+                    WIDE_INTEGER_PAGE_STATISTICS_KEY,
+                    page_idx);
 
             if (nullable && always_null)
             {
@@ -1660,8 +1758,16 @@ void Reader::applyColumnIndex(ColumnChunk & column, const PrimitiveColumnInfo & 
             }
             else
             {
-                column_info.decoder.decodeField(column_index.min_values[page_idx], /*is_max=*/ false, range.left);
-                column_info.decoder.decodeField(column_index.max_values[page_idx], /*is_max=*/ true, range.right);
+                if (wide_integer_page_range && wide_integer_page_range->has_value())
+                {
+                    range.left = wide_integer_page_range->value().first;
+                    range.right = wide_integer_page_range->value().second;
+                }
+                else
+                {
+                    column_info.decoder.decodeField(column_index.min_values[page_idx], /*is_max=*/ false, range.left);
+                    column_info.decoder.decodeField(column_index.max_values[page_idx], /*is_max=*/ true, range.right);
+                }
 
                 adjustRangeFromIndexIfNeeded(range, column_info, can_be_null);
             }
@@ -1671,6 +1777,7 @@ void Reader::applyColumnIndex(ColumnChunk & column, const PrimitiveColumnInfo & 
 
             if (!passes_filter)
             {
+                ++num_pruned_pages;
                 size_t start_row = column.offset_index.page_locations[page_idx].first_row_index;
                 size_t end_row = page_idx + 1 < num_pages ? column.offset_index.page_locations[page_idx + 1].first_row_index : row_group.meta->num_rows;
                 chassert(end_row > start_row); // validated in decodeOffsetIndex
@@ -1682,6 +1789,8 @@ void Reader::applyColumnIndex(ColumnChunk & column, const PrimitiveColumnInfo & 
 
         if (size_t(row_group.meta->num_rows) > prev_row_idx)
             column.row_ranges_after_column_index.emplace_back(prev_row_idx, row_group.meta->num_rows);
+
+        ProfileEvents::increment(ProfileEvents::ParquetPrunedPages, num_pruned_pages);
     }
     catch (Exception & e)
     {

--- a/src/Processors/Formats/Impl/Parquet/SchemaConverter.cpp
+++ b/src/Processors/Formats/Impl/Parquet/SchemaConverter.cpp
@@ -1419,6 +1419,10 @@ void SchemaConverter::processPrimitiveColumn(
                     type_hint->getSizeOfValueInMemory() == size_t(element.type_length))
                 {
                     out_inferred_type = type_hint;
+                    if (which.idx == TypeIndex::UInt128)
+                        out_decoder.wide_integer_statistics_type = PageDecoderInfo::WideIntegerStatisticsType::UInt128;
+                    else if (which.idx == TypeIndex::UInt256)
+                        out_decoder.wide_integer_statistics_type = PageDecoderInfo::WideIntegerStatisticsType::UInt256;
                 }
             }
 

--- a/src/Processors/Formats/Impl/Parquet/Write.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Write.cpp
@@ -198,6 +198,79 @@ struct StatisticsFixedStringCopy
     }
 };
 
+inline constexpr std::string_view WIDE_INTEGER_STATISTICS_KEY = "clickhouse.wide_integer_statistics";
+
+/// Parquet orders an unannotated `FIXED_LEN_BYTE_ARRAY` lexicographically, while ClickHouse's
+/// legacy wide-integer payload is little-endian. Keep standards-compliant physical statistics and
+/// additionally accumulate numeric bounds for ClickHouse readers.
+template <typename T>
+struct StatisticsWideUnsignedInteger
+{
+    static_assert(std::is_same_v<T, UInt128> || std::is_same_v<T, UInt256>);
+
+    StatisticsFixedStringCopy<sizeof(T), /*SIGNED=*/ false> physical;
+    bool empty = true;
+    T min {};
+    T max {};
+
+    void add(parquet::FixedLenByteArray a)
+    {
+        physical.add(a);
+
+        T value;
+        memcpy(&value, a.ptr, sizeof(value));
+        if (empty)
+        {
+            min = value;
+            max = value;
+            empty = false;
+        }
+        else
+        {
+            min = std::min(min, value);
+            max = std::max(max, value);
+        }
+    }
+
+    void merge(const StatisticsWideUnsignedInteger & s)
+    {
+        physical.merge(s.physical);
+        if (s.empty)
+            return;
+        if (empty)
+        {
+            min = s.min;
+            max = s.max;
+            empty = false;
+        }
+        else
+        {
+            min = std::min(min, s.min);
+            max = std::max(max, s.max);
+        }
+    }
+
+    void clear()
+    {
+        physical.clear();
+        empty = true;
+    }
+
+    parq::Statistics get(const WriteOptions & options) const
+    {
+        return physical.get(options);
+    }
+
+    std::optional<String> getWideIntegerStatisticsMetadata() const
+    {
+        if (empty)
+            return std::nullopt;
+
+        constexpr std::string_view type_name = std::is_same_v<T, UInt128> ? "UInt128" : "UInt256";
+        return fmt::format("1;{};{};{}", type_name, DB::toString(min), DB::toString(max));
+    }
+};
+
 struct StatisticsStringRef
 {
     parquet::ByteArray min;
@@ -535,12 +608,12 @@ struct ConverterFixedStringAsString
     }
 };
 
-template <typename T>
+template <typename T, typename StatisticsType = StatisticsFixedStringCopy<sizeof(T), /*SIGNED=*/ false>>
 struct ConverterNumberAsFixedString
 {
     /// Calculate min/max statistics for little-endian fixed strings, not numbers, because parquet
     /// doesn't know it's numbers.
-    using Statistics = StatisticsFixedStringCopy<sizeof(T), /*SIGNED=*/ false>;
+    using Statistics = StatisticsType;
 
     const ColumnVector<T> & column;
     PODArray<parquet::FixedLenByteArray> buf;
@@ -1197,6 +1270,18 @@ void writeColumnImpl(
 
         if (s.max_def == 1 && s.max_rep == 0)
             s.column_chunk.meta_data.statistics.__set_null_count(static_cast<Int64>(def_offset - data_offset));
+
+        if constexpr (requires { total_statistics.getWideIntegerStatisticsMetadata(); })
+        {
+            if (auto metadata = total_statistics.getWideIntegerStatisticsMetadata())
+            {
+                parq::KeyValue key_value;
+                key_value.__set_key(String(WIDE_INTEGER_STATISTICS_KEY));
+                key_value.__set_value(std::move(*metadata));
+                s.column_chunk.meta_data.key_value_metadata.push_back(std::move(key_value));
+                s.column_chunk.meta_data.__isset.key_value_metadata = true;
+            }
+        }
     }
 
     /// Report which encodings we've used.
@@ -1333,8 +1418,16 @@ void writeColumnChunkBody(
         #define F(source_type) \
             writeColumnImpl<parquet::FLBAType>( \
                 s, options, out, ConverterNumberAsFixedString<source_type>(s.primitive_column))
-        case TypeIndex::UInt128: F(UInt128); break;
-        case TypeIndex::UInt256: F(UInt256); break;
+        case TypeIndex::UInt128:
+            writeColumnImpl<parquet::FLBAType>(
+                s, options, out,
+                ConverterNumberAsFixedString<UInt128, StatisticsWideUnsignedInteger<UInt128>>(s.primitive_column));
+            break;
+        case TypeIndex::UInt256:
+            writeColumnImpl<parquet::FLBAType>(
+                s, options, out,
+                ConverterNumberAsFixedString<UInt256, StatisticsWideUnsignedInteger<UInt256>>(s.primitive_column));
+            break;
         case TypeIndex::Int128:  F(Int128); break;
         case TypeIndex::Int256:  F(Int256); break;
         case TypeIndex::IPv6:    F(IPv6); break;

--- a/src/Processors/Formats/Impl/Parquet/Write.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Write.cpp
@@ -199,6 +199,7 @@ struct StatisticsFixedStringCopy
 };
 
 inline constexpr std::string_view WIDE_INTEGER_STATISTICS_KEY = "clickhouse.wide_integer_statistics";
+inline constexpr std::string_view WIDE_INTEGER_PAGE_STATISTICS_KEY = "clickhouse.wide_integer_page_statistics";
 
 /// Parquet orders an unannotated `FIXED_LEN_BYTE_ARRAY` lexicographically, while ClickHouse's
 /// legacy wide-integer payload is little-endian. Keep standards-compliant physical statistics and
@@ -217,7 +218,7 @@ struct StatisticsWideUnsignedInteger
     {
         physical.add(a);
 
-        T value;
+        T value {};
         memcpy(&value, a.ptr, sizeof(value));
         if (empty)
         {
@@ -268,6 +269,20 @@ struct StatisticsWideUnsignedInteger
 
         constexpr std::string_view type_name = std::is_same_v<T, UInt128> ? "UInt128" : "UInt256";
         return fmt::format("1;{};{};{}", type_name, DB::toString(min), DB::toString(max));
+    }
+
+    void appendWideIntegerPageStatisticsMetadata(String & metadata) const
+    {
+        constexpr std::string_view type_name = std::is_same_v<T, UInt128> ? "UInt128" : "UInt256";
+        if (metadata.empty())
+            metadata = fmt::format("1;{}", type_name);
+
+        metadata += ';';
+        if (!empty)
+            metadata += DB::toString(min);
+        metadata += ';';
+        if (!empty)
+            metadata += DB::toString(max);
     }
 };
 
@@ -939,6 +954,7 @@ void writeColumnImpl(
 
     typename Converter::Statistics page_statistics;
     typename Converter::Statistics total_statistics;
+    String wide_integer_page_statistics_metadata;
 
     bool use_dictionary = options.use_dictionary_encoding && !s.is_bool;
 
@@ -1087,6 +1103,9 @@ void writeColumnImpl(
                 s.indexes.column_index.null_counts.emplace_back(page_stats.null_count);
             }
             s.indexes.column_index.null_pages.push_back(all_null_page);
+
+            if constexpr (requires { page_statistics.appendWideIntegerPageStatisticsMetadata(wide_integer_page_statistics_metadata); })
+                page_statistics.appendWideIntegerPageStatisticsMetadata(wide_integer_page_statistics_metadata);
         }
 
         total_statistics.merge(page_statistics);
@@ -1236,6 +1255,7 @@ void writeColumnImpl(
                 use_dictionary = false;
 
                 s.indexes = {};
+                wide_integer_page_statistics_metadata.clear();
                 /// (no need to clear hashes_for_bloom_filter)
 
 #ifndef NDEBUG
@@ -1282,6 +1302,15 @@ void writeColumnImpl(
                 s.column_chunk.meta_data.__isset.key_value_metadata = true;
             }
         }
+    }
+
+    if (!wide_integer_page_statistics_metadata.empty())
+    {
+        parq::KeyValue key_value;
+        key_value.__set_key(String(WIDE_INTEGER_PAGE_STATISTICS_KEY));
+        key_value.__set_value(wide_integer_page_statistics_metadata);
+        s.column_chunk.meta_data.key_value_metadata.push_back(std::move(key_value));
+        s.column_chunk.meta_data.__isset.key_value_metadata = true;
     }
 
     /// Report which encodings we've used.

--- a/tests/queries/0_stateless/04669_parquet_wide_unsigned_statistics.reference
+++ b/tests/queries/0_stateless/04669_parquet_wide_unsigned_statistics.reference
@@ -1,0 +1,20 @@
+round trip and numeric boundary values
+100	2100	2199
+100	2100	2199
+0	340282366920938463463374607431768211455	0	115792089237316195423570985008687907853269984665640564039457584007913129639935
+legacy little-endian payload
+01000000000000000100000000000000	0100000000000000000000000000000001000000000000000000000000000000
+UInt128 numeric statistics prune three row groups
+read=1 pruned=3
+UInt256 numeric statistics prune three row groups
+read=1 pruned=3
+nullable UInt128 statistics
+[2101]
+all-null UInt256 row group and numeric statistics prune every row group
+0
+read=0 pruned=4
+files without numeric statistics retain legacy behavior
+100
+read=4 pruned=0
+malformed numeric statistics are rejected
+rejected

--- a/tests/queries/0_stateless/04669_parquet_wide_unsigned_statistics.reference
+++ b/tests/queries/0_stateless/04669_parquet_wide_unsigned_statistics.reference
@@ -13,8 +13,21 @@ nullable UInt128 statistics
 all-null UInt256 row group and numeric statistics prune every row group
 0
 read=0 pruned=4
+UInt128 numeric page statistics prune fifteen pages
+[2100]
+pruned=15
+UInt256 numeric page statistics prune fifteen pages
+[2100]
+pruned=15
+nullable UInt256 numeric page statistics include an all-null page
+[300]
+pruned=15
+files without numeric page statistics retain legacy behavior
+pruned=0
 files without numeric statistics retain legacy behavior
 100
 read=4 pruned=0
 malformed numeric statistics are rejected
+rejected
+malformed numeric page statistics are rejected
 rejected

--- a/tests/queries/0_stateless/04669_parquet_wide_unsigned_statistics.sh
+++ b/tests/queries/0_stateless/04669_parquet_wide_unsigned_statistics.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: needs the Parquet format, which is not built in fasttest.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+DATA_FILE="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_data.parquet"
+CORRUPT_FILE="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_corrupt.parquet"
+LEGACY_FILE="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_legacy.parquet"
+trap 'rm -f "${DATA_FILE}" "${CORRUPT_FILE}" "${LEGACY_FILE}"' EXIT
+
+# Four row groups whose numeric ranges are disjoint but whose little-endian byte ranges are not
+# useful as numeric bounds. The last group also reaches the maximum value of each type.
+${CLICKHOUSE_LOCAL} --query="
+    SELECT
+        multiIf(
+            intDiv(number, 1000) = 0, toUInt128(number % 1000),
+            intDiv(number, 1000) = 1, bitShiftLeft(toUInt128(1), 64) + toUInt128(number % 1000),
+            intDiv(number, 1000) = 2, bitShiftLeft(toUInt128(1), 127) + toUInt128(number % 1000),
+            toUInt128(toUInt128('340282366920938463463374607431768211455') - toUInt128(999) + toUInt128(number % 1000))) AS u128,
+        multiIf(
+            intDiv(number, 1000) = 0, toUInt256(number % 1000),
+            intDiv(number, 1000) = 1, bitShiftLeft(toUInt256(1), 128) + toUInt256(number % 1000),
+            intDiv(number, 1000) = 2, bitShiftLeft(toUInt256(1), 255) + toUInt256(number % 1000),
+            toUInt256(toUInt256('115792089237316195423570985008687907853269984665640564039457584007913129639935') - toUInt256(999) + toUInt256(number % 1000))) AS u256,
+        if(number % 10 = 0, NULL, u128)::Nullable(UInt128) AS u128_nullable,
+        if(intDiv(number, 1000) = 0, NULL, u256)::Nullable(UInt256) AS u256_nullable,
+        number AS n
+    FROM numbers(4000)
+    SETTINGS
+        output_format_parquet_row_group_size = 1000,
+        output_format_parquet_max_dictionary_size = 0,
+        max_block_size = 1000000
+    FORMAT Parquet
+" > "${DATA_FILE}"
+
+STRUCTURE="u128 UInt128, u256 UInt256, u128_nullable Nullable(UInt128), u256_nullable Nullable(UInt256), n UInt64"
+RAW_STRUCTURE="u128 FixedString(16), u256 FixedString(32), u128_nullable Nullable(FixedString(16)), u256_nullable Nullable(FixedString(32)), n UInt64"
+
+echo "round trip and numeric boundary values"
+${CLICKHOUSE_LOCAL} --multiquery --query="
+    SELECT count(), min(n), max(n)
+    FROM file('${DATA_FILE}', Parquet, '${STRUCTURE}')
+    WHERE u128 BETWEEN bitShiftLeft(toUInt128(1), 127) + 100 AND bitShiftLeft(toUInt128(1), 127) + 199;
+    SELECT count(), min(n), max(n)
+    FROM file('${DATA_FILE}', Parquet, '${STRUCTURE}')
+    WHERE u256 BETWEEN bitShiftLeft(toUInt256(1), 255) + 100 AND bitShiftLeft(toUInt256(1), 255) + 199;
+    SELECT min(u128), max(u128), min(u256), max(u256)
+    FROM file('${DATA_FILE}', Parquet, '${STRUCTURE}');
+"
+
+echo "legacy little-endian payload"
+${CLICKHOUSE_LOCAL} --query="
+    SELECT hex(u128), hex(u256)
+    FROM file('${DATA_FILE}', Parquet, '${RAW_STRUCTURE}')
+    WHERE n = 1001;
+"
+
+CH="${CLICKHOUSE_LOCAL} --input_format_parquet_filter_push_down=1 --input_format_parquet_page_filter_push_down=0 --input_format_parquet_bloom_filter_push_down=0 --optimize_move_to_prewhere=0 --use_cache_for_count_from_files=0"
+
+profile_row_groups() {
+    local query="$1"
+    ${CH} --print-profile-events --query="${query} FORMAT Null" 2>&1 | awk '
+        /ParquetReadRowGroups:/   { read += $(NF-1) }
+        /ParquetPrunedRowGroups:/ { pruned += $(NF-1) }
+        END { print "read=" read+0 " pruned=" pruned+0 }
+    '
+}
+
+echo "UInt128 numeric statistics prune three row groups"
+profile_row_groups "
+    SELECT * FROM file('${DATA_FILE}', Parquet, '${STRUCTURE}')
+    WHERE u128 BETWEEN bitShiftLeft(toUInt128(1), 127) + 100 AND bitShiftLeft(toUInt128(1), 127) + 199"
+
+echo "UInt256 numeric statistics prune three row groups"
+profile_row_groups "
+    SELECT * FROM file('${DATA_FILE}', Parquet, '${STRUCTURE}')
+    WHERE u256 BETWEEN bitShiftLeft(toUInt256(1), 255) + 100 AND bitShiftLeft(toUInt256(1), 255) + 199"
+
+echo "nullable UInt128 statistics"
+${CLICKHOUSE_LOCAL} --query="
+    SELECT groupArray(n)
+    FROM file('${DATA_FILE}', Parquet, '${STRUCTURE}')
+    WHERE u128_nullable = bitShiftLeft(toUInt128(1), 127) + 101;
+"
+
+echo "all-null UInt256 row group and numeric statistics prune every row group"
+${CLICKHOUSE_LOCAL} --query="
+    SELECT count()
+    FROM file('${DATA_FILE}', Parquet, '${STRUCTURE}')
+    WHERE u256_nullable = toUInt256(1);
+"
+profile_row_groups "
+    SELECT * FROM file('${DATA_FILE}', Parquet, '${STRUCTURE}')
+    WHERE u256_nullable = toUInt256(1)"
+
+echo "files without numeric statistics retain legacy behavior"
+cp "${DATA_FILE}" "${LEGACY_FILE}"
+perl -0pi -e 's/clickhouse\.wide_integer_statistics/xlickhouse.wide_integer_statistics/g' "${LEGACY_FILE}"
+${CLICKHOUSE_LOCAL} --query="
+    SELECT count()
+    FROM file('${LEGACY_FILE}', Parquet, '${STRUCTURE}')
+    WHERE u128 BETWEEN bitShiftLeft(toUInt128(1), 127) + 100 AND bitShiftLeft(toUInt128(1), 127) + 199;
+"
+profile_row_groups "
+    SELECT * FROM file('${LEGACY_FILE}', Parquet, '${STRUCTURE}')
+    WHERE u128 BETWEEN bitShiftLeft(toUInt128(1), 127) + 100 AND bitShiftLeft(toUInt128(1), 127) + 199"
+
+echo "malformed numeric statistics are rejected"
+cp "${DATA_FILE}" "${CORRUPT_FILE}"
+perl -0pi -e 's/1;UInt128;/9;UInt128;/' "${CORRUPT_FILE}"
+if error=$(${CLICKHOUSE_LOCAL} --query="
+    SELECT count()
+    FROM file('${CORRUPT_FILE}', Parquet, '${STRUCTURE}')
+    WHERE u128 = toUInt128(1)
+" 2>&1); then
+    echo "unexpected success"
+elif grep -q 'Unsupported.*wide_integer_statistics.*version' <<< "${error}"; then
+    echo "rejected"
+else
+    echo "${error}"
+fi

--- a/tests/queries/0_stateless/04669_parquet_wide_unsigned_statistics.sh
+++ b/tests/queries/0_stateless/04669_parquet_wide_unsigned_statistics.sh
@@ -9,7 +9,10 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 DATA_FILE="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_data.parquet"
 CORRUPT_FILE="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_corrupt.parquet"
 LEGACY_FILE="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_legacy.parquet"
-trap 'rm -f "${DATA_FILE}" "${CORRUPT_FILE}" "${LEGACY_FILE}"' EXIT
+PAGE_FILE="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_pages.parquet"
+CORRUPT_PAGE_FILE="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_corrupt_pages.parquet"
+LEGACY_PAGE_FILE="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_legacy_pages.parquet"
+trap 'rm -f "${DATA_FILE}" "${CORRUPT_FILE}" "${LEGACY_FILE}" "${PAGE_FILE}" "${CORRUPT_PAGE_FILE}" "${LEGACY_PAGE_FILE}"' EXIT
 
 # Four row groups whose numeric ranges are disjoint but whose little-endian byte ranges are not
 # useful as numeric bounds. The last group also reaches the maximum value of each type.
@@ -36,8 +39,27 @@ ${CLICKHOUSE_LOCAL} --query="
     FORMAT Parquet
 " > "${DATA_FILE}"
 
+# One row group with 16 pages per wide-integer column. The final nullable page is all null.
+${CLICKHOUSE_LOCAL} --query="
+    SELECT
+        bitShiftLeft(toUInt128(1), 127) + toUInt128(number) AS u128,
+        bitShiftLeft(toUInt256(1), 255) + toUInt256(number) AS u256,
+        if(number >= 3840, NULL, u256)::Nullable(UInt256) AS u256_nullable,
+        number AS n
+    FROM numbers(4096)
+    SETTINGS
+        output_format_parquet_row_group_size = 100000,
+        output_format_parquet_data_page_size = 4096,
+        output_format_parquet_batch_size = 256,
+        output_format_parquet_max_dictionary_size = 0,
+        output_format_parquet_write_page_index = 1,
+        max_block_size = 1000000
+    FORMAT Parquet
+" > "${PAGE_FILE}"
+
 STRUCTURE="u128 UInt128, u256 UInt256, u128_nullable Nullable(UInt128), u256_nullable Nullable(UInt256), n UInt64"
 RAW_STRUCTURE="u128 FixedString(16), u256 FixedString(32), u128_nullable Nullable(FixedString(16)), u256_nullable Nullable(FixedString(32)), n UInt64"
+PAGE_STRUCTURE="u128 UInt128, u256 UInt256, u256_nullable Nullable(UInt256), n UInt64"
 
 echo "round trip and numeric boundary values"
 ${CLICKHOUSE_LOCAL} --multiquery --query="
@@ -69,6 +91,27 @@ profile_row_groups() {
     '
 }
 
+profile_pruned_pages() {
+    local query="$1"
+    local profile
+    if ! profile=$(${CLICKHOUSE_LOCAL} \
+            --input_format_parquet_filter_push_down=1 \
+            --input_format_parquet_page_filter_push_down=1 \
+            --input_format_parquet_bloom_filter_push_down=0 \
+            --input_format_parquet_use_offset_index=0 \
+            --optimize_move_to_prewhere=0 \
+            --use_cache_for_count_from_files=0 \
+            --print-profile-events \
+            --query="${query} FORMAT Null" 2>&1); then
+        echo "${profile}" >&2
+        return 1
+    fi
+    awk '
+        /ParquetPrunedPages:/ { pruned += $(NF-1) }
+        END { print "pruned=" pruned+0 }
+    ' <<< "${profile}"
+}
+
 echo "UInt128 numeric statistics prune three row groups"
 profile_row_groups "
     SELECT * FROM file('${DATA_FILE}', Parquet, '${STRUCTURE}')
@@ -96,9 +139,47 @@ profile_row_groups "
     SELECT * FROM file('${DATA_FILE}', Parquet, '${STRUCTURE}')
     WHERE u256_nullable = toUInt256(1)"
 
+echo "UInt128 numeric page statistics prune fifteen pages"
+${CLICKHOUSE_LOCAL} --query="
+    SELECT groupArray(n)
+    FROM file('${PAGE_FILE}', Parquet, '${PAGE_STRUCTURE}')
+    WHERE u128 = bitShiftLeft(toUInt128(1), 127) + toUInt128(2100)
+"
+profile_pruned_pages "
+    SELECT * FROM file('${PAGE_FILE}', Parquet, '${PAGE_STRUCTURE}')
+    WHERE u128 = bitShiftLeft(toUInt128(1), 127) + toUInt128(2100)"
+
+echo "UInt256 numeric page statistics prune fifteen pages"
+${CLICKHOUSE_LOCAL} --query="
+    SELECT groupArray(n)
+    FROM file('${PAGE_FILE}', Parquet, '${PAGE_STRUCTURE}')
+    WHERE u256 = bitShiftLeft(toUInt256(1), 255) + toUInt256(2100)
+"
+profile_pruned_pages "
+    SELECT * FROM file('${PAGE_FILE}', Parquet, '${PAGE_STRUCTURE}')
+    WHERE u256 = bitShiftLeft(toUInt256(1), 255) + toUInt256(2100)"
+
+echo "nullable UInt256 numeric page statistics include an all-null page"
+${CLICKHOUSE_LOCAL} --query="
+    SELECT groupArray(n)
+    FROM file('${PAGE_FILE}', Parquet, '${PAGE_STRUCTURE}')
+    WHERE u256_nullable = bitShiftLeft(toUInt256(1), 255) + toUInt256(300)
+"
+profile_pruned_pages "
+    SELECT * FROM file('${PAGE_FILE}', Parquet, '${PAGE_STRUCTURE}')
+    WHERE u256_nullable = bitShiftLeft(toUInt256(1), 255) + toUInt256(300)"
+
+echo "files without numeric page statistics retain legacy behavior"
+cp "${PAGE_FILE}" "${LEGACY_PAGE_FILE}"
+perl -0pi -e 's/clickhouse\.wide_integer_page_statistics/xlickhouse.wide_integer_page_statistics/g' "${LEGACY_PAGE_FILE}"
+profile_pruned_pages "
+    SELECT * FROM file('${LEGACY_PAGE_FILE}', Parquet, '${PAGE_STRUCTURE}')
+    WHERE u128 = bitShiftLeft(toUInt128(1), 127) + toUInt128(2100)"
+
 echo "files without numeric statistics retain legacy behavior"
 cp "${DATA_FILE}" "${LEGACY_FILE}"
 perl -0pi -e 's/clickhouse\.wide_integer_statistics/xlickhouse.wide_integer_statistics/g' "${LEGACY_FILE}"
+perl -0pi -e 's/clickhouse\.wide_integer_page_statistics/xlickhouse.wide_integer_page_statistics/g' "${LEGACY_FILE}"
 ${CLICKHOUSE_LOCAL} --query="
     SELECT count()
     FROM file('${LEGACY_FILE}', Parquet, '${STRUCTURE}')
@@ -118,6 +199,26 @@ if error=$(${CLICKHOUSE_LOCAL} --query="
 " 2>&1); then
     echo "unexpected success"
 elif grep -q 'Unsupported.*wide_integer_statistics.*version' <<< "${error}"; then
+    echo "rejected"
+else
+    echo "${error}"
+fi
+
+echo "malformed numeric page statistics are rejected"
+cp "${PAGE_FILE}" "${CORRUPT_PAGE_FILE}"
+perl -0pi -e 's/1;UInt128;/9;UInt128;/g' "${CORRUPT_PAGE_FILE}"
+if error=$(${CLICKHOUSE_LOCAL} \
+    --input_format_parquet_filter_push_down=0 \
+    --input_format_parquet_page_filter_push_down=1 \
+    --input_format_parquet_bloom_filter_push_down=0 \
+    --query="
+        SELECT *
+        FROM file('${CORRUPT_PAGE_FILE}', Parquet, '${PAGE_STRUCTURE}')
+        WHERE u128 = bitShiftLeft(toUInt128(1), 127) + toUInt128(2100)
+        FORMAT Null
+    " 2>&1); then
+    echo "unexpected success"
+elif grep -q 'Unsupported.*wide_integer_page_statistics.*version' <<< "${error}"; then
     echo "rejected"
 else
     echo "${error}"


### PR DESCRIPTION
Wide integers are serialized as `FIXED_LEN_BYTE_ARRAY`, which is little-endian. This makes min/max statistics unusable for row group filtering. Here we add custom stats that are numeric, which are usable for pruning:

```
key:   clickhouse.wide_integer_statistics
value: 1;UInt128;<decimal-min>;<decimal-max>
```

This does not interfere with any other consumer of Parquet files.

The added test fails to prune before the change.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add custom stats for UInt128 and UInt256 in Parquet serializer to allow pruning row groups and pages at query time.