### PR TITLE
Drop the always-failing refreshable view after test_query_retry

### DIFF
--- a/tests/integration/test_refreshable_mat_view_replicated/test.py
+++ b/tests/integration/test_refreshable_mat_view_replicated/test.py
@@ -457,6 +457,16 @@ def fn3_setup_tables():
         "CREATE TABLE tgt1 ON CLUSTER default (a DateTime) ENGINE = ReplicatedMergeTree ORDER BY tuple()"
     )
 
+    yield
+
+    # A leaked test_rmv keeps retrying every 2 seconds, and each failed attempt creates and drops
+    # a temp table, so later tests cannot enqueue their own DDL (Code 529). Stop the refresher on
+    # both replicas before the DROP, which is itself replicated DDL. SYSTEM STOP VIEW is a local
+    # no-op when the view does not exist, so it needs no guard.
+    for n in nodes:
+        n.query("SYSTEM STOP VIEW test_rmv")
+    node.query("DROP TABLE IF EXISTS test_rmv ON CLUSTER default SYNC")
+
 
 def test_query_fail(fn3_setup_tables):
     if node.is_built_with_sanitizer():


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/76867
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/76867

`test_refreshable_mat_view_replicated` fails intermittently on `ON CLUSTER` DDL with `Code: 529` `NOT_A_LEADER`, "Cannot enqueue query ... replication lag of N queries", in exactly the 2 tests declared after `test_query_retry`.

Failing job: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=76867&sha=b3bf393702ea13d62b0379ae3ff75de2be15c12c&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29

Root cause: `fn3_setup_tables` had no teardown, so `test_query_retry`'s view leaked. It refreshes `EVERY 2 SECOND` and always fails, and `determineNextRefreshTime` advances a timeslot once the retries are exhausted, so it retries forever. Being non-APPEND, every failed attempt creates and drops a temp table, which in a `Replicated` database is two DDL-log entries. `max_log_ptr` races ahead, and a replica more than `max_replication_lag_to_enqueue` (default 50) behind refuses its next `ON CLUSTER` DDL. The restart in `test_circular_dependencies_survive_restart` amplifies it by freezing that replica's `log_ptr`.

The fixture now has a `yield` teardown that stops the refresher on both replicas, then drops the view. `SYSTEM STOP VIEW` is a local action lock, so it adds no DDL-log entries and lag cannot block it; it runs before the `DROP`, which is replicated DDL. A missing view makes it a no-op, so it needs no guard; `test_query_fail` covers that path.

Validated with a Debug non-sanitizer binary, so the sanitizer skips do not fire.

- Holding one replica down 90 s reproduces the exact error: without the fix the lag reaches 705 and the next `ON CLUSTER` `CREATE TABLE` fails with `Code: 529 ... replication lag of 705 queries`; with the fix the lag is 0.
- Without the fix the leaked view is still there after `test_query_retry` and the DDL log grows 330 entries per idle minute; with the fix growth is 0.
- Full module 30 passed; 10 repeats of the 3 affected tests 40 passed; zero `529`.

Complementary to #113952, which quiesces the circular refresh cycle in the same file; the hunks are disjoint and apply cleanly.