### PR TITLE
Infer omitted Distributed and Buffer columns only in the engine builder

### DIFF
--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -178,16 +178,9 @@ StorageBuffer::StorageBuffer(
     , bg_pool(getContext()->getBufferFlushSchedulePool())
 {
     StorageInMemoryMetadata storage_metadata;
-    /// Reached when loading already-validated metadata, which stores no column list for this engine.
-    /// A freshly created table infers its structure in `registerStorageBuffer` under the user's context.
-    if (columns_.empty())
-    {
-        auto dest_table = DatabaseCatalog::instance().getTable(destination_id, context_);
-        auto dest_table_metadata = dest_table->getInMemoryMetadataPtr(context_, false);
-        storage_metadata.setColumns(dest_table_metadata->getColumns());
-    }
-    else
-        storage_metadata.setColumns(columns_);
+    /// Columns are always resolved by `registerStorageBuffer` under the user's context, so the
+    /// destination's structure is never read here under the long-lived context this storage holds.
+    storage_metadata.setColumns(columns_);
 
     storage_metadata.setConstraints(constraints_);
     storage_metadata.setComment(comment);
@@ -1494,14 +1487,15 @@ void registerStorageBuffer(StorageFactory & factory)
             destination_id.table_name = destination_table;
         }
 
-        /// An omitted structure is inferred here, under the user's context: `StorageBuffer` holds only
-        /// a long-lived context and would read the destination's columns with no user at all. Loading
-        /// of already-validated metadata has no user either, so it keeps inferring in the constructor.
+        /// Infer an omitted structure here, under the user's context, so the constructor never reads
+        /// the destination's columns under the long-lived context it holds. The `SHOW_COLUMNS` check
+        /// runs only for a freshly introduced definition; a metadata reload has no user to check.
         ColumnsDescription columns = args.columns;
-        if (columns.empty() && !destination_id.empty()
-            && !(isLoadingFromExistingMetadata(args.mode) || args.query.attach_short_syntax))
+        if (columns.empty() && !destination_id.empty())
         {
-            args.getLocalContext()->checkAccess(AccessType::SHOW_COLUMNS, destination_id);
+            if (!(isLoadingFromExistingMetadata(args.mode) || args.query.attach_short_syntax))
+                args.getLocalContext()->checkAccess(AccessType::SHOW_COLUMNS, destination_id);
+
             auto destination = DatabaseCatalog::instance().getTable(destination_id, args.getLocalContext());
             auto destination_metadata = destination->getInMemoryMetadataPtr(args.getLocalContext(), false);
             columns = destination_metadata->getColumns();

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -1487,17 +1487,19 @@ void registerStorageBuffer(StorageFactory & factory)
             destination_id.table_name = destination_table;
         }
 
-        /// Infer an omitted structure here, under the user's context, so the constructor never reads
-        /// the destination's columns under the long-lived context it holds. The `SHOW_COLUMNS` check
-        /// runs only for a freshly introduced definition; a metadata reload has no user to check.
+        /// Infer an omitted structure here, so the constructor never reads the destination under
+        /// the long-lived context it holds. A definition restored from metadata (including a short
+        /// `ATTACH`) has no user, so it is neither access-checked nor resolved under one.
         ColumnsDescription columns = args.columns;
         if (columns.empty() && !destination_id.empty())
         {
-            if (!(isLoadingFromExistingMetadata(args.mode) || args.query.attach_short_syntax))
+            const bool from_existing_metadata = isLoadingFromExistingMetadata(args.mode) || args.query.attach_short_syntax;
+            const ContextPtr & structure_context = from_existing_metadata ? args.getContext() : args.getLocalContext();
+            if (!from_existing_metadata)
                 args.getLocalContext()->checkAccess(AccessType::SHOW_COLUMNS, destination_id);
 
-            auto destination = DatabaseCatalog::instance().getTable(destination_id, args.getLocalContext());
-            auto destination_metadata = destination->getInMemoryMetadataPtr(args.getLocalContext(), false);
+            auto destination = DatabaseCatalog::instance().getTable(destination_id, structure_context);
+            auto destination_metadata = destination->getInMemoryMetadataPtr(structure_context, false);
             columns = destination_metadata->getColumns();
         }
 

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -458,17 +458,10 @@ StorageDistributed::StorageDistributed(
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Settings flush_on_detach=0 and background_insert_batch=1 are incompatible");
 
     StorageInMemoryMetadata storage_metadata;
-    /// Only a definition loaded from validated metadata reaches here with no columns; the creators
-    /// infer an omitted structure themselves, under the user's context.
-    if (columns_.empty())
-    {
-        StorageID id = StorageID::createEmpty();
-        id.table_name = remote_table;
-        id.database_name = remote_database;
-        storage_metadata.setColumns(getStructureOfRemoteTable(*getCluster(), id, getContext(), remote_table_function_ptr));
-    }
-    else
-        storage_metadata.setColumns(columns_);
+    /// Columns are always resolved by the caller (the engine creators and `TableFunctionRemote`)
+    /// under the user's context, so the remote structure is never inferred here under the global
+    /// context this storage holds.
+    storage_metadata.setColumns(columns_);
 
     storage_metadata.setConstraints(constraints_);
     storage_metadata.setComment(comment);
@@ -2218,11 +2211,12 @@ void registerStorageDistributed(StorageFactory & factory)
 
         finalizeDistributedSettings(distributed_settings, context);
 
-        /// Infer an omitted structure under the user's context, so that the `SHOW_COLUMNS` check for a
-        /// local shard is not made against the global context the constructor holds. Skipped when the
-        /// definition comes from already-validated metadata, which has no user to check against.
+        /// Infer an omitted structure under the user's context (like the `Remote` creator and
+        /// `TableFunctionRemote`), so the local-shard `SHOW_COLUMNS` check in
+        /// `getStructureOfRemoteTableInShard` runs against the user rather than the global context
+        /// the constructor holds.
         ColumnsDescription columns = args.columns;
-        if (columns.empty() && !(isLoadingFromExistingMetadata(args.mode) || args.query.attach_short_syntax))
+        if (columns.empty())
         {
             /// Expanded first, so this resolves the same cluster the constructor will: a Replicated
             /// database's implicit cluster is found by the expanded name only.

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -2211,20 +2211,21 @@ void registerStorageDistributed(StorageFactory & factory)
 
         finalizeDistributedSettings(distributed_settings, context);
 
-        /// Infer an omitted structure under the user's context (like the `Remote` creator and
-        /// `TableFunctionRemote`), so the local-shard `SHOW_COLUMNS` check in
-        /// `getStructureOfRemoteTableInShard` runs against the user rather than the global context
-        /// the constructor holds.
+        /// Infer an omitted structure here, so a fresh definition resolves under the user's context
+        /// and the local-shard `SHOW_COLUMNS` check applies to them. A definition restored from
+        /// metadata (including a short `ATTACH`) has no user, so it keeps the global context.
         ColumnsDescription columns = args.columns;
         if (columns.empty())
         {
+            const bool from_existing_metadata = isLoadingFromExistingMetadata(args.mode) || args.query.attach_short_syntax;
+            const ContextPtr & structure_context = from_existing_metadata ? context : local_context;
             /// Expanded first, so this resolves the same cluster the constructor will: a Replicated
             /// database's implicit cluster is found by the expanded name only.
-            const String expanded_cluster_name = local_context->getMacros()->expand(cluster_name);
+            const String expanded_cluster_name = structure_context->getMacros()->expand(cluster_name);
             columns = getStructureOfRemoteTable(
-                *local_context->getCluster(expanded_cluster_name),
+                *structure_context->getCluster(expanded_cluster_name),
                 StorageID{remote_database, remote_table},
-                local_context,
+                structure_context,
                 /* table_func_ptr = */ nullptr);
         }
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`Distributed` and `Buffer` tables that omit their column list now always infer the structure under the creating user's access rights.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1589` (included in `26.8` and later)
<!-- ch-version-info:end -->