### PR TITLE
Speed up 03173_set_transformed_partition_pruning by reading part counts from EXPLAIN ESTIMATE

### DIFF
--- a/tests/queries/0_stateless/03173_set_transformed_partition_pruning.sql
+++ b/tests/queries/0_stateless/03173_set_transformed_partition_pruning.sql
@@ -18,8 +18,7 @@ SELECT toDate('2100-01-01') + 10 * number FROM numbers(50);
 OPTIMIZE TABLE 03173_single_function FINAL;
 
 SELECT count() FROM 03173_single_function WHERE dt IN ('2024-01-20', '2024-05-25') SETTINGS log_comment='03173_single_function';
-SYSTEM FLUSH LOGS query_log;
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_single_function';
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_single_function WHERE dt IN ('2024-01-20', '2024-05-25'));
 
 DROP TABLE IF EXISTS 03173_single_function;
 
@@ -38,9 +37,8 @@ OPTIMIZE TABLE 03173_nested_function FINAL;
 
 SELECT count() FROM 03173_nested_function WHERE id IN (10) SETTINGS log_comment='03173_nested_function';
 SELECT count() FROM 03173_nested_function WHERE xxHash32(id) IN (2158931063, 1449383981) SETTINGS log_comment='03173_nested_function_subexpr';
-SYSTEM FLUSH LOGS query_log;
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function';
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function_subexpr';
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_nested_function WHERE id IN (10));
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_nested_function WHERE xxHash32(id) IN (2158931063, 1449383981));
 
 DROP TABLE IF EXISTS 03173_nested_function;
 
@@ -61,9 +59,8 @@ OPTIMIZE TABLE 03173_nested_function_lc FINAL;
 
 SELECT count() FROM 03173_nested_function_lc WHERE id IN (10) SETTINGS log_comment='03173_nested_function_lc';
 SELECT count() FROM 03173_nested_function_lc WHERE xxHash32(id) IN (2158931063, 1449383981) SETTINGS log_comment='03173_nested_function_subexpr_lc';
-SYSTEM FLUSH LOGS query_log;
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function_lc';
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function_subexpr_lc';
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_nested_function_lc WHERE id IN (10));
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_nested_function_lc WHERE xxHash32(id) IN (2158931063, 1449383981));
 
 DROP TABLE IF EXISTS 03173_nested_function_lc;
 
@@ -83,9 +80,8 @@ OPTIMIZE TABLE 03173_nested_function_null FINAL;
 
 SELECT count() FROM 03173_nested_function_null WHERE id IN (10) SETTINGS log_comment='03173_nested_function_null';
 SELECT count() FROM 03173_nested_function_null WHERE xxHash32(id) IN (2158931063, 1449383981) SETTINGS log_comment='03173_nested_function_subexpr_null';
-SYSTEM FLUSH LOGS query_log;
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function_null';
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function_subexpr_null';
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_nested_function_null WHERE id IN (10));
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_nested_function_null WHERE xxHash32(id) IN (2158931063, 1449383981));
 
 DROP TABLE IF EXISTS 03173_nested_function_null;
 
@@ -107,9 +103,8 @@ OPTIMIZE TABLE 03173_nested_function_lc_null FINAL;
 
 SELECT count() FROM 03173_nested_function_lc_null WHERE id IN (10) SETTINGS log_comment='03173_nested_function_lc_null';
 SELECT count() FROM 03173_nested_function_lc_null WHERE xxHash32(id) IN (2158931063, 1449383981) SETTINGS log_comment='03173_nested_function_subexpr_lc_null';
-SYSTEM FLUSH LOGS query_log;
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function_lc_null';
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_function_subexpr_lc_null';
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_nested_function_lc_null WHERE id IN (10));
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_nested_function_lc_null WHERE xxHash32(id) IN (2158931063, 1449383981));
 
 DROP TABLE IF EXISTS 03173_nested_function_lc_null;
 
@@ -127,8 +122,7 @@ INSERT INTO 03173_nonsafe_cast SELECT number FROM numbers(100);
 OPTIMIZE TABLE 03173_nonsafe_cast FINAL;
 
 SELECT count() FROM 03173_nonsafe_cast WHERE id IN (SELECT '50' UNION ALL SELECT '99') SETTINGS log_comment='03173_nonsafe_cast';
-SYSTEM FLUSH LOGS query_log;
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nonsafe_cast';
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_nonsafe_cast WHERE id IN (SELECT '50' UNION ALL SELECT '99'));
 
 DROP TABLE IF EXISTS 03173_nonsafe_cast;
 
@@ -148,11 +142,10 @@ OPTIMIZE TABLE 03173_multiple_partition_cols FINAL;
 
 SELECT count() FROM 03173_multiple_partition_cols WHERE key2 IN (4) SETTINGS log_comment='03173_multiple_columns';
 SELECT count() FROM 03173_multiple_partition_cols WHERE xxHash32(key2) IN (4251411170) SETTINGS log_comment='03173_multiple_columns_subexpr';
-SYSTEM FLUSH LOGS query_log;
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_multiple_columns';
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_multiple_partition_cols WHERE key2 IN (4));
 -- Due to xxHash32() in WHERE condition, MinMax is unable to eliminate any parts,
 -- so partition pruning leave two parts (for key1 // 50 = 0 and key1 // 50 = 1)
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_multiple_columns_subexpr';
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_multiple_partition_cols WHERE xxHash32(key2) IN (4251411170));
 
 -- Preparing base table for filtering by LowCardinality/Nullable sets
 DROP TABLE IF EXISTS 03173_base_data_source;
@@ -173,8 +166,7 @@ DROP TABLE IF EXISTS 03173_low_cardinality_set;
 CREATE TABLE 03173_low_cardinality_set (id LowCardinality(Int32)) ENGINE=Memory AS SELECT 10;
 
 SELECT count() FROM 03173_base_data_source WHERE id IN (SELECT id FROM 03173_low_cardinality_set) SETTINGS log_comment='03173_low_cardinality_set';
-SYSTEM FLUSH LOGS query_log;
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_low_cardinality_set';
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_base_data_source WHERE id IN (SELECT id FROM 03173_low_cardinality_set));
 
 DROP TABLE IF EXISTS 03173_low_cardinality_set;
 
@@ -184,8 +176,7 @@ DROP TABLE IF EXISTS 03173_nullable_set;
 CREATE TABLE 03173_nullable_set (id Nullable(Int32)) ENGINE=Memory AS SELECT 10;
 
 SELECT count() FROM 03173_base_data_source WHERE id IN (SELECT id FROM 03173_nullable_set) SETTINGS log_comment='03173_nullable_set';
-SYSTEM FLUSH LOGS query_log;
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nullable_set';
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_base_data_source WHERE id IN (SELECT id FROM 03173_nullable_set));
 
 DROP TABLE IF EXISTS 03173_nullable_set;
 
@@ -195,8 +186,7 @@ DROP TABLE IF EXISTS 03173_lc_nullable_set;
 CREATE TABLE 03173_lc_nullable_set (id LowCardinality(Nullable(Int32))) ENGINE=Memory AS SELECT 10 UNION ALL SELECT NULL;
 
 SELECT count() FROM 03173_base_data_source WHERE id IN (SELECT id FROM 03173_lc_nullable_set) SETTINGS log_comment='03173_lc_nullable_set';
-SYSTEM FLUSH LOGS query_log;
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_lc_nullable_set';
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_base_data_source WHERE id IN (SELECT id FROM 03173_lc_nullable_set));
 
 DROP TABLE IF EXISTS 03173_lc_nullable_set;
 
@@ -235,8 +225,7 @@ UNION ALL
 SELECT toString(toDate('2100-01-01') + 10 * number) FROM numbers(50);
 
 SELECT count() FROM 03173_nested_date_parsing WHERE id IN ('2000-01-21', '2023-05-02') SETTINGS log_comment='03173_nested_date_parsing', session_timezone = '';
-SYSTEM FLUSH LOGS query_log;
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_nested_date_parsing';
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT count() FROM 03173_nested_date_parsing WHERE id IN ('2000-01-21', '2023-05-02') SETTINGS session_timezone = '');
 SELECT count() FROM 03173_nested_date_parsing WHERE id IN ('not a date');
 
 DROP TABLE IF EXISTS 03173_nested_date_parsing;
@@ -255,7 +244,6 @@ INSERT INTO 03173_empty_transform SELECT number FROM numbers(6);
 OPTIMIZE TABLE 03173_empty_transform FINAL;
 
 SELECT id FROM 03173_empty_transform WHERE xxHash32(id) % 3 IN (xxHash32(2::Int32) % 3) SETTINGS log_comment='03173_empty_transform';
-SYSTEM FLUSH LOGS query_log;
-SELECT ProfileEvents['SelectedParts'] FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '03173_empty_transform';
+SELECT parts FROM (EXPLAIN ESTIMATE SELECT id FROM 03173_empty_transform WHERE xxHash32(id) % 3 IN (xxHash32(2::Int32) % 3));
 
 DROP TABLE IF EXISTS 03173_empty_transform;

--- a/tests/queries/0_stateless/03173_set_transformed_partition_pruning.sql
+++ b/tests/queries/0_stateless/03173_set_transformed_partition_pruning.sql
@@ -1,5 +1,6 @@
--- Tags: no-msan, long, no-azure-blob-storage
+-- Tags: no-msan, long, no-azure-blob-storage, no-parallel-replicas
 -- msan: too slow
+-- no-parallel-replicas: EXPLAIN ESTIMATE reports no rows when the plan has no ReadFromMergeTree
 
 SELECT '-- Single partition by function';
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112966
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up the stateless test `03173_set_transformed_partition_pruning`, which was hitting the 600 second hard timeout in the flaky check.

### Description

`03173_set_transformed_partition_pruning` reads the part count each section asserts out of
`system.query_log`, so it needs a `SYSTEM FLUSH LOGS query_log` before every read: 12 flushes
and 17 `ProfileEvents['SelectedParts']` selects.

`SYSTEM FLUSH LOGS` is server-global. One saving thread per log pops the whole queued backlog
in a single batch and serializes it entry by entry, and `query_log`'s 7500 ms flush interval is
not overridden under `tests/config/config.d/`. So each flush pays for every other test's
accumulated rows, not for this test's own 926. It is the single largest `SYSTEM FLUSH LOGS`
user in the stateless suite, and in the flaky check it was killed at the 600 s `--timeout`.

Measured on the failing job's own `query_log` artifact, the flushes were 91.5-99.0 % of each
run's server-side time and the `system.query_log` selects 0.4-1.6 %, so narrowing their scan
window would not have helped.

`EXPLAIN ESTIMATE`'s `parts` column and the `SelectedParts` profile event are the same number:
both come from `ReadFromMergeTree`'s `result.selected_parts`. So each assertion becomes
`SELECT parts FROM (EXPLAIN ESTIMATE <the same query>)` in place, and all 12 flushes are
deleted.

**The `.reference` file is unchanged, byte for byte.** One file changed, +19/-30 lines, no
`src/` change. Running the test emits output identical to the committed reference. The only
other change is a `no-parallel-replicas` tag, because `EXPLAIN ESTIMATE` reports no rows when
the plan has no `ReadFromMergeTree` step, as `03006_parallel_replicas_prewhere` documents.

Validation: reverting the `KeyCondition.cpp` change of #112966 under the rewritten test still
reddens the `-- Non-safe cast` section, so the assertions still detect what the test exists to
pin. All 17 reads emit exactly one row and match the committed reference. 50/50 randomized runs
pass; interleaved A/B is 2.59x faster with one copy and 3.76x with eight concurrent copies, in
both cases with non-overlapping ranges.