### PR TITLE
CI: reclaim leftover docker images before Install packages installs

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -564,6 +564,10 @@ class JobConfigs:
             ],
         ),
         timeout=900,
+        # Unpacking the packages needs ~4.4 GB, so reclaim another job's leftover
+        # images before installing, not just afterwards. Best-effort: praktika does
+        # not propagate a hook's exit code to the job status.
+        pre_hooks=["python3 ./ci/jobs/scripts/job_hooks/docker_clean_up_hook.py"],
         post_hooks=["python3 ./ci/jobs/scripts/job_hooks/docker_clean_up_hook.py"],
     ).parametrize(
         Job.ParamSet(
@@ -598,6 +602,8 @@ class JobConfigs:
             ],
         ),
         timeout=900,
+        # See install_check_jobs above.
+        pre_hooks=["python3 ./ci/jobs/scripts/job_hooks/docker_clean_up_hook.py"],
         post_hooks=["python3 ./ci/jobs/scripts/job_hooks/docker_clean_up_hook.py"],
     ).parametrize(
         Job.ParamSet(

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -561,6 +561,7 @@ class JobConfigs:
             include_paths=[
                 "./ci/jobs/install_check.py",
                 "./ci/docker/install",
+                "./ci/jobs/scripts/job_hooks/docker_clean_up_hook.py",
             ],
         ),
         timeout=900,
@@ -599,6 +600,7 @@ class JobConfigs:
             include_paths=[
                 "./ci/jobs/install_check.py",
                 "./ci/docker/install",
+                "./ci/jobs/scripts/job_hooks/docker_clean_up_hook.py",
             ],
         ),
         timeout=900,

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1299,6 +1299,9 @@ class JobConfigs:
                 "./ci/jobs/compatibility_check.py",
             ],
         ),
+        # Shares the style-checker runners with Install packages and leaves ~4 GB of docker
+        # residue per run, which is what the next job on that runner inherits.
+        post_hooks=["python3 ./ci/jobs/scripts/job_hooks/docker_clean_up_hook.py"],
     ).parametrize(
         Job.ParamSet(
             parameter="amd_release",

--- a/ci/jobs/scripts/job_hooks/docker_clean_up_hook.py
+++ b/ci/jobs/scripts/job_hooks/docker_clean_up_hook.py
@@ -10,15 +10,26 @@ def check():
         verbose=True,
     )
     print("Clean up non-latest images per each Repository")
+    # `{{.CreatedAt}}` is an ISO date, so `sort -M` compares every date equal and the order
+    # falls through to the hour. Remove by reference: `docker rmi <id>` without `-f` refuses
+    # an id that several repositories still tag.
     Shell.check(
-        "docker images --format '{{.Repository}} {{.ID}} {{.CreatedAt}}' "
-        " | sort -k1,1 -k3,3M -k4,4n -k5,5n "
-        " | tac "
-        " | awk '!seen[$1]++ {next} {print $2}' "
+        "docker images --format '{{.Repository}}:{{.Tag}} {{.Repository}} {{.CreatedAt}}' "
+        " | sort -k2,2 -k3,3r -k4,4r "
+        " | awk '!seen[$2]++ {next} {print $1}' "
         " | xargs -r docker rmi",
         verbose=True,
     )
     print("Clean up build cache")
+    # A `docker-container` builder keeps its cache in its own buildkit container, out of
+    # reach of the prunes below, and `buildx ls` has no --all-builders equivalent. Unindented
+    # rows are the builders; a builder that never built has no container yet, hence `|| true`.
+    Shell.check(
+        "docker buildx ls "
+        " | awk 'NR>1 && $0 !~ /^[[:space:]]/ && NF { sub(/[*]$/, \"\", $1); print $1 }' "
+        " | xargs -r -I% sh -c 'docker buildx prune -a -f --builder % || true'",
+        verbose=True,
+    )
     Shell.check("docker builder prune -a -f", verbose=True)
     print("Clean up stopped containers")
     Shell.check("docker container prune -f", verbose=True)

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -525,9 +525,6 @@ class Runner:
             # sampling thread is always joined even if TeePopen raised.
             host_metrics_collector.stop()
 
-        print("INFO: disk status after running a job:")
-        Shell.run("df -h")
-
         return exit_code
 
     def _get_result_object(
@@ -1150,6 +1147,10 @@ class Runner:
                 print("=== Post run script finished ===")
 
             result.dump()
+
+        # After the post hooks, so the numbers describe the disk the next job inherits.
+        print("INFO: disk status after running a job:")
+        Shell.run("df -h")
 
         if not res and not job.force_success:
             sys.exit(1)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113032
-->

Related: #113032


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`Install packages (amd_release)` failed on master sha `7039251dbe2db9b9f59c127ed1ec3ef3b1073183` with `dpkg: ... No space left on device` ([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=7039251dbe2db9b9f59c127ed1ec3ef3b1073183&name_0=MasterCI&name_1=Install%20packages%20%28amd_release%29)).

**The job starts on a disk another job filled.** The runner arrived 95% full (3.2 GiB free) while `apt` needs 4413 MB, so substep 1 of 18 was doomed. Measured over 12 master runs, the job is a net *producer* of free space (+3.0 to +4.6 GB each), so #111960, #112751 and #113032, all ancestors here, could not close it. The same exhaustion accounts for 15 runs in 20 days, 7 on master and 8 on release branches.

`Install packages` shares the `style-checker` pool with the Docker image builds and `Compatibility check`. Registering `docker_clean_up_hook` as a `pre_hooks` entry on both `Install packages` configs (4 parametrized jobs across PR, BackportPR, MasterCI, ReleaseBranchCI) reclaims that residue *before* installing.

The review then asked what still eats the disk. `Compatibility check` had no cleanup hook at all and loses 4 to 5 GB per run, so it gets the post hook. The Docker jobs do run the hook yet still lose 3 to 7 GB, reporting `Total: 0B` with zero images untagged, for two reasons reproduced locally on docker 29.5.1 / buildx v0.34.0: their `docker-container` buildx driver keeps its cache in its own buildkit container, which none of the hook's commands reaches (740.8 MB survived all four); and `sort -k3,3M` over an ISO `{{.CreatedAt}}` compares every date equal, so the keep-the-latest step kept an older image in 3 of 4 local repositories. Both fixes live in the shared hook, so the Docker jobs get them too. The runner also printed `disk status after running a job` before the post hooks ran, so those numbers excluded the cleanup.

No glob narrowed, no package skipped, no test touched. praktika does not propagate hook exit codes, so this stays best-effort.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.938` (included in `26.8` and later)
<!-- ch-version-info:end -->