### PR TITLE
Make 04329_iceberg_insert_stale_schema_field_id_107268 own its cache state

### DIFF
--- a/tests/queries/0_stateless/04329_iceberg_insert_stale_schema_field_id_107268.sh
+++ b/tests/queries/0_stateless/04329_iceberg_insert_stale_schema_field_id_107268.sh
@@ -1,19 +1,28 @@
 #!/usr/bin/env bash
 # Tags: no-fasttest, no-parallel
 # - no-fasttest: requires `IcebergLocal` (USE_AVRO build option).
-# - no-parallel: the repro deliberately relies on a warmed entry in the
-#   server-global Iceberg metadata files cache surviving between the warm-up
-#   SELECT and the INSERT, so that INSERT analysis serves the stale schema
-#   while the sink force-reads the latest one. A concurrent test running
-#   `SYSTEM DROP ICEBERG METADATA CACHE`, or LRU eviction under parallel cache
-#   pressure, would drop that entry; the INSERT would then take the fresh-read
-#   path, the stale-vs-latest disagreement would vanish, and the regression
-#   would silently stop firing. Unique table names isolate values but not the
-#   shared cache.
+# - no-parallel: `SYSTEM DROP ICEBERG METADATA CACHE` is used.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
+
+# Report the INSERT outcome for every outcome, so a run that stops exercising the
+# rejection path fails visibly instead of printing nothing.
+insert_outcome() {
+    local out
+    if out=$(${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --iceberg_metadata_staleness_ms=600000 \
+                --async_insert=0 --query "$1" 2>&1)
+    then
+        echo "NO_ERROR"
+    else
+        # The code name is the last parenthesised upper-case token before any stack trace.
+        local code
+        code=$(echo "$out" | grep -m1 '^Code: ' | sed 's/, Stack trace.*//' \
+                   | grep -o '([A-Z][A-Z0-9_]*)' | tail -1 | tr -d '()')
+        echo "${code:-UNPARSED_ERROR}"
+    fi
+}
 
 # --- Scenario 1: top-level column rename -------------------------------------------------------
 # The block carries a stale top-level name absent from the sink's force-fetched latest field-id map.
@@ -24,7 +33,9 @@ rm -rf "${TABLE_PATH}" 2>/dev/null
 ${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${TABLE} (c0 Int32, c1 String) ENGINE = IcebergLocal('${TABLE_PATH}')"
 ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE} SELECT 1, 'a'"
 
-# Warm the persistent metadata cache with the current schema {c0, c1}.
+# Warm the persistent metadata cache with the current schema {c0, c1}. Clear it first: a cache left
+# at its entry bound by earlier tests would evict this entry again before the INSERT below reads it.
+${CLICKHOUSE_CLIENT} --query "SYSTEM DROP ICEBERG METADATA CACHE"
 ${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=600000 --query "SELECT count() FROM ${TABLE}" > /dev/null
 
 # Another writer publishes a newer metadata version renaming c0 -> c9. The on-disk current schema
@@ -47,8 +58,7 @@ PY
 # A synchronous INSERT shaped by the stale schema (column c0) while the sink force-reads the latest
 # schema {c9, c1}. Before the fix this aborted the server with a std::out_of_range logical error in
 # Parquet::prepareColumnRecursive (unordered_map::at). After the fix it must be a clean query error.
-${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --iceberg_metadata_staleness_ms=600000 --async_insert=0 \
-    --query "INSERT INTO ${TABLE} (c0, c1) SELECT 2, 'b'" 2>&1 | grep -oF "INCORRECT_DATA" | head -1
+insert_outcome "INSERT INTO ${TABLE} (c0, c1) SELECT 2, 'b'"
 
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE}"
 rm -rf "${TABLE_PATH}" 2>/dev/null
@@ -65,6 +75,7 @@ rm -rf "${NTABLE_PATH}" 2>/dev/null
 ${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${NTABLE} (c0 Int32, t Tuple(a Int32)) ENGINE = IcebergLocal('${NTABLE_PATH}')"
 ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${NTABLE} SELECT 1, tuple(10)"
 
+${CLICKHOUSE_CLIENT} --query "SYSTEM DROP ICEBERG METADATA CACHE"
 ${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=600000 --query "SELECT count() FROM ${NTABLE}" > /dev/null
 
 # Publish a newer metadata version renaming the nested field t.a -> t.b. The top-level field t keeps
@@ -86,8 +97,7 @@ tmp = os.path.join(md, '.tmp_v3'); json.dump(m, open(tmp, 'w'))
 os.rename(tmp, os.path.join(md, 'v3.metadata.json'))
 PY
 
-${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --iceberg_metadata_staleness_ms=600000 --async_insert=0 \
-    --query "INSERT INTO ${NTABLE} (c0, t) SELECT 2, tuple(20)" 2>&1 | grep -oF "INCORRECT_DATA" | head -1
+insert_outcome "INSERT INTO ${NTABLE} (c0, t) SELECT 2, tuple(20)"
 
 # The server must still be alive after both scenarios (no abort).
 ${CLICKHOUSE_CLIENT} --query "SELECT 1"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/113010
Related: https://github.com/ClickHouse/ClickHouse/pull/109838

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04329_iceberg_insert_stale_schema_field_id_107268` failed 7 times on
`Stateless tests (arm_asan_ubsan, targeted)` across two unrelated PRs (#113010, #112866), both
expected `INCORRECT_DATA` lines missing each time. It is my test.

The test needs INSERT analysis to serve a stale schema while the sink force-reads the latest one, and
built that by warming the server-global Iceberg metadata files cache and hoping the entry survived to
the INSERT. That cache is SLRU-bounded at 1000 entries (`src/Core/Defines.h:121,123`) and shared with
every other test, so when earlier tests leave it at its bound the entry is evicted, the INSERT reads
fresh, both views agree, and the rejection correctly does not fire. A second defect hid
that: `grep -oF "INCORRECT_DATA"` prints nothing for a successful INSERT *and* nothing for a different
error code, so it could not distinguish a wrong code from no error, and in the opposite cache state it
passed vacuously.

The fix clears the cache immediately before each warm-up `SELECT`, so the test owns the state it
depends on, and reports the actual outcome for every outcome (error code name, or `NO_ERROR`).
`.reference` is unchanged, so the rejection must still fire twice; a run that stops exercising it now
fails and names why. `no-parallel` is kept, now guarding the cache clear, like
`03272_prewarm_mark_cache_add_column.sql`.

With the cache bound lowered to 40 and pre-filled to 40/40, the old form fails with a diff
byte-identical to CI and the new form passes on that same state. 50/50 randomized runs pass. `04214`
and `04337`, the only other users of `iceberg_metadata_staleness_ms`, are not exposed.

`v3.metadata.json` is still written directly: `ALTER ... RENAME COLUMN` calls
`invalidateMetadataCache()` and destroys the precondition. `04337` does the same, but I will move this
to an integration test if you prefer. #109838 also touches these two lines (expecting
`BAD_ARGUMENTS`), so whichever lands second needs a `.reference` rebase.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.757` (included in `26.8` and later)
<!-- ch-version-info:end -->