### PR TITLE
CI: tag every uploaded S3 artifact with a retention tag

### DIFF
--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -627,6 +627,12 @@ class Runner:
                 print(f"Job provides s3 artifacts [{providing_artifacts}]")
                 artifact_links = []
                 s3_path = f"{Settings.S3_ARTIFACT_PATH}/{env.get_s3_prefix()}/{Utils.normalize_string(env.JOB_NAME)}"
+                # Every object uploaded to the artifact bucket must carry a
+                # "retention" tag: S3 lifecycle filters cannot match "objects
+                # without a tag", so untagged objects would be covered by no
+                # rule. Default to short retention; per-artifact tags (e.g.
+                # retention=long) override on the "retention" key.
+                default_tags = {"retention": "default"}
                 for artifact in providing_artifacts:
                     if artifact.compress_zst:
                         if isinstance(artifact.path, (tuple, list)):
@@ -656,13 +662,7 @@ class Runner:
                                     f"Artifact {artifact_path} not found"
                                 )
                             Shell.check(f"ls -l {artifact_path}", verbose=True)
-                            # Every artifact object must carry a "retention"
-                            # tag: S3 lifecycle filters cannot match "objects
-                            # without a tag", so untagged objects would be
-                            # covered by no rule. Default to short retention;
-                            # per-artifact tags (e.g. retention=long) override.
-                            tags = {"retention": "default"}
-                            tags.update(artifact.ext.get("tags") or {})
+                            tags = {**default_tags, **(artifact.ext.get("tags") or {})}
                             for file_path in matched:
                                 link = S3.copy_file_to_s3(
                                     s3_path=s3_path,
@@ -686,7 +686,9 @@ class Runner:
                     with open(artifact_report_file, "w", encoding="utf-8") as f:
                         json.dump(artifact_report, f)
                     link = S3.copy_file_to_s3(
-                        s3_path=s3_path, local_path=artifact_report_file
+                        s3_path=s3_path,
+                        local_path=artifact_report_file,
+                        tags=default_tags,
                     )
                     result.set_link(link)
 

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -656,11 +656,18 @@ class Runner:
                                     f"Artifact {artifact_path} not found"
                                 )
                             Shell.check(f"ls -l {artifact_path}", verbose=True)
+                            # Every artifact object must carry a "retention"
+                            # tag: S3 lifecycle filters cannot match "objects
+                            # without a tag", so untagged objects would be
+                            # covered by no rule. Default to short retention;
+                            # per-artifact tags (e.g. retention=long) override.
+                            tags = {"retention": "default"}
+                            tags.update(artifact.ext.get("tags") or {})
                             for file_path in matched:
                                 link = S3.copy_file_to_s3(
                                     s3_path=s3_path,
                                     local_path=file_path,
-                                    tags=artifact.ext.get("tags"),
+                                    tags=tags,
                                 )
                                 result.set_link(link)
                                 artifact_links.append(link)

--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -5,7 +5,7 @@ import os
 import time
 from pathlib import Path
 from typing import Dict
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 from ._environment import _Environment
 from .settings import Settings
@@ -132,6 +132,12 @@ class S3:
                     extra_args["ContentType"] = inferred_content_type
                 if content_encoding:
                     extra_args["ContentEncoding"] = content_encoding
+                if tags:
+                    # Attach tags to the upload request itself (URL-encoded
+                    # querystring) instead of a follow-up put_object_tagging
+                    # call, so the object is never left untagged by a tagging
+                    # step that fails after a successful upload.
+                    extra_args["Tagging"] = urlencode(tags)
 
                 def _upload():
                     client = cls._get_boto3_client()
@@ -141,11 +147,6 @@ class S3:
                         )
                     else:
                         client.upload_file(str(local_path), bucket, key)
-                    if tags:
-                        tag_set = [{"Key": k, "Value": v} for k, v in tags.items()]
-                        client.put_object_tagging(
-                            Bucket=bucket, Key=key, Tagging={"TagSet": tag_set}
-                        )
 
                 # Retry on transient credential failures
                 cls._retry_on_no_credentials(_upload)
@@ -174,17 +175,12 @@ class S3:
                 cmd += f" --content-type {content_type}"
             if content_encoding:
                 cmd += f" --content-encoding {content_encoding}"
-            _ = cls.run_command_with_retries(cmd, no_strict=no_strict)
-
-            # Apply tags if provided
             if tags:
-                bucket = s3_full_path.split("/")[0]
-                key = "/".join(s3_full_path.split("/")[1:])
-                # Use JSON format for tagging to ensure correct syntax
-                tag_set = [{"Key": k, "Value": v} for k, v in tags.items()]
-                tagging_json = json.dumps({"TagSet": tag_set})
-                tag_cmd = f"aws s3api put-object-tagging --bucket {bucket} --key {key} --tagging '{tagging_json}'"
-                cls.run_command_with_retries(tag_cmd, no_strict=True)
+                # Apply tags during upload (single request) rather than a
+                # follow-up put-object-tagging that could fail and leave the
+                # object untagged.
+                cmd += f" --tagging '{urlencode(tags)}'"
+            _ = cls.run_command_with_retries(cmd, no_strict=no_strict)
 
         # Common cleanup and return for both paths
         try:

--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -111,76 +111,67 @@ class S3:
         if not s3_full_path.endswith(file_name) and not with_rename:
             s3_full_path = f"{s3_path}/{Path(local_path).name}"
 
-        # Use boto3 if available, otherwise fall back to AWS CLI
-        if BOTO3_AVAILABLE and cls._get_boto3_client():
-            try:
-                s3_full_path_clean = str(s3_full_path).removeprefix("s3://")
-                bucket, key = s3_full_path_clean.split("/", maxsplit=1)
+        # boto3 is required for S3 uploads. The AWS CLI fallback is deprecated
+        # (and does not support upload-time object tagging), so uploads must go
+        # through boto3 to keep the "all artifacts are retention-tagged"
+        # invariant. TODO: drop the remaining AWS CLI paths in this module.
+        assert (
+            BOTO3_AVAILABLE and cls._get_boto3_client()
+        ), "boto3 is required for S3 uploads (the AWS CLI fallback is deprecated)"
 
-                # Prepare ExtraArgs for upload_file
-                extra_args = {}
+        try:
+            s3_full_path_clean = str(s3_full_path).removeprefix("s3://")
+            bucket, key = s3_full_path_clean.split("/", maxsplit=1)
 
-                inferred_content_type = ""
-                if not content_type and not (text and not content_type):
-                    inferred_content_type, _ = mimetypes.guess_type(key)
+            # Prepare ExtraArgs for upload_file
+            extra_args = {}
 
-                if text and not content_type:
-                    extra_args["ContentType"] = "text/plain; charset=utf-8"
-                elif content_type:
-                    extra_args["ContentType"] = content_type
-                elif inferred_content_type:
-                    extra_args["ContentType"] = inferred_content_type
-                if content_encoding:
-                    extra_args["ContentEncoding"] = content_encoding
-                if tags:
-                    # Attach tags to the upload request itself (URL-encoded
-                    # querystring) instead of a follow-up put_object_tagging
-                    # call, so the object is never left untagged by a tagging
-                    # step that fails after a successful upload.
-                    extra_args["Tagging"] = urlencode(tags)
+            inferred_content_type = ""
+            if not content_type and not (text and not content_type):
+                inferred_content_type, _ = mimetypes.guess_type(key)
 
-                def _upload():
-                    client = cls._get_boto3_client()
-                    if extra_args:
-                        client.upload_file(
-                            str(local_path), bucket, key, ExtraArgs=extra_args
-                        )
-                    else:
-                        client.upload_file(str(local_path), bucket, key)
-
-                # Retry on transient credential failures
-                cls._retry_on_no_credentials(_upload)
-
-            except NoCredentialsError as e:
-                print(
-                    f"ERROR: Failed to upload to S3 using boto3 (no credentials): {e}"
-                )
-                if not no_strict:
-                    raise
-            except ClientError as e:
-                error_code = e.response.get("Error", {}).get("Code", "")
-                print(f"ERROR: Failed to upload to S3 using boto3: {error_code}")
-                if not no_strict:
-                    raise
-            except Exception as e:
-                print(f"ERROR: Failed to upload to S3 using boto3: {e}")
-                if not no_strict:
-                    raise
-        else:
-            # boto3 not available, use AWS CLI
-            cmd = f"aws s3 cp {local_path} s3://{s3_full_path}"
             if text and not content_type:
-                cmd += ' --content-type "text/plain; charset=utf-8"'
+                extra_args["ContentType"] = "text/plain; charset=utf-8"
             elif content_type:
-                cmd += f" --content-type {content_type}"
+                extra_args["ContentType"] = content_type
+            elif inferred_content_type:
+                extra_args["ContentType"] = inferred_content_type
             if content_encoding:
-                cmd += f" --content-encoding {content_encoding}"
+                extra_args["ContentEncoding"] = content_encoding
             if tags:
-                # Apply tags during upload (single request) rather than a
-                # follow-up put-object-tagging that could fail and leave the
-                # object untagged.
-                cmd += f" --tagging '{urlencode(tags)}'"
-            _ = cls.run_command_with_retries(cmd, no_strict=no_strict)
+                # Attach tags to the upload request itself (URL-encoded
+                # querystring) instead of a follow-up put_object_tagging
+                # call, so the object is never left untagged by a tagging
+                # step that fails after a successful upload.
+                extra_args["Tagging"] = urlencode(tags)
+
+            def _upload():
+                client = cls._get_boto3_client()
+                if extra_args:
+                    client.upload_file(
+                        str(local_path), bucket, key, ExtraArgs=extra_args
+                    )
+                else:
+                    client.upload_file(str(local_path), bucket, key)
+
+            # Retry on transient credential failures
+            cls._retry_on_no_credentials(_upload)
+
+        except NoCredentialsError as e:
+            print(
+                f"ERROR: Failed to upload to S3 using boto3 (no credentials): {e}"
+            )
+            if not no_strict:
+                raise
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            print(f"ERROR: Failed to upload to S3 using boto3: {error_code}")
+            if not no_strict:
+                raise
+        except Exception as e:
+            print(f"ERROR: Failed to upload to S3 using boto3: {e}")
+            if not no_strict:
+                raise
 
         # Common cleanup and return for both paths
         try:


### PR DESCRIPTION
Every uploaded S3 artifact is now tagged with a `retention` tag, defaulting
to `retention=default`. Per-artifact tags set in the workflows (e.g.
`retention=long` for the subset in `master.py` / `release_branches.py`)
override the default on the `retention` key.

Motivation: S3 lifecycle rule filters can only match objects positively
(by prefix, tag, or size) — they cannot express "objects *without* a tag".
A purely tag-based retention policy therefore leaves untagged objects
matched by no rule. Tagging every artifact ensures each object is covered
by exactly one retention rule. Note that for this to take effect the bucket
lifecycle rules must be tag-based and disjoint (a `retention=default` rule
and a `retention=long` rule, with no overlapping catch-all rule — on
overlap, S3 always honors the shortest expiration).

### Changelog category (leave one):
- CI Fix or Improvement


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.978` (included in `26.8` and later)
<!-- ch-version-info:end -->