### PR TITLE
Rework projection part storage around an owned-set descriptor API

### DIFF
--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -1,3 +1,4 @@
+#include <map>
 #include <string_view>
 #include <Backups/BackupEntryFromImmutableFile.h>
 #include <Backups/BackupEntryWrappedWith.h>
@@ -85,13 +86,66 @@ std::unique_ptr<ReadBufferFromFileBase> IDataPartStorage::readFile(
     return pipeline.build();
 }
 
-DataPartStorageOnDiskBase::DataPartStorageOnDiskBase(VolumePtr volume_, std::string root_path_, std::string part_dir_)
-    : volume(std::move(volume_)), root_path(std::move(root_path_)), part_dir(std::move(part_dir_))
+IDataPartStorage::Projection::Status IDataPartStorage::Projection::dirNameType(std::string_view dir_name)
+{
+    if (dir_name.ends_with(extTmp()))
+        return Status::Temp;
+    if (dir_name.ends_with(ext()))
+        return Status::Live;
+    return Status::None;
+}
+
+std::shared_ptr<IDataPartStorage> IDataPartStorage::getProjectionStorageForWrite(const Projection & placement, bool use_parent_transaction) // NOLINT
+{
+    if (!hasProjection(placement.dirName()))
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "Cannot get writable storage for projection {}: it is not owned by part storage {} (create it with createProjection first)",
+            placement.dirName(), getRelativePath());
+    return getProjectionStorage(placement.dirName(), use_parent_transaction);
+}
+
+void DataPartStorageOnDiskBase::seedFrozenCopy(IDataPartStorage & dest_storage) const
+{
+    Projections copied;
+    for (const auto & [projection_dir, projection] : getProjections())
+        if (!projection.is_temp)
+            copied.emplace(projection_dir, projection);
+    dest_storage.setProjections(std::move(copied));
+    dest_storage.setZeroCopyReplicationEnabled(zero_copy_replication_enabled);
+}
+
+namespace
+{
+
+using Projection = IDataPartStorage::Projection;
+using Projections = IDataPartStorage::Projections;
+
+/// "p.proj" -> {"p", false}; "p_1.tmp_proj" -> {"p_1", true}. Precondition: a projection dir name.
+std::pair<String, bool> splitProjectionDirName(std::string_view dir_name)
+{
+    if (Projection::dirNameType(dir_name) == Projection::Status::Temp)
+        return {String(dir_name.substr(0, dir_name.size() - Projection::extTmp().size())), true};
+    chassert(Projection::dirNameType(dir_name) == Projection::Status::Live);
+    return {String(dir_name.substr(0, dir_name.size() - Projection::ext().size())), false};
+}
+
+}
+
+DataPartStorageOnDiskBase::DataPartStorageOnDiskBase(
+    VolumePtr volume_,
+    std::string root_path_,
+    std::string part_dir_)
+    : volume(std::move(volume_))
+    , root_path(std::move(root_path_))
+    , part_dir(std::move(part_dir_))
 {
 }
 
 DataPartStorageOnDiskBase::DataPartStorageOnDiskBase(
-    VolumePtr volume_, std::string root_path_, std::string part_dir_, DiskTransactionPtr transaction_)
+    VolumePtr volume_,
+    std::string root_path_,
+    std::string part_dir_,
+    DiskTransactionPtr transaction_)
     : volume(std::move(volume_))
     , root_path(std::move(root_path_))
     , part_dir(std::move(part_dir_))
@@ -202,7 +256,11 @@ bool DataPartStorageOnDiskBase::looksLikeBrokenDetachedPartHasTheSameContent(con
     if (!existsFile("checksums.txt"))
         return false;
 
-    auto storage_from_detached = create(volume, fs::path(root_path) / MergeTreeData::DETACHED_DIR_NAME, detached_part_path, /*initialize=*/ true);
+    auto storage_from_detached = create(
+        volume,
+        fs::path(root_path) / MergeTreeData::DETACHED_DIR_NAME,
+        detached_part_path,
+        /*initialize=*/ true);
     if (!storage_from_detached->existsFile("checksums.txt"))
         return false;
 
@@ -253,6 +311,13 @@ void DataPartStorageOnDiskBase::setRelativePath(const std::string & path)
         skip_indices_packed_probed = false;
         skip_indices_packed_reader.reset();
     }
+    /// For the same reason the projection cache, which describes the old directory's projections, must be dropped (rename/changeRootPath
+    /// only move within the same content and keep it valid).
+    {
+        std::lock_guard lock(projections_mutex);
+        owned_projections_ready = false;
+        owned_projections.clear();
+    }
 }
 
 std::string DataPartStorageOnDiskBase::getPartDirectory() const
@@ -287,7 +352,8 @@ static UInt64 calculateTotalSizeOnDiskImpl(const DiskPtr & disk, const String & 
 
 UInt64 DataPartStorageOnDiskBase::calculateTotalSizeOnDisk() const
 {
-    return calculateTotalSizeOnDiskImpl(volume->getDisk(), fs::path(root_path) / part_dir);
+    auto disk = volume->getDisk();
+    return calculateTotalSizeOnDiskImpl(disk, fs::path(root_path) / part_dir);
 }
 
 std::string DataPartStorageOnDiskBase::getDiskName() const
@@ -432,7 +498,8 @@ void DataPartStorageOnDiskBase::backup(
     bool allow_backup_broken_projection) const
 {
     fs::path part_path_on_disk = fs::path{root_path} / part_dir;
-    fs::path part_path_in_backup = fs::path{path_in_backup} / part_dir;
+    /// The full destination dir comes from the caller: a projection goes under its logical name ("<name>.proj").
+    fs::path part_path_in_backup = path_in_backup;
 
     auto disk = volume->getDisk();
 
@@ -463,7 +530,7 @@ void DataPartStorageOnDiskBase::backup(
     auto files_to_backup = files_without_checksums;
     for (const auto & [name, _] : checksums.files)
     {
-        if (!name.ends_with(".proj"))
+        if (Projection::dirNameType(name) != Projection::Status::Live)
             files_to_backup.insert(name);
     }
 
@@ -535,94 +602,22 @@ void DataPartStorageOnDiskBase::backup(
 MutableDataPartStoragePtr DataPartStorageOnDiskBase::freeze(
     const std::string & to,
     const std::string & dir_path,
-    const ReadSettings & read_settings,
-    const WriteSettings & write_settings,
-    std::function<void(const DiskPtr &)> save_metadata_callback,
-    const ClonePartParams & params) const
-{
-    auto disk = volume->getDisk();
-    if (params.external_transaction)
-        params.external_transaction->createDirectories(to);
-    else
-        disk->createDirectories(to);
-
-    Backup(
-        disk,
-        disk,
-        getRelativePath(),
-        fs::path(to) / dir_path,
-        read_settings,
-        write_settings,
-        params.make_source_readonly,
-        /* max_level= */ {},
-        params.copy_instead_of_hardlink,
-        params.files_to_copy_instead_of_hardlinks,
-        params.external_transaction);
-
-    if (save_metadata_callback)
-        save_metadata_callback(disk);
-
-    /// Also remove any leftover `txn_version.txt.tmp`: leaving it without the main file makes the
-    /// cloned/frozen part load as a rolled-back transaction (see `VersionMetadataOnDisk::loadMetadata`)
-    /// and get discarded as `Outdated`. Remove the temporary file before the main file so the cleanup
-    /// is fail-closed: a failure between the two removals leaves a valid `txn_version.txt` rather than
-    /// the dangerous tmp-only state.
-    if (params.external_transaction)
-    {
-        params.external_transaction->removeFileIfExists(fs::path(to) / dir_path / "delete-on-destroy.txt");
-        params.external_transaction->removeFileIfExists(fs::path(to) / dir_path / VersionMetadata::TMP_TXN_VERSION_METADATA_FILE_NAME);
-        params.external_transaction->removeFileIfExists(fs::path(to) / dir_path / VersionMetadata::TXN_VERSION_METADATA_FILE_NAME);
-        if (!params.keep_metadata_version)
-            params.external_transaction->removeFileIfExists(fs::path(to) / dir_path / IMergeTreeDataPart::METADATA_VERSION_FILE_NAME);
-        IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*params.external_transaction, fs::path(to) / dir_path, params.invalidated_columns_to_write, write_settings);
-    }
-    else
-    {
-        disk->removeFileIfExists(fs::path(to) / dir_path / "delete-on-destroy.txt");
-        disk->removeFileIfExists(fs::path(to) / dir_path / VersionMetadata::TMP_TXN_VERSION_METADATA_FILE_NAME);
-        disk->removeFileIfExists(fs::path(to) / dir_path / VersionMetadata::TXN_VERSION_METADATA_FILE_NAME);
-        if (!params.keep_metadata_version)
-            disk->removeFileIfExists(fs::path(to) / dir_path / IMergeTreeDataPart::METADATA_VERSION_FILE_NAME);
-        IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*disk, fs::path(to) / dir_path, params.invalidated_columns_to_write, write_settings);
-    }
-
-    /// Make the hardlink clone durable (the Backup loop above fsyncs nothing). This runs
-    /// synchronously before freeze returns, so a caller that afterwards makes a destructive change
-    /// (e.g. DETACH commits a covering empty part and drops the source) sees the clone already on
-    /// disk. See the commit message / #111382 for the full rationale.
-    if (params.fsync_part_directory && !params.external_transaction && !disk->isRemote())
-        fsyncFrozenCloneTree(*disk, fs::path(to) / dir_path);
-
-    /// The SingleDiskVolume and the DataPartStorageOnDiskFull built by `create` are stored on the
-    /// frozen part for its whole lifetime; route them into the dedicated MergeTree arena, like the
-    /// builder-owned storage path.
-    ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
-    auto single_disk_volume = std::make_shared<SingleDiskVolume>(disk->getName(), disk, 0);
-
-    /// Do not initialize storage in case of DETACH because part may be broken.
-    bool to_detached = dir_path.starts_with(std::string_view((fs::path(MergeTreeData::DETACHED_DIR_NAME) / "").string()));
-    auto frozen_storage = create(single_disk_volume, to, dir_path, /*initialize=*/ !to_detached && !params.external_transaction);
-
-    return frozen_storage;
-}
-
-MutableDataPartStoragePtr DataPartStorageOnDiskBase::freezeRemote(
-    const std::string & to,
-    const std::string & dir_path,
-    const DiskPtr & dst_disk,
+    const DiskPtr & dst_disk_,
     const ReadSettings & read_settings,
     const WriteSettings & write_settings,
     std::function<void(const DiskPtr &)> save_metadata_callback,
     const ClonePartParams & params) const
 {
     auto src_disk = volume->getDisk();
+    auto dst_disk = dst_disk_ ? dst_disk_ : src_disk;
+    /// A remote destination cannot hardlink, so it always copies everything (files_to_copy_instead_of_hardlinks is then irrelevant).
+    const bool copy_instead_of_hardlink = params.copy_instead_of_hardlink || dst_disk != src_disk;
+
     if (params.external_transaction)
         params.external_transaction->createDirectories(to);
     else
         dst_disk->createDirectories(to);
 
-    /// freezeRemote() using copy instead of hardlinks for all files
-    /// In this case, files_to_copy_intead_of_hardlinks is set by empty
     Backup(
         src_disk,
         dst_disk,
@@ -631,12 +626,12 @@ MutableDataPartStoragePtr DataPartStorageOnDiskBase::freezeRemote(
         read_settings,
         write_settings,
         params.make_source_readonly,
-        /* max_level= */ {},
-        true,
-        /* files_to_copy_intead_of_hardlinks= */ {},
+        {},
+        copy_instead_of_hardlink,
+        params.files_to_copy_instead_of_hardlinks,
         params.external_transaction);
 
-    /// The save_metadata_callback function acts on the target dist.
+    /// The save_metadata_callback function acts on the target disk.
     if (save_metadata_callback)
         save_metadata_callback(dst_disk);
 
@@ -645,35 +640,42 @@ MutableDataPartStoragePtr DataPartStorageOnDiskBase::freezeRemote(
     /// and get discarded as `Outdated`. Remove the temporary file before the main file so the cleanup
     /// is fail-closed: a failure between the two removals leaves a valid `txn_version.txt` rather than
     /// the dangerous tmp-only state.
-    if (params.external_transaction)
+    auto remove_file_if_exists = [&](const String & file_name)
     {
-        params.external_transaction->removeFileIfExists(fs::path(to) / dir_path / "delete-on-destroy.txt");
-        params.external_transaction->removeFileIfExists(fs::path(to) / dir_path / VersionMetadata::TMP_TXN_VERSION_METADATA_FILE_NAME);
-        params.external_transaction->removeFileIfExists(fs::path(to) / dir_path / VersionMetadata::TXN_VERSION_METADATA_FILE_NAME);
-        if (!params.keep_metadata_version)
-            params.external_transaction->removeFileIfExists(fs::path(to) / dir_path / IMergeTreeDataPart::METADATA_VERSION_FILE_NAME);
-        IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*params.external_transaction, fs::path(to) / dir_path, params.invalidated_columns_to_write, write_settings);
-    }
-    else
-    {
-        dst_disk->removeFileIfExists(fs::path(to) / dir_path / "delete-on-destroy.txt");
-        dst_disk->removeFileIfExists(fs::path(to) / dir_path / VersionMetadata::TMP_TXN_VERSION_METADATA_FILE_NAME);
-        dst_disk->removeFileIfExists(fs::path(to) / dir_path / VersionMetadata::TXN_VERSION_METADATA_FILE_NAME);
-        if (!params.keep_metadata_version)
-            dst_disk->removeFileIfExists(fs::path(to) / dir_path / IMergeTreeDataPart::METADATA_VERSION_FILE_NAME);
-        IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*dst_disk, fs::path(to) / dir_path, params.invalidated_columns_to_write, write_settings);
-    }
+        if (params.external_transaction)
+            params.external_transaction->removeFileIfExists(fs::path(to) / dir_path / file_name);
+        else
+            dst_disk->removeFileIfExists(fs::path(to) / dir_path / file_name);
+    };
+    remove_file_if_exists("delete-on-destroy.txt");
+    remove_file_if_exists(VersionMetadata::TMP_TXN_VERSION_METADATA_FILE_NAME);
+    remove_file_if_exists(VersionMetadata::TXN_VERSION_METADATA_FILE_NAME);
+    if (!params.keep_metadata_version)
+        remove_file_if_exists(IMergeTreeDataPart::METADATA_VERSION_FILE_NAME);
 
-    /// The SingleDiskVolume and the DataPartStorageOnDiskFull built by `create` are stored on the
-    /// frozen part for its whole lifetime; route them into the dedicated MergeTree arena.
+    if (params.external_transaction)
+        IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*params.external_transaction, fs::path(to) / dir_path, params.invalidated_columns_to_write, write_settings);
+    else
+        IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*dst_disk, fs::path(to) / dir_path, params.invalidated_columns_to_write, write_settings);
+
+    /// Durability graft from master #111426: make the local hardlink clone durable before the caller
+    /// commits a covering part (the Backup loop above fsyncs nothing). Local destination, no external txn.
+    if (params.fsync_part_directory && !params.external_transaction && !dst_disk->isRemote())
+        fsyncFrozenCloneTree(*dst_disk, fs::path(to) / dir_path);
+
+    /// The SingleDiskVolume and the storage built by `create` are stored on the frozen part for its whole
+    /// lifetime; route them into the dedicated MergeTree arena, like the builder-owned storage path.
     ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
     auto single_disk_volume = std::make_shared<SingleDiskVolume>(dst_disk->getName(), dst_disk, 0);
 
     /// Do not initialize storage in case of DETACH because part may be broken.
     bool to_detached = dir_path.starts_with(std::string_view((fs::path(MergeTreeData::DETACHED_DIR_NAME) / "").string()));
-    auto frozen_storage = create(single_disk_volume, to, dir_path, /*initialize=*/ !to_detached && !params.external_transaction);
+    auto new_storage = create(
+        single_disk_volume, to, dir_path,
+        /*initialize=*/ !to_detached && !params.external_transaction);
 
-    return frozen_storage;
+    seedFrozenCopy(*new_storage);
+    return new_storage;
 }
 
 MutableDataPartStoragePtr DataPartStorageOnDiskBase::clonePart(
@@ -713,7 +715,10 @@ MutableDataPartStoragePtr DataPartStorageOnDiskBase::clonePart(
     /// cloned part for its whole lifetime; route them into the dedicated MergeTree arena.
     ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
     auto single_disk_volume = std::make_shared<SingleDiskVolume>(dst_disk->getName(), dst_disk, 0);
-    return create(single_disk_volume, to, dir_path, /*initialize=*/ true);
+    auto new_storage = create(single_disk_volume, to, dir_path, /*initialize=*/ true);
+
+    seedFrozenCopy(*new_storage);
+    return new_storage;
 }
 
 void DataPartStorageOnDiskBase::rename(
@@ -757,7 +762,6 @@ void DataPartStorageOnDiskBase::rename(
 
     String from = getRelativePath();
 
-    /// Why?
     executeWriteOperation([&](auto & disk)
     {
         disk.setLastModified(from, Poco::Timestamp::fromEpochTime(time(nullptr)));
@@ -798,6 +802,211 @@ void DataPartStorageOnDiskBase::rename(
     }
 }
 
+std::pair<std::string, std::string> DataPartStorageOnDiskBase::getProjectionRootAndDir(
+    const std::string & dir_name, ProjectionStorageFormat format) const
+{
+    switch (format)
+    {
+        case ProjectionStorageFormat::LEGACY_NESTED:
+            return {fs::path(root_path) / part_dir, dir_name};
+        default:
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected projection storage format: {}", static_cast<int>(format));
+    }
+}
+
+bool DataPartStorageOnDiskBase::existsProjectionDir(const std::string & dir_name, ProjectionStorageFormat format) const
+{
+    auto [root, dir] = getProjectionRootAndDir(dir_name, format);
+    return volume->getDisk()->existsDirectory(fs::path(root) / dir);
+}
+
+Projections DataPartStorageOnDiskBase::detectProjections(const ProjectionScan & scan) const
+{
+    auto disk = volume->getDisk();
+
+    auto add_to = [&](Projections & out, std::string_view dir_name, ProjectionStorageFormat format)
+    {
+        auto [name, is_temp] = splitProjectionDirName(dir_name);
+        out.emplace(String(dir_name), Projection{this, std::move(name), format, is_temp});
+    };
+
+    /// Manifest-driven probe: resolve only the named candidates by direct stat, no directory listing.
+    if (scan.candidates)
+    {
+        Projections probed;
+        for (const auto & dir_name : *scan.candidates)
+        {
+            if (probed.contains(dir_name))
+                continue;
+
+            if (!existsProjectionDir(dir_name, ProjectionStorageFormat::LEGACY_NESTED))
+                continue;
+
+            add_to(probed, dir_name, ProjectionStorageFormat::LEGACY_NESTED);
+        }
+        return probed;
+    }
+
+    /// Full discovery: list the part dir for projection sub-dirs.
+    Projections detected;
+
+    const fs::path nested_root = fs::path(root_path) / part_dir;
+    if (disk->existsDirectory(nested_root))
+        for (auto it = disk->iterateDirectory(nested_root); it->isValid(); it->next())
+            if (Projection::dirNameType(it->name()) != Projection::Status::None)
+                add_to(detected, it->name(), ProjectionStorageFormat::LEGACY_NESTED);
+
+    return detected;
+}
+
+Projections DataPartStorageOnDiskBase::getProjections() const
+{
+    std::lock_guard lock(projections_mutex);
+    if (!owned_projections_ready)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Projections were never set for part storage {}", fs::path(root_path) / part_dir);
+    return owned_projections;
+}
+
+void DataPartStorageOnDiskBase::setProjections(Projections projections_)
+{
+    /// Copies from another storage (freeze/clonePart hand the source's set to the copy) must not keep pointing at the source.
+    for (auto & [_, projection] : projections_)
+        projection.parent = this;
+
+    std::lock_guard lock(projections_mutex);
+    owned_projections = std::move(projections_);
+    owned_projections_ready = true;
+}
+
+bool DataPartStorageOnDiskBase::hasProjection(const std::string & dir_name) const
+{
+    /// Point query against the cache -- must not copy the whole owned set.
+    std::lock_guard lock(projections_mutex);
+    if (!owned_projections_ready)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Projections were never set for part storage {}", fs::path(root_path) / part_dir);
+    return owned_projections.contains(dir_name);
+}
+
+Projection DataPartStorageOnDiskBase::getProjection(const std::string & dir_name) const
+{
+    auto projection = tryGetProjection(dir_name);
+    if (!projection)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown projection {} in part {}", dir_name, getRelativePath());
+    return *projection;
+}
+
+std::optional<Projection> DataPartStorageOnDiskBase::tryGetProjection(const std::string & dir_name) const
+{
+    /// Point query against the cache -- must not copy the whole owned set.
+    std::lock_guard lock(projections_mutex);
+    if (!owned_projections_ready)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Projections were never set for part storage {}", fs::path(root_path) / part_dir);
+    auto it = owned_projections.find(dir_name);
+    if (it == owned_projections.end())
+        return std::nullopt;
+    return it->second;
+}
+
+Projection DataPartStorageOnDiskBase::projectionPlacement(const std::string & dir_name, ProjectionStorageFormat format) const
+{
+    chassert(format != ProjectionStorageFormat::NONE);
+    auto [name, is_temp] = splitProjectionDirName(dir_name);
+    return Projection{this, std::move(name), format, is_temp};
+}
+
+Projection DataPartStorageOnDiskBase::resolveProjectionForRead(const std::string & dir_name) const
+{
+    if (auto owned = tryGetProjection(dir_name))
+        return *owned;
+
+    /// Not owned: broken/missing, or a manifest desync. Probe disk for the actual layout; nested placeholder if absent in both.
+    auto probed = detectProjections({.candidates = Strings{dir_name}});
+    if (!probed.empty())
+        return probed.begin()->second;
+    return projectionPlacement(dir_name, ProjectionStorageFormat::LEGACY_NESTED);
+}
+
+void DataPartStorageOnDiskBase::addProjection(Projection projection_)
+{
+    projection_.parent = this;
+    std::lock_guard lock(projections_mutex);
+    if (!owned_projections_ready)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot register projection {} in part {}: projections were never set", projection_.dirName(), part_dir);
+    owned_projections[projection_.dirName()] = std::move(projection_);
+}
+
+void DataPartStorageOnDiskBase::dropProjection(const std::string & dir_name)
+{
+    std::lock_guard lock(projections_mutex);
+    owned_projections.erase(dir_name);
+}
+
+void DataPartStorageOnDiskBase::removeProjection(const Projection & projection)
+{
+    if (!hasProjection(projection.dirName()))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown projection {} in part {}", projection.dirName(), getRelativePath());
+    if (!projection.is_temp)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Projection {} in part {} is not temporary; it is removed only with its parent part", projection.dirName(), getRelativePath());
+
+    const auto [proj_root, proj_dir] = getProjectionRootAndDir(projection.dirName(), projection.format);
+    /// Temporary projections are transient by-products of materialization, their blobs are never shared.
+    executeWriteOperation([&](auto & disk) { disk.removeSharedRecursive(fs::path(proj_root) / proj_dir / "", false, {}); });
+    dropProjection(projection.dirName());
+}
+
+Projection DataPartStorageOnDiskBase::renameProjection(const Projection & projection, const std::string & new_dir_name, bool fsync)
+{
+    if (!hasProjection(projection.dirName()))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown projection {} in part {}", projection.dirName(), getRelativePath());
+
+    auto [new_name, new_is_temp] = splitProjectionDirName(new_dir_name);
+    Projection renamed{this, std::move(new_name), projection.format, new_is_temp};
+
+    /// An existing destination is residue of a failed operation on a same-named part (tmp part names repeat).
+    removeProjectionResidue(renamed);
+
+    const auto [from_root, from_dir] = getProjectionRootAndDir(projection.dirName(), projection.format);
+    const auto [to_root, to_dir] = getProjectionRootAndDir(renamed.dirName(), renamed.format);
+    executeWriteOperation([&](auto & disk) { disk.moveDirectory(fs::path(from_root) / from_dir, fs::path(to_root) / to_dir); });
+    if (fsync)
+    {
+        /// The rename entry lives in the enclosing dir (the part dir).
+        SyncGuardPtr sync_guard = volume->getDisk()->getDirectorySyncGuard(to_root);
+    }
+    dropProjection(projection.dirName());
+    addProjection(renamed);
+    return renamed;
+}
+
+void DataPartStorageOnDiskBase::syncProjectionStoragePath(const Projection & projection, IDataPartStorage & projection_storage) const
+{
+    if (!hasProjection(projection.dirName()))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown projection {} in part {}", projection.dirName(), getRelativePath());
+
+    const auto [proj_root, proj_dir] = getProjectionRootAndDir(projection.dirName(), projection.format);
+    dynamic_cast<DataPartStorageOnDiskBase &>(projection_storage).setPathKeepingCaches(proj_root, proj_dir);
+}
+
+void DataPartStorageOnDiskBase::removeProjectionResidue(const Projection & placement)
+{
+    /// Resolve against this storage, not placement.parent: callers may probe a placement here regardless of which storage minted the
+    /// descriptor.
+    if (!existsProjectionDir(placement.dirName(), placement.format))
+        return;
+
+    const auto [proj_root, proj_dir] = getProjectionRootAndDir(placement.dirName(), placement.format);
+    LOG_WARNING(getLogger("DataPartStorageOnDiskBase"), "Removing stale projection directory {}: residue of a failed operation on a same-named part",
+        fullPath(volume->getDisk(), fs::path(proj_root) / proj_dir));
+    const bool keep_shared = zero_copy_replication_enabled && volume->getDisk()->supportZeroCopyReplication();
+    volume->getDisk()->removeSharedRecursive(fs::path(proj_root) / proj_dir / "", keep_shared, {});
+}
+
+void DataPartStorageOnDiskBase::setPathKeepingCaches(std::string new_root_path, std::string new_part_dir)
+{
+    root_path = std::move(new_root_path);
+    part_dir = std::move(new_part_dir);
+}
+
 void DataPartStorageOnDiskBase::remove(
     CanRemoveCallback && can_remove_callback,
     const MergeTreeDataPartChecksums & checksums,
@@ -822,6 +1031,14 @@ void DataPartStorageOnDiskBase::remove(
     std::optional<CanRemoveDescription> can_remove_description;
     auto disk = volume->getDisk();
     fs::path to = fs::path(root_path) / part_dir_without_slash;
+
+
+    struct ProjectionToRemove
+    {
+        String destination;                 /// proj dir after the part's rename
+        MutableDataPartStoragePtr storage;  /// handle at the destination (used to read its checksums)
+    };
+    std::map<String, ProjectionToRemove> all_projections;
 
     if (!has_delete_prefix)
     {
@@ -884,7 +1101,42 @@ void DataPartStorageOnDiskBase::remove(
         /// use the current (existing) path. We intentionally don't update part_dir to avoid races.
         if (!can_remove_description)
             can_remove_description.emplace(can_remove_callback());
+    }
 
+    auto strip_trailing_slash = [](String path)
+    {
+        if (!path.empty() && path.back() == '/')
+            path.pop_back();
+        return path;
+    };
+    /// Built for the retry on a delete_tmp_ dir too (source == destination there): the later per-projection clearDirectory calls need the
+    /// map in both cases.
+    auto update_projection_info = [&](const String & proj_name)
+    {
+        if (all_projections.contains(proj_name))
+            return;
+        /// A checksums-referenced projection the owned set does not know (e.g. its dir is lost) resolves to where it would live; exists()
+        /// then skips it.
+        auto projection = resolveProjectionForRead(proj_name);
+        if (!projection.exists())
+            return;
+
+        auto destination = create(volume, to, proj_name, /*initialize=*/ true);
+
+        all_projections.emplace(
+            proj_name,
+            ProjectionToRemove{
+                strip_trailing_slash(destination->getRelativePath()),
+                destination});
+    };
+    for (const auto & projection : projections)
+        update_projection_info(Projection::dirName(projection.name, false));
+    for (const auto & [name, _] : checksums.files)
+        if (Projection::dirNameType(name) == Projection::Status::Live)
+            update_projection_info(name);
+
+    if (!has_delete_prefix)
+    {
         try
         {
             disk->moveDirectory(from, to);
@@ -918,10 +1170,9 @@ void DataPartStorageOnDiskBase::remove(
 
     // Record existing projection directories so we don't remove them twice
     std::unordered_set<String> projection_directories;
-    std::string proj_suffix = ".proj";
     for (const auto & projection : projections)
     {
-        std::string proj_dir_name = projection.name + proj_suffix;
+        std::string proj_dir_name = Projection::dirName(projection.name, false);
         projection_directories.emplace(proj_dir_name);
 
         NameSet files_not_to_remove_for_projection;
@@ -939,7 +1190,8 @@ void DataPartStorageOnDiskBase::remove(
             std::move(files_not_to_remove_for_projection),
         };
 
-        clearDirectory(fs::path(to) / proj_dir_name, proj_description, projection.checksums, is_temp, log);
+        if (auto it = all_projections.find(proj_dir_name); it != all_projections.end())
+            clearDirectory(it->second.destination, proj_description, projection.checksums, is_temp, log);
     }
 
     /// It is possible that we are removing the part which have a written but not loaded projection.
@@ -948,10 +1200,14 @@ void DataPartStorageOnDiskBase::remove(
     /// See test 01701_clear_projection_and_part.
     for (const auto & [name, _] : checksums.files)
     {
-        if (endsWith(name, proj_suffix) && !projection_directories.contains(name))
+        if (Projection::dirNameType(name) == Projection::Status::Live && !projection_directories.contains(name))
         {
+            auto it = all_projections.find(name);
+            if (it == all_projections.end())
+                continue;
+
             static constexpr auto checksums_name = "checksums.txt";
-            auto projection_storage = create(volume, to, name, /*initialize=*/ true);
+            const auto & projection_storage = it->second.storage;
 
             /// If we have a directory with suffix '.proj' it is likely a projection.
             /// Try to load checksums for it (to avoid recursive removing fallback).
@@ -963,7 +1219,7 @@ void DataPartStorageOnDiskBase::remove(
                     auto in = projection_storage->readFile(checksums_name, {}, {});
                     tmp_checksums.read(*in);
 
-                    clearDirectory(fs::path(to) / name, *can_remove_description, tmp_checksums, is_temp, log);
+                    clearDirectory(it->second.destination, *can_remove_description, tmp_checksums, is_temp, log);
                 }
                 catch (...)
                 {
@@ -1014,7 +1270,7 @@ void DataPartStorageOnDiskBase::clearDirectory(
     {
         NameSet names_to_remove = {"checksums.txt", "columns.txt"};
         for (const auto & [file, _] : checksums.files)
-            if (!endsWith(file, ".proj"))
+            if (Projection::dirNameType(file) != Projection::Status::Live)
                 names_to_remove.emplace(file);
 
         names_to_remove = getActualFileNamesOnDisk(names_to_remove);

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.h
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.h
@@ -17,7 +17,30 @@ class PackedFilesWriter;
 class DataPartStorageOnDiskBase : public IDataPartStorage
 {
 public:
-    DataPartStorageOnDiskBase(VolumePtr volume_, std::string root_path_, std::string part_dir_);
+    DataPartStorageOnDiskBase(
+        VolumePtr volume_,
+        std::string root_path_,
+        std::string part_dir_);
+
+    Projections getProjections() const override;
+    void setProjections(Projections projections_) override;
+    using IDataPartStorage::detectProjections; /// keep the no-arg overload visible under the override
+    Projections detectProjections(const ProjectionScan & scan) const override;
+
+    bool hasProjection(const std::string & dir_name) const override;
+    Projection getProjection(const std::string & dir_name) const override;
+    std::optional<Projection> tryGetProjection(const std::string & dir_name) const override;
+    Projection projectionPlacement(const std::string & dir_name, ProjectionStorageFormat format) const override;
+
+    std::pair<std::string, std::string> getProjectionRootAndDir(const std::string & dir_name, ProjectionStorageFormat format) const override;
+    bool existsProjectionDir(const std::string & dir_name, ProjectionStorageFormat format) const override;
+
+    void removeProjection(const Projection & projection) override;
+    Projection renameProjection(const Projection & projection, const std::string & new_dir_name, bool fsync) override;
+    void syncProjectionStoragePath(const Projection & projection, IDataPartStorage & projection_storage) const override;
+    void removeProjectionResidue(const Projection & placement) override;
+
+    void setZeroCopyReplicationEnabled(bool value) override { zero_copy_replication_enabled = value; }
 
     std::string getFullPath() const override;
     std::string getRelativePath() const override;
@@ -125,19 +148,11 @@ public:
     MutableDataPartStoragePtr freeze(
         const std::string & to,
         const std::string & dir_path,
+        const DiskPtr & dst_disk,
         const ReadSettings & read_settings,
         const WriteSettings & write_settings,
         std::function<void(const DiskPtr &)> save_metadata_callback,
         const ClonePartParams & params) const override;
-
-    MutableDataPartStoragePtr freezeRemote(
-    const std::string & to,
-    const std::string & dir_path,
-    const DiskPtr & dst_disk,
-    const ReadSettings & read_settings,
-    const WriteSettings & write_settings,
-    std::function<void(const DiskPtr &)> save_metadata_callback,
-    const ClonePartParams & params) const override;
 
     MutableDataPartStoragePtr clonePart(
         const std::string & to,
@@ -178,8 +193,32 @@ public:
 
 protected:
 
-    DataPartStorageOnDiskBase(VolumePtr volume_, std::string root_path_, std::string part_dir_, DiskTransactionPtr transaction_);
-    virtual MutableDataPartStoragePtr create(VolumePtr volume_, std::string root_path_, std::string part_dir_, bool initialize_) const = 0;
+    DataPartStorageOnDiskBase(
+        VolumePtr volume_,
+        std::string root_path_,
+        std::string part_dir_,
+        DiskTransactionPtr transaction_);
+
+    virtual MutableDataPartStoragePtr create(
+        VolumePtr volume_,
+        std::string root_path_,
+        std::string part_dir_,
+        bool initialize_) const = 0;
+
+    /// Incremental owned-set updates for createProjection/renameProjection/removeProjection; require an already-seeded set.
+    void addProjection(Projection projection_);
+    void dropProjection(const std::string & dir_name);
+
+    /// Descriptor for a READ handle: the owned one if present, else probed from disk across both layouts (a not-owned name is a
+    /// broken/missing projection or a manifest desync). Nested placeholder when absent in both layouts.
+    Projection resolveProjectionForRead(const std::string & dir_name) const;
+
+    /// Shared tail of freeze/clonePart: the copy owns exactly what the source owned (temps are
+    /// transient and not copied), plus the zero-copy flag; entries are re-parented to dest_storage.
+    void seedFrozenCopy(IDataPartStorage & dest_storage) const;
+
+    /// Repoint at a moved location; unlike setRelativePath, content is guaranteed unchanged, so caches stay.
+    void setPathKeepingCaches(std::string new_root_path, std::string new_part_dir);
 
     /// Lazily load the per-part skp_idx.packed archive (if any), reading it as a standalone disk
     /// file. Subsequent calls return the cached reader, or nullptr when there is no such file --
@@ -239,6 +278,15 @@ protected:
     std::string part_dir;
     DiskTransactionPtr transaction;
     bool has_shared_transaction = false;
+
+    /// Zero-copy replication policy; default true keeps residue blobs (fail-safe until seeded).
+    bool zero_copy_replication_enabled = true;
+
+    /// The owned projection set. ready=false: never seeded (reads throw); ready=true: authoritative (absent key = no projection). Paths are
+    /// derived, so only setRelativePath drops it.
+    mutable std::mutex projections_mutex;
+    mutable bool owned_projections_ready TSA_GUARDED_BY(projections_mutex) = false;
+    mutable Projections owned_projections TSA_GUARDED_BY(projections_mutex);
 
     /// Cached probe state for skp_idx.packed. probed=false means we haven't checked the disk yet;
     /// probed=true with reader=null means we checked and the archive isn't present.

--- a/src/Storages/MergeTree/DataPartStorageOnDiskFull.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskFull.cpp
@@ -9,6 +9,7 @@
 #include <IO/WriteBufferFromFileBase.h>
 #include <Interpreters/Context.h>
 #include <Storages/MergeTree/MergeTreeIndicesSerialization.h>
+#include <Common/logger_useful.h>
 #include <Common/typeid_cast.h>
 
 namespace DB
@@ -19,34 +20,65 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-DataPartStorageOnDiskFull::DataPartStorageOnDiskFull(VolumePtr volume_, std::string root_path_, std::string part_dir_)
+DataPartStorageOnDiskFull::DataPartStorageOnDiskFull(
+    VolumePtr volume_,
+    std::string root_path_,
+    std::string part_dir_)
     : DataPartStorageOnDiskBase(std::move(volume_), std::move(root_path_), std::move(part_dir_))
 {
 }
 
 DataPartStorageOnDiskFull::DataPartStorageOnDiskFull(
-    VolumePtr volume_, std::string root_path_, std::string part_dir_, DiskTransactionPtr transaction_)
-    : DataPartStorageOnDiskBase(std::move(volume_), std::move(root_path_), std::move(part_dir_), std::move(transaction_))
+    VolumePtr volume_,
+    std::string root_path_,
+    std::string part_dir_,
+    DiskTransactionPtr transaction_)
+    : DataPartStorageOnDiskBase(
+        std::move(volume_), std::move(root_path_), std::move(part_dir_), std::move(transaction_))
 {
 }
 
 MutableDataPartStoragePtr DataPartStorageOnDiskFull::create(
-    VolumePtr volume_, std::string root_path_, std::string part_dir_, bool /*initialize_*/) const
+    VolumePtr volume_,
+    std::string root_path_,
+    std::string part_dir_,
+    bool /*initialize_*/) const
 {
-    return std::make_shared<DataPartStorageOnDiskFull>(std::move(volume_), std::move(root_path_), std::move(part_dir_));
+    return std::make_shared<DataPartStorageOnDiskFull>(
+        std::move(volume_), std::move(root_path_), std::move(part_dir_));
 }
 
-MutableDataPartStoragePtr DataPartStorageOnDiskFull::getProjection(const std::string & name, bool use_parent_transaction) // NOLINT
+MutableDataPartStoragePtr DataPartStorageOnDiskFull::getProjectionStorage(const std::string & dir_name, bool use_parent_transaction) // NOLINT
 {
-    /// Not arena-scoped: most callers use this only as a short-lived filesystem handle (CHECK TABLE,
-    /// mutation hardlink/copy, existence probes). The part-lifetime projection storage is created via
-    /// `getProjectionPartBuilder`, which scopes the arena itself.
-    return std::shared_ptr<DataPartStorageOnDiskFull>(new DataPartStorageOnDiskFull(volume, std::string(fs::path(root_path) / part_dir), name, use_parent_transaction ? transaction : nullptr));
+    /// Resolves the dir path without registering it (dirs are created only via createProjection). Short-lived FS handle
+    /// (CHECK TABLE, mutation copy, existence probes); part-lifetime storage comes from getProjectionPartBuilder, which scopes the arena.
+    const auto projection = resolveProjectionForRead(dir_name);
+
+    auto [proj_root, proj_dir] = getProjectionRootAndDir(projection.dirName(), projection.format);
+    auto projection_storage = std::shared_ptr<DataPartStorageOnDiskFull>(new DataPartStorageOnDiskFull(
+        volume,
+        std::move(proj_root),
+        std::move(proj_dir),
+        use_parent_transaction ? transaction : nullptr));
+    projection_storage->zero_copy_replication_enabled = zero_copy_replication_enabled;
+    /// A projection sub-part owns no projections of its own.
+    projection_storage->setProjections({});
+    return projection_storage;
 }
 
-DataPartStoragePtr DataPartStorageOnDiskFull::getProjection(const std::string & name) const
+DataPartStoragePtr DataPartStorageOnDiskFull::getProjectionStorage(const std::string & dir_name) const
 {
-    return std::make_shared<DataPartStorageOnDiskFull>(volume, std::string(fs::path(root_path) / part_dir), name);
+    /// See the mutable overload.
+    const auto projection = resolveProjectionForRead(dir_name);
+
+    auto [proj_root, proj_dir] = getProjectionRootAndDir(projection.dirName(), projection.format);
+    auto projection_storage = std::make_shared<DataPartStorageOnDiskFull>(
+        volume,
+        std::move(proj_root),
+        std::move(proj_dir));
+    projection_storage->zero_copy_replication_enabled = zero_copy_replication_enabled;
+    projection_storage->setProjections({});
+    return projection_storage;
 }
 
 bool DataPartStorageOnDiskFull::exists() const
@@ -232,9 +264,16 @@ void DataPartStorageOnDiskFull::copyFileFrom(const IDataPartStorage & source, co
         getReadSettings());
 }
 
-void DataPartStorageOnDiskFull::createProjection(const std::string & name)
+IDataPartStorage::Projection DataPartStorageOnDiskFull::createProjection(const std::string & dir_name, ProjectionStorageFormat format)
 {
-    executeWriteOperation([&](auto & disk) { disk.createDirectory(fs::path(root_path) / part_dir / name); });
+    auto projection = projectionPlacement(dir_name, format);
+
+    /// A leftover directory is residue of a failed operation on a same-named part (tmp part names repeat).
+    removeProjectionResidue(projection);
+
+    executeWriteOperation([&](auto & disk) { disk.createDirectory(projection.relativePath()); });
+    addProjection(projection);
+    return projection;
 }
 
 void DataPartStorageOnDiskFull::beginTransaction()

--- a/src/Storages/MergeTree/DataPartStorageOnDiskFull.h
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskFull.h
@@ -9,11 +9,15 @@ namespace DB
 class DataPartStorageOnDiskFull final : public DataPartStorageOnDiskBase
 {
 public:
-    DataPartStorageOnDiskFull(VolumePtr volume_, std::string root_path_, std::string part_dir_);
+    DataPartStorageOnDiskFull(
+        VolumePtr volume_,
+        std::string root_path_,
+        std::string part_dir_);
+
     MergeTreeDataPartStorageType getType() const override { return MergeTreeDataPartStorageType::Full; }
 
-    MutableDataPartStoragePtr getProjection(const std::string & name, bool use_parent_transaction = true) override; // NOLINT
-    DataPartStoragePtr getProjection(const std::string & name) const override;
+    MutableDataPartStoragePtr getProjectionStorage(const std::string & dir_name, bool use_parent_transaction) override; /// NOLINT
+    DataPartStoragePtr getProjectionStorage(const std::string & dir_name) const override;
 
     bool exists() const override;
     bool existsDirectory(const std::string & name) const override;
@@ -25,7 +29,7 @@ public:
     std::vector<std::string> getRemotePaths(const std::string & file_name) const override;
     String getUniqueId() const override;
 
-    void createProjection(const std::string & name) override;
+    Projection createProjection(const std::string & dir_name, ProjectionStorageFormat format) override;
 
     std::unique_ptr<WriteBufferFromFileBase> writeFile(
         const String & name,
@@ -55,8 +59,17 @@ public:
 #endif
 
 private:
-    DataPartStorageOnDiskFull(VolumePtr volume_, std::string root_path_, std::string part_dir_, DiskTransactionPtr transaction_);
-    MutableDataPartStoragePtr create(VolumePtr volume_, std::string root_path_, std::string part_dir_, bool initialize_) const override;
+    DataPartStorageOnDiskFull(
+        VolumePtr volume_,
+        std::string root_path_,
+        std::string part_dir_,
+        DiskTransactionPtr transaction_);
+
+    MutableDataPartStoragePtr create(
+        VolumePtr volume_,
+        std::string root_path_,
+        std::string part_dir_,
+        bool initialize_) const override;
 
     NameSet getActualFileNamesOnDisk(const NameSet & file_names) const override { return file_names; }
 

--- a/src/Storages/MergeTree/DataPartStorageOnDiskPacked.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskPacked.cpp
@@ -61,19 +61,39 @@ MutableDataPartStoragePtr DataPartStorageOnDiskPacked::create(
     return std::make_shared<DataPartStorageOnDiskPacked>(std::move(volume_), std::move(root_path_), std::move(part_dir_), getReadSettings(), initialize_);
 }
 
-MutableDataPartStoragePtr DataPartStorageOnDiskPacked::getProjection(const std::string & name, bool use_parent_transaction) // NOLINT
+MutableDataPartStoragePtr DataPartStorageOnDiskPacked::getProjectionStorage(const std::string & dir_name, bool use_parent_transaction) // NOLINT
 {
-    return std::shared_ptr<DataPartStorageOnDiskPacked>(new DataPartStorageOnDiskPacked(volume, fs::path(root_path) / part_dir, name, use_parent_transaction ? transaction : nullptr, getReadSettings()));
+    /// Not owned: resolve where the dir would live (e.g. a broken-projection placeholder) without registering anything; directories come
+    /// into existence only through createProjection.
+    const auto projection = resolveProjectionForRead(dir_name);
+
+    auto [proj_root, proj_dir] = getProjectionRootAndDir(projection.dirName(), projection.format);
+    auto projection_storage = std::shared_ptr<DataPartStorageOnDiskPacked>(new DataPartStorageOnDiskPacked(
+        volume,
+        std::move(proj_root),
+        std::move(proj_dir),
+        use_parent_transaction ? transaction : nullptr,
+        getReadSettings()));
+    projection_storage->zero_copy_replication_enabled = zero_copy_replication_enabled;
+    /// A projection sub-part owns no projections of its own.
+    projection_storage->setProjections({});
+    return projection_storage;
 }
 
-MutableDataPartStoragePtr DataPartStorageOnDiskPacked::getProjectionNoInitialize(const std::string & name, bool use_parent_transaction) // NOLINT
+DataPartStoragePtr DataPartStorageOnDiskPacked::getProjectionStorage(const std::string & dir_name) const
 {
-    return std::shared_ptr<DataPartStorageOnDiskPacked>(new DataPartStorageOnDiskPacked(volume, fs::path(root_path) / part_dir, name, use_parent_transaction ? transaction : nullptr, getReadSettings(), false));
-}
+    /// See the mutable overload.
+    const auto projection = resolveProjectionForRead(dir_name);
 
-DataPartStoragePtr DataPartStorageOnDiskPacked::getProjection(const std::string & name) const
-{
-    return std::make_shared<DataPartStorageOnDiskPacked>(volume, std::string(fs::path(root_path) / part_dir), name, getReadSettings());
+    auto [proj_root, proj_dir] = getProjectionRootAndDir(projection.dirName(), projection.format);
+    auto projection_storage = std::make_shared<DataPartStorageOnDiskPacked>(
+        volume,
+        std::move(proj_root),
+        std::move(proj_dir),
+        getReadSettings());
+    projection_storage->zero_copy_replication_enabled = zero_copy_replication_enabled;
+    projection_storage->setProjections({});
+    return projection_storage;
 }
 
 bool DataPartStorageOnDiskPacked::exists() const
@@ -509,9 +529,16 @@ void DataPartStorageOnDiskPacked::copyFileFrom(const IDataPartStorage &, const s
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "DataPartStorageOnDiskPacked does not support copying files");
 }
 
-void DataPartStorageOnDiskPacked::createProjection(const std::string & name)
+IDataPartStorage::Projection DataPartStorageOnDiskPacked::createProjection(const std::string & dir_name, ProjectionStorageFormat format)
 {
-    executeWriteOperation([&](auto & disk) { disk.createDirectory(fs::path(root_path) / part_dir / name); });
+    auto projection = projectionPlacement(dir_name, format);
+
+    /// A leftover directory is residue of a failed operation on a same-named part (tmp part names repeat).
+    removeProjectionResidue(projection);
+
+    executeWriteOperation([&](auto & disk) { disk.createDirectory(projection.relativePath()); });
+    addProjection(projection);
+    return projection;
 }
 
 void DataPartStorageOnDiskPacked::beginTransaction()
@@ -861,152 +888,16 @@ String DataPartStorageOnDiskPacked::getActualFileNameOnDisk(const String & file_
 MutableDataPartStoragePtr DataPartStorageOnDiskPacked::freeze(
     const std::string & to,
     const std::string & dir_path,
-    const ReadSettings & read_settings,
-    const WriteSettings & write_settings,
-    std::function<void(const DiskPtr &)> save_metadata_callback,
-    const ClonePartParams & params) const
-{
-    auto disk = volume->getDisk();
-    auto src_disk = volume->getDisk();
-
-    auto single_disk_volume = std::make_shared<SingleDiskVolume>(disk->getName(), disk, 0);
-
-    std::shared_ptr<DataPartStorageOnDiskPacked> dest_storage;
-
-    bool to_detached = dir_path.starts_with(std::string_view((fs::path(MergeTreeData::DETACHED_DIR_NAME) / "").string()));
-    if (params.external_transaction)
-    {
-        dest_storage = std::shared_ptr<DataPartStorageOnDiskPacked>(new DataPartStorageOnDiskPacked(single_disk_volume, to, dir_path, params.external_transaction, read_settings));
-        params.external_transaction->createDirectories(dest_storage->getRelativePath());
-    }
-    else
-    {
-        dest_storage = std::make_shared<DataPartStorageOnDiskPacked>(single_disk_volume, to, dir_path, read_settings, !to_detached);
-        disk->createDirectories(dest_storage->getRelativePath());
-    }
-
-
-    bool need_commit = false;
-    if (!to_detached && (params.copy_instead_of_hardlink || cloneCopiesWholeArchive(params)))
-    {
-        if (!dest_storage->transaction)
-        {
-            dest_storage->beginTransaction();
-            need_commit = true;
-        }
-
-        auto files = reader->getFileNames();
-        bool metadata_version_emitted = false;
-        for (const auto & file : files)
-        {
-            if (file == IMergeTreeDataPart::METADATA_VERSION_FILE_NAME)
-            {
-                /// An explicit version override takes precedence over both keeping and dropping the
-                /// original, and must be honored regardless of keep_metadata_version (a caller that
-                /// relies on freeze to persist the destination version passes it with
-                /// keep_metadata_version = false).
-                if (params.metadata_version_to_write.has_value())
-                {
-                    auto write_buf = dest_storage->writeFile(file, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite, write_settings);
-                    writeIntText(*params.metadata_version_to_write, *write_buf);
-                    write_buf->finalize();
-                    metadata_version_emitted = true;
-                    continue;
-                }
-
-                /// No override: drop the version only when the caller does not want to keep it;
-                /// otherwise copy the original through the generic path below.
-                if (!params.keep_metadata_version)
-                    continue;
-            }
-
-            auto read_buf = reader->readFile(volume->getDisk(), getRelativeDataPath(), file, read_settings, {});
-            auto write_buf = dest_storage->writeFile(file, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite, write_settings);
-            copyData(*read_buf, *write_buf);
-            write_buf->finalize();
-        }
-
-        /// A caller that relies on freeze to persist the destination metadata version passes
-        /// metadata_version_to_write with keep_metadata_version = false. An old source part may have no
-        /// metadata_version.txt in its archive at all (loadPartAndFixMetadataImpl treats that as the
-        /// "very old part" case), so the loop above never reached the override branch. Create the file
-        /// here so the requested version is persisted regardless of whether the source archive had one.
-        if (params.metadata_version_to_write.has_value() && !metadata_version_emitted)
-        {
-            auto write_buf = dest_storage->writeFile(
-                IMergeTreeDataPart::METADATA_VERSION_FILE_NAME, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite, write_settings);
-            writeIntText(*params.metadata_version_to_write, *write_buf);
-            write_buf->finalize();
-        }
-    }
-    else if (disk->existsFile(getRelativeDataPath()))
-    {
-        /// Decide copy-vs-hardlink before transaction-vs-direct (mirrors the generic Backup path). A
-        /// detached clone of a zero-copy part sets copy_instead_of_hardlink so the detached part gets an
-        /// independent blob; the zero-copy bookkeeping then does not record hardlinks. Hardlinking
-        /// data.packed here (detached clones always arrive with an external transaction) would leave the
-        /// detached clone sharing an untracked blob that removing the source can delete. Honor the copy
-        /// request even inside an external transaction. anyArchivedFileRequestedForCopy covers a caller
-        /// that lists an archived file in files_to_copy_instead_of_hardlinks to get a fresh blob.
-        if (params.copy_instead_of_hardlink || anyArchivedFileRequestedForCopy(params.files_to_copy_instead_of_hardlinks))
-        {
-            if (params.external_transaction)
-                params.external_transaction->copyFile(getRelativeDataPath(), dest_storage->getRelativeDataPath(), read_settings, write_settings);
-            else
-                disk->copyFile(getRelativeDataPath(), *disk, dest_storage->getRelativeDataPath(), read_settings);
-        }
-        else if (params.external_transaction)
-            params.external_transaction->createHardLink(getRelativeDataPath(), dest_storage->getRelativeDataPath());
-        else
-            disk->createHardLink(getRelativeDataPath(), dest_storage->getRelativeDataPath());
-    }
-
-    IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*dest_storage, "", params.invalidated_columns_to_write, write_settings);
-
-    std::vector<std::string> all_files;
-    src_disk->listFiles(getRelativePath(), all_files);
-    for (const auto & file : all_files)
-    {
-         if (src_disk->existsDirectory(fs::path(getRelativePath()) / file))
-         {
-             auto projection_storage = getProjection(file);
-             auto params_copy = params;
-             params_copy.external_transaction = dest_storage->transaction;
-             /// The top-level fsync below covers the whole subtree; don't let each projection re-walk it.
-             params_copy.fsync_part_directory = false;
-             projection_storage->freeze(dest_storage->getRelativePath(), file, read_settings, write_settings, save_metadata_callback, params_copy);
-         }
-    }
-
-    if (need_commit)
-        dest_storage->commitTransaction();
-    else if (dest_storage->writer)
-        dest_storage->finalizeWriter();
-
-    if (!params.external_transaction && !to_detached)
-        dest_storage->resetReader(getReadSettings());
-
-    if (save_metadata_callback)
-        save_metadata_callback(disk);
-
-    /// Make the clone durable before the caller commits the covering part, same as the Full-storage
-    /// override (the hardlink/copy above fsyncs nothing). Runs once for the whole subtree here.
-    if (params.fsync_part_directory && !params.external_transaction && !disk->isRemote())
-        fsyncFrozenCloneTree(*disk, fs::path(to) / dir_path);
-
-    return dest_storage;
-}
-
-MutableDataPartStoragePtr DataPartStorageOnDiskPacked::freezeRemote(
-    const std::string & to,
-    const std::string & dir_path,
-    const DiskPtr & dst_disk,
+    const DiskPtr & dst_disk_,
     const ReadSettings & read_settings,
     const WriteSettings & write_settings,
     std::function<void(const DiskPtr &)> save_metadata_callback,
     const ClonePartParams & params) const
 {
     auto src_disk = volume->getDisk();
+    /// dst_disk == nullptr means the part's own disk; a different disk cannot hardlink, so it always copies.
+    auto dst_disk = dst_disk_ ? dst_disk_ : src_disk;
+    const bool same_disk = dst_disk == src_disk;
 
     auto single_disk_volume = std::make_shared<SingleDiskVolume>(dst_disk->getName(), dst_disk, 0);
 
@@ -1034,8 +925,6 @@ MutableDataPartStoragePtr DataPartStorageOnDiskPacked::freezeRemote(
         }
 
         auto files = reader->getFileNames();
-        std::vector<std::string> all_files;
-        src_disk->listFiles(getRelativePath(), all_files);
         bool metadata_version_emitted = false;
         for (const auto & file : files)
         {
@@ -1081,40 +970,64 @@ MutableDataPartStoragePtr DataPartStorageOnDiskPacked::freezeRemote(
     }
     else if (src_disk->existsFile(getRelativeDataPath()))
     {
-        if (params.external_transaction)
+        /// Decide copy-vs-hardlink before transaction-vs-direct (mirrors the generic Backup path). Same
+        /// disk can hardlink the whole archive; a different disk (dst_disk != src_disk) can never hardlink
+        /// and must copy. A detached clone of a zero-copy part sets copy_instead_of_hardlink so the
+        /// detached part gets an independent blob; the zero-copy bookkeeping then does not record
+        /// hardlinks. Hardlinking data.packed here (detached clones always arrive with an external
+        /// transaction) would leave the detached clone sharing an untracked blob that removing the source
+        /// can delete. Honor the copy request even inside an external transaction.
+        /// anyArchivedFileRequestedForCopy covers a caller that lists an archived file in
+        /// files_to_copy_instead_of_hardlinks to get a fresh blob.
+        const bool must_copy = !same_disk
+            || params.copy_instead_of_hardlink
+            || anyArchivedFileRequestedForCopy(params.files_to_copy_instead_of_hardlinks);
+        if (must_copy)
         {
-            if (dst_disk->getDataSourceDescription() == src_disk->getDataSourceDescription() && dst_disk->getMetadataStorage().get() == src_disk->getMetadataStorage().get())
+            if (params.external_transaction)
             {
-                params.external_transaction->copyFile(getRelativeDataPath(), dest_storage->getRelativeDataPath(), read_settings, write_settings);
+                if (dst_disk->getDataSourceDescription() == src_disk->getDataSourceDescription()
+                    && dst_disk->getMetadataStorage().get() == src_disk->getMetadataStorage().get())
+                {
+                    params.external_transaction->copyFile(getRelativeDataPath(), dest_storage->getRelativeDataPath(), read_settings, write_settings);
+                }
+                else
+                {
+                    /// Transactions don't support copy between different metadata storages, so do it manually.
+                    auto write_buf = dest_storage->transaction->writeFile(dest_storage->getRelativeDataPath(), DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite, write_settings);
+                    auto read_buf = src_disk->readFile(getRelativeDataPath(), read_settings);
+                    copyData(*read_buf, *write_buf);
+                    write_buf->finalize();
+                }
             }
             else
             {
-                /// Transactions doesn't support copy between different metadata storages, so doing it manually
-                auto write_buf = dest_storage->transaction->writeFile(dest_storage->getRelativeDataPath(), DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite, write_settings);
-                auto read_buf = src_disk->readFile(getRelativeDataPath(), read_settings);
-                copyData(*read_buf, *write_buf);
-                write_buf->finalize();
+                src_disk->copyFile(getRelativeDataPath(), *dst_disk, dest_storage->getRelativeDataPath(), read_settings, write_settings);
             }
         }
+        else if (params.external_transaction)
+            params.external_transaction->createHardLink(getRelativeDataPath(), dest_storage->getRelativeDataPath());
         else
-        {
-            src_disk->copyFile(getRelativeDataPath(), *dst_disk, dest_storage->getRelativeDataPath(), read_settings, write_settings);
-        }
+            dst_disk->createHardLink(getRelativeDataPath(), dest_storage->getRelativeDataPath());
     }
 
     IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*dest_storage, "", params.invalidated_columns_to_write, write_settings);
 
-    std::vector<std::string> all_files;
-    src_disk->listFiles(getRelativePath(), all_files);
-    for (const auto & file : all_files)
+    /// Nested projections recurse from the owned set, not from a disk walk of the part dir: residue
+    /// and temp dirs of an unrelated same-named part must not be carried into the copy.
+    for (const auto & [projection_dir, projection] : getProjections())
     {
-         if (src_disk->existsDirectory(fs::path(getRelativePath()) / file))
-         {
-             auto projection_storage = getProjection(file);
-             auto params_copy = params;
-             params_copy.external_transaction = dest_storage->transaction;
-             projection_storage->freezeRemote(dest_storage->getRelativePath(), file, dst_disk, read_settings, write_settings, save_metadata_callback, params_copy);
-         }
+        if (projection.is_temp)
+            continue;
+
+        auto projection_storage = getProjectionStorage(projection_dir);
+        /// The child keeps the parent's archive copy-vs-hardlink decision: blob tracking in cloneAndLoadDataPart keys on it.
+        auto child_params = params.forProjection(
+            dest_storage->transaction, params.copy_instead_of_hardlink || cloneCopiesWholeArchive(params));
+        child_params.fsync_part_directory = false;  /// the single top-level fsync below covers the whole subtree
+        projection_storage->freeze(
+            dest_storage->getRelativePath(), projection_dir, dst_disk_, read_settings, write_settings,
+            /*save_metadata_callback=*/ {}, child_params);
     }
 
     if (need_commit)
@@ -1122,11 +1035,17 @@ MutableDataPartStoragePtr DataPartStorageOnDiskPacked::freezeRemote(
     else if (dest_storage->writer)
         dest_storage->finalizeWriter();
 
-    if (!params.external_transaction)
+    if (!params.external_transaction && (!same_disk || !to_detached))
         dest_storage->resetReader(getReadSettings());
 
     if (save_metadata_callback)
         save_metadata_callback(dst_disk);
+
+    /// Durability graft from master #111426: one fsync for the whole subtree (children set false above).
+    if (params.fsync_part_directory && !params.external_transaction && !dst_disk->isRemote())
+        fsyncFrozenCloneTree(*dst_disk, fs::path(to) / dir_path);
+
+    seedFrozenCopy(*dest_storage);
 
     return dest_storage;
 }

--- a/src/Storages/MergeTree/DataPartStorageOnDiskPacked.h
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskPacked.h
@@ -33,9 +33,8 @@ public:
 
     MergeTreeDataPartStorageType getType() const override { return MergeTreeDataPartStorageType::Packed; }
 
-    MutableDataPartStoragePtr getProjection(const std::string & name, bool use_parent_transaction = true) override; // NOLINT
-    MutableDataPartStoragePtr getProjectionNoInitialize(const std::string & name, bool use_parent_transaction = true) override; // NOLINT
-    DataPartStoragePtr getProjection(const std::string & name) const override;
+    MutableDataPartStoragePtr getProjectionStorage(const std::string & dir_name, bool use_parent_transaction) override; // NOLINT
+    DataPartStoragePtr getProjectionStorage(const std::string & dir_name) const override;
 
     bool exists() const override;
     bool existsDirectory(const std::string & file_name) const override;
@@ -56,7 +55,7 @@ public:
         bool remove_new_dir_if_exists,
         bool fsync_part_dir) override;
 
-    void createProjection(const std::string & name) override;
+    Projection createProjection(const std::string & dir_name, ProjectionStorageFormat format) override;
 
     void changeRootPath(const std::string & from_root, const std::string & to_root) override;
 
@@ -95,14 +94,6 @@ public:
     bool cloneCopiesWholeArchive(const ClonePartParams & params) const override;
 
     MutableDataPartStoragePtr freeze(
-        const std::string & to,
-        const std::string & dir_path,
-        const ReadSettings & read_settings,
-        const WriteSettings & write_settings,
-        std::function<void(const DiskPtr &)> save_metadata_callback,
-        const ClonePartParams & params) const override;
-
-    MutableDataPartStoragePtr freezeRemote(
         const std::string & to,
         const std::string & dir_path,
         const DiskPtr & dst_disk,

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -249,7 +249,7 @@ MergeTreeData::DataPart::Checksums Service::sendPartFromDisk(
 
     for (const auto & [name, _] : part->checksums.files)
     {
-        if (endsWith(name, ".proj"))
+        if (IDataPartStorage::Projection::dirNameType(name) == IDataPartStorage::Projection::Status::Live)
             continue;
 
         files_to_replicate.insert(name);
@@ -297,13 +297,13 @@ MergeTreeData::DataPart::Checksums Service::sendPartFromDisk(
         {
             writeStringBinary(name, out);
             MergeTreeData::DataPart::Checksums projection_checksum = sendPartFromDisk(projection, out, client_protocol_version, from_remote_disk, false);
-            data_checksums.addFile(name + ".proj", projection_checksum.getTotalSizeOnDisk(), projection_checksum.getTotalChecksumUInt128());
+            data_checksums.addFile(IDataPartStorage::Projection::dirName(name, false), projection_checksum.getTotalSizeOnDisk(), projection_checksum.getTotalChecksumUInt128());
         }
-        else if (part->checksums.has(name + ".proj"))
+        else if (part->checksums.has(IDataPartStorage::Projection::dirName(name, false)))
         {
             // We don't send this projection, just add out checksum to bypass the following check
-            const auto & our_checksum = part->checksums.files.find(name + ".proj")->second;
-            data_checksums.addFile(name + ".proj", our_checksum.file_size, our_checksum.file_hash);
+            const auto & our_checksum = part->checksums.files.find(IDataPartStorage::Projection::dirName(name, false))->second;
+            data_checksums.addFile(IDataPartStorage::Projection::dirName(name, false), our_checksum.file_size, our_checksum.file_hash);
         }
     }
 
@@ -313,7 +313,7 @@ MergeTreeData::DataPart::Checksums Service::sendPartFromDisk(
     /// data_checksums so that checkEqual below does not fail.
     for (const auto & [name, checksum] : part->checksums.files)
     {
-        if (name.ends_with(".proj") && !data_checksums.has(name))
+        if (IDataPartStorage::Projection::dirNameType(name) == IDataPartStorage::Projection::Status::Live && !data_checksums.has(name))
             data_checksums.addFile(name, checksum.file_size, checksum.file_hash);
     }
 
@@ -826,6 +826,8 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
         ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
         auto v = std::make_shared<SingleDiskVolume>("volume_" + part_name, disk);
         auto s = std::make_shared<DataPartStorageOnDiskFull>(v, part_relative_path, part_dir);
+        s->setZeroCopyReplicationEnabled((*data_settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication]);
+        s->setProjections({});
         return std::pair{std::move(v), std::move(s)};
     }();
 
@@ -861,7 +863,7 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
             String projection_name;
             readStringBinary(projection_name, in);
 
-            /// Validate before getProjection()/createDirectories() so no attacker-named
+            /// Validate before getProjectionStorage()/createDirectories() so no attacker-named
             /// directory is ever created from an untrusted replica's projection name.
             if (!isProjectionNameSafe(projection_name))
                 throw Exception(ErrorCodes::INSECURE_PATH,
@@ -871,14 +873,15 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
 
             MergeTreeData::DataPart::Checksums projection_checksum;
 
-            auto projection_part_storage = part_storage_for_loading->getProjection(projection_name + ".proj");
-            projection_part_storage->createDirectories();
+            /// Fetched projection dirs don't exist yet; create them in this replica's configured layout.
+            part_storage_for_loading->createProjection(IDataPartStorage::Projection::dirName(projection_name, false), data.getProjectionStorageFormat());
+            auto projection_part_storage = part_storage_for_loading->getProjectionStorage(IDataPartStorage::Projection::dirName(projection_name, false), true);
 
             downloadBaseOrProjectionPartToDisk(
                 replica_path, projection_part_storage, in, output_buffer_getter, projection_checksum, throttler, sync);
 
             data_checksums.addFile(
-                projection_name + ".proj", projection_checksum.getTotalSizeOnDisk(), projection_checksum.getTotalChecksumUInt128());
+                IDataPartStorage::Projection::dirName(projection_name, false), projection_checksum.getTotalSizeOnDisk(), projection_checksum.getTotalChecksumUInt128());
         }
 
         downloadBaseOrProjectionPartToDisk(
@@ -946,7 +949,7 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
             /// not fail.
             for (const auto & [name, checksum] : new_data_part->checksums.files)
             {
-                if (name.ends_with(".proj") && !data_checksums.has(name))
+                if (IDataPartStorage::Projection::dirNameType(name) == IDataPartStorage::Projection::Status::Live && !data_checksums.has(name))
                     data_checksums.addFile(name, checksum.file_size, checksum.file_hash);
             }
             new_data_part->checksums.checkEqual(data_checksums, false, new_data_part->name);
@@ -964,7 +967,7 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
             /// entries from the expected checksums when throw_on_broken_projection is false. Genuine
             /// base-file corruption still fails checkEqual, so it is left to propagate.
             bool is_broken_projection = false;
-            auto computed_checksums = checkDataPart(new_data_part, /*require_checksums=*/ true, is_broken_projection);
+            auto check_result = checkDataPart(new_data_part, /*require_checksums=*/ true, is_broken_projection);
 
             /// checkDataPart returns an empty result (instead of throwing) when it hits a retryable error
             /// such as a transient read or memory-limit exception, expecting the check to be retried
@@ -972,7 +975,7 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
             /// result means the archive contents were never verified. Fail the fetch so it is retried
             /// rather than accepting a possibly-corrupted packed part. (A real part always has files, so a
             /// genuine part never yields empty checksums here.)
-            if (computed_checksums.empty())
+            if (check_result.computed_checksums.empty())
                 throw Exception(
                     ErrorCodes::ABORTED,
                     "Could not verify packed part {} on fetch (checksum computation was skipped because of a "

--- a/src/Storages/MergeTree/IDataPartStorage.h
+++ b/src/Storages/MergeTree/IDataPartStorage.h
@@ -9,8 +9,11 @@
 #include <base/types.h>
 #include <Common/TransactionID.h>
 
+#include <filesystem>
+#include <map>
 #include <memory>
 #include <optional>
+#include <string_view>
 
 #include <boost/core/noncopyable.hpp>
 #include <Poco/Timestamp.h>
@@ -100,6 +103,53 @@ public:
 
     virtual MergeTreeDataPartStorageType getType() const = 0;
 
+    struct Projection
+    {
+        /// A projection directory's status, classified from its name.
+        enum class Status : uint8_t
+        {
+            None,
+            Live,
+            Temp,
+        };
+
+        /// On-disk layout of a projection sub-part: LEGACY_NESTED = <root>/<part_dir>/<name>.proj (the only layout today;
+        /// kept as an explicit parameter so alternative layouts can be added without reworking the API). NONE = not configured yet.
+        enum class StorageFormat : uint8_t
+        {
+            NONE,
+            LEGACY_NESTED,
+        };
+
+        const IDataPartStorage * parent = nullptr;
+        String name;                    /// bare logical name: "p", "p_1" -- no extension
+        StorageFormat format = StorageFormat::NONE;
+        bool is_temp = false;
+
+        /// "p.proj" / "p_1.tmp_proj" -- the logical key used across the codebase.
+        String dirName() const { return dirName(name, is_temp); }
+        /// Root the dir lives in, relative to the disk (layout-dependent).
+        String rootPath() const;
+        /// rootPath()/physical dir name.
+        String relativePath() const;
+        /// Live disk probe via the parent.
+        bool exists() const;
+
+        static String ext() { return ".proj"; }
+        static String extTmp() { return ".tmp_proj"; }
+        static String dirName(const String & name_, bool is_temp_) { return name_ + (is_temp_ ? extTmp() : ext()); }
+
+        /// Classifies a directory basename: "*.proj" -> Live, "*.tmp_proj" -> Temp, else None.
+        static Status dirNameType(std::string_view dir_name);
+
+    };
+
+    /// Key: dirName() -- the same string stored in checksums and passed to getProjectionStorage.
+    using Projections = std::map<String, Projection, std::less<>>;
+
+    /// Compatibility alias: the enum lives on Projection so both the descriptor and the storage share it.
+    using ProjectionStorageFormat = Projection::StorageFormat;
+
     /// Methods to get path components of a data part.
     virtual std::string getFullPath() const = 0;         /// '/var/lib/clickhouse/data/database/table/moving/all_1_5_1'
     virtual std::string getRelativePath() const = 0;     ///                          'database/table/moving/all_1_5_1'
@@ -109,15 +159,48 @@ public:
     /// Can add it if needed                             ///                          'database/table/moving'
     /// virtual std::string getRelativeRootPath() const = 0;
 
-    /// Get a storage for projection.
-    virtual std::shared_ptr<IDataPartStorage> getProjection(const std::string & name, bool use_parent_transaction = true) = 0; // NOLINT
+    /// The owned projection set. Throws LOGICAL_ERROR if never seeded (won't silently disk-scan a same-named part's residue).
+    virtual Projections getProjections() const = 0;
 
-    virtual std::shared_ptr<IDataPartStorage> getProjectionNoInitialize(const std::string & name, bool use_parent_transaction = true) // NOLINT
+    /// Atomically replace the owned set (entries are re-parented to this storage); {} is a valid set.
+    virtual void setProjections(Projections projections) = 0;
+
+    /// Disk scan of on-disk projection dirs (residue included); does not touch the owned set. Disk-truth paths only.
+    /// candidates: stat just these dirName()s; else a full listing of the part dir.
+    struct ProjectionScan
     {
-        return getProjection(name, use_parent_transaction);
-    }
+        std::optional<Strings> candidates = std::nullopt;
+    };
+    virtual Projections detectProjections(const ProjectionScan & scan) const = 0;
+    /// Full-scan convenience (default args are disallowed on virtuals).
+    Projections detectProjections() const { return detectProjections(ProjectionScan{}); }
 
-    virtual std::shared_ptr<const IDataPartStorage> getProjection(const std::string & name) const = 0;
+    /// Owned-set membership by dirName().
+    virtual bool hasProjection(const std::string & dir_name) const = 0;
+
+    /// Owned descriptor; throws LOGICAL_ERROR if unknown.
+    virtual Projection getProjection(const std::string & dir_name) const = 0;
+    virtual std::optional<Projection> tryGetProjection(const std::string & dir_name) const = 0;
+
+    /// "Where would it live": descriptor for a name in the given layout; registers nothing.
+    virtual Projection projectionPlacement(const std::string & dir_name, ProjectionStorageFormat format) const = 0;
+
+    /// {disk-relative root, physical dir basename} of a (hypothetical) projection dir; the layout arithmetic behind Projection's accessors.
+    /// Absolute path for logging = getDiskPath()/root/dir.
+    virtual std::pair<std::string, std::string> getProjectionRootAndDir(const std::string & dir_name, ProjectionStorageFormat format) const = 0;
+    virtual bool existsProjectionDir(const std::string & dir_name, ProjectionStorageFormat format) const = 0;
+
+    /// Whether the table runs zero-copy replication (blobs may be shared cross-replica, invisible to the local refcount).
+    /// Default true is fail-safe: residue sweeps keep remote blobs.
+    virtual void setZeroCopyReplicationEnabled(bool value) = 0;
+
+    /// Sub-part storage bound to the projection's directory.
+    virtual std::shared_ptr<IDataPartStorage> getProjectionStorage(const std::string & dir_name, bool use_parent_transaction = true) = 0; // NOLINT
+    virtual std::shared_ptr<const IDataPartStorage> getProjectionStorage(const std::string & dir_name) const = 0;
+
+    /// Writable storage for a projection this storage owns; requires the descriptor produced by
+    /// createProjection (throws LOGICAL_ERROR otherwise), so a writer never builds over an unswept dir.
+    std::shared_ptr<IDataPartStorage> getProjectionStorageForWrite(const Projection & placement, bool use_parent_transaction = true); // NOLINT
 
     /// Part directory exists.
     virtual bool exists() const = 0;
@@ -243,6 +326,8 @@ public:
     /// Create a backup of a data part.
     /// This method adds a new entry to backup_entries.
     /// Also creates a new tmp_dir for internal disk (if disk is mentioned the first time).
+    /// `path_in_backup` is the full destination dir of THIS storage; the caller names it (a projection goes under its logical
+    /// "<name>.proj"), so the backup layout is independent of the on-disk layout.
     using TemporaryFilesOnDisks = std::map<DiskPtr, std::shared_ptr<TemporaryFileOnDisk>>;
     virtual void backup(
         const MergeTreeDataPartChecksums & checksums,
@@ -276,6 +361,19 @@ public:
         DiskTransactionPtr external_transaction = nullptr;
         std::optional<int32_t> metadata_version_to_write = std::nullopt;
         NameSet invalidated_columns_to_write = {};
+        /// Params for freezing one projection sub-part of a part frozen with *this: parent-only artifacts
+        /// (metadata version, invalidated system columns) must not materialize inside the projection dir.
+        ClonePartParams forProjection(DiskTransactionPtr projection_transaction, bool copy_instead_of_hardlink_) const
+        {
+            ClonePartParams res = *this;
+            res.external_transaction = std::move(projection_transaction);
+            res.copy_instead_of_hardlink = copy_instead_of_hardlink_;
+            res.metadata_version_to_write.reset();
+            res.keep_metadata_version = true;
+            res.invalidated_columns_to_write.clear();
+            return res;
+        }
+
         /// fsync the cloned/frozen directories (the clone subtree plus the ancestor chain up to
         /// the disk root) so the new hardlink directory entries survive a power loss. Only honored
         /// by freeze() on a local disk, outside an external transaction.
@@ -290,22 +388,16 @@ public:
     /// copies a whole archive.
     virtual bool cloneCopiesWholeArchive(const ClonePartParams & /*params*/) const { return false; }
 
+    /// Materializes a copy of the part at 'to/dir_path'. `dst_disk` == nullptr means the part's own disk;
+    /// a different disk cannot hardlink, so it always copies.
     virtual std::shared_ptr<IDataPartStorage> freeze(
         const std::string & to,
         const std::string & dir_path,
+        const DiskPtr & dst_disk,
         const ReadSettings & read_settings,
         const WriteSettings & write_settings,
         std::function<void(const DiskPtr &)> save_metadata_callback,
         const ClonePartParams & params) const = 0;
-
-    virtual std::shared_ptr<IDataPartStorage> freezeRemote(
-    const std::string & to,
-    const std::string & dir_path,
-    const DiskPtr & dst_disk,
-    const ReadSettings & read_settings,
-    const WriteSettings & write_settings,
-    std::function<void(const DiskPtr &)> save_metadata_callback,
-    const ClonePartParams & params) const = 0;
 
     /// Make a full copy of a data part into 'to/dir_path' (possibly to a different disk).
     virtual std::shared_ptr<IDataPartStorage> clonePart(
@@ -323,7 +415,27 @@ public:
     virtual void changeRootPath(const std::string & from_root, const std::string & to_root) = 0;
 
     virtual void createDirectories() = 0;
-    virtual void createProjection(const std::string & name) = 0;
+
+    /// The verbs that mutate the owned projection set; each keeps it true.
+
+    /// Creates the on-disk directory for a projection sub-part in the given layout and records it in the owned set. Sweeps a stale
+    /// leftover directory at the target first (tmp part names repeat across attempts).
+    virtual Projection createProjection(const std::string & dir_name, ProjectionStorageFormat format) = 0;
+
+    /// Only a temporary projection may be removed alone; a normal one goes only with its parent part.
+    virtual void removeProjection(const Projection & projection) = 0;
+
+    /// Rename within this part (e.g. "p_1.tmp_proj" -> "p.proj"); layout kept, returns the new descriptor.
+    /// `fsync` makes the rename entry durable (syncs the enclosing directory).
+    virtual Projection renameProjection(const Projection & projection, const std::string & new_dir_name, bool fsync) = 0;
+
+    /// Repoints a projection sub-part's storage at where this part's owned set says the projection lives now (used after the part or the
+    /// projection dir was renamed).
+    virtual void syncProjectionStoragePath(const Projection & projection, IDataPartStorage & projection_storage) const = 0;
+
+    /// If a dir exists at the placement, remove it with a log line: residue of a failed operation on a same-named
+    /// part. Remote blobs are kept only when zero-copy replication may share them invisibly to the local refcount.
+    virtual void removeProjectionResidue(const Projection & placement) = 0;
 
     /// Hint for the preferred on-disk order of files. Packed storage uses it to lay out the
     /// single archive; storages that keep files separately can ignore it (default no-op).
@@ -419,6 +531,22 @@ inline bool isFullPartStorage(const IDataPartStorage & storage)
 inline bool isPackedPartStorage(const IDataPartStorage & storage)
 {
     return storage.getType() == MergeTreeDataPartStorageType::Packed;
+}
+
+inline String IDataPartStorage::Projection::rootPath() const
+{
+    return parent->getProjectionRootAndDir(dirName(), format).first;
+}
+
+inline String IDataPartStorage::Projection::relativePath() const
+{
+    auto [root, dir] = parent->getProjectionRootAndDir(dirName(), format);
+    return std::filesystem::path(root) / dir;
+}
+
+inline bool IDataPartStorage::Projection::exists() const
+{
+    return parent->existsProjectionDir(dirName(), format);
 }
 
 }

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1014,7 +1014,7 @@ void IMergeTreeDataPart::removeIfNeeded()
                                 getDataPartStorage().getPartDirectory(), name);
 
             bool is_moving_part = isMovingPart();
-            if (!startsWith(file_name, "tmp") && !endsWith(file_name, ".tmp_proj") && !is_moving_part)
+            if (!startsWith(file_name, "tmp") && IDataPartStorage::Projection::dirNameType(file_name) != IDataPartStorage::Projection::Status::Temp && !is_moving_part)
             {
                 LOG_ERROR(
                     storage.log,
@@ -1407,7 +1407,22 @@ void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checks
         /// so keep it outside the arena scope above (each child re-enters the arena for its own
         /// persistent metadata, and its transient load scratch stays on the default per-CPU arenas).
         if (!parent_part)
+        {
+            /// Seed the owned projection set from a manifest-driven disk probe -- only a part loaded from disk
+            /// needs this. A part written by a mutation does NOT reach loadProjections through here (its finalize
+            /// calls loadProjections directly), and there createProjection/renameProjection already keep the owned
+            /// set true; a probe there could miss dirs still staged in the part's deferred object-storage transaction.
+            auto metadata_snapshot = storage.getInMemoryMetadataPtr(storage.getContext(), false);
+            Strings owned_projection_dirs;
+            for (const auto & [file_name, _] : checksums.files)
+                if (IDataPartStorage::Projection::dirNameType(file_name) == IDataPartStorage::Projection::Status::Live)
+                    owned_projection_dirs.push_back(file_name);
+            for (const auto & projection : metadata_snapshot->projections)
+                owned_projection_dirs.push_back(IDataPartStorage::Projection::dirName(projection.name, false));
+            getDataPartStorage().setProjections(getDataPartStorage().detectProjections({.candidates = owned_projection_dirs}));
+
             loadProjections(require_columns_checksums, check_consistency, has_broken_projections, false /* if_not_loaded */);
+        }
 
         /// Kept out of the dedicated arena scope above on purpose: the size computation is heavy
         /// short-lived churn (a sample column per column/substream). The finished, part-lifetime maps
@@ -1458,15 +1473,28 @@ void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checks
 MergeTreeDataPartBuilder IMergeTreeDataPart::getProjectionPartBuilder(
     const String & projection_name, ProjectionDescriptionRawPtr projection, bool is_temp_projection)
 {
-    const char * projection_extension = is_temp_projection ? ".tmp_proj" : ".proj";
     /// The projection storage is stored on the resulting projection part for its lifetime, so create
     /// it in the dedicated arena (this is the part-lifetime projection-storage creation site).
     MutableDataPartStoragePtr projection_storage;
     {
         ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
-        projection_storage = getDataPartStorage().getProjection(projection_name + projection_extension, !is_temp_projection);
+        projection_storage = getDataPartStorage().getProjectionStorage(
+            IDataPartStorage::Projection::dirName(projection_name, is_temp_projection), !is_temp_projection);
     }
     MergeTreeDataPartBuilder builder(storage, projection_name, projection_storage, getReadSettings());
+    return builder.withPartInfo(MergeListElement::FAKE_RESULT_PART_FOR_PROJECTION).withParentPart(this).withProjection(projection);
+}
+
+MergeTreeDataPartBuilder IMergeTreeDataPart::getProjectionPartBuilderForWrite(
+    const IDataPartStorage::Projection & placement, ProjectionDescriptionRawPtr projection)
+{
+    /// Same arena rationale as getProjectionPartBuilder; the storage accessor additionally verifies ownership.
+    MutableDataPartStoragePtr projection_storage;
+    {
+        ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
+        projection_storage = getDataPartStorage().getProjectionStorageForWrite(placement, !placement.is_temp);
+    }
+    MergeTreeDataPartBuilder builder(storage, placement.name, projection_storage, getReadSettings());
     return builder.withPartInfo(MergeListElement::FAKE_RESULT_PART_FOR_PROJECTION).withParentPart(this).withProjection(projection);
 }
 
@@ -1495,6 +1523,7 @@ void IMergeTreeDataPart::loadProjections(
     /// child's own `loadColumnsChecksumsIndexes`). The projection load's transient scratch is
     /// deliberately left on the default per-CPU arenas, so no arena scope is taken here.
     auto metadata_snapshot = storage.getInMemoryMetadataPtr(storage.getContext(), false);
+
     for (const auto & projection : metadata_snapshot->projections)
     {
         if (projection.with_block_number && isSystemColumnInvalidated(BlockNumberColumn::name))
@@ -1503,56 +1532,58 @@ void IMergeTreeDataPart::loadProjections(
         if (projection.with_block_offset && isSystemColumnInvalidated(BlockOffsetColumn::name))
             continue;
 
-        auto path = projection.name + ".proj";
-        if (getDataPartStorage().existsDirectory(path))
+        auto projection_path = IDataPartStorage::Projection::dirName(projection.name, false);
+        if (!checksums.has(projection_path))
+            continue;
+
+        if (hasProjection(projection.name))
         {
-            if (hasProjection(projection.name))
+            if (!if_not_loaded)
+                throw Exception(
+                    ErrorCodes::LOGICAL_ERROR, "Projection part {} in part {} is already loaded. This is a bug", projection.name, name);
+            continue;
+        }
+
+        auto part = getProjectionPartBuilder(projection.name, &projection).withPartFormatFromDisk().build();
+
+        /// Owned per the manifest but not present on disk in either layout: broken under a consistency load, ignored otherwise.
+        if (!getDataPartStorage().hasProjection(projection_path))
+        {
+            if (check_consistency)
             {
-                if (!if_not_loaded)
-                    throw Exception(
-                        ErrorCodes::LOGICAL_ERROR, "Projection part {} in part {} is already loaded. This is a bug", projection.name, name);
-            }
-            else
-            {
-                auto part = getProjectionPartBuilder(projection.name, &projection).withPartFormatFromDisk().build();
-
-                try
-                {
-                    if (only_metadata)
-                    {
-                        /// The metadata-only path does not go through `loadColumnsChecksumsIndexes`, so
-                        /// route the projection's part-lifetime checksums into the arena here.
-                        ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
-                        part->loadChecksums(require_columns_checksums);
-                    }
-                    else
-                        part->loadColumnsChecksumsIndexes(require_columns_checksums, check_consistency);
-                }
-                catch (...)
-                {
-                    if (isRetryableException(std::current_exception()))
-                        throw;
-
-                    auto message = getCurrentExceptionMessage(true);
-                    LOG_WARNING(storage.log, "Cannot load projection {}, "
-                                "will consider it broken. Reason: {}", projection.name, message);
-
-                    has_broken_projection = true;
-                    part->setBrokenReason(message, getCurrentExceptionCode());
-                }
-
+                part->setBrokenReason(
+                    "Projection directory " + projection_path + " does not exist while loading projections",
+                    ErrorCodes::NO_FILE_IN_DATA_PART);
+                has_broken_projection = true;
                 addProjectionPart(projection.name, std::move(part));
             }
+            continue;
         }
-        else if (check_consistency && checksums.has(path))
+
+        try
         {
-            auto part = getProjectionPartBuilder(projection.name, &projection).withPartFormatFromDisk().build();
-            part->setBrokenReason(
-                "Projection directory " + path + " does not exist while loading projections. Stacktrace: " + StackTrace().toString(),
-                ErrorCodes::NO_FILE_IN_DATA_PART);
-            addProjectionPart(projection.name, std::move(part));
-            has_broken_projection = true;
+            if (only_metadata)
+            {
+                /// The metadata-only path does not go through loadColumnsChecksumsIndexes, so route the
+                /// projection's part-lifetime checksums into the arena here.
+                ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
+                part->loadChecksums(require_columns_checksums);
+            }
+            else
+                part->loadColumnsChecksumsIndexes(require_columns_checksums, check_consistency);
         }
+        catch (...)
+        {
+            if (isRetryableException(std::current_exception()))
+                throw;
+
+            /// Listed in checksums but will not load: a real breach (missing dir / corrupt sub-part), not a manifest divergence.
+            auto message = getCurrentExceptionMessage(true);
+            LOG_WARNING(storage.log, "Cannot load projection {}, will consider it broken. Reason: {}", projection.name, message);
+            has_broken_projection = true;
+            part->setBrokenReason(message, getCurrentExceptionCode());
+        }
+        addProjectionPart(projection.name, std::move(part));
     }
 }
 
@@ -2035,7 +2066,21 @@ void IMergeTreeDataPart::loadChecksums(bool require)
         LOG_WARNING(storage.log, "Checksums for part {} not found. Will calculate them from data on disk.", name);
 
         bool noop = false;
-        checksums = checkDataPart(shared_from_this(), false, noop, /* is_cancelled */[]{ return false; }, /* throw_on_broken_projection */false);
+        auto result = checkDataPart(shared_from_this(), false, noop, /* is_cancelled */[]{ return false; }, /* throw_on_broken_projection */false);
+        checksums = std::move(result.computed_checksums);
+
+        /// Persist checksums for projection parts whose checksums.txt was also missing (recomputed by checkDataPart).
+        if (!result.computed_projections_checksums.empty())
+        {
+            auto metadata_snapshot = getMetadataSnapshot();
+            for (const auto & [projection_name, projection_checksums] : result.computed_projections_checksums)
+            {
+                const auto & projection = metadata_snapshot->projections.get(projection_name);
+                auto part = getProjectionPartBuilder(projection.name, &projection).withPartFormatFromDisk().build();
+                part->writeChecksums(projection_checksums, {});
+            }
+        }
+
         writeChecksums(checksums, {});
 
         bytes_on_disk = checksums.getTotalSizeOnDisk();
@@ -2508,24 +2553,31 @@ bool IMergeTreeDataPart::shallParticipateInMerges(const StoragePolicyPtr & stora
 
 void IMergeTreeDataPart::renameTo(const String & new_relative_path, bool remove_new_dir_if_exists)
 {
-    std::string relative_path = storage.relative_data_path;
-    bool fsync_dir = (*storage.getSettings())[MergeTreeSetting::fsync_part_directory];
-
     if (parent_part)
     {
-        /// For projections, move is only possible inside parent part dir.
-        relative_path = parent_part->getDataPartStorage().getRelativePath();
+        /// This part is a projection: it renames within its parent (e.g. "p_1.tmp_proj" -> "p.proj"). The parent's storage resolves both
+        /// dir names from its owned set and keeps that set true.
+        auto & parent_storage = const_cast<IMergeTreeDataPart *>(parent_part)->getDataPartStorage();
+        auto renamed = parent_storage.renameProjection(
+            parent_storage.getProjection(IDataPartStorage::Projection::dirName(name, is_temp)), new_relative_path,
+            (*storage.getSettings())[MergeTreeSetting::fsync_part_directory]);
+        parent_storage.syncProjectionStoragePath(renamed, getDataPartStorage());
+        return;
     }
 
-    auto old_projection_root_path = getDataPartStorage().getRelativePath();
-    auto to = fs::path(relative_path) / new_relative_path;
+    bool fsync_dir = (*storage.getSettings())[MergeTreeSetting::fsync_part_directory];
+    fs::path to = fs::path(storage.relative_data_path) / new_relative_path;
 
+    /// rename() moves FLAT projection siblings with the part and decides the parent/sibling move order itself from the destination (see
+    /// IDataPartStorage::rename).
     getDataPartStorage().rename(to.parent_path(), to.filename(), storage.log.load(), remove_new_dir_if_exists, fsync_dir);
 
-    auto new_projection_root_path = to.string();
-
-    for (const auto & [_, part] : projection_parts)
-        part->getDataPartStorage().changeRootPath(old_projection_root_path, new_projection_root_path);
+    /// Repoint in-memory projection storages at the moved part. A broken projection whose dir is lost has an in-memory placeholder part but
+    /// no owned dir, so there is nothing to repoint.
+    const auto owned_projections = getDataPartStorage().getProjections();
+    for (const auto & [projection_name, part] : projection_parts)
+        if (auto it = owned_projections.find(IDataPartStorage::Projection::dirName(projection_name, false)); it != owned_projections.end())
+            getDataPartStorage().syncProjectionStoragePath(it->second, part->getDataPartStorage());
 }
 
 std::pair<bool, NameSet> IMergeTreeDataPart::canRemovePart() const
@@ -2558,16 +2610,17 @@ void IMergeTreeDataPart::remove()
     chassert(assertHasValidVersionMetadata());
     part_is_probably_removed_from_disk = true;
 
+    /// Temporary projections are transient by-products of projections materialization and can always be removed. Go through the parent so
+    /// its owned set drops the entry together with the dir.
+    if (isProjectionPart() && is_temp)
+    {
+        auto & parent_storage = const_cast<IMergeTreeDataPart *>(parent_part)->getDataPartStorage();
+        parent_storage.removeProjection(parent_storage.getProjection(IDataPartStorage::Projection::dirName(name, true)));
+        return;
+    }
+
     auto can_remove_callback = [this] ()
     {
-        /// Temporary projections are "subparts" which are generated during projections materialization
-        /// We can always remove them without any additional checks.
-        if (isProjectionPart() && is_temp)
-        {
-            LOG_TRACE(storage.log, "Temporary projection part {} can be removed", name);
-            return CanRemoveDescription{.can_remove_anything = true, .files_not_to_remove = {} };
-        }
-
         auto [can_remove, files_not_to_remove] = canRemovePart();
         if (!can_remove)
             LOG_TRACE(storage.log, "Blobs of part {} cannot be removed", name);
@@ -2580,7 +2633,7 @@ void IMergeTreeDataPart::remove()
 
     /// Projections should be never removed by themselves, they will be removed
     /// with by parent part.
-    if (isProjectionPart() && !is_temp)
+    if (isProjectionPart())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Projection part {} should be removed by its parent {}", name, parent_part_name);
 
     std::list<IDataPartStorage::ProjectionChecksums> projection_checksums;
@@ -2625,6 +2678,15 @@ std::optional<String> IMergeTreeDataPart::getRelativePathForDetachedPart(const S
 String IMergeTreeDataPart::getRelativePathOfActivePart() const
 {
     return fs::path(getDataPartStorage().getFullRootPath()) / name / "";
+}
+
+void IMergeTreeDataPart::adoptOnDiskProjectionsForDetach()
+{
+    IDataPartStorage::Projections adopted;
+    for (const auto & [projection_dir, projection] : getDataPartStorage().detectProjections())
+        if (!projection.is_temp)
+            adopted.emplace(projection_dir, projection);
+    getDataPartStorage().setProjections(std::move(adopted));
 }
 
 void IMergeTreeDataPart::renameToDetached(const String & prefix, bool ignore_error)
@@ -2691,6 +2753,7 @@ DataPartStoragePtr IMergeTreeDataPart::makeCloneInDetached(const String & prefix
     return getDataPartStorage().freeze(
         storage.relative_data_path,
         *maybe_path_in_detached,
+        /* dst_disk= */ nullptr,
         Context::getGlobalContextInstance()->getReadSettings(),
         Context::getGlobalContextInstance()->getWriteSettings(),
         /* save_metadata_callback= */ {},
@@ -2710,7 +2773,14 @@ MutableDataPartStoragePtr IMergeTreeDataPart::makeCloneOnDisk(
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Can not clone data part {} to empty directory.", name);
 
     String path_to_clone = fs::path(storage.relative_data_path) / directory_name / "";
-    return getDataPartStorage().clonePart(path_to_clone, getDataPartStorage().getPartDirectory(), disk, read_settings, write_settings, storage.log.load(), cancellation_hook);
+    return getDataPartStorage().clonePart(
+        path_to_clone,
+        getDataPartStorage().getPartDirectory(),
+        disk,
+        read_settings,
+        write_settings,
+        storage.log.load(),
+        cancellation_hook);
 }
 
 IndexSize IMergeTreeDataPart::getIndexSizeFromFile() const
@@ -2788,7 +2858,7 @@ void IMergeTreeDataPart::checkConsistencyBase() const
             catch (const Exception & ex)
             {
                 /// For projection parts check will mark them broken in loadProjections
-                if (!parent_part && filename.ends_with(".proj"))
+                if (!parent_part && IDataPartStorage::Projection::dirNameType(filename) == IDataPartStorage::Projection::Status::Live)
                 {
                     std::string projection_name = fs::path(filename).stem();
                     LOG_INFO(storage.log, "Projection {} doesn't exist on start for part {}, marking it as broken", projection_name, name);

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -486,6 +486,10 @@ public:
     /// Moves a part to detached/ directory and adds prefix to its name
     void renameToDetached(const String & prefix, bool ignore_error = false);
 
+    /// Re-seed the owned projection set from disk before detaching a part that broke before loadProjections ran; otherwise its FLAT
+    /// siblings are stranded for the orphan GC.
+    void adoptOnDiskProjectionsForDetach();
+
     /// Makes checks and move part to new directory
     /// Changes only relative_dir_name, you need to update other metadata (name, is_temp) explicitly
     virtual void renameTo(const String & new_relative_path, bool remove_new_dir_if_exists);
@@ -540,8 +544,14 @@ public:
 
     const std::map<String, std::shared_ptr<IMergeTreeDataPart>> & getProjectionParts() const { return projection_parts; }
 
+    /// Read/load path (also serves the broken-projection placeholder, whose dir may not exist).
     MergeTreeDataPartBuilder
     getProjectionPartBuilder(const String & projection_name, ProjectionDescriptionRawPtr projection, bool is_temp_projection = false);
+
+    /// Write path: requires the descriptor produced by createProjection, so building a projection part
+    /// before creating its directory cannot compile away the residue sweep (see getProjectionStorageForWrite).
+    MergeTreeDataPartBuilder
+    getProjectionPartBuilderForWrite(const IDataPartStorage::Projection & placement, ProjectionDescriptionRawPtr projection);
 
     void addProjectionPart(const String & projection_name, std::shared_ptr<IMergeTreeDataPart> && projection_part);
 

--- a/src/Storages/MergeTree/MergeProjectionPartsTask.cpp
+++ b/src/Storages/MergeTree/MergeProjectionPartsTask.cpp
@@ -60,7 +60,7 @@ bool MergeProjectionPartsTask::executeStep()
         if (next_level_parts.empty())
         {
             LOG_DEBUG(log, "Merged a projection part in level {}", current_level);
-            selected_parts[0]->renameTo(projection.name + ".proj", true);
+            selected_parts[0]->renameTo(IDataPartStorage::Projection::dirName(projection.name, false), true);
             selected_parts[0]->setName(projection.name);
             selected_parts[0]->is_temp = false;
             selected_parts[0]->temp_projection_block_number.reset();
@@ -117,7 +117,7 @@ bool MergeProjectionPartsTask::executeStep()
             /* need_prefix */ true,
             &projection,
             new_data_part.get(),
-            ".tmp_proj");
+            IDataPartStorage::Projection::extTmp());
 
         next_level_parts.push_back(executeHere(tmp_part_merge_task));
 

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -592,7 +592,9 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
         std::optional<MergeTreeDataPartBuilder> builder;
         if (global_ctx->parent_part)
         {
-            auto data_part_storage = global_ctx->parent_part->getDataPartStorage().getProjection(local_tmp_part_basename,  /* use parent transaction */ false);
+            auto & parent_storage = global_ctx->parent_part->getDataPartStorage();
+            auto placement = parent_storage.createProjection(local_tmp_part_basename, global_ctx->data->getProjectionStorageFormat());
+            auto data_part_storage = parent_storage.getProjectionStorageForWrite(placement, /*use_parent_transaction=*/ false);
             builder.emplace(*global_ctx->data, global_ctx->future_part->name, data_part_storage, getReadSettings());
             builder->withParentPart(global_ctx->parent_part);
         }
@@ -610,7 +612,8 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
     }
     auto data_part_storage = global_ctx->new_data_part->getDataPartStoragePtr();
 
-    if (data_part_storage->exists())
+    /// A projection dir exists by now: createProjection above made it (sweeping any stale leftover).
+    if (!global_ctx->parent_part && data_part_storage->exists())
         throw Exception(ErrorCodes::DIRECTORY_ALREADY_EXISTS, "Directory {} already exists", data_part_storage->getFullPath());
 
     data_part_storage->beginTransaction();
@@ -2222,7 +2225,7 @@ bool MergeTask::MergeProjectionsStage::prepareProjections() const
             projection,
             global_ctx->new_data_part.get(),
             projection->with_parent_part_offset ? global_ctx->merged_part_offsets : nullptr,
-            ".proj",
+            IDataPartStorage::Projection::ext(),
             NO_TRANSACTION_PTR,
             global_ctx->data,
             global_ctx->mutator,

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3003,7 +3003,10 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks, std::optional<std::un
     bool replicated = dynamic_cast<StorageReplicatedMergeTree *>(this) != nullptr;
     if (!is_static_storage)
         for (auto & part : broken_parts_to_detach)
+        {
+            part->adoptOnDiskProjectionsForDetach();
             part->renameToDetached("broken-on-start", /*ignore_error=*/ replicated); /// detached parts must not have '_' in prefixes
+        }
 
     /// UNIQUE KEY — SST sweep + per-part validation for parts that landed
     /// without a usable sidecar (restore, freeze taken before UK shipped, or a
@@ -3368,7 +3371,10 @@ try
 
             chassert(load_state.part);
             if (load_state.is_broken)
+            {
+                load_state.part->adoptOnDiskProjectionsForDetach();
                 load_state.part->renameToDetached("broken-on-start", /*ignore_error=*/ replicated); /// detached parts must not have '_' in prefixes
+            }
         }, Priority{});
     }
     runner.waitForAllToFinishAndRethrowFirstError();
@@ -3461,6 +3467,7 @@ try
             if (res.is_broken)
             {
                 forcefullyRemoveBrokenOutdatedPartFromZooKeeperBeforeDetaching(res.part->name);
+                res.part->adoptOnDiskProjectionsForDetach();
                 res.part->renameToDetached("broken-on-start", /*ignore_error=*/ replicated); /// detached parts must not have '_' in prefixes
             }
             else if (res.part->is_duplicate)
@@ -3865,6 +3872,15 @@ scope_guard MergeTreeData::getTemporaryPartDirectoryHolder(const String & part_d
 {
     temporary_parts.add(part_dir_name);
     return [this, part_dir_name]() { temporary_parts.remove(part_dir_name); };
+}
+
+void MergeTreeData::reclaimStaleTemporaryDirectory(const DiskPtr & disk, const std::filesystem::path & relative_part_dir) const
+{
+    if (disk->existsDirectory(relative_part_dir))
+    {
+        LOG_WARNING(log, "Removing old temporary directory {}", (fs::path(disk->getPath()) / relative_part_dir).string());
+        disk->removeRecursive(relative_part_dir);
+    }
 }
 
 MergeTreeData::MutableDataPartPtr MergeTreeData::asMutableDeletingPart(const DataPartPtr & part)
@@ -4520,6 +4536,9 @@ void MergeTreeData::rename(const String & new_table_path, const StorageID & new_
     {
         auto & part_mutable = const_cast<IMergeTreeDataPart &>(*part);
         part_mutable.getDataPartStorage().changeRootPath(relative_data_path, new_table_path);
+        /// Repoint loaded projection sub-part storages too: they keep their own root_path sharing the table prefix.
+        for (const auto & [_, projection_part] : part_mutable.getProjectionParts())
+            const_cast<IMergeTreeDataPart &>(*projection_part).getDataPartStorage().changeRootPath(relative_data_path, new_table_path);
     }
 
     relative_data_path = new_table_path;
@@ -8107,19 +8126,22 @@ MergeTreeData::PartsBackupEntries MergeTreeData::backupParts(
         part->getDataPartStorage().backup(
             part->checksums,
             part->getFileNamesWithoutChecksums(),
-            data_path_in_backup,
+            fs::path{data_path_in_backup} / part->name,
             backup_settings,
             make_temporary_hard_links,
             backup_entries_from_part,
             &temp_dirs,
-            false, false);
+            /*is_projection_part=*/ false,
+            /*allow_backup_broken_projection=*/ false);
 
         auto backup_projection = [&](IDataPartStorage & storage, IMergeTreeDataPart & projection_part)
         {
+            /// A projection backs up under its logical name ("<name>.proj"), so the backup layout is independent of the on-disk projection
+            /// layout.
             storage.backup(
                 projection_part.checksums,
                 projection_part.getFileNamesWithoutChecksums(),
-                fs::path{data_path_in_backup} / part->name,
+                fs::path{data_path_in_backup} / part->name / IDataPartStorage::Projection::dirName(projection_part.name, false),
                 backup_settings,
                 make_temporary_hard_links,
                 backup_entries_from_part,
@@ -8129,7 +8151,6 @@ MergeTreeData::PartsBackupEntries MergeTreeData::backupParts(
         };
 
         auto projection_parts = part->getProjectionParts();
-        std::string proj_suffix = ".proj";
         std::unordered_set<String> defined_projections;
 
         for (const auto & [projection_name, projection_part] : projection_parts)
@@ -8147,9 +8168,9 @@ MergeTreeData::PartsBackupEntries MergeTreeData::backupParts(
         for (const auto & [name, _] : part->checksums.files)
         {
             auto projection_name = fs::path(name).stem().string();
-            if (endsWith(name, proj_suffix) && !defined_projections.contains(projection_name))
+            if (IDataPartStorage::Projection::dirNameType(name) == IDataPartStorage::Projection::Status::Live && !defined_projections.contains(projection_name))
             {
-                auto projection_storage = part->getDataPartStorage().getProjection(projection_name + proj_suffix);
+                auto projection_storage = part->getDataPartStorage().getProjectionStorage(IDataPartStorage::Projection::dirName(projection_name, false));
                 if (projection_storage->existsFile("checksums.txt"))
                 {
                     auto projection_part
@@ -10539,35 +10560,9 @@ std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> MergeTreeData::cloneAn
     if (params.copy_instead_of_hardlink)
         with_copy = " (copying data)";
 
-    /// Reclaim a stale leftover destination directory (e.g. tmp_clone_* / tmp_* left by a clone that was
-    /// interrupted or rolled back and then retried with the same deterministic name) before freeze
-    /// constructs the destination storage. Otherwise packed storage seeds its archive reader from the
-    /// leftover data.packed, and finalizeWriter carries stale archive members that the current source
-    /// does not rewrite into the new clone. The temporary-directory lock above guarantees no concurrent
-    /// operation owns this name, so an existing directory can only be such a stale leftover.
-    auto reclaim_stale_destination = [&](const DiskPtr & dst_disk)
-    {
-        auto relative_dst_dir = fs::path(relative_data_path) / tmp_dst_part_name;
-        if (dst_disk->existsDirectory(relative_dst_dir))
-        {
-            LOG_WARNING(log, "Removing old temporary directory {}", (fs::path(dst_disk->getPath()) / relative_dst_dir).string());
-            dst_disk->removeRecursive(relative_dst_dir);
-        }
-    };
-
-    std::shared_ptr<IDataPartStorage> dst_part_storage{};
-    if (on_same_disk)
-    {
-        reclaim_stale_destination(same_disk);
-        dst_part_storage = src_part_storage->freeze(
-            relative_data_path,
-            tmp_dst_part_name,
-            read_settings,
-            write_settings,
-            /* save_metadata_callback= */ {},
-            params);
-    }
-    else
+    /// freeze also copies the part's owned FLAT projection siblings. dst_disk == nullptr means the source's own disk.
+    DiskPtr dst_disk;
+    if (!on_same_disk)
     {
         auto reservation_on_dst_or_error = getStoragePolicy()->reserve(src_part->getBytesOnDisk());
         if (!reservation_on_dst_or_error)
@@ -10575,17 +10570,19 @@ std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> MergeTreeData::cloneAn
             const auto & error = reservation_on_dst_or_error.error();
             throw Exception(error.message, error.code);
         }
-        auto dst_disk = (*reservation_on_dst_or_error)->getDisk();
-        reclaim_stale_destination(dst_disk);
-        dst_part_storage = src_part_storage->freezeRemote(
-            relative_data_path,
-            tmp_dst_part_name,
-            /* dst_disk = */ dst_disk,
-            read_settings,
-            write_settings,
-            /* save_metadata_callback= */ {},
-            params);
+        dst_disk = (*reservation_on_dst_or_error)->getDisk();
     }
+    /// The clone tmp dir name repeats across retries; the leftover of a failed same-named attempt must
+    /// go before freeze constructs the destination storage (see reclaimStaleTemporaryDirectory).
+    reclaimStaleTemporaryDirectory(on_same_disk ? same_disk : dst_disk, fs::path(relative_data_path) / tmp_dst_part_name);
+    std::shared_ptr<IDataPartStorage> dst_part_storage = src_part_storage->freeze(
+        relative_data_path,
+        tmp_dst_part_name,
+        dst_disk,
+        read_settings,
+        write_settings,
+        /* save_metadata_callback= */ {},
+        params);
 
     if (params.metadata_version_to_write.has_value())
     {
@@ -10641,7 +10638,8 @@ std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> MergeTreeData::cloneAn
             const auto & projection_storage = projection_part->getDataPartStorage();
             for (auto it = projection_storage.iterate(); it->isValid(); it->next())
             {
-                auto file_name_with_projection_prefix = fs::path(projection_storage.getPartDirectory()) / it->name();
+                /// The zero-copy keep-list uses the logical projection dir name regardless of the on-disk projection layout.
+                auto file_name_with_projection_prefix = fs::path(IDataPartStorage::Projection::dirName(name, false)) / it->name();
                 if (!params.files_to_copy_instead_of_hardlinks.contains(file_name_with_projection_prefix)
                     && it->name() != IMergeTreeDataPart::DELETE_ON_DESTROY_MARKER_FILE_NAME_DEPRECATED
                     && it->name() != VersionMetadata::TXN_VERSION_METADATA_FILE_NAME)
@@ -10873,6 +10871,7 @@ PartitionCommandsResultInfo MergeTreeData::freezePartitionsByMatcher(
                 auto new_storage = data_part_storage->freeze(
                     backup_part_path,
                     part->getDataPartStorage().getPartDirectory(),
+                    /* dst_disk= */ nullptr,
                     local_context->getReadSettings(),
                     local_context->getWriteSettings(),
                     callback,
@@ -12026,6 +12025,13 @@ MergeTreeSettingsPtr MergeTreeData::getSettings(const SettingsChanges * settings
     }
 
     return data_settings;
+}
+
+IDataPartStorage::ProjectionStorageFormat MergeTreeData::getProjectionStorageFormat() const
+{
+    /// The only on-disk layout today; kept as the single source for the format passed to createProjection
+    /// so an alternative layout can be introduced without touching the call sites.
+    return IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED;
 }
 
 StorageMetadataHandle MergeTreeData::getInMemoryMetadataPtr(ContextPtr query_context, bool bypass_metadata_cache) const

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1225,6 +1225,10 @@ public:
     /// When `settings_changes` is provided, apply the overrides on top of the table settings.
     MergeTreeSettingsPtr getSettings(const SettingsChanges * settings_changes = nullptr) const;
 
+    /// On-disk layout for projection sub-parts of this table's parts (from the `projection_storage_format` setting). The single source of
+    /// truth: read it here wherever a projection directory is created.
+    IDataPartStorage::ProjectionStorageFormat getProjectionStorageFormat() const;
+
     StorageMetadataHandle getInMemoryMetadataPtr(ContextPtr query_context, bool bypass_metadata_cache) const override;
 
     /// Whether the per-part metadata version is stored in the engine's metadata storage instead of
@@ -1481,6 +1485,10 @@ public:
 
     /// Returns an object that protects temporary directory from cleanup
     scope_guard getTemporaryPartDirectoryHolder(const String & part_dir_name) const;
+
+    /// Remove a leftover dir of a failed same-named attempt BEFORE part storage is constructed over it
+    /// (packed storage seeds its reader at construction). Caller holds the temporary-directory name lock.
+    void reclaimStaleTemporaryDirectory(const DiskPtr & disk, const std::filesystem::path & relative_part_dir) const;
 
     void waitForOutdatedPartsToBeLoaded() const;
     void waitForUnexpectedPartsToBeLoaded() const;

--- a/src/Storages/MergeTree/MergeTreeDataPartBuilder.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartBuilder.cpp
@@ -4,6 +4,7 @@
 #include <Storages/MergeTree/DataPartStorageOnDiskFull.h>
 #include <Storages/MergeTree/DataPartStorageOnDiskPacked.h>
 #include <Storages/MergeTree/MergeTreeData.h>
+#include <Storages/MergeTree/MergeTreeSettings.h>
 
 #include <Common/Jemalloc.h>
 #include <Common/JemallocMergeTreeArena.h>
@@ -15,6 +16,11 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int UNKNOWN_PART_TYPE;
+}
+
+namespace MergeTreeSetting
+{
+    extern const MergeTreeSettingsBool allow_remote_fs_zero_copy_replication;
 }
 
 MergeTreeDataPartBuilder::MergeTreeDataPartBuilder(
@@ -69,6 +75,8 @@ std::shared_ptr<IMergeTreeDataPart> MergeTreeDataPartBuilder::build()
     if (!part_storage)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot create part {}, because part storage is not set", name);
 
+    part_storage->setZeroCopyReplicationEnabled((*data.getSettings())[MergeTreeSetting::allow_remote_fs_zero_copy_replication]);
+
     if (parent_part && data.format_version == MERGE_TREE_DATA_OLD_FORMAT_VERSION)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot create projection part in MergeTree table created in old syntax");
 
@@ -118,9 +126,20 @@ MutableDataPartStoragePtr MergeTreeDataPartBuilder::getPartStorageByType(
     switch (storage_type_.getValue())
     {
         case Type::Full:
-            return std::make_shared<DataPartStorageOnDiskFull>(volume_, root_path_, part_dir_);
+        {
+            auto storage = std::make_shared<DataPartStorageOnDiskFull>(volume_, root_path_, part_dir_);
+            /// Seed empty: a fresh part registers projections via createProjection, a loaded part re-seeds in loadProjections; a disk scan
+            /// here could adopt residue of a same-named part.
+            storage->setProjections({});
+            return storage;
+        }
         case Type::Packed:
-            return std::make_shared<DataPartStorageOnDiskPacked>(volume_, root_path_, part_dir_, read_settings, part_may_exist_on_disk);
+        {
+            auto storage = std::make_shared<DataPartStorageOnDiskPacked>(volume_, root_path_, part_dir_, read_settings, part_may_exist_on_disk);
+            /// Same empty-seed rationale as the Full case above.
+            storage->setProjections({});
+            return storage;
+        }
         default:
             throw Exception(ErrorCodes::UNKNOWN_PART_TYPE,
                 "Unknown type of storage for part {}", fs::path(root_path_) / part_dir_);

--- a/src/Storages/MergeTree/MergeTreeDataPartBuilder.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartBuilder.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <IO/ReadSettings.h>
+#include <Storages/MergeTree/IDataPartStorage.h>
 #include <Storages/MergeTree/MergeTreeIndexGranularityInfo.h>
 #include <Storages/MergeTree/MergeTreePartInfo.h>
 #include <Storages/MergeTree/MergeTreeDataPartType.h>

--- a/src/Storages/MergeTree/MergeTreeDataPartChecksum.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartChecksum.cpp
@@ -65,7 +65,17 @@ void MergeTreeDataPartChecksum::checkEqual(const MergeTreeDataPartChecksum & rhs
 
 void MergeTreeDataPartChecksum::checkSize(const IDataPartStorage & storage, const String & name) const
 {
-    // This is a projection, no need to check its size.
+    /// This is a projection, no need to check its size. It may be stored either nested inside the part directory or as a flat sibling of
+    /// it, so existsDirectory is not enough.
+    if (IDataPartStorage::Projection::dirNameType(name) == IDataPartStorage::Projection::Status::Live)
+    {
+        if (storage.hasProjection(name))
+            return;
+
+        throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Projection {} doesn't exist",
+            std::filesystem::path(storage.getRelativePath()) / name);
+    }
+
     if (storage.existsDirectory(name))
         return;
 

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -898,24 +898,10 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
         data_part_volume = createVolumeFromReservation(reservation, volume);
     }
 
-    /// The part directory name can be non-unique because of stale files from previous runs (an insert
-    /// interrupted or rolled back after the directory was created but before it was committed, then
-    /// retried with the same block/part name). Such a leftover must be removed BEFORE the part storage
-    /// is constructed: otherwise packed storage would seed its archive reader and snapshot the mark
-    /// layout (index_granularity_info) from the stale contents at construction, and a retry could
-    /// inherit them even though the directory is later reclaimed. The temporary-directory lock acquired
-    /// above guarantees no concurrent operation owns this name, so an existing directory can only be
-    /// such a stale leftover and is safe to remove.
+    /// The part dir name is non-unique across retries; the leftover of a failed same-named attempt
+    /// must be removed before the part storage is constructed (see reclaimStaleTemporaryDirectory).
     if (may_exist)
-    {
-        auto data_part_disk = data_part_volume->getDisk();
-        auto relative_part_dir = fs::path(data.getRelativeDataPath()) / part_dir;
-        if (data_part_disk->existsDirectory(relative_part_dir))
-        {
-            LOG_WARNING(log, "Removing old temporary directory {}", (fs::path(data_part_disk->getPath()) / relative_part_dir).string());
-            data_part_disk->removeRecursive(relative_part_dir);
-        }
-    }
+        data.reclaimStaleTemporaryDirectory(data_part_volume->getDisk(), fs::path(data.getRelativeDataPath()) / part_dir);
 
     auto part_format = data.choosePartFormat(expected_size, block.rows(), new_part_level, /*projection =*/nullptr);
     /// UNIQUE KEY parts must use Full part storage: the dense-index sidecar
@@ -1108,7 +1094,7 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPartImpl(
     bool is_temp,
     IMergeTreeDataPart * parent_part,
     const MergeTreeData & data,
-    LoggerPtr log,
+    LoggerPtr /* log */,
     Block block,
     const ProjectionDescription & projection,
     MergeTreeIndices indices,
@@ -1125,25 +1111,11 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPartImpl(
     MergeTreeData::reserveSpace(expected_size, parent_part->getDataPartStorage());
     part_type = data.choosePartFormat(expected_size, block.rows(), parent_part->info.level, &projection).part_type;
 
-    /// The projection temp directory name is deterministic (<projection>.tmp_proj), so a retried
-    /// materialization can hit a leftover directory from a failed earlier attempt. Remove it BEFORE
-    /// constructing the projection storage: getProjectionPartBuilder builds through the initializing
-    /// getProjection, which would seed a packed archive reader and snapshot the mark layout
-    /// (index_granularity_info) from the stale contents, and the subsequent write would proceed with
-    /// that stale layout. getProjectionNoInitialize gives a storage handle that does not seed the reader,
-    /// so removing through it is safe. Mirrors the base-part reclaim in writeTempPartImpl.
-    {
-        const char * projection_extension = is_temp ? ".tmp_proj" : ".proj";
-        auto stale_projection_storage = parent_part->getDataPartStorage().getProjectionNoInitialize(
-            part_name + projection_extension, /*use_parent_transaction=*/ false);
-        if (stale_projection_storage->exists())
-        {
-            LOG_WARNING(log, "Removing old temporary projection directory {}", stale_projection_storage->getFullPath());
-            stale_projection_storage->removeRecursive();
-        }
-    }
+    /// createProjection sweeps any stale same-named leftover and registers the dir; only its descriptor
+    /// unlocks a writable projection storage, so a packed reader can never seed from stale contents.
+    auto placement = parent_part->getDataPartStorage().createProjection(IDataPartStorage::Projection::dirName(part_name, is_temp), data.getProjectionStorageFormat());
 
-    auto new_data_part = parent_part->getProjectionPartBuilder(part_name, &projection, is_temp).withPartType(part_type).build();
+    auto new_data_part = parent_part->getProjectionPartBuilderForWrite(placement, &projection).withPartType(part_type).build();
     auto projection_part_storage = new_data_part->getDataPartStoragePtr();
     auto data_settings = data.getSettings(&projection.settings_changes);
 
@@ -1168,8 +1140,6 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPartImpl(
     infos.add(block);
 
     new_data_part->setColumns(columns, infos, metadata_snapshot->getMetadataVersion());
-
-    projection_part_storage->createDirectories();
 
     /// If we need to calculate some columns to sort.
     if (metadata_snapshot->hasSortingKey() || metadata_snapshot->hasSecondaryIndices())

--- a/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -273,7 +273,13 @@ MergeTreePartsMover::TemporaryClonedPart MergeTreePartsMover::clonePart(const Me
         {
             LOG_INFO(log, "Part {} was not fetched, we are the first who move it to another disk, so we will copy it", part->name);
             cloned_part_storage = part->getDataPartStorage().clonePart(
-                path_to_clone, part->getDataPartStorage().getPartDirectory(), disk, read_settings, write_settings, log, cancellation_hook);
+                path_to_clone,
+                part->getDataPartStorage().getPartDirectory(),
+                disk,
+                read_settings,
+                write_settings,
+                log,
+                cancellation_hook);
         }
     }
     else

--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -226,7 +226,7 @@ MergedBlockOutputStream::Finalizer MergedBlockOutputStream::finalizePartAsync(
     for (const auto & [projection_name, projection_part] : new_part->getProjectionParts())
     {
         checksums.addFile(
-            projection_name + ".proj",
+            IDataPartStorage::Projection::dirName(projection_name, false),
             projection_part->checksums.getTotalSizeOnDisk(),
             projection_part->checksums.getTotalChecksumUInt128());
     }

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1281,8 +1281,8 @@ static NameToNameVector collectFilesForRenames(
         }
         else if (command.type == MutationCommand::Type::DROP_PROJECTION)
         {
-            if (source_part->checksums.has(command.column_name + ".proj"))
-                add_rename(command.column_name + ".proj", "");
+            if (source_part->checksums.has(IDataPartStorage::Projection::dirName(command.column_name, false)))
+                add_rename(IDataPartStorage::Projection::dirName(command.column_name, false), "");
         }
         else if (isWidePart(source_part))
         {
@@ -2460,36 +2460,37 @@ private:
         /// Create hardlinks for unchanged files
         for (auto it = ctx->source_part->getDataPartStorage().iterate(); it->isValid(); it->next())
         {
-            if (!entries_to_hardlink.contains(it->name()))
-            {
-                /// Do nothing for skipped files
-            }
-            else if (it->isFile())
+            if (it->isFile() && entries_to_hardlink.contains(it->name()))
             {
                 ctx->new_data_part->getDataPartStorage().createHardLinkFrom(
                     ctx->source_part->getDataPartStorage(), it->name(), it->name());
                 hardlinked_files.insert(it->name());
             }
-            else
+        }
+
+        /// getProjections() is the owned set (layout-independent), so residue siblings of an unrelated
+        /// same-named part are not carried into the new part.
+        for (const auto & [projection_dir, projection] : ctx->source_part->getDataPartStorage().getProjections())
+        {
+            if (projection.is_temp || !entries_to_hardlink.contains(projection_dir))
+                continue;
+
+            auto placement = ctx->new_data_part->getDataPartStorage().createProjection(projection_dir, ctx->data->getProjectionStorageFormat());
+
+            auto projection_data_part_storage_src = ctx->source_part->getDataPartStorage().getProjectionStorage(projection_dir);
+            auto projection_data_part_storage_dst = ctx->new_data_part->getDataPartStorage().getProjectionStorageForWrite(placement);
+
+            for (auto p_it = projection_data_part_storage_src->iterate(); p_it->isValid(); p_it->next())
             {
-                // it's a projection part directory
-                ctx->new_data_part->getDataPartStorage().createProjection(it->name());
+                projection_data_part_storage_dst->createHardLinkFrom(
+                    *projection_data_part_storage_src, p_it->name(), p_it->name());
 
-                auto projection_data_part_storage_src = ctx->source_part->getDataPartStorage().getProjection(it->name());
-                auto projection_data_part_storage_dst = ctx->new_data_part->getDataPartStorage().getProjection(it->name());
-
-                for (auto p_it = projection_data_part_storage_src->iterate(); p_it->isValid(); p_it->next())
-                {
-                    projection_data_part_storage_dst->createHardLinkFrom(
-                        *projection_data_part_storage_src, p_it->name(), p_it->name());
-
-                    auto file_name_with_projection_prefix = fs::path(projection_data_part_storage_src->getPartDirectory()) / p_it->name();
-                    hardlinked_files.insert(file_name_with_projection_prefix);
-                }
-
-                ctx->new_data_part->getDataPartStorage().commitTransaction();
-                ctx->new_data_part->getDataPartStorage().beginTransaction();
+                /// The zero-copy keep-list uses the logical projection dir name regardless of the on-disk projection layout.
+                hardlinked_files.insert(fs::path(projection_dir) / p_it->name());
             }
+
+            ctx->new_data_part->getDataPartStorage().commitTransaction();
+            ctx->new_data_part->getDataPartStorage().beginTransaction();
         }
 
         /// Tracking of hardlinked files required for zero-copy replication.
@@ -2619,13 +2620,26 @@ private:
     {
         bool noop = false;
         ctx->new_data_part->setMinMaxIndex(std::move(ctx->minmax_idx));
-        ctx->new_data_part->loadProjections(false, false, noop, true /* if_not_loaded */);
         ctx->mutating_executor.reset();
         ctx->mutating_pipeline.reset();
+
+        /// Carry hardlinked projections (not rebuilt, so absent from getProjectionParts) into the manifest finalizePart writes.
+        for (const auto & [dir_name, _] : ctx->source_part->checksums.files)
+        {
+            if (IDataPartStorage::Projection::dirNameType(dir_name) != IDataPartStorage::Projection::Status::Live)
+                continue;
+            if (ctx->all_gathered_data.checksums.has(dir_name))
+                continue;
+            if (ctx->new_data_part->getDataPartStorage().hasProjection(dir_name))
+                ctx->all_gathered_data.checksums.addFile(dir_name, ctx->source_part->checksums.files.at(dir_name));
+        }
 
         auto out_mut = static_pointer_cast<MergedBlockOutputStream>(ctx->out);
         out_mut->finalizeIndexGranularity();
         out_mut->finalizePart(ctx->new_data_part, ctx->all_gathered_data, ctx->need_sync, nullptr);
+
+        /// Load projections now that the manifest is written, so the live in-memory part exposes them without a reload.
+        ctx->new_data_part->loadProjections(false, false, noop, true /* if_not_loaded */);
         ctx->out.reset();
     }
 
@@ -2787,35 +2801,46 @@ private:
                     hardlinked_files.insert(it->name());
                 }
             }
-            else if (!endsWith(it->name(), ".tmp_proj")) // ignore projection tmp merge dir
+        }
+
+        /// No checksums.has() filter here: legacy parts own metadata-declared
+        /// projections that checksums.txt does not reference.
+        for (const auto & [projection_dir, projection] : ctx->source_part->getDataPartStorage().getProjections())
+        {
+            if (projection.is_temp || ctx->files_to_skip.contains(projection_dir))
+                continue;
+
+            auto rename_it = std::find_if(ctx->files_to_rename.begin(), ctx->files_to_rename.end(), [&projection_dir](const auto & rename_pair)
             {
-                // it's a projection part directory
-                ctx->new_data_part->getDataPartStorage().createProjection(destination);
+                return rename_pair.first == projection_dir;
+            });
+            if (rename_it != ctx->files_to_rename.end())
+                continue;
 
-                auto projection_data_part_storage_src = ctx->source_part->getDataPartStorage().getProjection(destination);
-                auto projection_data_part_storage_dst = ctx->new_data_part->getDataPartStorage().getProjection(destination);
+            auto placement = ctx->new_data_part->getDataPartStorage().createProjection(projection_dir, ctx->data->getProjectionStorageFormat());
 
-                for (auto p_it = projection_data_part_storage_src->iterate(); p_it->isValid(); p_it->next())
+            auto projection_data_part_storage_src = ctx->source_part->getDataPartStorage().getProjectionStorage(projection_dir);
+            auto projection_data_part_storage_dst = ctx->new_data_part->getDataPartStorage().getProjectionStorageForWrite(placement);
+
+            for (auto p_it = projection_data_part_storage_src->iterate(); p_it->isValid(); p_it->next())
+            {
+                if ((*settings)[MergeTreeSetting::always_use_copy_instead_of_hardlinks])
                 {
-                    if ((*settings)[MergeTreeSetting::always_use_copy_instead_of_hardlinks])
-                    {
-                        projection_data_part_storage_dst->copyFileFrom(
-                            *projection_data_part_storage_src, p_it->name(), p_it->name());
-                    }
-                    else
-                    {
-                        auto file_name_with_projection_prefix = fs::path(projection_data_part_storage_src->getPartDirectory()) / p_it->name();
-
-                        projection_data_part_storage_dst->createHardLinkFrom(
-                            *projection_data_part_storage_src, p_it->name(), p_it->name());
-
-                        hardlinked_files.insert(file_name_with_projection_prefix);
-                    }
+                    projection_data_part_storage_dst->copyFileFrom(
+                        *projection_data_part_storage_src, p_it->name(), p_it->name());
                 }
+                else
+                {
+                    projection_data_part_storage_dst->createHardLinkFrom(
+                        *projection_data_part_storage_src, p_it->name(), p_it->name());
 
-                ctx->new_data_part->getDataPartStorage().commitTransaction();
-                ctx->new_data_part->getDataPartStorage().beginTransaction();
+                    /// The zero-copy keep-list uses the logical projection dir name regardless of the on-disk projection layout.
+                    hardlinked_files.insert(fs::path(projection_dir) / p_it->name());
+                }
             }
+
+            ctx->new_data_part->getDataPartStorage().commitTransaction();
+            ctx->new_data_part->getDataPartStorage().beginTransaction();
         }
 
         /// Tracking of hardlinked files required for zero-copy replication.
@@ -3028,7 +3053,7 @@ private:
                 if (projection_part->checksums.empty())
                     continue;
                 ctx->new_data_part->checksums.addFile(
-                    projection_name + ".proj",
+                    IDataPartStorage::Projection::dirName(projection_name, false),
                     projection_part->checksums.getTotalSizeOnDisk(),
                     projection_part->checksums.getTotalChecksumUInt128());
             }
@@ -3861,19 +3886,9 @@ bool MutateTask::prepare()
     String tmp_part_dir_name = prefix + ctx->future_part->name;
     ctx->temporary_directory_lock = ctx->data->getTemporaryPartDirectoryHolder(tmp_part_dir_name);
 
-    /// Reclaim a stale leftover temporary directory (a mutation interrupted or rolled back and retried
-    /// with the same deterministic name) BEFORE constructing the part storage. Otherwise packed storage
-    /// seeds its archive reader and snapshots the mark layout from the leftover data.packed, and
-    /// finalizeWriter later carries every logical file the new mutation did not rewrite into the new
-    /// part. The temporary-directory lock above guarantees no concurrent operation owns this name.
-    {
-        auto relative_tmp_dir = fs::path(ctx->data->getRelativeDataPath()) / tmp_part_dir_name;
-        if (ctx->disk->existsDirectory(relative_tmp_dir))
-        {
-            LOG_WARNING(ctx->log, "Removing old temporary directory {}", (fs::path(ctx->disk->getPath()) / relative_tmp_dir).string());
-            ctx->disk->removeRecursive(relative_tmp_dir);
-        }
-    }
+    /// The mutation tmp dir name repeats across retries; the leftover of a failed same-named attempt
+    /// must be removed before the part storage is constructed (see reclaimStaleTemporaryDirectory).
+    ctx->data->reclaimStaleTemporaryDirectory(ctx->disk, fs::path(ctx->data->getRelativeDataPath()) / tmp_part_dir_name);
 
     auto builder = ctx->data->getDataPartBuilder(ctx->future_part->name, single_disk_volume, tmp_part_dir_name, getReadSettings());
     builder.withPartFormat(ctx->future_part->part_format);

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -146,7 +146,7 @@ bool isRetryableException(std::exception_ptr exception_ptr)
     }
 }
 
-static IMergeTreeDataPart::Checksums checkDataPart(
+static CheckDataPartResult checkDataPart(
     MergeTreeData::DataPartPtr data_part,
     const IDataPartStorage & data_part_storage,
     const NamesAndTypesList & columns_list,
@@ -318,18 +318,14 @@ static IMergeTreeDataPart::Checksums checkDataPart(
         assertEOF(*buf);
     }
 
-    NameSet projections_on_disk;
     const auto & checksums_txt_files = checksums_txt.files;
     for (auto it = data_part_storage.iterate(); it->isValid(); it->next())
     {
         auto file_name = it->name();
 
         /// We will check projections later.
-        if (data_part_storage.existsDirectory(file_name) && file_name.ends_with(".proj"))
-        {
-            projections_on_disk.insert(file_name);
+        if (data_part_storage.existsDirectory(file_name) && IDataPartStorage::Projection::dirNameType(file_name) == IDataPartStorage::Projection::Status::Live)
             continue;
-        }
 
         auto checksum_it = checksums_data.files.find(file_name);
         /// Skip files that we already calculated. Also skip metadata files that are not checksummed.
@@ -353,90 +349,126 @@ static IMergeTreeDataPart::Checksums checkDataPart(
         }
     }
 
+    std::vector<std::pair<String, IMergeTreeDataPart::Checksums>> computed_projections_checksums;
     std::string broken_projections_message;
-    for (const auto & [name, projection] : data_part->getProjectionParts())
+
+    /// Check each declared projection, whatever its on-disk storage format.
+    NameSet remaining_projections_on_disk;
+    if (!data_part->isProjectionPart())
+        for (const auto & [projection_dir, projection] : data_part_storage.detectProjections())
+            if (!projection.is_temp)
+                remaining_projections_on_disk.insert(projection_dir);
+
+    if (!data_part->isProjectionPart())
     {
-        if (is_cancelled())
-            return {};
-
-        auto projection_file = name + ".proj";
-
-        IMergeTreeDataPart::Checksums projection_checksums;
-        try
+        auto metadata_snapshot = data_part->getMetadataSnapshot();
+        for (const auto & projection_desc : metadata_snapshot->projections)
         {
-            bool noop = false;
-            auto projection_storage = data_part_storage.getProjection(projection_file);
+            if (is_cancelled())
+                return {};
 
-            /// A projection part that failed to load before its columns were set (e.g. because of a
-            /// corrupted serialization.json) has an empty column list. Checking against it would
-            /// report a misleading "columns don't match" error and hide the real corruption, so
-            /// read the expected columns from the part's own columns.txt in that case. The current
-            /// projection metadata would not do: existing parts can legitimately lag behind it
-            /// after an ALTER (readable through alter conversions). If
-            /// columns.txt itself is unreadable, this throws the actual problem into the catch
-            /// below.
-            NamesAndTypesList projection_columns = projection->getColumns();
-            if (projection_columns.empty())
+            const auto projection_file = IDataPartStorage::Projection::dirName(projection_desc.name, false);
+            const bool projection_on_disk = remaining_projections_on_disk.erase(projection_file);
+
+            const String & name = projection_desc.name;
+            auto proj_it = data_part->getProjectionParts().find(name);
+            const bool loaded = proj_it != data_part->getProjectionParts().end();
+
+            /// A projection the part owns (loaded from its manifest or listed in checksums.txt) but whose
+            /// directory is gone is broken, not absent; skip only projections this part never materialized.
+            if (!projection_on_disk && !loaded && !checksums_txt.files.contains(projection_file))
+                continue;
+
+            IMergeTreeDataPart::Checksums projection_checksums;
+            bool recomputed = false;
+            try
             {
-                auto buf = projection_storage->readFile("columns.txt", read_settings, std::nullopt);
-                projection_columns.readText(*buf);
-                assertEOF(*buf);
+                bool noop = false;
+                auto projection_storage = data_part_storage.getProjectionStorage(projection_file);
+
+                /// Existing parts can lag the current metadata after an ALTER, so the expected columns are the part's own columns.txt.
+                NamesAndTypesList projection_columns = loaded ? proj_it->second->getColumns() : NamesAndTypesList{};
+                if (projection_columns.empty())
+                {
+                    auto buf = projection_storage->readFile("columns.txt", read_settings, std::nullopt);
+                    projection_columns.readText(*buf);
+                    assertEOF(*buf);
+                }
+
+                /// Advisory only - data integrity is enforced by the recompute below.
+                for (const auto & declared_col : projection_desc.sample_block)
+                {
+                    auto on_disk = projection_columns.tryGetByName(declared_col.name);
+                    if (!on_disk || !on_disk->type->equals(*declared_col.type))
+                        LOG_WARNING(log, "Part {} projection {} - column {} type {} doesn't match on-disk type {} - post-ALTER lag or stale orphan",
+                            data_part->name, name, declared_col.name, declared_col.type->getName(),
+                            on_disk ? on_disk->type->getName() : "missing");
+                }
+
+                if (loaded)
+                    projection_checksums = checkDataPart(
+                        proj_it->second, *projection_storage, projection_columns, proj_it->second->getType(),
+                        proj_it->second->getFileNamesWithoutChecksums(),
+                        read_settings, require_checksums, is_cancelled, noop, /* throw_on_broken_projection */false).computed_checksums;
+                else if (projection_storage->existsFile("checksums.txt"))
+                {
+                    auto buf = projection_storage->readFile("checksums.txt", read_settings, std::nullopt);
+                    if (!projection_checksums.read(*buf))
+                        throw Exception(ErrorCodes::CORRUPTED_DATA, "Unreadable checksums.txt for projection {}", name);
+                    assertEOF(*buf);
+                }
+                else
+                {
+                    LOG_WARNING(log, "Part {} projection {} - checksums.txt missing, recomputing from data", data_part->name, name);
+                    /// Throwaway sub-part just to drive the recompute; data_part is const here.
+                    auto projection = const_cast<IMergeTreeDataPart &>(*data_part)
+                        .getProjectionPartBuilder(name, &projection_desc).withPartFormatFromDisk().build();
+                    projection_checksums = checkDataPart(
+                        projection, *projection_storage, projection_columns, projection->getType(),
+                        projection->getFileNamesWithoutChecksums(),
+                        read_settings, require_checksums, is_cancelled, noop, /* throw_on_broken_projection */false).computed_checksums;
+                    recomputed = true;
+                }
+            }
+            catch (...)
+            {
+                if (isRetryableException(std::current_exception()))
+                    throw;
+
+                is_broken_projection = true;
+                checksums_txt.remove(projection_file);
+
+                const auto exception_message = getCurrentExceptionMessage(true);
+                LOG_WARNING(log, "Marking projection {} as broken ({}). Reason: {}", name, projection_file, exception_message);
+                if (loaded && !proj_it->second->is_broken)
+                    proj_it->second->setBrokenReason(exception_message, getCurrentExceptionCode());
+
+                if (throw_on_broken_projection)
+                {
+                    if (!broken_projections_message.empty())
+                        broken_projections_message += "\n";
+                    broken_projections_message += fmt::format(
+                        "Part `{}` has broken projection `{}` (error: {})", data_part->name, name, exception_message);
+                }
+
+                continue;
             }
 
-            projection_checksums = checkDataPart(
-                projection, *projection_storage,
-                projection_columns, projection->getType(),
-                projection->getFileNamesWithoutChecksums(),
-                read_settings, require_checksums, is_cancelled, noop, /* throw_on_broken_projection */false);
+            checksums_data.files[projection_file] = IMergeTreeDataPart::Checksums::Checksum(
+                projection_checksums.getTotalSizeOnDisk(),
+                projection_checksums.getTotalChecksumUInt128());
+            if (recomputed)
+                computed_projections_checksums.emplace_back(name, projection_checksums);
         }
-        catch (...)
-        {
-            if (isRetryableException(std::current_exception()))
-                throw;
-
-            is_broken_projection = true;
-            projections_on_disk.erase(projection_file);
-            checksums_txt.remove(projection_file);
-
-            const auto exception_message = getCurrentExceptionMessage(true);
-
-            if (!projection->is_broken)
-            {
-                LOG_WARNING(log, "Marking projection {} as broken ({}). Reason: {}",
-                            name, projection_file, exception_message);
-                projection->setBrokenReason(exception_message, getCurrentExceptionCode());
-            }
-
-            if (throw_on_broken_projection)
-            {
-                if (!broken_projections_message.empty())
-                    broken_projections_message += "\n";
-
-                broken_projections_message += fmt::format(
-                    "Part `{}` has broken projection `{}` (error: {})",
-                    data_part->name, name, exception_message);
-            }
-
-            continue;
-        }
-
-        checksums_data.files[projection_file] = IMergeTreeDataPart::Checksums::Checksum(
-            projection_checksums.getTotalSizeOnDisk(),
-            projection_checksums.getTotalChecksumUInt128());
-
-        projections_on_disk.erase(projection_file);
     }
 
-    /// Handle unknown projections: on disk and in checksums but not in the
-    /// part's projection list (e.g. a projection was dropped while the part
-    /// was detached, then re-attached).  Remove them from checksums_txt so
-    /// that the checkEqual below does not fail, and mark the part as having
-    /// a broken projection so the caller can handle it gracefully.
-    if (!projections_on_disk.empty())
+    /// Left over = on disk but not declared in metadata: residue, or a projection dropped while the part was detached.
+    if (!remaining_projections_on_disk.empty())
     {
         is_broken_projection = true;
-        for (const auto & projection_file : projections_on_disk)
-            checksums_txt.remove(projection_file);
+        for (const auto & projection_file : remaining_projections_on_disk)
+            if (checksums_txt.files.contains(projection_file))
+                checksums_txt.remove(projection_file);
     }
 
     /// Also handle leftover checksums entries for projections that are unknown to the current metadata
@@ -463,16 +495,12 @@ static IMergeTreeDataPart::Checksums checkDataPart(
     if (throw_on_broken_projection)
     {
         if (!broken_projections_message.empty())
-        {
             throw Exception(ErrorCodes::BROKEN_PROJECTION, "{}", broken_projections_message);
-        }
 
-        if (require_checksums && !projections_on_disk.empty())
-        {
+        if (require_checksums && !remaining_projections_on_disk.empty())
             throw Exception(ErrorCodes::UNEXPECTED_FILE_IN_DATA_PART,
                 "Found unexpected projection directories: {}",
-                fmt::join(projections_on_disk, ","));
-        }
+                fmt::join(remaining_projections_on_disk, ","));
     }
 
     if (is_cancelled())
@@ -481,10 +509,10 @@ static IMergeTreeDataPart::Checksums checkDataPart(
     if (require_checksums || !checksums_txt.files.empty())
         checksums_txt.checkEqual(checksums_data, check_uncompressed, data_part->name);
 
-    return checksums_data;
+    return {std::move(checksums_data), std::move(computed_projections_checksums)};
 }
 
-IMergeTreeDataPart::Checksums checkDataPart(
+CheckDataPartResult checkDataPart(
     MergeTreeData::DataPartPtr data_part,
     bool require_checksums,
     bool & is_broken_projection,
@@ -548,7 +576,7 @@ IMergeTreeDataPart::Checksums checkDataPart(
                 /// We were unable to check data part because of some temporary exception
                 /// like Memory limit exceeded. If part is actually broken we will retry check
                 /// with the next read attempt of this data part.
-                return IMergeTreeDataPart::Checksums{};
+                return CheckDataPartResult{};
             }
             throw;
         }

--- a/src/Storages/MergeTree/checkDataPart.h
+++ b/src/Storages/MergeTree/checkDataPart.h
@@ -6,8 +6,15 @@
 namespace DB
 {
 
+/// Recomputed checksums of the part and of every projection whose own checksums.txt was regenerated (missing on disk).
+struct CheckDataPartResult
+{
+    IMergeTreeDataPart::Checksums computed_checksums;
+    std::vector<std::pair<String, IMergeTreeDataPart::Checksums>> computed_projections_checksums;
+};
+
 /// Calculates checksums and compares them with checksums.txt.
-IMergeTreeDataPart::Checksums checkDataPart(
+CheckDataPartResult checkDataPart(
     MergeTreeData::DataPartPtr data_part,
     bool require_checksums,
     bool & is_broken_projection,

--- a/src/Storages/MergeTree/tests/gtest_projection_storage_schema.cpp
+++ b/src/Storages/MergeTree/tests/gtest_projection_storage_schema.cpp
@@ -1,0 +1,206 @@
+#include <gtest/gtest.h>
+
+#include <base/defines.h>
+#include <Common/Exception.h>
+#include <Disks/DiskLocal.h>
+#include <Disks/SingleDiskVolume.h>
+#include <Storages/MergeTree/DataPartStorageOnDiskFull.h>
+
+#include <filesystem>
+
+using namespace DB;
+
+/// LOGICAL_ERROR aborts in debug/sanitizer builds but throws in release (handle_error_code only aborts
+/// when debug_or_sanitizer_build is set); branch the assertion on build type to match the runtime.
+#ifdef DEBUG_OR_SANITIZER_BUILD
+#    define EXPECT_LOGICAL_ERROR(statement) EXPECT_DEATH(statement, ".*")
+#else
+#    define EXPECT_LOGICAL_ERROR(statement) EXPECT_THROW(statement, Exception)
+#endif
+
+namespace
+{
+
+/// Records which directories get a sync guard requested; the fsync tests assert guard placement.
+struct SyncGuardRecordingDisk : DiskLocal
+{
+    using DiskLocal::DiskLocal;
+    mutable Strings sync_guard_paths;
+
+    SyncGuardPtr getDirectorySyncGuard(const String & path) const override
+    {
+        /// Normalize the path-join trailing slash so assertions pin the directory, not its string form.
+        sync_guard_paths.push_back(path.ends_with('/') ? path.substr(0, path.size() - 1) : path);
+        return DiskLocal::getDirectorySyncGuard(path);
+    }
+};
+
+struct PartStorageFixture
+{
+    std::filesystem::path base_path;
+    std::string part_dir;
+    std::shared_ptr<SyncGuardRecordingDisk> disk;
+    VolumePtr volume;
+    std::shared_ptr<DataPartStorageOnDiskFull> storage;
+
+    PartStorageFixture()
+    {
+        auto base = std::filesystem::temp_directory_path();
+        auto unique_id = std::to_string(::getpid()) + "_" + std::to_string(reinterpret_cast<uintptr_t>(this));
+        base_path = base / ("projection_schema_gtest_" + unique_id);
+        std::filesystem::create_directories(base_path);
+        part_dir = "all_1_1_0";
+        std::filesystem::create_directories(base_path / part_dir);
+
+        disk = std::make_shared<SyncGuardRecordingDisk>("test_disk_" + unique_id, base_path.string());
+        volume = std::make_shared<SingleDiskVolume>("test_volume", disk);
+        storage = std::make_shared<DataPartStorageOnDiskFull>(volume, /*root_path=*/ "", part_dir);
+    }
+
+    ~PartStorageFixture()
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(base_path, ec);
+    }
+};
+
+}
+
+TEST(ProjectionDirNames, Classification)
+{
+    EXPECT_EQ(IDataPartStorage::Projection::dirNameType("p.proj"), IDataPartStorage::Projection::Status::Live);
+    EXPECT_EQ(IDataPartStorage::Projection::dirNameType("p.tmp_proj"), IDataPartStorage::Projection::Status::Temp);
+    EXPECT_EQ(IDataPartStorage::Projection::dirNameType("all_1_1_0"), IDataPartStorage::Projection::Status::None);
+    EXPECT_EQ(IDataPartStorage::Projection::dirNameType("proj"), IDataPartStorage::Projection::Status::None);
+    EXPECT_EQ(IDataPartStorage::Projection::dirNameType(""), IDataPartStorage::Projection::Status::None);
+}
+
+TEST(ProjectionStorageSchemaDeathTest, UnseededReadsAbort)
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    PartStorageFixture fixture;
+    EXPECT_LOGICAL_ERROR(fixture.storage->getProjections());
+    EXPECT_LOGICAL_ERROR(fixture.storage->getProjection("p.proj"));
+    EXPECT_LOGICAL_ERROR(fixture.storage->getProjectionStorage("p.proj", true));
+}
+
+TEST(ProjectionStorageSchemaDeathTest, RemoveLiveProjectionAborts)
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    PartStorageFixture fixture;
+    fixture.storage->setProjections({});
+    fixture.storage->createProjection("p_1.tmp_proj", IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    fixture.storage->renameProjection(fixture.storage->getProjection("p_1.tmp_proj"), "p.proj", /*fsync=*/ false);
+
+    /// Only temporary projections may be removed individually; removing a live one is a logical error.
+    EXPECT_LOGICAL_ERROR(fixture.storage->removeProjection(fixture.storage->getProjection("p.proj")));
+}
+
+TEST(ProjectionStorageSchemaDeathTest, WriteAccessRequiresOwnedProjection)
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    PartStorageFixture fixture;
+    fixture.storage->setProjections({});
+
+    /// A placement that never went through createProjection does not unlock writable storage.
+    EXPECT_LOGICAL_ERROR(fixture.storage->getProjectionStorageForWrite(fixture.storage->projectionPlacement("p.proj", IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED), true));
+
+    /// The descriptor produced by createProjection does.
+    auto placement = fixture.storage->createProjection("p.proj", IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    EXPECT_NE(fixture.storage->getProjectionStorageForWrite(placement, true), nullptr);
+}
+
+TEST(ProjectionStorageSchema, EmptySchemaIsValid)
+{
+    PartStorageFixture fixture;
+    fixture.storage->setProjections({});
+    EXPECT_TRUE(fixture.storage->getProjections().empty());
+    EXPECT_FALSE(fixture.storage->hasProjection("p.proj"));
+}
+
+TEST(ProjectionStorageSchema, CreateRenameRemoveMaintainCache)
+{
+    PartStorageFixture fixture;
+    fixture.storage->setProjections({});
+
+    fixture.storage->createProjection("p_1.tmp_proj", IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    ASSERT_TRUE(fixture.storage->hasProjection("p_1.tmp_proj"));
+    ASSERT_TRUE(std::filesystem::exists(fixture.base_path / "all_1_1_0" / "p_1.tmp_proj"));
+
+    fixture.storage->renameProjection(fixture.storage->getProjection("p_1.tmp_proj"), "p.proj", /*fsync=*/ false);
+    EXPECT_FALSE(fixture.storage->hasProjection("p_1.tmp_proj"));
+    ASSERT_TRUE(fixture.storage->hasProjection("p.proj"));
+    EXPECT_FALSE(std::filesystem::exists(fixture.base_path / "all_1_1_0" / "p_1.tmp_proj"));
+    ASSERT_TRUE(std::filesystem::exists(fixture.base_path / "all_1_1_0" / "p.proj"));
+
+    fixture.storage->createProjection("q.tmp_proj", IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    fixture.storage->removeProjection(fixture.storage->getProjection("q.tmp_proj"));
+    EXPECT_FALSE(fixture.storage->hasProjection("q.tmp_proj"));
+    EXPECT_FALSE(std::filesystem::exists(fixture.base_path / "all_1_1_0" / "q.tmp_proj"));
+
+    /// The schema survives and matches disk truth.
+    auto detected = fixture.storage->detectProjections();
+    ASSERT_EQ(detected.size(), 1u);
+    EXPECT_TRUE(detected.contains("p.proj"));
+    EXPECT_EQ(detected.at("p.proj").format, IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+}
+
+TEST(ProjectionStorageSchema, DetectProjections)
+{
+    PartStorageFixture fixture;
+    std::filesystem::create_directories(fixture.base_path / fixture.part_dir / "nested.proj");
+    std::filesystem::create_directories(fixture.base_path / fixture.part_dir / "tmp.tmp_proj");
+    std::filesystem::create_directories(fixture.base_path / fixture.part_dir / "not_a_projection");
+
+    auto detected = fixture.storage->detectProjections();
+    ASSERT_EQ(detected.size(), 2u);
+    EXPECT_EQ(detected.at("nested.proj").format, IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    EXPECT_TRUE(detected.at("tmp.tmp_proj").is_temp);
+}
+
+TEST(ProjectionStorageSchema, RenameKeepsHistoricalFsync)
+{
+    /// The historical single sync on the moved dir (02361_fsync_profile_events pins the event count).
+    PartStorageFixture plain;
+    plain.storage->setProjections({});
+    plain.disk->sync_guard_paths.clear();
+    plain.storage->rename("", "all_2_2_0", nullptr, false, /*fsync_part_dir=*/ true);
+    EXPECT_EQ(plain.disk->sync_guard_paths, (Strings{"all_2_2_0"}));
+
+    /// Without the setting nothing is synced.
+    PartStorageFixture fixture;
+    fixture.storage->setProjections({});
+    fixture.disk->sync_guard_paths.clear();
+    fixture.storage->rename("", "all_1_1_1", nullptr, false, /*fsync_part_dir=*/ false);
+    EXPECT_TRUE(fixture.disk->sync_guard_paths.empty());
+}
+
+TEST(ProjectionStorageSchema, RenameProjectionFsyncsEnclosingDir)
+{
+    PartStorageFixture fixture;
+    fixture.storage->setProjections({});
+
+    /// The rename entry lives in the part dir.
+    fixture.storage->createProjection("q_1.tmp_proj", IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    fixture.disk->sync_guard_paths.clear();
+    fixture.storage->renameProjection(fixture.storage->getProjection("q_1.tmp_proj"), "q.proj", /*fsync=*/ true);
+    EXPECT_EQ(fixture.disk->sync_guard_paths, (Strings{"all_1_1_0"}));
+
+    /// fsync=false requests no guards.
+    fixture.disk->sync_guard_paths.clear();
+    fixture.storage->renameProjection(fixture.storage->getProjection("q.proj"), "q_1.tmp_proj", /*fsync=*/ false);
+    EXPECT_TRUE(fixture.disk->sync_guard_paths.empty());
+}
+
+TEST(ProjectionStorageSchema, ProbeProjections)
+{
+    PartStorageFixture fixture;
+    std::filesystem::create_directories(fixture.base_path / fixture.part_dir / "nested.proj");
+    std::filesystem::create_directories(fixture.base_path / fixture.part_dir / "other.proj");
+
+    auto probed = fixture.storage->detectProjections({.candidates = Strings{"nested.proj", "other.proj", "absent.proj"}});
+    ASSERT_EQ(probed.size(), 2u);
+    EXPECT_EQ(probed.at("nested.proj").format, IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    EXPECT_EQ(probed.at("other.proj").format, IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    EXPECT_FALSE(probed.contains("absent.proj"));
+}

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -3436,7 +3436,7 @@ std::optional<CheckResult> StorageMergeTree::checkDataNext(DataValidationTasksPt
         {
             try
             {
-                auto calculated_checksums = checkDataPart(part, false, noop, /* is_cancelled */[]{ return false; }, /* throw_on_broken_projection */true);
+                auto calculated_checksums = checkDataPart(part, false, noop, /* is_cancelled */[]{ return false; }, /* throw_on_broken_projection */true).computed_checksums;
                 calculated_checksums.checkEqual(part->checksums, true, part->name);
 
                 auto & part_mutable = const_cast<IMergeTreeDataPart &>(*part);

--- a/tests/integration/test_projection_storage_format/configs/storage_conf.xml
+++ b/tests/integration/test_projection_storage_format/configs/storage_conf.xml
@@ -1,0 +1,31 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <s3>
+                <type>s3</type>
+                <endpoint>http://minio1:9001/root/data/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
+            </s3>
+        </disks>
+        <policies>
+            <s3>
+                <volumes>
+                    <main>
+                        <disk>s3</disk>
+                    </main>
+                </volumes>
+            </s3>
+            <default_and_s3>
+                <volumes>
+                    <main>
+                        <disk>default</disk>
+                    </main>
+                    <external>
+                        <disk>s3</disk>
+                    </external>
+                </volumes>
+            </default_and_s3>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_projection_storage_format/test.py
+++ b/tests/integration/test_projection_storage_format/test.py
@@ -1,0 +1,662 @@
+import os
+import time
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/storage_conf.xml"],
+    with_minio=True,
+    with_zookeeper=True,
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield
+    finally:
+        cluster.shutdown()
+
+
+# ==============================================================================
+# Shared helpers
+# ==============================================================================
+def setup_table(name, extra_settings="", n=node):
+    n.query(f"DROP TABLE IF EXISTS {name} SYNC")
+    n.query("SYSTEM STOP MERGES")  # keep a single, predictable part
+    settings = "min_bytes_for_wide_part = 0"
+    if extra_settings:
+        settings += ", " + extra_settings
+    n.query(
+        f"""CREATE TABLE {name} (key UInt64, id UInt64, value String,
+            PROJECTION p (SELECT key, id, value ORDER BY id))
+            ENGINE = MergeTree ORDER BY key SETTINGS {settings}"""
+    )
+    n.query(
+        f"INSERT INTO {name} SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+
+def part_dir(name, n=node):  # absolute container path, no trailing slash: .../all_1_1_0
+    return (
+        n.query(
+            f"SELECT path FROM system.parts WHERE table = '{name}' AND active = 1 LIMIT 1"
+        )
+        .strip()
+        .rstrip("/")
+    )
+
+
+def part_name(name, n=node):
+    return part_dir(name, n).split("/")[-1]
+
+
+def proj_query(name, n=node, extra_settings=""):
+    settings = "optimize_use_projections = 1"
+    if extra_settings:
+        settings += ", " + extra_settings
+    return n.query(
+        f"SELECT count(), sum(key) FROM {name} WHERE id < 200 SETTINGS {settings}"
+    ).strip()
+
+
+def check_table(name, n=node):
+    return n.query(
+        f"CHECK TABLE {name} SETTINGS check_query_single_value_result = 1"
+    ).strip()
+
+
+def path_exists(p, n=node):
+    return (
+        n.exec_in_container(
+            ["bash", "-c", f"test -e {p} && echo 1 || echo 0"],
+            privileged=True,
+            user="root",
+        ).strip()
+        == "1"
+    )
+
+
+def active_parts(name, n=node):
+    return n.query(
+        f"SELECT count() FROM system.parts WHERE table = '{name}' AND active = 1"
+    ).strip()
+
+
+def active_projection_parts(name, n=node):
+    return n.query(
+        f"SELECT count() FROM system.projection_parts WHERE table = '{name}' AND active = 1"
+    ).strip()
+
+
+def broken_projection_parts(name, n=node):
+    return n.query(
+        f"SELECT count() FROM system.projection_parts WHERE table = '{name}' AND is_broken"
+    ).strip()
+
+
+def wait_for(predicate, timeout=60):
+    for _ in range(timeout * 2):
+        if predicate():
+            return
+        time.sleep(0.5)
+    raise AssertionError(f"wait_for timed out after {timeout}s")
+
+
+def block_until_tables_loaded(name, n=node):
+    # Reads the real table to wait out its async load (async_load_databases = 1); a system.parts read does not.
+    # Call after a (re)start before asserting on system.* so the assert does not race the background loader.
+    n.query(f"SELECT count() FROM {name}")
+
+
+# Table-level settings clause that forces packed part storage regardless of part size.
+PACKED = "min_bytes_for_full_part_storage = '1G'"
+
+
+def packed_archive_member(part_path, member, n=node, disk="default"):
+    """Content of one member file of the data.packed archive at part_path."""
+    root = n.query(f"SELECT path FROM system.disks WHERE name = '{disk}'").strip()
+    rel = os.path.relpath(os.path.join(part_path, "data.packed"), root)
+    out_rel = "tmp_packed_extract"
+    out_abs = os.path.join(root, out_rel)
+    n.exec_in_container(["bash", "-c", f"rm -rf {out_abs}"], privileged=True, user="root")
+    n.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"clickhouse disks --config /etc/clickhouse-server/config.xml --disk {disk}"
+            f' --query "packed-io extract --disk-from {disk} {rel} {out_rel}"',
+        ],
+        privileged=True,
+        user="root",
+    )
+    content = n.exec_in_container(
+        ["bash", "-c", f"cat {out_abs}/{member} && rm -rf {out_abs}"],
+        privileged=True,
+        user="root",
+    ).strip()
+    return content
+
+
+# Storage kinds a test runs for; 'packed' appends the packed-threshold clause to the table settings.
+@pytest.fixture(params=["full", "packed"])
+def storage_kind(request):
+    return request.param
+
+
+def with_storage(extra_settings, storage_kind):
+    return extra_settings + (", " + PACKED if storage_kind == "packed" else "")
+
+
+# Disk backend a mutation/rebuild test runs for. 'local' is the default disk (immediate part
+# transactions); 's3' is the MinIO-backed disk, which runs DEFERRED transactions -- the setting the
+# object-storage projection-rebuild regression needs. See section N. (Azure/Azurite exercises the same
+# deferred-transaction path; it was verified manually but kept out of the automated matrix because a
+# per-worker azurite cluster times out under xdist parallelism -- s3 covers the regression.)
+@pytest.fixture(params=["local", "s3"])
+def disk(request):
+    return request.param
+
+
+def with_disk(extra_settings, disk):
+    return extra_settings + (f", storage_policy = '{disk}'" if disk != "local" else "")
+
+
+# ==============================================================================
+# A. Layout basics
+# ==============================================================================
+
+# This test pins the projection on-disk layout: the projection is stored nested inside its parent
+# part directory, and no sibling directory ever appears at the parts root.
+# Scenario:
+# - create table with a projection
+# - assert structure: the projection is nested inside the part, no sibling at the parts root
+# - assert SELECT through the projection
+# - restart, assert SELECT unchanged and the part is intact
+def test_layout_nested():
+    setup_table("t_nested")
+
+    # assert structure: nested inside the part, no sibling at the parts root
+    p = part_dir("t_nested")
+    assert path_exists(f"{p}/p.proj")
+    assert not path_exists(f"{p}.p.proj")
+
+    # assert SELECT through the projection
+    baseline = proj_query("t_nested")
+
+    # restart, assert SELECT unchanged and the part intact
+    node.restart_clickhouse()
+    assert proj_query("t_nested") == baseline
+    assert active_parts("t_nested") == "1"
+
+
+# ==============================================================================
+# F. Manifest desync, repair, and adoption policy
+# ==============================================================================
+
+# A projection dir present on disk and declared in metadata but missing from checksums.txt is NOT
+# adopted: checksums.txt is the commit point, loadProjections loads only what the manifest lists.
+
+
+def _make_desync_pair(
+    prefix,
+    extra="",
+    donor_rows=1000,
+    donor_offset=0,
+    projection="p (SELECT key, id ORDER BY id)",
+    donor_projection=None,
+    donor_id_type="UInt64",
+):
+    """Victim table whose part has NO projection dir/record + a donor providing a real dir.
+    The donor knobs shape the planted dir: row count/values, projection definition, column type."""
+    donor_projection = donor_projection or projection
+    node.query(f"DROP TABLE IF EXISTS {prefix} SYNC")
+    node.query(f"DROP TABLE IF EXISTS {prefix}_donor SYNC")
+    node.query("SYSTEM STOP MERGES")
+    settings = "min_bytes_for_wide_part = 0"
+    if extra:
+        settings += ", " + extra
+    node.query(
+        f"""CREATE TABLE {prefix} (key UInt64, id UInt64, value String,
+           PROJECTION {projection})
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS {settings}, materialize_projections_on_insert = 0"""
+    )
+    node.query(
+        f"""CREATE TABLE {prefix}_donor (key UInt64, id {donor_id_type}, value String,
+           PROJECTION {donor_projection})
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS {settings}"""
+    )
+    node.query(
+        f"INSERT INTO {prefix} SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+    node.query(
+        f"INSERT INTO {prefix}_donor SELECT number, number * 2, toString(number) FROM numbers({donor_offset}, {donor_rows})"
+    )
+
+
+def _manifest_mentions_projection(part_path):
+    return (
+        node.exec_in_container(
+            ["bash", "-c", f"grep -aco 'p\\.proj' {part_path}/checksums.txt || true"],
+            privileged=True,
+            user="root",
+        ).strip()
+        != "0"
+    )
+
+
+# This test checks that regenerating a lost manifest restores projection records: without the fix
+# checkDataPart folds them only from the (empty-during-repair) projection map and drops every projection.
+# Scenario:
+# - create table with a projection, capture SELECT baseline
+# - stop the server, delete checksums.txt, start it (manifest is regenerated)
+# - assert the data reads, the projection is healthy, SELECT matches, CHECK TABLE passes
+# - restart and assert the regenerated manifest still references the projection
+def test_desync_repair_regenerates_records():
+    # create table with a projection, capture baseline
+    setup_table("t_fix")
+    baseline = proj_query("t_fix")
+    p = part_dir("t_fix")
+
+    # delete checksums.txt so the manifest is regenerated on load
+    node.stop_clickhouse()
+    node.exec_in_container(
+        ["bash", "-c", f"rm {p}/checksums.txt"], privileged=True, user="root"
+    )
+    node.start_clickhouse()
+
+    # assert the data reads, the projection is healthy and served, CHECK passes
+    assert node.query("SELECT count() FROM t_fix").strip() == "1000"
+    assert broken_projection_parts("t_fix") == "0"
+    assert proj_query("t_fix", extra_settings="force_optimize_projection = 1") == baseline
+    assert check_table("t_fix") == "1"
+
+    # assert the regenerated manifest references the projection: it must survive a reload
+    node.restart_clickhouse()
+    block_until_tables_loaded("t_fix")
+    assert active_projection_parts("t_fix") == "1"
+    assert check_table("t_fix") == "1"
+
+
+# A projection dir planted inside a part but absent from checksums.txt is not adopted:
+# checksums is the commit point. The dir is ignored, the part reads from the base.
+# Scenario:
+# - build a desync pair whose victim has no projection record
+# - stop the server, copy the donor's projection dir into the victim part, start it
+# - assert the projection is not adopted (not active, not broken, not in the manifest) and data reads
+def test_desync_unlisted_dir_ignored():
+    # build a desync pair, then plant the donor's projection dir inside the victim part
+    _make_desync_pair("t_ln")
+    p = part_dir("t_ln")
+    donor_proj = f"{part_dir('t_ln_donor')}/p.proj"
+    node.stop_clickhouse()
+    node.exec_in_container(
+        ["bash", "-c", f"cp -r {donor_proj} {p}/p.proj && chmod -R 777 {p}/p.proj"],
+        privileged=True,
+        user="root",
+    )
+    node.start_clickhouse()
+    block_until_tables_loaded("t_ln")
+
+    # assert the unlisted dir is ignored, not adopted
+    assert node.query("SELECT count() FROM t_ln").strip() == "1000"
+    assert active_projection_parts("t_ln") == "0"
+    assert broken_projection_parts("t_ln") == "0"
+    assert not _manifest_mentions_projection(p)
+
+
+# ==============================================================================
+# G. Reload consistency
+# ==============================================================================
+
+# This test checks that CHECK TABLE classifies an unknown projection (left after DROP PROJECTION
+# on a detached part) as a projection problem, not a broken part.
+# Scenario:
+# - create table with a projection, DETACH PART, DROP PROJECTION, ATTACH PART
+# - run CHECK TABLE
+# - assert the result reports "unexpected projection" and the data is still readable
+def test_reload_check_table_dropped_projection():
+    # create table with a projection, then drop the projection while the part is detached
+    setup_table("t_chk")
+    name = part_name("t_chk")
+    node.query(f"ALTER TABLE t_chk DETACH PART '{name}'")
+    node.query("ALTER TABLE t_chk DROP PROJECTION p")
+    node.query(f"ALTER TABLE t_chk ATTACH PART '{name}'")
+
+    # assert CHECK TABLE flags the unknown projection and the data stays readable
+    result = node.query("CHECK TABLE t_chk SETTINGS check_query_single_value_result = 0")
+    assert "unexpected projection" in result, result
+    assert node.query("SELECT count() FROM t_chk").strip() == "1000"
+
+
+# ==============================================================================
+# M. Packed part storage
+# ==============================================================================
+
+
+# This test checks that REPLACE PARTITION FROM on packed parts does not apply parent-only
+# ClonePartParams to projection sub-parts: metadata_version_to_write must not overwrite the
+# projection's own metadata_version.txt (every part, projections included, carries one since
+# INSERT), and invalidated_system_columns.txt must not be manufactured inside the projection dir.
+# Scenario:
+# - create packed replicated src and dst tables with a projection; insert, then bump both tables'
+#   metadata version so the src part predates it
+# - REPLACE PARTITION on dst from src (this flow sets both parent-only params)
+# - assert the dst parent part carries the bumped version + the invalidated-columns file
+# - assert the dst projection sub-part keeps the part's original version and has no invalidated file
+def test_packed_replace_partition_no_parent_artifacts_in_projection():
+    for t, zk in (("t_pk_rp_src", "src"), ("t_pk_rp_dst", "dst")):
+        node.query(f"DROP TABLE IF EXISTS {t} SYNC")
+        node.query("SYSTEM STOP MERGES")
+        node.query(
+            f"""CREATE TABLE {t} (key UInt64, id UInt64, value String,
+                PROJECTION p (SELECT key, id, value ORDER BY id))
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/t_pk_rp_{zk}', '1')
+                ORDER BY key
+                SETTINGS min_bytes_for_wide_part = 0, {PACKED}"""
+        )
+    node.query(
+        "INSERT INTO t_pk_rp_src SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+    # Bump both tables to metadata version >= 1 after the insert (identical structures keep REPLACE
+    # legal; a comment-only change would not bump the version). The src part stays at version 0, so
+    # an override reaching the projection sub-part is distinguishable from the version INSERT wrote.
+    for t in ("t_pk_rp_src", "t_pk_rp_dst"):
+        node.query(f"ALTER TABLE {t} ADD COLUMN extra UInt8 DEFAULT 0")
+    node.query("ALTER TABLE t_pk_rp_dst REPLACE PARTITION ID 'all' FROM t_pk_rp_src")
+
+    # the cloned part is packed and carries its nested packed projection
+    p = part_dir("t_pk_rp_dst")
+    assert path_exists(f"{p}/data.packed")
+    assert path_exists(f"{p}/p.proj/data.packed")
+
+    # parent-only artifacts land at the part level: the overridden version and the invalidated file...
+    assert packed_archive_member(p, "metadata_version.txt") != "0"
+    assert path_exists(f"{p}/invalidated_system_columns.txt")
+
+    # ...and must not be applied to the projection sub-part
+    assert packed_archive_member(f"{p}/p.proj", "metadata_version.txt") == "0"
+    assert not path_exists(f"{p}/p.proj/invalidated_system_columns.txt")
+
+    # the projection still serves queries and the part passes CHECK TABLE
+    assert proj_query("t_pk_rp_dst") == proj_query("t_pk_rp_src")
+    assert check_table("t_pk_rp_dst") == "1"
+
+
+# This test checks that freeze of a packed part copies projections from the part's owned set instead
+# of walking the part dir on disk: residue directories of a failed operation (a live-named dir the
+# checksums manifest never adopted, or a *.tmp_proj leftover) must not be carried into the copy.
+# Scenario:
+# - create a packed table with a projection
+# - plant residue dirs inside the live part dir: residue.proj and p_1.tmp_proj
+# - FREEZE WITH NAME
+# - assert the shadow copy carries p.proj (with its archive) and neither residue dir
+def test_packed_freeze_excludes_residue():
+    setup_table("t_pk_frz", PACKED)
+    p = part_dir("t_pk_frz")
+    assert path_exists(f"{p}/data.packed")
+
+    # plant residue: an unadopted live-named dir and a temp leftover, both with a marker file
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"mkdir -p {p}/residue.proj {p}/p_1.tmp_proj"
+            f" && touch {p}/residue.proj/stale_marker.txt {p}/p_1.tmp_proj/stale_marker.txt"
+            f" && chmod -R 777 {p}/residue.proj {p}/p_1.tmp_proj",
+        ],
+        privileged=True,
+        user="root",
+    )
+
+    node.query("ALTER TABLE t_pk_frz FREEZE WITH NAME 'pkfrz'")
+
+    # the shadow copy carries the owned projection but no residue
+    name = part_name("t_pk_frz")
+    shadow = node.exec_in_container(
+        ["bash", "-c", f"find /var/lib/clickhouse/shadow/pkfrz -maxdepth 4 -name '{name}' -type d | head -1"],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert shadow != ""
+    assert path_exists(f"{shadow}/data.packed")
+    assert path_exists(f"{shadow}/p.proj/data.packed")
+    assert not path_exists(f"{shadow}/residue.proj")
+    assert not path_exists(f"{shadow}/p_1.tmp_proj")
+
+
+# This test checks that DETACH/ATTACH PART carries the nested packed projection sub-part
+# (freeze-based detach clone, then attach) and leaves it healthy.
+# Scenario:
+# - create a packed table with a projection, capture SELECT baseline
+# - DETACH PART; assert the detached copy carries p.proj/data.packed
+# - ATTACH PART; assert the projection is healthy and SELECT matches baseline
+def test_packed_detach_attach_carries_projection():
+    setup_table("t_pk_da", PACKED)
+    baseline = proj_query("t_pk_da")
+    live = part_dir("t_pk_da")
+    name = part_name("t_pk_da")
+    table_root = live.rsplit("/", 1)[0]
+    assert path_exists(f"{live}/data.packed")
+
+    node.query(f"ALTER TABLE t_pk_da DETACH PART '{name}'")
+    assert not path_exists(live)
+    assert path_exists(f"{table_root}/detached/{name}/data.packed")
+    assert path_exists(f"{table_root}/detached/{name}/p.proj/data.packed")
+
+    node.query(f"ALTER TABLE t_pk_da ATTACH PART '{name}'")
+    p = part_dir("t_pk_da")
+    assert path_exists(f"{p}/p.proj/data.packed")
+    assert broken_projection_parts("t_pk_da") == "0"
+    assert (
+        proj_query("t_pk_da", extra_settings="force_optimize_projection = 1") == baseline
+    )
+    assert check_table("t_pk_da") == "1"
+
+
+# This test checks that a mutation of a projected column rebuilds the packed projection (checksums
+# recalculated) and the rebuilt projection reflects the mutated data.
+# Scenario:
+# - create a packed table with a projection
+# - ALTER UPDATE a column read by the projection
+# - assert the projection is healthy, serves the updated data, and the part passes CHECK TABLE
+def test_packed_mutation_rebuilds_projection():
+    setup_table("t_pk_mut", PACKED)
+    assert path_exists(f"{part_dir('t_pk_mut')}/data.packed")
+    baseline = proj_query("t_pk_mut")
+
+    # mutate a non-key column the projection materializes
+    node.query(
+        "ALTER TABLE t_pk_mut UPDATE value = concat(value, 'xx') WHERE id < 200 SETTINGS mutations_sync = 2"
+    )
+
+    p = part_dir("t_pk_mut")
+    assert path_exists(f"{p}/p.proj/data.packed")
+    assert broken_projection_parts("t_pk_mut") == "0"
+    assert (
+        proj_query("t_pk_mut", extra_settings="force_optimize_projection = 1")
+        == baseline
+    )
+    # 100 rows have id < 200 (values "0".."99": 10 + 2*90 = 190 chars), each grew by 2 chars
+    updated = node.query(
+        "SELECT count(), sum(length(value)) FROM t_pk_mut WHERE id < 200 "
+        "SETTINGS optimize_use_projections = 1, force_optimize_projection = 1"
+    ).strip()
+    assert updated == "100\t390"
+    assert check_table("t_pk_mut") == "1"
+
+
+# ==============================================================================
+# N. Object-storage rebuild-path regression
+#
+# A projection REBUILT during a mutation on an object-storage disk must survive the part's final
+# rename. Object-storage disks run DEFERRED part transactions (master #89658 / 228ca4c8a4c): the
+# rebuilt projection's `<n>.tmp_proj -> <name>.proj` move is queued and not yet on disk when the
+# mutation's finalize re-derives the part's owned projection set from a disk probe, so the probe
+# misses it and the tmp->final repoint is skipped. The failure surfaces at READ time as
+# `Code 107 FILE_DOESNT_EXIST` on a `tmp_mut_.../<name>.proj/...` path, after the mutation itself
+# succeeded. On the default (local) disk the transaction is immediate, the probe sees the move, and
+# the bug is invisible -- which is why every other test in this file, all on the local disk, misses
+# it. Each test runs both on 'local' (control: must pass) and 's3' (the regression surface).
+#
+# Fail-closed: force_optimize_projection = 1 throws if the projection cannot serve the query, so a
+# silently-skipped (unused) projection cannot masquerade as a pass -- that is exactly what let the
+# regression through the existing suite.
+# ==============================================================================
+
+
+# This test checks the canonical failing class: ADD then MATERIALIZE a projection (a rebuild inside
+# a mutation) on an object-storage disk. The materialize succeeds; the projection must then be
+# readable, healthy, and survive a reload -- not left rooted at the vacated tmp_mut_ path.
+def test_os_materialize_projection_rebuild(storage_kind, disk):
+    node.query("DROP TABLE IF EXISTS t_os_mat SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        f"""CREATE TABLE t_os_mat (key UInt64, id UInt64, value String)
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS {with_disk(with_storage("min_bytes_for_wide_part = 0", storage_kind), disk)}"""
+    )
+    node.query(
+        "INSERT INTO t_os_mat SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # add and materialize the projection (rebuild path inside a mutation)
+    node.query("ALTER TABLE t_os_mat ADD PROJECTION p (SELECT key, id, value ORDER BY id)")
+    node.query("ALTER TABLE t_os_mat MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2")
+
+    # the mutation succeeded; a projection read must not open a vacated tmp_mut_ path
+    assert broken_projection_parts("t_os_mat") == "0"
+    assert (
+        proj_query("t_os_mat", extra_settings="force_optimize_projection = 1") == "100\t4950"
+    )
+    assert check_table("t_os_mat") == "1"
+
+    # the projection also survives a reload from disk (the load path this fix relocates)
+    node.restart_clickhouse()
+    block_until_tables_loaded("t_os_mat")
+    assert broken_projection_parts("t_os_mat") == "0"
+    assert (
+        proj_query("t_os_mat", extra_settings="force_optimize_projection = 1") == "100\t4950"
+    )
+
+
+# This test checks the same rebuild via a plain data mutation: ALTER UPDATE of a column the
+# projection materializes forces the projection to be rebuilt inside the mutation.
+def test_os_update_projected_column_rebuild(storage_kind, disk):
+    node.query("DROP TABLE IF EXISTS t_os_upd SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        f"""CREATE TABLE t_os_upd (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id, value ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS {with_disk(with_storage("min_bytes_for_wide_part = 0", storage_kind), disk)}"""
+    )
+    node.query(
+        "INSERT INTO t_os_upd SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # UPDATE a projected column -> the mutation rebuilds the projection
+    node.query(
+        "ALTER TABLE t_os_upd UPDATE value = concat(value, '!') WHERE id < 200 SETTINGS mutations_sync = 2"
+    )
+    assert broken_projection_parts("t_os_upd") == "0"
+    assert (
+        proj_query("t_os_upd", extra_settings="force_optimize_projection = 1") == "100\t4950"
+    )
+    assert check_table("t_os_upd") == "1"
+
+    # survives a reload from disk (load path)
+    node.restart_clickhouse()
+    block_until_tables_loaded("t_os_upd")
+    assert broken_projection_parts("t_os_upd") == "0"
+    assert check_table("t_os_upd") == "1"
+
+
+# This test checks the lightweight-DELETE rebuild path (lightweight_mutation_projection_mode =
+# 'rebuild'): the deleting mutation re-materializes the projection, which must survive on object storage.
+def test_os_lightweight_delete_rebuild(storage_kind, disk):
+    node.query("DROP TABLE IF EXISTS t_os_lwd SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        f"""CREATE TABLE t_os_lwd (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id, value ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS {with_disk(with_storage("min_bytes_for_wide_part = 0, lightweight_mutation_projection_mode = 'rebuild'", storage_kind), disk)}"""
+    )
+    node.query(
+        "INSERT INTO t_os_lwd SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # lightweight DELETE rebuilds the projection
+    node.query("DELETE FROM t_os_lwd WHERE key >= 500 SETTINGS mutations_sync = 2")
+    assert node.query("SELECT count() FROM t_os_lwd").strip() == "500"
+    assert broken_projection_parts("t_os_lwd") == "0"
+    # rows with id < 200 (key < 100) are untouched by the delete: still 100 rows, sum(key) = 4950
+    assert (
+        proj_query("t_os_lwd", extra_settings="force_optimize_projection = 1") == "100\t4950"
+    )
+    assert check_table("t_os_lwd") == "1"
+
+
+# This test probes the merge path: two parts merged with OPTIMIZE FINAL rebuild the projection into
+# the merged part, which must stay readable on object storage. (Merges use a different driver than
+# mutations; this guards that path too.)
+def test_os_optimize_final_merge(storage_kind, disk):
+    node.query("DROP TABLE IF EXISTS t_os_merge SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        f"""CREATE TABLE t_os_merge (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id, value ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS {with_disk(with_storage("min_bytes_for_wide_part = 0", storage_kind), disk)}"""
+    )
+    for rng in ("numbers(1000)", "numbers(1000, 1000)"):
+        node.query(
+            f"INSERT INTO t_os_merge SELECT number, number * 2, toString(number) FROM {rng}"
+        )
+
+    # merge into a single part; the merged part rebuilds the projection
+    node.query("SYSTEM START MERGES t_os_merge")
+    node.query("OPTIMIZE TABLE t_os_merge FINAL")
+    wait_for(lambda: active_parts("t_os_merge") == "1")
+
+    assert broken_projection_parts("t_os_merge") == "0"
+    assert (
+        proj_query("t_os_merge", extra_settings="force_optimize_projection = 1") == "100\t4950"
+    )
+    assert check_table("t_os_merge") == "1"
+
+
+# This test is the CONTROL: a mutation of a column the projection does NOT reference carries the
+# projection by hardlink/copy rather than rebuilding it. The carry loop commits its own part
+# transaction early, so this must pass both before and after the fix -- it proves the regression is
+# specific to the REBUILD path, not to object-storage mutations in general.
+def test_os_mutation_carries_unprojected_column(storage_kind, disk):
+    node.query("DROP TABLE IF EXISTS t_os_carry SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        f"""CREATE TABLE t_os_carry (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS {with_disk(with_storage("min_bytes_for_wide_part = 0", storage_kind), disk)}"""
+    )
+    node.query(
+        "INSERT INTO t_os_carry SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # UPDATE a column the projection does not reference -> projection is carried, not rebuilt
+    node.query(
+        "ALTER TABLE t_os_carry UPDATE value = concat(value, '!') WHERE id < 200 SETTINGS mutations_sync = 2"
+    )
+    assert broken_projection_parts("t_os_carry") == "0"
+    assert (
+        proj_query("t_os_carry", extra_settings="force_optimize_projection = 1") == "100\t4950"
+    )
+    assert check_table("t_os_carry") == "1"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry:
Rework projection handling in the MergeTree part storage layer around an explicit, manifest-driven projection set. Fixes projections lost by mutations on object-storage disks; `CHECK TABLE` now reports a projection the part owns but whose directory is missing as broken instead of skipping it, and regenerates a projection's lost `checksums.txt` from data instead of failing the whole part.

---

Preparation for the flat projection storage format (#108443) — the layout-independent half, split out to be reviewable on its own. The on-disk format is unchanged; behavior of healthy parts is unchanged.

## Major changes

1. **Owned projection set on `IDataPartStorage`.** Each part storage tracks the projections its part owns as `Projection` descriptors (`getProjections` / `createProjection` / `renameProjection` / `removeProjection`), replacing ad-hoc `".proj"` string paths and directory walks across the create/rename/freeze/remove/check paths. `checksums.txt` is the authoritative manifest: only manifest-listed projections are loaded, and an on-disk directory the manifest does not list is not adopted at load.

2. **Fix: mutations lost projections on object-storage disks** (query-time `FILE_DOESNT_EXIST` on a vacated `tmp_mut_*` path). Object-storage disks run deferred transactions (#89658), so a disk probe at mutation finalize cannot see the rebuilt projection's still-queued rename; the owned set is now maintained by the write path itself and probed from disk only on part load. Covered by the new `test_os_*` matrix ({full, packed} × {local, s3}).

3. **Fix: `CHECK TABLE` / part load report a projection the part owns but whose directory is missing as a broken projection** (previously skipped silently), **and regenerate a projection's missing `checksums.txt` from data** (previously this failed the whole part).

## Side changes

- Mutations fold carried (hardlinked) projections into the new part's `checksums.txt` before finalize, so the manifest commits atomically with the part.
- Regenerating a lost part-level `checksums.txt` restores the projection entries (previously the repaired manifest silently dropped every projection).
- `freezeRemote` is folded into `freeze(dst_disk)`; packed `freeze` copies projections from the owned set instead of a disk walk, so residue directories are not carried into clones.
- Replication fetch creates projection directories through `createProjection`, sweeping stale residue of a failed same-named attempt before download.
- Table `RENAME` repoints loaded projection sub-part storages (their roots kept the old table path).
- Backups place a projection under its logical `<name>.proj` name, independent of the on-disk layout.
- Stale temporary-directory reclaim is deduplicated into `MergeTreeData::reclaimStaleTemporaryDirectory`.
- Tests: a gtest for the owned-set invariants; integration suite `test_projection_storage_format` — manifest desync/repair, `CHECK TABLE` classification, packed-storage projection lifecycle, and the object-storage rebuild/carry matrix.

## Exact scenarios changed (vs master)

- Mutation rebuilding or carrying a projection on an object-storage disk: projection survives; was lost at query time (b, e).
- `CHECK TABLE` on a part owning a projection whose directory is missing: reports broken projection; was silent (c).
- `CHECK TABLE` / load of a projection missing its own `checksums.txt`: recomputed and persisted; previously failed the part (d).
- Load of a part with a projection directory not listed in `checksums.txt`: ignored (not adopted); previously could be picked up by the disk walk.
- Everything else — INSERT/merge/mutate/fetch/freeze/backup/move/detach on healthy parts — is behavior-preserving; `test_broken_projections` (the pre-existing suite) passes unchanged.
