### PR TITLE
Docs: add view/dictionary/named-collection usage limits

### DIFF
--- a/docs/products/cloud/guides/best-practices/usagelimits.mdx
+++ b/docs/products/cloud/guides/best-practices/usagelimits.mdx
@@ -49,8 +49,8 @@ The values above are default guardrails. The limit enforced for a specific servi
 For Single Replica Services, the maximum number of databases is restricted to 
 100, and the maximum number of tables is restricted to 500. In addition, storage
 for Basic Tier Services is limited to 1 TB. The view, dictionary, and named
-collection limits above apply to multi-replica services; they are not enforced
-on Single Replica Services.
+collection limits above are a single value that applies to all services,
+including Single Replica Services.
 </Note>
 
 Your service's specific warn and throw limits can be verified by querying system.server_settings. For example,

--- a/docs/products/cloud/guides/best-practices/usagelimits.mdx
+++ b/docs/products/cloud/guides/best-practices/usagelimits.mdx
@@ -25,6 +25,9 @@ or look together at how we can increase them in a controlled manner.
 |-------------------------------|---------------------------------------------------------------------------------------------------|
 | **Databases**                 | 1000                                                                                              |
 | **Tables**                    | 5000                                                                                              |
+| **Views**                     | 15000                                                                                             |
+| **Dictionaries**              | 5000                                                                                              |
+| **Named collections**         | 1000                                                                                              |
 | **Columns**                   | ~1000 (wide format is preferred to compact)                                                       |
 | **Partitions**                | 50k                                                                                               |
 | **Parts**                     | 10k (see [`max_parts_in_total`](/products/cloud/guides/cloud-compatibility#max_parts_in_total-10000) setting) |
@@ -45,12 +48,14 @@ The values above are default guardrails. The limit enforced for a specific servi
 <Note>
 For Single Replica Services, the maximum number of databases is restricted to 
 100, and the maximum number of tables is restricted to 500. In addition, storage
-for Basic Tier Services is limited to 1 TB.
+for Basic Tier Services is limited to 1 TB. The view, dictionary, and named
+collection limits above apply to multi-replica services; they are not enforced
+on Single Replica Services.
 </Note>
 
 Your service's specific warn and throw limits can be verified by querying system.server_settings. For example,
 ```
 SELECT * 
 FROM system.server_settings 
-WHERE name IN ('max_table_num_to_warn', 'max_table_num_to_throw', 'max_database_num_to_warn', 'max_database_num_to_throw')
+WHERE name IN ('max_table_num_to_warn', 'max_table_num_to_throw', 'max_database_num_to_warn', 'max_database_num_to_throw', 'max_view_num_to_warn', 'max_view_num_to_throw', 'max_dictionary_num_to_warn', 'max_dictionary_num_to_throw', 'max_named_collection_num_to_warn', 'max_named_collection_num_to_throw')
 ```

--- a/docs/products/cloud/guides/best-practices/usagelimits.mdx
+++ b/docs/products/cloud/guides/best-practices/usagelimits.mdx
@@ -27,7 +27,7 @@ or look together at how we can increase them in a controlled manner.
 | **Tables**                    | 5000                                                                                              |
 | **Views**                     | 15000                                                                                             |
 | **Dictionaries**              | 5000                                                                                              |
-| **Named collections**         | 1000                                                                                              |
+| **Named collections** (private preview)        | 1000                                                                                              |
 | **Columns**                   | ~1000 (wide format is preferred to compact)                                                       |
 | **Partitions**                | 50k                                                                                               |
 | **Parts**                     | 10k (see [`max_parts_in_total`](/products/cloud/guides/cloud-compatibility#max_parts_in_total-10000) setting) |


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

Updates the Cloud "Usage limits" page (`/cloud/bestpractices/usage-limits`) to document three additional guardrails that ClickHouse Cloud now enforces alongside the existing tables/databases limits:

| Dimension | Limit |
|---|---|
| Views | 15000 |
| Dictionaries | 5000 |
| Named collections | 1000 |

Changes:
- Adds the three rows to the guardrails table.
- Notes that these limits apply to multi-replica services and are not enforced on Single Replica Services.
- Extends the `system.server_settings` verification query so users can read the new `max_view_num_to_*`, `max_dictionary_num_to_*`, and `max_named_collection_num_to_*` warn/throw settings.

Values match the multi-replica guardrail defaults being rolled out via the data-plane webhook and base-configuration changes. English source only; localized copies are regenerated by the docs pipeline.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1085` (included in `26.8` and later)
<!-- ch-version-info:end -->