### PR TITLE
Avoid double compression in adaptive codec selection

### DIFF
--- a/src/Compression/CompressedSizeCalculator.cpp
+++ b/src/Compression/CompressedSizeCalculator.cpp
@@ -1,13 +1,27 @@
 #include <city.h>
-
-#include <base/defines.h>
-
 #include <Compression/CompressedSizeCalculator.h>
 #include <Compression/CompressionFactory.h>
+#include <base/defines.h>
 
 
 namespace DB
 {
+
+namespace
+{
+
+/// Compressed size of a single block as `compress` would produce it (block header + payload).
+/// If possible, calculate output size cheaply. If not, compress into a scratch buffer and keep only the returned size.
+UInt32 getCompressedBlockSize(const ICompressionCodec & codec, const char * src, UInt32 src_size, PODArray<char> & scratch)
+{
+    if (auto calculated = codec.tryGetCompressedSize(src, src_size))
+        return ICompressionCodec::getHeaderSize() + *calculated;
+
+    scratch.resize(codec.getCompressedReserveSize(src_size));
+    return codec.compress(src, src_size, scratch.data());
+}
+
+}
 
 CompressedSizeCalculator::CompressedSizeCalculator(CompressionCodecPtr codec_, size_t buf_size)
     : BufferWithOwnMemory<WriteBuffer>(buf_size)
@@ -15,17 +29,6 @@ CompressedSizeCalculator::CompressedSizeCalculator(CompressionCodecPtr codec_, s
 {
     if (!codec)
         codec = CompressionCodecFactory::instance().getDefaultCodec();
-}
-
-UInt32 CompressedSizeCalculator::getCompressedBlockSize(
-    const ICompressionCodec & codec, const char * src, UInt32 src_size, PODArray<char> & scratch)
-{
-    /// If possible, calculate output size cheaply. If not, compress into a scratch buffer and keep only the returned size.
-    if (auto calculated = codec.tryGetCompressedSize(src, src_size))
-        return ICompressionCodec::getHeaderSize() + *calculated;
-
-    scratch.resize(codec.getCompressedReserveSize(src_size));
-    return codec.compress(src, src_size, scratch.data());
 }
 
 void CompressedSizeCalculator::nextImpl()

--- a/src/Compression/CompressedSizeCalculator.h
+++ b/src/Compression/CompressedSizeCalculator.h
@@ -18,9 +18,6 @@ class CompressedSizeCalculator : public BufferWithOwnMemory<WriteBuffer>
 public:
     explicit CompressedSizeCalculator(CompressionCodecPtr codec_ = nullptr, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE);
 
-    /// Compressed size of a single block as `compress` would produce it: framework header + codec payload.
-    static UInt32 getCompressedBlockSize(const ICompressionCodec & codec, const char * src, UInt32 src_size, PODArray<char> & scratch);
-
     /// Total on-disk size of the streamed input (not a single block). Call `finalize` first.
     /// Per block it adds the 16-byte checksum on top of `getCompressedBlockSize` (per block: checksum + header + payload).
     UInt64 getCompressedBytes() const
@@ -34,6 +31,9 @@ public:
 
 private:
     void nextImpl() override;
+
+    /// Compressed size of a single block as `compress` would produce it (block header + payload).
+    static UInt32 getCompressedBlockSize(const ICompressionCodec & codec, const char * src, UInt32 src_size, PODArray<char> & scratch);
 
     CompressionCodecPtr codec;
     PODArray<char> scratch;

--- a/src/Compression/CompressedSizeCalculator.h
+++ b/src/Compression/CompressedSizeCalculator.h
@@ -19,7 +19,7 @@ public:
     explicit CompressedSizeCalculator(CompressionCodecPtr codec_ = nullptr, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE);
 
     /// Total on-disk size of the streamed input (not a single block). Call `finalize` first.
-    /// Per block it adds the 16-byte checksum on top of `getCompressedBlockSize` (per block: checksum + header + payload).
+    /// Per block: 16-byte checksum + block header + compressed payload.
     UInt64 getCompressedBytes() const
     {
         chassert(isFinalized());
@@ -31,9 +31,6 @@ public:
 
 private:
     void nextImpl() override;
-
-    /// Compressed size of a single block as `compress` would produce it (block header + payload).
-    static UInt32 getCompressedBlockSize(const ICompressionCodec & codec, const char * src, UInt32 src_size, PODArray<char> & scratch);
 
     CompressionCodecPtr codec;
     PODArray<char> scratch;

--- a/src/Compression/CompressionCodecAdaptive.cpp
+++ b/src/Compression/CompressionCodecAdaptive.cpp
@@ -113,6 +113,7 @@ UInt32 CompressionCodecAdaptive::compress(const char * source, UInt32 source_siz
     /// Otherwise, compress into `dest` if it is free, else into a lazily allocated scratch buffer.
     /// After the pass the winner reaches `dest` in one of three ways: a measured-only winner is compressed into it,
     /// a winner already there needs nothing, and a winner in scratch is copied over.
+    chassert(dest != nullptr);
     PODArray<char> scratch;
     const ICompressionCodec * best_codec = nullptr;
     char * best_compressed = nullptr;
@@ -151,6 +152,7 @@ UInt32 CompressionCodecAdaptive::compress(const char * source, UInt32 source_siz
 
     if (!best_compressed)
     {
+        chassert(best_codec);
         const UInt32 size = best_codec->compress(source, source_size, dest);
         chassert(size == best_size);
         return size;

--- a/src/Compression/CompressionCodecAdaptive.cpp
+++ b/src/Compression/CompressionCodecAdaptive.cpp
@@ -2,9 +2,10 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>
+#include <limits>
 #include <span>
 #include <string_view>
-#include <Compression/CompressedSizeCalculator.h>
 #include <Compression/CompressionFactory.h>
 #include <Core/Defines.h>
 #include <Core/TypeId.h>
@@ -99,27 +100,6 @@ bool AdaptiveCodec::isCandidateType(const IDataType & type)
     return false;
 }
 
-CompressionCodecPtr AdaptiveCodec::select(const Codecs & pool, const char * source, UInt32 source_size)
-{
-    chassert(!pool.empty());
-
-    PODArray<char> scratch;
-    size_t best_idx = 0;
-    UInt32 best_size = CompressedSizeCalculator::getCompressedBlockSize(*pool[0], source, source_size, scratch);
-
-    for (size_t i = 1; i < pool.size(); ++i)
-    {
-        const UInt32 size = CompressedSizeCalculator::getCompressedBlockSize(*pool[i], source, source_size, scratch);
-        if (size < best_size)
-        {
-            best_idx = i;
-            best_size = size;
-        }
-    }
-
-    return pool[best_idx];
-}
-
 CompressionCodecAdaptive::CompressionCodecAdaptive(const IDataType & type, const CompressionCodecPtr & deployment_default)
     : pool(AdaptiveCodec::poolForType(type, deployment_default))
 {
@@ -129,8 +109,57 @@ CompressionCodecAdaptive::CompressionCodecAdaptive(const IDataType & type, const
 
 UInt32 CompressionCodecAdaptive::compress(const char * source, UInt32 source_size, char * dest) const
 {
-    CompressionCodecPtr winner = AdaptiveCodec::select(pool, source, source_size);
-    return winner->compress(source, source_size, dest);
+    /// A single pass over the pool. A candidate that reports its compressed size cheaply is measured without compressing.
+    /// Otherwise, compress into `dest` if it is free, else into a lazily allocated scratch buffer.
+    /// After the pass the winner reaches `dest` in one of three ways: a measured-only winner is compressed into it,
+    /// a winner already there needs nothing, and a winner in scratch is copied over.
+    PODArray<char> scratch;
+    const ICompressionCodec * best_codec = nullptr;
+    char * best_compressed = nullptr;
+    UInt32 best_size = std::numeric_limits<UInt32>::max();
+
+    for (const auto & codec : pool)
+    {
+        if (auto calculated = codec->tryGetCompressedSize(source, source_size))
+        {
+            const UInt32 size = getHeaderSize() + *calculated;
+            if (size < best_size)
+            {
+                best_size = size;
+                best_codec = codec.get();
+                best_compressed = nullptr;
+            }
+        }
+        else
+        {
+            char * target = dest;
+            if (best_compressed == dest)
+            {
+                if (scratch.empty())
+                    scratch.resize_exact(getMaxCompressedDataSize(source_size));
+                target = scratch.data();
+            }
+            const UInt32 size = codec->compress(source, source_size, target);
+            if (size < best_size)
+            {
+                best_size = size;
+                best_codec = codec.get();
+                best_compressed = target;
+            }
+        }
+    }
+
+    if (!best_compressed)
+    {
+        const UInt32 size = best_codec->compress(source, source_size, dest);
+        chassert(size == best_size);
+        return size;
+    }
+
+    if (best_compressed != dest)
+        memcpy(dest, best_compressed, best_size);
+
+    return best_size;
 }
 
 UInt32 CompressionCodecAdaptive::getMaxCompressedDataSize(UInt32 uncompressed_size) const

--- a/src/Compression/CompressionCodecAdaptive.cpp
+++ b/src/Compression/CompressionCodecAdaptive.cpp
@@ -136,8 +136,7 @@ UInt32 CompressionCodecAdaptive::compress(const char * source, UInt32 source_siz
             char * target = dest;
             if (best_compressed == dest)
             {
-                if (scratch.empty())
-                    scratch.resize_exact(getMaxCompressedDataSize(source_size));
+                scratch.resize_exact(getMaxCompressedDataSize(source_size));
                 target = scratch.data();
             }
             const UInt32 size = codec->compress(source, source_size, target);

--- a/src/Compression/CompressionCodecAdaptive.cpp
+++ b/src/Compression/CompressionCodecAdaptive.cpp
@@ -65,6 +65,39 @@ CompressionCodecPtr buildCodecForType(std::string_view expr, const IDataType & t
     throw Exception(ErrorCodes::LOGICAL_ERROR, "CompressionCodecAdaptive must not be invoked directly: it never appears on disk");
 }
 
+/// Hands out destinations for candidate compressions over two buffers: the external one and a lazily allocated scratch.
+/// The buffer holding the current best is pinned: `takeWriteDestination` never hands it out.
+class CompressionDestinationMultiplexer
+{
+public:
+    CompressionDestinationMultiplexer(char * external_destination_, UInt32 internal_reserve_)
+        : external_destination(external_destination_)
+        , internal_reserve(internal_reserve_)
+    {
+    }
+
+    char * takeWriteDestination()
+    {
+        if (best_destination != external_destination)
+            return external_destination;
+
+        scratch.resize_exact(internal_reserve);
+        return scratch.data();
+    }
+
+    void recordCompression(char * to) { best_destination = to; }
+    void discardRecordedCompression() { best_destination = nullptr; }
+
+    /// nullptr: the best was measured only, never materialized.
+    char * getBestDestination() const { return best_destination; }
+
+private:
+    char * external_destination;
+    char * best_destination = nullptr;
+    UInt32 internal_reserve;
+    PODArray<char> scratch;
+};
+
 }
 
 Codecs AdaptiveCodec::poolForType(const IDataType & type, const CompressionCodecPtr & deployment_default)
@@ -110,13 +143,11 @@ CompressionCodecAdaptive::CompressionCodecAdaptive(const IDataType & type, const
 UInt32 CompressionCodecAdaptive::compress(const char * source, UInt32 source_size, char * dest) const
 {
     /// A single pass over the pool. A candidate that reports its compressed size cheaply is measured without compressing.
-    /// Otherwise, compress into `dest` if it is free, else into a lazily allocated scratch buffer.
     /// After the pass the winner reaches `dest` in one of three ways: a measured-only winner is compressed into it,
     /// a winner already there needs nothing, and a winner in scratch is copied over.
     chassert(dest != nullptr);
-    PODArray<char> scratch;
+    CompressionDestinationMultiplexer multiplexer(dest, getMaxCompressedDataSize(source_size));
     const ICompressionCodec * best_codec = nullptr;
-    char * best_compressed = nullptr;
     UInt32 best_size = std::numeric_limits<UInt32>::max();
 
     for (const auto & codec : pool)
@@ -128,26 +159,23 @@ UInt32 CompressionCodecAdaptive::compress(const char * source, UInt32 source_siz
             {
                 best_size = size;
                 best_codec = codec.get();
-                best_compressed = nullptr;
+                multiplexer.discardRecordedCompression();
             }
         }
         else
         {
-            char * target = dest;
-            if (best_compressed == dest)
-            {
-                scratch.resize_exact(getMaxCompressedDataSize(source_size));
-                target = scratch.data();
-            }
+            char * target = multiplexer.takeWriteDestination();
             const UInt32 size = codec->compress(source, source_size, target);
             if (size < best_size)
             {
                 best_size = size;
                 best_codec = codec.get();
-                best_compressed = target;
+                multiplexer.recordCompression(target);
             }
         }
     }
+
+    char * best_compressed = multiplexer.getBestDestination();
 
     if (!best_compressed)
     {

--- a/src/Compression/CompressionCodecAdaptive.h
+++ b/src/Compression/CompressionCodecAdaptive.h
@@ -16,20 +16,14 @@ namespace AdaptiveCodec
 
 /// Candidate codecs for `type`, in priority order. [0] is `NONE`: a block that no codec can shrink is stored uncompressed.
 /// [1] is the default codec, thus we get "no worse than the default" compression. Extra candidates come from a per-type table.
+/// Beyond [0] and [1], candidates must be ordered by descending decompression speed as draw in size should resolve to the fastest reads.
 Codecs poolForType(const IDataType & type, const CompressionCodecPtr & deployment_default);
-
-/// Pick the codec from `pool` whose compressed block is smallest.
-/// TODO: fold selection into `compress` and drop this function. Reserve `dest` for the best frame so far: each compress-priced
-/// candidate writes to `dest` if free, else to scratch, and an improvement is promoted into `dest`. Then every candidate is
-/// compressed at most once and only a cheap winner is recompressed.
-CompressionCodecPtr select(const Codecs & pool, const char * source, UInt32 source_size);
 
 /// The distinct types that can get a non-default codec.
 VectorWithMemoryTracking<TypeIndex> candidateTypeIndexes();
 
-/// Whether `type` has a candidate beyond `NONE` and the default. Only such types are wrapped: for the rest, selection would compress
-/// the default twice (once to measure, once to write) and could at best store a block raw, not worth the cost.
-/// TODO: once we save the compression result and reuse it, wrapping is free, wrap every type.
+/// Whether `type` has a candidate beyond `NONE` and the default. Only such types are wrapped for now.
+/// TODO: wrap every type, so a block the default expands falls back to `NONE` instead of being stored larger than raw.
 bool isCandidateType(const IDataType & type);
 
 }
@@ -45,8 +39,10 @@ public:
     uint8_t getMethodByte() const override;
     void updateHash(SipHash & hash) const override;
 
-    /// Selects the best codec for this block and delegates to it. The result carries the winner's method byte.
-    /// Runs on every block regardless of size. Selection cost scales with the block, so there is no small-block skip.
+    /// Compresses the block with whichever candidate produces the smallest output. Decompression cannot tell adaptive was involved.
+    /// Ties go to the earliest pool entry, so `NONE` beats an equal-sized compressor.
+    /// Candidates reporting their size via `tryGetCompressedSize` are compressed only if they win.
+    /// Selection cost scales with the block size, so there is no small-block skip.
     UInt32 compress(const char * source, UInt32 source_size, char * dest) const override;
 
     bool isCompression() const override { return true; }

--- a/src/Compression/tests/gtest_compression_codec_adaptive.cpp
+++ b/src/Compression/tests/gtest_compression_codec_adaptive.cpp
@@ -96,6 +96,24 @@ std::vector<char> bytesOf(const std::vector<T> & values)
     return bytes;
 }
 
+/// Compress `bytes` with the adaptive codec for `type_name` and return the winner's on-disk method byte.
+/// Round-trips the compressed block through the method-byte codec, as a normal reader would do.
+uint8_t adaptiveWinnerByte(const String & type_name, const std::vector<char> & bytes)
+{
+    const UInt32 size = static_cast<UInt32>(bytes.size());
+    CompressionCodecAdaptive adaptive(*type(type_name), defaultCodec());
+
+    PODArray<char> encoded(adaptive.getCompressedReserveSize(size));
+    const UInt32 encoded_size = adaptive.compress(bytes.data(), size, encoded.data());
+
+    const uint8_t method = ICompressionCodec::readMethod(encoded.data());
+    auto decoder = CompressionCodecFactory::instance().get(method);
+    PODArray<char> decoded(size);
+    EXPECT_EQ(decoder->decompress(encoded.data(), encoded_size, decoded.data()), size);
+    EXPECT_EQ(0, memcmp(decoded.data(), bytes.data(), size));
+    return method;
+}
+
 }
 
 TEST(AdaptiveCodecPool, EachCandidateTypeBuildsWithDefaultAnchor)
@@ -166,82 +184,31 @@ TEST(CompressionCodecFactory, IsDefaultCodec)
     EXPECT_FALSE(CompressionCodecFactory::isDefaultCodec(codec("Delta, Default")));
 }
 
-TEST(AdaptiveCodecSelector, MonotonicNarrowIntegersPickT64)
+TEST(CompressionCodecAdaptive, MonotonicNarrowIntegersPickT64)
 {
     std::vector<UInt32> values(100000);
     for (size_t i = 0; i < values.size(); ++i)
         values[i] = static_cast<UInt32>(i);
-    auto bytes = bytesOf(values);
 
-    auto pool = AdaptiveCodec::poolForType(*type("UInt32"), defaultCodec());
-    auto winner = AdaptiveCodec::select(pool, bytes.data(), static_cast<UInt32>(bytes.size()));
-    EXPECT_EQ(winner->getMethodByte(), T64);
+    EXPECT_EQ(adaptiveWinnerByte("UInt32", bytesOf(values)), T64);
 }
 
-TEST(AdaptiveCodecSelector, RepeatingWideValuesPickDefault)
+TEST(CompressionCodecAdaptive, RepeatingWideValuesPickDefault)
 {
     /// A short pattern of full-range values, repeated: LZ4 crushes the repetition, but T64 sees a wide min/max cannot shrink it.
     const std::vector<UInt32> pattern = {0u, 0xFFFFFFFFu, 0x0F0F0F0Fu, 0xF0F0F0F0u, 0x12345678u, 0x9ABCDEF0u, 0xDEADBEEFu, 0xCAFEBABEu};
     std::vector<UInt32> values(100000);
     for (size_t i = 0; i < values.size(); ++i)
         values[i] = pattern[i % pattern.size()];
-    auto bytes = bytesOf(values);
 
-    auto pool = AdaptiveCodec::poolForType(*type("UInt32"), defaultCodec());
-    auto winner = AdaptiveCodec::select(pool, bytes.data(), static_cast<UInt32>(bytes.size()));
-    EXPECT_EQ(winner->getMethodByte(), LZ4);
+    EXPECT_EQ(adaptiveWinnerByte("UInt32", bytesOf(values)), LZ4);
 }
 
-TEST(AdaptiveCodecSelector, ConstantColumnPicksT64)
+TEST(CompressionCodecAdaptive, ConstantColumnPicksT64)
 {
     std::vector<UInt32> values(100000, 42u);
-    auto bytes = bytesOf(values);
 
-    auto pool = AdaptiveCodec::poolForType(*type("UInt32"), defaultCodec());
-    auto winner = AdaptiveCodec::select(pool, bytes.data(), static_cast<UInt32>(bytes.size()));
-    EXPECT_EQ(winner->getMethodByte(), T64);
-}
-
-TEST(AdaptiveCodecSelector, TieGoesToEarliestCandidate)
-{
-    /// Two distinct but identical codecs produce the same size, the earliest must win (strict <).
-    auto lz4a = CompressionCodecFactory::instance().get("LZ4", {});
-    auto lz4b = CompressionCodecFactory::instance().get("LZ4", {});
-    ASSERT_NE(lz4a.get(), lz4b.get());
-    Codecs pool = {lz4a, lz4b};
-
-    std::vector<UInt32> values(1000);
-    for (size_t i = 0; i < values.size(); ++i)
-        values[i] = static_cast<UInt32>(i * 7);
-    auto bytes = bytesOf(values);
-
-    auto winner = AdaptiveCodec::select(pool, bytes.data(), static_cast<UInt32>(bytes.size()));
-    EXPECT_EQ(winner.get(), lz4a.get());
-    EXPECT_NE(winner.get(), lz4b.get());
-}
-
-TEST(CompressionCodecAdaptive, CompressRoundTripsViaWinnerByte)
-{
-    std::vector<UInt32> values(100000);
-    for (size_t i = 0; i < values.size(); ++i)
-        values[i] = static_cast<UInt32>(i);
-    auto bytes = bytesOf(values);
-    const UInt32 size = static_cast<UInt32>(bytes.size());
-
-    CompressionCodecAdaptive adaptive(*type("UInt32"), defaultCodec());
-
-    PODArray<char> encoded(adaptive.getCompressedReserveSize(size));
-    const UInt32 encoded_size = adaptive.compress(bytes.data(), size, encoded.data());
-
-    const uint8_t method = ICompressionCodec::readMethod(encoded.data());
-    EXPECT_EQ(method, T64); /// monotonic integers -> T64 wins
-
-    /// Decode exactly as a normal reader would: look the codec up by the on-disk method byte.
-    auto decoder = CompressionCodecFactory::instance().get(method);
-    PODArray<char> decoded(size);
-    const UInt32 decoded_size = decoder->decompress(encoded.data(), encoded_size, decoded.data());
-    ASSERT_EQ(decoded_size, size);
-    EXPECT_EQ(0, memcmp(decoded.data(), bytes.data(), size));
+    EXPECT_EQ(adaptiveWinnerByte("UInt32", bytesOf(values)), T64);
 }
 
 TEST(CompressionCodecAdaptive, TinyBlockStoredRaw)
@@ -250,14 +217,8 @@ TEST(CompressionCodecAdaptive, TinyBlockStoredRaw)
     std::vector<UInt32> values(4);
     for (size_t i = 0; i < values.size(); ++i)
         values[i] = static_cast<UInt32>(i);
-    auto bytes = bytesOf(values);
-    const UInt32 size = static_cast<UInt32>(bytes.size());
 
-    CompressionCodecAdaptive adaptive(*type("UInt32"), defaultCodec());
-
-    PODArray<char> encoded(adaptive.getCompressedReserveSize(size));
-    adaptive.compress(bytes.data(), size, encoded.data());
-    EXPECT_EQ(ICompressionCodec::readMethod(encoded.data()), NONE);
+    EXPECT_EQ(adaptiveWinnerByte("UInt32", bytesOf(values)), NONE);
 }
 
 TEST(CompressionCodecAdaptive, HashHasOwnNamespace)

--- a/src/Compression/tests/gtest_compression_codec_adaptive.cpp
+++ b/src/Compression/tests/gtest_compression_codec_adaptive.cpp
@@ -2,7 +2,6 @@
 #include <cstring>
 #include <thread>
 #include <vector>
-#include <Compression/CompressedSizeCalculator.h>
 #include <Compression/CompressionCodecAdaptive.h>
 #include <Compression/CompressionCodecMultiple.h>
 #include <Compression/CompressionFactory.h>
@@ -282,7 +281,7 @@ TEST(CompressionCodecAdaptive, ConcurrentCompressIsThreadSafe)
     EXPECT_TRUE(ok);
 }
 
-TEST(GetCompressedBlockSize, CalculateMatchesCompressForT64)
+TEST(TryGetCompressedSize, MatchesCompressForT64)
 {
     std::vector<UInt32> values(50000);
     for (size_t i = 0; i < values.size(); ++i)
@@ -295,11 +294,11 @@ TEST(GetCompressedBlockSize, CalculateMatchesCompressForT64)
     const auto & t64 = pool[2];
     ASSERT_EQ(t64->getMethodByte(), T64);
 
-    PODArray<char> scratch;
-    const UInt32 calculated = CompressedSizeCalculator::getCompressedBlockSize(*t64, bytes.data(), size, scratch);
+    const auto calculated = t64->tryGetCompressedSize(bytes.data(), size);
+    ASSERT_TRUE(calculated.has_value());
 
-    /// Re-derive size from a real compress: calculation must match exactly
+    /// Re-derive size from a real compress.
     PODArray<char> encoded(t64->getCompressedReserveSize(size));
     const UInt32 actual = t64->compress(bytes.data(), size, encoded.data());
-    EXPECT_EQ(calculated, actual);
+    EXPECT_EQ(ICompressionCodec::getHeaderSize() + *calculated, actual);
 }

--- a/src/Compression/tests/gtest_compression_codec_adaptive.cpp
+++ b/src/Compression/tests/gtest_compression_codec_adaptive.cpp
@@ -107,7 +107,10 @@ uint8_t adaptiveWinnerByte(const String & type_name, const std::vector<char> & b
 
     const uint8_t method = ICompressionCodec::readMethod(encoded.data());
     auto decoder = CompressionCodecFactory::instance().get(method);
-    PODArray<char> decoded(size);
+
+    /// Fast decompressors read and write in wide blocks past the logical end of both buffers.
+    encoded.resize(encoded_size + decoder->getAdditionalSizeAtTheEndOfBuffer());
+    PODArray<char> decoded(size + decoder->getAdditionalSizeAtTheEndOfBuffer());
     EXPECT_EQ(decoder->decompress(encoded.data(), encoded_size, decoded.data()), size);
     EXPECT_EQ(0, memcmp(decoded.data(), bytes.data(), size));
     return method;

--- a/tests/performance/adaptive_codec_merge.xml
+++ b/tests/performance/adaptive_codec_merge.xml
@@ -1,0 +1,18 @@
+<test>
+    <create_query>
+        CREATE TABLE adaptive_codec_merge (x UInt64)
+        ENGINE = MergeTree ORDER BY tuple()
+        SETTINGS allow_experimental_adaptive_codec_selection = 1
+    </create_query>
+
+    <!-- The default codec wins every block -->
+    <fill_query>SYSTEM STOP MERGES adaptive_codec_merge</fill_query>
+    <fill_query>INSERT INTO adaptive_codec_merge SELECT cityHash64(number % 1024) FROM numbers_mt(400000000)</fill_query>
+    <fill_query>SYSTEM START MERGES adaptive_codec_merge</fill_query>
+    <fill_query>OPTIMIZE TABLE adaptive_codec_merge FINAL</fill_query>
+
+    <!-- 1 -> 1 merge -->
+    <query>OPTIMIZE TABLE adaptive_codec_merge FINAL</query>
+
+    <drop_query>DROP TABLE IF EXISTS adaptive_codec_merge</drop_query>
+</test>

--- a/tests/performance/adaptive_codec_merge.xml
+++ b/tests/performance/adaptive_codec_merge.xml
@@ -7,7 +7,7 @@
 
     <!-- The default codec wins every block -->
     <fill_query>SYSTEM STOP MERGES adaptive_codec_merge</fill_query>
-    <fill_query>INSERT INTO adaptive_codec_merge SELECT cityHash64(number % 1024) FROM numbers_mt(400000000)</fill_query>
+    <fill_query>INSERT INTO adaptive_codec_merge SELECT cityHash64(number % 1024) FROM numbers_mt(150000000)</fill_query>
     <fill_query>SYSTEM START MERGES adaptive_codec_merge</fill_query>
     <fill_query>OPTIMIZE TABLE adaptive_codec_merge FINAL</fill_query>
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Adaptive compression used to have two phases: selection and compression. During selection, we compressed every candidate that cannot report its compressed size cheaply into a temporary buffer to measure it. If such a candidate won, the compression phase then compressed it again.

This fuses selection into compression. We do a single pass in which candidates with cheap sizing are only measured, and the rest compress into `dest`, or into a scratch buffer when `dest` holds the best result so far. After the pass the winner reaches `dest` one of three ways: it is already there, it is copied from scratch, or, for a measured-only winner, it is compressed now, for the first and only time. With today's pool this halves the compression work whenever the default codec wins a block.

Not for changelog because adaptive compression is released in 26.8 (https://github.com/ClickHouse/ClickHouse/pull/111834).


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Adaptive codec selection now compresses with each candidate codec at most once per block instead of measuring all candidates and then recompressing the winner.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113511&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/113511](https://github.com/search?q=head%3Async-upstream%2Fpr%2F113511+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1671` (included in `26.8` and later)
<!-- ch-version-info:end -->