### PR TITLE
Give each Merge child table its own PREWHERE filter DAG

### DIFF
--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -898,6 +898,20 @@ std::vector<ReadFromMerge::ChildPlan> ReadFromMerge::createChildrenPlans(SelectQ
                 }
             }
 
+            /// Filter DAGs can be modified by optimizations, so each child must own its own copy:
+            /// otherwise optimizing one child's plan invalidates the sibling headers that were
+            /// derived from the shared object.
+            if (modified_query_info.prewhere_info)
+                modified_query_info.prewhere_info = std::make_shared<PrewhereInfo>(modified_query_info.prewhere_info->clone());
+            if (modified_query_info.row_level_filter)
+            {
+                auto row_level_filter_copy = std::make_shared<FilterDAGInfo>();
+                row_level_filter_copy->actions = modified_query_info.row_level_filter->actions.clone();
+                row_level_filter_copy->column_name = modified_query_info.row_level_filter->column_name;
+                row_level_filter_copy->do_remove_column = modified_query_info.row_level_filter->do_remove_column;
+                modified_query_info.row_level_filter = std::move(row_level_filter_copy);
+            }
+
             if (!context->getSettingsRef()[Setting::allow_experimental_analyzer])
             {
                 auto storage_columns = storage_metadata_snapshot->getColumns();

--- a/tests/queries/0_stateless/04814_merge_prewhere_bare_column_explain_analyze.reference
+++ b/tests/queries/0_stateless/04814_merge_prewhere_bare_column_explain_analyze.reference
@@ -1,0 +1,24 @@
+identical structures, aggregate
+1
+identical structures, non-aggregate
+1
+identical structures, results
+1998
+1998
+1498500
+differing structures, aggregate
+1
+differing structures, non-aggregate
+1
+differing structures, results
+1998
+1998
+1498500
+three identical children, aggregate
+1
+three identical children, non-aggregate
+1
+three identical children, results
+2998
+2998
+2003000

--- a/tests/queries/0_stateless/04814_merge_prewhere_bare_column_explain_analyze.sql
+++ b/tests/queries/0_stateless/04814_merge_prewhere_bare_column_explain_analyze.sql
@@ -1,0 +1,90 @@
+-- `EXPLAIN ANALYZE` over a `Merge` table with several children, a bare-column `PREWHERE` and a
+-- separate `WHERE` used to fail with `Logical error: 'Required output position 1 is out of range for
+-- pass-through inputs'`: every child shared one `PrewhereInfo`, and pruning the first child's plan
+-- flipped the shared `remove_prewhere_column`, invalidating the sibling headers already derived from
+-- it. `EXPLAIN ANALYZE` is required because it optimizes the whole plan only after every child
+-- exists; on the plain `SELECT` path each child is pruned as it is built.
+--
+-- `query_plan_remove_unused_columns` is randomized by the test runner and both settings below are
+-- required to reach the path, so they are pinned per query. `viewExplain` keeps the assertion stable:
+-- raw `EXPLAIN ANALYZE` output carries timings.
+
+DROP TABLE IF EXISTS t04814_a;
+DROP TABLE IF EXISTS t04814_b;
+DROP TABLE IF EXISTS t04814_c;
+DROP TABLE IF EXISTS t04814_m;
+
+-- Fixture 1: identical child structures, so both children share one cached query info.
+CREATE TABLE t04814_a (k UInt64, v UInt64) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE t04814_b (k UInt64, v UInt64) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t04814_a SELECT number, number * 2 FROM numbers(1000);
+INSERT INTO t04814_b SELECT number + 1000, number FROM numbers(1000);
+CREATE TABLE t04814_m ENGINE = Merge(currentDatabase(), '^t04814_[ab]$');
+
+SELECT 'identical structures, aggregate';
+SELECT count() > 0 FROM viewExplain('EXPLAIN ANALYZE', '', (SELECT count() FROM t04814_m PREWHERE k WHERE v != 0))
+SETTINGS query_plan_remove_unused_columns = 1, query_plan_filter_push_down = 1;
+
+SELECT 'identical structures, non-aggregate';
+SELECT count() > 0 FROM viewExplain('EXPLAIN ANALYZE', '', (SELECT v FROM t04814_m PREWHERE k WHERE v != 0 ORDER BY v LIMIT 1))
+SETTINGS query_plan_remove_unused_columns = 1, query_plan_filter_push_down = 1;
+
+-- The plain `SELECT` path is correct today; these controls prove the fix only changes ownership of
+-- the filter DAG, not results.
+SELECT 'identical structures, results';
+SELECT count() FROM t04814_m PREWHERE k WHERE v != 0;
+SELECT count() FROM t04814_m WHERE k AND v != 0;
+SELECT sum(v) FROM t04814_m PREWHERE k WHERE v != 0;
+
+DROP TABLE t04814_m;
+DROP TABLE t04814_b;
+
+-- Fixture 2: differing child structures, so the children do not share a cached query info. Both
+-- shapes must be covered: they reach the fix site through different branches.
+CREATE TABLE t04814_b (k UInt64, v UInt64, extra String) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t04814_b SELECT number + 1000, number, 'x' FROM numbers(1000);
+CREATE TABLE t04814_m ENGINE = Merge(currentDatabase(), '^t04814_[ab]$');
+
+SELECT 'differing structures, aggregate';
+SELECT count() > 0 FROM viewExplain('EXPLAIN ANALYZE', '', (SELECT count() FROM t04814_m PREWHERE k WHERE v != 0))
+SETTINGS query_plan_remove_unused_columns = 1, query_plan_filter_push_down = 1;
+
+SELECT 'differing structures, non-aggregate';
+SELECT count() > 0 FROM viewExplain('EXPLAIN ANALYZE', '', (SELECT v FROM t04814_m PREWHERE k WHERE v != 0 ORDER BY v LIMIT 1))
+SETTINGS query_plan_remove_unused_columns = 1, query_plan_filter_push_down = 1;
+
+SELECT 'differing structures, results';
+SELECT count() FROM t04814_m PREWHERE k WHERE v != 0;
+SELECT count() FROM t04814_m WHERE k AND v != 0;
+SELECT sum(v) FROM t04814_m PREWHERE k WHERE v != 0;
+
+DROP TABLE t04814_m;
+DROP TABLE t04814_b;
+
+-- Fixture 3: three identical children. The first child misses the query-info cache and the other
+-- two hit it, so two children reach the fix site through the cache-hit branch. Two children are not
+-- enough for that: one takes each branch, so a fix applied to only one branch still hands out two
+-- distinct objects and looks correct.
+CREATE TABLE t04814_b (k UInt64, v UInt64) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE t04814_c (k UInt64, v UInt64) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t04814_b SELECT number + 1000, number FROM numbers(1000);
+INSERT INTO t04814_c SELECT number + 2000, number + 5 FROM numbers(1000);
+CREATE TABLE t04814_m ENGINE = Merge(currentDatabase(), '^t04814_[abc]$');
+
+SELECT 'three identical children, aggregate';
+SELECT count() > 0 FROM viewExplain('EXPLAIN ANALYZE', '', (SELECT count() FROM t04814_m PREWHERE k WHERE v != 0))
+SETTINGS query_plan_remove_unused_columns = 1, query_plan_filter_push_down = 1;
+
+SELECT 'three identical children, non-aggregate';
+SELECT count() > 0 FROM viewExplain('EXPLAIN ANALYZE', '', (SELECT v FROM t04814_m PREWHERE k WHERE v != 0 ORDER BY v LIMIT 1))
+SETTINGS query_plan_remove_unused_columns = 1, query_plan_filter_push_down = 1;
+
+SELECT 'three identical children, results';
+SELECT count() FROM t04814_m PREWHERE k WHERE v != 0;
+SELECT count() FROM t04814_m WHERE k AND v != 0;
+SELECT sum(v) FROM t04814_m PREWHERE k WHERE v != 0;
+
+DROP TABLE t04814_m;
+DROP TABLE t04814_c;
+DROP TABLE t04814_b;
+DROP TABLE t04814_a;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/113621
Related: https://github.com/ClickHouse/ClickHouse/pull/109932
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `Logical error: 'Required output position N is out of range for pass-through inputs'` in `EXPLAIN ANALYZE` over a `Merge` table with several children, a bare-column `PREWHERE` and a separate `WHERE`. Closes #113621.


### Description

`ReadFromMerge` handed every child table the same `PrewhereInfo`. `SelectQueryInfo::prewhere_info` is a `shared_ptr` and `getModifiedQueryInfo` starts from a shallow copy, deep-cloning the AST but not that pointer, so every child's `ReadFromMergeTree` aliased one object.

The position-based unused-column removal mutates it: pruning a child flips `remove_prewhere_column` from false to true. On the plain `SELECT` path each child is pruned as it is built, so later children derive their headers from the mutated object. `EXPLAIN ANALYZE` optimizes the plan only after every child exists, so the flip lands between sibling headers: a sibling still has two columns while the shared flag says the prewhere column is gone, so only one pass-through input remains and requesting position 1 throws, aborting the server in debug and sanitizer builds.

The fix deep-copies `prewhere_info` and `row_level_filter` once per child, where the query-info cache hit and miss branches converge, so no two children share a mutable filter DAG. This is the pattern merged in PR 109932 for `ReadFromMergeTree::clone`. `StorageMerge` never reads `query_info.prewhere_info` back, so un-sharing is behaviour-preserving, and `addFilter` and `addStorageFilter` already clone per child. `row_level_filter` is shared the same way and pruned in place by the same function, so it is cloned too; a row policy on the `Merge` table itself is what reaches it, and no failure was observed there.

Validation: on unmodified master the new test aborts the server on its first assertion; with the change it passes, 100/100 runs (50 randomized, 50 with randomization off), and the plain `SELECT` results are asserted unchanged. A slice of every stateless test that builds a `Merge` table or calls `merge`, plus every `prewhere` test, ran on both arms back to back: no test fails on only one arm and the reason buckets are identical. No release I tested reproduces it, so no backport is requested.

<details>
<summary>Mutation matrix (each arm on its own server, build id asserted)</summary>

| Arm | Verdict |
|---|---|
| Fix | passes |
| Revert the `prewhere_info` clone | fails, `Required output position 1 is out of range for pass-through inputs` |
| Clone only in the query-info cache-miss branch | fails, same message |
| Revert the `row_level_filter` clone | passes: this test builds no row policy, so it does not exercise that carrier |
| Unmodified master | fails, same message |

Two children are not enough to pin the cache-miss-only variant: one child takes each branch, so it still hands out two distinct objects. The test therefore also builds a `Merge` over three identical children, where two children reach the copy through the cache-hit branch.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.971` (included in `26.8` and later)
<!-- ch-version-info:end -->