### PR TITLE
Do not pin non-serializable placeholder columns into the INTERPOLATE step

### DIFF
--- a/src/Planner/PlannerExpressionAnalysis.cpp
+++ b/src/Planner/PlannerExpressionAnalysis.cpp
@@ -560,8 +560,14 @@ SortAnalysisResult analyzeSort(
         /// so here we add materialized ORDER BY columns manually, and append everything else after.
         ActionsDAG before_interpolate_actions_dag(before_sort_actions->dag.getResultColumns());
         for (const auto & out : actions_chain.getLastStepAvailableOutputColumns())
+        {
+            /// `Set` and `Function` placeholders have no serialization, so an output of this step
+            /// carrying one cannot be sent across a distributed stage boundary.
+            if (WhichDataType(out.type).isSet() || WhichDataType(out.type).isFunction())
+                continue;
             if (!before_sort_actions_dag_output_node_names.contains(out.name))
                 before_interpolate_actions_dag.getOutputs().push_back(&before_interpolate_actions_dag.addInput(out));
+        }
 
         for (auto & interpolate_node : interpolate_list_node.getNodes())
         {

--- a/tests/queries/0_stateless/04733_parallel_replicas_with_fill_interpolate_in_set.reference
+++ b/tests/queries/0_stateless/04733_parallel_replicas_with_fill_interpolate_in_set.reference
@@ -1,0 +1,71 @@
+scalar IN
+0	7
+1	8
+2	8
+3	7
+empty INTERPOLATE
+0	
+1	8
+2	8
+3	8
+subquery IN
+0	7
+1	8
+2	8
+3	7
+NOT IN
+0	7
+1	8
+2	8
+3	7
+IN in the SELECT list
+0	1
+1	1
+2	1
+3	1
+lambda, single node
+0	['z']
+1	['a8']
+2	['a8']
+3	['z']
+lambda
+0	['z']
+1	['a8']
+2	['a8']
+3	['z']
+clusterAllReplicas
+0	7
+1	8
+1	8
+1	8
+2	8
+2	8
+2	8
+3	7
+unprojected interpolate source
+0		0
+1	original	1
+2		3
+3		3
+4	original	4
+7	original	7
+Nullable(Nothing)
+0	7	\N
+1	8	\N
+2	8	\N
+3	7	\N
+Array(Nothing)
+0	7	[]
+1	8	[]
+2	8	[]
+3	7	[]
+Nullable(Nothing) as interpolate target
+0	\N
+1	\N
+2	\N
+3	\N
+Array(Nothing) as interpolate target
+0	[]
+1	[]
+2	[]
+3	[]

--- a/tests/queries/0_stateless/04733_parallel_replicas_with_fill_interpolate_in_set.sql
+++ b/tests/queries/0_stateless/04733_parallel_replicas_with_fill_interpolate_in_set.sql
@@ -8,8 +8,8 @@
 -- replica producing a mergeable state the pipeline output header could not be sent over the wire:
 -- `Code: 48 ... Serialization is not implemented for data type Set`.
 --
--- parallel_replicas_local_plan = 0 forces the read remote, which makes the failure deterministic;
--- with the default 1 it reproduced in roughly 3 of 30 runs.
+-- parallel_replicas_local_plan = 0 forces the read remote, which makes the failure deterministic
+-- (30 of 30 trials); at its default of 1 it reproduced in 8 of 100 trials.
 
 DROP TABLE IF EXISTS t_04733;
 CREATE TABLE t_04733 (k UInt32, s String) ENGINE = MergeTree ORDER BY k;
@@ -21,6 +21,20 @@ CREATE TABLE t_04733_unprojected (n Float32, source String, inter UInt64, inter2
 ENGINE = MergeTree ORDER BY n;
 INSERT INTO t_04733_unprojected SELECT toFloat32(number % 10), 'original', number, number + 1
 FROM numbers(10) WHERE (number % 3) = 1;
+
+-- serialize_query_plan = 0 because WITH FILL is not supported in serialized sort descriptions
+-- (serializeSortDescription throws NOT_IMPLEMENTED) and the CI `distributed plan` shard turns
+-- serialize_query_plan on globally; this test exercises the placeholder pin, not plan serialization.
+SET serialize_query_plan = 0;
+
+-- The fix is in the analyzer planner, so under the old-analyzer job every arm below would pass on
+-- unpatched master and the test would be vacuous there.
+SET enable_analyzer = 1;
+
+-- automatic_parallel_replicas_mode is randomized to 2 by the test runner, and at a non-zero value
+-- buildContext clears enable_parallel_replicas (InterpreterSelectQueryAnalyzer.cpp:137-156). That
+-- happens after the per-query SETTINGS are applied, so the SETTINGS clauses below cannot win.
+SET automatic_parallel_replicas_mode = 0;
 
 -- Rows are asserted, not merely the absence of an exception: a test checking only that the query
 -- runs would still pass if INTERPOLATE silently stopped interpolating. The expected values below

--- a/tests/queries/0_stateless/04733_parallel_replicas_with_fill_interpolate_in_set.sql
+++ b/tests/queries/0_stateless/04733_parallel_replicas_with_fill_interpolate_in_set.sql
@@ -1,0 +1,137 @@
+-- Regression test for the family of https://github.com/ClickHouse/ClickHouse/issues/111728
+-- (closed by https://github.com/ClickHouse/ClickHouse/pull/111919, which did not cover the
+-- read_tasks parallel-replicas path).
+--
+-- ORDER BY ... WITH FILL ... INTERPOLATE used to make the "Before INTERPOLATE" step pin every
+-- available chain column as one of its outputs, including the placeholder column of an IN set
+-- (type `Set`) or of a lambda (type `Function`). Those two types have no serialization, so on a
+-- replica producing a mergeable state the pipeline output header could not be sent over the wire:
+-- `Code: 48 ... Serialization is not implemented for data type Set`.
+--
+-- parallel_replicas_local_plan = 0 forces the read remote, which makes the failure deterministic;
+-- with the default 1 it reproduced in roughly 3 of 30 runs.
+
+DROP TABLE IF EXISTS t_04733;
+CREATE TABLE t_04733 (k UInt32, s String) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_04733 VALUES (1, '8');
+INSERT INTO t_04733 VALUES (2, '8');
+
+DROP TABLE IF EXISTS t_04733_unprojected;
+CREATE TABLE t_04733_unprojected (n Float32, source String, inter UInt64, inter2 UInt64)
+ENGINE = MergeTree ORDER BY n;
+INSERT INTO t_04733_unprojected SELECT toFloat32(number % 10), 'original', number, number + 1
+FROM numbers(10) WHERE (number % 3) = 1;
+
+-- Rows are asserted, not merely the absence of an exception: a test checking only that the query
+-- runs would still pass if INTERPOLATE silently stopped interpolating. The expected values below
+-- come from the same queries with enable_parallel_replicas = 0.
+
+SELECT 'scalar IN';
+SELECT k, s FROM t_04733 WHERE s IN ('8')
+ORDER BY k WITH FILL FROM 0 TO 4 INTERPOLATE (s AS '7')
+SETTINGS parallel_replicas_local_plan = 0, enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1;
+
+SELECT 'empty INTERPOLATE';
+SELECT k, s FROM t_04733 WHERE s IN ('8')
+ORDER BY k WITH FILL FROM 0 TO 4 INTERPOLATE ()
+SETTINGS parallel_replicas_local_plan = 0, enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1;
+
+SELECT 'subquery IN';
+SELECT k, s FROM t_04733 WHERE s IN (SELECT '8')
+ORDER BY k WITH FILL FROM 0 TO 4 INTERPOLATE (s AS '7')
+SETTINGS parallel_replicas_local_plan = 0, enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1;
+
+SELECT 'NOT IN';
+SELECT k, s FROM t_04733 WHERE s NOT IN ('9')
+ORDER BY k WITH FILL FROM 0 TO 4 INTERPOLATE (s AS '7')
+SETTINGS parallel_replicas_local_plan = 0, enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1;
+
+SELECT 'IN in the SELECT list';
+SELECT k, s IN ('8') AS f FROM t_04733
+ORDER BY k WITH FILL FROM 0 TO 4 INTERPOLATE (f AS 1)
+SETTINGS parallel_replicas_local_plan = 0, enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1;
+
+-- Second placeholder type: a lambda's `Function(String -> String)`. It needs no stage boundary at
+-- all: `FillingTransform` inserts a default into every header column when it synthesizes a row, and
+-- the placeholder cannot accept one, so a plain single-node query fails with
+-- `Code: 48 ... Cannot insert into Function`.
+SELECT 'lambda, single node';
+SELECT k, arrayMap(x -> x || s, ['a']) AS m FROM t_04733
+ORDER BY k WITH FILL FROM 0 TO 4 INTERPOLATE (m AS ['z'])
+SETTINGS enable_parallel_replicas = 0;
+
+SELECT 'lambda';
+SELECT k, arrayMap(x -> x || s, ['a']) AS m FROM t_04733
+ORDER BY k WITH FILL FROM 0 TO 4 INTERPOLATE (m AS ['z'])
+SETTINGS parallel_replicas_local_plan = 0, enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1;
+
+-- Each of the three replicas reads the same table, so every stored row appears three times.
+SELECT 'clusterAllReplicas';
+SELECT k, s FROM clusterAllReplicas('test_cluster_one_shard_three_replicas_localhost', currentDatabase(), t_04733)
+WHERE s IN ('8')
+ORDER BY k WITH FILL FROM 0 TO 4 INTERPOLATE (s AS '7')
+SETTINGS parallel_replicas_local_plan = 0, enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1;
+
+-- Controls. These are correct before the fix and must stay correct: they pin the two ways a
+-- narrower or a wider rule would go wrong.
+
+-- A storable column that only an INTERPOLATE expression references, and the SELECT does not
+-- project, must stay pinned into the header.
+SELECT 'unprojected interpolate source';
+SELECT n, source, inter FROM t_04733_unprojected
+ORDER BY n WITH FILL FROM 0 TO 4 INTERPOLATE (inter AS inter2 + inter)
+SETTINGS parallel_replicas_local_plan = 0, enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1;
+
+-- `Nothing` overrides doGetSerialization and serializes fine, so `Nullable(Nothing)` and
+-- `Array(Nothing)` must keep travelling in the header. `z` and `e` below are projected but are
+-- neither an ORDER BY key nor an INTERPOLATE target, which is what makes them reach the header
+-- through the same code path the fix filters; a rule keyed on `cannotBeStoredInTables()` instead
+-- drops them and these two queries fail with `Code: 47`.
+SELECT 'Nullable(Nothing)';
+SELECT k, s, NULL AS z FROM t_04733 WHERE s = '8'
+ORDER BY k WITH FILL FROM 0 TO 4 INTERPOLATE (s AS '7')
+SETTINGS parallel_replicas_local_plan = 0, enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1;
+
+SELECT 'Array(Nothing)';
+SELECT k, s, [] AS e FROM t_04733 WHERE s = '8'
+ORDER BY k WITH FILL FROM 0 TO 4 INTERPOLATE (s AS '7')
+SETTINGS parallel_replicas_local_plan = 0, enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1;
+
+-- The same two types as INTERPOLATE targets, which reach the DAG by a different route (the
+-- interpolate expressions are added unconditionally), so they do not discriminate the rule above.
+SELECT 'Nullable(Nothing) as interpolate target';
+SELECT k, NULL AS z FROM t_04733
+ORDER BY k WITH FILL FROM 0 TO 4 INTERPOLATE (z AS NULL)
+SETTINGS parallel_replicas_local_plan = 0, enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1;
+
+SELECT 'Array(Nothing) as interpolate target';
+SELECT k, [] AS e FROM t_04733
+ORDER BY k WITH FILL FROM 0 TO 4 INTERPOLATE (e AS [])
+SETTINGS parallel_replicas_local_plan = 0, enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1;
+
+DROP TABLE t_04733;
+DROP TABLE t_04733_unprojected;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/111919
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `ORDER BY ... WITH FILL ... INTERPOLATE` being rejected with `NOT_IMPLEMENTED` when the query also contains an `IN` predicate and runs with `enable_parallel_replicas = 1` (`Serialization is not implemented for data type Set`), or when it selects a lambda expression such as `arrayMap(x -> x || s, ['a'])` (`Cannot insert into Function`, reachable on a single node).

### Description

`ORDER BY ... WITH FILL ... INTERPOLATE` made the "Before INTERPOLATE" step declare every column still available in the actions chain as one of its own outputs. Two types in that set have no serialization: the placeholder of an `IN` set (`Set`) and of a lambda (`Function`). Both derive from `IDataTypeDummy`, whose `getSerialization` throws.

Pinning such a column as a step output has two user-visible consequences.

* Under parallel replicas the placeholder reaches the pipeline output header of a replica producing a mergeable state, and `NativeWriter` cannot send that header: `Code: 48 ... Serialization is not implemented for data type Set`. Deterministic with `parallel_replicas_local_plan = 0` (30 of 30 trials) and intermittent at its default of 1 (8 of 100 trials).
* For a lambda no distributed boundary is needed: `FillingTransform` inserts a default into every header column when it synthesizes a filled row, and the placeholder cannot accept one, so a single-node query fails with `Code: 48 ... Cannot insert into Function`.

The fix skips those columns when the step's outputs are built. `Set` and `Function` are the complete set of query-plan-reachable types with no serialization: of the three `IDataTypeDummy` subclasses in `src/DataTypes/`, only these two inherit the throwing `doGetSerialization`, while `DataTypeNothing` overrides it and returns a working `SerializationNothing`. That is also why `Nullable(Nothing)` and `Array(Nothing)` travel in headers today and must keep doing so. Every storable column is still pinned as before, so `EXPLAIN PLAN header = 1` is unchanged for any query that works today.

This is a residual of the family closed by #111919. That change gated the two sites that *execute* filling, which is correct; the defect is that the step's DAG hoards columns it does not need. None of the 6 stateless tests it shipped uses `IN`.

<details>
<summary>Validation</summary>

Debug build, one server with a 3-replica `test_cluster_one_shard_three_replicas_localhost`, restarted per arm with `SELECT lower(buildId())` asserted equal to the binary's own build id before every verdict.

Both directions, through `tests/clickhouse-test`: the new test fails on unpatched master with `Code: 48 ... data type Set` and passes with the fix. 50 of 50 randomized runs pass with the fix and 50 of 50 fail on unpatched master, so it is not vacuous.

The test pins `serialize_query_plan = 0` (as all six tests #111919 shipped do), `enable_analyzer = 1` and `automatic_parallel_replicas_mode = 0`. Each pin was verified load-bearing by removing it and re-running under the CI condition it defends against, reproduced with the real `tests/config/users.d` overlay.

Three mutants, each reddening on a distinct error and pinning one rejected alternative:

| mutant | error |
|---|---|
| no filter at all (unpatched master) | `Code: 48` `data type Set` |
| filter on `cannotBeStoredInTables()` | `Code: 47` `Unknown column: _CAST`, since it also drops `Nullable(Nothing)` / `Array(Nothing)` |
| add the columns as DAG inputs only | `Code: 10` `Not found column __table1.inter2`: an INTERPOLATE expression may reference a column the `SELECT` does not project, and the output pin is what keeps it alive |

Name-scoped regression suite (`interpolate` / `with_fill`, 62 runnable tests including the new one, randomization off): 62 verdicts per arm, the fix scoring 61 pass / 1 fail and unpatched master 60 pass / 2 fail. The only-in-fix failure set is empty and the only-in-base one is exactly the new test. The remaining shared failure is `04064_unused_interpolate_columns_without_wrapper`, which carries `no-parallel-replicas` and cannot pass in a parallel-replicas rig (#75186); its three `EXPLAIN PLAN header = 1` outputs were compared directly instead and are byte-identical to its committed reference on both arms.

</details>