### PR TITLE
Fix divergent mutation of Compact parts with 'basic' serialization info

### DIFF
--- a/src/DataTypes/Serializations/SerializationInfoSettings.cpp
+++ b/src/DataTypes/Serializations/SerializationInfoSettings.cpp
@@ -28,11 +28,13 @@ SerializationInfoSettings::SerializationInfoSettings(
 {
     /// New type specialized serialization version is valid only when using MergeTreeSerializationInfoVersion::WITH_TYPES.
     /// For older versions, it is automatically defaulted to preserve compatibility.
+    /// This includes `propagate_types_serialization_versions_to_nested_types`, which older versions cannot persist.
     if (version < MergeTreeSerializationInfoVersion::WITH_TYPES)
     {
         string_serialization_version = MergeTreeStringSerializationVersion::SINGLE_STREAM;
         nullable_serialization_version = MergeTreeNullableSerializationVersion::BASIC;
         map_serialization_version = MergeTreeMapSerializationVersion::BASIC;
+        propagate_types_serialization_versions_to_nested_types = false;
     }
 }
 

--- a/src/DataTypes/Serializations/tests/gtest_serialization_info.cpp
+++ b/src/DataTypes/Serializations/tests/gtest_serialization_info.cpp
@@ -237,52 +237,6 @@ TEST(SerializationInfoByNameJSON, WriteJSONCanBeReadBack)
     EXPECT_NE(restored.tryGet("tuple"), nullptr);
 }
 
-namespace
-{
-
-SerializationInfoSettings makeSettings(MergeTreeSerializationInfoVersion version, bool propagate)
-{
-    return SerializationInfoSettings(
-        /*ratio_of_defaults_for_sparse_=*/0.9375,
-        /*choose_kind_=*/true,
-        /*compute_exact_num_defaults_=*/false,
-        version,
-        MergeTreeStringSerializationVersion::SINGLE_STREAM,
-        MergeTreeNullableSerializationVersion::BASIC,
-        MergeTreeMapSerializationVersion::BASIC,
-        propagate);
-}
-
-}
-
-/// Versions below WITH_TYPES cannot persist `propagate_types_serialization_versions_to_nested_types`,
-/// so the constructor normalizes it: a settings object rebuilt from a BASIC `serialization.json`
-/// must be indistinguishable from the one that wrote it.
-TEST(SerializationInfoSettingsCtor, PropagateNormalizedBelowWithTypes)
-{
-    EXPECT_FALSE(makeSettings(MergeTreeSerializationInfoVersion::BASIC, true)
-                     .propagate_types_serialization_versions_to_nested_types);
-
-    /// Scoped, not a blanket disable: WITH_TYPES keeps the requested value.
-    EXPECT_TRUE(makeSettings(MergeTreeSerializationInfoVersion::WITH_TYPES, true)
-                    .propagate_types_serialization_versions_to_nested_types);
-    EXPECT_FALSE(makeSettings(MergeTreeSerializationInfoVersion::WITH_TYPES, false)
-                     .propagate_types_serialization_versions_to_nested_types);
-}
-
-/// The equality consequence, which is what a mutation compares to decide whether to
-/// re-materialize serialization info.
-TEST(SerializationInfoSettingsCtor, PropagateDoesNotAffectEqualityBelowWithTypes)
-{
-    EXPECT_EQ(
-        makeSettings(MergeTreeSerializationInfoVersion::BASIC, true),
-        makeSettings(MergeTreeSerializationInfoVersion::BASIC, false));
-
-    EXPECT_NE(
-        makeSettings(MergeTreeSerializationInfoVersion::WITH_TYPES, true),
-        makeSettings(MergeTreeSerializationInfoVersion::WITH_TYPES, false));
-}
-
 /// Malformed kind tests.
 /// stringToKind throws LOGICAL_ERROR which aborts in debug builds
 /// but throws a catchable exception in release builds.

--- a/src/DataTypes/Serializations/tests/gtest_serialization_info.cpp
+++ b/src/DataTypes/Serializations/tests/gtest_serialization_info.cpp
@@ -237,6 +237,52 @@ TEST(SerializationInfoByNameJSON, WriteJSONCanBeReadBack)
     EXPECT_NE(restored.tryGet("tuple"), nullptr);
 }
 
+namespace
+{
+
+SerializationInfoSettings makeSettings(MergeTreeSerializationInfoVersion version, bool propagate)
+{
+    return SerializationInfoSettings(
+        /*ratio_of_defaults_for_sparse_=*/0.9375,
+        /*choose_kind_=*/true,
+        /*compute_exact_num_defaults_=*/false,
+        version,
+        MergeTreeStringSerializationVersion::SINGLE_STREAM,
+        MergeTreeNullableSerializationVersion::BASIC,
+        MergeTreeMapSerializationVersion::BASIC,
+        propagate);
+}
+
+}
+
+/// Versions below WITH_TYPES cannot persist `propagate_types_serialization_versions_to_nested_types`,
+/// so the constructor normalizes it: a settings object rebuilt from a BASIC `serialization.json`
+/// must be indistinguishable from the one that wrote it.
+TEST(SerializationInfoSettingsCtor, PropagateNormalizedBelowWithTypes)
+{
+    EXPECT_FALSE(makeSettings(MergeTreeSerializationInfoVersion::BASIC, true)
+                     .propagate_types_serialization_versions_to_nested_types);
+
+    /// Scoped, not a blanket disable: WITH_TYPES keeps the requested value.
+    EXPECT_TRUE(makeSettings(MergeTreeSerializationInfoVersion::WITH_TYPES, true)
+                    .propagate_types_serialization_versions_to_nested_types);
+    EXPECT_FALSE(makeSettings(MergeTreeSerializationInfoVersion::WITH_TYPES, false)
+                     .propagate_types_serialization_versions_to_nested_types);
+}
+
+/// The equality consequence, which is what a mutation compares to decide whether to
+/// re-materialize serialization info.
+TEST(SerializationInfoSettingsCtor, PropagateDoesNotAffectEqualityBelowWithTypes)
+{
+    EXPECT_EQ(
+        makeSettings(MergeTreeSerializationInfoVersion::BASIC, true),
+        makeSettings(MergeTreeSerializationInfoVersion::BASIC, false));
+
+    EXPECT_NE(
+        makeSettings(MergeTreeSerializationInfoVersion::WITH_TYPES, true),
+        makeSettings(MergeTreeSerializationInfoVersion::WITH_TYPES, false));
+}
+
 /// Malformed kind tests.
 /// stringToKind throws LOGICAL_ERROR which aborts in debug builds
 /// but throws a catchable exception in release builds.

--- a/tests/queries/0_stateless/04771_mutation_serialization_info_basic_divergence.reference
+++ b/tests/queries/0_stateless/04771_mutation_serialization_info_basic_divergence.reference
@@ -1,0 +1,5 @@
+part types	['Compact','Compact']
+mutated parts identical	1
+mutated part hashes identical	1
+reads agree	1
+cleared values	['']	['']

--- a/tests/queries/0_stateless/04771_mutation_serialization_info_basic_divergence.sql
+++ b/tests/queries/0_stateless/04771_mutation_serialization_info_basic_divergence.sql
@@ -1,0 +1,51 @@
+-- A mutation of a Compact part must not depend on whether the source part's serialization info
+-- was still in memory or reloaded from `serialization.json`. `serialization_info_version = 'basic'`
+-- cannot persist `propagate_types_serialization_versions_to_nested_types`, which used to make the
+-- two settings objects compare unequal and emit info entries for columns that were never written.
+-- `arr` is the carrier: Array cannot use sparse serialization, so it gets no entry in the source part.
+
+DROP TABLE IF EXISTS t_in_memory SYNC;
+DROP TABLE IF EXISTS t_reloaded SYNC;
+
+CREATE TABLE t_in_memory (cleared String, arr Array(String) DEFAULT []) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS serialization_info_version = 'basic',
+         propagate_types_serialization_versions_to_nested_types = 1,
+         min_bytes_for_wide_part = 1000000000;
+
+CREATE TABLE t_reloaded (cleared String, arr Array(String) DEFAULT []) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS serialization_info_version = 'basic',
+         propagate_types_serialization_versions_to_nested_types = 1,
+         min_bytes_for_wide_part = 1000000000;
+
+INSERT INTO t_in_memory (cleared) VALUES ('x');
+INSERT INTO t_reloaded (cleared) VALUES ('x');
+
+-- The only difference between the two tables: this one rebuilds its serialization info from disk.
+DETACH TABLE t_reloaded;
+ATTACH TABLE t_reloaded;
+
+ALTER TABLE t_in_memory CLEAR COLUMN cleared SETTINGS mutations_sync = 2;
+ALTER TABLE t_reloaded CLEAR COLUMN cleared SETTINGS mutations_sync = 2;
+
+-- The pins have to hold or the assertions below measure nothing: the divergence needs a Compact part.
+SELECT 'part types', groupArray(part_type) FROM (SELECT part_type FROM system.parts
+    WHERE database = currentDatabase() AND table IN ('t_in_memory', 't_reloaded') AND active ORDER BY table);
+
+-- The witness.
+SELECT 'mutated parts identical',
+    (SELECT bytes_on_disk FROM system.parts WHERE database = currentDatabase() AND table = 't_in_memory' AND active)
+  = (SELECT bytes_on_disk FROM system.parts WHERE database = currentDatabase() AND table = 't_reloaded' AND active);
+
+SELECT 'mutated part hashes identical',
+    (SELECT (hash_of_all_files, hash_of_uncompressed_files) FROM system.parts WHERE database = currentDatabase() AND table = 't_in_memory' AND active)
+  = (SELECT (hash_of_all_files, hash_of_uncompressed_files) FROM system.parts WHERE database = currentDatabase() AND table = 't_reloaded' AND active);
+
+-- The control: the divergence was metadata-only, so this stays green before and after the fix.
+SELECT 'reads agree',
+    (SELECT groupArray((cleared, arr)) FROM t_in_memory) = (SELECT groupArray((cleared, arr)) FROM t_reloaded);
+
+-- Without this the rows above are all satisfied by two un-mutated parts, which are identical anyway.
+SELECT 'cleared values', (SELECT groupArray(cleared) FROM t_in_memory), (SELECT groupArray(cleared) FROM t_reloaded);
+
+DROP TABLE t_in_memory SYNC;
+DROP TABLE t_reloaded SYNC;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/113500
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a mutation of a Compact part producing a different result depending on whether the part's serialization info was still in memory or had been reloaded from `serialization.json`, when the table uses `serialization_info_version = 'basic'`. On `ReplicatedMergeTree` this made two replicas holding a byte-identical source part write different mutated parts, and the mutation failed with `CHECKSUM_DOESNT_MATCH`. Closes #113500.


### Description

`propagate_types_serialization_versions_to_nested_types` is written to `serialization.json` only when the serialization info version is at least `WITH_TYPES`, and `readJSONFromString` initializes it to `false`. A part reloaded from a `BASIC` file therefore always reported `false` while the storage reported the setting's own value.

A mutation compares a settings object built from the source part's infos against one built from the storage settings, and `operator==` is defaulted, so this never-persistable field alone made the two unequal. That fired the loop which materializes serialization info entries for every mutated column, including ones never written, so a part whose infos came from disk gained entries an in-memory one did not and the cross-replica checksum comparison failed.

The fix normalizes the field in the `SerializationInfoSettings` constructor, inside the existing `version < WITH_TYPES` block that already defaults the string, nullable and map versions for the same reason. All eight in-tree sites that build such an object from storage settings route through this constructor, so the writer, merge, mutate and reload paths agree by construction. `MutateTask` is not touched.

Nothing changes on disk: `writeJSON` already gates the key on `WITH_TYPES`, and under `BASIC` the sibling resets already force every nested serialization to its default, so the flag has no observable consumer. Measured over the nested types in Wide parts, the flag on and off gives identical files and content hashes; the same probe under `WITH_TYPES` gives 62 files vs 50, proving it can see the flag. No setting default changes, and existing parts stay readable with no migration.

Reverting the added line reddens the new stateless test. Applying the reset unconditionally, or forcing the flag on for `with_types`, reddens the existing `03800_string_size_stream_in_nested_types`, which already asserts the substreams of that table with the setting off and on.

Affected: master, 26.7, 26.6. Could someone add `v26.7-must-backport` and `v26.6-must-backport`?

<details>
<summary>Reproducer and measurements</summary>

Replication is only the carrier; two plain `MergeTree` tables in one server differ only in a `DETACH`/`ATTACH`:

```sql
CREATE TABLE a (cleared String, arr Array(String) DEFAULT []) ENGINE = MergeTree ORDER BY tuple()
  SETTINGS serialization_info_version = 'basic';
CREATE TABLE b (cleared String, arr Array(String) DEFAULT []) ENGINE = MergeTree ORDER BY tuple()
  SETTINGS serialization_info_version = 'basic';
INSERT INTO a (cleared) VALUES ('x');
INSERT INTO b (cleared) VALUES ('x');
DETACH TABLE b; ATTACH TABLE b;
ALTER TABLE a CLEAR COLUMN cleared SETTINGS mutations_sync = 2;
ALTER TABLE b CLEAR COLUMN cleared SETTINGS mutations_sync = 2;
```

Before: `a` 4 files / 208 bytes with no `serialization.json`; `b` 5 files / 295 bytes carrying
`{"kind":"Default","name":"arr","num_defaults":0,"num_rows":0}` for a column that was never written.
`data.bin` and every other file are byte-identical; only `serialization.json` differs, and
`checksums.txt` differs because it checksums it. After: both 4 files / 208 bytes.

`Array` is the minimal carrier because it cannot use sparse serialization, so it gets no entry in the
source part, and that is the entry the mutation invents.

Replicated arm, `system.part_log` scoped to the two replicas:

| | before | after |
|---|---|---|
| source parts identical | yes (424 bytes both) | yes (424 bytes both) |
| `MutatePart` errors | 1 (`error=40`) | 0 |
| mutated bytes | 519 vs 581 | 519 vs 519 |
| recovery `DownloadPart` | 1 | 0 |
| reads agree | yes | yes |
| `CHECK TABLE` on both replicas | 1 | 1 |

So the cost was a failed mutation plus a wasted mutate-and-refetch, not data loss or wrong results.

</details>
