### PR TITLE
Cover the reporter's Parquet bloom filter null-as-default reproducer

### DIFF
--- a/tests/queries/0_stateless/04646_parquet_v3_bloom_filter_null_safety.reference
+++ b/tests/queries/0_stateless/04646_parquet_v3_bloom_filter_null_safety.reference
@@ -12,7 +12,7 @@ required column: the bloom filter prunes a non-present value
 {"result":[{"count()":0}],"rows_read":0}
 String over ten row groups, null_as_default on: nulls decode to '', no row group must be pruned
 {"result":[{"count()":500}],"rows_read":1000}
-String over ten row groups, null_as_default on, both disjuncts on the nullable column
+String over ten row groups, null_as_default on, disjunction with an atom on another column
 {"result":[{"count()":501}],"rows_read":1000}
 String over ten row groups read as Nullable: the bloom filter still prunes a non-present value
 {"result":[{"count()":0}],"rows_read":0}

--- a/tests/queries/0_stateless/04646_parquet_v3_bloom_filter_null_safety.reference
+++ b/tests/queries/0_stateless/04646_parquet_v3_bloom_filter_null_safety.reference
@@ -10,3 +10,9 @@ read as Nullable: nulls stay null, the bloom filter still prunes a non-present v
 {"result":[{"count()":0}],"rows_read":0}
 required column: the bloom filter prunes a non-present value
 {"result":[{"count()":0}],"rows_read":0}
+String over ten row groups, null_as_default on: nulls decode to '', no row group must be pruned
+{"result":[{"count()":500}],"rows_read":1000}
+String over ten row groups, null_as_default on, both disjuncts on the nullable column
+{"result":[{"count()":501}],"rows_read":1000}
+String over ten row groups read as Nullable: the bloom filter still prunes a non-present value
+{"result":[{"count()":0}],"rows_read":0}

--- a/tests/queries/0_stateless/04646_parquet_v3_bloom_filter_null_safety.sh
+++ b/tests/queries/0_stateless/04646_parquet_v3_bloom_filter_null_safety.sh
@@ -72,3 +72,24 @@ ${CLICKHOUSE_CLIENT} --query="
 echo "required column: the bloom filter prunes a non-present value"
 ${CH} --input_format_parquet_dictionary_filter_push_down=0 --input_format_null_as_default=0 --query="select count() from file('${DATA_FILE_2}', Parquet, 'x UInt64') where x = 9999 FORMAT JSON" \
     | jq -c '{result: .data, rows_read: .statistics.rows_read}'
+
+# A String column over ten row groups: the default is the empty string, which is not a physical value
+# anywhere in the file, and the pruning decision is taken per column chunk rather than once.
+DATA_FILE_3="${CLICKHOUSE_TEST_UNIQUE_NAME}_string.parquet"
+${CLICKHOUSE_CLIENT} --query="
+    insert into function file('${DATA_FILE_3}', Parquet)
+    select number as id, if(number % 2 = 0, NULL, 'v' || toString(number)) as n
+    from numbers(1000)
+    settings output_format_parquet_row_group_size = 100, output_format_parquet_write_bloom_filter = 1,
+             engine_file_truncate_on_insert = 1, max_block_size = 1000000;
+"
+
+echo "String over ten row groups, null_as_default on: nulls decode to '', no row group must be pruned"
+run 0 1 "select count() from file('${DATA_FILE_3}', Parquet, 'id UInt64, n String') where n = ''"
+
+echo "String over ten row groups, null_as_default on, both disjuncts on the nullable column"
+run 0 1 "select count() from file('${DATA_FILE_3}', Parquet, 'id UInt64, n String') where n = '' or n = 'v3'"
+
+# Control: read as Nullable the guard does not apply, so the bloom filter must still prune everything.
+echo "String over ten row groups read as Nullable: the bloom filter still prunes a non-present value"
+run 0 0 "select count() from file('${DATA_FILE_3}', Parquet, 'id UInt64, n Nullable(String)') where n = 'absent'"

--- a/tests/queries/0_stateless/04646_parquet_v3_bloom_filter_null_safety.sh
+++ b/tests/queries/0_stateless/04646_parquet_v3_bloom_filter_null_safety.sh
@@ -87,8 +87,8 @@ ${CLICKHOUSE_CLIENT} --query="
 echo "String over ten row groups, null_as_default on: nulls decode to '', no row group must be pruned"
 run 0 1 "select count() from file('${DATA_FILE_3}', Parquet, 'id UInt64, n String') where n = ''"
 
-echo "String over ten row groups, null_as_default on, both disjuncts on the nullable column"
-run 0 1 "select count() from file('${DATA_FILE_3}', Parquet, 'id UInt64, n String') where n = '' or n = 'v3'"
+echo "String over ten row groups, null_as_default on, disjunction with an atom on another column"
+run 0 1 "select count() from file('${DATA_FILE_3}', Parquet, 'id UInt64, n String') where n = '' or id = 1"
 
 # Control: read as Nullable the guard does not apply, so the bloom filter must still prune everything.
 echo "String over ten row groups read as Nullable: the bloom filter still prunes a non-present value"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/112580   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/110567
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/112580
Related: https://github.com/ClickHouse/ClickHouse/pull/110567

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Test-only. @PedroTadim asked for a PR covering the #112580 reproducer.

That defect is already fixed on master by 3befbafe5b9e (#110567), which disables the
chunk-level bloom filter when a column is nullable in the file but read into a
non-nullable output. `04646_parquet_v3_bloom_filter_null_safety` landed with that fix,
but it only exercises an integer column in a single row group, so three properties of
the reported reproducer were untested:

- the empty-string default of a `String` column, which hashes through a different
  physical Parquet type than an integer;
- a disjunction whose other atom is on a different column, which combines a false bloom
  verdict for the guarded column with a surviving atom elsewhere in the RPN;
- a multi-row-group file, which is what the per-column-chunk pruning decision gates.

I added those as three arms over a ten-row-group `Nullable(String)` fixture, all on the
standalone bloom path. A dictionary-eligible arm would not test the guard: the exact
dictionary filter models null-as-default itself by hashing the default value, so it
answers correctly either way. The third arm reads the same fixture as `Nullable`, where
the guard does not apply, and asserts the bloom filter still prunes everything; without
it the first two arms could pass on a fixture where pruning never happens at all.

Validated by reverting the guard to its pre-fix behavior and rebuilding: arm 1 drops to
0 rows read from 1000, arm 2 to the single row group holding its other literal. Both
restore on the fixed binary. 100 consecutive randomized runs passed.

The issue was already closed by its author, so the `Closes` line above is a provenance
link rather than a closing action.
