### PR TITLE
Fix flaky 02703_max_local_read_bandwidth: restore throttler headroom

### DIFF
--- a/tests/queries/0_stateless/02703_max_local_read_bandwidth.sh
+++ b/tests/queries/0_stateless/02703_max_local_read_bandwidth.sh
@@ -11,8 +11,10 @@ $CLICKHOUSE_CLIENT -m -q "
     create table data (key UInt64 CODEC(NONE)) engine=MergeTree() order by tuple() settings min_bytes_for_wide_part=1e9;
 "
 
-# reading 1e6*8 bytes with 1M bandwith it should take (8-1)/1=7 seconds
-$CLICKHOUSE_CLIENT -q "insert into data select * from numbers(1e6)"
+# Reading 2e5*8 bytes at 160000 B/s takes 1.6e6/160000-1 = 9 seconds (-1 is the 1s token burst).
+# The throttler only sleeps while the arrival rate exceeds the cap, so the cap must stay far
+# below the natural read rate or the sleep assertion flaps on loaded runners.
+$CLICKHOUSE_CLIENT -q "insert into data select * from numbers(2e5)"
 
 read_methods=(
     read
@@ -25,14 +27,14 @@ read_methods=(
 )
 for read_method in "${read_methods[@]}"; do
     query_id=$(random_str 10)
-    $CLICKHOUSE_CLIENT --query_id "$query_id" -q "select * from data format Null settings max_local_read_bandwidth='1M', local_filesystem_read_method='$read_method'"
+    $CLICKHOUSE_CLIENT --query_id "$query_id" -q "select * from data format Null settings max_local_read_bandwidth=160000, local_filesystem_read_method='$read_method'"
     $CLICKHOUSE_CLIENT -m -q "
         SYSTEM FLUSH LOGS query_log;
         SELECT
             '$read_method',
             query_duration_ms >= 7e3,
-            ProfileEvents['ReadBufferFromFileDescriptorReadBytes'] > 8e6,
-            ProfileEvents['QueryLocalReadThrottlerBytes'] > 8e6,
+            ProfileEvents['ReadBufferFromFileDescriptorReadBytes'] > 1.5e6,
+            ProfileEvents['QueryLocalReadThrottlerBytes'] > 1.5e6,
             ProfileEvents['QueryLocalReadThrottlerSleepMicroseconds'] > 7e6*0.5
         FROM system.query_log
         WHERE event_date >= yesterday() AND event_time >= now() - 600 AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id' AND type != 'QueryStart'

--- a/tests/queries/0_stateless/02703_max_local_read_bandwidth.sh
+++ b/tests/queries/0_stateless/02703_max_local_read_bandwidth.sh
@@ -35,8 +35,8 @@ for read_method in "${read_methods[@]}"; do
         SELECT
             '$read_method',
             query_duration_ms >= 7e3,
-            ProfileEvents['ReadBufferFromFileDescriptorReadBytes'] > 1.5e6,
-            ProfileEvents['QueryLocalReadThrottlerBytes'] > 1.5e6,
+            ProfileEvents['ReadBufferFromFileDescriptorReadBytes'] > 1.6e6,
+            ProfileEvents['QueryLocalReadThrottlerBytes'] > 1.6e6,
             ProfileEvents['QueryLocalReadThrottlerSleepMicroseconds'] > 7e6*0.5
         FROM system.query_log
         WHERE event_date >= yesterday() AND event_time >= now() - 600 AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id' AND type != 'QueryStart'

--- a/tests/queries/0_stateless/02703_max_local_read_bandwidth.sh
+++ b/tests/queries/0_stateless/02703_max_local_read_bandwidth.sh
@@ -12,6 +12,8 @@ $CLICKHOUSE_CLIENT -m -q "
 "
 
 # Reading 2e5*8 bytes at 160000 B/s takes 1.6e6/160000-1 = 9 seconds (-1 is the 1s token burst).
+# The cap was 1e6 B/s over 1e6 rows, which owed exactly 7 seconds - the same value the
+# query_duration_ms assertion below demands, leaving the sleep assertion no margin.
 # The throttler only sleeps while the arrival rate exceeds the cap, so the cap must stay far
 # below the natural read rate or the sleep assertion flaps on loaded runners.
 $CLICKHOUSE_CLIENT -q "insert into data select * from numbers(2e5)"

--- a/tests/queries/0_stateless/02703_max_local_read_bandwidth.sh
+++ b/tests/queries/0_stateless/02703_max_local_read_bandwidth.sh
@@ -15,7 +15,7 @@ $CLICKHOUSE_CLIENT -m -q "
 # The cap was 1e6 B/s over 1e6 rows, which owed exactly 7 seconds - the same value the
 # query_duration_ms assertion below demands, leaving the sleep assertion no margin.
 # The throttler only sleeps while the arrival rate exceeds the cap, so the cap must stay far
-# below the natural read rate or the sleep assertion flaps on loaded runners.
+# below the natural read rate or the sleep assertion flaps on loaded runners (seen in #113107).
 $CLICKHOUSE_CLIENT -q "insert into data select * from numbers(2e5)"
 
 read_methods=(


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/113107
Related: https://github.com/ClickHouse/ClickHouse/pull/106680
Related: https://github.com/ClickHouse/ClickHouse/issues/103422

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`02703_max_local_read_bandwidth` intermittently fails on `pread_threadpool` with only its 4th column
wrong (`1 1 1 0`), most recently on this
[report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113107&sha=8f0f86485d192241fd2ed5bc0f5cb0b7630d244c&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%29).

**Root cause: the 4th assertion is a coupled oracle.** `Throttler::throttle` increments the bytes
counter unconditionally (`Throttler.cpp:63-64`) but the sleep counter only inside `if (block)`
(`:78-82`), and `block` requires `tokens_value < 0` (`:70`). The token bucket (`:110-125`) goes
negative only while bytes arrive faster than the cap, so once a loaded runner's read rate falls to
about the cap the throttler correctly does not sleep while bytes still record. The fixture had no
margin: at a 1e6 B/s cap over an 8 MB payload it owes exactly 7.0 s, exactly what column 1 also
demands, and column 4 had only 2.0x over its 3.5 s threshold.

The sleep is not lost or misattributed. In the reported failure `QueryLocalReadThrottlerBytes` passed
while its sibling sleep counter was 0, and both are charged through the same
`CurrentThread::getProfileEvents` a few lines apart, so a detached thread would have lost both. No
pool thread is involved either: for `pread_threadpool` the throttle call runs on the consuming
pipeline thread (`AsynchronousReadBufferFromFileDescriptor.cpp:141-142`), not in `ThreadPoolReader`,
which never throttles.

**The change** co-reduces the payload (1e6 -> 2e5 rows) and the cap (1e6 -> 160000 B/s), raising the
owed sleep to 9.0 s at comparable wall clock: 1.29x over the duration floor and 2.57x over the
unchanged 3.5 s sleep threshold. Byte thresholds track the payload at 8e6 -> 1.6e6,
still requiring the whole scan be throttled. All four assertions, both time thresholds and `.reference` are
unchanged. Same fix as #106680 for the sibling `04103_user_network_bandwidth_throttler`.

**Validation.** Capping the arrival rate (`max_execution_speed_bytes`, `max_threads=1`) reproduces
the signature: unmodified prints `1 1 1 0` on all three arms, `1 1 1 1` without the injection;
modified stays green. 50/50 clean local runs, runtime 1.18x.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.797` (included in `26.8` and later)
<!-- ch-version-info:end -->