### PR TITLE
Scale the cancellation-latency bounds of `04648_geohashes_in_box_cancellation` for sanitizer builds

### DIFF
--- a/tests/queries/0_stateless/04648_geohashes_in_box_cancellation.sh
+++ b/tests/queries/0_stateless/04648_geohashes_in_box_cancellation.sh
@@ -90,12 +90,17 @@ run_kill_case() {
     # cancellation and the test would pass without exercising the fix.
     # The poll runs over HTTP rather than through the client: a fresh client process costs ~70ms per
     # iteration against ~10ms for a request, and that overhead lands inside the measured kill latency.
+    # The window is sixty seconds on every build: it is not part of the oracle - it only waits for the
+    # query to start, and on busy runners (`arm_binary` and `amd_debug` in the report) the start alone
+    # outlasted the previous ten-second window. A query that dies at startup is caught by the liveness
+    # check on the client process instead of outwaiting the window.
     local waited=0 ready_ok=0
-    while [ "$waited" -lt 500 ]; do
+    while [ "$waited" -lt 3000 ]; do
         if [ "$(${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "SELECT $ready FROM system.processes WHERE query_id = '$query_id'")" = "1" ]; then
             ready_ok=1
             break
         fi
+        kill -0 "$query_pid" 2>/dev/null || break
         waited=$((waited + 1))
         sleep 0.02
     done

--- a/tests/queries/0_stateless/04648_geohashes_in_box_cancellation.sh
+++ b/tests/queries/0_stateless/04648_geohashes_in_box_cancellation.sh
@@ -26,12 +26,20 @@ BOX_DEGENERATE="1.0, 1.0, 0.0, 0.0, materialize(toUInt8(12))"
 BOX_NAN="nan, 1.0, 0.0, 0.0, materialize(toUInt8(12))"
 
 # 4x the 1s limit absorbs clock granularity, a busy runner and the work in flight when the check
-# fires; the unfixed path lands far above that.
+# fires; the unfixed path lands far above that. Sanitizer and coverage builds stretch the work in
+# flight when the check fires (overruns of up to ~7.2s against the plain 4s bound were observed on
+# ASan runners) while stretching the unfixed path, tens of seconds, at least as much, so the bound
+# scales on those builds and still separates.
+SCALE=1
+[ -n "$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS' AND value LIKE '%sanitize=%'")" ] && SCALE=3
+case "$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'WITH_COVERAGE'")" in ON|1) SCALE=3 ;; esac
+BOUND=$((SCALE * 4000))
+
 check_duration() {
     local query_id="$1" label="$2"
     ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS query_log"
     ${CLICKHOUSE_CLIENT} -q "
-        SELECT if(max(query_duration_ms) < 4000, '$label stopped promptly', '$label ran ' || toString(max(query_duration_ms)) || 'ms past a 1000ms limit')
+        SELECT if(max(query_duration_ms) < $BOUND, '$label stopped promptly', '$label ran ' || toString(max(query_duration_ms)) || 'ms past a 1000ms limit')
         FROM system.query_log
         WHERE query_id = '$query_id' AND current_database = currentDatabase() AND type != 'QueryStart'"
 }
@@ -111,8 +119,8 @@ run_kill_case() {
 # Readiness waits for the query to have been running rather than merely being visible: `ProcessList`
 # makes it visible before the executor is attached, and `addPipelineExecutor` raises a pending
 # cancellation itself, so a kill winning that race would pass even unfixed. One second of the block's
-# tens leaves the rest of it as the window in which the kill has to land. 4000ms as above.
-run_kill_case "expanding" "$BOX" 60000 "$SETTINGS" "max(elapsed) > 1" 4000
+# tens leaves the rest of it as the window in which the kill has to land. The bound scales as above.
+run_kill_case "expanding" "$BOX" 60000 "$SETTINGS" "max(elapsed) > 1" "$BOUND"
 
 # Liveness control: with no time limit the function must still return the documented result, so a
 # "fix" that simply always threw would fail here rather than pass.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Deflake the test `04648_geohashes_in_box_cancellation`: scale the cancellation-latency bounds for sanitizer and coverage builds, and extend the readiness window of the `KILL` case for slow runners.

After the earlier deflake in https://github.com/ClickHouse/ClickHouse/pull/112823, the remaining failures of this test (~24 in the last 14 days, across `master` and unrelated PRs) fall into two modes:

1. **Bound overruns on sanitizer builds.** The `KILL ... SYNC` latency reached 4464–4882 ms against the 4000 ms bound under TSan/MSan, e.g. [this report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110613&sha=e23d6eeccd2a175a5535fbfece080af0db7e9525&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%203%2F3%29) (`expanding kill blocked 4882ms`), and `query_duration_ms` reached 5355–7167 ms against the same 4000 ms bound on the ASan/UBSan Azure runner (`float64 throw ran 7167ms past a 1000ms limit`). The bound is now scaled 3x on sanitizer and coverage builds, following the existing pattern of `04722_count_substrings_cancellation` / `04650_replace_cancellation`: those builds stretch the work in flight when the cancellation check fires, but stretch the unfixed path (a block that runs for tens of seconds) at least as much, so the scaled bound of 12000 ms still separates the fixed behavior from the unfixed one. On release builds the bound stays 4000 ms.

2. **Readiness-poll timeouts on busy runners** (`expanding kill: query never reached the row loop`, the dominant mode: 11 failures on `arm_binary` and 6 on `amd_debug`). The readiness poll of `run_kill_case` was a fixed 500 iterations of 20 ms, and on a busy runner the query start alone can outlast those ten seconds. The window is not part of the fixed/unfixed oracle — it only waits for setup — so it is now sixty seconds on every build, with an early exit when the client process dies so a genuine startup failure still reports promptly instead of outwaiting the window.

The test still passes locally on a release build (byte-for-byte against the reference).

Closes: https://github.com/ClickHouse/ClickHouse/issues/113922
