### PR TITLE
Docs: fix issue with client properties name in Kafka connect sink docs

### DIFF
--- a/docs/integrations/connectors/data-ingestion/kafka/kafka-clickhouse-connect-sink.mdx
+++ b/docs/integrations/connectors/data-ingestion/kafka/kafka-clickhouse-connect-sink.mdx
@@ -862,7 +862,7 @@ For connector-level insert settings:
 The connector maintains HTTP connections to ClickHouse. Adjust timeouts for high-latency networks:
 
 ```json
-"clickhouseSettings": "socket_timeout=300000,connection_timeout=30000"
+"jdbcConnectionProperties": "?socket_timeout=300000,connection_timeout=30000"
 ```
 
 - **`socket_timeout`** (default: 30000 ms): Maximum time for read operations


### PR DESCRIPTION
## Description 

Updates Kafka Connect Sink documentation where wrongly mentioned that `clickhouseSettings` should be used for client config (`socket_timeout` and `connection_timeout`) while all client settings are passed via `jdbcConnectionProperties`  


### Changelog category (leave one):
- Documentation (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.744` (included in `26.8` and later)
<!-- ch-version-info:end -->