### PR TITLE
Fix flaky `03100_lwu_06_apply_patches`

### DIFF
--- a/tests/queries/0_stateless/03100_lwu_06_apply_patches.sql
+++ b/tests/queries/0_stateless/03100_lwu_06_apply_patches.sql
@@ -13,8 +13,9 @@ SETTINGS
     enable_block_number_column = 1,
     enable_block_offset_column = 1,
     apply_patches_on_merge = 0,
-    cleanup_delay_period = 1000,
-    max_cleanup_delay_period = 1000;
+    -- The test asserts the patch part with data version 2 in every parts listing, but once
+    -- `APPLY PATCHES` raises the regular parts to version 3 the cleanup thread is free to drop it.
+    remove_unused_patch_parts = 0;
 
 INSERT INTO t_shared SELECT number, number FROM numbers(20);
 INSERT INTO t_shared SELECT number, number FROM numbers(20, 10);


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110202
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #110202

The test asserted a patch part the engine is entitled to drop, so it lost the
`patch-...-all_0_0_0_2  15` row from a `system.parts` listing:
[failing report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110202&sha=702986aef420b1b00b18acf938bf37f9d3844e9d&name_0=PR&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20azure%2C%20parallel%29).

`clearUnusedPatchParts` drops a patch once its max source data version is `<=` the
minimum data version among the partition's **active regular** parts. The
`ALTER ... APPLY PATCHES, UPDATE` brings that minimum to 3, so from that point on the
patch with version 2 is droppable while the one with version 4 is not. That asymmetry
is exactly the observed diff, and it licenses the drop before all three of the test's
part listings, not only the last one. The `OPTIMIZE ... FINAL` does not lower the minimum.

The `cleanup_delay_period = 1000` the test relied on is not a barrier: the first cleanup
iteration is scheduled with no delay, and `wakeup` is a bare `task->schedule()` that
bypasses the delay from any of its call sites. So I pin `remove_unused_patch_parts = 0`
instead and drop the two delay settings it replaces. Same one-line idiom as #100273
(`03100_lwu_01_basics`) and #112158 (`03100_lwu_15_future_reads`), which pin it against
the same background drop. The `.reference` is unchanged.

Validated in both directions on one provoked state whose arms differ only in the pin:
forcing a cleanup wakeup reproduces exactly the CI diff with
`Will drop unused patch part patch-...-all_0_0_0_2` in the log, and with the pin the same
provoked run passes with that log line absent. 50/50 randomized runs pass.

I measured the data version of every part in the 9 tests that assert literal patch-part
names. Of those, only this one and the already-pinned `03100_lwu_01_basics` reach the drop
condition, so I left the other 7 alone. Tests that assert patch state in aggregate rather
than by name are outside that set; `03100_lwu_15_future_reads` and
`03100_lwu_51_condition_evaluated_once` are already pinned.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1134` (included in `26.8` and later)
<!-- ch-version-info:end -->