### PR TITLE
Docs: add ClickPipes CDC latency metrics

### DIFF
--- a/docs/integrations/clickpipes/monitoring.mdx
+++ b/docs/integrations/clickpipes/monitoring.mdx
@@ -90,8 +90,10 @@ Not every metric is emitted by every pipe type. In particular, CDC ClickPipes ex
 
 | Metric                                    | Type | Available for | Description |
 |-------------------------------------------|------|---------------|-------------|
-| `ClickPipes_Latency`                      | Gauge (_avg_) | Streaming, object storage | Time in milliseconds between when a record was produced at the source and when it was written to ClickHouse. |
+| `ClickPipes_Latency`                      | Gauge (_avg_) | All | Time in milliseconds between when a record was produced at the source and when it was written to ClickHouse. |
 | `ClickPipes_SourceReplicationLatency_MiB` | Gauge (_avg_) | CDC (Postgres only) | Replication slot lag at the source in MiB. Only emitted by Postgres ClickPipes. |
+| `ClickPipes_CDC_SourceLatency`            | Gauge (_avg_) | CDC | Lag in milliseconds from a source event timestamp to ClickPipes processing. |
+| `ClickPipes_CDC_DestinationLatency`       | Gauge (_avg_) | CDC | Lag in milliseconds from receiving an event in a ClickPipe to writing it into a ClickHouse table. |
 
 ### Resource utilization {#metrics-resources}
 


### PR DESCRIPTION
Ports the ClickPipes monitoring documentation update from the former documentation repository. This documents the `ClickPipes_CDC_SourceLatency` and `ClickPipes_CDC_DestinationLatency` Prometheus metrics and clarifies that `ClickPipes_Latency` is available for all pipe types.

Related: https://github.com/ClickHouse/clickhouse-docs/pull/6578

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Document ClickPipes CDC source and destination latency metrics and clarify the availability of the existing latency metric.
