### PR TITLE
Fix a bad cast when a row policy and PREWHERE both read a converted `Buffer` column

### DIFF
--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -430,7 +430,7 @@ void StorageBuffer::read(
                 /// carries each step's outputs forward, so such a column reaches the next prefix
                 /// already holding this table's type and must not be converted a second time. The
                 /// call order below must match the step order in the consumers building these steps
-                /// (MergeTreeSelectProcessor::getPrewhereActions, Parquet's Reader::preparePrewhere).
+                /// (`MergeTreeSelectProcessor::getPrewhereActions`, Parquet's `Reader::preparePrewhere`).
                 NameSet already_converted;
 
                 /// The prefix converts the whole sample block, but the filter runs inside the

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -424,28 +424,43 @@ void StorageBuffer::read(
             else
             {
                 auto src_table_query_info = query_info;
-                ActionsDAG converting_dag;
-                if (src_table_query_info.prewhere_info || src_table_query_info.row_level_filter)
-                {
-                    converting_dag = ActionsDAG::makeConvertingActions(
-                        header_after_adding_defaults.getColumnsWithTypeAndName(),
-                        header.getColumnsWithTypeAndName(),
-                        ActionsDAG::MatchColumnsMode::Name,
-                        local_context);
-                }
+
+                /// Columns a previously built prefix already converted and kept as an output of its
+                /// filter. Forwarded filters become consecutive prewhere steps over one block that
+                /// carries each step's outputs forward, so such a column reaches the next prefix
+                /// already holding this table's type and must not be converted a second time.
+                /// The call order below must match the step order in
+                /// MergeTreeSelectProcessor::getPrewhereActions (row-level filter, then PREWHERE).
+                NameSet already_converted;
 
                 /// The prefix converts the whole sample block, but the filter runs inside the
                 /// destination read, where only its own columns are known to have the declared
                 /// types. Keep just the filter's outputs; the rest converts after the read as usual.
                 auto merge_converting_prefix = [&](ActionsDAG filter_dag)
                 {
+                    auto source_columns = header_after_adding_defaults.getColumnsWithTypeAndName();
+                    for (auto & source_column : source_columns)
+                        if (already_converted.contains(source_column.name))
+                            source_column.type = header.getByName(source_column.name).type;
+
+                    auto converting_dag = ActionsDAG::makeConvertingActions(
+                        source_columns,
+                        header.getColumnsWithTypeAndName(),
+                        ActionsDAG::MatchColumnsMode::Name,
+                        local_context);
+
                     Names filter_outputs;
                     filter_outputs.reserve(filter_dag.getOutputs().size());
                     for (const auto * output : filter_dag.getOutputs())
                         filter_outputs.push_back(output->result_name);
 
-                    auto merged = ActionsDAG::merge(converting_dag.clone(), std::move(filter_dag));
+                    auto merged = ActionsDAG::merge(std::move(converting_dag), std::move(filter_dag));
                     merged.removeUnusedActions(filter_outputs);
+
+                    for (const auto & filter_output : filter_outputs)
+                        if (header.has(filter_output))
+                            already_converted.insert(filter_output);
+
                     return merged;
                 };
 

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -428,9 +428,9 @@ void StorageBuffer::read(
                 /// Columns a previously built prefix already converted and kept as an output of its
                 /// filter. Forwarded filters become consecutive prewhere steps over one block that
                 /// carries each step's outputs forward, so such a column reaches the next prefix
-                /// already holding this table's type and must not be converted a second time.
-                /// The call order below must match the step order in
-                /// MergeTreeSelectProcessor::getPrewhereActions (row-level filter, then PREWHERE).
+                /// already holding this table's type and must not be converted a second time. The
+                /// call order below must match the step order in the consumers building these steps
+                /// (MergeTreeSelectProcessor::getPrewhereActions, Parquet's Reader::preparePrewhere).
                 NameSet already_converted;
 
                 /// The prefix converts the whole sample block, but the filter runs inside the

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -425,12 +425,9 @@ void StorageBuffer::read(
             {
                 auto src_table_query_info = query_info;
 
-                /// Columns a previously built prefix already converted and kept as an output of its
-                /// filter. Forwarded filters become consecutive prewhere steps over one block that
-                /// carries each step's outputs forward, so such a column reaches the next prefix
-                /// already holding this table's type and must not be converted a second time. The
-                /// call order below must match the step order in the consumers building these steps
-                /// (`MergeTreeSelectProcessor::getPrewhereActions`, Parquet's `Reader::preparePrewhere`).
+                /// A column an earlier prefix converted and kept as a filter output reaches the next
+                /// prefix already holding this table's type, so it must not be converted again. The
+                /// calls below must follow the order the destination applies the filters in.
                 NameSet already_converted;
 
                 /// The prefix converts the whole sample block, but the filter runs inside the

--- a/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.reference
+++ b/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.reference
@@ -1,0 +1,20 @@
+B single PREWHERE on the converted column
+{'a':1,'b':2}
+C single row policy on the converted column
+{'a':1,'b':2}
+A row policy and PREWHERE on the converted column
+{'a':1,'b':2}
+J PREWHERE on another column
+{'a':1,'b':2}
+I row policy on another column
+{'a':1,'b':2}
+N additional_table_filters and PREWHERE
+{'a':1,'b':2}
+F Array parent, row policy and PREWHERE
+['10','20','30']
+G Array parent, single PREWHERE
+[10,20,30]
+W Nullable and LowCardinality parents, row policy and PREWHERE
+7	x
+D matching types, row policy and PREWHERE
+{'a':1,'b':2}

--- a/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.reference
+++ b/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.reference
@@ -1,6 +1,10 @@
 B single PREWHERE on the converted column
 {'a':1,'b':2}
+{'b':2}
+G Array parent, single PREWHERE
+['10','20','30']
 C single row policy on the converted column
+{'a':1}
 {'a':1,'b':2}
 A row policy and PREWHERE on the converted column
 {'a':1,'b':2}
@@ -12,9 +16,11 @@ N additional_table_filters and PREWHERE
 {'a':1,'b':2}
 F Array parent, row policy and PREWHERE
 ['10','20','30']
-G Array parent, single PREWHERE
-[10,20,30]
-W Nullable and LowCardinality parents, row policy and PREWHERE
+W Nullable parent, filters on distinct columns
 7	x
+W2 LowCardinality parent, both filters on the same column
+y
+Z bare-column row policy and PREWHERE on the same column
+5
 D matching types, row policy and PREWHERE
 {'a':1,'b':2}

--- a/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.reference
+++ b/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.reference
@@ -3,6 +3,7 @@ B single PREWHERE on the converted column
 {'b':2}
 G Array parent, single PREWHERE
 ['10','20','30']
+['50','60']
 C single row policy on the converted column
 {'a':1}
 {'a':1,'b':2}
@@ -21,6 +22,9 @@ W Nullable parent, filters on distinct columns
 W2 LowCardinality parent, both filters on the same column
 y
 Z bare-column row policy and PREWHERE on the same column
-5
+1
+2
+Y Nullable parent, both filters on the same column
+8
 D matching types, row policy and PREWHERE
 {'a':1,'b':2}

--- a/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.sql
+++ b/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.sql
@@ -15,6 +15,8 @@ DROP TABLE IF EXISTS t04741_lc_dst;
 DROP TABLE IF EXISTS t04741_lc_buf;
 DROP TABLE IF EXISTS t04741_bare_dst;
 DROP TABLE IF EXISTS t04741_bare_buf;
+DROP TABLE IF EXISTS t04741_nul_dst;
+DROP TABLE IF EXISTS t04741_nul_buf;
 DROP ROW POLICY IF EXISTS p04741_map ON t04741_map_buf;
 DROP ROW POLICY IF EXISTS p04741_map_k ON t04741_map_buf;
 DROP ROW POLICY IF EXISTS p04741_arr ON t04741_arr_buf;
@@ -22,8 +24,9 @@ DROP ROW POLICY IF EXISTS p04741_same ON t04741_same_buf;
 DROP ROW POLICY IF EXISTS p04741_wrap ON t04741_wrap_buf;
 DROP ROW POLICY IF EXISTS p04741_lc ON t04741_lc_buf;
 DROP ROW POLICY IF EXISTS p04741_bare ON t04741_bare_buf;
+DROP ROW POLICY IF EXISTS p04741_nul ON t04741_nul_buf;
 
--- Every destination holds one row both filters accept, one only the row policy rejects and one only
+-- Each destination holds a row both filters accept, a row only the row policy rejects and a row only
 -- the PREWHERE rejects, so dropping either filter changes the output of every two-filter arm.
 CREATE TABLE t04741_map_dst (k UInt8, m Array(Tuple(String, UInt64))) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t04741_map_dst VALUES (1, [('a', 1), ('b', 2)]), (2, [('b', 2)]), (3, [('a', 1)]);
@@ -31,7 +34,7 @@ CREATE TABLE t04741_map_buf (k UInt8, m Map(String, UInt64))
     ENGINE = Buffer(currentDatabase(), t04741_map_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
 
 CREATE TABLE t04741_arr_dst (k UInt8, a Array(UInt64)) ENGINE = MergeTree ORDER BY tuple();
-INSERT INTO t04741_arr_dst VALUES (1, [10, 20, 30]), (2, []), (3, [40]);
+INSERT INTO t04741_arr_dst VALUES (1, [10, 20, 30]), (2, []), (3, [40]), (4, [50, 60]);
 CREATE TABLE t04741_arr_buf (k UInt8, a Array(String))
     ENGINE = Buffer(currentDatabase(), t04741_arr_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
 
@@ -46,9 +49,14 @@ CREATE TABLE t04741_lc_buf (k UInt8, l LowCardinality(String))
     ENGINE = Buffer(currentDatabase(), t04741_lc_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
 
 CREATE TABLE t04741_bare_dst (k UInt8, f UInt8) ENGINE = MergeTree ORDER BY tuple();
-INSERT INTO t04741_bare_dst VALUES (1, 5), (2, 0), (3, 1);
+INSERT INTO t04741_bare_dst VALUES (1, 5), (2, 0), (3, 1), (4, 2);
 CREATE TABLE t04741_bare_buf (k UInt8, f UInt64)
     ENGINE = Buffer(currentDatabase(), t04741_bare_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+CREATE TABLE t04741_nul_dst (k UInt8, n Nullable(UInt64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04741_nul_dst VALUES (1, 7), (2, NULL), (3, 9), (4, 8);
+CREATE TABLE t04741_nul_buf (k UInt8, n Nullable(String))
+    ENGINE = Buffer(currentDatabase(), t04741_nul_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
 
 CREATE TABLE t04741_same_dst (k UInt8, m Map(String, UInt64)) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t04741_same_dst VALUES (1, map('a', 1, 'b', 2)), (2, map('b', 2)), (3, map('a', 1));
@@ -87,8 +95,9 @@ SELECT 'N additional_table_filters and PREWHERE';
 SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b') ORDER BY m
 SETTINGS additional_table_filters = {'t04741_map_buf': 'mapContains(m, \'a\')'};
 
--- A different parent type reaches a different cast, so cover it too.
-CREATE ROW POLICY p04741_arr ON t04741_arr_buf USING length(a) > 0 TO ALL;
+-- A different parent type reaches a different cast, so cover it too. The policy needs a conjunct the
+-- PREWHERE does not imply, or a row rejected only by the policy cannot exist.
+CREATE ROW POLICY p04741_arr ON t04741_arr_buf USING length(a) > 0 AND k != 4 TO ALL;
 
 SELECT 'F Array parent, row policy and PREWHERE';
 SELECT a FROM t04741_arr_buf PREWHERE length(a) > 1 ORDER BY a;
@@ -109,7 +118,14 @@ SELECT l FROM t04741_lc_buf PREWHERE length(l) < 2 ORDER BY l;
 CREATE ROW POLICY p04741_bare ON t04741_bare_buf USING f TO ALL;
 
 SELECT 'Z bare-column row policy and PREWHERE on the same column';
-SELECT f FROM t04741_bare_buf PREWHERE f > 1 ORDER BY f;
+SELECT f FROM t04741_bare_buf PREWHERE f < 4 ORDER BY f;
+
+-- A Nullable parent with both filters on the same column. The PREWHERE must accept the NULL row,
+-- otherwise it implies the policy and the arm cannot detect a lost row policy.
+CREATE ROW POLICY p04741_nul ON t04741_nul_buf USING n != '9' TO ALL;
+
+SELECT 'Y Nullable parent, both filters on the same column';
+SELECT n FROM t04741_nul_buf PREWHERE n != '7' ORDER BY n;
 
 CREATE ROW POLICY p04741_same ON t04741_same_buf USING mapContains(m, 'a') TO ALL;
 
@@ -121,6 +137,7 @@ DROP ROW POLICY p04741_same ON t04741_same_buf;
 DROP ROW POLICY p04741_wrap ON t04741_wrap_buf;
 DROP ROW POLICY p04741_lc ON t04741_lc_buf;
 DROP ROW POLICY p04741_bare ON t04741_bare_buf;
+DROP ROW POLICY p04741_nul ON t04741_nul_buf;
 DROP TABLE t04741_map_buf;
 DROP TABLE t04741_map_dst;
 DROP TABLE t04741_arr_buf;
@@ -133,3 +150,5 @@ DROP TABLE t04741_lc_buf;
 DROP TABLE t04741_lc_dst;
 DROP TABLE t04741_bare_buf;
 DROP TABLE t04741_bare_dst;
+DROP TABLE t04741_nul_buf;
+DROP TABLE t04741_nul_dst;

--- a/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.sql
+++ b/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.sql
@@ -26,8 +26,10 @@ DROP ROW POLICY IF EXISTS p04741_lc ON t04741_lc_buf;
 DROP ROW POLICY IF EXISTS p04741_bare ON t04741_bare_buf;
 DROP ROW POLICY IF EXISTS p04741_nul ON t04741_nul_buf;
 
--- Each destination holds a row both filters accept, a row only the row policy rejects and a row only
--- the PREWHERE rejects, so dropping either filter changes the output of every two-filter arm.
+-- Every arm whose two filters meet the same converted column holds a row both filters accept, a row
+-- only its row policy rejects and a row only its PREWHERE rejects, so neither filter can go missing
+-- unnoticed. Arms J and I are the deliberate exceptions, each showing a filter on another column is
+-- unaffected: J has no policy-only-rejected row and I has no PREWHERE-only-rejected row.
 CREATE TABLE t04741_map_dst (k UInt8, m Array(Tuple(String, UInt64))) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t04741_map_dst VALUES (1, [('a', 1), ('b', 2)]), (2, [('b', 2)]), (3, [('a', 1)]);
 CREATE TABLE t04741_map_buf (k UInt8, m Map(String, UInt64))
@@ -120,8 +122,9 @@ CREATE ROW POLICY p04741_bare ON t04741_bare_buf USING f TO ALL;
 SELECT 'Z bare-column row policy and PREWHERE on the same column';
 SELECT f FROM t04741_bare_buf PREWHERE f < 4 ORDER BY f;
 
--- A Nullable parent with both filters on the same column. The PREWHERE must accept the NULL row,
--- otherwise it implies the policy and the arm cannot detect a lost row policy.
+-- A Nullable parent with both filters on the same column. This is a control: a Nullable parent was
+-- already correct before the fix, so the arm pins that the fix does not regress it. The PREWHERE must
+-- accept the NULL row, otherwise it implies the policy and the arm cannot detect a lost row policy.
 CREATE ROW POLICY p04741_nul ON t04741_nul_buf USING n != '9' TO ALL;
 
 SELECT 'Y Nullable parent, both filters on the same column';

--- a/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.sql
+++ b/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.sql
@@ -1,0 +1,98 @@
+-- Tags: no-parallel-replicas
+
+-- Reading a Buffer whose destination declares a column differently logs a warning per read.
+SET send_logs_level = 'error';
+
+DROP TABLE IF EXISTS t04741_map_dst;
+DROP TABLE IF EXISTS t04741_map_buf;
+DROP TABLE IF EXISTS t04741_arr_dst;
+DROP TABLE IF EXISTS t04741_arr_buf;
+DROP TABLE IF EXISTS t04741_same_dst;
+DROP TABLE IF EXISTS t04741_same_buf;
+DROP TABLE IF EXISTS t04741_wrap_dst;
+DROP TABLE IF EXISTS t04741_wrap_buf;
+DROP ROW POLICY IF EXISTS p04741_map ON t04741_map_buf;
+DROP ROW POLICY IF EXISTS p04741_map_k ON t04741_map_buf;
+DROP ROW POLICY IF EXISTS p04741_arr ON t04741_arr_buf;
+DROP ROW POLICY IF EXISTS p04741_same ON t04741_same_buf;
+DROP ROW POLICY IF EXISTS p04741_wrap ON t04741_wrap_buf;
+
+CREATE TABLE t04741_map_dst (k UInt8, m Array(Tuple(String, UInt64))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04741_map_dst VALUES (1, [('a', 1), ('b', 2)]);
+CREATE TABLE t04741_map_buf (k UInt8, m Map(String, UInt64))
+    ENGINE = Buffer(currentDatabase(), t04741_map_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+CREATE TABLE t04741_arr_dst (k UInt8, a Array(UInt64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04741_arr_dst VALUES (1, [10, 20, 30]);
+CREATE TABLE t04741_arr_buf (k UInt8, a Array(String))
+    ENGINE = Buffer(currentDatabase(), t04741_arr_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+CREATE TABLE t04741_wrap_dst (k UInt8, s Nullable(UInt64), l String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04741_wrap_dst VALUES (1, 7, 'x');
+CREATE TABLE t04741_wrap_buf (k UInt8, s Nullable(String), l LowCardinality(String))
+    ENGINE = Buffer(currentDatabase(), t04741_wrap_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+CREATE TABLE t04741_same_dst (k UInt8, m Map(String, UInt64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04741_same_dst VALUES (1, map('a', 1, 'b', 2));
+CREATE TABLE t04741_same_buf (k UInt8, m Map(String, UInt64))
+    ENGINE = Buffer(currentDatabase(), t04741_same_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+SELECT 'B single PREWHERE on the converted column';
+SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b');
+
+CREATE ROW POLICY p04741_map ON t04741_map_buf USING mapContains(m, 'a') TO ALL;
+
+SELECT 'C single row policy on the converted column';
+SELECT m FROM t04741_map_buf;
+
+-- Both forwarded filters reference the same converted column: the row policy leaves it converted
+-- and the PREWHERE prefix must not convert it again.
+SELECT 'A row policy and PREWHERE on the converted column';
+SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b');
+
+SELECT 'J PREWHERE on another column';
+SELECT m FROM t04741_map_buf PREWHERE k = 1;
+
+DROP ROW POLICY p04741_map ON t04741_map_buf;
+CREATE ROW POLICY p04741_map_k ON t04741_map_buf USING k = 1 TO ALL;
+
+SELECT 'I row policy on another column';
+SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b');
+
+DROP ROW POLICY p04741_map_k ON t04741_map_buf;
+
+SELECT 'N additional_table_filters and PREWHERE';
+SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b')
+SETTINGS additional_table_filters = {'t04741_map_buf': 'mapContains(m, \'a\')'};
+
+-- A different parent type reaches a different cast, so cover it too.
+CREATE ROW POLICY p04741_arr ON t04741_arr_buf USING length(a) > 0 TO ALL;
+
+SELECT 'F Array parent, row policy and PREWHERE';
+SELECT a FROM t04741_arr_buf PREWHERE length(a) > 1;
+
+SELECT 'G Array parent, single PREWHERE';
+SELECT a FROM t04741_arr_dst PREWHERE length(a) > 1;
+
+-- Nullable and LowCardinality parents reach further distinct casts.
+CREATE ROW POLICY p04741_wrap ON t04741_wrap_buf USING s IS NOT NULL TO ALL;
+
+SELECT 'W Nullable and LowCardinality parents, row policy and PREWHERE';
+SELECT s, l FROM t04741_wrap_buf PREWHERE l != '';
+
+CREATE ROW POLICY p04741_same ON t04741_same_buf USING mapContains(m, 'a') TO ALL;
+
+SELECT 'D matching types, row policy and PREWHERE';
+SELECT m FROM t04741_same_buf PREWHERE mapContains(m, 'b');
+
+DROP ROW POLICY p04741_arr ON t04741_arr_buf;
+DROP ROW POLICY p04741_same ON t04741_same_buf;
+DROP ROW POLICY p04741_wrap ON t04741_wrap_buf;
+DROP TABLE t04741_map_buf;
+DROP TABLE t04741_map_dst;
+DROP TABLE t04741_arr_buf;
+DROP TABLE t04741_arr_dst;
+DROP TABLE t04741_same_buf;
+DROP TABLE t04741_same_dst;
+DROP TABLE t04741_wrap_buf;
+DROP TABLE t04741_wrap_dst;

--- a/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.sql
+++ b/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.sql
@@ -26,10 +26,11 @@ DROP ROW POLICY IF EXISTS p04741_lc ON t04741_lc_buf;
 DROP ROW POLICY IF EXISTS p04741_bare ON t04741_bare_buf;
 DROP ROW POLICY IF EXISTS p04741_nul ON t04741_nul_buf;
 
--- Every arm whose two filters meet the same converted column holds a row both filters accept, a row
--- only its row policy rejects and a row only its PREWHERE rejects, so neither filter can go missing
--- unnoticed. Arms J and I are the deliberate exceptions, each showing a filter on another column is
--- unaffected: J has no policy-only-rejected row and I has no PREWHERE-only-rejected row.
+-- Arms A, F, W, W2, Z, Y and D each hold a row both filters accept, a row only its row policy
+-- rejects and a row only its PREWHERE rejects, so neither filter can go missing unnoticed. J and I
+-- are the deliberate exceptions, each showing a filter on another column is unaffected: J has no
+-- policy-only-rejected row and I has no PREWHERE-only-rejected row. N pairs the PREWHERE with an
+-- additional_table_filters entry instead of a row policy, and B, G and C are single-filter controls.
 CREATE TABLE t04741_map_dst (k UInt8, m Array(Tuple(String, UInt64))) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t04741_map_dst VALUES (1, [('a', 1), ('b', 2)]), (2, [('b', 2)]), (3, [('a', 1)]);
 CREATE TABLE t04741_map_buf (k UInt8, m Map(String, UInt64))

--- a/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.sql
+++ b/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.sql
@@ -11,83 +11,116 @@ DROP TABLE IF EXISTS t04741_same_dst;
 DROP TABLE IF EXISTS t04741_same_buf;
 DROP TABLE IF EXISTS t04741_wrap_dst;
 DROP TABLE IF EXISTS t04741_wrap_buf;
+DROP TABLE IF EXISTS t04741_lc_dst;
+DROP TABLE IF EXISTS t04741_lc_buf;
+DROP TABLE IF EXISTS t04741_bare_dst;
+DROP TABLE IF EXISTS t04741_bare_buf;
 DROP ROW POLICY IF EXISTS p04741_map ON t04741_map_buf;
 DROP ROW POLICY IF EXISTS p04741_map_k ON t04741_map_buf;
 DROP ROW POLICY IF EXISTS p04741_arr ON t04741_arr_buf;
 DROP ROW POLICY IF EXISTS p04741_same ON t04741_same_buf;
 DROP ROW POLICY IF EXISTS p04741_wrap ON t04741_wrap_buf;
+DROP ROW POLICY IF EXISTS p04741_lc ON t04741_lc_buf;
+DROP ROW POLICY IF EXISTS p04741_bare ON t04741_bare_buf;
 
+-- Every destination holds one row both filters accept, one only the row policy rejects and one only
+-- the PREWHERE rejects, so dropping either filter changes the output of every two-filter arm.
 CREATE TABLE t04741_map_dst (k UInt8, m Array(Tuple(String, UInt64))) ENGINE = MergeTree ORDER BY tuple();
-INSERT INTO t04741_map_dst VALUES (1, [('a', 1), ('b', 2)]);
+INSERT INTO t04741_map_dst VALUES (1, [('a', 1), ('b', 2)]), (2, [('b', 2)]), (3, [('a', 1)]);
 CREATE TABLE t04741_map_buf (k UInt8, m Map(String, UInt64))
     ENGINE = Buffer(currentDatabase(), t04741_map_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
 
 CREATE TABLE t04741_arr_dst (k UInt8, a Array(UInt64)) ENGINE = MergeTree ORDER BY tuple();
-INSERT INTO t04741_arr_dst VALUES (1, [10, 20, 30]);
+INSERT INTO t04741_arr_dst VALUES (1, [10, 20, 30]), (2, []), (3, [40]);
 CREATE TABLE t04741_arr_buf (k UInt8, a Array(String))
     ENGINE = Buffer(currentDatabase(), t04741_arr_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
 
 CREATE TABLE t04741_wrap_dst (k UInt8, s Nullable(UInt64), l String) ENGINE = MergeTree ORDER BY tuple();
-INSERT INTO t04741_wrap_dst VALUES (1, 7, 'x');
+INSERT INTO t04741_wrap_dst VALUES (1, 7, 'x'), (2, NULL, 'q'), (3, 9, '');
 CREATE TABLE t04741_wrap_buf (k UInt8, s Nullable(String), l LowCardinality(String))
     ENGINE = Buffer(currentDatabase(), t04741_wrap_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
 
+CREATE TABLE t04741_lc_dst (k UInt8, l String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04741_lc_dst VALUES (1, 'y'), (2, ''), (3, 'zz');
+CREATE TABLE t04741_lc_buf (k UInt8, l LowCardinality(String))
+    ENGINE = Buffer(currentDatabase(), t04741_lc_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+CREATE TABLE t04741_bare_dst (k UInt8, f UInt8) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04741_bare_dst VALUES (1, 5), (2, 0), (3, 1);
+CREATE TABLE t04741_bare_buf (k UInt8, f UInt64)
+    ENGINE = Buffer(currentDatabase(), t04741_bare_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
 CREATE TABLE t04741_same_dst (k UInt8, m Map(String, UInt64)) ENGINE = MergeTree ORDER BY tuple();
-INSERT INTO t04741_same_dst VALUES (1, map('a', 1, 'b', 2));
+INSERT INTO t04741_same_dst VALUES (1, map('a', 1, 'b', 2)), (2, map('b', 2)), (3, map('a', 1));
 CREATE TABLE t04741_same_buf (k UInt8, m Map(String, UInt64))
     ENGINE = Buffer(currentDatabase(), t04741_same_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
 
+-- The single-filter controls read the Buffer before any row policy exists on their table.
 SELECT 'B single PREWHERE on the converted column';
-SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b');
+SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b') ORDER BY m;
+
+SELECT 'G Array parent, single PREWHERE';
+SELECT a FROM t04741_arr_buf PREWHERE length(a) > 1 ORDER BY a;
 
 CREATE ROW POLICY p04741_map ON t04741_map_buf USING mapContains(m, 'a') TO ALL;
 
 SELECT 'C single row policy on the converted column';
-SELECT m FROM t04741_map_buf;
+SELECT m FROM t04741_map_buf ORDER BY m;
 
 -- Both forwarded filters reference the same converted column: the row policy leaves it converted
 -- and the PREWHERE prefix must not convert it again.
 SELECT 'A row policy and PREWHERE on the converted column';
-SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b');
+SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b') ORDER BY m;
 
 SELECT 'J PREWHERE on another column';
-SELECT m FROM t04741_map_buf PREWHERE k = 1;
+SELECT m FROM t04741_map_buf PREWHERE k = 1 ORDER BY m;
 
 DROP ROW POLICY p04741_map ON t04741_map_buf;
 CREATE ROW POLICY p04741_map_k ON t04741_map_buf USING k = 1 TO ALL;
 
 SELECT 'I row policy on another column';
-SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b');
+SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b') ORDER BY m;
 
 DROP ROW POLICY p04741_map_k ON t04741_map_buf;
 
 SELECT 'N additional_table_filters and PREWHERE';
-SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b')
+SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b') ORDER BY m
 SETTINGS additional_table_filters = {'t04741_map_buf': 'mapContains(m, \'a\')'};
 
 -- A different parent type reaches a different cast, so cover it too.
 CREATE ROW POLICY p04741_arr ON t04741_arr_buf USING length(a) > 0 TO ALL;
 
 SELECT 'F Array parent, row policy and PREWHERE';
-SELECT a FROM t04741_arr_buf PREWHERE length(a) > 1;
-
-SELECT 'G Array parent, single PREWHERE';
-SELECT a FROM t04741_arr_dst PREWHERE length(a) > 1;
+SELECT a FROM t04741_arr_buf PREWHERE length(a) > 1 ORDER BY a;
 
 -- Nullable and LowCardinality parents reach further distinct casts.
 CREATE ROW POLICY p04741_wrap ON t04741_wrap_buf USING s IS NOT NULL TO ALL;
 
-SELECT 'W Nullable and LowCardinality parents, row policy and PREWHERE';
-SELECT s, l FROM t04741_wrap_buf PREWHERE l != '';
+SELECT 'W Nullable parent, filters on distinct columns';
+SELECT s, l FROM t04741_wrap_buf PREWHERE l != '' ORDER BY s;
+
+CREATE ROW POLICY p04741_lc ON t04741_lc_buf USING l != '' TO ALL;
+
+SELECT 'W2 LowCardinality parent, both filters on the same column';
+SELECT l FROM t04741_lc_buf PREWHERE length(l) < 2 ORDER BY l;
+
+-- A bare-column row policy makes the filter column a real table column, so the row-level step
+-- removes a column it also emits converted.
+CREATE ROW POLICY p04741_bare ON t04741_bare_buf USING f TO ALL;
+
+SELECT 'Z bare-column row policy and PREWHERE on the same column';
+SELECT f FROM t04741_bare_buf PREWHERE f > 1 ORDER BY f;
 
 CREATE ROW POLICY p04741_same ON t04741_same_buf USING mapContains(m, 'a') TO ALL;
 
 SELECT 'D matching types, row policy and PREWHERE';
-SELECT m FROM t04741_same_buf PREWHERE mapContains(m, 'b');
+SELECT m FROM t04741_same_buf PREWHERE mapContains(m, 'b') ORDER BY m;
 
 DROP ROW POLICY p04741_arr ON t04741_arr_buf;
 DROP ROW POLICY p04741_same ON t04741_same_buf;
 DROP ROW POLICY p04741_wrap ON t04741_wrap_buf;
+DROP ROW POLICY p04741_lc ON t04741_lc_buf;
+DROP ROW POLICY p04741_bare ON t04741_bare_buf;
 DROP TABLE t04741_map_buf;
 DROP TABLE t04741_map_dst;
 DROP TABLE t04741_arr_buf;
@@ -96,3 +129,7 @@ DROP TABLE t04741_same_buf;
 DROP TABLE t04741_same_dst;
 DROP TABLE t04741_wrap_buf;
 DROP TABLE t04741_wrap_dst;
+DROP TABLE t04741_lc_buf;
+DROP TABLE t04741_lc_dst;
+DROP TABLE t04741_bare_buf;
+DROP TABLE t04741_bare_dst;

--- a/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.sql
+++ b/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.sql
@@ -123,8 +123,9 @@ SELECT 'Z bare-column row policy and PREWHERE on the same column';
 SELECT f FROM t04741_bare_buf PREWHERE f < 4 ORDER BY f;
 
 -- A Nullable parent with both filters on the same column. This is a control: a Nullable parent was
--- already correct before the fix, so the arm pins that the fix does not regress it. The PREWHERE must
--- accept the NULL row, otherwise it implies the policy and the arm cannot detect a lost row policy.
+-- already correct before the fix, so the arm pins that the fix does not regress it. Both filters
+-- reject the NULL row, so the arm's sensitivity comes from the other two rows: n = '9' only the
+-- policy rejects, n = '7' only the PREWHERE rejects.
 CREATE ROW POLICY p04741_nul ON t04741_nul_buf USING n != '9' TO ALL;
 
 SELECT 'Y Nullable parent, both filters on the same column';

--- a/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.reference
+++ b/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.reference
@@ -1,0 +1,8 @@
+P1 no filter, the converted column reads correctly
+{'a':1,'b':2}
+{'b':2}
+{'a':1}
+P2 single row policy on the converted column
+{'a':1,'b':2}
+{'a':1}
+P3 row policy and PREWHERE on the converted column

--- a/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.sql
+++ b/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.sql
@@ -1,0 +1,34 @@
+-- Tags: no-fasttest
+-- no-fasttest: the Parquet format is unavailable in the fast test build.
+
+-- Reading a Buffer whose destination declares a column differently logs a warning per read, and the
+-- last query below raises an expected error the client would otherwise echo to stderr.
+SET send_logs_level = 'fatal';
+
+DROP TABLE IF EXISTS t04743_pq_buf;
+DROP TABLE IF EXISTS t04743_pq_dst;
+DROP ROW POLICY IF EXISTS p04743_pq ON t04743_pq_buf;
+
+-- A Parquet-backed destination forwards both filters through StorageFile, which builds their header
+-- in updateFormatPrewhereInfo. MergeTree never reaches that function, so the arm below covers a
+-- carrier the sibling test cannot.
+CREATE TABLE t04743_pq_dst (k UInt8, m Array(Tuple(String, UInt64))) ENGINE = File(Parquet);
+INSERT INTO t04743_pq_dst VALUES (1, [('a', 1), ('b', 2)]), (2, [('b', 2)]), (3, [('a', 1)]);
+CREATE TABLE t04743_pq_buf (k UInt8, m Map(String, UInt64))
+    ENGINE = Buffer(currentDatabase(), t04743_pq_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+SELECT 'P1 no filter, the converted column reads correctly';
+SELECT m FROM t04743_pq_buf ORDER BY k;
+
+SELECT 'P2 single row policy on the converted column';
+CREATE ROW POLICY p04743_pq ON t04743_pq_buf USING mapContains(m, 'a') TO ALL;
+SELECT m FROM t04743_pq_buf ORDER BY k;
+
+-- Both forwarded filters reference the same converted column. The row policy prefix leaves it
+-- holding this table's type, so the PREWHERE prefix must not convert it a second time.
+SELECT 'P3 row policy and PREWHERE on the converted column';
+SELECT m FROM t04743_pq_buf PREWHERE mapContains(m, 'b') ORDER BY k; -- { serverError TYPE_MISMATCH }
+
+DROP ROW POLICY p04743_pq ON t04743_pq_buf;
+DROP TABLE t04743_pq_buf;
+DROP TABLE t04743_pq_dst;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/113231
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a `Bad cast` logical error when a row policy and a `PREWHERE` both reference the same column of a `Buffer` table whose destination table declares that column with a different type. The column was converted twice, the second time from a type it no longer had.


### Description

A `Buffer` may declare a column with a different type than its destination, converting it on read. When a row policy *and* a `PREWHERE` both reference such a column, the server aborts:

```sql
CREATE TABLE dst (k UInt8, m Array(Tuple(String, UInt64))) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO dst VALUES (1, [('a', 1), ('b', 2)]);
CREATE TABLE buf (k UInt8, m Map(String, UInt64))
    ENGINE = Buffer(currentDatabase(), dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
CREATE ROW POLICY p ON buf USING mapContains(m, 'a') TO ALL;
SELECT m FROM buf PREWHERE mapContains(m, 'b');
```

`Logical error: 'Bad cast from type DB::ColumnMap to DB::ColumnArray'` in a debug or sanitizer build; a release build rejects it with `Code: 49`. It fails at planning time, so `EXPLAIN` fails too.

Root cause: `StorageBuffer::read` forwards both filters into the destination read, building a converting prefix per filter from one DAG whose `_CAST` binds the destination type. The prefixes then run as consecutive `PREWHERE` steps over one block carrying each step's outputs forward, so the second prefix casts a column the first converted, from a type it no longer has.

The change builds each prefix from its own source list, where a column a previous prefix converted already carries this table's type, so `makeConvertingActions` emits no cast. Not in 26.7 or earlier, so no backport is requested.

On pristine master a `Map` parent aborts and `Array` and `LowCardinality` parents give `Code: 44`; all arms pass on the fixed build. `Nullable` and matching-type parents are controls. Reverting only the type substitution reddens those three arms; an over-broad substitution reddens the other-column control alone. Conflicts textually with `#113231`, which touches the same lambda.

Reading such a column with `FINAL` and a row policy fails on unmodified master with a single filter: a separate `FINAL`-path defect, not addressed here.