### PR TITLE
Fix flaky test_replication_credentials replication race

### DIFF
--- a/tests/integration/test_replication_credentials/test.py
+++ b/tests/integration/test_replication_credentials/test.py
@@ -58,13 +58,13 @@ def test_same_credentials(same_credentials_cluster):
     node1.query("TRUNCATE TABLE test_table")
     node2.query("SYSTEM SYNC REPLICA test_table", timeout=10)
     node1.query("insert into test_table values ('2017-06-16', 111, 0)")
-    time.sleep(1)
+    node2.query("SYSTEM SYNC REPLICA test_table", timeout=60)
 
     assert node1.query("SELECT id FROM test_table order by id") == "111\n"
     assert node2.query("SELECT id FROM test_table order by id") == "111\n"
 
     node2.query("insert into test_table values ('2017-06-17', 222, 1)")
-    time.sleep(1)
+    node1.query("SYSTEM SYNC REPLICA test_table", timeout=60)
 
     assert node1.query("SELECT id FROM test_table order by id") == "111\n222\n"
     assert node2.query("SELECT id FROM test_table order by id") == "111\n222\n"
@@ -99,13 +99,13 @@ def test_no_credentials(no_credentials_cluster):
     node3.query("TRUNCATE TABLE test_table")
     node4.query("SYSTEM SYNC REPLICA test_table", timeout=10)
     node3.query("insert into test_table values ('2017-06-18', 111, 0)")
-    time.sleep(1)
+    node4.query("SYSTEM SYNC REPLICA test_table", timeout=60)
 
     assert node3.query("SELECT id FROM test_table order by id") == "111\n"
     assert node4.query("SELECT id FROM test_table order by id") == "111\n"
 
     node4.query("insert into test_table values ('2017-06-19', 222, 1)")
-    time.sleep(1)
+    node3.query("SYSTEM SYNC REPLICA test_table", timeout=60)
 
     assert node3.query("SELECT id FROM test_table order by id") == "111\n222\n"
     assert node4.query("SELECT id FROM test_table order by id") == "111\n222\n"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Made `test_replication_credentials::test_same_credentials` and `::test_no_credentials` deterministic by waiting on `SYSTEM SYNC REPLICA` instead of a fixed `time.sleep(1)` before each cross-replica read.

### Description

`test_same_credentials` and `test_no_credentials` insert into one replica and then
assert the table contents on the other, with a fixed `time.sleep(1)` as the only
barrier. When the INSERT returns its `/log/log-N` znode is durably in ZooKeeper,
but the other replica only learns of it asynchronously: it pulls the log, schedules
a background task, then fetches and commits the part over interserver HTTP. Nothing
in that chain is bounded by the test, so on a loaded runner it exceeds 1 s and the
assertion reads a stale replica:
`AssertionError: assert '111\n' == '111\n222\n'`. That has reached master
(sha `cfc1fd2512eb276fe020907434207a08fbaa5e0b`,
[report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=cfc1fd2512eb276fe020907434207a08fbaa5e0b&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%203%2F6%29)),
plus 6 more across 3 unrelated PRs in 90 days, counting only an `AssertionError` at
one of the four reads querying the replica that did not receive the insert.

This replaces the barrier rather than the timing constant: the replica about to be
read runs `SYSTEM SYNC REPLICA test_table` with an explicit `timeout=60`. That is
the engine's own catch-up signal: it pulls the log synchronously, forces scheduling,
and snapshots the pending entry ids atomically with registering its callback, so it
cannot miss the entry it waits for and returns as soon as the fetch lands. The file
already uses this idiom four times.

All 8 assertions are byte-identical; only the barrier changed. Scope is
deliberately 2 tests, 4 lines: in `test_different_credentials` and
`test_credentials_and_no_credentials` the sleep guards a negative assertion across
intentionally mismatched credentials, where a sync can never complete: measured, it
fails with `QueryTimeoutExceedException`.

Validation: with the fetch stalled deliberately, the assertion fails before the
change with the exact CI signature and passes after it on the same binary;
reverting the barrier reddens it. 200/200 over 50 repeats.

Other failures in this file are pre-existing and separate: a ZooKeeper-container
start failure, a MemorySanitizer report, a SIGSEGV, and a `Sanitizer assert` from
`cluster.shutdown()`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.855` (included in `26.8` and later)
<!-- ch-version-info:end -->