### PR TITLE
Fix `KafkaConsumersWithAssignment` drifting negative

### DIFF
--- a/src/Storages/Kafka/KafkaConsumer.cpp
+++ b/src/Storages/Kafka/KafkaConsumer.cpp
@@ -111,11 +111,6 @@ void KafkaConsumer::createConsumer(cppkafka::Configuration consumer_config)
         // with topics/partitions we were working with before rebalance
         LOG_TRACE(log, "Rebalance initiated. Revoking partitions: {}", topic_partitions);
 
-        if (!topic_partitions.empty())
-        {
-            CurrentMetrics::sub(CurrentMetrics::KafkaConsumersWithAssignment, 1);
-        }
-
         // we can not flush data to target from that point (it is pulled, not pushed)
         // so the best we can now it to
         // 1) repeat last commit in sync mode (async could be still in queue, we need to be sure is is properly committed before rebalance)
@@ -364,6 +359,10 @@ void KafkaConsumer::cleanUnprocessed()
     offsets_stored = 0;
 }
 
+/// Sole owner of the decrements for `KafkaAssignedPartitions` and `KafkaConsumersWithAssignment`.
+/// Every path that drops an assignment reaches it - the revocation callback, `moveConsumer` and
+/// `KafkaConsumer`'s destructor - so a caller that also decrements on its own makes the gauge drift
+/// by one per rebalance until it passes zero.
 void KafkaConsumer::cleanAssignment()
 {
     if (assignment.has_value())


### PR DESCRIPTION
The `KafkaConsumersWithAssignment` metric is decremented twice per rebalance revocation but incremented once per assignment, so it drifts down by one per rebalance and eventually reads negative.

The revocation callback in `KafkaConsumer::createConsumer` decrements the gauge directly, then calls `cleanAssignment`, which decrements it again. The assignment callback increments it once.

Measured on a 26.7.2.59 server up 39 hours with 8 Kafka tables:

| Metric | Value |
|---|---|
| `KafkaConsumersWithAssignment` | -60 |
| `KafkaRebalanceAssignments` | 76 |
| `KafkaRebalanceRevocations` | 68 |

`76 - 2 * 68 = -60`. Per-table `num_rebalance_assignments` and `num_rebalance_revocations` in `system.kafka_consumers` sum to the same 76 and 68. `KafkaAssignedPartitions` is decremented only in `cleanAssignment` and read a correct 21 on the same server.

`cleanAssignment` is reached by every path that drops an assignment - the revocation callback, `moveConsumer` and the destructor - so removing the callback's own decrement leaves exactly one decrement per assignment dropped.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix the `KafkaConsumersWithAssignment` metric drifting negative - it was decremented twice for every consumer group rebalance.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=113919&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/113919](https://github.com/search?q=head%3Async-upstream%2Fpr%2F113919+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.42` (included in `26.10` and later)
<!-- ch-version-info:end -->