### PR TITLE
Map arrow `OutOfMemory` status to `MEMORY_LIMIT_EXCEEDED` when reading Parquet record batches (26.3)

### DIFF
--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -1093,7 +1093,10 @@ void ParquetBlockInputFormat::decodeOneChunk(size_t row_group_batch_idx, std::un
         chassert(row_group_batch.record_batch_reader);
         auto batch = row_group_batch.record_batch_reader->Next();
         if (!batch.ok())
-            throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "Error while reading Parquet data: {}", batch.status().ToString());
+            throw Exception(
+                batch.status().IsOutOfMemory() ? ErrorCodes::MEMORY_LIMIT_EXCEEDED : ErrorCodes::CANNOT_READ_ALL_DATA,
+                "Error while reading Parquet data: {}",
+                batch.status().ToString());
         return batch;
     };
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

Fixes flakiness of `03147_parquet_memory_tracking` on the `26.3` branch. After the `arrow` 25.0.0 bump was backported (https://github.com/ClickHouse/ClickHouse/pull/113539), an allocation failure inside `RecordBatchReader::Next` can surface as an arrow `OutOfMemory` status instead of propagating the memory-tracker exception, so the query failed with `CANNOT_READ_ALL_DATA` (33) instead of the expected `MEMORY_LIMIT_EXCEEDED` (241). This maps `IsOutOfMemory` to `MEMORY_LIMIT_EXCEEDED` at that call site, exactly as the `THROW_ARROW_NOT_OK` macro in the same file already does.

This targets `26.3` directly because the legacy `ParquetBlockInputFormat` was removed on `master` (replaced by the native reader), so the bug does not exist there; among supported branches only `25.8` and `26.3` still have this file, and only `26.3` has the arrow 25.0.0 bump.

Seen in: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113929&sha=731b917fb0a2533da48dc46dc334bd30c8570bfe&name_0=BackportPR&name_1=Stateless%20tests%20%28amd_asan%2C%20db%20disk%2C%20distributed%20plan%2C%20sequential%29

Related: https://github.com/ClickHouse/ClickHouse/pull/113929
Related: https://github.com/ClickHouse/ClickHouse/pull/113539
