### PR TITLE
Fix cross-test access-entity name collisions in the 04516_role_rewrite test family

### DIFF
--- a/tests/queries/0_stateless/04516_role_rewrite.lib
+++ b/tests/queries/0_stateless/04516_role_rewrite.lib
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-table_name="table_04516_${CLICKHOUSE_DATABASE}"
-user_a="user_04516_a_${CLICKHOUSE_DATABASE}"
-user_b="user_04516_b_${CLICKHOUSE_DATABASE}"
-role1="role1_04516_${CLICKHOUSE_DATABASE}"
-role2="role2_04516_${CLICKHOUSE_DATABASE}"
-role3="role3_04516_${CLICKHOUSE_DATABASE}"
-role4="role4_04516_${CLICKHOUSE_DATABASE}"
+table_name="table_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+user_a="user_a_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+user_b="user_b_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+role1="role1_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+role2="role2_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+role3="role3_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+role4="role4_${CLICKHOUSE_TEST_UNIQUE_NAME}"
 
 query_as_user()
 {


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Name the global access entities in `04516_role_rewrite.lib` per test instead of per database, so the four tests sharing that library no longer collide when `clickhouse-test` runs with a fixed `--database`.


### Description

`04516_role_rewrite.lib` is shared by four tests (`04516`, `04521`, `04522`, `04523`) and derived every role, user and table name from `${CLICKHOUSE_DATABASE}`.

With an explicit `--database=X`, every test in the run gets that one value (`tests/clickhouse-test:2267`, `if testcase_args.database:`), so all four siblings compute byte-identical names, and since roles and users are global the per-test `DROP DATABASE ... SYNC` teardown never removes them. Run concurrently, their `cleanup`/`reset_access` DROP-then-CREATE sequences contend for one name:

```
Code: 493. DB::Exception: role `role1_04516_test_collide`: cannot insert because role
`role1_04516_test_collide` already exists in `local_directory`. (ACCESS_ENTITY_ALREADY_EXISTS)
```

The fix derives the seven names from `${CLICKHOUSE_TEST_UNIQUE_NAME}`, which embeds the basename of the sourcing `.sh` (`shell_config.sh:14-20`) and so differs per test in every database mode. 35 stateless `.sh` files already name a `CREATE ROLE`/`CREATE USER` entity from that variable, inline or via a variable assigned from it. The `04516_` infix is dropped since `CLICKHOUSE_TEST_NAME` carries the test number.

This is a latent robustness fix, not a repair for a failure seen in CI: today's stress jobs, the only fixed-`--database` consumer, use distinct per-worker databases and `--jobs 1`. It is reachable from any `--jobs N>1` plus a fixed `--database`.

Scope: this fixes collisions between the four distinct siblings. Two concurrent copies of the *same* test under a fixed `--database` still share a namespace, which no per-library naming scheme can change and which CI addresses with `--no-self-parallel`. The sibling `04510_select_access_rights_rewrite.lib` has the same defect plus database-less hardcoded names; it needs a much larger rename and is left separate.

Validated by running the four concurrently under a fixed database: every one of the 60 runs that executed fails before the change (the run aborts at `--max-failures-chain`), and all 80 pass after it. The same command with a random per-test database passes on the unfixed build. The default mode passes 200 of 200.