### PR TITLE
Fix segfault when a periodic update applies an empty configuration

### DIFF
--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -438,6 +438,10 @@ public:
         if (configs == new_configs)
             return;
 
+        /// The reader has not collected any configuration yet, so there is nothing to apply.
+        if (!new_configs)
+            return;
+
         /// The following check prevents a race when two threads are trying to update configuration
         /// at almost the same time:
         /// 1) first thread reads a configuration (for example as a part of periodic updates)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113006
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a segfault that could prevent the server from starting. The background updater for dictionaries and executable user defined functions could read an empty configuration before the first configuration repository was registered and then apply it, dereferencing a null pointer in `ExternalLoader::LoadingDispatcher::setConfiguration`.


### Description

Found on `Stress test (amd_debug)` as `Cannot start clickhouse-server`. Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113006&sha=8da6174d0244fdd0bb61d685e28844fe28322138&name_0=PR&name_1=Stress%20test%20%28amd_debug%29 (that carrier PR is unrelated, it only touches Arrow/Parquet).

```
Received signal Segmentation fault (11)
Address: 0x28. Access: read. Address not mapped to object.
3. ExternalLoader.cpp:447:42  LoadingDispatcher::setConfiguration(...)
4. ExternalLoader.cpp:1382:36 PeriodicUpdater::doPeriodicUpdates()
```

**Root cause.** `setConfiguration` null-checks the old snapshot pointer but dereferences the new one in the same comparison: `if (configs && (configs->counter >= new_configs->counter))`. With `configs` non-null and `new_configs` null, the left arm is true and `new_configs->counter` reads through a null `shared_ptr`. `counter` sits at offset `0x28` in `ObjectConfigs`, the faulting address.

A null snapshot legitimately means "nothing collected yet": `read()` returns null until the first `addConfigRepository` sets the reader's dirty flag. It can meet a non-null `configs` because `setConfiguration(read())` is two critical sections on two different mutexes with nothing held across the gap, while both loaders start their 5-second periodic updater from their constructor, before any repository exists. A tick that reads before the first registration and applies after it produces that pair.

**Fix:** return when there is nothing to apply. This is the shared sink of all six `setConfiguration(read())` call sites, and every other dereference of `new_configs` sits after the new guard. One `LoadingDispatcher` is shared by both `ExternalLoader` subclasses, so dictionaries and UDFs are both fixed. The guard cannot hide a real configuration: `object_configs` is only ever assigned from a freshly allocated `ObjectConfigs`, so it fires only on the default-constructed null sentinel, and an empty-but-collected configuration still passes through.

**Testing.** No committed test: the deterministic fail point and its integration test were dropped on review, and stress-test reproduction is accepted as coverage. Both directions were measured before the removal, on one build: without the guard the startup race reproduces `Address: 0x28` at `ExternalLoader.cpp:447`; with it, 10/10 runs pass.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.424` (included in `26.9` and later)
<!-- ch-version-info:end -->