### PR TITLE
Reject invalid cross-delimiter escapes in PromQL strings

### DIFF
--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil.cpp
@@ -28,7 +28,8 @@ namespace
     }
 
     /// Parses escape sequences in a string literal and replaces them with the characters which they mean.
-    bool tryUnescapeStringLiteral(std::string_view input, String & res_string, String * error_message, size_t * error_pos)
+    bool tryUnescapeStringLiteral(
+        std::string_view input, char quote_char, String & res_string, String * error_message, size_t * error_pos)
     {
         res_string.clear();
         res_string.reserve(input.length());
@@ -68,8 +69,19 @@ namespace
                 case 't':  res_string.push_back(0x09); pos += 2; break;  /// \t  U+0009 horizontal tab
                 case 'v':  res_string.push_back(0x0B); pos += 2; break;  /// \v  U+000B vertical tab
                 case '\\': res_string.push_back('\\'); pos += 2; break;  /// \\  U+005C backslash
-                case '\'': res_string.push_back('\''); pos += 2; break;  /// \'  U+0027 single quote
-                case '"':  res_string.push_back('"');  pos += 2; break;  /// \"  U+0022 double quote
+                case '\'':
+                case '"':
+                {
+                    if (c != quote_char)
+                    {
+                        setErrorMessage(error_message, "Invalid escape sequence {}", quoteString(input.substr(pos)));
+                        setErrorPos(error_pos, pos);
+                        return false;
+                    }
+                    res_string.push_back(c);
+                    pos += 2;
+                    break;
+                }
                 case 'x':
                 {
                     /// \x followed by exactly two hexadecimal digits represents a single byte.
@@ -243,7 +255,7 @@ bool PrometheusQueryParsingUtil::tryParseStringLiteral(
 
     /// A string literal enclosed in quotes or double quotes: escape sequences need to be parsed.
     std::string_view unquoted = input.substr(1, input.length() - 2);
-    if (!tryUnescapeStringLiteral(unquoted, res_string, error_message, error_pos))
+    if (!tryUnescapeStringLiteral(unquoted, quote_char, res_string, error_message, error_pos))
     {
         if (error_pos)
             ++*error_pos;

--- a/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
+++ b/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
@@ -1221,6 +1221,24 @@ TEST(PromQLParser, ErrorPosition)
 }
 
 
+TEST(PromQLParser, InvalidStringQuoteEscapes)
+{
+    for (const auto & [query, expected_error_pos] : std::initializer_list<std::pair<std::string_view, size_t>>{
+             {R"(up{label="a\'b"})", 11},
+             {R"(up{label='a\"b'})", 11},
+         })
+    {
+        PrometheusQueryTree query_tree;
+        String error_message;
+        size_t error_pos = String::npos;
+
+        EXPECT_FALSE(query_tree.tryParse(query, 3, &error_message, &error_pos));
+        EXPECT_EQ(error_pos, expected_error_pos) << query;
+        EXPECT_NE(error_message.find("Invalid escape sequence"), String::npos) << query;
+    }
+}
+
+
 TEST(PromQLParser, ParseStringLiterals)
 {
     EXPECT_EQ(parse(R"(


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Reject invalid cross-delimiter escapes in PromQL strings.

### Summary

Prometheus only allows an escaped quote when it matches the delimiter that opened the string. For example, `\"` is valid inside a double-quoted string and `\'` is valid inside a single-quoted string.

ClickHouse previously accepted both escaped quote characters in either quote style. This change passes the opening delimiter to the unescape helper and rejects `"a\'b"` and `\'a\"b\'`. Same-delimiter escapes and raw backtick strings are unchanged.

The behavior follows the Prometheus lexer:

- [Prometheus escape handling](https://github.com/prometheus/prometheus/blob/main/promql/parser/lex.go#L758-L781)
- [Prometheus quoted string handling](https://github.com/prometheus/prometheus/blob/main/promql/parser/lex.go#L828-L863)

### Tests

Added parser coverage for both invalid cross-delimiter escapes, including their error positions.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1007` (included in `26.8` and later)
<!-- ch-version-info:end -->