### PR TITLE
Build the boolean fixture of 04308_arrow_oob_reads_value with two rows

### DIFF
--- a/tests/queries/0_stateless/04308_arrow_oob_reads_value.sh
+++ b/tests/queries/0_stateless/04308_arrow_oob_reads_value.sh
@@ -51,9 +51,12 @@ def inflate_row_count(data, orig_n, large_n=LARGE_N):
 
 # 8. Boolean: 2 rows → still a 1-byte bit-packed buffer, so the inflated row count is the only
 #    corruption and the buffer length stays honest. A 1-row array puts the literal 1 in the
-#    buffer-length fields too, and inflating those declares a buffer longer than the whole file,
+#    buffer-length field too, and inflating it declares a buffer longer than the whole file,
 #    which is rejected before the per-element read. 4 and 8 collide with other metadata fields.
 d = write_arrow(pa.array([True, False], type=pa.bool_()))
+# Pin that: the needle must match the two row counts and nothing else.
+pos = [i for i in range(0, len(d) - 7, 8) if struct.unpack_from('<q', d, i)[0] == 2]
+assert len(pos) == 2, f'expected exactly 2 aligned int64==2 (the row counts), got {pos}'
 open(f'{out}/bool.arrow', 'wb').write(inflate_row_count(d, 2))
 
 # 9. Date32 slow path (no numeric type hint → check_date_range=true → Value() loop)

--- a/tests/queries/0_stateless/04308_arrow_oob_reads_value.sh
+++ b/tests/queries/0_stateless/04308_arrow_oob_reads_value.sh
@@ -49,9 +49,12 @@ def inflate_row_count(data, orig_n, large_n=LARGE_N):
         pos = idx + 1
     return data
 
-# 8. Boolean: 1 row → 1-byte bit buffer, inflated to 16384 rows
-d = write_arrow(pa.array([True], type=pa.bool_()))
-open(f'{out}/bool.arrow', 'wb').write(inflate_row_count(d, 1))
+# 8. Boolean: 2 rows → still a 1-byte bit-packed buffer, so the inflated row count is the only
+#    corruption and the buffer length stays honest. A 1-row array puts the literal 1 in the
+#    buffer-length fields too, and inflating those declares a buffer longer than the whole file,
+#    which is rejected before the per-element read. 4 and 8 collide with other metadata fields.
+d = write_arrow(pa.array([True, False], type=pa.bool_()))
+open(f'{out}/bool.arrow', 'wb').write(inflate_row_count(d, 2))
 
 # 9. Date32 slow path (no numeric type hint → check_date_range=true → Value() loop)
 d = write_arrow(pa.array([100], type=pa.date32()))


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Make the boolean case of `04308_arrow_oob_reads_value` corrupt only the declared row count, so it reaches the per-element bit-packed buffer guard it is meant to cover.

### Description

Each fixture is corrupted by `inflate_row_count`, which rewrites every 8-aligned little-endian `int64` equal to the original row count. For the `bool` case only, that sweep also hits a **buffer-length** field: a 1-row boolean is bit-packed into a single byte, so the literal `1` is a buffer length too. Of its four matching offsets two are row counts, one is `Buffer[1].length` and one a body byte, so the file declares a 16384-byte buffer inside an 8-byte body.

It is therefore rejected earlier than intended, by the generic message-envelope check, and the guard case 8 is documented to cover (the per-element bit-packed read) is never reached. The assertion still passes, so the arm is silently weak rather than red. Decoding every `write(inflate_row_count(` fixture in `04307`/`04308`/`04309` (7 + 9 + 7 = 23) shows this is the only one affected.

Fix: build the fixture with two rows and inflate on `orig_n = 2`. A 2-row boolean is still one byte, so `2` matches only the two row counts and the buffer length stays honest, which an added assertion now pins. `04307`'s `dict_indexes` case already uses this idiom; larger counts collide with other metadata. `inflate_row_count` is untouched, so the other eight fixtures stay byte-identical.

Validated on a master build at this base: the fixed fixture reports `Arrow IPC bool buffer is too small: have 1 bytes, need 2048` where the old one reported the envelope error, all nine cases still assert `INCORRECT_DATA` against an unchanged `.reference`, and 50/50 randomized runs pass. `04358` and `04410` still cover the envelope check.

The fixture also becomes reader-agnostic, which matters for the in-flight `arrow` 25.0.0 backports (#113539, #113541, #113542): under arrow 25 the old fixture dies at the IO layer with `File too short`, while the new one is read and then rejected for the undersized bool buffer.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.6.3.16`, `26.5.7.19`, `26.3.18.10`
<!-- ch-version-info:end -->