### PR TITLE
Do not send a JOIN to the shards of a cluster table function

### DIFF
--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -12,6 +12,8 @@
 #include <Interpreters/AddDefaultDatabaseVisitor.h>
 #include <Interpreters/TranslateQualifiedNamesVisitor.h>
 #include <Interpreters/InterpreterSelectQueryAnalyzer.h>
+#include <Interpreters/TreeRewriter.h>
+#include <Parsers/ASTSelectQuery.h>
 #include <Processors/Sources/RemoteSource.h>
 #include <QueryPipeline/narrowPipe.h>
 #include <QueryPipeline/Pipe.h>
@@ -117,6 +119,15 @@ void IStorageCluster::read(
         auto interpreter = InterpreterSelectQuery(query_info.query, context, SelectQueryOptions(processed_stage).analyze());
         sample_block = interpreter.getSampleBlock();
         query_to_send = interpreter.getQueryInfo().query->clone();
+
+        /// Shards have no access to the other joined tables, so send only this storage's own
+        /// single-table read; getQueryProcessingStage() stops at FetchColumns for such a query,
+        /// so the initiator performs the JOIN.
+        if (auto * select_to_send = query_to_send->as<ASTSelectQuery>(); select_to_send && hasJoin(*select_to_send))
+        {
+            TreeRewriterResult rewriter_result = *interpreter.getQueryInfo().syntax_analyzer_result;
+            removeJoin(*select_to_send, rewriter_result, context);
+        }
     }
 
     updateQueryToSendIfNeeded(query_to_send, storage_snapshot, context);
@@ -220,8 +231,13 @@ void ReadFromCluster::initializePipeline(QueryPipelineBuilder & pipeline, const 
 }
 
 QueryProcessingStage::Enum IStorageCluster::getQueryProcessingStage(
-    ContextPtr context, QueryProcessingStage::Enum to_stage, const StorageSnapshotPtr &, SelectQueryInfo &) const
+    ContextPtr context, QueryProcessingStage::Enum to_stage, const StorageSnapshotPtr &, SelectQueryInfo & query_info) const
 {
+    /// A JOIN must be done on the initiator: shards receive the query with the joined tables
+    /// removed (see removeJoin() in read()) because they cannot resolve them.
+    if (const auto * select = query_info.query->as<ASTSelectQuery>(); select && hasJoin(*select))
+        return QueryProcessingStage::FetchColumns;
+
     /// Only a follower reached by another node's cluster function (SECONDARY_QUERY) just fetches
     /// raw data. Everything else is the initiator of the distributed read, including internal
     /// contexts that never set the kind (NO_QUERY), e.g. a Replicated database DDL worker.

--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -127,12 +127,13 @@ void IStorageCluster::read(
         if (auto * select_to_send = query_to_send->as<ASTSelectQuery>(); select_to_send && select_to_send->hasJoin())
         {
             /// A join may sit behind an ARRAY JOIN, but removeJoin() only inspects the second table
-            /// element, so drop the ARRAY JOIN ones first. The initiator applies them after the join.
+            /// element, so drop the ARRAY JOIN ones first. The initiator applies them too.
             auto & tables_to_send = select_to_send->tables()->children;
-            tables_to_send.erase(
-                std::remove_if(tables_to_send.begin(), tables_to_send.end(), [](const ASTPtr & table_element)
-                    { return table_element->as<ASTTablesInSelectQueryElement &>().array_join != nullptr; }),
-                tables_to_send.end());
+            const auto first_array_join = std::remove_if(
+                tables_to_send.begin(), tables_to_send.end(), [](const ASTPtr & table_element)
+                    { return table_element->as<ASTTablesInSelectQueryElement &>().array_join != nullptr; });
+            const bool array_join_removed = first_array_join != tables_to_send.end();
+            tables_to_send.erase(first_array_join, tables_to_send.end());
 
             TreeRewriterResult rewriter_result = *interpreter.getQueryInfo().syntax_analyzer_result;
             removeJoin(*select_to_send, rewriter_result, context);
@@ -144,6 +145,15 @@ void IStorageCluster::read(
             select_to_send->setExpression(ASTSelectQuery::Expression::LIMIT_BY_LENGTH, {});
             select_to_send->setExpression(ASTSelectQuery::Expression::LIMIT_BY_OFFSET, {});
             select_to_send->limit_with_ties = false;
+
+            /// An un-aliased ARRAY JOIN output keeps the source column's name, so removeJoin()
+            /// reads such a predicate as belonging to this storage and keeps it, but shard-side
+            /// the name still denotes the unexpanded array.
+            if (array_join_removed)
+            {
+                select_to_send->setExpression(ASTSelectQuery::Expression::WHERE, {});
+                select_to_send->setExpression(ASTSelectQuery::Expression::PREWHERE, {});
+            }
         }
     }
 

--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -14,6 +14,7 @@
 #include <Interpreters/InterpreterSelectQueryAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>
 #include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTTablesInSelectQuery.h>
 #include <Processors/Sources/RemoteSource.h>
 #include <QueryPipeline/narrowPipe.h>
 #include <QueryPipeline/Pipe.h>
@@ -123,8 +124,16 @@ void IStorageCluster::read(
         /// Shards have no access to the other joined tables, so send only this storage's own
         /// single-table read; getQueryProcessingStage() stops at FetchColumns for such a query,
         /// so the initiator performs the JOIN.
-        if (auto * select_to_send = query_to_send->as<ASTSelectQuery>(); select_to_send && hasJoin(*select_to_send))
+        if (auto * select_to_send = query_to_send->as<ASTSelectQuery>(); select_to_send && select_to_send->hasJoin())
         {
+            /// A join may sit behind an ARRAY JOIN, but removeJoin() only inspects the second table
+            /// element, so drop the ARRAY JOIN ones first. The initiator applies them after the join.
+            auto & tables_to_send = select_to_send->tables()->children;
+            tables_to_send.erase(
+                std::remove_if(tables_to_send.begin(), tables_to_send.end(), [](const ASTPtr & table_element)
+                    { return table_element->as<ASTTablesInSelectQueryElement &>().array_join != nullptr; }),
+                tables_to_send.end());
+
             TreeRewriterResult rewriter_result = *interpreter.getQueryInfo().syntax_analyzer_result;
             removeJoin(*select_to_send, rewriter_result, context);
 
@@ -243,7 +252,7 @@ QueryProcessingStage::Enum IStorageCluster::getQueryProcessingStage(
 {
     /// A JOIN must be done on the initiator: shards receive the query with the joined tables
     /// removed (see removeJoin() in read()) because they cannot resolve them.
-    if (const auto * select = query_info.query->as<ASTSelectQuery>(); select && hasJoin(*select))
+    if (const auto * select = query_info.query->as<ASTSelectQuery>(); select && select->hasJoin())
         return QueryProcessingStage::FetchColumns;
 
     /// Only a follower reached by another node's cluster function (SECONDARY_QUERY) just fetches

--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -127,6 +127,14 @@ void IStorageCluster::read(
         {
             TreeRewriterResult rewriter_result = *interpreter.getQueryInfo().syntax_analyzer_result;
             removeJoin(*select_to_send, rewriter_result, context);
+
+            /// removeJoin() leaves these, but they may reference the joined side, and WITH TIES
+            /// needs the ORDER BY it just dropped. The initiator applies them after the join.
+            select_to_send->setExpression(ASTSelectQuery::Expression::WINDOW, {});
+            select_to_send->setExpression(ASTSelectQuery::Expression::LIMIT_BY, {});
+            select_to_send->setExpression(ASTSelectQuery::Expression::LIMIT_BY_LENGTH, {});
+            select_to_send->setExpression(ASTSelectQuery::Expression::LIMIT_BY_OFFSET, {});
+            select_to_send->limit_with_ties = false;
         }
     }
 

--- a/tests/queries/0_stateless/04900_cluster_table_function_join.reference
+++ b/tests/queries/0_stateless/04900_cluster_table_function_join.reference
@@ -1,0 +1,116 @@
+-- INNER
+1,"L1","R1"
+2,"L2","R2"
+3,"L3","R3"
+1,"L1","R1"
+2,"L2","R2"
+3,"L3","R3"
+-- LEFT
+1,"L1","R1"
+2,"L2","R2"
+3,"L3","R3"
+1,"L1","R1"
+2,"L2","R2"
+3,"L3","R3"
+-- RIGHT
+1,"L1","R1"
+2,"L2","R2"
+3,"L3","R3"
+4,"","R4"
+5,"","R5"
+1,"L1","R1"
+2,"L2","R2"
+3,"L3","R3"
+4,"","R4"
+5,"","R5"
+-- FULL
+1,"L1","R1"
+2,"L2","R2"
+3,"L3","R3"
+4,"","R4"
+5,"","R5"
+1,"L1","R1"
+2,"L2","R2"
+3,"L3","R3"
+4,"","R4"
+5,"","R5"
+-- CROSS
+15
+15
+-- self join on the same file
+1,"L1","L1"
+2,"L2","L2"
+3,"L3","L3"
+1,"L1","L1"
+2,"L2","L2"
+3,"L3","L3"
+-- three cluster sides
+75
+75
+-- JOIN a temporary table
+1,"L1","T1"
+2,"L2","T2"
+1,"L1","T1"
+2,"L2","T2"
+-- aggregation over the join
+1,4
+2,4
+3,4
+1,4
+2,4
+3,4
+-- WHERE spanning both sides
+2,"L2","R2"
+2,"L2","R2"
+-- HAVING
+1,1
+2,1
+3,1
+1,1
+2,1
+3,1
+-- ORDER BY and LIMIT
+3,"L3","R3"
+2,"L2","R2"
+3,"L3","R3"
+2,"L2","R2"
+-- shapes that must not change
+-- single cluster function
+1,"L1"
+2,"L2"
+3,"L3"
+1,"L1"
+2,"L2"
+3,"L3"
+-- cluster JOIN plain file
+1,"L1","R1"
+2,"L2","R2"
+3,"L3","R3"
+1,"L1","R1"
+2,"L2","R2"
+3,"L3","R3"
+-- plain file JOIN cluster
+1,"L1","R1"
+2,"L2","R2"
+3,"L3","R3"
+1,"L1","R1"
+2,"L2","R2"
+3,"L3","R3"
+-- ARRAY JOIN over a cluster function
+1,1
+1,2
+2,1
+2,2
+3,1
+3,2
+1,1
+1,2
+2,1
+2,2
+3,1
+3,2
+-- aggregation is still pushed down
+MergingAggregated
+└──ReadFromCluster
+MergingAggregated
+└──ReadFromCluster

--- a/tests/queries/0_stateless/04900_cluster_table_function_join.reference
+++ b/tests/queries/0_stateless/04900_cluster_table_function_join.reference
@@ -74,6 +74,25 @@
 2,"L2","R2"
 3,"L3","R3"
 2,"L2","R2"
+-- LIMIT BY the joined side
+1,"L1","R1"
+2,"L2","R2"
+3,"L3","R3"
+1,"L1","R1"
+2,"L2","R2"
+3,"L3","R3"
+-- named WINDOW over the joined side
+1,1
+2,1
+3,1
+1,1
+2,1
+3,1
+-- LIMIT WITH TIES
+1,"L1","R1"
+2,"L2","R2"
+1,"L1","R1"
+2,"L2","R2"
 -- shapes that must not change
 -- single cluster function
 1,"L1"

--- a/tests/queries/0_stateless/04900_cluster_table_function_join.reference
+++ b/tests/queries/0_stateless/04900_cluster_table_function_join.reference
@@ -131,6 +131,16 @@
 1,"L1",2,"T1"
 2,"L2",1,"T2"
 2,"L2",2,"T2"
+-- WHERE on an ARRAY JOIN alias
+1,"L1",2
+2,"L2",2
+3,"L3",2
+1,"L1",2
+2,"L2",2
+3,"L3",2
+-- WHERE on an un-aliased ARRAY JOIN
+1,"L1",11
+1,"L1",11
 -- shapes that must not change
 -- single cluster function
 1,"L1"

--- a/tests/queries/0_stateless/04900_cluster_table_function_join.reference
+++ b/tests/queries/0_stateless/04900_cluster_table_function_join.reference
@@ -93,6 +93,44 @@
 2,"L2","R2"
 1,"L1","R1"
 2,"L2","R2"
+-- ARRAY JOIN then INNER
+1,"L1",1,"R1"
+1,"L1",2,"R1"
+2,"L2",1,"R2"
+2,"L2",2,"R2"
+3,"L3",1,"R3"
+3,"L3",2,"R3"
+1,"L1",1,"R1"
+1,"L1",2,"R1"
+2,"L2",1,"R2"
+2,"L2",2,"R2"
+3,"L3",1,"R3"
+3,"L3",2,"R3"
+-- ARRAY JOIN then LEFT
+1,"L1",1,"R1"
+1,"L1",2,"R1"
+2,"L2",1,"R2"
+2,"L2",2,"R2"
+3,"L3",1,"R3"
+3,"L3",2,"R3"
+1,"L1",1,"R1"
+1,"L1",2,"R1"
+2,"L2",1,"R2"
+2,"L2",2,"R2"
+3,"L3",1,"R3"
+3,"L3",2,"R3"
+-- ARRAY JOIN then CROSS
+30
+30
+-- ARRAY JOIN then a temporary table
+1,"L1",1,"T1"
+1,"L1",2,"T1"
+2,"L2",1,"T2"
+2,"L2",2,"T2"
+1,"L1",1,"T1"
+1,"L1",2,"T1"
+2,"L2",1,"T2"
+2,"L2",2,"T2"
 -- shapes that must not change
 -- single cluster function
 1,"L1"

--- a/tests/queries/0_stateless/04900_cluster_table_function_join.sh
+++ b/tests/queries/0_stateless/04900_cluster_table_function_join.sh
@@ -46,6 +46,12 @@ run "WHERE spanning both sides" "SELECT a, lm, rm FROM $L AS x INNER JOIN $R AS 
 run "HAVING" "SELECT a, count() AS c FROM $L AS x INNER JOIN $R AS y USING (a) GROUP BY a HAVING c = 1 ORDER BY a FORMAT CSV"
 run "ORDER BY and LIMIT" "SELECT a, lm, rm FROM $L AS x INNER JOIN $R AS y USING (a) ORDER BY a DESC LIMIT 2 FORMAT CSV"
 
+# Clauses the shard query must not keep: they may name the joined side, and WITH TIES needs the
+# ORDER BY that the join strip removes.
+run "LIMIT BY the joined side" "SELECT a, lm, rm FROM $L AS x INNER JOIN $R AS y USING (a) ORDER BY a LIMIT 1 BY y.rm FORMAT CSV"
+run "named WINDOW over the joined side" "SELECT a, count() OVER w FROM $L AS x INNER JOIN $R AS y USING (a) WINDOW w AS (PARTITION BY y.rm) ORDER BY a FORMAT CSV"
+run "LIMIT WITH TIES" "SELECT a, lm, rm FROM $L AS x INNER JOIN $R AS y USING (a) ORDER BY a LIMIT 2 WITH TIES FORMAT CSV"
+
 printf "SELECT '-- shapes that must not change';\n"
 run "single cluster function" "SELECT * FROM $L ORDER BY a FORMAT CSV"
 run "cluster JOIN plain file" "SELECT a, lm, rm FROM $L AS x INNER JOIN $PR AS y USING (a) ORDER BY a FORMAT CSV"

--- a/tests/queries/0_stateless/04900_cluster_table_function_join.sh
+++ b/tests/queries/0_stateless/04900_cluster_table_function_join.sh
@@ -52,6 +52,12 @@ run "LIMIT BY the joined side" "SELECT a, lm, rm FROM $L AS x INNER JOIN $R AS y
 run "named WINDOW over the joined side" "SELECT a, count() OVER w FROM $L AS x INNER JOIN $R AS y USING (a) WINDOW w AS (PARTITION BY y.rm) ORDER BY a FORMAT CSV"
 run "LIMIT WITH TIES" "SELECT a, lm, rm FROM $L AS x INNER JOIN $R AS y USING (a) ORDER BY a LIMIT 2 WITH TIES FORMAT CSV"
 
+# An ARRAY JOIN before the join makes the join the third table element, not the second.
+run "ARRAY JOIN then INNER" "SELECT a, lm, e, rm FROM $L AS x ARRAY JOIN [1, 2] AS e INNER JOIN $R AS y USING (a) ORDER BY a, e FORMAT CSV"
+run "ARRAY JOIN then LEFT" "SELECT a, lm, e, rm FROM $L AS x ARRAY JOIN [1, 2] AS e LEFT JOIN $R AS y USING (a) ORDER BY a, e FORMAT CSV"
+run "ARRAY JOIN then CROSS" "SELECT count() FROM $L AS x ARRAY JOIN [1, 2] AS e CROSS JOIN $R AS y"
+run "ARRAY JOIN then a temporary table" "SELECT a, lm, e, tm FROM $L AS x ARRAY JOIN [1, 2] AS e INNER JOIN tt AS y USING (a) ORDER BY a, e FORMAT CSV"
+
 printf "SELECT '-- shapes that must not change';\n"
 run "single cluster function" "SELECT * FROM $L ORDER BY a FORMAT CSV"
 run "cluster JOIN plain file" "SELECT a, lm, rm FROM $L AS x INNER JOIN $PR AS y USING (a) ORDER BY a FORMAT CSV"

--- a/tests/queries/0_stateless/04900_cluster_table_function_join.sh
+++ b/tests/queries/0_stateless/04900_cluster_table_function_join.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Random settings limits: max_threads=(1, 3)
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -24,7 +25,7 @@ PR="file('${CLICKHOUSE_TEST_UNIQUE_NAME}/right.csv', 'CSV', 'a UInt32, rm String
 run() {
     printf "SELECT '-- %s';\n" "$1"
     for analyzer in 0 1; do
-        printf 'SET enable_analyzer = %s;\n%s;\n' "$analyzer" "$2"
+        printf '%s SETTINGS enable_analyzer = %s;\n' "$2" "$analyzer"
     done
 }
 

--- a/tests/queries/0_stateless/04900_cluster_table_function_join.sh
+++ b/tests/queries/0_stateless/04900_cluster_table_function_join.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+DIR="${USER_FILES_PATH}/${CLICKHOUSE_TEST_UNIQUE_NAME}"
+mkdir -p "$DIR"
+
+# Asymmetric fixtures with per-side marker columns: a symmetric one hides column misalignment.
+printf '1,L1\n2,L2\n3,L3\n' > "$DIR/left.csv"
+printf '1,R1\n2,R2\n3,R3\n4,R4\n5,R5\n' > "$DIR/right.csv"
+
+C="test_cluster_two_shards_localhost"
+L="fileCluster('$C', '${CLICKHOUSE_TEST_UNIQUE_NAME}/left.csv', 'CSV', 'a UInt32, lm String')"
+R="fileCluster('$C', '${CLICKHOUSE_TEST_UNIQUE_NAME}/right.csv', 'CSV', 'a UInt32, rm String')"
+PL="file('${CLICKHOUSE_TEST_UNIQUE_NAME}/left.csv', 'CSV', 'a UInt32, lm String')"
+PR="file('${CLICKHOUSE_TEST_UNIQUE_NAME}/right.csv', 'CSV', 'a UInt32, rm String')"
+
+# Both analyzers must agree, so the reference is a self-checking oracle.
+run() {
+    echo "-- $1"
+    for analyzer in 0 1; do
+        $CLICKHOUSE_CLIENT --enable_analyzer="$analyzer" --query "$2"
+    done
+}
+
+run "INNER" "SELECT a, lm, rm FROM $L AS x INNER JOIN $R AS y USING (a) ORDER BY a FORMAT CSV"
+run "LEFT" "SELECT a, lm, rm FROM $L AS x LEFT JOIN $R AS y USING (a) ORDER BY a FORMAT CSV"
+run "RIGHT" "SELECT a, lm, rm FROM $L AS x RIGHT JOIN $R AS y USING (a) ORDER BY a FORMAT CSV"
+run "FULL" "SELECT a, lm, rm FROM $L AS x FULL JOIN $R AS y USING (a) ORDER BY a FORMAT CSV"
+run "CROSS" "SELECT count() FROM $L AS x CROSS JOIN $R AS y"
+run "self join on the same file" "SELECT a, x.lm, y.lm FROM $L AS x INNER JOIN $L AS y USING (a) ORDER BY a FORMAT CSV"
+run "three cluster sides" "SELECT count() FROM $L AS x, $R AS y, $R AS z"
+
+# A temporary table exists only on the initiator, so this fails unless the shard query is
+# stripped of the join rather than merely being planned on the initiator.
+run "JOIN a temporary table" "CREATE TEMPORARY TABLE tt (a UInt32, tm String) ENGINE = Memory;
+INSERT INTO tt VALUES (1, 'T1'), (2, 'T2');
+SELECT a, lm, tm FROM $L AS x INNER JOIN tt AS y USING (a) ORDER BY a FORMAT CSV"
+
+run "aggregation over the join" "SELECT a, sum(length(lm) + length(rm)) FROM $L AS x INNER JOIN $R AS y USING (a) GROUP BY a ORDER BY a FORMAT CSV"
+run "WHERE spanning both sides" "SELECT a, lm, rm FROM $L AS x INNER JOIN $R AS y ON x.a = y.a WHERE x.a > 1 AND y.a < 3 ORDER BY a FORMAT CSV"
+run "HAVING" "SELECT a, count() AS c FROM $L AS x INNER JOIN $R AS y USING (a) GROUP BY a HAVING c = 1 ORDER BY a FORMAT CSV"
+run "ORDER BY and LIMIT" "SELECT a, lm, rm FROM $L AS x INNER JOIN $R AS y USING (a) ORDER BY a DESC LIMIT 2 FORMAT CSV"
+
+echo "-- shapes that must not change"
+run "single cluster function" "SELECT * FROM $L ORDER BY a FORMAT CSV"
+run "cluster JOIN plain file" "SELECT a, lm, rm FROM $L AS x INNER JOIN $PR AS y USING (a) ORDER BY a FORMAT CSV"
+run "plain file JOIN cluster" "SELECT a, lm, rm FROM $PL AS x INNER JOIN $R AS y USING (a) ORDER BY a FORMAT CSV"
+run "ARRAY JOIN over a cluster function" "SELECT a, e FROM (SELECT a, [1, 2] AS arr FROM $L) ARRAY JOIN arr AS e ORDER BY a, e FORMAT CSV"
+
+# Without a join, aggregation is still pushed to the shards.
+run "aggregation is still pushed down" "SELECT trimLeft(explain) FROM (EXPLAIN PLAN SELECT sum(a) FROM $L) WHERE explain ILIKE '%MergingAggregated%' OR explain ILIKE '%ReadFromCluster%'"
+
+rm -rf "$DIR"

--- a/tests/queries/0_stateless/04900_cluster_table_function_join.sh
+++ b/tests/queries/0_stateless/04900_cluster_table_function_join.sh
@@ -17,14 +17,16 @@ R="fileCluster('$C', '${CLICKHOUSE_TEST_UNIQUE_NAME}/right.csv', 'CSV', 'a UInt3
 PL="file('${CLICKHOUSE_TEST_UNIQUE_NAME}/left.csv', 'CSV', 'a UInt32, lm String')"
 PR="file('${CLICKHOUSE_TEST_UNIQUE_NAME}/right.csv', 'CSV', 'a UInt32, rm String')"
 
-# Both analyzers must agree, so the reference is a self-checking oracle.
+# Both analyzers must agree, so the reference is a self-checking oracle. Shapes are emitted as SQL
+# into a single session: a client process per query costs far more than the queries themselves.
 run() {
-    echo "-- $1"
+    printf "SELECT '-- %s';\n" "$1"
     for analyzer in 0 1; do
-        $CLICKHOUSE_CLIENT --enable_analyzer="$analyzer" --query "$2"
+        printf 'SET enable_analyzer = %s;\n%s;\n' "$analyzer" "$2"
     done
 }
 
+{
 run "INNER" "SELECT a, lm, rm FROM $L AS x INNER JOIN $R AS y USING (a) ORDER BY a FORMAT CSV"
 run "LEFT" "SELECT a, lm, rm FROM $L AS x LEFT JOIN $R AS y USING (a) ORDER BY a FORMAT CSV"
 run "RIGHT" "SELECT a, lm, rm FROM $L AS x RIGHT JOIN $R AS y USING (a) ORDER BY a FORMAT CSV"
@@ -35,16 +37,16 @@ run "three cluster sides" "SELECT count() FROM $L AS x, $R AS y, $R AS z"
 
 # A temporary table exists only on the initiator, so this fails unless the shard query is
 # stripped of the join rather than merely being planned on the initiator.
-run "JOIN a temporary table" "CREATE TEMPORARY TABLE tt (a UInt32, tm String) ENGINE = Memory;
-INSERT INTO tt VALUES (1, 'T1'), (2, 'T2');
-SELECT a, lm, tm FROM $L AS x INNER JOIN tt AS y USING (a) ORDER BY a FORMAT CSV"
+printf 'CREATE TEMPORARY TABLE tt (a UInt32, tm String) ENGINE = Memory;\n'
+printf "INSERT INTO tt VALUES (1, 'T1'), (2, 'T2');\n"
+run "JOIN a temporary table" "SELECT a, lm, tm FROM $L AS x INNER JOIN tt AS y USING (a) ORDER BY a FORMAT CSV"
 
 run "aggregation over the join" "SELECT a, sum(length(lm) + length(rm)) FROM $L AS x INNER JOIN $R AS y USING (a) GROUP BY a ORDER BY a FORMAT CSV"
 run "WHERE spanning both sides" "SELECT a, lm, rm FROM $L AS x INNER JOIN $R AS y ON x.a = y.a WHERE x.a > 1 AND y.a < 3 ORDER BY a FORMAT CSV"
 run "HAVING" "SELECT a, count() AS c FROM $L AS x INNER JOIN $R AS y USING (a) GROUP BY a HAVING c = 1 ORDER BY a FORMAT CSV"
 run "ORDER BY and LIMIT" "SELECT a, lm, rm FROM $L AS x INNER JOIN $R AS y USING (a) ORDER BY a DESC LIMIT 2 FORMAT CSV"
 
-echo "-- shapes that must not change"
+printf "SELECT '-- shapes that must not change';\n"
 run "single cluster function" "SELECT * FROM $L ORDER BY a FORMAT CSV"
 run "cluster JOIN plain file" "SELECT a, lm, rm FROM $L AS x INNER JOIN $PR AS y USING (a) ORDER BY a FORMAT CSV"
 run "plain file JOIN cluster" "SELECT a, lm, rm FROM $PL AS x INNER JOIN $R AS y USING (a) ORDER BY a FORMAT CSV"
@@ -52,5 +54,6 @@ run "ARRAY JOIN over a cluster function" "SELECT a, e FROM (SELECT a, [1, 2] AS 
 
 # Without a join, aggregation is still pushed to the shards.
 run "aggregation is still pushed down" "SELECT trimLeft(explain) FROM (EXPLAIN PLAN SELECT sum(a) FROM $L) WHERE explain ILIKE '%MergingAggregated%' OR explain ILIKE '%ReadFromCluster%'"
+} | $CLICKHOUSE_CLIENT
 
 rm -rf "$DIR"

--- a/tests/queries/0_stateless/04900_cluster_table_function_join.sh
+++ b/tests/queries/0_stateless/04900_cluster_table_function_join.sh
@@ -10,9 +10,11 @@ mkdir -p "$DIR"
 # Asymmetric fixtures with per-side marker columns: a symmetric one hides column misalignment.
 printf '1,L1\n2,L2\n3,L3\n' > "$DIR/left.csv"
 printf '1,R1\n2,R2\n3,R3\n4,R4\n5,R5\n' > "$DIR/right.csv"
+printf '1,L1,"[10,11]"\n2,L2,"[20,21]"\n3,L3,"[30,31]"\n' > "$DIR/left_arr.csv"
 
 C="test_cluster_two_shards_localhost"
 L="fileCluster('$C', '${CLICKHOUSE_TEST_UNIQUE_NAME}/left.csv', 'CSV', 'a UInt32, lm String')"
+LA="fileCluster('$C', '${CLICKHOUSE_TEST_UNIQUE_NAME}/left_arr.csv', 'CSV', 'a UInt32, lm String, arr Array(UInt32)')"
 R="fileCluster('$C', '${CLICKHOUSE_TEST_UNIQUE_NAME}/right.csv', 'CSV', 'a UInt32, rm String')"
 PL="file('${CLICKHOUSE_TEST_UNIQUE_NAME}/left.csv', 'CSV', 'a UInt32, lm String')"
 PR="file('${CLICKHOUSE_TEST_UNIQUE_NAME}/right.csv', 'CSV', 'a UInt32, rm String')"
@@ -57,6 +59,10 @@ run "ARRAY JOIN then INNER" "SELECT a, lm, e, rm FROM $L AS x ARRAY JOIN [1, 2] 
 run "ARRAY JOIN then LEFT" "SELECT a, lm, e, rm FROM $L AS x ARRAY JOIN [1, 2] AS e LEFT JOIN $R AS y USING (a) ORDER BY a, e FORMAT CSV"
 run "ARRAY JOIN then CROSS" "SELECT count() FROM $L AS x ARRAY JOIN [1, 2] AS e CROSS JOIN $R AS y"
 run "ARRAY JOIN then a temporary table" "SELECT a, lm, e, tm FROM $L AS x ARRAY JOIN [1, 2] AS e INNER JOIN tt AS y USING (a) ORDER BY a, e FORMAT CSV"
+# An un-aliased ARRAY JOIN output keeps the source column's name, so a predicate naming it looks
+# like one this storage can evaluate, while shard-side that name is still the unexpanded array.
+run "WHERE on an ARRAY JOIN alias" "SELECT a, lm, e FROM $L AS x ARRAY JOIN [1, 2] AS e INNER JOIN $R AS y USING (a) WHERE e = 2 ORDER BY a FORMAT CSV"
+run "WHERE on an un-aliased ARRAY JOIN" "SELECT a, lm, arr FROM $LA AS x ARRAY JOIN arr INNER JOIN $R AS y USING (a) WHERE arr = 11 ORDER BY a FORMAT CSV"
 
 printf "SELECT '-- shapes that must not change';\n"
 run "single cluster function" "SELECT * FROM $L ORDER BY a FORMAT CSV"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/46646
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes wrong results when a `JOIN` reads from a cluster table function (`s3Cluster`, `fileCluster`, `urlCluster`, `azureBlobStorageCluster`, `hdfsCluster`, `icebergCluster`, ...) with `enable_analyzer = 0`. Such queries returned no rows for `INNER`, `LEFT` and `CROSS` joins, and rows of the wrong side for `RIGHT` and `FULL` joins.

### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/46646

With `enable_analyzer = 0`, a query whose leftmost table expression is a cluster table function and which joins a further table returned wrong results, with no error.

`IStorageCluster::getQueryProcessingStage` claimed `WithMergeableState` for every initiator query, that is "I will process the whole query including the join", so `read` shipped that whole query to each shard paired with a task iterator belonging to the leftmost storage only. Both cluster functions on the shard drained that one iterator, so whichever drew first got the real file list and the other an empty one. `RIGHT` and `FULL` preserve that empty side, which is why left-hand values appeared under right-hand column names.

The fix stops at `FetchColumns` when the query carries a join, so the initiator performs it, and strips the join from the shard query, which cannot resolve the other tables anyway. This is the `StorageMerge` pattern. Aggregation over such a join is consequently no longer pushed down; joinless queries keep the pushdown, asserted with `EXPLAIN PLAN`.

The analyzer is unaffected: #94748 already wraps a leftmost cluster function in a subquery. The new test asserts full rows at both `enable_analyzer` settings, checking the old against the new.

A join whose other side is resolvable on the shards too, such as a cluster function joined to a local `MergeTree`, also moves to the initiator. Not a regression: the same race picks the winner of the shared iterator, so on master that shape is non-deterministic and the analyzers already disagree on it. On a 2-shard cluster, 6 identical runs answered from the initiator's table 4 times and from the shard's twice; after this change it is the initiator every time, matching `enable_analyzer = 1`. A table existing only on a shard was, and remains, `UNKNOWN_TABLE` at both settings.

<details><summary>Validation</summary>

Out of scope, as separate root causes: `IN (SELECT ... FROM <cluster fn>)`, 0 rows at **both** settings, and `GLOBAL JOIN`, `Code: 284`.

Verified against a debug build, with a pristine-master binary as the control arm. All rows below are at `enable_analyzer = 0`; every one of them already matched the correct answer at `enable_analyzer = 1`.

| shape | before | after |
|---|---|---|
| `L INNER JOIN R` | *empty* | 3 correct rows |
| `L LEFT JOIN R` | *empty* | 3 correct rows |
| `L RIGHT JOIN R` | `1,"","L1" 2,"","L2" 3,"","L3"` | `1,"L1","R1" ... 5,"","R5"` |
| `L FULL JOIN R` | same misaligned 3 rows | 5 correct rows |
| `count()` over `CROSS JOIN` | `0` | `15` |
| `count()` over three cluster sides | `0` | `75` |
| cluster function joined to a `TEMPORARY` table | *empty* | 2 correct rows |
| `L ARRAY JOIN arr JOIN R` | `Code: 117` | 6 correct rows |
| `WHERE` over an un-aliased `ARRAY JOIN` output | `Code: 117` | 1 correct row |

Unchanged results (asserted byte-identical to the control arm): a single cluster function alone, cluster joined to a plain `file()` and the reverse, `remote()` joined to `remote()`, `ARRAY JOIN` over a cluster function, and the `EXPLAIN PLAN` of an aggregate over a single cluster function. For the `file()` rows this covers the result only, not the execution site, which these single-node fixtures cannot observe; the 2-shard measurement above covers that.

On the shard side, `system.query_log` shows the whole join-carrying query before the change and one single-table query per side after it. Reverting the change makes the new test fail, and removing either half of it on its own also makes the test fail, so both halves are load-bearing.

The test passed 50/50 runs with randomized settings and another 50/50 forcing `enable_analyzer = 0`.

</details>

