### PR TITLE
docs: update BYOC feature availability to exclude ClickPipes

### DIFF
--- a/docs/products/cloud/guides/infrastructure/deployment-options/byoc/overview.mdx
+++ b/docs/products/cloud/guides/infrastructure/deployment-options/byoc/overview.mdx
@@ -65,8 +65,8 @@ The following requirements are fundamental to how BYOC is built and operated. Th
 ### Planned features (currently unsupported) {#planned-features-currently-unsupported}
 
 The following features have limitations or are not fully supported in Bring Your Own Cloud (BYOC) deployments.    
-- SQL Console: The standard SQL console is not available for BYOC deployments, but is on our roadmap.
-- ClickPipes Support: Currently available in private preview with streaming integrations such as Kafka, Kinesis supported. Additional integrations (CDC, object storage etc.) are on the roadmap. 
+- SQL Console: Not available for BYOC deployments, but on the roadmap.
+- ClickPipes: Not available for BYOC deployments, but on the roadmap.
 - Autoscaling: On the roadmap to add to future releases.
 - MySQL interface
 - AWS KMS aka CMEK (customer-managed encryption keys)


### PR DESCRIPTION
ClickPipes is not yet available for BYOC deployments; this is work-in-progress for H2. Correcting the documentation to avoid confusion.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1092` (included in `26.8` and later)
<!-- ch-version-info:end -->