### PR TITLE
Fix TTLDrop merge of a table with a text index or an inert index

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -1035,9 +1035,13 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
     /// When other TTL families are present, TTLTransform::finalize rebuilds
     /// their maps from scratch, and replicating that logic here would be
     /// fragile. hasOnlyRowsTTL already excludes WHERE-clause TTLs.
+    ///
+    /// A merge cancelled after selection has `need_remove_expired_values` cleared above and must
+    /// not drop rows, so it falls through to the normal pipeline, which builds no TTLTransform.
     const bool can_short_circuit_ttl_drop =
         global_ctx->future_part->merge_type == MergeType::TTLDrop
-        && global_ctx->metadata_snapshot->hasOnlyRowsTTL();
+        && global_ctx->metadata_snapshot->hasOnlyRowsTTL()
+        && ctx->need_remove_expired_values;
 
     if (can_short_circuit_ttl_drop)
     {

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -1080,15 +1080,27 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
         global_ctx->skip_indexes_by_column.clear();
         global_ctx->text_indexes_to_merge.clear();
 
-        auto all_skip_indexes = global_ctx->metadata_snapshot->getSecondaryIndices();
-        for (const auto & index : all_skip_indexes)
+        /// Repopulate only when the setting asks for it: the clear above this branch already
+        /// honoured `materialize_skip_indexes_on_merge = 0`, and putting the indexes back would
+        /// override the user's choice on a TTLDrop merge only.
+        if ((*merge_tree_settings)[MergeTreeSetting::materialize_skip_indexes_on_merge])
         {
-            if (!exclude_index_names.contains(index.name))
+            auto all_skip_indexes = global_ctx->metadata_snapshot->getSecondaryIndices();
+            for (const auto & index : all_skip_indexes)
             {
-                if (index.type == "text")
-                    global_ctx->text_indexes_to_merge.push_back(index);
-                else
-                    global_ctx->merging_skip_indexes.push_back(index);
+                if (!exclude_index_names.contains(index.name))
+                {
+                    /// Inert indices (a removed index type kept only for attach compatibility) hold
+                    /// no data and cannot be recomputed. Skip them so the merge does not wedge
+                    /// trying to aggregate them.
+                    if (MergeTreeIndexFactory::instance().get(global_ctx->metadata_snapshot, index, *global_ctx->data_settings)->isInert())
+                        continue;
+
+                    if (index.type == "text")
+                        global_ctx->text_indexes_to_merge.push_back(index);
+                    else
+                        global_ctx->merging_skip_indexes.push_back(index);
+                }
             }
         }
     }
@@ -2469,7 +2481,12 @@ bool MergeTask::MergeTextIndexStage::prepare() const
         auto index_ptr = MergeTreeIndexFactory::instance().get(global_ctx->metadata_snapshot, index, *global_ctx->data_settings);
         std::vector<TextIndexSegment> segments;
 
-        if (global_ctx->merge_may_reduce_rows)
+        if (global_ctx->ttl_drop_short_circuit)
+        {
+            /// No read pipeline ran, so no transform built segments. The resulting part has no
+            /// rows, which is exactly what a 0-row pipeline would have produced anyway.
+        }
+        else if (global_ctx->merge_may_reduce_rows)
         {
             /// Text index was built for the resulting part.
             segments = getTextIndexSegments(global_ctx->new_data_part->name, index.name, 0);

--- a/tests/queries/0_stateless/04790_ttl_drop_merge_text_index.reference
+++ b/tests/queries/0_stateless/04790_ttl_drop_merge_text_index.reference
@@ -13,3 +13,7 @@ idx_txt	text	0
 i0	hypothesis	0
 idx_txt	text	1
 1
+-- Case 4: default TTL settings
+0
+1
+1

--- a/tests/queries/0_stateless/04790_ttl_drop_merge_text_index.reference
+++ b/tests/queries/0_stateless/04790_ttl_drop_merge_text_index.reference
@@ -10,4 +10,6 @@ idx_txt	text	0
 -- Case 3: inert index
 1
 0
+i0	hypothesis	0
+idx_txt	text	1
 1

--- a/tests/queries/0_stateless/04790_ttl_drop_merge_text_index.reference
+++ b/tests/queries/0_stateless/04790_ttl_drop_merge_text_index.reference
@@ -1,0 +1,13 @@
+-- Case 1: text index
+0
+idx_txt	text	1
+1
+-- Case 2: materialize_skip_indexes_on_merge = 0 is respected
+0
+idx_set	set	0
+idx_txt	text	0
+1
+-- Case 3: inert index
+1
+0
+1

--- a/tests/queries/0_stateless/04790_ttl_drop_merge_text_index.sh
+++ b/tests/queries/0_stateless/04790_ttl_drop_merge_text_index.sh
@@ -48,7 +48,9 @@ ${CLICKHOUSE_CLIENT} -q "
     SETTINGS
         ttl_only_drop_parts = 1,
         merge_with_ttl_timeout = 0,
-        min_bytes_for_wide_part = 1;
+        min_bytes_for_wide_part = 1,
+        -- keep the 0-row part so the index assertions below have something to read
+        remove_empty_parts = 0;
 
     SYSTEM STOP MERGES t_ttl_drop_text;
 
@@ -98,7 +100,8 @@ ${CLICKHOUSE_CLIENT} -q "
         ttl_only_drop_parts = 1,
         merge_with_ttl_timeout = 0,
         min_bytes_for_wide_part = 1,
-        materialize_skip_indexes_on_merge = 0;
+        materialize_skip_indexes_on_merge = 0,
+        remove_empty_parts = 0;
 
     SYSTEM STOP MERGES t_ttl_drop_no_materialize;
 
@@ -128,16 +131,21 @@ echo "-- Case 3: inert index"
 # A legacy 'hypothesis' index is inert: it holds no data and cannot be recomputed, so
 # createIndexAggregator rejects it with ILLEGAL_INDEX. The short-circuit used to omit the
 # isInert filter the normal path applies, which wedged the merge and left the rows in place.
+# The non-inert sibling pins that the filter is per index rather than per table: it must still
+# materialize while the inert one is skipped.
 # Full-definition ATTACH is the only way to get such a table, and it needs an explicit UUID.
 uuid=$(${CLICKHOUSE_CLIENT} -q "SELECT generateUUIDv4()")
 ${CLICKHOUSE_CLIENT} -q "
     SET send_logs_level = 'fatal';
+    SET allow_experimental_full_text_index = 1;
 
     ATTACH TABLE t_ttl_drop_inert UUID '$uuid'
     (
         id UInt64,
+        value String,
         event_time DateTime DEFAULT now() - INTERVAL 2 DAY,
-        INDEX i0 90 % id TYPE hypothesis
+        INDEX i0 90 % id TYPE hypothesis,
+        INDEX idx_txt value TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1
     )
     ENGINE = MergeTree()
     PRIMARY KEY tuple()
@@ -145,7 +153,8 @@ ${CLICKHOUSE_CLIENT} -q "
     SETTINGS
         ttl_only_drop_parts = 1,
         merge_with_ttl_timeout = 0,
-        min_bytes_for_wide_part = 1;
+        min_bytes_for_wide_part = 1,
+        remove_empty_parts = 0;
 "
 
 ${CLICKHOUSE_CLIENT} -q "
@@ -156,8 +165,8 @@ ${CLICKHOUSE_CLIENT} -q "
 ${CLICKHOUSE_CLIENT} -q "
     SYSTEM STOP MERGES t_ttl_drop_inert;
 
-    INSERT INTO t_ttl_drop_inert (id) SELECT number FROM numbers(100);
-    INSERT INTO t_ttl_drop_inert (id) SELECT number + 100 FROM numbers(100);
+    INSERT INTO t_ttl_drop_inert (id, value) SELECT number, 'w' || toString(number) FROM numbers(100);
+    INSERT INTO t_ttl_drop_inert (id, value) SELECT number + 100, 'w' || toString(number) FROM numbers(100);
 
     SYSTEM START MERGES t_ttl_drop_inert;
 "
@@ -165,5 +174,14 @@ ${CLICKHOUSE_CLIENT} -q "
 wait_for_ttl_drop "t_ttl_drop_inert"
 
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_ttl_drop_inert;"
+
+# The inert index is skipped individually; its non-inert sibling still gets materialized.
+${CLICKHOUSE_CLIENT} -q "
+    SELECT name, type, data_compressed_bytes > 0
+    FROM system.data_skipping_indices
+    WHERE database = currentDatabase() AND table = 't_ttl_drop_inert'
+    ORDER BY name;
+"
+
 ${CLICKHOUSE_CLIENT} -q "CHECK TABLE t_ttl_drop_inert SETTINGS check_query_single_value_result = 1;"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_inert;"

--- a/tests/queries/0_stateless/04790_ttl_drop_merge_text_index.sh
+++ b/tests/queries/0_stateless/04790_ttl_drop_merge_text_index.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Tags: long
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# A TTLDrop merge takes the short-circuit that skips the read pipeline. Every index the
+# resulting empty part must still carry has to be handled there, because the builders that
+# normally produce them live inside the skipped pipeline.
+#
+# OPTIMIZE TABLE FINAL always assigns MergeType::Regular and so bypasses the short-circuit.
+# The cases below therefore drive a background TTL merge (merge_with_ttl_timeout = 0) and
+# wait for it, bounded by wall-clock time rather than a fixed iteration count.
+
+function wait_for_ttl_drop()
+{
+    local table=$1
+    local deadline=$((SECONDS + 90))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        local rows
+        rows=$(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM $table")
+        if [ "$rows" = "0" ]; then
+            return
+        fi
+        sleep 0.5
+    done
+    echo "timed out waiting for the TTL drop merge on $table"
+}
+
+echo "-- Case 1: text index"
+
+# Before the fix the merge threw LOGICAL_ERROR 'Text index transform for index ... not found'
+# and retried forever, so the expired rows were never dropped.
+${CLICKHOUSE_CLIENT} -q "
+    SET allow_experimental_full_text_index = 1;
+
+    CREATE TABLE t_ttl_drop_text
+    (
+        id UInt64,
+        value String,
+        event_time DateTime DEFAULT now() - INTERVAL 2 DAY,
+        INDEX idx_txt value TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1
+    )
+    ENGINE = MergeTree()
+    ORDER BY id
+    TTL event_time + INTERVAL 1 DAY
+    SETTINGS
+        ttl_only_drop_parts = 1,
+        merge_with_ttl_timeout = 0,
+        min_bytes_for_wide_part = 1;
+
+    SYSTEM STOP MERGES t_ttl_drop_text;
+
+    INSERT INTO t_ttl_drop_text (id, value) SELECT number, 'w' || toString(number) FROM numbers(100);
+    INSERT INTO t_ttl_drop_text (id, value) SELECT number, 'w' || toString(number) FROM numbers(100);
+
+    SYSTEM START MERGES t_ttl_drop_text;
+"
+
+wait_for_ttl_drop "t_ttl_drop_text"
+
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_ttl_drop_text;"
+
+# The empty part must still carry the text index files, byte-for-byte as the normal 0-row
+# path writes them: a replica that fetches the part compares checksums, so an index dropped
+# here would diverge. data_compressed_bytes counts the serialized index header, which is
+# non-empty even with no tokens -- it reads 0 when the index files are missing entirely.
+${CLICKHOUSE_CLIENT} -q "
+    SELECT name, type, data_compressed_bytes > 0
+    FROM system.data_skipping_indices
+    WHERE database = currentDatabase() AND table = 't_ttl_drop_text';
+"
+
+${CLICKHOUSE_CLIENT} -q "CHECK TABLE t_ttl_drop_text SETTINGS check_query_single_value_result = 1;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_text;"
+
+echo "-- Case 2: materialize_skip_indexes_on_merge = 0 is respected"
+
+# The 'forget about skip indexes' clear runs before the short-circuit, which used to put
+# every index straight back -- so the setting was honoured for a normal merge and silently
+# ignored for a TTLDrop merge. With a text index that also reintroduced case 1's failure.
+${CLICKHOUSE_CLIENT} -q "
+    SET allow_experimental_full_text_index = 1;
+
+    CREATE TABLE t_ttl_drop_no_materialize
+    (
+        id UInt64,
+        value String,
+        event_time DateTime DEFAULT now() - INTERVAL 2 DAY,
+        INDEX idx_txt value TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1,
+        INDEX idx_set id TYPE set(100) GRANULARITY 1
+    )
+    ENGINE = MergeTree()
+    ORDER BY id
+    TTL event_time + INTERVAL 1 DAY
+    SETTINGS
+        ttl_only_drop_parts = 1,
+        merge_with_ttl_timeout = 0,
+        min_bytes_for_wide_part = 1,
+        materialize_skip_indexes_on_merge = 0;
+
+    SYSTEM STOP MERGES t_ttl_drop_no_materialize;
+
+    INSERT INTO t_ttl_drop_no_materialize (id, value) SELECT number, 'w' || toString(number) FROM numbers(100);
+    INSERT INTO t_ttl_drop_no_materialize (id, value) SELECT number, 'w' || toString(number) FROM numbers(100);
+
+    SYSTEM START MERGES t_ttl_drop_no_materialize;
+"
+
+wait_for_ttl_drop "t_ttl_drop_no_materialize"
+
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_ttl_drop_no_materialize;"
+
+# The setting suppresses both index families, so neither writes any files.
+${CLICKHOUSE_CLIENT} -q "
+    SELECT name, type, data_compressed_bytes > 0
+    FROM system.data_skipping_indices
+    WHERE database = currentDatabase() AND table = 't_ttl_drop_no_materialize'
+    ORDER BY name;
+"
+
+${CLICKHOUSE_CLIENT} -q "CHECK TABLE t_ttl_drop_no_materialize SETTINGS check_query_single_value_result = 1;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_no_materialize;"
+
+echo "-- Case 3: inert index"
+
+# A legacy 'hypothesis' index is inert: it holds no data and cannot be recomputed, so
+# createIndexAggregator rejects it with ILLEGAL_INDEX. The short-circuit used to omit the
+# isInert filter the normal path applies, which wedged the merge and left the rows in place.
+# Full-definition ATTACH is the only way to get such a table, and it needs an explicit UUID.
+uuid=$(${CLICKHOUSE_CLIENT} -q "SELECT generateUUIDv4()")
+${CLICKHOUSE_CLIENT} -q "
+    SET send_logs_level = 'fatal';
+
+    ATTACH TABLE t_ttl_drop_inert UUID '$uuid'
+    (
+        id UInt64,
+        event_time DateTime DEFAULT now() - INTERVAL 2 DAY,
+        INDEX i0 90 % id TYPE hypothesis
+    )
+    ENGINE = MergeTree()
+    PRIMARY KEY tuple()
+    TTL event_time + INTERVAL 1 DAY
+    SETTINGS
+        ttl_only_drop_parts = 1,
+        merge_with_ttl_timeout = 0,
+        min_bytes_for_wide_part = 1;
+"
+
+${CLICKHOUSE_CLIENT} -q "
+    SELECT count() FROM system.data_skipping_indices
+    WHERE database = currentDatabase() AND table = 't_ttl_drop_inert' AND type = 'hypothesis';
+"
+
+${CLICKHOUSE_CLIENT} -q "
+    SYSTEM STOP MERGES t_ttl_drop_inert;
+
+    INSERT INTO t_ttl_drop_inert (id) SELECT number FROM numbers(100);
+    INSERT INTO t_ttl_drop_inert (id) SELECT number + 100 FROM numbers(100);
+
+    SYSTEM START MERGES t_ttl_drop_inert;
+"
+
+wait_for_ttl_drop "t_ttl_drop_inert"
+
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_ttl_drop_inert;"
+${CLICKHOUSE_CLIENT} -q "CHECK TABLE t_ttl_drop_inert SETTINGS check_query_single_value_result = 1;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_inert;"

--- a/tests/queries/0_stateless/04790_ttl_drop_merge_text_index.sh
+++ b/tests/queries/0_stateless/04790_ttl_drop_merge_text_index.sh
@@ -9,9 +9,9 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # resulting empty part must still carry has to be handled there, because the builders that
 # normally produce them live inside the skipped pipeline.
 #
-# OPTIMIZE TABLE FINAL always assigns MergeType::Regular and so bypasses the short-circuit.
-# The cases below therefore drive a background TTL merge (merge_with_ttl_timeout = 0) and
-# wait for it, bounded by wall-clock time rather than a fixed iteration count.
+# Only the background selector assigns MergeType::TTLDrop; OPTIMIZE TABLE FINAL assigns
+# MergeType::Regular. Every case below therefore drives a background TTL merge and waits for
+# it, bounded by wall-clock time rather than a fixed iteration count.
 
 function wait_for_ttl_drop()
 {
@@ -185,3 +185,48 @@ ${CLICKHOUSE_CLIENT} -q "
 
 ${CLICKHOUSE_CLIENT} -q "CHECK TABLE t_ttl_drop_inert SETTINGS check_query_single_value_result = 1;"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_inert;"
+
+echo "-- Case 4: default TTL settings"
+
+# TTLDrop selection ignores merge_with_ttl_timeout: TTLPartDropMergeSelector passes a null
+# merge_due_times, and selectPartsToMerge schedules no next time for MergeType::TTLDrop. So
+# the short-circuit is reachable with every TTL setting left at its default, including
+# ttl_only_drop_parts = 0, which the cases above do not cover.
+#
+# No OPTIMIZE here: with one level-0 part it would select a MergeType::Regular merge of its
+# own and could empty the table through the normal pipeline before the background TTLDrop is
+# picked up. Only the background selector produces the merge type this case is about.
+${CLICKHOUSE_CLIENT} -q "
+    SET allow_experimental_full_text_index = 1;
+
+    CREATE TABLE t_ttl_drop_default
+    (
+        c0 UInt64,
+        c1 Date,
+        c2 String,
+        INDEX idx0 c2 TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1
+    )
+    ENGINE = MergeTree()
+    ORDER BY c0
+    TTL c1 + INTERVAL 1 SECOND DELETE;
+
+    INSERT INTO t_ttl_drop_default SELECT number, toDate('2020-01-01'), 'w' || toString(number) FROM numbers(100);
+"
+
+wait_for_ttl_drop "t_ttl_drop_default"
+
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_ttl_drop_default;"
+
+# Emptying the table is not enough on its own: assert the merge that did it was a TTLDrop
+# that succeeded and read no rows. error = 0 excludes the failed-and-retried merge the
+# unfixed code produced, which MergePlainMergeTreeTask also logs under this merge_reason;
+# read_rows = 0 is what distinguishes the skipped pipeline from one that ran.
+${CLICKHOUSE_CLIENT} -q "
+    SYSTEM FLUSH LOGS part_log;
+    SELECT countIf(merge_reason = 'TTLDropMerge' AND error = 0 AND read_rows = 0) > 0
+    FROM system.part_log
+    WHERE database = currentDatabase() AND table = 't_ttl_drop_default' AND event_type = 'MergeParts';
+"
+
+${CLICKHOUSE_CLIENT} -q "CHECK TABLE t_ttl_drop_default SETTINGS check_query_single_value_result = 1;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_default;"


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/113223
Related: https://github.com/ClickHouse/ClickHouse/pull/105859
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a `MergeTree` table with a rows `TTL` and a `text` index never dropping its expired parts: the `TTLDrop` merge failed with `Text index transform for index ... not found` and retried forever.


### Description

Closes: #113223. Related: #105859.

A `MergeTree` table with an unconditional rows TTL and a `text` index never dropped its expired
parts: the TTLDrop merge failed with `LOGICAL_ERROR: Text index transform for index ... not found`
and retried forever.

#105859 added a short-circuit that skips the read pipeline for a TTLDrop merge but still
repopulates the skip-index containers, so the 0-row part carries the same index files. The text
index transform is built only inside the skipped `createMergedStream`, so `MergeTextIndexStage`
looked up one that never existed.

The fix builds the text index with an empty segment list -- exactly what a 0-row pipeline hands
over, since there the transform is registered but emits nothing
(`BuildTextIndexTransform::finalize` writes a segment only for a non-empty aggregator). Clearing
the container instead would diverge from a replica, because the normal 0-row path writes and
checksums those files (measured: all six `skp_idx_*`, 29-byte header).

Three more guards were missing from the same block, a copy of the Horizontal setup:

- the `isInert` filter, so a legacy `hypothesis` index reached `createIndexAggregator` and threw
  `ILLEGAL_INDEX`, wedging an attached legacy table with a rows TTL;
- the `materialize_skip_indexes_on_merge = 0` check, honoured for a normal merge but ignored here;
- `need_remove_expired_values`, cleared when TTL merges are cancelled after selection. Such a
  merge now takes the normal pipeline, which builds no `TTLTransform` and keeps the rows, rather
  than emitting a 0-row part and dropping them.

The first three reproduce deterministically; the new test fails on pristine `master` and passes
here, 50/50 randomized runs pass, and `04082`, `04267`, `03737` and `04500` pass -- `04267` pins
that a genuine TTLDrop still reads 0 rows, so the optimization is intact. The cancellation guard
has no test hook, as the same `prepare` already throws `ABORTED` when the blocker is set on entry.

#### Update 2026-09-19: still unfixed on `master`, and the changelog category was wrong

The bug is a regression that shipped: a production report on 26.8.2.7 is in the thread below, and
26.6.1 is clean, which brackets it to #105859. The category is therefore
`Bug Fix (user-visible misbehavior in an official stable release)`, not `Not for changelog`
(the `v26.8-must-backport` label was already set).

It keeps aborting fuzzer jobs. Master CI carrier of 2026-09-19:
https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=5ea18126eb8e645ebcfc5c4e86591e4f5a56e30a&name_0=MasterCI&name_1=BuzzHouse%20%28amd_debug%29
— `d8.t252` is a `MergeTree` with `TTL c4 - toIntervalSecond(65535)` and
`INDEX i0 c3 TYPE text(...)`, and `server.log` logs
`TTLDrop merge: skipping data pipeline, all 1 source parts are fully expired` immediately before
the abort. CIDB counts 11 hits of this STID between 2026-08-09 and 2026-09-19, across
`BuzzHouse (amd_debug / amd_msan / amd_tsan)`, two of them on `master`.

The branch has been merged with `master` (25480 commits). The merge is clean and was produced with
`git merge-tree`, so **nothing was rebuilt or re-tested locally** — CI is the check. `MergeTask.cpp`
changed a lot on `master` since the fork point, but not in the two regions this branch edits, and
the net diff against `master` is still only these three files. The previous head's two red jobs
were both unrelated: `Docs examples` was the date-dependent `toYYYYMM` example, fixed by #117459
and picked up by this merge, and `Container memory budget exceeded (/docker)` was a fleet-wide
infrastructure event on the day that CI ran (576 hits across 261 pull requests on 2026-08-31).

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=113385&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/113385](https://github.com/search?q=head%3Async-upstream%2Fpr%2F113385+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.9.1.1616`, `26.8.9.11`
<!-- ch-version-info:end -->