### PR TITLE
fix: handle `exists` in rerunFunctionResolve for PREWHERE with rewrite_in_to_join

### DIFF
--- a/src/Analyzer/Utils.cpp
+++ b/src/Analyzer/Utils.cpp
@@ -947,8 +947,9 @@ void rerunFunctionResolve(FunctionNode * function_node, ContextPtr context)
     const auto & name = function_node->getFunctionName();
     if (function_node->isOrdinaryFunction())
     {
-        // Special case, don't need to be resolved. It must be processed by GroupingFunctionsResolvePass.
-        if (name == "grouping")
+        // Special case, don't need to be resolved.
+        // grouping is processed by GroupingFunctionsResolvePass, exists is resolved by a dedicated path.
+        if (name == "grouping" || name == "exists")
             return;
         auto function = FunctionFactory::instance().get(name, context);
         function_node->resolveAsFunction(function->build(function_node->getArgumentColumns()));


### PR DESCRIPTION
### Fix `Unknown function exists` when `rewrite_in_to_join` is used with `PREWHERE`

When `rewrite_in_to_join = 1`, the analyzer rewrites `x IN (subquery)` into a special `exists(...)` `FunctionNode`. The `exists` function is resolved by a dedicated path, not through `FunctionFactory`.

However, `rerunFunctionResolve` in `src/Analyzer/Utils.cpp` is called during `PREWHERE` resolution (via `ReplaceColumnsVisitor`) and it tries to resolve all visited functions through `FunctionFactory::instance().get()`. It already special-cases `grouping` (which is also resolved outside the factory) but not `exists`, so the lookup throws `UNKNOWN_FUNCTION`.

**Fix**: Add `exists` to the special-case guard alongside `grouping`.

Closes #114026