### PR TITLE
Infer an omitted Buffer structure under the user's context

### DIFF
--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -15,6 +15,7 @@
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Interpreters/getColumnFromBlock.h>
 #include <Interpreters/ExpressionActions.h>
+#include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTInsertQuery.h>
@@ -177,6 +178,8 @@ StorageBuffer::StorageBuffer(
     , bg_pool(getContext()->getBufferFlushSchedulePool())
 {
     StorageInMemoryMetadata storage_metadata;
+    /// Reached when loading already-validated metadata, which stores no column list for this engine.
+    /// A freshly created table infers its structure in `registerStorageBuffer` under the user's context.
     if (columns_.empty())
     {
         auto dest_table = DatabaseCatalog::instance().getTable(destination_id, context_);
@@ -1486,9 +1489,22 @@ void registerStorageBuffer(StorageFactory & factory)
             destination_id.table_name = destination_table;
         }
 
+        /// An omitted structure is inferred here, under the user's context: `StorageBuffer` holds only
+        /// a long-lived context and would read the destination's columns with no user at all. Loading
+        /// of already-validated metadata has no user either, so it keeps inferring in the constructor.
+        ColumnsDescription columns = args.columns;
+        if (columns.empty() && !destination_id.empty()
+            && !(isLoadingFromExistingMetadata(args.mode) || args.query.attach_short_syntax))
+        {
+            args.getLocalContext()->checkAccess(AccessType::SHOW_COLUMNS, destination_id);
+            auto destination = DatabaseCatalog::instance().getTable(destination_id, args.getLocalContext());
+            auto destination_metadata = destination->getInMemoryMetadataPtr(args.getLocalContext(), false);
+            columns = destination_metadata->getColumns();
+        }
+
         return std::make_shared<StorageBuffer>(
             args.table_id,
-            args.columns,
+            columns,
             args.constraints,
             args.comment,
             args.getContext(),

--- a/tests/queries/0_stateless/03631_buffer_access_check.sh
+++ b/tests/queries/0_stateless/03631_buffer_access_check.sh
@@ -17,6 +17,9 @@ DROP USER IF EXISTS $user;
 CREATE USER $user;
 GRANT SELECT, CREATE, INSERT ON $db.test_buffer TO $user;
 GRANT TABLE ENGINE ON Buffer TO $user;
+-- Creating the buffer without a column list infers the structure from the destination, which needs
+-- SHOW COLUMNS on it. The read and write checks asserted below require SELECT and INSERT instead.
+GRANT SHOW COLUMNS ON $db.test_table TO $user;
 EOF
 
 ${CLICKHOUSE_CLIENT} --user $user --query "CREATE TABLE $db.test_buffer ENGINE = Buffer($db, test_table, 1, 10, 100, 10000, 1000000, 10000000, 100000000)"

--- a/tests/queries/0_stateless/04729_buffer_infer_columns_access.reference
+++ b/tests/queries/0_stateless/04729_buffer_infer_columns_access.reference
@@ -1,0 +1,16 @@
+-- 1. the destination's schema is not visible by the sanctioned route
+1
+-- 1. omitted columns, no rights on the destination: rejected
+1
+-- 2. omitted columns, with SHOW COLUMNS: allowed and inferred from the destination
+x	UInt64
+secret_column	String
+-- 3. a short ATTACH still works after the grant is revoked
+x	UInt64
+secret_column	String
+-- 4. explicit columns, no rights on the destination: still allowed
+x	UInt64
+-- 5. a temporary table with omitted columns is checked too
+1
+-- 6. SELECT on the destination implies SHOW COLUMNS, so reading users are unaffected
+42	shh

--- a/tests/queries/0_stateless/04729_buffer_infer_columns_access.sh
+++ b/tests/queries/0_stateless/04729_buffer_infer_columns_access.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database
+# no-replicated-database: on a replicated / shared-catalog database the DDL runs with no user, so the
+# access check asserted here is a no-op and the deny path silently allows.
+# Blocked on https://github.com/ClickHouse/ClickHouse/issues/111561 - re-enable when fixed.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+db=${CLICKHOUSE_DATABASE}
+user="user_04729_${CLICKHOUSE_DATABASE}"
+
+${CLICKHOUSE_CLIENT} <<EOF
+DROP USER IF EXISTS $user;
+CREATE TABLE $db.protected_target (x UInt64, secret_column String) ENGINE = MergeTree ORDER BY x;
+INSERT INTO $db.protected_target VALUES (42, 'shh');
+
+CREATE USER $user;
+-- The user may create tables in its own database, but starts without any rights on the destination
+-- the engine points at, so the check below is exercised in isolation.
+GRANT CREATE TABLE, DROP TABLE, SELECT, INSERT ON $db.* TO $user;
+GRANT CREATE TEMPORARY TABLE ON *.* TO $user;
+GRANT TABLE ENGINE ON Buffer TO $user;
+REVOKE SELECT, INSERT ON $db.protected_target FROM $user;
+EOF
+
+echo "-- 1. the destination's schema is not visible by the sanctioned route"
+${CLICKHOUSE_CLIENT} --user "$user" --query "DESCRIBE $db.protected_target" 2>&1 \
+    | grep -c -m1 "ACCESS_DENIED\|Not enough privileges"
+
+echo "-- 1. omitted columns, no rights on the destination: rejected"
+${CLICKHOUSE_CLIENT} --user "$user" --query \
+    "CREATE TABLE $db.b ENGINE = Buffer('$db', 'protected_target', 1, 10, 100, 10000, 1000000, 10000000, 100000000)" 2>&1 \
+    | grep -c -m1 "ACCESS_DENIED\|Not enough privileges"
+
+echo "-- 2. omitted columns, with SHOW COLUMNS: allowed and inferred from the destination"
+${CLICKHOUSE_CLIENT} --query "GRANT SHOW COLUMNS ON $db.protected_target TO $user"
+${CLICKHOUSE_CLIENT} --user "$user" --query \
+    "CREATE TABLE $db.b ENGINE = Buffer('$db', 'protected_target', 1, 10, 100, 10000, 1000000, 10000000, 100000000)"
+${CLICKHOUSE_CLIENT} --user "$user" --query \
+    "SELECT name, type FROM system.columns WHERE database = '$db' AND table = 'b' ORDER BY position"
+
+echo "-- 3. a short ATTACH still works after the grant is revoked"
+${CLICKHOUSE_CLIENT} --query "REVOKE SHOW COLUMNS ON $db.protected_target FROM $user"
+${CLICKHOUSE_CLIENT} --user "$user" --query "DETACH TABLE $db.b"
+${CLICKHOUSE_CLIENT} --user "$user" --query "ATTACH TABLE $db.b"
+${CLICKHOUSE_CLIENT} --user "$user" --query \
+    "SELECT name, type FROM system.columns WHERE database = '$db' AND table = 'b' ORDER BY position"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE $db.b"
+
+echo "-- 4. explicit columns, no rights on the destination: still allowed"
+${CLICKHOUSE_CLIENT} --user "$user" --query \
+    "CREATE TABLE $db.b_explicit (x UInt64) ENGINE = Buffer('$db', 'protected_target', 1, 10, 100, 10000, 1000000, 10000000, 100000000)"
+${CLICKHOUSE_CLIENT} --user "$user" --query \
+    "SELECT name, type FROM system.columns WHERE database = '$db' AND table = 'b_explicit' ORDER BY position"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE $db.b_explicit"
+
+echo "-- 5. a temporary table with omitted columns is checked too"
+${CLICKHOUSE_CLIENT} --user "$user" --query \
+    "CREATE TEMPORARY TABLE tmp_b ENGINE = Buffer('$db', 'protected_target', 1, 10, 100, 10000, 1000000, 10000000, 100000000)" 2>&1 \
+    | grep -c -m1 "ACCESS_DENIED\|Not enough privileges"
+
+echo "-- 6. SELECT on the destination implies SHOW COLUMNS, so reading users are unaffected"
+${CLICKHOUSE_CLIENT} --query "GRANT SELECT ON $db.protected_target TO $user"
+${CLICKHOUSE_CLIENT} --user "$user" --query \
+    "CREATE TABLE $db.b_select ENGINE = Buffer('$db', 'protected_target', 1, 10, 100, 10000, 1000000, 10000000, 100000000)"
+${CLICKHOUSE_CLIENT} --user "$user" --query "SELECT x, secret_column FROM $db.b_select ORDER BY x"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE $db.b_select"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS $user"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE $db.protected_target"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113220
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a case where `CREATE TABLE ... ENGINE = Buffer(...)` without a column list could reveal the structure of a destination table the creating user is not allowed to see. For a `CREATE` the local server executes itself, the structure is now inferred under the user's own context, so `SHOW COLUMNS` on the destination is required, as it already is for `Merge` and `Remote`. A `CREATE` replayed from the DDL queue (`ON CLUSTER`, or inside a `Replicated` database) is not covered.


### Description

Related: #113220, the `Distributed` sibling. No related open issue; found while sweeping the engines that infer an omitted structure from a local table.

**What breaks.** A user with `CREATE TABLE` on its own database can learn the columns and types of any local table by creating a columns-less `Buffer` over it and describing its own table. `Buffer` declares no `source_access_type`, so `TABLE ENGINE ON Buffer` is auto-granted on a default server and is the only other privilege needed. The inferred columns are persisted, so it survives a restart. Reads and writes were already authorized, so this is disclosure-only.

**Root cause.** The constructor infers the structure from the destination's in-memory metadata (`StorageBuffer.cpp:180-185`), and neither `DatabaseCatalog::getTable` nor `getInMemoryMetadataPtr` checks access. It is handed `args.getContext()`, which `StorageFactory::get` asserts is the global context, so there is no user to check. Master's own `03631_buffer_access_check` already records the bypass.

**The change.** The inference moves into `registerStorageBuffer`, where the user's context exists, with an unconditional `SHOW_COLUMNS` check -- the shape `Merge` (`StorageMerge.cpp:213`) and `Remote` (`StorageDistributed.cpp:2592`) already have. It is skipped for already-validated metadata (`isLoadingFromExistingMetadata || attach_short_syntax`), which has no user and stores no column list; the constructor keeps its branch for that path only. `SHOW_COLUMNS` is implied by `SELECT`, so readers are unaffected, and explicit-column creates are unchanged.

**Scope.** A queue-replayed `CREATE` reaches the engine with no user, so the check is a no-op there. `ON CLUSTER` sets one only with `distributed_ddl_use_initial_user_and_roles` on *and* `distributed_ddl_entry_format_version` at least 8 (default 5); a `Replicated` database records no initiator. Both want #113073.

**Validation.** New `04729_buffer_infer_columns_access` covers the denial, inference after the grant, explicit columns, temporary tables and re-attach; it fails on master and 50 randomized runs pass here. `03631` gains a `SHOW COLUMNS` grant so its create still reaches its own unchanged assertions.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.4.6`, `26.6.3.15`, `26.5.7.17`, `26.3.18.9`, `25.8.30.6`
<!-- ch-version-info:end -->