### PR TITLE
Fix flaky ResolvePoolTest ban-window assertions

### DIFF
--- a/src/Common/tests/gtest_resolve_pool.cpp
+++ b/src/Common/tests/gtest_resolve_pool.cpp
@@ -725,7 +725,11 @@ TEST_F(ResolvePoolTest, NoSampleBeforeDeadlineIsNotAFailure)
     /// The deadline is alive on entry and expires during that first refresh, so the helper
     /// crosses it having sampled nothing. There is no observation to judge, so it must return
     /// rather than report the absence of samples as a defect.
-    check_no_failed_address(1, resolver, addresses, failed_addr, metrics, now() + 500us);
+    check_no_failed_address(1, resolver, addresses, failed_addr, metrics, now() + 5ms);
+
+    /// The armed refresh must have been spent, otherwise the deadline expired before the first
+    /// `resolve()` and the crossing this test pins was never reached.
+    ASSERT_EQ(0u, slow_refreshes);
 }
 
 TEST_F(ResolvePoolTest, BanWindowAnchoredOnFailTimestamp)

--- a/src/Common/tests/gtest_resolve_pool.cpp
+++ b/src/Common/tests/gtest_resolve_pool.cpp
@@ -563,6 +563,13 @@ TEST_F(ResolvePoolTest, DuplicatesInAddresses)
 void check_no_failed_address(size_t iteration, auto & resolver, auto & addresses, auto & failed_addr, auto & metrics, auto deadline)
 {
     ASSERT_EQ(iteration, DB::CurrentThread::getProfileEvents()[metrics.failed]);
+
+    /// The ban window can already be over when this is called: the caller's anchor is a lower
+    /// bound on the ban's own timestamp, so it may sit a whole DNS refresh earlier. Nothing can
+    /// be asserted about a ban that is provably expired, so skip instead of reporting a defect.
+    if (now() > deadline)
+        return;
+
     for (size_t i = 0; i < 100; ++i)
     {
         auto next_addr = resolver->resolve();
@@ -616,7 +623,7 @@ TEST_F(ResolvePoolTest, BannedForConsiquenceFail)
     resolver->update();
 
     // too much time has passed
-    if (now() > before + 2*history)
+    if (now() > before + 2*history - epsilon)
         return;
 
     ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
@@ -634,11 +641,13 @@ TEST_F(ResolvePoolTest, NoAditionalBannForConcurrentFail)
     auto failed_addr = resolver->resolve();
     ASSERT_TRUE(addresses.contains(*failed_addr));
 
-    // Anchors bracket the ban's own timestamp; see BannedForConsiquenceFail. Only the last
-    // `setFail` matters here: concurrent fails do not extend the window.
+    // Anchors bracket the ban's own timestamp; see BannedForConsiquenceFail. `setFail` restamps
+    // that timestamp on every call, so the window under test belongs to the last one and the
+    // anchors go around it: bracketing all three would be sound but needlessly loose by two
+    // whole DNS refreshes.
+    failed_addr.setFail();
+    failed_addr.setFail();
     auto before = now();
-    failed_addr.setFail();
-    failed_addr.setFail();
     failed_addr.setFail();
     auto after = now();
 

--- a/src/Common/tests/gtest_resolve_pool.cpp
+++ b/src/Common/tests/gtest_resolve_pool.cpp
@@ -617,6 +617,10 @@ TEST_F(ResolvePoolTest, BannedForConsiquenceFail)
     // `setFail` stamps the ban's anchor before refreshing DNS, so the anchor lies in
     // [before, after]. Deadlines gating "still banned" must use `before`, waits for expiry
     // `after`; one anchor taken after `setFail` can outlive the ban it waits on.
+
+    /// The refresh is slow on purpose: a window narrower than one refresh cannot survive it,
+    /// and the assertion below then reads 0.
+    slow_down_refreshes(1, 20ms);
     auto before = now();
     failed_addr.setFail();
     auto after = now();
@@ -665,6 +669,9 @@ TEST_F(ResolvePoolTest, NoAditionalBannForConcurrentFail)
     // sound but needlessly loose by two whole DNS refreshes.
     failed_addr.setFail();
     failed_addr.setFail();
+
+    /// Arm only the refresh the window is anchored on, as in BannedForConsiquenceFail.
+    slow_down_refreshes(1, 20ms);
     auto before = now();
     failed_addr.setFail();
     auto after = now();
@@ -698,6 +705,27 @@ TEST_F(ResolvePoolTest, BanSurvivesSlowFailRefresh)
 
     ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
     ASSERT_EQ(1, CurrentMetrics::get(metrics.banned_count));
+}
+
+TEST_F(ResolvePoolTest, NoSampleBeforeDeadlineIsNotAFailure)
+{
+    auto history = 100ms;
+    auto resolver = make_resolver(toMilliseconds(history));
+
+    auto failed_addr = resolver->resolve();
+    ASSERT_TRUE(addresses.contains(*failed_addr));
+
+    failed_addr.setFail();
+
+    /// Age the resolver past `resolve_interval` (history / 3) so the helper's own first
+    /// `resolve()` has to refresh DNS, and make that refresh slower than the deadline below.
+    sleep_for(history / 3 + epsilon);
+    slow_down_refreshes(1, 30ms);
+
+    /// The deadline is alive on entry and expires during that first refresh, so the helper
+    /// crosses it having sampled nothing. There is no observation to judge, so it must return
+    /// rather than report the absence of samples as a defect.
+    check_no_failed_address(1, resolver, addresses, failed_addr, metrics, now() + 500us);
 }
 
 TEST_F(ResolvePoolTest, BanWindowAnchoredOnFailTimestamp)

--- a/src/Common/tests/gtest_resolve_pool.cpp
+++ b/src/Common/tests/gtest_resolve_pool.cpp
@@ -74,6 +74,12 @@ protected:
     {
         auto resolve_func = [&] (const String &)
         {
+            if (slow_refreshes > 0)
+            {
+                --slow_refreshes;
+                sleep_for(refresh_delay);
+            }
+
             std::vector<Poco::Net::IPAddress> result;
             result.reserve(addresses.size());
             for (const auto & item : addresses)
@@ -87,8 +93,19 @@ protected:
         return std::make_shared<ResolvePoolMock>("some_host", Poco::Timespan(history_ms * 1000), std::move(resolve_func));
     }
 
+    /// Makes the next `count` DNS refreshes take `delay`. A refresh is the only work that can
+    /// separate the ban's timestamp from a test's own clock reading, so this is what turns the
+    /// timing defects below into deterministic tests. Per-fixture, so it is parallel-safe.
+    void slow_down_refreshes(size_t count, std::chrono::milliseconds delay)
+    {
+        slow_refreshes = count;
+        refresh_delay = delay;
+    }
+
     DB::HostResolverMetrics metrics = DB::HostResolver::getMetrics();
     std::multiset<String> addresses;
+    size_t slow_refreshes = 0;
+    std::chrono::milliseconds refresh_delay{0};
 };
 
 TEST_F(ResolvePoolTest, CanResolve)
@@ -576,7 +593,10 @@ void check_no_failed_address(size_t iteration, auto & resolver, auto & addresses
 
         if (now() > deadline)
         {
-            ASSERT_NE(i, 0);
+            /// Crossing before the first sample measured nothing at all, so there is no
+            /// observation to report; only a crossing after a successful check is one.
+            if (i == 0)
+                return;
             break;
         }
 
@@ -660,6 +680,65 @@ TEST_F(ResolvePoolTest, NoAditionalBannForConcurrentFail)
     // ip is cleared after just 1 history_ms interval.
     ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
     ASSERT_EQ(0, CurrentMetrics::get(metrics.banned_count));
+}
+
+TEST_F(ResolvePoolTest, BanSurvivesSlowFailRefresh)
+{
+    auto history = 100ms;
+    auto resolver = make_resolver(toMilliseconds(history));
+
+    auto failed_addr = resolver->resolve();
+    ASSERT_TRUE(addresses.contains(*failed_addr));
+
+    /// `setFail` stamps the ban and only then refreshes DNS, and expiry is measured against the
+    /// refresh's own timestamp. A refresh slower than `history` therefore un-bans the address
+    /// immediately, so the window has to be wide enough to cover one.
+    slow_down_refreshes(1, 20ms);
+    failed_addr.setFail();
+
+    ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
+    ASSERT_EQ(1, CurrentMetrics::get(metrics.banned_count));
+}
+
+TEST_F(ResolvePoolTest, BanWindowAnchoredOnFailTimestamp)
+{
+    auto history = 100ms;
+    auto resolver = make_resolver(toMilliseconds(history));
+
+    auto failed_addr = resolver->resolve();
+    ASSERT_TRUE(addresses.contains(*failed_addr));
+
+    /// Fail once and let the ban lapse, so the next fail is consecutive and bans for 2 * history.
+    failed_addr.setFail();
+    auto first_fail_at = now();
+    sleep_until(first_fail_at + history + epsilon);
+    resolver->update();
+    ASSERT_EQ(0, CurrentMetrics::get(metrics.banned_count));
+
+    /// Both refreshes below are slow, which is what separates the ban's own timestamp from a
+    /// reading taken after `setFail`. Only the earlier of the two bounds the ban window; anchored
+    /// on the later one the deadline outlives the ban it is meant to gate.
+    slow_down_refreshes(2, 55ms);
+
+    auto before = now();
+    failed_addr.setFail();
+    auto after = now();
+
+    sleep_until(after + history + epsilon);
+    resolver->update();
+
+    /// Measured from `before` the window is provably over, so declining to assert is the only
+    /// sound outcome; anchored on `after` this guard would instead proceed into the assertion
+    /// and read a ban that is already gone. The skip is asserted so this cannot pass vacuously.
+    bool window_over = now() > before + 2*history - epsilon;
+    if (!window_over)
+        ASSERT_EQ(1, CurrentMetrics::get(metrics.banned_count));
+
+    ASSERT_TRUE(window_over);
+    ASSERT_EQ(0, CurrentMetrics::get(metrics.banned_count));
+
+    /// An expired deadline has to be declined by the helper rather than reported as a defect.
+    check_no_failed_address(2, resolver, addresses, failed_addr, metrics, before + 2*history - epsilon);
 }
 
 TEST_F(ResolvePoolTest, UnbannedAfterConcurrentSuccess)

--- a/src/Common/tests/gtest_resolve_pool.cpp
+++ b/src/Common/tests/gtest_resolve_pool.cpp
@@ -594,10 +594,9 @@ TEST_F(ResolvePoolTest, BannedForConsiquenceFail)
     ASSERT_TRUE(addresses.contains(*failed_addr));
 
 
-    // `setFail` stamps the ban's anchor before it refreshes DNS, so the anchor lies in
-    // [before, after]. A deadline that gates a "still banned" assertion must therefore use
-    // `before` (a lower bound on expiry) and one that waits for expiry must use `after` (an
-    // upper bound); a single anchor taken after `setFail` can outlive the ban it waits on.
+    // `setFail` stamps the ban's anchor before refreshing DNS, so the anchor lies in
+    // [before, after]. Deadlines gating "still banned" must use `before`, waits for expiry
+    // `after`; one anchor taken after `setFail` can outlive the ban it waits on.
     auto before = now();
     failed_addr.setFail();
     auto after = now();
@@ -642,9 +641,8 @@ TEST_F(ResolvePoolTest, NoAditionalBannForConcurrentFail)
     ASSERT_TRUE(addresses.contains(*failed_addr));
 
     // Anchors bracket the ban's own timestamp; see BannedForConsiquenceFail. `setFail` restamps
-    // that timestamp on every call, so the window under test belongs to the last one and the
-    // anchors go around it: bracketing all three would be sound but needlessly loose by two
-    // whole DNS refreshes.
+    // it on every call, so the window belongs to the last one: bracketing all three would be
+    // sound but needlessly loose by two whole DNS refreshes.
     failed_addr.setFail();
     failed_addr.setFail();
     auto before = now();

--- a/src/Common/tests/gtest_resolve_pool.cpp
+++ b/src/Common/tests/gtest_resolve_pool.cpp
@@ -582,15 +582,14 @@ void check_no_failed_address(size_t iteration, auto & resolver, auto & addresses
 {
     ASSERT_EQ(iteration, DB::CurrentThread::getProfileEvents()[metrics.failed]);
 
-    /// Tests pinning the entry path derive the deadline here, so a preemption between the
-    /// caller's clock reading and the guard below cannot consume it.
+    /// Tests pinning the entry path derive the deadline here, so it is alive by construction and
+    /// re-reading the clock below could only turn a preemption into a spurious skip.
     if (deadline_from_entry)
         deadline = now() + *deadline_from_entry;
-
-    /// The ban window can already be over when this is called: the caller's anchor is a lower
-    /// bound on the ban's own timestamp, so it may sit a whole DNS refresh earlier. Nothing can
-    /// be asserted about a ban that is provably expired, so skip instead of reporting a defect.
-    if (now() > deadline)
+    /// Otherwise the window can already be over: the caller's anchor is a lower bound on the ban's
+    /// own timestamp, so it may sit a whole DNS refresh earlier. Nothing can be asserted about a
+    /// ban that is provably expired, so skip instead of reporting a defect.
+    else if (now() > deadline)
         return;
 
     for (size_t i = 0; i < 100; ++i)

--- a/src/Common/tests/gtest_resolve_pool.cpp
+++ b/src/Common/tests/gtest_resolve_pool.cpp
@@ -577,9 +577,15 @@ TEST_F(ResolvePoolTest, DuplicatesInAddresses)
     ASSERT_EQ(3, DB::CurrentThread::getProfileEvents()[metrics.discovered]);
 }
 
-void check_no_failed_address(size_t iteration, auto & resolver, auto & addresses, auto & failed_addr, auto & metrics, auto deadline)
+void check_no_failed_address(size_t iteration, auto & resolver, auto & addresses, auto & failed_addr, auto & metrics, auto deadline,
+                             std::optional<std::chrono::milliseconds> deadline_from_entry = std::nullopt)
 {
     ASSERT_EQ(iteration, DB::CurrentThread::getProfileEvents()[metrics.failed]);
+
+    /// Tests pinning the entry path derive the deadline here, so a preemption between the
+    /// caller's clock reading and the guard below cannot consume it.
+    if (deadline_from_entry)
+        deadline = now() + *deadline_from_entry;
 
     /// The ban window can already be over when this is called: the caller's anchor is a lower
     /// bound on the ban's own timestamp, so it may sit a whole DNS refresh earlier. Nothing can
@@ -725,7 +731,7 @@ TEST_F(ResolvePoolTest, NoSampleBeforeDeadlineIsNotAFailure)
     /// The deadline is alive on entry and expires during that first refresh, so the helper
     /// crosses it having sampled nothing. There is no observation to judge, so it must return
     /// rather than report the absence of samples as a defect.
-    check_no_failed_address(1, resolver, addresses, failed_addr, metrics, now() + 5ms);
+    check_no_failed_address(1, resolver, addresses, failed_addr, metrics, now() + 5ms, 5ms);
 
     /// The armed refresh must have been spent, otherwise the deadline expired before the first
     /// `resolve()` and the crossing this test pins was never reached.
@@ -747,16 +753,17 @@ TEST_F(ResolvePoolTest, BanWindowAnchoredOnFailTimestamp)
     resolver->update();
     ASSERT_EQ(0, CurrentMetrics::get(metrics.banned_count));
 
-    /// Both refreshes below are slow, which is what separates the ban's own timestamp from a
-    /// reading taken after `setFail`. Only the earlier of the two bounds the ban window; anchored
-    /// on the later one the deadline outlives the ban it is meant to gate.
-    slow_down_refreshes(2, 55ms);
+    /// Only `setFail`'s own refresh separates the ban's timestamp from a reading taken after it,
+    /// so it is long; the second merely delays the final reading and would eat the margin of the
+    /// `ASSERT_LE` below, so it is short.
+    slow_down_refreshes(1, 150ms);
 
     auto before = now();
     failed_addr.setFail();
     auto after = now();
 
     sleep_until(after + history + epsilon);
+    slow_down_refreshes(1, 5ms);
     resolver->update();
 
     /// Measured from `before` the window is provably over, so declining to assert is the only
@@ -768,6 +775,10 @@ TEST_F(ResolvePoolTest, BanWindowAnchoredOnFailTimestamp)
 
     ASSERT_TRUE(window_over);
     ASSERT_EQ(0, CurrentMetrics::get(metrics.banned_count));
+
+    /// An `after`-anchored deadline must still be open here, otherwise both anchors agree and this
+    /// test no longer discriminates the mechanism it exists to pin.
+    ASSERT_LE(now(), after + 2*history - epsilon);
 
     /// An expired deadline has to be declined by the helper rather than reported as a defect.
     check_no_failed_address(2, resolver, addresses, failed_addr, metrics, before + 2*history - epsilon);

--- a/src/Common/tests/gtest_resolve_pool.cpp
+++ b/src/Common/tests/gtest_resolve_pool.cpp
@@ -580,65 +580,73 @@ void check_no_failed_address(size_t iteration, auto & resolver, auto & addresses
 
 TEST_F(ResolvePoolTest, BannedForConsiquenceFail)
 {
-    auto history = 10ms;
+    auto history = 100ms;
     auto resolver = make_resolver(toMilliseconds(history));
 
     auto failed_addr = resolver->resolve();
     ASSERT_TRUE(addresses.contains(*failed_addr));
 
 
+    // `setFail` stamps the ban's anchor before it refreshes DNS, so the anchor lies in
+    // [before, after]. A deadline that gates a "still banned" assertion must therefore use
+    // `before` (a lower bound on expiry) and one that waits for expiry must use `after` (an
+    // upper bound); a single anchor taken after `setFail` can outlive the ban it waits on.
+    auto before = now();
     failed_addr.setFail();
-    auto start_at = now();
+    auto after = now();
 
     ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
     ASSERT_EQ(1, CurrentMetrics::get(metrics.banned_count));
-    check_no_failed_address(1, resolver, addresses, failed_addr, metrics, start_at + history - epsilon);
+    check_no_failed_address(1, resolver, addresses, failed_addr, metrics, before + history - epsilon);
 
-    sleep_until(start_at + history + epsilon);
+    sleep_until(after + history + epsilon);
 
     resolver->update();
     ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
     ASSERT_EQ(0, CurrentMetrics::get(metrics.banned_count));
 
+    before = now();
     failed_addr.setFail();
-    start_at = now();
+    after = now();
 
-    check_no_failed_address(2, resolver, addresses, failed_addr, metrics, start_at + history - epsilon);
+    check_no_failed_address(2, resolver, addresses, failed_addr, metrics, before + history - epsilon);
 
-    sleep_until(start_at + history + epsilon);
+    sleep_until(after + history + epsilon);
 
     resolver->update();
 
     // too much time has passed
-    if (now() > start_at + 2*history - epsilon)
+    if (now() > before + 2*history)
         return;
 
     ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
     ASSERT_EQ(1, CurrentMetrics::get(metrics.banned_count));
 
     // ip still banned adter history_ms + update, because it was his second consiquent fail
-    check_no_failed_address(2, resolver, addresses, failed_addr, metrics, start_at + 2*history - epsilon);
+    check_no_failed_address(2, resolver, addresses, failed_addr, metrics, before + 2*history - epsilon);
 }
 
 TEST_F(ResolvePoolTest, NoAditionalBannForConcurrentFail)
 {
-    auto history = 10ms;
+    auto history = 100ms;
     auto resolver = make_resolver(toMilliseconds(history));
 
     auto failed_addr = resolver->resolve();
     ASSERT_TRUE(addresses.contains(*failed_addr));
 
+    // Anchors bracket the ban's own timestamp; see BannedForConsiquenceFail. Only the last
+    // `setFail` matters here: concurrent fails do not extend the window.
+    auto before = now();
     failed_addr.setFail();
     failed_addr.setFail();
     failed_addr.setFail();
-
-    auto start_at = now();
+    auto after = now();
 
     ASSERT_EQ(3, CurrentMetrics::get(metrics.active_count));
     ASSERT_EQ(1, CurrentMetrics::get(metrics.banned_count));
-    check_no_failed_address(3, resolver, addresses, failed_addr, metrics, start_at + history - epsilon);
+    check_no_failed_address(3, resolver, addresses, failed_addr, metrics, before + history - epsilon);
 
-    sleep_until(start_at + history + epsilon);
+    sleep_until(after + history + epsilon);
 
     resolver->update();
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/66989
Related: https://github.com/ClickHouse/ClickHouse/pull/66953
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Related: #66989 (same test, closed by #66953)

`ResolvePoolTest.BannedForConsiquenceFail` can read `banned_count == 0` where it asserts `1`, i.e.
assert "still banned" against a ban that already expired. Seen on an internal
`Unit tests (asan_ubsan)` run.

The cause is an anchor mismatch, not clock skew. `setFail` stamps `fail_time` on entry
(`HostResolvePool.cpp:170`) and only then runs a full DNS refresh (`:206`), while the test anchored
its deadline *after* `setFail()` returned. Expiry is measured from `fail_time` (`:317-322`), so that
anchor sits a whole refresh late, leaving the guard `epsilon` (1 ms) for the refresh. Test-only;
production semantics are correct.

Each `setFail()` is now bracketed by `before`/`after`. Since `before <= fail_time <= after`, "still
banned" deadlines use `before` and expiry waits use `after`. The window goes 10 ms -> 100 ms so a
sound guard does not simply skip. `NoAditionalBannForConcurrentFail` had the same defect. Such a
deadline can also be already past on its first consultation, which `check_no_failed_address`
reported as a failure; that crossing measured nothing, so it now returns early.

A new fixture hook slows a chosen number of DNS refreshes (default 0, so other tests are untouched),
making the gap deterministic without threads. Three tests pin one mechanism each -
`BanSurvivesSlowFailRefresh`, `BanWindowAnchoredOnFailTimestamp`,
`NoSampleBeforeDeadlineIsNotAFailure`; reverting one reddens only its own test. Sweeping that delay,
the old form fails from 9 ms and the new one tolerates 97 ms with the assertion observed executing,
while widening alone still reads 0 at 99 ms. Suite 50x: 1000/1000. Both reported tests show 0
failures in ~99k public runs over 90 days, so this needs a loaded sanitizer host.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1107` (included in `26.8` and later)
<!-- ch-version-info:end -->