### PR TITLE
Fix flaky test_refreshable_mv_skip_old_temp_tables_ddls: sync replicas before comparing rows

### DIFF
--- a/tests/integration/test_refreshable_mv_skip_old_temp_table_ddls/test.py
+++ b/tests/integration/test_refreshable_mv_skip_old_temp_table_ddls/test.py
@@ -137,6 +137,10 @@ def test_refreshable_mv_skip_old_temp_tables_ddls(
             f"SELECT uuid, name FROM system.tables WHERE database='{db_name}'",
             check_callback=lambda x: x == table_info1,
         )
+        # Pull both replicas' parts before comparing -- an APPEND refresh replicates rows
+        # via ReplicatedMergeTree, which SYSTEM WAIT VIEW does not wait for.
+        node1.query_with_retry(f"SYSTEM SYNC REPLICA {db_name}.mv")
+        node2.query_with_retry(f"SYSTEM SYNC REPLICA {db_name}.mv")
         data1 = TSV(node1.query(f"SELECT x FROM {db_name}.mv ORDER BY x"))
         data2 = TSV(node2.query(f"SELECT x FROM {db_name}.mv ORDER BY x"))
         assert data1 == data2

--- a/tests/integration/test_refreshable_mv_skip_old_temp_table_ddls/test.py
+++ b/tests/integration/test_refreshable_mv_skip_old_temp_table_ddls/test.py
@@ -139,8 +139,14 @@ def test_refreshable_mv_skip_old_temp_tables_ddls(
         )
         # Pull both replicas' parts before comparing -- an APPEND refresh replicates rows
         # via ReplicatedMergeTree, which SYSTEM WAIT VIEW does not wait for.
-        node1.query_with_retry(f"SYSTEM SYNC REPLICA {db_name}.mv")
-        node2.query_with_retry(f"SYSTEM SYNC REPLICA {db_name}.mv")
+        sync = f"SYSTEM SYNC REPLICA {db_name}.mv"
+        sync_settings = {"receive_timeout": 30}
+        node1.query_with_retry(
+            sync, retry_count=6, sleep_time=1, settings=sync_settings
+        )
+        node2.query_with_retry(
+            sync, retry_count=6, sleep_time=1, settings=sync_settings
+        )
         data1 = TSV(node1.query(f"SELECT x FROM {db_name}.mv ORDER BY x"))
         data2 = TSV(node2.query(f"SELECT x FROM {db_name}.mv ORDER BY x"))
         assert data1 == data2


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`test_refreshable_mv_skip_old_temp_tables_ddls` fails intermittently on `assert data1 == data2`
with node1 holding 3 rows and node2 only 1 or 2. Latest:
[Integration tests (arm_binary, distributed plan, 4/4) on #110118](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110118&sha=fbf54763f8dc97892184f1819a97c7da4d0275ad&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29).
CIDB, 120 days: 3 occurrences on 3 unrelated PRs, one contributing 19 hits in a single day. No
related open issue or PR.

Root cause: `SYSTEM WAIT VIEW` does not wait for cross-replica data visibility when the view is
APPEND. `RefreshTask::wait` calls `waitForLatestTargetTable` only `if (coordination.coordinated
&& !refresh_append)`, and an APPEND refresh never calls `setParentTable`, so it emits no
Replicated-database DDL entry at all: its rows reach the other replica purely as
ReplicatedMergeTree parts over ZooKeeper, asynchronously. The test compares both replicas'
rows with a bare `assert`, so node2 may still be missing parts. All values are `now()` and
collapse to one second, which is why the visible difference is only a row count.

The engine behaviour is correct - `RefreshTask::syncForDependentRefresh` issues an explicit
`trySyncReplica` in its own `refresh_append` branch for the same reason. The test is just
missing that barrier.

Fix: `SYSTEM SYNC REPLICA` on both nodes before reading, bounded (`retry_count=6`,
`receive_timeout=30`) so a divergence that never resolves fails here with
`TIMEOUT_EXCEEDED` in 237s rather than exhausting the 900s pytest budget. The retry is kept
for the documented `TABLE_IS_READ_ONLY` startup transient. The assertion itself is unchanged. It
covers both `with_inner_table` values without branching because `trySyncReplica` resolves a
materialized view to its target table. Sibling tests already do exactly this
(`test_refreshable_mv/test.py:532`, `test_refreshable_mv_keeper_loss/test.py:179`); this was the
only one missing it.

Validation: with node2's fetches stalled across the read point the assertion fails before the
change (node1=3, node2=1) and passes after it, with the sync observed in `system.query_log` on
both nodes. Full 8-parameter matrix x 50 runs: 400 passed, 0 failures; 24/24 under
`distributed plan`. Matrix wall-clock 61.5s before vs 67.6s after.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1133` (included in `26.8` and later)
<!-- ch-version-info:end -->