### PR TITLE
Fix "lightwegiht" typo in lightweight update lock timeout messages

### DIFF
--- a/src/Storages/MergeTree/PatchParts/PatchPartsLock.cpp
+++ b/src/Storages/MergeTree/PatchParts/PatchPartsLock.cpp
@@ -75,7 +75,7 @@ zkutil::EphemeralNodeHolderPtr getLockForSyncMode(
             lock_event->tryWait(lock_acquire_timeout);
     }
 
-    throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Failed to get lock with {} tries for lightwegiht update in sync mode", max_tries);
+    throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Failed to get lock with {} tries for lightweight update in sync mode", max_tries);
 }
 
 zkutil::EphemeralNodeHolderPtr getLockForAutoMode(
@@ -157,7 +157,7 @@ zkutil::EphemeralNodeHolderPtr getLockForAutoMode(
         return zkutil::EphemeralNodeHolder::existing(created_path, *zookeeper);
     }
 
-    throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Failed to get lock with {} tries for lightwegiht update in auto mode", max_tries);
+    throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Failed to get lock with {} tries for lightweight update in auto mode", max_tries);
 }
 
 }
@@ -287,7 +287,7 @@ void PlainLightweightUpdatesSync::lockColumns(const UpdateAffectedColumns & affe
     });
 
     if (!res)
-        throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Failed to get lock in {} ms for lightwegiht update with auto mode", timeout_ms);
+        throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Failed to get lock in {} ms for lightweight update with auto mode", timeout_ms);
 
     in_progress_columns.add(affected_columns);
 }

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -1145,7 +1145,7 @@ std::unique_ptr<PlainLightweightUpdateLock> StorageMergeTree::getLockForLightwei
         bool res = update_lock->sync_lock.try_lock_for(std::chrono::milliseconds(timeout_ms));
 
         if (!res)
-            throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Failed to get lock in {} ms for lightwegiht update with sync mode", timeout_ms);
+            throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Failed to get lock in {} ms for lightweight update with sync mode", timeout_ms);
 
         LOG_TRACE(log, "Got lock for lightweight update in sync mode");
     }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/114115
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/114115

Four `TIMEOUT_EXCEEDED` messages on the lightweight-update lock-timeout path spelled `lightweight` as `lightwegiht`, so a user grepping server logs or `system.text_log` for "lightweight" did not find them:

- `src/Storages/MergeTree/PatchParts/PatchPartsLock.cpp:78` (Replicated, sync mode)
- `src/Storages/MergeTree/PatchParts/PatchPartsLock.cpp:160` (Replicated, auto mode)
- `src/Storages/MergeTree/PatchParts/PatchPartsLock.cpp:290` (plain MergeTree, auto mode)
- `src/Storages/StorageMergeTree.cpp:1148` (plain MergeTree, sync mode)

Those are 2 engines x the 2 lock-taking `update_parallel_mode` arms (`sync`, `auto`; `async` takes no lock), which is every message in the family: `git grep lightwegiht` now returns nothing, and `git grep "Failed to get lock" -- src/` matches exactly these four lines. The issue reports the first three; the fourth lives in a different file because the sync-mode `try_lock_for` is inlined in `StorageMergeTree.cpp` while `lockColumns` sits in `PatchPartsLock.cpp`.

At the reporter's request this supersedes the changes in https://github.com/ClickHouse/ClickHouse/pull/114123, which covers the three `PatchPartsLock.cpp` sites only.

Text-only, +4/-4. No test: nothing pins these strings (`git grep "Failed to get lock" -- tests/ ci/ utils/ docs/` is empty, and there is no `lightwegiht` under `tests/` or `docs/`), and an error message's spelling is not a behavioral contract. Verified by running the sync-mode and auto-mode timeouts against a build of this branch and against pristine master: same query, same `Code: 159`, `lightwegiht` before and `lightweight` after.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1125` (included in `26.8` and later)
<!-- ch-version-info:end -->