### PR TITLE
Fix Iceberg `OPTIMIZE` rejecting multi-row position delete snapshots

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -956,8 +956,18 @@ static bool writeConsolidatedManifestFile(
     return true;
 }
 
-namespace
+bool overwriteIsPositionDeleteOnly(const SnapshotSummaryUpdateOverwrite & update)
 {
+    /// Every declared added file and row must be accounted for as a position delete: the
+    /// breakdown counters are optional and read as 0 when absent, so their absence is not
+    /// evidence. One delete file with deleted rows but no file count is a position delete file.
+    return update.added_files == 0 && update.added_records == 0 && update.added_delete_files != 0
+        && (update.added_position_delete_files == update.added_delete_files
+            || (update.added_position_delete_files == 0 && update.added_position_deletes != 0
+                && update.added_delete_files == 1))
+        && update.added_equality_delete_files == 0 && update.added_equality_deletes == 0
+        && update.deleted_data_files == 0 && update.removed_records == 0 && update.removed_files_size == 0;
+}
 
 [[nodiscard]] std::optional<SnapshotSummaryUpdateAppend> tryGetAppendUpdate(const Iceberg::IcebergHistoryRecord & history_record)
 {
@@ -972,9 +982,7 @@ namespace
         case SnapshotSummaryOperation::DELETE:
             return std::nullopt;
         case SnapshotSummaryOperation::OVERWRITE: {
-            const auto & update = summary->getUpdate<Iceberg::SnapshotSummaryUpdateOverwrite>();
-            /// current compaction (OPTIME TABLE my_iceberg) supports only overwrites wich has only position delete files
-            if (update.added_files == 0 && (update.added_position_deletes == update.added_delete_files) && update.added_position_deletes != 0)
+            if (overwriteIsPositionDeleteOnly(summary->getUpdate<Iceberg::SnapshotSummaryUpdateOverwrite>()))
                 return std::nullopt;
             [[fallthrough]];
         }
@@ -983,6 +991,8 @@ namespace
     }
 };
 
+namespace
+{
 
 /// Current experimental compact implementation expects snapshots to be either appends or overwrites which has only position deletes
 /// Lets force this invariant

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.h
@@ -11,6 +11,15 @@ namespace DB::Iceberg
 {
 #if USE_AVRO && !CLICKHOUSE_CLOUD
 
+/// True when compaction can skip an `overwrite` snapshot: it adds only position delete files
+/// and removes nothing. Compaction collects only data and position delete files, so any other
+/// delta would be dropped from the rewritten table.
+bool overwriteIsPositionDeleteOnly(const SnapshotSummaryUpdateOverwrite & update);
+
+/// The append delta compaction must replay, `std::nullopt` for a snapshot it may skip.
+/// Throws for one it cannot represent.
+[[nodiscard]] std::optional<SnapshotSummaryUpdateAppend> tryGetAppendUpdate(const IcebergHistoryRecord & history_record);
+
 void compactIcebergTable(
     IcebergHistory snapshots_info,
     const PersistentTableComponents & persistent_table_components,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_snapshot_summary.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_snapshot_summary.cpp
@@ -484,6 +484,13 @@ TEST(IcebergCompactionOverwriteClassification, PositionDeleteOnlyPredicate)
     /// which is why they live here and not in a stateless test.
     struct Case
     {
+        /// Constructor rather than in-class initializers: a default `skippable` would let a row omit
+        /// its expected verdict and silently assert `false`.
+        Case(const char * name_, DB::Iceberg::SnapshotSummaryUpdateOverwrite update_, bool skippable_)
+            : name(name_), update(update_), skippable(skippable_)
+        {
+        }
+
         const char * name;
         DB::Iceberg::SnapshotSummaryUpdateOverwrite update;
         bool skippable;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_snapshot_summary.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_snapshot_summary.cpp
@@ -7,6 +7,9 @@
 #include <Common/Exception.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Constant.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/SnapshotSummary.h>
+#if !CLICKHOUSE_CLOUD
+#include <Storages/ObjectStorage/DataLakes/Iceberg/Compaction.h>
+#endif
 
 #include <Poco/JSON/Object.h>
 #include <Poco/JSON/Parser.h>
@@ -467,5 +470,126 @@ TEST(IcebergSnapshotSummary, AppendPreservesInheritedEqualityDeletes)
     EXPECT_EQ(append.getTotals().delete_files, 2);       // preserved
     EXPECT_EQ(append.getTotals().records, 55);
 }
+
+#if !CLICKHOUSE_CLOUD
+TEST(IcebergCompactionOverwriteClassification, PositionDeleteOnlyPredicate)
+{
+    /// Compaction may skip an `overwrite` snapshot only when it adds position delete files and
+    /// nothing else, because it collects only data and position delete files: any other delta
+    /// would be dropped from the rewritten table. Every refused row satisfies each conjunct
+    /// except the one it names, so dropping any single term admits a named row: the accounting
+    /// proof is bounded above by the two count-exceeds rows and below by the three unaccounted
+    /// ones. The shapes are constructed because ClickHouse's own writer cannot emit them (it
+    /// never writes an equality delete or any removal counter), which is why this lives here
+    /// and not in a stateless test.
+    struct Case
+    {
+        const char * name;
+        DB::Iceberg::SnapshotSummaryUpdateOverwrite update;
+        bool skippable;
+    };
+
+    const Case cases[] = {
+        /// A foreign writer may omit the optional `added-position-delete-files` key. It reads as
+        /// 0, so requiring equality with `added-delete-files` would refuse a history that the
+        /// pre-fix guard accepted.
+        {"foreign_position_delete_file_count_absent",
+         {.added_delete_files = 1, .added_position_deletes = 1}, true},
+        /// The reported defect: one delete file marking many rows.
+        {"clickhouse_multi_row",
+         {.added_delete_files = 1, .added_position_delete_files = 1, .added_position_deletes = 10}, true},
+        {"clickhouse_single_row",
+         {.added_delete_files = 1, .added_position_delete_files = 1, .added_position_deletes = 1}, true},
+        /// A delete file marking no rows is still only a position delete file.
+        {"position_delete_file_marking_zero_rows",
+         {.added_delete_files = 1, .added_position_delete_files = 1}, true},
+
+        /// No delete file declared at all: nothing identifies this as a position delete overwrite.
+        {"no_delete_keys_at_all", {}, false},
+        /// Equality deletes are not collected, so admitting these would resurrect deleted rows.
+        {"equality_delete_files_and_rows",
+         {.added_delete_files = 2,
+          .added_position_delete_files = 1,
+          .added_equality_delete_files = 1,
+          .added_equality_deletes = 5}, false},
+        {"equality_delete_row_count_only",
+         {.added_delete_files = 1, .added_position_delete_files = 1, .added_equality_deletes = 5}, false},
+        {"equality_delete_file_count_only",
+         {.added_delete_files = 2, .added_position_delete_files = 1, .added_equality_delete_files = 1}, false},
+        /// Accounted for via the absent-counter exception, so only the equality file-count term
+        /// can refuse it.
+        {"equality_delete_file_count_only_via_absent_counter",
+         {.added_delete_files = 1, .added_position_deletes = 5, .added_equality_delete_files = 1}, false},
+        /// Adding data files makes this a rewrite, not a row delete.
+        {"data_files_added",
+         {.added_files = 1, .added_delete_files = 1, .added_position_delete_files = 1}, false},
+        /// `added-records` is a separate optional key from `added-data-files`, so a writer may
+        /// declare added rows while omitting the file count. Records were added either way.
+        {"data_records_added_without_file_count",
+         {.added_records = 10, .added_delete_files = 1, .added_position_delete_files = 1, .added_position_deletes = 10}, false},
+        /// More position delete files than delete files is incoherent metadata.
+        {"position_delete_file_count_exceeds_delete_file_count",
+         {.added_delete_files = 1, .added_position_delete_files = 2}, false},
+        /// Same shape with rows declared, so only the exception's own file-count term refuses it:
+        /// the exception requires the count to be absent, not merely unequal.
+        {"position_delete_file_count_exceeds_with_rows_declared",
+         {.added_delete_files = 1, .added_position_delete_files = 2, .added_position_deletes = 5}, false},
+        /// A summary that declares delete files but accounts for none of them proves nothing:
+        /// the equality counters are optional too, so their absence is not evidence.
+        {"aggregate_delete_files_only_unaccounted",
+         {.added_delete_files = 1}, false},
+        /// Two delete files, one accounted for as a position delete: the second may be an
+        /// equality delete whose optional breakdown keys the writer omitted.
+        {"delete_files_partially_accounted",
+         {.added_delete_files = 2, .added_position_delete_files = 1, .added_position_deletes = 5}, false},
+        {"delete_files_partially_accounted_file_count_absent",
+         {.added_delete_files = 2, .added_position_deletes = 5}, false},
+        /// Removals are refused: compaction never drops a data file collected from an earlier
+        /// snapshot, so a removed file would be resurrected.
+        {"data_file_removal_declared",
+         {.added_delete_files = 1, .added_position_delete_files = 1, .deleted_data_files = 1}, false},
+        {"removed_record_count_declared",
+         {.added_delete_files = 1, .added_position_delete_files = 1, .removed_records = 5}, false},
+        {"removed_file_size_declared",
+         {.added_delete_files = 1, .added_position_delete_files = 1, .removed_files_size = 100}, false},
+    };
+
+    for (const auto & c : cases)
+        EXPECT_EQ(DB::Iceberg::overwriteIsPositionDeleteOnly(c.update), c.skippable) << "case: " << c.name;
+}
+
+TEST(IcebergCompactionOverwriteClassification, HistoryGuardConsultsThePredicate)
+{
+    /// The predicate above is only useful if the history guard actually calls it, so drive the
+    /// guard itself: a skippable overwrite must yield no append delta, and a refused one must
+    /// throw. Without this, reverting the call site would leave every row above green.
+    const auto record_for = [](DB::Iceberg::SnapshotSummaryUpdateOverwrite update)
+    {
+        DB::Iceberg::IcebergHistoryRecord record;
+        record.snapshot_id = 1;
+        record.snapshot_summary = SnapshotSummary(
+            std::move(update),
+            SnapshotSummary(DB::Iceberg::SnapshotSummaryUpdateAppend{
+                .added_files = 3, .added_records = 30, .added_files_size = 1000, .num_partitions = 1}).getTotals());
+        return record;
+    };
+
+    const auto skippable = record_for({.added_delete_files = 1, .added_position_delete_files = 1, .added_position_deletes = 10});
+    EXPECT_FALSE(DB::Iceberg::tryGetAppendUpdate(skippable).has_value());
+
+    const auto refused = record_for({.added_delete_files = 1, .added_position_delete_files = 1, .added_equality_deletes = 5});
+    EXPECT_THROW(static_cast<void>(DB::Iceberg::tryGetAppendUpdate(refused)), DB::Exception);
+
+    /// An append is replayed rather than skipped, so a guard that answered `nullopt` for
+    /// everything would fail here too.
+    DB::Iceberg::IcebergHistoryRecord append_record;
+    append_record.snapshot_id = 2;
+    append_record.snapshot_summary = SnapshotSummary(DB::Iceberg::SnapshotSummaryUpdateAppend{
+        .added_files = 2, .added_records = 20, .added_files_size = 500, .num_partitions = 1});
+    const auto append = DB::Iceberg::tryGetAppendUpdate(append_record);
+    ASSERT_TRUE(append.has_value());
+    EXPECT_EQ(append->added_files, 2);
+}
+#endif
 
 #endif

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_snapshot_summary.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_snapshot_summary.cpp
@@ -474,14 +474,14 @@ TEST(IcebergSnapshotSummary, AppendPreservesInheritedEqualityDeletes)
 #if !CLICKHOUSE_CLOUD
 TEST(IcebergCompactionOverwriteClassification, PositionDeleteOnlyPredicate)
 {
-    /// Compaction may skip an `overwrite` snapshot only when it adds position delete files and
-    /// nothing else, because it collects only data and position delete files: any other delta
-    /// would be dropped from the rewritten table. Every refused row satisfies each conjunct
-    /// except the one it names, so dropping any single term admits a named row: the accounting
-    /// proof is bounded above by the two count-exceeds rows and below by the three unaccounted
-    /// ones. The shapes are constructed because ClickHouse's own writer cannot emit them (it
-    /// never writes an equality delete or any removal counter), which is why this lives here
-    /// and not in a stateless test.
+    /// Compaction may skip an `overwrite` snapshot only when it adds position delete files and nothing
+    /// else, because it collects only data and position delete files: any other delta would be dropped from
+    /// the rewritten table. Each conjunct has at least one row isolating it, satisfying every other
+    /// conjunct, so dropping any single term admits a named row; some rows fail more than one term besides.
+    /// The accounting proof is bounded above by the two rows declaring more position delete files than
+    /// delete files and below by the three unaccounted ones. The refused shapes are constructed because
+    /// ClickHouse's own writer cannot emit them (it never writes an equality delete or a removal counter),
+    /// which is why they live here and not in a stateless test.
     struct Case
     {
         const char * name;
@@ -498,6 +498,10 @@ TEST(IcebergCompactionOverwriteClassification, PositionDeleteOnlyPredicate)
         /// The reported defect: one delete file marking many rows.
         {"clickhouse_multi_row",
          {.added_delete_files = 1, .added_position_delete_files = 1, .added_position_deletes = 10}, true},
+        /// A partitioned delete writes one position delete file per touched partition, so the accepted
+        /// shape is not limited to a single delete file.
+        {"clickhouse_multi_partition",
+         {.added_delete_files = 2, .added_position_delete_files = 2, .added_position_deletes = 10}, true},
         {"clickhouse_single_row",
          {.added_delete_files = 1, .added_position_delete_files = 1, .added_position_deletes = 1}, true},
         /// A delete file marking no rows is still only a position delete file.

--- a/tests/queries/0_stateless/04815_iceberg_optimize_position_delete_row_count_113745.reference
+++ b/tests/queries/0_stateless/04815_iceberg_optimize_position_delete_row_count_113745.reference
@@ -1,0 +1,6 @@
+multi_row OPTIMIZE accepted the position delete snapshot
+multi_row position deletes compacted away
+multi_row	1	1	1
+single_row OPTIMIZE accepted the position delete snapshot
+single_row position deletes compacted away
+single_row	1	1	1

--- a/tests/queries/0_stateless/04815_iceberg_optimize_position_delete_row_count_113745.sh
+++ b/tests/queries/0_stateless/04815_iceberg_optimize_position_delete_row_count_113745.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# - no-fasttest: requires `IcebergLocal` (USE_AVRO build option)
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/113745:
+# `OPTIMIZE TABLE` on an Iceberg table whose history contains a row delete that
+# removed more than one row per position delete file used to throw
+# `Unsupported snapshot's operation type OVERWRITE`. The history guard compared
+# `added-position-deletes` (a row count) against `added-delete-files` (a file
+# count), so it only accepted the accidental one-row-per-file case.
+#
+# The single-row delete below is a regression control: it is a shape the old guard
+# already accepted by coincidence (1 == 1), so it distinguishes nothing about the
+# new conjuncts, it only shows they did not break what already worked. The refused
+# shapes are covered by `IcebergCompactionOverwriteClassification` in
+# `gtest_iceberg_snapshot_summary.cpp`, not here: ClickHouse's own writer emits
+# neither equality deletes nor any removal counter, so they cannot be built through
+# `IcebergLocal` at all.
+#
+# The bug lived in the synchronous compaction path (`compactIcebergTable`) used
+# by the open-source build. The cloud build routes `OPTIMIZE` through a different
+# code path (gated by a member flag rather than the query-level
+# `allow_experimental_iceberg_compaction` setting), so there `OPTIMIZE` reports a
+# regular user-facing exception instead of running the compaction. It must never
+# report the unsupported-operation error on any build; and on the open-source
+# build `OPTIMIZE` must additionally succeed, so the path this PR changes is
+# actually exercised (a plain failure there would otherwise pass silently).
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+IS_CLOUD=$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'CLICKHOUSE_CLOUD'")
+
+count_position_deletes()
+{
+    ${CLICKHOUSE_CLIENT} --query "
+        SELECT count() FROM system.iceberg_files
+        WHERE database = currentDatabase() AND table = '$1' AND content = 'POSITION_DELETE'
+    "
+}
+
+# $1: label, $2: DELETE predicate, $3: expected row count after OPTIMIZE,
+# $4: expected min(id), $5: expected max(id)
+run_case()
+{
+    local label="$1" predicate="$2" rows="$3" min_id="$4" max_id="$5"
+    local table="t_${CLICKHOUSE_DATABASE}_${label}"
+    local table_path="${USER_FILES_PATH}/${table}/"
+
+    ${CLICKHOUSE_CLIENT} --query "
+        CREATE TABLE ${table} (id Int64, data String)
+        ENGINE = IcebergLocal('${table_path}', 'Parquet')
+    "
+
+    ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query \
+        "INSERT INTO ${table} SELECT number, char(number + ascii('a')) FROM numbers(10, 90)"
+    ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --mutations_sync=2 --query \
+        "ALTER TABLE ${table} DELETE WHERE ${predicate}"
+    ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query \
+        "INSERT INTO ${table} SELECT number, char(number + ascii('a')) FROM numbers(100, 10)"
+
+    local pd_before pd_after
+    pd_before=$(count_position_deletes "${table}")
+
+    # This used to throw `Unsupported snapshot's operation type OVERWRITE` whenever
+    # the delete above removed more than one row per position delete file. Stderr is
+    # captured so that the cloud build's user-facing exception does not trip the
+    # "having stderror" check.
+    local optimize_err
+    optimize_err=$(${CLICKHOUSE_CLIENT} --allow_experimental_iceberg_compaction=1 --query \
+        "OPTIMIZE TABLE ${table}" 2>&1)
+
+    if echo "${optimize_err}" | grep -qF "Unsupported snapshot's operation type"; then
+        echo "${label} FAIL: OPTIMIZE rejected the position delete snapshot"
+    elif [[ "${IS_CLOUD}" = "1" ]]; then
+        echo "${label} OPTIMIZE accepted the position delete snapshot"
+    elif [[ -n "${optimize_err}" ]]; then
+        echo "${label} FAIL: OPTIMIZE failed on the open-source build: ${optimize_err}"
+    else
+        echo "${label} OPTIMIZE accepted the position delete snapshot"
+    fi
+
+    # Reads apply the position delete file whether or not compaction ran, so the row
+    # assertions below cannot tell a real compaction from a silent no-op. Compaction
+    # rewrites the manifests with data files only, so the delete file must be gone.
+    pd_after=$(count_position_deletes "${table}")
+    if [[ "${IS_CLOUD}" = "1" ]]; then
+        # Compaction does not run here, so there is nothing to assert about its effect.
+        echo "${label} position deletes compacted away"
+    elif [[ "${pd_before}" -gt 0 && "${pd_after}" -eq 0 ]]; then
+        echo "${label} position deletes compacted away"
+    else
+        echo "${label} FAIL: position delete file not compacted away: before=${pd_before} after=${pd_after}"
+    fi
+
+    # The deleted rows must stay deleted and the surviving ones must stay readable,
+    # so a fix that admits the snapshot but resurrects or loses rows fails here.
+    ${CLICKHOUSE_CLIENT} --query "
+        SELECT '${label}', count() = ${rows}, min(id) = ${min_id}, max(id) = ${max_id}
+        FROM ${table}
+    "
+
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE ${table} SYNC"
+    rm -rf "${table_path}" 2>/dev/null
+}
+
+# 10 rows deleted through a single position delete file: the reported defect.
+run_case multi_row "id < 20" 90 20 109
+# 1 row deleted: satisfied the old guard by coincidence, must stay working.
+run_case single_row "id = 11" 99 10 109


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/113745
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `OPTIMIZE TABLE` on an Iceberg table failing with `Unsupported snapshot's operation type OVERWRITE` when the table's history contained a row delete that removed more than one row per position delete file. Closes #113745.


### Description

`OPTIMIZE TABLE` with `allow_experimental_iceberg_compaction = 1` failed on any Iceberg table whose history contained a delete that removed more than one row per position delete file. The history guard accepted an `overwrite` snapshot only when `added_position_deletes == added_delete_files`, but those are different units: a row count and a file count. One position delete file marks arbitrarily many rows, so the equality held only on an unpartitioned table deleting exactly one row.

The predicate now compares file counts against file counts, `added_position_delete_files == added_delete_files` with both non-zero. That key is optional and reads as 0 when a foreign writer omits it; when it is absent but position deletes are declared and there is exactly one delete file, that file can only be a position delete file, so that shape is admitted too. It stops at one file: with two, the second could be an equality delete whose breakdown was also omitted.

Six further conjuncts refuse shapes ClickHouse never writes but a foreign engine can. `added_records == 0` joins the pre-existing `added_files == 0`, since those are independent optional keys: a writer may declare added rows while omitting the file count. Equality deletes are refused by both their file and row count, because compaction collects only data and position delete files and would otherwise drop those deletes while rewriting the data. The three removal counters are refused because `getPlan` never drops a data file collected from an earlier snapshot, so a removed file would reappear. This is not purely a widening: an overwrite also declaring added data, a removal or an equality delete is now refused.

Validated on a debug build: the 10-row delete fails on master with `Code: 48` and after the fix returns 90 rows with `min(id) = 20`; the 1-row delete, which satisfied the old guard, passes on both.

<details>
<summary>Affected versions, overlap with open PRs, and a pre-existing defect noticed while testing</summary>

Master, 26.7 and 26.6 carry the guard; 26.5, 26.3 and 25.8 do not.

`writeMetadataFiles` skips an admitted delete snapshot but keeps each retained snapshot's original `parent_id`, so the rewritten `snapshots` array can contain a parent id that is no longer present. This already happens on unmodified master for the one-row delete the current guard admits (measured: 1 dangling parent of 2 snapshots), and this change does not increase the count for the same input. The reader's ancestor walk terminates safely and `SELECT count()` is correct; the only consumer is `is_current_ancestor` in `system.iceberg_history`. Repairing it means rewriting the parent chain plus per-snapshot totals, which is a separate root cause. #109288 already repoints that parent chain in the same function, so it resolves this independently of the guard; the two changes touch `Compaction.cpp` in different places.

Draft PR #105198 (DROP PARTITION for Iceberg) happens to relax this same guard as a side effect, dropping the comparison entirely (`added_files == 0 && added_delete_files != 0`) without an equality delete exclusion. This one keeps that exclusion.
</details>


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.4.16`
<!-- ch-version-info:end -->