### PR TITLE
Fix flaky test `04323_text_index_marks_empty_part`

### DIFF
--- a/tests/queries/0_stateless/04323_text_index_marks_empty_part.sh
+++ b/tests/queries/0_stateless/04323_text_index_marks_empty_part.sh
@@ -17,7 +17,10 @@ ENGINE = MergeTree
 ORDER BY tuple()
 -- min_bytes_for_full_part_storage=0: the test edits/removes raw part files (skp_idx_idx.mrk4,
 -- checksums.txt); a packed part keeps them inside the single data.packed archive, not on disk.
-SETTINGS prewarm_mark_cache = true, compress_marks = 0, min_bytes_for_full_part_storage = 0"
+-- remove_empty_parts=0: the whole test operates on the empty part left by the DELETE mutation;
+-- otherwise the cleanup thread may drop it before the checks below see it in system.parts.
+SETTINGS prewarm_mark_cache = true, compress_marks = 0, min_bytes_for_full_part_storage = 0,
+         remove_empty_parts = 0"
 
 ${CLICKHOUSE_CLIENT} -q "INSERT INTO t_text_idx_empty SELECT toFixedString(toString(number), 37) FROM numbers(5)"
 ${CLICKHOUSE_CLIENT} -q "INSERT INTO t_text_idx_empty SELECT toFixedString(toString(number + 5), 37) FROM numbers(5)"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix flaky test `04323_text_index_marks_empty_part`.

The test operates on the empty part left by `ALTER TABLE ... DELETE`: the cleanup thread may drop that part before the `SELECT rows, marks FROM system.parts ... AND active` check sees it, so the first reference line (`0	0`) intermittently disappears:

```
@@ -1,3 +1,2 @@
-0	0
 0
 0
```

Pin `remove_empty_parts = 0` in the table settings, the same way https://github.com/ClickHouse/ClickHouse/pull/114050 fixed `04267_ttl_drop_merge_no_data_read`.

Failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108078&sha=1588d96287dc9c13f42492972c510487be49b696&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29 (all 23 in-place reruns passed; CIDB shows the same symptom on unrelated PRs on 2026-07-15).

Related: https://github.com/ClickHouse/ClickHouse/pull/114050


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1089` (included in `26.8` and later)
<!-- ch-version-info:end -->