### PR TITLE
Make countSubstrings observe cancellation and max_execution_time

### DIFF
--- a/src/Functions/CancellationBudget.cpp
+++ b/src/Functions/CancellationBudget.cpp
@@ -1,0 +1,38 @@
+#include <Functions/CancellationBudget.h>
+
+#include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
+#include <Common/CurrentThread.h>
+#include <Common/Exception.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int TIMEOUT_EXCEEDED;
+}
+
+std::function<void()> makeCancellationCheck(const char * function_name)
+{
+    /// Resolved from the executing thread rather than from the context that built the caller: a function
+    /// instance can be stored in table metadata and then run by any later query.
+    QueryStatusPtr process_list_element;
+    if (auto query_context = CurrentThread::tryGetQueryContext())
+        process_list_element = query_context->getProcessListElementSafe();
+
+    if (!process_list_element)
+        return {};
+
+    /// A false return means the deadline passed under the `break` overflow mode; a partial result from a
+    /// function is a wrong value rather than a smaller one, so it throws either way.
+    return [process_list_element, function_name]
+    {
+        if (!process_list_element->checkTimeLimit())
+            throw Exception(
+                ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", function_name);
+    };
+}
+
+}

--- a/src/Functions/CancellationBudget.h
+++ b/src/Functions/CancellationBudget.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+
+
+namespace DB
+{
+
+/// Throttled cancellation checkpoint for a loop inside one function call. Lives on the stack of a single
+/// vector call, so it is never shared between threads. Counted in loop ITERATIONS, not bytes: an iteration
+/// can cost a full search or match attempt while advancing almost no data. Bytes are charged on top,
+/// scaled down, because one iteration can also touch megabytes.
+struct CancellationBudget
+{
+    /// About 30ms of granularity on the cheapest loop.
+    static constexpr size_t units_per_check = 1ULL << 16;
+    /// Bytes of data read or written that count as one unit of work.
+    static constexpr size_t bytes_per_unit = 16;
+    /// Units a caller may accumulate locally before charging them in one call.
+    static constexpr size_t units_per_instruction_charge = 4096;
+
+    explicit CancellationBudget(const std::function<void()> & check_)
+        : check(check_ ? &check_ : nullptr) {}
+
+    /// One iteration of an unbounded loop, plus the bytes of data that iteration touched.
+    void charge(size_t bytes = 0) { chargeUnits(1 + bytes / bytes_per_unit); }
+
+    /// Work that is not proportional to the amount of data, e.g. constructing a matcher from a pattern.
+    void chargeUnits(size_t units)
+    {
+        if (units_left > units)
+        {
+            units_left -= units;
+            return;
+        }
+        units_left = units_per_check;
+        if (check)
+            (*check)();
+    }
+
+private:
+    const std::function<void()> * check;
+    size_t units_left = units_per_check;
+};
+
+/// Observes the running query's elapsed-time limit and killed flag, and throws when either is reached.
+/// Empty when there is no query to observe. Out of line so that including this header does not pull in
+/// `ProcessList`.
+std::function<void()> makeCancellationCheck(const char * function_name);
+
+}

--- a/src/Functions/CountSubstringsImpl.h
+++ b/src/Functions/CountSubstringsImpl.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <Functions/CancellationBudget.h>
 #include <Functions/PositionImpl.h>
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -43,6 +45,13 @@ struct CountSubstringsImpl
         /// `res_null` serves as an output parameter for implementing an XYZOrNull variant, and it's irrelevant for this function.
         chassert(!res_null);
 
+        /// Checked once on entry so that a deadline already passed is observed even by a call that
+        /// does no charged work, e.g. an empty needle returning all zeros.
+        const std::function<void()> check_cancellation = makeCancellationCheck(name);
+        if (check_cancellation)
+            check_cancellation();
+        CancellationBudget budget(check_cancellation);
+
         const UInt8 * const begin = haystack_data.data();
         const UInt8 * const end = haystack_data.data() + haystack_data.size();
         const UInt8 * pos = begin;
@@ -50,7 +59,7 @@ struct CountSubstringsImpl
         memset(res.data(), 0, res.size() * sizeof(res[0]));
 
         if (needle.empty())
-            return; // Return all zeros
+            return; /// Return all zeros; the entry checkpoint above already observed the deadline.
 
         /// Current index in the column of strings.
         size_t i = 0;
@@ -67,9 +76,15 @@ struct CountSubstringsImpl
 
         typename Impl::SearcherInBigHaystack searcher = Impl::createSearcherInBigHaystack(needle.data(), needle.size(), end - pos);
 
+        /// Bytes already accounted for, so each iteration is charged only for what it newly traversed.
+        const UInt8 * charged_up_to = pos;
+
         /// We will search for the next occurrence in all strings at once.
         while (pos < end && end != (pos = searcher.search(pos, end - pos)))
         {
+            budget.charge(pos - charged_up_to);
+            charged_up_to = pos;
+
             /// Determine which index it refers to.
             while (i < input_rows_count && begin + haystack_offsets[i] <= pos)
                 ++i;
@@ -112,6 +127,9 @@ struct CountSubstringsImpl
                 ++i;
             }
         }
+
+        /// A block with no match at all never enters the loop above, so charge its bytes on the way out.
+        budget.charge(end - charged_up_to);
     }
 
     /// Count number of occurrences of substring each time for a different inside each time different string.
@@ -130,6 +148,11 @@ struct CountSubstringsImpl
         /// `res_null` serves as an output parameter for implementing an XYZOrNull variant.
         chassert(!res_null);
 
+        const std::function<void()> check_cancellation = makeCancellationCheck(name);
+        if (check_cancellation)
+            check_cancellation();
+        CancellationBudget budget(check_cancellation);
+
         ColumnString::Offset prev_haystack_offset = 0;
         ColumnString::Offset prev_needle_offset = 0;
 
@@ -137,6 +160,9 @@ struct CountSubstringsImpl
         {
             size_t needle_size = needle_offsets[i] - prev_needle_offset;
             size_t haystack_size = haystack_offsets[i] - prev_haystack_offset;
+
+            /// A row without a match never reaches the inner charge below, yet still scans its bytes.
+            budget.charge(haystack_size);
 
             size_t start = 0;
             if (start_pos)
@@ -172,6 +198,7 @@ struct CountSubstringsImpl
                 /// searcher returns a pointer to the found substring or to the end of `haystack`.
                 while ((pos = searcher.search(beg, end)) < end)
                 {
+                    budget.charge(pos - beg);
                     ++res[i];
                     beg = pos + needle_size;
                 }
@@ -197,11 +224,19 @@ struct CountSubstringsImpl
         /// `res_null` serves as an output parameter for implementing an XYZOrNull variant.
         chassert(!res_null);
 
+        const std::function<void()> check_cancellation = makeCancellationCheck(name);
+        if (check_cancellation)
+            check_cancellation();
+        CancellationBudget budget(check_cancellation);
+
         /// NOTE You could use haystack indexing. But this is a rare case.
         ColumnString::Offset prev_needle_offset = 0;
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
+            /// A row whose needle is never found scans the whole haystack without reaching the charge below.
+            budget.charge(haystack.size());
+
             res[i] = 0;
             size_t start = 0;
             if (start_pos)
@@ -225,6 +260,7 @@ struct CountSubstringsImpl
                     const UInt8 * pos = nullptr;
                     while ((pos = searcher.search(beg, end)) < end)
                     {
+                        budget.charge(pos - beg);
                         ++res[i];
                         beg = pos + needle_size;
                     }

--- a/src/Functions/FunctionStringReplace.h
+++ b/src/Functions/FunctionStringReplace.h
@@ -5,11 +5,10 @@
 #include <Columns/ColumnConst.h>
 #include <Core/Settings.h>
 #include <DataTypes/DataTypeString.h>
+#include <Functions/CancellationBudget.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/ProcessList.h>
-#include <Common/CurrentThread.h>
 
 #include <functional>
 #include <limits>
@@ -21,7 +20,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
-    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace Setting
@@ -72,21 +70,7 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
-        /// Resolved from the executing thread rather than captured: this instance can be stored in table
-        /// metadata and then run by any later query.
-        QueryStatusPtr process_list_element;
-        if (auto query_context = CurrentThread::tryGetQueryContext())
-            process_list_element = query_context->getProcessListElementSafe();
-
-        /// `checkTimeLimit` returns false rather than throwing under the `break` overflow mode, but a
-        /// partially rewritten string is a wrong value rather than a shorter one, so it becomes a throw.
-        std::function<void()> check_cancellation;
-        if (process_list_element)
-            check_cancellation = [&process_list_element]
-            {
-                if (!process_list_element->checkTimeLimit())
-                    throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", name);
-            };
+        std::function<void()> check_cancellation = makeCancellationCheck(name);
 
         /// Before materialization: expanding a constant into a full column is itself unbounded.
         if (check_cancellation)

--- a/src/Functions/ReplaceRegexpImpl.h
+++ b/src/Functions/ReplaceRegexpImpl.h
@@ -89,7 +89,7 @@ struct ReplaceRegexpImpl
     }
 
     /// The replacement string references must not contain non-existing capturing groups.
-    static void checkSubstitutions(std::string_view replacement, int num_captures, ReplaceCancellationBudget & budget)
+    static void checkSubstitutions(std::string_view replacement, int num_captures, CancellationBudget & budget)
     {
         for (size_t i = 0; i < replacement.size(); ++i)
         {
@@ -106,7 +106,7 @@ struct ReplaceRegexpImpl
         }
     }
 
-    static Instructions createInstructions(std::string_view replacement, int num_captures, ReplaceCancellationBudget & budget)
+    static Instructions createInstructions(std::string_view replacement, int num_captures, CancellationBudget & budget)
     {
         checkSubstitutions(replacement, num_captures, budget);
 
@@ -147,7 +147,7 @@ struct ReplaceRegexpImpl
     /// `budget` is mandatory: this helper scans the whole replacement, and `analyze` the whole needle.
     static bool canFallbackToStringReplacement(
         const String & needle, const String & replacement, const re2::RE2 & searcher, int num_captures,
-        ReplaceCancellationBudget & budget)
+        CancellationBudget & budget)
     {
         if (searcher.NumberOfCapturingGroups())
             return false;
@@ -167,7 +167,7 @@ struct ReplaceRegexpImpl
         const re2::RE2 & searcher,
         int num_captures,
         const Instructions & instructions,
-        ReplaceCancellationBudget & budget)
+        CancellationBudget & budget)
     {
         std::string_view haystack(haystack_data, haystack_length);
         std::string_view matches[max_captures];
@@ -210,8 +210,8 @@ struct ReplaceRegexpImpl
                     if (!replacement.empty())
                         memcpy(&res_data[res_offset], replacement.data(), replacement.size());
                     res_offset += replacement.size();
-                    units_since_charge += 1 + replacement.size() / ReplaceCancellationBudget::bytes_per_unit;
-                    if (units_since_charge >= ReplaceCancellationBudget::units_per_instruction_charge)
+                    units_since_charge += 1 + replacement.size() / CancellationBudget::bytes_per_unit;
+                    if (units_since_charge >= CancellationBudget::units_per_instruction_charge)
                     {
                         budget.chargeUnits(units_since_charge);
                         units_since_charge = 0;
@@ -219,7 +219,7 @@ struct ReplaceRegexpImpl
                 }
 
                 /// This iteration, whatever the loop has not flushed, plus the prefix bytes copied.
-                budget.chargeUnits(1 + units_since_charge + bytes_to_copy / ReplaceCancellationBudget::bytes_per_unit);
+                budget.chargeUnits(1 + units_since_charge + bytes_to_copy / CancellationBudget::bytes_per_unit);
 
                 if constexpr (replace == ReplaceRegexpTraits::First)
                     can_finish_current_string = true;
@@ -271,7 +271,7 @@ struct ReplaceRegexpImpl
         const uint8_t ** capture_starts,
         const uint8_t ** capture_ends,
         const Instructions & instructions,
-        ReplaceCancellationBudget & budget)
+        CancellationBudget & budget)
     {
         const auto * begin = reinterpret_cast<const uint8_t *>(haystack_data);
         const auto * end = begin + haystack_length;
@@ -315,8 +315,8 @@ struct ReplaceRegexpImpl
                     if (!replacement.empty())
                         memcpy(&res_data[res_offset], replacement.data(), replacement.size());
                     res_offset += replacement.size();
-                    units_since_charge += 1 + replacement.size() / ReplaceCancellationBudget::bytes_per_unit;
-                    if (units_since_charge >= ReplaceCancellationBudget::units_per_instruction_charge)
+                    units_since_charge += 1 + replacement.size() / CancellationBudget::bytes_per_unit;
+                    if (units_since_charge >= CancellationBudget::units_per_instruction_charge)
                     {
                         budget.chargeUnits(units_since_charge);
                         units_since_charge = 0;
@@ -324,7 +324,7 @@ struct ReplaceRegexpImpl
                 }
 
                 /// See `processString`.
-                budget.chargeUnits(1 + units_since_charge + bytes_to_copy / ReplaceCancellationBudget::bytes_per_unit);
+                budget.chargeUnits(1 + units_since_charge + bytes_to_copy / CancellationBudget::bytes_per_unit);
 
                 if constexpr (replace == ReplaceRegexpTraits::First)
                     can_finish_current_string = true;
@@ -371,7 +371,7 @@ struct ReplaceRegexpImpl
         size_t regexp_jit_min_count = std::numeric_limits<size_t>::max(),
         const std::function<void()> & check_cancellation = {})
     {
-        ReplaceCancellationBudget budget(check_cancellation);
+        CancellationBudget budget(check_cancellation);
 
         if (needle.empty())
         {
@@ -455,7 +455,7 @@ struct ReplaceRegexpImpl
     {
         chassert(haystack_offsets.size() == needle_offsets.size());
 
-        ReplaceCancellationBudget budget(check_cancellation);
+        CancellationBudget budget(check_cancellation);
 
         ColumnString::Offset res_offset = 0;
         res_data.reserve(haystack_data.size());
@@ -514,7 +514,7 @@ struct ReplaceRegexpImpl
     {
         chassert(haystack_offsets.size() == replacement_offsets.size());
 
-        ReplaceCancellationBudget budget(check_cancellation);
+        CancellationBudget budget(check_cancellation);
 
         if (needle.empty())
         {
@@ -571,7 +571,7 @@ struct ReplaceRegexpImpl
         chassert(haystack_offsets.size() == needle_offsets.size());
         chassert(needle_offsets.size() == replacement_offsets.size());
 
-        ReplaceCancellationBudget budget(check_cancellation);
+        CancellationBudget budget(check_cancellation);
 
         ColumnString::Offset res_offset = 0;
         res_data.reserve(haystack_data.size());
@@ -632,7 +632,7 @@ struct ReplaceRegexpImpl
         size_t input_rows_count,
         const std::function<void()> & check_cancellation = {})
     {
-        ReplaceCancellationBudget budget(check_cancellation);
+        CancellationBudget budget(check_cancellation);
 
         if (needle.empty())
         {

--- a/src/Functions/ReplaceStringImpl.h
+++ b/src/Functions/ReplaceStringImpl.h
@@ -3,6 +3,7 @@
 #include <base/types.h>
 #include <Common/Volnitsky.h>
 #include <Columns/ColumnString.h>
+#include <Functions/CancellationBudget.h>
 
 #include <functional>
 
@@ -17,43 +18,6 @@ struct ReplaceStringTraits
         First,
         All
     };
-};
-
-/// Throttled cancellation checkpoint for the `replace*` functions. Lives on the stack of a single vector
-/// call, so it is never shared between threads. Counted in loop ITERATIONS, not bytes: an empty regexp
-/// match advances one byte and may copy nothing, yet costs a full `RE2::Match`. Bytes are charged on top,
-/// scaled down, because one iteration can copy megabytes.
-struct ReplaceCancellationBudget
-{
-    /// About 30ms of granularity on the cheapest loop.
-    static constexpr size_t units_per_check = 1ULL << 16;
-    /// Bytes of data read or written that count as one unit of work.
-    static constexpr size_t bytes_per_unit = 16;
-    /// Accumulated inside a substitution loop before being charged, so the loop body stays short.
-    static constexpr size_t units_per_instruction_charge = 4096;
-
-    explicit ReplaceCancellationBudget(const std::function<void()> & check_)
-        : check(check_ ? &check_ : nullptr) {}
-
-    /// One iteration of an unbounded loop, plus the bytes of data that iteration touched.
-    void charge(size_t bytes = 0) { chargeUnits(1 + bytes / bytes_per_unit); }
-
-    /// Work that is not proportional to the amount of data, e.g. constructing a matcher from a pattern.
-    void chargeUnits(size_t units)
-    {
-        if (units_left > units)
-        {
-            units_left -= units;
-            return;
-        }
-        units_left = units_per_check;
-        if (check)
-            (*check)();
-    }
-
-private:
-    const std::function<void()> * check;
-    size_t units_left = units_per_check;
 };
 
 /** Replace one or all occurencies of substring 'needle' to 'replacement'.
@@ -73,7 +37,7 @@ struct ReplaceStringImpl
         size_t input_rows_count,
         const std::function<void()> & check_cancellation = {})
     {
-        ReplaceCancellationBudget budget(check_cancellation);
+        CancellationBudget budget(check_cancellation);
 
         if (needle.empty())
         {
@@ -219,7 +183,7 @@ struct ReplaceStringImpl
     {
         chassert(haystack_offsets.size() == needle_offsets.size());
 
-        ReplaceCancellationBudget budget(check_cancellation);
+        CancellationBudget budget(check_cancellation);
 
         res_data.reserve(haystack_data.size());
         res_offsets.resize(input_rows_count);
@@ -297,7 +261,7 @@ struct ReplaceStringImpl
     {
         chassert(haystack_offsets.size() == replacement_offsets.size());
 
-        ReplaceCancellationBudget budget(check_cancellation);
+        CancellationBudget budget(check_cancellation);
 
         if (needle.empty())
         {
@@ -381,7 +345,7 @@ struct ReplaceStringImpl
         chassert(haystack_offsets.size() == needle_offsets.size());
         chassert(needle_offsets.size() == replacement_offsets.size());
 
-        ReplaceCancellationBudget budget(check_cancellation);
+        CancellationBudget budget(check_cancellation);
 
         res_data.reserve(haystack_data.size());
         res_offsets.resize(input_rows_count);
@@ -462,7 +426,7 @@ struct ReplaceStringImpl
         size_t input_rows_count,
         const std::function<void()> & check_cancellation = {})
     {
-        ReplaceCancellationBudget budget(check_cancellation);
+        CancellationBudget budget(check_cancellation);
 
         if (needle.empty() || needle == replacement)
         {

--- a/tests/queries/0_stateless/04722_count_substrings_cancellation.reference
+++ b/tests/queries/0_stateless/04722_count_substrings_cancellation.reference
@@ -1,0 +1,17 @@
+constant_vector: stopped within bound
+vector_vector: stopped within bound
+vector_vector_inner: stopped within bound
+vector_constant: stopped within bound
+no_match_rows: stopped within bound
+case_sensitive: stopped within bound
+case_insensitive: stopped within bound
+constant_vector_break: stopped within bound
+kill query returned promptly
+3	2	2
+2	2	2
+3	2	2
+2	2	2
+2	2	1
+0	0	0	0
+5	5
+3000000

--- a/tests/queries/0_stateless/04722_count_substrings_cancellation.sh
+++ b/tests/queries/0_stateless/04722_count_substrings_cancellation.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Tags: long, no-fasttest, no-coverage, no-flaky-check
+# no-coverage: per-test coverage instrumentation stretches the fixed side of the timed cases.
+# no-flaky-check: the cases verify timeout-based behavior, not suitable for rerun-based detection.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Each timed case puts over a second of work inside ONE function call and bounds the elapsed time the
+# server reports. The pins below keep one call per block, so the executor's between-block check cannot
+# bound the query instead of the function. Every case keeps at least 3.5x the bound unfixed, and the
+# bound scales for sanitizer and coverage builds, which stretch both sides.
+SCALE=1
+[ -n "$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS' AND value LIKE '%sanitize=%'")" ] && SCALE=2
+case "$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'WITH_COVERAGE'")" in ON|1) SCALE=2 ;; esac
+BOUND=$((SCALE * 3500))
+
+PINS="max_threads = 1, preferred_block_size_bytes = 0"
+# 11 MB with a match every 11 bytes: 1M matches inside a single row.
+BIG="repeat('\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0a', 1000000)"
+
+# The runner randomizes parallel replicas into every client call, and a `system` table read under it wants
+# a cluster a single-node server may not have.
+LOG_PINS="--enable_parallel_replicas 0"
+
+# $1 = label, $2 = query, $3 = overflow mode (default "throw")
+#
+# A duration alone cannot tell a stopped call from a query that never ran, so the verdict asserts the
+# termination cause too. Only `ExecutionSpeedLimits::checkTimeLimit` formats "elapsed N ms"; a kill landing
+# before the pipeline starts omits it, and such a run is reported as inconclusive rather than as a pass.
+run() {
+    local label="$1" query="$2" mode="${3:-throw}"
+    local query_id="04722_${label}_${CLICKHOUSE_DATABASE}" output elapsed_ms code rows breaks
+    # `log_profile_events` is pinned: the `break` verdict reads a counter out of the `query_log` row.
+    output=$(timeout 600 ${CLICKHOUSE_CLIENT} --query_id "$query_id" --max_execution_time 1 \
+        --log_profile_events 1 --timeout_overflow_mode "$mode" --query "$query" 2>&1)
+
+    if [ "$mode" = break ]; then
+        # Under `break` the pipeline turns the throw into a graceful finish, so the client sees no error and
+        # the cause is `ProfileEvents['OverflowBreak']`. The row count is read too: `max` over no rows
+        # returns 0, which would otherwise be below the bound and score as a pass.
+        ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS query_log"
+        # shellcheck disable=SC2086
+        read -r rows elapsed_ms breaks < <(${CLICKHOUSE_CLIENT} $LOG_PINS --query "
+            SELECT count(), max(query_duration_ms), max(ProfileEvents['OverflowBreak']) FROM system.query_log
+            WHERE query_id = '$query_id' AND current_database = currentDatabase() AND type != 'QueryStart'")
+        if [ "${rows:-0}" = 0 ]; then
+            echo "$label: NO QUERY LOG ROW"
+        elif [ "${breaks:-0}" = 0 ]; then
+            # A fast failure that never reached the deadline, e.g. an out-of-memory.
+            echo "$label: DEADLINE NEVER OBSERVED (no OverflowBreak)"
+        elif [ "$elapsed_ms" -lt "$BOUND" ]; then
+            echo "$label: stopped within bound"
+        else
+            echo "$label: OVERSHOT ${elapsed_ms} ms"
+        fi
+        return
+    fi
+
+    if ! printf '%s' "$output" | grep -q TIMEOUT_EXCEEDED; then
+        echo "$label: NOT STOPPED BY THE DEADLINE: $(printf '%s' "$output" | grep -oE 'Code: [0-9]+' | head -1)"
+        return
+    fi
+
+    ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS query_log"
+    # shellcheck disable=SC2086
+    code=$(${CLICKHOUSE_CLIENT} $LOG_PINS --query "
+        SELECT max(exception_code) FROM system.query_log
+        WHERE query_id = '$query_id' AND current_database = currentDatabase() AND type != 'QueryStart'")
+    elapsed_ms=$(printf '%s' "$output" | grep -oP 'elapsed \K[0-9]+(?=\.)' | head -1)
+
+    if [ -n "$code" ] && [ "$code" != 159 ]; then
+        echo "$label: WRONG EXCEPTION CODE $code"
+    elif [ -z "$elapsed_ms" ]; then
+        echo "$label: cancelled before the pipeline started"
+    elif [ "$elapsed_ms" -lt "$BOUND" ]; then
+        echo "$label: stopped within bound"
+    else
+        echo "$label: OVERSHOT ${elapsed_ms} ms"
+    fi
+}
+
+# 1. `constantVector`, the shape the hung-check report showed: a constant haystack with a materialized
+#    needle, so the all-constant fold does not apply and every row re-scans the whole 11 MB value.
+run "constant_vector" \
+    "SELECT sum(countSubstringsCaseInsensitiveUTF8($BIG, materialize('a'))) FROM numbers(1000) FORMAT Null SETTINGS max_block_size = 1000, $PINS"
+
+# 2. `vectorVector`, both arguments materialized. The needle repeatedly almost matches, so the searcher
+#    re-examines the row without advancing a match and only the per-row charge can stop it.
+run "vector_vector" \
+    "SELECT sum(countSubstringsCaseInsensitiveUTF8(materialize(repeat('Ж', 200)), materialize(repeat('Ж', 16) || 'Щ'))) FROM numbers(260000) FORMAT Null SETTINGS max_block_size = 260000, $PINS"
+
+# 3. `vectorVector` with the cost inside its inner match loop instead: one row of many matches, so the
+#    per-row charge is spent at row entry and only the per-match charge can stop the rest of the row.
+run "vector_vector_inner" \
+    "SELECT sum(countSubstringsCaseInsensitiveUTF8(materialize(repeat(repeat('Ж', 200) || 'Щ', 260000)), materialize(repeat('Ж', 16) || 'Щ'))) FROM numbers(1) FORMAT Null SETTINGS max_block_size = 1, $PINS"
+
+# 4. `vectorConstant`, a materialized haystack with a constant needle. Its charge is per MATCH, so every
+#    row here ends in one match and the bytes before it are what the searcher works through.
+run "vector_constant" \
+    "SELECT sum(countSubstringsCaseInsensitiveUTF8(materialize(repeat('Ж', 200) || 'Щ'), repeat('Ж', 16) || 'Щ')) FROM numbers(260000) FORMAT Null SETTINGS max_block_size = 260000, $PINS"
+
+# 5. Rows with no match at all, so the inner search loop is never entered and only the per-row charge can
+#    stop the query.
+run "no_match_rows" \
+    "SELECT sum(countSubstringsCaseInsensitiveUTF8(repeat('Ж', 1000000), materialize('ЩЩ'))) FROM numbers(1600) FORMAT Null SETTINGS max_block_size = 1600, $PINS"
+
+# 6. `countSubstrings`, a distinct instantiation over `CaseSensitiveStringSearcher`.
+run "case_sensitive" \
+    "SELECT sum(countSubstrings(repeat('a', 1000000), materialize('a'))) FROM numbers(1800) FORMAT Null SETTINGS max_block_size = 1800, $PINS"
+
+# 7. `countSubstringsCaseInsensitive`, the third instantiation, over `ASCIICaseInsensitiveStringSearcher`.
+run "case_insensitive" \
+    "SELECT sum(countSubstringsCaseInsensitive(repeat('a', 1000000), materialize('A'))) FROM numbers(2200) FORMAT Null SETTINGS max_block_size = 2200, $PINS"
+
+# 8. The `break` overflow mode, where `checkTimeLimit` returns false instead of throwing, so a path that
+#    never calls it ignores the deadline entirely.
+run "constant_vector_break" \
+    "SELECT sum(countSubstringsCaseInsensitiveUTF8($BIG, materialize('a'))) FROM numbers(1000) FORMAT Null SETTINGS max_block_size = 1000, $PINS" \
+    break
+
+# 9. `KILL QUERY`, the channel the report's `is_cancelled = 1` came from: it sets the killed flag and
+#    surfaces through a separate branch of the same check. No time limit is set, so only the kill can stop
+#    the query, and what is asserted is how long the synchronous kill blocks. It carries its own bound
+#    because the two sides are three orders of magnitude apart here.
+KILL_BOUND=$((SCALE * 8000))
+kill_id="04722_kill_${CLICKHOUSE_DATABASE}"
+# The row count is far above what the assertion needs: the target has to still be running when the poll
+# below observes it, and one poll is a whole client invocation. Only the fixed side runs it to the end.
+${CLICKHOUSE_CLIENT} --query_id "$kill_id" \
+    --query "SELECT sum(countSubstringsCaseInsensitiveUTF8($BIG, materialize('a'))) FROM numbers(2500) FORMAT Null SETTINGS max_block_size = 2500, $PINS" \
+    > /dev/null 2>&1 &
+kill_bg=$!
+
+# Waiting for the query to be RUNNING rather than merely visible: `ProcessList` makes it visible before the
+# executor is attached, and a kill winning that race would pass even unfixed.
+kill_seen=0
+for _ in $(seq 1 200); do
+    # shellcheck disable=SC2086
+    if [ "$(${CLICKHOUSE_CLIENT} $LOG_PINS --query "SELECT max(elapsed) > 0.5 FROM system.processes WHERE query_id = '$kill_id'")" = "1" ]; then
+        kill_seen=1
+        break
+    fi
+    sleep 0.05
+done
+
+sync_id="${kill_id}_sync"
+${CLICKHOUSE_CLIENT} --query_id "$sync_id" --query "KILL QUERY WHERE query_id = '$kill_id' SYNC" > /dev/null 2>&1
+wait $kill_bg 2>/dev/null
+${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS query_log"
+
+if [ "$kill_seen" != 1 ]; then
+    echo "kill query: TARGET NEVER REACHED THE SEARCH LOOP"
+else
+    # A kill returning in milliseconds never waited for a running call, so it measures the race and not the
+    # checkpoint. Reported as inconclusive rather than as a pass.
+    # shellcheck disable=SC2086
+    ${CLICKHOUSE_CLIENT} $LOG_PINS --query "
+        SELECT multiIf(count() = 0, 'kill query: NO QUERY LOG ROW',
+                       max(query_duration_ms) < 10, 'kill query: TARGET WAS NOT RUNNING WHEN KILLED',
+                       max(query_duration_ms) < $KILL_BOUND, 'kill query returned promptly',
+                       'kill query BLOCKED ' || toString(max(query_duration_ms)) || 'ms')
+        FROM system.query_log
+        WHERE query_id = '$sync_id' AND current_database = currentDatabase() AND type != 'QueryStart'"
+fi
+
+# 10. Liveness control: with no time limit the functions must still return the documented counts, so a
+#     "fix" that always threw, or throttling that dropped occurrences, would fail here. All three
+#     functions, all four dispatch branches, start positions, multibyte and empty needles.
+${CLICKHOUSE_CLIENT} --multiquery --query "
+SELECT countSubstrings(materialize('abcabcabc'), 'abc'), countSubstringsCaseInsensitive(materialize('AbCabc'), 'abc'), countSubstringsCaseInsensitiveUTF8(materialize('ПРИВЕТпривет'), 'привет');
+SELECT countSubstrings(materialize('aaaa'), materialize('aa')), countSubstringsCaseInsensitive(materialize('XyXy'), materialize('xy')), countSubstringsCaseInsensitiveUTF8(materialize('ЁЖЁж'), materialize('ёж'));
+SELECT countSubstrings('abcabcabc', materialize('abc')), countSubstringsCaseInsensitive('AbCabc', materialize('abc')), countSubstringsCaseInsensitiveUTF8('ПРИВЕТпривет', materialize('привет'));
+SELECT countSubstrings('aaaa', 'aa'), countSubstringsCaseInsensitive('AAaa', 'aa'), countSubstringsCaseInsensitiveUTF8('ЁЁёё', 'ёё');
+SELECT countSubstrings(materialize('abcabcabc'), 'abc', 4), countSubstrings('abcabcabc', materialize('abc'), 4), countSubstrings(materialize('abcabcabc'), materialize('abc'), materialize(toUInt64(7)));
+SELECT countSubstrings(materialize(''), 'a'), countSubstrings(materialize('abc'), ''), countSubstrings('', materialize('a')), countSubstrings('abc', materialize(''));
+SELECT countSubstringsCaseInsensitiveUTF8(materialize(repeat('\\0\\0a', 5)), materialize('a')), countSubstringsCaseInsensitiveUTF8(repeat('\\0\\0a', 5), materialize('a'));
+"
+
+# The rows above stay below the throttle; this one crosses it, so the checkpoint runs at least once with
+# no deadline set and must still return the exact count.
+${CLICKHOUSE_CLIENT} --query "SELECT sum(countSubstringsCaseInsensitiveUTF8($BIG, materialize('a'))) FROM numbers(3) SETTINGS max_block_size = 3, $PINS"


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/112203
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `countSubstrings`, `countSubstringsCaseInsensitive` and `countSubstringsCaseInsensitiveUTF8` ignoring `KILL QUERY` and `max_execution_time`: a call over many rows or many matches could run for minutes after the query was cancelled.

### Description

Related: #112203

A `Stress test (amd_tsan)` hung check reported a query running 767 s with `is_cancelled = 1` set and
`max_execution_time = 10`:

```
SELECT count() FROM (SELECT * FROM (SELECT * FROM system.numbers_mt
    QUALIFY countSubstringsCaseInsensitiveUTF8(repeat('\0\0\0\0\0\0\0\0\0\0a', 1000000),
                                               materialize('a'))
    LIMIT 1025) LIMIT 55)
```

[CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110936&sha=7d086a4de946fdf73c5d7f4458e821a2ddf1aaba&name_0=PR&name_1=Stress%20test%20%28amd_tsan%29)

**Root cause.** `CountSubstringsImpl` has no cancellation checkpoint, and cancellation and the
elapsed-time limit are otherwise only observed between pipeline blocks, so one call runs to completion.
The `materialize`d needle defeats the all-constant fold, giving about a million uninterruptible
iterations per row.

**The change.** Each `CountSubstringsImpl` method builds one `checkTimeLimit` callback per call,
resolving the running query from the executing thread, and charges a throttled, iteration-counted
budget from every unbounded loop. The budget struct and the callback factory move into a shared
header, and `replace*` now uses both.

`FunctionsStringSearch.h` is unchanged, so the budget stays out of the four other implementations
behind that dispatcher, which cover 19 of the 22 functions it instantiates: `position.cpp.o`,
`like.cpp.o`, `match.cpp.o`, `hasToken.cpp.o` and `visitParamHas.cpp.o` are byte-identical to master.

**Known limitation.** The checkpoint runs between searches, so one search must finish first. When one
call gets a very large range and the needle is absent, that search dominates: a 400 MB value takes
about 54 s to stop and a synchronous `KILL QUERY` is held about 53 s. Ordinary rows stay near 1 MB per
call and stop promptly. Bounding the window needs overlap handling at each boundary, so it is left to a
follow-up. `HasTokenImpl::vectorConstant` is also still unchecked.

**Validation.** New test `04722_count_substrings_cancellation.sh` covers all three dispatch branches
and all three public functions, no-match rows, `timeout_overflow_mode = 'break'`, `KILL QUERY` and a
correctness control. Each case asserts the termination cause, not only the duration, and leaves master
at least 3.5x over its bound. 50 runs pass.

<details><summary>Measured server-reported elapsed against a 1000 ms limit, 3 runs per arm</summary>

| case | master (optimized) | master (debug) | this PR |
|---|---|---|---|
| `constantVector` (the report's shape) | 13468-13837 ms | 13525 ms | 1000-1001 ms |
| `vectorVector`, no match within the row | 13413-13459 ms | 13407 ms | 1084-1091 ms |
| `vectorVector`, many matches in one row | 12915-12986 ms | 12899 ms | 1128-1132 ms |
| `vectorConstant` | 12990-13294 ms | 12874 ms | 1037-1046 ms |
| rows with no match | 12981-13080 ms | 13099 ms | 1000-1001 ms |
| `countSubstrings` | 12795-12852 ms | 12892 ms | 1000 ms |
| `countSubstringsCaseInsensitive` | 12501-12610 ms | 12762 ms | 1000 ms |
| `timeout_overflow_mode = 'break'` | 13539-13582 ms | 13686 ms | 1001 ms |
| `KILL QUERY ... SYNC` blocked for | 33452-33759 ms | 33554 ms | 103 ms |

</details>





<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.930` (included in `26.8` and later)
<!-- ch-version-info:end -->