### PR TITLE
Fix undefined behavior in the workload throttler's postponement delay

### DIFF
--- a/src/Common/Scheduler/Nodes/TimeShared/ThrottlerConstraint.h
+++ b/src/Common/Scheduler/Nodes/TimeShared/ThrottlerConstraint.h
@@ -4,7 +4,9 @@
 #include <Common/Scheduler/EventQueue.h>
 #include <Common/Scheduler/Debug.h>
 
+#include <algorithm>
 #include <chrono>
+#include <limits>
 #include <utility>
 
 
@@ -151,6 +153,32 @@ public:
     }
 
 private:
+    /// The largest representable delay and throttling duration (~292 years).
+    static constexpr auto max_duration = std::chrono::nanoseconds(std::numeric_limits<std::chrono::nanoseconds::rep>::max());
+
+    /// Bounds a delay so that it survives both the narrowing to `Int64` and the addition to `now`.
+    /// The comparison must happen before the cast: casting an out-of-range `Float64` is the
+    /// undefined behavior being avoided here.
+    static std::chrono::nanoseconds boundedDelay(double delay_ns, EventQueue::TimePoint now)
+    {
+        /// `steady_clock`'s epoch is unspecified, so clamp the elapsed part before subtracting.
+        auto elapsed = std::max(std::chrono::nanoseconds(now.time_since_epoch()), std::chrono::nanoseconds::zero());
+        auto room = max_duration - elapsed;
+        if (delay_ns < static_cast<double>(room.count()))
+            return std::chrono::nanoseconds(static_cast<Int64>(delay_ns));
+        return room;
+    }
+
+    /// `throttling_duration` accumulates over the whole node lifetime, so no bound on a single delay
+    /// can keep the sum in range. Saturate rather than wrap.
+    void addThrottlingDuration(std::chrono::nanoseconds delay)
+    {
+        if (delay > max_duration - throttling_duration) /// Both operands are non-negative
+            throttling_duration = max_duration;
+        else
+            throttling_duration += delay;
+    }
+
     void onPostponed()
     {
         postponed = EventQueue::not_postponed;
@@ -172,12 +200,12 @@ private:
             // Postpone activation until there is positive amount of tokens
             if (!do_not_postpone && tokens < 0.0)
             {
-                auto delay_ns = std::chrono::nanoseconds(static_cast<Int64>(-tokens / max_speed * 1e9));
+                auto delay_ns = boundedDelay(-tokens / max_speed * 1e9, now);
                 if (postponed == EventQueue::not_postponed)
                 {
                     postponed = event_queue.postpone(std::chrono::time_point_cast<EventQueue::Duration>(now + delay_ns),
                         [this] { onPostponed(); });
-                    throttling_duration += delay_ns;
+                    addThrottlingDuration(delay_ns);
                 }
             }
         }

--- a/src/Common/Scheduler/Nodes/TimeShared/ThrottlerConstraint.h
+++ b/src/Common/Scheduler/Nodes/TimeShared/ThrottlerConstraint.h
@@ -4,9 +4,7 @@
 #include <Common/Scheduler/EventQueue.h>
 #include <Common/Scheduler/Debug.h>
 
-#include <algorithm>
 #include <chrono>
-#include <limits>
 #include <utility>
 
 
@@ -21,6 +19,10 @@ class ThrottlerConstraint final : public ISchedulerConstraint
 {
 public:
     static constexpr double default_burst_seconds = 1.0;
+
+    /// Postponing a request for longer than this is meaningless, and the bound keeps the delay
+    /// arithmetic in `updateBucket` inside the `Int64` nanosecond range.
+    static constexpr auto max_delay = std::chrono::nanoseconds(std::chrono::hours(24 * 365));
 
     explicit ThrottlerConstraint(EventQueue & event_queue_, const SchedulerNodeInfo & info_ = {}, double max_speed_ = 0.0, double max_burst_ = 0.0)
         : ISchedulerConstraint(event_queue_, info_)
@@ -109,7 +111,8 @@ public:
     /// Should be called from the scheduler thread because it could lead to activation
     void updateConstraints(double new_max_speed, double new_max_burst)
     {
-        cancelPostponement();
+        event_queue.cancelPostponed(postponed);
+        postponed = EventQueue::not_postponed;
         bool was_active = active();
         updateBucket(0, true); // To apply previous params for duration since `last_update`
         max_speed = new_max_speed;
@@ -152,48 +155,13 @@ public:
     }
 
 private:
-    /// The largest representable delay and throttling duration (~292 years).
-    static constexpr auto max_duration = std::chrono::nanoseconds(std::numeric_limits<std::chrono::nanoseconds::rep>::max());
-
-    /// Bounds a delay so that it survives both the narrowing to `Int64` and the addition to `now`.
-    /// The comparison must happen before the cast: casting an out-of-range `Float64` is the
-    /// undefined behavior being avoided here.
-    static std::chrono::nanoseconds boundedDelay(double delay_ns, EventQueue::TimePoint now)
+    /// The bound has to be applied before the narrowing: casting an out-of-range `Float64` to
+    /// `Int64` is itself the undefined behavior.
+    static std::chrono::nanoseconds saturatingDelay(double delay_ns)
     {
-        /// `steady_clock`'s epoch is unspecified, so clamp the elapsed part before subtracting.
-        auto elapsed = std::max(std::chrono::nanoseconds(now.time_since_epoch()), std::chrono::nanoseconds::zero());
-        auto room = max_duration - elapsed;
-        if (delay_ns < static_cast<double>(room.count()))
+        if (delay_ns < static_cast<double>(max_delay.count()))
             return std::chrono::nanoseconds(static_cast<Int64>(delay_ns));
-        return room;
-    }
-
-    /// `throttling_duration` accumulates over the whole node lifetime, so no bound on a single delay
-    /// can keep the sum in range. Saturate rather than wrap.
-    void addThrottlingDuration(std::chrono::nanoseconds delay)
-    {
-        if (delay > max_duration - throttling_duration) /// Both operands are non-negative
-            throttling_duration = max_duration;
-        else
-            throttling_duration += delay;
-    }
-
-    /// Drops a postponement before it fires. The whole delay was counted up front, so give back the
-    /// part that never elapsed: the caller re-postpones and would otherwise count that part twice.
-    void cancelPostponement()
-    {
-        if (postponed != EventQueue::not_postponed)
-        {
-            /// A saturated total is a sentinel: less than the full delay went into it, so giving the
-            /// whole unelapsed part back would make the metric go down.
-            if (throttling_duration < max_duration)
-            {
-                auto remaining = std::max(postponed_until - event_queue.now(), EventQueue::Duration::zero());
-                throttling_duration -= std::min(std::chrono::nanoseconds(remaining), throttling_duration);
-            }
-            event_queue.cancelPostponed(postponed);
-            postponed = EventQueue::not_postponed;
-        }
+        return max_delay;
     }
 
     void onPostponed()
@@ -217,12 +185,14 @@ private:
             // Postpone activation until there is positive amount of tokens
             if (!do_not_postpone && tokens < 0.0)
             {
-                auto delay_ns = boundedDelay(-tokens / max_speed * 1e9, now);
+                auto delay_ns = saturatingDelay(-tokens / max_speed * 1e9);
                 if (postponed == EventQueue::not_postponed)
                 {
-                    postponed_until = std::chrono::time_point_cast<EventQueue::Duration>(now + delay_ns);
-                    postponed = event_queue.postpone(postponed_until, [this] { onPostponed(); });
-                    addThrottlingDuration(delay_ns);
+                    postponed = event_queue.postpone(std::chrono::time_point_cast<EventQueue::Duration>(now + delay_ns),
+                        [this] { onPostponed(); });
+                    /// The total accumulates for the node's lifetime, so bounding a single delay
+                    /// cannot keep the sum in range.
+                    throttling_duration += std::min(delay_ns, std::chrono::nanoseconds::max() - throttling_duration);
                 }
             }
         }
@@ -244,7 +214,6 @@ private:
 
     EventQueue::TimePoint last_update;
     UInt64 postponed = EventQueue::not_postponed;
-    EventQueue::TimePoint postponed_until; /// Valid iff `postponed != not_postponed`
     double tokens; /// in ResourceCost units
     bool child_active = false;
 

--- a/src/Common/Scheduler/Nodes/TimeShared/ThrottlerConstraint.h
+++ b/src/Common/Scheduler/Nodes/TimeShared/ThrottlerConstraint.h
@@ -109,8 +109,7 @@ public:
     /// Should be called from the scheduler thread because it could lead to activation
     void updateConstraints(double new_max_speed, double new_max_burst)
     {
-        event_queue.cancelPostponed(postponed);
-        postponed = EventQueue::not_postponed;
+        cancelPostponement();
         bool was_active = active();
         updateBucket(0, true); // To apply previous params for duration since `last_update`
         max_speed = new_max_speed;
@@ -179,6 +178,24 @@ private:
             throttling_duration += delay;
     }
 
+    /// Drops a postponement before it fires. The whole delay was counted up front, so give back the
+    /// part that never elapsed: the caller re-postpones and would otherwise count that part twice.
+    void cancelPostponement()
+    {
+        if (postponed != EventQueue::not_postponed)
+        {
+            /// A saturated total is a sentinel: less than the full delay went into it, so giving the
+            /// whole unelapsed part back would make the metric go down.
+            if (throttling_duration < max_duration)
+            {
+                auto remaining = std::max(postponed_until - event_queue.now(), EventQueue::Duration::zero());
+                throttling_duration -= std::min(std::chrono::nanoseconds(remaining), throttling_duration);
+            }
+            event_queue.cancelPostponed(postponed);
+            postponed = EventQueue::not_postponed;
+        }
+    }
+
     void onPostponed()
     {
         postponed = EventQueue::not_postponed;
@@ -203,8 +220,8 @@ private:
                 auto delay_ns = boundedDelay(-tokens / max_speed * 1e9, now);
                 if (postponed == EventQueue::not_postponed)
                 {
-                    postponed = event_queue.postpone(std::chrono::time_point_cast<EventQueue::Duration>(now + delay_ns),
-                        [this] { onPostponed(); });
+                    postponed_until = std::chrono::time_point_cast<EventQueue::Duration>(now + delay_ns);
+                    postponed = event_queue.postpone(postponed_until, [this] { onPostponed(); });
                     addThrottlingDuration(delay_ns);
                 }
             }
@@ -227,6 +244,7 @@ private:
 
     EventQueue::TimePoint last_update;
     UInt64 postponed = EventQueue::not_postponed;
+    EventQueue::TimePoint postponed_until; /// Valid iff `postponed != not_postponed`
     double tokens; /// in ResourceCost units
     bool child_active = false;
 

--- a/src/Common/Scheduler/Nodes/tests/gtest_throttler_constraint.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_throttler_constraint.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <limits>
 #include <gtest/gtest.h>
 
 #include <Common/Scheduler/Nodes/tests/ResourceTest.h>
@@ -9,6 +10,30 @@
 using namespace DB;
 
 using ResourceTest = ResourceTestClass;
+
+namespace
+{
+
+constexpr auto max_duration = std::chrono::nanoseconds(std::numeric_limits<std::chrono::nanoseconds::rep>::max());
+
+/// A speed of 2^-33 tokens/s parks a cost-1 request for 2^33 seconds. That delay fits in `Int64`
+/// nanoseconds, but two of them do not, and neither does one added to a large enough time point.
+constexpr double tiny_speed = 1.0 / 8589934592.0;
+constexpr auto tiny_speed_delay = std::chrono::nanoseconds(8589934592000000000);
+
+/// Parks one cost-1 request on a throttler installed as the root node, and returns that root.
+ThrottlerConstraint & parkOneRequest(ResourceTest & t, EventQueue::TimePoint start, double max_speed)
+{
+    t.process(start, 0);
+    t.add<ThrottlerConstraint>("/", SchedulerNodeInfo{}, max_speed, /*max_burst=*/ 0.0);
+    t.add<FifoQueue>("/A");
+    t.enqueue("/A", {1});
+    t.process(start);
+    t.consumed("A", 1);
+    return static_cast<ThrottlerConstraint &>(t.getRoot());
+}
+
+}
 
 TEST(SchedulerThrottlerConstraint, LeakyBucketConstraint)
 {
@@ -175,5 +200,66 @@ TEST(SchedulerThrottlerConstraint, ThrottlerAndFairness)
         t.consumed("B", static_cast<ResourceCost>(arrival_curve * share_b - consumed_b), max_latency_b);
         consumed_a = arrival_curve * share_a;
         consumed_b = arrival_curve * share_b;
+    }
+}
+
+/// The three cases below are separate tests on purpose: the sanitizer builds are compiled with
+/// `-fno-sanitize-recover=all`, so the first unbounded statement aborts the process and would hide
+/// the other two.
+
+/// A speed small enough that the quotient itself is outside `Int64`. Narrowing it is undefined.
+TEST(SchedulerThrottlerConstraint, TinySpeedDelayNarrowingIsBounded)
+{
+    ResourceTest t;
+    EventQueue::TimePoint start{std::chrono::seconds(1)};
+    auto & throttler = parkOneRequest(t, start, /*max_speed=*/ 1e-30);
+    EXPECT_EQ(throttler.getThrottlingDuration(), max_duration - start.time_since_epoch());
+}
+
+/// A representable quotient, but `now + delay` is not representable.
+TEST(SchedulerThrottlerConstraint, TinySpeedDeadlineIsBounded)
+{
+    ResourceTest t;
+    EventQueue::TimePoint start{std::chrono::nanoseconds(Int64(1) << 62)};
+    auto & throttler = parkOneRequest(t, start, tiny_speed);
+    EXPECT_EQ(throttler.getThrottlingDuration(), max_duration - start.time_since_epoch());
+}
+
+/// Two delays that are each representable, but whose sum is not. `steady_clock`'s epoch is
+/// unspecified, and a negative one leaves room for a delay longer than the time already elapsed.
+TEST(SchedulerThrottlerConstraint, ThrottlingDurationSaturates)
+{
+    ResourceTest t;
+    EventQueue::TimePoint start{std::chrono::seconds(-1)};
+    auto & throttler = parkOneRequest(t, start, tiny_speed);
+    EXPECT_EQ(throttler.getThrottlingDuration(), tiny_speed_delay);
+
+    /// Serve that postponement in full, then park a second request at the new time.
+    t.enqueue("/A", {1});
+    t.process(start + tiny_speed_delay);
+    t.consumed("A", 1);
+    EXPECT_EQ(throttler.getThrottlingDuration(), max_duration);
+}
+
+
+/// The two guards above must not be satisfied by suppressing the metric: an ordinary speed still
+/// has to accumulate the exact delay it postpones, once per postponement.
+TEST(SchedulerThrottlerConstraint, ThrottlingDurationIsAccumulated)
+{
+    ResourceTest t;
+    EventQueue::TimePoint start = EventQueue::Clock::now();
+    constexpr double max_speed = 0.001;
+    constexpr auto delay = std::chrono::seconds(1000);
+
+    auto & throttler = parkOneRequest(t, start, max_speed);
+    EXPECT_EQ(throttler.getThrottlingDuration(), delay);
+
+    /// Each request is served exactly when its postponement elapses, so each adds a whole delay.
+    for (int i = 1; i < 4; i++)
+    {
+        t.enqueue("/A", {1});
+        t.process(start + delay * i);
+        t.consumed("A", 1);
+        EXPECT_EQ(throttler.getThrottlingDuration(), delay * (i + 1));
     }
 }

--- a/src/Common/Scheduler/Nodes/tests/gtest_throttler_constraint.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_throttler_constraint.cpp
@@ -1,5 +1,4 @@
 #include <chrono>
-#include <limits>
 #include <gtest/gtest.h>
 
 #include <Common/Scheduler/Nodes/tests/ResourceTest.h>
@@ -14,12 +13,9 @@ using ResourceTest = ResourceTestClass;
 namespace
 {
 
-constexpr auto max_duration = std::chrono::nanoseconds(std::numeric_limits<std::chrono::nanoseconds::rep>::max());
-
 /// A speed of 2^-33 tokens/s parks a cost-1 request for 2^33 seconds. That delay fits in `Int64`
-/// nanoseconds, but two of them do not, and neither does one added to a large enough time point.
+/// nanoseconds, but adding it to a large enough time point does not.
 constexpr double tiny_speed = 1.0 / 8589934592.0;
-constexpr auto tiny_speed_delay = std::chrono::nanoseconds(8589934592000000000);
 
 /// Parks one cost-1 request on a throttler installed as the root node, and returns that root.
 ThrottlerConstraint & parkOneRequest(ResourceTest & t, EventQueue::TimePoint start, double max_speed)
@@ -213,7 +209,7 @@ TEST(SchedulerThrottlerConstraint, TinySpeedDelayNarrowingIsBounded)
     ResourceTest t;
     EventQueue::TimePoint start{std::chrono::seconds(1)};
     auto & throttler = parkOneRequest(t, start, /*max_speed=*/ 1e-30);
-    EXPECT_EQ(throttler.getThrottlingDuration(), max_duration - start.time_since_epoch());
+    EXPECT_EQ(throttler.getThrottlingDuration(), ThrottlerConstraint::max_delay);
 }
 
 /// A representable quotient, but `now + delay` is not representable.
@@ -222,75 +218,19 @@ TEST(SchedulerThrottlerConstraint, TinySpeedDeadlineIsBounded)
     ResourceTest t;
     EventQueue::TimePoint start{std::chrono::nanoseconds(Int64(1) << 62)};
     auto & throttler = parkOneRequest(t, start, tiny_speed);
-    EXPECT_EQ(throttler.getThrottlingDuration(), max_duration - start.time_since_epoch());
+    EXPECT_EQ(throttler.getThrottlingDuration(), ThrottlerConstraint::max_delay);
 }
 
-/// Two delays that are each representable, but whose sum is not. `steady_clock`'s epoch is
-/// unspecified, and a negative one leaves room for a delay longer than the time already elapsed.
+/// Each delay is bounded, but their sum is not: every `ALTER WORKLOAD` re-postpones the pending
+/// delay and counts it again, and 300 years of them overrun the ~292-year `Int64` range.
 TEST(SchedulerThrottlerConstraint, ThrottlingDurationSaturates)
 {
     ResourceTest t;
-    EventQueue::TimePoint start{std::chrono::seconds(-1)};
+    EventQueue::TimePoint start{std::chrono::seconds(1)};
     auto & throttler = parkOneRequest(t, start, tiny_speed);
-    EXPECT_EQ(throttler.getThrottlingDuration(), tiny_speed_delay);
+    EXPECT_EQ(throttler.getThrottlingDuration(), ThrottlerConstraint::max_delay);
 
-    /// Serve that postponement in full, then park a second request at the new time.
-    t.enqueue("/A", {1});
-    t.process(start + tiny_speed_delay);
-    t.consumed("A", 1);
-    EXPECT_EQ(throttler.getThrottlingDuration(), max_duration);
-
-    /// Cancelling the pending postponement must not undo the saturation: the total is a sentinel,
-    /// and less than that postponement's whole delay went into it. Dropping the limit altogether is
-    /// what makes a give-back observable, since then nothing re-postpones and re-adds it.
-    throttler.updateConstraints(/*new_max_speed=*/ 0.0, /*new_max_burst=*/ 0.0);
-    EXPECT_EQ(throttler.getThrottlingDuration(), max_duration);
-}
-
-/// Re-postponing an unelapsed delay must not count it twice. Unlike the cases above this needs no
-/// sanitizer and an ordinary speed: it is what makes `system.scheduler.throttling_us` report more
-/// throttling than the server has been up for.
-TEST(SchedulerThrottlerConstraint, ThrottlingDurationIsNotDoubleCounted)
-{
-    ResourceTest t;
-    EventQueue::TimePoint start = EventQueue::Clock::now();
-    constexpr double max_speed = 0.001; // A cost-1 request parks for 1000 seconds
-    constexpr auto delay = std::chrono::seconds(1000);
-
-    auto & throttler = parkOneRequest(t, start, max_speed);
-    EXPECT_EQ(throttler.getThrottlingDuration(), delay);
-
-    /// Nothing has elapsed, so the whole delay is still pending and re-postponing it adds nothing.
-    for (int i = 0; i < 3; i++)
-    {
-        throttler.updateConstraints(max_speed, /*new_max_burst=*/ 0.0);
-        EXPECT_EQ(throttler.getThrottlingDuration(), delay);
-    }
-
-    /// Halfway through, half the delay has been served and only the other half is re-postponed.
-    t.process(start + delay / 2, 0);
-    throttler.updateConstraints(max_speed, /*new_max_burst=*/ 0.0);
-    EXPECT_EQ(throttler.getThrottlingDuration(), delay);
-}
-
-/// The two guards above must not be satisfied by suppressing the metric: an ordinary speed still
-/// has to accumulate the exact delay it postpones, once per postponement.
-TEST(SchedulerThrottlerConstraint, ThrottlingDurationIsAccumulated)
-{
-    ResourceTest t;
-    EventQueue::TimePoint start = EventQueue::Clock::now();
-    constexpr double max_speed = 0.001;
-    constexpr auto delay = std::chrono::seconds(1000);
-
-    auto & throttler = parkOneRequest(t, start, max_speed);
-    EXPECT_EQ(throttler.getThrottlingDuration(), delay);
-
-    /// Each request is served exactly when its postponement elapses, so each adds a whole delay.
-    for (int i = 1; i < 4; i++)
-    {
-        t.enqueue("/A", {1});
-        t.process(start + delay * i);
-        t.consumed("A", 1);
-        EXPECT_EQ(throttler.getThrottlingDuration(), delay * (i + 1));
-    }
+    for (int i = 0; i < 300; i++)
+        throttler.updateConstraints(tiny_speed, /*new_max_burst=*/ 0.0);
+    EXPECT_EQ(throttler.getThrottlingDuration(), std::chrono::nanoseconds::max());
 }

--- a/src/Common/Scheduler/Nodes/tests/gtest_throttler_constraint.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_throttler_constraint.cpp
@@ -239,8 +239,39 @@ TEST(SchedulerThrottlerConstraint, ThrottlingDurationSaturates)
     t.process(start + tiny_speed_delay);
     t.consumed("A", 1);
     EXPECT_EQ(throttler.getThrottlingDuration(), max_duration);
+
+    /// Cancelling the pending postponement must not undo the saturation: the total is a sentinel,
+    /// and less than that postponement's whole delay went into it. Dropping the limit altogether is
+    /// what makes a give-back observable, since then nothing re-postpones and re-adds it.
+    throttler.updateConstraints(/*max_speed=*/ 0.0, /*max_burst=*/ 0.0);
+    EXPECT_EQ(throttler.getThrottlingDuration(), max_duration);
 }
 
+/// Re-postponing an unelapsed delay must not count it twice. Unlike the cases above this needs no
+/// sanitizer and an ordinary speed: it is what makes `system.scheduler.throttling_us` report more
+/// throttling than the server has been up for.
+TEST(SchedulerThrottlerConstraint, ThrottlingDurationIsNotDoubleCounted)
+{
+    ResourceTest t;
+    EventQueue::TimePoint start = EventQueue::Clock::now();
+    constexpr double max_speed = 0.001; // A cost-1 request parks for 1000 seconds
+    constexpr auto delay = std::chrono::seconds(1000);
+
+    auto & throttler = parkOneRequest(t, start, max_speed);
+    EXPECT_EQ(throttler.getThrottlingDuration(), delay);
+
+    /// Nothing has elapsed, so the whole delay is still pending and re-postponing it adds nothing.
+    for (int i = 0; i < 3; i++)
+    {
+        throttler.updateConstraints(max_speed, /*max_burst=*/ 0.0);
+        EXPECT_EQ(throttler.getThrottlingDuration(), delay);
+    }
+
+    /// Halfway through, half the delay has been served and only the other half is re-postponed.
+    t.process(start + delay / 2, 0);
+    throttler.updateConstraints(max_speed, /*max_burst=*/ 0.0);
+    EXPECT_EQ(throttler.getThrottlingDuration(), delay);
+}
 
 /// The two guards above must not be satisfied by suppressing the metric: an ordinary speed still
 /// has to accumulate the exact delay it postpones, once per postponement.

--- a/src/Common/Scheduler/Nodes/tests/gtest_throttler_constraint.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_throttler_constraint.cpp
@@ -243,7 +243,7 @@ TEST(SchedulerThrottlerConstraint, ThrottlingDurationSaturates)
     /// Cancelling the pending postponement must not undo the saturation: the total is a sentinel,
     /// and less than that postponement's whole delay went into it. Dropping the limit altogether is
     /// what makes a give-back observable, since then nothing re-postpones and re-adds it.
-    throttler.updateConstraints(/*max_speed=*/ 0.0, /*max_burst=*/ 0.0);
+    throttler.updateConstraints(/*new_max_speed=*/ 0.0, /*new_max_burst=*/ 0.0);
     EXPECT_EQ(throttler.getThrottlingDuration(), max_duration);
 }
 
@@ -263,13 +263,13 @@ TEST(SchedulerThrottlerConstraint, ThrottlingDurationIsNotDoubleCounted)
     /// Nothing has elapsed, so the whole delay is still pending and re-postponing it adds nothing.
     for (int i = 0; i < 3; i++)
     {
-        throttler.updateConstraints(max_speed, /*max_burst=*/ 0.0);
+        throttler.updateConstraints(max_speed, /*new_max_burst=*/ 0.0);
         EXPECT_EQ(throttler.getThrottlingDuration(), delay);
     }
 
     /// Halfway through, half the delay has been served and only the other half is re-postponed.
     t.process(start + delay / 2, 0);
-    throttler.updateConstraints(max_speed, /*max_burst=*/ 0.0);
+    throttler.updateConstraints(max_speed, /*new_max_burst=*/ 0.0);
     EXPECT_EQ(throttler.getThrottlingDuration(), delay);
 }
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a signed overflow in the workload throttler that made `system.scheduler.throttling_us` report a negative value for a workload whose `max_bytes_per_second`, `max_queries_per_second` or `max_cpus` is small enough to postpone a request for longer than a year. Such a postponement is now saturated at one year.


### Description

`ThrottlerConstraint::updateBucket` derives a postponement delay from a user-supplied throttler speed and feeds it into three unguarded signed statements. `WorkloadSettings::getFloat64` rejects only non-finite and negative values, so any tiny positive speed passes validation, and `-tokens / max_speed * 1e9` then grows without bound.

Two of those statements are undefined behavior: the `static_cast<Int64>` of that quotient and the following `now + delay_ns`. An ASan+UBSan build of master aborts on `CREATE WORKLOAD w IN all SETTINGS max_queries_per_second = 1e-30` plus one query through `w`. Without the sanitizer the narrowing yields `INT64_MIN` instead, and `system.scheduler.throttling_us` then reports `-9223372036854775`.

Postponing a request for longer than a year is meaningless, so the delay now saturates at one year. The bound is applied before the narrowing, because casting the out-of-range `Float64` is itself the undefined behavior. `now + delay` is then in range for any `steady_clock` less than 291 years past its epoch, which a monotonic-since-boot clock does not reach.

The third statement, `throttling_duration += delay_ns`, accumulates for the node's lifetime, so bounding a single delay cannot bound the sum: a pending delay is counted again on every re-postponement, and `ALTER WORKLOAD` re-postpones without waiting, so 293 of them overrun the `Int64` nanosecond range. That addition saturates as well.

Cancelling a postponement still re-counts the part of its delay that never elapsed, so a few hundred `ALTER WORKLOAD`s pin `throttling_us` at that ceiling. The commit that corrected that accounting is dropped from this PR, because that column is its only consumer.

Verified with 9 gtests in `gtest_throttler_constraint.cpp`, 3 of them new, and a two-mutant matrix in which removing either guard reddens a new arm while none of the 6 pre-existing arms ever reddens. The three statements were also checked standalone under `-fsanitize=undefined -fno-sanitize-recover=all`: the bounded form is silent, and each unbounded control aborts.
