### PR TITLE
docs(clickpipes): document clickpipes_egress_ips in static-ips API

### DIFF
--- a/docs/integrations/clickpipes/networking/static-ips.mdx
+++ b/docs/integrations/clickpipes/networking/static-ips.mdx
@@ -12,6 +12,18 @@ integration:
 
 The following tables list the static NAT IPs that ClickPipes uses to connect to your external services. Add the IPs for the ClickPipes region that serves your ClickHouse Cloud service to your IP allow list. In the case of object storage pipes you should also add the [ClickHouse cluster IPs](/products/cloud/guides/data-sources/cloud-endpoints-api) to your IP allow list.
 
+<Tip>
+The ClickPipes static NAT IPs are also available from the [Cloud endpoints API](/products/cloud/guides/data-sources/cloud-endpoints-api) under the `clickpipes_egress_ips` field of each region, so you can keep an allow list in sync automatically:
+
+```bash
+# AWS — replace <region> with the ClickPipes region serving your service
+curl -s https://api.clickhouse.cloud/static-ips.json | jq -r '.aws[] | select(.region == "<region>") | .clickpipes_egress_ips[]'
+
+# Google Cloud
+curl -s https://api.clickhouse.cloud/static-ips.json | jq -r '.gcp[] | select(.region == "<region>") | .clickpipes_egress_ips[]'
+```
+</Tip>
+
 Services in the Google Cloud regions listed in the Google Cloud table below use those Google Cloud IPs only if the service did not contain pre-existing ClickPipes prior to June 15th, 2026. Services in those regions with pre-existing ClickPipes prior to June 15th, 2026 continue to use the default region IPs listed below.
 
 For other services, ClickPipes traffic will originate from a default region based on your service's location:

--- a/docs/products/cloud/guides/data-sources/cloud-endpoints-api.mdx
+++ b/docs/products/cloud/guides/data-sources/cloud-endpoints-api.mdx
@@ -13,6 +13,8 @@ import { Image } from "/snippets/components/Image.jsx";
 
 If you need to fetch the list of static IPs, you can use the following ClickHouse Cloud API endpoint: [`https://api.clickhouse.cloud/static-ips.json`](https://api.clickhouse.cloud/static-ips.json). This API provides the endpoints for ClickHouse Cloud services, such as ingress/egress IPs and S3 endpoints per region and cloud.
 
+For regions where [ClickPipes](/integrations/clickpipes/home) is available, each entry also includes a `clickpipes_egress_ips` field listing the static NAT IPs that ClickPipes uses to egress to your data sources. Add these to your source's allow list when ingesting through ClickPipes. See [the ClickPipes list of static IPs](/integrations/clickpipes/networking/static-ips) for details.
+
 If you're using an integration like the MySQL or PostgreSQL Engine, it is possible that you need to authorize ClickHouse Cloud to access your instances. You can use this API to retrieve the public IPs and configure them in `firewalls` or `Authorized networks` in GCP or in `Security Groups` for Azure, AWS, or in any other infrastructure egress management system you're using.
 
 For example, to allow access from a ClickHouse Cloud service hosted on AWS in the region `ap-south-1`, you can add the `egress_ips` addresses for that region:
@@ -22,6 +24,14 @@ For example, to allow access from a ClickHouse Cloud service hosted on AWS in th
 {
   "aws": [
     {
+      "clickpipes_egress_ips": [
+        "13.203.140.189",
+        "13.232.213.12",
+        "13.235.145.208",
+        "35.154.167.40",
+        "65.0.39.245",
+        "65.1.225.89"
+      ],
       "egress_ips": [
         "3.110.39.68",
         "15.206.7.77",


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

The Cloud static-ips API (`https://api.clickhouse.cloud/static-ips.json`) now exposes a
`clickpipes_egress_ips` field per region, listing the static NAT IPs ClickPipes uses to egress to
customer data sources. Nothing in the docs mentioned it, so customers maintaining an IP allow list
had no way to discover the field or keep their allow list in sync automatically — the only
documented source was the hand-maintained table on the ClickPipes static IPs page.

Two additions:

- **`cloud-endpoints-api`** — a paragraph describing the field, plus `clickpipes_egress_ips` added
  to the existing `ap-south-1` JSON sample. The six IPs in the sample are the real ap-south-1
  values and match the `ap-south-1` row of the ClickPipes static IPs table exactly.
- **`clickpipes/networking/static-ips`** — a tip with `jq` one-liners for AWS and Google Cloud, so
  an allow list can be refreshed programmatically instead of by copying the table.

Docs-only; no code or behaviour changes.

---

Ported from ClickHouse/clickhouse-docs#6596, which was opened before the docs move to this repo and
had conflicted against the old repo's `main`. Rewritten for the current structure here: the source
files were reorganised (`docs/products/cloud/guides/data-sources/` and
`docs/integrations/clickpipes/networking/`), the `:::tip` admonition converted to the `<Tip>`
component, and the cross-links updated to this repo's path-based convention. The original PR is
being closed in favour of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
