### PR TITLE
fix: remove stale .lock file when .backup is absent after crash

### DIFF
--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -818,7 +818,12 @@ void BackupImpl::checkBackupDoesntExist() const
     {
         chassert(!lock_file_name.empty());
         if (writer->fileExists(lock_file_name))
-            throw Exception(ErrorCodes::BACKUP_ALREADY_EXISTS, "Backup {} is being written already", backup_name_for_logging);
+        {
+            /// If the .lock file exists but the backup file doesn't, the previous backup
+            /// was interrupted (crashed) before it could finalize. Remove the stale lock.
+            LOG_WARNING(log, "Stale lock file {} found (no backup file exists). Removing it.", lock_file_name);
+            writer->removeFile(lock_file_name);
+        }
     }
 }
 


### PR DESCRIPTION
### Problem
If a `BACKUP ... TO S3(...)` is interrupted (server crash / power loss / OOM kill) after it has created its `.lock` object but before it finalizes the backup, the destination is left permanently unusable. Every subsequent `BACKUP` to the same destination fails with `BACKUP_ALREADY_EXISTS: Backup S3('...') is being written already` because the stale `.lock` file survives forever.

The only recovery is to manually delete the `.lock` object from the bucket — there is no in-server mechanism to detect or remove orphaned locks.

### Fix
In `checkBackupDoesntExist()`, when the `.lock` file exists, check whether the backup marker file (`.backup` or the archive) exists. If the marker file exists, the backup is complete and we correctly throw `BACKUP_ALREADY_EXISTS`. If the marker file does **not** exist, the `.lock` is stale (from a previous crash) — remove it so the next backup can proceed.

The subsequent `createLockFile()` call will create a fresh `.lock` with the new UUID.

Closes #114109