### PR TITLE
Read a partially downloaded file segment from the cache in passive mode

### DIFF
--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -631,7 +631,9 @@ CachedOnDiskReadBufferFromFile::createReadFromFileSegmentState(
 
     if (info_.cache_settings.read_if_exists_otherwise_bypass)
     {
-        if (download_state == FileSegment::State::DOWNLOADED)
+        /// A DETACHED segment keeps `downloaded_size` but has no key metadata, so getPath() throws.
+        if (download_state == FileSegment::State::DOWNLOADED
+            || (download_state != FileSegment::State::DETACHED && canStartFromCache(offset, file_segment)))
             return create(ReadType::CACHED);
 
         LOG_TEST(

--- a/tests/queries/0_stateless/04757_passive_filesystem_cache_partial_segment.reference
+++ b/tests/queries/0_stateless/04757_passive_filesystem_cache_partial_segment.reference
@@ -1,4 +1,6 @@
-partial segment with a usable prefix exists: 1
+partially downloaded segment with downloaded bytes exists: 1
 passive read served more bytes from the cache than from the source: 1
+passive read fetched nothing from the source: 1
+passive read wrote nothing to the cache: 1
 full table read agrees across cache disabled / normal mode / passive mode: 1
 full table row count: 400000

--- a/tests/queries/0_stateless/04757_passive_filesystem_cache_partial_segment.reference
+++ b/tests/queries/0_stateless/04757_passive_filesystem_cache_partial_segment.reference
@@ -1,0 +1,4 @@
+partial segment with a usable prefix exists: 1
+passive read served more bytes from the cache than from the source: 1
+full table read agrees across cache disabled / normal mode / passive mode: 1
+full table row count: 400000

--- a/tests/queries/0_stateless/04757_passive_filesystem_cache_partial_segment.sh
+++ b/tests/queries/0_stateless/04757_passive_filesystem_cache_partial_segment.sh
@@ -2,10 +2,6 @@
 # Tags: no-fasttest
 # - no-fasttest: uses a filesystem cache disk
 
-# Regression test: under `read_from_filesystem_cache_if_exists_otherwise_bypass_cache` (passive mode)
-# a PARTIALLY_DOWNLOADED file segment used to be bypassed unconditionally, so a read that lies
-# entirely inside the already-downloaded prefix was re-fetched from the object storage.
-#
 # `boundary_alignment = max_file_segment_size` is load-bearing: it makes
 # `roundUpToMultiple(downloaded_size, boundary_alignment)` reach the whole segment range, so
 # `FileSegment::shrinkFileSegmentToDownloadedSize` early-returns and the segment stays
@@ -46,8 +42,7 @@ settings max_insert_block_size = 200000;
 "
 
 # The cache is freshly created with a per-database unique name, so it starts empty (no need to drop
-# it -- an unqualified `system drop filesystem cache` would wipe other tests' caches too).
-# Fill a prefix only: the LIMIT read stops in the middle of a 32Mi segment.
+# it). Fill a prefix only: the LIMIT read stops in the middle of a 32Mi segment.
 ${CLICKHOUSE_CLIENT} --query "
 select sum(length(b)) from (select b from test order by a limit 60000) format Null
 settings read_from_filesystem_cache_if_exists_otherwise_bypass_cache = 0, ${READ_SETTINGS};
@@ -62,9 +57,8 @@ where cache_name = '${CLICKHOUSE_TEST_UNIQUE_NAME}'
   and state = 'PARTIALLY DOWNLOADED' and downloaded_size > 0;
 "
 
-# The same read again, now in passive mode. Before the fix this served 14212 bytes from the cache and
-# re-fetched 20971520 from the source; after it, the source read is gone. Compare the two counters
-# instead of printing them: the raw values depend on the block size and the build.
+# The same read again, now in passive mode. Compare the two counters instead of printing them: the
+# raw values depend on the block size and the build.
 query_id="04757-${CLICKHOUSE_DATABASE}-passive"
 ${CLICKHOUSE_CLIENT} --query_id "$query_id" --query "
 select sum(length(b)) from (select b from test order by a limit 60000) format Null

--- a/tests/queries/0_stateless/04757_passive_filesystem_cache_partial_segment.sh
+++ b/tests/queries/0_stateless/04757_passive_filesystem_cache_partial_segment.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# - no-fasttest: uses a filesystem cache disk
+
+# Regression test: under `read_from_filesystem_cache_if_exists_otherwise_bypass_cache` (passive mode)
+# a PARTIALLY_DOWNLOADED file segment used to be bypassed unconditionally, so a read that lies
+# entirely inside the already-downloaded prefix was re-fetched from the object storage.
+#
+# `boundary_alignment = max_file_segment_size` is load-bearing: it makes
+# `roundUpToMultiple(downloaded_size, boundary_alignment)` reach the whole segment range, so
+# `FileSegment::shrinkFileSegmentToDownloadedSize` early-returns and the segment stays
+# PARTIALLY_DOWNLOADED with a usable prefix. `background_download_threads = 0` keeps it that way and
+# `cache_on_write_operations = 0` keeps the INSERT from pre-filling the cache.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Every setting the test depends on is pinned at query level (which beats the runner's
+# randomization), so no no-random-settings tag is needed. Two of them are worth spelling out:
+# `optimize_read_in_order` has to stay on, otherwise the `LIMIT` below reads the whole column instead
+# of stopping part way through and every segment ends up DOWNLOADED; and `use_uncompressed_cache` has
+# to stay off, otherwise the second read is served from the uncompressed cache and never reaches the
+# filesystem cache at all (both byte counters stay at 0).
+READ_SETTINGS="max_threads = 1, remote_filesystem_read_prefetch = 0,
+    remote_filesystem_read_method = 'read', filesystem_cache_segments_batch_size = 0,
+    max_block_size = 8192, read_through_distributed_cache = 0, enable_filesystem_cache = 1,
+    optimize_read_in_order = 1, use_uncompressed_cache = 0"
+
+${CLICKHOUSE_CLIENT} -m --query "
+drop table if exists test;
+create table test (a UInt64, b String) ENGINE = MergeTree() ORDER BY a
+settings disk = disk(
+    type = cache,
+    name = '${CLICKHOUSE_TEST_UNIQUE_NAME}',
+    path = '${CLICKHOUSE_TEST_UNIQUE_NAME}/',
+    max_size = '4Gi',
+    max_file_segment_size = '32Mi',
+    boundary_alignment = '32Mi',
+    background_download_threads = 0,
+    cache_on_write_operations = 0,
+    disk = disk(type = 'local_blob_storage', path = '${CLICKHOUSE_TEST_UNIQUE_NAME}_blob/')),
+  min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+insert into test select number, randomPrintableASCII(300) from numbers(400000)
+settings max_insert_block_size = 200000;
+system drop filesystem cache;
+"
+
+# Fill a prefix only: the LIMIT read stops in the middle of a 32Mi segment.
+${CLICKHOUSE_CLIENT} --query "
+select sum(length(b)) from (select b from test order by a limit 60000) format Null
+settings read_from_filesystem_cache_if_exists_otherwise_bypass_cache = 0, ${READ_SETTINGS};
+"
+
+# Fixture liveness: without a PARTIALLY DOWNLOADED segment carrying a usable prefix the oracle below
+# would pass vacuously. Note the state is spelled with a SPACE in system.filesystem_cache.
+echo -n 'partial segment with a usable prefix exists: '
+${CLICKHOUSE_CLIENT} --query "
+select count() > 0 from system.filesystem_cache
+where cache_name = '${CLICKHOUSE_TEST_UNIQUE_NAME}'
+  and state = 'PARTIALLY DOWNLOADED' and downloaded_size > 0;
+"
+
+# The same read again, now in passive mode. Before the fix this served 14212 bytes from the cache and
+# re-fetched 20971520 from the source; after it, the source read is gone. Compare the two counters
+# instead of printing them: the raw values depend on the block size and the build.
+query_id="04757-${CLICKHOUSE_DATABASE}-passive"
+${CLICKHOUSE_CLIENT} --query_id "$query_id" --query "
+select sum(length(b)) from (select b from test order by a limit 60000) format Null
+settings read_from_filesystem_cache_if_exists_otherwise_bypass_cache = 1, ${READ_SETTINGS};
+"
+
+${CLICKHOUSE_CLIENT} --query "system flush logs query_log"
+
+echo -n 'passive read served more bytes from the cache than from the source: '
+${CLICKHOUSE_CLIENT} --query "
+select ProfileEvents['CachedReadBufferReadFromCacheBytes']
+     > ProfileEvents['CachedReadBufferReadFromSourceBytes']
+from system.query_log
+where query_id = '$query_id' and type = 'QueryFinish' and current_database = currentDatabase();
+"
+
+# Correctness control. A full-table read has to leave the cached prefix half way through, which
+# exercises the CACHED -> bypass switchover in updateReadStateIfNeeded. The table is filled with
+# random data, so the checksum itself is not reproducible - what is asserted is that all three arms
+# return the same one.
+results=()
+for cache_settings in \
+    "enable_filesystem_cache = 0" \
+    "enable_filesystem_cache = 1, read_from_filesystem_cache_if_exists_otherwise_bypass_cache = 0" \
+    "enable_filesystem_cache = 1, read_from_filesystem_cache_if_exists_otherwise_bypass_cache = 1"
+do
+    results+=("$(${CLICKHOUSE_CLIENT} --query "
+    select sum(cityHash64(b)), count() from test
+    settings max_threads = 1, read_through_distributed_cache = 0, $cache_settings;
+    ")")
+done
+
+echo -n 'full table read agrees across cache disabled / normal mode / passive mode: '
+if [ "${results[0]}" = "${results[1]}" ] && [ "${results[1]}" = "${results[2]}" ]; then
+    echo 1
+else
+    echo "0 -- ${results[0]} | ${results[1]} | ${results[2]}"
+fi
+
+echo -n 'full table row count: '
+echo "${results[0]}" | cut -f2
+
+${CLICKHOUSE_CLIENT} --query "drop table test;"

--- a/tests/queries/0_stateless/04757_passive_filesystem_cache_partial_segment.sh
+++ b/tests/queries/0_stateless/04757_passive_filesystem_cache_partial_segment.sh
@@ -43,9 +43,10 @@ settings disk = disk(
   min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
 insert into test select number, randomPrintableASCII(300) from numbers(400000)
 settings max_insert_block_size = 200000;
-system drop filesystem cache;
 "
 
+# The cache is freshly created with a per-database unique name, so it starts empty (no need to drop
+# it -- an unqualified `system drop filesystem cache` would wipe other tests' caches too).
 # Fill a prefix only: the LIMIT read stops in the middle of a 32Mi segment.
 ${CLICKHOUSE_CLIENT} --query "
 select sum(length(b)) from (select b from test order by a limit 60000) format Null
@@ -54,7 +55,7 @@ settings read_from_filesystem_cache_if_exists_otherwise_bypass_cache = 0, ${READ
 
 # Fixture liveness: without a PARTIALLY DOWNLOADED segment carrying a usable prefix the oracle below
 # would pass vacuously. Note the state is spelled with a SPACE in system.filesystem_cache.
-echo -n 'partial segment with a usable prefix exists: '
+echo -n 'partially downloaded segment with downloaded bytes exists: '
 ${CLICKHOUSE_CLIENT} --query "
 select count() > 0 from system.filesystem_cache
 where cache_name = '${CLICKHOUSE_TEST_UNIQUE_NAME}'
@@ -76,6 +77,22 @@ echo -n 'passive read served more bytes from the cache than from the source: '
 ${CLICKHOUSE_CLIENT} --query "
 select ProfileEvents['CachedReadBufferReadFromCacheBytes']
      > ProfileEvents['CachedReadBufferReadFromSourceBytes']
+from system.query_log
+where query_id = '$query_id' and type = 'QueryFinish' and current_database = currentDatabase();
+"
+
+echo -n 'passive read fetched nothing from the source: '
+${CLICKHOUSE_CLIENT} --query "
+select ProfileEvents['CachedReadBufferReadFromSourceBytes'] = 0
+from system.query_log
+where query_id = '$query_id' and type = 'QueryFinish' and current_database = currentDatabase();
+"
+
+# Passive mode must never populate the cache. CachedReadBufferCacheWriteBytes is incremented only in
+# CachedOnDiskReadBufferFromFile::writeCache, so 0 pins the second half of the setting's contract.
+echo -n 'passive read wrote nothing to the cache: '
+${CLICKHOUSE_CLIENT} --query "
+select ProfileEvents['CachedReadBufferCacheWriteBytes'] = 0
 from system.query_log
 where query_id = '$query_id' and type = 'QueryFinish' and current_database = currentDatabase();
 "


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
With `read_from_filesystem_cache_if_exists_otherwise_bypass_cache` enabled, a `PARTIALLY_DOWNLOADED` file segment is now read from the filesystem cache when the requested range lies inside its already downloaded prefix, instead of being re-fetched from the object storage. This affects background merges and mutations, and `BACKUP`, which use this mode by default.

### Description

`CachedOnDiskReadBufferFromFile::createReadFromFileSegmentState` accepted only the `DOWNLOADED` state in the passive branch, so a `PARTIALLY_DOWNLOADED` segment was bypassed even when the requested bytes were already in the local cache file. The same function consults `canStartFromCache` on every other partial state (`DOWNLOADING`, `EMPTY`/`PARTIALLY_DOWNLOADED`, `PARTIALLY_DOWNLOADED_NO_CONTINUATION`, and the `temp_cache_only` path); the passive branch was the only one that did not.

Such a segment is a normal steady state rather than a transient one: `shrinkFileSegmentToDownloadedSize` returns early when `roundUpToMultiple(downloaded_size, boundary_alignment)` already covers the whole range, so the segment keeps its `PARTIALLY_DOWNLOADED` state and its usable prefix. Passive mode never writes to the cache, so the miss never repaired itself.

No setting is needed to reach this. `MergeTreeSequentialSource` derives passive mode from `force_read_through_cache_for_merges`, which defaults to false, so every background merge and mutation reads this way, as does `BACKUP`.

The change adds the missing `canStartFromCache` test, excluding `DETACHED`, because a detached segment keeps its `downloaded_size` but has no key metadata, so reading its path would throw. Nothing is written to the cache, so the setting's other half ("don't put more entries into the cache") is unchanged; a read that runs past the prefix switches to a bypass read through the existing `updateReadStateIfNeeded` path.

Measured on a 400k-row table over a cache disk holding two partial segments (20,971,520 cached bytes). The passive read reports `CachedReadBufferReadFromCacheBytes` / `CachedReadBufferReadFromSourceBytes` of `14,212` / `20,971,520` before the change and `20,199,300` / `0` after, i.e. the re-fetch of the cached prefixes is eliminated. Cache contents are byte-identical before and after a passive read, and a full-table read returns the same result with the cache disabled, in normal mode and in passive mode.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113607&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/113607](https://github.com/search?q=head%3Async-upstream%2Fpr%2F113607+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
