### PR TITLE
Return column names, not analyzer identifiers, from a Distributed read at FetchColumns

### DIFF
--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -2206,6 +2206,10 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(TableExpressionNodePtr table_
         ActionsDAG rename_actions_dag(query_plan.getCurrentHeader()->getColumnsWithTypeAndName());
         ActionsDAG::NodeRawConstPtrs updated_actions_dag_outputs;
 
+        /// `storage` above is scoped to the branch that read the table expression, so look it up again.
+        const auto * table_expression_storage = table_node ? table_node->getStorage().get()
+            : (table_function_node ? table_function_node->getStorage().get() : nullptr);
+
         for (auto & output_node : rename_actions_dag.getOutputs())
         {
             if (select_query_options.ignore_rename_columns)
@@ -2228,7 +2232,8 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(TableExpressionNodePtr table_
                     /// A remote read at FetchColumns can also return columns outside this table expression's
                     /// schema, joined columns from the right-hand table being the case. They have no identifier
                     /// here, so pass them through as is rather than dropping them.
-                    if (table_node && table_node->getStorage()->isRemote() && select_query_options.to_stage == QueryProcessingStage::FetchColumns)
+                    if (table_expression_storage && table_expression_storage->isRemote()
+                        && select_query_options.to_stage == QueryProcessingStage::FetchColumns)
                         updated_actions_dag_outputs.push_back(output_node);
                 }
                 else

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -2225,14 +2225,9 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(TableExpressionNodePtr table_
                 const auto * column_identifier = table_expression_data.getColumnIdentifierOrNull(output_node->result_name);
                 if (!column_identifier)
                 {
-                    /// This is needed only for distributed over distributed case with plan serialization as well.
-                    /// StorageDistributed::read apparently returns column identifiers instead of column names for
-                    /// to_stage == QueryProcessingStage::FetchColumns (unlike other storages, which do not aware about identifiers).
-                    /// So, we do not rename but just pass names as is.
-                    ///
-                    /// Overall, IStorage::read    -> FetchColumns returns normal column names (except Distributed, which is inconsistent)
-                    /// Interpreter::getQueryPlan  -> FetchColumns returns identifiers (why?) and this the reason for the bug ^ in Distributed
-                    /// Hopefully there is no other case when we read from Distributed up to FetchColumns.
+                    /// A remote read at FetchColumns can also return columns outside this table expression's
+                    /// schema, joined columns from the right-hand table being the case. They have no identifier
+                    /// here, so pass them through as is rather than dropping them.
                     if (table_node && table_node->getStorage()->isRemote() && select_query_options.to_stage == QueryProcessingStage::FetchColumns)
                         updated_actions_dag_outputs.push_back(output_node);
                 }

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1020,12 +1020,9 @@ QueryTreeNodePtr buildQueryTreeDistributed(SelectQueryInfo & query_info,
     return buildQueryTreeForShard(query_info.planner_context, query_tree_to_modify, /*allow_global_join_for_right_table*/ false);
 }
 
-/// Identifier-to-name map of the table expression standing for `storage` in `query_tree`, looked up
-/// in the context that analyzed that tree. Only this table expression's columns may be renamed; the
-/// others belong to a joined or external table, whose columns the caller expects as identifiers.
-/// The node is matched by storage rather than by its own address because `buildQueryTreeForShard`
-/// may clone the tree, which invalidates any node pointer taken beforehand while `cloneImpl` carries
-/// the storage over.
+/// Identifier-to-name map for the table expression standing for `storage`, from the context that
+/// analyzed `query_tree`. Only its own columns may be renamed: the rest belong to a joined or
+/// external table, whose columns the caller expects as identifiers. Matched by storage, not address.
 std::unordered_map<std::string, std::string> collectColumnIdentifierToColumnName(
     const QueryTreeNodePtr & query_tree, const IStorage & storage, const PlannerContext & planner_context)
 {

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -917,11 +917,14 @@ bool rewriteJoinToGlobalJoinIfNeeded(QueryTreeNodePtr join_tree)
     return rewrite;
 }
 
+/// `out_replacement_storage`, when given, receives the storage that stands in for the remote table.
+/// A storage outlives the query tree and, unlike a node pointer, is carried over by `cloneImpl`, so
+/// it stays a valid way to find the replacement table expression after the tree has been cloned.
 QueryTreeNodePtr buildQueryTreeDistributed(SelectQueryInfo & query_info,
     const StorageSnapshotPtr & distributed_storage_snapshot,
     const StorageID & remote_storage_id,
     const ASTPtr & remote_table_function,
-    QueryTreeNodePtr * out_replacement = nullptr)
+    StoragePtr * out_replacement_storage = nullptr)
 {
     auto & planner_context = query_info.planner_context;
     const auto & query_context = planner_context->getQueryContext();
@@ -988,8 +991,13 @@ QueryTreeNodePtr buildQueryTreeDistributed(SelectQueryInfo & query_info,
 
     replacement_table_expression->setAlias(query_info.table_expression->getAlias());
 
-    if (out_replacement)
-        *out_replacement = replacement_table_expression;
+    if (out_replacement_storage)
+    {
+        if (const auto * table_node = replacement_table_expression->as<TableNode>())
+            *out_replacement_storage = table_node->getStorage();
+        else if (const auto * table_function_node = replacement_table_expression->as<TableFunctionNode>())
+            *out_replacement_storage = table_function_node->getStorage();
+    }
 
     auto query_tree_to_modify = query_info.query_tree->cloneAndReplace(query_info.table_expression, std::move(replacement_table_expression));
     ReplaseAliasColumnsVisitor replace_alias_columns_visitor;
@@ -1012,6 +1020,37 @@ QueryTreeNodePtr buildQueryTreeDistributed(SelectQueryInfo & query_info,
     return buildQueryTreeForShard(query_info.planner_context, query_tree_to_modify, /*allow_global_join_for_right_table*/ false);
 }
 
+/// Identifier-to-name map of the table expression standing for `storage` in `query_tree`, looked up
+/// in the context that analyzed that tree. Only this table expression's columns may be renamed; the
+/// others belong to a joined or external table, whose columns the caller expects as identifiers.
+/// The node is matched by storage rather than by its own address because `buildQueryTreeForShard`
+/// may clone the tree, which invalidates any node pointer taken beforehand while `cloneImpl` carries
+/// the storage over.
+std::unordered_map<std::string, std::string> collectColumnIdentifierToColumnName(
+    const QueryTreeNodePtr & query_tree, const IStorage & storage, const PlannerContext & planner_context)
+{
+    for (const auto & table_expression :
+         extractTableExpressions(static_pointer_cast<ITableExpressionNode>(query_tree), /*add_array_join*/ false, /*recursive*/ true))
+    {
+        StoragePtr table_expression_storage;
+        if (const auto * table_node = table_expression->as<TableNode>())
+            table_expression_storage = table_node->getStorage();
+        else if (const auto * table_function_node = table_expression->as<TableFunctionNode>())
+            table_expression_storage = table_function_node->getStorage();
+
+        if (table_expression_storage.get() != &storage)
+            continue;
+
+        if (const auto * table_expression_data = planner_context.getTableExpressionDataOrNull(table_expression))
+        {
+            const auto & identifier_to_name = table_expression_data->getColumnIdentifierToColumnName();
+            return {identifier_to_name.begin(), identifier_to_name.end()};
+        }
+    }
+
+    return {};
+}
+
 }
 
 void StorageDistributed::read(
@@ -1029,8 +1068,7 @@ void StorageDistributed::read(
     SelectQueryInfo modified_query_info = query_info;
 
     /// At `FetchColumns` the plan's header carries analyzer column identifiers; see below.
-    PlannerContextPtr planner_context_holder;
-    const TableExpressionData::ColumnIdentifierToColumnName * identifier_to_name = nullptr;
+    std::unordered_map<std::string, std::string> identifier_to_name;
 
     const auto & settings = local_context->getSettingsRef();
 
@@ -1038,25 +1076,20 @@ void StorageDistributed::read(
     {
         StorageID remote_storage_id = StorageID{remote_database, remote_table};
 
-        QueryTreeNodePtr replacement_table_expression;
+        StoragePtr replacement_storage;
         auto query_tree_distributed = buildQueryTreeDistributed(modified_query_info,
             query_info.initial_storage_snapshot ? query_info.initial_storage_snapshot : storage_snapshot,
             remote_storage_id,
             remote_table_function_ptr,
-            &replacement_table_expression);
+            &replacement_storage);
         /// The map has to come from the context that produced this header: `buildQueryTreeForShard` renumbers
         /// the `__tableN` aliases from 1, so the outer planner's map holds different identifiers.
         auto [sample_block, distributed_planner_context] = InterpreterSelectQueryAnalyzer::getSampleBlockAndPlannerContext(
             query_tree_distributed, local_context, SelectQueryOptions(processed_stage).analyze());
         Block block = *sample_block;
-        if (processed_stage == QueryProcessingStage::FetchColumns)
-        {
-            if (const auto * table_expression_data
-                = distributed_planner_context->getTableExpressionDataOrNull(replacement_table_expression))
-                identifier_to_name = &table_expression_data->getColumnIdentifierToColumnName();
-            /// Keep the context alive: the map above is owned by it.
-            planner_context_holder = std::move(distributed_planner_context);
-        }
+        if (processed_stage == QueryProcessingStage::FetchColumns && replacement_storage)
+            identifier_to_name
+                = collectColumnIdentifierToColumnName(query_tree_distributed, *replacement_storage, *distributed_planner_context);
         /** For distributed tables we do not need constants in header, since we don't send them to remote servers.
           * Moreover, constants can break some functions like `hostName` that are constants only for local queries.
           */
@@ -1131,8 +1164,8 @@ void StorageDistributed::read(
 
     /// `IStorage::read` at `FetchColumns` must return column names, but the header above went through the
     /// planner's name-to-identifier rename, so alias the identifiers back. An output the map does not
-    /// resolve belongs to another table expression (a joined column) and is passed through untouched.
-    if (identifier_to_name)
+    /// resolve is left alone: it is a column of some other table expression, a joined one being the case.
+    if (!identifier_to_name.empty())
     {
         ActionsDAG rename_dag(query_plan.getCurrentHeader()->getColumnsWithTypeAndName());
         ActionsDAG::NodeRawConstPtrs outputs;
@@ -1141,8 +1174,8 @@ void StorageDistributed::read(
 
         for (const auto * output : rename_dag.getOutputs())
         {
-            auto it = identifier_to_name->find(output->result_name);
-            if (it == identifier_to_name->end() || it->second == output->result_name)
+            auto it = identifier_to_name.find(output->result_name);
+            if (it == identifier_to_name.end() || it->second == output->result_name)
             {
                 outputs.push_back(output);
                 continue;

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -920,7 +920,8 @@ bool rewriteJoinToGlobalJoinIfNeeded(QueryTreeNodePtr join_tree)
 QueryTreeNodePtr buildQueryTreeDistributed(SelectQueryInfo & query_info,
     const StorageSnapshotPtr & distributed_storage_snapshot,
     const StorageID & remote_storage_id,
-    const ASTPtr & remote_table_function)
+    const ASTPtr & remote_table_function,
+    QueryTreeNodePtr * out_replacement = nullptr)
 {
     auto & planner_context = query_info.planner_context;
     const auto & query_context = planner_context->getQueryContext();
@@ -987,6 +988,9 @@ QueryTreeNodePtr buildQueryTreeDistributed(SelectQueryInfo & query_info,
 
     replacement_table_expression->setAlias(query_info.table_expression->getAlias());
 
+    if (out_replacement)
+        *out_replacement = replacement_table_expression;
+
     auto query_tree_to_modify = query_info.query_tree->cloneAndReplace(query_info.table_expression, std::move(replacement_table_expression));
     ReplaseAliasColumnsVisitor replace_alias_columns_visitor;
     replace_alias_columns_visitor.visit(query_tree_to_modify);
@@ -1024,17 +1028,35 @@ void StorageDistributed::read(
 
     SelectQueryInfo modified_query_info = query_info;
 
+    /// At `FetchColumns` the plan's header carries analyzer column identifiers; see below.
+    PlannerContextPtr planner_context_holder;
+    const TableExpressionData::ColumnIdentifierToColumnName * identifier_to_name = nullptr;
+
     const auto & settings = local_context->getSettingsRef();
 
     if (settings[Setting::allow_experimental_analyzer])
     {
         StorageID remote_storage_id = StorageID{remote_database, remote_table};
 
+        QueryTreeNodePtr replacement_table_expression;
         auto query_tree_distributed = buildQueryTreeDistributed(modified_query_info,
             query_info.initial_storage_snapshot ? query_info.initial_storage_snapshot : storage_snapshot,
             remote_storage_id,
-            remote_table_function_ptr);
-        Block block = *InterpreterSelectQueryAnalyzer::getSampleBlock(query_tree_distributed, local_context, SelectQueryOptions(processed_stage).analyze());
+            remote_table_function_ptr,
+            &replacement_table_expression);
+        /// The map has to come from the context that produced this header: `buildQueryTreeForShard` renumbers
+        /// the `__tableN` aliases from 1, so the outer planner's map holds different identifiers.
+        auto [sample_block, distributed_planner_context] = InterpreterSelectQueryAnalyzer::getSampleBlockAndPlannerContext(
+            query_tree_distributed, local_context, SelectQueryOptions(processed_stage).analyze());
+        Block block = *sample_block;
+        if (processed_stage == QueryProcessingStage::FetchColumns)
+        {
+            if (const auto * table_expression_data
+                = distributed_planner_context->getTableExpressionDataOrNull(replacement_table_expression))
+                identifier_to_name = &table_expression_data->getColumnIdentifierToColumnName();
+            /// Keep the context alive: the map above is owned by it.
+            planner_context_holder = std::move(distributed_planner_context);
+        }
         /** For distributed tables we do not need constants in header, since we don't send them to remote servers.
           * Moreover, constants can break some functions like `hostName` that are constants only for local queries.
           */
@@ -1106,6 +1128,37 @@ void StorageDistributed::read(
     /// (e.g., every shard had a missing table with no remote replicas).
     if (!query_plan.isInitialized())
         throw Exception(ErrorCodes::ALL_CONNECTION_TRIES_FAILED, "No available shards to query");
+
+    /// `IStorage::read` at `FetchColumns` must return column names, but the header above went through the
+    /// planner's name-to-identifier rename, so alias the identifiers back. An output the map does not
+    /// resolve belongs to another table expression (a joined column) and is passed through untouched.
+    if (identifier_to_name)
+    {
+        ActionsDAG rename_dag(query_plan.getCurrentHeader()->getColumnsWithTypeAndName());
+        ActionsDAG::NodeRawConstPtrs outputs;
+        outputs.reserve(rename_dag.getOutputs().size());
+        bool renamed_any = false;
+
+        for (const auto * output : rename_dag.getOutputs())
+        {
+            auto it = identifier_to_name->find(output->result_name);
+            if (it == identifier_to_name->end() || it->second == output->result_name)
+            {
+                outputs.push_back(output);
+                continue;
+            }
+            outputs.push_back(&rename_dag.addAlias(*output, it->second));
+            renamed_any = true;
+        }
+
+        if (renamed_any)
+        {
+            rename_dag.getOutputs() = std::move(outputs);
+            auto rename_step = std::make_unique<ExpressionStep>(query_plan.getCurrentHeader(), std::move(rename_dag));
+            rename_step->setStepDescription("Change column identifiers to column names");
+            query_plan.addStep(std::move(rename_step));
+        }
+    }
 }
 
 

--- a/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.reference
+++ b/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.reference
@@ -1,0 +1,109 @@
+=== Buffer over Distributed, declared type differs ===
+-- buf_mismatch A
+header: __table1.A
+0
+18446744073709551517
+18446744073709551518
+18446744073709551519
+-- buf_mismatch B
+header: __table1.B
+0
+10
+100
+110
+-- buf_mismatch A, B
+header: __table1.A	__table1.B
+0	0
+18446744073709551517	990
+18446744073709551518	980
+18446744073709551519	970
+-- buf_mismatch B, A
+header: __table1.B	__table1.A
+0	0
+10	18446744073709551615
+100	18446744073709551606
+110	18446744073709551605
+-- buf_mismatch filtered
+header: __table1.A	__table1.B
+0	0
+18446744073709551517	990
+18446744073709551518	980
+18446744073709551519	970
+-- buf_mismatch expression
+header: __table1.A
+0
+18446744073709551517
+18446744073709551518
+18446744073709551519
+=== Buffer over Distributed, identical structure ===
+-- buf_matched A
+header: __table1.A
+-1
+-10
+-11
+-12
+-- buf_matched B
+header: __table1.B
+0
+10
+100
+110
+=== Buffer over Distributed, order-preserving widening ===
+-- buf_widen A
+header: __table1.A
+-1
+-2
+-3
+-4
+=== MaterializedView over a Distributed target ===
+-- mv1 A
+header: __table1.A
+0
+18446744073709551607
+18446744073709551608
+18446744073709551609
+=== Distributed read without a wrapper ===
+-- dist A
+header: __table1.A
+-1
+-10
+-11
+-12
+-- dist A, B
+header: __table1.A	__table1.B
+-1	10
+-10	100
+-11	110
+-12	120
+-- dist in a subquery
+header: __table1.A
+-1
+-10
+-11
+-12
+-- dist over dist
+header: __table1.A
+-1
+-10
+-11
+-12
+=== Columns from outside the storage schema are left alone ===
+-- join, Distributed on the left
+header: __table1.A	__table2.v	__table2.v
+-1	1	1
+-2	2	2
+-3	3	3
+-4	4	4
+=== Without the analyzer ===
+-- buf_mismatch A
+header: A
+0
+18446744073709551517
+18446744073709551518
+18446744073709551519
+-- dist A
+header: A
+-1
+-10
+-11
+-12

--- a/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.reference
+++ b/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.reference
@@ -72,6 +72,56 @@ rows: 20
 18446744073709551607
 18446744073709551608
 18446744073709551609
+=== Merge over Distributed ===
+-- mrg A
+header: __table1.A
+rows: 200
+-1
+-10
+-11
+-12
+-- mrg A, B
+header: __table1.A	__table1.B
+rows: 200
+-1	10
+-10	100
+-11	110
+-12	120
+-- mrg B, A
+header: __table1.B	__table1.A
+rows: 200
+0	0
+10	-1
+100	-10
+110	-11
+-- mrg filtered
+header: __table1.A	__table1.B
+rows: 200
+-1	10
+-10	100
+-11	110
+-12	120
+-- mrg, serialize_query_plan
+header: __table1.A
+rows: 200
+-1
+-10
+-11
+-12
+-- mrg_mismatch A
+header: __table1.A
+rows: 200
+0
+18446744073709551517
+18446744073709551518
+18446744073709551519
+-- mrg_mismatch B, A
+header: __table1.B	__table1.A
+rows: 200
+0	0
+10	18446744073709551615
+100	18446744073709551606
+110	18446744073709551605
 === Distributed read without a wrapper ===
 -- dist A
 header: __table1.A

--- a/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.reference
+++ b/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.reference
@@ -1,36 +1,42 @@
 === Buffer over Distributed, declared type differs ===
 -- buf_mismatch A
 header: __table1.A
+rows: 200
 0
 18446744073709551517
 18446744073709551518
 18446744073709551519
 -- buf_mismatch B
 header: __table1.B
+rows: 200
 0
 10
 100
 110
 -- buf_mismatch A, B
 header: __table1.A	__table1.B
+rows: 200
 0	0
 18446744073709551517	990
 18446744073709551518	980
 18446744073709551519	970
 -- buf_mismatch B, A
 header: __table1.B	__table1.A
+rows: 200
 0	0
 10	18446744073709551615
 100	18446744073709551606
 110	18446744073709551605
 -- buf_mismatch filtered
 header: __table1.A	__table1.B
+rows: 200
 0	0
 18446744073709551517	990
 18446744073709551518	980
 18446744073709551519	970
 -- buf_mismatch expression
 header: __table1.A
+rows: 200
 0
 18446744073709551517
 18446744073709551518
@@ -38,12 +44,14 @@ header: __table1.A
 === Buffer over Distributed, identical structure ===
 -- buf_matched A
 header: __table1.A
+rows: 200
 -1
 -10
 -11
 -12
 -- buf_matched B
 header: __table1.B
+rows: 200
 0
 10
 100
@@ -51,6 +59,7 @@ header: __table1.B
 === Buffer over Distributed, order-preserving widening ===
 -- buf_widen A
 header: __table1.A
+rows: 20
 -1
 -2
 -3
@@ -58,6 +67,7 @@ header: __table1.A
 === MaterializedView over a Distributed target ===
 -- mv1 A
 header: __table1.A
+rows: 20
 0
 18446744073709551607
 18446744073709551608
@@ -65,31 +75,101 @@ header: __table1.A
 === Distributed read without a wrapper ===
 -- dist A
 header: __table1.A
+rows: 200
 -1
 -10
 -11
 -12
 -- dist A, B
 header: __table1.A	__table1.B
+rows: 200
 -1	10
 -10	100
 -11	110
 -12	120
 -- dist in a subquery
 header: __table1.A
+rows: 200
 -1
 -10
 -11
 -12
 -- dist over dist
 header: __table1.A
+rows: 400
 -1
 -10
 -11
 -12
+=== Subquery shipped to the shards ===
+-- global in
+header: __table1.A	__table1.B
+rows: 200
+0	0
+18446744073709551517	990
+18446744073709551518	980
+18446744073709551519	970
+-- global in, Distributed subquery
+header: __table1.A	__table1.B
+rows: 200
+0	0
+18446744073709551517	990
+18446744073709551518	980
+18446744073709551519	970
+-- in, prefer_global_in_and_join
+header: __table1.A	__table1.B
+rows: 200
+0	0
+18446744073709551517	990
+18446744073709551518	980
+18446744073709551519	970
+-- in, distributed_product_mode=local
+header: __table1.A	__table1.B
+rows: 200
+0	0
+18446744073709551517	990
+18446744073709551518	980
+18446744073709551519	970
+-- in, distributed_product_mode=global
+header: __table1.A	__table1.B
+rows: 200
+0	0
+18446744073709551517	990
+18446744073709551518	980
+18446744073709551519	970
+=== Plan serialization ===
+-- buf_mismatch, serialize_query_plan
+header: __table1.A
+rows: 200
+0
+18446744073709551517
+18446744073709551518
+18446744073709551519
+-- dist over dist, serialize_query_plan
+header: __table1.A
+rows: 400
+-1
+-10
+-11
+-12
+-- mv1, serialize_query_plan
+header: __table1.A
+rows: 20
+0
+18446744073709551607
+18446744073709551608
+18446744073709551609
 === Columns from outside the storage schema are left alone ===
 -- join, Distributed on the left
 header: __table1.A	__table2.v	__table2.v
+rows: 10
+-1	1	1
+-2	2	2
+-3	3	3
+-4	4	4
+-- join, cluster() on the left
+header: __table1.A	__table2.v	__table2.v
+rows: 10
 -1	1	1
 -2	2	2
 -3	3	3
@@ -97,12 +177,14 @@ header: __table1.A	__table2.v	__table2.v
 === Without the analyzer ===
 -- buf_mismatch A
 header: A
+rows: 200
 0
 18446744073709551517
 18446744073709551518
 18446744073709551519
 -- dist A
 header: A
+rows: 200
 -1
 -10
 -11

--- a/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.sh
+++ b/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.sh
@@ -67,7 +67,8 @@ fetch() {
             echo "header: $header"
             rows=$(cat)
             echo "rows: $(printf '%s\n' "$rows" | grep -c .)"
-            printf '%s\n' "$rows" | sort -u | head -4
+            # LC_ALL=C: the values are negative, and a UTF-8 collation ignores the leading `-`.
+            printf '%s\n' "$rows" | LC_ALL=C sort -u | head -4
         }
 }
 

--- a/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.sh
+++ b/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, shard
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# No ORDER BY or LIMIT in any `--stage fetch_columns` query below: either one makes the stage
+# optimizer return a stage above FetchColumns, so the read under test never happens. Rows are
+# sorted by `sort` instead.
+
+${CLICKHOUSE_CLIENT} -m -q "
+CREATE TABLE src (A Int64, B Int64) ENGINE = MergeTree ORDER BY A;
+INSERT INTO src SELECT -number, number * 10 FROM numbers(100);
+CREATE TABLE dist (A Int64, B Int64)
+    ENGINE = Distributed(test_cluster_two_shards_localhost, currentDatabase(), src);
+CREATE TABLE dist_over_dist (A Int64, B Int64)
+    ENGINE = Distributed(test_cluster_two_shards_localhost, currentDatabase(), dist);
+
+-- Buffer whose declared type differs from the destination's un-order-preservingly.
+CREATE TABLE buf_mismatch (A UInt64, B Int64)
+    ENGINE = Buffer(currentDatabase(), dist, 1, 3600, 36000, 10000, 1000000, 10000000, 100000000);
+-- Buffer with the destination's exact structure: reads through a different conversion site.
+CREATE TABLE buf_matched (A Int64, B Int64)
+    ENGINE = Buffer(currentDatabase(), dist, 1, 3600, 36000, 10000, 1000000, 10000000, 100000000);
+-- Order-preserving widening, which must keep working.
+CREATE TABLE src32 (A Int32) ENGINE = MergeTree ORDER BY A;
+INSERT INTO src32 SELECT -number FROM numbers(10);
+CREATE TABLE dist32 (A Int32)
+    ENGINE = Distributed(test_cluster_two_shards_localhost, currentDatabase(), src32);
+CREATE TABLE buf_widen (A Int64)
+    ENGINE = Buffer(currentDatabase(), dist32, 1, 3600, 36000, 10000, 1000000, 10000000, 100000000);
+
+-- The view's declared type differs from its target's, so reading it needs a conversion too.
+CREATE TABLE mv_source (A Int64) ENGINE = MergeTree ORDER BY A;
+CREATE TABLE mv_target (A Int64) ENGINE = MergeTree ORDER BY A;
+CREATE TABLE dist_target (A Int64)
+    ENGINE = Distributed(test_cluster_two_shards_localhost, currentDatabase(), mv_target, A);
+CREATE MATERIALIZED VIEW mv1 TO dist_target AS SELECT toUInt64(A) AS A FROM mv_source;
+INSERT INTO mv_source SELECT -number FROM numbers(10);
+
+CREATE TABLE rt (k Int64, v Int64) ENGINE = MergeTree ORDER BY k;
+INSERT INTO rt SELECT -number, number FROM numbers(5);
+"
+
+# $1 label, $2 query. Asserts the column names of the result and its rows. A wrong name shows up
+# as an error or as rows that got replaced by a default, so both halves are needed. The Buffer
+# engine logs a warning for a type mismatch on every read, so server logs are silenced.
+fetch() {
+    echo "-- $1"
+    ${CLICKHOUSE_CLIENT} --stage fetch_columns --send_logs_level none --format TSVWithNames \
+        -q "$2" 2>&1 | { read -r header; echo "header: $header"; sort -u | head -4; }
+}
+
+echo '=== Buffer over Distributed, declared type differs ==='
+fetch 'buf_mismatch A' 'SELECT A FROM buf_mismatch'
+fetch 'buf_mismatch B' 'SELECT B FROM buf_mismatch'
+fetch 'buf_mismatch A, B' 'SELECT A, B FROM buf_mismatch'
+# Column order differs from the Buffer's declaration order, so a positional match would pair
+# B with A here instead of failing.
+fetch 'buf_mismatch B, A' 'SELECT B, A FROM buf_mismatch'
+fetch 'buf_mismatch filtered' 'SELECT A FROM buf_mismatch WHERE B > 900'
+fetch 'buf_mismatch expression' 'SELECT A + 1 FROM buf_mismatch'
+
+echo '=== Buffer over Distributed, identical structure ==='
+fetch 'buf_matched A' 'SELECT A FROM buf_matched'
+fetch 'buf_matched B' 'SELECT B FROM buf_matched'
+
+echo '=== Buffer over Distributed, order-preserving widening ==='
+fetch 'buf_widen A' 'SELECT A FROM buf_widen'
+
+echo '=== MaterializedView over a Distributed target ==='
+fetch 'mv1 A' 'SELECT A FROM mv1'
+
+echo '=== Distributed read without a wrapper ==='
+fetch 'dist A' 'SELECT A FROM dist'
+fetch 'dist A, B' 'SELECT A, B FROM dist'
+fetch 'dist in a subquery' 'SELECT A FROM (SELECT A FROM dist)'
+fetch 'dist over dist' 'SELECT A FROM dist_over_dist'
+
+echo '=== Columns from outside the storage schema are left alone ==='
+fetch 'join, Distributed on the left' \
+    "SELECT d.A, r.v FROM dist AS d JOIN ${CLICKHOUSE_DATABASE}.rt AS r ON d.A = r.k"
+
+echo '=== Without the analyzer ==='
+fetch 'buf_mismatch A' 'SELECT A FROM buf_mismatch SETTINGS enable_analyzer = 0'
+fetch 'dist A' 'SELECT A FROM dist SETTINGS enable_analyzer = 0'

--- a/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.sh
+++ b/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.sh
@@ -56,10 +56,9 @@ CREATE TABLE dist_keys (v Int64)
     ENGINE = Distributed(test_cluster_two_shards_localhost, currentDatabase(), keys);
 "
 
-# $1 label, $2 query. Asserts the column names of the result, its row count and its rows. A wrong
-# name shows up as an error or as rows replaced by a default, so all three are needed: the count
-# alone would miss a wrong value, the deduped prefix alone would miss a lost row.
-# The Buffer engine logs a warning for a type mismatch on every read, so server logs are silenced.
+# $1 label, $2 query. Asserts the result's column names, row count and rows: all three, because the
+# count alone would miss a wrong value and the deduped prefix alone would miss a lost row. Logs are
+# silenced because Buffer warns on every type-mismatched read.
 fetch() {
     echo "-- $1"
     ${CLICKHOUSE_CLIENT} --stage fetch_columns --send_logs_level none --format TSVWithNames \

--- a/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.sh
+++ b/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.sh
@@ -37,19 +37,33 @@ CREATE TABLE mv_target (A Int64) ENGINE = MergeTree ORDER BY A;
 CREATE TABLE dist_target (A Int64)
     ENGINE = Distributed(test_cluster_two_shards_localhost, currentDatabase(), mv_target, A);
 CREATE MATERIALIZED VIEW mv1 TO dist_target AS SELECT toUInt64(A) AS A FROM mv_source;
-INSERT INTO mv_source SELECT -number FROM numbers(10);
+-- Foreground insert, so the local shard is written before the reads below whatever
+-- prefer_localhost_replica the run happens to randomize.
+INSERT INTO mv_source SELECT -number FROM numbers(10) SETTINGS distributed_foreground_insert = 1;
 
 CREATE TABLE rt (k Int64, v Int64) ENGINE = MergeTree ORDER BY k;
 INSERT INTO rt SELECT -number, number FROM numbers(5);
+-- Keys matching a NONZERO B, so a value replaced by a default is visible in the result.
+CREATE TABLE keys (v Int64) ENGINE = MergeTree ORDER BY v;
+INSERT INTO keys SELECT (number + 1) * 10 FROM numbers(3);
+CREATE TABLE dist_keys (v Int64)
+    ENGINE = Distributed(test_cluster_two_shards_localhost, currentDatabase(), keys);
 "
 
-# $1 label, $2 query. Asserts the column names of the result and its rows. A wrong name shows up
-# as an error or as rows that got replaced by a default, so both halves are needed. The Buffer
-# engine logs a warning for a type mismatch on every read, so server logs are silenced.
+# $1 label, $2 query. Asserts the column names of the result, its row count and its rows. A wrong
+# name shows up as an error or as rows replaced by a default, so all three are needed: the count
+# alone would miss a wrong value, the deduped prefix alone would miss a lost row.
+# The Buffer engine logs a warning for a type mismatch on every read, so server logs are silenced.
 fetch() {
     echo "-- $1"
     ${CLICKHOUSE_CLIENT} --stage fetch_columns --send_logs_level none --format TSVWithNames \
-        -q "$2" 2>&1 | { read -r header; echo "header: $header"; sort -u | head -4; }
+        -q "$2" 2>&1 | {
+            read -r header
+            echo "header: $header"
+            rows=$(cat)
+            echo "rows: $(printf '%s\n' "$rows" | grep -c .)"
+            printf '%s\n' "$rows" | sort -u | head -4
+        }
 }
 
 echo '=== Buffer over Distributed, declared type differs ==='
@@ -78,9 +92,38 @@ fetch 'dist A, B' 'SELECT A, B FROM dist'
 fetch 'dist in a subquery' 'SELECT A FROM (SELECT A FROM dist)'
 fetch 'dist over dist' 'SELECT A FROM dist_over_dist'
 
+# Shipping a subquery to the shards as a temporary table clones the shard query tree again, so the
+# table expression carrying the identifiers cannot be remembered from before that step.
+echo '=== Subquery shipped to the shards ==='
+fetch 'global in' \
+    'SELECT A, B FROM buf_mismatch WHERE B GLOBAL IN (SELECT v FROM keys)'
+fetch 'global in, Distributed subquery' \
+    'SELECT A, B FROM buf_mismatch WHERE B GLOBAL IN (SELECT v FROM dist_keys)'
+fetch 'in, prefer_global_in_and_join' \
+    'SELECT A, B FROM buf_mismatch WHERE B IN (SELECT v FROM keys) SETTINGS prefer_global_in_and_join = 1'
+fetch 'in, distributed_product_mode=local' \
+    "SELECT A, B FROM buf_mismatch WHERE B IN (SELECT v FROM dist_keys) SETTINGS distributed_product_mode = 'local'"
+fetch 'in, distributed_product_mode=global' \
+    "SELECT A, B FROM buf_mismatch WHERE B IN (SELECT v FROM dist_keys) SETTINGS distributed_product_mode = 'global'"
+
+# Plan serialization reads a remote storage through its own FetchColumns interpreter, which renames
+# in the opposite direction. CI does not randomize that setting, so the test has to set it.
+echo '=== Plan serialization ==='
+fetch 'buf_mismatch, serialize_query_plan' \
+    'SELECT A FROM buf_mismatch SETTINGS serialize_query_plan = 1'
+fetch 'dist over dist, serialize_query_plan' \
+    'SELECT A FROM dist_over_dist SETTINGS serialize_query_plan = 1'
+fetch 'mv1, serialize_query_plan' \
+    'SELECT A FROM mv1 SETTINGS serialize_query_plan = 1'
+
 echo '=== Columns from outside the storage schema are left alone ==='
 fetch 'join, Distributed on the left' \
     "SELECT d.A, r.v FROM dist AS d JOIN ${CLICKHOUSE_DATABASE}.rt AS r ON d.A = r.k"
+# A table function resolves to a nested Distributed just like a table does, so its joined columns
+# need the same treatment.
+fetch 'join, cluster() on the left' \
+    "SELECT d.A, r.v FROM cluster(test_cluster_two_shards_localhost, ${CLICKHOUSE_DATABASE}, src) AS d
+        JOIN ${CLICKHOUSE_DATABASE}.rt AS r ON d.A = r.k"
 
 echo '=== Without the analyzer ==='
 fetch 'buf_mismatch A' 'SELECT A FROM buf_mismatch SETTINGS enable_analyzer = 0'

--- a/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.sh
+++ b/tests/queries/0_stateless/04759_distributed_fetch_columns_column_names.sh
@@ -41,6 +41,12 @@ CREATE MATERIALIZED VIEW mv1 TO dist_target AS SELECT toUInt64(A) AS A FROM mv_s
 -- prefer_localhost_replica the run happens to randomize.
 INSERT INTO mv_source SELECT -number FROM numbers(10) SETTINGS distributed_foreground_insert = 1;
 
+-- Merge forwards its child's stage, so a Distributed child is read at FetchColumns here too, and
+-- Merge adapts that header itself: by name when the names match, by position otherwise.
+CREATE TABLE mrg (A Int64, B Int64) ENGINE = Merge(currentDatabase(), '^dist$');
+-- Merge whose declared type differs from the child's un-order-preservingly, as buf_mismatch does.
+CREATE TABLE mrg_mismatch (A UInt64, B Int64) ENGINE = Merge(currentDatabase(), '^dist$');
+
 CREATE TABLE rt (k Int64, v Int64) ENGINE = MergeTree ORDER BY k;
 INSERT INTO rt SELECT -number, number FROM numbers(5);
 -- Keys matching a NONZERO B, so a value replaced by a default is visible in the result.
@@ -85,6 +91,18 @@ fetch 'buf_widen A' 'SELECT A FROM buf_widen'
 
 echo '=== MaterializedView over a Distributed target ==='
 fetch 'mv1 A' 'SELECT A FROM mv1'
+
+echo '=== Merge over Distributed ==='
+fetch 'mrg A' 'SELECT A FROM mrg'
+fetch 'mrg A, B' 'SELECT A, B FROM mrg'
+# Reversed projection, so a positional match against a differently ordered header would swap A and B.
+# Both of Merge's headers are built from the requested columns, so the two ways it can match agree
+# here; this case is what would show it if that ever stopped holding.
+fetch 'mrg B, A' 'SELECT B, A FROM mrg'
+fetch 'mrg filtered' 'SELECT A FROM mrg WHERE B > 900'
+fetch 'mrg, serialize_query_plan' 'SELECT A FROM mrg SETTINGS serialize_query_plan = 1'
+fetch 'mrg_mismatch A' 'SELECT A FROM mrg_mismatch'
+fetch 'mrg_mismatch B, A' 'SELECT B, A FROM mrg_mismatch'
 
 echo '=== Distributed read without a wrapper ==='
 fetch 'dist A' 'SELECT A FROM dist'


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed wrong results and spurious `THERE_IS_NO_COLUMN` errors when reading a `Buffer` table whose destination is `Distributed` at `QueryProcessingStage::FetchColumns`, for example with the client option `--stage fetch_columns`. `StorageDistributed` returned analyzer column identifiers such as `__table1.A` instead of column names, so the wrapping storage failed to adapt the result by name.


### Description

No related open issue found.

`IStorage::read` at `FetchColumns` is supposed to return column names. `StorageDistributed` was the
exception, and `PlannerJoinTree.cpp` already said so: "IStorage::read -> FetchColumns returns normal
column names (except Distributed, which is inconsistent) ... this the reason for the bug ^ in
Distributed / Hopefully there is no other case when we read from Distributed up to FetchColumns."

There are other cases. `StorageDistributed::read` derives its header by analyzing the rebuilt
distributed query tree, which passes through the planner's `FetchColumns` name-to-identifier rename,
so the header comes back as `__table1.A`. `StorageBuffer::read` then adapts it by name and misfires:
`addMissingDefaults` invents the requested column as a default, which constant-folds into silent
wrong results, or `makeConvertingActions` throws `Code 8: Cannot find column 'A' in source stream,
there are only columns: [__table1.A]`.

This needs no type mismatch: with `--stage fetch_columns`, a plain `Buffer` over a `Distributed` of
the same structure returns `Code 8` on master, and a retyped one returns 2000 rows all `0`.
`ORDER BY` or `LIMIT` hides it, since both push the stage above `FetchColumns`.

The fix restores the contract where it is broken: after `ClusterProxy::executeQuery`,
`StorageDistributed::read` aliases each identifier in the plan's output header back to its column
name, resolved from the shard query tree by matching the storage that stands in for the remote table
(a node pointer would not survive the second clone that shipping a subquery to the shards performs).
The header sent to shards is untouched, and an output the map cannot resolve is left alone.

Validated on a two-shard cluster: 16 of the 31 cases fixed, the other 15 byte-identical controls
(direct, nested and distributed-over-distributed reads, JOINs, plan serialization, a
`MaterializedView` over a `Distributed` target, a `Merge` over a `Distributed`).
Runs of the `distributed` and `buffer` suites show no failure attributable to the change.

<details><summary>Two notes for the reviewer</summary>

The `isRemote() && to_stage == FetchColumns` passthrough in `PlannerJoinTree` is retained and widened
from `table_node` to `table_node || table_function_node`: a remote read at this stage can return
columns outside the storage's schema, such as joined columns, which must not be dropped, and for
`cluster()` on the left of a join the non-null handle is the table function node, so the joined
column was dropped from the header. The passthrough fires only when the identifier lookup already
failed, so it cannot double-rename.

`MatchColumnsMode::Position` is not a fix here even though `StorageMerge` uses it for a similar
adaptation. The damage is done earlier, by `addMissingDefaults` matching by name, and `Buffer`
builds its header in declaration order while reading the destination in requested order, so
`SELECT B, A` would silently cast `B` into `A`. The regression test keeps that case.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=113413&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/113413](https://github.com/search?q=head%3Async-upstream%2Fpr%2F113413+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
