### PR TITLE
Do not run host-global SYSTEM START CLEANUP from a parallel test

### DIFF
--- a/tests/queries/0_stateless/04499_system_cluster_access_types.reference
+++ b/tests/queries/0_stateless/04499_system_cluster_access_types.reference
@@ -2,3 +2,5 @@ ok
 ok
 ok
 ok
+ok
+ok

--- a/tests/queries/0_stateless/04499_system_cluster_access_types.sh
+++ b/tests/queries/0_stateless/04499_system_cluster_access_types.sh
@@ -4,6 +4,34 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+cluster="test_shard_localhost"
+unavailable_cluster="test_cluster_multiple_nodes_all_unavailable"
+
+# getServerPort() only knows ports whose listener bound, but isSelfHostID reads the configured
+# one, so take both. 0 is a safe filler: a cluster node can never have port 0.
+secure_port=$(${CLICKHOUSE_CLIENT} --query "SELECT getServerPort('tcp_port_secure')" 2>/dev/null || echo 0)
+[ -n "$secure_port" ] || secure_port=0
+secure_port_cfg=${CLICKHOUSE_PORT_TCP_SECURE:-0}
+[ -n "$secure_port_cfg" ] || secure_port_cfg=0
+routable_ports="tcpPort(), $secure_port, $secure_port_cfg"
+
+# An entry can only be picked up here if its port matches tcp_port or tcp_port_secure exactly,
+# so a port that is neither makes this host unreachable whatever its hostname resolves to.
+# Abort rather than continue: the no-table probes are host-global, so running them against a
+# routable cluster would touch every other test's tables. Checked before anything is created.
+n_routable=$(${CLICKHOUSE_CLIENT} --query "
+    SELECT countIf(port IN ($routable_ports)) + 1000 * (count() = 0)
+    FROM system.clusters WHERE cluster = '$unavailable_cluster'")
+if [ "$n_routable" = 0 ]; then
+    echo "ok"
+else
+    echo "FAIL: $unavailable_cluster has $n_routable node(s) reachable here (or is missing)"
+    exit 1
+fi
+${CLICKHOUSE_CLIENT} --query "
+    SELECT if(countIf(port IN ($routable_ports)) > 0, 'ok', 'FAIL: expected a routable replica in $cluster')
+    FROM system.clusters WHERE cluster = '$cluster'"
+
 table="t_04499"
 cleanup_user="cleanup_user_04499_$CLICKHOUSE_DATABASE"
 vparts_user="vparts_user_04499_$CLICKHOUSE_DATABASE"
@@ -43,39 +71,14 @@ ${CLICKHOUSE_CLIENT} --query "CREATE USER $wrong_global_user IDENTIFIED WITH no_
 ${CLICKHOUSE_CLIENT} --query "GRANT CLUSTER ON *.* TO $wrong_global_user"
 ${CLICKHOUSE_CLIENT} --query "GRANT SYSTEM PULLING REPLICATION LOG ON *.* TO $wrong_global_user"
 
-cluster="test_shard_localhost"
-# The no-table form is host-global: it walks every database on the host. Route it to unreachable nodes
-# so the entry never executes here; the access check under test runs on the initiator before enqueue.
-unavailable_cluster="test_cluster_multiple_nodes_all_unavailable"
-
-# getServerPort() only knows ports whose listener bound, but isSelfHostID reads the configured
-# one, so take both. 0 is a safe filler: a cluster node can never have port 0.
-secure_port=$(${CLICKHOUSE_CLIENT} --query "SELECT getServerPort('tcp_port_secure')" 2>/dev/null || echo 0)
-[ -n "$secure_port" ] || secure_port=0
-secure_port_cfg=${CLICKHOUSE_PORT_TCP_SECURE:-0}
-[ -n "$secure_port_cfg" ] || secure_port_cfg=0
-routable_ports="tcpPort(), $secure_port, $secure_port_cfg"
-
-# An entry can only be picked up here if its port matches tcp_port or tcp_port_secure exactly,
-# so a port that is neither makes this host unreachable whatever its hostname resolves to.
-# Abort rather than continue: the no-table probes below are host-global, so running them
-# against a routable cluster would touch every other test's tables.
-n_routable=$(${CLICKHOUSE_CLIENT} --query "
-    SELECT countIf(port IN ($routable_ports)) + 1000 * (count() = 0)
-    FROM system.clusters WHERE cluster = '$unavailable_cluster'")
-if [ "$n_routable" = 0 ]; then
-    echo "ok"
-else
-    echo "FAIL: $unavailable_cluster has $n_routable node(s) reachable here (or is missing)"
-    exit 1
-fi
-${CLICKHOUSE_CLIENT} --query "
-    SELECT if(countIf(port IN ($routable_ports)) > 0, 'ok', 'FAIL: expected a routable replica in $cluster')
-    FROM system.clusters WHERE cluster = '$cluster'"
-
 run() { ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none "$@"; }
-# The unavailable nodes never report back, so do not wait for them.
-run_global() { run --distributed_ddl_task_timeout 0 "$@"; }
+# The no-table form is host-global: it walks every database on the host, so its cluster is not a
+# caller's choice. Append the unreachable one here so no probe can name a cluster of its own, and
+# keep any test hint last, after the clause. Those nodes never report back, so do not wait.
+run_global() {
+    local query="$1" hint="$2"; shift 2
+    run --distributed_ddl_task_timeout 0 --query "$query ON CLUSTER $unavailable_cluster $hint" "$@"
+}
 
 is_cloud=$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'CLICKHOUSE_CLOUD'")
 
@@ -98,7 +101,7 @@ vparts_allowed() {
 # silent success in both builds instead of BAD_ARGUMENTS.
 vparts_global_allowed() {
     local out
-    out=$(run_global --user "$1" --query "$2" 2>&1)
+    out=$(run_global "$2" "" --user "$1" 2>&1)
     if [ -z "$out" ]; then
         echo "ok"
     else
@@ -122,15 +125,15 @@ run --user "$wrong_user" --query "SYSTEM STOP VIRTUAL PARTS UPDATE ON CLUSTER $c
 # The no-table check is a single global grant on the initiator, so these need ON *.* grants.
 
 # Holder of global SYSTEM CLEANUP is allowed.
-run_global --user "$cleanup_global_user" --query "SYSTEM START CLEANUP ON CLUSTER $unavailable_cluster" >/dev/null || exit 1
+run_global "SYSTEM START CLEANUP" "" --user "$cleanup_global_user" >/dev/null || exit 1
 echo "ok"
-vparts_global_allowed "$vparts_global_user" "SYSTEM START VIRTUAL PARTS UPDATE ON CLUSTER $unavailable_cluster"
+vparts_global_allowed "$vparts_global_user" "SYSTEM START VIRTUAL PARTS UPDATE"
 
 # Holder of only global SYSTEM PULLING REPLICATION LOG is now denied both no-table commands.
 # This is the discriminating case: the no-table branch is a single global check, so the old code
 # would have allowed this user via the global SYSTEM PULLING REPLICATION LOG grant; the fix denies it.
-run_global --user "$wrong_global_user" --query "SYSTEM STOP CLEANUP ON CLUSTER $unavailable_cluster -- { serverError ACCESS_DENIED }"
-run_global --user "$wrong_global_user" --query "SYSTEM STOP VIRTUAL PARTS UPDATE ON CLUSTER $unavailable_cluster -- { serverError ACCESS_DENIED }"
+run_global "SYSTEM STOP CLEANUP" "-- { serverError ACCESS_DENIED }" --user "$wrong_global_user"
+run_global "SYSTEM STOP VIRTUAL PARTS UPDATE" "-- { serverError ACCESS_DENIED }" --user "$wrong_global_user"
 
 ${CLICKHOUSE_CLIENT} --query "DROP USER $cleanup_user, $vparts_user, $cleanup_global_user, $vparts_global_user, $wrong_user, $wrong_global_user"
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE $table"

--- a/tests/queries/0_stateless/04499_system_cluster_access_types.sh
+++ b/tests/queries/0_stateless/04499_system_cluster_access_types.sh
@@ -48,14 +48,29 @@ cluster="test_shard_localhost"
 # so the entry never executes here; the access check under test runs on the initiator before enqueue.
 unavailable_cluster="test_cluster_multiple_nodes_all_unavailable"
 
-# is_local is computed by the same isLocalAddress(resolved, tcp_port) predicate that
-# DDLTask::findCurrentHostID uses to pick up an entry, so these two guards pin where each
-# group of probes executes. count() > 0 keeps a missing cluster from passing vacuously.
+# getServerPort() only knows ports whose listener bound, but isSelfHostID reads the configured
+# one, so take both. 0 is a safe filler: a cluster node can never have port 0.
+secure_port=$(${CLICKHOUSE_CLIENT} --query "SELECT getServerPort('tcp_port_secure')" 2>/dev/null || echo 0)
+[ -n "$secure_port" ] || secure_port=0
+secure_port_cfg=${CLICKHOUSE_PORT_TCP_SECURE:-0}
+[ -n "$secure_port_cfg" ] || secure_port_cfg=0
+routable_ports="tcpPort(), $secure_port, $secure_port_cfg"
+
+# An entry can only be picked up here if its port matches tcp_port or tcp_port_secure exactly,
+# so a port that is neither makes this host unreachable whatever its hostname resolves to.
+# Abort rather than continue: the no-table probes below are host-global, so running them
+# against a routable cluster would touch every other test's tables.
+n_routable=$(${CLICKHOUSE_CLIENT} --query "
+    SELECT countIf(port IN ($routable_ports)) + 1000 * (count() = 0)
+    FROM system.clusters WHERE cluster = '$unavailable_cluster'")
+if [ "$n_routable" = 0 ]; then
+    echo "ok"
+else
+    echo "FAIL: $unavailable_cluster has $n_routable node(s) reachable here (or is missing)"
+    exit 1
+fi
 ${CLICKHOUSE_CLIENT} --query "
-    SELECT if(countIf(is_local) = 0 AND count() > 0, 'ok', 'FAIL: expected no local replica in $unavailable_cluster')
-    FROM system.clusters WHERE cluster = '$unavailable_cluster'"
-${CLICKHOUSE_CLIENT} --query "
-    SELECT if(countIf(is_local) > 0, 'ok', 'FAIL: expected a local replica in $cluster')
+    SELECT if(countIf(port IN ($routable_ports)) > 0, 'ok', 'FAIL: expected a routable replica in $cluster')
     FROM system.clusters WHERE cluster = '$cluster'"
 
 run() { ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none "$@"; }

--- a/tests/queries/0_stateless/04499_system_cluster_access_types.sh
+++ b/tests/queries/0_stateless/04499_system_cluster_access_types.sh
@@ -47,6 +47,17 @@ cluster="test_shard_localhost"
 # The no-table form is host-global: it walks every database on the host. Route it to unreachable nodes
 # so the entry never executes here; the access check under test runs on the initiator before enqueue.
 unavailable_cluster="test_cluster_multiple_nodes_all_unavailable"
+
+# is_local is computed by the same isLocalAddress(resolved, tcp_port) predicate that
+# DDLTask::findCurrentHostID uses to pick up an entry, so these two guards pin where each
+# group of probes executes. count() > 0 keeps a missing cluster from passing vacuously.
+${CLICKHOUSE_CLIENT} --query "
+    SELECT if(countIf(is_local) = 0 AND count() > 0, 'ok', 'FAIL: expected no local replica in $unavailable_cluster')
+    FROM system.clusters WHERE cluster = '$unavailable_cluster'"
+${CLICKHOUSE_CLIENT} --query "
+    SELECT if(countIf(is_local) > 0, 'ok', 'FAIL: expected a local replica in $cluster')
+    FROM system.clusters WHERE cluster = '$cluster'"
+
 run() { ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none "$@"; }
 # The unavailable nodes never report back, so do not wait for them.
 run_global() { run --distributed_ddl_task_timeout 0 "$@"; }

--- a/tests/queries/0_stateless/04499_system_cluster_access_types.sh
+++ b/tests/queries/0_stateless/04499_system_cluster_access_types.sh
@@ -44,7 +44,12 @@ ${CLICKHOUSE_CLIENT} --query "GRANT CLUSTER ON *.* TO $wrong_global_user"
 ${CLICKHOUSE_CLIENT} --query "GRANT SYSTEM PULLING REPLICATION LOG ON *.* TO $wrong_global_user"
 
 cluster="test_shard_localhost"
+# The no-table form is host-global: it walks every database on the host. Route it to unreachable nodes
+# so the entry never executes here; the access check under test runs on the initiator before enqueue.
+unavailable_cluster="test_cluster_multiple_nodes_all_unavailable"
 run() { ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none "$@"; }
+# The unavailable nodes never report back, so do not wait for them.
+run_global() { run --distributed_ddl_task_timeout 0 "$@"; }
 
 is_cloud=$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'CLICKHOUSE_CLOUD'")
 
@@ -63,6 +68,18 @@ vparts_allowed() {
     fi
 }
 
+# Same, for the no-table form: nothing executes on the unavailable cluster, so the grant holder gets a
+# silent success in both builds instead of BAD_ARGUMENTS.
+vparts_global_allowed() {
+    local out
+    out=$(run_global --user "$1" --query "$2" 2>&1)
+    if [ -z "$out" ]; then
+        echo "ok"
+    else
+        echo "FAIL: expected the enqueue to succeed silently: $out"
+    fi
+}
+
 # The ON CLUSTER path must check the dedicated grant, not SYSTEM PULLING REPLICATION LOG.
 
 # Holder of SYSTEM CLEANUP is allowed (command runs on MergeTree).
@@ -78,19 +95,16 @@ run --user "$wrong_user" --query "SYSTEM STOP VIRTUAL PARTS UPDATE ON CLUSTER $c
 # REPLICATION LOG grant to the dedicated global SYSTEM CLEANUP / SYSTEM VIRTUAL PARTS UPDATE grant.
 # The no-table check is a single global grant on the initiator, so these need ON *.* grants.
 
-# Holder of global SYSTEM CLEANUP is allowed. START (not STOP) only wakes cleanup threads: idempotent
-# and holds no lock, so it stays parallel-safe despite touching all tables on the host.
-run --user "$cleanup_global_user" --query "SYSTEM START CLEANUP ON CLUSTER $cluster" >/dev/null || exit 1
+# Holder of global SYSTEM CLEANUP is allowed.
+run_global --user "$cleanup_global_user" --query "SYSTEM START CLEANUP ON CLUSTER $unavailable_cluster" >/dev/null || exit 1
 echo "ok"
-# START, not STOP: both spellings share one access branch, and START cannot leave updates
-# globally stopped for other tests if the private build does execute the command.
-vparts_allowed "$vparts_global_user" "SYSTEM START VIRTUAL PARTS UPDATE ON CLUSTER $cluster"
+vparts_global_allowed "$vparts_global_user" "SYSTEM START VIRTUAL PARTS UPDATE ON CLUSTER $unavailable_cluster"
 
 # Holder of only global SYSTEM PULLING REPLICATION LOG is now denied both no-table commands.
 # This is the discriminating case: the no-table branch is a single global check, so the old code
 # would have allowed this user via the global SYSTEM PULLING REPLICATION LOG grant; the fix denies it.
-run --user "$wrong_global_user" --query "SYSTEM STOP CLEANUP ON CLUSTER $cluster -- { serverError ACCESS_DENIED }"
-run --user "$wrong_global_user" --query "SYSTEM STOP VIRTUAL PARTS UPDATE ON CLUSTER $cluster -- { serverError ACCESS_DENIED }"
+run_global --user "$wrong_global_user" --query "SYSTEM STOP CLEANUP ON CLUSTER $unavailable_cluster -- { serverError ACCESS_DENIED }"
+run_global --user "$wrong_global_user" --query "SYSTEM STOP VIRTUAL PARTS UPDATE ON CLUSTER $unavailable_cluster -- { serverError ACCESS_DENIED }"
 
 ${CLICKHOUSE_CLIENT} --query "DROP USER $cleanup_user, $vparts_user, $cleanup_global_user, $vparts_global_user, $wrong_user, $wrong_global_user"
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE $table"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/111922
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #111922
CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108078&sha=1588d96287dc9c13f42492972c510487be49b696&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29

`04499_system_cluster_access_types` ran `SYSTEM START CLEANUP ON CLUSTER test_shard_localhost` with no
table name. That cluster routes the entry back here, and the no-table form is host-global:
`InterpreterSystemQuery::startStopAction` walks every database and per table calls
`onActionLockRemove(Cleanup)` (wakes the cleanup thread, which drops empty parts) and
`ActionLocksManager::remove` (drops a table-scoped `SYSTEM STOP CLEANUP` lock). The test has no `Tags:`
line, so it hits other tests' tables.

So `04323_text_index_marks_empty_part` failed on an unrelated PR: its deliberately empty active part was
dropped between its two `SELECT`s and the reference line `0\t0` vanished. Five parallel tests (`02340`,
`02421`, `02486`, `03100_lwu_40_cleanup_race`, `04338`) hold table-scoped `STOP CLEANUP` locks and were
exposed the same way. #114070 converts 04323 to an integration test, which does not fix this.

The four no-table probes now go to `test_cluster_multiple_nodes_all_unavailable` with
`distributed_ddl_task_timeout = 0`; its nodes are `127.0.0.{1,2,3}:1234`, so `findCurrentHostID` never
matches and the entry executes nowhere. The tested branch is unaffected: the access check in
`executeDDLQueryOnCluster` runs on the initiator before the enqueue. The table-scoped probes keep
`test_shard_localhost` and keep executing, so no `no-parallel` tag is added, and the wrong
`parallel-safe` comment is deleted.

Two `system.clusters` guards pin that routing, so `.reference` grows from 4 to 6 `ok` lines. An entry is
claimed here only when its port equals `tcp_port` or `tcp_port_secure` exactly, so the guards assert that
no node of the unavailable cluster carries either port, and the negative one aborts before the probes
rather than only reporting. A config change making the entry executable here stops the test.

Validation: the old test drops another database's empty part and releases a held lock while the new test
leaves both intact; reintroducing the pre-fix access type on each no-table branch separately reddens the
test; each guard reddens when its cluster is swapped. 50/50 green for both tests.

<details>
<summary>Measured arms</summary>

Fixture is 04323's table shape in a separate database; a table-scoped `SYSTEM STOP CLEANUP` is held
across each run.

| arm | `rows, marks` after | `Will drop empty part` | verdict |
|---|---|---|---|
| old test (pristine) | *(zero rows)* | 1 | part dropped, lock released |
| new test | `0\t0` | 0 | part survives, lock held |
| `SYSTEM START CLEANUP` no table (direct) | *(zero rows)* | 1 | reproduces the CI signature |
| `SYSTEM START CLEANUP <db>.<tbl>` (control) | `0\t0` | 0 | table-scoped form is harmless |

Mutation arms, each reintroducing the pre-fix access type on one no-table branch:

| mutated branch | new test |
|---|---|
| `START/STOP CLEANUP`, no table | FAIL |
| `START/STOP VIRTUAL PARTS UPDATE`, no table | FAIL |
| none (final) | OK |

Guard arms, on a stock `tcp_port=9000` / `tcp_port_secure=9440` server: pointing guard 1 at
`test_shard_localhost`, at a nonexistent cluster, or inverting guard 2 each turn the test red. Dropping
the `count() = 0` term makes a nonexistent cluster pass vacuously.

The only other no-table `SYSTEM START/STOP` sites in stateless tests are
`01563_distributed_query_finish` and `04117_parser_system_query_variants`, both already `no-parallel`
(and the latter only runs `EXPLAIN SYNTAX`), so no other test needs changing.

</details>