### PR TITLE
Make the `auto` and `none` compression hints case-insensitive

### DIFF
--- a/src/IO/CompressionMethod.cpp
+++ b/src/IO/CompressionMethod.cpp
@@ -169,8 +169,12 @@ CompressionMethod chooseHTTPCompressionMethod(const std::string & list)
 
 CompressionMethod chooseCompressionMethod(const std::string & path, const std::string & hint)
 {
+    /// Both the autodetection gate below and the uncompressed fallback must agree on the spelling.
+    std::string hint_lower = hint;
+    boost::algorithm::to_lower(hint_lower);
+
     std::string file_extension;
-    if (hint.empty() || hint == "auto")
+    if (hint_lower.empty() || hint_lower == "auto")
     {
         auto pos = path.find_last_of('.');
         if (pos != std::string::npos)
@@ -180,7 +184,7 @@ CompressionMethod chooseCompressionMethod(const std::string & path, const std::s
     std::string method_str;
 
     if (file_extension.empty())
-        method_str = hint;
+        method_str = hint_lower;
     else
         method_str = std::move(file_extension);
 
@@ -202,7 +206,7 @@ CompressionMethod chooseCompressionMethod(const std::string & path, const std::s
         return CompressionMethod::Bzip2;
     if (method_str == "snappy")
         return CompressionMethod::Snappy;
-    if (hint.empty() || hint == "auto" || hint == "none")
+    if (hint_lower.empty() || hint_lower == "auto" || hint_lower == "none")
         return CompressionMethod::None;
 
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unknown compression method '{}'. "

--- a/tests/queries/0_stateless/04771_compression_method_hint_case_insensitive.reference
+++ b/tests/queries/0_stateless/04771_compression_method_hint_case_insensitive.reference
@@ -1,0 +1,20 @@
+C1 auto differs from none on .gz
+1
+C2 GZIP codec name
+100
+C3 unknown method still throws and echoes the raw spelling
+1	0
+C4 uppercase file extension autodetects
+1
+C5 empty hint autodetects
+1
+W1 AUTO on .gz equals auto
+1
+W2 NONE on .gz equals none
+1
+W3 Auto on .gz equals auto
+1
+W4 None on plain file equals none
+1
+W5 AUTO on the write path
+10

--- a/tests/queries/0_stateless/04771_compression_method_hint_case_insensitive.sql
+++ b/tests/queries/0_stateless/04771_compression_method_hint_case_insensitive.sql
@@ -1,0 +1,51 @@
+INSERT INTO FUNCTION file(currentDatabase() || '_04771.csv.gz', 'CSV', 'x UInt64', 'gzip')
+SELECT number FROM numbers(100) SETTINGS engine_file_truncate_on_insert = 1;
+
+INSERT INTO FUNCTION file(currentDatabase() || '_04771.csv', 'CSV', 'x UInt64', 'none')
+SELECT number FROM numbers(100) SETTINGS engine_file_truncate_on_insert = 1;
+
+INSERT INTO FUNCTION file(currentDatabase() || '_04771.CSV.GZ', 'CSV', 'x UInt64', 'gzip')
+SELECT number FROM numbers(100) SETTINGS engine_file_truncate_on_insert = 1;
+
+SELECT 'C1 auto differs from none on .gz';
+SELECT (SELECT sum(length(x)) FROM file(currentDatabase() || '_04771.csv.gz', 'RawBLOB', 'x String', 'auto'))
+    != (SELECT sum(length(x)) FROM file(currentDatabase() || '_04771.csv.gz', 'RawBLOB', 'x String', 'none'));
+
+SELECT 'C2 GZIP codec name';
+SELECT count() FROM file(currentDatabase() || '_04771.csv.gz', 'CSV', 'x UInt64', 'GZIP');
+
+SELECT 'C3 unknown method still throws and echoes the raw spelling';
+SELECT sum(length(x)) FROM file(currentDatabase() || '_04771.csv', 'RawBLOB', 'x String', 'BOGUS'); -- { serverError NOT_IMPLEMENTED }
+SYSTEM FLUSH LOGS query_log;
+SELECT countIf(position(exception, 'BOGUS') > 0) > 0, countIf(position(exception, 'bogus') > 0)
+FROM system.query_log
+WHERE current_database = currentDatabase() AND exception_code = 48 AND event_date >= yesterday();
+
+SELECT 'C4 uppercase file extension autodetects';
+SELECT (SELECT sum(length(x)) FROM file(currentDatabase() || '_04771.CSV.GZ', 'RawBLOB', 'x String'))
+    == (SELECT sum(length(x)) FROM file(currentDatabase() || '_04771.csv.gz', 'RawBLOB', 'x String', 'gzip'));
+
+SELECT 'C5 empty hint autodetects';
+SELECT (SELECT sum(length(x)) FROM file(currentDatabase() || '_04771.csv.gz', 'RawBLOB', 'x String'))
+    == (SELECT sum(length(x)) FROM file(currentDatabase() || '_04771.csv.gz', 'RawBLOB', 'x String', 'auto'));
+
+SELECT 'W1 AUTO on .gz equals auto';
+SELECT (SELECT sum(length(x)) FROM file(currentDatabase() || '_04771.csv.gz', 'RawBLOB', 'x String', 'AUTO'))
+    == (SELECT sum(length(x)) FROM file(currentDatabase() || '_04771.csv.gz', 'RawBLOB', 'x String', 'auto'));
+
+SELECT 'W2 NONE on .gz equals none';
+SELECT (SELECT sum(length(x)) FROM file(currentDatabase() || '_04771.csv.gz', 'RawBLOB', 'x String', 'NONE'))
+    == (SELECT sum(length(x)) FROM file(currentDatabase() || '_04771.csv.gz', 'RawBLOB', 'x String', 'none'));
+
+SELECT 'W3 Auto on .gz equals auto';
+SELECT (SELECT sum(length(x)) FROM file(currentDatabase() || '_04771.csv.gz', 'RawBLOB', 'x String', 'Auto'))
+    == (SELECT sum(length(x)) FROM file(currentDatabase() || '_04771.csv.gz', 'RawBLOB', 'x String', 'auto'));
+
+SELECT 'W4 None on plain file equals none';
+SELECT (SELECT count() FROM file(currentDatabase() || '_04771.csv', 'CSV', 'x UInt64', 'None'))
+    == (SELECT count() FROM file(currentDatabase() || '_04771.csv', 'CSV', 'x UInt64', 'none'));
+
+SELECT 'W5 AUTO on the write path';
+INSERT INTO FUNCTION file(currentDatabase() || '_04771_w.csv.gz', 'CSV', 'x UInt64', 'AUTO')
+SELECT number FROM numbers(10) SETTINGS engine_file_truncate_on_insert = 1;
+SELECT count() FROM file(currentDatabase() || '_04771_w.csv.gz', 'CSV', 'x UInt64', 'auto');


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/105667
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `Unknown compression method` being thrown for the `auto` and `none` compression hints written in any letter case other than all-lowercase, for example `file('data.csv.gz', 'CSV', 'x String', 'AUTO')`. Codec names such as `GZIP` were already accepted case-insensitively; the two special hints now behave the same way.


### Description

`chooseCompressionMethod(path, hint)` lowercases only the variable used for the
codec-name comparison, so `GZIP` has always worked. The two branches that
recognise the special `auto` and `none` hints compared the raw `hint`, so `AUTO`,
`Auto`, `None` and `NONE` matched neither branch and reached the
`NOT_IMPLEMENTED` throw. This affects every caller that forwards a user-supplied
compression string (`file()`, `url()`, `s3()`, object storage, `INTO OUTFILE ...
COMPRESSION`) and is roughly six years old, so it is present on every active
release branch. It is not a regression from #105667.

The fix normalises `hint` once at the top of the function so both branches see
the canonical spelling. The thrown message deliberately keeps echoing the user's
original spelling.

One note for reviewers, because the obvious smaller patch is wrong: `none` means
"no compression, do not autodetect", so if only the fallback branch is taught
about `AUTO` while the autodetection gate still matches lowercase `auto` only,
`AUTO` on a `.gz` file stops throwing and instead reads the file raw, turning a
loud error into silently wrong results. The regression test asserts the
autodetect-versus-none distinction explicitly so that shape cannot pass.

Behaviour changes only for inputs that throw `NOT_IMPLEMENTED` today. Every
currently-succeeding input is unaffected: all eight codecs in both letter cases,
the empty hint, and uppercase file *extensions* (the `path` argument is
deliberately not normalised) were measured identical before and after.

The four `compression_method != "auto"` tests in `TableFunctionURL.cpp` are
argument-emission sentinels for delegated calls, not hint parsing; the string
they emit reaches this function and is repaired here, so they are left alone as
a separate concern.

The bug reproduces on `26.7`, `26.6`, `26.5`, `26.3` and `25.8` as well. Could a
maintainer add the appropriate `v*-must-backport` labels if backporting is wanted?

<details>
<summary>Validation</summary>

Both arms built from this worktree, each with its own server restart and
`SELECT lower(buildId())` asserted against `readelf -n` before any verdict.

Base arm (pristine `2169bf5d402de64`, Build ID `a79b7525945...`): the new test
FAILS with `Unknown compression method 'AUTO'`. Because the discrimination
control is emitted first, the captured output shows all five controls correct and
`W1` as the first missing line.

Fixed arm (Build ID `454018fd0419...`): `[ OK ]`, and 100/100 runs pass
(50 with `--order random`, 50 plain).

Mutation matrix; each mutant reddens the named rows and nothing else:

| mutant | change | reddened |
|---|---|---|
| M1 | autodetection gate back to raw `hint` | W1, W3, W5 |
| M2 | fallback branch back to raw `hint` | W2, and W3/W4/W5 behind its abort |
| M3 | the naive fallback-only patch | W1, W3, W5 |
| M4 | throw `hint_lower` instead of `hint` | C3 only |

M3 is the shape a future contributor would most plausibly write. Under M3,
`AUTO` on a `.gz` returns 165 raw bytes where `auto` returns 290 decompressed:
the wrong-results hazard above, caught by W1/W3. M3 also keeps failing 20/20
under `--order random`, so the test still detects it with settings randomised.

Every mutant's Build ID differed, and the shipping Build ID returned byte-exactly
after restoring, so the mutants ran on genuinely different binaries.

A 121-test slice of every existing compression/gzip/zstd/brotli/bz2/snappy/outfile
stateless test was run on both arms: the deterministic failure sets are identical
(0 only-in-fix, 0 only-in-base). Three tests additionally hit the 600 s timeout on
the fixed arm only; all three pass in 0.89-3.70 s when run alone, and that run
carried 2.2x the wall time of the base run with 15 concurrent test processes, so
they are box load rather than a regression.
</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.918` (included in `26.8` and later)
<!-- ch-version-info:end -->