### PR TITLE
Do not write ANSI escape sequences into INTO OUTFILE when stdout is a tty

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1028,7 +1028,7 @@ try
                 out_buf, default_output_compression_method, 3, 0, client_context->getSettingsRef()[Setting::snappy_mode]);
 
         auto format_settings = getFormatSettings(client_context);
-        format_settings.is_writing_to_terminal = stdout_is_a_tty;
+        format_settings.is_writing_to_terminal = stdout_is_a_tty && !select_into_file;
 
         /// If the result is written to a terminal that does not support UTF-8 (e.g. with LANG=C),
         /// fall back to ASCII for the Pretty formats. Otherwise Unicode box-drawing characters

--- a/tests/queries/0_stateless/04312_client_chime_on_slow_query_92718.sh
+++ b/tests/queries/0_stateless/04312_client_chime_on_slow_query_92718.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-darwin
+# - long - slow
+# - no-darwin - darwin does not support "script -qc"
+#
 # Regression test for https://github.com/ClickHouse/ClickHouse/issues/92718
 # Verifies that `--chime N` makes the client emit ASCII `BEL` (`\x07`) on stderr
 # when a query finishes after running for at least N seconds AND stderr is

--- a/tests/queries/0_stateless/04625_client_chime_config.sh
+++ b/tests/queries/0_stateless/04625_client_chime_config.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
-# Tags: long
-# `long` (matching 04312_client_chime_on_slow_query_92718, which uses the same
-# `script -qc` pty mechanism) keeps this out of the `Fast test (arm_darwin)`
-# run: BSD `script` on macOS does not honour the GNU `-qc "cmd" file` form, so
-# the pty-attached client never runs and no `BEL` is captured there.
+# Tags: no-darwin
+# - no-darwin - darwin does not support "script -qc"
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04695_into_outfile_is_not_a_terminal.reference
+++ b/tests/queries/0_stateless/04695_into_outfile_is_not_a_terminal.reference
@@ -1,0 +1,6 @@
+Vertical INTO OUTFILE, pty stdout: no escapes
+Vertical INTO OUTFILE AND STDOUT, pty stdout: no escapes
+Vertical to pty stdout: escapes
+PrettyCompact INTO OUTFILE, pty stdout: no escapes
+PrettyCompact INTO OUTFILE AND STDOUT, pty stdout: no escapes
+PrettyCompact to pty stdout: escapes

--- a/tests/queries/0_stateless/04695_into_outfile_is_not_a_terminal.sh
+++ b/tests/queries/0_stateless/04695_into_outfile_is_not_a_terminal.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Tags: no-darwin
+# - no-darwin - darwin does not support "script -qc"
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# INTO OUTFILE writes to a file even when stdout is a terminal, so with the
+# default output_format_pretty_color=auto the file must not contain ANSI
+# escape sequences. The client is run under a pty (via script) to make its
+# stdout a terminal.
+
+out_file="${CLICKHOUSE_TMP}/04695_out_${CLICKHOUSE_DATABASE}.txt"
+tty_out="${CLICKHOUSE_TMP}/04695_tty_${CLICKHOUSE_DATABASE}.txt"
+
+esc_check() {
+    if grep -q $'\x1b' "$1"; then
+        echo "escapes"
+    else
+        echo "no escapes"
+    fi
+}
+
+for format in Vertical PrettyCompact; do
+    rm -f "$out_file"
+    script -eqc "${CLICKHOUSE_CLIENT} -q \"SELECT 1 AS x INTO OUTFILE '$out_file' FORMAT $format\"" /dev/null > /dev/null 2>&1
+    echo "$format INTO OUTFILE, pty stdout: $(esc_check "$out_file")"
+
+    rm -f "$out_file"
+    script -eqc "${CLICKHOUSE_CLIENT} -q \"SELECT 1 AS x INTO OUTFILE '$out_file' AND STDOUT FORMAT $format\"" /dev/null > /dev/null 2>&1
+    echo "$format INTO OUTFILE AND STDOUT, pty stdout: $(esc_check "$out_file")"
+
+    # control: the same query without INTO OUTFILE must be colored on the pty,
+    # otherwise the cases above pass vacuously
+    script -eqc "${CLICKHOUSE_CLIENT} -q 'SELECT 1 AS x FORMAT $format'" /dev/null > "$tty_out" 2>&1
+    echo "$format to pty stdout: $(esc_check "$tty_out")"
+done
+
+rm -f "$out_file" "$tty_out"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Do not write ANSI escape sequences into INTO OUTFILE when stdout is a tty