### PR TITLE
Reject duplicate storage namespaces within a policy

### DIFF
--- a/src/Disks/DiskEncrypted.cpp
+++ b/src/Disks/DiskEncrypted.cpp
@@ -189,8 +189,12 @@ namespace
     }
 
     /// Reads the name of a wrapped disk & the path on the wrapped disk and then finds that disk in a disk map.
-    void getDiskAndPathFromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_prefix, const DisksMap & map,
-                                  DiskPtr & out_disk, String & out_path)
+    void getDiskAndPathFromConfig(
+        const Poco::Util::AbstractConfiguration & config,
+        const String & config_prefix,
+        const DisksMap & map,
+        DiskPtr & out_disk,
+        String & out_path)
     {
         String disk_name = config.getString(config_prefix + ".disk", "");
         if (disk_name.empty())
@@ -207,6 +211,32 @@ namespace
         out_path = config.getString(config_prefix + ".path", "");
         if (!out_path.empty() && (out_path.back() != '/'))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Disk path must ends with '/', but '{}' doesn't.", quoteString(out_path));
+
+        /// The path must be relative to the wrapped disk's root. An absolute path would escape the delegate:
+        /// `DiskLocal` joins paths with `fs::path(delegate_root) / out_path`, and `fs::path::operator/` discards
+        /// the left-hand side when the right-hand side is absolute, so the files would land outside the delegate.
+        /// It also makes storage namespace identity unreliable, because disks over different delegates would appear
+        /// distinct while operating on the same underlying files. Rejecting absolute paths keeps the delegate's root
+        /// as a prefix of the effective path.
+        if (!out_path.empty() && (out_path.front() == '/'))
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Disk path must be relative to the wrapped disk, but '{}' is absolute.",
+                quoteString(out_path));
+
+        /// `DiskLocal` resolves the wrapped path on the filesystem, so traversal (`..`), current-directory (`.`)
+        /// and repeated-separator components are collapsed when files are accessed. Normalize the effective path
+        /// before checking that it stays under the delegate's root.
+        const fs::path delegate_root = fs::path(out_disk->getPath()).lexically_normal();
+        const fs::path effective_path = fs::path(out_disk->getPath() + out_path).lexically_normal();
+        if (const auto relative_to_root = effective_path.lexically_relative(delegate_root);
+            relative_to_root.empty() || *relative_to_root.begin() == "..")
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Disk path '{}' must stay within the wrapped disk's root '{}'.",
+                quoteString(out_path),
+                quoteString(out_disk->getPath()));
+
     }
 
     /// Parses the settings of an encrypted disk from the configuration.

--- a/src/Disks/DiskEncrypted.cpp
+++ b/src/Disks/DiskEncrypted.cpp
@@ -224,11 +224,17 @@ namespace
                 "Disk path must be relative to the wrapped disk, but '{}' is absolute.",
                 quoteString(out_path));
 
-        /// `DiskLocal` resolves the wrapped path on the filesystem, so traversal (`..`), current-directory (`.`)
-        /// and repeated-separator components are collapsed when files are accessed. Normalize the effective path
-        /// before checking that it stays under the delegate's root.
-        const fs::path delegate_root = fs::path(out_disk->getPath()).lexically_normal();
-        const fs::path effective_path = fs::path(out_disk->getPath() + out_path).lexically_normal();
+        /// Normalize the effective path before checking that it stays under the delegate's root. For local disks,
+        /// canonicalize the paths to resolve existing symlink components too. `weakly_canonical` also works when
+        /// the encrypted disk's trailing directories do not exist yet.
+        fs::path delegate_root = fs::path(out_disk->getPath()).lexically_normal();
+        fs::path effective_path = fs::path(out_disk->getPath() + out_path).lexically_normal();
+        if (out_disk->getDataSourceDescription().type == DataSourceType::Local)
+        {
+            delegate_root = fs::weakly_canonical(delegate_root);
+            effective_path = fs::weakly_canonical(effective_path);
+        }
+
         if (const auto relative_to_root = effective_path.lexically_relative(delegate_root);
             relative_to_root.empty() || *relative_to_root.begin() == "..")
             throw Exception(

--- a/src/Disks/StoragePolicy.cpp
+++ b/src/Disks/StoragePolicy.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <exception>
+#include <filesystem>
 #include <ranges>
 #include <set>
 
@@ -117,6 +118,7 @@ StoragePolicy::StoragePolicy(
                         "Disk move factor have to be in [0., 1.] interval, but set to {} in storage policy {}",
                         move_factor, backQuote(name));
 
+    validateDisksHaveDistinctStorageNamespaces();
     buildVolumeIndices();
     LOG_TRACE(log, "Storage policy {} created, total volumes {}", name, volumes.size());
 }
@@ -136,6 +138,7 @@ StoragePolicy::StoragePolicy(String name_, Volumes volumes_, double move_factor_
                         "Disk move factor have to be in [0., 1.] interval, but set to {} in storage policy {}",
                         move_factor, backQuote(name));
 
+    validateDisksHaveDistinctStorageNamespaces();
     buildVolumeIndices();
     LOG_TRACE(log, "Storage policy {} created, total volumes {}", name, volumes.size());
 }
@@ -170,6 +173,8 @@ StoragePolicy::StoragePolicy(StoragePolicyPtr storage_policy,
             }
         }
     }
+
+    validateDisksHaveDistinctStorageNamespaces();
 }
 
 
@@ -467,6 +472,46 @@ void StoragePolicy::buildVolumeIndices()
 
             volume_index_by_disk_name[disk_name] = index;
         }
+    }
+}
+
+void StoragePolicy::validateDisksHaveDistinctStorageNamespaces() const
+{
+    struct StorageNamespace
+    {
+        DataSourceType type;
+        ObjectStorageType object_storage_type;
+        String description;
+        String path;
+
+        auto operator<=>(const StorageNamespace &) const = default;
+    };
+
+    std::map<StorageNamespace, String> disk_by_namespace;
+    for (const auto & disk : getDisks())
+    {
+        const auto data_source = disk->getDataSourceDescription();
+
+        /// Separate in-memory disks do not share a persistent namespace even though their paths are empty.
+        if (data_source.type == DataSourceType::RAM)
+            continue;
+
+        StorageNamespace storage_namespace{
+            .type = data_source.type,
+            .object_storage_type = data_source.object_storage_type,
+            .description = data_source.type == DataSourceType::ObjectStorage ? data_source.description : String{},
+            .path = std::filesystem::path(disk->getPath()).lexically_normal().string(),
+        };
+
+        auto [it, inserted] = disk_by_namespace.emplace(storage_namespace, disk->getName());
+        if (!inserted && it->second != disk->getName())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Disks {} and {} in storage policy {} resolve to the same storage namespace ({})",
+                backQuote(it->second),
+                backQuote(disk->getName()),
+                backQuote(name),
+                quoteString(storage_namespace.path));
     }
 }
 

--- a/src/Disks/StoragePolicy.cpp
+++ b/src/Disks/StoragePolicy.cpp
@@ -2,6 +2,7 @@
 #include <base/sort.h>
 #include <Disks/DiskFactory.h>
 #include <Disks/DiskLocal.h>
+#include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h>
 #include <Disks/createVolume.h>
 
 #include <Interpreters/Context.h>
@@ -482,36 +483,51 @@ void StoragePolicy::validateDisksHaveDistinctStorageNamespaces() const
         DataSourceType type;
         ObjectStorageType object_storage_type;
         String description;
+        String objects_namespace;
+        String zookeeper_name;
         String path;
 
         auto operator<=>(const StorageNamespace &) const = default;
     };
 
     std::map<StorageNamespace, String> disk_by_namespace;
-    for (const auto & disk : getDisks())
+    for (const auto & volume : volumes)
     {
-        const auto data_source = disk->getDataSourceDescription();
+        for (const auto & disk : volume->getDisks())
+        {
+            const auto data_source = disk->getDataSourceDescription();
 
-        /// Separate in-memory disks do not share a persistent namespace even though their paths are empty.
-        if (data_source.type == DataSourceType::RAM)
-            continue;
+            /// Separate in-memory disks do not share a persistent namespace even though their paths are empty.
+            if (data_source.type == DataSourceType::RAM)
+                continue;
 
-        StorageNamespace storage_namespace{
-            .type = data_source.type,
-            .object_storage_type = data_source.object_storage_type,
-            .description = data_source.type == DataSourceType::ObjectStorage ? data_source.description : String{},
-            .path = std::filesystem::path(disk->getPath()).lexically_normal().string(),
-        };
+            auto path = std::filesystem::path(disk->getPath()).lexically_normal();
+            if (data_source.type == DataSourceType::Local)
+                path = std::filesystem::weakly_canonical(path);
 
-        auto [it, inserted] = disk_by_namespace.emplace(storage_namespace, disk->getName());
-        if (!inserted && it->second != disk->getName())
-            throw Exception(
-                ErrorCodes::BAD_ARGUMENTS,
-                "Disks {} and {} in storage policy {} resolve to the same storage namespace ({})",
-                backQuote(it->second),
-                backQuote(disk->getName()),
-                backQuote(name),
-                quoteString(storage_namespace.path));
+            String objects_namespace;
+            if (data_source.type == DataSourceType::ObjectStorage)
+                objects_namespace = disk->getObjectStorage()->getObjectsNamespace();
+
+            StorageNamespace storage_namespace{
+                .type = data_source.type,
+                .object_storage_type = data_source.object_storage_type,
+                .description = data_source.type == DataSourceType::ObjectStorage ? data_source.description : String{},
+                .objects_namespace = std::move(objects_namespace),
+                .zookeeper_name = data_source.type == DataSourceType::ObjectStorage ? data_source.zookeeper_name : String{},
+                .path = path.string(),
+            };
+
+            auto [it, inserted] = disk_by_namespace.emplace(storage_namespace, disk->getName());
+            if (!inserted && it->second != disk->getName())
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Disks {} and {} in storage policy {} resolve to the same storage namespace ({})",
+                    backQuote(it->second),
+                    backQuote(disk->getName()),
+                    backQuote(name),
+                    quoteString(storage_namespace.path));
+        }
     }
 }
 

--- a/src/Disks/StoragePolicy.h
+++ b/src/Disks/StoragePolicy.h
@@ -102,6 +102,7 @@ private:
     double move_factor = 0.1; /// by default move factor is 10%
 
     void buildVolumeIndices();
+    void validateDisksHaveDistinctStorageNamespaces() const;
 
     LoggerPtr log;
 };

--- a/src/Disks/tests/gtest_disk_encrypted.cpp
+++ b/src/Disks/tests/gtest_disk_encrypted.cpp
@@ -9,6 +9,8 @@
 #include <Disks/IDisk.h>
 #include <Disks/DiskLocal.h>
 #include <Disks/DiskEncrypted.h>
+#include <Disks/SingleDiskVolume.h>
+#include <Disks/StoragePolicy.h>
 #include <IO/FileEncryptionCommon.h>
 #include <IO/WriteHelpers.h>
 #include <IO/ReadHelpers.h>
@@ -54,6 +56,26 @@ protected:
         settings->disk_path = path;
         encrypted_disk = std::make_shared<DiskEncrypted>("encrypted_disk", std::move(settings));
         return encrypted_disk;
+    }
+
+    static void configureEncryptedDisk(
+        Poco::Util::XMLConfiguration & config,
+        const String & prefix,
+        const String & wrapped_disk,
+        const std::optional<String> & path)
+    {
+        config.setString(prefix + ".key", "1234567890123456");
+        config.setString(prefix + ".disk", wrapped_disk);
+        if (path)
+            config.setString(prefix + ".path", *path);
+    }
+
+    static std::shared_ptr<DiskEncrypted> makeConfiguredEncryptedDisk(
+        const String & name,
+        const Poco::Util::XMLConfiguration & config,
+        const DisksMap & disks)
+    {
+        return std::make_shared<DiskEncrypted>(name, config, name, disks);
     }
 
     String getFileNames()
@@ -481,4 +503,159 @@ TEST_F(DiskEncryptedTest, DoubleEncrypted)
     auto double_encrypted_disk = makeEncryptedDisk(FileEncryption::Algorithm::AES_128_CTR, "1234567890123456", single_encrypted_disk);
 
     testSeekAndReadUntilPosition(encrypted_disk, "a.txt", {});
+}
+
+TEST_F(DiskEncryptedTest, ConfigurationAllowsSameDelegateAndExplicitPathInDifferentPolicies)
+{
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", "data/");
+    configureEncryptedDisk(*config, "encrypted2", "local_disk", "data/");
+
+    DisksMap disks{{"local_disk", local_disk}};
+    auto encrypted1 = makeConfiguredEncryptedDisk("encrypted1", *config, disks);
+    disks.emplace("encrypted1", encrypted1);
+    auto encrypted2 = makeConfiguredEncryptedDisk("encrypted2", *config, disks);
+
+    EXPECT_NO_THROW(StoragePolicy("policy1", Volumes{std::make_shared<SingleDiskVolume>("volume1", encrypted1)}, 0.0));
+    EXPECT_NO_THROW(StoragePolicy("policy2", Volumes{std::make_shared<SingleDiskVolume>("volume2", encrypted2)}, 0.0));
+}
+
+TEST_F(DiskEncryptedTest, StoragePolicyRejectsSameDelegateAndExplicitPath)
+{
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", "data/");
+    configureEncryptedDisk(*config, "encrypted2", "local_disk", "data/");
+
+    DisksMap disks{{"local_disk", local_disk}};
+    auto encrypted1 = makeConfiguredEncryptedDisk("encrypted1", *config, disks);
+    disks.emplace("encrypted1", encrypted1);
+    auto encrypted2 = makeConfiguredEncryptedDisk("encrypted2", *config, disks);
+
+    Volumes volumes{
+        std::make_shared<SingleDiskVolume>("volume1", encrypted1),
+        std::make_shared<SingleDiskVolume>("volume2", encrypted2),
+    };
+    EXPECT_THROW(StoragePolicy("policy", std::move(volumes), 0.1), DB::Exception);
+}
+
+TEST_F(DiskEncryptedTest, StoragePolicyRejectsSameNamespaceOverDifferentDelegates)
+{
+    auto nested_local_disk = std::make_shared<DiskLocal>("nested_local_disk", getDirectory() + "data/");
+
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "nested_local_disk", "encrypted/");
+    configureEncryptedDisk(*config, "encrypted2", "local_disk", "data/encrypted/");
+
+    DisksMap disks{{"local_disk", local_disk}, {"nested_local_disk", nested_local_disk}};
+    auto encrypted1 = makeConfiguredEncryptedDisk("encrypted1", *config, disks);
+    disks.emplace("encrypted1", encrypted1);
+    auto encrypted2 = makeConfiguredEncryptedDisk("encrypted2", *config, disks);
+
+    Volumes volumes{
+        std::make_shared<SingleDiskVolume>("volume1", encrypted1),
+        std::make_shared<SingleDiskVolume>("volume2", encrypted2),
+    };
+    EXPECT_THROW(StoragePolicy("policy", std::move(volumes), 0.1), DB::Exception);
+}
+
+TEST_F(DiskEncryptedTest, ConfigurationRejectsAbsolutePath)
+{
+    /// An absolute `path` would escape the wrapped disk: `DiskLocal` joins paths with `fs::path(root) / path`,
+    /// and `fs::path::operator/` discards the root when the right-hand side is absolute. Such a path must be rejected
+    /// before storage-policy namespace validation because it violates the delegate boundary.
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", "/data/");
+
+    DisksMap disks{{"local_disk", local_disk}};
+    EXPECT_THROW(makeConfiguredEncryptedDisk("encrypted1", *config, disks), DB::Exception);
+}
+
+TEST_F(DiskEncryptedTest, StoragePolicyRejectsTraversalAliasOfSamePath)
+{
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", "a/../b/");
+    configureEncryptedDisk(*config, "encrypted2", "local_disk", "b/");
+
+    DisksMap disks{{"local_disk", local_disk}};
+    auto encrypted1 = makeConfiguredEncryptedDisk("encrypted1", *config, disks);
+    disks.emplace("encrypted1", encrypted1);
+    auto encrypted2 = makeConfiguredEncryptedDisk("encrypted2", *config, disks);
+
+    Volumes volumes{
+        std::make_shared<SingleDiskVolume>("volume1", encrypted1),
+        std::make_shared<SingleDiskVolume>("volume2", encrypted2),
+    };
+    EXPECT_THROW(StoragePolicy("policy", std::move(volumes), 0.1), DB::Exception);
+}
+
+TEST_F(DiskEncryptedTest, ConfigurationRejectsPathEscapingDelegateRoot)
+{
+    /// A relative `path` that escapes the delegate's root via `..` lands outside the wrapped disk, just like an
+    /// absolute path and breaks isolation. It must be rejected.
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", "../escape/");
+
+    DisksMap disks{{"local_disk", local_disk}};
+    EXPECT_THROW(makeConfiguredEncryptedDisk("encrypted1", *config, disks), DB::Exception);
+}
+
+TEST_F(DiskEncryptedTest, ConfigurationAllowsDifferentPathsOrDelegates)
+{
+    auto other_local_disk = std::make_shared<DiskLocal>("other_local_disk", getDirectory() + "other/");
+
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", "data/");
+    configureEncryptedDisk(*config, "encrypted2", "local_disk", "other_data/");
+    configureEncryptedDisk(*config, "encrypted3", "other_local_disk", "data/");
+
+    DisksMap disks{{"local_disk", local_disk}, {"other_local_disk", other_local_disk}};
+    auto encrypted1 = makeConfiguredEncryptedDisk("encrypted1", *config, disks);
+    disks.emplace("encrypted1", encrypted1);
+    auto encrypted2 = makeConfiguredEncryptedDisk("encrypted2", *config, disks);
+    disks.emplace("encrypted2", encrypted2);
+    auto encrypted3 = makeConfiguredEncryptedDisk("encrypted3", *config, disks);
+
+    Volumes volumes{
+        std::make_shared<SingleDiskVolume>("volume1", encrypted1),
+        std::make_shared<SingleDiskVolume>("volume2", encrypted2),
+        std::make_shared<SingleDiskVolume>("volume3", encrypted3),
+    };
+    EXPECT_NO_THROW(StoragePolicy("policy", std::move(volumes), 0.1));
+}
+
+TEST_F(DiskEncryptedTest, StoragePolicyAllowsEncryptedWithoutPathAsOnlyDisk)
+{
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", std::nullopt);
+
+    DisksMap disks{{"local_disk", local_disk}};
+    auto encrypted1 = makeConfiguredEncryptedDisk("encrypted1", *config, disks);
+
+    EXPECT_NO_THROW(StoragePolicy("policy", Volumes{std::make_shared<SingleDiskVolume>("volume", encrypted1)}, 0.0));
+}
+
+TEST_F(DiskEncryptedTest, StoragePolicyRejectsDelegateAndEncryptedWithoutPath)
+{
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", std::nullopt);
+
+    DisksMap disks{{"local_disk", local_disk}};
+    auto encrypted1 = makeConfiguredEncryptedDisk("encrypted1", *config, disks);
+
+    Volumes volumes{
+        std::make_shared<SingleDiskVolume>("plain_volume", local_disk),
+        std::make_shared<SingleDiskVolume>("encrypted_volume", encrypted1),
+    };
+    EXPECT_THROW(StoragePolicy("policy", std::move(volumes), 0.1), DB::Exception);
+}
+
+TEST_F(DiskEncryptedTest, StoragePolicyRejectsLocalDiskAliases)
+{
+    auto local_disk_alias = std::make_shared<DiskLocal>("local_disk_alias", getDirectory());
+
+    Volumes volumes{
+        std::make_shared<SingleDiskVolume>("volume1", local_disk),
+        std::make_shared<SingleDiskVolume>("volume2", local_disk_alias),
+    };
+    EXPECT_THROW(StoragePolicy("policy", std::move(volumes), 0.1), DB::Exception);
 }

--- a/src/Disks/tests/gtest_disk_encrypted.cpp
+++ b/src/Disks/tests/gtest_disk_encrypted.cpp
@@ -599,6 +599,22 @@ TEST_F(DiskEncryptedTest, ConfigurationRejectsPathEscapingDelegateRoot)
     EXPECT_THROW(makeConfiguredEncryptedDisk("encrypted1", *config, disks), DB::Exception);
 }
 
+TEST_F(DiskEncryptedTest, ConfigurationRejectsSymlinkEscapingDelegateRoot)
+{
+    const fs::path delegate_root = fs::path(getDirectory()) / "delegate";
+    const fs::path outside_root = fs::path(getDirectory()) / "outside";
+    fs::create_directories(delegate_root);
+    fs::create_directories(outside_root);
+    fs::create_directory_symlink(outside_root, delegate_root / "link");
+
+    auto delegate_disk = std::make_shared<DiskLocal>("delegate_disk", delegate_root);
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "delegate_disk", "link/encrypted/");
+
+    DisksMap disks{{"delegate_disk", delegate_disk}};
+    EXPECT_THROW(makeConfiguredEncryptedDisk("encrypted1", *config, disks), DB::Exception);
+}
+
 TEST_F(DiskEncryptedTest, ConfigurationAllowsDifferentPathsOrDelegates)
 {
     auto other_local_disk = std::make_shared<DiskLocal>("other_local_disk", getDirectory() + "other/");
@@ -656,6 +672,22 @@ TEST_F(DiskEncryptedTest, StoragePolicyRejectsLocalDiskAliases)
     Volumes volumes{
         std::make_shared<SingleDiskVolume>("volume1", local_disk),
         std::make_shared<SingleDiskVolume>("volume2", local_disk_alias),
+    };
+    EXPECT_THROW(StoragePolicy("policy", std::move(volumes), 0.1), DB::Exception);
+}
+
+TEST_F(DiskEncryptedTest, StoragePolicyRejectsLocalDiskSymlinkAliases)
+{
+    const fs::path real_path = fs::path(getDirectory()) / "real";
+    const fs::path alias_path = fs::path(getDirectory()) / "alias";
+    fs::create_directories(real_path);
+    fs::create_directory_symlink(real_path, alias_path);
+
+    auto real_disk = std::make_shared<DiskLocal>("real_disk", real_path);
+    auto alias_disk = std::make_shared<DiskLocal>("alias_disk", alias_path);
+    Volumes volumes{
+        std::make_shared<SingleDiskVolume>("volume1", real_disk),
+        std::make_shared<SingleDiskVolume>("volume2", alias_disk),
     };
     EXPECT_THROW(StoragePolicy("policy", std::move(volumes), 0.1), DB::Exception);
 }

--- a/tests/integration/test_disk_configuration/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_disk_configuration/configs/config.d/storage_configuration.xml
@@ -11,6 +11,27 @@
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
             </s3>
+            <s3_plain_bucket_root>
+                <type>s3_plain</type>
+                <endpoint>http://minio1:9001/root/data/disks/shared_plain/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
+                <readonly>true</readonly>
+            </s3_plain_bucket_root>
+            <s3_plain_bucket_root2>
+                <type>s3_plain</type>
+                <endpoint>http://minio1:9001/root2/data/disks/shared_plain/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
+                <readonly>true</readonly>
+            </s3_plain_bucket_root2>
+            <s3_plain_bucket_root_alias>
+                <type>s3_plain</type>
+                <endpoint>http://minio1:9001/root/data/disks/shared_plain/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
+                <readonly>true</readonly>
+            </s3_plain_bucket_root_alias>
         </disks>
         <policies>
             <local>
@@ -37,6 +58,16 @@
                     </s3>
                 </volumes>
             </hybrid>
+            <object_storage_different_buckets>
+                <volumes>
+                    <root>
+                        <disk>s3_plain_bucket_root</disk>
+                    </root>
+                    <root2>
+                        <disk>s3_plain_bucket_root2</disk>
+                    </root2>
+                </volumes>
+            </object_storage_different_buckets>
 
         </policies>
     </storage_configuration>

--- a/tests/integration/test_disk_configuration/configs/duplicate_object_storage_policy.xml
+++ b/tests/integration/test_disk_configuration/configs/duplicate_object_storage_policy.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <storage_configuration>
+        <policies>
+            <object_storage_same_bucket>
+                <volumes>
+                    <original>
+                        <disk>s3_plain_bucket_root</disk>
+                    </original>
+                    <alias>
+                        <disk>s3_plain_bucket_root_alias</disk>
+                    </alias>
+                </volumes>
+            </object_storage_same_bucket>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_disk_configuration/test.py
+++ b/tests/integration/test_disk_configuration/test.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import pytest
 
@@ -7,6 +8,7 @@ from helpers.config_cluster import minio_secret_key
 from helpers.blobs import wait_blobs_count_synchronization
 
 cluster = ClickHouseCluster(__file__)
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 @pytest.fixture(scope="module")
@@ -167,6 +169,39 @@ def test_merge_tree_disk_setting(start_cluster):
 
     wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
     wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
+
+
+def test_object_storage_namespace_in_storage_policy(start_cluster):
+    node = cluster.instances["node1"]
+    invalid_policy_path = "/etc/clickhouse-server/config.d/duplicate_object_storage_policy.xml"
+
+    assert (
+        node.query(
+            "SELECT count() FROM system.storage_policies "
+            "WHERE policy_name = 'object_storage_different_buckets'"
+        )
+        == "2\n"
+    )
+
+    node.copy_file_to_container(
+        os.path.join(SCRIPT_DIR, "configs/duplicate_object_storage_policy.xml"),
+        invalid_policy_path,
+    )
+    try:
+        node.query("SYSTEM RELOAD CONFIG")
+        assert node.wait_for_log_line(
+            "storage policy `object_storage_same_bucket` resolve to the same storage namespace"
+        )
+        assert (
+            node.query(
+                "SELECT count() FROM system.storage_policies "
+                "WHERE policy_name = 'object_storage_same_bucket'"
+            )
+            == "0\n"
+        )
+    finally:
+        node.exec_in_container(["rm", "-f", invalid_policy_path])
+        node.query("SYSTEM RELOAD CONFIG")
 
 
 def test_merge_tree_custom_disk_setting(start_cluster):


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/88808
Related: https://github.com/ClickHouse/ClickHouse/pull/107484

Two top-level disks in the same storage policy could resolve to the same underlying storage namespace. During `MergeTree` startup, the table scans every disk in its policy, so the same part can be loaded twice and one copy can be removed as a duplicate. If both disk objects refer to the same physical data, this removes the only copy and causes data loss.

The previous fix in https://github.com/ClickHouse/ClickHouse/pull/107484 compared every configured `encrypted` disk globally. That rejected safe configurations where separate tables use equivalent custom disks through separate single-disk policies. In particular, it broke `03820_plain_rewritable_over_another_disk_with_same_path` for `encrypted` disks layered directly over and through a cache on the same `s3_plain_rewritable` storage.

This change keeps the absolute-path, normalization, and delegate-boundary validation for `encrypted` disk paths, but moves duplicate namespace validation to `StoragePolicy`. Only top-level disks visible to the same policy are compared. This rejects the configuration that can make one table scan the same namespace twice, while allowing equivalent disks used by separate policies. The validation applies to configured, reloaded, and programmatically created policies and also covers wrapper/delegate and non-encrypted disk aliases.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reject storage policies whose top-level disks resolve to the same underlying storage namespace, which could cause data loss after a server restart.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113451&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/113451](https://github.com/search?q=head%3Async-upstream%2Fpr%2F113451+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
