### PR TITLE
Limit query string read in TCPHandler to max_query_size

### DIFF
--- a/src/IO/tests/gtest_read_string_binary.cpp
+++ b/src/IO/tests/gtest_read_string_binary.cpp
@@ -1,0 +1,55 @@
+#include <IO/ReadHelpers.h>
+#include <IO/WriteHelpers.h>
+#include <IO/ReadBufferFromMemory.h>
+#include <IO/WriteBufferFromString.h>
+#include <gtest/gtest.h>
+
+namespace DB::ErrorCodes
+{
+    extern const int TOO_LARGE_STRING_SIZE;
+}
+
+using namespace DB;
+
+TEST(ReadStringBinary, RespectsMaxSizeLimit)
+{
+    WriteBufferFromOwnString write_buf;
+
+    std::string payload(100, 'x');
+    writeStringBinary(payload, write_buf);
+    write_buf.finalize();
+
+    ReadBufferFromMemory read_buf(write_buf.str().data(), write_buf.str().size());
+    const size_t limit = 50;
+    std::string result;
+    EXPECT_THROW(readStringBinary(result, read_buf, limit), Exception);
+}
+
+TEST(ReadStringBinary, WithinLimitSucceeds)
+{
+    WriteBufferFromOwnString write_buf;
+
+    std::string payload(50, 'x');
+    writeStringBinary(payload, write_buf);
+    write_buf.finalize();
+
+    ReadBufferFromMemory read_buf(write_buf.str().data(), write_buf.str().size());
+    const size_t limit = 100;
+    std::string result;
+    readStringBinary(result, read_buf, limit);
+    EXPECT_EQ(result, payload);
+}
+
+TEST(ReadStringBinary, DefaultLimitIsLarge)
+{
+    WriteBufferFromOwnString write_buf;
+
+    std::string payload(1000, 'x');
+    writeStringBinary(payload, write_buf);
+    write_buf.finalize();
+
+    ReadBufferFromMemory read_buf(write_buf.str().data(), write_buf.str().size());
+    std::string result;
+    readStringBinary(result, read_buf);
+    EXPECT_EQ(result, payload);
+}

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -103,6 +103,7 @@ namespace Setting
     extern const SettingsBool input_format_defaults_for_omitted_fields;
     extern const SettingsUInt64 interactive_delay;
     extern const SettingsBool low_cardinality_allow_in_native_format;
+    extern const SettingsUInt64 max_query_size;
     extern const SettingsString network_compression_method;
     extern const SettingsInt64 network_zstd_compression_level;
     extern const SettingsBool partial_result_on_first_cancel;
@@ -2483,7 +2484,7 @@ void TCPHandler::processQuery(std::shared_ptr<QueryState> & state)
     state->compression = static_cast<Protocol::Compression>(compression);
     last_block_in.compression = state->compression;
 
-    readStringBinary(state->query, *in);
+    readStringBinary(state->query, *in, session->sessionOrGlobalContext()->getSettingsRef()[Setting::max_query_size]);
 
     Settings passed_params;
     if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_PARAMETERS)


### PR DESCRIPTION
## Description

The TCP protocol handler reads the query string from the wire using `readStringBinary` with a default 1 GiB limit (`DEFAULT_MAX_STRING_SIZE`), far exceeding the `max_query_size` setting (default 256 KiB). A client can send a query string up to 1 GiB, and the server allocates that memory before the `max_query_size` check in `executeQuery()` ever runs.

This is particularly problematic in inter-server mode where the hash check happens after the full query is read into memory.

## Fix

Pass the configured `max_query_size` as the `max_string_size` parameter so the wire read respects the configured limit. The setting is taken from the session context (`session->sessionOrGlobalContext()`), which is available before the query string is read and is not client-controlled.

Also adds unit tests verifying the `readStringBinary` size limit.

### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Limit the size of query strings read from the TCP wire to `max_query_size` instead of a hardcoded 1 GiB default.