### PR TITLE
Do not let test processes inherit the CI runner's output pipe

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -150,7 +150,14 @@ def run_tests(
     # fires only for a genuinely frozen process and never pre-empts the graceful
     # `GLOBAL_TIME_LIMIT_EXIT_CODE` stop (which would be reported as "Server died").
     outer_timeout = global_time_limit + 900 if global_time_limit > 0 else None
-    return Shell.run(command, verbose=True, timeout=outer_timeout)
+    try:
+        return Shell.run(command, verbose=True, timeout=outer_timeout)
+    finally:
+        # Reap tests that escaped `clickhouse-test`'s own cleanup, so they stop
+        # querying the server while the job tears down and collects logs. In the
+        # `finally` to cover every invocation: bugfix validation runs one per
+        # build type.
+        Shell.check("clickhouse-test --cleanup", verbose=True)
 
 
 OPTIONS_TO_INSTALL_ARGUMENTS = {

--- a/ci/tests/test_functional_tests_cleanup_after_run.py
+++ b/ci/tests/test_functional_tests_cleanup_after_run.py
@@ -1,0 +1,107 @@
+"""
+Regression test: the stateless job reaps escaped tests after every test run.
+
+`clickhouse-test --cleanup` kills the process groups recorded by the per-worker
+group pid files. It was wired only into `ClickHouseProc.run_test` (fast test), so
+the stateless job never ran it - tests that escaped into their own session kept
+consuming the machine and querying the server while the job tore down and
+collected logs.
+
+`run_tests` now calls it in a `finally`, which is what makes it cover every
+invocation: bugfix validation calls `run_tests` once per build type, so hanging
+the call off the first call site would silently skip the later runs. These tests
+assert both the presence and that placement, including when the run raises.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FUNCTIONAL_TESTS = _REPO_ROOT / "ci" / "jobs" / "functional_tests.py"
+
+sys.path.insert(0, str(_REPO_ROOT))
+
+CLEANUP_COMMAND = "clickhouse-test --cleanup"
+
+
+def _run_tests_node():
+    tree = ast.parse(_FUNCTIONAL_TESTS.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "run_tests":
+            return node
+    raise AssertionError("run_tests not found in functional_tests.py")
+
+
+def _cleanup_literals(node):
+    return [
+        literal.value
+        for literal in ast.walk(node)
+        if isinstance(literal, ast.Constant)
+        and isinstance(literal.value, str)
+        and CLEANUP_COMMAND in literal.value
+    ]
+
+
+def test_run_tests_invokes_cleanup():
+    assert _cleanup_literals(_run_tests_node()), (
+        f"run_tests must invoke `{CLEANUP_COMMAND}` so escaped tests are reaped"
+    )
+
+
+def test_cleanup_is_in_a_finally_so_it_covers_every_invocation():
+    """Placement, not just presence.
+
+    `run_tests` is called once per build type by bugfix validation. Only a
+    `finally` around the run covers all of them, and it still runs when the test
+    run raises.
+    """
+    node = _run_tests_node()
+    in_finally = [
+        literal
+        for trier in ast.walk(node)
+        if isinstance(trier, ast.Try)
+        for stmt in trier.finalbody
+        for literal in _cleanup_literals(stmt)
+    ]
+    assert in_finally, (
+        f"`{CLEANUP_COMMAND}` must sit in a `finally` inside run_tests, so it "
+        "covers every invocation and also runs when the test run raises"
+    )
+
+
+def test_cleanup_runs_for_every_run_tests_call(monkeypatch, tmp_path):
+    """Drive the real function twice, including one raising run."""
+    from ci.jobs import functional_tests
+
+    calls = []
+    monkeypatch.setattr(
+        functional_tests.Shell, "check", lambda cmd, **kw: calls.append(cmd) or True
+    )
+    monkeypatch.setattr(functional_tests, "temp_dir", str(tmp_path))
+    monkeypatch.setattr(
+        functional_tests, "stateless_memory_limit", lambda source: 1, raising=False
+    )
+    monkeypatch.setattr(
+        functional_tests.Info, "__init__", lambda self: None, raising=False
+    )
+    monkeypatch.setattr(
+        functional_tests.Info, "job_name", "amd_asan_ubsan", raising=False
+    )
+
+    monkeypatch.setattr(functional_tests.Shell, "run", lambda *a, **kw: 0)
+    assert functional_tests.run_tests(0, 0, build_type="amd_debug") == 0
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("test run died")
+
+    monkeypatch.setattr(functional_tests.Shell, "run", boom)
+    try:
+        functional_tests.run_tests(0, 0, build_type="amd_asan_ubsan")
+    except RuntimeError:
+        pass
+
+    cleanups = [cmd for cmd in calls if CLEANUP_COMMAND in cmd]
+    assert len(cleanups) == 2, (
+        f"expected a cleanup per run_tests call (incl. the raising one), got {calls}"
+    )

--- a/ci/tests/test_test_fds_detached_from_runner.py
+++ b/ci/tests/test_test_fds_detached_from_runner.py
@@ -20,7 +20,10 @@ joins blocked until the job was SIGKILLed - before the stages that collect the
 server log and check for an OOM kill.
 
 `clickhouse-test` now passes explicit sinks for both descriptors, so an escaped
-test cannot hold the runner's pipeline open.
+test cannot hold the runner's pipeline open. The wrapper's stderr gets an
+artifact of its own rather than the test's `2>` target, because that one is
+truncated by the test's redirect and is read back as `stderr`, where content is
+itself a verdict and is matched against `MESSAGES_TO_RETRY`.
 
 These tests drive the mechanism directly rather than running a real suite: the
 production failure needs a dying server and a two-hour window, but the wedge
@@ -38,10 +41,13 @@ unpatched spawn, so getting these wrong certifies a broken fix):
 """
 
 import ast
+import os
+import runpy
 import subprocess
 import sys
 import threading
 import time
+import types
 from pathlib import Path
 
 BASH = "/bin/bash"
@@ -160,59 +166,269 @@ def test_detaching_only_stdout_is_not_enough(tmp_path):
     )
 
 
-def test_run_single_test_passes_explicit_sinks():
-    """The real spawn site must keep passing both sinks.
+def _spawn_kwargs():
+    """The `Popen` keyword arguments of `run_single_test`, as AST nodes.
+
+    Also returns the enclosing function so a sink bound to a local name can be
+    resolved *within it*, which is what stops a decoy `open(...)` elsewhere in
+    `clickhouse-test` from satisfying the assertions below.
+    """
+    tree = ast.parse(_CLICKHOUSE_TEST.read_text())
+    found = [
+        (func, {kw.arg: kw.value for kw in call.keywords})
+        for func in ast.walk(tree)
+        if isinstance(func, ast.FunctionDef) and func.name == "run_single_test"
+        for call in ast.walk(func)
+        if isinstance(call, ast.Call) and getattr(call.func, "id", "") == "Popen"
+    ]
+    assert found, "no Popen call found in run_single_test"
+    return found
+
+
+def _resolve(func, node):
+    """`node`, or the value assigned to it if it is a local name of `func`."""
+    if not isinstance(node, ast.Name):
+        return node
+    assigned = [
+        assign.value
+        for assign in ast.walk(func)
+        if isinstance(assign, ast.Assign)
+        for target in assign.targets
+        if isinstance(target, ast.Name) and target.id == node.id
+    ]
+    assert len(assigned) == 1, (
+        f"expected exactly one assignment to `{node.id}` in run_single_test, "
+        f"got {len(assigned)}"
+    )
+    return assigned[0]
+
+
+def test_run_single_test_detaches_stdout():
+    """The real spawn site must send its stdout to `DEVNULL`.
 
     The timing tests above emulate the spawn, because driving the real one needs
-    a running server. This asserts the property directly on the source, so
-    dropping either argument from `run_single_test` fails here.
+    a running server, so they cannot catch a change here. Asserting the VALUE and
+    not just the presence of the keyword is what makes this a live pin:
+    `stdout=sys.stdout` or `stdout=None` restores the wedge while still passing a
+    presence check.
     """
-    tree = ast.parse(_CLICKHOUSE_TEST.read_text())
-    spawns = [
-        sorted(kw.arg for kw in call.keywords)
-        for func in ast.walk(tree)
-        if isinstance(func, ast.FunctionDef) and func.name == "run_single_test"
-        for call in ast.walk(func)
-        if isinstance(call, ast.Call) and getattr(call.func, "id", "") == "Popen"
-    ]
-    assert spawns, "no Popen call found in run_single_test"
-    for kwargs in spawns:
-        assert "stdout" in kwargs and "stderr" in kwargs, (
-            "run_single_test must pass explicit stdout and stderr so a test cannot "
-            f"inherit the runner's output pipe, got {kwargs}"
+    for _func, kwargs in _spawn_kwargs():
+        assert "stdout" in kwargs, (
+            "run_single_test must pass an explicit stdout so a test cannot inherit "
+            "the runner's output pipe"
+        )
+        assert ast.dump(kwargs["stdout"]) == ast.dump(
+            ast.parse("subprocess.DEVNULL", mode="eval").body
+        ), (
+            "the wrapping shell's stdout must be subprocess.DEVNULL, got "
+            f"`{ast.unparse(kwargs['stdout'])}`"
         )
 
 
-def test_wrapper_stderr_is_kept_not_discarded():
-    """The wrapper's stderr must reach the stderr artifact, not `DEVNULL`.
+def test_wrapper_stderr_goes_to_its_own_artifact():
+    """The wrapper's stderr must be a file of its own, not `DEVNULL`.
 
     The test's own output is redirected by the command, but the wrapping shell
-    still reports failures that happen before that redirect takes effect (a bad
-    redirect target, a syntax error) on its own fd2. Sending those to `DEVNULL`
-    would drop shell-level diagnostics - the same class of loss this change
-    exists to fix - so pin the sink to `self.stderr_file`.
+    reports job status (a killed or segfaulting test, a bad redirect target, a
+    syntax error) on its own fd2. `DEVNULL` would drop those - the same class of
+    loss this change exists to fix.
+
+    It must not be `stderr_file` either, for two measured reasons: the test
+    truncates that file when its own redirect opens it, which destroys anything
+    written before that; and it is read back as `stderr`, where content is itself
+    a verdict and is matched against `MESSAGES_TO_RETRY` - whose entries include
+    `No such file or directory`, which a quoted command line can contain.
     """
-    tree = ast.parse(_CLICKHOUSE_TEST.read_text())
-    spawns = [
-        {kw.arg: kw.value for kw in call.keywords}
-        for func in ast.walk(tree)
-        if isinstance(func, ast.FunctionDef) and func.name == "run_single_test"
-        for call in ast.walk(func)
-        if isinstance(call, ast.Call) and getattr(call.func, "id", "") == "Popen"
-    ]
-    assert spawns, "no Popen call found in run_single_test"
-    for kwargs in spawns:
-        stderr = ast.dump(kwargs["stderr"])
-        assert "DEVNULL" not in stderr, (
-            "the wrapping shell's stderr must go to the stderr artifact, not DEVNULL"
+    for func, kwargs in _spawn_kwargs():
+        assert "stderr" in kwargs, "run_single_test must pass an explicit stderr"
+        sink = _resolve(func, kwargs["stderr"])
+        assert "DEVNULL" not in ast.unparse(sink), (
+            "the wrapping shell's stderr must be reported, not sent to DEVNULL"
+        )
+        assert isinstance(sink, ast.Call) and getattr(sink.func, "id", "") == "open", (
+            f"expected the stderr sink to be an `open(...)`, got `{ast.unparse(sink)}`"
+        )
+        path, mode = sink.args[0], sink.args[1]
+        assert ast.unparse(path) == "self.wrapper_stderr_file", (
+            "the wrapper's stderr must go to its own artifact, not the test's `2>` "
+            f"target, got `{ast.unparse(path)}`"
+        )
+        assert ast.literal_eval(mode) == "ab", (
+            f"the sink must append so nothing is truncated, got {ast.unparse(mode)}"
         )
 
-    # The sink must be opened from `self.stderr_file`, in append mode so it adds
-    # to what the test itself writes there rather than truncating it.
-    source = _CLICKHOUSE_TEST.read_text()
-    assert 'open(self.stderr_file, "ab"' in source, (
-        "the wrapper's stderr sink must append to self.stderr_file"
+
+def test_wrapper_stderr_is_kept_out_of_the_retry_matcher():
+    """The relocated text must be reported without reaching the retry matcher.
+
+    `process_result_impl` builds the description the matcher sees; the wrapper's
+    lines are read there but appended by `process_result`, which runs after the
+    retry check. Pin that ordering: appending them to `debug_log` instead puts a
+    quoted command line in front of `MESSAGES_TO_RETRY`.
+    """
+    tree = ast.parse(_CLICKHOUSE_TEST.read_text())
+    functions = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    attribute = "wrapper_stderr_report"
+
+    def stores_to(func):
+        return [
+            node
+            for node in ast.walk(functions[func])
+            if isinstance(node, ast.Attribute)
+            and node.attr == attribute
+            and isinstance(node.ctx, ast.Store)
+        ]
+
+    assert stores_to("process_result_impl"), (
+        f"`process_result_impl` must read the wrapper's stderr into {attribute}"
     )
+    reported = [
+        node
+        for node in ast.walk(functions["process_result"])
+        if isinstance(node, ast.AugAssign)
+        and attribute in ast.unparse(node.value)
+    ]
+    assert reported, (
+        f"`process_result` must report {attribute}, so the text is visible in the "
+        "job log without being matched against MESSAGES_TO_RETRY"
+    )
+    matcher_fed = [
+        node
+        for node in ast.walk(functions["process_result_impl"])
+        if isinstance(node, ast.AugAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id in ("debug_log", "stderr", "description")
+        and attribute in ast.unparse(node.value)
+    ]
+    assert not matcher_fed, (
+        f"{attribute} must not be folded into the description built by "
+        "`process_result_impl`: that is what the retry matcher is handed"
+    )
+
+
+def _drive_process_result(tmp_path, wrapper_line, same_path):
+    """Run the real `process_result_impl` + `process_result` over a wrapper message.
+
+    `same_path` writes the line to the test's `2>` target instead of the wrapper's
+    own artifact, which is what the sink used to be. Returns the
+    `MESSAGES_TO_RETRY` entries the retry matcher would see and whether the line
+    was reported to the job log.
+    """
+    ct = runpy.run_path(str(_CLICKHOUSE_TEST))
+    test_case_cls, status_cls = ct["TestCase"], ct["TestStatus"]
+
+    class _Args:
+        debug_log_file = str(tmp_path / "dbg.log")
+        bash_tracing_file = str(tmp_path / "trace.log")
+        stop = False
+        testcase_database = "test_db"
+        test_runs = 1
+        flaky_check = False
+        cloud = False
+        record = False
+        unified = 3
+        check_zookeeper_session = False
+        dont_retry_failures = False
+
+    case = test_case_cls.__new__(test_case_cls)
+    case.name = "00001_probe"
+    case.stdout_file = str(tmp_path / "t.stdout")
+    case.stderr_file = str(tmp_path / "t.stderr")
+    case.wrapper_stderr_file = case.stderr_file + "-wrapper"
+    case.fatal_sanitizer_prefix = case.stderr_file + "-fatal"
+    case.reference_file = str(tmp_path / "t.reference")
+    case.testcase_args = case.args = _Args()
+    case.show_whitespaces_in_diff = False
+    case.tags = set()
+    case.debug_log_retry_substitution = None
+    case.wrapper_stderr_report = ""
+    case.suite = types.SimpleNamespace(blacklist_check=set())
+
+    for path in (case.stdout_file, case.stderr_file, case.reference_file):
+        Path(path).write_text("")
+    sink = case.stderr_file if same_path else case.wrapper_stderr_file
+    Path(sink).write_text(wrapper_line)
+    if same_path and os.path.exists(case.wrapper_stderr_file):
+        os.remove(case.wrapper_stderr_file)
+
+    # A non-zero exit code, the shape every arm of the routing table produces.
+    proc = types.SimpleNamespace(returncode=1, pid=os.getpid())
+    result = case.process_result_impl(proc, 1.0)
+    retry_input = case.retry_matcher_input(result.description)
+    matched = [msg for msg in ct["MESSAGES_TO_RETRY"] if msg in retry_input]
+    reported = case.process_result(
+        result, {status: f"[ {status.name} ]" for status in status_cls}
+    )
+    return matched, wrapper_line.strip() in reported.description
+
+
+def test_wrapper_message_does_not_trigger_a_retry(tmp_path):
+    """A quoted command line must not make a deterministic failure look flaky.
+
+    This is the line the `stdout redirect target unopenable` arm really produces;
+    it contains a verbatim `MESSAGES_TO_RETRY` entry. The `same_path` arm is the
+    mutation: pointing the sink back at the test's `2>` target reddens this, which
+    is what makes the assertion load-bearing rather than incidental.
+    """
+    line = "/bin/bash: line 1: /nonexistent/x.stdout: No such file or directory\n"
+
+    matched, reported = _drive_process_result(tmp_path, line, same_path=False)
+    assert matched == [], f"wrapper text reached the retry matcher: {matched}"
+    assert reported, "the wrapper's message must still be reported"
+
+    matched, reported = _drive_process_result(tmp_path, line, same_path=True)
+    assert "No such file or directory" in matched, (
+        "the mutation arm must show the retry channel this fix closes; if it does "
+        "not, this test no longer pins anything"
+    )
+    assert reported
+
+
+def test_empty_wrapper_file_is_not_left_behind():
+    """An empty wrapper file must be removed while it is still known to be empty.
+
+    `Popen` creates it whether or not the shell writes anything, and the OK-path
+    cleanup does not run for a failing test, so without this every non-passing
+    test leaks an empty file into the suite's tmp dir - which defaults to a
+    directory inside the source tree. Measured before the guard existed: a
+    220-test batch left 13283 of them.
+    """
+    tree = ast.parse(_CLICKHOUSE_TEST.read_text())
+    run_single = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "run_single_test"
+    )
+    guarded = [
+        node
+        for node in ast.walk(run_single)
+        if isinstance(node, ast.If)
+        and "getsize(self.wrapper_stderr_file) == 0" in ast.unparse(node.test)
+        and "remove(self.wrapper_stderr_file)" in ast.unparse(node.body)
+    ]
+    assert guarded, (
+        "run_single_test must remove the wrapper's file while it is still empty, so "
+        "a non-passing test does not leak one into the suite's tmp dir"
+    )
+
+
+def test_child_side_messages_are_reported_exactly_as_before(tmp_path):
+    """The classes that always went to the test's `2>` target must not move.
+
+    `Permission denied` and `No such file or directory` from a failed exec are
+    emitted after the fork, with the redirect already installed, so they are the
+    test's own stderr and must keep reaching the verdict and the matcher.
+    """
+    line = "/bin/bash: line 1: /tmp/x.sh: Permission denied\n"
+    matched, reported = _drive_process_result(tmp_path, line, same_path=True)
+    assert "Permission denied" in matched, (
+        "a child-side message is the test's own stderr and must still be matched"
+    )
+    assert reported
 
 
 def test_single_child_fixture_cannot_detect_the_wedge(tmp_path):

--- a/ci/tests/test_test_fds_detached_from_runner.py
+++ b/ci/tests/test_test_fds_detached_from_runner.py
@@ -1,0 +1,225 @@
+"""
+Regression test: a test process must not inherit the CI runner's output pipe.
+
+Background
+----------
+`Stateless tests (amd_asan_ubsan, distributed plan, parallel)` jobs
+intermittently finished with a job-level ERROR after producing no output at all
+for almost two hours, until the 9000s job watchdog killed them. No test failed
+and no server log was ever uploaded.
+
+`ci/jobs/functional_tests.py` runs the suite as a shell PIPELINE,
+`clickhouse-test ... | ts | tee -a <file>`, and `clickhouse-test` used to spawn
+each test with `Popen(..., start_new_session=True)` and no `stdout`/`stderr`
+arguments. The spawned `bash -c "<test> > out 2> err"` wrapper therefore
+inherited the write end of that pipe (the redirect applies only to the test the
+wrapper execs, not to the wrapper itself). A test that escaped into its own
+session outlived the worker, so `ts` never saw EOF, `tee` never exited, the
+top-level `bash` never exited, and `Shell.run`'s `proc.wait()` plus both reader
+joins blocked until the job was SIGKILLed - before the stages that collect the
+server log and check for an OOM kill.
+
+`clickhouse-test` now passes explicit sinks for both descriptors, so an escaped
+test cannot hold the runner's pipeline open.
+
+These tests drive the mechanism directly rather than running a real suite: the
+production failure needs a dying server and a two-hour window, but the wedge
+reproduces in seconds.
+
+Fixture requirements (each of the negative arms below passes even against the
+unpatched spawn, so getting these wrong certifies a broken fix):
+
+* it must be the PIPELINE shape - with a single child, `proc.wait()` returns
+  immediately and only the reader joins block;
+* the escaping process must be the WRAPPER, whose own fd1/fd2 are the pipe
+  while its redirect applies to the command it execs;
+* both descriptors matter - detaching stdout alone still leaves the stderr
+  reader blocked for the orphan's lifetime.
+"""
+
+import ast
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+BASH = "/bin/bash"
+_CLICKHOUSE_TEST = Path(__file__).resolve().parents[2] / "tests" / "clickhouse-test"
+
+# The orphan outlives its parent by this much. It must comfortably exceed
+# PROMPT_S so an unpatched spawn cannot pass by being merely fast, and stay
+# short enough that a wedged arm does not stall the suite.
+ORPHAN_LIFETIME_S = 8
+# A detached pipeline ends as soon as the worker exits; measured at ~0.02s.
+PROMPT_S = 3.0
+
+# Emulates one `clickhouse-test` worker: spawn the test wrapper in its own
+# session, then exit WITHOUT reaping it, which is what a SIGKILLed worker does.
+# `mode` selects the spawn under test.
+_WORKER = r"""
+import os, subprocess, sys
+mode, lifetime, out, err, sink = sys.argv[1:6]
+# Mirrors `run_single_test`: the redirect binds the command the wrapper execs,
+# so the wrapper itself keeps whatever fd1/fd2 it inherited from us.
+command = f"sleep {lifetime} > {out} 2> {err}"
+kwargs = {}
+if mode in ("detach_stdout", "detach_both"):
+    kwargs["stdout"] = subprocess.DEVNULL
+if mode == "detach_both":
+    kwargs["stderr"] = open(sink, "ab", buffering=0)
+subprocess.Popen(command, shell=True, executable=r"%s",
+                 start_new_session=True, **kwargs)
+print("spawned", flush=True)
+os._exit(0)
+""" % BASH
+
+
+def _run_pipeline(tmp_path, mode, pipeline=True):
+    """Run the worker inside the runner's pipeline shape and time the waits.
+
+    Returns `(proc_wait_s, both_joins_s)` measured from launch, the two waits
+    `Shell.run` performs: `proc.wait()` plus the stdout and stderr reader joins.
+    """
+    worker = tmp_path / "worker.py"
+    worker.write_text(_WORKER)
+    args = " ".join(
+        str(x)
+        for x in (
+            mode,
+            ORPHAN_LIFETIME_S,
+            tmp_path / "test.stdout",
+            tmp_path / "test.stderr",
+            tmp_path / "wrapper.stderr",
+        )
+    )
+    command = f"{sys.executable} {worker} {args}"
+    if pipeline:
+        # The exact shape of `run_tests`: `... | ts | tee -a <file>`. `cat`
+        # stands in for `ts`/`tee` so the test needs no moreutils.
+        command = f"set -o pipefail; {command} | cat | cat"
+
+    started = time.monotonic()
+    # pylint:disable-next=consider-using-with; the waits below are the assertion
+    proc = subprocess.Popen(
+        command,
+        shell=True,
+        executable=BASH,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    readers = [
+        threading.Thread(target=lambda s=stream: [None for _ in s], daemon=True)
+        for stream in (proc.stdout, proc.stderr)
+    ]
+    for reader in readers:
+        reader.start()
+
+    proc.wait()
+    proc_wait_s = time.monotonic() - started
+    for reader in readers:
+        reader.join(timeout=ORPHAN_LIFETIME_S * 3)
+    return proc_wait_s, time.monotonic() - started
+
+
+def test_detached_test_does_not_hold_the_runner_pipeline(tmp_path):
+    """An escaped test must not keep the runner's pipeline open.
+
+    No timeout and no watchdog are configured, so this passes only because the
+    descriptors are detached - not because something killed the orphan.
+    """
+    proc_wait_s, joins_s = _run_pipeline(tmp_path, "detach_both")
+    assert proc_wait_s < PROMPT_S, f"proc.wait() blocked for {proc_wait_s:.2f}s"
+    assert joins_s < PROMPT_S, f"reader joins blocked for {joins_s:.2f}s"
+
+
+def test_inherited_test_wedges_the_runner_pipeline(tmp_path):
+    """The unpatched spawn: both waits block for the orphan's whole lifetime.
+
+    This is the arm that fails if the fix is reverted, and it pins the
+    mechanism: nothing but the inherited descriptors keeps the pipeline alive.
+    """
+    proc_wait_s, joins_s = _run_pipeline(tmp_path, "inherit")
+    assert proc_wait_s >= ORPHAN_LIFETIME_S - 1, (
+        f"expected the wedge, got proc.wait()={proc_wait_s:.2f}s"
+    )
+    assert joins_s >= ORPHAN_LIFETIME_S - 1
+
+
+def test_detaching_only_stdout_is_not_enough(tmp_path):
+    """Both descriptors must be detached.
+
+    `Shell.run` joins the stdout AND stderr readers before `proc.wait()`, so an
+    orphan holding fd2 alone still blocks the runner for its whole lifetime even
+    though `proc.wait()` itself returns promptly.
+    """
+    proc_wait_s, joins_s = _run_pipeline(tmp_path, "detach_stdout")
+    assert proc_wait_s < PROMPT_S
+    assert joins_s >= ORPHAN_LIFETIME_S - 1, (
+        f"expected the stderr reader to block, got {joins_s:.2f}s"
+    )
+
+
+def test_run_single_test_passes_explicit_sinks():
+    """The real spawn site must keep passing both sinks.
+
+    The timing tests above emulate the spawn, because driving the real one needs
+    a running server. This asserts the property directly on the source, so
+    dropping either argument from `run_single_test` fails here.
+    """
+    tree = ast.parse(_CLICKHOUSE_TEST.read_text())
+    spawns = [
+        sorted(kw.arg for kw in call.keywords)
+        for func in ast.walk(tree)
+        if isinstance(func, ast.FunctionDef) and func.name == "run_single_test"
+        for call in ast.walk(func)
+        if isinstance(call, ast.Call) and getattr(call.func, "id", "") == "Popen"
+    ]
+    assert spawns, "no Popen call found in run_single_test"
+    for kwargs in spawns:
+        assert "stdout" in kwargs and "stderr" in kwargs, (
+            "run_single_test must pass explicit stdout and stderr so a test cannot "
+            f"inherit the runner's output pipe, got {kwargs}"
+        )
+
+
+def test_wrapper_stderr_is_kept_not_discarded():
+    """The wrapper's stderr must reach the stderr artifact, not `DEVNULL`.
+
+    The test's own output is redirected by the command, but the wrapping shell
+    still reports failures that happen before that redirect takes effect (a bad
+    redirect target, a syntax error) on its own fd2. Sending those to `DEVNULL`
+    would drop shell-level diagnostics - the same class of loss this change
+    exists to fix - so pin the sink to `self.stderr_file`.
+    """
+    tree = ast.parse(_CLICKHOUSE_TEST.read_text())
+    spawns = [
+        {kw.arg: kw.value for kw in call.keywords}
+        for func in ast.walk(tree)
+        if isinstance(func, ast.FunctionDef) and func.name == "run_single_test"
+        for call in ast.walk(func)
+        if isinstance(call, ast.Call) and getattr(call.func, "id", "") == "Popen"
+    ]
+    assert spawns, "no Popen call found in run_single_test"
+    for kwargs in spawns:
+        stderr = ast.dump(kwargs["stderr"])
+        assert "DEVNULL" not in stderr, (
+            "the wrapping shell's stderr must go to the stderr artifact, not DEVNULL"
+        )
+
+    # The sink must be opened from `self.stderr_file`, in append mode so it adds
+    # to what the test itself writes there rather than truncating it.
+    source = _CLICKHOUSE_TEST.read_text()
+    assert 'open(self.stderr_file, "ab"' in source, (
+        "the wrapper's stderr sink must append to self.stderr_file"
+    )
+
+
+def test_single_child_fixture_cannot_detect_the_wedge(tmp_path):
+    """Negative arm: without the pipeline this passes even unpatched.
+
+    Kept deliberately - a "simplified" fixture that drops `| cat | cat` reports
+    `proc.wait()` returning at once and silently stops testing anything.
+    """
+    proc_wait_s, _ = _run_pipeline(tmp_path, "inherit", pipeline=False)
+    assert proc_wait_s < PROMPT_S

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2669,6 +2669,8 @@ class TestCase:
         self.runs_count = 0
         # Set by `process_result_impl`; read by `retry_matcher_input`.
         self.debug_log_retry_substitution = None
+        # Set by `process_result_impl`; reported by `process_result`.
+        self.wrapper_stderr_report = ""
 
         has_no_random_settings_tag = self.tags and "no-random-settings" in self.tags
         has_no_random_merge_tree_settings_tag = (
@@ -3191,6 +3193,21 @@ class TestCase:
             debug_log_for_retry = trim_for_log(
                 retry_header + ":\n" + bash_body + expect_body + "\n", 100
             )
+        # The wrapping shell's own stderr (see the `Popen` in `run_single_test`). Read here,
+        # before the OK path below removes it, but appended by `process_result`, which runs
+        # after the retry check: a job-status line quotes the whole command, so entries as
+        # generic as `No such file or directory` would retry a deterministic failure.
+        self.wrapper_stderr_report = ""
+        self.wrapper_stderr_file = f"{self.stderr_file}-wrapper"
+        if (
+            os.path.exists(self.wrapper_stderr_file)
+            and os.path.getsize(self.wrapper_stderr_file) > 0
+        ):
+            with open(self.wrapper_stderr_file, "rb") as stream:
+                wrapper_text = str(stream.read(), errors="replace", encoding="utf-8")
+            self.wrapper_stderr_report = trim_for_log(
+                self.wrapper_stderr_file + ":\n" + wrapper_text + "\n", 100
+            )
         self.debug_log_retry_substitution = (
             (debug_log, debug_log_for_retry) if debug_log != debug_log_for_retry else None
         )
@@ -3469,6 +3486,8 @@ class TestCase:
             os.remove(self.stdout_file)
         if os.path.exists(self.stderr_file):
             os.remove(self.stderr_file)
+        if os.path.exists(self.wrapper_stderr_file):
+            os.remove(self.wrapper_stderr_file)
         for path in glob.glob(self.fatal_sanitizer_prefix + "*"):
             os.remove(path)
         if os.path.exists(self.testcase_args.debug_log_file):
@@ -3489,6 +3508,10 @@ class TestCase:
             description_full += f"\nReason: {result.reason.value} "
 
         description_full += result.description
+
+        # After the retry check in `run`, so the wrapping shell's job-status lines are
+        # reported without reaching the matcher; see where this is set.
+        description_full += getattr(self, "wrapper_stderr_report", "")
 
         description_full += "\n"
 
@@ -3521,6 +3544,12 @@ class TestCase:
         # Ensure that we start with empty files
         for path in glob.glob(self.fatal_sanitizer_prefix + "*"):
             os.remove(path)
+        # The wrapping shell's own stderr; see the `Popen` below. Removed, not emptied,
+        # like the traces below, so a retry is not reported the previous attempt's lines;
+        # `Popen` recreates it for append.
+        self.wrapper_stderr_file = f"{self.stderr_file}-wrapper"
+        if os.path.exists(self.wrapper_stderr_file):
+            os.remove(self.wrapper_stderr_file)
         # Same reason, for the expect trace: `exp_internal -f` opens for append, and since the
         # bash xtrace no longer shares this path nothing else truncates it. Removing (not
         # emptying) it matters - the report block above keys on existence alone, so an empty file
@@ -3613,12 +3642,13 @@ class TestCase:
             cgroup_name = f"clickhouse-test-{os.getpid()}"
             preexec_fn = setup_cgroup_with_memory_limit_cb(cgroup_name, self.memory_limit)
 
-        # A test escaping into its own session must not keep our fd1/fd2 open: under
-        # CI they are the write end of a `clickhouse-test | ts | tee` pipeline, which
-        # then never sees EOF. `pattern` already redirects the test's own output, so
-        # only the wrapping shell writes here.
+        # A test escaping into its own session must not keep our fd1/fd2 open: under CI
+        # they are the write end of a `clickhouse-test | ts | tee` pipeline, which then
+        # never sees EOF. `pattern` redirects the test's own output, so only the wrapping
+        # shell writes here, and its stderr must not share the test's `2>` target: that
+        # file is truncated by the test's redirect and is read back as the verdict.
         # pylint:disable-next=consider-using-with; TODO: fix
-        wrapper_stderr = open(self.stderr_file, "ab", buffering=0)
+        wrapper_stderr = open(self.wrapper_stderr_file, "ab", buffering=0)
         try:
             # pylint:disable-next=consider-using-with; TODO: fix
             proc = Popen(
@@ -3650,10 +3680,23 @@ class TestCase:
 
         total_time = (datetime.now() - start_time).total_seconds()
 
+        # `Popen` creates the wrapper's file whether or not the shell writes to it, and the
+        # cleanup on the OK path runs only for a passing test, so drop an empty one here or
+        # every non-passing test leaks a file into the suite's tmp dir.
+        if (
+            os.path.exists(self.wrapper_stderr_file)
+            and os.path.getsize(self.wrapper_stderr_file) == 0
+        ):
+            os.remove(self.wrapper_stderr_file)
+
         # Normalize randomized database names in stdout, stderr files.
         replace_in_file(self.stdout_file, database, "default")
         if args.hide_db_name:
             replace_in_file(self.stderr_file, database, "default")
+            # The wrapper's file too: its job-status lines quote the command, which
+            # carries `--database=`.
+            if os.path.exists(self.wrapper_stderr_file):
+                replace_in_file(self.wrapper_stderr_file, database, "default")
         if args.replicated_database:
             replace_in_file(self.stdout_file, "/auto_{shard}", "")
             replace_in_file(self.stdout_file, "auto_{replica}", "")

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3613,8 +3613,26 @@ class TestCase:
             cgroup_name = f"clickhouse-test-{os.getpid()}"
             preexec_fn = setup_cgroup_with_memory_limit_cb(cgroup_name, self.memory_limit)
 
+        # A test escaping into its own session must not keep our fd1/fd2 open: under
+        # CI they are the write end of a `clickhouse-test | ts | tee` pipeline, which
+        # then never sees EOF. `pattern` already redirects the test's own output, so
+        # only the wrapping shell writes here.
         # pylint:disable-next=consider-using-with; TODO: fix
-        proc = Popen(command, shell=True, executable=BASH, env=tests_env, start_new_session=True, preexec_fn=preexec_fn)
+        wrapper_stderr = open(self.stderr_file, "ab", buffering=0)
+        try:
+            # pylint:disable-next=consider-using-with; TODO: fix
+            proc = Popen(
+                command,
+                shell=True,
+                executable=BASH,
+                env=tests_env,
+                start_new_session=True,
+                preexec_fn=preexec_fn,
+                stdout=subprocess.DEVNULL,
+                stderr=wrapper_stderr,
+            )
+        finally:
+            wrapper_stderr.close()
         # proc.pid == PGID after start_new_session=True; write it atomically so
         # `clickhouse-test --cleanup` can find it even if we are killed with SIGKILL.
         _gpid_file = _GROUP_PID_PATH / f"{_GROUP_PID_NAME}.{os.getpid()}"

--- a/tests/clickhouse-test-process-management.md
+++ b/tests/clickhouse-test-process-management.md
@@ -49,7 +49,8 @@ partial write.
 ### Per-test bookkeeping
 
 ```python
-proc = Popen(command, shell=True, start_new_session=True, preexec_fn=cgroup_fn)
+proc = Popen(command, shell=True, start_new_session=True, preexec_fn=cgroup_fn,
+             stdout=subprocess.DEVNULL, stderr=wrapper_stderr)
 # proc.pid == PGID after start_new_session=True
 _gpid_file = _GROUP_PID_PATH / f"{_GROUP_PID_NAME}.{os.getpid()}"
 write_text_atomic(_gpid_file, f"{proc.pid}\n")
@@ -61,6 +62,15 @@ finally:
         cleanup_cgroup(cgroup_name)
     _gpid_file.unlink(missing_ok=True)
 ```
+
+The explicit sinks detach the test from our own stdout/stderr.  The command
+already redirects the test's output to the per-test `.stdout`/`.stderr` files, so
+only the wrapping shell writes to these; its stderr is appended to the `.stderr`
+file rather than discarded, and `stdout` is unused (see the comment on
+`pattern`).  Without this an orphan keeps our descriptors open, and under CI
+those are the write end of a `clickhouse-test | ts | tee` pipeline: `ts` never
+sees EOF, so the job produces no further output and hangs until its watchdog
+kills it, before the stages that collect the server log run.
 
 On a clean run every started test deletes its file in the `finally` block, so
 no files remain when `clickhouse-test` exits.  If `clickhouse-test` is
@@ -118,6 +128,7 @@ The hook contains no kill logic of its own — it just calls
 | `cleanup_child_processes` | SIGTERM/SIGINT/SIGHUP to `clickhouse-test` | `killpg` on each direct child's PGID |
 | test `finally` block | Any exit of the per-test code path (incl. SIGKILL to the worker) | `_gpid_file.unlink` — removes the per-worker file |
 | `run_test()` `finally` | Any exit of `clickhouse-test` (incl. SIGKILL) | `clickhouse-test --cleanup` → `kill_process_group` per PGID file |
+| `run_tests()` `finally` (stateless job) | Any exit of the test run, per invocation | same: `clickhouse-test --cleanup` |
 | Post-hook | Any exit of `fast_test.py` (incl. SIGKILL) | same — `clickhouse-test --cleanup` |
 
 ### Remaining limitation

--- a/tests/clickhouse-test-process-management.md
+++ b/tests/clickhouse-test-process-management.md
@@ -63,14 +63,26 @@ finally:
     _gpid_file.unlink(missing_ok=True)
 ```
 
-The explicit sinks detach the test from our own stdout/stderr.  The command
-already redirects the test's output to the per-test `.stdout`/`.stderr` files, so
-only the wrapping shell writes to these; its stderr is appended to the `.stderr`
-file rather than discarded, and `stdout` is unused (see the comment on
-`pattern`).  Without this an orphan keeps our descriptors open, and under CI
-those are the write end of a `clickhouse-test | ts | tee` pipeline: `ts` never
-sees EOF, so the job produces no further output and hangs until its watchdog
-kills it, before the stages that collect the server log run.
+The explicit sinks detach the test from our own stdout/stderr.  Without them an
+orphan keeps our descriptors open, and under CI those are the write end of a
+`clickhouse-test | ts | tee` pipeline: `ts` never sees EOF, so the job produces
+no further output and hangs until its watchdog kills it, before the stages that
+collect the server log run.
+
+Only the wrapping shell writes to these sinks, because the command redirects the
+test's own output to the per-test `.stdout`/`.stderr` files.  It writes nothing to
+fd 1, hence `DEVNULL`; fd 2 carries its job status (a killed or segfaulting test,
+a bad redirect target, a syntax error), which is reported rather than discarded.
+
+That goes to a `.stderr-wrapper` file of its own rather than the test's `2>`
+target, for two reasons: the test truncates that file when its own redirect opens
+it, destroying anything written earlier; and it is read back as `stderr`, where
+any content is itself a verdict (`STDERR`, or `SERVER_DIED` on
+`<Fatal>`/`Connection refused`) and is matched against `MESSAGES_TO_RETRY`.  A
+job-status line quotes the whole command, so sharing the file would let entries as
+generic as `No such file or directory` retry a deterministic failure and report it
+as flaky.  It is appended by `process_result`, which runs after the retry check,
+and removed while still empty so a non-passing test leaves nothing behind.
 
 On a clean run every started test deletes its file in the `finally` block, so
 no files remain when `clickhouse-test` exits.  If `clickhouse-test` is


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/108689
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/108689

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`Stateless tests (amd_asan_ubsan, distributed plan, parallel)` on
[this report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112504&sha=1f924407d1fc866769493d5ba8df685640afa21a&name_0=PR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%29)
lost its server around test 4291/12235, then produced no output for 1 h 55 m until the 9000 s
watchdog killed it. No test failed and no server log was uploaded.

Root cause: `clickhouse-test` spawned each test with `start_new_session=True` and no
`stdout`/`stderr`, so the `bash -c "<test> > out 2> err"` wrapper inherited its own fd1/fd2
(the redirect binds only the command it execs). Under CI those are the write end of
`clickhouse-test | ts | tee`, so a test escaping into its own session kept `ts` from seeing EOF:
`tee` never exited, `proc.wait()` never returned, and the job was SIGKILLed before
`CHECK_ERRORS` and `COLLECT_LOGS`. That is also why the shape carries no crash trace or
sanitizer report: those were never produced, so their absence says nothing about the server
(1 report link, versus 5 for the sibling job).

The spawn now passes explicit sinks: **12.03 s -> 0.03 s**, with no timeout configured. Both
descriptors matter, since `Shell.run` joins both reader threads. Nothing is lost: the test's own
output already went to the per-test `.stdout`/`.stderr` files, and the wrapper writes nothing to
fd 1. Its fd 2 carries job status (a killed test, a bad redirect target, a syntax error) and
gets a `.stderr-wrapper` file of its own, reported after the retry check rather than sharing the
test's `2>` target, which the test truncates and which is read back as the verdict. The job also
runs `clickhouse-test --cleanup` in a `finally`.

This does not fix #108689 and makes no claim about OOM; it makes the class attributable by
letting log collection and the dmesg OOM check run. A wedged but alive server is out of scope.
A local batch of 220 stateless tests gives identical statuses and reasons.


