### PR TITLE
Normalize open range bounds only for integer key types

### DIFF
--- a/src/Core/Range.cpp
+++ b/src/Core/Range.cpp
@@ -25,7 +25,6 @@ Range::Range(const FieldRef & left_, bool left_included_, const FieldRef & right
     , left_included(left_included_)
     , right_included(right_included_)
 {
-    shrinkToIncludedIfPossible();
 }
 
 Range Range::createWholeUniverse()
@@ -53,7 +52,6 @@ Range Range::createRightBounded(const FieldRef & right_point, bool right_include
     Range r = universe;
     r.right = right_point;
     r.right_included = right_included;
-    r.shrinkToIncludedIfPossible();
     // Special case for [-Inf, -Inf]
     if (r.right.isNegativeInfinity() && right_included)
         r.left_included = true;
@@ -70,16 +68,14 @@ Range Range::createLeftBounded(const FieldRef & left_point, bool left_included, 
     Range r = universe;
     r.left = left_point;
     r.left_included = left_included;
-    r.shrinkToIncludedIfPossible();
     // Special case for [+Inf, +Inf]
     if (r.left.isPositiveInfinity() && left_included)
         r.right_included = true;
     return r;
 }
 
-/** Optimize the range. If it has an open boundary and the Field type is "loose"
-  * - then convert it to closed, narrowing by one.
-  * That is, for example, turn (0,2) into [1].
+/** For a key type known to use unit-step integer values, convert open integer boundaries
+  * to closed ones by narrowing them by one. For example, turn (0,2) into [1].
   */
 void Range::shrinkToIncludedIfPossible()
 {

--- a/src/Core/Range.h
+++ b/src/Core/Range.h
@@ -71,9 +71,9 @@ public:
     static bool equals(const Field & lhs, const Field & rhs);
     static bool less(const Field & lhs, const Field & rhs);
 
-    /** Optimize the range. If it has an open boundary and the Field type is "loose"
-      * - then convert it to closed, narrowing by one.
-      * That is, for example, turn (0,2) into [1].
+    /** For a key type known to use unit-step integer values, convert open integer boundaries
+      * to closed ones by narrowing them by one. For example, turn (0,2) into [1].
+      * The caller must establish the key type; a Field's integer representation is not enough.
       */
     void shrinkToIncludedIfPossible();
 

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -3579,6 +3579,7 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
 
         MonotonicFunctionsChain chain;
         std::string func_name = func.getFunctionName();
+        bool key_type_is_integer_represented = false;
 
         if (atom_map.find(func_name) == std::end(atom_map))
             return false;
@@ -3866,6 +3867,8 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
             else
                 key_expr_type_not_null = key_expr_type;
 
+            key_type_is_integer_represented = key_expr_type_not_null->isValueRepresentedByInteger();
+
             /// Native integers and DateTime/DateTime64 are accurately compared without cast.
             bool cast_not_needed =
                 (isNativeInteger(key_expr_type_not_null) || isDateTimeOrDateTime64(key_expr_type_not_null))
@@ -4018,7 +4021,10 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
         out.monotonic_functions_chain = std::move(chain);
         out.argument_num_of_space_filling_curve = argument_num_of_space_filling_curve;
 
-        return atom_it->second(out, const_value);
+        const bool atom_created = atom_it->second(out, const_value);
+        if (atom_created && key_type_is_integer_represented)
+            out.range.shrinkToIncludedIfPossible();
+        return atom_created;
     }
     if (node.tryGetConstant(const_value, const_type))
     {

--- a/tests/queries/0_stateless/04811_datetime64_integer_minmax_bound.reference
+++ b/tests/queries/0_stateless/04811_datetime64_integer_minmax_bound.reference
@@ -1,0 +1,5 @@
+greater integer, no index	4
+greater integer, minmax	4
+less integer, no index	3
+less integer, minmax	3
+greater DateTime, minmax	4

--- a/tests/queries/0_stateless/04811_datetime64_integer_minmax_bound.sql
+++ b/tests/queries/0_stateless/04811_datetime64_integer_minmax_bound.sql
@@ -1,0 +1,44 @@
+DROP TABLE IF EXISTS datetime64_integer_minmax_bound;
+
+CREATE TABLE datetime64_integer_minmax_bound
+(
+    time DateTime64(9, 'UTC'),
+    INDEX idx_time time TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY tuple()
+SETTINGS index_granularity = 1;
+
+INSERT INTO datetime64_integer_minmax_bound VALUES
+    (0::Decimal(9, 2)::DateTime64(9, 'UTC')),
+    (0.01::Decimal(9, 2)::DateTime64(9, 'UTC')),
+    (0.99::Decimal(9, 2)::DateTime64(9, 'UTC')),
+    (1::Decimal(9, 2)::DateTime64(9, 'UTC')),
+    (1.01::Decimal(9, 2)::DateTime64(9, 'UTC'));
+
+SELECT 'greater integer, no index', count()
+FROM datetime64_integer_minmax_bound
+WHERE time > 0
+SETTINGS use_skip_indexes = 0;
+
+SELECT 'greater integer, minmax', count()
+FROM datetime64_integer_minmax_bound
+WHERE time > 0
+SETTINGS force_data_skipping_indices = 'idx_time';
+
+SELECT 'less integer, no index', count()
+FROM datetime64_integer_minmax_bound
+WHERE time < 1
+SETTINGS use_skip_indexes = 0;
+
+SELECT 'less integer, minmax', count()
+FROM datetime64_integer_minmax_bound
+WHERE time < 1
+SETTINGS force_data_skipping_indices = 'idx_time';
+
+SELECT 'greater DateTime, minmax', count()
+FROM datetime64_integer_minmax_bound
+WHERE time > toDateTime(0, 'UTC')
+SETTINGS force_data_skipping_indices = 'idx_time';
+
+DROP TABLE datetime64_integer_minmax_bound;


### PR DESCRIPTION
Closes https://github.com/ClickHouse/ClickHouse/issues/113993

`Range` previously tightened every `Int64` or `UInt64` endpoint without knowing the key type it would be compared against. Move that normalization into `KeyCondition` after checking the key type is represented by an integer, preserving integer pruning while keeping fractional and future non-integer domains open.

Related: https://github.com/ClickHouse/ClickHouse/issues/113993

Caused by: https://github.com/ClickHouse/ClickHouse/pull/98410

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed incorrect MergeTree index pruning for strict comparisons between fractional types and integer constants.
