### PR TITLE
CreateRelease: wait for the dpkg lock when installing repository tools

### DIFF
--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -266,12 +266,20 @@ def main():
                 # `libarchive-dev 3.6.0-1ubuntu1.7`) that Ubuntu already removed
                 # from the mirror pool, which makes `apt-get install` fail with a
                 # 404. Refreshing the index first resolves to the current version.
-                "command -v createrepo_c || (sudo apt-get update && sudo apt-get install -y createrepo-c) ||:",
+                #
+                # `-o DPkg::Lock::Timeout=300` on every apt-get: a freshly booted
+                # runner may still be running `unattended-upgrades`, which holds
+                # `/var/lib/dpkg/lock-frontend`. Without a timeout `apt-get install`
+                # aborts immediately ("Could not get lock ... held by process
+                # unattended-upgr"); swallowed by the trailing `||:`, it leaves the
+                # tools uninstalled and the fail-close check below aborts the whole
+                # release. The timeout makes apt wait for the lock instead.
+                "command -v createrepo_c || (sudo apt-get update -o DPkg::Lock::Timeout=300 && sudo apt-get install -o DPkg::Lock::Timeout=300 -y createrepo-c) ||:",
                 # reprepro 5.4.4+ is required for the 'Limit' field in distributions config.
                 # Ubuntu Jammy only has 5.3.0, so build from source if needed.
                 "reprepro --version 2>&1 | grep -qE '5\\.[4-9]' || ("
-                "  sudo apt-get update &&"
-                "  sudo apt-get install -y dpkg-dev fakeroot libgpgme-dev libdb-dev libbz2-dev liblzma-dev libarchive-dev shunit2 db-util debhelper &&"
+                "  sudo apt-get update -o DPkg::Lock::Timeout=300 &&"
+                "  sudo apt-get install -o DPkg::Lock::Timeout=300 -y dpkg-dev fakeroot libgpgme-dev libdb-dev libbz2-dev liblzma-dev libarchive-dev shunit2 db-util debhelper &&"
                 "  git clone https://salsa.debian.org/debian/reprepro.git /tmp/reprepro-src &&"
                 "  cd /tmp/reprepro-src &&"
                 "  dpkg-buildpackage -b --no-sign &&"

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -271,10 +271,15 @@ def main():
                 # runner may still be running `unattended-upgrades`, which holds
                 # `/var/lib/dpkg/lock-frontend`. Without a timeout `apt-get install`
                 # aborts immediately ("Could not get lock ... held by process
-                # unattended-upgr"); swallowed by the trailing `||:`, it leaves the
-                # tools uninstalled and the fail-close check below aborts the whole
-                # release. The timeout makes apt wait for the lock instead.
-                "command -v createrepo_c || (sudo apt-get update -o DPkg::Lock::Timeout=300 && sudo apt-get install -o DPkg::Lock::Timeout=300 -y createrepo-c) ||:",
+                # unattended-upgr"). The timeout makes apt wait for the lock instead.
+                #
+                # No trailing `||:`: an install failure must abort here with the
+                # actual apt error (404, lock, missing package), not be swallowed
+                # and re-surface later as the generic fail-close message below,
+                # which hides the root cause. The leading `command -v` / version
+                # `grep` still skip the install entirely when the tool is already
+                # present, so a machine that has the tools is never blocked.
+                "command -v createrepo_c || (sudo apt-get update -o DPkg::Lock::Timeout=300 && sudo apt-get install -o DPkg::Lock::Timeout=300 -y createrepo-c)",
                 # reprepro 5.4.4+ is required for the 'Limit' field in distributions config.
                 # Ubuntu Jammy only has 5.3.0, so build from source if needed.
                 "reprepro --version 2>&1 | grep -qE '5\\.[4-9]' || ("
@@ -284,21 +289,20 @@ def main():
                 "  cd /tmp/reprepro-src &&"
                 "  dpkg-buildpackage -b --no-sign &&"
                 "  sudo dpkg -i ../reprepro_$(dpkg-parsechangelog --show-field Version)_$(dpkg-architecture -q DEB_HOST_ARCH).deb"
-                ") ||:",
+                ")",
             ]
-            # The installs above are best-effort (`||:`) so a local dev machine
-            # without sudo/apt is not blocked. For a real release the repo tools
-            # must be present before any mutation (tags, GitHub release, repos),
-            # so verify them here and fail closed. Skipped on dry-run (local
+            # The installs above abort the step on failure. This final check is a
+            # belt-and-suspenders post-condition: for a real release the repo tools
+            # must be present before any mutation (tags, GitHub release, repos), so
+            # verify them here and fail closed. Skipped on dry-run (local
             # convenience).
             + (
                 []
                 if args.dry_run
                 else [
-                    # Verify the *version*, not just presence: an older
-                    # distro reprepro (5.3.x) may be installed while the 5.4+
-                    # source build failed under the trailing `||:`. reprepro
-                    # 5.4+ is required (the 'Limit' distributions field).
+                    # Verify the *version*, not just presence: reprepro 5.4+ is
+                    # required (the 'Limit' distributions field), so a stale
+                    # distro reprepro (5.3.x) must not satisfy the check.
                     "command -v createrepo_c >/dev/null"
                     " && reprepro --version 2>&1 | grep -qE '5\\.[4-9]'"
                     " || { echo 'ERROR: createrepo_c and reprepro 5.4+ must be"


### PR DESCRIPTION
The `CreateRelease` job installs `createrepo_c` and `reprepro` before mutating any release state (tags, GitHub release, repos), guarded by a fail-close check that aborts the release if either tool is missing. On a freshly booted runner `unattended-upgrades` may still be running and holding `/var/lib/dpkg/lock-frontend`, so `apt-get install` aborts immediately:

```
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 3498 (unattended-upgr)
```

Because the install is best-effort (trailing `||:`, so a dev machine without sudo/apt is not blocked), the lock error is swallowed and the tools stay uninstalled. The fail-close check then aborts the whole release with `ERROR: createrepo_c and reprepro 5.4+ must be installed for a release`. This is a distinct failure mode from the stale-index 404 addressed earlier by the preceding `apt-get update`.

Pass `-o DPkg::Lock::Timeout=300` to every `apt-get` invocation so it waits up to 5 minutes for the lock to be released instead of failing immediately.

CI run: https://github.com/ClickHouse/ClickHouse/actions/runs/30884242821/job/91923535982

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

