### PR TITLE
Charge an empty match for the distance it may have scanned in countMatches

### DIFF
--- a/src/Functions/countMatches.cpp
+++ b/src/Functions/countMatches.cpp
@@ -142,6 +142,8 @@ public:
     {
         /// Only one match is required, no need to copy more.
         static const unsigned matches_limit = 1;
+        /// Empty-match iterations a check interval always covers, bounding how often the check can run.
+        static constexpr size_t min_empty_iterations_per_check = 64;
 
         Pos begin = reinterpret_cast<Pos>(src.data());
         Pos end = reinterpret_cast<Pos>(src.data() + src.size());
@@ -163,8 +165,13 @@ public:
                 }
                 else
                 {
-                    /// `offset` is not a position for an empty match, so only the byte `pos` advances is charged.
-                    budget.charge();
+                    /// `offset` is not a position for an empty match, so the distance scanned is unknown and
+                    /// may be up to `end - pos`. Charged as that distance, but capped so that a single
+                    /// iteration cannot consume a whole check interval and force a check on every byte.
+                    static constexpr size_t max_units_per_empty_match
+                        = CancellationBudget::units_per_check / min_empty_iterations_per_check;
+                    const size_t scanned_units = 1 + (end - pos) / CancellationBudget::bytes_per_unit;
+                    budget.chargeUnits(scanned_units < max_units_per_empty_match ? scanned_units : max_units_per_empty_match);
 
                     if (count_matches_stop_at_empty_match)
                     {

--- a/src/Functions/countMatches.cpp
+++ b/src/Functions/countMatches.cpp
@@ -11,6 +11,8 @@
 #include <Functions/Regexps.h>
 #include <Interpreters/Context.h>
 
+#include <algorithm>
+
 
 namespace DB
 {
@@ -142,8 +144,10 @@ public:
     {
         /// Only one match is required, no need to copy more.
         static const unsigned matches_limit = 1;
-        /// Empty-match iterations a check interval always covers, bounding how often the check can run.
-        static constexpr size_t min_empty_iterations_per_check = 64;
+        /// An empty match is charged at most this much, so that one such iteration cannot consume a whole
+        /// check interval and force the check to run on every byte.
+        static constexpr size_t max_bytes_per_empty_match
+            = CancellationBudget::units_per_check / 64 * CancellationBudget::bytes_per_unit;
 
         Pos begin = reinterpret_cast<Pos>(src.data());
         Pos end = reinterpret_cast<Pos>(src.data() + src.size());
@@ -165,13 +169,9 @@ public:
                 }
                 else
                 {
-                    /// `offset` is not a position for an empty match, so the distance scanned is unknown and
-                    /// may be up to `end - pos`. Charged as that distance, but capped so that a single
-                    /// iteration cannot consume a whole check interval and force a check on every byte.
-                    static constexpr size_t max_units_per_empty_match
-                        = CancellationBudget::units_per_check / min_empty_iterations_per_check;
-                    const size_t scanned_units = 1 + (end - pos) / CancellationBudget::bytes_per_unit;
-                    budget.chargeUnits(scanned_units < max_units_per_empty_match ? scanned_units : max_units_per_empty_match);
+                    /// `offset` is not a position for an empty match, so the distance scanned is unknown
+                    /// and may be up to `end - pos`.
+                    budget.charge(std::min<size_t>(end - pos, max_bytes_per_empty_match));
 
                     if (count_matches_stop_at_empty_match)
                     {


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113886
-->
Closes: https://github.com/ClickHouse/ClickHouse/issues/114088

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes `countMatches` and `countMatchesCaseInsensitive` ignoring `max_execution_time` and `KILL QUERY` for a pattern that matches empty but whose match is only found after scanning far into the value.

### Description

Follow-up to #113886, which made the match loop observe cancellation but left the default
`count_matches_stop_at_empty_match = 0` path under-charged. That branch charged one unit, the byte
`pos` advances, while the search that produced the match can have scanned to the end of the value.
The loop continues instead of breaking, so one such search happens per byte and the whole value
stayed under a single unit against a 65536-unit check interval.

An empty match arrives from two places and only one hides the distance. A trivial empty pattern
reports the match at the position the search started from, having scanned nothing; re2 reports a
zero-length whole match as `offset = std::string::npos`, so its distance is bounded only by the rest
of the value. The charge is now that remaining distance, capped at a 64th of a check interval for
re2 and nothing for a trivial pattern, decided once before the loop since it is fixed for the call.

The cap is what makes the re2 side safe: charging the bare remainder makes every iteration exceed a
whole interval, so a 60 MB `x*` value takes one check per byte, a 23 percent regression.

Measured against `max_execution_time = 2`, pattern `\b(?:[^ ]{8}|[^a]{9}|[^b]{11}|[^c]{13})*` over a
run of spaces followed by `a`:

| value | before | after |
|---|---|---|
| 200 KB | 28371 ms | 2026 ms |
| 1 MB | 165029 ms | 2028 ms |
| 4 MB | 686679 ms | 2048 ms |
| `KILL QUERY ... SYNC` | 26324 ms | 185 ms |

Throughput without a deadline is unchanged: 1e9 trivial empty-match positions run 9.14 s before this
PR and 9.40 s here, and a re2 `x*` carrier is 30.1 to 30.4 s across both. Results are byte-identical
on the #113886 correctness suite.

<details>
<summary>Why the cap is 64, and no test is added</summary>

Sweep on the 60 MB `x*` value, whose baseline is 9.32 / 9.22 / 9.16 s, against the 200 KB carrier
above at a 2 s deadline. `units_per_check` is shared by five files, so it is capped locally here
rather than lowered globally.

| iterations per interval | 60 MB `x*` | 200 KB carrier |
|---|---|---|
| 1 (the uncapped form) | 11.42 / 11.34 / 11.25 s | 2002 ms |
| 4 | 9.79 / 9.77 / 9.64 s | 2000 ms |
| 64 (this PR) | 9.23 / 9.17 / 9.23 s | 2003 ms |

I wrote a case for `04822_count_matches_cancellation.sh` and confirmed it both directions: it passes
here, and on the parent exactly one line flips to `empty rescan: OVERSHOT 28493 ms` while the other
17 stay green. #114061 has since merged and deleted that file, so no test is included: re-adding it
conflicts with the deletion.

The only observable this fix changes is elapsed time. Both binaries raise `TIMEOUT_EXCEEDED` with the
identical message, under `timeout_overflow_mode = 'break'` too, and this path has no ProfileEvent, so
any guard is the wall-clock shape #114061 removed as flaky. Tell me which shape you would accept and
I will write it.

The bug is reachable on a stable release: on 26.7.4.12 the 200 KB carrier above runs 51861 ms against
`max_execution_time = 2`. CI report for this PR: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114100&sha=ace49715030202a86a29a99f19a2a2ba311f99c6&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20sequential%2C%202/2%29

</details>
