### PR TITLE
CI: fix the ss filter order in the Redpanda preflight TIME_WAIT check

### DIFF
--- a/ci/jobs/scripts/functional_tests/setup_kafka.sh
+++ b/ci/jobs/scripts/functional_tests/setup_kafka.sh
@@ -25,7 +25,7 @@ preflight() {
         fi
     done
     # TIME_WAIT on the RPC port also prevents bind; report it for diagnosis.
-    ss -tanH "sport = :${RPC_PORT}" state time-wait || true
+    ss -tanH state time-wait "sport = :${RPC_PORT}" || true
     if [ "$busy" -ne 0 ]; then
         echo "ERROR: cannot start Redpanda, required ports are occupied"
         return 1


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/105840
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

The preflight in `ci/jobs/scripts/functional_tests/setup_kafka.sh` reports TIME_WAIT on the Redpanda RPC port so a failed bind has evidence naming the cause. Its filter arguments are ordered wrongly, so the command only ever fails to parse:

```
+ ss -tanH 'sport = :19092' state time-wait
Error: "state" does not look like a port.
Cannot parse dst/src address.
```

`man ss` documents `FILTER := [ state STATE-FILTER ] [ EXPRESSION ]`, so `state` is a prefix of the filter. Placed after `sport =`, the literal token `state` becomes that operator's operand. Argument ordering, not a version difference: it fails identically on iproute2-5.15.0 (what `ci/docker/test-base` runs) and 6.1.0.

So the diagnostic added in #105840 has never produced output, and every kafka-enabled job log instead carries a bare `Error:` line that reads like a setup failure. It is not one, since the call ends in `|| true` and precedes the `busy` check. In `job.log` for 4 failing MasterCI jobs across 2 shas and 3 sanitizers the signature appears in 4/4, each followed by `Redpanda is ready (broker + schema registry)`.

Moving `state time-wait` ahead of the port expression matches the 3 other state-filtered `ss` calls in the repository. Measured on iproute2-5.15.0 with a real TIME_WAIT socket on 127.0.0.1:19092: the old form reports nothing (rc=1) while the new form prints the socket, and `sport = :1` returns empty, so the port predicate genuinely applies. Lines 21 and 23 select listening sockets via the `-l` flag rather than a `state` clause and are correct as written.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1076` (included in `26.8` and later)
<!-- ch-version-info:end -->