### PR TITLE
Throttle fsyncs in Keeper Changelog

### DIFF
--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -1,7 +1,9 @@
 #include <algorithm>
+#include <chrono>
 #include <exception>
 #include <filesystem>
 #include <mutex>
+#include <optional>
 #include <ranges>
 #include <variant>
 #include <Coordination/Changelog.h>
@@ -2258,11 +2260,21 @@ void Changelog::writeThread()
     WriteOperation write_operation;
     bool batch_append_ok = true;
     size_t pending_appends = 0;
-    bool try_batch_flush = false;
 
-    const auto flush_logs = [&](const auto & flush)
+    /// Flush request that we delay to batch it with more appends and to limit the flush frequency.
+    /// A newer Flush request subsumes an older pending one: its index is not less,
+    /// and one completion notification is enough for both.
+    std::optional<Flush> pending_flush;
+
+    /// We don't start a flush earlier than min_time_between_fsyncs_ms after the start of the previous flush.
+    std::chrono::steady_clock::time_point earliest_next_flush_time{};
+
+    const auto flush_logs = [&](const Flush & flush)
     {
         LOG_TEST(log, "Flushing {} logs", pending_appends);
+
+        earliest_next_flush_time
+            = std::chrono::steady_clock::now() + std::chrono::milliseconds(flush_settings.min_time_between_fsyncs_ms);
 
         {
             std::lock_guard writer_lock(writer_mutex);
@@ -2296,21 +2308,46 @@ void Changelog::writeThread()
         /// We assume that after some number of appends, we always get flush request
         while (true)
         {
-            if (try_batch_flush)
+            if (pending_flush)
             {
-                try_batch_flush = false;
-                /// we have Flush request stored in write operation
-                /// but we try to get new append operations
-                /// if there are none, we apply the currently set Flush
-                chassert(std::holds_alternative<Flush>(write_operation));
-                if (!write_operations.tryPop(write_operation))
+                bool do_flush = false;
+
+                if (!batch_append_ok)
                 {
-                    chassert(batch_append_ok);
-                    const auto & flush = std::get<Flush>(write_operation);
-                    flush_logs(flush);
+                    /// An append failed, fail the flush without batching more operations.
+                    do_flush = true;
+                }
+                else if (const auto now = std::chrono::steady_clock::now(); now < earliest_next_flush_time)
+                {
+                    /// Wait out the flush throttling interval, batching all appends that arrive in the meantime.
+                    /// (The batch may exceed max_flush_batch_size since we can't flush earlier anyway.)
+                    /// tryPop returns false either when the timeout expires or on shutdown; flush in both cases.
+                    const auto timeout = std::chrono::ceil<std::chrono::milliseconds>(earliest_next_flush_time - now);
+                    do_flush = !write_operations.tryPop(write_operation, timeout.count());
+                }
+                else
+                {
+                    /// Flush if we have the maximum allowed number of pending appends
+                    /// or no more operations are immediately available for batching.
+                    do_flush = pending_appends >= flush_settings.max_flush_batch_size || !write_operations.tryPop(write_operation);
+                }
+
+                if (do_flush)
+                {
+                    if (batch_append_ok)
+                    {
+                        flush_logs(*pending_flush);
+                    }
+                    else
+                    {
+                        std::lock_guard lock{durable_idx_mutex};
+                        *pending_flush->failed = true;
+                    }
+
                     notify_append_completion();
-                    if (!write_operations.pop(write_operation))
-                        break;
+                    pending_flush.reset();
+                    batch_append_ok = true;
+                    continue;
                 }
             }
             else if (!write_operations.pop(write_operation))
@@ -2333,26 +2370,7 @@ void Changelog::writeThread()
             }
             else
             {
-                const auto & flush = std::get<Flush>(write_operation);
-
-                if (batch_append_ok)
-                {
-                    /// we can try batching more logs for flush
-                    if (pending_appends < flush_settings.max_flush_batch_size)
-                    {
-                        try_batch_flush = true;
-                        continue;
-                    }
-                    /// we need to flush because we have maximum allowed pending records
-                    flush_logs(flush);
-                }
-                else
-                {
-                    std::lock_guard lock{durable_idx_mutex};
-                    *flush.failed = true;
-                }
-                notify_append_completion();
-                batch_append_ok = true;
+                pending_flush = std::get<Flush>(write_operation);
             }
         }
     }

--- a/src/Coordination/Changelog.h
+++ b/src/Coordination/Changelog.h
@@ -144,6 +144,7 @@ struct LogFileSettings
 struct FlushSettings
 {
     uint64_t max_flush_batch_size = 1000;
+    uint64_t min_time_between_fsyncs_ms = 5;
 };
 
 struct LogLocation

--- a/src/Coordination/CoordinationSettings.cpp
+++ b/src/Coordination/CoordinationSettings.cpp
@@ -58,6 +58,7 @@ namespace ErrorCodes
     DECLARE(NonZeroUInt64, max_requests_append_size, 100, "Max size of batch of requests that can be sent to replica in append request", 0) \
     DECLARE(UInt64, max_requests_append_bytes_size, 10*1024*1024, "Max size in bytes of batch of requests that can be sent to replica in append request", 0) \
     DECLARE(UInt64, max_flush_batch_size, 1000, "Max size of batch of requests that can be flushed together", 0) \
+    DECLARE(UInt64, min_time_between_fsyncs_ms, 5, "Min time between changelog flushes (fsyncs if force_sync is enabled), counted from the start of the previous flush. Flush requests that arrive earlier are delayed to batch more appends into one flush", 0) \
     DECLARE(UInt64, max_requests_quick_batch_size, 100, "Obsolete setting, does nothing." , SettingsTierType::OBSOLETE) \
     DECLARE(Bool, quorum_reads, false, "Execute read requests as writes through whole RAFT consensus with similar speed", HOT_RELOAD) \
     DECLARE(Bool, force_sync, true, "Call fsync on each change in RAFT changelog", 0) \

--- a/src/Coordination/KeeperStateManager.cpp
+++ b/src/Coordination/KeeperStateManager.cpp
@@ -29,6 +29,7 @@ namespace CoordinationSetting
     extern const CoordinationSettingsUInt64 log_file_overallocate_size;
     extern const CoordinationSettingsUInt64 max_flush_batch_size;
     extern const CoordinationSettingsUInt64 max_log_file_size;
+    extern const CoordinationSettingsUInt64 min_time_between_fsyncs_ms;
     extern const CoordinationSettingsNonZeroUInt64 rotate_log_storage_interval;
 }
 
@@ -320,6 +321,7 @@ KeeperStateManager::KeeperStateManager(
           FlushSettings
           {
               .max_flush_batch_size = keeper_context_->getCoordinationSettings()[CoordinationSetting::max_flush_batch_size],
+              .min_time_between_fsyncs_ms = keeper_context_->getCoordinationSettings()[CoordinationSetting::min_time_between_fsyncs_ms],
           },
           keeper_context_))
     , server_state_file_name(server_state_file_name_)

--- a/src/Coordination/tests/gtest_coordination_changelog.cpp
+++ b/src/Coordination/tests/gtest_coordination_changelog.cpp
@@ -4,6 +4,7 @@
 #include <Coordination/tests/gtest_coordination_common.h>
 
 #include <Coordination/KeeperLogStore.h>
+#include <Common/Stopwatch.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
 
 #include <thread>
@@ -53,6 +54,32 @@ TEST_P(CoordinationTestWithCompression, ChangelogTestSimple)
     EXPECT_EQ(changelog.last_entry()->get_term(), 77);
     EXPECT_EQ(changelog.entry_at(1)->get_term(), 77);
     EXPECT_EQ(changelog.log_entries(1, 2)->size(), 1);
+}
+
+TEST_P(CoordinationTestWithCompression, ChangelogTestFlushThrottling)
+{
+    ChangelogDirTest test("./logs");
+    this->setLogDirectory("./logs");
+
+    DB::KeeperLogStore changelog(
+        DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 1000},
+        DB::FlushSettings{.max_flush_batch_size = 1000, .min_time_between_fsyncs_ms = 100},
+        this->keeper_context);
+    changelog.init(0, 0);
+
+    Stopwatch watch;
+
+    /// The first flush is not throttled.
+    auto entry = getLogEntry("hello world", 77);
+    changelog.append(entry);
+    EXPECT_TRUE(changelog.flush());
+
+    /// The second flush must not start earlier than min_time_between_fsyncs_ms
+    /// after the start of the first one.
+    changelog.append(entry);
+    EXPECT_TRUE(changelog.flush());
+
+    EXPECT_GE(watch.elapsedMilliseconds(), 100);
 }
 
 TEST_P(CoordinationTestWithCompression, ChangelogTestFile)

--- a/tests/casa_del_dolor/properties.py
+++ b/tests/casa_del_dolor/properties.py
@@ -1913,6 +1913,7 @@ keeper_settings = {
         ),
         "min_request_size_for_cache": threshold_generator(0.2, 0.2, 0, 100 * 1024),
         "min_session_timeout_ms": threshold_generator(0.2, 0.2, 1000, 10000),
+        "min_time_between_fsyncs_ms": threshold_generator(0.2, 0.2, 0, 100),
         "nuraft_append_entries_backward_probe_throttle_threshold": threshold_generator(
             0.2, 0.2, 0, 128
         ),


### PR DESCRIPTION
From human: Useful for avoiding hitting EBS rate limit. (EBS rate limit may be shared with other things, like snapshots of text log. So if Changelog eats all EBS QPS quota it may cause snapshotting or text log writer to get slow.)

From Claude: Add CoordinationSetting min_time_between_fsyncs_ms (default 5 ms): the write thread does not start a flush of the changelog earlier than this much time after the start of the previous flush, batching all appends that arrive in the meantime. Restructure Changelog::writeThread around an explicit pending flush request instead of the try_batch_flush flag.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
- Keeper improvement: Add CoordinationSetting `min_time_between_fsyncs_ms` (default 5 ms): the write thread does not start a flush of the changelog earlier than this much time after the start of the previous flush, batching all appends that arrive in the meantime. 


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.942` (included in `26.8` and later)
<!-- ch-version-info:end -->