### PR TITLE
PromQL: Support lookback_delta in Prometheus HTTP API

### DIFF
--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -449,7 +449,7 @@ public:
 
         /// Some parameters (default_format, everything used in the code above) do not belong to the
         /// Settings class.
-        static const NameSet reserved_param_names{"user", "password", "query", "time", "start", "end", "step", "database", "table"};
+        static const NameSet reserved_param_names{"user", "password", "query", "time", "start", "end", "step", "lookback_delta", "database", "table"};
         return !reserved_param_names.contains(name);
     }
 
@@ -484,11 +484,11 @@ public:
                 String start = params->get("start", "");
                 String end = params->get("end", "");
                 String step = params->get("step", "");
+                String lookback_delta = params->get("lookback_delta", "");
 
                 /// TODO: Support the following **optional** query parameters:
                 /// - timeout=<duration>: Evaluation timeout
                 /// - limit=<number>: Maximum number of returned series
-                /// - lookback_delta=<number>: Override for the lookback period for this query.
 
                 PrometheusHTTPProtocolAPI::Params params
                 {
@@ -498,6 +498,7 @@ public:
                     .start_param = start,
                     .end_param = end,
                     .step_param = step,
+                    .lookback_delta_param = lookback_delta,
                 };
 
                 protocol.executePromQLQuery(getOutputStream(response), params, query_finish_callback);
@@ -506,6 +507,7 @@ public:
             {
                 String query = params->get("query", "");
                 String time = params->get("time", "");
+                String lookback_delta = params->get("lookback_delta", "");
 
                 /// TODO: Support optional parameters same as for the range query.
 
@@ -517,6 +519,7 @@ public:
                     .start_param = "",
                     .end_param = "",
                     .step_param = "",
+                    .lookback_delta_param = lookback_delta,
                 };
 
                 protocol.executePromQLQuery(getOutputStream(response), params, query_finish_callback);

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -57,6 +57,13 @@ void PrometheusHTTPProtocolAPI::executePromQLQuery(
         = splitTimeSeriesType(time_series_metadata->columns.get(TimeSeriesColumnNames::TimeSeries).type);
     UInt32 timestamp_scale = tryGetDecimalScale(*evaluation_settings.timestamp_data_type).value_or(0);
 
+    if (!params.lookback_delta_param.empty())
+    {
+        const auto lookback_delta = parseTimeSeriesDuration(params.lookback_delta_param, timestamp_scale);
+        if (lookback_delta > 0)
+            evaluation_settings.instant_selector_window = lookback_delta;
+    }
+
     auto query_tree = std::make_shared<PrometheusQueryTree>();
     query_tree->parse(params.promql_query, timestamp_scale);
     LOG_TRACE(log, "Parsed PromQL query: {}. Result type: {}", params.promql_query, query_tree->getResultType());

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -1,6 +1,7 @@
 #include <Storages/TimeSeries/PrometheusHTTPProtocolAPI.h>
 
 #include <Common/logger_useful.h>
+#include <Core/DecimalFunctions.h>
 #include <Core/Field.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
@@ -36,6 +37,25 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
 }
 
+namespace
+{
+constexpr UInt32 LOOKBACK_DELTA_SCALE = 9;
+
+Decimal64 parsePrometheusLookbackDelta(const String & value, UInt32 timestamp_scale)
+{
+    const auto high_precision_value = parseTimeSeriesDuration(value, LOOKBACK_DELTA_SCALE);
+    if (high_precision_value <= 0 || timestamp_scale >= LOOKBACK_DELTA_SCALE)
+        return high_precision_value;
+
+    const auto divisor = DecimalUtils::scaleMultiplier<Decimal64>(LOOKBACK_DELTA_SCALE - timestamp_scale);
+    auto timestamp_ticks = high_precision_value.value / divisor;
+    if (high_precision_value.value % divisor)
+        ++timestamp_ticks;
+
+    return Decimal64{timestamp_ticks};
+}
+}
+
 PrometheusHTTPProtocolAPI::PrometheusHTTPProtocolAPI(ConstStoragePtr time_series_storage_, const ContextMutablePtr & context_)
     : WithMutableContext{context_}
     , time_series_storage(storagePtrToTimeSeries(time_series_storage_))
@@ -59,7 +79,7 @@ void PrometheusHTTPProtocolAPI::executePromQLQuery(
 
     if (!params.lookback_delta_param.empty())
     {
-        const auto lookback_delta = parseTimeSeriesDuration(params.lookback_delta_param, timestamp_scale);
+        const auto lookback_delta = parsePrometheusLookbackDelta(params.lookback_delta_param, timestamp_scale);
         if (lookback_delta > 0)
             evaluation_settings.instant_selector_window = lookback_delta;
     }

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
@@ -39,6 +39,7 @@ public:
         String start_param;
         String end_param;
         String step_param;
+        String lookback_delta_param;
     };
 
     /// Execute an instant query (/api/v1/query) or range query (/api/v1/query_range)

--- a/tests/integration/test_prometheus_protocols/test_query_api.py
+++ b/tests/integration/test_prometheus_protocols/test_query_api.py
@@ -70,6 +70,15 @@ def start_cluster():
     try:
         cluster.start()
         node.query("CREATE TABLE prometheus ENGINE=TimeSeries")
+        node.query(
+            "CREATE TABLE prometheus_seconds "
+            "(time_series Array(Tuple(DateTime64(0), Float64))) ENGINE=TimeSeries"
+        )
+        node.query(
+            "INSERT INTO prometheus_seconds (metric_name, tags, time_series) VALUES"
+            " ('foo_seconds_old', {'shape': 'circle'}, [(toDateTime64(150, 0), 16)]),"
+            " ('foo_seconds_exact', {'shape': 'circle'}, [(toDateTime64(151, 0), 17)])"
+        )
         send_test_data()
         yield cluster
     finally:
@@ -142,6 +151,28 @@ def test_query_lookback_delta():
             )
             == expected
         )
+
+    error = execute_query_via_http_api(
+        node.ip_address, 9093, "/api/v1/query", query, timestamp=timestamp,
+        params={"lookback_delta": "banana"}, expect_error=True,
+    )
+    assert "Cannot parse duration" in error
+
+
+def test_query_lookback_delta_low_timestamp_precision():
+    old_sample = execute_query_via_http_api(
+        node.ip_address, 9093, "/dynamic_table/api/v1/query",
+        'foo_seconds_old{shape="circle"}', timestamp=151,
+        params={"table": "prometheus_seconds", "lookback_delta": "500ms"},
+    )
+    assert old_sample == '{"resultType": "vector", "result": []}'
+
+    exact_sample = execute_query_via_http_api(
+        node.ip_address, 9093, "/dynamic_table/api/v1/query",
+        'foo_seconds_exact{shape="circle"}', timestamp=151,
+        params={"table": "prometheus_seconds", "lookback_delta": "500ms"},
+    )
+    assert exact_sample == '{"resultType": "vector", "result": [{"metric": {"__name__": "foo_seconds_exact", "shape": "circle"}, "value": [151, "17"]}]}'
 
 
 def test_range_query_lookback_delta():

--- a/tests/integration/test_prometheus_protocols/test_query_api.py
+++ b/tests/integration/test_prometheus_protocols/test_query_api.py
@@ -119,6 +119,44 @@ def test_range_query_post_urlencoded():
     assert get_data == post_data
 
 
+def test_query_lookback_delta():
+    query = 'foo{shape="circle"}'
+    timestamp = 151
+
+    expected = '{"resultType": "vector", "result": [{"metric": {"__name__": "foo", "shape": "circle", "size": "l"}, "value": [151, "16"]}]}'
+    assert execute_query_via_http_api(node.ip_address, 9093, "/api/v1/query", query, timestamp=timestamp) == expected
+
+    assert (
+        execute_query_via_http_api(
+            node.ip_address, 9093, "/api/v1/query", query, timestamp=timestamp,
+            params={"lookback_delta": "500ms"},
+        )
+        == '{"resultType": "vector", "result": []}'
+    )
+
+    for lookback_delta in ("0", "-1"):
+        assert (
+            execute_query_via_http_api(
+                node.ip_address, 9093, "/api/v1/query", query, timestamp=timestamp,
+                params={"lookback_delta": lookback_delta},
+            )
+            == expected
+        )
+
+
+def test_range_query_lookback_delta():
+    query = 'foo{shape="circle"}'
+
+    expected = '{"resultType": "matrix", "result": [{"metric": {"__name__": "foo", "shape": "circle", "size": "l"}, "values": [[150, "16"]]}]}'
+    assert (
+        execute_range_query_via_http_api(
+            node.ip_address, 9093, "/api/v1/query_range", query, 150, 151, 1,
+            params={"lookback_delta": "0.5"},
+        )
+        == expected
+    )
+
+
 # Malformed PromQL is rejected at parse time.
 # The response must be a well-formed Prometheus error response `{"status":"error",...}`
 def test_error_while_parsing():


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Support the Prometheus HTTP API lookback_delta parameter for instant and range queries.

### Details
Prometheus documents lookback_delta as an optional per-query override for both /api/v1/query and /api/v1/query_range. It accepts duration syntax or a floating-point number of seconds.

This change passes the value to the existing instant selector lookback setting and keeps the parameter out of generic ClickHouse settings parsing. The value is parsed at nanosecond precision before being converted to the TimeSeries timestamp scale. Positive values are rounded up to at least one timestamp tick, so a value such as 500ms remains an active lookback on DateTime64(0). Zero and negative values continue to use the default lookback, matching Prometheus behavior.

References:
- [Prometheus HTTP API](https://prometheus.io/docs/prometheus/latest/querying/api/)
- [Prometheus querying basics](https://prometheus.io/docs/prometheus/latest/querying/basics/)

### Testing
- Added integration coverage for instant and range queries.
- Added a DateTime64(0) regression covering sub-tick lookback values and an exact-time sample.
- Added invalid lookback_delta coverage.
- python3 -m py_compile tests/integration/test_prometheus_protocols/test_query_api.py
- git diff --check


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1021` (included in `26.8` and later)
<!-- ch-version-info:end -->