### PR TITLE
Fix flaky test `02421_truncate_isolation_no_merges`

### DIFF
--- a/tests/queries/0_stateless/02421_truncate_isolation_no_merges.sh
+++ b/tests/queries/0_stateless/02421_truncate_isolation_no_merges.sh
@@ -128,6 +128,10 @@ function concurrent_drop_part_after()
 
     reset_table drop_part_after_table
 
+    # Truncating in a transaction sets remove_time = 0, so the background cleanup thread may log
+    # RemovePart before the part_log assertion below reads it. Keep the parts until it has run.
+    $CLICKHOUSE_CLIENT -q "system stop cleanup drop_part_after_table"
+
     tx 61 "begin transaction"
     tx 62             "begin transaction"
     tx 61 "truncate table drop_part_after_table"
@@ -143,6 +147,8 @@ function concurrent_drop_part_after()
     $CLICKHOUSE_CLIENT -q "select event_type, part_name from system.part_log
                               where event_date >= yesterday() AND event_time >= now() - 600 AND table='drop_part_after_table' and database=currentDatabase()
                               order by part_name"
+
+    $CLICKHOUSE_CLIENT -q "system start cleanup drop_part_after_table"
 }
 
 concurrent_drop_part_after


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix flaky test `02421_truncate_isolation_no_merges`, which raced with the background cleanup thread when reading `system.part_log`.

### Description

`concurrent_drop_part_after` reads `system.part_log` without filtering `event_type`, and the reference expects exactly the three `NewPart` rows. The sub-case truncates inside a transaction, so `removePartsFromWorkingSet` is called with `clear_without_timeout = true` and stores `remove_time = 0` on all three parts (`MergeTreeData.cpp:6319`, `:6334`). `grabOldParts` then tests `time_now - part_remove_time >= old_parts_lifetime` (`:3974`), true for **every** value of the setting when `remove_time = 0`, so once the transaction commits the background cleanup thread may remove the parts and log three extra `RemovePart` rows before the test reads the log. `order by part_name` interleaves each one next to its `NewPart` sibling.

Pinning `old_parts_lifetime` would therefore be a silent no-op: one of the two real CI failures already drew `480`, the setting's maximum.

The fix stops the background cleanup thread for that one table, for that one sub-case. Being per-table, it leaves parallel tests and the synchronous cleanup done by the scenario's own DDL untouched. No assertion changes and the reference file is untouched.

Rate, keyed on the failure payload rather than the test name: 2 occurrences across 2 unrelated pull requests in 180 days, 0 on master.

Validated: 50/50 randomized runs pass, and 18/18 pass under `--jobs 8` alongside the sibling `02421_truncate_isolation_with_mutations`. Forcing the cleanup cadence to 1s reproduced the race deterministically (the window measures about 400ms): 7/7 runs fail without the fix, 0/7 with it.

I considered adding `and event_type = 'NewPart'` to the `SELECT`, the majority convention in tree (56 of the 75 tests that `SELECT` from `system.part_log` filter on it in the same statement). I did not choose it because it would make the assertion unable to observe a `RemovePart` at all: the removal would still race, just invisibly. Happy to switch to the filter if you prefer it.