### PR TITLE
Stop a cache-warm read of an already-removed part from failing the lost-S3-keys checks

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -38,6 +38,46 @@ remote_servers:
 CLICKHOUSE_CI_LOGS_CLUSTER = "system_logs_export"
 CLICKHOUSE_CI_LOGS_USER = "ci"
 
+# Substrings marking a "Code: 499. The specified key does not exist" log line as benign for the
+# "Lost s3 keys" / "S3_ERROR No such key thrown" checks - keep in sync with
+# check_logs_for_critical_errors() in tests/docker_scripts/stress_tests.lib. Ignored:
+#  - "a.myext" is used by 02724_database_s3.sh and does not exist
+#  - "DistributedCacheTCPHandler" and "caller id: None:DistribCache" happen inside the distributed
+#    cache server
+#  - "ReadBuffer is canceled by the exception" is a normal cancellation, the message is kept for
+#    debugging purposes
+#  - "ReadBufferFromDistributedCache", "AsynchronousBoundedReadBuffer", "ReadBufferFromS3",
+#    "ReadBufferFromAzureBlobStorage" are printed internally by a buffer, the exception is rethrown
+#    and handled correctly
+#  - "Error during background download" is printed by the filesystem cache background download
+#    worker (CacheMetadata): the prefetched object can be concurrently removed (DROP, mutation, part
+#    removal), the download is just marked as failed and the data is re-read from the source later
+#  - "caller id: None:cache-warm" is a read issued by the cache warmer, which walks the files of a
+#    part that can be removed under it; the warmer treats a missing object as expected and the file
+#    segment is never served, so nothing is lost
+NO_SUCH_KEY_IGNORES = (
+    "a.myext",
+    "ReadBuffer is canceled by the exception",
+    "DistributedCacheTCPHandler",
+    "ReadBufferFromDistributedCache",
+    "ReadBufferFromS3",
+    "ReadBufferFromAzureBlobStorage",
+    "AsynchronousBoundedReadBuffer",
+    "Error during background download",
+    "caller id: None:DistribCache",
+    "caller id: None:cache-warm",
+)
+
+
+def no_such_key_check_command(log_dir):
+    """Command behind both "No such key" checks: fails if a non-ignored occurrence is found."""
+    ignores = " ".join(f"-e '{ignore}'" for ignore in NO_SUCH_KEY_IGNORES)
+    return (
+        f"cd {log_dir} && ! grep -a 'Code: 499.*The specified key does not exist' "
+        f"clickhouse-server*.log | grep -v {ignores} "
+        "| head -n100 | tee /dev/stderr | grep -q ."
+    )
+
 
 class ClickHouseProc:
     MINIO_LOG = f"{temp_dir}/minio.log"
@@ -1062,40 +1102,8 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                         )
                     )
 
-        # Both "No such key" checks below run the same scan, so the ignore list is
-        # built once - keep it in sync with check_logs_for_critical_errors() in
-        # tests/docker_scripts/stress_tests.lib. Ignored:
-        #  - "a.myext" is used by 02724_database_s3.sh and does not exist
-        #  - "DistributedCacheTCPHandler" and "caller id: None:DistribCache" happen
-        #    inside the distributed cache server
-        #  - "ReadBuffer is canceled by the exception" is a normal cancellation, the
-        #    message is kept for debugging purposes
-        #  - "ReadBufferFromDistributedCache", "AsynchronousBoundedReadBuffer",
-        #    "ReadBufferFromS3", "ReadBufferFromAzureBlobStorage" are printed
-        #    internally by a buffer, the exception is rethrown and handled correctly
-        #  - "Error during background download" is printed by the filesystem cache
-        #    background download worker (CacheMetadata): the prefetched object can be
-        #    concurrently removed (DROP, mutation, part removal), the download is just
-        #    marked as failed and the data is re-read from the source later
-        no_such_key_ignores = " ".join(
-            f"-e '{ignore}'"
-            for ignore in (
-                "a.myext",
-                "ReadBuffer is canceled by the exception",
-                "DistributedCacheTCPHandler",
-                "ReadBufferFromDistributedCache",
-                "ReadBufferFromS3",
-                "ReadBufferFromAzureBlobStorage",
-                "AsynchronousBoundedReadBuffer",
-                "Error during background download",
-                "caller id: None:DistribCache",
-            )
-        )
-        no_such_key_command = (
-            f"cd {self.log_dir} && ! grep -a 'Code: 499.*The specified key does not exist' "
-            f"clickhouse-server*.log | grep -v {no_such_key_ignores} "
-            "| head -n100 | tee /dev/stderr | grep -q ."
-        )
+        # Both "No such key" checks below run the same scan, so build it once.
+        no_such_key_command = no_such_key_check_command(self.log_dir)
         results.append(
             Result.from_commands_run(
                 name="Lost s3 keys",

--- a/ci/tests/test_no_such_key_ignores.py
+++ b/ci/tests/test_no_such_key_ignores.py
@@ -1,0 +1,94 @@
+"""
+Tests for the "Lost s3 keys" / "S3_ERROR No such key thrown" log checks of the
+functional tests jobs (`ci.jobs.scripts.clickhouse_proc.no_such_key_check_command`).
+
+The scan is line oriented, while a ClickHouse exception log entry spans many lines:
+the message, the stack trace, and a trailing `(version …) (…)` line carrying whatever
+`addMessage` appended. An entry printed by an ignored buffer therefore escapes its own
+ignore whenever that trailing line repeats the nested `Code: 499` text - which is how a
+best-effort cache-warm read of a blob deleted with its part turned into two red checks
+with every test green. Every ignored substring gets a case checking that it suppresses a
+line naming it and nothing else; a genuine lost key must still be reported.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.scripts.clickhouse_proc import (
+    NO_SUCH_KEY_IGNORES,
+    no_such_key_check_command,
+)
+
+# Verbatim from the failing job (clickhouse-private#67155, `Stateless tests
+# (amd_asan_ubsan, distributed cache, meta in keeper, s3 storage, parallel, 1/2)`),
+# shortened in the middle: the trailing line of a `<Debug> ReadBufferFromDistributedCache`
+# entry, naming the cache warmer as the caller.
+CACHE_WARM_TRAILING_LINE = (
+    " (version 26.8.1.1) (File name: test/ffx/avmoqhjkisdnuurkyppycsnrkkgjj, local file name: "
+    "data/5adcf7ee-55fc-4600-b251-c3c7714beaec/all_1_1_0/columns_substreams.txt, file offset: 0/73, "
+    "last error: Code: 900. DB::Exception: Received error from distributed cache: Code: 499. "
+    "DB::Exception: The specified key does not exist. This error happened for S3 disk: while reading "
+    "key: test/ffx/avmoqhjkisdnuurkyppycsnrkkgjj, from bucket: test: Cache info: file segments: 1 "
+    "(front: File segment: [0, 72], state: DOWNLOADING, downloaded size: 0, downloader id: "
+    "None:cache-warm:10623:3931, caller id: None:cache-warm:10623:3931, background download: 1)."
+)
+
+# A key that is really gone under a query - what the checks exist to catch.
+GENUINE_LOST_KEY_LINE = (
+    "2026.08.04 07:21:57.003116 [ 10623 ] {b6e0f6c5-1d0e-4f1d-9b02-2f5f0d4a1c77} <Error> executeQuery: "
+    "Code: 499. DB::Exception: The specified key does not exist. This error happened for S3 disk: "
+    "while reading key: test/ffx/avmoqhjkisdnuurkyppycsnrkkgjj, from bucket: test. (S3_ERROR) "
+    "(version 26.8.1.1) (from [::1]:50056) (in query: SELECT * FROM t)"
+)
+
+UNRELATED_LINE = "2026.08.04 07:21:57.003116 [ 10623 ] {} <Debug> executeQuery: Read 1 rows"
+
+
+def run_check(tmp_path, lines):
+    (tmp_path / "clickhouse-server.log").write_text("\n".join(lines) + "\n")
+    return subprocess.run(
+        no_such_key_check_command(tmp_path),
+        shell=True,
+        capture_output=True,
+        text=True,
+    ).returncode
+
+
+def test_genuine_lost_key_is_reported(tmp_path):
+    assert run_check(tmp_path, [UNRELATED_LINE, GENUINE_LOST_KEY_LINE]) != 0
+
+
+def test_clean_log_passes(tmp_path):
+    assert run_check(tmp_path, [UNRELATED_LINE]) == 0
+
+
+def test_cache_warm_trailing_line_is_ignored(tmp_path):
+    assert run_check(tmp_path, [CACHE_WARM_TRAILING_LINE]) == 0
+
+
+def test_stress_tests_lib_ignores_the_same_lines():
+    """The stress tests run their own copy of the scan; the two lists must not drift."""
+    lib = os.path.join(os.path.dirname(__file__), "../../tests/docker_scripts/stress_tests.lib")
+    scan_line = next(
+        line
+        for line in open(lib, encoding="utf-8")
+        if "Code: 499.*The specified key does not exist" in line
+    )
+    assert re.findall(r'-e "([^"]*)"', scan_line) == list(NO_SUCH_KEY_IGNORES)
+
+
+@pytest.mark.parametrize("ignore", NO_SUCH_KEY_IGNORES)
+def test_every_ignore_suppresses_its_own_line(tmp_path, ignore):
+    line = (
+        "2026.08.04 07:21:56.996964 [ 10623 ] {} <Debug> "
+        f"{ignore}: Code: 499. DB::Exception: The specified key does not exist. (S3_ERROR)"
+    )
+    assert run_check(tmp_path, [line]) == 0
+    # …and the same line without the ignored substring is still reported.
+    assert run_check(tmp_path, [line.replace(ignore, "SomeOtherLogger")]) != 0

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -336,7 +336,9 @@ function check_logs_for_critical_errors()
     #    exceptions printed internally by a buffer, exception will be rethrown and handled correctly
     #  - "Error during background download" printed by the filesystem cache background download worker (CacheMetadata):
     #    the prefetched object may be concurrently removed (DROP/mutation/part removal), the download is just marked failed and the data is re-read directly
-    rg --text "Code: 499.*The specified key does not exist" /var/log/clickhouse-server/clickhouse-server*.log | grep -v -e "a.myext" -e "ReadBuffer is canceled by the exception" -e "DistributedCacheTCPHandler" -e "ReadBufferFromDistributedCache" -e "ReadBufferFromS3" -e "ReadBufferFromAzureBlobStorage" -e "AsynchronousBoundedReadBuffer" -e "Error during background download" -e "caller id: None:DistribCache" > /test_output/no_such_key_errors.txt \
+    #  - "caller id: None:cache-warm" is a read issued by the cache warmer, which walks the files of a part that can be
+    #    removed under it; the warmer treats a missing object as expected and the file segment is never served
+    rg --text "Code: 499.*The specified key does not exist" /var/log/clickhouse-server/clickhouse-server*.log | grep -v -e "a.myext" -e "ReadBuffer is canceled by the exception" -e "DistributedCacheTCPHandler" -e "ReadBufferFromDistributedCache" -e "ReadBufferFromS3" -e "ReadBufferFromAzureBlobStorage" -e "AsynchronousBoundedReadBuffer" -e "Error during background download" -e "caller id: None:DistribCache" -e "caller id: None:cache-warm" > /test_output/no_such_key_errors.txt \
         && echo -e "S3_ERROR No such key thrown (see clickhouse-server.log or no_such_key_errors.txt)$FAIL$(trim_server_logs no_such_key_errors.txt)" >> /test_output/test_results.tsv \
         || echo -e "No lost s3 keys$OK" >> /test_output/test_results.tsv
 


### PR DESCRIPTION
## Problem

The `Lost s3 keys` and `S3_ERROR No such key thrown (in clickhouse-server.log or clickhouse-server.err.log)` checks both failed on a job whose tests were all green, quoting the same line (same `request id`):

```
File name: test/ffx/avmoqhjkisdnuurkyppycsnrkkgjj,
local file name: data/5adcf7ee-.../all_1_1_0/columns_substreams.txt,
last error: Code: 900. DB::Exception: Received error from distributed cache:
            Code: 499. DB::Exception: The specified key does not exist.
Cache info: file segments: 1 (front: File segment: [0, 72], state: DOWNLOADING, downloaded size: 0,
            downloader id: None:cache-warm:10623:3931, caller id: None:cache-warm:10623:3931,
            background download: 1)
```

The reader is a background cache-warm task and the file segment is still `DOWNLOADING` with `downloaded size: 0`. From the job's server log, the blob was deleted **0.99 s before** the read, legitimately, together with the part that owned it:

| time | event |
|---|---|
| 07:21:55.773 | `keeper_retries_r2` removes `all_1_1_0` |
| 07:21:55.817 | `deleteFileFromS3` deletes the shared blob `test/ffx/avmoqhjkisdnuurkyppycsnrkkgjj` |
| 07:21:56.808 | `CacheWarmer::downloaderThread` GETs that key → `NoSuchKey` |
| 07:21:57.003 | the distributed-cache fallback re-reads it directly → `NoSuchKey` again |

Nothing is lost: cache warming is best effort, the segment never leaves `DOWNLOADING`, and `CacheWarmer` already treats a missing object as expected (it logs `NO_SUCH_KEY` at test level, noting the part was deleted and that this happens a lot in practice) — consistent with that, the warmer printed nothing here. The only cost is a red job.

## Root cause

The checks grep line by line, but a ClickHouse exception log entry spans many lines: the message, the stack trace, then a trailing `(version …) (…)` line carrying whatever `addMessage` appended.

The entry that trips the checks is `<Debug> ReadBufferFromDistributedCache: Failed to read from distributed cache. Will read from object storage directly. Error: …` — a logger the ignore list already covers. But the addendum on its trailing line repeats the nested `Code: 499 … The specified key does not exist`, and that line carries no logger name, so none of the ignores matched it. Running the current `master` command over the job's 12 M-line server log leaves exactly this one line.

Two things this rules out: severity is not the trigger (all 17 lines mentioning the key are `<Debug>`/`<Trace>`, and the check is a plain text grep), and silencing the warmer would not help (the line is printed before the exception ever reaches it).

## Solution

Ignore `caller id: None:cache-warm`, mirroring the existing `caller id: None:DistribCache` entry. `FileSegment::getCallerId` renders a caller with no query id as `None:<thread name>:<tid>`, and the distributed-cache client sends the same string as the query id when its calling thread has none, so every cache-warmer read is tagged this way whether it goes through the distributed cache or straight to object storage. The ignore is narrow: a genuinely lost blob still fails the queries that read the part, and those are reported.

Both copies of the scan are updated — `ci/jobs/scripts/clickhouse_proc.py` and `check_logs_for_critical_errors` in `tests/docker_scripts/stress_tests.lib`.

The ignore list and the command move to module level so the check can be exercised from `ci/tests`. `ci/tests/test_no_such_key_ignores.py` runs the real command against a fixture log: the verbatim line from the failing job must pass, a genuine `<Error> executeQuery: … Code: 499 …` must fail, each ignored substring must suppress a line naming it while the same line without it is still reported, and the `-e` tokens of the `stress_tests.lib` copy must equal the Python list so the two cannot drift.

Verified against the failing job's own `clickhouse-server.log` (2.1 GB decompressed): without the new ignore the check exits 1 quoting the byte-identical line from the CI report; with it the check is clean.

CI report: https://s3.amazonaws.com/clickhouse-test-reports-private/PRs/67155/1182039bb62ad84459632386c2147ca05f0672a1/stateless_tests_amd_asan_ubsan_distributed_cache_meta_in_keeper_s3_storage_parallel_1_2.html (job `Stateless tests (amd_asan_ubsan, distributed cache, meta in keeper, s3 storage, parallel, 1/2)` of ClickHouse/clickhouse-private#67155, where the failure was observed; it is pre-existing and not caused by that PR)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
