### PR TITLE
Docs: fix unclosed code fence in `s3` table function docs

### DIFF
--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -736,6 +736,7 @@ SELECT
     data
 FROM s3('https://bucket-name/*.avro', 'Avro')
 SETTINGS schema_inference_mode='union';
+```
 
 ## Related {#related}
 


### PR DESCRIPTION
Close the SQL example fence in the embedded `s3` table function documentation. Without the closing fence, generated Mintlify documentation renders the following related links as part of the code block.

Related: https://github.com/ClickHouse/ClickHouse/pull/112141

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Close an unclosed code fence in the `s3` table function documentation.