### PR TITLE
Raise the `index_granularity` randomization floor for test 03469

### DIFF
--- a/tests/queries/0_stateless/03469_json_read_subcolumns_combined_2_compact_merge_tree.sql
+++ b/tests/queries/0_stateless/03469_json_read_subcolumns_combined_2_compact_merge_tree.sql
@@ -1,5 +1,7 @@
 -- Tags: no-fasttest, long
--- Random settings limits: index_granularity=(100, None); index_granularity_bytes=(100000, None); max_threads=(4, 32)
+-- Random settings limits: index_granularity=(8192, None); index_granularity_bytes=(100000, None); max_threads=(4, 32)
+-- index_granularity is floored at the engine default on purpose: tiny granules multiply the
+-- mark count over these 71 SELECTs and timed the test out on slow builds.
 
 SET enable_json_type = 1;
 set allow_experimental_variant_type = 1;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/109636
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`03469_json_read_subcolumns_combined_2_compact_merge_tree` times out on slow builds when the
randomizer draws a small `index_granularity`. All 19 failures on
`Stateless tests (amd_msan, WasmEdge, parallel, 2/2)` in 200 days are `Reason: Timeout!` at
600050-600360 ms against the runner's 600 s limit; none has differing results.

`index_granularity` is the discriminator: it is in [100, 211] in all 19 rows, while
`ratio_of_defaults_for_sparse_serialization` takes both extremes plus eight interior values among
the same failures. The test writes 80000 rows into a Compact part and runs 71 SELECTs over 32
distinct JSON subcolumn expressions, up to 23 in one query, and marks scale as
rows / `index_granularity`. On a debug build, 107 gives 747 marks and 8.06 s mean
wall against 11 marks and 1.69 s at 8192: 4.76x over four interleaved runs per arm,
non-overlapping, identical output.

The existing `(100, None)` limit went inert when 82d324be4ecbf4f raised the slow-build
generator to `randint(100, 65536)`: a floor of 100 cannot raise anything. Over 100000 draws
through the runner's clamp, 12.24% of values land below 8192 with the old bound, none with the
new one.

So raise only that bound to the engine default, per #111378 and #111214. Other MergeTree
settings, all query settings and the 8192-65536 range stay randomized; no tag added, no check
disabled. Only 40 stateless tests bound `index_granularity` at all
(`git grep -l 'Random settings limits.*index_granularity=' -- tests/queries/0_stateless/`), and
this moves one of them. Three other
tests already use `(8192, None)`; 99038677346579f pinned 8192 in this file's own DDL for the same
timeout, and `_2_wide_merge_tree` still pins it there.

Not immunity: the slowest passing run is 574.9 s against the 600 s wall, so the next lever
would be data volume. 31 other tests carry the same inert bound but no timeouts. #109636 derives
a setting from the pre-clamp `index_granularity`, affecting all 40.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.886` (included in `26.8` and later)
<!-- ch-version-info:end -->