### PR TITLE
Fix flaky 03100_lwu_07_merge_patches

### DIFF
--- a/tests/queries/0_stateless/03100_lwu_07_merge_patches.sql
+++ b/tests/queries/0_stateless/03100_lwu_07_merge_patches.sql
@@ -3,7 +3,10 @@ SET enable_lightweight_update = 1;
 
 CREATE TABLE t_lightweight (id UInt64, c1 UInt64)
 ENGINE = MergeTree ORDER BY id
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         -- the patch parts are listed one by one below, so only the explicit OPTIMIZE FINAL
+         -- (which ignores this limit) may merge them
+         max_bytes_to_merge_at_max_space_in_pool = 1;
 
 INSERT INTO t_lightweight SELECT number, number FROM numbers(20);
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108594
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/108594

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The test runs five lightweight `UPDATE`s, lists the five resulting patch parts from `system.parts`,
and only then runs an explicit `OPTIMIZE TABLE ... PARTITION ID 'patch-...' FINAL` and asserts they
collapsed into one. That first listing is not deterministic: patch parts are ordinary background
merge candidates (`MergeTreePartsCollector` declares `affordable_kinds{Regular, Patch}`, and nothing
in selection exempts them), and five tiny parts in one partition are an ideal merge range. When the
background merge wins, the first listing shows one `all_3_11_<lvl>_10` with 13 rows instead of five
lines.

#108594 masked the merge *level* in patch part names, fixing the variant where only the level
differed. This is the same race caught earlier, where the block *range* and the row count change too,
which a level mask cannot express.

Pinning `max_bytes_to_merge_at_max_space_in_pool = 1` stops background merges from selecting the
patch parts, while the explicit `OPTIMIZE FINAL` still merges them via
`selectAllPartsToMergeWithinPartition`, which does not read that limit. The setting's documentation
states this contract, and `04546_text_index_merge_fsync` and `04654_text_index_merge_with_empty_part`
already use the idiom for the same reason. The assertion stays as strict as before and `.reference`
is untouched.

This test is currently green in public CI (0 failures against ~37.5k OK rows in 7 days; the last
public failure predates #108594). It reproduces where the merge window is wider, so I validated
against the mechanism instead of a CI signal: forcing the background merge to win makes the unfixed
test fail with exactly the reported diff, while the pinned test passes and its explicit `OPTIMIZE`
still merges the five parts. Details in the validation comment.

`03100_lwu_03_join` is structurally susceptible to the same facet. I left it out to keep this to one
test, having no evidence its two failures in 60 days were this facet, but can pin it here on request.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1215` (included in `26.8` and later)
<!-- ch-version-info:end -->