### PR TITLE
Docs: document `X-ClickHouse-Replica-Tag` routing

### DIFF
--- a/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
+++ b/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
@@ -18,9 +18,9 @@ It's best-effort and doesn't guarantee isolation. The proxy maps each routing va
 <Warning>
 **Requires the HTTP interface**
 
-Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interface](/interfaces/http). Select the routing method available for your service from the tabs below.
+Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interface](/interfaces/http). ClickHouse Cloud is transitioning replica-aware routing from `session_id` to the `X-ClickHouse-Replica-Tag` header. The tabs below describe both methods during the rollout.
 
-Replica-aware routing is **not available over the native protocol** (native port, e.g. the [clickhouse-go](/integrations/go) driver in its default native mode). Native-protocol clients must switch to HTTP and send the routing value on every request.
+Replica-aware routing is **currently unavailable over the native protocol** (native port, e.g. the [clickhouse-go](/integrations/go) driver in its default native mode). Native-protocol clients must switch to HTTP and send the routing value on every request.
 </Warning>
 
 ## Prerequisites {#prerequisites}
@@ -31,12 +31,12 @@ Replica-aware routing is **not available over the native protocol** (native port
 
 ## Configuring replica-aware routing {#configuring-replica-aware-routing}
 
-Open a [support](https://clickhouse.com/support/program) ticket and ask to enable HTTP-based sticky replica routing. Include your service ID and why you need it (temporary tables, session state, cache reuse, or read-after-write consistency). After it's enabled, use the routing method available for your service. No restart is required.
+Open a [support](https://clickhouse.com/support/program) ticket and ask to enable HTTP-based sticky replica routing. Include your service ID and why you need it (temporary tables, session state, cache reuse, or read-after-write consistency). Before migrating an existing service, ask Support to confirm that header-based routing is enabled for it. Continue using `session_id` until you receive confirmation; `X-ClickHouse-Replica-Tag` won't provide sticky routing until the rollout reaches your service. No restart is required.
 
 ## HTTP-based routing {#http-based-routing}
 
 <Tabs>
-<Tab title="X-ClickHouse-Replica-Tag">
+<Tab title="X-ClickHouse-Replica-Tag (preferred)">
 
 To pin a workload to a replica, send an `X-ClickHouse-Replica-Tag` header on the [HTTPS interface](/interfaces/http). The proxy uses consistent hashing on the header value, so requests sharing it go to the same replica while the number of replicas remains unchanged. A different value hashes independently and may land on the same or a different replica, but you don't choose *which* replica a value maps to.
 
@@ -55,7 +55,7 @@ echo 'SELECT hostName()' | curl \
 For clickhouse-go (v2), set `Protocol: clickhouse.HTTP` and pass the header with the [`HttpHeaders` connection option](/integrations/language-clients/go/configuration#connection-settings).
 
 <Info>
-The header controls proxy routing only. Concurrent requests can reuse the same header value.
+`X-ClickHouse-Replica-Tag` provides replica affinity without creating a ClickHouse HTTP session. Concurrent requests can reuse the same tag without encountering `SESSION_IS_LOCKED`.
 </Info>
 
 ### Read-after-write consistency {#read-after-write-consistency}
@@ -70,16 +70,17 @@ Run the `SELECT hostName()` example again with the same `X-ClickHouse-Replica-Ta
 
 </Tab>
 
-<Tab title="session_id (deprecated)">
+<Tab title="session_id (legacy)">
 
 <Warning>
-The `session_id` routing method is deprecated. Use `X-ClickHouse-Replica-Tag` instead.
+`X-ClickHouse-Replica-Tag` is replacing `session_id` for replica-aware routing. Continue using `session_id` until Support confirms that header-based routing is enabled for your service.
 </Warning>
 
 **Concurrent requests fail with `SESSION_IS_LOCKED`**
 
-- If you only need replica-aware routing, use `X-ClickHouse-Replica-Tag` and omit `session_id`. Concurrent requests can share the same replica tag.
-- If you need ClickHouse HTTP session state, serialize requests sharing a `session_id`; only one query can run in a session at a time. The `session_id` routing method is being deprecated, so prefer `X-ClickHouse-Replica-Tag` for replica-aware routing.
+- Because `session_id` creates a ClickHouse HTTP session, only one query can run within a given session at a time.
+- After header-based routing is enabled for your service, workloads that only need replica affinity can switch to `X-ClickHouse-Replica-Tag`. Concurrent requests can share the same replica tag.
+- If you need ClickHouse HTTP session state, serialize requests sharing a `session_id`.
 
 To pin a workload to a replica, send a `session_id` query parameter on the [HTTPS interface](/interfaces/http). The proxy uses consistent hashing on the parameter value, so requests sharing it go to the same replica while the number of replicas remains unchanged. A different value hashes independently and may land on the same or a different replica, but you don't choose *which* replica a value maps to.
 
@@ -109,15 +110,15 @@ Run the `SELECT hostName()` example again with the same `session_id`. You should
 </Tab>
 </Tabs>
 
-## Subdomain-based routing (deprecated) {#subdomain-based-routing-deprecated}
+## Legacy subdomain-based routing {#subdomain-based-routing-deprecated}
 
-<Danger>
-**Deprecated**
+Subdomain-based routing is no longer enabled on new services. If you already use sticky subdomains, contact [Support](https://clickhouse.com/support/program) to migrate to the [HTTP header method](#http-based-routing).
 
-The subdomain-based mechanism is being **deprecated** and will no longer be enabled on new services. It doesn't scale (each sticky endpoint requires its own TLS certificate). Use the [HTTP header method](#http-based-routing) instead. If you already use sticky subdomains, contact [support](https://clickhouse.com/support/program) to enable HTTP-based routing. This is a breaking change and will require migration.
-</Danger>
+<Accordion title="How legacy subdomain-based routing works">
 
 Previously, enabling replica-aware routing allowed a wildcard subdomain on top of the service hostname. For a service with the host name `abcxyz123.us-west-2.aws.clickhouse.cloud`, any hostname matching `*.sticky.abcxyz123.us-west-2.aws.clickhouse.cloud` (e.g. `aaa.sticky.abcxyz123.us-west-2.aws.clickhouse.cloud`) was hashed by Envoy to a consistent replica. The original hostname continued to use `LEAST_CONNECTION` load balancing, the default routing algorithm.
+
+</Accordion>
 
 ## Limitations of replica-aware routing {#limitations-of-replica-aware-routing}
 
@@ -129,11 +130,11 @@ Scaling out or in changes the routing hash ring. Requests sharing the same routi
 
 Sticky routing only controls *which* replica handles a request. That replica may still serve other traffic. For dedicated compute, use [compute-compute separation](/cloud/reference/warehouses).
 
-### Private Link and the deprecated subdomain method {#replica-aware-routing-does-not-work-out-of-the-box-with-private-link}
+### Private Link and the legacy subdomain method {#replica-aware-routing-does-not-work-out-of-the-box-with-private-link}
 
 HTTP-based routing works with [private networking](/cloud/security/connectivity/private-networking) on your normal service hostname. No extra DNS entries are required.
 
-The deprecated subdomain method doesn't: you must add DNS for the `*.sticky.*` hostname pattern, and incorrect setup can imbalance load across replicas.
+The legacy subdomain method doesn't: you must add DNS for the `*.sticky.*` hostname pattern, and incorrect setup can imbalance load across replicas.
 
 ### Replica-aware routing requires the HTTP protocol {#replica-aware-routing-requires-http}
 

--- a/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
+++ b/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
@@ -2,7 +2,7 @@
 title: 'Replica-aware routing'
 slug: /manage/replica-aware-routing
 description: 'Route related requests to the same ClickHouse Cloud replica for temporary tables, sessions, cache reuse, and read-after-write consistency'
-keywords: ['cloud', 'sticky endpoints', 'sticky', 'endpoints', 'sticky routing', 'routing', 'replica aware routing', 'session_id', 'session affinity', 'temporary tables', 'read-after-write consistency']
+keywords: ['cloud', 'sticky endpoints', 'sticky', 'endpoints', 'sticky routing', 'routing', 'replica aware routing', 'X-ClickHouse-Replica-Tag', 'session_id', 'session affinity', 'temporary tables', 'read-after-write consistency']
 doc_type: 'guide'
 noindex: true
 ---
@@ -13,30 +13,79 @@ import { PrivatePreviewBadge } from "/snippets/components/PrivatePreviewBadge/Pr
 
 Replica-aware routing (also known as sticky sessions, sticky routing, or session affinity) routes related requests to the same ClickHouse replica. Use it when you need [temporary tables](/sql-reference/statements/create/table#temporary-tables) or [named session state](/interfaces/http#using-clickhouse-sessions-in-the-http-protocol) to stay reachable across queries, when you want related queries to reuse the same replica's local caches, or when you need [read-after-write consistency](#read-after-write-consistency) across a write and its follow-up reads.
 
-It's best-effort and doesn't guarantee isolation. Scaling, upgrades, and restarts can remap which replica a given `session_id` lands on.
+It's best-effort and doesn't guarantee isolation. The proxy maps each routing value to one replica. The mapping remains stable while the number of replicas remains unchanged; scaling the service can map the value to a different replica.
 
 <Warning>
 **Requires the HTTP interface**
 
-Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interface](/interfaces/http), using the `session_id` query parameter (see below). It's **not available over the native protocol** (native port, e.g. the [clickhouse-go](/integrations/go) driver in its default native mode). Native-protocol clients must switch to HTTP and pass a `session_id` on each request. For clickhouse-go (v2), set `Protocol: clickhouse.HTTP` and pass `session_id` as a [setting](/integrations/language-clients/go/database-sql-api#sessions). The driver sends it as the URL query parameter the proxy hashes on.
+Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interface](/interfaces/http). Select the routing method available for your service from the tabs below.
+
+Replica-aware routing is **not available over the native protocol** (native port, e.g. the [clickhouse-go](/integrations/go) driver in its default native mode). Native-protocol clients must switch to HTTP and send the routing value on every request.
 </Warning>
 
 ## Prerequisites {#prerequisites}
 
 - Your service needs **2 or more replicas**. On a single-replica service, there's nothing to pin to.
-- A **running** service. Waking an idle service can change which replica a `session_id` maps to.
 - Available on **Enterprise** by default when the feature is GA.
 - Supported on standard ClickHouse Cloud services. [BYOC](/cloud/reference/byoc/overview) isn't supported yet.
 
 ## Configuring replica-aware routing {#configuring-replica-aware-routing}
 
-Open a [support](https://clickhouse.com/support/program) ticket and ask to enable HTTP-based sticky replica routing. Include your service ID and why you need it (temporary tables, session state, cache reuse, or read-after-write consistency). After it's enabled, start sending `?session_id=` on HTTPS requests. No restart is required.
+Open a [support](https://clickhouse.com/support/program) ticket and ask to enable HTTP-based sticky replica routing. Include your service ID and why you need it (temporary tables, session state, cache reuse, or read-after-write consistency). After it's enabled, use the routing method available for your service. No restart is required.
 
-## HTTP-based routing (session_id) {#http-based-routing}
+## HTTP-based routing {#http-based-routing}
 
-To pin a workload to a replica, set the `session_id` query parameter on the [HTTPS interface](/interfaces/http). The proxy uses consistent hashing on that value to select a replica, so all requests sharing the same `session_id` go to the same server until the cluster topology changes.
+<Tabs>
+<Tab title="X-ClickHouse-Replica-Tag">
 
-You use your existing service hostname. No special sticky hostnames or DNS changes are required.
+To pin a workload to a replica, send an `X-ClickHouse-Replica-Tag` header on the [HTTPS interface](/interfaces/http). The proxy uses consistent hashing on the header value, so requests sharing it go to the same replica while the number of replicas remains unchanged. A different value hashes independently and may land on the same or a different replica, but you don't choose *which* replica a value maps to.
+
+Use your existing service hostname. No special sticky hostnames or DNS changes are required. The header value can be any string you choose, such as an application name, user ID, or workload label. Requests without the header keep normal load balancing.
+
+Set the `X-ClickHouse-Replica-Tag` header on each request:
+
+```bash
+echo 'SELECT hostName()' | curl \
+  -H 'X-ClickHouse-Replica-Tag: my-workload-1' \
+  -H 'X-ClickHouse-User: default' \
+  -H 'X-ClickHouse-Key: <password>' \
+  'https://<host>:8443/' -d @-
+```
+
+For clickhouse-go (v2), set `Protocol: clickhouse.HTTP` and pass the header with the [`HttpHeaders` connection option](/integrations/language-clients/go/configuration#connection-settings).
+
+<Info>
+The header controls proxy routing only. Concurrent requests can reuse the same header value.
+</Info>
+
+### Read-after-write consistency {#read-after-write-consistency}
+
+On a multi-replica service, a write on one replica may not be visible on the others until replication catches up. Send your write with an `X-ClickHouse-Replica-Tag` header, then reuse the same header value on follow-up reads. The proxy routes both to the same replica, so you read your own write even while other replicas are still behind. This pattern works for workloads that write and then immediately read back the same data, such as interactive applications or ETL jobs that validate inserts before moving on.
+
+For broader guarantees across all replicas, you can also set [`select_sequential_consistency`](/operations/settings/settings#select_sequential_consistency) to `1` on ClickHouse Cloud.
+
+### Check which replica you hit {#check-which-replica}
+
+Run the `SELECT hostName()` example again with the same `X-ClickHouse-Replica-Tag` value. You should get the same hostname while the number of replicas remains unchanged. A different header value may map to a different replica.
+
+</Tab>
+
+<Tab title="session_id (deprecated)">
+
+<Warning>
+The `session_id` routing method is deprecated. Use `X-ClickHouse-Replica-Tag` instead.
+</Warning>
+
+**Concurrent requests fail with `SESSION_IS_LOCKED`**
+
+- If you only need replica-aware routing, use `X-ClickHouse-Replica-Tag` and omit `session_id`. Concurrent requests can share the same replica tag.
+- If you need ClickHouse HTTP session state, serialize requests sharing a `session_id`; only one query can run in a session at a time. The `session_id` routing method is being deprecated, so prefer `X-ClickHouse-Replica-Tag` for replica-aware routing.
+
+To pin a workload to a replica, send a `session_id` query parameter on the [HTTPS interface](/interfaces/http). The proxy uses consistent hashing on the parameter value, so requests sharing it go to the same replica while the number of replicas remains unchanged. A different value hashes independently and may land on the same or a different replica, but you don't choose *which* replica a value maps to.
+
+Use your existing service hostname. No special sticky hostnames or DNS changes are required. The `session_id` can be any string you choose, such as an application name, user ID, or workload label. Requests without `session_id` keep normal load balancing.
+
+Set the `session_id` query parameter on each request:
 
 ```bash
 echo 'SELECT hostName()' | curl \
@@ -45,35 +94,36 @@ echo 'SELECT hostName()' | curl \
   'https://<host>:8443/?session_id=my-workload-1' -d @-
 ```
 
-Every request carrying `session_id=my-workload-1` lands on the same replica. A different `session_id` value hashes independently and may land on the same or a different replica. The mapping is consistent, but you don't choose *which* replica a given value maps to.
+For clickhouse-go (v2), set `Protocol: clickhouse.HTTP` and pass `session_id` as a [setting](/integrations/language-clients/go/database-sql-api#sessions). The driver sends it as a URL query parameter.
 
-`session_id` is any string you choose (application name, user id, or workload label). Requests without `session_id` keep normal load balancing.
+### Read-after-write consistency with `session_id` {#session-id-read-after-write-consistency}
 
-### Read-after-write consistency {#read-after-write-consistency}
-
-On a multi-replica service, a write on one replica may not be visible on the others until replication catches up. Send your write with a `session_id`, then reuse that same value on follow-up reads. The proxy routes both to the same replica, so you read your own write even while other replicas are still behind. This pattern works for workloads that write and then immediately read back the same data, such as interactive applications or ETL jobs that validate inserts before moving on.  
+On a multi-replica service, a write on one replica may not be visible on the others until replication catches up. Send your write with a `session_id`, then reuse the same `session_id` on follow-up reads. The proxy routes both to the same replica, so you read your own write even while other replicas are still behind. This pattern works for workloads that write and then immediately read back the same data, such as interactive applications or ETL jobs that validate inserts before moving on.
 
 For broader guarantees across all replicas, you can also set [`select_sequential_consistency`](/operations/settings/settings#select_sequential_consistency) to `1` on ClickHouse Cloud.
 
-### Check which replica you hit {#check-which-replica}
+### Check which replica you hit with `session_id` {#session-id-check-which-replica}
 
-Run the `SELECT hostName()` example above again with the same `session_id`. You should get the same hostname. A different `session_id` may map to a different replica.
+Run the `SELECT hostName()` example again with the same `session_id`. You should get the same hostname while the number of replicas remains unchanged. A different `session_id` may map to a different replica.
+
+</Tab>
+</Tabs>
 
 ## Subdomain-based routing (deprecated) {#subdomain-based-routing-deprecated}
 
 <Danger>
 **Deprecated**
 
-The subdomain-based mechanism is being **deprecated** and will no longer be enabled on new services. It doesn't scale (each sticky endpoint requires its own TLS certificate). Use the [HTTP-based `session_id` method](#http-based-routing) instead. If you already use sticky subdomains, contact [support](https://clickhouse.com/support/program) to enable `session_id` routing. This is a breaking change and will require migration.
+The subdomain-based mechanism is being **deprecated** and will no longer be enabled on new services. It doesn't scale (each sticky endpoint requires its own TLS certificate). Use the [HTTP header method](#http-based-routing) instead. If you already use sticky subdomains, contact [support](https://clickhouse.com/support/program) to enable HTTP-based routing. This is a breaking change and will require migration.
 </Danger>
 
 Previously, enabling replica-aware routing allowed a wildcard subdomain on top of the service hostname. For a service with the host name `abcxyz123.us-west-2.aws.clickhouse.cloud`, any hostname matching `*.sticky.abcxyz123.us-west-2.aws.clickhouse.cloud` (e.g. `aaa.sticky.abcxyz123.us-west-2.aws.clickhouse.cloud`) was hashed by Envoy to a consistent replica. The original hostname continued to use `LEAST_CONNECTION` load balancing, the default routing algorithm.
 
 ## Limitations of replica-aware routing {#limitations-of-replica-aware-routing}
 
-### Stickiness can break during service changes {#replica-aware-routing-does-not-guarantee-isolation}
+### Stickiness changes when the replica count changes {#replica-aware-routing-does-not-guarantee-isolation}
 
-Any disruption to the service changes the routing hash ring. That includes server pod restarts (version upgrade, crash, vertical scaling) and scaling out or in. Requests sharing the same `session_id` may then land on a different server pod. If you rely on temporary tables or session-level settings, be ready to recreate them after a remap.
+Scaling out or in changes the routing hash ring. Requests sharing the same routing value may then land on a different replica. If you rely on temporary tables or session-level settings, be ready to recreate them after a remap.
 
 ### Replica-aware routing isn't workload isolation {#not-workload-isolation}
 
@@ -81,18 +131,19 @@ Sticky routing only controls *which* replica handles a request. That replica may
 
 ### Private Link and the deprecated subdomain method {#replica-aware-routing-does-not-work-out-of-the-box-with-private-link}
 
-HTTP `session_id` routing works with [private networking](/cloud/security/connectivity/private-networking) on your normal service hostname. No extra DNS entries are required.
+HTTP-based routing works with [private networking](/cloud/security/connectivity/private-networking) on your normal service hostname. No extra DNS entries are required.
 
 The deprecated subdomain method doesn't: you must add DNS for the `*.sticky.*` hostname pattern, and incorrect setup can imbalance load across replicas.
 
 ### Replica-aware routing requires the HTTP protocol {#replica-aware-routing-requires-http}
 
-Sticky routing is keyed on the `session_id` query parameter, which only exists on the HTTP/HTTPS interface. The native binary protocol carries no such parameter for the proxy to hash on, so replica-aware routing isn't available over the native protocol. Today, native-protocol clients must move the relevant workload to the HTTP interface to use this feature.
+Sticky routing is keyed on an HTTP header or query parameter, depending on the routing method available for your service. The native binary protocol doesn't carry either value for the HTTP proxy to hash on, so replica-aware routing isn't available over the native protocol. Native-protocol clients must move the relevant workload to the HTTP interface to use this feature.
 
 ## Troubleshooting {#troubleshooting}
 
-**Queries still land on different replicas with the same `session_id`**
+**Queries still land on different replicas with the same routing value**
 
-- Confirm `session_id` is a URL query parameter (`?session_id=...`), not an HTTP header.
+- Confirm that you're using the routing method available for your service: the `X-ClickHouse-Replica-Tag` header or the legacy `session_id` URL query parameter.
+- Confirm that every request uses exactly the same routing value.
 - Wait briefly after enablement. It can take under a minute to take effect.
-- Check whether the service recently scaled or restarted; remapping is expected after topology changes. Use `SELECT hostName()` to discover the new mapping.
+- Check whether the number of replicas recently changed; remapping is expected after scaling. Use `SELECT hostName()` to discover the new mapping.


### PR DESCRIPTION
Updates the replica-aware routing documentation to describe `X-ClickHouse-Replica-Tag` as the preferred HTTP routing method while retaining the deprecated `session_id` instructions in a separate tab (to be removed after roll out)

The routing guarantee remains unchanged: a routing value maps consistently to one replica until the number of replicas changes. The updated guidance also explains that concurrent requests can reuse the same replica tag. Validated with the local Mint preview and `git diff --check`.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.