### PR TITLE
Key query condition cache entries by apply_deleted_mask

### DIFF
--- a/src/Interpreters/Cache/QueryConditionCache.cpp
+++ b/src/Interpreters/Cache/QueryConditionCache.cpp
@@ -21,12 +21,16 @@ namespace CurrentMetrics
 namespace DB
 {
 
-QueryConditionCache::Key QueryConditionCache::makeKey(const UUID & table_id, const String & part_name, UInt64 condition_hash)
+QueryConditionCache::Key QueryConditionCache::makeKey(
+    const UUID & table_id, const String & part_name, UInt64 condition_hash, bool apply_deleted_mask)
 {
     SipHash hash;
     hash.update(table_id);
     hash.update(part_name);
     hash.update(condition_hash);
+    /// Mixed in only for the unusual case, so that the keys of ordinary reads stay what they were.
+    if (!apply_deleted_mask)
+        hash.update("apply_deleted_mask=0");
     return hash.get128();
 }
 
@@ -58,12 +62,12 @@ QueryConditionCache::QueryConditionCache(const String & cache_policy, size_t max
 
 void QueryConditionCache::write(
     const UUID & table_id, const String & part_name, UInt64 condition_hash, const String & condition,
-    const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark)
+    const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark, bool apply_deleted_mask)
 {
     if (table_id == UUIDHelpers::Nil)
         return; /// Issue #92863: Certain database engines provide no table UUIDs
 
-    Key key = makeKey(table_id, part_name, condition_hash);
+    Key key = makeKey(table_id, part_name, condition_hash, apply_deleted_mask);
 
 #if defined(DEBUG_OR_SANITIZER_BUILD)
     auto load_func = [&](){ return std::make_shared<Entry>(marks_count, table_id, part_name, condition_hash, condition); };
@@ -120,12 +124,13 @@ void QueryConditionCache::write(
         has_final_mark);
 }
 
-std::optional<QueryConditionCache::MatchingMarks> QueryConditionCache::read(const UUID & table_id, const String & part_name, UInt64 condition_hash, bool increment_profile_events)
+std::optional<QueryConditionCache::MatchingMarks> QueryConditionCache::read(
+    const UUID & table_id, const String & part_name, UInt64 condition_hash, bool apply_deleted_mask, bool increment_profile_events)
 {
     if (table_id == UUIDHelpers::Nil)
         return {}; /// Issue #92864: Certain database engines provide no table UUIDs
 
-    Key key = makeKey(table_id, part_name, condition_hash);
+    Key key = makeKey(table_id, part_name, condition_hash, apply_deleted_mask);
 
     if (auto entry = cache.get(key))
     {

--- a/src/Interpreters/Cache/QueryConditionCache.h
+++ b/src/Interpreters/Cache/QueryConditionCache.h
@@ -73,8 +73,13 @@ private:
 public:
     using Cache = CacheBase<Key, Entry, UInt128TrivialHash, EntryWeight>;
 
-    /// Compute cache key from table UUID, part name and condition hash
-    static Key makeKey(const UUID & table_id, const String & part_name, UInt64 condition_hash);
+    /// Compute cache key from table UUID, part name and condition hash.
+    ///
+    /// `apply_deleted_mask` separates the key spaces of reads that see lightweight-deleted rows from
+    /// those that do not: a granule whose only matching rows are deleted is "no match" for one and
+    /// "may match" for the other, so the two must not share entries. Callers that cannot see deleted
+    /// rows at all (file- and object-storage tables) pass true.
+    static Key makeKey(const UUID & table_id, const String & part_name, UInt64 condition_hash, bool apply_deleted_mask);
 
     /// Compose the `part_name` component of a cache key for a file-backed table (e.g. `File`, `S3`,
     /// object storage). Uses the full path (not just the base name) so files that share a name in
@@ -91,13 +96,15 @@ public:
     /// Add an entry to the cache. The passed marks represent ranges of the column with matches of the predicate.
     void write(
         const UUID & table_id, const String & part_name, UInt64 condition_hash, const String & condition,
-        const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark);
+        const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark, bool apply_deleted_mask);
 
     /// Check the cache if it contains an entry for the given table + part id and predicate hash.
     /// A single logical consultation may probe more than one key (e.g. the bare condition hash and
     /// a skip-index-profiled hash); pass increment_profile_events = false on the extra probes so the
     /// QueryConditionCacheHits/Misses events count consultations, not internal key lookups.
-    std::optional<MatchingMarks> read(const UUID & table_id, const String & part_name, UInt64 condition_hash, bool increment_profile_events = true);
+    std::optional<MatchingMarks> read(
+        const UUID & table_id, const String & part_name, UInt64 condition_hash, bool apply_deleted_mask,
+        bool increment_profile_events = true);
 
     /// For debugging and system tables
     std::vector<QueryConditionCache::Cache::KeyMapped> dump() const;

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -3177,7 +3177,8 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
                     output->result_name,
                     remaining_ranges.ranges,
                     data_part->index_granularity->getMarksCount(),
-                    data_part->index_granularity->hasFinalMark());
+                    data_part->index_granularity->hasFinalMark(),
+                    reader_settings.apply_deleted_mask);
             }
         }
     }

--- a/src/Processors/Transforms/FilterTransform.cpp
+++ b/src/Processors/Transforms/FilterTransform.cpp
@@ -376,7 +376,8 @@ void FilterTransform::writeIntoQueryConditionCache(const MarkRangesInfoPtr & mar
             condition->second,
             buffered_mark_ranges_info->mark_ranges,
             buffered_mark_ranges_info->marks_count,
-            buffered_mark_ranges_info->has_final_mark);
+            buffered_mark_ranges_info->has_final_mark,
+            buffered_mark_ranges_info->apply_deleted_mask);
 
         buffered_mark_ranges_info = nullptr;
 
@@ -401,7 +402,8 @@ void FilterTransform::writeIntoQueryConditionCache(const MarkRangesInfoPtr & mar
                 condition->second,
                 buffered_mark_ranges_info->mark_ranges,
                 buffered_mark_ranges_info->marks_count,
-                buffered_mark_ranges_info->has_final_mark);
+                buffered_mark_ranges_info->has_final_mark,
+                buffered_mark_ranges_info->apply_deleted_mask);
 
             buffered_mark_ranges_info = std::static_pointer_cast<MarkRangesInfo>(mark_ranges_info->clone());
         }

--- a/src/Storages/MergeTree/MarkRange.cpp
+++ b/src/Storages/MergeTree/MarkRange.cpp
@@ -124,11 +124,14 @@ void MarkRanges::deserialize(ReadBuffer & in)
     }
 }
 
-MarkRangesInfo::MarkRangesInfo(UUID table_uuid_, const String & part_name_, size_t marks_count_, bool has_final_mark_, MarkRanges mark_ranges_)
+MarkRangesInfo::MarkRangesInfo(
+    UUID table_uuid_, const String & part_name_, size_t marks_count_, bool has_final_mark_, bool apply_deleted_mask_,
+    MarkRanges mark_ranges_)
     : table_uuid(table_uuid_)
     , part_name(part_name_)
     , marks_count(marks_count_)
     , has_final_mark(has_final_mark_)
+    , apply_deleted_mask(apply_deleted_mask_)
     , mark_ranges(mark_ranges_)
 {}
 void MarkRangesInfo::appendMarkRanges(const MarkRanges & mark_ranges_)

--- a/src/Storages/MergeTree/MarkRange.h
+++ b/src/Storages/MergeTree/MarkRange.h
@@ -65,13 +65,18 @@ void assertSortedAndNonIntersecting(const MarkRanges & ranges);
 class MarkRangesInfo : public ChunkInfoCloneable<MarkRangesInfo>
 {
 public:
-    MarkRangesInfo(UUID table_uuid_, const String & part_name_, size_t marks_count_, bool has_final_mark_, MarkRanges mark_ranges_);
+    MarkRangesInfo(
+        UUID table_uuid_, const String & part_name_, size_t marks_count_, bool has_final_mark_, bool apply_deleted_mask_,
+        MarkRanges mark_ranges_);
     void appendMarkRanges(const MarkRanges & mark_ranges_);
 
     UUID table_uuid;
     String part_name;
     size_t marks_count;
     bool has_final_mark;
+    /// Whether the read that produced the chunk hid lightweight-deleted rows. Part of the query
+    /// condition cache key, see QueryConditionCache::makeKey.
+    bool apply_deleted_mask;
     MarkRanges mark_ranges;
 };
 

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -112,6 +112,7 @@ namespace Setting
     extern const SettingsBool use_query_condition_cache;
     extern const SettingsBool use_query_condition_cache_for_top_k;
     extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool apply_deleted_mask;
     extern const SettingsBool secondary_indices_enable_bulk_filtering;
     extern const SettingsBool vector_search_with_rescoring;
     extern const SettingsBool use_skip_indexes_for_top_k;
@@ -1569,6 +1570,10 @@ void MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache(
 
     QueryConditionCachePtr query_condition_cache = context->getQueryConditionCache();
 
+    /// A read that shows lightweight-deleted rows has its own key space, see
+    /// QueryConditionCache::makeKey.
+    const bool apply_deleted_mask = settings[Setting::apply_deleted_mask];
+
     /// Each condition is looked up under two keys (see the write sides):
     ///   * the bare condition hash, holding row-level exclusions (FilterTransform,
     ///     MergeTreeSelectProcessor, object storage) which are always sound; and
@@ -1655,14 +1660,14 @@ void MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache(
             /// This is one logical cache consultation, so it must emit at most one
             /// QueryConditionCacheHits/Misses event regardless of how many keys are probed: count
             /// the hit/miss ourselves and suppress the per-read events on every lookup.
-            auto row_level_marks_opt = query_condition_cache->read(storage_id.uuid, data_part->name, condition_hash, /*increment_profile_events=*/false);
-            auto skip_index_marks_opt = query_condition_cache->read(storage_id.uuid, data_part->name, profiled_condition_hash, /*increment_profile_events=*/false);
+            auto row_level_marks_opt = query_condition_cache->read(storage_id.uuid, data_part->name, condition_hash, apply_deleted_mask, /*increment_profile_events=*/false);
+            auto skip_index_marks_opt = query_condition_cache->read(storage_id.uuid, data_part->name, profiled_condition_hash, apply_deleted_mask, /*increment_profile_events=*/false);
             std::optional<QueryConditionCache::MatchingMarks> topk_reuse_predicate_only_row_level_marks_opt;
             std::optional<QueryConditionCache::MatchingMarks> topk_reuse_predicate_only_skip_index_marks_opt;
             if (also_probe_topk_reuse_predicate_only_hash)
             {
-                topk_reuse_predicate_only_row_level_marks_opt = query_condition_cache->read(storage_id.uuid, data_part->name, topk_reuse_predicate_only_hash, /*increment_profile_events=*/false);
-                topk_reuse_predicate_only_skip_index_marks_opt = query_condition_cache->read(storage_id.uuid, data_part->name, topk_reuse_predicate_only_profiled_hash, /*increment_profile_events=*/false);
+                topk_reuse_predicate_only_row_level_marks_opt = query_condition_cache->read(storage_id.uuid, data_part->name, topk_reuse_predicate_only_hash, apply_deleted_mask, /*increment_profile_events=*/false);
+                topk_reuse_predicate_only_skip_index_marks_opt = query_condition_cache->read(storage_id.uuid, data_part->name, topk_reuse_predicate_only_profiled_hash, apply_deleted_mask, /*increment_profile_events=*/false);
             }
             if (!row_level_marks_opt && !skip_index_marks_opt
                 && !topk_reuse_predicate_only_row_level_marks_opt && !topk_reuse_predicate_only_skip_index_marks_opt)

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -304,6 +304,7 @@ MergeTreeSelectProcessor::readCurrentTask(MergeTreeReadTask & current_task, IMer
                     part_name,
                     data_part_info->getIndexGranularity().getMarksCount(),
                     data_part_info->getIndexGranularity().hasFinalMark(),
+                    reader_settings.apply_deleted_mask,
                     res.read_mark_ranges));
             }
 
@@ -447,7 +448,8 @@ ChunkAndProgress MergeTreeSelectProcessor::read()
                                 prewhere_info->prewhere_actions.getNames()[0],
                                 task->getPrewhereUnmatchedMarks(),
                                 data_part_info->getIndexGranularity().getMarksCount(),
-                                data_part_info->getIndexGranularity().hasFinalMark());
+                                data_part_info->getIndexGranularity().hasFinalMark(),
+                                reader_settings.apply_deleted_mask);
 
                             break;
                         }

--- a/src/Storages/ObjectStorage/IObjectIterator.cpp
+++ b/src/Storages/ObjectStorage/IObjectIterator.cpp
@@ -153,7 +153,8 @@ ObjectInfoPtr ObjectIteratorSplitByBuckets::next(size_t id)
                 auto matching_marks = query_condition_cache->read(
                     storage_id.uuid,
                     query_condition_cache_key,
-                    *format_filter_info->condition_hash);
+                    *format_filter_info->condition_hash,
+                    /*apply_deleted_mask=*/true);
                 if (matching_marks.has_value())
                 {
                     has_cache_entry = true;

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -752,7 +752,8 @@ Chunk StorageObjectStorageSource::generate()
                                 format_filter_info->filter_actions_dag->dumpNames(),
                                 unmatched_ranges,
                                 total_groups,
-                                false
+                                false,
+                                /*apply_deleted_mask=*/true
                             );
                         }
                     }
@@ -876,7 +877,8 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
             std::optional<QueryConditionCache::MatchingMarks> matching_marks;
             if (query_condition_cache_key)
                 matching_marks = query_condition_cache->read(
-                    storage_id.uuid, *query_condition_cache_key, *format_filter_info->condition_hash);
+                    storage_id.uuid, *query_condition_cache_key, *format_filter_info->condition_hash,
+                    /*apply_deleted_mask=*/true);
             if (matching_marks.has_value())
             {
                 const auto & marks = *matching_marks;

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -1813,7 +1813,8 @@ Chunk StorageFileSource::generate()
             {
                 const String cache_file_key = QueryConditionCache::makeFilePartName(current_path, *current_file_cache_version);
                 auto matching_marks = query_condition_cache->read(
-                    storage->getStorageID().uuid, cache_file_key, *format_filter_info->condition_hash);
+                    storage->getStorageID().uuid, cache_file_key, *format_filter_info->condition_hash,
+                    /*apply_deleted_mask=*/true);
                 if (matching_marks.has_value())
                 {
                     const auto & marks = *matching_marks;
@@ -2008,7 +2009,8 @@ Chunk StorageFileSource::generate()
                                 format_filter_info->filter_actions_dag->dumpNames(),
                                 unmatched_ranges,
                                 total_groups,
-                                /*has_final_mark=*/false);
+                                /*has_final_mark=*/false,
+                                /*apply_deleted_mask=*/true);
                         }
                     }
                 }

--- a/tests/queries/0_stateless/04700_query_condition_cache_apply_deleted_mask.reference
+++ b/tests/queries/0_stateless/04700_query_condition_cache_apply_deleted_mask.reference
@@ -1,0 +1,20 @@
+--- an ordinary read does not consume an apply_deleted_mask = 0 entry
+0
+0
+--- and an apply_deleted_mask = 0 read does not consume an ordinary entry
+0
+0
+--- within its own key space, apply_deleted_mask = 0 still prunes
+0
+0
+--- log_comment, (any QCC hit), (read no marks at all)
+04700_mask0_first	0	0
+04700_normal_after_mask0	0	0
+04700_normal_first	0	0
+04700_mask0_after_normal	0	0
+04700_mask0_prime	0	0
+04700_mask0_reuse	1	1
+--- results stay correct with the cache warm
+0
+10
+0

--- a/tests/queries/0_stateless/04700_query_condition_cache_apply_deleted_mask.sql
+++ b/tests/queries/0_stateless/04700_query_condition_cache_apply_deleted_mask.sql
@@ -1,0 +1,70 @@
+-- Tags: no-parallel, no-parallel-replicas
+-- no-parallel: drops the (instance-wide) query condition cache
+-- no-parallel-replicas: the cache is populated per replica, so the mark counts below are
+--                       deterministic only on a single replica
+
+-- A read with `apply_deleted_mask = 0` sees lightweight-deleted rows, so a granule whose only
+-- matching rows are deleted is "no match" for an ordinary read and "may match" for that one. The two
+-- therefore get separate query condition cache key spaces and must not reuse each other's entries.
+
+SET use_query_condition_cache = 1;
+-- The cache needs the analyzer on both the write and the read side.
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS t_qcc_mask;
+
+-- auto_statistics_types = '': randomized auto statistics would prune the whole part for the
+-- never-matching predicate below, leaving nothing to read and the mark counts vacuous.
+CREATE TABLE t_qcc_mask (id UInt64, v UInt64)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 0, auto_statistics_types = '';
+
+INSERT INTO t_qcc_mask SELECT number, number FROM numbers(100000);
+
+-- Materialize the delete, so the mask is committed part data and nothing stays pending.
+DELETE FROM t_qcc_mask WHERE id < 10 SETTINGS mutations_sync = 2;
+
+SELECT '--- an ordinary read does not consume an apply_deleted_mask = 0 entry';
+SYSTEM DROP QUERY CONDITION CACHE;
+SELECT count() FROM t_qcc_mask WHERE v = 123456789
+SETTINGS apply_deleted_mask = 0, log_comment = '04700_mask0_first';
+SELECT count() FROM t_qcc_mask WHERE v = 123456789
+SETTINGS log_comment = '04700_normal_after_mask0';
+
+SELECT '--- and an apply_deleted_mask = 0 read does not consume an ordinary entry';
+SYSTEM DROP QUERY CONDITION CACHE;
+SELECT count() FROM t_qcc_mask WHERE v = 123456789
+SETTINGS log_comment = '04700_normal_first';
+SELECT count() FROM t_qcc_mask WHERE v = 123456789
+SETTINGS apply_deleted_mask = 0, log_comment = '04700_mask0_after_normal';
+
+SELECT '--- within its own key space, apply_deleted_mask = 0 still prunes';
+SYSTEM DROP QUERY CONDITION CACHE;
+SELECT count() FROM t_qcc_mask WHERE v = 123456789
+SETTINGS apply_deleted_mask = 0, log_comment = '04700_mask0_prime';
+SELECT count() FROM t_qcc_mask WHERE v = 123456789
+SETTINGS apply_deleted_mask = 0, log_comment = '04700_mask0_reuse';
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT '--- log_comment, (any QCC hit), (read no marks at all)';
+SELECT
+    log_comment,
+    ProfileEvents['QueryConditionCacheHits'] > 0,
+    ProfileEvents['SelectedMarks'] = 0
+FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600
+    AND type = 'QueryFinish'
+    AND current_database = currentDatabase()
+    AND startsWith(log_comment, '04700_')
+ORDER BY event_time_microseconds;
+
+-- The one case the separation exists for: the deleted rows must come back for a reader that asks for
+-- them, however warm the cache is for the same predicate.
+SELECT '--- results stay correct with the cache warm';
+SYSTEM DROP QUERY CONDITION CACHE;
+SELECT count() FROM t_qcc_mask WHERE id < 10;
+SELECT count() FROM t_qcc_mask WHERE id < 10 SETTINGS apply_deleted_mask = 0;
+SELECT count() FROM t_qcc_mask WHERE id < 10;
+
+DROP TABLE t_qcc_mask;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/112947
Related: https://github.com/ClickHouse/ClickHouse/pull/107145

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Query condition cache entries are now keyed by `apply_deleted_mask`, so reads that show lightweight-deleted rows and ordinary reads no longer share entries.

### Description

A read with `apply_deleted_mask = 0` sees lightweight-deleted rows. A granule whose only matching rows are deleted is therefore "no match" for an ordinary read and "may match" for that one, and the two verdicts are not interchangeable. They shared a cache key all the same: `(table uuid, part name, condition hash)`.

Only one direction is unsound. An entry written by an ordinary read, consumed by an `apply_deleted_mask = 0` read, makes it skip a granule holding exactly the deleted rows it was asked to return. The reverse is conservative: the writer saw a superset of the rows, so its "no match" still holds.

#### The fix

`QueryConditionCache::makeKey` mixes the flag into the key, so the two get separate key spaces. The salt is added only when the mask is off, which leaves the keys of ordinary reads byte-identical and invalidates nothing on upgrade.

`read` and `write` take the flag explicitly rather than each site salting its own condition hash. Three places compute a condition hash independently (index analysis in `ReadFromMergeTree`, the PREWHERE write in `MergeTreeSelectProcessor`, the consult in `MergeTreeDataSelectExecutor`) and a fourth writes through `MarkRangesInfo` attached to the chunk. Salting at each of them means a missed site is a silent wrong-results bug; making it a parameter means a missed site does not compile. `MarkRangesInfo` carries the flag from `MergeTreeSelectProcessor` to `FilterTransform` for the WHERE write.

File- and object-storage tables have no deleted rows and pass `true`.

#### Relationship to https://github.com/ClickHouse/ClickHouse/pull/112947

That PR needs the same guarantee and takes the cheap route: queries with `apply_deleted_mask = 0` neither read nor write the cache. That is the right shape for a backport (it is three lines and cannot regress anything), and it is what should ship to 26.3/26.4/26.5.

This is the version for `master`: nothing has to be excluded, so `apply_deleted_mask = 0` keeps its pruning. The two are not independent at the end state, and the order matters. Whichever of them merges second has to remove #112947's two gates (in `MergeTreeIOSettings` and `MergeTreeDataSelectExecutor`) and flip the block in `04669_query_condition_cache_lightweight_delete` that pins the no-caching behaviour. Left in place, those gates keep `apply_deleted_mask = 0` out of the cache and the last assertion of `04700_query_condition_cache_apply_deleted_mask` (a repeated `apply_deleted_mask = 0` query prunes) fails. Landing #112947 first and removing its gates here is the cleaner sequence.

#### Tests

New `04700_query_condition_cache_apply_deleted_mask`:

- an ordinary read does not consume an `apply_deleted_mask = 0` entry (fails before this change: it hits and prunes)
- the reverse direction does not either
- an `apply_deleted_mask = 0` read still prunes on a repeat within its own key space
- the deleted rows come back for a reader that asks for them however warm the cache is

