### PR TITLE
Give checks_investigated explicit ReplicatedMergeTree arguments

### DIFF
--- a/ci/jobs/revert_ci_regressions.py
+++ b/ci/jobs/revert_ci_regressions.py
@@ -192,6 +192,15 @@ COMMITS_QUERY_LIMIT = 2000
 # Table in the CI database that records the investigations. It joins with
 # `checks`: `test_name`, `check_names`, `commit_shas`, `report_url` and
 # `offending_pull_request_number` all carry values from there.
+#
+# The engine takes its ZooKeeper path and replica name explicitly. The
+# argument-less form expands the server's `default_replica_path`, which
+# carries the `{uuid}` macro, and the CI database rejects that outside an
+# `ON CLUSTER` query or a `Replicated` database ("Macro 'uuid' in engine
+# arguments is only supported when the UUID is explicitly specified" -- how
+# the first live run of this job failed). The path mirrors the convention
+# the `checks` table itself uses: a per-table root with the `{shard}` and
+# `{replica}` macros.
 INVESTIGATION_TABLE = "checks_investigated"
 
 INVESTIGATION_TABLE_DDL = f"""\
@@ -216,7 +225,7 @@ CREATE TABLE IF NOT EXISTS {INVESTIGATION_TABLE}
     `revert_pull_request_number` UInt32 COMMENT 'The revert that was created and merged, 0 if none',
     `reintroduce_pull_request_number` UInt32 COMMENT 'The draft pull request reintroducing the change, 0 if none'
 )
-ENGINE = ReplicatedMergeTree
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{INVESTIGATION_TABLE}/{{shard}}', '{{replica}}')
 ORDER BY (investigation_time, test_name)
 """
 


### PR DESCRIPTION
The first live run of the `Revert CI regressions` job (after the `CREATE TABLE` grant was added) failed while creating its `checks_investigated` table:

```
Code: 36. DB::Exception: Macro 'uuid' in engine arguments is only supported when the UUID is
explicitly specified, used within an ON CLUSTER query, or when using the Replicated database
engine. (BAD_ARGUMENTS) (version 26.7.1.459 (official build))
```

https://github.com/ClickHouse/ClickHouse/actions/runs/31340011284

The DDL used the argument-less `ENGINE = ReplicatedMergeTree`, which expands the server's `default_replica_path` — and that carries the `{uuid}` macro, which the CI database rejects outside an `ON CLUSTER` query or a `Replicated` database. This pull request gives the engine its ZooKeeper path and replica name explicitly, mirroring the convention the `checks` table itself uses (a per-table root with the `{shard}` and `{replica}` macros):

```sql
ENGINE = ReplicatedMergeTree('/clickhouse/tables/checks_investigated/{shard}', '{replica}')
```

The access check runs before the `IF NOT EXISTS` existence check, but engine arguments are only validated when the table is actually created — so if the table is created by hand before this merges, the job's DDL becomes a no-op and both remedies compose.

Related: https://github.com/ClickHouse/ClickHouse/pull/112833

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1066` (included in `26.8` and later)
<!-- ch-version-info:end -->