### PR TITLE
Remove stranded ZooKeeper part nodes when a drop range completes

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2892,12 +2892,14 @@ MergeTreeData::MutableDataPartPtr StorageReplicatedMergeTree::executeFetchShared
     }
 }
 
+/// prefetched_parts, if set, must list <replica_path>/parts as of after the caller's last removal.
 static void paranoidCheckForCoveredPartsInZooKeeper(
     const ZooKeeperPtr & zookeeper,
     const String & replica_path,
     MergeTreeDataFormatVersion format_version,
     const String & covering_part_name,
-    const StorageReplicatedMergeTree & storage)
+    const StorageReplicatedMergeTree & storage,
+    const std::optional<Strings> & prefetched_parts = {})
 {
 #ifdef DEBUG_OR_SANITIZER_BUILD
     constexpr bool paranoid_check_for_covered_parts_default = true;
@@ -2912,7 +2914,11 @@ static void paranoidCheckForCoveredPartsInZooKeeper(
 
     auto dominated_info = MergeTreePartInfo::fromPartName(covering_part_name, format_version);
 
-    Strings parts_remain = zookeeper->getChildren(replica_path + "/parts");
+    std::optional<Strings> listed_parts;
+    if (!prefetched_parts)
+        listed_parts = zookeeper->getChildren(replica_path + "/parts");
+    const Strings & parts_remain = prefetched_parts ? *prefetched_parts : *listed_parts;
+
     Strings orphaned_parts;
     for (const auto & part_name : parts_remain)
     {
@@ -2931,29 +2937,33 @@ static void paranoidCheckForCoveredPartsInZooKeeper(
         covering_part_name);
 }
 
-void StorageReplicatedMergeTree::removeStrandedPartsInRangeFromZooKeeper(const MergeTreePartInfo & drop_range)
+Strings StorageReplicatedMergeTree::removeStrandedPartsInRangeFromZooKeeper(const MergeTreePartInfo & drop_range)
 {
     /// Precondition: the range cannot be satisfied by a live covering part instead of removing the
-    /// parts it covers (is_drop_part, MergeTreeData.cpp:6448). Every caller must test the same
-    /// predicate: a narrower one strands the node forever, a wider one removes a still covered node.
+    /// parts it covers (the is_drop_part predicate in MergeTreeData::grabActivePartsToRemoveForDropRange).
+    /// A narrower predicate strands the node forever, a wider one removes a still covered node.
     chassert(!(!drop_range.isFakeDropRangePart() && drop_range.min_block));
 
     auto zookeeper = getZooKeeper();
     Strings stranded_parts;
-    for (const auto & part_name : zookeeper->getChildren(replica_path + "/parts"))
+    Strings remaining_parts;
+    for (auto & part_name : zookeeper->getChildren(replica_path + "/parts"))
     {
         auto part_info = MergeTreePartInfo::tryParsePartName(part_name, format_version);
         if (part_info && drop_range.contains(*part_info))
-            stranded_parts.push_back(part_name);
+            stranded_parts.push_back(std::move(part_name));
+        else
+            remaining_parts.push_back(std::move(part_name));
     }
 
     if (stranded_parts.empty())
-        return;
+        return remaining_parts;
 
     LOG_WARNING(log, "Removing {} part(s) [{}] from ZooKeeper: covered by DROP_RANGE {}, but not present in the working set",
         stranded_parts.size(), fmt::join(stranded_parts, ", "), drop_range.getPartNameForLogs());
 
     removePartsFromZooKeeperWithRetries(stranded_parts);
+    return remaining_parts;
 }
 
 void StorageReplicatedMergeTree::waitForPreActivePartsInRange(const MergeTreePartInfo & drop_range) const
@@ -3019,7 +3029,8 @@ void StorageReplicatedMergeTree::executeDropRange(const LogEntry & entry)
     /// Therefore, we use all data parts.
 
     /// This range may be satisfied by a live covering part instead of removing the parts it covers,
-    /// in which case its ZooKeeper nodes must be kept (is_drop_part, MergeTreeData.cpp:6448).
+    /// in which case its ZooKeeper nodes must be kept (the is_drop_part predicate in
+    /// MergeTreeData::grabActivePartsToRemoveForDropRange).
     const bool may_be_covered_by_live_part = !drop_range_info.isFakeDropRangePart() && drop_range_info.min_block;
 
     PartsToRemoveFromZooKeeper parts_to_remove;
@@ -3048,9 +3059,11 @@ void StorageReplicatedMergeTree::executeDropRange(const LogEntry & entry)
 
     /// Forcibly remove parts from ZooKeeper
     removePartsFromZooKeeperWithRetries(parts_to_remove);
+    std::optional<Strings> parts_remain_in_zookeeper;
     if (!may_be_covered_by_live_part)
-        removeStrandedPartsInRangeFromZooKeeper(drop_range_info);
-    paranoidCheckForCoveredPartsInZooKeeper(getZooKeeper(), replica_path, format_version, entry.new_part_name, *this);
+        parts_remain_in_zookeeper = removeStrandedPartsInRangeFromZooKeeper(drop_range_info);
+    paranoidCheckForCoveredPartsInZooKeeper(
+        getZooKeeper(), replica_path, format_version, entry.new_part_name, *this, parts_remain_in_zookeeper);
 
     if (entry.detach)
         LOG_DEBUG(log, "Detached {} parts inside {}.", parts_to_remove.size(), entry.new_part_name);
@@ -3098,8 +3111,9 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
         drop_range = {};
     }
 
-    /// Same predicate as in executeDropRange (is_drop_part, MergeTreeData.cpp:6448); always false
-    /// here, because a replace range always spans a whole partition at MAX_LEVEL.
+    /// Same predicate as in executeDropRange (the is_drop_part predicate in
+    /// MergeTreeData::grabActivePartsToRemoveForDropRange); always false here, because a replace
+    /// range always spans a whole partition at MAX_LEVEL.
     const bool may_be_covered_by_live_part = !drop_range.isFakeDropRangePart() && drop_range.min_block;
 
     struct PartDescription
@@ -3197,10 +3211,12 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
         removePartsFromZooKeeperWithRetries(parts_to_remove);
         if (replace)
         {
+            std::optional<Strings> parts_remain_in_zookeeper;
             if (!may_be_covered_by_live_part)
-                removeStrandedPartsInRangeFromZooKeeper(drop_range);
+                parts_remain_in_zookeeper = removeStrandedPartsInRangeFromZooKeeper(drop_range);
             paranoidCheckForCoveredPartsInZooKeeper(
-                getZooKeeper(), replica_path, format_version, entry_replace.drop_range_part_name, *this);
+                getZooKeeper(), replica_path, format_version, entry_replace.drop_range_part_name, *this,
+                parts_remain_in_zookeeper);
         }
         return true;
     }
@@ -3528,9 +3544,11 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
     removePartsFromZooKeeperWithRetries(parts_to_remove);
     if (replace)
     {
+        std::optional<Strings> parts_remain_in_zookeeper;
         if (!may_be_covered_by_live_part)
-            removeStrandedPartsInRangeFromZooKeeper(drop_range);
-        paranoidCheckForCoveredPartsInZooKeeper(getZooKeeper(), replica_path, format_version, entry_replace.drop_range_part_name, *this);
+            parts_remain_in_zookeeper = removeStrandedPartsInRangeFromZooKeeper(drop_range);
+        paranoidCheckForCoveredPartsInZooKeeper(
+            getZooKeeper(), replica_path, format_version, entry_replace.drop_range_part_name, *this, parts_remain_in_zookeeper);
     }
     res_parts.clear();
     parts_to_remove.clear();

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2933,15 +2933,8 @@ static void paranoidCheckForCoveredPartsInZooKeeper(
 
 void StorageReplicatedMergeTree::removeStrandedPartsInRangeFromZooKeeper(const MergeTreePartInfo & drop_range)
 {
-    /// `removePartsInRangeFromWorkingSetAndGetPartsToRemoveFromZooKeeper` only sees parts that are
-    /// in the in-memory index (Active/Outdated/Deleting), so a part missing from it in every state
-    /// keeps its ZooKeeper node. Such a node is legal while an active part covers it (see
-    /// `paranoidCheckForCoveredPartsInZooKeeperOnStart`), but this drop removes every part of the
-    /// range: afterwards nothing covers the node, no replica can serve a fetch for it, and the
-    /// Outdated-driven cleanup thread never sees it. So it is garbage and we remove it here.
-    ///
-    /// Only valid for a full (fake) drop range: for a single-part DROP PART an empty removal set
-    /// instead means the drop is already satisfied by a live covering part, whose node must stay.
+    /// Only sound for a full drop range, which removes every part of the range: a single-part
+    /// DROP PART may instead be satisfied by a live covering part, whose node must be kept.
     chassert(drop_range.isFakeDropRangePart());
 
     auto zookeeper = getZooKeeper();

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2931,6 +2931,37 @@ static void paranoidCheckForCoveredPartsInZooKeeper(
         covering_part_name);
 }
 
+void StorageReplicatedMergeTree::removeStrandedPartsInRangeFromZooKeeper(const MergeTreePartInfo & drop_range)
+{
+    /// `removePartsInRangeFromWorkingSetAndGetPartsToRemoveFromZooKeeper` only sees parts that are
+    /// in the in-memory index (Active/Outdated/Deleting), so a part missing from it in every state
+    /// keeps its ZooKeeper node. Such a node is legal while an active part covers it (see
+    /// `paranoidCheckForCoveredPartsInZooKeeperOnStart`), but this drop removes every part of the
+    /// range: afterwards nothing covers the node, no replica can serve a fetch for it, and the
+    /// Outdated-driven cleanup thread never sees it. So it is garbage and we remove it here.
+    ///
+    /// Only valid for a full (fake) drop range: for a single-part DROP PART an empty removal set
+    /// instead means the drop is already satisfied by a live covering part, whose node must stay.
+    chassert(drop_range.isFakeDropRangePart());
+
+    auto zookeeper = getZooKeeper();
+    Strings stranded_parts;
+    for (const auto & part_name : zookeeper->getChildren(replica_path + "/parts"))
+    {
+        auto part_info = MergeTreePartInfo::tryParsePartName(part_name, format_version);
+        if (part_info && drop_range.contains(*part_info))
+            stranded_parts.push_back(part_name);
+    }
+
+    if (stranded_parts.empty())
+        return;
+
+    LOG_WARNING(log, "Removing {} part(s) [{}] from ZooKeeper: covered by DROP_RANGE {}, but not present in the working set",
+        stranded_parts.size(), fmt::join(stranded_parts, ", "), drop_range.getPartNameForLogs());
+
+    removePartsFromZooKeeperWithRetries(stranded_parts);
+}
+
 void StorageReplicatedMergeTree::waitForPreActivePartsInRange(const MergeTreePartInfo & drop_range) const
 {
     /// An INSERT on the originating replica commits a part to ZooKeeper (via the ZK multi-op
@@ -3005,16 +3036,20 @@ void StorageReplicatedMergeTree::executeDropRange(const LogEntry & entry)
 
         parts_to_remove = removePartsInRangeFromWorkingSetAndGetPartsToRemoveFromZooKeeper(NO_TRANSACTION_RAW, drop_range_info, data_parts_lock, /*create_empty_part=*/ true, clone_to_detached);
 
-        if (parts_to_remove.empty())
+        /// For a single-part DROP PART an empty set means the drop is already satisfied by a live
+        /// covering part, so there is nothing to do. For a full drop range it instead means no part
+        /// of the range is in the working set, and a covered ZooKeeper node may still be stranded.
+        if (parts_to_remove.empty() && !drop_range_info.isFakeDropRangePart())
         {
-            if (!drop_range_info.isFakeDropRangePart())
-                LOG_INFO(log, "Log entry {} tried to drop single part {}, but part does not exist", entry.znode_name, entry.new_part_name);
+            LOG_INFO(log, "Log entry {} tried to drop single part {}, but part does not exist", entry.znode_name, entry.new_part_name);
             return;
         }
     }
 
     /// Forcibly remove parts from ZooKeeper
     removePartsFromZooKeeperWithRetries(parts_to_remove);
+    if (drop_range_info.isFakeDropRangePart())
+        removeStrandedPartsInRangeFromZooKeeper(drop_range_info);
     paranoidCheckForCoveredPartsInZooKeeper(getZooKeeper(), replica_path, format_version, entry.new_part_name, *this);
 
     if (entry.detach)
@@ -3157,8 +3192,12 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
         LOG_INFO(log, "All parts from REPLACE PARTITION command have been already attached");
         removePartsFromZooKeeperWithRetries(parts_to_remove);
         if (replace)
+        {
+            if (drop_range.isFakeDropRangePart())
+                removeStrandedPartsInRangeFromZooKeeper(drop_range);
             paranoidCheckForCoveredPartsInZooKeeper(
                 getZooKeeper(), replica_path, format_version, entry_replace.drop_range_part_name, *this);
+        }
         return true;
     }
 
@@ -3484,7 +3523,11 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
 
     removePartsFromZooKeeperWithRetries(parts_to_remove);
     if (replace)
+    {
+        if (drop_range.isFakeDropRangePart())
+            removeStrandedPartsInRangeFromZooKeeper(drop_range);
         paranoidCheckForCoveredPartsInZooKeeper(getZooKeeper(), replica_path, format_version, entry_replace.drop_range_part_name, *this);
+    }
     res_parts.clear();
     parts_to_remove.clear();
     cleanup_thread.wakeup();

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2933,9 +2933,10 @@ static void paranoidCheckForCoveredPartsInZooKeeper(
 
 void StorageReplicatedMergeTree::removeStrandedPartsInRangeFromZooKeeper(const MergeTreePartInfo & drop_range)
 {
-    /// Only sound for a full drop range, which removes every part of the range: a single-part
-    /// DROP PART may instead be satisfied by a live covering part, whose node must be kept.
-    chassert(drop_range.isFakeDropRangePart());
+    /// Precondition: the range cannot be satisfied by a live covering part instead of removing the
+    /// parts it covers (is_drop_part, MergeTreeData.cpp:6448). Every caller must test the same
+    /// predicate: a narrower one strands the node forever, a wider one removes a still covered node.
+    chassert(!(!drop_range.isFakeDropRangePart() && drop_range.min_block));
 
     auto zookeeper = getZooKeeper();
     Strings stranded_parts;
@@ -3017,6 +3018,10 @@ void StorageReplicatedMergeTree::executeDropRange(const LogEntry & entry)
     /// And, if you do not, the parts will come to life after the server is restarted.
     /// Therefore, we use all data parts.
 
+    /// This range may be satisfied by a live covering part instead of removing the parts it covers,
+    /// in which case its ZooKeeper nodes must be kept (is_drop_part, MergeTreeData.cpp:6448).
+    const bool may_be_covered_by_live_part = !drop_range_info.isFakeDropRangePart() && drop_range_info.min_block;
+
     PartsToRemoveFromZooKeeper parts_to_remove;
     {
         auto data_parts_lock = lockParts();
@@ -3029,19 +3034,21 @@ void StorageReplicatedMergeTree::executeDropRange(const LogEntry & entry)
 
         parts_to_remove = removePartsInRangeFromWorkingSetAndGetPartsToRemoveFromZooKeeper(NO_TRANSACTION_RAW, drop_range_info, data_parts_lock, /*create_empty_part=*/ true, clone_to_detached);
 
-        /// For a single-part DROP PART an empty set means the drop is already satisfied by a live
-        /// covering part, so there is nothing to do. For a full drop range it instead means no part
-        /// of the range is in the working set, and a covered ZooKeeper node may still be stranded.
-        if (parts_to_remove.empty() && !drop_range_info.isFakeDropRangePart())
+        if (parts_to_remove.empty())
         {
-            LOG_INFO(log, "Log entry {} tried to drop single part {}, but part does not exist", entry.znode_name, entry.new_part_name);
-            return;
+            if (!drop_range_info.isFakeDropRangePart())
+                LOG_INFO(log, "Log entry {} tried to drop single part {}, but part does not exist", entry.znode_name, entry.new_part_name);
+
+            /// Only a live covering part can make an empty set mean "already done". Otherwise no
+            /// part of the range is in the working set, yet a covered ZooKeeper node may be stranded.
+            if (may_be_covered_by_live_part)
+                return;
         }
     }
 
     /// Forcibly remove parts from ZooKeeper
     removePartsFromZooKeeperWithRetries(parts_to_remove);
-    if (drop_range_info.isFakeDropRangePart())
+    if (!may_be_covered_by_live_part)
         removeStrandedPartsInRangeFromZooKeeper(drop_range_info);
     paranoidCheckForCoveredPartsInZooKeeper(getZooKeeper(), replica_path, format_version, entry.new_part_name, *this);
 
@@ -3090,6 +3097,10 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
     {
         drop_range = {};
     }
+
+    /// Same predicate as in executeDropRange (is_drop_part, MergeTreeData.cpp:6448); always false
+    /// here, because a replace range always spans a whole partition at MAX_LEVEL.
+    const bool may_be_covered_by_live_part = !drop_range.isFakeDropRangePart() && drop_range.min_block;
 
     struct PartDescription
     {
@@ -3186,7 +3197,7 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
         removePartsFromZooKeeperWithRetries(parts_to_remove);
         if (replace)
         {
-            if (drop_range.isFakeDropRangePart())
+            if (!may_be_covered_by_live_part)
                 removeStrandedPartsInRangeFromZooKeeper(drop_range);
             paranoidCheckForCoveredPartsInZooKeeper(
                 getZooKeeper(), replica_path, format_version, entry_replace.drop_range_part_name, *this);
@@ -3517,7 +3528,7 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
     removePartsFromZooKeeperWithRetries(parts_to_remove);
     if (replace)
     {
-        if (drop_range.isFakeDropRangePart())
+        if (!may_be_covered_by_live_part)
             removeStrandedPartsInRangeFromZooKeeper(drop_range);
         paranoidCheckForCoveredPartsInZooKeeper(getZooKeeper(), replica_path, format_version, entry_replace.drop_range_part_name, *this);
     }

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -691,9 +691,9 @@ private:
     /// This prevents a race between a concurrent INSERT and DROP_RANGE processing.
     void waitForPreActivePartsInRange(const MergeTreePartInfo & drop_range) const;
 
-    /// Remove ZooKeeper part nodes covered by a completed full drop range that have no part in the
-    /// working set. Only for a fake (full) drop range, and only after the parts of the range have
-    /// been removed from ZooKeeper. Must not be called under a data parts lock (does ZooKeeper I/O).
+    /// Remove ZooKeeper part nodes covered by a completed drop range that have no part in the working
+    /// set. Only when the range cannot be satisfied by a live covering part instead, and only after
+    /// its parts have been removed from ZooKeeper. Does ZooKeeper I/O, so not under a parts lock.
     void removeStrandedPartsInRangeFromZooKeeper(const MergeTreePartInfo & drop_range);
 
     /// Execute alter of table metadata. Set replica/metadata and replica/columns

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -692,9 +692,8 @@ private:
     void waitForPreActivePartsInRange(const MergeTreePartInfo & drop_range) const;
 
     /// Remove ZooKeeper part nodes covered by a completed drop range that have no part in the working
-    /// set. Only when the range cannot be satisfied by a live covering part instead, and only after
-    /// its parts have been removed from ZooKeeper. Does ZooKeeper I/O, so not under a parts lock.
-    /// Returns the remaining children of <replica_path>/parts, so callers need not list them again.
+    /// set, and return the remaining children of <replica_path>/parts. Only for a range that cannot be
+    /// satisfied by a live covering part instead. Does ZooKeeper I/O, so not under a parts lock.
     Strings removeStrandedPartsInRangeFromZooKeeper(const MergeTreePartInfo & drop_range);
 
     /// Execute alter of table metadata. Set replica/metadata and replica/columns

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -694,7 +694,8 @@ private:
     /// Remove ZooKeeper part nodes covered by a completed drop range that have no part in the working
     /// set. Only when the range cannot be satisfied by a live covering part instead, and only after
     /// its parts have been removed from ZooKeeper. Does ZooKeeper I/O, so not under a parts lock.
-    void removeStrandedPartsInRangeFromZooKeeper(const MergeTreePartInfo & drop_range);
+    /// Returns the remaining children of <replica_path>/parts, so callers need not list them again.
+    Strings removeStrandedPartsInRangeFromZooKeeper(const MergeTreePartInfo & drop_range);
 
     /// Execute alter of table metadata. Set replica/metadata and replica/columns
     /// nodes in zookeeper and also changes in memory metadata.

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -691,6 +691,11 @@ private:
     /// This prevents a race between a concurrent INSERT and DROP_RANGE processing.
     void waitForPreActivePartsInRange(const MergeTreePartInfo & drop_range) const;
 
+    /// Remove ZooKeeper part nodes covered by a completed full drop range that have no part in the
+    /// working set. Only for a fake (full) drop range, and only after the parts of the range have
+    /// been removed from ZooKeeper. Must not be called under a data parts lock (does ZooKeeper I/O).
+    void removeStrandedPartsInRangeFromZooKeeper(const MergeTreePartInfo & drop_range);
+
     /// Execute alter of table metadata. Set replica/metadata and replica/columns
     /// nodes in zookeeper and also changes in memory metadata.
     /// New metadata and columns values stored in entry.

--- a/tests/integration/test_drop_range_stranded_zk_part/test.py
+++ b/tests/integration/test_drop_range_stranded_zk_part/test.py
@@ -33,9 +33,7 @@ def remove_part_from_disk(node, table, part_name):
     ).strip()
     if not part_path:
         raise Exception("Part " + part_name + " doesn't exist")
-    node.exec_in_container(
-        ["bash", "-c", "rm -r {p}".format(p=part_path)], privileged=True
-    )
+    node.exec_in_container(["rm", "-r", part_path], privileged=True)
 
 
 def build_stranded_node(table):

--- a/tests/integration/test_drop_range_stranded_zk_part/test.py
+++ b/tests/integration/test_drop_range_stranded_zk_part/test.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance("node1", with_zookeeper=True)
+node2 = cluster.add_instance("node2", with_zookeeper=True)
+
+STRANDED_PART = "all_0_1_1"
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def parts_path(table):
+    return f"/clickhouse/tables/{table}/replicas/1/parts"
+
+
+def remove_part_from_disk(node, table, part_name):
+    part_path = node.query(
+        f"SELECT path FROM system.parts WHERE table = '{table}' AND name = '{part_name}'"
+    ).strip()
+    if not part_path:
+        raise Exception("Part " + part_name + " doesn't exist")
+    node.exec_in_container(
+        ["bash", "-c", "rm -r {p}".format(p=part_path)], privileged=True
+    )
+
+
+def build_stranded_node(table):
+    """Leave a ZooKeeper part node behind with no part in the working set on node1.
+
+    The part directory must be removed only after a covering part is already active: while
+    all_0_1_1 is still active, DETACH/ATTACH declares it broken and the replica re-fetches it
+    from node2, which dissolves the state under test.
+    """
+    for node, replica in [(node1, "1"), (node2, "2")]:
+        node.query(
+            f"CREATE TABLE {table} (n Int32) ENGINE = "
+            f"ReplicatedMergeTree('/clickhouse/tables/{table}', '{replica}') "
+            "ORDER BY n SETTINGS old_parts_lifetime = 100500"
+        )
+
+    node1.query(f"INSERT INTO {table} VALUES (1)")
+    node1.query(f"INSERT INTO {table} VALUES (2)")
+    node1.query(f"OPTIMIZE TABLE {table} FINAL")
+    # all_0_1_1 is active now; the second merge makes all_0_2_2 cover it.
+    node1.query(f"INSERT INTO {table} VALUES (3)")
+    node1.query(f"OPTIMIZE TABLE {table} FINAL")
+    node1.query(f"SYSTEM SYNC REPLICA {table}")
+
+    remove_part_from_disk(node1, table, STRANDED_PART)
+    node1.query(f"DETACH TABLE {table} SYNC")
+    node1.query(f"ATTACH TABLE {table}")
+    node1.query(f"SYSTEM WAIT LOADING PARTS {table}")
+
+    # Positive control: without both of these the scenario under test is not reproduced, and any
+    # assertion made after the drop would hold for the wrong reason.
+    assert (
+        node1.query(
+            f"SELECT count() FROM system.zookeeper WHERE path = '{parts_path(table)}' "
+            f"AND name = '{STRANDED_PART}'"
+        ).strip()
+        == "1"
+    )
+    assert (
+        node1.query(
+            f"SELECT count() FROM system.parts WHERE table = '{table}' AND name = '{STRANDED_PART}'"
+        ).strip()
+        == "0"
+    )
+
+
+def test_truncate_removes_stranded_zookeeper_part(start_cluster):
+    table = "rmt_truncate"
+    build_stranded_node(table)
+
+    node1.query(f"TRUNCATE TABLE {table} SETTINGS alter_sync = 2")
+
+    assert_eq_with_retry(
+        node1,
+        f"SELECT count() FROM system.zookeeper WHERE path = '{parts_path(table)}'",
+        "0\n",
+    )
+
+    for node in [node1, node2]:
+        node.query(f"DROP TABLE {table} SYNC")
+
+
+def test_detach_partition_removes_stranded_zookeeper_part(start_cluster):
+    table = "rmt_detach"
+    build_stranded_node(table)
+
+    node1.query(f"ALTER TABLE {table} DETACH PARTITION tuple() SETTINGS alter_sync = 2")
+
+    assert_eq_with_retry(
+        node1,
+        f"SELECT count() FROM system.zookeeper WHERE path = '{parts_path(table)}' "
+        f"AND name = '{STRANDED_PART}'",
+        "0\n",
+    )
+
+    for node in [node1, node2]:
+        node.query(f"DROP TABLE {table} SYNC")

--- a/tests/integration/test_drop_range_stranded_zk_part/test.py
+++ b/tests/integration/test_drop_range_stranded_zk_part/test.py
@@ -128,6 +128,7 @@ def test_empty_working_set_removes_stranded_zookeeper_part(start_cluster):
     # that the removal set still picks up, so wait for the table to hold no part in any state
     # before re-stranding the node. Only the cleanup period matters here: that part is created
     # with remove_time = 0, so old_parts_lifetime never holds it back.
+    # system.parts omits Deleting parts unless _state is referenced.
     node1.query(
         f"ALTER TABLE {table} MODIFY SETTING cleanup_delay_period = 1, "
         "max_cleanup_delay_period = 2"
@@ -135,7 +136,7 @@ def test_empty_working_set_removes_stranded_zookeeper_part(start_cluster):
     node1.query(f"TRUNCATE TABLE {table} SETTINGS alter_sync = 2")
     assert_eq_with_retry(
         node1,
-        f"SELECT count() FROM system.parts WHERE table = '{table}'",
+        f"SELECT count() FROM system.parts WHERE table = '{table}' AND _state != 'dummy'",
         "0\n",
         retry_count=60,
         sleep_time=1,
@@ -154,7 +155,9 @@ def test_empty_working_set_removes_stranded_zookeeper_part(start_cluster):
         == "1"
     )
     assert (
-        node1.query(f"SELECT count() FROM system.parts WHERE table = '{table}'").strip()
+        node1.query(
+            f"SELECT count() FROM system.parts WHERE table = '{table}' AND _state != 'dummy'"
+        ).strip()
         == "0"
     )
 

--- a/tests/integration/test_drop_range_stranded_zk_part/test.py
+++ b/tests/integration/test_drop_range_stranded_zk_part/test.py
@@ -113,3 +113,59 @@ def test_detach_partition_removes_stranded_zookeeper_part(start_cluster):
 
     for node in [node1, node2]:
         node.query(f"DROP TABLE {table} SYNC")
+
+
+def test_empty_working_set_removes_stranded_zookeeper_part(start_cluster):
+    """A drop range whose working set is already empty must still sweep ZooKeeper.
+
+    The sibling tests keep a covering part, so the removal set is non-empty and the
+    empty-set branch of executeDropRange is never taken.
+    """
+    table = "rmt_empty_set"
+    build_stranded_node(table)
+
+    # The first drop empties the working set, but leaves behind an Outdated empty covering part
+    # that the removal set still picks up, so wait for the table to hold no part in any state
+    # before re-stranding the node. Only the cleanup period matters here: that part is created
+    # with remove_time = 0, so old_parts_lifetime never holds it back.
+    node1.query(
+        f"ALTER TABLE {table} MODIFY SETTING cleanup_delay_period = 1, "
+        "max_cleanup_delay_period = 2"
+    )
+    node1.query(f"TRUNCATE TABLE {table} SETTINGS alter_sync = 2")
+    assert_eq_with_retry(
+        node1,
+        f"SELECT count() FROM system.parts WHERE table = '{table}'",
+        "0\n",
+        retry_count=60,
+        sleep_time=1,
+    )
+
+    zk = cluster.get_kazoo_client("zoo1")
+    zk.create(f"{parts_path(table)}/{STRANDED_PART}", b"")
+
+    # Positive control: the node is back and no part of the range is in the working set, which
+    # is what makes the drop below take the empty-set branch rather than the sibling tests' one.
+    assert (
+        node1.query(
+            f"SELECT count() FROM system.zookeeper WHERE path = '{parts_path(table)}' "
+            f"AND name = '{STRANDED_PART}'"
+        ).strip()
+        == "1"
+    )
+    assert (
+        node1.query(f"SELECT count() FROM system.parts WHERE table = '{table}'").strip()
+        == "0"
+    )
+
+    node1.query(f"TRUNCATE TABLE {table} SETTINGS alter_sync = 2")
+
+    assert_eq_with_retry(
+        node1,
+        f"SELECT count() FROM system.zookeeper WHERE path = '{parts_path(table)}' "
+        f"AND name = '{STRANDED_PART}'",
+        "0\n",
+    )
+
+    for node in [node1, node2]:
+        node.query(f"DROP TABLE {table} SYNC")


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/106700
Related: https://github.com/ClickHouse/ClickHouse/pull/114070
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a `LOGICAL_ERROR` (`Part(s) ... are covered by DROP_RANGE ...`) and a leak of ZooKeeper part nodes when a partition of a `ReplicatedMergeTree` table is truncated, dropped or detached while a part of that range exists in ZooKeeper but not in the table's working set.

### Description

`executeDropRange` removed ZooKeeper part nodes from the set returned by
`removePartsInRangeFromWorkingSetAndGetPartsToRemoveFromZooKeeper`, which is driven by the in-memory
parts index and reports only `Active`, `Outdated` and `Deleting` parts. A part absent from it in every
state kept its `/replicas/<r>/parts/<name>` node, and the paranoid check, reading ZooKeeper directly,
then found it covered by the drop range and threw.

Before the drop that node is a legal steady state, a part lost locally while a covering part exists:
the startup check excuses it, no fetch is enqueued, the `Outdated`-driven cleanup cannot see an
unloaded part, and `04215_replicated_missing_covered_part_on_start` asserts that it survives. The drop
turns it into garbage, so it is removed there, closing the same source-of-truth mismatch that
`waitForPreActivePartsInRange` (30c81e8431cf584c) closed for `PreActive` parts.

One helper covers all three sites running the check and shares its listing. It uses the verifier's own
predicate, gated on the range not being satisfiable by a live covering part instead (`is_drop_part` in
`MergeTreeData::grabActivePartsToRemoveForDropRange`). A mid-range single-part `DROP PART` stays
unswept: there an empty removal set can mean a live covering part already satisfies the drop, and
removing its node would create intersecting parts. The empty-set early return is narrowed the same way.
Deliberate trade-off: for a full drop range the sweep runs just before that check, so a covered
stranded node is now removed with a `LOG_WARNING` instead of raising `LOGICAL_ERROR`.

`tests/integration/test_drop_range_stranded_zk_part` fails on master with the reported error, fails on
builds with only the removal compiled out or only the early return widened, and passes here with the
node verifiably gone; `04215` and `02369`/`02370` pass 20 runs each on a debug build. It is an
integration test because it fabricates the state by removing a part directory.

Seen on master in
[Stress test (azure, amd_tsan)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=2c2cfce3aa53d7875b9fbd2ae268b913524a7f8c&name_0=MasterCI&name_1=Stress%20test%20%28azure%2C%20amd_tsan%29).

Related: #106700 (same error, closed for another mechanism), #114070