### PR TITLE
[#59913] Implement system.engine_settings table

### DIFF
--- a/src/Storages/Distributed/DistributedSettings.cpp
+++ b/src/Storages/Distributed/DistributedSettings.cpp
@@ -3,6 +3,7 @@
 #include <Core/SettingsEnums.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Storages/Distributed/DistributedSettings.h>
 #include <Common/Exception.h>
@@ -105,6 +106,11 @@ void DistributedSettings::applyChanges(const SettingsChanges & changes)
 bool DistributedSettings::hasBuiltin(std::string_view name)
 {
     return DistributedSettingsImpl::hasBuiltin(name);
+}
+
+void DistributedSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<DistributedSettingsImpl>(columns);
 }
 }
 

--- a/src/Storages/Distributed/DistributedSettings.h
+++ b/src/Storages/Distributed/DistributedSettings.h
@@ -3,6 +3,7 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 
 namespace Poco::Util
 {
@@ -40,6 +41,7 @@ struct DistributedSettings
     void applyChanges(const SettingsChanges & changes);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<DistributedSettingsImpl> impl;

--- a/src/Storages/ExecutableSettings.cpp
+++ b/src/Storages/ExecutableSettings.cpp
@@ -3,6 +3,7 @@
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSetQuery.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Storages/ExecutableSettings.h>
 #include <Common/Exception.h>
 
@@ -80,5 +81,10 @@ void ExecutableSettings::applyChanges(const SettingsChanges & changes)
 bool ExecutableSettings::hasBuiltin(std::string_view name)
 {
     return ExecutableSettingsImpl::hasBuiltin(name);
+}
+
+void ExecutableSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<ExecutableSettingsImpl>(columns);
 }
 }

--- a/src/Storages/ExecutableSettings.h
+++ b/src/Storages/ExecutableSettings.h
@@ -3,6 +3,7 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 #include <Common/VectorWithMemoryTracking.h>
 
 namespace DB
@@ -37,6 +38,7 @@ struct ExecutableSettings
     void applyChanges(const SettingsChanges & changes);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<ExecutableSettingsImpl> impl;

--- a/src/Storages/FileLog/FileLogSettings.cpp
+++ b/src/Storages/FileLog/FileLogSettings.cpp
@@ -3,6 +3,7 @@
 #include <Core/FormatFactorySettings.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Storages/FileLog/FileLogSettings.h>
 #include <Common/Exception.h>
@@ -80,5 +81,10 @@ void FileLogSettings::loadFromQuery(ASTStorage & storage_def)
 bool FileLogSettings::hasBuiltin(std::string_view name)
 {
     return FileLogSettingsImpl::hasBuiltin(name);
+}
+
+void FileLogSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<FileLogSettingsImpl>(columns);
 }
 }

--- a/src/Storages/FileLog/FileLogSettings.h
+++ b/src/Storages/FileLog/FileLogSettings.h
@@ -3,6 +3,7 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 
 namespace DB
 {
@@ -58,6 +59,7 @@ struct FileLogSettings
     void loadFromQuery(ASTStorage & storage_def);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<FileLogSettingsImpl> impl;

--- a/src/Storages/FileLog/StorageFileLog.cpp
+++ b/src/Storages/FileLog/StorageFileLog.cpp
@@ -907,6 +907,7 @@ void registerStorageFileLog(StorageFactory & factory)
         StorageFactory::StorageFeatures{
             .supports_settings = true,
             .has_builtin_setting_fn = FileLogSettings::hasBuiltin,
+            .fill_engine_settings_fn = FileLogSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = R"DOCS_MD(

--- a/src/Storages/Hive/HiveSettings.cpp
+++ b/src/Storages/Hive/HiveSettings.cpp
@@ -8,6 +8,7 @@
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSetQuery.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Common/Exception.h>
 
 #include <Poco/Util/AbstractConfiguration.h>
@@ -93,6 +94,11 @@ void HiveSettings::loadFromQuery(ASTStorage & storage_def)
 bool HiveSettings::hasBuiltin(std::string_view name)
 {
     return HiveSettingsImpl::hasBuiltin(name);
+}
+
+void HiveSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<HiveSettingsImpl>(columns);
 }
 }
 #endif

--- a/src/Storages/Hive/HiveSettings.h
+++ b/src/Storages/Hive/HiveSettings.h
@@ -7,6 +7,7 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 
 namespace Poco::Util
 {
@@ -65,6 +66,7 @@ struct HiveSettings
     void loadFromQuery(ASTStorage & storage_def);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<HiveSettingsImpl> impl;

--- a/src/Storages/Hive/StorageHive.cpp
+++ b/src/Storages/Hive/StorageHive.cpp
@@ -1151,6 +1151,7 @@ void registerStorageHive(StorageFactory & factory)
             .supports_sort_order = true,
             .source_access_type = AccessTypeObjects::Source::HIVE,
             .has_builtin_setting_fn = HiveSettings::hasBuiltin,
+            .fill_engine_settings_fn = HiveSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = R"DOCS_MD(

--- a/src/Storages/Kafka/KafkaSettings.cpp
+++ b/src/Storages/Kafka/KafkaSettings.cpp
@@ -3,6 +3,7 @@
 #include <Core/FormatFactorySettings.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTCreateQuery.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Storages/Kafka/KafkaSettings.h>
@@ -162,5 +163,10 @@ SettingsChanges KafkaSettings::getFormatSettings() const
 bool KafkaSettings::hasBuiltin(std::string_view name)
 {
     return KafkaSettingsImpl::hasBuiltin(name);
+}
+
+void KafkaSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<KafkaSettingsImpl>(columns);
 }
 }

--- a/src/Storages/Kafka/KafkaSettings.h
+++ b/src/Storages/Kafka/KafkaSettings.h
@@ -3,6 +3,7 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 #include <Common/NamedCollections/NamedCollections_fwd.h>
 #include <Common/SettingsChanges.h>
 
@@ -75,6 +76,7 @@ struct KafkaSettings
     void sanityCheck(ContextPtr global_context) const;
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<KafkaSettingsImpl> impl;

--- a/src/Storages/Kafka/StorageKafkaUtils.cpp
+++ b/src/Storages/Kafka/StorageKafkaUtils.cpp
@@ -327,6 +327,7 @@ void registerStorageKafka(StorageFactory & factory)
             .supports_settings = true,
             .source_access_type = AccessTypeObjects::Source::KAFKA,
             .has_builtin_setting_fn = KafkaSettings::hasBuiltin,
+            .fill_engine_settings_fn = KafkaSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = R"DOCS_MD(

--- a/src/Storages/MemorySettings.cpp
+++ b/src/Storages/MemorySettings.cpp
@@ -3,6 +3,7 @@
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
 #include <Storages/MemorySettings.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Common/Exception.h>
 
 
@@ -94,6 +95,11 @@ void MemorySettings::applyChanges(const DB::SettingsChanges & changes)
 bool MemorySettings::hasBuiltin(std::string_view name)
 {
     return MemorySettingsImpl::hasBuiltin(name);
+}
+
+void MemorySettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<MemorySettingsImpl>(columns);
 }
 }
 

--- a/src/Storages/MemorySettings.h
+++ b/src/Storages/MemorySettings.h
@@ -2,6 +2,7 @@
 
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 #include <Parsers/IAST_fwd.h>
 
 namespace DB
@@ -38,6 +39,7 @@ struct MemorySettings
     void applyChanges(const SettingsChanges & changes);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<MemorySettingsImpl> impl;

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -8,6 +8,7 @@
 #include <Core/MergeSelectorAlgorithm.h>
 #include <Core/MergeTreeSerializationEnums.h>
 #include <Core/SettingsEnums.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Core/SettingsChangesHistory.h>
 #include <Disks/DiskFromAST.h>
 #include <Parsers/ASTCreateQuery.h>
@@ -3080,5 +3081,10 @@ void MergeTreeSettings::checkCanSet(std::string_view name, const Field & value)
 bool MergeTreeSettings::isPartFormatSetting(const String & name)
 {
     return name == "min_bytes_for_wide_part" || name == "min_rows_for_wide_part" || name == "min_level_for_wide_part";
+}
+
+void MergeTreeSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<MergeTreeSettingsImpl>(columns);
 }
 }

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -105,6 +105,7 @@ struct MergeTreeSettings
 
     void dumpToSystemMergeTreeSettingsColumns(MutableColumnsAndConstraints & params) const;
     void dumpToSystemCompletionsColumns(MutableColumns & columns) const;
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
     void addToProgramOptionsIfNotPresent(boost::program_options::options_description & main_options, bool allow_repeated_settings);
 

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -1188,6 +1188,7 @@ void registerStorageMergeTree(StorageFactory & factory)
         .supports_parallel_insert = true,
         .supports_unique_key = true,
         .has_builtin_setting_fn = MergeTreeSettings::hasBuiltin,
+        .fill_engine_settings_fn = MergeTreeSettings::fillEngineSettingsColumns,
     };
 
     factory.registerStorage("MergeTree", create, features, Documentation{

--- a/src/Storages/MySQL/MySQLSettings.cpp
+++ b/src/Storages/MySQL/MySQLSettings.cpp
@@ -3,6 +3,7 @@
 #include <Core/Settings.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTCreateQuery.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Storages/MySQL/MySQLSettings.h>
@@ -135,5 +136,10 @@ void MySQLSettings::loadFromNamedCollection(const NamedCollection & named_collec
 bool MySQLSettings::hasBuiltin(std::string_view name)
 {
     return MySQLSettingsImpl::hasBuiltin(name);
+}
+
+void MySQLSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<MySQLSettingsImpl>(columns);
 }
 }

--- a/src/Storages/MySQL/MySQLSettings.h
+++ b/src/Storages/MySQL/MySQLSettings.h
@@ -3,6 +3,7 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 #include <Common/VectorWithMemoryTracking.h>
 
 namespace Poco::Util
@@ -48,6 +49,7 @@ struct MySQLSettings
     void loadFromNamedCollection(const NamedCollection & named_collection);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<MySQLSettingsImpl> impl;

--- a/src/Storages/NATS/NATSSettings.cpp
+++ b/src/Storages/NATS/NATSSettings.cpp
@@ -3,6 +3,7 @@
 #include <Core/FormatFactorySettings.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Storages/NATS/NATSSettings.h>
 #include <Common/Exception.h>
@@ -121,5 +122,10 @@ SettingsChanges NATSSettings::getFormatSettings() const
 bool NATSSettings::hasBuiltin(std::string_view name)
 {
     return NATSSettingsImpl::hasBuiltin(name);
+}
+
+void NATSSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<NATSSettingsImpl>(columns);
 }
 }

--- a/src/Storages/NATS/NATSSettings.h
+++ b/src/Storages/NATS/NATSSettings.h
@@ -3,6 +3,7 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 #include <Common/NamedCollections/NamedCollections_fwd.h>
 #include <Common/SettingsChanges.h>
 
@@ -59,6 +60,7 @@ struct NATSSettings
     SettingsChanges getFormatSettings() const;
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<NATSSettingsImpl> impl;

--- a/src/Storages/NATS/StorageNATS.cpp
+++ b/src/Storages/NATS/StorageNATS.cpp
@@ -866,6 +866,7 @@ void registerStorageNATS(StorageFactory & factory)
             .supports_settings = true,
             .source_access_type = AccessTypeObjects::Source::NATS,
             .has_builtin_setting_fn = NATSSettings::hasBuiltin,
+            .fill_engine_settings_fn = NATSSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = R"DOCS_MD(

--- a/src/Storages/ObjectStorage/DataLakes/DataLakeStorageSettings.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeStorageSettings.cpp
@@ -4,6 +4,7 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Storages/ObjectStorage/DataLakes/DataLakeStorageSettings.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Storages/System/MutableColumnsAndConstraints.h>
 #include <Common/Exception.h>
 
@@ -66,6 +67,11 @@ DataLakeStorageSettings DataLakeStorageSettings::deserialize(ReadBuffer & in)
     result.impl->readBinary(in);
 
     return result;
+}
+
+void DataLakeStorageSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<DataLakeStorageSettingsImpl>(columns);
 }
 
 }

--- a/src/Storages/ObjectStorage/DataLakes/DataLakeStorageSettings.h
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeStorageSettings.h
@@ -4,6 +4,7 @@
 #include <Core/FormatFactorySettings.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 
 
 namespace DB
@@ -124,6 +125,7 @@ struct DataLakeStorageSettings
     Field get(const std::string & name);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
     void serialize(WriteBuffer & out) const;
     static DataLakeStorageSettings deserialize(ReadBuffer & in);

--- a/src/Storages/ObjectStorage/StorageObjectStorageSettings.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSettings.cpp
@@ -5,6 +5,7 @@
 #include <Parsers/ASTSetQuery.h>
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Storages/ObjectStorage/StorageObjectStorageSettings.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Storages/System/MutableColumnsAndConstraints.h>
 #include <Common/Exception.h>
 
@@ -53,6 +54,11 @@ void StorageObjectStorageSettings::loadFromSettingsChanges(const SettingsChanges
         if (impl->has(name))
             impl->set(name, value);
     }
+}
+
+void StorageObjectStorageSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<StorageObjectStorageSettingsImpl>(columns);
 }
 
 }

--- a/src/Storages/ObjectStorage/StorageObjectStorageSettings.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSettings.h
@@ -3,6 +3,7 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 
 
 namespace DB
@@ -63,6 +64,7 @@ struct StorageObjectStorageSettings
     Field get(const std::string & name);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<StorageObjectStorageSettingsImpl> impl;

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -142,6 +142,7 @@ static void registerStorageAzure(StorageFactory & factory)
         .supports_schema_inference = true,
         .source_access_type = AccessTypeObjects::Source::AZURE,
         .has_builtin_setting_fn = StorageObjectStorageSettings::hasBuiltin,
+        .fill_engine_settings_fn = StorageObjectStorageSettings::fillEngineSettingsColumns,
     },
     Documentation{
         .description = R"DOCS_MD(
@@ -749,6 +750,7 @@ ENGINE = S3('https://my-bucket.s3.amazonaws.com/data/*.csv', extra_credentials(r
         .supports_schema_inference = true,
         .source_access_type = AccessTypeObjects::Source::S3,
         .has_builtin_setting_fn = StorageObjectStorageSettings::hasBuiltin,
+        .fill_engine_settings_fn = StorageObjectStorageSettings::fillEngineSettingsColumns,
     },
     Documentation{
         .description = description,
@@ -792,6 +794,7 @@ static void registerStorageHDFS(StorageFactory & factory)
         .supports_schema_inference = true,
         .source_access_type = AccessTypeObjects::Source::HDFS,
         .has_builtin_setting_fn = StorageObjectStorageSettings::hasBuiltin,
+        .fill_engine_settings_fn = StorageObjectStorageSettings::fillEngineSettingsColumns,
     },
     Documentation{
         .description = R"DOCS_MD(
@@ -1128,6 +1131,7 @@ void registerStorageIceberg(StorageFactory & factory)
             /// This source access type is probably a bug which was overlooked and we do not know how to fix it simply, so we keep it as it is.
             .source_access_type = AccessTypeObjects::Source::S3,
             .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+            .fill_engine_settings_fn = DataLakeStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = R"DOCS_MD(
@@ -1536,6 +1540,7 @@ SETTINGS iceberg_metadata_staleness_ms=120000
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::S3,
             .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+            .fill_engine_settings_fn = DataLakeStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = "Provides a read-only integration with existing Apache Iceberg tables stored in Amazon S3 or S3-compatible object storage.",
@@ -1575,6 +1580,7 @@ SETTINGS iceberg_metadata_staleness_ms=120000
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::AZURE,
             .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+            .fill_engine_settings_fn = DataLakeStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = "Provides a read-only integration with existing Apache Iceberg tables stored in Microsoft Azure Blob Storage.",
@@ -1596,6 +1602,7 @@ SETTINGS iceberg_metadata_staleness_ms=120000
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::HDFS,
             .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+            .fill_engine_settings_fn = DataLakeStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = "Provides a read-only integration with existing Apache Iceberg tables stored in HDFS.",
@@ -1634,6 +1641,7 @@ SETTINGS iceberg_metadata_staleness_ms=120000
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::FILE,
             .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+            .fill_engine_settings_fn = DataLakeStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = "Provides a read-only integration with existing Apache Iceberg tables stored on the local filesystem.",
@@ -1721,6 +1729,7 @@ void registerStoragePaimon(StorageFactory & factory)
             /// access-type resolution.
             .source_access_type = AccessTypeObjects::Source::S3,
             .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+            .fill_engine_settings_fn = DataLakeStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = R"DOCS_MD(
@@ -2022,6 +2031,7 @@ Data types supported in Paimon partition keys:
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::S3,
             .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+            .fill_engine_settings_fn = DataLakeStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = "Provides a read-only integration with existing Apache Paimon tables stored in Amazon S3 or S3-compatible object storage. "
@@ -2069,6 +2079,7 @@ Data types supported in Paimon partition keys:
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::AZURE,
             .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+            .fill_engine_settings_fn = DataLakeStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = "Provides a read-only integration with existing Apache Paimon tables stored in Microsoft Azure Blob Storage. "
@@ -2094,6 +2105,7 @@ Data types supported in Paimon partition keys:
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::HDFS,
             .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+            .fill_engine_settings_fn = DataLakeStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = "Provides a read-only integration with existing Apache Paimon tables stored in HDFS. "
@@ -2140,6 +2152,7 @@ Data types supported in Paimon partition keys:
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::FILE,
             .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+            .fill_engine_settings_fn = DataLakeStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = "Provides a read-only integration with existing Apache Paimon tables stored on the local filesystem. "
@@ -2196,6 +2209,7 @@ void registerStorageDeltaLake(StorageFactory & factory)
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::S3,
             .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+            .fill_engine_settings_fn = DataLakeStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = R"DOCS_MD(
@@ -2375,6 +2389,7 @@ The `DeltaLake` table engine and table function support data caching, the same a
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::S3,
             .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+            .fill_engine_settings_fn = DataLakeStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = "Provides a read-only integration with existing Delta Lake tables stored in Amazon S3 or S3-compatible object storage.",
@@ -2413,6 +2428,7 @@ The `DeltaLake` table engine and table function support data caching, the same a
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::AZURE,
             .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+            .fill_engine_settings_fn = DataLakeStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = "Provides a read-only integration with existing Delta Lake tables stored in Microsoft Azure Blob Storage.",
@@ -2450,6 +2466,7 @@ The `DeltaLake` table engine and table function support data caching, the same a
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::FILE,
             .has_builtin_setting_fn = StorageObjectStorageSettings::hasBuiltin,
+        .fill_engine_settings_fn = StorageObjectStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = "Provides a read-only integration with existing Delta Lake tables stored on the local filesystem.",
@@ -2475,6 +2492,7 @@ void registerStorageHudi(StorageFactory & factory)
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::S3,
             .has_builtin_setting_fn = DataLakeStorageSettings::hasBuiltin,
+            .fill_engine_settings_fn = DataLakeStorageSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = R"DOCS_MD(

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
@@ -3,6 +3,7 @@
 #include <Core/BaseSettings.h>
 #include <Core/BaseSettingsFwdMacrosImpl.h>
 #include <Parsers/ASTCreateQuery.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Storages/ObjectStorageQueue/ObjectStorageQueueSettings.h>
@@ -241,5 +242,10 @@ bool ObjectStorageQueueSettings::hasBuiltin(std::string_view name)
     if (auto maybe_new_name = adjustSettingName(name); maybe_new_name.has_value())
         name = *maybe_new_name;
     return ObjectStorageQueueSettingsImpl::hasBuiltin(name);
+}
+
+void ObjectStorageQueueSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<ObjectStorageQueueSettingsImpl>(columns);
 }
 }

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.h
@@ -3,6 +3,7 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 
 
 namespace DB
@@ -72,6 +73,7 @@ struct ObjectStorageQueueSettings
     Field get(const std::string & name);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<ObjectStorageQueueSettingsImpl> impl;

--- a/src/Storages/ObjectStorageQueue/registerQueueStorage.cpp
+++ b/src/Storages/ObjectStorageQueue/registerQueueStorage.cpp
@@ -168,6 +168,7 @@ void registerStorageS3Queue(StorageFactory & factory)
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::S3,
             .has_builtin_setting_fn = ObjectStorageQueueSettings::hasBuiltin,
+            .fill_engine_settings_fn = ObjectStorageQueueSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = R"DOCS_MD(
@@ -734,6 +735,7 @@ void registerStorageAzureQueue(StorageFactory & factory)
             .supports_schema_inference = true,
             .source_access_type = AccessTypeObjects::Source::AZURE,
             .has_builtin_setting_fn = ObjectStorageQueueSettings::hasBuiltin,
+            .fill_engine_settings_fn = ObjectStorageQueueSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = R"DOCS_MD(

--- a/src/Storages/PostgreSQL/MaterializedPostgreSQLSettings.cpp
+++ b/src/Storages/PostgreSQL/MaterializedPostgreSQLSettings.cpp
@@ -7,6 +7,7 @@
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTFunction.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Common/Exception.h>
 
 
@@ -90,6 +91,11 @@ void MaterializedPostgreSQLSettings::loadFromQuery(ASTStorage & storage_def)
 bool MaterializedPostgreSQLSettings::hasBuiltin(std::string_view name)
 {
     return MaterializedPostgreSQLSettingsImpl::hasBuiltin(name);
+}
+
+void MaterializedPostgreSQLSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<MaterializedPostgreSQLSettingsImpl>(columns);
 }
 }
 

--- a/src/Storages/PostgreSQL/MaterializedPostgreSQLSettings.h
+++ b/src/Storages/PostgreSQL/MaterializedPostgreSQLSettings.h
@@ -6,6 +6,7 @@
 
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 
 
 namespace DB
@@ -36,6 +37,7 @@ struct MaterializedPostgreSQLSettings
     void loadFromQuery(ASTStorage & storage_def);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<MaterializedPostgreSQLSettingsImpl> impl;

--- a/src/Storages/PostgreSQL/PostgreSQLSettings.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLSettings.cpp
@@ -3,6 +3,7 @@
 #include <Core/Settings.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTCreateQuery.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Storages/PostgreSQL/PostgreSQLSettings.h>
@@ -108,6 +109,11 @@ VectorWithMemoryTracking<std::string_view> PostgreSQLSettings::getAllRegisteredN
 bool PostgreSQLSettings::hasBuiltin(std::string_view name)
 {
     return PostgreSQLSettingsImpl::hasBuiltin(name);
+}
+
+void PostgreSQLSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<PostgreSQLSettingsImpl>(columns);
 }
 
 }

--- a/src/Storages/PostgreSQL/PostgreSQLSettings.h
+++ b/src/Storages/PostgreSQL/PostgreSQLSettings.h
@@ -3,6 +3,7 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 #include <Common/VectorWithMemoryTracking.h>
 
 namespace DB
@@ -46,6 +47,7 @@ struct PostgreSQLSettings
     void loadFromQueryContext(const Context & context);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<PostgreSQLSettingsImpl> impl;

--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
@@ -709,6 +709,7 @@ void registerStorageMaterializedPostgreSQL(StorageFactory & factory)
             .supports_sort_order = true,
             .source_access_type = AccessTypeObjects::Source::POSTGRES,
             .has_builtin_setting_fn = MaterializedPostgreSQLSettings::hasBuiltin,
+            .fill_engine_settings_fn = MaterializedPostgreSQLSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = R"DOCS_MD(

--- a/src/Storages/QueryRunnerSettings.cpp
+++ b/src/Storages/QueryRunnerSettings.cpp
@@ -3,6 +3,7 @@
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
 #include <Storages/QueryRunnerSettings.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Common/Exception.h>
 
 
@@ -54,6 +55,11 @@ void QueryRunnerSettings::loadFromQuery(ASTStorage & storage_def)
 bool QueryRunnerSettings::hasBuiltin(std::string_view name)
 {
     return QueryRunnerSettingsImpl::hasBuiltin(name);
+}
+
+void QueryRunnerSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<QueryRunnerSettingsImpl>(columns);
 }
 
 }

--- a/src/Storages/QueryRunnerSettings.h
+++ b/src/Storages/QueryRunnerSettings.h
@@ -3,6 +3,7 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 
 #include <memory>
 
@@ -33,6 +34,7 @@ struct QueryRunnerSettings
     void loadFromQuery(ASTStorage & storage_def);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<QueryRunnerSettingsImpl> impl;

--- a/src/Storages/RabbitMQ/RabbitMQSettings.cpp
+++ b/src/Storages/RabbitMQ/RabbitMQSettings.cpp
@@ -3,6 +3,7 @@
 #include <Core/FormatFactorySettings.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Storages/RabbitMQ/RabbitMQSettings.h>
 #include <Common/Exception.h>
@@ -123,5 +124,10 @@ SettingsChanges RabbitMQSettings::getFormatSettings() const
 bool RabbitMQSettings::hasBuiltin(std::string_view name)
 {
     return RabbitMQSettingsImpl::hasBuiltin(name);
+}
+
+void RabbitMQSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<RabbitMQSettingsImpl>(columns);
 }
 }

--- a/src/Storages/RabbitMQ/RabbitMQSettings.h
+++ b/src/Storages/RabbitMQ/RabbitMQSettings.h
@@ -3,6 +3,7 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 #include <Common/NamedCollections/NamedCollections_fwd.h>
 #include <Common/SettingsChanges.h>
 
@@ -58,6 +59,7 @@ struct RabbitMQSettings
     SettingsChanges getFormatSettings() const;
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<RabbitMQSettingsImpl> impl;

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -1504,6 +1504,7 @@ void registerStorageRabbitMQ(StorageFactory & factory)
             .supports_settings = true,
             .source_access_type = AccessTypeObjects::Source::RABBITMQ,
             .has_builtin_setting_fn = RabbitMQSettings::hasBuiltin,
+            .fill_engine_settings_fn = RabbitMQSettings::fillEngineSettingsColumns,
         },
         Documentation{
             .description = R"DOCS_MD(

--- a/src/Storages/RocksDB/RocksDBSettings.cpp
+++ b/src/Storages/RocksDB/RocksDBSettings.cpp
@@ -3,6 +3,7 @@
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
 #include <Storages/RocksDB/RocksDBSettings.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 
 namespace DB
 {
@@ -67,5 +68,10 @@ bool RocksDBSettings::hasBuiltin(std::string_view name)
 void RocksDBSettings::checkCanSet(std::string_view name, const Field & value)
 {
     RocksDBSettingsImpl::checkCanSet(name, value);
+}
+
+void RocksDBSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<RocksDBSettingsImpl>(columns);
 }
 }

--- a/src/Storages/RocksDB/RocksDBSettings.h
+++ b/src/Storages/RocksDB/RocksDBSettings.h
@@ -2,6 +2,7 @@
 
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 
 namespace DB
 {
@@ -29,6 +30,7 @@ struct RocksDBSettings
     void loadFromQuery(const ASTStorage & storage_def);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
     static void checkCanSet(std::string_view name, const Field & value);
 
 private:

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -1068,6 +1068,7 @@ void registerStorageEmbeddedRocksDB(StorageFactory & factory)
         .supports_ttl = true,
         .supports_parallel_insert = true,
         .has_builtin_setting_fn = RocksDBSettings::hasBuiltin,
+        .fill_engine_settings_fn = RocksDBSettings::fillEngineSettingsColumns,
     };
 
     factory.registerStorage("EmbeddedRocksDB", create, features, Documentation{

--- a/src/Storages/SetSettings.cpp
+++ b/src/Storages/SetSettings.cpp
@@ -3,6 +3,7 @@
 #include <Core/FormatFactorySettings.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Storages/SetSettings.h>
 #include <Common/Exception.h>
@@ -67,5 +68,10 @@ void SetSettings::loadFromQuery(ASTStorage & storage_def)
 bool SetSettings::hasBuiltin(std::string_view name)
 {
     return SetSettingsImpl::hasBuiltin(name);
+}
+
+void SetSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<SetSettingsImpl>(columns);
 }
 }

--- a/src/Storages/SetSettings.h
+++ b/src/Storages/SetSettings.h
@@ -3,6 +3,7 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 
 namespace DB
 {
@@ -56,6 +57,7 @@ struct SetSettings
     void loadFromQuery(ASTStorage & storage_def);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<SetSettingsImpl> impl;

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -2237,6 +2237,7 @@ void registerStorageDistributed(StorageFactory & factory)
         .supports_schema_inference = true,
         .source_access_type = AccessTypeObjects::Source::REMOTE,
         .has_builtin_setting_fn = DistributedSettings::hasBuiltin,
+        .fill_engine_settings_fn = DistributedSettings::fillEngineSettingsColumns,
     },
     Documentation{
         .description = R"DOCS_MD(
@@ -2676,6 +2677,7 @@ void registerStorageRemote(StorageFactory & factory)
         .supports_schema_inference = true,
         .source_access_type = AccessTypeObjects::Source::REMOTE,
         .has_builtin_setting_fn = DistributedSettings::hasBuiltin,
+        .fill_engine_settings_fn = DistributedSettings::fillEngineSettingsColumns,
     };
 
     const String common_description = R"DOCS_MD(

--- a/src/Storages/StorageExecutable.cpp
+++ b/src/Storages/StorageExecutable.cpp
@@ -289,6 +289,7 @@ void registerStorageExecutable(StorageFactory & factory)
     StorageFactory::StorageFeatures storage_features;
     storage_features.supports_settings = true;
     storage_features.has_builtin_setting_fn = ExecutableSettings::hasBuiltin;
+    storage_features.fill_engine_settings_fn = ExecutableSettings::fillEngineSettingsColumns;
 
     factory.registerStorage("Executable", [&](const StorageFactory::Arguments & args)
     {

--- a/src/Storages/StorageFactory.h
+++ b/src/Storages/StorageFactory.h
@@ -34,6 +34,9 @@ public:
     /// Used to validate if table settings belong to the engine or the query before the start of the query interpretation
     using HasBuiltinSettingFn = bool(std::string_view);
 
+    /// Function that fills system.engine_settings columns for a given engine
+    using FillEngineSettingsFn = void(*)(MutableColumns &);
+
     struct Arguments
     {
         const String & engine_name;
@@ -82,6 +85,7 @@ public:
         std::optional<AccessTypeObjects::Source> source_access_type = std::nullopt;
 
         HasBuiltinSettingFn * has_builtin_setting_fn = nullptr;
+        FillEngineSettingsFn fill_engine_settings_fn = nullptr;
     };
 
     using CreatorFn = std::function<StoragePtr(const Arguments & arguments)>;
@@ -120,6 +124,7 @@ public:
         .supports_sql_security = false,
         .source_access_type = std::nullopt,
         .has_builtin_setting_fn = nullptr,
+        .fill_engine_settings_fn = nullptr,
     }, Documentation documentation = {});
 
     const Storages & getAllStorages() const

--- a/src/Storages/StorageMemory.cpp
+++ b/src/Storages/StorageMemory.cpp
@@ -750,6 +750,7 @@ void registerStorageMemory(StorageFactory & factory)
         .supports_settings = true,
         .supports_parallel_insert = true,
         .has_builtin_setting_fn = MemorySettings::hasBuiltin,
+        .fill_engine_settings_fn = MemorySettings::fillEngineSettingsColumns,
     },
     Documentation{
         .description = R"DOCS_MD(

--- a/src/Storages/StorageMySQL.cpp
+++ b/src/Storages/StorageMySQL.cpp
@@ -492,6 +492,7 @@ void registerStorageMySQL(StorageFactory & factory)
         .supports_schema_inference = true,
         .source_access_type = AccessTypeObjects::Source::MYSQL,
         .has_builtin_setting_fn = MySQLSettings::hasBuiltin,
+        .fill_engine_settings_fn = MySQLSettings::fillEngineSettingsColumns,
     },
     Documentation{
         .description = R"DOCS_MD(

--- a/src/Storages/StoragePostgreSQL.cpp
+++ b/src/Storages/StoragePostgreSQL.cpp
@@ -753,6 +753,7 @@ void registerStoragePostgreSQL(StorageFactory & factory)
         .supports_schema_inference = true,
         .source_access_type = AccessTypeObjects::Source::POSTGRES,
         .has_builtin_setting_fn = PostgreSQLSettings::hasBuiltin,
+        .fill_engine_settings_fn = PostgreSQLSettings::fillEngineSettingsColumns,
     },
     Documentation{
         .description = R"DOCS_MD(

--- a/src/Storages/StorageQueryRunner.cpp
+++ b/src/Storages/StorageQueryRunner.cpp
@@ -957,6 +957,7 @@ void registerStorageQueryRunner(StorageFactory & factory)
         .supports_parallel_insert = true,
         .supports_sql_security = true,
         .has_builtin_setting_fn = QueryRunnerSettings::hasBuiltin,
+        .fill_engine_settings_fn = QueryRunnerSettings::fillEngineSettingsColumns,
     },
     Documentation{.description = R"DOC(A table engine whose write path runs queries instead of storing data. Rows inserted into a `QueryRunner` table are dispatched as queries to be executed (synchronously or asynchronously); it is used to orchestrate and run queries through an `INSERT` interface.)DOC"});
 }

--- a/src/Storages/StorageSet.cpp
+++ b/src/Storages/StorageSet.cpp
@@ -363,7 +363,7 @@ void registerStorageSet(StorageFactory & factory)
         DiskPtr disk = args.getContext()->getDisk(set_settings[SetSetting::disk]);
         return std::make_shared<StorageSet>(
             disk, args.relative_data_path, args.table_id, args.columns, args.constraints, args.comment, set_settings[SetSetting::persistent]);
-    }, StorageFactory::StorageFeatures{ .supports_settings = true, .has_builtin_setting_fn = SetSettings::hasBuiltin, },
+    }, StorageFactory::StorageFeatures{ .supports_settings = true, .has_builtin_setting_fn = SetSettings::hasBuiltin, .fill_engine_settings_fn = SetSettings::fillEngineSettingsColumns, },
     Documentation{
         .description = R"DOCS_MD(
 :::note

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -665,6 +665,7 @@ void registerStorageTimeSeries(StorageFactory & factory)
         .supports_settings = true,
         .supports_schema_inference = true,
         .has_builtin_setting_fn = TimeSeriesSettings::hasBuiltin,
+        .fill_engine_settings_fn = TimeSeriesSettings::fillEngineSettingsColumns,
     },
     Documentation{
         .description = R"DOCS_MD(

--- a/src/Storages/System/FillEngineSettingsColumns.h
+++ b/src/Storages/System/FillEngineSettingsColumns.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <Columns/IColumn.h>
+#include <Core/Field.h>
+#include <Core/SettingsTierType.h>
+
+namespace DB
+{
+
+/// Helper template that fills the system.engine_settings columns from a default-constructed BaseSettings instance.
+/// The columns (excluding engine_name, which the caller prepends) are:
+///   name, value, default, changed, description, min, max, disallowed_values, readonly, type, is_obsolete, tier
+template <typename SettingsImplType>
+void fillEngineSettingsColumnsFromImpl(MutableColumns & columns)
+{
+    SettingsImplType impl;
+    for (const auto & setting : impl.all())
+    {
+        size_t col = 0;
+        columns[col++]->insert(setting.getName());
+        columns[col++]->insert(setting.getValueString());
+        columns[col++]->insert(setting.getDefaultValueString());
+        columns[col++]->insert(setting.isValueChanged());
+        columns[col++]->insert(setting.getDescription());
+        columns[col++]->insertDefault(); // min (NULL)
+        columns[col++]->insertDefault(); // max (NULL)
+        columns[col++]->insert(Array{}); // disallowed_values
+        columns[col++]->insert(UInt64(0)); // readonly
+        columns[col++]->insert(setting.getTypeName());
+        columns[col++]->insert(setting.getTier() == SettingsTierType::OBSOLETE);
+        columns[col++]->insert(setting.getTier());
+    }
+}
+
+}

--- a/src/Storages/System/StorageSystemEngineSettings.cpp
+++ b/src/Storages/System/StorageSystemEngineSettings.cpp
@@ -1,0 +1,76 @@
+#include <Core/SettingsTierType.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeEnum.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Storages/StorageFactory.h>
+#include <Storages/System/StorageSystemEngineSettings.h>
+#include <Storages/System/SystemTableSourceRegistry.h>
+
+
+namespace DB
+{
+
+ColumnsDescription StorageSystemEngineSettings::getColumnsDescription()
+{
+    return ColumnsDescription
+    {
+        {"engine_name",  std::make_shared<DataTypeString>(), "Name of the table engine."},
+        {"name",         std::make_shared<DataTypeString>(), "Setting name."},
+        {"value",        std::make_shared<DataTypeString>(), "Setting value."},
+        {"default",      std::make_shared<DataTypeString>(), "Setting default value."},
+        {"changed",      std::make_shared<DataTypeUInt8>(), "1 if the setting was explicitly defined in the config or explicitly changed."},
+        {"description",  std::make_shared<DataTypeString>(), "Setting description."},
+        {"min",          std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>()), "Minimum value of the setting, if any is set via constraints. If the setting has no minimum value, contains NULL."},
+        {"max",          std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>()), "Maximum value of the setting, if any is set via constraints. If the setting has no maximum value, contains NULL."},
+        {"disallowed_values", std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>()), "List of disallowed values."},
+        {"readonly",     std::make_shared<DataTypeUInt8>(),
+            "Shows whether the current user can change the setting: "
+            "0 - Current user can change the setting, "
+            "1 - Current user can't change the setting."
+        },
+        {"type",         std::make_shared<DataTypeString>(), "Setting type (implementation specific string value)."},
+        {"is_obsolete",  std::make_shared<DataTypeUInt8>(), "Shows whether a setting is obsolete."},
+        {"tier", getSettingsTierEnum(), R"(
+Support level for this feature. ClickHouse features are organized in tiers, varying depending on the current status of their
+development and the expectations one might have when using them:
+* PRODUCTION: The feature is stable, safe to use and does not have issues interacting with other PRODUCTION features.
+* BETA: The feature is stable and safe. The outcome of using it together with other features is unknown and correctness is not guaranteed. Testing and reports are welcome.
+* EXPERIMENTAL: The feature is under development. Only intended for developers and ClickHouse enthusiasts. The feature might or might not work and could be removed at any time.
+* OBSOLETE: No longer supported. Either it is already removed or it will be removed in future releases.
+)"},
+    };
+}
+
+void StorageSystemEngineSettings::fillData(MutableColumns & res_columns, ContextPtr /*context*/, const ActionsDAG::Node *, std::vector<UInt8>) const
+{
+    const auto & storages = StorageFactory::instance().getAllStorages();
+
+    for (const auto & [engine_name, creator] : storages)
+    {
+        if (!creator.features.fill_engine_settings_fn)
+            continue;
+
+        /// Fill settings for this engine into temporary columns (without engine_name)
+        auto num_columns = res_columns.size();
+        MutableColumns setting_columns;
+        setting_columns.reserve(num_columns - 1);
+        for (size_t i = 1; i < num_columns; ++i)
+            setting_columns.push_back(res_columns[i]->cloneEmpty());
+
+        creator.features.fill_engine_settings_fn(setting_columns);
+
+        size_t num_rows = setting_columns[0]->size();
+        for (size_t row = 0; row < num_rows; ++row)
+        {
+            res_columns[0]->insert(engine_name);
+            for (size_t col = 1; col < num_columns; ++col)
+                res_columns[col]->insertFrom(*setting_columns[col - 1], row);
+        }
+    }
+}
+
+}
+
+namespace DB { REGISTER_SYSTEM_TABLE_SOURCE(StorageSystemEngineSettings) }

--- a/src/Storages/System/StorageSystemEngineSettings.h
+++ b/src/Storages/System/StorageSystemEngineSettings.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Storages/System/IStorageSystemOneBlock.h>
+
+
+namespace DB
+{
+
+class Context;
+
+/// Implements system table "engine_settings" which shows all settings for all table engines.
+class StorageSystemEngineSettings final : public IStorageSystemOneBlock
+{
+public:
+    std::string getName() const override { return "SystemEngineSettings"; }
+
+    static ColumnsDescription getColumnsDescription();
+
+protected:
+    using IStorageSystemOneBlock::IStorageSystemOneBlock;
+
+    void fillData(MutableColumns & res_columns, ContextPtr context, const ActionsDAG::Node *, std::vector<UInt8>) const override;
+};
+
+}

--- a/src/Storages/System/attachSystemTables.cpp
+++ b/src/Storages/System/attachSystemTables.cpp
@@ -64,6 +64,7 @@
 #include <Storages/System/StorageSystemSettings.h>
 #include <Storages/System/StorageSystemSettingsChanges.h>
 #include <Storages/System/StorageSystemMergeTreeSettings.h>
+#include <Storages/System/StorageSystemEngineSettings.h>
 #include <Storages/System/StorageSystemDatabaseEngines.h>
 #include <Storages/System/StorageSystemTableEngines.h>
 #include <Storages/System/StorageSystemTableFunctions.h>
@@ -193,6 +194,7 @@ void attachSystemTablesServer(ContextPtr context, IDatabase & system_database, b
     attach<StorageSystemSettingsChanges>(context, system_database, "settings_changes", "Contains the information about the settings changes through different ClickHouse versions. You may make ClickHouse behave like a particular previous version by changing the `compatibility` user-level settings.");
     attach<SystemMergeTreeSettings<false>>(context, system_database, "merge_tree_settings", "Contains a list of all MergeTree engine specific settings, their current and default values along with descriptions. You may change any of them in SETTINGS section in CREATE query.");
     attach<SystemMergeTreeSettings<true>>(context, system_database, "replicated_merge_tree_settings", "Contains a list of all ReplicatedMergeTree engine specific settings, their current and default values along with descriptions. You may change any of them in SETTINGS section in CREATE query. ");
+    attach<StorageSystemEngineSettings>(context, system_database, "engine_settings", "Contains a list of settings for all table engines that have engine-specific settings, along with their default values and descriptions.");
     attach<StorageSystemBuildOptions>(context, system_database, "build_options", "Contains a list of all build flags, compiler options and commit hash for used build.");
     attach<StorageSystemHypotheticalIndexes>(context, system_database, "hypothetical_indexes", "Shows session-scoped hypothetical indexes created with CREATE HYPOTHETICAL INDEX for use with EXPLAIN WHATIF.");
 #if USE_XRAY

--- a/src/Storages/TimeSeries/TimeSeriesSettings.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesSettings.cpp
@@ -5,6 +5,7 @@
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSetQuery.h>
+#include <Storages/System/FillEngineSettingsColumns.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
 #include <Storages/TimeSeries/TimeSeriesTagNames.h>
 
@@ -96,6 +97,11 @@ void TimeSeriesSettings::applyChanges(const SettingsChanges & changes)
 bool TimeSeriesSettings::hasBuiltin(std::string_view name)
 {
     return TimeSeriesSettingsImpl::hasBuiltin(name);
+}
+
+void TimeSeriesSettings::fillEngineSettingsColumns(MutableColumns & columns)
+{
+    fillEngineSettingsColumnsFromImpl<TimeSeriesSettingsImpl>(columns);
 }
 
 void checkTimeSeriesSettings(const TimeSeriesSettings & settings)

--- a/src/Storages/TimeSeries/TimeSeriesSettings.h
+++ b/src/Storages/TimeSeries/TimeSeriesSettings.h
@@ -3,6 +3,7 @@
 #include <Core/BaseSettingsFwdMacros.h>
 #include <Core/SettingFieldASTFunction.h>
 #include <Core/SettingsFields.h>
+#include <Columns/IColumn_fwd.h>
 
 
 namespace DB
@@ -45,6 +46,7 @@ struct TimeSeriesSettings
     void applyChanges(const SettingsChanges & changes);
 
     static bool hasBuiltin(std::string_view name);
+    static void fillEngineSettingsColumns(MutableColumns & columns);
 
 private:
     std::unique_ptr<TimeSeriesSettingsImpl> impl;

--- a/tests/queries/0_stateless/04695_system_engine_settings.reference
+++ b/tests/queries/0_stateless/04695_system_engine_settings.reference
@@ -1,0 +1,19 @@
+1
+engine_name	String
+name	String
+value	String
+default	String
+changed	UInt8
+description	String
+min	Nullable(String)
+max	Nullable(String)
+disallowed_values	Array(String)
+readonly	UInt8
+type	String
+is_obsolete	UInt8
+tier	Enum8('PRODUCTION' = 0, 'OBSOLETE' = 1, 'BETA' = 2, 'EXPERIMENTAL' = 3)
+1
+1
+MergeTree	index_granularity	0	0	0
+Memory	compress	false	Bool
+1

--- a/tests/queries/0_stateless/04695_system_engine_settings.sql
+++ b/tests/queries/0_stateless/04695_system_engine_settings.sql
@@ -1,0 +1,21 @@
+-- Tags: no-fasttest
+-- Verify system.engine_settings table exists and has correct structure
+SELECT count() > 0 FROM system.engine_settings;
+
+-- Verify required columns exist
+SELECT name, type FROM system.columns WHERE database = 'system' AND table = 'engine_settings' ORDER BY position;
+
+-- Verify MergeTree settings are present
+SELECT count() > 0 FROM system.engine_settings WHERE engine_name = 'MergeTree';
+
+-- Verify Memory settings are present
+SELECT count() > 0 FROM system.engine_settings WHERE engine_name = 'Memory';
+
+-- Verify basic settings metadata for a known MergeTree setting
+SELECT engine_name, name, changed, readonly, is_obsolete FROM system.engine_settings WHERE name = 'index_granularity' AND engine_name = 'MergeTree';
+
+-- Verify basic settings metadata for a known Memory setting
+SELECT engine_name, name, default, type FROM system.engine_settings WHERE name = 'compress' AND engine_name = 'Memory';
+
+-- Verify multiple engines have settings
+SELECT count(DISTINCT engine_name) > 3 FROM system.engine_settings;


### PR DESCRIPTION
Add a new system.engine_settings system table that exposes settings for all table engines, not just MergeTree. The table has the same structure as system.merge_tree_settings plus an engine_name column, allowing users to discover available settings for any engine via SQL.

Closes: https://github.com/ClickHouse/ClickHouse/issues/59913

Changelog category (leave one):
New Feature
Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Added system.engine_settings table that shows all available settings for every table engine (Memory, Kafka, Distributed, RocksDB, etc.), not just MergeTree.