### PR TITLE
Memoize consecutive id lookups in `ContextTimeSeriesTagsCollector::getGroupByID`

### DIFF
--- a/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
@@ -1008,19 +1008,29 @@ VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::getGroupByID(con
     size_t num_rows = unwrapped.data->size();
 
     Arena temp_arena;
-    auto keys = serializeIDs(*unwrapped.data, nullptr, temp_arena);
 
     VectorWithMemoryTracking<Group> res;
     res.reserve(num_rows);
 
     SharedLockGuard lock{mutex};
 
+    /// Id columns arrive in long runs of equal values (samples are sorted by id), so reuse the previous row's group.
+    Group prev_group = INVALID_GROUP;
     for (size_t i = 0; i != num_rows; ++i)
     {
-        const auto * it = groups_by_id.find(keys[i]);
+        if (i > 0 && prev_group != INVALID_GROUP
+            && unwrapped.data->compareAt(i, i - 1, *unwrapped.data, /* nan_direction_hint = */ 1) == 0)
+        {
+            res.push_back(prev_group);
+            continue;
+        }
+        const char * begin = nullptr;
+        auto key = unwrapped.data->serializeValueIntoArena(i, temp_arena, begin, /* settings = */ nullptr);
+        const auto * it = groups_by_id.find(key);
         if (!it)
             throwUnknownID(*unwrapped.column, i);
-        res.push_back(it->getMapped());
+        prev_group = it->getMapped();
+        res.push_back(prev_group);
     }
 
     return res;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up PromQL queries over TimeSeries tables: `timeSeriesIdToGroup` now reuses the previous row's group when consecutive rows carry the same series id, skipping the per-row id serialization and hash lookup.

### Description

Every PromQL selector is transpiled to `SELECT timeSeriesIdToGroup(id), timestamp, value FROM timeSeriesSelector(...)`, so `getGroupByID` runs once per *sample*. It serialized the id (default `Tuple(UInt64, UUID)`, 24 bytes) into an arena and did a string-keyed hash lookup per row. Since the samples table is sorted by `(id, timestamp)`, id columns arrive in long runs of equal values (typically thousands of rows per run); comparing with the previous row first makes the lookup O(runs) instead of O(rows).

Measured on a TimeSeries table with 62.5 billion samples (32 cores): a 30-day `sum by(namespace)(rate(container_cpu_usage_seconds_total[5m]))` query over 25,600 series drops from 39.9 s to 30.6 s cold (-23%); in a per-query CPU profile the `getGroupByID` + `serializeValueIntoArena` + `Arena::allocContinue` share (~19% of 1100 s total CPU) collapses. Query results are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.901` (included in `26.8` and later)
<!-- ch-version-info:end -->