### PR TITLE
Fix the double slash in the integration test runner play URL on 25.8

### DIFF
--- a/ci/jobs/scripts/integration_tests_runner.py
+++ b/ci/jobs/scripts/integration_tests_runner.py
@@ -819,7 +819,7 @@ class ClickhouseIntegrationTestsRunner:
         logging.info(query)
 
         url = (
-            f"{CLICKHOUSE_PLAY_URL}/?user={CLICKHOUSE_PLAY_USER}"
+            f"{CLICKHOUSE_PLAY_URL}?user={CLICKHOUSE_PLAY_USER}"
             f"&password={requests.compat.quote(CLICKHOUSE_PLAY_PASSWORD)}"
             f"&query={requests.compat.quote(query)}"
         )


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/113160
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/113160 (where @alexey-milovidov asked me to investigate the job error and send the fix separately)

`ci/jobs/scripts/integration_tests_runner.py:30` already ends the base URL with a slash, and line 822 appended a second one, so the CIDB query went to `https://play.clickhouse.com//?...`. `//` is not a valid handle, so the server answers `There is no handle //?...` with HTTP 404 and all three retries in `get_tests_execution_time` were guaranteed to fail.

The effect was silent rather than fatal: the caller catches the exception and falls back to grouping tests by count instead of by historical duration (`integration_tests_runner.py:1030-1035`), so integration jobs kept running with unbalanced batches. Seen in `Integration tests (amd_tsan, 5/6)` on the BackportPR run above, where the shard took 1:02:24.

Verified by driving the real `get_tests_execution_time` against play, once from the unmodified `25.8` file and once from the fixed one: the pre-fix method exhausts all three retries with 404, the fixed method returns durations for 1061 test modules.

**Why this targets a release branch directly.** `ci/jobs/scripts/integration_tests_runner.py` exists only on `25.8`. It is absent from `master`, `26.7`, `26.6`, `26.5` and `26.3`, where the duration query was replaced by the static table in `ci/jobs/scripts/integration_tests_configs.py`. There is therefore nothing to fix forward and no master PR that a `v25.8-must-backport` label could be applied to, so the usual label route does not exist here. If you would rather this were handled differently, say so and I will follow that instead.
