### PR TITLE
Reject window PARTITION BY and ORDER BY over an aggregate function state

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -2964,7 +2964,7 @@ ProjectionName QueryAnalyzer::resolveWindow(QueryTreeNodePtr & node, IdentifierR
     for (const auto & partition_by_node : window_node.getPartitionBy().getNodes())
     {
         validateGroupByKeyType(partition_by_node->getResultType(), scope);
-        validateWindowPartitionByKeyType(partition_by_node->getResultType());
+        validateWindowKeyType(partition_by_node->getResultType(), "PARTITION BY");
     }
 
     ProjectionNames order_by_projection_names = resolveSortNodeList(window_node.getOrderByNode(), scope);

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -2962,7 +2962,10 @@ ProjectionName QueryAnalyzer::resolveWindow(QueryTreeNodePtr & node, IdentifierR
         false /*allow_table_expression*/);
 
     for (const auto & partition_by_node : window_node.getPartitionBy().getNodes())
+    {
         validateGroupByKeyType(partition_by_node->getResultType(), scope);
+        validateWindowPartitionByKeyType(partition_by_node->getResultType());
+    }
 
     ProjectionNames order_by_projection_names = resolveSortNodeList(window_node.getOrderByNode(), scope);
 

--- a/src/DataTypes/validateGroupByKeyType.cpp
+++ b/src/DataTypes/validateGroupByKeyType.cpp
@@ -31,17 +31,17 @@ void validateGroupByKeyType(const DataTypePtr & key_type, bool allow_suspicious_
     key_type->forEachChild(check);
 }
 
-void validateWindowPartitionByKeyType(const DataTypePtr & key_type)
+void validateWindowKeyType(const DataTypePtr & key_type, std::string_view clause)
 {
-    /// A window partition is formed by sorting, and aggregate function states are not comparable:
-    /// ColumnAggregateFunction::compareAt reports every pair equal, so the sort path collapses all
-    /// states into one partition while the scatter path hashes their bytes into different ones.
+    /// A window is formed by sorting, and aggregate function states are not comparable:
+    /// ColumnAggregateFunction::compareAt reports every pair equal.
     if (hasAggregateFunctionType(key_type))
         throw Exception(
             ErrorCodes::ILLEGAL_COLUMN,
-            "Data type {} is not allowed in window PARTITION BY keys, because it contains an aggregate function state "
+            "Data type {} is not allowed in window {} keys, because it contains an aggregate function state "
             "whose values are not comparable",
-            key_type->getName());
+            key_type->getName(),
+            clause);
 }
 
 }

--- a/src/DataTypes/validateGroupByKeyType.cpp
+++ b/src/DataTypes/validateGroupByKeyType.cpp
@@ -1,4 +1,5 @@
 #include <DataTypes/validateGroupByKeyType.h>
+#include <DataTypes/DataTypeAggregateFunction.h>
 #include <DataTypes/IDataType.h>
 #include <Common/Exception.h>
 
@@ -28,6 +29,19 @@ void validateGroupByKeyType(const DataTypePtr & key_type, bool allow_suspicious_
 
     check(*key_type);
     key_type->forEachChild(check);
+}
+
+void validateWindowPartitionByKeyType(const DataTypePtr & key_type)
+{
+    /// A window partition is formed by sorting, and aggregate function states are not comparable:
+    /// ColumnAggregateFunction::compareAt reports every pair equal, so the sort path collapses all
+    /// states into one partition while the scatter path hashes their bytes into different ones.
+    if (hasAggregateFunctionType(key_type))
+        throw Exception(
+            ErrorCodes::ILLEGAL_COLUMN,
+            "Data type {} is not allowed in window PARTITION BY keys, because it contains an aggregate function state "
+            "whose values are not comparable",
+            key_type->getName());
 }
 
 }

--- a/src/DataTypes/validateGroupByKeyType.h
+++ b/src/DataTypes/validateGroupByKeyType.h
@@ -10,8 +10,9 @@ namespace DB
 /// are found and allow_suspicious_types is false.
 void validateGroupByKeyType(const DataTypePtr & key_type, bool allow_suspicious_types);
 
-/// Additional validation for window PARTITION BY keys only. GROUP BY keys must not use it:
-/// aggregate function states are usable there, while a window partition is formed by sorting.
-void validateWindowPartitionByKeyType(const DataTypePtr & key_type);
+/// Additional validation for window PARTITION BY and ORDER BY keys only. GROUP BY keys must not
+/// use it: aggregate function states are usable there, while a window is formed by sorting.
+/// `clause` is interpolated into the error message.
+void validateWindowKeyType(const DataTypePtr & key_type, std::string_view clause);
 
 }

--- a/src/DataTypes/validateGroupByKeyType.h
+++ b/src/DataTypes/validateGroupByKeyType.h
@@ -10,4 +10,8 @@ namespace DB
 /// are found and allow_suspicious_types is false.
 void validateGroupByKeyType(const DataTypePtr & key_type, bool allow_suspicious_types);
 
+/// Additional validation for window PARTITION BY keys only. GROUP BY keys must not use it:
+/// aggregate function states are usable there, while a window partition is formed by sorting.
+void validateWindowPartitionByKeyType(const DataTypePtr & key_type);
+
 }

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -688,7 +688,7 @@ void ExpressionAnalyzer::makeWindowDescriptionFromAST(const Context & context_,
                 if (col.name == with_alias->getColumnName())
                 {
                     DB::validateGroupByKeyType(col.type, context_.getSettingsRef()[Setting::allow_suspicious_types_in_group_by]);
-                    DB::validateWindowPartitionByKeyType(col.type);
+                    DB::validateWindowKeyType(col.type, "PARTITION BY");
                 }
             }
 
@@ -713,6 +713,14 @@ void ExpressionAnalyzer::makeWindowDescriptionFromAST(const Context & context_,
 
             auto actions_dag = std::make_unique<ActionsDAG>(aggregated_columns);
             getRootActions(column_ast, false, *actions_dag);
+
+            const auto & sort_key_name = order_by_element.children.front()->getColumnName();
+            for (const auto & col : actions_dag->getResultColumns())
+            {
+                if (col.name == sort_key_name)
+                    DB::validateWindowKeyType(col.type, "ORDER BY");
+            }
+
             desc.order_by_actions.push_back(std::move(actions_dag));
         }
     }

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -686,7 +686,10 @@ void ExpressionAnalyzer::makeWindowDescriptionFromAST(const Context & context_,
             for (const auto & col : actions_dag->getResultColumns())
             {
                 if (col.name == with_alias->getColumnName())
+                {
                     DB::validateGroupByKeyType(col.type, context_.getSettingsRef()[Setting::allow_suspicious_types_in_group_by]);
+                    DB::validateWindowPartitionByKeyType(col.type);
+                }
             }
 
             desc.partition_by_actions.push_back(std::move(actions_dag));

--- a/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.reference
+++ b/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.reference
@@ -1,0 +1,30 @@
+-- new analyzer: refused
+-- old analyzer: refused
+-- comparable types are untouched, new analyzer
+6
+6
+6
+6
+-- comparable types are untouched, old analyzer
+6
+6
+6
+6
+-- GROUP BY and DISTINCT over a state stay accepted
+6
+6
+6
+6
+-- ORDER BY over a state was already refused
+-- QBit is not an aggregate state and keeps working
+6
+6
+6
+6
+-- the pre-existing Dynamic/Variant gate is undisturbed
+3
+3
+-- a state reached through Dynamic is a known gap, still accepted with the opt-in
+6
+6
+-- a state inside Variant is refused, because Variant exposes its variants as children

--- a/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.reference
+++ b/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.reference
@@ -28,3 +28,4 @@
 6
 6
 -- a state inside Variant is refused, because Variant exposes its variants as children
+-- SimpleAggregateFunction storing a state is refused, like ORDER BY already refuses it

--- a/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.reference
+++ b/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.reference
@@ -1,11 +1,18 @@
 -- the analyzer: refused
 -- old analyzer: refused
+-- window ORDER BY over a state is refused, the analyzer
+-- window ORDER BY over a state is refused, old analyzer
+-- a named WINDOW clause and a derived window are refused too, both analyzers
 -- comparable types are untouched, the analyzer
 6
 6
 6
 6
+6
+6
 -- comparable types are untouched, old analyzer
+6
+6
 6
 6
 6
@@ -17,6 +24,8 @@
 6
 -- ORDER BY over a state was already refused
 -- QBit is not an aggregate state and keeps working
+6
+6
 6
 6
 6

--- a/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.reference
+++ b/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.reference
@@ -1,6 +1,6 @@
--- new analyzer: refused
+-- the analyzer: refused
 -- old analyzer: refused
--- comparable types are untouched, new analyzer
+-- comparable types are untouched, the analyzer
 6
 6
 6

--- a/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.sql
+++ b/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.sql
@@ -112,7 +112,19 @@ SELECT count() FROM (SELECT row_number() OVER (PARTITION BY v) FROM t_wpb_var) S
 SET enable_analyzer = 0;
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY v) FROM t_wpb_var) SETTINGS allow_suspicious_types_in_group_by = 1; -- { serverError ILLEGAL_COLUMN }
 
+SELECT '-- SimpleAggregateFunction storing a state is refused, like ORDER BY already refuses it';
+DROP TABLE IF EXISTS t_wpb_saf;
+CREATE TABLE t_wpb_saf (id UInt8, sn SimpleAggregateFunction(any, AggregateFunction(uniq, UInt64))) ENGINE = Memory;
+INSERT INTO t_wpb_saf SELECT number, uniqState(number) FROM numbers(6) GROUP BY number;
+SET enable_analyzer = 1;
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY sn) FROM t_wpb_saf); -- { serverError ILLEGAL_COLUMN }
+SELECT id FROM t_wpb_saf ORDER BY sn; -- { serverError ILLEGAL_COLUMN }
+SET enable_analyzer = 0;
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY sn) FROM t_wpb_saf); -- { serverError ILLEGAL_COLUMN }
+SELECT id FROM t_wpb_saf ORDER BY sn; -- { serverError ILLEGAL_COLUMN }
+
 DROP TABLE t_wpb_state;
 DROP TABLE t_wpb_qbit;
 DROP TABLE t_wpb_dyn;
 DROP TABLE t_wpb_var;
+DROP TABLE t_wpb_saf;

--- a/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.sql
+++ b/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.sql
@@ -26,7 +26,7 @@ SELECT number, uniqState(number), [uniqState(number)], tuple(uniqState(number)),
        toString(number % 3), toString(number % 3), toString(number % 3)
 FROM numbers(6) GROUP BY number;
 
-SELECT '-- new analyzer: refused';
+SELECT '-- the analyzer: refused';
 SET enable_analyzer = 1;
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY st) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY arr) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
@@ -44,7 +44,7 @@ SELECT count() FROM (SELECT row_number() OVER (PARTITION BY mp) FROM t_wpb_state
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY deep) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY id, st) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
 
-SELECT '-- comparable types are untouched, new analyzer';
+SELECT '-- comparable types are untouched, the analyzer';
 SET enable_analyzer = 1;
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY saf) FROM t_wpb_state);
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY s) FROM t_wpb_state);

--- a/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.sql
+++ b/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.sql
@@ -1,5 +1,5 @@
--- Window PARTITION BY over an aggregate function state used to be accepted, and partitioned
--- differently depending on max_threads. It is refused now, like ORDER BY already refuses it.
+-- Window PARTITION BY and ORDER BY over an aggregate function state used to be accepted by at
+-- least one analyzer. Both are refused now, like top-level ORDER BY already refuses them.
 
 SET allow_experimental_qbit_type = 1;
 SET allow_experimental_variant_type = 1;
@@ -44,8 +44,35 @@ SELECT count() FROM (SELECT row_number() OVER (PARTITION BY mp) FROM t_wpb_state
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY deep) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY id, st) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
 
+SELECT '-- window ORDER BY over a state is refused, the analyzer';
+SET enable_analyzer = 1;
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY st) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY arr) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY tup) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY mp) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY deep) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY id ORDER BY st) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+
+SELECT '-- window ORDER BY over a state is refused, old analyzer';
+SET enable_analyzer = 0;
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY st) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY arr) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY tup) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY mp) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY deep) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY id ORDER BY st) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+
+SELECT '-- a named WINDOW clause and a derived window are refused too, both analyzers';
+SET enable_analyzer = 1;
+SELECT count() FROM (SELECT row_number() OVER w FROM t_wpb_state WINDOW w AS (ORDER BY st)); -- { serverError ILLEGAL_COLUMN }
+SET enable_analyzer = 0;
+SELECT count() FROM (SELECT row_number() OVER w FROM t_wpb_state WINDOW w AS (ORDER BY st)); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (w ROWS UNBOUNDED PRECEDING) FROM t_wpb_state WINDOW w AS (ORDER BY st)); -- { serverError ILLEGAL_COLUMN }
+
 SELECT '-- comparable types are untouched, the analyzer';
 SET enable_analyzer = 1;
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY saf) FROM t_wpb_state);
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY s) FROM t_wpb_state);
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY saf) FROM t_wpb_state);
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY s) FROM t_wpb_state);
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY lc) FROM t_wpb_state);
@@ -53,6 +80,8 @@ SELECT count() FROM (SELECT row_number() OVER (PARTITION BY nl) FROM t_wpb_state
 
 SELECT '-- comparable types are untouched, old analyzer';
 SET enable_analyzer = 0;
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY saf) FROM t_wpb_state);
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY s) FROM t_wpb_state);
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY saf) FROM t_wpb_state);
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY s) FROM t_wpb_state);
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY lc) FROM t_wpb_state);
@@ -85,6 +114,12 @@ SELECT count() FROM (SELECT row_number() OVER (PARTITION BY qa) FROM t_wpb_qbit)
 SET enable_analyzer = 0;
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY q) FROM t_wpb_qbit);
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY qa) FROM t_wpb_qbit);
+-- The window ORDER BY guard is aggregate-state-specific, so it does not widen the old analyzer's
+-- acceptance of a QBit sort key. The analyzer refuses it for being incomparable, as it already did.
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY q) FROM t_wpb_qbit);
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY qa) FROM t_wpb_qbit);
+SET enable_analyzer = 1;
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY q) FROM t_wpb_qbit); -- { serverError ILLEGAL_COLUMN }
 
 SELECT '-- the pre-existing Dynamic/Variant gate is undisturbed';
 DROP TABLE IF EXISTS t_wpb_dyn;
@@ -118,9 +153,11 @@ CREATE TABLE t_wpb_saf (id UInt8, sn SimpleAggregateFunction(any, AggregateFunct
 INSERT INTO t_wpb_saf SELECT number, uniqState(number) FROM numbers(6) GROUP BY number;
 SET enable_analyzer = 1;
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY sn) FROM t_wpb_saf); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY sn) FROM t_wpb_saf); -- { serverError ILLEGAL_COLUMN }
 SELECT id FROM t_wpb_saf ORDER BY sn; -- { serverError ILLEGAL_COLUMN }
 SET enable_analyzer = 0;
 SELECT count() FROM (SELECT row_number() OVER (PARTITION BY sn) FROM t_wpb_saf); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (ORDER BY sn) FROM t_wpb_saf); -- { serverError ILLEGAL_COLUMN }
 SELECT id FROM t_wpb_saf ORDER BY sn; -- { serverError ILLEGAL_COLUMN }
 
 DROP TABLE t_wpb_state;

--- a/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.sql
+++ b/tests/queries/0_stateless/04817_window_partition_by_aggregate_function_state.sql
@@ -1,0 +1,118 @@
+-- Window PARTITION BY over an aggregate function state used to be accepted, and partitioned
+-- differently depending on max_threads. It is refused now, like ORDER BY already refuses it.
+
+SET allow_experimental_qbit_type = 1;
+SET allow_experimental_variant_type = 1;
+SET allow_experimental_dynamic_type = 1;
+
+DROP TABLE IF EXISTS t_wpb_state;
+CREATE TABLE t_wpb_state
+(
+    id UInt8,
+    st AggregateFunction(uniq, UInt64),
+    arr Array(AggregateFunction(uniq, UInt64)),
+    tup Tuple(a AggregateFunction(uniq, UInt64)),
+    mp Map(String, AggregateFunction(uniq, UInt64)),
+    deep Array(Tuple(a AggregateFunction(uniq, UInt64))),
+    saf SimpleAggregateFunction(sum, UInt64),
+    s String,
+    lc LowCardinality(String),
+    nl Nullable(String)
+) ENGINE = Memory;
+
+INSERT INTO t_wpb_state
+SELECT number, uniqState(number), [uniqState(number)], tuple(uniqState(number)),
+       map('k', uniqState(number)), [tuple(uniqState(number))], number,
+       toString(number % 3), toString(number % 3), toString(number % 3)
+FROM numbers(6) GROUP BY number;
+
+SELECT '-- new analyzer: refused';
+SET enable_analyzer = 1;
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY st) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY arr) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY tup) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY mp) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY deep) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY id, st) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+
+SELECT '-- old analyzer: refused';
+SET enable_analyzer = 0;
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY st) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY arr) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY tup) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY mp) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY deep) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY id, st) FROM t_wpb_state); -- { serverError ILLEGAL_COLUMN }
+
+SELECT '-- comparable types are untouched, new analyzer';
+SET enable_analyzer = 1;
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY saf) FROM t_wpb_state);
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY s) FROM t_wpb_state);
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY lc) FROM t_wpb_state);
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY nl) FROM t_wpb_state);
+
+SELECT '-- comparable types are untouched, old analyzer';
+SET enable_analyzer = 0;
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY saf) FROM t_wpb_state);
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY s) FROM t_wpb_state);
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY lc) FROM t_wpb_state);
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY nl) FROM t_wpb_state);
+
+SELECT '-- GROUP BY and DISTINCT over a state stay accepted';
+SET enable_analyzer = 1;
+SELECT count() FROM (SELECT st FROM t_wpb_state GROUP BY st);
+SELECT count() FROM (SELECT DISTINCT st FROM t_wpb_state);
+SET enable_analyzer = 0;
+SELECT count() FROM (SELECT st FROM t_wpb_state GROUP BY st);
+SELECT count() FROM (SELECT DISTINCT st FROM t_wpb_state);
+
+SELECT '-- ORDER BY over a state was already refused';
+SET enable_analyzer = 1;
+SELECT st FROM t_wpb_state ORDER BY st; -- { serverError ILLEGAL_COLUMN }
+SET enable_analyzer = 0;
+SELECT st FROM t_wpb_state ORDER BY st; -- { serverError ILLEGAL_COLUMN }
+
+SELECT '-- QBit is not an aggregate state and keeps working';
+DROP TABLE IF EXISTS t_wpb_qbit;
+CREATE TABLE t_wpb_qbit (id UInt8, q QBit(BFloat16, 16), qa Array(QBit(BFloat16, 16))) ENGINE = Memory;
+INSERT INTO t_wpb_qbit
+SELECT number, arrayMap(x -> toFloat32(number), range(16))::QBit(BFloat16, 16),
+       [arrayMap(x -> toFloat32(number), range(16))::QBit(BFloat16, 16)]
+FROM numbers(6);
+SET enable_analyzer = 1;
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY q) FROM t_wpb_qbit);
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY qa) FROM t_wpb_qbit);
+SET enable_analyzer = 0;
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY q) FROM t_wpb_qbit);
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY qa) FROM t_wpb_qbit);
+
+SELECT '-- the pre-existing Dynamic/Variant gate is undisturbed';
+DROP TABLE IF EXISTS t_wpb_dyn;
+CREATE TABLE t_wpb_dyn (d Dynamic, val UInt64) ENGINE = Memory;
+INSERT INTO t_wpb_dyn VALUES (1, 10), (2, 20), ('str', 30);
+SET enable_analyzer = 1;
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY d) FROM t_wpb_dyn); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY d) FROM t_wpb_dyn) SETTINGS allow_suspicious_types_in_group_by = 1;
+SET enable_analyzer = 0;
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY d) FROM t_wpb_dyn); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY d) FROM t_wpb_dyn) SETTINGS allow_suspicious_types_in_group_by = 1;
+
+SELECT '-- a state reached through Dynamic is a known gap, still accepted with the opt-in';
+SET enable_analyzer = 1;
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY CAST(st, 'Dynamic')) FROM t_wpb_state) SETTINGS allow_suspicious_types_in_group_by = 1;
+SET enable_analyzer = 0;
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY CAST(st, 'Dynamic')) FROM t_wpb_state) SETTINGS allow_suspicious_types_in_group_by = 1;
+
+SELECT '-- a state inside Variant is refused, because Variant exposes its variants as children';
+DROP TABLE IF EXISTS t_wpb_var;
+CREATE TABLE t_wpb_var (v Variant(AggregateFunction(uniq, UInt64), String), val UInt64) ENGINE = Memory;
+INSERT INTO t_wpb_var SELECT uniqState(number)::Variant(AggregateFunction(uniq, UInt64), String), number FROM numbers(3) GROUP BY number;
+SET enable_analyzer = 1;
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY v) FROM t_wpb_var) SETTINGS allow_suspicious_types_in_group_by = 1; -- { serverError ILLEGAL_COLUMN }
+SET enable_analyzer = 0;
+SELECT count() FROM (SELECT row_number() OVER (PARTITION BY v) FROM t_wpb_var) SETTINGS allow_suspicious_types_in_group_by = 1; -- { serverError ILLEGAL_COLUMN }
+
+DROP TABLE t_wpb_state;
+DROP TABLE t_wpb_qbit;
+DROP TABLE t_wpb_dyn;
+DROP TABLE t_wpb_var;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/113247
-->


### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A window `PARTITION BY` or `ORDER BY` over an `AggregateFunction` column is now rejected with `ILLEGAL_COLUMN`, as top-level `ORDER BY` over such a column already was. Previously such a query was accepted by at least one analyzer, and window `PARTITION BY` partitioned differently depending on `max_threads`. The refusal also covers a state nested in `Array`, `Tuple`, `Map`, `Variant` or `SimpleAggregateFunction`. A `SimpleAggregateFunction` over an ordinary type, `QBit`, and `GROUP BY` and `DISTINCT` over a state, are unaffected.


### Description

The two partitioning paths react differently to a state: the sort path calls `ColumnAggregateFunction::compareAt`, a stub returning `0` unconditionally, so all states collapse into one partition, while the scatter path hashes their raw bytes and scatters them. On the reporter's fixture `dense_rank()` gives `1,1,2,3,4,5,6,7,8` at `max_threads = 1` and `1,1,2,3,1,4,2,5,6` at `max_threads = 8`.

Validation missed it because window `PARTITION BY` routes through `validateGroupByKeyType`, which rejects only `Dynamic` and `Variant`, not through `validateSortingKeyType`, which carries the comparability check. The old analyzer's window `ORDER BY` branch validated no sort-key types at all, so `rank() OVER (ORDER BY st)` over nine distinct states returned nine `1`s there while the analyzer refused it. Both clauses are now guarded in both analyzers; guarding one leaves the other wrong.

The predicate is the existing `hasAggregateFunctionType` rather than a comparability predicate, which would also reject `QBit`; control rows pin that for both clauses. It follows a `SimpleAggregateFunction` to its storage type, so `SimpleAggregateFunction(sum, UInt64)` stays accepted while `SimpleAggregateFunction(any, AggregateFunction(uniq, UInt64))` is refused. `GROUP BY` and `DISTINCT` over a state are stable and untouched, so the shared helper is unchanged. No `SettingsChangesHistory.cpp` entry is owed, as in PR 105450.

Validated on debug builds with each server's `buildId` asserted before any verdict: the test fails on the parent and passes here, 50 randomized and 50 plain runs pass, each mutant is caught only by the rows meant to catch it, and a 162-test window slice has the same deterministic failures on both binaries.

<details><summary>Compatibility note on projections</summary>

A projection whose SELECT contains `OVER (PARTITION BY <state>)` could be created before this change. A server restart still loads the table and all its rows, dropping the projection from `system.projections` so its parts stop being used. An explicit `ATTACH TABLE` of such a table instead fails with `ILLEGAL_COLUMN` and leaves it detached until the next restart. The merged `Dynamic` and `Variant` equivalent, PR 105450, behaves the same way on master today. No stateless test can pin this, because the fixed binary cannot create the projection the case starts from. The `ORDER BY` half adds nothing here: a projection sorting a window by a state is refused identically before and after.

</details>

One boundary left for you to rule on, also asked in the issue thread: a state reached through `Dynamic` shows the same instability but is not covered, `Dynamic` exposing no children; it needs `allow_suspicious_types_in_group_by = 1`, whose error text already warns about unexpected results. A state inside `Variant` *is* refused. Both pinned by the test.
