### PR TITLE
Limit random index_granularity in 03246_alter_from_string_to_json

### DIFF
--- a/tests/queries/0_stateless/03246_alter_from_string_to_json.sql.j2
+++ b/tests/queries/0_stateless/03246_alter_from_string_to_json.sql.j2
@@ -1,5 +1,9 @@
--- Random settings limits: index_granularity=(100, 60000); index_granularity_bytes=(10000, None)
+-- Random settings limits: index_granularity=(8192, 60000); index_granularity_bytes=(102400, None)
 -- Tags: long
+-- After the ALTER the `json` column has ~97 substreams (typed paths plus every
+-- shared data bucket), and a compact part keeps one mark per granule per
+-- substream, so a tiny index_granularity multiplies the mark count by the
+-- substream count and makes this long test time out on sanitizer builds.
 
 SET enable_json_type = 1;
 set max_block_size = 20000;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/80743
Related: https://github.com/ClickHouse/ClickHouse/pull/94101
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/80743
Related: https://github.com/ClickHouse/ClickHouse/pull/94101

`03246_alter_from_string_to_json` timed out at 600 s on `amd_msan`, while the median duration of this test in the same job is 33.6 s and p99 is 87.5 s. The run itself was not slow: across all tests in that job the median duration ratio against the 30-day history is 1.09, so this is not host overload.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=c2c9039413b2e96f64fdbbdecaa23381fb9924df&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F2%29

`query_log` shows no hang - every statement made progress, but the first of the two `{% for %}` iterations alone needed 677 s: the mutation 134 s, `distinctJSONPaths` 98 s, `JSONSharedDataPaths` 101 s, `select json ... format Null` 109 s, and the test was killed inside the next query.

The cause is the randomized MergeTree settings for this run: `index_granularity=101` together with `object_shared_data_buckets_for_compact_part=27`. After `ALTER TABLE test MODIFY COLUMN json JSON` the column has 97 substreams (typed paths plus every shared data bucket), and a compact part keeps one mark per granule per substream, so the 200000-row part ended up with 1981 granules and ~192000 marks (`LoadedMarksCount` in `query_log` is 186214). Every scan then hops between substreams inside the single data file and re-decompresses the same blocks - `CompressedReadBufferBytes` is 48.5 MB for a 10.8 MB column. Reproduced locally on a release build: the whole test takes 12.7 s with `index_granularity=101` against 1.6 s with `index_granularity=8192` at the same bucket count, and MSan amplifies this mark-heavy path much more than average code.

Raise the randomized floor through the `Random settings limits` directive to `index_granularity=(8192, 60000)` and `index_granularity_bytes=(102400, None)`. This bounds the mark count at ~2400 while keeping both settings randomized. The previous floor of 100 came from #80743 and is too low for a column with this many substreams.

There is no open issue for this failure; the earlier one, https://github.com/ClickHouse/ClickHouse/issues/94006, was closed by #94101, which fixed a different cause (`merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability`).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.707` (included in `26.8` and later)
<!-- ch-version-info:end -->