### PR TITLE
Fix flaky test_concurrent_watches losing one watch

### DIFF
--- a/tests/integration/test_keeper_back_to_back/test.py
+++ b/tests/integration/test_keeper_back_to_back/test.py
@@ -757,8 +757,8 @@ def test_concurrent_watches(started_cluster, request):
 
         existing_path = []
         # A watch is one-shot per (path, session), so a mutation only notifies a registration
-        # that is live at that moment. Mutating a path this thread does not hold a token for can
-        # therefore consume another thread's registration, leaving it forever unnotified.
+        # live at that moment. Claim a token before mutating: mutating without one lets a stale
+        # removal drop the token of a later registration, which then never gets a mutation.
         existing_path_lock = threading.Lock()
         all_paths_created = []
         watches_created = 0
@@ -825,7 +825,7 @@ def test_concurrent_watches(started_cluster, request):
             time.sleep(0.1)
 
         assert watches_created == watches_must_be_created
-        assert trigger_called >= watches_trigger_must_be_called
+        assert trigger_called == watches_trigger_must_be_called
         assert len(existing_path) == 0
         if dumb_watch_triggered_counter != watches_must_be_triggered:
             print("All created paths", all_paths_created)

--- a/tests/integration/test_keeper_back_to_back/test.py
+++ b/tests/integration/test_keeper_back_to_back/test.py
@@ -1,6 +1,7 @@
 import os
 import random
 import string
+import threading
 import time
 from multiprocessing.dummy import Pool
 
@@ -755,8 +756,18 @@ def test_concurrent_watches(started_cluster, request):
         all_paths_triggered = []
 
         existing_path = []
+        # A watch is one-shot per (path, session), so a mutation only notifies a registration
+        # that is live at that moment. Mutating a path this thread does not hold a token for can
+        # therefore consume another thread's registration, leaving it forever unnotified.
+        existing_path_lock = threading.Lock()
         all_paths_created = []
         watches_created = 0
+
+        def claim_path():
+            with existing_path_lock:
+                if not existing_path:
+                    return None
+                return existing_path.pop(random.randrange(len(existing_path)))
 
         def create_path_and_watch(i):
             nonlocal watches_created
@@ -775,7 +786,8 @@ def test_concurrent_watches(started_cluster, request):
             fake_zk.get(global_path + "/" + str(i), watch=dumb_watch)
             all_paths_created.append(global_path + "/" + str(i))
             watches_created += 1
-            existing_path.append(i)
+            with existing_path_lock:
+                existing_path.append(i)
 
         trigger_called = 0
 
@@ -783,26 +795,19 @@ def test_concurrent_watches(started_cluster, request):
             nonlocal trigger_called
             trigger_called += 1
             fake_zk.set(global_path + "/" + str(i), b"somevalue")
-            try:
-                existing_path.remove(i)
-            except:
-                pass
 
         def call(total):
             for i in range(total):
                 create_path_and_watch(random.randint(0, 1000))
                 time.sleep(random.random() % 0.5)
-                try:
-                    rand_num = random.choice(existing_path)
+                rand_num = claim_path()
+                if rand_num is not None:
                     trigger_watch(rand_num)
-                except:
-                    pass
-            while existing_path:
-                try:
-                    rand_num = random.choice(existing_path)
-                    trigger_watch(rand_num)
-                except:
-                    pass
+            while True:
+                rand_num = claim_path()
+                if rand_num is None:
+                    break
+                trigger_watch(rand_num)
 
         p = Pool(10)
         arguments = [100] * 10


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`test_keeper_back_to_back::test_concurrent_watches` fails as `assert 999 == 1000` (test.py:832) on
`Integration tests (amd_asan_ubsan, db disk, old analyzer, 5/6)`:
[CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113692&sha=14d623eee2821f7fe35fc6ba81675c9845318ecb&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%205%2F6%29).
It is a test bug; Keeper honours the ZooKeeper contract.

**Root cause.** `trigger_watch` mutated a path *before* owning its `existing_path` token, then removed
the token inside a bare `except: pass`. `random.choice` + `set()` + `remove()` is not atomic across the
10 pool threads, so two threads can pick the same token. A watch is one-shot per (path, session), so
the second mutation notifies nobody, and the deferred `remove` consumes a token belonging to a
*different, still outstanding* registration, which is then never mutated and never fires. Observed on
`/487`: register, two mutations 1 ms apart, one event, a second register, then a stale remove eats its
token.

**Fix.** Claim the token atomically before mutating, and skip when nothing was claimed, so every
registration is followed by a mutation. `dumb_watch_triggered_counter == 1000` and two other
assertions are unchanged; `trigger_called >= 1000` is tightened to `== 1000`, which removing unclaimed
mutations makes exact. That tightening is what makes the fix testable: restoring the old bodies under
it fails `assert 1026 == 1000`, while under `>=` they passed. The lock covers only the test's own list,
never a Keeper call.

**Validation.** A deterministic replay of that schedule against a real Keeper fails 3/3 before and
passes 3/3 after. Pre-fix runs issue 1024-1034 mutations for 1000 tokens, versus exactly 1000 in 11/11
runs after (including 1-thread and 50-thread); a watch is lost only when a stale remove lands on a live
token, hence the low rate. 25/25 repetitions pass under the failing job, the suite passes 9/9, five
mutation arms each redden the assertion, and collisions are unchanged (372 duplicate registrations, up
to 6 per path), so the lock did not serialize the test.