### PR TITLE
Fix flaky `test_batch_set_processing_failure_does_not_crash` on 25.8

### DIFF
--- a/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
+++ b/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
@@ -308,6 +308,9 @@ def test_batch_set_processing_failure_does_not_crash(started_cluster):
             # Both conditions must land in the SAME batch, so pin the listing batch size instead
             # of relying on the engine default (1000) happening to exceed files_to_generate.
             "list_objects_batch_size": files_to_generate,
+            # The conflict node below is planted in `<keeper_path>/processing`, so the engine must
+            # use that directory rather than `persistent_processing`.
+            "use_persistent_processing_nodes": 0,
         },
     )
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112313
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

This test is red about half the time on `25.8`: over the 60 days to 2026-08-06 08:00 UTC, 15 FAIL /
20 OK there, across five failing PRs and six branch-side runs. `master` is 0 FAIL over thousands of
OK runs, and 26.x is zero.

**Root cause, in the test rather than the engine.** The test plants a Keeper conflict node at the
hard-coded path `{keeper_path}/processing/{node}` so the engine's `tryMulti` fails and
`ObjectStorageQueueFailedToBatchSetProcessing` increments. On `25.8` that directory is chosen at
runtime from `use_persistent_processing_nodes`
(`ObjectStorageQueueUnorderedFileMetadata.cpp:32` -> `ObjectStorageQueueIFileMetadata.cpp:203-205`),
which the shared helper randomizes (`helpers/s3_queue_common.py:172`, `:125` on `25.8`). On the losing
draw the engine uses `persistent_processing`, so the planted node is inert and the counter cannot rise.

**The change** pins `use_persistent_processing_nodes = 0` in the test's `additional_settings`, beside
the existing `list_objects_batch_size` pin for the same class of hazard;
`settings.update(additional_settings)` runs after the draw, so the value wins, and `test_5.py` pins it
too. No assertion is weakened and no `no-random-*` tag is added: this suite's other 95 unpinned
`create_table` sites keep the draw live.

**Why this targets `master`, which is green.** There the processing directory is the compile-time
literal `"processing"` (`ObjectStorageQueueUnorderedFileMetadata.cpp:27`) and the `CREATE`-time value
is never consumed: the metadata constructor gets a literal `true`
(`StorageObjectStorageQueue.cpp:442`). The test reached `25.8` via a robot cherry-pick of #108977, a
`pr-critical-bugfix`, leaving that branch a ~50%-blind regression test for a crash. Could a maintainer
add `v25.8-must-backport` so the existing automation replays it?

**Validation.** A plain run is vacuous half the time, so the draw was forced (2x2 below): pre-fix FAILs
in 315 s with the CI text verbatim, post-fix passes, and the winning-draw arm is the control showing
the probe discriminates. Reverting the `src/` guard from #108977 makes the repaired test fail with the
abort, not the timeout. Unforced, 50/50 green on both branches.


<details>
<summary>Measurement detail</summary>

2x2 on `25.8` (released `v25.8.29.51-lts`, buildId `c345ea4f094c8b6876f0e8beefbc0beb452a3389`):

| arm | pre-fix | post-fix |
|---|---|---|
| draw forced `True` (losing) | FAIL 315.20 s, `0 did not match expectations in 120 retries` | PASS 153.18 s |
| draw forced `False` (winning) | PASS 159.00 s (control) | PASS 135.44 s |

CI's own failing job took 315.69 s. Server-log confirmation, pre-fix vs post-fix: DDL
`use_persistent_processing_nodes = true` vs `= 0`; engine path `.../persistent_processing/<node>` vs
`.../processing/<node>`; `Failed to set files as processing` 0 for the table under test vs 1 naming it. A
sibling test in this module increments the same server-lifetime counter, so that line is attributed
by table name.

Unforced, randomizer live: `25.8` post-fix 50/50 PASS, with 50 distinct tables, 50 failpoint fires
and a processing-path histogram of 1118 `/processing/` to 0 `/persistent_processing/`. `25.8` pre-fix
over 20 runs: 7 of 20 red on the target signature, the other 4 failures being host network noise,
consistent with the 42.9% FAIL rate in CI. `master` post-fix 50/50 PASS. Whole-file arms on both
branches, compared as sets of failure reasons: 0 only-in-fix failures.

On `master` the setting is still accepted and still readable at runtime, since `ALTER MODIFY SETTING`
reaches `ObjectStorageQueueMetadata::updateSettings`. The inertness above is specifically about the
`CREATE`-time value and the directory literal, not about the setting being ignored.

</details>