### PR TITLE
Fix the documentation of `logTrace`

### DIFF
--- a/src/Functions/logTrace.cpp
+++ b/src/Functions/logTrace.cpp
@@ -58,7 +58,12 @@ namespace
 REGISTER_FUNCTION(LogTrace)
 {
     FunctionDocumentation::Description description = R"(
-Emits a trace log message to the server log for each [Block](/development/architecture/#block).
+Emits a trace log message to the server log.
+
+The function accepts a constant argument only, so the call is evaluated during query analysis and replaced
+by its result. The message is therefore emitted once while the query is analyzed, and not once per processed
+[Block](/development/architecture/#block): the number of rows and the setting `max_block_size` have no effect
+on how many messages appear in the log.
     )";
     FunctionDocumentation::Syntax syntax = "logTrace(message)";
     FunctionDocumentation::Arguments arguments = {


### PR DESCRIPTION
The documentation of `logTrace` says that it emits a trace log message to the server log "for each `Block`". It never did: the function accepts a constant argument only, so the call is eligible for constant folding and is evaluated during query analysis and replaced by its result. The message is emitted once while the query is analyzed; the number of rows, `max_block_size`, and the execution pipeline have no effect on it.

```sql
SELECT logTrace('Hello') FROM numbers(1000000) SETTINGS max_block_size = 1000 FORMAT Null;
-- one message in the server log, not one per block
```

This describes the actual behavior instead. The documentation page is generated from `system.functions`, so the `FunctionDocumentation` in the source is the single place to change.

Related: https://github.com/ClickHouse/ClickHouse/pull/110188

### Changelog category (leave one):
- Documentation (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1068` (included in `26.8` and later)
<!-- ch-version-info:end -->