### PR TITLE
Do not destroy a foreign detached part when cloning one from another shard

### DIFF
--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -865,7 +865,6 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
                 ostr << "VOLUME ";
                 break;
             case DataDestinationType::SHARD:
-                /// The parser requires the keyword, so omitting it makes the output unparsable.
                 ostr << "SHARD ";
                 break;
             case DataDestinationType::TABLE:

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -864,6 +864,10 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
             case DataDestinationType::VOLUME:
                 ostr << "VOLUME ";
                 break;
+            case DataDestinationType::SHARD:
+                /// The parser requires the keyword, so omitting it makes the output unparsable.
+                ostr << "SHARD ";
+                break;
             case DataDestinationType::TABLE:
                 ostr << "TABLE ";
                 if (!to_database.empty())

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3522,9 +3522,56 @@ void StorageReplicatedMergeTree::executeClonePartFromShard(const LogEntry & entr
         };
 
         part = get_part();
-        // The fetched part is valuable and should not be cleaned like a temp part.
+
+        /// `ALTER TABLE ... DETACH` claims a detached name under `lockParts`, so holding it here
+        /// makes the two mutually exclusive. Covers only the check and the rename: no download and
+        /// no ZooKeeper access under it.
+        auto data_parts_lock = lockParts();
+
+        /// `rename` below only probes our own disk, while the detached namespace spans the whole
+        /// storage policy, so a directory on another disk has to be found explicitly.
+        if (auto occupied_disk = tryGetDiskForDetachedPart(entry.new_part_name))
+        {
+            /// This entry is retried until it succeeds, so its own earlier publication has to be
+            /// accepted, and only its content identifies it: the log entry carries no checksum.
+            String occupant_checksum;
+            try
+            {
+                Expect404ResponseScope scope; /// 404 is not an error
+                auto volume = std::make_shared<SingleDiskVolume>("volume_" + entry.new_part_name, occupied_disk);
+                auto occupant = getDataPartBuilder(
+                    entry.new_part_name, volume, fs::path(DETACHED_DIR_NAME) / entry.new_part_name,
+                    getReadSettings(), PartDirIntent::OpenExisting)
+                    .withPartFormatFromDisk()
+                    .build();
+                /// `require` must stay true: the other branch writes checksums.txt into the occupant.
+                occupant->loadChecksums(/*require=*/ true);
+                occupant_checksum = occupant->checksums.getTotalChecksumHex();
+            }
+            catch (...)
+            {
+                /// An occupant that cannot be identified is foreign.
+                tryLogCurrentException(log, fmt::format(
+                    "cannot read checksums of detached part {}, treating it as a foreign part", entry.new_part_name));
+            }
+
+            if (!part->checksums.empty() && !occupant_checksum.empty()
+                && occupant_checksum == part->checksums.getTotalChecksumHex())
+            {
+                LOG_INFO(log, "Part {} is already in the detached directory with the same checksum, "
+                    "it was published by an earlier attempt of this entry", entry.new_part_name);
+                return;
+            }
+
+            throw Exception(ErrorCodes::DIRECTORY_ALREADY_EXISTS,
+                "Detached part directory {} already exists and holds a different part", entry.new_part_name);
+        }
+
+        part->renameTo(fs::path(DETACHED_DIR_NAME) / entry.new_part_name, /*remove_new_dir_if_exists=*/ false);
+
+        /// Cleared only once published: until then the destructor has to remove the staging
+        /// directory, since nothing sweeps leftovers inside `detached/`.
         part->is_temp = false;
-        part->renameTo(fs::path(DETACHED_DIR_NAME) / entry.new_part_name, true);
 
         LOG_INFO(log, "Cloned part {} to detached directory", part->name);
     }
@@ -9755,6 +9802,8 @@ void StorageReplicatedMergeTree::movePartitionToTable(const StoragePtr & dest_ta
 void StorageReplicatedMergeTree::movePartitionToShard(
     const ASTPtr & partition, bool move_part, const String & to, ContextPtr /*query_context*/)
 {
+    auto component_guard = Coordination::setCurrentComponent("StorageReplicatedMergeTree::movePartitionToShard");
+
     /// This is a lightweight operation that only optimistically checks if it could succeed and queues tasks.
 
     if (!move_part)

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3495,8 +3495,6 @@ void StorageReplicatedMergeTree::executeClonePartFromShard(const LogEntry & entr
 
     LOG_INFO(log, "Will clone part from shard {} and replica {}", entry.source_shard, replica);
 
-    MutableDataPartPtr part;
-
     {
         auto metadata_snapshot = getInMemoryMetadataPtr(getContext(), false);
         String source_replica_path = entry.source_shard + "/replicas/" + replica;
@@ -3521,7 +3519,8 @@ void StorageReplicatedMergeTree::executeClonePartFromShard(const LogEntry & entr
             return fetched_part;
         };
 
-        part = get_part();
+        /// Declared after the claim, so the staging directory is removed before its name is released.
+        MutableDataPartPtr part = get_part();
 
         /// `ALTER TABLE ... DETACH` claims a detached name under `lockParts`, so holding it here
         /// makes the two mutually exclusive. The scope is the probe, the occupant's checksum read

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -99,6 +99,7 @@
 #include <Planner/Utils.h>
 
 #include <IO/ReadBufferFromString.h>
+#include <IO/ReadHelpers.h>
 #include <IO/Operators.h>
 #include <IO/ConnectionTimeouts.h>
 #include <IO/Expect404ResponseScope.h>
@@ -919,6 +920,46 @@ std::vector<String> getAncestors(const String & path)
         }
     }
 
+    return result;
+}
+
+/// The part files that say how its data is to be interpreted and are excluded from the checksums.
+/// Held as bytes: parsing normalizes away differences that change how the data reads, an
+/// AggregateFunction serialization version among them.
+struct PartMetadataFiles
+{
+    std::map<String, std::optional<String>> files;
+
+    bool operator==(const PartMetadataFiles &) const = default;
+};
+
+/// A projection's own total checksum is what the parent's checksums roll up, and it excludes these
+/// files just as the parent's does, so the projections are walked too.
+PartMetadataFiles readPartMetadataFiles(const IDataPartStorage & storage, const ReadSettings & read_settings)
+{
+    static const std::array names = {
+        "columns.txt",
+        IMergeTreeDataPart::COLUMNS_SUBSTREAMS_FILE_NAME,
+        IMergeTreeDataPart::METADATA_VERSION_FILE_NAME,
+    };
+
+    PartMetadataFiles result;
+    auto read_into = [&](const IDataPartStorage & from, const String & prefix)
+    {
+        for (const auto & name : names)
+        {
+            auto & content = result.files[prefix + name];
+            if (auto buf = from.readFileIfExists(name, read_settings, std::nullopt))
+                readStringUntilEOF(content.emplace(), *buf);
+        }
+    };
+
+    read_into(storage, "");
+    for (auto it = storage.iterate(); it->isValid(); it->next())
+    {
+        if (it->name().ends_with(".proj") && storage.existsDirectory(it->name()))
+            read_into(*storage.getProjection(it->name()), it->name() + "/");
+    }
     return result;
 }
 
@@ -3539,6 +3580,7 @@ void StorageReplicatedMergeTree::executeClonePartFromShard(const LogEntry & entr
             /// This entry is retried until it succeeds, so its own earlier publication has to be
             /// accepted, and only its content identifies it: the log entry carries no checksum.
             String occupant_checksum;
+            std::optional<PartMetadataFiles> occupant_metadata;
             if (occupant_is_attachable)
             {
                 try
@@ -3552,21 +3594,26 @@ void StorageReplicatedMergeTree::executeClonePartFromShard(const LogEntry & entr
                         .build();
                     /// `require` must stay true: the other branch writes checksums.txt into the occupant.
                     occupant->loadChecksums(/*require=*/ true);
+                    occupant_metadata = readPartMetadataFiles(occupant->getDataPartStorage(), getReadSettings());
+                    /// Assigned last, so a partially read occupant stays unidentified.
                     occupant_checksum = occupant->checksums.getTotalChecksumHex();
                 }
                 catch (...)
                 {
                     /// An occupant that cannot be identified is foreign.
                     tryLogCurrentException(log, fmt::format(
-                        "cannot read checksums of detached part {}, treating it as a foreign part", entry.new_part_name));
+                        "cannot read metadata of detached part {}, treating it as a foreign part", entry.new_part_name));
                 }
             }
 
+            /// Two parts differing only in those files share a total checksum, so the checksum
+            /// alone does not identify this entry's own publication.
             if (occupant_is_attachable && !part->checksums.empty() && !occupant_checksum.empty()
-                && occupant_checksum == part->checksums.getTotalChecksumHex())
+                && occupant_checksum == part->checksums.getTotalChecksumHex()
+                && occupant_metadata == readPartMetadataFiles(part->getDataPartStorage(), getReadSettings()))
             {
-                LOG_INFO(log, "Part {} is already in the detached directory with the same checksum, "
-                    "it was published by an earlier attempt of this entry", entry.new_part_name);
+                LOG_INFO(log, "Part {} is already in the detached directory with the same checksum "
+                    "and metadata, it was published by an earlier attempt of this entry", entry.new_part_name);
                 return;
             }
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3524,8 +3524,8 @@ void StorageReplicatedMergeTree::executeClonePartFromShard(const LogEntry & entr
         part = get_part();
 
         /// `ALTER TABLE ... DETACH` claims a detached name under `lockParts`, so holding it here
-        /// makes the two mutually exclusive. Covers only the check and the rename: no download and
-        /// no ZooKeeper access under it.
+        /// makes the two mutually exclusive. The scope is the probe, the occupant's checksum read
+        /// and the rename: no part download and no ZooKeeper access.
         auto data_parts_lock = lockParts();
 
         /// `rename` below only probes our own disk, while the detached namespace spans the whole

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3532,30 +3532,38 @@ void StorageReplicatedMergeTree::executeClonePartFromShard(const LogEntry & entr
         /// storage policy, so a directory on another disk has to be found explicitly.
         if (auto occupied_disk = tryGetDiskForDetachedPart(entry.new_part_name))
         {
+            /// `getDetachedParts` skips read-only and write-once disks, so `ATTACH_PART` would find
+            /// no occupant there: accepting one as our own publication would stall the move at
+            /// `DESTINATION_ATTACH` instead of refusing it here.
+            const bool occupant_is_attachable = !occupied_disk->isReadOnly() && !occupied_disk->isWriteOnce();
+
             /// This entry is retried until it succeeds, so its own earlier publication has to be
             /// accepted, and only its content identifies it: the log entry carries no checksum.
             String occupant_checksum;
-            try
+            if (occupant_is_attachable)
             {
-                Expect404ResponseScope scope; /// 404 is not an error
-                auto volume = std::make_shared<SingleDiskVolume>("volume_" + entry.new_part_name, occupied_disk);
-                auto occupant = getDataPartBuilder(
-                    entry.new_part_name, volume, fs::path(DETACHED_DIR_NAME) / entry.new_part_name,
-                    getReadSettings(), PartDirIntent::OpenExisting)
-                    .withPartFormatFromDisk()
-                    .build();
-                /// `require` must stay true: the other branch writes checksums.txt into the occupant.
-                occupant->loadChecksums(/*require=*/ true);
-                occupant_checksum = occupant->checksums.getTotalChecksumHex();
-            }
-            catch (...)
-            {
-                /// An occupant that cannot be identified is foreign.
-                tryLogCurrentException(log, fmt::format(
-                    "cannot read checksums of detached part {}, treating it as a foreign part", entry.new_part_name));
+                try
+                {
+                    Expect404ResponseScope scope; /// 404 is not an error
+                    auto volume = std::make_shared<SingleDiskVolume>("volume_" + entry.new_part_name, occupied_disk);
+                    auto occupant = getDataPartBuilder(
+                        entry.new_part_name, volume, fs::path(DETACHED_DIR_NAME) / entry.new_part_name,
+                        getReadSettings(), PartDirIntent::OpenExisting)
+                        .withPartFormatFromDisk()
+                        .build();
+                    /// `require` must stay true: the other branch writes checksums.txt into the occupant.
+                    occupant->loadChecksums(/*require=*/ true);
+                    occupant_checksum = occupant->checksums.getTotalChecksumHex();
+                }
+                catch (...)
+                {
+                    /// An occupant that cannot be identified is foreign.
+                    tryLogCurrentException(log, fmt::format(
+                        "cannot read checksums of detached part {}, treating it as a foreign part", entry.new_part_name));
+                }
             }
 
-            if (!part->checksums.empty() && !occupant_checksum.empty()
+            if (occupant_is_attachable && !part->checksums.empty() && !occupant_checksum.empty()
                 && occupant_checksum == part->checksums.getTotalChecksumHex())
             {
                 LOG_INFO(log, "Part {} is already in the detached directory with the same checksum, "

--- a/tests/integration/test_part_moves_between_shards_detached/configs/merge_tree.xml
+++ b/tests/integration/test_part_moves_between_shards_detached/configs/merge_tree.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <merge_tree>
+        <assign_part_uuids>1</assign_part_uuids>
+        <part_moves_between_shards_enable>1</part_moves_between_shards_enable>
+        <part_moves_between_shards_delay_seconds>1</part_moves_between_shards_delay_seconds>
+    </merge_tree>
+</clickhouse>

--- a/tests/integration/test_part_moves_between_shards_detached/configs/storage_configuration.xml
+++ b/tests/integration/test_part_moves_between_shards_detached/configs/storage_configuration.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <jbod1>
+                <path>/jbod1/</path>
+            </jbod1>
+            <jbod2>
+                <path>/jbod2/</path>
+            </jbod2>
+        </disks>
+        <policies>
+            <two_disks>
+                <volumes>
+                    <first>
+                        <disk>jbod1</disk>
+                    </first>
+                    <second>
+                        <disk>jbod2</disk>
+                    </second>
+                </volumes>
+            </two_disks>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_part_moves_between_shards_detached/configs/storage_configuration.xml
+++ b/tests/integration/test_part_moves_between_shards_detached/configs/storage_configuration.xml
@@ -7,6 +7,13 @@
             <jbod2>
                 <path>/jbod2/</path>
             </jbod2>
+            <!-- Plain metadata makes the disk write-once, which `getDetachedParts` skips. -->
+            <write_once>
+                <type>object_storage</type>
+                <object_storage_type>local_blob_storage</object_storage_type>
+                <metadata_type>plain</metadata_type>
+                <path>/write_once/</path>
+            </write_once>
         </disks>
         <policies>
             <two_disks>
@@ -19,6 +26,16 @@
                     </second>
                 </volumes>
             </two_disks>
+            <with_write_once>
+                <volumes>
+                    <first>
+                        <disk>jbod1</disk>
+                    </first>
+                    <second>
+                        <disk>write_once</disk>
+                    </second>
+                </volumes>
+            </with_write_once>
         </policies>
     </storage_configuration>
 </clickhouse>

--- a/tests/integration/test_part_moves_between_shards_detached/test.py
+++ b/tests/integration/test_part_moves_between_shards_detached/test.py
@@ -57,9 +57,11 @@ def drop_tables(name):
 
 
 def detached_rows(node, name, columns="name, disk"):
+    # A refused clone is retried, and each retry re-stages into detached/tmp-fetch_<part>, which is
+    # itself a system.detached_parts row. Published parts never carry a tmp- prefix, so drop those.
     return node.query(
         f"SELECT {columns} FROM system.detached_parts WHERE database = currentDatabase()"
-        f" AND table = '{name}' ORDER BY name, disk"
+        f" AND table = '{name}' AND NOT startsWith(name, 'tmp-') ORDER BY name, disk"
     ).strip()
 
 

--- a/tests/integration/test_part_moves_between_shards_detached/test.py
+++ b/tests/integration/test_part_moves_between_shards_detached/test.py
@@ -16,7 +16,7 @@ s1 = cluster.add_instance(
     "s1",
     main_configs=["configs/merge_tree.xml", "configs/storage_configuration.xml"],
     with_zookeeper=True,
-    tmpfs=["/jbod1:size=100M", "/jbod2:size=100M"],
+    tmpfs=["/jbod1:size=100M", "/jbod2:size=100M", "/write_once:size=100M"],
 )
 
 PART = "all_0_0_0"
@@ -204,6 +204,55 @@ def test_move_reuses_its_own_published_part(started_cluster):
     assert not published_to_detached(s1, name), "the clone republished over an identical occupant"
     assert s0.query(f"SELECT count() FROM {name}").strip() == "0"
     assert s1.query(f"SELECT k, v FROM {name} ORDER BY k").strip() == "1\tfrom_s0"
+
+    drop_tables(name)
+
+
+def test_move_refuses_conflict_on_a_disk_attach_cannot_see(started_cluster):
+    """The occupant sits on a write-once disk, which `getDetachedParts` deliberately skips.
+
+    `DESTINATION_ATTACH` builds its candidates from that enumeration, so accepting such an
+    occupant as this entry's own publication would report success here and then fail at attach
+    time with an unrelated-looking NO_REPLICA_HAS_PART. Reuse has to mean "the publication attach
+    will consume", so the clone must refuse here instead."""
+    name = create_tables("t_hidden", dst_settings=", storage_policy = 'with_write_once'")
+
+    s0.query(f"INSERT INTO {name} VALUES (1, 'from_s0')")
+    # A write-once disk rejects FETCH PART and MOVE PART, which is why such an occupant only ever
+    # arrives as a directory - "produced on another machine", as getDetachedParts puts it. The copy
+    # is byte-identical to the part the move will fetch, so only the disk makes it unreusable.
+    src_part = s0.query(
+        f"SELECT path FROM system.parts WHERE database = currentDatabase()"
+        f" AND table = '{name}' AND active"
+    ).strip().rstrip("/")
+    dst_uuid = s1.query(
+        f"SELECT toString(uuid) FROM system.tables WHERE database = currentDatabase()"
+        f" AND name = '{name}'"
+    ).strip()
+    detached_dir = f"/write_once/store/{dst_uuid[:3]}/{dst_uuid}/detached"
+    occupant = f"{detached_dir}/{PART}"
+    started_cluster.copy_file_from_container_to_container(s0, src_part, s1, "/tmp/")
+    s1.exec_in_container(
+        ["bash", "-c", f"mkdir -p {detached_dir} && cp -r /tmp/{PART} {occupant}"]
+    )
+    # The premise of the whole test: the probe finds it, the enumeration does not.
+    assert detached_rows(s1, name) == "", "the occupant must be invisible to getDetachedParts"
+
+    move_to_shard(name)
+    wait_for_clone_outcome(s1, name)
+
+    assert not reused_detached_part(s1, name), "an occupant ATTACH cannot see was reused"
+    assert not published_to_detached(s1, name), "clone published over an occupied name"
+    assert "DIRECTORY_ALREADY_EXISTS" in s1.query(
+        f"SELECT last_exception FROM system.replication_queue"
+        f" WHERE database = currentDatabase() AND table = '{name}'"
+        f" AND type = 'CLONE_PART_FROM_SHARD'"
+    ), "the refusal has to name the conflict on this entry, not stall later at attach"
+    # Never modified, never removed.
+    assert (
+        s1.exec_in_container(["bash", "-c", f"cd {occupant} && md5sum * | sort"])
+        == s1.exec_in_container(["bash", "-c", f"cd /tmp/{PART} && md5sum * | sort"])
+    )
 
     drop_tables(name)
 

--- a/tests/integration/test_part_moves_between_shards_detached/test.py
+++ b/tests/integration/test_part_moves_between_shards_detached/test.py
@@ -57,11 +57,12 @@ def drop_tables(name):
 
 
 def detached_rows(node, name, columns="name, disk"):
-    # A refused clone is retried, and each retry re-stages into detached/tmp-fetch_<part>, which is
-    # itself a system.detached_parts row. Published parts never carry a tmp- prefix, so drop those.
+    # Only published parts have a parsed, prefix-less name (reason = ''). A refused clone is
+    # retried, and each retry stages and then deletes directories under detached/ whose names
+    # carry a prefix or do not parse; those must not count as rows here.
     return node.query(
         f"SELECT {columns} FROM system.detached_parts WHERE database = currentDatabase()"
-        f" AND table = '{name}' AND NOT startsWith(name, 'tmp-') ORDER BY name, disk"
+        f" AND table = '{name}' AND reason = '' ORDER BY name, disk"
     ).strip()
 
 

--- a/tests/integration/test_part_moves_between_shards_detached/test.py
+++ b/tests/integration/test_part_moves_between_shards_detached/test.py
@@ -200,6 +200,8 @@ def test_move_reuses_its_own_published_part(started_cluster):
     move_to_shard(name)
     wait_for_move_state(s0, name, "DONE")
 
+    assert reused_detached_part(s1, name), "the identical occupant was not reused"
+    assert not published_to_detached(s1, name), "the clone republished over an identical occupant"
     assert s0.query(f"SELECT count() FROM {name}").strip() == "0"
     assert s1.query(f"SELECT k, v FROM {name} ORDER BY k").strip() == "1\tfrom_s0"
 

--- a/tests/integration/test_part_moves_between_shards_detached/test.py
+++ b/tests/integration/test_part_moves_between_shards_detached/test.py
@@ -31,7 +31,7 @@ def started_cluster():
         cluster.shutdown()
 
 
-def create_tables(prefix, dst_settings=""):
+def create_tables(prefix, dst_settings="", columns="k UInt64, v String"):
     """Two INDEPENDENT tables, so the destination only ever receives the part through the
     MOVE PART TO SHARD under test. Both start empty, so both name their first part all_0_0_0.
 
@@ -42,7 +42,7 @@ def create_tables(prefix, dst_settings=""):
         node.query(
             f"""
             DROP TABLE IF EXISTS {name} SYNC;
-            CREATE TABLE {name} (k UInt64, v String)
+            CREATE TABLE {name} ({columns})
             ENGINE = ReplicatedMergeTree('/clickhouse/tables/{name}_{shard}', 'r1')
             ORDER BY k SETTINGS old_parts_lifetime = 100000{settings}
         """
@@ -256,6 +256,100 @@ def test_move_refuses_conflict_on_a_disk_attach_cannot_see(started_cluster):
         s1.exec_in_container(["bash", "-c", f"cd {occupant} && md5sum * | sort"])
         == s1.exec_in_container(["bash", "-c", f"cd /tmp/{PART} && md5sum * | sort"])
     )
+
+    drop_tables(name)
+
+
+@pytest.mark.parametrize(
+    "prefix, columns, insert, unchecked_file, edit",
+    [
+        # A different declared type: the data files read as something else.
+        (
+            "t_columns", "k UInt64, v String", "SELECT 1, 'from_s0'",
+            "columns.txt", "s/`k` UInt64/`k` Int64/",
+        ),
+        # A different AggregateFunction serialization version: same type, other state encoding.
+        # `AggregateFunction(1, ...)` and `AggregateFunction(...)` parse to types that compare
+        # equal, because `IDataType::equals` drops the version - so only the bytes tell them
+        # apart, and version 0 of groupBitmap omits the leading flag version 1 writes.
+        (
+            "t_version",
+            "k UInt64, v String, s AggregateFunction(1, groupBitmap, UInt32)",
+            "SELECT 1, 'from_s0', groupBitmapState(toUInt32(1))",
+            "columns.txt", "s/AggregateFunction(1, groupBitmap/AggregateFunction(0, groupBitmap/",
+        ),
+        # A different substream order: a Compact part's marks are indexed by the positions this
+        # file records, so reordering two of them makes the same bytes read as other subcolumns.
+        # The edit is a permutation, not a rename, so the file stays valid.
+        (
+            "t_substreams", "k UInt64, v String, t Tuple(a String, b String)",
+            "SELECT 1, 'from_s0', ('x', 'y')",
+            "columns_substreams.txt",
+            "/^\\tt%2Ea$/{h;d};/^\\tt%2Eb\\.size$/{G}",
+        ),
+        # The same, one level down: what the parent's checksums roll up for a projection is the
+        # projection's own total checksum, which excludes its columns.txt as the parent's does.
+        (
+            "t_projection",
+            "k UInt64, v String, PROJECTION p (SELECT v, count() GROUP BY v)",
+            "SELECT 1, 'from_s0'",
+            "p.proj/columns.txt", "s/`v` String/`v` FixedString(7)/",
+        ),
+        # A different metadata version: it decides which ALTER conversions count as applied to
+        # this data, so the same bytes are read through a different schema.
+        (
+            "t_metadata_version", "k UInt64, v String", "SELECT 1, 'from_s0'",
+            "metadata_version.txt", "s/^0$/1/",
+        ),
+    ],
+)
+def test_move_refuses_occupant_with_same_checksum_and_other_metadata(
+    started_cluster, prefix, columns, insert, unchecked_file, edit
+):
+    """The occupant's data files are byte-identical, but the metadata describing them is not.
+
+    Neither `columns.txt` nor `columns_substreams.txt` is part of the checksums, so such an
+    occupant shares the incoming part's total checksum. `ATTACH_PART` filters detached candidates
+    by that checksum alone, so accepting it here attaches a part whose data reads differently and
+    `SOURCE_DROP` then deletes the only correct copy."""
+    name = create_tables(prefix, columns=columns)
+
+    s0.query(f"INSERT INTO {name} {insert}")
+    # An interrupted attempt of this very clone is what the reuse branch exists for, so start from
+    # exactly that - then change only the unchecked file, leaving the checksums identical.
+    s1.query(f"ALTER TABLE {name} FETCH PART '{PART}' FROM '/clickhouse/tables/{name}_s0'")
+    occupant = s1.query(
+        f"SELECT path FROM system.detached_parts WHERE database = currentDatabase()"
+        f" AND table = '{name}' AND name = '{PART}'"
+    ).strip().rstrip("/")
+    before_checksums = s1.exec_in_container(["bash", "-c", f"cd {occupant} && md5sum checksums.txt"])
+    before = s1.exec_in_container(["bash", "-c", f"cat {occupant}/{unchecked_file}"])
+    s1.exec_in_container(["bash", "-c", f"sed -i '{edit}' {occupant}/{unchecked_file}"])
+    edited = s1.exec_in_container(["bash", "-c", f"cat {occupant}/{unchecked_file}"])
+    # The premise: the file really changed, and checksums.txt - which is what the total checksum
+    # is computed from - did not, so the checksums still match on both sides.
+    assert edited != before, f"the edit did not change {unchecked_file}"
+    assert s1.exec_in_container(["bash", "-c", f"cd {occupant} && md5sum checksums.txt"]) == before_checksums
+
+    move_to_shard(name)
+    wait_for_clone_outcome(s1, name)
+
+    assert not reused_detached_part(s1, name), "an occupant with other metadata was reused"
+    assert not published_to_detached(s1, name), "clone published over an occupied name"
+    assert "DIRECTORY_ALREADY_EXISTS" in s1.query(
+        f"SELECT last_exception FROM system.replication_queue"
+        f" WHERE database = currentDatabase() AND table = '{name}'"
+        f" AND type = 'CLONE_PART_FROM_SHARD'"
+    ), "the refusal has to name the conflict on this entry"
+    assert s1.exec_in_container(["bash", "-c", f"cat {occupant}/{unchecked_file}"]) == edited
+
+    # Recoverable: dropping the occupant lets the retried entry finish the move with the part the
+    # source actually holds.
+    s1.query(
+        f"ALTER TABLE {name} DROP DETACHED PART '{PART}'", settings={"allow_drop_detached": 1}
+    )
+    wait_for_move_state(s0, name, "DONE")
+    assert s1.query(f"SELECT k, v FROM {name} ORDER BY k").strip() == "1\tfrom_s0"
 
     drop_tables(name)
 

--- a/tests/integration/test_part_moves_between_shards_detached/test.py
+++ b/tests/integration/test_part_moves_between_shards_detached/test.py
@@ -1,0 +1,222 @@
+import time
+import uuid
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+s0 = cluster.add_instance(
+    "s0",
+    main_configs=["configs/merge_tree.xml"],
+    with_zookeeper=True,
+)
+s1 = cluster.add_instance(
+    "s1",
+    main_configs=["configs/merge_tree.xml", "configs/storage_configuration.xml"],
+    with_zookeeper=True,
+    tmpfs=["/jbod1:size=100M", "/jbod2:size=100M"],
+)
+
+PART = "all_0_0_0"
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def create_tables(prefix, dst_settings=""):
+    """Two INDEPENDENT tables, so the destination only ever receives the part through the
+    MOVE PART TO SHARD under test. Both start empty, so both name their first part all_0_0_0.
+
+    The name carries a fresh suffix: the assertions below read the shared server log, so a repeated
+    run must not match the previous one's lines."""
+    name = f"{prefix}_{uuid.uuid4().hex[:8]}"
+    for node, shard, settings in ((s0, "s0", ""), (s1, "s1", dst_settings)):
+        node.query(
+            f"""
+            DROP TABLE IF EXISTS {name} SYNC;
+            CREATE TABLE {name} (k UInt64, v String)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/{name}_{shard}', 'r1')
+            ORDER BY k SETTINGS old_parts_lifetime = 100000{settings}
+        """
+        )
+        node.query(f"SYSTEM STOP MERGES {name}")
+    return name
+
+
+def drop_tables(name):
+    for node in (s0, s1):
+        node.query(f"DROP TABLE IF EXISTS {name} SYNC")
+
+
+def detached_rows(node, name, columns="name, disk"):
+    return node.query(
+        f"SELECT {columns} FROM system.detached_parts WHERE database = currentDatabase()"
+        f" AND table = '{name}' ORDER BY name, disk"
+    ).strip()
+
+
+def logged_for_table(node, name, substring):
+    """Whether `substring` was logged for THIS table. The log is shared by every test on the
+    node, so the table name has to be part of the match."""
+    lines = node.grep_in_log(substring)
+    return any(f".{name} (" in line for line in lines.splitlines())
+
+
+def published_to_detached(node, name):
+    return logged_for_table(node, name, f"Cloned part {PART} to detached directory")
+
+
+def reused_detached_part(node, name):
+    return logged_for_table(node, name, "is already in the detached directory with the same checksum")
+
+
+def wait_for_move_state(node, name, state, timeout=120):
+    deadline = time.monotonic() + timeout
+    while True:
+        actual = node.query(
+            f"SELECT state FROM system.part_moves_between_shards"
+            f" WHERE database = currentDatabase() AND table = '{name}'"
+        ).strip()
+        if actual == state:
+            return
+        assert time.monotonic() < deadline, f"move state is {actual!r}, expected {state!r}"
+        time.sleep(0.5)
+
+
+def wait_for_clone_outcome(node, name, timeout=120):
+    """Return once the destination has acted on the clone. Refusing is the wanted outcome and is
+    reported on its queue entry, which is retried forever; publishing over the occupant and
+    mistaking it for our own leftover are the two failure modes, and both are returned here so the
+    caller rejects them by name instead of timing out."""
+    deadline = time.monotonic() + timeout
+    while True:
+        exception = node.query(
+            f"SELECT last_exception FROM system.replication_queue"
+            f" WHERE database = currentDatabase() AND table = '{name}'"
+            f" AND type = 'CLONE_PART_FROM_SHARD'"
+        ).strip()
+        if (
+            "DIRECTORY_ALREADY_EXISTS" in exception
+            or published_to_detached(node, name)
+            or reused_detached_part(node, name)
+        ):
+            return
+        assert time.monotonic() < deadline, f"clone did not run, last exception: {exception!r}"
+        time.sleep(0.5)
+
+
+def move_to_shard(name):
+    s0.query(
+        f"ALTER TABLE {name} MOVE PART '{PART}' TO SHARD '/clickhouse/tables/{name}_s1'"
+    )
+
+
+def test_move_does_not_destroy_foreign_detached_part(started_cluster):
+    """The destination parked its own part under the name the incoming clone wants."""
+    name = create_tables("t_conflict")
+
+    s0.query(f"INSERT INTO {name} VALUES (1, 'from_s0')")
+    s1.query(f"INSERT INTO {name} VALUES (2, 'parked_on_s1')")
+    s1.query(f"ALTER TABLE {name} DETACH PART '{PART}'")
+    detached_bytes = s1.query(
+        f"SELECT bytes_on_disk FROM system.detached_parts WHERE database = currentDatabase()"
+        f" AND table = '{name}' AND name = '{PART}'"
+    ).strip()
+
+    move_to_shard(name)
+    wait_for_clone_outcome(s1, name)
+
+    assert not published_to_detached(s1, name), "clone published over an occupied name"
+    assert not reused_detached_part(s1, name), "a foreign part was mistaken for our own leftover"
+    # Still exactly one detached/<part>, same size, and it still holds the parked row.
+    assert detached_rows(s1, name, "name") == PART
+    assert (
+        s1.query(
+            f"SELECT bytes_on_disk FROM system.detached_parts WHERE database = currentDatabase()"
+            f" AND table = '{name}' AND name = '{PART}'"
+        ).strip()
+        == detached_bytes
+    )
+    s1.query(f"ALTER TABLE {name} ATTACH PART '{PART}'")
+    assert s1.query(f"SELECT v FROM {name} WHERE k = 2").strip() == "parked_on_s1"
+
+    # The refusal is recoverable: freeing the name lets the retried entry finish the move.
+    wait_for_move_state(s0, name, "DONE")
+    assert s0.query(f"SELECT count() FROM {name}").strip() == "0"
+    assert s1.query(f"SELECT k, v FROM {name} ORDER BY k").strip() == "1\tfrom_s0\n2\tparked_on_s1"
+
+    drop_tables(name)
+
+
+def test_move_refuses_conflict_on_another_disk(started_cluster):
+    """The conflicting directory sits on another disk of the destination's policy.
+
+    `rename`'s own guard only looks at the clone's own disk, so without a table-wide check the
+    clone publishes and two logical detached/<part> exist until ATTACH consumes one."""
+    name = create_tables("t_disks", dst_settings=", storage_policy = 'two_disks'")
+
+    s0.query(f"INSERT INTO {name} VALUES (1, 'from_s0')")
+    s1.query(f"INSERT INTO {name} VALUES (2, 'parked_on_s1')")
+    s1.query(f"ALTER TABLE {name} MOVE PART '{PART}' TO DISK 'jbod2'")
+    s1.query(f"ALTER TABLE {name} DETACH PART '{PART}'")
+    # The clone reserves from the first volume, so the two sides are provably on different disks -
+    # otherwise this degenerates into the single-disk case above.
+    assert detached_rows(s1, name) == f"{PART}\tjbod2"
+
+    move_to_shard(name)
+    wait_for_clone_outcome(s1, name)
+
+    assert not published_to_detached(s1, name), "clone published over an occupied name"
+    assert not reused_detached_part(s1, name), "a foreign part was mistaken for our own leftover"
+    assert detached_rows(s1, name) == f"{PART}\tjbod2"
+
+    s1.query(f"ALTER TABLE {name} ATTACH PART '{PART}'")
+    wait_for_move_state(s0, name, "DONE")
+    assert s1.query(f"SELECT k, v FROM {name} ORDER BY k").strip() == "1\tfrom_s0\n2\tparked_on_s1"
+
+    drop_tables(name)
+
+
+def test_move_reuses_its_own_published_part(started_cluster):
+    """A checksum-identical occupant is this entry's own earlier publication, so the retried
+    entry must accept it: refusing here would stall the move before DESTINATION_ATTACH.
+
+    FETCH PART leaves exactly what an interrupted attempt of the clone leaves - the same part,
+    fetched from the same replica, under its canonical detached name."""
+    name = create_tables("t_leftover")
+
+    s0.query(f"INSERT INTO {name} VALUES (1, 'from_s0')")
+    s1.query(f"ALTER TABLE {name} FETCH PART '{PART}' FROM '/clickhouse/tables/{name}_s0'")
+    assert detached_rows(s1, name, "name") == PART
+
+    move_to_shard(name)
+    wait_for_move_state(s0, name, "DONE")
+
+    assert s0.query(f"SELECT count() FROM {name}").strip() == "0"
+    assert s1.query(f"SELECT k, v FROM {name} ORDER BY k").strip() == "1\tfrom_s0"
+
+    drop_tables(name)
+
+
+def test_move_without_conflict(started_cluster):
+    """Control: passes on unpatched master too, so the suite above is specific to the conflict."""
+    name = create_tables("t_control")
+
+    s0.query(f"INSERT INTO {name} VALUES (1, 'from_s0')")
+
+    move_to_shard(name)
+    wait_for_move_state(s0, name, "DONE")
+
+    assert s0.query(f"SELECT count() FROM {name}").strip() == "0"
+    assert s1.query(f"SELECT k, v FROM {name} ORDER BY k").strip() == "1\tfrom_s0"
+    assert detached_rows(s1, name, "name") == ""
+
+    drop_tables(name)

--- a/tests/queries/0_stateless/04126_parser_alter_query_variants.reference
+++ b/tests/queries/0_stateless/04126_parser_alter_query_variants.reference
@@ -17,6 +17,8 @@ ALTER TABLE db.t\n    (MOVE PARTITION 1 TO DISK \'mydisk\')
 ALTER TABLE db.t\n    (MOVE PARTITION 1 TO VOLUME \'myvol\')
 ALTER TABLE db.t\n    (MOVE PARTITION 1 TO TABLE db.u)
 ALTER TABLE db.t\n    (MOVE PART \'part_1_1_0\' TO DISK \'mydisk\')
+ALTER TABLE db.t\n    (MOVE PART \'part_1_1_0\' TO SHARD \'/clickhouse/shard2\')
+ALTER TABLE db.t\n    (MOVE PART \'part_1_1_0\' TO SHARD \'/clickhouse/shard2\')
 --- FETCH / REPLACE / ATTACH PARTITION ---
 ALTER TABLE db.t\n    (FETCH PARTITION 1 FROM \'/from\')
 ALTER TABLE db.t\n    (FETCH PART \'x\' FROM \'/from\')

--- a/tests/queries/0_stateless/04126_parser_alter_query_variants.sql
+++ b/tests/queries/0_stateless/04126_parser_alter_query_variants.sql
@@ -27,6 +27,11 @@ SELECT formatQuery('ALTER TABLE db.t MOVE PARTITION 1 TO DISK ''mydisk''');
 SELECT formatQuery('ALTER TABLE db.t MOVE PARTITION 1 TO VOLUME ''myvol''');
 SELECT formatQuery('ALTER TABLE db.t MOVE PARTITION 1 TO TABLE db.u');
 SELECT formatQuery('ALTER TABLE db.t MOVE PART ''part_1_1_0'' TO DISK ''mydisk''');
+SELECT formatQuery('ALTER TABLE db.t MOVE PART ''part_1_1_0'' TO SHARD ''/clickhouse/shard2''');
+-- Formatting the already-formatted form must be stable: this command has to survive a round trip.
+SELECT formatQuery('ALTER TABLE db.t (MOVE PART ''part_1_1_0'' TO SHARD ''/clickhouse/shard2'')');
+-- TO SHARD is accepted on MOVE PART only, never on MOVE PARTITION.
+SELECT formatQuery('ALTER TABLE db.t MOVE PARTITION 1 TO SHARD ''/clickhouse/shard2'''); -- { serverError SYNTAX_ERROR }
 
 SELECT '--- FETCH / REPLACE / ATTACH PARTITION ---';
 SELECT formatQuery('ALTER TABLE db.t FETCH PARTITION 1 FROM ''/from''');


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/112215
Related: https://github.com/ClickHouse/ClickHouse/pull/109060
-->

Related: #112215
Related: #109060

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes data loss in `ALTER TABLE ... MOVE PART ... TO SHARD` (experimental, `part_moves_between_shards_enable`): the destination shard deleted a pre-existing `detached/` part whose directory name matched the incoming one. Such a part is now left alone and the move reports `DIRECTORY_ALREADY_EXISTS` until the name is free. Also fixes this statement being formatted back without the `SHARD` keyword.


### Description

`MOVE PART ... TO SHARD` deleted a detached part on the destination that it did not create: `executeClonePartFromShard` published with `renameTo(detached/<part>, remove_new_dir_if_exists = true)`, so `rename` removed whatever occupied the name. Two independent tables both name their first part `all_0_0_0`, so a destination that parked its own part with `DETACH PART` loses it on the first move.

The publish step now runs under `lockParts()` (the lock `DETACH` holds when claiming a detached name), probes the whole storage policy with `tryGetDiskForDetachedPart` since `rename`'s probe is disk-local, and renames non-destructively. An occupant is accepted as this entry's own earlier publication only when its checksums AND the files saying how its data is read both match the fetched part's; anything else, unreadable ones included, is refused with `DIRECTORY_ALREADY_EXISTS`. Those files (`columns.txt`, `columns_substreams.txt`, `metadata_version.txt`, and the same set per projection) are excluded from the checksums while `ATTACH_PART` compares checksums alone, so otherwise a directory with identical data but another declared type, substream order or metadata version is attached and the source dropped. Compared as bytes: parsing normalizes away an `AggregateFunction` serialization version the state encoding depends on. The reuse branch is load-bearing: the entry is retried forever with no already-in-detached early return, so a bare non-destructive rename would wedge the move. All of it comes from the part in hand, so the log entry format is unchanged. Reuse is limited to disks `getDetachedParts` enumerates, where `DESTINATION_ATTACH` picks its candidate.

Two one-line omissions blocked any test of this path: `ASTAlterQuery::formatImpl` had no `case DataDestinationType::SHARD`, so it dropped the keyword the parser requires and the AST round-trip check aborted assert builds (byte-identical to #109060's hunk, so either merge order resolves); and `movePartitionToShard` set no Keeper component, aborting under `enforce_keeper_component_tracking`. The feature has had no coverage since its test directory was removed in 2023; this adds `tests/integration/test_part_moves_between_shards_detached/`.
