### PR TITLE
Treat a NUL byte as an ordinary literal in match() patterns

### DIFF
--- a/src/Common/RegexpUtils.cpp
+++ b/src/Common/RegexpUtils.cpp
@@ -192,7 +192,6 @@ RegexpFixedPrefix extractFixedPrefix(std::string_view regexp)
                 return {};
 
             /// None of these gives another fixed character.
-            case '\0':
             case '(':
             case ')':
             case '[':

--- a/src/Common/tests/gtest_regexp_utils.cpp
+++ b/src/Common/tests/gtest_regexp_utils.cpp
@@ -42,6 +42,13 @@ TEST(RegexpUtils, extractFixedPrefix)
     check("^abc\\\\", {.prefix = "abc\\", .is_perfect = true});
     check("^abc\\$", {.prefix = "abc$", .is_perfect = true});
 
+    /// A NUL is an ordinary literal character: the pattern is length-based and RE2 matches a NUL
+    /// literally, so the scan neither stops at it nor treats it as end-of-pattern.
+    check(std::string_view{"^abc\0def", 8}, {.prefix = String{"abc\0def", 7}, .is_perfect = true});
+    check(std::string_view{"^\0abc", 5}, {.prefix = String{"\0abc", 4}, .is_perfect = true});
+    check(std::string_view{"^a\0b$", 5}, {.prefix = String{"a\0b", 3}, .is_exact = true});
+    check(std::string_view{"^a\0b[12]", 8}, {.prefix = String{"a\0b", 3}});
+
     /// A trailing '$' makes the pattern an exact match.
     check("^abc$", {.prefix = "abc", .is_exact = true});
     check("^abc\\.$", {.prefix = "abc.", .is_exact = true});
@@ -56,7 +63,6 @@ TEST(RegexpUtils, extractFixedPrefix)
     check("^abc+", {.prefix = "abc"});
     check("^ab$cd", {.prefix = "ab"});
     check("^a^b", {.prefix = "a"});
-    check(std::string_view{"^abc\0def", 8}, {.prefix = "abc"});
 
     /// An invalid pattern must not be reported as exact, otherwise a point range could hide
     /// the exception the matcher throws.

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -354,11 +354,6 @@ const KeyCondition::AtomMap KeyCondition::atom_map
 
                 const String & expression = value.safeGet<String>();
 
-                /// ClickHouse `match` patterns must not contain NUL bytes.
-                /// Do not attempt to optimize such patterns.
-                if (expression.contains('\0'))
-                    return false;
-
                 auto prefix = extractFixedPrefixFromRegularExpression(expression, /*requires_perfect_prefix*/ false);
 
                 /// A pattern that matches a single string is equivalent to an equality, so use an exact point range.

--- a/tests/queries/0_stateless/03456_match_index_prefix_extraction.reference
+++ b/tests/queries/0_stateless/03456_match_index_prefix_extraction.reference
@@ -26,7 +26,7 @@ Condition: (path in [\'xxx}zzz\', \'xxx}zz{\'))
 1
 Condition: (path in [\'xxx-zzz\', \'xxx-zz{\'))
 1
-Condition: true
+0
 Condition: (path in [\'xxx\', \'xxy\'))
 0
 Condition: (path in [\'xxx\', \'xxy\'))

--- a/tests/queries/0_stateless/03456_match_index_prefix_extraction.sql
+++ b/tests/queries/0_stateless/03456_match_index_prefix_extraction.sql
@@ -78,9 +78,8 @@ SELECT count() FROM foo WHERE match(path, '^xxx\\}zzz') SETTINGS force_primary_k
 SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\-zzz')) WHERE explain like '%Condition%';
 SELECT count() FROM foo WHERE match(path, '^xxx\\-zzz') SETTINGS force_primary_key = 1;
 
--- No optimization: NUL bytes in regex are not supported
-SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\0bla')) WHERE explain like '%Condition%';
-SELECT count() FROM foo WHERE match(path, '^xxx\0bla') SETTINGS force_primary_key = 1; -- {serverError INDEX_NOT_USED}
+-- A NUL byte is an ordinary literal character — prefix "xxx\0bla"
+SELECT count() FROM foo WHERE match(path, '^xxx\0bla') SETTINGS force_primary_key = 1;
 
 -- TODO: Support transparent plain groups — could extract prefix "xxxbla"
 -- '(' stops extraction, prefix is "xxx"

--- a/tests/queries/0_stateless/04036_regex_primary_key_optimization.reference
+++ b/tests/queries/0_stateless/04036_regex_primary_key_optimization.reference
@@ -27,8 +27,9 @@ SELECT count() FROM test_regex_prefix WHERE match(id, '^aaa-1') SETTINGS force_p
 1
 SELECT * FROM test_regex_prefix WHERE match(id, '^aaa-1') ORDER BY id SETTINGS force_primary_key = 1, max_rows_to_read = 1;
 aaa-1
--- No optimization: match patterns containing NUL bytes are not optimized
-SELECT count() FROM test_regex_prefix WHERE match(id, '^aaa\0bbb') SETTINGS force_primary_key = 1; -- {serverError INDEX_NOT_USED}
+-- A NUL byte is an ordinary literal character, so the prefix "aaa\0bbb" is used and matches nothing
+SELECT count() FROM test_regex_prefix WHERE match(id, '^aaa\0bbb') SETTINGS force_primary_key = 1;
+0
 -- Escaped special chars become literal prefix characters
 SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM test_regex_prefix WHERE match(id, '^aaa\\.')) WHERE explain LIKE '%Condition%' OR explain LIKE '%Granules%';
 Condition: (id in [\'aaa.\', \'aaa/\'))

--- a/tests/queries/0_stateless/04036_regex_primary_key_optimization.sql
+++ b/tests/queries/0_stateless/04036_regex_primary_key_optimization.sql
@@ -25,8 +25,8 @@ SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM test_regex_
 SELECT count() FROM test_regex_prefix WHERE match(id, '^aaa-1') SETTINGS force_primary_key = 1, max_rows_to_read = 1;
 SELECT * FROM test_regex_prefix WHERE match(id, '^aaa-1') ORDER BY id SETTINGS force_primary_key = 1, max_rows_to_read = 1;
 
--- No optimization: match patterns containing NUL bytes are not optimized
-SELECT count() FROM test_regex_prefix WHERE match(id, '^aaa\0bbb') SETTINGS force_primary_key = 1; -- {serverError INDEX_NOT_USED}
+-- A NUL byte is an ordinary literal character, so the prefix "aaa\0bbb" is used and matches nothing
+SELECT count() FROM test_regex_prefix WHERE match(id, '^aaa\0bbb') SETTINGS force_primary_key = 1;
 
 -- Escaped special chars become literal prefix characters
 SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM test_regex_prefix WHERE match(id, '^aaa\\.')) WHERE explain LIKE '%Condition%' OR explain LIKE '%Granules%';


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Treat a NUL byte as an ordinary literal in match() patterns.

It seems there is no reason to stop at NUL byte. Strings are not null-terminated, the exact length for such patterns is always provided in our code. When we pass a string view to the `RE2` library, it doesn't stop at NUL byte in it.

See also https://github.com/ClickHouse/ClickHouse/pull/108427


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1497` (included in `26.8` and later)
<!-- ch-version-info:end -->