### PR TITLE
Make the cleanup DROP of a failed CREATE ... AS SELECT killable

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -2438,6 +2438,8 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
         ContextMutablePtr internal_context = Context::createCopy(current_context->getGlobalContext());
         internal_context->makeQueryContext();
         internal_context->setSettings(current_context->getSettingsRef());
+        /// The settings copied above can make the internal DROPs below wait; the element is the only way out.
+        internal_context->setProcessListElement(current_context->getProcessListElementSafe());
         internal_context->setDDLOrOnClusterInternal(true);
         if (bypass_size_guard)
         {

--- a/tests/queries/0_stateless/04765_kill_create_as_select_cleanup_drop.reference
+++ b/tests/queries/0_stateless/04765_kill_create_as_select_cleanup_drop.reference
@@ -1,0 +1,6 @@
+kill_landed 1
+returned_while_blocked 1
+1
+1
+0
+0

--- a/tests/queries/0_stateless/04765_kill_create_as_select_cleanup_drop.sh
+++ b/tests/queries/0_stateless/04765_kill_create_as_select_cleanup_drop.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel, no-ordinary-database, no-replicated-database
+# no-fasttest: relies on a failpoint (libfiu).
+# no-parallel: the failpoint parks the single global background drop thread, which would stall
+#   the drop queue of any concurrently running test.
+# no-ordinary-database: a plain CREATE ... AS SELECT is only routed through the temporary-table
+#   publish path (the code under test) on an Atomic database.
+# no-replicated-database: the internal context takes a different branch when a Replicated-database
+#   ZooKeeper transaction is present.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# A plain `CREATE TABLE ... AS SELECT` on an Atomic database populates a temporary table and
+# publishes it with a RENAME; if the populate fails, a cleanup DROP removes the temporary table.
+# That DROP runs on an internal context, and with
+# database_atomic_wait_for_drop_and_detach_synchronously = 1 it waits in
+# DatabaseCatalog::waitTableFinallyDropped until the background drop queue has finalized the
+# table. The wait's only exit is the process list element of its context, so an internal context
+# without one made the wait -- and therefore the whole CREATE -- unkillable.
+#
+# The wait is entered deterministically by parking the background drop thread at a failpoint
+# placed after dropTableFinally() and before the UUID is erased from tables_marked_dropped_ids:
+# the waiter's predicate still holds, so it cannot leave the loop on its own.
+
+FP="database_catalog_drop_finally_before_id_erase"
+QID="04765_${CLICKHOUSE_DATABASE}"
+CH="${CLICKHOUSE_CLIENT}"
+
+# Make sure the failpoint is off if a previous run left it enabled.
+$CH -q "SYSTEM DISABLE FAILPOINT ${FP}" 2>/dev/null
+
+# Warm the background drop task so the failpoint is reached promptly below.
+$CH -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.warm (x Int32) ENGINE = MergeTree ORDER BY tuple()"
+$CH -q "DROP TABLE ${CLICKHOUSE_DATABASE}.warm SYNC"
+
+$CH -q "SYSTEM ENABLE FAILPOINT ${FP}"
+
+# The populate throws, so the cleanup DROP runs and waits for the background finalization that
+# the failpoint is holding.
+$CH --query_id="${QID}" --database_atomic_wait_for_drop_and_detach_synchronously=1 \
+    -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.tgt ENGINE = MergeTree ORDER BY tuple()
+        AS SELECT throwIf(number = 2) AS x FROM numbers(3)" > /dev/null 2>&1 &
+CREATE_PID=$!
+
+# The drop thread is parked: the table is gone but its UUID is still in the queue's id set.
+$CH -q "SYSTEM WAIT FAILPOINT ${FP} PAUSE"
+
+# Wait until the CREATE is actually inside the wait, so the KILL cannot land before it.
+for _ in {1..600}; do
+    n=$($CH -q "SELECT count() FROM system.processes WHERE query_id = '${QID}'" 2>/dev/null)
+    [ "$n" = "1" ] && break
+    sleep 0.1
+done
+
+# ASYNC: a SYNC kill would itself block for as long as the query does, i.e. forever before the fix.
+$CH -q "KILL QUERY WHERE query_id = '${QID}' ASYNC" > /dev/null
+
+# Positive control that the kill landed. This is true on a pre-fix build too (the flag is set,
+# the wait just ignores it), so it is a control rather than the discriminator below.
+killed=0
+for _ in {1..600}; do
+    c=$($CH -q "SELECT is_cancelled FROM system.processes WHERE query_id = '${QID}'" 2>/dev/null)
+    [ "$c" = "1" ] && { killed=1; break; }
+    [ -z "$c" ] && { killed=1; break; }
+    sleep 0.1
+done
+echo "kill_landed ${killed}"
+
+# The discriminator: the query must return while the failpoint is still parked. Before the fix it
+# stayed in the wait and only the release below could end it. Bounded so a pre-fix build fails
+# fast with a diff instead of running into the runner's global timeout (which would also leave
+# the failpoint enabled for every later test).
+returned=0
+for _ in {1..600}; do
+    if ! kill -0 "$CREATE_PID" 2>/dev/null; then returned=1; break; fi
+    sleep 0.1
+done
+echo "returned_while_blocked ${returned}"
+
+$CH -q "SYSTEM DISABLE FAILPOINT ${FP}"
+wait "$CREATE_PID" 2>/dev/null
+
+# The cleanup DROP's error is logged and swallowed (the populate's own error is what reaches the
+# client), so the cancellation is asserted from the log. The first line is the positive control
+# that the wait was entered at all: without it a pass could just mean the cleanup never waited.
+$CH -q "SYSTEM FLUSH LOGS text_log"
+$CH -q "SELECT count() > 0 FROM system.text_log
+        WHERE query_id = '${QID}' AND message LIKE '%to be finally dropped%'"
+$CH -q "SELECT count() > 0 FROM system.text_log
+        WHERE query_id = '${QID}' AND message LIKE '%Cannot DROP temporary table%QUERY_WAS_CANCELLED%'"
+
+# The failed create leaves no table behind, and the temporary table is not stranded.
+$CH -q "EXISTS ${CLICKHOUSE_DATABASE}.tgt"
+$CH -q "SELECT count() FROM system.dropped_tables WHERE database = '${CLICKHOUSE_DATABASE}'"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113263
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a `CREATE TABLE ... AS SELECT` whose populating `SELECT` failed becoming unkillable when `database_atomic_wait_for_drop_and_detach_synchronously` is enabled: the internal cleanup `DROP` of the temporary table waited for the background drop queue and ignored both `KILL QUERY` and `max_execution_time`.


### Description

A plain `CREATE TABLE ... AS SELECT` on an Atomic database populates a temporary table and publishes it with a `RENAME`; if the populate fails, an internal `DROP` cleans it up. That `DROP` runs on a context built from the global context, which copies the caller's settings but not its process list element.

With `database_atomic_wait_for_drop_and_detach_synchronously = 1` the copied settings make that `DROP` synchronous, so it waits in `DatabaseCatalog::waitTableFinallyDropped`. The only way out is the `throw_if_cancelled` callback, which `InterpreterDropQuery::waitForTableToBeActuallyDroppedOrDetached` derives from the context's process list element. Without one it is a no-op, so the wait -- and the whole `CREATE` -- ignores `KILL QUERY` and `max_execution_time` for as long as the drop queue is busy.

Observed as a `Stress test (arm_release)` hung check: an internal query sat in that wait for 655 s with `is_cancelled = 1` and `max_execution_time = 10`. The sibling factory used by `CREATE OR REPLACE` copies the caller's context, so its cleanup `DROP` was already killable; this restores that property for the plain-create path.

Validated with a deterministic fixture: a failpoint parks the background drop thread where the waiter's predicate still holds, so the wait is always entered. Before the change the query stays in the wait and only releasing the failpoint ends it; after it, it returns 1.3 s after the `KILL`. Reverting only the added line reddens the new test. 50/50 randomized runs pass; 61 neighbouring drop-queue tests show no regression.

The factory's other caller (`CREATE TABLE IF NOT EXISTS ... AS SELECT` losing a race for the target name) has a separate pre-existing bug, left for its own change: it passes the context as a temporary while `InterpreterDropQuery` keeps only a weak pointer, so the server aborts with `LOGICAL_ERROR: Context has expired`. That reproduces on unmodified master with no failpoint.