### PR TITLE
Fix PromQL modulo with infinite divisors

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyMathBinaryOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyMathBinaryOperator.cpp
@@ -104,7 +104,19 @@ SQLQueryPiece applyMathBinaryOperator(
 
     auto apply_function_to_ast = [&](ASTPtr x, ASTPtr y) -> ASTPtr
     {
-        return makeASTFunction(impl_info->ch_function_name, std::move(x), std::move(y));
+        if (operator_name != "%")
+            return makeASTFunction(impl_info->ch_function_name, std::move(x), std::move(y));
+
+        ASTPtr result = makeASTFunction(impl_info->ch_function_name, x->clone(), y->clone());
+
+        return makeASTFunction(
+            "if",
+            makeASTFunction(
+                "and",
+                makeASTFunction("isInfinite", y->clone()),
+                makeASTFunction("isFinite", x->clone())),
+            std::move(x),
+            std::move(result));
     };
 
     return applySimpleBinaryOperator(

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -2000,6 +2000,46 @@ def test_math_binary_operators():
     )
 
     do_query_test(
+        "5 % +Inf",
+        100,
+        '{"resultType": "scalar", "result": [100, "5"]}',
+        [["1970-01-01 00:01:40.000", 5]],
+    )
+
+    do_query_test(
+        "vector(-5) % vector(-Inf)",
+        100,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [100, "-5"]}]}',
+        [["[]", "1970-01-01 00:01:40.000", -5]],
+    )
+
+    do_query_test(
+        "+Inf % 5",
+        100,
+        '{"resultType": "scalar", "result": [100, "NaN"]}',
+        [["1970-01-01 00:01:40.000", "nan"]],
+    )
+
+    do_query_test(
+        "5 % NaN",
+        100,
+        '{"resultType": "scalar", "result": [100, "NaN"]}',
+        [["1970-01-01 00:01:40.000", "nan"]],
+    )
+
+    do_query_test(
+        "(5 % (last_over_time(test[10s]) + +Inf))[120s:15s]",
+        210,
+        '{"resultType": "matrix", "result": [{"metric": {}, "values": [[120, "5"], [135, "5"], [195, "5"], [210, "5"]]}]}',
+        [
+            [
+                "[]",
+                "[('1970-01-01 00:02:00.000',5),('1970-01-01 00:02:15.000',5),('1970-01-01 00:03:15.000',5),('1970-01-01 00:03:30.000',5)]",
+            ]
+        ],
+    )
+
+    do_query_test(
         "25 ^ 0.5",
         100,
         '{"resultType": "scalar", "result": [100, "5"]}',


### PR DESCRIPTION
### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
PromQL: preserve finite values when using modulo with an infinite divisor.

### Description

PromQL defines the modulo operator using math.Mod. For a finite left operand and an infinite right operand, Prometheus returns the original left operand. The current ClickHouse lowering uses modulo(), whose floating-point implementation evaluates this as a - trunc(a / b) * b; with an infinite divisor, that produces NaN because 0 * Inf is NaN.

This keeps the generic ClickHouse modulo() behavior unchanged and handles the PromQL case in the lowering. The guard only returns the left operand when it is finite and the divisor is infinite. Other cases, including infinite or NaN left operands, continue through modulo().

Prometheus documents arithmetic operators, including %, in its [operator documentation](https://prometheus.io/docs/prometheus/latest/querying/operators/#arithmetic-binary-operators). Its scalar and vector binary evaluation uses Go's [math.Mod](https://github.com/prometheus/prometheus/blob/main/promql/engine.go#L3463-L3464).

### Testing

- git diff --check
- python3 -m py_compile tests/integration/test_prometheus_protocols/test_evaluation.py


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1006` (included in `26.8` and later)
<!-- ch-version-info:end -->