### PR TITLE
Fix environment dump on shell startup from clickhouse-bootstrap completion

### DIFF
--- a/programs/bash-completion/completions/clickhouse-bootstrap
+++ b/programs/bash-completion/completions/clickhouse-bootstrap
@@ -246,7 +246,11 @@ function _complete_clickhouse_generic()
 function _complete_clickhouse_bootstrap_main()
 {
     local runtime=/usr/share/bash-completion/bash_completion
-    if ! type _get_comp_words_by_ref >& /dev/null && [[ -f $runtime ]]; then
+    # BASH_COMPLETION_VERSINFO is assigned at the very top of the runtime, so
+    # it also detects a load that is still in progress (this file can be
+    # sourced by the runtime itself via BASH_COMPLETION_USER_FILE, and nested
+    # sourcing must be avoided)
+    if [[ ! -v BASH_COMPLETION_VERSINFO ]] && ! type _get_comp_words_by_ref >& /dev/null && [[ -f $runtime ]]; then
         source $runtime
     fi
     type _get_comp_words_by_ref >& /dev/null || return 0


### PR DESCRIPTION
Sourcing the runtime from within its own user-file hook (BASH_COMPLETION_USER_FILE) unsets _comp__init_original_set_v in the nested load, so the outer epilogue's unquoted "set $..." runs a bare "set". BASH_COMPLETION_VERSINFO is set by the runtime's first statement, so it also detects a load in progress.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix environment dump on shell startup from clickhouse-bootstrap completion


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.997` (included in `26.8` and later)
<!-- ch-version-info:end -->