### PR TITLE
Docs: state Managed Postgres credential handling once, as steady-state behavior

### DIFF
--- a/docs/products/managed-postgres/openapi.mdx
+++ b/docs/products/managed-postgres/openapi.mdx
@@ -79,12 +79,6 @@ like:
 
 Let's explore the lifecycle of a Postgres service.
 
-<Warning>
-**Credential redaction**
-
-The API does not return the `password` and `connectionString` properties in its responses. They appear only in the [create](#create) response and [password reset] response when the request contained no password. We recommend that you capture credentials from the [create](#create) response. If you manage services with Terraform, use provider **v3.21.0 or later** (see the [Terraform reference](/products/managed-postgres/terraform)).
-</Warning>
-
 ### Create {#create}
 
 First, create a new one
@@ -111,7 +105,9 @@ create_data='{
 ```
 
 Now use this data to create a new instance; note that it requires the content
-type header. Save the response in order to have access to the credentials it returns:
+type header. Save the response: it is the only one that includes the service
+credentials (the [password reset] response also returns them when the request
+does not supply a password):
 
 ```bash
 pg_created=$(curl -s --user "$KEY_ID:$KEY_SECRET" -H 'Content-Type: application/json' \
@@ -158,7 +154,8 @@ curl -s --user "$KEY_ID:$KEY_SECRET" \
     | jq
 ```
 
-The output will be similar to the JSON returned for creation (but without the `password` and `connectionString` properties), but keep an eye
+The output will be similar to the JSON returned for creation, minus the
+credentials, but keep an eye
 on the `state`; when it changes to `running`, the server is ready:
 
 ```bash

--- a/docs/products/managed-postgres/openapi.mdx
+++ b/docs/products/managed-postgres/openapi.mdx
@@ -80,9 +80,9 @@ like:
 Let's explore the lifecycle of a Postgres service.
 
 <Warning>
-**Credential redaction from July 31, 2026**
+**Credential redaction**
 
-As of **July 31, 2026**, the API no longer returns the `password` and `connectionString` properties in its responses. They appear only in the [create](#create) response and [password reset] response when the request contained no password. We recommend that you capture credentials from the [create](#create) response. If you manage services with Terraform, upgrade the provider to **v3.21.0 or later** before July 31, 2026 (see the [Terraform reference](/products/managed-postgres/terraform)).
+The API does not return the `password` and `connectionString` properties in its responses. They appear only in the [create](#create) response and [password reset] response when the request contained no password. We recommend that you capture credentials from the [create](#create) response. If you manage services with Terraform, use provider **v3.21.0 or later** (see the [Terraform reference](/products/managed-postgres/terraform)).
 </Warning>
 
 ### Create {#create}
@@ -158,7 +158,7 @@ curl -s --user "$KEY_ID:$KEY_SECRET" \
     | jq
 ```
 
-The output will be similar to the JSON returned for creation (but without the `password` and `connectionString` properties after July 31, 2026), but keep an eye
+The output will be similar to the JSON returned for creation (but without the `password` and `connectionString` properties), but keep an eye
 on the `state`; when it changes to `running`, the server is ready:
 
 ```bash
@@ -217,9 +217,7 @@ The returned data should include the new tags:
       "value": "production"
     }
   ],
-  "connectionString": "postgres://postgres:vV6cfEr2p_-TzkCDrZOx@my-postgres-6d8d2e3e.$PG_ID.c0.us-west-2.aws.pg.clickhouse-dev.com:5432/postgres?channel_binding=require",
   "username": "postgres",
-  "password": "vV6cfEr2p_-TzkCDrZOx",
   "hostname": "my-postgres-6d8d2e3e.$PG_ID.c0.us-west-2.aws.pg.clickhouse-dev.com",
   "isPrimary": true,
   "state": "running"

--- a/docs/products/managed-postgres/terraform.mdx
+++ b/docs/products/managed-postgres/terraform.mdx
@@ -17,12 +17,6 @@ ClickHouse Managed Postgres services can be created and managed using the `click
 This resource is in alpha and its behavior may change in future provider versions. It ships in the regular provider build. This page documents provider version **v3.21.0** and later. See the [provider releases](https://github.com/ClickHouse/terraform-provider-clickhouse/releases) for details.
 </Note>
 
-<Warning>
-**Upgrading from a provider earlier than v3.21.0**
-
-Earlier provider versions expect the API to echo credentials back and no longer work: they leave `connection_string` empty, and a service created without a declared `password` comes up with a generated password that is never captured anywhere. Upgrade to **v3.21.0** or later; your state migrates automatically on the first plan or apply. If any of your services rely on a server-generated password (no `password` in configuration), recover it first with `terraform state pull` and declare it, since v3.21.0 requires `password` or `password_wo` for a standard service.
-</Warning>
-
 ## Provider setup {#provider-setup}
 
 Add the ClickHouse provider to your Terraform configuration:

--- a/docs/products/managed-postgres/terraform.mdx
+++ b/docs/products/managed-postgres/terraform.mdx
@@ -14,15 +14,15 @@ import { BetaBadge } from "/snippets/components/BetaBadge/BetaBadge.jsx";
 ClickHouse Managed Postgres services can be created and managed using the `clickhouse_postgres_service` resource in the [ClickHouse Terraform provider](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs/resources/postgres_service). This page covers provider setup and configuration examples for the resource and its companion data sources.
 
 <Note>
-This resource is in alpha and its behavior may change in future provider versions. It ships in the regular provider build. This page documents provider version **v3.21.0** and later, which changed how credentials are managed; earlier versions behave differently and as of July 31, 2026 no longer work correctly. See the [provider releases](https://github.com/ClickHouse/terraform-provider-clickhouse/releases) for details.
+This resource is in alpha and its behavior may change in future provider versions. It ships in the regular provider build. This page documents provider version **v3.21.0** and later, which changed how credentials are managed; earlier versions no longer work correctly. See the [provider releases](https://github.com/ClickHouse/terraform-provider-clickhouse/releases) for details.
 </Note>
 
 <Warning>
-**Upgrade to provider v3.21.0 before July 31, 2026**
+**Provider v3.21.0 or later is required**
 
-As of **July 31, 2026**, the ClickHouse Managed Postgres API ceased to return the superuser password and connection string in its responses; credentials are returned only when a service is created or its password is reset. Provider versions **v3.21.0 and later** work identically before and after this change. Older provider versions rely on the API echoing credentials: as of July 31, 2026, they no longer populate `connection_string`, and a service created without a declared `password` succeeds while the generated password is never captured anywhere.
+The ClickHouse Managed Postgres API does not return the superuser password or connection string in its responses; credentials are returned only when a service is created or its password is reset. Provider versions **v3.21.0 and later** handle this. Older provider versions rely on the API echoing credentials: they do not populate `connection_string`, and a service created without a declared `password` succeeds while the generated password is never captured anywhere.
 
-Upgrade before July 31, 2026. Your state migrates automatically on the first plan or apply with v3.21.0. If any of your services rely on a server-generated password (no `password` in configuration), recover it first with `terraform state pull` and declare it, since v3.21.0 requires `password` or `password_wo` for a standard service.
+Your state migrates automatically on the first plan or apply with v3.21.0. If any of your services rely on a server-generated password (no `password` in configuration), recover it first with `terraform state pull` and declare it, since v3.21.0 requires `password` or `password_wo` for a standard service.
 </Warning>
 
 ## Provider setup {#provider-setup}

--- a/docs/products/managed-postgres/terraform.mdx
+++ b/docs/products/managed-postgres/terraform.mdx
@@ -14,15 +14,13 @@ import { BetaBadge } from "/snippets/components/BetaBadge/BetaBadge.jsx";
 ClickHouse Managed Postgres services can be created and managed using the `clickhouse_postgres_service` resource in the [ClickHouse Terraform provider](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs/resources/postgres_service). This page covers provider setup and configuration examples for the resource and its companion data sources.
 
 <Note>
-This resource is in alpha and its behavior may change in future provider versions. It ships in the regular provider build. This page documents provider version **v3.21.0** and later, which changed how credentials are managed; earlier versions no longer work correctly. See the [provider releases](https://github.com/ClickHouse/terraform-provider-clickhouse/releases) for details.
+This resource is in alpha and its behavior may change in future provider versions. It ships in the regular provider build. This page documents provider version **v3.21.0** and later. See the [provider releases](https://github.com/ClickHouse/terraform-provider-clickhouse/releases) for details.
 </Note>
 
 <Warning>
-**Provider v3.21.0 or later is required**
+**Upgrading from a provider earlier than v3.21.0**
 
-The ClickHouse Managed Postgres API does not return the superuser password or connection string in its responses; credentials are returned only when a service is created or its password is reset. Provider versions **v3.21.0 and later** handle this. Older provider versions rely on the API echoing credentials: they do not populate `connection_string`, and a service created without a declared `password` succeeds while the generated password is never captured anywhere.
-
-Your state migrates automatically on the first plan or apply with v3.21.0. If any of your services rely on a server-generated password (no `password` in configuration), recover it first with `terraform state pull` and declare it, since v3.21.0 requires `password` or `password_wo` for a standard service.
+Earlier provider versions expect the API to echo credentials back and no longer work: they leave `connection_string` empty, and a service created without a declared `password` comes up with a generated password that is never captured anywhere. Upgrade to **v3.21.0** or later; your state migrates automatically on the first plan or apply. If any of your services rely on a server-generated password (no `password` in configuration), recover it first with `terraform state pull` and declare it, since v3.21.0 requires `password` or `password_wo` for a standard service.
 </Warning>
 
 ## Provider setup {#provider-setup}
@@ -69,7 +67,7 @@ The `clickhouse_postgres_service` resource has the following arguments:
 | `read_replica_of` | No | ID of a primary service to replicate. See [Read replicas](#read-replicas). Mutually exclusive with `restore_to_point_in_time`. |
 | `restore_to_point_in_time` | No | Create the service by restoring another service to a point in time. See [Point-in-time restore](#point-in-time-restore). Mutually exclusive with `read_replica_of`. |
 
-The following attributes are read-only and populated by ClickHouse Cloud after creation: `id`, `state`, `created_at`, `is_primary`, `hostname`, `port`, and `username`. There is no `connection_string` attribute (removed in v3.21.0): build connection URIs from `hostname`, `port`, `username`, and the password you declare, for example `postgres://${username}:${password}@${hostname}:${port}/postgres?sslmode=require`.
+The following attributes are read-only and populated by ClickHouse Cloud after creation: `id`, `state`, `created_at`, `is_primary`, `hostname`, `port`, and `username`. There is no `connection_string` attribute: build connection URIs from `hostname`, `port`, `username`, and the password you declare, for example `postgres://${username}:${password}@${hostname}:${port}/postgres?sslmode=require`.
 
 <Warning>
 The `password` is stored in plain text in your Terraform state. Protect your state file accordingly, for example with a remote backend using encryption at rest, or use `password_wo` to keep the password out of state entirely.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

---

Builds on #113268 (the port of clickhouse-docs#6614) and supersedes it unless its author prefers to cherry-pick the follow-up commits.

#113268 removed the July 31, 2026 dates but kept the transition-era framing: "the API does not return `password` and `connectionString`" was still spelled out in full three times across the two pages (openapi warning, terraform note, terraform warning). Redaction is simply how the API behaves, so this PR states credential handling once, at the point of use, and drops the announcement-style callouts and version-history asides entirely:

**openapi.mdx**
- The "Credential redaction" warning at the top of the CRUD section is gone. Its content moved into the create step, where the reader actually needs it: save the create response, it is the only one that includes the credentials (with the password-reset caveat).
- The read step's parenthetical listing the exact redacted property names is trimmed to "minus the credentials".
- The Terraform provider-version pointer is dropped here; the Terraform page covers its own requirements.

**terraform.mdx**
- The upgrade warning is removed entirely; the page documents current behavior only. The provider-setup snippet already pins `version = ">= 3.21.0"`.
- The alpha note no longer explains credential-management history; it just states which provider version the page documents.
- "(removed in v3.21.0)" dropped from the `connection_string` attribute note.
- The two existing point-of-use mentions (password rules paragraph, import section) carry the explanation.

No behavioral or factual changes, wording only.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1256` (included in `26.8` and later)
<!-- ch-version-info:end -->