### PR TITLE
Make test_server_overload deterministic instead of probabilistic

### DIFF
--- a/tests/integration/test_server_overload/configs/early_drop.xml
+++ b/tests/integration/test_server_overload/configs/early_drop.xml
@@ -1,5 +1,8 @@
 <clickhouse>
     <os_cpu_busy_time_threshold>300000</os_cpu_busy_time_threshold>
     <min_os_cpu_wait_time_ratio_to_drop_connection>1.0</min_os_cpu_wait_time_ratio_to_drop_connection>
-    <max_os_cpu_wait_time_ratio_to_drop_connection>6.0</max_os_cpu_wait_time_ratio_to_drop_connection>
+    <!-- The drop probability ramps linearly from min to max ratio, so it only reaches 1 at
+         max ratio. Keep max below the wait/busy ratio the synthetic load produces, so an
+         overloaded window always drops instead of rolling dice. -->
+    <max_os_cpu_wait_time_ratio_to_drop_connection>1.5</max_os_cpu_wait_time_ratio_to_drop_connection>
 </clickhouse>

--- a/tests/integration/test_server_overload/test.py
+++ b/tests/integration/test_server_overload/test.py
@@ -41,9 +41,12 @@ def test_overload(started_cluster):
 
     for i in range(60):
         try:
-            node1.query("select 1 settings min_os_cpu_wait_time_ratio_to_throw=1, max_os_cpu_wait_time_ratio_to_throw=6")
+            # Max ratio is below the wait/busy ratio the load above produces, so the
+            # probability ramp saturates at 1 and an overloaded server always throws.
+            node1.query("select 1 settings min_os_cpu_wait_time_ratio_to_throw=1, max_os_cpu_wait_time_ratio_to_throw=1.5")
         except QueryRuntimeException as ex:
             assert "(SERVER_OVERLOADED)" in str(ex), "Only server overloaded error is expected"
+            assert "probability used to decide whether to discard the query 1." in str(ex), "Expected the throw probability to be saturated at 1, not a lucky Bernoulli draw"
             wait_for_queries() # Needed for flaky check to make sure CPU is not loaded with queries from previous runs
             return
         time.sleep(0.3)
@@ -68,6 +71,7 @@ def test_drop_connections(started_cluster):
             assert "Connection reset by peer" in str(ex), "Only connection drop is expected"
             assert node2.contains_in_log("CPU is overloaded, CPU is waiting for execution way more than executing"), "Expected server overloaded error in the log"
             assert node2.contains_in_log("probability used to decide whether to drop the connection"), "Expected message that the connection was dropped due to server overload in the log"
+            assert node2.contains_in_log("probability used to decide whether to drop the connection 1."), "Expected the drop probability to be saturated at 1, not a lucky Bernoulli draw"
             wait_for_queries() # Needed for flaky check to make sure CPU is not loaded with queries from previous runs
             return
         time.sleep(0.3)


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/112878
-->

Related: #112878

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`test_server_overload/test.py::test_drop_connections` fails intermittently with
`Expected to drop the connection due to the server being overloaded at least once`
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112878&sha=8f9de6fcea91353218cef07111e5cfe32380143d&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%201%2F6%29)).

Root cause: the test asserts an event it only makes probable. `checkCPUOverload` computes
`probability_to_throw = (clamp(cpu_load, min, max) - min) / (max - min)`, so it reaches 1 only
once `cpu_load >= max_ratio`. The test configured `min=1.0, max=6.0`, demanding a wait/busy
ratio of 6.0 for a certain drop while its own load produces 3.3 to 5.3. Every probe was a coin
flip near p=0.5, which is why #96106, doubling the probe count and load duration, did not help:
more attempts do not remove the dice.

I instrumented `checkCPUOverload` locally and sampled every accept-path evaluation with a probe
loop that does not stop at the first drop. Over 318 loaded evaluations at the shape the test
runs, the probability never once reached 1 (mean 0.53); the Bernoulli model is exact, predicting
67.0 drops where 63 occurred.

This change puts `max_ratio` below the achievable ratio (6.0 to 1.5) so an overloaded window
always drops, and both tests now assert the logged probability is 1. One loaded probe then
suffices, and probe count, pacing and metric reset phase stop mattering. The sibling
`test_overload` gets the same treatment.

The test becomes stricter, not weaker. The `busy_delta > os_cpu_busy_time_threshold`
precondition is untouched, so an idle server still yields `cpu_load == 0` and is not dropped:
over 254 idle probes that gate held every time with a 4x margin. Both `contains_in_log`
assertions and the `Connection reset by peer` check are unchanged.

Validation: 50 randomized repetitions of both cases pass, with the log now reporting
`probability used to decide whether to drop the connection 1`. Five mutants each turn the test
red, including removing the load, reverting only `max_ratio`, and neutering the accept-path
filter in `Server.cpp`.