### PR TITLE
Fix `remove_orphan_files` deleting a live Iceberg `version-hint.text`

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/SnapshotFilesTraversal.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/SnapshotFilesTraversal.cpp
@@ -6,6 +6,8 @@
 
 #include <Poco/JSON/Object.h>
 
+#include <filesystem>
+
 #include <Common/logger_useful.h>
 
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Constant.h>
@@ -93,8 +95,8 @@ void collectMetadataRootFiles(
 {
     out.insert(metadata_path);
 
-    auto version_hint = IcebergPathFromMetadata::deserialize(fmt::format("{}metadata/version-hint.text", resolver.getTableLocation()));
-    out.insert(resolver.resolve(version_hint));
+    /// version-hint.text is not a metadata path: it is a fixed object under the storage root.
+    out.insert(std::filesystem::path(resolver.getTableRoot()) / "metadata" / "version-hint.text");
 
     if (metadata->has(f_metadata_log))
     {

--- a/tests/integration/test_storage_iceberg_with_spark/test_remove_orphan_files.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_remove_orphan_files.py
@@ -33,10 +33,10 @@ class OrphanTestEnv:
 
     # -- table lifecycle -----------------------------------------------------
 
-    def populate(self, n_rows, format_version=2):
+    def populate(self, n_rows, format_version=2, **kwargs):
         create_iceberg_table(
             self.storage_type, self.instance, self.table_name,
-            self.cluster, "(x Int)", format_version,
+            self.cluster, "(x Int)", format_version, **kwargs,
         )
         for val in range(1, n_rows + 1):
             self.instance.query(
@@ -580,3 +580,32 @@ def test_remove_orphan_files_ignores_pinned_metadata(started_cluster_iceberg_wit
     assert full_result == "1\n2\n3\n", (
         f"All data should be intact when reading latest metadata, got: {full_result}"
     )
+
+
+@pytest.mark.parametrize("storage_type", ["local", "s3"])
+def test_remove_orphan_files_preserves_version_hint(started_cluster_iceberg_with_spark, storage_type):
+    """remove_orphan_files must treat metadata/version-hint.text as reachable.
+
+    The hint is a fixed object under the storage root, not a path stored in
+    metadata, so the reachable set must contain its storage key.  If that key is
+    malformed the live hint is classified as an orphan and deleted, and with
+    iceberg_use_version_hint = 1 the table then stops reading entirely."""
+    env = make_env(started_cluster_iceberg_with_spark, storage_type, "test_orphan_version_hint")
+    env.populate(2, use_version_hint=True)
+
+    # Guard against a fixture that never wrote the hint: without this the test
+    # would pass on a binary that deletes it.
+    assert env.exists("metadata", "version-hint.text"), \
+        "Fixture did not create metadata/version-hint.text"
+
+    env.add_orphan("data", "orphan-version-hint.parquet")
+    time.sleep(2)
+
+    env.remove_orphans(older_than=env.now_ts())
+
+    assert env.exists("metadata", "version-hint.text"), \
+        "remove_orphan_files deleted the live metadata/version-hint.text"
+    # The user-visible consequence: with the hint gone the table stops reading.
+    env.assert_data_intact()
+    assert not env.exists("data", "orphan-version-hint.parquet"), \
+        "The orphan data file should still have been deleted"


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/90740
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `ALTER TABLE ... EXECUTE remove_orphan_files` deleting a live `metadata/version-hint.text` of an Iceberg table. Its reachable-set entry was built by string concatenation assuming a trailing slash on a value which never has one, so the real hint file was never recognised as reachable and was removed once older than the `older_than` threshold. With `iceberg_use_version_hint = 1` the table then failed to read at all.


### Description

`collectMetadataRootFiles` built the version-hint entry of the reachable set as
`fmt::format("{}metadata/version-hint.text", resolver.getTableLocation())`. But
`IcebergPathResolver`'s constructor strips every trailing slash from `table_location` and is
its only writer, so `getTableLocation()` never ends with `/`: the key was always
`<location>metadata/version-hint.text`, missing one separator, in every configuration, and
`resolve()` silently yields a key matching no object rather than throwing.

So the real hint was absent from the reachable set, `findOrphanFiles` classified it as an
orphan, and past the age gate `deleteOrphanFiles` removed it. That is not cosmetic:
`getLatestOrExplicitMetadataFileAndVersion` has no exception handling and its
`iceberg_use_version_hint` branch reads the hint with a bare `readObject`.

The fix builds the path in the storage domain and inserts it directly:

```cpp
out.insert(std::filesystem::path(resolver.getTableRoot()) / "metadata" / "version-hint.text");
```

The hint is a fixed object under the storage prefix, never a path stored in metadata, so it
should not travel through `IcebergPathFromMetadata`/`resolve()`. The read side already joins
the storage-side `table_path` this way, so producer and consumer now agree by construction,
and `std::filesystem::path` is idempotent on the trailing slash.

Validation: a new integration arm (`local` and `s3`) asserts the hint survives and the table
still reads, with the orphan data file still deleted as a positive control. It fails on
unpatched master and passes with the fix; a mutant restoring the old concatenation reddens it.
Full module 31 passed; `04033_iceberg_mismatched_location` and
`04034_iceberg_spark_style_location` pass 100/100 over 50 randomized runs.

The affected line is also fixed incidentally by the open #90740, inside a larger reachable-set
restructure. This is the standalone minimal fix, and the two spellings are behaviourally
equivalent, so whichever lands first the other is a trivial conflict resolution.

Affected release branches: 26.7, 26.6, 26.5 (25.8 and 26.3 lack this code). Could a maintainer
add the corresponding `must-backport` labels?