### PR TITLE
Fix 03008_deduplication_diagnostics_opt_in timeout on arm_darwin

### DIFF
--- a/tests/queries/0_stateless/03008_deduplication_diagnostics_opt_in.sh
+++ b/tests/queries/0_stateless/03008_deduplication_diagnostics_opt_in.sh
@@ -189,14 +189,17 @@ if [ "\$n" = 1 ]; then
   echo "Code: 395. DB::Exception: DEDUP_ASSERT_FAILED phase=$phase table=t: while executing" >&2
   exit 395
 fi
-: > "\$D/rerun_started"
-# Bounded, and released by the driver below the moment the signal has been sent: an
-# unbounded wait would leave one spinning process per row behind on every run.
-i=0
-while [ ! -f "\$D/go" ] && [ \$i -lt 600 ]; do sleep 0.05; i=\$((i+1)); done
+exec 9<> "\$D/go_fifo"
+exec 8<> "\$D/started_fifo"
+echo started >&8
+# Blocking, bounded read instead of a poll loop: the driver writes one line the moment the
+# signal has been sent. A poll loop whose sentinel is removed with the probe directory spins
+# to its cap and is left behind as an orphan on every row.
+read -r -t 60 -u 9 _ || true
 exit 0
 STUB
         chmod +x "$I/client_block"
+        mkfifo "$I/go_fifo" "$I/started_fifo"
         {
           echo "CLICKHOUSE_CLIENT='$I/client_block'"
           # The driver's own capture and cleanup, which is what makes an unforwarded error
@@ -207,13 +210,18 @@ STUB
           echo "CASE_ARGS=(${REPLAY_ARGS[*]})"
           sed 's/^                        //' "$W/block.sh"
         } > "$I/run.sh"
+        # Held open for the whole handshake so neither side sees EOF from a transient
+        # absence of a peer, which would make the reads return immediately.
+        exec 8<> "$I/started_fifo"
+        exec 9<> "$I/go_fifo"
         bash "$I/run.sh" > /dev/null 2> "$I/fwd_int" &
         int_pid=$!
-        i=0
-        while [ ! -f "$I/rerun_started" ] && [ "$i" -lt 200 ]; do sleep 0.05; i=$((i+1)); done
+        # Blocking instead of polling, so the signal still always lands inside the rerun.
+        read -r -t 60 -u 8 _ || true
         kill -TERM "$int_pid" 2>/dev/null
-        : > "$I/go"
+        echo go >&9
         wait "$int_pid" 2>/dev/null
+        exec 8>&- 9>&-
         echo "$name $phase interrupted rerun forwards marker $(grep -c 'DEDUP_ASSERT_FAILED' "$I/fwd_int")"
         rm -rf "$W"
     done


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/112913
Related: https://github.com/ClickHouse/ClickHouse/pull/110202

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`03008_deduplication_diagnostics_opt_in` is killed at the 60 s per-test deadline on
`Fast test (arm_darwin)`. No open issue tracks it; @alexey-milovidov asked me to fix it in
https://github.com/ClickHouse/ClickHouse/pull/110202#issuecomment-5226915803. The test was added by
my own #112913, so this is a regression I introduced, not a pre-existing flake.

Root cause. The interrupted-rerun probe keeps its sub-probe inside the probe directory, and the stub
client waits for a `go` sentinel file by polling (600 iterations of 0.05 s). The driver's
`wait "$int_pid"` returns as soon as the `run.sh` shell dies from the SIGTERM, but the stub is a
grandchild and is never waited for, so the following `rm -rf` deletes the sentinel the live stub is
still polling for. It is created and destroyed inside one poll gap, so the stub never sees it, spins
to its cap and is left behind. That happens once per row, 12 times per run, each orphan burning 600
`sleep` spawns over 30 s.

This replaces both file-sentinel poll loops with blocking bounded reads on FIFOs, keeping `echo go`
after `kill -TERM` so the signal still lands inside the rerun. A FIFO write reaches the blocked
reader immediately, so the teardown can no longer strand anybody.

Measured locally, 3 runs each: orphans surviving the test 11-12 to 0, `sleep` spawns 1888-3686 to 0,
total `execve` 2897-4863 (non-deterministic) to 1189 (identical every run). Over 50 runs: reference
clean 50/50, 0 orphans, 0 `sleep` spawns. `.reference` is unchanged and the mutation arm still
reddens.

The wall-clock gain here is small (5.4 s to 4.9 s) because 96 cores absorb the spin. I have no
Darwin runner, so the arm_darwin improvement is unmeasured from here and CI on this PR is the real
measurement. I did not raise the timeout or skip the test.