### PR TITLE
musl: aarch64 asm `memmove`

### DIFF
--- a/contrib/musl-cmake/CMakeLists.txt
+++ b/contrib/musl-cmake/CMakeLists.txt
@@ -1499,6 +1499,10 @@ elseif (MUSL_ARCH STREQUAL "aarch64")
         "${MUSL_SOURCE_DIR}/src/signal/restore.c"
         "${MUSL_SOURCE_DIR}/src/signal/sigsetjmp.c"
         "${MUSL_SOURCE_DIR}/src/string/memcpy.c"
+        # memcpy.S handles overlaps and provides memmove as a second entry
+        # point (upstream musl has no aarch64 memmove asm; the generic C
+        # memmove sends only non-overlapping copies to the asm memcpy).
+        "${MUSL_SOURCE_DIR}/src/string/memmove.c"
         "${MUSL_SOURCE_DIR}/src/string/memset.c"
         "${MUSL_SOURCE_DIR}/src/thread/__set_thread_area.c"
         "${MUSL_SOURCE_DIR}/src/thread/__unmapself.c"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/109239

Bumps the `musl` submodule by one fork commit (branch [`aarch64-memmove`](https://github.com/ClickHouse/musl/tree/aarch64-memmove) in ClickHouse/musl):

The aarch64 asm `memcpy` (imported from ARM optimized-routines) is restored to its upstream single-entry memcpy/memmove form: an overlap check plus a backwards loop for large copies; small and medium copies (<= 128 bytes) read everything before writing and are inherently overlap-safe. `memmove` was previously the generic C 8-bytes-per-iteration loop for overlapping moves (e.g. `PODArray::erase` shifting elements).

The generic C `memmove.c` is dropped from the aarch64 source list in `contrib/musl-cmake`, matching the x86_64 branch with its asm `memmove`.

Validated with an exhaustive overlap sweep (~48k size/offset/misalignment combinations vs a byte-wise reference, both directions) under qemu-user and under ASan on a full-system QEMU kernel.

Affects only builds that link musl (the `amd_musl` build in CI; the effect is on aarch64 musl builds).

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
In aarch64 musl builds, `memmove` now uses the ARM optimized-routines asm implementation (shared with `memcpy`) instead of the generic C word-at-a-time loop.
