### PR TITLE
Collect RabbitMQ diagnostics once instead of until a second timeout expires

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3143,6 +3143,7 @@ class ClickHouseCluster:
                         self.base_rabbitmq_cmd + ["logs"], stdout=f
                     )
                 rabbitmq_debuginfo(self.rabbitmq_docker_id, self.rabbitmq_cookie)
+                break
             except Exception as ex:
                 logging.debug("Unable to get logs from docker: %s:", ex)
                 time.sleep(0.5)

--- a/tests/integration/test_cluster_waiters/test_rabbitmq_diagnostics_once.py
+++ b/tests/integration/test_cluster_waiters/test_rabbitmq_diagnostics_once.py
@@ -8,15 +8,43 @@ a copy of it. No Docker, no broker and no ClickHouseCluster instance is needed.
 
 import ast
 import os
-import time
 import types
 
 HELPERS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "helpers")
 CLUSTER_PY = os.path.normpath(os.path.join(HELPERS_DIR, "cluster.py"))
 FUNC_NAME = "wait_rabbitmq_to_start"
 
-# A short deadline keeps every arm sub-second. The helper's own default is 120.
-TIMEOUT = 1.0
+# The clock is faked, so every arm is instant and the retry counts below are
+# exact. This is the helper's own default deadline.
+TIMEOUT = 120.0
+
+
+class _FakeClock:
+    """Advances only when the code under test sleeps, so arms are exact and instant.
+
+    A loop that neither sleeps nor exits would therefore never reach its deadline,
+    so reads are capped: the cap fails such a loop immediately instead of leaving
+    it to pytest's 900s timeout. The legitimate arms below read the clock at most
+    364 times.
+    """
+
+    _MAX_READS = 100000
+
+    def __init__(self):
+        self.now = 0.0
+        self.reads = 0
+
+    def time(self):
+        self.reads += 1
+        if self.reads > self._MAX_READS:
+            raise AssertionError(
+                f"clock read over {self._MAX_READS} times without advancing: "
+                "the waiter is spinning without sleeping or exiting"
+            )
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += seconds
 
 
 def _waiter_ast():
@@ -29,7 +57,7 @@ def _waiter_ast():
     raise AssertionError(f"{FUNC_NAME} not found in {CLUSTER_PY}")
 
 
-def _run(readiness_ok, collection_ok):
+def _run(readiness_ok, collection_ok, debuginfo_ok=True):
     """Execute the shipped waiter against stubs and count collection attempts."""
     counts = {"logs": 0, "debuginfo": 0}
 
@@ -47,6 +75,8 @@ def _run(readiness_ok, collection_ok):
 
     def rabbitmq_debuginfo(docker_id, cookie):
         counts["debuginfo"] += 1
+        if not debuginfo_ok:
+            raise RuntimeError("stub: rabbitmq_debuginfo failed")
 
     def check_rabbitmq_is_available(docker_id, cookie):
         if readiness_ok:
@@ -58,7 +88,7 @@ def _run(readiness_ok, collection_ok):
         "subprocess": types.SimpleNamespace(check_call=check_call),
         "rabbitmq_debuginfo": rabbitmq_debuginfo,
         "check_rabbitmq_is_available": check_rabbitmq_is_available,
-        "time": time,
+        "time": _FakeClock(),
         "os": os,
         "open": lambda *a, **k: _NullFile(),
     }
@@ -87,7 +117,11 @@ def _run(readiness_ok, collection_ok):
 
 
 def test_collects_once_when_collection_succeeds():
-    """The failing path collects exactly one set of diagnostics before raising."""
+    """The failing path collects exactly one set of diagnostics before raising.
+
+    This arm also rules out a break placed between the two collection calls:
+    that would leave debuginfo at 0 here.
+    """
     raised, returned, counts = _run(readiness_ok=False, collection_ok=True)
     assert raised == "Cannot wait RabbitMQ container"
     assert returned is None
@@ -96,16 +130,33 @@ def test_collects_once_when_collection_succeeds():
 
 
 def test_retries_when_collection_fails():
-    """A collection that fails still retries to the deadline.
+    """A collection whose first call fails still retries to the deadline.
 
     This is the arm that pins the break's position: moving it out of the try
-    block leaves the count above green but drops this retry.
+    block leaves the count above green but drops this retry. 240 = 120s / 0.5s,
+    the collection loop retrying until its own deadline expires.
     """
     raised, returned, counts = _run(readiness_ok=False, collection_ok=False)
     assert raised == "Cannot wait RabbitMQ container"
     assert returned is None
-    assert counts["logs"] > 1
+    assert counts["logs"] == 240
     assert counts["debuginfo"] == 0
+
+
+def test_retries_when_debuginfo_fails():
+    """The second guarded call failing also retries to the deadline.
+
+    rabbitmq_debuginfo runs after subprocess.check_call, so here both counters
+    advance together on every attempt. Without this arm the second of the two
+    operations inside the guarded try is never made to fail.
+    """
+    raised, returned, counts = _run(
+        readiness_ok=False, collection_ok=True, debuginfo_ok=False
+    )
+    assert raised == "Cannot wait RabbitMQ container"
+    assert returned is None
+    assert counts["logs"] == 240
+    assert counts["debuginfo"] == 240
 
 
 def test_healthy_broker_collects_nothing():

--- a/tests/integration/test_cluster_waiters/test_rabbitmq_diagnostics_once.py
+++ b/tests/integration/test_cluster_waiters/test_rabbitmq_diagnostics_once.py
@@ -1,0 +1,141 @@
+"""Pins that ClickHouseCluster.wait_rabbitmq_to_start collects its RabbitMQ
+diagnostics once, not until a second deadline expires.
+
+The helper under test is loaded out of helpers/cluster.py by AST extraction and
+executed against stubs, so these assertions track the shipped source rather than
+a copy of it. No Docker, no broker and no ClickHouseCluster instance is needed.
+"""
+
+import ast
+import os
+import time
+import types
+
+HELPERS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "helpers")
+CLUSTER_PY = os.path.normpath(os.path.join(HELPERS_DIR, "cluster.py"))
+FUNC_NAME = "wait_rabbitmq_to_start"
+
+# A short deadline keeps every arm sub-second. The helper's own default is 120.
+TIMEOUT = 1.0
+
+
+def _waiter_ast():
+    with open(CLUSTER_PY, encoding="utf-8") as f:
+        source = f.read()
+    module = ast.parse(source)
+    for node in ast.walk(module):
+        if isinstance(node, ast.FunctionDef) and node.name == FUNC_NAME:
+            return node
+    raise AssertionError(f"{FUNC_NAME} not found in {CLUSTER_PY}")
+
+
+def _run(readiness_ok, collection_ok):
+    """Execute the shipped waiter against stubs and count collection attempts."""
+    counts = {"logs": 0, "debuginfo": 0}
+
+    class _NullFile:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def check_call(*args, **kwargs):
+        counts["logs"] += 1
+        if not collection_ok:
+            raise RuntimeError("stub: docker compose logs failed")
+
+    def rabbitmq_debuginfo(docker_id, cookie):
+        counts["debuginfo"] += 1
+
+    def check_rabbitmq_is_available(docker_id, cookie):
+        if readiness_ok:
+            return True
+        raise RuntimeError("stub: await_startup failed with return code 69")
+
+    namespace = {
+        "logging": types.SimpleNamespace(debug=lambda *a, **k: None),
+        "subprocess": types.SimpleNamespace(check_call=check_call),
+        "rabbitmq_debuginfo": rabbitmq_debuginfo,
+        "check_rabbitmq_is_available": check_rabbitmq_is_available,
+        "time": time,
+        "os": os,
+        "open": lambda *a, **k: _NullFile(),
+    }
+    exec(  # pylint:disable=exec-used
+        compile(ast.Module(body=[_waiter_ast()], type_ignores=[]), CLUSTER_PY, "exec"),
+        namespace,
+    )
+
+    cluster = types.SimpleNamespace(
+        print_all_docker_pieces=lambda: None,
+        get_instance_ip=lambda host: "127.0.0.1",
+        rabbitmq_host="rabbitmq1",
+        rabbitmq_docker_id="stub-docker-id",
+        rabbitmq_cookie="stub-cookie",
+        rabbitmq_dir="/tmp",
+        base_rabbitmq_cmd=["docker", "compose"],
+    )
+
+    raised = None
+    returned = None
+    try:
+        returned = namespace[FUNC_NAME](cluster, timeout=TIMEOUT)
+    except RuntimeError as ex:
+        raised = str(ex)
+    return raised, returned, counts
+
+
+def test_collects_once_when_collection_succeeds():
+    """The failing path collects exactly one set of diagnostics before raising."""
+    raised, returned, counts = _run(readiness_ok=False, collection_ok=True)
+    assert raised == "Cannot wait RabbitMQ container"
+    assert returned is None
+    assert counts["logs"] == 1
+    assert counts["debuginfo"] == 1
+
+
+def test_retries_when_collection_fails():
+    """A collection that fails still retries to the deadline.
+
+    This is the arm that pins the break's position: moving it out of the try
+    block leaves the count above green but drops this retry.
+    """
+    raised, returned, counts = _run(readiness_ok=False, collection_ok=False)
+    assert raised == "Cannot wait RabbitMQ container"
+    assert returned is None
+    assert counts["logs"] > 1
+    assert counts["debuginfo"] == 0
+
+
+def test_healthy_broker_collects_nothing():
+    """Reachability control, not a witness: a passing run never enters the loop.
+
+    It is green with or without the break, which is the point - it shows the
+    changed loop cannot affect a run that succeeds today.
+    """
+    raised, returned, counts = _run(readiness_ok=True, collection_ok=True)
+    assert raised is None
+    assert returned is True
+    assert counts["logs"] == 0
+    assert counts["debuginfo"] == 0
+
+
+def test_break_is_last_statement_of_try_body():
+    """The break must be a direct, final statement of the try body.
+
+    Checked positionally: a membership test over the whole subtree also accepts
+    a break placed after the try/except, which silently drops the retry above.
+    """
+    loops = [n for n in _waiter_ast().body if isinstance(n, ast.While)]
+    assert len(loops) == 2, "expected a readiness loop and a collection loop"
+
+    tries = [n for n in loops[1].body if isinstance(n, ast.Try)]
+    assert len(tries) == 1, "expected a single try in the collection loop"
+
+    assert isinstance(
+        tries[0].body[-1], ast.Break
+    ), "the break must be the last statement of the try body"
+    assert not any(
+        isinstance(n, ast.Break) for n in loops[1].body
+    ), "the break must be inside the try body, not a sibling of it"


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`ClickHouseCluster.wait_rabbitmq_to_start` has two loops. The first polls readiness
until its 120s deadline. The second collects the container log plus
`rabbitmq_debuginfo` for the report, but it has no `break` and sleeps only in its
`except` arm, so whenever collection succeeds it keeps re-collecting until a second
full deadline expires before raising. Collection succeeding is the normal path:
`rabbitmq_debuginfo` runs its `rabbitmq-diagnostics` subprocesses through
`Popen`/`communicate` without checking their return codes, so it cannot fail even
against a broker that never started.

Measured against a real `rabbitmq:4.2.1-management-alpine` container whose broker
never boots, which is the condition the failing jobs are in: the loop runs 21
collections over 121.35s and spawns 63 `rabbitmq-diagnostics` invocations against an
already wedged container. With the `break`, one collection runs and the function
proceeds to the raise.

The `break` is the last statement of the `try` body, so a collection that does fail
still retries to the deadline as before.

This changes the cost of the failure, not its verdict. The trailing `raise
RuntimeError("Cannot wait RabbitMQ container")` is unconditional, and the loop is
reachable only once the readiness deadline has expired, so no run that passes today
executes this line. Verified: against a healthy container the waiter returns from the
first loop and the second is entered zero times.

`wait_kafka_is_available` is the precedent: it collects diagnostics in a `try` placed
**outside** its wait loop, so collection there happens once by construction.
`wait_rabbitmq_to_start` is the only waiter in the file that collects inside a deadline
loop.

I am not fixing the underlying failure here. The broker never boots and the artifacts
do not say why: the container never leaves `health: starting`, docker's healthcheck
returns 69 on all 27 runs, and the broker emits no output. That belongs in a separate
report.

No related open issue found.

<details>
<summary>Occurrences and validation detail</summary>

Population, 120 days, `test_context_raw` matching `Cannot wait RabbitMQ container`
with `test_status IN ('FAIL','ERROR')`, split by raising caller: 18 occurrences reach
it from `cluster.start()` -> `wait_rabbitmq_to_start`, spread over two shards
(`Integration tests (arm_binary, distributed plan, 1/4)` and `2/4`) and 17 distinct
days, including two runs with `head_ref = 'master'`. One occurrence fails every test
in the module because the fixture is module-scoped, so the 2-58 rows per occurrence
are collateral rather than independent flakes.

Three failing jobs show the same interval between the last readiness probe and the
`RuntimeError` (121.7s, 121.1s, 121.8s) with `Unable to get logs from docker` absent,
so collection succeeded on every iteration there too.

Validation, all against real containers on this change:

- pre-fix, collection succeeds: 21 collections, 121.35s, reaches the deadline
- post-fix, collection succeeds: 1 collection, 5.89s, exits early
- post-fix, collection fails: still retries to the deadline, 24 attempts, which is
  what shows the `break` is inside the `try` and not after it
- healthy container: first loop returns, second loop entered 0 times
- wedged container as the control for that: second loop entered, exactly once

`ruff` is clean. The file is not `black`-formatted on master and I did not reformat it.
The change is formatting-neutral, checked by normalizing the file with and without it:
the two normalized forms differ by exactly the added `break` line and are otherwise
token-identical.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.936` (included in `26.8` and later)
<!-- ch-version-info:end -->