### PR TITLE
Docs: document HTTP connection reuse in replica-aware routing

### DIFF
--- a/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
+++ b/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
@@ -53,7 +53,7 @@ Every request carrying `session_id=my-workload-1` lands on the same replica. A d
 
 On a multi-replica service, a write on one replica may not be visible on the others until replication catches up. Send your write with a `session_id`, then reuse that same value on follow-up reads. The proxy routes both to the same replica, so you read your own write even while other replicas are still behind.
 
-This pattern works for workloads that write and then immediately read back the same data, such as interactive applications or ETL jobs that validate inserts before moving on.
+This pattern works for workloads that write and then immediately read back the same data, such as interactive applications or ETL jobs that validate inserts before moving on. For broader guarantees across all replicas, you can also set [`select_sequential_consistency`](/operations/settings/settings#select_sequential_consistency) to `1` on ClickHouse Cloud.
 
 ### Check which replica you hit {#check-which-replica}
 

--- a/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
+++ b/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
@@ -11,15 +11,13 @@ import { PrivatePreviewBadge } from "/snippets/components/PrivatePreviewBadge/Pr
 
 <PrivatePreviewBadge/>
 
-Replica-aware routing (also known as sticky sessions, sticky routing, or session affinity) routes related requests to the same ClickHouse replica. Use it when you need [temporary tables](/sql-reference/statements/create/table#temporary-tables) or [named session state](/interfaces/http#using-clickhouse-sessions-in-the-http-protocol) to stay reachable across queries, when you want related queries to reuse the same replica's local caches, or when you need [read-after-write consistency](#read-after-write-consistency) across a write and its follow-up reads.
+Replica-aware routing (also known as sticky sessions, sticky routing, or session affinity) routes related requests to the same ClickHouse replica. 
+Use it when you need [temporary tables](/sql-reference/statements/create/table#temporary-tables) 
+or [named session state](/interfaces/http#using-clickhouse-sessions-in-the-http-protocol) 
+to stay reachable across queries, when you want related queries to reuse the same replica's local caches, 
+or when you need [read-after-write consistency](#read-after-write-consistency) across a write and its follow-up reads.
 
 It's best-effort and doesn't guarantee isolation. Scaling, upgrades, and restarts can remap which replica a given `session_id` lands on.
-
-<Warning>
-**Requires the HTTP interface**
-
-Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interface](/interfaces/http), using the `session_id` query parameter (see below). It's **not available over the native protocol** (native port, e.g. the [clickhouse-go](/integrations/go) driver in its default native mode). Native-protocol clients must switch to HTTP and pass a `session_id` on each request. For clickhouse-go (v2), set `Protocol: clickhouse.HTTP` and pass `session_id` as a [setting](/integrations/language-clients/go/database-sql-api#sessions). The driver sends it as the URL query parameter the proxy hashes on.
-</Warning>
 
 ## Prerequisites {#prerequisites}
 
@@ -30,11 +28,13 @@ Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interfa
 
 ## Configuring replica-aware routing {#configuring-replica-aware-routing}
 
-Open a [support](https://clickhouse.com/support/program) ticket and ask to enable HTTP-based sticky replica routing. Include your service ID and why you need it (temporary tables, session state, cache reuse, or read-after-write consistency). After it's enabled, start sending `?session_id=` on HTTPS requests. No restart is required.
+Open a [support](https://clickhouse.com/support/program) ticket and ask to enable HTTP-based sticky replica routing. Include your service ID and why you need it 
+(temporary tables, session state, cache reuse, or read-after-write consistency). After it's enabled, start sending `?session_id=` on HTTPS requests. No restart is required.
 
 ## HTTP-based routing (session_id) {#http-based-routing}
 
-To pin a workload to a replica, set the `session_id` query parameter on the [HTTPS interface](/interfaces/http). The proxy uses consistent hashing on that value to select a replica, so all requests sharing the same `session_id` go to the same server until the cluster topology changes.
+To pin a workload to a replica, set the `session_id` query parameter on the [HTTPS interface](/interfaces/http). 
+The proxy uses consistent hashing on that value to select a replica, so all requests sharing the same `session_id` go to the same server until the cluster topology changes.
 
 You use your existing service hostname. No special sticky hostnames or DNS changes are required.
 
@@ -45,15 +45,19 @@ echo 'SELECT hostName()' | curl \
   'https://<host>:8443/?session_id=my-workload-1' -d @-
 ```
 
-Every request carrying `session_id=my-workload-1` lands on the same replica. A different `session_id` value hashes independently and may land on the same or a different replica. The mapping is consistent, but you don't choose *which* replica a given value maps to.
+Every request carrying `session_id=my-workload-1` lands on the same replica. A different `session_id` value hashes independently and 
+may land on the same or a different replica. The mapping is consistent, but you don't choose *which* replica a given value maps to.
 
 `session_id` is any string you choose (application name, user id, or workload label). Requests without `session_id` keep normal load balancing.
 
 ### Read-after-write consistency {#read-after-write-consistency}
 
-On a multi-replica service, a write on one replica may not be visible on the others until replication catches up. Send your write with a `session_id`, then reuse that same value on follow-up reads. The proxy routes both to the same replica, so you read your own write even while other replicas are still behind.
+On a multi-replica service, a write on one replica may not be visible on the others until replication catches up. Send your write with a `session_id`, 
+then reuse that same value on follow-up reads. The proxy routes both to the same replica, so you read your own write even while other replicas are still behind.
 
-This pattern works for workloads that write and then immediately read back the same data, such as interactive applications or ETL jobs that validate inserts before moving on. For broader guarantees across all replicas, you can also set [`select_sequential_consistency`](/operations/settings/settings#select_sequential_consistency) to `1` on ClickHouse Cloud.
+This pattern works for workloads that write and then immediately read back the same data, such as interactive applications or 
+ETL jobs that validate inserts before moving on. For broader guarantees across all replicas, 
+you can also set [`select_sequential_consistency`](/operations/settings/settings#select_sequential_consistency) to `1` on ClickHouse Cloud.
 
 ### Check which replica you hit {#check-which-replica}
 
@@ -61,45 +65,50 @@ Run the `SELECT hostName()` example again with the same `session_id`. You should
 
 ### HTTP connection reuse {#http-connection-reuse}
 
-Envoy may reuse an upstream connection to a replica across requests on the same client connection. That reuse is best-effort: the client connection can stay open when the replica is still reachable, or when Envoy can silently retry on another replica before response headers go out. Connection reuse is **not** a substitute for `session_id` when you need sticky routing or session-scoped state.
+Envoy may reuse an upstream connection to a replica across requests on the same client connection. 
+That reuse is best-effort: the client connection can stay open when the replica is still reachable, or when Envoy can silently retry on another replica before response headers go out. 
+Connection reuse is **not** a substitute for `session_id` when you need sticky routing or session-scoped state.
 
-The client connection closes when Envoy can't recover on the same connection: the replica connection fails with no successful retry, the replica dies while the client connection is idle, or a failure happens after headers are already sent. A failure on a different replica won't impact the connection. If there is a network blip, a retry can point the same client connection at a different replica on the next request.
+The client connection closes when Envoy can't recover on the same connection: the replica connection fails with no successful retry, 
+the replica dies while the client connection is idle, or a failure happens after headers are already sent. A failure on a different replica won't impact the connection. 
+If there is a network blip, a retry can point the same client connection at a different replica on the next request.
 
 ## Subdomain-based routing (deprecated) {#subdomain-based-routing-deprecated}
 
 <Danger>
 **Deprecated**
 
-The subdomain-based mechanism is being **deprecated** and will no longer be enabled on new services. It doesn't scale (each sticky endpoint requires its own TLS certificate). Use the [HTTP-based `session_id` method](#http-based-routing) instead. If you already use sticky subdomains, contact [support](https://clickhouse.com/support/program) to enable `session_id` routing. This is a breaking change and will require migration.
+The subdomain-based mechanism is being **deprecated** and will no longer be enabled on new services. It doesn't scale (each sticky endpoint 
+requires its own TLS certificate). Use the [HTTP-based `session_id` method](#http-based-routing) instead. 
+If you already use sticky subdomains, contact [support](https://clickhouse.com/support/program) to enable `session_id` routing. This is a breaking change and will require migration.
 </Danger>
 
-Previously, enabling replica-aware routing allowed a wildcard subdomain on top of the service hostname. For a service with the host name `abcxyz123.us-west-2.aws.clickhouse.cloud`, any hostname matching `*.sticky.abcxyz123.us-west-2.aws.clickhouse.cloud` (e.g. `aaa.sticky.abcxyz123.us-west-2.aws.clickhouse.cloud`) was hashed by Envoy to a consistent replica. The original hostname continued to use `LEAST_CONNECTION` load balancing, the default routing algorithm.
+Previously, enabling replica-aware routing allowed a wildcard subdomain on top of the service hostname. 
+For a service with the host name `abcxyz123.us-west-2.aws.clickhouse.cloud`, any hostname matching `*.sticky.abcxyz123.us-west-2.aws.clickhouse.cloud` 
+(e.g. `aaa.sticky.abcxyz123.us-west-2.aws.clickhouse.cloud`) was hashed by Envoy to a consistent replica. The original hostname continued to use `LEAST_CONNECTION` load balancing, 
+the default routing algorithm.
 
 ## Limitations of replica-aware routing {#limitations-of-replica-aware-routing}
 
-### Stickiness can break during service changes {#replica-aware-routing-does-not-guarantee-isolation}
+- Stickiness breaking during service changes: Any disruption to the service changes the routing hash ring. That includes server pod restarts (version upgrade, crash, vertical scaling) 
+and scaling out or in. Requests sharing the same `session_id` may then land on a different server pod. 
+If you rely on temporary tables or session-level settings, be ready to recreate them after a remap.
 
-Any disruption to the service changes the routing hash ring. That includes server pod restarts (version upgrade, crash, vertical scaling) and scaling out or in. Requests sharing the same `session_id` may then land on a different server pod. If you rely on temporary tables or session-level settings, be ready to recreate them after a remap.
+- Concurrent queries sharing a `session_id`: Because routing keys off `session_id`, and a ClickHouse [HTTP session](/interfaces/http#using-clickhouse-sessions-in-the-http-protocol) 
+allows only one query at a time, 
+concurrent requests that share the same `session_id` collide: one succeeds and the other fails with HTTP 500 and error code `373` (`SESSION_IS_LOCKED`). 
+The one-query-per-session limit applies regardless of the `session_check` setting. 
 
-### Concurrent queries sharing a `session_id` {#concurrent-queries-sharing-a-session-id}
+- Replica-aware routing isn't workload isolation: Sticky routing only controls *which* replica handles a request. That replica may still serve other traffic. 
+For dedicated compute, use [compute-compute separation](/cloud/reference/warehouses).
 
-Because routing keys off `session_id`, and a ClickHouse [HTTP session](/interfaces/http#using-clickhouse-sessions-in-the-http-protocol) allows only one query at a time, concurrent requests that share the same `session_id` collide: one succeeds and the other fails with HTTP 500 and error code `373` (`SESSION_IS_LOCKED`). The one-query-per-session limit applies regardless of the `session_check` setting.
-
-This is a known limitation. If a workload needs overlapping queries while still pinning traffic, give each concurrent request (or each client/worker) its own `session_id` instead of reusing one shared value across many in-flight queries.
-
-### Replica-aware routing isn't workload isolation {#not-workload-isolation}
-
-Sticky routing only controls *which* replica handles a request. That replica may still serve other traffic. For dedicated compute, use [compute-compute separation](/cloud/reference/warehouses).
-
-### Private Link and the deprecated subdomain method {#replica-aware-routing-does-not-work-out-of-the-box-with-private-link}
-
-HTTP `session_id` routing works with [private networking](/cloud/security/connectivity/private-networking) on your normal service hostname. No extra DNS entries are required.
-
+- Private Link and the deprecated subdomain method: HTTP `session_id` routing works with [private networking](/cloud/security/connectivity/private-networking) on your normal service hostname. 
+No extra DNS entries are required.
 The deprecated subdomain method doesn't: you must add DNS for the `*.sticky.*` hostname pattern, and incorrect setup can imbalance load across replicas.
 
-### Replica-aware routing requires the HTTP protocol {#replica-aware-routing-requires-http}
-
-Sticky routing is keyed on the `session_id` query parameter, which only exists on the HTTP/HTTPS interface. The native binary protocol carries no such parameter for the proxy to hash on, so replica-aware routing isn't available over the native protocol. Today, native-protocol clients must move the relevant workload to the HTTP interface to use this feature.
+- Native connection support: Sticky routing is keyed on the `session_id` query parameter, which only exists on the HTTP/HTTPS interface. 
+The native binary protocol carries no such parameter for the proxy to hash on, so replica-aware routing isn't available over the native protocol. 
+Today, native-protocol clients must move the relevant workload to the HTTP interface to use this feature. 
 
 ## Troubleshooting {#troubleshooting}
 

--- a/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
+++ b/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
@@ -12,8 +12,8 @@ import { PrivatePreviewBadge } from "/snippets/components/PrivatePreviewBadge/Pr
 <PrivatePreviewBadge/>
 
 Replica-aware routing (also known as sticky sessions, sticky routing, or session affinity) routes related requests to the same ClickHouse replica. 
-Use it when you need [temporary tables](/sql-reference/statements/create/table#temporary-tables) 
-or [named session state](/interfaces/http#using-clickhouse-sessions-in-the-http-protocol) 
+Use it when you need [temporary tables](/sql-reference/statements/create/table#temporary-tables),
+[named session state](/interfaces/http#using-clickhouse-sessions-in-the-http-protocol) 
 to stay reachable across queries, when you want related queries to reuse the same replica's local caches, 
 or when you need [read-after-write consistency](#read-after-write-consistency) across a write and its follow-up reads.
 

--- a/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
+++ b/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
@@ -61,9 +61,9 @@ Run the `SELECT hostName()` example again with the same `session_id`. You should
 
 ### HTTP connection reuse {#http-connection-reuse}
 
-ClickHouse uses Envoy to open one connection to a replica for each client connection and keeps using it until something breaks that link. The client connection stays open when the replica is still reachable, or when Envoy can silently retry on another replica before response headers go out.
+Envoy may reuse an upstream connection to a replica across requests on the same client connection. That reuse is best-effort: the client connection can stay open when the replica is still reachable, or when Envoy can silently retry on another replica before response headers go out. Connection reuse is **not** a substitute for `session_id` when you need sticky routing or session-scoped state.
 
-The client connection closes when Envoy can't fix things on the same connection: the replica connection fails with no successful retry, the replica dies while the client connection is idle, or a failure happens after headers are already sent. A failure on a different replica won't impact the connection. If there is a network blip, a retry can point the same client connection at a different replica on the next request.
+The client connection closes when Envoy can't recover on the same connection: the replica connection fails with no successful retry, the replica dies while the client connection is idle, or a failure happens after headers are already sent. A failure on a different replica won't impact the connection. If there is a network blip, a retry can point the same client connection at a different replica on the next request.
 
 ## Subdomain-based routing (deprecated) {#subdomain-based-routing-deprecated}
 
@@ -80,6 +80,12 @@ Previously, enabling replica-aware routing allowed a wildcard subdomain on top o
 ### Stickiness can break during service changes {#replica-aware-routing-does-not-guarantee-isolation}
 
 Any disruption to the service changes the routing hash ring. That includes server pod restarts (version upgrade, crash, vertical scaling) and scaling out or in. Requests sharing the same `session_id` may then land on a different server pod. If you rely on temporary tables or session-level settings, be ready to recreate them after a remap.
+
+### Concurrent queries sharing a `session_id` {#concurrent-queries-sharing-a-session-id}
+
+Because routing keys off `session_id`, and a ClickHouse [HTTP session](/interfaces/http#using-clickhouse-sessions-in-the-http-protocol) allows only one query at a time, concurrent requests that share the same `session_id` collide: one succeeds and the other fails with HTTP 500 and error code `373` (`SESSION_IS_LOCKED`). The one-query-per-session limit applies regardless of the `session_check` setting.
+
+This is a known limitation. If a workload needs overlapping queries while still pinning traffic, give each concurrent request (or each client/worker) its own `session_id` instead of reusing one shared value across many in-flight queries.
 
 ### Replica-aware routing isn't workload isolation {#not-workload-isolation}
 

--- a/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
+++ b/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
@@ -51,13 +51,19 @@ Every request carrying `session_id=my-workload-1` lands on the same replica. A d
 
 ### Read-after-write consistency {#read-after-write-consistency}
 
-On a multi-replica service, a write on one replica may not be visible on the others until replication catches up. Send your write with a `session_id`, then reuse that same value on follow-up reads. The proxy routes both to the same replica, so you read your own write even while other replicas are still behind. This pattern works for workloads that write and then immediately read back the same data, such as interactive applications or ETL jobs that validate inserts before moving on.  
+On a multi-replica service, a write on one replica may not be visible on the others until replication catches up. Send your write with a `session_id`, then reuse that same value on follow-up reads. The proxy routes both to the same replica, so you read your own write even while other replicas are still behind.
 
-For broader guarantees across all replicas, you can also set [`select_sequential_consistency`](/operations/settings/settings#select_sequential_consistency) to `1` on ClickHouse Cloud.
+This pattern works for workloads that write and then immediately read back the same data, such as interactive applications or ETL jobs that validate inserts before moving on.
 
 ### Check which replica you hit {#check-which-replica}
 
-Run the `SELECT hostName()` example above again with the same `session_id`. You should get the same hostname. A different `session_id` may map to a different replica.
+Run the `SELECT hostName()` example again with the same `session_id`. You should get the same hostname. A different `session_id` may map to a different replica.
+
+### HTTP connection reuse {#http-connection-reuse}
+
+ClickHouse uses Envoy to open one connection to a replica for each client connection and keeps using it until something breaks that link. The client connection stays open when the replica is still reachable, or when Envoy can silently retry on another replica before response headers go out.
+
+The client connection closes when Envoy can't fix things on the same connection: the replica connection fails with no successful retry, the replica dies while the client connection is idle, or a failure happens after headers are already sent. A failure on a different replica won't impact the connection. If there is a network blip, a retry can point the same client connection at a different replica on the next request.
 
 ## Subdomain-based routing (deprecated) {#subdomain-based-routing-deprecated}
 


### PR DESCRIPTION
Ports the HTTP connection reuse guidance to the Mintlify replica-aware routing page, and documents a known concurrency limitation: concurrent requests that share the same `session_id` can fail with `SESSION_IS_LOCKED` (code 373) because HTTP sessions allow only one query at a time.

Also softens the connection-reuse wording to best-effort so readers do not treat keep-alive as a substitute for `session_id`.

Related: https://github.com/ClickHouse/clickhouse-docs/pull/6607

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.