### PR TITLE
Stress test: honor storage skip tags by forwarding the backend

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -304,10 +304,15 @@ def run_func_test(
     global_time_limit: int,
     upgrade_check: bool,
     encrypted_storage: bool,
+    s3_storage: bool = False,
+    azure_blob_storage: bool = False,
     query_killer: Optional["RandomQueryKiller"] = None,
 ) -> List[Popen]:
     upgrade_check_option = "--upgrade-check" if upgrade_check else ""
     encrypted_storage_option = "--encrypted-storage" if encrypted_storage else ""
+    # clickhouse-test evaluates its storage skip tags from these flags alone.
+    s3_storage_option = "--s3-storage" if s3_storage else ""
+    azure_blob_storage_option = "--azure-blob-storage" if azure_blob_storage else ""
     global_time_limit_option = (
         f"--global_time_limit={global_time_limit}" if global_time_limit else ""
     )
@@ -329,6 +334,7 @@ def run_func_test(
         base_command = (
             f"{cmd} --stress-tests {options} "
             f"{skip_tests_option} {upgrade_check_option} {encrypted_storage_option} "
+            f"{s3_storage_option} {azure_blob_storage_option} "
         )
         full_command = f"{base_command} {global_time_limit_option} "
         commands.append(full_command)
@@ -615,6 +621,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--encrypted-storage", type=lambda x: bool(int(x)), default=False
     )
+    parser.add_argument("--s3-storage", type=lambda x: bool(int(x)), default=False)
+    parser.add_argument(
+        "--azure-blob-storage", type=lambda x: bool(int(x)), default=False
+    )
     parser.add_argument(
         "--no-random-query-killer",
         action="store_true",
@@ -652,6 +662,8 @@ def main():
             args.global_time_limit,
             args.upgrade_check,
             args.encrypted_storage,
+            args.s3_storage,
+            args.azure_blob_storage,
             query_killer,
         )
     finally:

--- a/ci/tests/test_stress_storage_forwarding.py
+++ b/ci/tests/test_stress_storage_forwarding.py
@@ -1,0 +1,157 @@
+"""
+Tests for the storage-backend flags `ci.jobs.scripts.stress.stress.run_func_test`
+puts on the `clickhouse-test` command line.
+
+`Stress test (*)` installs an object-storage default MergeTree policy, but for a
+long time it invoked `clickhouse-test` without saying which backend it had
+configured. `clickhouse-test` decides `no-object-storage` / `no-s3-storage` /
+`no-azure-blob-storage` / `no-encrypted-storage` purely from those flags, so the
+gates never fired and tests that declare they cannot run on object storage ran on
+it anyway. Issue #111053 is the visible damage: a test writing a raw plaintext
+file into a part directory poisons the table, because on object storage that file
+is not in `DiskObjectStorageMetadata` format, and every later server start fails.
+
+Command construction is this fix's entire payload, so it is what these tests pin:
+`run_func_test` must put `--s3-storage` / `--azure-blob-storage` on both the smoke
+check and the stress command exactly when the corresponding argument is true, and
+on neither otherwise. Nothing here starts a server or runs a test: the three
+side-effecting callables are patched out, and the command list is fully built
+before the first of them is reached.
+"""
+
+import inspect
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.scripts.stress.stress import run_func_test
+from ci.jobs.scripts.stress import stress
+
+
+class _FinishedProcess:
+    """Stub for `Popen`: already exited, so the wait loop ends on its first pass."""
+
+    returncode = 0
+
+    def poll(self):
+        return self.returncode
+
+
+def _capture(monkeypatch):
+    """Patch out everything that touches a shell or a server.
+
+    Returns (smoke_commands, stress_commands), both filled in by `run_func_test`.
+    """
+    smoke = []
+    stress_cmds = []
+
+    def fake_execute_bash(full_command, timeout=120):  # pylint:disable=unused-argument
+        smoke.append(full_command)
+        return ""
+
+    def fake_popen(command, **_kwargs):
+        stress_cmds.append(command)
+        return _FinishedProcess()
+
+    monkeypatch.setattr(stress, "execute_bash", fake_execute_bash)
+    monkeypatch.setattr(stress, "install_thread_pool_fault_injection", lambda: None)
+    monkeypatch.setattr(stress, "Popen", fake_popen)
+    return smoke, stress_cmds
+
+
+def _run(monkeypatch, tmp_path, **kwargs):
+    smoke, stress_cmds = _capture(monkeypatch)
+    run_func_test(
+        "clickhouse-test",
+        tmp_path,
+        1,
+        "",
+        1200,
+        False,
+        kwargs.pop("encrypted_storage", False),
+        **kwargs,
+    )
+    assert len(smoke) == 1, f"expected one smoke command, got {smoke}"
+    assert len(stress_cmds) == 1, f"expected one stress command, got {stress_cmds}"
+    return smoke[0], stress_cmds[0]
+
+
+# Match whitespace-delimited tokens, never `flag in command`: the substring form
+# is also true for `--no-s3-storage`, which would make every absence assertion
+# below pass vacuously.
+def _tokens(command):
+    return command.split()
+
+
+_ALL_FLAGS = ("--s3-storage", "--azure-blob-storage", "--encrypted-storage")
+
+
+@pytest.mark.parametrize(
+    "s3_storage,azure_blob_storage,encrypted_storage,expected",
+    [
+        pytest.param(False, False, False, (), id="local"),
+        pytest.param(True, False, False, ("--s3-storage",), id="s3"),
+        pytest.param(False, True, False, ("--azure-blob-storage",), id="azure"),
+        pytest.param(
+            True,
+            False,
+            True,
+            ("--s3-storage", "--encrypted-storage"),
+            id="s3-encrypted",
+        ),
+    ],
+)
+def test_backend_flags_on_both_commands(
+    monkeypatch, tmp_path, s3_storage, azure_blob_storage, encrypted_storage, expected
+):
+    """Both commands share `base_command`, and an edit could easily reach only one
+    of them, so presence and absence are asserted on each separately."""
+    smoke, stress_cmd = _run(
+        monkeypatch,
+        tmp_path,
+        s3_storage=s3_storage,
+        azure_blob_storage=azure_blob_storage,
+        encrypted_storage=encrypted_storage,
+    )
+    for command, label in ((smoke, "smoke check"), (stress_cmd, "stress")):
+        tokens = _tokens(command)
+        for flag in expected:
+            assert flag in tokens, f"{label} command lacks {flag}: {command}"
+        for flag in _ALL_FLAGS:
+            if flag not in expected:
+                assert (
+                    flag not in tokens
+                ), f"{label} command carries {flag} it was not asked for: {command}"
+
+
+def test_both_backends_forwarded_together(monkeypatch, tmp_path):
+    """`stress_runner.sh` passes both arguments on every run, so the two flags
+    must be independent rather than mutually exclusive."""
+    smoke, stress_cmd = _run(
+        monkeypatch, tmp_path, s3_storage=True, azure_blob_storage=True
+    )
+    for command in (smoke, stress_cmd):
+        tokens = _tokens(command)
+        assert "--s3-storage" in tokens
+        assert "--azure-blob-storage" in tokens
+
+
+def test_flags_default_off_for_positional_callers(monkeypatch, tmp_path):
+    """`upgrade_runner.sh` reaches `stress.py` without the new arguments; its
+    command line has to stay byte-identical to what it was before."""
+    smoke, stress_cmd = _run(monkeypatch, tmp_path)
+    for command in (smoke, stress_cmd):
+        tokens = _tokens(command)
+        assert "--s3-storage" not in tokens
+        assert "--azure-blob-storage" not in tokens
+
+
+def test_query_killer_stays_last_parameter():
+    """`main` passes `query_killer` positionally, so a parameter inserted after it
+    would silently bind the killer to a storage flag: no exception, no lint
+    warning, and the flags would follow the killer's truthiness."""
+    parameters = list(inspect.signature(run_func_test).parameters)
+    assert parameters[-3:] == ["s3_storage", "azure_blob_storage", "query_killer"]

--- a/ci/tests/test_stress_storage_forwarding.py
+++ b/ci/tests/test_stress_storage_forwarding.py
@@ -17,10 +17,15 @@ check and the stress command exactly when the corresponding argument is true, an
 on neither otherwise. Nothing here starts a server or runs a test: the three
 side-effecting callables are patched out, and the command list is fully built
 before the first of them is reached.
+
+The two production seams that reach those arguments are pinned as well, because
+each can drop the fix on its own: `main` forwarding the parsed arguments into
+`run_func_test`, and the `stress.py` invocation in `stress_runner.sh`.
 """
 
 import inspect
 import os
+import re
 import sys
 
 import pytest
@@ -155,3 +160,87 @@ def test_query_killer_stays_last_parameter():
     warning, and the flags would follow the killer's truthiness."""
     parameters = list(inspect.signature(run_func_test).parameters)
     assert parameters[-3:] == ["s3_storage", "azure_blob_storage", "query_killer"]
+
+
+@pytest.mark.parametrize(
+    "argv_flags,expected",
+    [
+        pytest.param(
+            ["--s3-storage", "1", "--azure-blob-storage", "0"], (True, False), id="s3"
+        ),
+        pytest.param(
+            ["--s3-storage", "0", "--azure-blob-storage", "1"],
+            (False, True),
+            id="azure",
+        ),
+        pytest.param([], (False, False), id="absent"),
+    ],
+)
+def test_cli_arguments_reach_run_func_test(monkeypatch, tmp_path, argv_flags, expected):
+    """First production seam: `main` forwards the parsed arguments positionally.
+    Dropping either one from that call leaves every command-construction test
+    above green, because they call `run_func_test` directly."""
+    captured = []
+
+    monkeypatch.setattr(
+        stress, "run_func_test", lambda *args: captured.append(args) or []
+    )
+    monkeypatch.setattr(stress, "call_with_retry", lambda *a, **k: None)
+    monkeypatch.setattr(stress, "compress_stress_logs", lambda *a, **k: None)
+
+    class _Killer:
+        def __init__(self, *a, **k):
+            pass
+
+        def stop(self):
+            pass
+
+    monkeypatch.setattr(stress, "RandomQueryKiller", _Killer)
+    monkeypatch.setattr(
+        sys, "argv", ["stress.py", "--output-folder", str(tmp_path)] + argv_flags
+    )
+
+    stress.main()
+
+    assert len(captured) == 1, f"expected one run_func_test call, got {captured}"
+    # Resolve by parameter name: hardcoded offsets would silently pass if a
+    # parameter were inserted ahead of them.
+    parameters = list(inspect.signature(run_func_test).parameters)
+    args = captured[0]
+    indexes = [parameters.index(name) for name in ("s3_storage", "azure_blob_storage")]
+    assert len(args) > max(indexes), (
+        f"main passed only {len(args)} positional arguments, so it never reaches "
+        f"{parameters[max(indexes)]}: {args}"
+    )
+    actual = tuple(args[index] for index in indexes)
+    assert actual == expected, f"main forwarded {actual}, expected {expected}"
+
+
+def test_stress_runner_forwards_both_backends():
+    """Second production seam: the shell invocation. `stress.py` defaults both
+    arguments to false, so a flag missing here disables the fix silently."""
+    runner = os.path.join(
+        os.path.dirname(__file__), "../..", "tests/docker_scripts/stress_runner.sh"
+    )
+    with open(runner, "r", encoding="utf-8") as file:
+        text = file.read()
+
+    match = re.search(r"^python3 [^\n]*stress\.py[^\n]*", text, re.M)
+    assert match, f"no stress.py invocation found in {runner}"
+    line = match.group(0)
+    # Whole tokens, never substrings: "--s3-storage" is also a substring of
+    # "--no-s3-storage".
+    tokens = line.split()
+
+    # The `:-0` default is load-bearing, not style: neither variable is exported
+    # on the local branch, and a bare "$VAR" hands argparse an empty string,
+    # whose `type=lambda x: bool(int(x))` exits rc=2 before the first test runs.
+    for flag, variable in (
+        ("--s3-storage", "USE_S3_STORAGE_FOR_MERGE_TREE"),
+        ("--azure-blob-storage", "USE_AZURE_STORAGE_FOR_MERGE_TREE"),
+    ):
+        assert flag in tokens, f"stress_runner.sh does not pass {flag}: {line}"
+        value = tokens[tokens.index(flag) + 1].strip('"')
+        assert (
+            value == f"${{{variable}:-0}}"
+        ), f"{flag} takes {value}, not a guarded default"

--- a/ci/tests/test_stress_storage_forwarding.py
+++ b/ci/tests/test_stress_storage_forwarding.py
@@ -20,7 +20,11 @@ before the first of them is reached.
 
 The two production seams that reach those arguments are pinned as well, because
 each can drop the fix on its own: `main` forwarding the parsed arguments into
-`run_func_test`, and the `stress.py` invocation in `stress_runner.sh`.
+`run_func_test`, and the `stress.py` invocation in `stress_runner.sh`. The
+pre-existing `--encrypted-storage` rides both seams and the same skip-tag
+mechanism, and `no-encrypted-storage` only becomes live again once a backend
+flag survives them too, so it is pinned at both seams rather than only at the
+command line.
 """
 
 import inspect
@@ -162,24 +166,45 @@ def test_query_killer_stays_last_parameter():
     assert parameters[-3:] == ["s3_storage", "azure_blob_storage", "query_killer"]
 
 
+_FORWARDED = ("s3_storage", "azure_blob_storage", "encrypted_storage")
+
+
 @pytest.mark.parametrize(
     "argv_flags,expected",
     [
         pytest.param(
-            ["--s3-storage", "1", "--azure-blob-storage", "0"], (True, False), id="s3"
+            [
+                "--s3-storage",
+                "1",
+                "--azure-blob-storage",
+                "0",
+                "--encrypted-storage",
+                "1",
+            ],
+            (True, False, True),
+            id="s3-encrypted",
         ),
         pytest.param(
-            ["--s3-storage", "0", "--azure-blob-storage", "1"],
-            (False, True),
+            [
+                "--s3-storage",
+                "0",
+                "--azure-blob-storage",
+                "1",
+                "--encrypted-storage",
+                "0",
+            ],
+            (False, True, False),
             id="azure",
         ),
-        pytest.param([], (False, False), id="absent"),
+        pytest.param([], (False, False, False), id="absent"),
     ],
 )
 def test_cli_arguments_reach_run_func_test(monkeypatch, tmp_path, argv_flags, expected):
     """First production seam: `main` forwards the parsed arguments positionally.
     Dropping either one from that call leaves every command-construction test
-    above green, because they call `run_func_test` directly."""
+    above green, because they call `run_func_test` directly. `encrypted_storage`
+    rides the same seam and the same skip-tag mechanism, so it is pinned here
+    too."""
     captured = []
 
     monkeypatch.setattr(
@@ -207,18 +232,23 @@ def test_cli_arguments_reach_run_func_test(monkeypatch, tmp_path, argv_flags, ex
     # parameter were inserted ahead of them.
     parameters = list(inspect.signature(run_func_test).parameters)
     args = captured[0]
-    indexes = [parameters.index(name) for name in ("s3_storage", "azure_blob_storage")]
+    indexes = [parameters.index(name) for name in _FORWARDED]
     assert len(args) > max(indexes), (
         f"main passed only {len(args)} positional arguments, so it never reaches "
         f"{parameters[max(indexes)]}: {args}"
     )
     actual = tuple(args[index] for index in indexes)
-    assert actual == expected, f"main forwarded {actual}, expected {expected}"
+    assert actual == expected, (
+        f"main forwarded {dict(zip(_FORWARDED, actual))}, "
+        f"expected {dict(zip(_FORWARDED, expected))}"
+    )
 
 
-def test_stress_runner_forwards_both_backends():
-    """Second production seam: the shell invocation. `stress.py` defaults both
-    arguments to false, so a flag missing here disables the fix silently."""
+def test_stress_runner_forwards_every_backend():
+    """Second production seam: the shell invocation. `stress.py` defaults the
+    backend arguments to false, so a flag missing here disables the fix
+    silently. `--encrypted-storage` is asserted alongside them because the same
+    edit drops it just as quietly."""
     runner = os.path.join(
         os.path.dirname(__file__), "../..", "tests/docker_scripts/stress_runner.sh"
     )
@@ -232,15 +262,18 @@ def test_stress_runner_forwards_both_backends():
     # "--no-s3-storage".
     tokens = line.split()
 
-    # The `:-0` default is load-bearing, not style: neither variable is exported
-    # on the local branch, and a bare "$VAR" hands argparse an empty string,
-    # whose `type=lambda x: bool(int(x))` exits rc=2 before the first test runs.
-    for flag, variable in (
-        ("--s3-storage", "USE_S3_STORAGE_FOR_MERGE_TREE"),
-        ("--azure-blob-storage", "USE_AZURE_STORAGE_FOR_MERGE_TREE"),
+    # Values are pinned exactly: an unset variable reaches argparse as "", whose
+    # `type=lambda x: bool(int(x))` exits rc=2 before the first test runs. Hence
+    # `:-0` on the two unexported backend variables, and the export check below.
+    for flag, value_token in (
+        ("--s3-storage", "${USE_S3_STORAGE_FOR_MERGE_TREE:-0}"),
+        ("--azure-blob-storage", "${USE_AZURE_STORAGE_FOR_MERGE_TREE:-0}"),
+        ("--encrypted-storage", "$USE_ENCRYPTED_STORAGE"),
     ):
         assert flag in tokens, f"stress_runner.sh does not pass {flag}: {line}"
         value = tokens[tokens.index(flag) + 1].strip('"')
-        assert (
-            value == f"${{{variable}:-0}}"
-        ), f"{flag} takes {value}, not a guarded default"
+        assert value == value_token, f"{flag} takes {value}, not {value_token}"
+
+    assert re.search(
+        r"^export USE_ENCRYPTED_STORAGE=", text, re.M
+    ), "USE_ENCRYPTED_STORAGE is no longer exported, so its unguarded use exits rc=2"

--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -295,7 +295,10 @@ cp -av --dereference /repo/ci/jobs/scripts/fuzzer/limit-recursion-settings.xml /
 start_server || { echo "Failed to start server"; exit 1; }
 
 cd /repo/tests/ || exit 1  # clickhouse-test can find queries dir from there
-python3 /repo/ci/jobs/scripts/stress/stress.py --hung-check --drop-databases --output-folder /test_output --skip-func-tests "$SKIP_TESTS_OPTION" --global-time-limit "${STRESS_GLOBAL_TIME_LIMIT:-1200}" --encrypted-storage "$USE_ENCRYPTED_STORAGE" \
+# Forward the backend chosen above so clickhouse-test can honor the storage skip tags.
+# Both variables are exported conditionally, so the :-0 defaults are required: stress.py
+# rejects an empty string and exits before running any test.
+python3 /repo/ci/jobs/scripts/stress/stress.py --hung-check --drop-databases --output-folder /test_output --skip-func-tests "$SKIP_TESTS_OPTION" --global-time-limit "${STRESS_GLOBAL_TIME_LIMIT:-1200}" --encrypted-storage "$USE_ENCRYPTED_STORAGE" --s3-storage "${USE_S3_STORAGE_FOR_MERGE_TREE:-0}" --azure-blob-storage "${USE_AZURE_STORAGE_FOR_MERGE_TREE:-0}" \
     && echo -e "Test script exit code$OK" >> /test_output/test_results.tsv \
     || echo -e "Test script failed$FAIL script exit code: $?" >> /test_output/test_results.tsv
 

--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -295,9 +295,7 @@ cp -av --dereference /repo/ci/jobs/scripts/fuzzer/limit-recursion-settings.xml /
 start_server || { echo "Failed to start server"; exit 1; }
 
 cd /repo/tests/ || exit 1  # clickhouse-test can find queries dir from there
-# Forward the backend chosen above so clickhouse-test can honor the storage skip tags.
-# Both variables are exported conditionally, so the :-0 defaults are required: stress.py
-# rejects an empty string and exits before running any test.
+# Forward the backend chosen above; :-0 because neither variable is set on the local branch.
 python3 /repo/ci/jobs/scripts/stress/stress.py --hung-check --drop-databases --output-folder /test_output --skip-func-tests "$SKIP_TESTS_OPTION" --global-time-limit "${STRESS_GLOBAL_TIME_LIMIT:-1200}" --encrypted-storage "$USE_ENCRYPTED_STORAGE" --s3-storage "${USE_S3_STORAGE_FOR_MERGE_TREE:-0}" --azure-blob-storage "${USE_AZURE_STORAGE_FOR_MERGE_TREE:-0}" \
     && echo -e "Test script exit code$OK" >> /test_output/test_results.tsv \
     || echo -e "Test script failed$FAIL script exit code: $?" >> /test_output/test_results.tsv


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/111053
Related: https://github.com/ClickHouse/ClickHouse/pull/111772
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #111053

`Stress test (*)` installs an object storage default MergeTree policy but ran `clickhouse-test`
without telling it which backend it configured, so the storage skip tags were inert there and the
145 tests tagged `no-object-storage` ran on object storage anyway. `stress_runner.sh` also
randomizes the backend (`RANDOM % 3`), so 2 of 3 runs of a plain flavour are affected, azure too.

The visible damage is #111053. A raw plaintext file written into a part directory is not
`DiskObjectStorageMetadata` format, so the part loader throws `Code: 27` reading it, `Code: 246` for
the fabricated intersecting parts, and every later server start then dies with
`Cannot start clickhouse-server`, losing the whole job rather than one test. 297 Stress jobs died so
in 30 days, 20 on master, e.g.
[Stress test (amd_msan)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=89e6f70bb685587883152cd24287f9dfd9b220d3&name_0=MasterCI&name_1=Stress%20test%20%28amd_msan%29).

This adds `--s3-storage` and `--azure-blob-storage` pass-throughs to `stress.py` and passes them
from `stress_runner.sh`, beside the `--encrypted-storage` flag already forwarded there. It is the
missing sibling of #111772, which did this for `upgrade_runner.sh`. Both default to false, so
`upgrade_runner.sh` is unaffected and `clickhouse-test` is unmodified.

Verified on a server differing from a passing control only in that default policy:
`04104_transaction_version_metadata_dummy_tid_load` fails there with that `Code: 27`, and is skipped
once the flag is forwarded. All four affected tags were checked both ways. Two consequences:

- `no-encrypted-storage` fires for the first time. `--encrypted-storage` was already forwarded, but
  `clickhouse-test` clears it unless an object storage backend is also set. It now applies when a run
  picks both, matching the encrypted policy `install.sh` installs there. 20 tests it skips carry no
  object-storage tag.
- `clickhouse-test` couples `--s3-storage` to `--no-random-settings` on non-release builds. That is
  pre-existing, but the shape matters: stochastic for the plain flavours, absent for azure, permanent
  for `Stress test (arm_asan_ubsan, s3)`. Skipped share per run: 1.3% on s3, 1.5% on azure.