### PR TITLE
Fix flaky test_attach_table_from_s3_plain_readonly: scope the upload

### DIFF
--- a/tests/integration/test_attach_table_from_s3_plain_readonly/test.py
+++ b/tests/integration/test_attach_table_from_s3_plain_readonly/test.py
@@ -77,17 +77,25 @@ def test_attach_table_from_s3_plain_readonly(started_cluster):
 
     assert int(node1.query("select num from local_db.test_table limit 1")) == 5
 
-    # Copy local MergeTree data into minio bucket
-    table_data_path = os.path.join(node1.path, "database/store")
-    minio = cluster.minio_client
-    upload_to_minio(
-        minio, cluster.minio_bucket, table_data_path, "data/disks/disk_s3_plain/store/"
-    )
-
-    # Drop the non-replicated table, we don't need it anymore
     table_uuid = node1.query(
         "SELECT uuid FROM system.tables WHERE database='local_db' AND table='test_table'"
     ).strip()
+
+    # Copy local MergeTree data into minio bucket. Scoped to this table: store/
+    # also holds the Atomic `system` database, whose parts a background flush can
+    # remove mid-walk.
+    table_data_path = os.path.join(
+        node1.path, "database/store", table_uuid[:3], table_uuid
+    )
+    minio = cluster.minio_client
+    upload_to_minio(
+        minio,
+        cluster.minio_bucket,
+        table_data_path,
+        f"data/disks/disk_s3_plain/store/{table_uuid[:3]}/{table_uuid}/",
+    )
+
+    # Drop the non-replicated table, we don't need it anymore
     node1.query("drop table local_db.test_table SYNC;")
 
     # Create a replicated database


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`upload_to_minio` was pointed at the node's entire `database/store` directory. That is the live,
bind-mounted data root of every Atomic database, and `system` is Atomic in server mode
(`loadMetadataSystem`, `src/Interpreters/loadMetadata.cpp`), so the system logs live under the
very tree the test walks. They flush on a background timer, so between `os.walk` enumerating a
path and `open()` reading it the server can rename a temp part into place or remove a part it has
just merged away. The resulting `FileNotFoundError` is not caught by the `except S3Error` handler,
so the test fails on a different missing file each time.

The partition id proves the racing writer is a system log, not the table under test:
`local_db.test_table` has no `PARTITION BY`, so its only possible part is `all_1_1_0`, while the
parts seen vanishing are `202608_...`, the `toYYYYMM(event_date)` partition every system log uses.

The fix scopes the walk to the one table the test means to copy, `store/<uuid[:3]>/<uuid>`, by
hoisting the UUID lookup that already existed a few lines below. Keys are
`minio_path + relative_to(local_path)`, so moving those two segments from the walk root into the
prefix leaves every uploaded key byte-identical and the `ATTACH` resolves unchanged. Skipping
`tmp_*` or catching `FileNotFoundError` were rejected: neither can distinguish a vanished
system-log part from a missing file of the table under test, which would turn a loud failure into
a silently incomplete upload.

Validation: with the walk slowed and log flushing forced, the unmodified test body fails on the
first attempt with the old walk root and passes with the scoped one, both existing `ATTACH`
assertions untouched. The uploaded object set matches the table's local part files 1:1. 20
consecutive runs pass, and the test gets faster (~56s to ~31s) since it no longer uploads
`system`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1075` (included in `26.8` and later)
<!-- ch-version-info:end -->