### PR TITLE
Allow ALTER MODIFY COLUMN to set a codec while turning an ALIAS physical

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1806,7 +1806,10 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
 
             if (command.codec)
             {
-                if (all_columns.hasAlias(column_name))
+                /// `default_kind` is what the parser set: `validate` runs before `prepare`, which back-fills it from the table.
+                const bool becomes_physical = command.default_expression
+                    && (command.default_kind == ColumnDefaultKind::Default || command.default_kind == ColumnDefaultKind::Materialized);
+                if (all_columns.hasAlias(column_name) && !becomes_physical)
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot specify codec for column type ALIAS");
                 CompressionCodecFactory::instance().validateCodecAndGetPreprocessedAST(
                     command.codec,

--- a/tests/queries/0_stateless/04819_alter_modify_column_alias_to_physical_codec.reference
+++ b/tests/queries/0_stateless/04819_alter_modify_column_alias_to_physical_codec.reference
@@ -11,3 +11,4 @@ ALIAS	JSONExtractUInt(event, \'type_uid\')
 EPHEMERAL	1	CODEC(T64, LZ4)
 EPHEMERAL	1	CODEC(T64, LZ4)
 {"type_uid":7}	7
+ALIAS	JSONExtractUInt(event, \'type_uid\')	

--- a/tests/queries/0_stateless/04819_alter_modify_column_alias_to_physical_codec.reference
+++ b/tests/queries/0_stateless/04819_alter_modify_column_alias_to_physical_codec.reference
@@ -1,0 +1,13 @@
+		CODEC(T64, LZ4)
+MATERIALIZED	JSONExtractUInt(event, \'type_uid\')	CODEC(T64, LZ4)
+MATERIALIZED	JSONExtractUInt(event, \'type_uid\')	CODEC(T64, LZ4)
+ALIAS	JSONExtractUInt(event, \'type_uid\')	
+MATERIALIZED	JSONExtractUInt(event, \'type_uid\')	CODEC(T64, LZ4)
+DEFAULT	JSONExtractUInt(event, \'type_uid\')	CODEC(T64, LZ4)
+MATERIALIZED	JSONExtractUInt(event, \'type_uid\')	CODEC(T64, LZ4)
+MATERIALIZED	JSONExtractUInt(event, \'type_uid\')	CODEC(T64, LZ4)
+ALIAS	JSONExtractUInt(event, \'type_uid\')	
+ALIAS	JSONExtractUInt(event, \'type_uid\')	
+EPHEMERAL	1	CODEC(T64, LZ4)
+EPHEMERAL	1	CODEC(T64, LZ4)
+{"type_uid":7}	7

--- a/tests/queries/0_stateless/04819_alter_modify_column_alias_to_physical_codec.sql
+++ b/tests/queries/0_stateless/04819_alter_modify_column_alias_to_physical_codec.sql
@@ -1,0 +1,124 @@
+-- Controls come first: on an unfixed binary the first witness throws and the runner stops the
+-- file, so this ordering keeps the diff self-describing.
+
+-- A column that is not an ALIAS accepts a codec.
+CREATE TABLE t_plain (event String, type_uid UInt32) ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_plain MODIFY COLUMN type_uid UInt32 CODEC(T64, LZ4);
+SELECT default_kind, default_expression, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table = 't_plain' AND name = 'type_uid';
+
+-- DEFAULT and MATERIALIZED sources already accepted the very same ALTER.
+CREATE TABLE t_default (event String, type_uid UInt32 DEFAULT JSONExtractUInt(event, 'type_uid'))
+ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_default MODIFY COLUMN type_uid UInt32 MATERIALIZED JSONExtractUInt(event, 'type_uid') CODEC(T64, LZ4);
+SELECT default_kind, default_expression, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table = 't_default' AND name = 'type_uid';
+
+CREATE TABLE t_mat (event String, type_uid UInt32 MATERIALIZED JSONExtractUInt(event, 'type_uid'))
+ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_mat MODIFY COLUMN type_uid UInt32 MATERIALIZED JSONExtractUInt(event, 'type_uid') CODEC(T64, LZ4);
+SELECT default_kind, default_expression, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table = 't_mat' AND name = 'type_uid';
+
+-- Turning a physical column into an ALIAS is fine as long as no codec is involved.
+CREATE TABLE t_mat_to_alias (event String, type_uid UInt32 MATERIALIZED JSONExtractUInt(event, 'type_uid'))
+ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_mat_to_alias MODIFY COLUMN type_uid UInt32 ALIAS JSONExtractUInt(event, 'type_uid');
+SELECT default_kind, default_expression, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table = 't_mat_to_alias' AND name = 'type_uid';
+
+-- The reported case: ALIAS -> MATERIALIZED together with a codec.
+CREATE TABLE t_alias_to_mat (event String, type_uid UInt32 ALIAS JSONExtractUInt(event, 'type_uid'))
+ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_alias_to_mat MODIFY COLUMN type_uid UInt32 MATERIALIZED JSONExtractUInt(event, 'type_uid') CODEC(T64, LZ4);
+SELECT default_kind, default_expression, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table = 't_alias_to_mat' AND name = 'type_uid';
+
+-- The same defect with DEFAULT as the target kind, which the issue does not mention.
+CREATE TABLE t_alias_to_default (event String, type_uid UInt32 ALIAS JSONExtractUInt(event, 'type_uid'))
+ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_alias_to_default MODIFY COLUMN type_uid UInt32 DEFAULT JSONExtractUInt(event, 'type_uid') CODEC(T64, LZ4);
+SELECT default_kind, default_expression, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table = 't_alias_to_default' AND name = 'type_uid';
+
+-- The type may be omitted; the column still becomes physical.
+CREATE TABLE t_alias_no_type (event String, type_uid UInt32 ALIAS JSONExtractUInt(event, 'type_uid'))
+ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_alias_no_type MODIFY COLUMN type_uid MATERIALIZED JSONExtractUInt(event, 'type_uid') CODEC(T64, LZ4);
+SELECT default_kind, default_expression, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table = 't_alias_no_type' AND name = 'type_uid';
+
+-- Same fix on a replicated table.
+CREATE TABLE t_alias_to_mat_rep (event String, type_uid UInt32 ALIAS JSONExtractUInt(event, 'type_uid'))
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/04819_alias_codec', 'r1') ORDER BY tuple();
+ALTER TABLE t_alias_to_mat_rep MODIFY COLUMN type_uid UInt32 MATERIALIZED JSONExtractUInt(event, 'type_uid') CODEC(T64, LZ4);
+SELECT default_kind, default_expression, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table = 't_alias_to_mat_rep' AND name = 'type_uid';
+
+-- The column stays an ALIAS, so the codec is still refused.
+CREATE TABLE t_alias_to_alias (event String, type_uid UInt32 ALIAS JSONExtractUInt(event, 'type_uid'))
+ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_alias_to_alias MODIFY COLUMN type_uid UInt32 ALIAS JSONExtractUInt(event, 'type_uid') CODEC(T64, LZ4); -- { serverError BAD_ARGUMENTS }
+
+-- Without a default specifier the ALIAS is preserved, so the codec is still refused.
+CREATE TABLE t_alias_no_specifier (event String, type_uid UInt32 ALIAS JSONExtractUInt(event, 'type_uid'))
+ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_alias_no_specifier MODIFY COLUMN type_uid UInt32 CODEC(T64, LZ4); -- { serverError BAD_ARGUMENTS }
+SELECT default_kind, default_expression, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table = 't_alias_no_specifier' AND name = 'type_uid';
+
+-- AUTO_INCREMENT carries no expression and also preserves the ALIAS.
+CREATE TABLE t_alias_auto_increment (event String, type_uid UInt32 ALIAS JSONExtractUInt(event, 'type_uid'))
+ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_alias_auto_increment MODIFY COLUMN type_uid UInt32 AUTO_INCREMENT CODEC(T64, LZ4); -- { serverError BAD_ARGUMENTS }
+ALTER TABLE t_alias_auto_increment MODIFY COLUMN type_uid UInt32 AUTO_INCREMENT;
+SELECT default_kind, default_expression, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table = 't_alias_auto_increment' AND name = 'type_uid';
+
+-- EPHEMERAL is not physical, so a codec is still refused for an ALIAS column.
+CREATE TABLE t_alias_to_ephemeral (event String, type_uid UInt32 ALIAS JSONExtractUInt(event, 'type_uid'))
+ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_alias_to_ephemeral MODIFY COLUMN type_uid UInt32 EPHEMERAL 1 CODEC(T64, LZ4); -- { serverError BAD_ARGUMENTS }
+
+-- A codec on an EPHEMERAL column of a non-ALIAS source keeps being accepted, in both directions.
+CREATE TABLE t_plain_to_ephemeral (event String, type_uid UInt32) ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_plain_to_ephemeral MODIFY COLUMN type_uid UInt32 EPHEMERAL 1 CODEC(T64, LZ4);
+SELECT default_kind, default_expression, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table = 't_plain_to_ephemeral' AND name = 'type_uid';
+
+CREATE TABLE t_mat_codec_to_ephemeral
+(event String, type_uid UInt32 MATERIALIZED JSONExtractUInt(event, 'type_uid') CODEC(T64, LZ4))
+ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_mat_codec_to_ephemeral MODIFY COLUMN type_uid UInt32 EPHEMERAL 1;
+SELECT default_kind, default_expression, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table = 't_mat_codec_to_ephemeral' AND name = 'type_uid';
+
+-- The reverse direction, physical -> ALIAS with a codec, stays rejected.
+CREATE TABLE t_plain_to_alias (event String, type_uid UInt32) ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_plain_to_alias MODIFY COLUMN type_uid UInt32 ALIAS JSONExtractUInt(event, 'type_uid') CODEC(T64, LZ4); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE t_mat_codec_to_alias
+(event String, type_uid UInt32 MATERIALIZED JSONExtractUInt(event, 'type_uid') CODEC(T64, LZ4))
+ENGINE = MergeTree() ORDER BY tuple();
+ALTER TABLE t_mat_codec_to_alias MODIFY COLUMN type_uid UInt32 ALIAS JSONExtractUInt(event, 'type_uid'); -- { serverError BAD_ARGUMENTS }
+
+-- Data is readable through a column that the ALTER made physical.
+INSERT INTO t_alias_to_mat VALUES ('{"type_uid":7}');
+SELECT event, type_uid FROM t_alias_to_mat;
+
+DROP TABLE t_plain;
+DROP TABLE t_default;
+DROP TABLE t_mat;
+DROP TABLE t_mat_to_alias;
+DROP TABLE t_alias_to_mat;
+DROP TABLE t_alias_to_default;
+DROP TABLE t_alias_no_type;
+DROP TABLE t_alias_to_mat_rep;
+DROP TABLE t_alias_to_alias;
+DROP TABLE t_alias_no_specifier;
+DROP TABLE t_alias_auto_increment;
+DROP TABLE t_alias_to_ephemeral;
+DROP TABLE t_plain_to_ephemeral;
+DROP TABLE t_mat_codec_to_ephemeral;
+DROP TABLE t_plain_to_alias;
+DROP TABLE t_mat_codec_to_alias;

--- a/tests/queries/0_stateless/04819_alter_modify_column_alias_to_physical_codec.sql
+++ b/tests/queries/0_stateless/04819_alter_modify_column_alias_to_physical_codec.sql
@@ -106,6 +106,18 @@ ALTER TABLE t_mat_codec_to_alias MODIFY COLUMN type_uid UInt32 ALIAS JSONExtract
 INSERT INTO t_alias_to_mat VALUES ('{"type_uid":7}');
 SELECT event, type_uid FROM t_alias_to_mat;
 
+-- Below, only AlterCommands::validate can reject: max_query_size = 0 skips the CREATE-query
+-- revalidation, and a replicated table reaches the other one only in a Replicated database.
+-- The setting is session-scoped, so this section must stay last.
+SET max_query_size = 0;
+
+CREATE TABLE t_alias_rep_unvalidated (event String, type_uid UInt32 ALIAS JSONExtractUInt(event, 'type_uid'))
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/04819_alias_codec_no_revalidation', 'r1') ORDER BY tuple();
+ALTER TABLE t_alias_rep_unvalidated MODIFY COLUMN type_uid UInt32 CODEC(T64, LZ4); -- { serverError BAD_ARGUMENTS }
+ALTER TABLE t_alias_rep_unvalidated MODIFY COLUMN type_uid UInt32 AUTO_INCREMENT CODEC(T64, LZ4); -- { serverError BAD_ARGUMENTS }
+SELECT default_kind, default_expression, compression_codec FROM system.columns
+WHERE database = currentDatabase() AND table = 't_alias_rep_unvalidated' AND name = 'type_uid';
+
 DROP TABLE t_plain;
 DROP TABLE t_default;
 DROP TABLE t_mat;
@@ -122,3 +134,4 @@ DROP TABLE t_plain_to_ephemeral;
 DROP TABLE t_mat_codec_to_ephemeral;
 DROP TABLE t_plain_to_alias;
 DROP TABLE t_mat_codec_to_alias;
+DROP TABLE t_alias_rep_unvalidated;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/113693
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes `ALTER TABLE ... MODIFY COLUMN` failing with `Cannot specify codec for column type ALIAS` when one statement both turns an `ALIAS` column into a physical one (`DEFAULT` or `MATERIALIZED`) and specifies a `CODEC`. Closes #113693.


### Description

`ALTER TABLE event MODIFY COLUMN type_uid UInt32 MATERIALIZED JSONExtractUInt(event, 'type_uid') CODEC(T64, LZ4)` was rejected with `Code: 36 ... Cannot specify codec for column type ALIAS` when `type_uid` was an `ALIAS` before the ALTER, even though that same statement makes the column physical, where a codec is legal. Dropping `CODEC` succeeds, and splitting it into two ALTERs reaches the intended state, so a legal single-statement migration was refused. Splitting it into one multi-command ALTER does not help either: `AlterCommands::validate` walks every command against one pre-ALTER snapshot.

Root cause: the guard in the `MODIFY_COLUMN` branch of `AlterCommands::validate` asked `ColumnsDescription::hasAlias`, which reports the kind stored in the table and so cannot see the kind the command is about to set. It now also consults the command's own default kind, accepting a codec exactly when the command makes the column physical.

The second term is an allowlist of the physical kinds, not a `!= Alias` test: a `!= Alias` test would additionally start accepting `ALIAS -> EPHEMERAL <expr> CODEC(...)`, an unrelated second change. `command.default_expression` is required alongside it because `AUTO_INCREMENT` parses no expression and leaves the kind at its `Default` initialiser, which the allowlist alone would misread for an ALTER that in fact preserves the ALIAS.

The defect was not specific to `MATERIALIZED`: `ALIAS -> DEFAULT expr CODEC(...)` failed identically, while `DEFAULT` and `MATERIALIZED` sources already accepted the same codec, so the scope is ALIAS to any physical kind. Correct rejections are unchanged, including the reverse physical-to-ALIAS direction, and `03224_invalid_alter` passes untouched. Not a recent regression: the guard has read the pre-ALTER kind since 2023 and every active release branch carries it.

Unrelated and left alone: bare `EPHEMERAL` (no expression) with a codec gives `Code: 47` from a different layer, on plain `CREATE TABLE` too.

<details>
<summary>Validation</summary>

Debug build, Build ID `1255f09f9fa683844ee54fe66e67dad7cffcec7c`; every verdict taken with the running server's `SELECT lower(buildId())` asserted equal to the binary.

Both directions, new test `04819_alter_modify_column_alias_to_physical_codec`: it FAILS on pristine master (`Code: 36` on the reported statement) and PASSES with the fix. 100/100 runs pass (50 randomized, 50 with randomization off); the test carries no opt-out tag, verified with the runner's own tag parser against a tagged control.

Mutation matrix, each arm rebuilt with its Build ID asserted, the shipped Build ID returning byte-exactly afterwards. Reverting the predicate reddens the four arms that turn an `ALIAS` physical while specifying a codec, and nothing else. Replacing the allowlist with `!= Alias` reddens the `ALIAS -> EPHEMERAL 1 CODEC` arm and only that arm, which is what pins the allowlist choice. Dropping the `default_expression` term reddens the two arms in the last section and only those: with `max_query_size = 0` on a `ReplicatedMergeTree` this check is the only rejector, so without that term a codec is persisted on a column that stays an `ALIAS`.

Regression slice of the 117 stateless tests that mention `MODIFY COLUMN` alongside a codec or a default kind, run on both binaries and compared as reason-bucketed sets: 111 OK and 6 FAIL on each arm, identical by name and by reason, so 0 only-in-fix and 0 reason changes. The 6 shared failures are environmental for a hand-built server. `03702_alter_codec_pk` and `03702_alter_codec_index` are the closest neighbours, each asserting an error for `MODIFY COLUMN id UInt64 ALIAS 3 CODEC(Delta, LZ4)`; both still pass, because a preceding statement has already made that column physical, so this guard is not what rejects them.

</details>