### PR TITLE
Build profile diff: stop reporting noise

### DIFF
--- a/ci/jobs/build_profile_diff_job.py
+++ b/ci/jobs/build_profile_diff_job.py
@@ -45,6 +45,12 @@ Notes on data coverage:
     linked (clickhouse-keeper has none when built as a symlink to clickhouse).
   * `binary_sizes` is complete on both sides; `binary_symbols` is complete on
     the PR side and on master builds since this check was introduced.
+  * The warmup build builds every object-file target ninja knows about while a
+    PR build builds only `clickhouse-bundle`, so the object-size comparison
+    covers the object files the PR build produced (see `compare_objects`).
+  * Names coming out of a ThinLTO link carry an unstable `.llvm.<hash>` clone
+    suffix, so symbols and per-function times are keyed by the name with that
+    suffix removed (see `strip_clone_suffix`).
 
 Local run (no AWS SSM secrets and no PR comment; `gh` is still required, to
 enumerate master history from the provided baseline):
@@ -108,9 +114,15 @@ BINARY_SIG_BYTES = 8 << 20  # stripped binary: 8 MiB and
 BINARY_SIG_RATIO = 0.01  # 1%
 OBJECT_REPORT_BYTES = 16 << 10  # .o file: report at 16 KiB,
 OBJECT_SIG_BYTES = 256 << 10  # significant at 256 KiB
-OPTFN_REPORT_SECONDS = 2  # per-function LTO time: report at |delta| >= 2s
-OPTFN_REPORT_RATIO = 1.5  # and 1.5x, significant at 15s
-OPTFN_SIG_SECONDS = 15
+# Per-function ThinLTO time is the noisiest signal of the check: the two links
+# run on different machines, with different flags, and the backend's per-function
+# time depends on the import decisions of the whole module. Measured on pull
+# requests that cannot possibly have changed the functions in question, single
+# functions of a few seconds drifted by up to a factor of two - which the old
+# 2 s / 1.5x reporting bar turned into a dozen-row table on every pull request.
+OPTFN_REPORT_SECONDS = 5  # per-function LTO time: report at |delta| >= 5s
+OPTFN_REPORT_RATIO = 2.0  # and 2x, significant at 20s
+OPTFN_SIG_SECONDS = 20
 TU_REPORT_SECONDS = 5  # per-TU compile time: report at |delta| >= 5s
 TU_REPORT_RATIO = 1.3  # and 1.3x, significant at 20s and 1.5x
 TU_SIG_SECONDS = 20
@@ -125,8 +137,14 @@ TU_SIG_RATIO = 1.5
 # baselines use the PR's flags, but not the PR's runner.
 TU_SKEW_SIG_RATIO = 1.2
 TU_SKEW_SIG_SECONDS = 300
-SYMBOL_REPORT_BYTES = 16 << 10  # per-symbol size: report at 16 KiB,
-SYMBOL_SIG_BYTES = 256 << 10  # significant at 256 KiB
+# Per-symbol sizes are baselined on the official master build, not on the
+# flag-identical warmup one: its different flags change ThinLTO's inlining and
+# import decisions, so individual functions really do differ in size between two
+# builds of the same source. The whole stripped binary drifts by ~3 MiB on a
+# no-op pull request, so the margins here are much wider than the object-file
+# ones (those are baselined on a build compiled with the PR's exact flags).
+SYMBOL_REPORT_BYTES = 64 << 10  # per-symbol size: report at 64 KiB,
+SYMBOL_SIG_BYTES = 512 << 10  # significant at 512 KiB
 MAX_TABLE_ROWS = 20
 MAX_NAME_LEN = 100
 
@@ -295,6 +313,33 @@ def md_code(name: str) -> str:
 
 def strip_build_dir(path: str) -> str:
     return path.removeprefix(f"{BUILD_DIR}/")
+
+
+# ThinLTO's clone suffix, in the demangled form (` [clone .llvm.123]`) and in the
+# mangled one (`.llvm.123`) - `binary_symbols` holds demangled names, the time
+# trace holds mangled ones.
+CLONE_SUFFIX_RE = r"' ?\\[clone \\.llvm\\.[0-9]+\\]'"
+LLVM_SUFFIX_RE = r"'\\.llvm\\.[0-9]+'"
+
+
+def strip_clone_suffix(column: str) -> str:
+    """SQL dropping ThinLTO's `.llvm.<hash>` suffix from a symbol name.
+
+    When ThinLTO imports a function it promotes the module-local symbols it
+    needs and renames them with a `.llvm.<hash>` suffix (`nm --demangle` renders
+    it as ` [clone .llvm.<hash>]`). The hash is derived from the defining
+    module's identity, so it is not stable across builds: two builds of the very
+    same source name the same clone differently.
+
+    Both sides are therefore normalized by dropping the suffix, which also folds
+    the several clones of one function into a single row. Without it an entirely
+    unchanged function appears twice - once as removed, once as new, at exactly
+    the same size - and those phantom pairs were the largest rows of the symbol
+    and ThinLTO tables on every pull request, and enough to declare both
+    sections significant.
+    """
+    without_clone = f"replaceRegexpAll({column}, {CLONE_SUFFIX_RE}, '')"
+    return f"replaceRegexpAll({without_clone}, {LLVM_SUFFIX_RE}, '')"
 
 
 _DEMANGLER = None
@@ -655,6 +700,19 @@ def compare_objects(db: Db, pr_side, base_side) -> Section:
     The warmup build is the only master build compiled with the PR's exact
     flags: the official master build keeps debug symbols inside every .o file
     while PR builds strip them, which would dwarf any real change.
+
+    Only the object files the PR build produced are compared. The two builds do
+    not have the same target set: the warmup build compiles every object-file
+    target ninja knows about (see PR_CACHE_WARMUP_BUILD_TYPES in
+    build_clickhouse.py), while a PR build only builds `clickhouse-bundle`, so
+    hundreds of object files - `grpc_unsecure`, protobuf-lite, the gRPC half of
+    google-cloud-cpp, the unit tests, the utils - exist on the warmup side alone.
+    Reading them as removals produced a "685 removed, -40 MiB" finding on every
+    pull request. A PR-only object file, on the other hand, is a real addition:
+    the warmup side builds a superset of the target set, so it is a source file
+    the PR added. The reverse signal - a source file the PR deletes - is left to
+    the binary and symbol sections; there is no way to tell it apart from the
+    target-set difference here.
     """
     section = Section(title="Object file sizes")
     if base_side is None:
@@ -667,16 +725,16 @@ def compare_objects(db: Db, pr_side, base_side) -> Section:
             toInt64(pr_size) - toInt64(base_size) AS delta
         FROM {both_sides("binary_sizes", "file, size", pr_side, base_side, OBJECT_FILTER)}
         GROUP BY file
-        HAVING abs(delta) >= {OBJECT_REPORT_BYTES}
+        HAVING pr_size > 0 AND abs(delta) >= {OBJECT_REPORT_BYTES}
         ORDER BY abs(delta) DESC
         LIMIT {MAX_TABLE_ROWS}"""
     )
     totals = db.query(
         f"""SELECT
             countIf(pr_size > 0 AND base_size > 0 AND pr_size != base_size) AS changed,
-            countIf(base_size = 0) AS added,
-            countIf(pr_size = 0) AS removed,
-            sum(toInt64(pr_size) - toInt64(base_size)) AS total_delta
+            countIf(pr_size > 0 AND base_size = 0) AS added,
+            countIf(pr_size = 0) AS base_only,
+            sumIf(toInt64(pr_size) - toInt64(base_size), pr_size > 0) AS total_delta
         FROM (
             SELECT file,
                 maxIf(size, side = 'pr') AS pr_size,
@@ -685,16 +743,21 @@ def compare_objects(db: Db, pr_side, base_side) -> Section:
             GROUP BY file
         )"""
     )[0]
-    changed, added, removed = (
+    changed, added, base_only = (
         int(totals["changed"]),
         int(totals["added"]),
-        int(totals["removed"]),
+        int(totals["base_only"]),
     )
-    if not rows and not added and not removed:
+    # The baseline-only files are the target-set difference, not a finding, so
+    # they never bring the section to life on their own. Say how many were left
+    # out in the job log even when the section stays silent.
+    if base_only:
+        print(f"{base_only} object files exist only in the warmup baseline (target-set difference) and are not compared")
+    if not rows and not added:
         return section
 
     lines = [
-        f"{changed} object files changed ({format_bytes_delta(int(totals['total_delta']), 0)} total), {added} added, {removed} removed.",
+        f"{changed} object files changed ({format_bytes_delta(int(totals['total_delta']), 0)} total), {added} added.",
         "",
         "| Object file | Master | PR | Δ |",
         "|---|---:|---:|---:|",
@@ -704,17 +767,23 @@ def compare_objects(db: Db, pr_side, base_side) -> Section:
         delta = int(row["delta"])
         # OBJECT_FILTER keeps only real compile-stage .o files (link-stage
         # artifacts do not end in .o, and scratch/incremental dirs are
-        # excluded), and both sides compile the full set of objects with the
-        # same flags - so a one-sided row is a genuinely added or removed
+        # excluded), and the warmup build compiles a superset of the PR's
+        # targets with the same flags - so a PR-only row is a genuinely added
         # object file. Its whole size is the delta, and it drives the verdict
         # exactly like a size change of a file present on both sides.
         if abs(delta) >= OBJECT_SIG_BYTES:
             section.significant = True
         base_text = format_bytes(base_size) if base_size else "new"
-        pr_text = format_bytes(pr_size) if pr_size else "removed"
-        lines.append(f"| {md_code(strip_build_dir(row['file']))} | {base_text} | {pr_text} | {format_bytes_delta(delta, base_size)} |")
+        lines.append(f"| {md_code(strip_build_dir(row['file']))} | {base_text} | {format_bytes(pr_size)} | {format_bytes_delta(delta, base_size)} |")
+    if base_only:
+        lines += [
+            "",
+            f"{base_only} more object {'file is' if base_only == 1 else 'files are'} built by the "
+            "master warmup baseline only (it builds every object-file target, a "
+            "pull request build only `clickhouse-bundle`) and not compared.",
+        ]
     section.body = "\n".join(lines)
-    section.summary = f"{changed} object files changed, {added} added, {removed} removed"
+    section.summary = f"{changed} object files changed, {added} added"
     return section
 
 
@@ -741,6 +810,22 @@ def compare_opt_functions(db: Db, pr_side, base_side) -> Section:
     uniform ratio. The median ratio over matched functions estimates the skew
     and per-function deltas are taken relative to it, the same way the per-TU
     compile-time section normalizes its machine-speed skew.
+
+    The skew is estimated per binary. Each binary is a separate ThinLTO link, so
+    the two links of a build do not even run at the same time, let alone the
+    links of the two sides: their ratios to the baseline routinely differ by more
+    than a factor of two. One median over both binaries splits the difference and
+    charges the whole gap to the functions of both - it reported the unchanged
+    functions of `clickhouse` as several seconds faster and those of
+    `clickhouse-keeper` as twice as slow, in the same table, on a pull request
+    that touched neither.
+
+    A shift that moves every function of a binary by the same factor is the skew
+    itself, so - unlike the per-TU compile-time section, which judges its skew on
+    the section level - it produces no finding here. Absolute link times are not
+    comparable between the two sides at all (the master build's debug info alone
+    changes them by tens of percent), so there is nothing to judge such a shift
+    against.
     """
     section = Section(title="Slowest function optimization changes (ThinLTO)")
     trace_where = "name = 'OptFunction' AND dur >= 50000"
@@ -781,25 +866,37 @@ def compare_opt_functions(db: Db, pr_side, base_side) -> Section:
         section.body = "\n".join(lines).rstrip()
         return section
     where = f"file IN ({in_list(comparable)}) AND {trace_where}"
+    # ThinLTO renames the clones it creates with an unstable hash, so both sides
+    # are keyed by the normalized function name (see strip_clone_suffix).
+    both = both_sides(
+        "build_time_trace",
+        f"file, {strip_clone_suffix('detail')} AS detail, dur",
+        pr_side,
+        base_side,
+        where,
+    )
     # The systematic skew between the sides, as the median PR/master time
-    # ratio over functions matched on both sides with a non-trivial baseline.
+    # ratio over functions matched on both sides with a non-trivial baseline,
+    # per binary (each is its own link, see above).
     # Interpolated: `medianExact` returns the upper middle element on an even
     # count, which overestimates the shift when a part of the functions
     # regressed and would normalize that regression away.
     skew_rows = db.query(
-        f"""SELECT quantileExactWeightedInterpolated(0.5)(pr_dur / base_dur, 1) AS skew, count() AS matched
+        f"""SELECT file, quantileExactWeightedInterpolated(0.5)(pr_dur / base_dur, 1) AS skew, count() AS matched
         FROM (
             SELECT file, detail,
                 sumIf(dur, side = 'pr') AS pr_dur,
                 sumIf(dur, side = 'base') AS base_dur
-            FROM {both_sides("build_time_trace", "file, detail, dur", pr_side, base_side, where)}
+            FROM {both}
             GROUP BY file, detail
             HAVING pr_dur >= 500000 AND base_dur >= 500000
-        )"""
+        )
+        GROUP BY file"""
     )
-    skew = 1.0
-    if skew_rows and int(skew_rows[0]["matched"]) >= 10:
-        skew = float(skew_rows[0]["skew"])
+    skews = {row["file"]: float(row["skew"]) for row in skew_rows if int(row["matched"]) >= 10}
+    skew_expr = "1.0"
+    if skews:
+        skew_expr = f"transform(file, [{in_list(skews)}], [{', '.join(f'{v}' for v in skews.values())}], 1.0)"
     report_us = int(OPTFN_REPORT_SECONDS * 1e6)
     # dur >= 50ms cuts the aggregation from ~1M rows per side to tens of
     # thousands; a function can only reach the report threshold if one side
@@ -808,22 +905,26 @@ def compare_opt_functions(db: Db, pr_side, base_side) -> Section:
         f"""SELECT file, detail,
             sumIf(dur, side = 'pr') AS pr_dur,
             sumIf(dur, side = 'base') AS base_dur,
-            toInt64(pr_dur) - toInt64(base_dur * {skew}) AS delta
-        FROM {both_sides("build_time_trace", "file, detail, dur", pr_side, base_side, where)}
+            base_dur * ({skew_expr}) AS adjusted_base_dur,
+            toInt64(pr_dur) - toInt64(adjusted_base_dur) AS delta
+        FROM {both}
         GROUP BY file, detail
         HAVING abs(delta) >= {report_us}
             AND (pr_dur = 0 OR base_dur = 0
-                 OR greatest(toFloat64(pr_dur), base_dur * {skew}) >= least(toFloat64(pr_dur), base_dur * {skew}) * {OPTFN_REPORT_RATIO})
+                 OR greatest(toFloat64(pr_dur), adjusted_base_dur) >= least(toFloat64(pr_dur), adjusted_base_dur) * {OPTFN_REPORT_RATIO})
         ORDER BY abs(delta) DESC
         LIMIT {MAX_TABLE_ROWS}"""
     )
     if not rows:
         section.body = "\n".join(lines).rstrip()
         return section
-    if abs(skew - 1.0) >= 0.05:
+    skewed = sorted((f, s) for f, s in skews.items() if abs(s - 1.0) >= 0.05)
+    if skewed:
+        ratios = ", ".join(f"{md_code(strip_build_dir(f))} ×{s:.2f}" for f, s in skewed)
         lines += [
-            f"Median per-function time ratio to the master baseline is ×{skew:.2f} "
-            "(different machine and build flags); deltas below are relative to that ratio.",
+            f"Median per-function time ratio to the master baseline: {ratios} "
+            "(each binary is linked separately, on a different machine and with "
+            "different build flags); deltas below are relative to it.",
             "",
         ]
     lines += [
@@ -832,7 +933,7 @@ def compare_opt_functions(db: Db, pr_side, base_side) -> Section:
     ]
     for row in rows:
         pr_s, base_s = int(row["pr_dur"]) / 1e6, int(row["base_dur"]) / 1e6
-        adjusted_base_s = base_s * skew
+        adjusted_base_s = base_s * skews.get(row["file"], 1.0)
         delta = pr_s - adjusted_base_s
         if abs(delta) >= OPTFN_SIG_SECONDS:
             section.significant = True
@@ -1066,7 +1167,7 @@ def drill_down_tu(db: Db, pr_side, base_side, file, library, skew=1.0) -> List[s
         FROM {
             both_sides(
                 "build_time_trace",
-                "name, detail, dur",
+                f"name, {strip_clone_suffix('detail')} AS detail, dur",
                 pr_side,
                 base_side,
                 f"file = {quote(file)} AND library = {quote(library)} AND detail != '' AND name IN ('InstantiateFunction', 'InstantiateClass', 'ParseClass', 'Source', 'OptFunction', 'CodeGen Function')",
@@ -1100,6 +1201,11 @@ def compare_symbols(db: Db, pr_side, base_side) -> Section:
     sides have its symbol data; a binary whose symbols the master baseline has
     but the PR build did not upload means the profile producer lost rows, and
     is flagged as an incomplete comparison instead of an all-green omission.
+
+    Symbols are keyed by the name with ThinLTO's clone suffix removed (see
+    `strip_clone_suffix`): the suffix is not stable across builds, so without
+    that the largest rows of the table are the same unchanged function listed
+    twice, once removed and once new.
     """
     section = Section(title="Symbol sizes")
     sides = db.query(
@@ -1137,7 +1243,15 @@ def compare_symbols(db: Db, pr_side, base_side) -> Section:
             sumIf(size, side = 'pr') AS pr_size,
             sumIf(size, side = 'base') AS base_size,
             toInt64(pr_size) - toInt64(base_size) AS delta
-        FROM {both_sides("binary_symbols", "file, symbol, size", pr_side, base_side, f"file IN ({in_list(comparable)}) AND size >= 1024")}
+        FROM {
+            both_sides(
+                "binary_symbols",
+                f"file, {strip_clone_suffix('symbol')} AS symbol, size",
+                pr_side,
+                base_side,
+                f"file IN ({in_list(comparable)}) AND size >= 1024",
+            )
+        }
         GROUP BY file, symbol
         HAVING abs(delta) >= {SYMBOL_REPORT_BYTES}
         ORDER BY abs(delta) DESC

--- a/ci/tests/test_build_profile_diff_job.py
+++ b/ci/tests/test_build_profile_diff_job.py
@@ -84,6 +84,31 @@ _SPEEDUP_TUS = [f"fast_tu{i}.cpp" for i in range(12)]
 _SPEEDUP_BASE_ROWS = _skew_rows(0, _BASE_SHA, "2026-06-30 00:00:00", "arm_release_pr_cache_warmup", "W0", 65000000, tus=_SPEEDUP_TUS)
 _SPEEDUP_PR_ROWS = _skew_rows(_PR, "prsha-uniform-speedup", "2026-07-02 00:00:00", "arm_release", "I14", 30000000, tus=_SPEEDUP_TUS)
 
+def _optfn_rows(pr_number, sha, check_start_time, instance_id, file, prefix, count, dur_us):
+    check_name = "arm_release"
+    return ",\n    ".join(
+        f"({pr_number}, '{sha}', '{check_start_time}', '{check_name}', '{instance_id}', '{file}', 'OptFunction', '{prefix}{i}', {dur_us})"
+        for i in range(count)
+    )
+
+
+# Per-binary ThinLTO skew. Each final binary is its own link, so the two links
+# of one build do not even run at the same time, let alone the links of the two
+# sides: their systematic ratio to the master baseline differs. Here twelve
+# functions of ``clickhouse`` are unchanged (40 s on both sides) while the whole
+# ``clickhouse-keeper`` link is three times slower (5 s -> 15 s). A single median
+# over both binaries is 2.0, which turns every unchanged ``clickhouse`` function
+# into an apparent -40 s regression (twice the significance bar) and normalizes
+# the keeper's real uniform shift away.
+_PER_BINARY_SKEW_ROWS = ",\n    ".join(
+    [
+        _optfn_rows(0, "basesha-skew", "2026-06-30 00:00:00", "IB", _MAIN, "skew_main_fn", 12, 40000000),
+        _optfn_rows(0, "basesha-skew", "2026-06-30 00:00:00", "IB", _KEEPER, "skew_keeper_fn", 12, 5000000),
+        _optfn_rows(_PR, "prsha-skew", "2026-07-02 00:00:00", "IS", _MAIN, "skew_main_fn", 12, 40000000),
+        _optfn_rows(_PR, "prsha-skew", "2026-07-02 00:00:00", "IS", _KEEPER, "skew_keeper_fn", 12, 15000000),
+    ]
+)
+
 _SCHEMA = f"""
 CREATE TABLE binary_sizes
 (
@@ -170,10 +195,10 @@ INSERT INTO build_time_trace (date, pull_request_number, commit_sha, check_start
 
 -- ThinLTO link-trace fixture: both final binaries have OptFunction rows on
 -- both sides. ``main_fn`` (clickhouse) is unchanged; ``keeper_fn``
--- (clickhouse-keeper) regresses 5 s -> 30 s, above the significance bar.
+-- (clickhouse-keeper) regresses 5 s -> 60 s, above the significance bar.
 INSERT INTO build_time_trace (pull_request_number, commit_sha, check_start_time, check_name, instance_id, file, name, detail, dur) VALUES
     ({_PR}, '{_PR_SHA}', '2026-07-02 00:00:00', 'arm_release', 'I2', '{_MAIN}', 'OptFunction', 'main_fn', 10000000),
-    ({_PR}, '{_PR_SHA}', '2026-07-02 00:00:00', 'arm_release', 'I2', '{_KEEPER}', 'OptFunction', 'keeper_fn', 30000000),
+    ({_PR}, '{_PR_SHA}', '2026-07-02 00:00:00', 'arm_release', 'I2', '{_KEEPER}', 'OptFunction', 'keeper_fn', 60000000),
     (0, '{_BASE_SHA}', '2026-06-30 00:00:00', 'arm_release', 'I0', '{_MAIN}', 'OptFunction', 'main_fn', 10000000),
     (0, '{_BASE_SHA}', '2026-06-30 00:00:00', 'arm_release', 'I0', '{_KEEPER}', 'OptFunction', 'keeper_fn', 5000000);
 
@@ -190,8 +215,10 @@ INSERT INTO binary_sizes (pull_request_number, commit_sha, check_start_time, che
     (0, 'basesha-no-stripped', '2026-06-30 00:00:00', 'arm_release', 'I7', '{_MAIN}', 1400);
 
 -- A PR run that adds one large object file (bar.cpp.o, 512 KiB, absent from
--- the warmup baseline) and no longer builds the baseline's foo.cpp.o: both
--- one-sided rows are above OBJECT_SIG_BYTES and must drive the verdict.
+-- the warmup baseline) and does not build the baseline's foo.cpp.o. The added
+-- object is above OBJECT_SIG_BYTES and must drive the verdict; the object the
+-- run does not build is the warmup build's larger target set (it builds every
+-- object-file target, a PR build only ``clickhouse-bundle``), not a removal.
 INSERT INTO binary_sizes (pull_request_number, commit_sha, check_start_time, check_name, instance_id, file, size) VALUES
     ({_PR}, 'prsha-new-object', '2026-07-02 00:00:00', 'arm_release', 'I8', '{_MAIN}', 1500),
     ({_PR}, 'prsha-new-object', '2026-07-02 00:00:00', 'arm_release', 'I8', '{_STRIPPED}', 1500),
@@ -238,6 +265,24 @@ INSERT INTO build_time_trace (pull_request_number, commit_sha, check_start_time,
     {_SPEEDUP_BASE_ROWS};
 INSERT INTO build_time_trace (pull_request_number, commit_sha, check_start_time, check_name, instance_id, file, name, detail, dur) VALUES
     {_SPEEDUP_PR_ROWS};
+
+-- Per-binary ThinLTO skew (see _PER_BINARY_SKEW_ROWS).
+INSERT INTO build_time_trace (pull_request_number, commit_sha, check_start_time, check_name, instance_id, file, name, detail, dur) VALUES
+    {_PER_BINARY_SKEW_ROWS};
+
+-- ThinLTO clone-suffix churn. When ThinLTO imports a function it promotes the
+-- module-local symbols it needs and renames them with a `.llvm.<hash>` suffix
+-- whose hash comes from the defining module, so two builds of the very same
+-- source name the same clone differently. One unchanged function therefore
+-- appears twice - once gone, once new, at exactly the same time and size - and
+-- such phantom pairs were the largest rows of both the ThinLTO and the symbol
+-- table on every pull request, enough to declare both sections significant.
+INSERT INTO build_time_trace (pull_request_number, commit_sha, check_start_time, check_name, instance_id, file, name, detail, dur) VALUES
+    (0, 'basesha-clone', '2026-06-30 00:00:00', 'arm_release', 'IC0', '{_MAIN}', 'OptFunction', '_ZN2DB9settingsEv.llvm.11069338206770680048', 40000000),
+    ({_PR}, 'prsha-clone', '2026-07-02 00:00:00', 'arm_release', 'IC', '{_MAIN}', 'OptFunction', '_ZN2DB9settingsEv.llvm.12487241783113815285', 40000000);
+INSERT INTO binary_symbols (pull_request_number, commit_sha, check_start_time, check_name, instance_id, file, address, size, type, symbol) VALUES
+    (0, 'basesha-clone', '2026-06-30 00:00:00', 'arm_release', 'IC0', '{_MAIN}', 0, 450000, 't', 'DB::settings() [clone .llvm.11069338206770680048]'),
+    ({_PR}, 'prsha-clone', '2026-07-02 00:00:00', 'arm_release', 'IC', '{_MAIN}', 0, 450000, 't', 'DB::settings() [clone .llvm.12487241783113815285]');
 """
 
 
@@ -440,7 +485,7 @@ def test_opt_functions_cover_the_keeper_binary():
     pr_side = job.resolve_run(db, job.PR_DAYS, _PR, _PR_SHA)
     base_side = job.resolve_run(db, job.BASE_DAYS, 0, _BASE_SHA)
     section = job.compare_opt_functions(db, pr_side, base_side)
-    # keeper_fn regressed 5 s -> 30 s: reported, significant, and attributed
+    # keeper_fn regressed 5 s -> 60 s: reported, significant, and attributed
     # to clickhouse-keeper.
     assert "keeper_fn" in section.body
     assert f"`{job.strip_build_dir(_KEEPER)}`" in section.body
@@ -506,26 +551,73 @@ def test_opt_functions_missing_pr_side_binary_is_flagged():
     assert "missing PR-side link trace" in section.summary
 
 
-def test_objects_added_and_removed_are_significant():
-    """A one-sided object row above the significance bar drives the verdict.
+def test_added_object_is_significant_and_a_baseline_only_one_is_not_a_removal():
+    """A PR-only object file is an addition; a baseline-only one is not a removal.
 
-    OBJECT_FILTER keeps only compile-stage .o files and both sides compile the
-    full object set with the same flags, so an object present on one side only
-    is a real addition or removal. Gating significance on ``pr_size and
-    base_size`` let a PR add or drop a multi-MiB object while the top-level
-    comment still said "No significant changes".
+    The two builds do not have the same target set: the warmup baseline builds
+    every object-file target ninja knows about, a pull request build only
+    ``clickhouse-bundle``. Hundreds of object files - the gRPC and protobuf
+    libraries, the unit tests, the utils - therefore exist on the warmup side
+    alone, and reading them as removals produced a "685 removed, -40 MiB"
+    finding on every pull request. The other direction is real: the warmup side
+    builds a superset, so an object only the PR has is a source file it added.
     """
     db = FixtureDb()
     pr_side = job.Side(job.PR_DAYS, _PR, "prsha-new-object", "2026-07-02 00:00:00", "I8")
     warmup_side = job.resolve_run(db, job.BASE_DAYS, 0, _BASE_SHA, check_name=job.WARMUP_CHECK_NAME)
     section = job.compare_objects(db, pr_side, warmup_side)
-    # bar.cpp.o (512 KiB) is added, foo.cpp.o (256 KiB) is removed: both
-    # one-sided and both above OBJECT_SIG_BYTES.
+    # bar.cpp.o (512 KiB) is added: one-sided, above OBJECT_SIG_BYTES.
     assert "bar.cpp.o" in section.body
-    assert "new" in section.body
-    assert "foo.cpp.o" in section.body
-    assert "removed" in section.body
+    assert "1 added" in section.body
     assert section.significant
+    # foo.cpp.o is built by the warmup baseline only: counted, never a row.
+    assert "foo.cpp.o" not in section.body
+    assert "removed" not in section.body
+    assert "1 more object file is built by the master warmup baseline only" in section.body
+    assert "removed" not in section.summary
+
+
+def test_opt_function_skew_is_estimated_per_binary():
+    """Each binary's ThinLTO time is normalized by its own median ratio.
+
+    A binary is its own ThinLTO link: the two links of one build do not even run
+    at the same time, let alone the links of the two sides, so their systematic
+    ratio to the master baseline differs - by more than a factor of two in
+    practice. Here ``clickhouse`` is unchanged and the whole ``clickhouse-keeper``
+    link is three times slower; one median over both binaries is 2.0, which
+    reports every unchanged ``clickhouse`` function as a 40 s speedup (twice the
+    significance bar) while erasing the keeper's real uniform shift. Per binary
+    both medians are exact, so nothing is reported at all.
+    """
+    db = FixtureDb()
+    pr_side = job.Side(job.PR_DAYS, _PR, "prsha-skew", "2026-07-02 00:00:00", "IS")
+    base_side = job.Side(job.BASE_DAYS, 0, "basesha-skew", "2026-06-30 00:00:00", "IB")
+    section = job.compare_opt_functions(db, pr_side, base_side)
+    assert "skew_main_fn" not in section.body
+    assert "skew_keeper_fn" not in section.body
+    assert not section.significant
+
+
+def test_thinlto_clone_suffix_churn_is_not_a_change():
+    """A `.llvm.<hash>` rename of an unchanged function is not a finding.
+
+    The hash comes from the defining module, so it differs between two builds of
+    the same source: an unchanged function shows up as one gone row and one new
+    row of exactly the same time and size, in both the ThinLTO and the symbol
+    table. Those pairs were the largest rows of the report on every pull request
+    and made both sections significant on their own.
+    """
+    db = FixtureDb()
+    pr_side = job.Side(job.PR_DAYS, _PR, "prsha-clone", "2026-07-02 00:00:00", "IC")
+    base_side = job.Side(job.BASE_DAYS, 0, "basesha-clone", "2026-06-30 00:00:00", "IC0")
+    opt_functions = job.compare_opt_functions(db, pr_side, base_side)
+    assert "settings" not in opt_functions.body
+    assert "gone" not in opt_functions.body
+    assert not opt_functions.significant
+    symbols = job.compare_symbols(db, pr_side, base_side)
+    assert "settings" not in symbols.body
+    assert "removed" not in symbols.body
+    assert not symbols.significant
 
 
 def test_opt_functions_trace_below_report_cutoff_is_not_a_lost_upload():


### PR DESCRIPTION
The `Build profile diff` check flagged three of its five sections as significant on #112788 — a change to `ParserCreateQuery` that cannot affect any of them — and every one of those findings was an artifact of the comparison rather than a property of the pull request: https://github.com/ClickHouse/ClickHouse/pull/112788#issuecomment-5163126582

* **"685 object files removed, -40.18 MiB"**: the two builds do not have the same target set. The master warmup build compiles every object-file target `ninja` knows about, a pull request build only `clickhouse-bundle`, so the gRPC and protobuf libraries, the unit tests and the utils exist on the warmup side alone. Only the object files the pull request build produced are compared now; the baseline-only ones are counted in a footnote (and in the job log) instead of read as removals. A PR-only object file stays a real addition — the warmup side builds a superset of the targets, so it is a source file the pull request added.
* **`+17.2 s` / `+439.45 KiB`, "new", next to an identical "gone" row**: ThinLTO renames the clones it creates with a `.llvm.<hash>` suffix whose hash comes from the defining module, so two builds of the very same source name the same clone differently. Both per-symbol sizes and per-function times are keyed by the name with that suffix removed, which also folds the several clones of one function into a single row.
* **`registerFunctionConversion` +104%, `_GLOBAL__sub_I_TargetLibraryInfo.cpp` +77%** in `clickhouse-keeper`, while `clickhouse`'s equally untouched functions came out 44-54% *faster* in the same table: each binary is its own ThinLTO link, and their systematic ratios to the master baseline differ by more than a factor of two. The skew is now estimated per binary instead of once for both.

The thresholds of the two sections whose baseline is the official master build — whose flags differ from a pull request build's, and whose stripped binary alone drifts by ~3 MiB on a no-op pull request — are widened to match that noise floor: per-function ThinLTO time is reported from 5 s and 2x (was 2 s and 1.5x) and is significant from 20 s (was 15 s); per-symbol size is reported from 64 KiB and is significant from 512 KiB (was 16 KiB / 256 KiB). The object-file thresholds are deliberately left alone: that comparison is against a build compiled with the pull request's exact flags, so it is deterministic and its tight bars are right.

Covered by three fixture tests in `ci/tests/test_build_profile_diff_job.py` (each verified to fail without its fix): a baseline-only object file is not a removal while a PR-only one still drives the verdict, a `.llvm.<hash>` rename of an unchanged function is not a finding in either section, and the ThinLTO skew is estimated per binary.

Related: https://github.com/ClickHouse/ClickHouse/pull/111164

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.722` (included in `26.8` and later)
<!-- ch-version-info:end -->