### PR TITLE
Infer an omitted Distributed structure under the user's context

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -458,6 +458,8 @@ StorageDistributed::StorageDistributed(
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Settings flush_on_detach=0 and background_insert_batch=1 are incompatible");
 
     StorageInMemoryMetadata storage_metadata;
+    /// Reached only when loading stored metadata that carries no column list: the creators infer an
+    /// omitted structure themselves, under the user's context.
     if (columns_.empty())
     {
         StorageID id = StorageID::createEmpty();
@@ -2216,9 +2218,23 @@ void registerStorageDistributed(StorageFactory & factory)
 
         finalizeDistributedSettings(distributed_settings, context);
 
+        /// Infer an omitted structure under the user's context, so that the `SHOW_COLUMNS` check for a
+        /// local shard is not made against the global context the constructor holds. Skipped when the
+        /// definition comes from already-validated metadata, which has no user to check against.
+        ColumnsDescription columns = args.columns;
+        if (columns.empty() && !(isLoadingFromExistingMetadata(args.mode) || args.query.attach_short_syntax))
+        {
+            /// `getCluster` expands macros, so this is the cluster the constructor will use.
+            columns = getStructureOfRemoteTable(
+                *local_context->getCluster(cluster_name),
+                StorageID{remote_database, remote_table},
+                local_context,
+                /* table_func_ptr = */ nullptr);
+        }
+
         return std::make_shared<StorageDistributed>(
             args.table_id,
-            args.columns,
+            columns,
             args.constraints,
             args.comment,
             remote_database,

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -458,8 +458,8 @@ StorageDistributed::StorageDistributed(
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Settings flush_on_detach=0 and background_insert_batch=1 are incompatible");
 
     StorageInMemoryMetadata storage_metadata;
-    /// Reached only when loading stored metadata that carries no column list: the creators infer an
-    /// omitted structure themselves, under the user's context.
+    /// Only a definition loaded from validated metadata reaches here with no columns; the creators
+    /// infer an omitted structure themselves, under the user's context.
     if (columns_.empty())
     {
         StorageID id = StorageID::createEmpty();
@@ -2224,9 +2224,11 @@ void registerStorageDistributed(StorageFactory & factory)
         ColumnsDescription columns = args.columns;
         if (columns.empty() && !(isLoadingFromExistingMetadata(args.mode) || args.query.attach_short_syntax))
         {
-            /// `getCluster` expands macros, so this is the cluster the constructor will use.
+            /// Expanded first, so this resolves the same cluster the constructor will: a Replicated
+            /// database's implicit cluster is found by the expanded name only.
+            const String expanded_cluster_name = local_context->getMacros()->expand(cluster_name);
             columns = getStructureOfRemoteTable(
-                *local_context->getCluster(cluster_name),
+                *local_context->getCluster(expanded_cluster_name),
                 StorageID{remote_database, remote_table},
                 local_context,
                 /* table_func_ptr = */ nullptr);

--- a/tests/queries/0_stateless/04715_distributed_infer_columns_access.reference
+++ b/tests/queries/0_stateless/04715_distributed_infer_columns_access.reference
@@ -1,0 +1,16 @@
+-- the user cannot describe the target directly
+1
+-- 1. omitted columns, no rights on the target: rejected
+1
+-- 1. nothing was created, so nothing was disclosed
+0
+-- 2. omitted columns, with SHOW COLUMNS on the target: allowed and inferred
+x	UInt64
+secret_column	String
+-- 3. explicit columns, no rights on the target: still allowed
+1
+-- 4. temporary table, omitted columns, no rights on the target: rejected
+1
+-- 5. a detached table with an inferred structure re-attaches without the grant
+x	UInt64
+secret_column	String

--- a/tests/queries/0_stateless/04715_distributed_infer_columns_access.sh
+++ b/tests/queries/0_stateless/04715_distributed_infer_columns_access.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Tags: shard, no-replicated-database
+# no-replicated-database: on a replicated / shared-catalog database the DDL runs with no user, so the
+# in-storage access check asserted here is a no-op and the deny path silently allows.
+# Blocked on https://github.com/ClickHouse/ClickHouse/issues/111561 - re-enable when fixed.
+
+# Regression coverage for the access check applied when a `Distributed` table omits its structure:
+#   1. Inferring the structure from a local-shard target requires `SHOW_COLUMNS` on that target, so a
+#      user who cannot describe the target cannot learn its columns by creating a `Distributed` over it.
+#   2. With `SHOW_COLUMNS` granted, the structure is still inferred (the check does not break inference).
+#   3. An explicit column list infers nothing and stays allowed without any rights on the target.
+#   4. The same check applies to a temporary table, which reaches the engine through its own path.
+#   5. A table whose structure was inferred still detaches and re-attaches after the grant is
+#      revoked: the inferred columns are persisted into its metadata, so the short `ATTACH` carries
+#      them and never re-infers.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+db=${CLICKHOUSE_DATABASE}
+user="user_04715_${CLICKHOUSE_DATABASE}"
+
+${CLICKHOUSE_CLIENT} <<EOF
+DROP USER IF EXISTS $user;
+CREATE TABLE $db.protected_target (x UInt64, secret_column String) ENGINE = MergeTree ORDER BY x;
+INSERT INTO $db.protected_target VALUES (42, 'secret');
+
+CREATE USER $user;
+-- The user may create and read tables in its own database, but holds no rights on the target the
+-- engine points at, so the check below is exercised in isolation.
+GRANT CREATE TABLE, SELECT, INSERT ON $db.* TO $user;
+-- CREATE TEMPORARY TABLE is a global-level privilege and cannot be granted on a database.
+GRANT CREATE TEMPORARY TABLE ON *.* TO $user;
+GRANT TABLE ENGINE ON Distributed TO $user;
+GRANT REMOTE ON *.* TO $user;
+REVOKE SELECT, INSERT ON $db.protected_target FROM $user;
+EOF
+
+echo "-- the user cannot describe the target directly"
+${CLICKHOUSE_CLIENT} --user "$user" --query "DESCRIBE $db.protected_target" 2>&1 \
+    | grep -c -m1 "ACCESS_DENIED\|Not enough privileges"
+
+echo "-- 1. omitted columns, no rights on the target: rejected"
+${CLICKHOUSE_CLIENT} --user "$user" --query \
+    "CREATE TABLE $db.d ENGINE = Distributed('test_shard_localhost', '$db', 'protected_target')" 2>&1 \
+    | grep -c -m1 "ACCESS_DENIED\|Not enough privileges"
+
+echo "-- 1. nothing was created, so nothing was disclosed"
+${CLICKHOUSE_CLIENT} --query \
+    "SELECT count() FROM system.tables WHERE database = '$db' AND name = 'd'"
+
+echo "-- 2. omitted columns, with SHOW COLUMNS on the target: allowed and inferred"
+${CLICKHOUSE_CLIENT} --query "GRANT SHOW COLUMNS ON $db.protected_target TO $user"
+${CLICKHOUSE_CLIENT} --user "$user" --query \
+    "CREATE TABLE $db.d ENGINE = Distributed('test_shard_localhost', '$db', 'protected_target')"
+${CLICKHOUSE_CLIENT} --user "$user" --query \
+    "SELECT name, type FROM system.columns WHERE database = '$db' AND table = 'd' ORDER BY position"
+
+echo "-- 3. explicit columns, no rights on the target: still allowed"
+${CLICKHOUSE_CLIENT} --query "REVOKE SHOW COLUMNS ON $db.protected_target FROM $user"
+${CLICKHOUSE_CLIENT} --user "$user" --query \
+    "CREATE TABLE $db.d_explicit (x UInt64) ENGINE = Distributed('test_shard_localhost', '$db', 'protected_target')"
+${CLICKHOUSE_CLIENT} --query \
+    "SELECT count() FROM system.tables WHERE database = '$db' AND name = 'd_explicit'"
+
+echo "-- 4. temporary table, omitted columns, no rights on the target: rejected"
+${CLICKHOUSE_CLIENT} --user "$user" --query \
+    "CREATE TEMPORARY TABLE tmp_d ENGINE = Distributed('test_shard_localhost', '$db', 'protected_target')" 2>&1 \
+    | grep -c -m1 "ACCESS_DENIED\|Not enough privileges"
+
+echo "-- 5. a detached table with an inferred structure re-attaches without the grant"
+${CLICKHOUSE_CLIENT} --query "GRANT DROP TABLE, UNDROP TABLE ON $db.* TO $user"
+${CLICKHOUSE_CLIENT} --user "$user" <<EOF
+DETACH TABLE $db.d;
+ATTACH TABLE $db.d;
+SELECT name, type FROM system.columns WHERE database = '$db' AND table = 'd' ORDER BY position;
+EOF
+
+${CLICKHOUSE_CLIENT} <<EOF
+DROP TABLE $db.d;
+DROP TABLE $db.d_explicit;
+DROP TABLE $db.protected_target;
+DROP USER $user;
+EOF


### PR DESCRIPTION

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a case where `CREATE TABLE ... ENGINE = Distributed(...)` without a column list could reveal the structure of a local table the creating user is not allowed to see. For a `CREATE` the local server executes itself, the structure is now inferred under the user's own context, so `SHOW COLUMNS` on the target table is required, as it already is for the `Remote` engine. A `CREATE` replayed from the DDL queue (`ON CLUSTER`, or one inside a `Replicated` database) is not covered.


### Description

Related: #113073. Found while reviewing engine-level schema inference.

**What breaks.** A user with `CREATE TABLE` on its own database plus `TABLE ENGINE ON Distributed` can learn the columns of a local table it may not `DESCRIBE`, by creating a columns-less `Distributed` table over it. On master that `CREATE` succeeds and persists them.

**Root cause.** The structure is inferred by `StorageDistributed`'s constructor, which holds only the global context because the storage outlives any query context. With no user, `full_access = !user_id` makes the `SHOW_COLUMNS` check in `getStructureOfRemoteTableInShard` a no-op for a local shard. The check is in the right place; the context it got cannot enforce it.

**The change.** `registerStorageDistributed` now infers the structure under `args.getLocalContext()` and passes the columns to the constructor, as the sibling `Remote` engine does, skipping it for already-validated metadata (server startup, short `ATTACH`). Explicit column lists, `Remote`/`RemoteSecure` and `remote()` are unaffected. `SHOW COLUMNS` is the narrowest privilege here, weaker than `Remote`'s `SELECT` plus `INSERT`.

**Scope: only a `CREATE` the local server executes itself.** A `CREATE` replayed from the DDL queue reaches the engine on a userless context, so the check is a no-op there; this PR does not change that. For `ON CLUSTER` the worker sets a user only when `distributed_ddl_use_initial_user_and_roles` is on *and* `distributed_ddl_entry_format_version` is at least 8 (the initiator is serialized from version 8; the default is 5); with both raised the denial fires. Inside a `Replicated` database `tryEnqueueReplicatedDDL` records no initiator, so no setting closes it. Both want #113073's initiator-side check.

**Validation.** New test `04715_distributed_infer_columns_access` covers the denial, inference once `SHOW COLUMNS` is granted, explicit column lists, the temporary-table path and re-attach; it fails on master, passes here. 50 randomized runs pass, as do the existing `Distributed` inference and `Remote` access tests. The queue paths need Keeper and were measured separately.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.929` (included in `26.8` and later)
- Backported to: `26.6.3.13`, `26.5.7.16`, `26.3.18.8`, `25.8.30.8`
<!-- ch-version-info:end -->