### PR TITLE
Fix clickhouse-client crash at exit when a query is cancelled

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -9,7 +9,9 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/program_options.hpp>
 #include <Common/Config/parseConnectionCredentials.h>
+#include <Common/ThreadPool.h>
 #include <Common/ThreadStatus.h>
+#include <Common/scope_guard_safe.h>
 
 #include <Access/AccessControl.h>
 
@@ -28,6 +30,7 @@
 
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
+#include <IO/SharedThreadPools.h>
 #include <IO/WriteBufferFromOStream.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/Context.h>
@@ -1399,6 +1402,13 @@ int mainEntryClickHouseClient(int argc, char ** argv);
 int mainEntryClickHouseClient(int argc, char ** argv)
 {
     DB::MainThreadStatus::getInstance();
+
+    /// Join global-pool threads before the statics they may have accessed are destroyed.
+    /// That way, accesses happen-before destruction.
+    SCOPE_EXIT_SAFE({
+        DB::StaticThreadPool::shutdownAll();
+        GlobalThreadPool::shutdown();
+    });
 
     try
     {


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/106386
-->

Related: #106386

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a crash of `clickhouse-client` at exit, which made it return code 139 instead of 0. It could happen after cancelling a query with Ctrl+C, or after an `INSERT` that reads data from stdin, because the client did not join its thread-pool threads before returning from `main`.


### Description

**What breaks.** `clickhouse-client` sometimes crashes at process exit, after its work is done,
reporting 139, so any script keying on its exit status sees a failure. Seen in CI on
`Stateless tests (arm_binary, parallel)` for `02290_client_insert_cancel`
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112945&sha=5edbad2c740429c3262652b1171e80a254f6907e&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29))
and `00900_long_parquet`, on two unrelated PRs. Exposure is 26.7 and newer.

**Root cause.** `UntrackedMemoryRegistry::instance()` is a function-local static holding a
`boost::intrusive::list` of `safe_link` hooks, so its destructor nulls the hooks of every still-linked
node. `clickhouse-client` was the only entry point that did not join its global-pool threads before
`main` returned: parsing stdin lazily creates the process-lifetime format-parsing pool
(`FormatFactory.cpp:510`, whose comment notes that the server and `clickhouse-local` instead do this at
startup), and those workers `detach()` themselves on the shrink branch, so nothing joins them. Such a
worker can still be unwinding during static destruction; its `~ThreadStatus` then reaches
`UntrackedMemoryRegistry::remove`, unlinking through the destroyed head. The core dump shows that.

**The change.** Add the shutdown guard to `mainEntryClickHouseClient`, identical to the
`clickhouse-local` precedent from `b219eaf99e94aeb` "Join threads from global thread pool
before exiting from main". `src/Common/UntrackedMemoryRegistry.*` is unchanged. All 9 entry points that
can create a `ThreadStatus` now carry it; the other 18 need none, since only a pool owned by a
process-lifetime static outlives `main`, and `FormatFactory.cpp:510` is input-path only.

**Validation.** Forcing the race reproduces the crash 15/15 before the change and 0/15 after, the probe
still firing in both arms; dropping `GlobalThreadPool::shutdown()` restores it 10/10. Since that call
can block, client exit was timed on four paths, including a piped stdin `INSERT` and a `kill -INT`
cancel: no hang, at most +7.6 ms. Both tests above already assert the contract, so no new test is
added; with three more they pass 160/160 under randomized settings. The per-tool audit and the
bypassing `_exit` paths are in the commit message.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.833` (included in `26.8` and later)
<!-- ch-version-info:end -->