### PR TITLE
darwin fast test: drop on-demand lldb install, exit on runner-init upgrade

### DIFF
--- a/ci/praktika/infrastructure/runner/runner-init.py
+++ b/ci/praktika/infrastructure/runner/runner-init.py
@@ -635,10 +635,6 @@ brew install \
     coreutils \
     llvm
 
-# Keg-only `llvm` does not link `lldb` system-wide, so expose it on the Homebrew
-# PATH as plain `lldb` for `clickhouse-test`'s `print_c_stacktraces`.
-ln -sf "$(brew --prefix llvm)/bin/lldb" "$(brew --prefix)/bin/lldb"
-
 # Python packages used by jobs. `boto3` is bootstrapped in `user_data_macos.txt`
 # because runner-init itself imports it; the rest are version-gated here.
 "$HOME/venv/bin/pip" install --upgrade pip

--- a/ci/praktika/infrastructure/runner/runner-init.py
+++ b/ci/praktika/infrastructure/runner/runner-init.py
@@ -224,22 +224,23 @@ class Runner:
             self.collect_logs("configure")
             raise Exception(f"Too many errors ({self.total_errors})")
 
-        # macOS runners run continuously without lifetime limits, so they must
-        # reboot to pick up a newer init script instead of ageing out like Linux.
+        # macOS runners run continuously without lifetime limits, so they exit
+        # to pick up a newer init script instead of ageing out like Linux.
         if config.init_environment == Environment.MACOS:
-            self._reboot_if_init_script_upgraded()
+            self._exit_if_init_script_upgraded()
             return
 
         runner_age = int(time.time()) - self.runner_start_time
         if config.max_life < runner_age:
             raise Exception(f"Runner lifetime exceeded: {runner_age}")
 
-    def _reboot_if_init_script_upgraded(self) -> None:
-        """Reboot when a newer runner-init script has been published to S3.
+    def _exit_if_init_script_upgraded(self) -> None:
+        """Exit when a newer runner-init script has been published to S3.
 
-        Called between jobs, so the runner is idle here. On reboot the instance
-        re-downloads and re-runs the init script, provisioning the new version.
-        A failure to read the remote version is a safe skip, not a reboot.
+        Called between jobs, so the runner is idle here. Raising unwinds through
+        `run`, which drops the provisioning marker; `user_data` then reboots and
+        re-provisions from the new script. A failure to read the remote version
+        is a safe skip, not an exit.
         """
         try:
             remote_version = EC2.get_remote_init_version()
@@ -248,13 +249,10 @@ class Runner:
             return
         if remote_version <= config.version:
             return
-        log(
+        raise Exception(
             f"Remote init version {remote_version} > running {config.version}, "
-            "rebooting to upgrade"
+            "exiting to re-provision"
         )
-        subprocess.run(["sudo", "reboot"], check=False)
-        # Block so the loop does not start another job while the OS tears down.
-        time.sleep(config.max_chill)
 
     def _cleanup_workspace(self) -> None:
         """Remove _work directory to clean up workspace."""

--- a/ci/praktika/infrastructure/runner/runner-init.py
+++ b/ci/praktika/infrastructure/runner/runner-init.py
@@ -40,7 +40,7 @@ class RunnerConfig:
     """Configuration and runtime state for the GitHub Actions runner."""
 
     # Constants
-    version: int = 74
+    version: int = 75
     init_environment: str = Environment.TEST
     verbose = False
     script_path = os.path.abspath(__file__)
@@ -224,13 +224,37 @@ class Runner:
             self.collect_logs("configure")
             raise Exception(f"Too many errors ({self.total_errors})")
 
-        # macOS runners run continuously without lifetime limits
+        # macOS runners run continuously without lifetime limits, so they must
+        # reboot to pick up a newer init script instead of ageing out like Linux.
         if config.init_environment == Environment.MACOS:
+            self._reboot_if_init_script_upgraded()
             return
 
         runner_age = int(time.time()) - self.runner_start_time
         if config.max_life < runner_age:
             raise Exception(f"Runner lifetime exceeded: {runner_age}")
+
+    def _reboot_if_init_script_upgraded(self) -> None:
+        """Reboot when a newer runner-init script has been published to S3.
+
+        Called between jobs, so the runner is idle here. On reboot the instance
+        re-downloads and re-runs the init script, provisioning the new version.
+        A failure to read the remote version is a safe skip, not a reboot.
+        """
+        try:
+            remote_version = EC2.get_remote_init_version()
+        except Exception as e:
+            log(f"Cannot get remote init version: {e}, skipping upgrade check")
+            return
+        if remote_version <= config.version:
+            return
+        log(
+            f"Remote init version {remote_version} > running {config.version}, "
+            "rebooting to upgrade"
+        )
+        subprocess.run(["sudo", "reboot"], check=False)
+        # Block so the loop does not start another job while the OS tears down.
+        time.sleep(config.max_chill)
 
     def _cleanup_workspace(self) -> None:
         """Remove _work directory to clean up workspace."""
@@ -612,6 +636,10 @@ brew install \
     bash \
     coreutils \
     llvm
+
+# Keg-only `llvm` does not link `lldb` system-wide, so expose it on the Homebrew
+# PATH as plain `lldb` for `clickhouse-test`'s `print_c_stacktraces`.
+ln -sf "$(brew --prefix llvm)/bin/lldb" "$(brew --prefix)/bin/lldb"
 
 # Python packages used by jobs. `boto3` is bootstrapped in `user_data_macos.txt`
 # because runner-init itself imports it; the rest are version-gated here.

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1050,58 +1050,12 @@ def get_transactions_list(args):
         return f"Cannot get list of transactions: {e}"
 
 
-_LLDB_INSTALL_ATTEMPTED = False
-
-
-def _ensure_lldb_installed():
-    """Make sure `lldb` is on PATH, installing it on the fly if not.
-
-    TEMPORARY scaffolding: the CI base images currently ship `gdb` (from the
-    `clickhouse/cctools` layer), not `lldb`. While the switch to `lldb` is in
-    flight, install it at runtime so `print_c_stacktraces` keeps working.
-    Once `ci/docker/cctools/Dockerfile` (and the images that copy from it)
-    install `lldb` permanently, this helper and its single call site below
-    should be removed.
-
-    Never raise: `print_c_stacktraces` is a best-effort diagnostic. If the
-    install fails (no sudo, no network, no `brew`, ...), let
-    `shell_get_output` return "" so the surrounding diagnostic flow keeps
-    going instead of crashing during an already-broken run.
-
-    Bounded and idempotent: each subprocess call has a hard timeout so a
-    stalled package mirror cannot wedge stacktrace collection for minutes,
-    and a process-wide flag ensures only the first call attempts the
-    install — `print_c_stacktraces` iterates over every server PID, and we
-    must not pay the install cost (or timeout) for each one if the first
-    attempt already failed.
-    """
-    global _LLDB_INSTALL_ATTEMPTED
-    if shutil.which("lldb"):
-        return
-    if _LLDB_INSTALL_ATTEMPTED:
-        return
-    _LLDB_INSTALL_ATTEMPTED = True
-    try:
-        if platform.system() == "Darwin":
-            subprocess.run(["brew", "install", "llvm"], check=True, timeout=180)
-        else:
-            env = {**os.environ, "DEBIAN_FRONTEND": "noninteractive"}
-            subprocess.run(["apt-get", "update"], check=True, env=env, timeout=60)
-            subprocess.run(
-                ["apt-get", "install", "-y", "lldb"],
-                check=True, env=env, timeout=120,
-            )
-    except Exception as e:
-        print(f"Could not install lldb on the fly: {e}", file=sys.stderr)
-
-
 # collect server stacktraces using lldb (used uniformly on Linux and macOS)
 def get_stacktraces_from_lldb(pid):
     # 30s ceiling: `thread backtrace all` should finish in seconds even on a
     # debug build with many threads; anything beyond that means lldb itself
     # is wedged (e.g. signal-handler deadlock on the inferior). Killing lldb
     # leaves the server process untouched.
-    _ensure_lldb_installed()  # TEMPORARY: see _ensure_lldb_installed docstring.
     # macOS restricts task_for_pid(): in --batch mode a non-root lldb cannot
     # attach to the server on a CI runner (the user is not in the _developer
     # group and there is no interactive authorization), so it exits 1. The


### PR DESCRIPTION
The macOS fast-test runner already `brew install`s `llvm` (which ships `lldb`), and `macos_job_path` already prepends `{brew}/opt/llvm/bin` to the job PATH, so `clickhouse-test`'s `print_c_stacktraces` resolves `lldb` without any extra install. Given that, the on-demand `_ensure_lldb_installed` scaffolding in `tests/clickhouse-test` and its single call site are removed.

macOS runners run continuously, so a between-jobs check exits when a newer `runner-init` version is published to S3; `user_data` then reboots and re-provisions from the new script. `config.version` is bumped so the new script deploys and running instances pick it up.

Related: https://github.com/ClickHouse/ClickHouse/pull/112058
Related: https://github.com/ClickHouse/ClickHouse/pull/104815

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.939` (included in `26.8` and later)
<!-- ch-version-info:end -->