### PR TITLE
Fix flaky 04344_server_ast_fuzzer_insert_limit (INSERT timeout)

### DIFF
--- a/tests/queries/0_stateless/04344_server_ast_fuzzer_insert_limit.sql
+++ b/tests/queries/0_stateless/04344_server_ast_fuzzer_insert_limit.sql
@@ -26,8 +26,10 @@ SETTINGS max_rows_to_read = 0, max_rows_to_read = 0, read_overflow_mode = 'throw
 
 DROP TABLE IF EXISTS t_04344;
 CREATE TABLE t_04344 (a UInt64, b String, c Array(UInt64)) ENGINE = MergeTree ORDER BY a;
+-- Both INSERTs pin max_execution_time: it bounds their whole 30-clone fuzz loop, must exceed the
+-- host's object-store write latency for one part, and is stripped from the fuzzed clones.
 INSERT INTO t_04344 SELECT number, toString(number), range(number % 8) FROM numbers(100)
-SETTINGS max_rows_to_read = 0, read_overflow_mode = 'throw';
+SETTINGS max_rows_to_read = 0, read_overflow_mode = 'throw', max_execution_time = 120;
 
 -- Block-forming carrier: a trivial INSERT ... SELECT into a table that prefers large blocks copies
 -- min_insert_block_size_rows into the SELECT's max_block_size, so a fuzzed numbers(100) inflated to
@@ -35,7 +37,7 @@ SETTINGS max_rows_to_read = 0, read_overflow_mode = 'throw';
 -- read cap can fire. The fix pins both block-forming settings small and strips the query's own
 -- overrides, so this stays bounded even though the seed asks for a 1M-row block.
 INSERT INTO t_04344 SELECT number, toString(number), range(number % 8) FROM numbers(100)
-SETTINGS min_insert_block_size_rows = 1000000, max_block_size = 1000000, max_rows_to_read = 0;
+SETTINGS min_insert_block_size_rows = 1000000, max_block_size = 1000000, max_rows_to_read = 0, max_execution_time = 120;
 
 -- CREATE storage-settings carrier: the cap is parked in ASTStorage::settings. After stripping the
 -- only setting the node is empty; without pruning it ASTStorage::formatImpl emits a bare `SETTINGS`

--- a/tests/queries/0_stateless/04344_server_ast_fuzzer_insert_limit.sql
+++ b/tests/queries/0_stateless/04344_server_ast_fuzzer_insert_limit.sql
@@ -26,10 +26,10 @@ SETTINGS max_rows_to_read = 0, max_rows_to_read = 0, read_overflow_mode = 'throw
 
 DROP TABLE IF EXISTS t_04344;
 CREATE TABLE t_04344 (a UInt64, b String, c Array(UInt64)) ENGINE = MergeTree ORDER BY a;
--- Both INSERTs pin max_execution_time: it bounds their whole 30-clone fuzz loop, must exceed the
--- host's object-store write latency for one part, and is stripped from the fuzzed clones.
+-- Both INSERTs raise max_execution_time: it bounds their whole 30-clone fuzz loop and must exceed
+-- the host's object-store write latency. 60 is the ceiling: the stress profile constrains it to 60.
 INSERT INTO t_04344 SELECT number, toString(number), range(number % 8) FROM numbers(100)
-SETTINGS max_rows_to_read = 0, read_overflow_mode = 'throw', max_execution_time = 120;
+SETTINGS max_rows_to_read = 0, read_overflow_mode = 'throw', max_execution_time = 60;
 
 -- Block-forming carrier: a trivial INSERT ... SELECT into a table that prefers large blocks copies
 -- min_insert_block_size_rows into the SELECT's max_block_size, so a fuzzed numbers(100) inflated to
@@ -37,7 +37,7 @@ SETTINGS max_rows_to_read = 0, read_overflow_mode = 'throw', max_execution_time 
 -- read cap can fire. The fix pins both block-forming settings small and strips the query's own
 -- overrides, so this stays bounded even though the seed asks for a 1M-row block.
 INSERT INTO t_04344 SELECT number, toString(number), range(number % 8) FROM numbers(100)
-SETTINGS min_insert_block_size_rows = 1000000, max_block_size = 1000000, max_rows_to_read = 0, max_execution_time = 120;
+SETTINGS min_insert_block_size_rows = 1000000, max_block_size = 1000000, max_rows_to_read = 0, max_execution_time = 60;
 
 -- CREATE storage-settings carrier: the cap is parked in ASTStorage::settings. After stripping the
 -- only setting the node is empty; without pruning it ASTStorage::formatImpl emits a bare `SETTINGS`


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/109209 (fixed the teardown-DROP facet of the same test)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04344_server_ast_fuzzer_insert_limit` intermittently fails with
`Code: 159 ... elapsed 25514.95756 ms, maximum: 20000 ms (TIMEOUT_EXCEEDED)` charged to one of its two
`INSERT`s: 3 times in 90 days, all on `Stateless tests (arm_asan_ubsan, azure, parallel)`, against 163,155
OK on PR refs and 0 / 14,497 OK on master and release. Its 5 other failures there (`DROP`/seed `Code: 159`,
see #109209; host OOM) are out of scope.

Root cause: the session `SET max_execution_time = 20` is sized for the fuzzer's work, but on the two
MergeTree `INSERT`s it also bounds object-store write latency the test does not control. In a failing
`arm_asan_ubsan, azure` run the worker thread logs `WriteBufferFromAzureBlobStorage: Committed single block`
**22.79 s after** reserving space for a 100-row block; a second repeats it at +28.3 s. 27 unrelated queries
also exceeded 20 s there, so the stall is host-wide.

It cannot just be removed: each fuzzable statement runs 30 fuzzed clones inside the outer query's clock,
and that deadline is the loop's only aggregate bound. So it is raised to 60 s on the two implicated
`INSERT`s, via their existing `SETTINGS` clauses. The session value stays 20 s and clones keep the
fuzz-context cap of 10 s (`max_execution_time` is stripped from fuzzed queries), the property under test.

60 s and not more: the Stress harness constrains `max_execution_time` to max 60
(`tests/docker_scripts/stress_tests.lib`) and a per-statement clause is checked with `THROW_ON_VIOLATION`,
so a larger value would be rejected before the statement runs, silently dropping this coverage. That is over
2x the failing costs (24.97 / 25.51 / 28.39 s).

Verified from `system.query_log`: the two `INSERT`s report an effective 60 where the unmodified statement
reports 20, and every clone still reports 10. With that constraint installed locally, 60 runs while a larger
value is rejected before a row is inserted. 50/50 randomized runs pass.