### PR TITLE
Docs: remove early upgrades from Cloud tiers

### DIFF
--- a/docs/products/cloud/features/cloud-tiers.mdx
+++ b/docs/products/cloud/features/cloud-tiers.mdx
@@ -74,12 +74,6 @@ This page discusses which tiers are right for your specific use case.
     <td>✓</td>
   </tr>
   <tr>
-    <td>Early upgrades</td>
-    <td></td>
-    <td>✓</td>
-    <td>✓</td>
-  </tr>
-  <tr>
     <td>Compute-compute separation</td>
     <td></td>
     <td>✓</td>


### PR DESCRIPTION
Removes the `Early upgrades` row from the ClickHouse Cloud tiers comparison because the feature should no longer be listed there. It is not listed on the website pricing page.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.