### PR TITLE
Fix flaky test_keeper_4lw_reconfiguration by not zeroing a possible leader's priority

### DIFF
--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -786,7 +786,7 @@ void KeeperDispatcher::executeClusterUpdateActionAndWaitConfigChange(const Clust
         }
         LOG_INFO(log, "Timeout exceeded waiting for configuration update {} to be applied, attempt {}/{}", action, attempt + 1, retry_count + 1);
     }
-    throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded (with retries count {}) waiting for configuration update {} to happen", action, retry_count);
+    throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded (with retries count {}) waiting for configuration update {} to happen", retry_count, action);
 }
 
 void KeeperDispatcher::checkReconfigCommandPreconditions(Poco::JSON::Object::Ptr reconfig_command)

--- a/tests/integration/test_keeper_4lw_reconfiguration/test.py
+++ b/tests/integration/test_keeper_4lw_reconfiguration/test.py
@@ -125,7 +125,7 @@ def three_to_five_reconfig(started_cluster):
         },
         "actions": [
             {
-                "set_priority": [{"id": 3, "priority": 1}]
+                "set_priority": [{"id": 3, "priority": 1}, {"id": 4, "priority": 1}, {"id": 5, "priority": 1}]
             },
             {
                 "add_members": [


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/113595#issuecomment-5226823500

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`test_reconfig_option2` failed in `Integration tests (amd_tsan, 6/6)` with
`assert 'error' == 'ok'` inside `three_to_five_reconfig`
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113595&sha=eb79d7629e2efe0b6ec503d98854d09ee9fd4006&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%206%2F6%29)).
It fired on four other days in the previous 60 of CIDB, twice on master.

The command plan was only valid if no election happened while it ran: it transferred leadership
to the joining servers 6 and 7 while 4 and 5 were still at priority 100, and zeroed 4 and 5 only
in the last action. `checkReconfigCommandActions` validated it against a static model in which
the transfer had already made 6 and 7 the only leaders, so it passed the pre-check. Two elections
then landed in that window, so the last action asked server 5 to zero its own priority while
leader. NuRaft refuses that by design: the server was right, the plan was not.

I lower 4 and 5 to priority 1 in the first action. A priority-1 node will not initiate a pre-vote
against a target priority of 100, while `yield_leadership` still nominates 6 or 7 and triggers
their election at once. Priority 1 rather than 0 is deliberate: 0 is self-refused by the same
rule, and makes a leader resign shortly after winning. All assertions and action types are
unchanged. Over three runs each way, 4 and 5 are eligible to start an election in that window
without the change and never with it. This narrows the window rather than closing it, since
`target_priority_` decays to 1 after nine election timeouts.

I also swap two format arguments in the `TIMEOUT_EXCEEDED` message, which printed the action and
the retry count in each other's slot.

Not fixed here: `applyConfigUpdate` discards `set_priority_v2`'s return value, so a refusal
surfaces as this timeout rather than its real reason. Reading that bool is unsound, since
`false` also means "forwarded, still pending".

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=113988&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/113988](https://github.com/search?q=head%3Async-upstream%2Fpr%2F113988+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
