### PR TITLE
Allow ALTER of column type when its key subcolumns are unchanged

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4780,6 +4780,16 @@ bool isSafeForKeyConversion(const IDataType * from, const IDataType * to)
     return false;
 }
 
+/// Comma-separated list of backquoted identifiers, for exception messages.
+String backQuotedList(const std::vector<String> & identifiers)
+{
+    std::vector<String> quoted;
+    quoted.reserve(identifiers.size());
+    for (const auto & identifier : identifiers)
+        quoted.push_back(backQuoteIfNeed(identifier));
+    return boost::join(quoted, ", ");
+}
+
 /// Special check for alters of VersionedCollapsingMergeTree version column
 void checkVersionColumnTypesConversion(const IDataType * old_type, const IDataType * new_type, const String column_name)
 {
@@ -5138,7 +5148,7 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
     /// Columns to check that the type change is safe for partition key.
     NameSet columns_alter_type_check_safe_for_partition;
 
-    /// Columns with subcolumns used in primary key or partition key.
+    /// Storage column -> its subcolumns used in the primary or partition key (raw names).
     std::unordered_map<String, std::vector<String>> column_to_subcolumns_used_in_keys;
 
     const auto & old_columns = old_metadata.getColumns();
@@ -5158,7 +5168,7 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
         {
             auto storage_column = old_columns.tryGetColumnOrSubcolumn(GetColumnsOptions::All, col);
             if (storage_column && storage_column->isSubcolumn())
-                column_to_subcolumns_used_in_keys[storage_column->getNameInStorage()].push_back(backQuoteIfNeed(col));
+                column_to_subcolumns_used_in_keys[storage_column->getNameInStorage()].push_back(col);
             else
                 columns_alter_type_check_safe_for_partition.insert(col);
         }
@@ -5176,7 +5186,7 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
         {
             auto storage_column = old_columns.tryGetColumnOrSubcolumn(GetColumnsOptions::All, col);
             if (storage_column && storage_column->isSubcolumn())
-                column_to_subcolumns_used_in_keys[storage_column->getNameInStorage()].push_back(backQuoteIfNeed(col));
+                column_to_subcolumns_used_in_keys[storage_column->getNameInStorage()].push_back(col);
             else
                 columns_alter_type_metadata_only.insert(col);
         }
@@ -5317,13 +5327,13 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
                                 backQuoteIfNeed(command.column_name));
             }
 
-            if (column_to_subcolumns_used_in_keys.contains(command.column_name))
+            if (auto it = column_to_subcolumns_used_in_keys.find(command.column_name); it != column_to_subcolumns_used_in_keys.end())
             {
                 throw Exception(
                     ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
                     "Trying to ALTER RENAME column {} whose subcolumns ({}) are part of key expression",
                     backQuoteIfNeed(command.column_name),
-                    boost::join(column_to_subcolumns_used_in_keys[command.column_name], ", "));
+                    backQuotedList(it->second));
             }
 
             if (index_mode == AlterColumnSecondaryIndexMode::THROW)
@@ -5356,13 +5366,13 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
                     "Trying to ALTER DROP key {} column which is a part of key expression", backQuoteIfNeed(command.column_name));
             }
 
-            if (column_to_subcolumns_used_in_keys.contains(command.column_name))
+            if (auto it = column_to_subcolumns_used_in_keys.find(command.column_name); it != column_to_subcolumns_used_in_keys.end())
             {
                 throw Exception(
                     ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
                     "Trying to ALTER DROP column {} whose subcolumns ({}) are part of key expression",
                     backQuoteIfNeed(command.column_name),
-                    boost::join(column_to_subcolumns_used_in_keys[command.column_name], ", "));
+                    backQuotedList(it->second));
             }
 
             if (!command.clear)
@@ -5430,13 +5440,31 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
                 throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN, "ALTER of key column {} is forbidden",
                     backQuoteIfNeed(command.column_name));
 
-            if (column_to_subcolumns_used_in_keys.contains(command.column_name))
+            /// A column whose subcolumn feeds the primary/partition key may still be ALTERed as long as
+            /// each key subcolumn keeps an on-disk-compatible type: a mutation does not re-sort data, so a
+            /// key subcolumn must convert the same way a top-level key column does (isSafeForKeyConversion),
+            /// while other subcolumns of the column may change freely.
+            if (auto it = column_to_subcolumns_used_in_keys.find(command.column_name); it != column_to_subcolumns_used_in_keys.end())
             {
-                throw Exception(
-                    ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
-                    "Trying to ALTER column {} whose subcolumns ({}) are part of key expression",
-                    backQuoteIfNeed(command.column_name),
-                    boost::join(column_to_subcolumns_used_in_keys[command.column_name], ", "));
+                const auto & new_columns = new_metadata.getColumns();
+                for (const String & subcolumn : it->second)
+                {
+                    /// The subcolumn is still present after the ALTER: removing it would break the key
+                    /// expression and fail earlier when the new metadata is validated.
+                    auto old_subcolumn = old_columns.tryGetColumnOrSubcolumn(GetColumnsOptions::All, subcolumn);
+                    auto new_subcolumn = new_columns.tryGetColumnOrSubcolumn(GetColumnsOptions::All, subcolumn);
+                    chassert(old_subcolumn.has_value() && new_subcolumn.has_value());
+
+                    if (!isSafeForKeyConversion(old_subcolumn->type.get(), new_subcolumn->type.get()))
+                        throw Exception(
+                            ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
+                            "ALTER of column {} is forbidden because its subcolumn {} is part of a key expression and the ALTER "
+                            "changes its type from {} to {}, which is not safe for the key representation",
+                            backQuoteIfNeed(command.column_name),
+                            backQuoteIfNeed(subcolumn),
+                            old_subcolumn->type->getName(),
+                            new_subcolumn->type->getName());
+                }
             }
 
             if (index_mode == AlterColumnSecondaryIndexMode::THROW || index_mode == AlterColumnSecondaryIndexMode::COMPATIBILITY)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -5449,13 +5449,13 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
                 const auto & new_columns = new_metadata.getColumns();
                 for (const String & subcolumn : it->second)
                 {
-                    /// The subcolumn is still present after the ALTER: removing it would break the key
-                    /// expression and fail earlier when the new metadata is validated.
                     auto old_subcolumn = old_columns.tryGetColumnOrSubcolumn(GetColumnsOptions::All, subcolumn);
+                    chassert(old_subcolumn.has_value());
                     auto new_subcolumn = new_columns.tryGetColumnOrSubcolumn(GetColumnsOptions::All, subcolumn);
-                    chassert(old_subcolumn.has_value() && new_subcolumn.has_value());
 
-                    if (!isSafeForKeyConversion(old_subcolumn->type.get(), new_subcolumn->type.get()))
+                    /// A missing new subcolumn means the ALTER removes it (e.g. drops a Tuple element);
+                    /// a changed type must be safe for the key representation, same as a top-level key column.
+                    if (!new_subcolumn || !isSafeForKeyConversion(old_subcolumn->type.get(), new_subcolumn->type.get()))
                         throw Exception(
                             ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
                             "ALTER of column {} is forbidden because its subcolumn {} is part of a key expression and the ALTER "
@@ -5463,7 +5463,7 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
                             backQuoteIfNeed(command.column_name),
                             backQuoteIfNeed(subcolumn),
                             old_subcolumn->type->getName(),
-                            new_subcolumn->type->getName());
+                            new_subcolumn ? new_subcolumn->type->getName() : "(removed)");
                 }
             }
 

--- a/tests/queries/0_stateless/03628_subcolumns_of_columns_with_dot_in_name.sql
+++ b/tests/queries/0_stateless/03628_subcolumns_of_columns_with_dot_in_name.sql
@@ -51,7 +51,8 @@ optimize table test final;
 select * from test;
 select * from test order by my.tuple.a;
 
-alter table test modify column my.tuple Tuple(a UInt32, b UInt32); -- {serverError ALTER_OF_COLUMN_IS_FORBIDDEN}
+-- Allowed: only an unrelated element `b` is added, the key subcolumn `my.tuple.a` is unchanged.
+alter table test modify column my.tuple Tuple(a UInt32, b UInt32);
 alter table test update `my.tuple` = tuple(0, 0) where 1; -- {serverError CANNOT_UPDATE_COLUMN}
 
 drop table test;

--- a/tests/queries/0_stateless/04811_alter_column_type_with_key_subcolumns.reference
+++ b/tests/queries/0_stateless/04811_alter_column_type_with_key_subcolumns.reference
@@ -1,0 +1,31 @@
+add unrelated typed path, key subcolumn unchanged -> allowed:
+pending mutations:	0
+key lookup after reload (data.a = 4):
+4	4
+adjust JSON param, key subcolumn unchanged -> allowed:
+SKIP unrelated path, key subcolumn unchanged -> allowed:
+0	0
+1	1
+2	2
+3	3
+4	4
+5	5
+change key subcolumn type unsafely -> reject:
+subcolumn in key expression, add unrelated path (data.a unchanged) -> allowed:
+0	0
+1	1
+2	2
+3	3
+subcolumn in key expression, retype data.a -> reject:
+add unrelated typed path, partition subcolumn unchanged -> allowed:
+9
+change partition subcolumn type unsafely -> reject:
+change non-key subcolumn only -> allowed:
+0	0	0
+1	1	1
+2	2	2
+3	3	3
+change key subcolumn unsafely -> reject:
+widen key subcolumn enum (safe) -> allowed:
+1	x	10
+2	y	20

--- a/tests/queries/0_stateless/04811_alter_column_type_with_key_subcolumns.reference
+++ b/tests/queries/0_stateless/04811_alter_column_type_with_key_subcolumns.reference
@@ -26,6 +26,7 @@ change non-key subcolumn only -> allowed:
 2	2	2
 3	3	3
 change key subcolumn unsafely -> reject:
+remove key subcolumn -> reject:
 widen key subcolumn enum (safe) -> allowed:
 1	x	10
 2	y	20

--- a/tests/queries/0_stateless/04811_alter_column_type_with_key_subcolumns.sql
+++ b/tests/queries/0_stateless/04811_alter_column_type_with_key_subcolumns.sql
@@ -75,6 +75,10 @@ SELECT id, t.a, t.b FROM t_alter_key_sub ORDER BY id;
 SELECT 'change key subcolumn unsafely -> reject:';
 ALTER TABLE t_alter_key_sub MODIFY COLUMN t Tuple(a Int64, b Int64); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
 
+-- Removing a key subcolumn is rejected: the sorting key can no longer resolve it.
+SELECT 'remove key subcolumn -> reject:';
+ALTER TABLE t_alter_key_sub MODIFY COLUMN t Tuple(b Int32); -- { serverError UNKNOWN_IDENTIFIER }
+
 DROP TABLE t_alter_key_sub;
 
 -- ============================================================

--- a/tests/queries/0_stateless/04811_alter_column_type_with_key_subcolumns.sql
+++ b/tests/queries/0_stateless/04811_alter_column_type_with_key_subcolumns.sql
@@ -1,0 +1,88 @@
+-- Allow ALTER MODIFY COLUMN of a column whose subcolumns feed the primary/partition key, as long
+-- as the key subcolumns keep an on-disk-compatible type (isSafeForKeyConversion). Other subcolumns
+-- of the column may change freely. A subcolumn used inside a key expression is forbidden, same as a
+-- plain column used in a key expression. The check is type-agnostic (JSON, Tuple, ...).
+
+SET allow_suspicious_types_in_order_by = 1;
+SET mutations_sync = 2;
+
+DROP TABLE IF EXISTS t_alter_key_sub;
+
+-- ============================================================
+-- JSON: subcolumn data.a in ORDER BY, kept unchanged.
+-- Also check the mutation materializes and the on-disk primary index is correct after a reload.
+-- ============================================================
+CREATE TABLE t_alter_key_sub (id UInt32, data JSON(a Int64)) ENGINE = MergeTree ORDER BY (data.a, id) SETTINGS index_granularity = 2;
+INSERT INTO t_alter_key_sub SELECT number, toJSONString(map('a', number)) FROM numbers(6);
+
+SELECT 'add unrelated typed path, key subcolumn unchanged -> allowed:';
+ALTER TABLE t_alter_key_sub MODIFY COLUMN data JSON(a Int64, b String);
+SELECT 'pending mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_alter_key_sub' AND NOT is_done;
+DETACH TABLE t_alter_key_sub;
+ATTACH TABLE t_alter_key_sub;
+SELECT 'key lookup after reload (data.a = 4):';
+SELECT id, data.a FROM t_alter_key_sub WHERE data.a = 4;
+
+SELECT 'adjust JSON param, key subcolumn unchanged -> allowed:';
+ALTER TABLE t_alter_key_sub MODIFY COLUMN data JSON(max_dynamic_paths = 0, a Int64, b String);
+SELECT 'SKIP unrelated path, key subcolumn unchanged -> allowed:';
+ALTER TABLE t_alter_key_sub MODIFY COLUMN data JSON(a Int64, SKIP b);
+SELECT id, data.a FROM t_alter_key_sub ORDER BY id;
+
+SELECT 'change key subcolumn type unsafely -> reject:';
+ALTER TABLE t_alter_key_sub MODIFY COLUMN data JSON(a Int32); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_alter_key_sub;
+
+-- ============================================================
+-- JSON: subcolumn data.a used inside a key expression. Allowed while data.a is unchanged (the key
+-- expression stays identical), rejected when data.a changes unsafely.
+-- ============================================================
+CREATE TABLE t_alter_key_sub (id UInt32, data JSON(a Int64)) ENGINE = MergeTree ORDER BY (toString(data.a), id);
+INSERT INTO t_alter_key_sub SELECT number, toJSONString(map('a', number)) FROM numbers(4);
+SELECT 'subcolumn in key expression, add unrelated path (data.a unchanged) -> allowed:';
+ALTER TABLE t_alter_key_sub MODIFY COLUMN data JSON(a Int64, b String);
+SELECT id, data.a FROM t_alter_key_sub ORDER BY id;
+SELECT 'subcolumn in key expression, retype data.a -> reject:';
+ALTER TABLE t_alter_key_sub MODIFY COLUMN data JSON(a Int32); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+DROP TABLE t_alter_key_sub;
+
+-- ============================================================
+-- JSON: subcolumn data.a in PARTITION BY, kept unchanged
+-- ============================================================
+CREATE TABLE t_alter_key_sub (id UInt32, data JSON(a Int64)) ENGINE = MergeTree PARTITION BY data.a ORDER BY id;
+INSERT INTO t_alter_key_sub SELECT number, toJSONString(map('a', number % 3)) FROM numbers(9);
+
+SELECT 'add unrelated typed path, partition subcolumn unchanged -> allowed:';
+ALTER TABLE t_alter_key_sub MODIFY COLUMN data JSON(a Int64, b String);
+SELECT count() FROM t_alter_key_sub;
+
+SELECT 'change partition subcolumn type unsafely -> reject:';
+ALTER TABLE t_alter_key_sub MODIFY COLUMN data JSON(a Int32); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_alter_key_sub;
+
+-- ============================================================
+-- Tuple (type-agnostic): subcolumn t.a in ORDER BY
+-- ============================================================
+CREATE TABLE t_alter_key_sub (id UInt32, t Tuple(a Int32, b Int32)) ENGINE = MergeTree ORDER BY (t.a, id);
+INSERT INTO t_alter_key_sub SELECT number, (number, number) FROM numbers(4);
+
+SELECT 'change non-key subcolumn only -> allowed:';
+ALTER TABLE t_alter_key_sub MODIFY COLUMN t Tuple(a Int32, b Int64);
+SELECT id, t.a, t.b FROM t_alter_key_sub ORDER BY id;
+
+SELECT 'change key subcolumn unsafely -> reject:';
+ALTER TABLE t_alter_key_sub MODIFY COLUMN t Tuple(a Int64, b Int64); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_alter_key_sub;
+
+-- ============================================================
+-- Tuple: key subcolumn changed in an on-disk-compatible way (enum widening) -> allowed
+-- ============================================================
+CREATE TABLE t_alter_key_sub (id UInt32, t Tuple(a Enum8('x' = 1, 'y' = 2), b Int32)) ENGINE = MergeTree ORDER BY (t.a, id);
+INSERT INTO t_alter_key_sub VALUES (1, ('x', 10)), (2, ('y', 20));
+SELECT 'widen key subcolumn enum (safe) -> allowed:';
+ALTER TABLE t_alter_key_sub MODIFY COLUMN t Tuple(a Enum8('x' = 1, 'y' = 2, 'z' = 3), b Int32);
+SELECT id, t.a, t.b FROM t_alter_key_sub ORDER BY t.a, id;
+DROP TABLE t_alter_key_sub;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/92808
Related: https://github.com/ClickHouse/ClickHouse/pull/112302

ALTER MODIFY COLUMN was forbidden for any column whose subcolumns are used in the primary or partition key, even when the ALTER did not change those subcolumns (e.g. adding an unrelated typed path to a `JSON` column, adjusting a parameter, or `SKIP`-ing a path, while the key subcolumn stays the same).

This relaxes the check to mirror how top-level key columns are handled: the ALTER is allowed as long as every key subcolumn keeps an on-disk-compatible type (`isSafeForKeyConversion`), and is rejected only when a used key subcolumn changes unsafely. Other subcolumns of the column may change freely. A mutation does not re-sort data, so a key subcolumn must convert the same order-preserving way a top-level key column does; the mutation then rebuilds `primary.idx` from the new data.

Similar subcolumn-level checks are added for the lazy `JSON` type-hint ALTER path in https://github.com/ClickHouse/ClickHouse/pull/112302; this PR does the same for the regular (mutation) ALTER path and should be merged after it.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow `ALTER TABLE ... MODIFY COLUMN` of a column whose subcolumns are used in the primary or partition key, as long as the subcolumns used in the key keep an on-disk-compatible type. Previously any such ALTER was forbidden.