### PR TITLE
Add `unicode_word` alias for `asciiCJK` tokenizer

### DIFF
--- a/src/Interpreters/TokenizerFactory.cpp
+++ b/src/Interpreters/TokenizerFactory.cpp
@@ -284,6 +284,7 @@ static void registerTokenizers(TokenizerFactory & factory)
 
     factory.registerTokenizer(AsciiCJKTokenizer::getName(), ITokenizer::Type::AsciiCJK, ascii_cjk_creator);
     factory.registerTokenizer("unicodeWord", ITokenizer::Type::AsciiCJK, ascii_cjk_creator);
+    factory.registerTokenizer("unicode_word", ITokenizer::Type::AsciiCJK, ascii_cjk_creator);
 
 #if USE_MECAB
     auto japanese_creator = [](const FieldVector & args) -> std::unique_ptr<ITokenizer>

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -360,9 +360,6 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       `MergeTreeBackgroundExecutor` line of the replicated case in a single entry.
 # `NO_SUCH_INTERSERVER_IO_ENDPOINT` is expected during upgrades because replicated tables try to fetch parts
 # from replicas that are being restarted and whose interserver endpoints are temporarily unavailable.
-# `Unknown tokenizer: 'unicode_word'` appears because the `unicode_word` tokenizer was renamed to `asciiCJK`
-#       (with `unicodeWord` as a transitional alias). Tables from old versions using `unicode_word` trigger this
-#       on attach. Narrowed to the exact legacy name so genuinely unsupported tokenizer names are not masked.
 # `Azure::Storage::StorageException.*Not found address of host` is a transient Azure blob DNS resolution failure
 #       for `openbucketforpublicci.blob.core.windows.net`. Filtered via regex in the secondary pipe below to match
 #       both the Azure SDK exception type AND the DNS error together, so non-Azure DNS errors are not masked.
@@ -536,7 +533,6 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Cannot parse projection test_projection" \
            -e "Key expressions cannot contain subqueries" \
            -e "Expression must be deterministic but it contains non-deterministic part" \
-           -e "Unknown tokenizer: 'unicode_word'" \
            -e "This engine is deprecated and is not supported in transactions" \
            -e "Prevent converting Nullable type to non-Nullable type inside mutation" \
            -e "e.what() = failed to parse response body" \

--- a/tests/queries/0_stateless/02346_system_tokenizers.reference
+++ b/tests/queries/0_stateless/02346_system_tokenizers.reference
@@ -8,3 +8,4 @@ splitByNonAlpha
 splitByString
 tokenbf_v1
 unicodeWord
+unicode_word

--- a/tests/queries/0_stateless/04038_ascii_cjk_tokenizer.reference
+++ b/tests/queries/0_stateless/04038_ascii_cjk_tokenizer.reference
@@ -70,8 +70,10 @@ default	tab	1	1	1
 explain estimate select * from tab where str like '%错误503需要%';
 default	tab	0	0	0
 drop table tab;
--- backward compatibility: unicodeWord alias
+-- Aliases
 select tokens('taichi张三丰in the house', 'unicodeWord');
+['taichi','张','三','丰','in','the','house']
+select tokens('taichi张三丰in the house', 'unicode_word');
 ['taichi','张','三','丰','in','the','house']
 drop table if exists tab2;
 create table tab2 (key UInt64, str String, index text_idx(str) type text(tokenizer = unicodeWord)) engine MergeTree order by key;

--- a/tests/queries/0_stateless/04038_ascii_cjk_tokenizer.sql
+++ b/tests/queries/0_stateless/04038_ascii_cjk_tokenizer.sql
@@ -54,8 +54,9 @@ explain estimate select * from tab where str like '%错误503需要%';
 
 drop table tab;
 
--- backward compatibility: unicodeWord alias
+-- Aliases
 select tokens('taichi张三丰in the house', 'unicodeWord');
+select tokens('taichi张三丰in the house', 'unicode_word');
 
 drop table if exists tab2;
 create table tab2 (key UInt64, str String, index text_idx(str) type text(tokenizer = unicodeWord)) engine MergeTree order by key;


### PR DESCRIPTION
Closes https://github.com/ClickHouse/ClickHouse/issues/112711

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix an incompatibility that text indexes created in ClickHouse 26.3 with `unicode_word` tokenizer cannot be loaded in later versions