### PR TITLE
Docs: Clarify mutation pool setting limit

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -540,8 +540,8 @@ Possible values:
 **Usage**
 
 The value of the `number_of_free_entries_in_pool_to_execute_mutation` setting
-should be less than the value of the [background_pool_size](/reference/settings/server-settings/settings/background#background_pool_size)
-* [background_merges_mutations_concurrency_ratio](/reference/settings/server-settings/settings/background-merges#background_merges_mutations_concurrency_ratio).
+must not exceed the product of [`background_pool_size`](/reference/settings/server-settings/settings/background#background_pool_size)
+and [`background_merges_mutations_concurrency_ratio`](/reference/settings/server-settings/settings/background-merges#background_merges_mutations_concurrency_ratio).
 Otherwise, ClickHouse will throw an exception.
 )", 0) \
     DECLARE(UInt64, max_number_of_mutations_for_replica, 0, R"(


### PR DESCRIPTION
The documentation for `number_of_free_entries_in_pool_to_execute_mutation` currently renders `background_merges_mutations_concurrency_ratio` as a list item instead of a multiplicative factor.

Clarify that the setting must not exceed the product of `background_pool_size` and `background_merges_mutations_concurrency_ratio`, matching the runtime validation and its allowance for equality.

Affected documentation: https://clickhouse.com/docs/reference/settings/merge-tree-settings/number-of#number_of_free_entries_in_pool_to_execute_mutation


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.890` (included in `26.8` and later)
<!-- ch-version-info:end -->