### PR TITLE
Add TimeSeries settings to set index granularity of inner tables

### DIFF
--- a/docs/en/engines/table-engines/integrations/time-series.md
+++ b/docs/en/engines/table-engines/integrations/time-series.md
@@ -410,6 +410,8 @@ Here is a list of settings which can be specified while defining a `TimeSeries` 
 | `store_min_time_and_max_time` | Bool | true | If set to true then the table will store `min_time` and `max_time` for each time series |
 | `aggregate_min_time_and_max_time` | Bool | true | When creating an inner target `tags` table, this flag enables using `SimpleAggregateFunction(min, Nullable(DateTime64(3)))` instead of just `Nullable(DateTime64(3))` as the type of the `min_time` column, and the same for the `max_time` column |
 | `filter_by_min_time_and_max_time` | Bool | true | If set to true then the table will use the `min_time` and `max_time` columns for filtering time series |
+| `samples_index_granularity` | UInt64 | 0 | Sets `index_granularity` of the inner [samples](#samples-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external samples table and when the engine declaration of the inner samples table already sets `index_granularity` explicitly |
+| `tags_index_granularity` | UInt64 | 0 | Sets `index_granularity` of the inner [tags](#tags-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external tags table and when the engine declaration of the inner tags table already sets `index_granularity` explicitly |
 
 # Functions {#functions}
 

--- a/docs/en/engines/table-engines/integrations/time-series.md
+++ b/docs/en/engines/table-engines/integrations/time-series.md
@@ -200,7 +200,7 @@ SAMPLES INNER COLUMNS
     `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
     `value` Float64 CODEC(Gorilla, ZSTD(1))
 )
-SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp)
+SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp) SETTINGS index_granularity = 32768
 TAGS INNER COLUMNS
 (
     `id` UUID DEFAULT reinterpretAsUUID(sipHash128(metric_name, all_tags)),
@@ -210,7 +210,7 @@ TAGS INNER COLUMNS
     `min_time` SimpleAggregateFunction(min, Nullable(DateTime64(3))),
     `max_time` SimpleAggregateFunction(max, Nullable(DateTime64(3)))
 )
-TAGS INNER ENGINE = AggregatingMergeTree PRIMARY KEY metric_name ORDER BY (metric_name, id) SETTINGS allow_dimensions_outside_sorting_key = 1
+TAGS INNER ENGINE = AggregatingMergeTree PRIMARY KEY metric_name ORDER BY (metric_name, id) SETTINGS allow_dimensions_outside_sorting_key = 1, index_granularity = 8192
 METRICS INNER COLUMNS
 (
     `metric_family_name` String,
@@ -237,6 +237,7 @@ CREATE TABLE default.`.inner_id.samples.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 )
 ENGINE = MergeTree
 ORDER BY (id, timestamp)
+SETTINGS index_granularity = 32768
 ```
 
 ```sql
@@ -252,7 +253,7 @@ CREATE TABLE default.`.inner_id.tags.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 ENGINE = AggregatingMergeTree
 PRIMARY KEY metric_name
 ORDER BY (metric_name, id)
-SETTINGS allow_dimensions_outside_sorting_key = 1
+SETTINGS allow_dimensions_outside_sorting_key = 1, index_granularity = 8192
 ```
 
 ```sql
@@ -265,6 +266,7 @@ CREATE TABLE default.`.inner_id.metrics.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 )
 ENGINE = ReplacingMergeTree
 ORDER BY metric_family_name
+SETTINGS index_granularity = 8192
 ```
 
 ## Creating a table AS existing table {#create-as}
@@ -410,8 +412,8 @@ Here is a list of settings which can be specified while defining a `TimeSeries` 
 | `store_min_time_and_max_time` | Bool | true | If set to true then the table will store `min_time` and `max_time` for each time series |
 | `aggregate_min_time_and_max_time` | Bool | true | When creating an inner target `tags` table, this flag enables using `SimpleAggregateFunction(min, Nullable(DateTime64(3)))` instead of just `Nullable(DateTime64(3))` as the type of the `min_time` column, and the same for the `max_time` column |
 | `filter_by_min_time_and_max_time` | Bool | true | If set to true then the table will use the `min_time` and `max_time` columns for filtering time series |
-| `samples_index_granularity` | UInt64 | 0 | Sets `index_granularity` of the inner [samples](#samples-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external samples table and when the engine declaration of the inner samples table already sets `index_granularity` explicitly |
-| `tags_index_granularity` | UInt64 | 0 | Sets `index_granularity` of the inner [tags](#tags-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external tags table and when the engine declaration of the inner tags table already sets `index_granularity` explicitly |
+| `samples_index_granularity` | UInt64 | 32768 | Sets `index_granularity` of the inner [samples](#samples-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external samples table and when the engine declaration of the inner samples table already sets `index_granularity` explicitly |
+| `tags_index_granularity` | UInt64 | 8192 | Sets `index_granularity` of the inner [tags](#tags-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external tags table and when the engine declaration of the inner tags table already sets `index_granularity` explicitly |
 
 # Functions {#functions}
 

--- a/docs/en/engines/table-engines/integrations/time-series.md
+++ b/docs/en/engines/table-engines/integrations/time-series.md
@@ -412,8 +412,8 @@ Here is a list of settings which can be specified while defining a `TimeSeries` 
 | `store_min_time_and_max_time` | Bool | true | If set to true then the table will store `min_time` and `max_time` for each time series |
 | `aggregate_min_time_and_max_time` | Bool | true | When creating an inner target `tags` table, this flag enables using `SimpleAggregateFunction(min, Nullable(DateTime64(3)))` instead of just `Nullable(DateTime64(3))` as the type of the `min_time` column, and the same for the `max_time` column |
 | `filter_by_min_time_and_max_time` | Bool | true | If set to true then the table will use the `min_time` and `max_time` columns for filtering time series |
-| `samples_index_granularity` | UInt64 | 32768 | Sets `index_granularity` of the inner [samples](#samples-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external samples table and when the engine declaration of the inner samples table already sets `index_granularity` explicitly |
-| `tags_index_granularity` | UInt64 | 8192 | Sets `index_granularity` of the inner [tags](#tags-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external tags table and when the engine declaration of the inner tags table already sets `index_granularity` explicitly |
+| `samples_index_granularity` | UInt64 | 32768 | Sets `index_granularity` of the inner [samples](#samples-table) table. When set explicitly, it overrides `index_granularity` from the engine declaration. Ignored for an external samples table and a non-MergeTree engine |
+| `tags_index_granularity` | UInt64 | 8192 | Sets `index_granularity` of the inner [tags](#tags-table) table. When set explicitly, it overrides `index_granularity` from the engine declaration. Ignored for an external tags table and a non-MergeTree engine |
 
 # Functions {#functions}
 

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -860,7 +860,7 @@ SAMPLES INNER COLUMNS
     `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
     `value` Float64 CODEC(Gorilla, ZSTD(1))
 )
-SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp)
+SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp) SETTINGS index_granularity = 32768
 TAGS INNER COLUMNS
 (
     `id` UUID DEFAULT reinterpretAsUUID(sipHash128(metric_name, all_tags)),
@@ -870,7 +870,7 @@ TAGS INNER COLUMNS
     `min_time` SimpleAggregateFunction(min, Nullable(DateTime64(3))),
     `max_time` SimpleAggregateFunction(max, Nullable(DateTime64(3)))
 )
-TAGS INNER ENGINE = AggregatingMergeTree PRIMARY KEY metric_name ORDER BY (metric_name, id) SETTINGS allow_dimensions_outside_sorting_key = 1
+TAGS INNER ENGINE = AggregatingMergeTree PRIMARY KEY metric_name ORDER BY (metric_name, id) SETTINGS allow_dimensions_outside_sorting_key = 1, index_granularity = 8192
 METRICS INNER COLUMNS
 (
     `metric_family_name` String,
@@ -897,6 +897,7 @@ CREATE TABLE default.`.inner_id.samples.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 )
 ENGINE = MergeTree
 ORDER BY (id, timestamp)
+SETTINGS index_granularity = 32768
 ```
 
 ```sql
@@ -912,7 +913,7 @@ CREATE TABLE default.`.inner_id.tags.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 ENGINE = AggregatingMergeTree
 PRIMARY KEY metric_name
 ORDER BY (metric_name, id)
-SETTINGS allow_dimensions_outside_sorting_key = 1
+SETTINGS allow_dimensions_outside_sorting_key = 1, index_granularity = 8192
 ```
 
 ```sql
@@ -925,6 +926,7 @@ CREATE TABLE default.`.inner_id.metrics.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 )
 ENGINE = ReplacingMergeTree
 ORDER BY metric_family_name
+SETTINGS index_granularity = 8192
 ```
 
 ## Creating a table AS existing table {#create-as}
@@ -1070,8 +1072,8 @@ Here is a list of settings which can be specified while defining a `TimeSeries` 
 | `store_min_time_and_max_time` | Bool | true | If set to true then the table will store `min_time` and `max_time` for each time series |
 | `aggregate_min_time_and_max_time` | Bool | true | When creating an inner target `tags` table, this flag enables using `SimpleAggregateFunction(min, Nullable(DateTime64(3)))` instead of just `Nullable(DateTime64(3))` as the type of the `min_time` column, and the same for the `max_time` column |
 | `filter_by_min_time_and_max_time` | Bool | true | If set to true then the table will use the `min_time` and `max_time` columns for filtering time series |
-| `samples_index_granularity` | UInt64 | 0 | Sets `index_granularity` of the inner [samples](#samples-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external samples table and when the engine declaration of the inner samples table already sets `index_granularity` explicitly |
-| `tags_index_granularity` | UInt64 | 0 | Sets `index_granularity` of the inner [tags](#tags-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external tags table and when the engine declaration of the inner tags table already sets `index_granularity` explicitly |
+| `samples_index_granularity` | UInt64 | 32768 | Sets `index_granularity` of the inner [samples](#samples-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external samples table and when the engine declaration of the inner samples table already sets `index_granularity` explicitly |
+| `tags_index_granularity` | UInt64 | 8192 | Sets `index_granularity` of the inner [tags](#tags-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external tags table and when the engine declaration of the inner tags table already sets `index_granularity` explicitly |
 
 # Functions {#functions}
 

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -1072,8 +1072,8 @@ Here is a list of settings which can be specified while defining a `TimeSeries` 
 | `store_min_time_and_max_time` | Bool | true | If set to true then the table will store `min_time` and `max_time` for each time series |
 | `aggregate_min_time_and_max_time` | Bool | true | When creating an inner target `tags` table, this flag enables using `SimpleAggregateFunction(min, Nullable(DateTime64(3)))` instead of just `Nullable(DateTime64(3))` as the type of the `min_time` column, and the same for the `max_time` column |
 | `filter_by_min_time_and_max_time` | Bool | true | If set to true then the table will use the `min_time` and `max_time` columns for filtering time series |
-| `samples_index_granularity` | UInt64 | 32768 | Sets `index_granularity` of the inner [samples](#samples-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external samples table and when the engine declaration of the inner samples table already sets `index_granularity` explicitly |
-| `tags_index_granularity` | UInt64 | 8192 | Sets `index_granularity` of the inner [tags](#tags-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external tags table and when the engine declaration of the inner tags table already sets `index_granularity` explicitly |
+| `samples_index_granularity` | UInt64 | 32768 | Sets `index_granularity` of the inner [samples](#samples-table) table. When set explicitly, it overrides `index_granularity` from the engine declaration. Ignored for an external samples table and a non-MergeTree engine |
+| `tags_index_granularity` | UInt64 | 8192 | Sets `index_granularity` of the inner [tags](#tags-table) table. When set explicitly, it overrides `index_granularity` from the engine declaration. Ignored for an external tags table and a non-MergeTree engine |
 
 # Functions {#functions}
 

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -1070,6 +1070,8 @@ Here is a list of settings which can be specified while defining a `TimeSeries` 
 | `store_min_time_and_max_time` | Bool | true | If set to true then the table will store `min_time` and `max_time` for each time series |
 | `aggregate_min_time_and_max_time` | Bool | true | When creating an inner target `tags` table, this flag enables using `SimpleAggregateFunction(min, Nullable(DateTime64(3)))` instead of just `Nullable(DateTime64(3))` as the type of the `min_time` column, and the same for the `max_time` column |
 | `filter_by_min_time_and_max_time` | Bool | true | If set to true then the table will use the `min_time` and `max_time` columns for filtering time series |
+| `samples_index_granularity` | UInt64 | 0 | Sets `index_granularity` of the inner [samples](#samples-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external samples table and when the engine declaration of the inner samples table already sets `index_granularity` explicitly |
+| `tags_index_granularity` | UInt64 | 0 | Sets `index_granularity` of the inner [tags](#tags-table) table. `0` means the default granularity of the table engine. The setting is ignored for an external tags table and when the engine declaration of the inner tags table already sets `index_granularity` explicitly |
 
 # Functions {#functions}
 

--- a/src/Storages/TimeSeries/TimeSeriesSettings.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesSettings.cpp
@@ -28,6 +28,8 @@ namespace ErrorCodes
     DECLARE(Bool, store_min_time_and_max_time, true, "If set to true then the table will store 'min_time' and 'max_time' for each time series", 0) \
     DECLARE(Bool, aggregate_min_time_and_max_time, true, "When creating an inner target 'tags' table, this flag enables using 'SimpleAggregateFunction(min, Nullable(DateTime64(3)))' instead of just 'Nullable(DateTime64(3))' as the type of the 'min_time' column, and the same for the 'max_time' column", 0) \
     DECLARE(Bool, filter_by_min_time_and_max_time, true, "If set to true then the table will use the 'min_time' and 'max_time' columns for filtering time series", 0) \
+    DECLARE(UInt64, samples_index_granularity, 0, "Sets 'index_granularity' of the inner 'samples' table. 0 means the default granularity of the table engine. The setting is ignored for an external samples table and when the engine declaration of the inner samples table already sets 'index_granularity' explicitly", 0) \
+    DECLARE(UInt64, tags_index_granularity, 0, "Sets 'index_granularity' of the inner 'tags' table. 0 means the default granularity of the table engine. The setting is ignored for an external tags table and when the engine declaration of the inner tags table already sets 'index_granularity' explicitly", 0) \
 
 DECLARE_SETTINGS_TRAITS(TimeSeriesSettingsTraits, LIST_OF_TIME_SERIES_SETTINGS, TIMESERIES_SETTINGS_SUPPORTED_TYPES)
 IMPLEMENT_SETTINGS_TRAITS(TimeSeriesSettingsTraits, LIST_OF_TIME_SERIES_SETTINGS, TimeSeriesSettings, TimeSeriesSetting)

--- a/src/Storages/TimeSeries/TimeSeriesSettings.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesSettings.cpp
@@ -28,8 +28,8 @@ namespace ErrorCodes
     DECLARE(Bool, store_min_time_and_max_time, true, "If set to true then the table will store 'min_time' and 'max_time' for each time series", 0) \
     DECLARE(Bool, aggregate_min_time_and_max_time, true, "When creating an inner target 'tags' table, this flag enables using 'SimpleAggregateFunction(min, Nullable(DateTime64(3)))' instead of just 'Nullable(DateTime64(3))' as the type of the 'min_time' column, and the same for the 'max_time' column", 0) \
     DECLARE(Bool, filter_by_min_time_and_max_time, true, "If set to true then the table will use the 'min_time' and 'max_time' columns for filtering time series", 0) \
-    DECLARE(UInt64, samples_index_granularity, 0, "Sets 'index_granularity' of the inner 'samples' table. 0 means the default granularity of the table engine. The setting is ignored for an external samples table and when the engine declaration of the inner samples table already sets 'index_granularity' explicitly", 0) \
-    DECLARE(UInt64, tags_index_granularity, 0, "Sets 'index_granularity' of the inner 'tags' table. 0 means the default granularity of the table engine. The setting is ignored for an external tags table and when the engine declaration of the inner tags table already sets 'index_granularity' explicitly", 0) \
+    DECLARE(UInt64, samples_index_granularity, 32768, "Sets 'index_granularity' of the inner 'samples' table. 0 means the default granularity of the table engine. The setting is ignored for an external samples table and when the engine declaration of the inner samples table already sets 'index_granularity' explicitly", 0) \
+    DECLARE(UInt64, tags_index_granularity, 8192, "Sets 'index_granularity' of the inner 'tags' table. 0 means the default granularity of the table engine. The setting is ignored for an external tags table and when the engine declaration of the inner tags table already sets 'index_granularity' explicitly", 0) \
 
 DECLARE_SETTINGS_TRAITS(TimeSeriesSettingsTraits, LIST_OF_TIME_SERIES_SETTINGS, TIMESERIES_SETTINGS_SUPPORTED_TYPES)
 IMPLEMENT_SETTINGS_TRAITS(TimeSeriesSettingsTraits, LIST_OF_TIME_SERIES_SETTINGS, TimeSeriesSettings, TimeSeriesSetting)

--- a/src/Storages/TimeSeries/TimeSeriesSettings.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesSettings.cpp
@@ -28,8 +28,8 @@ namespace ErrorCodes
     DECLARE(Bool, store_min_time_and_max_time, true, "If set to true then the table will store 'min_time' and 'max_time' for each time series", 0) \
     DECLARE(Bool, aggregate_min_time_and_max_time, true, "When creating an inner target 'tags' table, this flag enables using 'SimpleAggregateFunction(min, Nullable(DateTime64(3)))' instead of just 'Nullable(DateTime64(3))' as the type of the 'min_time' column, and the same for the 'max_time' column", 0) \
     DECLARE(Bool, filter_by_min_time_and_max_time, true, "If set to true then the table will use the 'min_time' and 'max_time' columns for filtering time series", 0) \
-    DECLARE(UInt64, samples_index_granularity, 32768, "Sets 'index_granularity' of the inner 'samples' table. 0 means the default granularity of the table engine. The setting is ignored for an external samples table and when the engine declaration of the inner samples table already sets 'index_granularity' explicitly", 0) \
-    DECLARE(UInt64, tags_index_granularity, 8192, "Sets 'index_granularity' of the inner 'tags' table. 0 means the default granularity of the table engine. The setting is ignored for an external tags table and when the engine declaration of the inner tags table already sets 'index_granularity' explicitly", 0) \
+    DECLARE(UInt64, samples_index_granularity, 32768, "Sets 'index_granularity' of the inner 'samples' table. When set explicitly, it overrides 'index_granularity' from the engine declaration. Ignored for an external samples table and a non-MergeTree engine", 0) \
+    DECLARE(UInt64, tags_index_granularity, 8192, "Sets 'index_granularity' of the inner 'tags' table. When set explicitly, it overrides 'index_granularity' from the engine declaration. Ignored for an external tags table and a non-MergeTree engine", 0) \
 
 DECLARE_SETTINGS_TRAITS(TimeSeriesSettingsTraits, LIST_OF_TIME_SERIES_SETTINGS, TIMESERIES_SETTINGS_SUPPORTED_TYPES)
 IMPLEMENT_SETTINGS_TRAITS(TimeSeriesSettingsTraits, LIST_OF_TIME_SERIES_SETTINGS, TimeSeriesSettings, TimeSeriesSetting)

--- a/src/Storages/TimeSeries/TimeSeriesSettings.h
+++ b/src/Storages/TimeSeries/TimeSeriesSettings.h
@@ -16,6 +16,7 @@ struct TimeSeriesSettingsImpl;
     M(CLASS_NAME, ASTFunction) \
     M(CLASS_NAME, Bool) \
     M(CLASS_NAME, Map) \
+    M(CLASS_NAME, UInt64) \
 
 TIMESERIES_SETTINGS_SUPPORTED_TYPES(TimeSeriesSettings, DECLARE_SETTING_TRAIT)
 

--- a/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
+++ b/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
@@ -44,7 +44,9 @@ namespace TimeSeriesSetting
 {
     extern const TimeSeriesSettingsBool aggregate_min_time_and_max_time;
     extern const TimeSeriesSettingsASTFunction id_generator;
+    extern const TimeSeriesSettingsUInt64 samples_index_granularity;
     extern const TimeSeriesSettingsBool store_min_time_and_max_time;
+    extern const TimeSeriesSettingsUInt64 tags_index_granularity;
     extern const TimeSeriesSettingsMap tags_to_columns;
     extern const TimeSeriesSettingsBool use_all_tags_column_to_generate_id;
 }
@@ -710,6 +712,26 @@ namespace
     }
 
 
+    /// Adds a setting to the SETTINGS clause of an inner table's engine declaration.
+    /// An explicit value already set by the user is respected.
+    void setEngineSettingIfAbsent(ASTStorage & storage, std::string_view name, Field value)
+    {
+        if (storage.settings)
+        {
+            for (const auto & change : storage.settings->changes)
+                if (change.name == name)
+                    return;
+        }
+        else
+        {
+            auto settings_ast = make_intrusive<ASTSetQuery>();
+            settings_ast->is_standalone = false;
+            storage.set(storage.settings, settings_ast);
+        }
+
+        storage.settings->changes.push_back(SettingChange{String(name), std::move(value)});
+    }
+
     /// The TimeSeries `tags` inner table keeps the tag columns (and the `tags`/`all_tags` Maps) outside
     /// the sorting key, but they are functionally dependent on `id`, which is part of it: every group of
     /// rows that a background merge collapses together shares the same `id`, hence the same values of
@@ -722,21 +744,17 @@ namespace
         if (!storage.engine || !storage.engine->name.contains("Aggregating"))
             return;
 
-        if (storage.settings)
-        {
-            /// Respect an explicit value if the user already set it.
-            for (const auto & change : storage.settings->changes)
-                if (change.name == "allow_dimensions_outside_sorting_key")
-                    return;
-        }
-        else
-        {
-            auto settings_ast = make_intrusive<ASTSetQuery>();
-            settings_ast->is_standalone = false;
-            storage.set(storage.settings, settings_ast);
-        }
+        setEngineSettingIfAbsent(storage, "allow_dimensions_outside_sorting_key", Field(static_cast<UInt64>(1)));
+    }
 
-        storage.settings->changes.push_back(SettingChange{"allow_dimensions_outside_sorting_key", Field(static_cast<UInt64>(1))});
+    /// Sets `index_granularity` of an inner table's engine from the `samples_index_granularity`
+    /// or `tags_index_granularity` setting. Zero means the engine's default granularity.
+    void applyIndexGranularity(ASTStorage & storage, UInt64 index_granularity)
+    {
+        if (!index_granularity || !storage.engine)
+            return;
+
+        setEngineSettingIfAbsent(storage, "index_granularity", Field(index_granularity));
     }
 
     /// Makes the definition of the default engine for an inner table.
@@ -1078,10 +1096,19 @@ void normalizeTimeSeriesDefinition(ASTCreateQuery & create_query, const ContextP
                 if (!create_query.getTargetInnerEngine(kind))
                     create_query.setTargetInnerEngine(kind, generateInnerEngine(kind, settings));
 
+                if (kind == ViewTarget::Samples)
+                {
+                    if (auto * samples_engine = create_query.getTargetInnerEngine(kind))
+                        applyIndexGranularity(*samples_engine, settings[TimeSeriesSetting::samples_index_granularity]);
+                }
+
                 if (kind == ViewTarget::Tags)
                 {
                     if (auto * tags_engine = create_query.getTargetInnerEngine(kind))
+                    {
                         allowOffKeyDimensionsForAggregatingTagsEngine(*tags_engine);
+                        applyIndexGranularity(*tags_engine, settings[TimeSeriesSetting::tags_index_granularity]);
+                    }
                 }
             }
         }

--- a/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
+++ b/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
@@ -711,52 +711,6 @@ namespace
         create_query.set(create_query.columns_list, new_outer_columns);
     }
 
-
-    /// Adds a setting to the SETTINGS clause of an inner table's engine declaration.
-    /// An explicit value already set by the user is respected.
-    void setEngineSettingIfAbsent(ASTStorage & storage, std::string_view name, Field value)
-    {
-        if (storage.settings)
-        {
-            for (const auto & change : storage.settings->changes)
-                if (change.name == name)
-                    return;
-        }
-        else
-        {
-            auto settings_ast = make_intrusive<ASTSetQuery>();
-            settings_ast->is_standalone = false;
-            storage.set(storage.settings, settings_ast);
-        }
-
-        storage.settings->changes.push_back(SettingChange{String(name), std::move(value)});
-    }
-
-    /// The TimeSeries `tags` inner table keeps the tag columns (and the `tags`/`all_tags` Maps) outside
-    /// the sorting key, but they are functionally dependent on `id`, which is part of it: every group of
-    /// rows that a background merge collapses together shares the same `id`, hence the same values of
-    /// those columns, so this off-key layout is safe here. `AggregatingMergeTree` rejects such a layout
-    /// by default (see the `allow_dimensions_outside_sorting_key` setting and
-    /// https://github.com/ClickHouse/ClickHouse/issues/751), so enable that setting on the inner tags
-    /// engine — both when we generate it and when the user specifies an aggregating engine explicitly.
-    void allowOffKeyDimensionsForAggregatingTagsEngine(ASTStorage & storage)
-    {
-        if (!storage.engine || !storage.engine->name.contains("Aggregating"))
-            return;
-
-        setEngineSettingIfAbsent(storage, "allow_dimensions_outside_sorting_key", Field(static_cast<UInt64>(1)));
-    }
-
-    /// Sets `index_granularity` of an inner table's engine from the `samples_index_granularity`
-    /// or `tags_index_granularity` setting. Zero means the engine's default granularity.
-    void applyIndexGranularity(ASTStorage & storage, UInt64 index_granularity)
-    {
-        if (!index_granularity || !storage.engine)
-            return;
-
-        setEngineSettingIfAbsent(storage, "index_granularity", Field(index_granularity));
-    }
-
     /// Makes the definition of the default engine for an inner table.
     boost::intrusive_ptr<ASTStorage> generateInnerEngine(ViewTarget::Kind target_kind, const TimeSeriesSettings & settings)
     {
@@ -808,6 +762,60 @@ namespace
         }
 
         return storage;
+    }
+
+    /// Whether the SETTINGS clause of an inner table's engine declaration contains the specified setting.
+    bool hasInnerEngineSetting(const ASTStorage & storage, std::string_view name)
+    {
+        return storage.settings && storage.settings->changes.tryGet(name);
+    }
+
+    /// Sets a setting in the SETTINGS clause of an inner table's engine declaration,
+    /// overwriting the existing value if present.
+    void setInnerEngineSetting(ASTStorage & storage, std::string_view name, const Field & value)
+    {
+        if (!storage.settings)
+        {
+            auto settings_ast = make_intrusive<ASTSetQuery>();
+            settings_ast->is_standalone = false;
+            storage.set(storage.settings, settings_ast);
+        }
+        storage.settings->changes.setSetting(name, value);
+    }
+
+    /// Applies engine settings driven by the TimeSeries settings to an inner table's engine,
+    /// whether the engine was generated or specified by the user.
+    void applyInnerEngineSettings(ViewTarget::Kind kind, ASTStorage & storage, const TimeSeriesSettings & settings)
+    {
+        if (!storage.engine)
+            return;
+
+        const auto & engine_name = storage.engine->name;
+
+        /// The `samples_index_granularity` and `tags_index_granularity` settings set `index_granularity`
+        /// of the inner samples and tags tables. A setting set explicitly overrides `index_granularity`
+        /// from the engine declaration. Engines outside the MergeTree family don't support `index_granularity`.
+        if ((kind == ViewTarget::Samples || kind == ViewTarget::Tags) && engine_name.ends_with("MergeTree"))
+        {
+            const auto & index_granularity = settings[(kind == ViewTarget::Samples)
+                ? TimeSeriesSetting::samples_index_granularity
+                : TimeSeriesSetting::tags_index_granularity];
+            if (index_granularity.isChanged() || !hasInnerEngineSetting(storage, "index_granularity"))
+                setInnerEngineSetting(storage, "index_granularity", Field(index_granularity.value));
+        }
+
+        /// The TimeSeries `tags` inner table keeps the tag columns (and the `tags`/`all_tags` Maps) outside
+        /// the sorting key, but they are functionally dependent on `id`, which is part of it: every group of
+        /// rows that a background merge collapses together shares the same `id`, hence the same values of
+        /// those columns, so this off-key layout is safe here. `AggregatingMergeTree` rejects such a layout
+        /// by default (see the `allow_dimensions_outside_sorting_key` setting and
+        /// https://github.com/ClickHouse/ClickHouse/issues/751), so enable that setting on the inner tags
+        /// engine — both when we generate it and when the user specifies an aggregating engine explicitly.
+        if (kind == ViewTarget::Tags && engine_name.contains("Aggregating")
+            && !hasInnerEngineSetting(storage, "allow_dimensions_outside_sorting_key"))
+        {
+            setInnerEngineSetting(storage, "allow_dimensions_outside_sorting_key", Field(static_cast<UInt64>(1)));
+        }
     }
 
     /// Checks that a target table or an inner-columns list has all the columns required by the
@@ -1096,20 +1104,8 @@ void normalizeTimeSeriesDefinition(ASTCreateQuery & create_query, const ContextP
                 if (!create_query.getTargetInnerEngine(kind))
                     create_query.setTargetInnerEngine(kind, generateInnerEngine(kind, settings));
 
-                if (kind == ViewTarget::Samples)
-                {
-                    if (auto * samples_engine = create_query.getTargetInnerEngine(kind))
-                        applyIndexGranularity(*samples_engine, settings[TimeSeriesSetting::samples_index_granularity]);
-                }
-
-                if (kind == ViewTarget::Tags)
-                {
-                    if (auto * tags_engine = create_query.getTargetInnerEngine(kind))
-                    {
-                        allowOffKeyDimensionsForAggregatingTagsEngine(*tags_engine);
-                        applyIndexGranularity(*tags_engine, settings[TimeSeriesSetting::tags_index_granularity]);
-                    }
-                }
+                if (auto * inner_engine = create_query.getTargetInnerEngine(kind))
+                    applyInnerEngineSettings(kind, *inner_engine, settings);
             }
         }
     }

--- a/tests/integration/test_prometheus_protocols/test_different_table_engines.py
+++ b/tests/integration/test_prometheus_protocols/test_different_table_engines.py
@@ -314,6 +314,19 @@ def test_inner_engines():
     check()
 
 
+# Checks that the `samples_index_granularity` setting sets `index_granularity`
+# of the samples inner table.
+def test_samples_index_granularity():
+    node.query("CREATE TABLE prometheus ENGINE=TimeSeries SETTINGS samples_index_granularity = 32768")
+    check()
+
+    samples_table = node.query("SELECT _table FROM timeSeriesSamples(prometheus) LIMIT 1").strip()
+    engine_full = node.query(
+        f"SELECT engine_full FROM system.tables WHERE database = currentDatabase() AND name = '{samples_table}'"
+    )
+    assert "index_granularity = 32768" in engine_full
+
+
 # Checks that a TimeSeries table can be used to access pre-existing external tables
 # instead of its own inner tables.
 def test_external_tables():

--- a/tests/integration/test_prometheus_protocols/test_different_table_engines.py
+++ b/tests/integration/test_prometheus_protocols/test_different_table_engines.py
@@ -314,17 +314,39 @@ def test_inner_engines():
     check()
 
 
-# Checks that the `samples_index_granularity` setting sets `index_granularity`
-# of the samples inner table.
-def test_samples_index_granularity():
-    node.query("CREATE TABLE prometheus ENGINE=TimeSeries SETTINGS samples_index_granularity = 32768")
+# Checks that the `samples_index_granularity` and `tags_index_granularity` settings
+# set `index_granularity` of the samples and tags inner tables.
+def test_index_granularity():
+    # The default value of `samples_index_granularity` is 32768,
+    # the default value of `tags_index_granularity` is 8192.
+    node.query("CREATE TABLE prometheus ENGINE=TimeSeries")
     check()
 
-    samples_table = node.query("SELECT _table FROM timeSeriesSamples(prometheus) LIMIT 1").strip()
-    engine_full = node.query(
-        f"SELECT engine_full FROM system.tables WHERE database = currentDatabase() AND name = '{samples_table}'"
+    assert "index_granularity = 32768" in node.query(
+        "SELECT engine_full FROM system.tables WHERE database = currentDatabase() "
+        "AND name = (SELECT _table FROM timeSeriesSamples(prometheus) LIMIT 1)"
     )
-    assert "index_granularity = 32768" in engine_full
+    assert "index_granularity = 8192" in node.query(
+        "SELECT engine_full FROM system.tables WHERE database = currentDatabase() "
+        "AND name = (SELECT _table FROM timeSeriesTags(prometheus) LIMIT 1)"
+    )
+
+    drop_prometheus_table()
+
+    node.query(
+        "CREATE TABLE prometheus ENGINE=TimeSeries "
+        "SETTINGS samples_index_granularity = 16384, tags_index_granularity = 4096"
+    )
+    check()
+
+    assert "index_granularity = 16384" in node.query(
+        "SELECT engine_full FROM system.tables WHERE database = currentDatabase() "
+        "AND name = (SELECT _table FROM timeSeriesSamples(prometheus) LIMIT 1)"
+    )
+    assert "index_granularity = 4096" in node.query(
+        "SELECT engine_full FROM system.tables WHERE database = currentDatabase() "
+        "AND name = (SELECT _table FROM timeSeriesTags(prometheus) LIMIT 1)"
+    )
 
 
 # Checks that a TimeSeries table can be used to access pre-existing external tables


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add TimeSeries settings `samples_index_granularity` and `tags_inner_granularity` to set index granularity of inner tables


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.712` (included in `26.8` and later)
<!-- ch-version-info:end -->