### PR TITLE
Fix wrong value for a virtual column on the right side of direct JOIN

### DIFF
--- a/src/Planner/PlannerJoins.cpp
+++ b/src/Planner/PlannerJoins.cpp
@@ -1142,6 +1142,11 @@ static std::shared_ptr<DirectKeyValueJoin> tryDirectJoin(const std::shared_ptr<T
         if (column_mapping_it == right_table_expression.column_mapping.end())
             return {};
 
+        /// `getByKeys` cannot return a column absent from the storage sample block, and its result is
+        /// re-indexed against this header by position, so that column's slot would get another's data.
+        if (!storage_sample_block.has(column_mapping_it->second))
+            return {};
+
         auto right_table_expression_column_with_storage_column_name = right_table_expression_column;
         right_table_expression_column_with_storage_column_name.name = column_mapping_it->second;
         right_table_expression_header_with_storage_column_names.insert(right_table_expression_column_with_storage_column_name);

--- a/tests/queries/0_stateless/04816_direct_join_virtual_column.reference
+++ b/tests/queries/0_stateless/04816_direct_join_virtual_column.reference
@@ -1,0 +1,11 @@
+VALA	t_04816_rocks
+VALA	t_04816_rocks
+one	d_04816
+one	d_04816
+VALA	1
+VALA	1
+VALA	t_04816_rocks
+VALA	t_04816_rocks
+VALA
+1
+0

--- a/tests/queries/0_stateless/04816_direct_join_virtual_column.sql
+++ b/tests/queries/0_stateless/04816_direct_join_virtual_column.sql
@@ -1,3 +1,4 @@
+-- Tags: use-rocksdb
 -- Direct join published a storage data column under a right-side virtual column's name.
 
 DROP TABLE IF EXISTS t_04816_rocks;

--- a/tests/queries/0_stateless/04816_direct_join_virtual_column.sql
+++ b/tests/queries/0_stateless/04816_direct_join_virtual_column.sql
@@ -1,0 +1,48 @@
+-- Direct join published a storage data column under a right-side virtual column's name.
+
+DROP TABLE IF EXISTS t_04816_rocks;
+DROP TABLE IF EXISTS t_04816_src;
+DROP DICTIONARY IF EXISTS d_04816;
+
+CREATE TABLE t_04816_rocks (k LowCardinality(String), v String) ENGINE = EmbeddedRocksDB PRIMARY KEY k;
+INSERT INTO t_04816_rocks VALUES ('KEYA', 'VALA');
+
+CREATE TABLE t_04816_src (k Nullable(UInt64), v String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_04816_src VALUES (1, 'one');
+CREATE DICTIONARY d_04816 (k Nullable(UInt64), v String) PRIMARY KEY k
+SOURCE(CLICKHOUSE(TABLE 't_04816_src' DB currentDatabase())) LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(0);
+
+SELECT dd.v, dd._table FROM (SELECT CAST('KEYA', 'LowCardinality(String)') AS pref) AS t
+LEFT JOIN t_04816_rocks AS dd ON t.pref = dd.k;
+SELECT dd.v, dd._table FROM (SELECT CAST('KEYA', 'LowCardinality(String)') AS pref) AS t
+LEFT JOIN t_04816_rocks AS dd ON t.pref = dd.k SETTINGS join_algorithm = 'hash';
+
+SELECT dd.v, dd._table FROM (SELECT CAST(1, 'Nullable(UInt64)') AS pref) AS t
+LEFT JOIN d_04816 AS dd ON t.pref = dd.k;
+SELECT dd.v, dd._table FROM (SELECT CAST(1, 'Nullable(UInt64)') AS pref) AS t
+LEFT JOIN d_04816 AS dd ON t.pref = dd.k SETTINGS join_algorithm = 'hash';
+
+SELECT dd.v, dd._database = currentDatabase() FROM (SELECT CAST('KEYA', 'LowCardinality(String)') AS pref) AS t
+LEFT JOIN t_04816_rocks AS dd ON t.pref = dd.k;
+SELECT dd.v, dd._database = currentDatabase() FROM (SELECT CAST('KEYA', 'LowCardinality(String)') AS pref) AS t
+LEFT JOIN t_04816_rocks AS dd ON t.pref = dd.k SETTINGS join_algorithm = 'hash';
+
+SELECT dd.v, dd._table FROM (SELECT CAST('KEYA', 'LowCardinality(String)') AS pref) AS t
+INNER JOIN t_04816_rocks AS dd ON t.pref = dd.k;
+SELECT dd.v, dd._table FROM (SELECT CAST('KEYA', 'LowCardinality(String)') AS pref) AS t
+INNER JOIN t_04816_rocks AS dd ON t.pref = dd.k SETTINGS join_algorithm = 'hash';
+
+SELECT dd.v FROM (SELECT CAST('KEYA', 'LowCardinality(String)') AS pref) AS t
+LEFT JOIN t_04816_rocks AS dd ON t.pref = dd.k;
+
+SELECT dd.v, dd._table FROM (SELECT CAST('KEYA', 'LowCardinality(String)') AS pref) AS t
+LEFT JOIN t_04816_rocks AS dd ON t.pref = dd.k SETTINGS join_algorithm = 'direct'; -- { serverError NOT_IMPLEMENTED }
+
+SELECT count() > 0 FROM (EXPLAIN actions = 1 SELECT dd.v FROM (SELECT CAST('KEYA', 'LowCardinality(String)') AS pref) AS t
+LEFT JOIN t_04816_rocks AS dd ON t.pref = dd.k) WHERE explain ILIKE '%Algorithm: DirectKeyValueJoin%';
+SELECT count() > 0 FROM (EXPLAIN actions = 1 SELECT dd.v, dd._table FROM (SELECT CAST('KEYA', 'LowCardinality(String)') AS pref) AS t
+LEFT JOIN t_04816_rocks AS dd ON t.pref = dd.k) WHERE explain ILIKE '%Algorithm: DirectKeyValueJoin%';
+
+DROP DICTIONARY d_04816;
+DROP TABLE t_04816_src;
+DROP TABLE t_04816_rocks;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a wrong value returned for a virtual column such as `_table` or `_database` selected from the right side of a JOIN served by `DirectKeyValueJoin` (a key-value storage such as `EmbeddedRocksDB`, `KeeperMap`, `Redis`, or a dictionary). The query returned the contents of a data column instead, or failed with `LOGICAL_ERROR`.

### Description

`SELECT dd.v, dd._table FROM t LEFT JOIN <key-value table> AS dd ON t.pref = dd.k` returned
`VALA KEYA` where `VALA s2` is correct: the join **key** column's value appeared where the table
name belongs. With a key type other than `LowCardinality(String)` it failed with `LOGICAL_ERROR`
(`Bad cast ... to ColumnLowCardinality`). Both occur at stock settings, since `join_algorithm`
defaults to `direct,parallel_hash,hash`.

Root cause: `DirectKeyValueJoin::joinBlock` builds the right-side columns in two steps that
disagree about indexing. `convertBlockStructure` skips any header column the storage does not
report (`DirectJoin.cpp:36-37`), returning a **compacted** column vector, and the insertion loop
re-indexes it **positionally** against the **uncompacted** header (`:188-192`). A
plan-materialized virtual column is exactly the skipped case, so a data column gets published
under the virtual column's name and declared type. For a dictionary `getByKeys` also prepends
the key columns (`IDictionary.h:460-466`), so the key lands in the slot reserved for `_table`.

The fix declines `DirectKeyValueJoin` in `tryDirectJoin` when a mapped header column is absent
from the storage's sample block, letting the existing `HashJoin` fallback, whose right subtree
does materialize virtual columns, answer the query. That function already carries two bail-outs
of this shape for the join key (`PlannerJoins.cpp:1108-1113`); this is the same rule for non-key
columns. `DirectJoin.cpp` is unchanged, so its positional re-index becomes unreachable here
rather than being removed.

Direct join is still chosen for every normal-column shape, and no existing test loses coverage.
Dictionaries and `EmbeddedRocksDB` are verified affected by measurement; `KeeperMap` and `Redis`
by construction, having an identical `getSampleBlock`. One deliberate behaviour change, pinned by
a test arm: with `join_algorithm = 'direct'` alone such a query now returns `NOT_IMPLEMENTED`
rather than a wrong value, as the existing bail-outs for a mixed `ON` condition and for
`RIGHT JOIN` already do.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.4.8`, `26.6.3.18`, `26.5.7.18`
<!-- ch-version-info:end -->