### PR TITLE
Refresh the least_used JBOD queue's cached free space

### DIFF
--- a/src/Disks/VolumeJBOD.cpp
+++ b/src/Disks/VolumeJBOD.cpp
@@ -1,5 +1,6 @@
 #include <Disks/VolumeJBOD.h>
 
+#include <base/scope_guard.h>
 #include <Common/StringUtils.h>
 #include <Common/formatReadable.h>
 #include <Common/quoteString.h>
@@ -172,9 +173,12 @@ ReservationPtr VolumeJBOD::reserveImpl(UInt64 bytes, const std::optional<Reserva
 
                 DiskWithSize disk = disks_by_size.top();
                 disks_by_size.pop();
+                /// try_reserve may throw (e.g. statvfs failure), and losing the entry would
+                /// eventually make top() a call on an empty queue.
+                auto restore_entry = make_scope_guard(
+                    [&]() TSA_NO_THREAD_SAFETY_ANALYSIS { disks_by_size.push(disk); });
 
                 reservation = disk.reserve(try_reserve);
-                disks_by_size.push(disk);
             }
 
             return reservation;

--- a/src/Disks/VolumeJBOD.cpp
+++ b/src/Disks/VolumeJBOD.cpp
@@ -168,18 +168,13 @@ ReservationPtr VolumeJBOD::reserveImpl(UInt64 bytes, const std::optional<Reserva
                 {
                     disks_by_size = LeastUsedDisksQueue(disks.begin(), disks.end());
                     least_used_update_watch.restart();
-
-                    DiskWithSize disk = disks_by_size.top();
-                    reservation = try_reserve(disk.disk);
                 }
-                else
-                {
-                    DiskWithSize disk = disks_by_size.top();
-                    disks_by_size.pop();
 
-                    reservation = try_reserve(disk.disk);
-                    disks_by_size.push(disk);
-                }
+                DiskWithSize disk = disks_by_size.top();
+                disks_by_size.pop();
+
+                reservation = disk.reserve(try_reserve);
+                disks_by_size.push(disk);
             }
 
             return reservation;

--- a/src/Disks/VolumeJBOD.h
+++ b/src/Disks/VolumeJBOD.h
@@ -104,7 +104,10 @@ private:
 
             /// Not just subtract bytes, but update the value,
             /// since some reservations may be done directly via IDisk, or not by ClickHouse.
-            free_size = reservation->getUnreservedSpace();
+            /// A disk reporting no free space limit stays unlimited: its reservation carries no
+            /// meaningful value, and an engaged 0 would outrank every unlimited sibling.
+            if (free_size.has_value())
+                free_size = reservation->getUnreservedSpace();
             return reservation;
         }
     };

--- a/src/Disks/VolumeJBOD.h
+++ b/src/Disks/VolumeJBOD.h
@@ -95,9 +95,10 @@ private:
             return free_size < rhs.free_size;
         }
 
-        ReservationPtr reserve(UInt64 bytes)
+        template <typename TryReserve>
+        ReservationPtr reserve(TryReserve && try_reserve)
         {
-            ReservationPtr reservation = disk->reserve(bytes);
+            ReservationPtr reservation = try_reserve(disk);
             if (!reservation)
                 return {};
 

--- a/tests/integration/test_jbod_load_balancing/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_jbod_load_balancing/configs/config.d/storage_configuration.xml
@@ -35,6 +35,19 @@
                     </disks>
                 </volumes>
             </jbod_least_used>
+            <jbod_least_used_default_ttl>
+                <volumes>
+                    <disks>
+                        <disk>jbod1</disk>
+                        <disk>jbod2</disk>
+                        <disk>jbod3</disk>
+
+                        <load_balancing>least_used</load_balancing>
+                        <!-- least_used_ttl_ms is deliberately not set here, so the default
+                             (60000) applies and the cached queue is actually consulted. -->
+                    </disks>
+                </volumes>
+            </jbod_least_used_default_ttl>
         </policies>
     </storage_configuration>
 </clickhouse>

--- a/tests/integration/test_jbod_load_balancing/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_jbod_load_balancing/configs/config.d/storage_configuration.xml
@@ -10,6 +10,15 @@
             <jbod3>
                 <path>/test_jbod_load_balancing_jbod3/</path>
             </jbod3>
+            <!-- Object storage disks report no free space limit, unlike the tmpfs disks above. -->
+            <blob1>
+                <type>local_blob_storage</type>
+                <path>/var/lib/clickhouse/test_jbod_load_balancing_blob1/</path>
+            </blob1>
+            <blob2>
+                <type>local_blob_storage</type>
+                <path>/var/lib/clickhouse/test_jbod_load_balancing_blob2/</path>
+            </blob2>
         </disks>
         <policies>
             <jbod_round_robin>
@@ -48,6 +57,17 @@
                     </disks>
                 </volumes>
             </jbod_least_used_default_ttl>
+            <blob_least_used>
+                <volumes>
+                    <disks>
+                        <disk>blob1</disk>
+                        <disk>blob2</disk>
+
+                        <load_balancing>least_used</load_balancing>
+                        <!-- Default least_used_ttl_ms, as in jbod_least_used_default_ttl. -->
+                    </disks>
+                </volumes>
+            </blob_least_used>
         </policies>
     </storage_configuration>
 </clickhouse>

--- a/tests/integration/test_jbod_load_balancing/test.py
+++ b/tests/integration/test_jbod_load_balancing/test.py
@@ -195,6 +195,109 @@ def test_jbod_load_balancing_least_used_default_ttl(start_cluster):
         node.query("DROP TABLE IF EXISTS data_least_used_default_ttl SYNC")
 
 
+def test_jbod_load_balancing_least_used_blob_storage(start_cluster):
+    # Same cached-queue behaviour as the test above, but on disks that report no free space
+    # limit at all. Their reservations carry no free-space value either, so the refresh has
+    # to leave such a disk unlimited; an unlimited disk that starts reporting a concrete
+    # number sorts above every untouched sibling and wins every reservation from then on.
+    #
+    # No out-of-space assertion is possible here, since these disks never run out. What must
+    # hold is that the parts still get spread.
+    node.query("SYSTEM RELOAD CONFIG")
+    try:
+        node.query(
+            """
+            CREATE TABLE data_least_used_blob
+            (
+                s String CODEC(NONE)
+            )
+            ENGINE = MergeTree
+            ORDER BY tuple()
+            SETTINGS storage_policy = 'blob_least_used';
+
+            SYSTEM STOP MERGES data_least_used_blob;
+            """
+        )
+
+        for _ in range(8):
+            node.query(
+                """
+                INSERT INTO data_least_used_blob
+                SELECT repeat('a', 100) FROM numbers(1e4) SETTINGS max_insert_threads = 1;
+                """
+            )
+
+        total, disks_used = (
+            node.query(
+                """
+                SELECT count(), uniqExact(disk_name)
+                FROM system.parts
+                WHERE table = 'data_least_used_blob' AND active
+                """
+            )
+            .strip()
+            .split("\t")
+        )
+        assert int(total) == 8
+        assert int(disks_used) >= 2
+    finally:
+        node.query("DROP TABLE IF EXISTS data_least_used_blob SYNC")
+
+
+def test_jbod_load_balancing_least_used_constraints(start_cluster):
+    # min_free_disk_bytes_to_perform_insert routes the insert through the constrained
+    # reservation path. The floor is above every disk's capacity, so no disk can satisfy it
+    # and the insert has to be rejected: a reservation that ignored the constraint would
+    # succeed on the largest disk instead.
+    node.query("SYSTEM RELOAD CONFIG")
+    try:
+        node.query(
+            """
+            CREATE TABLE data_least_used_constraints
+            (
+                s String CODEC(NONE)
+            )
+            ENGINE = MergeTree
+            ORDER BY tuple()
+            SETTINGS storage_policy = 'jbod_least_used_default_ttl';
+
+            SYSTEM STOP MERGES data_least_used_constraints;
+            """
+        )
+
+        # The volume's largest disk is 300MiB, so a 400MiB floor is unsatisfiable everywhere.
+        with pytest.raises(Exception) as exc_info:
+            node.query(
+                """
+                INSERT INTO data_least_used_constraints
+                SELECT repeat('a', 100) FROM numbers(6e5)
+                SETTINGS max_insert_threads = 1, min_free_disk_bytes_to_perform_insert = 419430400;
+                """
+            )
+        assert "min_free_disk_bytes_to_perform_insert" in str(exc_info.value)
+
+        # Without the floor the same insert fits, so the rejection above is the constraint's
+        # doing and not the volume being out of space.
+        node.query(
+            """
+            INSERT INTO data_least_used_constraints
+            SELECT repeat('a', 100) FROM numbers(6e5) SETTINGS max_insert_threads = 1;
+            """
+        )
+        assert (
+            node.query(
+                """
+                SELECT count()
+                FROM system.parts
+                WHERE table = 'data_least_used_constraints' AND active
+                """
+            ).strip()
+            == "1"
+        )
+    finally:
+        node.query("DROP TABLE IF EXISTS data_least_used_constraints SYNC")
+
+
 def test_jbod_load_balancing_least_used_detect_background_changes(start_cluster):
     def get_parts_on_disks():
         parts = node.query(

--- a/tests/integration/test_jbod_load_balancing/test.py
+++ b/tests/integration/test_jbod_load_balancing/test.py
@@ -140,6 +140,61 @@ def test_jbod_load_balancing_least_used_next_disk(start_cluster):
         node.query("DROP TABLE IF EXISTS data_least_used_next_disk SYNC")
 
 
+def test_jbod_load_balancing_least_used_default_ttl(start_cluster):
+    # The other least_used tests pin least_used_ttl_ms = 0, which rebuilds the volume's
+    # disk queue on every reservation. This one leaves the setting at its default so the
+    # cached queue is the thing under test: five 62MiB parts fit the volume (600MiB) but
+    # not any single disk, so placement has to move on once a disk fills up.
+    #
+    # The reload re-creates the volume, re-seeding its cached per-disk free space from
+    # statvfs, so a repeated run does not inherit the previous run's cache. It is fixture
+    # isolation only: with the reload in place this test still fails on an unfixed server.
+    node.query("SYSTEM RELOAD CONFIG")
+    try:
+        node.query(
+            """
+            CREATE TABLE data_least_used_default_ttl
+            (
+                s String CODEC(NONE)
+            )
+            ENGINE = MergeTree
+            ORDER BY tuple()
+            SETTINGS storage_policy = 'jbod_least_used_default_ttl';
+
+            SYSTEM STOP MERGES data_least_used_default_ttl;
+            """
+        )
+
+        # Sequential inserts, one thread each, so every reservation observes the previous
+        # part already finalized.
+        for _ in range(5):
+            node.query(
+                """
+                INSERT INTO data_least_used_default_ttl
+                SELECT repeat('a', 100) FROM numbers(6e5) SETTINGS max_insert_threads = 1;
+                """
+            )
+
+        # Exact placement is not asserted: which disk wins depends on how many bytes each
+        # part rounds up to. What must hold is that the parts get spread instead of piling
+        # onto one disk until it is full.
+        total, disks_used = (
+            node.query(
+                """
+                SELECT count(), uniqExact(disk_name)
+                FROM system.parts
+                WHERE table = 'data_least_used_default_ttl' AND active
+                """
+            )
+            .strip()
+            .split("\t")
+        )
+        assert int(total) == 5
+        assert int(disks_used) >= 2
+    finally:
+        node.query("DROP TABLE IF EXISTS data_least_used_default_ttl SYNC")
+
+
 def test_jbod_load_balancing_least_used_detect_background_changes(start_cluster):
     def get_parts_on_disks():
         parts = node.query(


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/56030
Related: https://github.com/ClickHouse/ClickHouse/pull/90878
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a JBOD volume with `load_balancing = least_used` placing every new part on a single disk, and eventually rejecting valid `INSERT`s with `NOT_ENOUGH_SPACE` while sibling disks in the same volume were still empty, because the volume's cached per-disk free space was never refreshed after a successful reservation.


### Description

A `least_used` volume orders its disks in a priority queue by a cached free-space value, so choosing the emptiest disk costs no `statvfs`. That cache must be updated when a reservation succeeds, or the disk just reserved on still compares as emptiest and wins again.

`DiskWithSize::reserve` did that update, but it hard-coded `disk->reserve(bytes)` and could not carry the reservation constraints added later, so both call sites were changed to call `disk.disk->reserve(...)` directly, leaving the method with no callers and the cache never refreshed. The queue then only changes on a wholesale rebuild gated on `least_used_ttl_ms` (default `60000`), so for a minute every part goes to one disk; once it is full the reservation fails.

The fix makes `DiskWithSize::reserve` take `reserveImpl`'s existing `try_reserve` callable, so it honours the constraints, and routes the `LEAST_USED` path through it. The rebuild branch reserved on a copy of `top()` without popping it, discarding its refresh too; popping there collapses the two branches. `reservation->getUnreservedSpace()` reads a value already stored on `DiskLocalReservation`, so this adds no `statvfs` call. A scope guard restores the popped entry, so a throwing `try_reserve` cannot drop it.

A disk reporting no free-space limit stays unlimited, so an object-storage `least_used` volume keeps rotating: `DiskObjectStorage` answers `nullopt`, and its reservation cannot substitute, since `DiskObjectStorageReservation` never populates the `unreserved_space` member it returns.

Three new integration tests cover tmpfs disks of 100/200/300 MiB at the default TTL, two `local_blob_storage` disks, and a `min_free_disk_bytes_to_perform_insert` floor no disk can meet. Each fails without its half of the change, 50 out of 50 with it. The four existing tests are unmodified and pass; the three `least_used` ones pin `least_used_ttl_ms = 0`.

Unchanged: the `LEAST_USED` loop does not advance past a disk that refuses on space, since the refused entry keeps its cached value and stays the queue top.

<details>
<summary>Measured validation matrix</summary>

Build IDs asserted (`SELECT lower(buildId())` against `readelf`) before every verdict.

Each test issues `SYSTEM RELOAD CONFIG` first, so repeated runs in one server session do not inherit the previous run's cache. That is fixture isolation, not masking: with the reload in place they still fail on an unfixed build.

Whole suite (7 tests), each arm's Build ID asserted:

| build | result |
|---|---|
| with the change | 7 passed |
| unmodified master | 1 failed (`…_default_ttl`, `Code: 243`), 6 passed |
| refresh reverted | 1 failed (`…_default_ttl`), 6 passed |
| refresh unguarded for unlimited disks | 1 failed (`…_blob_storage`, 1 disk not 2), 6 passed |
| constraints dropped from the refresh | 1 failed (`…_constraints`, insert not rejected), 6 passed |

Each half of the change is pinned by exactly one test, and no mutant reddens another's.

Disk sizes, default TTL, 5 sequential inserts:

| sizes (MiB) | with the change | unmodified |
|---|---|---|
| 100/200/300 | ok, 2 disks | `Code: 243`, 1 disk |
| 300/200/100 | ok, 2 disks | `Code: 243`, 1 disk |
| 200/200/200 | ok, 3 disks | ok, 3 disks |

Equal-sized disks tie-rotate in the heap and so cannot show the problem; the fixture uses unequal disks deliberately.

`least_used_ttl_ms`, disks 100/200/300 MiB:

| ttl | with the change | unmodified |
|---|---|---|
| 0 | ok, 2 disks | ok, 2 disks |
| 1000 | ok, 2 disks | ok 6 of 9, `Code: 243` in 3 |
| 60000 (default) | ok, 2 disks | `Code: 243` |
| 300000 | ok, 2 disks | `Code: 243` |

A 1000 ms TTL is borderline rather than safe: the five reserves are about 210 ms apart, so whether a rebuild lands inside the run is a race.

Two `local_blob_storage` disks, default TTL, 8 sequential inserts:

| build | disks used |
|---|---|
| with the change | 2 |
| unmodified master | 2 |
| refresh unguarded for unlimited disks | 1 |

</details>