### PR TITLE
Use higher quality hash for nullable fixed-width keys in external aggregation

### DIFF
--- a/src/Interpreters/AggregatedData.h
+++ b/src/Interpreters/AggregatedData.h
@@ -127,6 +127,8 @@ using AggregatedDataWithNullableUInt32Key = AggregationDataWithNullKey<Aggregate
 
 
 using AggregatedDataWithNullableUInt64Key = AggregationDataWithNullKey<AggregatedDataWithUInt64Key>;
+/// The better-hash counterpart, for the external-aggregation merge (see the `*Hash64` block above).
+using AggregatedDataWithNullableUInt64KeyHash64 = AggregationDataWithNullKey<AggregatedDataWithUInt64KeyHash64>;
 using AggregatedDataWithNullableStringKey = AggregationDataWithNullKey<AggregatedDataWithStringKey>;
 using AggregatedDataWithNullableShortStringKey = AggregationDataWithNullKey<AggregatedDataWithShortStringKey>;
 

--- a/src/Interpreters/AggregatedDataVariants.h
+++ b/src/Interpreters/AggregatedDataVariants.h
@@ -100,6 +100,12 @@ struct AggregatedDataVariants : private boost::noncopyable
     std::unique_ptr<AggregationMethodNullableSerialized<AggregatedDataWithStringKeyHash64>>          nullable_serialized_hash64;
     std::unique_ptr<AggregationMethodPreallocSerialized<AggregatedDataWithStringKeyHash64>>          prealloc_serialized_hash64;
     std::unique_ptr<AggregationMethodNullablePreallocSerialized<AggregatedDataWithStringKeyHash64>>  nullable_prealloc_serialized_hash64;
+    /// The nullable fixed-width keys need the better hash for the same reason as their non-nullable
+    /// counterparts. The packed forms reuse the plain `*Hash64` data: a nullable packed key carries its null
+    /// map inside the key, so only `has_nullable_keys` differs.
+    std::unique_ptr<AggregationMethodOneNumber<UInt64, AggregatedDataWithNullableUInt64KeyHash64, true, true>> nullable_key64_hash64;
+    std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys128Hash64, true>>       nullable_keys128_hash64;
+    std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys256Hash64, true>>       nullable_keys256_hash64;
 
     /// Support for nullable keys.
     std::unique_ptr<AggregationMethodOneNumber<UInt8, AggregatedDataWithNullableUInt8Key, false, true>>         nullable_key8;
@@ -177,6 +183,9 @@ struct AggregatedDataVariants : private boost::noncopyable
         M(nullable_serialized_hash64,          false) \
         M(prealloc_serialized_hash64,          false) \
         M(nullable_prealloc_serialized_hash64, false) \
+        M(nullable_key64_hash64,      false) \
+        M(nullable_keys128_hash64,    false) \
+        M(nullable_keys256_hash64,    false) \
         M(nullable_key8,             false) \
         M(nullable_key16,             false) \
         M(nullable_key32,             false) \
@@ -249,6 +258,9 @@ struct AggregatedDataVariants : private boost::noncopyable
         M(nullable_serialized_hash64) \
         M(prealloc_serialized_hash64) \
         M(nullable_prealloc_serialized_hash64) \
+        M(nullable_key64_hash64) \
+        M(nullable_keys128_hash64) \
+        M(nullable_keys256_hash64) \
         M(low_cardinality_key8) \
         M(low_cardinality_key16) \
 

--- a/src/Interpreters/AggregationMethod.cpp
+++ b/src/Interpreters/AggregationMethod.cpp
@@ -42,6 +42,7 @@ template struct AggregationMethodOneNumber<UInt8, AggregatedDataWithNullableUInt
 template struct AggregationMethodOneNumber<UInt16, AggregatedDataWithNullableUInt16Key, false, true>;
 template struct AggregationMethodOneNumber<UInt32, AggregatedDataWithNullableUInt32Key, true, true>;
 template struct AggregationMethodOneNumber<UInt64, AggregatedDataWithNullableUInt64Key, true, true>;
+template struct AggregationMethodOneNumber<UInt64, AggregatedDataWithNullableUInt64KeyHash64, true, true>;
 template struct AggregationMethodOneNumber<UInt32, AggregatedDataWithNullableUInt32KeyTwoLevel, true, true>;
 template struct AggregationMethodOneNumber<UInt64, AggregatedDataWithNullableUInt64KeyTwoLevel, true, true>;
 template struct AggregationMethodOneNumber<UInt8, AggregatedDataWithNullableUInt8Key, false>;
@@ -190,6 +191,8 @@ template struct AggregationMethodKeysFixed<AggregatedDataWithKeys128Hash64>;
 template struct AggregationMethodKeysFixed<AggregatedDataWithKeys256Hash64>;
 template struct AggregationMethodKeysFixed<AggregatedDataWithKeys128, true>;
 template struct AggregationMethodKeysFixed<AggregatedDataWithKeys256, true>;
+template struct AggregationMethodKeysFixed<AggregatedDataWithKeys128Hash64, true>;
+template struct AggregationMethodKeysFixed<AggregatedDataWithKeys256Hash64, true>;
 template struct AggregationMethodKeysFixed<AggregatedDataWithKeys128TwoLevel, true>;
 template struct AggregationMethodKeysFixed<AggregatedDataWithKeys256TwoLevel, true>;
 template struct AggregationMethodKeysFixed<AggregatedDataWithKeys128, false, true>;

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -4047,6 +4047,9 @@ Aggregator::AggregatedChunk Aggregator::mergeBlocks(
         M(nullable_serialized)            \
         M(prealloc_serialized)            \
         M(nullable_prealloc_serialized)   \
+        M(nullable_key64)                 \
+        M(nullable_keys128)               \
+        M(nullable_keys256)               \
 
 #define M(NAME) \
     if (merge_method == AggregatedDataVariants::Type::NAME) \

--- a/tests/queries/0_stateless/03023_group_by_use_nulls_analyzer_crashes.reference
+++ b/tests/queries/0_stateless/03023_group_by_use_nulls_analyzer_crashes.reference
@@ -82,9 +82,9 @@ a	a
 2	\N	nan
 0	\N	nan
 1	\N	nan
+\N	4	nan
 \N	2	nan
 \N	0	nan
-\N	4	nan
 \N	\N	nan
 []
 ['.']

--- a/tests/queries/0_stateless/04836_nullable_keys_better_hash_external_merge.reference
+++ b/tests/queries/0_stateless/04836_nullable_keys_better_hash_external_merge.reference
@@ -1,0 +1,8 @@
+nullable_key64
+5000	1	12497497	0	4999
+nullable_keys128
+22000	11	2000	21988923	100000
+nullable_keys256
+22000	11	2000	21988923	100000
+the spilled result matches the in-memory one
+1	1	1

--- a/tests/queries/0_stateless/04836_nullable_keys_better_hash_external_merge.sql
+++ b/tests/queries/0_stateless/04836_nullable_keys_better_hash_external_merge.sql
@@ -1,0 +1,36 @@
+-- External aggregation merges partitions whose combined key count can far exceed 4 billion, so
+-- `mergeBlocks` re-aggregates the spilled stream with a method that hashes over more than 32 bits. The
+-- nullable fixed-width keys take that path too, which re-aggregates them with `nullable_key64_hash64` /
+-- `nullable_keys128_hash64` / `nullable_keys256_hash64`. Those are new instantiations, so check that each
+-- still groups exactly as the in-memory aggregation does - including the NULL group, which for a single
+-- nullable key lives in a slot outside the cells and for the packed keys is folded into the key itself.
+-- The key widths below are what selects each method: a nullable key is packed together with its null map,
+-- so two `UInt32` keys fit in 128 bits while two `UInt64` keys need 256.
+
+SET max_bytes_before_external_group_by = 1;
+SET max_threads = 4;
+SET group_by_two_level_threshold = 100;
+SET collect_hash_table_stats_during_aggregation = 0;
+
+SELECT 'nullable_key64';
+SELECT count(), countIf(k IS NULL), sum(k), min(k), max(k)
+FROM (SELECT nullIf(toUInt64(number % 5000), 3) AS k FROM numbers_mt(200000) GROUP BY k);
+
+SELECT 'nullable_keys128';
+SELECT count(), countIf(a IS NULL), countIf(b IS NULL), sum(a), sum(b)
+FROM (SELECT nullIf(toUInt32(number % 2000), 7) AS a, nullIf(toUInt32(number % 11), 5) AS b
+      FROM numbers_mt(200000) GROUP BY a, b);
+
+SELECT 'nullable_keys256';
+SELECT count(), countIf(a IS NULL), countIf(b IS NULL), sum(a), sum(b)
+FROM (SELECT nullIf(toUInt64(number % 2000), 7) AS a, nullIf(toUInt64(number % 11), 5) AS b
+      FROM numbers_mt(200000) GROUP BY a, b);
+
+SELECT 'the spilled result matches the in-memory one';
+SELECT
+    (SELECT sum(cityHash64(k)) FROM (SELECT nullIf(toUInt64(number % 5000), 3) AS k FROM numbers_mt(200000) GROUP BY k))
+  = (SELECT sum(cityHash64(k)) FROM (SELECT nullIf(toUInt64(number % 5000), 3) AS k FROM numbers_mt(200000) GROUP BY k) SETTINGS max_bytes_before_external_group_by = 0),
+    (SELECT sum(cityHash64(a, b)) FROM (SELECT nullIf(toUInt32(number % 2000), 7) AS a, nullIf(toUInt32(number % 11), 5) AS b FROM numbers_mt(200000) GROUP BY a, b))
+  = (SELECT sum(cityHash64(a, b)) FROM (SELECT nullIf(toUInt32(number % 2000), 7) AS a, nullIf(toUInt32(number % 11), 5) AS b FROM numbers_mt(200000) GROUP BY a, b) SETTINGS max_bytes_before_external_group_by = 0),
+    (SELECT sum(cityHash64(a, b)) FROM (SELECT nullIf(toUInt64(number % 2000), 7) AS a, nullIf(toUInt64(number % 11), 5) AS b FROM numbers_mt(200000) GROUP BY a, b))
+  = (SELECT sum(cityHash64(a, b)) FROM (SELECT nullIf(toUInt64(number % 2000), 7) AS a, nullIf(toUInt64(number % 11), 5) AS b FROM numbers_mt(200000) GROUP BY a, b) SETTINGS max_bytes_before_external_group_by = 0);

--- a/tests/queries/0_stateless/04836_nullable_keys_better_hash_external_merge.sql
+++ b/tests/queries/0_stateless/04836_nullable_keys_better_hash_external_merge.sql
@@ -4,10 +4,6 @@
 -- `nullable_keys128_hash64` / `nullable_keys256_hash64`. Those are new instantiations, so check that each
 -- still groups exactly as the in-memory aggregation does - including the NULL group, which for a single
 -- nullable key lives in a slot outside the cells and for the packed keys is folded into the key itself.
--- The key widths below are what selects each method. Nullable packed keys reserve a null-map bitmap inside
--- the packed key - 2 bytes of the 16 for `keys128`, 4 of the 32 for `keys256` - so only 14 bytes are left
--- for the keys themselves in the 128-bit form: two `UInt32` keys fit, two `UInt64` keys do not and fall to
--- `keys256`.
 
 SET max_bytes_before_external_group_by = 1;
 SET max_threads = 4;

--- a/tests/queries/0_stateless/04836_nullable_keys_better_hash_external_merge.sql
+++ b/tests/queries/0_stateless/04836_nullable_keys_better_hash_external_merge.sql
@@ -4,8 +4,10 @@
 -- `nullable_keys128_hash64` / `nullable_keys256_hash64`. Those are new instantiations, so check that each
 -- still groups exactly as the in-memory aggregation does - including the NULL group, which for a single
 -- nullable key lives in a slot outside the cells and for the packed keys is folded into the key itself.
--- The key widths below are what selects each method: a nullable key is packed together with its null map,
--- so two `UInt32` keys fit in 128 bits while two `UInt64` keys need 256.
+-- The key widths below are what selects each method. Nullable packed keys reserve a null-map bitmap inside
+-- the packed key - 2 bytes of the 16 for `keys128`, 4 of the 32 for `keys256` - so only 14 bytes are left
+-- for the keys themselves in the 128-bit form: two `UInt32` keys fit, two `UInt64` keys do not and fall to
+-- `keys256`.
 
 SET max_bytes_before_external_group_by = 1;
 SET max_threads = 4;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
64-bit hash function is used now for external nullable fixed-width aggregation methods (avoids collision disaster for very high cardinality aggregation).  

---

External aggregation merges partitions whose combined key count can far exceed 4 billion, which is why `mergeBlocks` re-aggregates the spilled stream with a method hashing over more than 32 bits rather than `HashCRC32`. `key64`, `keys128`, `keys256` and the serialized methods all have such a counterpart and are remapped to it; the nullable fixed-width methods never got one, so a `GROUP BY` on a nullable key that spills is still re-aggregated with a 32-bit hash and takes the collision blowup the remap exists to avoid.

Add `nullable_key64_hash64`, `nullable_keys128_hash64` and `nullable_keys256_hash64`, and remap to them. The packed forms need no new data type: a nullable packed key carries its null map inside the key, so they reuse `AggregatedDataWithKeys128Hash64` / `…256Hash64` with `has_nullable_keys`. Only the single nullable key needs one, mirroring how `nullable_key64` wraps the `HashCRC32` map in `AggregationDataWithNullKey`.

`nullable_key32` is deliberately left out, matching the existing choice not to remap `key32`: a 32-bit key space cannot exceed 4 billion distinct values.