### PR TITLE
Fix `clang-tidy-22` warnings

### DIFF
--- a/src/Processors/QueryPlan/tests/gtest_packed_string_keys_plan_setting.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_packed_string_keys_plan_setting.cpp
@@ -49,7 +49,7 @@ bool wireCarriesSetting(const QueryPlanSerializationSettings & settings)
 {
     WriteBufferFromOwnString out;
     settings.writeChangedBinary(out);
-    return out.str().find("enable_packed_string_keys_in_aggregation") != std::string::npos;
+    return out.str().contains("enable_packed_string_keys_in_aggregation");
 }
 
 bool aggregatingStepCarriesSetting(

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3877,7 +3877,7 @@ void MergeTreeData::reclaimStaleTemporaryPartDirectory(const DiskPtr & disk, con
 {
     /// Only temporary names may be auto-reclaimed. Elsewhere (e.g. "detached/<dir>" during ATTACH) the
     /// directory contents are the payload, and reclaiming would destroy user data.
-    if (!startsWith(part_dir_name, "tmp") || part_dir_name.find('/') != String::npos)
+    if (!startsWith(part_dir_name, "tmp") || part_dir_name.contains('/'))
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot reclaim {}: not a temporary part directory name", part_dir_name);
 
     /// The claim is what makes the removal safe: with the name owned, an existing directory can only be


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1114` (included in `26.8` and later)
<!-- ch-version-info:end -->