### PR TITLE
Propagate the cluster-function read-task callback into SQL SECURITY views

### DIFF
--- a/src/Storages/StorageInMemoryMetadata.cpp
+++ b/src/Storages/StorageInMemoryMetadata.cpp
@@ -184,6 +184,11 @@ ContextMutablePtr StorageInMemoryMetadata::getSQLSecurityOverriddenContext(Conte
         new_context->setBlockMarshallingCallback(context->getBlockMarshallingCallback());
     }
 
+    /// Transport wiring, not invoker identity: a cluster table function inside the view sends its
+    /// read-task request over this callback, and only the initiator can decide whether to serve it.
+    if (context->hasClusterFunctionReadTaskCallback())
+        new_context->setClusterFunctionReadTaskCallback(context->getClusterFunctionReadTaskCallback());
+
     if (sql_security_type == SQLSecurityType::NONE)
     {
         new_context->applySettingsChanges(context->getSettingsRef().changes());

--- a/tests/queries/0_stateless/04810_definer_view_over_cluster_function.reference
+++ b/tests/queries/0_stateless/04810_definer_view_over_cluster_function.reference
@@ -1,0 +1,40 @@
+--- DEFINER / s3Cluster / enable_analyzer=1 ---
+cannot be nested inside another distributed query
+--- DEFINER / s3Cluster / enable_analyzer=0 ---
+cannot be nested inside another distributed query
+--- DEFINER / urlCluster / enable_analyzer=1 ---
+cannot be nested inside another distributed query
+--- DEFINER / urlCluster / enable_analyzer=0 ---
+cannot be nested inside another distributed query
+--- DEFINER / fileCluster / enable_analyzer=1 ---
+cannot be nested inside another distributed query
+--- DEFINER / fileCluster / enable_analyzer=0 ---
+cannot be nested inside another distributed query
+--- NONE / s3Cluster / enable_analyzer=1 ---
+cannot be nested inside another distributed query
+--- NONE / s3Cluster / enable_analyzer=0 ---
+cannot be nested inside another distributed query
+--- NONE / urlCluster / enable_analyzer=1 ---
+cannot be nested inside another distributed query
+--- NONE / urlCluster / enable_analyzer=0 ---
+cannot be nested inside another distributed query
+--- NONE / fileCluster / enable_analyzer=1 ---
+cannot be nested inside another distributed query
+--- NONE / fileCluster / enable_analyzer=0 ---
+cannot be nested inside another distributed query
+--- INVOKER / s3Cluster / enable_analyzer=1 ---
+cannot be nested inside another distributed query
+--- INVOKER / s3Cluster / enable_analyzer=0 ---
+cannot be nested inside another distributed query
+--- INVOKER / urlCluster / enable_analyzer=1 ---
+cannot be nested inside another distributed query
+--- INVOKER / urlCluster / enable_analyzer=0 ---
+cannot be nested inside another distributed query
+--- INVOKER / fileCluster / enable_analyzer=1 ---
+cannot be nested inside another distributed query
+--- INVOKER / fileCluster / enable_analyzer=0 ---
+cannot be nested inside another distributed query
+--- local read of a DEFINER view still works ---
+1
+--- server alive ---
+1

--- a/tests/queries/0_stateless/04810_definer_view_over_cluster_function.sh
+++ b/tests/queries/0_stateless/04810_definer_view_over_cluster_function.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Tag no-fasttest: uses s3Cluster/urlCluster/fileCluster over Minio and the HTTP port
+
+# A SQL SECURITY DEFINER/NONE view runs its inner query in a context rebuilt from the global
+# context, which used to drop the cluster-function read-task callback. When such a view was read as
+# a secondary query the *Cluster function inside it could no longer reach the initiator that decides
+# whether to serve the read task, and hit a LOGICAL_ERROR that aborts the server in debug builds.
+# The callback is now propagated, so the unsupported nesting is rejected with the same BAD_ARGUMENTS
+# an INVOKER view already produced, and the server stays alive.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+set -u
+
+DATA_FILE="${CLICKHOUSE_DATABASE}_04810.tsv"
+printf '1\n2\n3\n' > "${USER_FILES_PATH}/${DATA_FILE}"
+
+S3_OBJECT="http://localhost:11111/test/${CLICKHOUSE_DATABASE}_04810.tsv"
+$CLICKHOUSE_CLIENT --query "INSERT INTO FUNCTION s3('${S3_OBJECT}', 'TSV', 'x UInt8') SELECT 1 SETTINGS s3_truncate_on_insert = 1"
+
+S3_FN="s3Cluster('test_cluster_two_shards_localhost', '${S3_OBJECT}', 'TSV', 'x UInt8')"
+URL_FN="urlCluster('test_cluster_two_shards_localhost', 'http://localhost:${CLICKHOUSE_PORT_HTTP}/?query=SELECT+1', 'TSV', 'x UInt8')"
+FILE_FN="fileCluster('test_cluster_two_shards_localhost', '${DATA_FILE}', 'TSV', 'x UInt8')"
+
+# prefer_localhost_replica=0 makes the outer remote() ship the view read to the local shard as a
+# real secondary query, which is what turns on distributed processing inside the view. Without it
+# the read stays an initial query and the callback is never needed.
+# INVOKER is the control: it never lost the callback, so its verdict must be identical throughout.
+for security in DEFINER NONE INVOKER; do
+    for fn in s3Cluster urlCluster fileCluster; do
+        case "$fn" in
+            s3Cluster) inner="$S3_FN" ;;
+            urlCluster) inner="$URL_FN" ;;
+            fileCluster) inner="$FILE_FN" ;;
+        esac
+
+        $CLICKHOUSE_CLIENT --query "CREATE OR REPLACE VIEW v_04810 SQL SECURITY ${security} AS SELECT * FROM ${inner}"
+
+        for analyzer in 1 0; do
+            echo "--- ${security} / ${fn} / enable_analyzer=${analyzer} ---"
+            $CLICKHOUSE_CLIENT --query "
+                SELECT count() FROM remote('127.0.0.1:${CLICKHOUSE_PORT_TCP}', currentDatabase(), 'v_04810')
+                SETTINGS prefer_localhost_replica = 0, enable_analyzer = ${analyzer}
+            " 2>&1 | grep -o -m1 "cannot be nested inside another distributed query"
+        done
+    done
+done
+
+$CLICKHOUSE_CLIENT --query "DROP VIEW IF EXISTS v_04810"
+
+# A definer view over a cluster function read locally is a supported query and must keep working.
+echo "--- local read of a DEFINER view still works ---"
+$CLICKHOUSE_CLIENT --query "CREATE OR REPLACE VIEW v_04810 SQL SECURITY DEFINER AS SELECT * FROM ${S3_FN}"
+$CLICKHOUSE_CLIENT --query "SELECT count() FROM v_04810"
+$CLICKHOUSE_CLIENT --query "DROP VIEW v_04810"
+
+# The regression being prevented: BAD_ARGUMENTS must not abort the server.
+echo "--- server alive ---"
+$CLICKHOUSE_CLIENT --query "SELECT 1"
+
+rm -f "${USER_FILES_PATH}/${DATA_FILE}"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110972
-->

Related: #110972

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a `LOGICAL_ERROR` `Next task callback is not set for query` when a `SQL SECURITY DEFINER` or `SQL SECURITY NONE` view over a cluster table function (`s3Cluster`, `urlCluster`, `fileCluster`) was read as a secondary query, for example through `remote` or `clusterAllReplicas`. The unsupported nesting is now rejected with a normal query error instead of aborting the server in debug and sanitizer builds.


### Description

Found by CI: [Stress test (amd_tsan) on #110972](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110972&sha=9864b7ce87ce62565d1333f1e336c2f19da6d1fe&name_0=PR&name_1=Stress%20test%20%28amd_tsan%29). 6 hits in 30 days, over 5 unrelated pull requests by different authors plus one master run, so it is a trunk bug, not any one PR's fault.

What breaks: a `SELECT` through a `SQL SECURITY DEFINER` or `NONE` view over a cluster table function aborts a debug or sanitizer server when that `SELECT` arrives as a secondary query. The failing CI query was `SELECT count() FROM remoteSecure(..., 'test_view')`, wrapped by the AST fuzzer. Read locally the view always worked, so no stateless test caught this.

Root cause: `StorageInMemoryMetadata::getSQLSecurityOverriddenContext` rebuilds the view context from the global context for those two branches, so the definer does not inherit the invoker's identity, then re-propagates query state item by item. It carried the three MergeTree parallel-replicas callbacks but not `next_task_callback`, so the cluster function inside the view could not reach the initiator that decides whether to serve its read task. The ordinary `Context` copy constructor does carry it, and `INVOKER` uses that constructor, so an `INVOKER` view already worked: the omission was accidental, not policy.

The fix propagates the callback for the other two branches, above the `NONE` early return so both are covered, mirroring `7f75908b72374e3` which fixed the same bug class here for the MergeTree callbacks. The unsupported nesting then lands on the existing rejection in `RemoteQueryExecutor::processReadTaskRequest` and reports `BAD_ARGUMENTS`, as `INVOKER` already did, with the server alive. Legitimate distribution is unaffected, since those paths install a task iterator on the initiator, and the `LOGICAL_ERROR` at the three consumers stays a genuine invariant.

New test `04810_definer_view_over_cluster_function` covers the three security modes across the three cluster functions and both analyzers, with `INVOKER` as control.

<details>
<summary>Validation matrix (18 cells, before and after)</summary>

Note on a similar message: `Context::getMergeTreeAllRangesCallback` throws `Next task callback is not set for query with id:`, but reads a different member. That is the parallel-replicas variant tracked by #111677, which this PR does not address.

Each cell is a `SQL SECURITY <mode>` view over the named cluster function, read via `remote(...)` with `prefer_localhost_replica = 0`. The server was restarted before every cell and its `buildId` asserted against the binary under test, because a `LOGICAL_ERROR` aborts a debug server and would otherwise silently blind later cells.

| cell | pristine HEAD | with this change |
|---|---|---|
| DEFINER / s3Cluster, urlCluster, fileCluster (analyzer 1 and 0) | LOGICAL_ERROR, server aborted (6/6) | BAD_ARGUMENTS, server alive (6/6) |
| NONE / s3Cluster, urlCluster, fileCluster (analyzer 1 and 0) | LOGICAL_ERROR, server aborted (6/6) | BAD_ARGUMENTS, server alive (6/6) |
| INVOKER / s3Cluster, urlCluster, fileCluster (analyzer 1 and 0) | BAD_ARGUMENTS, server alive (6/6) | BAD_ARGUMENTS, server alive (6/6) |

The `INVOKER` row is the control: it never lost the callback, and its verdict is identical on both arms, so the difference in the other twelve cells is attributable to the change rather than to the environment.

Test `04810` fails on pristine HEAD with the `LOGICAL_ERROR` in the server log and passes with the change; 50/50 passes with randomized settings. `03850_nested_cluster_table_function_task_iterator` passes unchanged, which is the evidence that legitimate distribution still reads each task exactly once, as does `03667_view_with_s3_cluster_and_sql_security_definer`. A 56-test sweep of everything touching a cluster table function or `SQL SECURITY` gives identical verdicts on both arms.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.813` (included in `26.8` and later)
<!-- ch-version-info:end -->