### PR TITLE
Fix stress test failures due to internal queries was fuzzed

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -568,7 +568,8 @@ def make_query_command(query: str) -> str:
     return (
         f'clickhouse client -q "{query}" --receive_timeout=15 --max_untracked_memory=1Gi '
         "--memory_profiler_step=1Gi --max_memory_usage_for_user=0 --max_memory_usage_in_client=1000000000 "
-        "--enable-progress-table-toggle=0"
+        "--enable-progress-table-toggle=0 "
+        "--ast_fuzzer_runs=0",
     )
 
 


### PR DESCRIPTION
Error was for:

    [2026-08-10 05:00:51] Error on processing query: Timeout exceeded while receiving data from server. Waited for 15 seconds, timeout is 15 seconds.
    [2026-08-10 05:00:51] (query: SELECT value FROM system.server_settings WHERE name = 'cannot_allocate_thread_fault_injection_probability')

This was due to fuzzing:

    2026.08.10 07:00:35.127593 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Debug> executeQuery: (from [::1]:41902) (query 1, line 1) SELECT value FROM system.server_settings WHERE name = 'cannot_allocate_thread_fault_injection_probability' (stage: Complete)
    2026.08.10 07:00:35.128096 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Test> CancellationChecker: Added to set. query: SELECT value FROM system.server_settings WHERE name = 'cannot_allocate_thread_fault_injection_probability', timeout: 60000 milliseconds
    2026.08.10 07:00:35.148318 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Trace> Planner: Query to stage Complete
    2026.08.10 07:00:35.148967 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Trace> Planner: Query from stage FetchColumns to stage Complete
    2026.08.10 07:00:35.203023 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Test> QueryMetricLog: Scheduling next collecting task for query_id 9b3ad88a-ce22-4a34-b550-00862eab7c14 in 924 ms
    2026.08.10 07:00:35.227141 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Debug> executeQuery: Read 439 rows, 131.73 KiB in 0.095 sec., 4617.504 rows/sec., 1.35 MiB/sec.
    2026.08.10 07:00:35.229612 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Test> ProcessorProfileLog: Processors profile log:
    2026.08.10 07:00:35.231128 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Trace> ASTFuzzer: Fuzzed query: SELECT value FROM system.server_settings WHERE equals(name)
    2026.08.10 07:00:35.285188 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Trace> ASTFuzzer: Fuzzed query failed: Code: 42. DB::Exception: Number of arguments for function equals doesn't match: passed 1, should be 2: In scope SELECT value FROM system.server_settings WHERE equals(name). (NUMBER_OF_ARGUMENTS_DOESNT_MATCH) (version 26.8.1.1)
    2026.08.10 07:00:35.289274 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Trace> ASTFuzzer: Fuzzed query: SELECT DISTINCT value FROM system.server_settings WHERE name = 'cannot_allocate_thread_fault_injection_probability'
    2026.08.10 07:00:35.371717 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Debug> MemoryTracker: Query peak memory usage: 307.00 KiB.
    2026.08.10 07:00:35.374006 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Trace> ASTFuzzer: Fuzzed query: SELECT DISTINCT value FROM system.server_settings WHERE name = 'cannot_allocate_thread_fault_injection_probability'
    2026.08.10 07:00:35.459150 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Debug> MemoryTracker: Query peak memory usage: 307.00 KiB.
    2026.08.10 07:00:35.460910 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Trace> ASTFuzzer: Fuzzed query: SELECT DISTINCT value FROM merge('system', '.+') WHERE name = 'cannot_allocate_thread_fault_injection_probability'
    2026.08.10 07:00:51.858493 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Debug> MemoryTracker: Query peak memory usage: 57.48 MiB.
    2026.08.10 07:00:51.860026 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Trace> ASTFuzzer: Fuzzed query failed: Code: 139. DB::Exception: The `catboost_lib_path` setting is not configured, so clickhouse-library-bridge cannot be started: it is the only path the bridge is allowed to load shared libraries from. (NO_ELEMENTS_IN_CONFIG) (version 26.8.1.1)
    2026.08.10 07:00:51.883782 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Trace> ASTFuzzer: Fuzzed query: SELECT DISTINCT value FROM system.server_settings WHERE equals('cannot_allocate_thread_fault_injection_probability', name, 'cannot_allocate_thread_fault_injection_probability')
    2026.08.10 07:00:51.933465 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Trace> ASTFuzzer: Fuzzed query failed: Code: 42. DB::Exception: Number of arguments for function equals doesn't match: passed 3, should be 2: In scope SELECT DISTINCT value FROM system.server_settings WHERE equals('cannot_allocate_thread_fault_injection_probability', name, 'cannot_allocate_thread_fault_injection_probability'). (NUMBER_OF_ARGUMENTS_DOESNT_MATCH) (version 26.8.1.1)
    2026.08.10 07:00:51.933712 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Debug> MemoryTracker: Query peak memory usage: 315.20 KiB.
    2026.08.10 07:00:51.934314 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Debug> TCPHandler: Processed in 16.809 sec.
    2026.08.10 07:00:51.935510 [ 4326 ] {9b3ad88a-ce22-4a34-b550-00862eab7c14} <Test> CancellationChecker: Removing query 9b3ad88a-ce22-4a34-b550-00862eab7c14 from done tasks

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113927&sha=d73c7aab26cf62033a605876eb031669791a1958&name_0=PR&name_1=Stress%20test%20%28arm_release%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1091` (included in `26.8` and later)
<!-- ch-version-info:end -->