### PR TITLE
Do not run Python in the forked child when launching Spark's gateway

### DIFF
--- a/tests/integration/helpers/spark_tools.py
+++ b/tests/integration/helpers/spark_tools.py
@@ -1,40 +1,45 @@
-import contextlib
 import logging
 import os
-import subprocess
 
 import pyspark
+import pyspark.java_gateway
 from pyspark.context import SparkContext
 from pyspark.sql import SparkSession
 
 
-@contextlib.contextmanager
-def _fork_safe_popen():
-    """Replace pyspark's ``preexec_fn`` with ``start_new_session`` while the
-    gateway launches.
+def _make_gateway_launch_fork_safe():
+    """Give pyspark's gateway launch ``start_new_session`` instead of ``preexec_fn``.
 
-    ``preexec_fn`` disables both of CPython's exec-only launch paths
+    ``preexec_fn`` rules out both of CPython's exec-only launch paths
     (``posix_spawn`` and ``vfork`` each require it to be ``None``), so a plain
     ``fork()`` runs Python in the child. A lock a sibling thread held at fork
     time is then held in the child forever, so it never execs and the parent
     blocks in ``os.read(errpipe_read)`` until the test times out.
 
     ``start_new_session`` keeps SIGINT away from the JVM without running Python
-    in the child: the signal goes to the foreground process group, which the
-    child is no longer part of.
-    """
-    original_init = subprocess.Popen.__init__
+    in the child: the signal is delivered to the foreground process group, which
+    the child is no longer part of.
 
-    def __init__(self, *args, **kwargs):
+    ``launch_gateway`` resolves ``Popen`` through its own module global, so only
+    that name is rebound. It is done once at import, because restoring a
+    process-wide default around each launch would let concurrent launches strip
+    each other's protection and leave the wrapper installed for good.
+    """
+    if getattr(pyspark.java_gateway.Popen, "_clickhouse_fork_safe", False):
+        return
+
+    launcher = pyspark.java_gateway.Popen
+
+    def popen(*args, **kwargs):
         if kwargs.pop("preexec_fn", None) is not None:
             kwargs.setdefault("start_new_session", True)
-        original_init(self, *args, **kwargs)
+        return launcher(*args, **kwargs)
 
-    subprocess.Popen.__init__ = __init__
-    try:
-        yield
-    finally:
-        subprocess.Popen.__init__ = original_init
+    popen._clickhouse_fork_safe = True
+    pyspark.java_gateway.Popen = popen
+
+
+_make_gateway_launch_fork_safe()
 
 
 def write_spark_log_config(log_dir):
@@ -134,8 +139,7 @@ class ResilientSparkSession:
         if SparkContext._gateway is not None and not _gateway_is_live():
             logging.warning("Cached py4j gateway is dead, discarding it")
             _reset_pyspark_class_state()
-        with _fork_safe_popen():
-            return self._create()
+        return self._create()
 
     def _restart(self):
         logging.warning("Spark session is dead, restarting...")

--- a/tests/integration/helpers/spark_tools.py
+++ b/tests/integration/helpers/spark_tools.py
@@ -1,9 +1,40 @@
+import contextlib
 import logging
 import os
+import subprocess
 
 import pyspark
 from pyspark.context import SparkContext
 from pyspark.sql import SparkSession
+
+
+@contextlib.contextmanager
+def _fork_safe_popen():
+    """Replace pyspark's ``preexec_fn`` with ``start_new_session`` while the
+    gateway launches.
+
+    ``preexec_fn`` disables both of CPython's exec-only launch paths
+    (``posix_spawn`` and ``vfork`` each require it to be ``None``), so a plain
+    ``fork()`` runs Python in the child. A lock a sibling thread held at fork
+    time is then held in the child forever, so it never execs and the parent
+    blocks in ``os.read(errpipe_read)`` until the test times out.
+
+    ``start_new_session`` keeps SIGINT away from the JVM without running Python
+    in the child: the signal goes to the foreground process group, which the
+    child is no longer part of.
+    """
+    original_init = subprocess.Popen.__init__
+
+    def __init__(self, *args, **kwargs):
+        if kwargs.pop("preexec_fn", None) is not None:
+            kwargs.setdefault("start_new_session", True)
+        original_init(self, *args, **kwargs)
+
+    subprocess.Popen.__init__ = __init__
+    try:
+        yield
+    finally:
+        subprocess.Popen.__init__ = original_init
 
 
 def write_spark_log_config(log_dir):
@@ -103,7 +134,8 @@ class ResilientSparkSession:
         if SparkContext._gateway is not None and not _gateway_is_live():
             logging.warning("Cached py4j gateway is dead, discarding it")
             _reset_pyspark_class_state()
-        return self._create()
+        with _fork_safe_popen():
+            return self._create()
 
     def _restart(self):
         logging.warning("Spark session is dead, restarting...")

--- a/tests/integration/test_paimon_spark_smoke/test.py
+++ b/tests/integration/test_paimon_spark_smoke/test.py
@@ -12,6 +12,9 @@ import shutil
 import pyspark
 import pytest
 
+# Imported for its fork-safe gateway launch: pyspark's own preexec_fn runs
+# Python in the forked child, which can deadlock in a threaded worker.
+from helpers import spark_tools  # noqa: F401
 from helpers.cluster import ClickHouseCluster
 from helpers.s3_tools import LocalUploader
 

--- a/tests/integration/test_spark_session_recovery/test.py
+++ b/tests/integration/test_spark_session_recovery/test.py
@@ -6,6 +6,7 @@ import threading
 
 import pyspark
 import pyspark.java_gateway
+import pytest
 from pyspark.context import SparkContext
 from pyspark.sql import SparkSession
 
@@ -13,6 +14,10 @@ from helpers import spark_tools
 from helpers.spark_tools import ResilientSparkSession
 
 
+# The deadlock this pins happens inside the Popen constructor, before any call
+# with a timeout of its own, so the test carries its own bound: a regression
+# fails here in seconds instead of stalling the worker for the global 900 s.
+@pytest.mark.timeout(120)
 def test_gateway_launch_does_not_run_python_in_the_forked_child():
     """A gateway launch must not run Python in the forked child.
 

--- a/tests/integration/test_spark_session_recovery/test.py
+++ b/tests/integration/test_spark_session_recovery/test.py
@@ -1,5 +1,7 @@
 import os
 import signal
+import subprocess
+import threading
 
 import pyspark
 from pyspark.context import SparkContext
@@ -7,6 +9,58 @@ from pyspark.sql import SparkSession
 
 from helpers import spark_tools
 from helpers.spark_tools import ResilientSparkSession
+
+
+def test_gateway_launch_does_not_fork_deadlock():
+    """A relaunch must not run Python in the forked child.
+
+    pyspark's ``launch_gateway`` passes ``preexec_fn``, which rules out both
+    ``posix_spawn`` and ``vfork``, so the child runs Python and blocks on any
+    lock a sibling thread held at fork time; the parent then hangs in
+    ``os.read(errpipe_read)`` until the test times out. The factory below
+    reproduces that exact call, so without the fix this deadlocks rather than
+    fails.
+    """
+    held = threading.Lock()
+    held.acquire()
+    threading.Thread(target=held.acquire, daemon=True).start()
+
+    launched = []
+
+    def factory():
+        def preexec_func():
+            signal.signal(signal.SIGINT, signal.SIG_IGN)  # pyspark's own
+            held.acquire()  # stands in for inherited locked state
+
+        proc = subprocess.Popen(
+            ["/bin/true"],
+            stdin=subprocess.PIPE,
+            env=dict(os.environ),
+            preexec_fn=preexec_func,
+        )
+        proc.communicate()
+        launched.append(proc.returncode)
+        return "session"
+
+    with spark_tools._fork_safe_popen():
+        factory()
+    assert launched == [0]
+
+    # The shim is scoped: outside it pyspark's argument is untouched.
+    seen = {}
+    original_init = subprocess.Popen.__init__
+
+    def spy(self, *args, **kwargs):
+        seen.update(kwargs)
+        return original_init(self, *args, **kwargs)
+
+    subprocess.Popen.__init__ = spy
+    try:
+        subprocess.Popen(["/bin/true"], preexec_fn=lambda: None).communicate()
+    finally:
+        subprocess.Popen.__init__ = original_init
+    assert seen.get("preexec_fn") is not None
+    assert seen.get("start_new_session") is None
 
 
 def _jvm_proc():

--- a/tests/integration/test_spark_session_recovery/test.py
+++ b/tests/integration/test_spark_session_recovery/test.py
@@ -1,9 +1,11 @@
 import os
 import signal
 import subprocess
+import sys
 import threading
 
 import pyspark
+import pyspark.java_gateway
 from pyspark.context import SparkContext
 from pyspark.sql import SparkSession
 
@@ -11,56 +13,39 @@ from helpers import spark_tools
 from helpers.spark_tools import ResilientSparkSession
 
 
-def test_gateway_launch_does_not_fork_deadlock():
-    """A relaunch must not run Python in the forked child.
+def test_gateway_launch_does_not_run_python_in_the_forked_child():
+    """A gateway launch must not run Python in the forked child.
 
-    pyspark's ``launch_gateway`` passes ``preexec_fn``, which rules out both
-    ``posix_spawn`` and ``vfork``, so the child runs Python and blocks on any
-    lock a sibling thread held at fork time; the parent then hangs in
-    ``os.read(errpipe_read)`` until the test times out. The factory below
-    reproduces that exact call, so without the fix this deadlocks rather than
-    fails.
+    ``preexec_fn`` rules out both ``posix_spawn`` and ``vfork``, so the child
+    runs Python and blocks on any lock a sibling thread held at fork time; the
+    parent then hangs in ``os.read(errpipe_read)`` until the test times out. The
+    launch below goes through the same ``Popen`` name ``launch_gateway`` uses and
+    blocks on such a lock, so without the fix it deadlocks rather than fails.
     """
     held = threading.Lock()
     held.acquire()
     threading.Thread(target=held.acquire, daemon=True).start()
 
-    launched = []
+    def preexec_func():
+        signal.signal(signal.SIGINT, signal.SIG_IGN)  # pyspark's own
+        held.acquire()  # stands in for state locked at fork time
 
-    def factory():
-        def preexec_func():
-            signal.signal(signal.SIGINT, signal.SIG_IGN)  # pyspark's own
-            held.acquire()  # stands in for inherited locked state
+    # The child reports the identity Spark's signal isolation depends on, so
+    # dropping preexec_fn without setting start_new_session fails here too.
+    reporter = "import os; print(os.getpid() == os.getsid(0))"
+    proc = pyspark.java_gateway.Popen(
+        [sys.executable, "-c", reporter],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        env=dict(os.environ),
+        preexec_fn=preexec_func,
+    )
+    out, _ = proc.communicate(timeout=60)
+    assert proc.returncode == 0
+    assert out.strip() == b"True", "child must lead its own session"
 
-        proc = subprocess.Popen(
-            ["/bin/true"],
-            stdin=subprocess.PIPE,
-            env=dict(os.environ),
-            preexec_fn=preexec_func,
-        )
-        proc.communicate()
-        launched.append(proc.returncode)
-        return "session"
-
-    with spark_tools._fork_safe_popen():
-        factory()
-    assert launched == [0]
-
-    # The shim is scoped: outside it pyspark's argument is untouched.
-    seen = {}
-    original_init = subprocess.Popen.__init__
-
-    def spy(self, *args, **kwargs):
-        seen.update(kwargs)
-        return original_init(self, *args, **kwargs)
-
-    subprocess.Popen.__init__ = spy
-    try:
-        subprocess.Popen(["/bin/true"], preexec_fn=lambda: None).communicate()
-    finally:
-        subprocess.Popen.__init__ = original_init
-    assert seen.get("preexec_fn") is not None
-    assert seen.get("start_new_session") is None
+    # Only the launch is rebound; nothing else spawns processes differently.
+    assert subprocess.Popen is not pyspark.java_gateway.Popen
 
 
 def _jvm_proc():

--- a/tests/integration/test_storage_delta_shuffles/test.py
+++ b/tests/integration/test_storage_delta_shuffles/test.py
@@ -25,6 +25,9 @@ from pyspark.sql.types import (
 from decimal import Decimal
 from pyspark.sql.window import Window
 
+# Imported for its fork-safe gateway launch: pyspark's own preexec_fn runs
+# Python in the forked child, which can deadlock in a threaded worker.
+from helpers import spark_tools  # noqa: F401
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.config_cluster import minio_access_key, minio_secret_key


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/113636
Related: https://github.com/ClickHouse/ClickHouse/pull/110479
Related: https://github.com/ClickHouse/ClickHouse/pull/113697

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_spark_session_recovery` timed out after 900 s on three unrelated PRs. The deepest frame is `subprocess.py:1944`, where the parent reads the forked child's `CLOEXEC` error pipe. The kernel closes it only once the child execs or dies, so blocking there means the child never reached exec: the job log has no `spark-submit` and no `JAVA_GATEWAY_EXITED`.

`launch_gateway` passes `preexec_fn` (`java_gateway.py:96-97`) to ignore SIGINT in the JVM. Both of CPython's exec-only launch paths require it to be `None`, so a plain `fork()` is used and Python runs in the child, which `_posixsubprocess.c:1001` warns is "NOT SAFE if your application uses threads": a lock a sibling thread held at fork time is held in the child forever, so it never execs and the parent waits on a pipe nobody will close.

This change gives the launch `start_new_session` instead. The protection is preserved and stronger, since SIGINT goes to the foreground process group and the child no longer belongs to it, and no Python runs in the child, so CPython takes the `vfork` path. Only the `Popen` name `launch_gateway` resolves is rebound, once at import, so concurrent launches cannot strip each other's protection.

This test is the only one that relaunches the gateway inside a live `pytest-xdist` worker, which had 13 threads at the failure. Launching once at session start only makes the deadlock rarer, so all eight Spark suites now share this launch path.

The regression test carries its own `pytest.mark.timeout`, because the deadlock is inside the `Popen` constructor: the 900 s global bound was otherwise the only one, so a regression would stall a worker rather than report.

Validated both directions: unpatched, the test fails in 120.12 s at `os.read(errpipe_read)`, the frame CI reported; with the fix it passes in 0.18 s. A mutant dropping `preexec_fn` without setting `start_new_session` fails the session-identity assertion.
