### PR TITLE
Fix flaky `04655_pr_plan_based_join_runtime_filter_on_worker`

### DIFF
--- a/tests/queries/0_stateless/04655_pr_plan_based_join_runtime_filter_on_worker.reference
+++ b/tests/queries/0_stateless/04655_pr_plan_based_join_runtime_filter_on_worker.reference
@@ -1,4 +1,4 @@
 result	10000
 result	10000
-remote queries	1	filter built on worker	1	filter applied on worker	1
+remote queries	1	filter built on worker	1	filter applied on worker	1	filter never disabled	1
 no filter built	1

--- a/tests/queries/0_stateless/04655_pr_plan_based_join_runtime_filter_on_worker.sql
+++ b/tests/queries/0_stateless/04655_pr_plan_based_join_runtime_filter_on_worker.sql
@@ -34,6 +34,11 @@ SET query_plan_optimize_join_order_randomize = 0;
 -- Keep the filter on the row-level path: with index analysis the pruning happens at granule level instead,
 -- so the rows never reach `__applyFilter` and the row counters asserted below stop being comparable.
 SET enable_join_runtime_filters_index_analysis = 0;
+-- Never let the filter disable itself: `rf_build` holds the first 10000 probe keys and `rf_probe` is ordered
+-- by the same one, so a first block of at most 10000 rows passes every row and trips the pass-ratio
+-- heuristic. A skipped block is counted as `RuntimeFilterRowsSkipped` only, so it lands on neither side of
+-- the `Passed < Checked` assertion below, which then depends on the randomized block size.
+SET join_runtime_filter_blocks_to_skip_before_reenabling = 0;
 
 -- RIGHT JOIN: the build side is the coordinated side, so this is the shape whose split has to be lifted
 -- through `BuildRuntimeFilterStep` for the join to ship at all.
@@ -49,7 +54,8 @@ SYSTEM FLUSH LOGS query_log;
 SELECT 'remote queries', countIf(is_initial_query = 0) >= 1,
        'filter built on worker', sumIf(ProfileEvents['RuntimeFiltersCreated'], is_initial_query = 0) > 0,
        'filter applied on worker', sumIf(ProfileEvents['RuntimeFilterRowsPassed'], is_initial_query = 0)
-                                       < sumIf(ProfileEvents['RuntimeFilterRowsChecked'], is_initial_query = 0)
+                                       < sumIf(ProfileEvents['RuntimeFilterRowsChecked'], is_initial_query = 0),
+       'filter never disabled', sumIf(ProfileEvents['RuntimeFilterRowsSkipped'], is_initial_query = 0) = 0
 FROM system.query_log
 WHERE initial_query_id = (
     SELECT query_id FROM system.query_log


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/96844
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`04655_pr_plan_based_join_runtime_filter_on_worker` intermittently prints
`filter applied on worker 0` where the reference says `1`. Everything else stays correct,
`result 10000` included, so only the assertion that the filter was *applied* reads false. No related
open issue. It is unrelated to #96844, where it was last seen: `use_columns_cache` was randomized to
`0` there.

Root cause is the filter's self-disable heuristic. `IRuntimeFilter::updateStats` adds
`rows_checked * join_runtime_filter_blocks_to_skip_before_reenabling` to `rows_to_skip` once a block
passes more than `join_runtime_filter_pass_ratio_threshold_for_disabling` of its rows, and `find`
consults `shouldSkip` before `findImpl`. A skipped block increments `RuntimeFilterRowsSkipped` only,
so it counts on **neither** side of the test's `Passed < Checked`. `rf_build` holds the first 10000
probe keys and `rf_probe` is ordered by the same key, so a first block of at most 10000 rows passes
every row, trips the heuristic, and the rest of the scan is skipped: `Passed == Checked` and a strict
`<` that is false.

The test pins the heuristic off, so the counters stay comparable at any block size. No `src/` change:
the heuristic is correct product behaviour, asserted by
`03753_join_runtime_filter_dynamically_disable.sql`. Neither self-disable setting is randomized by
`clickhouse-test`, so this costs no coverage and the test keeps its `max_block_size` and
`max_threads` randomization, unlike a blanket `no-random-settings` tag.
`04357_join_runtime_filter_size_from_hash_table_stats.sql` and `03753` already pin the sibling.

The oracle also gains a `filter never disabled` column asserting `RuntimeFilterRowsSkipped = 0`, with
its passing value `1` appended to the reference row. That is a new assertion, not a re-baseline: the
three existing columns and their expected values are untouched. Without it the test passes when
the heuristic fires only part-way through the scan, since `Passed < Checked` still holds while the
first block is partly matching -- over a 36-cell grid the unfixed test satisfies the old oracle in 24
cells the new column reddens. `03753` asserts `RuntimeFilterBlocksSkipped = 0` too.

<details>
<summary>Validation</summary>

Reproducing it needs the whole randomized settings set from the failing run, which is why the earlier
`enable_join_runtime_filters_index_analysis` pin did not help and why a plain local re-run does not.
Two of those settings are individually necessary - `max_block_size <= 10000`, and
`min_bytes_for_wide_part` low enough that the fixture is Wide - but not sufficient: forcing only
those two over a 36-cell grid never reproduces, because the reader still rounds the first block up to
a granule multiple. Shrinking the recorded set gives a minimal reproducing subset of three query and
six MergeTree settings, itself marginal at two reproductions in three. The test's DDL sets none of
them, so the runner's injected values apply.

Replaying the failing run's full recorded settings:

| arm | `Checked` | `Passed` | `Skipped` | prints |
|---|---|---|---|---|
| before, 3/3 runs | 9954 | 9954 | 290046 | `0` |
| after, 5/5 runs | 300000 | 10000 | 0 | `1` |

`Checked + Skipped` is 300000 in both, so the difference is only which blocks reached the filter.
A 36-cell grid over `max_block_size` x `max_threads` x part type passes 36/36 after the change,
with `Skipped == 0` in every cell, and reddens in exactly 24 cells without it. Removing just the new
`SET` line reproduces the failure 3/3 with the same counters, so the pin is what fixes it. Removing
the new assertion column as well - the oracle as it stood before this change - makes that same cell
pass again, which is the blindness the column closes. 50 runs with randomization plus 50 with
`--no-random-settings` pass, and all 59 runtime-filter and plan-based-parallel-replicas tests pass.
Against the old three-column oracle the unfixed test passed 50/50, because the trigger is drawn far
more rarely than that; against the new column it fails 3/50, so the column is also the stronger
detector. The replay arms above remain the evidence, and the 50-run batches are corroboration.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.957` (included in `26.8` and later)
<!-- ch-version-info:end -->