### PR TITLE
Add multi-column text index support

### DIFF
--- a/docs/reference/engines/table-engines/mergetree-family/textindexes.mdx
+++ b/docs/reference/engines/table-engines/mergetree-family/textindexes.mdx
@@ -91,7 +91,7 @@ CREATE TABLE table
                                 [, preprocessor = expression(str)]
                                 [, postprocessor = expression(str)]
                                 [, support_phrase_search = 0 | 1 ] -- experimental
-                                [, field_ids = '{"str": 1}']
+                                [, field_ids = '{"str": 1}'] -- experimental
                                 -- Optional advanced parameters:
                                 [, dictionary_block_size = D]
                                 [, dictionary_block_frontcoding_compression = B]
@@ -126,12 +126,15 @@ CREATE TABLE documents
         field_ids = '{"title": 1, "body": 2}')
 )
 ENGINE = MergeTree
-ORDER BY id;
+ORDER BY id
+SETTINGS allow_experimental_multi_column_text_index = 1;
 
 SELECT id
 FROM documents
 WHERE hasToken(title, 'ClickHouse') AND hasToken(body, 'search');
 ```
+
+Creating a field-tagged index currently requires the experimental MergeTree setting `allow_experimental_multi_column_text_index = 1`.
 
 The `field_ids` argument is a user-maintained JSON object that assigns each indexed column a stable integer ID from 1 through 65535. It is mandatory for a multi-column index. Every active column must have an entry, and IDs must be unique across both active columns and retained entries for removed columns. Do not change or reuse an existing assignment.
 
@@ -157,7 +160,7 @@ ALTER TABLE table
                                 [, preprocessor = expression(str)]
                                 [, postprocessor = expression(str)]
                                 [, support_phrase_search = 0 | 1 ] -- experimental
-                                [, field_ids = '{"str": 1}']
+                                [, field_ids = '{"str": 1}'] -- experimental
                                 -- Optional advanced parameters:
                                 [, dictionary_block_size = D]
                                 [, dictionary_block_frontcoding_compression = B]

--- a/docs/reference/engines/table-engines/mergetree-family/textindexes.mdx
+++ b/docs/reference/engines/table-engines/mergetree-family/textindexes.mdx
@@ -91,6 +91,7 @@ CREATE TABLE table
                                 [, preprocessor = expression(str)]
                                 [, postprocessor = expression(str)]
                                 [, support_phrase_search = 0 | 1 ] -- experimental
+                                [, field_ids = '{"str": 1}']
                                 -- Optional advanced parameters:
                                 [, dictionary_block_size = D]
                                 [, dictionary_block_frontcoding_compression = B]
@@ -110,6 +111,34 @@ Text indexes can be defined on columns of these types:
 
 Columns of type [Nullable(T)](/reference/data-types/nullable) and [LowCardinality()](/reference/data-types/lowcardinality) are also supported, including `Array(Nullable(String or FixedString))`.
 
+### Multi-column text indexes {#multi-column-text-indexes}
+
+A single text index can index multiple plain columns. Queries still address each column separately and can combine predicates in SQL:
+
+```sql title="Query"
+CREATE TABLE documents
+(
+    id UInt64,
+    title String,
+    body String,
+    INDEX search_idx (title, body) TYPE text(
+        tokenizer = 'splitByNonAlpha',
+        field_ids = '{"title": 1, "body": 2}')
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+SELECT id
+FROM documents
+WHERE hasToken(title, 'ClickHouse') AND hasToken(body, 'search');
+```
+
+The `field_ids` argument is a user-maintained JSON object that assigns each indexed column a stable integer ID from 1 through 65535. It is mandatory for a multi-column index. Every active column must have an entry, and IDs must be unique across both active columns and retained entries for removed columns. Do not change or reuse an existing assignment.
+
+Supplying `field_ids` also selects the field-tagged layout for a single-column index. Field-tagged indexes currently support only plain column expressions and cannot use `preprocessor` or `postprocessor`. The dictionary-scan optimization for pattern-only predicates is not supported for this layout yet, so affected predicates fall back to row-level evaluation. The `mergeTreeTextIndex` table function also does not support field-tagged indexes yet.
+
+Existing parts do not record which individual fields they contain. Treat any change to the active columns or their IDs as an index replacement: use `DROP INDEX`, `ADD INDEX`, and `MATERIALIZE INDEX`, and wait for materialization to finish before relying on predicates for the changed fields. Keep removed fields in `field_ids` as tombstones so that their IDs are never reused.
+
 Alternatively, to add a text index to an existing table:
 
 ```sql title="Query"
@@ -128,6 +157,7 @@ ALTER TABLE table
                                 [, preprocessor = expression(str)]
                                 [, postprocessor = expression(str)]
                                 [, support_phrase_search = 0 | 1 ] -- experimental
+                                [, field_ids = '{"str": 1}']
                                 -- Optional advanced parameters:
                                 [, dictionary_block_size = D]
                                 [, dictionary_block_frontcoding_compression = B]

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1348,6 +1348,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
             {"packed_skip_index_max_bytes", 0, 1024 * 1024, "Promote to BETA and enable by default: pack skip-index substreams whose serialized on-disk size is at most 1 MiB into a single `skp_idx.packed` archive per part, cutting object count and read requests on object storage. Larger substreams keep the standalone `skp_idx_<name>.idx2` / `.mrk2` layout. Set to 0 to restore the previous behavior (no packing)."},
             {"compute_exact_num_defaults_for_sparse_columns", false, true, "Promote to BETA and enable by default: compute the exact per-column `num_defaults` counter during inserts and merges (instead of the sampling estimate), so `optimize_trivial_count_with_sparsity_filter` and sparsity-based pruning can rely on it."},
             {"allow_experimental_adaptive_codec_selection", false, false, "New setting."},
+            {"allow_experimental_multi_column_text_index", false, false, "New setting."},
             {"text_index_max_processed_tokens_before_flush", 100000000, 100000000, "New setting"},
             {"text_index_max_memory_usage_before_flush", std::numeric_limits<UInt64>::max(), 1073741824, "New setting. The previous value disables memory-based flushing to preserve pre-26.8 behavior"},
         });

--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -461,7 +461,13 @@ private:
             /// Take the first text index if there are multiple text indexes set for the same expression.
             /// It is ambiguous which index to use. However, we allow to use several indexes for different expressions.
             /// for example, we can use indexes both for mapKeys(m) and mapValues(m) in one function m['key'] = 'value'.
-            if (index_header.columns() != 1 || used_index_columns.contains(index_header.begin()->name))
+            ///
+            /// Multi-column text indexes are restricted at DDL validation to plain source columns,
+            /// so one predicate resolves at most one field in an index. `MergeTreeData::checkProperties`
+            /// also prevents any active column from belonging to two text indexes. Consequently the
+            /// first header column remains a stable per-index deduplication key here even though the
+            /// condition itself may match any header column.
+            if (used_index_columns.contains(index_header.begin()->name))
                 continue;
 
             auto search_query = text_index_condition.createTextSearchQuery(canonical_node);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1108,19 +1108,15 @@ void MergeTreeData::checkProperties(
 
             indices_names.insert(index.name);
 
-            /// Workaround for https://github.com/ClickHouse/ClickHouse/issues/82385 where functions hasAllTokens/hasAnyTokens don't work
-            /// on columns with more than one text index
+            /// Workaround for https://github.com/ClickHouse/ClickHouse/issues/82385 where functions `hasAllTokens` / `hasAnyTokens` don't work
+            /// on columns with more than one text index. For a multi-column text index, check every indexed column, not only the first one.
             if (index.type == TEXT_INDEX_NAME)
             {
-                const auto & column = index.column_names[0];
-
-                if (columns_with_text_indexes.contains(column))
-                    throw Exception(
-                        ErrorCodes::BAD_ARGUMENTS,
-                        "Column {} must not have more than one text index",
-                        backQuote(index.column_names[0]));
-
-                columns_with_text_indexes.insert(column);
+                for (const auto & column : index.column_names)
+                {
+                    if (!columns_with_text_indexes.insert(column).second)
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Column {} must not have more than one text index", backQuote(column));
+                }
             }
         }
     }

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -81,15 +81,15 @@ void TextSearchQuery::bindToField(UInt16 field_id_)
         /// Empty tokens are prune-all sentinels produced by some predicate conversions. Leaving
         /// them untagged preserves the invariant that they cannot match a dictionary entry.
         if (!token.empty())
-            appendTextIndexFieldId(token, field_id_);
+            encodeTextIndexFieldToken(token, field_id_);
     }
-    /// Appending a suffix can change the order of prefix-related tokens, for example `a` and `aa`.
+    /// Establish the physical dictionary order independently of how the query was constructed.
     std::sort(tokens.begin(), tokens.end());
 
     for (auto & token : phrase_tokens)
     {
         if (!token.empty())
-            appendTextIndexFieldId(token, field_id_);
+            encodeTextIndexFieldToken(token, field_id_);
     }
 
     initializeHash();
@@ -600,6 +600,7 @@ std::string MergeTreeIndexConditionText::getDescription() const
     }
     else
     {
+        String decoded_token_scratch;
         for (size_t i = 0; i < all_search_tokens.size(); ++i)
         {
             if (i > 0)
@@ -610,7 +611,7 @@ std::string MergeTreeIndexConditionText::getDescription() const
             {
                 /// Keep binary suffix bytes out of `EXPLAIN indexes` output while retaining the
                 /// selected-field identity that distinguishes otherwise equal logical tokens.
-                const auto decoded = decodeTextIndexFieldToken(token);
+                const auto decoded = decodeTextIndexFieldToken(token, decoded_token_scratch);
                 chassert(decoded);
                 description += fmt::format("\"{}\"@{}", decoded->token, decoded->field_id);
             }

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -74,6 +74,27 @@ TextSearchQuery::TextSearchQuery(
     initializeHash();
 }
 
+void TextSearchQuery::bindToField(UInt16 field_id_)
+{
+    for (auto & token : tokens)
+    {
+        /// Empty tokens are prune-all sentinels produced by some predicate conversions. Leaving
+        /// them untagged preserves the invariant that they cannot match a dictionary entry.
+        if (!token.empty())
+            appendTextIndexFieldId(token, field_id_);
+    }
+    /// Appending a suffix can change the order of prefix-related tokens, for example `a` and `aa`.
+    std::sort(tokens.begin(), tokens.end());
+
+    for (auto & token : phrase_tokens)
+    {
+        if (!token.empty())
+            appendTextIndexFieldId(token, field_id_);
+    }
+
+    initializeHash();
+}
+
 void TextSearchQuery::initializeHash()
 {
     SipHash hash_state;
@@ -130,7 +151,8 @@ MergeTreeIndexConditionText::MergeTreeIndexConditionText(
     TokenizerPtr tokenizer_,
     MergeTreeIndexTextPreprocessorPtr preprocessor_,
     MergeTreeIndexTextPostprocessorPtr postprocessor_,
-    bool has_positions_)
+    bool has_positions_,
+    TextIndexFieldIdsMapPtr field_ids_)
     : WithContext(context_)
     , header(index_sample_block)
     , owned_tokenizer(tokenizer_ && tokenizer_->isStateful() ? std::shared_ptr<const ITokenizer>(tokenizer_->clone()) : nullptr)
@@ -139,6 +161,7 @@ MergeTreeIndexConditionText::MergeTreeIndexConditionText(
     , has_preprocessor(preprocessor && preprocessor->hasActions())
     , postprocessor(postprocessor_)
     , has_postprocessor(postprocessor && postprocessor->hasActions())
+    , field_ids(std::move(field_ids_))
     , has_positions(has_positions_)
 {
     if (!predicate)
@@ -582,7 +605,19 @@ std::string MergeTreeIndexConditionText::getDescription() const
             if (i > 0)
                 description += ", ";
 
-            description += fmt::format("\"{}\"", all_search_tokens[i]);
+            const auto & token = all_search_tokens[i];
+            if (field_ids && !token.empty())
+            {
+                /// Keep binary suffix bytes out of `EXPLAIN indexes` output while retaining the
+                /// selected-field identity that distinguishes otherwise equal logical tokens.
+                const auto decoded = decodeTextIndexFieldToken(token);
+                chassert(decoded);
+                description += fmt::format("\"{}\"@{}", decoded->token, decoded->field_id);
+            }
+            else
+            {
+                description += fmt::format("\"{}\"", token);
+            }
         }
     }
 
@@ -881,6 +916,46 @@ static void validateRegexpPatterns(const Array & patterns, const Settings & sett
 }
 
 bool MergeTreeIndexConditionText::traverseFunctionNode(
+    const RPNBuilderFunctionTreeNode & function_node,
+    const RPNBuilderTreeNode & index_column_node,
+    DataTypePtr value_type,
+    Field value_field,
+    RPNElement & out) const
+{
+    if (!traverseFunctionNodeImpl(function_node, index_column_node, std::move(value_type), std::move(value_field), out))
+        return false;
+
+    if (!field_ids)
+        return true;
+
+    /// Pattern dictionary scans currently match the complete physical key. Until they decode the
+    /// suffix and filter by field id, a tagged index must not participate in this optimization.
+    for (const auto & query : out.text_search_queries)
+    {
+        if (!query->getPatterns().empty())
+        {
+            out.text_search_queries.clear();
+            return false;
+        }
+    }
+
+    /// Tagged indexes are restricted to plain source columns at DDL validation. Resolve that one
+    /// field here after all exact/phrase branches have produced their queries, so no producing
+    /// branch can forget to encode its physical dictionary keys.
+    const auto field = field_ids->find(index_column_node.getColumnName());
+    if (field == field_ids->end())
+    {
+        out.text_search_queries.clear();
+        return false;
+    }
+
+    for (auto & query : out.text_search_queries)
+        query->bindToField(field->second);
+
+    return true;
+}
+
+bool MergeTreeIndexConditionText::traverseFunctionNodeImpl(
     const RPNBuilderFunctionTreeNode & function_node,
     const RPNBuilderTreeNode & index_column_node,
     DataTypePtr value_type,
@@ -1648,6 +1723,7 @@ bool MergeTreeIndexConditionText::tryPrepareSetForTextSearch(
     RPNElement & out) const
 {
     std::optional<size_t> set_key_position;
+    std::optional<String> indexed_column_name;
 
     auto has_index = [&](const RPNBuilderTreeNode & node)
     {
@@ -1667,18 +1743,23 @@ bool MergeTreeIndexConditionText::tryPrepareSetForTextSearch(
 
             if (has_index(argument))
             {
-                /// Text index support only one index column.
+                /// One prepared-set predicate may use only one indexed tuple position. A shared
+                /// multi-column index still resolves exactly one source field for this query.
                 if (set_key_position.has_value())
                     return false;
 
                 set_key_position = i;
+                indexed_column_name = argument.getColumnName();
             }
         }
     }
     else
     {
         if (has_index(lhs))
+        {
             set_key_position = 0;
+            indexed_column_name = lhs.getColumnName();
+        }
     }
 
     if (!set_key_position.has_value())
@@ -1733,6 +1814,22 @@ bool MergeTreeIndexConditionText::tryPrepareSetForTextSearch(
         }
 
         out.text_search_queries.emplace_back(std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, TextIndexDirectReadMode::None, std::move(tokens)));
+    }
+
+    if (field_ids)
+    {
+        /// Prepared `IN` sets bypass `traverseFunctionNode`, so apply the same field binding here
+        /// before the queries are inserted into hash-keyed analyzer state.
+        chassert(indexed_column_name.has_value());
+        const auto field = field_ids->find(*indexed_column_name);
+        if (field == field_ids->end())
+        {
+            out.text_search_queries.clear();
+            return false;
+        }
+
+        for (auto & query : out.text_search_queries)
+            query->bindToField(field->second);
     }
 
     return true;

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -5,8 +5,18 @@
 #include <Common/OptimizedRegularExpression.h>
 #include <Common/VectorWithMemoryTracking.h>
 
+#include <optional>
+#include <unordered_map>
+
 namespace DB
 {
+
+/// Complete user-maintained ownership table for field-tagged text-index keys. It may contain
+/// hundreds of active fields and inactive tombstones, so it is shared rather than copied through
+/// `MergeTreeIndexTextParams` and per-query objects. A null pointer means only the legacy untagged
+/// single-column layout; an explicit map on one active column is still tagged.
+using TextIndexFieldIdsMap = std::unordered_map<String, UInt16>;
+using TextIndexFieldIdsMapPtr = std::shared_ptr<const TextIndexFieldIdsMap>;
 
 class TextIndexTokensCache;
 using TextIndexTokensCachePtr = std::shared_ptr<TextIndexTokensCache>;
@@ -59,10 +69,14 @@ struct TextSearchQuery
     const VectorWithMemoryTracking<String> & getPhraseTokens() const { return phrase_tokens; }
     UInt128 getHash() const { return hash; }
 
+    /// Encode a freshly constructed exact/phrase query before it is registered in condition maps.
+    /// The stable hash is recomputed after the physical keys are changed.
+    void bindToField(UInt16 field_id_);
+
 private:
     void initializeHash();
 
-    /// Fields are immutable after construction, otherwise the precomputed hash becomes stale.
+    /// Fields are immutable after optional field binding, otherwise the precomputed hash becomes stale.
     String function_name;
     TextSearchMode search_mode;
     TextIndexDirectReadMode direct_read_mode;
@@ -96,7 +110,8 @@ public:
         TokenizerPtr tokenizer_,
         MergeTreeIndexTextPreprocessorPtr preprocessor_,
         MergeTreeIndexTextPostprocessorPtr postprocessor_,
-        bool has_positions_);
+        bool has_positions_,
+        TextIndexFieldIdsMapPtr field_ids_);
 
     ~MergeTreeIndexConditionText() override = default;
     static bool isSupportedFunction(const String & function_name);
@@ -127,6 +142,7 @@ public:
     TokenizerPtr getTokenizer() const { return tokenizer; }
     MergeTreeIndexTextPreprocessorPtr getPreprocessor() const { return preprocessor; }
     MergeTreeIndexTextPostprocessorPtr getPostprocessor() const { return postprocessor; }
+    bool isFieldTagged() const { return field_ids != nullptr; }
 
 private:
     /// Uses RPN like KeyCondition
@@ -161,6 +177,16 @@ private:
     bool traverseAtomNode(const RPNBuilderTreeNode & node, RPNElement & out) const;
 
     bool traverseFunctionNode(
+        const RPNBuilderFunctionTreeNode & function_node,
+        const RPNBuilderTreeNode & index_column_node,
+        DataTypePtr value_type,
+        Field value_field,
+        RPNElement & out) const;
+
+    /// Predicate-specific matching logic. `traverseFunctionNode` wraps exact and phrase results
+    /// with the common field-binding step and rejects tagged pattern scans until they can decode
+    /// and filter composite dictionary keys.
+    bool traverseFunctionNodeImpl(
         const RPNBuilderFunctionTreeNode & function_node,
         const RPNBuilderTreeNode & index_column_node,
         DataTypePtr value_type,
@@ -215,6 +241,9 @@ private:
     /// Reference postprocessor expression
     MergeTreeIndexTextPostprocessorPtr postprocessor;
     bool has_postprocessor;
+    /// Null for the legacy untagged single-column layout. Non-null is the tagged-layout
+    /// discriminator and also resolves a queried source column to its stable field id.
+    TextIndexFieldIdsMapPtr field_ids;
     /// Whether the index has position data for phrase queries.
     bool has_positions = false;
     /// Cache for tokens and their infos (cardinality, etc.)

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -75,6 +75,7 @@ namespace ErrorCodes
 
 namespace MergeTreeSetting
 {
+    extern const MergeTreeSettingsBool allow_experimental_multi_column_text_index;
     extern const MergeTreeSettingsNonZeroUInt64 text_index_dictionary_block_size;
     extern const MergeTreeSettingsBool text_index_dictionary_block_frontcoding_compression;
     extern const MergeTreeSettingsNonZeroUInt64 text_index_posting_list_block_size;
@@ -2267,7 +2268,7 @@ MergeTreeIndexPtr textIndexCreator(StorageMetadataPtr metadata_snapshot, const I
     return std::make_shared<MergeTreeIndexText>(std::move(metadata_snapshot), index, index_params, std::move(tokenizer), std::move(posting_list_codec));
 }
 
-void textIndexValidator(const IndexDescription & index, bool /*attach*/, const MergeTreeSettings & settings)
+void textIndexValidator(const IndexDescription & index, bool attach, const MergeTreeSettings & settings)
 {
     auto options = convertArgumentsToOptionsMap(index.arguments);
 
@@ -2308,6 +2309,14 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/, const M
     PostingListCodecFactory::createPostingListCodec(posting_list_codec_name, index.name);
 
     auto field_ids_json = extractFieldOption<String>(options, ARGUMENT_FIELD_IDS);
+
+    /// Restrict new definitions only; existing metadata must remain attachable.
+    if (!attach && field_ids_json && !settings[MergeTreeSetting::allow_experimental_multi_column_text_index])
+        throw Exception(
+            ErrorCodes::SUPPORT_IS_DISABLED,
+            "Text index argument '{}' is experimental. Enable it with the MergeTree setting "
+            "`allow_experimental_multi_column_text_index = 1`.",
+            ARGUMENT_FIELD_IDS);
 
     if (!options.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected text index arguments: {}", fmt::join(std::views::keys(options), ", "));

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -43,6 +43,10 @@
 #include <base/types.h>
 #include <fmt/ranges.h>
 
+#include <Poco/Dynamic/Var.h>
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Parser.h>
+
 namespace ProfileEvents
 {
     extern const Event TextIndexReadDictionaryBlocks;
@@ -495,6 +499,15 @@ void MergeTreeIndexGranuleText::deserializeBinaryWithMultipleStreams(MergeTreeIn
     }
 
     auto text_index_header = loadHeader(*index_stream, state);
+    /// Metadata supplies the field ownership table, while each part independently records its
+    /// physical key layout. Never reinterpret legacy token bytes as tagged keys (or vice versa)
+    /// after an index-definition change.
+    if (text_index_header->has_field_ids != condition_text.isFieldTagged())
+        throw Exception(
+            ErrorCodes::CORRUPTED_DATA,
+            "Text index key layout does not match its definition: part has field ids {}, definition has field ids {}",
+            text_index_header->has_field_ids,
+            condition_text.isFieldTagged());
     auto postings_codec = PostingListCodecFactory::createPostingListCodec(text_index_header->codec_type);
     auto postings_serialization = PostingsSerialization(std::move(postings_codec), text_index_header->version);
     serialization_version = text_index_header->version;
@@ -1118,7 +1131,13 @@ void TextIndexSerialization::serializeTokenInfo(WriteBuffer & ostr, const TokenP
     }
 }
 
-void TextIndexSerialization::serializeHeader(const DictionarySparseIndex & sparse_index, IPostingListCodec::Type posting_list_codec_type, MergeTreeIndexVersion version, bool has_positions, WriteBuffer & ostr)
+void TextIndexSerialization::serializeHeader(
+    const DictionarySparseIndex & sparse_index,
+    IPostingListCodec::Type posting_list_codec_type,
+    MergeTreeIndexVersion version,
+    bool has_positions,
+    bool has_field_ids,
+    WriteBuffer & ostr)
 {
     UInt64 codec_type = static_cast<UInt64>(posting_list_codec_type);
 
@@ -1127,6 +1146,9 @@ void TextIndexSerialization::serializeHeader(const DictionarySparseIndex & spars
 
     if (version >= static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::WithPositions))
         writeVarUInt(static_cast<UInt64>(has_positions), ostr);
+
+    if (version >= static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::WithFieldIds))
+        writeVarUInt(static_cast<UInt64>(has_field_ids), ostr);
 
     /// Sparse indexes are created with raw columns and bit-packed only by optimize.
     /// The write path never calls optimize, so expect the raw columns here.
@@ -1147,7 +1169,7 @@ TextIndexHeader TextIndexSerialization::deserializeHeaderPrefix(ReadBuffer & ist
     UInt64 version = 0;
     readVarUInt(version, istr);
 
-    if (version > static_cast<UInt64>(TextIndexHeader::Version::WithPositions))
+    if (version > static_cast<UInt64>(TextIndexHeader::Version::WithFieldIds))
         throw Exception(ErrorCodes::CORRUPTED_DATA, "Unsupported version of sparse index ({})", version);
 
     TextIndexHeader header;
@@ -1169,6 +1191,15 @@ TextIndexHeader TextIndexSerialization::deserializeHeaderPrefix(ReadBuffer & ist
         UInt64 has_positions = 0;
         readVarUInt(has_positions, istr);
         header.has_positions = has_positions != 0;
+    }
+
+    if (version >= static_cast<UInt64>(TextIndexHeader::Version::WithFieldIds))
+    {
+        UInt64 has_field_ids = 0;
+        readVarUInt(has_field_ids, istr);
+        if (has_field_ids > 1)
+            throw Exception(ErrorCodes::CORRUPTED_DATA, "Invalid field-id flag in text index header: {}", has_field_ids);
+        header.has_field_ids = has_field_ids != 0;
     }
 
     return header;
@@ -1467,9 +1498,12 @@ void MergeTreeIndexGranuleTextWritable::serializeBinaryWithMultipleStreams(Merge
         positions_stream = it->second;
     }
 
-    /// Positional parts need a WithPositions reader.
+    /// Version 3 extends the current header instead of overloading column count. It still writes
+    /// the version-2 positions flag first, so tagged indexes work with or without `.pos` data.
+    const bool has_field_ids = params.field_ids != nullptr;
     auto serialization_version = static_cast<MergeTreeIndexVersion>(
-        params.positions ? TextIndexHeader::Version::WithPositions : TextIndexHeader::Version::WithCodec);
+        has_field_ids ? TextIndexHeader::Version::WithFieldIds
+                      : (params.positions ? TextIndexHeader::Version::WithPositions : TextIndexHeader::Version::WithCodec));
 
     auto postings_codec = PostingListCodecFactory::createPostingListCodec(posting_list_codec_type);
     PostingsSerialization postings_serialization(std::move(postings_codec), serialization_version);
@@ -1482,7 +1516,13 @@ void MergeTreeIndexGranuleTextWritable::serializeBinaryWithMultipleStreams(Merge
         postings_serialization,
         positions_stream);
 
-    TextIndexSerialization::serializeHeader(sparse_index_block, posting_list_codec_type, serialization_version, params.positions, index_stream->compressed_hashing);
+    TextIndexSerialization::serializeHeader(
+        sparse_index_block,
+        posting_list_codec_type,
+        serialization_version,
+        params.positions,
+        has_field_ids,
+        index_stream->compressed_hashing);
 }
 
 void MergeTreeIndexGranuleTextWritable::deserializeBinary(ReadBuffer &, MergeTreeIndexVersion)
@@ -1562,7 +1602,7 @@ void PostingListBuilder::add(UInt32 value, PostingListsHolder & postings_holder)
     }
 }
 
-void MergeTreeIndexTextGranuleBuilder::addDocument(std::string_view document)
+void MergeTreeIndexTextGranuleBuilder::addDocument(std::string_view document, std::optional<UInt16> field_id)
 {
     UInt32 token_position = 0;
     forEachToken(
@@ -1571,16 +1611,25 @@ void MergeTreeIndexTextGranuleBuilder::addDocument(std::string_view document)
         document.size(),
         [&](const char * token_start, size_t token_length)
         {
-            addToken({token_start, token_length}, token_position);
+            addToken({token_start, token_length}, token_position, field_id);
             ++token_position;
             return false;
         });
 }
 
-void MergeTreeIndexTextGranuleBuilder::addToken(std::string_view token, UInt32 token_position)
+void MergeTreeIndexTextGranuleBuilder::addToken(std::string_view token, UInt32 token_position, std::optional<UInt16> field_id)
 {
     if (postprocessor_drop_filter && postprocessor_drop_filter->shouldDrop(token))
         return;
+
+    /// Apply the field suffix only after the inline postprocessor has inspected the logical token.
+    /// The scratch-backed view is safe for both map insertions: `ArenaKeyHolder` persists new key
+    /// bytes into `arena`, and an existing key is already owned by the map.
+    if (field_id)
+    {
+        encodeTextIndexFieldToken(token, *field_id, field_token_scratch);
+        token = field_token_scratch;
+    }
 
     bool inserted = false;
     TokenToPostingsBuilderMap::LookupResult it;
@@ -1663,6 +1712,8 @@ void MergeTreeIndexTextGranuleBuilder::reset()
     tokens_map = {};
     posting_lists.clear();
     arena = std::make_unique<Arena>();
+    /// Do not retain a one-off large token allocation after the granule has been finalized.
+    field_token_scratch = String{};
 
     if (params.positions)
         position_map = std::make_unique<TokenToPositionListMap>();
@@ -1671,13 +1722,13 @@ void MergeTreeIndexTextGranuleBuilder::reset()
 }
 
 MergeTreeIndexAggregatorText::MergeTreeIndexAggregatorText(
-    String index_column_name_,
+    Names index_column_names_,
     MergeTreeIndexTextParams params_,
     TokenizerPtr tokenizer_,
     const IPostingListCodec * posting_list_codec_,
     MergeTreeIndexTextPreprocessorPtr preprocessor_,
     MergeTreeIndexTextPostprocessorPtr postprocessor_)
-    : index_column_name(std::move(index_column_name_))
+    : index_column_names(std::move(index_column_names_))
     , params(std::move(params_))
     , owned_tokenizer(tokenizer_ && tokenizer_->isStateful() ? std::shared_ptr<const ITokenizer>(tokenizer_->clone()) : nullptr)
     , tokenizer(owned_tokenizer ? owned_tokenizer.get() : tokenizer_)
@@ -1725,32 +1776,90 @@ void MergeTreeIndexAggregatorText::update(const Block & block, size_t * pos, siz
     if (rows_read == 0)
         return;
 
-    const auto & index_column = block.getByName(index_column_name);
-    auto [preprocessed_column, offset] = preprocessor->processColumn(index_column, *pos, rows_read);
+    if (!params.field_ids)
+    {
+        chassert(index_column_names.size() == 1);
+        const auto & column_name = index_column_names.front();
+        const auto & index_column = block.getByName(column_name);
+        auto [preprocessed_column, offset] = preprocessor->processColumn(index_column, *pos, rows_read);
 
-    if (postprocessor->hasActions() && !use_postprocessor_drop_fast_path)
-    {
-        ColumnPtr tokenized = tokenizeToArray(*tokenizer, *preprocessed_column, offset, rows_read);
-        ColumnPtr postprocessed = postprocessor->processTokensArrayBatch(assert_cast<const ColumnArray *>(tokenized.get()));
-        addDocumentsFromArray<false>(postprocessed, 0, rows_read);
-    }
-    else if (isArray(index_column.type))
-    {
-        addDocumentsFromArray<true>(preprocessed_column, offset, rows_read);
-    }
-    else
-    {
-        const bool column_is_nullable = isColumnNullableOrLowCardinalityNullable(*preprocessed_column);
-
-        for (size_t i = offset; i < offset + rows_read; ++i)
+        if (postprocessor->hasActions() && !use_postprocessor_drop_fast_path)
         {
-            if (!column_is_nullable || !preprocessed_column->isNullAt(i))
-            {
-                const std::string_view ref = preprocessed_column->getDataAt(i);
-                granule_builder.addDocument(ref);
-            }
-            granule_builder.incrementCurrentRow();
+            ColumnPtr tokenized = tokenizeToArray(*tokenizer, *preprocessed_column, offset, rows_read);
+            ColumnPtr postprocessed = postprocessor->processTokensArrayBatch(assert_cast<const ColumnArray *>(tokenized.get()));
+            addDocumentsFromArray<false>(postprocessed, 0, rows_read);
         }
+        else if (isArray(index_column.type))
+        {
+            addDocumentsFromArray<true>(preprocessed_column, offset, rows_read);
+        }
+        else
+        {
+            const bool column_is_nullable = isColumnNullableOrLowCardinalityNullable(*preprocessed_column);
+
+            for (size_t i = offset; i < offset + rows_read; ++i)
+            {
+                if (!column_is_nullable || !preprocessed_column->isNullAt(i))
+                    granule_builder.addDocument(preprocessed_column->getDataAt(i));
+                granule_builder.incrementCurrentRow();
+            }
+        }
+
+        *pos += rows_read;
+        return;
+    }
+
+    /// Every field-tagged index uses this path, including one with a single active column. The
+    /// initial field-tagged stage intentionally has no transform semantics; `field_ids`, rather
+    /// than active column count, is the physical-layout discriminator.
+    chassert(params.field_ids);
+    chassert(!preprocessor->hasActions());
+    chassert(!postprocessor->hasActions());
+
+    struct FieldColumn
+    {
+        const IColumn * column;
+        UInt16 field_id;
+    };
+
+    std::vector<FieldColumn> fields;
+    fields.reserve(index_column_names.size());
+    for (const auto & column_name : index_column_names)
+        fields.push_back({block.getByName(column_name).column.get(), params.field_ids->at(column_name)});
+
+    /// Add all fields of a source row before advancing the posting row id. Thus independently
+    /// queried fields use the same row-id space while their dictionary keys remain disjoint.
+    for (size_t row = *pos; row < *pos + rows_read; ++row)
+    {
+        for (const auto & field : fields)
+        {
+            const IColumn & column = *field.column;
+
+            if (const auto * column_array = typeid_cast<const ColumnArray *>(&column))
+            {
+                const IColumn & column_data = column_array->getData();
+                const auto & column_offsets = column_array->getOffsets();
+                const bool data_is_nullable = isColumnNullableOrLowCardinalityNullable(column_data);
+
+                for (size_t element = column_offsets[row - 1]; element < column_offsets[row]; ++element)
+                {
+                    if (data_is_nullable && column_data.isNullAt(element))
+                        continue;
+
+                    const std::string_view document = column_data.getDataAt(element);
+                    if (document.empty())
+                        continue;
+
+                    granule_builder.addDocument(document, field.field_id);
+                }
+            }
+            else if (!isColumnNullableOrLowCardinalityNullable(column) || !column.isNullAt(row))
+            {
+                granule_builder.addDocument(column.getDataAt(row), field.field_id);
+            }
+        }
+
+        granule_builder.incrementCurrentRow();
     }
 
     *pos += rows_read;
@@ -1799,6 +1908,10 @@ MergeTreeIndexText::MergeTreeIndexText(
     , params(std::move(params_))
     , tokenizer(std::move(tokenizer_))
     , posting_list_codec(std::move(posting_list_codec_))
+    /// A field-id-tagged index rejects preprocessing in this stage, but still owns a real no-op
+    /// object so existing condition and query-rewrite paths may dereference it unconditionally.
+    /// Pass the real, non-empty `index_`: with a null expression the AST conversion helpers return
+    /// before their single-column assertions and the constructor creates no actions.
     , preprocessor(std::make_shared<MergeTreeIndexTextPreprocessor>(params.preprocessor, index_))
     , postprocessor(std::make_shared<MergeTreeIndexTextPostprocessor>(params.postprocessor, index_))
 {
@@ -1835,7 +1948,9 @@ MergeTreeIndexFormat MergeTreeIndexText::getDeserializedFormat(const IMergeTreeD
         {MergeTreeIndexSubstream::Type::TextIndexPostings, ".pst", ".idx"}
     };
 
-    /// V2: positions file exists on disk.
+    /// `MergeTreeIndexFormat` V2 means that a positions substream exists. It is independent of
+    /// `TextIndexHeader::Version`; for example, a field-tagged header V3 with positions still
+    /// returns this stream-set format V2.
     if (indexFileExistsInChecksums(part.checksums, relative_path_prefix + ".pos", ".idx", part.getDataPartStoragePtr().get()))
     {
         substreams.push_back({MergeTreeIndexSubstream::Type::TextIndexPositions, ".pos", ".idx"});
@@ -1852,12 +1967,14 @@ MergeTreeIndexGranulePtr MergeTreeIndexText::createIndexGranule() const
 
 MergeTreeIndexAggregatorPtr MergeTreeIndexText::createIndexAggregator() const
 {
-    return std::make_shared<MergeTreeIndexAggregatorText>(index.column_names[0], params, tokenizer.get(), posting_list_codec.get(), preprocessor, postprocessor);
+    return std::make_shared<MergeTreeIndexAggregatorText>(
+        index.column_names, params, tokenizer.get(), posting_list_codec.get(), preprocessor, postprocessor);
 }
 
 MergeTreeIndexConditionPtr MergeTreeIndexText::createIndexCondition(const ActionsDAG::Node * predicate, ContextPtr context) const
 {
-    return std::make_shared<MergeTreeIndexConditionText>(predicate, context, index.sample_block, tokenizer.get(), preprocessor, postprocessor, params.positions);
+    return std::make_shared<MergeTreeIndexConditionText>(
+        predicate, context, index.sample_block, tokenizer.get(), preprocessor, postprocessor, params.positions, params.field_ids);
 }
 
 DataTypePtr MergeTreeIndexText::getNestedDataType(const DataTypePtr & data_type)
@@ -1885,6 +2002,7 @@ static const String ARGUMENT_DICTIONARY_BLOCK_FRONTCODING_COMPRESSION = "diction
 static const String ARGUMENT_POSTING_LIST_BLOCK_SIZE = "posting_list_block_size";
 static const String ARGUMENT_POSTING_LIST_CODEC = "posting_list_codec";
 static const String ARGUMENT_POSITIONS = "support_phrase_search";
+static const String ARGUMENT_FIELD_IDS = "field_ids";
 
 namespace
 {
@@ -1967,6 +2085,134 @@ std::unordered_map<String, ASTPtr> convertArgumentsToOptionsMap(const ASTPtr & a
     return options;
 }
 
+/// Multi-column indexes cannot derive ids from declaration order: the complete mapping is a
+/// user-visible persistence contract and must therefore be supplied explicitly.
+void validateFieldIdsPresence(const Names & column_names, const std::optional<String> & field_ids_json)
+{
+    if (column_names.size() > 1 && !field_ids_json)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "A multi-column text index requires an explicit '{}' argument", ARGUMENT_FIELD_IDS);
+}
+
+/// The first field-tagged stage deliberately has no transform-template semantics. Keep legacy
+/// untagged single-column transforms unchanged and reject tagged definitions explicitly instead
+/// of accidentally binding an expression to only the first indexed field.
+void validateFieldTaggedTransforms(
+    const std::optional<String> & field_ids_json, const ASTPtr & preprocessor_ast, const ASTPtr & postprocessor_ast)
+{
+    if (!field_ids_json)
+        return;
+
+    if (preprocessor_ast)
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Text index argument '{}' is not supported together with '{}'",
+            ARGUMENT_PREPROCESSOR,
+            ARGUMENT_FIELD_IDS);
+
+    if (postprocessor_ast)
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Text index argument '{}' is not supported together with '{}'",
+            ARGUMENT_POSTPROCESSOR,
+            ARGUMENT_FIELD_IDS);
+}
+
+/// Build one snapshot of the user-maintained, append-only field ownership table.
+///
+/// Every active index column must be present, while extra names are permitted as inactive
+/// tombstones. Id uniqueness is checked across the complete JSON object so a newly activated
+/// field cannot reinterpret postings written for a removed historical field. This validates one
+/// metadata snapshot only; it does not establish that every existing part covers every active field.
+TextIndexFieldIdsMap buildTextIndexFieldIds(const Names & column_names, const std::optional<String> & field_ids_json)
+{
+    if (!field_ids_json)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument '{}' is required", ARGUMENT_FIELD_IDS);
+
+    Poco::JSON::Object::Ptr object;
+    try
+    {
+        Poco::JSON::Parser parser;
+        object = parser.parse(*field_ids_json).extract<Poco::JSON::Object::Ptr>();
+    }
+    catch (const Poco::Exception & e)
+    {
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Text index argument '{}' must be a JSON object mapping field names to ids: {}",
+            ARGUMENT_FIELD_IDS,
+            e.displayText());
+    }
+
+    if (!object)
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS, "Text index argument '{}' must be a JSON object mapping field names to ids", ARGUMENT_FIELD_IDS);
+
+    TextIndexFieldIdsMap field_ids;
+    for (const auto & field_name : object->getNames())
+    {
+        const auto id_value = object->get(field_name);
+        /// `Poco::Dynamic::Var` converts strings and floating-point values to integers on request.
+        /// Field ids are a persistent byte-level contract, so accept JSON integers only. Poco also
+        /// reports booleans as integers and therefore needs the explicit second check.
+        if (!id_value.isInteger() || id_value.isBoolean())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Text index argument '{}' must assign an integer id to field '{}'",
+                ARGUMENT_FIELD_IDS,
+                field_name);
+
+        Int64 id = 0;
+        try
+        {
+            id = object->getValue<Int64>(field_name);
+        }
+        catch (const Poco::Exception & e)
+        {
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Text index argument '{}' has an invalid id for field '{}': {}",
+                ARGUMENT_FIELD_IDS,
+                field_name,
+                e.displayText());
+        }
+
+        if (id <= 0 || id > std::numeric_limits<UInt16>::max())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Text index argument '{}' has out-of-range id {} for field '{}' (expected 1..65535)",
+                ARGUMENT_FIELD_IDS,
+                id,
+                field_name);
+
+        field_ids.emplace(field_name, static_cast<UInt16>(id));
+    }
+
+    std::unordered_map<UInt16, std::string_view> fields_by_id;
+    for (const auto & [field_name, field_id] : field_ids)
+    {
+        const auto [owner, inserted] = fields_by_id.emplace(field_id, field_name);
+        if (!inserted)
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Text index argument '{}' assigns field id {} to both '{}' and '{}'",
+                ARGUMENT_FIELD_IDS,
+                field_id,
+                owner->second,
+                field_name);
+    }
+
+    for (const auto & column_name : column_names)
+    {
+        if (!field_ids.contains(column_name))
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Text index argument '{}' is missing an id for indexed field '{}'",
+                ARGUMENT_FIELD_IDS,
+                column_name);
+    }
+
+    return field_ids;
+}
 }
 
 MergeTreeIndexPtr textIndexCreator(StorageMetadataPtr metadata_snapshot, const IndexDescription & index, const MergeTreeSettings & settings)
@@ -1991,13 +2237,25 @@ MergeTreeIndexPtr textIndexCreator(StorageMetadataPtr metadata_snapshot, const I
 
     UInt64 positions = extractFieldOption<UInt64>(options, ARGUMENT_POSITIONS).value_or(DEFAULT_POSITIONS);
 
+    auto field_ids_json = extractFieldOption<String>(options, ARGUMENT_FIELD_IDS);
+    validateFieldIdsPresence(index.column_names, field_ids_json);
+    validateFieldTaggedTransforms(field_ids_json, preprocessor_ast, postprocessor_ast);
+
+    /// Supplying `field_ids` selects the tagged physical layout even for one active column. This
+    /// avoids rewriting the meaning of existing dictionary keys if the user later activates more
+    /// fields while preserving the same ownership table.
+    TextIndexFieldIdsMapPtr field_ids;
+    if (field_ids_json)
+        field_ids = std::make_shared<const TextIndexFieldIdsMap>(buildTextIndexFieldIds(index.column_names, field_ids_json));
+
     MergeTreeIndexTextParams index_params{
         dictionary_block_size,
         dictionary_block_frontcoding_compression,
         posting_list_block_size,
         positions,
         std::move(preprocessor_ast),
-        std::move(postprocessor_ast)};
+        std::move(postprocessor_ast),
+        std::move(field_ids)};
 
     String posting_list_codec_name = extractFieldOption<String>(options, ARGUMENT_POSTING_LIST_CODEC)
         .value_or(settings[MergeTreeSetting::text_index_posting_list_codec].toString());
@@ -2049,23 +2307,45 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/, const M
         .value_or(settings[MergeTreeSetting::text_index_posting_list_codec].toString());
     PostingListCodecFactory::createPostingListCodec(posting_list_codec_name, index.name);
 
+    auto field_ids_json = extractFieldOption<String>(options, ARGUMENT_FIELD_IDS);
+
     if (!options.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected text index arguments: {}", fmt::join(std::views::keys(options), ", "));
 
-    /// Check that the index is created on a single column
-    if (index.column_names.size() != 1 || index.data_types.size() != 1)
-        throw Exception(ErrorCodes::INCORRECT_NUMBER_OF_COLUMNS, "Text index must be created on a single column");
+    if (index.column_names.empty() || index.column_names.size() != index.data_types.size())
+        throw Exception(ErrorCodes::INCORRECT_NUMBER_OF_COLUMNS, "Text index must be created on at least one column");
 
-    DataTypePtr index_data_type = index.data_types[0];
-    WhichDataType which_data_type(MergeTreeIndexText::getNestedDataType(index_data_type));
+    validateFieldIdsPresence(index.column_names, field_ids_json);
+    validateFieldTaggedTransforms(field_ids_json, preprocessor_ast, postprocessor_ast);
 
-    if (!which_data_type.isString() && !which_data_type.isFixedString())
+    /// Tagged indexes bind ids directly to source-column names. Function expressions such as
+    /// `mapKeys(m)` and `JSONAllValues(j)` may cause one predicate to depend on multiple indexed
+    /// expressions and therefore remain available only to legacy untagged single-column indexes.
+    if (field_ids_json)
     {
-        throw Exception(
-            ErrorCodes::BAD_ARGUMENTS,
-            "Text index must be created on columns of type with base type of String or FixedString, got: {}",
-            index_data_type->getName());
+        chassert(index.expression_list_ast);
+        for (const auto & expression : index.expression_list_ast->children)
+        {
+            if (!expression->as<ASTIdentifier>())
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "A field-id-tagged text index supports only plain column expressions; got '{}'",
+                    expression->formatForErrorMessage());
+        }
     }
+
+    for (const auto & index_data_type : index.data_types)
+    {
+        WhichDataType which_data_type(MergeTreeIndexText::getNestedDataType(index_data_type));
+        if (!which_data_type.isString() && !which_data_type.isFixedString())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Text index must be created on columns of type with base type of String or FixedString, got: {}",
+                index_data_type->getName());
+    }
+
+    if (field_ids_json)
+        buildTextIndexFieldIds(index.column_names, field_ids_json);
 
     /// Create the preprocessor for validation.
     /// For very strict validation of the expression we fully parse it here.

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -101,12 +101,18 @@ struct MergeTreeIndexTextParams
 
 /// Field-tagged dictionary keys use one canonical physical layout:
 ///
-///   [ logical token bytes ][ field id: 2-byte little-endian `UInt16` ]
+///   [ escaped logical token bytes ][ 0x00 ][ escape flag ][ field id: big-endian `UInt16` ]
 ///
-/// The fixed-width suffix makes decoding unambiguous for arbitrary token bytes, while existing
-/// posting and position payload formats remain unchanged. Dictionary ordering is the byte order of
-/// the complete encoded key; it is not a logical tuple ordering for prefix-related token values.
+/// A logical NUL is escaped as 0x00 0xFF. The escape flag is 0x00 for ordinary tokens and 0x01
+/// when the token contains an escaped NUL. Both terminators sort before the encoded continuation
+/// of a longer token, while the big-endian field ID preserves numeric order. Consequently, sorting
+/// physical keys is equivalent to sorting `(logical token, field id)`, so all field variants of one
+/// token are contiguous even when another token has it as a prefix. Existing posting and position
+/// payload formats remain unchanged.
 inline constexpr size_t TEXT_INDEX_FIELD_ID_SIZE = 2;
+inline constexpr size_t TEXT_INDEX_TOKEN_TERMINATOR_SIZE = 2;
+inline constexpr UInt8 TEXT_INDEX_TOKEN_HAS_ESCAPES = 0x01;
+inline constexpr UInt8 TEXT_INDEX_TOKEN_ESCAPED_NUL = 0xFF;
 static_assert(sizeof(UInt16) == TEXT_INDEX_FIELD_ID_SIZE);
 
 struct DecodedTextIndexFieldToken
@@ -115,12 +121,47 @@ struct DecodedTextIndexFieldToken
     UInt16 field_id;
 };
 
-/// Append the canonical suffix in place. The query path uses this helper so it cannot diverge
-/// from the build-side encoding.
-inline void appendTextIndexFieldId(String & token, UInt16 field_id)
+/// Encode the order-preserving token component in place. Keeping this component separate from the
+/// field suffix allows a later query stage to construct one contiguous range for all field variants
+/// of a token without duplicating the escaping rules.
+inline void encodeTextIndexTokenComponent(String & token)
 {
-    token.push_back(static_cast<char>(field_id & 0xFF));
-    token.push_back(static_cast<char>((field_id >> 8) & 0xFF));
+    const size_t first_nul = token.find('\0');
+    const bool has_escaped_nul = first_nul != String::npos;
+    if (has_escaped_nul)
+    {
+        String escaped;
+        escaped.reserve(token.size() + 1 + TEXT_INDEX_TOKEN_TERMINATOR_SIZE + TEXT_INDEX_FIELD_ID_SIZE);
+
+        size_t chunk_begin = 0;
+        for (size_t nul = first_nul; nul != String::npos; nul = token.find('\0', chunk_begin))
+        {
+            escaped.append(token, chunk_begin, nul - chunk_begin);
+            escaped.push_back('\0');
+            escaped.push_back(static_cast<char>(TEXT_INDEX_TOKEN_ESCAPED_NUL));
+            chunk_begin = nul + 1;
+        }
+        escaped.append(token, chunk_begin);
+        token = std::move(escaped);
+    }
+
+    token.reserve(token.size() + TEXT_INDEX_TOKEN_TERMINATOR_SIZE + TEXT_INDEX_FIELD_ID_SIZE);
+    token.push_back('\0');
+    token.push_back(static_cast<char>(has_escaped_nul ? TEXT_INDEX_TOKEN_HAS_ESCAPES : 0x00));
+}
+
+inline void appendTextIndexFieldId(String & encoded_token_component, UInt16 field_id)
+{
+    encoded_token_component.push_back(static_cast<char>((field_id >> 8) & 0xFF));
+    encoded_token_component.push_back(static_cast<char>(field_id & 0xFF));
+}
+
+/// Encode an owned logical token in place. The query path uses this helper so it cannot diverge
+/// from the build-side encoding.
+inline void encodeTextIndexFieldToken(String & token, UInt16 field_id)
+{
+    encodeTextIndexTokenComponent(token);
+    appendTextIndexFieldId(token, field_id);
 }
 
 /// Encode a non-owning tokenizer result into caller-owned storage for dictionary insertion.
@@ -130,23 +171,61 @@ inline void encodeTextIndexFieldToken(std::string_view token, UInt16 field_id, S
         encoded.clear();
     else
         encoded.assign(token.data(), token.size());
-    appendTextIndexFieldId(encoded, field_id);
+    encodeTextIndexFieldToken(encoded, field_id);
 }
 
-/// Decode without copying the logical token. `std::nullopt` means the key is too short to contain
-/// the fixed-width suffix, allowing callers with tagged index context to reject malformed keys.
-inline std::optional<DecodedTextIndexFieldToken> decodeTextIndexFieldToken(std::string_view encoded)
+/// Decode the escaped logical token and fixed-width field ID. For the common case without escaped
+/// NUL bytes, the returned token points directly into `encoded`. Otherwise it points into the
+/// caller-owned `token_scratch`, which can be reused after the current view is consumed.
+/// `std::nullopt` means the key is not a canonical field-tagged key.
+inline std::optional<DecodedTextIndexFieldToken> decodeTextIndexFieldToken(std::string_view encoded, String & token_scratch)
 {
-    if (encoded.size() < TEXT_INDEX_FIELD_ID_SIZE)
+    constexpr size_t minimum_size = TEXT_INDEX_TOKEN_TERMINATOR_SIZE + TEXT_INDEX_FIELD_ID_SIZE;
+    if (encoded.size() < minimum_size)
         return std::nullopt;
 
-    const size_t token_size = encoded.size() - TEXT_INDEX_FIELD_ID_SIZE;
-    const auto low = static_cast<UInt16>(static_cast<unsigned char>(encoded[token_size]));
-    const auto high = static_cast<UInt16>(static_cast<unsigned char>(encoded[token_size + 1]));
-    return DecodedTextIndexFieldToken{
-        .token = encoded.substr(0, token_size),
-        .field_id = static_cast<UInt16>(low | (high << 8)),
-    };
+    const size_t field_id_offset = encoded.size() - TEXT_INDEX_FIELD_ID_SIZE;
+    const size_t token_end = field_id_offset - TEXT_INDEX_TOKEN_TERMINATOR_SIZE;
+    if (encoded[token_end] != '\0')
+        return std::nullopt;
+
+    const std::string_view encoded_token = encoded.substr(0, token_end);
+    const auto high = static_cast<UInt16>(static_cast<unsigned char>(encoded[field_id_offset]));
+    const auto low = static_cast<UInt16>(static_cast<unsigned char>(encoded[field_id_offset + 1]));
+    const UInt16 field_id = static_cast<UInt16>((high << 8) | low);
+
+    const auto escape_flag = static_cast<UInt8>(encoded[token_end + 1]);
+    if (escape_flag == 0)
+    {
+        if (encoded_token.find('\0') != std::string_view::npos)
+            return std::nullopt;
+        return DecodedTextIndexFieldToken{.token = encoded_token, .field_id = field_id};
+    }
+    if (escape_flag != TEXT_INDEX_TOKEN_HAS_ESCAPES)
+        return std::nullopt;
+
+    token_scratch.clear();
+    token_scratch.reserve(token_end);
+    bool decoded_nul = false;
+    for (size_t pos = 0; pos < token_end; ++pos)
+    {
+        const char byte = encoded[pos];
+        if (byte != '\0')
+        {
+            token_scratch.push_back(byte);
+            continue;
+        }
+
+        if (++pos >= token_end || static_cast<UInt8>(encoded[pos]) != TEXT_INDEX_TOKEN_ESCAPED_NUL)
+            return std::nullopt;
+        token_scratch.push_back('\0');
+        decoded_nul = true;
+    }
+
+    if (!decoded_nul)
+        return std::nullopt;
+
+    return DecodedTextIndexFieldToken{.token = token_scratch, .field_id = field_id};
 }
 
 using PostingList = roaring::Roaring;

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -18,6 +18,7 @@
 #include <absl/container/flat_hash_set.h>
 #include <base/types.h>
 
+#include <optional>
 #include <variant>
 #include <vector>
 
@@ -85,7 +86,68 @@ struct MergeTreeIndexTextParams
     size_t positions = 0;
     ASTPtr preprocessor;
     ASTPtr postprocessor;
+    /// Complete field ownership table supplied by the `field_ids` index argument.
+    /// Every active index column has an entry; additional entries are retained tombstones whose
+    /// ids cannot be reused. The caller owns the append-only stability contract across metadata
+    /// revisions. A null pointer is the legacy untagged single-column dictionary layout; a
+    /// non-null pointer selects the tagged layout even when only one column is currently active.
+    /// The initial tagged stage rejects `preprocessor` and `postprocessor`; those remain supported
+    /// without behavior changes on legacy untagged single-column indexes. Parts do not persist
+    /// per-field coverage in this stage, so changing the active fields or their ids is an index
+    /// replacement: complete the normal `DROP INDEX` / `ADD INDEX` and materialization lifecycle
+    /// before relying on predicates for the changed fields.
+    TextIndexFieldIdsMapPtr field_ids;
 };
+
+/// Field-tagged dictionary keys use one canonical physical layout:
+///
+///   [ logical token bytes ][ field id: 2-byte little-endian `UInt16` ]
+///
+/// The fixed-width suffix makes decoding unambiguous for arbitrary token bytes, while existing
+/// posting and position payload formats remain unchanged. Dictionary ordering is the byte order of
+/// the complete encoded key; it is not a logical tuple ordering for prefix-related token values.
+inline constexpr size_t TEXT_INDEX_FIELD_ID_SIZE = 2;
+static_assert(sizeof(UInt16) == TEXT_INDEX_FIELD_ID_SIZE);
+
+struct DecodedTextIndexFieldToken
+{
+    std::string_view token;
+    UInt16 field_id;
+};
+
+/// Append the canonical suffix in place. The query path uses this helper so it cannot diverge
+/// from the build-side encoding.
+inline void appendTextIndexFieldId(String & token, UInt16 field_id)
+{
+    token.push_back(static_cast<char>(field_id & 0xFF));
+    token.push_back(static_cast<char>((field_id >> 8) & 0xFF));
+}
+
+/// Encode a non-owning tokenizer result into caller-owned storage for dictionary insertion.
+inline void encodeTextIndexFieldToken(std::string_view token, UInt16 field_id, String & encoded)
+{
+    if (token.empty())
+        encoded.clear();
+    else
+        encoded.assign(token.data(), token.size());
+    appendTextIndexFieldId(encoded, field_id);
+}
+
+/// Decode without copying the logical token. `std::nullopt` means the key is too short to contain
+/// the fixed-width suffix, allowing callers with tagged index context to reject malformed keys.
+inline std::optional<DecodedTextIndexFieldToken> decodeTextIndexFieldToken(std::string_view encoded)
+{
+    if (encoded.size() < TEXT_INDEX_FIELD_ID_SIZE)
+        return std::nullopt;
+
+    const size_t token_size = encoded.size() - TEXT_INDEX_FIELD_ID_SIZE;
+    const auto low = static_cast<UInt16>(static_cast<unsigned char>(encoded[token_size]));
+    const auto high = static_cast<UInt16>(static_cast<unsigned char>(encoded[token_size + 1]));
+    return DecodedTextIndexFieldToken{
+        .token = encoded.substr(0, token_size),
+        .field_id = static_cast<UInt16>(low | (high << 8)),
+    };
+}
 
 using PostingList = roaring::Roaring;
 using PostingListPtr = std::shared_ptr<PostingList>;
@@ -290,12 +352,16 @@ struct TextIndexHeader
         Initial = 0,
         WithCodec = 1,
         WithPositions = 2,
+        WithFieldIds = 3,
     };
 
     MergeTreeIndexVersion version = static_cast<MergeTreeIndexVersion>(Version::Initial);
     IPostingListCodec::Type codec_type = IPostingListCodec::Type::None;
-    /// Persisted for version >= WithPositions.
+    /// Persisted for version >= `WithPositions`.
     bool has_positions = false;
+    /// Persisted for version >= `WithFieldIds`; this distinguishes legacy token keys from
+    /// field-tagged keys independently of the current metadata definition.
+    bool has_field_ids = false;
     DictionarySparseIndex sparse_index;
 };
 
@@ -315,7 +381,13 @@ struct TextIndexSerialization
 
     static void serializeTokens(const ColumnString & tokens, WriteBuffer & ostr, TokensFormat format);
     static void serializeTokenInfo(WriteBuffer & ostr, const TokenPostingsInfo & token_info);
-    static void serializeHeader(const DictionarySparseIndex & sparse_index, IPostingListCodec::Type posting_list_codec_type, MergeTreeIndexVersion version, bool has_positions, WriteBuffer & ostr);
+    static void serializeHeader(
+        const DictionarySparseIndex & sparse_index,
+        IPostingListCodec::Type posting_list_codec_type,
+        MergeTreeIndexVersion version,
+        bool has_positions,
+        bool has_field_ids,
+        WriteBuffer & ostr);
 
     static TextIndexHeader deserializeHeader(ReadBuffer & istr);
     /// Reads only the version and posting list codec from the start of the header, without the
@@ -455,10 +527,11 @@ struct MergeTreeIndexTextGranuleBuilder
         TokenizerPtr tokenizer_,
         const IPostingListCodec * posting_list_codec_);
 
-    /// Extracts tokens from the document and adds them to the granule.
-    void addDocument(std::string_view document);
-    // Adds a document to the granule. The document is inserted directly as a single token.
-    void addToken(std::string_view token, UInt32 token_position);
+    /// Extracts tokens from the document and adds them to the granule. `field_id` is set exactly
+    /// for the tagged physical layout; `std::nullopt` is reserved for legacy untagged indexes.
+    void addDocument(std::string_view document, std::optional<UInt16> field_id = std::nullopt);
+    /// Adds one already-tokenized value, preserving the supplied position for phrase search.
+    void addToken(std::string_view token, UInt32 token_position, std::optional<UInt16> field_id = std::nullopt);
 
     void incrementCurrentRow();
     void setCurrentRow(size_t row) { current_row = row; }
@@ -480,6 +553,9 @@ struct MergeTreeIndexTextGranuleBuilder
     std::list<PostingList> posting_lists;
     /// Keys may be serialized into arena (see ArenaKeyHolder).
     std::unique_ptr<Arena> arena;
+    /// Reused scratch storage for one composite key. `ArenaKeyHolder` persists the key bytes into
+    /// `arena` during insertion, so dictionary entries never retain a view into this buffer.
+    String field_token_scratch;
     /// Position data for phrase query support.
     /// Only allocated when params.positions is true.
     std::unique_ptr<TokenToPositionListMap> position_map;
@@ -497,7 +573,7 @@ using MergeTreeIndexTextPostprocessorPtr = std::shared_ptr<MergeTreeIndexTextPos
 struct MergeTreeIndexAggregatorText final : IMergeTreeIndexAggregator
 {
     MergeTreeIndexAggregatorText(
-        String index_column_name_,
+        Names index_column_names_,
         MergeTreeIndexTextParams params_,
         TokenizerPtr tokenizer_,
         const IPostingListCodec * posting_list_codec_,
@@ -513,11 +589,13 @@ struct MergeTreeIndexAggregatorText final : IMergeTreeIndexAggregator
     UInt64 getNumProcessedTokens() const { return granule_builder.num_processed_tokens; }
 
 private:
-    /// Iterates over a ColumnArray(String) slice and calls addDocument<tokenize> on each element.
+    /// Legacy untagged single-column path.
     template <bool tokenize>
     void addDocumentsFromArray(ColumnPtr column, size_t start_row, size_t rows_read);
 
-    String index_column_name;
+    /// One or more active index columns in declaration order. `params.field_ids != nullptr` is the
+    /// sole runtime discriminator for the physical key layout, including tagged single-column indexes.
+    Names index_column_names;
     MergeTreeIndexTextParams params;
     /// A private clone of the index tokenizer when it is stateful (e.g. the Japanese or sparse-grams
     /// tokenizers), so concurrent aggregators do not share mutable parsing state; null otherwise.

--- a/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.cpp
@@ -38,13 +38,18 @@ constexpr char preprocessor_column_name[] = "__text_index_column";
 
 ASTPtr convertASTForIndexColumn(const IndexDescription & index, const ASTPtr & expression_ast, bool replace_index_column)
 {
+    /// A null preprocessor expression means "no preprocessing" and needs no expression binding,
+    /// so return early before the single-column assertions. The constructor still receives the
+    /// real, non-empty `IndexDescription`, but a field-id-tagged index can now construct a no-op
+    /// `MergeTreeIndexTextPreprocessor` instead of leaving a null pointer that condition and
+    /// query-rewrite paths may dereference.
+    if (expression_ast == nullptr)
+        return nullptr;
+
     chassert(index.column_names.size() == 1);
     chassert(index.data_types.size() == 1);
     chassert(index.expression_list_ast != nullptr);
     chassert(index.expression_list_ast->children.size() == 1);
-
-    if (expression_ast == nullptr)
-        return nullptr;
 
     /// Transform a preprocessor AST like `lower(val)` into `arrayMap(x -> lower(x), val)`.
     /// This is done at the AST level so that ActionsVisitor can build the DAG naturally.
@@ -77,11 +82,13 @@ ASTPtr convertASTForIndexColumn(const IndexDescription & index, const ASTPtr & e
 
 ASTPtr convertASTForConstant(const IndexDescription & index, const ASTPtr & expression_ast)
 {
-    chassert(index.column_names.size() == 1);
-    chassert(index.data_types.size() == 1);
-
+    /// See `convertASTForIndexColumn`: the no-op case is column-agnostic and must return before
+    /// validating the legacy single-column expression contract.
     if (expression_ast == nullptr)
         return nullptr;
+
+    chassert(index.column_names.size() == 1);
+    chassert(index.data_types.size() == 1);
 
     ASTPtr body = expression_ast->clone();
     replaceExpressionToIdentifier(body, index.column_names.front(), preprocessor_column_name);

--- a/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.h
@@ -12,6 +12,11 @@ struct IndexDescription;
 class MergeTreeIndexTextPreprocessor
 {
 public:
+    /// A null expression constructs an empty-actions object. This object must still exist because
+    /// condition and query-rewrite paths dereference it unconditionally. In that no-op case the
+    /// `IndexDescription` may contain multiple columns, but it must be the real, fully initialized
+    /// description with at least one column and a non-null index expression; non-empty expressions
+    /// retain the legacy single-column contract.
     MergeTreeIndexTextPreprocessor(ASTPtr expression_ast, const IndexDescription & index_description);
 
     /// Processes n_rows rows of input column, starting at start_row.

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -702,6 +702,10 @@ Maximum estimated memory retained by a text index builder before flushing a temp
 Default posting list codec for text indexes.
 Can be overridden by explicit `posting_list_codec` index argument.
 )", 0) \
+    DECLARE(Bool, allow_experimental_multi_column_text_index, false, R"(
+Allow creating text indexes with the experimental `field_ids` argument,
+which enables the field-tagged layout used by multi-column text indexes.
+)", EXPERIMENTAL) \
     DECLARE(Bool, allow_experimental_text_index_phrase_search, false, R"(
 Allow creating text indexes with the experimental `support_phrase_search` argument
 which stores token positions to support exact phrase matching.

--- a/src/Storages/MergeTree/TextIndexUtils.cpp
+++ b/src/Storages/MergeTree/TextIndexUtils.cpp
@@ -33,6 +33,7 @@ namespace DB
 
 namespace ErrorCodes
 {
+    extern const int CORRUPTED_DATA;
     extern const int LOGICAL_ERROR;
     extern const int FILE_DOESNT_EXIST;
     extern const int SUPPORT_IS_DISABLED;
@@ -237,19 +238,33 @@ void BuildTextIndexTransform::writeTemporarySegment(size_t i)
 
 static PostingsSerialization createPostingsSerialization(const IMergeTreeIndex & index)
 {
-    const auto * codec = typeid_cast<const MergeTreeIndexText &>(index).getPostingListCodec();
+    const auto & text_index = typeid_cast<const MergeTreeIndexText &>(index);
+    const auto * codec = text_index.getPostingListCodec();
     auto codec_type = codec ? codec->getType() : IPostingListCodec::Type::None;
     auto codec_copy = PostingListCodecFactory::createPostingListCodec(codec_type);
+    const auto params = text_index.getParams();
+    const auto version = static_cast<MergeTreeIndexVersion>(
+        params.field_ids ? TextIndexHeader::Version::WithFieldIds
+                         : (params.positions ? TextIndexHeader::Version::WithPositions : TextIndexHeader::Version::WithCodec));
 
     /// The merged part is written in the current on-disk format.
-    return PostingsSerialization(std::move(codec_copy), static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::WithCodec));
+    return PostingsSerialization(std::move(codec_copy), version);
 }
 
-static PostingsSerialization createSourcePostingsSerialization(MergeTreeIndexReaderStream & header_stream)
+static PostingsSerialization createSourcePostingsSerialization(MergeTreeIndexReaderStream & header_stream, bool expected_field_ids)
 {
     header_stream.seekToStart();
     /// Only the version and codec are needed here, so skip deserializing the sparse index.
     auto header = TextIndexSerialization::deserializeHeaderPrefix(*header_stream.getDataBuffer());
+    /// Equal-key k-way merge is valid only when every input uses the same key codec. The complete
+    /// name-to-id mapping remains the user's metadata contract; the part header independently
+    /// prevents legacy raw keys and tagged composite keys from being merged as one ordering.
+    if (header.has_field_ids != expected_field_ids)
+        throw Exception(
+            ErrorCodes::CORRUPTED_DATA,
+            "Cannot merge text indexes with different key layouts: source has field ids {}, target has field ids {}",
+            header.has_field_ids,
+            expected_field_ids);
     return PostingsSerialization(PostingListCodecFactory::createPostingListCodec(header.codec_type), header.version);
 }
 
@@ -312,7 +327,7 @@ MergeTextIndexesTask::MergeTextIndexesTask(
     for (size_t i = 0; i < segments.size(); ++i)
     {
         auto * stream = input_streams[i].at(MergeTreeIndexSubstream::Type::Regular);
-        source_postings_serializations.emplace_back(createSourcePostingsSerialization(*stream));
+        source_postings_serializations.emplace_back(createSourcePostingsSerialization(*stream, params.field_ids != nullptr));
     }
 }
 
@@ -594,9 +609,19 @@ void MergeTextIndexesTask::finalize()
     auto * index_stream = output_streams.at(MergeTreeIndexSubstream::Type::Regular);
     DictionarySparseIndex sparse_index(std::move(sparse_index_tokens), std::move(sparse_index_offsets));
 
+    /// Preserve the tagged layout even for a single active field. Composite keys themselves merge
+    /// unchanged; posting and position payload formats do not depend on the field id.
+    const bool has_field_ids = params.field_ids != nullptr;
     auto serialization_version = static_cast<MergeTreeIndexVersion>(
-        params.positions ? TextIndexHeader::Version::WithPositions : TextIndexHeader::Version::WithCodec);
-    TextIndexSerialization::serializeHeader(sparse_index, postings_serialization.getPostingListCodec()->getType(), serialization_version, params.positions, index_stream->compressed_hashing);
+        has_field_ids ? TextIndexHeader::Version::WithFieldIds
+                      : (params.positions ? TextIndexHeader::Version::WithPositions : TextIndexHeader::Version::WithCodec));
+    TextIndexSerialization::serializeHeader(
+        sparse_index,
+        postings_serialization.getPostingListCodec()->getType(),
+        serialization_version,
+        params.positions,
+        has_field_ids,
+        index_stream->compressed_hashing);
 
     for (auto & stream : output_streams_holders)
         stream->finalize();

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -3644,8 +3644,10 @@ TEST(PostingListCursorTest, TextIndexFieldTokenCodecRoundTrip)
 {
     const std::vector<std::pair<String, UInt16>> cases = {
         {String{}, 1},
-        {String{"a"}, 0x1234},
+        {String{"a"}, 255},
+        {String{"aa"}, 256},
         {String{"a\0b", 3}, std::numeric_limits<UInt16>::max()},
+        {String{"\0a\0", 3}, 0x1234},
     };
 
     for (const auto & [token, field_id] : cases)
@@ -3653,21 +3655,114 @@ TEST(PostingListCursorTest, TextIndexFieldTokenCodecRoundTrip)
         String encoded;
         encodeTextIndexFieldToken(token, field_id, encoded);
 
-        ASSERT_EQ(encoded.size(), token.size() + TEXT_INDEX_FIELD_ID_SIZE);
-        EXPECT_EQ(static_cast<unsigned char>(encoded[encoded.size() - 2]), field_id & 0xFF);
-        EXPECT_EQ(static_cast<unsigned char>(encoded[encoded.size() - 1]), field_id >> 8);
+        const size_t escaped_nuls = std::ranges::count(token, '\0');
+        ASSERT_EQ(encoded.size(), token.size() + escaped_nuls + TEXT_INDEX_TOKEN_TERMINATOR_SIZE + TEXT_INDEX_FIELD_ID_SIZE);
+        EXPECT_EQ(encoded[encoded.size() - 4], '\0');
+        const UInt8 expected_escape_flag = escaped_nuls == 0 ? UInt8{0} : TEXT_INDEX_TOKEN_HAS_ESCAPES;
+        EXPECT_EQ(static_cast<UInt8>(encoded[encoded.size() - 3]), expected_escape_flag);
+        EXPECT_EQ(static_cast<unsigned char>(encoded[encoded.size() - 2]), field_id >> 8);
+        EXPECT_EQ(static_cast<unsigned char>(encoded[encoded.size() - 1]), field_id & 0xFF);
 
-        const auto decoded = decodeTextIndexFieldToken(encoded);
+        String token_scratch;
+        const auto decoded = decodeTextIndexFieldToken(encoded, token_scratch);
         ASSERT_TRUE(decoded);
         EXPECT_EQ(decoded->token, std::string_view(token));
         EXPECT_EQ(decoded->field_id, field_id);
+        if (escaped_nuls == 0)
+            EXPECT_EQ(decoded->token.data(), encoded.data());
+        else
+            EXPECT_EQ(decoded->token.data(), token_scratch.data());
     }
 
-    EXPECT_FALSE(decodeTextIndexFieldToken(String{}));
-    EXPECT_FALSE(decodeTextIndexFieldToken(String{"x"}));
+    String encoded_with_nul;
+    encodeTextIndexFieldToken(String{"a\0b", 3}, 0x1234, encoded_with_nul);
+    String expected_bytes;
+    expected_bytes.push_back('a');
+    expected_bytes.push_back('\0');
+    expected_bytes.push_back(static_cast<char>(TEXT_INDEX_TOKEN_ESCAPED_NUL));
+    expected_bytes.push_back('b');
+    expected_bytes.push_back('\0');
+    expected_bytes.push_back(static_cast<char>(TEXT_INDEX_TOKEN_HAS_ESCAPES));
+    expected_bytes.push_back(static_cast<char>(0x12));
+    expected_bytes.push_back(static_cast<char>(0x34));
+    EXPECT_EQ(encoded_with_nul, expected_bytes);
+
+    String token_scratch;
+    EXPECT_FALSE(decodeTextIndexFieldToken(String{}, token_scratch));
+    EXPECT_FALSE(decodeTextIndexFieldToken(String{"x"}, token_scratch));
+
+    String missing_terminator = "valid";
+    encodeTextIndexFieldToken(missing_terminator, 1);
+    missing_terminator[missing_terminator.size() - 4] = 'x';
+    EXPECT_FALSE(decodeTextIndexFieldToken(missing_terminator, token_scratch));
+
+    String invalid_escape_flag = "valid";
+    encodeTextIndexFieldToken(invalid_escape_flag, 1);
+    invalid_escape_flag[invalid_escape_flag.size() - 3] = static_cast<char>(0x02);
+    EXPECT_FALSE(decodeTextIndexFieldToken(invalid_escape_flag, token_scratch));
+
+    String unexpected_encoded_nul{"a\0b", 3};
+    encodeTextIndexFieldToken(unexpected_encoded_nul, 1);
+    unexpected_encoded_nul[unexpected_encoded_nul.size() - 3] = 0;
+    EXPECT_FALSE(decodeTextIndexFieldToken(unexpected_encoded_nul, token_scratch));
+
+    String missing_escape = "valid";
+    encodeTextIndexFieldToken(missing_escape, 1);
+    missing_escape[missing_escape.size() - 3] = static_cast<char>(TEXT_INDEX_TOKEN_HAS_ESCAPES);
+    EXPECT_FALSE(decodeTextIndexFieldToken(missing_escape, token_scratch));
+
+    String invalid_escape{"a\0b", 3};
+    encodeTextIndexFieldToken(invalid_escape, 1);
+    invalid_escape[2] = static_cast<char>(0xFE);
+    EXPECT_FALSE(decodeTextIndexFieldToken(invalid_escape, token_scratch));
+
+    String incomplete_escape{"\0", 1};
+    encodeTextIndexFieldToken(incomplete_escape, 1);
+    incomplete_escape.erase(1, 1);
+    EXPECT_FALSE(decodeTextIndexFieldToken(incomplete_escape, token_scratch));
 }
 
-TEST(PostingListCursorTest, TextIndexFieldBindingResortsAndRehashes)
+TEST(PostingListCursorTest, TextIndexFieldTokenCodecPreservesTupleOrdering)
+{
+    std::vector<String> tokens = {
+        String{},
+        String{"\0a", 2},
+        String{"a\0", 2},
+        String{"a\0a", 3},
+        String{"aa"},
+    };
+    for (UInt16 byte = 0; byte <= std::numeric_limits<UInt8>::max(); ++byte)
+        tokens.emplace_back(1, static_cast<char>(byte));
+
+    const std::vector<UInt16> field_ids = {1, 255, 256, std::numeric_limits<UInt16>::max()};
+    std::vector<std::pair<String, UInt16>> expected;
+    std::vector<String> encoded_keys;
+    for (const auto & token : tokens)
+    {
+        for (const auto field_id : field_ids)
+        {
+            expected.emplace_back(token, field_id);
+            String encoded;
+            encodeTextIndexFieldToken(token, field_id, encoded);
+            encoded_keys.emplace_back(std::move(encoded));
+        }
+    }
+
+    std::ranges::sort(expected);
+    std::ranges::sort(encoded_keys);
+    ASSERT_EQ(encoded_keys.size(), expected.size());
+
+    for (size_t i = 0; i < encoded_keys.size(); ++i)
+    {
+        String token_scratch;
+        const auto decoded = decodeTextIndexFieldToken(encoded_keys[i], token_scratch);
+        ASSERT_TRUE(decoded);
+        EXPECT_EQ(decoded->token, std::string_view(expected[i].first));
+        EXPECT_EQ(decoded->field_id, expected[i].second);
+    }
+}
+
+TEST(PostingListCursorTest, TextIndexFieldBindingPreservesOrderingAndRehashes)
 {
     TextSearchQuery max_id_query(
         "hasAllTokens", TextSearchMode::All, TextIndexDirectReadMode::None, VectorWithMemoryTracking<String>{"a", "aa"});
@@ -3676,14 +3771,14 @@ TEST(PostingListCursorTest, TextIndexFieldBindingResortsAndRehashes)
     max_id_query.bindToField(std::numeric_limits<UInt16>::max());
     ASSERT_EQ(max_id_query.getTokens().size(), 2);
 
-    /// With an all-ones suffix, `aa || id` sorts before `a || id`, unlike the logical tokens.
-    /// `bindToField` must restore physical dictionary order after appending the suffix.
-    const auto first = decodeTextIndexFieldToken(max_id_query.getTokens()[0]);
-    const auto second = decodeTextIndexFieldToken(max_id_query.getTokens()[1]);
+    String first_token_scratch;
+    String second_token_scratch;
+    const auto first = decodeTextIndexFieldToken(max_id_query.getTokens()[0], first_token_scratch);
+    const auto second = decodeTextIndexFieldToken(max_id_query.getTokens()[1], second_token_scratch);
     ASSERT_TRUE(first);
     ASSERT_TRUE(second);
-    EXPECT_EQ(first->token, "aa");
-    EXPECT_EQ(second->token, "a");
+    EXPECT_EQ(first->token, "a");
+    EXPECT_EQ(second->token, "aa");
     EXPECT_NE(max_id_query.getHash(), untagged_hash);
 
     TextSearchQuery min_id_query(

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -3622,7 +3622,13 @@ TEST(PostingListCursorTest, TextIndexHeaderPersistsCodecType)
     DictionarySparseIndex sparse_index(tokens->getPtr(), offsets->getPtr());
 
     WriteBufferFromOwnString out;
-    TextIndexSerialization::serializeHeader(sparse_index, IPostingListCodec::Type::Bitpacking, static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::WithCodec), /*has_positions=*/ false, out);
+    TextIndexSerialization::serializeHeader(
+        sparse_index,
+        IPostingListCodec::Type::Bitpacking,
+        static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::WithCodec),
+        /*has_positions=*/false,
+        /*has_field_ids=*/false,
+        out);
 
     ReadBufferFromString in(out.str());
     auto sparse_index_data = TextIndexSerialization::deserializeHeader(in);
@@ -3632,6 +3638,89 @@ TEST(PostingListCursorTest, TextIndexHeaderPersistsCodecType)
     EXPECT_EQ(sparse_index_data.sparse_index.size(), 1u);
     EXPECT_EQ(sparse_index_data.sparse_index.getToken(0), "alpha");
     EXPECT_EQ(sparse_index_data.sparse_index.getOffsetInFile(0), 42u);
+}
+
+TEST(PostingListCursorTest, TextIndexFieldTokenCodecRoundTrip)
+{
+    const std::vector<std::pair<String, UInt16>> cases = {
+        {String{}, 1},
+        {String{"a"}, 0x1234},
+        {String{"a\0b", 3}, std::numeric_limits<UInt16>::max()},
+    };
+
+    for (const auto & [token, field_id] : cases)
+    {
+        String encoded;
+        encodeTextIndexFieldToken(token, field_id, encoded);
+
+        ASSERT_EQ(encoded.size(), token.size() + TEXT_INDEX_FIELD_ID_SIZE);
+        EXPECT_EQ(static_cast<unsigned char>(encoded[encoded.size() - 2]), field_id & 0xFF);
+        EXPECT_EQ(static_cast<unsigned char>(encoded[encoded.size() - 1]), field_id >> 8);
+
+        const auto decoded = decodeTextIndexFieldToken(encoded);
+        ASSERT_TRUE(decoded);
+        EXPECT_EQ(decoded->token, std::string_view(token));
+        EXPECT_EQ(decoded->field_id, field_id);
+    }
+
+    EXPECT_FALSE(decodeTextIndexFieldToken(String{}));
+    EXPECT_FALSE(decodeTextIndexFieldToken(String{"x"}));
+}
+
+TEST(PostingListCursorTest, TextIndexFieldBindingResortsAndRehashes)
+{
+    TextSearchQuery max_id_query(
+        "hasAllTokens", TextSearchMode::All, TextIndexDirectReadMode::None, VectorWithMemoryTracking<String>{"a", "aa"});
+    const auto untagged_hash = max_id_query.getHash();
+
+    max_id_query.bindToField(std::numeric_limits<UInt16>::max());
+    ASSERT_EQ(max_id_query.getTokens().size(), 2);
+
+    /// With an all-ones suffix, `aa || id` sorts before `a || id`, unlike the logical tokens.
+    /// `bindToField` must restore physical dictionary order after appending the suffix.
+    const auto first = decodeTextIndexFieldToken(max_id_query.getTokens()[0]);
+    const auto second = decodeTextIndexFieldToken(max_id_query.getTokens()[1]);
+    ASSERT_TRUE(first);
+    ASSERT_TRUE(second);
+    EXPECT_EQ(first->token, "aa");
+    EXPECT_EQ(second->token, "a");
+    EXPECT_NE(max_id_query.getHash(), untagged_hash);
+
+    TextSearchQuery min_id_query(
+        "hasAllTokens", TextSearchMode::All, TextIndexDirectReadMode::None, VectorWithMemoryTracking<String>{"a", "aa"});
+    min_id_query.bindToField(1);
+    EXPECT_NE(max_id_query.getHash(), min_id_query.getHash());
+}
+
+TEST(PostingListCursorTest, TextIndexHeaderPersistsFieldLayout)
+{
+    auto tokens = ColumnString::create();
+    tokens->insert("alpha");
+
+    auto offsets = ColumnUInt64::create();
+    offsets->insertValue(42);
+
+    DictionarySparseIndex sparse_index(tokens->getPtr(), offsets->getPtr());
+
+    for (const bool has_positions : {false, true})
+    {
+        WriteBufferFromOwnString out;
+        TextIndexSerialization::serializeHeader(
+            sparse_index,
+            IPostingListCodec::Type::Bitpacking,
+            static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::WithFieldIds),
+            has_positions,
+            /*has_field_ids=*/true,
+            out);
+
+        ReadBufferFromString in(out.str());
+        const auto header = TextIndexSerialization::deserializeHeader(in);
+
+        EXPECT_EQ(header.version, static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::WithFieldIds));
+        EXPECT_EQ(header.has_positions, has_positions);
+        EXPECT_TRUE(header.has_field_ids);
+        EXPECT_EQ(header.sparse_index.getToken(0), "alpha");
+    }
 }
 
 TEST(PostingListCursorTest, TextIndexHeaderInitialVersionDefaultsToNoneCodec)

--- a/src/TableFunctions/TableFunctionMergeTreeTextIndex.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeTextIndex.cpp
@@ -114,6 +114,12 @@ StoragePtr TableFunctionMergeTreeTextIndex::executeImpl(
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Storage MergeTreeTextIndex expected MergeTree table, got: {}", source_table_ptr->getName());
 
     auto text_index = MergeTreeIndexFactory::instance().get(metadata_snapshot, index_desc, *merge_tree->getSettings());
+    /// Dictionary keys of a field-id-tagged index contain a binary suffix. Until this table
+    /// function exposes the logical token and field id separately, fail explicitly instead of
+    /// returning binary `token` values or applying logical token filters to physical keys.
+    if (typeid_cast<const MergeTreeIndexText &>(*text_index).getParams().field_ids)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Table function '{}' does not support field-id-tagged text indexes yet", getName());
+
     auto columns = getActualTableStructure(context, is_insert_query);
     StorageID storage_id(getDatabaseName(), table_name);
 

--- a/tests/queries/0_stateless/04757_multi_column_text_index_exact.reference
+++ b/tests/queries/0_stateless/04757_multi_column_text_index_exact.reference
@@ -1,0 +1,30 @@
+title_shared	[1,3]
+body_shared	[2,3]
+tags_shared	[1,3]
+nullable_shared	[3]
+fixed_shared	[2]
+field_isolation	[]
+direct_read_actions	2
+index_pruning
+Condition: true
+Parts: 2/2
+Granules: 5/5
+Name: idx
+Description: text GRANULARITY 100000000
+Condition: (mode: All; tokens: ["bodyonly"@42])
+Parts: 1/2
+Granules: 1/5
+cross_field_and	[1]
+same_token_and	[3]
+cross_field_or	[1,2]
+has_any	[1,2,3]
+has_all	[1]
+prepared_in	[2,3]
+phrase	[1]
+pattern_fallback	[1,3]
+direct_read_parity	1
+merged_title_shared	[1,3]
+merged_phrase	[1]
+tagged_single	[1]
+partially_materialized	[1,2]
+materialized	[1,2]

--- a/tests/queries/0_stateless/04757_multi_column_text_index_exact.sql
+++ b/tests/queries/0_stateless/04757_multi_column_text_index_exact.sql
@@ -13,6 +13,18 @@ SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injectio
 DROP TABLE IF EXISTS multi_text_exact;
 DROP TABLE IF EXISTS tagged_single;
 
+-- The field-tagged layout is experimental and must be explicitly enabled when it is created.
+CREATE TABLE multi_text_setting_disabled
+(
+    a String,
+    b String,
+    INDEX idx (a, b) TYPE text(
+        tokenizer = 'splitByNonAlpha',
+        field_ids = '{"a":1,"b":2}')
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError SUPPORT_IS_DISABLED }
+
 CREATE TABLE multi_text_exact
 (
     id UInt64,
@@ -30,6 +42,7 @@ ENGINE = MergeTree
 ORDER BY id
 SETTINGS
     index_granularity = 1,
+    allow_experimental_multi_column_text_index = 1,
     allow_experimental_text_index_phrase_search = 1,
     max_bytes_to_merge_at_max_space_in_pool = 0;
 
@@ -183,7 +196,8 @@ CREATE TABLE tagged_single
         field_ids = '{"value":17,"retired":3}')
 )
 ENGINE = MergeTree
-ORDER BY id;
+ORDER BY id
+SETTINGS allow_experimental_multi_column_text_index = 1;
 
 INSERT INTO tagged_single VALUES (1, 'single tagged'), (2, 'other');
 SELECT 'tagged_single', groupArray(id) FROM
@@ -209,6 +223,10 @@ PARTITION BY id
 ORDER BY id;
 
 INSERT INTO multi_text_materialize VALUES (1, 'old title', 'oldbody');
+ALTER TABLE multi_text_materialize ADD INDEX idx (title, body) TYPE text(
+    tokenizer = 'splitByNonAlpha',
+    field_ids = '{"title":11,"body":12}'); -- { serverError SUPPORT_IS_DISABLED }
+ALTER TABLE multi_text_materialize MODIFY SETTING allow_experimental_multi_column_text_index = 1;
 ALTER TABLE multi_text_materialize ADD INDEX idx (title, body) TYPE text(
     tokenizer = 'splitByNonAlpha',
     field_ids = '{"title":11,"body":12}');
@@ -240,7 +258,8 @@ CREATE TABLE multi_text_missing_map
     INDEX idx (a, b) TYPE text(tokenizer = 'splitByNonAlpha')
 )
 ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+ORDER BY tuple()
+SETTINGS allow_experimental_multi_column_text_index = 1; -- { serverError BAD_ARGUMENTS }
 
 CREATE TABLE multi_text_missing_field
 (
@@ -249,7 +268,8 @@ CREATE TABLE multi_text_missing_field
     INDEX idx (a, b) TYPE text(tokenizer = 'splitByNonAlpha', field_ids = '{"a":1}')
 )
 ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+ORDER BY tuple()
+SETTINGS allow_experimental_multi_column_text_index = 1; -- { serverError BAD_ARGUMENTS }
 
 CREATE TABLE multi_text_duplicate_id
 (
@@ -258,7 +278,8 @@ CREATE TABLE multi_text_duplicate_id
     INDEX idx (a, b) TYPE text(tokenizer = 'splitByNonAlpha', field_ids = '{"a":1,"b":2,"retired":1}')
 )
 ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+ORDER BY tuple()
+SETTINGS allow_experimental_multi_column_text_index = 1; -- { serverError BAD_ARGUMENTS }
 
 CREATE TABLE multi_text_invalid_id
 (
@@ -267,7 +288,8 @@ CREATE TABLE multi_text_invalid_id
     INDEX idx (a, b) TYPE text(tokenizer = 'splitByNonAlpha', field_ids = '{"a":0,"b":2}')
 )
 ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+ORDER BY tuple()
+SETTINGS allow_experimental_multi_column_text_index = 1; -- { serverError BAD_ARGUMENTS }
 
 CREATE TABLE multi_text_non_integer_id
 (
@@ -276,7 +298,8 @@ CREATE TABLE multi_text_non_integer_id
     INDEX idx (a, b) TYPE text(tokenizer = 'splitByNonAlpha', field_ids = '{"a":"1","b":2}')
 )
 ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+ORDER BY tuple()
+SETTINGS allow_experimental_multi_column_text_index = 1; -- { serverError BAD_ARGUMENTS }
 
 -- Transform templates are added in later stages; the first tagged stage rejects them explicitly.
 CREATE TABLE multi_text_preprocessor
@@ -289,7 +312,8 @@ CREATE TABLE multi_text_preprocessor
         field_ids = '{"a":1,"b":2}')
 )
 ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+ORDER BY tuple()
+SETTINGS allow_experimental_multi_column_text_index = 1; -- { serverError BAD_ARGUMENTS }
 
 CREATE TABLE multi_text_postprocessor
 (
@@ -301,7 +325,8 @@ CREATE TABLE multi_text_postprocessor
         field_ids = '{"a":1,"b":2}')
 )
 ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+ORDER BY tuple()
+SETTINGS allow_experimental_multi_column_text_index = 1; -- { serverError BAD_ARGUMENTS }
 
 CREATE TABLE tagged_single_preprocessor
 (
@@ -312,7 +337,8 @@ CREATE TABLE tagged_single_preprocessor
         field_ids = '{"a":1}')
 )
 ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+ORDER BY tuple()
+SETTINGS allow_experimental_multi_column_text_index = 1; -- { serverError BAD_ARGUMENTS }
 
 CREATE TABLE multi_text_expression
 (
@@ -323,7 +349,8 @@ CREATE TABLE multi_text_expression
         field_ids = '{"a":1,"lower(b)":2}')
 )
 ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+ORDER BY tuple()
+SETTINGS allow_experimental_multi_column_text_index = 1; -- { serverError BAD_ARGUMENTS }
 
 CREATE TABLE multi_text_overlap
 (
@@ -334,4 +361,5 @@ CREATE TABLE multi_text_overlap
     INDEX idx_bc (b, c) TYPE text(tokenizer = 'splitByNonAlpha', field_ids = '{"b":3,"c":4}')
 )
 ENGINE = MergeTree
-ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+ORDER BY tuple()
+SETTINGS allow_experimental_multi_column_text_index = 1; -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/04757_multi_column_text_index_exact.sql
+++ b/tests/queries/0_stateless/04757_multi_column_text_index_exact.sql
@@ -1,0 +1,337 @@
+SET enable_full_text_index = 1;
+SET explain_query_plan_default = 'legacy';
+SET enable_analyzer = 1;
+SET enable_parallel_replicas = 0;
+SET optimize_move_to_prewhere = 1;
+SET query_plan_optimize_prewhere = 1;
+SET query_plan_direct_read_from_text_index = 1;
+SET use_skip_indexes_on_data_read = 1;
+SET use_text_index_like_evaluation_by_dictionary_scan = 1;
+SET use_query_condition_cache = 0;
+SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0;
+
+DROP TABLE IF EXISTS multi_text_exact;
+DROP TABLE IF EXISTS tagged_single;
+
+CREATE TABLE multi_text_exact
+(
+    id UInt64,
+    title String,
+    body String,
+    tags Array(Nullable(String)),
+    note LowCardinality(Nullable(String)),
+    code FixedString(12),
+    INDEX idx (title, body, tags, note, code) TYPE text(
+        tokenizer = 'splitByNonAlpha',
+        support_phrase_search = 1,
+        field_ids = '{"title":7,"body":42,"tags":65535,"note":100,"code":101,"retired":99}')
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS
+    index_granularity = 1,
+    allow_experimental_text_index_phrase_search = 1,
+    max_bytes_to_merge_at_max_space_in_pool = 0;
+
+INSERT INTO multi_text_exact VALUES
+    (1, 'shared titleonly', 'bodyone', ['tagone', 'shared', NULL], NULL, 'fixedone'),
+    (2, 'second', 'shared bodyonly', ['tagtwo'], 'nullableonly', 'shared'),
+    (3, 'shared', 'shared', ['shared', 'tagthree'], 'shared', 'fixedthree');
+
+INSERT INTO multi_text_exact VALUES
+    (4, '', 'bodyone', [], NULL, ''),
+    (5, 'prefix', 'other', ['foo bar'], 'other', 'fixedfive');
+
+SELECT 'title_shared', groupArray(id) FROM (SELECT id FROM multi_text_exact WHERE hasToken(title, 'shared') ORDER BY id);
+SELECT 'body_shared', groupArray(id) FROM (SELECT id FROM multi_text_exact WHERE hasToken(body, 'shared') ORDER BY id);
+SELECT 'tags_shared', groupArray(id) FROM (SELECT id FROM multi_text_exact WHERE has(tags, 'shared') ORDER BY id);
+SELECT 'nullable_shared', groupArray(id) FROM (SELECT id FROM multi_text_exact WHERE hasToken(note, 'shared') ORDER BY id);
+SELECT 'fixed_shared', groupArray(id) FROM (SELECT id FROM multi_text_exact WHERE hasAnyTokens(code, ['shared']) ORDER BY id);
+SELECT 'field_isolation', groupArray(id) FROM (SELECT id FROM multi_text_exact WHERE hasToken(title, 'bodyonly') ORDER BY id);
+
+-- `EXPLAIN actions = 1` must expose two distinct text-index virtual inputs for predicates on
+-- different fields of the same index. Count their hashes instead of depending on plan formatting.
+SELECT 'direct_read_actions', uniqExact(field_hash)
+FROM
+(
+    SELECT arrayJoin(extractAll(explain, '__text_index_idx_hasToken_([0-9a-f]{32})')) AS field_hash
+    FROM
+    (
+        EXPLAIN actions = 1
+        SELECT id
+        FROM multi_text_exact
+        WHERE hasToken(title, 'titleonly') AND hasToken(body, 'bodyone')
+    )
+);
+
+-- Disable direct read for this plan so `EXPLAIN indexes = 1` reports the actual skip-index
+-- pruning performed by the multi-column `Text` index, including the field-tagged condition.
+SELECT 'index_pruning';
+SELECT trimLeft(explain)
+FROM
+(
+    EXPLAIN indexes = 1
+    SELECT id
+    FROM multi_text_exact
+    WHERE hasToken(body, 'bodyonly')
+    SETTINGS query_plan_direct_read_from_text_index = 0, use_skip_indexes_on_data_read = 0
+)
+WHERE explain LIKE '%Name:%'
+    OR explain LIKE '%Description:%'
+    OR explain LIKE '%Condition:%'
+    OR explain LIKE '%Parts:%/%'
+    OR explain LIKE '%Granules:%/%';
+SELECT 'cross_field_and', groupArray(id) FROM
+(
+    SELECT id
+    FROM multi_text_exact
+    WHERE hasToken(title, 'titleonly') AND hasToken(body, 'bodyone')
+    ORDER BY id
+);
+SELECT 'same_token_and', groupArray(id) FROM
+(
+    SELECT id
+    FROM multi_text_exact
+    WHERE hasToken(title, 'shared') AND hasToken(body, 'shared')
+    ORDER BY id
+);
+SELECT 'cross_field_or', groupArray(id) FROM
+(
+    SELECT id
+    FROM multi_text_exact
+    WHERE hasToken(title, 'titleonly') OR hasToken(body, 'bodyonly')
+    ORDER BY id
+);
+SELECT 'has_any', groupArray(id) FROM
+(
+    SELECT id
+    FROM multi_text_exact
+    WHERE hasAnyTokens(title, ['second', 'shared'])
+    ORDER BY id
+);
+SELECT 'has_all', groupArray(id) FROM
+(
+    SELECT id
+    FROM multi_text_exact
+    WHERE hasAllTokens(title, ['shared', 'titleonly'])
+    ORDER BY id
+);
+SELECT 'prepared_in', groupArray(id) FROM
+(
+    SELECT id
+    FROM multi_text_exact
+    WHERE title IN ('second', 'shared')
+    ORDER BY id
+);
+SELECT 'phrase', groupArray(id) FROM
+(
+    SELECT id
+    FROM multi_text_exact
+    WHERE hasPhrase(title, 'shared titleonly')
+    ORDER BY id
+);
+
+-- Dictionary pattern scans are a later stage. The tagged index must fall back to the row-level
+-- `LIKE` predicate instead of matching its binary physical keys.
+SELECT 'pattern_fallback', groupArray(id) FROM
+(
+    SELECT id
+    FROM multi_text_exact
+    WHERE title LIKE '%shared%'
+    ORDER BY id
+);
+
+SELECT 'direct_read_parity',
+    (SELECT groupArray(id) FROM
+    (
+        SELECT id
+        FROM multi_text_exact
+        WHERE hasToken(body, 'shared')
+        ORDER BY id
+        SETTINGS query_plan_direct_read_from_text_index = 1, use_skip_indexes_on_data_read = 1
+    )) =
+    (SELECT groupArray(id) FROM
+    (
+        SELECT id
+        FROM multi_text_exact
+        WHERE hasToken(body, 'shared')
+        ORDER BY id
+        SETTINGS query_plan_direct_read_from_text_index = 0, use_skip_indexes_on_data_read = 0
+    ));
+
+OPTIMIZE TABLE multi_text_exact FINAL;
+
+SELECT 'merged_title_shared', groupArray(id) FROM (SELECT id FROM multi_text_exact WHERE hasToken(title, 'shared') ORDER BY id);
+SELECT 'merged_phrase', groupArray(id) FROM
+(
+    SELECT id
+    FROM multi_text_exact
+    WHERE hasPhrase(title, 'shared titleonly')
+    ORDER BY id
+);
+
+SELECT * FROM mergeTreeTextIndex(currentDatabase(), multi_text_exact, idx); -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE multi_text_exact;
+
+CREATE TABLE tagged_single
+(
+    id UInt64,
+    value String,
+    INDEX idx value TYPE text(
+        tokenizer = 'splitByNonAlpha',
+        field_ids = '{"value":17,"retired":3}')
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO tagged_single VALUES (1, 'single tagged'), (2, 'other');
+SELECT 'tagged_single', groupArray(id) FROM
+(
+    SELECT id
+    FROM tagged_single
+    WHERE hasToken(value, 'tagged')
+    ORDER BY id
+);
+DROP TABLE tagged_single;
+
+-- A part created before `ADD INDEX` has no index files. Direct read must evaluate the source
+-- predicate for that part while using the tagged index for subsequently inserted parts.
+DROP TABLE IF EXISTS multi_text_materialize;
+CREATE TABLE multi_text_materialize
+(
+    id UInt64,
+    title String,
+    body String
+)
+ENGINE = MergeTree
+PARTITION BY id
+ORDER BY id;
+
+INSERT INTO multi_text_materialize VALUES (1, 'old title', 'oldbody');
+ALTER TABLE multi_text_materialize ADD INDEX idx (title, body) TYPE text(
+    tokenizer = 'splitByNonAlpha',
+    field_ids = '{"title":11,"body":12}');
+INSERT INTO multi_text_materialize VALUES (2, 'new title', 'newbody');
+
+SELECT 'partially_materialized', groupArray(id) FROM
+(
+    SELECT id
+    FROM multi_text_materialize
+    WHERE hasAnyTokens(body, ['oldbody', 'newbody'])
+    ORDER BY id
+);
+
+ALTER TABLE multi_text_materialize MATERIALIZE INDEX idx SETTINGS mutations_sync = 2;
+SELECT 'materialized', groupArray(id) FROM
+(
+    SELECT id
+    FROM multi_text_materialize
+    WHERE hasAnyTokens(body, ['oldbody', 'newbody'])
+    ORDER BY id
+);
+DROP TABLE multi_text_materialize;
+
+-- `field_ids` is a user-maintained ownership table and is mandatory for multiple fields.
+CREATE TABLE multi_text_missing_map
+(
+    a String,
+    b String,
+    INDEX idx (a, b) TYPE text(tokenizer = 'splitByNonAlpha')
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE multi_text_missing_field
+(
+    a String,
+    b String,
+    INDEX idx (a, b) TYPE text(tokenizer = 'splitByNonAlpha', field_ids = '{"a":1}')
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE multi_text_duplicate_id
+(
+    a String,
+    b String,
+    INDEX idx (a, b) TYPE text(tokenizer = 'splitByNonAlpha', field_ids = '{"a":1,"b":2,"retired":1}')
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE multi_text_invalid_id
+(
+    a String,
+    b String,
+    INDEX idx (a, b) TYPE text(tokenizer = 'splitByNonAlpha', field_ids = '{"a":0,"b":2}')
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE multi_text_non_integer_id
+(
+    a String,
+    b String,
+    INDEX idx (a, b) TYPE text(tokenizer = 'splitByNonAlpha', field_ids = '{"a":"1","b":2}')
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+-- Transform templates are added in later stages; the first tagged stage rejects them explicitly.
+CREATE TABLE multi_text_preprocessor
+(
+    a String,
+    b String,
+    INDEX idx (a, b) TYPE text(
+        tokenizer = 'splitByNonAlpha',
+        preprocessor = lower(a),
+        field_ids = '{"a":1,"b":2}')
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE multi_text_postprocessor
+(
+    a String,
+    b String,
+    INDEX idx (a, b) TYPE text(
+        tokenizer = 'splitByNonAlpha',
+        postprocessor = lower(a),
+        field_ids = '{"a":1,"b":2}')
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE tagged_single_preprocessor
+(
+    a String,
+    INDEX idx a TYPE text(
+        tokenizer = 'splitByNonAlpha',
+        preprocessor = lower(a),
+        field_ids = '{"a":1}')
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE multi_text_expression
+(
+    a String,
+    b String,
+    INDEX idx (a, lower(b)) TYPE text(
+        tokenizer = 'splitByNonAlpha',
+        field_ids = '{"a":1,"lower(b)":2}')
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE multi_text_overlap
+(
+    a String,
+    b String,
+    c String,
+    INDEX idx_ab (a, b) TYPE text(tokenizer = 'splitByNonAlpha', field_ids = '{"a":1,"b":2}'),
+    INDEX idx_bc (b, c) TYPE text(tokenizer = 'splitByNonAlpha', field_ids = '{"b":3,"c":4}')
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/04758_multi_column_text_index_binary_tokens.reference
+++ b/tests/queries/0_stateless/04758_multi_column_text_index_binary_tokens.reference
@@ -1,0 +1,8 @@
+left_nul	[1]
+right_nul	[2]
+index_pruning
+Parts: 3/3
+Granules: 3/3
+Name: idx
+Parts: 1/3
+Granules: 1/3

--- a/tests/queries/0_stateless/04758_multi_column_text_index_binary_tokens.sql
+++ b/tests/queries/0_stateless/04758_multi_column_text_index_binary_tokens.sql
@@ -1,0 +1,62 @@
+SET enable_full_text_index = 1;
+SET explain_query_plan_default = 'legacy';
+SET enable_analyzer = 1;
+SET enable_parallel_replicas = 0;
+SET use_query_condition_cache = 0;
+SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0;
+
+DROP TABLE IF EXISTS multi_text_binary_tokens;
+
+CREATE TABLE multi_text_binary_tokens
+(
+    id UInt64,
+    left_text String,
+    right_text String,
+    INDEX idx (left_text, right_text) TYPE text(
+        tokenizer = ngrams(3),
+        field_ids = '{"left_text":255,"right_text":256}')
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS
+    index_granularity = 1,
+    allow_experimental_multi_column_text_index = 1,
+    max_bytes_to_merge_at_max_space_in_pool = 0;
+
+-- Each insert stays in a separate part. The first two rows contain the same embedded-NUL token in
+-- different fields; the third token shares its binary prefix.
+INSERT INTO multi_text_binary_tokens VALUES (1, unhex('610062'), 'plain-left');
+INSERT INTO multi_text_binary_tokens VALUES (2, 'plain-right', unhex('610062'));
+INSERT INTO multi_text_binary_tokens VALUES (3, unhex('610063'), unhex('610063'));
+
+SELECT 'left_nul', groupArray(id) FROM
+(
+    SELECT id
+    FROM multi_text_binary_tokens
+    WHERE left_text = unhex('610062')
+    ORDER BY id
+);
+
+SELECT 'right_nul', groupArray(id) FROM
+(
+    SELECT id
+    FROM multi_text_binary_tokens
+    WHERE right_text = unhex('610062')
+    ORDER BY id
+);
+
+SELECT 'index_pruning';
+SELECT trimLeft(explain)
+FROM
+(
+    EXPLAIN indexes = 1
+    SELECT id
+    FROM multi_text_binary_tokens
+    WHERE left_text = unhex('610062')
+    SETTINGS query_plan_direct_read_from_text_index = 0, use_skip_indexes_on_data_read = 0
+)
+WHERE explain LIKE '%Name:%'
+    OR explain LIKE '%Parts:%/%'
+    OR explain LIKE '%Granules:%/%';
+
+DROP TABLE multi_text_binary_tokens;


### PR DESCRIPTION
This pull request implements Stage 1 of experimental multi-column `text` index support. It lets
several related source columns share one index lifecycle and dictionary while retaining the field
identity of every token. This provides the storage and per-field query foundation for Multi-Text
without combining the storage-format change with new cross-field SQL syntax, metadata ownership,
or online schema evolution in one review.

**Creating a tagged index**

Creating a multi-column index requires the experimental `MergeTree` setting and an explicit
user-maintained `field_ids` JSON object:

```sql
CREATE TABLE documents
(
    id UInt64,
    title String,
    body String,
    INDEX search_idx (title, body) TYPE text(
        tokenizer = 'splitByNonAlpha',
        field_ids = '{"title": 1, "body": 2}')
)
ENGINE = MergeTree
ORDER BY id
SETTINGS allow_experimental_multi_column_text_index = 1;
```

- `field_ids` is required when more than one source column is indexed. Supplying it for one source
  column explicitly selects the same tagged layout.
- Every active source column must have a unique integer ID in the inclusive range `1..65535`.
  Additional inactive names may remain in the JSON object as tombstones so their IDs are not
  reused. The user owns this stability contract in Stage 1.
- Tagged index expressions accept only plain source-column identifiers. Function expressions in
  the index column list are rejected.
- `preprocessor` and `postprocessor` are rejected for tagged indexes in this stage. All fields use
  the shared tokenizer policy.
- Supported inputs follow the existing string-family paths: `String`, `FixedString`, arrays of
  supported strings, and `Nullable`/`LowCardinality` wrappers.
- Creating a second `text` index over any already indexed source column is rejected, including a
  non-leading column of a multi-column index.

**Storage and compatibility contract**

Each logical `(token, field_id)` dictionary entry uses the physical key:

```text
escape_nuls(token_bytes) || 0x00 || escape_flag || UInt16_BE(field_id)
```

Each logical NUL byte is escaped as `0x00 0xFF`. `escape_flag` is `0x00` when the token contains no
NUL and `0x01` when it contains at least one escaped NUL. The terminator and flag make the token
component self-delimiting, and the final two bytes store the field ID in big-endian order. The
decoder accepts only canonical combinations of escapes and flags.

This encoding preserves the unsigned bytewise order of `(logical token, numeric field_id)`. All
field variants of one token are therefore contiguous even when another token has it as a prefix;
that property allows a later native field-selector query to use one dictionary range per token.
The common case adds four bytes per key, plus one byte for each logical NUL. The posting-list,
position, row-ID, dictionary, and front-coding representations remain unchanged.

- The presence of `field_ids`, rather than the number of columns, determines whether the tagged
  layout is used. A tagged one-column index therefore cannot be mistaken for a legacy untagged
  index.
- `TextIndexHeader::Version::WithFieldIds` defines this tagged-key codec and records the posting
  codec and positions capability. This pull request is its first introduction, so there is no
  merged or released earlier tagged layout to preserve. Readers and segment merges reject
  incompatible tagged/untagged layouts, while legacy versions remain unchanged.
- Tokens from every indexed field in one input row use the same part-relative row ID. Existing
  sorted dictionary construction and k-way segment merge operate on the complete physical key.
- Legacy single-column indexes without `field_ids` keep their existing format and behavior.
- Inserts, part merges, `OPTIMIZE FINAL`, and `MATERIALIZE INDEX` build or preserve the tagged
  representation. Parts without index files continue through source evaluation until materialized.

**Query and pruning capabilities**

Queries keep the existing field-local SQL form and may be combined with normal SQL `AND` and `OR`:

```sql
WHERE hasToken(title, 'error') OR hasToken(body, 'timeout')
```

- The covered query paths include `hasToken`, `hasAnyTokens`, `hasAllTokens`, `has` over supported
  arrays, prepared `IN`, and field-local `hasPhrase` when positions are enabled.
- Each predicate resolves its source column to one field ID and binds the token through the same
  canonical encoder used by index construction. A token present only in another field cannot
  contribute postings.
- Query hashes and direct-read virtual-column identities include the field-tagged physical keys, so
  identical logical tokens in different fields remain distinct.
- Several field-local predicates may use the same shared index for skip-index pruning or direct
  read. They still remain separate per-field query objects in Stage 1.
- `EXPLAIN actions = 1` exposes distinct virtual inputs for different fields, while
  `EXPLAIN indexes = 1` reports the selected field ID and demonstrates part/granule pruning.
- Positions remain field-local because each positions list belongs to a composite token-and-field
  key; phrases cannot cross a field boundary.

**Deliberate Stage 1 boundaries**

- There is no native selected-field or all-field predicate. Searching several fields uses existing
  per-field predicates and does not yet provide the RFC's no-fan-out execution, even though the
  physical ordering reserves a contiguous field range for that later stage.
- Tagged `LIKE`/`ILIKE` dictionary scans are disabled and retain correct row-level evaluation or
  conservative fallback. This PR adds no regexp, wildcard, or prefix dictionary-scan API.
- `mergeTreeTextIndex` rejects tagged indexes because its current output cannot expose field
  identity without rendering physical key-encoding bytes as part of the token.
- The user-maintained JSON object is not a per-part field-coverage catalog. Changing active fields
  or IDs in place is unsupported; users must replace and fully materialize the index.
- Engine-managed field IDs, native field selectors, transforms, online field-set evolution, and
  introspection are intentionally assigned to later RFC stages.

Regression coverage verifies tagged and legacy layouts, cross-field isolation across exact,
prepared-set, array, wrapper, and phrase paths, multi-field `AND`, inserts, materialization, segment
merge, `OPTIMIZE FINAL`, direct-read/source fallback parity, invalid DDL, and observable pruning via
both `EXPLAIN` forms. Focused codec tests additionally verify exact physical bytes, arbitrary
binary-token round trips, rejection of non-canonical encodings, field IDs around the `255`/`256`
boundary, and physical ordering against exhaustive logical `(token, field_id)` tuple ordering.

Related: https://github.com/ClickHouse/ClickHouse/issues/113249

### Changelog category (leave one):

- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add experimental support for a single `text` index over multiple columns. Enable
`allow_experimental_multi_column_text_index` and provide the `field_ids` index parameter to create
one shared field-aware index while continuing to query each source column with existing text-search
predicates.
