### PR TITLE
Honor query cancellation while building child plans of a `Merge` table

### DIFF
--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -26,6 +26,7 @@
 #include <Interpreters/IdentifierSemantic.h>
 #include <Interpreters/InterpreterSelectQuery.h>
 #include <Interpreters/InterpreterSelectQueryAnalyzer.h>
+#include <Interpreters/ProcessList.h>
 #include <Interpreters/TreeRewriter.h>
 #include <Interpreters/addTypeConversionToAST.h>
 #include <Interpreters/evaluateConstantExpression.h>
@@ -714,9 +715,16 @@ std::vector<ReadFromMerge::ChildPlan> ReadFromMerge::createChildrenPlans(SelectQ
     };
     std::unordered_map<String, CachedModifiedQueryInfo> query_info_cache;
 
+    QueryStatusPtr query_status = context->getProcessListElementSafe();
+
     /// Settings will be modified when planning children tables.
     for (const auto & table : selected_tables)
     {
+        /// Building a plan (including query analysis) for every child table can take a long time when
+        /// the Merge table matches many tables, so honor `KILL QUERY` and `max_execution_time` between tables.
+        if (query_status)
+            query_status->checkTimeLimit();
+
         const auto & storage = std::get<1>(table);
 
         LOG_TRACE(logger, "Building plan for child table {}", storage->getStorageID().getNameForLogs());


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/107567

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A query over a `Merge` table (or the `merge` table function) that matches many tables now reacts to `KILL QUERY` and `max_execution_time` while the per-table query plans are being built, instead of only after the planning of all children has finished.

### Description

Found by the `Hung check` in `Stress test (amd_debug)` on #107567: [report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107567&sha=d5ae3e0974cac915fa777aeaefdf33f1ea669caa&name_0=PR&name_1=Stress%20test%20%28amd_debug%29). A fuzzer-mutated query `SELECT * FROM merge(REGEXP('^'), '^') AS t1 INNER JOIN system.one AS t2 ON t1.dummy = t2.dummy LIMIT 0` sat in the processlist for 3693 seconds with `is_cancelled = 1` and `max_execution_time = 10`, stuck under `ReadFromMerge::getModifiedQueryInfo` (query analysis of a child table) called from `ReadFromMerge::createChildrenPlans`.

`merge(REGEXP('^'), '^')` matches every table in every database, and `createChildrenPlans` runs query analysis and plan construction for each of them without ever consulting the query status. On the stress host (debug build, `ThreadFuzzer` injecting sleeps, thousands of leftover test tables) that loop runs for over an hour, ignoring both `KILL QUERY` and `max_execution_time`, which the hung check then reports as a possible deadlock.

The fix adds a `QueryStatus::checkTimeLimit` call at the top of the per-table loop, following the same pattern as `JoinOrderOptimizer::checkLimits`, so cancellation and time limits are honored between child tables. There is no new stateless test: the slowness that makes the gap observable comes from `ThreadFuzzer` and the sheer number of matched tables, so a functional test would either pass trivially on fast builds or be flaky; the change itself is a standard cancellation checkpoint.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.875` (included in `26.8` and later)
<!-- ch-version-info:end -->