### PR TITLE
Fix `01603_read_with_backoff_bug` false-positive TOO_SLOW on the coverage build

### DIFF
--- a/tests/queries/0_stateless/01603_read_with_backoff_bug.sql
+++ b/tests/queries/0_stateless/01603_read_with_backoff_bug.sql
@@ -9,10 +9,12 @@ set max_rows_to_read = '30M';
 drop table if exists t;
 
 create table t (x UInt64, s String) engine = MergeTree order by x SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+-- Read-backoff test, not a perf test: only the first third of the rows build a long string,
+-- so the linear estimated-time projection false-positives this `INSERT` (`TOO_SLOW`).
 INSERT INTO t SELECT
     number,
     if(number < (8129 * 1024), arrayStringConcat(arrayMap(x -> toString(x), range(number % 128)), ' '), '')
-FROM numbers_mt((8129 * 1024) * 3) settings max_insert_threads=8, max_rows_to_read=0, max_memory_usage='10Gi';
+FROM numbers_mt((8129 * 1024) * 3) settings max_insert_threads=8, max_rows_to_read=0, max_memory_usage='10Gi', max_estimated_execution_time=0;
 
 -- optimize table t final;
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`01603_read_with_backoff_bug` fails on master with `Code: 160 TOO_SLOW`, only on
`Stateless tests (amd_llvm_coverage_per_test, per_test_coverage, 1/8)` - 7 times in 60 days on 7
distinct commits. No check without `coverage` in its name produces a `TOO_SLOW` row for this test in
that window.

Nothing hangs. The killed statement is the `INSERT`, never one of the three read-backoff `SELECT`s
the test asserts. It is killed by the *projection* behind `max_estimated_execution_time`, which
`tests/config/users.d/limits.yaml` sets to 600 s for every stateless job, alongside
`timeout_before_checking_execution_speed: 300`.

Root cause: that projection is linear - `elapsed * total_rows / read_rows` - while this `INSERT`'s
per-row cost is step-shaped. `if (number < 8129 * 1024, arrayStringConcat(...), '')` builds a long
string for exactly the first 33.333% of the rows and `''` for the rest, so a rate sampled inside
that expensive third and extrapolated over the cheap two-thirds overstates the total. Over 180 days
all 29 failures fire with 29.39-47.10% of rows read: at or near that third, and capped below ~50%
because the same ratio has to exceed 600 s to throw at all. Coverage only decides *whether* the
300 s sample lands inside the third, hence OK runs sometimes slower than failing ones (07-21 OK at
345.6 s vs 08-03 FAIL at 307.5 s).

Fix: pin `max_estimated_execution_time=0` on that `INSERT`'s existing `settings` clause. The 600 s
ceiling stays armed for the three `SELECT`s and every other test; the runner wall clock remains the
real safety net. Assertions, row count and `.reference` untouched. Same shape as
`02161_addressToLineWithInlines`, `03560_parallel_replicas_memory_bound_merging_projection` and the
`04033_tpc_ds` / `04040_tpc_h` libs, which pin it for the same reason.

Verified by scaling both profile settings to the measured crossing point: 15/15 fail before, 15/15
pass after. Completed-run margin and the rest of the validation are below.

<details>
<summary>Validation</summary>

Debug build, real CI config overlay, both settings asserted live and `buildId()` asserted against the
binary on every arm. A debug build finishes the expensive third in ~1.3 s, so at 300/600 the guard
never engages; the mechanism was reproduced by scaling the pair to a measured crossing point
(1.25 s / 3 s), putting the sample at 33.79-34.31% of rows read. Sweeping that sample time, the
projection peaks at 4.2 s at 34.05% read - just past the step - then falls to the real 2.67-2.94 s.
A uniform payload of the same total bytes never throws at any of those points, and
*under*-estimates itself when forced to.

| arm | result |
|---|---|
| before the fix, scaled settings | 15/15 FAIL, all `Code: 160` |
| after, same settings and binary | 15/15 PASS |
| pin removed again | 10/10 FAIL (load-bearing) |
| pin kept, ceiling cut to 1 s | 10/10 PASS (`INSERT` exempt, `SELECT`s ok) |
| 50 randomized / 50 not, real CI settings | 50/50 and 50/50 PASS |
| 11 neighbouring / estimator-using tests | identical verdicts |

The `SELECT`s stay subject to the guard; they just run in ~0.08 s at uniform cost, and a deliberately
slowed variant of the same scan does throw. Neither setting is randomized by the runner, so no
`no-random-settings` tag was added.

Completed-run margin: the 300.9-382.6 s recorded across those 29 failures is the *kill* time, at
under half the rows read, not the duration of a finishing run. Completed runs on that shard peak at
351 s over 180 days (108 runs, p95 325 s), with no harness timeout. Calibrating the cheap-row cost
from that 351 s run and applying each failing day's own rate puts the worst completed run at 466 s
against the runner's `--timeout` of 600 s.

Four other tests hit the same guard elsewhere under coverage, none on this shard; not fixed here,
one concern per PR. No related open issue (#107037 is the closed `Code: 241` ASan class, fixed by
#106962). No backport: NightlyCoverage runs on master only.

</details>