### PR TITLE
CI: temporarily skip docs team review requests

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/team_notifications.py
+++ b/ci/jobs/scripts/workflow_hooks/team_notifications.py
@@ -16,6 +16,10 @@ DOCS_TEAM = "docs"
 CLICKPIPES_TEAM = "clickpipes"
 INTEGRATIONS_ECOSYSTEM_TEAM = "integrations-ecosystem"
 
+# GitHub requires review teams to have repository access. Enable this after
+# `docs`, `clickpipes`, and `integrations-ecosystem` receive it.
+ENABLE_DOCS_TEAM_REVIEW_REQUESTS = False
+
 
 def normalize_path(file):
     return file.removeprefix(".").removeprefix("/")
@@ -51,7 +55,7 @@ def check():
         "most likely failed to fetch the PR file list from the GitHub API. "
         "See the Config Workflow logs for the underlying error."
     )
-    if info.event_action == "opened":
+    if ENABLE_DOCS_TEAM_REVIEW_REQUESTS and info.event_action == "opened":
         GH.request_team_reviews(get_docs_teams_to_request(changed_files))
 
     if any(

--- a/ci/tests/test_team_notifications.py
+++ b/ci/tests/test_team_notifications.py
@@ -48,7 +48,28 @@ def test_get_docs_teams_to_request(changed_files, expected_teams):
     assert team_notifications.get_docs_teams_to_request(changed_files) == expected_teams
 
 
-def test_check_requests_docs_teams(monkeypatch):
+def test_check_skips_docs_teams_without_repository_access(monkeypatch):
+    class FakeInfo:
+        event_action = "opened"
+
+        def get_kv_data(self, key):
+            assert key == "changed_files"
+            return [
+                "docs/integrations/clickpipes/home.mdx",
+                "docs/integrations/language-clients/python/index.mdx",
+            ]
+
+    monkeypatch.setattr(team_notifications, "Info", FakeInfo)
+    monkeypatch.setattr(
+        team_notifications.GH,
+        "request_team_reviews",
+        staticmethod(lambda *_args: pytest.fail("unexpected review request")),
+    )
+
+    assert team_notifications.check()
+
+
+def test_check_requests_docs_teams_when_enabled(monkeypatch):
     class FakeInfo:
         event_action = "opened"
 
@@ -65,6 +86,9 @@ def test_check_requests_docs_teams(monkeypatch):
         requested.extend(team_slugs)
 
     monkeypatch.setattr(team_notifications, "Info", FakeInfo)
+    monkeypatch.setattr(
+        team_notifications, "ENABLE_DOCS_TEAM_REVIEW_REQUESTS", True
+    )
     monkeypatch.setattr(
         team_notifications.GH, "request_team_reviews", staticmethod(fake_request)
     )


### PR DESCRIPTION
Temporarily disable automatic documentation-team review requests while the `docs`, `clickpipes`, and `integrations-ecosystem` teams do not have repository access - requested and waiting for a response. GitHub currently rejects the request with HTTP 422, which fails Config Workflow and drops downstream jobs. The routing logic remains behind a one-line flag and its enabled path stays covered by tests.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113773&sha=64a708987639087cbae0b8bf6f89c524fc4a58ed&name_0=PR&name_1=Config%20Workflow

Related: https://github.com/ClickHouse/ClickHouse/pull/113773

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Temporarily skip automatic documentation-team review requests until the teams receive repository access.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.945` (included in `26.8` and later)
<!-- ch-version-info:end -->