### PR TITLE
Cap max_threads in the DistributedQueryTest gtest

### DIFF
--- a/src/Server/DistributedQuery/tests/gtest_distributed_query.cpp
+++ b/src/Server/DistributedQuery/tests/gtest_distributed_query.cpp
@@ -515,6 +515,9 @@ try
 
     query_context->setSetting("distributed_plan_force_exchange_kind", exchangeKind);
 
+    /// Each task runs its own pipeline, so `max_threads` at auto multiplies core count by task count.
+    query_context->setSetting("max_threads", 1);
+
     {
         /// Create JOIN query plan
         auto query_plan = createHashJoinQueryPlan(data_a, data_b);

--- a/src/Server/DistributedQuery/tests/gtest_distributed_query.cpp
+++ b/src/Server/DistributedQuery/tests/gtest_distributed_query.cpp
@@ -515,8 +515,8 @@ try
 
     query_context->setSetting("distributed_plan_force_exchange_kind", exchangeKind);
 
-    /// Each task runs its own pipeline, so `max_threads` at auto multiplies core count by task count.
-    query_context->setSetting("max_threads", 1);
+    /// Each task runs its own pipeline; 4 is the shuffle bucket count the other pipelines use.
+    query_context->setSetting("max_threads", 4);
 
     {
         /// Create JOIN query plan


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`DistributedQueryTest.ShuffleHashJoin` left `max_threads` unset, so it resolved to auto, which on
a large host is the physical core count (192 here). Every distributed task runs its own pipeline,
so that value gets multiplied by the task count. It twice consumed the remaining budget of the
`Unit tests (tsan)` job and was killed at the 45-minute mark. Because gtest writes its JSON report
only after the binary exits, a kill loses the whole run's result: on those two runs the tsan arm
reported no pass count at all, while asan_ubsan and msan reported 19531 and 19527 passing tests.

The failure is a timeout, not a deadlock. Over 30 days this test's tsan duration has a median of
176 ms but a maximum among *passing* runs of 1445260 ms (24.1 min); asan_ubsan and msan never
exceed 736 ms. Thread population drives that tail: TSAN has 255 thread slots and does a stop-the-
world `DoReset` once they are exhausted. In both failing runs 35 threads including the main thread
were parked in `__tsan::SlotAttachAndLock`.

Setting `max_threads = 4` bounds the pipelines whose width derives from it: measured at every
`initializeExecution` call, all 14 task pipelines become 4 wide instead of 8 at 192 plus 6 at 4,
and threads created per run fall from ~877 to ~113 under TSAN.

4 rather than 1, because `max_threads` also sizes `ConcurrentHashJoin`'s shard count on the task
side, and at 1 that collapses to a single shard, so the cross-shard merge paths a test named
`ShuffleHashJoin` should cover stop executing. Measured shard-loop iterations per run: 2040 at
auto, 24 at 4, 0 at 1. Coverage is otherwise unchanged: same stages, tasks, exchanges and bucket
count, both exchange kinds run, no `no-tsan` tag, and each task keeps its own `startTask` thread
(14 `DistQueryTask` threads either way).
<details>
<summary>Validation</summary>

All arms pinned to 32 CPUs, which is required on the host used here because `unit_tests_dbms`
otherwise exhausts `RLIMIT_MEMLOCK` creating one io_uring per CPU. Interleaved A/B so box load
cannot explain the difference.

| measurement | before | after |
|---|---|---|
| debug, 20 runs/arm interleaved | 20/20 pass, p50 532 ms | 20/20 pass, p50 56 ms (9.5x) |
| TSAN, 6 runs/arm interleaved | 6/6 pass, 0 warnings, 913-1320 ms | 6/6 pass, 0 warnings, 133-297 ms |
| TSAN threads created per run (3 runs/arm) | 875-879 | 112-115 |
| debug threads created per run | 523 | 115 |
| `ConcurrentHashJoin` shards | 256 | 4 |
| cross-shard merge iterations per run | 2040 | 24 |
| distinct threads named `DistQueryTask` (TSAN) | 14 | 14 (unchanged by design) |
| whole binary under TSAN, job's own gdb launcher | 19470 tests, 0 failures, 0 errors, 1735 s | 19470 tests, 0 failures, 0 errors, 1696 s |
| this test inside that whole-binary run | 0.932 s | 0.093 s |

The TSAN ranges are non-overlapping; the debug ranges overlap at the edges (7 of 20 before at
or below the after maximum), so the debug result is given as a median ratio.

The whole-binary runs exclude the `ReadBufferFromS3Test`/`*S3*` suites, which abort identically
on both arms without a local MinIO endpoint. In both whole-binary runs the gtest JSON report
was written, which is the artifact a killed run loses.

Residuals, unchanged by this PR: `PipelineExecutor`'s upscaling drain loop
(`PipelineExecutor.cpp:429-434`) has no cancellation check or backoff and held 15-17 spinning
threads in the failing runs; and `startTask` spawns an unpooled `std::thread` per task, so slot
pressure still scales with fan-out. This reduces this test's contribution to TSAN slot
pressure; it does not make the binary immune.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1002` (included in `26.8` and later)
<!-- ch-version-info:end -->