### PR TITLE
Fix a false-negative EXPLAIN PIPELINE assertion in 03701_limit_by_in_order

### DIFF
--- a/tests/queries/0_stateless/03701_limit_by_in_order.sql
+++ b/tests/queries/0_stateless/03701_limit_by_in_order.sql
@@ -96,7 +96,7 @@ OPTIMIZE TABLE 03701_sorted FINAL;
 -- For now, we intentionally do not use in order LIMIT BY for parallel replicas.
 SELECT DISTINCT 'Sorted w/o ORDER BY: ' || replaceRegexpOne(trim(BOTH ' ' FROM explain), ' × \\d+$', '')
 FROM (EXPLAIN PIPELINE SELECT key FROM 03701_sorted LIMIT 1 BY key LIMIT 10 SETTINGS enable_parallel_replicas = 0)
-WHERE explain LIKE '%LimitBy%Transform';
+WHERE explain LIKE '%LimitBySortedStreamTransform%';
 
 SELECT '';
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/100391


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The `Sorted w/o ORDER BY` check asserts that the in-order `LIMIT BY` fast path
fires, via `WHERE explain LIKE '%LimitBy%Transform'`. That pattern is unterminated,
and the `WHERE` runs on the raw explain text -- the SELECT list's
`replaceRegexpOne(..., ' x \d+$', '')` strips the multiplicity suffix only
afterwards. `EXPLAIN PIPELINE` appends ` x N` to a processor instantiated more than
once, so in a multi-stream read the fast-path row is
`LimitBySortedStreamTransform x 2`, fails to match, and only the downstream dedup
`LimitByTransform` survives, so the test reports the fast path as not fired in a
shape where it demonstrably did.

`LimitByStep::transformPipeline` emits both processors by design on more than one
stream: pre-cap each sorted stream, `resize(1)`, then dedup with one
`LimitByTransform`. Results are correct either way, so this is a test-side false
negative, not an engine defect. The shape is reachable even though `OPTIMIZE TABLE
... FINAL` leaves one part: with the concurrent-read thresholds at 0 (the
remote-filesystem default) one part splits across `max_threads` once
`index_granularity` is below ~50.

Naming the fast-path processor makes the predicate *be* the asserted condition
instead of a proxy for it, as `04325_limit_by_in_order_outer_sort.sql` already does.
The reference file is unchanged and only this assertion is touched: 15 further
predicates keep the old spelling and 9 reference lines legitimately expect plain
`LimitByTransform`, so a blanket replacement would rewrite undefective lines. No
other test uses the unterminated form.

Validation: 5/5 FAIL before, 5/5 PASS after on the exposing configuration
(`index_granularity=13`, thresholds 0, `max_threads=2`); 50/50 PASS under default
randomization. Not weakened: with `optimize_limit_by_in_order=0` the new predicate
matches nothing and the test still fails.

The defect is latent - no CI job pairs a build allowing low `index_granularity` with
a config zeroing those thresholds. It becomes reachable if #100391 merges, hence
correcting the predicate rather than pinning a setting.