### PR TITLE
Observe query cancellation in the compact-part mark read loop

### DIFF
--- a/src/Storages/MergeTree/MergeTreeReaderCompactSingleBuffer.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompactSingleBuffer.cpp
@@ -22,7 +22,7 @@ namespace
 {
 
 /// A cancelled or timed-out query says nothing about the part's health, so such an exception must
-/// not reach reportBroken().
+/// not reach reportBroken.
 bool isQueryCancellation(std::exception_ptr exception_ptr)
 {
     try
@@ -70,7 +70,7 @@ try
     while (read_rows < max_rows_to_read)
     {
         /// Throws QUERY_WAS_CANCELLED on a cancelled query and TIMEOUT_EXCEEDED past
-        /// max_execution_time in throw mode; cheap (a flag plus an elapsed-timer read).
+        /// max_execution_time in throw mode.
         if (query_status)
             query_status->checkTimeLimit();
 

--- a/src/Storages/MergeTree/MergeTreeReaderCompactSingleBuffer.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompactSingleBuffer.cpp
@@ -35,7 +35,7 @@ bool isQueryCancellation(std::exception_ptr exception_ptr)
             || e.code() == ErrorCodes::QUERY_WAS_CANCELLED_BY_CLIENT
             || e.code() == ErrorCodes::TIMEOUT_EXCEEDED;
     }
-    catch (...)
+    catch (...) /// Ok: only DB::Exception carries an error code, so nothing else can be a cancellation.
     {
         return false;
     }

--- a/src/Storages/MergeTree/MergeTreeReaderCompactSingleBuffer.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompactSingleBuffer.cpp
@@ -11,38 +11,6 @@
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int QUERY_WAS_CANCELLED;
-    extern const int QUERY_WAS_CANCELLED_BY_CLIENT;
-    extern const int TIMEOUT_EXCEEDED;
-}
-
-namespace
-{
-
-/// A cancelled or timed-out query says nothing about the part's health, so such an exception must
-/// not reach reportBroken.
-bool isQueryCancellation(std::exception_ptr exception_ptr)
-{
-    try
-    {
-        rethrow_exception(exception_ptr);
-    }
-    catch (const Exception & e)
-    {
-        return e.code() == ErrorCodes::QUERY_WAS_CANCELLED
-            || e.code() == ErrorCodes::QUERY_WAS_CANCELLED_BY_CLIENT
-            || e.code() == ErrorCodes::TIMEOUT_EXCEEDED;
-    }
-    catch (...) /// Ok: only DB::Exception carries an error code, so nothing else can be a cancellation.
-    {
-        return false;
-    }
-}
-
-}
-
 size_t MergeTreeReaderCompactSingleBuffer::readRows(
     size_t from_mark, size_t current_task_last_mark,
     bool continue_reading, size_t max_rows_to_read,

--- a/src/Storages/MergeTree/MergeTreeReaderCompactSingleBuffer.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompactSingleBuffer.cpp
@@ -4,9 +4,44 @@
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/NestedUtils.h>
 #include <Compression/CachedCompressedReadBuffer.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
+#include <Common/CurrentThread.h>
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int QUERY_WAS_CANCELLED;
+    extern const int QUERY_WAS_CANCELLED_BY_CLIENT;
+    extern const int TIMEOUT_EXCEEDED;
+}
+
+namespace
+{
+
+/// A cancelled or timed-out query says nothing about the part's health, so such an exception must
+/// not reach reportBroken().
+bool isQueryCancellation(std::exception_ptr exception_ptr)
+{
+    try
+    {
+        rethrow_exception(exception_ptr);
+    }
+    catch (const Exception & e)
+    {
+        return e.code() == ErrorCodes::QUERY_WAS_CANCELLED
+            || e.code() == ErrorCodes::QUERY_WAS_CANCELLED_BY_CLIENT
+            || e.code() == ErrorCodes::TIMEOUT_EXCEEDED;
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+}
 
 size_t MergeTreeReaderCompactSingleBuffer::readRows(
     size_t from_mark, size_t current_task_last_mark,
@@ -25,8 +60,20 @@ try
     checkNumberOfColumns(num_columns);
     createColumnsForReading(res_columns);
 
+    /// One call reads every mark of the requested block, and query limits are otherwise only
+    /// enforced between blocks. With a small index_granularity a single block spans tens of
+    /// thousands of marks, so without a check here a cancelled query keeps reading to completion.
+    QueryStatusPtr query_status;
+    if (auto query_context = CurrentThread::tryGetQueryContext())
+        query_status = query_context->getProcessListElementSafe();
+
     while (read_rows < max_rows_to_read)
     {
+        /// Throws QUERY_WAS_CANCELLED on a cancelled query and TIMEOUT_EXCEEDED past
+        /// max_execution_time in throw mode; cheap (a flag plus an elapsed-timer read).
+        if (query_status)
+            query_status->checkTimeLimit();
+
         size_t rows_to_read = data_part_info_for_read->getIndexGranularity().getMarkRows(from_mark);
 
         if (rows_to_read <= rows_offset)
@@ -111,7 +158,7 @@ try
 }
 catch (...)
 {
-    if (!isRetryableException(std::current_exception()))
+    if (!isRetryableException(std::current_exception()) && !isQueryCancellation(std::current_exception()))
         data_part_info_for_read->reportBroken();
 
     /// Better diagnostics.

--- a/src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp
@@ -13,6 +13,8 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/inplaceBlockConversions.h>
+#include <Interpreters/ProcessList.h>
+#include <Common/CurrentThread.h>
 #include <Common/logger_useful.h>
 #include <Columns/ColumnsNumber.h>
 #include <Storages/MergeTree/TextIndexCache.h>
@@ -479,8 +481,20 @@ size_t MergeTreeReaderTextIndex::readRows(
 
     size_t fallback_offset = 0;
 
+    /// One call reads every mark of the requested block, and query limits are otherwise only
+    /// enforced between blocks. With a small index_granularity a single block spans tens of
+    /// thousands of marks, so without a check here a cancelled query keeps reading to completion.
+    QueryStatusPtr query_status;
+    if (auto query_context = CurrentThread::tryGetQueryContext())
+        query_status = query_context->getProcessListElementSafe();
+
     while (read_rows < max_rows_to_read && from_mark < total_marks)
     {
+        /// Throws QUERY_WAS_CANCELLED on a cancelled query and TIMEOUT_EXCEEDED past
+        /// max_execution_time in throw mode.
+        if (query_status)
+            query_status->checkTimeLimit();
+
         /// When the number of rows in a part is smaller than `index_granularity`,
         /// `MergeTreeReaderTextIndex` must ensure that the virtual column it reads
         /// contains no more data rows than actually exist in the part

--- a/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
+++ b/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
@@ -294,7 +294,7 @@ try
 catch (...)
 {
     /// Suspicion of the broken part. A part is added to the queue for verification.
-    if (!isRetryableException(std::current_exception()))
+    if (!isRetryableException(std::current_exception()) && !isQueryCancellation(std::current_exception()))
         read_task_info->data_part_info->reportBroken();
     throw;
 }

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -53,6 +53,9 @@ namespace ErrorCodes
     extern const int ABORTED;
     extern const int CANNOT_WRITE_TO_OSTREAM;
     extern const int CACHE_CANNOT_WRITE_TO_CACHE_DISK;
+    extern const int QUERY_WAS_CANCELLED;
+    extern const int QUERY_WAS_CANCELLED_BY_CLIENT;
+    extern const int TIMEOUT_EXCEEDED;
 }
 
 
@@ -142,6 +145,24 @@ bool isRetryableException(std::exception_ptr exception_ptr)
     {
         /// In fact, there can be other similar situations.
         /// But it is OK, because there is a safety guard against deleting too many parts.
+        return false;
+    }
+}
+
+bool isQueryCancellation(std::exception_ptr exception_ptr)
+{
+    try
+    {
+        rethrow_exception(exception_ptr);
+    }
+    catch (const Exception & e)
+    {
+        return e.code() == ErrorCodes::QUERY_WAS_CANCELLED
+            || e.code() == ErrorCodes::QUERY_WAS_CANCELLED_BY_CLIENT
+            || e.code() == ErrorCodes::TIMEOUT_EXCEEDED;
+    }
+    catch (...) /// Ok: only DB::Exception carries an error code, so nothing else can be a cancellation.
+    {
         return false;
     }
 }

--- a/src/Storages/MergeTree/checkDataPart.h
+++ b/src/Storages/MergeTree/checkDataPart.h
@@ -17,4 +17,8 @@ IMergeTreeDataPart::Checksums checkDataPart(
 bool isNotEnoughMemoryErrorCode(int code);
 bool isRetryableException(std::exception_ptr exception_ptr);
 
+/// A cancelled or timed-out query says nothing about the part's health, so such an exception must
+/// not reach reportBroken.
+bool isQueryCancellation(std::exception_ptr exception_ptr);
+
 }

--- a/src/Storages/MergeTree/checkDataPart.h
+++ b/src/Storages/MergeTree/checkDataPart.h
@@ -17,8 +17,7 @@ IMergeTreeDataPart::Checksums checkDataPart(
 bool isNotEnoughMemoryErrorCode(int code);
 bool isRetryableException(std::exception_ptr exception_ptr);
 
-/// A cancelled or timed-out query says nothing about the part's health, so such an exception must
-/// not reach reportBroken.
+/// True for a cancelled or timed-out query, which says nothing about the part's health.
 bool isQueryCancellation(std::exception_ptr exception_ptr);
 
 }

--- a/tests/queries/0_stateless/04746_compact_part_read_cancellation.reference
+++ b/tests/queries/0_stateless/04746_compact_part_read_cancellation.reference
@@ -8,3 +8,4 @@ part checks	0
 text part type	Compact
 text index used	1
 text timeout observed inside the part read
+text index reader ran	1

--- a/tests/queries/0_stateless/04746_compact_part_read_cancellation.reference
+++ b/tests/queries/0_stateless/04746_compact_part_read_cancellation.reference
@@ -1,0 +1,7 @@
+part type	Compact
+timeout observed inside the part read
+timeout honoured
+kill observed inside the part read
+active parts	1
+detached parts	0
+part checks	0

--- a/tests/queries/0_stateless/04746_compact_part_read_cancellation.reference
+++ b/tests/queries/0_stateless/04746_compact_part_read_cancellation.reference
@@ -1,11 +1,10 @@
 part type	Compact
 timeout observed inside the part read
-timeout honoured
 kill observed inside the part read
 active parts	1
 detached parts	0
 part checks	0
 text part type	Compact
 text index used	1
-text timeout observed inside the part read
-text index reader ran	1
+text kill observed inside the part read
+text index reader ran	1	0

--- a/tests/queries/0_stateless/04746_compact_part_read_cancellation.reference
+++ b/tests/queries/0_stateless/04746_compact_part_read_cancellation.reference
@@ -5,3 +5,6 @@ kill observed inside the part read
 active parts	1
 detached parts	0
 part checks	0
+text part type	Compact
+text index used	1
+text timeout observed inside the part read

--- a/tests/queries/0_stateless/04746_compact_part_read_cancellation.sh
+++ b/tests/queries/0_stateless/04746_compact_part_read_cancellation.sh
@@ -173,37 +173,56 @@ WHERE explain ILIKE '%Name: idx_s%'"
 # reader's own check, so the token would report an interrupt with the text-index check reverted.
 # Cancelled by KILL rather than by a deadline, for the reason given above the compact timeout arm:
 # analysing this index costs more than a fixed limit on a loaded runner, so a deadline can expire
-# before the read starts. KILL is ordered after the handshake below, so it always arrives while the
-# read is running.
+# before the read starts.
+#
+# The handshake below cannot prove the read has begun: SelectedMarks is incremented once index
+# analysis is over but before the pipeline runs, and no counter advances while the reader walks
+# marks, so every available signal either precedes the read or appears only after it ends. A cancel
+# sent on the earlier one lands before the reader is entered whenever the gap between them
+# stretches, which is what a loaded runner does. So retry, keyed on the same interrupt-site
+# diagnostic the compact arms use, growing the pause before the cancel until it lands inside.
+# Every pause stays below how long the read lasts, because one that outlasted it would let the query
+# finish and leave the diagnostic absent for the opposite reason, which this retry cannot tell apart
+# and would answer by pausing longer still. Load only slows the walk, so that margin is smallest on
+# an idle machine.
 text_err="${CLICKHOUSE_TMP}/04746_text_err.txt"
-text_query_id="text_read_cancel_${CLICKHOUSE_DATABASE}_$$"
-${CLICKHOUSE_CLIENT} --query_id "$text_query_id" \
-    --max_block_size 100000000 --preferred_block_size_bytes 0 --max_threads 1 \
-    --use_skip_indexes_on_data_read 0 --query_plan_direct_read_from_text_index 1 \
-    -q "$text_query" >/dev/null 2>"$text_err" &
-text_pid=$!
-
-# Wait until the query is inside the single block read: every mark has been selected, so analysis
-# is over, while no row has reached the pipeline yet (read_rows = 0), so the reader is still
-# walking marks. No counter advances during that walk, which is why the handshake tests entry
-# into the read rather than progress through it.
 text_reading=0
-for _ in $(seq 1 600); do
-    text_reading=$(${CLICKHOUSE_CLIENT} -q "
-        SELECT ProfileEvents['SelectedMarks'] > 0 AND read_rows = 0
-        FROM system.processes WHERE query_id = '$text_query_id'")
-    [ "$text_reading" = "1" ] && break
-    sleep 0.1
+for text_settle in 0 0.25 0.5 1 2 4; do
+    text_query_id="text_read_cancel_${CLICKHOUSE_DATABASE}_$$_${text_settle}"
+    ${CLICKHOUSE_CLIENT} --query_id "$text_query_id" \
+        --max_block_size 100000000 --preferred_block_size_bytes 0 --max_threads 1 \
+        --use_skip_indexes_on_data_read 0 --query_plan_direct_read_from_text_index 1 \
+        -q "$text_query" >/dev/null 2>"$text_err" &
+    text_pid=$!
+
+    # Every mark has been selected, so analysis is over, while no row has reached the pipeline yet
+    # (read_rows = 0), so the query has not delivered a block.
+    text_reading=0
+    for _ in $(seq 1 600); do
+        text_reading=$(${CLICKHOUSE_CLIENT} -q "
+            SELECT ProfileEvents['SelectedMarks'] > 0 AND read_rows = 0
+            FROM system.processes WHERE query_id = '$text_query_id'")
+        [ "$text_reading" = "1" ] && break
+        sleep 0.1
+    done
+
+    if [ "$text_reading" != "1" ]; then
+        wait "$text_pid" 2>/dev/null
+        break
+    fi
+
+    [ "$text_settle" != "0" ] && sleep "$text_settle"
+    ${CLICKHOUSE_CLIENT} -q "KILL QUERY WHERE query_id = '$text_query_id' SYNC FORMAT Null"
+    wait "$text_pid" 2>/dev/null
+    grep -qF 'While reading part' "$text_err" && break
 done
 
 echo -n 'text kill observed '
 if [ "$text_reading" != "1" ]; then
     echo 'did not observe the in-block read phase'
 else
-    ${CLICKHOUSE_CLIENT} -q "KILL QUERY WHERE query_id = '$text_query_id' SYNC FORMAT Null"
     inside_part_read "$text_err"
 fi
-wait "$text_pid" 2>/dev/null
 rm -f "$text_err"
 
 # The line above proves the query stopped inside a block read, and 'text index used' proves the

--- a/tests/queries/0_stateless/04746_compact_part_read_cancellation.sh
+++ b/tests/queries/0_stateless/04746_compact_part_read_cancellation.sh
@@ -162,12 +162,29 @@ SELECT 'text index used', count() > 0 FROM (EXPLAIN indexes = 1 $text_query) WHE
 # the predicate is evaluated over the physical column, and the token then comes from the compact
 # reader's own check, so the assertion would pass with the text-index check reverted.
 text_err="${CLICKHOUSE_TMP}/04746_text_err.txt"
-${CLICKHOUSE_CLIENT} --max_block_size 100000000 --preferred_block_size_bytes 0 --max_threads 1 \
+text_query_id="text_read_cancel_${CLICKHOUSE_DATABASE}_$$"
+${CLICKHOUSE_CLIENT} --query_id "$text_query_id" \
+    --max_block_size 100000000 --preferred_block_size_bytes 0 --max_threads 1 \
     --use_skip_indexes_on_data_read 0 --query_plan_direct_read_from_text_index 1 \
     --max_execution_time 1 --timeout_overflow_mode throw \
     -q "$text_query" >/dev/null 2>"$text_err"
 echo -n 'text timeout observed '
 inside_part_read "$text_err"
 rm -f "$text_err"
+
+# The line above proves the query stopped inside a block read, and 'text index used' proves the
+# index pruned granules, but neither proves the text index READER served the query: the direct-read
+# rewrite is decided separately from pruning. This event is incremented only at the top of
+# MergeTreeReaderTextIndex::readRows, and its scope guard reports during unwinding, so it is
+# recorded even though this query leaves that function by throwing. Match
+# ExceptionWhileProcessing, not QueryFinish: the fixed server ends this query with a thrown
+# TIMEOUT_EXCEEDED, so there is no QueryFinish row.
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS query_log"
+${CLICKHOUSE_CLIENT} -q "
+SELECT 'text index reader ran', ProfileEvents['TextIndexReaderTotalMicroseconds'] > 0
+FROM system.query_log
+WHERE current_database = currentDatabase() AND query_id = '$text_query_id'
+  AND type = 'ExceptionWhileProcessing' AND event_date >= yesterday()
+ORDER BY event_time DESC LIMIT 1"
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_text_read_cancel SYNC"

--- a/tests/queries/0_stateless/04746_compact_part_read_cancellation.sh
+++ b/tests/queries/0_stateless/04746_compact_part_read_cancellation.sh
@@ -4,8 +4,9 @@
 # no-random-settings: the read-speed family (local_filesystem_read_method, max_read_buffer_size,
 # enable_filesystem_cache, use_page_cache_for_local_disks,
 # merge_tree_compact_parts_min_granules_to_multibuffer_read) is randomized, and a fast enough
-# combination makes the unpatched read finish under the assertions below, which stops them
-# discriminating. max_block_size is randomized too, but every query that depends on it sets it.
+# combination lets the unpatched read finish before a cancel is delivered, which stops the
+# assertions discriminating. max_block_size is randomized too, but every query that depends on it
+# sets it.
 # The text arm additionally depends on use_skip_indexes_on_data_read and
 # query_plan_direct_read_from_text_index, which are randomized too; those it pins per query,
 # because each one on its own makes that assertion pass with the fix reverted.
@@ -51,22 +52,25 @@ inside_part_read() {
     grep -qF 'While reading part' "$1" && echo 'inside the part read' || echo "not interrupted inside the part read: $(head -c 400 "$1")"
 }
 
+# max_execution_time runs from the start of the query, so loading the marks and analysing the index
+# are charged against it, and several checks fire before the read begins. On a loaded runner the
+# work before the read can outlast a fixed limit, and the deadline then fires while the query is
+# still being prepared, so the read is never entered and the diagnostic above cannot appear. Retry
+# with a longer limit until the deadline lands inside the read, keyed on that diagnostic itself:
+# it is the only signal that reports where the query stopped. A limit that stops timing out at all
+# is already too generous, so the ladder ends there. The elapsed value is not asserted, because it
+# is everything before the read plus one mark, so it tracks machine load.
 timeout_err="${CLICKHOUSE_TMP}/04746_timeout_err.txt"
-${CLICKHOUSE_CLIENT} --max_block_size 100000000 --preferred_block_size_bytes 0 --max_threads 1 \
-    --max_execution_time 1 --timeout_overflow_mode throw \
-    -q "$read_query" >/dev/null 2>"$timeout_err"
+for limit in 1 2 4 8 16 32 64; do
+    ${CLICKHOUSE_CLIENT} --max_block_size 100000000 --preferred_block_size_bytes 0 --max_threads 1 \
+        --max_execution_time "$limit" --timeout_overflow_mode throw \
+        -q "$read_query" >/dev/null 2>"$timeout_err"
+    grep -qF 'While reading part' "$timeout_err" && break
+    grep -q 'Timeout exceeded' "$timeout_err" || break
+done
+
 echo -n 'timeout observed '
 inside_part_read "$timeout_err"
-
-# The whole point of the check is that max_execution_time is respected, so also require the
-# reported elapsed to stay near the limit. 5x the 1s limit is far above the fixed server (which
-# stops one mark past the limit) and far below an uninterrupted read of this part.
-elapsed=$(sed -nE 's/.*elapsed ([0-9]+)\.[0-9]+ ms.*/\1/p' "$timeout_err" | head -1)
-if [ -n "$elapsed" ] && [ "$elapsed" -lt 5000 ]; then
-    echo 'timeout honoured'
-else
-    echo "timeout overshot: elapsed=${elapsed}ms"
-fi
 
 query_id="compact_read_cancel_${CLICKHOUSE_DATABASE}_$$"
 kill_err="${CLICKHOUSE_TMP}/04746_kill_err.txt"
@@ -139,10 +143,12 @@ SELECT 'text part type', part_type FROM system.parts
 WHERE database = currentDatabase() AND table = 't_text_read_cancel' AND active"
 
 # Every row carries 'filler', so no mark is pruned and the walk covers all 400k of them. Each
-# extra predicate adds a virtual column whose posting list is materialized per mark, which is what
-# makes one block's walk long enough to measure.
+# extra predicate adds a virtual column whose posting list is materialized per mark, and the walk
+# costs about 150 ms per predicate, so the count sets how long the read lasts. It has to stay long
+# relative to the handshake below, which needs a few client round-trips: at 30 predicates the read
+# takes 4.5 s and the cancel can arrive after it has already finished.
 text_pred="1"
-for i in $(seq 1 30); do
+for i in $(seq 1 120); do
     text_pred="$text_pred AND hasAnyTokens(s, ['filler', 'tok$i'])"
 done
 text_query="SELECT count() FROM t_text_read_cancel WHERE $text_pred"
@@ -160,28 +166,51 @@ SELECT 'text index used', count() > 0 FROM (EXPLAIN indexes = 1 $text_query) WHE
 # the token reports its interrupt site.
 # query_plan_direct_read_from_text_index = 1: with it disabled the text reader is not used at all,
 # the predicate is evaluated over the physical column, and the token then comes from the compact
-# reader's own check, so the assertion would pass with the text-index check reverted.
+# reader's own check, so the token would report an interrupt with the text-index check reverted.
+# Cancelled by KILL rather than by a deadline, for the reason given above the compact timeout arm:
+# analysing this index costs more than a fixed limit on a loaded runner, so a deadline can expire
+# before the read starts. KILL is ordered after the handshake below, so it always arrives while the
+# read is running.
 text_err="${CLICKHOUSE_TMP}/04746_text_err.txt"
 text_query_id="text_read_cancel_${CLICKHOUSE_DATABASE}_$$"
 ${CLICKHOUSE_CLIENT} --query_id "$text_query_id" \
     --max_block_size 100000000 --preferred_block_size_bytes 0 --max_threads 1 \
     --use_skip_indexes_on_data_read 0 --query_plan_direct_read_from_text_index 1 \
-    --max_execution_time 1 --timeout_overflow_mode throw \
-    -q "$text_query" >/dev/null 2>"$text_err"
-echo -n 'text timeout observed '
-inside_part_read "$text_err"
+    -q "$text_query" >/dev/null 2>"$text_err" &
+text_pid=$!
+
+# Wait until the query is inside the single block read: every mark has been selected, so analysis
+# is over, while no row has reached the pipeline yet (read_rows = 0), so the reader is still
+# walking marks. No counter advances during that walk, which is why the handshake tests entry
+# into the read rather than progress through it.
+text_reading=0
+for _ in $(seq 1 600); do
+    text_reading=$(${CLICKHOUSE_CLIENT} -q "
+        SELECT ProfileEvents['SelectedMarks'] > 0 AND read_rows = 0
+        FROM system.processes WHERE query_id = '$text_query_id'")
+    [ "$text_reading" = "1" ] && break
+    sleep 0.1
+done
+
+echo -n 'text kill observed '
+if [ "$text_reading" != "1" ]; then
+    echo 'did not observe the in-block read phase'
+else
+    ${CLICKHOUSE_CLIENT} -q "KILL QUERY WHERE query_id = '$text_query_id' SYNC FORMAT Null"
+    inside_part_read "$text_err"
+fi
+wait "$text_pid" 2>/dev/null
 rm -f "$text_err"
 
 # The line above proves the query stopped inside a block read, and 'text index used' proves the
 # index pruned granules, but neither proves the text index READER served the query: the direct-read
 # rewrite is decided separately from pruning. This event is incremented only at the top of
 # MergeTreeReaderTextIndex::readRows, and its scope guard reports during unwinding, so it is
-# recorded even though this query leaves that function by throwing. Match
-# ExceptionWhileProcessing, not QueryFinish: the fixed server ends this query with a thrown
-# TIMEOUT_EXCEEDED, so there is no QueryFinish row.
+# recorded even though this query leaves that function by throwing. read_rows stays 0 because the
+# interrupted read delivers no block, which an uninterrupted walk would.
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS query_log"
 ${CLICKHOUSE_CLIENT} -q "
-SELECT 'text index reader ran', ProfileEvents['TextIndexReaderTotalMicroseconds'] > 0
+SELECT 'text index reader ran', ProfileEvents['TextIndexReaderTotalMicroseconds'] > 0, read_rows
 FROM system.query_log
 WHERE current_database = currentDatabase() AND query_id = '$text_query_id'
   AND type = 'ExceptionWhileProcessing' AND event_date >= yesterday()

--- a/tests/queries/0_stateless/04746_compact_part_read_cancellation.sh
+++ b/tests/queries/0_stateless/04746_compact_part_read_cancellation.sh
@@ -6,6 +6,9 @@
 # merge_tree_compact_parts_min_granules_to_multibuffer_read) is randomized, and a fast enough
 # combination makes the unpatched read finish under the assertions below, which stops them
 # discriminating. max_block_size is randomized too, but every query that depends on it sets it.
+# The text arm additionally depends on use_skip_indexes_on_data_read and
+# query_plan_direct_read_from_text_index, which are randomized too; those it pins per query,
+# because each one on its own makes that assertion pass with the fix reverted.
 # no-random-merge-tree-settings: the read must go through a Compact part with
 # index_granularity = 1, and both that and min_bytes_for_wide_part are randomized. Redundant
 # today, since no-random-settings already disables the merge-tree randomizer, but kept so the
@@ -40,9 +43,10 @@ WHERE database = currentDatabase() AND table = 't_compact_read_cancel' AND activ
 
 read_query="SELECT count(), sum(length(a)+length(b)+length(c)+length(d)+length(e)+length(f)+length(g)+length(h)+length(i)) FROM t_compact_read_cancel"
 
-# Only readRows() appends this diagnostic, so its presence proves the query stopped inside the
-# block read rather than after it. The wall clock is not asserted: it depends on the machine,
-# while the interrupt site does not.
+# This diagnostic is appended by MergeTreeReadersChain::read, whose try covers only the in-block
+# startReadingChain call, so its presence proves the query stopped inside the block read rather
+# than after it. The wall clock is not asserted: it depends on the machine, while the interrupt
+# site does not.
 inside_part_read() {
     grep -qF 'While reading part' "$1" && echo 'inside the part read' || echo "not interrupted inside the part read: $(head -c 400 "$1")"
 }
@@ -112,3 +116,58 @@ WHERE event_date >= yesterday()
   AND message LIKE 'Enqueueing%for check%'"
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_compact_read_cancel SYNC"
+
+# The text index reader has the same unchecked per-mark loop, and it is a separate reader: the
+# compact reader's check cannot fire for a query that reads no physical column, because such a
+# main reader is left out of the readers chain entirely.
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_text_read_cancel SYNC"
+${CLICKHOUSE_CLIENT} -q "
+CREATE TABLE t_text_read_cancel (k UInt64, s String, INDEX idx_s s TYPE text(tokenizer = 'splitByNonAlpha'))
+ENGINE = MergeTree
+ORDER BY k
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000
+"
+
+${CLICKHOUSE_CLIENT} \
+    --max_block_size 400000 --max_insert_block_size 400000 \
+    --min_insert_block_size_rows 0 --min_insert_block_size_bytes 0 \
+    -q "INSERT INTO t_text_read_cancel
+        SELECT number, concat('tok', toString(number % 1000), ' filler text here') FROM numbers(400000)"
+
+${CLICKHOUSE_CLIENT} -q "
+SELECT 'text part type', part_type FROM system.parts
+WHERE database = currentDatabase() AND table = 't_text_read_cancel' AND active"
+
+# Every row carries 'filler', so no mark is pruned and the walk covers all 400k of them. Each
+# extra predicate adds a virtual column whose posting list is materialized per mark, which is what
+# makes one block's walk long enough to measure.
+text_pred="1"
+for i in $(seq 1 30); do
+    text_pred="$text_pred AND hasAnyTokens(s, ['filler', 'tok$i'])"
+done
+text_query="SELECT count() FROM t_text_read_cancel WHERE $text_pred"
+
+# Assert the text index is what serves the query: if it silently fell back to a full scan the
+# reader under test would never run.
+${CLICKHOUSE_CLIENT} --use_skip_indexes_on_data_read 0 --query_plan_direct_read_from_text_index 1 -q "
+SELECT 'text index used', count() > 0 FROM (EXPLAIN indexes = 1 $text_query) WHERE explain ILIKE '%Name: idx_s%'"
+
+# Both settings are pinned per query because both are randomized and each one silently disarms the
+# assertion below.
+# use_skip_indexes_on_data_read = 0: with it enabled a MergeTreeReaderIndex is placed ahead of the
+# text reader in the chain, so the text reader is driven by continueReadingChain, which sits
+# outside the try that appends the token. With it disabled the text reader is the first reader and
+# the token reports its interrupt site.
+# query_plan_direct_read_from_text_index = 1: with it disabled the text reader is not used at all,
+# the predicate is evaluated over the physical column, and the token then comes from the compact
+# reader's own check, so the assertion would pass with the text-index check reverted.
+text_err="${CLICKHOUSE_TMP}/04746_text_err.txt"
+${CLICKHOUSE_CLIENT} --max_block_size 100000000 --preferred_block_size_bytes 0 --max_threads 1 \
+    --use_skip_indexes_on_data_read 0 --query_plan_direct_read_from_text_index 1 \
+    --max_execution_time 1 --timeout_overflow_mode throw \
+    -q "$text_query" >/dev/null 2>"$text_err"
+echo -n 'text timeout observed '
+inside_part_read "$text_err"
+rm -f "$text_err"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_text_read_cancel SYNC"

--- a/tests/queries/0_stateless/04746_compact_part_read_cancellation.sh
+++ b/tests/queries/0_stateless/04746_compact_part_read_cancellation.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 # Tags: long, no-random-settings, no-random-merge-tree-settings
 #
-# no-random-settings: a random max_execution_time / max_rows_to_read would end the queries
-# instead of the limits set here, and max_block_size must stay large enough for one block to
-# span every mark.
+# no-random-settings: the read-speed family (local_filesystem_read_method, max_read_buffer_size,
+# enable_filesystem_cache, use_page_cache_for_local_disks,
+# merge_tree_compact_parts_min_granules_to_multibuffer_read) is randomized, and a fast enough
+# combination makes the unpatched read finish under the assertions below, which stops them
+# discriminating. max_block_size is randomized too, but every query that depends on it sets it.
 # no-random-merge-tree-settings: the read must go through a Compact part with
-# index_granularity = 1, and both are randomized settings.
+# index_granularity = 1, and both that and min_bytes_for_wide_part are randomized. Redundant
+# today, since no-random-settings already disables the merge-tree randomizer, but kept so the
+# requirement is explicit.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04746_compact_part_read_cancellation.sh
+++ b/tests/queries/0_stateless/04746_compact_part_read_cancellation.sh
@@ -30,13 +30,13 @@ ORDER BY k
 SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000
 "
 
-# One Compact part with 400k marks. index_granularity = 1 plus a block size covering the whole
+# One Compact part with 100k marks. index_granularity = 1 plus a block size covering the whole
 # part means a single readRows call has to walk every mark, which takes many seconds.
 ${CLICKHOUSE_CLIENT} \
-    --max_block_size 400000 --max_insert_block_size 400000 \
+    --max_block_size 100000 --max_insert_block_size 100000 \
     --min_insert_block_size_rows 0 --min_insert_block_size_bytes 0 \
     -q "INSERT INTO t_compact_read_cancel
-        SELECT number, s, s, s, s, s, s, s, s, s FROM (SELECT number, repeat('x', 30) AS s FROM numbers(400000))"
+        SELECT number, s, s, s, s, s, s, s, s, s FROM (SELECT number, repeat('x', 30) AS s FROM numbers(100000))"
 
 ${CLICKHOUSE_CLIENT} -q "
 SELECT 'part type', part_type FROM system.parts
@@ -133,30 +133,34 @@ SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, min_rows_f
 "
 
 ${CLICKHOUSE_CLIENT} \
-    --max_block_size 400000 --max_insert_block_size 400000 \
+    --max_block_size 100000 --max_insert_block_size 100000 \
     --min_insert_block_size_rows 0 --min_insert_block_size_bytes 0 \
     -q "INSERT INTO t_text_read_cancel
-        SELECT number, concat('tok', toString(number % 1000), ' filler text here') FROM numbers(400000)"
+        SELECT number, concat('tok', toString(number % 1000), ' filler text here') FROM numbers(100000)"
 
 ${CLICKHOUSE_CLIENT} -q "
 SELECT 'text part type', part_type FROM system.parts
 WHERE database = currentDatabase() AND table = 't_text_read_cancel' AND active"
 
-# Every row carries 'filler', so no mark is pruned and the walk covers all 400k of them. Each
+# Every row carries 'filler', so no mark is pruned and the walk covers all 100k of them. Each
 # extra predicate adds a virtual column whose posting list is materialized per mark, and the walk
-# costs about 150 ms per predicate, so the count sets how long the read lasts. It has to stay long
+# costs about 37 ms per predicate, so the count sets how long the read lasts. It has to stay long
 # relative to the handshake below, which needs a few client round-trips: at 30 predicates the read
-# takes 4.5 s and the cancel can arrive after it has already finished.
+# takes 1.1 s and the cancel can arrive after it has already finished.
 text_pred="1"
-for i in $(seq 1 120); do
+for i in $(seq 1 240); do
     text_pred="$text_pred AND hasAnyTokens(s, ['filler', 'tok$i'])"
 done
 text_query="SELECT count() FROM t_text_read_cancel WHERE $text_pred"
 
 # Assert the text index is what serves the query: if it silently fell back to a full scan the
-# reader under test would never run.
+# reader under test would never run. Analysing the predicate costs about as much per term as
+# reading does, so this asks the same question of a single term: whether the index is usable for
+# this predicate shape does not depend on how many terms are conjoined.
 ${CLICKHOUSE_CLIENT} --use_skip_indexes_on_data_read 0 --query_plan_direct_read_from_text_index 1 -q "
-SELECT 'text index used', count() > 0 FROM (EXPLAIN indexes = 1 $text_query) WHERE explain ILIKE '%Name: idx_s%'"
+SELECT 'text index used', count() > 0
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_text_read_cancel WHERE hasAnyTokens(s, ['filler', 'tok1']))
+WHERE explain ILIKE '%Name: idx_s%'"
 
 # Both settings are pinned per query because both are randomized and each one silently disarms the
 # assertion below.

--- a/tests/queries/0_stateless/04746_compact_part_read_cancellation.sh
+++ b/tests/queries/0_stateless/04746_compact_part_read_cancellation.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Tags: long, no-random-settings, no-random-merge-tree-settings
+#
+# no-random-settings: a random max_execution_time / max_rows_to_read would end the queries
+# instead of the limits set here, and max_block_size must stay large enough for one block to
+# span every mark.
+# no-random-merge-tree-settings: the read must go through a Compact part with
+# index_granularity = 1, and both are randomized settings.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_compact_read_cancel SYNC"
+
+# ReplicatedMergeTree so that a wrongly reported broken part is observable: its
+# broken_part_callback enqueues a part check, while plain MergeTree's is a no-op.
+${CLICKHOUSE_CLIENT} -q "
+CREATE TABLE t_compact_read_cancel (k UInt64, a String, b String, c String, d String, e String, f String, g String, h String, i String)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/t_compact_read_cancel', 'r1')
+ORDER BY k
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000
+"
+
+# One Compact part with 400k marks. index_granularity = 1 plus a block size covering the whole
+# part means a single readRows call has to walk every mark, which takes many seconds.
+${CLICKHOUSE_CLIENT} \
+    --max_block_size 400000 --max_insert_block_size 400000 \
+    --min_insert_block_size_rows 0 --min_insert_block_size_bytes 0 \
+    -q "INSERT INTO t_compact_read_cancel
+        SELECT number, s, s, s, s, s, s, s, s, s FROM (SELECT number, repeat('x', 30) AS s FROM numbers(400000))"
+
+${CLICKHOUSE_CLIENT} -q "
+SELECT 'part type', part_type FROM system.parts
+WHERE database = currentDatabase() AND table = 't_compact_read_cancel' AND active"
+
+read_query="SELECT count(), sum(length(a)+length(b)+length(c)+length(d)+length(e)+length(f)+length(g)+length(h)+length(i)) FROM t_compact_read_cancel"
+
+# Only readRows() appends this diagnostic, so its presence proves the query stopped inside the
+# block read rather than after it. The wall clock is not asserted: it depends on the machine,
+# while the interrupt site does not.
+inside_part_read() {
+    grep -qF 'While reading part' "$1" && echo 'inside the part read' || echo "not interrupted inside the part read: $(head -c 400 "$1")"
+}
+
+timeout_err="${CLICKHOUSE_TMP}/04746_timeout_err.txt"
+${CLICKHOUSE_CLIENT} --max_block_size 100000000 --preferred_block_size_bytes 0 --max_threads 1 \
+    --max_execution_time 1 --timeout_overflow_mode throw \
+    -q "$read_query" >/dev/null 2>"$timeout_err"
+echo -n 'timeout observed '
+inside_part_read "$timeout_err"
+
+# The whole point of the check is that max_execution_time is respected, so also require the
+# reported elapsed to stay near the limit. 5x the 1s limit is far above the fixed server (which
+# stops one mark past the limit) and far below an uninterrupted read of this part.
+elapsed=$(sed -nE 's/.*elapsed ([0-9]+)\.[0-9]+ ms.*/\1/p' "$timeout_err" | head -1)
+if [ -n "$elapsed" ] && [ "$elapsed" -lt 5000 ]; then
+    echo 'timeout honoured'
+else
+    echo "timeout overshot: elapsed=${elapsed}ms"
+fi
+
+query_id="compact_read_cancel_${CLICKHOUSE_DATABASE}_$$"
+kill_err="${CLICKHOUSE_TMP}/04746_kill_err.txt"
+${CLICKHOUSE_CLIENT} --query_id "$query_id" \
+    --max_block_size 100000000 --preferred_block_size_bytes 0 --max_threads 1 \
+    -q "$read_query" >/dev/null 2>"$kill_err" &
+select_pid=$!
+
+# Wait until the query is inside the single block read: it decompresses blocks
+# (CompressedReadBufferBlocks grows) while no row has reached the pipeline yet (read_rows = 0),
+# so the cancel has to be observed inside readRows and not between blocks.
+reading=0
+for _ in $(seq 1 600); do
+    reading=$(${CLICKHOUSE_CLIENT} -q "
+        SELECT ProfileEvents['CompressedReadBufferBlocks'] > 1000 AND read_rows = 0
+        FROM system.processes WHERE query_id = '$query_id'")
+    [ "$reading" = "1" ] && break
+    sleep 0.1
+done
+
+if [ "$reading" != "1" ]; then
+    echo 'did not observe the in-block read phase'
+else
+    ${CLICKHOUSE_CLIENT} -q "KILL QUERY WHERE query_id = '$query_id' SYNC FORMAT Null"
+    echo -n 'kill observed '
+    inside_part_read "$kill_err"
+fi
+
+wait "$select_pid" 2>/dev/null
+rm -f "$timeout_err" "$kill_err"
+
+# A cancelled read says nothing about the part's health: it must stay active, must not be
+# detached, and must not have been queued for a check.
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS text_log"
+${CLICKHOUSE_CLIENT} -q "
+SELECT 'active parts', count() FROM system.parts
+WHERE database = currentDatabase() AND table = 't_compact_read_cancel' AND active"
+${CLICKHOUSE_CLIENT} -q "
+SELECT 'detached parts', count() FROM system.detached_parts
+WHERE database = currentDatabase() AND table = 't_compact_read_cancel'"
+# Scope by currentDatabase(): text_log is server-wide, so an unscoped match would also count
+# rows left by other runs of this test.
+${CLICKHOUSE_CLIENT} -q "
+SELECT 'part checks', count() FROM system.text_log
+WHERE event_date >= yesterday()
+  AND logger_name LIKE concat(currentDatabase(), '.t_compact_read_cancel%PartCheckThread%')
+  AND message LIKE 'Enqueueing%for check%'"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_compact_read_cancel SYNC"


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/107474
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `KILL QUERY`, and `max_execution_time` under the default `timeout_overflow_mode = 'throw'`, being ignored while a query reads a Compact `MergeTree` part with a small `index_granularity`. A single block read walked every mark without checking cancellation, so one call could run for minutes past the limit.

### Description

`MergeTreeReaderCompactSingleBuffer::readRows` walks one mark per iteration and had no
cancellation check. Limits are otherwise enforced only *between* blocks
(`MergeTreeSelectProcessor::read`, `PipelineExecutor::checkTimeLimit`), so with
`index_granularity = 1` one block spans as many marks as `max_block_size` allows and no limit
applies until it returns.

Measured on a 400k-mark Compact part: a 1 s `max_execution_time` reported **17.9 s** elapsed, and
`KILL QUERY ... SYNC` took **17-18 s**; both drop to the limit with this change. The overshoot
scales linearly with `max_block_size` (6.77x at 1e8, 1.43x at 300k, 1.07x at 65536), which is the
per-block interrupt granularity. The CI symptom is a Stress hung check: a cancelled
`INSERT ... SELECT` ran 1592 s with `is_cancelled = 1` after writing 10 rows (25 rows / 24 PRs /
1 master over 14 d on `Stress test (arm_asan_ubsan)` alone).

The catch guard is required, not incidental. `readRows` is a function-try-block whose catch calls
`reportBroken()` for anything `isRetryableException` does not recognise, and it lists neither
`QUERY_WAS_CANCELLED` nor `TIMEOUT_EXCEEDED` - so the check alone reports a
**healthy active part broken** (on `ReplicatedMergeTree`, an observed part check). The guard
is local to this catch; `isRetryableException` is untouched, because its 25 call sites drive fetch
retries where a cancellation is not retryable in any sense.

`MergeTreeReaderTextIndex::readRows` has the same loop and is fixed too, on either part type; it
needs no guard, reporting no broken part. The Wide main reader needs no check
(`MergeTreeReaderWide::readRows` loops per column, not per mark). Hot-path cost is within noise.

Scope: `KILL QUERY` is honoured in every overflow mode, but a plain `max_execution_time` expiry
under `timeout_overflow_mode = 'break'` still overshoots, because `checkTimeLimit` returns `false`
there instead of throwing. Making it stop would turn a documented silent stop
(`02896_max_execution_time_with_break_overflow_mode`) into a client-visible error, so it is left
out.

Part of the class tracked by #107474.