### PR TITLE
Disable regular merges in 03518_alter_logical_race so the ALTER's mutation is not starved

### DIFF
--- a/tests/queries/0_stateless/03518_alter_logical_race.sh
+++ b/tests/queries/0_stateless/03518_alter_logical_race.sh
@@ -69,6 +69,10 @@ $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS alter_table"
 # concurrent INSERT load they can starve the first mutation, which (replicated alters finish in strict
 # version order) stalls every later `MODIFY` until `timeout` fires with a spurious failure. CI report:
 # https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=2a3a502d2ed0af65bb0a5c91223c91c1b2e28047&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29
+# Regular merges are disabled too (`max_bytes_to_merge_at_max_space_in_pool = 0`): the merge-selecting
+# task tries a merge before a mutation, so while this test's INSERTs keep mergeable ranges available
+# every pass is spent on a merge and the ALTER's mutation never gets its `MUTATE_PART` entries. With
+# merges off parts accumulate, so the per-partition INSERT delay/throw thresholds are raised to match.
 $CLICKHOUSE_CLIENT << SQL
 CREATE TABLE alter_table (a UInt8, b UInt8, c UInt8, d UInt8, e UInt8, f UInt8, g UInt8)
 ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test_03518/alter_table', 'r1')
@@ -76,7 +80,10 @@ ORDER BY a
 PARTITION BY b % 10
 SETTINGS old_parts_lifetime = 1,
   max_replicated_mutations_in_queue = 100000,
-  number_of_free_entries_in_pool_to_execute_mutation = 0
+  number_of_free_entries_in_pool_to_execute_mutation = 0,
+  max_bytes_to_merge_at_max_space_in_pool = 0,
+  parts_to_delay_insert = 100000,
+  parts_to_throw_insert = 100000
 SQL
 
 # True while the workers should keep issuing (and retrying) statements. Every worker - both


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108060
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`03518_alter_logical_race` fails on `Stateless tests (amd_debug, parallel)` with
`TIMEOUT: ALTER TABLE alter_table DROP COLUMN h` plus `NO ALTER PROGRESS: completed zero full
ALTER ADD/MODIFY/DROP cycles`, its own progress guard firing
([CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111534&sha=b8c37b85647510a9b374b77fadaeeddd8ab957f5&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29)).

Root cause: `DROP`/`MODIFY COLUMN` on a physical column needs a data mutation, which advances
only when the merge-selecting task creates a `MUTATE_PART` entry per part. `try_assign_merge`
tries a regular merge first and returns `EntryCreated` before reaching mutation selection, then
reschedules immediately. This test's concurrent INSERTs keep mergeable ranges permanently
available, so every pass goes to a merge and the mutation starves: 2471 `MERGE_PARTS` against 44
`MUTATE_PART`. Strict alter-version ordering then blocks the second worker at metadata too, so
*zero* cycles complete. #108060 went one layer too shallow, unpinning count throttles the
mutation never reaches.

Fix: disable regular merges for the table (`max_bytes_to_merge_at_max_space_in_pool = 0`) so the
selector reaches mutation selection. Mutations are unaffected, reading
`getMaxSourcePartBytesForMutation` instead. With merges off parts accumulate, so
`parts_to_delay_insert` / `parts_to_throw_insert` are raised. Same approach as
`04652_mutate_part_ahead_of_table_metadata_version.sh`. `SYSTEM STOP MERGES` would not work even
table-scoped: it takes the `merges_blocker` lock, which
`ReplicatedMergeTreeQueue::shouldExecuteLogEntry` applies to `MUTATE_PART` too.

No assertion is weakened and the guard is untouched, so this makes the promised race happen
rather than tolerating its absence. Mutation-side column resolution is exercised 5.7x more
(`MUTATE_PART` 4,958 -> 28,249); the merge-side path under concurrent `ADD`/`DROP COLUMN` stays
covered by `01079_parallel_alter_add_drop_column_zookeeper` and `03144_..._on_steroids`, which
keep merges on and force them with `OPTIMIZE FINAL`. Raising the timeout was rejected: the
starved mutation decelerated with no bound.

Validation, same box and load, only the test file differing: master fails **5/50** with the
signature above; with the fix **50/50** on debug and **50/50** on ASAN. p95 drops 77.5s to
32.7s, nothing reaches the 180s hard deadline, the settings verifiably applied
(0 `MERGE_PARTS`), no `Too many parts`.