### PR TITLE
fix: validate BigQuery HTTP headers through HTTPHeaderFilter to prevent injection (clickgapai)

### DIFF
--- a/src/Storages/BigQuery/BigQueryClient.cpp
+++ b/src/Storages/BigQuery/BigQueryClient.cpp
@@ -226,6 +226,8 @@ Poco::JSON::Object::Ptr BigQueryClient::requestJSON(
             out_stream_callback = [&request_body](std::ostream & os) { os << request_body; };
         }
 
+        context->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers);
+
         auto buf = BuilderRWBufferFromHTTP(uri)
             .withConnectionGroup(HTTPConnectionGroupType::HTTP)
             .withMethod(method)


### PR DESCRIPTION
## Description

Adds HTTP header validation via `HTTPHeaderFilter::checkAndNormalizeHeaders` to the BigQuery HTTP client, preventing injection of malicious headers through `billing_project` or `access_token` arguments.

The `url` table function already rejects such values with `BAD_ARGUMENTS`, but the BigQuery path was missing the same check.

### Root cause

`BigQueryClient::requestJSON` builds `HTTPHeaderEntries` from user-controlled values (`billing_project`, `access_token`) and passes them directly to `BuilderRWBufferFromHTTP(...).withHeaders(headers)` without routing through `HTTPHeaderFilter::checkAndNormalizeHeaders`, which rejects any name or value containing `\n` and enforces the admin `<http_forbid_headers>` list.

### Fix

Added `context->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers)` after the headers are fully assembled, matching the same pattern used in `StorageURL.cpp:1095`.

### Impact

- Prevents header injection via `billing_project` or `access_token` arguments in `bigquery(...)` / `ENGINE = BigQuery(...)`
- Ensures `<http_forbid_headers>` admin configuration is enforced on BigQuery HTTP requests
- Consistent with the existing protection in `StorageURL`, `StorageURLCluster`, S3/Web object-storage configurations

Closes #114101