### PR TITLE
Fix quadratic JSON subcolumn skip-index matching over a large dotted constant

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexJSONSubcolumnHelper.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexJSONSubcolumnHelper.cpp
@@ -2,11 +2,7 @@
 #include <Storages/MergeTree/RPNBuilder.h>
 
 #include <DataTypes/DataTypeNullable.h>
-#include <DataTypes/NestedUtils.h>
 #include <Interpreters/convertFieldToType.h>
-
-#include <algorithm>
-#include <fmt/format.h>
 
 namespace DB
 {
@@ -40,34 +36,57 @@ std::optional<JSONSubcolumnIndexInfo> tryMatchJSONSubcolumnToIndex(
     const Names & index_columns,
     const String & json_function_name)
 {
-    /// Try all possible dot splits of the column name.
-    /// For "t.json.some.path" this produces:
-    ///   ("t", "json.some.path"), ("t.json", "some.path"), ("t.json.some", "path")
-    for (auto [candidate_col, subcolumn_part] : Nested::getAllColumnAndSubcolumnPairs(column_name))
+    /// Scan the index columns, not the dot positions of the name: the name can embed a folded
+    /// constant, so its length is unbounded while `index_columns` is not.
+    const std::string_view name = column_name;
+    const size_t json_column_offset = json_function_name.size() + 1;
+
+    std::string_view matched_json_column;
+    std::string_view matched_subcolumn;
+    size_t matched_position = 0;
+    bool matched = false;
+
+    for (size_t position = 0; position < index_columns.size(); ++position)
     {
-        auto index_column_name = fmt::format("{}({})", json_function_name, candidate_col);
-        auto it = std::find(index_columns.begin(), index_columns.end(), index_column_name);
-        if (it == index_columns.end())
+        const std::string_view entry = index_columns[position];
+
+        /// Entry must be `json_function_name(X)` with a non-empty X.
+        if (entry.size() < json_column_offset + 2 || entry.back() != ')' || !entry.starts_with(json_function_name)
+            || entry[json_function_name.size()] != '(')
             continue;
 
-        /// Sub-object access (^ prefix) is not supported for index filtering
-        if (subcolumn_part.starts_with("^"))
-            return std::nullopt;
+        const std::string_view json_column = entry.substr(json_column_offset, entry.size() - json_column_offset - 1);
 
-        String path = extractPathFromSubcolumn(subcolumn_part);
-        if (path.empty())
-            return std::nullopt;
+        /// The name must be `X.<non-empty subcolumn>`.
+        if (json_column.size() + 1 >= name.size() || !name.starts_with(json_column) || name[json_column.size()] != '.')
+            continue;
 
-        size_t position = static_cast<size_t>(std::distance(index_columns.begin(), it));
+        /// Shortest X wins, ties resolve to the first entry: several entries can match one name.
+        if (matched && json_column.size() >= matched_json_column.size())
+            continue;
 
-        return JSONSubcolumnIndexInfo{
-            .json_column_name = String(candidate_col),
-            .path = std::move(path),
-            .header_position = position,
-        };
+        matched_json_column = json_column;
+        matched_subcolumn = name.substr(json_column.size() + 1);
+        matched_position = position;
+        matched = true;
     }
 
-    return std::nullopt;
+    if (!matched)
+        return std::nullopt;
+
+    /// Sub-object access (^ prefix) is not supported for index filtering
+    if (matched_subcolumn.starts_with("^"))
+        return std::nullopt;
+
+    String path = extractPathFromSubcolumn(matched_subcolumn);
+    if (path.empty())
+        return std::nullopt;
+
+    return JSONSubcolumnIndexInfo{
+        .json_column_name = String(matched_json_column),
+        .path = std::move(path),
+        .header_position = matched_position,
+    };
 }
 
 std::optional<JSONSubcolumnIndexInfo> tryMatchNodeToJSONIndex(

--- a/src/Storages/MergeTree/MergeTreeIndexJSONSubcolumnHelper.h
+++ b/src/Storages/MergeTree/MergeTreeIndexJSONSubcolumnHelper.h
@@ -19,8 +19,9 @@ struct JSONSubcolumnIndexInfo
 };
 
 /// Try to match a column name from the filter DAG to a JSON index column in the header.
-/// Iterates all dot positions in `column_name` to handle JSON columns whose names contain dots
-/// (e.g., `my.json` JSON or `t Tuple(json JSON)` with index on `JSONAllPaths(t.json)`).
+/// Scans the index columns, not the dot positions of `column_name`, so cost is independent of the
+/// name's length. JSON columns whose own names contain dots are handled (e.g., `my.json` JSON or
+/// `t Tuple(json JSON)` with index on `JSONAllPaths(t.json)`); the shortest matching one wins.
 ///
 /// The `json_function_name` parameter specifies which index function to look for (e.g. "JSONAllPaths",
 /// "JSONAllValues").

--- a/tests/queries/0_stateless/04024_json_skip_index_bloom_filter.reference
+++ b/tests/queries/0_stateless/04024_json_skip_index_bloom_filter.reference
@@ -93,6 +93,15 @@ Tuple(JSON) subcolumn
 Skip
 Parts: 1/2
 Granules: 1/4
+ambiguous JSON column: path present in the shorter column
+Parts: 1/1
+Granules: 1/1
+ambiguous JSON column: path present only in the longer column
+Parts: 0/1
+Granules: 0/1
+result: ambiguous JSON column
+1
+0
 result: equals
 1
 result: typed subcolumn

--- a/tests/queries/0_stateless/04024_json_skip_index_bloom_filter.sql
+++ b/tests/queries/0_stateless/04024_json_skip_index_bloom_filter.sql
@@ -317,6 +317,38 @@ WHERE explain LIKE '%Parts:%' OR explain LIKE '%Granules:%' OR explain LIKE '%Sk
 
 DROP TABLE t_json_tuple;
 
+-- One index whose columns are JSONAllPaths(a) and JSONAllPaths(`a.b`): the name `a.b.<path>`
+-- matches both, so the choice decides which bloom filter is probed. The shorter JSON column wins,
+-- so `a.b.y` resolves to column `a` path `b.y`, which is absent from `a` and prunes.
+DROP TABLE IF EXISTS t_json_ambiguous;
+SET allow_suspicious_indices = 1;
+CREATE TABLE t_json_ambiguous
+(
+    a JSON,
+    `a.b` JSON,
+    INDEX idx (JSONAllPaths(a), JSONAllPaths(`a.b`)) TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 1;
+
+INSERT INTO t_json_ambiguous VALUES ('{"b": {"x": 1}}', '{"y": 2}');
+
+SELECT 'ambiguous JSON column: path present in the shorter column';
+SELECT trimLeft(explain)
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_json_ambiguous WHERE a.b.x = 1)
+WHERE explain LIKE '%Parts:%' OR explain LIKE '%Granules:%';
+
+SELECT 'ambiguous JSON column: path present only in the longer column';
+SELECT trimLeft(explain)
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_json_ambiguous WHERE a.b.y = 2)
+WHERE explain LIKE '%Parts:%' OR explain LIKE '%Granules:%';
+
+SELECT 'result: ambiguous JSON column';
+SELECT count() FROM t_json_ambiguous WHERE a.b.x = 1;
+SELECT count() FROM t_json_ambiguous WHERE a.b.y = 2;
+
+DROP TABLE t_json_ambiguous;
+
 -- =============================================================================
 -- Section 9: Correctness
 -- =============================================================================

--- a/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.reference
+++ b/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.reference
@@ -4,4 +4,4 @@ withjson OK
 tokens OK
 0
 Parts: 0 | Granules: 0
-Granules: 0/1
+Granules: 0/1000

--- a/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.reference
+++ b/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.reference
@@ -1,0 +1,7 @@
+plain OK
+longidx OK
+withjson OK
+tokens OK
+0
+Parts: 0 | Granules: 0
+Granules: 0/1

--- a/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
+++ b/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Tags: long, no-flaky-check
+# Test for https://github.com/ClickHouse/ClickHouse/issues/113003
+# Skip-index condition building matched a filter column name against JSONAllPaths(...) index
+# columns by enumerating every dot split of the name and formatting a lookup key per split. The
+# name embeds the text of a folded constant, so a large dotted constant made index analysis
+# quadratic in the constant's length.
+# Each arm compares a dotted constant against a no-dots constant of the same length. The oracle is
+# the allocated-bytes counter rather than wall clock: it is exactly reproducible, whereas the
+# ~2.6s planning delta is smaller than debug-build client startup jitter.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+set -e
+
+REPEATS=100000
+# Measured on a debug build: pre-fix the dotted arm allocates 2.8x-3.0x the control in every arm,
+# post-fix 1.0003x. 1.5 sits an order of magnitude away from the fixed behavior and ~1.9x below
+# the regression, so it discriminates with margin on both sides.
+MAX_RATIO_PERCENT=150
+
+LONG_SUFFIX=$(printf 'a%.0s' $(seq 1 170))
+
+$CLICKHOUSE_CLIENT -nm -q "
+    SET enable_json_type = 1, allow_suspicious_indices = 1;
+
+    -- No JSON column at all, so the matcher can never succeed: the reported shape.
+    CREATE TABLE plain (s String, INDEX ix s TYPE bloom_filter GRANULARITY 1)
+    ENGINE = MergeTree ORDER BY tuple();
+
+    -- index_columns carries a long NON-JSON entry. Bounding the split enumeration by the longest
+    -- index column would leave this arm quadratic.
+    CREATE TABLE longidx (s String, INDEX ilong concat(s, '${LONG_SUFFIX}') TYPE bloom_filter GRANULARITY 1)
+    ENGINE = MergeTree ORDER BY tuple();
+
+    -- A JSONAllPaths index IS present, so an early-out keyed on its absence cannot fire.
+    CREATE TABLE withjson (s String, j JSON,
+        INDEX ix s TYPE bloom_filter GRANULARITY 1,
+        INDEX jx JSONAllPaths(j) TYPE bloom_filter GRANULARITY 1)
+    ENGINE = MergeTree ORDER BY tuple();
+
+    -- Token indexes reach the same matcher through a different condition class.
+    CREATE TABLE tokens (s String, INDEX ix s TYPE tokenbf_v1(256, 2, 0) GRANULARITY 1)
+    ENGINE = MergeTree ORDER BY tuple();
+
+    INSERT INTO plain SELECT 'v' || toString(number % 10) FROM numbers(1000);
+    INSERT INTO longidx SELECT 'v' || toString(number % 10) FROM numbers(1000);
+    INSERT INTO withjson SELECT 'v' || toString(number % 10), '{\"a\":1}' FROM numbers(1000);
+    INSERT INTO tokens SELECT 'v' || toString(number % 10) FROM numbers(1000);
+"
+
+# Sets ALLOC_BYTES to the bytes the server allocated while planning one query.
+# EXPLAIN runs index analysis without reading data, so the measurement is the matcher's cost.
+alloc_bytes_for() {
+    local table="$1" unit="$2"
+    local query_id="04780-${CLICKHOUSE_DATABASE}-${table}-${unit}-${RANDOM}"
+    $CLICKHOUSE_CLIENT --query_id "$query_id" --max_query_size 1048576 --max_execution_time 300 -q "
+        SELECT count() FROM (
+            EXPLAIN indexes = 1
+            SELECT count() FROM ${table} WHERE position(repeat('${unit}', ${REPEATS}), s) = 1
+        )" >/dev/null
+    $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log" >/dev/null
+    ALLOC_BYTES=$($CLICKHOUSE_CLIENT -q "
+        SELECT ProfileEvents['MemoryAllocatedWithoutCheckBytes']
+        FROM system.query_log
+        WHERE query_id = '${query_id}' AND type = 'QueryFinish'")
+    [ -n "$ALLOC_BYTES" ] && [ "$ALLOC_BYTES" -gt 0 ]
+}
+
+for table in plain longidx withjson tokens; do
+    alloc_bytes_for "$table" 'a.' || { echo "FAIL: no query_log row for $table dotted arm" >&2; exit 1; }
+    dotted=$ALLOC_BYTES
+
+    alloc_bytes_for "$table" 'ab' || { echo "FAIL: no query_log row for $table control arm" >&2; exit 1; }
+    control=$ALLOC_BYTES
+
+    if [ $((dotted * 100)) -gt $((control * MAX_RATIO_PERCENT)) ]; then
+        echo "FAIL: $table index analysis over a constant with ${REPEATS} dots allocated ${dotted} bytes," \
+             "more than ${MAX_RATIO_PERCENT}% of the no-dots control (${control} bytes)" >&2
+        exit 1
+    fi
+    echo "$table OK"
+done
+
+# A dotted constant must not change which granules are read, and a real JSON subcolumn filter on
+# the same table must still prune.
+$CLICKHOUSE_CLIENT -nm -q "
+    SET enable_json_type = 1;
+    SELECT count() FROM withjson WHERE position(repeat('a.', 100), s) = 1;
+    SELECT trimLeft(explain) FROM (
+        EXPLAIN indexes = 1 SELECT count() FROM withjson WHERE j.absent_path = 'zzz'
+    ) WHERE explain LIKE '%Granules:%';
+"
+
+$CLICKHOUSE_CLIENT -nm -q "
+    DROP TABLE plain; DROP TABLE longidx; DROP TABLE withjson; DROP TABLE tokens;
+"

--- a/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
+++ b/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-flaky-check
+# Tags: long, no-fasttest, no-parallel-replicas, no-flaky-check
 # Test for https://github.com/ClickHouse/ClickHouse/issues/113003
 # Skip-index condition building matched a filter column name against JSONAllPaths(...) index
 # columns by enumerating every dot split of the name and formatting a lookup key per split. The
@@ -26,24 +26,27 @@ LONG_SUFFIX=$(printf 'a%.0s' $(seq 1 170))
 $CLICKHOUSE_CLIENT -nm -q "
     SET enable_json_type = 1, allow_suspicious_indices = 1;
 
+    -- index_granularity is pinned on every table: the granule counts asserted below are
+    -- ceil(rows / index_granularity), which the test runner otherwise randomizes.
+
     -- No JSON column at all, so the matcher can never succeed: the reported shape.
     CREATE TABLE plain (s String, INDEX ix s TYPE bloom_filter GRANULARITY 1)
-    ENGINE = MergeTree ORDER BY tuple();
+    ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1;
 
     -- index_columns carries a long NON-JSON entry. Bounding the split enumeration by the longest
     -- index column would leave this arm quadratic.
     CREATE TABLE longidx (s String, INDEX ilong concat(s, '${LONG_SUFFIX}') TYPE bloom_filter GRANULARITY 1)
-    ENGINE = MergeTree ORDER BY tuple();
+    ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1;
 
     -- A JSONAllPaths index IS present, so an early-out keyed on its absence cannot fire.
     CREATE TABLE withjson (s String, j JSON,
         INDEX ix s TYPE bloom_filter GRANULARITY 1,
         INDEX jx JSONAllPaths(j) TYPE bloom_filter GRANULARITY 1)
-    ENGINE = MergeTree ORDER BY tuple();
+    ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1;
 
     -- Token indexes reach the same matcher through a different condition class.
     CREATE TABLE tokens (s String, INDEX ix s TYPE tokenbf_v1(256, 2, 0) GRANULARITY 1)
-    ENGINE = MergeTree ORDER BY tuple();
+    ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1;
 
     INSERT INTO plain SELECT 'v' || toString(number % 10) FROM numbers(1000);
     INSERT INTO longidx SELECT 'v' || toString(number % 10) FROM numbers(1000);
@@ -65,7 +68,7 @@ alloc_bytes_for() {
     ALLOC_BYTES=$($CLICKHOUSE_CLIENT -q "
         SELECT ProfileEvents['MemoryAllocatedWithoutCheckBytes']
         FROM system.query_log
-        WHERE query_id = '${query_id}' AND type = 'QueryFinish'")
+        WHERE current_database = currentDatabase() AND query_id = '${query_id}' AND type = 'QueryFinish'")
     [ -n "$ALLOC_BYTES" ] && [ "$ALLOC_BYTES" -gt 0 ]
 }
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/113003
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a query plan optimization stall when a `WHERE` clause contains a large string constant with many dots and the table carries a `bloom_filter`, `tokenbf_v1`, `ngrambf_v1` or `text` skip index. Matching a filter column name against `JSONAllPaths(...)` index columns enumerated every dot split of the name, which made skip-index condition building quadratic in the constant's length. Closes #113003.


### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/113003

**What breaks.** A `SELECT` whose `WHERE` contains a large dotted string constant, over a table with a skip index, spends unbounded time in query plan optimization. The reporter measured 9.2 hours at 100% of one core with `max_execution_time = 300` set, on 26.4.3.37 and 26.7.1.1315. Nothing on that path observes cancellation, so `max_execution_time` fires and `KILL QUERY` is inert, no `QueryStart` row is written, and the handler thread is leaked until restart. Workaround was `SETTINGS use_skip_indexes = 0`.

**Root cause.** `tryMatchJSONSubcolumnToIndex` reads a filter column name as `<json_column>.<path>`. Not knowing where the split is, it enumerated every dot split of the name and per split formatted a lookup key and scanned the index columns. The name embeds a folded constant verbatim (`position('a.a.a...', s)`), so its length is user-controlled, giving O(length^2).

**The change.** Scan the index columns instead: keep entries shaped `JSONAllPaths(X)` and test each `X` against the name by prefix-plus-dot. Cost no longer depends on the name. Selection is deliberately unchanged (shortest matching `X`, ties to the first entry), which reproduces what walking dot positions left to right did.

This is not `bloom_filter`-specific: `tokenbf_v1`, `ngrambf_v1` and `text` reach the same helper, so all four are fixed at once.

**Validation.** The reporter's repro goes from 42.7s to 0.16s on a debug build. All 80 existing `EXPLAIN indexes = 1` cases in `04024_json_skip_index_*` pass unchanged; 3 new cases pin the previously untested ambiguous case where two index columns match one name. The new cost test asserts allocated bytes rather than wall clock, and was verified to fail on the pre-fix binary.

The cancellation gap is real and separate; it ships as a follow-up.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.4.40`, `26.6.3.61`, `26.5.7.47`
<!-- ch-version-info:end -->