### PR TITLE
Docs: add Managed Postgres notifications page

### DIFF
--- a/docs/products/managed-postgres/monitoring/notifications.mdx
+++ b/docs/products/managed-postgres/monitoring/notifications.mdx
@@ -1,0 +1,33 @@
+---
+slug: /cloud/managed-postgres/monitoring/notifications
+sidebarTitle: 'Notifications'
+title: 'ClickHouse Managed Postgres notifications'
+description: 'Cloud console notifications for ClickHouse Managed Postgres services'
+keywords: ['managed postgres', 'notifications', 'alerts', 'storage', 'disk usage']
+doc_type: 'guide'
+---
+
+import { BetaBadge } from "/snippets/components/BetaBadge/BetaBadge.jsx";
+
+<BetaBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} galaxyEvent="docs.managed-postgres.monitoring-notifications-beta" />
+
+ClickHouse Cloud sends notifications when a Managed Postgres service
+needs attention. Notifications are delivered through the
+[cloud console notification system](/products/cloud/features/monitoring/notifications):
+the console inbox, email, and Slack, and can be customized per
+notification from the **Postgres** section of the notification settings
+page. The section appears for organizations with Managed Postgres
+services.
+
+## Supported notifications {#supported-notifications}
+
+| Notify when | Specific alert condition | Default notification channels | Resolution steps |
+|---|---|---|---|
+| Postgres storage passed 85% threshold | When storage usage on a Managed Postgres service reaches 85% of capacity. Notification will only trigger once per calendar day. | UI, email | Storage scales automatically when usage reaches 90% (brief cutover downtime). No action is needed unless auto-scaling is already at its limit. |
+
+## Related pages {#related}
+
+- [Cloud notifications](/products/cloud/features/monitoring/notifications) — channels, severities, and
+  how to customize delivery
+- [Monitoring dashboard](/products/managed-postgres/monitoring/dashboard) —
+  live disk, CPU, and memory charts for each instance

--- a/docs/products/managed-postgres/monitoring/overview.mdx
+++ b/docs/products/managed-postgres/monitoring/overview.mdx
@@ -20,6 +20,7 @@ methods:
 | [Query Insights](/products/managed-postgres/monitoring/query-insights)              | Per-statement telemetry: every query pattern ranked by impact, with diagnostic counters    | None                    |
 | [Prometheus endpoint](/products/managed-postgres/monitoring/prometheus)             | Scrape metrics into Prometheus, Grafana, Datadog, or any OpenMetrics-compatible collector  | API key + scraper config |
 | [Metrics reference](/products/managed-postgres/monitoring/metrics)                  | Full list of metrics exposed by the Prometheus endpoint, with types, labels, and meanings  | N/A                     |
+| [Notifications](/products/managed-postgres/monitoring/notifications)                | Console, email, and Slack alerts when a service needs attention, such as storage nearing capacity | None                    |
 
 ## Quick start {#quick-start}
 

--- a/docs/products/managed-postgres/navigation.json
+++ b/docs/products/managed-postgres/navigation.json
@@ -64,7 +64,8 @@
         "products/managed-postgres/monitoring/dashboard",
         "products/managed-postgres/monitoring/metrics",
         "products/managed-postgres/monitoring/prometheus",
-        "products/managed-postgres/monitoring/query-insights"
+        "products/managed-postgres/monitoring/query-insights",
+        "products/managed-postgres/monitoring/notifications"
       ]
     },
     {


### PR DESCRIPTION
Port the Managed Postgres notifications documentation from the former documentation repository: a new page under Managed Postgres > Monitoring documenting the storage notification (fires at 85% of capacity, once per calendar day, UI and email by default), wired into the section navigation and the monitoring overview table. The notification name matches the console settings row.

Related: https://github.com/ClickHouse/clickhouse-docs/pull/6602

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.795` (included in `26.8` and later)
<!-- ch-version-info:end -->