### PR TITLE
Route old-leader reads through Raft in the Keeper compat snapshot test

### DIFF
--- a/tests/integration/test_keeper_snapshot_chunked_transfer/configs/quorum_reads.xml
+++ b/tests/integration/test_keeper_snapshot_chunked_transfer/configs/quorum_reads.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <keeper_server>
+        <coordination_settings>
+            <quorum_reads>true</quorum_reads>
+        </coordination_settings>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
+++ b/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
@@ -61,12 +61,14 @@ node10 = cluster.add_instance("node10", main_configs=["configs/enable_keeper10_l
 node11 = cluster.add_instance("node11", main_configs=["configs/enable_keeper11_large_chunk_s3.xml"], user_configs=[_small_buf_cfg], stay_alive=True, with_minio=True, with_remote_database_disk=False)
 node12 = cluster.add_instance("node12", main_configs=["configs/enable_keeper12_large_chunk_s3.xml", "configs/text_log.xml"], user_configs=[_small_buf_cfg], stay_alive=True, with_minio=True, with_remote_database_disk=False)
 
-# compat: old-version leader (no chunking support), new-version follower
-compat1 = cluster.add_instance("compat1", main_configs=["configs/enable_keeper_compat1.xml"], stay_alive=True, image="clickhouse/clickhouse-server", tag=CLICKHOUSE_CI_MIN_TESTED_VERSION, with_installed_binary=True, with_remote_database_disk=False)
+# compat: old-version leader (no chunking support), new-version follower.
+# The old leaders get quorum_reads because their pinned images predate the read-vs-session-close
+# fix and can drop a local read without a response. Followers under test keep the default.
+compat1 = cluster.add_instance("compat1", main_configs=["configs/enable_keeper_compat1.xml", "configs/quorum_reads.xml"], stay_alive=True, image="clickhouse/clickhouse-server", tag=CLICKHOUSE_CI_MIN_TESTED_VERSION, with_installed_binary=True, with_remote_database_disk=False)
 compat2 = cluster.add_instance("compat2", main_configs=["configs/enable_keeper_compat2.xml"], stay_alive=True, image="clickhouse/clickhouse-server", tag=CLICKHOUSE_CI_MIN_TESTED_VERSION, with_installed_binary=True, with_remote_database_disk=False)
 compat3 = cluster.add_instance("compat3", main_configs=["configs/enable_keeper_compat3.xml", "configs/text_log.xml"], stay_alive=True, with_remote_database_disk=False)
 
-compat_s3_1 = cluster.add_instance("compat_s3_1", main_configs=["configs/enable_keeper_compat_s3_1.xml"], stay_alive=True, image="clickhouse/clickhouse-server", tag="25.12", with_installed_binary=True, with_remote_database_disk=False)
+compat_s3_1 = cluster.add_instance("compat_s3_1", main_configs=["configs/enable_keeper_compat_s3_1.xml", "configs/quorum_reads.xml"], stay_alive=True, image="clickhouse/clickhouse-server", tag="25.12", with_installed_binary=True, with_remote_database_disk=False)
 compat_s3_2 = cluster.add_instance("compat_s3_2", main_configs=["configs/enable_keeper_compat_s3_2.xml"], stay_alive=True, image="clickhouse/clickhouse-server", tag="25.12", with_installed_binary=True, with_remote_database_disk=False)
 compat_s3_3 = cluster.add_instance("compat_s3_3", main_configs=["configs/enable_keeper_compat_s3_3.xml", "configs/text_log.xml"], user_configs=[_small_buf_cfg], stay_alive=True, with_minio=True, with_remote_database_disk=False)
 

--- a/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
+++ b/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
@@ -370,6 +370,16 @@ def test_recover_from_snapshot_sent_by_old_leader(started_cluster, nodes):
     node_lagging = nodes["lagging"]
     prefix = "/test_compat_snapshot_transfer"
 
+    # cleanup_test_tree below is already a read on the old leader, so the setting that makes
+    # its reads terminate has to be asserted before it, not after. wait_complete_readiness is
+    # off because its readiness probe is itself such a read.
+    keeper_utils.wait_until_connected(cluster, node_old_leader, wait_complete_readiness=False)
+    keeper_utils.wait_until_connected(cluster, node_lagging, wait_complete_readiness=False)
+    assert get_coordination_setting(node_old_leader, "quorum_reads") == "true", \
+        f"{node_old_leader.name} runs a pinned image and must serve reads through Raft"
+    assert get_coordination_setting(node_lagging, "quorum_reads") == "false", \
+        f"{node_lagging.name} is the node under test and must keep local reads"
+
     cleanup_test_tree(cluster, node_old_leader, prefix)
 
     kill_time = get_kill_timestamp(node_lagging)
@@ -381,14 +391,6 @@ def test_recover_from_snapshot_sent_by_old_leader(started_cluster, nodes):
     node_lagging.start_clickhouse(RESTART_TIMEOUT_SECONDS)
     keeper_utils.wait_until_connected(cluster, node_lagging)
     received = get_received_snapshot_info(node_lagging, kill_time)
-
-    # The reads below only terminate because the pinned leader serves them through Raft, so
-    # assert that on the server: losing configs/quorum_reads.xml must fail here rather than
-    # silently reintroduce a 900 s hang.
-    assert get_coordination_setting(node_old_leader, "quorum_reads") == "true", \
-        f"{node_old_leader.name} runs a pinned image and must serve reads through Raft"
-    assert get_coordination_setting(node_lagging, "quorum_reads") == "false", \
-        f"{node_lagging.name} is the node under test and must keep local reads"
 
     leader_zk = keeper_utils.get_fake_zk(cluster, node_old_leader.name)
     lagging_zk = keeper_utils.get_fake_zk(cluster, node_lagging.name)

--- a/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
+++ b/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
@@ -106,6 +106,16 @@ COMPAT_PARAMS = [
 ]
 
 
+def get_coordination_setting(node, name):
+    """Read an effective coordination setting from a running server via the 'conf' 4LW command."""
+    data = keeper_utils.send_4lw_cmd(cluster, node, cmd="conf")
+    settings = dict(
+        line.split("=", 1) for line in data.split("\n") if "=" in line
+    )
+    assert name in settings, f"'{name}' absent from 'conf' output of {node.name}: {data}"
+    return settings[name]
+
+
 @pytest.mark.parametrize("nodes", CHUNKED_TRANSFER_PARAMS)
 def test_recover_from_snapshot_with_chunked_transfer(started_cluster, nodes):
     node_leader = nodes["leader"]
@@ -371,6 +381,14 @@ def test_recover_from_snapshot_sent_by_old_leader(started_cluster, nodes):
     node_lagging.start_clickhouse(RESTART_TIMEOUT_SECONDS)
     keeper_utils.wait_until_connected(cluster, node_lagging)
     received = get_received_snapshot_info(node_lagging, kill_time)
+
+    # The reads below only terminate because the pinned leader serves them through Raft, so
+    # assert that on the server: losing configs/quorum_reads.xml must fail here rather than
+    # silently reintroduce a 900 s hang.
+    assert get_coordination_setting(node_old_leader, "quorum_reads") == "true", \
+        f"{node_old_leader.name} runs a pinned image and must serve reads through Raft"
+    assert get_coordination_setting(node_lagging, "quorum_reads") == "false", \
+        f"{node_lagging.name} is the node under test and must keep local reads"
 
     leader_zk = keeper_utils.get_fake_zk(cluster, node_old_leader.name)
     lagging_zk = keeper_utils.get_fake_zk(cluster, node_lagging.name)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113022
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`test_keeper_snapshot_chunked_transfer/test.py::test_recover_from_snapshot_sent_by_old_leader` can
hang for the full 900 s pytest-timeout and take its whole integration shard with it.

The stall is not in the code under test. It is on `compat1` / `compat_s3_1`, pinned to the released
`25.3` and `25.12` images. Those versions park a read that arrives while a write batch is assembling
in `read_request_queue[<last write's session_id>][<that write's xid>]`, which can belong to a
different session, and `finishSession` erases that whole session entry without responding. So when a
writer session expires, a co-batched read from another session is dropped silently and the client
waits on it forever.

Master fixed that in 5eb8dd3be12cff3 ("Keeper: fix race between read requests and session close"),
which also added `tests/integration/test_keeper_read_during_close`. Neither image has it, so nothing
needs fixing in `src/`.

In both pinned versions the only `read_request_queue` insertion is guarded by `!quorum_reads`, and the
branch above it routes the read through the write path when that setting is on. This PR sets it on
those two instances only, making the dropping path unreachable for every read they serve. The
followers under test and the quorum fillers keep the default local reads.

Bumping the images instead does not work: the earliest release carrying that commit is `26.4`, which
is also the earliest release shipping `snapshot_transfer_chunk_size`, so it stops being a leader
without chunking and the test's `n_chunks == 1` premise disappears.

The test also asserts the effective setting read back from both servers via the 4LW `conf` command, so
a later edit that drops the fragment fails there instead of silently restoring the hang. No existing
assertion is weakened.

Not addressed: `helpers/kazoo_client.py` calls `AsyncResult.get()` with no timeout, so a future lost
response would still burn 900 s. That unbounded wait is what lets `test_keeper_read_during_close`
detect a stuck reader, and 61 files reach it through `get_fake_zk`.

<details>
<summary>Validation</summary>

Config: `quorum_reads` present on exactly `compat1` + `compat_s3_1`, absent on the other four, and
the merged effective config (4LW `conf`) still carries `operation_timeout_ms`, `session_timeout_ms`,
`snapshot_distance`, `stale_log_gap`, `reserved_log_items` on both, so the fragment adds a setting
rather than replacing the generated block.

Mechanism, oracle = 4LW `lgif` `last_log_idx` (a quorum read is appended to the Raft log, a local
read is not). 40 reads per node:

| arm | compat1 (25.3) | compat_s3_1 (25.12) | compat3 (current build) |
|---|---|---|---|
| with fragment | +40 | +40 | +0 |
| fragment set to `false` | +0 | +0 | +0 |

A one-write control advances the index by 1 on every node in both arms, so the oracle is not
vacuous. (`Processing requests batch` is not usable here: `LOG_TRACE` in 25.3 but `LOG_TEST` in
25.12.)

Runs: both parametrizations 20/20 over 10 repeats; `test_keeper_read_during_close`,
`test_keeper_snapshot_chunked_transfer/test_concurrent.py` and
`test_keeper_snapshot_rotation_race/test.py` all pass unchanged.

Cost: `[local_disk]` 38.4 s -> 39.8 s, `[remote_disk]` 32.2 s -> 36.7 s, module 119.9 s -> 126.5 s.

</details>


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.14.13`
<!-- ch-version-info:end -->