### PR TITLE
diff-review: do not start a server where no browser can reach it

### DIFF
--- a/.claude/skills/diff-review/SKILL.md
+++ b/.claude/skills/diff-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: diff-review
-description: In-browser review of pending changes before committing or opening a PR. Starts a local server on localhost:3000 that renders the working-tree diff with @pierre/diffs CodeView, opens the user's browser, and waits for their line comments — which must then be read back and addressed. Only works where the user has a browser on this same machine, so it refuses to start over SSH, on a cloud VM, or in a headless session. Use when the user asks for a browser review of the changes.
+description: In-browser review of pending changes before committing or opening a PR. Starts a local server on localhost:3000 that renders the working-tree diff with @pierre/diffs CodeView, opens the user's browser, and waits for their line comments — which must then be read back and addressed. Works from a browser on the same machine, or from the user's own machine through an SSH-forwarded port (the server prints the `ssh -L` command); where nobody opens the page within 120 s, it exits on its own. Use when the user asks for a browser review of the changes.
 ---
 
 # diff-review — let the user review changes in the browser
@@ -11,12 +11,15 @@ line comments, and hands them back to you as JSON. You must address every commen
 
 ## When not to use it
 
-The server binds to loopback, so the UI is only reachable from a browser running
-on the very machine the server runs on. Over SSH, on a cloud VM, or in any
-headless session there is no such browser, and `server.mjs` exits 4 without doing
-anything (see **Exit code 4** below). Don't reach for this skill in those
-environments: show the diff in the terminal with `git diff` / `git show`, or just
-open the pull request and let review happen there.
+The server binds to loopback, so the UI is reachable from a browser on the very
+machine the server runs on — or from the user's own machine once they forward
+the port (when the machine looks remote, the server prints the exact `ssh -L`
+command to do that). What it cannot survive is an environment where nobody will
+ever open the page: an unattended run on an isolated VM. There the server exits
+4 on its own after 120 s (see **Exit code 4** below). Don't reach for this skill
+when there is no user around to open a browser: show the diff in the terminal
+with `git diff` / `git show`, or just open the pull request and let review
+happen there.
 
 ## How to run
 
@@ -39,13 +42,20 @@ open the pull request and let review happen there.
      `--base $(git merge-base origin/master HEAD) --committed`.
    - The server prints the URL, opens the user's browser automatically, and stays
      alive until the user clicks **Finish review** in the UI, then exits 0.
+   - On a remote-looking machine (an SSH session, a cloud instance, no graphical
+     session) it starts all the same, but prints an `ssh -L` port-forwarding
+     command for the user to review from their own machine, and exits 4 if no
+     browser opens the page within 120 s.
    - The UI is fully self-contained: `@pierre/diffs` is vendored (see
      `vendor/README.md`), so no network access is needed and no third-party CDN
      ever sees the diff.
 
-2. Tell the user the review is ready at `http://localhost:3000`, then **wait**.
-   Do not poll and do not proceed with the commit/PR — you will be notified when
-   the background command exits (i.e. when the user submits the review).
+2. Tell the user the review is ready at `http://localhost:3000` (and relay the
+   port-forwarding command if the server printed one), then **wait**. Do not
+   fetch the URL yourself — a request from you would count as the browser the
+   server is waiting for. Do not proceed with the commit/PR — you will be
+   notified when the background command exits (i.e. when the user submits the
+   review, or when nobody opened the page in time).
 
 3. Read the `--out` JSON file. Shape:
 
@@ -74,14 +84,15 @@ open the pull request and let review happen there.
 ## Troubleshooting
 
 - **Exit code 3** — nothing to review against the chosen `--base`.
-- **Exit code 4** — no browser on this machine could reach the server, so nothing
-  was started. The message lists which signals fired: an SSH session
-  (`SSH_CONNECTION`/`SSH_CLIENT`/`SSH_TTY`), cloud-init state or a cloud vendor in
-  the DMI strings, or a Linux session with neither `DISPLAY` nor
-  `WAYLAND_DISPLAY`. This is the expected outcome on an isolated VM — fall back to
-  a terminal diff and carry on; do not retry.
-  `--force` (or `DIFF_REVIEW_FORCE=1`) skips the check, but it exists for a user
-  who has forwarded the port themselves. Never pass it on your own initiative.
+- **Exit code 4** — the machine looked remote (an SSH session
+  (`SSH_CONNECTION`/`SSH_CLIENT`/`SSH_TTY`), cloud-init state or a cloud vendor
+  in the DMI strings, or a Linux session with neither `DISPLAY` nor
+  `WAYLAND_DISPLAY`) and no browser opened the review page within 120 s, despite
+  the printed port-forwarding command. This is the expected outcome on an
+  unattended, isolated VM — fall back to a terminal diff and carry on; do not
+  retry on your own initiative.
+  `--force` (or `DIFF_REVIEW_FORCE=1`) makes the server wait indefinitely — for
+  a user who asked for it because they need more time to forward the port.
 - **Port 3000 busy** — a stale server is probably running:
   `pkill -f "diff-review/server.mjs"`, or pass `--port <other>` and give the user
   the new URL.

--- a/.claude/skills/diff-review/SKILL.md
+++ b/.claude/skills/diff-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: diff-review
-description: In-browser review of pending changes before committing or opening a PR. Starts a local server on localhost:3000 that renders the working-tree diff with @pierre/diffs CodeView, opens the user's browser, and waits for their line comments — which must then be read back and addressed. Use ALWAYS before git commit or PR creation, and whenever the user asks to see or review the changes.
+description: In-browser review of pending changes before committing or opening a PR. Starts a local server on localhost:3000 that renders the working-tree diff with @pierre/diffs CodeView, opens the user's browser, and waits for their line comments — which must then be read back and addressed. Only works where the user has a browser on this same machine, so it refuses to start over SSH, on a cloud VM, or in a headless session. Use when the user asks for a browser review of the changes.
 ---
 
 # diff-review — let the user review changes in the browser
@@ -8,6 +8,15 @@ description: In-browser review of pending changes before committing or opening a
 The user wants to read and review code changes in a browser UI before anything is
 committed or pushed. This skill serves the diff on localhost, collects the user's
 line comments, and hands them back to you as JSON. You must address every comment.
+
+## When not to use it
+
+The server binds to loopback, so the UI is only reachable from a browser running
+on the very machine the server runs on. Over SSH, on a cloud VM, or in any
+headless session there is no such browser, and `server.mjs` exits 4 without doing
+anything (see **Exit code 4** below). Don't reach for this skill in those
+environments: show the diff in the terminal with `git diff` / `git show`, or just
+open the pull request and let review happen there.
 
 ## How to run
 
@@ -65,8 +74,15 @@ line comments, and hands them back to you as JSON. You must address every commen
 ## Troubleshooting
 
 - **Exit code 3** — nothing to review against the chosen `--base`.
+- **Exit code 4** — no browser on this machine could reach the server, so nothing
+  was started. The message lists which signals fired: an SSH session
+  (`SSH_CONNECTION`/`SSH_CLIENT`/`SSH_TTY`), cloud-init state or a cloud vendor in
+  the DMI strings, or a Linux session with neither `DISPLAY` nor
+  `WAYLAND_DISPLAY`. This is the expected outcome on an isolated VM — fall back to
+  a terminal diff and carry on; do not retry.
+  `--force` (or `DIFF_REVIEW_FORCE=1`) skips the check, but it exists for a user
+  who has forwarded the port themselves. Never pass it on your own initiative.
 - **Port 3000 busy** — a stale server is probably running:
   `pkill -f "diff-review/server.mjs"`, or pass `--port <other>` and give the user
   the new URL.
-- **Browser didn't open** (SSH / headless) — give the user the URL to open manually.
 - **User wants to abort** — stop the background task with TaskStop; don't wait forever.

--- a/.claude/skills/diff-review/server.mjs
+++ b/.claude/skills/diff-review/server.mjs
@@ -22,7 +22,7 @@ import { gunzipSync } from 'node:zlib';
 import { readFileSync, writeFileSync, lstatSync, readlinkSync, existsSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { tmpdir, hostname, userInfo } from 'node:os';
+import { tmpdir, userInfo } from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const args = process.argv.slice(2);
@@ -359,17 +359,28 @@ server.listen(PORT, '127.0.0.1', () => {
     }
   }
   if (remoteSignals.length > 0) {
-    let user;
-    try {
-      user = userInfo().username;
-    } catch {
-      user = '<user>';
+    // SSH_CONNECTION is "<client_ip> <client_port> <server_ip> <server_port>":
+    // the address and port the user's own ssh connected to, which a forwarding
+    // command must reuse. hostname() would often name a private interface
+    // (ip-172-31-…) that the user's machine cannot resolve, so without
+    // SSH_CONNECTION the hint shows placeholders instead of posing as
+    // copy-pasteable.
+    const ssh = (process.env.SSH_CONNECTION ?? '').trim().split(/\s+/);
+    let target = '<user>@<this-machine>';
+    if (ssh.length === 4) {
+      let user;
+      try {
+        user = userInfo().username;
+      } catch {
+        user = '<user>';
+      }
+      target = (ssh[3] === '22' ? '' : `-p ${ssh[3]} `) + `${user}@${ssh[2]}`;
     }
     process.stdout.write(
       'diff-review: this machine looks remote:\n' +
         remoteSignals.map((r) => `  - ${r}\n`).join('') +
         'diff-review: the server listens on loopback only. To review from your own machine, forward the port:\n' +
-        `diff-review:   ssh -L ${PORT}:localhost:${PORT} ${user}@${hostname()}\n` +
+        `diff-review:   ssh -L ${PORT}:localhost:${PORT} ${target}\n` +
         `diff-review: then open ${url} there.\n` +
         `diff-review: exiting in ${NO_VISITOR_WAIT_SECS} s unless the review page is opened (--force waits indefinitely).\n`
     );

--- a/.claude/skills/diff-review/server.mjs
+++ b/.claude/skills/diff-review/server.mjs
@@ -11,8 +11,9 @@
 // is ignored — use it to review already-committed branch work.
 //
 // Exits 0 after the user submits their review (comments written to --out),
-// exits 3 when there is nothing to review, exits 4 when this machine has no
-// browser that could reach the server, exits 1 on errors (e.g. port busy).
+// exits 3 when there is nothing to review, exits 4 when the machine looked
+// remote or headless and nobody opened the review page within the wait
+// window, exits 1 on errors (e.g. port busy).
 
 import { createServer } from 'node:http';
 import { spawnSync, spawn } from 'node:child_process';
@@ -21,7 +22,7 @@ import { gunzipSync } from 'node:zlib';
 import { readFileSync, writeFileSync, lstatSync, readlinkSync, existsSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { tmpdir } from 'node:os';
+import { tmpdir, hostname, userInfo } from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const args = process.argv.slice(2);
@@ -39,18 +40,23 @@ const COMMITTED = args.includes('--committed');
 const FORCE = args.includes('--force') || process.env.DIFF_REVIEW_FORCE === '1';
 const MAX_FILE_BYTES = 2_000_000;
 
-// ── Refuse to serve where nobody can look ────────────────────────────────────
-// The server binds to loopback, so the review UI is only reachable from a
-// browser running on this very host. On an isolated VM — a cloud instance we
-// reach over SSH, a headless container — there is no such browser. Starting a
-// server there helps nobody: it binds a port and leaves a background task
-// waiting for a review that can never be submitted. Decide this before doing
-// any work at all, so we neither shell out to git nor read the diff.
-function detectNoReachableBrowser() {
+// ── Signals that the user's browser is probably elsewhere ────────────────────
+// The server binds to loopback, so the review UI is reachable from a browser on
+// this very host — or from any machine, once the user forwards the port
+// (ssh -L 3000:localhost:3000). None of the signals below prove the page is
+// unreachable: a cloud desktop has a local browser, `ssh -X` opens one over the
+// wire, and a forwarded port reaches loopback from anywhere. So the signals
+// refuse nothing on their own. They decide two things: whether to print the
+// port-forwarding hint, and whether to arm a deadline so that on an isolated VM
+// — where a review can never be submitted — the server exits instead of leaving
+// a background task waiting forever. The refusal itself rests on the one
+// observation that does prove nobody is looking: no request arrived in time.
+function detectRemoteSignals() {
   const reasons = [];
 
-  // A remote shell: the user's browser runs on the machine at the other end of
-  // the connection, and that machine cannot reach our loopback socket.
+  // A remote shell: the user's browser usually runs on the machine at the other
+  // end of the connection, and reaches our loopback only through a forwarded
+  // port.
   if (process.env.SSH_CONNECTION || process.env.SSH_CLIENT || process.env.SSH_TTY)
     reasons.push('this is an SSH session (SSH_CONNECTION/SSH_CLIENT/SSH_TTY is set)');
 
@@ -81,24 +87,21 @@ function detectNoReachableBrowser() {
     }
   }
 
-  // No graphical session: nothing here can open a browser even locally. macOS
-  // and Windows always have a window server, so this only applies to Linux.
+  // No graphical session: no browser can be auto-opened here (the user may
+  // still bring their own through a forwarded port). macOS and Windows always
+  // have a window server, so this only applies to Linux.
   if (process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY)
     reasons.push('there is no graphical session (DISPLAY and WAYLAND_DISPLAY are both unset)');
 
   return reasons;
 }
 
-const noBrowserReasons = FORCE ? [] : detectNoReachableBrowser();
-if (noBrowserReasons.length > 0) {
-  process.stderr.write(
-    'diff-review: not starting a server, because no browser on this machine could reach it:\n' +
-      noBrowserReasons.map((r) => `  - ${r}\n`).join('') +
-      'diff-review: show the diff in the terminal instead, with git diff or git show.\n' +
-      'diff-review: --force overrides this, and is only for a user who forwarded the port themselves.\n'
-  );
-  process.exit(4);
-}
+// How long a remote-looking machine waits for the first request before giving
+// up. Long enough to copy the printed ssh -L command into another terminal;
+// short enough that an unattended run does not hang. --force waits forever.
+const NO_VISITOR_WAIT_SECS = 120;
+const remoteSignals = FORCE ? [] : detectRemoteSignals();
+let noVisitorTimer = null;
 
 // Per-session secret: embedded into the served page and required on /submit, so
 // that a submission can only come from the UI this server handed out — not from
@@ -229,6 +232,13 @@ const VENDOR_FILES = new Map([
 
 // ── HTTP server ──────────────────────────────────────────────────────────────
 const server = createServer((req, res) => {
+  // A request is the proof the environment signals could not give: some browser
+  // does reach this server. From here on, wait for the review indefinitely.
+  if (noVisitorTimer != null) {
+    clearTimeout(noVisitorTimer);
+    noVisitorTimer = null;
+    process.stdout.write('diff-review: a browser reached the server; waiting for the review\n');
+  }
   const url = new URL(req.url, `http://localhost:${PORT}`);
   if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/index.html')) {
     res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
@@ -328,7 +338,12 @@ server.listen(PORT, '127.0.0.1', () => {
     `diff-review: ${files.length} file(s) ready for review at ${url}\n` +
       `diff-review: waiting for the user to submit their review; comments will be written to ${OUT}\n`
   );
-  if (!NO_OPEN) {
+  // Auto-open skips only where it literally cannot work: Linux without a
+  // display. Under `ssh -X` or on a cloud desktop, DISPLAY is set and the
+  // browser opens on the user's screen despite the remote-looking signals.
+  const canOpenBrowser =
+    process.platform !== 'linux' || process.env.DISPLAY || process.env.WAYLAND_DISPLAY;
+  if (!NO_OPEN && canOpenBrowser) {
     const opener =
       process.platform === 'darwin'
         ? ['open', [url]]
@@ -342,6 +357,30 @@ server.listen(PORT, '127.0.0.1', () => {
     } catch {
       process.stdout.write(`diff-review: could not open a browser; open ${url} manually\n`);
     }
+  }
+  if (remoteSignals.length > 0) {
+    let user;
+    try {
+      user = userInfo().username;
+    } catch {
+      user = '<user>';
+    }
+    process.stdout.write(
+      'diff-review: this machine looks remote:\n' +
+        remoteSignals.map((r) => `  - ${r}\n`).join('') +
+        'diff-review: the server listens on loopback only. To review from your own machine, forward the port:\n' +
+        `diff-review:   ssh -L ${PORT}:localhost:${PORT} ${user}@${hostname()}\n` +
+        `diff-review: then open ${url} there.\n` +
+        `diff-review: exiting in ${NO_VISITOR_WAIT_SECS} s unless the review page is opened (--force waits indefinitely).\n`
+    );
+    noVisitorTimer = setTimeout(() => {
+      process.stderr.write(
+        `diff-review: no browser reached the server within ${NO_VISITOR_WAIT_SECS} s, exiting without a review.\n` +
+          'diff-review: show the diff in the terminal instead, with git diff or git show.\n' +
+          'diff-review: or forward the port and re-run with --force to wait indefinitely.\n'
+      );
+      process.exit(4);
+    }, NO_VISITOR_WAIT_SECS * 1000);
   }
 });
 

--- a/.claude/skills/diff-review/server.mjs
+++ b/.claude/skills/diff-review/server.mjs
@@ -4,20 +4,21 @@
 // @pierre/diffs bundle (see vendor/README.md) — nothing is loaded from a CDN.
 //
 // Usage:
-//   node server.mjs [--repo <path>] [--base <ref>] [--committed] [--port 3000] [--out <file>] [--no-open]
+//   node server.mjs [--repo <path>] [--base <ref>] [--committed] [--port 3000] [--out <file>] [--no-open] [--force]
 //
 // By default the working tree (staged + unstaged + untracked) is diffed against
 // --base. With --committed, <base>..HEAD is diffed instead and the working tree
 // is ignored — use it to review already-committed branch work.
 //
 // Exits 0 after the user submits their review (comments written to --out),
-// exits 3 when there is nothing to review, exits 1 on errors (e.g. port busy).
+// exits 3 when there is nothing to review, exits 4 when this machine has no
+// browser that could reach the server, exits 1 on errors (e.g. port busy).
 
 import { createServer } from 'node:http';
 import { spawnSync, spawn } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { gunzipSync } from 'node:zlib';
-import { readFileSync, writeFileSync, lstatSync, readlinkSync } from 'node:fs';
+import { readFileSync, writeFileSync, lstatSync, readlinkSync, existsSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
@@ -35,7 +36,70 @@ const REPO = resolve(argVal('--repo', process.cwd()));
 const OUT = resolve(argVal('--out', join(tmpdir(), `diff-review-${Date.now()}.json`)));
 const NO_OPEN = args.includes('--no-open');
 const COMMITTED = args.includes('--committed');
+const FORCE = args.includes('--force') || process.env.DIFF_REVIEW_FORCE === '1';
 const MAX_FILE_BYTES = 2_000_000;
+
+// ── Refuse to serve where nobody can look ────────────────────────────────────
+// The server binds to loopback, so the review UI is only reachable from a
+// browser running on this very host. On an isolated VM — a cloud instance we
+// reach over SSH, a headless container — there is no such browser. Starting a
+// server there helps nobody: it binds a port and leaves a background task
+// waiting for a review that can never be submitted. Decide this before doing
+// any work at all, so we neither shell out to git nor read the diff.
+function detectNoReachableBrowser() {
+  const reasons = [];
+
+  // A remote shell: the user's browser runs on the machine at the other end of
+  // the connection, and that machine cannot reach our loopback socket.
+  if (process.env.SSH_CONNECTION || process.env.SSH_CLIENT || process.env.SSH_TTY)
+    reasons.push('this is an SSH session (SSH_CONNECTION/SSH_CLIENT/SSH_TTY is set)');
+
+  // A cloud instance. cloud-init state is the cheapest reliable marker, and the
+  // DMI vendor strings cover images that clean it up. Both are plain file
+  // reads. Deliberately not IMDS: querying 169.254.169.254 costs a network
+  // round trip (two, under IMDSv2) and hangs where the link-local route is
+  // firewalled off, to report what the DMI strings already say for free.
+  const cloudInitMarker = ['/var/lib/cloud/instance', '/run/cloud-init/instance-data.json'].find(
+    (p) => existsSync(p)
+  );
+  if (cloudInitMarker) {
+    reasons.push(`cloud-init state is present (${cloudInitMarker})`);
+  } else {
+    const CLOUD_VENDORS =
+      /amazon ec2|google|microsoft corporation|digitalocean|hetzner|openstack|alibaba cloud|oraclecloud|scaleway|vultr/i;
+    for (const field of ['sys_vendor', 'chassis_asset_tag', 'board_vendor']) {
+      let value;
+      try {
+        value = readFileSync(`/sys/class/dmi/id/${field}`, 'utf8').trim();
+      } catch {
+        continue;
+      }
+      if (CLOUD_VENDORS.test(value)) {
+        reasons.push(`DMI ${field} reads "${value}", so this is a cloud instance`);
+        break;
+      }
+    }
+  }
+
+  // No graphical session: nothing here can open a browser even locally. macOS
+  // and Windows always have a window server, so this only applies to Linux.
+  if (process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY)
+    reasons.push('there is no graphical session (DISPLAY and WAYLAND_DISPLAY are both unset)');
+
+  return reasons;
+}
+
+const noBrowserReasons = FORCE ? [] : detectNoReachableBrowser();
+if (noBrowserReasons.length > 0) {
+  process.stderr.write(
+    'diff-review: not starting a server, because no browser on this machine could reach it:\n' +
+      noBrowserReasons.map((r) => `  - ${r}\n`).join('') +
+      'diff-review: show the diff in the terminal instead, with git diff or git show.\n' +
+      'diff-review: --force overrides this, and is only for a user who forwarded the port themselves.\n'
+  );
+  process.exit(4);
+}
+
 // Per-session secret: embedded into the served page and required on /submit, so
 // that a submission can only come from the UI this server handed out — not from
 // a random cross-origin tab or a blind POST to localhost.


### PR DESCRIPTION
The `diff-review` skill serves the diff over HTTP and binds to loopback. On an isolated VM - a cloud instance running an unattended session, a headless container - nobody ever opens the review page. Starting the server there helped nobody: it bound a port, spawned a browser that could not open, and left a background task waiting for a review that could never be submitted.

The first version of this PR refused to start the server whenever the machine looked remote (SSH session, cloud instance, no graphical session). Review pointed out that those signals prove nothing of the sort: a cloud desktop has a local browser, `ssh -X` opens one over the wire, and above all a forwarded port - `ssh -L 3000:localhost:3000` - makes loopback reachable from anywhere, which is a primary usecase.

So the signals are now advisory, and the refusal rests on the one observation that does prove nobody is looking. `server.mjs` always starts the server; when the machine looks remote, it additionally:

- prints the reasons, and a port-forwarding command for reviewing from another machine. The target is taken from `SSH_CONNECTION` - the address and port the user's own `ssh` connected to, with `-p` added for a non-default port - and degrades to `<user>@<this-machine>` placeholders when `SSH_CONNECTION` is absent, rather than presenting an unresolvable `hostname` as copy-pasteable,
- skips the browser auto-open only where it literally cannot work - Linux with neither `DISPLAY` nor `WAYLAND_DISPLAY` set (under `ssh -X` or on a cloud desktop, `DISPLAY` is set and the browser opens as usual),
- exits 4 if no HTTP request arrives within 120 seconds. The first request - the user's browser through the forwarded port, or a local one the signals misjudged - lifts the deadline, and the server waits for the review indefinitely, as it does on a machine with no remote signals at all.

The remote-looking signals are:

- an SSH session (`SSH_CONNECTION`, `SSH_CLIENT` or `SSH_TTY` is set),
- a cloud instance (cloud-init state under `/var/lib/cloud` or `/run/cloud-init`, or a cloud vendor in the DMI strings under `/sys/class/dmi/id`),
- no graphical session on Linux (neither `DISPLAY` nor `WAYLAND_DISPLAY`).

The cloud check reads files rather than querying IMDS on purpose: a request to `169.254.169.254` costs a network round trip, two under IMDSv2, and hangs where the link-local route is firewalled off, only to report what the DMI strings already say for free.

`--force` (or `DIFF_REVIEW_FORCE=1`) disables the signals entirely - no hint, no deadline - for a user who wants the server to wait longer than 120 seconds.

`SKILL.md` no longer says to use the skill ALWAYS before a commit or a pull request - that instruction is what pulled it in unprompted on machines where it cannot work. It is now for when the user asks for a browser review, it tells the agent to relay the port-forwarding command to the user, and not to fetch the URL itself, since a request from the agent would count as the browser the server is waiting for.

Checked on a `c8g.24xlarge` EC2 instance reached over SSH, where all three signals fire:

- with no visitor, the server prints the reasons and the `ssh -L` command, and exits 4 after the deadline;
- a request within the window lifts the deadline - the server survives it, and a full review round-trip (page, nonce, `/submit`) completes with exit 0;
- with `--force`, no hint is printed and no deadline is armed;
- without a display, the `xdg-open` attempt is skipped entirely instead of failing noisily.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1139` (included in `26.8` and later)
<!-- ch-version-info:end -->