### PR TITLE
Break a Context retain cycle in the DatabaseReplicated digest finalizer

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -1313,10 +1313,14 @@ void DatabaseReplicated::assertDigest(const ContextPtr & local_context)
     {
         if (auto txn = local_context->getZooKeeperMetadataTransaction())
         {
-            txn->addFinalizer([this, local_context]()
+            /// Weak because the `Context` owns this transaction. It cannot expire here:
+            /// `commit` runs the finalizer while its caller still holds that `Context`.
+            txn->addFinalizer([this, weak_context = ContextWeakPtr{local_context}]()
             {
+                auto context = weak_context.lock();
+                chassert(context);
                 std::lock_guard lock{metadata_mutex};
-                assertDigestWithProbability(local_context);
+                assertDigestWithProbability(context);
             });
         }
     }
@@ -1332,10 +1336,13 @@ void DatabaseReplicated::assertDigestInTransactionOrInline(const ContextPtr & lo
 #if defined(DEBUG_OR_SANITIZER_BUILD)
     if (txn)
     {
-        txn->addFinalizer([this, local_context]()
+        /// Weak for the same reason as in `assertDigest` above.
+        txn->addFinalizer([this, weak_context = ContextWeakPtr{local_context}]()
         {
+            auto context = weak_context.lock();
+            chassert(context);
             std::lock_guard lock{metadata_mutex};
-            assertDigestWithProbability(local_context);
+            assertDigestWithProbability(context);
         });
     }
     else


### PR DESCRIPTION
Repro - https://pastila.nl/?01eb64cc/50ef5c57e055be93ad88bd986be03c79#vXR4xuaQmEQ7Srt5FyeFnw==GCM
Sanitizer report - https://pastila.nl/?0000178e/79200a19fc7bf34a10da9445d8aa1749.terminal#2hyvhihFlzkbrQ4087lBjg==GCM

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/113954

`Stress test (*_asan_ubsan)` fails with `LeakSanitizer: detected memory leaks`, all
indirect and zero direct, the largest object being a `DB::Settings` copy from
`Context::createCopy`. Seen on 14+ unrelated pull requests, none on master.

`DatabaseReplicated::assertDigest` and `assertDigestInTransactionOrInline` register a
finalizer on the DDL metadata transaction that captures `local_context` as a strong
`ContextPtr`, while the same `Context` owns that transaction via
`ContextData::metadata_transaction`. That is a cycle, and only a successful
`ZooKeeperMetadataTransaction::commit` breaks it, by running the finalizer and clearing
it. When `multi()` throws, or the query is killed first, the `Context` graph is retained
for the process lifetime. All-indirect is the signature of a cycle: a chunk starts
`kDirectlyLeaked` and is downgraded only when another already-leaked chunk points at it.

The fix captures a `ContextWeakPtr`. Nothing else changes: `commit` runs the finalizer
while its caller still holds the registering `Context`, so the lock always succeeds
there, which is why the null case is a `chassert` rather than a runtime branch.

Both sites are inside `#if defined(DEBUG_OR_SANITIZER_BUILD)`, so release builds never
register the finalizer.

Related: `2064-22d0`, a second family with `QueryTreeBuilder` frames and no DDL frames, is
a different retention (materialized-CTE plan self-reference) and is fixed by #113397, not
here.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1046` (included in `26.8` and later)
<!-- ch-version-info:end -->