### PR TITLE
Settings-history style check: recognize a renamed record

### DIFF
--- a/ci/jobs/check_style.py
+++ b/ci/jobs/check_style.py
@@ -607,6 +607,12 @@ def check_settings_changes_history():
     the same to every record of that block at once, without touching a single entry line, so
     such a change reports the whole block.
 
+    A record RENAMED in place - removed and re-added in the same block, identical apart from the
+    setting name - is reported under the new name only (see `parse_settings_history_changes`).
+    The old name cannot be demanded here: the setting is gone, and 03999_stateless_settings_history
+    rejects a documented name that no longer exists, so requiring it would leave no history file
+    that satisfies both guards.
+
     Runs only when that file changed; the list of changed setting names is provided by the
     store_data.py workflow hook (which parses the PR / merge-queue diff). Returns "" on
     success or a non-empty error string on failure (consumed by Result.from_commands_run).
@@ -726,7 +732,9 @@ def check_settings_changes_history():
             f"an entry for each under the '{current_version}' block (older blocks may keep their "
             f"entries for backports). If this is a correction of what an older release recorded "
             f"and not a default change made here, split it into a change that touches only "
-            f"{path}:\n" + "\n".join(sorted(set(violations)))
+            f"{path}. If you RENAMED a setting, keep its record in the same block and change "
+            f"only the name in it - the values and the reason text must stay identical for the "
+            f"rename to be recognized:\n" + "\n".join(sorted(set(violations)))
         )
     return ""
 

--- a/ci/jobs/scripts/workflow_hooks/store_data.py
+++ b/ci/jobs/scripts/workflow_hooks/store_data.py
@@ -26,6 +26,15 @@ def _settings_history_entry_signature(entry_body):
     return re.sub(r',\s*"(?:[^"\\]|\\.)*"\s*\},?\s*$', "", entry_body).strip()
 
 
+def _settings_history_entry_without_name(entry_body):
+    """The entry with only its setting NAME removed, so a pure rename can be recognized: the
+    same recorded values and the same reason under a new name. Everything else is kept, reason
+    text included, because a no-op record (`{"s", false, false, "New setting."}`) is the most
+    common shape there is - matching on the values alone would treat an unrelated deleted and
+    added record as a rename of one another."""
+    return re.sub(r'^\{\s*"[A-Za-z0-9_]+"\s*,', "{", entry_body.strip())
+
+
 def _settings_history_block_header_index(file_lines, lineno):
     """Index in `file_lines` of the `addSettingsChanges` header of the block that physically
     contains the given new-file line number, or None when the line is outside any block."""
@@ -79,6 +88,14 @@ def parse_settings_history_changes(patch, file_lines):
     version come from the block that physically contains the line (new-file line number), not
     from global name presence - names can exist in both histories.
 
+    A pure rename in place is reported under the NEW name only: when the removed and the added
+    entry of one block are identical apart from the setting name, the old name is dropped from
+    the result. Demanding the old name under the current version block would be unsatisfiable -
+    the setting no longer exists, and 03999_stateless_settings_history rejects a documented name
+    that is not in system.settings / system.merge_tree_settings, so there is no history file
+    that passes both guards. The rename still has to be honest, because the new name is reported
+    and the caller requires it under the current version block like any other added record.
+
     Matching on the block, not on the value signature alone, is what closes the "move instead
     of delete" variant of the escape hatch: re-adding an unchanged entry under an OLDER block
     keeps the newest recorded value intact, so 03999_stateless_settings_history still passes,
@@ -105,8 +122,8 @@ def parse_settings_history_changes(patch, file_lines):
     file changed. A change that edits only this file - fixing what a past release recorded -
     is a historical correction, not a default change made now, so it is allowed there; that is
     what keeps a phantom record deletable."""
-    added = []  # (new_line_number, name, signature)
-    removed = []  # (new_line_number, name, signature)
+    added = []  # (new_line_number, name, signature, body_without_name)
+    removed = []  # (new_line_number, name, signature, body_without_name)
     headers_added = []  # new_line_number of an added `addSettingsChanges` header
     headers_removed = []  # new_line_number a removed `addSettingsChanges` header sat at
     new_lineno = None
@@ -123,7 +140,14 @@ def parse_settings_history_changes(patch, file_lines):
             m = _SETTINGS_HISTORY_ENTRY_RE.match(line[1:])
             if m:
                 signature = _settings_history_entry_signature(line[1:])
-                added.append((new_lineno, m.group(1), signature))
+                added.append(
+                    (
+                        new_lineno,
+                        m.group(1),
+                        signature,
+                        _settings_history_entry_without_name(line[1:]),
+                    )
+                )
             new_lineno += 1
         elif line.startswith("-") and not line.startswith("---"):
             if _SETTINGS_HISTORY_BLOCK_RE.search(line[1:]):
@@ -135,26 +159,52 @@ def parse_settings_history_changes(patch, file_lines):
                 # its block from the preceding line; otherwise removing the last entry of a
                 # block whose successor header follows immediately would be attributed to the
                 # next block. Removing entries does not move the surrounding block headers.
-                removed.append((new_lineno - 1, m.group(1), signature))
+                removed.append(
+                    (
+                        new_lineno - 1,
+                        m.group(1),
+                        signature,
+                        _settings_history_entry_without_name(line[1:]),
+                    )
+                )
             # A removed line does not advance the new-file line counter.
         else:
             new_lineno += 1
 
     def with_blocks(entries):
-        """(namespace, version, name, signature) for every entry that resolves to a block."""
+        """(namespace, version, name, signature, body_without_name) for every entry that
+        resolves to a block."""
         resolved = []
-        for lineno, name, signature in entries:
+        for lineno, name, signature, bare in entries:
             namespace, version = _settings_history_block_at(file_lines, lineno)
             if namespace:
-                resolved.append((namespace, version, name, signature))
+                resolved.append((namespace, version, name, signature, bare))
         return resolved
 
     added = with_blocks(added)
     removed = with_blocks(removed)
     # The key includes the block: a matching pair inside one block is a reason-only edit, while
     # the same pair spread over two blocks is a move of the record to another release.
-    added_keys = {(ns, ver, sig) for ns, ver, _, sig in added}
-    removed_keys = {(ns, ver, sig) for ns, ver, _, sig in removed}
+    added_keys = {(ns, ver, sig) for ns, ver, _, sig, _ in added}
+    removed_keys = {(ns, ver, sig) for ns, ver, _, sig, _ in removed}
+
+    # A pure RENAME of a record inside one block: the removed and the added entry are identical
+    # apart from the setting name, so nothing about what the history records changed and no
+    # record moved to another release. The OLD name must not be demanded under the current
+    # version block, because a record naming it cannot exist at all: the setting is gone, and
+    # 03999_stateless_settings_history rejects a documented name that is not in system.settings
+    # / system.merge_tree_settings ("DOES NOT EXIST (typo/rename?)"). Aliases do not rescue it
+    # either - system.merge_tree_settings has no alias rows. Only the NEW name is reported, and
+    # the caller then requires it under the current version block like any other added record,
+    # which is what keeps the rename honest.
+    added_by_bare = {}
+    for ns, ver, name, _, bare in added:
+        added_by_bare.setdefault((ns, ver, bare), set()).add(name)
+    renamed_away = {
+        (ns, name)
+        for ns, ver, name, _, bare in removed
+        if added_by_bare.get((ns, ver, bare), set()) - {name}
+    }
 
     result = []
     seen = set()
@@ -187,11 +237,17 @@ def parse_settings_history_changes(patch, file_lines):
                 seen.add((namespace, name))
                 result.append({"namespace": namespace, "name": name})
 
-    for entries, other_keys in ((added, removed_keys), (removed, added_keys)):
-        for namespace, version, name, signature in entries:
+    for entries, other_keys, exempt in (
+        (added, removed_keys, set()),
+        (removed, added_keys, renamed_away),
+    ):
+        for namespace, version, name, signature, _ in entries:
             if (namespace, version, signature) in other_keys:
                 # A reason-only edit of an existing entry: the recorded values did not change
                 # and the record stayed in the block it was already in.
+                continue
+            if (namespace, name) in exempt:
+                # The old name of a record renamed in place - see `renamed_away` above.
                 continue
             if (namespace, name) not in seen:
                 seen.add((namespace, name))

--- a/ci/tests/test_settings_history_diff_parser.py
+++ b/ci/tests/test_settings_history_diff_parser.py
@@ -288,3 +288,92 @@ def test_reason_only_edit_of_a_block_that_keeps_its_header_is_still_ignored():
         "         });\n"
     )
     assert parse_settings_history_changes(patch, HEADER_EDIT_FILE_LINES) == []
+
+
+RENAME_FILE_LINES = [
+    "        addSettingsChanges(settings_changes_history, \"26.8\",",
+    "        {",
+    "            {\"new_name\", false, false, \"New setting.\"},",
+    "        });",
+    "        addSettingsChanges(settings_changes_history, \"26.7\",",
+    "        {",
+    "            {\"renamed_in_an_older_block\", false, false, \"New setting.\"},",
+    "        });",
+]
+
+
+def test_pure_rename_in_place_reports_only_the_new_name():
+    # Renaming a setting means renaming its record. The recorded values and the block stay the
+    # same, so nothing is misattributed to another release - and the OLD name must not be
+    # required under the current version block, because a record naming it cannot exist:
+    # 03999_stateless_settings_history rejects a documented name that is no longer a setting.
+    # The NEW name is reported, so the record still has to sit under the current version block.
+    patch = (
+        "@@ -1,4 +1,4 @@\n"
+        " addSettingsChanges(settings_changes_history, \"26.8\",\n"
+        " {\n"
+        '-            {"old_name", false, false, "New setting."},\n'
+        '+            {"new_name", false, false, "New setting."},\n'
+        " });\n"
+    )
+    assert parse_settings_history_changes(patch, RENAME_FILE_LINES) == [
+        {"namespace": "Session", "name": "new_name"}
+    ]
+
+
+def test_rename_that_also_changes_the_recorded_values_reports_both_names():
+    # Not a pure rename: the values differ, so this is a value change wearing a new name. Both
+    # sides are reported and the current-block rule applies to each.
+    patch = (
+        "@@ -1,4 +1,4 @@\n"
+        " addSettingsChanges(settings_changes_history, \"26.8\",\n"
+        " {\n"
+        '-            {"old_name", false, true, "New setting."},\n'
+        '+            {"new_name", false, false, "New setting."},\n'
+        " });\n"
+    )
+    assert parse_settings_history_changes(patch, RENAME_FILE_LINES) == [
+        {"namespace": "Session", "name": "new_name"},
+        {"namespace": "Session", "name": "old_name"},
+    ]
+
+
+def test_unrelated_records_sharing_a_value_shape_are_both_reported():
+    # `{"s", false, false, "New setting."}` is the most common record there is, so matching on
+    # the values alone would read any deleted record plus any added record in the same block as
+    # a rename of one another. The reason text must match too - here it does not, so the removal
+    # is still reported and cannot be smuggled through behind an unrelated addition.
+    patch = (
+        "@@ -1,4 +1,4 @@\n"
+        " addSettingsChanges(settings_changes_history, \"26.8\",\n"
+        " {\n"
+        '-            {"old_name", false, false, "Some other reason"},\n'
+        '+            {"new_name", false, false, "New setting."},\n'
+        " });\n"
+    )
+    assert parse_settings_history_changes(patch, RENAME_FILE_LINES) == [
+        {"namespace": "Session", "name": "new_name"},
+        {"namespace": "Session", "name": "old_name"},
+    ]
+
+
+def test_rename_across_version_blocks_reports_both_names():
+    # The record is renamed AND lands in a different block than the one it was removed from, so
+    # the release it is attributed to changed. That is the misattribution the check exists for,
+    # so both names are reported.
+    patch = (
+        "@@ -1,4 +1,3 @@\n"
+        " addSettingsChanges(settings_changes_history, \"26.8\",\n"
+        " {\n"
+        '-            {"old_name", false, false, "New setting."},\n'
+        " });\n"
+        "@@ -5,3 +4,4 @@\n"
+        " addSettingsChanges(settings_changes_history, \"26.7\",\n"
+        " {\n"
+        '+            {"renamed_in_an_older_block", false, false, "New setting."},\n'
+        " });\n"
+    )
+    assert parse_settings_history_changes(patch, RENAME_FILE_LINES) == [
+        {"namespace": "Session", "name": "renamed_in_an_older_block"},
+        {"namespace": "Session", "name": "old_name"},
+    ]

--- a/ci/tests/test_settings_history_source_gate.py
+++ b/ci/tests/test_settings_history_source_gate.py
@@ -196,3 +196,50 @@ def test_editing_a_block_header_is_not_an_escape_hatch(monkeypatch):
 
     # The same header edit without any other source change is a historical correction: allowed.
     assert _run(monkeypatch, _kv([HISTORY], changed)) == ""
+
+
+def _rename_patch(old_name, new_name, block_version="26.8"):
+    """A pure rename of one record inside one block: only the setting name differs."""
+    reason = "New setting."
+    added = f'            {{"{new_name}", false, false, "{reason}"}},'
+    removed = f'            {{"{old_name}", false, false, "{reason}"}},'
+    file_lines = [
+        f'        addSettingsChanges(settings_changes_history, "{block_version}",',
+        "        {",
+        added,
+        "        });",
+    ]
+    patch = (
+        "@@ -1,4 +1,4 @@\n"
+        f' addSettingsChanges(settings_changes_history, "{block_version}",\n'
+        " {\n"
+        f"-{removed}\n"
+        f"+{added}\n"
+        " });\n"
+    )
+    return patch, file_lines
+
+
+def test_renaming_a_record_in_place_is_allowed(monkeypatch):
+    # End-to-end with the diff parser: renaming a setting renames its record. The old name must
+    # not be demanded under the current version block, because no history file could satisfy
+    # that and 03999_stateless_settings_history at the same time - that test rejects a documented
+    # name which is no longer a setting ("DOES NOT EXIST (typo/rename?)"), and for a MergeTree
+    # setting not even an alias makes the old name reappear (system.merge_tree_settings has no
+    # alias rows). `s3_base` is a real record of the current version block, so the check is
+    # satisfied by the new name alone.
+    patch, file_lines = _rename_patch("legacy_s3_base_name", "s3_base")
+    changed = parse_settings_history_changes(patch, file_lines)
+    assert changed == [{"namespace": "Session", "name": "s3_base"}]
+    assert _run(monkeypatch, _kv([HISTORY, "src/Core/Settings.cpp"], changed)) == ""
+
+
+def test_renaming_a_record_still_requires_the_new_name_under_the_current_block(monkeypatch):
+    # The rename is not a free pass: the NEW name goes through the current-block rule as any
+    # added record does, so renaming into a record that is not recorded under the current
+    # version still fails.
+    patch, file_lines = _rename_patch("some_old_name", "no_such_setting_at_all")
+    changed = parse_settings_history_changes(patch, file_lines)
+    assert changed == [{"namespace": "Session", "name": "no_such_setting_at_all"}]
+    error = _run(monkeypatch, _kv([HISTORY, "src/Core/Settings.cpp"], changed))
+    assert "no_such_setting_at_all" in error


### PR DESCRIPTION
The `settings_changes_history` style check reports every setting whose record in `src/Core/SettingsChangesHistory.cpp` was added, value-edited, removed or moved, and requires each one under the current version block. Renaming a setting means renaming its record, so the old name is reported as removed and demanded under the current block.

That demand cannot be satisfied. The setting no longer exists, and `03999_stateless_settings_history` rejects a documented name that is not in `system.settings` / `system.merge_tree_settings`:

```sql
SELECT 'MERGE_TREE_SETTING IN SettingsChangesHistory.cpp DOES NOT EXIST (typo/rename?): ' || name
FROM mergetree_documented WHERE name NOT IN (SELECT name FROM system.merge_tree_settings)
```

So keeping the record fails the functional test and removing it fails the style check. Keeping the old name as an alias does not rescue a MergeTree setting either: `system.merge_tree_settings` has no alias rows, so an alias never makes the recorded name reappear. The two guards have no common solution and **every MergeTree setting rename is currently blocked**, whether or not it keeps an alias. The escape hatch in the failure message ("split it into a change that touches only `SettingsChangesHistory.cpp`") does not help: either split order leaves master with a record naming a setting that does not exist, which trips `03999` instead.

A pure rename in place is now reported under the **new name only**: the removed and the added entry of one block being identical apart from the setting name means nothing about what the history records changed and no record moved to another release. The rename still has to be honest, because the new name goes through the current-block rule exactly like any other added record.

The pair must match on the whole entry, reason text included, not merely on the recorded values. `{"s", false, false, "New setting."}` is the most common record shape in the file, so matching on values alone would read an unrelated deleted record plus an unrelated added record in the same block as a rename of one another. Everything the check exists to catch stays reported:

- a removal with no replacement;
- a value change (with or without a new name);
- a move to another version or namespace block, including a move that also renames, since the release the record is attributed to changes;
- a block header edit.

Tests cover the pure rename, a rename that also changes the recorded values, two unrelated records that merely share a value shape, a rename across version blocks, and end to end both that a rename passes the check and that the new name is still required under the current version block. Verified locally: `ci/tests/test_settings_history_diff_parser.py` and `ci/tests/test_settings_history_source_gate.py` pass (31 tests, including the 15 pre-existing ones), and replaying the real diffs of the two rename PRs below through the parser and the check turns both from fail to pass, reporting only the new name.

Related: https://github.com/ClickHouse/ClickHouse/pull/113479
Related: https://github.com/ClickHouse/ClickHouse/pull/113480

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.869` (included in `26.8` and later)
<!-- ch-version-info:end -->