### PR TITLE
[DRAFT] Replace MinIO with (20x faster) RustFS in stateless CI

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -117,7 +117,7 @@ common_ft_job_config = Job.Config(
             "./tests/config",
             "./tests/*.txt",
             "./ci/docker/stateless-test",
-            "./ci/jobs/scripts/functional_tests/setup_minio.sh",
+            "./ci/jobs/scripts/functional_tests/setup_rustfs.sh",
         ],
     ),
     result_name_for_cidb="Tests",

--- a/ci/docker/stateless-test/Dockerfile
+++ b/ci/docker/stateless-test/Dockerfile
@@ -83,7 +83,7 @@ ENV NUM_TRIES=1
 
 # Keep RUSTFS_VERSION / MC_VERSION in sync with the defaults in setup_rustfs.sh
 # to have the same binaries for local running scenario
-ARG RUSTFS_VERSION=1.0.0-beta.12
+ARG RUSTFS_VERSION=1.0.0-beta.11
 ARG MC_VERSION=2025-05-21T01-59-54Z
 ARG TARGETARCH
 

--- a/ci/docker/stateless-test/Dockerfile
+++ b/ci/docker/stateless-test/Dockerfile
@@ -81,37 +81,44 @@ RUN mkdir -p /tmp/clickhouse-odbc-tmp \
 
 ENV NUM_TRIES=1
 
-# Unrelated to vars in setup_minio.sh, but should be the same there
+# Keep RUSTFS_VERSION / MC_VERSION in sync with the defaults in setup_rustfs.sh
 # to have the same binaries for local running scenario
-ARG MINIO_SERVER_VERSION=2025-06-13T11-33-47Z
-ARG MINIO_CLIENT_VERSION=2025-05-21T01-59-54Z
+ARG RUSTFS_VERSION=1.0.0-beta.12
+ARG MC_VERSION=2025-05-21T01-59-54Z
 ARG TARGETARCH
 
-# Download Minio-related binaries.
+# Download RustFS (the S3 server for stateless tests) and mc (still used to
+# provision users/policies/buckets - RustFS implements the MinIO admin API).
+# The musl build of RustFS is static-pie, so it runs on this image regardless
+# of its glibc version.
 # dl.min.io throttles under concurrent multi-arch image builds, so fetch with
 # --fail (never write an error body as a "binary") and retry with backoff on
 # transient errors/timeouts; otherwise one blip fails the build and the image
 # is never pushed, breaking every downstream stateless job with "image not found".
 RUN arch=${TARGETARCH:-amd64} \
+    && case "${arch}" in \
+        amd64) rustfs_arch=x86_64 ;; \
+        arm64) rustfs_arch=aarch64 ;; \
+        *) echo "unsupported architecture ${arch}" >&2; exit 1 ;; \
+    esac \
     && curl -fL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 60 --max-time 600 \
-        "https://dl.min.io/server/minio/release/linux-${arch}/archive/minio.RELEASE.${MINIO_SERVER_VERSION}" -o /minio \
+        "https://github.com/rustfs/rustfs/releases/download/${RUSTFS_VERSION}/rustfs-linux-${rustfs_arch}-musl-v${RUSTFS_VERSION}.zip" -o /tmp/rustfs.zip \
+    && unzip -q /tmp/rustfs.zip rustfs -d / \
+    && rm /tmp/rustfs.zip \
     && curl -fL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 60 --max-time 600 \
-        "https://dl.min.io/client/mc/release/linux-${arch}/archive/mc.RELEASE.${MINIO_CLIENT_VERSION}" -o /mc \
-    && chmod +x /mc /minio
+        "https://dl.min.io/client/mc/release/linux-${arch}/archive/mc.RELEASE.${MC_VERSION}" -o /mc \
+    && chmod +x /mc /rustfs
 
 # Pre-bundle the AIStor (licensed MinIO) binaries so AIStor jobs do not each
 # re-fetch them from dl.min.io at runtime: ~22 stateless AIStor jobs start at
 # once, and that per-job download was a thundering herd on the external endpoint
-# that throttled/stalled the fetch. setup_minio.sh copies these into place instead
-# of downloading when present (community jobs keep using the /minio above).
+# that throttled/stalled the fetch. AIStor jobs copy these into place instead of
+# downloading (community jobs use the /rustfs above).
 #
 # Pin explicit versions and fetch the versioned RELEASE archives rather than the
 # moving `edge` channel: an unpinned URL makes clickhouse/stateless-test
 # non-reproducible - rebuilding the same source could silently change the AIStor
-# version under CI with no Dockerfile diff. Keep AISTOR_SERVER_VERSION /
-# AISTOR_CLIENT_VERSION in sync with the minio_server_version / minio_client_version
-# defaults in setup_minio.sh, which fetches these same RELEASE archives for
-# non-docker runs.
+# version under CI with no Dockerfile diff.
 #
 # Use -f so a failed fetch fails the build rather than shipping a truncated binary,
 # and retry with backoff so a transient dl.min.io throttle during the concurrent
@@ -126,10 +133,11 @@ RUN arch=${TARGETARCH:-amd64} \
         "https://dl.min.io/aistor/mc/release/linux-${arch}/archive/mc.RELEASE.${AISTOR_CLIENT_VERSION}" -o /opt/aistor/mc \
     && chmod +x /opt/aistor/minio /opt/aistor/mc
 
+# root credentials for the AIStor bundle above
 ENV MINIO_ROOT_USER="clickhouse"
 ENV MINIO_ROOT_PASSWORD="clickhouse"
 
-# for minio to work without root
+# for the object storage setup (~/.aws credentials) to work without root
 RUN chmod 777 /home
 ENV HOME="/home"
 

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -835,7 +835,7 @@ def main():
 
         # Reasons recorded by the setup closure that must reach the persisted
         # Result.info (CIDB test_context_raw) even when setup ultimately
-        # succeeds - e.g. a non-fatal minio log-table/restart failure that would
+        # succeeds - e.g. a non-fatal rustfs log-table/restart failure that would
         # otherwise be invisible in CIDB (only visible as a report-page warning).
         setup_notes = []
 
@@ -844,10 +844,10 @@ def main():
             # Result.info (hence CIDB test_context_raw) only when it returns a
             # failing value. Print a concise "SETUP FAILURE: <sub-step>" marker
             # at each failure point so the opaque "Start ClickHouse Server"
-            # umbrella can be split into measurable sub-causes (minio /
+            # umbrella can be split into measurable sub-causes (rustfs /
             # wait_ready / kafka / stateful) instead of one bucket.
-            if not (CH.start_minio(test_type="stateless") and CH.start_azurite()):
-                print("SETUP FAILURE: minio/azurite did not start")
+            if not (CH.start_rustfs(test_type="stateless") and CH.start_azurite()):
+                print("SETUP FAILURE: rustfs/azurite did not start")
                 return False
             if not CH.start():
                 print("SETUP FAILURE: clickhouse-server process did not start")
@@ -907,7 +907,7 @@ def main():
                 command=start,
             )
         )
-        # Surface non-fatal setup notes (e.g. minio) into the persisted Result
+        # Surface non-fatal setup notes (e.g. rustfs) into the persisted Result
         # so they are queryable in CIDB test_context_raw even on the success path.
         for note in setup_notes:
             results[-1].set_info(note)
@@ -1013,9 +1013,9 @@ def main():
                     # `cp` over a running ELF fails with `Text file busy`,
                     # and `strict=True` ensures a failed switch is not ignored.
                     # Use `stop_server` rather than `terminate` so the auxiliary
-                    # services (Kafka/Redpanda, MinIO and its webhooks) started
+                    # services (Kafka/Redpanda, RustFS) started
                     # in the outer setup keep running for the next build type;
-                    # `terminate` would tear them down, making Kafka/MinIO tests
+                    # `terminate` would tear them down, making Kafka/RustFS tests
                     # spuriously "reproduce" a bug under later build types.
                     # `stop_server` does not guarantee that every descendant
                     # process (transient `clickhouse-client` invocations, stray
@@ -1084,7 +1084,7 @@ def main():
                     # the environment built once in the START stage is gone: for
                     # stateful suites, reload the stateful data and the
                     # `system.zookeeper` config. Auxiliary services
-                    # (Kafka/Redpanda, MinIO) keep running across `stop_server`,
+                    # (Kafka/Redpanda, RustFS) keep running across `stop_server`,
                     # so only the server-side state has to be rebuilt. Without
                     # this a stateful changed test fails only because
                     # `test.hits`/`datasets`/the auxiliary ZooKeeper row

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -40,7 +40,7 @@ CLICKHOUSE_CI_LOGS_USER = "ci"
 
 
 class ClickHouseProc:
-    MINIO_LOG = f"{temp_dir}/minio.log"
+    RUSTFS_LOG = f"{temp_dir}/rustfs.log"
     AZURITE_LOG = f"{temp_dir}/azurite.log"
     KAFKA_LOG = f"{temp_dir}/kafka.log"
     LOGS_SAVER_CLIENT_OPTIONS = "--max_memory_usage 10G --max_threads 1 --max_rows_to_read=0 --max_result_rows 0 --max_result_bytes 0 --max_bytes_to_read 0 --max_execution_time 0 --max_execution_time_leaf 0 --max_estimated_execution_time 0"
@@ -111,7 +111,7 @@ class ClickHouseProc:
         self.proc_2 = None
         self.pid = 0
         int(Utils.cpu_count() / 2)
-        self.minio_proc = None
+        self.rustfs_proc = None
         self.azurite_proc = None
         self.kafka_proc = None
         # The failing sub-command + its ClickHouse error tail from
@@ -157,37 +157,36 @@ class ClickHouseProc:
 </clickhouse>
 """)
 
-    def start_minio(self, test_type):
+    def start_rustfs(self, test_type):
         os.environ["TEMP_DIR"] = f"{Utils.cwd()}/ci/tmp"
         command = [
-            "./ci/jobs/scripts/functional_tests/setup_minio.sh",
+            "./ci/jobs/scripts/functional_tests/setup_rustfs.sh",
             test_type,
             "./tests",
         ]
-        with open(self.MINIO_LOG, "w") as log_file:
-            self.minio_proc = subprocess.Popen(
+        with open(self.RUSTFS_LOG, "w") as log_file:
+            self.rustfs_proc = subprocess.Popen(
                 command, stdout=log_file, stderr=subprocess.STDOUT
             )
-        print(f"Started setup_minio.sh asynchronously with PID {self.minio_proc.pid}")
+        print(f"Started setup_rustfs.sh asynchronously with PID {self.rustfs_proc.pid}")
 
-        # Wait for setup_minio.sh to fully exit, not just for the bucket to be
+        # Wait for setup_rustfs.sh to fully exit, not just for the bucket to be
         # listable: the server's S3 disks authenticate at startup and need the
-        # whole user/policy/ACL setup in place. The minio server is nohup'd and
+        # whole user/policy/ACL setup in place. The rustfs server is nohup'd and
         # outlives the script, so waiting on the script is safe. Its internal
         # waits are bounded (wait_for_it caps at 60s), so pad the timeout.
         try:
-            returncode = self.minio_proc.wait(timeout=120)
+            returncode = self.rustfs_proc.wait(timeout=120)
         except subprocess.TimeoutExpired:
-            print("Failed to start minio: setup_minio.sh did not finish in time")
-            self.minio_proc.kill()
+            print("Failed to start rustfs: setup_rustfs.sh did not finish in time")
+            self.rustfs_proc.kill()
             return False
         if returncode != 0:
-            print(f"setup_minio.sh exited with code {returncode}")
+            print(f"setup_rustfs.sh exited with code {returncode}")
             return False
 
-        # wait_for_it can exit 0 even if minio is down, so confirm the bucket.
-        if not Shell.check("/mc ls clickminio/test", verbose=False, retries=3):
-            print("Failed to start minio: bucket clickminio/test not reachable")
+        if not Shell.check("/mc ls clickrustfs/test", verbose=False, retries=3):
+            print("Failed to start rustfs: bucket clickrustfs/test not reachable")
             return False
         return True
 
@@ -749,10 +748,10 @@ clickhouse-client --query "SELECT count() FROM test.visits"
         """Gracefully stop only the ClickHouse server processes.
 
         Unlike `terminate`, this leaves the auxiliary services (Redpanda/Kafka,
-        MinIO) running. It is used between bugfix-validation iterations so the
+        RustFS) running. It is used between bugfix-validation iterations so the
         server binary can be swapped and restarted without tearing down the
         rest of the test environment: otherwise a changed test relying on
-        Kafka or MinIO would pass under the first build type and spuriously
+        Kafka or RustFS would pass under the first build type and spuriously
         "reproduce" a bug under the next one.
         """
         print("Stop ClickHouse processes")
@@ -818,8 +817,8 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                 res += self._collect_core_dumps()
                 res += self._collect_diagnostic_reports()
                 res += self._get_logs_archive_coordination()
-                if Path(self.MINIO_LOG).exists():
-                    res.append(self.MINIO_LOG)
+                if Path(self.RUSTFS_LOG).exists():
+                    res.append(self.RUSTFS_LOG)
                 if Path(self.AZURITE_LOG).exists():
                     res.append(self.AZURITE_LOG)
                 if Path(self.KAFKA_LOG).exists():
@@ -1425,10 +1424,10 @@ if __name__ == "__main__":
                 res = ch.stop_log_exports()
             else:
                 res = True
-        elif command == "start_minio":
+        elif command == "start_rustfs":
             param = sys.argv[2]
             assert param in ["stateless"]
-            res = ch.start_minio(param)
+            res = ch.start_rustfs(param)
         elif command == "start_azurite":
             res = ch.start_azurite()
         else:

--- a/ci/jobs/scripts/functional_tests/setup_rustfs.sh
+++ b/ci/jobs/scripts/functional_tests/setup_rustfs.sh
@@ -2,14 +2,14 @@
 
 set -euxf -o pipefail
 
-export MINIO_ROOT_USER=${MINIO_ROOT_USER:-clickhouse}
-export MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-clickhouse}
+export RUSTFS_ACCESS_KEY=${RUSTFS_ACCESS_KEY:-clickhouse}
+export RUSTFS_SECRET_KEY=${RUSTFS_SECRET_KEY:-clickhouse}
 TEST_DIR=${2:-/repo/tests/}
 
 if [ -d "$TEMP_DIR" ]; then
   TEST_DIR=$(readlink -f $TEST_DIR)
   cd "$TEMP_DIR"
-  # add / for minio mc in docker
+  # add / for rustfs and mc in docker
   PATH="/:.:$PATH"
 fi
 
@@ -64,42 +64,49 @@ find_os() {
   echo "${os}"
 }
 
-download_minio() {
+download_binaries() {
   local os
-  local arch
-  local minio_server_version=${MINIO_SERVER_VERSION:-2026-03-20T23-11-32Z}
-  local minio_client_version=${MINIO_CLIENT_VERSION:-2026-03-12T04-18-55Z}
+  local rustfs_version=${RUSTFS_VERSION:-1.0.0-beta.12}
+  local mc_version=${MC_VERSION:-2025-05-21T01-59-54Z}
 
   os=$(find_os)
-  arch=$(find_arch)
-  wget "https://dl.min.io/aistor/minio/release/${os}-${arch}/archive/minio.RELEASE.${minio_server_version}" -O ./minio
-  wget "https://dl.min.io/aistor/mc/release/${os}-${arch}/archive/mc.RELEASE.${minio_client_version}" -O ./mc
-  chmod +x ./mc ./minio
+  # the musl build is static-pie and runs on any libc
+  wget "https://github.com/rustfs/rustfs/releases/download/${rustfs_version}/rustfs-${os}-$(uname -m)-musl-v${rustfs_version}.zip" -O ./rustfs.zip
+  unzip -o ./rustfs.zip rustfs
+  rm ./rustfs.zip
+  wget "https://dl.min.io/client/mc/release/${os}-$(find_arch)/archive/mc.RELEASE.${mc_version}" -O ./mc
+  chmod +x ./mc ./rustfs
 }
 
-start_minio() {
+start_rustfs() {
   pwd
-  mkdir -p ./minio_data
-  minio --version
-  nohup minio server --address ":11111" ./minio_data &
+  mkdir -p ./rustfs_data
+  rustfs --version
+  # CI data is throwaway - trade durability (fsync on writes) and background
+  # scanner/heal cycles for speed
+  export RUSTFS_DURABILITY_MODE=none
+  export RUSTFS_SCANNER_SPEED=slowest
+  export RUSTFS_HEAL_AUTO_HEAL_ENABLE=false
+  export RUSTFS_CONSOLE_ENABLE=false
+  nohup rustfs server --address ":11111" ./rustfs_data &
   wait_for_it
   lsof -i :11111
 }
 
-setup_minio() {
+setup_rustfs() {
   local test_type=$1
-  echo "setup_minio(), test_type=$test_type"
-  mc alias set clickminio http://localhost:11111 clickhouse clickhouse
-  mc admin user add clickminio test testtest
-  mc admin policy attach clickminio readwrite --user=test ||:
-  mc mb --ignore-existing clickminio/test
+  echo "setup_rustfs(), test_type=$test_type"
+  mc alias set clickrustfs http://localhost:11111 "$RUSTFS_ACCESS_KEY" "$RUSTFS_SECRET_KEY"
+  mc admin user add clickrustfs test testtest
+  mc admin policy attach clickrustfs readwrite --user=test ||:
+  mc mb --ignore-existing clickrustfs/test
   if [ "$test_type" = "stateless" ]; then
-    echo "Create @test bucket in minio"
-    mc anonymous set public clickminio/test
+    echo "Make the test bucket in rustfs anonymously accessible"
+    mc anonymous set public clickrustfs/test
   fi
 }
 
-# uploads data to minio, by default after unpacking all tests
+# uploads data to rustfs, by default after unpacking all tests
 # will be in /usr/share/clickhouse-test/queries
 upload_data() {
   local query_dir=$1
@@ -107,17 +114,12 @@ upload_data() {
   local data_path=${test_path}/queries/${query_dir}/data_minio
   echo "upload_data() data_path=$data_path"
 
-  # iterating over globs will cause redundant file variable to be
-  # a path to a file, not a filename
-  # shellcheck disable=SC2045
   if [ -d "${data_path}" ]; then
-    mc cp --recursive "${data_path}"/ clickminio/test/
+    mc cp --recursive "${data_path}"/ clickrustfs/test/
   fi
 }
 
 setup_aws_credentials() {
-  local minio_root_user=${MINIO_ROOT_USER:-clickhouse}
-  local minio_root_password=${MINIO_ROOT_PASSWORD:-clickhouse}
   mkdir -p ~/.aws
   if [[ -f ~/.aws/credentials ]]; then
     if grep -q "^\[default\]" ~/.aws/credentials; then
@@ -127,8 +129,8 @@ setup_aws_credentials() {
   fi
   cat <<EOT >> ~/.aws/credentials
 [default]
-aws_access_key_id=${minio_root_user}
-aws_secret_access_key=${minio_root_password}
+aws_access_key_id=${RUSTFS_ACCESS_KEY}
+aws_secret_access_key=${RUSTFS_SECRET_KEY}
 EOT
 }
 
@@ -143,10 +145,10 @@ wait_for_it() {
   while ! curl "${params[@]}" "${url}" 2>&1 | grep AccessDenied
   do
     if [[ ${counter} == "${max_counter}" ]]; then
-      echo "failed to setup minio"
-      exit 0
+      echo "failed to setup rustfs"
+      exit 1
     fi
-    echo "trying to connect to minio"
+    echo "trying to connect to rustfs"
     sleep 1
     counter=$((counter + 1))
   done
@@ -155,12 +157,12 @@ wait_for_it() {
 main() {
   local query_dir
   query_dir=$(check_arg "$@")
-  if ! (minio --version && mc --version); then
-    download_minio
+  if ! (rustfs --version && mc --version); then
+    download_binaries
   fi
   setup_aws_credentials
-  start_minio
-  setup_minio "$1"
+  start_rustfs
+  setup_rustfs "$1"
   upload_data "${query_dir}" "$TEST_DIR"
 }
 

--- a/ci/jobs/scripts/functional_tests/setup_rustfs.sh
+++ b/ci/jobs/scripts/functional_tests/setup_rustfs.sh
@@ -66,7 +66,7 @@ find_os() {
 
 download_binaries() {
   local os
-  local rustfs_version=${RUSTFS_VERSION:-1.0.0-beta.12}
+  local rustfs_version=${RUSTFS_VERSION:-1.0.0-beta.11}
   local mc_version=${MC_VERSION:-2025-05-21T01-59-54Z}
 
   os=$(find_os)

--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -47,10 +47,10 @@ export ZOOKEEPER_FAULT_INJECTION=1
 # available for dump via clickhouse-local
 configure
 
-# run before start_minio to have valid aws creds
+# run before start_rustfs to have valid aws creds
 cd /repo && python3 /repo/ci/jobs/scripts/clickhouse_proc.py logs_export_config || echo "ERROR: Failed to create log export config"
 
-cd /repo && python3 /repo/ci/jobs/scripts/clickhouse_proc.py start_minio stateless || { echo "Failed to start minio"; exit 1; }
+cd /repo && python3 /repo/ci/jobs/scripts/clickhouse_proc.py start_rustfs stateless || { echo "Failed to start rustfs"; exit 1; }
 cd /repo && python3 /repo/ci/jobs/scripts/clickhouse_proc.py start_azurite || { echo "Failed to start azurite"; exit 1; }
 
 # Start Redpanda (Kafka-compatible broker) so that Kafka engine tests work and

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -20,7 +20,7 @@ ln -s /repo/tests/ci/get_previous_release_tag.py /usr/bin/get_previous_release_t
 source /repo/tests/docker_scripts/stress_tests.lib
 
 cd /repo && python3 /repo/ci/jobs/scripts/clickhouse_proc.py start_azurite || { echo "Failed to start azurite"; exit 1; }
-cd /repo && python3 /repo/ci/jobs/scripts/clickhouse_proc.py start_minio stateless || ( echo "Failed to start minio" && exit 1 ) # to have a proper environment
+cd /repo && python3 /repo/ci/jobs/scripts/clickhouse_proc.py start_rustfs stateless || ( echo "Failed to start rustfs" && exit 1 ) # to have a proper environment
 
 bash /repo/ci/jobs/scripts/functional_tests/setup_kafka.sh || { echo "Failed to start Kafka (Redpanda)"; exit 1; }
 

--- a/tests/queries/0_stateless/02833_url_without_path_encoding.reference
+++ b/tests/queries/0_stateless/02833_url_without_path_encoding.reference
@@ -1,2 +1,2 @@
 4
-test%2Fa.tsv
+test%2Fmissing.tsv

--- a/tests/queries/0_stateless/02833_url_without_path_encoding.sh
+++ b/tests/queries/0_stateless/02833_url_without_path_encoding.sh
@@ -7,6 +7,8 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 $CLICKHOUSE_CLIENT -q "select count() from url('http://localhost:11111/test%2Fa.tsv') settings enable_url_encoding=1"
 
-# Grep 'test%2Fa.tsv' to ensure that path wasn't encoded/decoded
-$CLICKHOUSE_CLIENT -q "select count() from url('http://localhost:11111/test%2Fa.tsv') settings enable_url_encoding=0" 2>&1 | \
- grep -o "test%2Fa.tsv" -m1 | head -n 1
+# Grep 'test%2Fmissing.tsv' in the error message to ensure that the path wasn't encoded/decoded.
+# The object must not exist: S3 servers that URL-decode the raw path (e.g. RustFS, like AWS S3)
+# would serve an existing object and return no error to grep.
+$CLICKHOUSE_CLIENT -q "select count() from url('http://localhost:11111/test%2Fmissing.tsv') settings enable_url_encoding=0" 2>&1 | \
+ grep -o "test%2Fmissing.tsv" -m1 | head -n 1

--- a/utils/auto-bisect/helpers/lib.sh
+++ b/utils/auto-bisect/helpers/lib.sh
@@ -9,10 +9,14 @@ function start_minio()
         cd $tmp_dir || exit 1
         # Check minio is run
         if ! lsof -i :"11111" > /dev/null 2>&1; then
-            rm -rf "${tmp_dir:?}"/minio_data
+            rm -rf "${tmp_dir:?}"/minio_data "${tmp_dir:?}"/rustfs_data
             echo "Setup minio"
-            # Different ClickHouse versions have setup_minio.sh in different locations
-            if [[ -f "$WORK_TREE/tests/docker_scripts/setup_minio.sh" ]]; then
+            # Different ClickHouse versions have the S3 setup script in different locations
+            if [[ -f "$WORK_TREE/ci/jobs/scripts/functional_tests/setup_rustfs.sh" ]]; then
+                file_path="$WORK_TREE/ci/jobs/scripts/functional_tests/setup_rustfs.sh"
+                export TEST_DIR=$WORK_TREE/tests
+                export TEMP_DIR=$tmp_dir
+            elif [[ -f "$WORK_TREE/tests/docker_scripts/setup_minio.sh" ]]; then
                 file_path="$WORK_TREE/tests/docker_scripts/setup_minio.sh"
             elif [[ -f "$WORK_TREE/ci/jobs/scripts/functional_tests/setup_minio.sh" ]]; then
                 file_path="$WORK_TREE/ci/jobs/scripts/functional_tests/setup_minio.sh"


### PR DESCRIPTION
_Note: sadly, but **unlikely this will be merged**, due to some setups uses MinIO and better to test on CI as well, but worth checking_

RustFS is ~20x faster. mc stays for provisioning via the MinIO admin API.

AIStor and integration tests keep MinIO.

Details:
- [MinIO **9.5sec**](https://pastila.nl/?01ed4a3c/c14543fc4b6edb8bde5adc03f13390ca#bdkhvZmWa6jtOfOHRyAx1Q==GCM)
- [rustfs **0.5sec**](https://pastila.nl/?0007c1b3/b8ce6b8310ff047b0b45e61539933fa3#ARirx1xTNWxO1wHhg+iB3g==GCM)
- [seaweedfs **0.5sec** (more production ready)](https://pastila.nl/?000ec9a4/3d1248eb43599d725fd7d550e8787342#Fz8gTWl90OhMCaoPyXR+yQ==GCM)

_Note, that **MinIO has some basic scalability** (at least last available OSS version) **issues** so even disabling `fsync` (it does not allows to do this, but I did it with `strace -qq -f -e inject=fsync,fdatasync:retval=0 -e exit_group -e signal=9 /usr/bin/minio server`) and literally nothing changed, `strace` shows some `futex` calls (even though it is not 100% accurate since `strace` itself has overhead)_

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Replace MinIO with (20x faster) RustFS in stateless CI