### PR TITLE
Give the one-match case of 04650_replace_cancellation a deadline of its own

### DIFF
--- a/tests/queries/0_stateless/04650_replace_cancellation.sh
+++ b/tests/queries/0_stateless/04650_replace_cancellation.sh
@@ -15,14 +15,21 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # prologue is not interruptible by this fix and scales the other way on an optimized build.
 # A sanitizer or coverage build stretches both sides, so the bound scales; coverage never reaches
 # CXX_FLAGS and has to be read from its own `system.build_options` row.
-DEADLINE=1
+DEADLINE_MS=1000
 SCALE=1
 [ -n "$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS' AND value LIKE '%sanitize=%'")" ] && SCALE=2
 case "$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'WITH_COVERAGE'")" in ON|1) SCALE=2 ;; esac
 BOUND=$((SCALE * 2000))
+# What a bound allows on top of its deadline. A case that needs a deadline of its own keeps this
+# allowance rather than the bound itself, so shortening a deadline does not loosen the assertion with it.
+SLACK_MS=$((BOUND - DEADLINE_MS))
+# `max_execution_time` is given in seconds; every deadline here is a whole number of milliseconds.
+to_seconds() { printf '%d.%03d' "$(($1 / 1000))" "$(($1 % 1000))"; }
+DEADLINE=$(to_seconds "$DEADLINE_MS")
 
 # $1 = label, $2 = query, $3 = overflow mode (default "throw"), $4 = query id (default none),
-# $5 = "fold" if the call is constant-folded (no pipeline), empty for a pipeline case
+# $5 = "fold" if the call is constant-folded (no pipeline), empty for a pipeline case,
+# $6 = the deadline in milliseconds (default `DEADLINE_MS`)
 #
 # Regexp compilation is pinned off for every case but the one that is about the compiled matcher: the
 # compiled-regexp cache is server-global with a compile threshold of 3, and this test runs up to 5 times,
@@ -37,11 +44,12 @@ BOUND=$((SCALE * 2000))
 # would assert query-level cancellation instead of the in-function checkpoint. That is reported as
 # inconclusive rather than passed.
 run() {
-    local label="$1" query="$2" mode="${3:-throw}" query_id="${4:-}" shape="${5:-}"
+    local label="$1" query="$2" mode="${3:-throw}" query_id="${4:-}" shape="${5:-}" deadline_ms="${6:-$DEADLINE_MS}"
     local output start_ms elapsed_ms wall_ms
+    local bound=$((deadline_ms + SLACK_MS))
     start_ms=$(date +%s%N)
     # shellcheck disable=SC2086
-    output=$(timeout 600 ${CLICKHOUSE_CLIENT} --max_execution_time "$DEADLINE" --timeout_overflow_mode "$mode" \
+    output=$(timeout 600 ${CLICKHOUSE_CLIENT} --max_execution_time "$(to_seconds "$deadline_ms")" --timeout_overflow_mode "$mode" \
         --compile_regular_expressions 0 \
         ${query_id:+--query_id "$query_id"} \
         --query "$query" 2>&1)
@@ -49,7 +57,7 @@ run() {
     elapsed_ms=$(printf '%s' "$output" | grep -oP 'elapsed \K[0-9]+(?=\.)' | head -1)
     # A verdict rather than the number itself keeps the reference stable across machine speeds.
     if [ -n "$elapsed_ms" ]; then
-        if [ "$elapsed_ms" -lt "$BOUND" ]; then
+        if [ "$elapsed_ms" -lt "$bound" ]; then
             echo "$label: stopped within bound"
         else
             echo "$label: OVERSHOT ${elapsed_ms} ms"
@@ -58,7 +66,7 @@ run() {
         echo "$label: no timeout"
     elif [ "$shape" = fold ]; then
         # Wall clock covers the whole client call, not server time alone, hence case 19's allowance.
-        if [ "$wall_ms" -lt "$((BOUND * 2))" ]; then
+        if [ "$wall_ms" -lt "$((bound * 2))" ]; then
             echo "$label: stopped within bound"
         else
             echo "$label: OVERSHOT ${wall_ms} ms"
@@ -166,8 +174,19 @@ run "per-row replacement" \
 # 15. A SINGLE match whose instruction list is itself over budget, so charging the list only after the loop
 #     finished would leave one match uninterruptible. Case 10's list is short enough that the per-match
 #     charge alone fires.
+#     Every instruction writes another copy of the whole match, so what the case can offer is capped by
+#     what the result may occupy, and how much of it a stopped call has already written grows with the
+#     speed of the machine. At the standard deadline the list had to be short enough that a fast build
+#     stayed inside the 5GiB test profile and long enough that a slow one did not finish it, and no
+#     single length satisfied both. So the case takes a deadline of its own, a tenth of the standard
+#     one: that divides what is written by ten whatever the machine, and leaves room for a list two
+#     orders of magnitude longer than one deadline's worth of copying. The prologue - one 1MB value and
+#     a 40KB replacement - is still under a tenth of even this deadline on a sanitizer build.
+#     The one step that stays uninterruptible is not a copy but the result buffer's own doubling, so the
+#     reported time overshoots the deadline by about what has been written so far, not by the whole list.
 run "one match, long instruction list" \
-    "SELECT length(replaceRegexpAll(repeat('a', 1000000), '(.*)', repeat('\\\\1', 2000))) FORMAT Null" throw "" fold
+    "SELECT length(replaceRegexpAll(repeat('a', 1000000), '(.*)', repeat('\\\\1', 20000))) FORMAT Null" \
+    throw "" fold "$((SCALE * 100))"
 
 # 16. The "replace first" specialization, which leaves the per-row loop at the first match - a different
 #     loop exit from "replace all". Empty haystacks with a per-row pattern make the matcher setup the whole


### PR DESCRIPTION
`04650_replace_cancellation` failed on `arm_binary` about once in a hundred runs, always on the same case:

```
-one match, long instruction list: stopped within bound
+one match, long instruction list: no timeout
```

That case builds a single match whose substitution list is executed in full, and every instruction writes another copy of the match, so the work it offers and the memory the result occupies are the same quantity - and how much of it a stopped call has already written grows with the speed of the machine. Against the standard one-second deadline the list therefore had to be short enough for a fast build to stay inside the 5GiB test profile, where it already reached 4GiB, and long enough that a slower build could not finish it, and no single length satisfies both: on a fast enough machine the call completed inside the deadline and the case reported `no timeout`.

`run` now takes a deadline per case and keeps the same allowance on top of it rather than the same absolute bound, so shortening a deadline does not loosen the assertion with it. Case 15 takes a tenth of the standard deadline and a list two orders of magnitude longer: the fastest build now has to finish 20GB of copying in 100ms to report `no timeout`, and what a stopped call has written falls in the same proportion as the deadline.

Measured against the `arm_binary` and `arm_tsan` builds of the failing commit, the case goes from 1000ms and 4GiB to 100ms and 390MiB, and on the sanitizer build to 210ms and 50MiB. The whole test passed 8/8 runs on `arm_binary` and 1/1 on `arm_tsan`.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=c2c9039413b2e96f64fdbbdecaa23381fb9924df&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20sequential%29

Related: https://github.com/ClickHouse/ClickHouse/pull/112483

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
