### PR TITLE
Build OpenSSL from portable C sources under MemorySanitizer

### DIFF
--- a/contrib/openssl-cmake/CMakeLists.txt
+++ b/contrib/openssl-cmake/CMakeLists.txt
@@ -47,6 +47,11 @@ option(OPENSSL_NO_ASM "Build OpenSSL from the portable C sources instead of the 
 if(NOT (ARCH_AMD64 OR ARCH_AARCH64 OR ARCH_PPC64LE OR ARCH_S390X OR ARCH_RISCV64 OR ARCH_LOONGARCH64))
     message(STATUS "OpenSSL: no assembly for ${CMAKE_SYSTEM_PROCESSOR}, building the portable C sources")
     set(OPENSSL_NO_ASM ON)
+elseif(SANITIZE STREQUAL "memory")
+    # MemorySanitizer cannot instrument assembly, so an asm cipher core leaves its output buffer
+    # poisoned. Upstream's `Configure` disables asm under MSan for this reason.
+    message(STATUS "OpenSSL: MSan build, building the portable C sources instead of the assembly")
+    set(OPENSSL_NO_ASM ON)
 endif()
 
 if(OPENSSL_NO_ASM)


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/113164
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/113164

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

MSan reports `use-of-uninitialized-value` in `ASN1_get_object` while a TLS 1.3 session ticket
is decrypted, through `tls_decrypt_ticket` -> `d2i_SSL_SESSION_ex` ->
`Poco::Net::SecureSocketImpl::completeHandshake`. No uninitialized read is involved:
`tls_decrypt_ticket` (`ssl/t1_lib.c:3242-3248`) decrypts into an `OPENSSL_malloc` buffer with
AES-256-CBC, which on amd64 and aarch64 dispatches into hand-written assembly MSan cannot
instrument, so the buffer is filled without its shadow being updated and stays poisoned.

Upstream disables assembly under MSan for this reason, `Configure:707`:
`sub { !$disabled{"msan"} } => [ "asm" ]`. `contrib/openssl-cmake` hand-transcribes the build
and never transcribed that cascade, so both MSan builds link the full assembly. The ten-plus
existing `__msan_unpoison` calls are this same class fixed one call site at a time; the cascade
covers all 38 assembly objects on amd64 and 22 on aarch64, via the `OPENSSL_NO_ASM` arm from
`e67d8f6ba7860eb`.

Cost, since the linked issue is about `amd_msan` stateless shards nearing their 9000 s budget:
a tight AES-CBC kernel is 2.71x slower, a mixed stateless batch only 1.06x, so on that issue's
6731 s p50 roughly +400 s of its ~1660 s headroom. Material, and worth weighing against an
open-ended series of per-call-site unpoison patches. Build time and size unchanged.

Validation, reproducible from public CI artifacts with no build. Run the `Build (amd_msan)`
`clickhouse` artifact of a recent master as a server with `tcp_port_secure` configured, under
`MSAN_OPTIONS=abort_on_error=0:exitcode=0:halt_on_error=0`:

```bash
# control: full handshakes, no session ticket -> 0 reports
for i in $(seq 5); do echo | openssl s_client -connect 127.0.0.1:PORT -tls1_3 -no_ticket; done
# one ticket resumption -> the stack above, twice
echo | openssl s_client -connect 127.0.0.1:PORT -tls1_3 -sess_out s.pem -quiet
echo | openssl s_client -connect 127.0.0.1:PORT -tls1_3 -sess_in s.pem
```

`-quiet` is load-bearing, otherwise no ticket is written and the resumption never happens. This
head's own `amd_msan` artifact gives 0 reports over 8 resumptions, all confirmed `Reused`.

0 assembly objects under `SANITIZE=memory`, 38/22 under `SANITIZE=`/`SANITIZE=address`, both
architectures. Crypto output byte-identical across 23 assertions plus an HTTPS fetch. No test,
as in `e67d8f6ba7860eb`: a link-time property of one build flavour the stateless suite cannot
assert.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.826` (included in `26.8` and later)
<!-- ch-version-info:end -->