### PR TITLE
fix: add output_format_arrow_enum_as_byte_array setting for Arrow output format [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -1494,6 +1494,10 @@ Write Date values as plain 16-bit numbers (read back as UInt16), instead of conv
 Output types having no conversion as raw binary data. If false - such types would raise UNKNOWN_TYPE exception.
 )", 0) \
     \
+    DECLARE(Bool, output_format_arrow_enum_as_byte_array, false, R"(
+Write enum values as a string (their names) instead of the underlying integer data type in Arrow output format.
+)", 0) \
+    \
     DECLARE(Bool, output_format_orc_string_as_string, true, R"(
 Use ORC String type instead of Binary for String columns
 )", 0) \

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -196,6 +196,7 @@ struct FormatSettings
         ArrowCompression output_compression_method = ArrowCompression::NONE;
         bool output_date_as_uint16 = false;
         bool output_unsupported_types_as_binary = true;
+        bool output_enum_as_byte_array = false;
     } arrow{};
 
     struct AvroSchemaRegistryTimeouts

--- a/src/Processors/Formats/Impl/ArrowIPC/RecordBatchEncoder.cpp
+++ b/src/Processors/Formats/Impl/ArrowIPC/RecordBatchEncoder.cpp
@@ -22,6 +22,7 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeVariant.h>
+#include <DataTypes/DataTypeEnum.h>
 #include <DataTypes/IDataType.h>
 #include <IO/NetUtils.h>
 #include <Core/UUID.h>
@@ -167,9 +168,23 @@ void RecordBatchEncoder::encodeValues(
         case TypeIndex::UInt32: appendFixedWidth<ColumnUInt32>(*this, column, num_rows); return;
         case TypeIndex::UInt64: appendFixedWidth<ColumnUInt64>(*this, column, num_rows); return;
         case TypeIndex::Int8: appendFixedWidth<ColumnInt8>(*this, column, num_rows); return;
-        case TypeIndex::Enum8: appendFixedWidth<ColumnInt8>(*this, column, num_rows); return;
+        case TypeIndex::Enum8:
+            if (settings.arrow.output_enum_as_byte_array)
+            {
+                encodeEnumAsString(column, type, num_rows, null_map_column);
+                return;
+            }
+            appendFixedWidth<ColumnInt8>(*this, column, num_rows);
+            return;
         case TypeIndex::Int16: appendFixedWidth<ColumnInt16>(*this, column, num_rows); return;
-        case TypeIndex::Enum16: appendFixedWidth<ColumnInt16>(*this, column, num_rows); return;
+        case TypeIndex::Enum16:
+            if (settings.arrow.output_enum_as_byte_array)
+            {
+                encodeEnumAsString(column, type, num_rows, null_map_column);
+                return;
+            }
+            appendFixedWidth<ColumnInt16>(*this, column, num_rows);
+            return;
         case TypeIndex::Int32: appendFixedWidth<ColumnInt32>(*this, column, num_rows); return;
         case TypeIndex::Int64: appendFixedWidth<ColumnInt64>(*this, column, num_rows); return;
         case TypeIndex::Float32: appendFixedWidth<ColumnFloat32>(*this, column, num_rows); return;
@@ -466,6 +481,42 @@ void RecordBatchEncoder::encodeValues(
                 "output_format_arrow_unsupported_types_as_binary = 1 to write it as binary",
                 type->getName());
     }
+}
+
+void RecordBatchEncoder::encodeEnumAsString(const IColumn & column, const DataTypePtr & type, size_t num_rows, const IColumn * null_map_column)
+{
+    const NullMap * null_map
+        = null_map_column ? &assert_cast<const ColumnUInt8 &>(*null_map_column).getData() : nullptr;
+    PODArray<Int32> arrow_offsets(num_rows + 1);
+    arrow_offsets[0] = 0;
+    PODArray<char> out_data;
+    Int64 cur = 0;
+    const WhichDataType which(type);
+    auto append_enum_names = [&](const auto & enum_column, const auto & enum_type)
+    {
+        const auto & data = enum_column.getData();
+        for (size_t i = 0; i < num_rows; ++i)
+        {
+            if (!(null_map && (*null_map)[i]))
+            {
+                const std::string_view s = enum_type.getNameForValue(data[i]);
+                cur += static_cast<Int64>(s.size());
+                if (cur > static_cast<Int64>(std::numeric_limits<Int32>::max()))
+                    throw Exception(ErrorCodes::TOO_LARGE_ARRAY_SIZE, "Arrow IPC string offset exceeds 32 bits");
+                const size_t old = out_data.size();
+                out_data.resize(out_data.size() + s.size());
+                if (!s.empty())
+                    memcpy(out_data.data() + old, s.data(), s.size());
+            }
+            arrow_offsets[i + 1] = static_cast<Int32>(cur);
+        }
+    };
+    if (which.isEnum8())
+        append_enum_names(assert_cast<const ColumnVector<Int8> &>(column), assert_cast<const DataTypeEnum8 &>(*type));
+    else
+        append_enum_names(assert_cast<const ColumnVector<Int16> &>(column), assert_cast<const DataTypeEnum16 &>(*type));
+    appendBuffer(arrow_offsets.data(), (num_rows + 1) * sizeof(Int32));
+    appendBuffer(out_data.data(), out_data.size());
 }
 
 void RecordBatchEncoder::encodeAsBinary(const IColumn & column, size_t num_rows, const IColumn * null_map_column)

--- a/src/Processors/Formats/Impl/ArrowIPC/RecordBatchEncoder.h
+++ b/src/Processors/Formats/Impl/ArrowIPC/RecordBatchEncoder.h
@@ -55,6 +55,9 @@ private:
     /// `output_format_arrow_unsupported_types_as_binary` fallback. Read back as `String`. `null_map_column`
     /// (when set) marks rows to emit as zero-length, so a NULL row's nested bytes are not written.
     void encodeAsBinary(const IColumn & column, size_t num_rows, const IColumn * null_map_column = nullptr);
+    /// Encodes an Enum8/Enum16 column as an Arrow `Binary`/`Utf8` column (its names) instead of the
+    /// underlying integer type, when `output_format_arrow_enum_as_byte_array` is enabled.
+    void encodeEnumAsString(const IColumn & column, const DataTypePtr & type, size_t num_rows, const IColumn * null_map_column);
 
     void appendEmptyBuffer();
     /// Emits the validity buffer: a packed LSB-first bitmap (1 = valid) for nullable columns, or an

--- a/src/Processors/Formats/Impl/ArrowIPC/SchemaConverter.cpp
+++ b/src/Processors/Formats/Impl/ArrowIPC/SchemaConverter.cpp
@@ -558,8 +558,26 @@ buildField(
             case TypeIndex::UInt16: make_int(16, false); break;
             case TypeIndex::UInt32: make_int(32, false); break;
             case TypeIndex::UInt64: make_int(64, false); break;
-            case TypeIndex::Int8: case TypeIndex::Enum8: make_int(8, true); break;
-            case TypeIndex::Int16: case TypeIndex::Enum16: make_int(16, true); break;
+            case TypeIndex::Int8: make_int(8, true); break;
+            case TypeIndex::Enum8:
+                if (settings.arrow.output_enum_as_byte_array)
+                {
+                    type_type = flatbuf::Type_Utf8;
+                    type_offset = flatbuf::CreateUtf8(b).Union();
+                }
+                else
+                    make_int(8, true);
+                break;
+            case TypeIndex::Int16: make_int(16, true); break;
+            case TypeIndex::Enum16:
+                if (settings.arrow.output_enum_as_byte_array)
+                {
+                    type_type = flatbuf::Type_Utf8;
+                    type_offset = flatbuf::CreateUtf8(b).Union();
+                }
+                else
+                    make_int(16, true);
+                break;
             case TypeIndex::Int32: make_int(32, true); break;
             case TypeIndex::Int64: make_int(64, true); break;
             case TypeIndex::DateTime: make_int(32, false); break;


### PR DESCRIPTION
### Description

Fixes #114130

Adds `output_format_arrow_enum_as_byte_array` setting (default: false) to write
Enum8/Enum16 values as their string names (utf8) instead of the underlying integer
type in Arrow output format. This mirrors the existing
`output_format_parquet_enum_as_byte_array` setting for Parquet.

### Changes
- **SchemaConverter.cpp**: Map Enum8/Enum16 to `Utf8` instead of `Int` when setting is enabled
- **RecordBatchEncoder.cpp**: Encode enum names as binary strings (using `getNameForValue`) when setting is enabled
- **FormatFactorySettings.h**: Declare `output_format_arrow_enum_as_byte_array` setting
- **FormatSettings.h**: Add `output_enum_as_byte_array` field to arrow struct

### Verification

With the default setting (`output_format_arrow_enum_as_byte_array=0`), behavior is unchanged.

With `output_format_arrow_enum_as_byte_array=1`:
```sql
SELECT CAST('SELECT', 'Enum16(''SELECT''=1)') FORMAT Arrow
```
will produce a utf8 string column with value `"SELECT"` instead of int16 `1`.

Wallet: fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT