### PR TITLE
Retry the SQLStorm repo clones so one transient timeout cannot abort the check

### DIFF
--- a/ci/jobs/sqlstorm_test.py
+++ b/ci/jobs/sqlstorm_test.py
@@ -389,6 +389,7 @@ def main():
                 if not Shell.check(
                     f"git clone https://github.com/ClickHouse/SQLStorm.git {sqlstorm_repo}",
                     verbose=True,
+                    retries=3,
                 ):
                     return False
             else:
@@ -420,6 +421,7 @@ def main():
                 if not Shell.check(
                     f"git clone https://github.com/SQL-Storm/OLAPBench.git {olapbench_repo}",
                     verbose=True,
+                    retries=3,
                 ):
                     return False
             else:

--- a/ci/jobs/sqlstorm_test.py
+++ b/ci/jobs/sqlstorm_test.py
@@ -396,6 +396,7 @@ def main():
                 if not Shell.check(
                     f"git -C {sqlstorm_repo} fetch origin",
                     verbose=True,
+                    retries=3,
                 ):
                     return False
             return Shell.check(
@@ -428,6 +429,7 @@ def main():
                 if not Shell.check(
                     f"git -C {olapbench_repo} fetch origin",
                     verbose=True,
+                    retries=3,
                 ):
                     return False
             return Shell.check(


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`SQLStorm test` failed on step `Clone OLAPBench repo` after a single attempt:

```
fatal: unable to access 'https://github.com/SQL-Storm/OLAPBench.git/': Failed to connect to
  github.com port 443 after 135221 ms: Connection timed out
ERROR: command failed after 1/1 attempt(s), exit code: 128
```

`Shell.check` forwards `retries` to `Shell.run` and both default to `retries=1`
(`ci/praktika/utils.py:231`, `:323`), and neither clone in `ci/jobs/sqlstorm_test.py` opted
in. Because every later step is gated on `results[-1].is_ok()`, one transient egress timeout
to a third-party host aborted a check whose budget is 3 hours.

This passes `retries=3` to both `git clone` calls, matching the existing git-clone retry at
`ci/jobs/docker_server.py:439-444`. The sibling SQLStorm clone has identical exposure, so both
are fixed.

Measured, driving the real closures with the upstream command strings and a git shim that
reproduces the observed failure (rc=128, and git removes its own partial target, so a retry
starts clean):

| attempts that fail | before | after |
|---|---|---|
| 1 (the observed failure) | fails, `1/1` | succeeds on attempt 2 |
| 2 | fails, `1/1` | succeeds on attempt 3 |
| all | fails, `1/1` | fails, `3/3` |

A genuine outage still fails the check, with the full stderr, and each argument is
independently load-bearing. Worst case on a permanent outage is about 6.8 min, 3.8% of the
10,800 s job budget; a fast permanent error costs 6.0 s.

The `fetch` branches, taken when the repo directory already exists, now carry the same
`retries=3` and measure the same way. That branch is unreachable in CI, since every job block
scheduling this check runs an unconditional `rm -rf ./ci/tmp` before the run step, but it is
reachable on a local rerun, where no workflow step runs and praktika never removes its temp
dir. Both `git checkout` calls are local only.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1505` (included in `26.8` and later)
<!-- ch-version-info:end -->