### PR TITLE
Fix flaky 03717_async_deduplication_with_mv losing a row

### DIFF
--- a/tests/queries/0_stateless/03717_async_deduplication_with_mv.sql
+++ b/tests/queries/0_stateless/03717_async_deduplication_with_mv.sql
@@ -62,7 +62,9 @@ SELECT count() as value FROM 03717_table;
 
 
 SET async_insert = 1, insert_deduplicate = 1, async_insert_deduplicate = 1, wait_for_async_insert = 0, deduplicate_blocks_in_dependent_materialized_views=1;
-set async_insert_use_adaptive_busy_timeout=0, async_insert_busy_timeout_min_ms=1000, async_insert_busy_timeout_max_ms=5000;
+-- The busy timeout must outlast this test: the table-scoped flush below waits only for the jobs it
+-- schedules itself, so a batch the deadline timer already drained is not waited for at all.
+set async_insert_use_adaptive_busy_timeout=0, async_insert_busy_timeout_min_ms=1000, async_insert_busy_timeout_max_ms=600000;
 
 SET max_block_size=1;
 SET max_insert_block_size=1;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/96130

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`03717_async_deduplication_with_mv` sporadically loses a row: `03717_table` returns 4 rows instead of 5 and the `count()` materialized views undercount by 1. Reported on #96130 (`Stateless tests (amd_asan_ubsan, flaky check)`, sha `0700a41`, 1 FAIL / 3 OK).

The cause is a synchronization gap in the test, not deduplication. It inserts with `wait_for_async_insert = 0` and then drains with the table-scoped `SYSTEM FLUSH ASYNC INSERT QUEUE`, which by design waits only for the jobs it schedules itself (`AsynchronousInsertQueue.cpp:813-815`; `flushAll` additionally calls `pool.wait()` and says so). With `async_insert_use_adaptive_busy_timeout = 0`, `getBusyWaitTimeoutMs` returns `async_insert_busy_timeout_max_ms` unconditionally, so the deadline is 5000 ms. When the second batch is drained by `processBatchDeadlines` before the flush statement arrives, the flush finds nothing, waits on nothing, and the following `SELECT` runs before the batch commits. Rows `1` and `3` of that batch are content duplicates anyway, so the only visible loss is `5` plus the two aggregates, which is exactly the observed diff.

Raise `async_insert_busy_timeout_max_ms` to 600000 so the scoped flush is the only thing that can drain the batch. This is the same remedy as the merged `89d47b3c9a7f34d` for `03148_async_queries_in_query_log_errors`, which documents this mechanism; of the 27 tests combining a scoped flush with `wait_for_async_insert = 0`, 19 now pin a large value including this one, the dedup siblings `03652`, `03662`, `04603` and `04614` at 600000. Reference unchanged, no source file touched.

Trade-off: a genuine server-side failure to flush now surfaces as the test's own timeout rather than a wrong answer, which is the trade the siblings and the precedent already accept.

Scope is this test only. Five other class members still pin 5000 and three more inherit that value from `users.d/timeouts.xml`, but none has an observed failure of this signature, and the discriminator is the insert-to-flush gap rather than the pin.

<details><summary>Validation</summary>

Deterministic repro with the `async_insert_flush_pause_in_executor` failpoint. Oracle is `value1` of the flush's own `Will wait for finishing of {} flushing jobs` row in `system.text_log`, scoped by `query_id`, i.e. `futures_to_wait.size()`:

| `max_ms` | insert-to-flush gap | `futures_to_wait` |
|---|---|---|
| 200 | 0 s | 0 |
| 600000 | 0 s | 1 |
| 5000 | 10 s | 0 |
| 600000 | 10 s | 1 |

`Found duplicate block IDs` occurs 0 times for the repro's own table in every arm, so no batch was deduplicated.

End to end on the test itself, 8 runs each: with the pin forced to 1 ms, 2 of 8 fail with a diff byte-identical to the CI one; at 600000, 8 of 8 pass. 50 of 50 randomized runs pass. The 37 async-insert and flush tests run identically on both arms, 34 OK and the same 3 pre-existing environmental failures with unchanged reasons, 0 regressions.

Not the cause, each measured: #96130 itself (it only adds `-- Tags: no-random-detach`, and the DETACH activity marker occurs 0 times in the job log); a reused `insert_deduplication_token` (the test supplies none, so tokens hash row content, and row `5` is new); wholesale dedup in `filterImpl` (needs all 3 batch tokens to conflict); #111049 or #112649 residuals (both already in the failing build, and the table has one partition).

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1019` (included in `26.8` and later)
<!-- ch-version-info:end -->