### PR TITLE
Honor a `break`-mode timeout while building child plans of a `Merge` table

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -178,6 +178,7 @@ static struct InitFiu
     REGULAR(zero_copy_unlock_zk_fail_after_op) \
     REGULAR(plain_rewritable_object_storage_azure_not_found_on_init) \
     PAUSEABLE(storage_merge_tree_background_clear_old_parts_pause) \
+    PAUSEABLE(storage_merge_create_children_plans_pause) \
     PAUSEABLE_ONCE(storage_shared_merge_tree_mutate_pause_before_wait) \
     PAUSEABLE(database_replicated_startup_pause) \
     ONCE(keeper_leader_sets_invalid_digest) \

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -68,6 +68,7 @@
 #include <Storages/VirtualColumnUtils.h>
 #include <Storages/checkAndGetLiteralArgument.h>
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 #include <Common/assert_cast.h>
 #include <Common/checkStackSize.h>
 #include <Common/typeid_cast.h>
@@ -89,6 +90,11 @@ namespace Setting
 namespace MergeTreeSetting
 {
     extern const MergeTreeSettingsBool share_nested_offsets;
+}
+
+namespace FailPoints
+{
+    extern const char storage_merge_create_children_plans_pause[];
 }
 
 namespace ErrorCodes
@@ -686,6 +692,11 @@ void ReadFromMerge::filterTablesAndCreateChildrenPlans()
 
     selected_tables = getSelectedTables(context);
     child_plans = createChildrenPlans(query_info);
+
+    /// A `'break'`-mode deadline stops that loop early, so drop the tables left unplanned to keep
+    /// `selected_tables` aligned 1:1 with `child_plans` for every reader.
+    if (child_plans->size() < selected_tables.size())
+        selected_tables.resize(child_plans->size());
 }
 
 std::vector<ReadFromMerge::ChildPlan> ReadFromMerge::createChildrenPlans(SelectQueryInfo & query_info_) const
@@ -750,8 +761,12 @@ std::vector<ReadFromMerge::ChildPlan> ReadFromMerge::createChildrenPlans(SelectQ
     {
         /// Building a plan (including query analysis) for every child table can take a long time when
         /// the Merge table matches many tables, so honor `KILL QUERY` and `max_execution_time` between tables.
-        if (query_status)
-            query_status->checkTimeLimit();
+        /// `checkTimeLimit` throws for `KILL QUERY` and `timeout_overflow_mode = 'throw'`; for `'break'` it
+        /// returns false instead, and the caller then truncates `selected_tables` to the plans built here.
+        if (query_status && !query_status->checkTimeLimit())
+            break;
+
+        FailPointInjection::pauseFailPoint(FailPoints::storage_merge_create_children_plans_pause);
 
         const auto & storage = std::get<1>(table);
 

--- a/tests/queries/0_stateless/04763_kill_query_merge_table_plan.reference
+++ b/tests/queries/0_stateless/04763_kill_query_merge_table_plan.reference
@@ -1,0 +1,7 @@
+10
+cancelled: the plan build stopped iterating over children
+1
+break mode: the plan build stopped iterating over children
+break mode client status: 0
+break mode stderr bytes: 0
+break mode planned fewer children than the control

--- a/tests/queries/0_stateless/04763_kill_query_merge_table_plan.reference
+++ b/tests/queries/0_stateless/04763_kill_query_merge_table_plan.reference
@@ -5,3 +5,4 @@ break mode: the plan build stopped iterating over children
 break mode client status: 0
 break mode stderr bytes: 0
 break mode planned fewer children than the control
+break mode built the pipeline of the children it planned

--- a/tests/queries/0_stateless/04763_kill_query_merge_table_plan.sh
+++ b/tests/queries/0_stateless/04763_kill_query_merge_table_plan.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-parallel
+# Tags: no-fasttest, no-parallel, no-random-settings
 # Tag no-fasttest: the deterministic waits below take about 23 seconds of a test that runs in
 # about 28, which is a large share of the fast test per-test timeout of 60 seconds.
 # Tag no-parallel: this test WAITS on a process-global PAUSEABLE failpoint, so a concurrent
 # instance pausing or resuming the same channel would break the synchronisation.
+# Tag no-random-settings: the two-second deadline must not elapse before the first child pauses
+# at the failpoint, and randomized settings change how much analysis work precedes that pause.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -23,7 +25,8 @@ function children_planned()
     $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS text_log"
     $CLICKHOUSE_CLIENT --max_rows_to_read 0 --query "
         SELECT count() FROM system.text_log
-        WHERE query_id = '$1' AND message LIKE 'Building plan for child table%'
+        WHERE event_date >= yesterday() AND event_time >= now() - 600
+          AND query_id = '$1' AND message LIKE 'Building plan for child table%'
     "
 }
 
@@ -139,7 +142,7 @@ rm -f "${CLICKHOUSE_TMP}/04763_break.err"
 # that stops the plan build has also stopped the pipeline, so both outcomes return zero rows.
 control_planned=$(children_planned "${CONTROL_QID}")
 break_planned=$(children_planned "${BREAK_QID}")
-if [ "$control_planned" -ne 4 ]; then
+if [ "$control_planned" -lt 4 ]; then
     echo "FAIL: the control planned ${control_planned} children instead of 4"
 elif [ "$break_planned" -lt "$control_planned" ]; then
     echo "break mode planned fewer children than the control"

--- a/tests/queries/0_stateless/04763_kill_query_merge_table_plan.sh
+++ b/tests/queries/0_stateless/04763_kill_query_merge_table_plan.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel
+# Tag no-fasttest: the deterministic waits below take about 23 seconds of a test that runs in
+# about 28, which is a large share of the fast test per-test timeout of 60 seconds.
+# Tag no-parallel: this test WAITS on a process-global PAUSEABLE failpoint, so a concurrent
+# instance pausing or resuming the same channel would break the synchronisation.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+set -e
+
+FP="storage_merge_create_children_plans_pause"
+CONTROL_QID="merge_plan_control_${CLICKHOUSE_DATABASE}_$$"
+KILL_QID="merge_plan_kill_${CLICKHOUSE_DATABASE}_$$"
+BREAK_QID="merge_plan_break_${CLICKHOUSE_DATABASE}_$$"
+
+# How many children a query built a plan for. `createChildrenPlans` logs one line per child, so
+# this counts exactly how far the loop got, which is what the deadline is supposed to bound.
+function children_planned()
+{
+    $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS text_log"
+    $CLICKHOUSE_CLIENT --max_rows_to_read 0 --query "
+        SELECT count() FROM system.text_log
+        WHERE query_id = '$1' AND message LIKE 'Building plan for child table%'
+    "
+}
+
+function cleanup()
+{
+    $CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT ${FP}" 2>/dev/null ||:
+    $CLICKHOUSE_CLIENT --query "KILL QUERY WHERE query_id IN ('${KILL_QID}', '${BREAK_QID}') FORMAT Null" 2>/dev/null ||:
+    wait 2>/dev/null ||:
+}
+trap cleanup EXIT
+
+for i in $(seq 1 4); do
+    $CLICKHOUSE_CLIENT --query "
+        DROP TABLE IF EXISTS t${i};
+        CREATE TABLE t${i} (x UInt64) ENGINE = MergeTree ORDER BY x;
+        INSERT INTO t${i} VALUES (${i});
+    "
+done
+
+# Positive control: with no deadline every matched child is planned and read.
+$CLICKHOUSE_CLIENT --query_id="${CONTROL_QID}" \
+    --query "SELECT sum(x) FROM merge(currentDatabase(), '^t[0-9]+$')"
+
+# The guard must stop the per-child loop on KILL QUERY.
+$CLICKHOUSE_CLIENT --query "SYSTEM ENABLE FAILPOINT ${FP}"
+
+$CLICKHOUSE_CLIENT --query_id="${KILL_QID}" \
+    --query "SELECT sum(x) FROM merge(currentDatabase(), '^t[0-9]+$')" > /dev/null 2>&1 &
+KILL_PID=$!
+
+# The first child is now paused inside the region under test. Bound the wait: if the query
+# never pauses, this must fail with a diagnostic instead of consuming the per-test timeout.
+if ! timeout 30 $CLICKHOUSE_CLIENT --query "SYSTEM WAIT FAILPOINT ${FP} PAUSE" > /dev/null 2>&1; then
+    echo "FAIL: the query never paused at the failpoint in the kill arm"
+fi
+
+# Set is_killed while the thread sits inside the per-child loop.
+$CLICKHOUSE_CLIENT --query "KILL QUERY WHERE query_id = '${KILL_QID}' FORMAT Null"
+
+# Resume WITHOUT disabling, so the failpoint channel survives for the second observation.
+$CLICKHOUSE_CLIENT --query "SYSTEM NOTIFY FAILPOINT ${FP}"
+
+# A cancelled build must stop, so it must never reach a second child and pause again.
+# Only status 124 means the wait timed out, which is the expected outcome. Status 0 means the
+# loop kept iterating, and any other status means the wait itself failed.
+kill_wait_rc=0
+timeout 10 $CLICKHOUSE_CLIENT --query "SYSTEM WAIT FAILPOINT ${FP} PAUSE" > /dev/null 2>&1 || kill_wait_rc=$?
+if [ "$kill_wait_rc" -eq 0 ]; then
+    echo "FAIL: the loop paused again after the query was cancelled"
+elif [ "$kill_wait_rc" -eq 124 ]; then
+    echo "cancelled: the plan build stopped iterating over children"
+else
+    echo "FAIL: the wait failed with status ${kill_wait_rc}"
+fi
+
+# Release before waiting: on an unpatched build the loop is paused at another child right now,
+# and DISABLE is the only statement that wakes it. NOTIFY would leave the channel enabled and
+# the loop would pause again at the next child.
+$CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT ${FP}"
+timeout 30 tail --pid="${KILL_PID}" -f /dev/null
+wait "${KILL_PID}" 2>/dev/null ||:
+
+$CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS query_log"
+$CLICKHOUSE_CLIENT --query "
+    SELECT count() FROM system.query_log
+    WHERE query_id = '${KILL_QID}' AND current_database = currentDatabase() AND exception_code = 394
+"
+
+# timeout_overflow_mode = 'break' makes checkTimeLimit return false instead of throwing, and such
+# a deadline never sets the killed flag, so ignoring that false would leave the loop
+# uninterruptible. The documented semantics of that mode are to return the partial result, so the
+# build must stop and the query must still succeed over the children planned before the deadline.
+# The pause makes the elapsed time exceed max_execution_time without relying on timing.
+$CLICKHOUSE_CLIENT --query "SYSTEM ENABLE FAILPOINT ${FP}"
+
+# max_execution_time is measured from before parsing, so leave enough margin that the budget
+# cannot elapse during startup and make the guard fire before any child pauses. The discriminator
+# is the sleep below, not this limit, so it must stay well under that sleep.
+$CLICKHOUSE_CLIENT --query_id="${BREAK_QID}" --query "
+    SELECT sum(x) FROM merge(currentDatabase(), '^t[0-9]+$')
+    SETTINGS max_execution_time = 2, timeout_overflow_mode = 'break'
+" > /dev/null 2> "${CLICKHOUSE_TMP}/04763_break.err" &
+BREAK_PID=$!
+
+if ! timeout 30 $CLICKHOUSE_CLIENT --query "SYSTEM WAIT FAILPOINT ${FP} PAUSE" > /dev/null 2>&1; then
+    echo "FAIL: the query never paused at the failpoint in the break arm"
+fi
+sleep 3
+$CLICKHOUSE_CLIENT --query "SYSTEM NOTIFY FAILPOINT ${FP}"
+
+break_wait_rc=0
+timeout 10 $CLICKHOUSE_CLIENT --query "SYSTEM WAIT FAILPOINT ${FP} PAUSE" > /dev/null 2>&1 || break_wait_rc=$?
+if [ "$break_wait_rc" -eq 0 ]; then
+    echo "FAIL: the loop paused again in 'break' overflow mode"
+elif [ "$break_wait_rc" -eq 124 ]; then
+    echo "break mode: the plan build stopped iterating over children"
+else
+    echo "FAIL: the wait failed with status ${break_wait_rc}"
+fi
+
+$CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT ${FP}"
+timeout 30 tail --pid="${BREAK_PID}" -f /dev/null
+break_client_rc=0
+wait "${BREAK_PID}" || break_client_rc=$?
+
+# 'break' returns a partial result, so the client must succeed with no error on stderr.
+echo "break mode client status: ${break_client_rc}"
+echo "break mode stderr bytes: $(wc -c < "${CLICKHOUSE_TMP}/04763_break.err")"
+rm -f "${CLICKHOUSE_TMP}/04763_break.err"
+
+# How far the loop got. The control above plans all four children; honoring the deadline must plan
+# strictly fewer. Note the row count cannot be used as the oracle here: the same elapsed budget
+# that stops the plan build has also stopped the pipeline, so both outcomes return zero rows.
+control_planned=$(children_planned "${CONTROL_QID}")
+break_planned=$(children_planned "${BREAK_QID}")
+if [ "$control_planned" -ne 4 ]; then
+    echo "FAIL: the control planned ${control_planned} children instead of 4"
+elif [ "$break_planned" -lt "$control_planned" ]; then
+    echo "break mode planned fewer children than the control"
+else
+    echo "FAIL: 'break' overflow mode planned all ${break_planned} children"
+fi

--- a/tests/queries/0_stateless/04763_kill_query_merge_table_plan.sh
+++ b/tests/queries/0_stateless/04763_kill_query_merge_table_plan.sh
@@ -30,6 +30,18 @@ function children_planned()
     "
 }
 
+# How many parts a query selected. `ReadFromMergeTree::initializePipeline` increments this while
+# building a child's pipeline, so a non-zero value means the retained plans were really built.
+function parts_selected()
+{
+    $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS query_log"
+    $CLICKHOUSE_CLIENT --max_rows_to_read 0 --query "
+        SELECT sum(ProfileEvents['SelectedParts']) FROM system.query_log
+        WHERE event_date >= yesterday() AND event_time >= now() - 600
+          AND query_id = '$1' AND type != 'QueryStart' AND current_database = currentDatabase()
+    "
+}
+
 function cleanup()
 {
     $CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT ${FP}" 2>/dev/null ||:
@@ -148,4 +160,14 @@ elif [ "$break_planned" -lt "$control_planned" ]; then
     echo "break mode planned fewer children than the control"
 else
     echo "FAIL: 'break' overflow mode planned all ${break_planned} children"
+fi
+
+# Stopping early must keep the children already planned, not discard them: over-truncating
+# `selected_tables` would leave the pipeline empty, which all the assertions above would still
+# accept. A lower bound, because the number of parts is not the property under test.
+break_parts=$(parts_selected "${BREAK_QID}")
+if [ "$break_parts" -ge 1 ]; then
+    echo "break mode built the pipeline of the children it planned"
+else
+    echo "FAIL: 'break' overflow mode selected ${break_parts} parts, so it dropped the planned children"
 fi


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113415
-->


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A `SELECT` from a `Merge` table that exceeds `max_execution_time` with `timeout_overflow_mode = 'break'` now stops building query plans for the remaining matched tables, instead of running full query analysis for every matched table before stopping. The query still finishes without an error, as that mode documents.

### Description

Follow-up to #113415, which added a cancellation checkpoint to the per-child loop in `ReadFromMerge::createChildrenPlans` but discarded `checkTimeLimit`'s return.

`checkTimeLimit` signals a timeout two ways. For `KILL QUERY` and `timeout_overflow_mode = 'throw'` it throws, gated on the killed flag. For `'break'` it returns `false` instead, and a `break` deadline never sets that flag, so the existing checkpoint cannot alter control flow and the loop keeps analysing every remaining matched table.

This stops the loop on the `false` return and truncates `selected_tables` to the plans built, keeping the two aligned 1:1 as `ReadFromMerge` documents. The stop is a `break` rather than a throw because that is what the setting declares (`Settings.cpp`: "stop executing the query and return the partial result, as if the source data ran out"), so the query stays silent and successful. No new error code, and `KILL QUERY` and `throw` mode are unaffected.

The behaviour change is confined to that mode. The deadline is shared with the pipeline, so such a query has already exceeded its execution-time budget: the saving is analysis work, not rows.

Validated with a new stateless test that paces the loop with a `PAUSEABLE` failpoint instead of timing it. Pre-fix the `break` arm fails: all 4 children are planned and the loop pauses at a second child. With the fix it stops after the first, and the client still exits 0 with empty stderr. Four mutants each redden only their own arm: reverting the guard, deleting the failpoint, and either direction of the truncation. Reverting it aborts in `initializePipeline` with `std::out_of_range`; over-truncating leaves the pipeline empty, which every other assertion accepts, so both directions are pinned. 50/50 runs pass (p50 26.1 s); the test opts out of settings randomization, so that is the only meaningful arm.