### PR TITLE
Detect gtest suites registered with GTEST_TEST in bugfix validation

### DIFF
--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -53,7 +53,11 @@ BEFORE_BINARY = f"{BEFORE_SRC}/build/src/unit_tests_dbms"
 BUILD_TYPE = BuildTypes.AMD_ASAN_UBSAN
 
 # gtest test-registration macros whose first argument is the test-suite name.
+# `TEST`/`TEST_F` are `#define`d to `GTEST_TEST`/`GTEST_TEST_F`, so both spellings of
+# each register a suite and both must be listed here.
 _GTEST_MACROS = (
+    "GTEST_TEST",
+    "GTEST_TEST_F",
     "TEST",
     "TEST_F",
     "TEST_P",

--- a/ci/tests/test_new_tests_check.py
+++ b/ci/tests/test_new_tests_check.py
@@ -34,6 +34,10 @@ from ci.defs.defs import JobNames
 from ci.jobs.scripts.workflow_hooks import new_tests_check
 from ci.praktika.result import Result
 
+# `_install_stubs` replaces `has_new_unit_tests` with a path-classification stub; keep
+# the real one so a test can opt back into the actual gtest-macro parsing.
+_REAL_HAS_NEW_UNIT_TESTS = new_tests_check.has_new_unit_tests
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -358,6 +362,37 @@ def test_unit_only_passes_without_per_arch(monkeypatch):
         changed_files=["src/Functions/tests/gtest_my_unit.cpp"],
         workflow_subresults=[],
     )
+    assert new_tests_check.check() is True
+
+
+def test_unit_only_gtest_test_macro_takes_the_unit_branch(monkeypatch, tmp_path):
+    """A unit test registered with `GTEST_TEST` must enable the `has_unit` branch.
+
+    Unlike the cases above, this one does NOT stub `has_new_unit_tests`: the file is
+    written to disk and the real predicate (which parses the gtest macros) runs. With
+    no CI-report link in the body, `check()` can only return True through the
+    `has_unit` branch, so it is a witness that the suite was recognized.
+    """
+    src = tmp_path / "src" / "Functions" / "tests"
+    src.mkdir(parents=True)
+    (src / "gtest_my_unit.cpp").write_text(
+        "#include <gtest/gtest.h>\nGTEST_TEST(MySuite, my_case) { EXPECT_TRUE(false); }\n"
+    )
+    changed = ["src/Functions/tests/gtest_my_unit.cpp"]
+    _install_stubs(
+        monkeypatch,
+        pr_body="A change.\n\n- [x]  Bug Fix\n",
+        changed_files=changed,
+        workflow_subresults=[],
+    )
+    # Restore the real predicate that `_install_stubs` replaced, and resolve the
+    # relative changed path against the fixture tree.
+    monkeypatch.setattr(
+        new_tests_check, "has_new_unit_tests", _REAL_HAS_NEW_UNIT_TESTS
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert new_tests_check.has_new_unit_tests(changed) is True
     assert new_tests_check.check() is True
 
 

--- a/ci/tests/test_unit_tests_bugfix_validation.py
+++ b/ci/tests/test_unit_tests_bugfix_validation.py
@@ -93,10 +93,16 @@ TEST_P(SuiteC, case_three) {}
 TYPED_TEST(SuiteD, case_four) {}
 TYPED_TEST_P(SuiteE, case_five) {}
 
+GTEST_TEST(SuiteG, case_six) {}        // `TEST` is #define'd to this
+GTEST_TEST_F(SuiteH, case_seven) {}    // `TEST_F` is #define'd to this
+
    TEST_F  (  SuiteF , spaced ) {}     // odd spacing must still match
 // TEST(CommentedOut, nope) {}         // commented-out line must be ignored
+// GTEST_TEST(CommentedOutG, nope) {}  // commented-out line must be ignored
 MY_TEST(NotAMacro, nope) {}            // macro as a substring must not match
+MY_GTEST_TEST(AlsoNotAMacro, nope) {}  // macro as a substring must not match
 EXPECT_TEST(AlsoNot, nope);            // macro as a substring must not match
+GTEST_TEST_(SuiteX, nope) {}           // trailing underscore is a different token
 TEST(SuiteA, duplicate_suite) {}       // duplicate suite collapses
 """
 
@@ -111,6 +117,8 @@ def test_derive_test_suites_all_macro_forms(tmp_path):
         "SuiteD",
         "SuiteE",
         "SuiteF",
+        "SuiteG",
+        "SuiteH",
     ]
 
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`_GTEST_MACROS` in `ci/jobs/unit_tests_bugfix_validation_job.py` was missing `GTEST_TEST`.
gtest defines `TEST` *as* `GTEST_TEST` (`gtest.h:2192`, primary at `:2185`; same for
`TEST_F`/`GTEST_TEST_F`), and 48 registrations across 15 files under `src/**/tests` use the primary
spelling. `derive_test_suites` therefore returned `[]` for such a file, and the validator read that
as "this PR has no unit tests" rather than "the parser did not understand this file": it finalizes
`OK` with "No gtest test suites found ... nothing to validate". A green check that validated
nothing.

`new_tests_check.has_new_unit_tests` deliberately imports the same predicate, so the merge gate's
unit branch is not entered either. What that costs depends on the rest of the PR: one that also
adds functional or integration tests is decided by the stricter per-arch branch and is unaffected
(`new_tests_check.py:213` tests those paths first), while a unit-only PR passes on the
CI-report-link fallback if its body carries such a link.

Not hypothetical: over 60 days the "No gtest test suites found" verdict fired 13 times across 5
PRs, and 3 of those 5 do contain gtest cases the regex could not see - including #111191, a merged
bugfix PR that shipped 5 `GTEST_TEST` cases across 3 new files with its unit validation skipped.

The fix adds `GTEST_TEST` and `GTEST_TEST_F` to the tuple; no verdict or policy changes and the
existing entries are not reordered. A 16-case probe matrix pins every registration form plus seven
negatives (substring, trailing underscore, instantiation, commented-out), each new assertion is
pinned by a mutation arm, and over `origin/master` 15 files go from 0 to >=1 derived suites with 0
regressions and 408/408 already-visible files unchanged.

A `pr-bugfix` PR whose `GTEST_TEST` test genuinely passes on the merge base will now be blocked
where it previously slipped through, and such PRs now run a before-build they previously skipped
(off the critical path).

<details>
<summary>The "No gtest test suites found" verdict, CIDB 60 d, classified per PR</summary>

Each `class` below is the verdict of the VALIDATOR, not the outcome of the merge gate: #111191,
#110997 and #106961 also add `0_stateless` tests, so all three were gate-decided by the per-arch
branch either way.

| PR | rows | state / author | changed unit-test file(s) | `GTEST_TEST` | hook-visible | class |
|---|---|---|---|---|---|---|
| #111191 | 3 | merged, alexey-milovidov | 3x `gtest_block_*.cpp` | 2+2+1 | 0 | false negative |
| #110997 | 4 | open, mine | `gtest_aggregate_function_version_race.cpp` | 10 | 0 | false negative |
| #106961 | 4 | open, mine | `gtest_saturated_duration.cpp`, `gtest_settings.cpp` | 11+9 | 0 | false negative |
| #109747 | 1 | open, mine | `gtest_actions_dag_partial_result_type_drift.cpp` | 0 | 9 | control (renamed, suite visible) |
| #113225 | 1 | open, mine | none match `src/**/tests/` | - | - | legitimate no-op |

Exactly one file still derives 0 suites after the fix:
`src/Coordination/tests/gtest_coordination_common.cpp` carries only `INSTANTIATE_TEST_SUITE_P`,
whose first argument is a prefix and not a suite name; its two suites are declared in the four
sibling files that include its header, and `build_gtest_filter` already emits the `*/Suite.*`
pattern that picks up instantiated cases. So "15 files" is not "the parser now sees everything".

Registration-macro census in `src/**/tests` at `origin/master`: `TEST` 2477, `TEST_F` 447,
`TEST_P` 212, `GTEST_TEST` 48, `TYPED_TEST` 22, `GTEST_TEST_F` 0, `TYPED_TEST_P` 0. So
`GTEST_TEST` was the only macro in use that the list missed; `GTEST_TEST_F` is listed for symmetry,
as `TYPED_TEST_P` already is at 0 users.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.791` (included in `26.8` and later)
<!-- ch-version-info:end -->