### PR TITLE
Make a MySQL connect cancellable so KILL QUERY and max_execution_time work

### DIFF
--- a/src/Common/mysqlxx/Connection.cpp
+++ b/src/Common/mysqlxx/Connection.cpp
@@ -24,10 +24,8 @@ namespace
 {
 
 /// Replacement for the connector's own pvio_socket_wait_io_or_timeout, installed via
-/// MARIADB_OPT_IO_WAIT. It waits in short slices so that a cancelled query stops instead of
-/// staying parked in a single poll() for the whole connect timeout.
-/// Contract: `timeout` is in milliseconds and <= 0 means wait indefinitely; a return value
-/// below 1 is a failure, 1 means the socket is ready.
+/// MARIADB_OPT_IO_WAIT. Contract: `timeout` is in milliseconds and <= 0 means wait indefinitely;
+/// a return value below 1 is a failure, 1 means the socket is ready.
 int cancellationAwareIoWait(my_socket handle, my_bool is_read, int timeout) noexcept
 {
     static constexpr int slice_ms = 200;
@@ -79,8 +77,7 @@ int cancellationAwareIoWait(my_socket handle, my_bool is_read, int timeout) noex
     }
 }
 
-/// Scoped so that only the connect is affected: the same hook is also the wait for ordinary
-/// reads and writes, whose cancellation is handled elsewhere.
+/// Scoped to connection establishment; post-connect reads and writes keep the library's own wait.
 struct ScopedCancellationAwareIoWait
 {
     MYSQL * driver;

--- a/src/Common/mysqlxx/Connection.cpp
+++ b/src/Common/mysqlxx/Connection.cpp
@@ -7,9 +7,92 @@
 #include <mysqlxx/Connection.h>
 #include <mysqlxx/Exception.h>
 
+#include <Common/CurrentThread.h>
+#include <Common/ThreadStatus.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <ctime>
+#include <poll.h>
+
 static inline const char* ifNotEmpty(const char* s)
 {
     return s && *s ? s : nullptr;
+}
+
+namespace
+{
+
+/// Replacement for the connector's own pvio_socket_wait_io_or_timeout, installed via
+/// MARIADB_OPT_IO_WAIT. It waits in short slices so that a cancelled query stops instead of
+/// staying parked in a single poll() for the whole connect timeout.
+/// Contract: `timeout` is in milliseconds and <= 0 means wait indefinitely; a return value
+/// below 1 is a failure, 1 means the socket is ready.
+int cancellationAwareIoWait(my_socket handle, my_bool is_read, int timeout) noexcept
+{
+    static constexpr int slice_ms = 200;
+
+    /// Invoked from C: nothing may escape. The cancellation predicate can throw.
+    try
+    {
+        pollfd poll_fd{};
+        poll_fd.fd = handle;
+        poll_fd.events = is_read ? POLLIN : POLLOUT;
+
+        const bool bounded = timeout > 0;
+        timespec start{};
+        if (bounded)
+            clock_gettime(CLOCK_MONOTONIC, &start);
+
+        int remaining = timeout;
+        while (true)
+        {
+            const int rc = poll(&poll_fd, 1, bounded ? std::min(remaining, slice_ms) : slice_ms);
+
+            /// Ready, or a failure other than a signal: hand it back untouched, errno included.
+            if (rc != 0 && !(rc == -1 && errno == EINTR))
+                return rc;
+
+            if (DB::CurrentThread::isInitialized() && DB::CurrentThread::get().isQueryCanceled())
+                return 0;
+
+            /// Recompute the budget from the start of the wait, so neither a signal nor a
+            /// slice boundary extends the deadline. An unbounded wait has no budget to spend.
+            if (bounded)
+            {
+                timespec now{};
+                clock_gettime(CLOCK_MONOTONIC, &now);
+                const int64_t elapsed_ms
+                    = (now.tv_sec - start.tv_sec) * 1000 + (now.tv_nsec - start.tv_nsec) / 1000000;
+                remaining = timeout - static_cast<int>(elapsed_ms);
+                if (remaining <= 0)
+                {
+                    errno = ETIMEDOUT;
+                    return 0;
+                }
+            }
+        }
+    }
+    catch (...)
+    {
+        return 0;
+    }
+}
+
+/// Scoped so that only the connect is affected: the same hook is also the wait for ordinary
+/// reads and writes, whose cancellation is handled elsewhere.
+struct ScopedCancellationAwareIoWait
+{
+    MYSQL * driver;
+
+    explicit ScopedCancellationAwareIoWait(MYSQL * driver_) : driver(driver_)
+    {
+        mysql_options(driver, MARIADB_OPT_IO_WAIT, reinterpret_cast<const void *>(&cancellationAwareIoWait));
+    }
+
+    ~ScopedCancellationAwareIoWait() { mysql_options(driver, MARIADB_OPT_IO_WAIT, nullptr); }
+};
+
 }
 
 namespace mysqlxx
@@ -120,12 +203,16 @@ void Connection::connect(const char* db,
     if (mysql_ssl_set(driver.get(), ifNotEmpty(ssl_key), ifNotEmpty(ssl_cert), ifNotEmpty(ssl_ca), nullptr, nullptr))
         throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
 
-    if (!mysql_real_connect(driver.get(), server, user, password, db, port, ifNotEmpty(socket), driver->client_flag))
-        throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
+    {
+        ScopedCancellationAwareIoWait io_wait_guard(driver.get());
 
-    /// Sets UTF-8 as default encoding. See https://mariadb.com/kb/en/mysql_set_character_set/
-    if (mysql_set_character_set(driver.get(), "utf8mb4"))
-        throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
+        if (!mysql_real_connect(driver.get(), server, user, password, db, port, ifNotEmpty(socket), driver->client_flag))
+            throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
+
+        /// Sets UTF-8 as default encoding. See https://mariadb.com/kb/en/mysql_set_character_set/
+        if (mysql_set_character_set(driver.get(), "utf8mb4"))
+            throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
+    }
 
     is_connected = true;
 }
@@ -151,7 +238,13 @@ void Connection::disconnect()
 
 bool Connection::ping()
 {
-    return is_connected && !mysql_ping(driver.get());
+    if (!is_connected)
+        return false;
+
+    /// With MYSQL_OPT_RECONNECT set, a dropped link makes ma_simple_command reconnect via
+    /// mariadb_reconnect -> mysql_real_connect, so a ping can block like a connect.
+    ScopedCancellationAwareIoWait io_wait_guard(driver.get());
+    return !mysql_ping(driver.get());
 }
 
 Query Connection::query(const std::string & str)

--- a/src/Common/mysqlxx/Connection.cpp
+++ b/src/Common/mysqlxx/Connection.cpp
@@ -30,7 +30,6 @@ int cancellationAwareIoWait(my_socket handle, my_bool is_read, int timeout) noex
 {
     static constexpr int slice_ms = 200;
 
-    /// Invoked from C: nothing may escape. The cancellation predicate can throw.
     try
     {
         pollfd poll_fd{};
@@ -71,6 +70,8 @@ int cancellationAwareIoWait(my_socket handle, my_bool is_read, int timeout) noex
             }
         }
     }
+    /// Ok: invoked from C, so nothing may escape through the connector's frames. The only throwing
+    /// call is the cancellation predicate, and 0 is the failure value the caller already handles.
     catch (...)
     {
         return 0;

--- a/src/Common/mysqlxx/PoolWithFailover.cpp
+++ b/src/Common/mysqlxx/PoolWithFailover.cpp
@@ -1,3 +1,4 @@
+#include <Common/CurrentThread.h>
 #include <Common/Exception.h>
 #include <Common/ReplicasReconnector.h>
 #include <algorithm>
@@ -229,6 +230,8 @@ PoolWithFailover::Entry PoolWithFailover::get()
                 if (bg_reconnect && !pool->isOnline())
                     continue;
 
+                DB::CurrentThread::checkIfNotCancelled();
+
                 try
                 {
                     Entry entry = shareable ? pool->get(wait_timeout) : pool->tryGet();
@@ -265,6 +268,10 @@ PoolWithFailover::Entry PoolWithFailover::get()
         else
             app.logger().error("Connection to mysql failed " + std::to_string(try_no + 1) + " times");
     }
+
+    /// The last attempt has no next iteration to reach the check above, and the full pool below
+    /// can still return a connection, so a cancelled query would be served or misreported.
+    DB::CurrentThread::checkIfNotCancelled();
 
     if (full_pool)
     {

--- a/tests/queries/0_stateless/04775_mysql_connect_cancellation.reference
+++ b/tests/queries/0_stateless/04775_mysql_connect_cancellation.reference
@@ -1,5 +1,7 @@
 kill_one_try ok
 kill_three_tries ok
 kill_unbounded_timeout ok
+kill_retry_count ok
+kill_engine_table ok
 max_execution_time ok
 not_cancelled_still_waits ok

--- a/tests/queries/0_stateless/04775_mysql_connect_cancellation.reference
+++ b/tests/queries/0_stateless/04775_mysql_connect_cancellation.reference
@@ -1,6 +1,7 @@
 kill_one_try ok
 kill_three_tries ok
 kill_unbounded_timeout ok
+unbounded_still_waits ok
 kill_retry_count ok
 kill_engine_table ok
 max_execution_time ok

--- a/tests/queries/0_stateless/04775_mysql_connect_cancellation.reference
+++ b/tests/queries/0_stateless/04775_mysql_connect_cancellation.reference
@@ -1,0 +1,5 @@
+kill_one_try ok
+kill_three_tries ok
+kill_unbounded_timeout ok
+max_execution_time ok
+not_cancelled_still_waits ok

--- a/tests/queries/0_stateless/04775_mysql_connect_cancellation.sh
+++ b/tests/queries/0_stateless/04775_mysql_connect_cancellation.sh
@@ -38,7 +38,7 @@ report()
 # Run a query in the background and cancel it once it is really inside the MySQL connect.
 # Echoes the elapsed milliseconds; the error text is left in ${CLICKHOUSE_TMP}/${name}.err.
 # With wait_connect = 1 the cancellation is held back until the pool has entered a connection
-# attempt, which arms that inspect what the connect did must ask for.
+# attempt, which every arm that cancels a connect must ask for.
 # Returns 1 if the query never started and 2 if the connect never began; in both cases the
 # fixture is broken and the caller must not judge the arm.
 run_and_cancel()
@@ -112,13 +112,18 @@ report_fixture_failure()
 }
 
 # Cancel a query that is inside the MySQL connect, and report how long it took to come back.
+# Every arm here asks for the connect-stage wait: cancelling before the pool is entered yields
+# the same QUERY_WAS_CANCELLED these arms assert, so without the wait they could pass on a build
+# where the connect is not cancellable at all.
 kill_arm()
 {
     local name=$1 settings=$2
-    local elapsed_ms error
+    local elapsed_ms error rc
 
-    if ! elapsed_ms=$(run_and_cancel "${name}" "SELECT * FROM mysql(${MYSQL_ARGS}, SETTINGS ${settings})"); then
-        echo "${name} query never appeared in system.processes"
+    elapsed_ms=$(run_and_cancel "${name}" "SELECT * FROM mysql(${MYSQL_ARGS}, SETTINGS ${settings})" 1)
+    rc=$?
+    if [ "${rc}" != "0" ]; then
+        report_fixture_failure "${name}" "${rc}"
         return
     fi
 
@@ -128,10 +133,12 @@ kill_arm()
 }
 
 # One try: the check before the final error is the only cancellation checkpoint left, so this
-# arm pins the error identity. Without it the cancellation surfaces as ALL_CONNECTION_TRIES_FAILED.
+# arm pins the error identity of a cancellation that really landed inside an attempt. Without it
+# the cancellation surfaces as ALL_CONNECTION_TRIES_FAILED.
 kill_arm kill_one_try "connect_timeout = 100, connection_max_tries = 1"
 # Three tries: latency alone does not pin the per-attempt check, because the sliced wait already
-# bounds each attempt to a fraction of a second. kill_retry_count below is what pins it.
+# bounds each attempt to a fraction of a second, and the first attempt is under way by then.
+# kill_retry_count below is what pins it.
 kill_arm kill_three_tries "connect_timeout = 100, connection_max_tries = 3"
 # connect_timeout = 0 means wait indefinitely, which must stay killable and must not fail early.
 kill_arm kill_unbounded_timeout "connect_timeout = 0, connection_max_tries = 1"

--- a/tests/queries/0_stateless/04775_mysql_connect_cancellation.sh
+++ b/tests/queries/0_stateless/04775_mysql_connect_cancellation.sh
@@ -35,25 +35,15 @@ report()
     echo "${name} ${verdict}"
 }
 
-# Run a query in the background and cancel it once it is really inside the MySQL connect.
-# Echoes the elapsed milliseconds; the error text is left in ${CLICKHOUSE_TMP}/${name}.err.
-# With wait_connect = 1 the cancellation is held back until the pool has entered a connection
-# attempt, which every arm that cancels a connect must ask for.
-# Returns 1 if the query never started and 2 if the connect never began; in both cases the
-# fixture is broken and the caller must not judge the arm.
-run_and_cancel()
+# Block until the query is really inside a MySQL connection attempt.
+# Returns 1 if the query never started and 2 if the connect never began; in both cases the query
+# is already reaped, the fixture is broken, and the caller must not judge the arm.
+wait_for_connect_start()
 {
-    local name=$1 query=$2 wait_connect=${3:-0}
-    local query_id="${CLICKHOUSE_DATABASE}_${name}"
-    local start_ms end_ms
+    local query_id=$1 client_pid=$2 wait_connect=${3:-0}
 
-    start_ms=$(date +%s%3N)
-    ${CLICKHOUSE_CLIENT_QUIET} --query_id "${query_id}" -q "${query}" \
-        > "${CLICKHOUSE_TMP}/${name}.err" 2>&1 &
-    local client_pid=$!
-
-    # Cancel only once the query is actually running, so the arm cannot pass by cancelling
-    # something that never started.
+    # Wait until the query is actually running, so an arm cannot pass by acting on something
+    # that never started.
     local seen=0
     for _ in {1..200}; do
         if [ "$(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.processes WHERE query_id = '${query_id}'")" = "1" ]; then
@@ -77,6 +67,8 @@ run_and_cancel()
             ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS text_log"
             # system.text_log is MergeTree backed, so the randomized parallel replicas settings
             # apply to reads of it. Pin them off per query rather than tagging the whole test.
+            # This marker is logged at DEBUG, so the arms need the CI logger level (trace); a
+            # coarser level makes them loud fixture failures rather than silent passes.
             if [ "$(${CLICKHOUSE_CLIENT} -q "SELECT count() > 0 FROM system.text_log
                     WHERE query_id = '${query_id}' AND logger_name = 'mysqlxx::Pool'
                       AND message LIKE 'Connecting to%'
@@ -92,6 +84,27 @@ run_and_cancel()
             return 2
         fi
     fi
+}
+
+# Run a query in the background and cancel it once it is really inside the MySQL connect.
+# Echoes the elapsed milliseconds; the error text is left in ${CLICKHOUSE_TMP}/${name}.err.
+# With wait_connect = 1 the cancellation is held back until the pool has entered a connection
+# attempt, which every arm that cancels a connect must ask for.
+# Propagates the wait_for_connect_start return codes.
+run_and_cancel()
+{
+    local name=$1 query=$2 wait_connect=${3:-0}
+    local query_id="${CLICKHOUSE_DATABASE}_${name}"
+    local start_ms end_ms rc
+
+    start_ms=$(date +%s%3N)
+    ${CLICKHOUSE_CLIENT_QUIET} --query_id "${query_id}" -q "${query}" \
+        > "${CLICKHOUSE_TMP}/${name}.err" 2>&1 &
+    local client_pid=$!
+
+    wait_for_connect_start "${query_id}" "${client_pid}" "${wait_connect}"
+    rc=$?
+    [ "${rc}" = "0" ] || return "${rc}"
 
     ${CLICKHOUSE_CLIENT} -q "KILL QUERY WHERE query_id = '${query_id}' SYNC FORMAT Null"
     wait "${client_pid}" 2>/dev/null
@@ -142,6 +155,34 @@ kill_arm kill_one_try "connect_timeout = 100, connection_max_tries = 1"
 kill_arm kill_three_tries "connect_timeout = 100, connection_max_tries = 3"
 # connect_timeout = 0 means wait indefinitely, which must stay killable and must not fail early.
 kill_arm kill_unbounded_timeout "connect_timeout = 0, connection_max_tries = 1"
+
+# The arm above only proves an unbounded wait can be interrupted; a build that mistook the first
+# cancellation-polling slice for a real timeout would still satisfy it, because the cancellation
+# flag is already set by then. So check the other direction: the unbounded wait must still be
+# running after several slices, before anything cancels it.
+UNBOUNDED_NAME=unbounded_still_waits
+UNBOUNDED_ID="${CLICKHOUSE_DATABASE}_${UNBOUNDED_NAME}"
+${CLICKHOUSE_CLIENT_QUIET} --query_id "${UNBOUNDED_ID}" -q \
+    "SELECT * FROM mysql(${MYSQL_ARGS}, SETTINGS connect_timeout = 0, connection_max_tries = 1)" \
+    > "${CLICKHOUSE_TMP}/${UNBOUNDED_NAME}.err" 2>&1 &
+UNBOUNDED_PID=$!
+wait_for_connect_start "${UNBOUNDED_ID}" "${UNBOUNDED_PID}" 1
+RC=$?
+if [ "${RC}" = "0" ]; then
+    sleep 3
+    STILL_RUNNING=$(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.processes WHERE query_id = '${UNBOUNDED_ID}'")
+    ${CLICKHOUSE_CLIENT} -q "KILL QUERY WHERE query_id = '${UNBOUNDED_ID}' SYNC FORMAT Null"
+    wait "${UNBOUNDED_PID}" 2>/dev/null
+    rm -f "${CLICKHOUSE_TMP}/${UNBOUNDED_NAME}.err"
+    if [ "${STILL_RUNNING}" = "1" ]; then
+        echo "${UNBOUNDED_NAME} ok"
+    else
+        echo "${UNBOUNDED_NAME} ended early"
+    fi
+else
+    rm -f "${CLICKHOUSE_TMP}/${UNBOUNDED_NAME}.err"
+    report_fixture_failure "${UNBOUNDED_NAME}" "${RC}"
+fi
 
 # The per-attempt check must stop the retry loop, not merely shorten each attempt. The pool logs
 # one line per completed retry, so count them. Waiting for the connect to start makes 1 exact

--- a/tests/queries/0_stateless/04775_mysql_connect_cancellation.sh
+++ b/tests/queries/0_stateless/04775_mysql_connect_cancellation.sh
@@ -37,10 +37,13 @@ report()
 
 # Run a query in the background and cancel it once it is really inside the MySQL connect.
 # Echoes the elapsed milliseconds; the error text is left in ${CLICKHOUSE_TMP}/${name}.err.
-# Returns non-zero if the query never started, in which case the caller must not judge it.
+# With wait_connect = 1 the cancellation is held back until the pool has entered a connection
+# attempt, which arms that inspect what the connect did must ask for.
+# Returns 1 if the query never started and 2 if the connect never began; in both cases the
+# fixture is broken and the caller must not judge the arm.
 run_and_cancel()
 {
-    local name=$1 query=$2
+    local name=$1 query=$2 wait_connect=${3:-0}
     local query_id="${CLICKHOUSE_DATABASE}_${name}"
     local start_ms end_ms
 
@@ -64,11 +67,48 @@ run_and_cancel()
         return 1
     fi
 
+    # A visible process row does not mean a connect has begun: the row is inserted before the
+    # interpreter that triggers analysis is constructed, so a cancellation can land ahead of the
+    # pool. The pool logs one line per attempt from inside the attempt itself, past the check
+    # that rejects an already cancelled query, so that line is the proof the connect started.
+    if [ "${wait_connect}" = "1" ]; then
+        local connecting=0
+        for _ in {1..200}; do
+            ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS text_log"
+            # system.text_log is MergeTree backed, so the randomized parallel replicas settings
+            # apply to reads of it. Pin them off per query rather than tagging the whole test.
+            if [ "$(${CLICKHOUSE_CLIENT} -q "SELECT count() > 0 FROM system.text_log
+                    WHERE query_id = '${query_id}' AND logger_name = 'mysqlxx::Pool'
+                      AND message LIKE 'Connecting to%'
+                    SETTINGS enable_parallel_replicas = 0")" = "1" ]; then
+                connecting=1
+                break
+            fi
+            sleep 0.1
+        done
+        if [ "${connecting}" = "0" ]; then
+            ${CLICKHOUSE_CLIENT} -q "KILL QUERY WHERE query_id = '${query_id}' SYNC FORMAT Null"
+            wait "${client_pid}" 2>/dev/null
+            return 2
+        fi
+    fi
+
     ${CLICKHOUSE_CLIENT} -q "KILL QUERY WHERE query_id = '${query_id}' SYNC FORMAT Null"
     wait "${client_pid}" 2>/dev/null
     end_ms=$(date +%s%3N)
 
     echo "$((end_ms - start_ms))"
+}
+
+# Report a broken fixture, distinguishing the two stages so the cause is legible.
+report_fixture_failure()
+{
+    local name=$1 rc=$2
+    if [ "${rc}" = "2" ]; then
+        echo "${name} connect never started"
+    else
+        echo "${name} query never appeared in system.processes"
+    fi
 }
 
 # Cancel a query that is inside the MySQL connect, and report how long it took to come back.
@@ -97,16 +137,16 @@ kill_arm kill_three_tries "connect_timeout = 100, connection_max_tries = 3"
 kill_arm kill_unbounded_timeout "connect_timeout = 0, connection_max_tries = 1"
 
 # The per-attempt check must stop the retry loop, not merely shorten each attempt. The pool logs
-# one line per completed retry, so count them: attempt 1 is already under way when the
-# cancellation arrives and legitimately logs its line, and retries 2 and 3 must not happen.
-# Expect exactly 1, never 0.
+# one line per completed retry, so count them. Waiting for the connect to start makes 1 exact
+# rather than lucky: attempt 1 is guaranteed under way when the cancellation arrives, so it
+# legitimately logs its line, while retries 2 and 3 must not run at all.
 KILL_RETRY_NAME=kill_retry_count
-if ELAPSED_MS=$(run_and_cancel "${KILL_RETRY_NAME}" \
-        "SELECT * FROM mysql(${MYSQL_ARGS}, SETTINGS connect_timeout = 100, connection_max_tries = 3)"); then
+ELAPSED_MS=$(run_and_cancel "${KILL_RETRY_NAME}" \
+    "SELECT * FROM mysql(${MYSQL_ARGS}, SETTINGS connect_timeout = 100, connection_max_tries = 3)" 1)
+RC=$?
+if [ "${RC}" = "0" ]; then
     rm -f "${CLICKHOUSE_TMP}/${KILL_RETRY_NAME}.err"
     ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS text_log"
-    # system.text_log is MergeTree backed, so the randomized parallel replicas settings apply to
-    # reads of it. Pin them off per query rather than tagging the whole test.
     RETRIES=$(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.text_log
         WHERE query_id = '${CLICKHOUSE_DATABASE}_${KILL_RETRY_NAME}'
           AND message LIKE 'Connection to mysql failed%times'
@@ -117,7 +157,7 @@ if ELAPSED_MS=$(run_and_cancel "${KILL_RETRY_NAME}" \
         echo "${KILL_RETRY_NAME} wrong retries: ${RETRIES}"
     fi
 else
-    echo "${KILL_RETRY_NAME} query never appeared in system.processes"
+    report_fixture_failure "${KILL_RETRY_NAME}" "${RC}"
 fi
 
 # A MySQL engine table connects from inside the pipeline (MySQLWithFailoverSource) instead of
@@ -126,11 +166,13 @@ fi
 ENGINE_NAME=kill_engine_table
 ${CLICKHOUSE_CLIENT} -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.mysql_engine_tbl (x Int32)
     ENGINE = MySQL(${MYSQL_ARGS}) SETTINGS connect_timeout = 100, connection_max_tries = 1"
-if ELAPSED_MS=$(run_and_cancel "${ENGINE_NAME}" "SELECT * FROM ${CLICKHOUSE_DATABASE}.mysql_engine_tbl"); then
+ELAPSED_MS=$(run_and_cancel "${ENGINE_NAME}" "SELECT * FROM ${CLICKHOUSE_DATABASE}.mysql_engine_tbl" 1)
+RC=$?
+if [ "${RC}" = "0" ]; then
     ERROR=$(cat "${CLICKHOUSE_TMP}/${ENGINE_NAME}.err")
     rm -f "${CLICKHOUSE_TMP}/${ENGINE_NAME}.err"
-    # Prove the arm really went through the storage rather than repeating the table function:
-    # only the engine path logs under the StorageMySQL logger.
+    # Distinguish this arm from the table function above: only the engine path plans through
+    # StorageMySQL. That the connect itself happened is already guaranteed by the wait.
     ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS text_log"
     VIA_STORAGE=$(${CLICKHOUSE_CLIENT} -q "SELECT count() > 0 FROM system.text_log
         WHERE query_id = '${CLICKHOUSE_DATABASE}_${ENGINE_NAME}' AND logger_name LIKE 'StorageMySQL%'
@@ -141,7 +183,7 @@ if ELAPSED_MS=$(run_and_cancel "${ENGINE_NAME}" "SELECT * FROM ${CLICKHOUSE_DATA
         echo "${ENGINE_NAME} did not reach the MySQL engine path"
     fi
 else
-    echo "${ENGINE_NAME} query never appeared in system.processes"
+    report_fixture_failure "${ENGINE_NAME}" "${RC}"
 fi
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.mysql_engine_tbl"
 

--- a/tests/queries/0_stateless/04775_mysql_connect_cancellation.sh
+++ b/tests/queries/0_stateless/04775_mysql_connect_cancellation.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Tag justification:
+#   no-fasttest: depends on libmysql (MySQL table function), not built in fast test.
+# No no-parallel tag: the mysql() table function attaches nothing to system.tables, so
+# concurrent copies cannot observe each other (unlike 04507, which ATTACHes a MySQL database).
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# A query cancelled while connecting to MySQL must stop promptly. The connect blocks in poll()
+# inside the client library during query analysis (schema inference), where no pipeline exists,
+# so neither KILL QUERY nor max_execution_time took effect until the connect timed out once per
+# retry: connection_max_tries * connect_timeout.
+# 192.0.2.1 (RFC 5737 TEST-NET-1) drops SYN packets rather than refusing them, so the connect
+# really blocks for the whole timeout; against a refused host it returns immediately and the
+# test would pass with or without the fix.
+MYSQL_ARGS="'192.0.2.1:3306', 'db', 'tbl', 'u', 'p'"
+
+CLICKHOUSE_CLIENT_QUIET=$(echo "${CLICKHOUSE_CLIENT}" | sed "s/--send_logs_level=${CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL}/--send_logs_level=fatal/g")
+
+# Durations are checked against 20 s: cancellation completes in ~2 s once fixed, while the
+# unfixed server took 100 s (one try), 300 s (three tries) and 133 s (unbounded connect), so
+# the bound separates them with a wide margin on slow CI.
+LIMIT_MS=20000
+
+report()
+{
+    local name=$1 elapsed_ms=$2 expected=$3 error=$4
+    local verdict="ok"
+    [ "${elapsed_ms}" -lt "${LIMIT_MS}" ] || verdict="TOO SLOW (${elapsed_ms}ms)"
+    echo "${error}" | grep -q "${expected}" || verdict="wrong error: ${error}"
+    echo "${name} ${verdict}"
+}
+
+# Cancel a query that is inside the MySQL connect, and report how long it took to come back.
+kill_arm()
+{
+    local name=$1 settings=$2
+    local query_id="${CLICKHOUSE_DATABASE}_${name}"
+    local start_ms end_ms error
+
+    start_ms=$(date +%s%3N)
+    ${CLICKHOUSE_CLIENT_QUIET} --query_id "${query_id}" \
+        -q "SELECT * FROM mysql(${MYSQL_ARGS}, SETTINGS ${settings})" > "${CLICKHOUSE_TMP}/${name}.err" 2>&1 &
+    local client_pid=$!
+
+    # Cancel only once the query is actually running, so the arm cannot pass by cancelling
+    # something that never started.
+    local seen=0
+    for _ in {1..200}; do
+        if [ "$(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.processes WHERE query_id = '${query_id}'")" = "1" ]; then
+            seen=1
+            break
+        fi
+        sleep 0.1
+    done
+    if [ "${seen}" = "0" ]; then
+        echo "${name} query never appeared in system.processes"
+        wait "${client_pid}" 2>/dev/null
+        return
+    fi
+
+    ${CLICKHOUSE_CLIENT} -q "KILL QUERY WHERE query_id = '${query_id}' SYNC FORMAT Null"
+    wait "${client_pid}" 2>/dev/null
+    end_ms=$(date +%s%3N)
+
+    error=$(cat "${CLICKHOUSE_TMP}/${name}.err")
+    rm -f "${CLICKHOUSE_TMP}/${name}.err"
+    report "${name}" "$((end_ms - start_ms))" "QUERY_WAS_CANCELLED" "${error}"
+}
+
+# One try: the check before the final error is the only cancellation checkpoint left, so this
+# arm pins the error identity. Without it the cancellation surfaces as ALL_CONNECTION_TRIES_FAILED.
+kill_arm kill_one_try "connect_timeout = 100, connection_max_tries = 1"
+# Three tries: the per-attempt check stops the remaining attempts, so this arm pins the latency.
+kill_arm kill_three_tries "connect_timeout = 100, connection_max_tries = 3"
+# connect_timeout = 0 means wait indefinitely, which must stay killable and must not fail early.
+kill_arm kill_unbounded_timeout "connect_timeout = 0, connection_max_tries = 1"
+
+# max_execution_time is enforced by a background watchdog that only raises the cancellation
+# flag, so it reaches the connect through the same checks as KILL QUERY.
+START_MS=$(date +%s%3N)
+ERROR=$(${CLICKHOUSE_CLIENT_QUIET} -q \
+    "SELECT * FROM mysql(${MYSQL_ARGS}, SETTINGS connect_timeout = 100, connection_max_tries = 1)
+     SETTINGS max_execution_time = 5" 2>&1)
+END_MS=$(date +%s%3N)
+report max_execution_time "$((END_MS - START_MS))" "TIMEOUT_EXCEEDED" "${ERROR}"
+
+# Without cancellation nothing changes: the same error, and the connect still consumes its
+# timeout instead of failing early.
+START_MS=$(date +%s%3N)
+ERROR=$(${CLICKHOUSE_CLIENT_QUIET} -q \
+    "SELECT * FROM mysql(${MYSQL_ARGS}, SETTINGS connect_timeout = 3, connection_max_tries = 1)" 2>&1)
+END_MS=$(date +%s%3N)
+ELAPSED_MS=$((END_MS - START_MS))
+if [ "${ELAPSED_MS}" -ge 2000 ]; then
+    report not_cancelled_still_waits "${ELAPSED_MS}" "ALL_CONNECTION_TRIES_FAILED" "${ERROR}"
+else
+    echo "not_cancelled_still_waits returned too early (${ELAPSED_MS}ms), connect did not block"
+fi

--- a/tests/queries/0_stateless/04775_mysql_connect_cancellation.sh
+++ b/tests/queries/0_stateless/04775_mysql_connect_cancellation.sh
@@ -2,8 +2,9 @@
 # Tags: no-fasttest
 # Tag justification:
 #   no-fasttest: depends on libmysql (MySQL table function), not built in fast test.
-# No no-parallel tag: the mysql() table function attaches nothing to system.tables, so
-# concurrent copies cannot observe each other (unlike 04507, which ATTACHes a MySQL database).
+# No no-parallel tag: the engine table lives in ${CLICKHOUSE_DATABASE} and inspecting it does not
+# connect, so concurrent copies cannot observe each other (unlike 04507, which ATTACHes a MySQL
+# database).
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -34,16 +35,18 @@ report()
     echo "${name} ${verdict}"
 }
 
-# Cancel a query that is inside the MySQL connect, and report how long it took to come back.
-kill_arm()
+# Run a query in the background and cancel it once it is really inside the MySQL connect.
+# Echoes the elapsed milliseconds; the error text is left in ${CLICKHOUSE_TMP}/${name}.err.
+# Returns non-zero if the query never started, in which case the caller must not judge it.
+run_and_cancel()
 {
-    local name=$1 settings=$2
+    local name=$1 query=$2
     local query_id="${CLICKHOUSE_DATABASE}_${name}"
-    local start_ms end_ms error
+    local start_ms end_ms
 
     start_ms=$(date +%s%3N)
-    ${CLICKHOUSE_CLIENT_QUIET} --query_id "${query_id}" \
-        -q "SELECT * FROM mysql(${MYSQL_ARGS}, SETTINGS ${settings})" > "${CLICKHOUSE_TMP}/${name}.err" 2>&1 &
+    ${CLICKHOUSE_CLIENT_QUIET} --query_id "${query_id}" -q "${query}" \
+        > "${CLICKHOUSE_TMP}/${name}.err" 2>&1 &
     local client_pid=$!
 
     # Cancel only once the query is actually running, so the arm cannot pass by cancelling
@@ -57,27 +60,90 @@ kill_arm()
         sleep 0.1
     done
     if [ "${seen}" = "0" ]; then
-        echo "${name} query never appeared in system.processes"
         wait "${client_pid}" 2>/dev/null
-        return
+        return 1
     fi
 
     ${CLICKHOUSE_CLIENT} -q "KILL QUERY WHERE query_id = '${query_id}' SYNC FORMAT Null"
     wait "${client_pid}" 2>/dev/null
     end_ms=$(date +%s%3N)
 
+    echo "$((end_ms - start_ms))"
+}
+
+# Cancel a query that is inside the MySQL connect, and report how long it took to come back.
+kill_arm()
+{
+    local name=$1 settings=$2
+    local elapsed_ms error
+
+    if ! elapsed_ms=$(run_and_cancel "${name}" "SELECT * FROM mysql(${MYSQL_ARGS}, SETTINGS ${settings})"); then
+        echo "${name} query never appeared in system.processes"
+        return
+    fi
+
     error=$(cat "${CLICKHOUSE_TMP}/${name}.err")
     rm -f "${CLICKHOUSE_TMP}/${name}.err"
-    report "${name}" "$((end_ms - start_ms))" "QUERY_WAS_CANCELLED" "${error}"
+    report "${name}" "${elapsed_ms}" "QUERY_WAS_CANCELLED" "${error}"
 }
 
 # One try: the check before the final error is the only cancellation checkpoint left, so this
 # arm pins the error identity. Without it the cancellation surfaces as ALL_CONNECTION_TRIES_FAILED.
 kill_arm kill_one_try "connect_timeout = 100, connection_max_tries = 1"
-# Three tries: the per-attempt check stops the remaining attempts, so this arm pins the latency.
+# Three tries: latency alone does not pin the per-attempt check, because the sliced wait already
+# bounds each attempt to a fraction of a second. kill_retry_count below is what pins it.
 kill_arm kill_three_tries "connect_timeout = 100, connection_max_tries = 3"
 # connect_timeout = 0 means wait indefinitely, which must stay killable and must not fail early.
 kill_arm kill_unbounded_timeout "connect_timeout = 0, connection_max_tries = 1"
+
+# The per-attempt check must stop the retry loop, not merely shorten each attempt. The pool logs
+# one line per completed retry, so count them: attempt 1 is already under way when the
+# cancellation arrives and legitimately logs its line, and retries 2 and 3 must not happen.
+# Expect exactly 1, never 0.
+KILL_RETRY_NAME=kill_retry_count
+if ELAPSED_MS=$(run_and_cancel "${KILL_RETRY_NAME}" \
+        "SELECT * FROM mysql(${MYSQL_ARGS}, SETTINGS connect_timeout = 100, connection_max_tries = 3)"); then
+    rm -f "${CLICKHOUSE_TMP}/${KILL_RETRY_NAME}.err"
+    ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS text_log"
+    # system.text_log is MergeTree backed, so the randomized parallel replicas settings apply to
+    # reads of it. Pin them off per query rather than tagging the whole test.
+    RETRIES=$(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.text_log
+        WHERE query_id = '${CLICKHOUSE_DATABASE}_${KILL_RETRY_NAME}'
+          AND message LIKE 'Connection to mysql failed%times'
+        SETTINGS enable_parallel_replicas = 0")
+    if [ "${RETRIES}" = "1" ]; then
+        echo "${KILL_RETRY_NAME} ok"
+    else
+        echo "${KILL_RETRY_NAME} wrong retries: ${RETRIES}"
+    fi
+else
+    echo "${KILL_RETRY_NAME} query never appeared in system.processes"
+fi
+
+# A MySQL engine table connects from inside the pipeline (MySQLWithFailoverSource) instead of
+# during analysis, which is a second entry into the same pool. Explicit columns keep CREATE from
+# connecting, so the connect happens on the SELECT.
+ENGINE_NAME=kill_engine_table
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.mysql_engine_tbl (x Int32)
+    ENGINE = MySQL(${MYSQL_ARGS}) SETTINGS connect_timeout = 100, connection_max_tries = 1"
+if ELAPSED_MS=$(run_and_cancel "${ENGINE_NAME}" "SELECT * FROM ${CLICKHOUSE_DATABASE}.mysql_engine_tbl"); then
+    ERROR=$(cat "${CLICKHOUSE_TMP}/${ENGINE_NAME}.err")
+    rm -f "${CLICKHOUSE_TMP}/${ENGINE_NAME}.err"
+    # Prove the arm really went through the storage rather than repeating the table function:
+    # only the engine path logs under the StorageMySQL logger.
+    ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS text_log"
+    VIA_STORAGE=$(${CLICKHOUSE_CLIENT} -q "SELECT count() > 0 FROM system.text_log
+        WHERE query_id = '${CLICKHOUSE_DATABASE}_${ENGINE_NAME}' AND logger_name LIKE 'StorageMySQL%'
+        SETTINGS enable_parallel_replicas = 0")
+    if [ "${VIA_STORAGE}" = "1" ]; then
+        report "${ENGINE_NAME}" "${ELAPSED_MS}" "QUERY_WAS_CANCELLED" "${ERROR}"
+    else
+        echo "${ENGINE_NAME} did not reach the MySQL engine path"
+    fi
+else
+    echo "${ENGINE_NAME} query never appeared in system.processes"
+fi
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.mysql_engine_tbl"
 
 # max_execution_time is enforced by a background watchdog that only raises the cancellation
 # flag, so it reaches the connect through the same checks as KILL QUERY.


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/79526
Related: https://github.com/ClickHouse/ClickHouse/issues/70857
Related: https://github.com/ClickHouse/ClickHouse/pull/113979

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `KILL QUERY` and `max_execution_time` having no effect on a query that is connecting to MySQL. A query using `mysql()` or a `MySQL` engine table against an unresponsive host stayed in `system.processes` with `is_cancelled = 1` for up to `connection_max_tries * connect_timeout`.

### Description

`mysql()` infers its schema during query analysis, before any pipeline exists, so the connect blocks in `poll()` inside the client library, where nothing reads the cancellation flag.

Two changes in `src/Common/mysqlxx`:

* `Connection.cpp` installs a `MARIADB_OPT_IO_WAIT` callback that waits in 200 ms slices and checks cancellation between them, preserving the connector's own `EINTR`, `ETIMEDOUT` and wait-indefinitely semantics. RAII scopes it to `mysql_real_connect` and `mysql_ping`, leaving post-connect I/O on the library's own wait.
* `PoolWithFailover.cpp` checks cancellation before each attempt, and once before the terminal `ALL_CONNECTION_TRIES_FAILED` throw: the last attempt has no next iteration, so a cancellation there was reported as a connection failure.

Against a blackholed host with `connect_timeout = 100`, `KILL QUERY` returns in 2.4 s instead of 100 s, now as `QUERY_WAS_CANCELLED`; `max_execution_time = 5` in 5.3 s as `TIMEOUT_EXCEEDED`. Uncancelled behaviour is unchanged. Two deliberate knock-on effects: the `ping` guard covers the whole `mysql_ping`, so on a healthy link it also governs one post-connect wait; and `onCancel`'s courtesy `KILL QUERY` to MySQL is skipped and logged on an executor thread of the cancelled query.

This is the first half of #79526: `PoolWithFailover::get` still holds the mutex across the blocking connect, so I left it open. The cancellation code reaches the client from `mysql()` and from a `SELECT` through a `MySQL` database; `SHOW CREATE TABLE` and `CREATE DATABASE ... ENGINE = MySQL` get the latency fix but still report `CANNOT_GET_CREATE_TABLE_QUERY` / `CANNOT_CREATE_DATABASE`, since the database engine wraps every exception, as it did with `ALL_CONNECTION_TRIES_FAILED` before. Also not covered: the `ping` reconnect, which needs an integration test; the retry loops in `Pool::Entry::forceConnected` and `Pool::get`; post-connect I/O; and the same gap in the PostgreSQL, ODBC and MongoDB clients.

<details>
<summary>Validation</summary>

Debug builds, two servers with asserted distinct build IDs (`SELECT lower(buildId())` checked in every arm); fix `194fda381c40`, pre-fix `76422598dac0`.

| arm | pre-fix | with fix |
|---|---|---|
| `KILL`, ct=100, tries=1 | 100.21 s, `ALL_CONNECTION_TRIES_FAILED` | 2.43 s, `QUERY_WAS_CANCELLED` |
| `KILL`, ct=100, tries=3 | 300.31 s, `ALL_CONNECTION_TRIES_FAILED` | 2.41 s, `QUERY_WAS_CANCELLED` |
| `max_execution_time=5`, ct=100 | 100.18 s, `ALL_CONNECTION_TRIES_FAILED` | 5.32 s, `TIMEOUT_EXCEEDED` |
| no cancellation, ct=2 | 2.10 s, `ALL_CONNECTION_TRIES_FAILED` | 2.12 s, same error |
| `KILL`, ct=0 (wait forever) | 132.94 s, `ALL_CONNECTION_TRIES_FAILED` | 2.28 s, `QUERY_WAS_CANCELLED` |
| ct=0, no cancellation | 133.62 s | 135.17 s, no early failure |
| ct=1 under a 100 ms profiler | 1.09 s | 1.10 s |
| warm pool broken, then `KILL` (manual, no test arm) | 200.25 s, `ALL_CONNECTION_TRIES_FAILED` | 5.39 s, `QUERY_WAS_CANCELLED` |

New test `04775_mysql_connect_cancellation` has 8 arms, passes in ~18 s with the fix, times out at 600 s on the pre-fix binary, and passed 50 randomized runs. `04507_mysql_connect_timeout_under_profiler`, `02888_system_tables_with_inaccessible_table_function` and the 268 stateless tests matching `mysql` or `dictionar` are green on both binaries.

Reverting each part in turn: without the terminal check a single-try cancellation returns `ALL_CONNECTION_TRIES_FAILED`; without the per-attempt check a cancelled query still starts all 3 attempts instead of 1; without slicing the full `connect_timeout` latency returns; forcing the bounded branch breaks `connect_timeout = 0`; treating `EINTR` as a failure aborts a valid connect on the first profiler signal (0.30 s instead of 1.09 s); making the check throw leaves the server running and the query failing normally. MySQL database refresh and dictionary loads have no query context, where both checks are no-ops.
</details>
