### PR TITLE
Report a too long async distributed INSERT directory name as a user error

### DIFF
--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -954,15 +954,7 @@ const std::string & Cluster::ShardInfo::insertPathForInternalReplication(bool pr
 
     const auto & paths = insert_path_for_internal_replication;
     if (!use_compact_format)
-    {
-        const auto & path = prefer_localhost_replica ? paths.prefer_localhost_replica : paths.no_prefer_localhost_replica;
-        if (path.size() > NAME_MAX)
-        {
-            throw Exception(ErrorCodes::LOGICAL_ERROR,
-                "Path '{}' for async distributed INSERT is too long (exceed {} limit)", path, NAME_MAX);
-        }
-        return path;
-    }
+        return prefer_localhost_replica ? paths.prefer_localhost_replica : paths.no_prefer_localhost_replica;
 
     return paths.compact;
 }

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -39,6 +39,7 @@
 
 #include <base/range.h>
 
+#include <climits>
 #include <filesystem>
 
 
@@ -89,6 +90,7 @@ namespace DistributedSetting
 
 namespace ErrorCodes
 {
+    extern const int ARGUMENT_OUT_OF_BOUND;
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
     extern const int TIMEOUT_EXCEEDED;
@@ -844,6 +846,15 @@ void DistributedSink::writeToShard(const Cluster::ShardInfo & shard_info, const 
 {
     OpenTelemetry::SpanHolder span(__PRETTY_FUNCTION__);
     span.addAttribute("clickhouse.shard_num", shard_info.shard_num);
+
+    /// Every directory this function creates is named after an element of `dir_names`, so reject
+    /// too long names here. The name embeds `user:password@host:port`, hence it is not reported
+    /// (see `maskDataPath` in StorageSystemDistributionQueue.cpp).
+    for (const auto & dir_name : dir_names)
+        if (dir_name.size() > NAME_MAX)
+            throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND,
+                "The max length of a directory name for async distributed INSERT into table {} (cluster {}, shard {}) is {}, current length is {}",
+                storage.getStorageID().getFullNameNotQuoted(), storage.getClusterName(), shard_info.shard_num, NAME_MAX, dir_name.size());
 
     const auto & settings = context->getSettingsRef();
     const auto & distributed_settings = storage.getDistributedSettingsRef();

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -793,13 +793,17 @@ void DistributedSink::writeAsyncImpl(const Block & block, size_t shard_id)
     }
     else
     {
-        if (shard_info.isLocal() && settings[Setting::prefer_localhost_replica])
-            writeToLocal(shard_info, block_to_send, shard_info.getLocalNodeCount());
-
         std::vector<std::string> dir_names;
         for (const auto & address : cluster->getShardsAddresses()[shard_id])
             if (!address.is_local || !settings[Setting::prefer_localhost_replica])
                 dir_names.push_back(address.toFullString(settings[Setting::use_compact_format_in_distributed_parts_names]));
+
+        /// Reject before the local write below, otherwise a shard holding both this server and a
+        /// too long remote destination inserts locally and still reports the INSERT as failed.
+        checkDirectoryNameLengths(shard_info, dir_names);
+
+        if (shard_info.isLocal() && settings[Setting::prefer_localhost_replica])
+            writeToLocal(shard_info, block_to_send, shard_info.getLocalNodeCount());
 
         if (!dir_names.empty())
             writeToShard(shard_info, block_to_send, dir_names);
@@ -842,19 +846,25 @@ void DistributedSink::writeToLocal(const Cluster::ShardInfo & shard_info, const 
 }
 
 
-void DistributedSink::writeToShard(const Cluster::ShardInfo & shard_info, const Block & block, const std::vector<std::string> & dir_names)
+void DistributedSink::checkDirectoryNameLengths(const Cluster::ShardInfo & shard_info, const std::vector<std::string> & dir_names) const
 {
-    OpenTelemetry::SpanHolder span(__PRETTY_FUNCTION__);
-    span.addAttribute("clickhouse.shard_num", shard_info.shard_num);
-
-    /// Every directory this function creates is named after an element of `dir_names`, so reject
-    /// too long names here. The name embeds `user:password@host:port`, hence it is not reported
+    /// The name embeds `user:password@host:port`, hence it is not reported
     /// (see `maskDataPath` in StorageSystemDistributionQueue.cpp).
     for (const auto & dir_name : dir_names)
         if (dir_name.size() > NAME_MAX)
             throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND,
                 "The max length of a directory name for async distributed INSERT into table {} (cluster {}, shard {}) is {}, current length is {}",
                 storage.getStorageID().getFullNameNotQuoted(), storage.getClusterName(), shard_info.shard_num, NAME_MAX, dir_name.size());
+}
+
+
+void DistributedSink::writeToShard(const Cluster::ShardInfo & shard_info, const Block & block, const std::vector<std::string> & dir_names)
+{
+    OpenTelemetry::SpanHolder span(__PRETTY_FUNCTION__);
+    span.addAttribute("clickhouse.shard_num", shard_info.shard_num);
+
+    /// Every directory this function creates is named after an element of `dir_names`.
+    checkDirectoryNameLengths(shard_info, dir_names);
 
     const auto & settings = context->getSettingsRef();
     const auto & distributed_settings = storage.getDistributedSettingsRef();

--- a/src/Storages/Distributed/DistributedSink.h
+++ b/src/Storages/Distributed/DistributedSink.h
@@ -72,6 +72,9 @@ private:
     /// Increments finished_writings_count after each repeat.
     void writeToLocal(const Cluster::ShardInfo & shard_info, const Block & block, size_t repeats);
 
+    /// Async inserts are spooled into a directory named after each element of `dir_names`.
+    void checkDirectoryNameLengths(const Cluster::ShardInfo & shard_info, const std::vector<std::string> & dir_names) const;
+
     void writeToShard(const Cluster::ShardInfo & shard_info, const Block & block, const std::vector<std::string> & dir_names);
 
 

--- a/tests/integration/test_distributed_format/configs/remote_servers.xml
+++ b/tests/integration/test_distributed_format/configs/remote_servers.xml
@@ -34,5 +34,13 @@
                 <replica><host>not_existing_replica_09</host><port>9000</port></replica>
             </shard>
         </test_cluster_internal_replication_long_path>
+
+        <!-- One shard holding this server plus a remote destination whose name exceeds NAME_MAX. -->
+        <test_cluster_mixed_local_long_path>
+            <shard>
+                <replica><host>node</host><port>9000</port></replica>
+                <replica><host>cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc</host><port>9000</port></replica>
+            </shard>
+        </test_cluster_mixed_local_long_path>
     </remote_servers>
 </clickhouse>

--- a/tests/integration/test_distributed_format/configs/remote_servers.xml
+++ b/tests/integration/test_distributed_format/configs/remote_servers.xml
@@ -16,5 +16,23 @@
                 <port>9000</port>
             </node>
         </test_cluster_no_internal_replication>
+
+        <!-- With internal replication every replica of the shard is concatenated into one
+             directory name, so 10 ordinary replicas already exceed the 255-byte NAME_MAX. -->
+        <test_cluster_internal_replication_long_path>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica><host>not_existing_replica_00</host><port>9000</port></replica>
+                <replica><host>not_existing_replica_01</host><port>9000</port></replica>
+                <replica><host>not_existing_replica_02</host><port>9000</port></replica>
+                <replica><host>not_existing_replica_03</host><port>9000</port></replica>
+                <replica><host>not_existing_replica_04</host><port>9000</port></replica>
+                <replica><host>not_existing_replica_05</host><port>9000</port></replica>
+                <replica><host>not_existing_replica_06</host><port>9000</port></replica>
+                <replica><host>not_existing_replica_07</host><port>9000</port></replica>
+                <replica><host>not_existing_replica_08</host><port>9000</port></replica>
+                <replica><host>not_existing_replica_09</host><port>9000</port></replica>
+            </shard>
+        </test_cluster_internal_replication_long_path>
     </remote_servers>
 </clickhouse>

--- a/tests/integration/test_distributed_format/test.py
+++ b/tests/integration/test_distributed_format/test.py
@@ -282,3 +282,49 @@ def test_invalid_shard_directory_format(started_cluster):
     # Clean up
     node.query("drop table test.dist_invalid sync")
     node.query("drop table test.local_invalid sync")
+
+
+def test_long_directory_name_internal_replication(started_cluster):
+    # With internal replication the async-insert directory is named after every replica of the
+    # shard concatenated, so it can exceed NAME_MAX without any single field being long. That has
+    # to be a user error rather than a logical error (which aborts assert builds). See #112719.
+    node.query("drop table if exists test.local_long_path sync")
+    node.query("drop table if exists test.distr_long_path sync")
+    node.query(
+        "create table test.local_long_path (x UInt64) engine = MergeTree order by x"
+    )
+    node.query(
+        "create table test.distr_long_path (x UInt64) engine = "
+        "Distributed('test_cluster_internal_replication_long_path', test, local_long_path)"
+    )
+
+    error = node.query_and_get_error(
+        "insert into test.distr_long_path values (1)",
+        settings={
+            "distributed_foreground_insert": "0",
+            "prefer_localhost_replica": "0",
+            "use_compact_format_in_distributed_parts_names": "0",
+        },
+    )
+    assert "ARGUMENT_OUT_OF_BOUND" in error
+    assert "The max length of a directory name" in error
+
+    # The compact format keeps the name bounded, so the same cluster still works with it.
+    node.query(
+        "insert into test.distr_long_path values (1)",
+        settings={
+            "distributed_foreground_insert": "0",
+            "prefer_localhost_replica": "0",
+            "use_compact_format_in_distributed_parts_names": "1",
+        },
+    )
+    assert (
+        node.query(
+            "select count() from system.distribution_queue "
+            "where database = 'test' and table = 'distr_long_path'"
+        ).strip()
+        != "0"
+    )
+
+    node.query("drop table test.distr_long_path sync")
+    node.query("drop table test.local_long_path sync")

--- a/tests/integration/test_distributed_format/test.py
+++ b/tests/integration/test_distributed_format/test.py
@@ -331,3 +331,35 @@ def test_long_directory_name_internal_replication(started_cluster):
 
     node.query("drop table test.distr_long_path sync")
     node.query("drop table test.local_long_path sync")
+
+
+def test_long_directory_name_rejected_before_local_write(started_cluster):
+    # A shard holding this server plus a too long remote destination must be rejected before the
+    # local write, otherwise the INSERT reports a failure it has already partly applied and a
+    # retry duplicates rows on the local replica.
+    node.query("drop table if exists test.local_mixed_path sync")
+    node.query("drop table if exists test.distr_mixed_path sync")
+    node.query(
+        "create table test.local_mixed_path (x UInt64) engine = MergeTree order by x"
+    )
+    node.query(
+        "create table test.distr_mixed_path (x UInt64) engine = "
+        "Distributed('test_cluster_mixed_local_long_path', test, local_mixed_path)"
+    )
+
+    settings = {
+        "distributed_foreground_insert": "0",
+        "prefer_localhost_replica": "1",
+        "use_compact_format_in_distributed_parts_names": "0",
+    }
+    for _ in range(3):
+        error = node.query_and_get_error(
+            "insert into test.distr_mixed_path values (1)", settings=settings
+        )
+        assert "ARGUMENT_OUT_OF_BOUND" in error
+        assert "The max length of a directory name" in error
+
+    assert node.query("select count() from test.local_mixed_path").strip() == "0"
+
+    node.query("drop table test.distr_mixed_path sync")
+    node.query("drop table test.local_mixed_path sync")

--- a/tests/integration/test_distributed_format/test.py
+++ b/tests/integration/test_distributed_format/test.py
@@ -308,6 +308,9 @@ def test_long_directory_name_internal_replication(started_cluster):
     )
     assert "ARGUMENT_OUT_OF_BOUND" in error
     assert "The max length of a directory name" in error
+    assert "distr_long_path" in error
+    assert "test_cluster_internal_replication_long_path" in error
+    assert "is 255" in error
 
     # The compact format keeps the name bounded, so the same cluster still works with it.
     node.query(

--- a/tests/queries/0_stateless/04725_distributed_async_insert_long_directory_name.reference
+++ b/tests/queries/0_stateless/04725_distributed_async_insert_long_directory_name.reference
@@ -1,0 +1,4 @@
+at_limit_queued	1
+multi_no_queue	0
+password_not_leaked	0
+compact_format_ok	1

--- a/tests/queries/0_stateless/04725_distributed_async_insert_long_directory_name.reference
+++ b/tests/queries/0_stateless/04725_distributed_async_insert_long_directory_name.reference
@@ -1,4 +1,5 @@
 at_limit_queued	1
 multi_no_queue	0
 password_not_leaked	0
+message_names_scope	1
 compact_format_ok	1

--- a/tests/queries/0_stateless/04725_distributed_async_insert_long_directory_name.sql
+++ b/tests/queries/0_stateless/04725_distributed_async_insert_long_directory_name.sql
@@ -30,6 +30,8 @@ INSERT INTO with_password_04725 SETTINGS distributed_foreground_insert = 0, pref
 SYSTEM FLUSH LOGS query_log;
 SELECT 'password_not_leaked', countIf(exception LIKE '%secret_04725%') FROM system.query_log
 WHERE current_database = currentDatabase() AND exception_code = 69;
+SELECT 'message_names_scope', countIf(exception LIKE '%over_limit_04725%' AND exception LIKE '%is 255%') FROM system.query_log
+WHERE current_database = currentDatabase() AND exception_code = 69 AND query LIKE '%over_limit_04725%';
 
 -- The compact format builds bounded 'shard<N>_replica<M>' names, so it is unaffected.
 INSERT INTO over_limit_04725 SETTINGS distributed_foreground_insert = 0, prefer_localhost_replica = 0, use_compact_format_in_distributed_parts_names = 1 VALUES (1);

--- a/tests/queries/0_stateless/04725_distributed_async_insert_long_directory_name.sql
+++ b/tests/queries/0_stateless/04725_distributed_async_insert_long_directory_name.sql
@@ -1,0 +1,42 @@
+-- An async INSERT into a Distributed/Remote table spools blocks into a directory named after the
+-- destination address, so a name over NAME_MAX (255) must be a user error, not a bare std::exception.
+-- The port is spelled out in every address so the name length does not depend on the server's config.
+
+DROP TABLE IF EXISTS target_04725;
+CREATE TABLE target_04725 (x UInt64) ENGINE = MergeTree ORDER BY x;
+
+-- A name of exactly 255 bytes ('default' + '@' + host + ':9000') is still accepted.
+CREATE TABLE at_limit_04725 (x UInt64) ENGINE = Remote('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:9000', currentDatabase(), target_04725);
+SYSTEM STOP DISTRIBUTED SENDS at_limit_04725;
+INSERT INTO at_limit_04725 SETTINGS distributed_foreground_insert = 0, prefer_localhost_replica = 0, use_compact_format_in_distributed_parts_names = 0 VALUES (1);
+SELECT 'at_limit_queued', data_files > 0 FROM system.distribution_queue WHERE database = currentDatabase() AND table = 'at_limit_04725';
+
+-- One byte over the limit is rejected.
+CREATE TABLE over_limit_04725 (x UInt64) ENGINE = Remote('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:9000', currentDatabase(), target_04725);
+SYSTEM STOP DISTRIBUTED SENDS over_limit_04725;
+INSERT INTO over_limit_04725 SETTINGS distributed_foreground_insert = 0, prefer_localhost_replica = 0, use_compact_format_in_distributed_parts_names = 0 VALUES (1); -- { serverError ARGUMENT_OUT_OF_BOUND }
+
+-- A shard whose FIRST destination is short and a LATER one too long is rejected too, and the short
+-- one gets no queue directory.
+CREATE TABLE multi_04725 (x UInt64) ENGINE = Remote('127.0.0.1:9000|bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:9000', currentDatabase(), target_04725);
+SYSTEM STOP DISTRIBUTED SENDS multi_04725;
+INSERT INTO multi_04725 SETTINGS distributed_foreground_insert = 0, prefer_localhost_replica = 0, use_compact_format_in_distributed_parts_names = 0 VALUES (1); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT 'multi_no_queue', count() FROM system.distribution_queue WHERE database = currentDatabase() AND table = 'multi_04725';
+
+-- The directory name embeds the password, so the message must not disclose it.
+CREATE TABLE with_password_04725 (x UInt64) ENGINE = Remote('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:9000', currentDatabase(), target_04725, 'default', 'secret_04725');
+SYSTEM STOP DISTRIBUTED SENDS with_password_04725;
+INSERT INTO with_password_04725 SETTINGS distributed_foreground_insert = 0, prefer_localhost_replica = 0, use_compact_format_in_distributed_parts_names = 0 VALUES (1); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SYSTEM FLUSH LOGS query_log;
+SELECT 'password_not_leaked', countIf(exception LIKE '%secret_04725%') FROM system.query_log
+WHERE current_database = currentDatabase() AND exception_code = 69;
+
+-- The compact format builds bounded 'shard<N>_replica<M>' names, so it is unaffected.
+INSERT INTO over_limit_04725 SETTINGS distributed_foreground_insert = 0, prefer_localhost_replica = 0, use_compact_format_in_distributed_parts_names = 1 VALUES (1);
+SELECT 'compact_format_ok', data_files > 0 FROM system.distribution_queue WHERE database = currentDatabase() AND table = 'over_limit_04725';
+
+DROP TABLE with_password_04725;
+DROP TABLE multi_04725;
+DROP TABLE over_limit_04725;
+DROP TABLE at_limit_04725;
+DROP TABLE target_04725;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/112719
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/112719

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed the error reported when an asynchronous `INSERT` into a `Distributed` table needs a queue directory whose name exceeds the 255-byte filesystem limit (reachable with `use_compact_format_in_distributed_parts_names = 0`). It was a `LOGICAL_ERROR` for a shard with `internal_replication` and an unattributed `Code: 1001. std::exception` otherwise; both now report `ARGUMENT_OUT_OF_BOUND` naming the table, the cluster and the limit.

### Description

With `use_compact_format_in_distributed_parts_names = 0` an async `INSERT` spools blocks into one directory per destination, named `user[:password]@host:port[#default_database]`. For a shard with `internal_replication` that name is comma-joined across all replicas, so ~10 replicas exceed `NAME_MAX` (255) with no single long field.

The condition is purely input-driven, so neither failure mode was an invariant violation:

* `internal_replication = true`: `Cluster::ShardInfo::insertPathForInternalReplication` threw `LOGICAL_ERROR`, which aborts the server in assert builds.
* `internal_replication = false`: no check at all. `mkdir` failed with `ENAMETOOLONG`, surfacing as `Code: 1001. DB::Exception: std::exception`, naming neither the cluster nor the limit.

The fix adds one length check at the top of `DistributedSink::writeToShard`, the sole creator of these directories (including the hardlink loop over the later destinations) and reached by both shard shapes. It throws `ARGUMENT_OUT_OF_BOUND`, mirroring `DatabaseOnDisk::checkTableNameLength`, before any disk reservation. The now-redundant `LOGICAL_ERROR` in `Cluster.cpp` is removed, leaving `insertPathForInternalReplication` a pure accessor. The message omits the name itself, which embeds the password `system.distribution_queue` masks out.

Names of 255 bytes or less behave exactly as before, and the compact format is unaffected (`shard<N>_replica<M>` is bounded by construction). The check is on the write path only, so a too long directory already on disk stays tolerated and table loading cannot start failing.

Rejecting the combination at `CREATE TABLE` or config parse time, as the issue suggests, is not possible: `use_compact_format_in_distributed_parts_names` is a per-query setting, so at that point it is unknown whether such a name is ever built.

Validated by a new stateless test (the unguarded branch, the exactly-255 boundary, a multi-destination shard whose first address is short, and the password not being disclosed) plus a new `test_distributed_format` case for the `internal_replication` half. Both fail on master.