### PR TITLE
Retry the job image pull so a registry reset cannot kill the whole job

### DIFF
--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -28,6 +28,21 @@ from .settings import Settings
 from .usage import ComputeUsage, StorageUsage
 from .utils import Shell, TeePopen, Utils
 
+# Matched against the pull's stderr. Transport-class phrases only: must never match a
+# permanent failure (`manifest unknown`, `pull access denied`, `no matching manifest`).
+_IMAGE_PULL_RETRY_ERRORS = [
+    "connection reset by peer",
+    "connection refused",
+    "TLS handshake timeout",
+    "i/o timeout",
+    "unexpected EOF",
+    # What `timeout --verbose` writes when it kills a stalled attempt. Plain `timeout`
+    # writes nothing, so without this entry a stall is not retried.
+    "sending signal TERM to command",
+]
+_IMAGE_PULL_TIMEOUT_S = 300  # per attempt, matching prefetch-integration-test-images
+_IMAGE_PULL_RETRIES = 3
+
 
 class Runner:
     @staticmethod
@@ -466,6 +481,18 @@ class Runner:
             print(f"Custom --workers [{workers}] will be passed to job's script")
             cmd += f" --workers {workers}"
         print(f"--- Run command [{cmd}]")
+
+        if job.run_in_docker and not no_docker:
+            # Retry the pull `docker run` would otherwise do implicitly and only once.
+            # Bounded per attempt: job.timeout only starts with TeePopen below. Guarded:
+            # a present image needs no registry. Non-fatal: local-only images have no pull.
+            if not Shell.check(f"docker image inspect {docker}", verbose=False):
+                Shell.run(
+                    f"timeout --verbose {_IMAGE_PULL_TIMEOUT_S} docker pull {docker}",
+                    retries=_IMAGE_PULL_RETRIES,
+                    retry_errors=_IMAGE_PULL_RETRY_ERRORS,
+                    verbose=True,
+                )
 
         # Sample whole-VM CPU/RAM usage in the background for the duration of the
         # job (see HostMetricsCollector). Runs on the host, so metrics cover the

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -487,11 +487,22 @@ class Runner:
             # Bounded per attempt: job.timeout only starts with TeePopen below. Guarded:
             # a present image needs no registry. Non-fatal: local-only images have no pull.
             if not Shell.check(f"docker image inspect {docker}", verbose=False):
+
+                def _warn_pull_retried(matched, attempt, attempts):
+                    # `env` is this frame's object and nothing dumps it after this
+                    # point, so the message survives. Info() would read a second
+                    # copy from disk, which a later stale dump can silently drop.
+                    env.add_workflow_warning(
+                        f"Job image pull failed with [{matched}] and was retried "
+                        f"({attempt}/{attempts}): {docker}"
+                    )
+
                 Shell.run(
                     f"timeout --verbose {_IMAGE_PULL_TIMEOUT_S} docker pull {docker}",
                     retries=_IMAGE_PULL_RETRIES,
                     retry_errors=_IMAGE_PULL_RETRY_ERRORS,
                     verbose=True,
+                    on_retry=_warn_pull_retried,
                 )
 
         # Sample whole-VM CPU/RAM usage in the background for the duration of the

--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -433,12 +433,12 @@ class Shell:
                     print(
                         f"Retryable error [{matched}] found, retry {retry+1}/{retries}"
                     )
-                if on_retry:
-                    # Reached only where a retry is actually about to be issued, so a
-                    # caller can surface it. Never lets a reporting failure fail the
-                    # command the retry is rescuing.
+                if on_retry and retry < retries - 1:
+                    # Only where another attempt actually follows: the last iteration
+                    # matches too, but nothing is retried after it. Never lets a
+                    # reporting failure fail the command the retry is rescuing.
                     try:
-                        on_retry(matched, retry + 1, retries)
+                        on_retry(matched, retry + 1, retries - 1)
                     except Exception as e:  # noqa: BLE001
                         print(f"WARNING: on_retry callback failed, ex [{e}]")
             except Exception as e:

--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -322,6 +322,7 @@ class Shell:
         timeout=None,
         retries=1,
         retry_errors: Union[List[str], str] = "",
+        on_retry=None,
         **kwargs,
     ):
         if retry_errors and retries < 2:
@@ -420,18 +421,26 @@ class Shell:
                         print("No retryable errors found, stopping retries")
                     break
 
+                matched = next(
+                    (
+                        err
+                        for err in retry_errors
+                        if any(err in line for line in err_output)
+                    ),
+                    "",
+                )
                 if verbose:
-                    matched = next(
-                        (
-                            err
-                            for err in retry_errors
-                            if any(err in line for line in err_output)
-                        ),
-                        "",
-                    )
                     print(
                         f"Retryable error [{matched}] found, retry {retry+1}/{retries}"
                     )
+                if on_retry:
+                    # Reached only where a retry is actually about to be issued, so a
+                    # caller can surface it. Never lets a reporting failure fail the
+                    # command the retry is rescuing.
+                    try:
+                        on_retry(matched, retry + 1, retries)
+                    except Exception as e:  # noqa: BLE001
+                        print(f"WARNING: on_retry callback failed, ex [{e}]")
             except Exception as e:
                 if verbose:
                     if retries == 1:

--- a/ci/tests/test_job_image_pull_retry.py
+++ b/ci/tests/test_job_image_pull_retry.py
@@ -151,6 +151,10 @@ def _drive_run(monkeypatch, tmp_path, *, image_present, pull_rc=0):
             return pull_rc
         return 0
 
+    # Pin the arch so the resolved tag is deterministic: `_run` appends `_arm`/`_amd` from the
+    # host arch, and CI runs this suite on arm while dev boxes are amd.
+    monkeypatch.setattr(runner_module.Utils, "is_arm", staticmethod(lambda: False))
+    monkeypatch.setattr(runner_module.Utils, "is_amd", staticmethod(lambda: True))
     monkeypatch.setattr(runner_module.Shell, "check", staticmethod(fake_check))
     monkeypatch.setattr(runner_module.Shell, "run", staticmethod(fake_run))
     monkeypatch.setattr(

--- a/ci/tests/test_job_image_pull_retry.py
+++ b/ci/tests/test_job_image_pull_retry.py
@@ -1,0 +1,387 @@
+"""
+Regression tests for the retried job-image pull in `Runner._run`.
+
+Background
+----------
+`docker run` pulls the job image implicitly, inside the same invocation that runs
+the job, and praktika executes that invocation exactly once (via `TeePopen`, which
+has no retry facility). So when the registry transfer is reset mid-stream the job
+dies with **zero tests executed** and is reported as a plain job-level `error`:
+
+    <N> layers: Pull complete
+    docker: failed to copy: read tcp <runner>:<port>-><registry>:443: read: connection reset by peer
+
+    Run 'docker run --help' for more information
+
+praktika retries transient registry errors everywhere else it owns a registry
+interaction as a distinct step (`docker.py` image build, `gh_auth.py`,
+`prefetch-integration-test-images`), but the job image pull was not a distinct
+step, so it inherited no retry. `Runner._run` now pulls it explicitly before
+`TeePopen`, retried on transport-class errors and bounded per attempt.
+
+Retrying `docker run` itself is not an option: `{job.command}` is inside that
+command string (a retry would re-run a whole test job) and its exit code is
+ambiguous by construction -- a container command exiting 125 gives docker rc=125,
+exactly what a pull failure returns.
+
+What these tests pin
+--------------------
+Arms 2, 3, 4 and 8 drive the **real** `Shell.run` retry loop with fake shell
+commands, so they exercise praktika's actual matching semantics rather than a
+model of them. Arms 1, 5, 6 and 7 drive `Runner._run`'s docker branch with the
+side-effecting collaborators stubbed out. No docker daemon and no `jq` is needed.
+
+Two properties make the narrow allowlist safe, and both are asserted here:
+`retry_errors` is matched against **stderr only** (`Shell.run` collects
+`err_output` from the stderr thread alone), while a successful pull writes its
+progress to **stdout** -- so pull progress can never trigger a retry. And the
+pulled command contains no job command at all, so nothing the job prints can
+reach this matcher.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.praktika import runner as runner_module
+from ci.praktika.runner import (
+    _IMAGE_PULL_RETRY_ERRORS,
+    _IMAGE_PULL_RETRIES,
+    _IMAGE_PULL_TIMEOUT_S,
+    Runner,
+)
+from ci.praktika.utils import Shell
+
+# The verbatim production error line, from the failing job's own `info`.
+PRODUCTION_RESET = (
+    "docker: failed to copy: read tcp 172.31.94.218:51334->54.231.230.177:443: "
+    "read: connection reset by peer"
+)
+# A permanent failure: must never be retried.
+PERMANENT_ERROR = (
+    "Error response from daemon: pull access denied for foo, "
+    "repository does not exist or may require 'docker login'"
+)
+# Verbatim progress lines from a successful `docker pull`, which go to stdout.
+PULL_PROGRESS = [
+    "latest: Pulling from library/hello-world",
+    "17eec7bbc9d7: Pulling fs layer",
+    "17eec7bbc9d7: Download complete",
+    "17eec7bbc9d7: Pull complete",
+    "Digest: sha256:0b6a027b5cf322f09f6706c754e086a232ec1ddba835c8a15c6cb74d2b114f3f",
+    "Status: Downloaded newer image for hello-world:latest",
+]
+
+DOCKER_IMAGE = "clickhouse/test-base:0abcdef123456_amd"
+
+
+# --------------------------------------------------------------------------- #
+# Helpers driving the REAL Shell.run retry loop with a fake command.
+# --------------------------------------------------------------------------- #
+def _counting_command(tmp_path, stdout_lines, stderr_lines, exit_code, succeed_on=None):
+    """A bash command that counts its own attempts in a file under `tmp_path`.
+
+    Emits `stdout_lines` on stdout and `stderr_lines` on stderr, exits
+    `exit_code` -- except on attempt `succeed_on`, where it exits 0 silently.
+    Returns (command, counter_path); read the counter to get the attempt count.
+    """
+    counter = tmp_path / "attempts"
+    counter.write_text("")
+    out = "".join(f"echo {line!r}; " for line in stdout_lines)
+    err = "".join(f"echo {line!r} >&2; " for line in stderr_lines)
+    succeed = f'if [ "$n" = "{succeed_on}" ]; then exit 0; fi; ' if succeed_on else ""
+    cmd = (
+        f"printf x >> {counter}; n=$(wc -c < {counter}); "
+        f"{succeed}{out}{err}exit {exit_code}"
+    )
+    return cmd, counter
+
+
+def _attempts(counter):
+    return len(counter.read_text())
+
+
+# --------------------------------------------------------------------------- #
+# Helpers driving Runner._run's docker branch.
+# --------------------------------------------------------------------------- #
+class _FakeJob:
+    """The minimum of a praktika Job that `_run`'s docker branch touches."""
+
+    def __init__(self):
+        self.name = "Stateless tests (amd_asan_ubsan)"
+        self.command = "python3 ./ci/jobs/functional_tests.py"
+        self.run_in_docker = "clickhouse/test-base"
+        self.timeout = 3600
+        self.timeout_shell_cleanup = ""
+        self.enable_gh_auth = False
+        self.requires = []
+        self.provides = []
+
+
+class _FakeTeePopen:
+    """Records the command `_run` would have executed, and reports success."""
+
+    def __init__(self, calls, cmd, **kwargs):
+        calls.append(("teepopen", cmd))
+        self.timeout_exceeded = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def wait(self):
+        return 0
+
+    def get_latest_log(self, max_lines=20):
+        return ""
+
+
+def _drive_run(monkeypatch, tmp_path, *, image_present, pull_rc=0):
+    """Run `Runner._run`'s docker branch with collaborators stubbed.
+
+    Returns the ordered list of recorded calls: ("check", cmd), ("run", cmd,
+    kwargs) and ("teepopen", cmd). `image_present` decides what
+    `docker image inspect` reports; `pull_rc` what the pull returns.
+    """
+    calls = []
+
+    def fake_check(command, **kwargs):
+        calls.append(("check", command))
+        if command.startswith("docker image inspect"):
+            return image_present
+        # No stale/running container with our name; nothing else is consulted.
+        return False
+
+    def fake_run(command, **kwargs):
+        calls.append(("run", command, kwargs))
+        if command.startswith("timeout") and "docker pull" in command:
+            # Honour the real Shell.run contract: a failed command raises when
+            # strict=True and merely returns non-zero otherwise. Without this the
+            # fail-open arm would stub out the very mechanism it exists to pin.
+            if pull_rc != 0 and kwargs.get("strict"):
+                raise RuntimeError(f"command failed, exit code {pull_rc}")
+            return pull_rc
+        return 0
+
+    monkeypatch.setattr(runner_module.Shell, "check", staticmethod(fake_check))
+    monkeypatch.setattr(runner_module.Shell, "run", staticmethod(fake_run))
+    monkeypatch.setattr(
+        runner_module,
+        "TeePopen",
+        lambda cmd, **kwargs: _FakeTeePopen(calls, cmd, **kwargs),
+    )
+
+    class _FakeMetrics:
+        def start(self):
+            return self
+
+        def stop(self):
+            return None
+
+    monkeypatch.setattr(
+        runner_module, "HostMetricsCollector", lambda *a, **kw: _FakeMetrics()
+    )
+
+    class _FakeResult:
+        def is_completed(self):
+            return True
+
+        def is_skipped(self):
+            return False
+
+        def is_running(self):
+            return False
+
+        def dump(self):
+            pass
+
+    monkeypatch.setattr(
+        runner_module.Result, "from_fs", staticmethod(lambda name: _FakeResult())
+    )
+
+    class _FakeEnv:
+        JOB_NAME = ""
+        WORKFLOW_CONFIG = None
+
+        def dump(self):
+            pass
+
+    monkeypatch.setattr(
+        runner_module._Environment, "get", staticmethod(lambda: _FakeEnv())
+    )
+
+    class _FakeRunConfig:
+        digest_dockers = {"clickhouse/test-base": "0abcdef123456"}
+
+    monkeypatch.setattr(
+        runner_module.RunConfig,
+        "from_workflow_data",
+        staticmethod(lambda: _FakeRunConfig()),
+    )
+    monkeypatch.chdir(tmp_path)
+
+    class _FakeWorkflow:
+        jobs = []
+        artifacts = []
+
+    Runner()._run(_FakeWorkflow(), _FakeJob())
+    return calls
+
+
+def _pull_calls(calls):
+    return [c for c in calls if c[0] == "run" and "docker pull" in c[1]]
+
+
+def _teepopen_index(calls):
+    return next(i for i, c in enumerate(calls) if c[0] == "teepopen")
+
+
+# --------------------------------------------------------------------------- #
+# 1. The allowlist and the retry count reach Shell.run.
+# --------------------------------------------------------------------------- #
+def test_pull_is_issued_with_the_allowlist_and_retries(monkeypatch, tmp_path):
+    """Without `retry_errors` the pull retries on ANY failure; without `retries`
+    it does not retry at all. Assert on the constant object, not a copy, so the
+    test cannot drift from the module."""
+    pulls = _pull_calls(_drive_run(monkeypatch, tmp_path, image_present=False))
+    assert len(pulls) == 1
+    kwargs = pulls[0][2]
+    assert kwargs["retry_errors"] is _IMAGE_PULL_RETRY_ERRORS
+    assert kwargs["retries"] >= 2
+
+
+# --------------------------------------------------------------------------- #
+# 2. A transport reset IS retried -- through the real Shell.run loop.
+# --------------------------------------------------------------------------- #
+def test_transport_reset_is_retried(tmp_path):
+    cmd, counter = _counting_command(
+        tmp_path, [], [PRODUCTION_RESET], exit_code=1, succeed_on=2
+    )
+    rc = Shell.run(
+        cmd, retries=_IMAGE_PULL_RETRIES, retry_errors=_IMAGE_PULL_RETRY_ERRORS
+    )
+    assert rc == 0
+    assert _attempts(counter) == 2
+
+
+# --------------------------------------------------------------------------- #
+# 3. A permanent error is NOT retried (the anti-over-broad-allowlist arm).
+# --------------------------------------------------------------------------- #
+def test_permanent_error_is_not_retried(tmp_path):
+    """A missing or misnamed image must fail fast rather than burn every attempt.
+    This is the regression guard for the over-broad-allowlist defect that forced
+    BUILDX_RETRY_ERRORS to be narrowed."""
+    cmd, counter = _counting_command(tmp_path, [], [PERMANENT_ERROR], exit_code=1)
+    rc = Shell.run(
+        cmd, retries=_IMAGE_PULL_RETRIES, retry_errors=_IMAGE_PULL_RETRY_ERRORS
+    )
+    assert rc != 0
+    assert _attempts(counter) == 1
+
+
+# --------------------------------------------------------------------------- #
+# 4. Pull PROGRESS on stdout can never trigger a retry.
+# --------------------------------------------------------------------------- #
+def test_pull_progress_on_stdout_does_not_trigger_a_retry(tmp_path):
+    """`retry_errors` is matched against stderr only, and a successful pull writes
+    its progress to stdout. Pin that split: progress plus an empty stderr must
+    yield exactly one attempt even on a non-zero exit."""
+    cmd, counter = _counting_command(tmp_path, PULL_PROGRESS, [], exit_code=1)
+    rc = Shell.run(
+        cmd, retries=_IMAGE_PULL_RETRIES, retry_errors=_IMAGE_PULL_RETRY_ERRORS
+    )
+    assert rc != 0
+    assert _attempts(counter) == 1
+
+
+# --------------------------------------------------------------------------- #
+# 5. Fail-open: a failed pull must not stop the job.
+# --------------------------------------------------------------------------- #
+def test_failed_pull_still_runs_the_container(monkeypatch, tmp_path):
+    """Images built locally by this workflow cannot be pulled at all (`docker pull`
+    fails with `pull access denied` while `docker run` succeeds), so the pull must
+    never be fatal. Without this arm a later `strict=True` would break every
+    locally-built image with all other arms green."""
+    calls = _drive_run(monkeypatch, tmp_path, image_present=False, pull_rc=1)
+    assert len(_pull_calls(calls)) == 1
+    teepopen = [c for c in calls if c[0] == "teepopen"]
+    assert len(teepopen) == 1
+    assert teepopen[0][1].startswith("docker run ")
+
+
+# --------------------------------------------------------------------------- #
+# 6. Ordering: the pull precedes `docker run`, on the fully resolved name:tag.
+# --------------------------------------------------------------------------- #
+def test_pull_precedes_docker_run_and_uses_the_resolved_tag(monkeypatch, tmp_path):
+    calls = _drive_run(monkeypatch, tmp_path, image_present=False)
+    pull_index = next(
+        i for i, c in enumerate(calls) if c[0] == "run" and "docker pull" in c[1]
+    )
+    assert pull_index < _teepopen_index(calls)
+    assert f"docker pull {DOCKER_IMAGE}" in calls[pull_index][1]
+
+
+# --------------------------------------------------------------------------- #
+# 7. The inspect guard: pull only when the image is absent.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "image_present,expected_pulls", [(True, 0), (False, 1)], ids=["present", "absent"]
+)
+def test_inspect_guard_pulls_only_when_absent(
+    monkeypatch, tmp_path, image_present, expected_pulls
+):
+    """A bare `docker run` uses an existing local image without contacting the
+    registry, so an unconditional pull would re-resolve a mutable tag. The absent
+    arm is what stops the guard from disabling the fix entirely."""
+    calls = _drive_run(monkeypatch, tmp_path, image_present=image_present)
+    assert len(_pull_calls(calls)) == expected_pulls
+    assert [c for c in calls if c[0] == "teepopen"]
+    assert any(
+        c[0] == "check" and c[1] == f"docker image inspect {DOCKER_IMAGE}"
+        for c in calls
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 8. A stalled attempt is bounded AND still retryable.
+# --------------------------------------------------------------------------- #
+def test_stalled_attempt_is_bounded(monkeypatch, tmp_path):
+    pulls = _pull_calls(_drive_run(monkeypatch, tmp_path, image_present=False))
+    assert f"timeout --verbose {_IMAGE_PULL_TIMEOUT_S} " in pulls[0][1]
+
+
+def test_stalled_attempt_is_retryable_only_with_verbose(tmp_path):
+    """`Shell.run(timeout=...)` bounds an attempt but its SIGTERMed child writes
+    nothing to stderr, so `retry_errors` matches nothing and the loop stops after one
+    attempt. Putting the bound in the command with `--verbose` emits a matchable line
+    instead. Both spellings return 124, so only the attempt COUNT discriminates them:
+    that contrast is what proves the allowlist entry is load-bearing, and a naive
+    "is it bounded?" assertion would stay green without it."""
+    verbose_counter = tmp_path / "verbose"
+    verbose_counter.write_text("")
+    verbose_rc = Shell.run(
+        f"printf x >> {verbose_counter}; timeout --verbose 1 sleep 30",
+        retries=_IMAGE_PULL_RETRIES,
+        retry_errors=_IMAGE_PULL_RETRY_ERRORS,
+    )
+
+    plain_counter = tmp_path / "plain"
+    plain_counter.write_text("")
+    plain_rc = Shell.run(
+        f"printf x >> {plain_counter}; timeout 1 sleep 30",
+        retries=_IMAGE_PULL_RETRIES,
+        retry_errors=_IMAGE_PULL_RETRY_ERRORS,
+    )
+
+    assert verbose_rc == 124 and plain_rc == 124
+    assert _attempts(verbose_counter) == _IMAGE_PULL_RETRIES
+    assert _attempts(plain_counter) == 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/ci/tests/test_job_image_pull_retry.py
+++ b/ci/tests/test_job_image_pull_retry.py
@@ -1,42 +1,24 @@
 """
 Regression tests for the retried job-image pull in `Runner._run`.
 
-Background
-----------
-`docker run` pulls the job image implicitly, inside the same invocation that runs
-the job, and praktika executes that invocation exactly once (via `TeePopen`, which
-has no retry facility). So when the registry transfer is reset mid-stream the job
-dies with **zero tests executed** and is reported as a plain job-level `error`:
+`docker run` pulled the image implicitly and praktika ran it once, so a reset
+registry transfer killed the job with zero tests run:
 
-    <N> layers: Pull complete
     docker: failed to copy: read tcp <runner>:<port>-><registry>:443: read: connection reset by peer
 
-    Run 'docker run --help' for more information
+The pull is now its own step before `TeePopen`, guarded by `docker image inspect`,
+retried on transport-class errors and bounded per attempt.
 
-praktika retries transient registry errors everywhere else it owns a registry
-interaction as a distinct step (`docker.py` image build, `gh_auth.py`,
-`prefetch-integration-test-images`), but the job image pull was not a distinct
-step, so it inherited no retry. `Runner._run` now pulls it explicitly before
-`TeePopen`, retried on transport-class errors and bounded per attempt.
-
-Retrying `docker run` itself is not an option: `{job.command}` is inside that
-command string (a retry would re-run a whole test job) and its exit code is
-ambiguous by construction -- a container command exiting 125 gives docker rc=125,
-exactly what a pull failure returns.
-
-What these tests pin
---------------------
-Arms 2, 3, 4 and 8 drive the **real** `Shell.run` retry loop with fake shell
-commands, so they exercise praktika's actual matching semantics rather than a
-model of them. Arms 1, 5, 6 and 7 drive `Runner._run`'s docker branch with the
-side-effecting collaborators stubbed out. No docker daemon and no `jq` is needed.
-
-Two properties make the narrow allowlist safe, and both are asserted here:
+Two properties keep the narrow allowlist safe, and both are asserted here.
 `retry_errors` is matched against **stderr only** (`Shell.run` collects
-`err_output` from the stderr thread alone), while a successful pull writes its
-progress to **stdout** -- so pull progress can never trigger a retry. And the
-pulled command contains no job command at all, so nothing the job prints can
-reach this matcher.
+`err_output` from the stderr thread alone) while a pull writes progress to stdout:
+progress is never retried (arm 4), and the production error itself is one attempt
+on stdout (arm 4b) where on stderr it is retried (arm 2). And the pulled command
+contains no job command, so nothing the job prints reaches this matcher.
+
+Arms 2, 3, 4, 4b and 8 drive the **real** `Shell.run` loop with fake shell
+commands; arms 1, 5, 6 and 7 drive `Runner._run`'s docker branch with stubbed
+collaborators. Neither docker nor `jq` is needed.
 """
 
 import os
@@ -285,13 +267,30 @@ def test_permanent_error_is_not_retried(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# 4. Pull PROGRESS on stdout can never trigger a retry.
+# 4. Pull PROGRESS is not an error: it can never trigger a retry.
 # --------------------------------------------------------------------------- #
 def test_pull_progress_on_stdout_does_not_trigger_a_retry(tmp_path):
-    """`retry_errors` is matched against stderr only, and a successful pull writes
-    its progress to stdout. Pin that split: progress plus an empty stderr must
-    yield exactly one attempt even on a non-zero exit."""
+    """A successful pull writes progress lines like `Pull complete`, and none of
+    them is an allowlisted phrase, so a non-zero exit whose only output is
+    progress must be a single attempt."""
     cmd, counter = _counting_command(tmp_path, PULL_PROGRESS, [], exit_code=1)
+    rc = Shell.run(
+        cmd, retries=_IMAGE_PULL_RETRIES, retry_errors=_IMAGE_PULL_RETRY_ERRORS
+    )
+    assert rc != 0
+    assert _attempts(counter) == 1
+
+
+# --------------------------------------------------------------------------- #
+# 4b. The stderr-only split itself: the SAME phrase on stdout must NOT retry.
+# --------------------------------------------------------------------------- #
+def test_allowlisted_phrase_on_stdout_does_not_trigger_a_retry(tmp_path):
+    """Arm 4 carries no allowlisted phrase, so it reads one attempt under a
+    stderr-only matcher AND under one that also matched stdout: it cannot pin the
+    split. This arm can. It sends the verbatim production error to stdout with an
+    empty stderr and must still be a single attempt, while arm 2 sends that same
+    line to stderr and is retried."""
+    cmd, counter = _counting_command(tmp_path, [PRODUCTION_RESET], [], exit_code=1)
     rc = Shell.run(
         cmd, retries=_IMAGE_PULL_RETRIES, retry_errors=_IMAGE_PULL_RETRY_ERRORS
     )

--- a/ci/tests/test_job_image_pull_retry.py
+++ b/ci/tests/test_job_image_pull_retry.py
@@ -16,9 +16,10 @@ progress is never retried (arm 4), and the production error itself is one attemp
 on stdout (arm 4b) where on stderr it is retried (arm 2). And the pulled command
 contains no job command, so nothing the job prints reaches this matcher.
 
-Arms 2, 3, 4, 4b and 8 drive the **real** `Shell.run` loop with fake shell
-commands; arms 1, 5, 6 and 7 drive `Runner._run`'s docker branch with stubbed
-collaborators. Neither docker nor `jq` is needed.
+Some arms drive the **real** `Shell.run` retry loop with fake shell commands, so
+they exercise the actual matching semantics rather than a model of them; the rest
+drive `Runner._run`'s docker branch with stubbed collaborators. Neither docker nor
+`jq` is needed.
 """
 
 import os
@@ -267,6 +268,29 @@ def test_permanent_error_is_not_retried(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
+# 3b. The other two permanent errors the allowlist comment names.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        # Verbatim from ci/praktika/docker.py's own build retry list.
+        "Error response from daemon: manifest unknown: manifest unknown",
+        # The phrase prefetch-integration-test-images greps for.
+        "no matching manifest for linux/arm64/v8 in the manifest list entries",
+    ],
+)
+def test_named_permanent_errors_are_not_retried(tmp_path, phrase):
+    """`_IMAGE_PULL_RETRY_ERRORS`' comment and the PR body both promise these fail
+    on the first attempt, but only `pull access denied` was tested (arm 3)."""
+    cmd, counter = _counting_command(tmp_path, [], [phrase], exit_code=1)
+    rc = Shell.run(
+        cmd, retries=_IMAGE_PULL_RETRIES, retry_errors=_IMAGE_PULL_RETRY_ERRORS
+    )
+    assert rc != 0
+    assert _attempts(counter) == 1
+
+
+# --------------------------------------------------------------------------- #
 # 4. Pull PROGRESS is not an error: it can never trigger a retry.
 # --------------------------------------------------------------------------- #
 def test_pull_progress_on_stdout_does_not_trigger_a_retry(tmp_path):
@@ -299,6 +323,30 @@ def test_allowlisted_phrase_on_stdout_does_not_trigger_a_retry(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
+# 4c. Every remaining transport entry is load-bearing.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "connection refused",
+        "TLS handshake timeout",
+        "i/o timeout",
+        "unexpected EOF",
+    ],
+)
+def test_each_transport_phrase_is_retried(tmp_path, phrase):
+    """Arms 2 and 4b already pin `connection reset by peer` and arm 8 pins
+    `sending signal TERM to command`; without these, dropping any of the other
+    four entries from the production list would leave the suite green."""
+    cmd, counter = _counting_command(tmp_path, [], [f"docker: {phrase}"], exit_code=1)
+    rc = Shell.run(
+        cmd, retries=_IMAGE_PULL_RETRIES, retry_errors=_IMAGE_PULL_RETRY_ERRORS
+    )
+    assert rc != 0
+    assert _attempts(counter) == _IMAGE_PULL_RETRIES
+
+
+# --------------------------------------------------------------------------- #
 # 5. Fail-open: a failed pull must not stop the job.
 # --------------------------------------------------------------------------- #
 def test_failed_pull_still_runs_the_container(monkeypatch, tmp_path):
@@ -317,12 +365,21 @@ def test_failed_pull_still_runs_the_container(monkeypatch, tmp_path):
 # 6. Ordering: the pull precedes `docker run`, on the fully resolved name:tag.
 # --------------------------------------------------------------------------- #
 def test_pull_precedes_docker_run_and_uses_the_resolved_tag(monkeypatch, tmp_path):
+    """Also pins the isolation property the narrow allowlist depends on: the pull
+    command ends at the image, so it carries no job command and nothing a job
+    prints can reach the matcher or make a retry re-run the job."""
     calls = _drive_run(monkeypatch, tmp_path, image_present=False)
     pull_index = next(
         i for i, c in enumerate(calls) if c[0] == "run" and "docker pull" in c[1]
     )
     assert pull_index < _teepopen_index(calls)
     assert f"docker pull {DOCKER_IMAGE}" in calls[pull_index][1]
+
+    pull_cmd = calls[pull_index][1]
+    job = _FakeJob()
+    assert job.command not in pull_cmd
+    # Forbids ANY suffix after the image, not just this fixture's command.
+    assert pull_cmd.endswith(DOCKER_IMAGE)
 
 
 # --------------------------------------------------------------------------- #

--- a/ci/tests/test_job_image_pull_retry.py
+++ b/ci/tests/test_job_image_pull_retry.py
@@ -124,12 +124,15 @@ class _FakeTeePopen:
         return ""
 
 
-def _drive_run(monkeypatch, tmp_path, *, image_present, pull_rc=0):
+def _drive_run(monkeypatch, tmp_path, *, image_present, pull_rc=0, retried_on=""):
     """Run `Runner._run`'s docker branch with collaborators stubbed.
 
     Returns the ordered list of recorded calls: ("check", cmd), ("run", cmd,
-    kwargs) and ("teepopen", cmd). `image_present` decides what
-    `docker image inspect` reports; `pull_rc` what the pull returns.
+    kwargs), ("teepopen", cmd) and ("env", env). `image_present` decides what
+    `docker image inspect` reports; `pull_rc` what the pull returns. When
+    `retried_on` is a phrase, the pull's `on_retry` callback is invoked with it
+    exactly as the real `Shell.run` loop would on a matched transport error, so
+    `_run`'s own callback body runs rather than a model of it.
     """
     calls = []
 
@@ -143,6 +146,8 @@ def _drive_run(monkeypatch, tmp_path, *, image_present, pull_rc=0):
     def fake_run(command, **kwargs):
         calls.append(("run", command, kwargs))
         if command.startswith("timeout") and "docker pull" in command:
+            if retried_on and kwargs.get("on_retry"):
+                kwargs["on_retry"](retried_on, 1, kwargs.get("retries", 1))
             # Honour the real Shell.run contract: a failed command raises when
             # strict=True and merely returns non-zero otherwise. Without this the
             # fail-open arm would stub out the very mechanism it exists to pin.
@@ -192,15 +197,23 @@ def _drive_run(monkeypatch, tmp_path, *, image_present, pull_rc=0):
     )
 
     class _FakeEnv:
+        """Records workflow warnings the way `_Environment` accumulates them."""
+
         JOB_NAME = ""
         WORKFLOW_CONFIG = None
+
+        def __init__(self):
+            self.warnings = []
 
         def dump(self):
             pass
 
-    monkeypatch.setattr(
-        runner_module._Environment, "get", staticmethod(lambda: _FakeEnv())
-    )
+        def add_workflow_warning(self, message, source=""):
+            self.warnings.append(message)
+
+    env = _FakeEnv()
+    calls.append(("env", env))
+    monkeypatch.setattr(runner_module._Environment, "get", staticmethod(lambda: env))
 
     class _FakeRunConfig:
         digest_dockers = {"clickhouse/test-base": "0abcdef123456"}
@@ -445,3 +458,123 @@ def test_stalled_attempt_is_retryable_only_with_verbose(tmp_path):
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))
+
+
+# --------------------------------------------------------------------------- #
+# 9. A retried pull is reported as a workflow warning.
+# --------------------------------------------------------------------------- #
+def test_retry_emits_a_workflow_warning(monkeypatch, tmp_path):
+    """The retry must not be silent: a pull that needed a second attempt shows up
+    on the job and workflow report pages."""
+    calls = _drive_run(
+        monkeypatch,
+        tmp_path,
+        image_present=False,
+        retried_on="connection reset by peer",
+    )
+    env = next(c[1] for c in calls if c[0] == "env")
+    assert len(env.warnings) == 1
+    assert "connection reset by peer" in env.warnings[0]
+    assert DOCKER_IMAGE in env.warnings[0]
+
+
+def test_a_clean_pull_emits_no_warning(monkeypatch, tmp_path):
+    """The negative control: without it the arm above would also pass against a
+    hook that warns unconditionally."""
+    calls = _drive_run(monkeypatch, tmp_path, image_present=False)
+    env = next(c[1] for c in calls if c[0] == "env")
+    assert env.warnings == []
+
+
+def test_a_skipped_pull_emits_no_warning(monkeypatch, tmp_path):
+    """An image already present is never pulled, so there is nothing to report."""
+    calls = _drive_run(
+        monkeypatch,
+        tmp_path,
+        image_present=True,
+        retried_on="connection reset by peer",
+    )
+    env = next(c[1] for c in calls if c[0] == "env")
+    assert env.warnings == []
+
+
+def test_on_retry_fires_once_per_retry_and_only_on_matched_errors(tmp_path):
+    """Drive the REAL `Shell.run` loop: the callback fires for each retry actually
+    issued, receives the matched phrase, and is never called for a permanent error
+    (which is the same code path that decides not to retry)."""
+    seen = []
+
+    cmd, counter = _counting_command(
+        tmp_path, [], [PRODUCTION_RESET], exit_code=1, succeed_on=3
+    )
+    rc = Shell.run(
+        cmd,
+        retries=_IMAGE_PULL_RETRIES,
+        retry_errors=_IMAGE_PULL_RETRY_ERRORS,
+        on_retry=lambda matched, attempt, attempts: seen.append(matched),
+    )
+    assert rc == 0
+    assert _attempts(counter) == 3
+    # Two retries were issued to reach the third attempt.
+    assert seen == ["connection reset by peer"] * 2
+
+    permanent = []
+    permanent_dir = tmp_path / "permanent"
+    permanent_dir.mkdir()
+    cmd2, counter2 = _counting_command(
+        permanent_dir, [], [PERMANENT_ERROR], exit_code=1
+    )
+    Shell.run(
+        cmd2,
+        retries=_IMAGE_PULL_RETRIES,
+        retry_errors=_IMAGE_PULL_RETRY_ERRORS,
+        on_retry=lambda matched, attempt, attempts: permanent.append(matched),
+    )
+    assert _attempts(counter2) == 1
+    assert permanent == []
+
+
+def test_a_failing_warning_hook_does_not_change_the_outcome(tmp_path):
+    """Reporting is best-effort. A rescued pull is the easy half; the discriminating
+    half is a pull that fails on every attempt, because `Shell.run`'s own
+    `except Exception` around the loop body reports an exception-terminated attempt as
+    exit code 1. So a hook that raises there would REPLACE the real exit code -- 124
+    for a stalled pull -- with 1, hiding the actual failure from the caller and from
+    the job report. Assert the code is preserved, not merely that the pull survived."""
+
+    def boom(matched, attempt, attempts):
+        raise RuntimeError("reporting is broken")
+
+    stalled = f"printf x >> {tmp_path / 'broken'}; timeout --verbose 1 sleep 30"
+    rc_broken = Shell.run(
+        stalled,
+        retries=_IMAGE_PULL_RETRIES,
+        retry_errors=_IMAGE_PULL_RETRY_ERRORS,
+        on_retry=boom,
+        verbose=False,
+    )
+    # Control: the same command with no hook at all, so the expected code is measured
+    # rather than assumed.
+    rc_plain = Shell.run(
+        f"printf x >> {tmp_path / 'plain2'}; timeout --verbose 1 sleep 30",
+        retries=_IMAGE_PULL_RETRIES,
+        retry_errors=_IMAGE_PULL_RETRY_ERRORS,
+        verbose=False,
+    )
+    assert rc_plain == 124
+    assert rc_broken == rc_plain
+
+    # And a hook that raises still lets a retry rescue the pull.
+    cmd, counter = _counting_command(
+        tmp_path, [], [PRODUCTION_RESET], exit_code=1, succeed_on=2
+    )
+    assert (
+        Shell.run(
+            cmd,
+            retries=_IMAGE_PULL_RETRIES,
+            retry_errors=_IMAGE_PULL_RETRY_ERRORS,
+            on_retry=boom,
+        )
+        == 0
+    )
+    assert _attempts(counter) == 2

--- a/ci/tests/test_job_image_pull_retry.py
+++ b/ci/tests/test_job_image_pull_retry.py
@@ -147,7 +147,8 @@ def _drive_run(monkeypatch, tmp_path, *, image_present, pull_rc=0, retried_on=""
         calls.append(("run", command, kwargs))
         if command.startswith("timeout") and "docker pull" in command:
             if retried_on and kwargs.get("on_retry"):
-                kwargs["on_retry"](retried_on, 1, kwargs.get("retries", 1))
+                # Same arguments the real loop passes on its first retry.
+                kwargs["on_retry"](retried_on, 1, kwargs.get("retries", 1) - 1)
             # Honour the real Shell.run contract: a failed command raises when
             # strict=True and merely returns non-zero otherwise. Without this the
             # fail-open arm would stub out the very mechanism it exists to pin.
@@ -517,6 +518,25 @@ def test_on_retry_fires_once_per_retry_and_only_on_matched_errors(tmp_path):
     assert _attempts(counter) == 3
     # Two retries were issued to reach the third attempt.
     assert seen == ["connection reset by peer"] * 2
+
+    # And when every attempt fails, the last one matches the allowlist too but nothing
+    # is retried after it, so the count must stay at the retries actually issued --
+    # otherwise the warning would claim a retry that never happened.
+    terminal = []
+    terminal_dir = tmp_path / "terminal"
+    terminal_dir.mkdir()
+    cmd3, counter3 = _counting_command(
+        terminal_dir, [], [PRODUCTION_RESET], exit_code=1
+    )
+    Shell.run(
+        cmd3,
+        retries=_IMAGE_PULL_RETRIES,
+        retry_errors=_IMAGE_PULL_RETRY_ERRORS,
+        on_retry=lambda matched, attempt, attempts: terminal.append(attempt),
+        verbose=False,
+    )
+    assert _attempts(counter3) == _IMAGE_PULL_RETRIES
+    assert terminal == list(range(1, _IMAGE_PULL_RETRIES))
 
     permanent = []
     permanent_dir = tmp_path / "permanent"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/109673
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Retry the praktika job's Docker image pull on transport-class registry errors, so a connection reset during the image transfer no longer kills the whole job before any test runs.


### Description

`docker run` pulls the job image implicitly, inside the same invocation that runs the job, and praktika executes that invocation exactly once (`TeePopen` has no retry facility). So a registry transfer reset there kills the job with **zero tests executed**, reported as a bare job-level error:

```
docker: failed to copy: read tcp <runner>:<port>-><registry>:443: read: connection reset by peer
```

praktika can retry a registry interaction it owns as a distinct step, and the `docker.py` image build does. The job image pull was not a step at all, so nothing could carry a retry.

`Runner._run` now pulls the image explicitly before `TeePopen`, retried on transport-class errors only. Retrying `docker run` itself is not an option: `{job.command}` sits inside that command string, so a retry would re-run a whole test job, and rc=125 is ambiguous anyway (a container command exiting 125 returns a pull failure's rc).

Three properties keep this narrow, each measured on docker 29.5.1:

* The pulled command holds no job command, so nothing a job prints can reach the matcher; and `retry_errors` matches stderr, while a successful pull writes its progress to stdout (335 bytes stdout, 0 stderr).
* Transport phrases only, so `manifest unknown` / `pull access denied` / `no matching manifest` still fail on the first attempt.
* Skipped when the image is present, since a bare `docker run` then contacts no registry: the warm case is unchanged.

Fail-open is required rather than defensive: an image built locally by this workflow cannot be pulled at all (`docker pull` gives `pull access denied` while `docker run` on that tag succeeds).

Each attempt is bounded, since `job.timeout` only starts with `TeePopen`. The bound is `timeout --verbose`, not `Shell.run(timeout=...)`, whose SIGTERMed child writes nothing to stderr, so the loop would stop after one attempt (measured 1 vs 3).

<details>
<summary>Reproduction, validation, and why this is not covered by <code>retry_infra_failures.yml</code></summary>

Reproduced end to end against a local `registry:2` behind a proxy resetting the downstream direction mid-transfer: rc=125, same error text, no container residue.

A cut-point sweep showed the same fault produces three different messages depending on where the transfer dies; only `connection reset by peer` matches all three.

Validated in both directions through praktika's real retry loop: a transport reset is retried and succeeds; a permanent error is attempted exactly once. The tests need no docker daemon, and a mutation matrix covers them: dropping `--verbose` or its allowlist entry each makes the stall protection dead and reddens its own arm.

`retry_infra_failures.yml` names "Docker image pull failures" and does decide `should_rerun=true` here, but it is complementary, and three gaps are measured: it reruns the **whole workflow**; it only selects `attempt == 1` (`:37`), and the motivating sighting was already on attempt 2, so a reset there is terminal; and it is PR-only (`:33`), so the master occurrence had no retry path. This fixes the pull where it happens, on master too, on any attempt.

All three occurrences, 2026-07-01 to 2026-08-06 (CIDB, each `check_status = error` with an empty `test_name`, i.e. no test row):

| when | job | where |
|---|---|---|
| 2026-07-31 | `Stateless tests (amd_asan_ubsan, db disk, distributed plan, sequential, 1/3)` | PR 109212, `ca19728c9e86` |
| 2026-07-09..14 | `Build (amd_release)` | **master** |
| 2026-07-09..14 | `Build (arm_binary)` | PR 107775 |

The first, verbatim after 17 `Pull complete` layers:

```
809bd340b23b: Pull complete
docker: failed to copy: read tcp 172.31.94.218:51334->54.231.230.177:443: read: connection reset by peer

Run 'docker run --help' for more information
```

Rare, but each costs an entire job and no PR diff can influence it.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1662` (included in `26.8` and later)
<!-- ch-version-info:end -->