### PR TITLE
Do not delete object storage blobs that a live part still hardlinks

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -199,6 +199,7 @@ static struct InitFiu
     ONCE(disk_object_storage_fail_precommit_metadata_transaction) \
     ONCE(write_file_operation_fail_on_read) \
     ONCE(unlink_file_operation_fail_on_remove) \
+    PAUSEABLE(unlink_file_operation_pause_after_counting_links) \
     PAUSEABLE(remove_recursive_operation_pause_after_traverse) \
     REGULAR(slowdown_parallel_replicas_local_plan_read) \
     ONCE(iceberg_writes_cleanup) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -198,6 +198,8 @@ static struct InitFiu
     ONCE(disk_object_storage_fail_commit_metadata_transaction) \
     ONCE(disk_object_storage_fail_precommit_metadata_transaction) \
     ONCE(write_file_operation_fail_on_read) \
+    ONCE(unlink_file_operation_fail_on_remove) \
+    PAUSEABLE(remove_recursive_operation_pause_after_traverse) \
     REGULAR(slowdown_parallel_replicas_local_plan_read) \
     ONCE(iceberg_writes_cleanup) \
     REGULAR(iceberg_slow_manifest_read) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -201,6 +201,7 @@ static struct InitFiu
     ONCE(unlink_file_operation_fail_on_remove) \
     PAUSEABLE(unlink_file_operation_pause_after_counting_links) \
     PAUSEABLE(remove_recursive_operation_pause_after_traverse) \
+    ONCE(remove_recursive_operation_fail_on_remove) \
     REGULAR(slowdown_parallel_replicas_local_plan_read) \
     ONCE(iceberg_writes_cleanup) \
     REGULAR(iceberg_slow_manifest_read) \
@@ -474,6 +475,19 @@ void FailPointInjection::waitForResume(const String & fail_point_name)
     });
 }
 
+std::optional<size_t> FailPointInjection::getPauseCount(const String & fail_point_name)
+{
+    if (!isRegisteredFailPoint(fail_point_name))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot find fail point {}", fail_point_name);
+
+    std::lock_guard lock(mu);
+    auto iter = fail_point_wait_channels.find(fail_point_name);
+    if (iter == fail_point_wait_channels.end())
+        return {};
+
+    return iter->second->pause_epoch;
+}
+
 std::vector<FailPointInjection::FailPointInfo> FailPointInjection::getFailPoints()
 {
     std::vector<FailPointInfo> result;
@@ -547,6 +561,11 @@ void FailPointInjection::waitForPause(const String &)
 }
 
 void FailPointInjection::waitForResume(const String &)
+{
+    throwDisabled();
+}
+
+std::optional<size_t> FailPointInjection::getPauseCount(const String &)
 {
     throwDisabled();
 }

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -200,6 +200,7 @@ static struct InitFiu
     ONCE(write_file_operation_fail_on_read) \
     ONCE(unlink_file_operation_fail_on_remove) \
     PAUSEABLE(unlink_file_operation_pause_after_counting_links) \
+    PAUSEABLE(metadata_transaction_pause_before_finalize) \
     PAUSEABLE(remove_recursive_operation_pause_after_traverse) \
     ONCE(remove_recursive_operation_fail_on_remove) \
     REGULAR(slowdown_parallel_replicas_local_plan_read) \

--- a/src/Common/FailPoint.h
+++ b/src/Common/FailPoint.h
@@ -27,6 +27,7 @@
 
 #endif // USE_LIBFIU
 
+#include <optional>
 #include <unordered_map>
 
 
@@ -187,6 +188,11 @@ public:
       * - Will timeout if notify was already called before wait starts
       */
     static void waitForResume(const String & fail_point_name);
+
+    /** Number of times a thread has paused at this failpoint since it was enabled, or nullopt
+      * when it is not enabled, so that "never paused" is not reported as a count.
+      */
+    static std::optional<size_t> getPauseCount(const String & fail_point_name);
 
     /** Return a snapshot of every registered failpoint with its type and enabled status.
       *

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.cpp
@@ -6,6 +6,7 @@
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 
+#include <Common/FailPoint.h>
 #include <Common/logger_useful.h>
 
 #include <memory>
@@ -17,6 +18,11 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+}
+
+namespace FailPoints
+{
+    extern const char metadata_transaction_pause_before_finalize[];
 }
 
 MetadataStorageFromDisk::MetadataStorageFromDisk(DiskPtr disk_, std::string compatible_key_prefix_, ObjectStorageKeyGeneratorPtr key_generator_, bool persist_removal_queue_, size_t removal_log_compaction_threshold_)
@@ -345,6 +351,9 @@ void MetadataStorageFromDiskTransaction::commit(const TransactionCommitOptionsVa
         std::unique_lock lock(metadata_storage.metadata_mutex);
         operations.commit();
     }
+
+    /// Outside the lock on purpose: parking inside it would serialize the exclusion under test.
+    FailPointInjection::pauseFailPoint(FailPoints::metadata_transaction_pause_before_finalize);
 
     {
         std::lock_guard guard(metadata_storage.finalize_mutex);

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.cpp
@@ -346,7 +346,10 @@ void MetadataStorageFromDiskTransaction::commit(const TransactionCommitOptionsVa
         operations.commit();
     }
 
-    operations.finalize();
+    {
+        std::lock_guard guard(metadata_storage.finalize_mutex);
+        operations.finalize();
+    }
 
     if (!objects_to_remove.empty())
     {

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.cpp
@@ -407,7 +407,7 @@ void MetadataStorageFromDiskTransaction::chmod(const String & path, mode_t mode)
 
 void MetadataStorageFromDiskTransaction::unlinkFile(const std::string & path, bool if_exists, bool should_remove_objects)
 {
-    operations.addOperation(std::make_unique<UnlinkFileOperation>(path, if_exists, should_remove_objects, metadata_storage.compatible_key_prefix, *metadata_storage.getDisk(), objects_to_remove));
+    operations.addOperation(std::make_unique<UnlinkFileOperation>(path, if_exists, should_remove_objects, metadata_storage.compatible_key_prefix, *metadata_storage.getDisk(), objects_to_remove, inode_release_allowed));
 }
 
 void MetadataStorageFromDiskTransaction::removeRecursive(const std::string & path, const ShouldRemoveObjectsPredicate & should_remove_objects)
@@ -447,7 +447,7 @@ void MetadataStorageFromDiskTransaction::moveDirectory(const std::string & path_
 
 void MetadataStorageFromDiskTransaction::replaceFile(const std::string & path_from, const std::string & path_to)
 {
-    operations.addOperation(std::make_unique<ReplaceFileOperation>(path_from, path_to, metadata_storage.compatible_key_prefix, *metadata_storage.getDisk(), objects_to_remove));
+    operations.addOperation(std::make_unique<ReplaceFileOperation>(path_from, path_to, metadata_storage.compatible_key_prefix, *metadata_storage.getDisk(), objects_to_remove, inode_release_allowed));
 }
 
 void MetadataStorageFromDiskTransaction::setReadOnly(const std::string & path)

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.h
@@ -135,6 +135,8 @@ private:
     /// We collect all removed in transaction blobs here. After successful tx commit
     /// these blobs will be scheduled for background removal (into in-memory queue of outdated blobs).
     StoredObjects objects_to_remove;
+    /// Shared by this transaction's unlink operations, each of which sees only its own hard link.
+    InodeReleaseVeto inode_release_allowed;
     MetadataOperationsHolder operations;
 
 public:

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.h
@@ -26,6 +26,10 @@ private:
     friend class MetadataStorageFromDiskTransaction;
 
     mutable SharedMutex metadata_mutex;
+    /// Serializes finalization, where an operation counts an inode's remaining hard links and
+    /// then unlinks one. Taken after metadata_mutex is released, never while holding
+    /// removed_objects_mutex.
+    mutable std::mutex finalize_mutex;
     const DiskPtr disk;
     const std::string compatible_key_prefix;
     const ObjectStorageKeyGeneratorPtr key_generator;

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.cpp
@@ -19,6 +19,8 @@
 #include <optional>
 #include <ranges>
 #include <filesystem>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 namespace fs = std::filesystem;
@@ -37,10 +39,27 @@ namespace ErrorCodes
 namespace FailPoints
 {
     extern const char write_file_operation_fail_on_read[];
+    extern const char unlink_file_operation_fail_on_remove[];
+    extern const char remove_recursive_operation_pause_after_traverse[];
 }
 
 namespace
 {
+
+/// Number of hard links to `path`, or nullopt if it cannot be determined. Callers must treat
+/// nullopt as "may still be referenced": leaking a blob is recoverable, deleting a live one is not.
+std::optional<uint64_t> tryGetHardLinkCount(const IDisk & disk, const std::string & path)
+{
+    try
+    {
+        return disk.stat(path).st_nlink;
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__, fmt::format("Cannot count hard links of {}, keeping its blobs", path));
+        return std::nullopt;
+    }
+}
 
 std::optional<DiskObjectStorageMetadata> tryReadMetadataFile(const std::string & compatible_key_prefix, const std::string & path, const IDisk & disk)
 {
@@ -155,15 +174,14 @@ void UnlinkFileOperation::tryUnlinkMetadataFile()
     if (!object_metadata.has_value())
         return;
 
-    uint32_t ref_count = object_metadata->ref_count;
-    if (ref_count > 0)
+    if (object_metadata->ref_count > 0)
     {
         object_metadata->ref_count -= 1;
         write_operation = std::make_unique<WriteFileOperation>(path, object_metadata->serializeToString(), disk);
         write_operation->execute();
     }
 
-    if (ref_count == 0 && should_remove_objects)
+    if (should_remove_objects)
         removed_objects.append_range(object_metadata->objects);
 }
 
@@ -197,10 +215,23 @@ void UnlinkFileOperation::undo()
 
 void UnlinkFileOperation::finalize()
 {
-    objects_to_remove.append_range(std::move(removed_objects));
+    if (!tmp_file_path.has_value())
+        return;
 
-    if (tmp_file_path.has_value())
-        disk.removeFile(tmp_file_path.value());
+    /// execute() only renamed the file aside, so the count still includes this link.
+    const auto links = tryGetHardLinkCount(disk, tmp_file_path.value());
+    const bool is_last_link = links.has_value() && *links == 1;
+
+    fiu_do_on(FailPoints::unlink_file_operation_fail_on_remove,
+    {
+        throw Exception(ErrorCodes::FAULT_INJECTED, "Injected fault in UnlinkFileOperation remove");
+    });
+
+    disk.removeFile(tmp_file_path.value());
+
+    /// Only after the link is really gone: an unlink that throws must not leave blobs enqueued.
+    if (is_last_link)
+        objects_to_remove.append_range(std::move(removed_objects));
 }
 
 CreateDirectoryOperation::CreateDirectoryOperation(std::string path_, IDisk & disk_)
@@ -280,17 +311,21 @@ void RemoveRecursiveOperation::traverseFile(const std::string & leaf)
     if (!object_metadata.has_value())
         return;
 
-    uint32_t ref_count = object_metadata->ref_count;
-    if (ref_count > 0)
+    const int64_t inode = disk.stat(leaf).st_ino;
+
+    if (object_metadata->ref_count > 0)
     {
         object_metadata->ref_count -= 1;
         write_operations.push_back(std::make_unique<WriteFileOperation>(leaf, object_metadata->serializeToString(), disk));
         write_operations.back()->execute();
     }
 
-    if (ref_count == 0)
-        if (!should_remove_objects || should_remove_objects(fs::relative(leaf, path)))
-            removed_objects.append_range(object_metadata->objects);
+    removal_candidates.push_back(RemovalCandidate{
+        .relative_path = fs::relative(leaf, path),
+        .inode = inode,
+        .should_remove_its_objects = !should_remove_objects || should_remove_objects(fs::relative(leaf, path)),
+        .objects = std::move(object_metadata->objects),
+    });
 }
 
 void RemoveRecursiveOperation::traverseDirectory(const std::string & mid_path)
@@ -326,6 +361,9 @@ void RemoveRecursiveOperation::execute()
     {
         traverseDirectory(path);
 
+        /// Decrements are persisted here but nothing is unlinked yet.
+        FailPointInjection::pauseFailPoint(FailPoints::remove_recursive_operation_pause_after_traverse);
+
         auto path_to = getRandomASCIIString(32);
         disk.moveDirectory(path, path_to);
         temp_directory_path = std::move(path_to);
@@ -345,12 +383,38 @@ void RemoveRecursiveOperation::undo()
 
 void RemoveRecursiveOperation::finalize()
 {
-    objects_to_remove.append_range(std::move(removed_objects));
+    /// One bulk removal can drop several links to the same inode, so decide per inode: release
+    /// only when every link the filesystem still reports is in this subtree.
+    std::unordered_map<int64_t, size_t> links_inside_subtree;
+    for (const auto & candidate : removal_candidates)
+        ++links_inside_subtree[candidate.inode];
+
+    /// One disallowed or unaccounted link vetoes the whole inode.
+    std::unordered_map<int64_t, bool> release_inode;
+    for (const auto & candidate : removal_candidates)
+    {
+        const std::string candidate_path = temp_file_path.has_value()
+            ? temp_file_path.value()
+            : (fs::path(temp_directory_path.value()) / candidate.relative_path).string();
+
+        const auto links = tryGetHardLinkCount(disk, candidate_path);
+        const bool ok = candidate.should_remove_its_objects && links.has_value() && *links == links_inside_subtree[candidate.inode];
+
+        auto [it, inserted] = release_inode.try_emplace(candidate.inode, ok);
+        if (!inserted)
+            it->second = it->second && ok;
+    }
 
     if (temp_file_path.has_value())
         disk.removeFile(temp_file_path.value());
     else if (temp_directory_path.has_value())
         disk.removeRecursive(temp_directory_path.value());
+
+    /// Only after the links are gone, and once per inode: every link carries the same blobs.
+    std::unordered_set<int64_t> already_released;
+    for (auto & candidate : removal_candidates)
+        if (release_inode[candidate.inode] && already_released.insert(candidate.inode).second)
+            objects_to_remove.append_range(std::move(candidate.objects));
 }
 
 CreateHardlinkOperation::CreateHardlinkOperation(std::string path_from_, std::string path_to_, const std::string & compatible_key_prefix_, IDisk & disk_)

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.cpp
@@ -40,6 +40,7 @@ namespace FailPoints
 {
     extern const char write_file_operation_fail_on_read[];
     extern const char unlink_file_operation_fail_on_remove[];
+    extern const char unlink_file_operation_pause_after_counting_links[];
     extern const char remove_recursive_operation_pause_after_traverse[];
 }
 
@@ -158,13 +159,14 @@ void WriteFileOperation::undo()
     // else: file existed but the file content is unchanged, leave it alone.
 }
 
-UnlinkFileOperation::UnlinkFileOperation(std::string path_, bool if_exists_, bool should_remove_objects_, const std::string & compatible_key_prefix_, IDisk & disk_, StoredObjects & objects_to_remove_)
+UnlinkFileOperation::UnlinkFileOperation(std::string path_, bool if_exists_, bool should_remove_objects_, const std::string & compatible_key_prefix_, IDisk & disk_, StoredObjects & objects_to_remove_, InodeReleaseVeto & inode_release_allowed_)
     : path(std::move(path_))
     , if_exists(if_exists_)
     , should_remove_objects(should_remove_objects_)
     , compatible_key_prefix(compatible_key_prefix_)
     , disk(disk_)
     , objects_to_remove(objects_to_remove_)
+    , inode_release_allowed(inode_release_allowed_)
 {
 }
 
@@ -173,6 +175,10 @@ void UnlinkFileOperation::tryUnlinkMetadataFile()
     auto object_metadata = tryReadMetadataFile(compatible_key_prefix, path, disk);
     if (!object_metadata.has_value())
         return;
+
+    /// Taken while the file still has its public name. Only metadata files get an inode recorded,
+    /// so a non-metadata file never contributes a verdict below.
+    inode = disk.stat(path).st_ino;
 
     if (object_metadata->ref_count > 0)
     {
@@ -198,6 +204,15 @@ void UnlinkFileOperation::execute()
     /// Let's update hardlink count written in serialized DiskObjectStorageMetadata before the move
     tryUnlinkMetadataFile();
 
+    /// Every execute() precedes every finalize(), so by the time any of them decides, the map
+    /// already carries the verdict of every link this transaction unlinks.
+    if (inode.has_value())
+    {
+        auto [it, inserted] = inode_release_allowed.try_emplace(*inode, should_remove_objects);
+        if (!inserted)
+            it->second = it->second && should_remove_objects;
+    }
+
     /// We need to move file to the random name for the possible undo and to save the fs hardlink count
     auto tmp_path = getRandomASCIIString(32);
     disk.moveFile(path, tmp_path);
@@ -222,15 +237,25 @@ void UnlinkFileOperation::finalize()
     const auto links = tryGetHardLinkCount(disk, tmp_file_path.value());
     const bool is_last_link = links.has_value() && *links == 1;
 
+    /// A sibling operation unlinking another link of this inode may have been told to keep the
+    /// objects. Being the last link is then not enough, or that instruction would be defeated by
+    /// whichever link happens to go last. A missing entry vetoes nothing.
+    bool release_allowed = true;
+    if (inode.has_value())
+        if (auto it = inode_release_allowed.find(*inode); it != inode_release_allowed.end())
+            release_allowed = it->second;
+
     fiu_do_on(FailPoints::unlink_file_operation_fail_on_remove,
     {
         throw Exception(ErrorCodes::FAULT_INJECTED, "Injected fault in UnlinkFileOperation remove");
     });
 
+    FailPointInjection::pauseFailPoint(FailPoints::unlink_file_operation_pause_after_counting_links);
+
     disk.removeFile(tmp_file_path.value());
 
     /// Only after the link is really gone: an unlink that throws must not leave blobs enqueued.
-    if (is_last_link)
+    if (is_last_link && release_allowed)
         objects_to_remove.append_range(std::move(removed_objects));
 }
 
@@ -320,10 +345,12 @@ void RemoveRecursiveOperation::traverseFile(const std::string & leaf)
         write_operations.back()->execute();
     }
 
+    const std::string relative_path = fs::relative(leaf, path);
+
     removal_candidates.push_back(RemovalCandidate{
-        .relative_path = fs::relative(leaf, path),
+        .relative_path = relative_path,
         .inode = inode,
-        .should_remove_its_objects = !should_remove_objects || should_remove_objects(fs::relative(leaf, path)),
+        .should_remove_its_objects = !should_remove_objects || should_remove_objects(relative_path),
         .objects = std::move(object_metadata->objects),
     });
 }
@@ -480,12 +507,13 @@ void MoveDirectoryOperation::undo()
     disk.moveDirectory(path_to, path_from);
 }
 
-ReplaceFileOperation::ReplaceFileOperation(std::string path_from_, std::string path_to_, const std::string & compatible_key_prefix_, IDisk & disk_, StoredObjects & objects_to_remove_)
+ReplaceFileOperation::ReplaceFileOperation(std::string path_from_, std::string path_to_, const std::string & compatible_key_prefix_, IDisk & disk_, StoredObjects & objects_to_remove_, InodeReleaseVeto & inode_release_allowed_)
     : path_from(path_from_)
     , path_to(path_to_)
     , compatible_key_prefix(compatible_key_prefix_)
     , disk(disk_)
     , objects_to_remove(objects_to_remove_)
+    , inode_release_allowed(inode_release_allowed_)
 {
 }
 
@@ -493,7 +521,7 @@ void ReplaceFileOperation::execute()
 {
     if (disk.existsFile(path_to))
     {
-        unlink_operation = std::make_unique<UnlinkFileOperation>(path_to, /*if_exists=*/false, /*should_remove_objects=*/true, compatible_key_prefix, disk, objects_to_remove);
+        unlink_operation = std::make_unique<UnlinkFileOperation>(path_to, /*if_exists=*/false, /*should_remove_objects=*/true, compatible_key_prefix, disk, objects_to_remove, inode_release_allowed);
         unlink_operation->execute();
     }
 

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.cpp
@@ -42,6 +42,7 @@ namespace FailPoints
     extern const char unlink_file_operation_fail_on_remove[];
     extern const char unlink_file_operation_pause_after_counting_links[];
     extern const char remove_recursive_operation_pause_after_traverse[];
+    extern const char remove_recursive_operation_fail_on_remove[];
 }
 
 namespace
@@ -431,6 +432,11 @@ void RemoveRecursiveOperation::finalize()
         if (!inserted)
             it->second = it->second && ok;
     }
+
+    fiu_do_on(FailPoints::remove_recursive_operation_fail_on_remove,
+    {
+        throw Exception(ErrorCodes::FAULT_INJECTED, "Injected fault in RemoveRecursiveOperation remove");
+    });
 
     if (temp_file_path.has_value())
         disk.removeFile(temp_file_path.value());

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.h
@@ -4,6 +4,7 @@
 #include <Disks/DiskObjectStorage/MetadataStorages/IMetadataStorage.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/StoredObject.h>
 
+#include <unordered_map>
 #include <unordered_set>
 
 namespace DB
@@ -12,6 +13,11 @@ namespace DB
 class MetadataStorageFromDisk;
 class MetadataStorageFromDiskTransaction;
 class IDisk;
+
+/// Per inode, whether the operations of one transaction that remove its hard links agree that its
+/// blobs may be released. False once any of those links is retention-listed. Shared by the unlink
+/// operations of a transaction, because each of them only ever sees its own link.
+using InodeReleaseVeto = std::unordered_map<int64_t, bool>;
 
 /**
  * Implementations for transactional operations with metadata used by MetadataStorageFromDisk.
@@ -70,7 +76,7 @@ private:
 
 struct UnlinkFileOperation final : public IMetadataOperation
 {
-    UnlinkFileOperation(std::string path_, bool if_exists_, bool should_remove_objects_, const std::string & compatible_key_prefix_, IDisk & disk_, StoredObjects & objects_to_remove_);
+    UnlinkFileOperation(std::string path_, bool if_exists_, bool should_remove_objects_, const std::string & compatible_key_prefix_, IDisk & disk_, StoredObjects & objects_to_remove_, InodeReleaseVeto & inode_release_allowed_);
 
     void tryUnlinkMetadataFile();
 
@@ -85,8 +91,10 @@ private:
     const std::string & compatible_key_prefix;
     IDisk & disk;
     StoredObjects & objects_to_remove;
+    InodeReleaseVeto & inode_release_allowed;
 
     std::optional<std::string> tmp_file_path;
+    std::optional<int64_t> inode;
     std::unique_ptr<WriteFileOperation> write_operation;
     /// Candidates only. Released in finalize() iff this unlink drops the last hard link.
     StoredObjects removed_objects;
@@ -211,7 +219,7 @@ private:
 
 struct ReplaceFileOperation final : public IMetadataOperation
 {
-    ReplaceFileOperation(std::string path_from_, std::string path_to_, const std::string & compatible_key_prefix, IDisk & disk_, StoredObjects & objects_to_remove_);
+    ReplaceFileOperation(std::string path_from_, std::string path_to_, const std::string & compatible_key_prefix, IDisk & disk_, StoredObjects & objects_to_remove_, InodeReleaseVeto & inode_release_allowed_);
 
     void execute() override;
     void undo() override;
@@ -223,6 +231,7 @@ private:
     const std::string & compatible_key_prefix;
     IDisk & disk;
     StoredObjects & objects_to_remove;
+    InodeReleaseVeto & inode_release_allowed;
 
     std::unique_ptr<UnlinkFileOperation> unlink_operation;
     bool moved = false;

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.h
@@ -88,6 +88,7 @@ private:
 
     std::optional<std::string> tmp_file_path;
     std::unique_ptr<WriteFileOperation> write_operation;
+    /// Candidates only. Released in finalize() iff this unlink drops the last hard link.
     StoredObjects removed_objects;
 };
 
@@ -149,11 +150,21 @@ private:
     IDisk & disk;
     StoredObjects & objects_to_remove;
 
+    /// One metadata file being removed. Entries share an inode when the subtree holds
+    /// hard links to the same file.
+    struct RemovalCandidate
+    {
+        std::string relative_path;
+        int64_t inode;
+        bool should_remove_its_objects;
+        StoredObjects objects;
+    };
+
     std::optional<std::string> temp_file_path;
     std::optional<std::string> temp_directory_path;
     std::unordered_set<int64_t> visited_inodes;
     std::vector<std::unique_ptr<WriteFileOperation>> write_operations;
-    StoredObjects removed_objects;
+    std::vector<RemovalCandidate> removal_candidates;
 };
 
 struct CreateHardlinkOperation final : public IMetadataOperation

--- a/src/Disks/tests/gtest_metadata_local_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_local_disk.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <exception>
@@ -32,6 +31,7 @@ namespace DB::FailPoints
 {
     extern const char unlink_file_operation_fail_on_remove[];
     extern const char unlink_file_operation_pause_after_counting_links[];
+    extern const char metadata_transaction_pause_before_finalize[];
     extern const char remove_recursive_operation_fail_on_remove[];
 }
 
@@ -1876,10 +1876,14 @@ TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenHardlinkIsCreatedAfterUnlinkInSame
 ///
 /// What is asserted is the exclusion itself, not a released blob, because the exclusion holds by
 /// construction while the release only follows from whichever interleaving a round happens to get.
-/// The failpoint is PAUSEABLE, so it blocks EVERY thread that reaches it: while the first
+/// The failpoints are PAUSEABLE, so they block EVERY thread that reaches them: while the first
 /// transaction is parked between counting and unlinking, a second park is reachable exactly when
 /// the second transaction can enter finalization concurrently. With the mutex it cannot, so the
 /// park count stays at one for as long as the first thread is held there.
+///
+/// The second transaction is released from a park immediately in front of the mutex, so what
+/// remains between the release and the assertion is a single mutex acquisition rather than a
+/// thread start and a whole execute() pass.
 TEST_F(MetadataLocalDiskTest, TestBlobReleasedWhenTwoTransactionsRaceToTakeTheLastHardlink)
 {
     auto metadata = getMetadataStorage("/TestBlobReleasedWhenTwoTransactionsRaceToTakeTheLastHardlink");
@@ -1916,24 +1920,28 @@ TEST_F(MetadataLocalDiskTest, TestBlobReleasedWhenTwoTransactionsRaceToTakeTheLa
         DB::FailPointInjection::waitForPause(DB::FailPoints::unlink_file_operation_pause_after_counting_links);
         EXPECT_EQ(DB::FailPointInjection::getPauseCount(DB::FailPoints::unlink_file_operation_pause_after_counting_links), 1UL);
 
-        std::atomic<bool> second_is_committing = false;
+        /// Enabled only now: the first thread is already past this point, so the park below is the
+        /// second thread's.
+        DB::FailPointInjection::enableFailPoint(DB::FailPoints::metadata_transaction_pause_before_finalize);
+
         std::thread second([&]
         {
             auto tx = metadata->createTransaction();
             tx->unlinkFile(second_name, /*if_exists=*/false, /*should_remove_objects=*/true);
-            second_is_committing = true;
             tx->commit(DB::NoCommitOptions{});
         });
 
-        /// Only a precondition for the window below: it says the second transaction has finished
-        /// its own execute() and entered commit(), so the window is not spent on thread startup.
-        while (!second_is_committing)
-            std::this_thread::yield();
+        /// Waits for the state "the second transaction is at the finalization gate" rather than for
+        /// a flag that only says it entered commit(), so arrival is proven and not assumed.
+        DB::FailPointInjection::waitForPause(DB::FailPoints::metadata_transaction_pause_before_finalize);
+        EXPECT_EQ(DB::FailPointInjection::getPauseCount(DB::FailPoints::metadata_transaction_pause_before_finalize), 1UL);
+        DB::FailPointInjection::disableFailPoint(DB::FailPoints::metadata_transaction_pause_before_finalize);
 
         /// The assertion. A second park means both transactions were inside finalization at once.
-        /// Polled rather than waited on because the expected outcome is that it never happens.
+        /// Polled rather than waited on because the expected outcome is that it never happens; the
+        /// window only has to cover one mutex acquisition by an already running thread.
         size_t observed_parks = 1;
-        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
         while (std::chrono::steady_clock::now() < deadline)
         {
             observed_parks

--- a/src/Disks/tests/gtest_metadata_local_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_local_disk.cpp
@@ -1,9 +1,11 @@
 #include <gtest/gtest.h>
+#include <atomic>
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
 #include <memory>
 #include <mutex>
+#include <thread>
 #include <Core/ServerUUID.h>
 #include <Disks/DiskLocal.h>
 #include <Disks/DiskObjectStorage/MetadataStorages/DiskObjectStorageMetadata.h>
@@ -28,6 +30,7 @@ namespace fs = std::filesystem;
 namespace DB::FailPoints
 {
     extern const char unlink_file_operation_fail_on_remove[];
+    extern const char unlink_file_operation_pause_after_counting_links[];
 }
 
 class MetadataLocalDiskTest : public testing::Test
@@ -1561,6 +1564,16 @@ TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenRefCountIsStrandedByCrash)
     /// "B" still points at the blob, so it must survive despite ref_count reading 0.
     EXPECT_TRUE(metadata->existsFile("B"));
     verifyBlobsToRemove(metadata, {});
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->unlinkFile("B", /*if_exists=*/false, /*should_remove_objects=*/true);
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    /// Keeping the blob must not become unconditional: the counter is still stranded low, but the
+    /// decision reads st_nlink, so taking the surviving link does release.
+    verifyBlobsToRemove(metadata, {"key1"});
 }
 
 TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenRefCountIsStrandedByCrashRecursive)
@@ -1586,6 +1599,14 @@ TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenRefCountIsStrandedByCrashRecursive
 
     EXPECT_TRUE(metadata->existsFile("outside"));
     verifyBlobsToRemove(metadata, {});
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->unlinkFile("outside", /*if_exists=*/false, /*should_remove_objects=*/true);
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    verifyBlobsToRemove(metadata, {"key1"});
 }
 
 TEST_F(MetadataLocalDiskTest, TestBlobReleasedOnlyByLastOfTwoTransactions)
@@ -1669,9 +1690,16 @@ TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenTheOnlyUnlinkOfTheTransactionFails
     verifyBlobsToRemove(metadata, {});
 }
 
-TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenOneHardlinkIsRetentionListed)
+/// Which of two aliases the recursive walk reaches first is unspecified, so both are covered:
+/// the AND-fold must give the same verdict either way.
+class MetadataLocalDiskRetentionListedAliasTest : public MetadataLocalDiskTest, public testing::WithParamInterface<std::string>
 {
-    auto metadata = getMetadataStorage("/TestBlobKeptWhenOneHardlinkIsRetentionListed");
+};
+
+TEST_P(MetadataLocalDiskRetentionListedAliasTest, TestBlobKeptWhenOneHardlinkIsRetentionListed)
+{
+    const std::string retained = GetParam();
+    auto metadata = getMetadataStorage("/TestBlobKeptWhenOneHardlinkIsRetentionListed." + retained);
 
     {
         auto tx = metadata->createTransaction();
@@ -1684,12 +1712,85 @@ TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenOneHardlinkIsRetentionListed)
 
     {
         auto tx = metadata->createTransaction();
-        tx->removeRecursive("root", [](const std::string & relative_path) { return relative_path != "B"; });
+        tx->removeRecursive("root", [&](const std::string & relative_path) { return relative_path != retained; });
         tx->commit(DB::NoCommitOptions{});
     }
 
-    /// The subtree removes both links to key1, but "B" is retention-listed, so key1 must be kept.
+    /// The subtree removes both links to key1, but one of them is retention-listed, so key1 must be kept.
     verifyBlobsToRemove(metadata, {"key2"});
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BothAliases,
+    MetadataLocalDiskRetentionListedAliasTest,
+    testing::Values("A", "B"),
+    [](const testing::TestParamInfo<std::string> & param_info) { return "Retaining" + param_info.param; });
+
+/// One transaction removing two links to one inode, where one link is retention-listed. Each
+/// unlink operation sees only its own link, so without a shared veto whichever link goes last
+/// finds a single remaining link and releases the blob the other link asked to keep.
+class MetadataLocalDiskRetentionListedUnlinkTest : public MetadataLocalDiskTest, public testing::WithParamInterface<bool>
+{
+};
+
+TEST_P(MetadataLocalDiskRetentionListedUnlinkTest, TestBlobKeptWhenOneOfTwoUnlinksKeepsObjects)
+{
+    const bool retained_goes_first = GetParam();
+    auto metadata = getMetadataStorage(std::string("/TestBlobKeptWhenOneOfTwoUnlinksKeepsObjects.") + (retained_goes_first ? "first" : "second"));
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createMetadataFile("A", {blobFor("key1", "A")});
+        tx->createHardLink("A", "B");
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    {
+        auto tx = metadata->createTransaction();
+        if (retained_goes_first)
+        {
+            tx->unlinkFile("A", /*if_exists=*/false, /*should_remove_objects=*/false);
+            tx->unlinkFile("B", /*if_exists=*/false, /*should_remove_objects=*/true);
+        }
+        else
+        {
+            tx->unlinkFile("A", /*if_exists=*/false, /*should_remove_objects=*/true);
+            tx->unlinkFile("B", /*if_exists=*/false, /*should_remove_objects=*/false);
+        }
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    EXPECT_FALSE(metadata->existsFile("A"));
+    EXPECT_FALSE(metadata->existsFile("B"));
+    verifyBlobsToRemove(metadata, {});
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BothOrders,
+    MetadataLocalDiskRetentionListedUnlinkTest,
+    testing::Bool(),
+    [](const testing::TestParamInfo<bool> & param_info) { return param_info.param ? "RetainedFirst" : "RetainedSecond"; });
+
+TEST_F(MetadataLocalDiskTest, TestBlobReleasedWhenBothUnlinksRemoveObjects)
+{
+    auto metadata = getMetadataStorage("/TestBlobReleasedWhenBothUnlinksRemoveObjects");
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createMetadataFile("A", {blobFor("key1", "A")});
+        tx->createHardLink("A", "B");
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->unlinkFile("A", /*if_exists=*/false, /*should_remove_objects=*/true);
+        tx->unlinkFile("B", /*if_exists=*/false, /*should_remove_objects=*/true);
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    /// The veto must not become a blanket suppression when no link asks to keep the objects.
+    verifyBlobsToRemove(metadata, {"key1"});
 }
 
 TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenHardlinkIsCreatedAfterUnlinkInSameTransaction)
@@ -1714,4 +1815,75 @@ TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenHardlinkIsCreatedAfterUnlinkInSame
     /// "C" outlives the transaction, so the blob must be kept.
     EXPECT_TRUE(metadata->existsFile("C"));
     verifyBlobsToRemove(metadata, {});
+}
+
+/// Two transactions each removing one of an inode's two hard links. The finalization mutex makes
+/// them count and unlink one at a time, so the second one sees a single remaining link and
+/// releases the blob. Without it both can count two links before either unlinks, both decline,
+/// and the blob is leaked with no hard link left that could ever release it.
+///
+/// The mutex makes that interleaving impossible rather than merely unlikely, so every round owes a
+/// release and a single round without one is a real failure. Rounds are repeated because the test
+/// has to HIT the failing interleaving to reject an implementation without the mutex; the pauseable
+/// failpoint widens the window so that hitting it is likely, by parking the first transaction
+/// between counting and unlinking while the second only has to reach its own count.
+TEST_F(MetadataLocalDiskTest, TestBlobReleasedWhenTwoTransactionsRaceToTakeTheLastHardlink)
+{
+    auto metadata = getMetadataStorage("/TestBlobReleasedWhenTwoTransactionsRaceToTakeTheLastHardlink");
+
+    static constexpr size_t rounds = 200;
+    std::set<std::string> expected_released;
+
+    for (size_t round = 0; round < rounds; ++round)
+    {
+        const std::string first_name = "A" + std::to_string(round);
+        const std::string second_name = "B" + std::to_string(round);
+        const std::string key = "key" + std::to_string(round);
+
+        {
+            auto tx = metadata->createTransaction();
+            tx->createMetadataFile(first_name, {blobFor(key, first_name)});
+            tx->createHardLink(first_name, second_name);
+            tx->commit(DB::NoCommitOptions{});
+        }
+
+        DB::FailPointInjection::enableFailPoint(DB::FailPoints::unlink_file_operation_pause_after_counting_links);
+
+        /// Parks inside finalize(), after counting this inode's links and before unlinking one.
+        std::thread first([&]
+        {
+            auto tx = metadata->createTransaction();
+            tx->unlinkFile(first_name, /*if_exists=*/false, /*should_remove_objects=*/true);
+            tx->commit(DB::NoCommitOptions{});
+        });
+
+        DB::FailPointInjection::waitForPause(DB::FailPoints::unlink_file_operation_pause_after_counting_links);
+
+        std::atomic<bool> second_is_committing = false;
+        std::thread second([&]
+        {
+            auto tx = metadata->createTransaction();
+            tx->unlinkFile(second_name, /*if_exists=*/false, /*should_remove_objects=*/true);
+            second_is_committing = true;
+            tx->commit(DB::NoCommitOptions{});
+        });
+
+        /// Returns once the second transaction is at the door. Under the mutex it then blocks on
+        /// it, which is the property under test; without the mutex it walks into the same window.
+        while (!second_is_committing)
+            std::this_thread::yield();
+
+        /// Resumes the parked thread and stops the second one from parking as well.
+        DB::FailPointInjection::disableFailPoint(DB::FailPoints::unlink_file_operation_pause_after_counting_links);
+
+        first.join();
+        second.join();
+
+        EXPECT_FALSE(metadata->existsFile(first_name));
+        EXPECT_FALSE(metadata->existsFile(second_name));
+
+        /// Each round takes both links of its own inode, so each round owes exactly one release.
+        expected_released.insert(key);
+        verifyBlobsToRemove(metadata, expected_released);
+    }
 }

--- a/src/Disks/tests/gtest_metadata_local_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_local_disk.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <atomic>
+#include <chrono>
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
@@ -31,6 +32,7 @@ namespace DB::FailPoints
 {
     extern const char unlink_file_operation_fail_on_remove[];
     extern const char unlink_file_operation_pause_after_counting_links[];
+    extern const char remove_recursive_operation_fail_on_remove[];
 }
 
 class MetadataLocalDiskTest : public testing::Test
@@ -1690,6 +1692,56 @@ TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenTheOnlyUnlinkOfTheTransactionFails
     verifyBlobsToRemove(metadata, {});
 }
 
+/// A recursive removal must not enqueue blobs before the links are actually gone, for the same
+/// reason a single unlink must not. The single link here is deliberate: with two links the link
+/// gate alone would withhold the blob, and the ordering would go untested.
+class MetadataLocalDiskRecursiveRemoveOrderingTest : public MetadataLocalDiskTest, public testing::WithParamInterface<bool>
+{
+};
+
+TEST_P(MetadataLocalDiskRecursiveRemoveOrderingTest, TestBlobKeptOnlyWhenRecursiveRemoveFails)
+{
+    const bool remove_fails = GetParam();
+    auto metadata = getMetadataStorage(std::string("/TestBlobKeptOnlyWhenRecursiveRemoveFails.") + (remove_fails ? "fails" : "succeeds"));
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createDirectory("root");
+        tx->createMetadataFile("root/A", {blobFor("key1", "root/A")});
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    if (remove_fails)
+        DB::FailPointInjection::enableFailPoint(DB::FailPoints::remove_recursive_operation_fail_on_remove);
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->removeRecursive("root", /*should_remove_objects=*/nullptr);
+        /// finalize() is best-effort, so the commit itself still succeeds either way.
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    if (remove_fails)
+    {
+        DB::FailPointInjection::disableFailPoint(DB::FailPoints::remove_recursive_operation_fail_on_remove);
+
+        /// The metadata file still exists under its temporary name, so it still references the blob.
+        verifyBlobsToRemove(metadata, {});
+    }
+    else
+    {
+        /// The same scenario without the injected failure must release, or the case above would
+        /// pass against an implementation that never releases here at all.
+        verifyBlobsToRemove(metadata, {"key1"});
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RemoveOutcome,
+    MetadataLocalDiskRecursiveRemoveOrderingTest,
+    testing::Bool(),
+    [](const testing::TestParamInfo<bool> & param_info) { return param_info.param ? "RemoveFails" : "RemoveSucceeds"; });
+
 /// Which of two aliases the recursive walk reaches first is unspecified, so both are covered:
 /// the AND-fold must give the same verdict either way.
 class MetadataLocalDiskRetentionListedAliasTest : public MetadataLocalDiskTest, public testing::WithParamInterface<std::string>
@@ -1822,16 +1874,19 @@ TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenHardlinkIsCreatedAfterUnlinkInSame
 /// releases the blob. Without it both can count two links before either unlinks, both decline,
 /// and the blob is leaked with no hard link left that could ever release it.
 ///
-/// The mutex makes that interleaving impossible rather than merely unlikely, so every round owes a
-/// release and a single round without one is a real failure. Rounds are repeated because the test
-/// has to HIT the failing interleaving to reject an implementation without the mutex; the pauseable
-/// failpoint widens the window so that hitting it is likely, by parking the first transaction
-/// between counting and unlinking while the second only has to reach its own count.
+/// What is asserted is the exclusion itself, not a released blob, because the exclusion holds by
+/// construction while the release only follows from whichever interleaving a round happens to get.
+/// The failpoint is PAUSEABLE, so it blocks EVERY thread that reaches it: while the first
+/// transaction is parked between counting and unlinking, a second park is reachable exactly when
+/// the second transaction can enter finalization concurrently. With the mutex it cannot, so the
+/// park count stays at one for as long as the first thread is held there.
 TEST_F(MetadataLocalDiskTest, TestBlobReleasedWhenTwoTransactionsRaceToTakeTheLastHardlink)
 {
     auto metadata = getMetadataStorage("/TestBlobReleasedWhenTwoTransactionsRaceToTakeTheLastHardlink");
 
-    static constexpr size_t rounds = 200;
+    /// Each round is a complete test of the property; a few are run only to catch a state leak
+    /// between rounds, not to make an unlikely interleaving eventually appear.
+    static constexpr size_t rounds = 3;
     std::set<std::string> expected_released;
 
     for (size_t round = 0; round < rounds; ++round)
@@ -1847,6 +1902,7 @@ TEST_F(MetadataLocalDiskTest, TestBlobReleasedWhenTwoTransactionsRaceToTakeTheLa
             tx->commit(DB::NoCommitOptions{});
         }
 
+        /// Enabling creates a fresh channel, so the park count below starts from zero each round.
         DB::FailPointInjection::enableFailPoint(DB::FailPoints::unlink_file_operation_pause_after_counting_links);
 
         /// Parks inside finalize(), after counting this inode's links and before unlinking one.
@@ -1858,6 +1914,7 @@ TEST_F(MetadataLocalDiskTest, TestBlobReleasedWhenTwoTransactionsRaceToTakeTheLa
         });
 
         DB::FailPointInjection::waitForPause(DB::FailPoints::unlink_file_operation_pause_after_counting_links);
+        EXPECT_EQ(DB::FailPointInjection::getPauseCount(DB::FailPoints::unlink_file_operation_pause_after_counting_links), 1UL);
 
         std::atomic<bool> second_is_committing = false;
         std::thread second([&]
@@ -1868,12 +1925,26 @@ TEST_F(MetadataLocalDiskTest, TestBlobReleasedWhenTwoTransactionsRaceToTakeTheLa
             tx->commit(DB::NoCommitOptions{});
         });
 
-        /// Returns once the second transaction is at the door. Under the mutex it then blocks on
-        /// it, which is the property under test; without the mutex it walks into the same window.
+        /// Only a precondition for the window below: it says the second transaction has finished
+        /// its own execute() and entered commit(), so the window is not spent on thread startup.
         while (!second_is_committing)
             std::this_thread::yield();
 
-        /// Resumes the parked thread and stops the second one from parking as well.
+        /// The assertion. A second park means both transactions were inside finalization at once.
+        /// Polled rather than waited on because the expected outcome is that it never happens.
+        size_t observed_parks = 1;
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (std::chrono::steady_clock::now() < deadline)
+        {
+            observed_parks
+                = DB::FailPointInjection::getPauseCount(DB::FailPoints::unlink_file_operation_pause_after_counting_links).value_or(0);
+            if (observed_parks > 1)
+                break;
+            sleepForMilliseconds(1);
+        }
+        EXPECT_EQ(observed_parks, 1UL) << "two transactions finalized concurrently in round " << round;
+
+        /// Resumes the parked thread. The second one then finalizes on its own.
         DB::FailPointInjection::disableFailPoint(DB::FailPoints::unlink_file_operation_pause_after_counting_links);
 
         first.join();
@@ -1882,7 +1953,8 @@ TEST_F(MetadataLocalDiskTest, TestBlobReleasedWhenTwoTransactionsRaceToTakeTheLa
         EXPECT_FALSE(metadata->existsFile(first_name));
         EXPECT_FALSE(metadata->existsFile(second_name));
 
-        /// Each round takes both links of its own inode, so each round owes exactly one release.
+        /// Serialized finalization leaves the second one looking at a single link, so the release
+        /// is owed in every round rather than in some of them.
         expected_released.insert(key);
         verifyBlobsToRemove(metadata, expected_released);
     }

--- a/src/Disks/tests/gtest_metadata_local_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_local_disk.cpp
@@ -6,7 +6,9 @@
 #include <mutex>
 #include <Core/ServerUUID.h>
 #include <Disks/DiskLocal.h>
+#include <Disks/DiskObjectStorage/MetadataStorages/DiskObjectStorageMetadata.h>
 #include <Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.h>
+#include <Common/FailPoint.h>
 #include <Common/ObjectStorageKeyGenerator.h>
 #include <Common/tests/gtest_global_context.h>
 #include <Common/tests/gtest_global_register.h>
@@ -22,6 +24,11 @@
 #include <base/sleep.h>
 
 namespace fs = std::filesystem;
+
+namespace DB::FailPoints
+{
+    extern const char unlink_file_operation_fail_on_remove[];
+}
 
 class MetadataLocalDiskTest : public testing::Test
 {
@@ -1463,4 +1470,248 @@ TEST_F(MetadataLocalDiskTest, TestNonExistingObjectsInTransaction)
                 transaction->commit(DB::NoCommitOptions{});
             });
     }
+}
+
+static DB::StoredObject blobFor(const std::string & key, const std::string & path)
+{
+    return DB::StoredObject(DB::ObjectStorageKey::createAsAbsolute(key).serialize(), path, 100);
+}
+
+/// Rewrites the metadata file in place (same inode, so every hard link sees it) with ref_count
+/// one lower than the number of links. That is exactly the state a crash between the persisted
+/// decrement and the unlink leaves behind.
+static void strandRefCount(const DB::MetadataStoragePtr & metadata, const std::string & prefix, const std::string & path)
+{
+    DB::DiskObjectStorageMetadata object_metadata(prefix, path);
+    object_metadata.deserializeFromString(metadata->readFileToString(path));
+    ASSERT_GT(object_metadata.ref_count, 0);
+    object_metadata.ref_count -= 1;
+
+    auto tx = metadata->createTransaction();
+    tx->writeStringToFile(path, object_metadata.serializeToString());
+    tx->commit(DB::NoCommitOptions{});
+}
+
+/// A blob is released only when the metadata file being removed is the last hard link to it.
+
+TEST_F(MetadataLocalDiskTest, TestBlobReleasedWhenRecursiveRemoveTakesAllHardlinks)
+{
+    auto metadata = getMetadataStorage("/TestBlobReleasedWhenRecursiveRemoveTakesAllHardlinks");
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createDirectory("root");
+        tx->createMetadataFile("root/A", {blobFor("key1", "root/A")});
+        tx->createHardLink("root/A", "root/B");
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->removeRecursive("root", /*should_remove_objects=*/nullptr);
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    /// One removal took every link, so the blob is unreferenced and must be released.
+    verifyBlobsToRemove(metadata, {"key1"});
+}
+
+TEST_F(MetadataLocalDiskTest, TestBlobReleasedWhenTwoUnlinksTakeAllHardlinks)
+{
+    auto metadata = getMetadataStorage("/TestBlobReleasedWhenTwoUnlinksTakeAllHardlinks");
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createMetadataFile("A", {blobFor("key1", "A")});
+        tx->createHardLink("A", "B");
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->unlinkFile("A", /*if_exists=*/false, /*should_remove_objects=*/true);
+        tx->unlinkFile("B", /*if_exists=*/false, /*should_remove_objects=*/true);
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    verifyBlobsToRemove(metadata, {"key1"});
+}
+
+TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenRefCountIsStrandedByCrash)
+{
+    const std::string prefix = "/TestBlobKeptWhenRefCountIsStrandedByCrash";
+    auto metadata = getMetadataStorage(prefix);
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createMetadataFile("A", {blobFor("key1", "A")});
+        tx->createHardLink("A", "B");
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    strandRefCount(metadata, prefix, "A");
+    EXPECT_EQ(metadata->getHardlinkCount("A"), 0);
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->unlinkFile("A", /*if_exists=*/false, /*should_remove_objects=*/true);
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    /// "B" still points at the blob, so it must survive despite ref_count reading 0.
+    EXPECT_TRUE(metadata->existsFile("B"));
+    verifyBlobsToRemove(metadata, {});
+}
+
+TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenRefCountIsStrandedByCrashRecursive)
+{
+    const std::string prefix = "/TestBlobKeptWhenRefCountIsStrandedByCrashRecursive";
+    auto metadata = getMetadataStorage(prefix);
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createDirectory("root");
+        tx->createMetadataFile("root/A", {blobFor("key1", "root/A")});
+        tx->createHardLink("root/A", "outside");
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    strandRefCount(metadata, prefix, "root/A");
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->removeRecursive("root", /*should_remove_objects=*/nullptr);
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    EXPECT_TRUE(metadata->existsFile("outside"));
+    verifyBlobsToRemove(metadata, {});
+}
+
+TEST_F(MetadataLocalDiskTest, TestBlobReleasedOnlyByLastOfTwoTransactions)
+{
+    auto metadata = getMetadataStorage("/TestBlobReleasedOnlyByLastOfTwoTransactions");
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createMetadataFile("A", {blobFor("key1", "A")});
+        tx->createHardLink("A", "B");
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->unlinkFile("A", /*if_exists=*/false, /*should_remove_objects=*/true);
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    verifyBlobsToRemove(metadata, {});
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->unlinkFile("B", /*if_exists=*/false, /*should_remove_objects=*/true);
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    verifyBlobsToRemove(metadata, {"key1"});
+}
+
+TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenOneUnlinkOfTheTransactionFails)
+{
+    auto metadata = getMetadataStorage("/TestBlobKeptWhenOneUnlinkOfTheTransactionFails");
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createMetadataFile("A", {blobFor("key1", "A")});
+        tx->createHardLink("A", "B");
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    /// Fires once, so only the first of the two unlinks fails to remove its file.
+    DB::FailPointInjection::enableFailPoint(DB::FailPoints::unlink_file_operation_fail_on_remove);
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->unlinkFile("A", /*if_exists=*/false, /*should_remove_objects=*/true);
+        tx->unlinkFile("B", /*if_exists=*/false, /*should_remove_objects=*/true);
+        /// finalize() is best-effort, so the commit itself still succeeds.
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    DB::FailPointInjection::disableFailPoint(DB::FailPoints::unlink_file_operation_fail_on_remove);
+
+    /// One link survives the failed unlink, so the blob is still referenced.
+    verifyBlobsToRemove(metadata, {});
+}
+
+TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenTheOnlyUnlinkOfTheTransactionFails)
+{
+    auto metadata = getMetadataStorage("/TestBlobKeptWhenTheOnlyUnlinkOfTheTransactionFails");
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createMetadataFile("A", {blobFor("key1", "A")});
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    DB::FailPointInjection::enableFailPoint(DB::FailPoints::unlink_file_operation_fail_on_remove);
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->unlinkFile("A", /*if_exists=*/false, /*should_remove_objects=*/true);
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    DB::FailPointInjection::disableFailPoint(DB::FailPoints::unlink_file_operation_fail_on_remove);
+
+    /// "A" was the last link, but the unlink did not happen, so the metadata file still
+    /// references the blob and the release decision it was premised on does not hold.
+    verifyBlobsToRemove(metadata, {});
+}
+
+TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenOneHardlinkIsRetentionListed)
+{
+    auto metadata = getMetadataStorage("/TestBlobKeptWhenOneHardlinkIsRetentionListed");
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createDirectory("root");
+        tx->createMetadataFile("root/A", {blobFor("key1", "root/A")});
+        tx->createHardLink("root/A", "root/B");
+        tx->createMetadataFile("root/C", {blobFor("key2", "root/C")});
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->removeRecursive("root", [](const std::string & relative_path) { return relative_path != "B"; });
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    /// The subtree removes both links to key1, but "B" is retention-listed, so key1 must be kept.
+    verifyBlobsToRemove(metadata, {"key2"});
+}
+
+TEST_F(MetadataLocalDiskTest, TestBlobKeptWhenHardlinkIsCreatedAfterUnlinkInSameTransaction)
+{
+    auto metadata = getMetadataStorage("/TestBlobKeptWhenHardlinkIsCreatedAfterUnlinkInSameTransaction");
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createMetadataFile("A", {blobFor("key1", "A")});
+        tx->createHardLink("A", "B");
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->unlinkFile("A", /*if_exists=*/false, /*should_remove_objects=*/true);
+        tx->createHardLink("B", "C");
+        tx->unlinkFile("B", /*if_exists=*/false, /*should_remove_objects=*/true);
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    /// "C" outlives the transaction, so the blob must be kept.
+    EXPECT_TRUE(metadata->existsFile("C"));
+    verifyBlobsToRemove(metadata, {});
 }

--- a/tests/integration/test_s3_metadata_hardlink_blob_release/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_s3_metadata_hardlink_blob_release/configs/config.d/storage_conf.xml
@@ -1,0 +1,28 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <s3>
+                <type>s3</type>
+                <endpoint>http://minio1:9001/root/data/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
+            </s3>
+        </disks>
+        <policies>
+            <s3>
+                <volumes>
+                    <main>
+                        <disk>s3</disk>
+                    </main>
+                </volumes>
+            </s3>
+        </policies>
+    </storage_configuration>
+
+    <merge_tree>
+        <!-- Wide parts, so every column is its own blob and a partial mutation hardlinks the
+             columns it does not rewrite. -->
+        <min_bytes_for_wide_part>0</min_bytes_for_wide_part>
+        <min_bytes_for_full_part_storage>0</min_bytes_for_full_part_storage>
+    </merge_tree>
+</clickhouse>

--- a/tests/integration/test_s3_metadata_hardlink_blob_release/test.py
+++ b/tests/integration/test_s3_metadata_hardlink_blob_release/test.py
@@ -1,0 +1,81 @@
+import logging
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+
+@pytest.fixture(scope="module")
+def cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance(
+            "node",
+            main_configs=["configs/config.d/storage_conf.xml"],
+            stay_alive=True,
+            with_minio=True,
+        )
+        logging.info("Starting cluster...")
+        cluster.start()
+        logging.info("Cluster started")
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_blobs_of_hardlinked_part_survive_crash_during_removal(cluster):
+    """FREEZE hardlinks a part's files into shadow/, so both names share one metadata file and
+    therefore one reference count. If the server is killed while UNFREEZE is removing the frozen
+    copy, the persisted counts are already decremented but no link is gone. Removing the frozen
+    copy afterwards must not delete blobs the live part still points to.
+    """
+    node = cluster.instances["node"]
+    table = "t_hardlink_blob_release"
+
+    node.query(f"DROP TABLE IF EXISTS {table} SYNC")
+    node.query(
+        f"""
+        CREATE TABLE {table} (a UInt64, d UInt64)
+        ENGINE = MergeTree ORDER BY a SETTINGS storage_policy = 's3'
+        """
+    )
+    node.query(f"INSERT INTO {table} SELECT number, number FROM numbers(10000)")
+
+    expected = node.query(f"SELECT count(), sum(d) FROM {table}").strip()
+
+    node.query(f"ALTER TABLE {table} FREEZE WITH NAME 'backup1'")
+
+    # Park the removal of the frozen copy after its traversal has persisted the reference-count
+    # decrements but before anything is unlinked, then kill the server in that window.
+    node.query("SYSTEM ENABLE FAILPOINT remove_recursive_operation_pause_after_traverse")
+    unfreeze = node.get_query_request(f"ALTER TABLE {table} UNFREEZE WITH NAME 'backup1'")
+    node.query(
+        "SYSTEM WAIT FAILPOINT remove_recursive_operation_pause_after_traverse PAUSE",
+        timeout=180,
+    )
+    # Kill only the server process: the harness helper pkills every "clickhouse" match,
+    # which also hits the container's wrapper shell and takes the container down with it.
+    server_pid = node.get_process_pid("clickhouse server")
+    assert server_pid is not None
+    node.exec_in_container(["bash", "-c", f"kill -9 {server_pid}"], user="root")
+
+    # start_clickhouse() waits for any process matching "clickhouse" to be gone, so the client
+    # that issued the parked UNFREEZE has to be reaped too.
+    unfreeze.get_answer_and_error()
+    for _ in range(60):
+        if node.get_process_pid("clickhouse") is None:
+            break
+        time.sleep(1)
+    else:
+        raise Exception("clickhouse processes did not exit after SIGKILL")
+
+    node.start_clickhouse()
+
+    # Finish removing the frozen copy, now with reference counts that are one too low.
+    node.query(f"ALTER TABLE {table} UNFREEZE WITH NAME 'backup1'")
+
+    # Reading the part proves its blobs were not deleted with the frozen copy.
+    assert node.query(f"SELECT count(), sum(d) FROM {table}").strip() == expected
+
+    node.query(f"DROP TABLE {table} SYNC")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/111188   (auto-closes the issue when this PR is merged into the default branch)
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/111188


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a loss of object storage blobs after an unclean shutdown. On a disk with `local` metadata, a part file removed while the server was killed could leave its persisted reference count one lower than the number of hard links to it, and the next removal then deleted blobs that a live part still pointed to, so reading that part failed with `The specified key does not exist`. A blob is now released only when the removal actually drops its last hard link. Closes #111188.


### Description

The reference count in a `local` metadata file is a redundant copy of that file's hard-link count, and its decrement is not crash-atomic with the unlink it pairs with: `UnlinkFileOperation::execute` persists the decrement and renames the file aside, and only `finalize()` unlinks. An exception is safe, since the transaction rolls back, but a kill in that window leaves the count one too low while every directory entry survives. The next removal reads zero and deletes a blob a live part still references. `RemoveRecursiveOperation` has the same shape. Parts share an inode through `FREEZE` and partial mutations.

The persisted counter no longer authorizes destruction. Each removal operation decides in its own `finalize()`, immediately before its own unlink, and releases a blob only when that unlink drops the last hard link. `RemoveRecursiveOperation` counts links per inode within the subtree it removes. A retention-listed alias vetoes the release for its whole inode, so "keep this file's blobs" cannot be defeated by unlink order. Both operations now enqueue only after the unlink succeeds; the enqueue came first before, so a failing unlink could enqueue a blob whose link survived. A dedicated mutex serializes finalization so two transactions dropping an inode's last two links cannot both see two and both decline; widening `metadata_mutex` instead would block metadata reads for a whole recursive deletion.

The counter keeps its meaning and serialization, so `getHardlinkCount`, the zero-copy consumer and the on-disk format are unchanged. A decrement already lost to an earlier crash now leaks its blob rather than deleting it; reclaiming those needs a startup repair scan, out of scope.

A new integration test reproduces the loss from `FREEZE`/`UNFREEZE` plus a kill, using only supported operations: 5/5 fail without the fix, 25/25 pass with it. Sixteen new unit cases cover both directions, including the previously uncovered leak direction.