### PR TITLE
Do not rewrite a plan that already carries a coordinated read

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/applyParallelReplicas.cpp
+++ b/src/Processors/QueryPlan/Optimizations/applyParallelReplicas.cpp
@@ -432,9 +432,9 @@ static bool planHasSubquerySet(const QueryPlan::Node * node)
     return false;
 }
 
-/// A read is in parallel-reading mode only after a coordinator has been created for it, so its presence
-/// means the phases below have already run on this plan. They are not idempotent, and a plan can be
-/// optimized more than once (StorageMerge child plans, set subplans).
+/// A read is in parallel-reading mode only after a coordinator has been created for it, so its presence means the
+/// phases below have already run on this plan. They are not idempotent, and a plan can be optimized more than
+/// once (StorageMerge child plans). optimizeTree.cpp guards its own transforms with planContainsLogicalExchange.
 static bool planHasCoordinatedRead(const QueryPlan::Node * node)
 {
     if (!node)

--- a/src/Processors/QueryPlan/Optimizations/applyParallelReplicas.cpp
+++ b/src/Processors/QueryPlan/Optimizations/applyParallelReplicas.cpp
@@ -434,7 +434,7 @@ static bool planHasSubquerySet(const QueryPlan::Node * node)
 
 /// A read is in parallel-reading mode only after a coordinator has been created for it, so its presence means the
 /// phases below have already run on this plan. They are not idempotent, and a plan can be optimized more than
-/// once (StorageMerge child plans). optimizeTree.cpp guards its own transforms with planContainsLogicalExchange.
+/// once (`StorageMerge` child plans). optimizeTree.cpp guards its own transforms with `planContainsLogicalExchange`.
 static bool planHasCoordinatedRead(const QueryPlan::Node * node)
 {
     if (!node)

--- a/src/Processors/QueryPlan/Optimizations/applyParallelReplicas.cpp
+++ b/src/Processors/QueryPlan/Optimizations/applyParallelReplicas.cpp
@@ -432,6 +432,22 @@ static bool planHasSubquerySet(const QueryPlan::Node * node)
     return false;
 }
 
+/// A read is in parallel-reading mode only after a coordinator has been created for it, so its presence
+/// means the phases below have already run on this plan. They are not idempotent, and a plan can be
+/// optimized more than once (StorageMerge child plans, set subplans).
+static bool planHasCoordinatedRead(const QueryPlan::Node * node)
+{
+    if (!node)
+        return false;
+    if (const auto * read = typeid_cast<const ReadFromMergeTree *>(node->step.get());
+        read && read->isParallelReadingFromReplicas())
+        return true;
+    for (const auto * child : node->children)
+        if (planHasCoordinatedRead(child))
+            return true;
+    return false;
+}
+
 /// Insertion phase: put a ParallelReplicasSplitStep directly above every eligible MergeTree read.
 /// Raising the markers up the plan (through expressions, aggregation and unions) and rewriting them
 /// into a distributed read is done by the phases below. The planner now builds only a plain local plan.
@@ -492,6 +508,9 @@ void applyParallelReplicas(QueryPlan & query_plan, QueryPlan::Nodes & nodes, con
 void applyParallelReplicas(QueryPlan & query_plan, QueryPlan::Nodes & nodes, const QueryPlanOptimizationSettings & settings)
 {
     if (!settings.enable_parallel_replicas)
+        return;
+
+    if (planHasCoordinatedRead(query_plan.getRootNode()))
         return;
 
     insertParallelReplicasSplit(query_plan, nodes);

--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -1564,12 +1564,7 @@ bool readingFromParallelReplicas(const QueryPlan::Node * node)
 
     if (typeid_cast<const ReadFromParallelRemoteReplicasStep *>(step))
         return true;
-    /// The plan-based path reaches this leaf as either the shipped fragment or, once it has been inlined, the local
-    /// read in parallel-reading mode. Both mean a coordinator exists, so ordering only this side would leave the two
-    /// sides in different coordination modes.
     if (typeid_cast<const ReadFromParallelReplicasStep *>(step))
-        return true;
-    if (const auto * read = typeid_cast<const ReadFromMergeTree *>(step); read && read->isParallelReadingFromReplicas())
         return true;
     return false;
 }

--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -21,6 +21,7 @@
 #include <Processors/QueryPlan/Optimizations/optimizeReadInOrder.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Processors/QueryPlan/ReadFromObjectStorageStep.h>
+#include <Processors/QueryPlan/ReadFromParallelReplicas.h>
 #include <Processors/QueryPlan/ReadFromRemote.h>
 #include <Processors/QueryPlan/SortingStep.h>
 #include <Processors/QueryPlan/UnionStep.h>
@@ -1561,7 +1562,16 @@ bool readingFromParallelReplicas(const QueryPlan::Node * node)
         node = node->children.front();
     }
 
-    return typeid_cast<const ReadFromParallelRemoteReplicasStep *>(step);
+    if (typeid_cast<const ReadFromParallelRemoteReplicasStep *>(step))
+        return true;
+    /// The plan-based path reaches this leaf as either the shipped fragment or, once it has been inlined, the local
+    /// read in parallel-reading mode. Both mean a coordinator exists, so ordering only this side would leave the two
+    /// sides in different coordination modes.
+    if (typeid_cast<const ReadFromParallelReplicasStep *>(step))
+        return true;
+    if (const auto * read = typeid_cast<const ReadFromMergeTree *>(step); read && read->isParallelReadingFromReplicas())
+        return true;
+    return false;
 }
 
 }

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -48,6 +48,7 @@
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
+#include <Processors/QueryPlan/ReadFromParallelReplicas.h>
 #include <Processors/Sources/NullSource.h>
 #include <Processors/Transforms/FilterTransform.h>
 #include <Processors/Transforms/MaterializingTransform.h>
@@ -1258,6 +1259,24 @@ SelectQueryInfo ReadFromMerge::getModifiedQueryInfo(const ContextMutablePtr & mo
     return modified_query_info;
 }
 
+/// A coordinated read has already been split into a local read plus a shipped remote fragment. The fragment is a
+/// separate plan this walk cannot reach, so reordering only the local side would leave the two in different
+/// coordination modes.
+static bool planHasCoordinatedRead(const QueryPlan::Node * node)
+{
+    if (!node)
+        return false;
+    if (typeid_cast<const ReadFromParallelReplicasStep *>(node->step.get()))
+        return true;
+    if (const auto * read = typeid_cast<const ReadFromMergeTree *>(node->step.get());
+        read && read->isParallelReadingFromReplicas())
+        return true;
+    for (const auto * child : node->children)
+        if (planHasCoordinatedRead(child))
+            return true;
+    return false;
+}
+
 static bool recursivelyApplyToReadingSteps(QueryPlan::Node * node, const std::function<bool(ReadFromMergeTree &)> & func)
 {
     bool ok = true;
@@ -1805,6 +1824,11 @@ bool ReadFromMerge::requestReadingInOrder(InputOrderInfoPtr order_info_, size_t 
     /// Otherwise, it can lead to incorrect final behavior because the implementation may rely on the reading in direct order).
     if (order_info_->direction != 1 && InterpreterSelectQuery::isQueryWithFinal(query_info))
         return false;
+
+    /// The shipped fragment of a coordinated child read cannot be reordered, so decline.
+    for (const auto & child_plan : *child_plans)
+        if (child_plan.plan.isInitialized() && planHasCoordinatedRead(child_plan.plan.getRootNode()))
+            return false;
 
     auto request_read_in_order = [order_info_, query_limit](ReadFromMergeTree & read_from_merge_tree)
     {

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -1259,9 +1259,9 @@ SelectQueryInfo ReadFromMerge::getModifiedQueryInfo(const ContextMutablePtr & mo
     return modified_query_info;
 }
 
-/// A coordinated read has already been split into a local read plus a shipped remote fragment. The fragment is a
-/// separate plan this walk cannot reach, so reordering only the local side would leave the two in different
-/// coordination modes.
+/// A coordinated child read is either a local read plus a shipped fragment, or, with no local plan, the fragment
+/// alone. Neither can be reordered: the fragment is a separate plan this walk cannot reach, so ordering only what it
+/// can reach leaves the two sides in different coordination modes.
 static bool planHasCoordinatedRead(const QueryPlan::Node * node)
 {
     if (!node)

--- a/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.reference
+++ b/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.reference
@@ -1,0 +1,26 @@
+merge one table
+4999950000
+merge two tables
+5000449500
+merge with filter
+4999949985
+merge joined
+499485
+merge joined reversed
+499485
+merge with forced index
+13600
+merge index analysis
+1	1	1
+merge forced index not used
+base table
+4999950000
+1
+view
+4999950000
+merge without plan based
+4999950000
+merge without local plan
+4999950000
+merge without parallel replicas
+4999950000

--- a/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.reference
+++ b/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.reference
@@ -10,6 +10,14 @@ merge joined reversed
 499485
 merge with forced index
 13600
+merge ordered
+0
+1
+2
+merge ordered no read in order
+0
+1
+2
 merge index analysis
 1	1	1
 merge plan shape

--- a/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.reference
+++ b/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.reference
@@ -14,6 +14,8 @@ merge ordered
 0
 1
 2
+merge ordered view
+1249975000
 merge ordered no read in order
 0
 1

--- a/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.reference
+++ b/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.reference
@@ -32,5 +32,7 @@ merge without plan based
 4999950000
 merge without local plan
 4999950000
+merge ordered without local plan
+0
 merge without parallel replicas
 4999950000

--- a/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.reference
+++ b/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.reference
@@ -16,6 +16,9 @@ merge ordered
 2
 merge ordered view
 1249975000
+merge ordered view plan shape
+1
+0
 merge ordered no read in order
 0
 1

--- a/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.reference
+++ b/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.reference
@@ -12,6 +12,8 @@ merge with forced index
 13600
 merge index analysis
 1	1	1
+merge plan shape
+1	1
 merge forced index not used
 base table
 4999950000

--- a/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.sql
+++ b/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.sql
@@ -1,0 +1,120 @@
+-- Tags: no-parallel-replicas
+-- A query plan can be optimized more than once, and `ReadFromMerge` does exactly that for its child
+-- plans. The parallel replicas rewrite was not idempotent: after the first run the inlined local plan
+-- already carries a coordinated read, and a second run distributed it again, so the query got two
+-- coordinators for one read. Only the first ever registered a stream, and a follower announcing to
+-- the second was rejected and then aborted the initiator with
+-- `LOGICAL_ERROR: Got read request from replica N for unknown stream <table>`.
+-- The witnesses below therefore killed the server before the fix.
+-- The controls read the same data by paths that never had the duplicate, so they pass with and
+-- without the fix on purpose: they fail only if the guard skips the rewrite too broadly and costs a
+-- first-time plan its distribution or its index analysis.
+-- See issue #110518.
+
+DROP TABLE IF EXISTS t_pr_ro;
+DROP TABLE IF EXISTS t2_pr_ro;
+DROP VIEW IF EXISTS v_pr_ro;
+
+CREATE TABLE t_pr_ro (timestamp DateTime, value UInt32)
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(timestamp)
+ORDER BY timestamp;
+
+CREATE TABLE t2_pr_ro (timestamp DateTime, value UInt32)
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(timestamp)
+ORDER BY timestamp;
+
+CREATE VIEW v_pr_ro AS SELECT * FROM t_pr_ro;
+
+INSERT INTO t_pr_ro
+SELECT toDateTime('2026-06-01 00:00:00') + number, number FROM numbers(100000);
+
+INSERT INTO t2_pr_ro
+SELECT toDateTime('2026-06-01 00:00:00') + number, number FROM numbers(1000);
+
+SET enable_analyzer = 1, enable_parallel_replicas = 1, automatic_parallel_replicas_mode = 0,
+    max_parallel_replicas = 3, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_min_number_of_rows_per_replica = 0,
+    parallel_replicas_plan_based = 1, parallel_replicas_local_plan = 1;
+
+-- Witness: one merged table. Aborted the server before the fix.
+SELECT 'merge one table';
+SELECT sum(value) FROM merge(currentDatabase(), '^t_pr_ro$');
+
+-- Witness: two merged tables. The duplicate was created once per merged table, so a fix that only
+-- handled a single branch would still abort here.
+SELECT 'merge two tables';
+SELECT sum(value) FROM merge(currentDatabase(), '^(t_pr_ro|t2_pr_ro)$');
+
+-- Witness: a filter pushed into the child read.
+SELECT 'merge with filter';
+SELECT sum(value) FROM merge(currentDatabase(), '^t_pr_ro$') WHERE value > 5;
+
+-- Witness: a JOIN over the merged table. This one reaches `ReadFromMerge::addFilter`, which optimizes
+-- the child plan from a second call site, so it pins that the guard covers the transform rather than
+-- one caller of it.
+SELECT 'merge joined';
+SELECT sum(a.value) FROM merge(currentDatabase(), '^t_pr_ro$') a
+JOIN t2_pr_ro b ON a.value = b.value
+WHERE a.value > 5;
+
+-- Witness: the same JOIN with the merged table on the right.
+SELECT 'merge joined reversed';
+SELECT sum(a.value) FROM t2_pr_ro b
+JOIN merge(currentDatabase(), '^t_pr_ro$') a ON a.value = b.value
+WHERE a.value > 5;
+
+-- Witness: the child read's index analysis must survive the guard. `force_index_by_date` and
+-- `force_primary_key` throw if the partition and primary key are not used, so a lost analysis fails
+-- this arm.
+SELECT 'merge with forced index';
+SELECT count() FROM merge(currentDatabase(), '^t_pr_ro$')
+WHERE timestamp >= toDateTime('2026-06-02 00:00:00')
+SETTINGS force_index_by_date = 1, force_primary_key = 1;
+
+-- Witness: index analysis is reported for the child read, independent of granule counts.
+SELECT 'merge index analysis';
+SELECT countIf(explain LIKE '%Min-Max%') > 0, countIf(explain LIKE '%Partition%') > 0,
+       countIf(explain LIKE '%PrimaryKey%') > 0
+FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM merge(currentDatabase(), '^t_pr_ro$')
+      WHERE timestamp >= toDateTime('2026-06-02 00:00:00'));
+
+-- Negative: a predicate that uses neither key must still be rejected, so the arm above passes because
+-- the index is used and not because forcing it became a no-op.
+SELECT 'merge forced index not used';
+SELECT count() FROM merge(currentDatabase(), '^t_pr_ro$')
+WHERE value = 1
+SETTINGS force_primary_key = 1; -- { serverError INDEX_NOT_USED }
+
+-- Control: reading the table directly is a first-time plan, so the guard must not skip its
+-- distribution. Results alone cannot show that, because parallel replicas is an optimization and a
+-- skipped one still returns the right answer, so assert the distributed read is in the plan.
+SELECT 'base table';
+SELECT sum(value) FROM t_pr_ro;
+SELECT countIf(explain LIKE '%ReadFromParallelReplicas%') > 0
+FROM (EXPLAIN SELECT sum(value) FROM t_pr_ro);
+
+-- Control: reading through a plain view never had a duplicate either.
+SELECT 'view';
+SELECT sum(value) FROM v_pr_ro;
+
+-- Control: the classic (not plan-based) parallel replicas path, which the guard never reaches.
+SELECT 'merge without plan based';
+SELECT sum(value) FROM merge(currentDatabase(), '^t_pr_ro$')
+SETTINGS parallel_replicas_plan_based = 0;
+
+-- Control: without a local plan there is no inlined coordinated read for a second pass to
+-- redistribute.
+SELECT 'merge without local plan';
+SELECT sum(value) FROM merge(currentDatabase(), '^t_pr_ro$')
+SETTINGS parallel_replicas_local_plan = 0;
+
+-- Control: no parallel replicas at all.
+SELECT 'merge without parallel replicas';
+SELECT sum(value) FROM merge(currentDatabase(), '^t_pr_ro$')
+SETTINGS enable_parallel_replicas = 0;
+
+DROP VIEW v_pr_ro;
+DROP TABLE t2_pr_ro;
+DROP TABLE t_pr_ro;

--- a/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.sql
+++ b/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.sql
@@ -11,6 +11,7 @@
 DROP TABLE IF EXISTS t_pr_ro;
 DROP TABLE IF EXISTS t2_pr_ro;
 DROP VIEW IF EXISTS v_pr_ro;
+DROP VIEW IF EXISTS v_ordered_pr_ro;
 
 CREATE TABLE t_pr_ro (timestamp DateTime, value UInt32)
 ENGINE = MergeTree
@@ -23,6 +24,8 @@ PARTITION BY toYYYYMMDD(timestamp)
 ORDER BY timestamp;
 
 CREATE VIEW v_pr_ro AS SELECT * FROM t_pr_ro;
+
+CREATE VIEW v_ordered_pr_ro AS SELECT * FROM t_pr_ro ORDER BY timestamp LIMIT 50000;
 
 INSERT INTO t_pr_ro
 SELECT toDateTime('2026-06-01 00:00:00') + number, number FROM numbers(100000);
@@ -79,6 +82,13 @@ SELECT 'merge ordered';
 SELECT value FROM merge(currentDatabase(), '^t_pr_ro$') ORDER BY timestamp LIMIT 3
 SETTINGS optimize_read_in_order = 1;
 
+-- Witness: the sort arrives from inside the view, so it sits within the child plan rather than above
+-- `ReadFromMerge`. Ordering is then decided by the union branch of read-in-order, not by
+-- `ReadFromMerge::requestReadingInOrder`, so this pins the decline on that second entry point.
+SELECT 'merge ordered view';
+SELECT sum(value) FROM merge(currentDatabase(), '^v_ordered_pr_ro$')
+SETTINGS optimize_read_in_order = 1;
+
 -- Control: the same ordered read with read-in-order off, the configuration that already worked.
 SELECT 'merge ordered no read in order';
 SELECT value FROM merge(currentDatabase(), '^t_pr_ro$') ORDER BY timestamp LIMIT 3
@@ -95,7 +105,7 @@ FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM merge(currentDatabase(), '^t_pr
 
 -- Witness: the merged child read must STILL be distributed after the guard. A result alone cannot
 -- show that, since parallel replicas is an optimization and a skipped one returns the same number,
--- so assert the plan shape for the merge() child directly. The guard must fire only on the second
+-- so assert the plan shape for the `merge` child directly. The guard must fire only on the second
 -- rewrite of this plan, never on the first.
 SELECT 'merge plan shape';
 SELECT countIf(explain LIKE '%ReadFromParallelReplicas%') > 0,
@@ -147,6 +157,7 @@ SELECT 'merge without parallel replicas';
 SELECT sum(value) FROM merge(currentDatabase(), '^t_pr_ro$')
 SETTINGS enable_parallel_replicas = 0;
 
+DROP VIEW v_ordered_pr_ro;
 DROP VIEW v_pr_ro;
 DROP TABLE t2_pr_ro;
 DROP TABLE t_pr_ro;

--- a/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.sql
+++ b/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.sql
@@ -69,6 +69,20 @@ SELECT count() FROM merge(currentDatabase(), '^t_pr_ro$')
 WHERE timestamp >= toDateTime('2026-06-02 00:00:00')
 SETTINGS force_index_by_date = 1, force_primary_key = 1;
 
+-- Witness: an ordered read through the merged table. Read-in-order runs after the rewrite has already
+-- shipped the fragment, and it can only reach the local read, so ordering a coordinated child would
+-- leave the two sides in different coordination modes and abort with the same unknown-stream error.
+-- `optimize_read_in_order` is randomized by the test runner and is what enables the optimization,
+-- so pin it here or this arm passes for the wrong reason.
+SELECT 'merge ordered';
+SELECT value FROM merge(currentDatabase(), '^t_pr_ro$') ORDER BY timestamp LIMIT 3
+SETTINGS optimize_read_in_order = 1;
+
+-- Control: the same ordered read with read-in-order off, the configuration that already worked.
+SELECT 'merge ordered no read in order';
+SELECT value FROM merge(currentDatabase(), '^t_pr_ro$') ORDER BY timestamp LIMIT 3
+SETTINGS optimize_read_in_order = 0;
+
 -- Control: index analysis is reported for the child read, independent of granule counts. It runs
 -- through EXPLAIN, which never builds a pipeline, so it is unaffected by the duplicate and passes
 -- either way.

--- a/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.sql
+++ b/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.sql
@@ -1,15 +1,11 @@
 -- Tags: no-parallel-replicas
 -- A query plan can be optimized more than once, and `ReadFromMerge` does exactly that for its child
--- plans. The parallel replicas rewrite was not idempotent: after the first run the inlined local plan
--- already carries a coordinated read, and a second run distributed it again, so the query got two
--- coordinators for one read. Only the first ever registered a stream, and a follower announcing to
--- the second was rejected and then aborted the initiator with
--- `LOGICAL_ERROR: Got read request from replica N for unknown stream <table>`.
--- The witnesses below therefore killed the server before the fix.
--- The controls read the same data by paths that never had the duplicate, so they pass with and
--- without the fix on purpose: they fail only if the guard skips the rewrite too broadly and costs a
--- first-time plan its distribution or its index analysis.
--- See issue #110518.
+-- plans. The parallel replicas rewrite was not idempotent, so a second run distributed an already
+-- coordinated read again: the query got two coordinators for one read, which aborted the server.
+-- The witnesses below therefore killed the server before the fix, except the plan-shape one, which
+-- asserts instead that the merged child read is still distributed after the guard.
+-- The controls read the same data by paths that never had the duplicate, so they pass either way and
+-- fail only if the guard skips the rewrite too broadly. See issue #110518.
 
 DROP TABLE IF EXISTS t_pr_ro;
 DROP TABLE IF EXISTS t2_pr_ro;
@@ -73,12 +69,23 @@ SELECT count() FROM merge(currentDatabase(), '^t_pr_ro$')
 WHERE timestamp >= toDateTime('2026-06-02 00:00:00')
 SETTINGS force_index_by_date = 1, force_primary_key = 1;
 
--- Witness: index analysis is reported for the child read, independent of granule counts.
+-- Control: index analysis is reported for the child read, independent of granule counts. It runs
+-- through EXPLAIN, which never builds a pipeline, so it is unaffected by the duplicate and passes
+-- either way.
 SELECT 'merge index analysis';
 SELECT countIf(explain LIKE '%Min-Max%') > 0, countIf(explain LIKE '%Partition%') > 0,
        countIf(explain LIKE '%PrimaryKey%') > 0
 FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM merge(currentDatabase(), '^t_pr_ro$')
       WHERE timestamp >= toDateTime('2026-06-02 00:00:00'));
+
+-- Witness: the merged child read must STILL be distributed after the guard. A result alone cannot
+-- show that, since parallel replicas is an optimization and a skipped one returns the same number,
+-- so assert the plan shape for the merge() child directly. The guard must fire only on the second
+-- rewrite of this plan, never on the first.
+SELECT 'merge plan shape';
+SELECT countIf(explain LIKE '%ReadFromParallelReplicas%') > 0,
+       countIf(explain LIKE '%ReadFromMerge%') > 0
+FROM (EXPLAIN SELECT sum(value) FROM merge(currentDatabase(), '^t_pr_ro$'));
 
 -- Negative: a predicate that uses neither key must still be rejected, so the arm above passes because
 -- the index is used and not because forcing it became a no-op.

--- a/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.sql
+++ b/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.sql
@@ -2,8 +2,9 @@
 -- A query plan can be optimized more than once, and `ReadFromMerge` does exactly that for its child
 -- plans. The parallel replicas rewrite was not idempotent, so a second run distributed an already
 -- coordinated read again: the query got two coordinators for one read, which aborted the server.
--- The witnesses below therefore killed the server before the fix, except the plan-shape one, which
--- asserts instead that the merged child read is still distributed after the guard.
+-- The witnesses below therefore killed the server before the fix, except the two that assert a plan
+-- shape instead: one that the merged child read is still distributed after the guard, and one that
+-- ordering is declined for a read shipped without a local plan.
 -- The controls read the same data by paths that never had the duplicate, so they pass either way and
 -- fail only if the guard skips the rewrite too broadly. See issue #110518.
 
@@ -135,7 +136,7 @@ SETTINGS parallel_replicas_local_plan = 0;
 -- recognise it by, so this pins that ordering is declined for that shape too. Rows are not an oracle
 -- here, since ORDER BY sorts either way, so assert the sort was not converted to a partially sorted
 -- one: `Prefix sort description` is printed only for a sort with a non-empty prefix. Before the fix
--- this arm read 1, and 10 of 30 runs returned the wrong three rows.
+-- this arm read 1, and the query it explains returned the wrong three rows in 6 of 40 runs.
 SELECT 'merge ordered without local plan';
 SELECT countIf(explain LIKE '%Prefix sort description%')
 FROM (EXPLAIN actions = 1 SELECT value FROM merge(currentDatabase(), '^t_pr_ro$') ORDER BY timestamp LIMIT 3

--- a/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.sql
+++ b/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.sql
@@ -89,6 +89,18 @@ SELECT 'merge ordered view';
 SELECT sum(value) FROM merge(currentDatabase(), '^v_ordered_pr_ro$')
 SETTINGS optimize_read_in_order = 1;
 
+-- Witness: the arm above asserts only a sum, which a purely local read returns too, so it would go
+-- green if the plan for this shape ever stopped being distributed. Assert the shipped fragment is in
+-- the plan, with the same query at `enable_parallel_replicas = 0` as the control that the assertion
+-- discriminates rather than matching everything.
+SELECT 'merge ordered view plan shape';
+SELECT countIf(explain LIKE '%ReadFromParallelReplicas%') > 0
+FROM (EXPLAIN SELECT sum(value) FROM merge(currentDatabase(), '^v_ordered_pr_ro$')
+      SETTINGS optimize_read_in_order = 1);
+SELECT countIf(explain LIKE '%ReadFromParallelReplicas%') > 0
+FROM (EXPLAIN SELECT sum(value) FROM merge(currentDatabase(), '^v_ordered_pr_ro$')
+      SETTINGS optimize_read_in_order = 1, enable_parallel_replicas = 0);
+
 -- Control: the same ordered read with read-in-order off, the configuration that already worked.
 SELECT 'merge ordered no read in order';
 SELECT value FROM merge(currentDatabase(), '^t_pr_ro$') ORDER BY timestamp LIMIT 3

--- a/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.sql
+++ b/tests/queries/0_stateless/04817_pr_repeated_optimize_unknown_stream.sql
@@ -131,6 +131,16 @@ SELECT 'merge without local plan';
 SELECT sum(value) FROM merge(currentDatabase(), '^t_pr_ro$')
 SETTINGS parallel_replicas_local_plan = 0;
 
+-- Witness: without a local plan the child read is the shipped fragment alone, with no local read to
+-- recognise it by, so this pins that ordering is declined for that shape too. Rows are not an oracle
+-- here, since ORDER BY sorts either way, so assert the sort was not converted to a partially sorted
+-- one: `Prefix sort description` is printed only for a sort with a non-empty prefix. Before the fix
+-- this arm read 1, and 10 of 30 runs returned the wrong three rows.
+SELECT 'merge ordered without local plan';
+SELECT countIf(explain LIKE '%Prefix sort description%')
+FROM (EXPLAIN actions = 1 SELECT value FROM merge(currentDatabase(), '^t_pr_ro$') ORDER BY timestamp LIMIT 3
+      SETTINGS optimize_read_in_order = 1, parallel_replicas_local_plan = 0);
+
 -- Control: no parallel replicas at all.
 SELECT 'merge without parallel replicas';
 SELECT sum(value) FROM merge(currentDatabase(), '^t_pr_ro$')


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/110518
Related: https://github.com/ClickHouse/ClickHouse/pull/113636


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a `LOGICAL_ERROR: Got read request from replica N for unknown stream ...` that aborts the initiator, and wrong results for a read given an in-order optimization, when a plan already using parallel replicas is optimized a second time. Both require `parallel_replicas_plan_based = 1`, for example a `merge` table function read; the wrong results also require `parallel_replicas_local_plan = 0` and one of the four `optimize_*_in_order` settings.


### Description

A query plan can be optimized more than once, and `ReadFromMerge` does that for its child plans: in `createChildrenPlans`, in `addFilter`, and while building the pipeline.

`applyParallelReplicas` did not tolerate that. After one run the second pass inlines the local plan, leaving a bare but already coordinated `ReadFromMergeTree` in the outer plan. A later run collects that read again, because `collectReadsToDistribute` filters only on `mergeTreeReadCanBeShipped`, and creates a second coordinator. Only one registers a stream while followers are dispatched against both, so a follower announcing to the second is dropped by the snapshot pin and its next read aborts.

The first fix skips the rewrite on a plan that already carries a coordinated read, the guard the sibling `tryMakeDistributed*` transforms were given in f34ffbbb4c7d1c6, which names `StorageMerge` child plans as the carrier. It can only fire on an already rewritten plan, since `is_parallel_reading_from_replicas` is set only after a coordinator exists.

Removing that abort exposes a second route to the same message. In-order optimizations run after the rewrite and could order only the local read, not the shipped fragment. Two entry points reach a merged read: `ReadFromMerge::requestReadingInOrder`, shared by all four, whose `ReadFromMergeTree` counterparts already declined on `isParallelReadingFromReplicas` while its own branches did not; and the union branch of `optimizeReadInOrder`, for a sort arriving from inside the child plan, whose guard recognised only the classic step. Both now decline, losing an optimization and never correctness.

Both routes need the experimental `parallel_replicas_plan_based = 1`. A classic path route reporting the same message is not addressed here: with that setting off the rewrite returns before the guard, so #110518 is only partly addressed.

Complements #113636, which guards a set-operation transform on the same child plans; that transform is untouched here and the diffs share no file.


<details>
<summary>Validation</summary>

Measured on a three replica cluster, counting `Creating parallel replicas coordinator` against `Created coordinator for stream`: a `merge` read over one table went from 2 coordinators with 1 registered stream to 1 and 1, over two tables from 4 and 2 to 2 and 2, a `JOIN` over `merge` from 3 and 1 to 1 and 1. A direct or view read is unchanged.

New test `04817_pr_repeated_optimize_unknown_stream` has 19 arms: 11 witnesses, 7 controls, 1 negative. Eight witnesses are `merge` shapes that abort the server without the fixes. The other three assert by `EXPLAIN` that the merged child read is still distributed after the guard, that the same holds for the ordered read through a view, and that ordering was declined for the shape shipped without a local plan; a result shows none of them. The controls read the same data by paths that never had the duplicate.

Mutation matrix, each mutant built and asserted separately:

| mutant | result |
|---|---|
| remove the rewrite guard | the aborting shapes redden, every other arm green |
| weaken its predicate to any MergeTree read | the `base table` control and plan shape witness redden, so it is not over-broad |
| revert the read in order decline only | the ordered witness reddens alone with the same unknown stream error, paired control green |
| remove either `optimize` call in `ReadFromMerge` | 8 existing tests redden for `createChildrenPlans`, the join runtime filter test for `addFilter`, so both stay |
| drop the remote-only arm of the `ReadFromMerge` guard | the shipped-fragment witness reddens alone, every other arm green |
| revert the new arm of the union guard | the view witness aborts, while the pre-round file stays green |

Regression slice of stateless tests matching `ENGINE = Merge`, `merge(` and the parallel replicas and read in order families: verdict sets identical on both binaries. The new test passes 50 of 50 randomized and 50 of 50 unrandomized runs.

</details>
