### PR TITLE
Docs: note configurable SAML SSO default role

### DIFF
--- a/docs/products/cloud/reference/security/console-roles.mdx
+++ b/docs/products/cloud/reference/security/console-roles.mdx
@@ -17,7 +17,7 @@ ClickHouse has four organization level roles available for user management. Only
 | Admin          | Perform all administrative activities for an organization and control all settings. This role is assigned to the first user in the organization by default and automatically has Service Admin permissions on all services. |
 | Billing        | View usage and invoices, and manage payment methods.                                         |
 | Org API reader | API permissions to manage organization level settings and users, no service access. |
-| Member         | Sign-in only with the ability to manage personal profile settings. Assigned to SAML SSO users by default. |
+| Member         | Sign-in only with the ability to manage personal profile settings. Assigned to SAML SSO users by default, unless the organization has configured a different default role. |
 
 ## Service roles {#service-roles}
 Refer to [Manage cloud users](/products/cloud/guides/security/cloud-access-management/manage-cloud-users) for instructions on assigning service roles.


### PR DESCRIPTION
Related: https://github.com/ClickHouse/clickhouse-docs/pull/6600

Clarifies the `Member` organization role description to explain that it is assigned to SAML SSO users by default only when the organization has not configured a different default role. This ports the clarification to the documentation’s new home in the ClickHouse repository.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.752` (included in `26.8` and later)
<!-- ch-version-info:end -->