### PR TITLE
Do not report a cancelled refresh as a failure to drop the temporary table

### DIFF
--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -755,6 +755,8 @@ void StorageMaterializedView::dropTempTable(StorageID table_id, ContextMutablePt
     /// set on refresh_context, and DatabaseReplicated needs it to skip stale temp-table entries.
     refresh_context->setSetting("max_table_size_to_drop", Field(UInt64{0}));
     refresh_context->setSetting("max_partition_size_to_drop", Field(UInt64{0}));
+    /// Nothing waits for this table afterwards, so keep the drop below asynchronous.
+    refresh_context->setSetting("database_atomic_wait_for_drop_and_detach_synchronously", false);
 
     auto query_scope = QueryScope::create(refresh_context);
 

--- a/tests/queries/0_stateless/04835_refreshable_mv_cancelled_temp_table_drop.reference
+++ b/tests/queries/0_stateless/04835_refreshable_mv_cancelled_temp_table_drop.reference
@@ -1,3 +1,4 @@
 no spurious error	0
+no cancelled temp drop	0
 temp table dropped	0
 refresh was cancelled	1

--- a/tests/queries/0_stateless/04835_refreshable_mv_cancelled_temp_table_drop.reference
+++ b/tests/queries/0_stateless/04835_refreshable_mv_cancelled_temp_table_drop.reference
@@ -1,0 +1,3 @@
+no spurious error	0
+temp table dropped	0
+refresh was cancelled	1

--- a/tests/queries/0_stateless/04835_refreshable_mv_cancelled_temp_table_drop.sh
+++ b/tests/queries/0_stateless/04835_refreshable_mv_cancelled_temp_table_drop.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Tags: atomic-database
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# The setting is pinned in the view's SELECT (not the session) because that is what reaches the
+# refresh context, where the drop of the temporary table runs.
+$CLICKHOUSE_CLIENT -q "
+    create materialized view v refresh every 1 year settings refresh_retries = 0 (x UInt64)
+        engine MergeTree order by x empty as
+        select number + sleepEachRow(0.05) as x from numbers(200)
+        settings max_block_size = 1, max_threads = 1,
+                 database_atomic_wait_for_drop_and_detach_synchronously = 1;
+    system refresh view v;"
+
+# Cancel only once the refresh has read a row, so there is a live pipeline to interrupt and the
+# temporary table already exists.
+for _ in {1..600}
+do
+    [ "`$CLICKHOUSE_CLIENT -q "select status = 'Running' and read_rows > 0 from system.view_refreshes where database = currentDatabase() and view = 'v'"`" = 1 ] && break
+    sleep 0.1
+done
+
+$CLICKHOUSE_CLIENT -q "system cancel view v"
+
+for _ in {1..600}
+do
+    [ "`$CLICKHOUSE_CLIENT -q "select status from system.view_refreshes where database = currentDatabase() and view = 'v'"`" = Scheduled ] && break
+    sleep 0.1
+done
+
+# The temporary table is dropped asynchronously, so give the background drop a moment to retire it
+# before asserting that nothing is left behind.
+for _ in {1..600}
+do
+    [ "`$CLICKHOUSE_CLIENT -q "select count() from system.tables where database = currentDatabase() and name like '.tmp.inner_id.%'"`" = 0 ] && break
+    sleep 0.1
+done
+
+$CLICKHOUSE_CLIENT -q "system flush logs text_log"
+
+# 1: the cancellation must not be reported as a failure to drop the temporary table.
+# 2: the temporary table must really be gone, so that 1 cannot pass by merely silencing the message.
+$CLICKHOUSE_CLIENT -q "
+    select 'no spurious error', count() from system.text_log
+        where event_date >= yesterday() and event_time >= now() - interval 10 minute
+            and logger_name = 'StorageMaterializedView'
+            and message like '%Failed to drop temporary table after refresh%'
+            and message like '%' || currentDatabase() || '.v:%'
+        settings max_rows_to_read = 0;
+    select 'temp table dropped', count() from system.tables
+        where database = currentDatabase() and name like '.tmp.inner_id.%';
+    select 'refresh was cancelled', exception = 'cancelled' from system.view_refreshes
+        where database = currentDatabase() and view = 'v';"

--- a/tests/queries/0_stateless/04835_refreshable_mv_cancelled_temp_table_drop.sh
+++ b/tests/queries/0_stateless/04835_refreshable_mv_cancelled_temp_table_drop.sh
@@ -39,16 +39,26 @@ do
     sleep 0.1
 done
 
-$CLICKHOUSE_CLIENT -q "system flush logs text_log"
+$CLICKHOUSE_CLIENT -q "system flush logs text_log, query_log"
 
 # 1: the cancellation must not be reported as a failure to drop the temporary table.
-# 2: the temporary table must really be gone, so that 1 cannot pass by merely silencing the message.
+# 2: the drop itself must not be cancelled, so that 1 cannot pass by merely silencing the message.
+#    The type restricts this to the drop; the refresh query is cancelled too and also logs code 394.
+# 3: the temporary table must really be gone.
 $CLICKHOUSE_CLIENT -q "
     select 'no spurious error', count() from system.text_log
         where event_date >= yesterday() and event_time >= now() - interval 10 minute
             and logger_name = 'StorageMaterializedView'
             and message like '%Failed to drop temporary table after refresh%'
             and message like '%' || currentDatabase() || '.v:%'
+        settings max_rows_to_read = 0;
+    select 'no cancelled temp drop', count() from system.query_log
+        where event_date >= yesterday() and event_time >= now() - interval 10 minute
+            and is_internal = 1
+            and current_database = currentDatabase()
+            and query like 'DROP TABLE IF EXISTS%.tmp.inner_id.%'
+            and type = 'ExceptionBeforeStart'
+            and exception_code = 394
         settings max_rows_to_read = 0;
     select 'temp table dropped', count() from system.tables
         where database = currentDatabase() and name like '.tmp.inner_id.%';


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/97032


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a spurious `Failed to drop temporary table after refresh. Table ... is left behind and requires manual cleanup.` error logged when a refreshable materialized view's refresh is cancelled (for example by a server shutdown) while `database_atomic_wait_for_drop_and_detach_synchronously` is enabled. The temporary table was in fact dropped, so no manual cleanup was ever needed.


### Description

`StorageMaterializedView::dropTempTable` cleans up the temporary inner table after a refresh and sets `sync = false`, because nothing waits for that table afterwards. `InterpreterDropQuery` overrides that back to synchronous when `database_atomic_wait_for_drop_and_detach_synchronously` is set, which CI pins in the default profile. The resulting wait calls `throwIfKilled()`, so with the refresh already cancelled it throws `QUERY_WAS_CANCELLED` out of a drop whose own work had succeeded, and the `catch` logs the error above.

Nothing is left behind: the drop completes before the wait is entered, so only the waiting is interrupted. In the CI report all three affected tables log `dropAllData: done.` and have their metadata removed 5 to 23 ms after the error claiming they are left behind.

The fix pins the setting to `false` on the refresh context, so the drop stays asynchronous as intended. `dropInnerTableIfAny` already drops this same `.tmp` table with `ignore_sync_setting = true`, as do the internal drops in `StorageTimeSeries`, `StorageMaterializedPostgreSQL` and `StorageWindowView`; `dropTempTable` alone was missing it.

The error message itself is left in place: on a `Replicated` database the cancellation is thrown before the entry is committed, so there the table really is retained and the message is accurate. That case is not addressed here.

Found by CI on an unrelated PR: [Upgrade check (amd_release)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97032&sha=eb095b366a9e67ef0caf324ac5a0a931b7205f67&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29). The signature hit 3 unrelated PRs and never master in 90 days, always in that check, which needs a refresh in flight exactly at the restart. `upgrade_runner.sh` does not allowlist the message, so it fails the check.

The new stateless test passes 50/50 with the fix and fails 10/10 with it reverted. Besides the absent message it asserts, via `system.query_log`, that no internal `DROP` of the temporary table was cancelled, so it cannot pass by silencing the message: with the fix reverted and the message suppressed by hand, that assertion still fails.

<details>
<summary>Local reproduction: the table is dropped before the error is logged</summary>

```
12:05:57.491860  Debug        DatabaseCatalog          Waiting for table 3680420b-bab1-4aea-91f7-de278cbc5a75 to be finally dropped
12:05:57.492483  Trace        <temp table>             dropAllData: done.
12:05:57.492508  Information  DatabaseCatalog          Removing metadata metadata_dropped/....3680420b-bab1-4aea-91f7-de278cbc5a75.
12:05:57.566474  Error        StorageMaterializedView  ...: Failed to drop temporary table after refresh. Table ....`.tmp.inner_id....` is left behind and requires manual cleanup.
```

The logged DROP text ends in `SYNC` even though `sync = false` is set two frames up, which is the
override described above. `system.tables` holds no `.tmp.inner_id.%` row afterwards.

</details>