### PR TITLE
Cache resolved part metadata in `MergeTreeBlockSizePredictor`

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
@@ -21,9 +21,6 @@
 #include <Interpreters/ExpressionActions.h>
 
 #include <algorithm>
-#include <unordered_set>
-
-
 namespace DB
 {
 
@@ -241,22 +238,47 @@ NameSet injectRequiredColumns(
 }
 
 MergeTreeBlockSizePredictor::MergeTreeBlockSizePredictor(
-    const DataPartPtr & data_part_, const Names & columns, const Block & sample_block, bool allow_subcolumns_sizes_calculation_)
-    : data_part(data_part_), allow_subcolumns_sizes_calculation(allow_subcolumns_sizes_calculation_)
+    const DataPartPtr & data_part, const Names & columns, bool allow_subcolumns_sizes_calculation)
 {
     number_of_rows_in_part = data_part->rows_count;
+
+    auto resolved_part_columns = std::make_shared<PartColumnsInfo>();
+    resolved_part_columns->reserve(columns.size());
+
+    Block sample_block;
+    for (const auto & column_name : columns)
+    {
+        if (resolved_part_columns->contains(column_name))
+            continue;
+
+        PartColumnInfo info;
+        if (auto column_from_part = data_part->tryGetColumn(column_name))
+        {
+            info.exists_in_part = true;
+            info.is_subcolumn = column_from_part->isSubcolumn();
+            info.name_in_storage = column_from_part->getNameInStorage();
+
+            auto column = column_from_part->type->createColumn();
+            if (info.is_subcolumn && allow_subcolumns_sizes_calculation)
+                info.column_size = data_part->getSubcolumnSize(column_name);
+            else
+                info.column_size = data_part->getColumnSize(info.name_in_storage);
+
+            sample_block.insert(ColumnWithTypeAndName(std::move(column), column_from_part->type, column_name));
+        }
+
+        resolved_part_columns->emplace(column_name, std::move(info));
+    }
+
+    part_columns_info = std::move(resolved_part_columns);
     /// Initialize with sample block until update won't called.
-    initialize(sample_block, {}, columns);
+    initialize(sample_block, {});
 }
 
-void MergeTreeBlockSizePredictor::initialize(const Block & sample_block, const Columns & columns, const Names & names, bool from_update)
+void MergeTreeBlockSizePredictor::initialize(const Block & sample_block, const Columns & columns, bool from_update)
 {
     fixed_columns_bytes_per_row = 0;
     dynamic_columns_infos.clear();
-
-    std::unordered_set<String> names_set;
-    if (!from_update)
-        names_set.insert(names.begin(), names.end());
 
     size_t num_columns = sample_block.columns();
     for (size_t pos = 0; pos < num_columns; ++pos)
@@ -265,15 +287,15 @@ void MergeTreeBlockSizePredictor::initialize(const Block & sample_block, const C
         const auto & column_name = column_with_type_and_name.name;
         const auto & column_data = from_update ? columns[pos] : column_with_type_and_name.column;
 
-        if (!from_update && !names_set.contains(column_name))
-            continue;
-
         /// At least PREWHERE filter column might be const.
         if (typeid_cast<const ColumnConst *>(column_data.get()))
             continue;
 
-        auto column_from_part = data_part->tryGetColumn(column_name);
-        if ((!column_from_part || !column_from_part->isSubcolumn()) && column_data->valuesHaveFixedSize())
+        const auto part_column_it = part_columns_info->find(column_name);
+        /// The read pipeline can add expression result columns which were not among the
+        /// physical columns used to construct the predictor. They cannot exist in the part.
+        const PartColumnInfo * part_column = part_column_it == part_columns_info->end() ? nullptr : &part_column_it->second;
+        if ((!part_column || !part_column->exists_in_part || !part_column->is_subcolumn) && column_data->valuesHaveFixedSize())
         {
             size_t size_of_value = column_data->sizeOfValueIfFixed();
             fixed_columns_bytes_per_row += column_data->sizeOfValueIfFixed();
@@ -283,16 +305,10 @@ void MergeTreeBlockSizePredictor::initialize(const Block & sample_block, const C
         {
             ColumnInfo info;
             info.name = column_name;
-            info.is_subcolumn = column_from_part && column_from_part->isSubcolumn();
-            /// If column isn't fixed and doesn't have checksum, than take first
-            ColumnSize column_size;
-            if (info.is_subcolumn && allow_subcolumns_sizes_calculation)
-                column_size = data_part->getSubcolumnSize(column_name);
-            else
-                column_size = data_part->getColumnSize(column_from_part ? column_from_part->getNameInStorage() : column_name);
+            info.is_subcolumn = part_column && part_column->is_subcolumn;
 
-            info.bytes_per_row_global = column_size.data_uncompressed
-                ? static_cast<double>(column_size.data_uncompressed) / static_cast<double>(number_of_rows_in_part)
+            info.bytes_per_row_global = part_column && part_column->column_size.data_uncompressed
+                ? static_cast<double>(part_column->column_size.data_uncompressed) / static_cast<double>(number_of_rows_in_part)
                 : static_cast<double>(column_data->byteSize()) / static_cast<double>(std::max<size_t>(1, column_data->size()));
 
             dynamic_columns_infos.emplace_back(info);
@@ -329,7 +345,7 @@ void MergeTreeBlockSizePredictor::update(const Block & sample_block, const Colum
     if (!is_initialized_in_update)
     {
         /// Reinitialize with read block to update estimation for DEFAULT and MATERIALIZED columns without data.
-        initialize(sample_block, columns, {}, true);
+        initialize(sample_block, columns, true);
         is_initialized_in_update = true;
     }
 

--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.h
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.h
@@ -2,8 +2,10 @@
 
 #include <Storages/MergeTree/MergeTreeReadTask.h>
 #include <Storages/MergeTree/MergeTreeRangeReader.h>
+#include <Storages/ColumnSize.h>
 
 #include <algorithm>
+#include <unordered_map>
 
 
 namespace DB
@@ -48,7 +50,7 @@ MergeTreeReadTaskColumns getReadTaskColumnsForMerge(
 
 struct MergeTreeBlockSizePredictor
 {
-    MergeTreeBlockSizePredictor(const DataPartPtr & data_part_, const Names & columns, const Block & sample_block, bool allow_subcolumns_sizes_calculation);
+    MergeTreeBlockSizePredictor(const DataPartPtr & data_part, const Names & columns, bool allow_subcolumns_sizes_calculation);
 
     /// Reset some values for correct statistics calculating
     void startBlock();
@@ -103,7 +105,16 @@ struct MergeTreeBlockSizePredictor
     static double calculateDecay() { return 1. - std::pow(TARGET_WEIGHT, 1. / NUM_UPDATES_TO_TARGET_WEIGHT); }
 
 protected:
-    DataPartPtr data_part;
+    struct PartColumnInfo
+    {
+        bool exists_in_part = false;
+        bool is_subcolumn = false;
+        String name_in_storage;
+        ColumnSize column_size;
+    };
+
+    using PartColumnsInfo = std::unordered_map<String, PartColumnInfo>;
+    std::shared_ptr<const PartColumnsInfo> part_columns_info;
 
     struct ColumnInfo
     {
@@ -126,9 +137,8 @@ protected:
     size_t number_of_rows_in_part;
 
     bool is_initialized_in_update = false;
-    bool allow_subcolumns_sizes_calculation = false;
 
-    void initialize(const Block & sample_block, const Columns & columns, const Names & names, bool from_update = false);
+    void initialize(const Block & sample_block, const Columns & columns, bool from_update = false);
 
 public:
 

--- a/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
@@ -288,17 +288,9 @@ MergeTreeReadPoolBase::buildReadTaskInfo(const RangesInDataPart & part_with_rang
             all_column_names.insert(pre_column_names.begin(), pre_column_names.end());
         }
 
-        Block sample_block_from_part;
-        for (const auto & column_name : all_column_names)
-        {
-            if (auto column_in_part = read_task_info.data_part->tryGetColumn(column_name))
-                sample_block_from_part.insert(ColumnWithTypeAndName(column_in_part->type->createColumn(), column_in_part->type, column_in_part->name));
-        }
-
         read_task_info.shared_size_predictor = std::make_unique<MergeTreeBlockSizePredictor>(
             read_task_info.data_part,
             Names(all_column_names.begin(), all_column_names.end()),
-            sample_block_from_part,
             settings[Setting::allow_calculating_subcolumns_sizes_for_merge_tree_reading]);
     }
 

--- a/tests/queries/0_stateless/04549_merge_tree_block_size_predictor_cached_part_metadata.reference
+++ b/tests/queries/0_stateless/04549_merge_tree_block_size_predictor_cached_part_metadata.reference
@@ -1,0 +1,4 @@
+wide sizes off	10	1	3	100	10	8	50
+wide sizes on	10	1	3	100	10	8	50
+compact sizes off	10	1	3	100	10	8	50
+compact sizes on	10	1	3	100	10	8	50

--- a/tests/queries/0_stateless/04549_merge_tree_block_size_predictor_cached_part_metadata.sql
+++ b/tests/queries/0_stateless/04549_merge_tree_block_size_predictor_cached_part_metadata.sql
@@ -1,0 +1,103 @@
+SET preferred_block_size_bytes = 1;
+SET max_threads = 4;
+SET enable_multiple_prewhere_read_steps = 1;
+
+DROP TABLE IF EXISTS predictor_metadata_wide;
+CREATE TABLE predictor_metadata_wide
+(
+    id UInt64,
+    j JSON(max_dynamic_paths = 4, typed Nullable(String)),
+    old_name String
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO predictor_metadata_wide VALUES
+    (1, '{"typed":"a","untyped":10}', 'x'),
+    (2, '{"typed":null,"untyped":20}', 'yy'),
+    (3, '{"typed":"c","untyped":30}', 'zzz'),
+    (4, '{"typed":"d","untyped":40}', 'wwww');
+
+ALTER TABLE predictor_metadata_wide RENAME COLUMN old_name TO renamed;
+ALTER TABLE predictor_metadata_wide
+    ADD COLUMN default_value String DEFAULT concat('d', toString(id)),
+    ADD COLUMN materialized_value UInt64 MATERIALIZED id + 10;
+
+SET allow_calculating_subcolumns_sizes_for_merge_tree_reading = 0;
+SELECT
+    'wide sizes off',
+    sum(id),
+    countIf(isNull(j.typed)),
+    sum(length(ifNull(j.typed, ''))),
+    sum(toUInt64(j.untyped)),
+    sum(length(renamed)),
+    sum(length(default_value)),
+    sum(materialized_value)
+FROM predictor_metadata_wide
+PREWHERE id > 0 AND length(renamed) > 0;
+
+SET allow_calculating_subcolumns_sizes_for_merge_tree_reading = 1;
+SELECT
+    'wide sizes on',
+    sum(id),
+    countIf(isNull(j.typed)),
+    sum(length(ifNull(j.typed, ''))),
+    sum(toUInt64(j.untyped)),
+    sum(length(renamed)),
+    sum(length(default_value)),
+    sum(materialized_value)
+FROM predictor_metadata_wide
+PREWHERE id > 0 AND length(renamed) > 0;
+
+DROP TABLE predictor_metadata_wide;
+
+DROP TABLE IF EXISTS predictor_metadata_compact;
+CREATE TABLE predictor_metadata_compact
+(
+    id UInt64,
+    j JSON(max_dynamic_paths = 4, typed Nullable(String)),
+    old_name String
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000;
+
+INSERT INTO predictor_metadata_compact VALUES
+    (1, '{"typed":"a","untyped":10}', 'x'),
+    (2, '{"typed":null,"untyped":20}', 'yy'),
+    (3, '{"typed":"c","untyped":30}', 'zzz'),
+    (4, '{"typed":"d","untyped":40}', 'wwww');
+
+ALTER TABLE predictor_metadata_compact RENAME COLUMN old_name TO renamed;
+ALTER TABLE predictor_metadata_compact
+    ADD COLUMN default_value String DEFAULT concat('d', toString(id)),
+    ADD COLUMN materialized_value UInt64 MATERIALIZED id + 10;
+
+SET allow_calculating_subcolumns_sizes_for_merge_tree_reading = 0;
+SELECT
+    'compact sizes off',
+    sum(id),
+    countIf(isNull(j.typed)),
+    sum(length(ifNull(j.typed, ''))),
+    sum(toUInt64(j.untyped)),
+    sum(length(renamed)),
+    sum(length(default_value)),
+    sum(materialized_value)
+FROM predictor_metadata_compact
+PREWHERE id > 0 AND length(renamed) > 0;
+
+SET allow_calculating_subcolumns_sizes_for_merge_tree_reading = 1;
+SELECT
+    'compact sizes on',
+    sum(id),
+    countIf(isNull(j.typed)),
+    sum(length(ifNull(j.typed, ''))),
+    sum(toUInt64(j.untyped)),
+    sum(length(renamed)),
+    sum(length(default_value)),
+    sum(materialized_value)
+FROM predictor_metadata_compact
+PREWHERE id > 0 AND length(renamed) > 0;
+
+DROP TABLE predictor_metadata_compact;


### PR DESCRIPTION
`MergeTreeBlockSizePredictor` re-resolved immutable part-column metadata when each read task processed its first block.

This is expensive for dynamic `JSON` subcolumns because type resolution constructs a complete default `SerializationJSON`, including every declared typed path.

 In a 716-query production-derived benchmark:

 - 4,334 of 66,972 attributed CPU samples were in dynamic-subcolumn metadata resolution.
 - 3,023 of those samples (69.8%) came from the block-size predictor.
 - 2,744 predictor samples (90.8%) occurred during the first per-task update.

 This change resolves column metadata and sizes once when creating the shared predictor. Task-local copies reuse it while continuing to update mutable size estimates from their first block.

 The test covers Wide and Compact parts, typed and dynamic JSON paths, renamed columns, missing `DEFAULT`/`MATERIALIZED` columns, and both subcolumn-size settings.

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduce CPU usage during MergeTree reads by reusing resolved part-column metadata in the block-size predictor.