### PR TITLE
Fix flaky test `04267_ttl_drop_merge_no_data_read`

### DIFF
--- a/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.sh
+++ b/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.sh
@@ -93,6 +93,9 @@ ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_no_read;"
 
 # -------------------------------------------------------------------
 # Case 2: TTLDrop with projections — projections should be empty
+# remove_empty_parts = 0 keeps the empty part produced by the TTLDrop
+# merge active; otherwise the cleanup thread may drop it before the
+# projections check below sees it in system.parts.
 # -------------------------------------------------------------------
 echo "-- Case 2: TTLDrop with projections"
 
@@ -110,7 +113,8 @@ ${CLICKHOUSE_CLIENT} -q "
     SETTINGS
         ttl_only_drop_parts = 1,
         merge_with_ttl_timeout = 0,
-        min_bytes_for_wide_part = 1;
+        min_bytes_for_wide_part = 1,
+        remove_empty_parts = 0;
 
     SYSTEM STOP MERGES t_ttl_drop_proj;
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/113248
Related: https://github.com/ClickHouse/ClickHouse/pull/105859

The test flaked on the amd_msan shard of PR #113248 ([CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113248&sha=0f4ecdf5bcb488588e9d664687d1b482d67d62f9&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%201%2F3%29)) and earlier twice on unrelated PR #96130, with the `[]` line of Case 2 missing from the output.

Case 2 checks that the part produced by a `TTLDropMerge` contains no projections, via `SELECT projections FROM system.parts WHERE ... AND active`. That merge produces an empty part, and `MergeTreeCleanupThread` calls `clearEmptyParts`, which drops parts with zero rows in the background (the `remove_empty_parts` MergeTree setting is enabled by default — its documentation even says "Remove empty parts after they were pruned by TTL"). When the removal wins the race against the check, the query returns zero rows instead of one row with `[]`.

The fix sets `remove_empty_parts = 0` on the Case 2 table, so the empty part deterministically stays active for the check. The other cases only query the table itself and `system.part_log`, both of which are unaffected by empty-part removal. Verified with `clickhouse local`: after the TTL merge with the setting applied, exactly one active part remains with `[]` projections and zero rows.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1056` (included in `26.8` and later)
<!-- ch-version-info:end -->