### PR TITLE
Fix materialized CTE read before materialization on EXPLAIN ANALYZE

### DIFF
--- a/src/QueryPipeline/QueryPipeline.cpp
+++ b/src/QueryPipeline/QueryPipeline.cpp
@@ -18,7 +18,6 @@
 #include <Processors/FractionalLimitTransform.h>
 #include <Processors/QueryPlan/ReadFromPreparedSource.h>
 #include <Processors/Sinks/EmptySink.h>
-#include <Processors/Sinks/NullSink.h>
 #include <Processors/Sinks/SinkToStorage.h>
 #include <Processors/Sources/DelayedSource.h>
 #include <Processors/Sources/NullSource.h>
@@ -28,6 +27,7 @@
 #include <Processors/Transforms/AggregatingTransform.h>
 #include <Processors/Transforms/CountingTransform.h>
 #include <Processors/Transforms/CreatingSetsTransform.h>
+#include <Processors/Transforms/DroppingTransform.h>
 #include <Processors/Transforms/ExpressionTransform.h>
 #include <Processors/Transforms/LimitByTransform.h>
 #include <Processors/Transforms/LimitsCheckingTransform.h>
@@ -502,16 +502,36 @@ QueryPipeline::QueryPipeline(std::shared_ptr<IOutputFormat> format)
     processors->emplace_back(std::move(format));
 }
 
-static void drop(OutputPort *& port, Processors & processors)
+/// Discards `totals`/`extremes` without adding a node that has no outputs: such a node is seeded by
+/// `ExecutingGraph::initializeExecution` and closes its input at once, and for an output of a
+/// `DelayedPortsProcessor` that also closes the gate's paired input. Requires `output != nullptr`.
+static void dropTotalsAndExtremesViaTransform(
+    OutputPort *& output, OutputPort *& totals, OutputPort *& extremes, Processors & processors)
 {
-    if (!port)
+    if (!totals && !extremes)
         return;
 
-    auto null_sink = std::make_shared<NullSink>(port->getSharedHeader());
-    connect(*port, null_sink->getPort());
+    chassert(output);
 
-    processors.emplace_back(std::move(null_sink));
-    port = nullptr;
+    auto dropping = std::make_shared<DroppingTransform>(
+        output->getSharedHeader(), /*num_streams_=*/1, totals != nullptr, extremes != nullptr);
+
+    connect(*output, dropping->getInputs().front());
+
+    if (totals)
+    {
+        connect(*totals, *dropping->getTotalsPort());
+        totals = nullptr;
+    }
+
+    if (extremes)
+    {
+        connect(*extremes, *dropping->getExtremesPort());
+        extremes = nullptr;
+    }
+
+    output = &dropping->getOutputs().front();
+    processors.emplace_back(std::move(dropping));
 }
 
 QueryPipeline::QueryPipeline(std::shared_ptr<SinkToStorage> sink) : QueryPipeline(Chain(std::move(sink))) {}
@@ -521,8 +541,7 @@ void QueryPipeline::complete(std::shared_ptr<ISink> sink)
     if (!pulling())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Pipeline must be pulling to be completed with sink");
 
-    drop(totals, *processors);
-    drop(extremes, *processors);
+    dropTotalsAndExtremesViaTransform(output, totals, extremes, *processors);
 
     connect(*output, sink->getPort());
     processors->emplace_back(std::move(sink));
@@ -536,8 +555,7 @@ void QueryPipeline::complete(Chain chain)
 
     resources = chain.detachResources();
 
-    drop(totals, *processors);
-    drop(extremes, *processors);
+    dropTotalsAndExtremesViaTransform(output, totals, extremes, *processors);
 
     for (auto processor : chain.getProcessors())
         processors->emplace_back(std::move(processor));

--- a/tests/queries/0_stateless/04815_materialized_cte_explain_analyze_aux_ports.reference
+++ b/tests/queries/0_stateless/04815_materialized_cte_explain_analyze_aux_ports.reference
@@ -1,0 +1,52 @@
+explain analyze with extremes
+1
+
+1
+1
+explain analyze with totals
+1
+explain analyze with totals and extremes
+1
+
+1
+1
+explain analyze with limit and extremes
+1
+
+1
+1
+select with extremes
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+
+0
+9
+select with totals
+0
+1
+2
+3
+4
+
+0
+select with limit 0 and extremes
+select with limit 1 and extremes
+0
+
+0
+0
+in subquery without a materialized cte
+0
+1
+2
+
+0
+2

--- a/tests/queries/0_stateless/04815_materialized_cte_explain_analyze_aux_ports.sql
+++ b/tests/queries/0_stateless/04815_materialized_cte_explain_analyze_aux_ports.sql
@@ -1,0 +1,61 @@
+-- Tags: no-fasttest
+-- no-fasttest: EXPLAIN ANALYZE executes the pipeline, which is slow in a fast-test build.
+
+SET enable_analyzer = 1;
+SET enable_materialized_cte = 1;
+
+-- A materialized CTE read behind an IN-subquery sits under a DelayedPortsProcessor gate.
+-- Completing such a pipeline with a sink used to discard the totals/extremes ports with a
+-- node that has no outputs; such a node is seeded before the pipeline runs and closed the
+-- gate's paired input, so the CTE was read before it had been materialized.
+--
+-- EXPLAIN ANALYZE is wrapped in viewExplain because its own output carries timings.
+
+SELECT 'explain analyze with extremes';
+SELECT count() > 0 FROM viewExplain('EXPLAIN ANALYZE', 'processors = 1', (
+    WITH a AS MATERIALIZED (SELECT number AS id FROM numbers(10))
+    SELECT id FROM a WHERE id IN (SELECT id FROM a)
+)) SETTINGS extremes = 1;
+
+SELECT 'explain analyze with totals';
+SELECT count() > 0 FROM viewExplain('EXPLAIN ANALYZE', 'processors = 1', (
+    WITH a AS MATERIALIZED (SELECT number AS id FROM numbers(10))
+    SELECT id FROM a WHERE id IN (SELECT id FROM a) GROUP BY id WITH TOTALS
+));
+
+SELECT 'explain analyze with totals and extremes';
+SELECT count() > 0 FROM viewExplain('EXPLAIN ANALYZE', 'processors = 1', (
+    WITH a AS MATERIALIZED (SELECT number AS id FROM numbers(10))
+    SELECT id FROM a WHERE id IN (SELECT id FROM a) GROUP BY id WITH TOTALS
+)) SETTINGS extremes = 1;
+
+SELECT 'explain analyze with limit and extremes';
+SELECT count() > 0 FROM viewExplain('EXPLAIN ANALYZE', 'processors = 1', (
+    WITH a AS MATERIALIZED (SELECT number AS id FROM numbers(10))
+    SELECT id FROM a WHERE id IN (SELECT id FROM a) ORDER BY id LIMIT 1
+)) SETTINGS extremes = 1;
+
+-- Results must be unchanged: the totals/extremes streams are still discarded, and the
+-- streams that are kept are still produced in full.
+SELECT 'select with extremes';
+WITH a AS MATERIALIZED (SELECT number AS id FROM numbers(10))
+SELECT id FROM a WHERE id IN (SELECT id FROM a) ORDER BY id
+SETTINGS extremes = 1;
+
+SELECT 'select with totals';
+WITH a AS MATERIALIZED (SELECT number AS id FROM numbers(5))
+SELECT id FROM a WHERE id IN (SELECT id FROM a) GROUP BY id WITH TOTALS ORDER BY id;
+
+SELECT 'select with limit 0 and extremes';
+WITH a AS MATERIALIZED (SELECT number AS id FROM numbers(10))
+SELECT id FROM a WHERE id IN (SELECT id FROM a) ORDER BY id LIMIT 0
+SETTINGS extremes = 1;
+
+SELECT 'select with limit 1 and extremes';
+WITH a AS MATERIALIZED (SELECT number AS id FROM numbers(10))
+SELECT id FROM a WHERE id IN (SELECT id FROM a) ORDER BY id LIMIT 1
+SETTINGS extremes = 1;
+
+SELECT 'in subquery without a materialized cte';
+SELECT number FROM numbers(5) WHERE number IN (SELECT number FROM numbers(3)) ORDER BY number
+SETTINGS extremes = 1;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/110176
Related: https://github.com/ClickHouse/ClickHouse/pull/111194
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the `LOGICAL_ERROR` `Reading from materialized CTE '...' before its materialization completed - DelayedPortsProcessor gate is missing in the query plan` when `EXPLAIN ANALYZE` runs a query that reads a materialized CTE behind an `IN` subquery together with `extremes = 1` or `GROUP BY ... WITH TOTALS`.


### Description

`QueryPipelineBuilder::addPipelineBefore` routes the totals and extremes streams through the `DelayedPortsProcessor` that gates a materialized CTE read, so they are gate output ports.

`QueryPipeline::complete` discarded them by attaching a `NullSink`. A `NullSink` has no outputs, so `ExecutingGraph::initializeExecution` seeds it and it runs first, and its `prepare` closes its input without ever pulling. That finishes a gate output; the gate finishes the pair and closes the paired input; the gated sub-pipeline is released. The CTE read then runs before `MaterializingCTETransform` has built it and the fail-fast check in `ReadFromMemoryStorageStep` throws, aborting the server in a build with assertions.

The two streams are now discarded with a `DroppingTransform` on the main output instead. It forwards the data stream 1:1 and drains totals/extremes, so it keeps data outputs and is not seeded. This is the mechanism `641fc75ea3f0d37` already established for the builder's own drop sites; extending it here leaves the file with no producer of an output-less discard node, so `drop` and the `NullSink.h` include are deleted. The helper returns immediately when neither port exists.

Reached from ordinary SQL, with only `enable_materialized_cte` gated. This does not close #110176 by itself, although it does fix that issue's reproducer: `INSERT ... SELECT` and an aggregating subquery reach the same error through `dropTotalsAndExtremes`, a separate site that #111194 addresses.

Validation: the four `EXPLAIN ANALYZE` shapes abort on unpatched master and pass with the change. Four mutants each redden the new test: reverting the helper call, discarding the aux ports with `NullSink` while keeping the transform, and corrupting a control or a witness reference line. Reintroducing a `drop` call no longer compiles. The test passes 100/100 runs (50 randomized, 50 not), and across 262 stateless cases using `extremes`, `WITH TOTALS`, `EXPLAIN ANALYZE` or materialized CTEs no case fails only with the change and no failure reason changes.