### PR TITLE
Add a regression test for a deduplicated insert of a sparse nested Tuple

### DIFF
--- a/tests/queries/0_stateless/04692_insert_dedup_retry_sparse_tuple.reference
+++ b/tests/queries/0_stateless/04692_insert_dedup_retry_sparse_tuple.reference
@@ -1,0 +1,11 @@
+source element is sparse	1
+nested tuple, first insert	20000
+nested tuple, repeated insert deduplicated	20000
+destination element is still sparse	1
+doubly nested tuple, first insert	20000
+doubly nested tuple, repeated insert deduplicated	20000
+materialized view target, first insert	20000
+materialized view target, repeated insert deduplicated	20000
+top level column is sparse	Sparse
+top level sparse, repeated insert deduplicated	20000
+insert without deduplication appends	40000

--- a/tests/queries/0_stateless/04692_insert_dedup_retry_sparse_tuple.reference
+++ b/tests/queries/0_stateless/04692_insert_dedup_retry_sparse_tuple.reference
@@ -2,10 +2,13 @@ source element is sparse	1
 nested tuple, first insert	20000
 nested tuple, repeated insert deduplicated	20000
 destination element is still sparse	1
+doubly nested source element is sparse	1
 doubly nested tuple, first insert	20000
 doubly nested tuple, repeated insert deduplicated	20000
+doubly nested destination element is still sparse	1
 materialized view target, first insert	20000
 materialized view target, repeated insert deduplicated	20000
+materialized view target element is still sparse	1
 top level column is sparse	Sparse
 top level sparse, repeated insert deduplicated	20000
 insert without deduplication appends	40000

--- a/tests/queries/0_stateless/04692_insert_dedup_retry_sparse_tuple.sql
+++ b/tests/queries/0_stateless/04692_insert_dedup_retry_sparse_tuple.sql
@@ -39,6 +39,8 @@ SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9;
 
 INSERT INTO t_dedup_sparse_nested_src SELECT number, tuple((number, number < 5)) FROM numbers(20000);
 
+SELECT 'doubly nested source element is sparse', dumpColumnStructure(body) LIKE '%Sparse%' FROM t_dedup_sparse_nested_src LIMIT 1;
+
 CREATE TABLE t_dedup_sparse_nested_dst (id UInt64, body Tuple(inner Tuple(key UInt64, flag Bool)))
 ENGINE = MergeTree ORDER BY id
 SETTINGS non_replicated_deduplication_window = 100, ratio_of_defaults_for_sparse_serialization = 0.9;
@@ -48,6 +50,8 @@ SELECT 'doubly nested tuple, first insert', count() FROM t_dedup_sparse_nested_d
 
 INSERT INTO t_dedup_sparse_nested_dst SELECT * FROM t_dedup_sparse_nested_src SETTINGS insert_deduplication_token = 'token_2';
 SELECT 'doubly nested tuple, repeated insert deduplicated', count() FROM t_dedup_sparse_nested_dst;
+
+SELECT 'doubly nested destination element is still sparse', dumpColumnStructure(body) LIKE '%Sparse%' FROM t_dedup_sparse_nested_dst LIMIT 1;
 
 -- The same, but deduplication happens on a materialized view target, which retries at view level.
 CREATE TABLE t_dedup_sparse_landing (id UInt64, body Tuple(key UInt64, flag Bool))
@@ -66,6 +70,8 @@ SELECT 'materialized view target, first insert', count() FROM t_dedup_sparse_mv_
 
 INSERT INTO t_dedup_sparse_landing SELECT * FROM t_dedup_sparse_src SETTINGS insert_deduplication_token = 'token_3';
 SELECT 'materialized view target, repeated insert deduplicated', count() FROM t_dedup_sparse_mv_target;
+
+SELECT 'materialized view target element is still sparse', dumpColumnStructure(body) LIKE '%Sparse%' FROM t_dedup_sparse_mv_target LIMIT 1;
 
 -- A sparse column at the top level was already handled and must keep working.
 CREATE TABLE t_dedup_sparse_top_src (id UInt64, flag Bool)

--- a/tests/queries/0_stateless/04692_insert_dedup_retry_sparse_tuple.sql
+++ b/tests/queries/0_stateless/04692_insert_dedup_retry_sparse_tuple.sql
@@ -9,6 +9,14 @@ DROP TABLE IF EXISTS t_dedup_sparse_top_src SETTINGS ignore_drop_queries_probabi
 DROP TABLE IF EXISTS t_dedup_sparse_top_dst SETTINGS ignore_drop_queries_probability = 0;
 DROP TABLE IF EXISTS t_dedup_sparse_plain_dst SETTINGS ignore_drop_queries_probability = 0;
 
+-- The INSERT SELECT dedup token embeds how the source read was chunked, so the retry only
+-- collides if both attempts chunk identically. Pin everything that shapes the read, or
+-- randomized settings and read-scheduler timing flake the dedup pairs to 40000.
+SET max_threads = 1;
+SET max_insert_threads = 1;
+SET max_block_size = 65409;
+SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0;
+
 -- A sparse-serialized element inside a Tuple: the tuple element is default in all but 5 of 20000 rows.
 CREATE TABLE t_dedup_sparse_src (id UInt64, body Tuple(key UInt64, flag Bool))
 ENGINE = MergeTree ORDER BY id

--- a/tests/queries/0_stateless/04692_insert_dedup_retry_sparse_tuple.sql
+++ b/tests/queries/0_stateless/04692_insert_dedup_retry_sparse_tuple.sql
@@ -1,0 +1,106 @@
+DROP TABLE IF EXISTS t_dedup_sparse_src SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_dedup_sparse_dst SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_dedup_sparse_nested_src SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_dedup_sparse_nested_dst SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_dedup_sparse_landing SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_dedup_sparse_mv_target SETTINGS ignore_drop_queries_probability = 0;
+DROP VIEW IF EXISTS t_dedup_sparse_mv SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_dedup_sparse_top_src SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_dedup_sparse_top_dst SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_dedup_sparse_plain_dst SETTINGS ignore_drop_queries_probability = 0;
+
+-- A sparse-serialized element inside a Tuple: the tuple element is default in all but 5 of 20000 rows.
+CREATE TABLE t_dedup_sparse_src (id UInt64, body Tuple(key UInt64, flag Bool))
+ENGINE = MergeTree ORDER BY id
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9;
+
+INSERT INTO t_dedup_sparse_src SELECT number, (number, number < 5) FROM numbers(20000);
+
+SELECT 'source element is sparse', dumpColumnStructure(body) LIKE '%Sparse%' FROM t_dedup_sparse_src LIMIT 1;
+
+CREATE TABLE t_dedup_sparse_dst (id UInt64, body Tuple(key UInt64, flag Bool))
+ENGINE = MergeTree ORDER BY id
+SETTINGS non_replicated_deduplication_window = 100, ratio_of_defaults_for_sparse_serialization = 0.9;
+
+INSERT INTO t_dedup_sparse_dst SELECT * FROM t_dedup_sparse_src SETTINGS insert_deduplication_token = 'token_1';
+SELECT 'nested tuple, first insert', count() FROM t_dedup_sparse_dst;
+
+-- Every block is a duplicate, so the deduplication retry is entered with nothing to retry.
+INSERT INTO t_dedup_sparse_dst SELECT * FROM t_dedup_sparse_src SETTINGS insert_deduplication_token = 'token_1';
+SELECT 'nested tuple, repeated insert deduplicated', count() FROM t_dedup_sparse_dst;
+
+-- The retried table keeps the sparse serialization of the tuple element.
+SELECT 'destination element is still sparse', dumpColumnStructure(body) LIKE '%Sparse%' FROM t_dedup_sparse_dst LIMIT 1;
+
+-- Sparse nested two levels deep.
+CREATE TABLE t_dedup_sparse_nested_src (id UInt64, body Tuple(inner Tuple(key UInt64, flag Bool)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9;
+
+INSERT INTO t_dedup_sparse_nested_src SELECT number, tuple((number, number < 5)) FROM numbers(20000);
+
+CREATE TABLE t_dedup_sparse_nested_dst (id UInt64, body Tuple(inner Tuple(key UInt64, flag Bool)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS non_replicated_deduplication_window = 100, ratio_of_defaults_for_sparse_serialization = 0.9;
+
+INSERT INTO t_dedup_sparse_nested_dst SELECT * FROM t_dedup_sparse_nested_src SETTINGS insert_deduplication_token = 'token_2';
+SELECT 'doubly nested tuple, first insert', count() FROM t_dedup_sparse_nested_dst;
+
+INSERT INTO t_dedup_sparse_nested_dst SELECT * FROM t_dedup_sparse_nested_src SETTINGS insert_deduplication_token = 'token_2';
+SELECT 'doubly nested tuple, repeated insert deduplicated', count() FROM t_dedup_sparse_nested_dst;
+
+-- The same, but deduplication happens on a materialized view target, which retries at view level.
+CREATE TABLE t_dedup_sparse_landing (id UInt64, body Tuple(key UInt64, flag Bool))
+ENGINE = MergeTree ORDER BY id
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9;
+
+CREATE TABLE t_dedup_sparse_mv_target (id UInt64, body Tuple(key UInt64, flag Bool))
+ENGINE = MergeTree ORDER BY id
+SETTINGS non_replicated_deduplication_window = 100, ratio_of_defaults_for_sparse_serialization = 0.9;
+
+CREATE MATERIALIZED VIEW t_dedup_sparse_mv TO t_dedup_sparse_mv_target
+AS SELECT id, body FROM t_dedup_sparse_landing;
+
+INSERT INTO t_dedup_sparse_landing SELECT * FROM t_dedup_sparse_src SETTINGS insert_deduplication_token = 'token_3';
+SELECT 'materialized view target, first insert', count() FROM t_dedup_sparse_mv_target;
+
+INSERT INTO t_dedup_sparse_landing SELECT * FROM t_dedup_sparse_src SETTINGS insert_deduplication_token = 'token_3';
+SELECT 'materialized view target, repeated insert deduplicated', count() FROM t_dedup_sparse_mv_target;
+
+-- A sparse column at the top level was already handled and must keep working.
+CREATE TABLE t_dedup_sparse_top_src (id UInt64, flag Bool)
+ENGINE = MergeTree ORDER BY id
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9;
+
+INSERT INTO t_dedup_sparse_top_src SELECT number, number < 5 FROM numbers(20000);
+
+SELECT 'top level column is sparse', serialization_kind FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_dedup_sparse_top_src' AND column = 'flag' AND active;
+
+CREATE TABLE t_dedup_sparse_top_dst (id UInt64, flag Bool)
+ENGINE = MergeTree ORDER BY id
+SETTINGS non_replicated_deduplication_window = 100, ratio_of_defaults_for_sparse_serialization = 0.9;
+
+INSERT INTO t_dedup_sparse_top_dst SELECT * FROM t_dedup_sparse_top_src SETTINGS insert_deduplication_token = 'token_4';
+INSERT INTO t_dedup_sparse_top_dst SELECT * FROM t_dedup_sparse_top_src SETTINGS insert_deduplication_token = 'token_4';
+SELECT 'top level sparse, repeated insert deduplicated', count() FROM t_dedup_sparse_top_dst;
+
+-- An insert of the same sparse data without deduplication must still append.
+CREATE TABLE t_dedup_sparse_plain_dst (id UInt64, body Tuple(key UInt64, flag Bool))
+ENGINE = MergeTree ORDER BY id
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9;
+
+INSERT INTO t_dedup_sparse_plain_dst SELECT * FROM t_dedup_sparse_src;
+INSERT INTO t_dedup_sparse_plain_dst SELECT * FROM t_dedup_sparse_src;
+SELECT 'insert without deduplication appends', count() FROM t_dedup_sparse_plain_dst;
+
+DROP VIEW t_dedup_sparse_mv;
+DROP TABLE t_dedup_sparse_plain_dst;
+DROP TABLE t_dedup_sparse_top_dst;
+DROP TABLE t_dedup_sparse_top_src;
+DROP TABLE t_dedup_sparse_mv_target;
+DROP TABLE t_dedup_sparse_landing;
+DROP TABLE t_dedup_sparse_nested_dst;
+DROP TABLE t_dedup_sparse_nested_src;
+DROP TABLE t_dedup_sparse_dst;
+DROP TABLE t_dedup_sparse_src;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/112018
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/112018

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Test-only. Issue #112018 reported that repeating an identical `INSERT ... SELECT` with the same `insert_deduplication_token`, into a MergeTree table whose column is a `Tuple` with a sparse-serialized element, raised `Block structure mismatch in function connect between SourceFromSingleChunk and ConvertingTransform`. Two fixes landed on 2026-07-30 by different mechanisms, https://github.com/ClickHouse/ClickHouse/pull/111103 (`goRetry` returns early on empty input, before building the retry pipeline) and https://github.com/ClickHouse/ClickHouse/pull/111191 (`haveCompatibleColumnStructure` recurses into `ColumnTuple`). Neither shipped a test for the sparse shape, and no test on master combines insert deduplication with sparse serialization, so I am adding the missing coverage.

The test has 7 cases: a sparse element in a `Tuple`, a doubly nested `Tuple`, a materialized-view target, plus controls for a top-level sparse column, an insert without deduplication, sparse serialization surviving on disk after the retry, and deduplication actually dropping the rows.

What it guards is the end-to-end behaviour, not either fix individually. Every deduplicating case uses one token per insert, so on the repeat all tokens collide and `goRetry` receives an empty block. #111103's guard therefore returns before #111191's structure check is consulted, and reverting either fix alone leaves the test green. Reverting both reproduces the reported message exactly. A partial-deduplication case, which would deliver a non-empty sparse block and pin the `Block.cpp` side alone, is not included here and is left as a follow-up.

This shape has not shown up in CI on its own: the reported pair `between SourceFromSingleChunk and ConvertingTransform` has zero rows in 90 days of CIDB, and the issue came from a user report. So this is regression protection for a logical error that is cheap to reintroduce silently, not a fix for CI noise.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.766` (included in `26.8` and later)
<!-- ch-version-info:end -->