### PR TITLE
Read a Join table that has a composite or a wide key

### DIFF
--- a/src/Interpreters/HashJoin/HashJoin.h
+++ b/src/Interpreters/HashJoin/HashJoin.h
@@ -241,6 +241,8 @@ public:
     /// Used for reading from StorageJoin and applying joinGet function. The single-LowCardinality-key
     /// maps store key values in maps physically identical to their non-LowCardinality counterparts, so
     /// they are read back the same way (the output key column is the parent LowCardinality type).
+    /// The keysN maps hold the key columns packed into one fixed-width blob, so each key column is
+    /// recovered from its own byte range. `hashed` is absent: its map key is a hash of the values.
     #define APPLY_FOR_JOIN_VARIANTS_LIMITED(M) \
         M(key8)                                \
         M(key16)                               \
@@ -248,6 +250,10 @@ public:
         M(key64)                               \
         M(key_string)                          \
         M(key_fixed_string)                    \
+        M(keys32)                              \
+        M(keys64)                              \
+        M(keys128)                             \
+        M(keys256)                             \
         M(low_cardinality_key_string)          \
         M(low_cardinality_key_fixed_string)
 

--- a/src/Storages/StorageJoin.cpp
+++ b/src/Storages/StorageJoin.cpp
@@ -3,6 +3,7 @@
 #include <Storages/StorageSet.h>
 #include <Storages/TableLockHolder.h>
 #include <Interpreters/HashJoin/HashJoin.h>
+#include <Interpreters/HashJoin/KeyGetter.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Parsers/ASTCreateQuery.h>
@@ -29,6 +30,8 @@
 #include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Poco/String.h>
 #include <filesystem>
+#include <numeric>
+#include <unordered_set>
 
 
 namespace fs = std::filesystem;
@@ -735,6 +738,71 @@ size_t rawSize(const std::string_view & t)
     return t.size();
 }
 
+/// Byte range of one key column inside a packed map key, plus the output column it belongs to.
+struct PackedKeyColumn
+{
+    size_t output_pos;
+    size_t offset;
+    size_t width;
+};
+
+/// How output key columns are recovered from a map key: the whole key for the single-key maps, or
+/// one byte range per key column for the keysN maps, which pack all key columns into one blob.
+struct KeyLayout
+{
+    std::optional<size_t> whole_key_pos;
+    std::vector<PackedKeyColumn> packed;
+    /// Indexed by output column position, so the fill loops stay a constant-time test per column.
+    std::vector<bool> is_key_column;
+};
+
+/// HashMethodKeysFixed is the only join key getter that packs key columns into one blob, and the only
+/// one declaring shuffleKeyColumns, so this selects exactly the keysN maps.
+template <typename KeyGetter>
+concept PacksKeysIntoBlob = requires(std::vector<IColumn *> & columns, const Sizes & sizes) {
+    { KeyGetter::shuffleKeyColumns(columns, sizes) } -> std::same_as<std::optional<Sizes>>;
+};
+
+/// Order in which key slots occupy bytes of the packed key. `packed_sizes` is what
+/// HashMethodKeysFixed::shuffleKeyColumns reports: the widths in packed order, or nothing for plain
+/// clause order. Slots of one width keep their clause order there, which makes the mapping unique.
+std::vector<size_t> packedKeyOrder(const Sizes & clause_sizes, const std::optional<Sizes> & packed_sizes)
+{
+    std::vector<size_t> order(clause_sizes.size());
+    if (!packed_sizes)
+    {
+        std::iota(order.begin(), order.end(), 0);
+        return order;
+    }
+
+    if (packed_sizes->size() != clause_sizes.size())
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "StorageJoin packed key has {} components but the join has {} keys",
+            packed_sizes->size(),
+            clause_sizes.size());
+
+    std::vector<bool> taken(clause_sizes.size(), false);
+    for (size_t position = 0; position < packed_sizes->size(); ++position)
+    {
+        auto slot = clause_sizes.size();
+        for (size_t i = 0; i < clause_sizes.size(); ++i)
+        {
+            if (!taken[i] && clause_sizes[i] == (*packed_sizes)[position])
+            {
+                slot = i;
+                break;
+            }
+        }
+        if (slot == clause_sizes.size())
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR, "StorageJoin has no key of size {} left to pack", (*packed_sizes)[position]);
+        taken[slot] = true;
+        order[position] = slot;
+    }
+    return order;
+}
+
 }
 
 class JoinSource final : public ISource
@@ -747,12 +815,14 @@ public:
         , max_block_size(max_block_size_)
         , sample_block(std::move(sample_block_))
     {
-        if (!join->getTableJoin().oneDisjunct())
+        const auto & table_join = join->getTableJoin();
+        if (!table_join.oneDisjunct())
             throw DB::Exception(ErrorCodes::NOT_IMPLEMENTED, "StorageJoin does not support OR for keys in JOIN ON section");
 
         column_indices.resize(sample_block->columns());
 
         auto & saved_block = join->getJoinedData()->sample_block;
+        std::unordered_map<String, size_t> key_output_positions;
 
         for (size_t i = 0; i < sample_block->columns(); ++i)
         {
@@ -760,6 +830,7 @@ public:
             if (join->right_table_keys.has(name))
             {
                 key_pos = i;
+                key_output_positions.emplace(name, i);
                 const auto & column = join->right_table_keys.getByName(name);
                 restored_block.insert(column);
             }
@@ -771,6 +842,25 @@ public:
                 const auto & column = saved_block.getByPosition(pos);
                 restored_block.insert(column);
             }
+        }
+
+        /// Key slots of a packed map key, in engine-clause order. They come from the clause and not
+        /// from right_table_keys, which deduplicates a repeated key name while the packed key does not.
+        const auto & key_names_right = table_join.getOnlyClause().key_names_right;
+        const auto & key_sizes = join->getKeySizes().at(0);
+        if (key_names_right.size() != key_sizes.size())
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "StorageJoin has {} key names but {} key sizes",
+                key_names_right.size(),
+                key_sizes.size());
+
+        key_slots.reserve(key_names_right.size());
+        for (size_t slot = 0; slot < key_names_right.size(); ++slot)
+        {
+            auto it = key_output_positions.find(key_names_right[slot]);
+            size_t output_pos = it == key_output_positions.end() ? not_selected : it->second;
+            key_slots.push_back({output_pos, 0, key_sizes[slot]});
         }
     }
 
@@ -801,8 +891,12 @@ private:
     SharedHeader sample_block;
     Block restored_block; /// sample_block with parent column types
 
+    static constexpr size_t not_selected = std::numeric_limits<size_t>::max();
+
     ColumnNumbers column_indices;
     std::optional<size_t> key_pos;
+    /// One entry per engine key argument, in clause order; `offset` is filled per map variant.
+    std::vector<PackedKeyColumn> key_slots;
 
     std::unique_ptr<void, std::function<void(void *)>> position; /// type erasure
 
@@ -818,13 +912,17 @@ private:
         {
 #define M(TYPE)                                           \
     case HashJoin::Type::TYPE:                                \
-        rows_added = fillColumns<KIND, STRICTNESS>(*maps.TYPE, mut_columns); \
+        rows_added = fillColumns<KIND, STRICTNESS, HashJoin::Type::TYPE>(*maps.TYPE, mut_columns); \
         break;
             APPLY_FOR_JOIN_VARIANTS_LIMITED(M)
 #undef M
 
             default:
-                throw Exception(ErrorCodes::UNSUPPORTED_JOIN_KEYS, "Unsupported JOIN keys of type {} in StorageJoin", join->data->type);
+                throw Exception(
+                    ErrorCodes::UNSUPPORTED_JOIN_KEYS,
+                    "Cannot read a Join table whose keys are stored as {}: the key values are not recoverable "
+                    "from the map. Read it with a JOIN or joinGet instead",
+                    join->data->type);
         }
 
         if (!rows_added)
@@ -853,11 +951,12 @@ private:
         return Chunk(std::move(columns), num_rows);
     }
 
-    template <JoinKind KIND, JoinStrictness STRICTNESS, typename Map>
+    template <JoinKind KIND, JoinStrictness STRICTNESS, HashJoin::Type TYPE, typename Map>
     size_t fillColumns(const Map & map, MutableColumns & columns)
     {
         size_t rows_added = 0;
         const StoredBlock * const * stored_columns = join->getJoinedData()->stored_columns_index->blocksData();
+        const KeyLayout layout = makeKeyLayout<TYPE, Map>();
 
         if (!position)
             position = decltype(position)(
@@ -871,32 +970,32 @@ private:
         {
             if constexpr (STRICTNESS == JoinStrictness::RightAny)
             {
-                fillOne<Map>(columns, column_indices, it, key_pos, rows_added, stored_columns);
+                fillOne<Map>(columns, column_indices, it, layout, rows_added, stored_columns);
             }
             else if constexpr (STRICTNESS == JoinStrictness::All)
             {
-                fillAll<Map>(columns, column_indices, it, key_pos, rows_added, stored_columns);
+                fillAll<Map>(columns, column_indices, it, layout, rows_added, stored_columns);
             }
             else if constexpr (STRICTNESS == JoinStrictness::Any)
             {
                 if constexpr (KIND == JoinKind::Left || KIND == JoinKind::Inner)
-                    fillOne<Map>(columns, column_indices, it, key_pos, rows_added, stored_columns);
+                    fillOne<Map>(columns, column_indices, it, layout, rows_added, stored_columns);
                 else if constexpr (KIND == JoinKind::Right)
-                    fillAll<Map>(columns, column_indices, it, key_pos, rows_added, stored_columns);
+                    fillAll<Map>(columns, column_indices, it, layout, rows_added, stored_columns);
             }
             else if constexpr (STRICTNESS == JoinStrictness::Semi)
             {
                 if constexpr (KIND == JoinKind::Left)
-                    fillOne<Map>(columns, column_indices, it, key_pos, rows_added, stored_columns);
+                    fillOne<Map>(columns, column_indices, it, layout, rows_added, stored_columns);
                 else if constexpr (KIND == JoinKind::Right)
-                    fillAll<Map>(columns, column_indices, it, key_pos, rows_added, stored_columns);
+                    fillAll<Map>(columns, column_indices, it, layout, rows_added, stored_columns);
             }
             else if constexpr (STRICTNESS == JoinStrictness::Anti)
             {
                 if constexpr (KIND == JoinKind::Left)
-                    fillOne<Map>(columns, column_indices, it, key_pos, rows_added, stored_columns);
+                    fillOne<Map>(columns, column_indices, it, layout, rows_added, stored_columns);
                 else if constexpr (KIND == JoinKind::Right)
-                    fillAll<Map>(columns, column_indices, it, key_pos, rows_added, stored_columns);
+                    fillAll<Map>(columns, column_indices, it, layout, rows_added, stored_columns);
             }
             else
                 throw Exception(ErrorCodes::NOT_IMPLEMENTED, "This JOIN is not implemented yet");
@@ -911,35 +1010,97 @@ private:
         return rows_added;
     }
 
+    /// Byte ranges of the key columns inside this map's key. Empty `packed` means the map key is a
+    /// single key value inserted whole, which is how every non-keysN variant behaves.
+    template <HashJoin::Type TYPE, typename Map>
+    KeyLayout makeKeyLayout() const
+    {
+        KeyLayout layout;
+        layout.whole_key_pos = key_pos;
+        layout.is_key_column.assign(sample_block->columns(), false);
+        if (key_pos)
+            layout.is_key_column[*key_pos] = true;
+
+        /// Note key32 and keys32 (likewise key64/keys64) share one map type, so the variant has to come
+        /// from the enum: only the keysN ones pack several key columns into the map key.
+        using KeyGetter = typename KeyGetterForType<TYPE, std::remove_cvref_t<Map>>::Type;
+        if constexpr (PacksKeysIntoBlob<KeyGetter>)
+        {
+            Sizes clause_sizes;
+            clause_sizes.reserve(key_slots.size());
+            for (const auto & slot : key_slots)
+                clause_sizes.push_back(slot.width);
+
+            /// Aggregation reports the packed order the same way (Aggregator.cpp: shuffleKeyColumns
+            /// feeding the sizes to insertKeyIntoColumns), so the two cannot disagree about the layout.
+            std::vector<IColumn *> unused_columns(key_slots.size(), nullptr);
+            const auto order = packedKeyOrder(clause_sizes, KeyGetter::shuffleKeyColumns(unused_columns, clause_sizes));
+
+            size_t offset = 0;
+            std::unordered_set<size_t> emitted;
+            for (size_t slot : order)
+            {
+                auto entry = key_slots[slot];
+                entry.offset = offset;
+                offset += entry.width;
+                /// A key name repeated in the engine arguments (Join(ALL, INNER, a, a, b)) occupies one
+                /// slot per argument, all holding the same value, but has one output column.
+                if (entry.output_pos != not_selected && emitted.insert(entry.output_pos).second)
+                {
+                    layout.packed.push_back(entry);
+                    layout.is_key_column[entry.output_pos] = true;
+                }
+            }
+
+            if (offset > sizeof(typename Map::key_type))
+                throw Exception(
+                    ErrorCodes::LOGICAL_ERROR,
+                    "StorageJoin keys occupy {} bytes but the map key holds {}",
+                    offset,
+                    sizeof(typename Map::key_type));
+
+            layout.whole_key_pos.reset();
+        }
+        return layout;
+    }
+
+    template <typename Map>
+    static void insertKey(MutableColumns & columns, const KeyLayout & layout, typename Map::const_iterator & it)
+    {
+        if (layout.whole_key_pos)
+            columns[*layout.whole_key_pos]->insertData(rawData(it->getKey()), rawSize(it->getKey()));
+        else
+            for (const auto & slot : layout.packed)
+                columns[slot.output_pos]->insertData(rawData(it->getKey()) + slot.offset, slot.width);
+    }
+
     template <typename Map>
     static void fillOne(MutableColumns & columns, const ColumnNumbers & column_indices, typename Map::const_iterator & it,
-                        const std::optional<size_t> & key_pos, size_t & rows_added, const StoredBlock * const * stored_columns)
+                        const KeyLayout & layout, size_t & rows_added, const StoredBlock * const * stored_columns)
     {
         /// The mapped value of MapsOne is a single encoded ref; the mapped value of MapsAll
         /// (RightAny under preferUseMapsAll) is a tagged ref list whose first element is taken.
         const UInt64 ref_word = firstRefWord(it->getMapped());
         const StoredBlock * block = stored_columns[refWordBlockNo(ref_word)];
         for (size_t j = 0; j < columns.size(); ++j)
-            if (j == key_pos)
-                columns[j]->insertData(rawData(it->getKey()), rawSize(it->getKey()));
-            else
+            if (!layout.is_key_column[j])
                 columns[j]->insertFrom(*block->columns[column_indices[j]], refWordRowNo(ref_word));
+        insertKey<Map>(columns, layout, it);
         ++rows_added;
     }
 
     template <typename Map>
     static void fillAll(MutableColumns & columns, const ColumnNumbers & column_indices, typename Map::const_iterator & it,
-                        const std::optional<size_t> & key_pos, size_t & rows_added, const StoredBlock * const * stored_columns)
+                        const KeyLayout & layout, size_t & rows_added, const StoredBlock * const * stored_columns)
     {
         for (auto ref_it = it->getMapped().begin(); ref_it.ok(); ++ref_it)
         {
             const UInt64 ref_word = *ref_it;
             const StoredBlock * block = stored_columns[refWordBlockNo(ref_word)];
             for (size_t j = 0; j < columns.size(); ++j)
-                if (j == key_pos)
-                    columns[j]->insertData(rawData(it->getKey()), rawSize(it->getKey()));
-                else
+                if (!layout.is_key_column[j])
                     columns[j]->insertFrom(*block->columns[column_indices[j]], refWordRowNo(ref_word));
+            insertKey<Map>(columns, layout, it);
             ++rows_added;
         }
     }

--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -12,11 +12,6 @@
     Cannot find column in source stream
 01358_mutation_delete_null_rows
 
-    Storage Join/Set
-    https://github.com/ClickHouse/ClickHouse/issues/74362
-    Unsupported JOIN keys of type keys128 in StorageJoin: While executing Join. (UNSUPPORTED_JOIN_KEYS) (query: SELECT id FROM t ANY LEFT JOIN joint ON t.id = joint.id;)
-01594_storage_join_uuid
-
     GLOBAL IN engine set not supported (Method read is not supported by storage Set. (NOT_IMPLEMENTED) (version 25.1.1.1927 (official build)) (from [::1]:42612) (comment: 01231_operator_null_in.sql) (in query: SELECT count() == 1 FROM null_in WHERE i global in test_set)
 01231_operator_null_in
 

--- a/tests/queries/0_stateless/04760_storage_join_composite_key_read.reference
+++ b/tests/queries/0_stateless/04760_storage_join_composite_key_read.reference
@@ -1,0 +1,82 @@
+three UInt64 keys (keys256)
+0	1	2	0
+1	2	3	100
+2	3	4	200
+3	4	5	300
+4	5	6	400
+0
+100
+200
+300
+400
+two UInt64 keys (keys128)
+0	500	0
+1	501	10
+2	502	20
+UInt8 + UInt16 keys (keys32, packed widest-first)
+7	4000	0
+8	4001	10
+9	4002	20
+UInt64 + UInt8 + UInt128 keys (keys256, packed in clause order)
+900	3	70000	0
+901	4	70001	10
+902	5	70002	20
+two UInt32 keys (keys64)
+0	500	0
+1	501	10
+2	502	20
+single wide numeric key
+61f0c404-5cb3-11e7-907b-a6006ad3dba0	7
+-12345678901234567890	7
+FixedString keys
+abcd	7	10
+efgh	8	20
+ab	cd	10
+ef	gh	20
+abc	10
+def	20
+four keys
+0	10	20	30	0
+1	11	21	31	7
+2	12	22	32	14
+repeated engine key name
+0	1000	0
+1	1001	10
+2	1002	20
+a subset of the key columns, reordered
+90000	7
+90001	8
+90002	9
+4000	0
+4001	10
+4002	20
+ANY INNER (one row per key)
+0	5	0
+1	6	10
+2	7	20
+ALL RIGHT (the key columns are also kept in the stored block)
+0	5	0
+1	6	10
+2	7	20
+several rows per key
+1	2	10
+1	2	20
+1	2	30
+5	6	50
+Nullable key component
+1	2	10
+4	5	40
+the scanned rows match the joined rows
+1
+single-column keys are unchanged
+0	0
+1	10
+2	20
+	3
+x	1
+yy	2
+x	1
+yy	2
+1	10
+3	30
+keys stored as a hash are still rejected

--- a/tests/queries/0_stateless/04760_storage_join_composite_key_read.sql
+++ b/tests/queries/0_stateless/04760_storage_join_composite_key_read.sql
@@ -1,0 +1,164 @@
+-- Reading a Join table directly (SELECT ... FROM <join table>), for composite and wide keys.
+-- Reproduces https://github.com/ClickHouse/ClickHouse/issues/74362 and
+-- https://github.com/ClickHouse/ClickHouse/issues/77394, which failed with
+-- "Unsupported JOIN keys of type keys256 in StorageJoin".
+-- 04305_storage_join_composite_keys covers composite keys but only ever joins *against* the
+-- table, so the scan path stayed unpinned.
+
+DROP TABLE IF EXISTS tj;
+
+SELECT 'three UInt64 keys (keys256)';
+CREATE TABLE tj (key1 UInt64, key2 UInt64, key3 UInt64, w UInt64)
+    ENGINE = Join(ALL, INNER, key1, key2, key3);
+INSERT INTO tj SELECT number, number + 1, number + 2, number * 100 FROM numbers(5);
+SELECT * FROM tj ORDER BY key1;
+-- The dispatch runs before any column is touched, so a non-key column alone used to throw too.
+SELECT w FROM tj ORDER BY w;
+DROP TABLE tj;
+
+SELECT 'two UInt64 keys (keys128)';
+CREATE TABLE tj (a UInt64, b UInt64, w UInt64) ENGINE = Join(ALL, INNER, a, b);
+INSERT INTO tj SELECT number, number + 500, number * 10 FROM numbers(3);
+SELECT * FROM tj ORDER BY a;
+DROP TABLE tj;
+
+-- Unequal key widths make packFixedBatch order the components widest-first, so the byte order
+-- is not the clause order here. A UInt16 decoded as a UInt8 cannot reach 4000.
+SELECT 'UInt8 + UInt16 keys (keys32, packed widest-first)';
+CREATE TABLE tj (a UInt8, b UInt16, w UInt64) ENGINE = Join(ALL, INNER, a, b);
+INSERT INTO tj SELECT toUInt8(number + 7), toUInt16(number + 4000), number * 10 FROM numbers(3);
+SELECT * FROM tj ORDER BY a;
+DROP TABLE tj;
+
+-- A key wider than 16 bytes cannot use the prepared-keys path, so this one is packed in clause
+-- order despite the widths differing. Together with the arm above it pins both layouts.
+SELECT 'UInt64 + UInt8 + UInt128 keys (keys256, packed in clause order)';
+CREATE TABLE tj (a UInt64, b UInt8, c UInt128, w UInt64) ENGINE = Join(ALL, INNER, a, b, c);
+INSERT INTO tj SELECT number + 900, toUInt8(number + 3), toUInt128(number + 70000), number * 10 FROM numbers(3);
+SELECT * FROM tj ORDER BY a;
+DROP TABLE tj;
+
+SELECT 'two UInt32 keys (keys64)';
+CREATE TABLE tj (a UInt32, b UInt32, w UInt64) ENGINE = Join(ALL, INNER, a, b);
+INSERT INTO tj SELECT toUInt32(number), toUInt32(number + 500), number * 10 FROM numbers(3);
+SELECT * FROM tj ORDER BY a;
+DROP TABLE tj;
+
+SELECT 'single wide numeric key';
+CREATE TABLE tj (a UUID, w UInt64) ENGINE = Join(ALL, INNER, a);
+INSERT INTO tj VALUES ('61f0c404-5cb3-11e7-907b-a6006ad3dba0', 7);
+SELECT * FROM tj;
+DROP TABLE tj;
+
+CREATE TABLE tj (a Int256, w UInt64) ENGINE = Join(ALL, INNER, a);
+INSERT INTO tj VALUES (-12345678901234567890, 7);
+SELECT * FROM tj;
+DROP TABLE tj;
+
+SELECT 'FixedString keys';
+CREATE TABLE tj (a FixedString(4), b UInt64, w UInt64) ENGINE = Join(ALL, INNER, a, b);
+INSERT INTO tj VALUES ('abcd', 7, 10), ('efgh', 8, 20);
+SELECT * FROM tj ORDER BY b;
+DROP TABLE tj;
+
+CREATE TABLE tj (a FixedString(2), b FixedString(2), w UInt64) ENGINE = Join(ALL, INNER, a, b);
+INSERT INTO tj VALUES ('ab', 'cd', 10), ('ef', 'gh', 20);
+SELECT * FROM tj ORDER BY w;
+DROP TABLE tj;
+
+-- Three of the four packed bytes are used, so the key is narrower than the map key.
+CREATE TABLE tj (a FixedString(3), w UInt64) ENGINE = Join(ALL, INNER, a);
+INSERT INTO tj VALUES ('abc', 10), ('def', 20);
+SELECT * FROM tj ORDER BY w;
+DROP TABLE tj;
+
+SELECT 'four keys';
+CREATE TABLE tj (a UInt64, b UInt64, c UInt64, d UInt64, w UInt64)
+    ENGINE = Join(ALL, INNER, a, b, c, d);
+INSERT INTO tj SELECT number, number + 10, number + 20, number + 30, number * 7 FROM numbers(3);
+SELECT * FROM tj ORDER BY a;
+DROP TABLE tj;
+
+-- A key name repeated in the engine arguments occupies one packed slot per argument, while the
+-- key block holds it once, so offsets taken from that block would misread b.
+SELECT 'repeated engine key name';
+CREATE TABLE tj (a UInt64, b UInt64, w UInt64) ENGINE = Join(ALL, INNER, a, a, b);
+INSERT INTO tj SELECT number, number + 1000, number * 10 FROM numbers(3);
+SELECT * FROM tj ORDER BY a;
+DROP TABLE tj;
+
+SELECT 'a subset of the key columns, reordered';
+CREATE TABLE tj (a UInt8, b UInt16, c UInt32, w UInt64) ENGINE = Join(ALL, INNER, a, b, c);
+INSERT INTO tj SELECT toUInt8(number + 7), toUInt16(number + 4000), toUInt32(number + 90000), number * 10 FROM numbers(3);
+SELECT c, a FROM tj ORDER BY a;
+SELECT b, w FROM tj ORDER BY b;
+DROP TABLE tj;
+
+SELECT 'ANY INNER (one row per key)';
+CREATE TABLE tj (a UInt64, b UInt64, w UInt64) ENGINE = Join(ANY, INNER, a, b);
+INSERT INTO tj SELECT number, number + 5, number * 10 FROM numbers(3);
+SELECT * FROM tj ORDER BY a;
+DROP TABLE tj;
+
+SELECT 'ALL RIGHT (the key columns are also kept in the stored block)';
+CREATE TABLE tj (a UInt64, b UInt64, w UInt64) ENGINE = Join(ALL, RIGHT, a, b);
+INSERT INTO tj SELECT number, number + 5, number * 10 FROM numbers(3);
+SELECT * FROM tj ORDER BY a;
+DROP TABLE tj;
+
+SELECT 'several rows per key';
+CREATE TABLE tj (a UInt64, b UInt64, w UInt64) ENGINE = Join(ALL, INNER, a, b);
+INSERT INTO tj VALUES (1, 2, 10), (1, 2, 20), (1, 2, 30), (5, 6, 50);
+SELECT * FROM tj ORDER BY a, w;
+DROP TABLE tj;
+
+-- A NULL in any key component is not inserted into the map, so it is not read back either.
+SELECT 'Nullable key component';
+CREATE TABLE tj (a Nullable(UInt64), b UInt64, w UInt64) ENGINE = Join(ALL, INNER, a, b);
+INSERT INTO tj VALUES (1, 2, 10), (NULL, 3, 20), (4, 5, 40);
+SELECT * FROM tj ORDER BY b;
+DROP TABLE tj;
+
+-- Scanning must agree with probing, which was already correct.
+SELECT 'the scanned rows match the joined rows';
+CREATE TABLE tj (a UInt8, b UInt16, w UInt64) ENGINE = Join(ALL, INNER, a, b);
+INSERT INTO tj SELECT toUInt8(number + 7), toUInt16(number + 4000), number * 10 FROM numbers(20);
+CREATE TABLE src AS tj ENGINE = Memory;
+INSERT INTO src SELECT * FROM tj;
+SELECT (SELECT groupArray(x) FROM (SELECT cityHash64(*) AS x FROM tj ORDER BY x))
+     = (SELECT groupArray(x) FROM (SELECT cityHash64(t.*) AS x FROM src AS s ALL INNER JOIN tj AS t USING (a, b) ORDER BY x));
+DROP TABLE src;
+DROP TABLE tj;
+
+SELECT 'single-column keys are unchanged';
+CREATE TABLE tj (a UInt64, w UInt64) ENGINE = Join(ALL, INNER, a);
+INSERT INTO tj SELECT number, number * 10 FROM numbers(3);
+SELECT * FROM tj ORDER BY a;
+DROP TABLE tj;
+
+CREATE TABLE tj (a String, w UInt64) ENGINE = Join(ALL, INNER, a);
+INSERT INTO tj VALUES ('x', 1), ('yy', 2), ('', 3);
+SELECT * FROM tj ORDER BY a;
+DROP TABLE tj;
+
+CREATE TABLE tj (a LowCardinality(String), w UInt64) ENGINE = Join(ALL, INNER, a);
+INSERT INTO tj VALUES ('x', 1), ('yy', 2);
+SELECT * FROM tj ORDER BY a;
+DROP TABLE tj;
+
+CREATE TABLE tj (a Nullable(UInt64), w UInt64) ENGINE = Join(ALL, INNER, a);
+INSERT INTO tj VALUES (1, 10), (NULL, 20), (3, 30);
+SELECT * FROM tj ORDER BY a;
+DROP TABLE tj;
+
+-- A hashed map stores hash128 of the key values, so the values cannot be recovered from it.
+SELECT 'keys stored as a hash are still rejected';
+CREATE TABLE tj (a UInt64, b String, w UInt64) ENGINE = Join(ALL, INNER, a, b);
+INSERT INTO tj VALUES (1, 'x', 10);
+SELECT * FROM tj; -- { serverError UNSUPPORTED_JOIN_KEYS }
+DROP TABLE tj;
+
+CREATE TABLE tj (a LowCardinality(String), b UInt64, w UInt64) ENGINE = Join(ALL, INNER, a, b);
+INSERT INTO tj VALUES ('x', 1, 10);
+SELECT * FROM tj; -- { serverError UNSUPPORTED_JOIN_KEYS }
+DROP TABLE tj;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/74362
Closes: https://github.com/ClickHouse/ClickHouse/issues/77394
Related: https://github.com/ClickHouse/ClickHouse/issues/29950
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `Unsupported JOIN keys of type keys256 in StorageJoin` when reading a `Join`-engine table whose key is composite (several columns) or a single 16/32-byte value such as `UUID`, `Int256` or `FixedString(4)`. Such a table could be created, written and joined against, but never read back with `SELECT`. Closes [#74362](https://github.com/ClickHouse/ClickHouse/issues/74362) and [#77394](https://github.com/ClickHouse/ClickHouse/issues/77394).


### Description

Issue 74362 reports this under parallel replicas, but that is only the carrier: it materializes the right table, turning the probe into a read of the `Join` table. A plain read reproduces it with no settings:

```sql
CREATE TABLE tj (key1 UInt64, key2 UInt64, key3 UInt64, w UInt64)
    ENGINE = Join(ALL, INNER, key1, key2, key3);
INSERT INTO tj SELECT number, number + 1, number + 2, number * 100 FROM numbers(5);
SELECT * FROM tj;   -- Code: 121
```

Two parts. `JoinSource::createChunk` dispatches over `APPLY_FOR_JOIN_VARIANTS_LIMITED`, which listed only the eight single-key variants, so every `keysN` map fell to a `default:` throw. And the reconstruction held a single `key_pos`, inserting the whole map key into that one column, which for a `keysN` map is every key column packed into one blob. Widening the dispatch alone would have put a 32-byte packed key into one column: wrong results instead of an error.

So each key column is now recovered from its own byte range of the packed key, using the `key_sizes` the join already keeps, and the dispatch is widened to `keys32/64/128/256`. `HashMethodKeysFixed` has two layouts, so the packed order comes from that same type's `shuffleKeyColumns` rather than being re-derived, as aggregation does when reading its own packed keys back. Offsets come from the engine's key clause, not the deduplicated key block: a repeated name (`Join(ALL, INNER, a, a, b)`) occupies one slot per argument.

`hashed` maps stay rejected, now with a message saying why: their key is `hash128` of the values, so the values are unrecoverable. That is the shape issue 29950 reports, so this PR only partly addresses it.

Nothing about the map is serialized (the engine persists the inserted blocks and rebuilds the map on restore), so there is no format change and no migration.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1201` (included in `26.8` and later)
<!-- ch-version-info:end -->