### PR TITLE
Add a brief summary to the top of four stateless tests

### DIFF
--- a/tests/queries/0_stateless/02354_vector_search_concurrent_readers.sql
+++ b/tests/queries/0_stateless/02354_vector_search_concurrent_readers.sql
@@ -3,6 +3,10 @@
 -- no-parallel-replicas: with parallel replicas the vector search optimization is disabled and the
 -- read layer uses a different pool, so the concurrency this test pins would not exist.
 
+-- Several threads search a vector similarity index over ONE part, so that the per-part vector
+-- search read hints are written and consumed while more than one reader is alive for that part. The
+-- assertions pin the split across readers, the index search, and equality with a single threaded read.
+
 -- The test runner can enable the query result cache. A cache hit returns an earlier attempt's answer
 -- without building a plan or reading the part, which would make every assertion below replay a stale
 -- result instead of measuring this attempt. Session wide, so a future assertion cannot forget it.

--- a/tests/queries/0_stateless/04652_paste_join_strictness_formatting.sql
+++ b/tests/queries/0_stateless/04652_paste_join_strictness_formatting.sql
@@ -1,5 +1,9 @@
 -- Tags: shard
 
+-- The formatter must not print a strictness modifier on a `PASTE JOIN`, because the parser rejects
+-- one and a formatted query carrying it fails on a remote server with `SYNTAX_ERROR`. It must still
+-- print the modifier, and the `PASTE` kind itself, everywhere the parser does accept them.
+
 SET join_default_strictness = 'ALL';
 SET any_join_distinct_right_table_keys = 0;
 SET enable_analyzer = 1;

--- a/tests/queries/0_stateless/04653_merging_aggregated_deserialized_thread_count.sql
+++ b/tests/queries/0_stateless/04653_merging_aggregated_deserialized_thread_count.sql
@@ -1,3 +1,7 @@
+-- A `MergingAggregatedStep` that the parallel replicas rewrite builds from a deserialized
+-- `AggregatingStep` must not keep the sentinel thread count 0. The same query without a serialized
+-- plan is the oracle, and two further oracles pin that a plan was really shipped and the rewrite ran.
+
 DROP TABLE IF EXISTS t_merging_aggregated_threads;
 
 CREATE TABLE t_merging_aggregated_threads (a UInt64, k UInt64)

--- a/tests/queries/0_stateless/04657_explain_estimates_rewrite.sql
+++ b/tests/queries/0_stateless/04657_explain_estimates_rewrite.sql
@@ -1,3 +1,6 @@
+-- `EXPLAIN ESTIMATE` must report the part, row and mark counts that `system.parts` reports for the
+-- same table, with the final mark of the part excluded.
+
 DROP TABLE IF EXISTS test;
 
 CREATE TABLE test (i Int64) ENGINE = MergeTree() ORDER BY i SETTINGS index_granularity = 16;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/112787
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

@rschu1ze asked on #112787 that a new test open with a brief summary of what it is
supposed to test, so a reader does not have to reconstruct the intent from the assertions.

This adds one to `02354_vector_search_concurrent_readers`, the test he commented on, and to
three other tests I added the same week that opened straight into executable code:
`04652_paste_join_strictness_formatting`,
`04653_merging_aggregated_deserialized_thread_count` and
`04657_explain_estimates_rewrite`.

Comments only. 15 added lines across 4 files, 0 removed, no executable statement added or
removed, and no `.reference` file changes, so no test behaviour changes. Each summary is the
first prose in its file, after the tag block in the two tests that carry one and above the
existing per-statement explanations, matching the placement the already compliant tests use.

Validation: each of the four tests was run against the same local server before and after
the change, and stdout plus the exit code are byte identical in every case. The two tests
that are fully runnable in my sandbox (`02354_vector_search_concurrent_readers`,
`04657_explain_estimates_rewrite`) pass 10/10 with setting randomization on. The other two
need a peer on the loopback aliases my sandbox does not bind, so they fail there
identically with and without this change.

Related: https://github.com/ClickHouse/ClickHouse/pull/112787#discussion_r3699338600


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.719` (included in `26.8` and later)
<!-- ch-version-info:end -->