### PR TITLE
Fix(PromQL): Merge non-overlapping series after unary negation in PromQL

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyUnaryOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyUnaryOperator.cpp
@@ -111,7 +111,7 @@ SQLQueryPiece applyUnaryOperator(
 
             res.select_query = builder.getSelectQuery();
 
-            return dropMetricName(std::move(res), context);
+            return dropMetricName(std::move(res), context, DuplicateSeriesHandling::MERGE_NON_OVERLAPPING);
         }
 
         case StoreMethod::CONST_STRING:

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/dropMetricName.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/dropMetricName.cpp
@@ -37,8 +37,8 @@ SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & co
         case StoreMethod::VECTOR_GRID:
         {
             /// When we remove the metric name `__name__` it's possible that we get the same set of tags (i.e. the same `group`)
-            /// on time series which were different before we removed the metric name.
-            /// This is not allowed, we can't have multiple time series with the same set of tags in the same resultset.
+            /// on time series which were different before we removed the metric name. PromQL merges such series when
+            /// their samples don't overlap, but rejects them when they have samples at the same timestamp.
             ///
             /// Example:
             ///             tags                           timestamp1        timestamp2
@@ -50,14 +50,15 @@ SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & co
             /// {tag1='value1', tag2='value2'}              value_a           value_b
             /// {tag1='value1', tag2='value2'}              value_c           value_d
             ///
-            /// That's why we need the function timeSeriesThrowDuplicateSeriesIf() to detect such cases and throw an exception.
+            /// That's why we merge values element-wise and use timeSeriesThrowDuplicateSeriesIf() to detect overlapping samples.
 
             /// Step 1:
             /// SELECT timeSeriesRemoveTag(group, '__name__') AS new_group,
-            ///        any(values) AS values
+            ///        anyForEach(values) AS values
             /// FROM <vector_grid>
             /// GROUP BY new_group
-            /// HAVING timeSeriesThrowDuplicateSeriesIf(count() > 1, new_group) = 0
+            /// HAVING timeSeriesThrowDuplicateSeriesIf(
+            ///     arrayExists(x -> x > 1, countForEach(values)), new_group) = 0
             ASTPtr metric_name_removing_query;
             {
                 SelectQueryBuilder builder;
@@ -66,7 +67,7 @@ SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & co
                     "timeSeriesRemoveTag", make_intrusive<ASTIdentifier>(ColumnNames::Group), make_intrusive<ASTLiteral>(kMetricName)));
                 builder.select_list.back()->setAlias(ColumnNames::NewGroup);
 
-                builder.select_list.push_back(makeASTFunction("any", make_intrusive<ASTIdentifier>(ColumnNames::Values)));
+                builder.select_list.push_back(makeASTFunction("anyForEach", make_intrusive<ASTIdentifier>(ColumnNames::Values)));
                 builder.select_list.back()->setAlias(ColumnNames::Values);
 
                 context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(query_piece.select_query), SQLSubqueryType::TABLE});
@@ -78,7 +79,12 @@ SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & co
                     "equals",
                     makeASTFunction(
                         "timeSeriesThrowDuplicateSeriesIf",
-                        makeASTFunction("greater", makeASTFunction("count"), make_intrusive<ASTLiteral>(1u)),
+                        makeASTFunction(
+                            "arrayExists",
+                            makeASTLambda(
+                                {"x"},
+                                makeASTFunction("greater", make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTLiteral>(1u))),
+                            makeASTFunction("countForEach", make_intrusive<ASTIdentifier>(ColumnNames::Values))),
                         make_intrusive<ASTIdentifier>(ColumnNames::NewGroup)),
                     make_intrusive<ASTLiteral>(0u));
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/dropMetricName.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/dropMetricName.cpp
@@ -21,7 +21,8 @@ namespace
 constexpr auto MergedValues = "merged_values";
 }
 
-SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & context)
+SQLQueryPiece dropMetricName(
+    SQLQueryPiece && query_piece, ConverterContext & context, DuplicateSeriesHandling duplicate_series_handling)
 {
     if (query_piece.metric_name_dropped)
         return std::move(query_piece);
@@ -42,8 +43,9 @@ SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & co
         case StoreMethod::VECTOR_GRID:
         {
             /// When we remove the metric name `__name__` it's possible that we get the same set of tags (i.e. the same `group`)
-            /// on time series which were different before we removed the metric name. PromQL merges such series when
-            /// their samples don't overlap, but rejects them when they have samples at the same timestamp.
+            /// on time series which were different before we removed the metric name. By default such duplicate series
+            /// are rejected. Callers that need PromQL's unary-negation behavior can request merging when their samples
+            /// don't overlap, while still rejecting samples at the same timestamp.
             ///
             /// Example:
             ///             tags                           timestamp1        timestamp2
@@ -55,49 +57,70 @@ SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & co
             /// {tag1='value1', tag2='value2'}              value_a           value_b
             /// {tag1='value1', tag2='value2'}              value_c           value_d
             ///
-            /// That's why we merge values element-wise and use timeSeriesThrowDuplicateSeriesIf() to detect overlapping samples.
+            /// In merge mode, values are merged element-wise and timeSeriesThrowDuplicateSeriesIf() detects overlapping samples.
 
             /// Step 1:
-            /// SELECT timeSeriesRemoveTag(group, '__name__') AS new_group,
-            ///        anyForEach(values) AS merged_values
+            /// SELECT timeSeriesRemoveTag(group, '__name__') AS new_group, ...
             /// FROM <vector_grid>
             /// GROUP BY new_group
-            /// HAVING timeSeriesThrowDuplicateSeriesIf(
-            ///     arrayExists(x -> x > 1, countForEach(values)), new_group) = 0
+            /// HAVING ...
             ASTPtr metric_name_removing_query;
             {
                 SelectQueryBuilder builder;
+
+                const bool merge_non_overlapping = duplicate_series_handling == DuplicateSeriesHandling::MERGE_NON_OVERLAPPING;
 
                 builder.select_list.push_back(makeASTFunction(
                     "timeSeriesRemoveTag", make_intrusive<ASTIdentifier>(ColumnNames::Group), make_intrusive<ASTLiteral>(kMetricName)));
                 builder.select_list.back()->setAlias(ColumnNames::NewGroup);
 
-                builder.select_list.push_back(makeASTFunction("anyForEach", make_intrusive<ASTIdentifier>(ColumnNames::Values)));
-                builder.select_list.back()->setAlias(MergedValues);
+                if (merge_non_overlapping)
+                {
+                    builder.select_list.push_back(makeASTFunction("anyForEach", make_intrusive<ASTIdentifier>(ColumnNames::Values)));
+                    builder.select_list.back()->setAlias(MergedValues);
+                }
+                else
+                {
+                    builder.select_list.push_back(makeASTFunction("any", make_intrusive<ASTIdentifier>(ColumnNames::Values)));
+                    builder.select_list.back()->setAlias(ColumnNames::Values);
+                }
 
                 context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(query_piece.select_query), SQLSubqueryType::TABLE});
                 builder.from_table = context.subqueries.back().name;
 
                 builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
 
-                builder.having = makeASTFunction(
-                    "equals",
-                    makeASTFunction(
-                        "timeSeriesThrowDuplicateSeriesIf",
+                if (merge_non_overlapping)
+                {
+                    builder.having = makeASTFunction(
+                        "equals",
                         makeASTFunction(
-                            "arrayExists",
-                            makeASTLambda(
-                                {"x"},
-                                makeASTFunction("greater", make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTLiteral>(1u))),
-                            makeASTFunction("countForEach", make_intrusive<ASTIdentifier>(ColumnNames::Values))),
-                        make_intrusive<ASTIdentifier>(ColumnNames::NewGroup)),
-                    make_intrusive<ASTLiteral>(0u));
+                            "timeSeriesThrowDuplicateSeriesIf",
+                            makeASTFunction(
+                                "arrayExists",
+                                makeASTLambda(
+                                    {"x"},
+                                    makeASTFunction("greater", make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTLiteral>(1u))),
+                                makeASTFunction("countForEach", make_intrusive<ASTIdentifier>(ColumnNames::Values))),
+                            make_intrusive<ASTIdentifier>(ColumnNames::NewGroup)),
+                        make_intrusive<ASTLiteral>(0u));
+                }
+                else
+                {
+                    builder.having = makeASTFunction(
+                        "equals",
+                        makeASTFunction(
+                            "timeSeriesThrowDuplicateSeriesIf",
+                            makeASTFunction("greater", makeASTFunction("count"), make_intrusive<ASTLiteral>(1u)),
+                            make_intrusive<ASTIdentifier>(ColumnNames::NewGroup)),
+                        make_intrusive<ASTLiteral>(0u));
+                }
 
                 metric_name_removing_query = builder.getSelectQuery();
             }
 
             /// Step 2:
-            /// SELECT new_group AS group, merged_values AS values
+            /// SELECT new_group AS group, <values> AS values
             /// FROM step1
             ASTPtr column_renaming_query;
             {
@@ -106,8 +129,15 @@ SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & co
                 builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
                 builder.select_list.back()->setAlias(ColumnNames::Group);
 
-                builder.select_list.push_back(make_intrusive<ASTIdentifier>(MergedValues));
-                builder.select_list.back()->setAlias(ColumnNames::Values);
+                if (duplicate_series_handling == DuplicateSeriesHandling::MERGE_NON_OVERLAPPING)
+                {
+                    builder.select_list.push_back(make_intrusive<ASTIdentifier>(MergedValues));
+                    builder.select_list.back()->setAlias(ColumnNames::Values);
+                }
+                else
+                {
+                    builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Values));
+                }
 
                 context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(metric_name_removing_query), SQLSubqueryType::TABLE});
                 builder.from_table = context.subqueries.back().name;

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/dropMetricName.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/dropMetricName.cpp
@@ -16,6 +16,11 @@ namespace DB::ErrorCodes
 namespace DB::PrometheusQueryToSQL
 {
 
+namespace
+{
+constexpr auto MergedValues = "merged_values";
+}
+
 SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & context)
 {
     if (query_piece.metric_name_dropped)
@@ -54,7 +59,7 @@ SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & co
 
             /// Step 1:
             /// SELECT timeSeriesRemoveTag(group, '__name__') AS new_group,
-            ///        anyForEach(values) AS values
+            ///        anyForEach(values) AS merged_values
             /// FROM <vector_grid>
             /// GROUP BY new_group
             /// HAVING timeSeriesThrowDuplicateSeriesIf(
@@ -68,7 +73,7 @@ SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & co
                 builder.select_list.back()->setAlias(ColumnNames::NewGroup);
 
                 builder.select_list.push_back(makeASTFunction("anyForEach", make_intrusive<ASTIdentifier>(ColumnNames::Values)));
-                builder.select_list.back()->setAlias(ColumnNames::Values);
+                builder.select_list.back()->setAlias(MergedValues);
 
                 context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(query_piece.select_query), SQLSubqueryType::TABLE});
                 builder.from_table = context.subqueries.back().name;
@@ -92,7 +97,7 @@ SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & co
             }
 
             /// Step 2:
-            /// SELECT new_group AS group, values
+            /// SELECT new_group AS group, merged_values AS values
             /// FROM step1
             ASTPtr column_renaming_query;
             {
@@ -101,7 +106,8 @@ SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & co
                 builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
                 builder.select_list.back()->setAlias(ColumnNames::Group);
 
-                builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Values));
+                builder.select_list.push_back(make_intrusive<ASTIdentifier>(MergedValues));
+                builder.select_list.back()->setAlias(ColumnNames::Values);
 
                 context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(metric_name_removing_query), SQLSubqueryType::TABLE});
                 builder.from_table = context.subqueries.back().name;

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/dropMetricName.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/dropMetricName.h
@@ -6,9 +6,20 @@
 namespace DB::PrometheusQueryToSQL
 {
 
+/// Controls how duplicate labelsets are handled after the metric name is removed.
+enum class DuplicateSeriesHandling
+{
+    THROW,
+    MERGE_NON_OVERLAPPING,
+};
+
 /// Drops the metric name (i.e. tag '__name__') if it hasn't been dropped before.
 /// Prometheus functions and operators returning instant vectors almost always do that.
 /// The function must not be called with StoreMethod::RAW_DATA.
-SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & context);
+/// By default duplicate labelsets are rejected; callers can request merging of non-overlapping samples.
+SQLQueryPiece dropMetricName(
+    SQLQueryPiece && query_piece,
+    ConverterContext & context,
+    DuplicateSeriesHandling duplicate_series_handling = DuplicateSeriesHandling::THROW);
 
 }

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -590,6 +590,32 @@ def do_clickhouse_only_range_query_test(
     ), f"actual_result_from_http_api: {actual_result_from_http_api}, expected: {result}"
 
 
+def do_clickhouse_only_range_query_test_expect_error(
+    query,
+    start_time,
+    end_time,
+    step,
+    expected_cherror,
+):
+    quoted_query = "'" + query.replace("'", "''") + "'"
+    sql_query = (
+        f"SELECT * FROM prometheusQueryRange(prometheus, {quoted_query}, {start_time}, {end_time}, {step})"
+    )
+    assert expected_cherror in node.query_and_get_error(sql_query)
+
+    actual_result_from_http_api = execute_range_query_via_http_api(
+        node.ip_address,
+        9093,
+        "/api/v1/query_range",
+        query,
+        start_time,
+        end_time,
+        step,
+        expect_error=True,
+    )
+    assert expected_cherror in actual_result_from_http_api
+
+
 def test_up():
     do_query_test(
         "up",
@@ -2593,6 +2619,23 @@ def test_multiple_series_in_same_resultset():
         200,
         "vector cannot contain metrics with the same labelset",
         "Multiple series have the same tags {'http_code': '404'}",
+    )
+
+    send_data(
+        [
+            ({"__name__": "rate_requests", "job": "rate_scope"}, {10: 1, 60: 2}),
+            ({"__name__": "rate_errors", "job": "rate_scope"}, {1210: 3, 1260: 5}),
+        ]
+    )
+
+    # Range functions keep the strict duplicate-labelset behavior. The two rate
+    # series do not overlap in the grid, but they still collapse to one labelset.
+    do_clickhouse_only_range_query_test_expect_error(
+        'rate({job="rate_scope"}[60s])',
+        0,
+        1260,
+        60,
+        "Multiple series have the same tags {'job': 'rate_scope'}",
     )
 
     # FIXME: Function count_over_time() is not implemented yet.

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -566,6 +566,30 @@ def do_clickhouse_only_query_test(
     ), f"actual_result_from_http_api: {actual_result_from_http_api}, expected: {result}"
 
 
+def do_clickhouse_only_range_query_test(
+    query,
+    start_time,
+    end_time,
+    step,
+    result,
+    chresult,
+    eps=0,
+):
+    actual_chresult = execute_range_query_in_clickhouse_sql(
+        query, start_time, end_time, step
+    )
+    assert tsv_close_to(
+        actual_chresult, chresult, eps=eps
+    ), f"actual result: {actual_chresult}, expected: {chresult}"
+
+    actual_result_from_http_api = execute_range_query_in_clickhouse_http_api(
+        query, start_time, end_time, step
+    )
+    assert http_api_response_close_to(
+        actual_result_from_http_api, result, eps=eps
+    ), f"actual_result_from_http_api: {actual_result_from_http_api}, expected: {result}"
+
+
 def test_up():
     do_query_test(
         "up",
@@ -1223,7 +1247,9 @@ def test_unary_operators():
         [["[('job','unary')]", "1970-01-01 00:20:00.000", -4]],
     )
 
-    do_range_query_test(
+    # Prometheus v3.5.0 rejects duplicate labelsets across a range result even when
+    # the samples occur at different timestamps, so this checks ClickHouse directly.
+    do_clickhouse_only_range_query_test(
         '-{job="unary"}',
         0,
         1200,

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -1201,6 +1201,55 @@ def test_unary_operators():
         ],
     )
 
+    send_data(
+        [
+            ({"__name__": "unary_requests", "job": "unary"}, {0: 2}),
+            ({"__name__": "unary_errors", "job": "unary"}, {1200: 4}),
+        ]
+    )
+
+    # Removing __name__ must merge series that have no samples at the same timestamp.
+    do_query_test(
+        '-{job="unary"}',
+        0,
+        '{"resultType": "vector", "result": [{"metric": {"job": "unary"}, "value": [0, "-2"]}]}',
+        [["[('job','unary')]", "1970-01-01 00:00:00.000", -2]],
+    )
+
+    do_query_test(
+        '-{job="unary"}',
+        1200,
+        '{"resultType": "vector", "result": [{"metric": {"job": "unary"}, "value": [1200, "-4"]}]}',
+        [["[('job','unary')]", "1970-01-01 00:20:00.000", -4]],
+    )
+
+    do_range_query_test(
+        '-{job="unary"}',
+        0,
+        1200,
+        1200,
+        '{"resultType": "matrix", "result": [{"metric": {"job": "unary"}, "values": [[0, "-2"], [1200, "-4"]]}]}',
+        [[
+            "[('job','unary')]",
+            "[('1970-01-01 00:00:00.000',-2),('1970-01-01 00:20:00.000',-4)]",
+        ]],
+    )
+
+    send_data(
+        [
+            ({"__name__": "unary_requests", "job": "unary_overlap"}, {2400: 1}),
+            ({"__name__": "unary_errors", "job": "unary_overlap"}, {2400: 2}),
+        ]
+    )
+
+    # The same labelset at the same timestamp is still an error.
+    do_query_test_expect_error(
+        '-{job="unary_overlap"}',
+        2400,
+        "vector cannot contain metrics with the same labelset",
+        "Multiple series have the same tags {'job': 'unary_overlap'}",
+    )
+
 
 def test_conversion_functions():
     do_query_test(

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -1302,6 +1302,26 @@ def test_unary_operators():
         "Multiple series have the same tags {'job': 'unary_overlap'}",
     )
 
+    send_data(
+        [
+            ({"__name__": "metric_a"}, {0: 1}),
+            ({"__name__": "metric_b"}, {0: 3, 600: 4}),
+        ]
+    )
+
+    # Unary metric-name removal must also compose correctly with the OR operator.
+    do_range_query_test(
+        "-metric_a or -metric_b",
+        0,
+        1200,
+        600,
+        '{"resultType": "matrix", "result": [{"metric": {}, "values": [[0, "-1"], [600, "-4"]]}]}',
+        [[
+            "[]",
+            "[('1970-01-01 00:00:00.000',-1),('1970-01-01 00:10:00.000',-4)]",
+        ]],
+    )
+
 
 def test_conversion_functions():
     do_query_test(


### PR DESCRIPTION
### Changelog category (leave one):
- **Bug Fix (user-visible misbehavior in an official stable release)**

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
**Merge non-overlapping PromQL series after unary negation while preserving strict duplicate-labelset checks for other operations.**

### Description

When unary negation removes `__name__`, series with different metric names can end up with the same labelset.

PromQL behavior:

- Non-overlapping samples are merged into one series.
- Samples at the same timestamp still return a duplicate labelset error.

Implementation:

- `dropMetricName` now accepts a `DuplicateSeriesHandling` policy.
- Existing callers keep the strict `THROW` behavior by default.
- Unary negation uses `MERGE_NON_OVERLAPPING`.
- `anyForEach` merges the values, while `countForEach` detects overlapping samples.
- The intermediate `merged_values` alias is renamed to `values` in the outer query.

### Tests

- Instant unary queries with non-overlapping samples.
- Range unary query with merged samples.
- Unary collision error.
- Unary negation combined with `OR`.
- `rate` regression confirming strict duplicate-labelset behavior is unchanged.
- Range cases checked directly against ClickHouse because Prometheus v3.5.0 rejects duplicate labelsets in range responses.
- `python -m py_compile tests/integration/test_prometheus_protocols/test_evaluation.py`
- `--check`

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113721&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/113721](https://github.com/search?q=head%3Async-upstream%2Fpr%2F113721+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
