### PR TITLE
Add `clickhouse/utils` container image with macOS binary signing tools

### DIFF
--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -131,6 +131,15 @@ DOCKERS = [
         platforms=Docker.Platforms.arm_amd,
         depends_on=["clickhouse/fasttest"],
     ),
+    # AMD only: the signing job runs on x86_64, and the pinned aws-kms-pkcs11
+    # asset is per OS release and per architecture, so arm would need a second
+    # pinned hash for no current benefit.
+    Docker.Config(
+        name="clickhouse/macos-signer",
+        path="./ci/docker/macos-signer",
+        platforms=[Docker.Platforms.AMD],
+        depends_on=["clickhouse/fasttest"],
+    ),
     Docker.Config(
         name="clickhouse/test-base",
         path="./ci/docker/test-base",

--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -131,9 +131,6 @@ DOCKERS = [
         platforms=Docker.Platforms.arm_amd,
         depends_on=["clickhouse/fasttest"],
     ),
-    # AMD only: the signing job runs on x86_64, and the pinned aws-kms-pkcs11
-    # asset is per OS release and per architecture, so arm would need a second
-    # pinned hash for no current benefit.
     Docker.Config(
         name="clickhouse/macos-signer",
         path="./ci/docker/macos-signer",

--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -132,8 +132,8 @@ DOCKERS = [
         depends_on=["clickhouse/fasttest"],
     ),
     Docker.Config(
-        name="clickhouse/macos-signer",
-        path="./ci/docker/macos-signer",
+        name="clickhouse/utils",
+        path="./ci/docker/utils",
         platforms=[Docker.Platforms.AMD],
         depends_on=["clickhouse/fasttest"],
     ),

--- a/ci/docker/macos-signer/Dockerfile
+++ b/ci/docker/macos-signer/Dockerfile
@@ -1,0 +1,32 @@
+# docker build -t clickhouse/macos-signer .
+
+ARG FROM_TAG=latest
+FROM clickhouse/fasttest:$FROM_TAG
+
+RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+        libjson-c5 \
+        p11-kit \
+        p11-kit-modules \
+        zip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
+
+ARG RC_GIT_REV=607b3c1d952b06c0affa12106f9d6bad2ffbc44a
+RUN ln -s "$(command -v clang-$LLVM_VERSION)" /usr/local/bin/cc \
+    && cargo install --git https://github.com/indygreg/apple-platform-rs \
+        --rev $RC_GIT_REV apple-codesign --features pkcs11 --locked \
+    && rm -rf /rust/cargo/registry /rust/cargo/git \
+    && rcodesign --version
+
+ARG KMS_PKCS11_VERSION=v0.0.17
+ARG KMS_PKCS11_SHA256=621db84872f1eacd84436b84a14f57efd155a4d389f7b457e0c012caa4e0b584
+RUN mkdir -p /usr/lib/aws-kms-pkcs11 \
+    && curl -fsSL -o /usr/lib/aws-kms-pkcs11/aws_kms_pkcs11.so \
+        "https://github.com/JackOfMostTrades/aws-kms-pkcs11/releases/download/$KMS_PKCS11_VERSION/aws_kms_pkcs11-ubuntu24.04-x86_64.so" \
+    && echo "$KMS_PKCS11_SHA256  /usr/lib/aws-kms-pkcs11/aws_kms_pkcs11.so" | sha256sum --check --strict
+
+RUN mkdir -p /usr/share/p11-kit/modules \
+    && echo "module: /usr/lib/aws-kms-pkcs11/aws_kms_pkcs11.so" > /usr/share/p11-kit/modules/awskms.module
+
+RUN test -e /usr/lib/x86_64-linux-gnu/p11-kit-proxy.so
+ENV PKCS11_PROXY_LIBRARY=/usr/lib/x86_64-linux-gnu/p11-kit-proxy.so

--- a/ci/docker/utils/Dockerfile
+++ b/ci/docker/utils/Dockerfile
@@ -1,4 +1,4 @@
-# docker build -t clickhouse/macos-signer .
+# docker build -t clickhouse/utils .
 
 ARG FROM_TAG=latest
 FROM clickhouse/fasttest:$FROM_TAG


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
Related: https://github.com/ClickHouse/ClickHouse/issues/90325
Related: https://github.com/ClickHouse/ClickHouse/issues/75921


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113813&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/113813](https://github.com/search?q=head%3Async-upstream%2Fpr%2F113813+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1588` (included in `26.8` and later)
- Backported to: `26.7.4.56`
<!-- ch-version-info:end -->