### PR TITLE
Docs: document horizontal autoscaling

### DIFF
--- a/docs/products/cloud/features/autoscaling/horizontal-autoscaling.mdx
+++ b/docs/products/cloud/features/autoscaling/horizontal-autoscaling.mdx
@@ -30,7 +30,7 @@ The gap between the watermarks provides hysteresis so the service doesn't oscill
 
 ## Enable horizontal autoscaling {#enable-horizontal-autoscaling}
 
-Horizontal autoscaling is configured from the **Settings** page of your service, or via the [ClickHouse Cloud API](/products/cloud/api-reference/service/instance-scaling-update).
+Horizontal autoscaling is configured from the **Settings** page of your service, or via the [ClickHouse Cloud replica scaling API](/products/cloud/api-reference/service/update-service-auto-scaling-settings).
 
 To enable it:
 

--- a/docs/products/cloud/features/autoscaling/horizontal-autoscaling.mdx
+++ b/docs/products/cloud/features/autoscaling/horizontal-autoscaling.mdx
@@ -1,0 +1,80 @@
+---
+sidebarTitle: 'Horizontal autoscaling'
+slug: /cloud/features/autoscaling/horizontal-autoscaling
+description: 'Configure horizontal autoscaling in ClickHouse Cloud'
+keywords: ['horizontal autoscaling', 'autoscaling', 'replicas', 'concurrent queries', 'scaling']
+title: 'Horizontal autoscaling'
+doc_type: 'guide'
+---
+
+<Note>
+Horizontal autoscaling is in Private Preview and is available on the Scale and Enterprise plans. To request access, contact your ClickHouse account team or support.
+</Note>
+
+Horizontal autoscaling automatically adds or removes replicas in your service in response to workload demand. Where vertical autoscaling changes the size of each replica, horizontal autoscaling changes the number of replicas, making it well suited to workloads where demand comes from more queries rather than heavier queries.
+
+## How it works {#how-it-works}
+
+The autoscaler continuously monitors your service and makes horizontal scaling recommendations every 10 minutes based on three signals:
+
+- **Concurrent queries:** Maximum number of queries running across replicas
+- **CPU utilization:** Maximum CPU usage across replicas
+- **Memory utilization:** Maximum memory usage across replicas
+
+The autoscaler targets 60% utilization across the service:
+
+- **Scale out:** When utilization rises above the high watermark of 80%, replicas are added up to your configured maximum
+- **Scale in:** When utilization falls below the low watermark of 45%, replicas are removed down to your configured minimum
+
+The gap between the watermarks provides hysteresis so the service doesn't oscillate between scaling out and in. Scale-in is intentionally more conservative than scale-out to protect running workloads.
+
+## Enable horizontal autoscaling {#enable-horizontal-autoscaling}
+
+Horizontal autoscaling is configured from the **Settings** page of your service, or via the [ClickHouse Cloud API](/products/cloud/api-reference/service/instance-scaling-update).
+
+To enable it:
+
+1. Pin the vertical size of your replicas by setting minimum memory equal to maximum memory. Horizontal autoscaling requires a fixed replica size for now; vertical and horizontal autoscaling can't be active on a service at the same time.
+2. Set maximum replicas greater than minimum replicas. The autoscaler operates within these bounds. Setting the two values equal pins the service to a fixed replica count and disables horizontal autoscaling.
+
+<Note>
+Services can scale horizontally to a maximum of 20 replicas. If you need additional replicas, contact our support team.
+</Note>
+
+## Configure your clients {#configure-your-clients}
+
+New replicas only help if your clients connect to them. Long-lived connections stay pinned to the replicas that existed when the connection was opened, so clients must refresh connections regularly to pick up new replicas.
+
+Configure clients in one of the following ways:
+
+- **HTTP protocol (recommended):** Connections are short-lived by default, so traffic spreads to new replicas automatically
+- **Native protocol:** Set the maximum connection lifetime to approximately 30 seconds so connections are re-established regularly
+
+## Choose the right replica size {#choose-the-right-replica-size}
+
+Horizontal autoscaling works best when each replica is large enough to comfortably run your typical queries. Adding replicas increases the number of queries the service can run in parallel; it doesn't increase the memory available to any single query.
+
+Recommended approach:
+
+1. Find a vertical size at which a few of your typical queries run comfortably without memory errors.
+2. Pin the service to that size.
+3. Let horizontal autoscaling add replicas as query volume grows.
+
+If replicas are too small for the workload, the autoscaler may add replicas that can't serve your queries. The autoscaler includes safeguards against this—for example, it won't scale out in response to a single oversized query that additional replicas can't help with—but correct sizing remains an important factor.
+
+## Load distribution {#load-distribution}
+
+Horizontal autoscaling assumes load is distributed evenly across replicas. If one replica runs at 90% utilization while others sit at 10%, adding replicas won't help, and the load imbalance should be addressed first. The autoscaler detects imbalanced load and won't recommend scaling out while it persists.
+
+Common causes of imbalance include long-lived connections concentrated on a few replicas (see [Configure your clients](#configure-your-clients)) and session-pinned workloads.
+
+## Observe scaling activity {#observe-scaling-activity}
+
+Scaling events are visible on the service's metrics dashboard in the ClickHouse Cloud console, which shows the current number of replicas and total resource allocation.
+
+## Known limitations {#known-limitations}
+
+- Horizontal autoscaling is in Private Preview and must be enabled for your organization by the ClickHouse support team.
+- The vertical replica size must be pinned by setting minimum memory equal to maximum memory.
+- Each service is limited to a maximum of 20 replicas. Contact support if you need additional replicas.
+- Recommendations are made every 10 minutes; horizontal autoscaling isn't designed to absorb sub-minute spikes. For predictable peaks, consider [scheduled scaling](/products/cloud/features/autoscaling/scheduled-scaling).

--- a/docs/products/cloud/features/autoscaling/overview.mdx
+++ b/docs/products/cloud/features/autoscaling/overview.mdx
@@ -19,7 +19,7 @@ Scale and Enterprise tiers support both single and multi-replica services, where
 
 ## How scaling works in ClickHouse Cloud {#how-scaling-works-in-clickhouse-cloud}
 
-ClickHouse Cloud supports vertical autoscaling and manual horizontal scaling for Scale tier services. [Horizontal autoscaling](/products/cloud/features/autoscaling/horizontal-autoscaling) is available in Private Preview for Scale and Enterprise tier services.
+ClickHouse Cloud supports manual horizontal scaling for Scale and Enterprise tier services. Scale tier services also support vertical autoscaling; Enterprise tier vertical autoscaling support depends on the profile, as described below. [Horizontal autoscaling](/products/cloud/features/autoscaling/horizontal-autoscaling) is available in Private Preview for Scale and Enterprise tier services.
 
 For Enterprise tier services scaling works as follows:
 

--- a/docs/products/cloud/features/autoscaling/overview.mdx
+++ b/docs/products/cloud/features/autoscaling/overview.mdx
@@ -19,7 +19,7 @@ Scale and Enterprise tiers support both single and multi-replica services, where
 
 ## How scaling works in ClickHouse Cloud {#how-scaling-works-in-clickhouse-cloud}
 
-Currently, ClickHouse Cloud supports vertical autoscaling and manual horizontal scaling for Scale tier services.
+ClickHouse Cloud supports vertical autoscaling and manual horizontal scaling for Scale tier services. [Horizontal autoscaling](/products/cloud/features/autoscaling/horizontal-autoscaling) is available in Private Preview for Scale and Enterprise tier services.
 
 For Enterprise tier services scaling works as follows:
 
@@ -40,6 +40,7 @@ This balances the need for existing queries to complete, while at the same time 
 ## Learn more {#learn-more}
 
 - [Vertical autoscaling](/products/cloud/features/autoscaling/vertical) — Automatic CPU and memory scaling based on usage
+- [Horizontal autoscaling](/products/cloud/features/autoscaling/horizontal-autoscaling) — Automatic replica scaling based on workload demand
 - [Horizontal scaling](/products/cloud/features/autoscaling/horizontal) — Manual replica scaling via API or UI
 - [Make Before Break (MBB)](/products/cloud/features/autoscaling/make-before-break) — How ClickHouse Cloud performs seamless scaling operations
 - [Automatic idling](/products/cloud/features/autoscaling/idling) — Cost savings through automatic service suspension

--- a/docs/products/cloud/navigation.json
+++ b/docs/products/cloud/navigation.json
@@ -41,6 +41,7 @@
                   "pages": [
                     "products/cloud/features/autoscaling/overview",
                     "products/cloud/features/autoscaling/vertical",
+                    "products/cloud/features/autoscaling/horizontal-autoscaling",
                     "products/cloud/features/autoscaling/horizontal",
                     "products/cloud/features/autoscaling/make-before-break",
                     "products/cloud/features/autoscaling/idling",


### PR DESCRIPTION
Adds a standalone horizontal autoscaling guide for ClickHouse Cloud Private Preview. The page explains scaling signals and thresholds, configuration requirements, client connection behavior, replica sizing, load distribution, observability, and current limitations; it is also linked from the autoscaling overview and Cloud navigation.

This gives eligible Scale and Enterprise customers the operational guidance needed to configure and use horizontal autoscaling safely.

Linear: https://linear.app/clickhouse/issue/DOC-917/create-a-new-docs-page-for-horizontal-autoscaling

The scoped Mintlify validation passes without warnings or errors.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1083` (included in `26.8` and later)
<!-- ch-version-info:end -->