### PR TITLE
Test: route specialized documentation review requests

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/team_notifications.py
+++ b/ci/jobs/scripts/workflow_hooks/team_notifications.py
@@ -11,6 +11,7 @@ INTEGRATIONS_DOCS_PREFIXES = (
     "docs/integrations/language-clients/",
     "docs/integrations/connectors/",
 )
+SPECIALIZED_DOCS_PREFIXES = (CLICKPIPES_DOCS_PREFIX, *INTEGRATIONS_DOCS_PREFIXES)
 
 DOCS_TEAM = "docs"
 CLICKPIPES_TEAM = "clickpipes"
@@ -38,7 +39,8 @@ def get_docs_teams_to_request(changed_files):
     ):
         teams.append(INTEGRATIONS_ECOSYSTEM_TEAM)
 
-    teams.append(DOCS_TEAM)
+    if any(not file.startswith(SPECIALIZED_DOCS_PREFIXES) for file in files):
+        teams.append(DOCS_TEAM)
     return teams
 
 

--- a/ci/jobs/scripts/workflow_hooks/team_notifications.py
+++ b/ci/jobs/scripts/workflow_hooks/team_notifications.py
@@ -6,6 +6,7 @@ from ci.praktika.info import Info
 INTEGRATIONS_ECOSYSTEM_FILES = ("src/Core/TypeId.h",)
 
 DOCS_PREFIX = "docs/"
+SOURCE_PREFIX = "src/"
 CLICKPIPES_DOCS_PREFIX = "docs/integrations/clickpipes/"
 INTEGRATIONS_DOCS_PREFIXES = (
     "docs/integrations/language-clients/",
@@ -24,6 +25,9 @@ def normalize_path(file):
 
 def get_docs_teams_to_request(changed_files):
     files = [normalize_path(file) for file in changed_files]
+    if any(file.startswith(SOURCE_PREFIX) for file in files):
+        return []
+
     files = [file for file in files if file.startswith(DOCS_PREFIX)]
     teams = []
 

--- a/ci/jobs/scripts/workflow_hooks/team_notifications.py
+++ b/ci/jobs/scripts/workflow_hooks/team_notifications.py
@@ -24,9 +24,10 @@ def normalize_path(file):
 
 def get_docs_teams_to_request(changed_files):
     files = [normalize_path(file) for file in changed_files]
+    files = [file for file in files if file.startswith(DOCS_PREFIX)]
     teams = []
 
-    if not files or not all(file.startswith(DOCS_PREFIX) for file in files):
+    if not files:
         return teams
 
     if any(file.startswith(CLICKPIPES_DOCS_PREFIX) for file in files):

--- a/ci/tests/test_team_notifications.py
+++ b/ci/tests/test_team_notifications.py
@@ -52,7 +52,11 @@ from ci.jobs.scripts.workflow_hooks import team_notifications
         ),
         (
             ["docs/integrations/clickpipes/home.mdx", "src/Core/Block.cpp"],
-            [],
+            ["clickpipes"],
+        ),
+        (
+            ["docs/reference/functions/array-functions.mdx", "src/Core/Block.cpp"],
+            ["docs"],
         ),
         (["src/Core/TypeId.h"], []),
         ([], []),

--- a/ci/tests/test_team_notifications.py
+++ b/ci/tests/test_team_notifications.py
@@ -52,11 +52,18 @@ from ci.jobs.scripts.workflow_hooks import team_notifications
         ),
         (
             ["docs/integrations/clickpipes/home.mdx", "src/Core/Block.cpp"],
-            ["clickpipes"],
+            [],
         ),
         (
             ["docs/reference/functions/array-functions.mdx", "src/Core/Block.cpp"],
-            ["docs"],
+            [],
+        ),
+        (
+            [
+                "ci/jobs/scripts/workflow_hooks/team_notifications.py",
+                "docs/integrations/clickpipes/home.mdx",
+            ],
+            ["clickpipes"],
         ),
         (["src/Core/TypeId.h"], []),
         ([], []),

--- a/ci/tests/test_team_notifications.py
+++ b/ci/tests/test_team_notifications.py
@@ -9,14 +9,22 @@ from ci.jobs.scripts.workflow_hooks import team_notifications
         (["docs/reference/functions/array-functions.mdx"], ["docs"]),
         (
             ["docs/integrations/clickpipes/kafka/index.mdx"],
-            ["clickpipes", "docs"],
+            ["clickpipes"],
+        ),
+        (
+            ["docs/integrations/language-clients/python/index.mdx"],
+            ["integrations-ecosystem"],
+        ),
+        (
+            ["docs/integrations/connectors/data-ingestion/index.mdx"],
+            ["integrations-ecosystem"],
         ),
         (
             [
                 "docs/integrations/language-clients/python/index.mdx",
                 "docs/integrations/connectors/data-ingestion/index.mdx",
             ],
-            ["integrations-ecosystem", "docs"],
+            ["integrations-ecosystem"],
         ),
         (
             [
@@ -26,8 +34,14 @@ from ci.jobs.scripts.workflow_hooks import team_notifications
             [
                 "clickpipes",
                 "integrations-ecosystem",
-                "docs",
             ],
+        ),
+        (
+            [
+                "docs/integrations/clickpipes/home.mdx",
+                "docs/reference/functions/array-functions.mdx",
+            ],
+            ["clickpipes", "docs"],
         ),
         (
             [
@@ -70,7 +84,7 @@ def test_check_requests_docs_teams(monkeypatch):
     )
 
     assert team_notifications.check()
-    assert requested == ["clickpipes", "integrations-ecosystem", "docs"]
+    assert requested == ["clickpipes", "integrations-ecosystem"]
 
 
 def test_check_does_not_manage_docs_reviews_after_open(monkeypatch):

--- a/docs/integrations/clickpipes/home.mdx
+++ b/docs/integrations/clickpipes/home.mdx
@@ -14,7 +14,7 @@ import { Image } from "/snippets/components/Image.jsx";
 
 ## Introduction {#introduction}
 
-[ClickPipes](/integrations/clickpipes/home) is a managed integration platform that makes ingesting data from a diverse set of sources as simple as clicking a few buttons. Designed for the most demanding workloads, ClickPipes's robust and scalable architecture ensures consistent performance and reliability. ClickPipes can be used for long-term streaming needs or one-time data loading job.
+[ClickPipes](/integrations/clickpipes/home) is a managed integration platform that makes ingesting data from a diverse set of sources as simple as clicking a few buttons. Designed for the most demanding workloads, ClickPipes's robust and scalable architecture ensures consistent performance and reliability. ClickPipes can be used for long-term streaming needs or a one-time data loading job.
 
 ClickPipes can be deployed and managed manually using the ClickPipes UI, as well as programmatically using [OpenAPI](/integrations/clickpipes/programmatic-access/openapi) and [Terraform](/integrations/clickpipes/programmatic-access/terraform).
 


### PR DESCRIPTION
Routes docs-only pull requests to the team responsible for each changed documentation area. `ClickPipes`, language-client, and connector documentation now requests only its specialist team, while general documentation continues to request `@ClickHouse/docs`.

The PR also includes a small `ClickPipes` documentation correction to exercise the review-request path now that the specialist teams have repository access.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.
