### PR TITLE
Add range checks for narrowing VarInt reads

### DIFF
--- a/src/IO/VarInt.cpp
+++ b/src/IO/VarInt.cpp
@@ -6,11 +6,31 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ATTEMPT_TO_READ_AFTER_EOF;
+    extern const int INCORRECT_DATA;
 }
 
 void throwReadAfterEOF()
 {
     throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
+}
+
+void throwVarUIntOutOfRange(UInt64 value, UInt64 max_value)
+{
+    throw Exception(
+        ErrorCodes::INCORRECT_DATA,
+        "VarUInt value {} is out of range for target type with maximum value {}",
+        value,
+        max_value);
+}
+
+void throwVarIntOutOfRange(Int64 value, Int64 min_value, Int64 max_value)
+{
+    throw Exception(
+        ErrorCodes::INCORRECT_DATA,
+        "VarInt value {} is out of range for target type [{}, {}]",
+        value,
+        min_value,
+        max_value);
 }
 
 }

--- a/src/IO/VarInt.h
+++ b/src/IO/VarInt.h
@@ -2,7 +2,6 @@
 
 #include <base/types.h>
 #include <base/defines.h>
-#include <Common/Exception.h>
 #include <IO/ReadBuffer.h>
 #include <IO/WriteBuffer.h>
 
@@ -12,14 +11,13 @@
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int INCORRECT_DATA;
-}
-
 /// Variable-Length Quantity (VLQ) Base-128 compression, also known as Variable Byte (VB) or Varint encoding.
 
 [[noreturn]] void throwReadAfterEOF();
+
+[[noreturn]] void throwVarUIntOutOfRange(UInt64 value, UInt64 max_value);
+
+[[noreturn]] void throwVarIntOutOfRange(Int64 value, Int64 min_value, Int64 max_value);
 
 
 inline void writeVarUInt(UInt64 x, WriteBuffer & ostr)
@@ -125,11 +123,7 @@ inline void ALWAYS_INLINE checkVarUIntFits(UInt64 value)
     constexpr UInt64 max_value = static_cast<UInt64>(std::numeric_limits<T>::max());
     if (value > max_value) [[unlikely]]
     {
-        throw Exception(
-            ErrorCodes::INCORRECT_DATA,
-            "VarUInt value {} is out of range for target type with maximum value {}",
-            value,
-            max_value);
+        throwVarUIntOutOfRange(value, max_value);
     }
 }
 
@@ -142,12 +136,7 @@ inline void ALWAYS_INLINE checkVarIntFits(Int64 value)
     constexpr Int64 max_value = static_cast<Int64>(std::numeric_limits<T>::max());
     if (value < min_value || value > max_value) [[unlikely]]
     {
-        throw Exception(
-            ErrorCodes::INCORRECT_DATA,
-            "VarInt value {} is out of range for target type [{}, {}]",
-            value,
-            min_value,
-            max_value);
+        throwVarIntOutOfRange(value, min_value, max_value);
     }
 }
 

--- a/src/IO/VarInt.h
+++ b/src/IO/VarInt.h
@@ -2,11 +2,20 @@
 
 #include <base/types.h>
 #include <base/defines.h>
+#include <Common/Exception.h>
 #include <IO/ReadBuffer.h>
 #include <IO/WriteBuffer.h>
 
+#include <limits>
+#include <type_traits>
+
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int INCORRECT_DATA;
+}
 
 /// Variable-Length Quantity (VLQ) Base-128 compression, also known as Variable Byte (VB) or Varint encoding.
 
@@ -108,6 +117,40 @@ inline void ALWAYS_INLINE ignoreVarUInt(ReadBuffer & istr)
     }
 }
 
+template <typename T>
+inline void ALWAYS_INLINE checkVarUIntFits(UInt64 value)
+{
+    static_assert(std::is_integral_v<T>);
+
+    constexpr UInt64 max_value = static_cast<UInt64>(std::numeric_limits<T>::max());
+    if (value > max_value) [[unlikely]]
+    {
+        throw Exception(
+            ErrorCodes::INCORRECT_DATA,
+            "VarUInt value {} is out of range for target type with maximum value {}",
+            value,
+            max_value);
+    }
+}
+
+template <typename T>
+inline void ALWAYS_INLINE checkVarIntFits(Int64 value)
+{
+    static_assert(std::is_integral_v<T> && std::is_signed_v<T>);
+
+    constexpr Int64 min_value = static_cast<Int64>(std::numeric_limits<T>::min());
+    constexpr Int64 max_value = static_cast<Int64>(std::numeric_limits<T>::max());
+    if (value < min_value || value > max_value) [[unlikely]]
+    {
+        throw Exception(
+            ErrorCodes::INCORRECT_DATA,
+            "VarInt value {} is out of range for target type [{}, {}]",
+            value,
+            min_value,
+            max_value);
+    }
+}
+
 }
 
 inline void ALWAYS_INLINE readVarUInt(UInt64 & x, ReadBuffer & istr)
@@ -181,6 +224,7 @@ inline void ALWAYS_INLINE readVarUInt(UInt32 & x, ReadBuffer & istr)
 {
     UInt64 tmp = 0;
     readVarUInt(tmp, istr);
+    varint_impl::checkVarUIntFits<UInt32>(tmp);
     x = static_cast<UInt32>(tmp);
 }
 
@@ -188,6 +232,7 @@ inline void ALWAYS_INLINE readVarInt(Int32 & x, ReadBuffer & istr)
 {
     Int64 tmp = 0;
     readVarInt(tmp, istr);
+    varint_impl::checkVarIntFits<Int32>(tmp);
     x = static_cast<Int32>(tmp);
 }
 
@@ -195,6 +240,7 @@ inline void ALWAYS_INLINE readVarUInt(UInt16 & x, ReadBuffer & istr)
 {
     UInt64 tmp = 0;
     readVarUInt(tmp, istr);
+    varint_impl::checkVarUIntFits<UInt16>(tmp);
     x = static_cast<UInt16>(tmp);
 }
 
@@ -202,6 +248,7 @@ inline void ALWAYS_INLINE readVarInt(Int16 & x, ReadBuffer & istr)
 {
     Int64 tmp = 0;
     readVarInt(tmp, istr);
+    varint_impl::checkVarIntFits<Int16>(tmp);
     x = static_cast<Int16>(tmp);
 }
 
@@ -211,6 +258,10 @@ inline void ALWAYS_INLINE readVarUInt(T & x, ReadBuffer & istr)
 {
     UInt64 tmp = 0;
     readVarUInt(tmp, istr);
+
+    if constexpr (std::is_integral_v<T>)
+        varint_impl::checkVarUIntFits<T>(tmp);
+
     x = static_cast<T>(tmp);
 }
 

--- a/src/IO/tests/gtest_varint.cpp
+++ b/src/IO/tests/gtest_varint.cpp
@@ -1,0 +1,130 @@
+#include <Common/Exception.h>
+#include <IO/ReadBufferFromMemory.h>
+#include <IO/VarInt.h>
+#include <IO/WriteBufferFromString.h>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+using namespace DB;
+
+namespace
+{
+
+template <typename T>
+T readVarUIntValue(UInt64 value)
+{
+    WriteBufferFromOwnString write_buffer;
+    writeVarUInt(value, write_buffer);
+    write_buffer.finalize();
+
+    const auto & data = write_buffer.str();
+    ReadBufferFromMemory read_buffer(data.data(), data.size());
+
+    T result{};
+    readVarUInt(result, read_buffer);
+    return result;
+}
+
+template <typename T>
+T readVarIntValue(Int64 value)
+{
+    WriteBufferFromOwnString write_buffer;
+    writeVarInt(value, write_buffer);
+    write_buffer.finalize();
+
+    const auto & data = write_buffer.str();
+    ReadBufferFromMemory read_buffer(data.data(), data.size());
+
+    T result{};
+    readVarInt(result, read_buffer);
+    return result;
+}
+
+}
+
+TEST(VarInt, VarUIntRejectsValuesOutsideTargetRange)
+{
+    EXPECT_THROW(
+        readVarUIntValue<UInt8>(
+            static_cast<UInt64>(std::numeric_limits<UInt8>::max()) + 1),
+        Exception);
+
+    EXPECT_THROW(
+        readVarUIntValue<UInt16>(
+            static_cast<UInt64>(std::numeric_limits<UInt16>::max()) + 1),
+        Exception);
+
+    EXPECT_THROW(
+        readVarUIntValue<UInt32>(
+            static_cast<UInt64>(std::numeric_limits<UInt32>::max()) + 1),
+        Exception);
+}
+
+TEST(VarInt, VarUIntAcceptsMaximumTargetValues)
+{
+    EXPECT_EQ(
+        readVarUIntValue<UInt8>(std::numeric_limits<UInt8>::max()),
+        std::numeric_limits<UInt8>::max());
+
+    EXPECT_EQ(
+        readVarUIntValue<UInt16>(std::numeric_limits<UInt16>::max()),
+        std::numeric_limits<UInt16>::max());
+
+    EXPECT_EQ(
+        readVarUIntValue<UInt32>(std::numeric_limits<UInt32>::max()),
+        std::numeric_limits<UInt32>::max());
+}
+
+TEST(VarInt, VarIntRejectsValuesOutsideInt16Range)
+{
+    EXPECT_THROW(
+        readVarIntValue<Int16>(
+            static_cast<Int64>(std::numeric_limits<Int16>::max()) + 1),
+        Exception);
+
+    EXPECT_THROW(
+        readVarIntValue<Int16>(
+            static_cast<Int64>(std::numeric_limits<Int16>::min()) - 1),
+        Exception);
+}
+
+TEST(VarInt, VarIntRejectsValuesOutsideInt32Range)
+{
+    EXPECT_THROW(
+        readVarIntValue<Int32>(
+            static_cast<Int64>(std::numeric_limits<Int32>::max()) + 1),
+        Exception);
+
+    EXPECT_THROW(
+        readVarIntValue<Int32>(
+            static_cast<Int64>(std::numeric_limits<Int32>::min()) - 1),
+        Exception);
+}
+
+TEST(VarInt, VarIntAcceptsSignedBoundaryValues)
+{
+    EXPECT_EQ(
+        readVarIntValue<Int16>(std::numeric_limits<Int16>::min()),
+        std::numeric_limits<Int16>::min());
+
+    EXPECT_EQ(
+        readVarIntValue<Int16>(std::numeric_limits<Int16>::max()),
+        std::numeric_limits<Int16>::max());
+
+    EXPECT_EQ(
+        readVarIntValue<Int32>(std::numeric_limits<Int32>::min()),
+        std::numeric_limits<Int32>::min());
+
+    EXPECT_EQ(
+        readVarIntValue<Int32>(std::numeric_limits<Int32>::max()),
+        std::numeric_limits<Int32>::max());
+}
+
+TEST(VarInt, UInt64ReadIsUnchanged)
+{
+    constexpr UInt64 value = 0x123456789ABCDEF0ULL;
+
+    EXPECT_EQ(readVarUIntValue<UInt64>(value), value);
+}


### PR DESCRIPTION
`readVarUInt` and `readVarInt` currently decode into `UInt64` / `Int64` first and then use `static_cast` when the caller requests a narrower integer type.

For example:

```cpp
inline void readVarUInt(UInt32 & x, ReadBuffer & istr)
{
    UInt64 tmp = 0;
    readVarUInt(tmp, istr);
    x = static_cast<UInt32>(tmp);
}
```

If the encoded value is outside the destination type's range, the conversion silently truncates or wraps it instead of rejecting malformed input. For example, a VarUInt value of `UINT32_MAX + 1` is currently decoded as `0` when read into a `UInt32`.

The same pattern also exists for `UInt16`, `Int32`, `Int16`, and integral types handled by the generic `readVarUInt(T &)` overload.

This change validates the decoded value before narrowing it:

* `readVarUInt` rejects values greater than the maximum representable value of an integral destination type.
* `readVarInt(Int32)` and `readVarInt(Int16)` reject values outside the destination type's signed range.
* `UInt64` and `Int64` decoding remains unchanged.
* Valid boundary values continue to decode normally.

This makes malformed VarInt input fail explicitly with `INCORRECT_DATA` instead of being silently converted to a different value.

The issue can also affect protocol fields that use narrow integer types, such as `client_tcp_protocol_version` in `TCPHandler::receiveHello()`. This PR intentionally treats that as an input-validation/correctness issue rather than relying on silent integer truncation behavior.

### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Reject VarInt values that do not fit into the requested integer type instead of silently truncating them.