### PR TITLE
Enable lazy text index posting list apply mode by default

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8443,10 +8443,11 @@ Using the text index header cache can significantly reduce latency and increase 
 Whether to cache deserialized text index deserialized posting lists in memory.
 Using the text index postings cache can significantly reduce latency and increase throughput when working with a large number of text index queries.
 )", 0) \
-    DECLARE(TextIndexPostingListApplyMode, text_index_posting_list_apply_mode, TextIndexPostingListApplyMode::MATERIALIZE, R"(
+    DECLARE(TextIndexPostingListApplyMode, text_index_posting_list_apply_mode, TextIndexPostingListApplyMode::LAZY, R"(
 Controls how posting lists are applied during text index queries.
-'materialize' (default) eagerly decodes posting lists into Roaring Bitmaps.
-'lazy' uses cursor-based on-demand decoding (requires an index format with a serialized codec).
+'materialize' eagerly decodes posting lists into Roaring Bitmaps.
+'lazy' (default) uses cursor-based on-demand decoding (requires an index format with a serialized codec).
+'lazy' is applied only where it is supported: queries with patterns (such as `LIKE`) and parts with an index written by an older version fall back to 'materialize'.
 )", 0) \
     DECLARE_WITH_ALIAS(Float, text_index_lazy_intersection_density_threshold, 0.2f, R"(
 Posting list density threshold that selects the intersection algorithm in lazy posting list apply mode (`text_index_posting_list_apply_mode = 'lazy'`).

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -70,6 +70,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"distributed_cache_min_inflight_bytes_to_discard_connection_on_seek", 0, 4 * 1024 * 1024, "New setting to drop and reopen a distributed cache connection on a seek when too many in-flight bytes would otherwise be discarded. Defaults to 4 MiB; 0 restores the previous behavior (always reuse the connection via the read range id)."},
             {"input_format_parquet_spatial_filter_push_down", false, true, "New setting: skip GeoParquet row groups and pages based on spatial predicates and bounding box statistics"},
             {"use_text_index_negative_tokens_cache", false, true, "New setting to cache absent text index tokens and avoid repeated dictionary lookups."},
+            {"text_index_posting_list_apply_mode", "materialize", "lazy", "Text index queries now decode posting lists on demand with a cursor instead of materializing them into Roaring Bitmaps, which reduces memory usage and CPU time for selective queries."},
         });
         addSettingsChanges(settings_changes_history, "26.7",
         {

--- a/tests/queries/0_stateless/04075_text_index_apply_mode.reference
+++ b/tests/queries/0_stateless/04075_text_index_apply_mode.reference
@@ -1,4 +1,4 @@
-Test text_index_posting_list_apply_mode = materialize (default)
+Test text_index_posting_list_apply_mode = materialize
 101	Alick a01
 106	Alick a06
 111	Alick b01
@@ -6,7 +6,7 @@ Test text_index_posting_list_apply_mode = materialize (default)
 101	Alick a01
 101	Alick a01
 111	Alick b01
-Test text_index_posting_list_apply_mode = lazy
+Test text_index_posting_list_apply_mode = lazy (default)
 101	Alick a01
 106	Alick a06
 111	Alick b01

--- a/tests/queries/0_stateless/04075_text_index_apply_mode.sql
+++ b/tests/queries/0_stateless/04075_text_index_apply_mode.sql
@@ -2,7 +2,7 @@ SET enable_full_text_index = 1;
 SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;
 
 ----------------------------------------------------
-SELECT 'Test text_index_posting_list_apply_mode = materialize (default)';
+SELECT 'Test text_index_posting_list_apply_mode = materialize';
 
 DROP TABLE IF EXISTS tab_mode;
 
@@ -25,7 +25,7 @@ SET text_index_posting_list_apply_mode = 'materialize';
 SELECT * FROM tab_mode WHERE s LIKE '%01%' ORDER BY k;
 
 ----------------------------------------------------
-SELECT 'Test text_index_posting_list_apply_mode = lazy';
+SELECT 'Test text_index_posting_list_apply_mode = lazy (default)';
 
 -- lazy mode: search with hasToken
 SET text_index_posting_list_apply_mode = 'lazy';


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry:
`text_index_posting_list_apply_mode` now defaults to `lazy`, so text index queries decode posting lists on demand at packed-block granularity with a cursor instead of eagerly materializing them into bitmaps for text indexes with set `posting_list_codec`.
