### PR TITLE
Keep the Map `bucket_indexes` stream in sync when rows are skipped

### DIFF
--- a/src/DataTypes/DataTypeMap.cpp
+++ b/src/DataTypes/DataTypeMap.cpp
@@ -392,7 +392,9 @@ The serialization layer computes which bucket the requested key belongs to and r
 When the full map is read (e.g., `SELECT m`), all buckets are read and reassembled into the original map. This is slower than `basic` serialization due to the overhead of reading and merging multiple substreams.
 
 :::note
-The order of keys within a map value may differ from the original insertion order when using `with_buckets` serialization. Keys are distributed across buckets by hash and are reassembled in bucket order, not insertion order. With `basic` serialization, the key order from inserted maps is preserved.
+Since version 26.8, `with_buckets` serialization preserves the original key order: an additional `bucket_indexes` substream records which bucket every key-value pair was taken from, so the map is reassembled in the order it was written instead of in bucket order.
+
+Parts written by earlier versions do not contain that substream. Their maps are still reassembled in bucket order, and the original key order cannot be restored for them because it was never stored on disk — rewriting such a part (by a merge or `OPTIMIZE FINAL`) freezes the bucket order it currently has instead of recovering the insertion order. With `basic` serialization, the key order from inserted maps has always been preserved.
 :::
 
 The bucket count can vary between parts. When parts with different bucket counts are merged, the new part's bucket count is recalculated from the merged statistics. Parts with `basic` and `with_buckets` serialization can coexist in the same table and are merged transparently.

--- a/src/DataTypes/Serializations/SerializationMap.cpp
+++ b/src/DataTypes/Serializations/SerializationMap.cpp
@@ -1424,6 +1424,15 @@ void SerializationMap::deserializeBinaryBulkWithMultipleStreams(
     /// otherwise fall back to bucket-ascending order (old parts without the index stream).
     else
     {
+        /// The `bucket_indexes` stream is a flat array with one entry per key-value pair, so the
+        /// number of entries that belong to the first `rows_offset` rows is not known in advance
+        /// and those entries cannot be skipped on their own. Read the skipped rows together with
+        /// the requested ones, reassemble the whole range in the original order and drop the
+        /// prefix afterwards, so that the index stream stays in sync with the bucket streams.
+        const bool reorder_with_skipped_rows = map_state->has_bucket_index && rows_offset != 0;
+        const size_t buckets_rows_offset = reorder_with_skipped_rows ? 0 : rows_offset;
+        const size_t buckets_limit = reorder_with_skipped_rows ? rows_offset + limit : limit;
+
         VectorWithMemoryTracking<ColumnPtr> map_buckets(buckets_info_state->buckets);
         for (size_t bucket = 0; bucket != buckets_info_state->buckets; ++bucket)
         {
@@ -1431,7 +1440,7 @@ void SerializationMap::deserializeBinaryBulkWithMultipleStreams(
             settings.path.back().bucket = bucket;
             map_buckets[bucket] = column_map.cloneEmpty();
             ColumnPtr nested_ptr = assert_cast<const ColumnMap &>(*map_buckets[bucket]).getNestedColumnPtr();
-            nested_serialization->deserializeBinaryBulkWithMultipleStreams(nested_ptr, rows_offset, limit, settings, map_state->bucket_nested_states[bucket], cache);
+            nested_serialization->deserializeBinaryBulkWithMultipleStreams(nested_ptr, buckets_rows_offset, buckets_limit, settings, map_state->bucket_nested_states[bucket], cache);
             settings.path.pop_back();
         }
 
@@ -1454,7 +1463,17 @@ void SerializationMap::deserializeBinaryBulkWithMultipleStreams(
                 bucket_index_column, 0, total_kv_pairs, settings, map_state->bucket_index_state, cache);
             settings.path.pop_back();
 
-            collectMapFromBucketsWithOrder(map_buckets, *bucket_index_column, column_map);
+            if (reorder_with_skipped_rows)
+            {
+                auto whole_range_column = column_map.cloneEmpty();
+                collectMapFromBucketsWithOrder(map_buckets, *bucket_index_column, *whole_range_column);
+                if (whole_range_column->size() > rows_offset)
+                    column_map.insertRangeFrom(*whole_range_column, rows_offset, whole_range_column->size() - rows_offset);
+            }
+            else
+            {
+                collectMapFromBucketsWithOrder(map_buckets, *bucket_index_column, column_map);
+            }
         }
         else
         {

--- a/src/DataTypes/Serializations/SerializationMapKeysOrValues.cpp
+++ b/src/DataTypes/Serializations/SerializationMapKeysOrValues.cpp
@@ -351,13 +351,22 @@ void SerializationMapKeysOrValues::deserializeBinaryBulkWithMultipleStreams(
     /// otherwise fall back to bucket-ascending order (old parts without the index stream).
     else
     {
+        /// The `bucket_indexes` stream is a flat array with one entry per key-value pair, so the
+        /// number of entries that belong to the first `rows_offset` rows is not known in advance
+        /// and those entries cannot be skipped on their own. Read the skipped rows together with
+        /// the requested ones, reassemble the whole range in the original order and drop the
+        /// prefix afterwards, so that the index stream stays in sync with the bucket streams.
+        const bool reorder_with_skipped_rows = map_keys_or_values_with_buckets_state->has_bucket_index && rows_offset != 0;
+        const size_t buckets_rows_offset = reorder_with_skipped_rows ? 0 : rows_offset;
+        const size_t buckets_limit = reorder_with_skipped_rows ? rows_offset + limit : limit;
+
         VectorWithMemoryTracking<ColumnPtr> keys_or_values_buckets(buckets_info_state_concrete->buckets);
         for (size_t bucket = 0; bucket != buckets_info_state_concrete->buckets; ++bucket)
         {
             settings.path.push_back(Substream::Bucket);
             settings.path.back().bucket = bucket;
             keys_or_values_buckets[bucket] = column->cloneEmpty();
-            keys_or_values_serialization->deserializeBinaryBulkWithMultipleStreams(keys_or_values_buckets[bucket], rows_offset, limit, settings, map_keys_or_values_with_buckets_state->bucket_keys_or_values_states[bucket], cache);
+            keys_or_values_serialization->deserializeBinaryBulkWithMultipleStreams(keys_or_values_buckets[bucket], buckets_rows_offset, buckets_limit, settings, map_keys_or_values_with_buckets_state->bucket_keys_or_values_states[bucket], cache);
             settings.path.pop_back();
         }
 
@@ -379,7 +388,17 @@ void SerializationMapKeysOrValues::deserializeBinaryBulkWithMultipleStreams(
                 bucket_index_column, 0, total_kv_pairs, settings, map_keys_or_values_with_buckets_state->bucket_index_state, cache);
             settings.path.pop_back();
 
-            collectMapKeysOrValuesFromBucketsWithOrder(keys_or_values_buckets, *bucket_index_column, *column->assumeMutable());
+            if (reorder_with_skipped_rows)
+            {
+                auto whole_range_column = column->cloneEmpty();
+                collectMapKeysOrValuesFromBucketsWithOrder(keys_or_values_buckets, *bucket_index_column, *whole_range_column);
+                if (whole_range_column->size() > rows_offset)
+                    column->assumeMutable()->insertRangeFrom(*whole_range_column, rows_offset, whole_range_column->size() - rows_offset);
+            }
+            else
+            {
+                collectMapKeysOrValuesFromBucketsWithOrder(keys_or_values_buckets, *bucket_index_column, *column->assumeMutable());
+            }
         }
         else
         {

--- a/src/DataTypes/Serializations/tests/gtest_map_bucketed_serialization.cpp
+++ b/src/DataTypes/Serializations/tests/gtest_map_bucketed_serialization.cpp
@@ -1,0 +1,168 @@
+#include <Columns/ColumnMap.h>
+#include <Core/Field.h>
+#include <Core/MergeTreeSerializationEnums.h>
+#include <DataTypes/IDataType.h>
+#include <DataTypes/DataTypeFactory.h>
+#include <DataTypes/Serializations/ISerialization.h>
+#include <DataTypes/Serializations/SerializationInfoSettings.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromString.h>
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <memory>
+
+using namespace DB;
+
+namespace
+{
+
+constexpr size_t NUM_BUCKETS = 4;
+
+/// A set of in-memory substreams, keyed by the substream name that a real data part would use
+/// as a file name. It plays the role of the on-disk streams of a single column.
+using Streams = std::map<String, String>;
+
+DataTypePtr getMapType()
+{
+    return DataTypeFactory::instance().get("Map(String, UInt64)");
+}
+
+SerializationPtr getBucketedSerialization(const DataTypePtr & type)
+{
+    SerializationInfoSettings info_settings;
+    info_settings.map_serialization_version = MergeTreeMapSerializationVersion::WITH_BUCKETS;
+    return type->getSerialization(info_settings);
+}
+
+/// A `Map` column where every row has a different number of key-value pairs and the keys of a
+/// single row land in several buckets in an order that is not the bucket order. Both properties
+/// are needed to notice a bucket index stream that is out of sync with the bucket streams.
+ColumnPtr makeTestColumn(const DataTypePtr & type, size_t num_rows)
+{
+    auto column = type->createColumn();
+    for (size_t row = 0; row != num_rows; ++row)
+    {
+        Map map;
+        for (size_t i = 0; i != 1 + row % 7; ++i)
+            map.push_back(Tuple{"key_" + std::to_string(row) + "_" + std::to_string(i), UInt64(row * 100 + i)});
+        column->insert(map);
+    }
+    return std::move(column);
+}
+
+Streams serializeWithBuckets(const DataTypePtr & type, const IColumn & column)
+{
+    std::map<String, std::unique_ptr<WriteBufferFromOwnString>> buffers;
+
+    ISerialization::SerializeBinaryBulkSettings settings;
+    settings.write_statistics = ISerialization::SerializeBinaryBulkSettings::StatisticsMode::PREFIX;
+    settings.max_buckets_in_map = NUM_BUCKETS;
+    settings.map_buckets_strategy = MergeTreeMapBucketsStrategy::CONSTANT;
+    settings.getter = [&](const ISerialization::SubstreamPath & path) -> WriteBuffer *
+    {
+        auto name = ISerialization::getSubcolumnNameForStream(path);
+        auto it = buffers.find(name);
+        if (it == buffers.end())
+            it = buffers.emplace(name, std::make_unique<WriteBufferFromOwnString>()).first;
+        return it->second.get();
+    };
+
+    auto serialization = getBucketedSerialization(type);
+    ISerialization::SerializeBinaryBulkStatePtr state;
+    serialization->serializeBinaryBulkStatePrefix(column, settings, state);
+    serialization->serializeBinaryBulkWithMultipleStreams(column, 0, column.size(), settings, state);
+    serialization->serializeBinaryBulkStateSuffix(settings, state);
+
+    Streams streams;
+    for (auto & [name, buffer] : buffers)
+    {
+        buffer->finalize();
+        streams[name] = buffer->str();
+    }
+    return streams;
+}
+
+/// Reads `limit` rows starting from `rows_offset` out of the serialized streams.
+/// `serialization` is either the whole-column serialization or a subcolumn one.
+ColumnPtr deserializeRange(
+    const SerializationPtr & serialization, const DataTypePtr & column_type, const Streams & streams, size_t rows_offset, size_t limit)
+{
+    std::map<String, std::unique_ptr<ReadBufferFromString>> buffers;
+
+    ISerialization::DeserializeBinaryBulkSettings settings;
+    settings.getter = [&](const ISerialization::SubstreamPath & path) -> ReadBuffer *
+    {
+        auto name = ISerialization::getSubcolumnNameForStream(path);
+        auto stream_it = streams.find(name);
+        if (stream_it == streams.end())
+            return nullptr;
+
+        auto it = buffers.find(name);
+        if (it == buffers.end())
+            it = buffers.emplace(name, std::make_unique<ReadBufferFromString>(stream_it->second)).first;
+        return it->second.get();
+    };
+    settings.check_stream_exists_callback = [&](const ISerialization::SubstreamPath & path)
+    {
+        return streams.contains(ISerialization::getSubcolumnNameForStream(path));
+    };
+
+    ISerialization::DeserializeBinaryBulkStatePtr state;
+    serialization->deserializeBinaryBulkStatePrefix(settings, state, nullptr);
+
+    ColumnPtr column = column_type->createColumn();
+    serialization->deserializeBinaryBulkWithMultipleStreams(column, rows_offset, limit, settings, state, nullptr);
+    return column;
+}
+
+void assertRangesEqual(const IColumn & expected, size_t expected_offset, const IColumn & actual)
+{
+    ASSERT_EQ(expected.size() - expected_offset, actual.size());
+    for (size_t row = 0; row != actual.size(); ++row)
+        ASSERT_EQ(expected[expected_offset + row], actual[row]) << "at row " << row;
+}
+
+}
+
+/// The `bucket_indexes` stream that restores the original key order holds one entry per key-value
+/// pair, so it cannot be positioned by a number of rows. Reading a range that starts in the middle
+/// of a granule (`rows_offset > 0`) must still return exactly the rows of that range, in the
+/// original key order, and not the bucket indexes of the skipped rows.
+TEST(MapBucketedSerialization, ReadWithRowsOffset)
+{
+    auto type = getMapType();
+    constexpr size_t num_rows = 20;
+    auto column = makeTestColumn(type, num_rows);
+    auto streams = serializeWithBuckets(type, *column);
+
+    /// More than one bucket is what makes the bucket index stream necessary in the first place.
+    ASSERT_TRUE(streams.contains("bucket_indexes"));
+
+    auto serialization = getBucketedSerialization(type);
+    for (size_t rows_offset = 0; rows_offset != num_rows; ++rows_offset)
+    {
+        auto result = deserializeRange(serialization, type, streams, rows_offset, num_rows - rows_offset);
+        assertRangesEqual(*column, rows_offset, *result);
+    }
+}
+
+/// The same holds for the `keys` subcolumn, which reassembles the keys of all buckets on its own.
+TEST(MapBucketedSerialization, ReadKeysSubcolumnWithRowsOffset)
+{
+    auto type = getMapType();
+    constexpr size_t num_rows = 20;
+    auto column = makeTestColumn(type, num_rows);
+    auto streams = serializeWithBuckets(type, *column);
+
+    auto keys_type = type->getSubcolumnType("keys");
+    auto keys_serialization = type->getSubcolumnSerialization("keys", getBucketedSerialization(type));
+    auto expected_keys = deserializeRange(keys_serialization, keys_type, streams, 0, num_rows);
+
+    for (size_t rows_offset = 1; rows_offset != num_rows; ++rows_offset)
+    {
+        auto result = deserializeRange(keys_serialization, keys_type, streams, rows_offset, num_rows - rows_offset);
+        assertRangesEqual(*expected_keys, rows_offset, *result);
+    }
+}


### PR DESCRIPTION
The bucketed `Map` serialization (`map_serialization_version = 'with_buckets'`) writes a flat `bucket_indexes` stream with one entry per key-value pair and uses it on read to restore the original key order. The two readers of that stream — `SerializationMap::deserializeBinaryBulkWithMultipleStreams` and `SerializationMapKeysOrValues::deserializeBinaryBulkWithMultipleStreams` — forwarded `rows_offset` to the per-bucket streams, but always read the index stream from its current position, i.e. with an implicit offset of zero.

The number of index entries that belong to the skipped rows is not `rows_offset`, it is the number of key-value pairs contained in those rows, so for a partial-granule read the index stream desynchronizes from the bucket streams: the kept rows get reassembled from the bucket ids of earlier rows, and when the skipped and the kept rows have different per-bucket counts the reconstruction can step past the selected bucket slice.

The fix reads the skipped rows together with the requested ones, reassembles the whole range in the original order and drops the prefix afterwards, so that both streams advance by the same amount. A new gtest round-trips a bucketed `Map` and its `keys` subcolumn through in-memory substreams for every `rows_offset`; without the fix it reconstructs the wrong rows and trips a huge allocation.

Note that no caller in this repository passes a non-zero `rows_offset` today (`MergeTreeRangeReader` reads and discards the skipped rows instead), so this is latent rather than user-visible — which is also why it cannot be covered by a stateless test.

The same commit updates the embedded `Map` documentation, which still claimed that `with_buckets` does not preserve the key order. It now states that the order is preserved since 26.8, and that parts written by earlier versions keep their bucket order permanently because the original order was never stored on disk — rewriting such a part by a merge or `OPTIMIZE FINAL` freezes its current bucket order instead of recovering the insertion order.

One review point of the original pull request is deliberately not addressed here, because it is a format decision: presence of the `bucket_indexes` stream is the only discriminator between the old and the new `with_buckets` layout, so an older binary silently ignores the stream and can merge such a part back into the pre-fix layout. Making rolling upgrades monotonic would need a real format/version bit or a compatibility knob.

Related: https://github.com/ClickHouse/ClickHouse/pull/109178

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.705` (included in `26.8` and later)
- Backported to: `26.7.4.3`, `26.6.3.24`, `26.5.7.25`, `26.3.18.14`
<!-- ch-version-info:end -->