### PR TITLE
ci: upload complete stacktraces (from i.e. hung check) into artifacts

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -1387,6 +1387,13 @@ def main():
     if test_result:
         test_result.sort()
 
+    # On a test timeout or a failed hung check the full server stacktrace
+    # dumps land in the working directory (stdout keeps a trimmed preview).
+    for stacktrace_log in ("sql_stacktraces.log", "c_stacktraces.log"):
+        stacktrace_log_path = Path(stacktrace_log)
+        if stacktrace_log_path.exists():
+            debug_files.append(stacktrace_log_path)
+
     R = Result.create_from(
         results=results,
         stopwatch=stop_watch,

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -5,6 +5,8 @@ import argparse
 import logging
 import os
 import random
+import shlex
+import shutil
 import signal
 import subprocess
 import time
@@ -736,15 +738,17 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main():
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
-    args = parse_args()
+def collect_stacktrace_dumps(output_folder: Path) -> None:
+    # stdout keeps only a trimmed preview of the server stacktrace dumps;
+    # the full dumps are written to the working directory.
+    for stacktrace_log in ("sql_stacktraces.log", "c_stacktraces.log"):
+        path = Path.cwd() / stacktrace_log
+        if path.exists():
+            # Not rename: source and destination are different mounts.
+            shutil.move(path, output_folder / stacktrace_log)
 
-    if args.drop_databases and not args.hung_check:
-        raise argparse.ArgumentTypeError(
-            "--drop-databases only used in hung check (--hung-check)"
-        )
 
+def run_stress_test(args: argparse.Namespace) -> None:
     call_with_retry(make_query_command("SELECT 1"), timeout=0.5, retry_count=20)
 
     # Create random query/client killer unless disabled or in upgrade check mode
@@ -823,11 +827,49 @@ def main():
             )
             hung_check_log = args.output_folder / "hung_check.log"  # type: Path
             with Popen(["/usr/bin/tee", hung_check_log], stdin=PIPE) as tee:
-                res = call(
-                    cmd, shell=True, stdout=tee.stdin, stderr=STDOUT, timeout=600
-                )
-                if tee.stdin is not None:
-                    tee.stdin.close()
+                try:
+                    # Own session, so that on timeout the whole process
+                    # tree can be killed at once; otherwise survivors keep
+                    # appending to the dumps while they are collected.
+                    with Popen(
+                        cmd,
+                        shell=True,
+                        stdout=tee.stdin,
+                        stderr=STDOUT,
+                        start_new_session=True,
+                    ) as hung_check:
+                        try:
+                            res = hung_check.wait(timeout=600)
+                        except subprocess.TimeoutExpired:
+                            os.killpg(hung_check.pid, signal.SIGKILL)
+                            # The test runner starts each test in its own
+                            # session, out of reach of the killpg above,
+                            # but records the pgid in a file for exactly
+                            # this situation. The test command may carry
+                            # options (e.g. in the upgrade check), while
+                            # cleanup needs only the executable.
+                            test_runner = shlex.split(args.test_cmd)[0]
+                            call([test_runner, "--cleanup"], timeout=60)
+                            raise
+                finally:
+                    if tee.stdin is not None:
+                        tee.stdin.close()
+                    try:
+                        # EOF on the pipe means every process that
+                        # inherited it as stdout/stderr has exited: the
+                        # barrier that keeps the collection of the dumps
+                        # from racing a live writer.
+                        tee.wait(timeout=60)
+                    except subprocess.TimeoutExpired:
+                        # A writer survived both kills, e.g. a process
+                        # in uninterruptible sleep dies only once its
+                        # kernel wait completes. Give up on the barrier:
+                        # a dump with a torn tail beats losing it to the
+                        # job timeout.
+                        logging.warning(
+                            "Some hung check process survived the kill"
+                        )
+                        tee.kill()
             if res != 0 and have_long_running_queries:
                 logging.info("Hung check failed with exit code %d", res)
 
@@ -891,6 +933,24 @@ def main():
                 logging.info("No queries hung")
 
     logging.info("Stress test finished")
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    args = parse_args()
+
+    if args.drop_databases and not args.hung_check:
+        raise argparse.ArgumentTypeError(
+            "--drop-databases only used in hung check (--hung-check)"
+        )
+
+    try:
+        run_stress_test(args)
+    finally:
+        # Any exit path can leave dumps behind: the upgrade check runs
+        # without the hung check, and the test run can raise before the
+        # hung check is reached.
+        collect_stacktrace_dumps(args.output_folder)
 
 
 if __name__ == "__main__":

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -135,6 +135,13 @@ stress --test-cmd="/usr/bin/clickhouse-test --queries=\"previous_release_reposit
     && echo -e "Test script exit code$OK" >> /test_output/test_results.tsv \
     || echo -e "Test script failed$FAIL script exit code: $?" >> /test_output/test_results.tsv
 
+# The full server stacktrace dumps must survive the removal of the phase
+# output folder below.
+for stacktrace_log in tmp_stress_output/sql_stacktraces.log tmp_stress_output/c_stacktraces.log; do
+    if [ -f "$stacktrace_log" ]; then
+        mv "$stacktrace_log" /test_output/
+    fi
+done
 rm -rf tmp_stress_output
 
 # We experienced deadlocks in this command in very rare cases. Let's debug it:


### PR DESCRIPTION
Otherwise it is hard to debug

Example: https://s3.amazonaws.com/clickhouse-test-reports/PRs/114127/6fe5a48b7b2a8285cb97fa3f081c07320d5d33ce/stress_test_amd_debug/hung_check.log

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1194` (included in `26.8` and later)
<!-- ch-version-info:end -->