### PR TITLE
Register prepared sets before expanding ALIAS columns of Merge child tables

### DIFF
--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -40,6 +40,7 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectQuery.h>
+#include <Planner/CollectSets.h>
 #include <Planner/PlannerActionsVisitor.h>
 #include <Planner/Utils.h>
 #include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
@@ -1223,6 +1224,10 @@ SelectQueryInfo ReadFromMerge::getModifiedQueryInfo(const ContextMutablePtr & mo
                     column_node = std::make_shared<ColumnNode>(*resolved_pair, modified_query_info.table_expression);
                 }
 
+                /// The set registry of the freshly derived planner context is empty, and
+                /// `PlannerActionsVisitor` resolves `IN` through it.
+                collectSets(column_node, *modified_query_info.planner_context);
+
                 ColumnNodePtrWithHashSet empty_correlated_columns_set;
                 PlannerActionsVisitor actions_visitor(modified_query_info.planner_context, empty_correlated_columns_set, false /*use_column_identifier_as_action_node_name*/);
                 actions_visitor.visit(*filter_actions_dag, column_node);
@@ -1681,6 +1686,9 @@ void ReadFromMerge::convertAndFilterSourceStream(
 
             QueryAnalysisPass query_analysis_pass(modified_query_info.table_expression);
             query_analysis_pass.run(query_tree, local_context);
+
+            /// On the query info cache path nothing registered this expression's sets.
+            collectSets(query_tree, *modified_query_info.planner_context);
 
             ColumnNodePtrWithHashSet empty_correlated_columns_set;
             PlannerActionsVisitor actions_visitor(modified_query_info.planner_context, empty_correlated_columns_set, false /*use_column_identifier_as_action_node_name*/);

--- a/tests/queries/0_stateless/04812_merge_alias_in_prepared_set.reference
+++ b/tests/queries/0_stateless/04812_merge_alias_in_prepared_set.reference
@@ -1,0 +1,19 @@
+constant tuple
+[0,1,7]
+explicit column
+[0,1,7]
+with filter
+[1]
+set table
+[0,1,7]
+not in
+[0,1,7]
+tuple key
+[0,1,7]
+nullable
+[1,7,255]	1
+query info cache
+[0,1,7]
+identical children
+[0,1]
+ALIAS	y IN (1, 2, 3)

--- a/tests/queries/0_stateless/04812_merge_alias_in_prepared_set.sql
+++ b/tests/queries/0_stateless/04812_merge_alias_in_prepared_set.sql
@@ -1,0 +1,100 @@
+-- Reading through `merge()` over a child table whose ALIAS column contains `IN` used to abort with
+-- `Logical error: No set is registered for key ...`. It triggers only when the children disagree
+-- about that column's default, which makes the Merge-level column look physical.
+
+-- The old analyzer reads an ALIAS column through `TreeRewriter`, which never consults the set
+-- registry, so every case below produces its expected value on an unfixed server unless this is set.
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS t04812_phys;
+DROP TABLE IF EXISTS t04812_alias;
+DROP TABLE IF EXISTS t04812_set;
+
+-- Constant tuple: the `findTuple` branch.
+CREATE TABLE t04812_phys (x UInt8) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t04812_alias (y UInt8, x UInt8 ALIAS y IN (1, 2, 3)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04812_phys VALUES (7);
+INSERT INTO t04812_alias VALUES (2), (9);
+SELECT 'constant tuple';
+SELECT arraySort(groupArray(x)) FROM merge(currentDatabase(), '^t04812_(phys|alias)$');
+
+-- The same shape with an explicit column list, not `SELECT *`.
+SELECT 'explicit column';
+SELECT arraySort(groupArray(x)) FROM (SELECT x FROM merge(currentDatabase(), '^t04812_(phys|alias)$'));
+
+-- A filter reaching the child read, which is how the failure was first seen in CI.
+SELECT 'with filter';
+SELECT arraySort(groupArray(x)) FROM merge(currentDatabase(), '^t04812_(phys|alias)$') WHERE x = 1;
+
+-- `Set` table: the `findStorage` branch, whose registry key carries no element types.
+DROP TABLE t04812_alias;
+CREATE TABLE t04812_set (k UInt8) ENGINE = Set;
+INSERT INTO t04812_set VALUES (1), (2);
+CREATE TABLE t04812_alias (y UInt8, x UInt8 ALIAS y IN t04812_set) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04812_alias VALUES (2), (9);
+SELECT 'set table';
+SELECT arraySort(groupArray(x)) FROM merge(currentDatabase(), '^t04812_(phys|alias)$');
+
+-- `NOT IN` reaches the same lookup.
+DROP TABLE t04812_alias;
+CREATE TABLE t04812_alias (y UInt8, x UInt8 ALIAS y NOT IN (1, 2, 3)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04812_alias VALUES (2), (9);
+SELECT 'not in';
+SELECT arraySort(groupArray(x)) FROM merge(currentDatabase(), '^t04812_(phys|alias)$');
+
+-- A tuple key, so the registry key carries two element types.
+DROP TABLE t04812_alias;
+CREATE TABLE t04812_alias (a UInt8, b UInt8, x UInt8 ALIAS (a, b) IN ((1, 2), (3, 4))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04812_alias VALUES (1, 2), (9, 9);
+SELECT 'tuple key';
+SELECT arraySort(groupArray(x)) FROM merge(currentDatabase(), '^t04812_(phys|alias)$');
+
+-- A Nullable operand, where the alias itself is Nullable.
+DROP TABLE t04812_phys;
+DROP TABLE t04812_alias;
+CREATE TABLE t04812_phys (x Nullable(UInt8)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t04812_alias (y Nullable(UInt8), x Nullable(UInt8) ALIAS y IN (1, 2, NULL)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04812_phys VALUES (7);
+INSERT INTO t04812_alias VALUES (2), (NULL);
+SELECT 'nullable';
+SELECT arraySort(groupArray(ifNull(x, 255))), countIf(x IS NULL) FROM merge(currentDatabase(), '^t04812_(phys|alias)$');
+
+DROP TABLE t04812_phys;
+DROP TABLE t04812_alias;
+DROP TABLE t04812_set;
+
+-- A third child identical to the second takes the query info cache path, which skips
+-- `getModifiedQueryInfo` and evaluates its alias in `convertAndFilterSourceStream` instead.
+-- The values are asserted so that a silently unevaluated alias fails this case.
+DROP TABLE IF EXISTS u04812_phys;
+DROP TABLE IF EXISTS u04812_a;
+DROP TABLE IF EXISTS u04812_b;
+CREATE TABLE u04812_phys (x UInt8) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE u04812_a (y UInt8, x UInt8 ALIAS y IN (1, 2, 3)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE u04812_b (y UInt8, x UInt8 ALIAS y IN (1, 2, 3)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO u04812_phys VALUES (7);
+INSERT INTO u04812_a VALUES (2);
+INSERT INTO u04812_b VALUES (9);
+SELECT 'query info cache';
+SELECT arraySort(groupArray(x)) FROM merge(currentDatabase(), '^u04812_');
+
+DROP TABLE u04812_phys;
+DROP TABLE u04812_a;
+DROP TABLE u04812_b;
+
+-- Control: with both children declaring the same ALIAS there is no disagreement, the Merge column
+-- keeps its ALIAS, and this case already passed before the fix. It is what shows that the
+-- discriminating condition of the cases above is the disagreement between children.
+DROP TABLE IF EXISTS v04812_a;
+DROP TABLE IF EXISTS v04812_b;
+CREATE TABLE v04812_a (y UInt8, x UInt8 ALIAS y IN (1, 2, 3)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE v04812_b (y UInt8, x UInt8 ALIAS y IN (1, 2, 3)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO v04812_a VALUES (2);
+INSERT INTO v04812_b VALUES (9);
+SELECT 'identical children';
+SELECT arraySort(groupArray(x)) FROM merge(currentDatabase(), '^v04812_');
+SELECT default_kind, default_expression FROM system.columns
+WHERE database = currentDatabase() AND table = 'v04812_a' AND name = 'x';
+
+DROP TABLE v04812_a;
+DROP TABLE v04812_b;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/113712


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `Logical error: No set is registered for key ...` when reading through a `Merge` table whose child declares an `ALIAS` column containing `IN`, and the children disagree about that column's default.

### Description

Reproducer, which aborts the server on master:

```sql
CREATE TABLE t1 (x UInt8) ENGINE = MergeTree ORDER BY tuple();
CREATE TABLE t2 (y UInt8, x UInt8 ALIAS y IN (1, 2, 3)) ENGINE = MergeTree ORDER BY tuple();
SELECT * FROM merge(currentDatabase(), '.+');
```

`getColumnsDescriptionFromSourceTablesImpl` clears a column's default when children disagree about it, so the Merge-level `x` looks physical and is requested from every child. `t2` still declares it as `ALIAS`, so `ReadFromMerge::getModifiedQueryInfo` expands it and builds actions with a `PlannerActionsVisitor`. That visitor resolves `IN` through `PlannerContext::getPreparedSets`, but its context was derived a few lines earlier and the deriving constructor does not copy `prepared_sets`, so the registry is empty and the lookup misses. Since `LOGICAL_ERROR` aborts at throw time under a sanitizer, the call has to be avoided rather than guarded.

The fix calls `collectSets` before building the actions, as two existing sites already do here: `Planner/Utils.cpp` for row policies, and `CollectTableExpressionData.cpp` for the same ALIAS expansion pattern. It is idempotent. The reachable right-hand sides here are a constant tuple and a `Set` table, and both now resolve; the `Set` table reaches the same lookup through a different branch. A subquery is rejected at DDL time, and a plain table already fails identically without a `Merge` table, so it is untouched.

`convertAndFilterSourceStream` needs the same call, being reached when a child hits the query info cache, which skips `getModifiedQueryInfo` and builds another empty context. The issue's `LIMIT -326, 33 FORMAT ORC` is incidental; a plain `SELECT *` aborts.

Validation: the new test fails on master and passes with the fix, through `clickhouse-test`, 100/100 runs (50 randomized, 50 with randomization off). Reverting either call reddens only the cases reaching that site. A 437-test slice over `merge()` and `ALIAS` columns has an identical failure set on both arms.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.951` (included in `26.8` and later)
- Backported to: `26.7.5.7`, `26.6.4.6`, `26.5.8.8`
<!-- ch-version-info:end -->