### PR TITLE
fix: return Unknown for NOT with unsupported inner predicate, preventing silent wrong results (#113676)

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/EnginePredicate.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/EnginePredicate.cpp
@@ -362,14 +362,35 @@ uintptr_t EngineIterator::getNextImpl(EngineIteratorData & iterator_data, const 
 
                 if (isFunctionNode(node->children[0]))
                 {
-                    EngineIteratorData current_iterator_data(
-                            iterator_data.state,
-                            node->children,
-                            iterator_data.predicate);
+                    const auto * inner_node = node->children[0];
+                    const auto inner_name = inner_node->function_base->getName();
 
-                    EngineIterator current_engine_iterator(current_iterator_data);
-                    auto column = ffi::visit_predicate_and(iterator_data.state, &current_engine_iterator);
-                    return ffi::visit_predicate_not(iterator_data.state, column);
+                    /// Only use visit_predicate_and + visit_predicate_not for comparison
+                    /// functions that the kernel can translate.  For unsupported inner
+                    /// functions (IS NULL, LIKE, OR, ...) the AND visitor would return
+                    /// a single Unknown child, which the kernel treats as an empty
+                    /// conjunction (TRUE), making NOT(TRUE) = FALSE and pruning every
+                    /// file — a silent wrong-result bug.  Returning Unknown for the
+                    /// whole NOT expression is always correct because the kernel's
+                    /// three-valued logic never skips a file on Unknown.
+                    if (inner_name == DB::NameEquals::name
+                        || inner_name == DB::NameNotEquals::name
+                        || inner_name == DB::NameGreater::name
+                        || inner_name == DB::NameGreaterOrEquals::name
+                        || inner_name == DB::NameLess::name
+                        || inner_name == DB::NameLessOrEquals::name)
+                    {
+                        EngineIteratorData current_iterator_data(
+                                iterator_data.state,
+                                node->children,
+                                iterator_data.predicate);
+
+                        EngineIterator current_engine_iterator(current_iterator_data);
+                        auto column = ffi::visit_predicate_and(iterator_data.state, &current_engine_iterator);
+                        return ffi::visit_predicate_not(iterator_data.state, column);
+                    }
+
+                    return VISITOR_FAILED_OR_UNSUPPORTED;
                 }
             }
             else if (func_name == DB::NameEquals::name


### PR DESCRIPTION
## Problem

`NOT (...)` wrapping an `IS NULL`, `LIKE`, or `OR` expression in a DeltaLake WHERE clause causes the engine predicate pushdown to prune **every data file**, silently returning 0 rows. Simple comparisons wrapped in `NOT` (`NOT (gender = 'M')`) work correctly.

## Root Cause

In `EnginePredicate.cpp`, the `NOT` handler for function children (line 363) unconditionally calls `visit_predicate_and` over the NOT's single child, then wraps the result with `visit_predicate_not`. When the inner function is not a supported comparison (`IS NULL`, `LIKE`, `OR`), the iterator returns a single `Unknown` predicate. The delta-kernel treats the single-`Unknown` AND as an empty conjunction (normalizes to `TRUE`), making `NOT(TRUE) = FALSE` — pruning every file.

## Fix

Check the inner function name before attempting translation. Only use the `AND+NOT` wrapping for the six comparison functions the kernel supports (`=`, `!=`, `>`, `>=`, `<`, `<=`). For all other functions, return `VISITOR_FAILED_OR_UNSUPPORTED` so the outer `getNext()` calls `visitUntranslated`, which returns an `Unknown` predicate. The kernel's three-valued logic never skips a file on `Unknown`, so this is always conservatively correct.

## Testing

| Query | Before | After | Expected |
|---|---|---|---|
| `WHERE NOT (gender = 'M')` | 15 ✅ | 15 ✅ | 15 |
| `WHERE NOT (gender IS NULL)` | **0** ❌ | 30 ✅ | 30 |
| `WHERE NOT (gender LIKE 'M')` | **0** ❌ | 15 ✅ | 15 |
| `WHERE NOT (gender = 'M' OR id > 5)` | **0** ❌ | 3 ✅ | 3 |

Fixes #113676