### PR TITLE
Document chDB ADBC support

### DIFF
--- a/docs/chdb/install/adbc.mdx
+++ b/docs/chdb/install/adbc.mdx
@@ -7,6 +7,10 @@ keywords: ['chdb', 'adbc', 'arrow', 'driver', 'clickhouse', 'sql', 'olap']
 doc_type: 'guide'
 ---
 
+import { ExperimentalBadge } from "/snippets/components/ExperimentalBadge/ExperimentalBadge.jsx";
+
+<ExperimentalBadge/>
+
 <Warning>
 The ADBC driver is experimental. Its behavior and options may change between releases.
 </Warning>
@@ -23,7 +27,7 @@ Install the driver from the ADBC Driver Foundry with [`dbc`](https://docs.column
 dbc install chdb
 ```
 
-The first published `dbc` package for chDB is version 26.7.0. To check the available versions:
+The first published `dbc` package for chDB is version 26.7.0. To check the available versions run:
 
 ```bash
 dbc search -v chdb

--- a/docs/chdb/install/adbc.mdx
+++ b/docs/chdb/install/adbc.mdx
@@ -1,0 +1,207 @@
+---
+title: 'chDB as an ADBC driver'
+sidebarTitle: 'ADBC'
+slug: /chdb/install/adbc
+description: 'How to use chDB through Arrow Database Connectivity (ADBC)'
+keywords: ['chdb', 'adbc', 'arrow', 'driver', 'clickhouse', 'sql', 'olap']
+doc_type: 'guide'
+---
+
+<Warning>
+The ADBC driver is experimental. Its behavior and options may change between releases.
+</Warning>
+
+[ADBC](https://arrow.apache.org/adbc/) is a vendor-neutral API for moving Arrow data between an application and a database. The chDB ADBC driver is distributed through the ADBC Driver Foundry and can be loaded by any ADBC driver manager.
+
+Results cross the boundary as Arrow record batches, with no row-by-row conversion. Applications can use the same driver from Python or from any other language with an ADBC driver manager.
+
+## Installation {#installation}
+
+Install the driver from the ADBC Driver Foundry with [`dbc`](https://docs.columnar.tech/dbc/):
+
+```bash
+dbc install chdb
+```
+
+The first published `dbc` package for chDB is version 26.7.0. To check the available versions:
+
+```bash
+dbc search -v chdb
+```
+
+The installed driver can be loaded by the name `chdb` from an ADBC driver manager.
+
+Linux and macOS are supported on x86-64 and arm64.
+
+## Connecting from Python {#connecting-from-python}
+
+Install the Python ADBC driver manager:
+
+```bash
+pip install adbc-driver-manager pyarrow
+```
+
+Then load the `dbc`-installed chDB driver by name:
+
+```python
+from adbc_driver_manager import dbapi
+
+with dbapi.connect(
+    driver="chdb",
+    db_kwargs={"uri": "chdb://"},
+    autocommit=True,
+) as conn:
+    with conn.cursor() as cur:
+        cur.execute("SELECT number FROM numbers(3)")
+        print(cur.fetch_arrow_table())
+```
+
+| `uri`                       | Database                                      |
+|-----------------------------|-----------------------------------------------|
+| `chdb://`                   | In-memory                                     |
+| `chdb:///absolute/path`     | On disk, persisted in the specified directory |
+
+## Connection lifecycle {#connection-lifecycle}
+
+chDB runs one embedded engine in each process while connections are open. Keep these rules in mind:
+
+- All simultaneously open ADBC connections in a process must resolve to the same storage path.
+- Multiple connections to that path are supported, including connections used concurrently from different threads. For concurrent queries, give each worker its own connection instead of running simultaneous operations on one connection.
+- Closing the last connection shuts the embedded engine down. A later connection can start it again, including with a different storage path, but repeated shutdown and startup costs time and memory. Keep at least one connection open for repeated work.
+- Only one operating-system process can open a given on-disk directory at a time. Give each process its own directory, or use an in-memory database.
+
+### Using ADBC with the Python chDB package {#using-python-chdb-package}
+
+The `dbc` package installs a standalone native ADBC driver. It is separate from the native library loaded by the Python `chdb` package.
+
+In one Python process, do not expect a `dbc`-loaded ADBC connection and a regular `chdb` connection to share in-memory tables or engine state. For a given database path, use either the ADBC driver or the Python `chdb` API at one time; do not keep both open on the same on-disk path. To move data between the two APIs, close all connections on one side before opening the other, or pass data explicitly through Arrow or files.
+
+## Implemented functionality {#implemented-functionality}
+
+`Not yet` identifies an ADBC driver capability that can be added later. `Not applicable` identifies a feature that does not match the current chDB or ClickHouse execution model.
+
+### Database {#database}
+
+| Function                                | Status    | Notes                                      |
+|-----------------------------------------|-----------|--------------------------------------------|
+| `AdbcDatabaseNew` / `Init` / `Release`  | Supported |                                            |
+| `AdbcDatabaseSetOption`                 | Supported | `uri`, `path`, and `chdb.*` engine options |
+
+### Connection {#connection}
+
+| Function                                  | Status         | Notes                                                              |
+|-------------------------------------------|----------------|--------------------------------------------------------------------|
+| `AdbcConnectionNew` / `Init` / `Release`  | Supported      |                                                                    |
+| `AdbcConnectionGetInfo`                   | Supported      |                                                                    |
+| `AdbcConnectionGetObjects`                | Supported      | All depths                                                         |
+| `AdbcConnectionGetTableSchema`            | Supported      |                                                                    |
+| `AdbcConnectionGetTableTypes`             | Supported      |                                                                    |
+| `AdbcConnectionGetOption`                 | Supported      | Includes the current `db_schema`                                   |
+| `AdbcConnectionSetOption`                 | Partial        | Autocommit must remain enabled; changing `db_schema` is not exposed |
+| `AdbcConnectionCommit` / `Rollback`       | Not applicable | ClickHouse statements are autocommit; there is no classic transaction to commit or roll back |
+| `AdbcConnectionGetStatistics`             | Not yet        | Table statistics are not exposed through the driver                |
+| `AdbcConnectionReadPartition`             | Not applicable | The driver does not produce distributed result partitions          |
+| `AdbcConnectionCancel`                    | Not yet        | chDB query cancellation is not yet exposed through ADBC            |
+
+### Statement {#statement}
+
+| Function                              | Status         | Notes                                             |
+|---------------------------------------|----------------|---------------------------------------------------|
+| `AdbcStatementNew` / `Release`        | Supported      |                                                   |
+| `AdbcStatementSetSqlQuery`            | Supported      | ClickHouse SQL                                    |
+| `AdbcStatementPrepare`                | Supported      |                                                   |
+| `AdbcStatementBind` / `BindStream`    | Supported      | Positional `?` parameters                         |
+| `AdbcStatementGetParameterSchema`     | Supported      |                                                   |
+| `AdbcStatementExecuteQuery`           | Supported      | Streams Arrow record batches                      |
+| `AdbcStatementSetOption`              | Supported      | Bulk ingestion, see below                         |
+| `AdbcStatementExecuteSchema`          | Not yet        | The result schema is currently available after execution |
+| `AdbcStatementExecutePartitions`      | Not applicable | Results are returned as an in-process Arrow stream |
+| `AdbcStatementSetSubstraitPlan`       | Not applicable | chDB accepts ClickHouse SQL, not Substrait plans  |
+| `AdbcStatementCancel`                 | Not yet        | chDB query cancellation is not yet exposed through ADBC |
+
+Bulk ingestion supports the `create`, `append`, `create_append`, and `replace` modes, into the default database or a named one.
+
+## ClickHouse SQL and type behavior {#clickhouse-sql-and-type-behavior}
+
+chDB uses ClickHouse SQL and its type system. The following ClickHouse semantics also apply when chDB is accessed through ADBC:
+
+- Columns are not nullable unless declared `Nullable(...)`. A typed NULL bound into a plain `String` column is stored as an empty string, not as NULL.
+- Use ClickHouse identifier quoting; the examples use backticks.
+- ClickHouse databases map to ADBC `db_schema`. There is no catalog layer above them, so catalog-scoped operations are not applicable.
+- `Decimal` does not accept negative scales, and `Date32` covers 1900-01-01 to 2299-12-31.
+- A `DateTime64` without a time zone is interpreted in the engine time zone.
+- The current ClickHouse Arrow output does not represent the `Time` type, so it cannot be read back through ADBC.
+
+Some Arrow types preserve their values but are read back as a different Arrow type:
+
+| Arrow type                                         | Stored as        | Read back as        |
+|----------------------------------------------------|------------------|---------------------|
+| `binary`, `large_binary`, `binary_view`            | `String`         | `string`            |
+| `fixed_size_binary` (bulk ingest into a new table) | `FixedString(n)` | `fixed_size_binary` |
+| `large_string`, `string_view`                      | `String`         | `string`            |
+| `float16`                                          | `Float32`        | `float`             |
+| `time32` / `time64` / `timestamp`                  | `DateTime64(n)`  | `timestamp`         |
+
+Binary data is stored as `String` and read back as UTF-8. Payloads that are not valid UTF-8 are therefore not supported as round-trip `binary` values.
+
+## Examples {#examples}
+
+### Bulk ingestion from Arrow {#bulk-ingestion}
+
+```python
+import pyarrow as pa
+from adbc_driver_manager import dbapi
+
+table = pa.table({"id": [1, 2, 3], "name": ["a", "b", "c"]})
+
+with dbapi.connect(
+    driver="chdb",
+    db_kwargs={"uri": "chdb://"},
+    autocommit=True,
+) as conn:
+    with conn.cursor() as cur:
+        cur.adbc_ingest("events", table, mode="create")
+        cur.execute("SELECT count() FROM events")
+        print(cur.fetchone())
+```
+
+### Parameters {#parameters}
+
+```python
+from adbc_driver_manager import dbapi
+
+with dbapi.connect(
+    driver="chdb",
+    db_kwargs={"uri": "chdb://"},
+    autocommit=True,
+) as conn:
+    with conn.cursor() as cur:
+        cur.execute("SELECT number FROM numbers(10) WHERE number > ?", (7,))
+        print(cur.fetch_arrow_table())
+```
+
+### C {#c-example}
+
+After `dbc install chdb`, the C driver manager can resolve the driver by name:
+
+```c
+#include <arrow-adbc/adbc.h>
+#include <arrow-adbc/adbc_driver_manager.h>
+
+struct AdbcDatabase database = {0};
+struct AdbcError error = {0};
+
+AdbcDatabaseNew(&database, &error);
+AdbcDatabaseSetOption(&database, "driver", "chdb", &error);
+AdbcDatabaseSetOption(&database, "uri", "chdb://", &error);
+AdbcDatabaseInit(&database, &error);
+```
+
+## How the driver is verified {#verification}
+
+The chDB ADBC release builds run two external suites against the native driver on Linux x86-64 and arm64, and macOS x86-64 and arm64:
+
+- the Apache Arrow ADBC conformance suite, which checks the C contract
+- the ADBC Driver Foundry validation suite, which checks SQL-level behavior, type round trips, metadata, and bulk ingestion
+
+The support tables on this page are derived from those runs. The suites live in [the chdb-core repository](https://github.com/chdb-io/chdb-core/tree/main/programs/local/adbc/validation).

--- a/docs/chdb/install/index.mdx
+++ b/docs/chdb/install/index.mdx
@@ -2,7 +2,7 @@
 title: 'Language integrations index'
 slug: /chdb/install
 description: 'Index page for chDB language integrations'
-keywords: ['python', 'NodeJS', 'Go', 'Rust', 'Bun', 'C', 'C++']
+keywords: ['python', 'NodeJS', 'Go', 'Rust', 'Bun', 'C', 'C++', 'ADBC', 'Arrow']
 doc_type: 'landing-page'
 ---
 
@@ -16,3 +16,4 @@ Instructions for how to get setup with chDB are available below for the followin
 | [Rust](/chdb/install/rust)     |
 | [Bun](/chdb/install/bun)       |
 | [C and C++](/chdb/install/c)   |
+| [ADBC](/chdb/install/adbc)     |

--- a/docs/chdb/navigation.json
+++ b/docs/chdb/navigation.json
@@ -16,7 +16,8 @@
         "chdb/install/go",
         "chdb/install/rust",
         "chdb/install/bun",
-        "chdb/install/c"
+        "chdb/install/c",
+        "chdb/install/adbc"
       ]
     },
     {


### PR DESCRIPTION
Adds a chDB ADBC documentation page and wires it into the chDB install navigation.

This version documents the released native driver path through `dbc install chdb`, with Python examples using `adbc-driver-manager`, plus C usage, connection lifecycle notes, type behavior, and the ADBC capability matrix.

Python package integration can be documented separately once the PyPI wheels expose the ADBC entrypoint consistently across supported platforms.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Document how to install and use chDB through Arrow Database Connectivity (ADBC).

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113429&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/113429](https://github.com/search?q=head%3Async-upstream%2Fpr%2F113429+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
