### PR TITLE
Route specialized documentation review requests

### DIFF
--- a/docs/integrations/clickpipes/home.mdx
+++ b/docs/integrations/clickpipes/home.mdx
@@ -14,7 +14,7 @@ import { Image } from "/snippets/components/Image.jsx";
 
 ## Introduction {#introduction}
 
-[ClickPipes](/integrations/clickpipes/home) is a managed integration platform that makes ingesting data from a diverse set of sources as simple as clicking a few buttons. Designed for the most demanding workloads, ClickPipes's robust and scalable architecture ensures consistent performance and reliability. ClickPipes can be used for long-term streaming needs or one-time data loading job.
+[ClickPipes](/integrations/clickpipes/home) is a managed integration platform that makes ingesting data from a diverse set of sources as simple as clicking a few buttons. Designed for the most demanding workloads, ClickPipes's robust and scalable architecture ensures consistent performance and reliability. ClickPipes can be used for long-term streaming needs or a one-time data loading job.
 
 ClickPipes can be deployed and managed manually using the ClickPipes UI, as well as programmatically using [OpenAPI](/integrations/clickpipes/programmatic-access/openapi) and [Terraform](/integrations/clickpipes/programmatic-access/terraform).
 


### PR DESCRIPTION
Routes docs-only pull requests to the team responsible for each changed documentation area. `ClickPipes`, language-client, and connector documentation now requests only its specialist team, while general documentation continues to request `@ClickHouse/docs`.

The PR also includes a small `ClickPipes` documentation correction to exercise the review-request path now that the specialist teams have repository access.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.
