### PR TITLE
Stop test_list_tables_pagination opting out of the create_table retry

### DIFF
--- a/tests/integration/helpers/catalog_manager_biglake.py
+++ b/tests/integration/helpers/catalog_manager_biglake.py
@@ -392,8 +392,10 @@ class BigLakeCatalogManager(CatalogManager):
                 # raise CommitStateUnknownException after committing). Reconcile
                 # the partial attempt FIRST -- for every exception, transient or
                 # not -- so nothing is leaked untracked, then decide retry vs
-                # re-raise.
-                self._drop_failed_attempt(candidate)
+                # re-raise. NoSuchNamespaceError is the exception: only the
+                # create call maps a 404 to it, so no table can exist yet.
+                if not isinstance(exc, NoSuchNamespaceError):
+                    self._drop_failed_attempt(candidate)
                 if not isinstance(exc, _TRANSIENT_CREATE_ERRORS):
                     raise
                 if time.monotonic() >= deadline:

--- a/tests/integration/helpers/catalog_manager_biglake.py
+++ b/tests/integration/helpers/catalog_manager_biglake.py
@@ -38,7 +38,7 @@ NAMESPACE_PREFIX = "ch_e2e_bl_"
 # object, never the token baked into the catalog. Retrying any catalog call after
 # the token expires just resends the same stale token until the deadline.
 # Rebuilding self.catalog mid-retry is unsafe because callers share it
-# concurrently (test_many_tables_pagination fans catalog calls across a 10-thread
+# concurrently (test_list_tables_pagination fans catalog calls across a 10-thread
 # pool), so auth expiry is always left to propagate. These mirror pyiceberg's own
 # retry-then-reraise set for its REST client (AuthorizationExpiredError,
 # UnauthorizedError; OAuthError covers the token-endpoint path).
@@ -51,10 +51,13 @@ _AUTH_EXPIRY_ERRORS = (
 # REST/network errors that create_table retries; pyiceberg's REST client
 # retries only auth errors (stop_after_attempt(2)), so these otherwise escape.
 # Auth-expiry errors are deliberately excluded (see _AUTH_EXPIRY_ERRORS).
+# NoSuchNamespaceError included: BigLake indexes a just-created namespace
+# asynchronously, so the session namespace can 404 for a few seconds.
 _TRANSIENT_CREATE_ERRORS = (
     ServerError,
     ServiceUnavailableError,
     CommitStateUnknownException,
+    NoSuchNamespaceError,
     requests.exceptions.RequestException,
 )
 
@@ -340,7 +343,7 @@ class BigLakeCatalogManager(CatalogManager):
         # uses a fresh unique name, so a partial prior attempt (table created,
         # append failed) cannot resurface as TableAlreadyExistsError nor
         # duplicate rows -- creation stays exactly-once. When a caller supplies
-        # a fixed table_name (test_many_tables_pagination asserts the exact
+        # a fixed table_name (test_list_tables_pagination asserts the exact
         # short names it passed appear in SHOW TABLES, so we cannot substitute a
         # UUID), a fresh name is not an option, so that path makes a single
         # attempt and lets a transient error propagate as before.

--- a/tests/integration/helpers/catalog_manager_biglake.py
+++ b/tests/integration/helpers/catalog_manager_biglake.py
@@ -38,8 +38,8 @@ NAMESPACE_PREFIX = "ch_e2e_bl_"
 # object, never the token baked into the catalog. Retrying any catalog call after
 # the token expires just resends the same stale token until the deadline.
 # Rebuilding self.catalog mid-retry is unsafe because callers share it
-# concurrently (test_list_tables_pagination fans catalog calls across a 10-thread
-# pool), so auth expiry is always left to propagate. These mirror pyiceberg's own
+# concurrently (callers may fan catalog calls across a thread pool), so auth
+# expiry is always left to propagate. These mirror pyiceberg's own
 # retry-then-reraise set for its REST client (AuthorizationExpiredError,
 # UnauthorizedError; OAuthError covers the token-endpoint path).
 _AUTH_EXPIRY_ERRORS = (
@@ -343,10 +343,9 @@ class BigLakeCatalogManager(CatalogManager):
         # uses a fresh unique name, so a partial prior attempt (table created,
         # append failed) cannot resurface as TableAlreadyExistsError nor
         # duplicate rows -- creation stays exactly-once. When a caller supplies
-        # a fixed table_name (test_list_tables_pagination asserts the exact
-        # short names it passed appear in SHOW TABLES, so we cannot substitute a
-        # UUID), a fresh name is not an option, so that path makes a single
-        # attempt and lets a transient error propagate as before.
+        # a fixed table_name, a fresh name is not an option, so that path makes
+        # a single attempt and lets a transient error propagate as before. It
+        # currently has no in-repo caller.
         namespace = self._session_namespace
         iceberg_schema = arrow_to_iceberg_schema(data)
 

--- a/tests/integration/helpers/catalog_manager_onelake.py
+++ b/tests/integration/helpers/catalog_manager_onelake.py
@@ -23,8 +23,7 @@ ONELAKE_BLOB_HOST = "onelake.blob.fabric.microsoft.com"
 ONELAKE_STORAGE_ENDPOINT = f"https://{ONELAKE_DFS_HOST}"
 ONELAKE_CATALOG_URL = "https://onelake.table.fabric.microsoft.com/iceberg"
 
-# All tables this manager creates -- including those produced by
-# `test_list_tables_pagination` (`e2e_pg_*`) -- start with this prefix.
+# All tables this manager creates start with this prefix.
 # Stale cleanup must restrict itself to this prefix so other workloads
 # sharing the same Fabric lakehouse are never touched.
 TABLE_NAME_PREFIX = "e2e_"

--- a/tests/integration/test_e2e_catalogs/test.py
+++ b/tests/integration/test_e2e_catalogs/test.py
@@ -1302,13 +1302,9 @@ def test_list_tables_pagination(node, catalog_manager):
     independently of this PR).
     """
     n_tables = 60  # > Fabric's ~50-per-page boundary
-    # `pg` sorts lexicographically after any pre-existing `e2e_<hex>`
-    # or `tbl_<hex>` names produced by other tests in the same session,
-    # so any silent truncation drops our tables first.
-    prefix = f"e2e_pg_{uuid.uuid4().hex[:6]}_"
+    # Truncation shows up as tables missing by count, not by name sort order.
     data = pa.table({"id": pa.array([1], type=pa.int64())})
 
-    expected = [f"{prefix}{i:03d}" for i in range(n_tables)]
     created = []
     db = None
     try:
@@ -1322,9 +1318,11 @@ def test_list_tables_pagination(node, catalog_manager):
         # them instead of leaking catalog/storage artifacts.
         first_exc = None
         with concurrent.futures.ThreadPoolExecutor(max_workers=10) as pool:
+            # No `table_name=`: only the auto-named path retries a transient
+            # catalog error, so the names must come back from create_table.
             futures = [
-                pool.submit(catalog_manager.create_table, data, table_name=short)
-                for short in expected
+                pool.submit(catalog_manager.create_table, data)
+                for _ in range(n_tables)
             ]
             for fut in concurrent.futures.as_completed(futures):
                 try:
@@ -1334,6 +1332,7 @@ def test_list_tables_pagination(node, catalog_manager):
                         first_exc = exc
         if first_exc is not None:
             raise first_exc
+        expected = sorted(created)
 
         db = catalog_manager.make_database_name()
         catalog_manager.create_catalog(node, db)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/109204
Related: https://github.com/ClickHouse/ClickHouse/pull/104531


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`test_e2e_catalogs::test_list_tables_pagination` creates 60 tables through a 10-worker pool. It
passed `table_name=` to `BigLakeCatalogManager.create_table`, whose named path is single-attempt by
design: #109204 carved it out of the retry because a same-name retry can resurface its own partial
attempt as `TableAlreadyExistsError`. That still holds. This test was the only `table_name=` call
site in the repo, so it made 60 un-retried round-trips and failed if any one blipped.

The test does not need fixed names: it asserts set membership of the names it created. It now lets
`create_table` generate them and builds `expected` from the returned values. Every attempt uses a
fresh name, so exactly-once creation holds by construction, which is what the carve-out protects.
The named branch is unchanged and then has no in-repo caller, but its contract is still correct.

Separately, `NoSuchNamespaceError` was retried by neither path: not being a `RESTError`, it fell
outside `_TRANSIENT_CREATE_ERRORS`, yet BigLake indexes a new namespace asynchronously so it can 404
for seconds. It is now in that tuple; a genuinely missing namespace still fails with the same
exception at the existing deadline.

Validated by fault injection against the real functions, since a live run needs BigLake credentials;
reverting any of the three changes reddens its own arm. The three assertions are untouched and still fail
on a truncated listing, which depends on 60 tables exceeding one ~50-entry page, not sort order. A duplicate auto-name raises `TableAlreadyExistsError`, which is not transient, so it fails
loudly.

Also fixed in review: the loop reconciled every failed attempt before classifying it, so a namespace
404 registered a name that was never created, whose unconfirmable drop then burns `cleanup_all`'s
whole 120s deadline. Reconciliation is now skipped for `NoSuchNamespaceError` alone, the one class
that cannot follow a commit. The others still reconcile.

`AwsGlue` and `OneLake` still never retry `create_table`; not addressed.
