### PR TITLE
Report a Glue table as absent only when Glue says it is not found

### DIFF
--- a/src/Databases/DataLake/GlueCatalog.cpp
+++ b/src/Databases/DataLake/GlueCatalog.cpp
@@ -326,12 +326,8 @@ CatalogTables GlueCatalog::listTablesInNamespaceDirect(const std::string & names
 
 bool GlueCatalog::existsTable(const std::string & database_name, const std::string & table_name) const
 {
-    Aws::Glue::Model::GetTableRequest request;
-    request.SetDatabaseName(database_name);
-    request.SetName(table_name);
-
-    auto outcome = glue_client->GetTable(request);
-    return outcome.IsSuccess();
+    TableMetadata metadata;
+    return tryGetTableMetadata(database_name, table_name, metadata);
 }
 
 bool GlueCatalog::tryGetTableMetadata(

--- a/src/Databases/DataLake/GlueCatalog.cpp
+++ b/src/Databases/DataLake/GlueCatalog.cpp
@@ -286,6 +286,11 @@ CatalogTables GlueCatalog::getTablesForDatabase(const std::string & db_name, siz
         }
         else
         {
+            /// The database is absent from Glue, so it contributes no tables. The error names the database, so
+            /// any pages already collected belong to a database that is gone and are dropped too.
+            if (outcome.GetError().GetErrorType() == Aws::Glue::GlueErrors::ENTITY_NOT_FOUND)
+                return {};
+
             throw DB::Exception(DB::ErrorCodes::DATALAKE_DATABASE_ERROR, "Exception calling GetTables {}", outcome.GetError().GetMessage());
         }
         if (limit != 0 && result.size() >= limit)

--- a/tests/integration/test_database_glue/test.py
+++ b/tests/integration/test_database_glue/test.py
@@ -1776,3 +1776,55 @@ def test_listing_propagates_non_not_found_error(started_cluster):
         )
     finally:
         node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
+
+
+def test_exists_table_answers_only_from_not_found(started_cluster):
+    # `EXISTS TABLE` must answer "absent" only when Glue reports the table as not found. Any other failure
+    # has to propagate, otherwise an outage makes an existing table look dropped, and the DDL paths that
+    # share this probe act on that answer.
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_exists_table_{uuid.uuid4().hex}"
+    namespace = f"{test_ref}_namespace"
+    table_name = f"{test_ref}_table"
+
+    catalog = load_catalog_impl(started_cluster)
+    catalog.create_namespace(namespace)
+    create_table(catalog, namespace, table_name)
+
+    create_clickhouse_glue_database(started_cluster, node, CATALOG_NAME)
+
+    assert (
+        "1"
+        == node.query(f"EXISTS TABLE {CATALOG_NAME}.`{namespace}.{table_name}`").strip()
+    )
+    assert (
+        "0"
+        == node.query(
+            f"EXISTS TABLE {CATALOG_NAME}.`{namespace}.no_such_table`"
+        ).strip()
+    )
+
+    # Reusing the name of the table created above is what makes the arm below an assertion about error
+    # handling rather than about absence: the table is known to exist, so answering "0" is the misreport.
+    db_name = f"{test_ref}_unreachable"
+    # ATTACH is lazy, so the unreachable endpoint is only contacted by the probe below.
+    node.query(
+        f"""
+        ATTACH DATABASE {db_name} ENGINE = DataLakeCatalog('http://fake-glue:1')
+        SETTINGS catalog_type = 'glue', region = 'us-east-1', storage_endpoint = 'http://fake-glue:1/x',
+                 aws_access_key_id = '{minio_access_key}', aws_secret_access_key = '{minio_secret_key}'
+        """
+    )
+    try:
+        error = node.query_and_get_error(
+            f"EXISTS TABLE {db_name}.`{namespace}.{table_name}`"
+        )
+        assert "DATALAKE_DATABASE_ERROR" in error, error
+        # This per-table message has a single emitter, so it pins the failure to the GetTable probe rather
+        # than to a listing: the error alone would also be satisfied by an unrelated failing call.
+        assert (
+            f"Exception calling GetTable for table {namespace}.{table_name}" in error
+        ), error
+    finally:
+        node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")

--- a/tests/integration/test_database_glue/test.py
+++ b/tests/integration/test_database_glue/test.py
@@ -1747,6 +1747,7 @@ def test_listing_propagates_non_not_found_error(started_cluster):
     node = started_cluster.instances["node1"]
 
     db_name = f"glue_unreachable_{uuid.uuid4().hex}"
+    missing_namespace = f"glue_unreachable_ns_{uuid.uuid4().hex}"
     # ATTACH is lazy, so the unreachable endpoint is only contacted by the listing below.
     node.query(
         f"""
@@ -1758,13 +1759,20 @@ def test_listing_propagates_non_not_found_error(started_cluster):
     try:
         # `name = 'ns.table'` is pushed down, so the failing call is the single-namespace listing -- the
         # same code path the previous test exercises -- rather than the enclosing database enumeration.
-        # A low retry count keeps the unreachable endpoint from retrying for minutes.
         error = node.query_and_get_error(
             f"SELECT name FROM system.tables WHERE database = '{db_name}' "
-            f"AND name = 'some_namespace.some_table' "
-            f"SETTINGS show_data_lake_catalogs_in_system_tables = true, s3_retry_attempts = 1"
+            f"AND name = '{missing_namespace}.some_table' "
+            f"SETTINGS show_data_lake_catalogs_in_system_tables = true"
         )
         assert "DATALAKE_DATABASE_ERROR" in error, error
         assert "Exception calling GetTables" in error, error
+
+        # The error above is only evidence about the changed branch if the single-namespace listing is what
+        # failed. The database enumeration throws with a byte-identical message from an unmodified function,
+        # so without this the arm would also pass on a degraded pushdown -- and then a guard widened to
+        # swallow every error type would still be reported as caught.
+        assert node.contains_in_log(
+            f"Getting tables for database '{missing_namespace}'"
+        )
     finally:
         node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")

--- a/tests/integration/test_database_glue/test.py
+++ b/tests/integration/test_database_glue/test.py
@@ -1720,6 +1720,11 @@ def test_listing_tolerates_missing_namespace(started_cluster):
         ).strip()
     )
 
+    # T1 is only meaningful if the absent namespace really was listed. Without the pushdown the query
+    # degrades to listing the namespaces Glue reports, which excludes this one, so nothing would reach
+    # the code under test and T1 would pass unpatched.
+    assert node.contains_in_log(f"Getting tables for database '{missing_namespace}'")
+
     # T2: the same pushdown still resolves a table in a namespace that does exist.
     assert (
         f"{namespace}.{table_name}"
@@ -1732,3 +1737,34 @@ def test_listing_tolerates_missing_namespace(started_cluster):
 
     # T3: the unfiltered listing still reports the table.
     assert table_name in node.query(f"SHOW TABLES FROM {CATALOG_NAME}")
+
+
+def test_listing_propagates_non_not_found_error(started_cluster):
+    # The tolerance above must stay narrow: only Glue's `EntityNotFoundException` may be read as "this
+    # database contributes no tables". Any other failure -- here an endpoint whose host does not resolve
+    # -- must still fail the listing loudly, so a misconfigured or unreachable catalog is never silently
+    # reported as empty.
+    node = started_cluster.instances["node1"]
+
+    db_name = f"glue_unreachable_{uuid.uuid4().hex}"
+    # ATTACH is lazy, so the unreachable endpoint is only contacted by the listing below.
+    node.query(
+        f"""
+        ATTACH DATABASE {db_name} ENGINE = DataLakeCatalog('http://fake-glue:1')
+        SETTINGS catalog_type = 'glue', region = 'us-east-1', storage_endpoint = 'http://fake-glue:1/x',
+                 aws_access_key_id = '{minio_access_key}', aws_secret_access_key = '{minio_secret_key}'
+        """
+    )
+    try:
+        # `name = 'ns.table'` is pushed down, so the failing call is the single-namespace listing -- the
+        # same code path the previous test exercises -- rather than the enclosing database enumeration.
+        # A low retry count keeps the unreachable endpoint from retrying for minutes.
+        error = node.query_and_get_error(
+            f"SELECT name FROM system.tables WHERE database = '{db_name}' "
+            f"AND name = 'some_namespace.some_table' "
+            f"SETTINGS show_data_lake_catalogs_in_system_tables = true, s3_retry_attempts = 1"
+        )
+        assert "DATALAKE_DATABASE_ERROR" in error, error
+        assert "Exception calling GetTables" in error, error
+    finally:
+        node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")

--- a/tests/integration/test_database_glue/test.py
+++ b/tests/integration/test_database_glue/test.py
@@ -1690,3 +1690,45 @@ def test_glue_catalog_user_attach_under_restriction_is_rejected(started_cluster)
 
     # With the opt-in the database is usable again, so it can be cleaned up.
     node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC", settings=allow)
+
+
+def test_listing_tolerates_missing_namespace(started_cluster):
+    # A Glue table listing must treat a database that is absent from Glue as contributing no tables, instead
+    # of failing the whole query. `name = 'ns.table'` is pushed down to a single-namespace listing, so naming a
+    # namespace that does not exist reaches the GetTables error branch with no race.
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_missing_namespace_{uuid.uuid4().hex}"
+    namespace = f"{test_ref}_namespace"
+    table_name = f"{test_ref}_table"
+    missing_namespace = f"{test_ref}_absent_namespace"
+
+    catalog = load_catalog_impl(started_cluster)
+    catalog.create_namespace(namespace)
+    table = create_table(catalog, namespace, table_name)
+    table.append(generate_arrow_data(10))
+
+    create_clickhouse_glue_database(started_cluster, node, CATALOG_NAME)
+
+    # T1: the missing namespace yields an empty listing, not an error.
+    assert (
+        ""
+        == node.query(
+            f"SELECT name FROM system.tables WHERE database = '{CATALOG_NAME}' "
+            f"AND name = '{missing_namespace}.no_such_table' "
+            f"SETTINGS show_data_lake_catalogs_in_system_tables = true"
+        ).strip()
+    )
+
+    # T2: the same pushdown still resolves a table in a namespace that does exist.
+    assert (
+        f"{namespace}.{table_name}"
+        == node.query(
+            f"SELECT name FROM system.tables WHERE database = '{CATALOG_NAME}' "
+            f"AND name = '{namespace}.{table_name}' "
+            f"SETTINGS show_data_lake_catalogs_in_system_tables = true"
+        ).strip()
+    )
+
+    # T3: the unfiltered listing still reports the table.
+    assert table_name in node.query(f"SHOW TABLES FROM {CATALOG_NAME}")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/94276

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes two cases where an AWS Glue `DataLakeCatalog` database reported a table as absent instead of reporting an error. `SHOW TABLES` and `system.tables` no longer fail with `DATALAKE_DATABASE_ERROR` ("Exception calling GetTables ... not found") when a Glue database is absent while its tables are listed, for example because an unrelated database in the same AWS account was dropped concurrently; such a database now contributes no tables instead of aborting the listing. `EXISTS TABLE` no longer answers `0` for a table that exists when the underlying `GetTable` call fails for a reason other than the table being absent, such as an authentication, DNS or 5xx failure. Every other Glue error still propagates in both paths.

### Description

Both paths broke the same rule: only Glue's `EntityNotFoundException` means absent, everything else must
propagate. That rule comes from `09f4d854d190f46` ("Fix misreporting of datalake catalog errors as missing
tables"), which `GlueCatalog::tryGetTableMetadata` already follows.

`getTablesForDatabase` treated every non-success `GetTables` outcome as fatal. `getTables` lists the account's
databases and then lists each one's tables, so a database dropped between those two calls aborts the whole
listing, and an unrelated `DROP DATABASE` breaks a reader's `SHOW TABLES`. It is also reachable with no race,
since the `Kind::Equals` pushdown turns `name = 'ns.table'` into a single-namespace listing. It now returns an
empty listing for that one error type. `return {}` rather than the pages gathered so far is deliberate: the
error names the database, so no page of it is trustworthy.

`existsTable` had the mirror-image defect, returning the `GetTable` outcome's success flag directly, so any
failure became "absent". `DatabaseDataLake::isTableExist` delegates to it, so an unreachable or misconfigured
catalog made `EXISTS TABLE` answer `0` for a table that exists, and the DDL paths sharing that probe acted on
the answer. It now delegates to `tryGetTableMetadata`, as `RestCatalog::existsTable` does.

401/403/5xx and throttling therefore still fail loudly in both paths, so #94276 is not reintroduced.

Validated with three moto-backed tests in `test_database_glue`, each failing on unpatched master and passing
with the fix; the module's other 27 tests pass unchanged on both arms. Without the fix the third test's
unreachable-catalog arm sees `EXISTS TABLE` return `0` for a table just created.

Found via a flaky `test_e2e_catalogs[glue]`, which runs only against real Glue credentials and so is not
observable in public CI, so the flake's disappearance is not publicly verifiable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1141` (included in `26.8` and later)
- Backported to: `26.7.6.50`
<!-- ch-version-info:end -->