### PR TITLE
Fix flaky test `04267_ttl_drop_merge_no_data_read`

### DIFF
--- a/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.sh
+++ b/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.sh
@@ -110,7 +110,11 @@ ${CLICKHOUSE_CLIENT} -q "
     SETTINGS
         ttl_only_drop_parts = 1,
         merge_with_ttl_timeout = 0,
-        min_bytes_for_wide_part = 1;
+        min_bytes_for_wide_part = 1,
+        -- keep the 0-row part produced by the merge: the projections query below
+        -- reads it from system.parts, and the background cleanup of empty parts
+        -- could otherwise drop it first
+        remove_empty_parts = 0;
 
     SYSTEM STOP MERGES t_ttl_drop_proj;
 


### PR DESCRIPTION
The `TTLDrop` merge in Case 2 (projections) produces a 0-row part, and the background cleanup of empty parts (the `remove_empty_parts` merge tree setting, enabled by default) drops it roughly 30 seconds after the merge. When the steps between the merge and the `SELECT projections FROM system.parts` check take longer than that (e.g. an MSan parallel run under load), no active part remains, so the expected `[]` line disappears from the output:

```
@@ -1,17 +1,16 @@
 -- Case 2: TTLDrop with projections
 TTLDropMerge	0	0
 0
-[]
 -- Case 3: TTLDrop with skip indexes
```

Keep the 0-row part with `remove_empty_parts = 0`, so the `projections` check always has a part to read.

Verified against the `amd_binary` master build from CI: 5/5 runs of the modified test match the reference, and without the setting the empty part is observably removed by the background cleanup ~30 seconds after the TTL merge (`active_parts` goes from 1 to 0), reproducing the missing `[]` line.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113248&sha=0f4ecdf5bcb488588e9d664687d1b482d67d62f9&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%201%2F3%29
Failed on: https://github.com/ClickHouse/ClickHouse/pull/113248

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
