### PR TITLE
Deduplicate the LowCardinality/Nullable unwrap in monotonicity analysis

### DIFF
--- a/src/DataTypes/DataTypeLowCardinality.cpp
+++ b/src/DataTypes/DataTypeLowCardinality.cpp
@@ -252,4 +252,13 @@ DataTypePtr removeLowCardinalityAndNullable(const DataTypePtr & type)
 {
     return removeNullable(removeLowCardinality(type));
 };
+
+const IDataType * removeLowCardinalityAndNullable(const IDataType * type)
+{
+    if (const auto * low_cardinality_type = typeid_cast<const DataTypeLowCardinality *>(type))
+        type = low_cardinality_type->getDictionaryType().get();
+    if (const auto * nullable_type = typeid_cast<const DataTypeNullable *>(type))
+        type = nullable_type->getNestedType().get();
+    return type;
+}
 }

--- a/src/DataTypes/DataTypeLowCardinality.h
+++ b/src/DataTypes/DataTypeLowCardinality.h
@@ -98,4 +98,9 @@ ColumnPtr recursiveLowCardinalityTypeConversion(const ColumnPtr & column, const 
 /// Removes LowCardinality and Nullable in a correct order and returns T
 /// if the type is LowCardinality(T) or LowCardinality(Nullable(T)); type otherwise
 DataTypePtr removeLowCardinalityAndNullable(const DataTypePtr & type);
+
+/// Same, for a caller that holds a raw `IDataType` and cannot call `getPtr()`
+/// (it throws for a type not owned by a `shared_ptr`). The result points into
+/// `type`'s wrapper chain, so it is valid as long as `type` is.
+const IDataType * removeLowCardinalityAndNullable(const IDataType * type);
 }

--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -3838,11 +3838,7 @@ public:
     /// that is not owned by a `shared_ptr`.
     static bool isCompoundForMonotonicity(const IDataType & type)
     {
-        const IDataType * unwrapped = &type;
-        if (const auto * low_cardinality = typeid_cast<const DataTypeLowCardinality *>(unwrapped))
-            unwrapped = low_cardinality->getDictionaryType().get();
-        if (const auto * nullable = typeid_cast<const DataTypeNullable *>(unwrapped))
-            unwrapped = nullable->getNestedType().get();
+        const IDataType * unwrapped = removeLowCardinalityAndNullable(&type);
         return isArray(*unwrapped) || isTuple(*unwrapped) || isMap(*unwrapped);
     }
 

--- a/src/Functions/IFunctionCustomWeek.h
+++ b/src/Functions/IFunctionCustomWeek.h
@@ -44,13 +44,7 @@ public:
 
     Monotonicity getMonotonicityForRange(const IDataType & type, const Field & left, const Field & right) const override
     {
-        const IDataType * type_ptr = &type;
-
-        if (const auto * lc_type = checkAndGetDataType<DataTypeLowCardinality>(type_ptr))
-            type_ptr = lc_type->getDictionaryType().get();
-
-        if (const auto * nullable_type = checkAndGetDataType<DataTypeNullable>(type_ptr))
-            type_ptr = nullable_type->getNestedType().get();
+        const IDataType * type_ptr = removeLowCardinalityAndNullable(&type);
 
         const IFunction::Monotonicity is_not_monotonic;
 

--- a/src/Functions/IFunctionDateOrDateTime.h
+++ b/src/Functions/IFunctionDateOrDateTime.h
@@ -126,13 +126,7 @@ public:
             if (left.isNull() || right.isNull())
                 return is_not_monotonic;
 
-            const auto * type_ptr = &type;
-
-            if (const auto * lc_type = checkAndGetDataType<DataTypeLowCardinality>(type_ptr))
-                type_ptr = lc_type->getDictionaryType().get();
-
-            if (const auto * nullable_type = checkAndGetDataType<DataTypeNullable>(type_ptr))
-                type_ptr = nullable_type->getNestedType().get();
+            const auto * type_ptr = removeLowCardinalityAndNullable(&type);
 
             /// The function is monotonous on the [left, right] segment, if the factor transformation returns the same values for them.
 

--- a/src/Functions/negate.cpp
+++ b/src/Functions/negate.cpp
@@ -40,15 +40,8 @@ template <> struct FunctionUnaryArithmeticMonotonicity<NameNegate>
     static bool has() { return true; }
     static IFunction::Monotonicity get(const IDataType & original_type, const Field & left, const Field & right)
     {
-        const IDataType * type = &original_type;
-        if (const DataTypeLowCardinality * t = typeid_cast<const DataTypeLowCardinality *>(type))
-            type = t->getDictionaryType().get();
-        bool is_nullable = false;
-        if (const DataTypeNullable * t = typeid_cast<const DataTypeNullable *>(type))
-        {
-            is_nullable = true;
-            type = t->getNestedType().get();
-        }
+        const IDataType * type = removeLowCardinalityAndNullable(&original_type);
+        const bool is_nullable = original_type.isNullable() || original_type.isLowCardinalityNullable();
 
         /// For compound types (Tuple, Array, etc.) monotonicity analysis is not applicable.
         if (!type->isValueRepresentedByNumber())

--- a/tests/queries/0_stateless/04747_unwrap_monotonicity_dedup.reference
+++ b/tests/queries/0_stateless/04747_unwrap_monotonicity_dedup.reference
@@ -1,0 +1,14 @@
+negate Nullable ORDER BY	-9900,-9800,-9700,-9600,-9500	-9900,-9800,-9700,-9600,-9500
+negate LC(Nullable) ORDER BY	-9900,-9800,-9700,-9600,-9500	-9900,-9800,-9700,-9600,-9500
+negate LC still prunes	1
+negate LC answers	1	1
+toDayOfWeek LC(Date) prunes	1
+toDayOfWeek LC(Date) answers	72	72
+toDayOfWeek LC(Nullable(Date)) prunes	1
+toDayOfWeek LC(Nullable(Date)) answers	72	72
+toMonth LC(Date) prunes	1
+toMonth LC(Date) answers	29	29
+toMonth LC(Nullable(Date)) prunes	1
+toMonth LC(Nullable(Date)) answers	29	29
+toStartOfMonth LC(Date) prunes	1
+toStartOfMonth LC(Date) answers	29	29

--- a/tests/queries/0_stateless/04747_unwrap_monotonicity_dedup.sql
+++ b/tests/queries/0_stateless/04747_unwrap_monotonicity_dedup.sql
@@ -18,8 +18,8 @@ SET allow_suspicious_low_cardinality_types = 1;
 -- type that `recursiveRemoveLowCardinality` has already stripped, so a wrong unwrap of the
 -- `LowCardinality` half is unobservable there. Both pins read the same values on
 -- unmodified code, so they remove an escape hatch rather than weakening an assertion.
-DROP TABLE IF EXISTS t_neg_null_04747 SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_mem_null_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_neg_null_04747;
+DROP TABLE IF EXISTS t_mem_null_04747;
 CREATE TABLE t_neg_null_04747 (a Nullable(Int64)) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1, allow_nullable_key = 1;
 CREATE TABLE t_mem_null_04747 (a Nullable(Int64)) ENGINE = Log;
 INSERT INTO t_neg_null_04747 SELECT if(number % 10 = 0, NULL, number * 100) FROM numbers(100);
@@ -28,8 +28,8 @@ SELECT 'negate Nullable ORDER BY', (SELECT arrayStringConcat(groupArray(toString
 
 -- The same shape under `LowCardinality(Nullable(...))`: the nullability sits inside the dictionary,
 -- so recovering it requires looking through the LowCardinality wrapper too.
-DROP TABLE IF EXISTS t_neg_lcn_04747 SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_mem_lcn_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_neg_lcn_04747;
+DROP TABLE IF EXISTS t_mem_lcn_04747;
 CREATE TABLE t_neg_lcn_04747 (a LowCardinality(Nullable(Int64))) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1, allow_nullable_key = 1;
 CREATE TABLE t_mem_lcn_04747 (a LowCardinality(Nullable(Int64))) ENGINE = Log;
 INSERT INTO t_neg_lcn_04747 SELECT if(number % 10 = 0, NULL, number * 100) FROM numbers(100);
@@ -38,8 +38,8 @@ SELECT 'negate LC(Nullable) ORDER BY', (SELECT arrayStringConcat(groupArray(toSt
 
 -- Control: `LowCardinality` delegates `isValueRepresentedByNumber` to its dictionary, so this row
 -- holds whether or not the unwrap happens. It guards against over-declining, not against a wrong unwrap.
-DROP TABLE IF EXISTS t_neg_lc_04747 SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_mem_lc_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_neg_lc_04747;
+DROP TABLE IF EXISTS t_mem_lc_04747;
 CREATE TABLE t_neg_lc_04747 (a LowCardinality(Int64)) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
 CREATE TABLE t_mem_lc_04747 (a LowCardinality(Int64)) ENGINE = Log;
 INSERT INTO t_neg_lc_04747 SELECT number * 100 FROM numbers(100);
@@ -49,8 +49,8 @@ SELECT 'negate LC answers', (SELECT count() FROM t_neg_lc_04747 WHERE negate(a) 
 
 -- Week transforms. `toDayOfWeek` has a non-trivial factor transform, so its verdict depends on the
 -- unwrapped key type being recognised as `Date`; a wrong unwrap loses the pruning below.
-DROP TABLE IF EXISTS t_week_lc_04747 SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_week_mem_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_week_lc_04747;
+DROP TABLE IF EXISTS t_week_mem_04747;
 CREATE TABLE t_week_lc_04747 (a LowCardinality(Date)) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
 CREATE TABLE t_week_mem_04747 (a LowCardinality(Date)) ENGINE = Log;
 INSERT INTO t_week_lc_04747 SELECT toDate('2020-01-01') + number FROM numbers(100);
@@ -58,8 +58,8 @@ INSERT INTO t_week_mem_04747 SELECT toDate('2020-01-01') + number FROM numbers(1
 SELECT 'toDayOfWeek LC(Date) prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_week_lc_04747 WHERE toDayOfWeek(a) >= 3) WHERE explain ILIKE '%Granules: 86/100%' SETTINGS use_lightweight_primary_key_index_analysis = 1;
 SELECT 'toDayOfWeek LC(Date) answers', (SELECT count() FROM t_week_lc_04747 WHERE toDayOfWeek(a) >= 3) AS keyed, (SELECT count() FROM t_week_mem_04747 WHERE toDayOfWeek(a) >= 3) AS oracle;
 
-DROP TABLE IF EXISTS t_week_lcn_04747 SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_week_memn_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_week_lcn_04747;
+DROP TABLE IF EXISTS t_week_memn_04747;
 CREATE TABLE t_week_lcn_04747 (a LowCardinality(Nullable(Date))) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1, allow_nullable_key = 1;
 CREATE TABLE t_week_memn_04747 (a LowCardinality(Nullable(Date))) ENGINE = Log;
 INSERT INTO t_week_lcn_04747 SELECT toDate('2020-01-01') + number FROM numbers(100);
@@ -80,13 +80,13 @@ SELECT 'toStartOfMonth LC(Date) answers', (SELECT count() FROM t_week_lc_04747 W
 -- The compound site the helper was extracted from keeps its own coverage in
 -- `04652_compound_key_monotonicity.sql`, which already pins `Nullable(Tuple(Int64, Int64))`.
 
-DROP TABLE IF EXISTS t_neg_null_04747 SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_mem_null_04747 SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_neg_lcn_04747 SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_mem_lcn_04747 SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_neg_lc_04747 SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_mem_lc_04747 SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_week_lc_04747 SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_week_mem_04747 SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_week_lcn_04747 SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS t_week_memn_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_neg_null_04747;
+DROP TABLE IF EXISTS t_mem_null_04747;
+DROP TABLE IF EXISTS t_neg_lcn_04747;
+DROP TABLE IF EXISTS t_mem_lcn_04747;
+DROP TABLE IF EXISTS t_neg_lc_04747;
+DROP TABLE IF EXISTS t_mem_lc_04747;
+DROP TABLE IF EXISTS t_week_lc_04747;
+DROP TABLE IF EXISTS t_week_mem_04747;
+DROP TABLE IF EXISTS t_week_lcn_04747;
+DROP TABLE IF EXISTS t_week_memn_04747;

--- a/tests/queries/0_stateless/04747_unwrap_monotonicity_dedup.sql
+++ b/tests/queries/0_stateless/04747_unwrap_monotonicity_dedup.sql
@@ -1,0 +1,92 @@
+-- Tags: no-random-merge-tree-settings
+-- no-random-merge-tree-settings: the pruning assertions read exact granule counts, which
+-- `index_granularity` randomization moves.
+
+-- Key analysis strips `LowCardinality` and then `Nullable` before it inspects a key type, in
+-- `negate`, in the week transforms and in the date transforms. A wrong unwrap silently disables
+-- pruning, or, for `negate` over a nullable key, returns the wrong rows. The `prunes` rows below
+-- read exact granule counts because that is the only observable a lost monotonicity verdict moves;
+-- the `answers` rows beside them are oracle comparisons that stay correct either way.
+SET allow_suspicious_low_cardinality_types = 1;
+
+-- `negate` over a `Nullable` key. `negate(NULL) = NULL` stays at the bottom of the sort order
+-- instead of flipping to the top, so `negate` must not be reported monotonic when the range can
+-- start at NULL. The unwrap must still recover that the ORIGINAL type was nullable.
+-- `optimize_read_in_order` is pinned because the sort optimization it gates is the only observable
+-- of that verdict, and the runner randomizes it. The pruning rows below likewise pin
+-- `use_lightweight_primary_key_index_analysis`: at 0 the index analysis hands the transform a key
+-- type that `recursiveRemoveLowCardinality` has already stripped, so a wrong unwrap of the
+-- `LowCardinality` half is unobservable there. Both pins read the same values on
+-- unmodified code, so they remove an escape hatch rather than weakening an assertion.
+DROP TABLE IF EXISTS t_neg_null_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_null_04747 SETTINGS ignore_drop_queries_probability = 0;
+CREATE TABLE t_neg_null_04747 (a Nullable(Int64)) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1, allow_nullable_key = 1;
+CREATE TABLE t_mem_null_04747 (a Nullable(Int64)) ENGINE = Log;
+INSERT INTO t_neg_null_04747 SELECT if(number % 10 = 0, NULL, number * 100) FROM numbers(100);
+INSERT INTO t_mem_null_04747 SELECT if(number % 10 = 0, NULL, number * 100) FROM numbers(100);
+SELECT 'negate Nullable ORDER BY', (SELECT arrayStringConcat(groupArray(toString(x)), ',') FROM (SELECT negate(a) AS x FROM t_neg_null_04747 ORDER BY negate(a) ASC LIMIT 5)) AS keyed, (SELECT arrayStringConcat(groupArray(toString(x)), ',') FROM (SELECT negate(a) AS x FROM t_mem_null_04747 ORDER BY negate(a) ASC LIMIT 5)) AS oracle SETTINGS optimize_read_in_order = 1;
+
+-- The same shape under `LowCardinality(Nullable(...))`: the nullability sits inside the dictionary,
+-- so recovering it requires looking through the LowCardinality wrapper too.
+DROP TABLE IF EXISTS t_neg_lcn_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_lcn_04747 SETTINGS ignore_drop_queries_probability = 0;
+CREATE TABLE t_neg_lcn_04747 (a LowCardinality(Nullable(Int64))) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1, allow_nullable_key = 1;
+CREATE TABLE t_mem_lcn_04747 (a LowCardinality(Nullable(Int64))) ENGINE = Log;
+INSERT INTO t_neg_lcn_04747 SELECT if(number % 10 = 0, NULL, number * 100) FROM numbers(100);
+INSERT INTO t_mem_lcn_04747 SELECT if(number % 10 = 0, NULL, number * 100) FROM numbers(100);
+SELECT 'negate LC(Nullable) ORDER BY', (SELECT arrayStringConcat(groupArray(toString(x)), ',') FROM (SELECT negate(a) AS x FROM t_neg_lcn_04747 ORDER BY negate(a) ASC LIMIT 5)) AS keyed, (SELECT arrayStringConcat(groupArray(toString(x)), ',') FROM (SELECT negate(a) AS x FROM t_mem_lcn_04747 ORDER BY negate(a) ASC LIMIT 5)) AS oracle SETTINGS optimize_read_in_order = 1;
+
+-- Control: `LowCardinality` delegates `isValueRepresentedByNumber` to its dictionary, so this row
+-- holds whether or not the unwrap happens. It guards against over-declining, not against a wrong unwrap.
+DROP TABLE IF EXISTS t_neg_lc_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_lc_04747 SETTINGS ignore_drop_queries_probability = 0;
+CREATE TABLE t_neg_lc_04747 (a LowCardinality(Int64)) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_mem_lc_04747 (a LowCardinality(Int64)) ENGINE = Log;
+INSERT INTO t_neg_lc_04747 SELECT number * 100 FROM numbers(100);
+INSERT INTO t_mem_lc_04747 SELECT number * 100 FROM numbers(100);
+SELECT 'negate LC still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_neg_lc_04747 WHERE negate(a) = toInt64(-5000)) WHERE explain ILIKE '%Granules: 2/100%' SETTINGS use_lightweight_primary_key_index_analysis = 1;
+SELECT 'negate LC answers', (SELECT count() FROM t_neg_lc_04747 WHERE negate(a) = toInt64(-5000)) AS keyed, (SELECT count() FROM t_mem_lc_04747 WHERE negate(a) = toInt64(-5000)) AS oracle;
+
+-- Week transforms. `toDayOfWeek` has a non-trivial factor transform, so its verdict depends on the
+-- unwrapped key type being recognised as `Date`; a wrong unwrap loses the pruning below.
+DROP TABLE IF EXISTS t_week_lc_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_week_mem_04747 SETTINGS ignore_drop_queries_probability = 0;
+CREATE TABLE t_week_lc_04747 (a LowCardinality(Date)) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1;
+CREATE TABLE t_week_mem_04747 (a LowCardinality(Date)) ENGINE = Log;
+INSERT INTO t_week_lc_04747 SELECT toDate('2020-01-01') + number FROM numbers(100);
+INSERT INTO t_week_mem_04747 SELECT toDate('2020-01-01') + number FROM numbers(100);
+SELECT 'toDayOfWeek LC(Date) prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_week_lc_04747 WHERE toDayOfWeek(a) >= 3) WHERE explain ILIKE '%Granules: 86/100%' SETTINGS use_lightweight_primary_key_index_analysis = 1;
+SELECT 'toDayOfWeek LC(Date) answers', (SELECT count() FROM t_week_lc_04747 WHERE toDayOfWeek(a) >= 3) AS keyed, (SELECT count() FROM t_week_mem_04747 WHERE toDayOfWeek(a) >= 3) AS oracle;
+
+DROP TABLE IF EXISTS t_week_lcn_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_week_memn_04747 SETTINGS ignore_drop_queries_probability = 0;
+CREATE TABLE t_week_lcn_04747 (a LowCardinality(Nullable(Date))) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1, allow_nullable_key = 1;
+CREATE TABLE t_week_memn_04747 (a LowCardinality(Nullable(Date))) ENGINE = Log;
+INSERT INTO t_week_lcn_04747 SELECT toDate('2020-01-01') + number FROM numbers(100);
+INSERT INTO t_week_memn_04747 SELECT toDate('2020-01-01') + number FROM numbers(100);
+SELECT 'toDayOfWeek LC(Nullable(Date)) prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_week_lcn_04747 WHERE toDayOfWeek(a) >= 3) WHERE explain ILIKE '%Granules: 86/100%' SETTINGS use_lightweight_primary_key_index_analysis = 1;
+SELECT 'toDayOfWeek LC(Nullable(Date)) answers', (SELECT count() FROM t_week_lcn_04747 WHERE toDayOfWeek(a) >= 3) AS keyed, (SELECT count() FROM t_week_memn_04747 WHERE toDayOfWeek(a) >= 3) AS oracle;
+
+-- Date transforms. `toMonth`'s factor transform likewise needs the unwrapped `Date`.
+SELECT 'toMonth LC(Date) prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_week_lc_04747 WHERE toMonth(a) = 2) WHERE explain ILIKE '%Granules: 30/100%' SETTINGS use_lightweight_primary_key_index_analysis = 1;
+SELECT 'toMonth LC(Date) answers', (SELECT count() FROM t_week_lc_04747 WHERE toMonth(a) = 2) AS keyed, (SELECT count() FROM t_week_mem_04747 WHERE toMonth(a) = 2) AS oracle;
+SELECT 'toMonth LC(Nullable(Date)) prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_week_lcn_04747 WHERE toMonth(a) = 2) WHERE explain ILIKE '%Granules: 30/100%' SETTINGS use_lightweight_primary_key_index_analysis = 1;
+SELECT 'toMonth LC(Nullable(Date)) answers', (SELECT count() FROM t_week_lcn_04747 WHERE toMonth(a) = 2) AS keyed, (SELECT count() FROM t_week_memn_04747 WHERE toMonth(a) = 2) AS oracle;
+-- Control: `toStartOfMonth` has a `ZeroTransform` factor, so it answers before the unwrap runs and
+-- is insensitive to it. It guards the always-monotonic shortcut, not the unwrap.
+SELECT 'toStartOfMonth LC(Date) prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_week_lc_04747 WHERE toStartOfMonth(a) = toDate('2020-02-01')) WHERE explain ILIKE '%Granules: 30/100%' SETTINGS use_lightweight_primary_key_index_analysis = 1;
+SELECT 'toStartOfMonth LC(Date) answers', (SELECT count() FROM t_week_lc_04747 WHERE toStartOfMonth(a) = toDate('2020-02-01')) AS keyed, (SELECT count() FROM t_week_mem_04747 WHERE toStartOfMonth(a) = toDate('2020-02-01')) AS oracle;
+
+-- The compound site the helper was extracted from keeps its own coverage in
+-- `04652_compound_key_monotonicity.sql`, which already pins `Nullable(Tuple(Int64, Int64))`.
+
+DROP TABLE IF EXISTS t_neg_null_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_null_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_neg_lcn_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_lcn_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_neg_lc_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_mem_lc_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_week_lc_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_week_mem_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_week_lcn_04747 SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS t_week_memn_04747 SETTINGS ignore_drop_queries_probability = 0;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112339
-->

Related: #112339

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

No behaviour change. This is the deduplication @PedroTadim and @Ergus both asked for on #112339,
which merged before I could apply it.

Four key-analysis sites open with the same prologue: walk a `const IDataType &` through a
`LowCardinality` wrapper, then a `Nullable` wrapper, by raw pointer, in that order.
`src/DataTypes/` exposed that unwrap only in `DataTypePtr` form, and
`IFunction::getMonotonicityForRange` receives a reference while `IDataType::getPtr()` throws for a
type not owned by a `shared_ptr` - so those callers could not use `removeLowCardinalityAndNullable`
and copied the walk instead. I add the missing raw-pointer overload beside it and convert
`FunctionBinaryArithmetic.h:3841`, `negate.cpp:43`, `IFunctionCustomWeek.h:47` and
`IFunctionDateOrDateTime.h:129`.

Correcting my earlier count in that thread: there are 4 copies under `src/Functions`, not 2, and 8 in
`src/`. I had missed the two `IFunction*` headers because they spell the casts
`checkAndGetDataType`, which is a one-line alias for `typeid_cast` (`FunctionHelpers.h:26-29`).

Four carriers are deliberately left alone: `KeyCondition.cpp:1789` and `:2843` (hottest file in key
analysis, several open PRs touching it), `SetUtils.cpp:34` (holds a `DataTypePtr` and can just call
the existing function - a separate cleanup), and `PNGSerializer.cpp:73` (#112846 rewrites that file,
and its `removeLowCardinalityType` half is also used alone at `:93`).

As stated in that thread, the **test** after the prologue stays different per site.
`isCompoundForMonotonicity` asks `isArray || isTuple || isMap`; `negate.cpp:54` asks
`!isValueRepresentedByNumber()`. Those are not complements - `DataTypeNullable` has no override and
the default is false - and `04652_compound_key_monotonicity.sql:219-224` pins why unifying them is
wrong: a `String` key with `+ INTERVAL 1 DAY` prunes today.

Only the first site was pinned against a silent regression, so this adds
`04747_unwrap_monotonicity_dedup`. Six mutants each fail it 20 of 20 randomized runs; it passes on
unmodified master, as a characterization test should.

<details>
<summary>Mutation matrix and the randomization pins</summary>

Each arm is a separate build; `deterministic` is `--no-random-settings`, `randomized` 20 runs with
randomization on.

| arm | mutation | deterministic | randomized |
|---|---|---|---|
| fix | (this change) | OK | 20 OK / 0 FAIL |
| base | pristine | OK | 20 OK / 0 FAIL |
| M1 | swap the helper's strips | FAIL | 0 OK / 20 FAIL |
| M2 | drop the Nullable strip | FAIL | 0 OK / 20 FAIL |
| M3 | drop the LowCardinality strip | FAIL | 0 OK / 20 FAIL |
| M4 | `negate.cpp`: force the recovered `is_nullable` false | FAIL | 0 OK / 20 FAIL |
| M5 | revert `IFunctionCustomWeek.h`'s unwrap | FAIL | 0 OK / 20 FAIL |
| M6 | revert `IFunctionDateOrDateTime.h`'s unwrap | FAIL | 0 OK / 20 FAIL |

M4 is the interesting one: under it the two `negate ... ORDER BY` rows return empty where the `Log`
oracle returns the five expected values, so that arm catches wrong results, not lost pruning.

Two settings are pinned per query. `optimize_read_in_order` is randomized 0/1, and at 0 the sort
optimization that is the only observable of the `negate` verdict is off - which made M4 pass 10/10
before the pin. `use_lightweight_primary_key_index_analysis` is randomized with p=0.6, and at 0 the
index analysis hands the transform a key type that `recursiveRemoveLowCardinality` already stripped
(`KeyCondition.cpp:5532`), where the sparse branch passes it raw (`:5973`) - so a mutant breaking
only the `LowCardinality` half of the unwrap is invisible there. Hence the two `LowCardinality`-half
mutants are exactly the ones that under-reddened: M1 13/20, M3 6/20 before the pin. Both settings
read identical values on unmodified code, so the pins remove an escape hatch rather than weaken an
assertion.

Rows that cannot move either way are labelled controls in the file: `LowCardinality` delegates
`isValueRepresentedByNumber` to its dictionary, and `toStartOfMonth` has a `ZeroTransform` factor, so
it returns before the unwrap.
</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=113458&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/113458](https://github.com/search?q=head%3Async-upstream%2Fpr%2F113458+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
