### PR TITLE
Fix wrong results and a crash in partial merge join with totals

### DIFF
--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -642,8 +642,8 @@ void MergeJoin::setTotals(const Block & totals_block)
     IJoin::setTotals(totals_block);
 }
 
-/// Finalizes the right side. Unlike setTotals(), the post build phase is always reached, and it
-/// runs in the work context, which mergeRightBlocks() requires because it drives a nested
+/// Finalizes the right side. Unlike `setTotals`, the post build phase is always reached, and it
+/// runs in the work context, which `mergeRightBlocks` requires because it drives a nested
 /// pipeline.
 void MergeJoin::runPostBuildPhase()
 {

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -637,10 +637,16 @@ MergeJoin::MergeJoin(std::shared_ptr<TableJoin> table_join_, SharedHeader right_
     }
 }
 
-/// Has to be called even if totals are empty
 void MergeJoin::setTotals(const Block & totals_block)
 {
     IJoin::setTotals(totals_block);
+}
+
+/// Finalizes the right side. Unlike setTotals(), the post build phase is always reached, and it
+/// runs in the work context, which mergeRightBlocks() requires because it drives a nested
+/// pipeline.
+void MergeJoin::runPostBuildPhase()
+{
     mergeRightBlocks();
 
     if (is_right || is_full)

--- a/src/Interpreters/MergeJoin.h
+++ b/src/Interpreters/MergeJoin.h
@@ -52,7 +52,7 @@ public:
 
     size_t getTotalRowCount() const override { return right_blocks.row_count; }
     size_t getTotalByteCount() const override { return right_blocks.bytes; }
-    /// Has to be called only after runPostBuildPhase()
+    /// Has to be called only after `runPostBuildPhase`
     bool alwaysReturnsEmptySet() const override { return (is_right || is_inner) && min_max_right_blocks.empty(); }
 
     IBlocksStreamPtr getNonJoinedBlocks(const Block & left_sample_block, const Block & result_sample_block, UInt64 max_block_size) const override;

--- a/src/Interpreters/MergeJoin.h
+++ b/src/Interpreters/MergeJoin.h
@@ -47,9 +47,12 @@ public:
 
     void setTotals(const Block &) override;
 
+    bool hasPostBuildPhase() const override { return true; }
+    void runPostBuildPhase() override;
+
     size_t getTotalRowCount() const override { return right_blocks.row_count; }
     size_t getTotalByteCount() const override { return right_blocks.bytes; }
-    /// Has to be called only after setTotals()/mergeRightBlocks()
+    /// Has to be called only after runPostBuildPhase()
     bool alwaysReturnsEmptySet() const override { return (is_right || is_inner) && min_max_right_blocks.empty(); }
 
     IBlocksStreamPtr getNonJoinedBlocks(const Block & left_sample_block, const Block & result_sample_block, UInt64 max_block_size) const override;

--- a/src/Processors/tests/gtest_merge_join_starved_totals.cpp
+++ b/src/Processors/tests/gtest_merge_join_starved_totals.cpp
@@ -100,7 +100,7 @@ std::vector<std::pair<UInt64, UInt64>> runFullJoinWithStarvedTotals(
 
 TEST(MergeJoinStarvedTotals, FullJoinKeepsRightRows)
 {
-    /// Keys 0 and 1 match; 2 is left only; 3 is right only. join_use_nulls defaults to false,
+    /// Keys 0 and 1 match; 2 is left only; 3 is right only. `join_use_nulls` defaults to false,
     /// so an unmatched side reads as 0.
     auto rows = runFullJoinWithStarvedTotals({0, 1, 2}, {0, 1, 3});
 

--- a/src/Processors/tests/gtest_merge_join_starved_totals.cpp
+++ b/src/Processors/tests/gtest_merge_join_starved_totals.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+
+#include <Columns/ColumnsNumber.h>
+#include <Core/Block.h>
+#include <Core/Settings.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Interpreters/MergeJoin.h>
+#include <Interpreters/TableJoin.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
+#include <Processors/Sources/NullSource.h>
+#include <Processors/Sources/SourceFromChunks.h>
+#include <Processors/Transforms/JoiningTransform.h>
+#include <QueryPipeline/QueryPipeline.h>
+
+using namespace DB;
+
+namespace
+{
+
+/// A totals port that exists but never delivers a chunk satisfies neither branch of
+/// `FillingRightJoinSideTransform::prepare`, so `setTotals` is never called. `NullSource` has the
+/// same empty-`Chunk` shape as `RemoteTotalsSource` when a remote sends no totals.
+
+SharedHeader keyHeader(const String & name)
+{
+    Block header{ColumnWithTypeAndName(std::make_shared<DataTypeUInt64>(), name)};
+    return std::make_shared<const Block>(std::move(header));
+}
+
+std::shared_ptr<ISource> keySource(const String & name, const std::vector<UInt64> & values)
+{
+    auto column = ColumnUInt64::create();
+    for (auto v : values)
+        column->insertValue(v);
+
+    Chunks chunks;
+    chunks.emplace_back(Chunk(Columns{std::move(column)}, values.size()));
+    return std::make_shared<SourceFromChunks>(keyHeader(name), std::move(chunks));
+}
+
+std::vector<std::pair<UInt64, UInt64>> runFullJoinWithStarvedTotals(
+    const std::vector<UInt64> & left_keys, const std::vector<UInt64> & right_keys)
+{
+    auto left_header = keyHeader("lk");
+    auto right_header = keyHeader("rk");
+
+    Settings settings;
+    auto table_join = std::make_shared<TableJoin>(settings, nullptr, nullptr);
+    table_join->getTableJoin().kind = JoinKind::Full;
+    table_join->getTableJoin().strictness = JoinStrictness::All;
+    table_join->addDisjunct();
+    table_join->getClauses().back().addKey("lk", "rk", /*null_safe_comparison=*/false);
+    table_join->setColumnsFromJoinedTable(right_header->getNamesAndTypesList(), {"lk"}, "", left_header->getNamesAndTypesList());
+    /// `rk` is a required right key, so the join emits it and the result can be compared per row.
+    table_join->setColumnsAddedByJoin(right_header->getNamesAndTypesList());
+
+    auto join = std::make_shared<MergeJoin>(table_join, right_header);
+
+    auto shared_output_header
+        = std::make_shared<const Block>(JoiningTransform::transformHeader(*left_header, join));
+
+    /// Right side: real rows plus a totals port that finishes without pushing anything.
+    auto right_source = keySource("rk", right_keys);
+    auto totals_source = std::make_shared<NullSource>(right_header);
+    auto filling = std::make_shared<FillingRightJoinSideTransform>(
+        right_header, join, std::make_shared<FinishCounter>(1));
+    auto * totals_port = filling->addTotalsPort();
+    connect(right_source->getPort(), filling->getInputs().front());
+    connect(totals_source->getPort(), *totals_port);
+
+    auto left_source = keySource("lk", left_keys);
+    auto joining = std::make_shared<JoiningTransform>(
+        left_header, shared_output_header, join, /*max_block_size_=*/0,
+        /*on_totals_=*/false, /*default_totals_=*/false, std::make_shared<FinishCounter>(1));
+    connect(left_source->getPort(), joining->getInputs().front());
+    connect(filling->getOutputs().front(), joining->getInputs().back());
+
+    auto processors = std::make_shared<Processors>();
+    processors->emplace_back(std::move(left_source));
+    processors->emplace_back(std::move(right_source));
+    processors->emplace_back(std::move(totals_source));
+    processors->emplace_back(std::move(filling));
+    processors->emplace_back(joining);
+
+    QueryPipeline pipeline(QueryPlanResourceHolder{}, processors, &joining->getOutputs().front());
+    PullingPipelineExecutor executor(pipeline);
+
+    std::vector<std::pair<UInt64, UInt64>> rows;
+    Block block;
+    while (executor.pull(block))
+    {
+        for (size_t i = 0; i < block.rows(); ++i)
+            rows.emplace_back(block.getByName("lk").column->getUInt(i), block.getByName("rk").column->getUInt(i));
+    }
+    std::sort(rows.begin(), rows.end());
+    return rows;
+}
+
+}
+
+TEST(MergeJoinStarvedTotals, FullJoinKeepsRightRows)
+{
+    /// Keys 0 and 1 match; 2 is left only; 3 is right only. join_use_nulls defaults to false,
+    /// so an unmatched side reads as 0.
+    auto rows = runFullJoinWithStarvedTotals({0, 1, 2}, {0, 1, 3});
+
+    const std::vector<std::pair<UInt64, UInt64>> expected{{0, 0}, {0, 3}, {1, 1}, {2, 0}};
+    ASSERT_EQ(rows, expected);
+}

--- a/tests/queries/0_stateless/04821_partial_merge_join_build_finalization.reference
+++ b/tests/queries/0_stateless/04821_partial_merge_join_build_finalization.reference
@@ -1,0 +1,46 @@
+-- inner: partial_merge vs hash
+8	8	28
+8	8	28
+-- left: partial_merge vs hash
+8	8	28
+8	8	28
+-- right: partial_merge vs hash
+8	8	28
+8	8	28
+-- full: partial_merge vs hash
+8	8	28
+8	8	28
+-- full with non-joined right rows: partial_merge vs hash
+10	10	2	45
+10	10	2	45
+-- right with non-joined right rows: partial_merge vs hash
+10	10	2	45
+10	10	2	45
+-- full, spilled right side: partial_merge vs hash
+10	10	2	45
+10	10	2	45
+-- totals still work
+0	0
+1	1
+2	2
+3	3
+4	4
+5	5
+6	6
+7	7
+8	8
+9	9
+
+0	45
+0	0
+1	1
+2	2
+3	3
+4	4
+5	5
+6	6
+7	7
+8	8
+9	9
+
+0	45

--- a/tests/queries/0_stateless/04821_partial_merge_join_build_finalization.reference
+++ b/tests/queries/0_stateless/04821_partial_merge_join_build_finalization.reference
@@ -19,6 +19,7 @@
 -- full, spilled right side: partial_merge vs hash
 10	10	2	45
 10	10	2	45
+1
 -- totals still work
 0	0
 1	1

--- a/tests/queries/0_stateless/04821_partial_merge_join_build_finalization.sql
+++ b/tests/queries/0_stateless/04821_partial_merge_join_build_finalization.sql
@@ -1,7 +1,7 @@
--- The right side is finalized on the build-phase-finish hook rather than as a side effect of
--- setTotals(), so a right side carrying WITH TOTALS must join exactly like one that does not,
--- and must agree with the hash algorithm. Before the fix a starved totals port left the right
--- side unmerged: RIGHT/FULL crashed on a null RowBitmaps and LEFT/INNER silently lost matches.
+-- The right side is finalized on the post build phase rather than as a side effect of
+-- `setTotals`, so a right side carrying `WITH TOTALS` must join exactly like one that does not,
+-- and must agree with the `hash` algorithm. The starved-totals-port case itself is covered by
+-- `04827_partial_merge_join_starved_totals_port`.
 
 DROP TABLE IF EXISTS t04821_l;
 DROP TABLE IF EXISTS t04821_r;
@@ -15,7 +15,7 @@ INSERT INTO t04821_r SELECT number, concat('r', toString(number)) FROM numbers(8
 SET join_use_nulls = 0;
 
 -- Every block below asserts that `partial_merge` agrees with `hash` on the same query.
--- countIf(rv != '') is the wrong-results detector: an unmerged right side yields 0.
+-- `countIf(rv != '')` is the wrong-results detector: an unmerged right side yields 0.
 
 SELECT '-- inner: partial_merge vs hash';
 SELECT count(), countIf(rv != ''), sum(k)
@@ -57,8 +57,8 @@ FROM t04821_l AS l FULL JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOT
 USING (k)
 SETTINGS join_algorithm = 'hash';
 
--- Non-joined rows are emitted by the RIGHT/FULL ALL path, which is the one that read the
--- null RowBitmaps. Keys 8 and 9 exist only on the right, so the bitmap is actually consulted.
+-- Non-joined rows are emitted by the `RIGHT`/`FULL ALL` path, which is the one that read the
+-- null `RowBitmaps`. Keys 8 and 9 exist only on the right, so the bitmap is actually consulted.
 INSERT INTO t04821_r SELECT number, concat('r', toString(number)) FROM numbers(8, 2);
 
 SELECT '-- full with non-joined right rows: partial_merge vs hash';
@@ -81,20 +81,29 @@ FROM t04821_l AS l RIGHT JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TO
 USING (k)
 SETTINGS join_algorithm = 'hash';
 
--- The spilled (on-disk) right side reaches the same finalization through mergeFlushedRightBlocks().
+-- The spilled (on-disk) right side reaches the same finalization through `mergeFlushedRightBlocks`.
+-- Its result is identical to the in-memory arm above, so the spill itself is asserted separately:
+-- without that, dropping `max_rows_in_join` would leave this arm green while covering nothing.
 SELECT '-- full, spilled right side: partial_merge vs hash';
 SELECT count(), countIf(rv != ''), countIf(lv = ''), sum(k)
 FROM t04821_l AS l FULL JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
 USING (k)
-SETTINGS join_algorithm = 'partial_merge', max_rows_in_join = 2, join_any_take_last_row = 0;
+SETTINGS join_algorithm = 'partial_merge', max_rows_in_join = 2, join_any_take_last_row = 0,
+         log_comment = '04821_spilled_right_side';
 SELECT count(), countIf(rv != ''), countIf(lv = ''), sum(k)
 FROM t04821_l AS l FULL JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
 USING (k)
 SETTINGS join_algorithm = 'hash';
 
--- Totals themselves must still be produced: setTotals() keeps its IJoin part. `rsum` exists
--- only on the right, so joinTotals() has to take its totals value from the right side; a
--- column shared with the left would be sourced from left_totals and could not detect that.
+SYSTEM FLUSH LOGS query_log;
+SELECT max(ProfileEvents['ExternalJoinWritePart']) > 0
+FROM system.query_log
+WHERE current_database = currentDatabase() AND log_comment = '04821_spilled_right_side'
+  AND type = 'QueryFinish';
+
+-- Totals themselves must still be produced: `setTotals` keeps its `IJoin` part. `rsum` exists
+-- only on the right, so `joinTotals` has to take its totals value from the right side; a
+-- column shared with the left would be sourced from `left_totals` and could not detect that.
 SELECT '-- totals still work';
 SELECT k, rsum FROM (SELECT k FROM t04821_l GROUP BY k WITH TOTALS) AS l
 FULL JOIN (SELECT k, sum(k) AS rsum FROM t04821_r GROUP BY k WITH TOTALS) AS r USING (k)

--- a/tests/queries/0_stateless/04821_partial_merge_join_build_finalization.sql
+++ b/tests/queries/0_stateless/04821_partial_merge_join_build_finalization.sql
@@ -1,0 +1,109 @@
+-- The right side is finalized on the build-phase-finish hook rather than as a side effect of
+-- setTotals(), so a right side carrying WITH TOTALS must join exactly like one that does not,
+-- and must agree with the hash algorithm. Before the fix a starved totals port left the right
+-- side unmerged: RIGHT/FULL crashed on a null RowBitmaps and LEFT/INNER silently lost matches.
+
+DROP TABLE IF EXISTS t04821_l;
+DROP TABLE IF EXISTS t04821_r;
+
+CREATE TABLE t04821_l (k UInt64, lv String) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE t04821_r (k UInt64, rv String) ENGINE = MergeTree ORDER BY k;
+
+INSERT INTO t04821_l SELECT number, concat('l', toString(number)) FROM numbers(8);
+INSERT INTO t04821_r SELECT number, concat('r', toString(number)) FROM numbers(8);
+
+SET join_use_nulls = 0;
+
+-- Every block below asserts that `partial_merge` agrees with `hash` on the same query.
+-- countIf(rv != '') is the wrong-results detector: an unmerged right side yields 0.
+
+SELECT '-- inner: partial_merge vs hash';
+SELECT count(), countIf(rv != ''), sum(k)
+FROM t04821_l AS l INNER JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
+USING (k)
+SETTINGS join_algorithm = 'partial_merge';
+SELECT count(), countIf(rv != ''), sum(k)
+FROM t04821_l AS l INNER JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
+USING (k)
+SETTINGS join_algorithm = 'hash';
+
+SELECT '-- left: partial_merge vs hash';
+SELECT count(), countIf(rv != ''), sum(k)
+FROM t04821_l AS l LEFT JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
+USING (k)
+SETTINGS join_algorithm = 'partial_merge';
+SELECT count(), countIf(rv != ''), sum(k)
+FROM t04821_l AS l LEFT JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
+USING (k)
+SETTINGS join_algorithm = 'hash';
+
+SELECT '-- right: partial_merge vs hash';
+SELECT count(), countIf(rv != ''), sum(k)
+FROM t04821_l AS l RIGHT JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
+USING (k)
+SETTINGS join_algorithm = 'partial_merge';
+SELECT count(), countIf(rv != ''), sum(k)
+FROM t04821_l AS l RIGHT JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
+USING (k)
+SETTINGS join_algorithm = 'hash';
+
+SELECT '-- full: partial_merge vs hash';
+SELECT count(), countIf(rv != ''), sum(k)
+FROM t04821_l AS l FULL JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
+USING (k)
+SETTINGS join_algorithm = 'partial_merge';
+SELECT count(), countIf(rv != ''), sum(k)
+FROM t04821_l AS l FULL JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
+USING (k)
+SETTINGS join_algorithm = 'hash';
+
+-- Non-joined rows are emitted by the RIGHT/FULL ALL path, which is the one that read the
+-- null RowBitmaps. Keys 8 and 9 exist only on the right, so the bitmap is actually consulted.
+INSERT INTO t04821_r SELECT number, concat('r', toString(number)) FROM numbers(8, 2);
+
+SELECT '-- full with non-joined right rows: partial_merge vs hash';
+SELECT count(), countIf(rv != ''), countIf(lv = ''), sum(k)
+FROM t04821_l AS l FULL JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
+USING (k)
+SETTINGS join_algorithm = 'partial_merge';
+SELECT count(), countIf(rv != ''), countIf(lv = ''), sum(k)
+FROM t04821_l AS l FULL JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
+USING (k)
+SETTINGS join_algorithm = 'hash';
+
+SELECT '-- right with non-joined right rows: partial_merge vs hash';
+SELECT count(), countIf(rv != ''), countIf(lv = ''), sum(k)
+FROM t04821_l AS l RIGHT JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
+USING (k)
+SETTINGS join_algorithm = 'partial_merge';
+SELECT count(), countIf(rv != ''), countIf(lv = ''), sum(k)
+FROM t04821_l AS l RIGHT JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
+USING (k)
+SETTINGS join_algorithm = 'hash';
+
+-- The spilled (on-disk) right side reaches the same finalization through mergeFlushedRightBlocks().
+SELECT '-- full, spilled right side: partial_merge vs hash';
+SELECT count(), countIf(rv != ''), countIf(lv = ''), sum(k)
+FROM t04821_l AS l FULL JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
+USING (k)
+SETTINGS join_algorithm = 'partial_merge', max_rows_in_join = 2, join_any_take_last_row = 0;
+SELECT count(), countIf(rv != ''), countIf(lv = ''), sum(k)
+FROM t04821_l AS l FULL JOIN (SELECT k, rv FROM t04821_r GROUP BY k, rv WITH TOTALS) AS r
+USING (k)
+SETTINGS join_algorithm = 'hash';
+
+-- Totals themselves must still be produced: setTotals() keeps its IJoin part. `rsum` exists
+-- only on the right, so joinTotals() has to take its totals value from the right side; a
+-- column shared with the left would be sourced from left_totals and could not detect that.
+SELECT '-- totals still work';
+SELECT k, rsum FROM (SELECT k FROM t04821_l GROUP BY k WITH TOTALS) AS l
+FULL JOIN (SELECT k, sum(k) AS rsum FROM t04821_r GROUP BY k WITH TOTALS) AS r USING (k)
+ORDER BY k
+SETTINGS join_algorithm = 'partial_merge';
+SELECT k, rsum FROM (SELECT k FROM t04821_l GROUP BY k WITH TOTALS) AS l
+FULL JOIN (SELECT k, sum(k) AS rsum FROM t04821_r GROUP BY k WITH TOTALS) AS r USING (k)
+ORDER BY k
+SETTINGS join_algorithm = 'hash';
+
+DROP TABLE t04821_l;
+DROP TABLE t04821_r;

--- a/tests/queries/0_stateless/04827_partial_merge_join_starved_totals_port.reference
+++ b/tests/queries/0_stateless/04827_partial_merge_join_starved_totals_port.reference
@@ -1,0 +1,7 @@
+-- the join under test runs on MergeJoin and has a totals input
+PartialMergeJoin
+1
+-- starved totals port
+8	0
+0
+ok

--- a/tests/queries/0_stateless/04827_partial_merge_join_starved_totals_port.sql
+++ b/tests/queries/0_stateless/04827_partial_merge_join_starved_totals_port.sql
@@ -1,0 +1,60 @@
+-- Tags: no-parallel, shard
+-- - no-parallel: uses a fail point (global server state)
+-- - shard: needs the test cluster to build a `Distributed` table
+
+DROP TABLE IF EXISTS t04827_local SYNC;
+DROP TABLE IF EXISTS t04827_dist SYNC;
+DROP VIEW IF EXISTS v04827_join;
+
+CREATE TABLE t04827_local (k UInt64, rv String) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t04827_local SELECT number, concat('r', toString(number)) FROM numbers(8);
+
+CREATE TABLE t04827_dist (k UInt64, rv String)
+ENGINE = Distributed(test_shard_localhost, currentDatabase(), t04827_local);
+
+-- The join and its settings live in a view, so the assertions below and the query that reproduces
+-- the bug are the same SQL by construction: neither `WITH TOTALS` nor `join_algorithm` can be
+-- changed for one and not the other.
+CREATE VIEW v04827_join AS
+SELECT count() AS rows_joined, countIf(rv != '') AS right_rows_seen
+FROM (SELECT number AS k FROM numbers(8)) AS l
+FULL JOIN (SELECT k, rv FROM t04827_dist GROUP BY k, rv WITH TOTALS) AS r USING (k)
+SETTINGS join_algorithm = 'partial_merge', skip_unavailable_shards = 1,
+         prefer_localhost_replica = 0, async_socket_for_remote = 0,
+         async_query_sending_for_remote = 0, max_threads = 1;
+
+-- The reproduction is defined by things being absent, so assert both ingredients first. The join
+-- has to run on `MergeJoin`, and it has to have a totals port: `FillingRightJoinSide` reports two
+-- inputs (right side plus totals) only when the right pipeline has totals, and reports no input
+-- count otherwise.
+SELECT '-- the join under test runs on MergeJoin and has a totals input';
+SELECT extract(explain, 'Algorithm: (\\w+)') FROM (EXPLAIN PLAN actions = 1 SELECT * FROM v04827_join)
+WHERE explain ILIKE '%Algorithm:%';
+SELECT count() FROM (EXPLAIN PIPELINE SELECT * FROM v04827_join)
+WHERE explain ILIKE '%FillingRightJoinSide 2 %';
+
+SYSTEM ENABLE FAILPOINT remote_query_executor_cancel_before_send;
+
+-- The cancelled shard never sends a Totals packet, so the totals port asserted above delivers zero
+-- chunks. The right side must still be finalized: reading it unmerged dereferences a null
+-- `RowBitmaps`.
+-- The result is the oracle, so it is printed rather than discarded: `8 0` means the shard was
+-- cancelled as intended, and `8 8` would mean the right rows arrived and the starved-totals path
+-- was never taken. A throwing timeout keeps an incomplete execution from passing as success.
+SELECT '-- starved totals port';
+SELECT * FROM v04827_join
+SETTINGS max_execution_time = 60, timeout_overflow_mode = 'throw';
+
+-- The fail point is once-only, so it disables itself when consumed. A still-enabled fail point
+-- here would mean the cancellation never fired and the query above proved nothing.
+SELECT count() FROM system.fail_points
+WHERE enabled AND name = 'remote_query_executor_cancel_before_send';
+
+SYSTEM DISABLE FAILPOINT remote_query_executor_cancel_before_send;
+
+-- The server must still be alive (the null dereference is fatal under UBSan).
+SELECT 'ok';
+
+DROP VIEW v04827_join;
+DROP TABLE t04827_local SYNC;
+DROP TABLE t04827_dist SYNC;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/109637


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix wrong results in `JOIN` with `join_algorithm = 'partial_merge'` when the right side carries totals: the right side could be left unmerged, so `LEFT` joins substituted default values for real matches and `INNER`/`RIGHT` joins returned no rows at all. In the `RIGHT`/`FULL` non-joined path the same state dereferenced a null pointer, which crashed the server.

### Description

`MergeJoin` finalized its whole right side as a side effect of `setTotals()`: that method
called `mergeRightBlocks()` and allocated `used_rows_bitmap`, and its comment ("Has to be
called even if totals are empty") documented the fragility.

`FillingRightJoinSideTransform::prepare` only calls `setTotals()` when it pulls a chunk from
the totals port, or, when there is no totals port, through the synthesized-empty-totals branch.
Those two branches are chained by `else if`, so a totals port that **exists but delivers zero
chunks** reaches neither, and `setTotals()` never runs. `RemoteTotalsSource::generate()` returns
an empty chunk when a remote sends no totals, and it is attached exactly when the port is
created, so the state is reachable rather than hypothetical.

With finalization skipped, three things are wrong at once: `loaded_right_blocks` is empty (the
probe sees zero right blocks and drops every right row), `min_max_right_blocks` is empty, and
`used_rows_bitmap` is null. `LEFT` therefore emits defaults instead of matches, `INNER`/`RIGHT`
return nothing, and `FULL`/`RIGHT ALL` dereference the null bitmap in
`NotJoinedMerge::fillColumns`, which UBSan reports as `reference binding to null pointer of
type 'DB::RowBitmaps'`.

The fix finalizes the right side on the **post build phase** instead. `prepare` calls
`onBuildPhaseFinish()` after both totals branches and, when the join reports
`hasPostBuildPhase()`, returns `Ready` so the executor runs `runPostBuildPhase()` from `work()`.
That strictly dominates `setTotals()` in reachability, and `work()` is the correct context for
this body: `mergeRightBlocks()` drives a nested pipeline, while `IProcessor` documents `prepare`
as O(1) work only. `HashJoin` uses the same seam for its own heavy build steps in
`runPostBuildPhase()`. `setTotals()` keeps its `IJoin` part, so totals results are unchanged.

<details>
<summary>Validation</summary>

Both directions on ASAN+UBSan builds, with the totals port starved:

* pre-fix: `shared_ptr.h:574:12: runtime error: reference binding to null pointer of type
  'element_type' (aka 'DB::RowBitmaps')`, symbolized stack `operator*` ->
  `NotJoinedMerge::fillColumns` -> `NotJoinedBlocks::nextImpl` -> `IBlocksStream::next` ->
  `JoiningTransform::work`, matching the CI report frame for frame.
* pre-fix wrong results on the same query: `LEFT` returned `0 0 | 1 0 | 2 0 | 3 0 | 4 0`
  and `INNER`/`RIGHT` returned no rows, where `hash` returns `0 0 | 1 1 | 2 2 | 3 3 | 4 4`.
* post-fix: no sanitizer report, and all four join kinds match `hash` exactly.

New gtest `MergeJoinStarvedTotals.FullJoinKeepsRightRows` wires the starved-totals state at
processor level and asserts the join result: on code byte-identical to unmodified master it
fails, losing every right value and the right-only key, and it passes on the fix. New stateless
test `04821_partial_merge_join_build_finalization` is a regression guard that asserts
`partial_merge` equals `hash` for `INNER`/`LEFT`/`RIGHT`/`FULL` over a right side with totals,
including non-joined right rows, a spilled right side and a right-only totals column. Mutants
confirm each half is pinned independently: dropping `mergeRightBlocks()` reddens the result
rows, dropping the bitmap allocation crashes the server, and making `setTotals()` a no-op
reddens only the totals arm. 50/50 randomized runs pass. A 349-test join/totals regression run
against pristine master gives identical failure sets and identical reason buckets, so there are
no regressions. Finalization is measured to run exactly once per query, and to complete before
the non-joined stream is constructed, on the in-memory, spilled, `JoinSwitcher` and `RIGHT`
paths.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1539` (included in `26.8` and later)
<!-- ch-version-info:end -->