### PR TITLE
Fix flaky test_tcp_handler_connection_limits

### DIFF
--- a/tests/integration/test_tcp_handler_connection_limits/test.py
+++ b/tests/integration/test_tcp_handler_connection_limits/test.py
@@ -1,6 +1,5 @@
 import pytest
 import subprocess
-import time
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
@@ -13,11 +12,6 @@ def started_cluster():
         yield cluster
     finally:
         cluster.shutdown()
-
-@pytest.fixture(scope="module", autouse=True)
-def stabilize_container(started_cluster):
-    """Wait for container startup processes to complete before running tests"""
-    time.sleep(1)
 
 def execute_queries_persistent_connection(queries):
     """Execute multiple queries through a single persistent clickhouse-client connection"""
@@ -34,17 +28,19 @@ def execute_queries_persistent_connection(queries):
 
     return stdout, stderr
 
-def get_connection_done_count():
-    try:
-        log_result = node.exec_in_container(
-            ["grep", "-c", "Done processing connection", "/var/log/clickhouse-server/clickhouse-server.log"]
-        )
-        return int(log_result.strip())
-    except Exception:
-        return 0
+def get_limit_closed_count(reason):
+    """Count the connections that the server closed because a limit was reached.
+
+    Counting every closed connection instead would be racy: the readiness probe of
+    `cluster.start` connects to the port and closes it without sending any data, and the
+    server accepts that connection only once it starts serving, which can happen after the
+    test has already sampled the initial count. Connections closed for other reasons never
+    report a limit, so counting only those keeps the assertion exact.
+    """
+    return int(node.count_in_log(f"Closing connection due to limits: {reason}").strip())
 
 def test_query_count_limit(started_cluster):
-    initial_count = get_connection_done_count()
+    initial_count = get_limit_closed_count("queries=")
 
     queries = ["SELECT 1;", "SELECT 2;", "SELECT 3;", "SELECT 4;", "SELECT 5;"]
     stdout, stderr = execute_queries_persistent_connection(queries)
@@ -53,11 +49,11 @@ def test_query_count_limit(started_cluster):
     assert "4" not in stdout and "5" not in stdout
     assert "TCP_CONNECTION_LIMIT_REACHED" in stderr
 
-    final_count = get_connection_done_count()
+    final_count = get_limit_closed_count("queries=")
     assert final_count == initial_count + 1, f"Expected exactly 1 connection closure, got {final_count - initial_count}"
 
 def test_time_limit(started_cluster):
-    initial_count = get_connection_done_count()
+    initial_count = get_limit_closed_count("elapsed=")
 
     queries = ["SELECT sleep(3);", "SELECT 1;", "SELECT 2;"]
     stdout, stderr = execute_queries_persistent_connection(queries)
@@ -65,5 +61,5 @@ def test_time_limit(started_cluster):
     assert "1" not in stdout and "2" not in stdout
     assert "TCP_CONNECTION_LIMIT_REACHED" in stderr
 
-    final_count = get_connection_done_count()
+    final_count = get_limit_closed_count("elapsed=")
     assert final_count == initial_count + 1, f"Expected exactly 1 connection closure, got {final_count - initial_count}"

--- a/tests/integration/test_tcp_handler_connection_limits/test.py
+++ b/tests/integration/test_tcp_handler_connection_limits/test.py
@@ -9,6 +9,11 @@ node = cluster.add_instance("node", main_configs=["configs/config.d/tcp_connecti
 def started_cluster():
     try:
         cluster.start()
+        # `cluster.start` only waits until the TCP port completes a handshake, which the
+        # kernel does as soon as the socket is listening - the server can still be starting
+        # up and not accepting yet. Wait until a query actually goes through, so that the
+        # connection of a test is not queued behind the rest of the startup.
+        node.query("SELECT 1")
         yield cluster
     finally:
         cluster.shutdown()


### PR DESCRIPTION
`test_tcp_handler_connection_limits` counted every `Done processing connection.` message in the server log and asserted that its own connection was the only one that closed. Two unrelated connections break that count.

The readiness probe of `cluster.start` connects to the TCP port and closes it without sending any data. The port is bound and listening from `createServers` onwards, so the kernel completes the handshake long before the server starts accepting; the probe is served only once startup finishes, which can be after the test has already sampled the initial count. That is the MSan failure, where startup takes seconds:

```
Application: Ready for connections.
TCPHandlerFactory: TCP Request. Address: 172.16.2.1:59612
TCPHandler: Client has not sent any data.
TCPHandler: Done processing connection.     <-- counted, but not sampled
```

Also, `clickhouse-client` reconnects after the server drops it, so a single run of the test can close two connections by itself. That is the shape of the earlier failures, where both tests reported a delta of two.

Count the connections closed *because a limit was reached* instead - the server logs `Closing connection due to limits` exactly once per such connection, and the reason distinguishes the query-count limit from the time limit. Neither the readiness probe nor a reconnecting client reaches a limit: `query_count` and `connection_timer` are per-connection, so a fresh connection starts from zero. With the count no longer polluted by startup connections, the `sleep` that tried to wait them out is not needed.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=7d22d13ab50ff1474fad83ba8e19db7b60c24412&name_0=MasterCI&name_1=Integration%20tests%20%28amd_msan%2C%203%2F8%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)