### PR TITLE
Record Streaming Queries Inner Snapshot Reading Plan

### DIFF
--- a/tests/queries/0_stateless/04726_streaming_queries_commit_order_snapshot_plan.reference
+++ b/tests/queries/0_stateless/04726_streaming_queries_commit_order_snapshot_plan.reference
@@ -1,0 +1,108 @@
+-- cursor over blocks [4, 6]: only merged parts, direct in-order commit_order projection read, consumed and future parts pruned by part minmax
+Output: a, _partition_id, _block_number, _block_offset
+
+Sorting (Sorting for ORDER BY)
+│  Prefix sort description: _block_number ASC, _block_offset ASC
+│  Result sort description: _block_number ASC, _block_offset ASC
+└──ReadFromMergeTree (commit_order)
+      Read type: InOrder
+      Parts: 2 | Granules: 48
+      Output: _partition_id, _block_number, _block_offset, a
+      Prewhere filter
+      Prewhere filter column:  _partition_id = \'all\' AND _block_number <= 6 AND (_block_number > 3 OR _block_number = 3 AND _block_offset > 15)
+      Indexes:
+        Min-Max
+          Keys:
+            _block_number
+            _block_offset
+          Condition: and(or(and((_block_offset in [16, +Inf)), (_block_number in [3, 3])), (_block_number in [4, +Inf))), (_block_number in (-Inf, 6]))
+          Parts: 2/2
+          Granules: 64/64
+        PrimaryKey
+          Keys:
+            _block_number
+            _block_offset
+          Condition: and(or(and((_block_offset in [16, +Inf)), (_block_number in [3, 3])), (_block_number in [4, +Inf))), (_block_number in (-Inf, 6]))
+          Parts: 2/2
+          Granules: 48/64
+          Search Algorithm: generic exclusion search
+        Ranges: 2
+
+-- cursor over blocks [4, 8]: merged parts read via the projection, level-0 parts via the main table
+Output: a, _partition_id, _block_number, _block_offset
+
+Sorting (Sorting for ORDER BY)
+│  Prefix sort description: _block_number ASC, _block_offset ASC
+│  Result sort description: _block_number ASC, _block_offset ASC
+└──Union
+   ├──Sorting
+   │  │  Sort description: _block_number ASC, _block_offset ASC
+   │  └──ReadFromMergeTree (default.t_commit_order_snapshot)
+   │        Read type: Default
+   │        Parts: 3 | Granules: 80
+   │        Output: _partition_id, _block_number, _block_offset, a
+   │        Prewhere filter
+   │        Prewhere filter column:  (_block_number > 3 OR _block_number = 3 AND _block_offset > 15) AND _block_number <= 8 AND _partition_id = \'all\'
+   │        Indexes:
+   │          Min-Max
+   │            Keys:
+   │              _block_number
+   │              _block_offset
+   │            Condition: and(or(and((_block_offset in [16, +Inf)), (_block_number in [3, 3])), (_block_number in [4, +Inf))), (_block_number in (-Inf, 8]))
+   │            Parts: 3/5
+   │            Granules: 80/128
+   │          PrimaryKey
+   │            Condition: true
+   │            Parts: 3/3
+   │            Granules: 80/80
+   │          Skip
+   │            Name: auto_minmax_index__block_number
+   │            Description: minmax GRANULARITY 1
+   │            Condition: and(or((_block_number in [3, 3]), (_block_number in [4, +Inf))), (_block_number in (-Inf, 8]))
+   │            Parts: 3/3
+   │            Granules: 80/80
+   │          Skip
+   │            Name: auto_minmax_index__block_offset
+   │            Description: minmax GRANULARITY 1
+   │            Condition: true
+   │            Parts: 3/3
+   │            Granules: 80/80
+   │          Skip
+   │            Name: <Combined skip indexes>
+   │            Description: Final set of granules after AND/OR processing
+   │            Parts: 3/3
+   │            Granules: 80/80
+   │          Ranges: 1
+   │        Projections:
+   │          Name: commit_order
+   │            Description: Projection commit_order is selected as the best with 80 marks to read, while the original table requires scanning 80 marks
+   │            Condition: and(or(and((_block_offset in [16, +Inf)), (_block_number in [3, 3])), (_block_number in [4, +Inf))), (_block_number in (-Inf, 8]))
+   │            Search Algorithm: generic exclusion search
+   │            Parts: 2
+   │            Marks: 64
+   │            Ranges: 2
+   │            Rows: 64
+   │            Filtered Parts: 0
+   └──ReadFromMergeTree (commit_order)
+         Read type: InOrder
+         Parts: 2 | Granules: 64
+         Output: _partition_id, _block_number, _block_offset, a
+         Prewhere filter
+         Prewhere filter column:  _partition_id = \'all\' AND _block_number <= 8 AND (_block_number > 3 OR _block_number = 3 AND _block_offset > 15)
+         Indexes:
+           Min-Max
+             Keys:
+               _block_number
+               _block_offset
+             Condition: and(or(and((_block_offset in [16, +Inf)), (_block_number in [3, 3])), (_block_number in [4, +Inf))), (_block_number in (-Inf, 8]))
+             Parts: 2/2
+             Granules: 64/64
+           PrimaryKey
+             Keys:
+               _block_number
+               _block_offset
+             Condition: and(or(and((_block_offset in [16, +Inf)), (_block_number in [3, 3])), (_block_number in [4, +Inf))), (_block_number in (-Inf, 8]))
+             Parts: 2/2
+             Granules: 64/64
+             Search Algorithm: generic exclusion search
+           Ranges: 2

--- a/tests/queries/0_stateless/04726_streaming_queries_commit_order_snapshot_plan.sql
+++ b/tests/queries/0_stateless/04726_streaming_queries_commit_order_snapshot_plan.sql
@@ -1,0 +1,54 @@
+-- Tags: no-random-settings, no-random-merge-tree-settings, no-shared-merge-tree, no-parallel-replicas
+
+SET enable_analyzer = 1;
+SET optimize_use_projections = 1;
+SET optimize_read_in_order = 1;
+SET optimize_move_to_prewhere = 1;
+SET query_plan_optimize_prewhere = 1;
+
+DROP TABLE IF EXISTS t_commit_order_snapshot SYNC;
+
+CREATE TABLE t_commit_order_snapshot
+(
+    a UInt64,
+    PROJECTION commit_order INDEX * TYPE commit_order
+)
+ENGINE = MergeTree
+ORDER BY a
+SETTINGS enable_block_number_column = 1,
+         enable_block_offset_column = 1,
+         allow_commit_order_projection = 1,
+         part_minmax_index_columns = 'with_block_number_offset',
+         add_minmax_index_for_block_number_column = 1,
+         add_minmax_index_for_block_offset_column = 1,
+         index_granularity = 1,
+         merge_selector_algorithm = 'Manual';
+
+INSERT INTO t_commit_order_snapshot SELECT number FROM numbers(16); -- all_1_1_0
+INSERT INTO t_commit_order_snapshot SELECT number FROM numbers(16); -- all_2_2_0
+INSERT INTO t_commit_order_snapshot SELECT number FROM numbers(16); -- all_3_3_0
+INSERT INTO t_commit_order_snapshot SELECT number FROM numbers(16); -- all_4_4_0
+INSERT INTO t_commit_order_snapshot SELECT number FROM numbers(16); -- all_5_5_0
+INSERT INTO t_commit_order_snapshot SELECT number FROM numbers(16); -- all_6_6_0
+INSERT INTO t_commit_order_snapshot SELECT number FROM numbers(16); -- all_7_7_0
+INSERT INTO t_commit_order_snapshot SELECT number FROM numbers(16); -- all_8_8_0
+
+SYSTEM SCHEDULE MERGE t_commit_order_snapshot PARTS 'all_2_2_0', 'all_3_3_0'; -- all_2_3_1
+SYSTEM SCHEDULE MERGE t_commit_order_snapshot PARTS 'all_4_4_0', 'all_5_5_0'; -- all_4_5_1
+SYSTEM SCHEDULE MERGE t_commit_order_snapshot PARTS 'all_6_6_0', 'all_7_7_0'; -- all_6_7_1
+SYSTEM SYNC MERGES t_commit_order_snapshot;
+
+SELECT '-- cursor over blocks [4, 6]: only merged parts, direct in-order commit_order projection read, consumed and future parts pruned by part minmax';
+EXPLAIN indexes = 1, projections = 1
+SELECT a, _partition_id, _block_number, _block_offset
+FROM t_commit_order_snapshot
+WHERE _partition_id = 'all' AND _block_number <= 6 AND (_block_number > 3 OR (_block_number = 3 AND _block_offset > 15))
+ORDER BY _block_number, _block_offset;
+
+SELECT '';
+SELECT '-- cursor over blocks [4, 8]: merged parts read via the projection, level-0 parts via the main table';
+EXPLAIN indexes = 1, projections = 1
+SELECT a, _partition_id, _block_number, _block_offset
+FROM t_commit_order_snapshot
+WHERE _partition_id = 'all' AND _block_number <= 8 AND (_block_number > 3 OR (_block_number = 3 AND _block_offset > 15))
+ORDER BY _block_number, _block_offset;

--- a/tests/queries/0_stateless/04726_streaming_queries_commit_order_snapshot_plan.sql
+++ b/tests/queries/0_stateless/04726_streaming_queries_commit_order_snapshot_plan.sql
@@ -5,6 +5,7 @@ SET optimize_use_projections = 1;
 SET optimize_read_in_order = 1;
 SET optimize_move_to_prewhere = 1;
 SET query_plan_optimize_prewhere = 1;
+SET enable_streaming_queries = 1;
 
 DROP TABLE IF EXISTS t_commit_order_snapshot SYNC;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

This patch fixates optimizations that should work for streaming queries, inner snapshot reading query.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.775` (included in `26.8` and later)
<!-- ch-version-info:end -->