### PR TITLE
Docs: remove obsolete Managed Postgres credential redaction dates

### DIFF
--- a/docs/products/managed-postgres/openapi.mdx
+++ b/docs/products/managed-postgres/openapi.mdx
@@ -80,9 +80,9 @@ like:
 Let's explore the lifecycle of a Postgres service.
 
 <Warning>
-**Credential redaction from July 31, 2026**
+**Credential redaction**
 
-As of **July 31, 2026**, the API no longer returns the `password` and `connectionString` properties in its responses. They appear only in the [create](#create) response and [password reset] response when the request contained no password. We recommend that you capture credentials from the [create](#create) response. If you manage services with Terraform, upgrade the provider to **v3.21.0 or later** before July 31, 2026 (see the [Terraform reference](/products/managed-postgres/terraform)).
+The API does not return the `password` and `connectionString` properties in its responses. They appear only in the [create](#create) response and [password reset] response when the request contained no password. We recommend that you capture credentials from the [create](#create) response. If you manage services with Terraform, use provider **v3.21.0 or later** (see the [Terraform reference](/products/managed-postgres/terraform)).
 </Warning>
 
 ### Create {#create}
@@ -158,7 +158,7 @@ curl -s --user "$KEY_ID:$KEY_SECRET" \
     | jq
 ```
 
-The output will be similar to the JSON returned for creation (but without the `password` and `connectionString` properties after July 31, 2026), but keep an eye
+The output will be similar to the JSON returned for creation (but without the `password` and `connectionString` properties), but keep an eye
 on the `state`; when it changes to `running`, the server is ready:
 
 ```bash
@@ -217,9 +217,7 @@ The returned data should include the new tags:
       "value": "production"
     }
   ],
-  "connectionString": "postgres://postgres:vV6cfEr2p_-TzkCDrZOx@my-postgres-6d8d2e3e.$PG_ID.c0.us-west-2.aws.pg.clickhouse-dev.com:5432/postgres?channel_binding=require",
   "username": "postgres",
-  "password": "vV6cfEr2p_-TzkCDrZOx",
   "hostname": "my-postgres-6d8d2e3e.$PG_ID.c0.us-west-2.aws.pg.clickhouse-dev.com",
   "isPrimary": true,
   "state": "running"

--- a/docs/products/managed-postgres/terraform.mdx
+++ b/docs/products/managed-postgres/terraform.mdx
@@ -14,15 +14,15 @@ import { BetaBadge } from "/snippets/components/BetaBadge/BetaBadge.jsx";
 ClickHouse Managed Postgres services can be created and managed using the `clickhouse_postgres_service` resource in the [ClickHouse Terraform provider](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs/resources/postgres_service). This page covers provider setup and configuration examples for the resource and its companion data sources.
 
 <Note>
-This resource is in alpha and its behavior may change in future provider versions. It ships in the regular provider build. This page documents provider version **v3.21.0** and later, which changed how credentials are managed; earlier versions behave differently and as of July 31, 2026 no longer work correctly. See the [provider releases](https://github.com/ClickHouse/terraform-provider-clickhouse/releases) for details.
+This resource is in alpha and its behavior may change in future provider versions. It ships in the regular provider build. This page documents provider version **v3.21.0** and later, which changed how credentials are managed; earlier versions no longer work correctly. See the [provider releases](https://github.com/ClickHouse/terraform-provider-clickhouse/releases) for details.
 </Note>
 
 <Warning>
-**Upgrade to provider v3.21.0 before July 31, 2026**
+**Provider v3.21.0 or later is required**
 
-As of **July 31, 2026**, the ClickHouse Managed Postgres API ceased to return the superuser password and connection string in its responses; credentials are returned only when a service is created or its password is reset. Provider versions **v3.21.0 and later** work identically before and after this change. Older provider versions rely on the API echoing credentials: as of July 31, 2026, they no longer populate `connection_string`, and a service created without a declared `password` succeeds while the generated password is never captured anywhere.
+The ClickHouse Managed Postgres API does not return the superuser password or connection string in its responses; credentials are returned only when a service is created or its password is reset. Provider versions **v3.21.0 and later** handle this. Older provider versions rely on the API echoing credentials: they do not populate `connection_string`, and a service created without a declared `password` succeeds while the generated password is never captured anywhere.
 
-Upgrade before July 31, 2026. Your state migrates automatically on the first plan or apply with v3.21.0. If any of your services rely on a server-generated password (no `password` in configuration), recover it first with `terraform state pull` and declare it, since v3.21.0 requires `password` or `password_wo` for a standard service.
+Your state migrates automatically on the first plan or apply with v3.21.0. If any of your services rely on a server-generated password (no `password` in configuration), recover it first with `terraform state pull` and declare it, since v3.21.0 requires `password` or `password_wo` for a standard service.
 </Warning>
 
 ## Provider setup {#provider-setup}


### PR DESCRIPTION
Port the Managed Postgres credential-redaction cleanup from the former documentation repository. The July 31, 2026 transition date has passed, so the OpenAPI and Terraform pages now describe credential redaction as unconditional and the status-response example no longer includes redacted credential fields.

Related: https://github.com/ClickHouse/clickhouse-docs/pull/6614

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.
