### PR TITLE
Fix flaky 02040_clickhouse_benchmark_query_id_pass_through

### DIFF
--- a/tests/queries/0_stateless/02040_clickhouse_benchmark_query_id_pass_through.sh
+++ b/tests/queries/0_stateless/02040_clickhouse_benchmark_query_id_pass_through.sh
@@ -6,6 +6,11 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 query_id="${CLICKHOUSE_DATABASE}_$$"
 benchmark_args=(
+    # A loaded runner can take longer than the default 10 s handshake_timeout_ms
+    # to send Hello; the benchmark then exits without running a query and
+    # query_log has 0 rows instead of 3.
+    --connect_timeout 60
+    --handshake_timeout_ms 60000
     --iterations 1
     --log_queries 1
     --query_id "$query_id"


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110102
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`02040_clickhouse_benchmark_query_id_pass_through` asserts that one
`clickhouse-benchmark` run logs 3 queries under a single `initial_query_id`. It
read `0` instead of `3` on the run reported in #110102.

The benchmark process never ran its query. `Connection::connect` uses
`handshake_timeout_ms` as the socket receive timeout for the server Hello, and
`clickhouse-benchmark` and `clickhouse-client` take that value from different
places: the benchmark reads the setting (`src/Core/Settings.cpp:410`, default
`10000`) via `ConnectionTimeouts::getTCPTimeoutsWithoutFailover`, while the client
reads its own config with a much larger fallback
(`src/Client/ConnectionParameters.cpp:177`, `DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC *
1000`, so `300000`). Nothing in `tests/config` or `tests/queries/shell_config.sh`
sets it for either. So a stall past 10 s makes the benchmark exit
`SOCKET_TIMEOUT` before sending any query, while a client on the same stall waits.

That is what happened. In the reported job's `clickhouse-server.log` the server
accepted no TCP connection for 22.50 s (21:45:14.247 to 21:45:36.747, zero
`TCPHandlerFactory` accepts in between). The benchmark's connection was accepted at
the end of that window and the server logged `Client has gone away`. The job's
`query_log.tsv` confirms it: the failing instance has 0 rows with
`client_name = 'ClickHouse benchmark'`, while each of the 6 in-place reruns has
exactly 3.

The fix gives the benchmark's connect and handshake a generous budget, matching
#108570 for `01600_benchmark_query` and the same flags in
`03630_benchmark_accept_invalid_certificate` and
`03636_benchmark_error_messages`. The assertion is untouched, so what the test
verifies is unchanged. Of the 27 stateless tests invoking `CLICKHOUSE_BENCHMARK`,
3 carry these flags on `master` today and this makes it 4; over the last 30 days
the one fixed in #108570 has 0 failures.

The two `CLICKHOUSE_CLIENT` calls are deliberately left alone: their effective
`handshake_timeout_ms` is already `300000`, and their stderr is not redirected, so
a client-side stall fails the test on non-empty stderr with the exception
attached rather than producing this diff.

<details><summary>Reproduction and validation</summary>

Deterministic, against a listener that accepts and then withholds Hello, debug
binary Build ID `72b3babbc0b7cda0`:

| stall | invocation | outcome | elapsed |
|---|---|---|---|
| 22.5 s | `benchmark`, pre-fix | `Code: 209` `10000 ms` | 10.21 s |
| 22.5 s | `benchmark`, fixed | survives, waits for the peer | 22.57 s |
| 22.5 s | `client`, default | waits out the whole stall | 22.58 s |
| 70 s | `benchmark`, pre-fix | `Code: 209` `10000 ms` | 10.21 s |
| 70 s | `client`, default | waits out the whole stall | 70.09 s |

End-to-end through a stalling proxy in front of a real server, reproducing the
reported diff exactly:

| arm | benchmark rc | `count()` | reference |
|---|---|---|---|
| pre-fix | 209 | **0** | 3 |
| fixed | 0 | **3** | 3 |

The budget provably tracks the setting: `--handshake_timeout_ms 2000` reports
`2000 ms` and fails in 2.23 s, `5000` reports `5000 ms` in 5.24 s, the default
reports `10000 ms`. A misspelled option or a bad value is rejected loudly
(`Code: 552` / `Code: 27`), so the flags cannot silently become a no-op.

Fixed test: 50/50 OK with randomized settings and random order. The flags are
inert on the healthy path: interleaved A/B of 60 runs per arm gives an identical
p50 of 0.190 s (min 0.168 vs 0.170).

</details>
