### PR TITLE
Remove unnecessary ignore_drop_queries_probability = 0 from 04692

### DIFF
--- a/tests/queries/0_stateless/04692_insert_dedup_retry_sparse_tuple.sql
+++ b/tests/queries/0_stateless/04692_insert_dedup_retry_sparse_tuple.sql
@@ -1,13 +1,13 @@
-DROP TABLE IF EXISTS t_dedup_sparse_src SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_dedup_sparse_dst SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_dedup_sparse_nested_src SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_dedup_sparse_nested_dst SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_dedup_sparse_landing SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_dedup_sparse_mv_target SETTINGS ignore_drop_queries_probability = 0;
-DROP VIEW IF EXISTS t_dedup_sparse_mv SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_dedup_sparse_top_src SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_dedup_sparse_top_dst SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_dedup_sparse_plain_dst SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_dedup_sparse_src;
+DROP TABLE IF EXISTS t_dedup_sparse_dst;
+DROP TABLE IF EXISTS t_dedup_sparse_nested_src;
+DROP TABLE IF EXISTS t_dedup_sparse_nested_dst;
+DROP TABLE IF EXISTS t_dedup_sparse_landing;
+DROP TABLE IF EXISTS t_dedup_sparse_mv_target;
+DROP VIEW IF EXISTS t_dedup_sparse_mv;
+DROP TABLE IF EXISTS t_dedup_sparse_top_src;
+DROP TABLE IF EXISTS t_dedup_sparse_top_dst;
+DROP TABLE IF EXISTS t_dedup_sparse_plain_dst;
 
 -- The INSERT SELECT dedup token embeds how the source read was chunked, so the retry only
 -- collides if both attempts chunk identically. Pin everything that shapes the read, or


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113117
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Requested here: https://github.com/ClickHouse/ClickHouse/pull/112005#discussion_r3704717758 ("Send a PR removing unnecessary `SETTINGS ignore_drop_queries_probability = 0`").

`04692_insert_dedup_retry_sparse_tuple.sql` carried the setting on its 10 `DROP ... IF EXISTS` prologue statements. Pinning it there buys nothing. The default is 0, and only two jobs inject a nonzero value: the Stress test (`ci/jobs/scripts/stress/stress.py:222`, `=0.2`) and the Upgrade check via `clickhouse-client --fake-drop` (`programs/client/Client.cpp:988-989`, `=1`). Neither compares per-test results. `tests/docker_scripts/stress_runner.sh:298-300` records a single row built from the wrapper's own exit code, and the per-`clickhouse-test` exit code is discarded: `stress.py:395-404` collects `retcodes` only to count finished processes and then returns the pipe list, which the caller ignores. So a stateless test cannot be reddened by an ignored `DROP` in the only jobs where one can happen.

The pinning was also internally inconsistent: the same test's epilogue drops, where the tables always exist, were never pinned.

Measured on this change: the test passes with output byte-identical to the reference at the default probability, at the 0.2 the stress runner injects (50 randomized runs), and at 1. Leftover-table counts after the run are the same before and after the change, so removing the pins changes nothing observable.

#113117 removes the setting from the other six stateless tests that carry it, so master reaches zero once both land. No file overlap with it.