### PR TITLE
Docs: align Galaxy attribution with marketing website

### DIFF
--- a/docs/_site/customizations/README.mdx
+++ b/docs/_site/customizations/README.mdx
@@ -9,7 +9,7 @@ See Mintlify's docs on [custom scripts](https://www.mintlify.com/docs/customize/
 
 - `ask-ai-button.js` — tweaks the Ask-AI button styling/behavior.
 - `custom-footer.js` — renders the custom site footer (`#ch-custom-footer`).
-- `galaxy.js` — initializes ClickHouse Galaxy analytics, tracks docs and knowledge-base page lifecycle events across Mintlify SPA navigation, sends canonical `https://clickhouse.com/docs` traffic to the production Galaxy API and `.mintlify.app` preview traffic to the development Galaxy API (disabled on localhost and unknown origins), and adds attribution plus the Galaxy visitor ID to ClickHouse Cloud links only on canonical production docs.
+- `galaxy.js` — initializes ClickHouse Galaxy analytics, applies the same 30-day last-touch, non-direct referrer and UTM attribution model as the marketing website to every event, tracks docs and knowledge-base page lifecycle events across Mintlify SPA navigation, sends canonical `https://clickhouse.com/docs` traffic to the production Galaxy API and `.mintlify.app` preview traffic to the development Galaxy API (disabled on localhost and unknown origins), and adds stored campaign parameters plus the Galaxy visitor ID to ClickHouse Cloud links only on canonical production docs.
 - `inkeep-init.js` — replaces Mintlify's native search (⌘K / navbar search bar) with the Inkeep search modal. Search-only; AI chat stays on Kapa.
 - `kapa-init.js` — bootstraps the Kapa.ai RAG widget.
 - `navbar-cta.js` — adds the "Get started" CTA to the navbar.

--- a/docs/_site/customizations/galaxy.js
+++ b/docs/_site/customizations/galaxy.js
@@ -24,6 +24,9 @@
   var FLUSH_INTERVAL_MS = 5000;
   var KEEPALIVE_LIMIT_BYTES = 60 * 1024;
   var ATTRIBUTION_HOSTS = ['clickhouse.cloud', 'console.clickhouse.cloud'];
+  var ATTRIBUTION_TTL_DAYS = 30;
+  var INTERNAL_REFERRER_DOMAINS = ['clickhouse.com', 'clickhouse.cloud'];
+  var initialTouchProcessed = false;
 
   if (window.__clickhouseGalaxyInitialized) return;
   window.__clickhouseGalaxyInitialized = true;
@@ -123,7 +126,13 @@
   function track(event, properties) {
     if (!event) return;
 
-    var eventProperties = properties || { interaction: 'click' };
+    // Match the marketing website: attribution rides on every Galaxy event,
+    // while explicit event properties win when keys collide.
+    var eventProperties = Object.assign(
+      {},
+      getAttributionProperties(),
+      properties || { interaction: 'click' }
+    );
     var interaction = eventProperties.interaction;
     var extraProperties = {};
     for (var key in eventProperties) {
@@ -202,6 +211,10 @@
     return flushInFlight;
   }
 
+  // Evaluate the hard-page landing before any galaxy:ready listener can emit
+  // an event, so the event sees the new last non-direct touch immediately.
+  recordAttributionTouch();
+
   window.galaxy = {
     track: track,
     flushEvents: flushEvents,
@@ -224,10 +237,39 @@
     if (!event.persisted) stopGalaxy();
   });
 
+  function getAttributionProperties() {
+    var params = new URLSearchParams(window.location.search);
+    var stored = storedAttribution() || {};
+
+    function get(key) {
+      var fromUrl = params.get(key);
+      if (fromUrl !== null) return fromUrl;
+      return typeof stored[key] === 'string' ? stored[key] : undefined;
+    }
+
+    var referrer = document.referrer || undefined;
+    var lastTouchReferrer = typeof stored.referrer === 'string'
+      ? stored.referrer
+      : undefined;
+
+    return {
+      utm_source: get('utm_source'),
+      utm_medium: get('utm_medium'),
+      utm_campaign: get('utm_campaign'),
+      utm_term: get('utm_term'),
+      utm_content: get('utm_content'),
+      utm_id: get('utm_id'),
+      gclid: get('gclid'),
+      path: window.location.pathname,
+      referrer: referrer,
+      referrerDomain: getDomain(referrer),
+      lastTouchReferrer: lastTouchReferrer,
+      lastTouchReferrerDomain: getDomain(lastTouchReferrer),
+    };
+  }
+
   function trackPageEvent(action) {
-    track('docs.window.' + action, {
-      interaction: 'trigger',
-    });
+    track('docs.window.' + action, { interaction: 'trigger' });
   }
 
   // Docusaurus hooks tracked load, focus, and blur for every docs and KB page.
@@ -281,6 +323,7 @@
     var path = window.location.pathname;
     if (path !== lastPath) {
       lastPath = path;
+      recordAttributionTouch();
       trackPageEvent('load');
       updateCloudLinks();
     }
@@ -288,28 +331,58 @@
   }
   window.requestAnimationFrame(watchPath);
 
-  // Preserve the attribution behavior from src/clientModules/utmPersistence:
-  // retain campaign parameters and attach the Galaxy ID and page paths to
-  // links into ClickHouse Cloud.
-  function saveAttribution() {
+  // Match the marketing website's last-touch, non-direct, 30-day model.
+  // Campaign parameters replace the previous touch on every route. An
+  // external referrer replaces it only once per hard page load; direct visits
+  // leave the stored touch and its existing expiry unchanged.
+  function recordAttributionTouch() {
+    var params = new URLSearchParams(window.location.search);
+    var values = {};
+    params.forEach(function (value, key) {
+      if (key.indexOf('utm_') === 0 || key === 'gclid') values[key] = value;
+    });
+    if (Object.keys(values).length > 0) {
+      storeAttribution(values);
+    } else if (!initialTouchProcessed) {
+      var referrer = getExternalReferrer();
+      if (referrer) storeAttribution({ referrer: referrer });
+    }
+    initialTouchProcessed = true;
+  }
+
+  function storeAttribution(attribution) {
+    var expiration = new Date();
+    expiration.setDate(expiration.getDate() + ATTRIBUTION_TTL_DAYS);
+    storageSet(window.localStorage, 'ch-utms', JSON.stringify({
+      data: attribution,
+      timestamp: expiration.getTime(),
+    }));
+  }
+
+  function getExternalReferrer() {
+    var referrer = document.referrer;
+    if (!referrer) return null;
+
     try {
-      var params = new URLSearchParams(window.location.search);
-      var values = {};
-      params.forEach(function (value, key) {
-        if (key.indexOf('utm_') === 0 || key === 'gclid') values[key] = value;
-      });
-      if (Object.keys(values).length > 0) {
-        var expiration = new Date();
-        expiration.setDate(expiration.getDate() + 14);
-        window.localStorage.setItem('ch-utms', JSON.stringify({
-          data: values,
-          timestamp: expiration.getTime(),
-        }));
+      var hostname = new URL(referrer).hostname;
+      if (hostname === window.location.hostname) return null;
+      for (var i = 0; i < INTERNAL_REFERRER_DOMAINS.length; i++) {
+        var domain = INTERNAL_REFERRER_DOMAINS[i];
+        if (hostname === domain || hostname.endsWith('.' + domain)) return null;
       }
-      if (!window.localStorage.getItem('origPath')) {
-        window.localStorage.setItem('origPath', window.location.pathname);
-      }
-    } catch (e) {}
+      return referrer;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function getDomain(url) {
+    if (!url) return undefined;
+    try {
+      return new URL(url).hostname;
+    } catch (e) {
+      return undefined;
+    }
   }
 
   function storedAttribution() {
@@ -321,7 +394,7 @@
         window.localStorage.removeItem('ch-utms');
         return null;
       }
-      return parsed.data;
+      return parsed.data || null;
     } catch (e) {
       return null;
     }
@@ -334,7 +407,9 @@
   function updateCloudLinks() {
     if (!isCanonicalDocs) return;
 
-    saveAttribution();
+    if (!storageGet(window.localStorage, 'origPath')) {
+      storageSet(window.localStorage, 'origPath', window.location.pathname);
+    }
     var attribution = storedAttribution();
     var links = document.querySelectorAll('a[href*="clickhouse.cloud"]');
 
@@ -345,7 +420,7 @@
 
         if (attribution) {
           for (var key in attribution) {
-            if (Object.prototype.hasOwnProperty.call(attribution, key)) {
+            if (Object.prototype.hasOwnProperty.call(attribution, key) && key !== 'referrer') {
               url.searchParams.set(key, attribution[key]);
             }
           }


### PR DESCRIPTION
Aligns the Mintlify docs Galaxy adapter with the marketing website's 30-day last-touch, non-direct attribution model. Docs now preserve campaign and external-referrer touches consistently, attach attribution to every Galaxy event, and keep referrer touches out of ClickHouse Cloud signup URLs while retaining `glxid` stitching.

This prevents organic and AI-referred docs visitors from appearing as direct signups and avoids retaining stale paid attribution after a newer referrer touch.

Related: https://github.com/ClickHouse/marketing-website/pull/1639

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Align docs Galaxy attribution with the marketing website's last-touch model.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.900` (included in `26.8` and later)
<!-- ch-version-info:end -->