### PR TITLE
Docs: clarify the lambda-based `WITH` example

### DIFF
--- a/docs/en/sql-reference/statements/select/with.md
+++ b/docs/en/sql-reference/statements/select/with.md
@@ -272,16 +272,14 @@ ORDER BY table_disk_usage DESC
 LIMIT 10;
 ```
 
-**Example 6:** Reusing a lambda-defined common scalar expression in a subquery
-
-Define the common scalar expression as a lambda so that its argument is explicitly bound:
+**Example 6:** Reusing a common scalar expression in a subquery
 
 ```sql
 WITH (value) -> value + 1 AS increment
-SELECT increment(first_result) AS second_increment
+SELECT increment(first_increment) AS second_increment
 FROM
 (
-    SELECT increment(number) AS first_result
+    SELECT increment(number) AS first_increment
     FROM numbers(3)
 );
 ```

--- a/docs/en/sql-reference/statements/select/with.md
+++ b/docs/en/sql-reference/statements/select/with.md
@@ -272,7 +272,7 @@ ORDER BY table_disk_usage DESC
 LIMIT 10;
 ```
 
-**Example 6:** Reusing a common scalar expression in a subquery
+**Example 6:** Reusing a lambda-defined common scalar expression in a subquery
 
 Define the common scalar expression as a lambda so that its argument is explicitly bound:
 

--- a/docs/en/sql-reference/statements/select/with.md
+++ b/docs/en/sql-reference/statements/select/with.md
@@ -274,12 +274,14 @@ LIMIT 10;
 
 **Example 6:** Reusing a common scalar expression in a subquery
 
+Define the common scalar expression as a lambda so that its argument is explicitly bound:
+
 ```sql
 WITH (value) -> value + 1 AS increment
-SELECT increment(first_increment) AS second_increment
+SELECT increment(first_result) AS second_increment
 FROM
 (
-    SELECT increment(number) AS first_increment
+    SELECT increment(number) AS first_result
     FROM numbers(3)
 );
 ```

--- a/docs/reference/statements/select/with.mdx
+++ b/docs/reference/statements/select/with.mdx
@@ -272,14 +272,16 @@ ORDER BY table_disk_usage DESC
 LIMIT 10;
 ```
 
-**Example 6:** Reusing a common scalar expression in a subquery
+**Example 6:** Reusing a lambda-defined common scalar expression in a subquery
+
+Define the common scalar expression as a lambda so that its argument is explicitly bound:
 
 ```sql
 WITH (value) -> value + 1 AS increment
-SELECT increment(first_increment) AS second_increment
+SELECT increment(first_result) AS second_increment
 FROM
 (
-    SELECT increment(number) AS first_increment
+    SELECT increment(number) AS first_result
     FROM numbers(3)
 );
 ```


### PR DESCRIPTION
The Russian translation of the `WITH` documentation shows a stale, invalid self-referencing CTE in Example 6:
https://clickhouse.com/docs/ru/reference/statements/select/with

This updates `docs/reference/statements/select/with.mdx`, the current documentation source, to make the valid lambda-based common scalar expression explicit and renames its intermediate alias to `first_result`. The source change allows the translation pipeline to resynchronize the runnable SQL example across localized documentation.


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.807` (included in `26.8` and later)
<!-- ch-version-info:end -->