### PR TITLE
Fix test under parallel replicas

### DIFF
--- a/tests/queries/0_stateless/04561_ie_join_storage_join.sql
+++ b/tests/queries/0_stateless/04561_ie_join_storage_join.sql
@@ -1,4 +1,6 @@
--- Tags: no-old-analyzer
+-- Tags: no-old-analyzer, no-parallel-replicas
+-- no-parallel-replicas: the storage-join path this test is about is not taken at all, so the plan
+-- routes through `IEJoin` and both `ON` sections below join without the errors asserted here.
 
 -- A `Join` engine table on the right side keeps the storage-join path even when `ie_join`
 -- is listed first in `join_algorithm`.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The new inequality join test cannot run with parallel replicas. Fixes this CI failure https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=cf2c7af4bba7f62d15f8fc37d0329d63d74fd9b2&name_0=MasterCI&name_1=Stateless+tests+%28amd_llvm_coverage%2C+ParallelReplicas%2C+s3+storage%2C+parallel%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.993` (included in `26.8` and later)
<!-- ch-version-info:end -->