### PR TITLE
Fix flaky test_replicated_database_and_unavailable_s3: wait for the digest rewrite

### DIFF
--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -1705,12 +1705,20 @@ def test_replicated_database_and_unavailable_s3(started_cluster, use_delta_kerne
 
         node2.restart_clickhouse()
 
-        assert (
-            node2.query(
+        # `restart_clickhouse` only waits until the server answers a query, but the
+        # digest is rewritten by the background `startup Replicated database` job, so
+        # poll instead of reading it once.
+        digest = None
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            digest = node2.query(
                 f"SELECT value FROM system.zookeeper WHERE path = '{replica_path}' AND name = 'digest'"
             ).strip()
-            != "123456"
-        )
+            if digest != "123456":
+                break
+            time.sleep(1)
+
+        assert digest != "123456"
 
 
 def test_session_token(started_cluster):

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -1691,6 +1691,10 @@ def test_replicated_database_and_unavailable_s3(started_cluster, use_delta_kerne
 
         replica_path = f"/clickhouse/databases/{DB_NAME}/replicas/shard1|node2"
         zk = started_cluster.get_kazoo_client("zoo1")
+        expected_digest = node2.query(
+            f"SELECT value FROM system.zookeeper WHERE path = '{replica_path}' AND name = 'digest'"
+        ).strip()
+        assert expected_digest != "123456"
         zk.set(replica_path + "/digest", "123456".encode())
 
         # Compare the `digest` value exactly instead of substring-matching the
@@ -1705,20 +1709,22 @@ def test_replicated_database_and_unavailable_s3(started_cluster, use_delta_kerne
 
         node2.restart_clickhouse()
 
-        # `restart_clickhouse` only waits until the server answers a query, but the
-        # digest is rewritten by the background `startup Replicated database` job, so
-        # poll instead of reading it once.
+        # `restart_clickhouse` only waits until the server answers a query, while the
+        # digest is rewritten later, from replica recovery on a background thread, so
+        # poll instead of reading it once. Compare against the digest from before the
+        # overwrite: any other value ("42" to force recovery, an empty result from a
+        # missing znode) means the digest was not restored.
         digest = None
         deadline = time.monotonic() + 60
         while time.monotonic() < deadline:
             digest = node2.query(
                 f"SELECT value FROM system.zookeeper WHERE path = '{replica_path}' AND name = 'digest'"
             ).strip()
-            if digest != "123456":
+            if digest == expected_digest:
                 break
             time.sleep(1)
 
-        assert digest != "123456"
+        assert digest == expected_digest
 
 
 def test_session_token(started_cluster):

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -1709,20 +1709,15 @@ def test_replicated_database_and_unavailable_s3(started_cluster, use_delta_kerne
 
         node2.restart_clickhouse()
 
-        # `restart_clickhouse` only waits until the server answers a query, while the
-        # digest is rewritten later, from replica recovery on a background thread, so
-        # poll instead of reading it once. Compare against the digest from before the
-        # overwrite: any other value ("42" to force recovery, an empty result from a
-        # missing znode) means the digest was not restored.
-        digest = None
-        deadline = time.monotonic() + 60
-        while time.monotonic() < deadline:
-            digest = node2.query(
-                f"SELECT value FROM system.zookeeper WHERE path = '{replica_path}' AND name = 'digest'"
-            ).strip()
-            if digest == expected_digest:
-                break
-            time.sleep(1)
+        # Replica recovery rewrites the digest from a background thread, and the first
+        # read can still hit a not-yet-connected Keeper session, so retry on both. Only
+        # the original value counts as restored ("42" forces recovery, empty = no znode).
+        digest = node2.query_with_retry(
+            f"SELECT value FROM system.zookeeper WHERE path = '{replica_path}' AND name = 'digest'",
+            retry_count=60,
+            sleep_time=1,
+            check_callback=lambda x: x.strip() == expected_digest,
+        ).strip()
 
         assert digest == expected_digest
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/100332

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_storage_delta/test.py::test_replicated_database_and_unavailable_s3` overwrites
the `digest` znode of the `node2` replica with the sentinel `123456`, restarts
`node2`, and asserts the replica recomputed the digest.

The assertion read the znode once, right after `restart_clickhouse` returned. That
return only means the server answers a query (`Instance.wait_start` polls
`SELECT 20`), but the znode is rewritten later, from replica recovery on a
background thread: `DatabaseReplicated::startupDatabaseAsync` schedules the
`startup Replicated database` job on `TablesLoaderBackgroundStartupPoolId`, and only
that job reaches `DatabaseReplicatedDDLWorker::initializeReplication` ->
`recoverLostReplica`, which performs the write. The query interface is up first, so
the single read could still observe the sentinel and fail. The window is widest on
slow builds, which is where this is reported (`amd_asan_ubsan`).

The change polls the digest instead of reading it once, bounded by 60 seconds of
wall-clock time with a 1 second sleep between reads, and compares against the digest
captured *before* the overwrite rather than merely "not the sentinel". The old
`!= "123456"` form also accepted values that mean the digest was **not** restored:
the literal `"42"` (`DatabaseReplicatedDDLWorker::FORCE_AUTO_RECOVERY_DIGEST`, written
to force another recovery), an empty result from a missing znode, or any wrong value.

The test still fails if the replica genuinely does not restore its digest; it just no
longer depends on the background recovery winning a race against the next statement.

<details>
<summary>Validation</summary>

The assertion loop was exercised against recorded server responses. Only the healthy
sequences pass, and every regression still fails:

| Scenario | Digest observed | Result |
|---|---|---|
| digest rewritten after a few polls (the race) | pre-overwrite value | pass |
| digest rewritten immediately (fast machine) | pre-overwrite value | pass, 1 poll, no added latency |
| digest never rewritten | `123456` | fail |
| stuck at `FORCE_AUTO_RECOVERY_DIGEST` | `42` | fail |
| znode missing | empty | fail |
| wrong digest written | `777` | fail |

The last three pass under the previous `!= "123456"` assertion, so the oracle is
strictly stronger than before. `ruff check --select F401,F403,F405,F541,F841` is clean
on the changed file.
</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.756` (included in `26.8` and later)
<!-- ch-version-info:end -->