### PR TITLE
Fix hang of a synchronous replica wait when the table is shutting down or the query is cancelled

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -7720,13 +7720,26 @@ bool StorageReplicatedMergeTree::tryWaitForReplicaToProcessLogEntry(
     bool check_timeout = wait_for_inactive_timeout > 0;
     Stopwatch time_waiting;
 
+    /// Get the process list element to check for query cancellation while waiting.
+    QueryStatusPtr process_list_element;
+    if (CurrentThread::isInitialized())
+    {
+        auto query_context = CurrentThread::get().tryGetQueryContext();
+        if (query_context)
+            process_list_element = query_context->getProcessListElement();
+    }
+
     const auto & stop_waiting = [&]()
     {
-        bool stop_waiting_itself = waiting_itself && (partial_shutdown_called || shutdown_prepared_called || shutdown_called);
+        /// The two terminal latches stop the wait for any replica. `partial_shutdown_called` is
+        /// local-only because it is reset when the ZooKeeper session is restored.
+        bool stop_waiting_itself = (waiting_itself && partial_shutdown_called) || shutdown_prepared_called || shutdown_called;
         bool timeout_exceeded = check_timeout && static_cast<double>(wait_for_inactive_timeout) < time_waiting.elapsedSeconds();
         bool stop_waiting_inactive = (!wait_for_inactive || timeout_exceeded)
             && !getZooKeeper()->exists(fs::path(table_zookeeper_path) / "replicas" / replica / "is_active");
-        return is_dropped || stop_waiting_itself || stop_waiting_inactive;
+        /// Throws TIMEOUT_EXCEEDED or QUERY_WAS_CANCELLED; returns false only for OverflowMode::BREAK.
+        bool query_cancelled = process_list_element && !process_list_element->checkTimeLimit();
+        return is_dropped || stop_waiting_itself || stop_waiting_inactive || query_cancelled;
     };
 
     /// Don't recheck ZooKeeper too often

--- a/tests/queries/0_stateless/04740_alter_sync_wait_shutdown_and_cancel.reference
+++ b/tests/queries/0_stateless/04740_alter_sync_wait_shutdown_and_cancel.reference
@@ -1,0 +1,4 @@
+Code: 159. Timeout exceeded: maximum: 5000 ms
+Code: 394. Query was cancelled
+database dropped
+Code: 341. Timeout exceeded while waiting for replicas r2 to process entry log-N

--- a/tests/queries/0_stateless/04740_alter_sync_wait_shutdown_and_cancel.reference
+++ b/tests/queries/0_stateless/04740_alter_sync_wait_shutdown_and_cancel.reference
@@ -1,4 +1,6 @@
 Code: 159. Timeout exceeded: maximum: 5000 ms
 Code: 394. Query was cancelled
+entry queued on r2
+Code: 394. Query was cancelled
 database dropped
 Code: 341. Timeout exceeded while waiting for replicas r2 to process entry log-N

--- a/tests/queries/0_stateless/04740_alter_sync_wait_shutdown_and_cancel.sh
+++ b/tests/queries/0_stateless/04740_alter_sync_wait_shutdown_and_cancel.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Tags: long, replica, zookeeper, no-shared-merge-tree
+# Tags: long, replica, zookeeper, no-shared-merge-tree, no-replicated-database
+# no-replicated-database: creates two explicit replicas (r1, r2) sharing one ZooKeeper path,
+#                         and the replica name is rewritten under a Replicated database
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04740_alter_sync_wait_shutdown_and_cancel.sh
+++ b/tests/queries/0_stateless/04740_alter_sync_wait_shutdown_and_cancel.sh
@@ -62,25 +62,47 @@ grep -om1 'Code: 394.*Query was cancelled' "$KILL_OUT" | sed 's/DB::Exception: /
 # only ever reach the first stage. Letting r2 pull the entry into its queue and blocking execution
 # instead sends the wait into waitForDisappear on the queue node.
 $CLICKHOUSE_CLIENT -q "SYSTEM START PULLING REPLICATION LOG r2; SYSTEM STOP REPLICATION QUEUES r2"
-$CLICKHOUSE_CLIENT -q "$TRUNCATE_UNLIMITED" > "$QUEUE_OUT" 2>&1 &
-wait_for_truncate
-# Reaching the third stage requires this TRUNCATE's own entry to be in r2's queue. The entry exists
-# by now, so the log size read here already counts it, and waiting for r2 to copy past that number
-# proves this entry was copied. Comparing against a freshly read log_max_index instead would prove
-# nothing: log_pointer is the maximum copied entry plus one and may point at an entry that does not
-# exist yet, so the arm could degenerate into a copy of arm 2.
-target=$($CLICKHOUSE_CLIENT -q "
+# The log maximum has to be sampled before the statement starts: its process list row appears
+# before the interpreter creates the log node, so a value read after wait_for_truncate can still
+# be the previous maximum.
+before=$($CLICKHOUSE_CLIENT -q "
     SELECT log_max_index FROM system.replicas
     WHERE database = currentDatabase() AND table = 'r2'")
+$CLICKHOUSE_CLIENT -q "$TRUNCATE_UNLIMITED" > "$QUEUE_OUT" 2>&1 &
+wait_for_truncate
+# Reaching the third stage requires this TRUNCATE's own entry to be in r2's queue. The advance of
+# the log maximum past the pre-statement value is what proves that entry exists, and the observed
+# value names it. Comparing log_pointer against a freshly read log_max_index instead would prove
+# nothing: log_pointer is the maximum copied entry plus one and may point at an entry that does not
+# exist yet, so the arm could degenerate into a copy of arm 2.
+entry_index=
 for _ in {1..600}; do
-    if [ "$($CLICKHOUSE_CLIENT -q "
-                SELECT log_pointer > $target FROM system.replicas
-                WHERE database = currentDatabase() AND table = 'r2'")" = "1" ]; then
-        echo 'entry queued on r2'
+    current=$($CLICKHOUSE_CLIENT -q "
+        SELECT log_max_index FROM system.replicas
+        WHERE database = currentDatabase() AND table = 'r2'")
+    if [ -n "$current" ] && [ "$current" -gt "$before" ]; then
+        entry_index=$current
         break
     fi
     sleep 0.5
 done
+if [ -z "$entry_index" ]; then
+    echo 'log entry for the TRUNCATE never appeared'
+else
+    # log_pointer is the maximum copied entry plus one, so this means entry_index was copied.
+    queued=
+    for _ in {1..600}; do
+        if [ "$($CLICKHOUSE_CLIENT -q "
+                    SELECT log_pointer > $entry_index FROM system.replicas
+                    WHERE database = currentDatabase() AND table = 'r2'")" = "1" ]; then
+            queued=1
+            echo 'entry queued on r2'
+            break
+        fi
+        sleep 0.5
+    done
+    [ -n "$queued" ] || echo "r2 never copied log entry $entry_index"
+fi
 query_id=$($CLICKHOUSE_CLIENT -q "
     SELECT query_id FROM system.processes
     WHERE current_database = currentDatabase() AND query LIKE 'TRUNCATE%' LIMIT 1")

--- a/tests/queries/0_stateless/04740_alter_sync_wait_shutdown_and_cancel.sh
+++ b/tests/queries/0_stateless/04740_alter_sync_wait_shutdown_and_cancel.sh
@@ -97,5 +97,8 @@ wait_for_truncate
 $CLICKHOUSE_CLIENT -q "DROP DATABASE ${CLICKHOUSE_DATABASE} SYNC"
 echo 'database dropped'
 wait
-grep -om1 'Code: 341.*Timeout exceeded while waiting for replicas r2 to process entry log-[0-9]*' "$DROP_OUT" \
-    | sed 's/DB::Exception: //g; s/Received from [^ ]* //; s/log-[0-9]*/log-N/'
+# r1 can also lose the race to the shutdown latch, so require r2 as a member in any order.
+grep -om1 'Code: 341.*Timeout exceeded while waiting for replicas [^.]* to process entry log-[0-9]*' "$DROP_OUT" \
+    | sed 's/DB::Exception: //g; s/Received from [^ ]* //; s/log-[0-9]*/log-N/' \
+    | grep -E 'replicas ([a-z0-9_]+, )*r2(, [a-z0-9_]+)* to process' \
+    | sed -E 's/replicas [^ ]*(, [^ ]*)* to process/replicas r2 to process/'

--- a/tests/queries/0_stateless/04740_alter_sync_wait_shutdown_and_cancel.sh
+++ b/tests/queries/0_stateless/04740_alter_sync_wait_shutdown_and_cancel.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Tags: long, replica, zookeeper, no-shared-merge-tree
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+KILL_OUT="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_kill.out"
+DROP_OUT="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_drop.out"
+trap 'rm -f "$KILL_OUT" "$DROP_OUT"' EXIT
+
+$CLICKHOUSE_CLIENT -q "
+    CREATE TABLE r1 (k UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/04740/t', 'r1') ORDER BY k;
+    CREATE TABLE r2 (k UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/04740/t', 'r2') ORDER BY k;
+    INSERT INTO r1 VALUES (1);
+    SYSTEM SYNC REPLICA r2;
+"
+
+# Blocks pullLogsToQueue for r2 (throws ABORTED) while r2's is_active node survives, so an
+# alter_sync = 2 wait for r2 can never be satisfied and cannot escape through the inactive-replica
+# path. replication_wait_for_inactive_replica_timeout = -1 pins that wait to unlimited, so a green
+# result cannot come from the pre-existing timeout.
+$CLICKHOUSE_CLIENT -q "SYSTEM STOP PULLING REPLICATION LOG r2"
+
+TRUNCATE_UNLIMITED="TRUNCATE TABLE r1 SETTINGS alter_sync = 2, replication_wait_for_inactive_replica_timeout = -1"
+
+# Waits until exactly one TRUNCATE of this test's database is waiting in the process list.
+wait_for_truncate()
+{
+    for _ in {1..600}; do
+        if [ "$($CLICKHOUSE_CLIENT -q "
+                    SELECT count() FROM system.processes
+                    WHERE current_database = currentDatabase() AND query LIKE 'TRUNCATE%'")" = "1" ]; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    echo 'TRUNCATE never appeared in system.processes'
+}
+
+# 1. max_execution_time must terminate the wait.
+$CLICKHOUSE_CLIENT -q "
+    TRUNCATE TABLE r1 SETTINGS alter_sync = 2, max_execution_time = 5,
+        replication_wait_for_inactive_replica_timeout = -1
+" 2>&1 | grep -om1 'Code: 159.*Timeout exceeded: elapsed [0-9.]* ms, maximum: 5000 ms' \
+       | sed 's/DB::Exception: //g; s/elapsed [0-9.]* ms, //'
+
+# 2. KILL QUERY must terminate the wait.
+$CLICKHOUSE_CLIENT -q "$TRUNCATE_UNLIMITED" > "$KILL_OUT" 2>&1 &
+wait_for_truncate
+query_id=$($CLICKHOUSE_CLIENT -q "
+    SELECT query_id FROM system.processes
+    WHERE current_database = currentDatabase() AND query LIKE 'TRUNCATE%' LIMIT 1")
+$CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '$query_id' SYNC" > /dev/null
+wait
+grep -om1 'Code: 394.*Query was cancelled' "$KILL_OUT" | sed 's/DB::Exception: //g; s/Received from [^ ]* //'
+
+# 3. Dropping the database calls flushAndPrepareForShutdown on both tables, which stops r2 from
+# ever processing the entry. The waiting TRUNCATE must give up so the DROP is not deadlocked behind
+# it. No cancellation is involved here, so this covers the shutdown escape on its own.
+$CLICKHOUSE_CLIENT -q "$TRUNCATE_UNLIMITED" > "$DROP_OUT" 2>&1 &
+wait_for_truncate
+$CLICKHOUSE_CLIENT -q "DROP DATABASE ${CLICKHOUSE_DATABASE} SYNC"
+echo 'database dropped'
+wait
+grep -om1 'Code: 341.*Timeout exceeded while waiting for replicas r2 to process entry log-[0-9]*' "$DROP_OUT" \
+    | sed 's/DB::Exception: //g; s/Received from [^ ]* //; s/log-[0-9]*/log-N/'

--- a/tests/queries/0_stateless/04740_alter_sync_wait_shutdown_and_cancel.sh
+++ b/tests/queries/0_stateless/04740_alter_sync_wait_shutdown_and_cancel.sh
@@ -8,8 +8,9 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 KILL_OUT="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_kill.out"
+QUEUE_OUT="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_queue.out"
 DROP_OUT="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_drop.out"
-trap 'rm -f "$KILL_OUT" "$DROP_OUT"' EXIT
+trap 'rm -f "$KILL_OUT" "$QUEUE_OUT" "$DROP_OUT"' EXIT
 
 $CLICKHOUSE_CLIENT -q "
     CREATE TABLE r1 (k UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/04740/t', 'r1') ORDER BY k;
@@ -57,9 +58,40 @@ $CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '$query_id' SYNC" > /dev/null
 wait
 grep -om1 'Code: 394.*Query was cancelled' "$KILL_OUT" | sed 's/DB::Exception: //g; s/Received from [^ ]* //'
 
-# 3. Dropping the database calls flushAndPrepareForShutdown on both tables, which stops r2 from
+# 3. Same, but for the last of the three wait stages. Arms 1 and 2 block pullLogsToQueue, so they
+# only ever reach the first stage. Letting r2 pull the entry into its queue and blocking execution
+# instead sends the wait into waitForDisappear on the queue node.
+$CLICKHOUSE_CLIENT -q "SYSTEM START PULLING REPLICATION LOG r2; SYSTEM STOP REPLICATION QUEUES r2"
+$CLICKHOUSE_CLIENT -q "$TRUNCATE_UNLIMITED" > "$QUEUE_OUT" 2>&1 &
+wait_for_truncate
+# Reaching the third stage requires this TRUNCATE's own entry to be in r2's queue. The entry exists
+# by now, so the log size read here already counts it, and waiting for r2 to copy past that number
+# proves this entry was copied. Comparing against a freshly read log_max_index instead would prove
+# nothing: log_pointer is the maximum copied entry plus one and may point at an entry that does not
+# exist yet, so the arm could degenerate into a copy of arm 2.
+target=$($CLICKHOUSE_CLIENT -q "
+    SELECT log_max_index FROM system.replicas
+    WHERE database = currentDatabase() AND table = 'r2'")
+for _ in {1..600}; do
+    if [ "$($CLICKHOUSE_CLIENT -q "
+                SELECT log_pointer > $target FROM system.replicas
+                WHERE database = currentDatabase() AND table = 'r2'")" = "1" ]; then
+        echo 'entry queued on r2'
+        break
+    fi
+    sleep 0.5
+done
+query_id=$($CLICKHOUSE_CLIENT -q "
+    SELECT query_id FROM system.processes
+    WHERE current_database = currentDatabase() AND query LIKE 'TRUNCATE%' LIMIT 1")
+$CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '$query_id' SYNC" > /dev/null
+wait
+grep -om1 'Code: 394.*Query was cancelled' "$QUEUE_OUT" | sed 's/DB::Exception: //g; s/Received from [^ ]* //'
+
+# 4. Dropping the database calls flushAndPrepareForShutdown on both tables, which stops r2 from
 # ever processing the entry. The waiting TRUNCATE must give up so the DROP is not deadlocked behind
 # it. No cancellation is involved here, so this covers the shutdown escape on its own.
+$CLICKHOUSE_CLIENT -q "SYSTEM START REPLICATION QUEUES r2; SYSTEM STOP PULLING REPLICATION LOG r2"
 $CLICKHOUSE_CLIENT -q "$TRUNCATE_UNLIMITED" > "$DROP_OUT" 2>&1 &
 wait_for_truncate
 $CLICKHOUSE_CLIENT -q "DROP DATABASE ${CLICKHOUSE_DATABASE} SYNC"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113023
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a hang of `ALTER`, `OPTIMIZE`, `TRUNCATE` and partition manipulation statements with `alter_sync = 2` on `ReplicatedMergeTree` when the table starts shutting down while the statement waits for another replica, for example because of a concurrent `DROP DATABASE ... SYNC`. Such a statement now fails with `UNFINISHED` and also honours `max_execution_time` and `KILL QUERY`.


### Description

Found by the `Stress test (arm_release)` hung check on #113023 ([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113023&sha=0a1652b91d1caf7891b704d1415d2ab4f90ffac6&name_0=PR&name_1=Stress%20test%20%28arm_release%29)), not caused by it: a `TRUNCATE ... SYNC` and a `DROP DATABASE ... SYNC` from `00623_replicated_truncate_table_zookeeper_long` were stuck for 2937 s, with five more DDL queries queued behind them.

**Root cause.** In `tryWaitForReplicaToProcessLogEntry` the only shutdown escape of the wait predicate was `waiting_itself && (partial_shutdown_called || shutdown_prepared_called || shutdown_called)`. With `alter_sync = 2` waiting on a remote replica `waiting_itself` is false, so the local shutdown flags could not break the wait, while `DROP DATABASE ... SYNC` calls `flushAndPrepareForShutdown`, after which the other replica's `queueUpdatingTask` stops pulling the log and the awaited entry is never processed. The other escapes are unreachable there: the inactive-replica check needs that replica's `is_active` node gone, but it is removed only in `partialShutdown`, and `is_dropped` is set only after the drop that is blocked completes. The loop consulted no `QueryStatus` either, so cancellation was ignored.

**Change.** `shutdown_prepared_called` and `shutdown_called` are now checked independently of `waiting_itself`, since they are terminal latches after which no replica will process the entry. `partial_shutdown_called` stays local-only: it is reset when the ZooKeeper session is restored. The wait now also calls `QueryStatus::checkTimeLimit`, as the sibling `waitMutationToFinishOnReplicas` already does. Failures stay visible as `UNFINISHED`.

**Validation.** `SYSTEM STOP PULLING REPLICATION LOG` gives a deterministic repro. On master the statement hangs, `KILL QUERY ... SYNC` hangs too, and the concurrent `DROP DATABASE ... SYNC` deadlocks; with the fix all three return within seconds. New test `04740_alter_sync_wait_shutdown_and_cancel` passes 50/50 with randomized settings; reverting either half of the change alone reddens only its own assertion.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.820` (included in `26.8` and later)
<!-- ch-version-info:end -->