### PR TITLE
CI: skip `Build profile diff` for documentation-only changes

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -208,6 +208,9 @@ def should_skip_job(job_name):
         print("WARNING: no changed files found for PR - do not filter jobs")
         return False, ""
 
+    if job_name == JobNames.BUILD_PROFILE_DIFF and only_docs(changed_files):
+        return True, "Skipped, only documentation changed"
+
     # Run Keeper Stress jobs only when there are changes in src/Coordination,
     # tests/stress/keeper, or ci/jobs/keeper_stress_job.py
     if job_name == KEEPER_STRESS_PR_NAME:

--- a/ci/tests/test_config_job_no_cidb.py
+++ b/ci/tests/test_config_job_no_cidb.py
@@ -174,6 +174,34 @@ def test_merge_queue_jobs_are_filtered_without_cidb(monkeypatch):
     assert calls == [], f"config-time CIDB requests: {calls}"
 
 
+def test_build_profile_diff_skipped_for_docs_only_changes(monkeypatch):
+    _use_fake_info(
+        monkeypatch,
+        changed_files=("docs/en/development/continuous-integration.md",),
+    )
+
+    assert fj.should_skip_job(fj.JobNames.BUILD_PROFILE_DIFF) == (
+        True,
+        "Skipped, only documentation changed",
+    )
+
+
+@pytest.mark.parametrize(
+    "changed_files",
+    [
+        ("src/Core/Settings.cpp",),
+        (
+            "docs/en/development/continuous-integration.md",
+            "src/Core/Settings.cpp",
+        ),
+    ],
+)
+def test_build_profile_diff_runs_for_non_docs_changes(monkeypatch, changed_files):
+    _use_fake_info(monkeypatch, changed_files=changed_files)
+
+    assert fj.should_skip_job(fj.JobNames.BUILD_PROFILE_DIFF) == (False, "")
+
+
 def test_cidb_outage_changes_no_filter_decision(monkeypatch):
     """A CIDB outage must degrade to "run the default set", not drop the matrix.
 


### PR DESCRIPTION
Skip `Build profile diff` when every changed file is documentation. The profile comparison always requires `Build (arm_release)`, so keeping it affected defeated change-based job filtering and compiled ClickHouse for docs-only pull requests.

The filter now skips the comparison before required-artifact rescue. Pull requests containing source changes continue to run it.

Related: https://github.com/ClickHouse/ClickHouse/pull/111164
Related: https://github.com/ClickHouse/ClickHouse/pull/113082

Validated with `ci/tests/test_config_job_no_cidb.py` and `ci/tests/test_job_filtering.py` (23 tests passed).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.688` (included in `26.8` and later)
<!-- ch-version-info:end -->