### PR TITLE
Fix REPLACE/EXCHANGE TABLE on filesystems without atomic rename

### DIFF
--- a/src/Common/atomicRename.cpp
+++ b/src/Common/atomicRename.cpp
@@ -242,4 +242,17 @@ bool renameExchangeIfSupported(const std::string & old_path, const std::string &
     return renameat2(old_path, new_path, RENAME_EXCHANGE);
 }
 
+void renameExchangeNonAtomic(const std::string & old_path, const std::string & new_path)
+{
+    if (fs::exists(new_path))
+    {
+        std::string temp_path = old_path + ".tmp_rename_exchange";
+        fs::rename(old_path, temp_path);
+        fs::rename(new_path, old_path);
+        fs::rename(temp_path, new_path);
+    }
+    else
+        fs::rename(old_path, new_path);
+}
+
 }

--- a/src/Common/atomicRename.cpp
+++ b/src/Common/atomicRename.cpp
@@ -2,6 +2,7 @@
 #include <Common/Exception.h>
 #include <Common/ErrnoException.h>
 #include <Common/VersionNumber.h>
+#include <Common/logger_useful.h>
 #include <Poco/Environment.h>
 #include <filesystem>
 
@@ -244,15 +245,62 @@ bool renameExchangeIfSupported(const std::string & old_path, const std::string &
 
 void renameExchangeNonAtomic(const std::string & old_path, const std::string & new_path)
 {
-    if (fs::exists(new_path))
+    if (!fs::exists(new_path))
     {
-        std::string temp_path = old_path + ".tmp_rename_exchange";
-        fs::rename(old_path, temp_path);
-        fs::rename(new_path, old_path);
-        fs::rename(temp_path, new_path);
-    }
-    else
         fs::rename(old_path, new_path);
+        return;
+    }
+
+    /// Emulate the atomic exchange with three renames through a temporary name. This is not
+    /// atomic, so if a rename fails partway we roll back to leave both paths where they were --
+    /// otherwise one of the files would be stranded under the temporary name, which is exactly
+    /// the kind of corruption this whole code path exists to avoid. A hard crash between the
+    /// renames still leaves such an artifact; that is unavoidable without an atomic exchange.
+    const std::string temp_path = old_path + ".tmp_rename_exchange";
+    fs::rename(old_path, temp_path); /// old_path -> temp_path
+
+    try
+    {
+        fs::rename(new_path, old_path); /// new_path -> old_path
+    }
+    catch (...)
+    {
+        try
+        {
+            fs::rename(temp_path, old_path); /// undo: temp_path -> old_path
+        }
+        catch (...)
+        {
+            LOG_ERROR(
+                getLogger("renameExchangeNonAtomic"),
+                "Could not roll back a failed non-atomic exchange of {} and {}. The original {} is "
+                "left as {}; move it back manually to recover.",
+                old_path, new_path, old_path, temp_path);
+        }
+        throw;
+    }
+
+    try
+    {
+        fs::rename(temp_path, new_path); /// temp_path -> new_path
+    }
+    catch (...)
+    {
+        try
+        {
+            fs::rename(old_path, new_path); /// undo second rename: old_path -> new_path
+            fs::rename(temp_path, old_path); /// undo first rename: temp_path -> old_path
+        }
+        catch (...)
+        {
+            LOG_ERROR(
+                getLogger("renameExchangeNonAtomic"),
+                "Could not roll back a failed non-atomic exchange of {} and {}. The original {} is "
+                "left as {}; move it back manually to recover.",
+                old_path, new_path, old_path, temp_path);
+        }
+        throw;
+    }
 }
 
 }

--- a/src/Common/atomicRename.h
+++ b/src/Common/atomicRename.h
@@ -17,4 +17,10 @@ void renameExchange(const std::string & old_path, const std::string & new_path);
 /// Returns false instead of throwing exception if renameat2 is not supported
 bool renameExchangeIfSupported(const std::string & old_path, const std::string & new_path);
 
+/// Non-atomic emulation of renameExchange for filesystems that do not support the atomic
+/// exchange (renameat2 with RENAME_EXCHANGE returns EINVAL, e.g. some FUSE filesystems and
+/// Docker Desktop bind mounts on macOS). Swaps the two files via a temporary name, or, if
+/// new_path does not exist, just moves old_path to new_path. NOTE it's not crash-safe.
+void renameExchangeNonAtomic(const std::string & old_path, const std::string & new_path);
+
 }

--- a/src/Common/tests/gtest_atomic_rename.cpp
+++ b/src/Common/tests/gtest_atomic_rename.cpp
@@ -1,0 +1,103 @@
+#include <gtest/gtest.h>
+
+#include <Common/atomicRename.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+
+std::string readAll(const fs::path & path)
+{
+    std::ifstream in(path);
+    return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+
+void writeAll(const fs::path & path, const std::string & content)
+{
+    std::ofstream out(path);
+    out << content;
+}
+
+/// Drives DB::renameExchangeNonAtomic -- the fallback used by DiskLocal::renameExchange on
+/// filesystems that do not support renameat2(RENAME_EXCHANGE). Normal CI runs on filesystems
+/// where the atomic exchange succeeds, so this path is otherwise never exercised.
+class RenameExchangeNonAtomicTest : public ::testing::Test
+{
+protected:
+    fs::path dir;
+
+    void SetUp() override
+    {
+        const auto * info = ::testing::UnitTest::GetInstance()->current_test_info();
+        dir = fs::temp_directory_path()
+            / ("ch_gtest_rename_exchange_" + std::to_string(getpid()) + "_" + info->name());
+        std::error_code ec;
+        fs::remove_all(dir, ec);
+        fs::create_directories(dir);
+    }
+
+    void TearDown() override
+    {
+        std::error_code ec;
+        fs::remove_all(dir, ec);
+    }
+};
+
+}
+
+TEST_F(RenameExchangeNonAtomicTest, SwapsTwoExistingFiles)
+{
+    const auto a = dir / "a.sql";
+    const auto b = dir / "b.sql";
+    writeAll(a, "AAA");
+    writeAll(b, "BBB");
+
+    DB::renameExchangeNonAtomic(a.string(), b.string());
+
+    EXPECT_EQ(readAll(a), "BBB");
+    EXPECT_EQ(readAll(b), "AAA");
+    /// No temporary file left behind.
+    EXPECT_FALSE(fs::exists(a.string() + ".tmp_rename_exchange"));
+}
+
+TEST_F(RenameExchangeNonAtomicTest, MovesWhenTargetMissing)
+{
+    const auto a = dir / "a.sql";
+    const auto b = dir / "b.sql";
+    writeAll(a, "AAA");
+
+    DB::renameExchangeNonAtomic(a.string(), b.string());
+
+    EXPECT_FALSE(fs::exists(a));
+    ASSERT_TRUE(fs::exists(b));
+    EXPECT_EQ(readAll(b), "AAA");
+}
+
+/// The `Atomic` database reaches its metadata `.sql` files through a directory symlink
+/// (metadata/<db> -> store/<uuid>). Make sure the fallback swaps correctly through it.
+TEST_F(RenameExchangeNonAtomicTest, WorksThroughDirectorySymlink)
+{
+    fs::create_directories(dir / "store");
+    fs::create_directory_symlink("store", dir / "meta");
+
+    const auto a = dir / "meta" / "A.sql";
+    const auto b = dir / "meta" / "B.sql";
+    writeAll(a, "TABLE_A");
+    writeAll(b, "TABLE_B");
+
+    DB::renameExchangeNonAtomic(a.string(), b.string());
+
+    EXPECT_EQ(readAll(a), "TABLE_B");
+    EXPECT_EQ(readAll(b), "TABLE_A");
+    /// The physical files under the symlink target are swapped too.
+    EXPECT_EQ(readAll(dir / "store" / "A.sql"), "TABLE_B");
+    EXPECT_EQ(readAll(dir / "store" / "B.sql"), "TABLE_A");
+}

--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -364,7 +364,11 @@ void DatabaseAtomic::renameTable(ContextPtr local_context, const String & table_
     else
         db_disk->moveFile(old_metadata_path, new_metadata_path);
 
-    /// After metadata was successfully moved, the following methods should not throw (if they do, it's a logical error)
+    /// After metadata was successfully moved, the following methods should not throw (if they do,
+    /// it's a logical error). The exchange above is a single atomic syscall where the filesystem
+    /// supports it, and a non-atomic swap that rolls back on failure otherwise (see
+    /// DiskLocal::renameExchange), so reaching this point always means the swap fully applied --
+    /// a mid-sequence failure throws with the metadata left unchanged rather than half-swapped.
     table_data_path = detach(*this, table_name, table->storesDataOnDisk());
     if (exchange)
         other_table_data_path = detach(other_db, to_table_name, other_table->storesDataOnDisk());

--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -14,7 +14,6 @@
 #include <base/isSharedPtrUnique.h>
 #include <Common/PoolId.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
-#include <Common/atomicRename.h>
 #include <Common/logger_useful.h>
 #include <Common/AsyncLoader.h>
 #include <Common/CurrentThread.h>
@@ -256,10 +255,10 @@ void DatabaseAtomic::renameTable(ContextPtr local_context, const String & table_
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Moving tables between databases of different engines is not supported");
     }
 
-    std::string message;
-    if (exchange && !supportsAtomicRename(&message))
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "RENAME EXCHANGE is not supported because exchanging files is not supported by the OS ({})", message);
-
+    /// Whether the metadata files can be exchanged is a per-disk property, not an OS one, so
+    /// the decision is delegated to `IDisk::renameExchange`: `DiskLocal` and
+    /// `DiskObjectStorage` fall back to a non-atomic swap when the filesystem cannot do an
+    /// atomic exchange, other disks throw a clear per-disk `NOT_IMPLEMENTED`.
     createDirectories();
     waitDatabaseStarted();
 

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -367,22 +367,14 @@ void DiskLocal::renameExchange(const std::string & old_path, const std::string &
 
     /// The filesystem does not support atomically exchanging two files (`renameat2` with
     /// `RENAME_EXCHANGE` fails with `EINVAL`), as observed on some FUSE filesystems and on
-    /// Docker Desktop `virtiofs` bind mounts on macOS. Fall back to a non-atomic swap through
-    /// a temporary name, the same way `DiskObjectStorage::renameExchange` does. NOTE it's not
-    /// crash-safe, but such filesystems cannot provide an atomic exchange anyway. Only the
-    /// `Atomic` database metadata swap uses this method (see `DatabaseAtomic::renameTable`),
-    /// and it already relies on non-atomic fallbacks for `CREATE`/`RENAME`/`ALTER` on the
-    /// same filesystems. The shared `DB::renameExchange` helper stays fail-closed for other
+    /// Docker Desktop `virtiofs` bind mounts on macOS. Fall back to a non-atomic swap. NOTE
+    /// it's not crash-safe, but such filesystems cannot provide an atomic exchange anyway.
+    /// Only the `Atomic` database metadata swap uses this method (see
+    /// `DatabaseAtomic::renameTable`), and it already relies on non-atomic fallbacks for
+    /// `CREATE`/`RENAME`/`ALTER` on the same filesystems; `DiskObjectStorage::renameExchange`
+    /// does the same. The shared `DB::renameExchange` helper stays fail-closed for other
     /// callers.
-    if (existsFile(new_path))
-    {
-        std::string temp_path = old_file.string() + ".tmp_rename_exchange";
-        fs::rename(old_file, temp_path);
-        fs::rename(new_file, old_file);
-        fs::rename(temp_path, new_file);
-    }
-    else
-        fs::rename(old_file, new_file);
+    DB::renameExchangeNonAtomic(old_file, new_file);
 }
 
 bool DiskLocal::renameExchangeIfSupported(const std::string & old_path, const std::string & new_path)

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -359,7 +359,30 @@ void DiskLocal::replaceFile(const String & from_path, const String & to_path)
 
 void DiskLocal::renameExchange(const std::string & old_path, const std::string & new_path)
 {
-    DB::renameExchange(fs::path(disk_path) / old_path, fs::path(disk_path) / new_path);
+    fs::path old_file = fs::path(disk_path) / old_path;
+    fs::path new_file = fs::path(disk_path) / new_path;
+
+    if (DB::renameExchangeIfSupported(old_file, new_file))
+        return;
+
+    /// The filesystem does not support atomically exchanging two files (`renameat2` with
+    /// `RENAME_EXCHANGE` fails with `EINVAL`), as observed on some FUSE filesystems and on
+    /// Docker Desktop `virtiofs` bind mounts on macOS. Fall back to a non-atomic swap through
+    /// a temporary name, the same way `DiskObjectStorage::renameExchange` does. NOTE it's not
+    /// crash-safe, but such filesystems cannot provide an atomic exchange anyway. Only the
+    /// `Atomic` database metadata swap uses this method (see `DatabaseAtomic::renameTable`),
+    /// and it already relies on non-atomic fallbacks for `CREATE`/`RENAME`/`ALTER` on the
+    /// same filesystems. The shared `DB::renameExchange` helper stays fail-closed for other
+    /// callers.
+    if (existsFile(new_path))
+    {
+        std::string temp_path = old_file.string() + ".tmp_rename_exchange";
+        fs::rename(old_file, temp_path);
+        fs::rename(new_file, old_file);
+        fs::rename(temp_path, new_file);
+    }
+    else
+        fs::rename(old_file, new_file);
 }
 
 bool DiskLocal::renameExchangeIfSupported(const std::string & old_path, const std::string & new_path)

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -374,6 +374,12 @@ void DiskLocal::renameExchange(const std::string & old_path, const std::string &
     /// `CREATE`/`RENAME`/`ALTER` on the same filesystems; `DiskObjectStorage::renameExchange`
     /// does the same. The shared `DB::renameExchange` helper stays fail-closed for other
     /// callers.
+    LOG_WARNING(
+        logger,
+        "Filesystem of disk {} does not support an atomic file exchange (renameat2 with "
+        "RENAME_EXCHANGE); exchanging {} and {} with a non-atomic fallback, which is not "
+        "crash-safe.",
+        name, old_file.string(), new_file.string());
     DB::renameExchangeNonAtomic(old_file, new_file);
 }
 

--- a/src/Formats/FormatSchemaInfo.cpp
+++ b/src/Formats/FormatSchemaInfo.cpp
@@ -284,9 +284,12 @@ void FormatSchemaInfo::storeSchemaOnDisk(const fs::path & file_path, const Strin
         out.sync();
         out.close();
 
-        if (fs::exists(file_path))
-            DB::renameExchange(temp_path, file_path);
-        else
+        /// The schema file is content-addressed, so if `file_path` already exists (possibly
+        /// published by a concurrent writer) it has the same content as our temporary copy.
+        /// Keep the published file and discard our copy instead of exchanging them: an
+        /// exchange is not atomic on all filesystems and would briefly make `file_path`
+        /// disappear, which a concurrent reader could observe as `FILE_DOESNT_EXIST`.
+        if (!fs::exists(file_path))
             DB::renameNoReplace(temp_path, file_path);
 
         fs::remove(temp_path);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix

### Changelog entry:
Fixed `REPLACE TABLE`, `CREATE OR REPLACE`, and `EXCHANGE TABLES` in `Atomic` databases on filesystems without atomic rename support.

---

Closes: #83524