### PR TITLE
Fix use-after-free of a replicated right-side column in ConstantJoin

### DIFF
--- a/src/Interpreters/JoinUtils.cpp
+++ b/src/Interpreters/JoinUtils.cpp
@@ -133,8 +133,14 @@ Block materializeColumnsFromRightBlock(Block block, const Block & sample_block)
 
             /// We support replicated columns on the right side.
             const auto * replicated_column = typeid_cast<const ColumnReplicated *>(actual_column.get());
+            /// Keep an owning reference: `column.column` is reassigned below, which can drop the last
+            /// reference to this `ColumnReplicated` and free the indexes it owns.
+            ColumnPtr replicated_indexes;
             if (replicated_column)
+            {
+                replicated_indexes = replicated_column->getIndexesColumn();
                 actual_column = replicated_column->getNestedColumn();
+            }
 
             /// Sparse columns are not supported on the right side.
             actual_column = recursiveRemoveSparse(actual_column);
@@ -150,8 +156,8 @@ Block materializeColumnsFromRightBlock(Block block, const Block & sample_block)
             if (sample_column.column->isNullable())
                 JoinCommon::convertColumnToNullable(column);
 
-            if (replicated_column)
-                column.column = ColumnReplicated::create(column.column, replicated_column->getIndexesColumn());
+            if (replicated_indexes)
+                column.column = ColumnReplicated::create(column.column, replicated_indexes);
         }
     }
 

--- a/tests/queries/0_stateless/04817_constantjoin_replicated_column_use_after_free.reference
+++ b/tests/queries/0_stateless/04817_constantjoin_replicated_column_use_after_free.reference
@@ -1,0 +1,11 @@
+witness: reporter repro, SEMI LEFT, Nullable(UInt8) right column
+witness: non-Nullable right column, not fixed and contiguous
+witness: runtime-constant ON that evaluates to true
+1	0
+witness: ANY INNER with any_join_distinct_right_table_keys
+witness: fixed right column wider than 8 bytes
+control: parse-time constant ON returns early before the replicated right row is materialized
+control: lazy replication disabled
+control: fixed 8-byte right column is not lazily replicated
+control: CROSS JOIN stores the right rows instead of selecting one
+1	0

--- a/tests/queries/0_stateless/04817_constantjoin_replicated_column_use_after_free.sql
+++ b/tests/queries/0_stateless/04817_constantjoin_replicated_column_use_after_free.sql
@@ -3,6 +3,11 @@
 -- `enable_lazy_columns_replication` is pinned in every query because the test runner randomizes it.
 -- Join swapping and join-order optimization are pinned too: reversing `LEFT SEMI` into `RIGHT SEMI`
 -- would move the query off the selected-right-row path that materializes the replicated column.
+-- The analyzer is pinned because the deprecated interpreter cannot reach the faulting branch: it
+-- rewrites a true constant `ON` to `CROSS` (which stores all right rows) and rejects a
+-- runtime-constant `ON` outright, so no query shape covers the defect there.
+
+SET enable_analyzer = 1;
 
 SELECT 'witness: reporter repro, SEMI LEFT, Nullable(UInt8) right column';
 SELECT l, r

--- a/tests/queries/0_stateless/04817_constantjoin_replicated_column_use_after_free.sql
+++ b/tests/queries/0_stateless/04817_constantjoin_replicated_column_use_after_free.sql
@@ -1,65 +1,67 @@
 -- A `ConstantJoin` right side that carries a lazily replicated column used to read a freed
 -- `ColumnReplicated` while materializing the selected right row.
 -- `enable_lazy_columns_replication` is pinned in every query because the test runner randomizes it.
+-- Join swapping and join-order optimization are pinned too: reversing `LEFT SEMI` into `RIGHT SEMI`
+-- would move the query off the selected-right-row path that materializes the replicated column.
 
 SELECT 'witness: reporter repro, SEMI LEFT, Nullable(UInt8) right column';
 SELECT l, r
 FROM (SELECT 1::UInt8 AS l) AS t1
 SEMI LEFT JOIN (SELECT toUInt8(moduloOrNull(number, 10)) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
 ON not(materialize(1))
-SETTINGS enable_lazy_columns_replication = 1;
+SETTINGS enable_lazy_columns_replication = 1, query_plan_join_swap_table = false, query_plan_optimize_join_order_limit = 0;
 
 SELECT 'witness: non-Nullable right column, not fixed and contiguous';
 SELECT l, r
 FROM (SELECT 1::UInt8 AS l) AS t1
 SEMI LEFT JOIN (SELECT toString(number) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
 ON not(materialize(1))
-SETTINGS enable_lazy_columns_replication = 1;
+SETTINGS enable_lazy_columns_replication = 1, query_plan_join_swap_table = false, query_plan_optimize_join_order_limit = 0;
 
 SELECT 'witness: runtime-constant ON that evaluates to true';
 SELECT l, r
 FROM (SELECT 1::UInt8 AS l) AS t1
 SEMI LEFT JOIN (SELECT toUInt8(moduloOrNull(number, 10)) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
 ON materialize(1)
-SETTINGS enable_lazy_columns_replication = 1;
+SETTINGS enable_lazy_columns_replication = 1, query_plan_join_swap_table = false, query_plan_optimize_join_order_limit = 0;
 
 SELECT 'witness: ANY INNER with any_join_distinct_right_table_keys';
 SELECT l, r
 FROM (SELECT 1::UInt8 AS l) AS t1
 ANY INNER JOIN (SELECT toUInt8(moduloOrNull(number, 10)) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
 ON not(materialize(1))
-SETTINGS enable_lazy_columns_replication = 1, any_join_distinct_right_table_keys = 1;
+SETTINGS enable_lazy_columns_replication = 1, any_join_distinct_right_table_keys = 1, query_plan_join_swap_table = false, query_plan_optimize_join_order_limit = 0;
 
 SELECT 'witness: fixed right column wider than 8 bytes';
 SELECT l, r
 FROM (SELECT 1::UInt8 AS l) AS t1
 SEMI LEFT JOIN (SELECT toDecimal128(number, 2) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
 ON not(materialize(1))
-SETTINGS enable_lazy_columns_replication = 1;
+SETTINGS enable_lazy_columns_replication = 1, query_plan_join_swap_table = false, query_plan_optimize_join_order_limit = 0;
 
 SELECT 'control: parse-time constant ON returns early before the replicated right row is materialized';
 SELECT l, r
 FROM (SELECT 1::UInt8 AS l) AS t1
 SEMI LEFT JOIN (SELECT toUInt8(moduloOrNull(number, 10)) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
 ON 1 = 2
-SETTINGS enable_lazy_columns_replication = 1;
+SETTINGS enable_lazy_columns_replication = 1, query_plan_join_swap_table = false, query_plan_optimize_join_order_limit = 0;
 
 SELECT 'control: lazy replication disabled';
 SELECT l, r
 FROM (SELECT 1::UInt8 AS l) AS t1
 SEMI LEFT JOIN (SELECT toUInt8(moduloOrNull(number, 10)) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
 ON not(materialize(1))
-SETTINGS enable_lazy_columns_replication = 0;
+SETTINGS enable_lazy_columns_replication = 0, query_plan_join_swap_table = false, query_plan_optimize_join_order_limit = 0;
 
 SELECT 'control: fixed 8-byte right column is not lazily replicated';
 SELECT l, r
 FROM (SELECT 1::UInt8 AS l) AS t1
 SEMI LEFT JOIN (SELECT number AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
 ON not(materialize(1))
-SETTINGS enable_lazy_columns_replication = 1;
+SETTINGS enable_lazy_columns_replication = 1, query_plan_join_swap_table = false, query_plan_optimize_join_order_limit = 0;
 
 SELECT 'control: CROSS JOIN stores the right rows instead of selecting one';
 SELECT l, r
 FROM (SELECT 1::UInt8 AS l) AS t1
 CROSS JOIN (SELECT toUInt8(moduloOrNull(number, 10)) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
-SETTINGS enable_lazy_columns_replication = 1;
+SETTINGS enable_lazy_columns_replication = 1, query_plan_join_swap_table = false, query_plan_optimize_join_order_limit = 0;

--- a/tests/queries/0_stateless/04817_constantjoin_replicated_column_use_after_free.sql
+++ b/tests/queries/0_stateless/04817_constantjoin_replicated_column_use_after_free.sql
@@ -1,0 +1,65 @@
+-- A `ConstantJoin` right side that carries a lazily replicated column used to read a freed
+-- `ColumnReplicated` while materializing the selected right row.
+-- `enable_lazy_columns_replication` is pinned in every query because the test runner randomizes it.
+
+SELECT 'witness: reporter repro, SEMI LEFT, Nullable(UInt8) right column';
+SELECT l, r
+FROM (SELECT 1::UInt8 AS l) AS t1
+SEMI LEFT JOIN (SELECT toUInt8(moduloOrNull(number, 10)) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
+ON not(materialize(1))
+SETTINGS enable_lazy_columns_replication = 1;
+
+SELECT 'witness: non-Nullable right column, not fixed and contiguous';
+SELECT l, r
+FROM (SELECT 1::UInt8 AS l) AS t1
+SEMI LEFT JOIN (SELECT toString(number) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
+ON not(materialize(1))
+SETTINGS enable_lazy_columns_replication = 1;
+
+SELECT 'witness: runtime-constant ON that evaluates to true';
+SELECT l, r
+FROM (SELECT 1::UInt8 AS l) AS t1
+SEMI LEFT JOIN (SELECT toUInt8(moduloOrNull(number, 10)) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
+ON materialize(1)
+SETTINGS enable_lazy_columns_replication = 1;
+
+SELECT 'witness: ANY INNER with any_join_distinct_right_table_keys';
+SELECT l, r
+FROM (SELECT 1::UInt8 AS l) AS t1
+ANY INNER JOIN (SELECT toUInt8(moduloOrNull(number, 10)) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
+ON not(materialize(1))
+SETTINGS enable_lazy_columns_replication = 1, any_join_distinct_right_table_keys = 1;
+
+SELECT 'witness: fixed right column wider than 8 bytes';
+SELECT l, r
+FROM (SELECT 1::UInt8 AS l) AS t1
+SEMI LEFT JOIN (SELECT toDecimal128(number, 2) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
+ON not(materialize(1))
+SETTINGS enable_lazy_columns_replication = 1;
+
+SELECT 'control: parse-time constant ON returns early before the replicated right row is materialized';
+SELECT l, r
+FROM (SELECT 1::UInt8 AS l) AS t1
+SEMI LEFT JOIN (SELECT toUInt8(moduloOrNull(number, 10)) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
+ON 1 = 2
+SETTINGS enable_lazy_columns_replication = 1;
+
+SELECT 'control: lazy replication disabled';
+SELECT l, r
+FROM (SELECT 1::UInt8 AS l) AS t1
+SEMI LEFT JOIN (SELECT toUInt8(moduloOrNull(number, 10)) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
+ON not(materialize(1))
+SETTINGS enable_lazy_columns_replication = 0;
+
+SELECT 'control: fixed 8-byte right column is not lazily replicated';
+SELECT l, r
+FROM (SELECT 1::UInt8 AS l) AS t1
+SEMI LEFT JOIN (SELECT number AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
+ON not(materialize(1))
+SETTINGS enable_lazy_columns_replication = 1;
+
+SELECT 'control: CROSS JOIN stores the right rows instead of selecting one';
+SELECT l, r
+FROM (SELECT 1::UInt8 AS l) AS t1
+CROSS JOIN (SELECT toUInt8(moduloOrNull(number, 10)) AS r FROM numbers(1) ARRAY JOIN [1]) AS t2
+SETTINGS enable_lazy_columns_replication = 1;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/113859


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a server crash when joining with a constant `ON` expression against a right side that contains an `ARRAY JOIN`. Reading a lazily replicated right-side column used a freed `ColumnReplicated`. Closes #113859.

### Description

`JoinCommon::materializeColumnsFromRightBlock` captured a raw, non-owning `const ColumnReplicated *` (`src/Interpreters/JoinUtils.cpp:135`) and then rebound `actual_column` to the nested column (`:137`), leaving `column.column` as the only owning reference. The later `column.column = actual_column` (`:148`) therefore destroyed the `ColumnReplicated`, and the `ColumnReplicated::create(column.column, replicated_column->getIndexesColumn())` at `:154` dereferenced the freed object. `getIndexesColumn` returns `const ColumnPtr &`, i.e. a reference *into* the destroyed object, on which `create` calls `assumeMutable` (`src/Columns/ColumnReplicated.h:31`), so a release build reads the freed vtable slot and segfaults in `intrusive_ptr_add_ref`.

ASan confirms `heap-use-after-free`: freed at `JoinUtils.cpp:148`, read at `ColumnReplicated.h:31` from `JoinUtils.cpp:154`. This is a use-after-free, not the null dereference the issue proposed.

`ConstantJoin::addBlockToJoin` (`src/Interpreters/ConstantJoin.cpp:219`) is the only caller that faults today, because it passes `std::move` of a `Block::cloneWithCutColumns` result and `IColumn::cut` builds a brand-new column whose sole owner is that block. The other four callers pass a `const Block &`, so the by-value parameter copy leaves an independent owning reference; they carry the same latent lifetime defect and are protected only by their callers' ownership. The fix therefore goes in the shared helper: hold an owning `ColumnPtr` to the indexes across the reassignment. Gating on it is exactly equivalent to gating on the raw pointer, because a `ColumnReplicated` can never have null indexes.

The crash needs no non-default setting: `enable_lazy_columns_replication` is on by default. `Nullable` is not required: `isLazyReplicationUseful` accepts any column that is not fixed-and-contiguous, or wider than 8 bytes.

<details><summary>Validation</summary>

All arms on Build IDs asserted against the running binary.

- Both directions, 9 committed cases (5 witnesses + 4 controls): base `6de8ff8c` SIGSEGVs 5/5 witnesses and passes 4/4 controls; fix `0216d9b2` passes 9/9. Base also fails through `clickhouse-test` with `server died`.
- ASan differential: mutating only the gate back to the raw pointer reproduces `heap-use-after-free` 5/5 with the identical free/read pair; the fix reports 0/5.
- 336-cell join-kind x right-column-type x `ARRAY JOIN` sweep vs unpatched base: 20 base crashes become 0, and all 316 non-crashing cells are byte-identical.
- 50/50 randomized runs of the new test on the fix: 50 passed, 0 failed.
- 245-test join + lazy-replication regression slice on both arms: 0 only-in-fix failures, 0 reason changes (the shared failures are sandbox-environmental: no cluster, `Code: 279`/`344`).
- Audited all 23 other `typeid_cast<const ColumnReplicated *>` sites in `src/`: none holds a raw pointer across a reassignment of the owning `ColumnPtr`.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1234` (included in `26.8` and later)
<!-- ch-version-info:end -->