### PR TITLE
Column-native IN/set constant handling (remove Field)

### DIFF
--- a/src/Analyzer/Resolve/resolveFunction.cpp
+++ b/src/Analyzer/Resolve/resolveFunction.cpp
@@ -2040,13 +2040,13 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
         if (first_argument_constant_node && second_argument_constant_node)
         {
             const auto & first_argument_constant_type = first_argument_constant_node->getResultType();
-            const auto second_argument_constant_literal = second_argument_constant_node->getValue();
+            const auto & second_argument_constant_column = second_argument_constant_node->getColumn();
             const auto & second_argument_constant_type = second_argument_constant_node->getResultType();
 
             const auto & settings = scope.context->getSettingsRef();
 
             auto result_block = getSetElementsForConstantValue(
-                first_argument_constant_type, second_argument_constant_literal, second_argument_constant_type,
+                first_argument_constant_type, second_argument_constant_column, second_argument_constant_type,
                 GetSetElementParams{
                     .transform_null_in = settings[Setting::transform_null_in],
                     .forbid_unknown_enum_values = settings[Setting::validate_enum_literals_in_operators],

--- a/src/Analyzer/SetUtils.cpp
+++ b/src/Analyzer/SetUtils.cpp
@@ -115,38 +115,27 @@ std::optional<ColumnPtr> convertColumnToTypeCheckEnum(
     }
 }
 
-/// Fast path for a single native-number key: convert all members with one accurate batch cast instead
-/// of a per-member cast. Applies only when the target and every member's source type are plain native
-/// numbers (no `Bool`/`Decimal`/`Enum`/`Nullable`/wide-int) - exactly the case where
-/// `castColumnAccurateOrNull` provably matches the strict per-member `convertColumnToType` (pinned by
-/// `gtest_convert_column_to_type`). It is element-wise, so per-row results and their order are identical
-/// to the per-member loop; only not-representable values (NULL in the cast result) are dropped, matching
-/// strict conversion into the non-nullable native target. Returns false (caller uses the per-member
-/// loop) for anything else, so no reordering or behavior change can leak in. `out` is the non-nullable
-/// target column being built.
-bool tryConvertNativeNumberMembersBatch(IColumn & out, const SetMembers & members, const DataTypePtr & lhs_type)
+/// Whether a whole `source`-typed column can be converted to `lhs_type` with one accurate batch cast
+/// instead of per-element conversion: both must be plain native numbers (no
+/// `Bool`/`Decimal`/`Enum`/`Nullable`/wide-int). This is exactly the case where
+/// `castColumnAccurateOrNull` provably matches the strict per-element `convertColumnToType` (pinned by
+/// `gtest_convert_column_to_type`).
+bool nativeBatchApplicable(const DataTypePtr & source_type, const DataTypePtr & lhs_type)
 {
-    if (!isNativeNumber(lhs_type) || isBool(lhs_type))
-        return false;
+    return isNativeNumber(source_type) && isNativeNumber(lhs_type) && !isBool(source_type) && !isBool(lhs_type);
+}
 
-    if (members.empty())
-        return true;
+/// Batch-convert every row of `source` (a column of `source_type`) into `lhs_type` with one accurate
+/// cast and append the results to `out`. Precondition: `nativeBatchApplicable(source_type, lhs_type)`.
+/// The cast is element-wise, so per-row results and their order match the per-element loop; only
+/// not-representable values (NULL in the cast result) are dropped, matching strict conversion into the
+/// non-nullable native target. `out` is the non-nullable target column being built.
+void appendNativeBatch(IColumn & out, const IColumn & source, const DataTypePtr & source_type, const DataTypePtr & lhs_type)
+{
+    if (source.empty())
+        return;
 
-    const DataTypePtr & source_type = members.front().type;
-    if (!isNativeNumber(source_type) || isBool(source_type))
-        return false;
-    for (const auto & member : members)
-        if (!member.type->equals(*source_type))
-            return false;
-
-    /// Gather the size-1 member columns into one column of the (homogeneous) source type. This is a
-    /// plain copy - no conversion - so the single accurate cast below carries all the per-element cost.
-    MutableColumnPtr gathered = source_type->createColumn();
-    gathered->reserve(members.size());
-    for (const auto & member : members)
-        gathered->insertRangeFrom(*member.column, 0, 1);
-
-    ColumnPtr casted = castColumnAccurateOrNull({std::move(gathered), source_type, ""}, lhs_type);
+    ColumnPtr casted = castColumnAccurateOrNull({source.getPtr(), source_type, ""}, lhs_type);
     casted = casted->convertToFullColumnIfConst();
     const auto & nullable = assert_cast<const ColumnNullable &>(*casted);
     const auto & null_map = nullable.getNullMapData();
@@ -156,7 +145,36 @@ bool tryConvertNativeNumberMembersBatch(IColumn & out, const SetMembers & member
     for (size_t i = 0, size = null_map.size(); i < size; ++i)
         if (!null_map[i])
             out.insertFrom(nested, i);
+}
 
+/// Fast path for a single native-number key whose members are separate size-1 columns (e.g. a `Tuple`
+/// collection): gather them into one column and convert with a single batch cast. Returns false (caller
+/// uses the per-member loop) unless the target and every member share a plain native-number type, so no
+/// reordering or behavior change can leak in. For an `Array` collection the elements are already
+/// contiguous, so `build_from_array` converts the data column directly and never reaches here.
+bool tryConvertNativeNumberMembersBatch(IColumn & out, const SetMembers & members, const DataTypePtr & lhs_type)
+{
+    if (!isNativeNumber(lhs_type) || isBool(lhs_type))
+        return false;
+
+    if (members.empty())
+        return true;
+
+    const DataTypePtr & source_type = members.front().type;
+    if (!nativeBatchApplicable(source_type, lhs_type))
+        return false;
+    for (const auto & member : members)
+        if (!member.type->equals(*source_type))
+            return false;
+
+    /// Gather the size-1 member columns into one column of the (homogeneous) source type. This is a
+    /// plain copy - no conversion - so the single accurate cast carries all the per-element cost.
+    MutableColumnPtr gathered = source_type->createColumn();
+    gathered->reserve(members.size());
+    for (const auto & member : members)
+        gathered->insertRangeFrom(*member.column, 0, 1);
+
+    appendNativeBatch(out, *gathered, source_type, lhs_type);
     return true;
 }
 
@@ -373,6 +391,191 @@ SetMembers membersFromArray(const ColumnPtr & rhs_column, const DataTypePtr & ar
     return members;
 }
 
+/// Single native key (`x IN [...]`): batch-convert the whole key column with one accurate cast, then
+/// emit the set column honoring NULLs. `source` is the (non-nullable) native value column and
+/// `element_null` (may be null) marks genuine NULL array elements - i.e. a `Nullable(native)` element
+/// type. `source_type`/`lhs_type` may be `Nullable`; only their inner native types matter for the cast.
+///
+/// Per row, matching the general per-element single-key loop exactly:
+///   - genuine NULL element -> insert NULL iff `transform_null_in` and the target is nullable, else skip;
+///   - not-representable value (NULL in the accurate-cast result) -> skip;
+///   - otherwise -> insert the converted value.
+ColumnsWithTypeAndName buildSingleNativeKey(
+    const ColumnPtr & source, const DataTypePtr & source_type, const DataTypePtr & lhs_type,
+    const NullMap * element_null, bool transform_null_in)
+{
+    ColumnPtr casted = castColumnAccurateOrNull({source, removeNullable(source_type), ""}, removeNullable(lhs_type));
+    casted = casted->convertToFullColumnIfConst();
+    const auto & casted_nullable = assert_cast<const ColumnNullable &>(*casted);
+    const IColumn & casted_nested = casted_nullable.getNestedColumn();
+
+    const bool lhs_nullable = lhs_type->isNullable();
+    MutableColumnPtr out = lhs_type->createColumn();
+    out->reserve(source->size());
+
+    for (size_t row = 0, n = source->size(); row < n; ++row)
+    {
+        if (element_null && (*element_null)[row])
+        {
+            if (transform_null_in && lhs_nullable)
+            {
+                auto & nullable_out = assert_cast<ColumnNullable &>(*out);
+                nullable_out.getNestedColumn().insertDefault();
+                nullable_out.getNullMapData().push_back(UInt8(1));
+            }
+            continue;
+        }
+
+        if (casted_nullable.isNullAt(row)) /// not representable in the target
+            continue;
+
+        if (lhs_nullable)
+        {
+            auto & nullable_out = assert_cast<ColumnNullable &>(*out);
+            nullable_out.getNestedColumn().insertFrom(casted_nested, row);
+            nullable_out.getNullMapData().push_back(UInt8(0));
+        }
+        else
+        {
+            out->insertFrom(casted_nested, row);
+        }
+    }
+
+    ColumnsWithTypeAndName res(1);
+    res[0].type = lhs_type;
+    res[0].column = std::move(out);
+    return res;
+}
+
+/// Batch-convert `k > 1` parallel source key columns (each `n` rows) into `target_types` with one
+/// accurate cast per key, then keep only the rows where every key converts. Precondition: every
+/// `nativeBatchApplicable(source_types[j], target_types[j])` (in particular every target is a
+/// non-nullable native number).
+///
+/// A set row (one key tuple) is kept iff it is not an array-element NULL (`element_null`, for an
+/// `Array(Nullable(Tuple))` RHS; may be null) and every key value is exactly representable in its target
+/// (a NULL in the accurate-cast result means not-representable; native targets are non-nullable so
+/// `transform_null_in` never keeps a NULL). This matches the general per-element multi-key loop exactly,
+/// but converts each key column as a whole instead of cutting per element.
+ColumnsWithTypeAndName buildNativeKeysBatch(
+    const Columns & sources, const DataTypes & source_types, const DataTypes & target_types, const NullMap * element_null)
+{
+    const size_t k = sources.size();
+    const size_t n = sources.empty() ? 0 : sources[0]->size();
+
+    std::vector<const ColumnNullable *> casted(k);
+    Columns casted_holder(k);
+    for (size_t j = 0; j < k; ++j)
+    {
+        ColumnPtr c = castColumnAccurateOrNull({sources[j], source_types[j], ""}, target_types[j]);
+        casted_holder[j] = c->convertToFullColumnIfConst();
+        casted[j] = &assert_cast<const ColumnNullable &>(*casted_holder[j]);
+    }
+
+    MutableColumns out(k);
+    for (size_t j = 0; j < k; ++j)
+    {
+        out[j] = target_types[j]->createColumn();
+        out[j]->reserve(n);
+    }
+
+    for (size_t row = 0; row < n; ++row)
+    {
+        bool skip = element_null && (*element_null)[row];
+        for (size_t j = 0; !skip && j < k; ++j)
+            skip = casted[j]->isNullAt(row);
+        if (skip)
+            continue;
+        for (size_t j = 0; j < k; ++j)
+            out[j]->insertFrom(casted[j]->getNestedColumn(), row);
+    }
+
+    ColumnsWithTypeAndName res(k);
+    for (size_t j = 0; j < k; ++j)
+    {
+        res[j].type = target_types[j];
+        res[j].column = std::move(out[j]);
+    }
+    return res;
+}
+
+/// Columnar fast path for an `Array` RHS whose key columns are all native numbers - single scalar key
+/// (`x IN [...]`, including a `Nullable` element type and/or a `Nullable` key) or a multi-column key over
+/// an array of tuples (`(a, b) IN [(1, 2), (3, 4)]`). Because an `Array` is homogeneous, every element
+/// shares one nested type, so the `k` key values are already laid out as `k` contiguous columns (the
+/// array's data column, or the sub-columns of its data `Tuple`) - converted directly, without
+/// `membersFromArray` cutting each element into a size-1 column. Returns nullopt (caller uses the general
+/// per-element path, preserving its exact errors) unless every target key column is native (ignoring an
+/// outer `Nullable`) and the RHS shape lines up.
+std::optional<ColumnsWithTypeAndName> tryBuildFromNativeArray(
+    const ColumnPtr & rhs_column, const DataTypePtr & nested_type, const DataTypes & lhs_unpacked_types,
+    GetSetElementParams params)
+{
+    const size_t k = lhs_unpacked_types.size();
+
+    ColumnPtr full = rhs_column->convertToFullColumnIfConst();
+    const ColumnPtr & data = assert_cast<const ColumnArray &>(*full).getDataPtr();
+
+    if (k == 1)
+    {
+        /// Single scalar key: the array's data column is the only key column. Multi-key handling below
+        /// requires non-nullable native keys, but a single key can be `Nullable` on either side - the
+        /// per-row NULL policy is handled by `buildSingleNativeKey`.
+        const DataTypePtr & lhs_type = lhs_unpacked_types[0];
+        if (!nativeBatchApplicable(removeNullable(nested_type), removeNullable(lhs_type)))
+            return std::nullopt;
+
+        /// Unwrap a `Nullable` element type into the inner native column + the element null-map.
+        ColumnPtr source = data;
+        const NullMap * element_null = nullptr;
+        if (const auto * nullable = typeid_cast<const ColumnNullable *>(data.get()))
+        {
+            element_null = &nullable->getNullMapData();
+            source = nullable->getNestedColumnPtr();
+        }
+
+        return buildSingleNativeKey(source, nested_type, lhs_type, element_null, params.transform_null_in);
+    }
+
+    {
+        Columns sources;
+        DataTypes source_types;
+        const NullMap * element_null = nullptr;
+        /// Multi-column key: the elements must be tuples of matching arity, all key columns native.
+        DataTypePtr inner = nested_type;
+        if (const auto * nullable_type = typeid_cast<const DataTypeNullable *>(inner.get()))
+            inner = nullable_type->getNestedType();
+        const auto * tuple_type = typeid_cast<const DataTypeTuple *>(inner.get());
+        if (!tuple_type)
+            return std::nullopt;
+
+        const auto & element_types = tuple_type->getElements();
+        if (element_types.size() != k)
+            return std::nullopt;
+        for (size_t j = 0; j < k; ++j)
+            if (!nativeBatchApplicable(element_types[j], lhs_unpacked_types[j]))
+                return std::nullopt;
+
+        const IColumn * data_col = data.get();
+        if (const auto * nullable = typeid_cast<const ColumnNullable *>(data_col))
+        {
+            element_null = &nullable->getNullMapData();
+            data_col = &nullable->getNestedColumn();
+        }
+        const auto & tuple_column = assert_cast<const ColumnTuple &>(*data_col);
+
+        sources.reserve(k);
+        source_types.reserve(k);
+        for (size_t j = 0; j < k; ++j)
+        {
+            sources.push_back(tuple_column.getColumnPtr(j));
+            source_types.push_back(element_types[j]);
+        }
+
+        return buildNativeKeysBatch(sources, source_types, lhs_unpacked_types, element_null);
+    }
+}
+
 /// Build set members from a `Tuple` collection column (size-1, holds one tuple): the members are the
 /// tuple's elements (each a size-1 column), with the tuple element types.
 SetMembers membersFromTuple(const ColumnPtr & rhs_column, const DataTypePtr & tuple_type)
@@ -502,6 +705,13 @@ ColumnsWithTypeAndName getSetElementsForConstantValue(
 
     auto build_from_array = [&](const DataTypePtr & type)
     {
+        /// Hot path: an `Array` RHS whose key columns are all native numbers (single scalar key, or a
+        /// multi-column key over an array of tuples). The array is homogeneous, so its elements are
+        /// already contiguous key columns - convert them directly, without `membersFromArray` cutting
+        /// each element into a size-1 column. Everything else keeps the general per-element path.
+        const auto & nested_type = assert_cast<const DataTypeArray &>(*type).getNestedType();
+        if (auto fast = tryBuildFromNativeArray(rhs_column, nested_type, lhs_unpacked_types, params))
+            return std::move(*fast);
         return createBlockFromCollection(membersFromArray(rhs_column, type), lhs_unpacked_types, params);
     };
 

--- a/src/Analyzer/SetUtils.cpp
+++ b/src/Analyzer/SetUtils.cpp
@@ -5,6 +5,7 @@
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnTuple.h>
+#include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -125,47 +126,40 @@ bool nativeBatchApplicable(const DataTypePtr & source_type, const DataTypePtr & 
     return isNativeNumber(source_type) && isNativeNumber(lhs_type) && !isBool(source_type) && !isBool(lhs_type);
 }
 
-/// Batch-convert every row of `source` (a column of `source_type`) into `lhs_type` with one accurate
-/// cast and append the results to `out`. Precondition: `nativeBatchApplicable(source_type, lhs_type)`.
-/// The cast is element-wise, so per-row results and their order match the per-element loop; only
-/// not-representable values (NULL in the cast result) are dropped, matching strict conversion into the
-/// non-nullable native target. `out` is the non-nullable target column being built.
-void appendNativeBatch(IColumn & out, const IColumn & source, const DataTypePtr & source_type, const DataTypePtr & lhs_type)
+/// Build an `IColumn::filter` (1 = keep) that drops the NULL rows of `null_map` (keeps row `i` where
+/// `null_map[i] == 0`); `kept` receives the number of kept rows.
+IColumn::Filter keepNotNullFilter(const NullMap & null_map, size_t & kept)
 {
-    if (source.empty())
-        return;
-
-    ColumnPtr casted = castColumnAccurateOrNull({source.getPtr(), source_type, ""}, lhs_type);
-    casted = casted->convertToFullColumnIfConst();
-    const auto & nullable = assert_cast<const ColumnNullable &>(*casted);
-    const auto & null_map = nullable.getNullMapData();
-    const auto & nested = nullable.getNestedColumn();
-
-    out.reserve(out.size() + null_map.size());
-    for (size_t i = 0, size = null_map.size(); i < size; ++i)
-        if (!null_map[i])
-            out.insertFrom(nested, i);
+    IColumn::Filter filter(null_map.size());
+    kept = 0;
+    for (size_t i = 0, n = null_map.size(); i < n; ++i)
+    {
+        filter[i] = null_map[i] ? 0 : 1;
+        kept += filter[i];
+    }
+    return filter;
 }
 
 /// Fast path for a single native-number key whose members are separate size-1 columns (e.g. a `Tuple`
-/// collection): gather them into one column and convert with a single batch cast. Returns false (caller
-/// uses the per-member loop) unless the target and every member share a plain native-number type, so no
-/// reordering or behavior change can leak in. For an `Array` collection the elements are already
-/// contiguous, so `build_from_array` converts the data column directly and never reaches here.
-bool tryConvertNativeNumberMembersBatch(IColumn & out, const SetMembers & members, const DataTypePtr & lhs_type)
+/// collection): gather them into one column, cast once, and drop the not-representable rows with a
+/// single `IColumn::filter`. Returns nullopt (caller uses the per-member loop) unless the target and
+/// every member share a plain native-number type, so no reordering or behavior change can leak in. For
+/// an `Array` collection the elements are already contiguous, so `build_from_array` converts the data
+/// column directly and never reaches here.
+std::optional<ColumnPtr> tryConvertNativeNumberMembersBatch(const SetMembers & members, const DataTypePtr & lhs_type)
 {
     if (!isNativeNumber(lhs_type) || isBool(lhs_type))
-        return false;
+        return std::nullopt;
 
     if (members.empty())
-        return true;
+        return ColumnPtr(lhs_type->createColumn());
 
     const DataTypePtr & source_type = members.front().type;
     if (!nativeBatchApplicable(source_type, lhs_type))
-        return false;
+        return std::nullopt;
     for (const auto & member : members)
         if (!member.type->equals(*source_type))
-            return false;
+            return std::nullopt;
 
     /// Gather the size-1 member columns into one column of the (homogeneous) source type. This is a
     /// plain copy - no conversion - so the single accurate cast carries all the per-element cost.
@@ -174,8 +168,13 @@ bool tryConvertNativeNumberMembersBatch(IColumn & out, const SetMembers & member
     for (const auto & member : members)
         gathered->insertRangeFrom(*member.column, 0, 1);
 
-    appendNativeBatch(out, *gathered, source_type, lhs_type);
-    return true;
+    ColumnPtr casted = castColumnAccurateOrNull({std::move(gathered), source_type, ""}, lhs_type);
+    casted = casted->convertToFullColumnIfConst();
+    const auto & nullable = assert_cast<const ColumnNullable &>(*casted);
+
+    size_t kept = 0;
+    IColumn::Filter filter = keepNotNullFilter(nullable.getNullMapData(), kept);
+    return nullable.getNestedColumn().filter(filter, kept);
 }
 
 /// Unwrap a non-NULL member column down to its `ColumnTuple` (the member holds a Tuple value at row 0).
@@ -203,8 +202,6 @@ ColumnsWithTypeAndName createBlockFromCollection(
     if (num_elements == 1)
     {
         const auto & lhs_type = lhs_unpacked_types[0];
-        MutableColumnPtr column = lhs_type->createColumn();
-        column->reserve(members.size());
 
         /// For `Nullable(Tuple(...))` we process tuple members element-by-element:
         /// - to correctly skip unknown enum literals when `validate_enum_literals_in_operators = 0`
@@ -216,6 +213,8 @@ ColumnsWithTypeAndName createBlockFromCollection(
         if (lhs_tuple)
         {
             const auto & lhs_tuple_element_types = lhs_tuple->getElements();
+            MutableColumnPtr column = lhs_type->createColumn();
+            column->reserve(members.size());
             auto & nullable_column = assert_cast<ColumnNullable &>(*column);
 
             for (const auto & member : members)
@@ -295,16 +294,24 @@ ColumnsWithTypeAndName createBlockFromCollection(
         }
 
         /// Generic single-key column (all cases except `Nullable(Tuple(...))`, e.g. T / Nullable(T) / Tuple() / Tuple(T))
-        if (!tryConvertNativeNumberMembersBatch(*column, members, lhs_type))
+        /// Fast path: all members share one native-number type -> one batch cast + a single filter.
+        if (auto fast = tryConvertNativeNumberMembersBatch(members, lhs_type))
         {
-            for (const auto & member : members)
-            {
-                auto converted = convertColumnToTypeCheckEnum(*member.column, member.type, lhs_type, params.forbid_unknown_enum_values);
+            ColumnsWithTypeAndName res(1);
+            res[0].type = lhs_type;
+            res[0].column = std::move(*fast);
+            return res;
+        }
 
-                bool need_insert_null = params.transform_null_in && column->isNullable();
-                if (converted && (!(*converted)->isNullAt(0) || need_insert_null))
-                    column->insertRangeFrom(**converted, 0, 1);
-            }
+        MutableColumnPtr column = lhs_type->createColumn();
+        column->reserve(members.size());
+        for (const auto & member : members)
+        {
+            auto converted = convertColumnToTypeCheckEnum(*member.column, member.type, lhs_type, params.forbid_unknown_enum_values);
+
+            bool need_insert_null = params.transform_null_in && column->isNullable();
+            if (converted && (!(*converted)->isNullAt(0) || need_insert_null))
+                column->insertRangeFrom(**converted, 0, 1);
         }
 
         ColumnsWithTypeAndName res(1);
@@ -400,51 +407,43 @@ SetMembers membersFromArray(const ColumnPtr & rhs_column, const DataTypePtr & ar
 ///   - genuine NULL element -> insert NULL iff `transform_null_in` and the target is nullable, else skip;
 ///   - not-representable value (NULL in the accurate-cast result) -> skip;
 ///   - otherwise -> insert the converted value.
-ColumnsWithTypeAndName buildSingleNativeKey(
+ColumnPtr buildSingleNativeKey(
     const ColumnPtr & source, const DataTypePtr & source_type, const DataTypePtr & lhs_type,
     const NullMap * element_null, bool transform_null_in)
 {
     ColumnPtr casted = castColumnAccurateOrNull({source, removeNullable(source_type), ""}, removeNullable(lhs_type));
     casted = casted->convertToFullColumnIfConst();
     const auto & casted_nullable = assert_cast<const ColumnNullable &>(*casted);
-    const IColumn & casted_nested = casted_nullable.getNestedColumn();
+    const NullMap & casted_null = casted_nullable.getNullMapData();
 
+    const size_t n = source->size();
     const bool lhs_nullable = lhs_type->isNullable();
-    MutableColumnPtr out = lhs_type->createColumn();
-    out->reserve(source->size());
 
-    for (size_t row = 0, n = source->size(); row < n; ++row)
+    /// Build the keep filter (and, for a nullable target, the result null-map) in one pass, then apply a
+    /// single vectorized `filter`. This mirrors the general per-element loop: a genuine NULL element is
+    /// kept as NULL iff `transform_null_in` and the target is nullable (else dropped); a not-representable
+    /// value (NULL in the accurate cast) is dropped; otherwise the converted value is kept.
+    IColumn::Filter keep(n);
+    auto result_null_map = lhs_nullable ? ColumnUInt8::create() : ColumnUInt8::MutablePtr{};
+    NullMap * result_null_data = result_null_map ? &result_null_map->getData() : nullptr;
+    size_t kept = 0;
+    for (size_t row = 0; row < n; ++row)
     {
-        if (element_null && (*element_null)[row])
+        const bool genuine_null = element_null && (*element_null)[row];
+        UInt8 k = genuine_null ? static_cast<UInt8>(transform_null_in && lhs_nullable) : static_cast<UInt8>(!casted_null[row]);
+        keep[row] = k;
+        if (k)
         {
-            if (transform_null_in && lhs_nullable)
-            {
-                auto & nullable_out = assert_cast<ColumnNullable &>(*out);
-                nullable_out.getNestedColumn().insertDefault();
-                nullable_out.getNullMapData().push_back(UInt8(1));
-            }
-            continue;
-        }
-
-        if (casted_nullable.isNullAt(row)) /// not representable in the target
-            continue;
-
-        if (lhs_nullable)
-        {
-            auto & nullable_out = assert_cast<ColumnNullable &>(*out);
-            nullable_out.getNestedColumn().insertFrom(casted_nested, row);
-            nullable_out.getNullMapData().push_back(UInt8(0));
-        }
-        else
-        {
-            out->insertFrom(casted_nested, row);
+            ++kept;
+            if (result_null_data)
+                result_null_data->push_back(static_cast<UInt8>(genuine_null));
         }
     }
 
-    ColumnsWithTypeAndName res(1);
-    res[0].type = lhs_type;
-    res[0].column = std::move(out);
-    return res;
+    ColumnPtr nested_kept = casted_nullable.getNestedColumn().filter(keep, kept);
+    if (!lhs_nullable)
+        return nested_kept;
+    return ColumnNullable::create(nested_kept, std::move(result_null_map));
 }
 
 /// Batch-convert `k > 1` parallel source key columns (each `n` rows) into `target_types` with one
@@ -472,29 +471,24 @@ ColumnsWithTypeAndName buildNativeKeysBatch(
         casted[j] = &assert_cast<const ColumnNullable &>(*casted_holder[j]);
     }
 
-    MutableColumns out(k);
-    for (size_t j = 0; j < k; ++j)
-    {
-        out[j] = target_types[j]->createColumn();
-        out[j]->reserve(n);
-    }
-
+    /// Build one shared keep filter (a row/tuple is kept iff it is not an array-element NULL and every
+    /// key is representable), then apply a single vectorized `filter` per key column.
+    IColumn::Filter keep(n);
+    size_t kept = 0;
     for (size_t row = 0; row < n; ++row)
     {
-        bool skip = element_null && (*element_null)[row];
-        for (size_t j = 0; !skip && j < k; ++j)
-            skip = casted[j]->isNullAt(row);
-        if (skip)
-            continue;
-        for (size_t j = 0; j < k; ++j)
-            out[j]->insertFrom(casted[j]->getNestedColumn(), row);
+        bool drop = element_null && (*element_null)[row];
+        for (size_t j = 0; !drop && j < k; ++j)
+            drop = casted[j]->isNullAt(row);
+        keep[row] = drop ? 0 : 1;
+        kept += keep[row];
     }
 
     ColumnsWithTypeAndName res(k);
     for (size_t j = 0; j < k; ++j)
     {
         res[j].type = target_types[j];
-        res[j].column = std::move(out[j]);
+        res[j].column = casted[j]->getNestedColumn().filter(keep, kept);
     }
     return res;
 }
@@ -534,7 +528,7 @@ std::optional<ColumnsWithTypeAndName> tryBuildFromNativeArray(
             source = nullable->getNestedColumnPtr();
         }
 
-        return buildSingleNativeKey(source, nested_type, lhs_type, element_null, params.transform_null_in);
+        return ColumnsWithTypeAndName{{buildSingleNativeKey(source, nested_type, lhs_type, element_null, params.transform_null_in), lhs_type, ""}};
     }
 
     {

--- a/src/Analyzer/SetUtils.cpp
+++ b/src/Analyzer/SetUtils.cpp
@@ -11,6 +11,7 @@
 #include <DataTypes/DataTypeTuple.h>
 
 #include <Interpreters/Set.h>
+#include <Interpreters/castColumn.h>
 #include <Interpreters/convertColumnToType.h>
 
 #include <Common/assert_cast.h>
@@ -112,6 +113,51 @@ std::optional<ColumnPtr> convertColumnToTypeCheckEnum(
             return std::nullopt;
         throw;
     }
+}
+
+/// Fast path for a single native-number key: convert all members with one accurate batch cast instead
+/// of a per-member cast. Applies only when the target and every member's source type are plain native
+/// numbers (no `Bool`/`Decimal`/`Enum`/`Nullable`/wide-int) - exactly the case where
+/// `castColumnAccurateOrNull` provably matches the strict per-member `convertColumnToType` (pinned by
+/// `gtest_convert_column_to_type`). It is element-wise, so per-row results and their order are identical
+/// to the per-member loop; only not-representable values (NULL in the cast result) are dropped, matching
+/// strict conversion into the non-nullable native target. Returns false (caller uses the per-member
+/// loop) for anything else, so no reordering or behavior change can leak in. `out` is the non-nullable
+/// target column being built.
+bool tryConvertNativeNumberMembersBatch(IColumn & out, const SetMembers & members, const DataTypePtr & lhs_type)
+{
+    if (!isNativeNumber(lhs_type) || isBool(lhs_type))
+        return false;
+
+    if (members.empty())
+        return true;
+
+    const DataTypePtr & source_type = members.front().type;
+    if (!isNativeNumber(source_type) || isBool(source_type))
+        return false;
+    for (const auto & member : members)
+        if (!member.type->equals(*source_type))
+            return false;
+
+    /// Gather the size-1 member columns into one column of the (homogeneous) source type. This is a
+    /// plain copy - no conversion - so the single accurate cast below carries all the per-element cost.
+    MutableColumnPtr gathered = source_type->createColumn();
+    gathered->reserve(members.size());
+    for (const auto & member : members)
+        gathered->insertRangeFrom(*member.column, 0, 1);
+
+    ColumnPtr casted = castColumnAccurateOrNull({std::move(gathered), source_type, ""}, lhs_type);
+    casted = casted->convertToFullColumnIfConst();
+    const auto & nullable = assert_cast<const ColumnNullable &>(*casted);
+    const auto & null_map = nullable.getNullMapData();
+    const auto & nested = nullable.getNestedColumn();
+
+    out.reserve(out.size() + null_map.size());
+    for (size_t i = 0, size = null_map.size(); i < size; ++i)
+        if (!null_map[i])
+            out.insertFrom(nested, i);
+
+    return true;
 }
 
 /// Unwrap a non-NULL member column down to its `ColumnTuple` (the member holds a Tuple value at row 0).
@@ -231,13 +277,16 @@ ColumnsWithTypeAndName createBlockFromCollection(
         }
 
         /// Generic single-key column (all cases except `Nullable(Tuple(...))`, e.g. T / Nullable(T) / Tuple() / Tuple(T))
-        for (const auto & member : members)
+        if (!tryConvertNativeNumberMembersBatch(*column, members, lhs_type))
         {
-            auto converted = convertColumnToTypeCheckEnum(*member.column, member.type, lhs_type, params.forbid_unknown_enum_values);
+            for (const auto & member : members)
+            {
+                auto converted = convertColumnToTypeCheckEnum(*member.column, member.type, lhs_type, params.forbid_unknown_enum_values);
 
-            bool need_insert_null = params.transform_null_in && column->isNullable();
-            if (converted && (!(*converted)->isNullAt(0) || need_insert_null))
-                column->insertRangeFrom(**converted, 0, 1);
+                bool need_insert_null = params.transform_null_in && column->isNullable();
+                if (converted && (!(*converted)->isNullAt(0) || need_insert_null))
+                    column->insertRangeFrom(**converted, 0, 1);
+            }
         }
 
         ColumnsWithTypeAndName res(1);

--- a/src/Analyzer/SetUtils.cpp
+++ b/src/Analyzer/SetUtils.cpp
@@ -2,6 +2,7 @@
 
 #include <Core/Block.h>
 
+#include <Columns/ColumnArray.h>
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnTuple.h>
 #include <DataTypes/DataTypeArray.h>
@@ -10,7 +11,7 @@
 #include <DataTypes/DataTypeTuple.h>
 
 #include <Interpreters/Set.h>
-#include <Interpreters/convertFieldToType.h>
+#include <Interpreters/convertColumnToType.h>
 
 #include <Common/assert_cast.h>
 
@@ -80,135 +81,147 @@ size_t getCompoundTypeDepth(const IDataType & type)
     return depth;
 }
 
-/// Uses `convertFieldToType` with `strict=true` to prevent unexpected results in case of conversion with loss of precision.
-/// Example: `SELECT 33.3 :: Decimal(9, 1) AS a WHERE a IN (33.33 :: Decimal(9, 2))`
-/// 33.33 in the set is converted to 33.3, but it is not equal to 33.3 in the column, so the result should still be empty.
-/// We can not include values that don't represent any possible value from the type of filtered column to the set.
-std::optional<Field> convertFieldToTypeCheckEnum(
-    const Field & from_value, const IDataType & from_type, const IDataType & to_type, bool forbid_unknown_enum_values)
+/// A single set member as a size-1 column of `type` (its value is at row 0).
+struct SetMember
+{
+    ColumnPtr column;
+    DataTypePtr type;
+};
+using SetMembers = std::vector<SetMember>;
+
+/// Column-native twin of the previous `convertFieldToTypeCheckEnum`. Converts row 0 of the size-1
+/// `member` column of type `from_type` into `to_type` with `strict=true` (so values not exactly
+/// representable in `to_type` are excluded from the set - e.g. `33.33 :: Decimal(9,2)` for a
+/// `Decimal(9,1)` column). Returns:
+///   - `std::nullopt` to SKIP the member: not representable (`convertColumnToTypeOrNull` returned {}),
+///     or an unknown enum literal when `forbid_unknown_enum_values` is false;
+///   - otherwise a size-1 column of `to_type` (which may hold NULL for a genuine NULL member).
+std::optional<ColumnPtr> convertColumnToTypeCheckEnum(
+    const IColumn & member, const DataTypePtr & from_type, const DataTypePtr & to_type, bool forbid_unknown_enum_values)
 {
     try
     {
-        Field result = convertFieldToType(from_value, to_type, &from_type, {}, /*strict=*/ true);
-
-        /// `convertFieldToType` with `strict=true` returns Null on failed conversion (out-of-range,
-        /// loss of precision, non-representable Bool values like 10, etc). We treat this as
-        /// "not representable in the target type" and return nullopt so the value is excluded
-        /// from the set, rather than being inserted as NULL. The NULL -> NULL case is kept valid
-        /// because a genuine NULL in the source should remain NULL in the set.
-        if (!from_value.isNull() && result.isNull())
+        ColumnPtr result = convertColumnToTypeOrNull(member, from_type, to_type, {}, /*strict=*/true);
+        if (!result)
             return std::nullopt;
-
         return result;
     }
     catch (const Exception & e)
     {
         if (!forbid_unknown_enum_values && isEnum(to_type) && e.code() == ErrorCodes::UNKNOWN_ELEMENT_OF_ENUM)
-            return {};
+            return std::nullopt;
         throw;
     }
 }
 
-/// rhs_collection can be:
-/// Array: [1, 2, 3] or [(1, 2), (3, 4)] or [NULL]
-/// Tuple: (1, 2, 3) or ((1, 2), (3, 4), (5, 6), (7, 8)) or (NULL, NULL)
-template <typename Collection>
-ColumnsWithTypeAndName createBlockFromCollection(
-    const Collection & rhs_collection, const DataTypes & rhs_types, const DataTypes & lhs_unpacked_types, GetSetElementParams params)
+/// Unwrap a non-NULL member column down to its `ColumnTuple` (the member holds a Tuple value at row 0).
+const ColumnTuple & getMemberTuple(const ColumnPtr & member_column, ColumnPtr & holder)
 {
-    chassert(rhs_collection.size() == rhs_types.size());
+    holder = member_column->convertToFullColumnIfConst();
+    if (const auto * nullable = typeid_cast<const ColumnNullable *>(holder.get()))
+        holder = nullable->getNestedColumnPtr();
+    return assert_cast<const ColumnTuple &>(*holder);
+}
 
+/// Build the converted set columns from the set members (each a size-1 column). Column-native
+/// counterpart of the previous `Field`-based `createBlockFromCollection`.
+///
+/// members can be:
+/// - single-key: [1], [2], [3] (each member a scalar), or Tuple members for a `Nullable(Tuple)` LHS;
+/// - multi-key: each member a Tuple that is unpacked into `lhs_unpacked_types.size()` columns.
+ColumnsWithTypeAndName createBlockFromCollection(
+    const SetMembers & members, const DataTypes & lhs_unpacked_types, GetSetElementParams params)
+{
     size_t num_elements = lhs_unpacked_types.size();
 
     /// Fast path: single key column (lhs_unpacked_types.size() == 1)
-    /// Special-case `Nullable(Tuple(...))`; otherwise generic scalar conversion
+    /// Special-case `Nullable(Tuple(...))`; otherwise generic scalar conversion.
     if (num_elements == 1)
     {
         const auto & lhs_type = lhs_unpacked_types[0];
         MutableColumnPtr column = lhs_type->createColumn();
-        column->reserve(rhs_collection.size());
+        column->reserve(members.size());
 
-        /// For `Nullable(Tuple(...))` we process tuple values element-by-element:
+        /// For `Nullable(Tuple(...))` we process tuple members element-by-element:
         /// - to correctly skip unknown enum literals when `validate_enum_literals_in_operators = 0`
         /// - to implement `transform_null_in = 0` semantics for NULLs inside tuple elements (skip such tuple values)
-        ///
-        /// Example:
-        /// - CAST((NULL, 42) AS Nullable(Tuple(Nullable(UInt32), Nullable(UInt32)))) IN ((NULL, 42)) SETTINGS transform_null_in = 0
-        ///   set elements: {} (tuple literal is skipped, because it has NULL element)
         const auto * lhs_nullable = typeid_cast<const DataTypeNullable *>(lhs_type.get());
         const auto * lhs_tuple = lhs_nullable ? typeid_cast<const DataTypeTuple *>(lhs_nullable->getNestedType().get()) : nullptr;
 
         /// Nullable(Tuple(...)) case
         if (lhs_tuple)
         {
-            chassert(lhs_nullable);
             const auto & lhs_tuple_element_types = lhs_tuple->getElements();
+            auto & nullable_column = assert_cast<ColumnNullable &>(*column);
 
-            for (size_t collection_index = 0; collection_index < rhs_collection.size(); ++collection_index)
+            for (const auto & member : members)
             {
-                const auto & rhs_element = rhs_collection[collection_index];
-
                 /// The NULL can be of any type but that's okay
-                if (rhs_element.isNull())
+                if (member.column->isNullAt(0))
                 {
                     if (params.transform_null_in)
                         column->insert(Null{});
                     continue;
                 }
 
-                if (rhs_element.getType() != Field::Types::Tuple)
-                    throw Exception(
-                        ErrorCodes::INCORRECT_ELEMENT_OF_SET, "Invalid type in set. Expected tuple, got {}", rhs_element.getTypeName());
-
-                const auto & rhs_element_as_tuple = rhs_element.template safeGet<Tuple>();
-                const size_t tuple_size = rhs_element_as_tuple.size();
-
-                if (tuple_size != lhs_tuple_element_types.size())
-                    throw Exception(
-                        ErrorCodes::INCORRECT_ELEMENT_OF_SET,
-                        "Incorrect size of tuple in set: {} instead of {}",
-                        tuple_size,
-                        lhs_tuple_element_types.size());
-
-                const DataTypePtr & rhs_element_type = rhs_types[collection_index];
-                const DataTypeTuple * rhs_tuple_type = getTupleType(rhs_element_type);
-
+                const DataTypeTuple * rhs_tuple_type = getTupleType(member.type);
                 if (!rhs_tuple_type)
                     throw Exception(ErrorCodes::INCORRECT_ELEMENT_OF_SET,
-                        "Invalid element type in set. Expected Tuple, got {}", rhs_element_type->getName());
+                        "Invalid element type in set. Expected Tuple, got {}", member.type->getName());
 
                 const DataTypes & rhs_tuple_element_types = rhs_tuple_type->getElements();
 
-                Tuple converted_tuple;
-                converted_tuple.reserve(tuple_size);
+                if (rhs_tuple_element_types.size() != lhs_tuple_element_types.size())
+                    throw Exception(
+                        ErrorCodes::INCORRECT_ELEMENT_OF_SET,
+                        "Incorrect size of tuple in set: {} instead of {}",
+                        rhs_tuple_element_types.size(),
+                        lhs_tuple_element_types.size());
+
+                ColumnPtr member_holder;
+                const ColumnTuple & member_tuple = getMemberTuple(member.column, member_holder);
+
+                Columns converted_elements;
+                converted_elements.reserve(rhs_tuple_element_types.size());
 
                 bool skip_tuple_value = false;
-                for (size_t i = 0; i < tuple_size; ++i)
+                for (size_t i = 0; i < rhs_tuple_element_types.size(); ++i)
                 {
-                    auto converted_field = convertFieldToTypeCheckEnum(
-                        rhs_element_as_tuple[i],
-                        *rhs_tuple_element_types[i],
-                        *lhs_tuple_element_types[i],
+                    auto converted = convertColumnToTypeCheckEnum(
+                        *member_tuple.getColumnPtr(i),
+                        rhs_tuple_element_types[i],
+                        lhs_tuple_element_types[i],
                         params.forbid_unknown_enum_values);
 
-                    if (!converted_field)
+                    if (!converted)
                     {
                         skip_tuple_value = true;
                         break;
                     }
 
                     bool need_insert_null = params.transform_null_in && lhs_tuple_element_types[i]->isNullable();
-                    if (converted_field->isNull() && !need_insert_null)
+                    if ((*converted)->isNullAt(0) && !need_insert_null)
                     {
                         skip_tuple_value = true;
                         break;
                     }
 
-                    converted_tuple.emplace_back(std::move(*converted_field));
+                    converted_elements.push_back(std::move(*converted));
                 }
 
-                if (!skip_tuple_value)
-                    column->insert(converted_tuple);
+                if (skip_tuple_value)
+                    continue;
+
+                /// `ColumnTuple::create` rejects a zero-column tuple, so an empty `Nullable(Tuple())`
+                /// element is inserted as a default (empty) tuple row directly.
+                if (converted_elements.empty())
+                    nullable_column.getNestedColumn().insertDefault();
+                else
+                {
+                    auto tuple_column = ColumnTuple::create(std::move(converted_elements));
+                    nullable_column.getNestedColumn().insertRangeFrom(*tuple_column, 0, 1);
+                }
+                nullable_column.getNullMapData().push_back(UInt8(0));
             }
 
             ColumnsWithTypeAndName res(1);
@@ -218,16 +231,13 @@ ColumnsWithTypeAndName createBlockFromCollection(
         }
 
         /// Generic single-key column (all cases except `Nullable(Tuple(...))`, e.g. T / Nullable(T) / Tuple() / Tuple(T))
-        for (size_t collection_index = 0; collection_index < rhs_collection.size(); ++collection_index)
+        for (const auto & member : members)
         {
-            const auto & rhs_element = rhs_collection[collection_index];
-
-            auto field
-                = convertFieldToTypeCheckEnum(rhs_element, *rhs_types[collection_index], *lhs_type, params.forbid_unknown_enum_values);
+            auto converted = convertColumnToTypeCheckEnum(*member.column, member.type, lhs_type, params.forbid_unknown_enum_values);
 
             bool need_insert_null = params.transform_null_in && column->isNullable();
-            if (field && (!field->isNull() || need_insert_null))
-                column->insert(*field);
+            if (converted && (!(*converted)->isNullAt(0) || need_insert_null))
+                column->insertRangeFrom(**converted, 0, 1);
         }
 
         ColumnsWithTypeAndName res(1);
@@ -240,61 +250,50 @@ ColumnsWithTypeAndName createBlockFromCollection(
     for (size_t i = 0; i < num_elements; ++i)
     {
         columns[i] = lhs_unpacked_types[i]->createColumn();
-        columns[i]->reserve(rhs_collection.size());
+        columns[i]->reserve(members.size());
     }
 
-    Row converted_rhs_element_unpacked;
+    Columns converted_row(num_elements);
 
-    for (size_t collection_index = 0; collection_index < rhs_collection.size(); ++collection_index)
+    for (const auto & member : members)
     {
-        const auto & rhs_element = rhs_collection[collection_index];
-
-        if (rhs_element.isNull())
-        {
+        if (member.column->isNullAt(0))
             continue;
-        }
 
-        if (rhs_element.getType() != Field::Types::Tuple)
-            throw Exception(ErrorCodes::INCORRECT_ELEMENT_OF_SET, "Invalid type in set. Expected tuple, got {}", rhs_element.getTypeName());
-
-        const auto & rhs_element_as_tuple = rhs_element.template safeGet<Tuple>();
-
-        const DataTypePtr & rhs_element_type = rhs_types[collection_index];
-        const DataTypeTuple * tuple_type = getTupleType(rhs_element_type);
-
+        const DataTypeTuple * tuple_type = getTupleType(member.type);
         if (!tuple_type)
             throw Exception(ErrorCodes::INCORRECT_ELEMENT_OF_SET,
-                "Invalid element type in set. Expected Tuple, got {}", rhs_element_type->getName());
+                "Invalid element type in set. Expected Tuple, got {}", member.type->getName());
 
         const DataTypes & rhs_element_unpacked_types = tuple_type->getElements();
 
-        size_t tuple_size = rhs_element_as_tuple.size();
-
-        if (tuple_size != num_elements)
+        if (rhs_element_unpacked_types.size() != num_elements)
             throw Exception(
-                ErrorCodes::INCORRECT_ELEMENT_OF_SET, "Incorrect size of tuple in set: {} instead of {}", tuple_size, num_elements);
+                ErrorCodes::INCORRECT_ELEMENT_OF_SET,
+                "Incorrect size of tuple in set: {} instead of {}", rhs_element_unpacked_types.size(), num_elements);
 
-        if (converted_rhs_element_unpacked.empty())
-            converted_rhs_element_unpacked.resize(tuple_size);
+        ColumnPtr member_holder;
+        const ColumnTuple & member_tuple = getMemberTuple(member.column, member_holder);
 
         size_t i = 0;
-        for (; i < tuple_size; ++i)
+        for (; i < num_elements; ++i)
         {
-            auto converted_field = convertFieldToTypeCheckEnum(
-                rhs_element_as_tuple[i], *rhs_element_unpacked_types[i], *lhs_unpacked_types[i], params.forbid_unknown_enum_values);
-            if (!converted_field)
+            auto converted = convertColumnToTypeCheckEnum(
+                *member_tuple.getColumnPtr(i), rhs_element_unpacked_types[i], lhs_unpacked_types[i], params.forbid_unknown_enum_values);
+            if (!converted)
                 break;
-            converted_rhs_element_unpacked[i] = std::move(*converted_field);
 
             bool need_insert_null = params.transform_null_in && lhs_unpacked_types[i]->isNullable();
-            if (converted_rhs_element_unpacked[i].isNull() && !need_insert_null)
+            if ((*converted)->isNullAt(0) && !need_insert_null)
                 break;
+
+            converted_row[i] = std::move(*converted);
         }
 
-        if (i == tuple_size)
+        if (i == num_elements)
         {
-            for (i = 0; i < tuple_size; ++i)
-                columns[i]->insert(converted_rhs_element_unpacked[i]);
+            for (i = 0; i < num_elements; ++i)
+                columns[i]->insertRangeFrom(*converted_row[i], 0, 1);
         }
     }
 
@@ -308,44 +307,94 @@ ColumnsWithTypeAndName createBlockFromCollection(
     return res;
 }
 
-bool hasNullInCollection(const Field & rhs, const WhichDataType & rhs_which_type)
+/// Build set members from an `Array` collection column (size-1, holds one array): the members are the
+/// array's elements, all of the array's nested type.
+SetMembers membersFromArray(const ColumnPtr & rhs_column, const DataTypePtr & array_type)
 {
+    const auto & nested_type = assert_cast<const DataTypeArray &>(*array_type).getNestedType();
+    ColumnPtr full = rhs_column->convertToFullColumnIfConst();
+    const auto & array_column = assert_cast<const ColumnArray &>(*full);
+    const ColumnPtr & elements = array_column.getDataPtr();
+
+    SetMembers members;
+    size_t size = elements->size();
+    members.reserve(size);
+    for (size_t i = 0; i < size; ++i)
+        members.push_back({elements->cut(i, 1), nested_type});
+    return members;
+}
+
+/// Build set members from a `Tuple` collection column (size-1, holds one tuple): the members are the
+/// tuple's elements (each a size-1 column), with the tuple element types.
+SetMembers membersFromTuple(const ColumnPtr & rhs_column, const DataTypePtr & tuple_type)
+{
+    const auto & element_types = assert_cast<const DataTypeTuple &>(*tuple_type).getElements();
+    ColumnPtr full = rhs_column->convertToFullColumnIfConst();
+    const auto & tuple_column = assert_cast<const ColumnTuple &>(*full);
+
+    SetMembers members;
+    members.reserve(element_types.size());
+    for (size_t i = 0; i < element_types.size(); ++i)
+        members.push_back({tuple_column.getColumnPtr(i), element_types[i]});
+    return members;
+}
+
+/// A single-value collection: the RHS itself is the only member.
+SetMembers membersFromSingleValue(const ColumnPtr & rhs_column, const DataTypePtr & rhs_type)
+{
+    return {{rhs_column->convertToFullColumnIfConst(), rhs_type}};
+}
+
+/// Whether any element of the collection column (Array or Tuple) is NULL.
+bool columnCollectionHasNull(const ColumnPtr & rhs_column, WhichDataType rhs_which_type)
+{
+    ColumnPtr full = rhs_column->convertToFullColumnIfConst();
     if (rhs_which_type.isArray())
     {
-        const auto & rhs_array = rhs.safeGet<Array>();
-        for (const auto & elem : rhs_array)
-            if (elem.isNull())
+        const auto & elements = assert_cast<const ColumnArray &>(*full).getData();
+        for (size_t i = 0, size = elements.size(); i < size; ++i)
+            if (elements.isNullAt(i))
                 return true;
+        return false;
     }
-    else if (rhs_which_type.isTuple())
+    if (rhs_which_type.isTuple())
     {
-        const auto & rhs_tuple = rhs.safeGet<Tuple>();
-        for (const auto & elem : rhs_tuple)
-            if (elem.isNull())
+        const auto & tuple = assert_cast<const ColumnTuple &>(*full);
+        for (size_t i = 0, size = tuple.tupleSize(); i < size; ++i)
+            if (tuple.getColumn(i).isNullAt(0))
                 return true;
+        return false;
     }
     return false;
 }
 
-bool hasTupleInCollection(const Field & rhs, const WhichDataType & rhs_which_type)
+/// Whether any non-NULL element of the collection (Array or Tuple) holds a Tuple value.
+/// A column's elements are homogeneously typed, so "is a Tuple" is a type check on the element type;
+/// but the value must also be non-NULL to match the `Field`-based version, where a NULL value has
+/// `Field::Types::Null` (not `Tuple`) regardless of the declared element type.
+bool columnCollectionHasTuple(const ColumnPtr & rhs_column, const DataTypePtr & rhs_type, WhichDataType rhs_which_type)
 {
+    ColumnPtr full = rhs_column->convertToFullColumnIfConst();
     if (rhs_which_type.isArray())
     {
-        const auto & rhs_array = rhs.safeGet<Array>();
-        for (const auto & elem : rhs_array)
-            if (elem.getType() == Field::Types::Tuple)
+        if (getTupleType(assert_cast<const DataTypeArray &>(*rhs_type).getNestedType()) == nullptr)
+            return false;
+        const auto & elements = assert_cast<const ColumnArray &>(*full).getData();
+        for (size_t i = 0, size = elements.size(); i < size; ++i)
+            if (!elements.isNullAt(i))
                 return true;
+        return false;
     }
-    else if (rhs_which_type.isTuple())
+    if (rhs_which_type.isTuple())
     {
-        const auto & rhs_tuple = rhs.safeGet<Tuple>();
-        for (const auto & elem : rhs_tuple)
-            if (elem.getType() == Field::Types::Tuple)
+        const auto & element_types = assert_cast<const DataTypeTuple &>(*rhs_type).getElements();
+        const auto & tuple = assert_cast<const ColumnTuple &>(*full);
+        for (size_t i = 0, size = tuple.tupleSize(); i < size; ++i)
+            if (getTupleType(element_types[i]) != nullptr && !tuple.getColumn(i).isNullAt(0))
                 return true;
     }
     return false;
 }
-
 
 }
 
@@ -356,7 +405,7 @@ bool hasTupleInCollection(const Field & rhs, const WhichDataType & rhs_which_typ
 /// If `transform_null_in` is false, then `SELECT NULL IN (NULL, 1)` returns NULL, otherwise it returns true.
 
 ColumnsWithTypeAndName getSetElementsForConstantValue(
-    const DataTypePtr & lhs_expression_type, const Field & rhs, const DataTypePtr & rhs_type, GetSetElementParams params)
+    const DataTypePtr & lhs_expression_type, const ColumnPtr & rhs_column, const DataTypePtr & rhs_type, GetSetElementParams params)
 {
     DataTypes lhs_unpacked_types = {lhs_expression_type};
 
@@ -402,26 +451,19 @@ ColumnsWithTypeAndName getSetElementsForConstantValue(
         lhs_unpacked_types = {std::make_shared<DataTypeNullable>(nested_tuple_type)};
     }
 
-    auto build_from_array = [&](const Field & rhs_value, const DataTypePtr & type)
+    auto build_from_array = [&](const DataTypePtr & type)
     {
-        const auto * array_type = assert_cast<const DataTypeArray *>(type.get());
-        const auto & rhs_array = rhs_value.safeGet<Array>();
-        DataTypes rhs_types(rhs_array.size(), array_type->getNestedType());
-        return createBlockFromCollection(rhs_array, rhs_types, lhs_unpacked_types, params);
+        return createBlockFromCollection(membersFromArray(rhs_column, type), lhs_unpacked_types, params);
     };
 
-    auto build_from_tuple = [&](const Field & rhs_value, const DataTypePtr & type)
+    auto build_from_tuple = [&](const DataTypePtr & type)
     {
-        const auto * tuple_type = assert_cast<const DataTypeTuple *>(type.get());
-        const auto & rhs_tuple = rhs_value.safeGet<Tuple>();
-        const auto & rhs_types = tuple_type->getElements();
-        return createBlockFromCollection(rhs_tuple, rhs_types, lhs_unpacked_types, params);
+        return createBlockFromCollection(membersFromTuple(rhs_column, type), lhs_unpacked_types, params);
     };
 
-    auto build_from_single_value = [&](const Field & rhs_value, const DataTypePtr & type)
+    auto build_from_single_value = [&](const DataTypePtr & type)
     {
-        /// Maybe we can inline without this lambda? But this way it's more readable.
-        return createBlockFromCollection(Array{rhs_value}, DataTypes{type}, lhs_unpacked_types, params);
+        return createBlockFromCollection(membersFromSingleValue(rhs_column, type), lhs_unpacked_types, params);
     };
 
     auto append_set_elements = [](ColumnsWithTypeAndName & destination, const ColumnsWithTypeAndName & source)
@@ -456,21 +498,21 @@ ColumnsWithTypeAndName getSetElementsForConstantValue(
     /// CAST(NULL, `Nullable(Tuple(...))`) IN NULL
     if (lhs_type_depth == rhs_type_depth + 1)
     {
-        if (rhs.isNull())
-            return build_from_single_value(rhs, rhs_type);
+        if (rhs_column->isNullAt(0))
+            return build_from_single_value(rhs_type);
     }
     else if (lhs_type_depth == rhs_type_depth)
     {
         WhichDataType rhs_which_type(rhs_type);
 
-        bool is_null_in_rhs = hasNullInCollection(rhs, rhs_which_type);
-        bool has_tuple_in_rhs = hasTupleInCollection(rhs, rhs_which_type);
+        bool is_null_in_rhs = columnCollectionHasNull(rhs_column, rhs_which_type);
+        bool has_tuple_in_rhs = columnCollectionHasTuple(rhs_column, rhs_type, rhs_which_type);
 
         if (lhs_is_tuple && rhs_which_type.isArray() && is_null_in_rhs)
         {
             /// CAST(NULL, `Nullable(Tuple(...))`) IN [NULL, NULL, (...)]
             /// Tuple(...) IN [NULL, NULL, (...)]
-            return build_from_array(rhs, rhs_type);
+            return build_from_array(rhs_type);
         }
 
         if (lhs_is_tuple && rhs_which_type.isTuple() && is_null_in_rhs && (lhs_is_nullable || has_tuple_in_rhs))
@@ -479,24 +521,21 @@ ColumnsWithTypeAndName getSetElementsForConstantValue(
             /// - a set of elements (NULLs and/or tuples): (NULL, NULL, (1, 2), ...)
             /// - a tuple literal (not a set): (NULL, 42) for `Tuple(Nullable(...), ...)`
             ///
-            /// Examples:
-            /// - CAST(NULL, `Nullable(Tuple(...))`) IN (NULL, NULL, (1, 2), ...)
-            /// - Tuple(...) IN (NULL, NULL, (1, 2), ...)
-            /// - Nullable(Tuple(...)) IN (NULL, 42) SETTINGS transform_null_in = 1
-            ///
-            /// If RHS contains a non-null non-tuple element, it cannot be a set of tuples
-            const auto & rhs_tuple = rhs.safeGet<Tuple>();
+            /// If RHS contains a non-null non-tuple element, it cannot be a set of tuples.
+            ColumnPtr rhs_full = rhs_column->convertToFullColumnIfConst();
+            const auto & rhs_tuple = assert_cast<const ColumnTuple &>(*rhs_full);
+            const auto & rhs_tuple_element_types = assert_cast<const DataTypeTuple &>(*rhs_type).getElements();
 
             bool rhs_tuple_all_null = true;
             bool rhs_tuple_has_non_null_non_tuple = false;
-            for (const auto & elem : rhs_tuple)
+            for (size_t i = 0, size = rhs_tuple.tupleSize(); i < size; ++i)
             {
-                if (elem.isNull())
+                if (rhs_tuple.getColumn(i).isNullAt(0))
                     continue;
 
                 rhs_tuple_all_null = false;
 
-                if (elem.getType() != Field::Types::Tuple)
+                if (getTupleType(rhs_tuple_element_types[i]) == nullptr)
                 {
                     rhs_tuple_has_non_null_non_tuple = true;
                     break;
@@ -508,13 +547,11 @@ ColumnsWithTypeAndName getSetElementsForConstantValue(
             /// - CAST(NULL, `Nullable(Tuple(...))`) IN (NULL, NULL, (1, 2), ...)
             if (!rhs_tuple_has_non_null_non_tuple)
             {
-                auto res = build_from_tuple(rhs, rhs_type);
+                auto res = build_from_tuple(rhs_type);
 
                 /// Additionally, for `Nullable(Tuple(...)) IN (NULL, NULL)` also treat RHS as a tuple literal `(NULL, NULL)`
-                /// when it can be cast to the LHS tuple type (so both interpretations are supported)
-                /// Example: tuple(NULL, NULL)::Nullable(Tuple(Nullable(UInt32), Nullable(UInt32))) IN (NULL, NULL) SETTINGS transform_null_in = 1
-                /// For `Nullable(Tuple(...)) IN (NULL, NULL)` also add a tuple-literal interpretation `(NULL, NULL)` when possible
-                if (lhs_is_nullable && rhs_tuple_all_null && rhs_tuple.size() == lhs_tuple_type->getElements().size())
+                /// when it can be cast to the LHS tuple type (so both interpretations are supported).
+                if (lhs_is_nullable && rhs_tuple_all_null && rhs_tuple.tupleSize() == lhs_tuple_type->getElements().size())
                 {
                     /// Tuple literal `(NULL, NULL)` is representable only if all tuple elements are Nullable,
                     /// otherwise it would require NULL -> non-nullable conversion (e.g. `Nullable(Tuple(Int64, Int64))`).
@@ -528,12 +565,8 @@ ColumnsWithTypeAndName getSetElementsForConstantValue(
                         }
                     }
 
-                    /// `res` already contains the "set-of-elements" interpretation of RHS:
-                    /// (NULL, NULL) -> {NULL, NULL}
-                    /// If tuple literal `(NULL, NULL)` is representable for the LHS type, also add it:
-                    /// {NULL, NULL, (NULL, NULL)}
                     if (all_tuple_elements_nullable)
-                        append_set_elements(res, build_from_single_value(rhs, rhs_type));
+                        append_set_elements(res, build_from_single_value(rhs_type));
                 }
 
                 return res;
@@ -541,7 +574,7 @@ ColumnsWithTypeAndName getSetElementsForConstantValue(
         }
 
         /// 1 in 1; (1, 2) in (1, 2); identity(tuple(tuple(tuple(1)))) in tuple(tuple(tuple(1))); etc.
-        return build_from_single_value(rhs, rhs_type);
+        return build_from_single_value(rhs_type);
     }
     else if (lhs_type_depth + 1 == rhs_type_depth)
     {
@@ -549,10 +582,10 @@ ColumnsWithTypeAndName getSetElementsForConstantValue(
         WhichDataType rhs_which_type(rhs_type);
 
         if (rhs_which_type.isArray())
-            return build_from_array(rhs, rhs_type);
+            return build_from_array(rhs_type);
 
         if (rhs_which_type.isTuple())
-            return build_from_tuple(rhs, rhs_type);
+            return build_from_tuple(rhs_type);
 
         throw Exception(
             ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,

--- a/src/Analyzer/SetUtils.h
+++ b/src/Analyzer/SetUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Core/ColumnsWithTypeAndName.h>
+#include <Columns/IColumn_fwd.h>
 
 #include <memory>
 
@@ -9,7 +10,6 @@ namespace DB
 
 class IDataType;
 using DataTypePtr = std::shared_ptr<const IDataType>;
-class Field;
 class Set;
 using SetPtr = std::shared_ptr<Set>;
 
@@ -25,6 +25,8 @@ struct GetSetElementParams
   * Example: SELECT id FROM test_table WHERE id IN (1, 2, 3, 4);
   * Example: SELECT id FROM test_table WHERE id IN ((1, 2), (3, 4));
   */
-ColumnsWithTypeAndName getSetElementsForConstantValue(const DataTypePtr & expression_type, const Field & rhs, const DataTypePtr & rhs_type, GetSetElementParams params);
+/// `rhs_column` is a size-1 (const) column holding the constant right-hand side of `IN` (a scalar,
+/// Array or Tuple). Values are read column-natively - no `Field` is materialized.
+ColumnsWithTypeAndName getSetElementsForConstantValue(const DataTypePtr & expression_type, const ColumnPtr & rhs_column, const DataTypePtr & rhs_type, GetSetElementParams params);
 
 }

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -28,8 +28,10 @@
 #include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/DataTypeNullable.h>
 
+#include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnSet.h>
+#include <Columns/ColumnTuple.h>
 
 #include <Storages/StorageSet.h>
 #if CLICKHOUSE_CLOUD
@@ -56,6 +58,7 @@
 #include <Interpreters/IdentifierSemantic.h>
 #include <Interpreters/Set.h>
 #include <Interpreters/convertFieldToType.h>
+#include <Interpreters/convertColumnToType.h>
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Interpreters/interpretSubquery.h>
 #include <Interpreters/misc.h>
@@ -103,7 +106,12 @@ static NamesAndTypesList::iterator findColumn(const String & name, NamesAndTypes
 
 namespace
 {
-std::pair<Field, DataTypePtr> buildCollectionFieldAndTypeFromASTFunction(
+/// Build the constant right-hand side of `IN` as a single-row column plus its exact type, without
+/// materializing a `Field`. Each `tuple`/`array` element is evaluated individually
+/// (`evaluateConstantExpressionAsColumn` fast-paths literals) and assembled column-natively, because
+/// interpreting a large tuple/array as a whole function through `evaluateConstantExpression` is
+/// extremely slow.
+std::pair<ColumnPtr, DataTypePtr> buildCollectionColumnAndTypeFromASTFunction(
     const boost::intrusive_ptr<ASTFunction> & func, ContextPtr context)
 {
     if (!func)
@@ -111,55 +119,40 @@ std::pair<Field, DataTypePtr> buildCollectionFieldAndTypeFromASTFunction(
 
     const auto & args = func->arguments->children;
 
-    if (func->name == "tuple")
+    /// An empty `tuple()` is not handled here: `ColumnTuple::create` rejects a zero-column tuple, so it
+    /// falls through to the generic path below, which builds a size-1 empty-tuple column of type `Tuple()`.
+    if (func->name == "tuple" && !args.empty())
     {
-        Tuple rhs_tuple;
-        rhs_tuple.reserve(args.size());
+        Columns element_columns;
+        element_columns.reserve(args.size());
 
         DataTypes element_types;
         element_types.reserve(args.size());
 
         for (const auto & arg : args)
         {
-            if (const auto * lit = arg->as<ASTLiteral>())
-            {
-                const Field & value = lit->value;
-                rhs_tuple.emplace_back(value);
-                element_types.emplace_back(applyVisitor(FieldToDataType(), value));
-            }
-            else
-            {
-                auto value_raw = evaluateConstantExpression(arg, context);
-                rhs_tuple.emplace_back(std::move(value_raw.first));
-                element_types.emplace_back(std::move(value_raw.second));
-            }
+            auto [column, type] = evaluateConstantExpressionAsColumn(arg, context);
+            element_columns.emplace_back(column->convertToFullColumnIfConst());
+            element_types.emplace_back(std::move(type));
         }
 
-        return {Field(std::move(rhs_tuple)), std::make_shared<DataTypeTuple>(std::move(element_types))};
+        auto tuple_column = ColumnTuple::create(std::move(element_columns));
+        return {std::move(tuple_column), std::make_shared<DataTypeTuple>(std::move(element_types))};
     }
 
     if (func->name == "array")
     {
-        Array rhs_array;
-        rhs_array.reserve(args.size());
+        Columns element_columns;
+        element_columns.reserve(args.size());
 
         DataTypes element_types;
         element_types.reserve(args.size());
 
         for (const auto & arg : args)
         {
-            if (const auto * lit = arg->as<ASTLiteral>())
-            {
-                const Field & value = lit->value;
-                rhs_array.emplace_back(value);
-                element_types.emplace_back(applyVisitor(FieldToDataType(), value));
-            }
-            else
-            {
-                auto value_raw = evaluateConstantExpression(arg, context);
-                rhs_array.emplace_back(std::move(value_raw.first));
-                element_types.emplace_back(std::move(value_raw.second));
-            }
+            auto [column, type] = evaluateConstantExpressionAsColumn(arg, context);
+            element_columns.emplace_back(column->convertToFullColumnIfConst());
+            element_types.emplace_back(std::move(type));
         }
 
         DataTypePtr nested_type;
@@ -168,19 +161,24 @@ std::pair<Field, DataTypePtr> buildCollectionFieldAndTypeFromASTFunction(
         else
             nested_type = getLeastSupertype(element_types);
 
-        for (size_t i = 0; i < rhs_array.size(); ++i)
+        auto data = nested_type->createColumn();
+        data->reserve(element_columns.size());
+        for (size_t i = 0; i < element_columns.size(); ++i)
         {
-            if (!rhs_array[i].isNull())
-                rhs_array[i] = convertFieldToType(rhs_array[i], *nested_type, element_types[i].get());
+            /// Every element is convertible to the common supertype, so this never fails.
+            ColumnPtr converted = convertColumnToTypeOrThrow(*element_columns[i], element_types[i], nested_type);
+            data->insertRangeFrom(*converted, 0, 1);
         }
 
-        return {Field(std::move(rhs_array)), std::make_shared<DataTypeArray>(std::move(nested_type))};
+        auto offsets = ColumnArray::ColumnOffsets::create();
+        offsets->insertValue(element_columns.size());
+        auto array_column = ColumnArray::create(std::move(data), std::move(offsets));
+        return {std::move(array_column), std::make_shared<DataTypeArray>(std::move(nested_type))};
     }
 
     /// For non tuple/array functions, we fall back to the generic path
     ASTPtr func_ast = func;
-    auto value_raw = evaluateConstantExpression(func_ast, context);
-    return value_raw;
+    return evaluateConstantExpressionAsColumn(func_ast, context);
 }
 
 
@@ -196,7 +194,7 @@ ColumnsWithTypeAndName createBlockForSet(
     const ASTPtr & right_arg,
     ContextPtr context)
 {
-    auto [right_arg_value, right_arg_type] = evaluateConstantExpression(right_arg, context);
+    auto [right_arg_column, right_arg_type] = evaluateConstantExpressionAsColumn(right_arg, context);
 
     GetSetElementParams params{
         .transform_null_in = context->getSettingsRef()[Setting::transform_null_in],
@@ -204,7 +202,7 @@ ColumnsWithTypeAndName createBlockForSet(
     };
 
     /// Reuse the analyzer logic
-    return getSetElementsForConstantValue(left_arg_type, right_arg_value, right_arg_type, params);
+    return getSetElementsForConstantValue(left_arg_type, right_arg_column, right_arg_type, params);
 }
 
 /** Create a block for set from literal.
@@ -221,10 +219,10 @@ ColumnsWithTypeAndName createBlockForSet(
         .forbid_unknown_enum_values = context->getSettingsRef()[Setting::validate_enum_literals_in_operators],
     };
 
-    auto [right_arg_value, right_arg_type] = buildCollectionFieldAndTypeFromASTFunction(right_arg, context);
+    auto [right_arg_column, right_arg_type] = buildCollectionColumnAndTypeFromASTFunction(right_arg, context);
 
     /// Reuse the analyzer logic
-    return getSetElementsForConstantValue(left_arg_type, right_arg_value, right_arg_type, params);
+    return getSetElementsForConstantValue(left_arg_type, right_arg_column, right_arg_type, params);
 }
 }
 

--- a/src/Interpreters/convertColumnToType.cpp
+++ b/src/Interpreters/convertColumnToType.cpp
@@ -30,25 +30,31 @@ namespace
 {
 
 /// Column-native conversion for the cases where CAST provably matches `convertFieldToType`:
-/// plain numeric-to-numeric in the default mode. `castColumnAccurateOrNull` uses the same accurate
-/// numeric conversion (`accurate::convertNumeric`, strict) as `convertFieldToType`'s default path
-/// (out-of-range / inexact-narrowing -> NULL). Returns:
+/// plain native-numeric-to-native-numeric, in the default AND `strict` modes. `castColumnAccurateOrNull`
+/// uses the same accurate numeric conversion (`accurate::convertNumeric`) as `convertFieldToType`'s
+/// default path (out-of-range / inexact-narrowing -> NULL). For native numbers `strict` and default
+/// agree with it too: `strict` only rejects additional cases for types that are already excluded here -
+/// `Bool` (10 is not a valid `Bool`) and `Decimal` (scale reduction; `castColumnAccurateOrNull` would
+/// round, so it must NOT be used for strict Decimal - and it isn't, `Decimal` is not a native number).
+/// The strict native-number equivalence is pinned by `gtest_convert_column_to_type`. Returns:
 ///   - the converted size-1 column of `to` on success,
 ///   - a null `ColumnPtr{}` when not representable,
 ///   - std::nullopt when this fast path does not apply (caller falls back to the `Field` path).
-/// Excluded: `strict` / `convert_inexact_floats` modes (different rounding/precision rules), `Bool`
-/// (clamp semantics), and anything non-native-numeric (Decimal/Date/Enum/String/wrappers/composite).
+/// Excluded: `convert_inexact_floats` mode (allows rounding, so `castColumnAccurateOrNull` differs),
+/// `Bool` (clamp/validity semantics), and anything non-native-numeric
+/// (Decimal/Date/Enum/String/wide-int/wrappers/composite).
 std::optional<ColumnPtr> tryConvertNumericColumnNative(
     const IColumn & value,
     const DataTypePtr & from,
     const DataTypePtr & to,
-    bool strict,
     bool convert_inexact_floats)
 {
-    if (strict || convert_inexact_floats)
+    if (convert_inexact_floats)
         return std::nullopt;
     if (!isNativeNumber(from) || !isNativeNumber(to) || isBool(from) || isBool(to))
         return std::nullopt;
+    /// `strict` is intentionally not a parameter: for native numbers it is equivalent to the default
+    /// accurate path (both reject non-representable values), so this fast path serves strict too.
 
     ColumnWithTypeAndName arg{value.getPtr(), from, ""};
     ColumnPtr casted = castColumnAccurateOrNull(arg, to);
@@ -139,7 +145,7 @@ ColumnPtr convertColumnToTypeOrNull(
     const ColumnPtr full = value.convertToFullColumnIfConst();
     const IColumn & unwrapped = *full;
 
-    if (auto native = tryConvertNumericColumnNative(unwrapped, from, to, strict, convert_inexact_floats))
+    if (auto native = tryConvertNumericColumnNative(unwrapped, from, to, convert_inexact_floats))
         return std::move(*native);
 
     /// Fallback: materialize a `Field`, reuse `convertFieldToType`, rebuild a column. Column-native

--- a/src/Interpreters/tests/gtest_convert_column_to_type.cpp
+++ b/src/Interpreters/tests/gtest_convert_column_to_type.cpp
@@ -170,6 +170,28 @@ TEST(ConvertColumnToType, MatchesConvertFieldToType)
         {"Date", Field(UInt64(19000)), "String"},
         {"Decimal64(2)", Field(DecimalField<Decimal64>(Decimal64(3333), 2)), "String"},
         {"IPv4", Field(IPv4(0x7f000001)), "String"},
+
+        /// `strict` native-number matrix. `convertColumnToType` now serves `strict` for native numbers
+        /// via the column-native fast path (`castColumnAccurateOrNull`), which must match
+        /// `convertFieldToType` with `strict=true`. This is what the IN/set set builder relies on
+        /// (it converts with `strict=true` to exclude values not exactly representable in the LHS type).
+        {"UInt64", Field(UInt64(5)), "UInt8", true},                       // in range -> 5
+        {"UInt64", Field(UInt64(256)), "UInt8", true},                     // overflow -> null
+        {"Int64", Field(Int64(-1)), "UInt8", true},                        // negative -> null
+        {"Int64", Field(Int64(-128)), "Int8", true},                       // in range -> -128
+        {"Int64", Field(Int64(-129)), "Int8", true},                       // overflow -> null
+        {"Float64", Field(Float64(3.0)), "Int32", true},                   // exact -> 3
+        {"Float64", Field(Float64(3.5)), "Int32", true},                   // non-integer -> null
+        {"Float64", Field(Float64(0.5)), "Float32", true},                 // exact -> 0.5
+        {"Float64", Field(Float64(1e300)), "Float32", true},               // overflow -> null
+        {"Int64", Field(Int64(9007199254740993ll)), "Float64", true},      // int -> float precision loss
+        {"Int64", Field(Int64(5)), "Float32", true},                       // exact int -> float
+        {"UInt64", Field(UInt64(5)), "Int8", true},                        // in range across sign -> 5
+
+        /// `strict` non-native controls: these keep going through the `Field` fallback (Decimal must NOT
+        /// use `castColumnAccurateOrNull`, which would round `33.33` to `33.3` instead of rejecting it).
+        {"Decimal64(2)", Field(DecimalField<Decimal64>(Decimal64(3333), 2)), "Decimal64(1)", true}, // scale loss -> null
+        {"Decimal64(1)", Field(DecimalField<Decimal64>(Decimal64(333), 1)), "Decimal64(2)", true},  // widen -> 33.30
     };
 
     for (const auto & c : cases)

--- a/src/Planner/CollectSets.cpp
+++ b/src/Planner/CollectSets.cpp
@@ -125,7 +125,7 @@ public:
         else if (const auto * constant_node = in_second_argument->as<ConstantNode>())
         {
             auto set = getSetElementsForConstantValue(
-                in_first_argument->getResultType(), constant_node->getValue(), constant_node->getResultType(),
+                in_first_argument->getResultType(), constant_node->getColumn(), constant_node->getResultType(),
                 GetSetElementParams{
                     .transform_null_in = settings[Setting::transform_null_in],
                     .forbid_unknown_enum_values = settings[Setting::validate_enum_literals_in_operators],

--- a/tests/queries/0_stateless/04692_bool_tag_faithful_in_set.reference
+++ b/tests/queries/0_stateless/04692_bool_tag_faithful_in_set.reference
@@ -1,0 +1,8 @@
+scalar	1	0
+array	1	0
+multikey	1	0
+array-of-bool	1
+scalar	1	0
+array	1	0
+multikey	1	0
+array-of-bool	1

--- a/tests/queries/0_stateless/04692_bool_tag_faithful_in_set.sql
+++ b/tests/queries/0_stateless/04692_bool_tag_faithful_in_set.sql
@@ -1,0 +1,19 @@
+-- Bool set elements converted to a textual left-hand type must use the canonical Bool text
+-- ('true'/'false'), not the numeric collapse ('1'/'0'). The IN/set path builds the set column-natively
+-- via convertColumnToType, which preserves the Bool tag (the previous Field-based path collapsed
+-- Bool to UInt64 first, producing '1'/'0'). This mirrors the values() table function fix.
+-- Checked on both the analyzer and the legacy execution paths.
+
+SET allow_experimental_analyzer = 1;
+
+SELECT 'scalar' AS shape, 'true' IN (true) AS textual_matches, '1' IN (true) AS numeric_matches;
+SELECT 'array' AS shape, 'false' IN [true, false] AS textual_matches, '0' IN [true, false] AS numeric_matches;
+SELECT 'multikey' AS shape, ('true', 5) IN ((true, 5)) AS textual_matches, ('1', 5) IN ((true, 5)) AS numeric_matches;
+SELECT 'array-of-bool' AS shape, ['true'] IN (CAST([true], 'Array(Bool)')) AS textual_matches;
+
+SET allow_experimental_analyzer = 0;
+
+SELECT 'scalar' AS shape, 'true' IN (true) AS textual_matches, '1' IN (true) AS numeric_matches;
+SELECT 'array' AS shape, 'false' IN [true, false] AS textual_matches, '0' IN [true, false] AS numeric_matches;
+SELECT 'multikey' AS shape, ('true', 5) IN ((true, 5)) AS textual_matches, ('1', 5) IN ((true, 5)) AS numeric_matches;
+SELECT 'array-of-bool' AS shape, ['true'] IN (CAST([true], 'Array(Bool)')) AS textual_matches;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/112308
-->

Column-native `IN`/set constant handling, continuing the removal of `DB::Field` from constant-expression evaluation.

### What

1. **`convertColumnToType`: column-native `strict` numeric path.** The set builder converts values with `strict=true` (to exclude values not exactly representable in the LHS type), and `convertColumnToType` previously excluded `strict` from its column-native fast path, forcing a `Field` reconstruction for every strict conversion. For native numbers `castColumnAccurateOrNull` (already used for the default mode) matches `convertFieldToType` with `strict=true` exactly; `strict` only differs for types already excluded from the fast path — `Bool` and `Decimal` (where accurate cast rounds `33.33`→`33.3` instead of rejecting it, so `Decimal` correctly stays on the `Field` fallback). Verified by a strict native-number matrix added to `gtest_convert_column_to_type`.

2. **Make the `IN`/set builder column-native.** `getSetElementsForConstantValue` now takes the right-hand side as a `ColumnPtr` instead of a `Field`, and `createBlockFromCollection` iterates the collection's member columns (`Array` elements as rows, `Tuple` elements as subcolumns) instead of `Array`/`Tuple` of `Field`. Per-element conversion goes through `convertColumnToType` (strict) via a new `convertColumnToTypeCheckEnum` (the column twin of `convertFieldToTypeCheckEnum`); the not-representable vs genuine-NULL distinction uses `convertColumnToType`'s null channel rather than inspecting `Field::isNull`. The dispatch (`transform_null_in`, `Nullable(Tuple)` dual interpretation, tuple-vs-set disambiguation) is preserved. Analyzer callers (`CollectSets`, `resolveFunction`) pass `ConstantNode::getColumn`; the legacy `ActionsVisitor` path evaluates with `evaluateConstantExpressionAsColumn`.

3. **Batch accurate cast for a single native-number key.** For the common `x IN (1, 2, ...)` / `x IN [1, 2, ...]` case, when the target and every member share a plain native-number type, all members are converted with one `castColumnAccurateOrNull` instead of a per-member cast, keeping parity with the previous `Field` path for large `IN` lists. The cast is element-wise, so results and order are identical to the per-member loop.

### Behavior change (bug fix)

Because the set is now built with `convertColumnToType` (tag-faithful for `Bool` since #112308), a `Bool` set element converted to a textual left-hand type is now the canonical `'true'`/`'false'` rather than the numeric collapse `'1'`/`'0'` produced by the old `Field` path (`IColumn::get` erased the `Bool` tag to `UInt64` before `convertFieldToType`). This matches the `values` table function and `CAST`, on both the analyzer and legacy execution paths. Covered by `04692_bool_tag_faithful_in_set`. The incidental fix is kept, not pinned.

Related: https://github.com/ClickHouse/ClickHouse/pull/112308

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a `Bool` constant on the right-hand side of `IN` being converted to a `String` left-hand side as `'1'`/`'0'` instead of the canonical `'true'`/`'false'` (now consistent with `CAST` and the `values` table function).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1200` (included in `26.8` and later)
<!-- ch-version-info:end -->