### PR TITLE
Report the original exception of a chained pytest failure

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1653,7 +1653,11 @@ class ResultTranslator:
                                             composed = []
                                             for re_entry in rt.get("reprentries", []):
                                                 dd = re_entry.get("data", {})
-                                                fileloc = dd.get("reprfileloc", {}) if isinstance(dd, dict) else {}
+                                                # a frame with no source location serializes the key
+                                                # as present-and-null, so a get() default never fires
+                                                fileloc = dd.get("reprfileloc") if isinstance(dd, dict) else None
+                                                if not isinstance(fileloc, dict):
+                                                    fileloc = {}
                                                 fpath = fileloc.get("path")
                                                 flineno = fileloc.get("lineno")
                                                 fmsg = fileloc.get("message")
@@ -1738,7 +1742,9 @@ class ResultTranslator:
                                         for re_entry in rt.get("reprentries", []):
                                             dd = re_entry.get("data", {})
                                             # include per-frame file location for full stack context
-                                            fileloc = dd.get("reprfileloc", {}) if isinstance(dd, dict) else {}
+                                            fileloc = dd.get("reprfileloc") if isinstance(dd, dict) else None
+                                            if not isinstance(fileloc, dict):
+                                                fileloc = {}
                                             fpath = fileloc.get("path")
                                             flineno = fileloc.get("lineno")
                                             fmsg = fileloc.get("message")
@@ -1776,7 +1782,9 @@ class ResultTranslator:
                                                 if "reprentries" in rt:
                                                     for re_entry in rt.get("reprentries", []):
                                                         dd = re_entry.get("data", {})
-                                                        fileloc = dd.get("reprfileloc", {}) if isinstance(dd, dict) else {}
+                                                        fileloc = dd.get("reprfileloc") if isinstance(dd, dict) else None
+                                                        if not isinstance(fileloc, dict):
+                                                            fileloc = {}
                                                         fpath = fileloc.get("path")
                                                         flineno = fileloc.get("lineno")
                                                         fmsg = fileloc.get("message")

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1439,6 +1439,71 @@ class ResultTranslator:
     GTEST_RESULT_FILE = Path("./ci/tmp/gtest.json").absolute()
     PYTEST_RESULT_FILE = Path("./ci/tmp/pytest.jsonl").absolute()
 
+    @staticmethod
+    def _render_chain(chain):
+        """Render a serialized pytest longrepr "chain": every exception, oldest first."""
+        out = ""
+        for pair in chain:
+            if not isinstance(pair, list):
+                continue
+            # a rendered traceback already ends with its own message, so the
+            # per-entry reprcrash would only repeat it
+            has_rt = len(pair) >= 1 and isinstance(pair[0], dict) and "reprentries" in pair[0]
+            if has_rt:
+                for re_entry in pair[0].get("reprentries", []):
+                    dd = re_entry.get("data", {})
+                    if not isinstance(dd, dict):
+                        continue
+                    # a frame with no source location serializes the key as
+                    # present-and-null, so a get() default never fires
+                    fileloc = dd.get("reprfileloc")
+                    if not isinstance(fileloc, dict):
+                        fileloc = {}
+                    fpath = fileloc.get("path")
+                    flineno = fileloc.get("lineno")
+                    fmsg = fileloc.get("message")
+                    header_parts = []
+                    if fpath is not None and flineno is not None:
+                        header_parts.append(f"File: {fpath}:{flineno}")
+                    if fmsg:
+                        header_parts.append(str(fmsg))
+                    if header_parts:
+                        if out:
+                            out += "\n"
+                        out += " - ".join(header_parts)
+                    if dd.get("lines"):
+                        if out:
+                            out += "\n"
+                        out += "\n".join(dd["lines"])
+            elif len(pair) >= 2 and isinstance(pair[1], dict):
+                crash = pair[1]
+                p = crash.get("path")
+                ln = crash.get("lineno")
+                msg = crash.get("message")
+                seg = []
+                if p is not None and ln is not None:
+                    seg.append(f"File: {p}:{ln}")
+                if msg:
+                    seg.append(str(msg))
+                if seg:
+                    if out:
+                        out += "\n"
+                    out += "\n".join(seg)
+            # pytest attaches the causal separator to the entry it follows
+            if len(pair) >= 3 and pair[2]:
+                if out:
+                    out += "\n"
+                out += str(pair[2])
+        return out
+
+    @staticmethod
+    def _chain_of(longrepr):
+        """The chain, only when it is authoritative: reprtraceback is just its last entry."""
+        if not isinstance(longrepr, dict):
+            return None
+        chain = longrepr.get("chain")
+        return chain if isinstance(chain, list) and len(chain) > 1 else None
+
     @classmethod
     def from_gtest(cls):
         """The json is described by the next proto3 scheme:
@@ -1636,7 +1701,10 @@ class ResultTranslator:
                                     # Best-effort: mirror traceback builder from TestReport for dict shape
                                     try:
                                         lr_txt = ""
-                                        crash = longrepr.get("reprcrash") if isinstance(longrepr, dict) else None
+                                        _chain = cls._chain_of(longrepr)
+                                        if _chain is not None:
+                                            lr_txt = cls._render_chain(_chain)
+                                        crash = longrepr.get("reprcrash") if _chain is None else None
                                         if isinstance(crash, dict):
                                             p = crash.get("path")
                                             ln = crash.get("lineno")
@@ -1648,7 +1716,7 @@ class ResultTranslator:
                                                 seg.append(str(msg))
                                             if seg:
                                                 lr_txt += "\n".join(seg)
-                                        rt = longrepr.get("reprtraceback") if isinstance(longrepr, dict) else None
+                                        rt = longrepr.get("reprtraceback") if _chain is None else None
                                         if isinstance(rt, dict) and "reprentries" in rt:
                                             composed = []
                                             for re_entry in rt.get("reprentries", []):
@@ -1732,8 +1800,7 @@ class ResultTranslator:
                                 # A chained failure carries every exception in "chain" (oldest
                                 # first), while "reprtraceback" is only its last entry, so the
                                 # chain is authoritative whenever it holds more than one.
-                                _chain = data.get("chain") if isinstance(data, dict) else None
-                                _use_chain = isinstance(_chain, list) and len(_chain) > 1
+                                _use_chain = cls._chain_of(data) is not None
                                 # reprtraceback: collect lines
                                 if not _use_chain and data and isinstance(data, dict) and "reprtraceback" in data:
                                     rt = data.get("reprtraceback", {})
@@ -1765,62 +1832,11 @@ class ResultTranslator:
                                 # also the fallback when there is no top-level reprtraceback
                                 elif data and isinstance(data, dict) and "chain" in data:
                                     try:
-                                        chain = data.get("chain", [])
-                                        for pair in chain:
-                                            # pair typically is [reprtraceback, reprcrash, context]
-                                            if not isinstance(pair, list):
-                                                continue
-                                            # mirror the reprcrash suppression above: a traceback
-                                            # already ends with the exception message
-                                            _pair_has_rt = (
-                                                len(pair) >= 1
-                                                and isinstance(pair[0], dict)
-                                                and "reprentries" in pair[0]
-                                            )
-                                            if len(pair) >= 1 and isinstance(pair[0], dict):
-                                                rt = pair[0]
-                                                if "reprentries" in rt:
-                                                    for re_entry in rt.get("reprentries", []):
-                                                        dd = re_entry.get("data", {})
-                                                        fileloc = dd.get("reprfileloc") if isinstance(dd, dict) else None
-                                                        if not isinstance(fileloc, dict):
-                                                            fileloc = {}
-                                                        fpath = fileloc.get("path")
-                                                        flineno = fileloc.get("lineno")
-                                                        fmsg = fileloc.get("message")
-                                                        header_parts = []
-                                                        if fpath is not None and flineno is not None:
-                                                            header_parts.append(f"File: {fpath}:{flineno}")
-                                                        if fmsg:
-                                                            header_parts.append(str(fmsg))
-                                                        if header_parts:
-                                                            if traceback_str:
-                                                                traceback_str += "\n"
-                                                            traceback_str += " - ".join(header_parts)
-                                                        if isinstance(dd, dict) and "lines" in dd and dd["lines"]:
-                                                            if traceback_str:
-                                                                traceback_str += "\n"
-                                                            traceback_str += "\n".join(dd["lines"])
-                                            if len(pair) >= 2 and isinstance(pair[1], dict) and not _pair_has_rt:
-                                                crash = pair[1]
-                                                p = crash.get("path")
-                                                ln = crash.get("lineno")
-                                                msg = crash.get("message")
-                                                seg = []
-                                                if p is not None and ln is not None:
-                                                    seg.append(f"File: {p}:{ln}")
-                                                if msg:
-                                                    seg.append(str(msg))
-                                                if seg:
-                                                    if traceback_str:
-                                                        traceback_str += "\n"
-                                                    traceback_str += "\n".join(seg)
-                                            # pytest attaches the causal separator to the entry
-                                            # it follows, so emit it after that entry's text
-                                            if len(pair) >= 3 and pair[2]:
-                                                if traceback_str:
-                                                    traceback_str += "\n"
-                                                traceback_str += str(pair[2])
+                                        rendered = cls._render_chain(data.get("chain") or [])
+                                        if rendered:
+                                            if traceback_str:
+                                                traceback_str += "\n"
+                                            traceback_str += rendered
                                     except Exception:
                                         # Be resilient to unexpected shapes
                                         pass

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1725,8 +1725,13 @@ class ResultTranslator:
                                             parts.append(str(message))
                                         if parts:
                                             traceback_str += "\n".join(parts)
+                                # A chained failure carries every exception in "chain" (oldest
+                                # first), while "reprtraceback" is only its last entry, so the
+                                # chain is authoritative whenever it holds more than one.
+                                _chain = data.get("chain") if isinstance(data, dict) else None
+                                _use_chain = isinstance(_chain, list) and len(_chain) > 1
                                 # reprtraceback: collect lines
-                                if data and isinstance(data, dict) and "reprtraceback" in data:
+                                if not _use_chain and data and isinstance(data, dict) and "reprtraceback" in data:
                                     rt = data.get("reprtraceback", {})
                                     if isinstance(rt, dict) and "reprentries" in rt:
                                         composed = []
@@ -1750,7 +1755,8 @@ class ResultTranslator:
                                             if traceback_str:
                                                 traceback_str += "\n"
                                             traceback_str += "\n".join(composed)
-                                # chain: fallback/additional entries (only if no reprtraceback)
+                                # chain: every exception of a chained failure, oldest first;
+                                # also the fallback when there is no top-level reprtraceback
                                 elif data and isinstance(data, dict) and "chain" in data:
                                     try:
                                         chain = data.get("chain", [])
@@ -1758,6 +1764,13 @@ class ResultTranslator:
                                             # pair typically is [reprtraceback, reprcrash, context]
                                             if not isinstance(pair, list):
                                                 continue
+                                            # mirror the reprcrash suppression above: a traceback
+                                            # already ends with the exception message
+                                            _pair_has_rt = (
+                                                len(pair) >= 1
+                                                and isinstance(pair[0], dict)
+                                                and "reprentries" in pair[0]
+                                            )
                                             if len(pair) >= 1 and isinstance(pair[0], dict):
                                                 rt = pair[0]
                                                 if "reprentries" in rt:
@@ -1780,7 +1793,7 @@ class ResultTranslator:
                                                             if traceback_str:
                                                                 traceback_str += "\n"
                                                             traceback_str += "\n".join(dd["lines"])
-                                            if len(pair) >= 2 and isinstance(pair[1], dict):
+                                            if len(pair) >= 2 and isinstance(pair[1], dict) and not _pair_has_rt:
                                                 crash = pair[1]
                                                 p = crash.get("path")
                                                 ln = crash.get("lineno")
@@ -1794,6 +1807,12 @@ class ResultTranslator:
                                                     if traceback_str:
                                                         traceback_str += "\n"
                                                     traceback_str += "\n".join(seg)
+                                            # pytest attaches the causal separator to the entry
+                                            # it follows, so emit it after that entry's text
+                                            if len(pair) >= 3 and pair[2]:
+                                                if traceback_str:
+                                                    traceback_str += "\n"
+                                                traceback_str += str(pair[2])
                                     except Exception:
                                         # Be resilient to unexpected shapes
                                         pass

--- a/ci/tests/test_result_chained_exceptions.py
+++ b/ci/tests/test_result_chained_exceptions.py
@@ -247,6 +247,29 @@ def test_collection_failure_with_null_file_location_still_renders():
     assert FINAL in info, f"exception missing from:\n{info}"
 
 
+def test_chained_collection_failure_keeps_the_original_cause():
+    """Collection-time chains (a module, class body, package or hook that
+    re-raises) use the same layout, so the cause must survive there too."""
+    info = _render_collect(CHAINED)
+    assert CAUSE in info, f"original cause erased from:\n{info}"
+    assert FINAL in info, f"final exception missing from:\n{info}"
+    assert info.index(CAUSE) < info.index(SEPARATOR) < info.index(FINAL)
+    assert info.count(CAUSE) == 1, f"cause rendered {info.count(CAUSE)}x:\n{info}"
+    assert info.count(FINAL) == 1, f"final rendered {info.count(FINAL)}x:\n{info}"
+
+
+def test_unchained_collection_failure_render_is_unchanged():
+    """A single-exception collection failure must render as it always has."""
+    info = _render_collect(UNCHAINED)
+    assert info == (
+        f"File: /abs/t.py:11\n{FINAL}\n"
+        "File: t.py:11 - AssertionError\n"
+        ">       assert False, 'postcondition'\n"
+        f"E       {FINAL}"
+    ), f"unchained collection rendering changed:\n{info}"
+    assert SEPARATOR not in info
+
+
 if __name__ == "__main__":
     for _name, _fn in sorted(list(globals().items())):
         if _name.startswith("test_"):

--- a/ci/tests/test_result_chained_exceptions.py
+++ b/ci/tests/test_result_chained_exceptions.py
@@ -50,6 +50,32 @@ _CAUSE_TB = _traceback(
     2,
     "TimeoutError",
 )
+
+
+def _traceback_no_fileloc(lines):
+    """As pytest serializes a frame with no source location: the key is present and null.
+
+    Produced by `pytest.fail(..., pytrace=False)` (style "value") and whenever
+    every frame was hidden by `__tracebackhide__` (style "long", no entry).
+    """
+    return {
+        "reprentries": [
+            {
+                "type": "ReprEntry",
+                "data": {
+                    "lines": lines,
+                    "reprfuncargs": None,
+                    "reprlocals": None,
+                    "reprfileloc": None,
+                    "style": "value",
+                },
+            }
+        ],
+        "extraline": None,
+        "style": "value",
+    }
+
+
 _CAUSE_CRASH = {"path": "/abs/t.py", "lineno": 2, "message": CAUSE}
 _FINAL_TB = _traceback(
     [">       assert False, 'postcondition'", f"E       {FINAL}"],
@@ -104,6 +130,37 @@ def _render(longrepr):
         os.unlink(f.name)
 
 
+def _render_collect(longrepr):
+    """Same, for a collection-time failure, which has its own renderer."""
+    entries = (
+        [{"pytest_version": "8.0.0", "$report_type": "SessionStart"}]
+        + [
+            {
+                "$report_type": "CollectReport",
+                "nodeid": "t.py",
+                "outcome": "failed",
+                "sections": [],
+                "longrepr": longrepr,
+            }
+        ]
+        + [{"exitstatus": 2, "$report_type": "SessionFinish"}]
+    )
+    f = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+    )
+    for entry in entries:
+        f.write(json.dumps(entry) + "\n")
+    f.close()
+    try:
+        r = ResultTranslator.from_pytest_jsonl(f.name)
+        assert len(r.results) == 1
+        item = r.results[0]
+        assert item.status == Result.Status.ERROR
+        return item.info or ""
+    finally:
+        os.unlink(f.name)
+
+
 CHAINED = _longrepr(
     [
         [_CAUSE_TB, _CAUSE_CRASH, SEPARATOR],
@@ -111,6 +168,22 @@ CHAINED = _longrepr(
     ]
 )
 UNCHAINED = _longrepr([[_FINAL_TB, _FINAL_CRASH, None]])
+
+_CAUSE_TB_NO_LOC = _traceback_no_fileloc([CAUSE])
+_FINAL_TB_NO_LOC = _traceback_no_fileloc([FINAL])
+CHAINED_NO_LOC = _longrepr(
+    [
+        [_CAUSE_TB_NO_LOC, _CAUSE_CRASH, SEPARATOR],
+        [_FINAL_TB_NO_LOC, _FINAL_CRASH, None],
+    ]
+)
+CHAINED_MIXED_LOC = _longrepr(
+    [
+        [_CAUSE_TB_NO_LOC, _CAUSE_CRASH, SEPARATOR],
+        [_FINAL_TB, _FINAL_CRASH, None],
+    ]
+)
+UNCHAINED_NO_LOC = _longrepr([[_FINAL_TB_NO_LOC, _FINAL_CRASH, None]])
 
 
 def test_chained_failure_keeps_the_original_cause():
@@ -144,6 +217,34 @@ def test_unchained_failure_render_is_unchanged():
         f"E       {FINAL}"
     ), f"unchained rendering changed:\n{info}"
     assert SEPARATOR not in info
+
+
+def test_chained_failure_with_null_file_location_still_renders():
+    """A frame with no source location must not silence the whole chain."""
+    info = _render(CHAINED_NO_LOC)
+    assert info, "info empty for a chain of location-less frames"
+    assert CAUSE in info, f"original cause erased from:\n{info}"
+    assert FINAL in info, f"final exception missing from:\n{info}"
+
+
+def test_chained_failure_with_mixed_file_locations_renders_all():
+    """A location-less cause must not cost the later entries their rendering."""
+    info = _render(CHAINED_MIXED_LOC)
+    assert CAUSE in info, f"original cause erased from:\n{info}"
+    assert FINAL in info, f"final exception missing from:\n{info}"
+    assert info.index(CAUSE) < info.index(FINAL), f"reverse causal order:\n{info}"
+
+
+def test_unchained_failure_with_null_file_location_still_renders():
+    """The single-exception path reads the same location field."""
+    info = _render(UNCHAINED_NO_LOC)
+    assert FINAL in info, f"exception missing from:\n{info}"
+
+
+def test_collection_failure_with_null_file_location_still_renders():
+    """`pytest.fail(pytrace=False)` at import time reaches the collect renderer."""
+    info = _render_collect(UNCHAINED_NO_LOC)
+    assert FINAL in info, f"exception missing from:\n{info}"
 
 
 if __name__ == "__main__":

--- a/ci/tests/test_result_chained_exceptions.py
+++ b/ci/tests/test_result_chained_exceptions.py
@@ -1,0 +1,154 @@
+"""
+Tests for chained-exception handling in ResultTranslator.from_pytest_jsonl.
+
+A chained failure (a test body raises, then a context manager's __exit__, a
+`finally` or an `except` handler raises too) puts every exception in longrepr's
+"chain", oldest first, while "reprtraceback" is only its last entry.  The
+rendered info must name the original cause, not just the final exception.
+"""
+
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.praktika.result import Result, ResultTranslator
+
+CAUSE = "TimeoutError: REAL_CAUSE"
+FINAL = "AssertionError: postcondition"
+
+
+def _traceback(lines, path, lineno, message):
+    """A serialized pytest ReprTraceback with a single frame."""
+    return {
+        "reprentries": [
+            {
+                "type": "ReprEntry",
+                "data": {
+                    "lines": lines,
+                    "reprfuncargs": {"args": []},
+                    "reprlocals": None,
+                    "reprfileloc": {
+                        "path": path,
+                        "lineno": lineno,
+                        "message": message,
+                    },
+                    "style": "long",
+                },
+            }
+        ],
+        "extraline": None,
+        "style": "long",
+    }
+
+
+_CAUSE_TB = _traceback(
+    [">   def _raise(): raise TimeoutError('REAL_CAUSE')", f"E   {CAUSE}"],
+    "t.py",
+    2,
+    "TimeoutError",
+)
+_CAUSE_CRASH = {"path": "/abs/t.py", "lineno": 2, "message": CAUSE}
+_FINAL_TB = _traceback(
+    [">       assert False, 'postcondition'", f"E       {FINAL}"],
+    "t.py",
+    11,
+    "AssertionError",
+)
+_FINAL_CRASH = {"path": "/abs/t.py", "lineno": 11, "message": FINAL}
+SEPARATOR = "During handling of the above exception, another exception occurred:"
+
+
+def _longrepr(chain):
+    """pytest sets reprtraceback/reprcrash from the LAST chain entry."""
+    return {
+        "reprcrash": chain[-1][1],
+        "reprtraceback": chain[-1][0],
+        "sections": [],
+        "chain": chain,
+    }
+
+
+def _render(longrepr):
+    """Run from_pytest_jsonl over a one-failure report-log, return its info."""
+    entries = (
+        [{"pytest_version": "8.0.0", "$report_type": "SessionStart"}]
+        + [
+            {
+                "$report_type": "TestReport",
+                "nodeid": "t.py::test_x",
+                "when": "call",
+                "outcome": "failed",
+                "duration": 0.1,
+                "sections": [],
+                "longrepr": longrepr,
+            }
+        ]
+        + [{"exitstatus": 1, "$report_type": "SessionFinish"}]
+    )
+    f = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+    )
+    for entry in entries:
+        f.write(json.dumps(entry) + "\n")
+    f.close()
+    try:
+        r = ResultTranslator.from_pytest_jsonl(f.name)
+        assert len(r.results) == 1
+        test = r.results[0]
+        assert test.status == Result.Status.FAIL
+        return test.info or ""
+    finally:
+        os.unlink(f.name)
+
+
+CHAINED = _longrepr(
+    [
+        [_CAUSE_TB, _CAUSE_CRASH, SEPARATOR],
+        [_FINAL_TB, _FINAL_CRASH, None],
+    ]
+)
+UNCHAINED = _longrepr([[_FINAL_TB, _FINAL_CRASH, None]])
+
+
+def test_chained_failure_keeps_the_original_cause():
+    """The cause must be present, not only the exception that masked it."""
+    info = _render(CHAINED)
+    assert CAUSE in info, f"original cause erased from:\n{info}"
+    assert FINAL in info, f"final exception missing from:\n{info}"
+
+
+def test_chained_failure_is_cause_first_with_separator():
+    """Causal order, with pytest's own separator between the two exceptions."""
+    info = _render(CHAINED)
+    assert info.index(CAUSE) < info.index(FINAL), f"reverse causal order:\n{info}"
+    assert SEPARATOR in info, f"causal separator dropped from:\n{info}"
+    assert info.index(CAUSE) < info.index(SEPARATOR) < info.index(FINAL)
+
+
+def test_chained_failure_does_not_duplicate_messages():
+    """A rendered traceback already ends with its message; do not repeat it."""
+    info = _render(CHAINED)
+    assert info.count(CAUSE) == 1, f"cause rendered {info.count(CAUSE)}x:\n{info}"
+    assert info.count(FINAL) == 1, f"final rendered {info.count(FINAL)}x:\n{info}"
+
+
+def test_unchained_failure_render_is_unchanged():
+    """The common single-exception case must render exactly as it always has."""
+    info = _render(UNCHAINED)
+    assert info == (
+        "File: t.py:11 - AssertionError\n"
+        ">       assert False, 'postcondition'\n"
+        f"E       {FINAL}"
+    ), f"unchained rendering changed:\n{info}"
+    assert SEPARATOR not in info
+
+
+if __name__ == "__main__":
+    for _name, _fn in sorted(list(globals().items())):
+        if _name.startswith("test_"):
+            _fn()
+            print(f"PASS {_name}")
+    print("All tests passed.")


### PR DESCRIPTION
Report the original exception of a chained pytest failure

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/83334
Related: https://github.com/ClickHouse/ClickHouse/pull/113756
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not user-facing: CI harness only.


### Description

When a pytest test fails with a **chained** exception (the body raises, then a context manager's
`__exit__`, a `finally` or an `except` handler raises too) praktika reported only the final one. The
original cause was **absent** from the rendered `Result.info`, i.e. from the CI report and CIDB.

`ResultTranslator.from_pytest_jsonl` handled `longrepr["chain"]` behind an `elif` after
`reprtraceback`, which is always present for a real failure, so the chain branch never ran. pytest
puts every exception in `chain` (oldest first) and sets `reprtraceback` to the **last** entry only
(`ExceptionChainRepr.__init__`). Erased in **5 of 5** chaining shapes measured. A recent
`test_cancel_backup.py` failure, reported as a `NoTrashChecker.__exit__` assert while the real cause
was a 660 s query stall, needed the raw `job.log`; 120 CIDB rows in 180 days, >=64 provably masked.

Related: https://github.com/ClickHouse/ClickHouse/issues/83334
Related: https://github.com/ClickHouse/ClickHouse/pull/113756

A chain holding more than one exception now becomes the authoritative rendering, in pytest's own
order and with each entry's causal separator, mirroring `ExceptionChainRepr.toterminal`. An entry's
`reprcrash` is suppressed when that entry supplied a traceback, mirroring the top-level `has_rt`
guard, so nothing is repeated. Collection-time failures (a module, class body, package `__init__` or
a collection hook that re-raises) use the same layout, so they share the walk. An uncaught
`ImportError` is unaffected: pytest renders that one to a string.

Second, a location-less frame (`pytest.fail(pytrace=False)`, or all frames hidden by
`__tracebackhide__`) serializes `reprfileloc` as present-and-null, so the old `.get(key, {})` default
never fired and the read raised, emptying the info or collapsing the report to one ERROR. All three
reads are normalized; located frames stay byte-identical.

Validated by ten `ci/tests` arms, eight red on pristine master, each site pinned by its own mutation
control, six chained collection shapes checked on real `--report-log` output, and an unchanged
`ci/tests/` failure set. Chained reports grow ~2-3x, 23 lines worst case, under the 50-line cap.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1683` (included in `26.8` and later)
<!-- ch-version-info:end -->