### PR TITLE
Fix PromQL DateTime64 offset scaling

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOffset.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOffset.cpp
@@ -63,7 +63,7 @@ namespace
                     /// timestamp + INTERVAL x MILLISECONDS
                     chassert(context.timestamp_scale <= 9); /// Maximum scale for DateTime64 is 9 (nanoseconds).
                     /// Round up the scale to next number divisible by 3.
-                    UInt32 scale = std::max<UInt32>((context.timestamp_scale + 2) / 3 * 3, 9);
+                    UInt32 scale = std::min<UInt32>((context.timestamp_scale + 2) / 3 * 3, 9);
                     Decimal64 scaled_offset_value = DecimalUtils::convertTo<Decimal64>(scale, offset_value, context.timestamp_scale);
 
                     static const std::string_view to_interval_functions[] = {"toIntervalSecond", "toIntervalMillisecond", "toIntervalMicrosecond", "toIntervalNanosecond"};

--- a/tests/integration/test_prometheus_protocols/test_different_table_engines.py
+++ b/tests/integration/test_prometheus_protocols/test_different_table_engines.py
@@ -54,6 +54,17 @@ test_queries = [
         ],
     ),
     (
+        'up{instance=~"demo-service-0:.*"} offset 1.5s',
+        '{"resultType": "vector", "result": [{"metric": {"__name__": "up", "instance": "demo-service-0:10000", "job": "demo"}, "value": [1753199684.626, "1"]}]}',
+        [
+            [
+                "[('__name__','up'),('instance','demo-service-0:10000'),('job','demo')]",
+                "2025-07-22 15:54:44.626",
+                "1",
+            ]
+        ],
+    ),
+    (
         'irate(prometheus_http_requests_total{code="200",handler="/api/v1/query"}[30s])',
         '{"resultType": "vector", "result": [{"metric": {"code": "200", "handler": "/api/v1/query", "instance": "prometheus:9090", "job": "prometheus"}, "value": [1753199684.626, "0.2"]}]}',
         [


### PR DESCRIPTION
### Changelog category (leave one):
- **Bug Fix (user-visible misbehavior in an official stable release)**


### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
**Fix PromQL offset queries for TimeSeries tables with DateTime64 timestamps.**


### Description

The DateTime64 path in applyOffset currently rounds the timestamp scale with std::max(..., 9). Since DateTime64 supports scales up to 9, this always selects scale 9.

As a result, PromQL offset queries use a nanosecond interval even for millisecond or microsecond timestamps. For example, a fractional offset query can fail with ILLEGAL_TYPE_OF_ARGUMENT.

Use std::min to cap the rounded scale at 9. This keeps second, millisecond, microsecond, and nanosecond offsets on the matching interval function.

The integration coverage adds a fractional offset query and runs it with both the default millisecond and microsecond timestamp layouts.


### Tests

- **Checks:**  --check
- **Checks:**  -m py_compile tests/integration/test_prometheus_protocols/test_different_table_engines.py
- **Checks:**  ./promql/parser
