### PR TITLE
Fix `clickhouse-disks move` of a directory on `plain_rewritable` disks

### DIFF
--- a/programs/disks/CommandMove.cpp
+++ b/programs/disks/CommandMove.cpp
@@ -42,7 +42,6 @@ public:
             if (!disk.getDisk()->existsDirectory(target_location))
             {
                 LOG_INFO(log, "Moving directory from '{}' to '{}' at disk '{}'", path_from, target_location, disk.getDisk()->getName());
-                disk.getDisk()->createDirectory(target_location);
                 disk.getDisk()->moveDirectory(path_from, target_location);
             }
             else

--- a/tests/queries/0_stateless/04812_clickhouse_disks_move_directory.reference
+++ b/tests/queries/0_stateless/04812_clickhouse_disks_move_directory.reference
@@ -1,0 +1,13 @@
+# test_disk_04812
+dst
+parent
+child
+# test_disk_plain_rewritable_04812
+dst
+parent
+child
+# missing parent: test_disk_04812
+src
+# missing parent: test_disk_plain_rewritable_04812
+aa
+cc

--- a/tests/queries/0_stateless/04812_clickhouse_disks_move_directory.sh
+++ b/tests/queries/0_stateless/04812_clickhouse_disks_move_directory.sh
@@ -8,6 +8,11 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 config="$CUR_DIR/04812_clickhouse_disks_move_directory.xml"
 
 base_dir="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}"
+# The disk-level `remove -r` cannot empty a directory holding a virtual child on
+# `plain_rewritable`, so residue survives it. Own the backing directory outright to keep the
+# test repeatable (`clickhouse-test --database=X` shares one CLICKHOUSE_TMP across runs).
+rm -rf "$base_dir"
+trap 'rm -rf "$base_dir"' EXIT
 mkdir -p \
     "$base_dir/local/data" "$base_dir/local/metadata" \
     "$base_dir/plain_rewritable"

--- a/tests/queries/0_stateless/04812_clickhouse_disks_move_directory.sh
+++ b/tests/queries/0_stateless/04812_clickhouse_disks_move_directory.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+config="$CUR_DIR/04812_clickhouse_disks_move_directory.xml"
+
+base_dir="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}"
+mkdir -p \
+    "$base_dir/local/data" "$base_dir/local/metadata" \
+    "$base_dir/plain_rewritable"
+export TEST_DISK_04812_PATH="$(realpath "$base_dir/local/data")/"
+export TEST_DISK_04812_METADATA_PATH="$(realpath "$base_dir/local/metadata")/"
+export TEST_DISK_PLAIN_REWRITABLE_04812_PATH="$(realpath "$base_dir/plain_rewritable")/"
+
+dir="$CLICKHOUSE_TEST_UNIQUE_NAME"
+
+function disks()
+{
+    clickhouse-disks -C "$config" --disk "$disk" --query "$1" 2>/dev/null
+}
+
+# Renaming a directory must behave identically on the `local` and `plain_rewritable`
+# metadata backends. `clickhouse-disks` always exits 0, so assert the disk state.
+function run_move_test()
+{
+    local disk="$1"
+    echo "# $disk"
+
+    disks "remove -r $dir"
+    disks "mkdir --parents $dir/src"
+
+    # Renaming to a name that does not exist yet moves the directory: the target
+    # appears and the source is gone.
+    disks "cd $dir; move src dst"
+    disks "list $dir"
+
+    # The target may name a path whose parent already exists.
+    disks "mkdir $dir/parent"
+    disks "cd $dir; move dst parent/child"
+    disks "list $dir"
+    disks "list $dir/parent"
+
+    disks "remove -r $dir"
+}
+
+# Moving to a path whose intermediate directories do not exist. Here the two backends
+# legitimately diverge, so this is kept out of `run_move_test`: the `plain_rewritable`
+# rename materializes the missing intermediates, a local rename fails with ENOENT.
+function run_move_missing_parent_test()
+{
+    local disk="$1"
+    # Own working directory: `remove -r` does not empty a directory that holds a
+    # virtual child on `plain_rewritable`, so reusing `$dir` would carry residue in.
+    local mp="${dir}_mp"
+    echo "# missing parent: $disk"
+
+    disks "remove -r $mp"
+    disks "mkdir --parents $mp/src"
+
+    disks "cd $mp; move src aa/bb/cc"
+    # On `plain_rewritable` the source is gone and the moved directory is reachable at
+    # the full nested path. On a local disk the move failed and the source is still there.
+    disks "list $mp"
+    disks "list $mp/aa/bb"
+
+    disks "remove -r $mp"
+}
+
+run_move_test "test_disk_04812"
+run_move_test "test_disk_plain_rewritable_04812"
+
+run_move_missing_parent_test "test_disk_04812"
+run_move_missing_parent_test "test_disk_plain_rewritable_04812"

--- a/tests/queries/0_stateless/04812_clickhouse_disks_move_directory.xml
+++ b/tests/queries/0_stateless/04812_clickhouse_disks_move_directory.xml
@@ -1,0 +1,19 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <test_disk_plain_rewritable_04812>
+                <type>object_storage</type>
+                <object_storage_type>local</object_storage_type>
+                <metadata_type>plain_rewritable</metadata_type>
+                <path from_env="TEST_DISK_PLAIN_REWRITABLE_04812_PATH"></path>
+            </test_disk_plain_rewritable_04812>
+            <test_disk_04812>
+                <type>object_storage</type>
+                <object_storage_type>local</object_storage_type>
+                <metadata_type>local</metadata_type>
+                <path from_env="TEST_DISK_04812_PATH"></path>
+                <metadata_path from_env="TEST_DISK_04812_METADATA_PATH"></metadata_path>
+            </test_disk_04812>
+        </disks>
+    </storage_configuration>
+</clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `clickhouse-disks move` of a directory failing with `DIRECTORY_ALREADY_EXISTS` on disks with `metadata_type = plain_rewritable` (for example `s3_plain_rewritable`), which also left an empty destination directory behind.

### Description

`clickhouse-disks --disk <D> move <dir> <newname>` always failed on a disk with
`metadata_type = plain_rewritable`, and left a stray empty destination directory that the
user had to remove by hand:

```
$ clickhouse-disks --disk pr_disk --query "mkdir somedir"
$ clickhouse-disks --disk pr_disk --query "move somedir newname"
Code: 84. DB::Exception: Directory 'newname/' already exists. (DIRECTORY_ALREADY_EXISTS)
$ clickhouse-disks --disk pr_disk --query "list ."
newname
somedir
```

Root cause: `CommandMove::executeImpl` pre-created the destination and then renamed onto it.
`DiskObjectStorage::createDirectory` and `DiskObjectStorage::moveDirectory` each commit their
own transaction, so the pre-created directory was durably visible to the rename, and
`plain_rewritable`'s move operation rejects an existing `path_to`. `DiskLocal::moveDirectory`
is `fs::rename`, which tolerates an existing empty target, which is why the local path masked
this and existing coverage never saw it.

The fix deletes the `createDirectory` call so the directory move is a plain rename, which is
what `moveDirectory` already promises on every backend. The pre-creation was not merely
redundant: non-recursive `createDirectory` requires the target's parent to exist, while the
rename materializes missing intermediate nodes itself, so `move src aa/bb/cc` with `aa/bb`
absent now succeeds on `plain_rewritable` instead of failing `DIRECTORY_DOESNT_EXIST`. On a
local disk that shape still fails, only with `in rename` instead of `in create_directory`. The `createDirectory` call in
`CommandCopy` is left alone: `copyDirectoryContent` copies *into* an existing target.

Validated by a new stateless test running the same scenarios against a `local` and a
`plain_rewritable` metadata disk, asserting disk state (`clickhouse-disks` exits 0 even on
this failure, so an exit-code oracle would prove nothing).

Two adjacent pre-existing defects are deliberately **not** addressed here: `move` onto an
existing *empty* target also fails on `plain_rewritable` (that path pre-creates nothing, so it
is a separate callee-side difference), and `move` of a directory on `metadata_type = plain`
returns `NOT_IMPLEMENTED` because `moveDirectory` is not overridden there at all.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.966` (included in `26.8` and later)
<!-- ch-version-info:end -->