### PR TITLE
Do not query the CI database while configuring the workflow

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -348,25 +348,13 @@ def should_skip_job(job_name):
             return True, "Skipped, not a bug-fix PR"
 
     if "flaky" in job_name.lower():
-        from ci.jobs.scripts.find_tests import Targeting
-
-        targeter = Targeting(info=_info_cache)
-        # _info_cache.job_name is the hook runner job, not the flaky check job.
-        # Set job_type explicitly from the job_name argument so CIDB queries use
-        # the correct check_name prefix (e.g. 'Stateless%' instead of None).
-        if "stateless" in job_name.lower():
-            targeter.job_type = Targeting.STATELESS_JOB_TYPE
-        elif "integration" in job_name.lower():
-            targeter.job_type = Targeting.INTEGRATION_JOB_TYPE
         changed_files = _info_cache.get_changed_files()
         if "stateless" in job_name.lower():
-            changed_tests = targeter.get_changed_tests()
-            try:
-                previously_failed = targeter.get_previously_failed_tests()
-            except Exception as e:
-                print(f"Warning: failed to fetch previously-failed tests: {e}")
-                previously_failed = []
-            if not changed_tests and not previously_failed:
+            from ci.jobs.scripts.find_tests import Targeting
+
+            # Mirrors the in-job selection in `functional_tests.py`. Runs inside
+            # `Config Workflow`, so it must issue no CIDB query.
+            if not Targeting(info=_info_cache).get_changed_tests():
                 return True, "Skipped, no tests to run"
         if "integration" in job_name.lower() and not has_new_integration_tests(
             changed_files

--- a/ci/tests/test_config_job_no_cidb.py
+++ b/ci/tests/test_config_job_no_cidb.py
@@ -1,0 +1,282 @@
+"""Tests for the config-time CIDB reachability invariant of the workflow filter hooks.
+
+`Config Workflow` is declared with `timeout=600` (`ci/praktika/native_jobs.py`), and
+praktika marks every dependee job `DROPPED` when it fails. `CIDB.query` retries 5 times
+with a 60s per-request timeout and exponential backoff, so one query can take
+5 * 60 + (2 + 4 + 8 + 16) = 330s. The filter hooks run once per job
+(`ci/praktika/native_jobs.py`), so a single CIDB call in `should_skip_job` is multiplied
+by the number of jobs that reach it and can outlast the job's whole allowance - a
+transient CIDB slowdown then voids the entire test matrix.
+
+The hooks must therefore issue no CIDB query at all. That is asserted here by
+monkeypatching `requests.post` in `ci.praktika.cidb` (the single network boundary of
+every `CIDB` method) and driving the hooks over the real workflows' own job lists, so a
+newly added parametrization is covered without editing this file.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+import pytest
+
+import ci.praktika.cidb as cidb_module
+import ci.jobs.scripts.workflow_hooks.filter_job as fj
+import ci.jobs.scripts.workflow_hooks.new_tests_check as ntc
+from ci.jobs.scripts.find_tests import Targeting
+from ci.praktika.native_jobs import _is_praktika_job
+
+PR_NUMBER = 105710
+CHANGED_TEST = "tests/queries/0_stateless/04652_probe.sh"
+FLAKY_CHECK_JOB = "Stateless tests (amd_debug, flaky check)"
+
+
+class FakeInfo:
+    """Stand-in for praktika's `Info`: only what the hooks read.
+
+    `job_name` is the hook runner job, matching production - the hooks are called
+    from `Config Workflow`, not from the job being filtered.
+    """
+
+    job_name = "Config Workflow"
+    pr_number = PR_NUMBER
+    pr_labels = ()
+    pr_body = ""
+    is_local_run = False
+
+    def __init__(self, changed_files=(CHANGED_TEST,)):
+        self._changed_files = list(changed_files)
+
+    def get_kv_data(self, key):
+        return self._changed_files if key == "changed_files" else None
+
+    def get_changed_files(self):
+        return self._changed_files
+
+    def add_workflow_note(self, message):
+        pass
+
+    def get_secret(self, name):
+        # Resolvable without CI credentials, so a reintroduced CIDB call reaches the
+        # request boundary `_record_cidb_requests` watches instead of failing earlier on
+        # secret lookup (which would make the guard pass for the wrong reason).
+        return _FakeSecret(name)
+
+
+class _FakeSecret:
+    def __init__(self, name):
+        self.name = name
+
+    def join_with(self, other):
+        return self
+
+    def get_value(self):
+        return ("http://cidb.invalid/", "user", "passwd")
+
+
+def _use_fake_info(monkeypatch, changed_files=(CHANGED_TEST,)):
+    info = FakeInfo(changed_files)
+    monkeypatch.setattr(fj, "_info_cache", info)
+    # `has_new_*_tests` and the release-branch guard construct their own `Info()`.
+    monkeypatch.setattr(fj, "Info", lambda: info)
+    monkeypatch.setattr(ntc, "Info", lambda: info)
+    return info
+
+
+def _record_cidb_requests(monkeypatch):
+    """Return a list that collects every attempted CIDB HTTP request.
+
+    Patched at `requests.post`, which `CIDB.query`, `insert_rows` and `check` all go
+    through, so a CIDB call added through any other `CIDB` method is caught too.
+
+    The call is RECORDED rather than only raised, because `should_skip_job` used to wrap
+    its CIDB lookup in `except Exception` - an assertion raised here would be swallowed
+    and the test would pass against the very code it must reject. Callers assert the
+    list is empty after driving the hooks.
+    """
+    calls = []
+
+    def _record(*args, **kwargs):
+        calls.append(kwargs.get("url") or (args[0] if args else None))
+        raise RuntimeError("CIDB unreachable")
+
+    monkeypatch.setattr(cidb_module.requests, "post", _record)
+    # The retry loop sleeps 2+4+8+16s per query; the assertions are about reachability,
+    # not timing, so skip the wait.
+    monkeypatch.setattr(cidb_module.time, "sleep", lambda _s: None)
+    return calls
+
+
+def _pr_workflow_job_names():
+    from ci.workflows.pull_request import workflow
+
+    return [j.name for j in workflow.jobs if not _is_praktika_job(j.name)]
+
+
+def _merge_queue_job_names():
+    from ci.workflows.merge_queue import workflow
+
+    return [j.name for j in workflow.jobs if not _is_praktika_job(j.name)]
+
+
+def test_pr_workflow_jobs_are_filtered_without_cidb(monkeypatch):
+    _use_fake_info(monkeypatch)
+    calls = _record_cidb_requests(monkeypatch)
+    job_names = _pr_workflow_job_names()
+    assert any(
+        "flaky" in n.lower() for n in job_names
+    ), "no flaky job in the PR workflow"
+    for name in job_names:
+        should_skip, _ = fj.should_skip_job(name)
+        assert isinstance(should_skip, bool), name
+    assert calls == [], f"config-time CIDB requests: {calls}"
+
+
+def test_every_workflow_using_the_hook_is_filtered_without_cidb(monkeypatch):
+    """`should_skip_job` is the filter hook of four workflows, not just `PR`.
+
+    Covers `master`, `release_branches` and `backport_branches` too, so a flaky-check
+    parametrization added to any of them cannot reintroduce a config-time CIDB call.
+    """
+    for module in (
+        "pull_request",
+        "master",
+        "release_branches",
+        "backport_branches",
+    ):
+        workflow = __import__(f"ci.workflows.{module}", fromlist=["workflow"]).workflow
+        fj._pipeline_note_labels.clear()
+        _use_fake_info(monkeypatch)
+        calls = _record_cidb_requests(monkeypatch)
+        for job in workflow.jobs:
+            if _is_praktika_job(job.name):
+                continue
+            fj.should_skip_job(job.name)
+        assert calls == [], f"{module}: config-time CIDB requests: {calls}"
+
+
+def test_merge_queue_jobs_are_filtered_without_cidb(monkeypatch):
+    _use_fake_info(monkeypatch)
+    calls = _record_cidb_requests(monkeypatch)
+    for name in _merge_queue_job_names():
+        should_skip, _ = fj.should_skip_merge_queue_job(name)
+        assert isinstance(should_skip, bool), name
+    assert calls == [], f"config-time CIDB requests: {calls}"
+
+
+def test_cidb_outage_changes_no_filter_decision(monkeypatch):
+    """A CIDB outage must degrade to "run the default set", not drop the matrix.
+
+    Compares an unreachable CIDB against a healthy one that answers every query, so a
+    reintroduced config-time lookup whose result differs between the two is caught even
+    if it never raises.
+    """
+    _use_fake_info(monkeypatch)
+    _record_cidb_requests(monkeypatch)
+    with_cidb_down = {n: fj.should_skip_job(n) for n in _pr_workflow_job_names()}
+
+    fj._pipeline_note_labels.clear()
+    _use_fake_info(monkeypatch)
+    monkeypatch.setattr(
+        cidb_module.requests,
+        "post",
+        lambda *a, **kw: _OkResponse("04652_probe\n01666_merge_tree_max_query_limit\n"),
+    )
+    with_cidb_up = {n: fj.should_skip_job(n) for n in _pr_workflow_job_names()}
+
+    assert with_cidb_down == with_cidb_up
+
+
+class _OkResponse:
+    ok = True
+    status_code = 200
+
+    def __init__(self, text):
+        self.text = text
+
+
+def test_flaky_check_runs_when_stateless_tests_changed(monkeypatch):
+    _use_fake_info(monkeypatch)
+    calls = _record_cidb_requests(monkeypatch)
+    monkeypatch.setattr(Targeting, "get_changed_tests", lambda self: ["04652_probe."])
+    assert fj.should_skip_job(FLAKY_CHECK_JOB) == (False, "")
+    assert calls == [], f"config-time CIDB requests: {calls}"
+
+
+def test_flaky_check_skipped_when_no_stateless_tests_changed(monkeypatch):
+    _use_fake_info(monkeypatch)
+    calls = _record_cidb_requests(monkeypatch)
+    monkeypatch.setattr(Targeting, "get_changed_tests", lambda self: [])
+    should_skip, reason = fj.should_skip_job(FLAKY_CHECK_JOB)
+    assert should_skip is True
+    assert reason == "Skipped, no tests to run"
+    assert calls == [], f"config-time CIDB requests: {calls}"
+
+
+def test_previously_failed_cannot_change_flaky_coverage(monkeypatch):
+    """Why dropping the previously-failed lookup loses no coverage.
+
+    The flaky check selects `get_changed_tests` in-job and exits SKIPPED when that is
+    empty, so the only row where previously-failed flipped the config decision
+    scheduled a job that immediately self-skipped.
+    """
+    _use_fake_info(monkeypatch)
+    calls = _record_cidb_requests(monkeypatch)
+    monkeypatch.setattr(Targeting, "get_changed_tests", lambda self: [])
+
+    # Same source of truth on both sides of the decision.
+    in_job_selection = Targeting(info=fj._info_cache).get_changed_tests()
+    assert in_job_selection == []
+    assert fj.should_skip_job(FLAKY_CHECK_JOB)[0] is True
+    assert calls == [], f"config-time CIDB requests: {calls}"
+
+
+def test_integration_flaky_check_needs_no_cidb(monkeypatch):
+    _use_fake_info(monkeypatch, changed_files=("src/Core/Settings.cpp",))
+    calls = _record_cidb_requests(monkeypatch)
+    should_skip, reason = fj.should_skip_job(
+        "Integration tests (amd_asan_ubsan, flaky)"
+    )
+    assert should_skip is True
+    assert reason == "Skipped, no integration tests updates"
+    assert calls == [], f"config-time CIDB requests: {calls}"
+
+
+def test_get_changed_tests_issues_no_cidb_query(monkeypatch):
+    """`get_changed_tests` reads the diff only, so it is safe at config time.
+
+    Pinned because the fix relies on it: it is the single selector both the config-time
+    skip and the in-job selection use.
+    """
+    info = _use_fake_info(monkeypatch)
+    calls = _record_cidb_requests(monkeypatch)
+    assert Targeting(info=info).get_changed_tests() == []
+    assert calls == [], f"config-time CIDB requests: {calls}"
+
+
+def test_cidb_worst_case_budget_exceeds_the_config_job_timeout():
+    """The arithmetic that makes a config-time CIDB call unsafe.
+
+    Documents why the reachability assertions above are the regression, not a retuning
+    of these constants: even one query can outlast the whole job.
+    """
+    import inspect
+
+    from ci.praktika.settings import Settings
+    from ci.praktika.cidb import CIDB
+    from ci.praktika import native_jobs
+
+    retries = inspect.signature(CIDB.query).parameters["retries"].default
+    backoff = sum(2**attempt for attempt in range(1, retries))
+    one_query = retries * Settings.CI_DB_QUERY_TIMEOUT_SEC + backoff
+    config_job_timeout = native_jobs._workflow_config_job.timeout
+
+    assert one_query > config_job_timeout / 2, (
+        f"one CIDB query is {one_query}s against a {config_job_timeout}s job timeout; "
+        "config-time CIDB queries must stay removed"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/ci/tests/test_config_job_no_cidb.py
+++ b/ci/tests/test_config_job_no_cidb.py
@@ -28,7 +28,11 @@ from ci.jobs.scripts.find_tests import Targeting
 from ci.praktika.native_jobs import _is_praktika_job
 
 PR_NUMBER = 105710
-CHANGED_TEST = "tests/queries/0_stateless/04652_probe.sh"
+# Must name a file that exists: `Targeting.get_changed_tests` silently skips paths
+# failing `Path(fpath).exists()`, which would empty the selection and make every
+# assertion below run against the no-tests-changed state instead.
+CHANGED_TEST = "tests/queries/0_stateless/04652_compound_key_monotonicity.sql"
+CHANGED_TEST_NAME = "04652_compound_key_monotonicity."
 FLAKY_CHECK_JOB = "Stateless tests (amd_debug, flaky check)"
 
 
@@ -121,12 +125,17 @@ def _merge_queue_job_names():
 
 
 def test_pr_workflow_jobs_are_filtered_without_cidb(monkeypatch):
-    _use_fake_info(monkeypatch)
+    info = _use_fake_info(monkeypatch)
     calls = _record_cidb_requests(monkeypatch)
     job_names = _pr_workflow_job_names()
     assert any(
         "flaky" in n.lower() for n in job_names
     ), "no flaky job in the PR workflow"
+    # The fixture must actually select a test (it names a real file, and `Path` is
+    # relative, so run from the repo root), otherwise every job below is filtered in
+    # the no-tests-changed state and the changed-tests branch is never traversed.
+    assert Targeting(info=info).get_changed_tests() == [CHANGED_TEST_NAME]
+    assert fj.should_skip_job(FLAKY_CHECK_JOB) == (False, "")
     for name in job_names:
         should_skip, _ = fj.should_skip_job(name)
         assert isinstance(should_skip, bool), name
@@ -171,17 +180,25 @@ def test_cidb_outage_changes_no_filter_decision(monkeypatch):
     Compares an unreachable CIDB against a healthy one that answers every query, so a
     reintroduced config-time lookup whose result differs between the two is caught even
     if it never raises.
+
+    The changed file is deliberately *not* a stateless test: that is the only state in
+    which a previously-failed lookup could ever change a decision (with a test changed,
+    the job runs either way), so it is the only state where the two arms can differ.
     """
-    _use_fake_info(monkeypatch)
+    no_tests_changed = ("src/Core/Settings.cpp",)
+
+    _use_fake_info(monkeypatch, changed_files=no_tests_changed)
     _record_cidb_requests(monkeypatch)
     with_cidb_down = {n: fj.should_skip_job(n) for n in _pr_workflow_job_names()}
 
     fj._pipeline_note_labels.clear()
-    _use_fake_info(monkeypatch)
+    _use_fake_info(monkeypatch, changed_files=no_tests_changed)
     monkeypatch.setattr(
         cidb_module.requests,
         "post",
-        lambda *a, **kw: _OkResponse("04652_probe\n01666_merge_tree_max_query_limit\n"),
+        lambda *a, **kw: _OkResponse(
+            f"{CHANGED_TEST_NAME.rstrip('.')}\n01666_merge_tree_max_query_limit\n"
+        ),
     )
     with_cidb_up = {n: fj.should_skip_job(n) for n in _pr_workflow_job_names()}
 
@@ -214,22 +231,41 @@ def test_flaky_check_skipped_when_no_stateless_tests_changed(monkeypatch):
     assert calls == [], f"config-time CIDB requests: {calls}"
 
 
-def test_previously_failed_cannot_change_flaky_coverage(monkeypatch):
+def test_previously_failed_cannot_change_flaky_coverage():
     """Why dropping the previously-failed lookup loses no coverage.
 
     The flaky check selects `get_changed_tests` in-job and exits SKIPPED when that is
     empty, so the only row where previously-failed flipped the config decision
-    scheduled a job that immediately self-skipped.
+    scheduled a job that immediately self-skipped. Asserted structurally - both sides
+    of the decision must consult that one selector, and neither may consult CIDB.
     """
-    _use_fake_info(monkeypatch)
-    calls = _record_cidb_requests(monkeypatch)
-    monkeypatch.setattr(Targeting, "get_changed_tests", lambda self: [])
+    import ast
+    import inspect
 
-    # Same source of truth on both sides of the decision.
-    in_job_selection = Targeting(info=fj._info_cache).get_changed_tests()
-    assert in_job_selection == []
-    assert fj.should_skip_job(FLAKY_CHECK_JOB)[0] is True
-    assert calls == [], f"config-time CIDB requests: {calls}"
+    import ci.jobs.functional_tests as functional_tests
+
+    # In-job side: the `is_flaky_check` branch that picks the test list must pick it
+    # from `get_changed_tests`. Matched on the AST rather than on text, because
+    # `is_flaky_check` also gates an unrelated worker-count branch.
+    selectors = set()
+    for node in ast.walk(ast.parse(inspect.getsource(functional_tests))):
+        if not isinstance(node, ast.If):
+            continue
+        if not (isinstance(node.test, ast.Name) and node.test.id == "is_flaky_check"):
+            continue
+        for stmt in node.body:
+            if not isinstance(stmt, ast.Assign) or not isinstance(stmt.value, ast.Call):
+                continue
+            if any(
+                isinstance(t, ast.Name) and t.id == "tests" for t in stmt.targets
+            ) and isinstance(stmt.value.func, ast.Attribute):
+                selectors.add(stmt.value.func.attr)
+    assert selectors == {"get_changed_tests"}, selectors
+
+    # Config-time side: the same selector, and no CIDB-backed one.
+    hook = inspect.getsource(fj)
+    assert "get_changed_tests" in hook
+    assert "get_previously_failed_tests" not in hook
 
 
 def test_integration_flaky_check_needs_no_cidb(monkeypatch):
@@ -251,31 +287,8 @@ def test_get_changed_tests_issues_no_cidb_query(monkeypatch):
     """
     info = _use_fake_info(monkeypatch)
     calls = _record_cidb_requests(monkeypatch)
-    assert Targeting(info=info).get_changed_tests() == []
+    assert Targeting(info=info).get_changed_tests() == [CHANGED_TEST_NAME]
     assert calls == [], f"config-time CIDB requests: {calls}"
-
-
-def test_cidb_worst_case_budget_exceeds_the_config_job_timeout():
-    """The arithmetic that makes a config-time CIDB call unsafe.
-
-    Documents why the reachability assertions above are the regression, not a retuning
-    of these constants: even one query can outlast the whole job.
-    """
-    import inspect
-
-    from ci.praktika.settings import Settings
-    from ci.praktika.cidb import CIDB
-    from ci.praktika import native_jobs
-
-    retries = inspect.signature(CIDB.query).parameters["retries"].default
-    backoff = sum(2**attempt for attempt in range(1, retries))
-    one_query = retries * Settings.CI_DB_QUERY_TIMEOUT_SEC + backoff
-    config_job_timeout = native_jobs._workflow_config_job.timeout
-
-    assert one_query > config_job_timeout / 2, (
-        f"one CIDB query is {one_query}s against a {config_job_timeout}s job timeout; "
-        "config-time CIDB queries must stay removed"
-    )
 
 
 if __name__ == "__main__":

--- a/ci/tests/test_config_job_no_cidb.py
+++ b/ci/tests/test_config_job_no_cidb.py
@@ -216,7 +216,9 @@ class _OkResponse:
 def test_flaky_check_runs_when_stateless_tests_changed(monkeypatch):
     _use_fake_info(monkeypatch)
     calls = _record_cidb_requests(monkeypatch)
-    monkeypatch.setattr(Targeting, "get_changed_tests", lambda self: ["04652_probe."])
+    monkeypatch.setattr(
+        Targeting, "get_changed_tests", lambda self: [CHANGED_TEST_NAME]
+    )
     assert fj.should_skip_job(FLAKY_CHECK_JOB) == (False, "")
     assert calls == [], f"config-time CIDB requests: {calls}"
 
@@ -244,9 +246,12 @@ def test_previously_failed_cannot_change_flaky_coverage():
 
     import ci.jobs.functional_tests as functional_tests
 
-    # In-job side: the `is_flaky_check` branch that picks the test list must pick it
-    # from `get_changed_tests`. Matched on the AST rather than on text, because
-    # `is_flaky_check` also gates an unrelated worker-count branch.
+    targeting_methods = {n for n in dir(Targeting) if not n.startswith("__")}
+
+    # In-job side: every `Targeting` selector reached anywhere inside an
+    # `is_flaky_check` branch must be `get_changed_tests`. The whole branch body is
+    # walked, so `tests += ...` and `tests.extend(...)` count too; non-`Targeting`
+    # calls (`join`, `append`) are filtered out.
     selectors = set()
     for node in ast.walk(ast.parse(inspect.getsource(functional_tests))):
         if not isinstance(node, ast.If):
@@ -254,18 +259,24 @@ def test_previously_failed_cannot_change_flaky_coverage():
         if not (isinstance(node.test, ast.Name) and node.test.id == "is_flaky_check"):
             continue
         for stmt in node.body:
-            if not isinstance(stmt, ast.Assign) or not isinstance(stmt.value, ast.Call):
-                continue
-            if any(
-                isinstance(t, ast.Name) and t.id == "tests" for t in stmt.targets
-            ) and isinstance(stmt.value.func, ast.Attribute):
-                selectors.add(stmt.value.func.attr)
+            for sub in ast.walk(stmt):
+                if (
+                    isinstance(sub, ast.Call)
+                    and isinstance(sub.func, ast.Attribute)
+                    and sub.func.attr in targeting_methods
+                ):
+                    selectors.add(sub.func.attr)
     assert selectors == {"get_changed_tests"}, selectors
 
-    # Config-time side: the same selector, and no CIDB-backed one.
-    hook = inspect.getsource(fj)
-    assert "get_changed_tests" in hook
-    assert "get_previously_failed_tests" not in hook
+    # Config-time side: the same selector, and no CIDB-backed one. Scoped to the hook
+    # this PR changed, so an unrelated mention elsewhere in the module cannot mask it.
+    hook_calls = {
+        n.func.attr
+        for n in ast.walk(ast.parse(inspect.getsource(fj.should_skip_job)))
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+    }
+    assert "get_changed_tests" in hook_calls
+    assert "get_previously_failed_tests" not in hook_calls
 
 
 def test_integration_flaky_check_needs_no_cidb(monkeypatch):

--- a/ci/tests/test_config_job_no_cidb.py
+++ b/ci/tests/test_config_job_no_cidb.py
@@ -268,6 +268,20 @@ def test_previously_failed_cannot_change_flaky_coverage():
                     selectors.add(sub.func.attr)
     assert selectors == {"get_changed_tests"}, selectors
 
+    # Shape-independent backstop: the scan above only enters `if is_flaky_check:`, so a
+    # hoist into the enclosing `if is_flaky_check or is_bugfix_validation:` escapes it.
+    # Satisfiable because the targeted check reads `get_all_relevant_tests_with_info`.
+    module_targeting_calls = {
+        n.func.attr
+        for n in ast.walk(ast.parse(inspect.getsource(functional_tests)))
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr in targeting_methods
+    }
+    assert "get_previously_failed_tests" not in module_targeting_calls, (
+        module_targeting_calls
+    )
+
     # Config-time side: the same selector, and no CIDB-backed one. Scoped to the hook
     # this PR changed, so an unrelated mention elsewhere in the module cannot mask it.
     hook_calls = {


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/99396
Related: https://github.com/ClickHouse/ClickHouse/pull/112358
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

A transient CI database slowdown could kill the `Config Workflow` job and take the whole
test matrix with it. The affected head reports 174 completed check-runs (172 `skipped` plus
`Config Workflow` failed), so the run looks finished though nothing was tested, and praktika
does not re-run a completed-failed run. One 6-minute CIDB blip on 2026-08-01 voided 54 of my
open PRs and at least 3 from other contributors; none recovered.

`Config Workflow` is declared `timeout=600`, but `CIDB.query` retries 5 times with a 60s
per-request timeout and exponential backoff, so one query can take
`5 * 60 + (2 + 4 + 8 + 16) = 330s`, and nothing in the retry loop consults the wall clock.
The hooks run once per job and each stateless flaky-check job issued its own uncached
`get_previously_failed_tests` query, so today's 4 such jobs give a worst case of 1320s
against a 600s ceiling. The `try/except` around it is correct but unreachable: the process
is SIGKILLed mid-request first.

The lookup was also dead weight, orphaned by 4a5d222245225d3. No coverage is lost;
`get_previously_failed_tests` stays for its two in-job callers.

Config-time CIDB work drops to ~45s worst case, independent of how many flaky-check
parametrizations exist. One observable behaviour change: a PR with no changed stateless
tests but previous failures now skips the flaky job at config time rather than scheduling a
runner that would self-skip, matching the merge-queue counterpart.

Validated by driving praktika's per-job hook loop with CIDB blackholed: before, killed at
661s with 130 of 169 jobs unevaluated; after, all 169 evaluated, no CIDB request.

<details>
<summary>Why no coverage is lost, and reproduction / mutation evidence</summary>

4a5d222245225d3 moved previously-failed tests to the targeted check but edited only
`ci/jobs/functional_tests.py`, orphaning this config-time copy. The flaky check selects
`get_changed_tests` in-job and exits SKIPPED when that is empty, so the one case where
previously-failed flipped the config decision scheduled a job that immediately self-skipped
- the same reason e008b39c864f97d deleted the sibling `relevant_tests` term from this
condition. The targeted check, the real consumer, queries in-job inside a multi-hour budget.

The repro drives `native_jobs.py`'s hook loop over `ci.workflows.pull_request` with
`Targeting._ci_db` pointed at a non-routable address, so every attempt hits the real 60s
timeout; a 600s watchdog stands in for praktika's SIGKILL:

```
before: [0.0s -> 330.2s] 'Stateless tests (amd_asan_ubsan, flaky check)' cost 330s
        [330.2s -> 661.0s] 'Stateless tests (amd_tsan, flaky check)' cost 331s
        WATCHDOG: 661s > 600s -- 39/169 jobs filtered, 130 never evaluated
after:  TOTAL 0.0s, processed 169/169, 0 CIDB requests
```

| Mutation | Expected | Observed |
|---|---|---|
| revert the deletion | fail | 6 of 9 fail |
| a CIDB call via another method (`CIDB.check`) in `except Exception` | tests fail | 4 of 9 fail |
| add a 5th stateless flaky parametrization | still pass, still cover it | pass; blocked requests 20 -> 25 with the fix reverted |

The second mutation is why the guard records requests at `requests.post` rather than
raising: an `AssertionError` thrown there was swallowed by the old `except Exception`, so the
reachability tests passed against the code they had to reject. The third was run against
#112358's head (5 flaky checks, pre-fix worst case 1650s).

Full `ci/tests/`: 556 passed / 3 failed, against 547 / 3 on the pristine base - the same 3
failures (they need a live server the sandbox lacks), plus exactly the 9 new tests.

</details>

Adjacent, deliberately out of scope (separate root cause): `_check_db` returns `FAIL` on a
CIDB blip and `Result.create_from` aggregates it, so a CIDB failure at `check()` time fails
the config job with no timeout involved - fail-closed, where this change is fail-open.