### PR TITLE
Fix data race on the transaction pointer in PostgreSQLSource

### DIFF
--- a/src/Core/PostgreSQL/ConnectionHolder.h
+++ b/src/Core/PostgreSQL/ConnectionHolder.h
@@ -9,6 +9,8 @@
 #include <base/BorrowedObjectPool.h>
 #include <Core/PostgreSQL/Connection.h>
 
+#include <atomic>
+
 
 namespace postgres
 {
@@ -64,7 +66,8 @@ private:
     PoolPtr pool;
     ConnectionPtr connection;
     bool auto_close;
-    bool is_broken = false;
+    /// Written by the cancelling thread and by the thread that starts the read, which can race.
+    std::atomic<bool> is_broken = false;
 };
 
 using ConnectionHolderPtr = std::unique_ptr<ConnectionHolder>;

--- a/src/Processors/Sources/PostgreSQLSource.cpp
+++ b/src/Processors/Sources/PostgreSQLSource.cpp
@@ -74,6 +74,35 @@ void PostgreSQLSource<T>::init(const Block & sample_block)
 }
 
 
+/// Finalizes the state of the source: cancels the query still running on the connection, closes the
+/// COPY stream and marks the connection broken. A null argument means there is nothing of that kind
+/// to finalize. Must be called with tx_mutex released, since the calls below block.
+template<typename T>
+void PostgreSQLSource<T>::finalize(const std::shared_ptr<T> & tx_to_cancel, pqxx::stream_from * stream_to_close) noexcept
+{
+    try
+    {
+        if (tx_to_cancel)
+        {
+            /// libpq forbids two threads from manipulating one connection at a time.
+            std::lock_guard lock(cancel_mutex);
+            tx_to_cancel->conn().cancel_query();
+        }
+
+        /// Closing it here keeps the exception out of the transaction's pending error, where it
+        /// would hide the message.
+        if (stream_to_close)
+            stream_to_close->close();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+
+    if (connection_holder)
+        connection_holder->setBroken();
+}
+
 template<typename T>
 void PostgreSQLSource<T>::onStart()
 {
@@ -101,11 +130,11 @@ void PostgreSQLSource<T>::onStart()
 
     /// A cancel arriving while the transaction was being constructed saw `tx` still null, so it
     /// consumed `is_completed` and skipped its own teardown. Do that teardown here, otherwise the
-    /// connection is returned to the pool with the transaction left open.
+    /// connection is returned to the pool with the transaction left open. No statement was issued
+    /// on it yet, so there is nothing to cancel.
     if (is_completed.load())
     {
-        if (connection_holder)
-            connection_holder->setBroken();
+        finalize(nullptr, nullptr);
         return;
     }
 
@@ -116,24 +145,7 @@ void PostgreSQLSource<T>::onStart()
     /// interrupted nothing, and it consumed `is_completed`, so the destructor returns early and
     /// does not cancel it either. Cancel it here, where it exists.
     if (is_completed.load())
-    {
-        try
-        {
-            {
-                /// That cancel may still be inside cancel_query() on this same connection.
-                std::lock_guard lock(cancel_mutex);
-                tx->conn().cancel_query();
-            }
-            stream->close();
-        }
-        catch (...)
-        {
-            tryLogCurrentException(__PRETTY_FUNCTION__);
-        }
-
-        if (connection_holder)
-            connection_holder->setBroken();
-    }
+        finalize(tx, stream.get());
 }
 
 template<typename T>
@@ -248,18 +260,8 @@ void PostgreSQLSource<T>::onCancel() noexcept
         /// The code is executed only if onStart() was not finished mainly due to freezing on pqxx::from_query
         if (!started.load() && tx_snapshot && tx_snapshot->conn().is_open())
         {
-            try
-            {
-                std::lock_guard lock(cancel_mutex);
-                tx_snapshot->conn().cancel_query();
-            }
-            catch (...)
-            {
-                tryLogCurrentException(__PRETTY_FUNCTION__);
-            }
-
-            if (connection_holder)
-                connection_holder->setBroken();
+            /// `stream` belongs to onStart(), which is still running, so it is not touched here.
+            finalize(tx_snapshot, nullptr);
         }
     }
     catch (...)
@@ -275,32 +277,11 @@ PostgreSQLSource<T>::~PostgreSQLSource()
     if (is_completed.exchange(true))
         return;
 
-    try
-    {
-        if (stream)
-        {
-            /** Internally libpqxx::stream_from runs PostgreSQL copy query `COPY query TO STDOUT`.
-                 * During transaction abort we try to execute PostgreSQL `ROLLBACK` command and if
-                 * copy query is not cancelled, we wait until it finishes.
-                 */
-            tx->conn().cancel_query();
-
-            /** If stream is not closed, libpqxx::stream_from closes stream in destructor, but that way
-                 * exception is added into transaction pending error and we can potentially ignore exception message.
-                 */
-            stream->close();
-        }
-    }
-    catch (...)
-    {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
-    }
+    /// Without cancelling the COPY the ROLLBACK issued during transaction abort waits for it.
+    finalize(stream ? tx : nullptr, stream.get());
 
     stream.reset();
     tx.reset();
-
-    if (connection_holder)
-        connection_holder->setBroken();
 }
 
 template

--- a/src/Processors/Sources/PostgreSQLSource.cpp
+++ b/src/Processors/Sources/PostgreSQLSource.cpp
@@ -84,7 +84,8 @@ void PostgreSQLSource<T>::finalize(const std::shared_ptr<T> & tx_to_cancel, pqxx
     {
         if (tx_to_cancel)
         {
-            /// libpq forbids two threads from manipulating one connection at a time.
+            /// `cancel_query` reads the connection to build its `PGcancel`, so onCancel() and the
+            /// destructor must not reach it at once. It does not make the connection shareable.
             std::lock_guard lock(cancel_mutex);
             tx_to_cancel->conn().cancel_query();
         }
@@ -106,7 +107,7 @@ void PostgreSQLSource<T>::finalize(const std::shared_ptr<T> & tx_to_cancel, pqxx
 template<typename T>
 void PostgreSQLSource<T>::onStart()
 {
-    if (is_completed.load())
+    if (stop_requested.load())
         return;
 
     if (!tx)
@@ -123,29 +124,28 @@ void PostgreSQLSource<T>::onStart()
             connection_holder->update();
             new_tx = std::make_shared<T>(connection_holder->get());
         }
+        catch (...)
+        {
+            /// BEGIN failed on a connection we already took out of the pool - do not hand it back
+            /// for reuse. The destructor cannot do this: there is no transaction for it to see.
+            connection_holder->setBroken();
+            throw;
+        }
 
         std::lock_guard lock(tx_mutex);
         tx = std::move(new_tx);
     }
 
-    /// A cancel arriving while the transaction was being constructed saw `tx` still null, so it
-    /// consumed `is_completed` and skipped its own teardown. Do that teardown here, otherwise the
-    /// connection is returned to the pool with the transaction left open. No statement was issued
-    /// on it yet, so there is nothing to cancel.
-    if (is_completed.load())
-    {
-        finalize(nullptr, nullptr);
+    /// A cancel during the constructor found `tx` null and could only ask us to stop. Do not open
+    /// the COPY then - the destructor tears the transaction down.
+    if (stop_requested.load())
         return;
-    }
 
     LOG_TEST(getLogger("PostgreSQLSource"), "Stream data from database");
     stream = std::make_unique<pqxx::stream_from>(*tx, pqxx::from_query, std::string_view{query_str});
 
-    /// A cancel arriving while the COPY was starting ran before the backend had it, so it
-    /// interrupted nothing, and it consumed `is_completed`, so the destructor returns early and
-    /// does not cancel it either. Cancel it here, where it exists.
-    if (is_completed.load())
-        finalize(tx, stream.get());
+    /// No recheck for a cancel racing the line above: it may have interrupted nothing, and the
+    /// destructor cancels the stream that exists by then.
 }
 
 template<typename T>
@@ -158,15 +158,19 @@ IProcessor::Status PostgreSQLSource<T>::prepare()
     }
 
     auto status = ISource::prepare();
-    if (status == Status::Finished)
+    if (status == Status::Finished && !stop_requested.load())
     {
+        /// Only a finish that was not cancelled commits here and claims the teardown. After a
+        /// cancel it is left to the destructor: the cancelling thread may still be in
+        /// `cancel_query` on this connection, and a `COMMIT` racing it is what libpq forbids.
         if (stream)
             stream->close();
 
         if (tx && auto_commit)
             tx->commit();
 
-        is_completed.store(true);
+        stop_requested.store(true);
+        finalized.store(true);
     }
 
     return status;
@@ -178,7 +182,7 @@ Chunk PostgreSQLSource<T>::generate()
     LOG_TEST(getLogger("PostgreSQLSource"), "Generate a chunk from stream");
 
     /// Check if source was cancelled or completed
-    if (is_completed.load() || isCancelled())
+    if (stop_requested.load() || isCancelled())
         return {};
 
     /// Check if pqxx::stream_from is finished
@@ -188,7 +192,7 @@ Chunk PostgreSQLSource<T>::generate()
     MutableColumns columns = description.sample_block.cloneEmptyColumns();
     size_t num_rows = 0;
 
-    while (!isCancelled() && !is_completed.load())
+    while (!isCancelled() && !stop_requested.load())
     {
         const std::vector<pqxx::zview> * row{stream->read_row()};
 
@@ -243,9 +247,9 @@ Chunk PostgreSQLSource<T>::generate()
 template<typename T>
 void PostgreSQLSource<T>::onCancel() noexcept
 {
-    /// Use atomic flag to prevent double-cancellation
-    if (is_completed.exchange(true))
-        return;
+    /// A signal, not a claim on the teardown: this runs while onStart() may still be creating `tx`
+    /// and `stream`, so it cannot finish the job, and taking the claim here would leave nobody to.
+    stop_requested.store(true);
 
     /// Outer try/catch: this function is noexcept, and locking tx_mutex may throw.
     try
@@ -257,7 +261,9 @@ void PostgreSQLSource<T>::onCancel() noexcept
             tx_snapshot = tx;
         }
 
-        /// The code is executed only if onStart() was not finished mainly due to freezing on pqxx::from_query
+        /// Interrupt the connection only while onStart() is blocked on it (typically in
+        /// pqxx::from_query). Once streaming, the pipeline thread owns it, so the flag has to be
+        /// enough: generate() drops out between rows and the destructor then cancels the COPY.
         if (!started.load() && tx_snapshot && tx_snapshot->conn().is_open())
         {
             /// `stream` belongs to onStart(), which is still running, so it is not touched here.
@@ -273,12 +279,11 @@ void PostgreSQLSource<T>::onCancel() noexcept
 template<typename T>
 PostgreSQLSource<T>::~PostgreSQLSource()
 {
-    /// Use atomic flag to prevent double cleanup
-    if (is_completed.exchange(true))
-        return;
-
-    /// Without cancelling the COPY the ROLLBACK issued during transaction abort waits for it.
-    finalize(stream ? tx : nullptr, stream.get());
+    /// The teardown owner for every path but a clean finish, which prepare() claims. Without
+    /// cancelling the COPY the ROLLBACK issued during transaction abort waits for it. With no
+    /// transaction nothing reached the connection, so it stays healthy and is left in the pool.
+    if (!finalized.exchange(true) && tx)
+        finalize(stream ? tx : nullptr, stream.get());
 
     stream.reset();
     tx.reset();

--- a/src/Processors/Sources/PostgreSQLSource.cpp
+++ b/src/Processors/Sources/PostgreSQLSource.cpp
@@ -119,7 +119,11 @@ void PostgreSQLSource<T>::onStart()
     {
         try
         {
-            tx->conn().cancel_query();
+            {
+                /// That cancel may still be inside cancel_query() on this same connection.
+                std::lock_guard lock(cancel_mutex);
+                tx->conn().cancel_query();
+            }
             stream->close();
         }
         catch (...)
@@ -246,6 +250,7 @@ void PostgreSQLSource<T>::onCancel() noexcept
         {
             try
             {
+                std::lock_guard lock(cancel_mutex);
                 tx_snapshot->conn().cancel_query();
             }
             catch (...)

--- a/src/Processors/Sources/PostgreSQLSource.cpp
+++ b/src/Processors/Sources/PostgreSQLSource.cpp
@@ -99,6 +99,16 @@ void PostgreSQLSource<T>::onStart()
         tx = std::move(new_tx);
     }
 
+    /// A cancel arriving while the transaction was being constructed saw `tx` still null, so it
+    /// consumed `is_completed` and skipped its own teardown. Do that teardown here, otherwise the
+    /// connection is returned to the pool with the transaction left open.
+    if (is_completed.load())
+    {
+        if (connection_holder)
+            connection_holder->setBroken();
+        return;
+    }
+
     LOG_TEST(getLogger("PostgreSQLSource"), "Stream data from database");
     stream = std::make_unique<pqxx::stream_from>(*tx, pqxx::from_query, std::string_view{query_str});
 }

--- a/src/Processors/Sources/PostgreSQLSource.cpp
+++ b/src/Processors/Sources/PostgreSQLSource.cpp
@@ -111,6 +111,25 @@ void PostgreSQLSource<T>::onStart()
 
     LOG_TEST(getLogger("PostgreSQLSource"), "Stream data from database");
     stream = std::make_unique<pqxx::stream_from>(*tx, pqxx::from_query, std::string_view{query_str});
+
+    /// A cancel arriving while the COPY was starting ran before the backend had it, so it
+    /// interrupted nothing, and it consumed `is_completed`, so the destructor returns early and
+    /// does not cancel it either. Cancel it here, where it exists.
+    if (is_completed.load())
+    {
+        try
+        {
+            tx->conn().cancel_query();
+            stream->close();
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+
+        if (connection_holder)
+            connection_holder->setBroken();
+    }
 }
 
 template<typename T>

--- a/src/Processors/Sources/PostgreSQLSource.cpp
+++ b/src/Processors/Sources/PostgreSQLSource.cpp
@@ -82,16 +82,21 @@ void PostgreSQLSource<T>::onStart()
 
     if (!tx)
     {
+        /// Construct outside tx_mutex: the transaction constructor issues BEGIN, i.e. network I/O.
+        std::shared_ptr<T> new_tx;
         try
         {
             auto & conn = connection_holder->get();
-            tx = std::make_shared<T>(conn);
+            new_tx = std::make_shared<T>(conn);
         }
         catch (const pqxx::broken_connection &)
         {
             connection_holder->update();
-            tx = std::make_shared<T>(connection_holder->get());
+            new_tx = std::make_shared<T>(connection_holder->get());
         }
+
+        std::lock_guard lock(tx_mutex);
+        tx = std::move(new_tx);
     }
 
     LOG_TEST(getLogger("PostgreSQLSource"), "Stream data from database");
@@ -197,20 +202,35 @@ void PostgreSQLSource<T>::onCancel() noexcept
     if (is_completed.exchange(true))
         return;
 
-    /// The code is executed only if onStart() was not finished mainly due to freezing on pqxx::from_query
-    if (!started.load() && tx && tx->conn().is_open())
+    /// Outer try/catch: this function is noexcept, and locking tx_mutex may throw.
+    try
     {
-        try
+        /// Snapshot under the lock, then use it with the lock released: the pqxx calls below block.
+        std::shared_ptr<T> tx_snapshot;
         {
-            tx->conn().cancel_query();
-        }
-        catch (...)
-        {
-            tryLogCurrentException(__PRETTY_FUNCTION__);
+            std::lock_guard lock(tx_mutex);
+            tx_snapshot = tx;
         }
 
-        if (connection_holder)
-            connection_holder->setBroken();
+        /// The code is executed only if onStart() was not finished mainly due to freezing on pqxx::from_query
+        if (!started.load() && tx_snapshot && tx_snapshot->conn().is_open())
+        {
+            try
+            {
+                tx_snapshot->conn().cancel_query();
+            }
+            catch (...)
+            {
+                tryLogCurrentException(__PRETTY_FUNCTION__);
+            }
+
+            if (connection_holder)
+                connection_holder->setBroken();
+        }
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
     }
 }
 

--- a/src/Processors/Sources/PostgreSQLSource.h
+++ b/src/Processors/Sources/PostgreSQLSource.h
@@ -61,6 +61,11 @@ private:
     /// cancelling thread while onStart() is still in flight. Must not be held across pqxx calls.
     std::mutex tx_mutex;
 
+    /// libpq forbids two threads from manipulating one connection at a time, and onStart() and
+    /// onCancel() can both cancel on the same one. Only ever held across cancel_query(), and only
+    /// ever taken with tx_mutex released.
+    std::mutex cancel_mutex;
+
     postgres::ConnectionHolderPtr connection_holder;
 
     UnorderedMapWithMemoryTracking<size_t, PostgreSQLArrayInfo> array_info;

--- a/src/Processors/Sources/PostgreSQLSource.h
+++ b/src/Processors/Sources/PostgreSQLSource.h
@@ -50,6 +50,8 @@ protected:
 private:
     void init(const Block & sample_block);
 
+    void finalize(const std::shared_ptr<T> & tx_to_cancel, pqxx::stream_from * stream_to_close) noexcept;
+
     const UInt64 max_block_size;
     bool auto_commit = true;
     ExternalResultDescription description;
@@ -57,13 +59,7 @@ private:
     std::atomic<bool> started{false};
     std::atomic<bool> is_completed{false};
 
-    /// Serializes publication of `tx` in onStart() against the read in onCancel(), which runs on the
-    /// cancelling thread while onStart() is still in flight. Must not be held across pqxx calls.
     std::mutex tx_mutex;
-
-    /// libpq forbids two threads from manipulating one connection at a time, and onStart() and
-    /// onCancel() can both cancel on the same one. Only ever held across cancel_query(), and only
-    /// ever taken with tx_mutex released.
     std::mutex cancel_mutex;
 
     postgres::ConnectionHolderPtr connection_holder;

--- a/src/Processors/Sources/PostgreSQLSource.h
+++ b/src/Processors/Sources/PostgreSQLSource.h
@@ -57,9 +57,15 @@ private:
     ExternalResultDescription description;
 
     std::atomic<bool> started{false};
-    std::atomic<bool> is_completed{false};
+    /// Asks the read to stop. A signal only: it never takes the teardown from whoever owes it.
+    std::atomic<bool> stop_requested{false};
+    /// Claimed once by whoever tears the connection down: prepare() on an uncancelled finish, else
+    /// the destructor. onCancel()'s interrupt does not claim it - it cannot close the stream.
+    std::atomic<bool> finalized{false};
 
+    /// tx and stream are written only by the pipeline thread; this is for onCancel() to read tx.
     std::mutex tx_mutex;
+    /// Serializes the cancel_query() in finalize() between onCancel() and the destructor.
     std::mutex cancel_mutex;
 
     postgres::ConnectionHolderPtr connection_holder;

--- a/src/Processors/Sources/PostgreSQLSource.h
+++ b/src/Processors/Sources/PostgreSQLSource.h
@@ -10,6 +10,8 @@
 #include <Core/PostgreSQL/ConnectionHolder.h>
 #include <Core/PostgreSQL/Utils.h>
 
+#include <mutex>
+
 
 namespace DB
 {
@@ -54,6 +56,10 @@ private:
 
     std::atomic<bool> started{false};
     std::atomic<bool> is_completed{false};
+
+    /// Serializes publication of `tx` in onStart() against the read in onCancel(), which runs on the
+    /// cancelling thread while onStart() is still in flight. Must not be held across pqxx calls.
+    std::mutex tx_mutex;
 
     postgres::ConnectionHolderPtr connection_holder;
 

--- a/tests/integration/test_postgresql_kill_query/test.py
+++ b/tests/integration/test_postgresql_kill_query/test.py
@@ -226,6 +226,9 @@ class StatementStallingProxy:
 
     def _pump(self, source, destination, is_client_to_server):
         stalled_once = False
+        # TCP is a stream, so the marker can straddle two reads. Keep the last few bytes of the
+        # previous one to search across the boundary.
+        carry = b""
         while not self._stop:
             try:
                 data = source.recv(4096)
@@ -236,7 +239,13 @@ class StatementStallingProxy:
             if not data:
                 break
 
-            if is_client_to_server and not stalled_once and self._marker in data:
+            seen_marker = False
+            if is_client_to_server and not stalled_once:
+                seen_marker = self._marker in carry + data
+                keep = len(self._marker) - 1
+                carry = (carry + data)[-keep:] if keep else b""
+
+            if seen_marker:
                 stalled_once = True
                 if self._should_stall():
                     self._stalled.set()
@@ -308,10 +317,10 @@ class StatementStallingProxy:
 def test_kill_query_while_transaction_is_starting(started_cluster, setup_infinite_query):
     """A cancel arriving while the transaction is still being constructed must not be lost.
 
-    In that window `onStart` has not published `tx`, so `onCancel` cannot cancel anything --
-    it only consumes the one-shot `is_completed` flag. Without a recheck after publication,
-    `onStart` then proceeds into the blocking COPY and the cancellation is dropped, so the
-    query keeps running until PostgreSQL finishes it on its own.
+    In that window `onStart` has not published `tx`, so `onCancel` cannot reach the connection
+    and only raises `stop_requested`. `onStart` has to honour that flag once the transaction is
+    published, instead of proceeding into the blocking COPY, or the cancellation is dropped and
+    the query keeps running until PostgreSQL finishes it on its own.
     """
     _, _ = setup_infinite_query
     proxy = StatementStallingProxy(marker=StatementStallingProxy.BEGIN)
@@ -388,9 +397,9 @@ ENGINE = PostgreSQL(
         )
     finally:
         # A failed assertion must not leave the read, the proxy or the table behind for the
-        # tests that run after this one. Tear the proxy down before joining: the first cancel
-        # already consumed `is_completed`, so a second KILL QUERY can be a no-op, and dropping
-        # the connection is then what ends a read that reached the endless COPY.
+        # tests that run after this one. Tear the proxy down before joining: a second KILL QUERY
+        # can find the source already streaming, where `onCancel` leaves the connection to the
+        # pipeline thread, and dropping the connection is then what ends the endless COPY.
         node1.query(f"KILL QUERY WHERE query_id='{query_id}' ASYNC", ignore_error=True)
         proxy.stop()
         query_thread.join(timeout=60)
@@ -405,9 +414,9 @@ def test_kill_query_while_copy_is_starting(started_cluster, setup_streaming_view
     This is one step later than `test_kill_query_while_transaction_is_starting`. Here `tx` is
     already published, so `onCancel` does call `cancel_query()` -- but no statement is running
     on that connection yet, so PostgreSQL has nothing to interrupt and the cancel is dropped.
-    `onStart` then opens the COPY anyway, and nothing cancels it afterwards: `onCancel` already
-    consumed the one-shot `is_completed` flag, so the destructor returns early and never
-    reaches its own `cancel_query()`, which leaves the rollback waiting for the COPY.
+    `onStart` opens the COPY straight afterwards, so the destructor has to be the one that
+    cancels it. If a cancel could take the teardown away from it, nothing would, and the
+    rollback would sit waiting for the COPY.
 
     Stalling the COPY request rather than the `BEGIN` is what places the cancel in this
     window; `test_kill_query_while_transaction_is_starting` cannot reach it, because there

--- a/tests/integration/test_postgresql_kill_query/test.py
+++ b/tests/integration/test_postgresql_kill_query/test.py
@@ -95,6 +95,45 @@ SELECT sleepy_start() AS id;"""
 
 
 @pytest.fixture(scope="module")
+def setup_streaming_view(started_cluster):
+    """A view whose COPY starts streaming at once but keeps running for a long time.
+
+    `infinite_counter` cannot be used for this: it is a plpgsql `SETOF` function, so
+    PostgreSQL builds its whole result set before the first row and never sends
+    `CopyOutResponse`. `pqxx::stream_from`'s constructor then blocks and `onStart` never
+    regains control, which is a different window from the one under test here.
+
+    The leading bulk rows make PostgreSQL send `CopyOutResponse` immediately, so the
+    constructor returns; the sleeping tail keeps the COPY running long enough to cancel it. A
+    single fast row is not enough, because `CopyOutResponse` is not sent until there is a
+    buffer of output to send with it.
+    """
+    conn = get_postgres_conn(
+        started_cluster.postgres_ip, started_cluster.postgres_port, database=True
+    )
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """CREATE TABLE streaming_head AS
+SELECT g AS counter, repeat('y', 900) AS pad FROM generate_series(1, 20000) g;"""
+    )
+    cursor.execute(
+        """CREATE OR REPLACE VIEW streaming_counter AS
+SELECT counter FROM streaming_head
+UNION ALL
+SELECT g FROM generate_series(1, 600) g
+CROSS JOIN LATERAL (SELECT pg_sleep(0.5) WHERE g IS NOT NULL) s;"""
+    )
+
+    yield
+
+    cursor.execute("DROP VIEW IF EXISTS streaming_counter")
+    cursor.execute("DROP TABLE IF EXISTS streaming_head")
+    cursor.close()
+    conn.close()
+
+
+@pytest.fixture(scope="module")
 def setup_big_data_table(started_cluster):
     # Connect to postgres_database database
     conn = get_postgres_conn(
@@ -149,13 +188,15 @@ def wait_for_proxy_listener_closed(host, port):
     raise AssertionError("PostgreSQL proxy listener is still accepting connections")
 
 
-class BeginStallingProxy:
-    """Forwards the PostgreSQL wire protocol, but withholds a `BEGIN READ ONLY` from the
-    server until release() is called.
+class StatementStallingProxy:
+    """Forwards the PostgreSQL wire protocol, but withholds the first client statement that
+    contains `marker` from the server until release() is called.
 
-    `pqxx::ReadTransaction`'s constructor issues that statement, so stalling it pins the
-    reading source inside the transaction constructor: `onStart` has not published `tx` yet,
-    which is exactly the window a cancel has to arrive in to be lost.
+    Stalling `BEGIN READ ONLY` pins the reading source inside `pqxx::ReadTransaction`'s
+    constructor, before `onStart` has published `tx`. Stalling the `COPY` pins it one step
+    later, inside `pqxx::stream_from`'s constructor, with `tx` published and still no
+    statement running on the connection. Those are the two startup windows in which a cancel
+    finds nothing to interrupt.
 
     `skip` exists because the source's transaction is not the only one on the wire. Reading
     through `postgresql()` without an explicit column list first fetches the table structure,
@@ -164,8 +205,10 @@ class BeginStallingProxy:
     """
 
     BEGIN = b"BEGIN READ ONLY"
+    COPY = b"COPY ("
 
-    def __init__(self, skip=0):
+    def __init__(self, skip=0, marker=BEGIN):
+        self._marker = marker
         self._skip = skip
         self._seen = 0
         self._seen_lock = threading.Lock()
@@ -193,7 +236,7 @@ class BeginStallingProxy:
             if not data:
                 break
 
-            if is_client_to_server and not stalled_once and self.BEGIN in data:
+            if is_client_to_server and not stalled_once and self._marker in data:
                 stalled_once = True
                 if self._should_stall():
                     self._stalled.set()
@@ -248,7 +291,7 @@ class BeginStallingProxy:
 
     def wait_until_stalled(self, timeout=60):
         if not self._stalled.wait(timeout=timeout):
-            raise AssertionError("proxy never saw BEGIN READ ONLY")
+            raise AssertionError(f"proxy never saw {self._marker.decode()}")
 
     def release(self):
         self._release.set()
@@ -271,14 +314,14 @@ def test_kill_query_while_transaction_is_starting(started_cluster, setup_infinit
     query keeps running until PostgreSQL finishes it on its own.
     """
     _, _ = setup_infinite_query
-    proxy = BeginStallingProxy()
+    proxy = StatementStallingProxy(marker=StatementStallingProxy.BEGIN)
     port = proxy.start((started_cluster.postgres_ip, started_cluster.postgres_port))
     proxy_host = socket.gethostbyname(socket.gethostname())
     query_id = str(uuid.uuid4())
     query_errors = []
 
     # An engine table with a declared structure, created before the proxy starts stalling, so
-    # that the read is the only thing that opens a transaction (see BeginStallingProxy).
+    # that the read is the only thing that opens a transaction (see StatementStallingProxy).
     node1.query("DROP TABLE IF EXISTS stalled_counter")
     node1.query(
         f"""CREATE TABLE stalled_counter (counter Nullable(Int32))
@@ -352,6 +395,104 @@ ENGINE = PostgreSQL(
         proxy.stop()
         query_thread.join(timeout=60)
         node1.query("DROP TABLE IF EXISTS stalled_counter")
+        assert not query_thread.is_alive(), "query thread outlived the test"
+
+
+def test_kill_query_while_copy_is_starting(started_cluster, setup_streaming_view):
+    """A cancel arriving after the transaction is published but before the COPY starts must
+    not be lost either.
+
+    This is one step later than `test_kill_query_while_transaction_is_starting`. Here `tx` is
+    already published, so `onCancel` does call `cancel_query()` -- but no statement is running
+    on that connection yet, so PostgreSQL has nothing to interrupt and the cancel is dropped.
+    `onStart` then opens the COPY anyway, and nothing cancels it afterwards: `onCancel` already
+    consumed the one-shot `is_completed` flag, so the destructor returns early and never
+    reaches its own `cancel_query()`, which leaves the rollback waiting for the COPY.
+
+    Stalling the COPY request rather than the `BEGIN` is what places the cancel in this
+    window; `test_kill_query_while_transaction_is_starting` cannot reach it, because there
+    the source is still pinned before publication.
+
+    The view has to start streaming promptly (see `setup_streaming_view`), otherwise
+    `stream_from`'s constructor never returns and the source is pinned before this window
+    instead of inside it.
+    """
+    proxy = StatementStallingProxy(marker=StatementStallingProxy.COPY)
+    port = proxy.start((started_cluster.postgres_ip, started_cluster.postgres_port))
+    proxy_host = socket.gethostbyname(socket.gethostname())
+    query_id = str(uuid.uuid4())
+    query_errors = []
+
+    node1.query("DROP TABLE IF EXISTS copy_stalled_counter")
+    node1.query(
+        f"""CREATE TABLE copy_stalled_counter (counter Nullable(Int32))
+ENGINE = PostgreSQL(
+    '{proxy_host}:{port}',
+    'postgres_database',
+    'streaming_counter',
+    'postgres',
+    'ClickHouse_PostgreSQL_P@ssw0rd')"""
+    )
+
+    def execute_query():
+        _, error = node1.query_and_get_answer_with_error(
+            "SELECT * FROM copy_stalled_counter",
+            query_id=query_id,
+            timeout=120,
+        )
+        query_errors.append(error)
+
+    query_thread = threading.Thread(target=execute_query)
+    query_thread.start()
+
+    try:
+        try:
+            # The source has published `tx` and is now pinned inside the `stream_from`
+            # constructor, with the COPY request withheld from the server.
+            proxy.wait_until_stalled()
+
+            assert_eq_with_retry(
+                node1,
+                f"SELECT count() FROM system.processes WHERE query_id='{query_id}'",
+                "1",
+                retry_count=60,
+                sleep_time=0.5,
+            )
+
+            node1.query(f"KILL QUERY WHERE query_id='{query_id}' ASYNC")
+            # Deliver the cancel while the COPY is still withheld, so that `onCancel` runs
+            # against a connection with no statement in progress.
+            assert_eq_with_retry(
+                node1,
+                f"SELECT is_cancelled FROM system.processes WHERE query_id='{query_id}'",
+                "1",
+                retry_count=60,
+                sleep_time=0.5,
+            )
+        finally:
+            proxy.release()
+
+        # Once the COPY reaches the server the read has to be abandoned. Without the fix the
+        # dropped cancel leaves the source streaming the view to its end, so this join times
+        # out.
+        query_thread.join(timeout=60)
+        assert (
+            not query_thread.is_alive()
+        ), "cancelled query kept running after the COPY started"
+        assert query_errors and "QUERY_WAS_CANCELLED" in query_errors[0], query_errors
+
+        assert_eq_with_retry(
+            node1,
+            f"SELECT count() FROM system.processes WHERE query_id='{query_id}'",
+            "0",
+            retry_count=60,
+            sleep_time=0.5,
+        )
+    finally:
+        node1.query(f"KILL QUERY WHERE query_id='{query_id}' ASYNC", ignore_error=True)
+        proxy.stop()
+        query_thread.join(timeout=60)
+        node1.query("DROP TABLE IF EXISTS copy_stalled_counter")
         assert not query_thread.is_alive(), "query thread outlived the test"
 
 

--- a/tests/integration/test_postgresql_kill_query/test.py
+++ b/tests/integration/test_postgresql_kill_query/test.py
@@ -345,11 +345,14 @@ ENGINE = PostgreSQL(
         )
     finally:
         # A failed assertion must not leave the read, the proxy or the table behind for the
-        # tests that run after this one.
+        # tests that run after this one. Tear the proxy down before joining: the first cancel
+        # already consumed `is_completed`, so a second KILL QUERY can be a no-op, and dropping
+        # the connection is then what ends a read that reached the endless COPY.
         node1.query(f"KILL QUERY WHERE query_id='{query_id}' ASYNC", ignore_error=True)
-        query_thread.join(timeout=60)
         proxy.stop()
+        query_thread.join(timeout=60)
         node1.query("DROP TABLE IF EXISTS stalled_counter")
+        assert not query_thread.is_alive(), "query thread outlived the test"
 
 
 def test_kill_query_when_postgresql_cancel_connection_fails(

--- a/tests/integration/test_postgresql_kill_query/test.py
+++ b/tests/integration/test_postgresql_kill_query/test.py
@@ -149,6 +149,200 @@ def wait_for_proxy_listener_closed(host, port):
     raise AssertionError("PostgreSQL proxy listener is still accepting connections")
 
 
+class BeginStallingProxy:
+    """Forwards the PostgreSQL wire protocol, but withholds a `BEGIN READ ONLY` from the
+    server until release() is called.
+
+    `pqxx::ReadTransaction`'s constructor issues that statement, so stalling it pins the
+    reading source inside the transaction constructor: `onStart` has not published `tx` yet,
+    which is exactly the window a cancel has to arrive in to be lost.
+
+    `skip` exists because the source's transaction is not the only one on the wire. Reading
+    through `postgresql()` without an explicit column list first fetches the table structure,
+    which opens its own read transaction. Stalling that earlier one pins the query in
+    analysis instead, where it is killed before a pipeline exists and the source never runs.
+    """
+
+    BEGIN = b"BEGIN READ ONLY"
+
+    def __init__(self, skip=0):
+        self._skip = skip
+        self._seen = 0
+        self._seen_lock = threading.Lock()
+        self._release = threading.Event()
+        self._stalled = threading.Event()
+        self._sock = None
+        self._threads = []
+        self._stop = False
+
+    def _should_stall(self):
+        # Connections are pumped by independent threads, so the counter is shared state.
+        with self._seen_lock:
+            self._seen += 1
+            return self._seen > self._skip
+
+    def _pump(self, source, destination, is_client_to_server):
+        stalled_once = False
+        while not self._stop:
+            try:
+                data = source.recv(4096)
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            if not data:
+                break
+
+            if is_client_to_server and not stalled_once and self.BEGIN in data:
+                stalled_once = True
+                if self._should_stall():
+                    self._stalled.set()
+                    # Hold the statement back. The bounded wait keeps a failure surfacing as
+                    # an assertion in the test body rather than as a hung worker.
+                    self._release.wait(timeout=60)
+
+            try:
+                destination.sendall(data)
+            except OSError:
+                break
+
+        for s in (source, destination):
+            try:
+                s.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+
+    def _serve(self):
+        while not self._stop:
+            try:
+                downstream, _ = self._sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+
+            upstream = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                upstream.connect(self._address)
+            except OSError:
+                downstream.close()
+                continue
+
+            downstream.settimeout(1)
+            upstream.settimeout(1)
+            for args in ((downstream, upstream, True), (upstream, downstream, False)):
+                t = threading.Thread(target=self._pump, args=args, daemon=True)
+                self._threads.append(t)
+                t.start()
+
+    def start(self, address):
+        self._address = address
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(("", 0))
+        self._sock.listen()
+        self._sock.settimeout(1)
+        self._runner = threading.Thread(target=self._serve, daemon=True)
+        self._runner.start()
+        return self._sock.getsockname()[1]
+
+    def wait_until_stalled(self, timeout=60):
+        if not self._stalled.wait(timeout=timeout):
+            raise AssertionError("proxy never saw BEGIN READ ONLY")
+
+    def release(self):
+        self._release.set()
+
+    def stop(self):
+        self._stop = True
+        self._release.set()
+        if self._sock:
+            self._sock.close()
+        for t in self._threads:
+            t.join(timeout=5)
+
+
+def test_kill_query_while_transaction_is_starting(started_cluster, setup_infinite_query):
+    """A cancel arriving while the transaction is still being constructed must not be lost.
+
+    In that window `onStart` has not published `tx`, so `onCancel` cannot cancel anything --
+    it only consumes the one-shot `is_completed` flag. Without a recheck after publication,
+    `onStart` then proceeds into the blocking COPY and the cancellation is dropped, so the
+    query keeps running until PostgreSQL finishes it on its own.
+    """
+    _, _ = setup_infinite_query
+    proxy = BeginStallingProxy()
+    port = proxy.start((started_cluster.postgres_ip, started_cluster.postgres_port))
+    proxy_host = socket.gethostbyname(socket.gethostname())
+    query_id = str(uuid.uuid4())
+    query_errors = []
+
+    # An engine table with a declared structure, created before the proxy starts stalling, so
+    # that the read is the only thing that opens a transaction (see BeginStallingProxy).
+    node1.query("DROP TABLE IF EXISTS stalled_counter")
+    node1.query(
+        f"""CREATE TABLE stalled_counter (counter Nullable(Int32))
+ENGINE = PostgreSQL(
+    '{proxy_host}:{port}',
+    'postgres_database',
+    'infinite_counter',
+    'postgres',
+    'ClickHouse_PostgreSQL_P@ssw0rd')"""
+    )
+
+    def execute_query():
+        _, error = node1.query_and_get_answer_with_error(
+            "SELECT * FROM stalled_counter",
+            query_id=query_id,
+            timeout=120,
+        )
+        query_errors.append(error)
+
+    query_thread = threading.Thread(target=execute_query)
+    query_thread.start()
+
+    try:
+        # The source is now pinned inside the transaction constructor, before `tx` is published.
+        proxy.wait_until_stalled()
+
+        assert_eq_with_retry(
+            node1,
+            f"SELECT count() FROM system.processes WHERE query_id='{query_id}'",
+            "1",
+            retry_count=60,
+            sleep_time=0.5,
+        )
+
+        node1.query(f"KILL QUERY WHERE query_id='{query_id}' ASYNC")
+        # Let the cancel be delivered to the source while it is still stalled, so that
+        # `onCancel` runs with `tx` still null and consumes the flag.
+        assert_eq_with_retry(
+            node1,
+            f"SELECT is_cancelled FROM system.processes WHERE query_id='{query_id}'",
+            "1",
+            retry_count=60,
+            sleep_time=0.5,
+        )
+    finally:
+        proxy.release()
+
+    # The recheck must abandon the read. Without it the source enters the COPY and the query
+    # runs on against an endless view, so this join times out.
+    query_thread.join(timeout=60)
+    assert not query_thread.is_alive(), "cancelled query kept running after the transaction started"
+    assert query_errors and "QUERY_WAS_CANCELLED" in query_errors[0], query_errors
+
+    assert_eq_with_retry(
+        node1,
+        f"SELECT count() FROM system.processes WHERE query_id='{query_id}'",
+        "0",
+        retry_count=60,
+        sleep_time=0.5,
+    )
+    proxy.stop()
+    node1.query("DROP TABLE stalled_counter")
+
+
 def test_kill_query_when_postgresql_cancel_connection_fails(
     started_cluster, setup_sleepy_view
 ):

--- a/tests/integration/test_postgresql_kill_query/test.py
+++ b/tests/integration/test_postgresql_kill_query/test.py
@@ -302,45 +302,54 @@ ENGINE = PostgreSQL(
     query_thread.start()
 
     try:
-        # The source is now pinned inside the transaction constructor, before `tx` is published.
-        proxy.wait_until_stalled()
+        try:
+            # The source is now pinned inside the transaction constructor, before `tx` is
+            # published.
+            proxy.wait_until_stalled()
+
+            assert_eq_with_retry(
+                node1,
+                f"SELECT count() FROM system.processes WHERE query_id='{query_id}'",
+                "1",
+                retry_count=60,
+                sleep_time=0.5,
+            )
+
+            node1.query(f"KILL QUERY WHERE query_id='{query_id}' ASYNC")
+            # Let the cancel be delivered to the source while it is still stalled, so that
+            # `onCancel` runs with `tx` still null and consumes the flag.
+            assert_eq_with_retry(
+                node1,
+                f"SELECT is_cancelled FROM system.processes WHERE query_id='{query_id}'",
+                "1",
+                retry_count=60,
+                sleep_time=0.5,
+            )
+        finally:
+            proxy.release()
+
+        # The recheck must abandon the read. Without it the source enters the COPY and the
+        # query runs on against an endless view, so this join times out.
+        query_thread.join(timeout=60)
+        assert (
+            not query_thread.is_alive()
+        ), "cancelled query kept running after the transaction started"
+        assert query_errors and "QUERY_WAS_CANCELLED" in query_errors[0], query_errors
 
         assert_eq_with_retry(
             node1,
             f"SELECT count() FROM system.processes WHERE query_id='{query_id}'",
-            "1",
-            retry_count=60,
-            sleep_time=0.5,
-        )
-
-        node1.query(f"KILL QUERY WHERE query_id='{query_id}' ASYNC")
-        # Let the cancel be delivered to the source while it is still stalled, so that
-        # `onCancel` runs with `tx` still null and consumes the flag.
-        assert_eq_with_retry(
-            node1,
-            f"SELECT is_cancelled FROM system.processes WHERE query_id='{query_id}'",
-            "1",
+            "0",
             retry_count=60,
             sleep_time=0.5,
         )
     finally:
-        proxy.release()
-
-    # The recheck must abandon the read. Without it the source enters the COPY and the query
-    # runs on against an endless view, so this join times out.
-    query_thread.join(timeout=60)
-    assert not query_thread.is_alive(), "cancelled query kept running after the transaction started"
-    assert query_errors and "QUERY_WAS_CANCELLED" in query_errors[0], query_errors
-
-    assert_eq_with_retry(
-        node1,
-        f"SELECT count() FROM system.processes WHERE query_id='{query_id}'",
-        "0",
-        retry_count=60,
-        sleep_time=0.5,
-    )
-    proxy.stop()
-    node1.query("DROP TABLE stalled_counter")
+        # A failed assertion must not leave the read, the proxy or the table behind for the
+        # tests that run after this one.
+        node1.query(f"KILL QUERY WHERE query_id='{query_id}' ASYNC", ignore_error=True)
+        query_thread.join(timeout=60)
+        proxy.stop()
+        node1.query("DROP TABLE IF EXISTS stalled_counter")
 
 
 def test_kill_query_when_postgresql_cancel_connection_fails(


### PR DESCRIPTION


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed cancellation of `postgresql` table function and PostgreSQL engine reads. Cancelling while the read was still starting up could race on the transaction pointer, and the cancellation could be lost entirely, leaving the query running until PostgreSQL finished it. A cancel that reaches PostgreSQL before the `COPY` statement has begun executing can still be dropped; that narrower, pre-existing window is tracked separately in issue #114080.

### Description

Four pre-existing cancellation bugs in `PostgreSQLSource`. Bugs 2 to 4 were found by kssenii in review here and folded in.

**1. Data race on the transaction pointer.** ThreadSanitizer reports an 8-byte race on `PostgreSQLSource<T>::tx`, `onCancel` against the `onStart` store; the neighbouring guard loads a different object, so it orders nothing. Fixed by publishing `tx` under a new `std::mutex tx_mutex`, snapshotted in `onCancel` and used with the lock released. Holding it across `stream_from` would deadlock cancellation against the call it must interrupt.

**2. Cancellation lost while the transaction is starting.** A cancel arriving before `tx` is published saw it null, so `onCancel` consumed the one-shot `is_completed` flag and skipped `cancel_query` and `setBroken`; `onStart` entered the blocking `COPY` anyway, so the read ran on and the connection went back to the pool with the transaction open. `onStart` now rechecks after publishing and does not open the `COPY`; the destructor does that teardown. `ConnectionHolder::is_broken` becomes atomic, the one site the flag does not serialize.

**3. Cancellation lost while the COPY is starting.** One step later `tx` is published, so `onCancel` does call `cancel_query()`, but the backend holds no statement yet, so nothing is interrupted. `onStart` opened the `COPY` regardless, and the consumed flag made the destructor return before its own cancel, so the rollback waited for the read. The one-shot flag was doing three jobs at once, and kssenii reworked the ownership (b3c76ce8): `stop_requested` is now a pure stop signal, `finalized` is the teardown claim, and the destructor owns the teardown on every path except an uncancelled clean finish, cancelling the `COPY` that exists by the time it runs.

**4. Two cancels on one connection.** `onCancel` interrupts the startup from the `KILL QUERY` thread while another teardown path may still reach the same connection, which libpq forbids. Both reach `PQgetCancel`, which reads the cancel key and keepalive options out of the `PGconn` and can append to its error buffer, so it is a race on that object, not a harmless duplicate. A mutex around the cancel serializes them, held across that call only, and `prepare` no longer commits after a cancel for the same reason.

**Known remaining window (deliberate).** A cancel that reaches the backend before the `COPY` has started executing is discarded: a PostgreSQL cancel request only interrupts the statement running at the moment it is processed. The destructor is then the remaining canceller, and it cannot run until the `pqxx::stream_from` constructor returns, so for query shapes that materialize their result before sending `CopyOutResponse`, the read still runs until PostgreSQL finishes it. No rows are streamed and the connection is still torn down correctly; what is lost is the promptness of the interruption. Closing it needs a deferred-cancel design rather than a local change, so it is left for follow-up in issue #114080.


<details>
<summary>Validation</summary>

The racing branch was taken on 40 of 40 cancellations. Both lost cancellations have regression tests, each verified to fail on the binary without its fix. A proxy withholds one client statement on the wire: withholding `BEGIN READ ONLY` pins the source inside the transaction constructor (bug 2), withholding the `COPY` pins it one step later with `tx` published (bug 3).

Bug 3's test needs a view whose `COPY` starts streaming at once but keeps running, so that the constructor returns and the window is entered. A plpgsql `SETOF` function is not usable: PostgreSQL materialises its whole result set before the first row and never sends `CopyOutResponse`, so the constructor blocks and the source is pinned before the window instead of inside it.

Build IDs `ef2e840a26cedb4c` (without) and `67310dcb3cedaf01` (with): the new test fails on the first with the cancelled query still running, passes on the second, and the suite is 7/7. Bug 2's test was 18/18 across random-order repeats.

The pointer race does not reproduce locally: the branch arms every time, but the write and read are ~100 ms apart in the harness, so TSan's shadow cell is evicted first. CI hits it because the fuzzer cancels in process, which is why that half ships on the report plus the memory-model argument.

Under a TSan build: `test_postgresql_kill_query` 24/24 across random-order repeats, `test_storage_postgresql` + `test_dictionaries_postgresql` 39/39. A mis-scoped variant holding the lock across `stream_from` makes `test_kill_query_when_postgresql_cancel_connection_fails` fail, so that suite detects a wrong lock scope.

Report, both stacks, `Stress test (arm_tsan)`, STID `1855-2bf1` (also on `amd_tsan`): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106073&sha=0e95fededea7e7956d4a75cd0bf447854b702663&name_0=PR&name_1=Stress%20test%20%28arm_tsan%29

</details>

Related: https://github.com/ClickHouse/ClickHouse/issues/114080





<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1061` (included in `26.8` and later)
<!-- ch-version-info:end -->