### PR TITLE
Assert Keeper TTL sibling expiry ordering deterministically instead of racing the GC

### DIFF
--- a/src/Coordination/tests/gtest_coordination_storage.cpp
+++ b/src/Coordination/tests/gtest_coordination_storage.cpp
@@ -1874,6 +1874,78 @@ TEST_P(CoordinationTest, TestTTLNodeExpiry)
     EXPECT_TRUE(storage.collectExpiredTTLPaths(ttl_ms + 1, 1000000).empty());
 }
 
+/// Eligibility is asserted at exact instants because `collectExpiredTTLPaths` takes the clock as
+/// an argument, while the garbage collector reads it in the caller. An integration test cannot
+/// assert the same ordering without observing a transient window and racing the real collector.
+TEST_P(CoordinationTest, TestTTLSiblingExpiryOrdering)
+{
+    using namespace DB;
+    using namespace Coordination;
+
+    const auto storage_ptr = DB::KeeperStorage::create(500, "", this->keeper_context);
+    DB::KeeperStorage & storage = *storage_ptr;
+    int64_t zxid = 0;
+    const int64_t session_id = 1;
+    const int64_t create_time = 1000;
+    const int64_t short_ttl_ms = 1000;
+    const int64_t long_ttl_ms = 3000;
+
+    auto create = [&](const std::string & path, bool with_ttl, int64_t ttl_ms)
+    {
+        auto request = std::make_shared<ZooKeeperCreateRequest>();
+        request->path = path;
+        request->include_ttl = with_ttl;
+        request->ttl = ttl_ms;
+        storage.preprocessRequest(request, session_id, create_time, ++zxid, /*check_acl=*/true, /*digest=*/std::nullopt, /*log_idx=*/0);
+        auto responses = storage.processRequest(request, session_id, zxid);
+        ASSERT_FALSE(responses.empty());
+        ASSERT_EQ(responses[0].response->error, Error::ZOK) << "Unexpected error creating " << path;
+    };
+
+    create("/root", /*with_ttl=*/false, 0);
+    create("/a", /*with_ttl=*/true, short_ttl_ms);
+    create("/b", /*with_ttl=*/true, long_ttl_ms);
+
+    const auto collected_paths = [&](int64_t now_ms)
+    {
+        std::vector<std::string> paths;
+        for (const auto & [path, _] : storage.collectExpiredTTLPaths(now_ms, 1000000))
+            paths.push_back(path);
+        std::sort(paths.begin(), paths.end());
+        return paths;
+    };
+
+    EXPECT_EQ(collected_paths(create_time + short_ttl_ms - 1), std::vector<std::string>{});
+    EXPECT_EQ(collected_paths(create_time + short_ttl_ms), std::vector<std::string>{"/a"});
+    EXPECT_EQ(collected_paths(create_time + long_ttl_ms - 1), std::vector<std::string>{"/a"});
+    EXPECT_EQ(collected_paths(create_time + long_ttl_ms), (std::vector<std::string>{"/a", "/b"}));
+
+    auto gc_remove = [&](const std::string & path, int64_t at_ms)
+    {
+        auto request = std::make_shared<ZooKeeperRemoveRequest>();
+        request->path = path;
+        request->version = -1;
+        request->try_remove = true;
+        storage.preprocessRequest(
+            request, keeper_internal_ttl_garbage_collector_session_id, at_ms, ++zxid, /*check_acl=*/true, /*digest=*/std::nullopt, /*log_idx=*/0);
+        return storage.processRequest(request, keeper_internal_ttl_garbage_collector_session_id, zxid);
+    };
+
+    auto remove_a_responses = gc_remove("/a", create_time + short_ttl_ms);
+    ASSERT_FALSE(remove_a_responses.empty());
+    ASSERT_EQ(remove_a_responses[0].response->error, Error::ZOK);
+
+    EXPECT_FALSE(storage.containsTTLPath("/a"));
+    EXPECT_TRUE(storage.containsTTLPath("/b"));
+    EXPECT_TRUE(storage.nodes_storage->getCommittedNodeSimple("/b", /*out_stats=*/nullptr, /*out_data=*/nullptr));
+    EXPECT_TRUE(storage.nodes_storage->getCommittedNodeSimple("/root", /*out_stats=*/nullptr, /*out_data=*/nullptr));
+
+    /// A collection request for /b issued before its destroy_time is refused at commit time.
+    gc_remove("/b", create_time + short_ttl_ms);
+    EXPECT_TRUE(storage.containsTTLPath("/b"));
+    EXPECT_TRUE(storage.nodes_storage->getCommittedNodeSimple("/b", /*out_stats=*/nullptr, /*out_data=*/nullptr));
+}
+
 TEST_P(CoordinationTest, TestTTLNodeSetRefreshesUncommittedDestroyTime)
 {
     using namespace DB;

--- a/tests/integration/test_keeper_ttl_nodes/test.py
+++ b/tests/integration/test_keeper_ttl_nodes/test.py
@@ -164,24 +164,15 @@ def test_many_nodes_with_different_ttls():
         node1_zk = get_fake_zk(cluster, "node1")
         node2_zk = get_fake_zk(cluster, "node2")
 
-        # Consecutive nodes' destroy_times differ by this step. Each "still alive" assertion
-        # below runs right after wait_nodes_gone() for the previous node, whose return can
-        # overshoot the target's destroy_time (GC period + Raft commit + poll granularity +
-        # round-trips under load). Keep the step well above that overshoot so an assertion
-        # never races a just-expired node.
-        ttl_step_ms = 3000
+        # Heterogeneous TTLs exercise batched collection across many nodes. That a node with a
+        # longer TTL is not collected together with a shorter-TTL sibling is asserted at exact
+        # instants in CoordinationTest.TestTTLSiblingExpiryOrdering; asserting it here would
+        # require observing a transient window and races the real garbage collector.
+        ttl_step_ms = 1000
         for i in range(10):
             node1_zk.create(f"/n{i}", str(i).encode(), ttl=ttl_step_ms * (i + 1))
 
-        wait_nodes_gone([node1_zk, node2_zk], ["/n0"])
-        for i in range(1, 10):
-            assert node1_zk.exists(f"/n{i}")
-            assert node2_zk.exists(f"/n{i}")
-
-        wait_nodes_gone([node1_zk, node2_zk], ["/n1", "/n2"])
-        for i in range(3, 10):
-            assert node1_zk.exists(f"/n{i}")
-            assert node2_zk.exists(f"/n{i}")
+        wait_nodes_gone([node1_zk, node2_zk], [f"/n{i}" for i in range(10)])
     finally:
         cluster.shutdown()
         if node1_zk:
@@ -212,13 +203,12 @@ def test_sibling_ttl_independence():
         node1_zk.create("/root/a", b"a", ttl=1000)
         node1_zk.create("/root/b", b"b", ttl=3000)
 
-        wait_nodes_gone([node1_zk, node2_zk], ["/root/a"])
-        assert node1_zk.exists("/root/b")
-        assert node1_zk.exists("/root")
-        assert node2_zk.exists("/root/b")
-        assert node2_zk.exists("/root")
+        # Both TTL children must be collected on both replicas. Their relative expiry order is
+        # asserted at exact instants in CoordinationTest.TestTTLSiblingExpiryOrdering; asserting
+        # it here would require observing a transient window and races the real collector.
+        wait_nodes_gone([node1_zk, node2_zk], ["/root/a", "/root/b"])
 
-        wait_nodes_gone([node1_zk, node2_zk], ["/root/b"])
+        # A node created without a TTL has no destroy_time, so no delay can make it disappear.
         assert node1_zk.exists("/root")
         assert node2_zk.exists("/root")
     finally:

--- a/tests/integration/test_keeper_ttl_nodes/test.py
+++ b/tests/integration/test_keeper_ttl_nodes/test.py
@@ -164,11 +164,6 @@ def test_many_nodes_with_different_ttls():
         node1_zk = get_fake_zk(cluster, "node1")
         node2_zk = get_fake_zk(cluster, "node2")
 
-        # Sentinel whose TTL is far past this test's upper bound: an engine that collects a node
-        # before its destroy_time removes it too. Created before the others, so wait_nodes_gone
-        # returning for them on the follower implies the follower applied this create as well.
-        node1_zk.create("/sentinel", b"sentinel", ttl=600000)
-
         # Ten nodes with distinct TTLs; each must be collected. The relative expiry order is
         # asserted at exact instants in CoordinationTest.TestTTLSiblingExpiryOrdering, since
         # observing it here would race the collector. Keep ttl_step_ms low: the longest TTL is
@@ -176,6 +171,12 @@ def test_many_nodes_with_different_ttls():
         ttl_step_ms = 1000
         for i in range(10):
             node1_zk.create(f"/n{i}", str(i).encode(), ttl=ttl_step_ms * (i + 1))
+
+        # Created last and awaited on both replicas, so each has applied the creates above and a
+        # later absence means collected rather than not-yet-applied. Its TTL is far past this
+        # test's upper bound, so an engine collecting before destroy_time removes it too.
+        node1_zk.create("/sentinel", b"sentinel", ttl=600000)
+        wait_nodes_exist([node1_zk, node2_zk], ["/sentinel"])
 
         wait_nodes_gone([node1_zk, node2_zk], [f"/n{i}" for i in range(10)])
 
@@ -208,12 +209,13 @@ def test_sibling_ttl_independence():
         node1_zk = get_fake_zk(cluster, "node1")
         node2_zk = get_fake_zk(cluster, "node2")
         node1_zk.create("/root", b"root")
-        # Sentinel whose TTL is far past this test's upper bound; see the same node in
-        # test_many_nodes_with_different_ttls. Kept a sibling of /root because a TTL node cannot
-        # have children.
-        node1_zk.create("/sentinel", b"sentinel", ttl=600000)
         node1_zk.create("/root/a", b"a", ttl=1000)
         node1_zk.create("/root/b", b"b", ttl=3000)
+
+        # See the same node in test_many_nodes_with_different_ttls. Kept outside /root so it
+        # cannot interact with the child count of the subtree under test.
+        node1_zk.create("/sentinel", b"sentinel", ttl=600000)
+        wait_nodes_exist([node1_zk, node2_zk], ["/sentinel"])
 
         # Both TTL children must be collected on both replicas. Their relative expiry order is
         # asserted at exact instants in CoordinationTest.TestTTLSiblingExpiryOrdering; asserting

--- a/tests/integration/test_keeper_ttl_nodes/test.py
+++ b/tests/integration/test_keeper_ttl_nodes/test.py
@@ -164,6 +164,11 @@ def test_many_nodes_with_different_ttls():
         node1_zk = get_fake_zk(cluster, "node1")
         node2_zk = get_fake_zk(cluster, "node2")
 
+        # Created before the nodes below, so it is a collection candidate for every garbage
+        # collector pass that can select any of them: an engine removing a node before its
+        # destroy_time removes this one too, and the waits below cannot finish first.
+        node1_zk.create("/canary", b"canary", ttl=600000)
+
         # Ten nodes with distinct TTLs; each must be collected. The relative expiry order is
         # asserted at exact instants in CoordinationTest.TestTTLSiblingExpiryOrdering, since
         # observing it here would race the collector. Keep ttl_step_ms low: the longest TTL is
@@ -172,16 +177,17 @@ def test_many_nodes_with_different_ttls():
         for i in range(10):
             node1_zk.create(f"/n{i}", str(i).encode(), ttl=ttl_step_ms * (i + 1))
 
-        # Created last and awaited on both replicas, so each has applied the creates above and a
-        # later absence means collected rather than not-yet-applied. Its TTL is far past this
-        # test's upper bound, so an engine collecting before destroy_time removes it too.
-        node1_zk.create("/sentinel", b"sentinel", ttl=600000)
-        wait_nodes_exist([node1_zk, node2_zk], ["/sentinel"])
+        # Created last and awaited on both replicas, so each has applied every create above and a
+        # later absence means collected rather than not-yet-applied.
+        node1_zk.create("/barrier", b"barrier", ttl=600000)
+        wait_nodes_exist([node1_zk, node2_zk], ["/barrier"])
 
         wait_nodes_gone([node1_zk, node2_zk], [f"/n{i}" for i in range(10)])
 
-        assert node1_zk.exists("/sentinel")
-        assert node2_zk.exists("/sentinel")
+        assert node1_zk.exists("/canary")
+        assert node2_zk.exists("/canary")
+        assert node1_zk.exists("/barrier")
+        assert node2_zk.exists("/barrier")
     finally:
         cluster.shutdown()
         if node1_zk:
@@ -209,13 +215,20 @@ def test_sibling_ttl_independence():
         node1_zk = get_fake_zk(cluster, "node1")
         node2_zk = get_fake_zk(cluster, "node2")
         node1_zk.create("/root", b"root")
+
+        # Created before the TTL children below, so it is a collection candidate for every garbage
+        # collector pass that can select either of them: an engine removing a node before its
+        # destroy_time removes this one too. Kept outside /root so it cannot interact with the
+        # child count of the subtree under test.
+        node1_zk.create("/canary", b"canary", ttl=600000)
+
         node1_zk.create("/root/a", b"a", ttl=1000)
         node1_zk.create("/root/b", b"b", ttl=3000)
 
-        # See the same node in test_many_nodes_with_different_ttls. Kept outside /root so it
-        # cannot interact with the child count of the subtree under test.
-        node1_zk.create("/sentinel", b"sentinel", ttl=600000)
-        wait_nodes_exist([node1_zk, node2_zk], ["/sentinel"])
+        # Created last and awaited on both replicas, so each has applied every create above and a
+        # later absence means collected rather than not-yet-applied.
+        node1_zk.create("/barrier", b"barrier", ttl=600000)
+        wait_nodes_exist([node1_zk, node2_zk], ["/barrier"])
 
         # Both TTL children must be collected on both replicas. Their relative expiry order is
         # asserted at exact instants in CoordinationTest.TestTTLSiblingExpiryOrdering; asserting
@@ -225,8 +238,10 @@ def test_sibling_ttl_independence():
         # A node created without a TTL has no destroy_time, so no delay can make it disappear.
         assert node1_zk.exists("/root")
         assert node2_zk.exists("/root")
-        assert node1_zk.exists("/sentinel")
-        assert node2_zk.exists("/sentinel")
+        assert node1_zk.exists("/canary")
+        assert node2_zk.exists("/canary")
+        assert node1_zk.exists("/barrier")
+        assert node2_zk.exists("/barrier")
     finally:
         cluster.shutdown()
         if node1_zk:

--- a/tests/integration/test_keeper_ttl_nodes/test.py
+++ b/tests/integration/test_keeper_ttl_nodes/test.py
@@ -164,15 +164,23 @@ def test_many_nodes_with_different_ttls():
         node1_zk = get_fake_zk(cluster, "node1")
         node2_zk = get_fake_zk(cluster, "node2")
 
-        # Heterogeneous TTLs exercise batched collection across many nodes. That a node with a
-        # longer TTL is not collected together with a shorter-TTL sibling is asserted at exact
-        # instants in CoordinationTest.TestTTLSiblingExpiryOrdering; asserting it here would
-        # require observing a transient window and races the real garbage collector.
+        # Sentinel whose TTL is far past this test's upper bound: an engine that collects a node
+        # before its destroy_time removes it too. Created before the others, so wait_nodes_gone
+        # returning for them on the follower implies the follower applied this create as well.
+        node1_zk.create("/sentinel", b"sentinel", ttl=600000)
+
+        # Ten nodes with distinct TTLs; each must be collected. The relative expiry order is
+        # asserted at exact instants in CoordinationTest.TestTTLSiblingExpiryOrdering, since
+        # observing it here would race the collector. Keep ttl_step_ms low: the longest TTL is
+        # ttl_step_ms * 10 and must land well inside wait_nodes_gone's 30s deadline.
         ttl_step_ms = 1000
         for i in range(10):
             node1_zk.create(f"/n{i}", str(i).encode(), ttl=ttl_step_ms * (i + 1))
 
         wait_nodes_gone([node1_zk, node2_zk], [f"/n{i}" for i in range(10)])
+
+        assert node1_zk.exists("/sentinel")
+        assert node2_zk.exists("/sentinel")
     finally:
         cluster.shutdown()
         if node1_zk:
@@ -200,6 +208,10 @@ def test_sibling_ttl_independence():
         node1_zk = get_fake_zk(cluster, "node1")
         node2_zk = get_fake_zk(cluster, "node2")
         node1_zk.create("/root", b"root")
+        # Sentinel whose TTL is far past this test's upper bound; see the same node in
+        # test_many_nodes_with_different_ttls. Kept a sibling of /root because a TTL node cannot
+        # have children.
+        node1_zk.create("/sentinel", b"sentinel", ttl=600000)
         node1_zk.create("/root/a", b"a", ttl=1000)
         node1_zk.create("/root/b", b"b", ttl=3000)
 
@@ -211,6 +223,8 @@ def test_sibling_ttl_independence():
         # A node created without a TTL has no destroy_time, so no delay can make it disappear.
         assert node1_zk.exists("/root")
         assert node2_zk.exists("/root")
+        assert node1_zk.exists("/sentinel")
+        assert node2_zk.exists("/sentinel")
     finally:
         cluster.shutdown()
         if node1_zk:


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/109193


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Two assertions in `tests/integration/test_keeper_ttl_nodes/test.py` fail as
`AssertionError: assert None` on loaded sanitizer lanes: `test_many_nodes_with_different_ttls`
(`exists("/n1")`) and `test_sibling_ttl_independence` (`exists("/root/b")`).

The engine is correct: removal is re-validated at Raft commit and refused before `destroy_time`
(`KeeperStorageImpl.cpp`). The tests are at fault. Both assert a *transient* state ("X is gone
**and** X+1 is still alive"), observable only during
`[destroy_time(X) + gc_lag, destroy_time(X+1))`. `gc_lag` (collector scheduling, one
`ttl_gc_period_ms`, Raft commit, poll granularity, follower lag) is unbounded by the test, so under
load one scan sweeps X and X+1 together. My earlier #109193 widened the step 1000 -> 3000 ms, which
raises the stall needed to trigger the race but does not remove the dependency, so the flake
returned.

This moves the invariant to the layer where the clock is an input.
`collectExpiredTTLPaths(now_ms, batch_size)` takes `now_ms` as an argument, so the new
`CoordinationTest.TestTTLSiblingExpiryOrdering` asserts which nodes are eligible at exact instants
(before the first `destroy_time`, at it, just before the second, past both), plus that a collection
request issued before `destroy_time` is a no-op at commit. The invariant is asserted more strictly,
not weakened; the integration tests keep only stall-immune claims (eventual collection on both
replicas, survival of a no-TTL node, and two long-TTL nodes: a canary created first, which an
over-eager collector would remove, and a barrier created last, which proves both replicas applied
the earlier creates).

`ttl_step_ms` returns to 1000, deliberately reverting #109193. Nothing observes the step any more,
and the new shape needs it: the ten-node test waits for every node, so the longest TTL
(`ttl_step_ms * 10`) must expire well inside `wait_nodes_gone`'s own 30s deadline.

Public CI cannot confirm this (0 FAIL over 30d, about 47,000 OK runs for each of the 7 tests in the
file), so the evidence is a mutation matrix.

<details><summary>Mutation matrix (13 arms)</summary>

Local debug build, pristine Build ID `1f396dc3508509ead00633b685769e5f85eeab11`. Each mutated arm
asserted a clean build and a moved Build ID before being trusted.

| # | arm | expected | observed |
|---|---|---|---|
| 1 | new gtest, pristine engine | PASS | PASS |
| 2 | `now_ms >= stats.destroyTime()` -> `now_ms >= 0` | FAIL | FAIL at 3 instants |
| 3 | same line -> `now_ms > stats.destroyTime()` | FAIL | FAIL at both boundaries |
| 4 | drop the commit-time revalidation | FAIL | FAIL at the no-op check |
| 5 | revert all mutations | PASS | PASS, 12/12 TTL gtests |
| 6 | both changed integration tests, pristine engine | PASS | PASS |
| 7 | `sleep(4.0)`, sibling test (> whole TTL span) | PASS | PASS |
| 8 | `sleep(15.0)`, many-nodes test (past all TTLs) | PASS | PASS |
| 9 | TTL nodes never collected | both FAIL | FAIL, `/n0 still exists ... after 30.0s` |
| 10 | old test + `sleep(2.5)` before the assertion | FAIL | FAIL, `assert None` at `exists('/root/b')`, the CI signature |
| 11 | collect before `destroy_time`, both gates broken | both FAIL | FAIL, `assert None` at `exists('/canary')` |
| 12 | a replica stops applying the Raft log | FAIL at the barrier | FAIL, `/barrier did not appear ... within 30.0s` |
| 13 | narrow premature collection, `destroyTime()` -> `mtime` | both FAIL | FAIL, `assert None` at `exists('/canary')` |

Arms 7-8 show the old failure mode is structurally gone, not merely wider. Arms 9, 11 and 13 guard
both directions the tests must still detect: never collecting, and collecting too early. Arm 12
freezes a follower's log application, showing the barrier is load-bearing.

Repeats on this exact tree: 12x each changed test under 24 CPU burners, 24/24 passed. Zero TTL-race
signatures, though the same greps match arms 9, 12 and 13.

</details>

Separately noticed, not changed: `test_simple:56` waits via `wait_nodes_exist` on a `ttl=1000` node,
so if it is collected first the wait cannot succeed. It has never fired and has no observed
consequence.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1108` (included in `26.8` and later)
<!-- ch-version-info:end -->