### PR TITLE
Skip the aggregation hash-table stats cache key without GROUP BY keys

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/calculateHashTableCacheKeys.cpp
+++ b/src/Processors/QueryPlan/Optimizations/calculateHashTableCacheKeys.cpp
@@ -233,7 +233,10 @@ void setAggregationHashTableCacheKeys(const QueryPlanOptimizationSettings & opti
         {
             auto * node = stack.back();
             stack.pop_back();
-            if (typeid_cast<AggregatingStep *>(node->step.get()))
+            /// Without GROUP BY keys the method is `without_key`, whose `init` discards the size
+            /// hint, so such a key can never be consumed.
+            if (const auto * aggregating = typeid_cast<const AggregatingStep *>(node->step.get());
+                aggregating && !aggregating->getParams().keys.empty())
                 aggregating_nodes.push_back(node);
             for (auto * child : node->children)
                 stack.push_back(child);


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/113037   (auto-closes the issue when this PR is merged into the default branch)
-->


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a performance regression where an aggregation without `GROUP BY` keys serialized its whole input plan subtree, including the full contents of constant-folded literals, on every execution to compute a hash-table-size cache key it can never use. A query such as `SELECT quantileMerge(arrayJoin(arrayMap(x -> state, range(5000000))))` spent about 63 ms per execution in query-plan optimization and now spends 0.15 ms.

### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/113037
Related: #107643 (introduced the pass)

`setAggregationHashTableCacheKeys` admitted every `AggregatingStep` and serialized its input subtree to derive a cache key. `ActionsDAG::serialize` writes the full binary content of constant columns, so a folded `range(5000000)` literal materialized about 40 MB into a buffer on every execution.

A keyless aggregation cannot use that key. `AggregatedDataVariants::chooseMethod` starts with `if (keys_size == 0) return Type::without_key;`, `init` discards the `size_hint` for `without_key`, and `without_key` is absent from `APPLY_FOR_VARIANTS_CONVERTIBLE_TO_TWO_LEVEL`. Such aggregations also wrote a meaningless entry (`median_size` = 1) into the shared statistics cache, evicting useful ones.

The fix admits an `AggregatingStep` only when `!getParams().keys.empty()`. The early return when no aggregation is present, the per-node `try/catch` and the compute-all-then-stamp-all ordering are unchanged, and the key stays an optional flagged field in `AggregatingStep::serialize`, so no format or setting default changes.

Validated on x86_64 (the issue reports aarch64), release, against pristine master with distinct build IDs. `QueryPlanOptimizeMicroseconds` for the reported query, median of 9: 63000 to 154. Keyed aggregations keep preallocating, and the existing keyed tests are the regression guard here; a keyless assertion would need a process-global asynchronous metric or a timing counter, both flaky.

<details><summary>Validation matrix</summary>

- `04509_hash_table_sizes_stats_table_functions` still reports 650000 and 520000 on both branches.
- `HashTableStatsCacheEntries` grows by 12 for 12 distinct keyed aggregations on both branches; for 12 keyless ones it grows by 12 on master and by 0 with this change.
- `hash_table_sizes_stats`, `hash_table_sizes_stats_small` and `group_by_consecutive_keys` queries: ratios 0.93 to 1.02.
- Full `aggregat`/`group_by` stateless suite, 460 tests: identical per-test verdicts.
- 50 runs each of `04506` and `04507`: 100 OK, 0 FAIL on both branches.
- Wall clock for the reported query, min of 15: 275 ms to 214 ms.

</details>

`optimizeJoin` and `considerEnablingParallelReplicas` reuse these subtree hashes and run after this pass, so with a keyless aggregation under a join their key values shift: the flag bit recording whether a key was stamped now differs. `HashTablesStatistics` is process-local, so the cost is one un-preallocated execution.

Constant serialization is still costly for keyed aggregations, about 62 ms here, and is left to a separate fix.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1275` (included in `26.8` and later)
<!-- ch-version-info:end -->