### PR TITLE
Bound the randomized granule size in 03174_split_parts_ranges_..._final_and_read-in-order_bug

### DIFF
--- a/tests/queries/0_stateless/03174_split_parts_ranges_into_intersecting_and_non_intersecting_final_and_read-in-order_bug.sql
+++ b/tests/queries/0_stateless/03174_split_parts_ranges_into_intersecting_and_non_intersecting_final_and_read-in-order_bug.sql
@@ -1,5 +1,8 @@
 -- Tags: no-tsan, no-asan, no-msan, no-fasttest
 -- Test is slow
+-- Random settings limits: index_granularity=(8192, None); index_granularity_bytes=(229376, None); merge_max_block_size=(8192, None)
+-- A small granule size multiplies the mark count of this 1e7-row FINAL merge by orders of magnitude,
+-- which can push it past the client's receive timeout. merge_max_block_size is bounded as a precaution.
 create table tab (x DateTime('UTC'), y UInt32, v Int32) engine = ReplacingMergeTree(v) order by x;
 insert into tab select toDateTime('2000-01-01', 'UTC') + number, number, 1 from numbers(1e7);
 optimize table tab final;

--- a/tests/queries/0_stateless/03174_split_parts_ranges_into_intersecting_and_non_intersecting_final_and_read-in-order_bug.sql
+++ b/tests/queries/0_stateless/03174_split_parts_ranges_into_intersecting_and_non_intersecting_final_and_read-in-order_bug.sql
@@ -1,4 +1,4 @@
--- Tags: no-tsan, no-asan, no-msan, no-fasttest
+-- Tags: long, no-tsan, no-asan, no-msan, no-fasttest
 -- Test is slow
 -- Random settings limits: index_granularity=(8192, None); index_granularity_bytes=(229376, None); merge_max_block_size=(8192, None)
 -- A small granule size multiplies the mark count of this 1e7-row FINAL merge by orders of magnitude,


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
No changelog entry required: test-only change.

### Description

This test inserts 1e7 rows and runs `optimize table tab final`. CI randomizes `index_granularity`
from `randint(1, 65536)` (`tests/clickhouse-test:1876-1878`), and it is a hard row cap on granule size
(`std::min` at `MergeTreeIndexGranularity.cpp:153`), so a tiny draw yields millions of granules. Nothing misbehaves, the merge is just slower, but `OPTIMIZE` is synchronous and returns
an empty pipeline (`InterpreterOptimizeQuery.cpp:139-140`), so the socket stays silent for the whole
merge and the default 300s `receive_timeout` (`Defines.h:15`) is the ceiling. Measured on the fixture, `optimize table tab final` goes from **0.69s** at the defaults (1,232
marks) to **161.8s** at `index_granularity=3` (3,333,343 marks), a value CI's own diagnostics named.
The existing clamp covers only sanitizer/debug/coverage builds (`tests/clickhouse-test:1959`).

This bounds the three drivers per-test at the **product defaults**, leaving the other 57
randomized MergeTree settings live, per the standing "pin the ones that cause issues" guidance rather
than a blanket `no-random-*` tag. Over 120,000 seeded draws through the runner's own randomizer and
clamp, observed minima are exactly 8192 / 229376 / 8192, and 1 / 1201 / 1 with the limits emptied.

The `long` tag is separate. Even at the clamped floor the flaky check runs this one test 8-up
against itself (`--jobs 8`): p50 84.8s versus 9.4s in `amd_debug, parallel`, and 5 of 20 attempts
crossed the 180s flaky-check cap (`tests/clickhouse-test:3572-3577`). The 600s per-test timeout is
untouched and the three limits parse identically.

`long` also reduces the flaky check's repeat count for this test to
`max(int(50 * 0.1), 1) = 5` (`tests/clickhouse-test:4391-4393`); the two are one tag and cannot be
separated per-test. That run executed 20 of its 50 attempts before `--max-failures 5` aborted
it, so the delta is 20 to 5, each still drawing fresh settings. The ordinary lanes still run this test
fully randomized on every PR and on master, and both `--no-long` call sites also pass
`--no-random-merge-tree-settings`.
