### PR TITLE
Docs: update docs.json to use clickhouse-private docs repo as source

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -116,7 +116,7 @@
                 "$ref": "./products/kubernetes-operator/navigation.json"
               },
               {
-                "$ref": "./products/clickhouse-private/navigation.json"
+                "sourceRef": "ClickHouse/airgap-docs"
               }
             ],
             "tab": "Solutions"

--- a/docs/gt.config.json
+++ b/docs/gt.config.json
@@ -100,7 +100,9 @@
         "./en/**/*.md",
         "./en/**/*.mdx",
         "./products/cloud/api-reference/**/*.md",
-        "./products/cloud/api-reference/**/*.mdx"
+        "./products/cloud/api-reference/**/*.mdx",
+        "./products/clickhouse-private/**/*.md",
+        "./products/clickhouse-private/**/*.mdx"
       ]
     }
   },


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
Use the airgapped-docs repo as the source of truth for docs

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.672` (included in `26.8` and later)
<!-- ch-version-info:end -->