### PR TITLE
Honor query cancellation while resolving Variant alternatives

### DIFF
--- a/src/Functions/FunctionVariantAdaptor.cpp
+++ b/src/Functions/FunctionVariantAdaptor.cpp
@@ -504,6 +504,7 @@ ColumnPtr ExecutableFunctionVariantAdaptor::executeImpl(
     /// we will insert NULL values in these rows.
 
     const auto process_list_element = tryGetProcessListElement();
+    const auto function_name = getName();
 
     for (size_t i = 0; i < num_variants; ++i)
     {
@@ -511,7 +512,7 @@ ColumnPtr ExecutableFunctionVariantAdaptor::executeImpl(
         if (!variants[i].column)
             continue;
 
-        checkQueryTimeLimit(process_list_element, getName());
+        checkQueryTimeLimit(process_list_element, function_name);
 
         auto func_base = try_build(variants_arguments[i]);
         if (!func_base)
@@ -786,10 +787,11 @@ FunctionBaseVariantAdaptor::FunctionBaseVariantAdaptor(
     result_types.reserve(variant_alternatives.size());
 
     const auto process_list_element = tryGetProcessListElement();
+    const auto function_name = function_overload_resolver->getName();
 
     for (const auto & alternative : variant_alternatives)
     {
-        checkQueryTimeLimit(process_list_element, function_overload_resolver->getName());
+        checkQueryTimeLimit(process_list_element, function_name);
 
         /// Create arguments with this alternative instead of the Variant.
         /// Preserve original columns (especially ColumnConst) for non-Variant arguments.

--- a/src/Functions/FunctionVariantAdaptor.cpp
+++ b/src/Functions/FunctionVariantAdaptor.cpp
@@ -13,6 +13,7 @@
 #include <Columns/ColumnVariant.h>
 #include <Interpreters/castColumn.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
 
 namespace DB
 {
@@ -29,6 +30,25 @@ extern const int ILLEGAL_TYPE_OF_ARGUMENT;
 extern const int TYPE_MISMATCH;
 extern const int CANNOT_CONVERT_TYPE;
 extern const int NO_COMMON_TYPE;
+extern const int TIMEOUT_EXCEEDED;
+}
+
+/// `checkTimeLimit` throws for `KILL QUERY` and the 'throw' overflow mode and returns false under
+/// 'break'; a partially resolved alternative list is a wrong result type rather than a smaller one, so
+/// the false return becomes a throw too.
+static void checkQueryTimeLimit(const QueryStatusPtr & process_list_element, const String & function_name)
+{
+    if (process_list_element && !process_list_element->checkTimeLimit())
+        throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", function_name);
+}
+
+/// Resolved from the executing thread rather than captured: an adaptor instance can be reused by a
+/// later query.
+static QueryStatusPtr tryGetProcessListElement()
+{
+    if (auto query_context = CurrentThread::tryGetQueryContext())
+        return query_context->getProcessListElementSafe();
+    return {};
 }
 
 ExecutableFunctionVariantAdaptor::ExecutableFunctionVariantAdaptor(
@@ -483,11 +503,15 @@ ColumnPtr ExecutableFunctionVariantAdaptor::executeImpl(
     /// Index num_variants is allocated for rows with NULL values, it doesn't have any result,
     /// we will insert NULL values in these rows.
 
+    const auto process_list_element = tryGetProcessListElement();
+
     for (size_t i = 0; i < num_variants; ++i)
     {
         /// Skip variants that don't exist in the data.
         if (!variants[i].column)
             continue;
+
+        checkQueryTimeLimit(process_list_element, getName());
 
         auto func_base = try_build(variants_arguments[i]);
         if (!func_base)
@@ -761,8 +785,12 @@ FunctionBaseVariantAdaptor::FunctionBaseVariantAdaptor(
     DataTypes result_types;
     result_types.reserve(variant_alternatives.size());
 
+    const auto process_list_element = tryGetProcessListElement();
+
     for (const auto & alternative : variant_alternatives)
     {
+        checkQueryTimeLimit(process_list_element, function_overload_resolver->getName());
+
         /// Create arguments with this alternative instead of the Variant.
         /// Preserve original columns (especially ColumnConst) for non-Variant arguments.
         ColumnsWithTypeAndName alt_columns_with_type = arguments_with_type_;

--- a/tests/queries/0_stateless/04763_variant_adaptor_cancellation.reference
+++ b/tests/queries/0_stateless/04763_variant_adaptor_cancellation.reference
@@ -1,0 +1,8 @@
+positive control: one Variant argument resolves and executes normally
+Nullable(String)	az
+Nullable(String)
+positive control: several Variant arguments still return the right type when not cancelled
+Nullable(String)	aaaz
+cancellation is observed while resolving alternatives
+cancellation is observed with variant_throw_on_type_mismatch disabled
+cancellation is observed with several discriminators present in the data

--- a/tests/queries/0_stateless/04763_variant_adaptor_cancellation.sql
+++ b/tests/queries/0_stateless/04763_variant_adaptor_cancellation.sql
@@ -1,0 +1,44 @@
+-- Resolving a function over a Variant argument re-enters the Variant adaptor once per alternative, so
+-- with several Variant arguments the work is exponential. The loops must observe query cancellation.
+
+DROP TABLE IF EXISTS t_04763;
+DROP TABLE IF EXISTS t_04763_mixed;
+
+CREATE TABLE t_04763 (v Variant(String, UInt64, Array(String), Map(String, String),
+                                Tuple(a String), Array(UInt64), Array(Array(String)),
+                                Map(UInt64, String)))
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_04763 VALUES ('a');
+
+CREATE TABLE t_04763_mixed (v Variant(String, UInt64, Array(String), Map(String, String),
+                                      Tuple(a String), Array(UInt64), Array(Array(String)),
+                                      Map(UInt64, String)))
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_04763_mixed VALUES ('a'), (42), (['x']);
+
+SELECT 'positive control: one Variant argument resolves and executes normally';
+SELECT toTypeName(concat(v, 'z')), concat(v, 'z') FROM t_04763;
+SELECT toTypeName(concat(v, 'z')) FROM t_04763_mixed ORDER BY 1 LIMIT 1;
+
+SELECT 'positive control: several Variant arguments still return the right type when not cancelled';
+SELECT toTypeName(concat(v, v, v, 'z')), concat(v, v, v, 'z') FROM t_04763;
+
+SELECT 'cancellation is observed while resolving alternatives';
+-- Under the 'break' overflow mode an unfixed server runs the whole traversal and returns a result far
+-- past the deadline; only a server that polls inside the loop reports the timeout. The 'throw' mode
+-- cannot tell the two apart, because the deadline is also reported once the traversal ends.
+SELECT toTypeName(concat(v, v, v, v, v, v, v, v, 'z')) FROM t_04763
+SETTINGS max_execution_time = 1, timeout_overflow_mode = 'break'; -- { serverError TIMEOUT_EXCEEDED }
+
+SELECT 'cancellation is observed with variant_throw_on_type_mismatch disabled';
+-- The resolution loop swallows type errors for this setting; a timeout must not be swallowed with them.
+SELECT toTypeName(concat(v, v, v, v, v, v, v, v, 'z')) FROM t_04763
+SETTINGS max_execution_time = 1, timeout_overflow_mode = 'break',
+         variant_throw_on_type_mismatch = 0; -- { serverError TIMEOUT_EXCEEDED }
+
+SELECT 'cancellation is observed with several discriminators present in the data';
+SELECT toTypeName(concat(v, v, v, v, v, v, v, v, 'z')) FROM t_04763_mixed
+SETTINGS max_execution_time = 1, timeout_overflow_mode = 'break'; -- { serverError TIMEOUT_EXCEEDED }
+
+DROP TABLE t_04763;
+DROP TABLE t_04763_mixed;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a query over a `Variant` column ignoring `max_execution_time` and `KILL QUERY`. Calling a function with several `Variant` arguments resolved the function once per alternative of every argument, and neither of the two loops doing that work checked for cancellation, so such a query could not be stopped until it finished.

### Description

Resolving a function over a `Variant` argument builds it once per alternative (`FunctionBaseVariantAdaptor`'s constructor). When another argument is also a `Variant`, that build re-enters the same constructor, so the number of resolutions is `k^N` for `k` alternatives and `N` `Variant` arguments. Depth stays bounded, because a `Variant` alternative can never itself be a `Variant` and each level replaces one `Variant` argument with a concrete type, but the work is exponential and neither the constructor's loop nor the sibling per-variant loop in `ExecutableFunctionVariantAdaptor::executeImpl` polled any cancellation state.

Reproducer on a plain `MergeTree` column, with no experimental setting (the `Variant` gate is obsolete):

```sql
CREATE TABLE t (v Variant(String, UInt64, Array(String), Map(String, String),
                          Tuple(a String), Array(UInt64), Array(Array(String)),
                          Map(UInt64, String))) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO t VALUES ('a');
SELECT toTypeName(concat(v, v, v, v, v, v, v, v, 'z')) FROM t
SETTINGS max_execution_time = 1, timeout_overflow_mode = 'break';
```

Before this change the query runs 19.8 s despite the 1 s deadline; after it, it stops in 1.3 s. Under the `throw` overflow mode the deadline was also reported, but only once the whole traversal had ended, which is why the new test asserts under `break`, where an unfixed server reports nothing at all. The fix adds one `checkTimeLimit` poll per alternative in each of the two loops, following four existing sites in `src/Functions/`. It changes no result, type or error code for any query that completes, adds no setting, and caps nothing: the fanout is inherent to resolving every alternative, and shapes that are merely slow still return correct answers.

Validated with the new test failing on unpatched master and passing here, 100/100 runs (50 randomized, 50 plain, longest 3.6 s), and the `Variant`/`Dynamic` stateless suite showing no regression against pristine master (identical failure sets and reasons).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.919` (included in `26.8` and later)
<!-- ch-version-info:end -->