### PR TITLE
Add test: IEJoin bail-out for a prepared `Join`-storage right side is untested

### DIFF
--- a/tests/queries/0_stateless/04561_ie_join_storage_join.reference
+++ b/tests/queries/0_stateless/04561_ie_join_storage_join.reference
@@ -1,0 +1,3 @@
+inner not routed	0
+inner	1	1	10	3	5
+inner	2	5	20	9	1

--- a/tests/queries/0_stateless/04561_ie_join_storage_join.sql
+++ b/tests/queries/0_stateless/04561_ie_join_storage_join.sql
@@ -1,0 +1,39 @@
+-- Tags: no-old-analyzer
+
+-- A `Join` engine table on the right side keeps the storage-join path even when `ie_join`
+-- is listed first in `join_algorithm`.
+
+DROP TABLE IF EXISTS ie_sj_left;
+DROP TABLE IF EXISTS ie_sj_inner;
+DROP TABLE IF EXISTS ie_sj_left_eng;
+SET join_algorithm = 'ie_join,hash';
+
+DROP TABLE IF EXISTS ie_sj_left;
+DROP TABLE IF EXISTS ie_sj_inner;
+DROP TABLE IF EXISTS ie_sj_left_eng;
+
+CREATE TABLE ie_sj_left (k Int32, x Int32, y Int32) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE ie_sj_inner (k Int32, x Int32, y Int32) ENGINE = Join(ALL, INNER, k);
+CREATE TABLE ie_sj_left_eng (k Int32, x Int32, y Int32) ENGINE = Join(ALL, LEFT, k);
+
+INSERT INTO ie_sj_left VALUES (1, 1, 10), (2, 5, 20), (3, 7, 30), (4, 2, 40);
+INSERT INTO ie_sj_inner VALUES (1, 3, 5), (2, 9, 1), (3, 1, 40);
+INSERT INTO ie_sj_left_eng VALUES (1, 3, 5), (2, 9, 1), (3, 1, 40);
+
+SELECT 'inner not routed', count() FROM (
+    EXPLAIN SELECT l.k FROM ie_sj_left l JOIN ie_sj_inner r ON l.k = r.k AND l.x < r.x AND l.y > r.y
+) WHERE explain LIKE '%IEJoin%';
+
+SELECT 'inner', l.k, l.x, l.y, r.x, r.y
+FROM ie_sj_left l JOIN ie_sj_inner r ON l.k = r.k AND l.x < r.x AND l.y > r.y
+ORDER BY ALL;
+
+-- An outer join whose ON section the `Join` engine cannot evaluate keeps its pre-existing error
+SELECT count() FROM ie_sj_left l LEFT JOIN ie_sj_left_eng r ON l.k = r.k AND l.x < r.x AND l.y > r.y; -- { serverError INCOMPATIBLE_TYPE_OF_JOIN }
+
+-- Without an equality on the storage key the storage join keeps its pre-existing error too
+SELECT count() FROM ie_sj_left l JOIN ie_sj_inner r ON l.x < r.x AND l.y > r.y; -- { serverError INCOMPATIBLE_TYPE_OF_JOIN }
+
+DROP TABLE ie_sj_left;
+DROP TABLE ie_sj_inner;
+DROP TABLE ie_sj_left_eng;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #109920](https://github.com/ClickHouse/ClickHouse/pull/109920).
That PR Adds the sort-based IEJoin algorithm (`ie_join` value of `join_algorithm`) for joins whose `ON` section has two inequality comparisons. New: `JoinAlgorithm::IE_JOIN` enum + setting value, `IEJoinStep` query plan step, `IEJoinTransform`/`IEJoinAlgorithm` merging transform, `QueryPipelineBuilder::join

**1. IEJoin bail-out for a prepared `Join`-storage right side is untested**
  `src/Processors/QueryPlan/JoinStepLogical.cpp:918`
  **Risk:** `buildPhysicalJoinImpl` calls `tryExtractIEJoinDescription` as soon as `isIEJoinPreferred` holds (`ie_join` first + supported kind/strictness + two inequality conjuncts). The only thing that stops IEJoin from claiming a join against a prepared `Join` storage is `JoinStepLogical.cpp:918-919 `if (planning_context.is_storage_join) return {};`, which the LLVM report marks uncovered. Risk: if this bail-out is broken or removed, a join against a `Join`-engine table (or any prepared join storage) …
  **What's unique vs PR tests:** The PR's routing negatives (`04544_ie_join_detection_negatives.sql`, `04556_ie_join_detection_strictness_negatives.sql`, `04548_ie_join_algorithm_priority.sql`) all reject IEJoin on the shape of the `ON` expression or on the strictness. None of them exercises the planning-context bail-out: no test in the repository combines `ie_join` with an `ENGINE = Join` right side. If this PR is already merged, the cases can equivalently be appended to `04544_ie_join_detection_negatives.sql` instead of …
  **Tags:** `-- Tags: no-old-analyzer` — `no-old-analyzer`: IEJoin is planned only by the analyzer-based planner (`JoinStepLogical`); the same tag is used by every IEJoin test the PR adds.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/2bd4db02-acc2-4f22-b6b7-921117e52cc4)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.953` (included in `26.8` and later)
<!-- ch-version-info:end -->