### PR TITLE
Stop the ColumnTuple gtest from clearing the main thread's current_thread

### DIFF
--- a/src/Columns/tests/gtest_column_tuple.cpp
+++ b/src/Columns/tests/gtest_column_tuple.cpp
@@ -100,7 +100,8 @@ TEST(ColumnTuple, InsertDefaultIsExceptionSafe)
     auto tuple = ColumnTuple::create(std::move(elements));
 
     {
-        ThreadStatus thread_status;
+        /// Drain deferred allocations so the clamp below is exact; a no-op with no thread status.
+        CurrentThread::flushUntrackedMemory();
         const Int64 prev_hard_limit = total_memory_tracker.getHardLimit();
         SCOPE_EXIT_SAFE(total_memory_tracker.setHardLimit(prev_hard_limit));
         total_memory_tracker.setHardLimit(total_memory_tracker.get() + 1024);


### PR DESCRIPTION

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/106895

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`ColumnTuple.InsertDefaultIsExceptionSafe` declared a bare `ThreadStatus` on the main thread. Its
destructor sets `current_thread` to `nullptr` (`ThreadStatus.cpp:311-313`), and `MainThreadStatus`
is a one-shot function-local static (`:356-359`), so nothing re-establishes it. Every suite shares
one `unit_tests_dbms` process, so later `CurrentThread::get()` calls throw
`Thread #N status was not initialized`.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101841&sha=11f3432adb28f9a03548af9bbdbba93ca34b472d&name_0=PR&name_1=Unit%20tests%20%28amd_llvm_coverage%29
- 11 tests fail there. This test runs at index 950; `AllocationInterceptors` at 1483 is the next to
read `current_thread`, and 5 of its 13 tests plus the 6 `PerCPUMemory` tests calling `resetTrackers`
are exactly those 11.

Three conditions must coincide, hence not persistent: neither Debug nor sanitizer, so
`chassert(!current_thread)` at `:120` is inert (only `amd_llvm_coverage`); an earlier test must
already have called `MainThreadStatus::getInstance()`, and on master nothing does before index 950;
and no later main-thread `ThreadStatus` may re-establish the pointer in between.

The test only needs the untracked-memory batch drained so the clamped hard limit is exact.
`CurrentThread::flushUntrackedMemory()` does that without owning a status: it returns early when
`current_thread` is null (`CurrentThread.cpp:247`), and allocations then go straight to
`total_memory_tracker` unbatched (`CurrentMemoryTracker.cpp:63-67`), so the clamp bites either way.

Verified both directions on a non-debug build across six shuffle orders: before, seed 3 gives 12
`status was not initialized` and 6 failing tests; after, all six are clean, and 33/33 pass on a
Debug build where `chassert` is live. Deleting `ColumnTuple::insertDefault`'s rollback still fails
this test, so its own subject stays covered.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1121` (included in `26.8` and later)
<!-- ch-version-info:end -->