### PR TITLE
Introduce `wmt::` Namespace with Aliases to `*WithMemoryTracking` Containers

### DIFF
--- a/src/Common/DequeWithMemoryTracking.h
+++ b/src/Common/DequeWithMemoryTracking.h
@@ -21,4 +21,12 @@ namespace DB
 template <typename T>
 using DequeWithMemoryTracking = std::deque<T, AllocatorWithMemoryTracking<T>>;
 
+namespace wmt
+{
+
+template <typename T>
+using deque = std::deque<T, AllocatorWithMemoryTracking<T>>;
+
+}
+
 }

--- a/src/Common/DequeWithMemoryTracking.h
+++ b/src/Common/DequeWithMemoryTracking.h
@@ -25,7 +25,7 @@ namespace wmt
 {
 
 template <typename T>
-using deque = std::deque<T, AllocatorWithMemoryTracking<T>>;
+using deque = DequeWithMemoryTracking<T>;
 
 }
 

--- a/src/Common/ListWithMemoryTracking.h
+++ b/src/Common/ListWithMemoryTracking.h
@@ -25,7 +25,7 @@ namespace wmt
 {
 
 template <typename T>
-using list = std::list<T, AllocatorWithMemoryTracking<T>>;
+using list = ListWithMemoryTracking<T>;
 
 }
 

--- a/src/Common/ListWithMemoryTracking.h
+++ b/src/Common/ListWithMemoryTracking.h
@@ -21,4 +21,12 @@ namespace DB
 template <typename T>
 using ListWithMemoryTracking = std::list<T, AllocatorWithMemoryTracking<T>>;
 
+namespace wmt
+{
+
+template <typename T>
+using list = std::list<T, AllocatorWithMemoryTracking<T>>;
+
+}
+
 }

--- a/src/Common/MapWithMemoryTracking.h
+++ b/src/Common/MapWithMemoryTracking.h
@@ -24,4 +24,15 @@ using MapWithMemoryTracking = std::map<K, V, Compare, AllocatorWithMemoryTrackin
 template <typename K, typename V, typename Compare = std::less<K>>
 using MultiMapWithMemoryTracking = std::multimap<K, V, Compare, AllocatorWithMemoryTracking<std::pair<const K, V>>>;
 
+namespace wmt
+{
+
+template <typename K, typename V, typename Compare = std::less<K>>
+using map = std::map<K, V, Compare, AllocatorWithMemoryTracking<std::pair<const K, V>>>;
+
+template <typename K, typename V, typename Compare = std::less<K>>
+using multimap = std::multimap<K, V, Compare, AllocatorWithMemoryTracking<std::pair<const K, V>>>;
+
+}
+
 }

--- a/src/Common/MapWithMemoryTracking.h
+++ b/src/Common/MapWithMemoryTracking.h
@@ -28,10 +28,10 @@ namespace wmt
 {
 
 template <typename K, typename V, typename Compare = std::less<K>>
-using map = std::map<K, V, Compare, AllocatorWithMemoryTracking<std::pair<const K, V>>>;
+using map = MapWithMemoryTracking<K, V, Compare>;
 
 template <typename K, typename V, typename Compare = std::less<K>>
-using multimap = std::multimap<K, V, Compare, AllocatorWithMemoryTracking<std::pair<const K, V>>>;
+using multimap = MultiMapWithMemoryTracking<K, V, Compare>;
 
 }
 

--- a/src/Common/QueueWithMemoryTracking.h
+++ b/src/Common/QueueWithMemoryTracking.h
@@ -21,4 +21,12 @@ namespace DB
 template <typename T>
 using QueueWithMemoryTracking = std::queue<T, DequeWithMemoryTracking<T>>;
 
+namespace wmt
+{
+
+template <typename T>
+using queue = std::queue<T, deque<T>>;
+
+}
+
 }

--- a/src/Common/QueueWithMemoryTracking.h
+++ b/src/Common/QueueWithMemoryTracking.h
@@ -25,7 +25,7 @@ namespace wmt
 {
 
 template <typename T>
-using queue = std::queue<T, deque<T>>;
+using queue = QueueWithMemoryTracking<T>;
 
 }
 

--- a/src/Common/SetWithMemoryTracking.h
+++ b/src/Common/SetWithMemoryTracking.h
@@ -24,4 +24,15 @@ using SetWithMemoryTracking = std::set<K, Compare, AllocatorWithMemoryTracking<K
 template <typename K, typename Compare = std::less<K>>
 using MultiSetWithMemoryTracking = std::multiset<K, Compare, AllocatorWithMemoryTracking<K>>;
 
+namespace wmt
+{
+
+template <typename K, typename Compare = std::less<K>>
+using set = std::set<K, Compare, AllocatorWithMemoryTracking<K>>;
+
+template <typename K, typename Compare = std::less<K>>
+using multiset = std::multiset<K, Compare, AllocatorWithMemoryTracking<K>>;
+
+}
+
 }

--- a/src/Common/SetWithMemoryTracking.h
+++ b/src/Common/SetWithMemoryTracking.h
@@ -28,10 +28,10 @@ namespace wmt
 {
 
 template <typename K, typename Compare = std::less<K>>
-using set = std::set<K, Compare, AllocatorWithMemoryTracking<K>>;
+using set = SetWithMemoryTracking<K, Compare>;
 
 template <typename K, typename Compare = std::less<K>>
-using multiset = std::multiset<K, Compare, AllocatorWithMemoryTracking<K>>;
+using multiset = MultiSetWithMemoryTracking<K, Compare>;
 
 }
 

--- a/src/Common/StringWithMemoryTracking.h
+++ b/src/Common/StringWithMemoryTracking.h
@@ -10,3 +10,10 @@ class StringWithMemoryTracking : public std::basic_string<char, std::char_traits
 {
     using std::basic_string<char, std::char_traits<char>, AllocatorWithMemoryTracking<char>>::basic_string;
 };
+
+namespace DB::wmt
+{
+
+using string = StringWithMemoryTracking;
+
+}

--- a/src/Common/StringWithMemoryTracking.h
+++ b/src/Common/StringWithMemoryTracking.h
@@ -4,6 +4,9 @@
 
 #include <string>
 
+namespace DB
+{
+
 /// String that can throw MEMORY_LIMIT_EXCEEDED
 /// Use it when the string may require significant memory.
 class StringWithMemoryTracking : public std::basic_string<char, std::char_traits<char>, AllocatorWithMemoryTracking<char>>
@@ -11,9 +14,11 @@ class StringWithMemoryTracking : public std::basic_string<char, std::char_traits
     using std::basic_string<char, std::char_traits<char>, AllocatorWithMemoryTracking<char>>::basic_string;
 };
 
-namespace DB::wmt
+namespace wmt
 {
 
 using string = StringWithMemoryTracking;
+
+}
 
 }

--- a/src/Common/UnorderedMapWithMemoryTracking.h
+++ b/src/Common/UnorderedMapWithMemoryTracking.h
@@ -29,10 +29,10 @@ namespace wmt
 {
 
 template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>>
-using unordered_map = std::unordered_map<K, V, Hash, KeyEqual, AllocatorWithMemoryTracking<std::pair<const K, V>>>;
+using unordered_map = UnorderedMapWithMemoryTracking<K, V, Hash, KeyEqual>;
 
 template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>>
-using unordered_multimap = std::unordered_multimap<K, V, Hash, KeyEqual, AllocatorWithMemoryTracking<std::pair<const K, V>>>;
+using unordered_multimap = UnorderedMultiMapWithMemoryTracking<K, V, Hash, KeyEqual>;
 
 }
 

--- a/src/Common/UnorderedMapWithMemoryTracking.h
+++ b/src/Common/UnorderedMapWithMemoryTracking.h
@@ -25,4 +25,15 @@ template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqua
 using UnorderedMultiMapWithMemoryTracking
     = std::unordered_multimap<K, V, Hash, KeyEqual, AllocatorWithMemoryTracking<std::pair<const K, V>>>;
 
+namespace wmt
+{
+
+template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>>
+using unordered_map = std::unordered_map<K, V, Hash, KeyEqual, AllocatorWithMemoryTracking<std::pair<const K, V>>>;
+
+template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>>
+using unordered_multimap = std::unordered_multimap<K, V, Hash, KeyEqual, AllocatorWithMemoryTracking<std::pair<const K, V>>>;
+
+}
+
 }

--- a/src/Common/UnorderedSetWithMemoryTracking.h
+++ b/src/Common/UnorderedSetWithMemoryTracking.h
@@ -23,4 +23,16 @@ using UnorderedSetWithMemoryTracking = std::unordered_set<K, Hash, KeyEqual, All
 
 template <typename K, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>>
 using UnorderedMultiSetWithMemoryTracking = std::unordered_multiset<K, Hash, KeyEqual, AllocatorWithMemoryTracking<K>>;
+
+namespace wmt
+{
+
+template <typename K, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>>
+using unordered_set = std::unordered_set<K, Hash, KeyEqual, AllocatorWithMemoryTracking<K>>;
+
+template <typename K, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>>
+using unordered_multiset = std::unordered_multiset<K, Hash, KeyEqual, AllocatorWithMemoryTracking<K>>;
+
+}
+
 }

--- a/src/Common/UnorderedSetWithMemoryTracking.h
+++ b/src/Common/UnorderedSetWithMemoryTracking.h
@@ -28,10 +28,10 @@ namespace wmt
 {
 
 template <typename K, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>>
-using unordered_set = std::unordered_set<K, Hash, KeyEqual, AllocatorWithMemoryTracking<K>>;
+using unordered_set = UnorderedSetWithMemoryTracking<K, Hash, KeyEqual>;
 
 template <typename K, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>>
-using unordered_multiset = std::unordered_multiset<K, Hash, KeyEqual, AllocatorWithMemoryTracking<K>>;
+using unordered_multiset = UnorderedMultiSetWithMemoryTracking<K, Hash, KeyEqual>;
 
 }
 

--- a/src/Common/VectorWithMemoryTracking.h
+++ b/src/Common/VectorWithMemoryTracking.h
@@ -25,7 +25,7 @@ namespace wmt
 {
 
 template <typename T>
-using vector = std::vector<T, AllocatorWithMemoryTracking<T>>;
+using vector = VectorWithMemoryTracking<T>;
 
 }
 

--- a/src/Common/VectorWithMemoryTracking.h
+++ b/src/Common/VectorWithMemoryTracking.h
@@ -21,4 +21,12 @@ namespace DB
 template <typename T>
 using VectorWithMemoryTracking = std::vector<T, AllocatorWithMemoryTracking<T>>;
 
+namespace wmt
+{
+
+template <typename T>
+using vector = std::vector<T, AllocatorWithMemoryTracking<T>>;
+
+}
+
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

This patch adds a bunch of aliases to `WithMemoryTracking` containers. Aliases have the form `wmt::vector<T>`.
