### PR TITLE
Fix AI SQL generation failing on prompts that need several schema lookups

### DIFF
--- a/src/Client/AI/AIConfiguration.h
+++ b/src/Client/AI/AIConfiguration.h
@@ -36,8 +36,10 @@ struct AIConfiguration
     /// Custom system prompt (optional)
     std::string system_prompt;
 
-    /// Maximum steps for multi-step tool calling
-    size_t max_steps = 5;
+    /// Maximum steps for multi-step tool calling. The model's final answer also takes
+    /// a step: exploring the schema of a few tables can easily take five steps, and when
+    /// the limit is reached before the model produced its answer, no query is generated.
+    size_t max_steps = 10;
 
     /// Enable schema access - allows AI to query database/table information
     bool enable_schema_access = true;

--- a/src/Client/AI/AISQLGenerator.cpp
+++ b/src/Client/AI/AISQLGenerator.cpp
@@ -86,7 +86,8 @@ std::string AISQLGenerator::generateSQL(const std::string & prompt)
         display.showSeparator();
 
         // Display the generated SQL
-        std::string sql = cleanSQL(result.text);
+        const std::string & final_text = result.steps.empty() ? result.text : result.steps.back().text;
+        std::string sql = cleanSQL(final_text);
         if (!sql.empty())
         {
             display.showProgress("✨ SQL query generated successfully!");
@@ -104,8 +105,8 @@ std::string AISQLGenerator::generateSQL(const std::string & prompt)
             display.showProgress("⚠️  No SQL query was generated");
             /// The model replied with prose instead of a query (e.g. an explanation of
             /// why it cannot be answered) - show it to the user.
-            if (!result.text.empty())
-                output_stream << result.text << std::endl;
+            if (!final_text.empty())
+                output_stream << final_text << std::endl;
         }
 
         return sql;

--- a/src/Client/AI/AISQLGenerator.cpp
+++ b/src/Client/AI/AISQLGenerator.cpp
@@ -4,6 +4,7 @@
 #include <Client/AI/AIToolExecutionDisplay.h>
 #include <base/terminalColors.h>
 #include <Common/Exception.h>
+#include <fmt/format.h>
 
 namespace DB
 {
@@ -90,9 +91,21 @@ std::string AISQLGenerator::generateSQL(const std::string & prompt)
         {
             display.showProgress("✨ SQL query generated successfully!");
         }
+        else if (result.finish_reason == ai::kFinishReasonToolCalls)
+        {
+            /// The generation ended by exhausting `max_steps` while the model was still
+            /// calling schema exploration tools, before it produced its final answer.
+            display.showProgress(fmt::format(
+                "⚠️  No SQL query was generated: the schema exploration step limit was reached (ai.max_steps = {})",
+                config.max_steps));
+        }
         else
         {
             display.showProgress("⚠️  No SQL query was generated");
+            /// The model replied with prose instead of a query (e.g. an explanation of
+            /// why it cannot be answered) - show it to the user.
+            if (!result.text.empty())
+                output_stream << result.text << std::endl;
         }
 
         return sql;
@@ -131,18 +144,23 @@ std::string AISQLGenerator::buildCompletePrompt(const std::string & user_prompt)
 
 std::string AISQLGenerator::cleanSQL(const std::string & sql)
 {
-    std::string cleaned = sql;
+    /// The model is instructed to wrap the final query in `<sql>` tags, and in a
+    /// multi-step generation the SDK concatenates the text of all steps, so the text
+    /// can contain explanatory prose before the query. Extract the last tagged block -
+    /// it is the one produced by the final step. No tags means no query was generated:
+    /// return an empty string rather than mistaking the prose for SQL.
+    static constexpr std::string_view open_tag = "<sql>";
+    static constexpr std::string_view close_tag = "</sql>";
 
-    // Extract SQL from <sql> tags
-    size_t start_tag = cleaned.find("<sql>");
-    size_t end_tag = cleaned.find("</sql>");
+    const size_t end_tag = sql.rfind(close_tag);
+    if (end_tag == std::string::npos)
+        return {};
+    const size_t start_tag = sql.rfind(open_tag, end_tag);
+    if (start_tag == std::string::npos)
+        return {};
 
-    if (start_tag != std::string::npos && end_tag != std::string::npos)
-    {
-        // Extract content between tags
-        start_tag += 5; // Length of "<sql>"
-        cleaned = cleaned.substr(start_tag, end_tag - start_tag);
-    }
+    const size_t query_begin = start_tag + open_tag.size();
+    std::string cleaned = sql.substr(query_begin, end_tag - query_begin);
 
     // Trim whitespace
     cleaned.erase(0, cleaned.find_first_not_of(" \n\r\t"));

--- a/src/Client/AI/AISQLGenerator.cpp
+++ b/src/Client/AI/AISQLGenerator.cpp
@@ -145,22 +145,23 @@ std::string AISQLGenerator::buildCompletePrompt(const std::string & user_prompt)
 
 std::string AISQLGenerator::cleanSQL(const std::string & sql)
 {
-    /// The model is instructed to wrap the final query in `<sql>` tags, and in a
-    /// multi-step generation the SDK concatenates the text of all steps, so the text
-    /// can contain explanatory prose before the query. Extract the last tagged block -
-    /// it is the one produced by the final step. No tags means no query was generated:
-    /// return an empty string rather than mistaking the prose for SQL.
+    /// The model is instructed to wrap the final query in `<sql>` tags, possibly
+    /// surrounded by prose. Extract the outermost tagged block - the first opening and
+    /// the last closing tag - because the tags can also appear inside the query itself
+    /// (e.g. in a string literal), where an inner pair would truncate the query.
+    /// No tags means no query was generated: return an empty string rather than
+    /// mistaking the prose for SQL.
     static constexpr std::string_view open_tag = "<sql>";
     static constexpr std::string_view close_tag = "</sql>";
 
-    const size_t end_tag = sql.rfind(close_tag);
-    if (end_tag == std::string::npos)
-        return {};
-    const size_t start_tag = sql.rfind(open_tag, end_tag);
+    const size_t start_tag = sql.find(open_tag);
     if (start_tag == std::string::npos)
         return {};
-
     const size_t query_begin = start_tag + open_tag.size();
+    const size_t end_tag = sql.rfind(close_tag);
+    if (end_tag == std::string::npos || end_tag < query_begin)
+        return {};
+
     std::string cleaned = sql.substr(query_begin, end_tag - query_begin);
 
     // Trim whitespace

--- a/src/Client/AI/AISQLGenerator.h
+++ b/src/Client/AI/AISQLGenerator.h
@@ -27,9 +27,9 @@ public:
     /// Get the provider name
     std::string getProviderName() const;
 
-    /// Extract the SQL query from the model response: take the last `<sql>` tagged block
-    /// and trim the surrounding whitespace. Returns an empty string when there are no
-    /// tags, which means no query was generated.
+    /// Extract the SQL query from the model response: take the outermost `<sql>` tagged
+    /// block and trim the surrounding whitespace. Returns an empty string when there are
+    /// no tags, which means no query was generated.
     static std::string cleanSQL(const std::string & sql);
 
 private:

--- a/src/Client/AI/AISQLGenerator.h
+++ b/src/Client/AI/AISQLGenerator.h
@@ -27,6 +27,11 @@ public:
     /// Get the provider name
     std::string getProviderName() const;
 
+    /// Extract the SQL query from the model response: take the last `<sql>` tagged block
+    /// and trim the surrounding whitespace. Returns an empty string when there are no
+    /// tags, which means no query was generated.
+    static std::string cleanSQL(const std::string & sql);
+
 private:
     AIConfiguration config;
     ai::Client client;
@@ -38,9 +43,6 @@ private:
 
     /// Build the complete prompt with context
     std::string buildCompletePrompt(const std::string & user_prompt) const;
-
-    /// Clean SQL from markdown formatting and whitespace
-    static std::string cleanSQL(const std::string & sql);
 
     /// Get the appropriate model string for the provider
     std::string getModelString() const;

--- a/src/Client/AI/tests/gtest_ai_sql_generator.cpp
+++ b/src/Client/AI/tests/gtest_ai_sql_generator.cpp
@@ -237,6 +237,36 @@ TEST(AISQLGenerator, ConfigurationValidation)
     }, Exception);
 }
 
+/// `cleanSQL` is a pure function, so these tests need no AI credentials.
+
+TEST(AISQLGenerator, CleanSQLExtractsLastTaggedBlock)
+{
+    EXPECT_EQ(AISQLGenerator::cleanSQL("<sql>SELECT 1</sql>"), "SELECT 1");
+
+    /// In a multi-step generation the SDK concatenates the text of all steps, so the
+    /// text can contain several tagged blocks; the final step's query is the last one.
+    EXPECT_EQ(
+        AISQLGenerator::cleanSQL("Let me explore. <sql>SELECT 1</sql> Refined: <sql>SELECT 2</sql>"),
+        "SELECT 2");
+}
+
+TEST(AISQLGenerator, CleanSQLTrimsWhitespace)
+{
+    EXPECT_EQ(AISQLGenerator::cleanSQL("<sql>  SELECT 1  </sql>"), "SELECT 1");
+}
+
+TEST(AISQLGenerator, CleanSQLReturnsEmptyWithoutTags)
+{
+    /// Without the tags no query was generated (e.g. the model replied with prose
+    /// explaining why it cannot answer); the prose must not be mistaken for SQL.
+    EXPECT_EQ(AISQLGenerator::cleanSQL("I'll help you generate a ClickHouse SQL query."), "");
+    EXPECT_EQ(AISQLGenerator::cleanSQL(""), "");
+
+    /// Incomplete tags do not count either.
+    EXPECT_EQ(AISQLGenerator::cleanSQL("<sql>SELECT 1"), "");
+    EXPECT_EQ(AISQLGenerator::cleanSQL("SELECT 1</sql>"), "");
+}
+
 /// Test SQL injection attempts in natural language queries
 TEST_F(AITestFixture, SQLInjectionProtection)
 {

--- a/src/Client/AI/tests/gtest_ai_sql_generator.cpp
+++ b/src/Client/AI/tests/gtest_ai_sql_generator.cpp
@@ -239,15 +239,18 @@ TEST(AISQLGenerator, ConfigurationValidation)
 
 /// `cleanSQL` is a pure function, so these tests need no AI credentials.
 
-TEST(AISQLGenerator, CleanSQLExtractsLastTaggedBlock)
+TEST(AISQLGenerator, CleanSQLExtractsTaggedQuery)
 {
     EXPECT_EQ(AISQLGenerator::cleanSQL("<sql>SELECT 1</sql>"), "SELECT 1");
+    EXPECT_EQ(AISQLGenerator::cleanSQL("Here is the query: <sql>SELECT 1</sql> Enjoy!"), "SELECT 1");
+}
 
-    /// In a multi-step generation the SDK concatenates the text of all steps, so the
-    /// text can contain several tagged blocks; the final step's query is the last one.
-    EXPECT_EQ(
-        AISQLGenerator::cleanSQL("Let me explore. <sql>SELECT 1</sql> Refined: <sql>SELECT 2</sql>"),
-        "SELECT 2");
+TEST(AISQLGenerator, CleanSQLKeepsLiteralTagsInsideTheQuery)
+{
+    /// The tags can appear inside the query itself, e.g. in a string literal; the
+    /// outermost pair delimits the query.
+    EXPECT_EQ(AISQLGenerator::cleanSQL("<sql>SELECT '<sql>' AS marker</sql>"), "SELECT '<sql>' AS marker");
+    EXPECT_EQ(AISQLGenerator::cleanSQL("<sql>SELECT '</sql>' AS marker</sql>"), "SELECT '</sql>' AS marker");
 }
 
 TEST(AISQLGenerator, CleanSQLTrimsWhitespace)
@@ -262,9 +265,10 @@ TEST(AISQLGenerator, CleanSQLReturnsEmptyWithoutTags)
     EXPECT_EQ(AISQLGenerator::cleanSQL("I'll help you generate a ClickHouse SQL query."), "");
     EXPECT_EQ(AISQLGenerator::cleanSQL(""), "");
 
-    /// Incomplete tags do not count either.
+    /// Incomplete or misordered tags do not count either.
     EXPECT_EQ(AISQLGenerator::cleanSQL("<sql>SELECT 1"), "");
     EXPECT_EQ(AISQLGenerator::cleanSQL("SELECT 1</sql>"), "");
+    EXPECT_EQ(AISQLGenerator::cleanSQL("</sql>SELECT 1<sql>"), "");
 }
 
 /// Test SQL injection attempts in natural language queries


### PR DESCRIPTION
AI SQL generation (`??`) failed on any prompt needing more than one schema lookup: the bundled `ai-sdk-cpp` rebuilt every step's request from the initial options, so the model lost all earlier tool results and kept re-requesting the same schemas until the step limit — and the client then prepopulated the model's explanatory text as if it were the generated query, claiming success.

Observed output (result previews trimmed):

```
:) ?? query all nodes for their partitions with most active parts (only show one row per node, ...)
•  Starting AI SQL generation with schema discovery...
─────────────────────────────────────────────────
🔧 Calling: list_databases [toolu_01...]
✓  list_databases completed
🔧 Calling: list_tables_in_database [toolu_01...]
   └─ Args: {"database":"system"}
✓  list_tables_in_database completed
🔧 Calling: get_schema_for_table [toolu_01...]
   └─ Args: {"database":"system","table":"parts"}
✓  get_schema_for_table completed
🔧 Calling: get_schema_for_table [toolu_01...]
   └─ Args: {"database":"system","table":"clusters"}
✓  get_schema_for_table completed
🔧 Calling: get_schema_for_table [toolu_01...]
   └─ Args: {"database":"system","table":"parts"}
✓  get_schema_for_table completed
🔧 Calling: get_schema_for_table [toolu_01...]
   └─ Args: {"database":"system","table":"clusters"}
✓  get_schema_for_table completed
🔧 Calling: get_schema_for_table [toolu_01...]
   └─ Args: {"database":"system","table":"parts"}
✓  get_schema_for_table completed
🔧 Calling: get_schema_for_table [toolu_01...]
   └─ Args: {"database":"system","table":"clusters"}
✓  get_schema_for_table completed
─────────────────────────────────────────────────
•  ⚠️  No SQL query was generated: the schema exploration step limit was reached (ai.max_steps = 10)
```

(The honest final status line is itself part of this PR — previously this run ended with `✨ SQL query generated successfully!` and the model's explanatory prose prepopulated at the prompt.)

Update `ai-sdk-cpp` to the upstream fix (https://github.com/ClickHouse/ai-sdk-cpp/pull/40). On the client side: extract the query from the last `<sql>` block and treat a response without the tags as "no query generated"; report when the step limit was reached (naming `ai.max_steps`); show the model's text when it answered with prose.

Also raise the default `ai.max_steps` from 5 to 10: the [client documentation](https://clickhouse.com/docs/concepts/features/interfaces/client) has always stated the default is `10`, and 5 was too small in practice — the final answer consumes a step too, so exploring even two tables could exhaust the limit.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed AI SQL generation (`??` in `clickhouse-client`) failing on prompts that require several schema lookups: the model lost earlier tool results between steps and re-requested the same schemas until the step limit was reached. The client now reports honestly when no query was generated, and the default `ai.max_steps` matches the documented value of 10.
