### PR TITLE
fix: retry transient NO_SUCH_KEY on prefix.path read during metadata load [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -13,6 +13,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <thread>
 #include <optional>
 #include <vector>
 #include <IO/ReadHelpers.h>
@@ -164,9 +165,42 @@ void MetadataStorageFromPlainRewritableObjectStorage::load(bool is_initial_load,
                     if (metadata->size_bytes == 0)
                         LOG_TRACE(log, "The object with the key '{}' has size 0, skipping the read", object_path);
                     else
+                    else
                     {
-                        auto read_buf = object_storage->readObject(object, settings);
-                        readStringUntilEOF(local_path, *read_buf);
+                        /// Retry transient NO_SUCH_KEY (transient 404) on the prefix.path read.
+                        /// A momentary object-store blip (eventual-consistency 404, proxy hiccup,
+                        /// throttling surfaced as 404) must not silently hide committed rows.
+                        /// https://github.com/ClickHouse/ClickHouse/issues/114023
+                        static constexpr int max_attempts = 3;
+                        for (int attempt = 0;; ++attempt)
+                        {
+                            try
+                            {
+                                auto read_buf = object_storage->readObject(object, settings);
+                                readStringUntilEOF(local_path, *read_buf);
+                                break;
+                            }
+#if USE_AWS_S3
+                            catch (const S3Exception & e)
+                            {
+                                if (e.getS3ErrorCode() != Aws::S3::S3Errors::NO_SUCH_KEY)
+                                    throw;
+                                if (attempt + 1 >= max_attempts)
+                                    return;  /// Directory was genuinely removed.
+                                std::this_thread::sleep_for(std::chrono::milliseconds(100 << attempt));
+                            }
+#endif
+#if USE_AZURE_BLOB_STORAGE
+                            catch (const Azure::Storage::StorageException & e)
+                            {
+                                if (e.StatusCode != Azure::Core::Http::HttpStatusCode::NotFound)
+                                    throw;
+                                if (attempt + 1 >= max_attempts)
+                                    return;
+                                std::this_thread::sleep_for(std::chrono::milliseconds(100 << attempt));
+                            }
+#endif
+                        }
                     }
 
                     if (do_not_load_unchanged_directories)

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -165,7 +165,6 @@ void MetadataStorageFromPlainRewritableObjectStorage::load(bool is_initial_load,
                     if (metadata->size_bytes == 0)
                         LOG_TRACE(log, "The object with the key '{}' has size 0, skipping the read", object_path);
                     else
-                    else
                     {
                         /// Retry transient NO_SUCH_KEY (transient 404) on the prefix.path read.
                         /// A momentary object-store blip (eventual-consistency 404, proxy hiccup,


### PR DESCRIPTION
fixes #114023

## Background

On an `s3_plain_rewritable` (object-storage-only) MergeTree, a transient `NoSuchKey` (HTTP 404) on the read of a directory's `prefix.path` object during the metadata load at server start makes the part that directory holds **silently invisible**: `SELECT` succeeds and returns an *incomplete* result with no error.

## Root cause

`MetadataStorageFromPlainRewritableObjectStorage::load()` reads each directory's `prefix.path` object. If the GET returns `NO_SUCH_KEY` (S3) / `NotFound` (Azure), the handler silently `return`s — skipping that directory entirely. The comment says "It is ok if a directory was removed just now." This is correct for a directory legitimately removed between the `__meta` LIST and this GET, but the code cannot distinguish that from a transient 404 on a still-present object.

## Fix

Instead of immediately returning on `NO_SUCH_KEY`/`NotFound`, retry the read up to 3 times with exponential backoff (100ms, 200ms, 400ms). Only give up after all retries are exhausted, at which point the directory was likely genuinely removed.