### PR TITLE
Document TPC-DS Q69 as a known problem (same cause as Q35)

### DIFF
--- a/tests/benchmarks/tpc-ds/README.md
+++ b/tests/benchmarks/tpc-ds/README.md
@@ -5,6 +5,10 @@ The query returns `nan` instead of `NULL` when `stddev_samp` is called on a sing
 ## Q35
 Memory Limit Exceeded with reasonable amount of memory.
 
+## Q69
+Memory Limit Exceeded with reasonable amount of memory - same root cause as Q35, see
+https://github.com/ClickHouse/ClickHouse/issues/113407.
+
 ## Q47
 The query doesn't work out-of-the-box due to https://github.com/ClickHouse/ClickHouse/issues/94858. The alternative formulation with a minor fix works.
 


### PR DESCRIPTION
Related: #113407
Related: #101863

Q69 exhibits the same unbounded memory growth caused by CROSS JOIN
decorrelation as Q35. It involves the same three correlated columns
(`ss_customer_sk`, `ws_bill_customer_sk`, and `cs_ship_customer_sk`),
each compared with `customer.c_customer_sk`, and has the same
nullability-mismatch root cause.

This was confirmed using `EXPLAIN PLAN`, which produces three
`Type: cross` nodes, and by observing the same behavior as Q35 at
SF100: `read_rows` stops increasing while `memory_usage` continues
to grow.

This PR only adds a README note, consistent with the existing entries
for Q17, Q35, Q47, Q57, Q58, and Q75. It does not modify
`queries/query_69.sql`, in accordance with the outcome of #113346:
"We shouldn't alter benchmark queries to be better."

### Changelog category (leave one):
- Not for changelog

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required for this category. This is a documentation-only change to
a benchmark README and does not affect server behavior.