### PR TITLE
Fix a restart hazard in test `04626_s3_base_setting` under the stress test

### DIFF
--- a/tests/queries/0_stateless/04626_s3_base_setting.sh
+++ b/tests/queries/0_stateless/04626_s3_base_setting.sh
@@ -42,11 +42,11 @@ ${CLICKHOUSE_CLIENT} -q "DROP TABLE test_s3_base"
 
 echo '--- S3 table engine from a named collection with a relative URL, resolved URL is materialized into the DDL'
 NC="nc_${CLICKHOUSE_TEST_UNIQUE_NAME}"
-# Drop a leftover table from an interrupted previous run before dropping the named collection it
-# references, for the same reason as at the end of the test.
-${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS test_s3_base_nc"
-${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION IF EXISTS ${NC}"
-${CLICKHOUSE_CLIENT} -q "CREATE NAMED COLLECTION ${NC} AS url = '${FILE}', access_key_id = 'test', secret_access_key = 'testtest', format = 'TSV'"
+# Never drop the named collection here: an interrupted previous run can leave both the collection and
+# the table behind, and dropping only the collection is exactly the broken state described at the end
+# of the test. Reuse a leftover collection instead of recreating it - its contents are deterministic -
+# and let the `DROP TABLE IF EXISTS` below remove a leftover table.
+${CLICKHOUSE_CLIENT} -q "CREATE NAMED COLLECTION IF NOT EXISTS ${NC} AS url = '${FILE}', access_key_id = 'test', secret_access_key = 'testtest', format = 'TSV'"
 ${CLICKHOUSE_CLIENT} -q "SET s3_base = '${BUCKET_URL}/'; DROP TABLE IF EXISTS test_s3_base_nc; CREATE TABLE test_s3_base_nc (n UInt32, s String) ENGINE = S3(${NC});"
 ${CLICKHOUSE_CLIENT} -q "SHOW CREATE TABLE test_s3_base_nc FORMAT TabSeparatedRaw" | grep -cF "url = '${BUCKET_URL}/${FILE}'"
 # The table must survive DETACH/ATTACH in a session where s3_base is not set.

--- a/tests/queries/0_stateless/04626_s3_base_setting.sh
+++ b/tests/queries/0_stateless/04626_s3_base_setting.sh
@@ -42,6 +42,9 @@ ${CLICKHOUSE_CLIENT} -q "DROP TABLE test_s3_base"
 
 echo '--- S3 table engine from a named collection with a relative URL, resolved URL is materialized into the DDL'
 NC="nc_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+# Drop a leftover table from an interrupted previous run before dropping the named collection it
+# references, for the same reason as at the end of the test.
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS test_s3_base_nc"
 ${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION IF EXISTS ${NC}"
 ${CLICKHOUSE_CLIENT} -q "CREATE NAMED COLLECTION ${NC} AS url = '${FILE}', access_key_id = 'test', secret_access_key = 'testtest', format = 'TSV'"
 ${CLICKHOUSE_CLIENT} -q "SET s3_base = '${BUCKET_URL}/'; DROP TABLE IF EXISTS test_s3_base_nc; CREATE TABLE test_s3_base_nc (n UInt32, s String) ENGINE = S3(${NC});"
@@ -50,8 +53,11 @@ ${CLICKHOUSE_CLIENT} -q "SHOW CREATE TABLE test_s3_base_nc FORMAT TabSeparatedRa
 ${CLICKHOUSE_CLIENT} -q "DETACH TABLE test_s3_base_nc"
 ${CLICKHOUSE_CLIENT} -q "ATTACH TABLE test_s3_base_nc"
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM test_s3_base_nc"
-${CLICKHOUSE_CLIENT} -q "DROP TABLE test_s3_base_nc"
-${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION ${NC}"
+# Drop the named collection only after the table drop has succeeded. Under the stress test the
+# server can be killed mid-test; the failed `DROP TABLE` is then skipped while the `DROP NAMED
+# COLLECTION` succeeds against the restarted server, leaving a table whose `ATTACH` references a
+# missing named collection — and the next server restart fails to load metadata.
+${CLICKHOUSE_CLIENT} -q "DROP TABLE test_s3_base_nc" && ${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION ${NC}"
 
 echo '--- s3_base without a scheme is an error'
 ${CLICKHOUSE_CLIENT} -q "SELECT * FROM s3('${FILE}', 'test', 'testtest', 'TSV', 'n UInt32, s String') SETTINGS s3_base = 'localhost:11111/test/'" 2>&1 | grep -oF 'must contain a scheme' | head -1


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix a restart hazard in the stateless test `04626_s3_base_setting` under the stress test: when the server is killed on the test's `DROP TABLE test_s3_base_nc`, the failed drop is skipped while the following `DROP NAMED COLLECTION` succeeds against the restarted server, leaving a table whose `ATTACH` references a missing named collection. The next server restart then fails to load metadata with `NAMED_COLLECTION_DOESNT_EXIST` ("Cannot start clickhouse-server").

The test now never drops the named collection while a table can still reference it:
- the final `DROP NAMED COLLECTION` is chained on the success of `DROP TABLE`;
- the setup does not drop the collection at all - `CREATE NAMED COLLECTION IF NOT EXISTS` reuses a collection left over from an interrupted previous run (its contents are deterministic), and the `DROP TABLE IF EXISTS` that already precedes `CREATE TABLE` in the same client invocation removes a leftover table.

`DROP NAMED COLLECTION` does refuse to drop a collection a table depends on (`NAMED_COLLECTION_IS_USED`), but that check cannot save this test: with `async_load_databases` enabled by default, a table restored after the restart may not be attached yet when the drop runs, so no dependency is registered for it.

Seen in `Stress test (amd_msan)` on an unrelated pull request: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105249&sha=d7f7bec8860b2f5dfe789e97cfc9713006f21b86&name_0=PR&name_1=Stress%20test%20%28amd_msan%29

Related: https://github.com/ClickHouse/ClickHouse/pull/105249
