### PR TITLE
Make countMatches observe cancellation and max_execution_time

### DIFF
--- a/src/Functions/countMatches.cpp
+++ b/src/Functions/countMatches.cpp
@@ -167,8 +167,12 @@ public:
                     budget.charge();
 
                     if (count_matches_stop_at_empty_match)
+                    {
+                        /// The matcher may have scanned the rest of the value to find this match.
+                        budget.charge(end - pos);
                         /// Progress should be made, but with empty match the progress will not be done.
                         break;
+                    }
 
                     /// Progress is made by a single character in case the pattern does not match or have zero-byte match.
                     /// The reason is simply because the pattern could match another part of input when forwarded.

--- a/src/Functions/countMatches.cpp
+++ b/src/Functions/countMatches.cpp
@@ -154,17 +154,18 @@ public:
             /// for zero-width assertions such as `\b` and `^`. The returned offsets are relative to `begin`.
             if (re.match(begin, end - begin, pos - begin, matches, matches_limit))
             {
-                /// Charged for the distance scanned, which is not the distance `pos` advances: an empty match
-                /// moves `pos` a single byte however far ahead the match was found.
-                budget.charge(matches[0].offset + matches[0].length - (pos - begin));
-
                 if (matches[0].length > 0)
                 {
+                    /// Charged for the distance scanned, which is not the distance `pos` advances.
+                    budget.charge(matches[0].offset + matches[0].length - (pos - begin));
                     pos = begin + matches[0].offset + matches[0].length;
                     ++match_count;
                 }
                 else
                 {
+                    /// `offset` is not a position for an empty match, so only the byte `pos` advances is charged.
+                    budget.charge();
+
                     if (count_matches_stop_at_empty_match)
                         /// Progress should be made, but with empty match the progress will not be done.
                         break;

--- a/src/Functions/countMatches.cpp
+++ b/src/Functions/countMatches.cpp
@@ -7,6 +7,7 @@
 #include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeString.h>
+#include <Functions/CancellationBudget.h>
 #include <Functions/Regexps.h>
 #include <Interpreters/Context.h>
 
@@ -66,6 +67,12 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
+        std::function<void()> check_cancellation = makeCancellationCheck(name);
+
+        /// The bulk paths below return without entering the match loop, so they are covered only here.
+        if (check_cancellation)
+            check_cancellation();
+
         const IColumn * col_pattern = arguments[1].column.get();
         const ColumnConst * col_pattern_const = checkAndGetColumnConst<ColumnString>(col_pattern);
         if (col_pattern_const == nullptr)
@@ -75,11 +82,14 @@ public:
 
         const IColumn * col_haystack = arguments[0].column.get();
         OptimizedRegularExpression::MatchVec matches;
+        /// One budget for the whole call, so a block of cheap rows accumulates towards a check instead of
+        /// resetting per row.
+        CancellationBudget budget(check_cancellation);
 
         if (const ColumnConst * col_haystack_const = checkAndGetColumnConstStringOrFixedString(col_haystack))
         {
             auto str = col_haystack_const->getDataColumn().getDataAt(0);
-            uint64_t matches_count = countMatches(str, re, matches);
+            uint64_t matches_count = countMatches(str, re, matches, budget);
             return result_type->createColumnConst(input_rows_count, matches_count);
         }
         if (const ColumnString * col_haystack_string = checkAndGetColumn<ColumnString>(col_haystack))
@@ -101,7 +111,7 @@ public:
                 Pos end = reinterpret_cast<Pos>(&src_chars[current_src_offset]);
 
                 std::string_view str(pos, end - pos);
-                vec_res[i] = countMatches(str, re, matches);
+                vec_res[i] = countMatches(str, re, matches, budget);
             }
 
             return col_res;
@@ -116,7 +126,7 @@ public:
             for (size_t i = 0; i < input_rows_count; ++i)
             {
                 std::string_view str = col_haystack_fixedstring->getDataAt(i);
-                vec_res[i] = countMatches(str, re, matches);
+                vec_res[i] = countMatches(str, re, matches, budget);
             }
 
             return col_res;
@@ -124,7 +134,11 @@ public:
         throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Could not cast haystack argument to String or FixedString");
     }
 
-    uint64_t countMatches(std::string_view src, const OptimizedRegularExpression & re, OptimizedRegularExpression::MatchVec & matches) const
+    uint64_t countMatches(
+        std::string_view src,
+        const OptimizedRegularExpression & re,
+        OptimizedRegularExpression::MatchVec & matches,
+        CancellationBudget & budget) const
     {
         /// Only one match is required, no need to copy more.
         static const unsigned matches_limit = 1;
@@ -140,6 +154,10 @@ public:
             /// for zero-width assertions such as `\b` and `^`. The returned offsets are relative to `begin`.
             if (re.match(begin, end - begin, pos - begin, matches, matches_limit))
             {
+                /// Charged for the distance scanned, which is not the distance `pos` advances: an empty match
+                /// moves `pos` a single byte however far ahead the match was found.
+                budget.charge(matches[0].offset + matches[0].length - (pos - begin));
+
                 if (matches[0].length > 0)
                 {
                     pos = begin + matches[0].offset + matches[0].length;
@@ -157,7 +175,11 @@ public:
                 }
             }
             else
+            {
+                /// A failing match scans the rest of the string before the loop is left.
+                budget.charge(end - pos);
                 break;
+            }
         }
 
         return match_count;

--- a/tests/queries/0_stateless/04822_count_matches_cancellation.reference
+++ b/tests/queries/0_stateless/04822_count_matches_cancellation.reference
@@ -4,6 +4,7 @@ fixed string: stopped within bound
 many rows: stopped within bound
 sparse matches: stopped within bound
 empty matches: stopped within bound
+empty stop: stopped within bound
 case insensitive: stopped within bound
 break pipeline: stopped within bound
 TIMEOUT_EXCEEDED

--- a/tests/queries/0_stateless/04822_count_matches_cancellation.reference
+++ b/tests/queries/0_stateless/04822_count_matches_cancellation.reference
@@ -3,6 +3,7 @@ pipeline: stopped within bound
 fixed string: stopped within bound
 many rows: stopped within bound
 sparse matches: stopped within bound
+empty matches: stopped within bound
 case insensitive: stopped within bound
 break pipeline: stopped within bound
 TIMEOUT_EXCEEDED

--- a/tests/queries/0_stateless/04822_count_matches_cancellation.reference
+++ b/tests/queries/0_stateless/04822_count_matches_cancellation.reference
@@ -1,0 +1,14 @@
+fold: stopped within bound
+pipeline: stopped within bound
+fixed string: stopped within bound
+many rows: stopped within bound
+sparse matches: stopped within bound
+case insensitive: stopped within bound
+break pipeline: stopped within bound
+TIMEOUT_EXCEEDED
+kill query: killed within bound
+stored expression: stopped within bound
+stored expression leak: no query state retained
+100	0	0	0	2	0	1	2	2	1	1	2	1	0	1	2	2	3
+0	0	0	0	1
+190

--- a/tests/queries/0_stateless/04822_count_matches_cancellation.sh
+++ b/tests/queries/0_stateless/04822_count_matches_cancellation.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Tags: long, no-fasttest, no-parallel, no-flaky-check
-# no-parallel: case 8 samples the process-wide `CurrentMetrics::QueryNonInternal`.
+# no-parallel: case 9 samples the process-wide `CurrentMetrics::QueryNonInternal`.
 # no-flaky-check: The test verifies a timeout-based behavior and is not suitable for rerun-based flakiness detection.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -28,8 +28,8 @@ DEADLINE=$(to_seconds "$DEADLINE_MS")
 # $5 = "fold" if the call is constant-folded (no pipeline), empty for a pipeline case,
 # $6 = the deadline in milliseconds (default `DEADLINE_MS`)
 #
-# Regexp compilation is pinned off so a pattern this test has already run cannot arrive compiled: the
-# compiled-regexp cache is server-global with a compile threshold of 3, and this test runs up to 5 times.
+# Regexp compilation is pinned off belt-and-braces: this function builds its matcher directly and never
+# consults that setting, so the pins are inert here and only keep the client invocations uniform.
 #
 # Two messages report the same enforced deadline and only one carries a number: `CancellationChecker` can
 # win the race against this function's own check, and its error then has no elapsed part to read. For a
@@ -107,6 +107,14 @@ run "sparse matches" \
 #     when the match is empty, so this is also the shape that would read one if it were read unguarded.
 run "empty matches" \
     "SELECT countMatches(materialize(repeat(repeat('a', 1000000), 60)), 'x*') FROM numbers(1) FORMAT Null"
+
+# 5c. The legacy empty-match setting leaves the loop at the first empty match, so that single match attempt
+#     is the only chance to observe the deadline. `\b` makes the match a boundary rather than the position
+#     asked for, so the matcher scans to the end of the value before reporting a zero-length match, and the
+#     counted classes are what make that scan cost enough to outlast the deadline. Charging one unit for it
+#     would put the whole call under a single unit per row.
+run "empty stop" \
+    "SELECT sum(countMatches(materialize(concat(repeat(' ', 1000000), 'a')), '\\\\b(?:[^ ]{8}|[^a]{9}|[^b]{11}|[^c]{13})*')) FROM numbers(1600) SETTINGS max_block_size = 1600, count_matches_stop_at_empty_match = 1"
 
 # 6. `countMatchesCaseInsensitive`, the second registered function: the same template with
 #    `case_insensitive = true`, so it is covered by construction rather than by its own charge.

--- a/tests/queries/0_stateless/04822_count_matches_cancellation.sh
+++ b/tests/queries/0_stateless/04822_count_matches_cancellation.sh
@@ -20,6 +20,18 @@ BOUND=$((SCALE * 4000))
 # What a bound allows on top of its deadline. A case that needs a deadline of its own keeps this
 # allowance rather than the bound itself, so shortening a deadline does not loosen the assertion with it.
 SLACK_MS=$((BOUND - DEADLINE_MS))
+# The two cases below whose haystack is a megabyte per row. Materializing `BIG_ROWS` megabytes is not
+# interruptible here, so it has to cost well under `BIG_DEADLINE_MS` or the query stops in the prologue
+# and the case passes whatever the function does. Only the thread sanitizer is slow enough for a
+# gigabyte and a half to reach that deadline, and it slows the match loop three times harder than the
+# materialization, which is the room this trade needs. The other sanitizers stay on the larger haystack,
+# where they need every row of it to outlast the deadline at all.
+BIG_ROWS=1600
+BIG_DEADLINE_MS=$DEADLINE_MS
+if [ -n "$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS' AND value LIKE '%sanitize=thread%'")" ]; then
+    BIG_ROWS=200
+    BIG_DEADLINE_MS=4000
+fi
 # `max_execution_time` is given in seconds; every deadline here is a whole number of milliseconds.
 to_seconds() { printf '%d.%03d' "$(($1 / 1000))" "$(($1 % 1000))"; }
 DEADLINE=$(to_seconds "$DEADLINE_MS")
@@ -96,11 +108,12 @@ run "many rows" \
 # 5. One match per row over a megabyte: about two loop iterations per row, so an iteration counter alone
 #    never reaches its threshold and the deadline is observed only because the bytes each match scanned are
 #    charged too. This is the case that distinguishes charging bytes from counting iterations. The rows must
-#    arrive in one block, which puts the whole haystack in memory at once, so the row count is what keeps
-#    that block well inside the 5G `max_memory_usage` the test profile sets; the alternation pattern rather
-#    than a larger block is what makes the call outlast the deadline.
+#    arrive in one block, which puts the whole haystack in memory at once, so `BIG_ROWS` is what keeps that
+#    block well inside the 5G `max_memory_usage` the test profile sets; the alternation pattern rather than
+#    a larger block is what makes the call outlast the deadline.
 run "sparse matches" \
-    "SELECT sum(countMatches(materialize(concat(repeat('a', 1000000), 'b')), '(a|aa|aaa|aaaa)*b')) FROM numbers(1600) SETTINGS max_block_size = 1600"
+    "SELECT sum(countMatches(materialize(concat(repeat('a', 1000000), 'b')), '(a|aa|aaa|aaaa)*b')) FROM numbers($BIG_ROWS) SETTINGS max_block_size = $BIG_ROWS" \
+    throw "" "" "$BIG_DEADLINE_MS"
 
 # 5b. A pattern that matches empty, which advances a single byte per iteration and reaches its own charge
 #     rather than the one a non-empty match reaches. A whole-match offset is a sentinel and not a position
@@ -114,7 +127,8 @@ run "empty matches" \
 #     counted classes are what make that scan cost enough to outlast the deadline. Charging one unit for it
 #     would put the whole call under a single unit per row.
 run "empty stop" \
-    "SELECT sum(countMatches(materialize(concat(repeat(' ', 1000000), 'a')), '\\\\b(?:[^ ]{8}|[^a]{9}|[^b]{11}|[^c]{13})*')) FROM numbers(1600) SETTINGS max_block_size = 1600, count_matches_stop_at_empty_match = 1"
+    "SELECT sum(countMatches(materialize(concat(repeat(' ', 1000000), 'a')), '\\\\b(?:[^ ]{8}|[^a]{9}|[^b]{11}|[^c]{13})*')) FROM numbers($BIG_ROWS) SETTINGS max_block_size = $BIG_ROWS, count_matches_stop_at_empty_match = 1" \
+    throw "" "" "$BIG_DEADLINE_MS"
 
 # 6. `countMatchesCaseInsensitive`, the second registered function: the same template with
 #    `case_insensitive = true`, so it is covered by construction rather than by its own charge.

--- a/tests/queries/0_stateless/04822_count_matches_cancellation.sh
+++ b/tests/queries/0_stateless/04822_count_matches_cancellation.sh
@@ -95,9 +95,18 @@ run "many rows" \
 
 # 5. One match per row over a megabyte: about two loop iterations per row, so an iteration counter alone
 #    never reaches its threshold and the deadline is observed only because the bytes each match scanned are
-#    charged too. This is the case that distinguishes charging bytes from counting iterations.
+#    charged too. This is the case that distinguishes charging bytes from counting iterations. The rows must
+#    arrive in one block, which puts the whole haystack in memory at once, so the row count is what keeps
+#    that block well inside the 5G `max_memory_usage` the test profile sets; the alternation pattern rather
+#    than a larger block is what makes the call outlast the deadline.
 run "sparse matches" \
-    "SELECT sum(countMatches(materialize(concat(repeat('a', 1000000), 'b')), '[^a]')) FROM numbers(4000) SETTINGS max_block_size = 4000"
+    "SELECT sum(countMatches(materialize(concat(repeat('a', 1000000), 'b')), '(a|aa|aaa|aaaa)*b')) FROM numbers(1600) SETTINGS max_block_size = 1600"
+
+# 5b. A pattern that matches empty, which advances a single byte per iteration and reaches its own charge
+#     rather than the one a non-empty match reaches. A whole-match offset is a sentinel and not a position
+#     when the match is empty, so this is also the shape that would read one if it were read unguarded.
+run "empty matches" \
+    "SELECT countMatches(materialize(repeat(repeat('a', 1000000), 60)), 'x*') FROM numbers(1) FORMAT Null"
 
 # 6. `countMatchesCaseInsensitive`, the second registered function: the same template with
 #    `case_insensitive = true`, so it is covered by construction rather than by its own charge.

--- a/tests/queries/0_stateless/04822_count_matches_cancellation.sh
+++ b/tests/queries/0_stateless/04822_count_matches_cancellation.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Tags: long, no-fasttest, no-parallel, no-flaky-check
+# no-parallel: case 8 samples the process-wide `CurrentMetrics::QueryNonInternal`.
+# no-flaky-check: The test verifies a timeout-based behavior and is not suitable for rerun-based flakiness detection.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Every timing case bounds how long a `countMatches` call runs past the deadline it was given: the fix
+# bounds it, the unfixed code does not. Each one keeps its prologue - materializing an argument, reading
+# rows, building a block - small and puts the cost inside the function, because the prologue is not
+# interruptible by this fix. A sanitizer or coverage build stretches both sides, so the bound scales;
+# coverage never reaches CXX_FLAGS and has to be read from its own `system.build_options` row.
+DEADLINE_MS=2000
+SCALE=1
+[ -n "$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS' AND value LIKE '%sanitize=%'")" ] && SCALE=2
+case "$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'WITH_COVERAGE'")" in ON|1) SCALE=2 ;; esac
+BOUND=$((SCALE * 4000))
+# What a bound allows on top of its deadline. A case that needs a deadline of its own keeps this
+# allowance rather than the bound itself, so shortening a deadline does not loosen the assertion with it.
+SLACK_MS=$((BOUND - DEADLINE_MS))
+# `max_execution_time` is given in seconds; every deadline here is a whole number of milliseconds.
+to_seconds() { printf '%d.%03d' "$(($1 / 1000))" "$(($1 % 1000))"; }
+DEADLINE=$(to_seconds "$DEADLINE_MS")
+
+# $1 = label, $2 = query, $3 = overflow mode (default "throw"), $4 = query id (default none),
+# $5 = "fold" if the call is constant-folded (no pipeline), empty for a pipeline case,
+# $6 = the deadline in milliseconds (default `DEADLINE_MS`)
+#
+# Regexp compilation is pinned off so a pattern this test has already run cannot arrive compiled: the
+# compiled-regexp cache is server-global with a compile threshold of 3, and this test runs up to 5 times.
+#
+# Two messages report the same enforced deadline and only one carries a number: `CancellationChecker` can
+# win the race against this function's own check, and its error then has no elapsed part to read. For a
+# folded call that is still this function's stop to make, since the fold runs during analysis and there is
+# no pipeline to cancel, so the wall clock is bounded instead. For a pipeline case it is not:
+# `addPipelineExecutor` throws on the killed flag before the executor is registered, so the query can end
+# without ever entering the function, and accepting it on wall time would assert query-level cancellation
+# instead of the in-function checkpoint. That is reported as inconclusive rather than passed.
+run() {
+    local label="$1" query="$2" mode="${3:-throw}" query_id="${4:-}" shape="${5:-}" deadline_ms="${6:-$DEADLINE_MS}"
+    local output start_ms elapsed_ms wall_ms
+    local bound=$((deadline_ms + SLACK_MS))
+    start_ms=$(date +%s%N)
+    # shellcheck disable=SC2086
+    output=$(timeout 600 ${CLICKHOUSE_CLIENT} --max_execution_time "$(to_seconds "$deadline_ms")" --timeout_overflow_mode "$mode" \
+        --compile_regular_expressions 0 \
+        ${query_id:+--query_id "$query_id"} \
+        --query "$query" 2>&1)
+    wall_ms=$(( ($(date +%s%N) - start_ms) / 1000000 ))
+    elapsed_ms=$(printf '%s' "$output" | grep -oP 'elapsed \K[0-9]+(?=\.)' | head -1)
+    # A verdict rather than the number itself keeps the reference stable across machine speeds.
+    if [ -n "$elapsed_ms" ]; then
+        if [ "$elapsed_ms" -lt "$bound" ]; then
+            echo "$label: stopped within bound"
+        else
+            echo "$label: OVERSHOT ${elapsed_ms} ms"
+        fi
+    elif ! printf '%s' "$output" | grep -q TIMEOUT_EXCEEDED; then
+        echo "$label: no timeout"
+    elif [ "$shape" = fold ]; then
+        # Wall clock covers the whole client call, not server time alone, hence the doubled allowance.
+        if [ "$wall_ms" -lt "$((bound * 2))" ]; then
+            echo "$label: stopped within bound"
+        else
+            echo "$label: OVERSHOT ${wall_ms} ms"
+        fi
+    else
+        echo "$label: cancelled before the pipeline started"
+    fi
+}
+
+# The haystack is NUL-heavy because that is the shape the fuzzer reports arrive in, and the pattern is a
+# negated class so the matcher cannot prefilter with memchr and skip the scan the checkpoint is charged for.
+HAYSTACK="repeat(repeat('\0\0\0\0\0\0\0\0\0\0a', 1000000), 10)"
+
+# 1. Constant folding: no pipeline exists while this runs, which is the shape the original report showed.
+run "fold" "SELECT countMatches($HAYSTACK, '[^q]') FORMAT Null" throw "" fold
+
+# 2. The same work in the pipeline, which makes case 1 non-vacuous: the defect is the missing in-function
+#    checkpoint, not something specific to constant folding.
+run "pipeline" "SELECT countMatches(materialize($HAYSTACK), '[^q]') FROM numbers(1) FORMAT Null"
+
+# 3. A FixedString haystack, which reaches the match loop through its own entry point rather than the
+#    ColumnString one. The rows must arrive in one block, or the pipeline's own between-block check bounds
+#    the query whatever the function does.
+run "fixed string" \
+    "SELECT sum(countMatches(toFixedString(materialize(repeat('ab', 500000)), 1000000), '[^q]')) FROM numbers(200) SETTINGS max_block_size = 200"
+
+# 4. Many small rows: the per-row loop, which a checkpoint scoped to a single value would never reach, and
+#    which is also what requires the budget to live across rows rather than per call to `countMatches`.
+run "many rows" \
+    "SELECT sum(countMatches(materialize(repeat('ab', 10000)), '[^q]')) FROM numbers(20000) SETTINGS max_block_size = 20000"
+
+# 5. One match per row over a megabyte: about two loop iterations per row, so an iteration counter alone
+#    never reaches its threshold and the deadline is observed only because the bytes each match scanned are
+#    charged too. This is the case that distinguishes charging bytes from counting iterations.
+run "sparse matches" \
+    "SELECT sum(countMatches(materialize(concat(repeat('a', 1000000), 'b')), '[^a]')) FROM numbers(4000) SETTINGS max_block_size = 4000"
+
+# 6. `countMatchesCaseInsensitive`, the second registered function: the same template with
+#    `case_insensitive = true`, so it is covered by construction rather than by its own charge.
+run "case insensitive" \
+    "SELECT countMatchesCaseInsensitive(repeat(repeat('\0\0\0\0\0\0\0\0\0\0A', 1000000), 10), '[^q]') FORMAT Null" throw "" fold
+
+# 7. The "break" overflow mode, where checkTimeLimit() returns false instead of throwing, so a path that
+#    never calls it ignores the deadline entirely. What is asserted is the wall time, not the presence of an
+#    error: in the pipeline the executor's soft check and this function's check race, and both are correct
+#    stops.
+break_start=$(date +%s%N)
+timeout 600 ${CLICKHOUSE_CLIENT} --max_execution_time "$DEADLINE" --timeout_overflow_mode break \
+    --compile_regular_expressions 0 \
+    --query "SELECT countMatches(materialize($HAYSTACK), '[^q]') FROM numbers(1) FORMAT Null" \
+    > /dev/null 2>&1
+break_ms=$(( ($(date +%s%N) - break_start) / 1000000 ))
+if [ "$break_ms" -lt "$((BOUND * 2))" ]; then
+    echo "break pipeline: stopped within bound"
+else
+    echo "break pipeline: OVERSHOT ${break_ms} ms"
+fi
+
+#     A folded call has no way to report a partial result, so there the timeout always surfaces as an error.
+timeout 600 ${CLICKHOUSE_CLIENT} --max_execution_time "$DEADLINE" --timeout_overflow_mode break \
+    --compile_regular_expressions 0 \
+    --query "SELECT countMatches($HAYSTACK, '[^q]') FORMAT Null" 2>&1 \
+    | grep -o -m1 "TIMEOUT_EXCEEDED" || echo "break fold: no timeout"
+
+# 8. KILL QUERY, a different channel from the elapsed-time limit: it sets the killed flag and surfaces
+#    through a separate branch of the same check. No time limit is set, so only the kill can stop the query,
+#    and what is asserted is how long the synchronous kill waits. Both halves are needed - that the target
+#    was really running, and that KILL reported killing it - otherwise a query that never started would be
+#    "killed" instantly.
+kill_id="${CLICKHOUSE_DATABASE}_count_matches_kill"
+${CLICKHOUSE_CLIENT} --query_id "$kill_id" --compile_regular_expressions 0 \
+    --query "SELECT countMatches(repeat(repeat('\0\0\0\0\0\0\0\0\0\0a', 1000000), 40), '[^q]') FORMAT Null" \
+    > /dev/null 2>&1 &
+kill_bg=$!
+kill_seen=0
+for _ in $(seq 1 100); do
+    if [ "$(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.processes WHERE query_id = '$kill_id'")" = 1 ]; then
+        kill_seen=1
+        break
+    fi
+    sleep 0.1
+done
+kill_start=$(date +%s%N)
+kill_rows=$(${CLICKHOUSE_CLIENT} --query "KILL QUERY WHERE query_id = '$kill_id' SYNC FORMAT TSV" 2>/dev/null | grep -c "$kill_id")
+kill_ms=$(( ($(date +%s%N) - kill_start) / 1000000 ))
+wait $kill_bg 2>/dev/null
+if [ "$kill_seen" != 1 ]; then
+    echo "kill query: TARGET NEVER RAN"
+elif [ "$kill_rows" != 1 ]; then
+    echo "kill query: KILL DID NOT REPORT THE TARGET"
+elif [ "$kill_ms" -lt "$((BOUND * 2))" ]; then
+    echo "kill query: killed within bound"
+else
+    echo "kill query: OVERSHOT ${kill_ms} ms"
+fi
+
+# 9. A `countMatches` call inside a stored expression (a key, a skip index or a TTL). The instance built
+#    while that expression is analysed is kept for the table's lifetime and executed by unrelated later
+#    queries, so the query to check is the one running the call, not the one that defined it: a
+#    definition-time query would be the wrong deadline and, held alive, a permanent
+#    `CurrentMetrics::QueryNonInternal` leak. Asserted from both sides. The rows must arrive in one block,
+#    or the pipeline's own check bounds the INSERT whatever the function does.
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS t_count_matches_stored SYNC"
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE t_count_matches_stored (k String) ENGINE = MergeTree
+    PARTITION BY countMatches(k, '[^q]') % 2 ORDER BY tuple()"
+run "stored expression" \
+    "INSERT INTO t_count_matches_stored SELECT repeat('\0\0\0\0\0\0\0\0\0\0a', 1000000) FROM numbers(20) SETTINGS max_insert_block_size = 20, min_insert_block_size_rows = 20"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE t_count_matches_stored SYNC"
+
+#     The leak side: a retained QueryStatus keeps the `CurrentMetrics::QueryNonInternal` increment it owns,
+#     so the count never returns to where it was. Only a rise is a retention: `~QueryStatus` releases the
+#     increment, so the count can fall. Still no tolerance: the metric excludes internal queries, so
+#     background work cannot move it, and the test is no-parallel, so every non-internal query in the
+#     window is one of this test's own and cancels in the difference.
+sample_queries() {
+    local m=999999 v
+    for _ in 1 2 3 4 5; do
+        v=$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.metrics WHERE metric = 'QueryNonInternal'")
+        [ "$v" -lt "$m" ] && m=$v
+    done
+    echo "$m"
+}
+
+for i in 1 2 3 4 5 6; do
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS t_count_matches_stored_$i SYNC"
+done
+queries_before=$(sample_queries)
+for i in 1 2 3 4 5 6; do
+    ${CLICKHOUSE_CLIENT} --query "CREATE TABLE t_count_matches_stored_$i (k String, v String) ENGINE = MergeTree ORDER BY k"
+    # ALTER, not CREATE: a CREATE analyses the expression on a context carrying no query state, so nothing
+    # could be captured there and the case would be vacuous.
+    ${CLICKHOUSE_CLIENT} --max_execution_time "$DEADLINE" --query "
+        ALTER TABLE t_count_matches_stored_$i ADD INDEX ix countMatches(v, '[0-9]') TYPE set(10) GRANULARITY 1"
+done
+queries_after=$(sample_queries)
+if [ "$((queries_after - queries_before))" -le 0 ]; then
+    echo "stored expression leak: no query state retained"
+else
+    echo "stored expression leak: RETAINED $((queries_after - queries_before)) query states"
+fi
+for i in 1 2 3 4 5 6; do
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE t_count_matches_stored_$i SYNC"
+done
+
+# 10. Results are unchanged by the charge. The zero-byte and NUL-heavy shapes are the ones the charge could
+#     have disturbed, because the amount charged is derived from how far each match advanced `pos`, and both
+#     values of `count_matches_stop_at_empty_match` are covered so both branches of the empty-match handling
+#     are exercised.
+${CLICKHOUSE_CLIENT} --query "
+    SELECT countMatches(repeat('\0\0\0\0\0\0\0\0\0\0a', 100), 'a'),
+           countMatches('aaa', ''), countMatches('aaa', 'x*'), countMatches('', 'x*'),
+           countMatches('hello 123 world 456 test', '[0-9]+'),
+           countMatches('', 'a'), countMatches('a', 'a'), countMatches('aa', 'a'),
+           countMatches('ab ab', '\\\\bab'), countMatches('aaa', '^a'), countMatches('aaa', 'a\$'),
+           countMatches(toFixedString('abcabc', 6), 'abc'), countMatches(toFixedString('a\0b', 3), '\0'),
+           countMatches('\0\0\0', ''), countMatches('\0\0\0', '\0*'), countMatches('\0a\0', '\0'),
+           countMatchesCaseInsensitive('Hello HELLO world', 'hello'),
+           countMatchesCaseInsensitive('AAA', 'a')"
+${CLICKHOUSE_CLIENT} --query "
+    SELECT countMatches('aaa', ''), countMatches('aaa', 'x*'), countMatches('', 'x*'),
+           countMatches('\0\0\0', ''), countMatches('\0\0\0', '\0*')
+    SETTINGS count_matches_stop_at_empty_match = 1"
+${CLICKHOUSE_CLIENT} --query "
+    SELECT sum(countMatches(materialize(concat('x', toString(number), 'y')), '[0-9]')) FROM numbers(100)"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/112203
Related: https://github.com/ClickHouse/ClickHouse/pull/113369
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes `countMatches` and `countMatchesCaseInsensitive` ignoring `max_execution_time` and `KILL QUERY` while counting the matches of one large value, which kept a cancelled query running for minutes. With a constant argument, the call happens during query analysis, so no pipeline exists to cancel it.


### Description

Requested in [#112203](https://github.com/ClickHouse/ClickHouse/issues/112203). Both functions loop over the repeated matches of one value inside a single `executeImpl()` call and never consult the query status, so neither the elapsed-time limit nor the killed flag is observed while it runs.

Against a 2 s deadline on a debug build, a fold over a 110 MB haystack ran 16.8 s and a synchronous `KILL QUERY` waited 66.4 s; both stop at 2.0 s now. `replaceRegexpAll`, which gained this checkpoint in `1c965fb5047`, is the control.

<details><summary>All eight measured shapes</summary>

| call | before | after |
|---|---|---|
| `replaceRegexpAll` (control) | 2.0 s | 2.0 s |
| `countMatches`, folded 110 MB haystack | 16.8 s | 2.0 s |
| `countMatchesCaseInsensitive`, folded | 16.8 s | 2.0 s |
| `FixedString`, 200 rows of 1 MB | 30.0 s | 2.0 s |
| 20000 rows | 60.2 s | 2.0 s |
| one match per MB, 1600 rows | 5.1 s | 2.0 s |
| pattern matching empty, 60 MB | 9.1 s | 2.0 s |
| `KILL QUERY ... SYNC` | 66.4 s | 2.0 s |

</details>

The match loop now charges the shared `CancellationBudget` from #113369, with the check resolved per call by `makeCancellationCheck` so an instance stored in table metadata is not bound to the query that built it. All three column entry points reach the one private helper owning the loop, and both functions are one template.

Each branch charges what it can account for: a non-empty match the distance the matcher scanned, which is not the distance `pos` advances, and a failing match the rest of the value. Counting iterations alone would not bound one match per megabyte.

An empty whole match is charged in two parts, because `OptimizedRegularExpression::match` reports one as `offset = std::string::npos` rather than as a position, so how far it scanned is not knowable there. By default `pos` advances one byte and the loop continues, so only that byte is charged: charging the remainder every iteration would call the check per byte. That bounds `x*`, and bounds `\bx*`, whose empty match is found further ahead, proportionally less well. Under `count_matches_stop_at_empty_match` the loop leaves at that match instead, so there the remaining distance is charged once. Reporting the position from the shared wrapper would change what `npos` means to the other ten `Match::offset` reads in `src/`.

Cancellation for `extractAll`, `extractAllGroups*` and the array functions follows in separate pull requests.