### PR TITLE
Fix flaky test 04691_intdiv_by_minus_one_minimal_signed

### DIFF
--- a/tests/queries/0_stateless/04691_intdiv_by_minus_one_minimal_signed.sql
+++ b/tests/queries/0_stateless/04691_intdiv_by_minus_one_minimal_signed.sql
@@ -32,7 +32,7 @@ INSERT INTO t_intdiv_min SELECT number FROM numbers(100);
 INSERT INTO t_intdiv_min SELECT number FROM numbers(100);
 INSERT INTO t_intdiv_min SELECT number + 9223372036854775806 FROM numbers(100);
 
-SELECT DISTINCT intDiv(x, -1) AS d FROM t_intdiv_min ORDER BY d ASC; -- { serverError ILLEGAL_DIVISION }
+SELECT DISTINCT intDiv(x, -1) AS d FROM t_intdiv_min ORDER BY d ASC FORMAT Null; -- { serverError ILLEGAL_DIVISION }
 
 DROP TABLE t_intdiv_min;
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113048
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04691_intdiv_by_minus_one_minimal_signed` can fail with `result differs with reference`
although the server behaves correctly. Its last query asserts only an exception:

```sql
SELECT DISTINCT intDiv(x, -1) AS d FROM t_intdiv_min ORDER BY d ASC; -- { serverError ILLEGAL_DIVISION }
```

`ORDER BY d ASC` over the monotonically decreasing `intDiv(x, -1)` is planned as a reverse
in-order MergeTree read. The part holding the minimal signed number is read across several
marks, so complete blocks of safe values can reach the output format before the block
containing that number throws. Those rows are not in the reference file, so the test fails on
a correct server. The exception always fires, and the leaked values are legitimate
(`-9223372036854775807` is `intDiv(INT64_MAX, -1)`), not the silent wrap #113048 fixed.

Two conditions are needed, which is why it is rare: the drawn `index_granularity` must split
the part into at least 5 marks (measured: leaks at 28 and below, clean at 29 and above), and
more than one reading stream must be active (at `max_threads = 1` it never leaks).
`tests/clickhouse-test` clamps `index_granularity` to at least 100 on sanitizer, debug and
coverage builds, so only release-type builds can draw into the leaking band.

The fix adds `FORMAT Null` so the query's only observable outcome is the exception it
asserts. The reference file is unchanged and no tag is added, so the test still runs under
full randomization.

Pinning `index_granularity` was rejected: at the drawn value the fixture has 153 marks and
pinning it to the default would leave 6, removing the multi-granule reverse read #113048
exists to cover, and `max_threads` would have to be pinned too because the leak is a race.

<details>
<summary>Validation</summary>

In CIDB over 30 days exactly one run of this `test_name` failed, against tens of
thousands that passed: `Stateless tests (arm_binary, parallel)` drawing `--index_granularity
2`, whose own diagnosis reported 142 failures in 185 reruns.

`FORMAT Null` changes only the sink: the server sets `null_format` and stops sending data
while still pulling the pipeline to completion, so the reverse in-order read, the `DISTINCT`
and the throw are unchanged. `EXPLAIN PIPELINE` shows that plan as three `ReverseTransform`,
each feeding a `MergeTreeSelect(algorithm: InReverseOrder)`, four
`DistinctSortedStreamTransform` and `MergingSortedTransform 3 -> 1`.

Both directions, through `clickhouse-test` with `--merge-tree-settings "--index_granularity 2"`
on a debug build, 30 runs each: without `FORMAT Null` 19 of 30 fail with `Reason: result
differs with reference`, with it 30 of 30 pass, every failing diff carrying the two extra
leading lines above. Also green: 50 of 50 randomized and 50 of 50 with randomization off,
though a debug build cannot draw the trigger, so the forced runs are load-bearing.

That the exception still fires under `FORMAT Null` is measured. A correct run is exit 0 with
empty stderr, because the client consumes the matched error, so three controls pin it: with
the hint removed the query exits 153 with `Division of minimal signed number by minus one`;
with the expected error changed to `ILLEGAL_TYPE_OF_ARGUMENT` the test fails 6 of 6 with
`Expected server error code: 43 but got: 153`; and with the fixture rebuilt without the
minimal signed number the hint reports `The query succeeded but the server error '153' was
expected`.

The other five `serverError`-hinted queries cannot leak: each is a single-row expression
producing no output before it throws.

The idiom is established: 48 other stateless tests already end a query with exactly
`FORMAT Null; -- { serverError`, 64 allowing an interposed `SETTINGS` clause.

</details>