### PR TITLE
Refactor text index posting list codec into pluggable block framework

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCodec.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCodec.cpp
@@ -1,28 +1,25 @@
 #include <Storages/MergeTree/MergeTreeIndexTextPostingListCodec.h>
 #include <Storages/MergeTree/MergeTreeIndexText.h>
 #include <Storages/MergeTree/BitpackingBlockCodec.h>
+#include <Storages/MergeTree/PostingListBlockCodec.h>
 
 #include <roaring/roaring.hh>
 
 namespace DB
 {
-namespace ErrorCodes
-{
-    extern const int CORRUPTED_DATA;
-    extern const int LOGICAL_ERROR;
-}
 
 /// Normalize the requested block size to a multiple of BLOCK_SIZE.
 /// We encode/decode posting lists in fixed-size blocks, and the SIMD bit-packing
 /// implementation expects block-aligned sizes for efficient processing.
-PostingListCodecBitpackingImpl::PostingListCodecBitpackingImpl(size_t postings_list_block_size)
+SegmentedPostingListCodecImpl::SegmentedPostingListCodecImpl(size_t postings_list_block_size, IPostingListCodec::Type block_codec_type_)
     : max_rowids_in_segment((postings_list_block_size + BLOCK_SIZE - 1) & ~(BLOCK_SIZE - 1))
+    , block_codec(createPostingListBlockCodec(block_codec_type_))
 {
     compressed_data.reserve(BLOCK_SIZE);
     current_segment.reserve(BLOCK_SIZE);
 }
 
-void PostingListCodecBitpackingImpl::insert(uint32_t row_id)
+void SegmentedPostingListCodecImpl::insert(uint32_t row_id)
 {
     if (row_ids_in_current_segment == 0)
     {
@@ -53,7 +50,7 @@ void PostingListCodecBitpackingImpl::insert(uint32_t row_id)
         flushCurrentSegment();
 }
 
-void PostingListCodecBitpackingImpl::insert(std::span<uint32_t> row_ids)
+void SegmentedPostingListCodecImpl::insert(std::span<uint32_t> row_ids)
 {
     chassert(row_ids.size() == BLOCK_SIZE && row_ids_in_current_segment % BLOCK_SIZE == 0);
 
@@ -80,10 +77,13 @@ void PostingListCodecBitpackingImpl::insert(std::span<uint32_t> row_ids)
         flushCurrentSegment();
 }
 
-void PostingListCodecBitpackingImpl::decode(ReadBuffer & in, PostingList & postings)
+void SegmentedPostingListCodecImpl::decode(ReadBuffer & in, PostingList & postings)
 {
     Header header;
     header.read(in);
+
+    /// The segment header is self-describing: create the block codec it was written with.
+    block_codec = createPostingListBlockCodec(header.codec_type);
 
     prev_row_id = header.first_row_id;
 
@@ -100,17 +100,17 @@ void PostingListCodecBitpackingImpl::decode(ReadBuffer & in, PostingList & posti
     std::span<const std::byte> compressed_data_span(reinterpret_cast<const std::byte*>(compressed_data.data()), compressed_data.size());
     for (size_t i = 0; i < num_blocks; i++)
     {
-        decodeBlock(compressed_data_span, BLOCK_SIZE, prev_row_id, current_segment);
+        decodeBlock(compressed_data_span, BLOCK_SIZE);
         postings.addMany(current_segment.size(), current_segment.data());
     }
     if (tail_size)
     {
-        decodeBlock(compressed_data_span, tail_size, prev_row_id, current_segment);
+        decodeBlock(compressed_data_span, tail_size);
         postings.addMany(current_segment.size(), current_segment.data());
     }
 }
 
-void PostingListCodecBitpackingImpl::serializeTo(WriteBuffer & out, TokenPostingsInfo & info) const
+void SegmentedPostingListCodecImpl::serializeTo(WriteBuffer & out, TokenPostingsInfo & info) const
 {
     info.offsets.reserve(segment_descriptors.size());
     info.ranges.reserve(segment_descriptors.size());
@@ -122,7 +122,7 @@ void PostingListCodecBitpackingImpl::serializeTo(WriteBuffer & out, TokenPosting
         info.ranges.emplace_back(descriptor.row_id_begin, descriptor.row_id_end);
 
         Header header(descriptor.compressed_data_size, descriptor.cardinality, descriptor.row_id_begin);
-        header.write(out);
+        header.write(out, block_codec->type());
         out.write(compressed_data.data() + descriptor.compressed_data_offset, descriptor.compressed_data_size);
 
         /// Index Section: append per-block metadata after segment payload.
@@ -140,24 +140,9 @@ void PostingListCodecBitpackingImpl::serializeTo(WriteBuffer & out, TokenPosting
     }
 }
 
-namespace
+void SegmentedPostingListCodecImpl::encodeBlock(std::span<uint32_t> segment)
 {
-void writeByte(uint8_t x, std::span<char> & out)
-{
-    out[0] = static_cast<char>(x);
-    out = out.subspan(1);
-}
-
-uint8_t readByte(std::span<const std::byte> & in)
-{
-    auto v = static_cast<uint8_t>(in[0]);
-    in = in.subspan(1);
-    return v;
-}
-}
-
-void PostingListCodecBitpackingImpl::encodeBlock(std::span<uint32_t> segment)
-{
+    chassert(block_codec);
     auto & segment_descriptor = segment_descriptors.back();
     segment_descriptor.cardinality += segment.size();
     segment_descriptor.row_id_end = prev_row_id;
@@ -171,78 +156,40 @@ void PostingListCodecBitpackingImpl::encodeBlock(std::span<uint32_t> segment)
         compressed_data.size() - segment_descriptor.compressed_data_offset
     });
 
-    auto [needed_bytes_without_header, max_bits] = BitpackingBlockCodec::calculateNeededBytesAndMaxBits(segment);
-    size_t remaining_memory = compressed_data.capacity() - compressed_data.size();
-    size_t needed_bytes_with_header = needed_bytes_without_header + 1;
-    if (remaining_memory < needed_bytes_with_header)
-    {
-        size_t min_need = needed_bytes_with_header - remaining_memory;
-        compressed_data.reserve(compressed_data.size() + 2 * min_need);
-    }
-    /// Block Layout: [1byte(max_bits)][payload]
-    size_t offset = compressed_data.size();
-    compressed_data.resize(compressed_data.size() + needed_bytes_with_header);
-    std::span<char> compressed_data_span(compressed_data.data() + offset, needed_bytes_with_header);
-    writeByte(static_cast<uint8_t>(max_bits), compressed_data_span);
-    auto used_memory = BitpackingBlockCodec::encode(segment, max_bits, compressed_data_span);
-
-    if (used_memory != needed_bytes_without_header || !compressed_data_span.empty())
-    {
-        throw Exception(ErrorCodes::LOGICAL_ERROR,
-        "Bitpacking encode size mismatch: expected {} bytes payload with {} bits encoding for {} integers, "
-        "but actually used {} bytes with {} bytes remaining in buffer",
-        needed_bytes_without_header,
-        max_bits,
-        segment.size(),
-        used_memory,
-        compressed_data_span.size());
-    }
+    block_codec->encodeBlock(segment, compressed_data);
 
     segment_descriptor.compressed_data_size = compressed_data.size() - segment_descriptor.compressed_data_offset;
 }
 
-void PostingListCodecBitpackingImpl::decodeBlock(
-        std::span<const std::byte> & in, size_t count, uint32_t & prev_row_id, std::vector<uint32_t> & current_segment)
+void SegmentedPostingListCodecImpl::decodeBlock(std::span<const std::byte> & in, size_t count)
 {
     chassert(count <= BLOCK_SIZE);
-    if (in.empty())
-        throw Exception(ErrorCodes::CORRUPTED_DATA, "Corrupted data: expected at least {} bytes, but got {}", 1, in.size());
-
-    uint8_t bits = readByte(in);
-    if (bits > 32)
-        throw Exception(ErrorCodes::CORRUPTED_DATA, "Corrupted data: expected bits <= 32, but got {}", bits);
+    chassert(block_codec);
     current_segment.resize(count);
-
-    size_t required_size = BitpackingBlockCodec::bitpackingCompressedBytes(count, bits);
-    if (in.size() < required_size)
-        throw Exception(ErrorCodes::CORRUPTED_DATA, "Corrupted data: expected data size {}, but got {}", required_size, in.size());
-
-    /// Decode postings to buffer named temp.
     std::span<uint32_t> current_span(current_segment.data(), current_segment.size());
-    size_t consumed_size = BitpackingBlockCodec::decode(in, count, bits, current_span);
-    if (required_size != consumed_size)
-        throw Exception(ErrorCodes::CORRUPTED_DATA,
-        "Bitpacking decode size mismatch: expected to consume {} bytes for {} integers with {} bits, but actually consumed {} bytes",
-        required_size,
-        count,
-        bits,
-        consumed_size);
+
+    /// `in` is the remaining segment payload: a full block self-delimits, and the final tail block sees exactly
+    /// its own bytes remaining (the Index Section is not part of this buffer). We only need `in` advanced past it.
+    block_codec->decodeBlock(in, count, current_span);
 
     /// Restore the original array from the decompressed delta values.
     std::inclusive_scan(current_segment.begin(), current_segment.end(), current_segment.begin(), std::plus<uint32_t>{}, prev_row_id);
     prev_row_id = current_segment.empty() ? prev_row_id : current_segment.back();
 }
 
-void PostingListCodecBitpacking::decode(ReadBuffer & in, PostingList & postings) const
+namespace
 {
-    PostingListCodecBitpackingImpl impl;
-    impl.decode(in, postings);
-}
-
-void PostingListCodecBitpacking::encode(
-        const PostingList & postings, size_t max_rowids_in_segment, TokenPostingsInfo & info, WriteBuffer & out) const
+/// Shared block-feeding loop for both block codecs: full BLOCK_SIZE chunks via the bulk insert, the
+/// remaining tail one row id at a time, then flush. The on-disk segment/Index Section layout is identical;
+/// only `block_codec_type` selects the per-block payload format.
+void encodePostingsInBlocks(
+    const PostingList & postings,
+    size_t max_rowids_in_segment,
+    IPostingListCodec::Type block_codec_type,
+    TokenPostingsInfo & info,
+    WriteBuffer & out)
 {
-    PostingListCodecBitpackingImpl impl(max_rowids_in_segment);
+    SegmentedPostingListCodecImpl impl(max_rowids_in_segment, block_codec_type);
     std::vector<uint32_t> rowids;
     rowids.resize(postings.cardinality());
     postings.toUint32Array(rowids.data());
@@ -261,6 +208,19 @@ void PostingListCodecBitpacking::encode(
             impl.insert(rowid);
     }
     impl.encode(out, info);
+}
+}
+
+void PostingListCodecBitpacking::decode(ReadBuffer & in, PostingList & postings) const
+{
+    SegmentedPostingListCodecImpl impl;
+    impl.decode(in, postings);
+}
+
+void PostingListCodecBitpacking::encode(
+        const PostingList & postings, size_t max_rowids_in_segment, TokenPostingsInfo & info, WriteBuffer & out) const
+{
+    encodePostingsInBlocks(postings, max_rowids_in_segment, IPostingListCodec::Type::Bitpacking, info, out);
 }
 }
 

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCodec.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCodec.cpp
@@ -11,7 +11,7 @@ namespace DB
 /// Normalize the requested block size to a multiple of BLOCK_SIZE.
 /// We encode/decode posting lists in fixed-size blocks, and the SIMD bit-packing
 /// implementation expects block-aligned sizes for efficient processing.
-SegmentedPostingListCodecImpl::SegmentedPostingListCodecImpl(size_t postings_list_block_size, IPostingListCodec::Type block_codec_type_)
+SegmentedPostingListCodec::SegmentedPostingListCodec(size_t postings_list_block_size, IPostingListCodec::Type block_codec_type_)
     : max_rowids_in_segment((postings_list_block_size + BLOCK_SIZE - 1) & ~(BLOCK_SIZE - 1))
     , block_codec(createPostingListBlockCodec(block_codec_type_))
 {
@@ -19,7 +19,7 @@ SegmentedPostingListCodecImpl::SegmentedPostingListCodecImpl(size_t postings_lis
     current_segment.reserve(BLOCK_SIZE);
 }
 
-void SegmentedPostingListCodecImpl::insert(uint32_t row_id)
+void SegmentedPostingListCodec::insert(uint32_t row_id)
 {
     if (row_ids_in_current_segment == 0)
     {
@@ -50,7 +50,7 @@ void SegmentedPostingListCodecImpl::insert(uint32_t row_id)
         flushCurrentSegment();
 }
 
-void SegmentedPostingListCodecImpl::insert(std::span<uint32_t> row_ids)
+void SegmentedPostingListCodec::insert(std::span<uint32_t> row_ids)
 {
     chassert(row_ids.size() == BLOCK_SIZE && row_ids_in_current_segment % BLOCK_SIZE == 0);
 
@@ -77,7 +77,7 @@ void SegmentedPostingListCodecImpl::insert(std::span<uint32_t> row_ids)
         flushCurrentSegment();
 }
 
-void SegmentedPostingListCodecImpl::decode(ReadBuffer & in, PostingList & postings)
+void SegmentedPostingListCodec::decode(ReadBuffer & in, PostingList & postings)
 {
     Header header;
     header.read(in);
@@ -110,7 +110,7 @@ void SegmentedPostingListCodecImpl::decode(ReadBuffer & in, PostingList & postin
     }
 }
 
-void SegmentedPostingListCodecImpl::serializeTo(WriteBuffer & out, TokenPostingsInfo & info) const
+void SegmentedPostingListCodec::serializeTo(WriteBuffer & out, TokenPostingsInfo & info) const
 {
     info.offsets.reserve(segment_descriptors.size());
     info.ranges.reserve(segment_descriptors.size());
@@ -140,7 +140,7 @@ void SegmentedPostingListCodecImpl::serializeTo(WriteBuffer & out, TokenPostings
     }
 }
 
-void SegmentedPostingListCodecImpl::encodeBlock(std::span<uint32_t> segment)
+void SegmentedPostingListCodec::encodeBlock(std::span<uint32_t> segment)
 {
     chassert(block_codec);
     auto & segment_descriptor = segment_descriptors.back();
@@ -161,7 +161,7 @@ void SegmentedPostingListCodecImpl::encodeBlock(std::span<uint32_t> segment)
     segment_descriptor.compressed_data_size = compressed_data.size() - segment_descriptor.compressed_data_offset;
 }
 
-void SegmentedPostingListCodecImpl::decodeBlock(std::span<const std::byte> & in, size_t count)
+void SegmentedPostingListCodec::decodeBlock(std::span<const std::byte> & in, size_t count)
 {
     chassert(count <= BLOCK_SIZE);
     chassert(block_codec);
@@ -179,9 +179,10 @@ void SegmentedPostingListCodecImpl::decodeBlock(std::span<const std::byte> & in,
 
 namespace
 {
-/// Shared block-feeding loop for both block codecs: full BLOCK_SIZE chunks via the bulk insert, the
-/// remaining tail one row id at a time, then flush. The on-disk segment/Index Section layout is identical;
-/// only `block_codec_type` selects the per-block payload format.
+
+/// Shared block-feeding loop for all block codecs: full BLOCK_SIZE chunks via the bulk insert,
+/// the remaining tail one row id at a time, then flush.
+/// The on-disk segment/Index Section layout is identical; only `block_codec_type` selects the per-block payload format.
 void encodePostingsInBlocks(
     const PostingList & postings,
     size_t max_rowids_in_segment,
@@ -189,7 +190,7 @@ void encodePostingsInBlocks(
     TokenPostingsInfo & info,
     WriteBuffer & out)
 {
-    SegmentedPostingListCodecImpl impl(max_rowids_in_segment, block_codec_type);
+    SegmentedPostingListCodec impl(max_rowids_in_segment, block_codec_type);
     std::vector<uint32_t> rowids;
     rowids.resize(postings.cardinality());
     postings.toUint32Array(rowids.data());
@@ -209,11 +210,12 @@ void encodePostingsInBlocks(
     }
     impl.encode(out, info);
 }
+
 }
 
 void PostingListCodecBitpacking::decode(ReadBuffer & in, PostingList & postings) const
 {
-    SegmentedPostingListCodecImpl impl;
+    SegmentedPostingListCodec impl;
     impl.decode(in, postings);
 }
 
@@ -222,5 +224,6 @@ void PostingListCodecBitpacking::encode(
 {
     encodePostingsInBlocks(postings, max_rowids_in_segment, IPostingListCodec::Type::Bitpacking, info, out);
 }
+
 }
 

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCodec.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCodec.h
@@ -5,6 +5,9 @@
 #include <IO/ReadHelpers.h>
 #include <IO/WriteBuffer.h>
 #include <Storages/MergeTree/IPostingListCodec.h>
+#include <Storages/MergeTree/PostingListBlockCodec.h>
+
+#include <memory>
 
 namespace DB
 {
@@ -18,16 +21,17 @@ namespace ErrorCodes
     extern const int CORRUPTED_DATA;
 }
 
-/// A codec for a postings list stored in a compact block-compressed format.
+/// Segment + block + delta framework for serializing a posting list in a compact block-compressed format.
 ///
-/// Values are first delta-compressed then bigpacked, each within fixed-size blocks (physical chunks, controlled by BLOCK_SIZE).
-/// Each compressed block is stored as: [1 byte: bits-width][payload].
+/// Values are delta-compressed, then each fixed-size block (physical chunk, controlled by BLOCK_SIZE) is encoded
+/// by a per-block payload codec (IPostingListBlockCodec — currently bitpacking). The block payload is the only
+/// codec-specific part; the segment / block / Index Section layout below is shared by all block codecs.
 ///
 /// Posting lists are additionally split into "segments" (logical chunks, controlled by postings_list_block_size)
 /// to simplify metadata and to support multiple ranges per token (min/max row id per segment).
 ///
 /// Assumes that input row ids are strictly increasing.
-class PostingListCodecBitpackingImpl
+class SegmentedPostingListCodecImpl
 {
     /// Header written at the beginning of each segment before the payload.
     struct Header
@@ -41,10 +45,9 @@ class PostingListCodecBitpackingImpl
         {
         }
 
-        void write(WriteBuffer & out) const
+        void write(WriteBuffer & out, IPostingListCodec::Type codec_type_) const
         {
-            /// At the moment, bitpacking is the only supported codec, could add more codecs in future
-            writeVarUInt(static_cast<uint8_t>(IPostingListCodec::Type::Bitpacking), out);
+            writeVarUInt(static_cast<uint8_t>(codec_type_), out);
             writeVarUInt(payload_bytes, out);
             writeVarUInt(cardinality, out);
             writeVarUInt(first_row_id, out);
@@ -56,6 +59,7 @@ class PostingListCodecBitpackingImpl
             readVarUInt(v, in);
             if (v != static_cast<uint8_t>(IPostingListCodec::Type::Bitpacking))
                 throw Exception(ErrorCodes::CORRUPTED_DATA, "Corrupted data: expected codec type Bitpacking, got {}", v);
+            codec_type = static_cast<IPostingListCodec::Type>(v);
 
             readVarUInt(v, in);
             payload_bytes = static_cast<uint64_t>(v);
@@ -67,6 +71,8 @@ class PostingListCodecBitpackingImpl
             first_row_id = static_cast<uint32_t>(v);
         }
 
+        /// Block codec used for this segment's payload. Filled by read.
+        IPostingListCodec::Type codec_type = IPostingListCodec::Type::Bitpacking;
         /// Number of compressed bytes (per segment) following this header
         uint64_t payload_bytes = 0;
         /// Number of postings (row ids) in this segment
@@ -103,8 +109,9 @@ class PostingListCodecBitpackingImpl
     };
 
 public:
-    PostingListCodecBitpackingImpl() = default;
-    explicit PostingListCodecBitpackingImpl(size_t postings_list_block_size);
+    SegmentedPostingListCodecImpl() = default;
+    explicit SegmentedPostingListCodecImpl(
+        size_t postings_list_block_size, IPostingListCodec::Type block_codec_type_ = IPostingListCodec::Type::Bitpacking);
 
     /// Add a single increasing row id.
     ///
@@ -192,11 +199,12 @@ private:
 
     /// Decode one compressed block into `current_segment` and reconstruct absolute row ids.
     ///
-    /// - Reads bits-width byte
-    /// - Codec::decode fills `current_segment` with delta values
+    /// - Delegates the block payload to `block_codec` (bitpacking reads a bits-width byte), which fills
+    ///   `current_segment` with delta values
     /// - inclusive_scan converts deltas -> row ids using `prev_row_id` as initial prefix
     /// - Updates prev_row_id to the last decoded row id
-    static void decodeBlock(std::span<const std::byte> & in, size_t count, uint32_t & prev_row_id, std::vector<uint32_t> & current_segment);
+    /// Decodes into the `current_segment` member and advances `prev_row_id`.
+    void decodeBlock(std::span<const std::byte> & in, size_t count);
 
     /// All segments
     std::string compressed_data;
@@ -214,6 +222,9 @@ private:
     size_t row_ids_in_current_segment = 0;
     /// Segment size
     const size_t max_rowids_in_segment = 1024 * 1024;
+    /// Per-block payload codec (bitpacking). On encode it is fixed by the constructor; on decode it
+    /// is created from the segment header. One instance is reused across all blocks of a single encode/decode call.
+    std::unique_ptr<IPostingListBlockCodec> block_codec;
 };
 
 /// Codec for serializing/deserializing a postings list to/from a binary stream.

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCodec.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCodec.h
@@ -31,7 +31,7 @@ namespace ErrorCodes
 /// to simplify metadata and to support multiple ranges per token (min/max row id per segment).
 ///
 /// Assumes that input row ids are strictly increasing.
-class SegmentedPostingListCodecImpl
+class SegmentedPostingListCodec
 {
     /// Header written at the beginning of each segment before the payload.
     struct Header
@@ -109,9 +109,8 @@ class SegmentedPostingListCodecImpl
     };
 
 public:
-    SegmentedPostingListCodecImpl() = default;
-    explicit SegmentedPostingListCodecImpl(
-        size_t postings_list_block_size, IPostingListCodec::Type block_codec_type_ = IPostingListCodec::Type::Bitpacking);
+    SegmentedPostingListCodec() = default;
+    explicit SegmentedPostingListCodec(size_t postings_list_block_size, IPostingListCodec::Type block_codec_type_);
 
     /// Add a single increasing row id.
     ///

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -3,12 +3,14 @@
 #include <Storages/MergeTree/TextIndexCache.h>
 #include <Storages/MergeTree/MergeTreeReaderStream.h>
 #include <Storages/MergeTree/MergeTreeIndexTextPostingListCodec.h>
+#include <Storages/MergeTree/PostingListBlockCodec.h>
 #include <Formats/MarkInCompressedFile.h>
 #include <Common/ProfileEvents.h>
 #include <Columns/ColumnsCommon.h>
 #include <Columns/ColumnsNumber.h>
 #include <IO/ReadHelpers.h>
 #include <Common/TargetSpecific.h>
+#include <config.h>
 #include <algorithm>
 #include <cstring>
 #include <numeric>
@@ -182,6 +184,8 @@ PostingListSegment PostingListCursor::buildPostingSegment(size_t segment_idx)
         throw Exception(ErrorCodes::CORRUPTED_DATA,
             "Corrupted data in lazy cursor: expected codec type Bitpacking, got {}", codec_type);
 
+    segment.codec_type = static_cast<IPostingListCodec::Type>(codec_type);
+
     UInt64 payload_bytes = 0;
     readVarUInt(payload_bytes, *data_buffer);
     UInt64 seg_cardinality = 0;
@@ -210,10 +214,16 @@ PostingListSegment PostingListCursor::buildPostingSegment(size_t segment_idx)
             segment.doc_count, range_span, segment_range.begin, segment_range.end);
     }
 
-    /// Cap `payload_bytes` before resizing so corrupted metadata can't force a huge allocation. Per-block
-    /// upper bound: `1` (bits header) + `4 * BLOCK_SIZE` (bit-pure max at `bits = 32`) + 16 (SIMD alignment).
+    /// Create the per-block codec for this segment's codec type now and reuse it for decoding (see
+    /// `decodeBlock`). It owns the codec-specific per-block worst-case size, so the cursor can bound
+    /// `payload_bytes` against corrupted metadata without naming a concrete codec.
+    if (!block_codec || block_codec->type() != segment.codec_type)
+        block_codec = createPostingListBlockCodec(segment.codec_type);
+
+    /// Cap `payload_bytes` before resizing so corrupted metadata can't force a huge allocation.
     const UInt64 max_blocks_count = (static_cast<UInt64>(segment.doc_count) + BLOCK_SIZE - 1) / BLOCK_SIZE;
-    const UInt64 max_payload_bytes = max_blocks_count * (1 + sizeof(UInt32) * BLOCK_SIZE + 16);
+    const UInt64 per_block_cap = block_codec->maxBlockBytes();
+    const UInt64 max_payload_bytes = max_blocks_count * per_block_cap;
 
     if (payload_bytes > max_payload_bytes)
     {
@@ -337,28 +347,26 @@ void PostingListCursor::decodeBlock(size_t block_idx)
         reinterpret_cast<const std::byte *>(segment.payload_buffer.data() + payload_offset),
         block_size);
 
-    /// Decode: [1 byte bits][bitpacked payload]
     if (block_data.empty())
         throw Exception(ErrorCodes::CORRUPTED_DATA, "Corrupted data: empty block at index {}", block_idx);
 
-    uint8_t bits = static_cast<uint8_t>(block_data[0]);
-    block_data = block_data.subspan(1);
-
-    if (bits > 32)
-        throw Exception(ErrorCodes::CORRUPTED_DATA, "Corrupted data: expected bits <= 32, but got {}", bits);
-
-    /// Validate the budget before decode so corrupted metadata can't drive the SIMD intrinsic past the segment payload.
-    const size_t required_bytes = BitpackingBlockCodec::bitpackingCompressedBytes(count, bits);
-    if (required_bytes > block_data.size())
-    {
-        throw Exception(ErrorCodes::CORRUPTED_DATA,
-            "Corrupted data in lazy posting list cursor: block {} requires {} packed bytes for "
-            "count={} bits={}, but only {} bytes remain in payload",
-            block_idx, required_bytes, count, bits, block_data.size());
-    }
-
     std::span<uint32_t> out_span(decoded_values, count);
-    BitpackingBlockCodec::decode(block_data, count, bits, out_span);
+
+    /// Lazily create the per-block payload codec for this segment's codec type and reuse it across blocks.
+    /// A posting list is written with a single codec, so this is effectively created once per cursor.
+    if (!block_codec || block_codec->type() != segment.codec_type)
+        block_codec = createPostingListBlockCodec(segment.codec_type);
+
+    /// The block span comes from the Index Section offsets and must be consumed in full: a bitpacking block is
+    /// [1 byte bits][bitpacked payload]; a FastPFOR block is a self-delimited payload. Comparing consumed bytes
+    /// against the exact span guards corrupted metadata from driving a decode past the block boundary.
+    const size_t expected_bytes = block_data.size();
+    const size_t consumed_bytes = block_codec->decodeBlock(block_data, count, out_span);
+    if (consumed_bytes != expected_bytes)
+        throw Exception(ErrorCodes::CORRUPTED_DATA,
+            "Corrupted data in lazy posting list cursor: block {} consumed {} bytes but its "
+            "Index Section span is {} bytes",
+            block_idx, consumed_bytes, expected_bytes);
 
     /// Restore absolute row ids from deltas directly in decoded_values.
     std::inclusive_scan(decoded_values, decoded_values + count, decoded_values, std::plus<uint32_t>{}, last_decoded_doc_id);

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -357,11 +357,10 @@ void PostingListCursor::decodeBlock(size_t block_idx)
     if (!block_codec || block_codec->type() != segment.codec_type)
         block_codec = createPostingListBlockCodec(segment.codec_type);
 
-    /// The block span comes from the Index Section offsets and must be consumed in full: a bitpacking block is
-    /// [1 byte bits][bitpacked payload]; a FastPFOR block is a self-delimited payload. Comparing consumed bytes
-    /// against the exact span guards corrupted metadata from driving a decode past the block boundary.
+    /// The block span comes from the Index Section offsets and must be consumed in full.
     const size_t expected_bytes = block_data.size();
     const size_t consumed_bytes = block_codec->decodeBlock(block_data, count, out_span);
+
     if (consumed_bytes != expected_bytes)
         throw Exception(ErrorCodes::CORRUPTED_DATA,
             "Corrupted data in lazy posting list cursor: block {} consumed {} bytes but its "

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
@@ -4,6 +4,7 @@
 #include <base/defines.h>
 #include <base/types.h>
 #include <Storages/MergeTree/BitpackingBlockCodec.h>
+#include <Storages/MergeTree/PostingListBlockCodec.h>
 #include <Storages/MergeTree/PostingListSegment.h>
 #include <memory>
 #include <vector>
@@ -127,6 +128,10 @@ private:
     /// into `shared_values`, avoiding a copy and supporting arrays larger than BLOCK_SIZE.
     alignas(16) uint32_t decoded_values[BLOCK_SIZE]{};
     const uint32_t * decoded_values_ptr = decoded_values;
+
+    /// Per-block payload codec for the current segment's codec type; lazily created and reused across all
+    /// blocks of this cursor (a posting list is written with a single codec).
+    std::unique_ptr<IPostingListBlockCodec> block_codec;
 
     size_t decoded_count = 0;    /// Number of valid entries reachable via `decoded_values_ptr`.
     size_t index = 0;            /// Read position within `decoded_values_ptr`.

--- a/src/Storages/MergeTree/PostingListBlockCodec.cpp
+++ b/src/Storages/MergeTree/PostingListBlockCodec.cpp
@@ -1,0 +1,114 @@
+#include <Storages/MergeTree/PostingListBlockCodec.h>
+
+#include <Storages/MergeTree/BitpackingBlockCodec.h>
+#include <Common/Exception.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int CORRUPTED_DATA;
+    extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+    void writeByte(uint8_t x, std::span<char> & out)
+    {
+        out[0] = static_cast<char>(x);
+        out = out.subspan(1);
+    }
+
+    uint8_t readByte(std::span<const std::byte> & in)
+    {
+        auto v = static_cast<uint8_t>(in[0]);
+        in = in.subspan(1);
+        return v;
+    }
+
+    /// [1 byte bits][bitpacked payload]. The bits byte selects the per-block bit width; the payload is the
+    /// SIMD/portable bit-packed stream produced by BitpackingBlockCodec.
+    class BitpackingPostingListBlockCodec : public IPostingListBlockCodec
+    {
+    public:
+        size_t encodeBlock(std::span<uint32_t> deltas, std::string & out) override
+        {
+            auto [needed_bytes_without_header, max_bits] = BitpackingBlockCodec::calculateNeededBytesAndMaxBits(deltas);
+            size_t remaining_memory = out.capacity() - out.size();
+            size_t needed_bytes_with_header = needed_bytes_without_header + 1;
+            if (remaining_memory < needed_bytes_with_header)
+            {
+                size_t min_need = needed_bytes_with_header - remaining_memory;
+                out.reserve(out.size() + 2 * min_need);
+            }
+            /// Block Layout: [1byte(max_bits)][payload]
+            size_t offset = out.size();
+            out.resize(out.size() + needed_bytes_with_header);
+            std::span<char> out_span(out.data() + offset, needed_bytes_with_header);
+            writeByte(static_cast<uint8_t>(max_bits), out_span);
+            auto used_memory = BitpackingBlockCodec::encode(deltas, max_bits, out_span);
+
+            if (used_memory != needed_bytes_without_header || !out_span.empty())
+            {
+                throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Bitpacking encode size mismatch: expected {} bytes payload with {} bits encoding for {} integers, "
+                "but actually used {} bytes with {} bytes remaining in buffer",
+                needed_bytes_without_header,
+                max_bits,
+                deltas.size(),
+                used_memory,
+                out_span.size());
+            }
+
+            return needed_bytes_with_header;
+        }
+
+        size_t decodeBlock(std::span<const std::byte> & in, size_t count, std::span<uint32_t> out) override
+        {
+            if (in.empty())
+                throw Exception(ErrorCodes::CORRUPTED_DATA, "Corrupted data: expected at least {} bytes, but got {}", 1, in.size());
+
+            uint8_t bits = readByte(in);
+            if (bits > 32)
+                throw Exception(ErrorCodes::CORRUPTED_DATA, "Corrupted data: expected bits <= 32, but got {}", bits);
+
+            size_t required_size = BitpackingBlockCodec::bitpackingCompressedBytes(count, bits);
+            if (in.size() < required_size)
+                throw Exception(ErrorCodes::CORRUPTED_DATA, "Corrupted data: expected data size {}, but got {}", required_size, in.size());
+
+            size_t consumed_size = BitpackingBlockCodec::decode(in, count, bits, out);
+            if (required_size != consumed_size)
+                throw Exception(ErrorCodes::CORRUPTED_DATA,
+                "Bitpacking decode size mismatch: expected to consume {} bytes for {} integers with {} bits, but actually consumed {} bytes",
+                required_size,
+                count,
+                bits,
+                consumed_size);
+
+            /// Total bytes consumed from `in`: the bits byte plus the bit-packed payload.
+            return 1 + consumed_size;
+        }
+
+        /// `1` (bits header) + `4 * BLOCK_SIZE` (bit-pure max at `bits = 32`) + 16 (SIMD alignment slack).
+        size_t maxBlockBytes() const override { return 1 + sizeof(uint32_t) * BLOCK_SIZE + 16; }
+
+        IPostingListCodec::Type type() const override { return IPostingListCodec::Type::Bitpacking; }
+    };
+
+}
+
+std::unique_ptr<IPostingListBlockCodec> createPostingListBlockCodec(IPostingListCodec::Type type)
+{
+    switch (type)
+    {
+        case IPostingListCodec::Type::None:
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Posting list codec 'None' has no per-block codec");
+        case IPostingListCodec::Type::Bitpacking:
+            return std::make_unique<BitpackingPostingListBlockCodec>();
+    }
+
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown posting list codec type: {}", static_cast<int>(type));
+}
+
+}

--- a/src/Storages/MergeTree/PostingListBlockCodec.cpp
+++ b/src/Storages/MergeTree/PostingListBlockCodec.cpp
@@ -35,13 +35,8 @@ namespace
         size_t encodeBlock(std::span<uint32_t> deltas, std::string & out) override
         {
             auto [needed_bytes_without_header, max_bits] = BitpackingBlockCodec::calculateNeededBytesAndMaxBits(deltas);
-            size_t remaining_memory = out.capacity() - out.size();
             size_t needed_bytes_with_header = needed_bytes_without_header + 1;
-            if (remaining_memory < needed_bytes_with_header)
-            {
-                size_t min_need = needed_bytes_with_header - remaining_memory;
-                out.reserve(out.size() + 2 * min_need);
-            }
+
             /// Block Layout: [1byte(max_bits)][payload]
             size_t offset = out.size();
             out.resize(out.size() + needed_bytes_with_header);
@@ -52,13 +47,13 @@ namespace
             if (used_memory != needed_bytes_without_header || !out_span.empty())
             {
                 throw Exception(ErrorCodes::LOGICAL_ERROR,
-                "Bitpacking encode size mismatch: expected {} bytes payload with {} bits encoding for {} integers, "
-                "but actually used {} bytes with {} bytes remaining in buffer",
-                needed_bytes_without_header,
-                max_bits,
-                deltas.size(),
-                used_memory,
-                out_span.size());
+                    "Bitpacking encode size mismatch: expected {} bytes payload with {} bits encoding for {} integers, "
+                    "but actually used {} bytes with {} bytes remaining in buffer",
+                    needed_bytes_without_header,
+                    max_bits,
+                    deltas.size(),
+                    used_memory,
+                    out_span.size());
             }
 
             return needed_bytes_with_header;

--- a/src/Storages/MergeTree/PostingListBlockCodec.h
+++ b/src/Storages/MergeTree/PostingListBlockCodec.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <Storages/MergeTree/IPostingListCodec.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+
+namespace DB
+{
+
+/// Per-block payload codec for the segmented posting-list framework (see SegmentedPostingListCodecImpl).
+///
+/// Encodes / decodes ONE block (1..BLOCK_SIZE delta values) including any codec-specific framing. The
+/// surrounding segment / Index Section layout is identical across codecs; only the per-block payload differs:
+///   - Bitpacking: [1 byte bits][bitpacked payload]
+///   - FastPFOR:   [self-delimited FastPFOR payload]
+///
+/// This header is dependency-free (no SIMD / FastPFOR headers), so it stays include-safe in builds without
+/// FastPFOR. FastPFOR availability is enforced inside FastPFORBlockCodec, which createPostingListBlockCodec
+/// constructs — on a build without FastPFOR that construction throws SUPPORT_IS_DISABLED.
+class IPostingListBlockCodec
+{
+public:
+    virtual ~IPostingListBlockCodec() = default;
+
+    /// Append one encoded block of `deltas` (1..BLOCK_SIZE values) to `out`. Returns the number of bytes appended.
+    virtual size_t encodeBlock(std::span<uint32_t> deltas, std::string & out) = 0;
+
+    /// Decode one block of `count` (1..BLOCK_SIZE) delta values from `in` into `out` (which must hold at least
+    /// `count` slots), advancing `in` past the consumed bytes. Returns the number of bytes consumed.
+    virtual size_t decodeBlock(std::span<const std::byte> & in, size_t count, std::span<uint32_t> out) = 0;
+
+    /// Upper bound on the encoded size of one block (1..BLOCK_SIZE delta values), in bytes. The lazy cursor
+    /// queries it through this interface to bound untrusted segment payload sizes before allocating, so it
+    /// never has to name a concrete codec.
+    virtual size_t maxBlockBytes() const = 0;
+
+    /// The codec type recorded in each segment header.
+    virtual IPostingListCodec::Type type() const = 0;
+};
+
+/// Creates the per-block payload codec for `type`. Throws for `None` (it has no blocks). For `FastPFOR` on a
+/// build without FastPFOR, the underlying FastPFORBlockCodec constructor throws SUPPORT_IS_DISABLED.
+std::unique_ptr<IPostingListBlockCodec> createPostingListBlockCodec(IPostingListCodec::Type type);
+
+}

--- a/src/Storages/MergeTree/PostingListBlockCodec.h
+++ b/src/Storages/MergeTree/PostingListBlockCodec.h
@@ -11,16 +11,11 @@
 namespace DB
 {
 
-/// Per-block payload codec for the segmented posting-list framework (see SegmentedPostingListCodecImpl).
+/// Per-block payload codec for the segmented posting-list framework (see SegmentedPostingListCodec).
 ///
-/// Encodes / decodes ONE block (1..BLOCK_SIZE delta values) including any codec-specific framing. The
-/// surrounding segment / Index Section layout is identical across codecs; only the per-block payload differs:
+/// Encodes / decodes ONE block (1..BLOCK_SIZE delta values) including any codec-specific framing.
+/// The surrounding segment / Index Section layout is identical across codecs; only the per-block payload differs:
 ///   - Bitpacking: [1 byte bits][bitpacked payload]
-///   - FastPFOR:   [self-delimited FastPFOR payload]
-///
-/// This header is dependency-free (no SIMD / FastPFOR headers), so it stays include-safe in builds without
-/// FastPFOR. FastPFOR availability is enforced inside FastPFORBlockCodec, which createPostingListBlockCodec
-/// constructs — on a build without FastPFOR that construction throws SUPPORT_IS_DISABLED.
 class IPostingListBlockCodec
 {
 public:
@@ -33,17 +28,14 @@ public:
     /// `count` slots), advancing `in` past the consumed bytes. Returns the number of bytes consumed.
     virtual size_t decodeBlock(std::span<const std::byte> & in, size_t count, std::span<uint32_t> out) = 0;
 
-    /// Upper bound on the encoded size of one block (1..BLOCK_SIZE delta values), in bytes. The lazy cursor
-    /// queries it through this interface to bound untrusted segment payload sizes before allocating, so it
-    /// never has to name a concrete codec.
+    /// Upper bound on the encoded size of one block (1..BLOCK_SIZE delta values), in bytes.
     virtual size_t maxBlockBytes() const = 0;
 
     /// The codec type recorded in each segment header.
     virtual IPostingListCodec::Type type() const = 0;
 };
 
-/// Creates the per-block payload codec for `type`. Throws for `None` (it has no blocks). For `FastPFOR` on a
-/// build without FastPFOR, the underlying FastPFORBlockCodec constructor throws SUPPORT_IS_DISABLED.
+/// Creates the per-block payload codec for `type`. Throws for `None` (it has no blocks).
 std::unique_ptr<IPostingListBlockCodec> createPostingListBlockCodec(IPostingListCodec::Type type);
 
 }

--- a/src/Storages/MergeTree/PostingListSegment.h
+++ b/src/Storages/MergeTree/PostingListSegment.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <base/types.h>
 #include <Common/PODArray.h>
+#include <Storages/MergeTree/IPostingListCodec.h>
 #include <cstdint>
 #include <memory>
 
@@ -27,6 +28,8 @@ struct PostingListSegment
     size_t block_count = 0;
     /// Element count of the tail block (< BLOCK_SIZE), 0 if the segment is block-aligned.
     size_t tail_size = 0;
+    /// Block codec used to compress this segment's packed blocks (Bitpacking or FastPFOR).
+    IPostingListCodec::Type codec_type = IPostingListCodec::Type::Bitpacking;
 
     size_t bytesAllocated() const
     {

--- a/src/Storages/MergeTree/PostingListSegment.h
+++ b/src/Storages/MergeTree/PostingListSegment.h
@@ -28,7 +28,7 @@ struct PostingListSegment
     size_t block_count = 0;
     /// Element count of the tail block (< BLOCK_SIZE), 0 if the segment is block-aligned.
     size_t tail_size = 0;
-    /// Block codec used to compress this segment's packed blocks (Bitpacking or FastPFOR).
+    /// Block codec used to compress this segment's packed blocks.
     IPostingListCodec::Type codec_type = IPostingListCodec::Type::Bitpacking;
 
     size_t bytesAllocated() const

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <config.h>
 
 #include <Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h>
 #include <Storages/MergeTree/MergeTreeIndexText.h>
@@ -201,10 +202,12 @@ struct MultiBlockTestData
 /// Build a multi-segment TokenPostingsInfo and data buffer for testing.
 ///
 /// @param blocks  Vector of sorted doc ID vectors, one per segment.
-///                Each segment is encoded independently using PostingListCodecBitpackingImpl.
+///                Each segment is encoded independently using SegmentedPostingListCodecImpl.
 ///
 /// Returns a MultiBlockTestData with the binary buffer, TokenPostingsInfo, and flattened doc list.
-MultiBlockTestData makeMultiBlockData(const std::vector<std::vector<uint32_t>> & blocks)
+MultiBlockTestData makeMultiBlockData(
+    const std::vector<std::vector<uint32_t>> & blocks,
+    IPostingListCodec::Type block_codec_type = IPostingListCodec::Type::Bitpacking)
 {
     MultiBlockTestData result;
     auto & info = result.info;
@@ -226,7 +229,7 @@ MultiBlockTestData makeMultiBlockData(const std::vector<std::vector<uint32_t>> &
     for (const auto & block_docs : blocks)
     {
         /// Use a segment size large enough to hold all docs in one segment.
-        PostingListCodecBitpackingImpl codec(block_docs.size() + BLOCK_SIZE);
+        SegmentedPostingListCodecImpl codec(block_docs.size() + BLOCK_SIZE, block_codec_type);
         for (auto doc : block_docs)
             codec.insert(doc);
         codec.encode(out, info);

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -202,7 +202,7 @@ struct MultiBlockTestData
 /// Build a multi-segment TokenPostingsInfo and data buffer for testing.
 ///
 /// @param blocks  Vector of sorted doc ID vectors, one per segment.
-///                Each segment is encoded independently using SegmentedPostingListCodecImpl.
+///                Each segment is encoded independently using SegmentedPostingListCodec.
 ///
 /// Returns a MultiBlockTestData with the binary buffer, TokenPostingsInfo, and flattened doc list.
 MultiBlockTestData makeMultiBlockData(
@@ -229,7 +229,7 @@ MultiBlockTestData makeMultiBlockData(
     for (const auto & block_docs : blocks)
     {
         /// Use a segment size large enough to hold all docs in one segment.
-        SegmentedPostingListCodecImpl codec(block_docs.size() + BLOCK_SIZE, block_codec_type);
+        SegmentedPostingListCodec codec(block_docs.size() + BLOCK_SIZE, block_codec_type);
         for (auto doc : block_docs)
             codec.insert(doc);
         codec.encode(out, info);


### PR DESCRIPTION
Generalize the bitpacking-only segment codec into a pluggable per-block framework (`IPostingListBlockCodec`).

Cherry picked from commit b5e8bdd32e121a11d1a774ed2f07a667033fa75f. Taken from PR #107408 to unlock future developments.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.998` (included in `26.8` and later)
<!-- ch-version-info:end -->