### PR TITLE
Recover a dead py4j gateway in ResilientSparkSession

### DIFF
--- a/tests/integration/helpers/spark_tools.py
+++ b/tests/integration/helpers/spark_tools.py
@@ -2,6 +2,8 @@ import logging
 import os
 
 import pyspark
+from pyspark.context import SparkContext
+from pyspark.sql import SparkSession
 
 
 def write_spark_log_config(log_dir):
@@ -38,6 +40,42 @@ appender.file.layout.pattern = %d{{yy/MM/dd HH:mm:ss}} %p %c{{1}}: %m%n%ex
     return props_path
 
 
+def _gateway_is_live():
+    """Round-trip one trivial call against the class-cached py4j gateway.
+
+    Returns False when nothing is cached (nothing to reuse) or when the cached
+    handle no longer answers.
+    """
+    gateway = SparkContext._gateway
+    if gateway is None:
+        return False
+    try:
+        gateway.jvm.System.currentTimeMillis()
+        return True
+    except Exception:
+        return False
+
+
+def _reset_pyspark_class_state():
+    """Drop the cached gateway so ``_ensure_initialized`` relaunches the JVM.
+
+    ``_ensure_initialized`` skips the relaunch while ``SparkContext._gateway`` is
+    truthy, and neither ``SparkContext.stop()`` nor ``SparkSession.stop()`` clears
+    it. Each clear is tolerant so a pyspark upgrade cannot break the harness.
+    """
+    for owner, attr in (
+        (SparkContext, "_gateway"),
+        (SparkContext, "_jvm"),
+        (SparkContext, "_active_spark_context"),
+        (SparkSession, "_instantiatedSession"),
+        (SparkSession, "_activeSession"),
+    ):
+        try:
+            setattr(owner, attr, None)
+        except Exception:
+            pass
+
+
 class ResilientSparkSession:
     """Wrapper around SparkSession that automatically restarts on JVM/py4j failures.
 
@@ -51,7 +89,21 @@ class ResilientSparkSession:
 
     def __init__(self, create_session_fn):
         self._create = create_session_fn
-        self._session = create_session_fn()
+        # Set before creating so a factory failure cannot leave the attribute
+        # missing, which would make __getattr__ recurse through _is_alive.
+        self._session = None
+        self._session = self._prepare_and_create()
+
+    def _prepare_and_create(self):
+        """Create a session, first discarding a cached gateway that is dead.
+
+        The reset is conditional: a live gateway must be reused, otherwise the
+        still-running JVM is orphaned and a needless one is launched.
+        """
+        if SparkContext._gateway is not None and not _gateway_is_live():
+            logging.warning("Cached py4j gateway is dead, discarding it")
+            _reset_pyspark_class_state()
+        return self._create()
 
     def _restart(self):
         logging.warning("Spark session is dead, restarting...")
@@ -59,16 +111,16 @@ class ResilientSparkSession:
             self._session.stop()
         except Exception:
             pass
-        # Clear any cached singleton so getOrCreate builds a fresh one
-        pyspark.sql.SparkSession.builder._options = {}
         try:
             pyspark.sql.SparkSession._instantiatedSession = None
         except Exception:
             pass
-        self._session = self._create()
+        self._session = self._prepare_and_create()
         logging.warning("Spark session restarted successfully")
 
     def _is_alive(self):
+        if self.__dict__.get("_session") is None:
+            return False
         try:
             self._session.sparkContext._jsc.sc().defaultParallelism()
             return True

--- a/tests/integration/test_spark_session_recovery/test.py
+++ b/tests/integration/test_spark_session_recovery/test.py
@@ -1,0 +1,78 @@
+import os
+import signal
+import time
+
+import pyspark
+from pyspark.context import SparkContext
+
+from helpers.spark_tools import ResilientSparkSession
+
+
+def _jvm_pid():
+    gateway = SparkContext._gateway
+    proc = getattr(gateway, "proc", None) if gateway is not None else None
+    return proc.pid if proc is not None else None
+
+
+def _alive(pid):
+    try:
+        os.kill(pid, 0)
+        return True
+    except Exception:
+        return False
+
+
+def _create():
+    return (
+        pyspark.sql.SparkSession.builder.appName("spark_session_recovery")
+        .master("local[1]")
+        .getOrCreate()
+    )
+
+
+def test_recovers_dead_gateway_and_reuses_live_one():
+    """A jointly ordered scenario: pyspark caches the py4j gateway in class state
+    and no stop() clears it, so a session built after the JVM died must discard
+    that handle, while a session built while it still answers must reuse it."""
+    session = ResilientSparkSession(_create)
+    first_pid = _jvm_pid()
+    assert session.range(3).count() == 3
+    assert first_pid is not None
+
+    # A stopped session leaves the gateway cached and the JVM running.
+    session.stop()
+    assert SparkContext._gateway is not None
+    assert _alive(first_pid)
+
+    # No leak: the next session must reuse that live JVM, not launch another.
+    reused = ResilientSparkSession(_create)
+    assert _jvm_pid() == first_pid
+    assert reused.range(2).count() == 2
+
+    # _restart() on a live gateway must also reuse it.
+    reused._restart()
+    assert _jvm_pid() == first_pid
+    assert reused.range(4).count() == 4
+
+    # Recovery: with the JVM dead, the next session must relaunch it. Before the
+    # fix this raised "SparkConf does not exist in the JVM" from __init__.
+    os.kill(first_pid, signal.SIGKILL)
+    deadline = time.monotonic() + 30
+    while _alive(first_pid) and time.monotonic() < deadline:
+        time.sleep(0.2)
+
+    recovered = ResilientSparkSession(_create)
+    second_pid = _jvm_pid()
+    assert second_pid != first_pid
+    assert recovered.range(5).count() == 5
+
+    # Attribute access on a wrapper whose JVM has since died goes through
+    # __getattr__ -> _restart, which must recover the same way __init__ does.
+    os.kill(second_pid, signal.SIGKILL)
+    deadline = time.monotonic() + 30
+    while _alive(second_pid) and time.monotonic() < deadline:
+        time.sleep(0.2)
+
+    assert recovered.range(6).count() == 6
+    assert _jvm_pid() not in (first_pid, second_pid)
+    recovered.stop()

--- a/tests/integration/test_spark_session_recovery/test.py
+++ b/tests/integration/test_spark_session_recovery/test.py
@@ -4,6 +4,7 @@ import signal
 import pyspark
 from pyspark.context import SparkContext
 
+from helpers import spark_tools
 from helpers.spark_tools import ResilientSparkSession
 
 
@@ -49,41 +50,50 @@ def test_recovers_dead_gateway_and_reuses_live_one():
     """A jointly ordered scenario: pyspark caches the py4j gateway in class state
     and no stop() clears it, so a session built after the JVM died must discard
     that handle, while a session built while it still answers must reuse it."""
-    session = ResilientSparkSession(_create)
-    first_proc = _jvm_proc()
-    first_pid = _jvm_pid()
-    assert session.range(3).count() == 3
-    assert first_pid is not None
+    try:
+        session = ResilientSparkSession(_create)
+        first_proc = _jvm_proc()
+        first_pid = _jvm_pid()
+        assert session.range(3).count() == 3
+        assert first_pid is not None
 
-    # A stopped session leaves the gateway cached and the JVM running.
-    session.stop()
-    assert SparkContext._gateway is not None
-    assert _alive(first_pid)
+        # A stopped session leaves the gateway cached and the JVM running.
+        session.stop()
+        assert SparkContext._gateway is not None
+        assert _alive(first_pid)
 
-    # No leak: the next session must reuse that live JVM, not launch another.
-    reused = ResilientSparkSession(_create)
-    assert _jvm_pid() == first_pid
-    assert reused.range(2).count() == 2
+        # No leak: the next session must reuse that live JVM, not launch another.
+        reused = ResilientSparkSession(_create)
+        assert _jvm_pid() == first_pid
+        assert reused.range(2).count() == 2
 
-    # _restart() on a live gateway must also reuse it.
-    reused._restart()
-    assert _jvm_pid() == first_pid
-    assert reused.range(4).count() == 4
+        # _restart() on a live gateway must also reuse it.
+        reused._restart()
+        assert _jvm_pid() == first_pid
+        assert reused.range(4).count() == 4
 
-    # Recovery: with the JVM dead, the next session must relaunch it. Before the
-    # fix this raised "SparkConf does not exist in the JVM" from __init__.
-    _kill_jvm_and_reap(first_proc)
+        # Recovery: with the JVM dead, the next session must relaunch it. Before
+        # the fix this raised "... does not exist in the JVM" from __init__ -- for
+        # SparkSession$ here, not CI's SparkConf, because _restart above left
+        # SparkSession._instantiatedSession set and getOrCreate asks for it first.
+        _kill_jvm_and_reap(first_proc)
 
-    recovered = ResilientSparkSession(_create)
-    second_proc = _jvm_proc()
-    second_pid = _jvm_pid()
-    assert second_pid != first_pid
-    assert recovered.range(5).count() == 5
+        recovered = ResilientSparkSession(_create)
+        second_proc = _jvm_proc()
+        second_pid = _jvm_pid()
+        assert second_pid != first_pid
+        assert recovered.range(5).count() == 5
 
-    # Attribute access on a wrapper whose JVM has since died goes through
-    # __getattr__ -> _restart, which must recover the same way __init__ does.
-    _kill_jvm_and_reap(second_proc)
+        # Attribute access on a wrapper whose JVM has since died goes through
+        # __getattr__ -> _restart, which must recover the same way __init__ does.
+        _kill_jvm_and_reap(second_proc)
 
-    assert recovered.range(6).count() == 6
-    assert _jvm_pid() not in (first_pid, second_pid)
-    recovered.stop()
+        assert recovered.range(6).count() == 6
+        assert _jvm_pid() not in (first_pid, second_pid)
+        recovered.stop()
+    finally:
+        # A failure above can leave a dead gateway cached, breaking the next
+        # module in this worker that builds a session without the wrapper.
+        # Conditional: dropping a live gateway would orphan its JVM.
+        if SparkContext._gateway is not None and not spark_tools._gateway_is_live():
+            spark_tools._reset_pyspark_class_state()

--- a/tests/integration/test_spark_session_recovery/test.py
+++ b/tests/integration/test_spark_session_recovery/test.py
@@ -1,6 +1,5 @@
 import os
 import signal
-import time
 
 import pyspark
 from pyspark.context import SparkContext
@@ -8,9 +7,13 @@ from pyspark.context import SparkContext
 from helpers.spark_tools import ResilientSparkSession
 
 
-def _jvm_pid():
+def _jvm_proc():
     gateway = SparkContext._gateway
-    proc = getattr(gateway, "proc", None) if gateway is not None else None
+    return getattr(gateway, "proc", None) if gateway is not None else None
+
+
+def _jvm_pid():
+    proc = _jvm_proc()
     return proc.pid if proc is not None else None
 
 
@@ -20,6 +23,18 @@ def _alive(pid):
         return True
     except Exception:
         return False
+
+
+def _kill_jvm_and_reap(proc):
+    """Kill the gateway JVM and wait until it is reaped, not merely signalled.
+
+    Nothing in pyspark ever waits on ``gateway.proc``, so a killed JVM stays a
+    zombie and ``os.kill(pid, 0)`` keeps succeeding; ``wait()`` is what makes
+    the liveness check below able to fail.
+    """
+    os.kill(proc.pid, signal.SIGKILL)
+    proc.wait(timeout=30)
+    assert not _alive(proc.pid)
 
 
 def _create():
@@ -35,6 +50,7 @@ def test_recovers_dead_gateway_and_reuses_live_one():
     and no stop() clears it, so a session built after the JVM died must discard
     that handle, while a session built while it still answers must reuse it."""
     session = ResilientSparkSession(_create)
+    first_proc = _jvm_proc()
     first_pid = _jvm_pid()
     assert session.range(3).count() == 3
     assert first_pid is not None
@@ -56,22 +72,17 @@ def test_recovers_dead_gateway_and_reuses_live_one():
 
     # Recovery: with the JVM dead, the next session must relaunch it. Before the
     # fix this raised "SparkConf does not exist in the JVM" from __init__.
-    os.kill(first_pid, signal.SIGKILL)
-    deadline = time.monotonic() + 30
-    while _alive(first_pid) and time.monotonic() < deadline:
-        time.sleep(0.2)
+    _kill_jvm_and_reap(first_proc)
 
     recovered = ResilientSparkSession(_create)
+    second_proc = _jvm_proc()
     second_pid = _jvm_pid()
     assert second_pid != first_pid
     assert recovered.range(5).count() == 5
 
     # Attribute access on a wrapper whose JVM has since died goes through
     # __getattr__ -> _restart, which must recover the same way __init__ does.
-    os.kill(second_pid, signal.SIGKILL)
-    deadline = time.monotonic() + 30
-    while _alive(second_pid) and time.monotonic() < deadline:
-        time.sleep(0.2)
+    _kill_jvm_and_reap(second_proc)
 
     assert recovered.range(6).count() == 6
     assert _jvm_pid() not in (first_pid, second_pid)

--- a/tests/integration/test_spark_session_recovery/test.py
+++ b/tests/integration/test_spark_session_recovery/test.py
@@ -3,19 +3,18 @@ import signal
 
 import pyspark
 from pyspark.context import SparkContext
+from pyspark.sql import SparkSession
 
 from helpers import spark_tools
 from helpers.spark_tools import ResilientSparkSession
 
 
 def _jvm_proc():
-    gateway = SparkContext._gateway
-    return getattr(gateway, "proc", None) if gateway is not None else None
+    return getattr(SparkContext._gateway, "proc", None)
 
 
 def _jvm_pid():
-    proc = _jvm_proc()
-    return proc.pid if proc is not None else None
+    return getattr(_jvm_proc(), "pid", None)
 
 
 def _alive(pid):
@@ -27,12 +26,9 @@ def _alive(pid):
 
 
 def _kill_jvm_and_reap(proc):
-    """Kill the gateway JVM and wait until it is reaped, not merely signalled.
-
-    Nothing in pyspark ever waits on ``gateway.proc``, so a killed JVM stays a
-    zombie and ``os.kill(pid, 0)`` keeps succeeding; ``wait()`` is what makes
-    the liveness check below able to fail.
-    """
+    """Kill the gateway JVM and wait until reaped, not merely signalled: nothing
+    in pyspark waits on ``gateway.proc``, so a killed JVM stays a zombie whose
+    ``os.kill(pid, 0)`` keeps succeeding until ``wait()`` reaps it."""
     os.kill(proc.pid, signal.SIGKILL)
     proc.wait(timeout=30)
     assert not _alive(proc.pid)
@@ -47,9 +43,9 @@ def _create():
 
 
 def test_recovers_dead_gateway_and_reuses_live_one():
-    """A jointly ordered scenario: pyspark caches the py4j gateway in class state
-    and no stop() clears it, so a session built after the JVM died must discard
-    that handle, while a session built while it still answers must reuse it."""
+    """pyspark caches the py4j gateway in class state and no stop() clears it, so
+    a session built after the JVM died must discard it, while one built while it
+    still answers must reuse it."""
     try:
         session = ResilientSparkSession(_create)
         first_proc = _jvm_proc()
@@ -73,9 +69,9 @@ def test_recovers_dead_gateway_and_reuses_live_one():
         assert reused.range(4).count() == 4
 
         # Recovery: with the JVM dead, the next session must relaunch it. Before
-        # the fix this raised "... does not exist in the JVM" from __init__ -- for
-        # SparkSession$ here, not CI's SparkConf, because _restart above left
-        # SparkSession._instantiatedSession set and getOrCreate asks for it first.
+        # the fix __init__ raised "... does not exist in the JVM" -- naming
+        # SparkSession$, not CI's SparkConf, because _restart left
+        # _instantiatedSession set and getOrCreate asks for that first.
         _kill_jvm_and_reap(first_proc)
 
         recovered = ResilientSparkSession(_create)
@@ -84,16 +80,23 @@ def test_recovers_dead_gateway_and_reuses_live_one():
         assert second_pid != first_pid
         assert recovered.range(5).count() == 5
 
-        # Attribute access on a wrapper whose JVM has since died goes through
-        # __getattr__ -> _restart, which must recover the same way __init__ does.
+        # Attribute access on a wrapper whose JVM died goes through __getattr__
+        # -> _restart, which must recover the same way __init__ does.
         _kill_jvm_and_reap(second_proc)
 
         assert recovered.range(6).count() == 6
         assert _jvm_pid() not in (first_pid, second_pid)
         recovered.stop()
     finally:
-        # A failure above can leave a dead gateway cached, breaking the next
-        # module in this worker that builds a session without the wrapper.
+        # A failure leaves a live session or a dead gateway; both poison the next
+        # module here. getOrCreate reuses a live session via
+        # applyModifiableSettings, which cannot apply a static conf: stop it.
+        active = SparkSession._instantiatedSession
+        if active is not None:
+            try:
+                active.stop()  # raises once the gateway is dead; tolerated
+            except Exception:
+                pass
         # Conditional: dropping a live gateway would orphan its JVM.
         if SparkContext._gateway is not None and not spark_tools._gateway_is_live():
             spark_tools._reset_pyspark_class_state()


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112175
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/112175

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Requested on #112175 as a separate PR.

Every test in a spark-dependent integration module can error at fixture setup with
`Py4JError: SparkConf does not exist in the JVM`, losing the module's coverage and failing the
job. Seen on `Integration tests (amd_asan_ubsan, db disk, old analyzer, 5/6)`, 6 of 805
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112175&sha=5af55d5ac9dbe8d076e99c2022053c89a17accd9&name_0=BackportPR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%205%2F6%29)).
CIDB, 21 days: 11 rows, that shard only, none on master.

**Root cause.** The message is not a missing class: py4j's `GatewayClient.send_command` swallows
a `Py4JNetworkError` and returns `proto.ERROR`, which `JVMView.__getattr__` re-labels
(`java_gateway.py:1722-1725`): the gateway socket is dead. pyspark caches that socket in class
state and relaunches the JVM only `if not SparkContext._gateway` (3.5.5 `context.py:435-437`).
Neither `stop()` clears it, so once the JVM dies no relaunch happens in that process, and xdist
reuses it across modules. The wrapper could not recover either: `_is_alive` guards an
already-built wrapper, but the failure is in `__init__`.

**Change.** Probe the cached gateway before building a session and discard it only when it stops
answering. The probe is conditional: the JVM survives `stop()` (the failing job's log shows it
answering 10 minutes later), so an unconditional reset would orphan a live JVM per module.
`_restart()` shares the path, so restarting on a live gateway still reuses the JVM. It recovers
from the death, not prevents it; the trigger is not recoverable from the artifacts. Also drops a
dead `builder._options` line.

**Validation.** Reproduced in the runner image on the CI-pinned pyspark, with the message and
frame above. The new test fails on pristine master at its recovery arm and passes with the fix,
10/10 stable; mutants confirm the arms are live. It reports the relabel as `SparkSession$`, not
`SparkConf`: `getOrCreate` asks for that name first while `_instantiatedSession` is set
(`session.py:502`).

Out of scope: `test_sts.py:42` and `test_storage_delta_shuffles/test.py:121` bypass the wrapper,
and `retry_ok` is consumed only under LLVM coverage.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.841` (included in `26.8` and later)
- Backported to: `26.7.4.45`, `26.6.3.45`
<!-- ch-version-info:end -->