### PR TITLE
Fix flaky `test_dirty_pages_force_purge`

### DIFF
--- a/tests/integration/test_dirty_pages_force_purge/configs/overrides.yaml
+++ b/tests/integration/test_dirty_pages_force_purge/configs/overrides.yaml
@@ -1,3 +1,7 @@
 ---
 max_server_memory_usage: 4Gi
-memory_worker_purge_dirty_pages_threshold_ratio: 0.2
+# The threshold must be reliably exceeded by a single iteration of the test query
+# (peak usage ~417 MiB). With a higher ratio, `pdirty` may plateau below the threshold,
+# because jemalloc reuses dirty pages within the same arenas across iterations,
+# and the number of touched arenas depends on the machine and the number of threads.
+memory_worker_purge_dirty_pages_threshold_ratio: 0.05


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110188

The test `test_dirty_pages_force_purge` occasionally times out waiting for the `MemoryAllocatorPurge` event (seen on unrelated PRs #110188, #111332, #113192, #107442, #105056; e.g. [this report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110188&sha=5b0dd0156a543c7e72ceb73c0ebb890d53cb1f83&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29)).

Root cause: the test query peaks at ~417 MiB, but the forced purge fires only when jemalloc dirty pages exceed `max_server_memory_usage` (4 GiB) × `memory_worker_purge_dirty_pages_threshold_ratio` (0.2) = 819 MiB. Since jemalloc reuses dirty pages within the same arenas across iterations, `pdirty` can plateau below the threshold when few arenas are touched — for example, when the number of query threads is lowered by `MemoryTrackerUtils` on a constrained CI machine (the failing run shows `Lower number of threads for query to 3 (5 requested)` and all 100 iterations peaking at exactly 416.86 MiB) — so the event never fires and the test times out.

Fix: lower the ratio to 0.05 (~205 MiB), so a single iteration of the test query reliably exceeds the threshold. The purge is still attributable to dirty-page volume rather than the total-memory threshold (0.9 × 4 GiB = 3.6 GiB, and the test keeps asserting peak memory < 3 GiB).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1044` (included in `26.8` and later)
<!-- ch-version-info:end -->