### PR TITLE
Add test: `precision > max_precision` rejection of a Parquet DECIMAL whose physical type is too narrow is untested

### DIFF
--- a/tests/queries/0_stateless/04671_parquet_decimal_precision_exceeds_physical_type.reference
+++ b/tests/queries/0_stateless/04671_parquet_decimal_precision_exceeds_physical_type.reference
@@ -1,4 +1,4 @@
 -- INT32 physical with declared precision 18 (exceeds 9): rejected
-INCORRECT_DATA
+precision or scale is too big
 -- INT64 physical with declared precision 38 (exceeds 18): rejected
-INCORRECT_DATA
+precision or scale is too big

--- a/tests/queries/0_stateless/04671_parquet_decimal_precision_exceeds_physical_type.reference
+++ b/tests/queries/0_stateless/04671_parquet_decimal_precision_exceeds_physical_type.reference
@@ -1,0 +1,4 @@
+-- INT32 physical with declared precision 18 (exceeds 9): rejected
+INCORRECT_DATA
+-- INT64 physical with declared precision 38 (exceeds 18): rejected
+INCORRECT_DATA

--- a/tests/queries/0_stateless/04671_parquet_decimal_precision_exceeds_physical_type.sh
+++ b/tests/queries/0_stateless/04671_parquet_decimal_precision_exceeds_physical_type.sh
@@ -25,31 +25,45 @@ PREC = {9: bytes([0x15, 0x12]), 18: bytes([0x15, 0x24]), 38: bytes([0x15, 0x4C])
 
 def patch_precision(path, was, now):
     b = bytearray(open(path, "rb").read())
+    assert b[:4] == b"PAR1" and b[-4:] == b"PAR1", "not a parquet file"
     flen = struct.unpack("<I", b[-8:-4])[0]
     start = len(b) - 8 - flen
     foot = b[start:start + flen]
     assert foot.count(SCALE2 + PREC[was]) >= 1, f"declared precision {was} absent"
-    b[start:start + flen] = foot.replace(SCALE2 + PREC[was], SCALE2 + PREC[now])
+    patched = foot.replace(SCALE2 + PREC[was], SCALE2 + PREC[now])
+    # Prove the widen actually landed: the old precision varint is gone and the new one is present,
+    # so the footer now declares Decimal(now, 2) over the same, untouched physical element.
+    assert SCALE2 + PREC[was] not in patched and patched.count(SCALE2 + PREC[now]) >= 1, \
+        f"precision {was} -> {now} rewrite did not take"
+    b[start:start + flen] = patched
     open(path, "wb").write(bytes(b))
 
 
-def write(name, physical_precision, declare):
+def write(name, physical_precision, declare, physical):
     path = os.path.join(OUT, name + ".parquet")
     vals = [decimal.Decimal(f"{i}.{i % 100:02d}") for i in range(20)]
     pq.write_table(pa.table({"k": pa.array(vals, type=pa.decimal128(physical_precision, 2))}),
                    path, use_dictionary=True, compression="none", version="2.6",
                    store_decimal_as_integer=True, write_statistics=True)
+    # Prove the physical layout is the narrow integer type the guard keys off, while the file is
+    # still spec-valid. This must run pre-patch: once patch_precision widens the declared precision
+    # past what INT32/INT64 can hold, pyarrow itself refuses to open the file (the very spec
+    # violation the guard rejects), so a post-patch pq.ParquetFile read is impossible here.
+    c = pq.ParquetFile(path).schema.column(0)
+    assert c.physical_type == physical, f"{name}: physical {c.physical_type}, wanted {physical}"
+    assert str(c.logical_type) == f"Decimal(precision={physical_precision}, scale=2)", \
+        f"{name}: pre-patch logical {c.logical_type}"
     patch_precision(path, physical_precision, declare)
 
 
 # INT32 physical (max 9 digits), declared precision 18 -> 18 > 9.
-write("int32_prec18", 9, 18)
+write("int32_prec18", 9, 18, "INT32")
 # INT64 physical (max 18 digits), declared precision 38 -> 38 > 18.
-write("int64_prec38", 18, 38)
+write("int64_prec38", 18, 38, "INT64")
 PYEOF
 
 echo '-- INT32 physical with declared precision 18 (exceeds 9): rejected'
-$CLICKHOUSE_LOCAL -q "SELECT count() FROM file('$DATA/int32_prec18.parquet', Parquet)" 2>&1 | grep -o -m1 'INCORRECT_DATA'
+$CLICKHOUSE_LOCAL -q "SELECT count() FROM file('$DATA/int32_prec18.parquet', Parquet)" 2>&1 | grep -o -m1 'precision or scale is too big'
 
 echo '-- INT64 physical with declared precision 38 (exceeds 18): rejected'
-$CLICKHOUSE_LOCAL -q "SELECT count() FROM file('$DATA/int64_prec38.parquet', Parquet)" 2>&1 | grep -o -m1 'INCORRECT_DATA'
+$CLICKHOUSE_LOCAL -q "SELECT count() FROM file('$DATA/int64_prec38.parquet', Parquet)" 2>&1 | grep -o -m1 'precision or scale is too big'

--- a/tests/queries/0_stateless/04671_parquet_decimal_precision_exceeds_physical_type.sh
+++ b/tests/queries/0_stateless/04671_parquet_decimal_precision_exceeds_physical_type.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: needs pyarrow to craft the fixtures, and Parquet is not built in fasttest.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+DATA="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}"
+rm -rf "$DATA"
+mkdir -p "$DATA"
+trap 'rm -rf "$DATA"' EXIT
+
+# A DECIMAL whose declared precision cannot fit its physical element (INT32 caps at 9 digits, INT64
+# at 18) is spec-violating. The reader must reject it, not decode into a too-narrow column.
+python3 - "$DATA" <<'PYEOF'
+import decimal, os, struct, sys
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+OUT = sys.argv[1]
+SCALE2 = bytes([0x15, 0x04])
+PREC = {9: bytes([0x15, 0x12]), 18: bytes([0x15, 0x24]), 38: bytes([0x15, 0x4C])}
+
+
+def patch_precision(path, was, now):
+    b = bytearray(open(path, "rb").read())
+    flen = struct.unpack("<I", b[-8:-4])[0]
+    start = len(b) - 8 - flen
+    foot = b[start:start + flen]
+    assert foot.count(SCALE2 + PREC[was]) >= 1, f"declared precision {was} absent"
+    b[start:start + flen] = foot.replace(SCALE2 + PREC[was], SCALE2 + PREC[now])
+    open(path, "wb").write(bytes(b))
+
+
+def write(name, physical_precision, declare):
+    path = os.path.join(OUT, name + ".parquet")
+    vals = [decimal.Decimal(f"{i}.{i % 100:02d}") for i in range(20)]
+    pq.write_table(pa.table({"k": pa.array(vals, type=pa.decimal128(physical_precision, 2))}),
+                   path, use_dictionary=True, compression="none", version="2.6",
+                   store_decimal_as_integer=True, write_statistics=True)
+    patch_precision(path, physical_precision, declare)
+
+
+# INT32 physical (max 9 digits), declared precision 18 -> 18 > 9.
+write("int32_prec18", 9, 18)
+# INT64 physical (max 18 digits), declared precision 38 -> 38 > 18.
+write("int64_prec38", 18, 38)
+PYEOF
+
+echo '-- INT32 physical with declared precision 18 (exceeds 9): rejected'
+$CLICKHOUSE_LOCAL -q "SELECT count() FROM file('$DATA/int32_prec18.parquet', Parquet)" 2>&1 | grep -o -m1 'INCORRECT_DATA'
+
+echo '-- INT64 physical with declared precision 38 (exceeds 18): rejected'
+$CLICKHOUSE_LOCAL -q "SELECT count() FROM file('$DATA/int64_prec38.parquet', Parquet)" 2>&1 | grep -o -m1 'INCORRECT_DATA'


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #113046](https://github.com/ClickHouse/ClickHouse/pull/113046).
PR fixes an out-of-bounds write when the native v3 Parquet reader reads a `DECIMAL` column whose physical element is wider than its declared precision maps to (e.g. `DECIMAL(9,2)` stored as physical `INT64`). In `SchemaConverter::processPrimitiveColumn` (src/Processors/Formats/Impl/Parquet/SchemaCon

**1. `precision > max_precision` rejection of a Parquet DECIMAL whose physical type is too narrow is untested**
  `src/Processors/Formats/Impl/Parquet/SchemaConverter.cpp:1288`
  **Risk:** `SchemaConverter::processPrimitiveColumn` computes `max_precision` from the physical type, then at `SchemaConverter.cpp`:1288 does `if (precision > max_precision) throw INCORRECT_DATA`. This branch — LLVM-confirmed uncovered — is the invariant guaranteeing the decoded column width always fits the physical decoder; if it regresses (or `max_precision` is miscomputed by a future refactor of the very reconciliation this PR added), spec-violating Parquet would be silently accepted and could re-open …
  **What's unique vs PR tests:** The PR's 04670 test only builds fixtures whose declared precision FITS the physical width (declared 9 backed by INT64, i.e. precision < max_precision), plus one `overflow` case where a single VALUE exceeds the declared precision (a `DECIMAL_OVERFLOW` at cast time). It never declares a precision that EXCEEDS the physical type's capacity, so the schema-time `precision > max_precision` rejection at line 1288 is never reached by any PR or existing test.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.803` (included in `26.8` and later)
<!-- ch-version-info:end -->