### PR TITLE
Check query cancellation inside the row loop of formatQuery and friends

### DIFF
--- a/src/Functions/FunctionHelpers.cpp
+++ b/src/Functions/FunctionHelpers.cpp
@@ -8,6 +8,7 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <Functions/FunctionHelpers.h>
 #include <Functions/IFunction.h>
+#include <Interpreters/ProcessList.h>
 
 
 namespace DB
@@ -20,6 +21,13 @@ extern const int LOGICAL_ERROR;
 extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
 extern const int SIZES_OF_ARRAYS_DONT_MATCH;
 extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+extern const int TIMEOUT_EXCEEDED;
+}
+
+void checkQueryCancellation(const QueryStatusPtr & query_status, std::string_view function_name)
+{
+    if (query_status && !query_status->checkTimeLimit())
+        throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", function_name);
 }
 
 const ColumnConst * checkAndGetColumnConstStringOrFixedString(const IColumn * column)

--- a/src/Functions/FunctionHelpers.cpp
+++ b/src/Functions/FunctionHelpers.cpp
@@ -8,7 +8,9 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <Functions/FunctionHelpers.h>
 #include <Functions/IFunction.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/ProcessList.h>
+#include <Common/CurrentThread.h>
 
 
 namespace DB
@@ -22,6 +24,13 @@ extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
 extern const int SIZES_OF_ARRAYS_DONT_MATCH;
 extern const int ILLEGAL_TYPE_OF_ARGUMENT;
 extern const int TIMEOUT_EXCEEDED;
+}
+
+QueryStatusPtr getQueryStatusOfExecutingQuery()
+{
+    if (auto query_context = CurrentThread::tryGetQueryContext())
+        return query_context->getProcessListElementSafe();
+    return {};
 }
 
 void checkQueryCancellation(const QueryStatusPtr & query_status, std::string_view function_name)

--- a/src/Functions/FunctionHelpers.h
+++ b/src/Functions/FunctionHelpers.h
@@ -23,16 +23,19 @@ class IFunction;
 class QueryStatus;
 using QueryStatusPtr = std::shared_ptr<QueryStatus>;
 
+/// The executing query, which need not be the one that built the function: an `IFunction` is retained in
+/// table metadata and re-executed later. Empty when the thread has no query context, or the query has no
+/// process-list entry, in which case the checks below are no-ops.
+QueryStatusPtr getQueryStatusOfExecutingQuery();
+
 /// Polls query cancellation from inside a per-row loop, which pipeline-level cancellation cannot reach.
 /// `QueryStatus::checkTimeLimit` throws for `KILL QUERY` and for the `throw` overflow mode and returns
 /// false for `break`; a scalar has no meaningful partial result, so `break` is a hard stop here as well.
-/// `query_status` is empty for callers that have no process-list entry, where the check stays a no-op.
 void checkQueryCancellation(const QueryStatusPtr & query_status, std::string_view function_name);
 
 /// Throttled form of the above, for loops whose per-row work can be small enough that an unconditional
-/// poll dominates it. Accumulate the bytes each row parses and poll only on crossing a 64 KiB stride, so
-/// worst-case latency between polls is one stride's parsing, or one row when a row exceeds the stride.
-/// Each row counts as at least one byte, so a block of empty strings still polls.
+/// poll dominates it. Poll only on crossing a 64 KiB stride, so worst-case latency between polls is one
+/// stride's parsing. Each row counts as at least one byte, so a block of empty strings still polls.
 inline void checkQueryCancellationThrottled(
     const QueryStatusPtr & query_status, std::string_view function_name, size_t bytes, size_t & bytes_since_check)
 {

--- a/src/Functions/FunctionHelpers.h
+++ b/src/Functions/FunctionHelpers.h
@@ -23,22 +23,16 @@ class IFunction;
 class QueryStatus;
 using QueryStatusPtr = std::shared_ptr<QueryStatus>;
 
-/// Cancellation is only polled between pipeline tasks, so a function whose `executeImpl` does unbounded
-/// per-row work must poll it inside that loop too. Otherwise a whole block is one uninterruptible unit
-/// which outlives `max_execution_time` and `KILL QUERY`.
+/// Polls query cancellation from inside a per-row loop, which pipeline-level cancellation cannot reach.
 /// `QueryStatus::checkTimeLimit` throws for `KILL QUERY` and for the `throw` overflow mode and returns
 /// false for `break`; a scalar has no meaningful partial result, so `break` is a hard stop here as well.
 /// `query_status` is empty for callers that have no process-list entry, where the check stays a no-op.
 void checkQueryCancellation(const QueryStatusPtr & query_status, std::string_view function_name);
 
-/// Throttled form of the above, for loops whose per-row work can be as small as tens of nanoseconds.
-/// A poll costs a `clock_gettime` plus a `QueryStatus::cancel_mutex` acquisition (about 31 ns measured),
-/// so polling unconditionally per row makes `tokenizeQuery` over short inputs six times slower. Accumulate
-/// the bytes each row parses and poll only on crossing a stride, the way `geohashesInBox`, `arrayFold` and
-/// `Base58` throttle theirs. Count each row as at least one byte so a block of empty strings still polls.
-/// Worst-case latency between polls is the work of one stride: 64 KiB of SQL text, which parses in about
-/// 50 ms, or a single row when a row is larger than that. Both are far below the one-second granularity
-/// `max_execution_time` is expressed in.
+/// Throttled form of the above, for loops whose per-row work can be small enough that an unconditional
+/// poll dominates it. Accumulate the bytes each row parses and poll only on crossing a 64 KiB stride, so
+/// worst-case latency between polls is one stride's parsing, or one row when a row exceeds the stride.
+/// Each row counts as at least one byte, so a block of empty strings still polls.
 inline void checkQueryCancellationThrottled(
     const QueryStatusPtr & query_status, std::string_view function_name, size_t bytes, size_t & bytes_since_check)
 {

--- a/src/Functions/FunctionHelpers.h
+++ b/src/Functions/FunctionHelpers.h
@@ -20,6 +20,17 @@ namespace ErrorCodes
 
 class IFunction;
 
+class QueryStatus;
+using QueryStatusPtr = std::shared_ptr<QueryStatus>;
+
+/// Cancellation is only polled between pipeline tasks, so a function whose `executeImpl` does unbounded
+/// per-row work must poll it inside that loop too. Otherwise a whole block is one uninterruptible unit
+/// which outlives `max_execution_time` and `KILL QUERY`.
+/// `QueryStatus::checkTimeLimit` throws for `KILL QUERY` and for the `throw` overflow mode and returns
+/// false for `break`; a scalar has no meaningful partial result, so `break` is a hard stop here as well.
+/// `query_status` is empty for callers that have no process-list entry, where the check stays a no-op.
+void checkQueryCancellation(const QueryStatusPtr & query_status, std::string_view function_name);
+
 /// Methods, that helps dispatching over real column types.
 
 template <typename Type>

--- a/src/Functions/FunctionHelpers.h
+++ b/src/Functions/FunctionHelpers.h
@@ -31,6 +31,27 @@ using QueryStatusPtr = std::shared_ptr<QueryStatus>;
 /// `query_status` is empty for callers that have no process-list entry, where the check stays a no-op.
 void checkQueryCancellation(const QueryStatusPtr & query_status, std::string_view function_name);
 
+/// Throttled form of the above, for loops whose per-row work can be as small as tens of nanoseconds.
+/// A poll costs a `clock_gettime` plus a `QueryStatus::cancel_mutex` acquisition (about 31 ns measured),
+/// so polling unconditionally per row makes `tokenizeQuery` over short inputs six times slower. Accumulate
+/// the bytes each row parses and poll only on crossing a stride, the way `geohashesInBox`, `arrayFold` and
+/// `Base58` throttle theirs. Count each row as at least one byte so a block of empty strings still polls.
+/// Worst-case latency between polls is the work of one stride: 64 KiB of SQL text, which parses in about
+/// 50 ms, or a single row when a row is larger than that. Both are far below the one-second granularity
+/// `max_execution_time` is expressed in.
+inline void checkQueryCancellationThrottled(
+    const QueryStatusPtr & query_status, std::string_view function_name, size_t bytes, size_t & bytes_since_check)
+{
+    static constexpr size_t bytes_between_cancellation_checks = 65536;
+
+    bytes_since_check += bytes ? bytes : 1;
+    if (bytes_since_check >= bytes_between_cancellation_checks)
+    {
+        bytes_since_check = 0;
+        checkQueryCancellation(query_status, function_name);
+    }
+}
+
 /// Methods, that helps dispatching over real column types.
 
 template <typename Type>

--- a/src/Functions/QueryTokenizationImpl.h
+++ b/src/Functions/QueryTokenizationImpl.h
@@ -67,6 +67,9 @@ public:
     {
         if (context)
         {
+            /// Some callers have no process-list entry, so the cancellation check must stay a no-op there.
+            query_status = context->getProcessListElementSafe();
+
             const auto & settings = context->getSettingsRef();
             parser_settings.max_parser_depth = settings[Setting::max_parser_depth];
             parser_settings.max_parser_backtracks = settings[Setting::max_parser_backtracks];
@@ -108,6 +111,8 @@ public:
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
+            checkQueryCancellation(query_status, name);
+
             std::string_view query = col_query.getDataAt(i);
 
             Impl::processRow(query, data_begin, data_end, data_type, total, parser_settings);
@@ -125,6 +130,7 @@ public:
 
 private:
     QueryTokenizationSettings parser_settings;
+    QueryStatusPtr query_status;
 };
 
 }

--- a/src/Functions/QueryTokenizationImpl.h
+++ b/src/Functions/QueryTokenizationImpl.h
@@ -67,8 +67,6 @@ public:
     {
         if (context)
         {
-            query_status = context->getProcessListElementSafe();
-
             const auto & settings = context->getSettingsRef();
             parser_settings.max_parser_depth = settings[Setting::max_parser_depth];
             parser_settings.max_parser_backtracks = settings[Setting::max_parser_backtracks];
@@ -108,6 +106,7 @@ public:
 
         size_t total = 0;
         size_t bytes_since_check = 0;
+        const QueryStatusPtr query_status = getQueryStatusOfExecutingQuery();
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
@@ -130,7 +129,6 @@ public:
 
 private:
     QueryTokenizationSettings parser_settings;
-    QueryStatusPtr query_status;
 };
 
 }

--- a/src/Functions/QueryTokenizationImpl.h
+++ b/src/Functions/QueryTokenizationImpl.h
@@ -67,7 +67,6 @@ public:
     {
         if (context)
         {
-            /// Some callers have no process-list entry, so the cancellation check must stay a no-op there.
             query_status = context->getProcessListElementSafe();
 
             const auto & settings = context->getSettingsRef();

--- a/src/Functions/QueryTokenizationImpl.h
+++ b/src/Functions/QueryTokenizationImpl.h
@@ -108,12 +108,13 @@ public:
         offsets.resize(input_rows_count);
 
         size_t total = 0;
+        size_t bytes_since_check = 0;
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            checkQueryCancellation(query_status, name);
-
             std::string_view query = col_query.getDataAt(i);
+
+            checkQueryCancellationThrottled(query_status, name, query.size(), bytes_since_check);
 
             Impl::processRow(query, data_begin, data_end, data_type, total, parser_settings);
 

--- a/src/Functions/formatQuery.cpp
+++ b/src/Functions/formatQuery.cpp
@@ -111,12 +111,13 @@ private:
 
         size_t prev_offset = 0;
         size_t res_data_size = 0;
+        size_t bytes_since_check = 0;
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
             /// Outside the `try` below on purpose: for ErrorHandling::Null that handler swallows every
             /// exception into a NULL and continues, which would turn cancellation into wrong results.
-            checkQueryCancellation(query_status, name);
+            checkQueryCancellationThrottled(query_status, name, offsets[i] - prev_offset, bytes_since_check);
 
             const char * begin = reinterpret_cast<const char *>(&data[prev_offset]);
             const char * end = begin + offsets[i] - prev_offset;

--- a/src/Functions/formatQuery.cpp
+++ b/src/Functions/formatQuery.cpp
@@ -48,7 +48,6 @@ public:
     FunctionFormatQuery(ContextPtr context, String name_, OutputFormatting output_formatting_, ErrorHandling error_handling_)
         : name(name_), output_formatting(output_formatting_), error_handling(error_handling_)
     {
-        /// Some callers have no process-list entry, so the cancellation check must stay a no-op there.
         query_status = context->getProcessListElementSafe();
 
         const Settings & settings = context->getSettingsRef();

--- a/src/Functions/formatQuery.cpp
+++ b/src/Functions/formatQuery.cpp
@@ -7,6 +7,7 @@
 #include <Functions/FunctionHelpers.h>
 #include <IO/WriteBufferFromString.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
 #include <Parsers/IAST.h>
 #include <Parsers/ParserQuery.h>
 #include <Parsers/parseQuery.h>
@@ -25,6 +26,7 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
+    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace
@@ -48,6 +50,9 @@ public:
     FunctionFormatQuery(ContextPtr context, String name_, OutputFormatting output_formatting_, ErrorHandling error_handling_)
         : name(name_), output_formatting(output_formatting_), error_handling(error_handling_)
     {
+        /// Some callers have no process-list entry, so the cancellation check must stay a no-op there.
+        query_status = context->getProcessListElementSafe();
+
         const Settings & settings = context->getSettingsRef();
         max_query_size = settings[Setting::max_query_size];
         max_parser_depth = settings[Setting::max_parser_depth];
@@ -111,6 +116,10 @@ private:
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
+            /// Outside the `try` below on purpose: for ErrorHandling::Null that handler swallows every
+            /// exception into a NULL and continues, which would turn cancellation into wrong results.
+            checkCancellation();
+
             const char * begin = reinterpret_cast<const char *>(&data[prev_offset]);
             const char * end = begin + offsets[i] - prev_offset;
 
@@ -161,9 +170,19 @@ private:
         res_data.resize(res_data_size);
     }
 
+    /// Cancellation is only polled between pipeline tasks, so an unbounded per-row loop must poll it too.
+    /// `checkTimeLimit` throws for `KILL QUERY` and the `throw` overflow mode and returns false for
+    /// `break`; a scalar has no meaningful partial result, so `break` is a hard stop here as well.
+    void checkCancellation() const
+    {
+        if (query_status && !query_status->checkTimeLimit())
+            throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", name);
+    }
+
     String name;
     OutputFormatting output_formatting;
     ErrorHandling error_handling;
+    QueryStatusPtr query_status;
 
     size_t max_query_size;
     size_t max_parser_depth;

--- a/src/Functions/formatQuery.cpp
+++ b/src/Functions/formatQuery.cpp
@@ -7,7 +7,6 @@
 #include <Functions/FunctionHelpers.h>
 #include <IO/WriteBufferFromString.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/ProcessList.h>
 #include <Parsers/IAST.h>
 #include <Parsers/ParserQuery.h>
 #include <Parsers/parseQuery.h>
@@ -26,7 +25,6 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
-    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace
@@ -118,7 +116,7 @@ private:
         {
             /// Outside the `try` below on purpose: for ErrorHandling::Null that handler swallows every
             /// exception into a NULL and continues, which would turn cancellation into wrong results.
-            checkCancellation();
+            checkQueryCancellation(query_status, name);
 
             const char * begin = reinterpret_cast<const char *>(&data[prev_offset]);
             const char * end = begin + offsets[i] - prev_offset;
@@ -168,15 +166,6 @@ private:
         }
 
         res_data.resize(res_data_size);
-    }
-
-    /// Cancellation is only polled between pipeline tasks, so an unbounded per-row loop must poll it too.
-    /// `checkTimeLimit` throws for `KILL QUERY` and the `throw` overflow mode and returns false for
-    /// `break`; a scalar has no meaningful partial result, so `break` is a hard stop here as well.
-    void checkCancellation() const
-    {
-        if (query_status && !query_status->checkTimeLimit())
-            throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", name);
     }
 
     String name;

--- a/src/Functions/formatQuery.cpp
+++ b/src/Functions/formatQuery.cpp
@@ -48,8 +48,6 @@ public:
     FunctionFormatQuery(ContextPtr context, String name_, OutputFormatting output_formatting_, ErrorHandling error_handling_)
         : name(name_), output_formatting(output_formatting_), error_handling(error_handling_)
     {
-        query_status = context->getProcessListElementSafe();
-
         const Settings & settings = context->getSettingsRef();
         max_query_size = settings[Setting::max_query_size];
         max_parser_depth = settings[Setting::max_parser_depth];
@@ -87,7 +85,9 @@ public:
         if (const ColumnString * col_query_string = checkAndGetColumn<ColumnString>(col_query.get()))
         {
             auto col_res = ColumnString::create();
-            formatVector(col_query_string->getChars(), col_query_string->getOffsets(), col_res->getChars(), col_res->getOffsets(), col_null_map, input_rows_count);
+            formatVector(
+                col_query_string->getChars(), col_query_string->getOffsets(), col_res->getChars(), col_res->getOffsets(),
+                col_null_map, input_rows_count, getQueryStatusOfExecutingQuery());
 
             if (error_handling == ErrorHandling::Null)
                 return ColumnNullable::create(std::move(col_res), std::move(col_null_map));
@@ -103,7 +103,8 @@ private:
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
         ColumnUInt8::MutablePtr & res_null_map,
-        size_t input_rows_count) const
+        size_t input_rows_count,
+        const QueryStatusPtr & query_status) const
     {
         res_offsets.resize(input_rows_count);
         res_data.resize(data.size());
@@ -171,7 +172,6 @@ private:
     String name;
     OutputFormatting output_formatting;
     ErrorHandling error_handling;
-    QueryStatusPtr query_status;
 
     size_t max_query_size;
     size_t max_parser_depth;

--- a/src/Functions/formatQueryFromJSON.cpp
+++ b/src/Functions/formatQueryFromJSON.cpp
@@ -2,10 +2,10 @@
 #include <Core/Settings.h>
 #include <DataTypes/DataTypeString.h>
 #include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
 #include <Functions/IFunction.h>
 #include <IO/WriteBufferFromString.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/ProcessList.h>
 #include <Parsers/ASTFromJSON.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/IAST.h>
@@ -33,7 +33,6 @@ namespace ErrorCodes
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
     extern const int SYNTAX_ERROR;
-    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace
@@ -301,7 +300,7 @@ public:
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            checkCancellation();
+            checkQueryCancellation(query_status, name);
 
             auto json = String(json_col->getDataAt(i));
 
@@ -379,15 +378,6 @@ public:
     }
 
 private:
-    /// Cancellation is only polled between pipeline tasks, so an unbounded per-row loop must poll it too.
-    /// `checkTimeLimit` throws for `KILL QUERY` and the `throw` overflow mode and returns false for
-    /// `break`; a scalar has no meaningful partial result, so `break` is a hard stop here as well.
-    void checkCancellation() const
-    {
-        if (query_status && !query_status->checkTimeLimit())
-            throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", name);
-    }
-
     QueryStatusPtr query_status;
     size_t max_ast_depth;
     size_t max_ast_elements;

--- a/src/Functions/formatQueryFromJSON.cpp
+++ b/src/Functions/formatQueryFromJSON.cpp
@@ -252,7 +252,6 @@ public:
 
     explicit FunctionFormatQueryFromJSON(ContextPtr context)
     {
-        /// Some callers have no process-list entry, so the cancellation check must stay a no-op there.
         query_status = context->getProcessListElementSafe();
 
         const Settings & settings = context->getSettingsRef();
@@ -303,7 +302,9 @@ public:
         {
             auto json = String(json_col->getDataAt(i));
 
-            checkQueryCancellationThrottled(query_status, name, json.size(), bytes_since_check);
+            /// Both arguments are parsed per row, so both count toward the stride.
+            const size_t row_bytes = json.size() + (orig_col ? orig_col->getDataAt(i).size() : 0);
+            checkQueryCancellationThrottled(query_status, name, row_bytes, bytes_since_check);
 
             /// Enforce `max_query_size` on the raw JSON before handing it to `Poco::JSON::Parser`,
             /// mirroring the `clickhouse_json` client/server entry points: a shallow document with a

--- a/src/Functions/formatQueryFromJSON.cpp
+++ b/src/Functions/formatQueryFromJSON.cpp
@@ -5,6 +5,7 @@
 #include <Functions/IFunction.h>
 #include <IO/WriteBufferFromString.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
 #include <Parsers/ASTFromJSON.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/IAST.h>
@@ -32,6 +33,7 @@ namespace ErrorCodes
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
     extern const int SYNTAX_ERROR;
+    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace
@@ -251,6 +253,9 @@ public:
 
     explicit FunctionFormatQueryFromJSON(ContextPtr context)
     {
+        /// Some callers have no process-list entry, so the cancellation check must stay a no-op there.
+        query_status = context->getProcessListElementSafe();
+
         const Settings & settings = context->getSettingsRef();
         max_ast_depth = settings[Setting::max_ast_depth];
         max_ast_elements = settings[Setting::max_ast_elements];
@@ -296,6 +301,8 @@ public:
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
+            checkCancellation();
+
             auto json = String(json_col->getDataAt(i));
 
             /// Enforce `max_query_size` on the raw JSON before handing it to `Poco::JSON::Parser`,
@@ -372,6 +379,16 @@ public:
     }
 
 private:
+    /// Cancellation is only polled between pipeline tasks, so an unbounded per-row loop must poll it too.
+    /// `checkTimeLimit` throws for `KILL QUERY` and the `throw` overflow mode and returns false for
+    /// `break`; a scalar has no meaningful partial result, so `break` is a hard stop here as well.
+    void checkCancellation() const
+    {
+        if (query_status && !query_status->checkTimeLimit())
+            throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", name);
+    }
+
+    QueryStatusPtr query_status;
     size_t max_ast_depth;
     size_t max_ast_elements;
     size_t max_query_size;

--- a/src/Functions/formatQueryFromJSON.cpp
+++ b/src/Functions/formatQueryFromJSON.cpp
@@ -297,12 +297,13 @@ public:
 
         const auto * json_col = arguments[0].column.get();
         const auto * orig_col = arguments.size() > 1 ? arguments[1].column.get() : nullptr;
+        size_t bytes_since_check = 0;
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            checkQueryCancellation(query_status, name);
-
             auto json = String(json_col->getDataAt(i));
+
+            checkQueryCancellationThrottled(query_status, name, json.size(), bytes_since_check);
 
             /// Enforce `max_query_size` on the raw JSON before handing it to `Poco::JSON::Parser`,
             /// mirroring the `clickhouse_json` client/server entry points: a shallow document with a

--- a/src/Functions/formatQueryFromJSON.cpp
+++ b/src/Functions/formatQueryFromJSON.cpp
@@ -252,8 +252,6 @@ public:
 
     explicit FunctionFormatQueryFromJSON(ContextPtr context)
     {
-        query_status = context->getProcessListElementSafe();
-
         const Settings & settings = context->getSettingsRef();
         max_ast_depth = settings[Setting::max_ast_depth];
         max_ast_elements = settings[Setting::max_ast_elements];
@@ -297,6 +295,7 @@ public:
         const auto * json_col = arguments[0].column.get();
         const auto * orig_col = arguments.size() > 1 ? arguments[1].column.get() : nullptr;
         size_t bytes_since_check = 0;
+        const QueryStatusPtr query_status = getQueryStatusOfExecutingQuery();
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
@@ -380,7 +379,6 @@ public:
     }
 
 private:
-    QueryStatusPtr query_status;
     size_t max_ast_depth;
     size_t max_ast_elements;
     size_t max_query_size;

--- a/src/Functions/fuzzQuery.cpp
+++ b/src/Functions/fuzzQuery.cpp
@@ -6,7 +6,6 @@
 #include <Functions/FunctionHelpers.h>
 #include <IO/WriteBufferFromString.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/ProcessList.h>
 #include <Interpreters/executeQuery.h>
 #include <Parsers/IAST.h>
 #include <Parsers/ParserQuery.h>
@@ -27,7 +26,6 @@ namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
     extern const int SUPPORT_IS_DISABLED;
-    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace
@@ -97,7 +95,7 @@ public:
 
             for (size_t i = 0; i < input_rows_count; ++i)
             {
-                checkCancellation();
+                checkQueryCancellation(query_status, name);
 
                 ASTPtr fuzzed_ast = ast->clone();
                 {
@@ -126,7 +124,7 @@ private:
         size_t prev_offset = 0;
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            checkCancellation();
+            checkQueryCancellation(query_status, name);
 
             const char * begin = reinterpret_cast<const char *>(&data[prev_offset]);
             const char * end = reinterpret_cast<const char *>(&data[offsets[i]]);
@@ -145,15 +143,6 @@ private:
             col_res.insertData(buf.str().data(), buf.str().size());
             prev_offset = offsets[i];
         }
-    }
-
-    /// Cancellation is only polled between pipeline tasks, so an unbounded per-row loop must poll it too.
-    /// `checkTimeLimit` throws for `KILL QUERY` and the `throw` overflow mode and returns false for
-    /// `break`; a scalar has no meaningful partial result, so `break` is a hard stop here as well.
-    void checkCancellation() const
-    {
-        if (query_status && !query_status->checkTimeLimit())
-            throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", name);
     }
 
     QueryStatusPtr query_status;

--- a/src/Functions/fuzzQuery.cpp
+++ b/src/Functions/fuzzQuery.cpp
@@ -6,6 +6,7 @@
 #include <Functions/FunctionHelpers.h>
 #include <IO/WriteBufferFromString.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
 #include <Interpreters/executeQuery.h>
 #include <Parsers/IAST.h>
 #include <Parsers/ParserQuery.h>
@@ -26,6 +27,7 @@ namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
     extern const int SUPPORT_IS_DISABLED;
+    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace
@@ -42,6 +44,9 @@ public:
             throw Exception(
                 ErrorCodes::SUPPORT_IS_DISABLED,
                 "Function `fuzzQuery` is disabled. Set `allow_fuzz_query_functions` to 1 to enable it");
+
+        /// Some callers have no process-list entry, so the cancellation check must stay a no-op there.
+        query_status = context->getProcessListElementSafe();
 
         const Settings & settings = context->getSettingsRef();
         max_query_size = settings[Setting::max_query_size];
@@ -92,6 +97,8 @@ public:
 
             for (size_t i = 0; i < input_rows_count; ++i)
             {
+                checkCancellation();
+
                 ASTPtr fuzzed_ast = ast->clone();
                 {
                     auto [fuzzer, lock] = getGlobalASTFuzzer();
@@ -119,6 +126,8 @@ private:
         size_t prev_offset = 0;
         for (size_t i = 0; i < input_rows_count; ++i)
         {
+            checkCancellation();
+
             const char * begin = reinterpret_cast<const char *>(&data[prev_offset]);
             const char * end = reinterpret_cast<const char *>(&data[offsets[i]]);
 
@@ -138,6 +147,16 @@ private:
         }
     }
 
+    /// Cancellation is only polled between pipeline tasks, so an unbounded per-row loop must poll it too.
+    /// `checkTimeLimit` throws for `KILL QUERY` and the `throw` overflow mode and returns false for
+    /// `break`; a scalar has no meaningful partial result, so `break` is a hard stop here as well.
+    void checkCancellation() const
+    {
+        if (query_status && !query_status->checkTimeLimit())
+            throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", name);
+    }
+
+    QueryStatusPtr query_status;
     size_t max_query_size;
     size_t max_parser_depth;
     size_t max_parser_backtracks;

--- a/src/Functions/fuzzQuery.cpp
+++ b/src/Functions/fuzzQuery.cpp
@@ -93,9 +93,12 @@ public:
             ParserQuery parser(end, false, implicit_select);
             ASTPtr ast = parseQuery(parser, begin, end, "fuzzQuery", max_query_size, max_parser_depth, max_parser_backtracks);
 
+            size_t bytes_since_check = 0;
             for (size_t i = 0; i < input_rows_count; ++i)
             {
-                checkQueryCancellation(query_status, name);
+                /// Every row fuzzes and re-formats the same parsed query, so each one costs the same
+                /// as parsing that text once.
+                checkQueryCancellationThrottled(query_status, name, data.size(), bytes_since_check);
 
                 ASTPtr fuzzed_ast = ast->clone();
                 {
@@ -122,9 +125,10 @@ private:
         size_t input_rows_count) const
     {
         size_t prev_offset = 0;
+        size_t bytes_since_check = 0;
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            checkQueryCancellation(query_status, name);
+            checkQueryCancellationThrottled(query_status, name, offsets[i] - prev_offset, bytes_since_check);
 
             const char * begin = reinterpret_cast<const char *>(&data[prev_offset]);
             const char * end = reinterpret_cast<const char *>(&data[offsets[i]]);

--- a/src/Functions/fuzzQuery.cpp
+++ b/src/Functions/fuzzQuery.cpp
@@ -43,8 +43,6 @@ public:
                 ErrorCodes::SUPPORT_IS_DISABLED,
                 "Function `fuzzQuery` is disabled. Set `allow_fuzz_query_functions` to 1 to enable it");
 
-        query_status = context->getProcessListElementSafe();
-
         const Settings & settings = context->getSettingsRef();
         max_query_size = settings[Setting::max_query_size];
         max_parser_depth = settings[Setting::max_parser_depth];
@@ -71,6 +69,7 @@ public:
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
         const ColumnPtr col_query = arguments[0].column;
+        const QueryStatusPtr query_status = getQueryStatusOfExecutingQuery();
 
         if (const ColumnString * col_query_string = checkAndGetColumn<ColumnString>(col_query.get()))
         {
@@ -78,7 +77,7 @@ public:
             fuzzVector(
                 col_query_string->getChars(), col_query_string->getOffsets(),
                 *col_res,
-                input_rows_count);
+                input_rows_count, query_status);
             return col_res;
         }
 
@@ -121,7 +120,8 @@ private:
         const ColumnString::Chars & data,
         const ColumnString::Offsets & offsets,
         ColumnString & col_res,
-        size_t input_rows_count) const
+        size_t input_rows_count,
+        const QueryStatusPtr & query_status) const
     {
         size_t prev_offset = 0;
         size_t bytes_since_check = 0;
@@ -148,7 +148,6 @@ private:
         }
     }
 
-    QueryStatusPtr query_status;
     size_t max_query_size;
     size_t max_parser_depth;
     size_t max_parser_backtracks;

--- a/src/Functions/fuzzQuery.cpp
+++ b/src/Functions/fuzzQuery.cpp
@@ -43,7 +43,6 @@ public:
                 ErrorCodes::SUPPORT_IS_DISABLED,
                 "Function `fuzzQuery` is disabled. Set `allow_fuzz_query_functions` to 1 to enable it");
 
-        /// Some callers have no process-list entry, so the cancellation check must stay a no-op there.
         query_status = context->getProcessListElementSafe();
 
         const Settings & settings = context->getSettingsRef();

--- a/src/Functions/parseQueryToJSON.cpp
+++ b/src/Functions/parseQueryToJSON.cpp
@@ -44,8 +44,6 @@ public:
 
     explicit FunctionParseQueryToJSON(ContextPtr context)
     {
-        query_status = context->getProcessListElementSafe();
-
         const Settings & settings = context->getSettingsRef();
         max_query_size = settings[Setting::max_query_size];
         max_parser_depth = settings[Setting::max_parser_depth];
@@ -76,6 +74,7 @@ public:
 
         const auto * col = arguments[0].column.get();
         size_t bytes_since_check = 0;
+        const QueryStatusPtr query_status = getQueryStatusOfExecutingQuery();
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
@@ -100,7 +99,6 @@ public:
     }
 
 private:
-    QueryStatusPtr query_status;
     size_t max_query_size;
     size_t max_parser_depth;
     size_t max_parser_backtracks;

--- a/src/Functions/parseQueryToJSON.cpp
+++ b/src/Functions/parseQueryToJSON.cpp
@@ -44,7 +44,6 @@ public:
 
     explicit FunctionParseQueryToJSON(ContextPtr context)
     {
-        /// Some callers have no process-list entry, so the cancellation check must stay a no-op there.
         query_status = context->getProcessListElementSafe();
 
         const Settings & settings = context->getSettingsRef();

--- a/src/Functions/parseQueryToJSON.cpp
+++ b/src/Functions/parseQueryToJSON.cpp
@@ -2,9 +2,9 @@
 #include <Core/Settings.h>
 #include <DataTypes/DataTypeString.h>
 #include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
 #include <Functions/IFunction.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/ProcessList.h>
 #include <Parsers/ASTToJSON.h>
 #include <Parsers/IAST.h>
 #include <Parsers/ParserQuery.h>
@@ -27,7 +27,6 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
-    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace
@@ -80,7 +79,7 @@ public:
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            checkCancellation();
+            checkQueryCancellation(query_status, name);
 
             auto sql = col->getDataAt(i);
 
@@ -101,15 +100,6 @@ public:
     }
 
 private:
-    /// Cancellation is only polled between pipeline tasks, so an unbounded per-row loop must poll it too.
-    /// `checkTimeLimit` throws for `KILL QUERY` and the `throw` overflow mode and returns false for
-    /// `break`; a scalar has no meaningful partial result, so `break` is a hard stop here as well.
-    void checkCancellation() const
-    {
-        if (query_status && !query_status->checkTimeLimit())
-            throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", name);
-    }
-
     QueryStatusPtr query_status;
     size_t max_query_size;
     size_t max_parser_depth;

--- a/src/Functions/parseQueryToJSON.cpp
+++ b/src/Functions/parseQueryToJSON.cpp
@@ -4,6 +4,7 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/IFunction.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
 #include <Parsers/ASTToJSON.h>
 #include <Parsers/IAST.h>
 #include <Parsers/ParserQuery.h>
@@ -26,6 +27,7 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace
@@ -43,6 +45,9 @@ public:
 
     explicit FunctionParseQueryToJSON(ContextPtr context)
     {
+        /// Some callers have no process-list entry, so the cancellation check must stay a no-op there.
+        query_status = context->getProcessListElementSafe();
+
         const Settings & settings = context->getSettingsRef();
         max_query_size = settings[Setting::max_query_size];
         max_parser_depth = settings[Setting::max_parser_depth];
@@ -75,6 +80,8 @@ public:
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
+            checkCancellation();
+
             auto sql = col->getDataAt(i);
 
             ParserQuery parser(sql.data() + sql.size(), allow_settings_after_format_in_insert, implicit_select);
@@ -94,6 +101,16 @@ public:
     }
 
 private:
+    /// Cancellation is only polled between pipeline tasks, so an unbounded per-row loop must poll it too.
+    /// `checkTimeLimit` throws for `KILL QUERY` and the `throw` overflow mode and returns false for
+    /// `break`; a scalar has no meaningful partial result, so `break` is a hard stop here as well.
+    void checkCancellation() const
+    {
+        if (query_status && !query_status->checkTimeLimit())
+            throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", name);
+    }
+
+    QueryStatusPtr query_status;
     size_t max_query_size;
     size_t max_parser_depth;
     size_t max_parser_backtracks;

--- a/src/Functions/parseQueryToJSON.cpp
+++ b/src/Functions/parseQueryToJSON.cpp
@@ -76,12 +76,13 @@ public:
         auto result = ColumnString::create();
 
         const auto * col = arguments[0].column.get();
+        size_t bytes_since_check = 0;
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            checkQueryCancellation(query_status, name);
-
             auto sql = col->getDataAt(i);
+
+            checkQueryCancellationThrottled(query_status, name, sql.size(), bytes_since_check);
 
             ParserQuery parser(sql.data() + sql.size(), allow_settings_after_format_in_insert, implicit_select);
             auto ast = parseQuery(parser, sql.data(), sql.data() + sql.size(), "",

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
@@ -1,4 +1,5 @@
 all bounded	1
+two-argument bounded	1
 SELECT\n    a,\n    b\nFROM t
 SELECT a, b FROM t
 1

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
@@ -5,4 +5,7 @@ SELECT a, b FROM t
 1
 1
 1
+1
+1
+1
 ok

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
@@ -9,5 +9,5 @@ SELECT a, b FROM t
 1
 1
 1
-3000
+200
 ok

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
@@ -1,5 +1,4 @@
 all bounded	1
-two-argument bounded	1
 SELECT\n    a,\n    b\nFROM t
 SELECT a, b FROM t
 1

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
@@ -9,4 +9,5 @@ SELECT a, b FROM t
 1
 1
 1
+3000
 ok

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
@@ -3,4 +3,6 @@ SELECT\n    a,\n    b\nFROM t
 SELECT a, b FROM t
 1
 1
+1
+1
 ok

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
@@ -1,0 +1,6 @@
+all bounded	1
+SELECT\n    a,\n    b\nFROM t
+SELECT a, b FROM t
+1
+1
+ok

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.reference
@@ -8,4 +8,5 @@ SELECT a, b FROM t
 1
 1
 1
+1
 ok

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -1,62 +1,93 @@
 -- Tags: no-fasttest
 -- no-fasttest: needs enough rows of moderate SQL text that an unpatched parse loop overshoots the limit.
 
--- `formatQuery` and friends parse one row at a time inside a single pipeline task. Cancellation is only
--- polled between tasks, so before the fix a whole block ran to completion and the query outlived
+-- The query-parsing functions parse one row at a time inside a single pipeline task. Cancellation is
+-- only polled between tasks, so before the fix a whole block ran to completion and the query outlived
 -- `max_execution_time` and `KILL QUERY` (measured: 23 s under a 1 s limit; 1247 s in CI under MSan).
 --
 -- Note the assertion is on the ELAPSED TIME, not on the error: an unpatched server also raises
 -- TIMEOUT_EXCEEDED, just tens of seconds late, so `-- { serverError TIMEOUT_EXCEEDED }` alone would
--- pass without the fix. Each case below therefore reports whether it stopped anywhere near the limit.
+-- pass without the fix. Case 6 is the load-bearing one and checks how late each case stopped.
+--
+-- Every timed query pins `max_block_size` and `max_threads`, which the test runner otherwise
+-- randomizes: a small block lets an unpatched server finish its uninterruptible unit soon enough to
+-- stay under case 6's threshold, silently disarming it. The pins are per query so that they cannot
+-- leak into case 6's own read. Each timed query carries the `04691_timed` marker that case 6 counts.
 
 SET max_execution_time = 1;
 SET allow_fuzz_query_functions = 1;
 
 -- 1. formatQuery: many rows of moderate SQL text in one block.
-SELECT sum(length(formatQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40))))
-FROM numbers(200000) FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+SELECT sum(length(formatQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
+FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
 -- 2. formatQueryOrNull must raise, not swallow the cancellation into NULLs. Its per-row `catch (...)`
 --    turns any exception into NULL and continues, so the check has to sit outside that handler.
-SELECT sum(length(formatQueryOrNull('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40))))
-FROM numbers(200000) FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+SELECT sum(length(formatQueryOrNull('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
+FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
 -- 3. The single-line variants share the same loop.
-SELECT sum(length(formatQuerySingleLine('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40))))
-FROM numbers(200000) FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+SELECT sum(length(formatQuerySingleLine('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
+FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
-SELECT sum(length(formatQuerySingleLineOrNull('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40))))
-FROM numbers(200000) FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+SELECT sum(length(formatQuerySingleLineOrNull('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
+FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
 -- 4. Siblings with the same per-row parse loop.
-SELECT sum(length(parseQueryToJSON('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40))))
-FROM numbers(200000) FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+SELECT sum(length(parseQueryToJSON('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
+FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
-SELECT sum(length(fuzzQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40))))
-FROM numbers(200000) FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+--    `highlightQuery` and `tokenizeQuery` share one row loop in FunctionQueryTokenization.
+--    `highlightQuery` runs a full parse per row and covers that loop. `tokenizeQuery` is lexer-only and
+--    its cost is dominated by the size of the token array it builds, so it exhausts memory well before
+--    it overshoots a time limit; it gets no case of its own rather than one whose oracle cannot redden.
+SELECT sum(length(highlightQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
+FROM numbers(60000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
-SELECT sum(length(formatQueryFromJSON(parseQueryToJSON('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))))
-FROM numbers(200000) FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+-- 5. `fuzzQuery` has one row loop per argument shape and both need the poll.
+--    Non-constant argument, so this one takes the ColumnString loop.
+SELECT sum(length(fuzzQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
+FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
--- 5. The real assertion: every case above stopped near its limit rather than running the block out.
---    Pre-fix these report ~23000 ms against a 1000 ms limit; with the fix they report ~1000 ms.
+--    Constant argument: `fuzzQuery` opts out of the default constant handling, so this reaches the
+--    separate ColumnConst loop. It is not folded away because the function is non-deterministic.
+SELECT sum(length(fuzzQuery('SELECT 1 WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
+FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
+
+--    `formatQueryFromJSON` takes JSON from a scalar computed once and then materialized. Nesting the
+--    `parseQueryToJSON` call inside the timed expression instead would let the inner function's own
+--    poll raise first, leaving this one unexercised.
+WITH parseQueryToJSON('SELECT 1 WHERE x=0' || repeat(' OR (y = 1)', 40)) AS json
+SELECT sum(length(formatQueryFromJSON(materialize(json)))) /* 04691_timed */
+FROM numbers(100000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
+
+-- 6. The real assertion: every case above stopped near its limit rather than running its block out.
+--    Pre-fix they report 21000-90000 ms against a 1000 ms limit; with the fix they report ~1000 ms.
+--    `count() = 9` keeps the assertion from going vacuous: countIf(...) = 0 over an empty result set is
+--    trivially true, so a marker that stopped matching would silently disarm the whole test. The type
+--    filter selects exactly the nine timed queries, all of which are expected to have raised.
+--    max_execution_time = 0: the session limit above applies to the flush and to this unindexed
+--    query_log scan as well, and on a loaded sanitizer host either can exceed one second and time the
+--    oracle itself out. SYSTEM FLUSH LOGS takes no SETTINGS clause, hence the session-level SET.
+--    enable_parallel_replicas = 0: the test runner can inject parallel replicas, which this local
+--    system-table read must not go through.
+SET max_execution_time = 0;
 SYSTEM FLUSH LOGS query_log;
 
--- enable_parallel_replicas = 0: the test runner can inject parallel replicas, which this local
--- system-table read must not go through.
-SELECT 'all bounded', countIf(query_duration_ms > 15000) = 0
+SELECT 'all bounded', count() = 9 AND countIf(query_duration_ms > 15000) = 0
 FROM system.query_log
 WHERE current_database = currentDatabase()
-  AND type != 'QueryStart'
+  AND type = 'ExceptionWhileProcessing'
   AND event_time > now() - INTERVAL 10 MINUTE
-  AND query LIKE '%OR (y = 1)%'
-  AND query LIKE '%FROM numbers(200000)%'
-SETTINGS enable_parallel_replicas = 0;
+  AND query LIKE '%04691\_timed%'
+SETTINGS max_execution_time = 0, enable_parallel_replicas = 0;
 
--- 6. Results are unchanged when no limit is hit, including the OrNull NULL-on-parse-error contract.
+-- 7. Results are unchanged when no limit is hit, including the OrNull NULL-on-parse-error contract.
 SELECT formatQuery('select    a,b from  t') SETTINGS max_execution_time = 0;
 SELECT formatQuerySingleLine('select    a,b from  t') SETTINGS max_execution_time = 0;
 SELECT formatQueryOrNull('this is not a query') IS NULL SETTINGS max_execution_time = 0;
 SELECT length(parseQueryToJSON('SELECT 1')) > 0 SETTINGS max_execution_time = 0;
+SELECT length(highlightQuery('SELECT 1')) > 0 SETTINGS max_execution_time = 0;
+SELECT length(tokenizeQuery('SELECT 1')) > 0 SETTINGS max_execution_time = 0;
 
 SELECT 'ok';

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -61,6 +61,21 @@ WITH parseQueryToJSON('SELECT 1 WHERE x=0' || repeat(' OR (y = 1)', 40)) AS json
 SELECT sum(length(formatQueryFromJSON(materialize(json)))) /* 04691_timed */
 FROM numbers(100000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
+--    The two-argument form also parses the second argument per row, so its bytes have to count
+--    toward the stride as well. A small JSON with a large original is the shape that overshoots when
+--    only the JSON is counted: the JSON floor (339 bytes for the smallest valid AST) admits 193 rows
+--    per stride, each lexing the whole original. `max_query_size` is raised because at its default
+--    the original is capped at 262144 bytes, which bounds the overshoot to ~1.7 s -- under case 7's
+--    threshold, so the default-settings form cannot discriminate. This case therefore carries its own
+--    latency assertion below rather than case 7's marker, since it needs those raised settings. Its
+--    marker spells no other case's marker: a comment is part of the logged query text, so mentioning
+--    one here would make this query match that case's own count and inflate it.
+WITH parseQueryToJSON('SELECT 1') AS json
+SELECT sum(length(formatQueryFromJSON(materialize(json), materialize('SELECT 1 WHERE x=0' || repeat(' OR (y = 1)', 110000))))) /* 04691_twoarg */
+FROM numbers(200) FORMAT Null
+SETTINGS max_block_size = 200000, max_threads = 1, max_query_size = 2000000,
+         max_ast_elements = 100000000, max_parser_depth = 1000000; -- { serverError TIMEOUT_EXCEEDED }
+
 -- 6. `timeout_overflow_mode = 'break'` needs its own case. There `checkTimeLimit` returns false
 --    instead of throwing, and this fix turns that false into a hard stop, so the observable behaviour
 --    changes from "ran the block out, returned a result" to "stopped mid-block". The `throw`-mode
@@ -95,6 +110,17 @@ WHERE current_database = currentDatabase()
   AND type != 'QueryStart'
   AND event_time > now() - INTERVAL 10 MINUTE
   AND (query LIKE '%04691\_timed%' OR query LIKE '%04691\_break%')
+SETTINGS max_execution_time = 0, enable_parallel_replicas = 0;
+
+--    The two-argument case gets its own bound because it needs a raised `max_query_size`, which the
+--    cases above deliberately leave at the default. Measured: 4.7-5.3 s before counting the second
+--    argument's bytes, 1.08-1.13 s after, against a 1 s limit. 3000 ms sits clear of both.
+SELECT 'two-argument bounded', count() = 1 AND countIf(query_duration_ms > 3000) = 0
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type != 'QueryStart'
+  AND event_time > now() - INTERVAL 10 MINUTE
+  AND query LIKE '%04691\_twoarg%'
 SETTINGS max_execution_time = 0, enable_parallel_replicas = 0;
 
 -- 8. Results are unchanged when no limit is hit, including the OrNull NULL-on-parse-error contract.

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -14,7 +14,9 @@
 -- stay under case 7's threshold, silently disarming it. The pins are per query so that they cannot
 -- leak into case 7's own read. Each timed query carries a `04691_` marker that case 7 counts.
 
-SET max_execution_time = 1;
+-- The limit is what each timed query costs: they are limit-bound, not fixture-bound, so ten of them
+-- cost ten times this. It has to stay well above the poll's own overshoot, one 64 KiB stride.
+SET max_execution_time = 0.3;
 SET allow_fuzz_query_functions = 1;
 
 -- 1. formatQuery: many rows of moderate SQL text in one block.
@@ -78,7 +80,7 @@ SETTINGS max_block_size = 200000, max_threads = 1, timeout_overflow_mode = 'brea
 --    The bound is on CPU time, not on `query_duration_ms`: wall clock also absorbs scheduling delay,
 --    and this test runs concurrently with copies of itself, so a wall-clock budget wide enough for a
 --    starved host would have to exceed the pre-fix cost it exists to detect. Pre-fix these statements
---    burn tens of seconds of CPU against a 1000 ms limit; with the fix, one stride of parsing more.
+--    burn tens of seconds of CPU against a 300 ms limit; with the fix, one stride of parsing more.
 --    `count() = 10` keeps the assertion from going vacuous: countIf(...) = 0 over an empty result set is
 --    trivially true, so a marker that stopped matching would silently disarm the whole test.
 --    `type != 'QueryStart'` rather than `= 'ExceptionWhileProcessing'` because the break case above
@@ -145,8 +147,8 @@ FROM numbers(20000) SETTINGS max_execution_time = 0, max_block_size = 200000;
 DROP TABLE IF EXISTS t_04691_retained;
 CREATE TABLE t_04691_retained (q String, n UInt64)
 ENGINE = MergeTree PARTITION BY cityHash64(formatQuery(q)) ORDER BY n;
-ALTER TABLE t_04691_retained ADD COLUMN extra UInt8 DEFAULT 0 SETTINGS max_execution_time = 3;
-SELECT sleep(3), sleep(1) FORMAT Null SETTINGS max_execution_time = 0;
+ALTER TABLE t_04691_retained ADD COLUMN extra UInt8 DEFAULT 0 SETTINGS max_execution_time = 1;
+SELECT sleep(1), sleep(0.2) FORMAT Null SETTINGS max_execution_time = 0;
 INSERT INTO t_04691_retained (q, n)
 SELECT 'SELECT ' || toString(number % 4) || ' -- ' || repeat('x', 700), number FROM numbers(200)
 SETTINGS max_execution_time = 0, max_block_size = 200000;

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -130,4 +130,19 @@ WITH parseQueryToJSON('SELECT 1') AS json
 SELECT sum(length(formatQueryFromJSON(materialize(json), materialize('SELECT 1')))) > 0 FROM numbers(100000)
 SETTINGS max_execution_time = 0, max_block_size = 200000;
 
+-- 10. The poll must read the EXECUTING query, not the one that built the function. `ALTER` rebuilds the
+--     partition key from its own query context and `adjustPartitionKey` hands that same object to later
+--     inserts, rebuilding only when the key contains `modulo`, hence the plain key here. Reading a
+--     per-instance `QueryStatus` would fail this insert on the ALTER's long-expired 1 s limit.
+DROP TABLE IF EXISTS t_04691_retained;
+CREATE TABLE t_04691_retained (q String, n UInt64)
+ENGINE = MergeTree PARTITION BY cityHash64(formatQuery(q)) ORDER BY n;
+ALTER TABLE t_04691_retained ADD COLUMN extra UInt8 DEFAULT 0 SETTINGS max_execution_time = 1;
+SELECT sleep(2) FORMAT Null SETTINGS max_execution_time = 0;
+INSERT INTO t_04691_retained (q, n)
+SELECT 'SELECT ' || toString(number) || repeat(' OR (y = 1)', 60), number FROM numbers(3000)
+SETTINGS max_execution_time = 0, max_partitions_per_insert_block = 0, max_block_size = 200000;
+SELECT count() FROM t_04691_retained SETTINGS max_execution_time = 0;
+DROP TABLE t_04691_retained;
+
 SELECT 'ok';

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -106,42 +106,45 @@ SELECT formatQueryOrNull('this is not a query') IS NULL SETTINGS max_execution_t
 --    unconditionally, has to be caught somewhere, and everywhere else these functions appear
 --    TIMEOUT_EXCEEDED is the expected result. One call per polled row loop, no limit set.
 --    Each call has to actually REACH the check, and the check is throttled on accumulated input
---    bytes, so a single short query never polls at all and would make this arm vacuous. These run
---    enough rows in one block to cross the stride many times over, so a spurious throw shows up here.
+--    bytes, so a single short query never polls at all and would make this arm vacuous. The stride
+--    is charged in raw bytes, so a padded row buys the same crossings with far fewer rows than a
+--    bare 'SELECT 1' would: 20000 rows of 39 bytes cross the 64 KiB stride 12 times over.
 --    `fuzzQuery` is non-deterministic, so only the length is asserted.
-SELECT sum(length(formatQuery(materialize('SELECT 1')))) > 0 FROM numbers(100000)
+SELECT sum(length(formatQuery(materialize('SELECT 1 -- ' || repeat('x', 27))))) > 0 FROM numbers(20000)
 SETTINGS max_execution_time = 0, max_block_size = 200000;
-SELECT sum(length(parseQueryToJSON(materialize('SELECT 1')))) > 0 FROM numbers(100000)
+SELECT sum(length(parseQueryToJSON(materialize('SELECT 1 -- ' || repeat('x', 27))))) > 0 FROM numbers(20000)
 SETTINGS max_execution_time = 0, max_block_size = 200000;
-SELECT sum(length(highlightQuery(materialize('SELECT 1')))) > 0 FROM numbers(100000)
+SELECT sum(length(highlightQuery(materialize('SELECT 1 -- ' || repeat('x', 27))))) > 0 FROM numbers(20000)
 SETTINGS max_execution_time = 0, max_block_size = 200000;
-SELECT sum(length(tokenizeQuery(materialize('SELECT 1')))) > 0 FROM numbers(100000)
+SELECT sum(length(tokenizeQuery(materialize('SELECT 1 -- ' || repeat('x', 27))))) > 0 FROM numbers(20000)
 SETTINGS max_execution_time = 0, max_block_size = 200000;
-SELECT sum(length(fuzzQuery(materialize('SELECT 1')))) > 0 FROM numbers(100000)
+SELECT sum(length(fuzzQuery(materialize('SELECT 1 -- ' || repeat('x', 27))))) > 0 FROM numbers(20000)
 SETTINGS max_execution_time = 0, max_block_size = 200000;
-WITH parseQueryToJSON('SELECT 1') AS json
-SELECT sum(length(formatQueryFromJSON(materialize(json)))) > 0 FROM numbers(100000)
+WITH parseQueryToJSON('SELECT 1 -- ' || repeat('x', 27)) AS json
+SELECT sum(length(formatQueryFromJSON(materialize(json)))) > 0 FROM numbers(20000)
 SETTINGS max_execution_time = 0, max_block_size = 200000;
 
 --    The two-argument form takes a separate branch, so without a line of its own nothing would redden
---    if the check threw unconditionally there. Both arguments are small, so the stride is crossed by
---    row count rather than by row size.
-WITH parseQueryToJSON('SELECT 1') AS json
-SELECT sum(length(formatQueryFromJSON(materialize(json), materialize('SELECT 1')))) > 0 FROM numbers(100000)
-SETTINGS max_execution_time = 0, max_block_size = 200000;
+--    if the check threw unconditionally there.
+WITH parseQueryToJSON('SELECT 1 -- ' || repeat('x', 27)) AS json
+SELECT sum(length(formatQueryFromJSON(materialize(json), materialize('SELECT 1 -- ' || repeat('x', 27))))) > 0
+FROM numbers(20000) SETTINGS max_execution_time = 0, max_block_size = 200000;
 
 -- 10. The poll must read the EXECUTING query, not the one that built the function. `ALTER` rebuilds the
 --     partition key from its own query context and `adjustPartitionKey` hands that same object to later
 --     inserts, rebuilding only when the key contains `modulo`, hence the plain key here. Reading a
---     per-instance `QueryStatus` would fail this insert on the ALTER's long-expired 1 s limit.
+--     per-instance `QueryStatus` would fail this insert on the ALTER's expired limit, so the limit only
+--     has to be finite and elapse, not tight: a tight one can time the ALTER itself out on a loaded host.
+--     The insert only needs one stride crossing for the poll to fire, and padded rows reach it with few
+--     enough rows to keep the partition count low.
 DROP TABLE IF EXISTS t_04691_retained;
 CREATE TABLE t_04691_retained (q String, n UInt64)
 ENGINE = MergeTree PARTITION BY cityHash64(formatQuery(q)) ORDER BY n;
-ALTER TABLE t_04691_retained ADD COLUMN extra UInt8 DEFAULT 0 SETTINGS max_execution_time = 1;
-SELECT sleep(2) FORMAT Null SETTINGS max_execution_time = 0;
+ALTER TABLE t_04691_retained ADD COLUMN extra UInt8 DEFAULT 0 SETTINGS max_execution_time = 3;
+SELECT sleep(3), sleep(1) FORMAT Null SETTINGS max_execution_time = 0;
 INSERT INTO t_04691_retained (q, n)
-SELECT 'SELECT ' || toString(number) || repeat(' OR (y = 1)', 60), number FROM numbers(3000)
-SETTINGS max_execution_time = 0, max_partitions_per_insert_block = 0, max_block_size = 200000;
+SELECT 'SELECT ' || toString(number % 4) || ' -- ' || repeat('x', 700), number FROM numbers(200)
+SETTINGS max_execution_time = 0, max_block_size = 200000;
 SELECT count() FROM t_04691_retained SETTINGS max_execution_time = 0;
 DROP TABLE t_04691_retained;
 

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -1,5 +1,7 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, long
 -- no-fasttest: needs enough rows of moderate SQL text that an unpatched parse loop overshoots the limit.
+-- long: `fuzzQuery` holds one process-global mutex per row, so copies of this test run by the flaky
+-- check serialize against each other and its two `fuzzQuery` cases alone cost about 110 s of a run.
 
 -- The query-parsing functions parse one row at a time inside a single pipeline task. Cancellation is
 -- only polled between tasks, so before the fix a whole block ran to completion and the query outlived

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -162,15 +162,20 @@ FROM numbers(100) SETTINGS max_execution_time = 0, max_block_size = 200000;
 -- 10. The poll must read the EXECUTING query, not the one that built the function. `ALTER` rebuilds the
 --     partition key from its own query context and `adjustPartitionKey` hands that same object to later
 --     inserts, rebuilding only when the key contains `modulo`, hence the plain key here. Reading a
---     per-instance `QueryStatus` would fail this insert on the ALTER's expired limit, so the limit only
---     has to be finite and elapse, not tight: a tight one can time the ALTER itself out on a loaded host.
---     The insert only needs one stride crossing for the poll to fire, and padded rows reach it with few
---     enough rows to keep the partition count low.
+--     per-instance `QueryStatus` would fail this insert on the ALTER's expired limit, so the ALTER's
+--     limit has to be shorter than the wait below: with a limit longer than the wait, a stale timer has
+--     not expired by the time the insert runs and the case passes either way.
+--     `break` is what lets the limit be that short without the ALTER timing itself out: on expiry
+--     `CancellationChecker::cancelTask` calls `checkTimeLimit` instead of `cancelQuery(TIMEOUT)`, so
+--     `is_killed` is never set and the ALTER always completes, while the stopwatch a stale status would
+--     read keeps running. The insert only needs one stride crossing for the poll to fire, and padded
+--     rows reach it with few enough rows to keep the partition count low.
 DROP TABLE IF EXISTS t_04691_retained;
 CREATE TABLE t_04691_retained (q String, n UInt64)
 ENGINE = MergeTree PARTITION BY cityHash64(formatQuery(q)) ORDER BY n;
-ALTER TABLE t_04691_retained ADD COLUMN extra UInt8 DEFAULT 0 SETTINGS max_execution_time = 30;
-SELECT sleep(1), sleep(0.2) FORMAT Null SETTINGS max_execution_time = 0;
+ALTER TABLE t_04691_retained ADD COLUMN extra UInt8 DEFAULT 0
+SETTINGS max_execution_time = 0.5, timeout_overflow_mode = 'break';
+SELECT sleep(1) FORMAT Null SETTINGS max_execution_time = 0;
 INSERT INTO t_04691_retained (q, n)
 SELECT 'SELECT ' || toString(number % 4) || ' -- ' || repeat('x', 700), number FROM numbers(200)
 SETTINGS max_execution_time = 0, max_block_size = 200000;

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -7,12 +7,12 @@
 --
 -- Note the assertion is on the ELAPSED TIME, not on the error: an unpatched server also raises
 -- TIMEOUT_EXCEEDED, just tens of seconds late, so `-- { serverError TIMEOUT_EXCEEDED }` alone would
--- pass without the fix. Case 6 is the load-bearing one and checks how late each case stopped.
+-- pass without the fix. Case 7 is the load-bearing one and checks how late each case stopped.
 --
 -- Every timed query pins `max_block_size` and `max_threads`, which the test runner otherwise
 -- randomizes: a small block lets an unpatched server finish its uninterruptible unit soon enough to
--- stay under case 6's threshold, silently disarming it. The pins are per query so that they cannot
--- leak into case 6's own read. Each timed query carries the `04691_timed` marker that case 6 counts.
+-- stay under case 7's threshold, silently disarming it. The pins are per query so that they cannot
+-- leak into case 7's own read. Each timed query carries a `04691_` marker that case 7 counts.
 
 SET max_execution_time = 1;
 SET allow_fuzz_query_functions = 1;
@@ -61,11 +61,26 @@ WITH parseQueryToJSON('SELECT 1 WHERE x=0' || repeat(' OR (y = 1)', 40)) AS json
 SELECT sum(length(formatQueryFromJSON(materialize(json)))) /* 04691_timed */
 FROM numbers(100000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
--- 6. The real assertion: every case above stopped near its limit rather than running its block out.
+-- 6. `timeout_overflow_mode = 'break'` needs its own case. There `checkTimeLimit` returns false
+--    instead of throwing, and this fix turns that false into a hard stop, so the observable behaviour
+--    changes from "ran the block out, returned a result" to "stopped mid-block". The `throw`-mode
+--    cases above cannot exercise that return at all, and `timeout_overflow_mode` is not one of the
+--    settings the test runner randomizes, so nothing else would ever reach it. `04648` covers the
+--    identical decision for `geohashesInBox` the same way.
+--    A stopped aggregate emits no row rather than a partial sum, and this query succeeds in both
+--    directions, so the latency bound in case 7 is what discriminates: 69783 ms pre-fix, 1045 ms with
+--    it. The marker is separate because a successful query lands in `query_log` as `QueryFinish`.
+SELECT sum(length(formatQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_break */
+FROM numbers(200000) FORMAT Null
+SETTINGS max_block_size = 200000, max_threads = 1, timeout_overflow_mode = 'break';
+
+-- 7. The real assertion: every case above stopped near its limit rather than running its block out.
 --    Pre-fix they report 21000-90000 ms against a 1000 ms limit; with the fix they report ~1000 ms.
---    `count() = 9` keeps the assertion from going vacuous: countIf(...) = 0 over an empty result set is
---    trivially true, so a marker that stopped matching would silently disarm the whole test. The type
---    filter selects exactly the nine timed queries, all of which are expected to have raised.
+--    `count() = 10` keeps the assertion from going vacuous: countIf(...) = 0 over an empty result set is
+--    trivially true, so a marker that stopped matching would silently disarm the whole test.
+--    `type != 'QueryStart'` rather than `= 'ExceptionWhileProcessing'` because the break case above
+--    succeeds; `04648`'s duration check filters the same way. Both markers share the `04691_` prefix so
+--    one pattern counts all ten, and each query carries exactly one marker.
 --    max_execution_time = 0: the session limit above applies to the flush and to this unindexed
 --    query_log scan as well, and on a loaded sanitizer host either can exceed one second and time the
 --    oracle itself out. SYSTEM FLUSH LOGS takes no SETTINGS clause, hence the session-level SET.
@@ -74,20 +89,38 @@ FROM numbers(100000) FORMAT Null SETTINGS max_block_size = 200000, max_threads =
 SET max_execution_time = 0;
 SYSTEM FLUSH LOGS query_log;
 
-SELECT 'all bounded', count() = 9 AND countIf(query_duration_ms > 15000) = 0
+SELECT 'all bounded', count() = 10 AND countIf(query_duration_ms > 15000) = 0
 FROM system.query_log
 WHERE current_database = currentDatabase()
-  AND type = 'ExceptionWhileProcessing'
+  AND type != 'QueryStart'
   AND event_time > now() - INTERVAL 10 MINUTE
-  AND query LIKE '%04691\_timed%'
+  AND (query LIKE '%04691\_timed%' OR query LIKE '%04691\_break%')
 SETTINGS max_execution_time = 0, enable_parallel_replicas = 0;
 
--- 7. Results are unchanged when no limit is hit, including the OrNull NULL-on-parse-error contract.
+-- 8. Results are unchanged when no limit is hit, including the OrNull NULL-on-parse-error contract.
 SELECT formatQuery('select    a,b from  t') SETTINGS max_execution_time = 0;
 SELECT formatQuerySingleLine('select    a,b from  t') SETTINGS max_execution_time = 0;
 SELECT formatQueryOrNull('this is not a query') IS NULL SETTINGS max_execution_time = 0;
-SELECT length(parseQueryToJSON('SELECT 1')) > 0 SETTINGS max_execution_time = 0;
-SELECT length(highlightQuery('SELECT 1')) > 0 SETTINGS max_execution_time = 0;
-SELECT length(tokenizeQuery('SELECT 1')) > 0 SETTINGS max_execution_time = 0;
+
+-- 9. The liveness arm: a regression that made the check fire when it should not, or throw
+--    unconditionally, has to be caught somewhere, and everywhere else these functions appear
+--    TIMEOUT_EXCEEDED is the expected result. One call per polled row loop, no limit set.
+--    Each call has to actually REACH the check, and the check is throttled on accumulated input
+--    bytes, so a single short query never polls at all and would make this arm vacuous. These run
+--    enough rows in one block to cross the stride many times over, so a spurious throw shows up here.
+--    `fuzzQuery` is non-deterministic, so only the length is asserted.
+SELECT sum(length(formatQuery(materialize('SELECT 1')))) > 0 FROM numbers(100000)
+SETTINGS max_execution_time = 0, max_block_size = 200000;
+SELECT sum(length(parseQueryToJSON(materialize('SELECT 1')))) > 0 FROM numbers(100000)
+SETTINGS max_execution_time = 0, max_block_size = 200000;
+SELECT sum(length(highlightQuery(materialize('SELECT 1')))) > 0 FROM numbers(100000)
+SETTINGS max_execution_time = 0, max_block_size = 200000;
+SELECT sum(length(tokenizeQuery(materialize('SELECT 1')))) > 0 FROM numbers(100000)
+SETTINGS max_execution_time = 0, max_block_size = 200000;
+SELECT sum(length(fuzzQuery(materialize('SELECT 1')))) > 0 FROM numbers(100000)
+SETTINGS max_execution_time = 0, max_block_size = 200000;
+WITH parseQueryToJSON('SELECT 1') AS json
+SELECT sum(length(formatQueryFromJSON(materialize(json)))) > 0 FROM numbers(100000)
+SETTINGS max_execution_time = 0, max_block_size = 200000;
 
 SELECT 'ok';

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -1,0 +1,62 @@
+-- Tags: no-fasttest
+-- no-fasttest: needs enough rows of moderate SQL text that an unpatched parse loop overshoots the limit.
+
+-- `formatQuery` and friends parse one row at a time inside a single pipeline task. Cancellation is only
+-- polled between tasks, so before the fix a whole block ran to completion and the query outlived
+-- `max_execution_time` and `KILL QUERY` (measured: 23 s under a 1 s limit; 1247 s in CI under MSan).
+--
+-- Note the assertion is on the ELAPSED TIME, not on the error: an unpatched server also raises
+-- TIMEOUT_EXCEEDED, just tens of seconds late, so `-- { serverError TIMEOUT_EXCEEDED }` alone would
+-- pass without the fix. Each case below therefore reports whether it stopped anywhere near the limit.
+
+SET max_execution_time = 1;
+SET allow_fuzz_query_functions = 1;
+
+-- 1. formatQuery: many rows of moderate SQL text in one block.
+SELECT sum(length(formatQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40))))
+FROM numbers(200000) FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+
+-- 2. formatQueryOrNull must raise, not swallow the cancellation into NULLs. Its per-row `catch (...)`
+--    turns any exception into NULL and continues, so the check has to sit outside that handler.
+SELECT sum(length(formatQueryOrNull('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40))))
+FROM numbers(200000) FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+
+-- 3. The single-line variants share the same loop.
+SELECT sum(length(formatQuerySingleLine('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40))))
+FROM numbers(200000) FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+
+SELECT sum(length(formatQuerySingleLineOrNull('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40))))
+FROM numbers(200000) FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+
+-- 4. Siblings with the same per-row parse loop.
+SELECT sum(length(parseQueryToJSON('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40))))
+FROM numbers(200000) FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+
+SELECT sum(length(fuzzQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40))))
+FROM numbers(200000) FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+
+SELECT sum(length(formatQueryFromJSON(parseQueryToJSON('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))))
+FROM numbers(200000) FORMAT Null; -- { serverError TIMEOUT_EXCEEDED }
+
+-- 5. The real assertion: every case above stopped near its limit rather than running the block out.
+--    Pre-fix these report ~23000 ms against a 1000 ms limit; with the fix they report ~1000 ms.
+SYSTEM FLUSH LOGS query_log;
+
+-- enable_parallel_replicas = 0: the test runner can inject parallel replicas, which this local
+-- system-table read must not go through.
+SELECT 'all bounded', countIf(query_duration_ms > 15000) = 0
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type != 'QueryStart'
+  AND event_time > now() - INTERVAL 10 MINUTE
+  AND query LIKE '%OR (y = 1)%'
+  AND query LIKE '%FROM numbers(200000)%'
+SETTINGS enable_parallel_replicas = 0;
+
+-- 6. Results are unchanged when no limit is hit, including the OrNull NULL-on-parse-error contract.
+SELECT formatQuery('select    a,b from  t') SETTINGS max_execution_time = 0;
+SELECT formatQuerySingleLine('select    a,b from  t') SETTINGS max_execution_time = 0;
+SELECT formatQueryOrNull('this is not a query') IS NULL SETTINGS max_execution_time = 0;
+SELECT length(parseQueryToJSON('SELECT 1')) > 0 SETTINGS max_execution_time = 0;
+
+SELECT 'ok';

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -61,21 +61,6 @@ WITH parseQueryToJSON('SELECT 1 WHERE x=0' || repeat(' OR (y = 1)', 40)) AS json
 SELECT sum(length(formatQueryFromJSON(materialize(json)))) /* 04691_timed */
 FROM numbers(100000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
---    The two-argument form also parses the second argument per row, so its bytes have to count
---    toward the stride as well. A small JSON with a large original is the shape that overshoots when
---    only the JSON is counted: the JSON floor (339 bytes for the smallest valid AST) admits 193 rows
---    per stride, each lexing the whole original. `max_query_size` is raised because at its default
---    the original is capped at 262144 bytes, which bounds the overshoot to ~1.7 s -- under case 7's
---    threshold, so the default-settings form cannot discriminate. This case therefore carries its own
---    latency assertion below rather than case 7's marker, since it needs those raised settings. Its
---    marker spells no other case's marker: a comment is part of the logged query text, so mentioning
---    one here would make this query match that case's own count and inflate it.
-WITH parseQueryToJSON('SELECT 1') AS json
-SELECT sum(length(formatQueryFromJSON(materialize(json), materialize('SELECT 1 WHERE x=0' || repeat(' OR (y = 1)', 110000))))) /* 04691_twoarg */
-FROM numbers(200) FORMAT Null
-SETTINGS max_block_size = 200000, max_threads = 1, max_query_size = 2000000,
-         max_ast_elements = 100000000, max_parser_depth = 1000000; -- { serverError TIMEOUT_EXCEEDED }
-
 -- 6. `timeout_overflow_mode = 'break'` needs its own case. There `checkTimeLimit` returns false
 --    instead of throwing, and this fix turns that false into a hard stop, so the observable behaviour
 --    changes from "ran the block out, returned a result" to "stopped mid-block". The `throw`-mode
@@ -110,17 +95,6 @@ WHERE current_database = currentDatabase()
   AND type != 'QueryStart'
   AND event_time > now() - INTERVAL 10 MINUTE
   AND (query LIKE '%04691\_timed%' OR query LIKE '%04691\_break%')
-SETTINGS max_execution_time = 0, enable_parallel_replicas = 0;
-
---    The two-argument case gets its own bound because it needs a raised `max_query_size`, which the
---    cases above deliberately leave at the default. Measured: 4.7-5.3 s before counting the second
---    argument's bytes, 1.08-1.13 s after, against a 1 s limit. 3000 ms sits clear of both.
-SELECT 'two-argument bounded', count() = 1 AND countIf(query_duration_ms > 3000) = 0
-FROM system.query_log
-WHERE current_database = currentDatabase()
-  AND type != 'QueryStart'
-  AND event_time > now() - INTERVAL 10 MINUTE
-  AND query LIKE '%04691\_twoarg%'
 SETTINGS max_execution_time = 0, enable_parallel_replicas = 0;
 
 -- 8. Results are unchanged when no limit is hit, including the OrNull NULL-on-parse-error contract.

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -24,42 +24,51 @@
 SET max_execution_time = 3;
 SET allow_fuzz_query_functions = 1;
 
+-- Every row below carries a long trailing comment. The poll is throttled on accumulated input BYTES,
+-- while a row's parse cost is set by how many AST nodes it has, so the longest a cancellation can go
+-- unobserved is one stride of parsing: 64 KiB divided by the row size, times the per-row cost. Rows of
+-- 40 `OR` clauses in 458 bytes are the worst case for that ratio, and on MSan one stride cost 29 s
+-- against this 3 s limit. Comment bytes count toward the stride but add no AST, so padding a row to
+-- 2462 bytes cuts the wait more than fivefold for no extra parse work. The row counts are halved to
+-- hold peak memory where it was, and both have to stay large enough that one unpolled block still
+-- exceeds case 7's threshold by a wide margin.
+
 -- 1. formatQuery: many rows of moderate SQL text in one block.
-SELECT sum(length(formatQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
-FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
+SELECT sum(length(formatQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40) || ' -- ' || repeat('c', 2000)))) /* 04691_timed */
+FROM numbers(100000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
 -- 2. formatQueryOrNull must raise, not swallow the cancellation into NULLs. Its per-row `catch (...)`
 --    turns any exception into NULL and continues, so the check has to sit outside that handler.
-SELECT sum(length(formatQueryOrNull('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
-FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
+SELECT sum(length(formatQueryOrNull('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40) || ' -- ' || repeat('c', 2000)))) /* 04691_timed */
+FROM numbers(100000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
 -- 3. The single-line variants share the same loop.
-SELECT sum(length(formatQuerySingleLine('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
-FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
+SELECT sum(length(formatQuerySingleLine('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40) || ' -- ' || repeat('c', 2000)))) /* 04691_timed */
+FROM numbers(100000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
-SELECT sum(length(formatQuerySingleLineOrNull('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
-FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
+SELECT sum(length(formatQuerySingleLineOrNull('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40) || ' -- ' || repeat('c', 2000)))) /* 04691_timed */
+FROM numbers(100000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
 -- 4. Siblings with the same per-row parse loop.
-SELECT sum(length(parseQueryToJSON('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
-FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
+SELECT sum(length(parseQueryToJSON('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40) || ' -- ' || repeat('c', 2000)))) /* 04691_timed */
+FROM numbers(100000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
 --    `highlightQuery` and `tokenizeQuery` share one row loop in FunctionQueryTokenization.
 --    `highlightQuery` runs a full parse per row and covers that loop. `tokenizeQuery` is lexer-only and
 --    its cost is dominated by the size of the token array it builds, so it exhausts memory well before
 --    it overshoots a time limit; it gets no case of its own rather than one whose oracle cannot redden.
-SELECT sum(length(highlightQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
+SELECT sum(length(highlightQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40) || ' -- ' || repeat('c', 2000)))) /* 04691_timed */
 FROM numbers(60000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
 -- 5. `fuzzQuery` has one row loop per argument shape and both need the poll.
 --    Non-constant argument, so this one takes the ColumnString loop.
-SELECT sum(length(fuzzQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
-FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
+SELECT sum(length(fuzzQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40) || ' -- ' || repeat('c', 2000)))) /* 04691_timed */
+FROM numbers(100000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
 --    Constant argument: `fuzzQuery` opts out of the default constant handling, so this reaches the
 --    separate ColumnConst loop. It is not folded away because the function is non-deterministic.
-SELECT sum(length(fuzzQuery('SELECT 1 WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_timed */
-FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
+SELECT sum(length(fuzzQuery('SELECT 1 WHERE x=0' || repeat(' OR (y = 1)', 40) || ' -- ' || repeat('c', 2000)))) /* 04691_timed */
+FROM numbers(100000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1; -- { serverError TIMEOUT_EXCEEDED }
 
 --    `formatQueryFromJSON` takes JSON from a scalar computed once and then materialized. Nesting the
 --    `parseQueryToJSON` call inside the timed expression instead would let the inner function's own
@@ -75,17 +84,17 @@ FROM numbers(100000) FORMAT Null SETTINGS max_block_size = 200000, max_threads =
 --    settings the test runner randomizes, so nothing else would ever reach it. `04648` covers the
 --    identical decision for `geohashesInBox` the same way.
 --    A stopped aggregate emits no row rather than a partial sum, and this query succeeds in both
---    directions, so the latency bound in case 7 is what discriminates: 69783 ms pre-fix, 1045 ms with
---    it. The marker is separate because a successful query lands in `query_log` as `QueryFinish`.
-SELECT sum(length(formatQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40)))) /* 04691_break */
-FROM numbers(200000) FORMAT Null
+--    directions, so the latency bound in case 7 is what discriminates: 34413 ms unpolled, 3005 ms with
+--    the poll. The marker is separate because a successful query lands in `query_log` as `QueryFinish`.
+SELECT sum(length(formatQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40) || ' -- ' || repeat('c', 2000)))) /* 04691_break */
+FROM numbers(100000) FORMAT Null
 SETTINGS max_block_size = 200000, max_threads = 1, timeout_overflow_mode = 'break';
 
 -- 7. The real assertion: every case above stopped near its limit rather than running its block out.
 --    The bound is on CPU time, not on `query_duration_ms`: wall clock also absorbs scheduling delay,
 --    and this test runs concurrently with copies of itself, so a wall-clock budget wide enough for a
---    starved host would have to exceed the pre-fix cost it exists to detect. Pre-fix a single one of
---    these statements burns about 70 s of CPU; with the fix it stops within a stride of its limit.
+--    starved host would have to exceed the pre-fix cost it exists to detect. Unpolled a single one of
+--    these statements burns about 35 s of CPU; with the poll it stops within a stride of its limit.
 --    `count() = 10` keeps the assertion from going vacuous: countIf(...) = 0 over an empty result set is
 --    trivially true, so a marker that stopped matching would silently disarm the whole test.
 --    `type != 'QueryStart'` rather than `= 'ExceptionWhileProcessing'` because the break case above
@@ -160,7 +169,7 @@ FROM numbers(100) SETTINGS max_execution_time = 0, max_block_size = 200000;
 DROP TABLE IF EXISTS t_04691_retained;
 CREATE TABLE t_04691_retained (q String, n UInt64)
 ENGINE = MergeTree PARTITION BY cityHash64(formatQuery(q)) ORDER BY n;
-ALTER TABLE t_04691_retained ADD COLUMN extra UInt8 DEFAULT 0 SETTINGS max_execution_time = 1;
+ALTER TABLE t_04691_retained ADD COLUMN extra UInt8 DEFAULT 0 SETTINGS max_execution_time = 30;
 SELECT sleep(1), sleep(0.2) FORMAT Null SETTINGS max_execution_time = 0;
 INSERT INTO t_04691_retained (q, n)
 SELECT 'SELECT ' || toString(number % 4) || ' -- ' || repeat('x', 700), number FROM numbers(200)

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -123,4 +123,11 @@ WITH parseQueryToJSON('SELECT 1') AS json
 SELECT sum(length(formatQueryFromJSON(materialize(json)))) > 0 FROM numbers(100000)
 SETTINGS max_execution_time = 0, max_block_size = 200000;
 
+--    The two-argument form takes a separate branch, so without a line of its own nothing would redden
+--    if the check threw unconditionally there. Both arguments are small, so the stride is crossed by
+--    row count rather than by row size.
+WITH parseQueryToJSON('SELECT 1') AS json
+SELECT sum(length(formatQueryFromJSON(materialize(json), materialize('SELECT 1')))) > 0 FROM numbers(100000)
+SETTINGS max_execution_time = 0, max_block_size = 200000;
+
 SELECT 'ok';

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -1,7 +1,5 @@
--- Tags: no-fasttest, long
+-- Tags: no-fasttest
 -- no-fasttest: needs enough rows of moderate SQL text that an unpatched parse loop overshoots the limit.
--- long: ten statements each run until they hit the limit set below, so the test costs about ten times
--- that limit, and the limit has to clear a sanitizer build's query-planning cost (see below).
 
 -- The query-parsing functions parse one row at a time inside a single pipeline task. Cancellation is
 -- only polled between tasks, so before the fix a whole block ran to completion and the query outlived

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -114,28 +114,31 @@ SELECT formatQueryOrNull('this is not a query') IS NULL SETTINGS max_execution_t
 --    TIMEOUT_EXCEEDED is the expected result. One call per polled row loop, no limit set.
 --    Each call has to actually REACH the check, and the check is throttled on accumulated input
 --    bytes, so a single short query never polls at all and would make this arm vacuous. The stride
---    is charged in raw bytes, so a padded row buys the same crossings with far fewer rows than a
---    bare 'SELECT 1' would: 20000 rows of 39 bytes cross the 64 KiB stride 12 times over.
+--    is charged in bytes while the parse costs per row, so a few long rows reach it far more cheaply
+--    than many short ones: 100 rows of 7809 bytes cross the 64 KiB stride 11 times over.
+--    The padding sits in a string literal rather than in a trailing comment because a comment is not
+--    part of the AST: `parseQueryToJSON` emits the same 339 bytes however long the comment is, so the
+--    two `formatQueryFromJSON` calls below, whose rows are that JSON, would never cross the stride.
 --    `fuzzQuery` is non-deterministic, so only the length is asserted.
-SELECT sum(length(formatQuery(materialize('SELECT 1 -- ' || repeat('x', 27))))) > 0 FROM numbers(20000)
+SELECT sum(length(formatQuery(materialize('SELECT ''' || repeat('x', 7800) || '''')))) > 0 FROM numbers(100)
 SETTINGS max_execution_time = 0, max_block_size = 200000;
-SELECT sum(length(parseQueryToJSON(materialize('SELECT 1 -- ' || repeat('x', 27))))) > 0 FROM numbers(20000)
+SELECT sum(length(parseQueryToJSON(materialize('SELECT ''' || repeat('x', 7800) || '''')))) > 0 FROM numbers(100)
 SETTINGS max_execution_time = 0, max_block_size = 200000;
-SELECT sum(length(highlightQuery(materialize('SELECT 1 -- ' || repeat('x', 27))))) > 0 FROM numbers(20000)
+SELECT sum(length(highlightQuery(materialize('SELECT ''' || repeat('x', 7800) || '''')))) > 0 FROM numbers(100)
 SETTINGS max_execution_time = 0, max_block_size = 200000;
-SELECT sum(length(tokenizeQuery(materialize('SELECT 1 -- ' || repeat('x', 27))))) > 0 FROM numbers(20000)
+SELECT sum(length(tokenizeQuery(materialize('SELECT ''' || repeat('x', 7800) || '''')))) > 0 FROM numbers(100)
 SETTINGS max_execution_time = 0, max_block_size = 200000;
-SELECT sum(length(fuzzQuery(materialize('SELECT 1 -- ' || repeat('x', 27))))) > 0 FROM numbers(20000)
+SELECT sum(length(fuzzQuery(materialize('SELECT ''' || repeat('x', 7800) || '''')))) > 0 FROM numbers(100)
 SETTINGS max_execution_time = 0, max_block_size = 200000;
-WITH parseQueryToJSON('SELECT 1 -- ' || repeat('x', 27)) AS json
-SELECT sum(length(formatQueryFromJSON(materialize(json)))) > 0 FROM numbers(20000)
+WITH parseQueryToJSON('SELECT ''' || repeat('x', 7800) || '''') AS json
+SELECT sum(length(formatQueryFromJSON(materialize(json)))) > 0 FROM numbers(100)
 SETTINGS max_execution_time = 0, max_block_size = 200000;
 
 --    The two-argument form takes a separate branch, so without a line of its own nothing would redden
 --    if the check threw unconditionally there.
-WITH parseQueryToJSON('SELECT 1 -- ' || repeat('x', 27)) AS json
-SELECT sum(length(formatQueryFromJSON(materialize(json), materialize('SELECT 1 -- ' || repeat('x', 27))))) > 0
-FROM numbers(20000) SETTINGS max_execution_time = 0, max_block_size = 200000;
+WITH parseQueryToJSON('SELECT ''' || repeat('x', 7800) || '''') AS json
+SELECT sum(length(formatQueryFromJSON(materialize(json), materialize('SELECT ''' || repeat('x', 7800) || '''')))) > 0
+FROM numbers(100) SETTINGS max_execution_time = 0, max_block_size = 200000;
 
 -- 10. The poll must read the EXECUTING query, not the one that built the function. `ALTER` rebuilds the
 --     partition key from its own query context and `adjustPartitionKey` hands that same object to later

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -1,5 +1,7 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, long
 -- no-fasttest: needs enough rows of moderate SQL text that an unpatched parse loop overshoots the limit.
+-- long: ten statements each run until they hit the limit set below, so the test costs about ten times
+-- that limit, and the limit has to clear a sanitizer build's query-planning cost (see below).
 
 -- The query-parsing functions parse one row at a time inside a single pipeline task. Cancellation is
 -- only polled between tasks, so before the fix a whole block ran to completion and the query outlived
@@ -14,9 +16,12 @@
 -- stay under case 7's threshold, silently disarming it. The pins are per query so that they cannot
 -- leak into case 7's own read. Each timed query carries a `04691_` marker that case 7 counts.
 
--- The limit is what each timed query costs: they are limit-bound, not fixture-bound, so ten of them
--- cost ten times this. It has to stay well above the poll's own overshoot, one 64 KiB stride.
-SET max_execution_time = 0.3;
+-- `max_execution_time` runs from query start, so it also has to cover parsing, analysis, planning and
+-- pipeline construction. On a sanitizer build that prelude alone reached 276 ms of a 300 ms budget, and
+-- the query then timed out before reading a row, leaving the row loop below jointly unexercised. The
+-- limit therefore has to exceed the prelude by enough that what remains still reaches the loop; 3 s
+-- sits between the observed 1.6 s worst-case prelude and the tens of seconds an unpolled block costs.
+SET max_execution_time = 3;
 SET allow_fuzz_query_functions = 1;
 
 -- 1. formatQuery: many rows of moderate SQL text in one block.
@@ -79,8 +84,8 @@ SETTINGS max_block_size = 200000, max_threads = 1, timeout_overflow_mode = 'brea
 -- 7. The real assertion: every case above stopped near its limit rather than running its block out.
 --    The bound is on CPU time, not on `query_duration_ms`: wall clock also absorbs scheduling delay,
 --    and this test runs concurrently with copies of itself, so a wall-clock budget wide enough for a
---    starved host would have to exceed the pre-fix cost it exists to detect. Pre-fix these statements
---    burn tens of seconds of CPU against a 300 ms limit; with the fix, one stride of parsing more.
+--    starved host would have to exceed the pre-fix cost it exists to detect. Pre-fix a single one of
+--    these statements burns about 70 s of CPU; with the fix it stops within a stride of its limit.
 --    `count() = 10` keeps the assertion from going vacuous: countIf(...) = 0 over an empty result set is
 --    trivially true, so a marker that stopped matching would silently disarm the whole test.
 --    `type != 'QueryStart'` rather than `= 'ExceptionWhileProcessing'` because the break case above
@@ -94,8 +99,13 @@ SETTINGS max_block_size = 200000, max_threads = 1, timeout_overflow_mode = 'brea
 SET max_execution_time = 0;
 SYSTEM FLUSH LOGS query_log;
 
+--    `countIf(read_rows = 0) = 0` is what keeps the CPU bound from passing vacuously: a query that
+--    exhausted the limit during planning never reached the row loop, so it trivially satisfies a CPU
+--    bound while asserting nothing about cancellation. Observed on a sanitizer build, where 16 of 19
+--    runs read no rows at all and the whole test still reported success.
 SELECT 'all bounded',
        count() = 10
+   AND countIf(read_rows = 0) = 0
    AND countIf(ProfileEvents['UserTimeMicroseconds'] + ProfileEvents['SystemTimeMicroseconds'] > 15000000) = 0
 FROM system.query_log
 WHERE current_database = currentDatabase()

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit.sql
@@ -75,7 +75,10 @@ FROM numbers(200000) FORMAT Null
 SETTINGS max_block_size = 200000, max_threads = 1, timeout_overflow_mode = 'break';
 
 -- 7. The real assertion: every case above stopped near its limit rather than running its block out.
---    Pre-fix they report 21000-90000 ms against a 1000 ms limit; with the fix they report ~1000 ms.
+--    The bound is on CPU time, not on `query_duration_ms`: wall clock also absorbs scheduling delay,
+--    and this test runs concurrently with copies of itself, so a wall-clock budget wide enough for a
+--    starved host would have to exceed the pre-fix cost it exists to detect. Pre-fix these statements
+--    burn tens of seconds of CPU against a 1000 ms limit; with the fix, one stride of parsing more.
 --    `count() = 10` keeps the assertion from going vacuous: countIf(...) = 0 over an empty result set is
 --    trivially true, so a marker that stopped matching would silently disarm the whole test.
 --    `type != 'QueryStart'` rather than `= 'ExceptionWhileProcessing'` because the break case above
@@ -89,7 +92,9 @@ SETTINGS max_block_size = 200000, max_threads = 1, timeout_overflow_mode = 'brea
 SET max_execution_time = 0;
 SYSTEM FLUSH LOGS query_log;
 
-SELECT 'all bounded', count() = 10 AND countIf(query_duration_ms > 15000) = 0
+SELECT 'all bounded',
+       count() = 10
+   AND countIf(ProfileEvents['UserTimeMicroseconds'] + ProfileEvents['SystemTimeMicroseconds'] > 15000000) = 0
 FROM system.query_log
 WHERE current_database = currentDatabase()
   AND type != 'QueryStart'

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit_kill.reference
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit_kill.reference
@@ -1,0 +1,1 @@
+killed promptly

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit_kill.sh
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit_kill.sh
@@ -17,10 +17,12 @@ QUERY_ID="04691_kill_${CLICKHOUSE_DATABASE}"
 
 # No max_execution_time, so only the KILL can stop this. max_block_size / max_threads are pinned because
 # the test runner randomizes both, and a small block would let an unpatched server finish its
-# uninterruptible unit quickly enough to stay under the bound asserted below.
+# uninterruptible unit quickly enough to stay under the bound asserted below. The rows carry a trailing
+# comment for the reason the `.sql` companion gives: the poll is throttled on input bytes while a row's
+# parse cost is per AST node, so the KILL went unobserved for one stride, 19 s on MSan when unpadded.
 $CLICKHOUSE_CLIENT --query_id "$QUERY_ID" --max_execution_time 0 -q "
-    SELECT sum(length(formatQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40))))
-    FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1
+    SELECT sum(length(formatQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40) || ' -- ' || repeat('c', 2000))))
+    FROM numbers(100000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1
 " &>/dev/null &
 
 # Readiness waits for the query to have been running rather than merely being visible: `ProcessList`

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit_kill.sh
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit_kill.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: needs enough rows of moderate SQL text that an unpatched parse loop outlives the KILL.
+
+# Companion to 04691_format_query_respects_time_limit.sql, which covers the `max_execution_time` half of
+# the contract. KILL takes a different path (`is_killed` plus `throwProperExceptionIfNeeded`) than the
+# timeout (`ExecutionSpeedLimits::checkTimeLimit`), so timeout coverage does not cover it: before the fix
+# a `KILL QUERY ... SYNC` on one of these queries waited about 21 s for the block to run out.
+
+set -e
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+QUERY_ID="04691_kill_${CLICKHOUSE_DATABASE}"
+
+# No max_execution_time, so only the KILL can stop this. max_block_size / max_threads are pinned because
+# the test runner randomizes both, and a small block would let an unpatched server finish its
+# uninterruptible unit quickly enough to stay under the bound asserted below.
+$CLICKHOUSE_CLIENT --query_id "$QUERY_ID" --max_execution_time 0 -q "
+    SELECT sum(length(formatQuery('SELECT ' || toString(number) || ' WHERE x=0' || repeat(' OR (y = 1)', 40))))
+    FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1
+" &>/dev/null &
+
+# Wait for the query to reach the process list, bounded by wall clock rather than an iteration count.
+running=0
+deadline=$((SECONDS + 30))
+while [ "$SECONDS" -lt "$deadline" ]; do
+    if [ "$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.processes WHERE query_id = '$QUERY_ID'")" == "1" ]; then
+        running=1
+        break
+    fi
+    sleep 0.2
+done
+
+# Without this the test could pass blind: a KILL that matches nothing is a silent no-op that returns
+# immediately, so the latency bound below would report success having killed no query at all.
+if [ "$running" != "1" ]; then
+    echo "query never reached system.processes"
+    wait || true
+    exit 0
+fi
+
+started=$SECONDS
+killed=$($CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '$QUERY_ID' SYNC" 2>/dev/null | wc -l)
+elapsed=$((SECONDS - started))
+
+# 15 s matches the .sql test's threshold: about 21 s before the fix, about 0 s after it. The row count
+# guards the same way as the wait above: KILL must report having acted on exactly one query.
+if [ "$killed" != "1" ]; then
+    echo "KILL reported $killed killed queries, expected 1"
+elif [ "$elapsed" -lt 15 ]; then
+    echo "killed promptly"
+else
+    echo "KILL took ${elapsed}s, expected under 15s"
+fi
+
+# The killed query's client exits non-zero, which is the expected outcome here.
+wait || true

--- a/tests/queries/0_stateless/04691_format_query_respects_time_limit_kill.sh
+++ b/tests/queries/0_stateless/04691_format_query_respects_time_limit_kill.sh
@@ -23,11 +23,15 @@ $CLICKHOUSE_CLIENT --query_id "$QUERY_ID" --max_execution_time 0 -q "
     FROM numbers(200000) FORMAT Null SETTINGS max_block_size = 200000, max_threads = 1
 " &>/dev/null &
 
-# Wait for the query to reach the process list, bounded by wall clock rather than an iteration count.
+# Readiness waits for the query to have been running rather than merely being visible: `ProcessList`
+# makes it visible before the executor is attached, and `addPipelineExecutor` raises a pending
+# cancellation itself, so a kill winning that race would return promptly even unfixed. `max(elapsed)`
+# over an empty set is 0, so this is false both while the query is absent and while it is only
+# pending. Bounded by wall clock rather than an iteration count.
 running=0
-deadline=$((SECONDS + 30))
+deadline=$((SECONDS + 60))
 while [ "$SECONDS" -lt "$deadline" ]; do
-    if [ "$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.processes WHERE query_id = '$QUERY_ID'")" == "1" ]; then
+    if [ "$($CLICKHOUSE_CLIENT -q "SELECT max(elapsed) > 1 FROM system.processes WHERE query_id = '$QUERY_ID'")" == "1" ]; then
         running=1
         break
     fi
@@ -37,7 +41,7 @@ done
 # Without this the test could pass blind: a KILL that matches nothing is a silent no-op that returns
 # immediately, so the latency bound below would report success having killed no query at all.
 if [ "$running" != "1" ]; then
-    echo "query never reached system.processes"
+    echo "query never reached the row loop"
     wait || true
     exit 0
 fi


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/107125
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `max_execution_time` and `KILL QUERY` being ignored by `formatQuery`, `formatQueryOrNull`, `formatQuerySingleLine`, `formatQuerySingleLineOrNull`, `formatQueryFromJSON`, `parseQueryToJSON`, `fuzzQuery`, `highlightQuery` and `tokenizeQuery`. These functions parse one row at a time inside a single pipeline task, and cancellation was only checked between tasks, so a query ran far past its limit.

### Description

Requested in https://github.com/ClickHouse/ClickHouse/pull/107125#issuecomment-5150937807. Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107125&sha=c2d8b026702b6eed289c8a6d56d6532d2a7d4105&name_0=PR&name_1=Stress%20test%20%28arm_msan%29

**What breaks.** `PipelineExecutor::cancel` only sets flags, so cancellation is observed between pipeline tasks. These functions parse per row in one `executeImpl` and never obtained a `QueryStatus`, making a block one uninterruptible unit. On a debug build, 200000 rows of moderate SQL with `max_execution_time = 1` stopped after 70 s instead of 1 s. The AST fuzzer reaches this at scale with a 30 s deadline per task.

**The change.** Call `checkTimeLimit` inside each per-row loop, following `FunctionBaseXXConversion`, fixed for the same bug class. The `QueryStatus` is resolved per `executeImpl` call from `CurrentThread` rather than stored on the function: an `IFunction` is retained in table metadata, `ALTER` rebuilds the partition key from its own query context, and later inserts reuse that object, so a stored status failed them on the ALTER's expired limit. In `formatQuery` the check sits outside the existing `try`/`catch`: for `ErrorHandling::Null` that handler turns any exception into a NULL, so checking inside would give wrong results.

**Performance.** A poll costs a `clock_gettime` plus a `cancel_mutex` acquisition, so it is throttled on 64 KiB of accumulated input, as `geohashesInBox` and `arrayFold` do. Worst case is `tokenizeQuery` over short inputs: unthrottled polling was 5.95x slower, the shipped throttle 1.12x.

**Validation.** New tests `04691_format_query_respects_time_limit` and its `_kill` companion assert elapsed time, not the error code: an unpatched server also raises `TIMEOUT_EXCEEDED`, just tens of seconds late. `timeout_overflow_mode = 'break'`, where `checkTimeLimit` returns false instead of throwing, gets its own case. Both fail unpatched and pass fixed with only the binary differing, the timed case reporting 71142 ms against a 1 s limit before and 1016 ms after. A case for the retained-metadata path above fails the same way on a stored status. Fifty randomized runs at `-j 1`: 100/100.
