### PR TITLE
Fix hang when dropping a Refreshable Materialized View during refresh planning

### DIFF
--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -1329,6 +1329,20 @@ std::optional<UUID> RefreshTask::executeRefreshUnlocked(int32_t root_znode_versi
                 query_for_logging, normalized_query_hash, refresh_query.get(), refresh_context, Stopwatch{CLOCK_MONOTONIC}.getStart(), internal);
 
             refresh_context->setProcessListElement(process_list_entry->getQueryStatus());
+
+            /// Publish the query status before interpreting the query, not just around the pipeline executor
+            /// below: planning runs nested pipelines for `IN (subquery)` sets, and only the status cancels those.
+            {
+                std::unique_lock exec_lock(execution.executor_mutex);
+                if (execution.interrupt_execution.load())
+                    throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Refresh for view {} cancelled", view_storage_id.getFullTableName());
+                execution.executing_query_status = process_list_entry->getQueryStatus();
+            }
+            SCOPE_EXIT({
+                std::unique_lock exec_lock(execution.executor_mutex);
+                execution.executing_query_status = nullptr;
+            });
+
             /// Carry the refresh query's normalized hash so that `NORMALIZED_QUERY_HASH` quotas account
             /// the refresh write (`WRITTEN_BYTES` pre-check and `CountingTransform`) to the refresh
             /// pattern's bucket instead of the shared hash-0 bucket.
@@ -1370,12 +1384,10 @@ std::optional<UUID> RefreshTask::executeRefreshUnlocked(int32_t root_znode_versi
                     if (execution.interrupt_execution.load())
                         throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Refresh for view {} cancelled", view_storage_id.getFullTableName());
                     execution.executor = &executor;
-                    execution.executing_query_status = process_list_entry ? process_list_entry->getQueryStatus() : nullptr;
                 }
                 SCOPE_EXIT({
                     std::unique_lock exec_lock(execution.executor_mutex);
                     execution.executor = nullptr;
-                    execution.executing_query_status = nullptr;
                 });
 
                 executor.execute(pipeline.getNumThreads(), pipeline.getConcurrencyControl());

--- a/src/Storages/MaterializedView/RefreshTask.h
+++ b/src/Storages/MaterializedView/RefreshTask.h
@@ -290,7 +290,7 @@ private:
         std::atomic_bool interrupt_execution {false};
         PipelineExecutor * executor = nullptr;
         /// Process-list entry of the in-flight refresh query, so interruptExecution() can mark it
-        /// killed. Set/cleared together with `executor`.
+        /// killed. Set as soon as the query enters the process list, before it is interpreted.
         std::shared_ptr<QueryStatus> executing_query_status;
         /// Interrupts internal CREATE/EXCHANGE/DROP queries that refresh does. Only used during shutdown.
         StopSource cancel_ddl_queries;

--- a/tests/queries/0_stateless/04661_refreshable_mv_cancel_during_planning.reference
+++ b/tests/queries/0_stateless/04661_refreshable_mv_cancel_during_planning.reference
@@ -1,0 +1,1 @@
+dropped

--- a/tests/queries/0_stateless/04661_refreshable_mv_cancel_during_planning.sh
+++ b/tests/queries/0_stateless/04661_refreshable_mv_cancel_during_planning.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "
+    create table src (k UInt64) engine MergeTree order by k as select number from numbers(10);"
+
+# `k IN (subquery)` over the primary key materializes the set during query planning
+# (ReadFromMergeTree::buildIndexes -> KeyCondition -> FutureSetFromSubquery::buildOrderedSetInplace),
+# so the refresh blocks in a nested pipeline that it does not own an executor for yet.
+$CLICKHOUSE_CLIENT -q "
+    create materialized view rmv refresh every 1 second (k UInt64) engine MergeTree order by k as
+        select k from src where k in (select number from numbers(30) where sleepEachRow(1) = 0)
+        settings max_block_size = 1;"
+
+# Wait until the refresh is inside that nested pipeline.
+for _ in {1..300}; do
+    started=$($CLICKHOUSE_CLIENT -q "
+        select count() from system.processes
+        where current_database = currentDatabase() and query like 'INSERT INTO%sleepEachRow%' and elapsed > 2")
+    if [ "$started" = "1" ]; then
+        break
+    fi
+    sleep 0.2
+done
+
+# The drop must cancel the refresh, not wait for the blocked planning to finish.
+if timeout 10 $CLICKHOUSE_CLIENT -q "drop table rmv"; then
+    echo "dropped"
+else
+    echo "drop did not finish"
+fi
+
+$CLICKHOUSE_CLIENT -q "drop table src"

--- a/tests/queries/0_stateless/04661_refreshable_mv_cancel_during_planning.sh
+++ b/tests/queries/0_stateless/04661_refreshable_mv_cancel_during_planning.sh
@@ -15,15 +15,19 @@ $CLICKHOUSE_CLIENT -q "
         select k from src where k in (select number from numbers(30) where sleepEachRow(1) = 0)
         settings max_block_size = 1;"
 
-# Wait until the refresh is inside that nested pipeline.
-for _ in {1..300}; do
-    started=$($CLICKHOUSE_CLIENT -q "
+# Wait until the refresh is inside that nested pipeline. Fail hard on timeout: a drop that never
+# meets a blocked refresh returns quickly for the wrong reason, and the test would then match the
+# reference without exercising the cancellation path it covers.
+i=0
+while [ "$($CLICKHOUSE_CLIENT -q "
         select count() from system.processes
-        where current_database = currentDatabase() and query like 'INSERT INTO%sleepEachRow%' and elapsed > 2")
-    if [ "$started" = "1" ]; then
-        break
+        where current_database = currentDatabase() and query like 'INSERT INTO%sleepEachRow%' and elapsed > 2")" -ne 1 ]; do
+    sleep 0.3
+    i=$((i + 1))
+    if [ "$i" -gt 200 ]; then
+        echo "Refresh did not reach the planning stage in time" >&2
+        exit 1
     fi
-    sleep 0.2
 done
 
 # The drop must cancel the refresh, not wait for the blocked planning to finish.


### PR DESCRIPTION
`DROP TABLE` of a Refreshable Materialized View waited for the in-flight refresh to finish planning its query, because the refresh query became cancellable only once its pipeline existed. It is now published to the process list before interpretation.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `DROP TABLE` and `SYSTEM STOP VIEW` hanging when a Refreshable Materialized View is blocked while planning its refresh query.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.988` (included in `26.8` and later)
- Backported to: `26.7.4.38`, `26.6.3.54`, `26.5.7.62`, `26.3.20.3`
<!-- ch-version-info:end -->