### PR TITLE
Fix mixed-case PromQL aggregation operators

### DIFF
--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
@@ -1,6 +1,7 @@
 #include <Parsers/Prometheus/PrometheusQueryParsingUtil.h>
 
 #include <Common/Exception.h>
+#include <Common/StringUtils.h>
 #include <Common/UTF8Helpers.h>
 
 #include "config.h"
@@ -703,6 +704,7 @@ namespace
                 throwInconsistentSchema("Aggregation", ctx->getText());
 
             auto operator_name = getText(operator_name_ctx);
+            toLowerASCII(operator_name);
             return makeAggregationOperator(operator_name, arguments, ctx->by(), ctx->without());
         }
 

--- a/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
+++ b/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
@@ -21,6 +21,39 @@ namespace
 }
 
 
+TEST(PromQLParser, CaseInsensitiveAggregationOperators)
+{
+    EXPECT_EQ(parse("SuM(up)"), R"(
+sum(up)
+
+PrometheusQueryTree(INSTANT_VECTOR):
+    AggregationOperator(sum)
+        InstantSelector:
+            __name__ EQ 'up'
+)");
+
+    EXPECT_EQ(parse("ToPk BY(job) (1, up)"), R"(
+topk by (job) (1, up)
+
+PrometheusQueryTree(INSTANT_VECTOR):
+    AggregationOperator(topk)
+        by job
+        Scalar(1)
+        InstantSelector:
+            __name__ EQ 'up'
+)");
+
+    /// Aggregation operator keywords can also be metric names and must keep their original case.
+    EXPECT_EQ(parse("SUM"), R"(
+SUM
+
+PrometheusQueryTree(INSTANT_VECTOR):
+    InstantSelector:
+        __name__ EQ 'SUM'
+)");
+}
+
+
 /// Parse queries from https://github.com/prometheus/compliance/blob/main/promql/promql-test-queries.yml
 TEST(PromQLParser, ComplianceQueries)
 {


### PR DESCRIPTION
### Description

PromQL keywords are case-insensitive, and the grammar already accepts mixed-case aggregation operators. However, the parser kept the original spelling in the query tree, so expressions such as `SuM(up)` reached lowercase-only lowering dispatch and failed as unsupported.

This change normalizes aggregation operator names when building the query tree. The normalization is limited to aggregation expressions, so metric names such as bare `SUM` and case-sensitive function names keep their original spelling. Parser coverage includes mixed-case `sum`, mixed-case `topk` with grouping, and preservation of the bare `SUM` metric name.

### Changelog category (leave one):
- **Experimental Feature**

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
**PromQL aggregation operators now accept mixed letter casing, matching Prometheus.**


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1569` (included in `26.8` and later)
<!-- ch-version-info:end -->