### PR TITLE
Docs: correct use_persistent_processing_nodes description in S3Queue

### DIFF
--- a/src/Storages/ObjectStorageQueue/registerQueueStorage.cpp
+++ b/src/Storages/ObjectStorageQueue/registerQueueStorage.cpp
@@ -498,11 +498,13 @@ For 'Ordered' mode. Available since `24.6`. If there are several replicas of S3Q
 
 ### `use_persistent_processing_nodes` {#use_persistent_processing_nodes}
 
-By default S3Queue table has always used ephemeral processing nodes, which could lead to duplicates in data in case zookeeper session expires before S3Queue commits processed files in zookeeper, but after it has started processing. This setting forces the server to eliminate possibility of duplicates in case of expired keeper session.
+Persistent processing nodes eliminate the possibility of duplicates when a keeper session expires after processing has started but before S3Queue commits the processed file. Earlier versions used ephemeral processing nodes, which could produce duplicates in that case.
+
+This setting is deprecated and its value is ignored: persistent processing nodes are always used. A table created with `use_persistent_processing_nodes = 0` still uses them, and settings introspection, including `SHOW CREATE TABLE`, reports `1` regardless of the value supplied.
 
 ### `persistent_processing_node_ttl_seconds` {#persistent_processing_node_ttl_seconds}
 
-In case of non-graceful server termination, it is possible that if `use_persistent_processing_nodes` is enabled, we can have not removed processing nodes. This setting defines a period of time when these processing nodes can safely be cleaned up. The same TTL is also used for the bucket lock in `Ordered` mode, which can be held for a longer time than a single processing node, so the value should account for that as well.
+In case of non-graceful server termination, it is possible that we can have not removed processing nodes. This setting defines a period of time when these processing nodes can safely be cleaned up. The same TTL is also used for the bucket lock in `Ordered` mode, which can be held for a longer time than a single processing node, so the value should account for that as well.
 
 Default value: `21600` (6 hours).
 
@@ -604,7 +606,7 @@ Constructions with `{}` are similar to the [remote](/reference/functions/table-f
 
 - an exception happens during parsing in the middle of file processing and retries are enabled via `s3queue_loading_retries`;
 
-- `S3Queue` is configured on multiple servers pointing to the same path in zookeeper and keeper session expires before one server managed to commit processed file, which could lead to another server taking processing of the file, which could be partially or fully processed by the first server; However, this is not true since version 25.8 if `use_persistent_processing_nodes = 1`.
+- `S3Queue` is configured on multiple servers pointing to the same path in zookeeper and keeper session expires before one server managed to commit processed file, which could lead to another server taking processing of the file, which could be partially or fully processed by the first server; However, this is prevented by persistent processing nodes, which have been available since version 25.8 and are now always used (see [`use_persistent_processing_nodes`](#use_persistent_processing_nodes)).
 
 - abnormal server termination.
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/113163

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Corrected the S3Queue documentation for `use_persistent_processing_nodes`: the setting is deprecated, its configured value is ignored, and settings introspection reports `true` regardless of what was supplied.

---

The S3Queue page describes `use_persistent_processing_nodes` as a working toggle. It is deprecated and its configured value is ignored, so the page tells readers they have control they do not have.

The text is edited here rather than in `docs/`, because the page body is generated. `ci/jobs/scripts/docs/autogenerate/autogenerate_docs.py` regenerates every engine reference page from `system.table_engines`, whose `description` column holds the full Markdown body, so the prose lives in this file and `docs/reference/engines/table-engines/integrations/s3queue.mdx` is regenerated from it by the nightly job.

**What the code does.** The value is passed hardcoded, so persistent processing nodes are unconditionally enabled:

```cpp
// src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
        /* use_persistent_processing_nodes */true,
```

There is also a write-back that reports the engine's own value into the settings map, so `SHOW CREATE TABLE` and settings introspection return `true` even for a table created with `false`:

```cpp
settings[ObjectStorageQueueSetting::use_persistent_processing_nodes]
    = files_metadata->usePersistentProcessingNode();
```

Both are present on every currently supported branch:

| branch | hardcoded pass | introspection write-back |
|---|---|---|
| `26.3` | `:389` | `:1598` |
| `26.4` | `:400` | `:1625` |
| `master` | `:442` | `:1788` |

The declaration itself already says so, which the page does not reflect:

```cpp
// src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp:44
DECLARE(Bool, use_persistent_processing_nodes, true, "This setting is deprecated", 0)
```

**Three changes, all the same fact:**

1. `### use_persistent_processing_nodes` — replaced "This setting forces the server to eliminate possibility of duplicates" with a statement that persistent processing nodes eliminate it, plus a note that the setting is deprecated, its value ignored, and that introspection reports `true` regardless. The introspection half is the part that makes this hard to notice from outside.
2. `### persistent_processing_node_ttl_seconds` — dropped "if `use_persistent_processing_nodes` is enabled", which implies a condition that is always met.
3. Limitations item — replaced "this is not true since version 25.8 if `use_persistent_processing_nodes = 1`" with a reference to the setting section, since the reader cannot set it to anything else.

**Not claimed:** the release in which the value stopped being read. It is already hardcoded on `26.3`, the oldest branch checked, so the change predates that. The "since version 25.8" reference is retained as the availability of persistent processing nodes, not as the point the setting stopped being honoured.

No headings renamed and no anchors changed.

`#113163` tracks the underlying defect, namely whether the setting should be rejected, warned on, or removed, whether the introspection write-back described above is intended, and whether an opt-out should return. This PR only corrects the documentation of current behaviour and takes no position on any of those.
