### PR TITLE
Concentrate the arrayFold cancellation fixtures of 04752 in one row

### DIFF
--- a/tests/queries/0_stateless/04752_persisted_expression_cancellation.sh
+++ b/tests/queries/0_stateless/04752_persisted_expression_cancellation.sh
@@ -15,7 +15,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # already-finished deadline), so the in-loop cancellation check the function already contains reads a
 # query that is not the one running and never fires.
 #
-# Each case below therefore runs a persisted expression from a LATER query. Three fixture properties
+# Each case below therefore runs a persisted expression from a LATER query. Four fixture properties
 # are load-bearing, and getting any of them wrong makes the case pass unfixed:
 #   * no `%` in a `PARTITION BY` key. `MergeTreePartition::adjustPartitionKey` rebuilds the whole key
 #     description with the INSERT's own context when the key mentions `modulo`, which hands the
@@ -24,6 +24,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 #     on a direct call with a correct status, and never reaches the persisted expression.
 #   * arguments must be column-dependent. A constant argument is folded once, so the function runs a
 #     single time whatever the row count.
+#   * `arrayFold`'s elements must sit in one row rather than spread evenly. Its checkpoints are in the
+#     fold loop, which runs `max_array_size` times over every row, while the selector loop and
+#     `scatter` ahead of them are O(total elements) and effectively uninterruptible; spread evenly the
+#     arm pays that prologue on all of them and lands only about twice the bound unfixed.
 #
 # `max_insert_block_size`/`min_insert_block_size_rows`/`max_threads` are pinned statement-level because
 # the runner randomizes them and the effect size is a function of rows-per-block: split into enough
@@ -86,7 +90,7 @@ deadline_case "geohash_partition" \
     "src_f"
 deadline_case "arrayfold_partition" \
     "CREATE TABLE t_arrayfold_partition (a UInt64, k UInt64) ENGINE = MergeTree
-     PARTITION BY intDiv(arrayFold((acc, x) -> acc + x + a, range(3000), toUInt64(0)), 100000000000) ORDER BY tuple()" \
+     PARTITION BY intDiv(arrayFold((acc, x) -> acc + x + a, range(if(k = 0, 400000, 1)), toUInt64(0)), 100000000000) ORDER BY tuple()" \
     "src_i"
 # Three `sleep` calls, not one: a single call cannot overshoot by more than
 # `function_sleep_max_microseconds_per_block` (3s by default) whatever the deadline, which is under the
@@ -110,7 +114,7 @@ deadline_case "geohash_orderby" \
     "src_f"
 deadline_case "arrayfold_orderby" \
     "CREATE TABLE t_arrayfold_orderby (a UInt64, k UInt64) ENGINE = MergeTree
-     ORDER BY (k, arrayFold((acc, x) -> acc + x + a, range(3000), toUInt64(0)))" \
+     ORDER BY (k, arrayFold((acc, x) -> acc + x + a, range(if(k = 0, 400000, 1)), toUInt64(0)))" \
     "src_i"
 deadline_case "sleep_orderby" \
     "CREATE TABLE t_sleep_orderby (a UInt64, k UInt64) ENGINE = MergeTree


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/109454
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

The two `arrayFold` arms of `04752_persisted_expression_cancellation` sat about twice their bound
rather than four times below it, and one reported `OVERSHOT 4258ms past a 1000ms limit` on
`Stateless tests (amd_debug, sequential)`. Surfaced by @ alexey-milovidov on #109454; no related open
issue exists. This is not the `grep` oracle of #113943, which cannot affect it: the failing assertion
is the duration oracle, and the two PRs touch disjoint lines of the file.

`arrayFold`'s cancellation checkpoints sit in its per-slice fold loop, but the selector loop and
`scatter` ahead of them are O(total elements) and effectively uninterruptible. The old fixture spread
1.8e8 elements evenly over 60000 rows, so the arm paid about 2.9s of prologue before the deadline
could be observed, against a 4000ms bound, and crossed it on a slower runner.

Concentrating the same fold in one row (`range(if(k = 0, 400000, 1))`) leaves the interruptible work
intact, since the fold loop runs `max_array_size` times over all rows regardless of individual array
lengths, while the prologue drops by the same factor. No bound is widened, no tag is added, the
oracle and `.reference` are untouched, and peak memory drops from 2.01 GiB to 1.56 GiB. Both arms are
changed: the one that has not fired yet had the identical margin.

Validated on a debug build matching `amd_debug`: 50/50 runs pass, `.reference` matches byte for byte,
and the arms stop at 1040-1161ms worst case, a 3.45x margin. With the engine fix of #113456 reverted
on a separately built binary they still redden, at about 14.8s against the old 5.7s, so the oracle
discriminates more sharply than before rather than less.

`arrayFold`'s prologue remains effectively uninterruptible, so a fold over a very large evenly shaped
argument still observes the deadline late. The query is cancelled, only later, and that is left as is.