### PR TITLE
Qualify a parameterized view's name when rendering it for another server

### DIFF
--- a/src/Analyzer/TableFunctionNode.cpp
+++ b/src/Analyzer/TableFunctionNode.cpp
@@ -1,5 +1,7 @@
 #include <Analyzer/TableFunctionNode.h>
 
+#include <Analyzer/Identifier.h>
+
 #include <Common/assert_cast.h>
 #include <Common/SipHash.h>
 
@@ -8,6 +10,7 @@
 #include <IO/Operators.h>
 
 #include <Storages/IStorage.h>
+#include <Storages/StorageView.h>
 
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSetQuery.h>
@@ -148,6 +151,18 @@ ASTPtr TableFunctionNode::toASTImpl(const ConvertToASTOptions & options) const
     auto table_function_ast = make_intrusive<ASTFunction>();
 
     table_function_ast->name = table_function_name;
+
+    /// An unqualified parameterized-view name re-resolves against the receiving server's default
+    /// database, so qualify it from `storage_id`. Only a 2-part result is resolvable as a
+    /// parameterized view, so a dotted database name is left alone.
+    if (const auto * storage_view = storage ? storage->as<StorageView>() : nullptr;
+        storage_view && storage_view->isParameterizedView() && storage_id.hasDatabase()
+        && Identifier{table_function_name}.getPartsSize() == 1)
+    {
+        const auto database_name = storage_id.getDatabaseName();
+        if (Identifier{database_name}.getPartsSize() == 1)
+            table_function_ast->name = database_name + "." + storage_id.getTableName();
+    }
 
     const auto & arguments = getArguments();
     table_function_ast->children.push_back(arguments.toAST(options));

--- a/tests/queries/0_stateless/04678_parameterized_view_database_on_shard.reference
+++ b/tests/queries/0_stateless/04678_parameterized_view_database_on_shard.reference
@@ -1,0 +1,32 @@
+-- non-GLOBAL IN through a Distributed table
+6
+-- JOIN ... ON
+18
+-- JOIN ... USING
+18
+-- remote()
+3
+-- a same-named view in the database the shard falls back to must not shadow it
+-- per-shard rows, one local replica
+1	3
+2	3
+-- per-shard rows, every replica remote
+1	3
+2	3
+-- per-shard rows without any view, the denominator
+1	3
+2	3
+-- CONTROL a regular table function keeps its unqualified name
+6
+-- CONTROL GLOBAL IN
+6
+-- CONTROL an ordinary view
+6
+-- CONTROL an already qualified call
+6
+-- CONTROL an unresolved parse renders unchanged
+SELECT *\nFROM pv(x = 1)
+-- a dotted database name still resolves locally
+3
+-- and is not qualified for the shard, so it keeps failing under its own name
+Unknown table function pvd.

--- a/tests/queries/0_stateless/04678_parameterized_view_database_on_shard.sh
+++ b/tests/queries/0_stateless/04678_parameterized_view_database_on_shard.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Tags: shard
+
+# A parameterized view referenced unqualified in a query that is shipped to a shard used to arrive
+# without its database, so the shard re-resolved the name against its own default database. The
+# session database must be the view's own database and the call must be unqualified, or nothing is
+# measured. `enable_analyzer` is pinned because the parameterized view is only represented as a
+# resolved table function node in the analyzer.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+CLIENT="${CLICKHOUSE_CLIENT} --enable_analyzer 1"
+
+# A same-named view in `default` is what the shard falls back to, so it turns the failure from a
+# hard error into a silently wrong answer. Its name carries the test database to stay unique.
+shadow="pv_${CLICKHOUSE_DATABASE}"
+
+${CLIENT} -q "
+CREATE TABLE src (tenant_id String, host_id UInt64) ENGINE = MergeTree ORDER BY tenant_id;
+INSERT INTO src SELECT 't1', number FROM numbers(3);
+
+CREATE TABLE local_data (tenant_id String, v UInt64) ENGINE = MergeTree ORDER BY tenant_id;
+INSERT INTO local_data SELECT 't1', number FROM numbers(3);
+
+CREATE TABLE dist AS local_data
+    ENGINE = Distributed('test_cluster_two_shards', '${CLICKHOUSE_DATABASE}', 'local_data', rand());
+
+CREATE VIEW ${shadow} AS SELECT tenant_id, host_id FROM src WHERE tenant_id IN {tenants:Array(String)};
+CREATE VIEW plain AS SELECT tenant_id, host_id FROM src;
+"
+
+echo '-- non-GLOBAL IN through a Distributed table'
+${CLIENT} -q "SELECT count() FROM dist WHERE tenant_id IN (SELECT tenant_id FROM ${shadow}(tenants = ['t1']))"
+
+echo '-- JOIN ... ON'
+${CLIENT} -q "SELECT count() FROM dist AS d JOIN ${shadow}(tenants = ['t1']) AS p ON d.tenant_id = p.tenant_id"
+
+echo '-- JOIN ... USING'
+${CLIENT} -q "SELECT count() FROM dist JOIN ${shadow}(tenants = ['t1']) USING (tenant_id) SETTINGS joined_subquery_requires_alias = 0"
+
+echo '-- remote()'
+${CLIENT} -q "SELECT count() FROM remote('127.0.0.2', '${CLICKHOUSE_DATABASE}', 'local_data') WHERE tenant_id IN (SELECT tenant_id FROM ${shadow}(tenants = ['t1']))"
+
+echo '-- a same-named view in the database the shard falls back to must not shadow it'
+${CLIENT} -q "
+CREATE TABLE default.src_${CLICKHOUSE_DATABASE} (tenant_id String, host_id UInt64) ENGINE = MergeTree ORDER BY tenant_id;
+INSERT INTO default.src_${CLICKHOUSE_DATABASE} VALUES ('zzz_never', 999);
+CREATE VIEW default.${shadow} AS
+    SELECT tenant_id, host_id FROM default.src_${CLICKHOUSE_DATABASE} WHERE tenant_id IN {tenants:Array(String)};
+"
+
+echo '-- per-shard rows, one local replica'
+${CLIENT} -q "SELECT _shard_num, count() FROM dist WHERE tenant_id IN (SELECT tenant_id FROM ${shadow}(tenants = ['t1'])) GROUP BY _shard_num ORDER BY _shard_num"
+
+echo '-- per-shard rows, every replica remote'
+${CLIENT} -q "SELECT _shard_num, count() FROM dist WHERE tenant_id IN (SELECT tenant_id FROM ${shadow}(tenants = ['t1'])) GROUP BY _shard_num ORDER BY _shard_num SETTINGS prefer_localhost_replica = 0"
+
+echo '-- per-shard rows without any view, the denominator'
+${CLIENT} -q "SELECT _shard_num, count() FROM dist GROUP BY _shard_num ORDER BY _shard_num"
+
+echo '-- CONTROL a regular table function keeps its unqualified name'
+${CLIENT} -q "SELECT count() FROM dist WHERE 1 IN (SELECT number FROM numbers(3))"
+
+echo '-- CONTROL GLOBAL IN'
+${CLIENT} -q "SELECT count() FROM dist WHERE tenant_id GLOBAL IN (SELECT tenant_id FROM ${shadow}(tenants = ['t1']))"
+
+echo '-- CONTROL an ordinary view'
+${CLIENT} -q "SELECT count() FROM dist WHERE tenant_id IN (SELECT tenant_id FROM plain)"
+
+echo '-- CONTROL an already qualified call'
+${CLIENT} -q "SELECT count() FROM dist WHERE tenant_id IN (SELECT tenant_id FROM ${CLICKHOUSE_DATABASE}.${shadow}(tenants = ['t1']))"
+
+echo '-- CONTROL an unresolved parse renders unchanged'
+${CLIENT} -q "SELECT formatQuery('SELECT * FROM pv(x = 1)')"
+
+${CLIENT} -q "
+DROP VIEW default.${shadow};
+DROP TABLE default.src_${CLICKHOUSE_DATABASE};
+"
+
+# A database whose name contains a dot has no resolvable qualified spelling, because
+# extractDatabaseAndTableNameForParameterizedView reads only one or two identifier parts. Such a
+# name must be left exactly as the user wrote it, so the failure keeps naming the view alone.
+dotted="${CLICKHOUSE_DATABASE}.sub"
+${CLIENT} -q "
+CREATE DATABASE \`${dotted}\`;
+CREATE TABLE \`${dotted}\`.src (tenant_id String, host_id UInt64) ENGINE = MergeTree ORDER BY tenant_id;
+INSERT INTO \`${dotted}\`.src SELECT 't1', number FROM numbers(3);
+CREATE TABLE \`${dotted}\`.local_data (tenant_id String, v UInt64) ENGINE = MergeTree ORDER BY tenant_id;
+INSERT INTO \`${dotted}\`.local_data SELECT 't1', number FROM numbers(3);
+CREATE TABLE \`${dotted}\`.dist AS \`${dotted}\`.local_data
+    ENGINE = Distributed('test_cluster_two_shards', '${dotted}', 'local_data', rand());
+CREATE VIEW \`${dotted}\`.pvd AS
+    SELECT tenant_id, host_id FROM \`${dotted}\`.src WHERE tenant_id IN {tenants:Array(String)};
+"
+
+DOTTED_CLIENT="${CLIENT//--database=${CLICKHOUSE_DATABASE}/--database=${dotted}}"
+
+echo '-- a dotted database name still resolves locally'
+${DOTTED_CLIENT} -q "SELECT count() FROM pvd(tenants = ['t1'])"
+
+echo '-- and is not qualified for the shard, so it keeps failing under its own name'
+${DOTTED_CLIENT} -q "SELECT count() FROM dist WHERE tenant_id IN (SELECT tenant_id FROM pvd(tenants = ['t1']))" 2>&1 \
+    | grep -oE 'Unknown table function [^ ]*' | head -n 1
+
+${CLIENT} -q "DROP DATABASE \`${dotted}\`"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->
Closes: https://github.com/ClickHouse/ClickHouse/issues/65318

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a parameterized view losing its database when a query referencing it unqualified is sent to a shard, so the shard resolved the name against its own default database. Depending on what that database contained, the query either failed with `UNKNOWN_FUNCTION` or silently returned rows from a different view. Affects `IN`, `JOIN` and `remote()` through a `Distributed` table.

### Description

`TableFunctionNode::toASTImpl` emitted the function name from `table_function_name`, the identifier as the user wrote it, and never consulted `storage_id`. An unqualified parameterized-view call therefore stayed unqualified all the way to the shard, which re-resolved it against its own default database.

Measured on a two-shard cluster with the session database set to the view's database and the call unqualified: `IN`, `JOIN ... ON`, `JOIN ... USING` and `remote()` all failed with `Code: 46 ... Received from 127.0.0.2 ... Unknown table function pv`, raised by the remote shard, which is direct evidence the name arrived unqualified. When that shard's default database held a same-named parameterized view, the query instead returned a wrong answer with nothing on stderr: 3 rows where 6 is correct. A qualified `db.pv(...)` call has always worked: the existing workaround.

Before #68978 a parameterized view became a `TableNode`, whose `toASTIdentifier` qualifies from `storage_id`; keeping it a resolved `TableFunctionNode` is what lost the database.

The initiator's database is the correct target. A parameterized view is expanded against the initiator's catalog, and its `storage_id` always has a database, since `extractDatabaseAndTableNameForParameterizedView` defaults it to the current one. The cross-replication case that `TableNode::toASTIdentifier` guards against is expressed by `Cluster::maybeCrossReplication`, which `buildQueryTreeForShard` consults to hand `TableNode` an empty database; no cluster or context reaches `toASTImpl`, so that signal cannot apply here.

Two conditions keep the change narrow. The parameterized-view discriminator is required: a regular table function also carries a storage id, whose database is the internal `_table_function`, so unconditional qualification renders `numbers(3)` as `_table_function.numbers(3)`, and a test pins that. Qualification is also skipped unless the result is a two-part identifier, since that helper resolves only one or two parts, so a dotted database name is left as it is today.

The change is render-only: `EXPLAIN QUERY TREE` and `EXPLAIN SYNTAX` are byte-identical before and after.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.902` (included in `26.8` and later)
<!-- ch-version-info:end -->