### PR TITLE
Do not fail the hung-query report on a non-UTF-8 processlist

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -6199,7 +6199,9 @@ ORDER BY (test_name, callee_offset)
                     "\nFound hung queries in processlist:", args, "red", attrs=["bold"]
                 )
             )
-            print(processlist.decode())
+            # The query text of a hung query may contain arbitrary bytes, so a strict decode
+            # could throw and mask the whole hung-query report.
+            print(processlist.decode(errors="replace"))
             print(get_transactions_list(args))
 
             # `processlist` above already shows per-thread stacks for


### PR DESCRIPTION
In the stress-test hung check of `clickhouse-test`, `print(processlist.decode())` throws `UnicodeDecodeError` when the text of a hung query contains invalid UTF-8 (stress and fuzzer workloads produce such queries). The harness then crashes right before printing the list of hung queries, so the CI report shows a Python traceback instead of the processlist, transaction list, and stack traces — exactly the information needed to diagnose the hang. Decode with `errors="replace"` so the report survives arbitrary bytes.

Seen in the `Stress test (arm_asan_ubsan, s3)` hung check on https://github.com/ClickHouse/ClickHouse/pull/110166: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110166&sha=10655e82855be7d888b7905bdbffcbc8f25157fd&name_0=PR&name_1=Stress%20test%20%28arm_asan_ubsan%2C%20s3%29

Related: https://github.com/ClickHouse/ClickHouse/pull/110166

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)
