### PR TITLE
Keep a Buffer's forwarded filter from retyping the destination's own columns

### DIFF
--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -437,15 +437,72 @@ void StorageBuffer::read(
                 /// The prefix converts the whole sample block, but the filter runs inside the
                 /// destination read, where only its own columns are known to have the declared
                 /// types. Keep just the filter's outputs; the rest converts after the read as usual.
-                auto merge_converting_prefix = [&](ActionsDAG filter_dag)
+                /// Only the predicate is converted: an output that merely passes a destination
+                /// column through must keep the type the destination will actually produce.
+                auto merge_converting_prefix = [&](ActionsDAG filter_dag, String & filter_column_name, bool & remove_filter_column)
                 {
+                    /// A bare predicate ("USING f", "PREWHERE f") is the very node it carries as data,
+                    /// so one name would have to hold both types at once. An alias separates the two
+                    /// roles; a computed predicate is already distinct and needs nothing.
+                    const auto & predicate = filter_dag.findInOutputs(filter_column_name);
+                    if (predicate.type == ActionsDAG::ActionType::INPUT)
+                    {
+                        /// The destination may have a column of this name, and on SELECT * both reach
+                        /// one block, where Block::insert throws.
+                        String alias_name = "__buffer_converted_filter";
+                        for (size_t i = 0; filter_dag.tryFindInOutputs(alias_name) != nullptr
+                                        || header_after_adding_defaults.has(alias_name); ++i)
+                            alias_name = "__buffer_converted_filter_" + std::to_string(i);
+                        const auto & alias = filter_dag.addAlias(predicate, alias_name);
+
+                        /// The predicate's first occurrence becomes the alias; the node returns once as
+                        /// data where it has that role.
+                        size_t occurrences = 0;
+                        ActionsDAG::NodeRawConstPtrs new_outputs;
+                        new_outputs.reserve(filter_dag.getOutputs().size() + 1);
+                        for (const auto * output : filter_dag.getOutputs())
+                        {
+                            if (output != &predicate)
+                                new_outputs.push_back(output);
+                            else if (++occurrences == 1)
+                                new_outputs.push_back(&alias);
+                        }
+                        if (occurrences > 1 || !remove_filter_column)
+                            new_outputs.push_back(&predicate);
+                        filter_dag.getOutputs() = std::move(new_outputs);
+
+                        /// The alias is internal to the destination read, so it goes after filtering.
+                        filter_column_name = alias_name;
+                        remove_filter_column = true;
+                    }
+
                     Names filter_outputs;
+                    std::vector<size_t> passthrough_positions;
                     filter_outputs.reserve(filter_dag.getOutputs().size());
                     for (const auto * output : filter_dag.getOutputs())
+                    {
+                        if (output->type == ActionsDAG::ActionType::INPUT)
+                            passthrough_positions.push_back(filter_outputs.size());
                         filter_outputs.push_back(output->result_name);
+                    }
 
                     auto merged = ActionsDAG::merge(converting_dag.clone(), std::move(filter_dag));
                     merged.removeUnusedActions(filter_outputs);
+
+                    /// merge() maps the filter's inputs onto the prefix's outputs, so these inputs are
+                    /// the destination-typed columns and restoring a pass-through adds no actions.
+                    std::unordered_map<std::string_view, const ActionsDAG::Node *> destination_inputs;
+                    for (const auto * input : merged.getInputs())
+                        destination_inputs.emplace(input->result_name, input);
+
+                    auto & merged_outputs = merged.getOutputs();
+                    for (size_t position : passthrough_positions)
+                    {
+                        auto it = destination_inputs.find(filter_outputs[position]);
+                        if (it != destination_inputs.end() && merged_outputs[position]->result_name == filter_outputs[position])
+                            merged_outputs[position] = it->second;
+                    }
+
                     return merged;
                 };
 
@@ -454,15 +511,22 @@ void StorageBuffer::read(
                     auto row_level_filter = std::make_shared<FilterDAGInfo>();
                     row_level_filter->column_name = src_table_query_info.row_level_filter->column_name;
                     row_level_filter->do_remove_column = src_table_query_info.row_level_filter->do_remove_column;
-                    row_level_filter->actions = merge_converting_prefix(src_table_query_info.row_level_filter->actions.clone());
+                    row_level_filter->actions = merge_converting_prefix(
+                        src_table_query_info.row_level_filter->actions.clone(),
+                        row_level_filter->column_name,
+                        row_level_filter->do_remove_column);
                     src_table_query_info.row_level_filter = std::move(row_level_filter);
                 }
 
                 if (src_table_query_info.prewhere_info)
                 {
-                    src_table_query_info.prewhere_info = std::make_shared<PrewhereInfo>(src_table_query_info.prewhere_info->clone());
-                    src_table_query_info.prewhere_info->prewhere_actions
-                        = merge_converting_prefix(std::move(src_table_query_info.prewhere_info->prewhere_actions));
+                    auto prewhere_info = std::make_shared<PrewhereInfo>(src_table_query_info.prewhere_info->clone());
+                    auto merged_prewhere = merge_converting_prefix(
+                        std::move(prewhere_info->prewhere_actions),
+                        prewhere_info->prewhere_column_name,
+                        prewhere_info->remove_prewhere_column);
+                    prewhere_info->prewhere_actions = std::move(merged_prewhere);
+                    src_table_query_info.prewhere_info = std::move(prewhere_info);
                 }
 
                 src_table_query_info.initial_storage_snapshot = storage_snapshot;

--- a/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.reference
+++ b/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.reference
@@ -1,0 +1,30 @@
+B single PREWHERE on the converted column
+{'a':1,'b':2}
+{'b':2}
+G Array parent, single PREWHERE
+['10','20','30']
+['50','60']
+C single row policy on the converted column
+{'a':1}
+{'a':1,'b':2}
+A row policy and PREWHERE on the converted column
+{'a':1,'b':2}
+J PREWHERE on another column
+{'a':1,'b':2}
+I row policy on another column
+{'a':1,'b':2}
+N additional_table_filters and PREWHERE
+{'a':1,'b':2}
+F Array parent, row policy and PREWHERE
+['10','20','30']
+W Nullable parent, filters on distinct columns
+7	x
+W2 LowCardinality parent, both filters on the same column
+y
+Z bare-column row policy and PREWHERE on the same column
+1
+2
+Y Nullable parent, both filters on the same column
+8
+D matching types, row policy and PREWHERE
+{'a':1,'b':2}

--- a/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.sql
+++ b/tests/queries/0_stateless/04741_buffer_two_filters_converted_column.sql
@@ -1,0 +1,159 @@
+-- Tags: no-parallel-replicas
+
+-- Reading a Buffer whose destination declares a column differently logs a warning per read.
+SET send_logs_level = 'error';
+
+DROP TABLE IF EXISTS t04741_map_dst;
+DROP TABLE IF EXISTS t04741_map_buf;
+DROP TABLE IF EXISTS t04741_arr_dst;
+DROP TABLE IF EXISTS t04741_arr_buf;
+DROP TABLE IF EXISTS t04741_same_dst;
+DROP TABLE IF EXISTS t04741_same_buf;
+DROP TABLE IF EXISTS t04741_wrap_dst;
+DROP TABLE IF EXISTS t04741_wrap_buf;
+DROP TABLE IF EXISTS t04741_lc_dst;
+DROP TABLE IF EXISTS t04741_lc_buf;
+DROP TABLE IF EXISTS t04741_bare_dst;
+DROP TABLE IF EXISTS t04741_bare_buf;
+DROP TABLE IF EXISTS t04741_nul_dst;
+DROP TABLE IF EXISTS t04741_nul_buf;
+DROP ROW POLICY IF EXISTS p04741_map ON t04741_map_buf;
+DROP ROW POLICY IF EXISTS p04741_map_k ON t04741_map_buf;
+DROP ROW POLICY IF EXISTS p04741_arr ON t04741_arr_buf;
+DROP ROW POLICY IF EXISTS p04741_same ON t04741_same_buf;
+DROP ROW POLICY IF EXISTS p04741_wrap ON t04741_wrap_buf;
+DROP ROW POLICY IF EXISTS p04741_lc ON t04741_lc_buf;
+DROP ROW POLICY IF EXISTS p04741_bare ON t04741_bare_buf;
+DROP ROW POLICY IF EXISTS p04741_nul ON t04741_nul_buf;
+
+-- Arms A, F, W, W2, Z, Y and D each hold a row both filters accept, a row only its row policy
+-- rejects and a row only its PREWHERE rejects, so neither filter can go missing unnoticed. J and I
+-- are the deliberate exceptions, each showing a filter on another column is unaffected: J has no
+-- policy-only-rejected row and I has no PREWHERE-only-rejected row. N pairs the PREWHERE with an
+-- additional_table_filters entry instead of a row policy, and B, G and C are single-filter controls.
+CREATE TABLE t04741_map_dst (k UInt8, m Array(Tuple(String, UInt64))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04741_map_dst VALUES (1, [('a', 1), ('b', 2)]), (2, [('b', 2)]), (3, [('a', 1)]);
+CREATE TABLE t04741_map_buf (k UInt8, m Map(String, UInt64))
+    ENGINE = Buffer(currentDatabase(), t04741_map_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+CREATE TABLE t04741_arr_dst (k UInt8, a Array(UInt64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04741_arr_dst VALUES (1, [10, 20, 30]), (2, []), (3, [40]), (4, [50, 60]);
+CREATE TABLE t04741_arr_buf (k UInt8, a Array(String))
+    ENGINE = Buffer(currentDatabase(), t04741_arr_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+CREATE TABLE t04741_wrap_dst (k UInt8, s Nullable(UInt64), l String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04741_wrap_dst VALUES (1, 7, 'x'), (2, NULL, 'q'), (3, 9, '');
+CREATE TABLE t04741_wrap_buf (k UInt8, s Nullable(String), l LowCardinality(String))
+    ENGINE = Buffer(currentDatabase(), t04741_wrap_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+CREATE TABLE t04741_lc_dst (k UInt8, l String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04741_lc_dst VALUES (1, 'y'), (2, ''), (3, 'zz');
+CREATE TABLE t04741_lc_buf (k UInt8, l LowCardinality(String))
+    ENGINE = Buffer(currentDatabase(), t04741_lc_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+CREATE TABLE t04741_bare_dst (k UInt8, f UInt8) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04741_bare_dst VALUES (1, 5), (2, 0), (3, 1), (4, 2);
+CREATE TABLE t04741_bare_buf (k UInt8, f UInt64)
+    ENGINE = Buffer(currentDatabase(), t04741_bare_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+CREATE TABLE t04741_nul_dst (k UInt8, n Nullable(UInt64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04741_nul_dst VALUES (1, 7), (2, NULL), (3, 9), (4, 8);
+CREATE TABLE t04741_nul_buf (k UInt8, n Nullable(String))
+    ENGINE = Buffer(currentDatabase(), t04741_nul_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+CREATE TABLE t04741_same_dst (k UInt8, m Map(String, UInt64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04741_same_dst VALUES (1, map('a', 1, 'b', 2)), (2, map('b', 2)), (3, map('a', 1));
+CREATE TABLE t04741_same_buf (k UInt8, m Map(String, UInt64))
+    ENGINE = Buffer(currentDatabase(), t04741_same_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+-- The single-filter controls read the Buffer before any row policy exists on their table.
+SELECT 'B single PREWHERE on the converted column';
+SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b') ORDER BY m;
+
+SELECT 'G Array parent, single PREWHERE';
+SELECT a FROM t04741_arr_buf PREWHERE length(a) > 1 ORDER BY a;
+
+CREATE ROW POLICY p04741_map ON t04741_map_buf USING mapContains(m, 'a') TO ALL;
+
+SELECT 'C single row policy on the converted column';
+SELECT m FROM t04741_map_buf ORDER BY m;
+
+-- Both forwarded filters reference the same converted column: the row policy leaves it converted
+-- and the PREWHERE prefix must not convert it again.
+SELECT 'A row policy and PREWHERE on the converted column';
+SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b') ORDER BY m;
+
+SELECT 'J PREWHERE on another column';
+SELECT m FROM t04741_map_buf PREWHERE k = 1 ORDER BY m;
+
+DROP ROW POLICY p04741_map ON t04741_map_buf;
+CREATE ROW POLICY p04741_map_k ON t04741_map_buf USING k = 1 TO ALL;
+
+SELECT 'I row policy on another column';
+SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b') ORDER BY m;
+
+DROP ROW POLICY p04741_map_k ON t04741_map_buf;
+
+SELECT 'N additional_table_filters and PREWHERE';
+SELECT m FROM t04741_map_buf PREWHERE mapContains(m, 'b') ORDER BY m
+SETTINGS additional_table_filters = {'t04741_map_buf': 'mapContains(m, \'a\')'};
+
+-- A different parent type reaches a different cast, so cover it too. The policy needs a conjunct the
+-- PREWHERE does not imply, or a row rejected only by the policy cannot exist.
+CREATE ROW POLICY p04741_arr ON t04741_arr_buf USING length(a) > 0 AND k != 4 TO ALL;
+
+SELECT 'F Array parent, row policy and PREWHERE';
+SELECT a FROM t04741_arr_buf PREWHERE length(a) > 1 ORDER BY a;
+
+-- Nullable and LowCardinality parents reach further distinct casts.
+CREATE ROW POLICY p04741_wrap ON t04741_wrap_buf USING s IS NOT NULL TO ALL;
+
+SELECT 'W Nullable parent, filters on distinct columns';
+SELECT s, l FROM t04741_wrap_buf PREWHERE l != '' ORDER BY s;
+
+CREATE ROW POLICY p04741_lc ON t04741_lc_buf USING l != '' TO ALL;
+
+SELECT 'W2 LowCardinality parent, both filters on the same column';
+SELECT l FROM t04741_lc_buf PREWHERE length(l) < 2 ORDER BY l;
+
+-- A bare-column row policy makes the filter column a real table column, so the row-level step
+-- removes a column it also emits converted.
+CREATE ROW POLICY p04741_bare ON t04741_bare_buf USING f TO ALL;
+
+SELECT 'Z bare-column row policy and PREWHERE on the same column';
+SELECT f FROM t04741_bare_buf PREWHERE f < 4 ORDER BY f;
+
+-- A Nullable parent with both filters on the same column. This is a control: a Nullable parent was
+-- already correct before the fix, so the arm pins that the fix does not regress it. Both filters
+-- reject the NULL row, so the arm's sensitivity comes from the other two rows: n = '9' only the
+-- policy rejects, n = '7' only the PREWHERE rejects.
+CREATE ROW POLICY p04741_nul ON t04741_nul_buf USING n != '9' TO ALL;
+
+SELECT 'Y Nullable parent, both filters on the same column';
+SELECT n FROM t04741_nul_buf PREWHERE n != '7' ORDER BY n;
+
+CREATE ROW POLICY p04741_same ON t04741_same_buf USING mapContains(m, 'a') TO ALL;
+
+SELECT 'D matching types, row policy and PREWHERE';
+SELECT m FROM t04741_same_buf PREWHERE mapContains(m, 'b') ORDER BY m;
+
+DROP ROW POLICY p04741_arr ON t04741_arr_buf;
+DROP ROW POLICY p04741_same ON t04741_same_buf;
+DROP ROW POLICY p04741_wrap ON t04741_wrap_buf;
+DROP ROW POLICY p04741_lc ON t04741_lc_buf;
+DROP ROW POLICY p04741_bare ON t04741_bare_buf;
+DROP ROW POLICY p04741_nul ON t04741_nul_buf;
+DROP TABLE t04741_map_buf;
+DROP TABLE t04741_map_dst;
+DROP TABLE t04741_arr_buf;
+DROP TABLE t04741_arr_dst;
+DROP TABLE t04741_same_buf;
+DROP TABLE t04741_same_dst;
+DROP TABLE t04741_wrap_buf;
+DROP TABLE t04741_wrap_dst;
+DROP TABLE t04741_lc_buf;
+DROP TABLE t04741_lc_dst;
+DROP TABLE t04741_bare_buf;
+DROP TABLE t04741_bare_dst;
+DROP TABLE t04741_nul_buf;
+DROP TABLE t04741_nul_dst;

--- a/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.reference
+++ b/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.reference
@@ -1,0 +1,9 @@
+P1 no filter, the converted column reads correctly
+{'a':1,'b':2}
+{'b':2}
+{'a':1}
+P2 single row policy on the converted column
+{'a':1,'b':2}
+{'a':1}
+P3 row policy and PREWHERE on the converted column
+{'a':1,'b':2}

--- a/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.reference
+++ b/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.reference
@@ -15,3 +15,10 @@ P3 the policy reached the destination read
 1
 P3 the same with the legacy analyzer
 1
+P4 bare PREWHERE on the converted column
+2
+P4 the alias stays out of the read header
+0
+P4 the same with the legacy analyzer
+2
+0

--- a/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.reference
+++ b/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.reference
@@ -5,5 +5,13 @@ P1 no filter, the converted column reads correctly
 P2 single row policy on the converted column
 {'a':1,'b':2}
 {'a':1}
+P2 the policy reached the destination read
+1
+P2 the same with the legacy analyzer
+1
 P3 row policy and PREWHERE on the converted column
 {'a':1,'b':2}
+P3 the policy reached the destination read
+1
+P3 the same with the legacy analyzer
+1

--- a/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.sql
+++ b/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.sql
@@ -1,0 +1,33 @@
+-- Tags: no-fasttest
+-- no-fasttest: the Parquet format is unavailable in the fast test build.
+
+-- Reading a Buffer whose destination declares a column differently logs a warning per read.
+SET send_logs_level = 'fatal';
+
+DROP TABLE IF EXISTS t04743_pq_buf;
+DROP TABLE IF EXISTS t04743_pq_dst;
+DROP ROW POLICY IF EXISTS p04743_pq ON t04743_pq_buf;
+
+-- A Parquet-backed destination forwards both filters through StorageFile, which builds their header
+-- in updateFormatPrewhereInfo. MergeTree never reaches that function, so the arm below covers a
+-- carrier the sibling test cannot.
+CREATE TABLE t04743_pq_dst (k UInt8, m Array(Tuple(String, UInt64))) ENGINE = File(Parquet);
+INSERT INTO t04743_pq_dst VALUES (1, [('a', 1), ('b', 2)]), (2, [('b', 2)]), (3, [('a', 1)]);
+CREATE TABLE t04743_pq_buf (k UInt8, m Map(String, UInt64))
+    ENGINE = Buffer(currentDatabase(), t04743_pq_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+SELECT 'P1 no filter, the converted column reads correctly';
+SELECT m FROM t04743_pq_buf ORDER BY k;
+
+SELECT 'P2 single row policy on the converted column';
+CREATE ROW POLICY p04743_pq ON t04743_pq_buf USING mapContains(m, 'a') TO ALL;
+SELECT m FROM t04743_pq_buf ORDER BY k;
+
+-- Both forwarded filters reference the same converted column. The row policy prefix leaves it
+-- holding this table's type, so the PREWHERE prefix must not convert it a second time.
+SELECT 'P3 row policy and PREWHERE on the converted column';
+SELECT m FROM t04743_pq_buf PREWHERE mapContains(m, 'b') ORDER BY k;
+
+DROP ROW POLICY p04743_pq ON t04743_pq_buf;
+DROP TABLE t04743_pq_buf;
+DROP TABLE t04743_pq_dst;

--- a/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.sql
+++ b/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.sql
@@ -6,6 +6,8 @@ SET send_logs_level = 'fatal';
 
 DROP TABLE IF EXISTS t04743_pq_buf;
 DROP TABLE IF EXISTS t04743_pq_dst;
+DROP TABLE IF EXISTS t04743_bare_buf;
+DROP TABLE IF EXISTS t04743_bare_dst;
 DROP ROW POLICY IF EXISTS p04743_pq ON t04743_pq_buf;
 
 -- A Parquet-backed destination forwards both filters through StorageFile, which builds their header
@@ -15,6 +17,14 @@ CREATE TABLE t04743_pq_dst (k UInt8, m Array(Tuple(String, UInt64))) ENGINE = Fi
 INSERT INTO t04743_pq_dst VALUES (1, [('a', 1), ('b', 2)]), (2, [('b', 2)]), (3, [('a', 1)]);
 CREATE TABLE t04743_pq_buf (k UInt8, m Map(String, UInt64))
     ENGINE = Buffer(currentDatabase(), t04743_pq_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+-- A bare PREWHERE makes the predicate and the carried column the same node, so the converting
+-- prefix has to separate the two roles. Float64 into UInt8 changes truthiness rather than
+-- preserving it, so a predicate left on the destination's own column returns a row too many.
+CREATE TABLE t04743_bare_dst (k UInt8, f Float64) ENGINE = File(Parquet);
+INSERT INTO t04743_bare_dst VALUES (1, 0.5), (2, 0.0), (3, 2.0);
+CREATE TABLE t04743_bare_buf (k UInt8, f UInt8)
+    ENGINE = Buffer(currentDatabase(), t04743_bare_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
 
 SELECT 'P1 no filter, the converted column reads correctly';
 SELECT m FROM t04743_pq_buf ORDER BY k;
@@ -52,6 +62,25 @@ SELECT count() > 0 FROM (EXPLAIN actions = 1, pretty = 0 SELECT m FROM t04743_pq
 WHERE explain LIKE '%Row level filter column:%';
 SET enable_analyzer = 1;
 
+-- A bare PREWHERE is the only shape where the predicate is itself the carried column, and it
+-- needs no setting to reach the destination read. The row this admits tells the two apart: only
+-- a converted predicate rejects 0.5. The internal alias must also stay out of that read's header.
+SELECT 'P4 bare PREWHERE on the converted column';
+SELECT f FROM t04743_bare_buf PREWHERE f ORDER BY f;
+
+SELECT 'P4 the alias stays out of the read header';
+SELECT count() FROM (EXPLAIN header = 1, pretty = 0 SELECT * FROM t04743_bare_buf PREWHERE f ORDER BY f)
+WHERE explain LIKE '%Header:%' AND explain LIKE '%__buffer_converted_filter%';
+
+SET enable_analyzer = 0;
+SELECT 'P4 the same with the legacy analyzer';
+SELECT f FROM t04743_bare_buf PREWHERE f ORDER BY f;
+SELECT count() FROM (EXPLAIN header = 1, pretty = 0 SELECT * FROM t04743_bare_buf PREWHERE f ORDER BY f)
+WHERE explain LIKE '%Header:%' AND explain LIKE '%__buffer_converted_filter%';
+SET enable_analyzer = 1;
+
 DROP ROW POLICY p04743_pq ON t04743_pq_buf;
 DROP TABLE t04743_pq_buf;
 DROP TABLE t04743_pq_dst;
+DROP TABLE t04743_bare_buf;
+DROP TABLE t04743_bare_dst;

--- a/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.sql
+++ b/tests/queries/0_stateless/04743_buffer_two_filters_converted_column_parquet.sql
@@ -23,10 +23,34 @@ SELECT 'P2 single row policy on the converted column';
 CREATE ROW POLICY p04743_pq ON t04743_pq_buf USING mapContains(m, 'a') TO ALL;
 SELECT m FROM t04743_pq_buf ORDER BY k;
 
+-- The rows above are the same whether the policy is forwarded into the destination read or applied
+-- above it, and only the forwarded path runs the converting prefix this test covers. The marker
+-- comes from query_info.row_level_filter, which both planners populate; pretty = 0 makes it
+-- unconditional.
+SELECT 'P2 the policy reached the destination read';
+SELECT count() > 0 FROM (EXPLAIN actions = 1, pretty = 0 SELECT m FROM t04743_pq_buf ORDER BY k)
+WHERE explain LIKE '%Row level filter column:%';
+
+SET enable_analyzer = 0;
+SELECT 'P2 the same with the legacy analyzer';
+SELECT count() > 0 FROM (EXPLAIN actions = 1, pretty = 0 SELECT m FROM t04743_pq_buf ORDER BY k)
+WHERE explain LIKE '%Row level filter column:%';
+SET enable_analyzer = 1;
+
 -- Both forwarded filters reference the same converted column. The row policy prefix leaves it
 -- holding this table's type, so the PREWHERE prefix must not convert it a second time.
 SELECT 'P3 row policy and PREWHERE on the converted column';
 SELECT m FROM t04743_pq_buf PREWHERE mapContains(m, 'b') ORDER BY k;
+
+SELECT 'P3 the policy reached the destination read';
+SELECT count() > 0 FROM (EXPLAIN actions = 1, pretty = 0 SELECT m FROM t04743_pq_buf PREWHERE mapContains(m, 'b') ORDER BY k)
+WHERE explain LIKE '%Row level filter column:%';
+
+SET enable_analyzer = 0;
+SELECT 'P3 the same with the legacy analyzer';
+SELECT count() > 0 FROM (EXPLAIN actions = 1, pretty = 0 SELECT m FROM t04743_pq_buf PREWHERE mapContains(m, 'b') ORDER BY k)
+WHERE explain LIKE '%Row level filter column:%';
+SET enable_analyzer = 1;
 
 DROP ROW POLICY p04743_pq ON t04743_pq_buf;
 DROP TABLE t04743_pq_buf;

--- a/tests/queries/0_stateless/04812_buffer_row_policy_converted_column_parquet.reference
+++ b/tests/queries/0_stateless/04812_buffer_row_policy_converted_column_parquet.reference
@@ -1,6 +1,9 @@
 --- B policy on the converted column, WHERE moved to PREWHERE ---
 {'a':1,'b':2}
 {'a':1}
+--- B the policy reached the destination read, analyzer and legacy ---
+1
+1
 --- L the converted column beside another ---
 1	{'a':1,'b':2}
 3	{'a':1}
@@ -33,3 +36,6 @@
 --- U2 URL destination, policy alone ---
 {'a':1,'b':2}
 {'a':1}
+--- U2 the policy reached the second reader too, analyzer and legacy ---
+1
+1

--- a/tests/queries/0_stateless/04812_buffer_row_policy_converted_column_parquet.reference
+++ b/tests/queries/0_stateless/04812_buffer_row_policy_converted_column_parquet.reference
@@ -1,0 +1,35 @@
+--- B policy on the converted column, WHERE moved to PREWHERE ---
+{'a':1,'b':2}
+{'a':1}
+--- L the converted column beside another ---
+1	{'a':1,'b':2}
+3	{'a':1}
+--- I the filter names the converted column too ---
+{'a':1,'b':2}
+--- D policy and explicit PREWHERE on the converted column ---
+{'a':1,'b':2}
+--- C the same query with the move disabled ---
+{'a':1,'b':2}
+{'a':1}
+--- E no filter at all ---
+{'a':1,'b':2}
+{'a':1}
+--- F the converted column is not projected ---
+1
+3
+--- P the read is above FetchColumns ---
+1	1
+3	1
+--- ZS bare-column policy, the destination type is no filter ---
+1
+1
+--- ZF bare-column policy, converting the predicate would change truthiness ---
+2
+--- ZF the same rows with no filter ---
+2
+--- U1 URL destination, policy and WHERE ---
+{'a':1,'b':2}
+{'a':1}
+--- U2 URL destination, policy alone ---
+{'a':1,'b':2}
+{'a':1}

--- a/tests/queries/0_stateless/04812_buffer_row_policy_converted_column_parquet.sh
+++ b/tests/queries/0_stateless/04812_buffer_row_policy_converted_column_parquet.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database, no-fasttest
+
+# A row policy on a Buffer column the destination declares differently used to abort the server
+# (Logical error: 'Unexpected return type from materialize') once the implicit WHERE -> PREWHERE
+# move fired, and to fail with TYPE_MISMATCH on a URL destination even without a filter.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user="user04812_${CLICKHOUSE_DATABASE}_$RANDOM"
+db=${CLICKHOUSE_DATABASE}
+
+${CLICKHOUSE_CLIENT} --multiquery <<EOF
+SET send_logs_level = 'fatal';
+
+DROP TABLE IF EXISTS ${db}.t04812_pq_dst;
+DROP TABLE IF EXISTS ${db}.t04812_pq_buf;
+DROP TABLE IF EXISTS ${db}.t04812_str_dst;
+DROP TABLE IF EXISTS ${db}.t04812_str_buf;
+DROP TABLE IF EXISTS ${db}.t04812_flt_dst;
+DROP TABLE IF EXISTS ${db}.t04812_flt_buf;
+DROP TABLE IF EXISTS ${db}.t04812_url_src;
+DROP TABLE IF EXISTS ${db}.t04812_url_dst;
+DROP TABLE IF EXISTS ${db}.t04812_url_buf;
+
+-- Map over the equivalent Array(Tuple(...)): the divergence supportedPrewhereColumns admits.
+CREATE TABLE ${db}.t04812_pq_dst (k UInt8, m Array(Tuple(String, UInt64))) ENGINE = File(Parquet);
+INSERT INTO ${db}.t04812_pq_dst VALUES (1, [('a', 1), ('b', 2)]), (2, [('b', 2)]), (3, [('a', 1)]);
+CREATE TABLE ${db}.t04812_pq_buf (k UInt8, m Map(String, UInt64))
+    ENGINE = Buffer(${db}, t04812_pq_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+-- A bare-column policy makes the predicate and the carried column the same node, and the
+-- destination's String is not usable as a filter at all, so a converted predicate is rejected.
+CREATE TABLE ${db}.t04812_str_dst (k UInt8, f String) ENGINE = File(Parquet);
+INSERT INTO ${db}.t04812_str_dst VALUES (1, '1'), (2, '0'), (3, '1');
+CREATE TABLE ${db}.t04812_str_buf (k UInt8, f UInt8)
+    ENGINE = Buffer(${db}, t04812_str_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+-- Same shape where converting the predicate changes truthiness instead of failing:
+-- 0.5 is true as Float64 and false once cast to the Buffer's UInt8.
+CREATE TABLE ${db}.t04812_flt_dst (k UInt8, f Float64) ENGINE = File(Parquet);
+INSERT INTO ${db}.t04812_flt_dst VALUES (1, 0.5), (2, 0.0), (3, 2.0);
+CREATE TABLE ${db}.t04812_flt_buf (k UInt8, f UInt8)
+    ENGINE = Buffer(${db}, t04812_flt_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+-- A URL destination reaches the same forwarded filter through a different reader.
+CREATE TABLE ${db}.t04812_url_src (k UInt8, m Array(Tuple(String, UInt64))) ENGINE = MergeTree ORDER BY k;
+INSERT INTO ${db}.t04812_url_src VALUES (1, [('a', 1), ('b', 2)]), (2, [('b', 2)]), (3, [('a', 1)]);
+CREATE TABLE ${db}.t04812_url_dst (k UInt8, m Array(Tuple(String, UInt64)))
+    ENGINE = URL('http://127.0.0.1:${CLICKHOUSE_PORT_HTTP}/?query=SELECT+*+FROM+${db}.t04812_url_src+ORDER+BY+k+FORMAT+Parquet', 'Parquet');
+CREATE TABLE ${db}.t04812_url_buf (k UInt8, m Map(String, UInt64))
+    ENGINE = Buffer(${db}, t04812_url_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+DROP USER IF EXISTS ${user};
+CREATE USER ${user} IDENTIFIED WITH no_password;
+GRANT SELECT ON ${db}.* TO ${user};
+
+DROP ROW POLICY IF EXISTS rp04812_pq ON ${db}.t04812_pq_buf;
+DROP ROW POLICY IF EXISTS rp04812_str ON ${db}.t04812_str_buf;
+DROP ROW POLICY IF EXISTS rp04812_flt ON ${db}.t04812_flt_buf;
+DROP ROW POLICY IF EXISTS rp04812_url ON ${db}.t04812_url_buf;
+CREATE ROW POLICY rp04812_pq ON ${db}.t04812_pq_buf FOR SELECT USING mapContains(m, 'a') TO ${user};
+CREATE ROW POLICY rp04812_str ON ${db}.t04812_str_buf FOR SELECT USING f TO ${user};
+CREATE ROW POLICY rp04812_flt ON ${db}.t04812_flt_buf FOR SELECT USING f TO ${user};
+CREATE ROW POLICY rp04812_url ON ${db}.t04812_url_buf FOR SELECT USING mapContains(m, 'a') TO ${user};
+EOF
+
+run() { ${CLICKHOUSE_CLIENT} --user "${user}" --query "SET send_logs_level = 'fatal'; $1"; }
+
+# The mistyped column only has to be projected: it need not appear in the filter.
+echo "--- B policy on the converted column, WHERE moved to PREWHERE ---"
+run "SELECT m FROM ${db}.t04812_pq_buf WHERE k > 0 ORDER BY k"
+
+echo "--- L the converted column beside another ---"
+run "SELECT k, m FROM ${db}.t04812_pq_buf WHERE k > 0 ORDER BY k"
+
+echo "--- I the filter names the converted column too ---"
+run "SELECT m FROM ${db}.t04812_pq_buf WHERE mapContains(m, 'b') ORDER BY k"
+
+echo "--- D policy and explicit PREWHERE on the converted column ---"
+run "SELECT m FROM ${db}.t04812_pq_buf PREWHERE mapContains(m, 'b') ORDER BY k"
+
+# Controls: each holds without the fix, so a change here is a regression, not a repair.
+echo "--- C the same query with the move disabled ---"
+run "SELECT m FROM ${db}.t04812_pq_buf WHERE k > 0 ORDER BY k SETTINGS optimize_move_to_prewhere = 0"
+
+echo "--- E no filter at all ---"
+run "SELECT m FROM ${db}.t04812_pq_buf ORDER BY k"
+
+echo "--- F the converted column is not projected ---"
+run "SELECT k FROM ${db}.t04812_pq_buf WHERE k > 0 ORDER BY k"
+
+echo "--- P the read is above FetchColumns ---"
+run "SELECT k, count() FROM ${db}.t04812_pq_buf WHERE k > 0 GROUP BY k ORDER BY k"
+
+# The predicate is the carried column itself, so it must keep both types at once.
+echo "--- ZS bare-column policy, the destination type is no filter ---"
+run "SELECT f FROM ${db}.t04812_str_buf WHERE k > 0 ORDER BY k"
+
+echo "--- ZF bare-column policy, converting the predicate would change truthiness ---"
+run "SELECT f FROM ${db}.t04812_flt_buf WHERE k > 0 ORDER BY k"
+
+echo "--- ZF the same rows with no filter ---"
+run "SELECT f FROM ${db}.t04812_flt_buf ORDER BY k"
+
+echo "--- U1 URL destination, policy and WHERE ---"
+run "SELECT m FROM ${db}.t04812_url_buf WHERE k > 0 ORDER BY k"
+
+echo "--- U2 URL destination, policy alone ---"
+run "SELECT m FROM ${db}.t04812_url_buf ORDER BY k"
+
+${CLICKHOUSE_CLIENT} --multiquery <<EOF
+SET send_logs_level = 'fatal';
+DROP ROW POLICY rp04812_pq ON ${db}.t04812_pq_buf;
+DROP ROW POLICY rp04812_str ON ${db}.t04812_str_buf;
+DROP ROW POLICY rp04812_flt ON ${db}.t04812_flt_buf;
+DROP ROW POLICY rp04812_url ON ${db}.t04812_url_buf;
+DROP USER ${user};
+DROP TABLE ${db}.t04812_pq_buf;
+DROP TABLE ${db}.t04812_pq_dst;
+DROP TABLE ${db}.t04812_str_buf;
+DROP TABLE ${db}.t04812_str_dst;
+DROP TABLE ${db}.t04812_flt_buf;
+DROP TABLE ${db}.t04812_flt_dst;
+DROP TABLE ${db}.t04812_url_buf;
+DROP TABLE ${db}.t04812_url_dst;
+DROP TABLE ${db}.t04812_url_src;
+EOF

--- a/tests/queries/0_stateless/04812_buffer_row_policy_converted_column_parquet.sh
+++ b/tests/queries/0_stateless/04812_buffer_row_policy_converted_column_parquet.sh
@@ -69,38 +69,57 @@ EOF
 
 run() { ${CLICKHOUSE_CLIENT} --user "${user}" --query "SET send_logs_level = 'fatal'; $1"; }
 
+# The row policy has to reach the destination read for this table's converting prefix to run at
+# all. If a later change stops forwarding it, every arm below still returns these rows through a
+# filter above the read, so assert the plan too. The marker comes from query_info.row_level_filter,
+# which both planners populate; pretty = 0 makes it unconditional.
+pushed_down() {
+    if ${CLICKHOUSE_CLIENT} --user "${user}" --query \
+        "SET send_logs_level = 'fatal'; SET enable_analyzer = $1; EXPLAIN actions = 1, pretty = 0 $2" \
+        2>/dev/null | grep -q 'Row level filter column:'
+    then echo 1; else echo 0; fi
+}
+
+# The implicit move is randomized away in about one run in ten, and either setting alone disables
+# it, so the arms that need it pin both. Without that they read like the control below them.
+moved="SETTINGS optimize_move_to_prewhere = 1, query_plan_optimize_prewhere = 1"
+
 # The mistyped column only has to be projected: it need not appear in the filter.
 echo "--- B policy on the converted column, WHERE moved to PREWHERE ---"
-run "SELECT m FROM ${db}.t04812_pq_buf WHERE k > 0 ORDER BY k"
+run "SELECT m FROM ${db}.t04812_pq_buf WHERE k > 0 ORDER BY k ${moved}"
+
+echo "--- B the policy reached the destination read, analyzer and legacy ---"
+pushed_down 1 "SELECT m FROM ${db}.t04812_pq_buf WHERE k > 0 ORDER BY k ${moved}"
+pushed_down 0 "SELECT m FROM ${db}.t04812_pq_buf WHERE k > 0 ORDER BY k ${moved}"
 
 echo "--- L the converted column beside another ---"
-run "SELECT k, m FROM ${db}.t04812_pq_buf WHERE k > 0 ORDER BY k"
+run "SELECT k, m FROM ${db}.t04812_pq_buf WHERE k > 0 ORDER BY k ${moved}"
 
 echo "--- I the filter names the converted column too ---"
-run "SELECT m FROM ${db}.t04812_pq_buf WHERE mapContains(m, 'b') ORDER BY k"
+run "SELECT m FROM ${db}.t04812_pq_buf WHERE mapContains(m, 'b') ORDER BY k ${moved}"
 
 echo "--- D policy and explicit PREWHERE on the converted column ---"
 run "SELECT m FROM ${db}.t04812_pq_buf PREWHERE mapContains(m, 'b') ORDER BY k"
 
 # Controls: each holds without the fix, so a change here is a regression, not a repair.
 echo "--- C the same query with the move disabled ---"
-run "SELECT m FROM ${db}.t04812_pq_buf WHERE k > 0 ORDER BY k SETTINGS optimize_move_to_prewhere = 0"
+run "SELECT m FROM ${db}.t04812_pq_buf WHERE k > 0 ORDER BY k SETTINGS optimize_move_to_prewhere = 0, query_plan_optimize_prewhere = 0"
 
 echo "--- E no filter at all ---"
 run "SELECT m FROM ${db}.t04812_pq_buf ORDER BY k"
 
 echo "--- F the converted column is not projected ---"
-run "SELECT k FROM ${db}.t04812_pq_buf WHERE k > 0 ORDER BY k"
+run "SELECT k FROM ${db}.t04812_pq_buf WHERE k > 0 ORDER BY k ${moved}"
 
 echo "--- P the read is above FetchColumns ---"
-run "SELECT k, count() FROM ${db}.t04812_pq_buf WHERE k > 0 GROUP BY k ORDER BY k"
+run "SELECT k, count() FROM ${db}.t04812_pq_buf WHERE k > 0 GROUP BY k ORDER BY k ${moved}"
 
 # The predicate is the carried column itself, so it must keep both types at once.
 echo "--- ZS bare-column policy, the destination type is no filter ---"
-run "SELECT f FROM ${db}.t04812_str_buf WHERE k > 0 ORDER BY k"
+run "SELECT f FROM ${db}.t04812_str_buf WHERE k > 0 ORDER BY k ${moved}"
 
 echo "--- ZF bare-column policy, converting the predicate would change truthiness ---"
-run "SELECT f FROM ${db}.t04812_flt_buf WHERE k > 0 ORDER BY k"
+run "SELECT f FROM ${db}.t04812_flt_buf WHERE k > 0 ORDER BY k ${moved}"
 
 echo "--- ZF the same rows with no filter ---"
 run "SELECT f FROM ${db}.t04812_flt_buf ORDER BY k"
@@ -110,6 +129,10 @@ run "SELECT m FROM ${db}.t04812_url_buf WHERE k > 0 ORDER BY k"
 
 echo "--- U2 URL destination, policy alone ---"
 run "SELECT m FROM ${db}.t04812_url_buf ORDER BY k"
+
+echo "--- U2 the policy reached the second reader too, analyzer and legacy ---"
+pushed_down 1 "SELECT m FROM ${db}.t04812_url_buf ORDER BY k"
+pushed_down 0 "SELECT m FROM ${db}.t04812_url_buf ORDER BY k"
 
 ${CLICKHOUSE_CLIENT} --multiquery <<EOF
 SET send_logs_level = 'fatal';

--- a/tests/queries/0_stateless/04849_buffer_converted_column_text_index_and_lazy_final.reference
+++ b/tests/queries/0_stateless/04849_buffer_converted_column_text_index_and_lazy_final.reference
@@ -1,0 +1,28 @@
+A text index direct read, PREWHERE and WHERE on the converted column
+32
+A control, skip indexes off
+32
+B single PREWHERE on the converted column
+32
+B control, skip indexes off
+32
+R reversed types, PREWHERE and WHERE on the converted column
+32
+R control, skip indexes off
+32
+S matching types, PREWHERE and WHERE on the same column
+32
+S plan, the direct read from the text index is in the plan
+1
+S control, skip indexes off
+32
+L lazy FINAL, PREWHERE and WHERE on the converted column
+32
+L plan, lazy FINAL is in the plan
+1
+L control, lazy FINAL off
+32
+M lazy FINAL, single predicate
+32
+M control, lazy FINAL off
+32

--- a/tests/queries/0_stateless/04849_buffer_converted_column_text_index_and_lazy_final.sql
+++ b/tests/queries/0_stateless/04849_buffer_converted_column_text_index_and_lazy_final.sql
@@ -1,0 +1,136 @@
+-- Tags: no-parallel-replicas
+
+-- Reading a Buffer whose destination declares a column differently logs a warning per read.
+SET send_logs_level = 'error';
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS t04849_ti_dst;
+DROP TABLE IF EXISTS t04849_ti_buf;
+DROP TABLE IF EXISTS t04849_rev_dst;
+DROP TABLE IF EXISTS t04849_rev_buf;
+DROP TABLE IF EXISTS t04849_lf_dst;
+DROP TABLE IF EXISTS t04849_lf_buf;
+DROP TABLE IF EXISTS t04849_same_dst;
+DROP TABLE IF EXISTS t04849_same_buf;
+
+-- Every arm stores 32 matching rows out of 64, so an all-rows or no-rows answer is visible.
+-- Each arm is paired with a control that disables only the consumer under test: the control
+-- must return the same count, or the arm cannot tell a fix from a wrong result.
+
+CREATE TABLE t04849_ti_dst (id UInt64, version UInt64, str Array(String),
+    INDEX idx (str) TYPE text(tokenizer = array) GRANULARITY 100000000)
+ENGINE = ReplacingMergeTree(version) ORDER BY id;
+INSERT INTO t04849_ti_dst SELECT number, 1, if(number % 2 = 0, ['bar', 'baz'], ['baz']) FROM numbers(64);
+CREATE TABLE t04849_ti_buf (id UInt64, version UInt64, str Array(LowCardinality(String)))
+    ENGINE = Buffer(currentDatabase(), t04849_ti_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+CREATE TABLE t04849_rev_dst (id UInt64, version UInt64, str Array(LowCardinality(String)),
+    INDEX idx (str) TYPE text(tokenizer = array) GRANULARITY 100000000)
+ENGINE = ReplacingMergeTree(version) ORDER BY id;
+INSERT INTO t04849_rev_dst SELECT number, 1, if(number % 2 = 0, ['bar', 'baz'], ['baz']) FROM numbers(64);
+CREATE TABLE t04849_rev_buf (id UInt64, version UInt64, str Array(String))
+    ENGINE = Buffer(currentDatabase(), t04849_rev_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+-- The types agree here, so this arm pins that the fix does not regress the ordinary case.
+CREATE TABLE t04849_same_dst (id UInt64, version UInt64, str Array(String),
+    INDEX idx (str) TYPE text(tokenizer = array) GRANULARITY 100000000)
+ENGINE = ReplacingMergeTree(version) ORDER BY id;
+INSERT INTO t04849_same_dst SELECT number, 1, if(number % 2 = 0, ['bar', 'baz'], ['baz']) FROM numbers(64);
+CREATE TABLE t04849_same_buf (id UInt64, version UInt64, str Array(String))
+    ENGINE = Buffer(currentDatabase(), t04849_same_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+-- Lazy FINAL rewrites the filter against a second read it builds for the deduplicating keys, so
+-- it needs more than one part holding the same key.
+CREATE TABLE t04849_lf_dst (id UInt64, version UInt64, str Array(String))
+ENGINE = ReplacingMergeTree(version) ORDER BY id;
+SYSTEM STOP MERGES t04849_lf_dst;
+INSERT INTO t04849_lf_dst SELECT number, 1, if(number % 2 = 0, ['bar', 'baz'], ['baz']) FROM numbers(64);
+INSERT INTO t04849_lf_dst SELECT number, 2, if(number % 2 = 0, ['bar', 'baz'], ['baz']) FROM numbers(64);
+CREATE TABLE t04849_lf_buf (id UInt64, version UInt64, str Array(LowCardinality(String)))
+    ENGINE = Buffer(currentDatabase(), t04849_lf_dst, 1, 100, 100, 1000, 10000, 1000000, 10000000);
+
+-- Both filters read the converted column, so the PREWHERE prefix must leave the pass-through
+-- output typed as the destination produces it.
+-- `query_plan_direct_read_from_text_index` is randomized off ~5%; pin it on so the arm reaches
+-- the consumer it is written for.
+SELECT 'A text index direct read, PREWHERE and WHERE on the converted column';
+SELECT count() FROM t04849_ti_buf PREWHERE hasAllTokens(str, 'bar') WHERE hasAllTokens(str, 'bar')
+SETTINGS query_plan_direct_read_from_text_index = 1;
+
+SELECT 'A control, skip indexes off';
+SELECT count() FROM t04849_ti_buf PREWHERE hasAllTokens(str, 'bar') WHERE hasAllTokens(str, 'bar')
+SETTINGS use_skip_indexes = 0;
+
+SELECT 'B single PREWHERE on the converted column';
+SELECT count() FROM t04849_ti_buf PREWHERE hasAllTokens(str, 'bar')
+SETTINGS query_plan_direct_read_from_text_index = 1;
+
+SELECT 'B control, skip indexes off';
+SELECT count() FROM t04849_ti_buf PREWHERE hasAllTokens(str, 'bar') SETTINGS use_skip_indexes = 0;
+
+-- The header match is by name, so the opposite type direction reaches the same defect.
+SELECT 'R reversed types, PREWHERE and WHERE on the converted column';
+SELECT count() FROM t04849_rev_buf PREWHERE hasAllTokens(str, 'bar') WHERE hasAllTokens(str, 'bar')
+SETTINGS query_plan_direct_read_from_text_index = 1;
+
+SELECT 'R control, skip indexes off';
+SELECT count() FROM t04849_rev_buf PREWHERE hasAllTokens(str, 'bar') WHERE hasAllTokens(str, 'bar')
+SETTINGS use_skip_indexes = 0;
+
+SELECT 'S matching types, PREWHERE and WHERE on the same column';
+SELECT count() FROM t04849_same_buf PREWHERE hasAllTokens(str, 'bar') WHERE hasAllTokens(str, 'bar')
+SETTINGS query_plan_direct_read_from_text_index = 1;
+
+-- The direct read is in the plan here, so this file exercises that consumer for real. The
+-- diverging arms above cannot carry this assertion: once the pass-through keeps the
+-- destination's type, their haystack is a CAST rather than a bare column and the rewrite
+-- declines, which is why they pin the setting instead.
+SELECT 'S plan, the direct read from the text index is in the plan';
+SELECT count() > 0 FROM
+(
+    EXPLAIN actions = 1
+    SELECT count() FROM t04849_same_buf PREWHERE hasAllTokens(str, 'bar') WHERE hasAllTokens(str, 'bar')
+    SETTINGS query_plan_direct_read_from_text_index = 1
+) WHERE explain ILIKE '%__text_index_idx%';
+
+SELECT 'S control, skip indexes off';
+SELECT count() FROM t04849_same_buf PREWHERE hasAllTokens(str, 'bar') WHERE hasAllTokens(str, 'bar')
+SETTINGS use_skip_indexes = 0;
+
+-- Lazy FINAL clones the filter onto its own read, which advertises the Buffer's type. Skip indexes
+-- are not involved on this path, so the control turns off lazy FINAL instead.
+-- `min_filtered_ratio_for_lazy_final = 0` avoids the fallback to regular FINAL, which randomized
+-- `index_granularity` can otherwise trigger.
+SELECT 'L lazy FINAL, PREWHERE and WHERE on the converted column';
+SELECT count() FROM t04849_lf_buf FINAL PREWHERE has(str, 'bar') WHERE has(str, 'bar')
+SETTINGS query_plan_optimize_lazy_final = 1, min_filtered_ratio_for_lazy_final = 0;
+
+-- Lazy FINAL is in the plan, so the arm above cannot pass by falling back to ordinary FINAL.
+SELECT 'L plan, lazy FINAL is in the plan';
+SELECT count() > 0 FROM
+(
+    EXPLAIN actions = 0
+    SELECT count() FROM t04849_lf_buf FINAL PREWHERE has(str, 'bar') WHERE has(str, 'bar')
+    SETTINGS query_plan_optimize_lazy_final = 1, min_filtered_ratio_for_lazy_final = 0
+) WHERE explain LIKE '%InputSelector%';
+
+SELECT 'L control, lazy FINAL off';
+SELECT count() FROM t04849_lf_buf FINAL PREWHERE has(str, 'bar') WHERE has(str, 'bar')
+SETTINGS query_plan_optimize_lazy_final = 0;
+
+SELECT 'M lazy FINAL, single predicate';
+SELECT count() FROM t04849_lf_buf FINAL PREWHERE has(str, 'bar')
+SETTINGS query_plan_optimize_lazy_final = 1, min_filtered_ratio_for_lazy_final = 0;
+
+SELECT 'M control, lazy FINAL off';
+SELECT count() FROM t04849_lf_buf FINAL PREWHERE has(str, 'bar')
+SETTINGS query_plan_optimize_lazy_final = 0;
+
+DROP TABLE t04849_ti_buf;
+DROP TABLE t04849_ti_dst;
+DROP TABLE t04849_rev_buf;
+DROP TABLE t04849_rev_dst;
+DROP TABLE t04849_same_buf;
+DROP TABLE t04849_same_dst;
+DROP TABLE t04849_lf_buf;
+DROP TABLE t04849_lf_dst;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/113624
Related: https://github.com/ClickHouse/ClickHouse/pull/113231
Related: https://github.com/ClickHouse/ClickHouse/pull/110321
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a `LOGICAL_ERROR` (`Unexpected return type from materialize`, a server abort in debug and sanitizer builds) when reading a `Buffer` table whose destination declares a column with a different but convertible type and a forwarded filter references that column: with a row policy and the implicit `WHERE` to `PREWHERE` move, and under `query_plan_optimize_lazy_final`. The same cause made such a read fail with `NOT_FOUND_COLUMN_IN_BLOCK` when a text index on that column was read directly and the predicate appeared in both `PREWHERE` and `WHERE`, fail with `TYPE_MISMATCH` over a `URL(Parquet)` destination, and abort with `Bad cast from ColumnMap to ColumnArray` when a row policy and an explicit `PREWHERE` both referenced it.


### Description

Declaring a `Buffer` column differently from its destination is supported:
`StorageBuffer::supportedPrewhereColumns` says so because `read()` prepends a
converting prefix to a forwarded filter.

That prefix converted **every** output of the filter's DAG, and `buildFilterInfo`
also appends the filter's inputs as outputs, which are pass-throughs of the
destination's own columns. Converting them made the read advertise columns the
destination cannot produce, and whichever consumer looked first broke:

* the **plan header**, where the moved `PREWHERE` feeds a Buffer-typed column into
  a destination-typed `materialize` node;
* the **text index direct read** (`NOT_FOUND_COLUMN_IN_BLOCK`, at default settings);
* **lazy FINAL**, which clones the filter onto the read it builds for the
  deduplicating keys;
* the **Parquet reader**, which takes the field as a per-column type hint;
* the **second prefix**, which cast an already-converted column.

Now only the predicate is converted. A pass-through output is restored to the
merged DAG's own input node, which the merge already maps onto the prefix's
destination-typed source, so no action is emitted. A bare predicate (`USING f`,
`PREWHERE f`) is the very node it carries as data, so one name would have to hold
two types at once; that case aliases the predicate, as
`StorageMerge::RowPolicyData::init` already does.

Validated on debug builds of this branch and of its merge base, at
`enable_analyzer` 1 and 0: 13 witness shapes fixed, 10 controls unchanged,
`EXPLAIN` byte-identical on every non-diverging control, and no regression in a
607-test row-policy/prewhere/buffer slice. The lazy FINAL consumer is what the
`AST fuzzer` hit on #110321; the text index one came out of reproducing it. Each
arm of the new `04849` test has a control disabling only its own consumer, so a
wrong row count cannot pass.

Supersedes #113624, whose tests are carried over here.