### PR TITLE
Fix wrong results for hash joins on a single LowCardinality wide-integer key

### DIFF
--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -339,8 +339,7 @@ static HashJoin::Type chooseMethod(const ColumnRawPtrs & key_columns, Sizes & ke
     if (keys_size == 1 && key_columns[0]->isNumeric())
     {
         size_t size_of_field = key_columns[0]->sizeOfValueIfFixed();
-        /// The loop above bails out before assigning for a LowCardinality column, and the packed
-        /// keys128/keys256 getters read key_sizes to copy the key bytes.
+        /// The loop above bails out before assigning `key_sizes` for a `LowCardinality` column.
         key_sizes[0] = size_of_field;
         if (size_of_field == 1)
             return Type::key8;

--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -339,6 +339,9 @@ static HashJoin::Type chooseMethod(const ColumnRawPtrs & key_columns, Sizes & ke
     if (keys_size == 1 && key_columns[0]->isNumeric())
     {
         size_t size_of_field = key_columns[0]->sizeOfValueIfFixed();
+        /// The loop above bails out before assigning for a LowCardinality column, and the packed
+        /// keys128/keys256 getters read key_sizes to copy the key bytes.
+        key_sizes[0] = size_of_field;
         if (size_of_field == 1)
             return Type::key8;
         if (size_of_field == 2)

--- a/tests/queries/0_stateless/04745_join_low_cardinality_wide_int_key.reference
+++ b/tests/queries/0_stateless/04745_join_low_cardinality_wide_int_key.reference
@@ -1,0 +1,17 @@
+lc_uint128 using	1
+lc_uint128 on	1	1
+lc_uint128 hash	1
+lc_uint128 parallel_hash	1
+lc_uint128 grace_hash	1
+lc_uint128 full_sorting_merge	1
+lc_int128	1
+lc_uint256	1
+lc_int256	1
+lc_uint8	1
+lc_uint64	1
+plain_uint128	1
+lc_string	1
+lc_uuid	1
+lc_nullable_uint128	1
+lc_uint128_multikey	1
+lc_uint128_asof	1	1

--- a/tests/queries/0_stateless/04745_join_low_cardinality_wide_int_key.reference
+++ b/tests/queries/0_stateless/04745_join_low_cardinality_wide_int_key.reference
@@ -13,5 +13,10 @@ plain_uint128	1
 lc_string	1
 lc_uuid	1
 lc_nullable_uint128	1
+lc_nullable_uint128 rows	1	1
 lc_uint128_multikey	1
 lc_uint128_asof	1	1
+lc_uint128 highbits	18446744073709551617
+lc_uint256 highbits	340282366920938463463374607431768211457
+lc_int128 highbits	-1
+lc_int256 highbits	-1

--- a/tests/queries/0_stateless/04745_join_low_cardinality_wide_int_key.sql
+++ b/tests/queries/0_stateless/04745_join_low_cardinality_wide_int_key.sql
@@ -88,9 +88,11 @@ DROP TABLE t_r;
 
 CREATE TABLE t_l (id LowCardinality(Nullable(UInt128))) ENGINE = Memory;
 CREATE TABLE t_r (id LowCardinality(Nullable(UInt128))) ENGINE = Memory;
-INSERT INTO t_l VALUES (5), (1);
-INSERT INTO t_r VALUES (7), (0), (1);
+INSERT INTO t_l VALUES (5), (1), (NULL);
+INSERT INTO t_r VALUES (7), (0), (1), (NULL);
+-- A NULL key matches nothing, so the count stays 1.
 SELECT 'lc_nullable_uint128', count() FROM t_l JOIN t_r USING (id);
+SELECT 'lc_nullable_uint128 rows', a.id, b.id FROM t_l a JOIN t_r b ON a.id = b.id ORDER BY a.id;
 DROP TABLE t_l;
 DROP TABLE t_r;
 
@@ -109,5 +111,42 @@ CREATE TABLE t_r (k LowCardinality(UInt128), t UInt64) ENGINE = Memory;
 INSERT INTO t_l VALUES (1, 10), (5, 10);
 INSERT INTO t_r VALUES (1, 5), (7, 5);
 SELECT 'lc_uint128_asof', a.k, b.k FROM t_l a ASOF JOIN t_r b ON a.k = b.k AND a.t >= b.t ORDER BY a.k;
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+-- The key must be compared over its whole width. In each pair below the two left values share
+-- their low 8 (Int128/UInt128) or 16 (Int256/UInt256) bytes and differ only above, so a copy that
+-- reads fewer bytes than the key type makes them collide and the right value matches both.
+
+CREATE TABLE t_l (id LowCardinality(UInt128)) ENGINE = Memory;
+CREATE TABLE t_r (id LowCardinality(UInt128)) ENGINE = Memory;
+INSERT INTO t_l VALUES (toUInt128(1) + bitShiftLeft(toUInt128(1), 64)), (toUInt128(1) + bitShiftLeft(toUInt128(2), 64));
+INSERT INTO t_r VALUES (toUInt128(1) + bitShiftLeft(toUInt128(1), 64));
+SELECT 'lc_uint128 highbits', a.id FROM t_l a JOIN t_r b ON a.id = b.id ORDER BY a.id;
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+CREATE TABLE t_l (id LowCardinality(UInt256)) ENGINE = Memory;
+CREATE TABLE t_r (id LowCardinality(UInt256)) ENGINE = Memory;
+INSERT INTO t_l VALUES (toUInt256(1) + bitShiftLeft(toUInt256(1), 128)), (toUInt256(1) + bitShiftLeft(toUInt256(2), 128));
+INSERT INTO t_r VALUES (toUInt256(1) + bitShiftLeft(toUInt256(1), 128));
+SELECT 'lc_uint256 highbits', a.id FROM t_l a JOIN t_r b ON a.id = b.id ORDER BY a.id;
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+-- Signed high half: -1 is all-ones, so it shares its low bytes with the positive 2^64-1 / 2^128-1.
+CREATE TABLE t_l (id LowCardinality(Int128)) ENGINE = Memory;
+CREATE TABLE t_r (id LowCardinality(Int128)) ENGINE = Memory;
+INSERT INTO t_l VALUES (toInt128(-1)), (toInt128(bitShiftLeft(toUInt128(1), 64) - 1));
+INSERT INTO t_r VALUES (toInt128(-1));
+SELECT 'lc_int128 highbits', a.id FROM t_l a JOIN t_r b ON a.id = b.id ORDER BY a.id;
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+CREATE TABLE t_l (id LowCardinality(Int256)) ENGINE = Memory;
+CREATE TABLE t_r (id LowCardinality(Int256)) ENGINE = Memory;
+INSERT INTO t_l VALUES (toInt256(-1)), (toInt256(bitShiftLeft(toUInt256(1), 128) - 1));
+INSERT INTO t_r VALUES (toInt256(-1));
+SELECT 'lc_int256 highbits', a.id FROM t_l a JOIN t_r b ON a.id = b.id ORDER BY a.id;
 DROP TABLE t_l;
 DROP TABLE t_r;

--- a/tests/queries/0_stateless/04745_join_low_cardinality_wide_int_key.sql
+++ b/tests/queries/0_stateless/04745_join_low_cardinality_wide_int_key.sql
@@ -1,12 +1,11 @@
 SET allow_suspicious_low_cardinality_types = 1;
 
--- A single LowCardinality key wider than 8 bytes selects a packed keys128/keys256 map, which
--- reads key_sizes to copy the key bytes. Keys must match by value, not degenerate to one bucket.
+-- A single `LowCardinality` key wider than 8 bytes must match by value, not collapse to one bucket.
 
 DROP TABLE IF EXISTS t_l;
 DROP TABLE IF EXISTS t_r;
 
--- LowCardinality(UInt128): 1 must match only 1, not 5 or 7.
+-- `LowCardinality(UInt128)`: 1 must match only 1, not 5 or 7.
 CREATE TABLE t_l (id LowCardinality(UInt128)) ENGINE = Memory;
 CREATE TABLE t_r (id LowCardinality(UInt128)) ENGINE = Memory;
 INSERT INTO t_l VALUES (5), (1);
@@ -90,13 +89,13 @@ CREATE TABLE t_l (id LowCardinality(Nullable(UInt128))) ENGINE = Memory;
 CREATE TABLE t_r (id LowCardinality(Nullable(UInt128))) ENGINE = Memory;
 INSERT INTO t_l VALUES (5), (1), (NULL);
 INSERT INTO t_r VALUES (7), (0), (1), (NULL);
--- A NULL key matches nothing, so the count stays 1.
+-- A `NULL` key matches nothing, so the count stays 1.
 SELECT 'lc_nullable_uint128', count() FROM t_l JOIN t_r USING (id);
 SELECT 'lc_nullable_uint128 rows', a.id, b.id FROM t_l a JOIN t_r b ON a.id = b.id ORDER BY a.id;
 DROP TABLE t_l;
 DROP TABLE t_r;
 
--- Multi-column key containing a wide LowCardinality column.
+-- Multi-column key containing a wide `LowCardinality` column.
 CREATE TABLE t_l (a LowCardinality(UInt128), b UInt8) ENGINE = Memory;
 CREATE TABLE t_r (a LowCardinality(UInt128), b UInt8) ENGINE = Memory;
 INSERT INTO t_l VALUES (5, 1), (1, 2);
@@ -105,7 +104,7 @@ SELECT 'lc_uint128_multikey', count() FROM t_l JOIN t_r USING (a, b);
 DROP TABLE t_l;
 DROP TABLE t_r;
 
--- ASOF join over a wide LowCardinality equality key.
+-- `ASOF` join over a wide `LowCardinality` equality key.
 CREATE TABLE t_l (k LowCardinality(UInt128), t UInt64) ENGINE = Memory;
 CREATE TABLE t_r (k LowCardinality(UInt128), t UInt64) ENGINE = Memory;
 INSERT INTO t_l VALUES (1, 10), (5, 10);
@@ -114,9 +113,8 @@ SELECT 'lc_uint128_asof', a.k, b.k FROM t_l a ASOF JOIN t_r b ON a.k = b.k AND a
 DROP TABLE t_l;
 DROP TABLE t_r;
 
--- The key must be compared over its whole width. In each pair below the two left values share
--- their low 8 (Int128/UInt128) or 16 (Int256/UInt256) bytes and differ only above, so a copy that
--- reads fewer bytes than the key type makes them collide and the right value matches both.
+-- Below, the two left values share their low half and differ only above, so a comparison narrower
+-- than the key type makes them collide and the single right value matches both.
 
 CREATE TABLE t_l (id LowCardinality(UInt128)) ENGINE = Memory;
 CREATE TABLE t_r (id LowCardinality(UInt128)) ENGINE = Memory;

--- a/tests/queries/0_stateless/04745_join_low_cardinality_wide_int_key.sql
+++ b/tests/queries/0_stateless/04745_join_low_cardinality_wide_int_key.sql
@@ -1,0 +1,113 @@
+SET allow_suspicious_low_cardinality_types = 1;
+
+-- A single LowCardinality key wider than 8 bytes selects a packed keys128/keys256 map, which
+-- reads key_sizes to copy the key bytes. Keys must match by value, not degenerate to one bucket.
+
+DROP TABLE IF EXISTS t_l;
+DROP TABLE IF EXISTS t_r;
+
+-- LowCardinality(UInt128): 1 must match only 1, not 5 or 7.
+CREATE TABLE t_l (id LowCardinality(UInt128)) ENGINE = Memory;
+CREATE TABLE t_r (id LowCardinality(UInt128)) ENGINE = Memory;
+INSERT INTO t_l VALUES (5), (1);
+INSERT INTO t_r VALUES (7), (0), (1);
+SELECT 'lc_uint128 using', count() FROM t_l JOIN t_r USING (id);
+SELECT 'lc_uint128 on', a.id, b.id FROM t_l a JOIN t_r b ON a.id = b.id ORDER BY a.id, b.id;
+SELECT 'lc_uint128 hash', count() FROM t_l JOIN t_r USING (id) SETTINGS join_algorithm = 'hash';
+SELECT 'lc_uint128 parallel_hash', count() FROM t_l JOIN t_r USING (id) SETTINGS join_algorithm = 'parallel_hash', max_threads = 8;
+SELECT 'lc_uint128 grace_hash', count() FROM t_l JOIN t_r USING (id) SETTINGS join_algorithm = 'grace_hash';
+SELECT 'lc_uint128 full_sorting_merge', count() FROM t_l JOIN t_r USING (id) SETTINGS join_algorithm = 'full_sorting_merge';
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+-- Sibling affected widths.
+CREATE TABLE t_l (id LowCardinality(Int128)) ENGINE = Memory;
+CREATE TABLE t_r (id LowCardinality(Int128)) ENGINE = Memory;
+INSERT INTO t_l VALUES (5), (1);
+INSERT INTO t_r VALUES (7), (0), (1);
+SELECT 'lc_int128', count() FROM t_l JOIN t_r USING (id);
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+CREATE TABLE t_l (id LowCardinality(UInt256)) ENGINE = Memory;
+CREATE TABLE t_r (id LowCardinality(UInt256)) ENGINE = Memory;
+INSERT INTO t_l VALUES (5), (1);
+INSERT INTO t_r VALUES (7), (0), (1);
+SELECT 'lc_uint256', count() FROM t_l JOIN t_r USING (id);
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+CREATE TABLE t_l (id LowCardinality(Int256)) ENGINE = Memory;
+CREATE TABLE t_r (id LowCardinality(Int256)) ENGINE = Memory;
+INSERT INTO t_l VALUES (5), (1);
+INSERT INTO t_r VALUES (7), (0), (1);
+SELECT 'lc_int256', count() FROM t_l JOIN t_r USING (id);
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+-- Unaffected shapes: regression guards, all correct before the fix.
+CREATE TABLE t_l (id LowCardinality(UInt8)) ENGINE = Memory;
+CREATE TABLE t_r (id LowCardinality(UInt8)) ENGINE = Memory;
+INSERT INTO t_l VALUES (5), (1);
+INSERT INTO t_r VALUES (7), (0), (1);
+SELECT 'lc_uint8', count() FROM t_l JOIN t_r USING (id);
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+CREATE TABLE t_l (id LowCardinality(UInt64)) ENGINE = Memory;
+CREATE TABLE t_r (id LowCardinality(UInt64)) ENGINE = Memory;
+INSERT INTO t_l VALUES (5), (1);
+INSERT INTO t_r VALUES (7), (0), (1);
+SELECT 'lc_uint64', count() FROM t_l JOIN t_r USING (id);
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+CREATE TABLE t_l (id UInt128) ENGINE = Memory;
+CREATE TABLE t_r (id UInt128) ENGINE = Memory;
+INSERT INTO t_l VALUES (5), (1);
+INSERT INTO t_r VALUES (7), (0), (1);
+SELECT 'plain_uint128', count() FROM t_l JOIN t_r USING (id);
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+CREATE TABLE t_l (id LowCardinality(String)) ENGINE = Memory;
+CREATE TABLE t_r (id LowCardinality(String)) ENGINE = Memory;
+INSERT INTO t_l VALUES ('5'), ('1');
+INSERT INTO t_r VALUES ('7'), ('0'), ('1');
+SELECT 'lc_string', count() FROM t_l JOIN t_r USING (id);
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+CREATE TABLE t_l (id LowCardinality(UUID)) ENGINE = Memory;
+CREATE TABLE t_r (id LowCardinality(UUID)) ENGINE = Memory;
+INSERT INTO t_l VALUES ('00000000-0000-0000-0000-000000000005'), ('00000000-0000-0000-0000-000000000001');
+INSERT INTO t_r VALUES ('00000000-0000-0000-0000-000000000007'), ('00000000-0000-0000-0000-000000000000'), ('00000000-0000-0000-0000-000000000001');
+SELECT 'lc_uuid', count() FROM t_l JOIN t_r USING (id);
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+CREATE TABLE t_l (id LowCardinality(Nullable(UInt128))) ENGINE = Memory;
+CREATE TABLE t_r (id LowCardinality(Nullable(UInt128))) ENGINE = Memory;
+INSERT INTO t_l VALUES (5), (1);
+INSERT INTO t_r VALUES (7), (0), (1);
+SELECT 'lc_nullable_uint128', count() FROM t_l JOIN t_r USING (id);
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+-- Multi-column key containing a wide LowCardinality column.
+CREATE TABLE t_l (a LowCardinality(UInt128), b UInt8) ENGINE = Memory;
+CREATE TABLE t_r (a LowCardinality(UInt128), b UInt8) ENGINE = Memory;
+INSERT INTO t_l VALUES (5, 1), (1, 2);
+INSERT INTO t_r VALUES (7, 1), (0, 2), (1, 2);
+SELECT 'lc_uint128_multikey', count() FROM t_l JOIN t_r USING (a, b);
+DROP TABLE t_l;
+DROP TABLE t_r;
+
+-- ASOF join over a wide LowCardinality equality key.
+CREATE TABLE t_l (k LowCardinality(UInt128), t UInt64) ENGINE = Memory;
+CREATE TABLE t_r (k LowCardinality(UInt128), t UInt64) ENGINE = Memory;
+INSERT INTO t_l VALUES (1, 10), (5, 10);
+INSERT INTO t_r VALUES (1, 5), (7, 5);
+SELECT 'lc_uint128_asof', a.k, b.k FROM t_l a ASOF JOIN t_r b ON a.k = b.k AND a.t >= b.t ORDER BY a.k;
+DROP TABLE t_l;
+DROP TABLE t_r;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


Related: https://github.com/ClickHouse/ClickHouse/pull/112957

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed wrong results when a hash join has a single `LowCardinality` key of a type wider than 8 bytes (`UInt128`, `Int128`, `UInt256`, `Int256`, and their `Nullable` variants). Such a join silently returned rows whose key values are not equal.

### Description

`HashJoin::chooseMethod` selects the packed `keys128` / `keys256` map for a single numeric key of 16 or 32 bytes. That map's key getter reads `key_sizes` to copy the key bytes, but the selecting branch never assigned it.

For a non-`LowCardinality` column this went unnoticed, because the `all_fixed` loop above had already stored the same value. `ColumnLowCardinality::isFixedAndContiguous` is `false`, so that loop breaks before assigning, while `isNumeric` and `sizeOfValueIfFixed` forward to the dictionary and still report a 16 or 32 byte numeric key. The branch is thus entered with `key_sizes[0]` left at 0, `usePreparedKeys` rejects it, and `packFixed` copies zero bytes. Every key becomes all-zero, so keys that differ compare equal and the join reports non-matching rows as matches.

```sql
SET allow_suspicious_low_cardinality_types = 1;
SELECT count() FROM (SELECT toLowCardinality(toUInt128(1)) AS id) AS a
JOIN (SELECT toLowCardinality(toUInt128(materialize(0))) AS id) AS b USING (id);
-- returned 1, must be 0
```

The setting above is only needed to declare the column. Ordinary queries reach this at default settings too, because the analyzer produces the type on its own: `toTypeName(toLowCardinality(toUInt128(materialize(0))))` is `LowCardinality(UInt128)`.

The fix assigns `key_sizes[0] = size_of_field` in that branch. For every non-`LowCardinality` key the value written is the one already present, and map selection is unchanged, so no query plan or performance characteristic changes. It also repairs `ConcurrentHashJoin::selectDispatchBlock`, which reads the same `key_sizes` and until now sent every row to a single shard.

Wrong results reproduce under `hash`, `parallel_hash` and `grace_hash`. Keys of 8 bytes or less were never affected, because `HashMethodOneNumber` ignores `key_sizes`.

`04745_join_low_cardinality_wide_int_key` fails before the change and passes after it. It covers the four affected types plus `Nullable`, and asserts that unaffected shapes stay correct: `LowCardinality` over `UInt8`, `UInt64`, `String`, `UUID`, plain `UInt128`, multi-column keys, ASOF and `full_sorting_merge`.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.4.46`, `26.6.3.46`, `26.3.31.5`, `25.8.34.11`
<!-- ch-version-info:end -->