### PR TITLE
Run the deadly signal handlers on the alternative stack

### DIFF
--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -308,7 +308,8 @@ void HandledSignals::addSignalHandler(
     [[maybe_unused]] const std::vector<int> & signals,
     [[maybe_unused]] signal_function handler,
     [[maybe_unused]] bool register_signal,
-    [[maybe_unused]] const std::vector<int> & additional_masked_signals)
+    [[maybe_unused]] const std::vector<int> & additional_masked_signals,
+    [[maybe_unused]] bool use_alt_stack)
 {
 #if !defined(OS_HAS_SIGNAL_HANDLERS)
     return;
@@ -317,6 +318,9 @@ void HandledSignals::addSignalHandler(
     memset(&sa, 0, sizeof(sa));
     sa.sa_sigaction = handler;
     sa.sa_flags = SA_SIGINFO;
+
+    if (use_alt_stack)
+        sa.sa_flags |= SA_ONSTACK;
 
 #if defined(OS_DARWIN)
     sigemptyset(&sa.sa_mask);
@@ -835,8 +839,17 @@ void HandledSignals::setupCommonDeadlySignalHandlers()
 #else
     const std::vector<int> unwind_recovery_signals;
 #endif
-    addSignalHandler(
-        {SIGABRT, SIGSEGV, SIGILL, SIGBUS, SIGSYS, SIGFPE, SIGTSTP, SIGTRAP}, signalHandler, true, unwind_recovery_signals);
+    const std::vector<int> fault_signals{SIGABRT, SIGSEGV, SIGILL, SIGBUS, SIGSYS, SIGFPE, SIGTRAP};
+    /// Each call masks the other's signals, so both keep the `sa_mask` of the single registration that
+    /// once covered all eight.
+    std::vector<int> fault_masked_signals = unwind_recovery_signals;
+    fault_masked_signals.push_back(SIGTSTP);
+    std::vector<int> tstp_masked_signals = unwind_recovery_signals;
+    tstp_masked_signals.insert(tstp_masked_signals.end(), fault_signals.begin(), fault_signals.end());
+
+    /// Not SIGTSTP: it is never raised by stack exhaustion, and its handler returns.
+    addSignalHandler(fault_signals, signalHandler, true, fault_masked_signals, /*use_alt_stack=*/true);
+    addSignalHandler({SIGTSTP}, signalHandler, true, tstp_masked_signals);
 
 #if defined(SANITIZER)
     __sanitizer_set_death_callback(sanitizerDeathCallback);

--- a/src/Common/SignalHandlers.h
+++ b/src/Common/SignalHandlers.h
@@ -138,11 +138,14 @@ struct HandledSignals
 
     /// `additional_masked_signals` are blocked while `handler` runs (added to `sa_mask`) but the
     /// handler is not registered for them.
+    /// `use_alt_stack` requests `SA_ONSTACK`: required for any handler that must still run after the
+    /// faulting thread's stack is exhausted.
     void addSignalHandler(
         const std::vector<int> & signals,
         signal_function handler,
         bool register_signal,
-        const std::vector<int> & additional_masked_signals = {});
+        const std::vector<int> & additional_masked_signals = {},
+        bool use_alt_stack = false);
 
     void reset(bool close_pipe = true);
 

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -81,6 +81,26 @@ struct ThreadStack
     }
     ~ThreadStack()
     {
+        /// The deadly signal handlers request SA_ONSTACK, so a signal delivered after this point would
+        /// run on freed memory. The thread keeps executing thread_local destructors after this one.
+        stack_t disable{};
+        disable.ss_flags = SS_DISABLE;
+        /// Darwin rejects a zero size even when disabling.
+        disable.ss_size = getSize();
+        if (sigaltstack(&disable, nullptr) != 0)
+        {
+            const auto saved_errno = errno;
+            /// Leak rather than free a stack signals may still be delivered onto.
+            try
+            {
+                LOG_FATAL(getLogger("ThreadStatus"), "Cannot disable the alternative signal stack, leaking it, {}", errnoToString(saved_errno));
+            }
+            catch (...) // NOLINT(bugprone-empty-catch) Ok: a destructor must not throw, and logging is best-effort
+            {
+            }
+            return;
+        }
+
         if constexpr (guardPagesEnabled())
             memoryGuardRemove(data, getPageSize());
 
@@ -142,34 +162,15 @@ ThreadStatus::ThreadStatus()
         /// Don't repeat tries even if not installed successfully.
         has_alt_stack = true;
 
-        /// We have to call 'sigaltstack' before first 'sigaction'. (It does not work other way, for unknown reason).
         stack_t altstack_description{};
         altstack_description.ss_sp = alt_stack.getData();
         altstack_description.ss_flags = 0;
         altstack_description.ss_size = ThreadStack::getSize();
 
+        /// `SA_ONSTACK` is requested once for all deadly signals in `setupCommonDeadlySignalHandlers`;
+        /// the kernel selects this stack at delivery time, so it may be installed afterwards.
         if (0 != sigaltstack(&altstack_description, nullptr))
-        {
             LOG_WARNING(log, "Cannot set alternative signal stack for thread, {}", errnoToString());
-        }
-        else
-        {
-            /// Obtain existing sigaction and modify it by adding a flag.
-            struct sigaction action{};
-            if (0 != sigaction(SIGSEGV, nullptr, &action))
-            {
-                LOG_WARNING(log, "Cannot obtain previous signal action to set alternative signal stack for thread, {}", errnoToString());
-            }
-            else if (!(action.sa_flags & SA_ONSTACK))
-            {
-                action.sa_flags |= SA_ONSTACK;
-
-                if (0 != sigaction(SIGSEGV, &action, nullptr))
-                {
-                    LOG_WARNING(log, "Cannot set action with alternative signal stack for thread, {}", errnoToString());
-                }
-            }
-        }
     }
 #endif
 }

--- a/src/Common/tests/gtest_signal_handler_alt_stack.cpp
+++ b/src/Common/tests/gtest_signal_handler_alt_stack.cpp
@@ -1,0 +1,99 @@
+#include <Common/SignalHandlers.h>
+
+#include <base/defines.h>
+#include <Common/StackTraceServiceSignal.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+#if defined(OS_HAS_SIGNAL_HANDLERS)
+
+namespace
+{
+
+void noopHandler(int, siginfo_t *, void *)
+{
+}
+
+/// A failed gtest assertion in the child would not reach the parent, which sees only the exit code.
+void require(bool condition, const std::string & what)
+{
+    if (!condition)
+    {
+        std::cerr << "failed: " << what << '\n';
+        std::_Exit(1);
+    }
+}
+
+[[noreturn]] void checkAlternativeStackIsRequested()
+{
+    /// Everything `setupCommonDeadlySignalHandlers` registers.
+    const std::vector<int> registered{SIGABRT, SIGSEGV, SIGILL, SIGBUS, SIGSYS, SIGFPE, SIGTSTP, SIGTRAP};
+
+    /// Both registrations mask everything the single pre-split registration masked.
+    std::vector<int> expected_mask = registered;
+#if defined(OS_LINUX) || defined(OS_DARWIN)
+    for (int sig : {SIGUSR1, SIGUSR2, DB::STACK_TRACE_SERVICE_SIGNAL})
+        expected_mask.push_back(sig);
+#endif
+
+    HandledSignals::instance().setupCommonDeadlySignalHandlers();
+
+    struct sigaction reference{};
+    require(sigaction(SIGSEGV, nullptr, &reference) == 0, "reading the SIGSEGV action");
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdisabled-macro-expansion"
+    require(reference.sa_sigaction != nullptr, "SIGSEGV has a handler");
+
+    for (int sig : registered)
+    {
+        const std::string suffix = ", signal " + std::to_string(sig);
+        struct sigaction actual{};
+        require(sigaction(sig, nullptr, &actual) == 0, "reading the action" + suffix);
+        /// SIGTSTP is the one whose handler returns, so it stays off the alternative stack.
+        require(bool(actual.sa_flags & SA_ONSTACK) == (sig != SIGTSTP), "SA_ONSTACK" + suffix);
+        /// `SA_ONSTACK` must be the only difference the split introduces.
+        require(actual.sa_sigaction == reference.sa_sigaction, "same handler" + suffix);
+        require((actual.sa_flags & ~SA_ONSTACK) == (reference.sa_flags & ~SA_ONSTACK), "same flags" + suffix);
+        for (int masked = 1; masked < NSIG; ++masked)
+        {
+            const bool expected = std::find(expected_mask.begin(), expected_mask.end(), masked) != expected_mask.end();
+            require((sigismember(&actual.sa_mask, masked) == 1) == expected, "mask member " + std::to_string(masked) + suffix);
+        }
+    }
+
+    /// Anchors the identity above to the fault handler: only it reports a whole fault record, so
+    /// rewiring both registrations to any other handler would leave the comparisons above intact.
+    HandledSignals::instance().signal_pipe.setNonBlockingRead();
+    require(raise(SIGTSTP) == 0, "raising SIGTSTP");
+    char report[signal_pipe_buf_size];
+    const ssize_t reported = ::read(HandledSignals::instance().signal_pipe.fds_rw[0], report, sizeof(report));
+    require(reported > static_cast<ssize_t>(sizeof(int) + sizeof(siginfo_t)), "a fault record was reported");
+
+    /// `use_alt_stack` is opt-in: an ordinary caller using the default must not acquire the flag.
+    HandledSignals::instance().addSignalHandler({SIGSYS}, noopHandler, false);
+    struct sigaction defaulted{};
+    require(sigaction(SIGSYS, nullptr, &defaulted) == 0, "reading the defaulted action");
+    require(!(defaulted.sa_flags & SA_ONSTACK), "the default is off the alternative stack");
+#pragma clang diagnostic pop
+
+    std::_Exit(0);
+}
+
+}
+
+/// Runs in a child process: it installs the real handlers, which must not survive into the rest of
+/// the test binary.
+TEST(SignalHandlersDeathTest, DeadlySignalHandlersRequestAlternativeStack)
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    EXPECT_EXIT(checkAlternativeStackIsRequested(), ::testing::ExitedWithCode(0), ".*");
+}
+
+#endif


### PR DESCRIPTION
Run the deadly signal handlers on the alternative stack

Related: https://github.com/ClickHouse/ClickHouse/issues/113835


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Report a stack overflow instead of dying silently: the deadly signal handlers now run on the alternative signal stack, so `SIGSEGV`, `SIGABRT`, `SIGILL`, `SIGBUS`, `SIGSYS`, `SIGFPE` and `SIGTRAP` produce a stack trace even when the faulting thread has exhausted its stack.

### Description

A stack overflow arrives as `SIGSEGV` on the exhausted stack itself, so `signalHandler` can only report it from an alternative stack, which needs `SA_ONSTACK`. `addSignalHandler` never set that flag. Non-sanitizer builds install an alternative stack in `ThreadStatus`, and under AddressSanitizer the runtime installs one, so the stack existed and was never used: the handler faulted again and the process died from the default action, giving the signature in issue #113835 (bare `SIGSEGV`, exit 139, no `<Fatal>` block, no sanitizer report).

`setupCommonDeadlySignalHandlers` now registers in two calls so only the fault signals get the flag; `SIGTSTP` is excluded because it is never raised by stack exhaustion and its handler returns. Each call masks the other's signals, so the `sa_mask` is unchanged. `ThreadStack`'s destructor now disables the alternative stack before freeing it: a thread runs more `thread_local` destructors afterwards, and a signal arriving in that window would otherwise be delivered onto freed memory, which matters now that the recoverable paths can return. `ThreadStatus` no longer patches `SIGSEGV` itself: `SA_ONSTACK` is set for the whole process and the kernel selects the stack at delivery time, so installing it afterwards works (verified both directions). In non-sanitizer builds the alternative stack still comes from `ThreadStatus`, so a thread without one (the main thread before `MainThreadStatus`, and `clickhouse-disks`, which never creates it) is unchanged here: it had neither the stack nor the flag before. Sanitizer builds are covered by the runtime, which installs one before `main`.

This does not fix the crash in issue #113835, which stays open. The overflow is measured, but the frames that consumed the stack are not recoverable from the collected cores, so there is no stack size change here. It makes the trace a sizing fix needs possible.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1078` (included in `26.8` and later)
<!-- ch-version-info:end -->