### PR TITLE
Retry the build-profile telemetry INSERT through the CI logs cluster memory-pressure spikes

### DIFF
--- a/ci/jobs/scripts/log_cluster.py
+++ b/ci/jobs/scripts/log_cluster.py
@@ -110,6 +110,12 @@ class LogCluster:
 
         response = None
         for retry in range(retries):
+            # A retry re-sends the whole body. requests consumes a file-like
+            # body on the first attempt, and re-posting the exhausted stream
+            # would run an INSERT with an empty body: it succeeds and the
+            # telemetry is silently lost. Rewind it before every attempt.
+            if hasattr(data, "seek"):
+                data.seek(0)
             try:
                 response = self._session.post(
                     url=self.url,
@@ -125,14 +131,18 @@ class LogCluster:
                         f"WARNING: LogCluster query failed with code {response.status_code}"
                     )
                 if response.status_code >= 500:
-                    # A retryable error
-                    time.sleep(1)
+                    # A retryable error: the shared cluster goes through
+                    # minutes-long server-wide memory-pressure spikes (Code 241
+                    # for every query), the same ones `select` below rides out
+                    # on this schedule.
+                    time.sleep(5 * (retry + 1))
                     continue
                 else:
                     break
             except Exception:
                 print("WARNING: LogCluster query failed with exception")
                 traceback.print_exc()
+                time.sleep(5 * (retry + 1))
         if response is not None:
             print(
                 f"ERROR: Failed to query LogCluster, query:\n {query}\n    reason:\n {response.text}"
@@ -226,17 +236,23 @@ class LogClusterBuildProfileQueries:
     def insert_profile_data(self, build_name, start_time, file, reduced=False):
         query = self._profile_query(build_name, start_time, reduced=reduced)
         with open(file, "rb") as data_fd:
-            assert self._log_cluster.do_query(query, data=data_fd, timeout=50)
+            assert self._log_cluster.do_query(
+                query, data=data_fd, retries=8, timeout=50
+            )
 
     def insert_build_size_data(self, build_name, start_time, file):
         query = self._build_size_query(build_name, start_time)
         with open(file, "rb") as data_fd:
-            assert self._log_cluster.do_query(query, data=data_fd, timeout=50)
+            assert self._log_cluster.do_query(
+                query, data=data_fd, retries=8, timeout=50
+            )
 
     def insert_binary_symbol_data(self, build_name, start_time, file):
         query = self._binary_symbol_query(build_name, start_time)
         with open(file, "rb") as data_fd:
-            assert self._log_cluster.do_query(query, data=data_fd, timeout=50)
+            assert self._log_cluster.do_query(
+                query, data=data_fd, retries=8, timeout=50
+            )
 
     def _profile_query(self, build_name, start_time, reduced=False):
         where = ""

--- a/ci/tests/test_build_profile_hook.py
+++ b/ci/tests/test_build_profile_hook.py
@@ -23,7 +23,9 @@ Layers covered:
   stops halfway must not leave that marker behind.
 * The upload transport (``LogCluster.do_query``): the telemetry INSERT runs
   with parallel parsing disabled so its peak parse memory stays under the
-  shared cluster's per-user limit.
+  shared cluster's per-user limit, and retries transient 5xx rejections with
+  the body rewound, riding out the cluster's memory-pressure spikes instead of
+  failing the whole build job on the first one.
 * The endpoint routing (``LogCluster.READONLY_URL``): the consumer reads
   through the read-only sub-service of the cluster and sends no settings there,
   while the uploads keep the writer endpoint.
@@ -671,6 +673,78 @@ def test_do_query_disables_parallel_parsing():
 
     assert cluster.do_query("INSERT INTO t FORMAT JSONEachRow", data=b"")
     assert cluster._session.params["input_format_parallel_parsing"] == 0
+
+
+def test_do_query_retries_transient_500_with_rewound_body(monkeypatch):
+    """A transient 500 must be retried, and the retry must re-send the body.
+
+    The shared cluster goes through minutes-long memory-pressure spikes (Code
+    241 for every query); a single-attempt INSERT during a spike fails the
+    whole build job. And since requests consumes a file-like body on the first
+    attempt, a retry that does not rewind it would POST an empty body - an
+    INSERT that succeeds while the telemetry is silently lost.
+    """
+    import io
+
+    from ci.jobs.scripts import log_cluster as log_cluster_module
+
+    monkeypatch.setattr(log_cluster_module.time, "sleep", lambda _: None)
+
+    class _Resp:
+        def __init__(self, status_code):
+            self.status_code = status_code
+            self.ok = status_code < 400
+            self.text = ""
+
+    class _Session:
+        def __init__(self):
+            self.bodies = []
+            self.codes = [500, 500, 200]
+
+        def post(self, url, params, data, headers, timeout):
+            self.bodies.append(data.read())
+            return _Resp(self.codes[len(self.bodies) - 1])
+
+    cluster = LogCluster()
+    cluster.is_ready = lambda: True
+    cluster.url = "https://example"
+    cluster._auth = {}
+    cluster._session = _Session()
+
+    body = io.BytesIO(b'{"a": 1}\n')
+    assert cluster.do_query("INSERT INTO t FORMAT JSONEachRow", data=body, retries=8)
+    # Three attempts, each with the full body, not the first attempt's leftover.
+    assert cluster._session.bodies == [b'{"a": 1}\n'] * 3
+
+
+def test_do_query_does_not_retry_client_errors(monkeypatch):
+    """A 4xx is not transient: retrying a rejected query only re-runs the
+    rejection, so a single attempt must be the end of it."""
+    from ci.jobs.scripts import log_cluster as log_cluster_module
+
+    monkeypatch.setattr(log_cluster_module.time, "sleep", lambda _: None)
+
+    class _Resp:
+        status_code = 400
+        ok = False
+        text = "syntax error"
+
+    class _Session:
+        def __init__(self):
+            self.posts = 0
+
+        def post(self, url, params, data, headers, timeout):
+            self.posts += 1
+            return _Resp()
+
+    cluster = LogCluster()
+    cluster.is_ready = lambda: True
+    cluster.url = "https://example"
+    cluster._auth = {}
+    cluster._session = _Session()
+
+    assert not cluster.do_query("INSERT INTO t FORMAT JSONEachRow", data=b"", retries=8)
+    assert cluster._session.posts == 1
 
 
 # --- endpoint routing: reads on the read-only sub-service -----------------


### PR DESCRIPTION
Since 2026-08-03, the `Post Hooks` step of `Build (arm_release)` (and other profiled build variants) fails fleet-wide — 354/468 runs on 2026-08-03 and 456/528 on 2026-08-04, on PRs and master alike. The build-profile telemetry INSERT into the shared CI logs cluster is rejected with HTTP 500, Code 241 `MEMORY_LIMIT_EXCEEDED` ("User memory limit exceeded ... OvercommitTracker decision: Query was selected to stop"), and `build_profile_hook.py` (correctly) fails closed. The wave started right after https://github.com/ClickHouse/ClickHouse/pull/111164 began uploading reduced build profiles for every PR build, multiplying the INSERT rate against the writer endpoint.

`LogCluster.do_query` (the INSERT transport) made a single attempt (`retries=1`), while `select` in the same file already retries 8 times with a growing backoff — its comment documenting exactly these "minutes-long server-wide memory-pressure spikes (Code 241 for every query)". This PR retries the three profile INSERTs on the same schedule, and rewinds a file-like body before every attempt: `requests` consumes the stream on the first POST, so re-sending the exhausted stream would run an INSERT with an empty body — a "success" with the telemetry silently lost. 4xx rejections still stop after the first attempt, and the fail-close `assert` stays, so a genuinely lost upload still fails the job.

Unit tests cover the retry-with-rewound-body behavior and the no-retry-on-4xx behavior in `ci/tests/test_build_profile_hook.py`.

Note this is a mitigation for the transport; the writer endpoint's inflated per-user memory accounting ("would use 2.50 TiB", cap 29.80 GiB) likely also needs infra attention — see the issue.

Example report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109496&sha=latest&name_0=PR&name_1=Build%20(arm_release)
Related: https://github.com/ClickHouse/ClickHouse/issues/113408
Related: https://github.com/ClickHouse/ClickHouse/pull/111164

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.876` (included in `26.8` and later)
<!-- ch-version-info:end -->