### PR TITLE
Docs: make long documentation TOCs scrollable

### DIFF
--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -1922,6 +1922,12 @@ html.dark .prose a.betaBadge:not(.card):not(.card *),
     margin-right: 8px;
 }
 
+html:not(.dark) .prose a.cloudNotSupportedBadge:not(.card):not(.card *),
+a.cloudNotSupportedBadge {
+    color: #660099 !important;
+    text-decoration: none !important;
+}
+
 .cloudNotSupportedIcon svg path {
     stroke: #660099;
 }
@@ -1929,6 +1935,12 @@ html.dark .prose a.betaBadge:not(.card):not(.card *),
 .dark .cloudNotSupportedBadge {
     background-color: #33004D;
     color: #EECCFF;
+}
+
+html.dark .prose a.cloudNotSupportedBadge:not(.card):not(.card *),
+.dark a.cloudNotSupportedBadge {
+    color: #EECCFF !important;
+    text-decoration: none !important;
 }
 
 .dark .cloudNotSupportedIcon svg path {

--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -1922,12 +1922,6 @@ html.dark .prose a.betaBadge:not(.card):not(.card *),
     margin-right: 8px;
 }
 
-html:not(.dark) .prose a.cloudNotSupportedBadge:not(.card):not(.card *),
-a.cloudNotSupportedBadge {
-    color: #660099 !important;
-    text-decoration: none !important;
-}
-
 .cloudNotSupportedIcon svg path {
     stroke: #660099;
 }
@@ -1935,12 +1929,6 @@ a.cloudNotSupportedBadge {
 .dark .cloudNotSupportedBadge {
     background-color: #33004D;
     color: #EECCFF;
-}
-
-html.dark .prose a.cloudNotSupportedBadge:not(.card):not(.card *),
-.dark a.cloudNotSupportedBadge {
-    color: #EECCFF !important;
-    text-decoration: none !important;
 }
 
 .dark .cloudNotSupportedIcon svg path {
@@ -2259,6 +2247,12 @@ html.dark .prose a.experimentalBadge:not(.card):not(.card *),
 /* Reset negative margin on Table of Contents to prevent overlap with description */
 #table-of-contents {
     margin-top: 0 !important;
+}
+
+/* Keep contextual controls visible below long tables of contents */
+#table-of-contents-content {
+    max-height: calc(100vh - 22rem);
+    overflow-y: auto;
 }
 
 /* Fix layout overlap in flex-row-reverse pages (like secure-rds) */


### PR DESCRIPTION
Long tables of contents currently push contextual controls such as `View as Markdown` below the visible sidebar. Cap the table of contents height relative to the viewport and let it scroll independently so those controls remain visible.

Validated with the isolated Mintlify preview and `git diff --check`.

### Changelog category (leave one):
- Documentation

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1172` (included in `26.8` and later)
<!-- ch-version-info:end -->