### PR TITLE
Retry the inconclusive outcome in `04722_count_substrings_cancellation`

### DIFF
--- a/tests/queries/0_stateless/04722_count_substrings_cancellation.sh
+++ b/tests/queries/0_stateless/04722_count_substrings_cancellation.sh
@@ -29,9 +29,22 @@ LOG_PINS="--enable_parallel_replicas 0"
 # A duration alone cannot tell a stopped call from a query that never ran, so the verdict asserts the
 # termination cause too. Only `ExecutionSpeedLimits::checkTimeLimit` formats "elapsed N ms"; a kill landing
 # before the pipeline starts omits it, and such a run is reported as inconclusive rather than as a pass.
+#
+# On a loaded runner the deadline can expire while the query is still being parsed and analyzed, which
+# yields exactly that inconclusive verdict without any server defect. Such a case is retried: a missing
+# checkpoint makes the call OVERSHOOT, never turn inconclusive, so retrying does not mask the regression.
 run() {
-    local label="$1" query="$2" mode="${3:-throw}"
-    local query_id="04722_${label}_${CLICKHOUSE_DATABASE}" output elapsed_ms code rows breaks
+    local label="$1" query="$2" mode="${3:-throw}" verdict attempt
+    for attempt in 1 2 3 4 5; do
+        verdict=$(run_once "$label" "$query" "$mode" "$attempt")
+        [ "$verdict" = "$label: cancelled before the pipeline started" ] || break
+    done
+    echo "$verdict"
+}
+
+run_once() {
+    local label="$1" query="$2" mode="$3" attempt="$4"
+    local query_id="04722_${label}_${attempt}_${CLICKHOUSE_DATABASE}" output elapsed_ms code rows breaks
     # `log_profile_events` is pinned: the `break` verdict reads a counter out of the `query_log` row.
     output=$(timeout 600 ${CLICKHOUSE_CLIENT} --query_id "$query_id" --max_execution_time 1 \
         --log_profile_events 1 --timeout_overflow_mode "$mode" --query "$query" 2>&1)


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

Retry the inconclusive outcome in `04722_count_substrings_cancellation`.

On a loaded runner the 1-second `max_execution_time` can expire while the query is still being parsed and analyzed. The client then sees `TIMEOUT_EXCEEDED` without the "elapsed N ms" that only `ExecutionSpeedLimits::checkTimeLimit` formats, so the case is reported as "cancelled before the pipeline started" — an inconclusive verdict, deliberately distinct from a pass — and the output diffs against the reference:

```
-constant_vector: stopped within bound
+constant_vector: cancelled before the pipeline started
```

Seen on `Stateless tests (amd_tsan, parallel)` across unrelated PRs, e.g. https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112928&sha=601afbea7fe7956bf3bcb6dd1d0fe67e5f042d27&name_0=PR (reruns passed).

The fix retries such a case up to 5 times with a unique `query_id` per attempt. This does not weaken the test: a missing cancellation checkpoint makes the call OVERSHOOT (or never stop), it can never produce the inconclusive verdict, so retrying cannot mask the regression the test guards.

Related: https://github.com/ClickHouse/ClickHouse/pull/112928
Related: https://github.com/ClickHouse/ClickHouse/pull/113369
