### PR TITLE
Retry an object store not-found when loading an active data part

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1454,8 +1454,11 @@ void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checks
     }
     catch (...)
     {
-        /// Don't scare people with broken part error if it's retryable.
-        if (!isRetryableException(std::current_exception()))
+        auto load_exception = std::current_exception();
+
+        /// Don't scare people with broken part error if it's retryable or the object store just
+        /// reported the object absent: neither says anything about this part's contents.
+        if (!isRetryableException(load_exception) && !isObjectStorageNotFoundException(load_exception))
         {
             auto message = getCurrentExceptionMessage(true);
             LOG_ERROR(storage.log, "Part {} is broken and needs manual correction. Reason: {}",

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2491,7 +2491,8 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPart(
     const String & part_name,
     const DiskPtr & part_disk_ptr,
     MergeTreeDataPartState to_state,
-    DB::SharedMutex & part_loading_mutex)
+    DB::SharedMutex & part_loading_mutex,
+    bool retry_not_found)
 {
     auto component_guard = Coordination::setCurrentComponent("MergeTreeData::loadDataPart");
     LOG_TRACE(log, "Loading {} part {} from disk {}", magic_enum::enum_name(to_state), part_name, part_disk_ptr->getName());
@@ -2540,6 +2541,17 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPart(
             fs::path(getFullPathOnDisk(part_disk_ptr)) / part_name, part_size_str);
     };
 
+    /// A single not-found cannot distinguish a momentary blip from a really deleted object, so
+    /// retry while attempts remain. Active only: PreActive and Outdated never detach here, and a
+    /// throw would break their callers.
+    auto should_rethrow = [&](std::exception_ptr exception_ptr)
+    {
+        if (isRetryableException(exception_ptr))
+            return true;
+
+        return retry_not_found && to_state == DataPartState::Active && isObjectStorageNotFoundException(exception_ptr);
+    };
+
     try
     {
         res.part = getDataPartBuilder(part_name, single_disk_volume, part_name, getReadSettings(), PartDirIntent::OpenExisting)
@@ -2551,7 +2563,7 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPart(
     {
         /// Don't count the part as broken if there was a retryalbe error
         /// during loading, such as "not enough memory" or network error.
-        if (isRetryableException(std::current_exception()))
+        if (should_rethrow(std::current_exception()))
             throw;
 
         LOG_DEBUG(log, "Failed to load data part {} with exception: {}", part_name, getExceptionMessage(std::current_exception(), false));
@@ -2567,7 +2579,7 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPart(
     {
         /// Don't count the part as broken if there was a retryalbe error
         /// during loading, such as "not enough memory" or network error.
-        if (isRetryableException(std::current_exception()))
+        if (should_rethrow(std::current_exception()))
             throw;
 
         mark_broken();
@@ -2652,11 +2664,15 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPartWithRetries(
     {
         try
         {
-            return loadDataPart(part_info, part_name, part_disk_ptr, to_state, part_loading_mutex);
+            /// On the final attempt loadDataPart must settle the outcome itself (mark the part
+            /// broken) rather than rethrow, because there is no attempt left to absorb it.
+            bool retry_not_found = try_no + 1 < max_tries;
+            return loadDataPart(part_info, part_name, part_disk_ptr, to_state, part_loading_mutex, retry_not_found);
         }
         catch (...)
         {
-            if (isRetryableException(std::current_exception()))
+            if (isRetryableException(std::current_exception())
+                || (to_state == DataPartState::Active && isObjectStorageNotFoundException(std::current_exception())))
                 handle_exception(std::current_exception(),try_no);
             else
                 throw;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2541,9 +2541,9 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPart(
             fs::path(getFullPathOnDisk(part_disk_ptr)) / part_name, part_size_str);
     };
 
-    /// A single not-found cannot distinguish a momentary blip from a really deleted object, so
-    /// retry while attempts remain. Active only: PreActive and Outdated never detach here, and a
-    /// throw would break their callers.
+    /// A single not-found cannot distinguish a momentary blip from a really deleted
+    /// object, so retry while attempts remain. Active only: `loadOutdatedDataParts`
+    /// terminates the server if a load throws, and the `PreActive` caller reschedules.
     auto should_rethrow = [&](std::exception_ptr exception_ptr)
     {
         if (isRetryableException(exception_ptr))

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2664,8 +2664,8 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPartWithRetries(
     {
         try
         {
-            /// On the final attempt loadDataPart must settle the outcome itself (mark the part
-            /// broken) rather than rethrow, because there is no attempt left to absorb it.
+            /// The final attempt has nothing left to absorb a not-found, so loadDataPart's
+            /// part-reading catches settle it there instead of rethrowing into this loop.
             bool retry_not_found = try_no + 1 < max_tries;
             return loadDataPart(part_info, part_name, part_disk_ptr, to_state, part_loading_mutex, retry_not_found);
         }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2541,9 +2541,9 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPart(
             fs::path(getFullPathOnDisk(part_disk_ptr)) / part_name, part_size_str);
     };
 
-    /// A single not-found cannot distinguish a momentary blip from a really deleted
-    /// object, so retry while attempts remain. Active only: `loadOutdatedDataParts`
-    /// terminates the server if a load throws, and the `PreActive` caller reschedules.
+    /// A single not-found cannot distinguish a momentary blip from a really deleted object,
+    /// so retry while attempts remain. Active only: the other states' callers already handle
+    /// a throw their own way (`loadOutdatedDataParts` terminates the server).
     auto should_rethrow = [&](std::exception_ptr exception_ptr)
     {
         if (isRetryableException(exception_ptr))

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -2161,12 +2161,15 @@ private:
     /// Returns default settings for storage with possible changes from global config.
     virtual std::unique_ptr<MergeTreeSettings> getDefaultSettings() const = 0;
 
+    /// @param retry_not_found - rethrow an object store not-found instead of marking the part
+    /// broken, so the caller's retry budget can absorb a transient one.
     LoadPartResult loadDataPart(
         const MergeTreePartInfo & part_info,
         const String & part_name,
         const DiskPtr & part_disk_ptr,
         MergeTreeDataPartState to_state,
-        DB::SharedMutex & part_loading_mutex);
+        DB::SharedMutex & part_loading_mutex,
+        bool retry_not_found = false);
 
     LoadPartResult loadDataPartWithRetries(
         const MergeTreePartInfo & part_info,

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -155,10 +155,10 @@ bool isObjectStorageNotFoundException(std::exception_ptr exception_ptr)
 #if USE_AWS_S3
     catch (const S3Exception & s3_exception)
     {
-        /// Deliberately narrower than S3::isNotFoundError, which also covers NO_SUCH_BUCKET:
-        /// a missing bucket is a whole-storage condition, not a per-object one.
-        auto code = s3_exception.getS3ErrorCode();
-        return code == Aws::S3::S3Errors::NO_SUCH_KEY || code == Aws::S3::S3Errors::RESOURCE_NOT_FOUND;
+        /// Only the codes `unretryable_errors` (S3Common.cpp) actually classifies as
+        /// non-retryable: `RESOURCE_NOT_FOUND` is retryable there and already gets the
+        /// budget, and `NO_SUCH_BUCKET` is a whole-storage condition, not a per-object one.
+        return s3_exception.getS3ErrorCode() == Aws::S3::S3Errors::NO_SUCH_KEY;
     }
 #endif
 #if USE_AZURE_BLOB_STORAGE

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -169,6 +169,8 @@ bool isObjectStorageNotFoundException(std::exception_ptr exception_ptr)
 #endif
     catch (...)
     {
+        /// Ok to answer "not a not-found" here: this only classifies, the caller keeps the
+        /// exception and decides what to do with it.
         return false;
     }
 }

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -164,7 +164,9 @@ bool isObjectStorageNotFoundException(std::exception_ptr exception_ptr)
 #if USE_AZURE_BLOB_STORAGE
     catch (const Azure::Core::RequestFailedException & e)
     {
-        return e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound;
+        /// Azure answers 404 for a missing container too, which is a whole-storage condition
+        /// rather than a per-object one, so exclude it just like S3's `NO_SUCH_BUCKET`.
+        return e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound && e.ErrorCode != "ContainerNotFound";
     }
 #endif
     catch (...)

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -146,6 +146,33 @@ bool isRetryableException(std::exception_ptr exception_ptr)
     }
 }
 
+bool isObjectStorageNotFoundException(std::exception_ptr exception_ptr)
+{
+    try
+    {
+        rethrow_exception(exception_ptr);
+    }
+#if USE_AWS_S3
+    catch (const S3Exception & s3_exception)
+    {
+        /// Deliberately narrower than S3::isNotFoundError, which also covers NO_SUCH_BUCKET:
+        /// a missing bucket is a whole-storage condition, not a per-object one.
+        auto code = s3_exception.getS3ErrorCode();
+        return code == Aws::S3::S3Errors::NO_SUCH_KEY || code == Aws::S3::S3Errors::RESOURCE_NOT_FOUND;
+    }
+#endif
+#if USE_AZURE_BLOB_STORAGE
+    catch (const Azure::Core::RequestFailedException & e)
+    {
+        return e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound;
+    }
+#endif
+    catch (...)
+    {
+        return false;
+    }
+}
+
 static IMergeTreeDataPart::Checksums checkDataPart(
     MergeTreeData::DataPartPtr data_part,
     const IDataPartStorage & data_part_storage,

--- a/src/Storages/MergeTree/checkDataPart.h
+++ b/src/Storages/MergeTree/checkDataPart.h
@@ -17,4 +17,8 @@ IMergeTreeDataPart::Checksums checkDataPart(
 bool isNotEnoughMemoryErrorCode(int code);
 bool isRetryableException(std::exception_ptr exception_ptr);
 
+/// True for an object store answering "this object does not exist" (S3 NoSuchKey, Azure HTTP 404).
+/// Disjoint from isRetryableException: both providers classify not-found as non-retryable.
+bool isObjectStorageNotFoundException(std::exception_ptr exception_ptr);
+
 }

--- a/tests/integration/test_merge_tree_azure_blob_storage/test.py
+++ b/tests/integration/test_merge_tree_azure_blob_storage/test.py
@@ -763,6 +763,9 @@ def get_azure_client(container_name, port):
     return blob_service_client.get_container_client(container_name)
 
 
+BROKEN_PART_ERROR = "is broken and needs manual correction"
+
+
 def test_azure_broken_parts(cluster):
     node = cluster.instances[NODE_NAME]
     account_name = "devstoreaccount1"
@@ -810,6 +813,10 @@ def test_azure_broken_parts(cluster):
     client = get_azure_client(container_name, port)
     client.delete_blob(remote_path)
 
+    try_0_before = int(node.count_in_log("at try 0 with retryable error"))
+    try_1_before = int(node.count_in_log("at try 1 with retryable error"))
+    broken_before = int(node.count_in_log(BROKEN_PART_ERROR))
+
     azure_query(node, "DETACH TABLE t_azure_broken_parts")
     azure_query(node, "ATTACH TABLE t_azure_broken_parts")
 
@@ -822,3 +829,10 @@ def test_azure_broken_parts(cluster):
     ).strip()
 
     assert int(result) == 1
+
+    # A deleted blob answers 404, so both attempts before the part is given up on are
+    # absorbed and logged; these deltas fail if the Azure not-found arm stops matching.
+    # The part is reported through the detach path only, not as needing correction.
+    assert int(node.count_in_log("at try 0 with retryable error")) > try_0_before
+    assert int(node.count_in_log("at try 1 with retryable error")) > try_1_before
+    assert int(node.count_in_log(BROKEN_PART_ERROR)) == broken_before

--- a/tests/integration/test_merge_tree_s3_failover/s3_endpoint/endpoint.py
+++ b/tests/integration/test_merge_tree_s3_failover/s3_endpoint/endpoint.py
@@ -17,9 +17,16 @@ def fail_request(_request_number, _method=None):
     if request_number > 0:
         cache["request_number"] = request_number
         cache["fail_method"] = _method.upper() if _method else None
+        # Optional query parameters; the defaults reproduce a single 500 ExpectedError.
+        cache["fail_status"] = int(request.query.get("status") or 500)
+        cache["fail_code"] = request.query.get("code") or "ExpectedError"
+        cache["fail_repeat"] = int(request.query.get("repeat") or 1)
     else:
         cache.pop("request_number", None)
         cache.pop("fail_method", None)
+        cache.pop("fail_status", None)
+        cache.pop("fail_code", None)
+        cache.pop("fail_repeat", None)
     return "OK"
 
 
@@ -61,10 +68,20 @@ def server(_bucket, _path):
             if request_number > 0:
                 cache["request_number"] = request_number
             else:
-                cache.pop("fail_method", None)
-                response.status = 500
+                # Once the counter reaches the target request, fail it `repeat` times in a
+                # row (repeat=1 clears the fault immediately, as it always did).
+                repeat = cache.get("fail_repeat", 1) - 1
+                if repeat > 0:
+                    cache["request_number"] = 1
+                    cache["fail_repeat"] = repeat
+                else:
+                    cache.pop("fail_method", None)
+                    cache.pop("fail_repeat", None)
+                response.status = cache.get("fail_status", 500)
                 response.content_type = "text/xml"
-                return '<?xml version="1.0" encoding="UTF-8"?><Error><Code>ExpectedError</Code><Message>Expected Error</Message><RequestId>txfbd566d03042474888193-00608d7537</RequestId></Error>'
+                return '<?xml version="1.0" encoding="UTF-8"?><Error><Code>{}</Code><Message>Expected Error</Message><RequestId>txfbd566d03042474888193-00608d7537</RequestId></Error>'.format(
+                    cache.get("fail_code", "ExpectedError")
+                )
 
         if cache.get("throttle_request_number", None):
             request_number = cache.pop("throttle_request_number") - 1

--- a/tests/integration/test_merge_tree_s3_failover/test.py
+++ b/tests/integration/test_merge_tree_s3_failover/test.py
@@ -338,6 +338,9 @@ def test_retry_loading_parts(cluster):
     node.query("DROP TABLE s3_retry_loading_parts")
 
 
+BROKEN_PART_ERROR = "is broken and needs manual correction"
+
+
 def create_not_found_table(node, name):
     node.query(
         """
@@ -359,8 +362,9 @@ def detached_parts(node, name):
     ).strip()
 
 
-# A transient not-found must not cost the part: the object is still there, so the load is
-# retried and the part comes back intact.
+# A transient not-found must not cost the part: the object is still there, so the load
+# is retried and the part comes back intact. A part that attaches is not broken, so the
+# absorbed attempt must not report it as needing manual correction either.
 def test_transient_not_found_at_part_load(cluster):
     node = cluster.instances["node"]
     create_not_found_table(node, "s3_transient_not_found")
@@ -368,6 +372,7 @@ def test_transient_not_found_at_part_load(cluster):
     node.query("DETACH TABLE s3_transient_not_found")
 
     retries_before = int(node.count_in_log("at try 0 with retryable error"))
+    broken_before = int(node.count_in_log(BROKEN_PART_ERROR))
     fail_request(cluster, 5, "GET", status=404, code="NoSuchKey")
     node.query("ATTACH TABLE s3_transient_not_found")
     fail_request(cluster, 0)
@@ -375,6 +380,7 @@ def test_transient_not_found_at_part_load(cluster):
     assert node.query("SELECT count() FROM s3_transient_not_found") == "1\n"
     assert detached_parts(node, "s3_transient_not_found") == "0"
     assert int(node.count_in_log("at try 0 with retryable error")) > retries_before
+    assert int(node.count_in_log(BROKEN_PART_ERROR)) == broken_before
 
     node.query("DROP TABLE s3_transient_not_found")
 

--- a/tests/integration/test_merge_tree_s3_failover/test.py
+++ b/tests/integration/test_merge_tree_s3_failover/test.py
@@ -396,26 +396,31 @@ def test_no_fault_at_part_load(cluster):
 
 
 # Control: a not-found that outlives the retry budget is treated as genuine absence and
-# still detaches the part, exactly as before. Same outcome with and without the fix, so
-# this arm cannot fail on the buggy build - it guards the bound on the new retry.
+# still detaches the part, exactly as before. The retry-log deltas assert that the budget was
+# really exhausted (two absorbed attempts before the final one settles the outcome), so the
+# test also fails if the implementation gave up early.
 def test_persistent_not_found_at_part_load(cluster):
     node = cluster.instances["node"]
     create_not_found_table(node, "s3_persistent_not_found")
 
     node.query("DETACH TABLE s3_persistent_not_found")
 
+    try_0_before = int(node.count_in_log("at try 0 with retryable error"))
+    try_1_before = int(node.count_in_log("at try 1 with retryable error"))
     fail_request(cluster, 5, "GET", status=404, code="NoSuchKey", repeat=3)
     node.query("ATTACH TABLE s3_persistent_not_found")
     fail_request(cluster, 0)
 
     assert node.query("SELECT count() FROM s3_persistent_not_found") == "0\n"
     assert detached_parts(node, "s3_persistent_not_found") == "1"
+    assert int(node.count_in_log("at try 0 with retryable error")) > try_0_before
+    assert int(node.count_in_log("at try 1 with retryable error")) > try_1_before
 
     node.query("DROP TABLE s3_persistent_not_found")
 
 
-# Control: a corrupt part is still detached - the new retry is scoped to not-found and did
-# not widen to every load failure.
+# Control: a corrupt part is still detached with zero absorbed retries - the new retry is
+# scoped to not-found and did not widen to every load failure.
 def test_corrupted_part_still_detached(cluster):
     node = cluster.instances["node"]
     create_not_found_table(node, "s3_corrupted_part")
@@ -433,9 +438,11 @@ def test_corrupted_part_still_detached(cluster):
     cluster.minio_client.put_object(
         cluster.minio_bucket, remote_path, io.BytesIO(garbage), len(garbage)
     )
+    retries_before = int(node.count_in_log("at try 0 with retryable error"))
     node.query("ATTACH TABLE s3_corrupted_part")
 
     assert node.query("SELECT count() FROM s3_corrupted_part") == "0\n"
     assert detached_parts(node, "s3_corrupted_part") == "1"
+    assert int(node.count_in_log("at try 0 with retryable error")) == retries_before
 
     node.query("DROP TABLE s3_corrupted_part")

--- a/tests/integration/test_merge_tree_s3_failover/test.py
+++ b/tests/integration/test_merge_tree_s3_failover/test.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import os
 import time
@@ -41,10 +42,19 @@ def run_endpoint(cluster):
     logging.info("S3 endpoint started")
 
 
-def fail_request(cluster, request, method=None):
+def fail_request(cluster, request, method=None, status=None, code=None, repeat=None):
     url = "http://resolver:8080/fail_request/{}".format(request)
     if method:
         url += "/{}".format(method)
+    params = []
+    if status is not None:
+        params.append("status={}".format(status))
+    if code is not None:
+        params.append("code={}".format(code))
+    if repeat is not None:
+        params.append("repeat={}".format(repeat))
+    if params:
+        url += "?" + "&".join(params)
     response = cluster.exec_in_container(
         cluster.get_container_id("resolver"),
         ["curl", "-s", url],
@@ -326,3 +336,106 @@ def test_retry_loading_parts(cluster):
     )
     assert node.query("SELECT * FROM s3_retry_loading_parts") == "42\n"
     node.query("DROP TABLE s3_retry_loading_parts")
+
+
+def create_not_found_table(node, name):
+    node.query(
+        """
+        CREATE TABLE {} (id Int64) ENGINE=MergeTree() ORDER BY id
+        SETTINGS storage_policy='s3_no_retries'
+        """.format(
+            name
+        )
+    )
+    node.query("INSERT INTO {} VALUES (42)".format(name))
+    assert node.query("SELECT count() FROM {}".format(name)) == "1\n"
+
+
+def detached_parts(node, name):
+    return node.query(
+        "SELECT count() FROM system.detached_parts WHERE table = '{}' AND reason = 'broken-on-start'".format(
+            name
+        )
+    ).strip()
+
+
+# A transient not-found must not cost the part: the object is still there, so the load is
+# retried and the part comes back intact.
+def test_transient_not_found_at_part_load(cluster):
+    node = cluster.instances["node"]
+    create_not_found_table(node, "s3_transient_not_found")
+
+    node.query("DETACH TABLE s3_transient_not_found")
+
+    retries_before = int(node.count_in_log("at try 0 with retryable error"))
+    fail_request(cluster, 5, "GET", status=404, code="NoSuchKey")
+    node.query("ATTACH TABLE s3_transient_not_found")
+    fail_request(cluster, 0)
+
+    assert node.query("SELECT count() FROM s3_transient_not_found") == "1\n"
+    assert detached_parts(node, "s3_transient_not_found") == "0"
+    assert int(node.count_in_log("at try 0 with retryable error")) > retries_before
+
+    node.query("DROP TABLE s3_transient_not_found")
+
+
+# Control: without a fault nothing is retried and nothing is detached.
+def test_no_fault_at_part_load(cluster):
+    node = cluster.instances["node"]
+    create_not_found_table(node, "s3_no_fault_load")
+
+    retries_before = int(node.count_in_log("at try 0 with retryable error"))
+    node.query("DETACH TABLE s3_no_fault_load")
+    node.query("ATTACH TABLE s3_no_fault_load")
+
+    assert node.query("SELECT count() FROM s3_no_fault_load") == "1\n"
+    assert detached_parts(node, "s3_no_fault_load") == "0"
+    assert int(node.count_in_log("at try 0 with retryable error")) == retries_before
+
+    node.query("DROP TABLE s3_no_fault_load")
+
+
+# Control: a not-found that outlives the retry budget is treated as genuine absence and
+# still detaches the part, exactly as before. Same outcome with and without the fix, so
+# this arm cannot fail on the buggy build - it guards the bound on the new retry.
+def test_persistent_not_found_at_part_load(cluster):
+    node = cluster.instances["node"]
+    create_not_found_table(node, "s3_persistent_not_found")
+
+    node.query("DETACH TABLE s3_persistent_not_found")
+
+    fail_request(cluster, 5, "GET", status=404, code="NoSuchKey", repeat=3)
+    node.query("ATTACH TABLE s3_persistent_not_found")
+    fail_request(cluster, 0)
+
+    assert node.query("SELECT count() FROM s3_persistent_not_found") == "0\n"
+    assert detached_parts(node, "s3_persistent_not_found") == "1"
+
+    node.query("DROP TABLE s3_persistent_not_found")
+
+
+# Control: a corrupt part is still detached - the new retry is scoped to not-found and did
+# not widen to every load failure.
+def test_corrupted_part_still_detached(cluster):
+    node = cluster.instances["node"]
+    create_not_found_table(node, "s3_corrupted_part")
+
+    data_path = node.query(
+        "SELECT data_paths[1] FROM system.tables WHERE name = 's3_corrupted_part'"
+    ).strip()
+    remote_path = node.query(
+        "SELECT remote_path FROM system.remote_data_paths "
+        "WHERE path || local_path = '{}' || 'all_1_1_0/checksums.txt'".format(data_path)
+    ).strip()
+
+    node.query("DETACH TABLE s3_corrupted_part")
+    garbage = b"garbage"
+    cluster.minio_client.put_object(
+        cluster.minio_bucket, remote_path, io.BytesIO(garbage), len(garbage)
+    )
+    node.query("ATTACH TABLE s3_corrupted_part")
+
+    assert node.query("SELECT count() FROM s3_corrupted_part") == "0\n"
+    assert detached_parts(node, "s3_corrupted_part") == "1"
+
+    node.query("DROP TABLE s3_corrupted_part")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/110724
Related: https://github.com/ClickHouse/ClickHouse/issues/114023
Related: https://github.com/ClickHouse/ClickHouse/pull/109021
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/110724
Related: https://github.com/ClickHouse/ClickHouse/issues/114023
Related: https://github.com/ClickHouse/ClickHouse/pull/109021

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes data loss where a data part on object storage is permanently detached as `broken-on-start` because the object store momentarily answers "not found" (S3 `NoSuchKey`, Azure HTTP 404) while the part is loading. Such a not-found is now retried within the existing part loading budget, so a transient one no longer costs the part. One that persists is still detached, as before.


### Description

No issue reports this. I found it by inspection and reproduced it with a fault-injecting fixture. The linked issues are the same misclassification elsewhere; this fixes neither.

What breaks: a `MergeTree` on object storage with one committed part, restarted while the store answers a single 404 for it.

```
SELECT count() FROM t;                                        -- 1 before, 0 after
SELECT count() FROM system.detached_parts WHERE table = 't';   -- 1, reason broken-on-start
```

The object is intact and a further restart does not bring the rows back. `test_transient_not_found_at_part_load` covers it: fails on master, passes here.

Cause: `loadDataPart` marks a part broken for any error `isRetryableException` does not recognise, and a not-found is deliberately non-retryable there (`NO_SUCH_KEY` is in `unretryable_errors`; Azure retries only transport errors and 5xx). So the part gets one attempt, and `loadDataPartWithRetries` never engages because `loadDataPart` returns `is_broken`. One broken part does not reach `max_suspicious_broken_parts = 100`, so it detaches at once; under zero-copy replication `GET_PART` has no other copy.

A not-found on the active loading path is now rethrown while attempts remain, so the existing budget (3 tries, 100 ms to 5 s) retries it; on the last attempt it detaches as before. Later phases keep their loud failure.

Scoped deliberately:

- `src/IO/S3Common.cpp` is untouched: every S3 caller reads that set, including existence probes where 404 is correct, which is why #109021 kept it.
- `NO_SUCH_BUCKET` and a missing Azure container are excluded as whole-storage conditions; only the `Active` load retries.
- `loadColumnsChecksumsIndexes` no longer logs "needs manual correction" for a not-found: it asks the operator to act while saying nothing about the contents. A part given up on still logs its reason and detach.
- Not addressed: `loadUnexpectedDataPart` (#107091), `loadPartRestoredFromBackup` (own retry loop), `loadProjections` (degradation, not loss).

Controls cover no fault, a persistent not-found and a corrupt part.
