### PR TITLE
Fix(PromQL): Negative subquery timestamp alignment in PromQL

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/alignTimestampWithStep.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/alignTimestampWithStep.cpp
@@ -17,6 +17,8 @@ TimestampType alignTimestampWithStep(TimestampType timestamp, DurationType step)
     auto x = timestamp % step;
     if (!x)
         return timestamp;
+    if (x < 0)
+        x += step;
     return timestamp - x;
 }
 

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -2620,6 +2620,17 @@ def test_alignment_with_subquery_step():
         "vector(1)[19:20]", 9999, '{"resultType": "matrix", "result": []}', ""
     )
 
+    # The offset makes the effective subquery timestamp negative without using a negative query timestamp.
+    do_query_test(
+        "vector(time())[40s:20s] offset 31s",
+        10,
+        '{"resultType": "matrix", "result": [{"metric": {}, "values": [[-60, "-60"], [-40, "-40"]]}]}',
+        [[
+            "[]",
+            "[('1969-12-31 23:59:00.000',-60),('1969-12-31 23:59:20.000',-40)]",
+        ]],
+    )
+
 
 def test_math_binary_operators():
     do_query_test(


### PR DESCRIPTION
### Changelog category (leave one):
- **Bug Fix (user-visible misbehavior in an official stable release)**

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
**Align negative PromQL subquery timestamps to the preceding step.**

### Description

alignTimestampWithStep currently uses the signed C++ remainder directly. For a negative timestamp that is not divisible by the step, this rounds toward zero instead of down to the previous step.

When a subquery offset makes its effective timestamp negative, the evaluation grid can therefore move forward by one step. This change normalizes negative remainders before subtracting them, so timestamps are aligned to the greatest step boundary not greater than the input.

### Tests

- PromQL subquery regression using `vector(time())[40s:20s] offset 31s` at outer timestamp 10, which exercises effective timestamps below the Unix epoch.
- **Checks:**  -m py_compile tests/integration/test_prometheus_protocols/test_evaluation.py
- **Checks:**  --check

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113726&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/113726](https://github.com/search?q=head%3Async-upstream%2Fpr%2F113726+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
