### PR TITLE
Fix wrong results reading a re-added Nested subcolumn with shared offsets

### DIFF
--- a/src/DataTypes/NestedUtils.cpp
+++ b/src/DataTypes/NestedUtils.cpp
@@ -464,22 +464,21 @@ using NameToDataType = std::map<String, DataTypePtr>;
 NameToDataType getSubcolumnsOfNested(const NamesAndTypesList & names_and_types)
 {
     std::unordered_map<String, NamesAndTypesList> nested;
+    std::unordered_map<String, NameSet> added_members;
+
+    /// Unite flat arrays (`n.a`, `n.b`) into a Nested type. A member reached only via a subcolumn
+    /// (e.g. `n.a.null`) is taken from its storage column, so it too shares the Nested offsets.
     for (const auto & name_type : names_and_types)
     {
-        /// Skip subcolumns (e.g. `c0.c2.null` derived from `c0.c2 Array(Nullable(Tuple()))`).
-        /// They are not real flat-nested columns like `n.a Array(T)`, `n.b Array(T)`.
-        if (name_type.isSubcolumn())
+        const auto & type = name_type.isSubcolumn() ? name_type.getTypeInStorage() : name_type.type;
+        const auto * type_arr = typeid_cast<const DataTypeArray *>(type.get());
+        if (isNested(type) || !type_arr)
             continue;
 
-        const auto * type_arr = typeid_cast<const DataTypeArray *>(name_type.type.get());
-
-        /// Ignore true Nested type, but try to unite flatten arrays to Nested type.
-        if (!isNested(name_type.type) && type_arr)
-        {
-            auto split = splitName(name_type.name);
-            if (!split.second.empty())
-                nested[split.first].emplace_back(split.second, type_arr->getNestedType());
-        }
+        /// Dedup: a member may be reached by both its full column and a subcolumn of it.
+        auto split = splitName(name_type.getNameInStorage());
+        if (!split.second.empty() && added_members[split.first].insert(split.second).second)
+            nested[split.first].emplace_back(split.second, type_arr->getNestedType());
     }
 
     std::map<String, DataTypePtr> nested_types;
@@ -512,6 +511,8 @@ NamesAndTypesList collect(const NamesAndTypesList & names_and_types)
 
 NamesAndTypesList convertToSubcolumns(const NamesAndTypesList & names_and_types)
 {
+    /// Includes members reached only via a subcolumn, so `arr.nested.b` is remapped onto Nested
+    /// `arr` (and shares its offsets cache) even when the full `arr.nested` is absent or missing.
     auto nested_types = getSubcolumnsOfNested(names_and_types);
     auto res = names_and_types;
 
@@ -697,18 +698,30 @@ DataTypePtr getBaseTypeOfArray(DataTypePtr type, const Names & tuple_elements)
 {
     auto it = tuple_elements.begin();
 
-    /// Get underlying type for array, but w/o processing tuple elements that are not part of the nested, so it is done in 3 steps:
-    /// 1. Find Nested type (since it can be part of Tuple/Array)
-    /// 2. Process all Nested types (this is Array(Tuple()), it is responsibility of the caller to re-create proper Array nesting)
-    /// 3. Strip all nested arrays (it is responsibility of the caller to re-create proper Array nesting)
-
-    /// 1. Find Nested type (since it can be part of Tuple/Array)
+    /// Strip Array levels and descend the named Tuple / flattened-Nested elements until the tuple
+    /// elements are consumed. Navigating all kinds in one loop matters because a Nested member can
+    /// itself be a plain Tuple with a deeper subcolumn (e.g. `nested.b`). The caller re-creates the
+    /// stripped Array nesting from `num_empty_dimensions`.
     while (true)
     {
         if (type->hasCustomName())
-            break;
+        {
+            const auto * type_nested = typeid_cast<const DataTypeNestedCustomName *>(type->getCustomName());
+            if (!type_nested || it == tuple_elements.end())
+                break;
+
+            const auto & names = type_nested->getNames();
+            auto pos = std::find(names.begin(), names.end(), *it);
+            if (pos == names.end())
+                break;
+            ++it;
+
+            type = type_nested->getElements().at(std::distance(names.begin(), pos));
+        }
         else if (const auto * type_array = typeid_cast<const DataTypeArray *>(type.get()))
+        {
             type = type_array->getNestedType();
+        }
         else if (const auto * type_tuple = typeid_cast<const DataTypeTuple *>(type.get()))
         {
             if (it == tuple_elements.end())
@@ -724,30 +737,6 @@ DataTypePtr getBaseTypeOfArray(DataTypePtr type, const Names & tuple_elements)
         else
             break;
     }
-
-    /// 2. Process all Nested types (this is Array(Tuple()), it is responsibility of the caller to re-create proper Array nesting)
-    while (type->hasCustomName())
-    {
-        if (const auto * type_nested = typeid_cast<const DataTypeNestedCustomName *>(type->getCustomName()))
-        {
-            if (it == tuple_elements.end())
-                break;
-
-            const auto & names = type_nested->getNames();
-            auto pos = std::find(names.begin(), names.end(), *it);
-            if (pos == names.end())
-                break;
-            ++it;
-
-            type = type_nested->getElements().at(std::distance(names.begin(), pos));
-        }
-        else
-            break;
-    }
-
-    /// 3. Strip all nested arrays (it is responsibility of the caller to re-create proper Array nesting)
-    while (const auto * type_array = typeid_cast<const DataTypeArray *>(type.get()))
-        type = type_array->getNestedType();
 
     return type;
 }

--- a/tests/queries/0_stateless/04616_nested_subcolumn_shared_offsets_cache.reference
+++ b/tests/queries/0_stateless/04616_nested_subcolumn_shared_offsets_cache.reference
@@ -1,0 +1,6 @@
+part type	Wide
+wide prefetch single block	30000	0	0
+wide multi block	30000	0	0
+compact type	Compact
+compact control	100	0	0
+no shared offsets	0	0

--- a/tests/queries/0_stateless/04616_nested_subcolumn_shared_offsets_cache.sql
+++ b/tests/queries/0_stateless/04616_nested_subcolumn_shared_offsets_cache.sql
@@ -1,0 +1,91 @@
+-- Reading a Nested-element subcolumn (`arr.nested.b`) beside a surviving sibling (`arr.id`) must
+-- keep resolving to `name_in_storage = "arr"`, so both share the offsets substreams cache and the
+-- shared offsets stream is read only once. After DROP + ADD of `arr.nested` on a Wide part the
+-- subcolumn used to resolve to `name_in_storage = "arr.nested"` (the reconstructed Nested type had
+-- no `nested` member, because it was referenced only through a subcolumn), splitting the cache. The
+-- shared offsets stream was then read twice: with prefetch the sibling's mark seek was suppressed,
+-- and across several blocks the second read continued from the wrong position. Either way the
+-- sibling `arr.id` came back default-filled.
+
+DROP TABLE IF EXISTS t_shared_wide;
+DROP TABLE IF EXISTS t_shared_compact;
+DROP TABLE IF EXISTS t_shared_no_offsets;
+
+CREATE TABLE t_shared_wide
+(
+    id UInt64,
+    `arr.id` Array(UInt64),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS share_nested_offsets = 1, min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_shared_wide SELECT number, [number + 10], [(toString(number), number * 1.5)] FROM numbers(30000);
+
+ALTER TABLE t_shared_wide DROP COLUMN `arr.nested`;
+ALTER TABLE t_shared_wide ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
+
+SELECT 'part type', any(part_type) FROM system.parts WHERE database = currentDatabase() AND table = 't_shared_wide' AND active;
+
+-- Content oracles: the surviving sibling keeps its values, and the re-added subcolumn reads one
+-- default element per row from the shared offsets. `length` alone is not enough - the bad read
+-- corrupted lengths only across blocks, not within one.
+
+-- Single block, prefetch on.
+SELECT 'wide prefetch single block',
+    sum(length(nb)), sum(arraySum(nb)), countIf(aid != [id + 10])
+FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_wide)
+SETTINGS local_filesystem_read_prefetch = 1, max_block_size = 100000;
+
+-- Range split across several blocks: exercises the prefetch-independent continue_reading path.
+SELECT 'wide multi block',
+    sum(length(nb)), sum(arraySum(nb)), countIf(aid != [id + 10])
+FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_wide)
+SETTINGS local_filesystem_read_prefetch = 1, max_block_size = 1000;
+
+-- Control: Compact parts were never affected.
+CREATE TABLE t_shared_compact
+(
+    id UInt64,
+    `arr.id` Array(UInt64),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS share_nested_offsets = 1, min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000;
+
+INSERT INTO t_shared_compact SELECT number, [number + 10], [(toString(number), number * 1.5)] FROM numbers(100);
+
+ALTER TABLE t_shared_compact DROP COLUMN `arr.nested`;
+ALTER TABLE t_shared_compact ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
+
+SELECT 'compact type', any(part_type) FROM system.parts WHERE database = currentDatabase() AND table = 't_shared_compact' AND active;
+
+SELECT 'compact control',
+    sum(length(nb)), sum(arraySum(nb)), countIf(aid != [id + 10])
+FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_compact)
+SETTINGS local_filesystem_read_prefetch = 1, max_block_size = 1000;
+
+-- Control: without shared offsets `arr.nested` has its own (dropped) offsets stream, so it reads
+-- as empty arrays and never contends for the sibling's stream.
+CREATE TABLE t_shared_no_offsets
+(
+    id UInt64,
+    `arr.id` Array(UInt64),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS share_nested_offsets = 0, min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_shared_no_offsets SELECT number, [number + 10], [(toString(number), number * 1.5)] FROM numbers(100);
+
+ALTER TABLE t_shared_no_offsets DROP COLUMN `arr.nested`;
+ALTER TABLE t_shared_no_offsets ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
+
+SELECT 'no shared offsets',
+    sum(length(nb)), countIf(aid != [id + 10])
+FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_no_offsets)
+SETTINGS local_filesystem_read_prefetch = 1, max_block_size = 1000;
+
+DROP TABLE t_shared_wide;
+DROP TABLE t_shared_compact;
+DROP TABLE t_shared_no_offsets;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix wrong results reading a re-added Nested subcolumn with shared offsets. This is the correct fix instead of https://github.com/ClickHouse/ClickHouse/pull/112997
