### PR TITLE
Docs: add ap-east-2 ClickPipes static IPs

### DIFF
--- a/docs/integrations/clickpipes/networking/static-ips.mdx
+++ b/docs/integrations/clickpipes/networking/static-ips.mdx
@@ -22,6 +22,7 @@ For other services, ClickPipes traffic will originate from a default region base
 - **ap-northeast-2**: For services in AWS `ap-northeast-2` created on or after 14 Nov 2025 (services created before this date use `us-east-2` IPs).
 - **af-south-1**: For services in AWS `af-south-1` created on or after 15 Apr 2026 (services created before this date use `us-east-2` IPs).
 - **ap-east-1**: For services in AWS `ap-east-1` created on or after 15 Apr 2026 (services created before this date use `us-east-2` IPs).
+- **ap-east-2**: For services in AWS `ap-east-2` created on or after 31 Jul 2026 (services created before this date use `us-east-2` IPs).
 - **ap-northeast-1**: For services in AWS `ap-northeast-1` created on or after 15 Apr 2026 (services created before this date use `us-east-2` IPs).
 - **ap-southeast-1**: For services in AWS `ap-southeast-1` created on or after 18 Mar 2026 (services created before this date use `us-east-2` IPs).
 - **ap-southeast-2**: For services in AWS `ap-southeast-2` created on or after 25 Jun 2025 (services created before this date use `us-east-2` IPs).
@@ -49,6 +50,7 @@ For other services, ClickPipes traffic will originate from a default region base
 | **ap-southeast-2** - Sydney (from 25 Jun 2025)          | `3.106.48.103`, `52.62.168.142`, `13.55.113.162`, `3.24.61.148`, `54.206.77.184`, `54.79.253.17`                                                     |
 | **af-south-1** - Cape Town (from 15 Apr 2026)           | `13.245.187.24`, `15.240.60.178`, `15.240.81.191`, `13.245.25.101`, `13.245.91.225`, `15.240.54.195`                                                 |
 | **ap-east-1** - Hong Kong (from 15 Apr 2026)            | `18.166.168.168`, `43.199.224.85`, `95.40.0.242`, `16.162.107.229`, `43.199.125.240`, `54.46.86.27`                                                  |
+| **ap-east-2** - Taipei (from 31 Jul 2026)               | `43.212.222.227`, `43.212.223.232`, `43.213.177.170`, `43.213.191.245`, `43.213.254.52`, `54.54.16.115`                                              |
 | **ap-northeast-1** - Tokyo (from 15 Apr 2026)           | `54.168.88.92`, `35.76.97.79`, `54.64.100.89`, `54.178.40.17`, `52.195.101.208`, `13.193.109.245`                                                    |
 | **ap-southeast-3** - Jakarta (from 6 Mar 2026)          | `16.78.195.195`, `43.218.184.235`, `16.79.88.54`, `15.232.6.147`, `15.232.46.145`, `108.137.199.68`                                                  |
 | **ca-central-1** - Canada (from 15 Apr 2026)            | `52.60.123.235`, `3.97.222.98`, `3.99.62.248`, `15.223.61.186`, `3.96.255.101`, `3.97.29.96`                                                         |


### PR DESCRIPTION
Ports the `ap-east-2` (Taipei) ClickPipes static NAT IP documentation into the ClickHouse monorepo. This adds the region's rollout date and all six static egress IPs so users can configure their IP allow lists correctly.

Related: https://github.com/ClickHouse/clickhouse-docs/pull/6605

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Document the ClickPipes static NAT IPs for AWS `ap-east-2` (Taipei).
