### PR TITLE
fix: skip virtual columns inside indexHint for non-MergeTree storages (#114013)

### DIFF
--- a/src/Planner/CollectTableExpressionData.cpp
+++ b/src/Planner/CollectTableExpressionData.cpp
@@ -64,6 +64,16 @@ public:
         if (is_inside_index_hint_function && isColumnSourceMergeTree(*column_node))
             return;
 
+        /// For non-MergeTree storages, also skip virtual columns inside indexHint
+        /// (e.g. _table for Merge) — they are materialized after the read step and are
+        /// not available as inputs of the child read step.
+        if (is_inside_index_hint_function)
+        {
+            auto * source_table = column_node->getColumnSource()->as<TableNode>();
+            if (source_table && source_table->getStorageSnapshot()->metadata->isVirtualColumn(column_node->getColumnName()))
+                return;
+        }
+
         auto column_source_node = column_node->getColumnSource();
         auto column_source_node_type = column_source_node->getNodeType();
 

--- a/src/Planner/collectSelectedColumnsFromTable.cpp
+++ b/src/Planner/collectSelectedColumnsFromTable.cpp
@@ -41,7 +41,11 @@ public:
         /// A special case for the "indexHint" function. We don't need its arguments for execution if column's source table is MergeTree.
         /// Instead, we prepare an ActionsDAG for its arguments and store it inside a function (see ActionsDAG::buildFilterActionsDAG).
         /// So this optimization allows not to read arguments of "indexHint" (if not needed in other contexts) but only to use index analysis for them.
-        if (is_inside_index_hint_function && source_table->getStorage()->isMergeTree())
+        /// For non-MergeTree storages, skip virtual columns (e.g. _table for Merge) inside indexHint
+        /// for the same reason — they are materialized after the read step and are not available as inputs of the child read step.
+        if (is_inside_index_hint_function
+            && (source_table->getStorage()->isMergeTree()
+                || source_table->getStorageSnapshot()->metadata->isVirtualColumn(column_node->getColumnName())))
             return;
 
         selected_columns.insert(column_node->getColumnName());

--- a/tests/queries/0_stateless/04530_indexHint_merge_virtual_column.reference
+++ b/tests/queries/0_stateless/04530_indexHint_merge_virtual_column.reference
@@ -1,0 +1,32 @@
+-- { echo }
+
+DROP TABLE IF EXISTS m_v1;
+DROP TABLE IF EXISTS m_v2;
+DROP TABLE IF EXISTS m_all;
+
+CREATE TABLE m_v1 (key UInt32, value UInt32) ENGINE = MergeTree ORDER BY key;
+CREATE TABLE m_v2 (key UInt32, value UInt32) ENGINE = MergeTree ORDER BY key;
+
+INSERT INTO m_v1 VALUES (1, 10);
+INSERT INTO m_v2 VALUES (2, 20);
+
+CREATE TABLE m_all (key UInt32, value UInt32) ENGINE = Merge(currentDatabase(), '^m_v[0-9]$');
+
+SELECT _table, key FROM m_all WHERE indexHint(_table = 'm_v1') AND (_table = 'm_v1') ORDER BY key;
+m_v1	1
+
+-- Also test with different virtual column value to ensure indexHint works correctly
+SELECT _table, key FROM m_all WHERE indexHint(_table = 'm_v2') AND (_table = 'm_v2') ORDER BY key;
+m_v2	2
+
+-- Virtual column outside indexHint should still work as before
+SELECT _table, key FROM m_all WHERE _table = 'm_v1' ORDER BY key;
+m_v1	1
+
+-- Multiple indexHint virtual columns
+SELECT _table, key FROM m_all WHERE indexHint(_table = 'm_v1') AND _table = 'm_v1' AND indexHint(key = 1) ORDER BY key;
+m_v1	1
+
+DROP TABLE IF EXISTS m_all;
+DROP TABLE IF EXISTS m_v1;
+DROP TABLE IF EXISTS m_v2;

--- a/tests/queries/0_stateless/04530_indexHint_merge_virtual_column.sql
+++ b/tests/queries/0_stateless/04530_indexHint_merge_virtual_column.sql
@@ -1,0 +1,32 @@
+-- Test: indexHint over Merge table with virtual column _table should not fail
+-- https://github.com/ClickHouse/ClickHouse/issues/114013
+-- { echo }
+
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS m_v1;
+DROP TABLE IF EXISTS m_v2;
+DROP TABLE IF EXISTS m_all;
+
+CREATE TABLE m_v1 (key UInt32, value UInt32) ENGINE = MergeTree ORDER BY key;
+CREATE TABLE m_v2 (key UInt32, value UInt32) ENGINE = MergeTree ORDER BY key;
+
+INSERT INTO m_v1 VALUES (1, 10);
+INSERT INTO m_v2 VALUES (2, 20);
+
+CREATE TABLE m_all (key UInt32, value UInt32) ENGINE = Merge(currentDatabase(), '^m_v[0-9]$');
+
+SELECT _table, key FROM m_all WHERE indexHint(_table = 'm_v1') AND (_table = 'm_v1') ORDER BY key;
+
+-- Also test with different virtual column value to ensure indexHint works correctly
+SELECT _table, key FROM m_all WHERE indexHint(_table = 'm_v2') AND (_table = 'm_v2') ORDER BY key;
+
+-- Virtual column outside indexHint should still work as before
+SELECT _table, key FROM m_all WHERE _table = 'm_v1' ORDER BY key;
+
+-- Multiple indexHint virtual columns
+SELECT _table, key FROM m_all WHERE indexHint(_table = 'm_v1') AND _table = 'm_v1' AND indexHint(key = 1) ORDER BY key;
+
+DROP TABLE IF EXISTS m_all;
+DROP TABLE IF EXISTS m_v1;
+DROP TABLE IF EXISTS m_v2;


### PR DESCRIPTION
### Bug

`indexHint(_table = 'm_v1') AND (_table = 'm_v1')` on a Merge table fails with `NOT_FOUND_COLUMN_IN_BLOCK` because the virtual column `_table` is added to selected_columns, and the child read step (which reads from the underlying MergeTree tables) does not provide it.

Fixes #114013.

### Root cause

`collectSelectedColumnsFromTable` and `CollectTableExpressionData` skip columns inside `indexHint` only when the source table is MergeTree (`isMergeTree()`). For a Merge table, `isMergeTree()` returns false, so the `_table` virtual column leaks into `selected_columns`. The Merge table's child read step then demands `_table` as an input, but the underlying MergeTree read does not provide it.

### Fix

When collecting columns inside `indexHint`, also skip virtual columns of the storage (not just MergeTree columns). Virtual columns like `_table` of a Merge table are materialized by `StorageWithCommonVirtualColumns` after the read step, so they are not available as inputs of the child read step. The `indexHint` function only needs them for index analysis, not for actual reading.

### Changes

- `src/Planner/collectSelectedColumnsFromTable.cpp`: extend the `is_inside_index_hint_function` check to also skip virtual columns
- `src/Planner/CollectTableExpressionData.cpp`: add the same virtual column check
- `tests/queries/0_stateless/04530_indexHint_merge_virtual_column.sql`: new regression test
- `tests/queries/0_stateless/04530_indexHint_merge_virtual_column.reference`: expected output

### Test

```sql
CREATE TABLE m_v1 (key UInt32, value UInt32) ENGINE = MergeTree ORDER BY key;
CREATE TABLE m_v2 (key UInt32, value UInt32) ENGINE = MergeTree ORDER BY key;
CREATE TABLE m_all (key UInt32, value UInt32) ENGINE = Merge(currentDatabase(), '^m_v[0-9]$');

SELECT _table, key FROM m_all WHERE indexHint(_table = 'm_v1') AND (_table = 'm_v1') ORDER BY key;
-- Before: NOT_FOUND_COLUMN_IN_BLOCK
-- After:  m_v1  1
```