### PR TITLE
Do not send a shard a LIMIT WITH TIES whose ORDER BY was removed

### DIFF
--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -1051,6 +1051,12 @@ QueryTreeNodePtr replaceTableExpressionAndRemoveJoin(
     if (query_node->hasLimitByOffset())
         query_node->getLimitByOffset() = {};
     query_node->getLimitBy().getNodes().clear();
+    /// LIMIT selects rows relative to the ORDER BY cleared just above, so it is stale here.
+    query_node->setIsLimitWithTies(false);
+    if (query_node->hasLimit())
+        query_node->getLimit() = {};
+    if (query_node->hasOffset())
+        query_node->getOffset() = {};
 
     auto & projection = modified_query_node->getProjection().getNodes();
     projection.clear();
@@ -1215,7 +1221,14 @@ SelectQueryInfo ReadFromMerge::getModifiedQueryInfo(const ContextMutablePtr & mo
         /// Original query could contain JOIN but we need only the first joined table and its columns.
         auto & modified_select = modified_query_info.query->as<ASTSelectQuery &>();
         TreeRewriterResult new_analyzer_res = *modified_query_info.syntax_analyzer_result;
-        removeJoin(modified_select, new_analyzer_res, modified_context);
+        if (removeJoin(modified_select, new_analyzer_res, modified_context))
+        {
+            /// removeJoin cleared the ORDER BY, so the LIMIT it selected rows for is stale.
+            /// Only when a JOIN was actually removed: a child without one may own its LIMIT.
+            modified_select.limit_with_ties = false;
+            modified_select.setExpression(ASTSelectQuery::Expression::LIMIT_LENGTH, {});
+            modified_select.setExpression(ASTSelectQuery::Expression::LIMIT_OFFSET, {});
+        }
         modified_query_info.syntax_analyzer_result = std::make_shared<TreeRewriterResult>(std::move(new_analyzer_res));
     }
 

--- a/tests/queries/0_stateless/04757_with_ties_merge_over_distributed_join.reference
+++ b/tests/queries/0_stateless/04757_with_ties_merge_over_distributed_join.reference
@@ -69,3 +69,10 @@
 998
 997
 997
+-- 10 witness: the initiator side, no remote shard needed
+19
+19
+18
+18
+17
+17

--- a/tests/queries/0_stateless/04757_with_ties_merge_over_distributed_join.reference
+++ b/tests/queries/0_stateless/04757_with_ties_merge_over_distributed_join.reference
@@ -1,0 +1,71 @@
+-- 1 witness: Merge over Distributed + JOIN + WITH TIES
+19
+19
+18
+18
+17
+17
+-- 2 witness, old analyzer
+19
+19
+18
+18
+17
+17
+-- 3 witness via the merge() table function
+19
+19
+18
+18
+17
+17
+-- 4 witness with GLOBAL INNER JOIN
+19
+19
+18
+18
+17
+17
+-- 5 control: plain Distributed + JOIN already worked
+19
+19
+18
+18
+17
+17
+-- 6 control: Merge over Distributed without a JOIN already worked
+19
+19
+18
+18
+17
+17
+-- 7 ties are still honored: plain LIMIT 5 returns five rows
+19
+19
+18
+18
+17
+-- 8 a child without a JOIN keeps its own LIMIT
+999
+998
+997
+996
+995
+999
+998
+997
+996
+995
+-- 9 the child must not pre-limit an unordered read
+999
+999
+998
+998
+997
+999
+999
+998
+998
+997
+997

--- a/tests/queries/0_stateless/04757_with_ties_merge_over_distributed_join.sql
+++ b/tests/queries/0_stateless/04757_with_ties_merge_over_distributed_join.sql
@@ -14,6 +14,9 @@ DROP TABLE IF EXISTS d_local_112029;
 DROP TABLE IF EXISTS m_local_112029;
 DROP TABLE IF EXISTS d_wide_112029;
 DROP TABLE IF EXISTS m_wide_112029;
+DROP TABLE IF EXISTS t_view_112029;
+DROP VIEW IF EXISTS v_112029;
+DROP TABLE IF EXISTS d_view_112029;
 
 CREATE TABLE t_112029 (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY a;
 INSERT INTO t_112029 SELECT number, number % 3 FROM numbers(20);
@@ -81,6 +84,22 @@ ORDER BY m.a DESC LIMIT 5;
 SELECT m.a FROM m_wide_112029 AS m LEFT JOIN r_112029 AS r ON m.b = r.b
 ORDER BY m.a DESC LIMIT 5 WITH TIES;
 
+CREATE TABLE t_view_112029 (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY a;
+INSERT INTO t_view_112029 SELECT number, number % 3 FROM numbers(20);
+CREATE VIEW v_112029 AS SELECT a, b FROM t_view_112029;
+CREATE TABLE d_view_112029 (a UInt32, b UInt32)
+    ENGINE = Distributed(test_shard_localhost, currentDatabase(), v_112029);
+
+-- The same malformed child also fails on the initiator, before any shard sees it: a local shard
+-- is planned by `createLocalPlan`, and `collectFiltersForAnalysis` plans that child at the
+-- `Complete` stage, the only planner run that builds a limit step for it, so an orderless child
+-- carrying `WITH TIES` raises a `LOGICAL_ERROR` there. `prefer_localhost_replica` is pinned
+-- because only the local-shard plan reaches that path and the runner randomizes it. The
+-- `ARRAY JOIN` doubles every row, so `a` = 17 is tied and `LIMIT 5` returns six rows.
+SELECT '-- 10 witness: the initiator side, no remote shard needed';
+SELECT a FROM merge(currentDatabase(), '^d_view_112029$') LEFT ARRAY JOIN [1, 2] AS z
+ORDER BY a DESC LIMIT 5 WITH TIES SETTINGS prefer_localhost_replica = 1;
+
 DROP TABLE t_112029;
 DROP TABLE d_112029;
 DROP TABLE m_112029;
@@ -90,3 +109,6 @@ DROP TABLE d_local_112029;
 DROP TABLE m_local_112029;
 DROP TABLE d_wide_112029;
 DROP TABLE m_wide_112029;
+DROP TABLE d_view_112029;
+DROP VIEW v_112029;
+DROP TABLE t_view_112029;

--- a/tests/queries/0_stateless/04757_with_ties_merge_over_distributed_join.sql
+++ b/tests/queries/0_stateless/04757_with_ties_merge_over_distributed_join.sql
@@ -1,0 +1,92 @@
+-- Tags: distributed
+
+-- Reading a Merge table over a Distributed table with a JOIN used to send the shards a query
+-- that kept LIMIT ... WITH TIES after its ORDER BY was removed, which the shard's parser
+-- rejects with WITH_TIES_WITHOUT_ORDER_BY. test_cluster_two_shards has a genuinely remote
+-- shard, so the fragment is really serialized; an all-local cluster does not reproduce it.
+
+DROP TABLE IF EXISTS t_112029;
+DROP TABLE IF EXISTS d_112029;
+DROP TABLE IF EXISTS m_112029;
+DROP TABLE IF EXISTS r_112029;
+DROP TABLE IF EXISTS t_wide_112029;
+DROP TABLE IF EXISTS d_local_112029;
+DROP TABLE IF EXISTS m_local_112029;
+DROP TABLE IF EXISTS d_wide_112029;
+DROP TABLE IF EXISTS m_wide_112029;
+
+CREATE TABLE t_112029 (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY a;
+INSERT INTO t_112029 SELECT number, number % 3 FROM numbers(20);
+CREATE TABLE d_112029 (a UInt32, b UInt32)
+    ENGINE = Distributed(test_cluster_two_shards, currentDatabase(), t_112029);
+CREATE TABLE m_112029 (a UInt32, b UInt32) ENGINE = Merge(currentDatabase(), '^d_112029$');
+CREATE TABLE r_112029 (b UInt32) ENGINE = MergeTree ORDER BY b;
+INSERT INTO r_112029 SELECT number FROM numbers(3);
+
+-- Each value of `a` appears twice because the cluster has two shards reading the same table,
+-- so rows 5 and 6 are tied on a = 17 and WITH TIES extends LIMIT 5 to six rows.
+
+SELECT '-- 1 witness: Merge over Distributed + JOIN + WITH TIES';
+SELECT m.a FROM m_112029 AS m LEFT JOIN r_112029 AS r ON m.b = r.b
+ORDER BY m.a DESC LIMIT 5 WITH TIES;
+
+SELECT '-- 2 witness, old analyzer';
+SELECT m.a FROM m_112029 AS m LEFT JOIN r_112029 AS r ON m.b = r.b
+ORDER BY m.a DESC LIMIT 5 WITH TIES SETTINGS enable_analyzer = 0;
+
+SELECT '-- 3 witness via the merge() table function';
+SELECT s.a FROM merge(currentDatabase(), '^d_112029$') AS s LEFT JOIN r_112029 AS r ON s.b = r.b
+ORDER BY s.a DESC LIMIT 5 WITH TIES;
+
+SELECT '-- 4 witness with GLOBAL INNER JOIN';
+SELECT m.a FROM m_112029 AS m GLOBAL INNER JOIN r_112029 AS r ON m.b = r.b
+ORDER BY m.a DESC LIMIT 5 WITH TIES;
+
+SELECT '-- 5 control: plain Distributed + JOIN already worked';
+SELECT d.a FROM d_112029 AS d LEFT JOIN r_112029 AS r ON d.b = r.b
+ORDER BY d.a DESC LIMIT 5 WITH TIES;
+
+-- max_threads is pinned only here: at 1 this path concatenates the per-shard streams instead of
+-- merging them and answers 19 18 17 16 15, which is a separate pre-existing defect of the no-join
+-- path and would mask this arm. Every witness above stays fully randomized.
+SELECT '-- 6 control: Merge over Distributed without a JOIN already worked';
+SELECT m.a FROM m_112029 AS m ORDER BY m.a DESC LIMIT 5 WITH TIES SETTINGS max_threads = 2;
+
+-- Five rows here against six in arm 1 shows WITH TIES is still applied above the JOIN.
+SELECT '-- 7 ties are still honored: plain LIMIT 5 returns five rows';
+SELECT m.a FROM m_112029 AS m LEFT JOIN r_112029 AS r ON m.b = r.b
+ORDER BY m.a DESC LIMIT 5;
+
+CREATE TABLE t_wide_112029 (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY a;
+INSERT INTO t_wide_112029 SELECT number, number % 3 FROM numbers(1000);
+CREATE TABLE d_local_112029 (a UInt32, b UInt32)
+    ENGINE = Distributed(test_shard_localhost, currentDatabase(), t_wide_112029);
+CREATE TABLE m_local_112029 (a UInt32, b UInt32) ENGINE = Merge(currentDatabase(), '^d_local_112029$');
+
+-- Without a JOIN the child keeps its own ORDER BY, so it also keeps and applies its LIMIT.
+-- Returning 1000 rows here means the reset was applied to a child that owns its LIMIT.
+SELECT '-- 8 a child without a JOIN keeps its own LIMIT';
+SELECT a FROM m_local_112029 ORDER BY a DESC LIMIT 5 SETTINGS enable_analyzer = 1;
+SELECT a FROM m_local_112029 ORDER BY a DESC LIMIT 5 SETTINGS enable_analyzer = 0;
+
+CREATE TABLE d_wide_112029 (a UInt32, b UInt32)
+    ENGINE = Distributed(test_cluster_two_shards, currentDatabase(), t_wide_112029);
+CREATE TABLE m_wide_112029 (a UInt32, b UInt32) ENGINE = Merge(currentDatabase(), '^d_wide_112029$');
+
+-- The physical order is the reverse of the requested one, so a child that truncated to its
+-- first rows would answer 4 3 2 1 0 instead of the largest values.
+SELECT '-- 9 the child must not pre-limit an unordered read';
+SELECT m.a FROM m_wide_112029 AS m LEFT JOIN r_112029 AS r ON m.b = r.b
+ORDER BY m.a DESC LIMIT 5;
+SELECT m.a FROM m_wide_112029 AS m LEFT JOIN r_112029 AS r ON m.b = r.b
+ORDER BY m.a DESC LIMIT 5 WITH TIES;
+
+DROP TABLE t_112029;
+DROP TABLE d_112029;
+DROP TABLE m_112029;
+DROP TABLE r_112029;
+DROP TABLE t_wide_112029;
+DROP TABLE d_local_112029;
+DROP TABLE m_local_112029;
+DROP TABLE d_wide_112029;
+DROP TABLE m_wide_112029;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/112029
Closes: https://github.com/ClickHouse/ClickHouse/issues/114036
Related: https://github.com/ClickHouse/ClickHouse/pull/113759


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `Code: 476` (`Can not use WITH TIES without ORDER BY`) raised by a remote shard, and the logical error `LIMIT WITH TIES without ORDER BY` raised on the initiator, when selecting from a `Merge` table over a `Distributed` table with a `JOIN` and `ORDER BY ... LIMIT n WITH TIES`. The child query kept its `LIMIT` clause after its `ORDER BY` was removed.

### Description

`StorageMerge` hands each child a query producing un-joined data, so it removes the `JOIN` and everything depending on joined columns, including the `ORDER BY`. Both join-removal paths left the `LIMIT ... WITH TIES` modifiers behind, so the child became `LIMIT n WITH TIES` with no `ORDER BY`. That is not valid SQL, and the one malformed child surfaces in two places:

- On a remote shard the fragment is serialized and shipped, so the shard's own parser rejects it with `Code: 476`. This is #112029.
- On the initiator, a `Distributed` constituent with a local shard is planned by `createLocalPlan`, and `collectFiltersForAnalysis` plans that child at the `Complete` stage. That is the only planner run which builds a limit step for a child otherwise read at `FetchColumns`, so `addLimitStep` raises `LIMIT WITH TIES without ORDER BY`. This is #114036.

The fix clears the whole stale child `LIMIT` clause, length and offset and the `WITH TIES` flag, in the same two places that clear the `ORDER BY`. The child must return all rows for the parent to sort above the join, so nothing is lost, and the parent still applies `WITH TIES`.

Both arms are now reproduced and verified in both directions on one tree. The initiator arm needs no remote shard: a `Merge` over a `Distributed` whose own remote table passes the filter-collection gate, a `View` being cheapest. Arm 10 covers it; `prefer_localhost_replica` is pinned because only the local-shard plan reaches that path.

Since this was opened, #113759 landed `select.limit_with_ties = false` in `removeJoin`, superseding the old-analyzer half here, which I will reduce to the remaining length and offset reset when I merge master. The analyzer path is still unfixed on master.

Also noticed, not addressed here: a `Merge` over a two-shard `Distributed` with no `JOIN` at `max_threads = 1` returns one shard's rows instead of both, on unmodified master. Area of #111464.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.866` (included in `26.9` and later)
<!-- ch-version-info:end -->