### PR TITLE
Docs: clarify AWS PrivateLink cross-region setup

### DIFF
--- a/docs/products/cloud/guides/security/connectivity/private-networking/aws-privatelink.mdx
+++ b/docs/products/cloud/guides/security/connectivity/private-networking/aws-privatelink.mdx
@@ -50,7 +50,10 @@ ClickHouse Cloud supports [cross-region PrivateLink](https://aws.amazon.com/abou
 - us-west-1
 - us-east-2
 - us-east-1
-Pricing considerations: AWS will charge users for cross region data transfer, see pricing [here](https://aws.amazon.com/privatelink/pricing/).
+</Note>
+
+<Note>
+AWS charges for cross-region data transfer. See [AWS PrivateLink pricing](https://aws.amazon.com/privatelink/pricing/) for details.
 </Note>
 
 **Please complete the following to enable AWS PrivateLink**:
@@ -144,7 +147,9 @@ Select **Endpoint services that use NLBs and GWLBs** and use `Service name`<sup>
 
 <Image img="/images/cloud/security/aws-privatelink-endpoint-settings.webp" size="md" alt="AWS PrivateLink Endpoint Settings" border/>
 
-If you want to establish a cross-regional connection via PrivateLink, enable the "Cross region endpoint" checkbox and specify the service region. The service region is where the ClickHouse instance is running.
+<Note>
+For a cross-region connection, enable the **Cross region endpoint** checkbox and specify the service region where your ClickHouse service is running.
+</Note>
 
 If you get a "Service name couldn't be verified." error, please contact Customer Support to request adding new regions to the supported regions list.
 


### PR DESCRIPTION
Clarifies the AWS PrivateLink cross-region guidance by separating data transfer pricing into its own note and highlighting the required AWS console option. This makes the configuration step and its cost implications easier to discover.

Related: https://linear.app/clickhouse/issue/DOC-946/clarify-aws-privatelink-cross-region-docs

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.994` (included in `26.8` and later)
<!-- ch-version-info:end -->