### PR TITLE
Fix flaky test_named_collections_encrypted2 by syncing the kazoo client before reads

### DIFF
--- a/tests/integration/test_named_collections_encrypted2/test.py
+++ b/tests/integration/test_named_collections_encrypted2/test.py
@@ -94,6 +94,7 @@ def wait_zk_child_absent(zk, path, child, timeout=10):
 
 
 def check_encrypted(zk, collection):
+    zk.sync(ZK_PATH)
     content = zk.get(f"{ZK_PATH}/{collection}.sql")[0]
     assert content[:3] == b"ENC"
     return content
@@ -749,6 +750,7 @@ def test_new_replica_encrypted_data_integrity(stopped_node3):
         password='P@ssw0rd!Complex#123'
     """)
 
+    zk.sync(ZK_PATH)
     content = zk.get(f"{ZK_PATH}/encrypted_coll.sql")[0]
     assert content[:3] == b"ENC"
     assert b"super_secret_api_key_12345" not in content


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112846
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_named_collections_encrypted2/test.py::test_zookeeper_encrypted_storage` fails
intermittently with `kazoo.exceptions.NoNodeError` reading `{ZK_PATH}/enc_test.sql`
(`test.py:97` in `check_encrypted`). No open issue.

The test's kazoo client is pinned to a single ensemble member, zoo1
(`helpers/cluster.py:4651`, `hosts=f"{ip}:{port}"` at `:4673`), while the server's session
spans zoo1/zoo2/zoo3. `CREATE NAMED COLLECTION` writes synchronously and commits on
leader+quorum before returning (`NamedCollectionsMetadataStorage.cpp:313`), so there is no
server-side durability gap. But `quorum_reads` defaults to false
(`src/Coordination/CoordinationSettings.cpp:62`, not overridden by any integration keeper
config), so a follower read is not linearizable: if zoo1 has not yet applied the committed
transaction, its `get` answers from the pre-write snapshot. The read is also effectively
single-shot: `KazooRetry`'s retry set does not contain `NoNodeError`, so it is re-raised
on the first attempt.

`zk.sync(path)` makes the connected follower catch up with the leader before responding,
eliminating the race rather than waiting it out. It is a real raft barrier:
`ZooKeeperSyncRequest::isReadRequest()` is false (`ZooKeeperCommon.h:124`) and `OpNum::Sync`
is classified as a write (`ZooKeeperConstants.cpp:132`). This mirrors
`9476b38b6109097482ad7a0f2531516b94a350f8`, which fixed the same class in the sibling module
`test_named_collections/test.py` with eight `zk.sync(ZK_PATH)` insertions.

The two sites changed are the only unpolled external kazoo reads left in the file; the reads
inside `wait_zk_child_exists`/`wait_zk_child_absent` are bounded polling loops. The
`check_encrypted` edit covers five tests; the inline read in
`test_new_replica_encrypted_data_integrity` needs its own line and is where a second
occurrence was recorded. Every existing assertion is unchanged, so a missing or unencrypted
znode still fails.

`test_named_collections_encrypted/test.py:84` has the same shape and is deliberately left
alone (one concern per PR).

<details>
<summary>Validation</summary>

Interleaved A/B, alternating arms, three rounds each, exercising the shipped
`check_encrypted` immediately after the write while zoo1 is isolated from raft (the
server's session pinned to zoo2/zoo3, so the write path is untouched):

| arm | rounds | sites reporting `NoNodeError` |
|---|---|---|
| without this change | 3/3 | 2 of 2 |
| with this change | 3/3 | 0 of 2 |

Per site, across those rounds: `:97` reads `NoNodeError` after 12-14 ms without the
change, versus a correct read after 6596-6622 ms with it (the sync waits out the lag);
the inline `:752` shape, 9-12 ms versus 6415-6493 ms. Each arm carries two positive
controls: the shipped function succeeds with no lever, and a bare read of a throwaway
znode misses, proving the isolation is actually in effect in that cell.

Liveness, with request logging enabled over the `lgrq` 4lw command: the change adds one
`Sync` request per read at Keeper (delta `Sync` 1 with the change, 0 without), with an
ordinary `Get` as the control that request logging is capturing (delta `Get` 1 and 3
respectively). Note the `Received request` trace is gated on `shouldLogRequests()`
(`KeeperTCPHandler.cpp:833`), which is off unless `lgrq` is sent.

Whole-module runs on both arms produced no `NoNodeError` and no assertion failures. The
remaining failures in both arms are container casualties of a loaded local box
(`ValueError: bad hostname` when a zoo container dies under the 12 GiB limit with a debug
binary at load 84-173); they are scattered differently per run and their counts are not
comparable between arms, so no comparative claim is made from them.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.950` (included in `26.8` and later)
<!-- ch-version-info:end -->