### PR TITLE
Stop stateless tests from leaving the shared database Replicated

### DIFF
--- a/tests/queries/0_stateless/02483_add_engine_full_column_to_system_databases.reference
+++ b/tests/queries/0_stateless/02483_add_engine_full_column_to_system_databases.reference
@@ -1,1 +1,1 @@
-Replicated(\'some/path/default/replicated_database_test\', \'shard_1\', \'replica_1\') SETTINGS max_broken_tables_ratio = 1
+Replicated(\'some/path/default_2/replicated_database_test\', \'shard_1\', \'replica_1\') SETTINGS max_broken_tables_ratio = 1

--- a/tests/queries/0_stateless/02483_add_engine_full_column_to_system_databases.sql
+++ b/tests/queries/0_stateless/02483_add_engine_full_column_to_system_databases.sql
@@ -1,3 +1,6 @@
-DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE:Identifier};
-CREATE DATABASE IF NOT EXISTS {CLICKHOUSE_DATABASE:Identifier} ENGINE = Replicated('some/path/' || currentDatabase() || '/replicated_database_test', 'shard_1', 'replica_1') SETTINGS max_broken_tables_ratio=1;
-SELECT engine_full FROM system.databases WHERE name = current_database();
+-- {CLICKHOUSE_DATABASE} must not be re-engined: with --database it is shared by every test in
+-- the client. {CLICKHOUSE_DATABASE_2} is shared too, so both DROPs are required.
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_2:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE_2:Identifier} ENGINE = Replicated('some/path/' || {CLICKHOUSE_DATABASE_2:String} || '/replicated_database_test', 'shard_1', 'replica_1') SETTINGS max_broken_tables_ratio=1;
+SELECT engine_full FROM system.databases WHERE name = {CLICKHOUSE_DATABASE_2:String};
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_2:Identifier};

--- a/tests/queries/0_stateless/03001_matview_columns_after_modify_query.sh
+++ b/tests/queries/0_stateless/03001_matview_columns_after_modify_query.sh
@@ -60,7 +60,10 @@ show_mv_and_inner
 echo $'\nTest 3. MODIFY QUERY can even fix wrong columns.' # We need that because of https://github.com/ClickHouse/ClickHouse/issues/60369
 
 mv_metadata_path=$(${CLICKHOUSE_CLIENT} -q "SELECT metadata_path FROM system.tables WHERE table='mv' AND database=currentDatabase()")
-${CLICKHOUSE_CLIENT} -q "DETACH TABLE mv"
+# Rewriting the metadata of a still-attached table corrupts a Replicated database's digest,
+# so a refused DETACH must fail the test rather than let the rewrite below run.
+detach_out=$(${CLICKHOUSE_CLIENT} -q "DETACH TABLE mv" 2>&1) \
+    || { echo "FAIL: DETACH TABLE mv failed: $detach_out"; exit 1; }
 
 data_path=$(${CLICKHOUSE_CLIENT} -q "SELECT path FROM system.disks WHERE name = 'default'")
 

--- a/tests/queries/0_stateless/03224_invalid_alter.reference
+++ b/tests/queries/0_stateless/03224_invalid_alter.reference
@@ -6,3 +6,4 @@ localhost	9000	0		0	0
 localhost	9000	0		0	0
 test3	test3a	test3a	test3c
 test4	test4a	test4a	test4c
+0

--- a/tests/queries/0_stateless/03224_invalid_alter.sql
+++ b/tests/queries/0_stateless/03224_invalid_alter.sql
@@ -62,6 +62,9 @@ ALTER TABLE test3 ON CLUSTER test_shard_localhost ADD COLUMN valid_column_2 Stri
 INSERT INTO test3(str, column_with_codec) VALUES ('test3', 'test32');
 SELECT str, column_with_alias, valid_column_1, valid_column_2 FROM test3;
 
+-- ignore_drop_queries_probability = 0: the stress runner sets it to 0.2, which makes a DROP a no-op.
+DROP TABLE test3 SETTINGS ignore_drop_queries_probability = 0;
+
 -- {CLICKHOUSE_DATABASE} must not be re-engined: with --database it is shared by every test in
 -- the client. {CLICKHOUSE_DATABASE_2} is shared too, so both DROPs are required.
 DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_2:Identifier};
@@ -86,3 +89,7 @@ INSERT INTO {CLICKHOUSE_DATABASE_2:Identifier}.test4(str, column_with_codec) VAL
 SELECT str, column_with_alias, valid_column_1, valid_column_2 FROM {CLICKHOUSE_DATABASE_2:Identifier}.test4;
 
 DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_2:Identifier};
+
+-- The engine varies with the runner flags, so assert only what must hold: this test must never
+-- leave the database it was given Replicated.
+SELECT engine = 'Replicated' FROM system.databases WHERE name = currentDatabase();

--- a/tests/queries/0_stateless/03224_invalid_alter.sql
+++ b/tests/queries/0_stateless/03224_invalid_alter.sql
@@ -62,10 +62,12 @@ ALTER TABLE test3 ON CLUSTER test_shard_localhost ADD COLUMN valid_column_2 Stri
 INSERT INTO test3(str, column_with_codec) VALUES ('test3', 'test32');
 SELECT str, column_with_alias, valid_column_1, valid_column_2 FROM test3;
 
-DROP DATABASE {CLICKHOUSE_DATABASE:Identifier};
-CREATE DATABASE {CLICKHOUSE_DATABASE:Identifier} ENGINE = Replicated('/clickhouse/03224_invalid_alter/{database}_replicated', 'shard1', 'replica1') FORMAT Null;
+-- {CLICKHOUSE_DATABASE} must not be re-engined: with --database it is shared by every test in
+-- the client. {CLICKHOUSE_DATABASE_2} is shared too, so both DROPs are required.
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_2:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE_2:Identifier} ENGINE = Replicated('/clickhouse/03224_invalid_alter/{database}_replicated', 'shard1', 'replica1') FORMAT Null;
 
-CREATE TABLE test4
+CREATE TABLE {CLICKHOUSE_DATABASE_2:Identifier}.test4
 (
     str String,
     column_with_codec String CODEC(ZSTD),
@@ -75,10 +77,12 @@ ENGINE = ReplicatedMergeTree()
 ORDER BY tuple()
 FORMAT Null;
 
-ALTER TABLE test4 ADD COLUMN invalid_column String MATERIALIZED concat(str, 'b' AS a) FORMAT Null SETTINGS distributed_ddl_output_mode='throw'; -- { serverError MULTIPLE_EXPRESSIONS_FOR_ALIAS }
-ALTER TABLE test4 ADD COLUMN invalid_column String DEFAULT concat(str, 'b' AS a) FORMAT Null SETTINGS distributed_ddl_output_mode='throw'; -- { serverError MULTIPLE_EXPRESSIONS_FOR_ALIAS }
-ALTER TABLE test4 MODIFY COLUMN column_with_codec String ALIAS str FORMAT Null SETTINGS distributed_ddl_output_mode='throw'; -- { serverError BAD_ARGUMENTS }
-ALTER TABLE test4 ADD COLUMN valid_column_1 String DEFAULT concat(str, 'a' AS a) FORMAT Null SETTINGS distributed_ddl_output_mode='throw';
-ALTER TABLE test4 ADD COLUMN valid_column_2 String MATERIALIZED concat(str, 'c' AS c) FORMAT Null SETTINGS distributed_ddl_output_mode='throw';
-INSERT INTO test4(str, column_with_codec) VALUES ('test4', 'test42');
-SELECT str, column_with_alias, valid_column_1, valid_column_2 FROM test4;
+ALTER TABLE {CLICKHOUSE_DATABASE_2:Identifier}.test4 ADD COLUMN invalid_column String MATERIALIZED concat(str, 'b' AS a) FORMAT Null SETTINGS distributed_ddl_output_mode='throw'; -- { serverError MULTIPLE_EXPRESSIONS_FOR_ALIAS }
+ALTER TABLE {CLICKHOUSE_DATABASE_2:Identifier}.test4 ADD COLUMN invalid_column String DEFAULT concat(str, 'b' AS a) FORMAT Null SETTINGS distributed_ddl_output_mode='throw'; -- { serverError MULTIPLE_EXPRESSIONS_FOR_ALIAS }
+ALTER TABLE {CLICKHOUSE_DATABASE_2:Identifier}.test4 MODIFY COLUMN column_with_codec String ALIAS str FORMAT Null SETTINGS distributed_ddl_output_mode='throw'; -- { serverError BAD_ARGUMENTS }
+ALTER TABLE {CLICKHOUSE_DATABASE_2:Identifier}.test4 ADD COLUMN valid_column_1 String DEFAULT concat(str, 'a' AS a) FORMAT Null SETTINGS distributed_ddl_output_mode='throw';
+ALTER TABLE {CLICKHOUSE_DATABASE_2:Identifier}.test4 ADD COLUMN valid_column_2 String MATERIALIZED concat(str, 'c' AS c) FORMAT Null SETTINGS distributed_ddl_output_mode='throw';
+INSERT INTO {CLICKHOUSE_DATABASE_2:Identifier}.test4(str, column_with_codec) VALUES ('test4', 'test42');
+SELECT str, column_with_alias, valid_column_1, valid_column_2 FROM {CLICKHOUSE_DATABASE_2:Identifier}.test4;
+
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_2:Identifier};

--- a/tests/queries/0_stateless/03762_create_as_url_cluster.sql
+++ b/tests/queries/0_stateless/03762_create_as_url_cluster.sql
@@ -1,6 +1,11 @@
 -- Tags: no-replicated-database
 -- no-replicated-database: It messes up the output and this test explicitly checks the replicated database
 
-DROP DATABASE {CLICKHOUSE_DATABASE:Identifier};
-CREATE DATABASE {CLICKHOUSE_DATABASE:Identifier} ENGINE = Replicated('/clickhouse/03762_create_as_url_cluster/{database}_replicated', 'shard1', 'replica1') FORMAT Null;
-CREATE TABLE {CLICKHOUSE_DATABASE:Identifier}.test (c0 Int) ENGINE = Memory AS (SELECT 1 FROM url('http://localhost:8123/?query=SELECT+1+FORMAT+Values', 'Values', 'c0 Int') tx)
+-- Use a scratch database instead of re-engining {CLICKHOUSE_DATABASE}: in shared-database mode
+-- (stress lane) that database is shared by every test in the client and is never recreated, so
+-- leaving it Replicated breaks later tests that edit on-disk metadata. The leading DROP makes this
+-- test immune to a predecessor's leftover, the trailing one stops it becoming that predecessor.
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = Replicated('/clickhouse/03762_create_as_url_cluster/{database}_replicated', 'shard1', 'replica1') FORMAT Null;
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.test (c0 Int) ENGINE = Memory AS (SELECT 1 FROM url('http://localhost:8123/?query=SELECT+1+FORMAT+Values', 'Values', 'c0 Int') tx);
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};

--- a/tests/queries/0_stateless/03762_create_as_url_cluster.sql
+++ b/tests/queries/0_stateless/03762_create_as_url_cluster.sql
@@ -1,11 +1,9 @@
 -- Tags: no-replicated-database
 -- no-replicated-database: It messes up the output and this test explicitly checks the replicated database
 
--- Use a scratch database instead of re-engining {CLICKHOUSE_DATABASE}: in shared-database mode
--- (stress lane) that database is shared by every test in the client and is never recreated, so
--- leaving it Replicated breaks later tests that edit on-disk metadata. The leading DROP makes this
--- test immune to a predecessor's leftover, the trailing one stops it becoming that predecessor.
-DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
-CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = Replicated('/clickhouse/03762_create_as_url_cluster/{database}_replicated', 'shard1', 'replica1') FORMAT Null;
-CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.test (c0 Int) ENGINE = Memory AS (SELECT 1 FROM url('http://localhost:8123/?query=SELECT+1+FORMAT+Values', 'Values', 'c0 Int') tx);
-DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
+-- {CLICKHOUSE_DATABASE} must not be re-engined: with --database it is shared by every test in
+-- the client. {CLICKHOUSE_DATABASE_2} is shared too, so both DROPs are required.
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_2:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE_2:Identifier} ENGINE = Replicated('/clickhouse/03762_create_as_url_cluster/{database}_replicated', 'shard1', 'replica1') FORMAT Null;
+CREATE TABLE {CLICKHOUSE_DATABASE_2:Identifier}.test (c0 Int) ENGINE = Memory AS (SELECT 1 FROM url('http://localhost:8123/?query=SELECT+1+FORMAT+Values', 'Values', 'c0 Int') tx);
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_2:Identifier};

--- a/tests/queries/0_stateless/04365_create_as_select_cluster_function_replicated_db.sql
+++ b/tests/queries/0_stateless/04365_create_as_select_cluster_function_replicated_db.sql
@@ -8,27 +8,33 @@
 -- so IStorageCluster::getQueryProcessingStage wrongly treated it as a follower and stopped
 -- the local plan at FetchColumns, producing an empty header. See issue #107057.
 
-DROP DATABASE {CLICKHOUSE_DATABASE:Identifier};
-CREATE DATABASE {CLICKHOUSE_DATABASE:Identifier}
+-- Use a scratch database instead of re-engining {CLICKHOUSE_DATABASE}: in shared-database mode
+-- (stress lane) that database is shared by every test in the client and is never recreated, so
+-- leaving it Replicated breaks later tests that edit on-disk metadata. The leading DROP makes this
+-- test immune to a predecessor's leftover, the trailing one stops it becoming that predecessor.
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier}
     ENGINE = Replicated('/clickhouse/{database}/04365_repl', 'shard1', 'replica1') FORMAT Null;
 
 -- The data file lives in the shared user_files dir, so its name must be unique per test
 -- run or parallel copies clobber each other's file and fileCluster reads the union.
-INSERT INTO FUNCTION file({CLICKHOUSE_DATABASE:String} || '_04365_data.tsv', 'TSV', 'id UInt64, value String')
+INSERT INTO FUNCTION file({CLICKHOUSE_DATABASE_1:String} || '_04365_data.tsv', 'TSV', 'id UInt64, value String')
 SELECT number, toString(number) FROM numbers(5)
 SETTINGS engine_file_truncate_on_insert = 1;
 
-CREATE TABLE {CLICKHOUSE_DATABASE:Identifier}.t
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t
     ENGINE = MergeTree() ORDER BY id
-    AS SELECT id, value FROM fileCluster('test_shard_localhost', {CLICKHOUSE_DATABASE:String} || '_04365_data.tsv', 'TSV', 'id UInt64, value String') FORMAT Null;
+    AS SELECT id, value FROM fileCluster('test_shard_localhost', {CLICKHOUSE_DATABASE_1:String} || '_04365_data.tsv', 'TSV', 'id UInt64, value String') FORMAT Null;
 
-SELECT count(), sum(id) FROM {CLICKHOUSE_DATABASE:Identifier}.t;
+SELECT count(), sum(id) FROM {CLICKHOUSE_DATABASE_1:Identifier}.t;
 
 -- Positional arguments must also be resolved on the Replicated DDL worker (query_kind =
 -- NO_QUERY): QueryAnalyzer::replaceNodesWithPositionalArguments gated on == INITIAL_QUERY,
 -- so GROUP BY 1 was left unresolved and threw NOT_AN_AGGREGATE.
-CREATE TABLE {CLICKHOUSE_DATABASE:Identifier}.t_pos
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t_pos
     ENGINE = MergeTree() ORDER BY id
-    AS SELECT id, count() AS c FROM fileCluster('test_shard_localhost', {CLICKHOUSE_DATABASE:String} || '_04365_data.tsv', 'TSV', 'id UInt64, value String') GROUP BY 1 FORMAT Null;
+    AS SELECT id, count() AS c FROM fileCluster('test_shard_localhost', {CLICKHOUSE_DATABASE_1:String} || '_04365_data.tsv', 'TSV', 'id UInt64, value String') GROUP BY 1 FORMAT Null;
 
-SELECT count(), sum(id) FROM {CLICKHOUSE_DATABASE:Identifier}.t_pos;
+SELECT count(), sum(id) FROM {CLICKHOUSE_DATABASE_1:Identifier}.t_pos;
+
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};

--- a/tests/queries/0_stateless/04365_create_as_select_cluster_function_replicated_db.sql
+++ b/tests/queries/0_stateless/04365_create_as_select_cluster_function_replicated_db.sql
@@ -8,33 +8,31 @@
 -- so IStorageCluster::getQueryProcessingStage wrongly treated it as a follower and stopped
 -- the local plan at FetchColumns, producing an empty header. See issue #107057.
 
--- Use a scratch database instead of re-engining {CLICKHOUSE_DATABASE}: in shared-database mode
--- (stress lane) that database is shared by every test in the client and is never recreated, so
--- leaving it Replicated breaks later tests that edit on-disk metadata. The leading DROP makes this
--- test immune to a predecessor's leftover, the trailing one stops it becoming that predecessor.
-DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
-CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier}
+-- {CLICKHOUSE_DATABASE} must not be re-engined: with --database it is shared by every test in
+-- the client. {CLICKHOUSE_DATABASE_2} is shared too, so both DROPs are required.
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_2:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE_2:Identifier}
     ENGINE = Replicated('/clickhouse/{database}/04365_repl', 'shard1', 'replica1') FORMAT Null;
 
 -- The data file lives in the shared user_files dir, so its name must be unique per test
 -- run or parallel copies clobber each other's file and fileCluster reads the union.
-INSERT INTO FUNCTION file({CLICKHOUSE_DATABASE_1:String} || '_04365_data.tsv', 'TSV', 'id UInt64, value String')
+INSERT INTO FUNCTION file({CLICKHOUSE_DATABASE_2:String} || '_04365_data.tsv', 'TSV', 'id UInt64, value String')
 SELECT number, toString(number) FROM numbers(5)
 SETTINGS engine_file_truncate_on_insert = 1;
 
-CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t
+CREATE TABLE {CLICKHOUSE_DATABASE_2:Identifier}.t
     ENGINE = MergeTree() ORDER BY id
-    AS SELECT id, value FROM fileCluster('test_shard_localhost', {CLICKHOUSE_DATABASE_1:String} || '_04365_data.tsv', 'TSV', 'id UInt64, value String') FORMAT Null;
+    AS SELECT id, value FROM fileCluster('test_shard_localhost', {CLICKHOUSE_DATABASE_2:String} || '_04365_data.tsv', 'TSV', 'id UInt64, value String') FORMAT Null;
 
-SELECT count(), sum(id) FROM {CLICKHOUSE_DATABASE_1:Identifier}.t;
+SELECT count(), sum(id) FROM {CLICKHOUSE_DATABASE_2:Identifier}.t;
 
 -- Positional arguments must also be resolved on the Replicated DDL worker (query_kind =
 -- NO_QUERY): QueryAnalyzer::replaceNodesWithPositionalArguments gated on == INITIAL_QUERY,
 -- so GROUP BY 1 was left unresolved and threw NOT_AN_AGGREGATE.
-CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t_pos
+CREATE TABLE {CLICKHOUSE_DATABASE_2:Identifier}.t_pos
     ENGINE = MergeTree() ORDER BY id
-    AS SELECT id, count() AS c FROM fileCluster('test_shard_localhost', {CLICKHOUSE_DATABASE_1:String} || '_04365_data.tsv', 'TSV', 'id UInt64, value String') GROUP BY 1 FORMAT Null;
+    AS SELECT id, count() AS c FROM fileCluster('test_shard_localhost', {CLICKHOUSE_DATABASE_2:String} || '_04365_data.tsv', 'TSV', 'id UInt64, value String') GROUP BY 1 FORMAT Null;
 
-SELECT count(), sum(id) FROM {CLICKHOUSE_DATABASE_1:Identifier}.t_pos;
+SELECT count(), sum(id) FROM {CLICKHOUSE_DATABASE_2:Identifier}.t_pos;
 
-DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_2:Identifier};

--- a/tests/queries/0_stateless/04545_attach_projection_part_offset_setting_disabled.sh
+++ b/tests/queries/0_stateless/04545_attach_projection_part_offset_setting_disabled.sh
@@ -34,7 +34,11 @@ attach_with_gate_disabled() {
     local rel_path meta
     rel_path=$(${CLICKHOUSE_CLIENT} -q "SELECT metadata_path FROM system.tables WHERE database = currentDatabase() AND name = '$table'")
     meta="$data_path$rel_path"
-    ${CLICKHOUSE_CLIENT} -q "DETACH TABLE $table"
+    # Rewriting the metadata of a still-attached table corrupts a Replicated database's digest,
+    # so a refused DETACH must fail the test rather than let the sed below run.
+    local detach_out
+    detach_out=$(${CLICKHOUSE_CLIENT} -q "DETACH TABLE $table" 2>&1) \
+        || { echo "FAIL: DETACH TABLE $table failed: $detach_out"; exit 1; }
     # sed exits 0 even when it rewrites nothing, so assert the enabled spelling exists before the edit
     # and the disabled spelling exists after it. Otherwise a SHOW CREATE formatting drift away from
     # "$setting = 1" would leave the metadata untouched and re-attach it -- a false positive.


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/112378
Related: https://github.com/ClickHouse/ClickHouse/pull/113009
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes a `LOGICAL_ERROR: Digest does not match` server abort in `Stress test (arm_tsan)`
(STID `5007-4590`). No product code is at fault: the assertion correctly detected a divergence two
tests manufactured between them.

**Root cause.** In shared-database mode the stress lane points some clients at one long-lived
database (`get_options`, `stress.py`), created once and never recreated, so leftovers persist for
the whole
run. `03762_create_as_url_cluster.sql` re-created it as `Replicated` and never restored it;
`no-replicated-database` cannot prevent that, because the guard reads a static CLI flag
(`should_skip_test`, `clickhouse-test`). `04545_attach_projection_part_offset_setting_disabled.sh`
then ran there,
its `DETACH` was refused with `Code: 80`, and because the helper ignored that status `sed -i`
rewrote a live table's metadata. The next `ALTER` compared that file against the stale in-memory
digest and aborted.

**The change,** two independent halves, tests only.

1. **Fail closed** in the two tests that rewrite table metadata (`04545`, `03001`, the complete
   in-tree set): a refused `DETACH` now prints the server's error and `exit 1`s instead of letting
   the rewrite proceed.
2. **Stop the leak:** the four tests that re-engined the shared database (`03762`, `04365`,
   `02483`, `03224`) now build their `Replicated` database as `{CLICKHOUSE_DATABASE_2:Identifier}`,
   bracketed by `DROP DATABASE IF EXISTS`. That holds by construction rather than by cleanup,
   because the lane's killer SIGTERMs a random client on one branch of its 3 s loop
   (`RandomQueryKiller._run`, `stress.py`), skipping any cleanup-at-the-end fix. `_2` because the
   scratch aliases
   are shared too (`shell_config.sh`) but far less contended: 3 consumers against 105, with 0
   bare creators against 19.

**Validation.** Under the `database_replicated_force_metadata_digest_check` failpoint the `ALTER`
aborts before the change with a stack matching the CI artifact frame-for-frame, and after it
succeeds with the database still `Atomic`. In shared-database mode, `02483` and `03224` previously
passed green while leaving it `Replicated`; now all four leave it `Atomic`, no scratch leftover.

<details>
<summary>Mutation matrix and scope notes</summary>

Each mutant reverts one half and reddens only its own property:

| mutant | result |
|---|---|
| leak restored, guard kept | `DETACH` refused, metadata **not** rewritten, no abort: half 1 alone stops the corruption |
| leading `DROP` deleted, predecessor's scratch database present | `CREATE` fails `Code: 82`; with the `DROP` it succeeds |
| `exit 1` to `return 1` at `03001`'s top level | bash rejects `return`, **continues into the rewrite**, exits `0` |
| `03224` retarget reverted, oracle kept | the engine assertion prints `1` and the test fails; with the retarget, `0` |

`02483`'s reference pins the database name, so its retarget is self-checking. `03224`'s was not:
every renamed database is absent from its output, so reverting it still produced the full expected
result. It now asserts the invariant (`engine = 'Replicated'` must be false for `currentDatabase()`)
rather than a specific engine, since the engine depends on the runner flags. Retargeting its last
phase also removed the only cleanup of its phase-3 `test3`, so it drops that table explicitly,
pinning `ignore_drop_queries_probability = 0` as `02354_vector_search_concurrent_readers` does.

A per-test database name is not available to a `.sql` test: the runner passes only
`CLICKHOUSE_DATABASE`, `_1` and `_2` (the `--param_CLICKHOUSE_DATABASE*` arguments the runner
builds), all derived from the shared
name; `{CLICKHOUSE_TEST_UNIQUE_NAME}` is shell-only and resolves to `Code: 456`.

Not addressed: `02072`, `03321`, `03362`, `03655` and `04239` delete the shared database outright
instead of re-engining it, a different class from this digest assertion.
</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1393` (included in `26.8` and later)
<!-- ch-version-info:end -->