### PR TITLE
Docs: document dbt `server_host_name` profile option

### DIFF
--- a/docs/integrations/connectors/data-ingestion/etl-tools/dbt/features-and-configurations.mdx
+++ b/docs/integrations/connectors/data-ingestion/etl-tools/dbt/features-and-configurations.mdx
@@ -36,6 +36,7 @@ your_profile_name:
       secure: [False] # Use TLS (native protocol) or HTTPS (http protocol)
       client_cert: [null] # Path to a TLS client certificate in .pem format
       client_cert_key: [null] # Path to the private key for the TLS client certificate
+      server_host_name: [null] # Override the TLS SNI and hostname verification target. Useful when connecting via a DNS alias (e.g. an internal CNAME or AWS PrivateLink endpoint) where the TLS certificate is issued for a different hostname than the one used in `host`.
       retries: [1] # Number of times to retry a "retriable" database exception (such as a 503 'Service Unavailable' error)
       compression: [<empty string>] # Use gzip compression if truthy (http), or compression type for a native connection
       connect_timeout: [10] # Timeout in seconds to establish a connection to ClickHouse


### PR DESCRIPTION
Document the dbt ClickHouse profile's `server_host_name` option, including its use for TLS SNI and hostname verification when `host` is a DNS alias or private endpoint.

This ports the documentation change from the former documentation repository after the docs migration.

Related: https://github.com/ClickHouse/clickhouse-docs/pull/6545

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Document the dbt `server_host_name` profile option.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1124` (included in `26.8` and later)
<!-- ch-version-info:end -->