### PR TITLE
Scope `SHOW DATABASES` in 02105_backslash_letter_commands

### DIFF
--- a/tests/queries/0_stateless/02105_backslash_letter_commands.expect
+++ b/tests/queries/0_stateless/02105_backslash_letter_commands.expect
@@ -32,13 +32,16 @@ send -- "\\c;\r"
 expect "Syntax error: "
 expect ":) "
 
-send -- "  \\l ;  \\d;  \r"
+# The `like` predicate keeps the matched output independent of databases that
+# concurrently running tests create.
+send -- "  \\l like 'system' ;  \\d;  \r"
 expect ":) "
 
-send -- "  \\l  ;\r"
+send -- "  \\l like 'system'  ;\r"
 expect "SHOW"
 expect "DATABASES"
 expect "system"
+expect "1 row in set"
 expect ":) "
 
 send -- "\\c system;\r"


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`02105_backslash_letter_commands.expect` matches against `SHOW DATABASES`, whose size is set by
whatever other tests are running. It is the only one of the 54 `.expect` tests rendering
`SHOW DATABASES` or `SHOW TABLES` unscoped, which is why the sibling client tests passed in
every job where it failed.

The rendered table pads every row to the widest database name (bounded only by
`output_format_pretty_max_column_pad_width`, default 250), so a concurrent test creating very
long names inflated what this test must match by 7.6x. Past a few kilobytes the client stops
emitting output mid-stream, the prompt is never written, and `expect_after` turns the 60s
timeout into a failure. The reason strings `return code: 1` and
`Timeout! Killing process group` are one event.

This scopes both `\l` sends with `like 'system'`, the idiom this test already uses for `\d` on
line 49. Measured against ~120 databases whose widest name is 214 characters: the largest
buffer expect must retain drops from 6001 characters, exactly its cap of `3 * match_max + 1`,
to about 340, and buffers at that cap from 11 to 0. Interleaved to cancel load drift, the
current test fails 9 of 12 runs and the scoped one 0 of 12; 50 randomized and 50 plain runs
pass.

Since the client echoes the formatted query, the predicate alone would have let
`expect "system"` match the echoed `LIKE 'system'` rather than a result row, so the test also
gains a `1 row in set` assertion. That count is printed only below the rendered result, and the
unfiltered statement reports a count that varies with the environment and is never one.
`00419_show_sql_queries.sh` still covers unfiltered `SHOW DATABASES`.

I did not identify why the client stops writing, and this does not claim to. It removes the
measured precondition: a test matching unbounded output controlled by other tests.