### PR TITLE
Type `IN (subquery)` over `LowCardinality` the same as `IN (literal list)`

### DIFF
--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -774,8 +774,12 @@ DataTypePtr IFunctionOverloadResolver::getReturnType(const ColumnsWithTypeAndNam
 
         for (ColumnWithTypeAndName & arg : args_without_low_cardinality)
         {
-            bool is_const = arg.column && isColumnConst(*arg.column);
-            if (is_const)
+            /// A Set-typed argument always becomes a constant column in the plan (`ColumnSet` is
+            /// always wrapped in `ColumnConst`); during analysis the set from a subquery is not
+            /// built yet and has no column, so without this it would count as a full column and
+            /// the same expression would get a different type than with a literal set.
+            bool is_const = (arg.column && isColumnConst(*arg.column)) || WhichDataType(arg.type).isSet();
+            if (is_const && arg.column)
                 arg.column = arg.column->convertToFullColumnIfLowCardinality();
 
             if (const auto * low_cardinality_type = typeid_cast<const DataTypeLowCardinality *>(arg.type.get()))

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -4543,23 +4543,11 @@ ActionsDAG ActionsDAG::deserialize(ReadBuffer & in, DeserializedSetsRegistry & r
                     rhs_type = std::make_shared<DataTypeTuple>(rhs_tuple->getElements());
 
                 if (!lhs_type->equals(*rhs_type))
-                {
-                    /// Analysis types a function over a subquery set (e.g. `in`) with a
-                    /// non-constant set argument, so a `LowCardinality` argument does not wrap
-                    /// the result type. Here the set is a constant, so the rebuilt function can
-                    /// wrap it. Keep the serialized type: execution uses `result_type`, so the
-                    /// node computes the same column as on the serializing side.
-                    bool has_set_argument = false;
-                    for (const auto * child : node.children)
-                        has_set_argument |= WhichDataType(child->result_type).isSet();
-
-                    if (!has_set_argument || !lhs_type->equals(*removeLowCardinality(rhs_type)))
-                        throw Exception(ErrorCodes::INCORRECT_DATA,
-                            "Deserialized function {} has invalid type. Expected {}, deserialized {}.",
-                            function_name,
-                            rhs_type->getName(),
-                            lhs_type->getName());
-                }
+                    throw Exception(ErrorCodes::INCORRECT_DATA,
+                        "Deserialized function {} has invalid type. Expected {}, deserialized {}.",
+                        function_name,
+                        rhs_type->getName(),
+                        lhs_type->getName());
             }
         }
         else if (node.type == ActionType::ARRAY_JOIN)

--- a/tests/queries/0_stateless/04201_inverse_dictionary_lookup_edge_cases.reference
+++ b/tests/queries/0_stateless/04201_inverse_dictionary_lookup_edge_cases.reference
@@ -296,11 +296,11 @@ rewrite: Nullable(K) key, opt off
 rewrite: LC(Nullable(K)) key - plan
 SELECT count() AS `count()`
 FROM default.data_str_lc_nullable AS __table1
-WHERE _CAST(in(__table1.id, (
+WHERE in(__table1.id, (
     SELECT id AS id
     FROM dictionary(\'dict_string\')
     WHERE equals(name, \'abc\')
-)), \'LowCardinality(Nullable(UInt8))\')
+))
 SETTINGS optimize_inverse_dictionary_lookup = 1
 rewrite: LC(Nullable(K)) key
 1

--- a/tests/queries/0_stateless/04838_in_subquery_lowcardinality_result_type.reference
+++ b/tests/queries/0_stateless/04838_in_subquery_lowcardinality_result_type.reference
@@ -1,0 +1,8 @@
+-- the literal and the subquery forms have the same type
+LowCardinality(UInt8)
+LowCardinality(UInt8)
+-- results agree
+50
+50
+-- the distributed plan round-trip accepts the type
+50

--- a/tests/queries/0_stateless/04838_in_subquery_lowcardinality_result_type.sql
+++ b/tests/queries/0_stateless/04838_in_subquery_lowcardinality_result_type.sql
@@ -1,0 +1,27 @@
+-- Tags: no-old-analyzer
+-- no-old-analyzer: the distributed-plan probe requires the analyzer.
+
+-- The result type of `IN` over a `LowCardinality` argument must not depend on whether the
+-- right-hand side is a literal list or a subquery: the set is a constant column in the plan
+-- in both cases, so both forms get the `LowCardinality`-wrapped result type. The subquery
+-- form used to get plain `UInt8`; a worker deserializing a distributed plan rebuilt the
+-- function with the wrapped type and failed the plan type check.
+
+DROP TABLE IF EXISTS t_lc_in;
+CREATE TABLE t_lc_in (s LowCardinality(String), k UInt64) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_lc_in SELECT toString(number % 4), number FROM numbers(100);
+
+SELECT '-- the literal and the subquery forms have the same type';
+SELECT DISTINCT toTypeName(s IN ('0', '1')) FROM t_lc_in;
+SELECT DISTINCT toTypeName(s IN (SELECT toString(number) FROM numbers(2))) FROM t_lc_in;
+
+SELECT '-- results agree';
+SELECT count() FROM t_lc_in WHERE s IN ('0', '1');
+SELECT count() FROM t_lc_in WHERE s IN (SELECT toString(number) FROM numbers(2));
+
+SELECT '-- the distributed plan round-trip accepts the type';
+SELECT count() FROM t_lc_in WHERE s IN (SELECT toString(number) FROM numbers(2))
+    SETTINGS make_distributed_plan = 1, distributed_plan_execute_locally = 1,
+        enable_parallel_replicas = 0, max_rows_to_group_by = 0;
+
+DROP TABLE t_lc_in;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/113826

Follow-up to the review of the `ActionsDAG` type-check relaxation in the PR above: revert the relaxation and fix the root cause outside of `ActionsDAG` instead.

The result type of `IN` over a `LowCardinality` argument used to depend on the form of the right-hand side: with a literal list it was `LowCardinality(UInt8)`, with a subquery it was plain `UInt8`. The general typing rule wraps the result in `LowCardinality` only when all other arguments are constants, and during analysis the set from a subquery is not built yet and has no column, so it did not count as a constant — while a set is always a constant column in the plan (`ColumnSet` is always wrapped in `ColumnConst`). A worker deserializing a distributed plan rebuilt the function with the constant set, got the wrapped type, and the type check failed; the previous fix accepted the difference in the check.

The typing rule now counts a `Set`-typed argument as a constant. `x IN (subquery)` over a `LowCardinality` column returns `LowCardinality(UInt8)`, the same as `x IN (literal list)`, in both analyzers, and the serialized and rebuilt types agree, so the strict type check in `ActionsDAG::deserialize` is restored exactly as before the PR above. A mixed-version window exists only between that PR and this one (both master-only, no stable release in between, and the affected path is the experimental `make_distributed_plan`): a not-yet-upgraded initiator sends the unwrapped type and an upgraded worker rejects the plan with a clear `INCORRECT_DATA` error.

The visible type change: `toTypeName(x IN (subquery))`, `EXPLAIN` headers, and column types of `CREATE ... AS SELECT` over such expressions now show `LowCardinality(UInt8)` instead of `UInt8`. The values do not change. A sweep of the stateless suite found no existing test that observes the type. Execution of `IN` over `LowCardinality` with a subquery also becomes cheaper: it now takes the same probe-per-distinct-value path as literal lists.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`x IN (subquery)` over a `LowCardinality` column now returns `LowCardinality(UInt8)` — the same type as `x IN (literal list)`. Previously the two forms returned different types, and distributed plans with such an `IN` needed a special case in the plan type check.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1173` (included in `26.8` and later)
<!-- ch-version-info:end -->