### PR TITLE
Do not throw a logical error when `StorageKafka2` is not active

### DIFF
--- a/src/Storages/Kafka/StorageKafka2.cpp
+++ b/src/Storages/Kafka/StorageKafka2.cpp
@@ -395,9 +395,10 @@ void StorageKafka2::activateAndReschedule()
 
 void StorageKafka2::assertActive() const
 {
-    // TODO(antaljanosbenjamin): change LOGICAL_ERROR to something sensible
+    /// The table becomes inactive at any moment when the Keeper session expires and `partialShutdown` runs,
+    /// racing with direct reads and MV streaming, so this is an expected runtime condition, not a logical error.
     if (!is_active)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Table is not active (replica path: {})", replica_path);
+        throw Exception(ErrorCodes::ABORTED, "Table is not active (replica path: {})", replica_path);
 }
 
 

--- a/tests/integration/test_storage_kafka/test_keeper_session_loss_direct_read.py
+++ b/tests/integration/test_storage_kafka/test_keeper_session_loss_direct_read.py
@@ -1,0 +1,92 @@
+"""A direct read from an inactive `StorageKafka2` must fail with a regular exception.
+
+When the Keeper session expires, `partialShutdown` marks the table inactive until it is
+reactivated. A direct read (`Kafka2Source::generateImpl`) reopening its Keeper then hits
+`StorageKafka2::assertActive`, which must throw `ABORTED` instead of `LOGICAL_ERROR`
+(a logical error aborts the server in debug and sanitizer builds).
+"""
+
+import logging
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.network import PartitionManager
+import helpers.kafka.common as k
+
+cluster = ClickHouseCluster(__file__)
+instance = cluster.add_instance(
+    "instance",
+    main_configs=["configs/kafka.xml", "configs/named_collection.xml"],
+    user_configs=["configs/users.xml"],
+    with_kafka=True,
+    with_zookeeper=True,
+    macros={
+        "kafka_broker": "kafka1",
+        "kafka_topic_old": k.KAFKA_TOPIC_OLD,
+        "kafka_group_name_old": k.KAFKA_CONSUMER_GROUP_OLD,
+        "kafka_topic_new": k.KAFKA_TOPIC_NEW,
+        "kafka_group_name_new": k.KAFKA_CONSUMER_GROUP_NEW,
+        "kafka_client_id": "instance",
+        "kafka_format_json_each_row": "JSONEachRow",
+    },
+    clickhouse_path_dir="clickhouse_path",
+)
+
+
+@pytest.fixture(scope="module")
+def kafka_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def kafka_setup_teardown():
+    k.clean_test_database_and_topics(instance, cluster)
+    yield
+
+
+def test_direct_read_from_inactive_table_is_not_a_logical_error(kafka_cluster):
+    suffix = k.random_string(6)
+    kafka_table = f"kafka_inactive_{suffix}"
+    topic_name = f"inactive_direct_read_{suffix}"
+
+    admin_client = k.get_admin_client(kafka_cluster)
+
+    with k.kafka_topic(admin_client, topic_name):
+        instance.query(
+            k.generate_new_create_table_query(
+                kafka_table,
+                "key UInt64, value UInt64",
+                topic_list=topic_name,
+                consumer_group=topic_name,
+            )
+        )
+        instance.wait_for_log_line(f"{kafka_table}.*Table activated successfully")
+
+        with PartitionManager() as pm:
+            pm.drop_instance_zk_connections(instance)
+            # The activation task notices the expired session (its check period is one
+            # minute), runs `partialShutdown` and, since Keeper is unreachable, fails to
+            # reactivate: from this line on the table stays inactive while the network
+            # partition holds.
+            instance.wait_for_log_line(
+                f"{kafka_table}.*Failed to establish a new ZK connection. Will try again",
+                timeout=180,
+            )
+
+            error = instance.query_and_get_error(
+                f"SELECT * FROM test.{kafka_table} LIMIT 1"
+            )
+            logging.debug("Direct read from an inactive table failed with: %s", error)
+            assert "Table is not active" in error
+            assert "Code: 236" in error  # ABORTED
+            assert "Logical error" not in error
+
+        # The server must survive (in debug builds a logical error would abort it).
+        assert instance.query("SELECT 1").strip() == "1"
+
+        instance.query(f"DROP TABLE test.{kafka_table} SYNC")


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Kafka tables with Keeper-stored offsets (`kafka_keeper_path`) now throw `ABORTED` instead of `LOGICAL_ERROR` when the table becomes inactive after a Keeper session loss (e.g. during a direct read or materialized-view streaming).

`StorageKafka2::assertActive` threw `LOGICAL_ERROR` when the table is not active. But the table legitimately becomes inactive at any moment when the Keeper session expires and `partialShutdown` runs, racing with direct reads (`Kafka2Source::generateImpl` calls `getZooKeeperAndAssertActive`) and with the materialized-view streaming task. So an inactive table on these paths is an expected runtime condition, not a bug — the code even carried a `TODO(antaljanosbenjamin): change LOGICAL_ERROR to something sensible`.

In debug and sanitizer builds a `LOGICAL_ERROR` aborts the server, and this surfaced in the stress test as `Logical error: Table is not active (replica path: A)`:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112788&sha=ba3438849a503d92dd66f6b64e89ff66c29bf6cc&name_0=PR&name_1=Stress%20test%20%28amd_debug%29

Throw `ABORTED` instead, consistent with the neighboring `Table is detached` exception in the same file.

A focused regression test, `test_storage_kafka/test_keeper_session_loss_direct_read.py`, forces a Keeper session loss (network partition), waits until `partialShutdown` has run and reactivation keeps failing, then runs a direct `SELECT` and asserts it fails with `ABORTED` instead of a logical error.

Related: https://github.com/ClickHouse/ClickHouse/pull/112788

