### PR TITLE
Add the flat projection storage format

### DIFF
--- a/docs/reference/engines/table-engines/mergetree-family/mergetree.mdx
+++ b/docs/reference/engines/table-engines/mergetree-family/mergetree.mdx
@@ -679,7 +679,14 @@ Currently supported:
 The framework allows adding more index types in the future.
 
 ### Projection storage {#projection-storage}
-Projections are stored inside the part directory. It's similar to an index but contains a subdirectory that stores an anonymous `MergeTree` table's part. The table is induced by the definition query of the projection. If there is a `GROUP BY` clause, the underlying storage engine becomes [AggregatingMergeTree](/reference/engines/table-engines/mergetree-family/aggregatingmergetree), and all aggregate functions are converted to `AggregateFunction`. If there is an `ORDER BY` clause, the `MergeTree` table uses it as its primary key expression. During the merge process the projection part is merged via its storage's merge routine. The checksum of the parent table's part is combined with the projection's part. Other maintenance jobs are similar to skip indices.
+A projection is stored alongside the data part it belongs to. It is similar to an index but holds an anonymous `MergeTree` table's part, induced by the projection's definition query. If there is a `GROUP BY` clause, the underlying storage engine becomes [AggregatingMergeTree](/reference/engines/table-engines/mergetree-family/aggregatingmergetree), and all aggregate functions are converted to `AggregateFunction`. If there is an `ORDER BY` clause, the `MergeTree` table uses it as its primary key expression. During the merge process the projection part is merged via its storage's merge routine. The checksum of the parent table's part is combined with the projection's part. Other maintenance jobs are similar to skip indices.
+
+The on-disk layout is controlled by the experimental [`projection_storage_format`](/reference/settings/merge-tree-settings) setting. For a part `all_1_1_0` with a projection `p`:
+
+- `legacy_nested` (default) — a subdirectory inside the part directory: `store/uuid/all_1_1_0/p.proj`
+- `flat` — a sibling directory at the part root: `store/uuid/all_1_1_0.p.proj`
+
+Both layouts are always read transparently; the setting only controls the layout of newly written parts. Changing it does not rewrite existing parts — every subsequent insert, merge, mutation, or materialization writes new parts in the chosen layout. `flat` is intended for storage engines with atomic multi-directory commit.
 
 ### Query analysis {#projection-query-analysis}
 1. Check if the projection can be used to answer the given query, that is, it generates the same answer as querying the base table.

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -169,6 +169,8 @@ static struct InitFiu
     PAUSEABLE(infinite_sleep) \
     PAUSEABLE(async_insert_flush_pause_in_executor) \
     PAUSEABLE(stop_moving_part_before_swap_with_active) \
+    PAUSEABLE(pause_before_flat_projection_sibling_moves) \
+    ONCE(throw_after_flat_projection_sibling_move) \
     REGULAR(replicated_merge_tree_all_replicas_stale) \
     REGULAR(zero_copy_lock_zk_fail_before_op) \
     REGULAR(zero_copy_lock_zk_fail_after_op) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1343,6 +1343,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
     {
         addSettingsChanges(merge_tree_settings_changes_history, "26.8",
         {
+            {"projection_storage_format", "legacy_nested", "legacy_nested", "New setting to control the on-disk storage format of projection sub-parts."},
             {"allow_experimental_adaptive_codec_selection", false, false, "New setting."},
             {"text_index_max_processed_tokens_before_flush", 100000000, 100000000, "New setting"},
             {"text_index_max_memory_usage_before_flush", std::numeric_limits<UInt64>::max(), 1073741824, "New setting. The previous value disables memory-based flushing to preserve pre-26.8 behavior"},

--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -240,6 +240,10 @@ IMPLEMENT_SETTING_ENUM(DeduplicateMergeProjectionMode, ErrorCodes::BAD_ARGUMENTS
      {"drop", DeduplicateMergeProjectionMode::DROP},
      {"rebuild", DeduplicateMergeProjectionMode::REBUILD}})
 
+IMPLEMENT_SETTING_ENUM(ProjectionStorageFormat, ErrorCodes::BAD_ARGUMENTS,
+    {{"legacy_nested", ProjectionStorageFormat::LEGACY_NESTED},
+     {"flat", ProjectionStorageFormat::FLAT}})
+
 IMPLEMENT_SETTING_ENUM(UniqueKeyProbeImplementation, ErrorCodes::BAD_ARGUMENTS,
     {{"auto", UniqueKeyProbeImplementation::Auto},
      {"simple", UniqueKeyProbeImplementation::Simple}})

--- a/src/Core/SettingsEnums.h
+++ b/src/Core/SettingsEnums.h
@@ -376,6 +376,14 @@ enum class DeduplicateMergeProjectionMode : uint8_t
 
 DECLARE_SETTING_ENUM(DeduplicateMergeProjectionMode)
 
+enum class ProjectionStorageFormat : uint8_t
+{
+    LEGACY_NESTED,
+    FLAT,
+};
+
+DECLARE_SETTING_ENUM(ProjectionStorageFormat)
+
 enum class AlterColumnSecondaryIndexMode : uint8_t
 {
     THROW,

--- a/src/Storages/Freeze.cpp
+++ b/src/Storages/Freeze.cpp
@@ -1,6 +1,7 @@
 #include <Storages/Freeze.h>
 
 #include <Disks/DiskObjectStorage/MetadataStorages/IMetadataStorage.h>
+#include <Storages/MergeTree/IDataPartStorage.h>
 #include <Storages/PartitionCommands.h>
 #include <Interpreters/Context.h>
 #include <Common/escapeForFileName.h>
@@ -214,9 +215,41 @@ PartitionCommandsResultInfo Unfreezer::unfreezePartitionsFromTableDirectory(Merg
         if (!disk->existsDirectory(table_directory))
             continue;
 
+        /// Group projection siblings by owner up front: one directory scan instead of one per part.
+        std::unordered_map<String, Strings> siblings_by_owner;
+        NameSet part_directories;
+        for (auto it = disk->iterateDirectory(table_directory); it->isValid(); it->next())
+        {
+            if (auto owner = IDataPartStorage::Projection::owner(table_directory, it->name()); !owner.empty())
+                siblings_by_owner[owner].push_back(it->name());
+            else if (IDataPartStorage::Projection::dirNameType(it->name()) == IDataPartStorage::Projection::Status::None)
+                part_directories.insert(it->name());
+        }
+
+        /// A crash between freeze's sibling and parent copies (commit-last) leaves an owner-less sibling
+        /// here; no other cleanup visits shadow/, so reap it under the same partition matcher.
+        for (const auto & [owner, siblings] : siblings_by_owner)
+        {
+            if (part_directories.contains(owner))
+                continue;
+            auto owner_partition_sep = owner.find('_');
+            if (owner_partition_sep == std::string::npos || !matcher(owner.substr(0, owner_partition_sep)))
+                continue;
+            for (const auto & sibling : siblings)
+            {
+                LOG_WARNING(log, "Removing frozen projection sibling {} whose part directory {} does not exist", sibling, owner);
+                /// No per-part freeze metadata to consult here: keep blobs whenever the disk could share them.
+                disk->removeSharedRecursive(fs::path(table_directory) / sibling / "", disk->supportZeroCopyReplication(), {});
+            }
+        }
+
         for (auto it = disk->iterateDirectory(table_directory); it->isValid(); it->next())
         {
             const auto & partition_directory = it->name();
+
+            /// FLAT projection siblings are not parts: each is removed with its owner below, under the owner's keep_shared decision.
+            if (IDataPartStorage::Projection::dirNameType(partition_directory) != IDataPartStorage::Projection::Status::None)
+                continue;
 
             /// Partition ID is prefix of part directory name: <partition id>_<rest of part directory name>
             auto found = partition_directory.find('_');
@@ -230,6 +263,15 @@ PartitionCommandsResultInfo Unfreezer::unfreezePartitionsFromTableDirectory(Merg
             const auto & path = it->path();
 
             bool keep_shared = removeFrozenPart(disk, path, partition_directory, local_context, zookeeper);
+
+            if (auto sibling_it = siblings_by_owner.find(partition_directory); sibling_it != siblings_by_owner.end())
+            {
+                for (const auto & sibling : sibling_it->second)
+                {
+                    disk->removeSharedRecursive(fs::path(table_directory) / sibling / "", keep_shared, {});
+                    LOG_DEBUG(log, "Unfrozen projection sibling {} of part {}, keep shared data: {}", sibling, partition_directory, keep_shared);
+                }
+            }
 
             result.push_back(PartitionCommandResultInfo{
                 .command_type = "UNFREEZE PART",

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -26,6 +26,7 @@
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeDataPartChecksum.h>
 #include <Storages/MergeTree/MergeTreeIndicesSerialization.h>
+#include <Common/FailPoint.h>
 #include <Common/formatReadable.h>
 #include <Common/logger_useful.h>
 
@@ -41,6 +42,13 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
     extern const int FILE_DOESNT_EXIST;
     extern const int CORRUPTED_DATA;
+    extern const int FAULT_INJECTED;
+}
+
+namespace FailPoints
+{
+    extern const char pause_before_flat_projection_sibling_moves[];
+    extern const char throw_after_flat_projection_sibling_move[];
 }
 
 namespace
@@ -95,6 +103,22 @@ IDataPartStorage::Projection::Status IDataPartStorage::Projection::dirNameType(s
     return Status::None;
 }
 
+String IDataPartStorage::Projection::owner(const std::string & root, std::string_view dir_name)
+{
+    if (dirNameType(dir_name) == Status::None)
+        return "";
+
+    auto first_dot = dir_name.find('.');
+    auto owner_prefix = dir_name.substr(0, first_dot);
+    /// FLAT projection
+    if (!owner_prefix.empty() && dirNameType(dir_name.substr(first_dot + 1)) != Status::None)
+        return String(owner_prefix);
+
+    /// NESTED projection
+    std::string root_without_slash = root.ends_with('/') ? root.substr(0, root.size() - 1) : root;
+    return std::filesystem::path(root_without_slash).filename();
+}
+
 std::shared_ptr<IDataPartStorage> IDataPartStorage::getProjectionStorageForWrite(const Projection & placement, bool use_parent_transaction) // NOLINT
 {
     if (!hasProjection(placement.dirName()))
@@ -112,6 +136,21 @@ void DataPartStorageOnDiskBase::seedFrozenCopy(IDataPartStorage & dest_storage) 
             copied.emplace(projection_dir, projection);
     dest_storage.setProjections(std::move(copied));
     dest_storage.setZeroCopyReplicationEnabled(zero_copy_replication_enabled);
+    dest_storage.setFlatProjectionStorageInUse(flat_projection_storage_in_use);
+}
+
+void DataPartStorageOnDiskBase::removeStaleProjectionSiblingAtDestination(
+    const DiskPtr & dst_disk, const std::string & proj_dst, const DiskTransactionPtr & external_transaction) const
+{
+    if (!dst_disk->existsDirectory(proj_dst))
+        return;
+
+    LOG_WARNING(getLogger("DataPartStorageOnDiskBase"), "Removing stale projection directory {} at freeze destination", fullPath(dst_disk, proj_dst));
+    const bool keep_shared = zero_copy_replication_enabled && dst_disk->supportZeroCopyReplication();
+    if (external_transaction)
+        external_transaction->removeSharedRecursive(fs::path(proj_dst) / "", keep_shared, {});
+    else
+        dst_disk->removeSharedRecursive(fs::path(proj_dst) / "", keep_shared, {});
 }
 
 namespace
@@ -353,7 +392,14 @@ static UInt64 calculateTotalSizeOnDiskImpl(const DiskPtr & disk, const String & 
 UInt64 DataPartStorageOnDiskBase::calculateTotalSizeOnDisk() const
 {
     auto disk = volume->getDisk();
-    return calculateTotalSizeOnDiskImpl(disk, fs::path(root_path) / part_dir);
+    UInt64 res = calculateTotalSizeOnDiskImpl(disk, fs::path(root_path) / part_dir);
+    /// FLAT projections are siblings of the part dir, so the walk above misses them (NESTED ones live inside it). Skip the parts-root
+    /// discovery scan for a legacy_nested table, which never writes flat siblings.
+    if (flat_projection_storage_in_use)
+        for (const auto & [projection_dir, projection] : detectProjections())
+            if (projection.format == ProjectionStorageFormat::FLAT)
+                res += calculateTotalSizeOnDiskImpl(disk, projection.relativePath());
+    return res;
 }
 
 std::string DataPartStorageOnDiskBase::getDiskName() const
@@ -498,7 +544,8 @@ void DataPartStorageOnDiskBase::backup(
     bool allow_backup_broken_projection) const
 {
     fs::path part_path_on_disk = fs::path{root_path} / part_dir;
-    /// The full destination dir comes from the caller: a projection goes under its logical name ("<name>.proj").
+    /// The full destination dir comes from the caller: a projection goes under its logical name ("<name>.proj"), never under its on-disk
+    /// dir name (FLAT is "<part_dir>.<name>.proj").
     fs::path part_path_in_backup = path_in_backup;
 
     auto disk = volume->getDisk();
@@ -618,6 +665,29 @@ MutableDataPartStoragePtr DataPartStorageOnDiskBase::freeze(
     else
         dst_disk->createDirectories(to);
 
+    /// LEGACY_NESTED projections copy with the main part dir; FLAT siblings copy separately, before it (commit-last). The owned set
+    /// excludes residue of an unrelated same-named part.
+    for (const auto & [projection_dir, projection] : getProjections())
+    {
+        if (projection.format != ProjectionStorageFormat::FLAT || projection.is_temp)
+            continue;
+
+        String proj_dst = fs::path(to) / (dir_path + "." + projection_dir);
+        removeStaleProjectionSiblingAtDestination(dst_disk, proj_dst, params.external_transaction);
+
+        Backup(
+            src_disk,
+            dst_disk,
+            projection.relativePath(),
+            proj_dst,
+            read_settings,
+            write_settings,
+            params.make_source_readonly,
+            {},
+            copy_instead_of_hardlink,
+            params.files_to_copy_instead_of_hardlinks,
+            params.external_transaction);
+    }
     Backup(
         src_disk,
         dst_disk,
@@ -697,10 +767,47 @@ MutableDataPartStoragePtr DataPartStorageOnDiskBase::clonePart(
                         dir_path, getRelativePath(), path_to_clone, fullPath(dst_disk, path_to_clone));
     }
 
+    /// Unlike the ambiguous occupied parent dir above, a sibling without its parent dir is provably residue of an interrupted clone
+    /// (siblings copy before the parent); left in place it would taint the copy.
+    {
+        const String dest_root = fs::path(to) / fs::path(dir_path).parent_path();
+        const String sibling_prefix = fs::path(dir_path).filename().string() + ".";
+        std::vector<String> stale_siblings;
+        if (dst_disk->existsDirectory(dest_root))
+            for (auto it = dst_disk->iterateDirectory(dest_root); it->isValid(); it->next())
+                if (it->name().starts_with(sibling_prefix) && Projection::dirNameType(it->name()) != Projection::Status::None)
+                    stale_siblings.push_back(fs::path(dest_root) / it->name());
+
+        for (const auto & stale : stale_siblings)
+        {
+            LOG_WARNING(log, "Removing stale projection directory {} left by an interrupted clone", fullPath(dst_disk, stale));
+            /// Destination content only ever comes from copyDirectoryContent, so blobs are never shared
+            dst_disk->removeRecursive(stale);
+        }
+    }
+
+    /// LEGACY_NESTED projections copy with the main part; FLAT ones are separate sibling dirs. getProjections() is the owned set, so
+    /// residue of an unrelated same-named part is not adopted.
+    std::vector<std::pair<String, String>> flat_projection_copies;
+    for (const auto & [projection_dir, projection] : getProjections())
+    {
+        if (projection.format != ProjectionStorageFormat::FLAT || projection.is_temp)
+            continue;
+
+        String proj_to = fs::path(to) / (dir_path + "." + projection_dir);
+        flat_projection_copies.emplace_back(projection.relativePath(), std::move(proj_to));
+    }
+
     try
     {
         dst_disk->createDirectories(to);
+        for (const auto & [proj_from, proj_to] : flat_projection_copies)
+        {
+            dst_disk->createDirectories(proj_to);
+            src_disk->copyDirectoryContent(proj_from, dst_disk, proj_to, read_settings, write_settings, cancellation_hook);
+        }
         src_disk->copyDirectoryContent(getRelativePath(), dst_disk, path_to_clone, read_settings, write_settings, cancellation_hook);
+
     }
     catch (...)
     {
@@ -708,6 +815,12 @@ MutableDataPartStoragePtr DataPartStorageOnDiskBase::clonePart(
         /// because we've just did full copy through copyDirectoryContent
         LOG_WARNING(log, "Removing directory {} after failed attempt to move a data part", path_to_clone);
         dst_disk->removeRecursive(path_to_clone);
+
+        for (const auto & [proj_from, proj_to] : flat_projection_copies)
+        {
+            if (dst_disk->existsDirectory(proj_to))
+                dst_disk->removeRecursive(proj_to);
+        }
         throw;
     }
 
@@ -762,16 +875,120 @@ void DataPartStorageOnDiskBase::rename(
 
     String from = getRelativePath();
 
+    /// FLAT projection siblings move with the part dir; the owned set excludes residue of an unrelated same-named part, so no source scan
+    /// or ownership filter is needed.
+    std::vector<std::pair<String, String>> flat_projection_moves;
+    for (const auto & [projection_dir, projection] : getProjections())
+    {
+        if (projection.format != ProjectionStorageFormat::FLAT)
+            continue;
+
+        flat_projection_moves.emplace_back(
+            projection.relativePath(),
+            fs::path(new_root_path) / (new_part_dir + "." + projection_dir));
+    }
+
+    /// Nothing has moved yet, so any existing sibling at a destination name is residue of a failed op on a same-named part; overwriting it
+    /// would resurrect foreign data (it must be swept even when THIS part owns no projection -- the residue belongs to a prior part at the
+    /// same name). Only a flat table can have such siblings, so the default legacy_nested table skips this whole-parts-root listing. A
+    /// table switched flat->legacy_nested is the one gap: its pre-switch residue is no longer swept here (rare; needs same-name reuse).
+    if (flat_projection_storage_in_use)
+    {
+        const String dest_prefix = new_part_dir + ".";
+        std::vector<String> stale_siblings;
+        if (volume->getDisk()->existsDirectory(new_root_path))
+            for (auto it = volume->getDisk()->iterateDirectory(new_root_path); it->isValid(); it->next())
+                if (it->name().starts_with(dest_prefix) && Projection::dirNameType(it->name()) != Projection::Status::None)
+                    stale_siblings.push_back(it->name());
+
+        const bool keep_shared_residue_blobs = zero_copy_replication_enabled && volume->getDisk()->supportZeroCopyReplication();
+        for (const auto & entry : stale_siblings)
+        {
+            if (log)
+                LOG_WARNING(log, "Removing stale projection sibling {} at rename destination",
+                    fullPath(volume->getDisk(), fs::path(new_root_path) / entry));
+
+            executeWriteOperation([&](auto & disk) { disk.removeSharedRecursive(fs::path(new_root_path) / entry / "", keep_shared_residue_blobs, {}); });
+        }
+    }
+
+    /// Entering the live namespace the parent dir moves last (commits after its FLAT siblings); leaving it (temp/delete_tmp_/detached) it
+    /// moves first, so a crash strands only parentless siblings, never a live parent.
+    const bool parent_moves_first =
+        new_part_dir.starts_with("tmp_")
+        || new_part_dir.starts_with("tmp-fetch_")
+        || new_part_dir.starts_with("delete_tmp_")
+        || fs::path(new_root_path).filename() == MergeTreeData::DETACHED_DIR_NAME;
+
     executeWriteOperation([&](auto & disk)
     {
         disk.setLastModified(from, Poco::Timestamp::fromEpochTime(time(nullptr)));
-        disk.moveDirectory(from, to);
+
+        /// The orphan GC ages siblings by mtime and moveDirectory does not refresh it; touch them so a briefly ownerless sibling in the
+        /// commit window below cannot look like an aged orphan.
+        for (const auto & [proj_from, _] : flat_projection_moves)
+            disk.setLastModified(proj_from, Poco::Timestamp::fromEpochTime(time(nullptr)));
+
+        /// moveDirectory is not atomic across the part's directories and the caller's rollback keys off the destination, so on a partial
+        /// failure reverse the committed moves here, leaving the source intact (power loss is still handled by commit-last + orphan GC).
+        std::vector<std::pair<String, String>> committed_moves;
+        auto move = [&](const String & move_from, const String & move_to)
+        {
+            disk.moveDirectory(move_from, move_to);
+            committed_moves.emplace_back(move_to, move_from);
+        };
+
+        try
+        {
+            if (parent_moves_first)
+                move(from, to);
+
+            /// Test-only pause inside the sibling-move commit window.
+            if (!flat_projection_moves.empty())
+                FailPointInjection::pauseFailPoint(FailPoints::pause_before_flat_projection_sibling_moves);
+
+            for (const auto & [proj_from, proj_to] : flat_projection_moves)
+            {
+                move(proj_from, proj_to);
+
+                /// Test-only throw after a committed sibling move, to exercise the rollback below.
+                fiu_do_on(FailPoints::throw_after_flat_projection_sibling_move,
+                    throw Exception(ErrorCodes::FAULT_INJECTED, "injected mid-rename failure after a sibling move"));
+            }
+
+            /// Rename entries live in the enclosing directory: make the sibling moves durable before
+            /// the parent's move commits the part (commit-last must hold across power loss too).
+            if (fsync_part_dir && !parent_moves_first && !flat_projection_moves.empty())
+            {
+                SyncGuardPtr siblings_sync_guard = volume->getDisk()->getDirectorySyncGuard(new_root_path);
+            }
+
+            if (!parent_moves_first)
+                move(from, to);
+        }
+        catch (...)
+        {
+            /// Best-effort unwind: a failure here is logged and swallowed so the original exception propagates.
+            for (auto it = committed_moves.rbegin(); it != committed_moves.rend(); ++it)
+            {
+                try
+                {
+                    disk.moveDirectory(it->first, it->second);
+                }
+                catch (...)
+                {
+                    tryLogCurrentException(__PRETTY_FUNCTION__, "Failed to roll back a partial part rename");
+                }
+            }
+            throw;
+        }
 
         /// Only after moveDirectory() since before the directory does not exist.
         if (fsync_part_dir)
         {
             /// Sync child before parent so a parent dentry never points at a not-yet-synced
-            /// child: the moved dir, then the parent(s) holding the renamed dentry.
+            /// child: the moved dir, then the parent(s) holding the renamed dentry. to_parent is the
+            /// parts root, which also holds the FLAT projection siblings' rename entries.
             { SyncGuardPtr to_sync_guard = volume->getDisk()->getDirectorySyncGuard(to); }
 
             /// parent_path() twice: step past the trailing slash on `to`/`from`, then to the container.
@@ -809,6 +1026,8 @@ std::pair<std::string, std::string> DataPartStorageOnDiskBase::getProjectionRoot
     {
         case ProjectionStorageFormat::LEGACY_NESTED:
             return {fs::path(root_path) / part_dir, dir_name};
+        case ProjectionStorageFormat::FLAT:
+            return {root_path, part_dir + "." + dir_name};
         default:
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected projection storage format: {}", static_cast<int>(format));
     }
@@ -839,15 +1058,32 @@ Projections DataPartStorageOnDiskBase::detectProjections(const ProjectionScan & 
             if (probed.contains(dir_name))
                 continue;
 
-            if (!existsProjectionDir(dir_name, ProjectionStorageFormat::LEGACY_NESTED))
+            /// A nested child shadows a same-named flat sibling.
+            ProjectionStorageFormat format = ProjectionStorageFormat::NONE;
+            if (existsProjectionDir(dir_name, ProjectionStorageFormat::LEGACY_NESTED))
+                format = ProjectionStorageFormat::LEGACY_NESTED;
+            else if (existsProjectionDir(dir_name, ProjectionStorageFormat::FLAT))
+                format = ProjectionStorageFormat::FLAT;
+            if (format == ProjectionStorageFormat::NONE)
                 continue;
 
-            add_to(probed, dir_name, ProjectionStorageFormat::LEGACY_NESTED);
+            add_to(probed, dir_name, format);
         }
         return probed;
     }
 
-    /// Full discovery: list the part dir for projection sub-dirs.
+    /// Full discovery across both layouts.
+    Strings root_dir_entries;
+    if (scan.root_listing)
+        root_dir_entries = *scan.root_listing;
+    else
+    {
+        const fs::path flat_root = fs::path(root_path) / fs::path(part_dir).parent_path();
+        if (disk->existsDirectory(flat_root))
+            for (auto it = disk->iterateDirectory(flat_root); it->isValid(); it->next())
+                root_dir_entries.push_back(it->name());
+    }
+
     Projections detected;
 
     const fs::path nested_root = fs::path(root_path) / part_dir;
@@ -855,6 +1091,18 @@ Projections DataPartStorageOnDiskBase::detectProjections(const ProjectionScan & 
         for (auto it = disk->iterateDirectory(nested_root); it->isValid(); it->next())
             if (Projection::dirNameType(it->name()) != Projection::Status::None)
                 add_to(detected, it->name(), ProjectionStorageFormat::LEGACY_NESTED);
+
+    /// Flat siblings live next to the part dir (handles a part under a subdirectory like "moving/all_1_1_1"); a nested child shadows a
+    /// same-named flat sibling.
+    const String flat_prefix = fs::path(part_dir).filename().string() + ".";
+    for (const auto & entry : root_dir_entries)
+    {
+        if (!startsWith(entry, flat_prefix))
+            continue;
+        const std::string stripped = entry.substr(flat_prefix.size());
+        if (Projection::dirNameType(stripped) != Projection::Status::None && !detected.contains(stripped))
+            add_to(detected, stripped, ProjectionStorageFormat::FLAT);
+    }
 
     return detected;
 }
@@ -970,7 +1218,7 @@ Projection DataPartStorageOnDiskBase::renameProjection(const Projection & projec
     executeWriteOperation([&](auto & disk) { disk.moveDirectory(fs::path(from_root) / from_dir, fs::path(to_root) / to_dir); });
     if (fsync)
     {
-        /// The rename entry lives in the enclosing dir (the part dir).
+        /// The rename entry lives in the enclosing dir (NESTED: the part dir, FLAT: the parts root).
         SyncGuardPtr sync_guard = volume->getDisk()->getDirectorySyncGuard(to_root);
     }
     dropProjection(projection.dirName());
@@ -1035,7 +1283,9 @@ void DataPartStorageOnDiskBase::remove(
 
     struct ProjectionToRemove
     {
-        String destination;                 /// proj dir after the part's rename
+        bool is_flat;                       /// flat sibling (true) or nested child (false)
+        String source;                      /// proj dir before the rename
+        String destination;                 /// proj dir after the rename
         MutableDataPartStoragePtr storage;  /// handle at the destination (used to read its checksums)
     };
     std::map<String, ProjectionToRemove> all_projections;
@@ -1121,11 +1371,18 @@ void DataPartStorageOnDiskBase::remove(
         if (!projection.exists())
             return;
 
-        auto destination = create(volume, to, proj_name, /*initialize=*/ true);
+        String source = strip_trailing_slash(projection.relativePath());
+        bool is_flat = projection.format == ProjectionStorageFormat::FLAT;
+
+        auto destination = is_flat
+            ? create(volume, root_path, part_dir_without_slash.string() + "." + proj_name, /*initialize=*/ true)
+            : create(volume, to, proj_name, /*initialize=*/ true);
 
         all_projections.emplace(
             proj_name,
             ProjectionToRemove{
+                is_flat,
+                std::move(source),
                 strip_trailing_slash(destination->getRelativePath()),
                 destination});
     };
@@ -1137,6 +1394,22 @@ void DataPartStorageOnDiskBase::remove(
 
     if (!has_delete_prefix)
     {
+        for (const auto & [_, projection] : all_projections)
+        {
+            if (!projection.is_flat || !disk->existsDirectory(projection.destination))
+                continue;
+
+            LOG_WARNING(log, "Directory {} (to which projection must be renamed before removing) already exists. "
+                        "Most likely this is due to unclean restart or race condition. Removing it.", fullPath(disk, projection.destination));
+            disk->removeSharedRecursive(
+                fs::path(projection.destination) / "", !can_remove_description->can_remove_anything, can_remove_description->files_not_to_remove);
+        }
+
+        /// See rename(): refresh mtimes so the orphan GC's age guard covers the ownerless window below.
+        for (const auto & [_, projection] : all_projections)
+            if (projection.is_flat && disk->existsDirectory(projection.source))
+                disk->setLastModified(projection.source, Poco::Timestamp::fromEpochTime(time(nullptr)));
+
         try
         {
             disk->moveDirectory(from, to);
@@ -1162,6 +1435,31 @@ void DataPartStorageOnDiskBase::remove(
                 return;
             }
             throw;
+        }
+
+        /// The parent is already at its delete_tmp_ name: an individually missing sibling (removed by a concurrent cleaner or manually)
+        /// must not abort the cleanup.
+        for (const auto & [_, projection] : all_projections)
+        {
+            if (!projection.is_flat)
+                continue;
+
+            try
+            {
+                disk->moveDirectory(projection.source, projection.destination);
+            }
+            catch (const Exception & e)
+            {
+                if (e.code() != ErrorCodes::FILE_DOESNT_EXIST)
+                    throw;
+                LOG_WARNING(log, "Projection directory {} doesn't exist while removing part. Ignoring.", fullPath(disk, projection.source));
+            }
+            catch (const fs::filesystem_error & e)
+            {
+                if (e.code() != std::errc::no_such_file_or_directory)
+                    throw;
+                LOG_WARNING(log, "Projection directory {} doesn't exist while removing part. Ignoring.", fullPath(disk, projection.source));
+            }
         }
     }
 
@@ -1365,12 +1663,37 @@ std::unique_ptr<WriteBufferFromFileBase> DataPartStorageOnDiskBase::writeTransac
 
 void DataPartStorageOnDiskBase::removeRecursive()
 {
-    executeWriteOperation([&](auto & disk) { disk.removeRecursive(fs::path(root_path) / part_dir); });
+    /// Physical teardown uses disk truth, not the owned cache: every FLAT sibling and temp projection dir on disk must go, ownership is
+    /// irrelevant here. A legacy_nested table has no flat siblings, so skip the parts-root discovery scan; any residue that outlives the
+    /// part is left ownerless and reaped by clearOrphanProjectionSiblings.
+    const auto detected = flat_projection_storage_in_use ? detectProjections() : Projections{};
+    executeWriteOperation([&](auto & disk)
+    {
+        for (const auto & [projection_dir, projection] : detected)
+        {
+            if (projection.format != ProjectionStorageFormat::FLAT)
+                continue;
+            disk.removeRecursive(projection.relativePath());
+        }
+        disk.removeRecursive(fs::path(root_path) / part_dir);
+    });
 }
 
 void DataPartStorageOnDiskBase::removeSharedRecursive(bool keep_in_remote_fs)
 {
-    executeWriteOperation([&](auto & disk) { disk.removeSharedRecursive(fs::path(root_path) / part_dir, keep_in_remote_fs, {}); });
+    /// See removeRecursive: disk truth, not the owned cache; skip the scan for a legacy_nested table (stray residue is reaped by
+    /// clearOrphanProjectionSiblings).
+    const auto detected = flat_projection_storage_in_use ? detectProjections() : Projections{};
+    executeWriteOperation([&](auto & disk)
+    {
+        for (const auto & [projection_dir, projection] : detected)
+        {
+            if (projection.format != ProjectionStorageFormat::FLAT)
+                continue;
+            disk.removeSharedRecursive(projection.relativePath(), keep_in_remote_fs, {});
+        }
+        disk.removeSharedRecursive(fs::path(root_path) / part_dir, keep_in_remote_fs, {});
+    });
 }
 
 void DataPartStorageOnDiskBase::createDirectories()

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.h
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.h
@@ -41,6 +41,7 @@ public:
     void removeProjectionResidue(const Projection & placement) override;
 
     void setZeroCopyReplicationEnabled(bool value) override { zero_copy_replication_enabled = value; }
+    void setFlatProjectionStorageInUse(bool value) override { flat_projection_storage_in_use = value; }
 
     std::string getFullPath() const override;
     std::string getRelativePath() const override;
@@ -217,6 +218,11 @@ protected:
     /// transient and not copied), plus the zero-copy flag; entries are re-parented to dest_storage.
     void seedFrozenCopy(IDataPartStorage & dest_storage) const;
 
+    /// A dir at a freeze destination sibling placement is residue of a failed operation on a
+    /// same-named part; remote blobs are kept only when zero-copy replication may share them.
+    void removeStaleProjectionSiblingAtDestination(
+        const DiskPtr & dst_disk, const std::string & proj_dst, const DiskTransactionPtr & external_transaction) const;
+
     /// Repoint at a moved location; unlike setRelativePath, content is guaranteed unchanged, so caches stay.
     void setPathKeepingCaches(std::string new_root_path, std::string new_part_dir);
 
@@ -281,6 +287,10 @@ protected:
 
     /// Zero-copy replication policy; default true keeps residue blobs (fail-safe until seeded).
     bool zero_copy_replication_enabled = true;
+
+    /// Whether the table uses the FLAT projection layout; default true is fail-safe (an unset storage still scans for siblings). Gates the
+    /// flat-sibling parts-root scans so the default legacy_nested table pays no per-part listing. See setFlatProjectionStorageInUse.
+    bool flat_projection_storage_in_use = true;
 
     /// The owned projection set. ready=false: never seeded (reads throw); ready=true: authoritative (absent key = no projection). Paths are
     /// derived, so only setRelativePath drops it.

--- a/src/Storages/MergeTree/DataPartStorageOnDiskPacked.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskPacked.cpp
@@ -915,6 +915,25 @@ MutableDataPartStoragePtr DataPartStorageOnDiskPacked::freeze(
         dst_disk->createDirectories(dest_storage->getRelativePath());
     }
 
+    /// FLAT siblings copy separately, before the main archive (commit-last); the owned set excludes
+    /// residue of an unrelated same-named part.
+    for (const auto & [projection_dir, projection] : getProjections())
+    {
+        if (projection.format != ProjectionStorageFormat::FLAT || projection.is_temp)
+            continue;
+
+        String proj_dst_dir = dir_path + "." + projection_dir;
+        removeStaleProjectionSiblingAtDestination(dst_disk, fs::path(to) / proj_dst_dir, params.external_transaction);
+
+        auto projection_storage = getProjectionStorage(projection_dir);
+        auto child_params = params.forProjection(
+            params.external_transaction, params.copy_instead_of_hardlink || cloneCopiesWholeArchive(params));
+        child_params.fsync_part_directory = false;  /// the single top-level fsync below covers the whole subtree
+        projection_storage->freeze(
+            to, proj_dst_dir, dst_disk_, read_settings, write_settings,
+            /*save_metadata_callback=*/ {}, child_params);
+    }
+
     bool need_commit = false;
     if (!to_detached && (params.copy_instead_of_hardlink || cloneCopiesWholeArchive(params)))
     {
@@ -1017,7 +1036,7 @@ MutableDataPartStoragePtr DataPartStorageOnDiskPacked::freeze(
     /// and temp dirs of an unrelated same-named part must not be carried into the copy.
     for (const auto & [projection_dir, projection] : getProjections())
     {
-        if (projection.is_temp)
+        if (projection.format == ProjectionStorageFormat::FLAT || projection.is_temp)
             continue;
 
         auto projection_storage = getProjectionStorage(projection_dir);

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -827,6 +827,7 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
         auto v = std::make_shared<SingleDiskVolume>("volume_" + part_name, disk);
         auto s = std::make_shared<DataPartStorageOnDiskFull>(v, part_relative_path, part_dir);
         s->setZeroCopyReplicationEnabled((*data_settings)[MergeTreeSetting::allow_remote_fs_zero_copy_replication]);
+        s->setFlatProjectionStorageInUse(data.getProjectionStorageFormat() == IDataPartStorage::ProjectionStorageFormat::FLAT);
         s->setProjections({});
         return std::pair{std::move(v), std::move(s)};
     }();

--- a/src/Storages/MergeTree/IDataPartStorage.h
+++ b/src/Storages/MergeTree/IDataPartStorage.h
@@ -113,12 +113,13 @@ public:
             Temp,
         };
 
-        /// On-disk layout of a projection sub-part: LEGACY_NESTED = <root>/<part_dir>/<name>.proj (the only layout today;
-        /// kept as an explicit parameter so alternative layouts can be added without reworking the API). NONE = not configured yet.
+        /// On-disk layout: LEGACY_NESTED = <root>/<part_dir>/<name>.proj, FLAT = <root>/<part_dir>.<name>.proj. Distinct from the
+        /// user-facing setting enum DB::ProjectionStorageFormat; NONE = not configured yet.
         enum class StorageFormat : uint8_t
         {
             NONE,
             LEGACY_NESTED,
+            FLAT,
         };
 
         const IDataPartStorage * parent = nullptr;
@@ -128,9 +129,9 @@ public:
 
         /// "p.proj" / "p_1.tmp_proj" -- the logical key used across the codebase.
         String dirName() const { return dirName(name, is_temp); }
-        /// Root the dir lives in, relative to the disk (layout-dependent).
+        /// Root the dir lives in, relative to the disk (differs between NESTED and FLAT).
         String rootPath() const;
-        /// rootPath()/physical dir name.
+        /// rootPath()/physical dir name (FLAT physical name is "<parent_dir>.<dirName()>").
         String relativePath() const;
         /// Live disk probe via the parent.
         bool exists() const;
@@ -142,6 +143,9 @@ public:
         /// Classifies a directory basename: "*.proj" -> Live, "*.tmp_proj" -> Temp, else None.
         static Status dirNameType(std::string_view dir_name);
 
+        /// Owner part dir of a projection dir ("" if not one). Call as ("<root>", "<owner>.<name>.proj") for FLAT or ("<root>/<owner>",
+        /// "<name>.proj") for NESTED; told apart by dots, a dotted NESTED name reads as FLAT.
+        static String owner(const std::string & root, std::string_view dir_name);
     };
 
     /// Key: dirName() -- the same string stored in checksums and passed to getProjectionStorage.
@@ -165,11 +169,12 @@ public:
     /// Atomically replace the owned set (entries are re-parented to this storage); {} is a valid set.
     virtual void setProjections(Projections projections) = 0;
 
-    /// Disk scan of on-disk projection dirs (residue included); does not touch the owned set. Disk-truth paths only.
-    /// candidates: stat just these dirName()s; else a full listing of the part dir.
+    /// Disk scan of on-disk projection dirs across both layouts (residue included); does not touch the owned set. Disk-truth paths only.
+    /// candidates: stat just these dirName()s; else root_listing reuses a caller's parts-root listing for full discovery.
     struct ProjectionScan
     {
         std::optional<Strings> candidates = std::nullopt;
+        std::optional<Strings> root_listing = std::nullopt;
     };
     virtual Projections detectProjections(const ProjectionScan & scan) const = 0;
     /// Full-scan convenience (default args are disallowed on virtuals).
@@ -193,6 +198,11 @@ public:
     /// Whether the table runs zero-copy replication (blobs may be shared cross-replica, invisible to the local refcount).
     /// Default true is fail-safe: residue sweeps keep remote blobs.
     virtual void setZeroCopyReplicationEnabled(bool value) = 0;
+
+    /// Whether this table writes projections in the FLAT layout (sibling dirs at the part root). Only then can a `<part>.<name>.proj`
+    /// sibling -- owned or stale residue -- exist, so the flat-sibling parts-root scans are skipped when this is false (the default
+    /// legacy_nested table). Default true is fail-safe: an unset storage keeps scanning.
+    virtual void setFlatProjectionStorageInUse(bool value) = 0;
 
     /// Sub-part storage bound to the projection's directory.
     virtual std::shared_ptr<IDataPartStorage> getProjectionStorage(const std::string & dir_name, bool use_parent_transaction = true) = 0; // NOLINT
@@ -478,6 +488,7 @@ public:
     /// Ideally, new_root_path should be the same as current root (but it is not true).
     /// Examples are: 'all_1_2_1' -> 'detached/all_1_2_1'
     ///               'moving/tmp_all_1_2_1' -> 'all_1_2_1'
+    /// FLAT projection siblings move with the part dir.
     virtual void rename(
         std::string new_root_path,
         std::string new_part_dir,

--- a/src/Storages/MergeTree/MergeTreeCleanupThread.cpp
+++ b/src/Storages/MergeTree/MergeTreeCleanupThread.cpp
@@ -1,5 +1,7 @@
 #include <Storages/MergeTree/MergeTreeCleanupThread.h>
 
+#include <algorithm>
+
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/StorageMergeTree.h>
@@ -45,6 +47,9 @@ Float32 MergeTreeCleanupThread::iterate()
         /// Both use relative_data_path which changes during rename, so we do it under share lock
         cleaned_part_like += storage.clearOldTemporaryDirectories(
             (*storage.getSettings())[MergeTreeSetting::temporary_directories_lifetime].totalSeconds());
+        cleaned_part_like += storage.clearOrphanProjectionSiblings(
+            std::max<size_t>((*storage.getSettings())[MergeTreeSetting::temporary_directories_lifetime].totalSeconds(),
+                             MergeTreeData::MIN_ORPHAN_GRACE_SECONDS));
     }
 
     if (auto lock = time_after_previous_cleanup_parts.compareAndRestartDeferred(

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -327,6 +327,7 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsBool prewarm_primary_key_cache;
     extern const MergeTreeSettingsBool prewarm_mark_cache;
     extern const MergeTreeSettingsBool primary_key_lazy_load;
+    extern const MergeTreeSettingsProjectionStorageFormat projection_storage_format;
     extern const MergeTreeSettingsBool apply_patches_on_merge;
     extern const MergeTreeSettingsBool enforce_index_structure_match_on_partition_manipulation;
     extern const MergeTreeSettingsUInt64 min_bytes_to_prewarm_caches;
@@ -2857,8 +2858,9 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks, std::optional<std::un
             auto local_component_guard = Coordination::setCurrentComponent(component_name);
             for (auto it = disk_ptr->iterateDirectory(relative_data_path); it->isValid(); it->next())
             {
-                /// Skip temporary directories, file 'format_version.txt' and directory 'detached'.
+                /// Skip temporary directories, projection directories, file 'format_version.txt' and directory 'detached'.
                 if (startsWith(it->name(), "tmp")
+                    || IDataPartStorage::Projection::dirNameType(it->name()) != IDataPartStorage::Projection::Status::None
                     || it->name() == MergeTreeData::FORMAT_VERSION_FILE_NAME
                     || it->name() == DETACHED_DIR_NAME)
                     continue;
@@ -3774,6 +3776,63 @@ size_t MergeTreeData::clearOldTemporaryDirectories(size_t custom_directories_lif
     return cleared_count;
 }
 
+size_t MergeTreeData::clearOrphanProjectionSiblings(size_t max_age_seconds)
+{
+    size_t cleared_count = 0;
+
+    for (const auto & disk : getDisks())
+    {
+        /// Skip RO/write-once disks like getDetachedParts: removeSharedRecursive would throw and fail table init on startup/attach.
+        if (disk->isBroken() || disk->isReadOnly() || disk->isWriteOnce())
+            continue;
+
+        /// moving/ is deliberately not scanned: clearOldTemporaryDirectories's stale-moving-parts sweep owns it, and an in-flight clone's
+        /// sibling is ownerless there for the whole copy.
+        for (const auto & root : {fs::path(relative_data_path), fs::path(relative_data_path) / DETACHED_DIR_NAME})
+        {
+            if (!disk->existsDirectory(root))
+                continue;
+
+            Strings orphans;
+            for (auto it = disk->iterateDirectory(root); it->isValid(); it->next())
+            {
+                const String entry = it->name();
+                if (IDataPartStorage::Projection::dirNameType(entry) == IDataPartStorage::Projection::Status::None)
+                    continue;
+
+                const String owner = IDataPartStorage::Projection::owner(root, entry);
+                if (owner.empty() || disk->existsDirectory(root / owner))
+                    continue;
+
+                /// The rename commit window legitimately shows a sibling without its owner dir (commit-last); a young orphan may still be
+                /// adopted, so only reap aged ones.
+                if (max_age_seconds && disk->getLastModified(root / entry).epochTime() + time_t(max_age_seconds) > time(nullptr))
+                    continue;
+
+                orphans.push_back(entry);
+            }
+
+            for (const auto & entry : orphans)
+            {
+                LOG_WARNING(log, "Removing orphan projection directory {} whose part directory {} does not exist",
+                    fullPath(disk, root / entry), IDataPartStorage::Projection::owner(root, entry));
+
+                /// Zero-copy replication may share blobs across replicas invisibly to the local refcount.
+                bool keep_shared = false;
+                if (disk->supportZeroCopyReplication() && (*getSettings())[MergeTreeSetting::allow_remote_fs_zero_copy_replication])
+                {
+                    LOG_WARNING(log, "Since zero-copy replication is enabled we are not going to remove blobs from shared storage for {}", fullPath(disk, root / entry));
+                    keep_shared = true;
+                }
+                disk->removeSharedRecursive(root / entry / "", keep_shared, {});
+                ++cleared_count;
+            }
+        }
+    }
+
+    return cleared_count;
+}
+
 size_t MergeTreeData::clearOldTemporaryDirectories(const String & root_path, size_t custom_directories_lifetime_seconds, const NameSet & valid_prefixes)
 {
     /// If the method is already called from another thread, then we don't need to do anything.
@@ -3820,7 +3879,12 @@ size_t MergeTreeData::clearOldTemporaryDirectories(const String & root_path, siz
                 {
                     ThreadFuzzer::maybeInjectSleep();
 
-                    if (temporary_parts.contains(basename))
+                    /// A flat projection sibling is in use whenever its parent part is.
+                    String in_use_name = basename;
+                    if (auto owner = IDataPartStorage::Projection::owner(root_path, basename); !owner.empty())
+                        in_use_name = owner;
+
+                    if (temporary_parts.contains(in_use_name))
                     {
                         /// Actually we don't rely on temporary_directories_lifetime when removing old temporaries directories,
                         /// it's just an extra level of protection just in case we have a bug.
@@ -4641,6 +4705,7 @@ void MergeTreeData::dropAllData()
         try
         {
             bool keep_shared = removeDetachedPart(part.disk, fs::path(relative_data_path) / DETACHED_DIR_NAME / part.dir_name / "", part.dir_name);
+            removeDetachedProjectionSiblings(part.disk, part.dir_name, keep_shared);
             LOG_DEBUG(log, "dropAllData: Dropped detached part {}, keep shared data: {}", part.dir_name, keep_shared);
         }
         catch (...)
@@ -5967,6 +6032,19 @@ void MergeTreeData::PartsTemporaryRename::addPart(const String & part_name, cons
 void MergeTreeData::PartsTemporaryRename::tryRenameAll()
 {
     renamed = true;
+    const auto full_path = fs::path(storage.relative_data_path) / source_dir;
+
+    /// Scan the parts root once per disk and reuse it via detectProjections({.root_listing = ...}).
+    std::map<String, Strings> root_entries_by_disk;
+    auto get_root_entries = [&](const DiskPtr & disk) -> const Strings &
+    {
+        auto [it, inserted] = root_entries_by_disk.try_emplace(disk->getName());
+        if (inserted && disk->existsDirectory(full_path))
+            for (auto dir_it = disk->iterateDirectory(full_path); dir_it->isValid(); dir_it->next())
+                it->second.push_back(dir_it->name());
+        return it->second;
+    };
+
     for (size_t i = 0; i < old_and_new_names.size(); ++i)
     {
         try
@@ -5974,8 +6052,16 @@ void MergeTreeData::PartsTemporaryRename::tryRenameAll()
             const auto & [_, old_dir, new_dir, disk] = old_and_new_names[i];
             if (old_dir.empty() || new_dir.empty())
                 throw DB::Exception(ErrorCodes::LOGICAL_ERROR, "Empty part name. Most likely it's a bug.");
-            const auto full_path = fs::path(storage.relative_data_path) / source_dir;
-            disk->moveDirectory(fs::path(full_path) / old_dir, fs::path(full_path) / new_dir);
+
+            /// Rename via part storage so the FLAT projection siblings move with the part (sweeps a stale destination, commits the part dir last).
+            auto part_storage = std::make_shared<DataPartStorageOnDiskFull>(
+                std::make_shared<SingleDiskVolume>("volume_" + old_dir, disk, 0), full_path, old_dir);
+            part_storage->setProjections(part_storage->detectProjections({.root_listing = get_root_entries(disk)}));
+            part_storage->setZeroCopyReplicationEnabled(
+                (*storage.getSettings())[MergeTreeSetting::allow_remote_fs_zero_copy_replication]);
+            part_storage->setFlatProjectionStorageInUse(
+                storage.getProjectionStorageFormat() == IDataPartStorage::ProjectionStorageFormat::FLAT);
+            part_storage->rename(full_path, new_dir, storage.log.load(), /*remove_new_dir_if_exists=*/ false, /*fsync_part_dir=*/ false);
         }
         catch (...)
         {
@@ -5993,6 +6079,18 @@ void MergeTreeData::PartsTemporaryRename::rollBackAll()
         return;
 
     std::exception_ptr first_exception;
+    const String full_path = fs::path(storage.relative_data_path) / source_dir;
+
+    /// Scan the parts root once per disk and reuse it via detectProjections({.root_listing = ...}).
+    std::map<String, Strings> root_entries_by_disk;
+    auto get_root_entries = [&](const DiskPtr & disk) -> const Strings &
+    {
+        auto [it, inserted] = root_entries_by_disk.try_emplace(disk->getName());
+        if (inserted && disk->existsDirectory(full_path))
+            for (auto dir_it = disk->iterateDirectory(full_path); dir_it->isValid(); dir_it->next())
+                it->second.push_back(dir_it->name());
+        return it->second;
+    };
 
     for (const auto & [_, old_dir, new_dir, disk] : old_and_new_names)
     {
@@ -6001,8 +6099,14 @@ void MergeTreeData::PartsTemporaryRename::rollBackAll()
 
         try
         {
-            const String full_path = fs::path(storage.relative_data_path) / source_dir;
-            disk->moveFile(fs::path(full_path) / new_dir, fs::path(full_path) / old_dir);
+            auto part_storage = std::make_shared<DataPartStorageOnDiskFull>(
+                std::make_shared<SingleDiskVolume>("volume_" + new_dir, disk, 0), full_path, new_dir);
+            part_storage->setProjections(part_storage->detectProjections({.root_listing = get_root_entries(disk)}));
+            part_storage->setZeroCopyReplicationEnabled(
+                (*storage.getSettings())[MergeTreeSetting::allow_remote_fs_zero_copy_replication]);
+            part_storage->setFlatProjectionStorageInUse(
+                storage.getProjectionStorageFormat() == IDataPartStorage::ProjectionStorageFormat::FLAT);
+            part_storage->rename(full_path, old_dir, storage.log.load(), /*remove_new_dir_if_exists=*/ false, /*fsync_part_dir=*/ false);
         }
         catch (...)
         {
@@ -9073,9 +9177,25 @@ DetachedPartsInfo MergeTreeData::getDetachedParts() const
         /// Note: we don't care about TOCTOU issue here.
         if (disk->existsDirectory(detached_path))
         {
+            /// FLAT projection siblings are folded into their owner entry instead of being listed as detached parts of their own.
+            std::unordered_map<String, size_t> index_by_dir_name;
+            Strings sibling_names;
             for (auto it = disk->iterateDirectory(detached_path); it->isValid(); it->next())
             {
+                if (IDataPartStorage::Projection::dirNameType(it->name()) != IDataPartStorage::Projection::Status::None)
+                {
+                    sibling_names.push_back(it->name());
+                    continue;
+                }
+                index_by_dir_name[it->name()] = res.size();
                 res.push_back(DetachedPartInfo::parseDetachedPartName(disk, it->name(), format_version));
+            }
+            for (const auto & sibling : sibling_names)
+            {
+                auto owner = index_by_dir_name.find(IDataPartStorage::Projection::owner(detached_path, sibling));
+                /// An orphan sibling (owner gone) stays unlisted; clearOrphanProjectionSiblings reaps it.
+                if (owner != index_by_dir_name.end())
+                    res[owner->second].projection_siblings.push_back(sibling);
             }
         }
     }
@@ -9126,6 +9246,8 @@ void MergeTreeData::dropDetached(const ASTPtr & partition, bool part, ContextPtr
     for (auto & [_, old_dir, new_dir, disk] : renamed_parts.old_and_new_names)
     {
         bool keep_shared = removeDetachedPart(disk, fs::path(relative_data_path) / DETACHED_DIR_NAME / new_dir / "", old_dir);
+        /// tryRenameAll moved the FLAT siblings to "deleting_<part>.<projection>.proj" together with the parent; drop them with it.
+        removeDetachedProjectionSiblings(disk, new_dir, keep_shared);
         LOG_DEBUG(log, "Dropped detached part {}, keep shared data: {}", old_dir, keep_shared);
         old_dir.clear();
     }
@@ -10927,6 +11049,21 @@ bool MergeTreeData::removeDetachedPart(DiskPtr disk, const String & path, const 
     return false;
 }
 
+void MergeTreeData::removeDetachedProjectionSiblings(const DiskPtr & disk, const String & dir_name, bool keep_shared)
+{
+    fs::path detached_root = fs::path(relative_data_path) / DETACHED_DIR_NAME;
+    Strings siblings;
+    for (auto it = disk->iterateDirectory(detached_root); it->isValid(); it->next())
+        if (IDataPartStorage::Projection::owner(detached_root, it->name()) == dir_name)
+            siblings.push_back(it->name());
+
+    for (const auto & name : siblings)
+    {
+        LOG_DEBUG(log, "Dropping projection sibling {} of detached part {}, keep shared data: {}", name, dir_name, keep_shared);
+        disk->removeSharedRecursive(detached_root / name / "", keep_shared, {});
+    }
+}
+
 PartitionCommandsResultInfo MergeTreeData::unfreezePartitionsByMatcher(MatcherFn matcher, const String & backup_name, ContextPtr local_context)
 {
     auto component_guard = Coordination::setCurrentComponent("MergeTreeData::unfreezePartitionsByMatcher");
@@ -12029,8 +12166,8 @@ MergeTreeSettingsPtr MergeTreeData::getSettings(const SettingsChanges * settings
 
 IDataPartStorage::ProjectionStorageFormat MergeTreeData::getProjectionStorageFormat() const
 {
-    /// The only on-disk layout today; kept as the single source for the format passed to createProjection
-    /// so an alternative layout can be introduced without touching the call sites.
+    if ((*getSettings())[MergeTreeSetting::projection_storage_format] == ProjectionStorageFormat::FLAT)
+        return IDataPartStorage::ProjectionStorageFormat::FLAT;
     return IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED;
 }
 

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1005,6 +1005,17 @@ public:
     size_t clearOldTemporaryDirectories(size_t custom_directories_lifetime_seconds, const NameSet & valid_prefixes = {"tmp_", "tmp-fetch_"});
     size_t clearOldTemporaryDirectories(const String & root_path, size_t custom_directories_lifetime_seconds, const NameSet & valid_prefixes);
 
+    /// Grace floor for periodic orphan cleaners so a mid-publish sibling survives even when `temporary_directories_lifetime` is 0.
+    static constexpr size_t MIN_ORPHAN_GRACE_SECONDS = 60;
+
+    /// Removes FLAT projection siblings whose owner part dir does not exist. `max_age_seconds` guards the rename commit window (a sibling
+    /// is briefly ownerless); startup passes 0 (no renames in flight).
+    size_t clearOrphanProjectionSiblings(size_t max_age_seconds);
+
+    /// Removes FLAT projection siblings of a removed detached part. `keep_shared` must be the value removeDetachedPart returned for the
+    /// owner: its zero-copy lock covers the projection blobs too.
+    void removeDetachedProjectionSiblings(const DiskPtr & disk, const String & dir_name, bool keep_shared);
+
     size_t clearEmptyParts();
 
     /// Moves to outdated state patch parts that do not need to be applied to regular parts.

--- a/src/Storages/MergeTree/MergeTreeDataPartBuilder.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartBuilder.cpp
@@ -76,6 +76,7 @@ std::shared_ptr<IMergeTreeDataPart> MergeTreeDataPartBuilder::build()
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot create part {}, because part storage is not set", name);
 
     part_storage->setZeroCopyReplicationEnabled((*data.getSettings())[MergeTreeSetting::allow_remote_fs_zero_copy_replication]);
+    part_storage->setFlatProjectionStorageInUse(data.getProjectionStorageFormat() == IDataPartStorage::ProjectionStorageFormat::FLAT);
 
     if (parent_part && data.format_version == MERGE_TREE_DATA_OLD_FORMAT_VERSION)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot create projection part in MergeTree table created in old syntax");

--- a/src/Storages/MergeTree/MergeTreePartInfo.h
+++ b/src/Storages/MergeTree/MergeTreePartInfo.h
@@ -180,6 +180,10 @@ struct DetachedPartInfo : public MergeTreePartInfo
 
     DiskPtr disk;
 
+    /// FLAT projection sibling dirs ("<dir_name>.<projection>.proj") belonging to this entry. They are data of this part, not detached
+    /// entries of their own.
+    std::vector<String> projection_siblings;
+
     /// If false, MergeTreePartInfo is in invalid state (directory name was not successfully parsed).
     bool valid_name{};
 

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -2229,6 +2229,13 @@ Possible values:
 - `drop`
 - `rebuild`
 )", 0) \
+    DECLARE(ProjectionStorageFormat, projection_storage_format, ProjectionStorageFormat::LEGACY_NESTED, R"(
+On-disk layout of projection sub-parts: `legacy_nested` stores each projection inside its parent part directory, `flat` stores it as a sibling directory at the part root. `flat` is intended for engines with atomic multi-directory commit.
+
+Both layouts are always read transparently; the setting only controls the layout of newly written parts. It applies to both full and packed part storage (a packed projection sub-part keeps its own `data.packed` archive in either layout).
+
+Downgrade note: a server version without `flat` support loads a `flat` part with its projections marked broken (queries fall back to reading the parent part; projections can be rebuilt with `ALTER TABLE ... MATERIALIZE PROJECTION`), and it never removes the sibling directories, so they remain on disk until a version with `flat` support cleans them up. To downgrade cleanly, set `projection_storage_format = 'legacy_nested'` and rewrite `flat` parts first (for example with `OPTIMIZE TABLE ... FINAL`).
+)", EXPERIMENTAL) \
     DECLARE(DeduplicateMergeProjectionMode, deduplicate_merge_projection_mode, DeduplicateMergeProjectionMode::THROW, R"(
 Whether to allow create projection for the table with non-classic MergeTree,
 that is not (Replicated, Shared) MergeTree. Ignore option is purely for

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -50,6 +50,7 @@ struct MutableColumnsAndConstraints;
     M(CLASS_NAME, MergeSelectorAlgorithm) \
     M(CLASS_NAME, Milliseconds) \
     M(CLASS_NAME, NonZeroUInt64) \
+    M(CLASS_NAME, ProjectionStorageFormat) \
     M(CLASS_NAME, Seconds) \
     M(CLASS_NAME, String) \
     M(CLASS_NAME, UInt32) \

--- a/src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp
@@ -197,6 +197,7 @@ void ReplicatedMergeTreeAttachThread::runImpl()
     /// Temporary directories contain uninitialized results of Merges or Fetches (after forced restart),
     /// don't allow to reinitialize them, delete each of them immediately.
     storage.clearOldTemporaryDirectories(0, {"tmp_", "delete_tmp_", "tmp-fetch_"});
+    storage.clearOrphanProjectionSiblings(/*max_age_seconds=*/ 0);
 
     storage.createNewZooKeeperNodes(/* zookeeper_retries_info = */ {});
     storage.syncPinnedPartUUIDs(/* zookeeper_retries_info = */ {});

--- a/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp
@@ -52,6 +52,9 @@ Float32 ReplicatedMergeTreeCleanupThread::iterate()
         /// Both use relative_data_path which changes during rename, so we
         /// do it under share lock
         cleaned_part_like += storage.clearOldTemporaryDirectories((*storage.getSettings())[MergeTreeSetting::temporary_directories_lifetime].totalSeconds());
+        cleaned_part_like += storage.clearOrphanProjectionSiblings(
+            std::max<size_t>((*storage.getSettings())[MergeTreeSetting::temporary_directories_lifetime].totalSeconds(),
+                             MergeTreeData::MIN_ORPHAN_GRACE_SECONDS));
     }
 
     /// This is loose condition: no problem if we actually had lost leadership at this moment

--- a/src/Storages/MergeTree/tests/gtest_projection_storage_schema.cpp
+++ b/src/Storages/MergeTree/tests/gtest_projection_storage_schema.cpp
@@ -70,9 +70,28 @@ TEST(ProjectionDirNames, Classification)
 {
     EXPECT_EQ(IDataPartStorage::Projection::dirNameType("p.proj"), IDataPartStorage::Projection::Status::Live);
     EXPECT_EQ(IDataPartStorage::Projection::dirNameType("p.tmp_proj"), IDataPartStorage::Projection::Status::Temp);
+    EXPECT_EQ(IDataPartStorage::Projection::dirNameType("all_1_1_0.p.proj"), IDataPartStorage::Projection::Status::Live);
+    EXPECT_EQ(IDataPartStorage::Projection::dirNameType("all_1_1_0.p_1.tmp_proj"), IDataPartStorage::Projection::Status::Temp);
     EXPECT_EQ(IDataPartStorage::Projection::dirNameType("all_1_1_0"), IDataPartStorage::Projection::Status::None);
     EXPECT_EQ(IDataPartStorage::Projection::dirNameType("proj"), IDataPartStorage::Projection::Status::None);
     EXPECT_EQ(IDataPartStorage::Projection::dirNameType(""), IDataPartStorage::Projection::Status::None);
+}
+
+TEST(ProjectionDirNames, SiblingOwner)
+{
+    /// FLAT sibling: the owner is the prefix before the first dot.
+    EXPECT_EQ(IDataPartStorage::Projection::owner("store/uuid", "all_1_1_0.p.proj"), "all_1_1_0");
+    EXPECT_EQ(IDataPartStorage::Projection::owner("store/uuid", "all_1_1_0.p.tmp_proj"), "all_1_1_0");
+    /// Projection names may contain dots; the owner is everything before the first one.
+    EXPECT_EQ(IDataPartStorage::Projection::owner("store/uuid", "all_1_1_0.my.p.proj"), "all_1_1_0");
+    /// NESTED child: the owner is the basename of the root the projection dir lives in.
+    EXPECT_EQ(IDataPartStorage::Projection::owner("store/uuid/all_1_1_0", "p.proj"), "all_1_1_0");
+    EXPECT_EQ(IDataPartStorage::Projection::owner("store/uuid/all_1_1_0/", "p.tmp_proj"), "all_1_1_0");
+    /// Not a projection dir at all.
+    EXPECT_EQ(IDataPartStorage::Projection::owner("store/uuid", "all_1_1_0"), "");
+    /// Owner equality distinguishes "part_1" from "part_10".
+    EXPECT_EQ(IDataPartStorage::Projection::owner("store/uuid", "part_10.p.proj"), "part_10");
+    EXPECT_NE(IDataPartStorage::Projection::owner("store/uuid", "part_10.p.proj"), "part_1");
 }
 
 TEST(ProjectionStorageSchemaDeathTest, UnseededReadsAbort)
@@ -89,7 +108,7 @@ TEST(ProjectionStorageSchemaDeathTest, RemoveLiveProjectionAborts)
     ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     PartStorageFixture fixture;
     fixture.storage->setProjections({});
-    fixture.storage->createProjection("p_1.tmp_proj", IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    fixture.storage->createProjection("p_1.tmp_proj", IDataPartStorage::ProjectionStorageFormat::FLAT);
     fixture.storage->renameProjection(fixture.storage->getProjection("p_1.tmp_proj"), "p.proj", /*fsync=*/ false);
 
     /// Only temporary projections may be removed individually; removing a live one is a logical error.
@@ -103,10 +122,10 @@ TEST(ProjectionStorageSchemaDeathTest, WriteAccessRequiresOwnedProjection)
     fixture.storage->setProjections({});
 
     /// A placement that never went through createProjection does not unlock writable storage.
-    EXPECT_LOGICAL_ERROR(fixture.storage->getProjectionStorageForWrite(fixture.storage->projectionPlacement("p.proj", IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED), true));
+    EXPECT_LOGICAL_ERROR(fixture.storage->getProjectionStorageForWrite(fixture.storage->projectionPlacement("p.proj", IDataPartStorage::ProjectionStorageFormat::FLAT), true));
 
     /// The descriptor produced by createProjection does.
-    auto placement = fixture.storage->createProjection("p.proj", IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    auto placement = fixture.storage->createProjection("p.proj", IDataPartStorage::ProjectionStorageFormat::FLAT);
     EXPECT_NE(fixture.storage->getProjectionStorageForWrite(placement, true), nullptr);
 }
 
@@ -123,56 +142,68 @@ TEST(ProjectionStorageSchema, CreateRenameRemoveMaintainCache)
     PartStorageFixture fixture;
     fixture.storage->setProjections({});
 
-    fixture.storage->createProjection("p_1.tmp_proj", IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    fixture.storage->createProjection("p_1.tmp_proj", IDataPartStorage::ProjectionStorageFormat::FLAT);
     ASSERT_TRUE(fixture.storage->hasProjection("p_1.tmp_proj"));
-    ASSERT_TRUE(std::filesystem::exists(fixture.base_path / "all_1_1_0" / "p_1.tmp_proj"));
+    ASSERT_TRUE(std::filesystem::exists(fixture.base_path / "all_1_1_0.p_1.tmp_proj"));
 
     fixture.storage->renameProjection(fixture.storage->getProjection("p_1.tmp_proj"), "p.proj", /*fsync=*/ false);
     EXPECT_FALSE(fixture.storage->hasProjection("p_1.tmp_proj"));
     ASSERT_TRUE(fixture.storage->hasProjection("p.proj"));
-    EXPECT_FALSE(std::filesystem::exists(fixture.base_path / "all_1_1_0" / "p_1.tmp_proj"));
-    ASSERT_TRUE(std::filesystem::exists(fixture.base_path / "all_1_1_0" / "p.proj"));
+    EXPECT_FALSE(std::filesystem::exists(fixture.base_path / "all_1_1_0.p_1.tmp_proj"));
+    ASSERT_TRUE(std::filesystem::exists(fixture.base_path / "all_1_1_0.p.proj"));
 
-    fixture.storage->createProjection("q.tmp_proj", IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    fixture.storage->createProjection("q.tmp_proj", IDataPartStorage::ProjectionStorageFormat::FLAT);
     fixture.storage->removeProjection(fixture.storage->getProjection("q.tmp_proj"));
     EXPECT_FALSE(fixture.storage->hasProjection("q.tmp_proj"));
-    EXPECT_FALSE(std::filesystem::exists(fixture.base_path / "all_1_1_0" / "q.tmp_proj"));
+    EXPECT_FALSE(std::filesystem::exists(fixture.base_path / "all_1_1_0.q.tmp_proj"));
 
     /// The schema survives and matches disk truth.
     auto detected = fixture.storage->detectProjections();
     ASSERT_EQ(detected.size(), 1u);
     EXPECT_TRUE(detected.contains("p.proj"));
-    EXPECT_EQ(detected.at("p.proj").format, IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    EXPECT_EQ(detected.at("p.proj").format, IDataPartStorage::ProjectionStorageFormat::FLAT);
 }
 
-TEST(ProjectionStorageSchema, DetectProjections)
+TEST(ProjectionStorageSchema, DetectProjectionsBothLayouts)
 {
     PartStorageFixture fixture;
     std::filesystem::create_directories(fixture.base_path / fixture.part_dir / "nested.proj");
-    std::filesystem::create_directories(fixture.base_path / fixture.part_dir / "tmp.tmp_proj");
-    std::filesystem::create_directories(fixture.base_path / fixture.part_dir / "not_a_projection");
+    std::filesystem::create_directories(fixture.base_path / "all_1_1_0.flat.proj");
+    std::filesystem::create_directories(fixture.base_path / "all_1_1_0.tmp.tmp_proj");
+    std::filesystem::create_directories(fixture.base_path / "all_1_1_1.other.proj");   /// different owner
 
     auto detected = fixture.storage->detectProjections();
-    ASSERT_EQ(detected.size(), 2u);
+    ASSERT_EQ(detected.size(), 3u);
     EXPECT_EQ(detected.at("nested.proj").format, IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    EXPECT_EQ(detected.at("flat.proj").format, IDataPartStorage::ProjectionStorageFormat::FLAT);
     EXPECT_TRUE(detected.at("tmp.tmp_proj").is_temp);
 }
 
-TEST(ProjectionStorageSchema, RenameKeepsHistoricalFsync)
+TEST(ProjectionStorageSchema, RenameFsyncsSiblingNamespace)
 {
-    /// The historical single sync on the moved dir (02361_fsync_profile_events pins the event count).
+    PartStorageFixture fixture;
+    fixture.storage->setProjections({});
+    fixture.storage->createProjection("p.proj", IDataPartStorage::ProjectionStorageFormat::FLAT);
+
+    /// Publish (parent moves last): a sync on the root makes the sibling moves durable, then the moved
+    /// part dir; the trailing parent sync collapses to the disk root here (empty path -> not re-synced).
+    fixture.disk->sync_guard_paths.clear();
+    fixture.storage->rename(/*new_root_path=*/ "", /*new_part_dir=*/ "all_1_1_1", /*log=*/ nullptr,
+                            /*remove_new_dir_if_exists=*/ false, /*fsync_part_dir=*/ true);
+    EXPECT_EQ(fixture.disk->sync_guard_paths, (Strings{"", "all_1_1_1"}));
+
+    /// Without the setting nothing is synced.
+    fixture.disk->sync_guard_paths.clear();
+    fixture.storage->rename("", "all_1_1_2", nullptr, false, /*fsync_part_dir=*/ false);
+    EXPECT_TRUE(fixture.disk->sync_guard_paths.empty());
+
+    /// A sibling-less rename keeps the historical single sync on the moved dir
+    /// (02361_fsync_profile_events pins the event count).
     PartStorageFixture plain;
     plain.storage->setProjections({});
     plain.disk->sync_guard_paths.clear();
     plain.storage->rename("", "all_2_2_0", nullptr, false, /*fsync_part_dir=*/ true);
     EXPECT_EQ(plain.disk->sync_guard_paths, (Strings{"all_2_2_0"}));
-
-    /// Without the setting nothing is synced.
-    PartStorageFixture fixture;
-    fixture.storage->setProjections({});
-    fixture.disk->sync_guard_paths.clear();
-    fixture.storage->rename("", "all_1_1_1", nullptr, false, /*fsync_part_dir=*/ false);
-    EXPECT_TRUE(fixture.disk->sync_guard_paths.empty());
 }
 
 TEST(ProjectionStorageSchema, RenameProjectionFsyncsEnclosingDir)
@@ -180,7 +211,13 @@ TEST(ProjectionStorageSchema, RenameProjectionFsyncsEnclosingDir)
     PartStorageFixture fixture;
     fixture.storage->setProjections({});
 
-    /// The rename entry lives in the part dir.
+    /// FLAT: the rename entry lives in the parts root.
+    fixture.storage->createProjection("p_1.tmp_proj", IDataPartStorage::ProjectionStorageFormat::FLAT);
+    fixture.disk->sync_guard_paths.clear();
+    fixture.storage->renameProjection(fixture.storage->getProjection("p_1.tmp_proj"), "p.proj", /*fsync=*/ true);
+    EXPECT_EQ(fixture.disk->sync_guard_paths, (Strings{""}));
+
+    /// NESTED: the rename entry lives in the part dir.
     fixture.storage->createProjection("q_1.tmp_proj", IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
     fixture.disk->sync_guard_paths.clear();
     fixture.storage->renameProjection(fixture.storage->getProjection("q_1.tmp_proj"), "q.proj", /*fsync=*/ true);
@@ -192,15 +229,19 @@ TEST(ProjectionStorageSchema, RenameProjectionFsyncsEnclosingDir)
     EXPECT_TRUE(fixture.disk->sync_guard_paths.empty());
 }
 
-TEST(ProjectionStorageSchema, ProbeProjections)
+TEST(ProjectionStorageSchema, ProbeProjectionsBothLayouts)
 {
     PartStorageFixture fixture;
     std::filesystem::create_directories(fixture.base_path / fixture.part_dir / "nested.proj");
-    std::filesystem::create_directories(fixture.base_path / fixture.part_dir / "other.proj");
+    std::filesystem::create_directories(fixture.base_path / "all_1_1_0.flat.proj");
+    std::filesystem::create_directories(fixture.base_path / "all_1_1_0.shadowed.proj");
+    std::filesystem::create_directories(fixture.base_path / fixture.part_dir / "shadowed.proj");
 
-    auto probed = fixture.storage->detectProjections({.candidates = Strings{"nested.proj", "other.proj", "absent.proj"}});
-    ASSERT_EQ(probed.size(), 2u);
+    auto probed = fixture.storage->detectProjections({.candidates = Strings{"nested.proj", "flat.proj", "shadowed.proj", "absent.proj"}});
+    ASSERT_EQ(probed.size(), 3u);
     EXPECT_EQ(probed.at("nested.proj").format, IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
-    EXPECT_EQ(probed.at("other.proj").format, IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
+    EXPECT_EQ(probed.at("flat.proj").format, IDataPartStorage::ProjectionStorageFormat::FLAT);
+    /// A nested child shadows a same-named flat sibling.
+    EXPECT_EQ(probed.at("shadowed.proj").format, IDataPartStorage::ProjectionStorageFormat::LEGACY_NESTED);
     EXPECT_FALSE(probed.contains("absent.proj"));
 }

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -247,6 +247,7 @@ void StorageMergeTree::startup()
     /// Temporary directories contain incomplete results of merges (after forced restart)
     ///  and don't allow to reinitialize them, so delete each of them immediately
     clearOldTemporaryDirectories(0, {"tmp_", "delete_tmp_", "tmp-fetch_"});
+    clearOrphanProjectionSiblings(/*max_age_seconds=*/ 0);
 
     /// NOTE background task will also do the above cleanups periodically.
 

--- a/src/Storages/System/StorageSystemDetachedParts.cpp
+++ b/src/Storages/System/StorageSystemDetachedParts.cpp
@@ -82,7 +82,7 @@ struct WorkerState
     struct Task
     {
         DiskPtr disk;
-        String path;
+        Strings paths;
         std::atomic<size_t> * counter = nullptr;
     };
 
@@ -164,9 +164,13 @@ private:
         for (auto p_id = begin; p_id < detached_parts.size(); ++p_id)
         {
             auto & part = detached_parts[p_id];
-            auto part_path = fs::path(MergeTreeData::DETACHED_DIR_NAME) / part.dir_name;
-            auto relative_path = fs::path(current_info.data->getRelativeDataPath()) / part_path;
-            worker_state.tasks.push_back({part.disk, relative_path, &parts_sizes.at(p_id - begin)});
+            auto detached_path = fs::path(current_info.data->getRelativeDataPath()) / MergeTreeData::DETACHED_DIR_NAME;
+            /// The entry's size includes its FLAT projection siblings.
+            Strings paths;
+            paths.push_back(detached_path / part.dir_name);
+            for (const auto & sibling : part.projection_siblings)
+                paths.push_back(detached_path / sibling);
+            worker_state.tasks.push_back({part.disk, std::move(paths), &parts_sizes.at(p_id - begin)});
         }
 
         auto max_thread_to_run = std::max(size_t(1), std::min(support_threads, worker_state.tasks.size() / 10));
@@ -184,7 +188,9 @@ private:
                 for (auto id = worker_state.next_task++; id < worker_state.tasks.size(); id = worker_state.next_task++)
                 {
                     auto & task = worker_state.tasks.at(id);
-                    size_t size = calculateTotalSizeOnDisk(task.disk, task.path);
+                    size_t size = 0;
+                    for (const auto & path : task.paths)
+                        size += calculateTotalSizeOnDisk(task.disk, path);
                     task.counter->store(size);
                 }
             };

--- a/tests/integration/test_projection_storage_format/configs/backups.xml
+++ b/tests/integration/test_projection_storage_format/configs/backups.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <backups>
+        <allowed_path>/var/lib/clickhouse/backups/</allowed_path>
+    </backups>
+</clickhouse>

--- a/tests/integration/test_projection_storage_format/test.py
+++ b/tests/integration/test_projection_storage_format/test.py
@@ -7,11 +7,21 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
     "node",
-    main_configs=["configs/storage_conf.xml"],
+    main_configs=["configs/storage_conf.xml", "configs/backups.xml"],
     with_minio=True,
     with_zookeeper=True,
     stay_alive=True,
 )
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/storage_conf.xml", "configs/backups.xml"],
+    with_minio=True,
+    with_zookeeper=True,
+    stay_alive=True,
+)
+
+# Each known issue links to its PR review comment.
+REVIEW = "https://github.com/ClickHouse/ClickHouse/pull/108443#discussion_r"
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -54,6 +64,14 @@ def part_dir(name, n=node):  # absolute container path, no trailing slash: .../a
 
 def part_name(name, n=node):
     return part_dir(name, n).split("/")[-1]
+
+
+def table_path(name, n=node):
+    return (
+        n.query(f"SELECT data_paths[1] FROM system.tables WHERE name = '{name}'")
+        .strip()
+        .rstrip("/")
+    )
 
 
 def proj_query(name, n=node, extra_settings=""):
@@ -100,6 +118,12 @@ def broken_projection_parts(name, n=node):
     ).strip()
 
 
+def outdated_parts(name, n=node):
+    return n.query(
+        f"SELECT count() FROM system.parts WHERE table = '{name}' AND active = 0"
+    ).strip()
+
+
 def wait_for(predicate, timeout=60):
     for _ in range(timeout * 2):
         if predicate():
@@ -114,8 +138,56 @@ def block_until_tables_loaded(name, n=node):
     n.query(f"SELECT count() FROM {name}")
 
 
+def plant_stale_tmp_dir(stale, n=node):
+    """Simulate leftovers of a failed operation: a stale temporary part dir plus its
+    flat projection sibling, both containing a marker file. chmod so the server
+    (clickhouse user) can remove root-created content."""
+    n.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"mkdir -p {stale} {stale}.p.proj"
+            f" && touch {stale}/stale_marker.txt {stale}.p.proj/stale_marker.txt"
+            f" && chmod -R 777 {stale} {stale}.p.proj",
+        ],
+        privileged=True,
+        user="root",
+    )
+
+
+def plant_stale_live_sibling(path):
+    """A flat projection sibling under a LIVE part name whose parent never committed:
+    the residue of a publish that crashed between the sibling and parent renames."""
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"mkdir -p {path} && touch {path}/stale_marker.txt && chmod -R 777 {path}",
+        ],
+        privileged=True,
+        user="root",
+    )
+
+
 # Table-level settings clause that forces packed part storage regardless of part size.
 PACKED = "min_bytes_for_full_part_storage = '1G'"
+
+
+def packed_archive_files(part_path, n=node, disk="default"):
+    """Member file names of the data.packed archive of the part (or projection) at part_path."""
+    root = n.query(f"SELECT path FROM system.disks WHERE name = '{disk}'").strip()
+    rel = os.path.relpath(os.path.join(part_path, "data.packed"), root)
+    out = n.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"clickhouse disks --config /etc/clickhouse-server/config.xml --disk {disk}"
+            f" --query \"packed-io list {rel}\" | awk '{{print $1}}'",
+        ],
+        privileged=True,
+        user="root",
+    )
+    return out.split()
 
 
 def packed_archive_member(part_path, member, n=node, disk="default"):
@@ -167,21 +239,49 @@ def with_disk(extra_settings, disk):
     return extra_settings + (f", storage_policy = '{disk}'" if disk != "local" else "")
 
 
+# Projection layout the object-storage regression tests run for: the deferred-transaction bug is
+# layout-independent (the probe misses a queued rename whether the projection is nested or a flat
+# sibling), so section N pins both layouts.
+@pytest.fixture(params=["legacy_nested", "flat"])
+def storage_format(request):
+    return request.param
+
+
+def minio_keys():
+    return {
+        o.object_name
+        for o in cluster.minio_client.list_objects(
+            cluster.minio_bucket, "data/", recursive=True
+        )
+    }
+
+
+def sibling_blob_keys(uuid, part, n=node):
+    # local_path is relative to the disk root; the store/<prefix>/<uuid>/ segment is unique per table
+    return set(
+        n.query(
+            f"""SELECT remote_path FROM system.remote_data_paths
+                WHERE local_path LIKE '%/{uuid}/{part}.p.proj/%'"""
+        ).split()
+    )
+
+
 # ==============================================================================
-# A. Layout basics
+# A. Layout basics and format selection
 # ==============================================================================
 
-# This test pins the projection on-disk layout: the projection is stored nested inside its parent
-# part directory, and no sibling directory ever appears at the parts root.
+# This test checks that a projection defaults to the nested layout when the format setting is
+# unset, so a flat sibling is never written by accident.
 # Scenario:
-# - create table with a projection
-# - assert structure: the projection is nested inside the part, no sibling at the parts root
+# - create table with a projection and the default (unset) storage format
+# - assert structure: the projection is nested inside the part, no flat sibling
 # - assert SELECT through the projection
 # - restart, assert SELECT unchanged and the part is intact
-def test_layout_nested():
+def test_layout_default_is_nested():
+    # create table with the default (unset) storage format
     setup_table("t_nested")
 
-    # assert structure: nested inside the part, no sibling at the parts root
+    # assert structure: nested inside the part, no flat sibling
     p = part_dir("t_nested")
     assert path_exists(f"{p}/p.proj")
     assert not path_exists(f"{p}.p.proj")
@@ -195,12 +295,1374 @@ def test_layout_nested():
     assert active_parts("t_nested") == "1"
 
 
+# This test checks that projection_storage_format = 'flat' writes the projection as a flat sibling
+# and that the layout survives a merge and a restart, not just the initial insert.
+# Scenario:
+# - create table with a 'flat' projection
+# - assert structure: the projection is a flat sibling, not nested
+# - INSERT a second part and MERGE (OPTIMIZE TABLE FINAL)
+# - assert structure: the merged part keeps the flat layout, SELECT matches
+# - restart, assert the part and SELECT survive
+def test_layout_flat_setting_persists(storage_kind):
+    # create table with a 'flat' projection
+    setup_table(
+        "t_flat_setting", with_storage("projection_storage_format = 'flat'", storage_kind)
+    )
+
+    # assert structure: the server wrote the projection as a flat sibling, not nested
+    p = part_dir("t_flat_setting")
+    assert path_exists(f"{p}.p.proj")
+    assert not path_exists(f"{p}/p.proj")
+    baseline = proj_query("t_flat_setting")
+
+    # insert a second part and merge; the merge keeps the flat layout
+    node.query(
+        "INSERT INTO t_flat_setting SELECT number, number * 2, toString(number) FROM numbers(1000, 1000)"
+    )
+    node.query("SYSTEM START MERGES")
+    node.query("OPTIMIZE TABLE t_flat_setting FINAL")
+    merged = part_dir("t_flat_setting")
+    assert path_exists(f"{merged}.p.proj")
+    assert not path_exists(f"{merged}/p.proj")
+    assert active_parts("t_flat_setting") == "1"
+    assert int(active_projection_parts("t_flat_setting")) >= 1
+    assert proj_query("t_flat_setting") == baseline
+
+    # restart, assert the part and SELECT survive
+    node.restart_clickhouse()
+    block_until_tables_loaded("t_flat_setting")
+    assert active_parts("t_flat_setting") == "1"
+    assert proj_query("t_flat_setting") == baseline
+
+
+# This test checks that a nested part manually relocated to the flat sibling name is accepted by the
+# server on load, so an operator can migrate a part's layout out of band.
+# Scenario:
+# - create table with a nested projection, capture SELECT baseline
+# - stop the server and move <part>/p.proj to the flat sibling name
+# - start the server
+# - assert structure: only the flat sibling exists
+# - assert the projection is active and SELECT matches baseline
+def test_layout_flat_after_manual_relocation():
+    # create table with a nested projection, capture baseline
+    setup_table("t_flat")
+    p = part_dir("t_flat")
+    baseline = proj_query("t_flat")
+
+    # move the nested dir to the flat sibling name while the server is down
+    node.stop_clickhouse()
+    node.exec_in_container(
+        ["bash", "-c", f"mv {p}/p.proj {p}.p.proj"], privileged=True, user="root"
+    )
+    node.start_clickhouse()
+    block_until_tables_loaded("t_flat")
+
+    # assert structure: only the flat sibling exists, and the projection is usable
+    assert path_exists(f"{p}.p.proj")
+    assert not path_exists(f"{p}/p.proj")
+    assert active_parts("t_flat") == "1"
+    assert int(active_projection_parts("t_flat")) >= 1
+    assert proj_query("t_flat") == baseline
+
+
+# This test checks that the flat layout is applied to COMPACT parts too, not only WIDE ones: a
+# part-type gate would silently keep the projection nested on compact parts.
+# Scenario:
+# - create table with a 'flat' projection and a large min_bytes_for_wide_part (forces a compact part)
+# - assert the part is compact
+# - assert structure: the projection is a flat sibling, not nested
+# - assert SELECT through the projection
+def test_layout_flat_compact_part():
+    # create table whose threshold forces a compact part
+    node.query("DROP TABLE IF EXISTS t_compact SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        """CREATE TABLE t_compact (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id, value ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 1000000000, projection_storage_format = 'flat'"""
+    )
+    node.query(
+        "INSERT INTO t_compact SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # assert the part is compact
+    part_type = node.query(
+        "SELECT part_type FROM system.parts WHERE table = 't_compact' AND active = 1"
+    ).strip()
+    assert part_type == "Compact", part_type
+
+    # assert structure: flat sibling, not nested
+    p = part_dir("t_compact")
+    assert path_exists(f"{p}.p.proj")
+    assert not path_exists(f"{p}/p.proj")
+
+    # assert SELECT through the projection
+    assert (
+        proj_query("t_compact", extra_settings="force_optimize_projection = 1")
+        == "100\t4950"
+    )
+
+
+# This test checks that switching projection_storage_format to 'flat' rewrites an existing nested
+# part on the next merge: the setting must govern newly written parts, the source layout must not stick.
+# Scenario:
+# - create table with a default (nested) projection, insert two parts
+# - assert structure: nested
+# - MODIFY SETTING projection_storage_format = 'flat'
+# - MERGE (OPTIMIZE TABLE FINAL)
+# - assert structure: the merged part is a flat sibling, no nested dir
+# - assert SELECT and CHECK TABLE
+def test_layout_convert_nested_to_flat(storage_kind):
+    # create table with a default (nested) projection, insert two parts
+    node.query("DROP TABLE IF EXISTS t_n2f SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        f"""CREATE TABLE t_n2f (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id, value ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS {with_storage("min_bytes_for_wide_part = 0", storage_kind)}"""
+    )
+    for rng in ("numbers(1000)", "numbers(1000, 1000)"):
+        node.query(
+            f"INSERT INTO t_n2f SELECT number, number * 2, toString(number) FROM {rng}"
+        )
+
+    # assert structure: nested
+    assert path_exists(f"{part_dir('t_n2f')}/p.proj")
+
+    # switch the layout to 'flat'
+    node.query("ALTER TABLE t_n2f MODIFY SETTING projection_storage_format = 'flat'")
+
+    # merge rewrites the part in the current (flat) layout
+    node.query("SYSTEM START MERGES t_n2f")
+    node.query("OPTIMIZE TABLE t_n2f FINAL")
+
+    # assert structure: merged part is a flat sibling, no nested dir
+    p = part_dir("t_n2f")
+    assert path_exists(f"{p}.p.proj")
+    assert not path_exists(f"{p}/p.proj")
+
+    # assert SELECT and CHECK TABLE
+    assert active_parts("t_n2f") == "1"
+    assert broken_projection_parts("t_n2f") == "0"
+    assert proj_query("t_n2f", extra_settings="force_optimize_projection = 1") == "100\t4950"
+    assert check_table("t_n2f") == "1"
+
+
+# This test checks the reverse (downgrade) conversion: switching back to 'legacy_nested' and merging
+# must rewrite a flat part into the nested layout, leaving no flat sibling behind.
+# Scenario:
+# - create table with a 'flat' projection, insert two parts
+# - assert structure: flat siblings
+# - MODIFY SETTING projection_storage_format = 'legacy_nested'
+# - MERGE (OPTIMIZE TABLE FINAL)
+# - assert structure: the merged part is nested, no flat sibling
+# - assert SELECT and CHECK TABLE
+def test_layout_convert_flat_to_nested(storage_kind):
+    # create table with a 'flat' projection, insert two parts
+    node.query("DROP TABLE IF EXISTS t_f2n SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        f"""CREATE TABLE t_f2n (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id, value ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS {with_storage("min_bytes_for_wide_part = 0, projection_storage_format = 'flat'", storage_kind)}"""
+    )
+    for rng in ("numbers(1000)", "numbers(1000, 1000)"):
+        node.query(
+            f"INSERT INTO t_f2n SELECT number, number * 2, toString(number) FROM {rng}"
+        )
+
+    # assert structure: flat siblings
+    assert path_exists(f"{part_dir('t_f2n')}.p.proj")
+
+    # switch the layout back to nested
+    node.query(
+        "ALTER TABLE t_f2n MODIFY SETTING projection_storage_format = 'legacy_nested'"
+    )
+
+    # merge rewrites the part in the current (nested) layout
+    node.query("SYSTEM START MERGES t_f2n")
+    node.query("OPTIMIZE TABLE t_f2n FINAL")
+
+    # assert structure: merged part is nested, no flat sibling
+    p = part_dir("t_f2n")
+    assert path_exists(f"{p}/p.proj")
+    assert not path_exists(f"{p}.p.proj")
+
+    # assert SELECT and CHECK TABLE
+    assert active_parts("t_f2n") == "1"
+    assert broken_projection_parts("t_f2n") == "0"
+    assert proj_query("t_f2n", extra_settings="force_optimize_projection = 1") == "100\t4950"
+    assert check_table("t_f2n") == "1"
+
+
 # ==============================================================================
-# F. Manifest desync, repair, and adoption policy
+# B. Lifecycle operations carry the flat sibling
 # ==============================================================================
 
-# A projection dir present on disk and declared in metadata but missing from checksums.txt is NOT
-# adopted: checksums.txt is the commit point, loadProjections loads only what the manifest lists.
+# This test checks that a replicated fetch materializes the projection in the flat layout on the
+# receiving replica, instead of a nested or missing sibling. (Issue #5)
+# Scenario:
+# - create the replicated 'flat' table on both replicas
+# - insert on replica 1, SYNC replica 2 (replica 2 fetches the part)
+# - assert structure: the fetched part carries a flat sibling
+# - assert SELECT matches across replicas
+# @pytest.mark.xfail(reason=REVIEW + "3473479560", strict=False)
+def test_carry_replicated_fetch(storage_kind):
+    # create the replicated 'flat' table on both replicas
+    for n, replica in ((node, "1"), (node2, "2")):
+        n.query("DROP TABLE IF EXISTS t_repl SYNC")
+        n.query("SYSTEM STOP MERGES")
+        n.query(
+            f"""CREATE TABLE t_repl (key UInt64, id UInt64, value String,
+                PROJECTION p (SELECT key, id, value ORDER BY id))
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/t_repl', '{replica}')
+                ORDER BY key
+                SETTINGS {with_storage("min_bytes_for_wide_part = 0, projection_storage_format = 'flat'", storage_kind)}"""
+        )
+
+    # insert on replica 1, sync replica 2 (which fetches the part)
+    node.query(
+        "INSERT INTO t_repl SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+    node2.query("SYSTEM SYNC REPLICA t_repl")
+
+    # assert structure: the fetched part carries a flat sibling; fail closed: it is usable, not a silent base-part fallback
+    p = part_dir("t_repl", node2)
+    assert path_exists(f"{p}.p.proj", node2)
+    assert broken_projection_parts("t_repl", node2) == "0"
+    assert proj_query(
+        "t_repl", node2, extra_settings="force_optimize_projection = 1"
+    ) == proj_query("t_repl", node, extra_settings="force_optimize_projection = 1")
+
+
+# This test checks that a merge on a ReplicatedMergeTree writes the flat layout on each replica
+# (merges execute locally): a replica must not end up with a nested or missing sibling.
+# Scenario:
+# - create the replicated 'flat' table on both replicas
+# - insert two parts on replica 1, SYNC replica 2
+# - MERGE (OPTIMIZE TABLE FINAL), SYNC replica 2
+# - assert structure: both replicas expose a single flat-sibling part
+# - assert SELECT matches across replicas
+def test_carry_replicated_merge(storage_kind):
+    # create the replicated 'flat' table on both replicas
+    for n, replica in ((node, "1"), (node2, "2")):
+        n.query("DROP TABLE IF EXISTS t_rmerge SYNC")
+        n.query("SYSTEM STOP MERGES")
+        n.query(
+            f"""CREATE TABLE t_rmerge (key UInt64, id UInt64, value String,
+                PROJECTION p (SELECT key, id, value ORDER BY id))
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/t_rmerge', '{replica}')
+                ORDER BY key
+                SETTINGS {with_storage("min_bytes_for_wide_part = 0, projection_storage_format = 'flat'", storage_kind)}"""
+        )
+
+    # insert two parts on replica 1, sync replica 2
+    for rng in ("numbers(1000)", "numbers(1000, 1000)"):
+        node.query(
+            f"INSERT INTO t_rmerge SELECT number, number * 2, toString(number) FROM {rng}"
+        )
+    node2.query("SYSTEM SYNC REPLICA t_rmerge")
+
+    # merge: each replica lands the merged part in its own flat layout
+    for n in (node, node2):
+        n.query("SYSTEM START MERGES t_rmerge")
+    node.query("OPTIMIZE TABLE t_rmerge FINAL")
+    node2.query("SYSTEM SYNC REPLICA t_rmerge")
+
+    # assert structure: both replicas expose one flat-sibling part
+    for n in (node, node2):
+        wait_for(lambda n=n: active_parts("t_rmerge", n) == "1")
+        p = part_dir("t_rmerge", n)
+        assert path_exists(f"{p}.p.proj", n)
+        assert not path_exists(f"{p}/p.proj", n)
+        assert broken_projection_parts("t_rmerge", n) == "0"
+
+    # assert SELECT matches across replicas
+    assert proj_query("t_rmerge", node2) == proj_query("t_rmerge", node)
+
+
+# This test checks that ATTACH PARTITION FROM (clonePart) copies the flat projection sibling into
+# the destination table, instead of dropping it. (Issue #2)
+# Scenario:
+# - create 'flat' source and destination tables
+# - TRUNCATE the destination, then ATTACH PARTITION FROM the source
+# - assert structure: the destination part carries a flat sibling
+# - assert SELECT matches the source
+# @pytest.mark.xfail(reason=REVIEW + "3472535412", strict=False)
+def test_carry_attach_partition_from(storage_kind):
+    # create 'flat' source and destination tables
+    setup_table("t_src", with_storage("projection_storage_format = 'flat'", storage_kind))
+    setup_table("t_dst", with_storage("projection_storage_format = 'flat'", storage_kind))
+
+    # clear the destination and attach the source partition into it
+    node.query("TRUNCATE TABLE t_dst")
+    node.query("ALTER TABLE t_dst ATTACH PARTITION tuple() FROM t_src")
+
+    # assert structure: the destination part carries a flat sibling; fail closed: it is usable, not a silent base-part fallback
+    p = part_dir("t_dst")
+    assert path_exists(f"{p}.p.proj")
+    assert broken_projection_parts("t_dst") == "0"
+    assert proj_query(
+        "t_dst", extra_settings="force_optimize_projection = 1"
+    ) == proj_query("t_src", extra_settings="force_optimize_projection = 1")
+
+
+# This test checks that DETACH/ATTACH PART moves the flat sibling with the part on disk and in
+# memory: after ATTACH the projection part's root must point at the attached location, not detached/.
+# Scenario:
+# - create table with a 'flat' projection, capture SELECT baseline
+# - DETACH PART, then ATTACH PART
+# - assert structure: the flat sibling is at the attached location and nothing is left under detached/
+# - assert the projection is healthy and SELECT matches baseline
+# @pytest.mark.xfail(reason=REVIEW + "3473543140", strict=False)
+def test_carry_detach_attach_part(storage_kind):
+    # create table with a 'flat' projection, capture baseline
+    setup_table("t_da", with_storage("projection_storage_format = 'flat'", storage_kind))
+    baseline = proj_query("t_da")
+    name = part_name("t_da")
+
+    # DETACH then ATTACH the part
+    node.query(f"ALTER TABLE t_da DETACH PART '{name}'")
+    node.query(f"ALTER TABLE t_da ATTACH PART '{name}'")
+
+    # assert structure: sibling at the attached location, nothing left under detached/
+    p = part_dir("t_da")
+    table_root = p.rsplit("/", 1)[0]
+    assert path_exists(f"{p}.p.proj")
+    leftover = node.exec_in_container(
+        ["bash", "-c", f"find {table_root}/detached -maxdepth 1 -name '*.proj' | wc -l"],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert leftover == "0"
+
+    # fail closed: the attached part must serve the projection from its new location
+    assert broken_projection_parts("t_da") == "0"
+    assert (
+        proj_query("t_da", extra_settings="force_optimize_projection = 1") == baseline
+    )
+
+
+# This test checks that DETACH/ATTACH PART never leaves a mixed on-disk state: a live-named parent
+# without its sibling, or a sibling stranded under detached/.
+# Scenario:
+# - create table with a 'flat' projection, capture SELECT baseline
+# - DETACH PART; assert nothing of the part stays at live names, both parent and sibling under detached/
+# - ATTACH PART; assert parent and sibling live again, nothing left under detached/
+# - assert the projection is healthy and SELECT matches baseline
+def test_carry_detach_attach_no_mixed_state(storage_kind):
+    # create table with a 'flat' projection, capture baseline
+    setup_table("t_mix", with_storage("projection_storage_format = 'flat'", storage_kind))
+    baseline = proj_query("t_mix")
+    live = part_dir("t_mix")
+    name = part_name("t_mix")
+    table_root = live.rsplit("/", 1)[0]
+
+    # DETACH: nothing stays at live names, parent + sibling both under detached/
+    node.query(f"ALTER TABLE t_mix DETACH PART '{name}'")
+    assert not path_exists(live)
+    assert not path_exists(f"{live}.p.proj")
+    assert path_exists(f"{table_root}/detached/{name}")
+    assert path_exists(f"{table_root}/detached/{name}.p.proj")
+
+    # ATTACH: parent + sibling live again, nothing left under detached/
+    node.query(f"ALTER TABLE t_mix ATTACH PART '{name}'")
+    p = part_dir("t_mix")
+    assert path_exists(f"{p}.p.proj")
+    leftover = node.exec_in_container(
+        ["bash", "-c", f"find {table_root}/detached -maxdepth 1 -name '*.proj' | wc -l"],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert leftover == "0"
+
+    # assert the projection is healthy and SELECT matches baseline
+    assert broken_projection_parts("t_mix") == "0"
+    assert (
+        proj_query("t_mix", extra_settings="force_optimize_projection = 1") == baseline
+    )
+
+
+# This test checks that a part loaded from disk after a restart keeps its flat layout for later
+# operations: a reloaded part must still DETACH/ATTACH as flat. (Issue #3)
+# Scenario:
+# - create table with a 'flat' projection, capture SELECT baseline
+# - restart the server (the part is reloaded from disk)
+# - DETACH PART, then ATTACH PART
+# - assert structure: the flat sibling is present and SELECT matches baseline
+# @pytest.mark.xfail(reason=REVIEW + "3472535414", strict=False)
+def test_carry_after_restart_detach_attach():
+    # create table with a 'flat' projection, capture the forced-projection baseline
+    setup_table("t_reload", "projection_storage_format = 'flat'")
+    baseline = proj_query("t_reload", extra_settings="force_optimize_projection = 1")
+
+    # restart, then round-trip the reloaded part through DETACH/ATTACH
+    node.restart_clickhouse()
+    block_until_tables_loaded("t_reload")
+    name = part_name("t_reload")
+    node.query(f"ALTER TABLE t_reload DETACH PART '{name}'")
+    node.query(f"ALTER TABLE t_reload ATTACH PART '{name}'")
+
+    # assert structure: flat sibling present; fail closed: the reloaded-then-round-tripped part is usable
+    p = part_dir("t_reload")
+    assert path_exists(f"{p}.p.proj")
+    assert broken_projection_parts("t_reload") == "0"
+    assert proj_query("t_reload", extra_settings="force_optimize_projection = 1") == baseline
+
+
+# This test checks that after DETACH PART, system.detached_parts shows exactly one entry (no junk
+# row for the sibling) whose bytes_on_disk includes the sibling, and DROP DETACHED PART removes both.
+# Scenario:
+# - create table with a 'flat' projection, DETACH PART
+# - assert the surface: exactly one detached entry, bytes_on_disk covers parent + sibling
+# - DROP DETACHED PART
+# - assert both parent and sibling are gone and nothing is left under detached/
+# https://github.com/ClickHouse/ClickHouse/pull/108443#discussion_r3569019447
+def test_carry_detached_parts_surface():
+    # create table with a 'flat' projection, DETACH PART
+    setup_table("t_det_surf", "projection_storage_format = 'flat'")
+    name = part_name("t_det_surf")
+    table_root = part_dir("t_det_surf").rsplit("/", 1)[0]
+    node.query(f"ALTER TABLE t_det_surf DETACH PART '{name}'")
+
+    # assert the surface: exactly one detached entry, no row for the sibling
+    rows = node.query(
+        "SELECT name FROM system.detached_parts WHERE table = 't_det_surf'"
+    ).strip()
+    assert rows == name  # exactly one entry, no row for the sibling
+    bytes_on_disk = int(
+        node.query(
+            f"SELECT bytes_on_disk FROM system.detached_parts WHERE table = 't_det_surf' AND name = '{name}'"
+        ).strip()
+    )
+
+    def files_size(path):
+        return int(
+            node.exec_in_container(
+                [
+                    "bash",
+                    "-c",
+                    f"find {path} -type f -printf '%s\\n' | awk '{{s+=$1}} END {{print s+0}}'",
+                ],
+                privileged=True,
+                user="root",
+            ).strip()
+        )
+
+    # assert bytes_on_disk covers the parent + the sibling
+    parent_size = files_size(f"{table_root}/detached/{name}")
+    sibling_size = files_size(f"{table_root}/detached/{name}.p.proj")
+    assert sibling_size > 0
+    assert bytes_on_disk >= parent_size + sibling_size
+
+    # DROP DETACHED PART removes parent and sibling, nothing left under detached/
+    node.query(
+        f"ALTER TABLE t_det_surf DROP DETACHED PART '{name}' SETTINGS allow_drop_detached = 1"
+    )
+    assert not path_exists(f"{table_root}/detached/{name}")
+    assert not path_exists(f"{table_root}/detached/{name}.p.proj")
+    leftovers = node.exec_in_container(
+        ["bash", "-c", f"find {table_root}/detached -maxdepth 1 -name '*.proj' | wc -l"],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert leftovers == "0"
+
+
+# This test checks that MATERIALIZE PROJECTION inside a mutation finalizes the winner tmp_proj into
+# a flat sibling, leaves no tmp residue, and survives the part's final rename.
+# Scenario:
+# - create a 'flat' table without a projection, insert data
+# - ADD PROJECTION, then MATERIALIZE PROJECTION (mutation)
+# - assert structure: a flat sibling, no nested dir, no *.tmp_proj residue
+# - assert CHECK TABLE and SELECT survive a restart
+def test_carry_materialize_projection(storage_kind):
+    # create a 'flat' table without a projection, insert data
+    node.query("DROP TABLE IF EXISTS t_mat SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        f"""CREATE TABLE t_mat (key UInt64, id UInt64, value String)
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS {with_storage("min_bytes_for_wide_part = 0, projection_storage_format = 'flat'", storage_kind)}"""
+    )
+    node.query(
+        "INSERT INTO t_mat SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # add and materialize the projection
+    node.query("ALTER TABLE t_mat ADD PROJECTION p (SELECT key, id, value ORDER BY id)")
+    node.query(
+        "ALTER TABLE t_mat MATERIALIZE PROJECTION p SETTINGS mutations_sync = 2"
+    )
+
+    # assert structure: flat sibling, no nested dir, no tmp residue
+    p = part_dir("t_mat")
+    assert path_exists(f"{p}.p.proj")
+    assert not path_exists(f"{p}/p.proj")
+    tmp_residue = node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "find /var/lib/clickhouse/data/default/t_mat -maxdepth 1 -name '*.tmp_proj' | wc -l",
+        ],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert tmp_residue == "0"
+    assert check_table("t_mat") == "1"
+
+    # assert SELECT survives a restart
+    baseline = proj_query("t_mat")
+    node.restart_clickhouse()
+    assert proj_query("t_mat") == baseline
+    assert int(active_projection_parts("t_mat")) >= 1
+
+
+# This test checks that a lightweight DELETE in 'rebuild' projection mode re-materializes the
+# projection in the flat layout: the rebuilt part must carry a flat sibling, not a nested dir.
+# Scenario:
+# - create table with a 'flat' projection and lightweight_mutation_projection_mode = 'rebuild'
+# - lightweight DELETE of some rows (mutation rebuilds the projection)
+# - assert structure: the new part carries a flat sibling, no nested dir
+# - assert SELECT and CHECK TABLE
+def test_carry_lightweight_delete_rebuild():
+    # create table with a 'flat' projection that rebuilds on lightweight delete
+    node.query("DROP TABLE IF EXISTS t_lwd SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        """CREATE TABLE t_lwd (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id, value ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat',
+               lightweight_mutation_projection_mode = 'rebuild'"""
+    )
+    node.query(
+        "INSERT INTO t_lwd SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # lightweight DELETE rebuilds the projection into the current (flat) layout
+    node.query("DELETE FROM t_lwd WHERE key >= 500 SETTINGS mutations_sync = 2")
+
+    # assert structure: the rebuilt part carries a flat sibling, no nested dir
+    p = part_dir("t_lwd")
+    assert path_exists(f"{p}.p.proj")
+    assert not path_exists(f"{p}/p.proj")
+
+    # assert SELECT and CHECK TABLE
+    assert node.query("SELECT count() FROM t_lwd").strip() == "500"
+    assert broken_projection_parts("t_lwd") == "0"
+    assert proj_query("t_lwd", extra_settings="force_optimize_projection = 1") == "100\t4950"
+    assert check_table("t_lwd") == "1"
+
+
+# This test checks that a part with two projections in the flat layout gets one sibling per
+# projection (<part>.p.proj and <part>.q.proj) and that both survive a merge.
+# Scenario:
+# - create a 'flat' table with two projections p and q, insert two parts
+# - MERGE (OPTIMIZE TABLE FINAL)
+# - assert structure: both flat siblings present, neither nested
+# - assert both projection parts are active and CHECK TABLE passes
+def test_carry_multiple_projections(storage_kind):
+    # create a 'flat' table with two projections, insert two parts
+    node.query("DROP TABLE IF EXISTS t_multi SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        f"""CREATE TABLE t_multi (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id ORDER BY id),
+           PROJECTION q (SELECT id, key ORDER BY key))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS {with_storage("min_bytes_for_wide_part = 0, projection_storage_format = 'flat'", storage_kind)}"""
+    )
+    for rng in ("numbers(1000)", "numbers(1000, 1000)"):
+        node.query(
+            f"INSERT INTO t_multi SELECT number, number * 2, toString(number) FROM {rng}"
+        )
+
+    # merge into a single part
+    node.query("SYSTEM START MERGES t_multi")
+    node.query("OPTIMIZE TABLE t_multi FINAL")
+
+    # assert structure: both flat siblings present, neither nested
+    p = part_dir("t_multi")
+    assert path_exists(f"{p}.p.proj")
+    assert path_exists(f"{p}.q.proj")
+    assert not path_exists(f"{p}/p.proj")
+    assert not path_exists(f"{p}/q.proj")
+
+    # assert both projection parts are active and CHECK TABLE passes
+    assert active_parts("t_multi") == "1"
+    assert int(active_projection_parts("t_multi")) >= 2
+    assert broken_projection_parts("t_multi") == "0"
+    assert check_table("t_multi") == "1"
+    assert proj_query("t_multi", extra_settings="force_optimize_projection = 1") == "100\t4950"
+
+
+# This test checks that a partitioned 'flat' table keeps a per-partition flat sibling through a
+# merge: each partition's merged part must have its own sibling and stay healthy.
+# Scenario:
+# - create a partitioned table with a 'flat' projection, insert several parts across partitions
+# - MERGE (OPTIMIZE TABLE FINAL)
+# - assert structure: each active part has a flat sibling, none nested
+# - assert SELECT and CHECK TABLE
+def test_carry_partitioned_merge(storage_kind):
+    # create a partitioned 'flat' table, insert across partitions
+    node.query("DROP TABLE IF EXISTS t_part SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        f"""CREATE TABLE t_part (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id, value ORDER BY id))
+           ENGINE = MergeTree PARTITION BY key % 2 ORDER BY key
+           SETTINGS {with_storage("min_bytes_for_wide_part = 0, projection_storage_format = 'flat'", storage_kind)}"""
+    )
+    for rng in ("numbers(1000)", "numbers(1000, 1000)"):
+        node.query(
+            f"INSERT INTO t_part SELECT number, number * 2, toString(number) FROM {rng}"
+        )
+
+    # merge each partition
+    node.query("SYSTEM START MERGES t_part")
+    node.query("OPTIMIZE TABLE t_part FINAL")
+
+    # assert structure: one part per partition, each with a flat sibling, none nested
+    assert active_parts("t_part") == "2"
+    paths = node.query(
+        "SELECT path FROM system.parts WHERE table = 't_part' AND active = 1"
+    ).split()
+    for path in paths:
+        p = path.rstrip("/")
+        assert path_exists(f"{p}.p.proj")
+        assert not path_exists(f"{p}/p.proj")
+
+    # assert SELECT and CHECK TABLE
+    assert broken_projection_parts("t_part") == "0"
+    assert proj_query("t_part", extra_settings="force_optimize_projection = 1") == "100\t4950"
+    assert check_table("t_part") == "1"
+
+
+# This test checks that RENAME TABLE repoints the loaded projection sub-part storages in memory, so
+# the projection stays readable from the new table path without a restart. Only an Ordinary database
+# moves data on rename (an Atomic database keeps the UUID path), so the table lives in one here.
+# Scenario:
+# - create an Ordinary database with a 'flat' table and a projection, capture SELECT baseline
+# - RENAME TABLE to a new name (the data directory moves on disk)
+# - assert structure: the flat sibling exists under the new table path
+# - without a restart, assert the projection still serves the query and CHECK TABLE passes
+# https://github.com/ClickHouse/ClickHouse/pull/108443#discussion_r3595946442
+def test_carry_rename_table():
+    # create an Ordinary database: Atomic keeps the UUID path, so only Ordinary moves data on rename
+    node.query("DROP DATABASE IF EXISTS t_ren_db SYNC")
+    node.query(
+        "CREATE DATABASE t_ren_db ENGINE = Ordinary",
+        settings={"allow_deprecated_database_ordinary": 1},
+    )
+
+    # create a 'flat' table with a projection and capture the baseline before the rename
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        """CREATE TABLE t_ren_db.src (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id, value ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat'"""
+    )
+    node.query(
+        "INSERT INTO t_ren_db.src SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+    baseline = proj_query("t_ren_db.src", extra_settings="force_optimize_projection = 1")
+
+    # rename the table; the data directory moves on disk
+    node.query("RENAME TABLE t_ren_db.src TO t_ren_db.dst")
+
+    # assert structure: the flat sibling moved under the new table path
+    p = (
+        node.query(
+            "SELECT path FROM system.parts WHERE database = 't_ren_db' AND table = 'dst' AND active = 1 LIMIT 1"
+        )
+        .strip()
+        .rstrip("/")
+    )
+    assert "/dst/" in p
+    assert path_exists(f"{p}.p.proj")
+
+    # without a restart, the repointed storage must serve the projection from the new path
+    broken = node.query(
+        "SELECT count() FROM system.projection_parts WHERE database = 't_ren_db' AND table = 'dst' AND is_broken"
+    ).strip()
+    assert broken == "0"
+    assert (
+        proj_query("t_ren_db.dst", extra_settings="force_optimize_projection = 1")
+        == baseline
+    )
+    assert check_table("t_ren_db.dst") == "1"
+
+
+# This test checks that MOVE PART across disks (clonePart's flat_projection_copies path) carries a
+# materialized flat projection sibling onto the destination disk, healthy and usable -- the positive
+# counterpart to test_unowned_move_part_skips, whose part owns no projection so the copy loop is a no-op. (Issue #2)
+# Scenario:
+# - create a 'flat' table on a multi-disk policy with the projection materialized on insert
+# - capture the forced-projection baseline, then MOVE the part to the s3 disk
+# - assert structure: the destination carries a flat (not nested) sibling and one non-broken projection part
+# - fail closed: the forced-projection SELECT still matches the baseline and CHECK TABLE passes
+def test_carry_move_part_to_disk(storage_kind):
+    # create a 'flat' table on a multi-disk policy, projection materialized on insert (the default)
+    node.query("DROP TABLE IF EXISTS t_move_carry SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        f"""CREATE TABLE t_move_carry (key UInt64, id UInt64, value String,
+            PROJECTION p (SELECT key, id, value ORDER BY id))
+            ENGINE = MergeTree ORDER BY key
+            SETTINGS {with_storage("min_bytes_for_wide_part = 0, projection_storage_format = 'flat', storage_policy = 'default_and_s3'", storage_kind)}"""
+    )
+    node.query(
+        "INSERT INTO t_move_carry SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # the projection is materialized on the default disk; capture the forced-projection baseline
+    baseline = proj_query("t_move_carry", extra_settings="force_optimize_projection = 1")
+    assert active_projection_parts("t_move_carry") == "1"
+    src = part_dir("t_move_carry")
+    name = part_name("t_move_carry")
+    assert path_exists(f"{src}.p.proj")
+
+    # move the part across disks (clonePart copies the flat sibling to the s3 disk)
+    node.query(f"ALTER TABLE t_move_carry MOVE PART '{name}' TO DISK 's3'")
+
+    # assert structure: destination carries a flat (not nested) sibling and one non-broken projection part
+    dst = part_dir("t_move_carry")
+    assert dst != src  # the part really moved to the other disk
+    assert path_exists(f"{dst}.p.proj")
+    assert not path_exists(f"{dst}/p.proj")
+    assert active_projection_parts("t_move_carry") == "1"
+    assert broken_projection_parts("t_move_carry") == "0"
+
+    # fail closed: the moved part serves the projection from its new location, not a silent base-part fallback
+    assert (
+        proj_query("t_move_carry", extra_settings="force_optimize_projection = 1")
+        == baseline
+    )
+    assert check_table("t_move_carry") == "1"
+
+
+# ==============================================================================
+# C. Sibling cleanup on removal
+# ==============================================================================
+
+# This test checks that outdated-part cleanup removes the flat projection sibling too, instead of
+# leaving it stranded after the part is dropped. (Issue #1)
+# Scenario:
+# - create table with a 'flat' projection
+# - DROP PART
+# - assert the flat sibling is removed
+# @pytest.mark.xfail(reason=REVIEW + "3472535408", strict=False)
+def test_cleanup_drop_part_removes_sibling(storage_kind):
+    # create table with a 'flat' projection
+    setup_table("t_rm", with_storage("projection_storage_format = 'flat'", storage_kind))
+    p = part_dir("t_rm")
+    assert path_exists(f"{p}.p.proj")
+
+    # drop the part; the flat sibling must be removed with it
+    node.query(f"ALTER TABLE t_rm DROP PART '{part_name('t_rm')}'")
+    wait_for(lambda: not path_exists(f"{p}.p.proj"))
+    assert not path_exists(f"{p}.p.proj")
+
+
+# This test checks that DROP PROJECTION on a live 'flat' table removes the flat sibling from the
+# rewritten parts instead of leaving an orphan dir behind.
+# Scenario:
+# - create table with a 'flat' projection
+# - assert structure: the flat sibling exists
+# - DROP PROJECTION p (mutation)
+# - assert structure: no flat sibling on the new part and no active projection part
+# - assert the base data reads and CHECK TABLE passes
+def test_cleanup_drop_projection_removes_sibling(storage_kind):
+    # create table with a 'flat' projection
+    setup_table(
+        "t_drop_proj", with_storage("projection_storage_format = 'flat'", storage_kind)
+    )
+
+    # assert structure: the flat sibling exists
+    p = part_dir("t_drop_proj")
+    assert path_exists(f"{p}.p.proj")
+
+    # DROP PROJECTION rewrites the affected parts
+    node.query("ALTER TABLE t_drop_proj DROP PROJECTION p SETTINGS mutations_sync = 2")
+
+    # assert structure: no flat sibling on the new part, no active projection part
+    new_p = part_dir("t_drop_proj")
+    assert not path_exists(f"{new_p}.p.proj")
+    assert not path_exists(f"{new_p}/p.proj")
+    assert active_projection_parts("t_drop_proj") == "0"
+
+    # assert the base data reads and CHECK TABLE passes
+    assert node.query("SELECT count() FROM t_drop_proj").strip() == "1000"
+    assert check_table("t_drop_proj") == "1"
+
+
+# This test checks that a leftover delete_tmp_ pair from an interrupted removal does not block a new
+# removal of the same part name, and that the flat sibling is cleaned with it.
+# Scenario:
+# - create table with a 'flat' projection
+# - plant a stale delete_tmp_<part> pair (parent + sibling)
+# - DROP PART
+# - assert the part, its sibling, and both delete_tmp_ leftovers are gone
+def test_cleanup_delete_tmp_leftovers():
+    # create table with a 'flat' projection
+    setup_table("t_dtmp", "projection_storage_format = 'flat'")
+    name = part_name("t_dtmp")
+    root = part_dir("t_dtmp").rsplit("/", 1)[0]
+
+    # plant a stale delete_tmp_ pair, then drop the part
+    plant_stale_tmp_dir(f"{root}/delete_tmp_{name}")
+    node.query(f"ALTER TABLE t_dtmp DROP PART '{name}'")
+
+    # assert the part, its sibling, and both delete_tmp_ leftovers are gone
+    wait_for(lambda: not path_exists(f"{root}/{name}"))
+    wait_for(lambda: not path_exists(f"{root}/{name}.p.proj"))
+    wait_for(lambda: not path_exists(f"{root}/delete_tmp_{name}"))
+    wait_for(lambda: not path_exists(f"{root}/delete_tmp_{name}.p.proj"))
+    assert not path_exists(f"{root}/delete_tmp_{name}.p.proj")
+
+
+# This test checks that DROP PART of a part whose flat sibling has vanished still removes the part
+# completely, instead of aborting the cleanup halfway.
+# Scenario:
+# - create table with a 'flat' projection
+# - stop the server and delete the flat sibling, then start it
+# - assert the base data still reads
+# - DROP PART
+# - assert the part is gone and no delete_tmp_ leftover remains
+def test_cleanup_tolerates_missing_sibling():
+    # create table with a 'flat' projection
+    setup_table("t_nosib", "projection_storage_format = 'flat'")
+    p = part_dir("t_nosib")
+    name = part_name("t_nosib")
+    root = p.rsplit("/", 1)[0]
+
+    # delete the flat sibling out of band while the server is down
+    node.stop_clickhouse()
+    node.exec_in_container(
+        ["bash", "-c", f"rm -rf {p}.p.proj"], privileged=True, user="root"
+    )
+    node.start_clickhouse()
+    assert node.query("SELECT count() FROM t_nosib").strip() == "1000"
+
+    # drop the part; removal must complete despite the missing sibling
+    node.query(f"ALTER TABLE t_nosib DROP PART '{name}'")
+    wait_for(lambda: not path_exists(p))
+    assert not path_exists(p)
+    leftovers = node.exec_in_container(
+        ["bash", "-c", f"find {root} -maxdepth 1 -name 'delete_tmp_*' | wc -l"],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert leftovers == "0"
+
+
+# ==============================================================================
+# D. Stale residue and destination-clearing
+# ==============================================================================
+
+# This test checks that when an insert reuses a failed insert's tmp dir, collision cleanup wipes the
+# stale flat sibling too; else the fresh projection is written into the leftover and published live.
+# Scenario:
+# - create a 'flat' table
+# - plant a stale tmp_insert_<part> pair at the name the first insert will reuse
+# - INSERT (the collision branch runs)
+# - assert neither the part nor its projection adopted stale files, and no stale sibling is left
+# - assert the projection is healthy, SELECT and CHECK TABLE pass
+# @pytest.mark.xfail(reason=REVIEW + "3544856348", strict=False)
+def test_residue_insert_tmp_collision(storage_kind):
+    # create a 'flat' table
+    node.query("DROP TABLE IF EXISTS t_ins SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        f"""CREATE TABLE t_ins (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id, value ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS {with_storage("min_bytes_for_wide_part = 0, projection_storage_format = 'flat'", storage_kind)}"""
+    )
+
+    # plant a stale tmp dir at the name the first insert reuses (tmp_insert_all_1_1_0)
+    stale = f"{table_path('t_ins')}/tmp_insert_all_1_1_0"
+    plant_stale_tmp_dir(stale)
+    node.query(
+        "INSERT INTO t_ins SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # assert the collision branch ran and nothing adopted the stale files
+    p = part_dir("t_ins")
+    assert p.endswith("all_1_1_0")  # the collision branch really ran
+    assert path_exists(f"{p}.p.proj")
+    assert not path_exists(f"{p}/stale_marker.txt")
+    assert not path_exists(f"{p}.p.proj/stale_marker.txt")
+    assert not path_exists(f"{stale}.p.proj")
+
+    # assert the projection is healthy, SELECT and CHECK TABLE pass
+    assert broken_projection_parts("t_ins") == "0"
+    assert (
+        proj_query("t_ins", extra_settings="force_optimize_projection = 1")
+        == "100\t4950"
+    )
+    assert check_table("t_ins") == "1"
+
+
+# This test checks that a retried fetch (removeSharedRecursive of the previous tmp-fetch_ dir) wipes
+# the stale flat sibling with it; else the retried download mixes stale files into the fetched part.
+# Scenario:
+# - create the replicated 'flat' table on both replicas, stop fetches on replica 2
+# - insert on replica 1, plant a stale tmp-fetch_<part> pair on replica 2
+# - start fetches and SYNC replica 2
+# - assert the fetched part adopted no stale files and no stale sibling is left
+# - assert the projection is healthy, SELECT and CHECK TABLE pass
+# @pytest.mark.xfail(reason=REVIEW + "3534142472", strict=False)
+def test_residue_fetch_tmp_collision():
+    # create the replicated 'flat' table on both replicas
+    for n, replica in ((node, "1"), (node2, "2")):
+        n.query("DROP TABLE IF EXISTS t_fetch SYNC")
+        n.query("SYSTEM STOP MERGES")
+        n.query(
+            f"""CREATE TABLE t_fetch (key UInt64, id UInt64, value String,
+                PROJECTION p (SELECT key, id, value ORDER BY id))
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/t_fetch', '{replica}')
+                ORDER BY key
+                SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat'"""
+        )
+
+    # insert on replica 1, plant a stale tmp-fetch_ pair on replica 2
+    node2.query("SYSTEM STOP FETCHES t_fetch")
+    node.query(
+        "INSERT INTO t_fetch SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+    name = part_name("t_fetch", node)
+    stale = f"{table_path('t_fetch', node2)}/tmp-fetch_{name}"
+    plant_stale_tmp_dir(stale, node2)
+
+    # start fetches and sync replica 2
+    node2.query("SYSTEM START FETCHES t_fetch")
+    node2.query("SYSTEM SYNC REPLICA t_fetch")
+
+    # assert the fetched part adopted no stale files and no stale sibling is left
+    p2 = part_dir("t_fetch", node2)
+    assert path_exists(f"{p2}.p.proj", node2)
+    assert not path_exists(f"{p2}/stale_marker.txt", node2)
+    assert not path_exists(f"{p2}.p.proj/stale_marker.txt", node2)
+    assert not path_exists(f"{stale}.p.proj", node2)
+
+    # assert the projection is healthy, SELECT and CHECK TABLE pass
+    assert broken_projection_parts("t_fetch", node2) == "0"
+    assert proj_query(
+        "t_fetch", node2, extra_settings="force_optimize_projection = 1"
+    ) == proj_query("t_fetch", node)
+    assert check_table("t_fetch", node2) == "1"
+
+
+# This test checks that a stale flat sibling left at a LIVE part name is not adopted by a later part
+# reusing that name: publishing the name again removes the leftover.
+# Scenario:
+# - create a 'flat' table with materialize_projections_on_insert = 0
+# - plant a stale sibling at the future live part name
+# - INSERT a part WITHOUT a projection at that name
+# - restart the server
+# - assert no projection part is active, no flat sibling remains, and the data reads
+def test_residue_live_not_adopted():
+    # create a 'flat' table that does not materialize the projection on insert
+    node.query("DROP TABLE IF EXISTS t_adopt SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        """CREATE TABLE t_adopt (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id, value ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat',
+               materialize_projections_on_insert = 0"""
+    )
+
+    # plant a stale sibling at the future live name, then insert a projection-less part there
+    plant_stale_live_sibling(f"{table_path('t_adopt')}/all_1_1_0.p.proj")
+    node.query(
+        "INSERT INTO t_adopt SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+    p = part_dir("t_adopt")
+    assert p.endswith("all_1_1_0")  # the name collision really happened
+
+    # restart; the part was written without the projection, so nothing may serve one
+    node.restart_clickhouse()
+    block_until_tables_loaded("t_adopt")
+    assert active_projection_parts("t_adopt") == "0"
+    assert not path_exists(f"{p}.p.proj")
+    assert node.query("SELECT count() FROM t_adopt").strip() == "1000"
+    assert check_table("t_adopt") == "1"
+
+
+# This test checks that publishing a part WITH a projection over a stale sibling at the destination
+# name clears the leftover instead of failing the sibling rename.
+# Scenario:
+# - create a 'flat' table
+# - plant a stale sibling at the future live part name
+# - INSERT a part WITH a projection at that name
+# - assert the real sibling replaced the stale one and CHECK TABLE passes
+def test_residue_live_replaced_by_real(storage_kind):
+    # create a 'flat' table
+    node.query("DROP TABLE IF EXISTS t_repl_sib SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        f"""CREATE TABLE t_repl_sib (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id, value ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS {with_storage("min_bytes_for_wide_part = 0, projection_storage_format = 'flat'", storage_kind)}"""
+    )
+
+    # plant a stale sibling at the future live name, then insert a real projection there
+    plant_stale_live_sibling(f"{table_path('t_repl_sib')}/all_1_1_0.p.proj")
+    node.query(
+        "INSERT INTO t_repl_sib SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # assert the real sibling replaced the stale one and CHECK TABLE passes
+    p = part_dir("t_repl_sib")
+    assert p.endswith("all_1_1_0")
+    assert path_exists(f"{p}.p.proj")
+    assert not path_exists(f"{p}.p.proj/stale_marker.txt")
+    assert (
+        proj_query("t_repl_sib", extra_settings="force_optimize_projection = 1")
+        == "100\t4950"
+    )
+    assert check_table("t_repl_sib") == "1"
+
+
+# This test checks destination-clearing in the detached namespace: a stale sibling under detached/
+# must not fail DETACH of a real part carrying the same name.
+# Scenario:
+# - create table with a 'flat' projection, capture SELECT baseline
+# - plant a stale sibling under detached/<part>
+# - DETACH PART (over the stale sibling), then ATTACH PART
+# - assert the stale marker is gone, the sibling is present, and SELECT matches baseline
+def test_residue_detached_cleared_on_detach():
+    # create table with a 'flat' projection, capture baseline
+    setup_table("t_det_sib", "projection_storage_format = 'flat'")
+    baseline = proj_query("t_det_sib")
+    name = part_name("t_det_sib")
+    table_root = part_dir("t_det_sib").rsplit("/", 1)[0]
+
+    # plant a stale sibling under detached/, then DETACH the real part over it
+    plant_stale_live_sibling(f"{table_root}/detached/{name}.p.proj")
+    node.query(f"ALTER TABLE t_det_sib DETACH PART '{name}'")
+    assert path_exists(f"{table_root}/detached/{name}.p.proj")
+    assert not path_exists(f"{table_root}/detached/{name}.p.proj/stale_marker.txt")
+
+    # ATTACH the part back and verify the projection serves from its new location
+    node.query(f"ALTER TABLE t_det_sib ATTACH PART '{name}'")
+    p = part_dir("t_det_sib")
+    assert path_exists(f"{p}.p.proj")
+    assert broken_projection_parts("t_det_sib") == "0"
+    assert (
+        proj_query("t_det_sib", extra_settings="force_optimize_projection = 1")
+        == baseline
+    )
+
+
+# This test checks the publish crash window (tmp -> live): a crash after the sibling moved but before
+# the parent moved leaves a live-named sibling and a tmp-named parent; startup must clear both.
+# Scenario:
+# - create table with a 'flat' projection
+# - plant a tmp_merge_<part> parent + a live-named <part>.p.proj sibling
+# - restart the server
+# - assert both planted dirs are gone and the real part is untouched
+def test_residue_crash_window_publish():
+    # create table with a 'flat' projection
+    setup_table("t_cw_pub", "projection_storage_format = 'flat'")
+    root = table_path("t_cw_pub")
+
+    # plant the half-published state: tmp parent + committed live sibling
+    node.stop_clickhouse()
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"mkdir -p {root}/tmp_merge_all_1_1_1 {root}/all_1_1_1.p.proj"
+            f" && touch {root}/tmp_merge_all_1_1_1/stale_marker.txt {root}/all_1_1_1.p.proj/stale_marker.txt"
+            f" && chmod -R 777 {root}/tmp_merge_all_1_1_1 {root}/all_1_1_1.p.proj",
+        ],
+        privileged=True,
+        user="root",
+    )
+    node.start_clickhouse()
+
+    # assert the interrupted publish is rolled back completely: tmp parent and committed sibling gone
+    wait_for(lambda: not path_exists(f"{root}/tmp_merge_all_1_1_1"))
+    assert not path_exists(f"{root}/tmp_merge_all_1_1_1")
+    wait_for(lambda: not path_exists(f"{root}/all_1_1_1.p.proj"))
+    assert not path_exists(f"{root}/all_1_1_1.p.proj")
+
+    # assert the real part and its projection are untouched
+    assert active_parts("t_cw_pub") == "1"
+    assert broken_projection_parts("t_cw_pub") == "0"
+    assert check_table("t_cw_pub") == "1"
+
+
+# This test checks the removal crash window (live -> delete_tmp_): a crash after the parent moved but
+# before the sibling moved leaves a delete_tmp_ parent and a live-named orphan sibling; startup clears both.
+# Scenario:
+# - create table with a 'flat' projection
+# - plant a delete_tmp_<part> parent + a live-named <part>.p.proj sibling
+# - restart the server
+# - assert both planted dirs are gone and the real part is untouched
+def test_residue_crash_window_remove():
+    # create table with a 'flat' projection
+    setup_table("t_cw_rm", "projection_storage_format = 'flat'")
+    root = table_path("t_cw_rm")
+
+    # plant the half-removed state: delete_tmp_ parent + live-named orphan sibling
+    node.stop_clickhouse()
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"mkdir -p {root}/delete_tmp_gone_0_0_0 {root}/gone_0_0_0.p.proj"
+            f" && touch {root}/delete_tmp_gone_0_0_0/stale_marker.txt {root}/gone_0_0_0.p.proj/stale_marker.txt"
+            f" && chmod -R 777 {root}/delete_tmp_gone_0_0_0 {root}/gone_0_0_0.p.proj",
+        ],
+        privileged=True,
+        user="root",
+    )
+    node.start_clickhouse()
+
+    # assert startup cleared both the delete_tmp_ parent and the orphan sibling
+    wait_for(lambda: not path_exists(f"{root}/delete_tmp_gone_0_0_0"))
+    assert not path_exists(f"{root}/delete_tmp_gone_0_0_0")
+    wait_for(lambda: not path_exists(f"{root}/gone_0_0_0.p.proj"))
+    assert not path_exists(f"{root}/gone_0_0_0.p.proj")
+
+    # assert the real part and its projection are untouched
+    assert active_parts("t_cw_rm") == "1"
+    assert broken_projection_parts("t_cw_rm") == "0"
+    assert check_table("t_cw_rm") == "1"
+
+
+# This test checks that a failed ATTACH (occupied attaching_ destination) rolls whole parts back: the
+# detached part and its sibling stay intact and a retry succeeds.
+# Scenario:
+# - create table with a 'flat' projection, DETACH PARTITION
+# - occupy the attaching_<part> destination so the rename fails
+# - ATTACH PARTITION and assert it raises, with the detached part + sibling intact
+# - free the destination and ATTACH PARTITION again; assert it succeeds
+def test_residue_attach_rollback():
+    # create table with a 'flat' projection, DETACH the partition
+    setup_table("t_rollback", "projection_storage_format = 'flat'")
+    name = part_name("t_rollback")
+    node.query("ALTER TABLE t_rollback DETACH PARTITION tuple()")
+    detached_root = node.query(
+        "SELECT path FROM system.detached_parts WHERE table = 't_rollback' LIMIT 1"
+    ).strip()
+    if not detached_root:
+        detached_root = "/var/lib/clickhouse/data/default/t_rollback/detached"
+    else:
+        detached_root = detached_root.rstrip("/").rsplit("/", 1)[0]
+    assert path_exists(f"{detached_root}/{name}.p.proj")
+
+    # occupy the temporary rename destination to make tryRenameAll fail
+    node.exec_in_container(
+        ["bash", "-c", f"mkdir -p {detached_root}/attaching_{name}"],
+        privileged=True,
+        user="root",
+    )
+    assert "Exception" in node.query_and_get_error(
+        "ALTER TABLE t_rollback ATTACH PARTITION tuple()"
+    )
+
+    # assert nothing was lost or half-renamed
+    assert path_exists(f"{detached_root}/{name}")
+    assert path_exists(f"{detached_root}/{name}.p.proj")
+
+    # free the destination and retry; the attach now succeeds
+    node.exec_in_container(
+        ["bash", "-c", f"rmdir {detached_root}/attaching_{name}"],
+        privileged=True,
+        user="root",
+    )
+    node.query("ALTER TABLE t_rollback ATTACH PARTITION tuple()")
+    assert active_parts("t_rollback") == "1"
+    assert proj_query("t_rollback") != ""
+
+
+# A throw after the first committed sibling move rolls the whole ATTACH rename back: part + BOTH siblings return to detached/<name> and no attaching_ residue remains, exercising the reverse-order unwind test_residue_attach_rollback misses (it dies in the existsDirectory(to) preflight, before any move commits).
+# https://github.com/ClickHouse/ClickHouse/pull/108443#discussion_r3603799704
+def test_flat_projection_sibling_move_rollback():
+    # create a 'flat' table with two projections (so a part has two sibling dirs), DETACH the partition
+    node.query("DROP TABLE IF EXISTS t_sib_rollback SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        """CREATE TABLE t_sib_rollback (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id ORDER BY id),
+           PROJECTION q (SELECT key, value ORDER BY value))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat'"""
+    )
+    node.query(
+        "INSERT INTO t_sib_rollback SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+    name = part_name("t_sib_rollback")
+    node.query("ALTER TABLE t_sib_rollback DETACH PARTITION tuple()")
+    detached = f"{table_path('t_sib_rollback')}/detached"
+    assert path_exists(f"{detached}/{name}")
+    assert path_exists(f"{detached}/{name}.p.proj")
+    assert path_exists(f"{detached}/{name}.q.proj")
+
+    # ATTACH renames detached/<name> -> detached/attaching_<name>; a throw after the first sibling move forces the partial-rename rollback
+    node.query("SYSTEM ENABLE FAILPOINT throw_after_flat_projection_sibling_move")
+    try:
+        assert "Exception" in node.query_and_get_error(
+            "ALTER TABLE t_sib_rollback ATTACH PARTITION tuple()"
+        )
+    finally:
+        node.query(
+            "SYSTEM DISABLE FAILPOINT throw_after_flat_projection_sibling_move"
+        )
+
+    # the rollback returned the part and BOTH siblings to detached/<name>, leaving no attaching_ residue
+    assert active_parts("t_sib_rollback") == "0"
+    assert path_exists(f"{detached}/{name}")
+    assert path_exists(f"{detached}/{name}.p.proj")
+    assert path_exists(f"{detached}/{name}.q.proj")
+    assert not path_exists(f"{detached}/attaching_{name}")
+    assert not path_exists(f"{detached}/attaching_{name}.p.proj")
+    assert not path_exists(f"{detached}/attaching_{name}.q.proj")
+
+    # free of the failpoint, the attach now succeeds and the data reads
+    node.query("ALTER TABLE t_sib_rollback ATTACH PARTITION tuple()")
+    assert active_parts("t_sib_rollback") == "1"
+    assert node.query("SELECT count() FROM t_sib_rollback").strip() == "1000"
+
+
+# ==============================================================================
+# E. Unowned-sibling filter (residue that a part does not own must not be carried)
+# ==============================================================================
+
+# This test checks that MOVE PART (cross-disk clonePart) copies only the part's own projections, so
+# an unowned residue sibling is structurally excluded from the moved part.
+# Scenario:
+# - create a 'flat' table with materialize_projections_on_insert = 0 on a multi-disk policy, insert
+# - plant an unowned residue sibling at the source part name
+# - MOVE PART to the s3 disk
+# - assert the destination has no projection sibling and no active projection part, data reads
+# https://github.com/ClickHouse/ClickHouse/pull/108443#discussion_r3569019427
+def test_unowned_move_part_skips():
+    # create a projection-less-on-insert 'flat' table on a multi-disk policy
+    node.query("DROP TABLE IF EXISTS t_move SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        """CREATE TABLE t_move (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat',
+               materialize_projections_on_insert = 0, storage_policy = 'default_and_s3'"""
+    )
+    node.query(
+        "INSERT INTO t_move SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # plant an unowned residue sibling at the source part name, then move the part
+    src = part_dir("t_move")
+    name = part_name("t_move")
+    plant_stale_live_sibling(f"{src}.p.proj")
+    node.query(f"ALTER TABLE t_move MOVE PART '{name}' TO DISK 's3'")
+
+    # assert the destination excluded the unowned residue and the data reads
+    dst = part_dir("t_move")
+    assert dst != src  # the part really moved
+    assert not path_exists(f"{dst}.p.proj")
+    assert not path_exists(f"{dst}/p.proj")
+    assert active_projection_parts("t_move") == "0"
+    assert node.query("SELECT count() FROM t_move").strip() == "1000"
+
+
+# This test checks that cross-disk ATTACH PARTITION FROM (freezeRemote path) applies the same
+# owned-projections filter as the same-disk freeze path, excluding an unowned residue sibling.
+# Scenario:
+# - create 'flat' source (default disk) and destination (s3) tables, projection-less on insert, insert into source
+# - plant an unowned residue sibling at the source part name
+# - ATTACH PARTITION FROM the source into the destination
+# - assert the destination has no projection sibling and no active projection part, data reads, CHECK passes
+# https://github.com/ClickHouse/ClickHouse/pull/108443#discussion_r3569019441
+def test_unowned_attach_cross_disk_skips():
+    # create 'flat' source (default disk) and destination (s3) tables
+    node.query("DROP TABLE IF EXISTS t_att_src SYNC")
+    node.query("DROP TABLE IF EXISTS t_att_dst SYNC")
+    node.query("SYSTEM STOP MERGES")
+    for tname, policy in (("t_att_src", ""), ("t_att_dst", ", storage_policy = 's3'")):
+        node.query(
+            f"""CREATE TABLE {tname} (key UInt64, id UInt64, value String,
+                PROJECTION p (SELECT key, id ORDER BY id))
+                ENGINE = MergeTree ORDER BY key
+                SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat',
+                    materialize_projections_on_insert = 0{policy}"""
+        )
+    node.query(
+        "INSERT INTO t_att_src SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # plant an unowned residue sibling at the source part name, then attach cross-disk
+    plant_stale_live_sibling(f"{part_dir('t_att_src')}.p.proj")
+    node.query("ALTER TABLE t_att_dst ATTACH PARTITION tuple() FROM t_att_src")
+
+    # assert the destination excluded the unowned residue, data reads, CHECK passes
+    p = part_dir("t_att_dst")
+    assert not path_exists(f"{p}.p.proj")
+    assert not path_exists(f"{p}/p.proj")
+    assert active_projection_parts("t_att_dst") == "0"
+    assert node.query("SELECT count() FROM t_att_dst").strip() == "1000"
+    assert check_table("t_att_dst") == "1"
+
+
+# This test checks that the column-subset mutation (which discovers projections from disk) does not
+# hardlink a sibling the source part's checksums do not reference into the mutated part.
+# Scenario:
+# - create a 'flat' table projection-less on insert, insert
+# - plant an unowned residue sibling at the source part name
+# - mutate a column (UPDATE ... WHERE 1)
+# - assert the mutated part has no projection sibling and no active projection part, data reads
+def test_unowned_mutation_skips():
+    # create a projection-less-on-insert 'flat' table
+    node.query("DROP TABLE IF EXISTS t_mut SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        """CREATE TABLE t_mut (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat',
+               materialize_projections_on_insert = 0"""
+    )
+    node.query(
+        "INSERT INTO t_mut SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # plant an unowned residue sibling at the source part name, then mutate a column
+    src = part_dir("t_mut")
+    plant_stale_live_sibling(f"{src}.p.proj")
+    node.query(
+        "ALTER TABLE t_mut UPDATE value = concat(value, 'x') WHERE 1 SETTINGS mutations_sync = 1"
+    )
+
+    # assert the mutated part excluded the unowned residue and the data reads
+    p = part_dir("t_mut")
+    assert p != src  # the mutation produced a new part
+    assert not path_exists(f"{p}.p.proj")
+    assert not path_exists(f"{p}/p.proj")
+    assert active_projection_parts("t_mut") == "0"
+    assert node.query("SELECT count() FROM t_mut").strip() == "1000"
+
+
+# ==============================================================================
+# F. Manifest desync, repair, and adoption policy (trust-and-heal with a row check)
+# ==============================================================================
+
+# A projection dir present on disk and declared in metadata but missing from checksums.txt is either
+# (L) this part's own dir after a manifest loss, or (F) residue of another same-named part
+# generation. NESTED dirs are provably (L) (they live inside the part dir): warn + load, no rewrite.
+# FLAT dirs are ambiguous: the row check against the parent decides - a pass heals the checksums
+# record in place, a failure marks the projection broken.
 
 
 def _make_desync_pair(
@@ -252,47 +1714,139 @@ def _manifest_mentions_projection(part_path):
     )
 
 
+# A projection dir present on disk but absent from checksums.txt (checksums is the commit point) is not
+# adopted: loadProjections loads only what the manifest lists. The dir is ignored, data reads from the base part.
+# Scenario:
+# - create a 'flat' table, then a projection-less-on-insert twin, insert into both
+# - stop the server and copy the source's flat sibling onto the twin, then start it
+# - assert the twin's data reads, the unlisted dir is not adopted (not active, not in the manifest, not broken)
+def test_desync_unlisted_dir_ignored():
+    # create a 'flat' source table and a projection-less-on-insert twin
+    setup_table("t_warn_src", "projection_storage_format = 'flat'")
+    node.query("DROP TABLE IF EXISTS t_warn SYNC")
+    node.query(
+        """CREATE TABLE t_warn (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id, value ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat',
+               materialize_projections_on_insert = 0"""
+    )
+    node.query(
+        "INSERT INTO t_warn SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # copy the source sibling onto the twin (an unlisted dir), then reload
+    src_sib = f"{part_dir('t_warn_src')}.p.proj"
+    dst_sib = f"{part_dir('t_warn')}.p.proj"
+    node.stop_clickhouse()
+    node.exec_in_container(
+        ["bash", "-c", f"cp -r {src_sib} {dst_sib} && chmod -R 777 {dst_sib}"],
+        privileged=True,
+        user="root",
+    )
+    node.start_clickhouse()
+    block_until_tables_loaded("t_warn")
+
+    # assert the data reads and the unlisted dir is ignored, not adopted
+    assert node.query("SELECT count() FROM t_warn").strip() == "1000"
+    assert active_projection_parts("t_warn") == "0"
+    assert broken_projection_parts("t_warn") == "0"
+    assert not _manifest_mentions_projection(part_dir("t_warn"))
+
+
 # This test checks that regenerating a lost manifest restores projection records: without the fix
 # checkDataPart folds them only from the (empty-during-repair) projection map and drops every projection.
-# Scenario:
+# Scenario (nested and flat):
 # - create table with a projection, capture SELECT baseline
 # - stop the server, delete checksums.txt, start it (manifest is regenerated)
 # - assert the data reads, the projection is healthy, SELECT matches, CHECK TABLE passes
 # - restart and assert the regenerated manifest still references the projection
 def test_desync_repair_regenerates_records():
-    # create table with a projection, capture baseline
-    setup_table("t_fix")
-    baseline = proj_query("t_fix")
-    p = part_dir("t_fix")
+    for tname, extra in (
+        ("t_fix_nested", ""),
+        ("t_fix_flat", "projection_storage_format = 'flat'"),
+    ):
+        # create table with a projection, capture baseline
+        setup_table(tname, extra)
+        baseline = proj_query(tname)
+        p = part_dir(tname)
 
-    # delete checksums.txt so the manifest is regenerated on load
+        # delete checksums.txt so the manifest is regenerated on load
+        node.stop_clickhouse()
+        node.exec_in_container(
+            ["bash", "-c", f"rm {p}/checksums.txt"], privileged=True, user="root"
+        )
+        node.start_clickhouse()
+
+        # assert the data reads, the projection is healthy and served, CHECK passes
+        assert node.query(f"SELECT count() FROM {tname}").strip() == "1000", tname
+        assert broken_projection_parts(tname) == "0", tname
+        assert (
+            proj_query(tname, extra_settings="force_optimize_projection = 1")
+            == baseline
+        ), tname
+        assert check_table(tname) == "1", tname
+
+        # assert the regenerated manifest references the projection: it must survive a reload
+        node.restart_clickhouse()
+        block_until_tables_loaded(tname)
+        assert active_projection_parts(tname) == "1", tname
+        assert check_table(tname) == "1", tname
+
+
+# This test checks that regenerating a lost checksums.txt restores records only for metadata-declared
+# projections; an undeclared projection dir must not be legitimized by the regenerated manifest.
+# Scenario:
+# - create a 'flat' table, capture SELECT baseline
+# - stop the server, copy the sibling to an undeclared q.proj name, delete checksums.txt, start it
+# - assert the "Not restoring ... q.proj" message is logged
+# - assert the regenerated manifest references p.proj but not q.proj, projection healthy, SELECT matches
+def test_desync_repair_skips_undeclared_dir():
+    # create a 'flat' table, capture baseline
+    setup_table("t_undecl", "projection_storage_format = 'flat'")
+    baseline = proj_query("t_undecl")
+    p = part_dir("t_undecl")
+
+    # add an undeclared sibling (q.proj) and drop checksums.txt so the manifest is regenerated
     node.stop_clickhouse()
     node.exec_in_container(
-        ["bash", "-c", f"rm {p}/checksums.txt"], privileged=True, user="root"
+        [
+            "bash",
+            "-c",
+            f"cp -r {p}.p.proj {p}.q.proj && chmod -R 777 {p}.q.proj && rm {p}/checksums.txt",
+        ],
+        privileged=True,
+        user="root",
     )
     node.start_clickhouse()
+    block_until_tables_loaded("t_undecl")
 
-    # assert the data reads, the projection is healthy and served, CHECK passes
-    assert node.query("SELECT count() FROM t_fix").strip() == "1000"
-    assert broken_projection_parts("t_fix") == "0"
-    assert proj_query("t_fix", extra_settings="force_optimize_projection = 1") == baseline
-    assert check_table("t_fix") == "1"
+    # assert the undeclared dir was refused and only the declared projection is in the regenerated manifest
+    assert node.query("SELECT count() FROM t_undecl").strip() == "1000"
+    manifest = node.exec_in_container(
+        ["bash", "-c", f"grep -ao '[pq]\\.proj' {p}/checksums.txt | sort -u"],
+        privileged=True,
+        user="root",
+    )
+    assert "p.proj" in manifest
+    assert "q.proj" not in manifest
 
-    # assert the regenerated manifest references the projection: it must survive a reload
-    node.restart_clickhouse()
-    block_until_tables_loaded("t_fix")
-    assert active_projection_parts("t_fix") == "1"
-    assert check_table("t_fix") == "1"
+    # assert the projection is healthy and SELECT matches baseline
+    assert broken_projection_parts("t_undecl") == "0"
+    assert (
+        proj_query("t_undecl", extra_settings="force_optimize_projection = 1")
+        == baseline
+    )
 
 
-# A projection dir planted inside a part but absent from checksums.txt is not adopted:
-# checksums is the commit point. The dir is ignored, the part reads from the base.
+# A NESTED projection dir planted inside a part but absent from checksums.txt is not adopted either:
+# checksums is the commit point for both layouts. The dir is ignored, the part reads from the base.
 # Scenario:
 # - build a desync pair whose victim has no projection record
-# - stop the server, copy the donor's projection dir into the victim part, start it
+# - stop the server, copy the donor's NESTED dir into the victim part, start it
 # - assert the projection is not adopted (not active, not broken, not in the manifest) and data reads
-def test_desync_unlisted_dir_ignored():
-    # build a desync pair, then plant the donor's projection dir inside the victim part
+def test_desync_nested_unlisted_ignored():
+    # build a desync pair, then plant the donor's nested dir inside the victim part
     _make_desync_pair("t_ln")
     p = part_dir("t_ln")
     donor_proj = f"{part_dir('t_ln_donor')}/p.proj"
@@ -305,42 +1859,891 @@ def test_desync_unlisted_dir_ignored():
     node.start_clickhouse()
     block_until_tables_loaded("t_ln")
 
-    # assert the unlisted dir is ignored, not adopted
+    # assert the unlisted nested dir is ignored, not adopted
     assert node.query("SELECT count() FROM t_ln").strip() == "1000"
     assert active_projection_parts("t_ln") == "0"
     assert broken_projection_parts("t_ln") == "0"
     assert not _manifest_mentions_projection(p)
 
 
+# A foreign FLAT sibling planted next to a part but absent from checksums.txt is not adopted, whatever its
+# shape - fail-close collapses the old heal/reject/tolerate branches into one rule: not listed, not loaded.
+# Scenario:
+# - build a FLAT desync pair, move the donor's flat sibling onto the victim
+# - assert the sibling is ignored (not active, not broken, not in the manifest) and the data reads
+def test_desync_flat_unlisted_ignored():
+    # build a FLAT desync pair, plant the donor's flat sibling on the victim
+    _make_desync_pair("t_flat_ign", "projection_storage_format = 'flat'")
+    p = part_dir("t_flat_ign")
+    donor_sib = f"{part_dir('t_flat_ign_donor')}.p.proj"
+    node.stop_clickhouse()
+    node.exec_in_container(
+        ["bash", "-c", f"mv {donor_sib} {p}.p.proj"], privileged=True, user="root"
+    )
+    node.start_clickhouse()
+    block_until_tables_loaded("t_flat_ign")
+
+    # assert the unlisted sibling is ignored, not adopted
+    assert node.query("SELECT count() FROM t_flat_ign").strip() == "1000"
+    assert active_projection_parts("t_flat_ign") == "0"
+    assert broken_projection_parts("t_flat_ign") == "0"
+    assert not _manifest_mentions_projection(p)
+
+
+# The #3613153379 scenario: a foreign FLAT sibling of identical definition AND row count but DIFFERENT data
+# (another generation of the same-named part) was adopted by the old shape gate and served foreign rows. Under
+# fail-close it is not in checksums, so it is never loaded and the query reads correct rows from the base part.
+# Scenario:
+# - build a FLAT desync pair whose donor holds a different row range of the same shape
+# - stop the server, move the donor's flat sibling to the victim, start it
+# - assert the sibling is not adopted and the query returns the parent's rows, not the donor's
+def test_desync_flat_same_shape_not_adopted():
+    # build a FLAT desync pair whose donor holds a different row range of the same shape
+    _make_desync_pair(
+        "t_hole", "projection_storage_format = 'flat'", donor_offset=1000  # rows 1000..1999
+    )
+    p = part_dir("t_hole")
+    donor_sib = f"{part_dir('t_hole_donor')}.p.proj"
+    node.stop_clickhouse()
+    node.exec_in_container(
+        ["bash", "-c", f"mv {donor_sib} {p}.p.proj"], privileged=True, user="root"
+    )
+    node.start_clickhouse()
+    block_until_tables_loaded("t_hole")
+
+    # assert the foreign sibling is not adopted
+    assert active_projection_parts("t_hole") == "0"
+    assert broken_projection_parts("t_hole") == "0"
+    assert not _manifest_mentions_projection(p)
+
+    # assert no foreign rows are served: the base part answers, and enabling projections just falls back to it
+    base = node.query(
+        "SELECT count() FROM t_hole WHERE id < 200 SETTINGS optimize_use_projections = 0"
+    ).strip()
+    with_projections = node.query(
+        "SELECT count() FROM t_hole WHERE id < 200 SETTINGS optimize_use_projections = 1"
+    ).strip()
+    assert base == "100"
+    assert with_projections == "100"
+
+
+# Recovery must regenerate a projection whose OWN checksums.txt is also gone: checkDataPart recomputes it from
+# data, loadChecksums persists the regenerated projection manifest, and the projection loads healthy and usable.
+# Scenario:
+# - create a 'flat' table with a materialized projection, capture the projection SELECT baseline
+# - stop the server, delete both the part's checksums.txt and the projection's own checksums.txt, start it
+# - assert the projection manifest is regenerated on disk, the projection is active/healthy/served, CHECK passes
+def test_recovery_flat_recompute_missing_projection_checksums():
+    # create a 'flat' table with a materialized projection, capture baseline
+    setup_table("t_recomp", "projection_storage_format = 'flat'")
+    baseline = proj_query("t_recomp")
+    p = part_dir("t_recomp")
+
+    # delete both the part manifest and the projection's own manifest
+    node.stop_clickhouse()
+    node.exec_in_container(
+        ["bash", "-c", f"rm {p}/checksums.txt {p}.p.proj/checksums.txt"],
+        privileged=True,
+        user="root",
+    )
+    node.start_clickhouse()
+    block_until_tables_loaded("t_recomp")
+
+    # assert recovery recomputed the projection, wrote its manifest back, and the projection is served
+    assert path_exists(f"{p}.p.proj/checksums.txt")
+    assert _manifest_mentions_projection(p)
+    assert active_projection_parts("t_recomp") == "1"
+    assert broken_projection_parts("t_recomp") == "0"
+    assert proj_query("t_recomp", extra_settings="force_optimize_projection = 1") == baseline
+    assert check_table("t_recomp") == "1"
+
+
 # ==============================================================================
 # G. Reload consistency
 # ==============================================================================
 
-# This test checks that CHECK TABLE classifies an unknown projection (left after DROP PROJECTION
-# on a detached part) as a projection problem, not a broken part.
+# This test checks that reloading a part does not mark a present flat projection broken: the
+# consistency check probed a nested dir for the "p.proj" entry, so a flat sibling was reported missing.
 # Scenario:
+# - create a 'flat' table, capture SELECT baseline, assert no broken projection part
+# - restart the server
+# - assert still no broken projection part
+# - fail closed: the projection must actually be used, SELECT matches baseline
+# @pytest.mark.xfail(reason=REVIEW + "3481208077", strict=False)
+def test_reload_flat_not_broken():
+    # create a 'flat' table, capture baseline
+    setup_table("t_consist", "projection_storage_format = 'flat'")
+    baseline = proj_query("t_consist")
+    assert broken_projection_parts("t_consist") == "0"
+
+    # restart; the reloaded flat projection must not be reported broken
+    node.restart_clickhouse()
+    block_until_tables_loaded("t_consist")
+    assert broken_projection_parts("t_consist") == "0"
+
+    # fail closed: the projection must actually be used, not silently skipped
+    assert (
+        proj_query("t_consist", extra_settings="force_optimize_projection = 1")
+        == baseline
+    )
+
+
+# This test checks that CHECK TABLE classifies an unknown flat projection (left after DROP PROJECTION
+# on a detached part) as a projection problem, not a broken part - the nested-only scan misses flat siblings.
+# Scenario (nested and flat):
 # - create table with a projection, DETACH PART, DROP PROJECTION, ATTACH PART
 # - run CHECK TABLE
 # - assert the result reports "unexpected projection" and the data is still readable
 def test_reload_check_table_dropped_projection():
-    # create table with a projection, then drop the projection while the part is detached
-    setup_table("t_chk")
-    name = part_name("t_chk")
-    node.query(f"ALTER TABLE t_chk DETACH PART '{name}'")
-    node.query("ALTER TABLE t_chk DROP PROJECTION p")
-    node.query(f"ALTER TABLE t_chk ATTACH PART '{name}'")
+    for tname, extra in (
+        ("t_chk_nested", ""),
+        ("t_chk_flat", "projection_storage_format = 'flat'"),
+    ):
+        # create table with a projection, then drop the projection while the part is detached
+        setup_table(tname, extra)
+        name = part_name(tname)
+        node.query(f"ALTER TABLE {tname} DETACH PART '{name}'")
+        node.query(f"ALTER TABLE {tname} DROP PROJECTION p")
+        node.query(f"ALTER TABLE {tname} ATTACH PART '{name}'")
 
-    # assert CHECK TABLE flags the unknown projection and the data stays readable
-    result = node.query("CHECK TABLE t_chk SETTINGS check_query_single_value_result = 0")
-    assert "unexpected projection" in result, result
-    assert node.query("SELECT count() FROM t_chk").strip() == "1000"
+        # assert CHECK TABLE flags the unknown projection and the data stays readable
+        result = node.query(
+            f"CHECK TABLE {tname} SETTINGS check_query_single_value_result = 0"
+        )
+        assert "unexpected projection" in result, (tname, result)
+        assert node.query(f"SELECT count() FROM {tname}").strip() == "1000"
+
+
+# ==============================================================================
+# H. Zero-copy and blob lifecycle on object storage
+# ==============================================================================
+
+# This test checks that on zero-copy storage a mutation keeps blobs hardlinked by flat projections:
+# the removal filters the keep-list by the logical dir name ("p.proj/..."), so entries under the
+# physical name would mismatch and drop the blobs.
+# Scenario:
+# - create the replicated zero-copy 'flat' table on both replicas, insert on replica 1, SYNC replica 2
+# - mutate on replica 1 and zero-copy-fetch the result on replica 2
+# - drop replica 1 so replica 2's removal decides the fate of the shared blobs
+# - assert no outdated parts, no broken projection, SELECT matches baseline, CHECK TABLE passes
+def test_blob_zero_copy_mutation_preserves():
+    # create the replicated zero-copy 'flat' table on both replicas
+    for n, replica in ((node, "1"), (node2, "2")):
+        n.query("DROP TABLE IF EXISTS t_zc SYNC")
+        n.query(
+            f"""CREATE TABLE t_zc (key UInt64, id UInt64, value String,
+                PROJECTION p (SELECT key, id ORDER BY id))
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/t_zc', '{replica}')
+                ORDER BY key
+                SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat',
+                    storage_policy = 's3', allow_remote_fs_zero_copy_replication = 1,
+                    old_parts_lifetime = 20, cleanup_delay_period = 1, max_cleanup_delay_period = 3"""
+        )
+
+    # insert on replica 1, sync replica 2, capture baseline
+    node.query(
+        "INSERT INTO t_zc SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+    node2.query("SYSTEM SYNC REPLICA t_zc")
+    baseline = proj_query("t_zc")
+    assert proj_query("t_zc", node2) == baseline
+    p2 = part_dir("t_zc", node2)
+    assert path_exists(f"{p2}.p.proj", node2)
+
+    # make replica 1 execute the mutation and replica 2 zero-copy-fetch its result
+    node2.query("SYSTEM STOP REPLICATION QUEUES t_zc")
+    node.query(
+        "ALTER TABLE t_zc UPDATE value = concat(value, 'x') WHERE 1 SETTINGS mutations_sync = 1"
+    )
+    node2.query("SYSTEM START REPLICATION QUEUES t_zc")
+    node2.query("SYSTEM SYNC REPLICA t_zc")
+    assert active_parts("t_zc", node2) == "1"
+
+    # release replica 1's zero-copy locks before replica 2 removes the old part, so replica 2's
+    # removal is the one that decides the fate of the shared blobs
+    node.query("DROP TABLE t_zc SYNC")
+    wait_for(lambda: outdated_parts("t_zc", node2) == "0")
+
+    # assert the shared blobs survived: projection healthy, SELECT matches, CHECK passes
+    assert outdated_parts("t_zc", node2) == "0"
+    assert broken_projection_parts("t_zc", node2) == "0"
+    assert (
+        proj_query("t_zc", node2, extra_settings="force_optimize_projection = 1")
+        == baseline
+    )
+    assert check_table("t_zc", node2) == "1"
+
+
+# This test checks that the default hardlink mutation shares inodes with the source projection and
+# keeps the projection usable after the source part is dropped (keep-list correctness).
+# Scenario:
+# - create a 'flat' table whose projection excludes the mutated column, insert data
+# - mutate the column (carried by hardlink)
+# - assert the new sibling shares inodes with the source projection
+# - drop the source part from disk, assert CHECK TABLE and SELECT still work
+def test_blob_mutation_hardlinks():
+    # create a 'flat' table whose projection excludes the mutated column
+    node.query("DROP TABLE IF EXISTS t_hl SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        """CREATE TABLE t_hl (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat',
+               old_parts_lifetime = 1, cleanup_delay_period = 1, max_cleanup_delay_period = 3,
+               cleanup_delay_period_random_add = 1"""
+    )
+    node.query("SYSTEM STOP CLEANUP t_hl")
+    node.query(
+        "INSERT INTO t_hl SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # mutate the non-projection column; the projection is carried by hardlink
+    node.query(
+        "ALTER TABLE t_hl UPDATE value = 'x' WHERE key = 1 SETTINGS mutations_sync = 2"
+    )
+    new_part = part_dir("t_hl")
+    links = node.exec_in_container(
+        ["bash", "-c", f"stat -c %h {new_part}.p.proj/checksums.txt"],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert int(links) >= 2  # hardlinked from the source projection
+
+    # drop the source part from disk and verify the new part still works. Removal is a background,
+    # time-gated task: old_parts_lifetime = 1 makes the outdated source eligible ~1s after the mutation,
+    # and the cleanup_delay_period settings cap the sweep cadence at a few seconds, so a short wait
+    # suffices - a timeout here means removal genuinely stalled, not runner lag.
+    node.query("SYSTEM START CLEANUP t_hl")
+    node.query("SYSTEM START MERGES t_hl")
+    wait_for(lambda: outdated_parts("t_hl") == "0", timeout=30)
+    assert outdated_parts("t_hl") == "0"
+    assert check_table("t_hl") == "1"
+    assert proj_query("t_hl") != ""
+
+
+# This test checks that always_use_copy_instead_of_hardlinks carries the projection by copying: no
+# inode is shared with the source part and the zero-copy keep-list stays empty.
+# Scenario:
+# - create a 'flat' table with always_use_copy_instead_of_hardlinks = 1 whose projection excludes the mutated column
+# - mutate the column (carried by copy)
+# - assert the new sibling shares no inode (link count 1) and CHECK TABLE / SELECT work
+def test_blob_mutation_always_copy():
+    # create a 'flat' table that copies instead of hardlinking, projection excludes the mutated column
+    node.query("DROP TABLE IF EXISTS t_copy SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        """CREATE TABLE t_copy (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat',
+                    always_use_copy_instead_of_hardlinks = 1"""
+    )
+    node.query(
+        "INSERT INTO t_copy SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+
+    # mutate the non-projection column; the projection is carried by copy
+    old_part = part_dir("t_copy")
+    node.query(
+        "ALTER TABLE t_copy UPDATE value = 'x' WHERE key = 1 SETTINGS mutations_sync = 2"
+    )
+    new_part = part_dir("t_copy")
+    assert new_part != old_part
+    assert path_exists(f"{new_part}.p.proj")
+
+    # assert no inode is shared (link count 1) and the part is healthy
+    links = node.exec_in_container(
+        ["bash", "-c", f"stat -c %h {new_part}.p.proj/checksums.txt"],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert links == "1"
+    assert check_table("t_copy") == "1"
+    assert proj_query("t_copy") != ""
+
+
+# This test checks that the orphan reaper removes remote blobs of a reaped orphan sibling when there
+# is no zero-copy: keeping them (keep_in_remote_fs=true) would leak them in object storage forever.
+# Scenario:
+# - create a 'flat' table on the s3 disk, insert, record the sibling's blob keys
+# - stop the server, hide the owner part dir so the sibling becomes a genuine orphan, start it
+# - assert startup GC reaps the orphan sibling metadata
+# - assert the sibling's blobs are gone from object storage
+def test_blob_orphan_gc_removes_without_zero_copy():
+    # create a 'flat' table on the s3 disk, record the sibling's blob keys
+    node.query("DROP TABLE IF EXISTS t_leak SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        """CREATE TABLE t_leak (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat',
+               storage_policy = 's3'"""
+    )
+    node.query(
+        "INSERT INTO t_leak SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+    p = part_dir("t_leak")
+    name = part_name("t_leak")
+    uuid = node.query("SELECT uuid FROM system.tables WHERE name = 't_leak'").strip()
+    sibling_keys = sibling_blob_keys(uuid, name)
+    assert sibling_keys  # the projection really lives on the object storage disk
+    assert sibling_keys <= minio_keys()  # sanity: key format matches the listing
+
+    # hide the owner dir so the sibling becomes a genuine orphan, then restart
+    node.stop_clickhouse()
+    node.exec_in_container(
+        ["bash", "-c", f"mv {p} /tmp/hidden_{name}"], privileged=True, user="root"
+    )
+    node.start_clickhouse()
+
+    # assert startup GC reaps the orphan sibling metadata and its blobs are gone
+    wait_for(lambda: not path_exists(f"{p}.p.proj"))
+    assert not path_exists(f"{p}.p.proj")
+    leaked = sibling_keys & minio_keys()
+    assert leaked == set()
+
+    # cleanup
+    node.exec_in_container(
+        ["bash", "-c", f"rm -rf /tmp/hidden_{name}"], privileged=True, user="root"
+    )
+    node.query("DROP TABLE t_leak SYNC")
+
+
+# This test checks that the publish-time destination sweep removes remote blobs of the residue it
+# clears when there is no zero-copy: keeping them would be a permanent S3 leak.
+# Scenario:
+# - create a 'flat' s3 donor (real blob-backed sibling) and a projection-less-on-insert 'flat' s3 table
+# - move the donor sibling as residue to the table's future part name, record its blob keys
+# - INSERT to publish the part (the destination sweep clears the residue)
+# - assert the residue is gone, its blobs are gone, and the data reads
+def test_blob_publish_sweep_removes():
+    # create an s3 donor (real blob-backed sibling) and a projection-less-on-insert s3 table
+    node.query("DROP TABLE IF EXISTS t_sweep SYNC")
+    node.query("DROP TABLE IF EXISTS t_sweep_donor SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        """CREATE TABLE t_sweep_donor (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat',
+               storage_policy = 's3'"""
+    )
+    node.query(
+        """CREATE TABLE t_sweep (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat',
+               storage_policy = 's3', materialize_projections_on_insert = 0"""
+    )
+    node.query(
+        "INSERT INTO t_sweep_donor SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+    donor_sib = f"{part_dir('t_sweep_donor')}.p.proj"
+    donor_uuid = node.query(
+        "SELECT uuid FROM system.tables WHERE name = 't_sweep_donor'"
+    ).strip()
+    donor_part = part_name("t_sweep_donor")
+    sibling_keys = sibling_blob_keys(donor_uuid, donor_part)
+    assert sibling_keys
+    assert sibling_keys <= minio_keys()  # sanity: key format matches the listing
+
+    # plant the donor's sibling as residue at t_sweep's future part name (mv, not cp: a metadata
+    # copy would lie about blob refcounts); the donor table is sacrificed
+    residue = f"{table_path('t_sweep')}/all_1_1_0.p.proj"
+    node.exec_in_container(
+        ["bash", "-c", f"mv {donor_sib} {residue}"], privileged=True, user="root"
+    )
+
+    # the first insert publishes all_1_1_0; the destination sweep must remove the residue with its blobs
+    node.query("INSERT INTO t_sweep SELECT number, number, '' FROM numbers(100)")
+    p = part_dir("t_sweep")
+    assert p.endswith("all_1_1_0")  # the name collision really happened
+    assert not path_exists(residue)
+    leaked = sibling_keys & minio_keys()
+    assert leaked == set()
+    assert node.query("SELECT count() FROM t_sweep").strip() == "100"
+
+    # cleanup
+    node.query("DROP TABLE t_sweep SYNC")
+    node.query("DROP TABLE t_sweep_donor SYNC")
+
+
+# This test checks the ATTACH-path destination sweep removes remote blobs of the residue it clears
+# when there is no zero-copy: PartsTemporaryRename built its storages without the zero-copy flag, so
+# it always kept the blobs - the same S3 leak.
+# Scenario:
+# - create two 'flat' s3 tables, insert into both, DETACH a part from the first
+# - move the donor sibling as residue to the attaching_ destination name, record its blob keys
+# - ATTACH the detached part (the destination sweep clears the residue)
+# - assert the sweep fired, the residue and its blobs are gone, and the attached part serves its projection
+def test_blob_attach_sweep_removes():
+    # create two 'flat' s3 tables, insert into both, DETACH a part from the first
+    node.query("DROP TABLE IF EXISTS t_att SYNC")
+    node.query("DROP TABLE IF EXISTS t_att_donor SYNC")
+    node.query("SYSTEM STOP MERGES")
+    for tname in ("t_att", "t_att_donor"):
+        node.query(
+            f"""CREATE TABLE {tname} (key UInt64, id UInt64, value String,
+               PROJECTION p (SELECT key, id ORDER BY id))
+               ENGINE = MergeTree ORDER BY key
+               SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat',
+                   storage_policy = 's3'"""
+        )
+        node.query(
+            f"INSERT INTO {tname} SELECT number, number * 2, toString(number) FROM numbers(1000)"
+        )
+    name = part_name("t_att")
+    node.query(f"ALTER TABLE t_att DETACH PART '{name}'")
+
+    # record the donor's blob keys
+    donor_sib = f"{part_dir('t_att_donor')}.p.proj"
+    donor_uuid = node.query(
+        "SELECT uuid FROM system.tables WHERE name = 't_att_donor'"
+    ).strip()
+    donor_part = part_name("t_att_donor")
+    sibling_keys = sibling_blob_keys(donor_uuid, donor_part)
+    assert sibling_keys
+    assert sibling_keys <= minio_keys()  # sanity: key format matches the listing
+
+    # plant the donor's sibling as residue at the attaching_ destination name (mv, not cp)
+    residue = f"{table_path('t_att')}/detached/attaching_{name}.p.proj"
+    node.exec_in_container(
+        ["bash", "-c", f"mv {donor_sib} {residue}"], privileged=True, user="root"
+    )
+
+    # ATTACH renames detached/<name> to detached/attaching_<name>; the sweep must remove the residue + blobs
+    node.query(f"ALTER TABLE t_att ATTACH PART '{name}'")
+    assert node.wait_for_log_line(f"detached/attaching_{name}.p.proj")
+    assert not path_exists(residue)
+    leaked = sibling_keys & minio_keys()
+    assert leaked == set()
+
+    # assert the attached part serves its own projection
+    assert broken_projection_parts("t_att") == "0"
+    assert proj_query("t_att", extra_settings="force_optimize_projection = 1") != ""
+
+    # cleanup
+    node.query("DROP TABLE t_att SYNC")
+    node.query("DROP TABLE t_att_donor SYNC")
+
+
+# ==============================================================================
+# I. Orphan-sibling garbage collection
+# ==============================================================================
+
+# This test checks that the periodic cleaner reaps aged orphan siblings from the live root but never
+# a young one (it may belong to an in-flight rename); moving/ falls to the stale-moving-parts sweep,
+# and startup (age 0) reaps everything.
+# Scenario:
+# - create a 'flat' table with a short cleanup interval, plant an aged orphan, a young orphan, and an aged moving/ orphan
+# - trigger the background cleanup with a merge
+# - assert the aged orphans are reaped, the young one is spared
+# - restart; assert the startup pass reaps even the young orphan
+def test_orphan_gc_periodic_and_startup():
+    # create a 'flat' table with a short cleanup interval, plant aged/young/moving orphans
+    setup_table(
+        "t_gc",
+        "projection_storage_format = 'flat', temporary_directories_lifetime = 3600, "
+        "merge_tree_clear_old_temporary_directories_interval_seconds = 1",
+    )
+    data_root = "/".join(part_dir("t_gc").split("/")[:-1])
+    aged = f"{data_root}/gone_0_0_0.p.proj"
+    young = f"{data_root}/fresh_0_0_0.p.proj"
+    moving_aged = f"{data_root}/moving/gone_1_1_1.p.proj"
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"mkdir -p {aged} {young} {moving_aged} && touch -d '2 hours ago' {aged} {moving_aged}",
+        ],
+        privileged=True,
+        user="root",
+    )
+
+    # background cleanup runs only when there is work for the cleanup task
+    node.query("SYSTEM START MERGES t_gc")
+    node.query("INSERT INTO t_gc SELECT number, number, '' FROM numbers(10)")
+    node.query("OPTIMIZE TABLE t_gc FINAL")
+
+    # assert the aged orphans are reaped and the young one is spared (age guard)
+    wait_for(lambda: not path_exists(aged))
+    assert not path_exists(aged)
+    wait_for(lambda: not path_exists(moving_aged))
+    assert not path_exists(moving_aged)
+    assert path_exists(young)  # age guard: far younger than the 3600s lifetime, cannot age out mid-test
+
+    # restart: startup() runs the age-0 sweep synchronously, before its background tasks start. A table
+    # read blocks on waitTableStarted until startup() has finished, so the young orphan is already reaped
+    # when the read returns - no need to poll the filesystem for it.
+    node.restart_clickhouse()
+    block_until_tables_loaded("t_gc")
+    assert not path_exists(young)
+
+
+# This test checks that the orphan-GC age guard does not reap a sibling whose owner is mid-rename:
+# renames never refresh mtime, so during DROP DETACHED PART an aged sibling of a valid in-flight
+# operation must not look like a reapable orphan. A failpoint pauses the rename to make the race deterministic.
+# Scenario:
+# - create a 'flat' table with a short cleanup interval, DETACH PART, age the detached sibling and an aged decoy orphan
+# - enable the sibling-rename failpoint and start DROP DETACHED PART (parent moves, sibling waits)
+# - drive the cleaner until it provably cycled inside the window (the decoy is reaped)
+# - assert the in-flight sibling was spared and no reap log line mentions it
+def test_orphan_gc_spares_inflight_rename():
+    # create a 'flat' table with a short cleanup interval, DETACH the part
+    setup_table(
+        "t_race",
+        "projection_storage_format = 'flat', "
+        "merge_tree_clear_old_temporary_directories_interval_seconds = 1",
+    )
+    name = part_name("t_race")
+    root = table_path("t_race")
+    node.query(f"ALTER TABLE t_race DETACH PART '{name}'")
+    sib = f"{root}/detached/{name}.p.proj"
+    assert path_exists(sib)
+
+    # trigger inserts must not create flat siblings of their own: their publish rename would park on
+    # the same failpoint that holds the DROP DETACHED window open
+    node.query("ALTER TABLE t_race MODIFY SETTING materialize_projections_on_insert = 0")
+
+    # age the detached sibling and an aged decoy orphan (a positive control for the cleaner cycling)
+    decoy = f"{root}/detached/gone_0_0_0.p.proj"
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"mkdir -p {decoy} && touch -d '2 days ago' {decoy} {sib} {root}/detached/{name}",
+        ],
+        privileged=True,
+        user="root",
+    )
+
+    # open the commit window: the parent moves to deleting_<name>, the sibling waits at the old name
+    node.query("SYSTEM ENABLE FAILPOINT pause_before_flat_projection_sibling_moves")
+    try:
+        drop = node.get_query_request(
+            f"ALTER TABLE t_race DROP DETACHED PART '{name}' SETTINGS allow_drop_detached = 1"
+        )
+        wait_for(
+            lambda: path_exists(f"{root}/detached/deleting_{name}")
+            and path_exists(sib)
+        )
+        assert path_exists(f"{root}/detached/deleting_{name}")
+
+        # nudge the background assignee until the cleaner provably ran inside the window
+        def cleaner_ran():
+            node.query("INSERT INTO t_race SELECT number, number, '' FROM numbers(10)")
+            return not path_exists(decoy)
+
+        wait_for(cleaner_ran, timeout=30)
+        assert not path_exists(decoy)  # positive control: the cleaner cycled
+        still_there = path_exists(sib)
+    finally:
+        node.query(
+            "SYSTEM DISABLE FAILPOINT pause_before_flat_projection_sibling_moves"
+        )
+    drop.get_answer_and_error()  # let the drop finish either way
+
+    # assert the cleaner did not reap a sibling whose owner is mid-rename. The decoy's reap line is the
+    # barrier: the decoy and the in-flight sibling are weighed in the same clearOrphanProjectionSiblings
+    # sweep, so once the decoy line is in the log that sweep has run and flushed - a sibling reap, had it
+    # happened, would be on disk by now too. This lets the negative check read a settled log, no polling.
+    assert still_there
+    node.wait_for_log_line(f"{decoy} whose part directory")
+    assert not node.contains_in_log(f"{sib} whose part directory")
+
+
+# This test checks that a part that breaks before loadProjections seeds the owned set still carries
+# its flat sibling into detached/ for later repair, instead of the startup orphan GC deleting it.
+# Scenario:
+# - create a 'flat' table
+# - stop the server, corrupt checksums.txt (breaks before the owned set is seeded), start it
+# - assert the part was detached as broken and its sibling followed it into detached/
+# - assert no sibling is stranded at the live name
+def test_orphan_gc_broken_part_preserves_sibling():
+    # create a 'flat' table
+    setup_table("t_broken", "projection_storage_format = 'flat'")
+    p = part_dir("t_broken")
+    name = part_name("t_broken")
+    root = table_path("t_broken")
+    assert path_exists(f"{p}.p.proj")
+
+    # corrupt checksums.txt so the part breaks before loadProjections seeds the owned set
+    node.stop_clickhouse()
+    node.exec_in_container(
+        ["bash", "-c", f"echo garbage > {p}/checksums.txt"],
+        privileged=True,
+        user="root",
+    )
+    node.start_clickhouse()
+
+    # assert the part was detached as broken and its sibling followed it into detached/.
+    # With async_load_databases the part is loaded - and detected broken during loadDataParts - in the
+    # background after start_clickhouse() returns. Nothing here queries the table (a pure filesystem
+    # check does not force the load), so wait for the broken part to land in detached/ before asserting.
+    def find_broken_part():
+        return node.exec_in_container(
+            ["bash", "-c", f"find {root}/detached -maxdepth 1 -type d -name 'broken*{name}' | head -1"],
+            privileged=True,
+            user="root",
+        ).strip()
+
+    wait_for(lambda: find_broken_part() != "", timeout=120)
+    detached_parent = find_broken_part()
+    assert detached_parent != ""  # the part really was detached as broken
+    assert path_exists(f"{detached_parent}.p.proj")
+    assert not path_exists(f"{p}.p.proj")
+
+
+# ==============================================================================
+# J. Freeze / shadow siblings
+# ==============================================================================
+
+# This test checks that FREEZE copies the flat projection sibling into shadow/, instead of dropping it. (Issue #2)
+# Scenario:
+# - create a 'flat' table
+# - FREEZE WITH NAME
+# - assert a projection sibling exists under shadow/
+# @pytest.mark.xfail(reason=REVIEW + "3472535412", strict=False)
+def test_freeze_copies_sibling():
+    # create a 'flat' table and freeze it
+    setup_table("t_freeze", "projection_storage_format = 'flat'")
+    node.query("ALTER TABLE t_freeze FREEZE WITH NAME 'flatproj'")
+
+    # assert a projection sibling exists under shadow/
+    found = node.exec_in_container(
+        ["bash", "-c", "find /var/lib/clickhouse/shadow/flatproj -name '*p.proj' | head -1"],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert found != ""
+
+
+# This test checks that UNFREEZE removes flat projection siblings from shadow/ together with their
+# owner, leaving no part dirs or projection siblings behind.
+# Scenario:
+# - create a 'flat' table, FREEZE WITH NAME, assert a sibling exists under shadow/
+# - UNFREEZE WITH NAME
+# - assert no part dirs and no projection siblings remain, and the table is intact
+def test_freeze_unfreeze_removes_siblings():
+    # create a 'flat' table and freeze it
+    setup_table("t_unfreeze", "projection_storage_format = 'flat'")
+    node.query("ALTER TABLE t_unfreeze FREEZE WITH NAME 'unfr'")
+    found = node.exec_in_container(
+        ["bash", "-c", "find /var/lib/clickhouse/shadow/unfr -name '*p.proj' | wc -l"],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert int(found) >= 1
+
+    # unfreeze; the empty dir skeleton may remain but no part dirs / projection siblings may
+    node.query("ALTER TABLE t_unfreeze UNFREEZE WITH NAME 'unfr'")
+    leftovers = node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "find /var/lib/clickhouse/shadow/unfr \\( -name '*_*' -o -name '*.proj' -o -name '*.tmp_proj' \\) 2>/dev/null | wc -l",
+        ],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert leftovers == "0"
+    assert check_table("t_unfreeze") == "1"
+
+
+# This test checks that UNFREEZE reaps an owner-less shadow sibling (a crash between freeze's sibling
+# and parent copies leaves one, and no other cleanup visits shadow/).
+# Scenario:
+# - create a 'flat' table, FREEZE WITH NAME, locate an owner and its sibling
+# - simulate the crash window: remove the owner dir but keep the sibling
+# - UNFREEZE WITH NAME
+# - assert the "Removing frozen projection sibling" log line, no *.proj leftovers, table intact
+def test_freeze_unfreeze_reaps_ownerless_sibling():
+    # create a 'flat' table, freeze it, locate an owner + its sibling
+    setup_table("t_shadow", "projection_storage_format = 'flat'")
+    node.query("ALTER TABLE t_shadow FREEZE WITH NAME 'orph'")
+    owner = node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "find /var/lib/clickhouse/shadow/orph -type d -name '*_*_*_*' ! -name '*.proj' | head -1",
+        ],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert owner != ""
+    assert path_exists(f"{owner}.p.proj")
+
+    # simulate the crash window: the sibling was copied, the parent dir was not
+    node.exec_in_container(["bash", "-c", f"rm -rf {owner}"], privileged=True, user="root")
+    node.query("ALTER TABLE t_shadow UNFREEZE WITH NAME 'orph'")
+
+    # assert the owner-less sibling was reaped and the live table is untouched
+    assert node.wait_for_log_line("Removing frozen projection sibling")
+    leftovers = node.exec_in_container(
+        ["bash", "-c", "find /var/lib/clickhouse/shadow/orph -name '*.proj' 2>/dev/null | wc -l"],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert leftovers == "0"
+    assert check_table("t_shadow") == "1"
+    assert proj_query("t_shadow", extra_settings="force_optimize_projection = 1") != ""
+
+
+# This test checks that the owner-less reap respects the partition matcher: UNFREEZE PARTITION must
+# only touch orphan siblings of the matched partition.
+# Scenario:
+# - create a partitioned 'flat' table, FREEZE WITH NAME, make an orphan sibling in partition 0
+# - UNFREEZE PARTITION 1; assert partition 0's orphan is untouched
+# - UNFREEZE PARTITION 0; assert partition 0's orphan is reaped, table intact
+def test_freeze_unfreeze_partition_scopes_reap():
+    # create a partitioned 'flat' table and freeze it
+    node.query("DROP TABLE IF EXISTS t_shadow2 SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        """CREATE TABLE t_shadow2 (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id ORDER BY id))
+           ENGINE = MergeTree PARTITION BY key % 2 ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat'"""
+    )
+    node.query(
+        "INSERT INTO t_shadow2 SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+    node.query("ALTER TABLE t_shadow2 FREEZE WITH NAME 'orph2'")
+
+    # make an orphan sibling in partition 0 (remove its owner dir)
+    owner0 = node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "find /var/lib/clickhouse/shadow/orph2 -type d -name '0_*' ! -name '*.proj' | head -1",
+        ],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert owner0 != ""
+    node.exec_in_container(["bash", "-c", f"rm -rf {owner0}"], privileged=True, user="root")
+
+    def orphan_sibling_count():
+        return node.exec_in_container(
+            ["bash", "-c", "find /var/lib/clickhouse/shadow/orph2 -name '0_*.proj' 2>/dev/null | wc -l"],
+            privileged=True,
+            user="root",
+        ).strip()
+
+    # unfreezing the OTHER partition must not touch partition 0's orphan sibling
+    node.query("ALTER TABLE t_shadow2 UNFREEZE PARTITION 1 WITH NAME 'orph2'")
+    assert orphan_sibling_count() == "1"
+
+    # unfreezing partition 0 reaps its orphan sibling
+    node.query("ALTER TABLE t_shadow2 UNFREEZE PARTITION 0 WITH NAME 'orph2'")
+    assert orphan_sibling_count() == "0"
+    assert check_table("t_shadow2") == "1"
+
+
+# ==============================================================================
+# K. Backup and restore
+# ==============================================================================
+
+# This test checks that BACKUP/RESTORE stores and finds flat projection data under the LOGICAL name
+# (<part>/p.proj/...), so backups are layout-independent; the physical sibling name would restore a
+# bogus nested dir.
+# Scenario:
+# - create a 'flat' table, capture SELECT baseline
+# - BACKUP TABLE to a file
+# - assert the backup uses the logical p.proj name, never a physical *.*.proj dir
+# - RESTORE to a new table
+# - assert the restore reads, the projection is healthy, SELECT matches, CHECK TABLE passes
+def test_backup_restore_flat():
+    # create a 'flat' table, capture baseline, clear any prior backup
+    setup_table("t_bk", "projection_storage_format = 'flat'")
+    baseline = proj_query("t_bk")
+    node.query("DROP TABLE IF EXISTS t_bk2 SYNC")
+    node.exec_in_container(
+        ["bash", "-c", "rm -rf /var/lib/clickhouse/backups/t_bk"],
+        privileged=True,
+        user="root",
+    )
+
+    # back up the table and assert the backup uses the logical name, not the physical sibling name
+    node.query("BACKUP TABLE t_bk TO File('/var/lib/clickhouse/backups/t_bk')")
+    physical_dirs = node.exec_in_container(
+        ["bash", "-c", "find /var/lib/clickhouse/backups/t_bk -type d -name '*.*.proj' | wc -l"],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert physical_dirs == "0"
+    logical_dirs = node.exec_in_container(
+        ["bash", "-c", "find /var/lib/clickhouse/backups/t_bk -type d -name 'p.proj' | wc -l"],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert logical_dirs == "1"
+
+    # restore into a new table and assert it is healthy and matches baseline
+    node.query("RESTORE TABLE t_bk AS t_bk2 FROM File('/var/lib/clickhouse/backups/t_bk')")
+    assert node.query("SELECT count() FROM t_bk2").strip() == "1000"
+    assert broken_projection_parts("t_bk2") == "0"
+    assert proj_query("t_bk2", extra_settings="force_optimize_projection = 1") == baseline
+    assert check_table("t_bk2") == "1"
+
+
+# ==============================================================================
+# L. fsync durability smoke
+# ==============================================================================
+
+# This test checks that fsync_part_directory=1 exercises the directory-sync points added for flat
+# siblings across the lifecycle (power-loss durability itself is untestable in CI; guard placement is
+# pinned by the gtest).
+# Scenario:
+# - create a 'flat' table with fsync_part_directory=1, insert, add and materialize a second projection
+# - MERGE (OPTIMIZE TABLE FINAL), drop outdated source parts, DETACH/ATTACH the covering part
+# - restart the server
+# - assert one active part, no broken projection, both projection parts active, CHECK TABLE passes
+def test_fsync_flat_lifecycle():
+    # create a 'flat' table with fsync enabled, insert data
+    node.query("DROP TABLE IF EXISTS t_fsync SYNC")
+    node.query("SYSTEM STOP MERGES")
+    node.query(
+        """CREATE TABLE t_fsync (key UInt64, id UInt64, value String,
+           PROJECTION p (SELECT key, id ORDER BY id))
+           ENGINE = MergeTree ORDER BY key
+           SETTINGS min_bytes_for_wide_part = 0, projection_storage_format = 'flat',
+               fsync_part_directory = 1, old_parts_lifetime = 1"""
+    )
+    node.query(
+        "INSERT INTO t_fsync SELECT number, number * 2, toString(number) FROM numbers(1000)"
+    )
+    assert path_exists(f"{part_dir('t_fsync')}.p.proj")
+
+    # add and materialize a second projection, then merge
+    node.query("ALTER TABLE t_fsync ADD PROJECTION q (SELECT id, key ORDER BY key)")
+    node.query("ALTER TABLE t_fsync MATERIALIZE PROJECTION q SETTINGS mutations_sync = 2")
+    node.query("SYSTEM START MERGES t_fsync")
+    node.query("OPTIMIZE TABLE t_fsync FINAL")
+
+    # drop the outdated source parts first: once the covering part is detached and re-attached under
+    # a new block number, a surviving outdated part would resurrect as active on restart
+    wait_for(lambda: outdated_parts("t_fsync") == "0", timeout=120)
+
+    # round-trip the covering part through DETACH/ATTACH, then restart
+    name = part_name("t_fsync")
+    node.query(f"ALTER TABLE t_fsync DETACH PART '{name}'")
+    node.query(f"ALTER TABLE t_fsync ATTACH PART '{name}'")
+    node.restart_clickhouse()
+    block_until_tables_loaded("t_fsync")
+
+    # assert the lifecycle left one healthy part with both projections
+    assert active_parts("t_fsync") == "1"
+    assert broken_projection_parts("t_fsync") == "0"
+    assert int(active_projection_parts("t_fsync")) >= 2
+    assert check_table("t_fsync") == "1"
 
 
 # ==============================================================================
 # M. Packed part storage
 # ==============================================================================
-
-
 # This test checks that REPLACE PARTITION FROM on packed parts does not apply parent-only
 # ClonePartParams to projection sub-parts: metadata_version_to_write must not overwrite the
 # projection's own metadata_version.txt (every part, projections included, carries one since
@@ -432,8 +2835,8 @@ def test_packed_freeze_excludes_residue():
     assert not path_exists(f"{shadow}/p_1.tmp_proj")
 
 
-# This test checks that DETACH/ATTACH PART carries the nested packed projection sub-part
-# (freeze-based detach clone, then attach) and leaves it healthy.
+# This test mirrors test_carry_detach_attach_part for packed storage: DETACH/ATTACH PART must carry
+# the nested packed projection sub-part (freeze-based detach clone, then attach) and leave it healthy.
 # Scenario:
 # - create a packed table with a projection, capture SELECT baseline
 # - DETACH PART; assert the detached copy carries p.proj/data.packed
@@ -461,7 +2864,141 @@ def test_packed_detach_attach_carries_projection():
     assert check_table("t_pk_da") == "1"
 
 
-# This test checks that a mutation of a projected column rebuilds the packed projection (checksums
+# This test checks that projection_storage_format = 'flat' applies to packed parts: the projection
+# is a sibling directory with its own data.packed, it survives a merge, serves queries, and its
+# sibling dirs are removed with the part.
+# Scenario:
+# - create a packed 'flat' table, insert two parts
+# - assert each part has a flat sibling with data.packed and no nested p.proj
+# - OPTIMIZE FINAL; assert the merged part keeps the flat packed layout, projection healthy
+# - TRUNCATE; assert no projection siblings remain at the table root
+def test_packed_flat_lifecycle():
+    # old_parts_lifetime = 1: sibling removal happens at part removal, so dropped parts must not
+    # linger as Outdated for the default 8 minutes
+    setup_table(
+        "t_pk_flat", f"projection_storage_format = 'flat', old_parts_lifetime = 1, {PACKED}"
+    )
+    node.query(
+        "INSERT INTO t_pk_flat SELECT number, number * 2, toString(number) FROM numbers(1000, 1000)"
+    )
+    baseline = proj_query("t_pk_flat")
+
+    # every part: packed archive, flat sibling with its own archive, no nested projection dir
+    parts = node.query(
+        "SELECT path FROM system.parts WHERE table = 't_pk_flat' AND active"
+    ).split()
+    assert len(parts) == 2
+    for p in (x.rstrip("/") for x in parts):
+        assert path_exists(f"{p}/data.packed")
+        assert path_exists(f"{p}.p.proj/data.packed")
+        assert not path_exists(f"{p}/p.proj")
+
+    # merge keeps the flat packed layout and the projection stays healthy
+    node.query("SYSTEM START MERGES t_pk_flat")
+    node.query("OPTIMIZE TABLE t_pk_flat FINAL")
+    wait_for(lambda: active_parts("t_pk_flat") == "1")
+    p = part_dir("t_pk_flat")
+    assert path_exists(f"{p}/data.packed")
+    assert path_exists(f"{p}.p.proj/data.packed")
+    assert not path_exists(f"{p}/p.proj")
+    assert broken_projection_parts("t_pk_flat") == "0"
+    assert (
+        proj_query("t_pk_flat", extra_settings="force_optimize_projection = 1")
+        == baseline
+    )
+    assert check_table("t_pk_flat") == "1"
+
+    # part removal takes the siblings with it
+    table_root = p.rsplit("/", 1)[0]
+    node.query("TRUNCATE TABLE t_pk_flat")
+    wait_for(
+        lambda: node.exec_in_container(
+            ["bash", "-c", f"find {table_root} -maxdepth 1 -name '*.p.proj' | wc -l"],
+            privileged=True,
+            user="root",
+        ).strip()
+        == "0",
+        timeout=120,
+    )
+
+
+# This test checks that a merge crossing the packed->full storage threshold under 'flat' keeps the
+# flat layout on both sides: small level-0 parts are packed with packed flat siblings, the merged
+# level-1 part is full storage with a plain flat sibling.
+# Scenario:
+# - create a 'flat' table with min_level_for_full_part_storage = 1, insert two parts
+# - assert the inserted parts are packed with flat packed siblings
+# - OPTIMIZE FINAL; assert the merged part is full storage, its flat sibling has no archive
+def test_packed_threshold_crossing_merge_keeps_flat():
+    setup_table(
+        "t_pk_cross",
+        "projection_storage_format = 'flat', min_level_for_full_part_storage = 1",
+    )
+    node.query(
+        "INSERT INTO t_pk_cross SELECT number, number * 2, toString(number) FROM numbers(1000, 1000)"
+    )
+    baseline = proj_query("t_pk_cross")
+
+    # level-0 inserts are packed, with packed flat siblings
+    parts = node.query(
+        "SELECT path FROM system.parts WHERE table = 't_pk_cross' AND active"
+    ).split()
+    assert len(parts) == 2
+    for p in (x.rstrip("/") for x in parts):
+        assert path_exists(f"{p}/data.packed")
+        assert path_exists(f"{p}.p.proj/data.packed")
+
+    # the level-1 merged part crosses the threshold to full storage, layout stays flat
+    node.query("SYSTEM START MERGES t_pk_cross")
+    node.query("OPTIMIZE TABLE t_pk_cross FINAL")
+    wait_for(lambda: active_parts("t_pk_cross") == "1")
+    p = part_dir("t_pk_cross")
+    assert not path_exists(f"{p}/data.packed")
+    assert path_exists(f"{p}.p.proj")
+    assert not path_exists(f"{p}.p.proj/data.packed")
+    assert broken_projection_parts("t_pk_cross") == "0"
+    assert (
+        proj_query("t_pk_cross", extra_settings="force_optimize_projection = 1")
+        == baseline
+    )
+    assert check_table("t_pk_cross") == "1"
+
+
+# This test mirrors test_freeze_copies_sibling / test_freeze_unfreeze_removes_siblings for packed
+# storage: FREEZE of a packed 'flat' part copies the packed sibling into shadow/ (owned-set freeze
+# recursion + frozen-copy seeding shared with full storage), and UNFREEZE reaps it with the owner.
+# Scenario:
+# - create a packed 'flat' table, FREEZE WITH NAME
+# - assert the shadow sibling exists and contains its own data.packed
+# - UNFREEZE; assert no part dirs or projection siblings remain, table intact
+def test_packed_flat_freeze_unfreeze():
+    setup_table("t_pk_fz", f"projection_storage_format = 'flat', {PACKED}")
+    node.query("ALTER TABLE t_pk_fz FREEZE WITH NAME 'pkflat'")
+
+    sibling = node.exec_in_container(
+        ["bash", "-c", "find /var/lib/clickhouse/shadow/pkflat -name '*.p.proj' -type d | head -1"],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert sibling != ""
+    assert path_exists(f"{sibling}/data.packed")
+
+    node.query("ALTER TABLE t_pk_fz UNFREEZE WITH NAME 'pkflat'")
+    leftovers = node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "find /var/lib/clickhouse/shadow/pkflat \\( -name '*_*' -o -name '*.proj' -o -name '*.tmp_proj' \\) 2>/dev/null | wc -l",
+        ],
+        privileged=True,
+        user="root",
+    ).strip()
+    assert leftovers == "0"
+    assert check_table("t_pk_fz") == "1"
+
+
+# This test checks that a mutation on a packed part rebuilds the projection sub-part through the
+# createProjection -> writable-storage path (packed storage forbids hardlinks, so every projection is
 # recalculated) and the rebuilt projection reflects the mutated data.
 # Scenario:
 # - create a packed table with a projection
@@ -494,7 +3031,7 @@ def test_packed_mutation_rebuilds_projection():
 
 
 # ==============================================================================
-# N. Object-storage rebuild-path regression
+# N. Object-storage rebuild-path regression (#108443)
 #
 # A projection REBUILT during a mutation on an object-storage disk must survive the part's final
 # rename. Object-storage disks run DEFERRED part transactions (master #89658 / 228ca4c8a4c): the
@@ -515,13 +3052,13 @@ def test_packed_mutation_rebuilds_projection():
 # This test checks the canonical failing class: ADD then MATERIALIZE a projection (a rebuild inside
 # a mutation) on an object-storage disk. The materialize succeeds; the projection must then be
 # readable, healthy, and survive a reload -- not left rooted at the vacated tmp_mut_ path.
-def test_os_materialize_projection_rebuild(storage_kind, disk):
+def test_os_materialize_projection_rebuild(storage_kind, disk, storage_format):
     node.query("DROP TABLE IF EXISTS t_os_mat SYNC")
     node.query("SYSTEM STOP MERGES")
     node.query(
         f"""CREATE TABLE t_os_mat (key UInt64, id UInt64, value String)
            ENGINE = MergeTree ORDER BY key
-           SETTINGS {with_disk(with_storage("min_bytes_for_wide_part = 0", storage_kind), disk)}"""
+           SETTINGS {with_disk(with_storage(f"min_bytes_for_wide_part = 0, projection_storage_format = '{storage_format}'", storage_kind), disk)}"""
     )
     node.query(
         "INSERT INTO t_os_mat SELECT number, number * 2, toString(number) FROM numbers(1000)"
@@ -549,14 +3086,14 @@ def test_os_materialize_projection_rebuild(storage_kind, disk):
 
 # This test checks the same rebuild via a plain data mutation: ALTER UPDATE of a column the
 # projection materializes forces the projection to be rebuilt inside the mutation.
-def test_os_update_projected_column_rebuild(storage_kind, disk):
+def test_os_update_projected_column_rebuild(storage_kind, disk, storage_format):
     node.query("DROP TABLE IF EXISTS t_os_upd SYNC")
     node.query("SYSTEM STOP MERGES")
     node.query(
         f"""CREATE TABLE t_os_upd (key UInt64, id UInt64, value String,
            PROJECTION p (SELECT key, id, value ORDER BY id))
            ENGINE = MergeTree ORDER BY key
-           SETTINGS {with_disk(with_storage("min_bytes_for_wide_part = 0", storage_kind), disk)}"""
+           SETTINGS {with_disk(with_storage(f"min_bytes_for_wide_part = 0, projection_storage_format = '{storage_format}'", storage_kind), disk)}"""
     )
     node.query(
         "INSERT INTO t_os_upd SELECT number, number * 2, toString(number) FROM numbers(1000)"
@@ -581,14 +3118,14 @@ def test_os_update_projected_column_rebuild(storage_kind, disk):
 
 # This test checks the lightweight-DELETE rebuild path (lightweight_mutation_projection_mode =
 # 'rebuild'): the deleting mutation re-materializes the projection, which must survive on object storage.
-def test_os_lightweight_delete_rebuild(storage_kind, disk):
+def test_os_lightweight_delete_rebuild(storage_kind, disk, storage_format):
     node.query("DROP TABLE IF EXISTS t_os_lwd SYNC")
     node.query("SYSTEM STOP MERGES")
     node.query(
         f"""CREATE TABLE t_os_lwd (key UInt64, id UInt64, value String,
            PROJECTION p (SELECT key, id, value ORDER BY id))
            ENGINE = MergeTree ORDER BY key
-           SETTINGS {with_disk(with_storage("min_bytes_for_wide_part = 0, lightweight_mutation_projection_mode = 'rebuild'", storage_kind), disk)}"""
+           SETTINGS {with_disk(with_storage(f"min_bytes_for_wide_part = 0, projection_storage_format = '{storage_format}', lightweight_mutation_projection_mode = 'rebuild'", storage_kind), disk)}"""
     )
     node.query(
         "INSERT INTO t_os_lwd SELECT number, number * 2, toString(number) FROM numbers(1000)"
@@ -608,14 +3145,14 @@ def test_os_lightweight_delete_rebuild(storage_kind, disk):
 # This test probes the merge path: two parts merged with OPTIMIZE FINAL rebuild the projection into
 # the merged part, which must stay readable on object storage. (Merges use a different driver than
 # mutations; this guards that path too.)
-def test_os_optimize_final_merge(storage_kind, disk):
+def test_os_optimize_final_merge(storage_kind, disk, storage_format):
     node.query("DROP TABLE IF EXISTS t_os_merge SYNC")
     node.query("SYSTEM STOP MERGES")
     node.query(
         f"""CREATE TABLE t_os_merge (key UInt64, id UInt64, value String,
            PROJECTION p (SELECT key, id, value ORDER BY id))
            ENGINE = MergeTree ORDER BY key
-           SETTINGS {with_disk(with_storage("min_bytes_for_wide_part = 0", storage_kind), disk)}"""
+           SETTINGS {with_disk(with_storage(f"min_bytes_for_wide_part = 0, projection_storage_format = '{storage_format}'", storage_kind), disk)}"""
     )
     for rng in ("numbers(1000)", "numbers(1000, 1000)"):
         node.query(
@@ -638,14 +3175,14 @@ def test_os_optimize_final_merge(storage_kind, disk):
 # projection by hardlink/copy rather than rebuilding it. The carry loop commits its own part
 # transaction early, so this must pass both before and after the fix -- it proves the regression is
 # specific to the REBUILD path, not to object-storage mutations in general.
-def test_os_mutation_carries_unprojected_column(storage_kind, disk):
+def test_os_mutation_carries_unprojected_column(storage_kind, disk, storage_format):
     node.query("DROP TABLE IF EXISTS t_os_carry SYNC")
     node.query("SYSTEM STOP MERGES")
     node.query(
         f"""CREATE TABLE t_os_carry (key UInt64, id UInt64, value String,
            PROJECTION p (SELECT key, id ORDER BY id))
            ENGINE = MergeTree ORDER BY key
-           SETTINGS {with_disk(with_storage("min_bytes_for_wide_part = 0", storage_kind), disk)}"""
+           SETTINGS {with_disk(with_storage(f"min_bytes_for_wide_part = 0, projection_storage_format = '{storage_format}'", storage_kind), disk)}"""
     )
     node.query(
         "INSERT INTO t_os_carry SELECT number, number * 2, toString(number) FROM numbers(1000)"


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry:
Added an experimental MergeTree setting `projection_storage_format` that selects the on-disk layout of projection sub-parts: `legacy_nested` (default — each projection stored inside its parent part directory, the existing behavior) or `flat` (the projection stored as a sibling directory at the part root, `<part_dir>.<name>.proj`, intended for storage engines with atomic multi-directory commit). Both layouts are always read transparently; the setting only affects newly written parts, for both full and packed part storage.

---

The feature half of [#108443](https://github.com/ClickHouse/ClickHouse/pull/108443), **stacked on [#113278](https://github.com/ClickHouse/ClickHouse/pull/113278)** (the owned-set part-storage rework) — this PR targets that branch and will be rebased onto master once it merges. Together the two supersede #108443.

## What the setting does

```
legacy_nested (default):   <parts_root>/<part_dir>/<name>.proj/...
flat (opt-in, EXPERIMENTAL): <parts_root>/<part_dir>.<name>.proj/...
```

`flat` keeps a projection sub-part out of its parent's directory tree, for storage engines where moving one directory is atomic but nothing above it is. Reads resolve both layouts transparently (a nested child shadows a same-named flat sibling), so mixing layouts across parts — e.g. after `ALTER TABLE ... MODIFY SETTING` — is fine; a merge rewrites parts in the current format.

## Logical changes

1. **Setting + enum** — `projection_storage_format` (`MergeTreeSettings`, EXPERIMENTAL tier, 26.8 settings-history entry, docs incl. a downgrade note); the storage-layer `StorageFormat` enum gains `FLAT`; `MergeTreeData::getProjectionStorageFormat()` now reads the setting (in #113278 it returns the constant).
2. **Layout arithmetic** — the `FLAT` case in `getProjectionRootAndDir` (the single source of layout truth); `detectProjections` probes/lists both layouts.
3. **Commit crash-safety in `rename()`** — flat siblings move with the part under a commit-last discipline: entering the live namespace the parent directory moves **last** (a crash strands only parentless siblings, never a live parent referencing missing sub-parts); leaving it (temp/delete/detached) the parent moves first. Sibling mtimes are refreshed so the orphan GC's age guard covers the commit window; a best-effort unwind reverses committed moves if a later move throws. Destination residue of a failed operation on a same-named part is swept before anything moves. Exercised by two failpoints (`pause_before_flat_projection_sibling_moves`, `throw_after_flat_projection_sibling_move`).
4. **Default-path cost guard** — every flat-sibling parts-root scan (rename/remove/size) is gated by a per-storage `flat_projection_storage_in_use` flag: a `legacy_nested` table pays **zero** per-part root listings.
5. **Lifecycle carry** — freeze, `clonePart` (cross-disk MOVE), fetch, detach/attach carry flat siblings for both full and packed storage (a packed projection keeps its own `data.packed` in either layout); detached siblings are folded into their owner's entry in `system.detached_parts` and dropped with it.
6. **Orphan-sibling GC** — `clearOrphanProjectionSiblings` reaps a flat sibling whose owner part directory is gone, after an age grace (the rename commit window legitimately shows a briefly ownerless sibling); wired to startup and the periodic cleanup threads.
7. **Zero-copy replication** — hardlink keep-lists stay keyed on logical `<name>.proj` paths, so blob refcounting is layout-agnostic; residue sweeps keep remote blobs whenever zero-copy may share them.

## Scenarios covered by tests

- Layout selection, persistence over merge/restart, nested⇄flat conversion via `MODIFY SETTING` + `OPTIMIZE FINAL`, compact parts.
- Lifecycle carry: replicated fetch, merge, `ATTACH PARTITION FROM`, detach/attach, restart, `MATERIALIZE PROJECTION`, lightweight-delete rebuild, multiple projections, partitioned merges, table rename, cross-disk `MOVE PART` — fail-closed (`broken_projection_parts == 0` + `force_optimize_projection = 1` + `CHECK TABLE`).
- Residue and crash-window: tmp-name collisions on insert/fetch, live-named residue not adopted, crash between sibling and parent renames (both directions, via failpoints), mid-rename rollback.
- Manifest desync over flat siblings: unlisted/foreign/same-shape siblings never adopted; manifest regeneration restores only declared projections.
- Zero-copy blob lifecycle on s3: mutation hardlink preservation, publish/attach residue sweeps not leaking shared blobs, orphan GC with and without zero-copy.
- Freeze/unfreeze shadow copies, backup/restore, fsync lifecycle, packed-flat (own archive, threshold-crossing merges, freeze/unfreeze).
- The object-storage rebuild matrix from #113278 is parametrized over both layouts here ({legacy_nested, flat} × {full, packed} × {local, s3}), so the nested coverage stays and `flat` is added on top.
