### PR TITLE
Fix incorrect compile options API usage in memcpy-bench

### DIFF
--- a/utils/memcpy-bench/CMakeLists.txt
+++ b/utils/memcpy-bench/CMakeLists.txt
@@ -17,7 +17,7 @@ clickhouse_add_executable (memcpy-bench
     glibc/memmove-avx512-no-vzeroupper.S
     )
 
-add_compile_options(memcpy-bench PRIVATE -fno-tree-loop-distribute-patterns)
+target_compile_options(memcpy-bench PRIVATE -fno-tree-loop-distribute-patterns)
 
 if (OS_SUNOS)
     target_compile_options(memcpy-bench PRIVATE "-Wa,--divide")


### PR DESCRIPTION
Replace `add_compile_options` with `target_compile_options` so `-fno-tree-loop-distribute-patterns` is applied as a private target option.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `memcpy-bench` CMake so `-fno-tree-loop-distribute-patterns` is applied via `target_compile_options` instead of being treated as a directory-level flag.

