### PR TITLE
Install the binary last in the Install packages job

### DIFF
--- a/ci/jobs/install_check.py
+++ b/ci/jobs/install_check.py
@@ -124,7 +124,6 @@ bash -ex /packages/initd_test.sh""",
         "Install keeper deb": r"""#!/bin/bash -ex
 apt-get install /packages/clickhouse-keeper*deb -y
 bash -ex /packages/keeper_test.sh""",
-        "Install clickhouse binary in deb": r"bash -ex /packages/binary_test.sh",
     }
     return test_install(image, tests)
 
@@ -140,9 +139,18 @@ bash -ex /packages/server_test.sh""",
         "Install keeper rpm": r"""#!/bin/bash -ex
 yum localinstall --disablerepo=* --allowerasing -y /packages/clickhouse-keeper*rpm
 bash -ex /packages/keeper_test.sh""",
-        "Install clickhouse binary in rpm": r"bash -ex /packages/binary_test.sh",
     }
     return test_install(image, tests)
+
+
+def test_install_binary(image: DockerImage, name: str) -> List[Result]:
+    # By far the most disk hungry test of the job. The self-extracting archive unpacks in
+    # place, so `/packages/clickhouse` grows from 1 GiB to 4 GiB, and `clickhouse install`
+    # needs as much again: it hard links the binary into `/usr/bin` when it can, but
+    # `/packages` is a directory mounted from the host, so the link cannot be made and the
+    # binary is copied instead. On top of that, the installer refuses to start unless the
+    # whole size of the binary is available, which is why this test runs last - see `main`.
+    return test_install(image, {name: r"bash -ex /packages/binary_test.sh"})
 
 
 def test_install_tgz(image: DockerImage, debug_symbols: bool) -> List[Result]:
@@ -345,6 +353,22 @@ def main():
         # Debian, for which the debug symbols add nothing but two minutes.
         test_results.extend(test_install_tgz(deb_image, debug_symbols=True))
         test_results.extend(test_install_tgz(rpm_image, debug_symbols=False))
+        free_packages("*.tgz*")
+
+    # The binary tests need nothing but `/packages/clickhouse`, and they need around 7 GiB
+    # of disk for it, more than twice as much as any other test here. The runners hand the
+    # job as little as 4 GiB of free space, so run these tests once every package has been
+    # deleted, which is worth 7 GiB on its own. Keeping the binary packed until the very
+    # end leaves 3 GiB more for the tgz tests as well.
+    print("Test the binary")
+    if args.deb:
+        test_results.extend(
+            test_install_binary(deb_image, "Install clickhouse binary in deb")
+        )
+    if args.rpm:
+        test_results.extend(
+            test_install_binary(rpm_image, "Install clickhouse binary in rpm")
+        )
 
     Result.create_from(
         results=test_results,

--- a/ci/jobs/scripts/job_hooks/docker_clean_up_hook.py
+++ b/ci/jobs/scripts/job_hooks/docker_clean_up_hook.py
@@ -22,7 +22,9 @@ def check():
     Shell.check("docker builder prune -a -f", verbose=True)
     print("Clean up stopped containers")
     Shell.check("docker container prune -f", verbose=True)
-    Shell.check("docker system prune", verbose=True)
+    # Without `-f` it only asks for a confirmation on a terminal that is not there, and
+    # exits without deleting anything.
+    Shell.check("docker system prune -f", verbose=True)
     return True
 
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/111960

`Install clickhouse binary in deb` fails on master from time to time:

> Code: 243. DB::Exception: Not enough space for clickhouse binary in `/usr/bin`, required 3.96 GiB, available 2.46 GiB. (`NOT_ENOUGH_SPACE`)

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=c2c9039413b2e96f64fdbbdecaa23381fb9924df&name_0=MasterCI&name_1=Install%20packages%20%28amd_release%29

The runners hand this job 4-6 GiB of free space out of 58 GiB, and the binary test is by far the most disk hungry of the job. The self-extracting archive unpacks in place, so `/packages/clickhouse` grows from 1 GiB to 4 GiB, and `clickhouse install` needs as much again to copy the binary into `/usr/bin`: it hard links the binary when it can, but `/packages` is a directory mounted from the host, so the link cannot be made. On top of that the installer refuses to start unless the whole size of the binary is available. Altogether that is around 7 GiB, and the test used to run in the middle of the job while more than 6 GiB of packages it does not need at all were still on disk. The very same test passed later in the same run, after the deb packages had been deleted.

Both binary tests now run at the very end, once every package has been deleted, which is worth 7 GiB on its own, and the tgz packages are deleted as well. Keeping the binary packed until then leaves 3 GiB more for the tgz tests, which are the next most disk hungry.

`docker system prune` in the clean up hook of the job also gets `-f`: without it the command was asking for a confirmation on a terminal that is not there and exiting without deleting anything.

### Changelog category (leave one):
- CI Fix or Improvement


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.650` (included in `26.8` and later)
<!-- ch-version-info:end -->