### PR TITLE
Docs: document `part_storage_type` version availability

### DIFF
--- a/docs/resources/support-center/knowledge-base/data-management/understanding-part-types-and-storage-formats.mdx
+++ b/docs/resources/support-center/knowledge-base/data-management/understanding-part-types-and-storage-formats.mdx
@@ -128,6 +128,10 @@ These two concepts are orthogonal and you can have any combination:
 
 You can inspect the part type and part storage type of existing parts using the [`system.parts`](/reference/system-tables/parts) table:
 
+<Note>
+In open-source ClickHouse, `part_storage_type` is exposed by `system.parts` starting with version 26.9. In version 26.8 and earlier, omit `part_storage_type` from the query and group and order only by `part_type`.
+</Note>
+
 ```sql
 SELECT
     part_type,


### PR DESCRIPTION
Document that `system.parts.part_storage_type` is available in open-source ClickHouse starting with version 26.9 and explain how to adapt the example query on earlier versions.

The current example raises `UNKNOWN_IDENTIFIER` on released versions that do not expose the column. This note gives those readers version-specific guidance while preserving the current query for newer releases.

Affected page: https://clickhouse.com/docs/ru/resources/support-center/knowledge-base/data-management/understanding-part-types-and-storage-formats

Validated with the scoped Mintlify documentation validator.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.709` (included in `26.8` and later)
<!-- ch-version-info:end -->