### PR TITLE
Make `test_dirty_pages_force_purge` deterministic

### DIFF
--- a/tests/integration/test_dirty_pages_force_purge/configs/overrides.yaml
+++ b/tests/integration/test_dirty_pages_force_purge/configs/overrides.yaml
@@ -1,3 +1,8 @@
 ---
 max_server_memory_usage: 4Gi
-memory_worker_purge_dirty_pages_threshold_ratio: 0.2
+# The threshold must be reliably crossed by the dirty pages of a single test query
+# (~400 MB). jemalloc reuses freed extents within an arena, so repeating the same
+# query does not accumulate dirty pages beyond one query's footprint per arena, and
+# a higher threshold is only crossed when queries happen to land on different pool
+# threads (= different arenas), which made the test flaky.
+memory_worker_purge_dirty_pages_threshold_ratio: 0.04


### PR DESCRIPTION
The test waits for a `MemoryAllocatorPurge` event, but the purge fires only when jemalloc dirty pages exceed `memory_worker_purge_dirty_pages_threshold_ratio` (0.2) of `max_server_memory_usage` (4Gi) = 0.8 GiB. A single test query dirties only ~400 MB, and jemalloc reuses freed extents within an arena, so repeating the same query does not accumulate dirty pages beyond one query's footprint per arena. Crossing the threshold therefore depended on queries landing on different thread-pool threads (= different arenas), and when they did not, the test timed out waiting for the event — 7 failures across unrelated PRs (#113192, #110188, #110144, #111332, …) in the last 14 days per CIDB. Example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113042&sha=9a329692501a39e051b9c908b281282f4110e0fb&name_0=PR on https://github.com/ClickHouse/ClickHouse/pull/113042.

Lower the ratio in the test config so the dirty pages of a single query reliably cross the threshold. Verified locally: the test now passes in ~7 s (the purge fires on the first query) instead of looping.

Related: https://github.com/ClickHouse/ClickHouse/pull/113042

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...