### PR TITLE
Fix flaky NATS test_direct_select_leftover_does_not_pollute_view

### DIFF
--- a/tests/integration/test_storage_nats/test_system_stop.py
+++ b/tests/integration/test_storage_nats/test_system_stop.py
@@ -99,6 +99,22 @@ def jetstream_ack_pending(nats_cluster, stream, durable):
     return asyncio.run(run())
 
 
+def jetstream_delivered_count(nats_cluster, stream, durable):
+    """Cumulative number of deliveries to the consumer. Monotone, and it counts redeliveries,
+    unlike num_ack_pending, which stops rising once every message is already pending."""
+
+    async def run():
+        nc = await nats_connect_ssl(nats_cluster)
+        js = nc.jetstream()
+        info = await js.consumer_info(stream, durable)
+        await nc.close()
+        return info.delivered
+
+    delivered = asyncio.run(run())
+    assert delivered is not None, f"consumer {durable} reported no delivery information"
+    return delivered.consumer_seq
+
+
 def setup_consuming_table(table, subject):
     instance.query(
         f"""
@@ -745,16 +761,36 @@ def test_direct_select_leftover_does_not_pollute_view(nats_cluster):
     )
     jetstream_publish(nats_cluster, subject, 0, n)
 
-    # One direct read returns a single row (block size 1) and leaves the rest of the delivered burst
-    # buffered locally; retry until a read returns, confirming the burst was delivered.
-    for _ in range(40):
-        res = instance.query(
-            f"SELECT key FROM test.{table} SETTINGS stream_like_engine_allow_direct_select = 1",
-            ignore_error=True,
+    # A direct read returns a single row (block size 1) while the broker keeps streaming the rest of
+    # the burst into the consumer's local queue, so a read that returns a row proves only that one
+    # message arrived. Retry until one read is seen to have been delivered more than it returned,
+    # which is what leaves stale copies for the view below to inherit. Each attempt issues exactly
+    # one read on purpose: a second read drops that queue before resubscribing. The surplus is
+    # measured on delivered.consumer_seq because num_ack_pending stops rising once all messages are
+    # already pending, and ack_wait here is short enough for that to happen.
+    deadline = time.time() + 60
+    left_over = False
+    returned = surplus = 0
+    while time.time() < deadline and not left_over:
+        delivered_before = jetstream_delivered_count(nats_cluster, stream, durable)
+        returned = len(
+            [
+                key
+                for key in instance.query(
+                    f"SELECT key FROM test.{table} SETTINGS stream_like_engine_allow_direct_select = 1",
+                    ignore_error=True,
+                ).split()
+                if key.strip()
+            ]
         )
-        if res.strip():
-            break
-    assert jetstream_ack_pending(nats_cluster, stream, durable) == n
+        surplus = jetstream_delivered_count(nats_cluster, stream, durable) - delivered_before
+        left_over = returned > 0 and surplus > returned
+        if not left_over:
+            time.sleep(0.3)
+    assert left_over, (
+        f"no direct SELECT left unreturned messages buffered in the consumer "
+        f"(last attempt returned {returned} of {surplus} delivered)"
+    )
 
     # Let the unacked messages pass ack_wait so the broker will redeliver them to the next subscription.
     time.sleep(3)

--- a/tests/integration/test_storage_nats/test_system_stop.py
+++ b/tests/integration/test_storage_nats/test_system_stop.py
@@ -99,22 +99,6 @@ def jetstream_ack_pending(nats_cluster, stream, durable):
     return asyncio.run(run())
 
 
-def jetstream_delivered_count(nats_cluster, stream, durable):
-    """Cumulative number of deliveries to the consumer. Monotone, and it counts redeliveries,
-    unlike num_ack_pending, which stops rising once every message is already pending."""
-
-    async def run():
-        nc = await nats_connect_ssl(nats_cluster)
-        js = nc.jetstream()
-        info = await js.consumer_info(stream, durable)
-        await nc.close()
-        return info.delivered
-
-    delivered = asyncio.run(run())
-    assert delivered is not None, f"consumer {durable} reported no delivery information"
-    return delivered.consumer_seq
-
-
 def setup_consuming_table(table, subject):
     instance.query(
         f"""
@@ -761,36 +745,15 @@ def test_direct_select_leftover_does_not_pollute_view(nats_cluster):
     )
     jetstream_publish(nats_cluster, subject, 0, n)
 
-    # A direct read returns a single row (block size 1) while the broker keeps streaming the rest of
-    # the burst into the consumer's local queue, so a read that returns a row proves only that one
-    # message arrived. Retry until one read is seen to have been delivered more than it returned,
-    # which is what leaves stale copies for the view below to inherit. Each attempt issues exactly
-    # one read on purpose: a second read drops that queue before resubscribing. The surplus is
-    # measured on delivered.consumer_seq because num_ack_pending stops rising once all messages are
-    # already pending, and ack_wait here is short enough for that to happen.
+    # A block-size-1 read returns one row while the broker is still streaming the rest of the burst,
+    # so keep reading until all n are delivered and unacked, leaving stale copies for the view below.
     deadline = time.time() + 60
-    left_over = False
-    returned = surplus = 0
-    while time.time() < deadline and not left_over:
-        delivered_before = jetstream_delivered_count(nats_cluster, stream, durable)
-        returned = len(
-            [
-                key
-                for key in instance.query(
-                    f"SELECT key FROM test.{table} SETTINGS stream_like_engine_allow_direct_select = 1",
-                    ignore_error=True,
-                ).split()
-                if key.strip()
-            ]
+    while time.time() < deadline and jetstream_ack_pending(nats_cluster, stream, durable) < n:
+        instance.query(
+            f"SELECT key FROM test.{table} SETTINGS stream_like_engine_allow_direct_select = 1",
+            ignore_error=True,
         )
-        surplus = jetstream_delivered_count(nats_cluster, stream, durable) - delivered_before
-        left_over = returned > 0 and surplus > returned
-        if not left_over:
-            time.sleep(0.3)
-    assert left_over, (
-        f"no direct SELECT left unreturned messages buffered in the consumer "
-        f"(last attempt returned {returned} of {surplus} delivered)"
-    )
+    assert jetstream_ack_pending(nats_cluster, stream, durable) == n
 
     # Let the unacked messages pass ack_wait so the broker will redeliver them to the next subscription.
     time.sleep(3)


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_storage_nats/test_system_stop.py::test_direct_select_leftover_does_not_pollute_view` failed
with `assert 6 == 10` on `Integration tests (arm_binary, distributed plan, 1/4)`. No related open
issue found.

**What breaks.** The guard loop exited on the first direct `SELECT` that returned any row, and the
next line asserted an exact count of unacknowledged messages. `StorageNATS` builds every
`NATSSource` with `max_block_size = 1`, so a read returns after one row, while JetStream delivery is
asynchronous and per message: one fetch request covers up to 128 messages and the broker streams them
into the consumer callback one at a time, so `num_ack_pending` rises per delivered message. The loop
therefore proved only that one message had arrived while the assertion demanded all ten, so on a fast
runner it read the count mid-burst. The failing run took 293 ms against an OK median of 10.3 s for a
test whose mandatory sleeps total 8 s, all after that line, which places the abort there.

**What the change does.** It keeps issuing direct reads until the broker reports all `n` messages
delivered and unacknowledged, then asserts that count. This is the polling idiom
`test_commit_on_select_consumes_only_when_enabled` already uses a few functions above, at the same
`ack_wait`. The original assertion is unchanged, no new helper is needed, and the loop is bounded by
a deadline: five lines, one file.

**Validation.** Test-only change; nothing under `src/`.

<details><summary>Validation detail</summary>

The natural reproduction is vacuous: filtering `default.checks` to this `test_name` gives one failure
ever, against tens of thousands of OK runs and none on master. The CI race is transient, so the
witness is a consumer `max_ack_pending = 6` that a background thread lifts mid-test: the pending
count is temporarily below `n`, which is the reported observable, and eventually reaches it.

| arm | result |
|---|---|
| pre-fix (identical to master), transient cap, 3 runs | 3 failed, `assert 6 == 10` (the reported message) |
| post-fix, same cap, 5 runs | 5 passed |
| post-fix, unmodified, 20 runs | 20 passed |
| whole module, post-fix | 29 passed, 0 regressions, 29 = the module's test count |

The cap is scaffolding for the measurement and is not part of this change.

Deleting `consumer->dropBuffered()` from `StorageNATS::subscribeConsumers`, the one-line source
change this test guards, still fails the test: 10 repeats give zero passes. It reddens at the
duplicated-rows assertion (`stale direct-SELECT copies duplicated rows in the view`) and, in the
repeats where the stale handle is acked on the closed direct-read subscription, crashes the server in
`natsMsg_Ack`. Those are the two consequences the test's own comment describes.

The sibling test whose idiom this adopts has no recorded failure over the same 60-day window, at the
same `ack_wait`.

</details>
