### PR TITLE
Bake the Apache Paimon Spark bundle into the integration runner image

### DIFF
--- a/ci/docker/integration/runner/Dockerfile
+++ b/ci/docker/integration/runner/Dockerfile
@@ -83,7 +83,8 @@ com.amazonaws:aws-java-sdk-bundle:1.12.262,\
 org.apache.hadoop:hadoop-azure:3.3.4,\
 com.microsoft.azure:azure-storage:8.6.6,\
 org.apache.spark:spark-avro_2.12:3.5.1,\
-org.apache.sedona:sedona-spark-3.5_2.12:1.6.1"\
+org.apache.sedona:sedona-spark-3.5_2.12:1.6.1,\
+org.apache.paimon:paimon-spark-3.5:1.1.1"\
     && /spark-3.5.5-bin-hadoop3/bin/spark-shell --packages "$packages" \
     && find /root/.ivy2/ -name '*.jar' -exec ln -sf {} /spark-3.5.5-bin-hadoop3/jars/ \;
 

--- a/tests/integration/test_paimon_spark_smoke/test.py
+++ b/tests/integration/test_paimon_spark_smoke/test.py
@@ -5,13 +5,26 @@ ClickHouse reads it back through `paimonLocal`. If the bundle disappears from
 the image, the Paimon catalog fails to load here.
 """
 
+import os
+import re
+import shutil
+
 import pyspark
 import pytest
 
 from helpers.cluster import ClickHouseCluster
 from helpers.s3_tools import LocalUploader
 
-WAREHOUSE = "/var/lib/clickhouse/user_files/paimon_smoke"
+# The warehouse is a host path shared by Spark and the uploader, so it is
+# namespaced by xdist worker and harness run id (the pattern of
+# helpers/iceberg_utils.iceberg_local_interop_dir): under the flaky check
+# (--dist=each) several workers run this module at once, and two harness runs
+# on one host must not share state either.
+_WORKER = os.environ.get("PYTEST_XDIST_WORKER", "master")
+_RUN_ID = re.sub(r"[^A-Za-z0-9_]", "_", os.environ.get("INTEGRATION_TESTS_RUN_ID", ""))
+WAREHOUSE = f"/var/lib/clickhouse/user_files/paimon_smoke_{_WORKER}" + (
+    f"_{_RUN_ID}" if _RUN_ID else ""
+)
 
 
 def get_spark():
@@ -35,6 +48,9 @@ def started_cluster():
         cluster = ClickHouseCluster(__file__)
         cluster.add_instance("node1", stay_alive=True)
         cluster.start()
+        # A rerun on the same worker inherits the same namespaced path, so any
+        # stale warehouse from a previous run is removed before Spark starts.
+        shutil.rmtree(WAREHOUSE, ignore_errors=True)
         # Registered on the cluster so shutdown() stops the session and the
         # JVM does not outlive this module.
         cluster.spark_session = get_spark()

--- a/tests/integration/test_paimon_spark_smoke/test.py
+++ b/tests/integration/test_paimon_spark_smoke/test.py
@@ -1,0 +1,54 @@
+"""In-tree consumer of the Paimon Spark bundle baked into the runner image
+(ci/docker/integration/runner/Dockerfile): Spark in the runner writes a Paimon
+table using only the baked jars — deliberately no `spark.jars.packages` — and
+ClickHouse reads it back through `paimonLocal`. If the bundle disappears from
+the image, the Paimon catalog fails to load here.
+"""
+
+import pyspark
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.s3_tools import LocalUploader
+
+WAREHOUSE = "/var/lib/clickhouse/user_files/paimon_smoke"
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance("node1", stay_alive=True)
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_spark_paimon_write_clickhouse_read(started_cluster):
+    node = started_cluster.instances["node1"]
+    spark = (
+        pyspark.sql.SparkSession.builder.appName("paimon_smoke")
+        # Deliberately no spark.jars.packages: the baked bundle must resolve.
+        .config("spark.sql.catalog.paimon", "org.apache.paimon.spark.SparkCatalog")
+        .config("spark.sql.catalog.paimon.warehouse", f"file:{WAREHOUSE}")
+        .config(
+            "spark.sql.extensions",
+            "org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions",
+        )
+        .master("local")
+        .getOrCreate()
+    )
+    spark.sql("CREATE DATABASE IF NOT EXISTS paimon.default")
+    spark.sql(
+        "CREATE TABLE paimon.default.smoke (id INT NOT NULL, val STRING) "
+        "TBLPROPERTIES ('file.format' = 'parquet')"
+    )
+    spark.sql("INSERT INTO paimon.default.smoke VALUES (1, 'one'), (2, 'two')")
+
+    table_dir = f"{WAREHOUSE}/default.db/smoke"
+    LocalUploader(node).upload_directory(table_dir, table_dir)
+    assert (
+        node.query(f"SELECT id, val FROM paimonLocal('{table_dir}') ORDER BY id")
+        == "1\tone\n2\ttwo\n"
+    )

--- a/tests/integration/test_paimon_spark_smoke/test.py
+++ b/tests/integration/test_paimon_spark_smoke/test.py
@@ -14,20 +14,8 @@ from helpers.s3_tools import LocalUploader
 WAREHOUSE = "/var/lib/clickhouse/user_files/paimon_smoke"
 
 
-@pytest.fixture(scope="module")
-def started_cluster():
-    try:
-        cluster = ClickHouseCluster(__file__)
-        cluster.add_instance("node1", stay_alive=True)
-        cluster.start()
-        yield cluster
-    finally:
-        cluster.shutdown()
-
-
-def test_spark_paimon_write_clickhouse_read(started_cluster):
-    node = started_cluster.instances["node1"]
-    spark = (
+def get_spark():
+    return (
         pyspark.sql.SparkSession.builder.appName("paimon_smoke")
         # Deliberately no spark.jars.packages: the baked bundle must resolve.
         .config("spark.sql.catalog.paimon", "org.apache.paimon.spark.SparkCatalog")
@@ -39,6 +27,25 @@ def test_spark_paimon_write_clickhouse_read(started_cluster):
         .master("local")
         .getOrCreate()
     )
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance("node1", stay_alive=True)
+        cluster.start()
+        # Registered on the cluster so shutdown() stops the session and the
+        # JVM does not outlive this module.
+        cluster.spark_session = get_spark()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_spark_paimon_write_clickhouse_read(started_cluster):
+    node = started_cluster.instances["node1"]
+    spark = started_cluster.spark_session
     spark.sql("CREATE DATABASE IF NOT EXISTS paimon.default")
     spark.sql(
         "CREATE TABLE paimon.default.smoke (id INT NOT NULL, val STRING) "


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/102343
Related: https://github.com/ClickHouse/ClickHouse/pull/104657

Bakes the Apache Paimon Spark bundle (`org.apache.paimon:paimon-spark-3.5:1.1.1`, the version used to generate the `tests/queries/0_stateless/data_minio/paimon_*` fixtures) into the integration runner image, alongside the Delta/Iceberg/Hudi jars that are already provisioned this way.

Paimon integration tests write their test tables with Spark, like the other data-lake suites; without the baked jar the Paimon Spark catalog has to be resolved from Maven/Ivy at Spark session launch, which makes test runs depend on an external artifact service at runtime. Baking the jar removes that dependency (ivy resolves from the local cache, so any remaining `spark.jars.packages` declaration becomes a no-op).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.921` (included in `26.8` and later)
<!-- ch-version-info:end -->