### PR TITLE
Enable bucket-region cache per catalogs

### DIFF
--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -8,6 +8,7 @@
 #include <Common/CurrentThread.h>
 #include <Common/ThreadStatus.h>
 #include <Common/Exception.h>
+#include <Common/MemoryTrackerBlockerInThread.h>
 #include <Common/SipHash.h>
 
 #include <aws/core/Aws.h>
@@ -87,6 +88,8 @@ namespace ErrorCodes
 
 namespace S3
 {
+
+static constexpr size_t MAX_CACHES_BY_ENDPOINT_AND_BUCKET = 10000;
 
 Client::RetryStrategy::RetryStrategy(const PocoHTTPClientConfiguration::RetryStrategy & config_)
     : config(config_)
@@ -386,7 +389,7 @@ bool Client::checkIfWrongRegionDefined(const std::string & bucket, const Aws::S3
 void Client::insertRegionOverride(const std::string & bucket, const std::string & region) const
 {
     std::lock_guard lock(cache->region_cache_mutex);
-    auto [it, inserted] = cache->region_for_bucket_cache.emplace(bucket, region);
+    auto [it, inserted] = cache->region_for_bucket_cache.insert_or_assign(bucket, region);
     if (inserted)
         LOG_INFO(log, "Detected different region ('{}') for bucket {} than the one defined ('{}')", region, bucket, explicit_region);
 }
@@ -1164,7 +1167,8 @@ size_t ClientCacheRegistry::getClientRefcountForTesting(ClientCache * client)
 
 void ClientCacheRegistry::pruneExpiredCachesLocked()
 {
-    std::erase_if(cache_by_endpoint_bucket, [](const auto & pair) { return pair.second.expired(); });
+    /// The registry itself is the only owner left, so no client can observe the cache disappearing.
+    std::erase_if(cache_by_endpoint_bucket, [](const auto & pair) { return pair.second.use_count() == 1; });
 }
 
 std::shared_ptr<ClientCache> ClientCacheRegistry::getOrCreateCacheForKey(const std::string & endpoint, const std::string & bucket)
@@ -1176,16 +1180,13 @@ std::shared_ptr<ClientCache> ClientCacheRegistry::getOrCreateCacheForKey(const s
     UInt128 key = hash.get128();
 
     std::lock_guard lock(cache_by_key_mutex);
-    if (auto it = cache_by_endpoint_bucket.find(key); it != cache_by_endpoint_bucket.end())
-    {
-        if (auto cached = it->second.lock(); cached)
-            return cached;
-        cache_by_endpoint_bucket.erase(it);
-    }
-    auto cache = std::make_shared<ClientCache>();
-    cache_by_endpoint_bucket[key] = cache;
 
-    pruneExpiredCachesLocked();
+    if (cache_by_endpoint_bucket.size() >= MAX_CACHES_BY_ENDPOINT_AND_BUCKET)
+        pruneExpiredCachesLocked();
+
+    auto & cache = cache_by_endpoint_bucket[key];
+    if (!cache)
+        cache = std::make_shared<ClientCache>();
 
     return cache;
 }
@@ -1212,7 +1213,8 @@ void ClientCacheRegistry::clearCacheForAll()
 
     {
         std::lock_guard lock(cache_by_key_mutex);
-        pruneExpiredCachesLocked();
+        for (const auto & [_, cache] : cache_by_endpoint_bucket)
+            cache->clearCache();
     }
 }
 

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -8,7 +8,6 @@
 #include <Common/CurrentThread.h>
 #include <Common/ThreadStatus.h>
 #include <Common/Exception.h>
-#include <Common/MemoryTrackerBlockerInThread.h>
 #include <Common/SipHash.h>
 
 #include <aws/core/Aws.h>
@@ -1165,7 +1164,7 @@ size_t ClientCacheRegistry::getClientRefcountForTesting(ClientCache * client)
     return it->second.second;
 }
 
-void ClientCacheRegistry::pruneExpiredCachesLocked()
+void ClientCacheRegistry::pruneUnusedCachesLocked()
 {
     /// The registry itself is the only owner left, so no client can observe the cache disappearing.
     std::erase_if(cache_by_endpoint_bucket, [](const auto & pair) { return pair.second.use_count() == 1; });
@@ -1182,11 +1181,13 @@ std::shared_ptr<ClientCache> ClientCacheRegistry::getOrCreateCacheForKey(const s
     std::lock_guard lock(cache_by_key_mutex);
 
     if (cache_by_endpoint_bucket.size() >= MAX_CACHES_BY_ENDPOINT_AND_BUCKET)
-        pruneExpiredCachesLocked();
+        pruneUnusedCachesLocked();
 
-    auto & cache = cache_by_endpoint_bucket[key];
-    if (!cache)
-        cache = std::make_shared<ClientCache>();
+    if (auto it = cache_by_endpoint_bucket.find(key); it != cache_by_endpoint_bucket.end())
+        return it->second;
+
+    auto cache = std::make_shared<ClientCache>();
+    cache_by_endpoint_bucket.emplace(key, cache);
 
     return cache;
 }
@@ -1213,6 +1214,7 @@ void ClientCacheRegistry::clearCacheForAll()
 
     {
         std::lock_guard lock(cache_by_key_mutex);
+        pruneUnusedCachesLocked();
         for (const auto & [_, cache] : cache_by_endpoint_bucket)
             cache->clearCache();
     }

--- a/src/IO/S3/Client.h
+++ b/src/IO/S3/Client.h
@@ -92,7 +92,7 @@ private:
     std::mutex clients_mutex;
     UnorderedMapWithMemoryTracking<ClientCache *, std::pair<std::weak_ptr<ClientCache>, size_t>> client_caches TSA_GUARDED_BY(clients_mutex);
     std::mutex cache_by_key_mutex;
-    UnorderedMapWithMemoryTracking<UInt128, std::weak_ptr<ClientCache>, UInt128Hash> cache_by_endpoint_bucket TSA_GUARDED_BY(cache_by_key_mutex);
+    UnorderedMapWithMemoryTracking<UInt128, std::shared_ptr<ClientCache>, UInt128Hash> cache_by_endpoint_bucket TSA_GUARDED_BY(cache_by_key_mutex);
 };
 
 bool isS3ExpressEndpoint(const std::string & endpoint);

--- a/src/IO/S3/Client.h
+++ b/src/IO/S3/Client.h
@@ -87,7 +87,7 @@ public:
 private:
     ClientCacheRegistry() = default;
 
-    void pruneExpiredCachesLocked() TSA_REQUIRES(cache_by_key_mutex);
+    void pruneUnusedCachesLocked() TSA_REQUIRES(cache_by_key_mutex);
 
     std::mutex clients_mutex;
     UnorderedMapWithMemoryTracking<ClientCache *, std::pair<std::weak_ptr<ClientCache>, size_t>> client_caches TSA_GUARDED_BY(clients_mutex);


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
There is bucket-region cache in S3 Client. However, it didn't work for data lake catalogs. This PR fixes such behaviour

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113330&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/113330](https://github.com/search?q=head%3Async-upstream%2Fpr%2F113330+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1858` (included in `26.8` and later)
<!-- ch-version-info:end -->