### PR TITLE
[WIP] Part manifest prep - extract storage components

### DIFF
--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -24,7 +24,13 @@
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeDataPartChecksum.h>
+#include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/MergeTreeIndicesSerialization.h>
+#include <Storages/Statistics/Statistics.h>
+#include <Compression/CompressedReadBuffer.h>
+#include <Common/FailPoint.h>
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
+#include <Common/escapeForFileName.h>
 #include <Common/formatReadable.h>
 #include <Common/logger_useful.h>
 
@@ -35,11 +41,17 @@ namespace DB
 
 namespace ErrorCodes
 {
+    extern const int CANNOT_READ_ALL_DATA;
     extern const int DIRECTORY_ALREADY_EXISTS;
     extern const int NOT_ENOUGH_SPACE;
     extern const int LOGICAL_ERROR;
     extern const int FILE_DOESNT_EXIST;
     extern const int CORRUPTED_DATA;
+}
+
+namespace FailPoints
+{
+    extern const char merge_tree_load_statistics_throw[];
 }
 
 namespace
@@ -420,17 +432,18 @@ DataPartStorageOnDiskBase::getReplicatedFilesDescriptionForRemoteDisk(const Name
     return description;
 }
 
-void DataPartStorageOnDiskBase::backup(
-    const MergeTreeDataPartChecksums & checksums,
-    const NameSet & files_without_checksums,
-    const String & path_in_backup,
-    const BackupSettings & backup_settings,
-    bool make_temporary_hard_links,
-    BackupEntries & backup_entries,
-    TemporaryFilesOnDisks * temp_dirs,
-    bool is_projection_part,
-    bool allow_backup_broken_projection) const
+void DataPartStorageOnDiskBase::backup(const BackupParams & params) const
 {
+    const auto & checksums = params.checksums;
+    const auto & files_without_checksums = params.files_without_checksums;
+    const auto & path_in_backup = params.path_in_backup;
+    const auto & backup_settings = params.backup_settings;
+    const bool make_temporary_hard_links = params.make_temporary_hard_links;
+    auto & backup_entries = params.backup_entries;
+    auto * temp_dirs = params.temp_dirs;
+    const bool is_projection_part = params.is_projection_part;
+    const bool allow_backup_broken_projection = params.allow_backup_broken_projection;
+
     fs::path part_path_on_disk = fs::path{root_path} / part_dir;
     fs::path part_path_in_backup = fs::path{path_in_backup} / part_dir;
 
@@ -463,7 +476,7 @@ void DataPartStorageOnDiskBase::backup(
     auto files_to_backup = files_without_checksums;
     for (const auto & [name, _] : checksums.files)
     {
-        if (!name.ends_with(".proj"))
+        if (!IDataPartProjectionStorage::isProjectionDirectoryName(name))
             files_to_backup.insert(name);
     }
 
@@ -719,10 +732,12 @@ MutableDataPartStoragePtr DataPartStorageOnDiskBase::clonePart(
 void DataPartStorageOnDiskBase::rename(
     std::string new_root_path,
     std::string new_part_dir,
-    LoggerPtr log,
-    bool remove_new_dir_if_exists,
-    bool fsync_part_dir)
+    const RenameParams & params)
 {
+    const auto & log = params.log;
+    const bool remove_new_dir_if_exists = params.remove_new_dir_if_exists;
+    const bool fsync_part_dir = params.fsync_part_dir;
+
     if (new_root_path.ends_with('/'))
         new_root_path.pop_back();
     if (new_part_dir.ends_with('/'))
@@ -798,13 +813,14 @@ void DataPartStorageOnDiskBase::rename(
     }
 }
 
-void DataPartStorageOnDiskBase::remove(
-    CanRemoveCallback && can_remove_callback,
-    const MergeTreeDataPartChecksums & checksums,
-    std::list<ProjectionChecksums> projections,
-    bool is_temp,
-    LoggerPtr log)
+void DataPartStorageOnDiskBase::remove(RemoveParams params)
 {
+    auto can_remove_callback = std::move(params.can_remove_callback);
+    const auto & checksums = params.checksums;
+    auto & projections = params.projections;
+    const bool is_temp = params.is_temp;
+    const auto & log = params.log;
+
     /// NOTE We rename part to delete_tmp_<relative_path> instead of delete_tmp_<name> to avoid race condition
     /// when we try to remove two parts with the same name, but different relative paths,
     /// for example all_1_2_1 (in Deleting state) and tmp_merge_all_1_2_1 (in Temporary state).
@@ -918,7 +934,7 @@ void DataPartStorageOnDiskBase::remove(
 
     // Record existing projection directories so we don't remove them twice
     std::unordered_set<String> projection_directories;
-    std::string proj_suffix = ".proj";
+    std::string proj_suffix{IDataPartProjectionStorage::PROJECTION_DIRECTORY_SUFFIX};
     for (const auto & projection : projections)
     {
         std::string proj_dir_name = projection.name + proj_suffix;
@@ -1014,7 +1030,7 @@ void DataPartStorageOnDiskBase::clearDirectory(
     {
         NameSet names_to_remove = {"checksums.txt", "columns.txt"};
         for (const auto & [file, _] : checksums.files)
-            if (!endsWith(file, ".proj"))
+            if (!IDataPartProjectionStorage::isProjectionDirectoryName(file))
                 names_to_remove.emplace(file);
 
         names_to_remove = getActualFileNamesOnDisk(names_to_remove);
@@ -1366,6 +1382,227 @@ void DataPartStorageOnDiskBase::filterPackedSkipIndicesArchiveTo(
     /// nullptr, and the surviving packed index's size is latched at zero.
     if (auto * disk_storage = dynamic_cast<DataPartStorageOnDiskBase *>(&new_storage))
         disk_storage->seedSkipIndicesPackedReader(packed_index);
+}
+
+
+/// ===== Facets of the data part composition (declared in IDataPartStorage.h) =====
+
+DataPartProjectionStorage::DataPartProjectionStorage(
+    String projection_name_,
+    MutableDataPartStoragePtr storage_,
+    DataPartStoragePtr parent_storage_)
+    : projection_name(std::move(projection_name_))
+    , storage(std::move(storage_))
+    , parent_storage(std::move(parent_storage_))
+{
+    if (!storage)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Projection {} has no storage", projection_name);
+    if (!parent_storage)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Projection {} has no parent storage", projection_name);
+}
+
+bool DataPartProjectionStorage::isTemporary() const
+{
+    return isTemporaryProjectionDirectoryName(storage->getPartDirectory());
+}
+
+bool DataPartIndexStorage::isInPackedArchive(const IMergeTreeIndex & index) const
+{
+    const auto * disk_storage = dynamic_cast<const DataPartStorageOnDiskBase *>(&part.getDataPartStorage());
+    if (!disk_storage)
+        return false;
+
+    const String file_name = index.getFileName();
+
+    /// Probe what the part actually holds, not the writer's current `getSubstreams`, so a legacy
+    /// member inside `skp_idx.packed` on an upgraded part is found.
+    for (const auto & substream : index.getAllSubstreamsInPart(part.checksums, file_name, &part.getDataPartStorage()))
+        if (disk_storage->isFileInPackedSkipIndicesArchive(file_name + substream.suffix + substream.extension))
+            return true;
+
+    return false;
+}
+
+bool DataPartIndexStorage::exists(const String & index_name, bool escape_index_filenames) const
+{
+    auto component_guard = Coordination::setCurrentComponent("DataPartIndexStorage::exists");
+
+    auto file_name = getIndexFileName(index_name, escape_index_filenames);
+    return part.getStreamNameOrHashResolved(file_name, ".idx").has_value()
+        || part.getStreamNameOrHashResolved(file_name, ".idx2").has_value();
+}
+
+static const ColumnDescription * getColumnForStatisticsFile(const String & filename, const ColumnsDescription & all_columns, const NameSet & required_columns)
+{
+    chassert(filename.starts_with(STATS_FILE_PREFIX));
+    chassert(filename.ends_with(STATS_FILE_SUFFIX));
+
+    size_t num_chars_to_truncate = STATS_FILE_PREFIX.size() + STATS_FILE_SUFFIX.size();
+    String column_name = unescapeForFileName(filename.substr(STATS_FILE_PREFIX.size(), filename.size() - num_chars_to_truncate));
+
+    /// `<col>.null` subcolumn may appear in required_columns when
+    /// `optimize_functions_to_subcolumns=1`, keep stats for the parent column in that case.
+    if (!required_columns.empty()
+        && !required_columns.contains(column_name)
+        && !required_columns.contains(column_name + ".null"))
+    {
+        return nullptr;
+    }
+
+    return all_columns.tryGet(column_name);
+}
+
+DataPartStatisticsStoragePacked::DataPartStatisticsStoragePacked(const IMergeTreeDataPart & part_) : part(part_)
+{
+}
+
+DataPartStatisticsStoragePacked::~DataPartStatisticsStoragePacked() = default;
+
+const PackedFilesReader & DataPartStatisticsStoragePacked::getReader() const
+{
+    std::lock_guard lock(reader_mutex);
+    if (reader)
+        return *reader;
+
+    const auto * disk_storage = dynamic_cast<const DataPartStorageOnDiskBase *>(&part.getDataPartStorage());
+    if (!disk_storage)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Packed statistics reader requires on-disk part storage");
+
+    const String packed_file = fs::path(part.getDataPartStorage().getRelativePath()) / String(ColumnsStatistics::FILENAME);
+    reader = std::make_unique<PackedFilesReader>(
+        disk_storage->getDisk(),
+        packed_file,
+        part.storage.getContext()->getReadSettings());
+
+    return *reader;
+}
+
+ColumnsStatistics DataPartStatisticsStoragePacked::loadImpl(const NameSet & required_columns) const
+{
+    ColumnsStatistics result;
+    auto read_settings = part.storage.getContext()->getReadSettings();
+
+    const auto & packed_reader = getReader();
+
+    /// The reader holds only the index; resolve the archive's current location here so a part
+    /// that has since been renamed or moved still reads from the right place.
+    const auto * disk_storage = dynamic_cast<const DataPartStorageOnDiskBase *>(&part.getDataPartStorage());
+    if (!disk_storage)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Packed statistics reader requires on-disk part storage");
+    const auto disk = disk_storage->getDisk();
+    const String packed_file = fs::path(part.getDataPartStorage().getRelativePath()) / String(ColumnsStatistics::FILENAME);
+
+    for (const auto & filename : packed_reader.getFileNames())
+    {
+        if (!filename.ends_with(STATS_FILE_SUFFIX) || !filename.starts_with(STATS_FILE_PREFIX))
+            throw Exception(ErrorCodes::CORRUPTED_DATA, "File {} is not a statistics file", filename);
+
+        const auto * column_desc = getColumnForStatisticsFile(filename, part.getColumnsDescription(), required_columns);
+        if (!column_desc)
+            continue;
+
+        size_t file_size = packed_reader.getFileSize(filename);
+        auto file_buf = packed_reader.readFile(disk, packed_file, filename, read_settings, file_size);
+        CompressedReadBuffer compressed_buf(*file_buf);
+        try
+        {
+            fiu_do_on(FailPoints::merge_tree_load_statistics_throw,
+            {
+                throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "Injected failure in loadStatistics");
+            });
+
+            auto column_stat = ColumnStatistics::deserialize(compressed_buf, column_desc->type);
+            if (column_stat)
+                result.emplace(column_desc->name, std::move(column_stat));
+        }
+        catch (Exception & e)
+        {
+            e.addMessage(
+                "(while loading statistics for column {} from file {} in packed file {} of part {})",
+                column_desc->name,
+                filename,
+                ColumnsStatistics::FILENAME,
+                part.name);
+            throw;
+        }
+    }
+
+    return result;
+}
+
+ColumnsStatistics DataPartStatisticsStoragePacked::load() const
+{
+    auto component_guard = Coordination::setCurrentComponent("DataPartStatisticsStoragePacked::load");
+    return loadImpl({});
+}
+
+ColumnsStatistics DataPartStatisticsStoragePacked::load(const Names & required_columns) const
+{
+    auto component_guard = Coordination::setCurrentComponent("DataPartStatisticsStoragePacked::load");
+    return loadImpl(NameSet(required_columns.begin(), required_columns.end()));
+}
+
+ColumnsStatistics DataPartStatisticsStorageWide::loadImpl(const NameSet & required_columns) const
+{
+    ColumnsStatistics result;
+    auto read_settings = part.storage.getContext()->getReadSettings();
+
+    for (const auto & [filename, checksum] : part.checksums.files)
+    {
+        if (!filename.ends_with(STATS_FILE_SUFFIX) || !filename.starts_with(STATS_FILE_PREFIX))
+            continue;
+
+        const auto * column_desc = getColumnForStatisticsFile(filename, part.getColumnsDescription(), required_columns);
+        if (!column_desc)
+            continue;
+
+        auto file_buf = part.getDataPartStorage().readFile(filename, read_settings, checksum.file_size);
+        CompressedReadBuffer compressed_buf(*file_buf);
+        try
+        {
+            fiu_do_on(FailPoints::merge_tree_load_statistics_throw,
+            {
+                throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "Injected failure in loadStatistics");
+            });
+
+            auto column_stat = ColumnStatistics::deserialize(compressed_buf, column_desc->type);
+            if (column_stat)
+                result.emplace(column_desc->name, std::move(column_stat));
+        }
+        catch (Exception & e)
+        {
+            e.addMessage(
+                "(while loading statistics for column {} from file {} in part {})",
+                column_desc->name,
+                filename,
+                part.name);
+            throw;
+        }
+    }
+
+    return result;
+}
+
+ColumnsStatistics DataPartStatisticsStorageWide::load() const
+{
+    auto component_guard = Coordination::setCurrentComponent("DataPartStatisticsStorageWide::load");
+    return loadImpl({});
+}
+
+ColumnsStatistics DataPartStatisticsStorageWide::load(const Names & required_columns) const
+{
+    auto component_guard = Coordination::setCurrentComponent("DataPartStatisticsStorageWide::load");
+    return loadImpl(NameSet(required_columns.begin(), required_columns.end()));
+}
+
+DataPartStatisticsStoragePtr createDataPartStatisticsStorage(const IMergeTreeDataPart & part)
+{
+    const bool has_packed_archive = part.checksums.has(String(ColumnsStatistics::FILENAME))
+        && dynamic_cast<const DataPartStorageOnDiskBase *>(&part.getDataPartStorage()) != nullptr;
+
+    if (has_packed_archive)
+        return std::make_unique<DataPartStatisticsStoragePacked>(part);
+    return std::make_unique<DataPartStatisticsStorageWide>(part);
 }
 
 }

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.h
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.h
@@ -111,16 +111,7 @@ public:
     ReplicatedFilesDescription getReplicatedFilesDescription(const NameSet & file_names) const override;
     ReplicatedFilesDescription getReplicatedFilesDescriptionForRemoteDisk(const NameSet & file_names) const override;
 
-    void backup(
-        const MergeTreeDataPartChecksums & checksums,
-        const NameSet & files_without_checksums,
-        const String & path_in_backup,
-        const BackupSettings & backup_settings,
-        bool make_temporary_hard_links,
-        BackupEntries & backup_entries,
-        TemporaryFilesOnDisks * temp_dirs,
-        bool is_projection_part,
-        bool allow_backup_broken_projection) const override;
+    void backup(const BackupParams & params) const override;
 
     MutableDataPartStoragePtr freeze(
         const std::string & to,
@@ -152,16 +143,9 @@ public:
     void rename(
         std::string new_root_path,
         std::string new_part_dir,
-        LoggerPtr log,
-        bool remove_new_dir_if_exists,
-        bool fsync_part_dir) override;
+        const RenameParams & params) override;
 
-    void remove(
-        CanRemoveCallback && can_remove_callback,
-        const MergeTreeDataPartChecksums & checksums,
-        std::list<ProjectionChecksums> projections,
-        bool is_temp,
-        LoggerPtr log) override;
+    void remove(RemoveParams params) override;
 
     void changeRootPath(const std::string & from_root, const std::string & to_root) override;
     void createDirectories() override;

--- a/src/Storages/MergeTree/DataPartStorageOnDiskPacked.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskPacked.cpp
@@ -391,11 +391,9 @@ std::unique_ptr<ReadBufferFromFileBase> DataPartStorageOnDiskPacked::readFileIfE
 void DataPartStorageOnDiskPacked::rename(
     std::string new_root_path,
     std::string new_part_dir,
-    LoggerPtr log,
-    bool remove_new_dir_if_exists,
-    bool fsync_part_dir)
+    const RenameParams & params)
 {
-    DataPartStorageOnDiskBase::rename(std::move(new_root_path), std::move(new_part_dir), log, remove_new_dir_if_exists, fsync_part_dir);
+    DataPartStorageOnDiskBase::rename(std::move(new_root_path), std::move(new_part_dir), params);
     /// The reader's index is path-independent and reads resolve the current path via readFile, so
     /// the relocation needs no reader refresh.
 }
@@ -616,8 +614,8 @@ bool DataPartStorageOnDiskPacked::isWrittenSeparately(const String & file_name) 
         return true;
 
     auto path = fs::path(file_name);
-    return path.extension() == ".proj"
-        || path.extension() == ".tmp_proj"
+    return path.extension() == IDataPartProjectionStorage::PROJECTION_DIRECTORY_SUFFIX
+        || path.extension() == IDataPartProjectionStorage::TEMPORARY_PROJECTION_DIRECTORY_SUFFIX
         || (path.extension() == ".tmp" && files_written_separately.contains(path.stem()));
 }
 

--- a/src/Storages/MergeTree/DataPartStorageOnDiskPacked.h
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskPacked.h
@@ -52,9 +52,7 @@ public:
     void rename(
         std::string new_root_path,
         std::string new_part_dir,
-        LoggerPtr log,
-        bool remove_new_dir_if_exists,
-        bool fsync_part_dir) override;
+        const RenameParams & params) override;
 
     void createProjection(const std::string & name) override;
 

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -249,7 +249,7 @@ MergeTreeData::DataPart::Checksums Service::sendPartFromDisk(
 
     for (const auto & [name, _] : part->checksums.files)
     {
-        if (endsWith(name, ".proj"))
+        if (IDataPartProjectionStorage::isProjectionDirectoryName(name))
             continue;
 
         files_to_replicate.insert(name);
@@ -297,13 +297,13 @@ MergeTreeData::DataPart::Checksums Service::sendPartFromDisk(
         {
             writeStringBinary(name, out);
             MergeTreeData::DataPart::Checksums projection_checksum = sendPartFromDisk(projection, out, client_protocol_version, from_remote_disk, false);
-            data_checksums.addFile(name + ".proj", projection_checksum.getTotalSizeOnDisk(), projection_checksum.getTotalChecksumUInt128());
+            data_checksums.addFile(IDataPartProjectionStorage::getDirectoryName(name), projection_checksum.getTotalSizeOnDisk(), projection_checksum.getTotalChecksumUInt128());
         }
-        else if (part->checksums.has(name + ".proj"))
+        else if (part->checksums.has(IDataPartProjectionStorage::getDirectoryName(name)))
         {
             // We don't send this projection, just add out checksum to bypass the following check
-            const auto & our_checksum = part->checksums.files.find(name + ".proj")->second;
-            data_checksums.addFile(name + ".proj", our_checksum.file_size, our_checksum.file_hash);
+            const auto & our_checksum = part->checksums.files.find(IDataPartProjectionStorage::getDirectoryName(name))->second;
+            data_checksums.addFile(IDataPartProjectionStorage::getDirectoryName(name), our_checksum.file_size, our_checksum.file_hash);
         }
     }
 
@@ -313,7 +313,7 @@ MergeTreeData::DataPart::Checksums Service::sendPartFromDisk(
     /// data_checksums so that checkEqual below does not fail.
     for (const auto & [name, checksum] : part->checksums.files)
     {
-        if (name.ends_with(".proj") && !data_checksums.has(name))
+        if (IDataPartProjectionStorage::isProjectionDirectoryName(name) && !data_checksums.has(name))
             data_checksums.addFile(name, checksum.file_size, checksum.file_hash);
     }
 
@@ -873,14 +873,14 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
 
             MergeTreeData::DataPart::Checksums projection_checksum;
 
-            auto projection_part_storage = part_storage_for_loading->getProjection(projection_name + ".proj");
+            auto projection_part_storage = part_storage_for_loading->getProjection(IDataPartProjectionStorage::getDirectoryName(projection_name));
             projection_part_storage->createDirectories();
 
             downloadBaseOrProjectionPartToDisk(
                 replica_path, projection_part_storage, in, output_buffer_getter, projection_checksum, throttler, sync);
 
             data_checksums.addFile(
-                projection_name + ".proj", projection_checksum.getTotalSizeOnDisk(), projection_checksum.getTotalChecksumUInt128());
+                IDataPartProjectionStorage::getDirectoryName(projection_name), projection_checksum.getTotalSizeOnDisk(), projection_checksum.getTotalChecksumUInt128());
         }
 
         downloadBaseOrProjectionPartToDisk(
@@ -948,7 +948,7 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
             /// not fail.
             for (const auto & [name, checksum] : new_data_part->checksums.files)
             {
-                if (name.ends_with(".proj") && !data_checksums.has(name))
+                if (IDataPartProjectionStorage::isProjectionDirectoryName(name) && !data_checksums.has(name))
                     data_checksums.addFile(name, checksum.file_size, checksum.file_hash);
             }
             new_data_part->checksums.checkEqual(data_checksums, false, new_data_part->name);

--- a/src/Storages/MergeTree/IDataPartStorage.h
+++ b/src/Storages/MergeTree/IDataPartStorage.h
@@ -10,6 +10,7 @@
 #include <Common/TransactionID.h>
 
 #include <memory>
+#include <mutex>
 #include <optional>
 
 #include <boost/core/noncopyable.hpp>
@@ -176,15 +177,20 @@ public:
         const MergeTreeDataPartChecksums & checksums;
     };
 
+    /// Everything the removal of a data part depends on, gathered in one place.
+    /// can_remove_callback answers whether shared data may be removed (specific for DiskObjectStorage).
+    /// projections and checksums are needed to avoid recursive listing.
+    struct RemoveParams
+    {
+        CanRemoveCallback can_remove_callback;
+        const MergeTreeDataPartChecksums & checksums;
+        std::list<ProjectionChecksums> projections = {};
+        bool is_temp = false;
+        LoggerPtr log = nullptr;
+    };
+
     /// Remove data part.
-    /// can_remove_shared_data, names_not_to_remove are specific for DiskObjectStorage.
-    /// projections, checksums are needed to avoid recursive listing
-    virtual void remove(
-        CanRemoveCallback && can_remove_callback,
-        const MergeTreeDataPartChecksums & checksums,
-        std::list<ProjectionChecksums> projections,
-        bool is_temp,
-        LoggerPtr log) = 0;
+    virtual void remove(RemoveParams params) = 0;
 
     /// Get a name like 'prefix_partdir_tryN' which does not exist in a root dir.
     /// TODO: remove it.
@@ -240,20 +246,27 @@ public:
     virtual ReplicatedFilesDescription getReplicatedFilesDescription(const NameSet & file_names) const = 0;
     virtual ReplicatedFilesDescription getReplicatedFilesDescriptionForRemoteDisk(const NameSet & file_names) const = 0;
 
-    /// Create a backup of a data part.
-    /// This method adds a new entry to backup_entries.
-    /// Also creates a new tmp_dir for internal disk (if disk is mentioned the first time).
     using TemporaryFilesOnDisks = std::map<DiskPtr, std::shared_ptr<TemporaryFileOnDisk>>;
-    virtual void backup(
-        const MergeTreeDataPartChecksums & checksums,
-        const NameSet & files_without_checksums,
-        const String & path_in_backup,
-        const BackupSettings & backup_settings,
-        bool make_temporary_hard_links,
-        BackupEntries & backup_entries,
-        TemporaryFilesOnDisks * temp_dirs,
-        bool is_projection_part,
-        bool allow_backup_broken_projection) const = 0;
+
+    /// Everything the backup of a data part depends on, gathered in one place.
+    struct BackupParams
+    {
+        const MergeTreeDataPartChecksums & checksums;
+        NameSet files_without_checksums;
+        String path_in_backup;
+        const BackupSettings & backup_settings;
+        bool make_temporary_hard_links = false;
+        /// Output: new entries are added here.
+        BackupEntries & backup_entries;
+        TemporaryFilesOnDisks * temp_dirs = nullptr;
+        bool is_projection_part = false;
+        bool allow_backup_broken_projection = false;
+    };
+
+    /// Create a backup of a data part.
+    /// This method adds a new entry to params.backup_entries.
+    /// Also creates a new tmp_dir for internal disk (if disk is mentioned the first time).
+    virtual void backup(const BackupParams & params) const = 0;
 
     /// Creates hardlinks into 'to/dir_path' for every file in data part.
     /// Some files can be copied instead of hardlinks. It's because of details of zero copy replication
@@ -362,6 +375,14 @@ public:
     virtual void createHardLinkFrom(const IDataPartStorage & source, const std::string & from, const std::string & to) = 0;
     virtual void copyFileFrom(const IDataPartStorage & source, const std::string & from, const std::string & to) = 0;
 
+    /// Options of the rename operation which do not describe the destination itself.
+    struct RenameParams
+    {
+        LoggerPtr log = nullptr;
+        bool remove_new_dir_if_exists = false;
+        bool fsync_part_dir = false;
+    };
+
     /// Rename part.
     /// Ideally, new_root_path should be the same as current root (but it is not true).
     /// Examples are: 'all_1_2_1' -> 'detached/all_1_2_1'
@@ -369,9 +390,7 @@ public:
     virtual void rename(
         std::string new_root_path,
         std::string new_part_dir,
-        LoggerPtr log,
-        bool remove_new_dir_if_exists,
-        bool fsync_part_dir) = 0;
+        const RenameParams & params) = 0;
 
     /// Starts a transaction of mutable operations.
     virtual void beginTransaction() = 0;
@@ -389,6 +408,195 @@ public:
 
 using DataPartStoragePtr = std::shared_ptr<const IDataPartStorage>;
 using MutableDataPartStoragePtr = std::shared_ptr<IDataPartStorage>;
+
+class IMergeTreeDataPart;
+struct IMergeTreeIndex;
+class ColumnsStatistics;
+class PackedFilesReader;
+
+/// ===== Facets of the data part composition =====
+///
+/// A data part is composed of an immutable main part (column data, marks, primary index)
+/// plus optional sub-blocks stored inside the part directory but logically separate:
+/// projections, secondary indexes and statistics - all re-materializable from the main part.
+/// Each facet below owns the on-disk structure of one sub-block; IMergeTreeDataPart composes
+/// them and stays the logical representation.
+
+/// Projection sub-block of a data part.
+///
+/// Defines the placement and naming of a projection directory ("<name>.proj",
+/// or "<name>.tmp_proj" while the projection is being materialized) inside its
+/// parent part, and gives access to the physical layout of both sides.
+class IDataPartProjectionStorage
+{
+public:
+    virtual ~IDataPartProjectionStorage() = default;
+
+    static constexpr std::string_view PROJECTION_DIRECTORY_SUFFIX = ".proj";
+    static constexpr std::string_view TEMPORARY_PROJECTION_DIRECTORY_SUFFIX = ".tmp_proj";
+
+    /// "proj_a" -> "proj_a.proj" (or "proj_a.tmp_proj" for a temporary projection).
+    static String getDirectoryName(const String & projection_name, bool is_temporary = false)
+    {
+        return projection_name + String(is_temporary ? TEMPORARY_PROJECTION_DIRECTORY_SUFFIX : PROJECTION_DIRECTORY_SUFFIX);
+    }
+
+    static bool isProjectionDirectoryName(std::string_view directory_name)
+    {
+        return directory_name.ends_with(PROJECTION_DIRECTORY_SUFFIX);
+    }
+
+    static bool isTemporaryProjectionDirectoryName(std::string_view directory_name)
+    {
+        return directory_name.ends_with(TEMPORARY_PROJECTION_DIRECTORY_SUFFIX);
+    }
+
+    /// Name of the projection this storage belongs to.
+    virtual String getProjectionName() const = 0;
+
+    /// True for a projection which is being materialized ("<name>.tmp_proj").
+    virtual bool isTemporary() const = 0;
+
+    /// Physical layout of the projection itself.
+    virtual IDataPartStorage & getStorage() = 0;
+    virtual const IDataPartStorage & getStorage() const = 0;
+
+    /// Physical layout of the parent part the projection is placed in.
+    virtual const IDataPartStorage & getParentStorage() const = 0;
+};
+
+using DataPartProjectionStoragePtr = std::unique_ptr<IDataPartProjectionStorage>;
+
+/// On-disk implementation of the projection sub-block: the projection's own storage
+/// (rooted at "<parent>/<name>.proj") together with the parent part storage it is placed in.
+class DataPartProjectionStorage final : public IDataPartProjectionStorage
+{
+public:
+    DataPartProjectionStorage(
+        String projection_name_,
+        MutableDataPartStoragePtr storage_,
+        DataPartStoragePtr parent_storage_);
+
+    String getProjectionName() const override { return projection_name; }
+    bool isTemporary() const override;
+
+    IDataPartStorage & getStorage() override { return *storage; }
+    const IDataPartStorage & getStorage() const override { return *storage; }
+
+    const IDataPartStorage & getParentStorage() const override { return *parent_storage; }
+
+private:
+    String projection_name;
+    MutableDataPartStoragePtr storage;
+    DataPartStoragePtr parent_storage;
+};
+
+/// Secondary (skip) indexes sub-block of a data part.
+///
+/// Knows how index substreams are laid out on disk - standalone "skp_idx_*" files or
+/// members of the per-part "skp_idx.packed" archive - and answers structural questions
+/// about them. A single index can mix both layouts (small substreams stay in the archive,
+/// large ones spill into standalone files), so the layout is a per-file property answered
+/// by probing, not a per-part implementation split.
+class IDataPartIndexStorage
+{
+public:
+    virtual ~IDataPartIndexStorage() = default;
+
+    /// True iff any substream of the index is stored inside the part's
+    /// "skp_idx.packed" archive. Probes what the part actually holds, not the
+    /// writer's current substream set, so a legacy member inside the archive
+    /// on an upgraded part is found.
+    virtual bool isInPackedArchive(const IMergeTreeIndex & index) const = 0;
+
+    /// True iff the part physically stores the index. Probes both the current
+    /// and the legacy data file extensions (".idx2" and ".idx").
+    virtual bool exists(const String & index_name, bool escape_index_filenames) const = 0;
+};
+
+using DataPartIndexStoragePtr = std::unique_ptr<IDataPartIndexStorage>;
+
+/// On-disk implementation of the secondary indexes sub-block. Answers structural questions
+/// from the part's checksums and its physical storage (including the "skp_idx.packed"
+/// archive overlay that lives in DataPartStorageOnDiskBase).
+class DataPartIndexStorage final : public IDataPartIndexStorage
+{
+public:
+    explicit DataPartIndexStorage(const IMergeTreeDataPart & part_) : part(part_) {}
+
+    bool isInPackedArchive(const IMergeTreeIndex & index) const override;
+    bool exists(const String & index_name, bool escape_index_filenames) const override;
+
+private:
+    const IMergeTreeDataPart & part;
+};
+
+/// Statistics sub-block of a data part.
+///
+/// Loads column statistics from their on-disk representation. The representation is a
+/// per-part property decided by the part's contents (see createDataPartStatisticsStorage),
+/// so each representation gets its own implementation of load.
+class IDataPartStatisticsStorage
+{
+public:
+    virtual ~IDataPartStatisticsStorage() = default;
+
+    /// Load statistics for all columns of the part.
+    virtual ColumnsStatistics load() const = 0;
+
+    /// Load statistics only for the given columns. Statistics of a parent column are
+    /// kept when its ".null" subcolumn is requested (optimize_functions_to_subcolumns).
+    virtual ColumnsStatistics load(const Names & required_columns) const = 0;
+};
+
+using DataPartStatisticsStoragePtr = std::unique_ptr<IDataPartStatisticsStorage>;
+
+/// Statistics stored as a single "statistics.packed" archive with one virtual
+/// "statistics_<col>.stats" member per column (parts written with the packed
+/// statistics format on full/regular part storage).
+class DataPartStatisticsStoragePacked final : public IDataPartStatisticsStorage
+{
+public:
+    /// Out-of-line: the members require the complete PackedFilesReader type.
+    explicit DataPartStatisticsStoragePacked(const IMergeTreeDataPart & part_);
+    ~DataPartStatisticsStoragePacked() override;
+
+    ColumnsStatistics load() const override;
+    ColumnsStatistics load(const Names & required_columns) const override;
+
+private:
+    ColumnsStatistics loadImpl(const NameSet & required_columns) const;
+
+    /// Reader for the archive index, lazily created on first load.
+    const PackedFilesReader & getReader() const;
+
+    const IMergeTreeDataPart & part;
+
+    mutable std::mutex reader_mutex;
+    mutable std::unique_ptr<PackedFilesReader> reader;
+};
+
+/// Statistics stored as one standalone compressed "statistics_<col>.stats" file per
+/// column (legacy parts, and packed part storage where the files live inside data.packed).
+class DataPartStatisticsStorageWide final : public IDataPartStatisticsStorage
+{
+public:
+    explicit DataPartStatisticsStorageWide(const IMergeTreeDataPart & part_) : part(part_) {}
+
+    ColumnsStatistics load() const override;
+    ColumnsStatistics load(const Names & required_columns) const override;
+
+private:
+    ColumnsStatistics loadImpl(const NameSet & required_columns) const;
+
+    const IMergeTreeDataPart & part;
+};
+
+/// Picks the statistics representation of the part: "statistics.packed" archive when the
+/// part's checksums list one (and the part is on on-disk storage), per-column files
+/// otherwise. Must be called after the part's checksums are loaded - the decision is
+/// made once per part object.
+DataPartStatisticsStoragePtr createDataPartStatisticsStorage(const IMergeTreeDataPart & part);
 
 /// A holder that encapsulates data part storage and
 /// gives access to const storage from const methods

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -536,10 +536,15 @@ IMergeTreeDataPart::IMergeTreeDataPart(
     auto component_guard = Coordination::setCurrentComponent("IMergeTreeDataPart::IMergeTreeDataPart");
     version = std::make_unique<VersionMetadataOnDisk>(this, intent);
 
+    index_storage = std::make_unique<DataPartIndexStorage>(*this);
+
     if (parent_part)
     {
         chassert(parent_part_name.starts_with(parent_part->info.getPartitionId()));     /// Make sure there's no prefix
         state = MergeTreeDataPartState::Active;
+
+        projection_storage = std::make_unique<DataPartProjectionStorage>(
+            name, getDataPartStoragePtr(), parent_part->getDataPartStoragePtr());
     }
 
     incrementStateMetric(state);
@@ -561,6 +566,26 @@ IMergeTreeDataPart::IMergeTreeDataPart(
 
     /// By default set the order of common metadata files. Later on it can be changed by the part itself.
     getDataPartStorage().setPreferredFileOrder(COMMON_METADATA_FILES);
+}
+
+const IDataPartProjectionStorage & IMergeTreeDataPart::getProjectionStorage() const
+{
+    if (!projection_storage)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Part {} is not a projection part and has no projection storage", name);
+    return *projection_storage;
+}
+
+const IDataPartStatisticsStorage & IMergeTreeDataPart::getStatisticsStorage() const
+{
+    std::lock_guard lock(statistics_storage_mutex);
+    if (!statistics_storage)
+    {
+        /// The representation is picked from the checksums; a premature call would latch
+        /// the wrong implementation.
+        chassert(areChecksumsLoaded());
+        statistics_storage = createDataPartStatisticsStorage(*this);
+    }
+    return *statistics_storage;
 }
 
 IMergeTreeDataPart::~IMergeTreeDataPart()
@@ -1043,7 +1068,7 @@ void IMergeTreeDataPart::removeIfNeeded()
                                 getDataPartStorage().getPartDirectory(), name);
 
             bool is_moving_part = isMovingPart();
-            if (!startsWith(file_name, "tmp") && !endsWith(file_name, ".tmp_proj") && !is_moving_part)
+            if (!startsWith(file_name, "tmp") && !IDataPartProjectionStorage::isTemporaryProjectionDirectoryName(file_name) && !is_moving_part)
             {
                 LOG_ERROR(
                     storage.log,
@@ -1192,163 +1217,6 @@ String IMergeTreeDataPart::getColumnNameWithMinimumCompressedSize(const NamesAnd
     return *minimum_size_column;
 }
 
-PackedFilesReader * IMergeTreeDataPart::getStatisticsPackedReader() const
-{
-    std::lock_guard lock(statistics_reader_mutex);
-    if (statistics_reader)
-        return statistics_reader.get();
-
-    const String filename = String(ColumnsStatistics::FILENAME);
-    if (!checksums.has(filename))
-        return nullptr;
-
-    const auto & storage_path = getDataPartStorage().getRelativePath();
-    const String packed_file = fs::path(storage_path) / filename;
-    const auto * disk_storage = dynamic_cast<const DataPartStorageOnDiskBase *>(&getDataPartStorage());
-
-    if (!disk_storage)
-        return nullptr;
-
-    statistics_reader = std::make_unique<PackedFilesReader>(
-        disk_storage->getDisk(),
-        packed_file,
-        storage.getContext()->getReadSettings());
-
-    return statistics_reader.get();
-}
-
-static const ColumnDescription * getColumnForStatisticsFile(const String & filename, const ColumnsDescription & all_columns, const NameSet & required_columns)
-{
-    chassert(filename.starts_with(STATS_FILE_PREFIX));
-    chassert(filename.ends_with(STATS_FILE_SUFFIX));
-
-    size_t num_chars_to_truncate = STATS_FILE_PREFIX.size() + STATS_FILE_SUFFIX.size();
-    String column_name = unescapeForFileName(filename.substr(STATS_FILE_PREFIX.size(), filename.size() - num_chars_to_truncate));
-
-    /// `<col>.null` subcolumn may appear in required_columns when
-    /// `optimize_functions_to_subcolumns=1`, keep stats for the parent column in that case.
-    if (!required_columns.empty()
-        && !required_columns.contains(column_name)
-        && !required_columns.contains(column_name + ".null"))
-    {
-        return nullptr;
-    }
-
-    return all_columns.tryGet(column_name);
-}
-
-ColumnsStatistics IMergeTreeDataPart::loadStatisticsPacked(const PackedFilesReader & reader, const NameSet & required_columns) const
-{
-    ColumnsStatistics result;
-    auto read_settings = storage.getContext()->getReadSettings();
-
-    /// The reader holds only the index; resolve the archive's current location here so a part
-    /// that has since been renamed or moved still reads from the right place.
-    const auto * disk_storage = dynamic_cast<const DataPartStorageOnDiskBase *>(&getDataPartStorage());
-    if (!disk_storage)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Statistics packed reader requires on-disk part storage");
-    const auto disk = disk_storage->getDisk();
-    const String packed_file = fs::path(getDataPartStorage().getRelativePath()) / String(ColumnsStatistics::FILENAME);
-
-    for (const auto & filename : reader.getFileNames())
-    {
-        if (!filename.ends_with(STATS_FILE_SUFFIX) || !filename.starts_with(STATS_FILE_PREFIX))
-            throw Exception(ErrorCodes::CORRUPTED_DATA, "File {} is not a statistics file", filename);
-
-        const auto * column_desc = getColumnForStatisticsFile(filename, getColumnsDescription(), required_columns);
-        if (!column_desc)
-            continue;
-
-        size_t file_size = reader.getFileSize(filename);
-        auto file_buf = reader.readFile(disk, packed_file, filename, read_settings, file_size);
-        CompressedReadBuffer compressed_buf(*file_buf);
-        try
-        {
-            fiu_do_on(FailPoints::merge_tree_load_statistics_throw,
-            {
-                throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "Injected failure in loadStatistics");
-            });
-
-            auto column_stat = ColumnStatistics::deserialize(compressed_buf, column_desc->type);
-            if (column_stat)
-                result.emplace(column_desc->name, std::move(column_stat));
-        }
-        catch (Exception & e)
-        {
-            e.addMessage(
-                "(while loading statistics for column {} from file {} in packed file {} of part {})",
-                column_desc->name,
-                filename,
-                ColumnsStatistics::FILENAME,
-                name);
-            throw;
-        }
-    }
-
-    return result;
-}
-
-ColumnsStatistics IMergeTreeDataPart::loadStatisticsWide(const NameSet & required_columns) const
-{
-    ColumnsStatistics result;
-    auto read_settings = storage.getContext()->getReadSettings();
-
-    for (const auto & [filename, checksum] : checksums.files)
-    {
-        if (!filename.ends_with(STATS_FILE_SUFFIX) || !filename.starts_with(STATS_FILE_PREFIX))
-            continue;
-
-        const auto * column_desc = getColumnForStatisticsFile(filename, getColumnsDescription(), required_columns);
-        if (!column_desc)
-            continue;
-
-        auto file_buf = getDataPartStorage().readFile(filename, read_settings, checksum.file_size);
-        CompressedReadBuffer compressed_buf(*file_buf);
-        try
-        {
-            fiu_do_on(FailPoints::merge_tree_load_statistics_throw,
-            {
-                throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "Injected failure in loadStatistics");
-            });
-
-            auto column_stat = ColumnStatistics::deserialize(compressed_buf, column_desc->type);
-            if (column_stat)
-                result.emplace(column_desc->name, std::move(column_stat));
-        }
-        catch (Exception & e)
-        {
-            e.addMessage(
-                "(while loading statistics for column {} from file {} in part {})",
-                column_desc->name,
-                filename,
-                name);
-            throw;
-        }
-    }
-
-    return result;
-}
-
-ColumnsStatistics IMergeTreeDataPart::loadStatistics() const
-{
-    auto component_guard = Coordination::setCurrentComponent("IMergeTreeDataPart::loadStatistics");
-
-    if (auto * reader = getStatisticsPackedReader())
-        return loadStatisticsPacked(*reader, {});
-
-    return loadStatisticsWide({});
-}
-
-ColumnsStatistics IMergeTreeDataPart::loadStatistics(const Names & required_columns) const
-{
-    auto component_guard = Coordination::setCurrentComponent("IMergeTreeDataPart::loadStatistics");
-    NameSet required_columns_set(required_columns.begin(), required_columns.end());
-
-    if (auto * reader = getStatisticsPackedReader())
-        return loadStatisticsPacked(*reader, required_columns_set);
-
-    return loadStatisticsWide(required_columns_set);
-}
 
 Estimates IMergeTreeDataPart::getEstimates() const
 {
@@ -1360,7 +1228,7 @@ Estimates IMergeTreeDataPart::getEstimates() const
     /// The raw statistics are transient, so load them in the default arena; only the cached
     /// estimates map is long-lived (kept on the part until reload), so build it in the dedicated
     /// arena, like the rest of the part's metadata.
-    auto statistics = loadStatistics();
+    auto statistics = getStatisticsStorage().load();
 
     {
         ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
@@ -1489,18 +1357,18 @@ void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checks
 MergeTreeDataPartBuilder IMergeTreeDataPart::getProjectionPartBuilder(
     const String & projection_name, ProjectionDescriptionRawPtr projection, PartDirIntent intent, bool is_temp_projection)
 {
-    const char * projection_extension = is_temp_projection ? ".tmp_proj" : ".proj";
     /// The projection storage is stored on the resulting projection part for its lifetime, so create
     /// it in the dedicated arena (this is the part-lifetime projection-storage creation site).
     /// `CreateFresh` takes the non-initializing variant, so nothing is seeded from a nested leftover.
-    MutableDataPartStoragePtr projection_storage;
+    const auto projection_dir_name = IDataPartProjectionStorage::getDirectoryName(projection_name, is_temp_projection);
+    MutableDataPartStoragePtr projection_part_storage;
     {
         ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
-        projection_storage = intent == PartDirIntent::CreateFresh
-            ? getDataPartStorage().getProjectionNoInitialize(projection_name + projection_extension, !is_temp_projection)
-            : getDataPartStorage().getProjection(projection_name + projection_extension, !is_temp_projection);
+        projection_part_storage = intent == PartDirIntent::CreateFresh
+            ? getDataPartStorage().getProjectionNoInitialize(projection_dir_name, !is_temp_projection)
+            : getDataPartStorage().getProjection(projection_dir_name, !is_temp_projection);
     }
-    if (intent == PartDirIntent::CreateFresh && projection_storage->exists())
+    if (intent == PartDirIntent::CreateFresh && projection_part_storage->exists())
     {
         /// Nested projection directories have no claim (the cleaner cannot see inside part directories),
         /// so a retried materialization reclaims the leftover of an interrupted attempt here.
@@ -1511,12 +1379,12 @@ MergeTreeDataPartBuilder IMergeTreeDataPart::getProjectionPartBuilder(
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
                 "Cannot reclaim projection directory {}: it belongs to a committed part",
-                projection_storage->getFullPath());
+                projection_part_storage->getFullPath());
 
-        LOG_WARNING(storage.log, "Removing stale temporary projection directory {}", projection_storage->getFullPath());
-        projection_storage->removeRecursive();
+        LOG_WARNING(storage.log, "Removing stale temporary projection directory {}", projection_part_storage->getFullPath());
+        projection_part_storage->removeRecursive();
     }
-    MergeTreeDataPartBuilder builder(storage, projection_name, projection_storage, getReadSettings(), intent);
+    MergeTreeDataPartBuilder builder(storage, projection_name, projection_part_storage, getReadSettings(), intent);
     return builder.withPartInfo(MergeListElement::FAKE_RESULT_PART_FOR_PROJECTION).withParentPart(this).withProjection(projection);
 }
 
@@ -1553,7 +1421,7 @@ void IMergeTreeDataPart::loadProjections(
         if (projection.with_block_offset && isSystemColumnInvalidated(BlockOffsetColumn::name))
             continue;
 
-        auto path = projection.name + ".proj";
+        auto path = IDataPartProjectionStorage::getDirectoryName(projection.name);
         if (getDataPartStorage().existsDirectory(path))
         {
             if (hasProjection(projection.name))
@@ -2575,7 +2443,15 @@ void IMergeTreeDataPart::renameTo(const String & new_relative_path, bool remove_
     auto old_projection_root_path = getDataPartStorage().getRelativePath();
     auto to = fs::path(relative_path) / new_relative_path;
 
-    getDataPartStorage().rename(to.parent_path(), to.filename(), storage.log.load(), remove_new_dir_if_exists, fsync_dir);
+    getDataPartStorage().rename(
+        to.parent_path(),
+        to.filename(),
+        IDataPartStorage::RenameParams
+        {
+            .log = storage.log.load(),
+            .remove_new_dir_if_exists = remove_new_dir_if_exists,
+            .fsync_part_dir = fsync_dir,
+        });
 
     auto new_projection_root_path = to.string();
 
@@ -2634,7 +2510,14 @@ void IMergeTreeDataPart::remove()
     }
 
     bool is_temporary_part = is_temp || state == MergeTreeDataPartState::Temporary;
-    getDataPartStorage().remove(std::move(can_remove_callback), checksums, projection_checksums, is_temporary_part, storage.log.load());
+    getDataPartStorage().remove(IDataPartStorage::RemoveParams
+    {
+        .can_remove_callback = std::move(can_remove_callback),
+        .checksums = checksums,
+        .projections = std::move(projection_checksums),
+        .is_temp = is_temporary_part,
+        .log = storage.log.load(),
+    });
 }
 
 std::optional<String> IMergeTreeDataPart::getRelativePathForPrefix(const String & prefix, bool detached, bool broken) const
@@ -2831,7 +2714,7 @@ void IMergeTreeDataPart::checkConsistencyBase() const
             catch (const Exception & ex)
             {
                 /// For projection parts check will mark them broken in loadProjections
-                if (!parent_part && filename.ends_with(".proj"))
+                if (!parent_part && IDataPartProjectionStorage::isProjectionDirectoryName(filename))
                 {
                     std::string projection_name = fs::path(filename).stem();
                     LOG_INFO(storage.log, "Projection {} doesn't exist on start for part {}, marking it as broken", projection_name, name);
@@ -3126,25 +3009,7 @@ IndexSize IMergeTreeDataPart::getTotalSecondaryIndicesSize() const
 
 bool IMergeTreeDataPart::hasSecondaryIndex(const String & index_name, const StorageMetadataPtr & metadata) const
 {
-    auto component_guard = Coordination::setCurrentComponent("IMergeTreeDataPart::hasSecondaryIndex");
-
-    auto file_name = getIndexFileName(index_name, metadata->escape_index_filenames);
-    return getStreamNameOrHashResolved(file_name, ".idx").has_value()
-        || getStreamNameOrHashResolved(file_name, ".idx2").has_value();
-}
-
-bool IMergeTreeDataPart::isSkipIndexInPackedArchive(const IMergeTreeIndex & skip_index) const
-{
-    const auto * disk_storage = dynamic_cast<const DataPartStorageOnDiskBase *>(&getDataPartStorage());
-    if (!disk_storage)
-        return false;
-    const String file_name = skip_index.getFileName();
-    /// Probe what the part actually holds, not the writer's current `getSubstreams`, so a legacy
-    /// member inside `skp_idx.packed` on an upgraded part is found.
-    for (const auto & substream : skip_index.getAllSubstreamsInPart(checksums, file_name, &getDataPartStorage()))
-        if (disk_storage->isFileInPackedSkipIndicesArchive(file_name + substream.suffix + substream.extension))
-            return true;
-    return false;
+    return getIndexStorage().exists(index_name, metadata->escape_index_filenames);
 }
 
 void IMergeTreeDataPart::accumulateColumnSizes(ColumnToSize & column_to_size) const

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -173,11 +173,14 @@ public:
     /// Returns true if there is materialized index with specified name in part.
     bool hasSecondaryIndex(const String & index_name, const StorageMetadataPtr & metadata) const;
 
-    /// True iff any of @index's substreams (base plus side streams like .dct/.pst for text indices)
-    /// is stored inside this part's skp_idx.packed archive. Probing every substream, not just
-    /// .idx/.idx2, keeps a mixed-layout index from looking absent and losing its packed side
-    /// streams. Returns false on storages without a packed archive.
-    bool isSkipIndexInPackedArchive(const IMergeTreeIndex & skip_index) const;
+    /// Facets of the part composition. The part itself is the logical representation;
+    /// each facet owns the on-disk structure of one of its sub-blocks.
+    const IDataPartIndexStorage & getIndexStorage() const { return *index_storage; }
+    /// Lazily picks the statistics representation (packed archive vs per-column files)
+    /// from the loaded checksums on first access.
+    const IDataPartStatisticsStorage & getStatisticsStorage() const;
+    /// Placement of this projection inside the parent part. Only for projection parts.
+    const IDataPartProjectionStorage & getProjectionStorage() const;
 
     /// Return information about column size on disk for all columns in part
     ColumnSize getTotalColumnsSize() const;
@@ -237,8 +240,6 @@ public:
 
     void remove();
 
-    ColumnsStatistics loadStatistics() const;
-    ColumnsStatistics loadStatistics(const Names & required_columns) const;
     Estimates getEstimates() const;
     void setEstimates(const Estimates & new_estimates);
 
@@ -804,11 +805,6 @@ private:
     /// The number of subcolumns can be infinite due to dynamic subcolumns in JSON, so we use LRU cache here.
     mutable Poco::LRUCache<String, ColumnSize> subcolumns_sizes_cache = Poco::LRUCache<String, ColumnSize>(1024);
 
-    /// PackedFilesReader for statistics archive.
-    /// Lazily loaded on first access to loadStatistics when packed format is used.
-    mutable std::mutex statistics_reader_mutex;
-    mutable std::unique_ptr<PackedFilesReader> statistics_reader TSA_GUARDED_BY(statistics_reader_mutex);
-
 protected:
     /// Total size on disk, not only columns. May not contain size of
     /// checksums.txt and columns.txt. 0 - if not counted;
@@ -822,6 +818,18 @@ protected:
     String parent_part_name;
 
     mutable std::map<String, std::shared_ptr<IMergeTreeDataPart>> projection_parts;
+
+    /// On-disk structure facets of the part sub-blocks (secondary indexes, statistics).
+    /// The part composes them; each facet answers structural questions about its sub-block.
+    DataPartIndexStoragePtr index_storage;
+
+    /// The statistics representation depends on the part's checksums, which are loaded after
+    /// construction, so the facet is created lazily by getStatisticsStorage.
+    mutable std::mutex statistics_storage_mutex;
+    mutable DataPartStatisticsStoragePtr statistics_storage TSA_GUARDED_BY(statistics_storage_mutex);
+
+    /// Placement of this projection inside the parent part. Not null only for projection parts.
+    DataPartProjectionStoragePtr projection_storage;
 
     /// Set of source parts for patch parts. Empty for regular parts.
     SourcePartsSetForPatch source_parts_set;
@@ -923,10 +931,6 @@ private:
     /// any specifial compression.
     void loadDefaultCompressionCodec();
     void loadSourcePartsSet();
-
-    ColumnsStatistics loadStatisticsPacked(const PackedFilesReader & reader, const NameSet & required_columns) const;
-    ColumnsStatistics loadStatisticsWide(const NameSet & required_columns) const;
-    PackedFilesReader * getStatisticsPackedReader() const;
 
     void writeColumns(const NamesAndTypesList & columns_, const WriteSettings & settings);
 

--- a/src/Storages/MergeTree/MergeProjectionPartsTask.cpp
+++ b/src/Storages/MergeTree/MergeProjectionPartsTask.cpp
@@ -60,7 +60,7 @@ bool MergeProjectionPartsTask::executeStep()
         if (next_level_parts.empty())
         {
             LOG_DEBUG(log, "Merged a projection part in level {}", current_level);
-            selected_parts[0]->renameTo(projection.name + ".proj", true);
+            selected_parts[0]->renameTo(IDataPartProjectionStorage::getDirectoryName(projection.name), true);
             selected_parts[0]->setName(projection.name);
             selected_parts[0]->is_temp = false;
             selected_parts[0]->temp_projection_block_number.reset();
@@ -116,7 +116,7 @@ bool MergeProjectionPartsTask::executeStep()
             NO_TRANSACTION_PTR,
             &projection,
             new_data_part.get(),
-            ".tmp_proj");
+            String(IDataPartProjectionStorage::TEMPORARY_PROJECTION_DIRECTORY_SUFFIX));
 
         next_level_parts.push_back(executeHere(tmp_part_merge_task));
 

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -869,7 +869,7 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
             if (result_statistics.empty())
                 continue;
 
-            auto part_statistics = part->loadStatistics();
+            auto part_statistics = part->getStatisticsStorage().load();
 
             for (const auto & [column_name, column_stats] : result_statistics)
             {
@@ -2191,7 +2191,7 @@ bool MergeTask::MergeProjectionsStage::prepareProjections() const
         auto projection_future_part = std::make_shared<FutureMergedMutatedPart>();
         projection_future_part->assign(std::move(projection_parts), /*patch_parts_=*/ {}, projection);
         projection_future_part->name = projection->name;
-        projection_future_part->path = global_ctx->future_part->path + "/" + projection->name + ".proj/";
+        projection_future_part->path = global_ctx->future_part->path + "/" + IDataPartProjectionStorage::getDirectoryName(projection->name) + "/";
         projection_future_part->part_info = MergeListElement::FAKE_RESULT_PART_FOR_PROJECTION;
 
         MergeTreeData::MergingParams projection_merging_params;
@@ -2219,7 +2219,7 @@ bool MergeTask::MergeProjectionsStage::prepareProjections() const
             projection,
             global_ctx->new_data_part.get(),
             projection->with_parent_part_offset ? global_ctx->merged_part_offsets : nullptr,
-            ".proj",
+            String(IDataPartProjectionStorage::PROJECTION_DIRECTORY_SUFFIX),
             NO_TRANSACTION_PTR,
             global_ctx->data,
             global_ctx->mutator,

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -920,7 +920,7 @@ ConditionSelectivityEstimatorPtr MergeTreeData::getConditionSelectivityEstimator
     for (const auto & part : parts)
     {
         auto parts_lock = readLockParts();
-        auto stats = part.data_part->loadStatistics(required_columns);
+        auto stats = part.data_part->getStatisticsStorage().load(required_columns);
         estimator_builder.markDataPart(part.data_part);
         for (const auto & [column_name, stat] : stats)
             estimator_builder.addStatistics(column_name, stat);
@@ -3308,7 +3308,7 @@ try
     for (const DataPartPtr & data_part : data_parts)
     {
         auto parts_lock = readLockParts();
-        auto stats = data_part->loadStatistics();
+        auto stats = data_part->getStatisticsStorage().load();
         estimator_builder.markDataPart(data_part);
         for (const auto & [column_name, stat] : stats)
             estimator_builder.addStatistics(column_name, stat);
@@ -8151,32 +8151,35 @@ MergeTreeData::PartsBackupEntries MergeTreeData::backupParts(
         }
 
         BackupEntries backup_entries_from_part;
-        part->getDataPartStorage().backup(
-            part->checksums,
-            part->getFileNamesWithoutChecksums(),
-            data_path_in_backup,
-            backup_settings,
-            make_temporary_hard_links,
-            backup_entries_from_part,
-            &temp_dirs,
-            false, false);
+        part->getDataPartStorage().backup(IDataPartStorage::BackupParams
+        {
+            .checksums = part->checksums,
+            .files_without_checksums = part->getFileNamesWithoutChecksums(),
+            .path_in_backup = data_path_in_backup,
+            .backup_settings = backup_settings,
+            .make_temporary_hard_links = make_temporary_hard_links,
+            .backup_entries = backup_entries_from_part,
+            .temp_dirs = &temp_dirs,
+        });
 
         auto backup_projection = [&](IDataPartStorage & storage, IMergeTreeDataPart & projection_part)
         {
-            storage.backup(
-                projection_part.checksums,
-                projection_part.getFileNamesWithoutChecksums(),
-                fs::path{data_path_in_backup} / part->name,
-                backup_settings,
-                make_temporary_hard_links,
-                backup_entries_from_part,
-                &temp_dirs,
-                projection_part.is_broken,
-                backup_settings.allow_backup_broken_projections);
+            storage.backup(IDataPartStorage::BackupParams
+            {
+                .checksums = projection_part.checksums,
+                .files_without_checksums = projection_part.getFileNamesWithoutChecksums(),
+                .path_in_backup = fs::path{data_path_in_backup} / part->name,
+                .backup_settings = backup_settings,
+                .make_temporary_hard_links = make_temporary_hard_links,
+                .backup_entries = backup_entries_from_part,
+                .temp_dirs = &temp_dirs,
+                .is_projection_part = projection_part.is_broken,
+                .allow_backup_broken_projection = backup_settings.allow_backup_broken_projections,
+            });
         };
 
         auto projection_parts = part->getProjectionParts();
-        std::string proj_suffix = ".proj";
+        std::string proj_suffix{IDataPartProjectionStorage::PROJECTION_DIRECTORY_SUFFIX};
         std::unordered_set<String> defined_projections;
 
         for (const auto & [projection_name, projection_part] : projection_parts)

--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -227,7 +227,7 @@ MergedBlockOutputStream::Finalizer MergedBlockOutputStream::finalizePartAsync(
     for (const auto & [projection_name, projection_part] : new_part->getProjectionParts())
     {
         checksums.addFile(
-            projection_name + ".proj",
+            IDataPartProjectionStorage::getDirectoryName(projection_name),
             projection_part->checksums.getTotalSizeOnDisk(),
             projection_part->checksums.getTotalChecksumUInt128());
     }

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1350,8 +1350,8 @@ static NameToNameVector collectFilesForRenames(
         }
         else if (command.type == MutationCommand::Type::DROP_PROJECTION)
         {
-            if (source_part->checksums.has(command.column_name + ".proj"))
-                add_rename(command.column_name + ".proj", "");
+            if (source_part->checksums.has(IDataPartProjectionStorage::getDirectoryName(command.column_name)))
+                add_rename(IDataPartProjectionStorage::getDirectoryName(command.column_name), "");
         }
         else if (isWidePart(source_part))
         {
@@ -2271,7 +2271,7 @@ static bool isIndexResolvableFromOwnFiles(
     const MergeTreeSettings & data_settings,
     const String & index_name)
 {
-    if (source_part->isSkipIndexInPackedArchive(index))
+    if (source_part->getIndexStorage().isInPackedArchive(index))
         return true;
 
     const auto & index_factory = MergeTreeIndexFactory::instance();
@@ -2459,7 +2459,7 @@ private:
             /// with different number of marks.
             bool need_recalculate = ctx->materialized_indices.contains(idx.name)
                 || (!is_full_wide_part && ctx->source_part->hasSecondaryIndex(idx.name, ctx->metadata_snapshot))
-                || ctx->source_part->isSkipIndexInPackedArchive(*index_ptr)
+                || ctx->source_part->getIndexStorage().isInPackedArchive(*index_ptr)
                 || index_checksums_missing;
 
             if (need_recalculate)
@@ -2766,7 +2766,7 @@ public:
 private:
     void prepare()
     {
-        ctx->all_gathered_data.statistics = ctx->source_part->loadStatistics();
+        ctx->all_gathered_data.statistics = ctx->source_part->getStatisticsStorage().load();
 
         MutationHelpers::processStatisticsChanges(
             ctx->files_to_skip,
@@ -3094,7 +3094,7 @@ private:
                 if (projection_part->checksums.empty())
                     continue;
                 ctx->new_data_part->checksums.addFile(
-                    projection_name + ".proj",
+                    IDataPartProjectionStorage::getDirectoryName(projection_name),
                     projection_part->checksums.getTotalSizeOnDisk(),
                     projection_part->checksums.getTotalChecksumUInt128());
             }
@@ -3572,7 +3572,7 @@ void updateIndicesToRecalculateAndDrop(std::shared_ptr<MutationContext> & ctx)
                 continue;
 
             auto surviving_index = index_factory.get(ctx->metadata_snapshot, index, *ctx->data->getSettings());
-            if (!source_part->isSkipIndexInPackedArchive(*surviving_index))
+            if (!source_part->getIndexStorage().isInPackedArchive(*surviving_index))
                 continue;
 
             const String surviving_file_name = surviving_index->getFileName();
@@ -3626,7 +3626,7 @@ void updateIndicesToRecalculateAndDrop(std::shared_ptr<MutationContext> & ctx)
             || (source_has_archive && writer_can_open_archive);
         if (!archive_dirty)
             for (const auto & idx : ctx->indices_to_recalc)
-                if (source_part->isSkipIndexInPackedArchive(*idx)) { archive_dirty = true; break; }
+                if (source_part->getIndexStorage().isInPackedArchive(*idx)) { archive_dirty = true; break; }
 
         if (archive_dirty)
         {

--- a/src/Storages/MergeTree/WhatIfStatisticalEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfStatisticalEstimator.cpp
@@ -41,7 +41,7 @@ bool tryEstimateWithStatistics(
 
     for (const auto & part : parts)
     {
-        auto stats = part.data_part->loadStatistics();
+        auto stats = part.data_part->getStatisticsStorage().load();
         if (!stats.empty())
         {
             builder.markDataPart(part.data_part);

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -325,7 +325,7 @@ static IMergeTreeDataPart::Checksums checkDataPart(
         auto file_name = it->name();
 
         /// We will check projections later.
-        if (data_part_storage.existsDirectory(file_name) && file_name.ends_with(".proj"))
+        if (data_part_storage.existsDirectory(file_name) && IDataPartProjectionStorage::isProjectionDirectoryName(file_name))
         {
             projections_on_disk.insert(file_name);
             continue;
@@ -359,7 +359,7 @@ static IMergeTreeDataPart::Checksums checkDataPart(
         if (is_cancelled())
             return {};
 
-        auto projection_file = name + ".proj";
+        auto projection_file = IDataPartProjectionStorage::getDirectoryName(name);
 
         IMergeTreeDataPart::Checksums projection_checksums;
         try
@@ -449,7 +449,7 @@ static IMergeTreeDataPart::Checksums checkDataPart(
     {
         Names removed_projection_files;
         for (const auto & [name, _] : checksums_txt.files)
-            if (name.ends_with(".proj") && !checksums_data.files.contains(name))
+            if (IDataPartProjectionStorage::isProjectionDirectoryName(name) && !checksums_data.files.contains(name))
                 removed_projection_files.push_back(name);
 
         if (!removed_projection_files.empty())

--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -1,4 +1,5 @@
 #include <Storages/ProjectionsDescription.h>
+#include <Storages/MergeTree/IDataPartStorage.h>
 #include <DataTypes/DataTypeString.h>
 
 #include <Access/AccessControl.h>
@@ -74,6 +75,12 @@ extern const MergeTreeSettingsBool add_minmax_index_for_block_number_column;
 extern const MergeTreeSettingsBool add_minmax_index_for_block_offset_column;
 
 }
+
+String ProjectionDescription::getDirectoryName() const
+{
+    return IDataPartProjectionStorage::getDirectoryName(name);
+}
+
 
 bool ProjectionDescription::isPrimaryKeyColumnPossiblyWrappedInFunctions(const ASTPtr & node) const
 {

--- a/src/Storages/ProjectionsDescription.h
+++ b/src/Storages/ProjectionsDescription.h
@@ -158,7 +158,8 @@ struct ProjectionDescription
     /// Only the query AST is used to compute the output block.
     Block calculateByQuery(const Block & block, UInt64 starting_offset, ContextPtr context, const IColumnPermutation * perm_ptr = nullptr) const;
 
-    String getDirectoryName() const { return name + ".proj"; }
+    /// "<name>.proj"; see IDataPartProjectionStorage.
+    String getDirectoryName() const;
 };
 
 using ProjectionDescriptionRawPtr = const ProjectionDescription *;

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -5834,7 +5834,10 @@ MergeTreeData::MutableDataPartPtr StorageReplicatedMergeTree::fetchExistsPart(
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Part {} fetched on wrong disk {}", part->name, part->getDataPartStorage().getDiskName());
 
         auto replaced_path = fs::path(replaced_part_path);
-        part->getDataPartStorage().rename(replaced_path.parent_path(), replaced_path.filename(), nullptr, true, false);
+        part->getDataPartStorage().rename(
+            replaced_path.parent_path(),
+            replaced_path.filename(),
+            IDataPartStorage::RenameParams{.remove_new_dir_if_exists = true});
     }
     catch (const Exception & e)
     {


### PR DESCRIPTION
First preparatory step towards per-part manifest files: break the data part monolith into storage facets and clean up per-operation argument lists, with no behavior change.

- Introduce `IDataPartProjectionStorage`, `IDataPartIndexStorage` and `IDataPartStatisticsStorage` with on-disk implementations. `IMergeTreeDataPart` composes them and exposes `getIndexStorage`, `getStatisticsStorage` and `getProjectionStorage`; `loadStatistics`, `isSkipIndexInPackedArchive` and the statistics packed reader moved into the facets.
- Gather the argument zoo of `IDataPartStorage::remove`, `backup` and `rename` into per-operation params structs (`RemoveParams`, `BackupParams`, `RenameParams`).
- Route `.proj`/`.tmp_proj` directory naming through `IDataPartProjectionStorage` helpers.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
TODO
