### PR TITLE
Poll all materialized views with one query in test_rabbitmq_mv_combo

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -772,11 +772,9 @@ def test_rabbitmq_mv_combo(rabbitmq_cluster, db, unique):
     deadline = time.monotonic() + 180
     expected = messages_num * threads_num * NUM_MV
     while time.monotonic() < deadline:
-        result = 0
-        for mv_id in range(NUM_MV):
-            result += int(
-                instance.query(f"SELECT count() FROM {db}.combo_{mv_id}")
-            )
+        # Every instance.query() spawns a clickhouse-client, so poll all NUM_MV targets at once.
+        # The anchor keeps the combo_N_mv views out: reading a view counts its combo_N target again.
+        result = int(instance.query(f"SELECT count() FROM merge({db!r}, '^combo_[0-9]+$')"))
         if int(result) == expected:
             break
         logging.debug(f"Result: {result} / {expected}")


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/109909
Related: https://github.com/ClickHouse/ClickHouse/pull/110224


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

This does not touch the 180 second deadline or its failure message. It removes work from inside
that deadline, which is what #110224 asked for when it reverted my earlier timeout change.

In the failing report the test is neither stalled nor far behind: consumption is monotonic across
all 37 observations and reaches 940800 / 1000000 (94.08%), needing about 20 more seconds at its
own late rate. The budget goes to the polling loop. Each iteration ran one
`SELECT count()` per materialized view, and every `instance.query()` spawns a
`clickhouse-client` in the container, so much of the wall clock is client start-up; under msan
that cost is the same whatever the query.

Polling all five targets with one `merge()` count cuts the spawns. Measured on one box in one
session, single worker: 5.14 spawns per poll to 1.02, and polling overhead 19.8s of a 53.8s poll
span (36.8%) to 7.8s of 54.8s (14.2%). With three pytest workers, the shard condition in the
failing job, overhead goes from about 38.7% to about 13.4%. Reverting only the merged query
restores every number.

The load, the deadline, the `sleep(1)`, the failure message and the final assertion are unchanged,
and the merged count was verified equal to the previous per-table sum both while rows were arriving
and once settled. The pattern is anchored on purpose: unanchored, `combo_[0-9]+`
also matches the five `combo_N_mv` views, and reading a view goes to its target `combo_N`, so
every row would be counted twice and the loop would exit at half the real progress.

This may not eliminate the failure. Since #110224 the test fails about twice in 24 days over
roughly 47000 runs and never on master, so the claim is the measured overhead reduction rather
than a rate change. 21 repeat runs with three workers passed.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1011` (included in `26.8` and later)
<!-- ch-version-info:end -->