### PR TITLE
Let the investigation agent traverse to its workspace

### DIFF
--- a/ci/jobs/revert_ci_regressions.py
+++ b/ci/jobs/revert_ci_regressions.py
@@ -1869,6 +1869,43 @@ def chown(owner: str, *paths: str) -> None:
     Shell.check(f"sudo -n chown -R {owner} {quoted}", verbose=True, strict=True)
 
 
+def allow_traversal(*paths: str) -> None:
+    """Let `AGENT_USER` *reach* `paths`: give every ancestor directory that
+    lacks it the execute bit for other users.
+
+    Owning the workdir is not enough to use it. Resolving a path needs the
+    execute bit on every directory on the way, the runner image is free to
+    create the job user's home without it -- Ubuntu has made `/home/<user>`
+    0750 since 21.04 -- and the workdir lives inside the checkout, inside
+    that home: the agent is stopped at the door of an ancestor, however
+    thoroughly its own directories were handed over. The same chain also
+    carries what the agent's `git` reads through the clone's alternates
+    file, which points into the job checkout's `.git/objects`.
+
+    Execute without read is traversal by known name only: the directory
+    cannot be listed, and every file on the way keeps its own mode. So what
+    `confine_agent_user` relies on -- the job user's files being another
+    uid's and unreadable -- stays true; the agent gains a corridor, not a
+    view. Only the directories that are actually closed are touched."""
+    ancestors: List[str] = []
+    for path in paths:
+        directory = os.path.dirname(os.path.realpath(path))
+        while directory not in ancestors:
+            ancestors.append(directory)
+            parent = os.path.dirname(directory)
+            if parent == directory:
+                break
+            directory = parent
+    closed = [
+        directory
+        for directory in ancestors
+        if not os.stat(directory).st_mode & 0o001
+    ]
+    if closed:
+        quoted = " ".join(shlex.quote(directory) for directory in sorted(closed))
+        Shell.check(f"sudo -n chmod o+x {quoted}", verbose=True, strict=True)
+
+
 def run_agent(prompt: str, verdict_file: str, workdir: str) -> str:
     """Run the codex agent once in `workdir` and return what it wrote to
     `verdict_file`.
@@ -1960,8 +1997,12 @@ def run_agent(prompt: str, verdict_file: str, workdir: str) -> str:
         try:
             chown(f"{AGENT_USER}:", workdir, codex_home, gh_config_dir)
             # The runner's directory layout must actually let the other uid
-            # in -- a home directory without world-execute would stop the
-            # agent at the door, and better loudly here than obscurely there.
+            # in, and on a stock Ubuntu image it does not: the job user's
+            # home is 0750 and everything here lives inside it. So the
+            # closed ancestors are opened -- traversal only, see
+            # `allow_traversal` -- and the probe below stays: better loudly
+            # here than obscurely there.
+            allow_traversal(workdir, codex_home, gh_config_dir)
             Shell.check(
                 f"sudo -n -u {AGENT_USER} test -w {shlex.quote(workdir)}",
                 strict=True,

--- a/ci/jobs/revert_ci_regressions.py
+++ b/ci/jobs/revert_ci_regressions.py
@@ -1908,10 +1908,25 @@ def kill_agent_processes() -> None:
     `/proc` -- its environment, its working directory -- would hand it every
     path the moment the agent starts. What holds is absence: nothing of the
     agent's user runs before a workspace is handed over, and nothing after
-    it is taken back. `pkill` exits 1 when there was nothing to kill, which
-    is the expected case, not a failure."""
+    it is taken back.
+
+    `pkill` exits 1 when there was nothing to kill, which is the expected
+    case, not a failure -- but the 1 that may pass has to be `pkill`'s own.
+    `sudo` exits 1 for its own failures too: a `pkill` it cannot execute, a
+    rule that stopped matching. Those are precisely the failures this guard
+    exists for, so judging the status after `sudo` has returned -- where the
+    two are indistinguishable -- would turn them into a silent no-op and let
+    a survivor of the previous attempt watch the next agent. The status is
+    judged inside the privileged shell instead, while it is still `pkill`'s:
+    1 becomes success, and everything else -- a `pkill` error, a shell that
+    could not run it, `sudo`'s own 1 -- fails the check, so `run_agent`
+    raises and hands no workspace over."""
+    kill = (
+        f"pkill -KILL -U {AGENT_USER}; status=$?; "
+        f'[ "$status" -eq 1 ] && exit 0; exit "$status"'
+    )
     Shell.check(
-        f"sudo -n pkill -KILL -U {AGENT_USER}; [ $? -le 1 ]",
+        f"sudo -n /bin/sh -c {shlex.quote(kill)}",
         verbose=True,
         strict=True,
     )

--- a/ci/jobs/revert_ci_regressions.py
+++ b/ci/jobs/revert_ci_regressions.py
@@ -252,6 +252,18 @@ IMDS_PROBE_URL = "http://169.254.169.254/latest/meta-data/"
 INVESTIGATION_RESERVE_SEC = MAX_AGENT_ATTEMPTS * AGENT_TIMEOUT_SEC + REVERT_RESERVE_SEC
 
 TEMP_DIR = "./ci/tmp"
+# Where the agent's scratch space lives -- the disposable clone, `CODEX_HOME`,
+# `GH_CONFIG_DIR`. Not `TEMP_DIR`: resolving a path needs the execute bit on
+# every ancestor directory, `TEMP_DIR` is inside the checkout, inside the job
+# user's home, and a stock Ubuntu image creates `/home/<user>` 0750 (since
+# 21.04) -- the agent's user would own its workspace and still be stopped at
+# the door of an ancestor. Opening those ancestors is not an option either:
+# with the home traversable, every world-readable file of the job user's
+# becomes readable to the agent by known name. So the agent's directories are
+# simply not put behind the job user's door: every ancestor of `/var/tmp` is
+# world-traversable by construction, and unlike `/tmp` it is on disk rather
+# than in memory on a tmpfs image. See `agent_scratch_root`.
+AGENT_SCRATCH_PARENT = "/var/tmp"
 # How much of the recorded failure output is put in front of the agent. The full
 # text can be a megabyte of stress-test log; the head is what identifies it.
 CONTEXT_LIMIT = 4000
@@ -1869,41 +1881,22 @@ def chown(owner: str, *paths: str) -> None:
     Shell.check(f"sudo -n chown -R {owner} {quoted}", verbose=True, strict=True)
 
 
-def allow_traversal(*paths: str) -> None:
-    """Let `AGENT_USER` *reach* `paths`: give every ancestor directory that
-    lacks it the execute bit for other users.
+def agent_scratch_root() -> str:
+    """A fresh directory under `AGENT_SCRATCH_PARENT` that `AGENT_USER` can
+    traverse and nobody but the job user can plant names in.
 
-    Owning the workdir is not enough to use it. Resolving a path needs the
-    execute bit on every directory on the way, the runner image is free to
-    create the job user's home without it -- Ubuntu has made `/home/<user>`
-    0750 since 21.04 -- and the workdir lives inside the checkout, inside
-    that home: the agent is stopped at the door of an ancestor, however
-    thoroughly its own directories were handed over. The same chain also
-    carries what the agent's `git` reads through the clone's alternates
-    file, which points into the job checkout's `.git/objects`.
-
-    Execute without read is traversal by known name only: the directory
-    cannot be listed, and every file on the way keeps its own mode. So what
-    `confine_agent_user` relies on -- the job user's files being another
-    uid's and unreadable -- stays true; the agent gains a corridor, not a
-    view. Only the directories that are actually closed are touched."""
-    ancestors: List[str] = []
-    for path in paths:
-        directory = os.path.dirname(os.path.realpath(path))
-        while directory not in ancestors:
-            ancestors.append(directory)
-            parent = os.path.dirname(directory)
-            if parent == directory:
-                break
-            directory = parent
-    closed = [
-        directory
-        for directory in ancestors
-        if not os.stat(directory).st_mode & 0o001
-    ]
-    if closed:
-        quoted = " ".join(shlex.quote(directory) for directory in sorted(closed))
-        Shell.check(f"sudo -n chmod o+x {quoted}", verbose=True, strict=True)
+    The parent is world-writable (`/var/tmp` is 1777), which is exactly why
+    nothing is created there at a name chosen in advance: `mkdtemp` picks a
+    random name and creates it exclusively, so a leftover process of an
+    earlier agent cannot have squatted the path. The root is then the job
+    user's, mode 0711 -- execute without read or write for everyone else --
+    so the agent can resolve the known names inside it but cannot list it or
+    create siblings, and a fixed name inside the root (the clone that
+    `investigation_clone` removes and recreates per attempt) can only ever
+    be recreated by the job user."""
+    root = tempfile.mkdtemp(prefix="praktika-agent-", dir=AGENT_SCRATCH_PARENT)
+    os.chmod(root, 0o711)
+    return root
 
 
 def run_agent(prompt: str, verdict_file: str, workdir: str) -> str:
@@ -1984,8 +1977,12 @@ def run_agent(prompt: str, verdict_file: str, workdir: str) -> str:
     openai_key = Secret.Config(
         name=OPENAI_KEY_SECRET, type=Secret.Type.AWS_SSM_PARAMETER
     ).get_value()
-    with tempfile.TemporaryDirectory(dir=TEMP_DIR) as codex_home, (
-        tempfile.TemporaryDirectory(dir=TEMP_DIR)
+    # In `AGENT_SCRATCH_PARENT`, not `TEMP_DIR`: the agent's user must be able
+    # to reach these, and `TEMP_DIR` is behind the job user's closed home.
+    # Directly in the parent, with no fixed component: `TemporaryDirectory` is
+    # exclusive creation at a random name, safe in a world-writable directory.
+    with tempfile.TemporaryDirectory(dir=AGENT_SCRATCH_PARENT) as codex_home, (
+        tempfile.TemporaryDirectory(dir=AGENT_SCRATCH_PARENT)
     ) as gh_config_dir:
         subprocess.run(
             [codex, "login", "--with-api-key"],
@@ -1997,12 +1994,10 @@ def run_agent(prompt: str, verdict_file: str, workdir: str) -> str:
         try:
             chown(f"{AGENT_USER}:", workdir, codex_home, gh_config_dir)
             # The runner's directory layout must actually let the other uid
-            # in, and on a stock Ubuntu image it does not: the job user's
-            # home is 0750 and everything here lives inside it. So the
-            # closed ancestors are opened -- traversal only, see
-            # `allow_traversal` -- and the probe below stays: better loudly
-            # here than obscurely there.
-            allow_traversal(workdir, codex_home, gh_config_dir)
+            # in. Everything the agent touches lives under
+            # `AGENT_SCRATCH_PARENT`, outside the job user's 0750 home,
+            # precisely so that it does -- and the probe checks that it
+            # holds: better loudly here than obscurely there.
             Shell.check(
                 f"sudo -n -u {AGENT_USER} test -w {shlex.quote(workdir)}",
                 strict=True,
@@ -2049,19 +2044,23 @@ def investigation_clone(path: str, repo: str) -> None:
 
     Cloned from GitHub anonymously -- the URL carries no token and the
     checkout's git config holds none (`persist-credentials: false`), so there
-    is nothing to leak into the clone's config. `--reference` points the clone
-    at the job checkout's object store: the objects come from the local disk
-    via an alternates *path*, which shares no file the agent could write
-    through (unlike hardlinks), and only what the checkout is missing is
-    fetched over the network. `--filter=tree:0` matches how the checkout
-    itself was unshallowed: the full commit history is present for `git log`,
-    and trees and blobs of older commits are fetched on demand -- from
-    `origin`, which in this clone is the public GitHub URL, so the lazy
-    fetches are anonymous too."""
+    is nothing to leak into the clone's config. `--reference .` borrows the
+    job checkout's object store for the transfer, so only what the checkout
+    is missing is fetched over the network, and `--dissociate` then copies
+    the borrowed objects into the clone and drops the alternates link. The
+    link could not stay: it is a *path* back into the checkout, behind the
+    job user's closed home (see `AGENT_SCRATCH_PARENT`), where the agent's
+    `git` could not follow it. The dissociated clone stands alone, and shares
+    no file the agent could write through either -- which is also what ruled
+    out hardlinks. `--filter=tree:0` matches how the checkout itself was
+    unshallowed: the full commit history is present for `git log`, and trees
+    and blobs of older commits are fetched on demand -- from `origin`, which
+    in this clone is the public GitHub URL, so the lazy fetches are anonymous
+    too."""
     Shell.check(f"rm -rf {shlex.quote(path)}", verbose=True, strict=True)
     Shell.check(
         f"git clone --filter=tree:0 --no-tags --single-branch "
-        f"--branch {BASE_BRANCH} --reference . "
+        f"--branch {BASE_BRANCH} --reference . --dissociate "
         f"https://github.com/{repo}.git {shlex.quote(path)}",
         verbose=True,
         strict=True,
@@ -2078,8 +2077,9 @@ def reset_worktree() -> None:
     either way, and the reset costs nothing. The branch is re-fetched every
     time because the job moves it itself: a second revert in the same run has
     to be built on top of the first one, not on the master the run started
-    with. `ci/tmp` is spared, since that is where the job keeps its own state,
-    including the investigation clones and the verdict files."""
+    with. `ci/tmp` is spared, since that is where the job keeps its own
+    state. (The investigation clones and the verdict files are elsewhere
+    entirely -- under `AGENT_SCRATCH_PARENT`, outside the checkout.)"""
     Shell.check("git revert --abort", verbose=False)
     Shell.check(
         f"git fetch --no-tags --prune --no-recurse-submodules origin "
@@ -2254,35 +2254,41 @@ def create_reintroduce(
 def investigate(failure: Failure, index: int, repo: str) -> Investigation:
     """Ask the agent about one failure and return the recorded investigation."""
     investigation = Investigation(failure=failure)
-    clone = os.path.abspath(f"{TEMP_DIR}/investigation_{index}")
+    root = agent_scratch_root()
+    clone = os.path.join(root, f"investigation_{index}")
     verdict_file = os.path.join(clone, "verdict.json")
     prompt = investigation_prompt(failure, verdict_file)
     raw = ""
     error = ""
-    for attempt in range(1, MAX_AGENT_ATTEMPTS + 1):
-        # No GitHub token is minted here, deliberately. The agent must not hold a
-        # credential that can write -- see `run_agent` -- and this process makes
-        # no GitHub call until the guards in `act` do, which mint their own.
-        reset_worktree()
-        try:
-            # A fresh clone per attempt, not per failure: whatever the previous
-            # attempt's agent left in it is exactly what must not carry over.
-            investigation_clone(clone, repo)
-            raw = run_agent(prompt, verdict_file, clone)
-            for name, value in parse_verdict(raw).items():
-                setattr(investigation, name, value)
-            error = ""
-            break
-        except Exception as e:  # noqa: BLE001 -- any failure here is worth one retry
-            error = f"{type(e).__name__}: {e}"
-            print(
-                f"WARNING: investigation attempt {attempt}/{MAX_AGENT_ATTEMPTS} of "
-                f"{failure.title!r} failed: {error}"
-            )
-            traceback.print_exc()
-        finally:
-            Shell.check(f"rm -rf {shlex.quote(clone)}", verbose=False)
+    try:
+        for attempt in range(1, MAX_AGENT_ATTEMPTS + 1):
+            # No GitHub token is minted here, deliberately. The agent must not
+            # hold a credential that can write -- see `run_agent` -- and this
+            # process makes no GitHub call until the guards in `act` do, which
+            # mint their own.
             reset_worktree()
+            try:
+                # A fresh clone per attempt, not per failure: whatever the
+                # previous attempt's agent left in it is exactly what must not
+                # carry over.
+                investigation_clone(clone, repo)
+                raw = run_agent(prompt, verdict_file, clone)
+                for name, value in parse_verdict(raw).items():
+                    setattr(investigation, name, value)
+                error = ""
+                break
+            except Exception as e:  # noqa: BLE001 -- worth one retry
+                error = f"{type(e).__name__}: {e}"
+                print(
+                    f"WARNING: investigation attempt {attempt}/"
+                    f"{MAX_AGENT_ATTEMPTS} of {failure.title!r} failed: {error}"
+                )
+                traceback.print_exc()
+            finally:
+                Shell.check(f"rm -rf {shlex.quote(clone)}", verbose=False)
+                reset_worktree()
+    finally:
+        Shell.check(f"rm -rf {shlex.quote(root)}", verbose=False)
     if error:
         investigation.verdict = "error"
         investigation.confidence = ""

--- a/ci/jobs/revert_ci_regressions.py
+++ b/ci/jobs/revert_ci_regressions.py
@@ -1890,13 +1890,31 @@ def agent_scratch_root() -> str:
     random name and creates it exclusively, so a leftover process of an
     earlier agent cannot have squatted the path. The root is then the job
     user's, mode 0711 -- execute without read or write for everyone else --
-    so the agent can resolve the known names inside it but cannot list it or
-    create siblings, and a fixed name inside the root (the clone that
-    `investigation_clone` removes and recreates per attempt) can only ever
-    be recreated by the job user."""
+    so the agent can resolve the known names inside it, but cannot list it,
+    plant names in it, or discover the per-attempt directories `investigate`
+    makes inside it."""
     root = tempfile.mkdtemp(prefix="praktika-agent-", dir=AGENT_SCRATCH_PARENT)
     os.chmod(root, 0o711)
     return root
+
+
+def kill_agent_processes() -> None:
+    """Kill every process of `AGENT_USER`, so that none is left to watch the
+    next agent run.
+
+    The scratch paths are unpredictable and their ancestors unlistable, but
+    against a survivor of an earlier attempt that is no boundary at all: it
+    runs as the same uid as the next attempt's agent, and that agent's own
+    `/proc` -- its environment, its working directory -- would hand it every
+    path the moment the agent starts. What holds is absence: nothing of the
+    agent's user runs before a workspace is handed over, and nothing after
+    it is taken back. `pkill` exits 1 when there was nothing to kill, which
+    is the expected case, not a failure."""
+    Shell.check(
+        f"sudo -n pkill -KILL -U {AGENT_USER}; [ $? -le 1 ]",
+        verbose=True,
+        strict=True,
+    )
 
 
 def run_agent(prompt: str, verdict_file: str, workdir: str) -> str:
@@ -1939,7 +1957,11 @@ def run_agent(prompt: str, verdict_file: str, workdir: str) -> str:
       to whom the job user's files -- and `/proc` environments -- are another
       user's and unreadable. `confine_agent_user` establishes all of that
       strictly, probes the metadata service as that user, and refuses to run
-      the agent unless the probe is refused.
+      the agent unless the probe is refused. And no process of that user
+      outlives an attempt (`kill_agent_processes`, before the workspace is
+      handed over and again before it is taken back): a survivor would share
+      the next agent's uid, and the next agent's own `/proc` would hand it
+      the workspace paths that unpredictable names keep from everyone else.
     - The agent's environment is built from nothing (`env -i`): no
       `GH_TOKEN`/`GITHUB_TOKEN`, no `AWS_*` keys, nothing inherited at all --
       only `HOME`, `PATH`, `CODEX_HOME` and a `GH_CONFIG_DIR` pointing at an
@@ -1977,12 +1999,14 @@ def run_agent(prompt: str, verdict_file: str, workdir: str) -> str:
     openai_key = Secret.Config(
         name=OPENAI_KEY_SECRET, type=Secret.Type.AWS_SSM_PARAMETER
     ).get_value()
-    # In `AGENT_SCRATCH_PARENT`, not `TEMP_DIR`: the agent's user must be able
-    # to reach these, and `TEMP_DIR` is behind the job user's closed home.
-    # Directly in the parent, with no fixed component: `TemporaryDirectory` is
-    # exclusive creation at a random name, safe in a world-writable directory.
-    with tempfile.TemporaryDirectory(dir=AGENT_SCRATCH_PARENT) as codex_home, (
-        tempfile.TemporaryDirectory(dir=AGENT_SCRATCH_PARENT)
+    # Next to the workdir, in the scratch directory of this one attempt (see
+    # `investigate`) -- never `TEMP_DIR`, which is behind the job user's
+    # closed home. The agent's user can reach them there, and nothing else
+    # can find them: the ancestors are execute-only, and the attempt
+    # directory's random name dies with the attempt.
+    scratch = os.path.dirname(workdir)
+    with tempfile.TemporaryDirectory(dir=scratch) as codex_home, (
+        tempfile.TemporaryDirectory(dir=scratch)
     ) as gh_config_dir:
         subprocess.run(
             [codex, "login", "--with-api-key"],
@@ -1992,6 +2016,7 @@ def run_agent(prompt: str, verdict_file: str, workdir: str) -> str:
             env={**os.environ, "CODEX_HOME": codex_home},
         )
         try:
+            kill_agent_processes()
             chown(f"{AGENT_USER}:", workdir, codex_home, gh_config_dir)
             # The runner's directory layout must actually let the other uid
             # in. Everything the agent touches lives under
@@ -2020,6 +2045,7 @@ def run_agent(prompt: str, verdict_file: str, workdir: str) -> str:
                 timeout=AGENT_TIMEOUT_SEC,
             )
         finally:
+            kill_agent_processes()
             chown(f"{os.getuid()}:{os.getgid()}", workdir, codex_home, gh_config_dir)
     if not os.path.exists(verdict_file):
         raise ValueError(f"the agent did not write {verdict_file}")
@@ -2255,9 +2281,6 @@ def investigate(failure: Failure, index: int, repo: str) -> Investigation:
     """Ask the agent about one failure and return the recorded investigation."""
     investigation = Investigation(failure=failure)
     root = agent_scratch_root()
-    clone = os.path.join(root, f"investigation_{index}")
-    verdict_file = os.path.join(clone, "verdict.json")
-    prompt = investigation_prompt(failure, verdict_file)
     raw = ""
     error = ""
     try:
@@ -2267,6 +2290,15 @@ def investigate(failure: Failure, index: int, repo: str) -> Investigation:
             # process makes no GitHub call until the guards in `act` do, which
             # mint their own.
             reset_worktree()
+            # A scratch directory per attempt, not per investigation: the
+            # second attempt must not reappear at a path the first attempt's
+            # agent was already handed, and `mkdtemp` inside the unlistable
+            # root keeps the name unknowable from outside as well.
+            attempt_dir = tempfile.mkdtemp(prefix="attempt-", dir=root)
+            os.chmod(attempt_dir, 0o711)
+            clone = os.path.join(attempt_dir, f"investigation_{index}")
+            verdict_file = os.path.join(clone, "verdict.json")
+            prompt = investigation_prompt(failure, verdict_file)
             try:
                 # A fresh clone per attempt, not per failure: whatever the
                 # previous attempt's agent left in it is exactly what must not
@@ -2285,7 +2317,7 @@ def investigate(failure: Failure, index: int, repo: str) -> Investigation:
                 )
                 traceback.print_exc()
             finally:
-                Shell.check(f"rm -rf {shlex.quote(clone)}", verbose=False)
+                Shell.check(f"rm -rf {shlex.quote(attempt_dir)}", verbose=False)
                 reset_worktree()
     finally:
         Shell.check(f"rm -rf {shlex.quote(root)}", verbose=False)

--- a/ci/tests/test_revert_ci_regressions.py
+++ b/ci/tests/test_revert_ci_regressions.py
@@ -2119,7 +2119,7 @@ def test_the_reserve_covers_the_worst_case_of_what_it_guards():
 # --- the agent holds no credential that can write -----------------------------
 
 
-def test_the_investigation_mints_no_github_token(monkeypatch):
+def test_the_investigation_mints_no_github_token(monkeypatch, tmp_path):
     """The agent executes commands with network access over CI output a merged
     pull request can write, and anything it changed on GitHub would happen
     before every guard in `act`. A token it can reach is a token it can use --
@@ -2129,6 +2129,7 @@ def test_the_investigation_mints_no_github_token(monkeypatch):
     monkeypatch.setattr(
         job.GHAuth, "auth", lambda **kwargs: calls.append(kwargs) or True
     )
+    monkeypatch.setattr(job, "AGENT_SCRATCH_PARENT", str(tmp_path))
     monkeypatch.setattr(job, "reset_worktree", lambda *a, **k: None)
     monkeypatch.setattr(job, "investigation_clone", lambda *a, **k: None)
     monkeypatch.setattr(job.Shell, "check", lambda *a, **k: True)
@@ -2163,7 +2164,7 @@ def test_the_agent_runs_as_its_own_user_with_an_empty_environment(
         verdict_file.write_text('{"verdict": "inconclusive"}', encoding="utf-8")
         return True
 
-    monkeypatch.setattr(job, "TEMP_DIR", str(tmp_path))
+    monkeypatch.setattr(job, "AGENT_SCRATCH_PARENT", str(tmp_path))
     monkeypatch.setattr(job.Secret, "Config", FakeSecret)
     monkeypatch.setattr(job, "confine_agent_user", lambda: None)
     monkeypatch.setattr(job.shutil, "which", lambda name: "/usr/local/bin/codex")
@@ -2201,46 +2202,26 @@ def test_the_agent_runs_as_its_own_user_with_an_empty_environment(
     )
 
 
-def test_closed_ancestors_are_opened_for_traversal_only(monkeypatch, tmp_path):
+def test_the_agent_workspace_is_outside_the_home_and_squat_proof(monkeypatch, tmp_path):
     """Owning the workdir does not let the agent reach it: resolving the path
     needs the execute bit on every ancestor, and a stock Ubuntu image creates
-    the job user's home 0750 -- which is where the checkout, and inside it
-    the workdir, live. Every closed ancestor is opened with the execute bit
-    for others and nothing more, only the closed ones are touched, and a
-    layout that is already open changes nothing at all."""
-    home = tmp_path / "home"
-    work = home / "checkout" / "ci" / "tmp"
-    work.mkdir(parents=True)
-    workdir = work / "investigation_0"
-    workdir.mkdir()
-    os.chmod(home, 0o750)
+    the job user's home 0750 -- which is where the checkout, and `TEMP_DIR`
+    inside it, live. Opening those ancestors would let the agent read every
+    world-readable file of the job user's by known name, so the workspace
+    lives outside the home instead, under a world-traversable parent. The
+    root is created at a random name (the parent is world-writable, a chosen
+    name could be squatted by a leftover process of an earlier agent) and is
+    traversal-only for others: the names inside it can only be planted by
+    the job user, and cannot be listed by anyone else."""
+    monkeypatch.setattr(job, "AGENT_SCRATCH_PARENT", str(tmp_path))
 
-    commands = []
-    monkeypatch.setattr(
-        job.Shell, "check", lambda command, **_: commands.append(command) or True
-    )
+    root = job.agent_scratch_root()
 
-    job.allow_traversal(str(workdir))
-
-    assert len(commands) == 1
-    command = commands[0]
-    assert command.startswith("sudo -n chmod o+x ")
-    listed = command.split("chmod o+x ", 1)[1]
-    # The closed home is opened; the directories that are already open and
-    # the workdir itself are left alone; and traversal only -- no read bit.
-    # (The test's own temporary directory may have closed ancestors of its
-    # own -- pytest keeps its base private -- and those are rightly listed
-    # too, so the assertions are about membership, not about the whole list.)
-    assert shlex.quote(str(home)) in listed
-    assert str(workdir) not in command
-    assert str(work) not in listed
-    assert "o+r" not in command
-
-    # Once the way is open, this door is not touched again.
-    os.chmod(home, 0o751)
-    commands.clear()
-    job.allow_traversal(str(workdir))
-    assert all(shlex.quote(str(home)) not in c for c in commands)
+    assert os.path.dirname(root) == str(tmp_path)
+    assert os.stat(root).st_mode & 0o777 == 0o711
+    # Distinct runs get distinct roots: the name is never reused, so it is
+    # never predictable.
+    assert job.agent_scratch_root() != root
 
 
 def test_the_agent_cannot_recover_a_token_from_the_default_gh_store(
@@ -2276,7 +2257,7 @@ def test_the_agent_cannot_recover_a_token_from_the_default_gh_store(
         verdict_file.write_text('{"verdict": "inconclusive"}', encoding="utf-8")
         return True
 
-    monkeypatch.setattr(job, "TEMP_DIR", str(tmp_path))
+    monkeypatch.setattr(job, "AGENT_SCRATCH_PARENT", str(tmp_path))
     monkeypatch.setattr(job.Secret, "Config", FakeSecret)
     monkeypatch.setattr(job, "confine_agent_user", lambda: None)
     monkeypatch.setattr(job.shutil, "which", lambda name: "/usr/local/bin/codex")
@@ -2363,7 +2344,9 @@ def test_a_job_that_hides_the_checkout_token_cannot_pre_authenticate_gh():
         )
 
 
-def test_the_agent_investigates_a_disposable_clone_and_not_the_checkout(monkeypatch):
+def test_the_agent_investigates_a_disposable_clone_and_not_the_checkout(
+    monkeypatch, tmp_path
+):
     """`reset_worktree` restores the worktree, but a writable `.git` can carry
     a rewritten `origin`, an `insteadOf` mapping or a `pre-push` hook past it,
     and the privileged phase then fetches from whatever `origin` says and
@@ -2389,6 +2372,7 @@ def test_the_agent_investigates_a_disposable_clone_and_not_the_checkout(monkeypa
             removals.append(command)
         return True
 
+    monkeypatch.setattr(job, "AGENT_SCRATCH_PARENT", str(tmp_path))
     monkeypatch.setattr(job, "reset_worktree", lambda *a, **k: None)
     monkeypatch.setattr(job, "investigation_clone", fake_clone)
     monkeypatch.setattr(job, "run_agent", fake_agent)
@@ -2400,18 +2384,27 @@ def test_the_agent_investigates_a_disposable_clone_and_not_the_checkout(monkeypa
     assert len(cloned) == 1
     path, repo = cloned[0]
     assert repo == "ClickHouse/ClickHouse"
-    # The agent worked in the clone, and the clone did not outlive the run.
+    # The agent worked in the clone, and the clone lives inside a scratch
+    # root of this investigation's own, under the traversable parent.
     assert agent_ran_in == [path]
-    assert removals == [f"rm -rf {shlex.quote(path)}"]
+    root = os.path.dirname(path)
+    assert os.path.dirname(root) == str(tmp_path)
+    # Neither the clone nor its root outlives the run.
+    assert removals == [
+        f"rm -rf {shlex.quote(path)}",
+        f"rm -rf {shlex.quote(root)}",
+    ]
     # A clone of its own, not the checkout the privileged phase trusts.
     assert os.path.abspath(path) != os.path.abspath(".")
 
 
 def test_the_clone_is_anonymous_and_carries_the_full_history(monkeypatch):
     """Cloned over the public HTTPS URL with no token in it, borrowing objects
-    from the checkout by an alternates path rather than by hardlinks, and
-    treeless the same way the checkout was unshallowed, so `git log` has the
-    whole history and older trees are fetched on demand -- anonymously,
+    from the checkout only for the transfer -- the clone is dissociated, so no
+    alternates path points back into the checkout behind the job user's
+    closed home, and no file is shared the way a hardlink would share it --
+    and treeless the same way the checkout was unshallowed, so `git log` has
+    the whole history and older trees are fetched on demand -- anonymously,
     because `origin` is the public URL."""
     commands = []
     monkeypatch.setattr(
@@ -2425,7 +2418,7 @@ def test_the_clone_is_anonymous_and_carries_the_full_history(monkeypatch):
     assert "git clone" in clone
     assert "https://github.com/ClickHouse/ClickHouse.git" in clone
     assert "--filter=tree:0" in clone
-    assert "--reference ." in clone
+    assert "--reference . --dissociate" in clone
     assert f"--branch {job.BASE_BRANCH}" in clone
     assert "@" not in clone  # no credential baked into any URL
     assert clone.endswith(" /scratch/investigation_0")

--- a/ci/tests/test_revert_ci_regressions.py
+++ b/ci/tests/test_revert_ci_regressions.py
@@ -2164,7 +2164,6 @@ def test_the_agent_runs_as_its_own_user_with_an_empty_environment(
         verdict_file.write_text('{"verdict": "inconclusive"}', encoding="utf-8")
         return True
 
-    monkeypatch.setattr(job, "AGENT_SCRATCH_PARENT", str(tmp_path))
     monkeypatch.setattr(job.Secret, "Config", FakeSecret)
     monkeypatch.setattr(job, "confine_agent_user", lambda: None)
     monkeypatch.setattr(job.shutil, "which", lambda name: "/usr/local/bin/codex")
@@ -2224,6 +2223,100 @@ def test_the_agent_workspace_is_outside_the_home_and_squat_proof(monkeypatch, tm
     assert job.agent_scratch_root() != root
 
 
+def test_every_attempt_gets_a_scratch_subtree_of_its_own(monkeypatch, tmp_path):
+    """A helper the first attempt's agent leaves behind shares the uid the
+    second attempt's directories are handed to, so the second attempt must
+    not reappear at a path the first attempt already knew: every attempt
+    works in a fresh `mkdtemp` under the unlistable root, and each attempt's
+    subtree is removed when the attempt ends."""
+    workdirs = []
+    removals = []
+
+    def fake_agent(prompt, verdict_file, workdir):
+        workdirs.append(workdir)
+        if len(workdirs) == 1:
+            raise RuntimeError("the first attempt dies")
+        return (
+            '{"verdict": "inconclusive", "confidence": "low",'
+            ' "explanation": "could not tell"}'
+        )
+
+    def fake_check(command, **_):
+        if command.startswith("rm -rf "):
+            removals.append(command)
+        return True
+
+    monkeypatch.setattr(job, "AGENT_SCRATCH_PARENT", str(tmp_path))
+    monkeypatch.setattr(job, "reset_worktree", lambda *a, **k: None)
+    monkeypatch.setattr(job, "investigation_clone", lambda *a, **k: None)
+    monkeypatch.setattr(job, "run_agent", fake_agent)
+    monkeypatch.setattr(job.Shell, "check", fake_check)
+
+    investigation = job.investigate(make_failure(), 0, "ClickHouse/ClickHouse")
+
+    assert investigation.verdict == "inconclusive"
+    assert len(workdirs) == 2
+    first, second = (os.path.dirname(w) for w in workdirs)
+    assert first != second
+    # Both attempts live under the same investigation root...
+    assert os.path.dirname(first) == os.path.dirname(second)
+    # ...and each attempt's subtree is removed with the attempt, the root
+    # with the investigation.
+    assert removals == [
+        f"rm -rf {shlex.quote(first)}",
+        f"rm -rf {shlex.quote(second)}",
+        f"rm -rf {shlex.quote(os.path.dirname(first))}",
+    ]
+
+
+def test_no_process_of_the_agents_user_survives_an_attempt(monkeypatch, tmp_path):
+    """Unpredictable, unlistable paths stop an outside observer, not a
+    survivor: a process the agent leaves behind runs as the same uid as the
+    next attempt's agent, and that agent's own `/proc` would hand it every
+    path the moment it starts. The boundary is absence -- every process of
+    `AGENT_USER` is killed before the workspace is handed over and again
+    before it is taken back."""
+    verdict_file = tmp_path / "verdict.json"
+    commands = []
+
+    class FakeSecret:
+        def __init__(self, **_):
+            pass
+
+        def get_value(self):
+            return "openai-key"
+
+    def fake_check(command, **_):
+        commands.append(command)
+        verdict_file.write_text('{"verdict": "inconclusive"}', encoding="utf-8")
+        return True
+
+    monkeypatch.setattr(job.Secret, "Config", FakeSecret)
+    monkeypatch.setattr(job, "confine_agent_user", lambda: None)
+    monkeypatch.setattr(job.shutil, "which", lambda name: "/usr/local/bin/codex")
+    monkeypatch.setattr(job.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(job.Shell, "check", fake_check)
+    # Keep `scrub_gh_credentials` away from the developer's real `gh` store.
+    monkeypatch.setenv("GH_CONFIG_DIR", str(tmp_path / "gh-config"))
+
+    assert job.run_agent("investigate", str(verdict_file), str(tmp_path))
+
+    kills = [
+        i
+        for i, c in enumerate(commands)
+        if f"pkill -KILL -U {job.AGENT_USER}" in c
+    ]
+    agent = [i for i, c in enumerate(commands) if "codex" in c and " exec " in c]
+    handed = [i for i, c in enumerate(commands) if "chown" in c]
+    assert len(kills) == 2
+    assert len(agent) == 1
+    assert len(handed) == 2
+    # Killed before the hand-over, and killed again after the agent, before
+    # the workspace is taken back.
+    assert kills[0] < handed[0] < agent[0]
+    assert agent[0] < kills[1] < handed[1]
+
+
 def test_the_agent_cannot_recover_a_token_from_the_default_gh_store(
     monkeypatch, tmp_path
 ):
@@ -2257,7 +2350,6 @@ def test_the_agent_cannot_recover_a_token_from_the_default_gh_store(
         verdict_file.write_text('{"verdict": "inconclusive"}', encoding="utf-8")
         return True
 
-    monkeypatch.setattr(job, "AGENT_SCRATCH_PARENT", str(tmp_path))
     monkeypatch.setattr(job.Secret, "Config", FakeSecret)
     monkeypatch.setattr(job, "confine_agent_user", lambda: None)
     monkeypatch.setattr(job.shutil, "which", lambda name: "/usr/local/bin/codex")
@@ -2384,14 +2476,19 @@ def test_the_agent_investigates_a_disposable_clone_and_not_the_checkout(
     assert len(cloned) == 1
     path, repo = cloned[0]
     assert repo == "ClickHouse/ClickHouse"
-    # The agent worked in the clone, and the clone lives inside a scratch
-    # root of this investigation's own, under the traversable parent.
+    # The agent worked in the clone, and the clone lives inside the attempt's
+    # own scratch directory, inside the investigation's root, under the
+    # traversable parent.
     assert agent_ran_in == [path]
-    root = os.path.dirname(path)
+    attempt_dir = os.path.dirname(path)
+    root = os.path.dirname(attempt_dir)
     assert os.path.dirname(root) == str(tmp_path)
-    # Neither the clone nor its root outlives the run.
+    # Both levels let the agent through by known name and nothing more.
+    assert os.stat(attempt_dir).st_mode & 0o777 == 0o711
+    assert os.stat(root).st_mode & 0o777 == 0o711
+    # Neither the attempt's directory nor the root outlives the run.
     assert removals == [
-        f"rm -rf {shlex.quote(path)}",
+        f"rm -rf {shlex.quote(attempt_dir)}",
         f"rm -rf {shlex.quote(root)}",
     ]
     # A clone of its own, not the checkout the privileged phase trusts.

--- a/ci/tests/test_revert_ci_regressions.py
+++ b/ci/tests/test_revert_ci_regressions.py
@@ -2201,6 +2201,48 @@ def test_the_agent_runs_as_its_own_user_with_an_empty_environment(
     )
 
 
+def test_closed_ancestors_are_opened_for_traversal_only(monkeypatch, tmp_path):
+    """Owning the workdir does not let the agent reach it: resolving the path
+    needs the execute bit on every ancestor, and a stock Ubuntu image creates
+    the job user's home 0750 -- which is where the checkout, and inside it
+    the workdir, live. Every closed ancestor is opened with the execute bit
+    for others and nothing more, only the closed ones are touched, and a
+    layout that is already open changes nothing at all."""
+    home = tmp_path / "home"
+    work = home / "checkout" / "ci" / "tmp"
+    work.mkdir(parents=True)
+    workdir = work / "investigation_0"
+    workdir.mkdir()
+    os.chmod(home, 0o750)
+
+    commands = []
+    monkeypatch.setattr(
+        job.Shell, "check", lambda command, **_: commands.append(command) or True
+    )
+
+    job.allow_traversal(str(workdir))
+
+    assert len(commands) == 1
+    command = commands[0]
+    assert command.startswith("sudo -n chmod o+x ")
+    listed = command.split("chmod o+x ", 1)[1]
+    # The closed home is opened; the directories that are already open and
+    # the workdir itself are left alone; and traversal only -- no read bit.
+    # (The test's own temporary directory may have closed ancestors of its
+    # own -- pytest keeps its base private -- and those are rightly listed
+    # too, so the assertions are about membership, not about the whole list.)
+    assert shlex.quote(str(home)) in listed
+    assert str(workdir) not in command
+    assert str(work) not in listed
+    assert "o+r" not in command
+
+    # Once the way is open, this door is not touched again.
+    os.chmod(home, 0o751)
+    commands.clear()
+    job.allow_traversal(str(workdir))
+    assert all(shlex.quote(str(home)) not in c for c in commands)
+
+
 def test_the_agent_cannot_recover_a_token_from_the_default_gh_store(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
The third live run of the `Revert CI regressions` job got past the investigation table (created by hand), selected a repeated failure, and then had both agent attempts die on the pre-flight probe in `run_agent`: the workdir had just been `chown`'d to `praktika-agent`, and `test -w` as that user still returned false, with empty stderr.

https://github.com/ClickHouse/ClickHouse/actions/runs/31341308626

The cause is the one the probe's own comment anticipated ("a home directory without world-execute would stop the agent at the door"): owning the workdir is not enough to *reach* it. Resolving a path needs the execute bit on every ancestor directory, a stock Ubuntu image creates the job user's home `0750` (since 21.04), and everything the agent got — the disposable clone, `CODEX_HOME`, `GH_CONFIG_DIR` — lived inside that home, under the runner's checkout. The same closed chain would also have blocked the agent's `git` from reading objects through the clone's alternates file, which points into the job checkout's `.git/objects`.

The first version of this change opened the closed ancestors with `chmod o+x`, and the review rightly rejected it: with the home traversable, every world-readable file of the job user's becomes readable to the agent by known name (`~/.bashrc`, `~/.profile`, the checkout's `.git/config`), and the relaxed modes survived the run. So the door stays shut and the workspace moves instead:

- The disposable clone, `CODEX_HOME` and `GH_CONFIG_DIR` now live under a fresh `mkdtemp` root in `/var/tmp` (`agent_scratch_root`): every ancestor is world-traversable by construction, nothing of the job user's tree is `chmod`'ed at all. The root is the job user's, mode `0711` — the agent can resolve the known names inside it, but cannot list it or plant names in it (the random, exclusively-created name is what makes the root itself safe to plant in the world-writable `/var/tmp`). Inside the root, every attempt gets a fresh `mkdtemp` subtree of its own holding the clone, `CODEX_HOME` and `GH_CONFIG_DIR`, removed with the attempt; the root is removed with the investigation, so no state outlives it.
- No process of the agent's user outlives an attempt: `kill_agent_processes` runs before the workspace is handed over and again before it is taken back. Unpredictable names alone are no boundary against a survivor of an earlier attempt — it shares the next agent's uid and could read the workspace paths out of the next agent's `/proc` — so the boundary is that the observer does not exist. The kill fails closed: `pkill` exits 1 when there was nothing to kill, but so does `sudo` when it could not run `pkill` at all, so the status is judged inside the privileged shell where it is still `pkill`'s, and anything but `pkill`'s own 1 stops the attempt before the workspace is handed over.
- The clone is now made with `--dissociate`: `--reference .` still saves the network transfer, but the borrowed objects are copied into the clone and the alternates link — a path back into the checkout behind the closed home — is dropped. The clone keeps `remote.origin.promisor`, so the lazy `tree:0` fetches keep going to the anonymous GitHub `origin` (verified against a partial-clone reference: no alternates file remains, and old blobs are fetched on demand).
- The `test -w` probe stays where it was, as the check that this actually works — still loudly here rather than obscurely inside the agent.

With this, the run reaches the agent itself; the two earlier first-run failures were the missing `CREATE TABLE` grant (fixed by a grant on the CI database) and the argument-less `ReplicatedMergeTree` DDL (https://github.com/ClickHouse/ClickHouse/pull/114078).

Related: https://github.com/ClickHouse/ClickHouse/pull/112833
Related: https://github.com/ClickHouse/ClickHouse/pull/114078

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

