### PR TITLE
Fix flaky `04357_table_readonly_background_moves`

### DIFF
--- a/tests/config/config.d/storage_conf.xml
+++ b/tests/config/config.d/storage_conf.xml
@@ -143,7 +143,13 @@
             <local_remote>
                 <volumes>
                     <local><disk>default</disk></local>
-                    <remote><disk>s3_disk</disk></remote>
+                    <!-- A part always starts on the 'local' volume, even when its move TTL
+                         expired while the INSERT was still running. The background mover
+                         ignores this setting, so TTL moves still happen. -->
+                    <remote>
+                        <disk>s3_disk</disk>
+                        <perform_ttl_move_on_insert>0</perform_ttl_move_on_insert>
+                    </remote>
                 </volumes>
             </local_remote>
             <s3_cache>

--- a/tests/queries/0_stateless/04357_table_readonly_background_moves.sh
+++ b/tests/queries/0_stateless/04357_table_readonly_background_moves.sh
@@ -18,9 +18,9 @@ ${CLICKHOUSE_CLIENT} -m -q "
 DROP TABLE IF EXISTS t_ro_move;
 DROP TABLE IF EXISTS t_w_move;
 
--- 'TTL ... TO VOLUME' with a small delay: the part is first written to the 'local' volume and only
--- becomes eligible for a background move to the 'remote' volume a few seconds later. now() is an
--- absolute instant, so a randomized session_timezone does not shift this boundary.
+-- 'TTL ... TO VOLUME': the part is first written to the 'local' volume and is then eligible for a
+-- background move to the 'remote' volume. now() is an absolute instant, so a randomized
+-- session_timezone does not shift this boundary.
 CREATE TABLE t_ro_move (d DateTime, x UInt64) ENGINE = MergeTree ORDER BY x
 TTL d + INTERVAL 5 SECOND TO VOLUME 'remote'
 SETTINGS storage_policy = 'local_remote';
@@ -33,11 +33,16 @@ SETTINGS storage_policy = 'local_remote';
 SYSTEM STOP MOVES t_ro_move;
 SYSTEM STOP MOVES t_w_move;
 
-INSERT INTO t_ro_move VALUES (now(), 1);
-INSERT INTO t_w_move VALUES (now(), 1);
+-- The move TTL is ALREADY expired at insert. perform_ttl_move_on_insert is disabled for the
+-- 'remote' volume of the 'local_remote' policy (tests/config/config.d/storage_conf.xml), so the
+-- part must still be written to the 'local' volume; without that setting it would be reserved
+-- directly on 'remote' and born on s3_disk.
+INSERT INTO t_ro_move VALUES (now() - INTERVAL 1 MINUTE, 1);
+INSERT INTO t_w_move VALUES (now() - INTERVAL 1 MINUTE, 1);
 "
 
-# Both parts must start on the local volume (disk 'default'): the move TTL has not expired yet at insert.
+# Both parts must start on the local volume (disk 'default') even though the move TTL is already
+# expired, because perform_ttl_move_on_insert is disabled for the 'remote' volume.
 echo "initial readonly disk:"
 ${CLICKHOUSE_CLIENT} -q "SELECT disk_name FROM system.parts WHERE database = currentDatabase() AND table = 't_ro_move' AND active"
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`04357_table_readonly_background_moves` failed once on `Stateless tests (amd_tsan, parallel)` with
both `disk_name` reads flipped while the writable control line between them still passed:

```
 initial readonly disk:
-default
+s3_disk
 writable control moved to remote: OK
```

The read-only table's part was already on the remote volume at the *first* observation, before the
test had set `table_readonly = 1`. **This is not a product defect**: the read-only flag is set after
the INSERT, so no guard was ever handed a local part to hold.

The cause is a wall-clock assumption in the fixture. `SYSTEM STOP MOVES` cancels
`parts_mover.moves_blocker`, which only the background mover reads, so it cannot gate the INSERT's
own space reservation. When a part's move TTL is already expired at write time,
`tryReserveSpacePreferringTTLRules` reserves directly on the TTL destination volume, because
`perform_ttl_move_on_insert` defaults to `true` and the `local_remote` policy did not override it.
The interval that must stay under the 5-second TTL is therefore *inside* the INSERT, from the
`now()` constant fixed at analysis time to the `time(nullptr)` read at reservation.

This sets `perform_ttl_move_on_insert` to `0` on that volume, so a part always starts on the local
volume however long the INSERT takes, and makes the test insert an already-expired `d` so that path
runs every time rather than only on a slow runner. The flag is insert-only and `MergeTreePartsMover`
never reads it, so the part stays move-eligible and the writable control table still moves.
`local_remote` is the only multi-volume policy in the stateless config set that a test combines with
a move TTL, so this disables the insert-time TTL move for the whole stateless suite; the
already-expired insert keeps that path asserted here, and `tests/integration/test_ttl_move` covers it
with the setting enabled. The reference and tags are unchanged. This signature has one occurrence in
180 days and none on master.

### Validation

Two mutants redden different assertions, which is what proves the two arms are independently armed:
reverting only the config element fails on `initial readonly disk`, and reverting only the
`table_readonly` guard in `scheduleDataMovingJob` fails on `readonly disk after control moved`.
`system.storage_policies` reports `perform_ttl_move_on_insert = 0` for the `remote` volume with this
change and `1` without it. 100/100 runs pass (50 randomized, 50 with randomization off). The two
other `local_remote` tests, `02870_move_partition_to_volume_io_throttling` and
`04603_zero_copy_lock_dtor_keeper_component`, use explicit `ALTER ... MOVE` with no TTL clause and
pass 10/10 each.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.952` (included in `26.8` and later)
<!-- ch-version-info:end -->