### PR TITLE
Fix spurious PreconditionFailed on a retried Iceberg metadata write

### DIFF
--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -554,7 +554,12 @@ Model::CompleteMultipartUploadOutcome Client::CompleteMultipartUpload(CompleteMu
     const auto & key = request.GetKey();
     const auto & bucket = request.GetBucket();
 
+    /// For a conditional completion mere existence proves nothing: the object may be the one the
+    /// condition was meant to reject. Leave the error for the caller, which can verify authorship.
+    const bool is_conditional = request.IfNoneMatchHasBeenSet() || request.IfMatchHasBeenSet();
+
     if (!outcome.IsSuccess()
+        && !is_conditional
         && outcome.GetError().GetErrorType() == Aws::S3::S3Errors::NO_SUCH_UPLOAD)
     {
         auto check_request = HeadObjectRequest()

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -694,12 +694,15 @@ bool WriteBufferFromS3::completeMultipartUpload()
 
         const auto & error = outcome.GetError();
 
-        /// A 412 on our own object means this completion was replayed after it had succeeded.
-        /// Anything we cannot prove we wrote is a pre-existing object and must still throw.
-        if (error.GetExceptionName() == "PreconditionFailed" && isObjectWrittenByThisBuffer())
+        /// A 412, or a NO_SUCH_UPLOAD reporting an upload id the server already consumed, on our own
+        /// object means this completion was replayed after it had succeeded. Anything we cannot prove
+        /// we wrote is a pre-existing object and must still throw.
+        const bool replayed_after_success = error.GetExceptionName() == "PreconditionFailed"
+            || error.GetErrorType() == Aws::S3::S3Errors::NO_SUCH_UPLOAD;
+        if (replayed_after_success && isObjectWrittenByThisBuffer())
         {
-            LOG_INFO(log, "Multipart upload has completed by an earlier attempt of this write. {}, Parts: {}",
-                     getShortLogDetails(), multipart_tags.size());
+            LOG_INFO(log, "Multipart upload has completed by an earlier attempt of this write ({}). {}, Parts: {}",
+                     error.GetExceptionName(), getShortLogDetails(), multipart_tags.size());
             return true;
         }
 

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -420,8 +420,9 @@ void WriteBufferFromS3::createMultipartUpload()
     /// If we don't do it, AWS SDK can mistakenly set it to application/xml, see https://github.com/aws/aws-sdk-cpp/issues/1840
     req.SetContentType("binary/octet-stream");
 
-    if (object_metadata.has_value())
-        req.SetMetadata(object_metadata.value());
+    /// Metadata set here lands on the completed object, so a HEAD after completion sees the token.
+    if (auto metadata = metadataWithWriteToken())
+        req.SetMetadata(*metadata);
 
     /// The storage class of a multipart-uploaded object is determined by the CreateMultipartUpload
     /// request; it cannot be set on UploadPart or CompleteMultipartUpload. See issue #68551.
@@ -692,6 +693,16 @@ bool WriteBufferFromS3::completeMultipartUpload()
         ProfileEvents::increment(ProfileEvents::WriteBufferFromS3RequestsErrors, 1);
 
         const auto & error = outcome.GetError();
+
+        /// A 412 on our own object means this completion was replayed after it had succeeded.
+        /// Anything we cannot prove we wrote is a pre-existing object and must still throw.
+        if (error.GetExceptionName() == "PreconditionFailed" && isObjectWrittenByThisBuffer())
+        {
+            LOG_INFO(log, "Multipart upload has completed by an earlier attempt of this write. {}, Parts: {}",
+                     getShortLogDetails(), multipart_tags.size());
+            return true;
+        }
+
         if (isTransientCompleteMultipartUploadError(error))
         {
             last_error_type = error.GetErrorType();
@@ -724,14 +735,8 @@ S3::PutObjectRequest WriteBufferFromS3::getPutRequest(PartData & data)
     req.SetKey(key);
     req.SetContentLength(data.data_size);
     req.SetBody(data.createAwsBuffer());
-    if (!write_token.empty())
-    {
-        auto metadata = object_metadata.value_or(ObjectAttributes{});
-        metadata[WRITE_TOKEN_METADATA_KEY] = write_token;
-        req.SetMetadata(metadata);
-    }
-    else if (object_metadata.has_value())
-        req.SetMetadata(object_metadata.value());
+    if (auto metadata = metadataWithWriteToken())
+        req.SetMetadata(*metadata);
     if (!request_settings[S3RequestSetting::storage_class_name].value.empty())
         req.SetStorageClass(Aws::S3::Model::StorageClassMapper::GetStorageClassForName(request_settings[S3RequestSetting::storage_class_name]));
 
@@ -747,6 +752,16 @@ S3::PutObjectRequest WriteBufferFromS3::getPutRequest(PartData & data)
     client_ptr->setKMSHeaders(req);
 
     return req;
+}
+
+std::optional<ObjectAttributes> WriteBufferFromS3::metadataWithWriteToken() const
+{
+    if (write_token.empty())
+        return object_metadata;
+
+    auto metadata = object_metadata.value_or(ObjectAttributes{});
+    metadata[WRITE_TOKEN_METADATA_KEY] = write_token;
+    return metadata;
 }
 
 bool WriteBufferFromS3::isObjectWrittenByThisBuffer() const

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -18,6 +18,7 @@
 #include <IO/S3/Requests.h>
 #include <IO/S3/getObjectInfo.h>
 #include <Common/BlobStorageLogWriter.h>
+#include <Common/getRandomASCIIString.h>
 
 #include <utility>
 
@@ -65,6 +66,9 @@ namespace ErrorCodes
     extern const int INVALID_CONFIG_PARAMETER;
     extern const int LOGICAL_ERROR;
 }
+
+/// Custom object metadata key carrying the write token, see WriteBufferFromS3::write_token.
+static constexpr auto WRITE_TOKEN_METADATA_KEY = "clickhouse-write-token";
 
 struct WriteBufferFromS3::PartData
 {
@@ -115,6 +119,7 @@ WriteBufferFromS3::WriteBufferFromS3(
     , write_settings(write_settings_)
     , client_ptr(std::move(client_ptr_))
     , object_metadata(std::move(object_metadata_))
+    , write_token(write_settings.object_storage_write_if_none_match.empty() ? "" : getRandomASCIIString(32))
     , buffer_allocation_policy(createBufferAllocationPolicy(request_settings))
     , task_tracker(
           std::make_unique<TaskTracker>(
@@ -719,7 +724,13 @@ S3::PutObjectRequest WriteBufferFromS3::getPutRequest(PartData & data)
     req.SetKey(key);
     req.SetContentLength(data.data_size);
     req.SetBody(data.createAwsBuffer());
-    if (object_metadata.has_value())
+    if (!write_token.empty())
+    {
+        auto metadata = object_metadata.value_or(ObjectAttributes{});
+        metadata[WRITE_TOKEN_METADATA_KEY] = write_token;
+        req.SetMetadata(metadata);
+    }
+    else if (object_metadata.has_value())
         req.SetMetadata(object_metadata.value());
     if (!request_settings[S3RequestSetting::storage_class_name].value.empty())
         req.SetStorageClass(Aws::S3::Model::StorageClassMapper::GetStorageClassForName(request_settings[S3RequestSetting::storage_class_name]));
@@ -736,6 +747,25 @@ S3::PutObjectRequest WriteBufferFromS3::getPutRequest(PartData & data)
     client_ptr->setKMSHeaders(req);
 
     return req;
+}
+
+bool WriteBufferFromS3::isObjectWrittenByThisBuffer() const
+{
+    if (write_token.empty())
+        return false;
+
+    try
+    {
+        auto info = S3::getObjectInfoIfExists(*client_ptr, bucket, key, /* version_id = */ {}, /* with_metadata = */ true);
+        auto it = info.metadata.find(WRITE_TOKEN_METADATA_KEY);
+        return it != info.metadata.end() && it->second == write_token;
+    }
+    catch (...)
+    {
+        /// Report the original write error rather than a confusing read error.
+        tryLogCurrentException(log, "Failed to verify the write token of " + key);
+        return false;
+    }
 }
 
 void WriteBufferFromS3::makeSinglepartUpload(WriteBufferFromS3::PartData && data)
@@ -791,8 +821,19 @@ void WriteBufferFromS3::makeSinglepartUpload(WriteBufferFromS3::PartData && data
                 /// PreconditionFailed is an expected response for conditional writes (e.g. If-None-Match: *),
                 /// not a genuine error — the caller handles it.
                 if (outcome.GetError().GetExceptionName() == "PreconditionFailed")
+                {
+                    /// A 412 on our own object means this PUT was replayed after it had succeeded.
+                    /// Anything we cannot prove we wrote is a pre-existing object and must still throw.
+                    if (isObjectWrittenByThisBuffer())
+                    {
+                        LOG_INFO(log, "Single part upload has completed by an earlier attempt of this write. {}, size {}",
+                                 getShortLogDetails(), content_length);
+                        return;
+                    }
+
                     LOG_INFO(log, "S3Exception name {}, Message: {}, bucket {}, key {}, object size {}",
                               outcome.GetError().GetExceptionName(), outcome.GetError().GetMessage(), bucket, key, content_length);
+                }
                 else
                     LOG_ERROR(log, "S3Exception name {}, Message: {}, bucket {}, key {}, object size {}",
                               outcome.GetError().GetExceptionName(), outcome.GetError().GetMessage(), bucket, key, content_length);

--- a/src/IO/WriteBufferFromS3.h
+++ b/src/IO/WriteBufferFromS3.h
@@ -79,6 +79,10 @@ private:
     S3::PutObjectRequest getPutRequest(PartData & data);
     void makeSinglepartUpload(PartData && data);
 
+    /// True only if the object stored under `key` carries this buffer's `write_token`, i.e. this
+    /// buffer wrote it. Absent object, absent or foreign token, or a failed HEAD all give false.
+    bool isObjectWrittenByThisBuffer() const;
+
     /// Returns true if not a single byte was written to the buffer
     bool isEmpty() const { return total_size == 0 && count() == 0 && hidden_size == 0 && offset() == 0; }
 
@@ -88,6 +92,9 @@ private:
     const WriteSettings write_settings;
     const std::shared_ptr<const S3::Client> client_ptr;
     const std::optional<ObjectAttributes> object_metadata;
+    /// Identifies this buffer's conditional create-if-absent write; empty when the write is not
+    /// conditional. Sent as custom object metadata so a replayed PUT can recognise its own object.
+    const String write_token;
     LoggerPtr log = getLogger("WriteBufferFromS3");
     LogSeriesLimiterPtr limited_log = std::make_shared<LogSeriesLimiter>(log, 1, 5);
 

--- a/src/IO/WriteBufferFromS3.h
+++ b/src/IO/WriteBufferFromS3.h
@@ -79,6 +79,9 @@ private:
     S3::PutObjectRequest getPutRequest(PartData & data);
     void makeSinglepartUpload(PartData && data);
 
+    /// `object_metadata` with `write_token` merged in when the write is conditional.
+    std::optional<ObjectAttributes> metadataWithWriteToken() const;
+
     /// True only if the object stored under `key` carries this buffer's `write_token`, i.e. this
     /// buffer wrote it. Absent object, absent or foreign token, or a failed HEAD all give false.
     bool isObjectWrittenByThisBuffer() const;

--- a/src/IO/tests/gtest_writebuffer_s3.cpp
+++ b/src/IO/tests/gtest_writebuffer_s3.cpp
@@ -723,6 +723,41 @@ struct CompleteMPUPreconditionFailedInjection : InjectionModel
     std::vector<BucketMemStore::Metadata> seen_create_metadata;
 };
 
+/// Reports `NO_SUCH_UPLOAD` on every CompleteMultipartUpload, optionally completing the upload
+/// server-side first -- the shape of an upload id the server has already consumed. Records the
+/// `If-None-Match` of every attempt because this injection serves conditional and unconditional arms.
+struct CompleteMPUNoSuchUploadInjection : InjectionModel
+{
+    CompleteMPUNoSuchUploadInjection(std::shared_ptr<S3MemStrore> store_, bool complete_first_attempt_)
+        : store(std::move(store_)), complete_first_attempt(complete_first_attempt_) {}
+
+    std::optional<Aws::S3::Model::CompleteMultipartUploadOutcome> call(
+        const Aws::S3::Model::CompleteMultipartUploadRequest & request) override
+    {
+        seen_if_none_match.push_back(request.GetIfNoneMatch());
+
+        if (complete_first_attempt && calls == 0)
+        {
+            std::vector<std::string> etags;
+            for (const auto & part : request.GetMultipartUpload().GetParts())
+                etags.push_back(part.GetETag());
+            store->GetBucketStore(request.GetBucket()).CompleteMPU(request.GetKey(), request.GetUploadId(), etags);
+        }
+        ++calls;
+
+        return Aws::Client::AWSError<Aws::S3::S3Errors>(
+            Aws::S3::S3Errors::NO_SUCH_UPLOAD,
+            "NoSuchUpload",
+            "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
+            false);
+    }
+
+    std::shared_ptr<S3MemStrore> store;
+    bool complete_first_attempt;
+    size_t calls = 0;
+    std::vector<std::string> seen_if_none_match;
+};
+
 struct BaseSyncPolicy
 {
     virtual ~BaseSyncPolicy() = default;
@@ -847,6 +882,14 @@ public:
     {
         WriteSettings write_settings;
         write_settings.object_storage_write_if_none_match = "*";
+        return write_settings;
+    }
+
+    /// The Iceberg conditional replace-this-version write: `If-Match: <etag>`, no token minted.
+    static WriteSettings conditionalReplaceWriteSettings()
+    {
+        WriteSettings write_settings;
+        write_settings.object_storage_write_if_match = "some-etag";
         return write_settings;
     }
 
@@ -1362,6 +1405,117 @@ TEST_P(SyncAsync, MultipartConditionalCompleteDoesNotMaskForeignObject) {
     /// CreateMultipartUpload carried a token, so the guard had something to compare and rejected it.
     ASSERT_FALSE(injection->seen_create_metadata.empty());
     EXPECT_FALSE(injection->seen_create_metadata[0].at("clickhouse-write-token").empty());
+}
+
+/// The other door into the same replay: a completion that already landed can come back as
+/// `NO_SUCH_UPLOAD` (consumed upload id) instead of 412. On our own object that is still success.
+TEST_P(SyncAsync, MultipartConditionalCompleteRecoversNoSuchUploadOnOwnObject) {
+    setInjectionModel(std::make_shared<MockS3::CompleteMPUNoSuchUploadInjection>(
+        client->store, /* complete_first_attempt= */ true));
+
+    getSettings()[Setting::s3_max_single_part_upload_size] = 0; // force the multipart path
+    getSettings()[Setting::s3_min_upload_part_size] = 1;
+
+    auto buffer = getWriteBuffer("conditional_mpu_no_such_upload", conditionalCreateWriteSettings());
+    buffer->write('A');
+
+    getAsyncPolicy().setAutoExecute(true);
+    buffer->finalize();
+
+    /// The token was consulted rather than existence assumed, and the completed upload is not aborted.
+    EXPECT_GE(client->counters.headObject, 1u);
+    EXPECT_EQ(client->counters.multiUploadAbort, 0u);
+
+    auto & bStore = client->store->GetBucketStore(bucket);
+    EXPECT_EQ(bStore.objects["conditional_mpu_no_such_upload"], "A");
+    EXPECT_FALSE(bStore.object_metadata["conditional_mpu_no_such_upload"].at("clickhouse-write-token").empty());
+}
+
+/// The same `NO_SUCH_UPLOAD` over an object somebody else wrote must still fail: existence at the key
+/// is not authorship, and reporting success would let a conditional create silently lose its payload.
+TEST_P(SyncAsync, MultipartConditionalCompleteDoesNotMaskForeignObjectOnNoSuchUpload) {
+    auto & bStore = client->store->GetBucketStore(bucket);
+    bStore.PutObject("conditional_mpu_no_such_upload_foreign", "A", {{"clickhouse-write-token", "written-by-somebody-else"}});
+
+    auto injection = std::make_shared<MockS3::CompleteMPUNoSuchUploadInjection>(
+        client->store, /* complete_first_attempt= */ false);
+    setInjectionModel(injection);
+
+    getSettings()[Setting::s3_max_single_part_upload_size] = 0; // force the multipart path
+    getSettings()[Setting::s3_min_upload_part_size] = 1;
+
+    EXPECT_THROW({
+        try {
+            auto buffer = getWriteBuffer("conditional_mpu_no_such_upload_foreign", conditionalCreateWriteSettings());
+            buffer->write('A');
+
+            getAsyncPolicy().setAutoExecute(true);
+            buffer->finalize();
+        }
+        catch (const DB::Exception & e)
+        {
+            ASSERT_EQ(ErrorCodes::S3_ERROR, e.code());
+            EXPECT_THAT(e.what(), testing::HasSubstr("The specified upload does not exist"));
+            throw;
+        }
+      }, DB::S3Exception);
+
+    EXPECT_EQ(bStore.objects["conditional_mpu_no_such_upload_foreign"], "A");
+    EXPECT_EQ(
+        bStore.object_metadata["conditional_mpu_no_such_upload_foreign"].at("clickhouse-write-token"),
+        "written-by-somebody-else");
+    ASSERT_FALSE(injection->seen_if_none_match.empty());
+    EXPECT_EQ(injection->seen_if_none_match[0], "*");
+}
+
+/// `If-Match` is conditional too, and it mints no write token, so nothing can prove authorship: the
+/// existence-only recovery must not fire there either.
+TEST_P(SyncAsync, MultipartIfMatchCompleteDoesNotRecoverNoSuchUpload) {
+    setInjectionModel(std::make_shared<MockS3::CompleteMPUNoSuchUploadInjection>(
+        client->store, /* complete_first_attempt= */ true));
+
+    getSettings()[Setting::s3_max_single_part_upload_size] = 0; // force the multipart path
+    getSettings()[Setting::s3_min_upload_part_size] = 1;
+
+    EXPECT_THROW({
+        try {
+            auto buffer = getWriteBuffer("conditional_mpu_if_match", conditionalReplaceWriteSettings());
+            buffer->write('A');
+
+            getAsyncPolicy().setAutoExecute(true);
+            buffer->finalize();
+        }
+        catch (const DB::Exception & e)
+        {
+            ASSERT_EQ(ErrorCodes::S3_ERROR, e.code());
+            EXPECT_THAT(e.what(), testing::HasSubstr("The specified upload does not exist"));
+            throw;
+        }
+      }, DB::S3Exception);
+}
+
+/// An unconditional completion keeps the existing recover-if-the-object-exists behaviour, which backs
+/// copyS3File and the disk write paths: the conditional gate must not change them.
+TEST_P(SyncAsync, MultipartUnconditionalCompleteStillRecoversNoSuchUpload) {
+    setInjectionModel(std::make_shared<MockS3::CompleteMPUNoSuchUploadInjection>(
+        client->store, /* complete_first_attempt= */ true));
+
+    getSettings()[Setting::s3_max_single_part_upload_size] = 0; // force the multipart path
+    getSettings()[Setting::s3_min_upload_part_size] = 1;
+
+    auto buffer = getWriteBuffer("unconditional_mpu_no_such_upload");
+    buffer->write('A');
+
+    getAsyncPolicy().setAutoExecute(true);
+    buffer->finalize();
+
+    /// Recovered by the wrapper's own HEAD, with no token to look up.
+    EXPECT_GE(client->counters.headObject, 1u);
+    EXPECT_EQ(client->counters.multiUploadAbort, 0u);
+
+    auto & bStore = client->store->GetBucketStore(bucket);
+    EXPECT_EQ(bStore.objects["unconditional_mpu_no_such_upload"], "A");
+    EXPECT_FALSE(bStore.object_metadata["unconditional_mpu_no_such_upload"].contains("clickhouse-write-token"));
 }
 
 /// A transient MinIO `InvalidPart` on CompleteMultipartUpload must be retried, not surfaced as a

--- a/src/IO/tests/gtest_writebuffer_s3.cpp
+++ b/src/IO/tests/gtest_writebuffer_s3.cpp
@@ -91,9 +91,12 @@ public:
     using MPU_ID = std::string;
     using MPUPartsInProgress = std::map<ETag, Data>;
     using MPUParts = std::vector<Data>;
+    using Metadata = std::map<std::string, std::string>;
 
 
     std::map<Key, Data> objects;
+    /// Custom object metadata (`x-amz-meta-*`), stored alongside the object and served by HeadObject.
+    std::map<Key, Metadata> object_metadata;
     std::map<MPU_ID, MPUPartsInProgress> multiPartUploads;
     std::vector<std::pair<MPU_ID, MPUParts>> CompletedPartUploads;
 
@@ -114,9 +117,10 @@ public:
         return etag;
     }
 
-    void PutObject(const std::string & key, const std::string & data)
+    void PutObject(const std::string & key, const std::string & data, const Metadata & metadata = {})
     {
         objects[key] = data;
+        object_metadata[key] = metadata;
     }
 
     void CompleteMPU(const std::string & key, const std::string & upload_id, const std::vector<std::string> & etags)
@@ -306,7 +310,10 @@ struct Client : DB::S3::Client
 
         auto & bStore = store->GetBucketStore(request.GetBucket());
         const std::string data = readRequestBody(request.GetBody(), request.GetContentLength());
-        bStore.PutObject(request.GetKey(), data);
+        BucketMemStore::Metadata metadata;
+        for (const auto & [name, value] : request.GetMetadata())
+            metadata[name] = value;
+        bStore.PutObject(request.GetKey(), data, metadata);
         counters.writtenSize += data.length();
 
         Aws::S3::Model::PutObjectOutcome outcome;
@@ -358,6 +365,13 @@ struct Client : DB::S3::Client
         Aws::S3::Model::HeadObjectOutcome outcome;
         Aws::S3::Model::HeadObjectResult result(outcome.GetResultWithOwnership());
         result.SetContentLength(obj.length());
+        if (auto it = bStore.object_metadata.find(request.GetKey()); it != bStore.object_metadata.end())
+        {
+            Aws::Map<Aws::String, Aws::String> metadata;
+            for (const auto & [name, value] : it->second)
+                metadata[name] = value;
+            result.SetMetadata(std::move(metadata));
+        }
         return result;
     }
 
@@ -560,6 +574,69 @@ struct CompleteMPUInvalidPartOnceIngection : InjectionModel
     size_t calls = 0;
 };
 
+/// `PreconditionFailed` as the SDK actually produces it: 412 carries an <Code>PreconditionFailed</Code>
+/// that has no typed S3 model error, so AWSErrorMarshaller yields UNKNOWN and keeps the raw code in the
+/// exception name only -- the shape WriteBufferFromS3 must recognise.
+inline Aws::Client::AWSError<Aws::Client::CoreErrors> makePreconditionFailedError()
+{
+    return Aws::Client::AWSError<Aws::Client::CoreErrors>(
+        Aws::Client::CoreErrors::UNKNOWN,
+        "PreconditionFailed",
+        "At least one of the pre-conditions you specified did not hold",
+        false);
+}
+
+/// Replays the lost-response scenario for a conditional (`If-None-Match: *`) PutObject: the first
+/// attempt lands the object server-side but its response is lost, reported as the bogus MinIO
+/// NO_SUCH_KEY that WriteBufferFromS3 retries; the replay then sees the object it just wrote and gets
+/// 412. Records the metadata of every request so a test can assert what was stamped.
+struct PutObjectLostResponseThenPreconditionFailed : InjectionModel
+{
+    PutObjectLostResponseThenPreconditionFailed(std::shared_ptr<S3MemStrore> store_, bool store_first_attempt_)
+        : store(std::move(store_)), store_first_attempt(store_first_attempt_) {}
+
+    std::optional<Aws::S3::Model::PutObjectOutcome> call(const Aws::S3::Model::PutObjectRequest & request) override
+    {
+        BucketMemStore::Metadata metadata;
+        for (const auto & [name, value] : request.GetMetadata())
+            metadata[name] = value;
+        seen_metadata.push_back(metadata);
+
+        if (calls++ > 0)
+            return makePreconditionFailedError();
+
+        if (store_first_attempt)
+        {
+            const std::string data = readRequestBody(request.GetBody(), request.GetContentLength());
+            store->GetBucketStore(request.GetBucket()).PutObject(request.GetKey(), data, metadata);
+        }
+
+        return Aws::Client::AWSError<Aws::S3::S3Errors>(
+            Aws::S3::S3Errors::NO_SUCH_KEY, "NoSuchKey", "The specified key does not exist.", false);
+    }
+
+    std::shared_ptr<S3MemStrore> store;
+    bool store_first_attempt;
+    size_t calls = 0;
+    std::vector<BucketMemStore::Metadata> seen_metadata;
+};
+
+/// Every conditional PutObject attempt fails with 412 -- a genuinely pre-existing object, written by
+/// somebody else. Records request metadata so a test can assert what was stamped.
+struct PutObjectPreconditionFailedInjection : InjectionModel
+{
+    std::optional<Aws::S3::Model::PutObjectOutcome> call(const Aws::S3::Model::PutObjectRequest & request) override
+    {
+        BucketMemStore::Metadata metadata;
+        for (const auto & [name, value] : request.GetMetadata())
+            metadata[name] = value;
+        seen_metadata.push_back(metadata);
+        return makePreconditionFailedError();
+    }
+
+    std::vector<BucketMemStore::Metadata> seen_metadata;
+};
+
 struct BaseSyncPolicy
 {
     virtual ~BaseSyncPolicy() = default;
@@ -655,7 +732,10 @@ public:
         return *async_policy;
     }
 
-    std::unique_ptr<WriteBufferFromS3> getWriteBuffer(String file_name = "file")
+    std::unique_ptr<WriteBufferFromS3> getWriteBuffer(
+        String file_name = "file",
+        const WriteSettings & write_settings = {},
+        std::optional<ObjectAttributes> object_metadata = std::nullopt)
     {
         S3::S3RequestSettings request_settings;
         request_settings.updateFromSettings(settings, /* if_changed */true, /* validate_settings */false);
@@ -671,8 +751,17 @@ public:
                     DBMS_DEFAULT_BUFFER_SIZE,
                     request_settings,
                     nullptr,
-                    std::nullopt,
-                    getAsyncPolicy().getScheduler());
+                    std::move(object_metadata),
+                    getAsyncPolicy().getScheduler(),
+                    write_settings);
+    }
+
+    /// The Iceberg conditional create-if-absent write: `If-None-Match: *`.
+    static WriteSettings conditionalCreateWriteSettings()
+    {
+        WriteSettings write_settings;
+        write_settings.object_storage_write_if_none_match = "*";
+        return write_settings;
     }
 
     void setInjectionModel(std::shared_ptr<MockS3::InjectionModel> injections_)
@@ -931,6 +1020,120 @@ TEST_P(SyncAsync, ExceptionOnCompleteMPU) {
             throw;
         }
       }, DB::S3Exception);
+}
+
+/// A conditional (`If-None-Match: *`) PutObject replayed after it already succeeded must report
+/// success, not the spurious `PreconditionFailed` the replay gets back. Regression test for the
+/// `Code: 499 ... PreconditionFailed` flake on Iceberg `CREATE TABLE` / commit. The injection lands the
+/// object on attempt 1 but reports the bogus MinIO NO_SUCH_KEY (lost response), so WriteBufferFromS3
+/// retries and the replay sees its own object. Without the write-token recovery the 412 is thrown
+/// straight through and this test fails.
+TEST_P(SyncAsync, SinglepartConditionalPutRetryAfterLostResponse) {
+    auto injection = std::make_shared<MockS3::PutObjectLostResponseThenPreconditionFailed>(
+        client->store, /* store_first_attempt= */ true);
+    setInjectionModel(injection);
+
+    auto buffer = getWriteBuffer("conditional_put_lost_response", conditionalCreateWriteSettings());
+    buffer->write('A');
+
+    getAsyncPolicy().setAutoExecute(true);
+    buffer->finalize();
+
+    /// Two PUT attempts (NO_SUCH_KEY then 412) and one HEAD that verified our own write token.
+    EXPECT_EQ(client->counters.putObject, 2u);
+    EXPECT_EQ(client->counters.headObject, 1u);
+
+    auto & bStore = client->store->GetBucketStore(bucket);
+    EXPECT_EQ(bStore.objects["conditional_put_lost_response"], "A");
+
+    /// Both attempts carried the same token, and it is the one stored with the object.
+    ASSERT_EQ(injection->seen_metadata.size(), 2u);
+    const auto token = injection->seen_metadata[0].at("clickhouse-write-token");
+    EXPECT_FALSE(token.empty());
+    EXPECT_EQ(injection->seen_metadata[1].at("clickhouse-write-token"), token);
+    EXPECT_EQ(bStore.object_metadata["conditional_put_lost_response"].at("clickhouse-write-token"), token);
+}
+
+/// The recovery above must not weaken the compare-and-swap: a 412 caused by an object this request did
+/// NOT write must still fail. The pre-existing object is byte-identical to the payload -- deliberately
+/// the literal "1" Iceberg writes to `version-hint.text`, which two independent creators produce
+/// identically -- so a size or byte comparison would wrongly accept it and mask TABLE_ALREADY_EXISTS.
+TEST_P(SyncAsync, SinglepartConditionalPutDoesNotMaskForeignObject) {
+    auto & bStore = client->store->GetBucketStore(bucket);
+    bStore.PutObject("conditional_put_foreign", "1", {{"clickhouse-write-token", "written-by-somebody-else"}});
+
+    auto injection = std::make_shared<MockS3::PutObjectPreconditionFailedInjection>();
+    setInjectionModel(injection);
+
+    EXPECT_THROW({
+        try {
+            auto buffer = getWriteBuffer("conditional_put_foreign", conditionalCreateWriteSettings());
+            buffer->write('1');
+
+            getAsyncPolicy().setAutoExecute(true);
+            buffer->finalize();
+        }
+        catch (const DB::Exception & e)
+        {
+            ASSERT_EQ(ErrorCodes::S3_ERROR, e.code());
+            /// The thrown message carries the 412 text; the exception name is logged, not rethrown.
+            EXPECT_THAT(e.what(), testing::HasSubstr("pre-conditions you specified did not hold"));
+            throw;
+        }
+      }, DB::S3Exception);
+
+    /// The foreign object is untouched.
+    EXPECT_EQ(bStore.objects["conditional_put_foreign"], "1");
+    EXPECT_EQ(bStore.object_metadata["conditional_put_foreign"].at("clickhouse-write-token"), "written-by-somebody-else");
+}
+
+/// An ordinary (unconditional) S3 write is untouched: no token is stamped on the request, and a 412 is
+/// still thrown. Proves the `object_storage_write_if_none_match` guard is load-bearing.
+TEST_P(SyncAsync, SinglepartPutWithoutIfNoneMatchStillThrows) {
+    auto injection = std::make_shared<MockS3::PutObjectPreconditionFailedInjection>();
+    setInjectionModel(injection);
+
+    EXPECT_THROW({
+        try {
+            auto buffer = getWriteBuffer("unconditional_put_412");
+            buffer->write('A');
+
+            getAsyncPolicy().setAutoExecute(true);
+            buffer->finalize();
+        }
+        catch (const DB::Exception & e)
+        {
+            ASSERT_EQ(ErrorCodes::S3_ERROR, e.code());
+            /// The thrown message carries the 412 text; the exception name is logged, not rethrown.
+            EXPECT_THAT(e.what(), testing::HasSubstr("pre-conditions you specified did not hold"));
+            throw;
+        }
+      }, DB::S3Exception);
+
+    /// No token was stamped, and no HEAD was issued to look one up.
+    ASSERT_FALSE(injection->seen_metadata.empty());
+    for (const auto & metadata : injection->seen_metadata)
+        EXPECT_FALSE(metadata.contains("clickhouse-write-token"));
+    EXPECT_EQ(client->counters.headObject, 0u);
+}
+
+/// A caller-supplied `object_metadata` must survive next to the write token -- the token is merged in,
+/// never substituted for the caller's map.
+TEST_P(SyncAsync, SinglepartConditionalPutKeepsCallerMetadata) {
+    auto injection = std::make_shared<MockS3::PutObjectLostResponseThenPreconditionFailed>(
+        client->store, /* store_first_attempt= */ true);
+    setInjectionModel(injection);
+
+    auto buffer = getWriteBuffer(
+        "conditional_put_caller_metadata", conditionalCreateWriteSettings(), ObjectAttributes{{"caller-key", "caller-value"}});
+    buffer->write('A');
+
+    getAsyncPolicy().setAutoExecute(true);
+    buffer->finalize();
+
+    ASSERT_FALSE(injection->seen_metadata.empty());
+    EXPECT_EQ(injection->seen_metadata[0].at("caller-key"), "caller-value");
+    EXPECT_FALSE(injection->seen_metadata[0].at("clickhouse-write-token").empty());
 }
 
 /// A transient MinIO `InvalidPart` on CompleteMultipartUpload must be retried, not surfaced as a

--- a/src/IO/tests/gtest_writebuffer_s3.cpp
+++ b/src/IO/tests/gtest_writebuffer_s3.cpp
@@ -98,14 +98,18 @@ public:
     /// Custom object metadata (`x-amz-meta-*`), stored alongside the object and served by HeadObject.
     std::map<Key, Metadata> object_metadata;
     std::map<MPU_ID, MPUPartsInProgress> multiPartUploads;
+    /// Metadata of an in-flight upload, carried from CreateMultipartUpload onto the completed object
+    /// the way real S3 does -- that is what makes a HEAD after completion see it.
+    std::map<MPU_ID, Metadata> multiPartUploadMetadata;
     std::vector<std::pair<MPU_ID, MPUParts>> CompletedPartUploads;
 
     Sequencer sequencer;
 
-    std::string CreateMPU()
+    std::string CreateMPU(const Metadata & metadata = {})
     {
         auto id = sequencer.next_id();
         multiPartUploads.emplace(id, MPUPartsInProgress{});
+        multiPartUploadMetadata.emplace(id, metadata);
         return id;
     }
 
@@ -140,12 +144,16 @@ public:
 
         CompletedPartUploads.emplace_back(upload_id, std::move(completedParts));
         objects[key] = file_data.str();
+        if (auto it = multiPartUploadMetadata.find(upload_id); it != multiPartUploadMetadata.end())
+            object_metadata[key] = it->second;
         multiPartUploads.erase(upload_id);
+        multiPartUploadMetadata.erase(upload_id);
     }
 
     void AbortMPU(const std::string & upload_id)
     {
         multiPartUploads.erase(upload_id);
+        multiPartUploadMetadata.erase(upload_id);
     }
 
 
@@ -388,7 +396,10 @@ struct Client : DB::S3::Client
         }
 
         auto & bStore = store->GetBucketStore(request.GetBucket());
-        auto mpu_id = bStore.CreateMPU();
+        BucketMemStore::Metadata metadata;
+        for (const auto & [name, value] : request.GetMetadata())
+            metadata[name] = value;
+        auto mpu_id = bStore.CreateMPU(metadata);
 
         Aws::S3::Model::CreateMultipartUploadResult result;
         result.SetUploadId(mpu_id.c_str());
@@ -597,6 +608,8 @@ struct PutObjectLostResponseThenPreconditionFailed : InjectionModel
 
     std::optional<Aws::S3::Model::PutObjectOutcome> call(const Aws::S3::Model::PutObjectRequest & request) override
     {
+        EXPECT_FALSE(request.GetIfNoneMatch().empty());
+
         BucketMemStore::Metadata metadata;
         for (const auto & [name, value] : request.GetMetadata())
             metadata[name] = value;
@@ -621,8 +634,9 @@ struct PutObjectLostResponseThenPreconditionFailed : InjectionModel
     std::vector<BucketMemStore::Metadata> seen_metadata;
 };
 
-/// Every conditional PutObject attempt fails with 412 -- a genuinely pre-existing object, written by
-/// somebody else. Records request metadata so a test can assert what was stamped.
+/// Every PutObject attempt fails with 412 -- a genuinely pre-existing object, written by somebody
+/// else. Records the metadata and the `If-None-Match` of every request; this injection serves both
+/// the conditional and the unconditional arms, so each asserts the header it expects.
 struct PutObjectPreconditionFailedInjection : InjectionModel
 {
     std::optional<Aws::S3::Model::PutObjectOutcome> call(const Aws::S3::Model::PutObjectRequest & request) override
@@ -631,10 +645,82 @@ struct PutObjectPreconditionFailedInjection : InjectionModel
         for (const auto & [name, value] : request.GetMetadata())
             metadata[name] = value;
         seen_metadata.push_back(metadata);
+        seen_if_none_match.push_back(request.GetIfNoneMatch());
         return makePreconditionFailedError();
     }
 
     std::vector<BucketMemStore::Metadata> seen_metadata;
+    std::vector<std::string> seen_if_none_match;
+};
+
+/// A conditional PutObject that gets 412 while the HEAD used to verify the write token also fails.
+/// The write must report the original 412, never succeed on an unverifiable object.
+struct PutObjectPreconditionFailedAndHeadFailsInjection : InjectionModel
+{
+    std::optional<Aws::S3::Model::PutObjectOutcome> call(const Aws::S3::Model::PutObjectRequest & request) override
+    {
+        EXPECT_FALSE(request.GetIfNoneMatch().empty());
+        return makePreconditionFailedError();
+    }
+
+    std::optional<Aws::S3::Model::HeadObjectOutcome> call(const Aws::S3::Model::HeadObjectRequest & /*request*/) override
+    {
+        return Aws::Client::AWSError<Aws::Client::CoreErrors>(
+            Aws::Client::CoreErrors::VALIDATION, "FailInjection", "HeadObjectFailIngection", false);
+    }
+};
+
+/// Replays the lost-response scenario for a conditional CompleteMultipartUpload: the first attempt
+/// completes the upload server-side but its response is lost (reported as the MinIO NO_SUCH_KEY that
+/// WriteBufferFromS3 retries), so the replay sees the object it just wrote and gets 412.
+struct CompleteMPULostResponseThenPreconditionFailed : InjectionModel
+{
+    explicit CompleteMPULostResponseThenPreconditionFailed(std::shared_ptr<S3MemStrore> store_)
+        : store(std::move(store_)) {}
+
+    std::optional<Aws::S3::Model::CompleteMultipartUploadOutcome> call(
+        const Aws::S3::Model::CompleteMultipartUploadRequest & request) override
+    {
+        EXPECT_FALSE(request.GetIfNoneMatch().empty());
+
+        if (calls++ > 0)
+            return makePreconditionFailedError();
+
+        std::vector<std::string> etags;
+        for (const auto & part : request.GetMultipartUpload().GetParts())
+            etags.push_back(part.GetETag());
+        store->GetBucketStore(request.GetBucket()).CompleteMPU(request.GetKey(), request.GetUploadId(), etags);
+
+        return Aws::Client::AWSError<Aws::S3::S3Errors>(
+            Aws::S3::S3Errors::NO_SUCH_KEY, "NoSuchKey", "The specified key does not exist.", false);
+    }
+
+    std::shared_ptr<S3MemStrore> store;
+    size_t calls = 0;
+};
+
+/// Every conditional CompleteMultipartUpload attempt fails with 412 -- a genuinely pre-existing
+/// object. Records the metadata CreateMultipartUpload stamped so a test can assert the token.
+struct CompleteMPUPreconditionFailedInjection : InjectionModel
+{
+    std::optional<Aws::S3::Model::CreateMultipartUploadOutcome> call(
+        const Aws::S3::Model::CreateMultipartUploadRequest & request) override
+    {
+        BucketMemStore::Metadata metadata;
+        for (const auto & [name, value] : request.GetMetadata())
+            metadata[name] = value;
+        seen_create_metadata.push_back(metadata);
+        return std::nullopt;
+    }
+
+    std::optional<Aws::S3::Model::CompleteMultipartUploadOutcome> call(
+        const Aws::S3::Model::CompleteMultipartUploadRequest & request) override
+    {
+        EXPECT_FALSE(request.GetIfNoneMatch().empty());
+        return makePreconditionFailedError();
+    }
+
+    std::vector<BucketMemStore::Metadata> seen_create_metadata;
 };
 
 struct BaseSyncPolicy
@@ -1023,11 +1109,7 @@ TEST_P(SyncAsync, ExceptionOnCompleteMPU) {
 }
 
 /// A conditional (`If-None-Match: *`) PutObject replayed after it already succeeded must report
-/// success, not the spurious `PreconditionFailed` the replay gets back. Regression test for the
-/// `Code: 499 ... PreconditionFailed` flake on Iceberg `CREATE TABLE` / commit. The injection lands the
-/// object on attempt 1 but reports the bogus MinIO NO_SUCH_KEY (lost response), so WriteBufferFromS3
-/// retries and the replay sees its own object. Without the write-token recovery the 412 is thrown
-/// straight through and this test fails.
+/// success, not the spurious `PreconditionFailed` the replay gets back.
 TEST_P(SyncAsync, SinglepartConditionalPutRetryAfterLostResponse) {
     auto injection = std::make_shared<MockS3::PutObjectLostResponseThenPreconditionFailed>(
         client->store, /* store_first_attempt= */ true);
@@ -1054,10 +1136,8 @@ TEST_P(SyncAsync, SinglepartConditionalPutRetryAfterLostResponse) {
     EXPECT_EQ(bStore.object_metadata["conditional_put_lost_response"].at("clickhouse-write-token"), token);
 }
 
-/// The recovery above must not weaken the compare-and-swap: a 412 caused by an object this request did
-/// NOT write must still fail. The pre-existing object is byte-identical to the payload -- deliberately
-/// the literal "1" Iceberg writes to `version-hint.text`, which two independent creators produce
-/// identically -- so a size or byte comparison would wrongly accept it and mask TABLE_ALREADY_EXISTS.
+/// A 412 caused by an object this request did NOT write must still fail. The pre-existing object is
+/// byte-identical to the payload on purpose, so a byte or size comparison would wrongly accept it.
 TEST_P(SyncAsync, SinglepartConditionalPutDoesNotMaskForeignObject) {
     auto & bStore = client->store->GetBucketStore(bucket);
     bStore.PutObject("conditional_put_foreign", "1", {{"clickhouse-write-token", "written-by-somebody-else"}});
@@ -1082,9 +1162,11 @@ TEST_P(SyncAsync, SinglepartConditionalPutDoesNotMaskForeignObject) {
         }
       }, DB::S3Exception);
 
-    /// The foreign object is untouched.
+    /// The foreign object is untouched, and the PUT really was conditional.
     EXPECT_EQ(bStore.objects["conditional_put_foreign"], "1");
     EXPECT_EQ(bStore.object_metadata["conditional_put_foreign"].at("clickhouse-write-token"), "written-by-somebody-else");
+    ASSERT_FALSE(injection->seen_if_none_match.empty());
+    EXPECT_EQ(injection->seen_if_none_match[0], "*");
 }
 
 /// An ordinary (unconditional) S3 write is untouched: no token is stamped on the request, and a 412 is
@@ -1110,10 +1192,12 @@ TEST_P(SyncAsync, SinglepartPutWithoutIfNoneMatchStillThrows) {
         }
       }, DB::S3Exception);
 
-    /// No token was stamped, and no HEAD was issued to look one up.
+    /// The request was not conditional, no token was stamped, and no HEAD looked one up.
     ASSERT_FALSE(injection->seen_metadata.empty());
     for (const auto & metadata : injection->seen_metadata)
         EXPECT_FALSE(metadata.contains("clickhouse-write-token"));
+    for (const auto & if_none_match : injection->seen_if_none_match)
+        EXPECT_TRUE(if_none_match.empty());
     EXPECT_EQ(client->counters.headObject, 0u);
 }
 
@@ -1134,6 +1218,150 @@ TEST_P(SyncAsync, SinglepartConditionalPutKeepsCallerMetadata) {
     ASSERT_FALSE(injection->seen_metadata.empty());
     EXPECT_EQ(injection->seen_metadata[0].at("caller-key"), "caller-value");
     EXPECT_FALSE(injection->seen_metadata[0].at("clickhouse-write-token").empty());
+}
+
+/// A 412 must not be accepted on an object carrying no token at all -- a pre-Fix or non-ClickHouse
+/// writer produced it, so this is a genuine conflict.
+TEST_P(SyncAsync, SinglepartConditionalPutDoesNotMaskUntokenedObject) {
+    auto & bStore = client->store->GetBucketStore(bucket);
+    bStore.PutObject("conditional_put_untokened", "1", {});
+
+    auto injection = std::make_shared<MockS3::PutObjectPreconditionFailedInjection>();
+    setInjectionModel(injection);
+
+    EXPECT_THROW({
+        try {
+            auto buffer = getWriteBuffer("conditional_put_untokened", conditionalCreateWriteSettings());
+            buffer->write('1');
+
+            getAsyncPolicy().setAutoExecute(true);
+            buffer->finalize();
+        }
+        catch (const DB::Exception & e)
+        {
+            ASSERT_EQ(ErrorCodes::S3_ERROR, e.code());
+            EXPECT_THAT(e.what(), testing::HasSubstr("pre-conditions you specified did not hold"));
+            throw;
+        }
+      }, DB::S3Exception);
+
+    EXPECT_EQ(bStore.objects["conditional_put_untokened"], "1");
+    EXPECT_TRUE(bStore.object_metadata["conditional_put_untokened"].empty());
+    ASSERT_FALSE(injection->seen_if_none_match.empty());
+    EXPECT_EQ(injection->seen_if_none_match[0], "*");
+}
+
+/// A 412 with no object stored at all (a pathological server) must throw: the guard proves our own
+/// write, it never infers one from the status code.
+TEST_P(SyncAsync, SinglepartConditionalPutDoesNotMaskAbsentObject) {
+    auto injection = std::make_shared<MockS3::PutObjectPreconditionFailedInjection>();
+    setInjectionModel(injection);
+
+    EXPECT_THROW({
+        try {
+            auto buffer = getWriteBuffer("conditional_put_absent", conditionalCreateWriteSettings());
+            buffer->write('A');
+
+            getAsyncPolicy().setAutoExecute(true);
+            buffer->finalize();
+        }
+        catch (const DB::Exception & e)
+        {
+            ASSERT_EQ(ErrorCodes::S3_ERROR, e.code());
+            EXPECT_THAT(e.what(), testing::HasSubstr("pre-conditions you specified did not hold"));
+            throw;
+        }
+      }, DB::S3Exception);
+
+    /// The guard was consulted and found nothing to match against, so the payload never landed.
+    EXPECT_EQ(client->counters.headObject, 1u);
+    EXPECT_TRUE(client->store->GetBucketStore(bucket).objects["conditional_put_absent"].empty());
+}
+
+/// When the verifying HEAD itself fails the write must still report the original 412, not the HEAD
+/// error and not success.
+TEST_P(SyncAsync, SinglepartConditionalPutThrowsWhenHeadFails) {
+    setInjectionModel(std::make_shared<MockS3::PutObjectPreconditionFailedAndHeadFailsInjection>());
+
+    EXPECT_THROW({
+        try {
+            auto buffer = getWriteBuffer("conditional_put_head_fails", conditionalCreateWriteSettings());
+            buffer->write('A');
+
+            getAsyncPolicy().setAutoExecute(true);
+            buffer->finalize();
+        }
+        catch (const DB::Exception & e)
+        {
+            ASSERT_EQ(ErrorCodes::S3_ERROR, e.code());
+            EXPECT_THAT(e.what(), testing::HasSubstr("pre-conditions you specified did not hold"));
+            EXPECT_THAT(e.what(), testing::Not(testing::HasSubstr("HeadObjectFailIngection")));
+            throw;
+        }
+      }, DB::S3Exception);
+
+    EXPECT_GE(client->counters.headObject, 1u);
+}
+
+/// The multipart carrier of the same defect: with `s3_max_single_part_upload_size = 0` a conditional
+/// Iceberg create takes the multipart path, whose CompleteMultipartUpload sets the same
+/// `If-None-Match` and is likewise replayed on a lost response. The token is stamped on
+/// CreateMultipartUpload and lands on the completed object.
+TEST_P(SyncAsync, MultipartConditionalCompleteRetryAfterLostResponse) {
+    setInjectionModel(std::make_shared<MockS3::CompleteMPULostResponseThenPreconditionFailed>(client->store));
+
+    getSettings()[Setting::s3_max_single_part_upload_size] = 0; // force the multipart path
+    getSettings()[Setting::s3_min_upload_part_size] = 1;
+
+    auto buffer = getWriteBuffer("conditional_mpu_lost_response", conditionalCreateWriteSettings());
+    buffer->write('A');
+
+    getAsyncPolicy().setAutoExecute(true);
+    buffer->finalize();
+
+    EXPECT_EQ(client->counters.multiUploadComplete, 2u);
+    EXPECT_EQ(client->counters.headObject, 1u);
+    EXPECT_EQ(client->counters.multiUploadAbort, 0u);
+
+    auto & bStore = client->store->GetBucketStore(bucket);
+    EXPECT_EQ(bStore.objects["conditional_mpu_lost_response"], "A");
+    EXPECT_FALSE(bStore.object_metadata["conditional_mpu_lost_response"].at("clickhouse-write-token").empty());
+}
+
+/// The multipart twin of the foreign-object arm: a 412 on a completion whose object somebody else
+/// wrote must still fail. The pre-existing object is byte-identical on purpose.
+TEST_P(SyncAsync, MultipartConditionalCompleteDoesNotMaskForeignObject) {
+    auto & bStore = client->store->GetBucketStore(bucket);
+    bStore.PutObject("conditional_mpu_foreign", "A", {{"clickhouse-write-token", "written-by-somebody-else"}});
+
+    auto injection = std::make_shared<MockS3::CompleteMPUPreconditionFailedInjection>();
+    setInjectionModel(injection);
+
+    getSettings()[Setting::s3_max_single_part_upload_size] = 0; // force the multipart path
+    getSettings()[Setting::s3_min_upload_part_size] = 1;
+
+    EXPECT_THROW({
+        try {
+            auto buffer = getWriteBuffer("conditional_mpu_foreign", conditionalCreateWriteSettings());
+            buffer->write('A');
+
+            getAsyncPolicy().setAutoExecute(true);
+            buffer->finalize();
+        }
+        catch (const DB::Exception & e)
+        {
+            ASSERT_EQ(ErrorCodes::S3_ERROR, e.code());
+            EXPECT_THAT(e.what(), testing::HasSubstr("pre-conditions you specified did not hold"));
+            throw;
+        }
+      }, DB::S3Exception);
+
+    EXPECT_EQ(bStore.objects["conditional_mpu_foreign"], "A");
+    EXPECT_EQ(bStore.object_metadata["conditional_mpu_foreign"].at("clickhouse-write-token"), "written-by-somebody-else");
+
+    /// CreateMultipartUpload carried a token, so the guard had something to compare and rejected it.
+    ASSERT_FALSE(injection->seen_create_metadata.empty());
+    EXPECT_FALSE(injection->seen_create_metadata[0].at("clickhouse-write-token").empty());
 }
 
 /// A transient MinIO `InvalidPart` on CompleteMultipartUpload must be retried, not surfaced as a


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/96121
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/96121


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a spurious `PreconditionFailed` (`Code: 499`) error when creating or committing to an Iceberg table. If the object store drops the response to the metadata write after the object was written, the retry of that conditional write hits its own object and the query fails even though the write succeeded. Also stops a conditional multipart completion from reporting success over an object it did not write, silently losing the write it was meant to reject.

### Description

`CREATE TABLE ... ENGINE = IcebergS3(...)` and Iceberg commits intermittently fail with
`Code: 499 ... PreconditionFailed ... (S3_ERROR)` for a write that landed: 6 occurrences over 6
unrelated PRs and 4 tests in 120 days of public CI, 0 on master
([latest report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113148&sha=1995558acebc7967b9b9f600cc1031f58d81f223&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29)).

Root cause: Iceberg writes its metadata with `If-None-Match: *`, so the write is not idempotent.
When the response to a successful attempt is lost, or MinIO returns the bogus `NO_SUCH_KEY` that
`WriteBufferFromS3` already retries, the request is re-sent, finds its own object, and gets 412.
`IcebergMetadata::createInitial` swallows that only under `IF NOT EXISTS`.

Fix: a conditional create-if-absent write now carries a random per-buffer token in S3 custom
metadata, and reports success on a replay only when one `HeadObject` finds that exact token.
Token absent, token different, object absent, or a failed `HeadObject` all throw the original
error, so a genuinely pre-existing table still fails. Three sites are covered: the single-part
`PUT`; the conditional `CompleteMultipartUpload`, reachable from an ordinary
`SET s3_max_single_part_upload_size = 0`; and the `NoSuchUpload` recovery in `S3::Client`, which
rewrote a failure into a success whenever a bare `HeadObject` found any object at the key, so a
conditional create could report success over a foreign object. It is now gated on the request
being unconditional.

Comparing content instead would not be sound: `version-hint.text` is the literal `"1"`, so two
writers produce identical bytes. Custom metadata is not object content, so the JSON other engines
read is unchanged; token and recovery are guarded on `object_storage_write_if_none_match`, whose
only non-test producer is Iceberg.

Validated by thirteen deterministic unit tests on the existing mock S3 client (no S3, no network)
and thirteen mutations that each redden exactly the expected tests.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.303` (included in `26.9` and later)
<!-- ch-version-info:end -->