### PR TITLE
Do not push a predicate into a subquery whose SELECT list uses `untuple`

### DIFF
--- a/src/Interpreters/ExtractExpressionInfoVisitor.cpp
+++ b/src/Interpreters/ExtractExpressionInfoVisitor.cpp
@@ -24,6 +24,10 @@ void ExpressionInfoMatcher::visit(const ASTFunction & ast_function, const ASTPtr
     {
         data.is_array_join = true;
     }
+    else if (ast_function.name == "untuple")
+    {
+        data.is_untuple = true;
+    }
     // "is_aggregate_function" is used to determine whether we can move a filter
     // (1) from HAVING to WHERE or (2) from WHERE of a parent query to HAVING of
     // a subquery.
@@ -92,8 +96,10 @@ bool hasNonRewritableFunction(const ASTPtr & node, ContextPtr context)
         ExpressionInfoVisitor::Data expression_info{WithContext{context}, tables};
         ExpressionInfoVisitor(expression_info).visit(select_expression);
 
+        /// `untuple` expands at execution build time: its output names are not referenceable here.
         if (expression_info.is_stateful_function
-            || expression_info.is_window_function)
+            || expression_info.is_window_function
+            || expression_info.is_untuple)
         {
             // If an outer query has a WHERE on window function, we can't move
             // it into the subquery, because window functions are not allowed in

--- a/src/Interpreters/ExtractExpressionInfoVisitor.h
+++ b/src/Interpreters/ExtractExpressionInfoVisitor.h
@@ -19,6 +19,7 @@ struct ExpressionInfoMatcher
         const TablesWithColumns & tables;
 
         bool is_array_join = false;
+        bool is_untuple = false;
         bool is_stateful_function = false;
         bool is_aggregate_function = false;
         bool is_window_function = false;

--- a/tests/queries/0_stateless/04812_predicate_pushdown_untuple.reference
+++ b/tests/queries/0_stateless/04812_predicate_pushdown_untuple.reference
@@ -1,0 +1,47 @@
+-- 1 untuple(arrayJoin(map)), three levels
+a
+a
+a
+-- 2 untuple of a named tuple, no arrayJoin
+x
+x
+-- 3 untuple in a UNION ALL branch
+x
+y
+x
+y
+-- 4 three levels with re-aliasing
+5
+5
+-- 5 two untuples, predicate on the second
+x	y
+x	y
+-- 6 control: arrayJoin without untuple still pushes
+1
+1
+-- 7 control: tuple column with element access still pushes
+2	3
+2	3
+-- 8 control: a column literally named `u.v` still pushes
+5
+5
+-- 9 the coverage the barrier trades away: predicate on a sibling ordinary column
+x	3
+x	4
+x	3
+x	4
+-- 10 untuple of an aggregate tuple under GROUP BY
+3	3
+3	3
+-- 11 untuple inside a CTE consulted by the same barrier
+x
+x
+-- 12 unaliased untuple: the outputs are named after the generated tupleElement calls
+1
+1
+-- 13 positive oracle: a subquery without untuple still receives the pushed predicate
+Condition: and((x in [5, 5]), (x in [5, 5]))
+Condition: (x in [5, 5])
+-- 14 the barrier is blanket: an untuple sibling also stops receiving the pushed predicate
+Condition: (x in [5, 5])
+Condition: (x in [5, 5])

--- a/tests/queries/0_stateless/04812_predicate_pushdown_untuple.sql
+++ b/tests/queries/0_stateless/04812_predicate_pushdown_untuple.sql
@@ -1,0 +1,197 @@
+-- The old analyzer's AST predicate pushdown must not push a predicate into a subquery
+-- whose SELECT list contains `untuple`: the names `untuple` produces appear in that
+-- subquery's output block but cannot be referenced inside it.
+-- Each row is run with the pushdown both enabled and disabled, so the reference itself
+-- proves the two arms agree. `enable_optimize_predicate_expression` is randomized by the
+-- test runner, so it is pinned per statement.
+
+SELECT '-- 1 untuple(arrayJoin(map)), three levels';
+SELECT t.keys AS label
+FROM (SELECT untuple(arrayJoin(m)) AS t
+      FROM (SELECT map('a', 1, 'b', 0) AS m) AS mt) AS tt
+WHERE t.values > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 1;
+
+SELECT t.keys AS label
+FROM (SELECT untuple(arrayJoin(m)) AS t
+      FROM (SELECT map('a', 1, 'b', 0) AS m) AS mt) AS tt
+WHERE t.values > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT t.keys AS label
+FROM (SELECT untuple(arrayJoin(m)) AS t
+      FROM (SELECT map('a', 1, 'b', 0) AS m) AS mt) AS tt
+WHERE t.values > 0
+SETTINGS enable_analyzer = 1;
+
+SELECT '-- 2 untuple of a named tuple, no arrayJoin';
+SELECT u.k AS label
+FROM (SELECT untuple(CAST(('x', 5), 'Tuple(k String, v UInt8)')) AS u FROM numbers(1)) AS tt
+WHERE u.v > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 1;
+
+SELECT u.k AS label
+FROM (SELECT untuple(CAST(('x', 5), 'Tuple(k String, v UInt8)')) AS u FROM numbers(1)) AS tt
+WHERE u.v > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- 3 untuple in a UNION ALL branch';
+SELECT u.k AS label FROM (
+    SELECT untuple(CAST(('x', 5), 'Tuple(k String, v UInt8)')) AS u FROM numbers(1)
+    UNION ALL
+    SELECT untuple(CAST(('y', 7), 'Tuple(k String, v UInt8)')) AS u FROM numbers(1)
+) AS tt
+WHERE u.v > 0
+ORDER BY label
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 1;
+
+SELECT u.k AS label FROM (
+    SELECT untuple(CAST(('x', 5), 'Tuple(k String, v UInt8)')) AS u FROM numbers(1)
+    UNION ALL
+    SELECT untuple(CAST(('y', 7), 'Tuple(k String, v UInt8)')) AS u FROM numbers(1)
+) AS tt
+WHERE u.v > 0
+ORDER BY label
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- 4 three levels with re-aliasing';
+SELECT w FROM (
+    SELECT v AS w FROM (
+        SELECT u.v AS v FROM (
+            SELECT untuple(CAST(('x', 5), 'Tuple(k String, v UInt8)')) AS u FROM numbers(1)
+        ) AS a
+    ) AS b
+) AS c
+WHERE w > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 1;
+
+SELECT w FROM (
+    SELECT v AS w FROM (
+        SELECT u.v AS v FROM (
+            SELECT untuple(CAST(('x', 5), 'Tuple(k String, v UInt8)')) AS u FROM numbers(1)
+        ) AS a
+    ) AS b
+) AS c
+WHERE w > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- 5 two untuples, predicate on the second';
+SELECT p.a AS l1, q.c AS l2
+FROM (SELECT untuple(CAST(('x', 1), 'Tuple(a String, b UInt8)')) AS p,
+             untuple(CAST(('y', 2), 'Tuple(c String, d UInt8)')) AS q
+      FROM numbers(1)) AS tt
+WHERE q.d > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 1;
+
+SELECT p.a AS l1, q.c AS l2
+FROM (SELECT untuple(CAST(('x', 1), 'Tuple(a String, b UInt8)')) AS p,
+             untuple(CAST(('y', 2), 'Tuple(c String, d UInt8)')) AS q
+      FROM numbers(1)) AS tt
+WHERE q.d > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- 6 control: arrayJoin without untuple still pushes';
+SELECT v FROM (SELECT arrayJoin([1, 0]) AS v) AS tt WHERE v > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 1;
+
+SELECT v FROM (SELECT arrayJoin([1, 0]) AS v) AS tt WHERE v > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- 7 control: tuple column with element access still pushes';
+SELECT t.1 AS a, t.2 AS b FROM (SELECT tuple(2, 3) AS t FROM numbers(1)) AS tt WHERE t.2 > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 1;
+
+SELECT t.1 AS a, t.2 AS b FROM (SELECT tuple(2, 3) AS t FROM numbers(1)) AS tt WHERE t.2 > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- 8 control: a column literally named `u.v` still pushes';
+SELECT `u.v` FROM (SELECT 5 AS `u.v` FROM numbers(1)) AS tt WHERE `u.v` > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 1;
+
+SELECT `u.v` FROM (SELECT 5 AS `u.v` FROM numbers(1)) AS tt WHERE `u.v` > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- 9 the coverage the barrier trades away: predicate on a sibling ordinary column';
+SELECT u.k AS label, x FROM (
+    SELECT untuple(CAST(('x', 5), 'Tuple(k String, v UInt8)')) AS u, number AS x FROM numbers(5)
+) AS tt
+WHERE x > 2
+ORDER BY x
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 1;
+
+SELECT u.k AS label, x FROM (
+    SELECT untuple(CAST(('x', 5), 'Tuple(k String, v UInt8)')) AS u, number AS x FROM numbers(5)
+) AS tt
+WHERE x > 2
+ORDER BY x
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- 10 untuple of an aggregate tuple under GROUP BY';
+SELECT u.mn, u.cnt FROM (
+    SELECT untuple(CAST((min(number), count()), 'Tuple(mn UInt64, cnt UInt64)')) AS u, intDiv(number, 3) AS g
+    FROM numbers(9) GROUP BY g
+) AS tt
+WHERE g = 1
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 1;
+
+SELECT u.mn, u.cnt FROM (
+    SELECT untuple(CAST((min(number), count()), 'Tuple(mn UInt64, cnt UInt64)')) AS u, intDiv(number, 3) AS g
+    FROM numbers(9) GROUP BY g
+) AS tt
+WHERE g = 1
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- 11 untuple inside a CTE consulted by the same barrier';
+WITH c AS (SELECT untuple(CAST(('x', 5), 'Tuple(k String, v UInt8)')) AS u FROM numbers(1))
+SELECT u.k AS label FROM (SELECT * FROM c) AS tt WHERE u.v > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 1;
+
+WITH c AS (SELECT untuple(CAST(('x', 5), 'Tuple(k String, v UInt8)')) AS u FROM numbers(1))
+SELECT u.k AS label FROM (SELECT * FROM c) AS tt WHERE u.v > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- 12 unaliased untuple: the outputs are named after the generated tupleElement calls';
+SELECT 1 AS ok FROM (SELECT untuple(CAST(('x', 5), 'Tuple(k String, v UInt8)')) FROM numbers(1)) AS tt
+WHERE `tupleElement(CAST(('x', 5), 'Tuple(k String, v UInt8)'), 2)` > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 1;
+
+SELECT 1 AS ok FROM (SELECT untuple(CAST(('x', 5), 'Tuple(k String, v UInt8)')) FROM numbers(1)) AS tt
+WHERE `tupleElement(CAST(('x', 5), 'Tuple(k String, v UInt8)'), 2)` > 0
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+-- The rows above compare results only, so they would all stay green if the pushdown became a
+-- global no-op. The two below read the index condition instead, which is a direct observation
+-- of whether the AST rewrite added its conjunct: pushing produces the duplicate
+-- `and((x in [5, 5]), (x in [5, 5]))`, because the plan-level filter pushdown supplies the same
+-- condition anyway.
+DROP TABLE IF EXISTS t_04812;
+CREATE TABLE t_04812 (x UInt64) ENGINE = MergeTree ORDER BY x;
+INSERT INTO t_04812 SELECT number FROM numbers(1000);
+
+SELECT '-- 13 positive oracle: a subquery without untuple still receives the pushed predicate';
+SELECT trim(explain) FROM (
+    EXPLAIN indexes = 1 SELECT x FROM (SELECT x FROM t_04812) AS tt WHERE x = 5
+) WHERE explain LIKE '%Condition:%'
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 1;
+
+SELECT trim(explain) FROM (
+    EXPLAIN indexes = 1 SELECT x FROM (SELECT x FROM t_04812) AS tt WHERE x = 5
+) WHERE explain LIKE '%Condition:%'
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- 14 the barrier is blanket: an untuple sibling also stops receiving the pushed predicate';
+SELECT trim(explain) FROM (
+    EXPLAIN indexes = 1 SELECT u.k, x FROM (
+        SELECT untuple(CAST(('x', 5), 'Tuple(k String, v UInt8)')) AS u, x FROM t_04812
+    ) AS tt WHERE x = 5
+) WHERE explain LIKE '%Condition:%'
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 1;
+
+SELECT trim(explain) FROM (
+    EXPLAIN indexes = 1 SELECT u.k, x FROM (
+        SELECT untuple(CAST(('x', 5), 'Tuple(k String, v UInt8)')) AS u, x FROM t_04812
+    ) AS tt WHERE x = 5
+) WHERE explain LIKE '%Condition:%'
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+DROP TABLE t_04812;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/113250#issuecomment-5178327763
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `UNKNOWN_IDENTIFIER` with `enable_analyzer = 0` when a `WHERE` refers to a column produced by `untuple` inside a subquery, for example `SELECT t.keys FROM (SELECT untuple(arrayJoin(m)) AS t FROM ...) WHERE t.values > 0`. The `enable_optimize_predicate_expression` rewrite pushed such a predicate into the subquery as a `HAVING`, where the name does not yet exist.


### Description

With `enable_analyzer = 0` this throws `Code: 47 ... Missing columns: 't.values'` instead of
returning `a`, on 25.8 through 26.7. `enable_optimize_predicate_expression` defaults to `1`, so it
is the default path.

```sql
SELECT t.keys FROM (SELECT untuple(arrayJoin(map('a', 1, 'b', 0))) AS t) AS tt
WHERE t.values > 0;
```

**Root cause.** `untuple` is a SELECT-list expander, not a function: `ActionsMatcher::doUntuple`
resolves it at execution build time and aliases its outputs `` `t.keys` ``/`` `t.values` ``. Those
names reach the subquery's output block but are not referenceable inside it. The pushdown resolves
the predicate against that output list and attaches it as a `HAVING`, analysed before the expansion.

**The change.** `untuple` joins the existing `hasNonRewritableFunction` barrier, which already
returns true for stateful and window functions for the same reason, matched on the AST name since
`untuple` is absent from `FunctionFactory`. In `rewriteSubquery`, it covers the `WITH` clause and
every `UNION` branch.

**Cost.** The barrier reads the whole SELECT list, so it also blocks pushdown for a predicate on an
ordinary sibling column of such a subquery; the names `untuple` will produce are exactly what
AST-rewrite time cannot know. Locally that is free (2M-row MergeTree: identical granules and rows
read either way). A distributed read pays, since the AST rewrite is what filters the shipped query:
over `remote()`, a leg that read 1 row now reads 1,000,000. Writing that predicate inside the
subquery, or using the new analyzer, keeps the filter.

**Validation.** New test, seven witnesses and five controls, each run pushdown-on and off,
plus two rows reading the rendered index condition so the file separates "the barrier works" from
"the pushdown never runs". Regression slices over 69 pre-existing tests show none. `untuple` of an unnamed tuple and
`arr.size0` subcolumns fail under the new analyzer too, so both are out of scope.