### PR TITLE
Re-add test 04756 for reading a Nested sibling beside a re-added subcolumn

### DIFF
--- a/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.reference
+++ b/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.reference
@@ -1,0 +1,11 @@
+part type	Wide
+both columns in reader header	1
+prefetch limit permits prefetching	1
+missing subcolumn first	199	0	0
+sibling first	199	0	0
+sibling between	199	0	0
+prefetch off	199	0
+many granules	199	0
+wrapped element types	199	0	0
+compact part type	Compact
+compact control	199	0

--- a/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.sql
+++ b/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.sql
@@ -34,7 +34,7 @@ FROM (EXPLAIN header = 1
     SELECT sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1)))
     FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_offsets_wide));
 
-SET local_filesystem_read_prefetch = 1;
+SET local_filesystem_read_prefetch = 1, remote_filesystem_read_prefetch = 1;
 
 -- A nonzero `filesystem_prefetches_limit` below the number of columns read skips prefetching
 -- entirely, which would make every assertion below pass without taking the prefetch path. Read the
@@ -52,7 +52,7 @@ FROM (SELECT id, `arr.id` AS aid, `arr.nested`.b AS nb, `arr.s` AS s FROM t_shar
 
 SELECT 'prefetch off', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1)))
 FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_offsets_wide)
-SETTINGS local_filesystem_read_prefetch = 0;
+SETTINGS local_filesystem_read_prefetch = 0, remote_filesystem_read_prefetch = 0;
 
 -- More than one granule, so group and type resolution must hold for every mark, not only the first.
 CREATE TABLE t_shared_offsets_granules

--- a/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.sql
+++ b/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.sql
@@ -1,0 +1,131 @@
+DROP TABLE IF EXISTS t_shared_offsets_wide;
+DROP TABLE IF EXISTS t_shared_offsets_granules;
+DROP TABLE IF EXISTS t_shared_offsets_wrapped;
+DROP TABLE IF EXISTS t_shared_offsets_compact;
+
+-- A prefetch positions a stream for the column that issued it. Under `share_nested_offsets` several
+-- Nested siblings name one offsets stream, so every other column reading it must still seek.
+CREATE TABLE t_shared_offsets_wide
+(
+    `id` UInt64,
+    `arr.id` Array(UInt64),
+    `arr.s` Array(String),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS share_nested_offsets = 1, min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_shared_offsets_wide SELECT
+    number,
+    arrayMap(x -> x + 10, range(number % 3 + 1)),
+    arrayMap(x -> concat('s', toString(x)), range(number % 3 + 1)),
+    arrayMap(x -> (toString(x), x * 1.5), range(number % 3 + 1))
+FROM numbers(100);
+
+ALTER TABLE t_shared_offsets_wide DROP COLUMN `arr.nested`;
+ALTER TABLE t_shared_offsets_wide ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
+
+SELECT 'part type', any(part_type) FROM system.parts WHERE database = currentDatabase() AND table = 't_shared_offsets_wide' AND active;
+
+-- The reader must be asked for both columns, otherwise `query_plan_remove_unused_columns` prunes the
+-- subcolumn and the shared stream is read by a single column.
+SELECT 'both columns in reader header', countIf(explain LIKE '%arr.nested.b%') > 0 AND countIf(explain LIKE '%arr.id%') > 0
+FROM (EXPLAIN header = 1
+    SELECT sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1)))
+    FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_offsets_wide));
+
+SET local_filesystem_read_prefetch = 1;
+
+-- A nonzero `filesystem_prefetches_limit` below the number of columns read skips prefetching
+-- entirely, which would make every assertion below pass without taking the prefetch path. Read the
+-- effective value rather than pinning it, so such a limit fails this test instead of silencing it.
+-- No query below reads more than 8 columns; 0 means unlimited.
+SELECT 'prefetch limit permits prefetching', getSetting('filesystem_prefetches_limit') = 0 OR getSetting('filesystem_prefetches_limit') > 8;
+
+SELECT 'missing subcolumn first', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1))), countIf(s != arrayMap(x -> concat('s', toString(x)), range(id % 3 + 1)))
+FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid, `arr.s` AS s FROM t_shared_offsets_wide);
+
+SELECT 'sibling first', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1))), countIf(s != arrayMap(x -> concat('s', toString(x)), range(id % 3 + 1)))
+FROM (SELECT id, `arr.id` AS aid, `arr.s` AS s, `arr.nested`.b AS nb FROM t_shared_offsets_wide);
+
+SELECT 'sibling between', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1))), countIf(s != arrayMap(x -> concat('s', toString(x)), range(id % 3 + 1)))
+FROM (SELECT id, `arr.id` AS aid, `arr.nested`.b AS nb, `arr.s` AS s FROM t_shared_offsets_wide);
+
+SELECT 'prefetch off', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1)))
+FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_offsets_wide)
+SETTINGS local_filesystem_read_prefetch = 0;
+
+-- More than one granule, so the seek must be right for every mark, not only the first.
+CREATE TABLE t_shared_offsets_granules
+(
+    `id` UInt64,
+    `arr.id` Array(UInt64),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS share_nested_offsets = 1, min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 8;
+
+INSERT INTO t_shared_offsets_granules SELECT
+    number,
+    arrayMap(x -> x + 10, range(number % 3 + 1)),
+    arrayMap(x -> (toString(x), x * 1.5), range(number % 3 + 1))
+FROM numbers(100);
+
+ALTER TABLE t_shared_offsets_granules DROP COLUMN `arr.nested`;
+ALTER TABLE t_shared_offsets_granules ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
+
+SELECT 'many granules', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1)))
+FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_offsets_granules);
+
+-- Wrapped element types resolve to the same shared offsets stream.
+CREATE TABLE t_shared_offsets_wrapped
+(
+    `id` UInt64,
+    `arr.n` Array(Nullable(UInt64)),
+    `arr.lc` Array(LowCardinality(String)),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS share_nested_offsets = 1, min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_shared_offsets_wrapped SELECT
+    number,
+    arrayMap(x -> if(x % 2 = 0, NULL, x + 10), range(number % 3 + 1)),
+    arrayMap(x -> concat('l', toString(x)), range(number % 3 + 1)),
+    arrayMap(x -> (toString(x), x * 1.5), range(number % 3 + 1))
+FROM numbers(100);
+
+ALTER TABLE t_shared_offsets_wrapped DROP COLUMN `arr.nested`;
+ALTER TABLE t_shared_offsets_wrapped ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
+
+SELECT 'wrapped element types', sum(length(nb)), countIf(n != arrayMap(x -> if(x % 2 = 0, NULL, x + 10), range(id % 3 + 1))), countIf(lc != arrayMap(x -> concat('l', toString(x)), range(id % 3 + 1)))
+FROM (SELECT id, `arr.nested`.b AS nb, `arr.n` AS n, `arr.lc` AS lc FROM t_shared_offsets_wrapped);
+
+-- Compact parts keep per-column offsets and were never affected; a control against overfitting.
+CREATE TABLE t_shared_offsets_compact
+(
+    `id` UInt64,
+    `arr.id` Array(UInt64),
+    `arr.nested` Array(Tuple(a String, b Float64))
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS share_nested_offsets = 1, min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000;
+
+INSERT INTO t_shared_offsets_compact SELECT
+    number,
+    arrayMap(x -> x + 10, range(number % 3 + 1)),
+    arrayMap(x -> (toString(x), x * 1.5), range(number % 3 + 1))
+FROM numbers(100);
+
+ALTER TABLE t_shared_offsets_compact DROP COLUMN `arr.nested`;
+ALTER TABLE t_shared_offsets_compact ADD COLUMN `arr.nested` Array(Tuple(a String, b Float64));
+
+SELECT 'compact part type', any(part_type) FROM system.parts WHERE database = currentDatabase() AND table = 't_shared_offsets_compact' AND active;
+
+SELECT 'compact control', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1)))
+FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_offsets_compact);
+
+DROP TABLE t_shared_offsets_wide;
+DROP TABLE t_shared_offsets_granules;
+DROP TABLE t_shared_offsets_wrapped;
+DROP TABLE t_shared_offsets_compact;

--- a/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.sql
+++ b/tests/queries/0_stateless/04756_nested_sibling_shared_offsets_prefetch.sql
@@ -3,8 +3,8 @@ DROP TABLE IF EXISTS t_shared_offsets_granules;
 DROP TABLE IF EXISTS t_shared_offsets_wrapped;
 DROP TABLE IF EXISTS t_shared_offsets_compact;
 
--- A prefetch positions a stream for the column that issued it. Under `share_nested_offsets` several
--- Nested siblings name one offsets stream, so every other column reading it must still seek.
+-- Under `share_nested_offsets` a re-added Nested member and its siblings share one offsets stream,
+-- so its group and element types must be rebuilt from metadata or the siblings read wrong values.
 CREATE TABLE t_shared_offsets_wide
 (
     `id` UInt64,
@@ -39,7 +39,6 @@ SET local_filesystem_read_prefetch = 1;
 -- A nonzero `filesystem_prefetches_limit` below the number of columns read skips prefetching
 -- entirely, which would make every assertion below pass without taking the prefetch path. Read the
 -- effective value rather than pinning it, so such a limit fails this test instead of silencing it.
--- No query below reads more than 8 columns; 0 means unlimited.
 SELECT 'prefetch limit permits prefetching', getSetting('filesystem_prefetches_limit') = 0 OR getSetting('filesystem_prefetches_limit') > 8;
 
 SELECT 'missing subcolumn first', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, range(id % 3 + 1))), countIf(s != arrayMap(x -> concat('s', toString(x)), range(id % 3 + 1)))
@@ -55,7 +54,7 @@ SELECT 'prefetch off', sum(length(nb)), countIf(aid != arrayMap(x -> x + 10, ran
 FROM (SELECT id, `arr.nested`.b AS nb, `arr.id` AS aid FROM t_shared_offsets_wide)
 SETTINGS local_filesystem_read_prefetch = 0;
 
--- More than one granule, so the seek must be right for every mark, not only the first.
+-- More than one granule, so group and type resolution must hold for every mark, not only the first.
 CREATE TABLE t_shared_offsets_granules
 (
     `id` UInt64,


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112997
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/112997
Related: https://github.com/ClickHouse/ClickHouse/pull/113225
Related: https://github.com/ClickHouse/ClickHouse/pull/113461


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Tests only. #113461 reverted #112997 together with its test; the shapes that test covers are fixed by #113225, so it is re-added on its own to pin that fix, as asked in #112997.

It is a live witness, not a control. Reverting #113225's `getSubcolumnsOfNested` and type-computation repairs makes three of the eleven assertions report mismatching rows where 0 is correct:

| assertion | correct | with #113225 reverted |
|---|---|---|
| `missing subcolumn first` | 199 0 0 | 199 **100 100** |
| `many granules` | 199 0 | 199 **100** |
| `wrapped element types` | 199 0 0 | 199 **66 100** |

Deterministic, three rounds. The remaining eight assertions (part type, reader header, prefetch limit, the two sibling-ordering cases, prefetch off, and the Compact-part pair) hold on both arms and are kept as controls; none was weakened to make the test pass.

The `no-random-merge-tree-settings` tag the pre-revert file carried is dropped rather than restored. The test already pins `index_granularity`, `min_bytes_for_wide_part` and `min_rows_for_wide_part` in its `CREATE TABLE ... SETTINGS` clause, which takes precedence over runner injection, and `share_nested_offsets` is not randomized at all. Measured 250 randomized runs green without it (200 at `--jobs 8`, 50 at `--jobs 1`), plus 50 more with `default_compression_codec` forced to `ZSTD`, since that tag also pinned the codec to LZ4. Keeping randomization on is preferable to a blanket opt-out.

The test asserts content, not `length`, which the defect preserves, and asserts via `EXPLAIN header = 1` that both columns reach the reader, since `query_plan_remove_unused_columns` would otherwise prune the subcolumn and the shapes would stop exercising the bug.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.963` (included in `26.8` and later)
<!-- ch-version-info:end -->