### PR TITLE
Fix two stateless tests a Replicated database refuses to run

### DIFF
--- a/tests/queries/0_stateless/03990_alter_rename_column_swap_different_types.sql
+++ b/tests/queries/0_stateless/03990_alter_rename_column_swap_different_types.sql
@@ -1,5 +1,9 @@
--- Tags: no-random-merge-tree-settings
+-- Tags: no-random-merge-tree-settings, no-replicated-database
 -- ^ wide/compact split is asserted explicitly via min_bytes_for_wide_part.
+-- Tag no-replicated-database: one assertion combines RENAME and UPDATE in a single ALTER, which a
+-- Replicated database refuses (InterpreterAlterQuery groups an ALTER's commands into segments by
+-- kind and rejects any multi-segment ALTER, QUERY_IS_PROHIBITED). The combined form is the
+-- assertion here, so it cannot be split into two ALTERs.
 
 -- Regression test for https://github.com/ClickHouse/ClickHouse/issues/103247
 -- A compound RENAME that reuses a freed column name (a "swap") between columns

--- a/tests/queries/0_stateless/04510_s3_explicit_url_named_secret_mask.reference
+++ b/tests/queries/0_stateless/04510_s3_explicit_url_named_secret_mask.reference
@@ -218,3 +218,4 @@ EXPLAIN QUERY TREE run_passes = 0 SELECT * FROM s3(\'http://localhost:11111/test
 EXPLAIN QUERY TREE run_passes = 0 SELECT * FROM s3(\'http://localhost:11111/test/04510qt\', NOSIGN, \'TSV\', \'x UInt8\', headers(\'Authorization\' = \'[HIDDEN]\'))
 EXPLAIN QUERY TREE run_passes = 0 SELECT * FROM s3(nc_04510_missing, url = \'https://[HIDDEN]@localhost:11111/test/04510qt?X-Amz-Signature=[HIDDEN]\', structure = \'x UInt8\')
 EXPLAIN QUERY TREE run_passes = 0 SELECT * FROM s3(\'http://localhost:11111/test/04510qt\', \'ak\', \'[HIDDEN]\', \'TSV\', \'x UInt8\') UNION ALL SELECT 1
+1	0

--- a/tests/queries/0_stateless/04510_s3_explicit_url_named_secret_mask.sql
+++ b/tests/queries/0_stateless/04510_s3_explicit_url_named_secret_mask.sql
@@ -333,3 +333,13 @@ WHERE current_database = currentDatabase()
                                   -- initiator's initial_query_id but gets a fresh query_id
   AND event_date >= yesterday() AND event_time > now() - INTERVAL 5 MINUTE
 ORDER BY event_time_microseconds;
+
+-- The transcript above is scoped to the statements this test issued. A Replicated database also
+-- logs each DDL from the replay worker, which re-masks a rewritten AST independently, so assert
+-- the masking property over every row this test produced, replay rows included. count() > 0 keeps
+-- an empty row set from passing vacuously.
+SELECT count() > 0, countIf(query LIKE '%SEKRIT%')
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type != 'QueryStart'
+  AND event_date >= yesterday() AND event_time > now() - INTERVAL 5 MINUTE;

--- a/tests/queries/0_stateless/04510_s3_explicit_url_named_secret_mask.sql
+++ b/tests/queries/0_stateless/04510_s3_explicit_url_named_secret_mask.sql
@@ -328,5 +328,8 @@ WHERE current_database = currentDatabase()
   AND type != 'QueryStart'
   AND query_kind != 'Set' -- sent by the test harness, not by this test
   AND query NOT ILIKE 'SYSTEM FLUSH%' -- its own terminal event races with the flush it performs
+  AND query_id = initial_query_id -- only the statements issued here: a Replicated database logs
+                                  -- each DDL again from the replay worker, which inherits the
+                                  -- initiator's initial_query_id but gets a fresh query_id
   AND event_date >= yesterday() AND event_time > now() - INTERVAL 5 MINUTE
 ORDER BY event_time_microseconds;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/112052


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Two of the nine failures @alexey-milovidov asked me to investigate on #112052, in the
`Stateless tests (amd_llvm_coverage, old analyzer, s3 storage, DBReplicated, WasmEdge, parallel, 1/3)`
job. Both fail on every run of that flavour, and look flaky only because the diagnostics rerun drops
`--replicated-database` and llvm-coverage force-sets `OK`. Six of the nine are already fixed (#112862,
#112993); `04511` is a distributed-DDL timeout tracked elsewhere. Tests only.

**1. `03990_alter_rename_column_swap_different_types`, `Code: 392 QUERY_IS_PROHIBITED`.** One assertion
issues `RENAME COLUMN ..., RENAME COLUMN ..., UPDATE ... WHERE 1` as a single ALTER, which
`InterpreterAlterQuery` refuses on a `DatabaseReplicated` because it spans two command kinds. That form
is the assertion: the `UPDATE` forces the part rewrite exercising `getColumnsForNewDataPart` while the
renamed-from column holds no data, so splitting it loses the #103247 coverage. Tagged
`no-replicated-database`, as merged for `04278` in #112862, which costs Replicated, Cloud and
shared-catalog coverage. The file's twelve other ALTERs are single-kind and unaffected.

**2. `04510_s3_explicit_url_named_secret_mask`, result differs by 14 lines.** Its closing oracle is a
byte-exact `system.query_log` transcript scoped only by `current_database`, and the DDL replay worker
logs each DDL a second time. Every secret is still `[HIDDEN]` there: masking is intact, the oracle
over-specifies. A skip tag would lose coverage of 47 tagged secrets, so I scoped the transcript with
`AND query_id = initial_query_id`: a replay row gets a fresh `query_id` but inherits the initiator's.
That path masks a rewritten AST independently instead of copying the initiator's masked text, so the
filter alone would leave a regression there undetected. So I also assert over every row, replay
included, that no tagged secret appears, guarded by `count() > 0` against a vacuous pass.

Both reproduce deterministically with `--replicated-database`, pass after the fix, still pass without
it, and survive 50 randomized runs per flavour. The new assertion is armed both ways.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.814` (included in `26.8` and later)
<!-- ch-version-info:end -->