### PR TITLE
Measure the disconnection abort server-side in test_long_disconnection_stops_backup

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -741,24 +741,30 @@ def test_long_disconnection_stops_backup():
         with PartitionManager() as pm:
             random_sleep(3)
 
-            time_before_disconnection = time.monotonic()
-
             node_to_drop_zk_connection = random_node()
             print(
                 f"Dropping connection between {get_node_name(node_to_drop_zk_connection)} and ZooKeeper at {format_current_time()}"
             )
+            # `now64` is evaluated on the server, so this clickhouse-client's launch cost
+            # falls outside the interval. Issued last before the drop, so the interval
+            # still covers the whole abort.
+            time_before_disconnection = initiator.query("SELECT now64(6)").strip()
             pm.drop_instance_zk_connections(node_to_drop_zk_connection)
 
             # Being disconnected from ZooKeeper a backup is expected to fail.
-            wait_status(initiator, "BACKUP_FAILED", backup_id=backup_id)
+            end_time = wait_status(initiator, "BACKUP_FAILED", backup_id=backup_id)
 
-            time_to_fail = time.monotonic() - time_before_disconnection
+            # Both endpoints are server-recorded, so the clickhouse-client wait_status
+            # launches on every poll iteration is no longer charged to the abort.
+            time_to_fail = seconds_between(time_before_disconnection, end_time)
             error = get_error(initiator, backup_id=backup_id)
             print(f"error={error}")
             assert "Lost connection" in error
 
             # A backup is expected to fail, but it isn't expected to fail too soon.
-            print(f"Backup failed after {time_to_fail} seconds disconnection")
+            print(
+                f"Backup failed after {time_to_fail} seconds disconnection (server-side)"
+            )
             assert time_to_fail > 3
             assert time_to_fail < 45
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112217
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_long_disconnection_stops_backup` fails as `assert 45.54 < 45` at
`test_cancel_backup.py:763`. `time_to_fail` is the difference of two `time.monotonic()` reads
in the pytest process (`:744`, `:755`), so it charges the backup's abort latency for work the
harness does in between: the `iptables` `docker exec` in
`drop_instance_zk_connections`, and (dominant) one **fresh `clickhouse-client` process per
poll iteration** of `wait_status` (`helpers/client.py:208`). The number grows with the abort
latency itself, so a contended runner crosses a ceiling the engine is nowhere near.

#112217 established exactly this for the two sibling tests in this file and converted them to
server-recorded timestamps, adding `seconds_between` (`:116`) and making `wait_status` return
the server-stamped `end_time` (`:191`). This call site was left behind: `end_time` is used at
`:523`/`:592` and discarded at `:753`. It was the file's last timing assertion on a client-side
stopwatch.

This PR converts it. The left endpoint is a `SELECT now64(6)` on the initiator, issued last
before the disconnection - `now64` is evaluated on the server, so the client launch falls
outside the interval, while placing it before the drop keeps the whole abort covered. **Both
bounds (`> 3`, `< 45`) are unchanged**; only the measurement is corrected, so the assertion
becomes strictly tighter against a real abort-latency regression. 11 added / 5 removed lines in
one test file; no source change.

Two residuals remain inside the interval by design: the `iptables` exec, and the marker query's
own response latency after `now64` is evaluated. Removed is the term that scales with
contention.

### Validation

Instrumented probe printing both numbers side by side, 20 runs: the server-side value is
smaller in **20/20** (gap min 0.264 / p50 0.680 / max 1.318 s) - the p50 alone exceeds the
0.54 s overshoot above. Fails-without / passes-with, using a per-run ceiling placed between the
two values: **pre-fix 6/6 FAIL** with the original signature, **fixed 6/6 PASS**. Lower bound
checked per disconnection case, since the initiator-dropped case has the tighter floor: Case A
n=15 min 6.236 s, Case B n=5 min 9.673 s, i.e. every run clears `> 3` with at least 3.2 s to spare.
50 repeats of the test pass 50/50; a 5x module A/B (7 tests, 35 executions per arm) is 35/35 on
both arms, i.e. zero failures either side.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.968` (included in `26.8` and later)
<!-- ch-version-info:end -->