### PR TITLE
Stress test: honor storage skip tags by forwarding --s3-storage / --azure-blob-storage

### DIFF
--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -294,8 +294,18 @@ cp -av --dereference /repo/ci/jobs/scripts/fuzzer/limit-recursion-settings.xml /
 
 start_server || { echo "Failed to start server"; exit 1; }
 
+# clickhouse-test must know which storage backend the server actually uses, or its storage skip
+# tags are inert and incompatible tests run on an unsupported backend. Both variables are already
+# final here: the policy choice above, including its RANDOM % 3 fallback, exports them.
+test_cmd_opts=""
+if [[ "$USE_S3_STORAGE_FOR_MERGE_TREE" == "1" ]]; then
+    test_cmd_opts=" --s3-storage"
+elif [[ "$USE_AZURE_STORAGE_FOR_MERGE_TREE" == "1" ]]; then
+    test_cmd_opts=" --azure-blob-storage"
+fi
+
 cd /repo/tests/ || exit 1  # clickhouse-test can find queries dir from there
-python3 /repo/ci/jobs/scripts/stress/stress.py --hung-check --drop-databases --output-folder /test_output --skip-func-tests "$SKIP_TESTS_OPTION" --global-time-limit "${STRESS_GLOBAL_TIME_LIMIT:-1200}" --encrypted-storage "$USE_ENCRYPTED_STORAGE" \
+python3 /repo/ci/jobs/scripts/stress/stress.py --test-cmd="/usr/bin/clickhouse-test${test_cmd_opts}" --hung-check --drop-databases --output-folder /test_output --skip-func-tests "$SKIP_TESTS_OPTION" --global-time-limit "${STRESS_GLOBAL_TIME_LIMIT:-1200}" --encrypted-storage "$USE_ENCRYPTED_STORAGE" \
     && echo -e "Test script exit code$OK" >> /test_output/test_results.tsv \
     || echo -e "Test script failed$FAIL script exit code: $?" >> /test_output/test_results.tsv
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/111053
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/111053
Related: https://github.com/ClickHouse/ClickHouse/pull/111772

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`stress_runner.sh` invokes `stress.py` without `--test-cmd`, so `clickhouse-test` is never told the
storage backend. The storage skip tags are gated on exactly that (`tests/clickhouse-test:2985-3001`
needs `args.s3_storage` / `args.azure_blob_storage`, set only by the CLI flags), so
`no-object-storage` is inert in every Stress run. Meanwhile `stress_runner.sh:103-121` puts even a
non-`s3` flavour on object storage in 2 of 3 draws (`RANDOM % 3`), which is why most of these
failures land on flavours without `s3` in the name.

`04630_merge_over_stale_packed_tmp_dir` carries that tag because it `cp -r`s a live part directory.
On object storage those are metadata files whose blob `ref_count` lives inside them
(`DiskObjectStorageMetadata.h:24`) and is bumped only by ClickHouse's own hardlink path, so the copy
claims `ref_count == 0`; reclaiming that leftover deletes the blob still referenced by the active
part `all_1_1_0`, and every later read of it fails on the missing key. Over 14 days: 10 rows across
10 unrelated PRs, all S3, 5 Stress flavours, 0 on master.

The fix forwards the backend the runner already chose, in the same shape as the sibling
`upgrade_runner.sh:134` (#111772); on `default`-policy runs the composed command is byte-identical to
today's. Validated with MinIO: pre-fix `[ FAIL ]`, post-fix `[ SKIPPED ] object-storage`, local
control `[ OK ]`, 3/3 each.

Effects, up front. Tests declared incompatible with the drawn backend now SKIP instead of running on
it, so Stress test counts drop there: 177 on an s3 draw (`no-object-storage` 150 plus
`no-s3-storage` 36, 9 in both), 203 on azure (150 plus `no-azure-blob-storage` 53). Only
`amd_debug` / `arm_debug` drawing s3 lose settings randomization (`:5828`, pre-existing, already
shipped for `Stateless tests (amd_debug, ..., s3 storage, ...)`). `--encrypted-storage`, a silent
no-op here today (`:7135`), starts working, reactivating `no-encrypted-storage` (26 tests).

Out of scope: the one non-PR row is release branch `26.6` (a missing ignore-list backport), and PR
111992's is a different family.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1037` (included in `26.8` and later)
<!-- ch-version-info:end -->