### PR TITLE
fix: check type compatibility in canEvaluateSubtree to prevent LOGICAL_ERROR on filter pushdown

### DIFF
--- a/src/Storages/VirtualColumnUtils.cpp
+++ b/src/Storages/VirtualColumnUtils.cpp
@@ -568,8 +568,12 @@ static bool canEvaluateSubtree(const ActionsDAG::Node * node, const Block * allo
         if (cur->type == ActionsDAG::ActionType::ARRAY_JOIN)
             return false;
 
-        if (cur->type == ActionsDAG::ActionType::INPUT && allowed_inputs && !allowed_inputs->has(cur->result_name))
-            return false;
+        if (cur->type == ActionsDAG::ActionType::INPUT && allowed_inputs)
+        {
+            const auto * input = allowed_inputs->findByName(cur->result_name);
+            if (!input || !input->type->equals(*cur->result_type))
+                return false;
+        }
 
         for (const auto * child : cur->children)
             nodes.push(child);


### PR DESCRIPTION
### Fixes #113982

The AST fuzzer found a logical error when a filter is pushed down into `system.tables` through the `information_schema.tables` view:

```sql
SELECT 1 FROM (SELECT 1 FROM information_schema.tables WHERE indexHint(toString(engine)));
```

```
Code: 49. DB::Exception: Unexpected return type from toString. Expected Nullable(String). Got String. (LOGICAL_ERROR)
```

### Root cause

`canEvaluateSubtree` in `src/Storages/VirtualColumnUtils.cpp` decides whether a predicate subtree can be pushed down by matching the DAG's `INPUT` nodes against the allowed-inputs sample block **by name only**:

```cpp
if (cur->type == ActionsDAG::ActionType::INPUT && allowed_inputs && !allowed_inputs->has(cur->result_name))
    return false;
```

Here the predicate is typed against the view header, where `engine` is `Nullable(String)` (`information_schema.tables` declares it nullable), but `getFilteredTables` evaluates the split-off DAG over a block where `engine` is `String`. `toString` then returns `String` while the DAG node promises `Nullable(String)`, and `ExpressionActions` fails the return-type assertion.

### Fix

Also require the INPUT node's `result_type` to match the column type in the allowed-inputs block. When the types differ, the subtree cannot be safely evaluated over that block, so it is not pushed down (the filter is applied later over the full result — conservatively correct).

```cpp
if (cur->type == ActionsDAG::ActionType::INPUT && allowed_inputs)
{
    const auto * input = allowed_inputs->findByName(cur->result_name);
    if (!input || !input->type->equals(*cur->result_type))
        return false;
}
```