### PR TITLE
fix: clear ORDER BY ALL flag when WINDOW VIEW clears ORDER BY clause

### DIFF
--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -773,6 +773,7 @@ ASTPtr StorageWindowView::getSourceTableSelectQuery()
     {
         modified_select.setExpression(ASTSelectQuery::Expression::HAVING, {});
         modified_select.setExpression(ASTSelectQuery::Expression::GROUP_BY, {});
+        modified_select.group_by_all = false;
     }
 
     auto select_list = make_intrusive<ASTExpressionList>();
@@ -798,6 +799,8 @@ ASTPtr StorageWindowView::getSourceTableSelectQuery()
     }
     else
         modified_select.setExpression(ASTSelectQuery::Expression::ORDER_BY, {});
+        modified_select.order_by_all = false;
+        modified_select.group_by_all = false;
 
     const auto select_with_union_query = make_intrusive<ASTSelectWithUnionQuery>();
     select_with_union_query->list_of_selects = make_intrusive<ASTExpressionList>();


### PR DESCRIPTION
### Fix null pointer dereference on WINDOW VIEW with ORDER BY ALL

StorageWindowView::getSourceTableSelectQuery clears the ORDER BY expression for proc-time window views (line 800) but does not reset `order_by_all`, so `expandOrderByAll` in TreeRewriter dereferences a null pointer and SIGSEGVs the server.

**Root cause:** The `else` branch at StorageWindowView.cpp:800 clears ORDER BY via `setExpression(ORDER_BY, {})` but leaves `order_by_all == true`. The resulting query triggers `expandOrderByAll` -> `select_query->orderBy()->children[0]` on a null pointer.

**Fix:** Reset `order_by_all = false` alongside clearing the ORDER BY expression. Also reset `group_by_all = false` alongside the GROUP BY clearing at line 775 for symmetry.

**Reproduction:**
```sql
SET allow_experimental_window_view = 1;
SET allow_experimental_analyzer = 0;
CREATE TABLE t_wv_oba_src (a UInt32, ts DateTime) ENGINE = MergeTree ORDER BY ts;
CREATE WINDOW VIEW t_wv_oba ENGINE Memory POPULATE AS
  SELECT count(a) AS cnt, tumbleStart(w_id) AS w_start
  FROM t_wv_oba_src
  GROUP BY tumble(now(), INTERVAL '1' SECOND) AS w_id
  ORDER BY ALL;
```

Fixes #114097
