### PR TITLE
Map wire-controlled checks in SerializationReplicated to INCORRECT_DATA

### DIFF
--- a/src/DataTypes/Serializations/SerializationReplicated.cpp
+++ b/src/DataTypes/Serializations/SerializationReplicated.cpp
@@ -231,7 +231,7 @@ void SerializationReplicated::deserializeBinaryBulkWithMultipleStreams(
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected value of rows_offset in Native format: {}. Expected 0", rows_offset);
 
     if (!column->empty())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Reading into non-empty column ColumnReplicated is not supported in Native format");
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Reading into non-empty column ColumnReplicated is not supported in Native format");
 
     auto mutable_column = column->assumeMutable();
     auto & column_replicated = assert_cast<ColumnReplicated &>(*mutable_column);
@@ -247,7 +247,7 @@ void SerializationReplicated::deserializeBinaryBulkWithMultipleStreams(
     readVarUInt(num_rows, *indexes_stream);
     /// In Native format we always read the whole serialized column.
     if (num_rows != limit)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected number of rows in indexes column in ColumnReplicated in Native format: {}. Expected {}", num_rows, limit);
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Unexpected number of rows in indexes column in ColumnReplicated in Native format: {}. Expected {}", num_rows, limit);
 
     UInt8 size_of_indexes_type = 0;
     readBinary(size_of_indexes_type, *indexes_stream);
@@ -273,7 +273,7 @@ void SerializationReplicated::deserializeBinaryBulkWithMultipleStreams(
             SerializationNumber<UInt64>::create()->deserializeBinaryBulk(*indexes, *indexes_stream, 0, limit, 0);
             break;
         default:
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected size of index type for ColumnReplicated: {}", UInt32(size_of_indexes_type));
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Unexpected size of index type for ColumnReplicated: {}", UInt32(size_of_indexes_type));
     }
 
     settings.path.push_back(Substream::ReplicatedElements);

--- a/tests/queries/0_stateless/04616_replicated_serialization_oob_index_native_protocol.python
+++ b/tests/queries/0_stateless/04616_replicated_serialization_oob_index_native_protocol.python
@@ -368,9 +368,122 @@ def truncatedElementsScenario():
         print("truncated elements: caught expected exception INCORRECT_DATA")
 
 
+def sendReplicatedBlockWithInvalidIndexTypeSize(s):
+    # The index type width is read straight off the wire; an unsupported value must be
+    # rejected with INCORRECT_DATA instead of hitting the switch's LOGICAL_ERROR default.
+    limit = 4
+
+    ba = bytearray()
+    writeVarUInt(2, ba)  # Data
+    writeStringBinary("", ba)  # table name
+    serializeBlockInfo(ba)
+    writeVarUInt(1, ba)  # columns
+    writeVarUInt(limit, ba)  # rows
+    writeStringBinary("x", ba)
+    writeStringBinary("UInt64", ba)
+    ba.append(1)  # has_custom serialization
+    ba.append(4)  # KindStackBinarySerializationType::REPLICATED
+
+    # ReplicatedIndexes substream: correct row count, but an unsupported index type width.
+    writeVarUInt(limit, ba)
+    ba.append(3)  # size_of_index_type = 3 -- not one of sizeof(UInt8/16/32/64)
+
+    s.sendall(ba)
+    s.shutdown(socket.SHUT_WR)
+
+
+def invalidIndexTypeSizeScenario():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(30)
+        s.connect((CLICKHOUSE_HOST, CLICKHOUSE_PORT))
+        connectAndStartInsert(s)
+        sendReplicatedBlockWithInvalidIndexTypeSize(s)
+        expectIncorrectData(s, "Unexpected size of index type")
+        print("invalid index type size: caught expected exception INCORRECT_DATA")
+
+
+def sendReplicatedBlockWithIndexRowCountMismatch(s):
+    # The index row count is read straight off the wire; a value that disagrees with the
+    # block row count must be rejected with INCORRECT_DATA, not LOGICAL_ERROR.
+    limit = 4
+
+    ba = bytearray()
+    writeVarUInt(2, ba)  # Data
+    writeStringBinary("", ba)  # table name
+    serializeBlockInfo(ba)
+    writeVarUInt(1, ba)  # columns
+    writeVarUInt(limit, ba)  # rows
+    writeStringBinary("x", ba)
+    writeStringBinary("UInt64", ba)
+    ba.append(1)  # has_custom serialization
+    ba.append(4)  # KindStackBinarySerializationType::REPLICATED
+
+    # ReplicatedIndexes substream: advertise a row count that disagrees with the block.
+    writeVarUInt(limit + 1, ba)
+
+    s.sendall(ba)
+    s.shutdown(socket.SHUT_WR)
+
+
+def indexRowCountMismatchScenario():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(30)
+        s.connect((CLICKHOUSE_HOST, CLICKHOUSE_PORT))
+        connectAndStartInsert(s)
+        sendReplicatedBlockWithIndexRowCountMismatch(s)
+        expectIncorrectData(s, "Unexpected number of rows in indexes column")
+        print("index row count mismatch: caught expected exception INCORRECT_DATA")
+
+
+def sendSparseOverReplicatedBlock(s):
+    # A Sparse-over-Replicated kind stack makes SerializationSparse hand its values column
+    # (a fresh ColumnSparse always seeds one default value) to the nested Replicated
+    # deserialization, which then hits the "non-empty column" check. That check is decided
+    # by the wire-supplied kind stack and must be INCORRECT_DATA, not LOGICAL_ERROR.
+    END_OF_GRANULE_FLAG = 1 << 62
+    limit = 4
+
+    ba = bytearray()
+    writeVarUInt(2, ba)  # Data
+    writeStringBinary("", ba)  # table name
+    serializeBlockInfo(ba)
+    writeVarUInt(1, ba)  # columns
+    writeVarUInt(limit, ba)  # rows
+    writeStringBinary("x", ba)
+    writeStringBinary("UInt64", ba)
+    ba.append(1)  # has_custom serialization
+    # KindStackBinarySerializationType::COMBINATION: {Default, Replicated, Sparse}, which
+    # wraps as Sparse(Replicated(UInt64)) so Sparse is the outer serialization.
+    ba.append(5)  # COMBINATION
+    writeVarUInt(3, ba)  # number of kinds
+    ba.append(0)  # Kind::DEFAULT
+    ba.append(3)  # Kind::REPLICATED
+    ba.append(1)  # Kind::SPARSE
+
+    # SparseOffsets substream: a single end-of-granule group covering all rows with no
+    # non-default values, so offset reading returns cleanly before Replicated is invoked.
+    writeVarUInt(limit | END_OF_GRANULE_FLAG, ba)
+
+    s.sendall(ba)
+    s.shutdown(socket.SHUT_WR)
+
+
+def sparseOverReplicatedScenario():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(30)
+        s.connect((CLICKHOUSE_HOST, CLICKHOUSE_PORT))
+        connectAndStartInsert(s)
+        sendSparseOverReplicatedBlock(s)
+        expectIncorrectData(s, "Reading into non-empty column ColumnReplicated")
+        print("sparse over replicated: caught expected exception INCORRECT_DATA")
+
+
 def main():
     outOfBoundsIndexScenario()
     truncatedElementsScenario()
+    invalidIndexTypeSizeScenario()
+    indexRowCountMismatchScenario()
+    sparseOverReplicatedScenario()
 
 
 if __name__ == "__main__":

--- a/tests/queries/0_stateless/04616_replicated_serialization_oob_index_native_protocol.reference
+++ b/tests/queries/0_stateless/04616_replicated_serialization_oob_index_native_protocol.reference
@@ -1,3 +1,6 @@
 out-of-bounds index: caught expected exception INCORRECT_DATA
 truncated elements: caught expected exception INCORRECT_DATA
+invalid index type size: caught expected exception INCORRECT_DATA
+index row count mismatch: caught expected exception INCORRECT_DATA
+sparse over replicated: caught expected exception INCORRECT_DATA
 server alive	0


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/113997
Related: https://github.com/ClickHouse/ClickHouse/pull/112331

`SerializationReplicated::deserializeBinaryBulkWithMultipleStreams` had three sibling checks that still threw `LOGICAL_ERROR` for conditions decided purely by untrusted native-protocol bytes:

- a non-empty target column, reachable via a `Sparse`-over-`Replicated` kind stack (a fresh `ColumnSparse` always seeds one default value, which is then handed to the nested `Replicated` deserialization);
- an index row count that disagrees with the block row count;
- an unsupported index-type width.

In debug and sanitizer builds `LOGICAL_ERROR` is routed to `abortOnFailedAssertion`, so a crafted block sent by any authenticated client aborts the server; in release builds it is the wrong error class and trips CI checks that scan logs for `Logical error`.

This changes all three to `INCORRECT_DATA`, matching the checks added in #112331 and the analogous `SerializationLowCardinality` code. The native-protocol regression test `04616_replicated_serialization_oob_index_native_protocol` is extended with the three scenarios (invalid index type width, index row count mismatch, `Sparse`-over-`Replicated`), each asserting error code `117` and that the server stays alive. Verified against a Debug build.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the error code reported for some malformed `Replicated`-serialized columns received over the Native protocol: these are now rejected with `INCORRECT_DATA` instead of `LOGICAL_ERROR` (which aborted the server in debug and sanitizer builds).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1364` (included in `26.8` and later)
<!-- ch-version-info:end -->