### PR TITLE
Resolve the query status per call in functions that check for cancellation

### DIFF
--- a/src/Functions/FunctionBaseXXConversion.h
+++ b/src/Functions/FunctionBaseXXConversion.h
@@ -10,6 +10,7 @@
 #include <Interpreters/ProcessList.h>
 #include <fmt/format.h>
 #include <Common/Base58.h>
+#include <Common/CurrentThread.h>
 
 #include <functional>
 
@@ -300,8 +301,8 @@ class FunctionBaseXXConversion final : public IFunction
 public:
     static constexpr auto name = Func::name;
 
-    FunctionBaseXXConversion(QueryStatusPtr query_status_, size_t max_input_size_)
-        : query_status(std::move(query_status_)), max_input_size(max_input_size_) {}
+    explicit FunctionBaseXXConversion(size_t max_input_size_)
+        : max_input_size(max_input_size_) {}
 
     static FunctionPtr create(ContextPtr context)
     {
@@ -310,7 +311,7 @@ public:
         size_t max_input_size = Func::default_max_input_size;
         if (max_input_size != 0)
             max_input_size = context->getSettingsRef()[Setting::function_base58_max_input_size];
-        return std::make_shared<FunctionBaseXXConversion>(context->getProcessListElementSafe(), max_input_size);
+        return std::make_shared<FunctionBaseXXConversion>(max_input_size);
     }
     String getName() const override { return Func::name; }
     bool isVariadic() const override { return has_size_optimization; }
@@ -354,9 +355,15 @@ public:
         /// `checkTimeLimit` throws for `KILL QUERY` and for the `throw` overflow mode; for the `break` overflow
         /// mode it returns `false` instead. There is no meaningful partial result for a single scalar value, so
         /// a `break` request is turned into a hard stop here as well.
+        /// Resolved from the executing thread rather than captured: this instance can be stored in table
+        /// metadata and then run by any later query.
+        QueryStatusPtr query_status;
+        if (auto query_context = CurrentThread::tryGetQueryContext())
+            query_status = query_context->getProcessListElementSafe();
+
         std::function<void()> check_cancellation;
         if (query_status)
-            check_cancellation = [this]
+            check_cancellation = [&query_status]
             {
                 if (!query_status->checkTimeLimit())
                     throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", name);
@@ -416,7 +423,6 @@ public:
     }
 
 private:
-    QueryStatusPtr query_status;
     size_t max_input_size;
 };
 

--- a/src/Functions/array/arrayFold.cpp
+++ b/src/Functions/array/arrayFold.cpp
@@ -1,5 +1,6 @@
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnFunction.h>
+#include <Common/CurrentThread.h>
 #include <Common/Exception.h>
 #include <Common/VectorWithMemoryTracking.h>
 #include <DataTypes/DataTypeArray.h>
@@ -31,12 +32,7 @@ class FunctionArrayFold final : public IFunction
 {
 public:
     static constexpr auto name = "arrayFold";
-    static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionArrayFold>(context); }
-
-    explicit FunctionArrayFold(ContextPtr context)
-        : process_list_element(context ? context->getProcessListElement() : nullptr)
-    {
-    }
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionArrayFold>(); }
 
     bool isVariadic() const override { return true; }
     size_t getNumberOfArguments() const override { return 0; }
@@ -93,6 +89,12 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
+        /// Resolved from the executing thread rather than captured: this instance can be stored in table
+        /// metadata and then run by any later query.
+        QueryStatusPtr process_list_element;
+        if (auto query_context = CurrentThread::tryGetQueryContext())
+            process_list_element = query_context->getProcessListElementSafe();
+
         const auto & lambda_function_with_type_and_name = arguments[0];
 
         if (!lambda_function_with_type_and_name.column)
@@ -192,7 +194,7 @@ public:
         {
             /// This loop is O(total array elements) and also runs uninterruptibly inside executeImpl().
             if ((i & 0xFFFFF) == 0)
-                checkQueryTimeLimit();
+                checkQueryTimeLimit(process_list_element);
 
             selector[i] = cur_element_in_cur_array;
             ++cur_element_in_cur_array;
@@ -244,7 +246,7 @@ public:
             /// a very long array (e.g. range(number) with a result-growing lambda) ignores KILL QUERY and
             /// max_execution_time and keeps running. Each iteration performs a full lambda->reduce(), so the
             /// per-iteration check is negligible.
-            checkQueryTimeLimit();
+            checkQueryTimeLimit(process_list_element);
 
             IColumn::Selector prev_selector(unfinished_rows); /// 1 for rows which have slice_i-many elements, otherwise 0
             size_t prev_index = 0;
@@ -319,14 +321,12 @@ public:
     }
 
 private:
-    QueryStatusPtr process_list_element;
-
     /// checkTimeLimit() throws for KILL QUERY and the 'throw' overflow mode; for the 'break' overflow
     /// mode it returns false instead. A fold has no meaningful partial result (a half-folded accumulator
     /// is a wrong value, not a smaller one), so we throw on the false (break) return to stop the runaway
     /// fold. In 'break' mode the pipeline absorbs this timeout into a clean cancellation, so the query
     /// ends without a client-visible error and yields no rows for the cancelled fold.
-    void checkQueryTimeLimit() const
+    static void checkQueryTimeLimit(const QueryStatusPtr & process_list_element)
     {
         if (process_list_element && !process_list_element->checkTimeLimit())
             throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", name);

--- a/src/Functions/geohashesInBox.cpp
+++ b/src/Functions/geohashesInBox.cpp
@@ -9,6 +9,7 @@
 #include <DataTypes/DataTypeString.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ProcessList.h>
+#include <Common/CurrentThread.h>
 
 #include <memory>
 #include <string>
@@ -31,12 +32,7 @@ class FunctionGeohashesInBox final : public IFunction
 {
 public:
     static constexpr auto name = "geohashesInBox";
-    static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionGeohashesInBox>(context); }
-
-    explicit FunctionGeohashesInBox(ContextPtr context)
-        : process_list_element(context ? context->getProcessListElement() : nullptr)
-    {
-    }
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionGeohashesInBox>(); }
 
     String getName() const override { return name; }
 
@@ -78,7 +74,8 @@ public:
         const IColumn * lat_max_column,
         const IColumn * precision_column,
         ColumnPtr & result,
-        size_t input_rows_count) const
+        size_t input_rows_count,
+        const QueryStatusPtr & process_list_element) const
     {
         static constexpr size_t max_array_size = 10'000'000;
         /// The span between two checkpoints is the work a cancelled query still has to finish, so it
@@ -154,7 +151,7 @@ public:
             if (items_since_check >= items_between_cancellation_checks)
             {
                 items_since_check = 0;
-                checkQueryTimeLimit();
+                checkQueryTimeLimit(process_list_element);
             }
 
             res_strings_offsets.reserve(res_strings_offsets.size() + prepared_args.items_count);
@@ -193,24 +190,28 @@ public:
         const IColumn * precision = arguments[4].column.get();
         ColumnPtr res;
 
+        /// Resolved from the executing thread rather than captured: this instance can be stored in table
+        /// metadata and then run by any later query.
+        QueryStatusPtr process_list_element;
+        if (auto query_context = CurrentThread::tryGetQueryContext())
+            process_list_element = query_context->getProcessListElementSafe();
+
         // Dispatch on the declared argument type, not the runtime column class: a constant
         // coordinate stays wrapped in ColumnConst when the call mixes const and non-const
         // arguments, so checkColumn<ColumnVector<...>> on the raw column would misclassify it.
         if (WhichDataType(arguments[0].type).isFloat32())
-            execute<Float32, UInt8>(lon_min, lat_min, lon_max, lat_max, precision, res, input_rows_count);
+            execute<Float32, UInt8>(lon_min, lat_min, lon_max, lat_max, precision, res, input_rows_count, process_list_element);
         else
-            execute<Float64, UInt8>(lon_min, lat_min, lon_max, lat_max, precision, res, input_rows_count);
+            execute<Float64, UInt8>(lon_min, lat_min, lon_max, lat_max, precision, res, input_rows_count, process_list_element);
 
         return res;
     }
 
 private:
-    QueryStatusPtr process_list_element;
-
     /// `checkTimeLimit` throws for `KILL QUERY` and the 'throw' overflow mode; for the 'break' mode it
     /// returns false instead. A half-filled `Array(String)` result is a wrong value, not a smaller one,
     /// so we throw on the false return too; the pipeline absorbs it into a clean cancellation.
-    void checkQueryTimeLimit() const
+    static void checkQueryTimeLimit(const QueryStatusPtr & process_list_element)
     {
         if (process_list_element && !process_list_element->checkTimeLimit())
             throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", name);

--- a/src/Functions/h3PolygonToCells.cpp
+++ b/src/Functions/h3PolygonToCells.cpp
@@ -16,6 +16,7 @@
 #include <Functions/FunctionHelpers.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ProcessList.h>
+#include <Common/CurrentThread.h>
 #include <Common/VectorWithMemoryTracking.h>
 
 #include <constants.h>
@@ -63,12 +64,7 @@ class FunctionH3PolygonToCells final : public IFunction
 public:
     static constexpr auto name = "h3PolygonToCells";
     String getName() const override { return name; }
-    static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionH3PolygonToCells>(context); }
-
-    explicit FunctionH3PolygonToCells(ContextPtr context)
-        : process_list_element(context ? context->getProcessListElement() : nullptr)
-    {
-    }
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionH3PolygonToCells>(); }
 
     size_t getNumberOfArguments() const override { return 2; }
     bool useDefaultImplementationForConstants() const override { return true; }
@@ -81,6 +77,12 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
+        /// Resolved from the executing thread rather than captured: this instance can be stored in table
+        /// metadata and then run by any later query.
+        QueryStatusPtr process_list_element;
+        if (auto query_context = CurrentThread::tryGetQueryContext())
+            process_list_element = query_context->getProcessListElementSafe();
+
         const bool is_const_geometry = isColumnConst(*arguments[0].column);
 
         /// Avoid materializing const geometry to full column — extract the inner data column instead,
@@ -245,8 +247,6 @@ public:
     }
 
 private:
-    QueryStatusPtr process_list_element;
-
     class GeoPolygonContainer
     {
     private:

--- a/src/Functions/h3PolygonToCellsWithContainment.cpp
+++ b/src/Functions/h3PolygonToCellsWithContainment.cpp
@@ -21,6 +21,7 @@
 #include <Interpreters/ProcessList.h>
 #include <Interpreters/castColumn.h>
 
+#include <Common/CurrentThread.h>
 #include <Common/VectorWithMemoryTracking.h>
 #include <constants.h>
 #include <h3api.h>
@@ -81,14 +82,9 @@ class Functionh3PolygonToCellsWithContainment : public IFunction
 public:
     static constexpr auto name = "h3PolygonToCellsWithContainment";
     String getName() const override { return name; }
-    static FunctionPtr create(ContextPtr context)
+    static FunctionPtr create(ContextPtr)
     {
-        return std::make_shared<Functionh3PolygonToCellsWithContainment>(context);
-    }
-
-    explicit Functionh3PolygonToCellsWithContainment(ContextPtr context)
-        : process_list_element(context ? context->getProcessListElement() : nullptr)
-    {
+        return std::make_shared<Functionh3PolygonToCellsWithContainment>();
     }
 
     size_t getNumberOfArguments() const override { return 3; }
@@ -107,6 +103,12 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
+        /// Resolved from the executing thread rather than captured: this instance can be stored in table
+        /// metadata and then run by any later query.
+        QueryStatusPtr process_list_element;
+        if (auto query_context = CurrentThread::tryGetQueryContext())
+            process_list_element = query_context->getProcessListElementSafe();
+
         const bool is_const_geometry = isColumnConst(*arguments[0].column);
 
         ColumnPtr col_array_holder;
@@ -320,8 +322,6 @@ public:
     }
 
 private:
-    QueryStatusPtr process_list_element;
-
     class GeoPolygonContainer
     {
     private:

--- a/src/Functions/sleep.cpp
+++ b/src/Functions/sleep.cpp
@@ -8,6 +8,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/ProcessList.h>
 #include <base/sleep.h>
+#include <Common/CurrentThread.h>
 #include <Common/FailPoint.h>
 #include <Common/FieldVisitorConvertToNumber.h>
 #include <Common/ProfileEvents.h>
@@ -60,22 +61,19 @@ private:
     const char * function_name;
     FunctionSleepVariant variant;
     UInt64 max_microseconds;
-    QueryStatusPtr query_status;
 
 public:
-    FunctionSleep(const char * name_, FunctionSleepVariant variant_, UInt64 max_microseconds_, QueryStatusPtr query_status_)
+    FunctionSleep(const char * name_, FunctionSleepVariant variant_, UInt64 max_microseconds_)
         : function_name(name_)
         , variant(variant_)
         , max_microseconds(std::min(max_microseconds_, static_cast<UInt64>(std::numeric_limits<UInt32>::max())))
-        , query_status(query_status_)
     {
     }
 
     static FunctionPtr create(const char * name, FunctionSleepVariant variant, ContextPtr context)
     {
         return std::make_shared<FunctionSleep>(
-            name, variant,
-            context->getSettingsRef()[Setting::function_sleep_max_microseconds_per_block], context->getProcessListElementSafe());
+            name, variant, context->getSettingsRef()[Setting::function_sleep_max_microseconds_per_block]);
     }
 
     String getName() const override { return function_name; }
@@ -112,6 +110,12 @@ public:
 
     ColumnPtr execute(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, bool dry_run) const
     {
+        /// Resolved from the executing thread rather than captured: this instance can be stored in table
+        /// metadata and then run by any later query.
+        QueryStatusPtr query_status;
+        if (auto query_context = CurrentThread::tryGetQueryContext())
+            query_status = query_context->getProcessListElementSafe();
+
         const IColumn * col = arguments[0].column.get();
 
         if (!isColumnConst(*col))

--- a/tests/queries/0_stateless/04752_persisted_expression_cancellation.reference
+++ b/tests/queries/0_stateless/04752_persisted_expression_cancellation.reference
@@ -19,6 +19,10 @@ base58_orderby: stopped promptly
 TIMEOUT_EXCEEDED
 geohash_skipindex: stopped promptly
 TIMEOUT_EXCEEDED
+h3cells_orderby_deadline: stopped promptly
+TIMEOUT_EXCEEDED
+h3containment_orderby_deadline: stopped promptly
+TIMEOUT_EXCEEDED
 TIMEOUT_EXCEEDED
 TIMEOUT_EXCEEDED
 h3cells_orderby: killed promptly

--- a/tests/queries/0_stateless/04752_persisted_expression_cancellation.reference
+++ b/tests/queries/0_stateless/04752_persisted_expression_cancellation.reference
@@ -1,0 +1,34 @@
+TIMEOUT_EXCEEDED
+control_partition: stopped promptly
+TIMEOUT_EXCEEDED
+geohash_partition: stopped promptly
+TIMEOUT_EXCEEDED
+arrayfold_partition: stopped promptly
+TIMEOUT_EXCEEDED
+sleep_partition: stopped promptly
+TIMEOUT_EXCEEDED
+base58_partition: stopped promptly
+TIMEOUT_EXCEEDED
+geohash_orderby: stopped promptly
+TIMEOUT_EXCEEDED
+arrayfold_orderby: stopped promptly
+TIMEOUT_EXCEEDED
+sleep_orderby: stopped promptly
+TIMEOUT_EXCEEDED
+base58_orderby: stopped promptly
+TIMEOUT_EXCEEDED
+geohash_skipindex: stopped promptly
+TIMEOUT_EXCEEDED
+TIMEOUT_EXCEEDED
+TIMEOUT_EXCEEDED
+h3cells_orderby: killed promptly
+h3containment_orderby: killed promptly
+kill_geohash: killed promptly
+stored expression leak: no query state retained
+['sx1q','sx1r','sx32','sx1w','sx1x','sx38']
+55
+hello
+0
+8
+8
+4	6

--- a/tests/queries/0_stateless/04752_persisted_expression_cancellation.sh
+++ b/tests/queries/0_stateless/04752_persisted_expression_cancellation.sh
@@ -46,7 +46,9 @@ ${CLICKHOUSE_CLIENT} -q "
     CREATE TABLE src_g (a Array(Tuple(Float64, Float64)), k UInt64) ENGINE = MergeTree ORDER BY tuple();
     INSERT INTO src_f SELECT number * 1e-9, number FROM numbers(60000);
     INSERT INTO src_i SELECT number, number FROM numbers(60000);
-    INSERT INTO src_s SELECT base58Encode(repeat('Q', 7000) || toString(number)), number FROM numbers(3000);
+    -- 'Q' is a base58 digit, so this needs no base58Encode to be decodable, and the length varies per
+    -- row so the argument stays column-dependent.
+    INSERT INTO src_s SELECT repeat('Q', 4000 + (number % 7)), number FROM numbers(3000);
     INSERT INTO src_g SELECT [(number * 1e-7, 0.), (number * 1e-7 + 2., 0.), (number * 1e-7 + 2., 2.), (number * 1e-7, 2.), (number * 1e-7, 0.)], number FROM numbers(2000);"
 
 # $1 = label, $2 = the table DDL carrying the persisted expression, $3 = the source table

--- a/tests/queries/0_stateless/04752_persisted_expression_cancellation.sh
+++ b/tests/queries/0_stateless/04752_persisted_expression_cancellation.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Tags: long, no-fasttest, no-parallel, no-flaky-check
+# no-parallel: the leak case samples the process-wide `CurrentMetrics::QueryNonInternal`.
+# no-flaky-check: every assertion is a cancellation latency, and the flaky check runs many copies of
+# one test on a single runner; that contention overlaps the unfixed distribution, so no bound both
+# passes fixed and fails unfixed.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# A function that resolves its `QueryStatusPtr` when the object is built captures the status of
+# whichever query analysed the expression. For an expression stored in table metadata that is a global
+# context (sorting key, skip index: empty status) or the `CREATE TABLE` query (`PARTITION BY`: an
+# already-finished deadline), so the in-loop cancellation check the function already contains reads a
+# query that is not the one running and never fires.
+#
+# Each case below therefore runs a persisted expression from a LATER query. Three fixture properties
+# are load-bearing, and getting any of them wrong makes the case pass unfixed:
+#   * no `%` in a `PARTITION BY` key. `MergeTreePartition::adjustPartitionKey` rebuilds the whole key
+#     description with the INSERT's own context when the key mentions `modulo`, which hands the
+#     expression a correct status and hides the defect.
+#   * the INSERT's SELECT side must be cheap. If it burns the deadline itself the timeout fires there,
+#     on a direct call with a correct status, and never reaches the persisted expression.
+#   * arguments must be column-dependent. A constant argument is folded once, so the function runs a
+#     single time whatever the row count.
+#
+# `max_insert_block_size`/`min_insert_block_size_rows`/`max_threads` are pinned statement-level because
+# the runner randomizes them and the effect size is a function of rows-per-block: split into enough
+# blocks, the pipeline's own between-blocks check bounds the query however the function behaves.
+# `max_execution_time` and `timeout_overflow_mode` are the oracle and are not randomized.
+BLOCK="max_insert_block_size = 100000, min_insert_block_size_rows = 100000, max_threads = 1"
+
+# 4x the 1s limit absorbs clock granularity, a busy runner and the work in flight when the check fires;
+# a sanitizer or coverage build stretches both sides, so the bound scales. The unfixed path lands far
+# above either.
+SCALE=1
+[ -n "$(${CLICKHOUSE_CLIENT} -q "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS' AND value LIKE '%sanitize=%'")" ] && SCALE=2
+case "$(${CLICKHOUSE_CLIENT} -q "SELECT value FROM system.build_options WHERE name = 'WITH_COVERAGE'")" in ON|1) SCALE=2 ;; esac
+BOUND=$((SCALE * 4000))
+
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE src_f (a Float64, k UInt64) ENGINE = MergeTree ORDER BY tuple();
+    CREATE TABLE src_i (a UInt64, k UInt64) ENGINE = MergeTree ORDER BY tuple();
+    CREATE TABLE src_s (a String, k UInt64) ENGINE = MergeTree ORDER BY tuple();
+    CREATE TABLE src_g (a Array(Tuple(Float64, Float64)), k UInt64) ENGINE = MergeTree ORDER BY tuple();
+    INSERT INTO src_f SELECT number * 1e-9, number FROM numbers(60000);
+    INSERT INTO src_i SELECT number, number FROM numbers(60000);
+    INSERT INTO src_s SELECT base58Encode(repeat('Q', 7000) || toString(number)), number FROM numbers(3000);
+    INSERT INTO src_g SELECT [(number * 1e-7, 0.), (number * 1e-7 + 2., 0.), (number * 1e-7 + 2., 2.), (number * 1e-7, 2.), (number * 1e-7, 0.)], number FROM numbers(2000);"
+
+# $1 = label, $2 = the table DDL carrying the persisted expression, $3 = the source table
+deadline_case() {
+    local label="$1" ddl="$2" src="$3"
+    local query_id="04752_${label}_${CLICKHOUSE_DATABASE}"
+
+    ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_$label SYNC"
+    ${CLICKHOUSE_CLIENT} -q "$ddl"
+    ${CLICKHOUSE_CLIENT} --query_id "$query_id" --max_execution_time 1 --timeout_overflow_mode throw \
+        -q "INSERT INTO t_$label SELECT * FROM $src SETTINGS $BLOCK" 2>&1 \
+        | grep -o -m1 "TIMEOUT_EXCEEDED" || echo "$label: no timeout"
+    ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS query_log"
+    ${CLICKHOUSE_CLIENT} -q "
+        SELECT if(max(query_duration_ms) < $BOUND, '$label: stopped promptly',
+                  '$label: OVERSHOT ' || toString(max(query_duration_ms)) || 'ms past a 1000ms limit')
+        FROM system.query_log
+        WHERE query_id = '$query_id' AND current_database = currentDatabase() AND type != 'QueryStart'"
+    ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_$label SYNC"
+}
+
+# CONTROL. `replaceRegexpAll` already resolves its status per call, so it is bounded with and without
+# this change. It is what makes the carrier cases an attribution rather than "these functions are
+# slow": execution-time resolution demonstrably works on a persisted expression.
+deadline_case "control_partition" \
+    "CREATE TABLE t_control_partition (a String, k UInt64) ENGINE = MergeTree
+     PARTITION BY intDiv(length(replaceRegexpAll(a, '(a)', 'xyxyxyxyxy')), 1000000) ORDER BY tuple()" \
+    "(SELECT repeat('ab', 2000) || toString(number) AS a, number AS k FROM numbers(60000))"
+
+# The `PARTITION BY` route: `KeyDescription::getKeyFromAST` builds the expression once at DDL time and
+# the metadata keeps it, so every later write re-executes that instance with the `CREATE`'s status.
+deadline_case "geohash_partition" \
+    "CREATE TABLE t_geohash_partition (a Float64, k UInt64) ENGINE = MergeTree
+     PARTITION BY intDiv(length(geohashesInBox(a, a, a + toFloat64(1), a + toFloat64(1), 7)), 1000000) ORDER BY tuple()" \
+    "src_f"
+deadline_case "arrayfold_partition" \
+    "CREATE TABLE t_arrayfold_partition (a UInt64, k UInt64) ENGINE = MergeTree
+     PARTITION BY intDiv(arrayFold((acc, x) -> acc + x + a, range(3000), toUInt64(0)), 100000000000) ORDER BY tuple()" \
+    "src_i"
+# Three `sleep` calls, not one: a single call cannot overshoot by more than
+# `function_sleep_max_microseconds_per_block` (3s by default) whatever the deadline, which is under the
+# bound on its own, so a one-call case passes unfixed. The arguments must differ - identical calls are
+# one common subexpression and run once (measured: `sleep(3) + sleep(3)` takes 3s, `sleep(3) +
+# sleep(2.9)` takes 6s).
+deadline_case "sleep_partition" \
+    "CREATE TABLE t_sleep_partition (a UInt64, k UInt64) ENGINE = MergeTree
+     PARTITION BY intDiv(a, 1000000) + sleep(3) + sleep(2.9) + sleep(2.8) ORDER BY tuple()" \
+    "src_i"
+deadline_case "base58_partition" \
+    "CREATE TABLE t_base58_partition (a String, k UInt64) ENGINE = MergeTree
+     PARTITION BY intDiv(length(base58Decode(a)), 1000000) ORDER BY tuple()" \
+    "src_s"
+
+# The sorting-key route fails differently and so needs its own case per carrier: `MergeTreeData`'s
+# context is its global one, so the captured status is empty rather than merely wrong.
+deadline_case "geohash_orderby" \
+    "CREATE TABLE t_geohash_orderby (a Float64, k UInt64) ENGINE = MergeTree
+     ORDER BY (k, length(geohashesInBox(a, a, a + toFloat64(1), a + toFloat64(1), 7)))" \
+    "src_f"
+deadline_case "arrayfold_orderby" \
+    "CREATE TABLE t_arrayfold_orderby (a UInt64, k UInt64) ENGINE = MergeTree
+     ORDER BY (k, arrayFold((acc, x) -> acc + x + a, range(3000), toUInt64(0)))" \
+    "src_i"
+deadline_case "sleep_orderby" \
+    "CREATE TABLE t_sleep_orderby (a UInt64, k UInt64) ENGINE = MergeTree
+     ORDER BY (k, sleep(3) + sleep(2.9) + sleep(2.8))" \
+    "src_i"
+deadline_case "base58_orderby" \
+    "CREATE TABLE t_base58_orderby (a String, k UInt64) ENGINE = MergeTree
+     ORDER BY (k, length(base58Decode(a)))" \
+    "src_s"
+
+# A skip index is built through the same global-context call as the sorting key but by a separate
+# function, so it is asserted rather than assumed to follow.
+deadline_case "geohash_skipindex" \
+    "CREATE TABLE t_geohash_skipindex (a Float64, k UInt64,
+        INDEX ix length(geohashesInBox(a, a, a + toFloat64(1), a + toFloat64(1), 7)) TYPE minmax GRANULARITY 1)
+     ENGINE = MergeTree ORDER BY tuple()" \
+    "src_f"
+
+# BASELINE. The same functions on a non-persisted path are bounded with and without this change, which
+# is what confines the defect to the persisted routes rather than to the functions themselves.
+for fn in "sum(length(geohashesInBox(a, a, a + toFloat64(1), a + toFloat64(1), 7))) FROM src_f" \
+          "sum(arrayFold((acc, x) -> acc + x + a, range(3000), toUInt64(0))) FROM src_i" \
+          "sum(length(base58Decode(a))) FROM src_s"; do
+    ${CLICKHOUSE_CLIENT} --max_execution_time 1 --timeout_overflow_mode throw \
+        -q "SELECT $fn SETTINGS max_block_size = 100000, max_threads = 1" 2>&1 \
+        | grep -o -m1 "TIMEOUT_EXCEEDED" || echo "direct baseline: no timeout"
+done
+
+# `h3PolygonToCells` and `h3PolygonToCellsWithContainment` check `isKilled()` rather than
+# `checkTimeLimit()`, so their loop consults no deadline at all and only `KILL QUERY` can stop them.
+# A `max_execution_time` case on these two would stay red after a fully correct fix; that missing
+# deadline check is a separate defect and is out of scope here.
+kill_case() {
+    local label="$1" ddl="$2"
+    local query_id="04752_kill_${label}_${CLICKHOUSE_DATABASE}"
+
+    ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_$label SYNC"
+    ${CLICKHOUSE_CLIENT} -q "$ddl"
+    ${CLICKHOUSE_CLIENT} --query_id "$query_id" \
+        -q "INSERT INTO t_$label SELECT * FROM src_g SETTINGS $BLOCK" > /dev/null 2>&1 &
+    local query_pid=$!
+
+    # Readiness waits for the query to have been RUNNING, not merely visible: `ProcessList` makes it
+    # visible before the executor is attached, and `addPipelineExecutor` raises a pending cancellation
+    # itself, so a kill winning that race would pass even unfixed. Killing an id that never started
+    # also returns promptly, so the poll reports its own failure rather than looking like a pass.
+    # The poll runs over HTTP: a fresh client process costs ~70ms per iteration against ~10ms for a
+    # request, and that overhead would land inside the measured kill latency.
+    local waited=0 ready_ok=0
+    while [ "$waited" -lt 500 ]; do
+        if [ "$(${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "SELECT max(elapsed) > 1 FROM system.processes WHERE query_id = '$query_id'")" = "1" ]; then
+            ready_ok=1
+            break
+        fi
+        waited=$((waited + 1))
+        sleep 0.02
+    done
+    [ "$ready_ok" = "0" ] && echo "$label: query never reached the row loop"
+
+    ${CLICKHOUSE_CLIENT} --query_id "${query_id}_sync" -q "KILL QUERY WHERE query_id = '$query_id' SYNC" > /dev/null
+    wait $query_pid 2>/dev/null
+
+    ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS query_log"
+    ${CLICKHOUSE_CLIENT} -q "
+        SELECT if(max(query_duration_ms) < $BOUND, '$label: killed promptly',
+                  '$label: KILL BLOCKED ' || toString(max(query_duration_ms)) || 'ms')
+        FROM system.query_log
+        WHERE query_id = '${query_id}_sync' AND current_database = currentDatabase() AND type != 'QueryStart'"
+    ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_$label SYNC"
+}
+
+kill_case "h3cells_orderby" \
+    "CREATE TABLE t_h3cells_orderby (a Array(Tuple(Float64, Float64)), k UInt64) ENGINE = MergeTree
+     ORDER BY (k, length(h3PolygonToCells(a, 7)))"
+# Resolution 8 rather than 7: at 7 this fixture runs for about three seconds, so a kill landing after
+# one second finishes inside the bound however the function behaves. Every kill case needs the target to
+# outlast the bound by enough that only a prompt cancellation can satisfy it.
+kill_case "h3containment_orderby" \
+    "CREATE TABLE t_h3containment_orderby (a Array(Tuple(Float64, Float64)), k UInt64) ENGINE = MergeTree
+     ORDER BY (k, length(h3PolygonToCellsWithContainment(a, 8, 0)))"
+
+# A `geohashesInBox` case on the same channel, so the `KILL` half is not asserted for the h3 pair only.
+kill_geohash_id="04752_kill_geohash_${CLICKHOUSE_DATABASE}"
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE t_kill_geohash (a Float64, k UInt64) ENGINE = MergeTree
+    ORDER BY (k, length(geohashesInBox(a, a, a + toFloat64(1), a + toFloat64(1), 7)))"
+${CLICKHOUSE_CLIENT} --query_id "$kill_geohash_id" \
+    -q "INSERT INTO t_kill_geohash SELECT * FROM src_f SETTINGS $BLOCK" > /dev/null 2>&1 &
+kill_geohash_pid=$!
+waited=0 ready_ok=0
+while [ "$waited" -lt 500 ]; do
+    if [ "$(${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "SELECT max(elapsed) > 1 FROM system.processes WHERE query_id = '$kill_geohash_id'")" = "1" ]; then
+        ready_ok=1
+        break
+    fi
+    waited=$((waited + 1))
+    sleep 0.02
+done
+[ "$ready_ok" = "0" ] && echo "kill_geohash: query never reached the row loop"
+${CLICKHOUSE_CLIENT} --query_id "${kill_geohash_id}_sync" -q "KILL QUERY WHERE query_id = '$kill_geohash_id' SYNC" > /dev/null
+wait $kill_geohash_pid 2>/dev/null
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS query_log"
+${CLICKHOUSE_CLIENT} -q "
+    SELECT if(max(query_duration_ms) < $BOUND, 'kill_geohash: killed promptly',
+              'kill_geohash: KILL BLOCKED ' || toString(max(query_duration_ms)) || 'ms')
+    FROM system.query_log
+    WHERE query_id = '${kill_geohash_id}_sync' AND current_database = currentDatabase() AND type != 'QueryStart'"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_kill_geohash SYNC"
+
+# The leak side of the same line. A `QueryStatusPtr` member kept the `CurrentMetrics::QueryNonInternal`
+# increment its `QueryStatus` owns, so on a `PARTITION BY` instance retained for the table's lifetime
+# the count never returned to where it started. The assertion is a zero delta rather than a tolerance,
+# which a drop in either direction would mask: the metric excludes internal queries, so background work
+# cannot move it, and this test is no-parallel, so every non-internal query in the window is one of its
+# own and cancels in the difference.
+sample_queries() {
+    local m=999999 v
+    for _ in 1 2 3 4 5; do
+        v=$(${CLICKHOUSE_CLIENT} -q "SELECT value FROM system.metrics WHERE metric = 'QueryNonInternal'")
+        [ "$v" -lt "$m" ] && m=$v
+    done
+    echo "$m"
+}
+
+for i in 1 2 3 4 5 6; do
+    ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_leak_$i SYNC"
+done
+queries_before=$(sample_queries)
+for i in 1 2 3 4 5 6; do
+    ${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_leak_$i (a Float64, k UInt64) ENGINE = MergeTree ORDER BY k"
+    # ALTER, not CREATE: a CREATE analyses the expression on a context carrying no query state, so
+    # nothing could be captured there and the case would be vacuous.
+    ${CLICKHOUSE_CLIENT} -q "
+        ALTER TABLE t_leak_$i ADD INDEX ix length(geohashesInBox(a, a, a + toFloat64(1), a + toFloat64(1), 7))
+        TYPE minmax GRANULARITY 1"
+done
+queries_after=$(sample_queries)
+if [ "$((queries_after - queries_before))" = 0 ]; then
+    echo "stored expression leak: no query state retained"
+else
+    echo "stored expression leak: RETAINED $((queries_after - queries_before)) query states"
+fi
+for i in 1 2 3 4 5 6; do
+    ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_leak_$i SYNC"
+done
+
+# Liveness. With no time limit each function must still return its documented result, so a "fix" that
+# simply always threw, or that lost the checkpoint entirely, fails here instead of passing.
+${CLICKHOUSE_CLIENT} -q "
+    SELECT geohashesInBox(24.48, 40.56, 24.785, 40.81, 4);
+    SELECT arrayFold((acc, x) -> acc + x, range(11), toUInt64(0));
+    SELECT base58Decode(base58Encode('hello'));
+    SELECT sleep(0.01);
+    SELECT length(h3PolygonToCells([(0., 0.), (0., 1.), (1., 1.), (1., 0.), (0., 0.)], 4));
+    SELECT length(h3PolygonToCellsWithContainment([(0., 0.), (0., 1.), (1., 1.), (1., 0.), (0., 0.)], 4, 0));"
+
+# The persisted expressions must also still produce the documented values when nothing is cancelled,
+# which the timing cases above cannot show because every one of them ends in a timeout.
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE t_live (a Float64, k UInt64) ENGINE = MergeTree
+    PARTITION BY intDiv(length(geohashesInBox(a, a, a + toFloat64(1), a + toFloat64(1), 3)), 100)
+    ORDER BY (k, arrayFold((acc, x) -> acc + x, range(3), toUInt64(0)));
+    INSERT INTO t_live SELECT number, number FROM numbers(4);
+    SELECT count(), sum(k) FROM t_live;
+    DROP TABLE t_live SYNC;"

--- a/tests/queries/0_stateless/04752_persisted_expression_cancellation.sh
+++ b/tests/queries/0_stateless/04752_persisted_expression_cancellation.sh
@@ -129,6 +129,21 @@ deadline_case "geohash_skipindex" \
      ENGINE = MergeTree ORDER BY tuple()" \
     "src_f"
 
+# The h3 pair checks `isKilled()` rather than `checkTimeLimit()`, which still observes a deadline in
+# the default `throw` mode: `CancellationChecker` calls `cancelQuery(TIMEOUT)` there, which sets
+# `is_killed`. Under `timeout_overflow_mode = 'break'` nothing sets it and these two run to completion,
+# so only the default mode is asserted here.
+deadline_case "h3cells_orderby_deadline" \
+    "CREATE TABLE t_h3cells_orderby_deadline (a Array(Tuple(Float64, Float64)), k UInt64)
+     ENGINE = MergeTree ORDER BY (k, length(h3PolygonToCells(a, 7)))" \
+    "src_g"
+# Resolution 8 rather than 7 for the same reason as the kill case below: at 7 this fixture finishes
+# inside the bound unfixed, so the case would pass either way.
+deadline_case "h3containment_orderby_deadline" \
+    "CREATE TABLE t_h3containment_orderby_deadline (a Array(Tuple(Float64, Float64)), k UInt64)
+     ENGINE = MergeTree ORDER BY (k, length(h3PolygonToCellsWithContainment(a, 8, 0)))" \
+    "src_g"
+
 # BASELINE. The same functions on a non-persisted path are bounded with and without this change, which
 # is what confines the defect to the persisted routes rather than to the functions themselves.
 for fn in "sum(length(geohashesInBox(a, a, a + toFloat64(1), a + toFloat64(1), 7))) FROM src_f" \
@@ -139,10 +154,8 @@ for fn in "sum(length(geohashesInBox(a, a, a + toFloat64(1), a + toFloat64(1), 7
         | grep -o -m1 "TIMEOUT_EXCEEDED" || echo "direct baseline: no timeout"
 done
 
-# `h3PolygonToCells` and `h3PolygonToCellsWithContainment` check `isKilled()` rather than
-# `checkTimeLimit()`, so their loop consults no deadline at all and only `KILL QUERY` can stop them.
-# A `max_execution_time` case on these two would stay red after a fully correct fix; that missing
-# deadline check is a separate defect and is out of scope here.
+# `KILL QUERY` needs its own channel for the h3 pair: it is the one cancellation their loop observes in
+# every overflow mode.
 kill_case() {
     local label="$1" ddl="$2"
     local query_id="04752_kill_${label}_${CLICKHOUSE_DATABASE}"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112273
Related: https://github.com/ClickHouse/ClickHouse/issues/107941
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `max_execution_time` and `KILL QUERY` being ignored while a query evaluates `geohashesInBox`, `arrayFold`, `sleep`, `base58Decode`, `h3PolygonToCells` or `h3PolygonToCellsWithContainment` inside an expression stored in table metadata, such as a sorting key, a skip index or a `PARTITION BY` key.


### Description

Six functions in `src/Functions/` read `getProcessListElement()` in their constructor and keep the result in a member. Built for an expression stored in table metadata, the captured pointer is not the query that later executes the call, so the in-loop cancellation checkpoint each already contains never fires. An `INSERT` then ignores its own `max_execution_time` and `KILL QUERY`.

Two routes reach it and fail differently. `MergeTreeData::getSortingKeyAndSkipIndicesExpression` builds the sorting-key and skip-index expressions from `MergeTreeData`'s own context, the global one, so the member is empty and the check is dead. `KeyDescription::getKeyFromAST` builds the `PARTITION BY` expression once at DDL time and the metadata keeps it, so every later write re-executes that instance holding the `CREATE TABLE` query's already finished status, which that strong reference also leaks.

The status is now resolved from the executing thread inside the execute path, matching `FunctionStringReplace.h`; one line caused both problems, so the retained reference is fixed too. What is checked is unchanged: the two h3 functions still consult `isKilled()` only, the other four `checkTimeLimit()`. Both observe a deadline, because in the default `throw` mode `CancellationChecker` cancels with `CancelReason::TIMEOUT`, which sets `is_killed`. Under `timeout_overflow_mode = 'break'` nothing sets it, so the h3 pair still runs to completion there, as it does today.

Measured on one debug binary, `INSERT` with `max_execution_time = 1`, one block, `max_threads = 1`:

<details><summary>Elapsed against the 1000 ms limit, before and after</summary>

| expression | before | after |
|---|---|---|
| `geohashesInBox` in `PARTITION BY` | 26057 ms | 1101 ms |
| `geohashesInBox` in a sorting key | 26117 ms | 1109 ms |
| `geohashesInBox` in a skip index | 26588 ms | 1105 ms |
| `base58Decode` in `PARTITION BY` / sorting key | 57087 / 57112 ms | 1081 / 1081 ms |
| `arrayFold` in `PARTITION BY` / sorting key | 5262 / 5124 ms | 2879 / 2841 ms |
| one `sleep(3)` call in `PARTITION BY` / sorting key | 3093 / 3095 ms | 1083 / 1083 ms |
| `h3PolygonToCells` in a sorting key | 13768 ms | 1115 ms |
| `h3PolygonToCellsWithContainment` in a sorting key | 11225 ms | 1123 ms |
| **control** `replaceRegexpAll` in `PARTITION BY`, already resolved per call | 1076 ms | 1112 ms |
| **baseline** the same functions on a non-persisted path | bounded | bounded |

`arrayFold` lands at 2879 ms because that is what one of its slices costs; its own direct call measures
2801 ms. A single `sleep` cannot overshoot past `function_sleep_max_microseconds_per_block` (3 s by
default) however long the deadline is exceeded, which is why the regression test uses three calls with
distinct arguments instead. The two h3 rows are `throw` mode, where `is_killed` carries the deadline; in `break` mode both stay at
their unbounded cost before and after. The control and the baseline are what make these numbers an
attribution rather than "these functions are slow": execution-time resolution demonstrably works on a
persisted expression, and the same functions off that path honour the same deadline either way.

</details>

Two constructors also read a setting off that global context (`function_base58_max_input_size`, `function_sleep_max_microseconds_per_block`), so those take the server default on a persisted expression. Left alone here.

`base58Encode` and `tryBase58Decode` share the changed `FunctionBaseXXConversion` template, so one site serves all three. The linear `base32`/`base64` aliases are unaffected: their `perform` ignores the callback.

New test `04752_persisted_expression_cancellation`: every arm fails without this change, and one mutant per function reddens exactly that function's arms.

Related: https://github.com/ClickHouse/ClickHouse/pull/112273
Related: https://github.com/ClickHouse/ClickHouse/issues/107941
