### PR TITLE
Recognize nested `*Settings.cpp` files in the `feature_docs` hook

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/feature_docs.py
+++ b/ci/jobs/scripts/workflow_hooks/feature_docs.py
@@ -1,5 +1,4 @@
 import sys
-from pathlib import PurePosixPath
 
 from praktika.info import Info
 
@@ -41,8 +40,6 @@ source_owned_doc_paths = inline_doc_paths + [
     "src/Storages/",
 ]
 
-source_owned_doc_globs = [f"src/**/*{suffix}" for suffix in embedded_doc_suffixes]
-
 source_owned_doc_markers = (
     "FunctionDocumentation",
     "Documentation{",
@@ -70,9 +67,11 @@ def is_source_owned_doc(file_path):
     ) and file_contains_any_marker(file_path, source_owned_doc_markers):
         return True
 
-    return any(
-        PurePosixPath(file_path).match(glob) for glob in source_owned_doc_globs
-    ) and file_contains_any_marker(file_path, settings_doc_markers)
+    return (
+        file_path.startswith("src/")
+        and file_path.endswith(tuple(embedded_doc_suffixes))
+        and file_contains_any_marker(file_path, settings_doc_markers)
+    )
 
 
 def check_docs():


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

`ci/jobs/scripts/workflow_hooks/feature_docs.py` accepts embedded settings documentation (the `DECLARE` docstrings from which the settings reference pages are autogenerated) by matching changed files against the glob `src/**/*Settings.cpp` / `src/**/*Settings.h` with `PurePosixPath.match`. But `PurePosixPath.match` treats `**` like a single `*`, so the glob matched `src/Core/Settings.cpp` and `src/Core/FormatFactorySettings.h`, yet not the more deeply nested `src/Storages/MergeTree/MergeTreeSettings.cpp`. As a result, a `pr-feature` PR that adds a new MergeTree setting together with its `DECLARE` docstring — the only correct place to document it, since `docs/reference/settings/**` is autogenerated and direct edits there are rejected — failed the hook with "No documentation changes found, please update the documentation".

Replace the glob with an explicit `src/` prefix + suffix check, keeping the existing `DECLARE_SETTING` / `DECLARE(` content-marker requirement.

Seen on https://github.com/ClickHouse/ClickHouse/pull/113020 ([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113020&sha=c6ca56a5bc62a9b8c5e1b853f623f4b4d4e19fbe&name_0=PR&name_1=Finish%20Workflow)).

Related: https://github.com/ClickHouse/ClickHouse/pull/113020


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.785` (included in `26.8` and later)
<!-- ch-version-info:end -->