### PR TITLE
Honour the declared result type in FunctionIn

### DIFF
--- a/src/Functions/in.cpp
+++ b/src/Functions/in.cpp
@@ -4,6 +4,7 @@
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Columns/ColumnConst.h>
+#include <Columns/ColumnNullable.h>
 #include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnTuple.h>
 #include <Columns/ColumnSet.h>
@@ -74,17 +75,31 @@ public:
 
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
 
-    ColumnPtr executeImplDryRun(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
+    ColumnPtr executeImplDryRun(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
-        return executeImpl(arguments, true, input_rows_count);
+        return executeImpl(arguments, result_type, true, input_rows_count);
     }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
-        return executeImpl(arguments, false, input_rows_count);
+        return executeImpl(arguments, result_type, false, input_rows_count);
     }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, bool dry_run, size_t input_rows_count) const
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type,
+                          bool dry_run, size_t input_rows_count) const
+    {
+        auto res = executeUInt8(arguments, dry_run, input_rows_count);
+
+        /// group_by_use_nulls can promote the declared type on the query-tree node while this
+        /// function still produces UInt8. Nullability driven by the arguments does not reach
+        /// result_type here, so that promotion is its only source and no row can be NULL.
+        if (result_type->isNullable() && !res->isNullable())
+            return makeNullable(res);
+
+        return res;
+    }
+
+    ColumnPtr executeUInt8(const ColumnsWithTypeAndName & arguments, bool dry_run, size_t input_rows_count) const
     {
         if (ignore_set)
             return ColumnUInt8::create(input_rows_count, static_cast<UInt8>(0));

--- a/tests/queries/0_stateless/04812_group_by_use_nulls_grouping_sets_global_in.reference
+++ b/tests/queries/0_stateless/04812_group_by_use_nulls_grouping_sets_global_in.reference
@@ -1,0 +1,20 @@
+globalIn
+Nullable(UInt8)	1
+globalNotIn
+Nullable(UInt8)	0
+globalNullIn
+Nullable(UInt8)	1
+globalNotNullIn
+Nullable(UInt8)	0
+empty set
+Nullable(UInt8)	0
+low cardinality left
+Nullable(UInt8)	1
+control low cardinality result type
+LowCardinality(Nullable(UInt8))	1
+control local in
+Nullable(UInt8)	1
+control no group_by_use_nulls
+UInt8	1
+control subquery set
+Nullable(UInt8)	1

--- a/tests/queries/0_stateless/04812_group_by_use_nulls_grouping_sets_global_in.sql
+++ b/tests/queries/0_stateless/04812_group_by_use_nulls_grouping_sets_global_in.sql
@@ -8,7 +8,7 @@
 -- filled during distributed execution, so header computation runs the function against an
 -- unready set. With a subquery the set is built beforehand and the mismatch never surfaces.
 
--- The promotion under test is the new analyzer's: the old analyzer's `appendGroupByModifiers`
+-- The promotion under test is the analyzer's: the old analyzer's `appendGroupByModifiers`
 -- returns early for GROUPING SETS, so no key is promoted there and `UInt8` is correct.
 SET enable_analyzer = 1;
 

--- a/tests/queries/0_stateless/04812_group_by_use_nulls_grouping_sets_global_in.sql
+++ b/tests/queries/0_stateless/04812_group_by_use_nulls_grouping_sets_global_in.sql
@@ -8,6 +8,10 @@
 -- filled during distributed execution, so header computation runs the function against an
 -- unready set. With a subquery the set is built beforehand and the mismatch never surfaces.
 
+-- The promotion under test is the new analyzer's: the old analyzer's `appendGroupByModifiers`
+-- returns early for GROUPING SETS, so no key is promoted there and `UInt8` is correct.
+SET enable_analyzer = 1;
+
 DROP TABLE IF EXISTS t_04812;
 DROP TABLE IF EXISTS t_04812_empty;
 

--- a/tests/queries/0_stateless/04812_group_by_use_nulls_grouping_sets_global_in.sql
+++ b/tests/queries/0_stateless/04812_group_by_use_nulls_grouping_sets_global_in.sql
@@ -53,12 +53,14 @@ SETTINGS group_by_use_nulls = 1;
 
 -- LowCardinality left argument: the framework strips LowCardinality before calling the
 -- function, so this checks that such an argument does not change the reconciliation.
+-- `serialize_query_plan = 0` keeps this arm off the unrelated issue #112028, where a
+-- LowCardinality argument to `IN` loses that wrapper across plan serialization.
 SELECT 'low cardinality left';
 SELECT toTypeName(materialize(toLowCardinality(1)) GLOBAL IN (t_04812)) AS t,
        materialize(toLowCardinality(1)) GLOBAL IN (t_04812) AS s
 FROM remote('127.0.0.1', system, one)
 GROUP BY GROUPING SETS ((materialize(toLowCardinality(1)) GLOBAL IN (t_04812)))
-SETTINGS group_by_use_nulls = 1;
+SETTINGS group_by_use_nulls = 1, serialize_query_plan = 0;
 
 -- Control: with a literal set the declared type is LowCardinality(Nullable(UInt8)). The
 -- reconciliation must leave that wrapper alone, so the type must stay LowCardinality here.

--- a/tests/queries/0_stateless/04812_group_by_use_nulls_grouping_sets_global_in.sql
+++ b/tests/queries/0_stateless/04812_group_by_use_nulls_grouping_sets_global_in.sql
@@ -1,0 +1,94 @@
+-- Tags: shard
+
+-- Regression test: `group_by_use_nulls` promotes a GROUPING SETS key's declared type to
+-- Nullable(UInt8), but `FunctionIn` produced a plain UInt8 column, aborting the server with
+-- `Unexpected return type from globalIn. Expected Nullable(UInt8). Got UInt8`.
+--
+-- A table identifier on the right of GLOBAL IN is load-bearing: the set is then a FutureSet
+-- filled during distributed execution, so header computation runs the function against an
+-- unready set. With a subquery the set is built beforehand and the mismatch never surfaces.
+
+DROP TABLE IF EXISTS t_04812;
+DROP TABLE IF EXISTS t_04812_empty;
+
+CREATE TABLE t_04812 (x UInt8) ENGINE = MergeTree ORDER BY x;
+INSERT INTO t_04812 VALUES (1);
+
+CREATE TABLE t_04812_empty (x UInt8) ENGINE = MergeTree ORDER BY x;
+
+-- Each arm selects the raw expression as well as its type: a `toTypeName`-only projection is
+-- constant-folded before the failing check and would pass even on the unfixed server.
+
+SELECT 'globalIn';
+SELECT toTypeName(1 GLOBAL IN (t_04812)) AS t, 1 GLOBAL IN (t_04812) AS s
+FROM remote('127.0.0.1', system, one)
+GROUP BY GROUPING SETS ((1 GLOBAL IN (t_04812)))
+SETTINGS group_by_use_nulls = 1;
+
+SELECT 'globalNotIn';
+SELECT toTypeName(1 GLOBAL NOT IN (t_04812)) AS t, 1 GLOBAL NOT IN (t_04812) AS s
+FROM remote('127.0.0.1', system, one)
+GROUP BY GROUPING SETS ((1 GLOBAL NOT IN (t_04812)))
+SETTINGS group_by_use_nulls = 1;
+
+SELECT 'globalNullIn';
+SELECT toTypeName(globalNullIn(1, t_04812)) AS t, globalNullIn(1, t_04812) AS s
+FROM remote('127.0.0.1', system, one)
+GROUP BY GROUPING SETS ((globalNullIn(1, t_04812)))
+SETTINGS group_by_use_nulls = 1;
+
+SELECT 'globalNotNullIn';
+SELECT toTypeName(globalNotNullIn(1, t_04812)) AS t, globalNotNullIn(1, t_04812) AS s
+FROM remote('127.0.0.1', system, one)
+GROUP BY GROUPING SETS ((globalNotNullIn(1, t_04812)))
+SETTINGS group_by_use_nulls = 1;
+
+-- Empty set: a distinct query shape that still runs the function against an unready set while
+-- the header is computed, so it witnesses the same defect independently of the arms above.
+SELECT 'empty set';
+SELECT toTypeName(1 GLOBAL IN (t_04812_empty)) AS t, 1 GLOBAL IN (t_04812_empty) AS s
+FROM remote('127.0.0.1', system, one)
+GROUP BY GROUPING SETS ((1 GLOBAL IN (t_04812_empty)))
+SETTINGS group_by_use_nulls = 1;
+
+-- LowCardinality left argument: the framework strips LowCardinality before calling the
+-- function, so this checks that such an argument does not change the reconciliation.
+SELECT 'low cardinality left';
+SELECT toTypeName(materialize(toLowCardinality(1)) GLOBAL IN (t_04812)) AS t,
+       materialize(toLowCardinality(1)) GLOBAL IN (t_04812) AS s
+FROM remote('127.0.0.1', system, one)
+GROUP BY GROUPING SETS ((materialize(toLowCardinality(1)) GLOBAL IN (t_04812)))
+SETTINGS group_by_use_nulls = 1;
+
+-- Control: with a literal set the declared type is LowCardinality(Nullable(UInt8)). The
+-- reconciliation must leave that wrapper alone, so the type must stay LowCardinality here.
+SELECT 'control low cardinality result type';
+SELECT toTypeName(materialize(toLowCardinality('a')) GLOBAL IN ('a', 'b')) AS t,
+       materialize(toLowCardinality('a')) GLOBAL IN ('a', 'b') AS s
+FROM remote('127.0.0.1', system, one)
+GROUP BY GROUPING SETS ((materialize(toLowCardinality('a')) GLOBAL IN ('a', 'b')))
+SETTINGS group_by_use_nulls = 1;
+
+-- Control: local IN keeps its Nullable(UInt8) type and its value.
+SELECT 'control local in';
+SELECT toTypeName(1 IN (t_04812)) AS t, 1 IN (t_04812) AS s
+FROM remote('127.0.0.1', system, one)
+GROUP BY GROUPING SETS ((1 IN (t_04812)))
+SETTINGS group_by_use_nulls = 1;
+
+-- Control: without group_by_use_nulls the declared type is not Nullable, so the reconciliation
+-- must be inert and the result must stay plain UInt8.
+SELECT 'control no group_by_use_nulls';
+SELECT toTypeName(1 GLOBAL IN (t_04812)) AS t, 1 GLOBAL IN (t_04812) AS s
+FROM remote('127.0.0.1', system, one)
+GROUP BY GROUPING SETS ((1 GLOBAL IN (t_04812)));
+
+-- Control: a subquery set does not reach the failing exit, and its type is unchanged.
+SELECT 'control subquery set';
+SELECT toTypeName(1 GLOBAL IN (SELECT 1)) AS t, 1 GLOBAL IN (SELECT 1) AS s
+FROM remote('127.0.0.1', system, one)
+GROUP BY GROUPING SETS ((1 GLOBAL IN (SELECT 1)))
+SETTINGS group_by_use_nulls = 1;
+
+DROP TABLE t_04812;
+DROP TABLE t_04812_empty;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->

Related: https://github.com/ClickHouse/ClickHouse/pull/109455
Related: https://github.com/ClickHouse/ClickHouse/issues/110551

Closes: https://github.com/ClickHouse/ClickHouse/issues/114254

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `LOGICAL_ERROR: Unexpected return type from globalIn. Expected Nullable(UInt8). Got UInt8` when a `GLOBAL IN` over a table is used as a `GROUPING SETS` key with `group_by_use_nulls = 1`. `in` and its seven sibling functions now return a column matching the result type they are given.


### Description

Reported on https://github.com/ClickHouse/ClickHouse/pull/109455 as a `Stress test (arm_debug)` failure unrelated to that PR. The failing query was an AST-fuzzer mutation, but the defect is reachable from plain SQL.

**Root cause.** `group_by_use_nulls` promotes a grouping key's declared type to `Nullable(UInt8)` via `FunctionNode::getResultType` (`src/Analyzer/FunctionNode.h:193`), and the DAG node stores it; `FunctionIn` declares plain `UInt8` (`src/Functions/in.cpp:58`) and discarded the `result_type` handed to it. Neither framework wrapper covers this: the constant one is disabled (`:66`) and the Nullable one reacts only to argument nullability. With `GLOBAL IN` over a table the set is still unfilled while the header is computed, so the dry-run path returned a bare `ColumnUInt8` where `Nullable(UInt8)` was declared, and `columnMatchesType` failed at `src/Interpreters/ActionsDAG.cpp:1341`.

**Change.** `result_type` is threaded into the private `executeImpl` and the produced column is reconciled against it once, at a chokepoint above all seven returns. Argument-driven nullability is resolved before `executeImpl` is reached (`src/Functions/IFunction.cpp:215`, `:232`), so a `Nullable` here can only come from the promotion above and no row can be NULL. All `in` variants share this class, and behaviour is unchanged whenever the declared type is not `Nullable`. `FunctionsLogical.cpp:786` reads the same predicate.

**Validation.** New stateless test whose first arm is the reported query: six witness arms and four controls, each asserting a value and a type. Every witness aborts an unpatched debug server and passes with the change; the controls read identically on both. 100/100 runs pass (50 randomized, 50 without) and a 197-test slice shows 0 regressions. A release build gives a query error, not an abort. The test pins `enable_analyzer = 1`, the analyzer whose promotion it asserts: the old analyzer returns early for `GROUPING SETS` (`src/Interpreters/ExpressionAnalyzer.cpp:1597`), so `UInt8` is correct there, and an unpatched server still aborts on the first witness arm with the pin in place.