### PR TITLE
Push down catalog filters for system.iceberg_history

### DIFF
--- a/src/Storages/System/StorageSystemIcebergHistory.cpp
+++ b/src/Storages/System/StorageSystemIcebergHistory.cpp
@@ -27,6 +27,7 @@
 #include <Storages/SelectQueryInfo.h>
 #include <Storages/System/StorageSystemIcebergHistory.h>
 #include <Storages/System/SystemTableSourceRegistry.h>
+#include <Storages/System/extractTableNameFilter.h>
 #include <Storages/VirtualColumnUtils.h>
 
 #if USE_AVRO
@@ -160,6 +161,8 @@ void StorageSystemIcebergHistory::fillData(
     MutableColumnPtr database_column = ColumnString::create();
     MutableColumnPtr table_column = ColumnString::create();
 
+    const TablesFilter tables_filter = extractTableNameFilter(predicate, "table");
+
     for (size_t i = 0; i < filtered_databases.size(); ++i)
     {
         const String database_name{filtered_databases.getDataAt(i)};
@@ -167,10 +170,10 @@ void StorageSystemIcebergHistory::fillData(
         if (!database)
             continue;
 
-        for (auto iterator = database->getTablesIterator(context_copy, {}, true); iterator->isValid(); iterator->next())
+        for (const auto & table_details : database->getLightweightTablesIteratorWithHint(context_copy, {}, true, tables_filter))
         {
             database_column->insert(database_name);
-            table_column->insert(iterator->name());
+            table_column->insert(table_details.name);
         }
     }
 

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -1,6 +1,7 @@
 #include <Storages/System/StorageSystemTables.h>
 #include <Storages/System/DatabaseTablesCursor.h>
 #include <Storages/System/SystemTableSourceRegistry.h>
+#include <Storages/System/extractTableNameFilter.h>
 
 #include <set>
 
@@ -36,12 +37,8 @@
 #include <Storages/StorageView.h>
 #include <Storages/System/getQueriedColumnsMaskAndHeader.h>
 #include <Storages/VirtualColumnUtils.h>
-#include <Columns/ColumnConst.h>
-#include <Functions/IFunction.h>
 #include <Common/Exception.h>
-#include <Common/StringUtils.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
-#include <Common/typeid_cast.h>
 
 #include <boost/range/adaptor/map.hpp>
 
@@ -55,140 +52,6 @@ namespace Setting
     extern const SettingsBool show_table_uuid_in_table_create_query_if_not_nil;
     extern const SettingsBool show_data_lake_catalogs_in_system_tables;
     extern const SettingsBool show_remote_databases_in_system_tables;
-}
-
-namespace
-{
-
-/// Try to read a constant string from `node` and return its single value.
-/// Unwraps aliases and reads the value via `ColumnConst::getField`, which works
-/// even for a `ColumnConst` of logical size 0 (a "pure" constant, as produced by
-/// the analyzer) — unlike `column[0]`, which an `empty()` check has to guard.
-std::optional<String> tryReadConstString(const ActionsDAG::Node * node)
-{
-    while (node && node->type == ActionsDAG::ActionType::ALIAS && !node->children.empty())
-        node = node->children[0];
-    if (!node || !node->column)
-        return {};
-    const IColumn * column = node->column.get();
-    /// Unwrap `ColumnConst` to its single-row data column. This reads the value
-    /// even for a `ColumnConst` of logical size 0 (the analyzer's "pure" constant).
-    if (const auto * const_column = typeid_cast<const ColumnConst *>(column))
-        column = &const_column->getDataColumn();
-    if (column->empty())
-        return {};
-    Field field = (*column)[0];
-    if (field.getType() != Field::Types::String)
-        return {};
-    return field.safeGet<String>();
-}
-
-/// Unwrap ALIAS nodes to reach the underlying node.
-const ActionsDAG::Node * skipAliases(const ActionsDAG::Node * node)
-{
-    while (node && node->type == ActionsDAG::ActionType::ALIAS && !node->children.empty())
-        node = node->children[0];
-    return node;
-}
-
-/// Escape SQL LIKE wildcards (`%`, `_`) and the escape char (`\`) so a literal
-/// prefix (e.g. from `startsWith`) becomes an equivalent LIKE pattern.
-String escapeForLikeLiteral(const String & s)
-{
-    String result;
-    result.reserve(s.size());
-    for (char c : s)
-    {
-        if (c == '%' || c == '_' || c == '\\')
-            result += '\\';
-        result += c;
-    }
-    return result;
-}
-
-/// Extract a namespace-pushdown hint from a top-level `name` conjunct: `name = '…'`
-/// (Equals), or `name LIKE '…%'` / its analyzer rewrite `startsWith(name, '…')` (Like).
-TablesFilter extractTableNameFilter(const ActionsDAG::Node * predicate)
-{
-    if (!predicate)
-        return {};
-
-    /// Collect top-level conjuncts.
-    std::vector<const ActionsDAG::Node *> conjuncts;
-    const auto * node = predicate;
-    while (node->type == ActionsDAG::ActionType::ALIAS && !node->children.empty())
-        node = node->children[0];
-
-    if (node->type == ActionsDAG::ActionType::FUNCTION
-        && node->function_base
-        && node->function_base->getName() == "and")
-    {
-        for (const auto * child : node->children)
-            conjuncts.push_back(child);
-    }
-    else
-    {
-        conjuncts.push_back(node);
-    }
-
-    TablesFilter like_filter;
-    for (const auto * conjunct : conjuncts)
-    {
-        while (conjunct->type == ActionsDAG::ActionType::ALIAS && !conjunct->children.empty())
-            conjunct = conjunct->children[0];
-
-        if (conjunct->type != ActionsDAG::ActionType::FUNCTION
-            || !conjunct->function_base
-            || conjunct->children.size() != 2)
-            continue;
-
-        const auto & fn_name = conjunct->function_base->getName();
-
-        const auto * lhs = skipAliases(conjunct->children[0]);
-        const auto * rhs = skipAliases(conjunct->children[1]);
-
-        /// The `name` column reads as an INPUT named "name" once aliases are
-        /// unwrapped. (A constant carries `column`; the column reference does not.)
-        auto is_name_column = [](const ActionsDAG::Node * n)
-        {
-            return n && n->result_name == "name" && !n->column;
-        };
-        const bool lhs_is_name = is_name_column(lhs);
-        const bool rhs_is_name = is_name_column(rhs);
-        if (!lhs_is_name && !rhs_is_name)
-            continue;
-
-        if (fn_name == "equals")
-        {
-            /// `equals` is symmetric (literal either side); prefer it — most selective.
-            if (auto literal = tryReadConstString(lhs_is_name ? rhs : lhs))
-                return {TablesFilter::Kind::Equals, std::move(*literal)};
-        }
-        else if (fn_name == "like")
-        {
-            /// Not symmetric: only `name LIKE 'pattern'` (name on lhs) constrains `name`.
-            /// Keep the first such pattern if no `equals` is found.
-            if (lhs_is_name && like_filter.kind == TablesFilter::Kind::None)
-            {
-                if (auto literal = tryReadConstString(rhs))
-                    like_filter = {TablesFilter::Kind::Like, std::move(*literal)};
-            }
-        }
-        else if (fn_name == "startsWith")
-        {
-            /// Analyzer rewrite of a perfect-prefix `name LIKE 'prefix%'`. The literal
-            /// is a plain prefix, so escape it and append `%` to recover the LIKE pattern.
-            if (lhs_is_name && like_filter.kind == TablesFilter::Kind::None)
-            {
-                if (auto literal = tryReadConstString(rhs))
-                    like_filter = {TablesFilter::Kind::Like, escapeForLikeLiteral(*literal) + "%"};
-            }
-        }
-    }
-
-    return like_filter;
-}
-
 }
 
 namespace detail
@@ -230,7 +93,7 @@ ColumnPtr getFilteredTables(
 
     TablesFilter tables_filter;
     if (dag)
-        tables_filter = extractTableNameFilter(dag->getOutputs().at(0));
+        tables_filter = extractTableNameFilter(dag->getOutputs().at(0), "name");
 
     if (dag)
     {
@@ -1237,7 +1100,7 @@ void ReadFromSystemTables::applyFilters(ActionDAGNodes added_filter_nodes)
         ColumnWithTypeAndName(nullptr, std::make_shared<DataTypeString>(), "uuid"),
         ColumnWithTypeAndName(nullptr, std::make_shared<DataTypeString>(), "engine")};
     if (auto dag = VirtualColumnUtils::splitFilterDagForAllowedInputs(predicate, &sample, context))
-        tables_filter = extractTableNameFilter(dag->getOutputs().at(0));
+        tables_filter = extractTableNameFilter(dag->getOutputs().at(0), "name");
 }
 
 void ReadFromSystemTables::initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)

--- a/src/Storages/System/extractTableNameFilter.cpp
+++ b/src/Storages/System/extractTableNameFilter.cpp
@@ -1,0 +1,137 @@
+#include <Storages/System/extractTableNameFilter.h>
+
+#include <Columns/ColumnConst.h>
+#include <Functions/IFunction.h>
+#include <Common/typeid_cast.h>
+
+
+namespace DB
+{
+
+namespace
+{
+
+/// Try to read a constant string from `node` and return its single value.
+/// Unwraps aliases and reads the value via `ColumnConst::getField`, which works
+/// even for a `ColumnConst` of logical size 0 (a "pure" constant, as produced by
+/// the analyzer) — unlike `column[0]`, which an `empty` check has to guard.
+std::optional<String> tryReadConstString(const ActionsDAG::Node * node)
+{
+    while (node && node->type == ActionsDAG::ActionType::ALIAS && !node->children.empty())
+        node = node->children[0];
+    if (!node || !node->column)
+        return {};
+    const IColumn * column = node->column.get();
+    /// Unwrap `ColumnConst` to its single-row data column. This reads the value
+    /// even for a `ColumnConst` of logical size 0 (the analyzer's "pure" constant).
+    if (const auto * const_column = typeid_cast<const ColumnConst *>(column))
+        column = &const_column->getDataColumn();
+    if (column->empty())
+        return {};
+    Field field = (*column)[0];
+    if (field.getType() != Field::Types::String)
+        return {};
+    return field.safeGet<String>();
+}
+
+/// Unwrap ALIAS nodes to reach the underlying node.
+const ActionsDAG::Node * skipAliases(const ActionsDAG::Node * node)
+{
+    while (node && node->type == ActionsDAG::ActionType::ALIAS && !node->children.empty())
+        node = node->children[0];
+    return node;
+}
+
+/// Escape SQL LIKE wildcards (`%`, `_`) and the escape char (`\`) so a literal
+/// prefix (e.g. from `startsWith`) becomes an equivalent LIKE pattern.
+String escapeForLikeLiteral(const String & s)
+{
+    String result;
+    result.reserve(s.size());
+    for (char c : s)
+    {
+        if (c == '%' || c == '_' || c == '\\')
+            result += '\\';
+        result += c;
+    }
+    return result;
+}
+
+}
+
+TablesFilter extractTableNameFilter(const ActionsDAG::Node * predicate, const String & column_name)
+{
+    if (!predicate)
+        return {};
+
+    /// Collect top-level conjuncts.
+    std::vector<const ActionsDAG::Node *> conjuncts;
+    const auto * node = predicate;
+    while (node->type == ActionsDAG::ActionType::ALIAS && !node->children.empty())
+        node = node->children[0];
+
+    if (node->type == ActionsDAG::ActionType::FUNCTION && node->function_base && node->function_base->getName() == "and")
+    {
+        for (const auto * child : node->children)
+            conjuncts.push_back(child);
+    }
+    else
+    {
+        conjuncts.push_back(node);
+    }
+
+    TablesFilter like_filter;
+    for (const auto * conjunct : conjuncts)
+    {
+        while (conjunct->type == ActionsDAG::ActionType::ALIAS && !conjunct->children.empty())
+            conjunct = conjunct->children[0];
+
+        if (conjunct->type != ActionsDAG::ActionType::FUNCTION || !conjunct->function_base || conjunct->children.size() != 2)
+            continue;
+
+        const auto & function_name = conjunct->function_base->getName();
+
+        const auto * lhs = skipAliases(conjunct->children[0]);
+        const auto * rhs = skipAliases(conjunct->children[1]);
+
+        /// The filtered column reads as an INPUT named `column_name` once aliases
+        /// are unwrapped. A constant carries `column`; the column reference does not.
+        auto is_filtered_column = [&](const ActionsDAG::Node * current_node)
+        { return current_node && current_node->result_name == column_name && !current_node->column; };
+        const bool lhs_is_filtered_column = is_filtered_column(lhs);
+        const bool rhs_is_filtered_column = is_filtered_column(rhs);
+        if (!lhs_is_filtered_column && !rhs_is_filtered_column)
+            continue;
+
+        if (function_name == "equals")
+        {
+            /// `equals` is symmetric (literal either side); prefer it — most selective.
+            if (auto literal = tryReadConstString(lhs_is_filtered_column ? rhs : lhs))
+                return {TablesFilter::Kind::Equals, std::move(*literal)};
+        }
+        else if (function_name == "like")
+        {
+            /// Not symmetric: only `column LIKE 'pattern'` constrains the column.
+            /// Keep the first such pattern if no `equals` is found.
+            if (lhs_is_filtered_column && like_filter.kind == TablesFilter::Kind::None)
+            {
+                if (auto literal = tryReadConstString(rhs))
+                    like_filter = {TablesFilter::Kind::Like, std::move(*literal)};
+            }
+        }
+        else if (function_name == "startsWith")
+        {
+            /// Analyzer rewrite of a perfect-prefix `column LIKE 'prefix%'`. The literal
+            /// is a plain prefix, so escape it and append `%` to recover the LIKE pattern.
+            if (lhs_is_filtered_column && like_filter.kind == TablesFilter::Kind::None)
+            {
+                if (auto literal = tryReadConstString(rhs))
+                    like_filter = {TablesFilter::Kind::Like, escapeForLikeLiteral(*literal) + "%"};
+            }
+        }
+    }
+
+    return like_filter;
+}
+
+}

--- a/src/Storages/System/extractTableNameFilter.h
+++ b/src/Storages/System/extractTableNameFilter.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <Databases/IDatabase.h>
+#include <Interpreters/ActionsDAG.h>
+
+
+namespace DB
+{
+
+/// Extract a namespace-pushdown hint from a predicate on `column_name`.
+TablesFilter extractTableNameFilter(const ActionsDAG::Node * predicate, const String & column_name);
+
+}

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -294,8 +294,8 @@ def escape_like_literal(s):
 
 def test_namespace_filter_pushdown(started_cluster):
     """
-    Verify that `system.tables` and `system.iceberg_history` predicates that fully bind the namespace
-    (`name`/`table = '<ns>.<table>'`, `name`/`table LIKE '<ns>.%'`) only fetch the table list
+    Verify that `system.tables` predicates that fully bind the namespace
+    (`name = '<ns>.<table>'`, `name LIKE '<ns>.%'`) only fetch the table list
     from the targeted namespace instead of enumerating the whole catalog.
     See issue #105022.
 
@@ -397,19 +397,59 @@ def test_namespace_filter_pushdown(started_cluster):
         one_table,
     )
 
-    # `system.iceberg_history` exposes the catalog table name as `table`, but
-    # should pass the same namespace hint to the catalog.
-    assert_scoped(
-        f"SELECT count() FROM system.iceberg_history WHERE database = '{CATALOG_NAME}' "
-        f"AND table LIKE '{escape_like_literal(namespace_1)}.%'",
-        "0",
+
+def test_iceberg_history_namespace_filter_pushdown(started_cluster):
+    """
+    A predicate on `system.iceberg_history.table` must be passed to the REST
+    catalog so ClickHouse requests the target namespace's table list only.
+
+    The result alone cannot prove pushdown because filtering after a full catalog
+    scan returns the same rows. `RestCatalog` logs every namespace whose `/tables`
+    endpoint it requests, so this test verifies that the target request happens
+    and the sibling request does not.
+    """
+    node = started_cluster.instances["node1"]
+
+    root_namespace = f"clickhouse_{uuid.uuid4()}"
+    target_namespace = f"{root_namespace}.target"
+    sibling_namespace = f"{root_namespace}.sibling"
+    table_name = "history_table"
+
+    catalog = load_catalog_impl(started_cluster)
+    catalog.create_namespace(target_namespace)
+    catalog.create_namespace(sibling_namespace)
+
+    target_table = create_table(catalog, target_namespace, table_name)
+    target_table.append(pa.Table.from_pylist([generate_record()]))
+    sibling_table = create_table(catalog, sibling_namespace, table_name)
+    sibling_table.append(pa.Table.from_pylist([generate_record()]))
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+
+    target_table_name = f"{target_namespace}.{table_name}"
+    target_log_message = (
+        f"Received tables response for namespace: {target_namespace}"
+    )
+    sibling_log_message = (
+        f"Received tables response for namespace: {sibling_namespace}"
     )
 
-    assert_scoped(
-        f"SELECT count() FROM system.iceberg_history WHERE database = '{CATALOG_NAME}' "
-        f"AND table = '{one_table}'",
-        "0",
-    )
+    predicates = [
+        f"table = '{target_table_name}'",
+        f"table LIKE '{escape_like_literal(target_namespace)}.%'",
+    ]
+    for predicate in predicates:
+        target_requests_before = int(node.count_in_log(target_log_message))
+        sibling_requests_before = int(node.count_in_log(sibling_log_message))
+
+        result = node.query(
+            f"SELECT DISTINCT table FROM system.iceberg_history "
+            f"WHERE database = '{CATALOG_NAME}' AND {predicate}"
+        ).strip()
+
+        assert result == target_table_name
+        assert int(node.count_in_log(target_log_message)) == target_requests_before + 1
+        assert int(node.count_in_log(sibling_log_message)) == sibling_requests_before
 
 
 def test_check_database(started_cluster):

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -294,8 +294,8 @@ def escape_like_literal(s):
 
 def test_namespace_filter_pushdown(started_cluster):
     """
-    Verify that `system.tables` predicates that fully bind the namespace
-    (`name = '<ns>.<table>'`, `name LIKE '<ns>.%'`) only fetch the table list
+    Verify that `system.tables` and `system.iceberg_history` predicates that fully bind the namespace
+    (`name`/`table = '<ns>.<table>'`, `name`/`table LIKE '<ns>.%'`) only fetch the table list
     from the targeted namespace instead of enumerating the whole catalog.
     See issue #105022.
 
@@ -395,6 +395,20 @@ def test_namespace_filter_pushdown(started_cluster):
         f"SELECT name FROM system.tables WHERE database = '{CATALOG_NAME}' AND name = '{one_table}' ORDER BY name "
         "SETTINGS show_data_lake_catalogs_in_system_tables = true",
         one_table,
+    )
+
+    # `system.iceberg_history` exposes the catalog table name as `table`, but
+    # should pass the same namespace hint to the catalog.
+    assert_scoped(
+        f"SELECT count() FROM system.iceberg_history WHERE database = '{CATALOG_NAME}' "
+        f"AND table LIKE '{escape_like_literal(namespace_1)}.%'",
+        "0",
+    )
+
+    assert_scoped(
+        f"SELECT count() FROM system.iceberg_history WHERE database = '{CATALOG_NAME}' "
+        f"AND table = '{one_table}'",
+        "0",
     )
 
 


### PR DESCRIPTION
Pushes equality, `LIKE`, and `startsWith` predicates on `system.iceberg_history.table` through the database table iterator hint. Data lake catalogs can therefore list only matching namespaces instead of enumerating the whole catalog before filtering.

The predicate extraction introduced for `system.tables` is shared so both system tables use the same pushdown behavior. The REST catalog integration test verifies that matching queries do not fetch a sibling namespace.

Related: https://github.com/ClickHouse/ClickHouse/pull/106029


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Queries to `system.iceberg_history` with filters on `table` now avoid listing unrelated data lake catalog namespaces.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=113867&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/113867](https://github.com/search?q=head%3Async-upstream%2Fpr%2F113867+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.283` (included in `26.10` and later)
<!-- ch-version-info:end -->