### PR TITLE
Support text indexes with distributed plan execution

### DIFF
--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -78,7 +78,11 @@ static constexpr auto DBMS_MERGE_TREE_PART_INFO_VERSION = 1;
 /// unknown name (`QueryPlanSerializationSettings::readBinary` throws), so towards such a peer the name is
 /// written only when omitting it could corrupt two-level distributed merging - failing closed on an explicit
 /// error instead of silently mixing the two hash methods, whose two-level bucket numbering differs.
-static constexpr auto DBMS_QUERY_PLAN_SERIALIZATION_VERSION = 5;
+/// Version 6 ships text-index direct-read state on a serialized `ReadFromMergeTree` (the search queries
+/// behind the `__text_index_*` virtual columns and their default expressions). An older peer would leave
+/// the payload unconsumed and misparse the rest of the plan, so the serializer fails closed below
+/// version 6 when the read carries such state.
+static constexpr auto DBMS_QUERY_PLAN_SERIALIZATION_VERSION = 6;
 /// The parallel-replicas remote plan is serialized once (at DBMS_QUERY_PLAN_SERIALIZATION_VERSION) and
 /// that one blob is reused for every replica, so a replica below this version must be excluded up front
 /// rather than sent a blob it cannot parse. Tied to DBMS_QUERY_PLAN_SERIALIZATION_VERSION itself so a
@@ -91,6 +95,9 @@ static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_WINDOW_STEP
 /// plan setting name. Gates writing it in `AggregatingStep::serializeSettings` /
 /// `MergingAggregatedStep::serializeSettings`.
 static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_PACKED_STRING_KEYS_SETTING = 5;
+/// First query-plan serialization version that ships text-index direct-read state on a serialized
+/// `ReadFromMergeTree`. Gates writing it in `ReadFromMergeTree::serialize`.
+static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_TEXT_INDEX_READ_TASKS = 6;
 /// Version 1 added the initiator's settings changes to the task.
 /// Version 2 added per-stream streaming-exchange ports to exchange_stream_sources.
 static constexpr auto DBMS_DISTRIBUTED_TASK_SERIALIZATION_VERSION = 2;

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8596,9 +8596,7 @@ Enabling it automatically adjusts settings that control features not supported b
 - `enable_parallel_replicas = 0` and `automatic_parallel_replicas_mode = 0` — the distributed plan does its own work distribution;
 - `rewrite_in_to_join = 1` — rewrites `IN (subquery)` to a `JOIN` so that it can be distributed (only when `allow_experimental_correlated_subqueries` is enabled);
 - `correlated_subqueries_use_in_memory_buffer = 0`;
-- `use_skip_indexes_on_data_read = 0`;
-- `compile_expressions = 0`;
-- `query_plan_direct_read_from_text_index = 0`.
+- `compile_expressions = 0`.
 )", EXPERIMENTAL) \
     DECLARE(Bool, distributed_plan_execute_locally, false, R"(
 Run all tasks of a distributed query plan locally. Useful for testing and debugging.

--- a/src/Core/SettingsQuirks.cpp
+++ b/src/Core/SettingsQuirks.cpp
@@ -53,9 +53,7 @@ namespace Setting
     extern const SettingsBool rewrite_in_to_join;
     extern const SettingsBool allow_experimental_correlated_subqueries;
     extern const SettingsBool correlated_subqueries_use_in_memory_buffer;
-    extern const SettingsBool use_skip_indexes_on_data_read;
     extern const SettingsBool compile_expressions;
-    extern const SettingsBool query_plan_direct_read_from_text_index;
     extern const SettingsNonZeroUInt64 input_format_parquet_max_block_size;
     extern const SettingsNonZeroUInt64 max_block_size;
     extern const SettingsNonZeroUInt64 max_insert_block_size;
@@ -97,9 +95,8 @@ void applySettingsQuirks(Settings & settings, LoggerPtr log)
     }
 }
 
-/// TODO: This is a temporary workaround (issues #109476, #109329). Remove each override once
-/// distributed plans support the corresponding feature - e.g. for the text index direct read,
-/// let the worker re-run the rewrite over its pinned part list instead of disabling it.
+/// TODO: This is a temporary workaround (issue #109476). Remove each override once
+/// distributed plans support the corresponding feature.
 void adjustSettingsForMakeDistributedPlan(Settings & settings)
 {
     if (!settings[Setting::make_distributed_plan])
@@ -127,20 +124,10 @@ void adjustSettingsForMakeDistributedPlan(Settings & settings)
         settings[Setting::correlated_subqueries_use_in_memory_buffer] = false;
         adjusted.emplace_back("correlated_subqueries_use_in_memory_buffer = 0");
     }
-    if (settings[Setting::use_skip_indexes_on_data_read])
-    {
-        settings[Setting::use_skip_indexes_on_data_read] = false;
-        adjusted.emplace_back("use_skip_indexes_on_data_read = 0");
-    }
     if (settings[Setting::compile_expressions])
     {
         settings[Setting::compile_expressions] = false;
         adjusted.emplace_back("compile_expressions = 0");
-    }
-    if (settings[Setting::query_plan_direct_read_from_text_index])
-    {
-        settings[Setting::query_plan_direct_read_from_text_index] = false;
-        adjusted.emplace_back("query_plan_direct_read_from_text_index = 0");
     }
 
     if (!adjusted.empty())

--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -845,8 +845,7 @@ static const ActionsDAG::Node * processAndOptimizeTextIndexDAG(
     }
 
     const auto & indexes = read_from_merge_tree_step.getIndexes();
-    bool is_final = read_from_merge_tree_step.isQueryWithFinal();
-    read_from_merge_tree_step.createReadTasksForTextIndex(indexes->skip_indexes, result.added_columns, result.removed_columns, is_final);
+    read_from_merge_tree_step.createReadTasksForTextIndex(indexes->skip_indexes, result.added_columns, result.removed_columns);
     return result.filter_node;
 }
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -31,6 +31,9 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ExpressionListParsers.h>
+#include <Parsers/parseQuery.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Interpreters/parseIdentifiersOrStringLiteralsWithSettings.h>
 #include <Processors/ConcatProcessor.h>
 #include <Processors/Merges/MergingSortedTransform.h>
@@ -50,6 +53,7 @@
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Storages/MergeTree/MergeTreeDataSelectExecutor.h>
 #include <Storages/MergeTree/ConditionTemplate.h>
+#include <Storages/MergeTree/MergeTreeIndexConditionText.h>
 #include <Storages/MergeTree/MergeTreeIndexMinMax.h>
 #include <Storages/MergeTree/MergeTreeIndexReadResultPool.h>
 #include <Storages/MergeTree/MergeTreeIndexText.h>
@@ -306,6 +310,7 @@ namespace MergeTreeSetting
 namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
+    extern const int INCORRECT_DATA;
     extern const int INDEX_NOT_USED;
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
@@ -5693,17 +5698,16 @@ bool ReadFromMergeTree::supportsBucketedRead() const
 #endif
     return !query_info.input_order_info
         && !unsupported_deferred_filters
-        && !(analyzed_result_ptr && analyzed_result_ptr->readFromProjection())
-        && index_read_tasks.empty();
+        && !(analyzed_result_ptr && analyzed_result_ptr->readFromProjection());
 }
 
 
 void ReadFromMergeTree::verifyBucketedReadSupported() const
 {
-    /// A bucketed read is pinned to the coordinator's part list and cannot re-derive read-in-order,
-    /// a projection, or text index tasks. A non-bucket read reaches a node that re-plans it locally
-    /// and re-derives them (a full replica; reads the stateless worker cannot reproduce are routed to
-    /// a replica too). Deferred FINAL filters are gated in supportsBucketedRead (bucketed only for the
+    /// A bucketed read is pinned to the coordinator's part list and cannot re-derive read-in-order
+    /// or a projection. A non-bucket read reaches a node that re-plans it locally and re-derives
+    /// them (a full replica; reads the stateless worker cannot reproduce are routed to a replica
+    /// too). Deferred FINAL filters are gated in supportsBucketedRead (bucketed only for the
     /// worker path) and rejected in serialize.
     if (distributed_read_bucket_count == 0)
         return;
@@ -5714,11 +5718,138 @@ void ReadFromMergeTree::verifyBucketedReadSupported() const
     if (analyzed_result_ptr && analyzed_result_ptr->readFromProjection())
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
             "make_distributed_plan does not support a distributed read from a projection");
-    if (!index_read_tasks.empty())
-        throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
-            "make_distributed_plan does not support a distributed read using direct text index tasks");
 }
 
+
+void ReadFromMergeTree::serializeIndexReadTasksForTextIndex(Serialization & ctx) const
+{
+    /// Only tasks that read virtual columns are shipped. Tasks without columns exist to give the
+    /// other useful text indexes their own read step; the receiving node re-derives its own index
+    /// analysis, so they carry no information it could use.
+    std::vector<const IndexReadTasks::value_type *> tasks_to_serialize;
+    for (const auto & task : index_read_tasks)
+    {
+        if (!task.second.columns.empty())
+            tasks_to_serialize.push_back(&task);
+    }
+
+    writeVarUInt(tasks_to_serialize.size(), ctx.out);
+
+    for (const auto * task_entry : tasks_to_serialize)
+    {
+        const auto & [index_name, task] = *task_entry;
+        const auto & condition = task.index.condition_template->generateUnsubstituted();
+        const auto * condition_text = typeid_cast<const MergeTreeIndexConditionText *>(condition.get());
+        if (!condition_text)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Read task for index {} does not have a text index condition", index_name);
+
+        writeStringBinary(index_name, ctx.out);
+        writeBinary(task.is_final, ctx.out);
+        writeBinary(static_cast<UInt8>(condition_text->getGlobalSearchMode()), ctx.out);
+
+        writeVarUInt(task.columns.size(), ctx.out);
+        for (const auto & column : task.columns)
+        {
+            writeStringBinary(column.name, ctx.out);
+            condition_text->getSearchQueryForVirtualColumn(column.name)->serialize(ctx.out);
+
+            const auto * virtual_column = storage_snapshot->metadata->virtuals.tryGetDescription(
+                column.name, VirtualsKind::All, VirtualsMaterializationPlace::All);
+            if (!virtual_column)
+                throw Exception(ErrorCodes::LOGICAL_ERROR,
+                    "Virtual column {} of a text index read task not found in the storage snapshot", column.name);
+
+            const auto & default_expression = virtual_column->default_desc.expression;
+            writeStringBinary(default_expression ? default_expression->formatWithSecretsOneLine() : "", ctx.out);
+        }
+    }
+}
+
+ReadFromMergeTree::SerializedTextIndexReadTasks ReadFromMergeTree::deserializeIndexReadTasksForTextIndex(Deserialization & ctx)
+{
+    size_t num_tasks = 0;
+    readVarUInt(num_tasks, ctx.in);
+
+    SerializedTextIndexReadTasks tasks(num_tasks);
+    for (auto & task : tasks)
+    {
+        readStringBinary(task.index_name, ctx.in);
+        readBinary(task.is_final, ctx.in);
+
+        UInt8 global_search_mode = 0;
+        readBinary(global_search_mode, ctx.in);
+        if (global_search_mode > static_cast<UInt8>(TextSearchMode::Phrase))
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid search mode {} in a serialized text index read task", static_cast<UInt32>(global_search_mode));
+        task.global_search_mode = static_cast<TextSearchMode>(global_search_mode);
+
+        size_t num_columns = 0;
+        readVarUInt(num_columns, ctx.in);
+        task.columns.resize(num_columns);
+        for (auto & column : task.columns)
+        {
+            readStringBinary(column.name, ctx.in);
+            column.search_query = TextSearchQuery::deserialize(ctx.in);
+
+            String default_expression;
+            readStringBinary(default_expression, ctx.in);
+            if (!default_expression.empty())
+            {
+                ParserExpression parser;
+                column.default_expression = parseQuery(
+                    parser, default_expression, "default expression of a text index virtual column",
+                    /*max_query_size=*/ 0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
+            }
+        }
+    }
+
+    return tasks;
+}
+
+void ReadFromMergeTree::restoreIndexReadTasksForTextIndex(const SerializedTextIndexReadTasks & tasks)
+{
+    const auto & metadata_snapshot = storage_snapshot->metadata;
+    const auto & secondary_indices = metadata_snapshot->getSecondaryIndices();
+
+    for (const auto & task : tasks)
+    {
+        /// The table could have been altered concurrently after the plan was serialized,
+        /// so a missing index is a regular error, not a logical one.
+        auto index_it = std::ranges::find_if(secondary_indices, [&](const auto & index) { return index.name == task.index_name; });
+        if (index_it == secondary_indices.end())
+            throw Exception(ErrorCodes::INCORRECT_DATA,
+                "Text index {} required by a distributed plan does not exist in table {}",
+                task.index_name, data.getStorageID().getNameForLogs());
+
+        auto index_helper = MergeTreeIndexFactory::instance().get(metadata_snapshot, *index_it, *data.getSettings());
+        if (!index_helper->isTextIndex())
+            throw Exception(ErrorCodes::INCORRECT_DATA,
+                "Index {} required by a distributed plan is not a text index in table {}",
+                task.index_name, data.getStorageID().getNameForLogs());
+
+        auto condition = index_helper->createIndexCondition(/*predicate=*/ nullptr, context);
+        auto * condition_text = typeid_cast<MergeTreeIndexConditionText *>(condition.get());
+        if (!condition_text)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Condition for text index {} is not a text index condition", task.index_name);
+
+        IndexReadTask index_read_task;
+        std::map<String, TextSearchQueryPtr> queries_by_virtual_column;
+        for (const auto & column : task.columns)
+        {
+            queries_by_virtual_column[column.name] = column.search_query;
+            index_read_task.columns.emplace_back(column.name, std::make_shared<DataTypeUInt8>());
+        }
+
+        condition_text->setSearchQueriesForVirtualColumns(task.global_search_mode, queries_by_virtual_column);
+
+        auto factory = [condition](const ActionsDAG *, const ActionsDAG::Node *) { return condition; };
+        auto condition_template = std::make_shared<ConditionTemplate<MergeTreeIndexConditionPtr>>(
+            /*dag=*/ nullptr, std::move(factory), metadata_snapshot, context, /*skip_folding=*/ false);
+
+        index_read_task.index = MergeTreeIndexWithCondition(std::move(index_helper), std::move(condition_template));
+        index_read_task.is_final = task.is_final;
+        index_read_tasks.emplace(task.index_name, std::move(index_read_task));
+    }
+}
 
 void ReadFromMergeTree::serialize(Serialization & ctx) const
 {
@@ -5798,6 +5929,17 @@ void ReadFromMergeTree::serialize(Serialization & ctx) const
     /// Every distributed bucket's marks travel in its own `read_bucket` task parameter (set during
     /// fan-out), so the shared step carries only the bucket count.
     writeVarUInt(distributed_read_bucket_count, ctx.out);
+
+    /// Direct reads from a text index: the shipped filter references `__text_index_*` virtual columns
+    /// instead of the original text-search functions, and only the state below lets the receiving node
+    /// materialize them (see `restoreIndexReadTasksForTextIndex`).
+    if (ctx.version >= DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_TEXT_INDEX_READ_TASKS)
+        serializeIndexReadTasksForTextIndex(ctx);
+    else if (std::ranges::any_of(index_read_tasks, [](const auto & task) { return !task.second.columns.empty(); }))
+        throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
+            "A distributed read using direct text index tasks requires query plan serialization "
+            "version >= {}; all nodes must run the same version",
+            DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_TEXT_INDEX_READ_TASKS);
 }
 
 std::unique_ptr<IQueryPlanStep> ReadFromMergeTree::deserialize(Deserialization & ctx)
@@ -5858,6 +6000,10 @@ std::unique_ptr<IQueryPlanStep> ReadFromMergeTree::deserialize(Deserialization &
             "make_distributed_plan: a bucketed ReadFromMergeTree read requires query plan serialization "
             "version >= 2; all nodes must run the same version");
 
+    SerializedTextIndexReadTasks text_index_read_tasks;
+    if (ctx.version >= DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_TEXT_INDEX_READ_TASKS)
+        text_index_read_tasks = deserializeIndexReadTasksForTextIndex(ctx);
+
     /// The plan is only being drained off the buffer (TCPHandler::skipData) and will be discarded.
     /// All serialized fields have been consumed above, so return a lightweight placeholder that
     /// carries the serialized header (satisfies the header check) instead of doing a table lookup,
@@ -5878,7 +6024,29 @@ std::unique_ptr<IQueryPlanStep> ReadFromMergeTree::deserialize(Deserialization &
     MergeTreeData & table = *merge_tree;
     MergeTreeDataSelectExecutor executor(table);
 
-    const auto metadata_snapshot = table.getInMemoryMetadataPtr(ctx.context, false);
+    auto metadata_snapshot = table.getInMemoryMetadataPtr(ctx.context, false);
+
+    /// Register the shipped `__text_index_*` virtual columns before the step is built: the shipped
+    /// column list and filters reference them, and resolving either against a snapshot that does not
+    /// know them fails with NOT_FOUND_COLUMN_IN_BLOCK.
+    if (!text_index_read_tasks.empty())
+    {
+        auto new_metadata = StorageInMemoryMetadata::clone(metadata_snapshot);
+        for (const auto & task : text_index_read_tasks)
+        {
+            for (const auto & column : task.columns)
+            {
+                VirtualColumnDescription virtual_column(
+                    column.name, std::make_shared<DataTypeUInt8>(), /*codec=*/ nullptr, task.index_name,
+                    VirtualsKind::Ephemeral, VirtualsMaterializationPlace::Reader);
+                virtual_column.default_desc.kind = ColumnDefaultKind::Default;
+                virtual_column.default_desc.expression = column.default_expression;
+                new_metadata->virtuals.add(std::move(virtual_column));
+            }
+        }
+        metadata_snapshot = std::move(new_metadata);
+    }
+
     StorageSnapshotPtr storage_snapshot = table.getStorageSnapshot(metadata_snapshot, ctx.context);
     const auto & snapshot_data = assert_cast<const MergeTreeData::SnapshotData &>(*storage_snapshot->data);
 
@@ -5901,12 +6069,17 @@ std::unique_ptr<IQueryPlanStep> ReadFromMergeTree::deserialize(Deserialization &
         enable_parallel_reading,
         /*extension*/ nullptr);
 
-    if (distributed_read_bucket_count)
+    if (distributed_read_bucket_count || !text_index_read_tasks.empty())
     {
         auto * read_from_merge_tree_step = dynamic_cast<ReadFromMergeTree *>(step.get());
         if (!read_from_merge_tree_step)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "ReadFromMergeTree step is expected to be created by readFromParts");
-        read_from_merge_tree_step->setDistributedRead(distributed_read_bucket_count);
+
+        if (distributed_read_bucket_count)
+            read_from_merge_tree_step->setDistributedRead(distributed_read_bucket_count);
+
+        if (!text_index_read_tasks.empty())
+            read_from_merge_tree_step->restoreIndexReadTasksForTextIndex(text_index_read_tasks);
     }
 
     /// Need to keep shared pointer to MergeTree table till the end of plan execution

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -5752,7 +5752,11 @@ void ReadFromMergeTree::serializeTextIndexReadTasks(Serialization & ctx) const
             condition_text->getSearchQueryForVirtualColumn(column.name)->serialize(ctx.out);
 
             const auto & virtual_column = storage_snapshot->metadata->virtuals.getDescription(column.name, VirtualsKind::All, VirtualsMaterializationPlace::All);
-            writeStringBinary(virtual_column.default_desc.expression ? virtual_column.default_desc.expression->formatWithSecretsOneLine() : "", ctx.out);
+            const auto & default_expression = virtual_column.default_desc.expression;
+
+            /// `formatWithSecretsOneLine` keeps secrets and bypasses the log masker,
+            /// so the worker parses back exactly the fallback predicate the initiator planned.
+            writeStringBinary(default_expression ? default_expression->formatWithSecretsOneLine() : "", ctx.out);
         }
     }
 }

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -5191,7 +5191,7 @@ bool ReadFromMergeTree::announceEmptyReadRangesToCoordinatorIfInitiator()
     return true;
 }
 
-void ReadFromMergeTree::createReadTasksForTextIndex(const UsefulSkipIndexes & skip_indexes, const IndexReadColumns & added_columns, const Names & removed_columns, bool is_final)
+void ReadFromMergeTree::createReadTasksForTextIndex(const UsefulSkipIndexes & skip_indexes, const IndexReadColumns & added_columns, const Names & removed_columns)
 {
     index_read_tasks.clear();
 
@@ -5224,7 +5224,6 @@ void ReadFromMergeTree::createReadTasksForTextIndex(const UsefulSkipIndexes & sk
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Index {} not found in analyzed indexes", index_name);
 
             index_task.index = *index_it;
-            index_task.is_final = is_final;
         }
 
         for (const auto & added_virtual_column : added_virtual_columns)
@@ -5246,7 +5245,7 @@ void ReadFromMergeTree::createReadTasksForTextIndex(const UsefulSkipIndexes & sk
             /// Create tasks for text indexes which don't read virtual columns.
             /// It's required to always read text indexes on separate step on data read.
             if (!index_read_tasks.contains(index.index->index.name))
-                index_read_tasks.emplace(index.index->index.name, IndexReadTask{.columns = {}, .index = index, .is_final = is_final});
+                index_read_tasks.emplace(index.index->index.name, IndexReadTask{.columns = {}, .index = index});
         }
     }
 
@@ -5721,15 +5720,14 @@ void ReadFromMergeTree::verifyBucketedReadSupported() const
 }
 
 
-void ReadFromMergeTree::serializeIndexReadTasksForTextIndex(Serialization & ctx) const
+void ReadFromMergeTree::serializeTextIndexReadTasks(Serialization & ctx) const
 {
-    /// Only tasks that read virtual columns are shipped. Tasks without columns exist to give the
-    /// other useful text indexes their own read step; the receiving node re-derives its own index
-    /// analysis, so they carry no information it could use.
+    /// Only tasks that read virtual columns are shipped.
     std::vector<const IndexReadTasks::value_type *> tasks_to_serialize;
+
     for (const auto & task : index_read_tasks)
     {
-        if (!task.second.columns.empty())
+        if (task.second.index.index->isTextIndex() && !task.second.columns.empty())
             tasks_to_serialize.push_back(&task);
     }
 
@@ -5740,32 +5738,26 @@ void ReadFromMergeTree::serializeIndexReadTasksForTextIndex(Serialization & ctx)
         const auto & [index_name, task] = *task_entry;
         const auto & condition = task.index.condition_template->generateUnsubstituted();
         const auto * condition_text = typeid_cast<const MergeTreeIndexConditionText *>(condition.get());
+
         if (!condition_text)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Read task for index {} does not have a text index condition", index_name);
 
         writeStringBinary(index_name, ctx.out);
-        writeBinary(task.is_final, ctx.out);
         writeBinary(static_cast<UInt8>(condition_text->getGlobalSearchMode()), ctx.out);
-
         writeVarUInt(task.columns.size(), ctx.out);
+
         for (const auto & column : task.columns)
         {
             writeStringBinary(column.name, ctx.out);
             condition_text->getSearchQueryForVirtualColumn(column.name)->serialize(ctx.out);
 
-            const auto * virtual_column = storage_snapshot->metadata->virtuals.tryGetDescription(
-                column.name, VirtualsKind::All, VirtualsMaterializationPlace::All);
-            if (!virtual_column)
-                throw Exception(ErrorCodes::LOGICAL_ERROR,
-                    "Virtual column {} of a text index read task not found in the storage snapshot", column.name);
-
-            const auto & default_expression = virtual_column->default_desc.expression;
-            writeStringBinary(default_expression ? default_expression->formatWithSecretsOneLine() : "", ctx.out);
+            const auto & virtual_column = storage_snapshot->metadata->virtuals.getDescription(column.name, VirtualsKind::All, VirtualsMaterializationPlace::All);
+            writeStringBinary(virtual_column.default_desc.expression ? virtual_column.default_desc.expression->formatWithSecretsOneLine() : "", ctx.out);
         }
     }
 }
 
-ReadFromMergeTree::SerializedTextIndexReadTasks ReadFromMergeTree::deserializeIndexReadTasksForTextIndex(Deserialization & ctx)
+ReadFromMergeTree::SerializedTextIndexReadTasks ReadFromMergeTree::deserializeTextIndexReadTasks(Deserialization & ctx)
 {
     size_t num_tasks = 0;
     readVarUInt(num_tasks, ctx.in);
@@ -5774,17 +5766,19 @@ ReadFromMergeTree::SerializedTextIndexReadTasks ReadFromMergeTree::deserializeIn
     for (auto & task : tasks)
     {
         readStringBinary(task.index_name, ctx.in);
-        readBinary(task.is_final, ctx.in);
 
         UInt8 global_search_mode = 0;
         readBinary(global_search_mode, ctx.in);
+
         if (global_search_mode > static_cast<UInt8>(TextSearchMode::Phrase))
             throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid search mode {} in a serialized text index read task", static_cast<UInt32>(global_search_mode));
+
         task.global_search_mode = static_cast<TextSearchMode>(global_search_mode);
 
         size_t num_columns = 0;
         readVarUInt(num_columns, ctx.in);
         task.columns.resize(num_columns);
+
         for (auto & column : task.columns)
         {
             readStringBinary(column.name, ctx.in);
@@ -5792,12 +5786,17 @@ ReadFromMergeTree::SerializedTextIndexReadTasks ReadFromMergeTree::deserializeIn
 
             String default_expression;
             readStringBinary(default_expression, ctx.in);
+
             if (!default_expression.empty())
             {
                 ParserExpression parser;
                 column.default_expression = parseQuery(
-                    parser, default_expression, "default expression of a text index virtual column",
-                    /*max_query_size=*/ 0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
+                    parser,
+                    default_expression,
+                    "default expression of a text index virtual column",
+                    /*max_query_size=*/ 0,
+                    DBMS_DEFAULT_MAX_PARSER_DEPTH,
+                    DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
             }
         }
     }
@@ -5815,16 +5814,21 @@ void ReadFromMergeTree::restoreIndexReadTasksForTextIndex(const SerializedTextIn
         /// The table could have been altered concurrently after the plan was serialized,
         /// so a missing index is a regular error, not a logical one.
         auto index_it = std::ranges::find_if(secondary_indices, [&](const auto & index) { return index.name == task.index_name; });
+
         if (index_it == secondary_indices.end())
+        {
             throw Exception(ErrorCodes::INCORRECT_DATA,
                 "Text index {} required by a distributed plan does not exist in table {}",
                 task.index_name, data.getStorageID().getNameForLogs());
+        }
 
         auto index_helper = MergeTreeIndexFactory::instance().get(metadata_snapshot, *index_it, *data.getSettings());
         if (!index_helper->isTextIndex())
+        {
             throw Exception(ErrorCodes::INCORRECT_DATA,
                 "Index {} required by a distributed plan is not a text index in table {}",
                 task.index_name, data.getStorageID().getNameForLogs());
+        }
 
         auto condition = index_helper->createIndexCondition(/*predicate=*/ nullptr, context);
         auto * condition_text = typeid_cast<MergeTreeIndexConditionText *>(condition.get());
@@ -5833,6 +5837,7 @@ void ReadFromMergeTree::restoreIndexReadTasksForTextIndex(const SerializedTextIn
 
         IndexReadTask index_read_task;
         std::map<String, TextSearchQueryPtr> queries_by_virtual_column;
+
         for (const auto & column : task.columns)
         {
             queries_by_virtual_column[column.name] = column.search_query;
@@ -5846,7 +5851,6 @@ void ReadFromMergeTree::restoreIndexReadTasksForTextIndex(const SerializedTextIn
             /*dag=*/ nullptr, std::move(factory), metadata_snapshot, context, /*skip_folding=*/ false);
 
         index_read_task.index = MergeTreeIndexWithCondition(std::move(index_helper), std::move(condition_template));
-        index_read_task.is_final = task.is_final;
         index_read_tasks.emplace(task.index_name, std::move(index_read_task));
     }
 }
@@ -5934,12 +5938,16 @@ void ReadFromMergeTree::serialize(Serialization & ctx) const
     /// instead of the original text-search functions, and only the state below lets the receiving node
     /// materialize them (see `restoreIndexReadTasksForTextIndex`).
     if (ctx.version >= DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_TEXT_INDEX_READ_TASKS)
-        serializeIndexReadTasksForTextIndex(ctx);
+    {
+        serializeTextIndexReadTasks(ctx);
+    }
     else if (std::ranges::any_of(index_read_tasks, [](const auto & task) { return !task.second.columns.empty(); }))
+    {
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
             "A distributed read using direct text index tasks requires query plan serialization "
             "version >= {}; all nodes must run the same version",
             DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_TEXT_INDEX_READ_TASKS);
+    }
 }
 
 std::unique_ptr<IQueryPlanStep> ReadFromMergeTree::deserialize(Deserialization & ctx)
@@ -6002,7 +6010,7 @@ std::unique_ptr<IQueryPlanStep> ReadFromMergeTree::deserialize(Deserialization &
 
     SerializedTextIndexReadTasks text_index_read_tasks;
     if (ctx.version >= DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_TEXT_INDEX_READ_TASKS)
-        text_index_read_tasks = deserializeIndexReadTasksForTextIndex(ctx);
+        text_index_read_tasks = deserializeTextIndexReadTasks(ctx);
 
     /// The plan is only being drained off the buffer (TCPHandler::skipData) and will be discarded.
     /// All serialized fields have been consumed above, so return a lightweight placeholder that

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -5804,7 +5804,7 @@ ReadFromMergeTree::SerializedTextIndexReadTasks ReadFromMergeTree::deserializeTe
     return tasks;
 }
 
-void ReadFromMergeTree::restoreIndexReadTasksForTextIndex(const SerializedTextIndexReadTasks & tasks)
+void ReadFromMergeTree::restoreTextIndexReadTasks(const SerializedTextIndexReadTasks & tasks)
 {
     const auto & metadata_snapshot = storage_snapshot->metadata;
     const auto & secondary_indices = metadata_snapshot->getSecondaryIndices();
@@ -5823,20 +5823,16 @@ void ReadFromMergeTree::restoreIndexReadTasksForTextIndex(const SerializedTextIn
         }
 
         auto index_helper = MergeTreeIndexFactory::instance().get(metadata_snapshot, *index_it, *data.getSettings());
-        if (!index_helper->isTextIndex())
+        const auto * text_index = typeid_cast<const MergeTreeIndexText *>(index_helper.get());
+        if (!text_index)
         {
             throw Exception(ErrorCodes::INCORRECT_DATA,
                 "Index {} required by a distributed plan is not a text index in table {}",
                 task.index_name, data.getStorageID().getNameForLogs());
         }
 
-        auto condition = index_helper->createIndexCondition(/*predicate=*/ nullptr, context);
-        auto * condition_text = typeid_cast<MergeTreeIndexConditionText *>(condition.get());
-        if (!condition_text)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Condition for text index {} is not a text index condition", task.index_name);
-
         IndexReadTask index_read_task;
-        std::map<String, TextSearchQueryPtr> queries_by_virtual_column;
+        std::unordered_map<String, TextSearchQueryPtr> queries_by_virtual_column;
 
         for (const auto & column : task.columns)
         {
@@ -5844,11 +5840,10 @@ void ReadFromMergeTree::restoreIndexReadTasksForTextIndex(const SerializedTextIn
             index_read_task.columns.emplace_back(column.name, std::make_shared<DataTypeUInt8>());
         }
 
-        condition_text->setSearchQueriesForVirtualColumns(task.global_search_mode, queries_by_virtual_column);
+        auto condition = text_index->createIndexConditionForVirtualColumns(task.global_search_mode, std::move(queries_by_virtual_column), context);
 
         auto factory = [condition](const ActionsDAG *, const ActionsDAG::Node *) { return condition; };
-        auto condition_template = std::make_shared<ConditionTemplate<MergeTreeIndexConditionPtr>>(
-            /*dag=*/ nullptr, std::move(factory), metadata_snapshot, context, /*skip_folding=*/ false);
+        auto condition_template = std::make_shared<ConditionTemplate<MergeTreeIndexConditionPtr>>(/*dag=*/ nullptr, std::move(factory), metadata_snapshot, context, /*skip_folding=*/ false);
 
         index_read_task.index = MergeTreeIndexWithCondition(std::move(index_helper), std::move(condition_template));
         index_read_tasks.emplace(task.index_name, std::move(index_read_task));
@@ -5936,7 +5931,7 @@ void ReadFromMergeTree::serialize(Serialization & ctx) const
 
     /// Direct reads from a text index: the shipped filter references `__text_index_*` virtual columns
     /// instead of the original text-search functions, and only the state below lets the receiving node
-    /// materialize them (see `restoreIndexReadTasksForTextIndex`).
+    /// materialize them (see `restoreTextIndexReadTasks`).
     if (ctx.version >= DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_TEXT_INDEX_READ_TASKS)
     {
         serializeTextIndexReadTasks(ctx);
@@ -6034,24 +6029,29 @@ std::unique_ptr<IQueryPlanStep> ReadFromMergeTree::deserialize(Deserialization &
 
     auto metadata_snapshot = table.getInMemoryMetadataPtr(ctx.context, false);
 
-    /// Register the shipped `__text_index_*` virtual columns before the step is built: the shipped
-    /// column list and filters reference them, and resolving either against a snapshot that does not
-    /// know them fails with NOT_FOUND_COLUMN_IN_BLOCK.
+    /// Register the shipped `__text_index_*` virtual columns before the step is built.
     if (!text_index_read_tasks.empty())
     {
         auto new_metadata = StorageInMemoryMetadata::clone(metadata_snapshot);
+
         for (const auto & task : text_index_read_tasks)
         {
             for (const auto & column : task.columns)
             {
                 VirtualColumnDescription virtual_column(
-                    column.name, std::make_shared<DataTypeUInt8>(), /*codec=*/ nullptr, task.index_name,
-                    VirtualsKind::Ephemeral, VirtualsMaterializationPlace::Reader);
+                    column.name,
+                    std::make_shared<DataTypeUInt8>(),
+                    /*codec=*/ nullptr,
+                    task.index_name,
+                    VirtualsKind::Ephemeral,
+                    VirtualsMaterializationPlace::Reader);
+
                 virtual_column.default_desc.kind = ColumnDefaultKind::Default;
                 virtual_column.default_desc.expression = column.default_expression;
                 new_metadata->virtuals.add(std::move(virtual_column));
             }
         }
+
         metadata_snapshot = std::move(new_metadata);
     }
 
@@ -6087,7 +6087,7 @@ std::unique_ptr<IQueryPlanStep> ReadFromMergeTree::deserialize(Deserialization &
             read_from_merge_tree_step->setDistributedRead(distributed_read_bucket_count);
 
         if (!text_index_read_tasks.empty())
-            read_from_merge_tree_step->restoreIndexReadTasksForTextIndex(text_index_read_tasks);
+            read_from_merge_tree_step->restoreTextIndexReadTasks(text_index_read_tasks);
     }
 
     /// Need to keep shared pointer to MergeTree table till the end of plan execution

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -419,7 +419,7 @@ public:
 
     /// Adds virtual columns for reading from text index.
     /// Removes physical text columns that were eliminated by direct read from text index.
-    void createReadTasksForTextIndex(const UsefulSkipIndexes & skip_indexes, const IndexReadColumns & added_columns, const Names & removed_columns, bool is_final);
+    void createReadTasksForTextIndex(const UsefulSkipIndexes & skip_indexes, const IndexReadColumns & added_columns, const Names & removed_columns);
 
     /// Text-index direct-read state shipped with a serialized plan: everything the receiving node of
     /// a distributed query needs to rebuild `index_read_tasks` against its own copy of the table.
@@ -437,7 +437,6 @@ public:
         };
 
         String index_name;
-        bool is_final = false;
         TextSearchMode global_search_mode{};
         std::vector<Column> columns;
     };
@@ -533,8 +532,8 @@ public:
     static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
 
 private:
-    void serializeIndexReadTasksForTextIndex(Serialization & ctx) const;
-    static SerializedTextIndexReadTasks deserializeIndexReadTasksForTextIndex(Deserialization & ctx);
+    void serializeTextIndexReadTasks(Serialization & ctx) const;
+    static SerializedTextIndexReadTasks deserializeTextIndexReadTasks(Deserialization & ctx);
     /// Rebuilds `index_read_tasks` from the shipped state against this node's own metadata.
     /// The `__text_index_*` virtual columns must already be present in the storage snapshot.
     void restoreIndexReadTasksForTextIndex(const SerializedTextIndexReadTasks & tasks);

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -421,18 +421,16 @@ public:
     /// Removes physical text columns that were eliminated by direct read from text index.
     void createReadTasksForTextIndex(const UsefulSkipIndexes & skip_indexes, const IndexReadColumns & added_columns, const Names & removed_columns);
 
-    /// Text-index direct-read state shipped with a serialized plan: everything the receiving node of
-    /// a distributed query needs to rebuild `index_read_tasks` against its own copy of the table.
-    /// It cannot be re-derived there because the shipped filter references the `__text_index_*`
-    /// virtual columns instead of the original text-search functions.
+    /// State shipped with a serialized plan to rebuild `index_read_tasks` on the receiving node.
+    /// It cannot be re-derived there: the shipped filter references `__text_index_*` virtual columns.
     struct SerializedTextIndexReadTask
     {
         struct Column
         {
             String name;
             TextSearchQueryPtr search_query;
-            /// Default expression of the virtual column (null if none). The reader evaluates it for
-            /// parts where the index is not materialized and for abandoned pattern scans.
+            /// Default expression of the virtual column (null if none).
+            /// The reader evaluates it for parts where the index is not materialized.
             ASTPtr default_expression;
         };
 
@@ -535,8 +533,7 @@ private:
     void serializeTextIndexReadTasks(Serialization & ctx) const;
     static SerializedTextIndexReadTasks deserializeTextIndexReadTasks(Deserialization & ctx);
     /// Rebuilds `index_read_tasks` from the shipped state against this node's own metadata.
-    /// The `__text_index_*` virtual columns must already be present in the storage snapshot.
-    void restoreIndexReadTasksForTextIndex(const SerializedTextIndexReadTasks & tasks);
+    void restoreTextIndexReadTasks(const SerializedTextIndexReadTasks & tasks);
 
     MergeTreeSettingsPtr data_settings;
     MergeTreeReaderSettings reader_settings;

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -28,6 +28,10 @@ using PartitionIdToMaxBlockPtr = std::shared_ptr<const PartitionIdToMaxBlock>;
 class LazilyReadFromMergeTree;
 struct QueryIdHolder;
 
+struct TextSearchQuery;
+using TextSearchQueryPtr = std::shared_ptr<TextSearchQuery>;
+enum class TextSearchMode : uint8_t;
+
 struct MergeTreeDataSelectSamplingData
 {
     bool use_sampling = false;
@@ -417,6 +421,29 @@ public:
     /// Removes physical text columns that were eliminated by direct read from text index.
     void createReadTasksForTextIndex(const UsefulSkipIndexes & skip_indexes, const IndexReadColumns & added_columns, const Names & removed_columns, bool is_final);
 
+    /// Text-index direct-read state shipped with a serialized plan: everything the receiving node of
+    /// a distributed query needs to rebuild `index_read_tasks` against its own copy of the table.
+    /// It cannot be re-derived there because the shipped filter references the `__text_index_*`
+    /// virtual columns instead of the original text-search functions.
+    struct SerializedTextIndexReadTask
+    {
+        struct Column
+        {
+            String name;
+            TextSearchQueryPtr search_query;
+            /// Default expression of the virtual column (null if none). The reader evaluates it for
+            /// parts where the index is not materialized and for abandoned pattern scans.
+            ASTPtr default_expression;
+        };
+
+        String index_name;
+        bool is_final = false;
+        TextSearchMode global_search_mode{};
+        std::vector<Column> columns;
+    };
+
+    using SerializedTextIndexReadTasks = std::vector<SerializedTextIndexReadTask>;
+
     const std::optional<Indexes> & getIndexes() const { return indexes; }
     ConditionSelectivityEstimatorPtr getConditionSelectivityEstimator(const Names & required_columns) const;
 
@@ -506,6 +533,12 @@ public:
     static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
 
 private:
+    void serializeIndexReadTasksForTextIndex(Serialization & ctx) const;
+    static SerializedTextIndexReadTasks deserializeIndexReadTasksForTextIndex(Deserialization & ctx);
+    /// Rebuilds `index_read_tasks` from the shipped state against this node's own metadata.
+    /// The `__text_index_*` virtual columns must already be present in the storage snapshot.
+    void restoreIndexReadTasksForTextIndex(const SerializedTextIndexReadTasks & tasks);
+
     MergeTreeSettingsPtr data_settings;
     MergeTreeReaderSettings reader_settings;
 

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -130,6 +130,7 @@ std::shared_ptr<TextSearchQuery> TextSearchQuery::deserialize(ReadBuffer & in)
 
     UInt8 direct_read_mode = 0;
     readBinary(direct_read_mode, in);
+
     if (direct_read_mode > static_cast<UInt8>(TextIndexDirectReadMode::Hint))
         throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid direct read mode {} in a serialized text search query", static_cast<UInt32>(direct_read_mode));
 
@@ -137,6 +138,7 @@ std::shared_ptr<TextSearchQuery> TextSearchQuery::deserialize(ReadBuffer & in)
     readVarUInt(num_tokens, in);
     VectorWithMemoryTracking<String> tokens;
     tokens.reserve(num_tokens);
+
     for (size_t i = 0; i < num_tokens; ++i)
     {
         String token;
@@ -148,6 +150,7 @@ std::shared_ptr<TextSearchQuery> TextSearchQuery::deserialize(ReadBuffer & in)
     readVarUInt(num_patterns, in);
     std::vector<TextSearchPatternSource> pattern_sources;
     pattern_sources.reserve(num_patterns);
+
     for (size_t i = 0; i < num_patterns; ++i)
     {
         TextSearchPatternSource pattern_source;
@@ -160,6 +163,7 @@ std::shared_ptr<TextSearchQuery> TextSearchQuery::deserialize(ReadBuffer & in)
     readVarUInt(num_phrase_tokens, in);
     VectorWithMemoryTracking<String> phrase_tokens;
     phrase_tokens.reserve(num_phrase_tokens);
+
     for (size_t i = 0; i < num_phrase_tokens; ++i)
     {
         String token;
@@ -190,25 +194,15 @@ void TextSearchQuery::initializeHash()
         hash_state.update(token);
     }
 
-    if (!patterns.empty())
+    /// Hash the source form: `patterns` is derived from it, and a trivial pattern keeps no RE2 to hash.
+    if (!pattern_sources.empty())
     {
-        hash_state.update(patterns.size());
-        for (const auto & pattern : patterns)
+        hash_state.update(pattern_sources.size());
+        for (const auto & pattern_source : pattern_sources)
         {
-            if (const auto & re2 = pattern.getRE2())
-            {
-                hash_state.update(re2->pattern());
-            }
-            else
-            {
-                std::string required_substring;
-                bool is_trivial = false;
-                bool required_substring_is_prefix = false;
-                pattern.getAnalyzeResult(required_substring, is_trivial, required_substring_is_prefix);
-                hash_state.update(required_substring);
-                hash_state.update(is_trivial);
-                hash_state.update(required_substring_is_prefix);
-            }
+            hash_state.update(pattern_source.like_pattern.size());
+            hash_state.update(pattern_source.like_pattern);
+            hash_state.update(pattern_source.case_insensitive);
         }
     }
 
@@ -226,7 +220,6 @@ void TextSearchQuery::initializeHash()
 }
 
 MergeTreeIndexConditionText::MergeTreeIndexConditionText(
-    const ActionsDAG::Node * predicate,
     ContextPtr context_,
     const Block & index_sample_block,
     const std::optional<String> & normalized_index_column_name_,
@@ -244,6 +237,19 @@ MergeTreeIndexConditionText::MergeTreeIndexConditionText(
     , postprocessor(postprocessor_)
     , has_postprocessor(postprocessor && postprocessor->hasActions())
     , has_positions(has_positions_)
+{
+}
+
+MergeTreeIndexConditionText::MergeTreeIndexConditionText(
+    const ActionsDAG::Node * predicate,
+    ContextPtr context_,
+    const Block & index_sample_block,
+    const std::optional<String> & normalized_index_column_name_,
+    TokenizerPtr tokenizer_,
+    MergeTreeIndexTextPreprocessorPtr preprocessor_,
+    MergeTreeIndexTextPostprocessorPtr postprocessor_,
+    bool has_positions_)
+    : MergeTreeIndexConditionText(context_, index_sample_block, normalized_index_column_name_, tokenizer_, preprocessor_, postprocessor_, has_positions_)
 {
     if (!predicate)
     {
@@ -275,7 +281,41 @@ MergeTreeIndexConditionText::MergeTreeIndexConditionText(
             global_search_mode = TextSearchMode::Any;
     }
 
-    all_search_tokens = Names(all_search_tokens_set.begin(), all_search_tokens_set.end());
+    finalizeSearchTokens(all_search_tokens_set);
+}
+
+MergeTreeIndexConditionText::MergeTreeIndexConditionText(
+    TextSearchMode global_search_mode_,
+    std::unordered_map<String, TextSearchQueryPtr> virtual_column_to_search_query_,
+    ContextPtr context_,
+    const Block & index_sample_block,
+    const std::optional<String> & normalized_index_column_name_,
+    TokenizerPtr tokenizer_,
+    MergeTreeIndexTextPreprocessorPtr preprocessor_,
+    MergeTreeIndexTextPostprocessorPtr postprocessor_,
+    bool has_positions_)
+    : MergeTreeIndexConditionText(context_, index_sample_block, normalized_index_column_name_, tokenizer_, preprocessor_, postprocessor_, has_positions_)
+{
+    /// The queries are reached through the virtual columns, so the RPN never analyzes granules.
+    rpn.emplace_back(RPNElement::FUNCTION_UNKNOWN);
+    initializeCaches();
+    global_search_mode = global_search_mode_;
+    virtual_column_to_search_query = std::move(virtual_column_to_search_query_);
+
+    NameSet all_search_tokens_set;
+
+    for (const auto & [_, search_query] : virtual_column_to_search_query)
+    {
+        all_search_tokens_set.insert(search_query->getTokens().begin(), search_query->getTokens().end());
+        all_search_queries[search_query->getHash()] = search_query;
+    }
+
+    finalizeSearchTokens(all_search_tokens_set);
+}
+
+void MergeTreeIndexConditionText::finalizeSearchTokens(const NameSet & tokens)
+{
+    all_search_tokens = Names(tokens.begin(), tokens.end());
     std::ranges::sort(all_search_tokens); /// Technically not necessary but leads to nicer read patterns on sorted dictionary blocks
     cardinalities_cache = std::make_shared<TokensCardinalitiesCache>(all_search_tokens);
 }
@@ -284,11 +324,11 @@ void MergeTreeIndexConditionText::initializeCaches()
 {
     const auto & settings = getContext()->getSettingsRef();
     static constexpr auto cache_policy = "SLRU";
+
     /// Local caches: ~10% of the query memory budget, capped at 100 MiB; max_memory_usage == 0 (unlimited) uses the cap, not a 0-size cache.
     static constexpr size_t local_cache_size_cap = 100ULL * 1024 * 1024;
     const size_t query_memory_limit = settings[Setting::max_memory_usage];
-    const size_t local_cache_max_size
-        = query_memory_limit == 0 ? local_cache_size_cap : std::min<size_t>(query_memory_limit / 10, local_cache_size_cap);
+    const size_t local_cache_max_size = query_memory_limit == 0 ? local_cache_size_cap : std::min<size_t>(query_memory_limit / 10, local_cache_size_cap);
 
     /// If usage of global text index caches is disabled, create local
     /// one to share them between threads that read the same data parts.
@@ -307,31 +347,6 @@ void MergeTreeIndexConditionText::initializeCaches()
         postings_cache = getContext()->getTextIndexPostingsCache();
     else
         postings_cache = std::make_shared<TextIndexPostingsCache>(cache_policy, local_cache_max_size, 0, 1.0);
-}
-
-void MergeTreeIndexConditionText::setSearchQueriesForVirtualColumns(
-    TextSearchMode global_search_mode_,
-    const std::map<String, TextSearchQueryPtr> & queries_by_virtual_column)
-{
-    /// Only a condition created without a predicate (a fresh one on the receiving node
-    /// of a distributed plan) may be populated this way.
-    if (!all_search_queries.empty() || !virtual_column_to_search_query.empty())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Text index condition already has search queries");
-
-    initializeCaches();
-    global_search_mode = global_search_mode_;
-
-    NameSet all_search_tokens_set;
-    for (const auto & [column_name, search_query] : queries_by_virtual_column)
-    {
-        all_search_tokens_set.insert(search_query->getTokens().begin(), search_query->getTokens().end());
-        all_search_queries[search_query->getHash()] = search_query;
-        virtual_column_to_search_query[column_name] = search_query;
-    }
-
-    all_search_tokens = Names(all_search_tokens_set.begin(), all_search_tokens_set.end());
-    std::ranges::sort(all_search_tokens);
-    cardinalities_cache = std::make_shared<TokensCardinalitiesCache>(all_search_tokens);
 }
 
 bool MergeTreeIndexConditionText::requiresReadingAllTokens(const RPNElement & element)

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -13,7 +13,9 @@
 #include <Functions/MultiSearchImpl.h>
 #include <Functions/checkHyperscanRegexp.h>
 #include <Functions/hasAnyAllTokens.h>
+#include <IO/ReadHelpers.h>
 #include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
 #include <Functions/Regexps.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
@@ -39,6 +41,7 @@ namespace DB
 
 namespace ErrorCodes
 {
+    extern const int INCORRECT_DATA;
     extern const int LOGICAL_ERROR;
     extern const int NO_SUCH_COLUMN_IN_TABLE;
 }
@@ -58,22 +61,119 @@ namespace Setting
     extern const SettingsBool reject_expensive_hyperscan_regexps;
 }
 
+static std::vector<OptimizedRegularExpression> compilePatterns(const std::vector<TextSearchPatternSource> & pattern_sources)
+{
+    std::vector<OptimizedRegularExpression> patterns;
+    patterns.reserve(pattern_sources.size());
+
+    for (const auto & pattern_source : pattern_sources)
+    {
+        if (pattern_source.case_insensitive)
+            patterns.emplace_back(Regexps::createRegexp</*like=*/ true, /*no_capture=*/ true, /*case_insensitive=*/ true>(pattern_source.like_pattern));
+        else
+            patterns.emplace_back(Regexps::createRegexp</*like=*/ true, /*no_capture=*/ true, /*case_insensitive=*/ false>(pattern_source.like_pattern));
+    }
+
+    return patterns;
+}
+
 TextSearchQuery::TextSearchQuery(
     String function_name_,
     TextSearchMode search_mode_,
     TextIndexDirectReadMode direct_read_mode_,
     VectorWithMemoryTracking<String> tokens_,
-    std::vector<OptimizedRegularExpression> patterns_,
+    std::vector<TextSearchPatternSource> pattern_sources_,
     VectorWithMemoryTracking<String> phrase_tokens_)
     : function_name(std::move(function_name_))
     , search_mode(search_mode_)
     , direct_read_mode(direct_read_mode_)
     , tokens(std::move(tokens_))
-    , patterns(std::move(patterns_))
+    , patterns(compilePatterns(pattern_sources_))
+    , pattern_sources(std::move(pattern_sources_))
     , phrase_tokens(std::move(phrase_tokens_))
 {
     std::sort(tokens.begin(), tokens.end());
     initializeHash();
+}
+
+void TextSearchQuery::serialize(WriteBuffer & out) const
+{
+    writeStringBinary(function_name, out);
+    writeBinary(static_cast<UInt8>(search_mode), out);
+    writeBinary(static_cast<UInt8>(direct_read_mode), out);
+
+    writeVarUInt(tokens.size(), out);
+    for (const auto & token : tokens)
+        writeStringBinary(token, out);
+
+    writeVarUInt(pattern_sources.size(), out);
+    for (const auto & pattern_source : pattern_sources)
+    {
+        writeStringBinary(pattern_source.like_pattern, out);
+        writeBinary(pattern_source.case_insensitive, out);
+    }
+
+    writeVarUInt(phrase_tokens.size(), out);
+    for (const auto & token : phrase_tokens)
+        writeStringBinary(token, out);
+}
+
+std::shared_ptr<TextSearchQuery> TextSearchQuery::deserialize(ReadBuffer & in)
+{
+    String function_name;
+    readStringBinary(function_name, in);
+
+    UInt8 search_mode = 0;
+    readBinary(search_mode, in);
+    if (search_mode > static_cast<UInt8>(TextSearchMode::Phrase))
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid search mode {} in a serialized text search query", static_cast<UInt32>(search_mode));
+
+    UInt8 direct_read_mode = 0;
+    readBinary(direct_read_mode, in);
+    if (direct_read_mode > static_cast<UInt8>(TextIndexDirectReadMode::Hint))
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid direct read mode {} in a serialized text search query", static_cast<UInt32>(direct_read_mode));
+
+    size_t num_tokens = 0;
+    readVarUInt(num_tokens, in);
+    VectorWithMemoryTracking<String> tokens;
+    tokens.reserve(num_tokens);
+    for (size_t i = 0; i < num_tokens; ++i)
+    {
+        String token;
+        readStringBinary(token, in);
+        tokens.push_back(std::move(token));
+    }
+
+    size_t num_patterns = 0;
+    readVarUInt(num_patterns, in);
+    std::vector<TextSearchPatternSource> pattern_sources;
+    pattern_sources.reserve(num_patterns);
+    for (size_t i = 0; i < num_patterns; ++i)
+    {
+        TextSearchPatternSource pattern_source;
+        readStringBinary(pattern_source.like_pattern, in);
+        readBinary(pattern_source.case_insensitive, in);
+        pattern_sources.push_back(std::move(pattern_source));
+    }
+
+    size_t num_phrase_tokens = 0;
+    readVarUInt(num_phrase_tokens, in);
+    VectorWithMemoryTracking<String> phrase_tokens;
+    phrase_tokens.reserve(num_phrase_tokens);
+    for (size_t i = 0; i < num_phrase_tokens; ++i)
+    {
+        String token;
+        readStringBinary(token, in);
+        phrase_tokens.push_back(std::move(token));
+    }
+
+    return std::make_shared<TextSearchQuery>(
+        std::move(function_name),
+        static_cast<TextSearchMode>(search_mode),
+        static_cast<TextIndexDirectReadMode>(direct_read_mode),
+        std::move(tokens),
+        std::move(pattern_sources),
+        std::move(phrase_tokens));
 }
 
 void TextSearchQuery::initializeHash()
@@ -151,31 +251,7 @@ MergeTreeIndexConditionText::MergeTreeIndexConditionText(
         return;
     }
 
-    const auto & settings = context_->getSettingsRef();
-    static constexpr auto cache_policy = "SLRU";
-    /// Local caches: ~10% of the query memory budget, capped at 100 MiB; max_memory_usage == 0 (unlimited) uses the cap, not a 0-size cache.
-    static constexpr size_t local_cache_size_cap = 100ULL * 1024 * 1024;
-    const size_t query_memory_limit = settings[Setting::max_memory_usage];
-    const size_t local_cache_max_size
-        = query_memory_limit == 0 ? local_cache_size_cap : std::min<size_t>(query_memory_limit / 10, local_cache_size_cap);
-
-    /// If usage of global text index caches is disabled, create local
-    /// one to share them between threads that read the same data parts.
-    if (settings[Setting::use_text_index_tokens_cache])
-        tokens_cache = context_->getTextIndexTokensCache();
-    else
-        tokens_cache = std::make_shared<TextIndexTokensCache>(cache_policy, local_cache_max_size, 0, 1.0);
-
-    use_global_header_cache = settings[Setting::use_text_index_header_cache];
-    if (use_global_header_cache)
-        header_cache = context_->getTextIndexHeaderCache();
-    else
-        header_cache = std::make_shared<TextIndexHeaderCache>(cache_policy, local_cache_max_size, 0, 1.0);
-
-    if (settings[Setting::use_text_index_postings_cache])
-        postings_cache = context_->getTextIndexPostingsCache();
-    else
-        postings_cache = std::make_shared<TextIndexPostingsCache>(cache_policy, local_cache_max_size, 0, 1.0);
+    initializeCaches();
 
     rpn = std::move(RPNBuilder<RPNElement>(
         predicate,
@@ -201,6 +277,60 @@ MergeTreeIndexConditionText::MergeTreeIndexConditionText(
 
     all_search_tokens = Names(all_search_tokens_set.begin(), all_search_tokens_set.end());
     std::ranges::sort(all_search_tokens); /// Technically not necessary but leads to nicer read patterns on sorted dictionary blocks
+    cardinalities_cache = std::make_shared<TokensCardinalitiesCache>(all_search_tokens);
+}
+
+void MergeTreeIndexConditionText::initializeCaches()
+{
+    const auto & settings = getContext()->getSettingsRef();
+    static constexpr auto cache_policy = "SLRU";
+    /// Local caches: ~10% of the query memory budget, capped at 100 MiB; max_memory_usage == 0 (unlimited) uses the cap, not a 0-size cache.
+    static constexpr size_t local_cache_size_cap = 100ULL * 1024 * 1024;
+    const size_t query_memory_limit = settings[Setting::max_memory_usage];
+    const size_t local_cache_max_size
+        = query_memory_limit == 0 ? local_cache_size_cap : std::min<size_t>(query_memory_limit / 10, local_cache_size_cap);
+
+    /// If usage of global text index caches is disabled, create local
+    /// one to share them between threads that read the same data parts.
+    if (settings[Setting::use_text_index_tokens_cache])
+        tokens_cache = getContext()->getTextIndexTokensCache();
+    else
+        tokens_cache = std::make_shared<TextIndexTokensCache>(cache_policy, local_cache_max_size, 0, 1.0);
+
+    use_global_header_cache = settings[Setting::use_text_index_header_cache];
+    if (use_global_header_cache)
+        header_cache = getContext()->getTextIndexHeaderCache();
+    else
+        header_cache = std::make_shared<TextIndexHeaderCache>(cache_policy, local_cache_max_size, 0, 1.0);
+
+    if (settings[Setting::use_text_index_postings_cache])
+        postings_cache = getContext()->getTextIndexPostingsCache();
+    else
+        postings_cache = std::make_shared<TextIndexPostingsCache>(cache_policy, local_cache_max_size, 0, 1.0);
+}
+
+void MergeTreeIndexConditionText::setSearchQueriesForVirtualColumns(
+    TextSearchMode global_search_mode_,
+    const std::map<String, TextSearchQueryPtr> & queries_by_virtual_column)
+{
+    /// Only a condition created without a predicate (a fresh one on the receiving node
+    /// of a distributed plan) may be populated this way.
+    if (!all_search_queries.empty() || !virtual_column_to_search_query.empty())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Text index condition already has search queries");
+
+    initializeCaches();
+    global_search_mode = global_search_mode_;
+
+    NameSet all_search_tokens_set;
+    for (const auto & [column_name, search_query] : queries_by_virtual_column)
+    {
+        all_search_tokens_set.insert(search_query->getTokens().begin(), search_query->getTokens().end());
+        all_search_queries[search_query->getHash()] = search_query;
+        virtual_column_to_search_query[column_name] = search_query;
+    }
+
+    all_search_tokens = Names(all_search_tokens_set.begin(), all_search_tokens_set.end());
+    std::ranges::sort(all_search_tokens);
     cardinalities_cache = std::make_shared<TokensCardinalitiesCache>(all_search_tokens);
 }
 
@@ -781,7 +911,7 @@ VectorWithMemoryTracking<String> MergeTreeIndexConditionText::stringLikeToTokens
     return VectorWithMemoryTracking<String>(unique_tokens.begin(), unique_tokens.end());
 }
 
-std::vector<OptimizedRegularExpression> MergeTreeIndexConditionText::stringLikeToPatterns(const Field & field, bool case_insensitive) const
+std::vector<TextSearchPatternSource> MergeTreeIndexConditionText::stringLikeToPatterns(const Field & field, bool case_insensitive) const
 {
     /// Only handles the pure '%value%' form: one leading '%', a non-empty alphanumeric token immediately following,
     /// then one trailing '%' immediately after the token, and nothing else.
@@ -838,12 +968,7 @@ std::vector<OptimizedRegularExpression> MergeTreeIndexConditionText::stringLikeT
     pattern.append(data + start, end - start);
     pattern += '%';
 
-    std::vector<OptimizedRegularExpression> patterns;
-    if (case_insensitive)
-        patterns.emplace_back(Regexps::createRegexp<true, true, true>(pattern));
-    else
-        patterns.emplace_back(Regexps::createRegexp<true, true, false>(pattern));
-    return patterns;
+    return {TextSearchPatternSource{.like_pattern = std::move(pattern), .case_insensitive = case_insensitive}};
 }
 
 /// Converts a Field value to its text representation using `serializeText`,
@@ -1216,7 +1341,7 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
                 TextSearchMode::Phrase,
                 direct_read_mode,
                 std::move(unique_tokens),
-                std::vector<OptimizedRegularExpression>{},
+                std::vector<TextSearchPatternSource>{},
                 std::move(phrase_tokens));
 
             out.function = RPNElement::FUNCTION_HAS_PHRASE;

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <map>
-
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/RPNBuilder.h>
 #include <Common/OptimizedRegularExpression.h>
@@ -45,9 +43,8 @@ enum class TextIndexDirectReadMode : uint8_t
     Hint,
 };
 
-/// Source form of a search pattern: a LIKE pattern plus a case flag. The compiled
-/// OptimizedRegularExpression cannot be serialized, so queries keep the source form
-/// and recompile it, e.g. on a node that receives the query with a distributed plan.
+/// Source form of a search pattern: a LIKE pattern plus a case flag.
+/// The compiled OptimizedRegularExpression cannot be serialized, so queries keep the source form and recompile it.
 struct TextSearchPatternSource
 {
     String like_pattern;
@@ -87,6 +84,7 @@ private:
     VectorWithMemoryTracking<String> tokens;
     /// Compiled in the constructor from `pattern_sources`.
     std::vector<OptimizedRegularExpression> patterns;
+    /// Source of truth for `patterns`: serialization and the hash use it, the compiled form is not invertible.
     std::vector<TextSearchPatternSource> pattern_sources;
     /// Not sorted, not deduplicated.
     VectorWithMemoryTracking<String> phrase_tokens;
@@ -108,8 +106,21 @@ using MergeTreeIndexTextPostprocessorPtr = std::shared_ptr<MergeTreeIndexTextPos
 class MergeTreeIndexConditionText final : public IMergeTreeIndexCondition, public WithContext
 {
 public:
+    /// Extracts the search queries from `predicate`.
     MergeTreeIndexConditionText(
         const ActionsDAG::Node * predicate,
+        ContextPtr context_,
+        const Block & index_sample_block,
+        const std::optional<String> & normalized_index_column_name_,
+        TokenizerPtr tokenizer_,
+        MergeTreeIndexTextPreprocessorPtr preprocessor_,
+        MergeTreeIndexTextPostprocessorPtr postprocessor_,
+        bool has_positions_);
+
+    /// Takes the search queries shipped in a distributed plan, keyed by virtual column name.
+    MergeTreeIndexConditionText(
+        TextSearchMode global_search_mode_,
+        std::unordered_map<String, TextSearchQueryPtr> virtual_column_to_search_query_,
         ContextPtr context_,
         const Block & index_sample_block,
         const std::optional<String> & normalized_index_column_name_,
@@ -137,13 +148,6 @@ public:
     /// Returns generated virtual column name for the replacement of related function node.
     std::optional<String> replaceToVirtualColumn(const TextSearchQuery & query, const String & index_name);
     TextSearchQueryPtr getSearchQueryForVirtualColumn(const String & column_name) const;
-
-    /// Populates a condition constructed without a predicate with search queries shipped in a
-    /// distributed query plan, keyed by text-index virtual column name. The receiving node cannot
-    /// re-derive them: the shipped filter references the virtual columns, not the original
-    /// text-search functions. `global_search_mode_` is the initiator's value; it cannot be derived
-    /// from the queries alone (it depends on how the predicate combines them).
-    void setSearchQueriesForVirtualColumns(TextSearchMode global_search_mode_, const std::map<String, TextSearchQueryPtr> & queries_by_virtual_column);
 
     TextIndexTokensCachePtr tokensCache() const { return tokens_cache; }
     TextIndexHeaderCachePtr headerCache() const { return header_cache; }
@@ -184,6 +188,19 @@ private:
     };
 
     using RPN = std::vector<RPNElement>;
+
+    /// Initializes everything except the search queries; both public constructors delegate to it.
+    MergeTreeIndexConditionText(
+        ContextPtr context_,
+        const Block & index_sample_block,
+        const std::optional<String> & normalized_index_column_name_,
+        TokenizerPtr tokenizer_,
+        MergeTreeIndexTextPreprocessorPtr preprocessor_,
+        MergeTreeIndexTextPostprocessorPtr postprocessor_,
+        bool has_positions_);
+
+    /// Sorts the tokens collected from the search queries and builds the cardinalities cache over them.
+    void finalizeSearchTokens(const NameSet & tokens);
 
     bool traverseAtomNode(const RPNBuilderTreeNode & node, RPNElement & out) const;
 

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <map>
+
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/RPNBuilder.h>
 #include <Common/OptimizedRegularExpression.h>
@@ -7,6 +9,9 @@
 
 namespace DB
 {
+
+class ReadBuffer;
+class WriteBuffer;
 
 class TextIndexTokensCache;
 using TextIndexTokensCachePtr = std::shared_ptr<TextIndexTokensCache>;
@@ -40,6 +45,15 @@ enum class TextIndexDirectReadMode : uint8_t
     Hint,
 };
 
+/// Source form of a search pattern: a LIKE pattern plus a case flag. The compiled
+/// OptimizedRegularExpression cannot be serialized, so queries keep the source form
+/// and recompile it, e.g. on a node that receives the query with a distributed plan.
+struct TextSearchPatternSource
+{
+    String like_pattern;
+    bool case_insensitive = false;
+};
+
 /// Represents a single text-search function
 struct TextSearchQuery
 {
@@ -48,7 +62,7 @@ struct TextSearchQuery
         TextSearchMode search_mode_,
         TextIndexDirectReadMode direct_read_mode_,
         VectorWithMemoryTracking<String> tokens_,
-        std::vector<OptimizedRegularExpression> patterns_ = {},
+        std::vector<TextSearchPatternSource> pattern_sources_ = {},
         VectorWithMemoryTracking<String> phrase_tokens_ = {});
 
     const String & getFunctionName() const { return function_name; }
@@ -59,6 +73,9 @@ struct TextSearchQuery
     const VectorWithMemoryTracking<String> & getPhraseTokens() const { return phrase_tokens; }
     UInt128 getHash() const { return hash; }
 
+    void serialize(WriteBuffer & out) const;
+    static std::shared_ptr<TextSearchQuery> deserialize(ReadBuffer & in);
+
 private:
     void initializeHash();
 
@@ -68,7 +85,9 @@ private:
     TextIndexDirectReadMode direct_read_mode;
     /// Sorted in the constructor.
     VectorWithMemoryTracking<String> tokens;
+    /// Compiled in the constructor from `pattern_sources`.
     std::vector<OptimizedRegularExpression> patterns;
+    std::vector<TextSearchPatternSource> pattern_sources;
     /// Not sorted, not deduplicated.
     VectorWithMemoryTracking<String> phrase_tokens;
     /// Precomputed in the constructor because getHash is called on hot paths.
@@ -118,6 +137,13 @@ public:
     /// Returns generated virtual column name for the replacement of related function node.
     std::optional<String> replaceToVirtualColumn(const TextSearchQuery & query, const String & index_name);
     TextSearchQueryPtr getSearchQueryForVirtualColumn(const String & column_name) const;
+
+    /// Populates a condition constructed without a predicate with search queries shipped in a
+    /// distributed query plan, keyed by text-index virtual column name. The receiving node cannot
+    /// re-derive them: the shipped filter references the virtual columns, not the original
+    /// text-search functions. `global_search_mode_` is the initiator's value; it cannot be derived
+    /// from the queries alone (it depends on how the predicate combines them).
+    void setSearchQueriesForVirtualColumns(TextSearchMode global_search_mode_, const std::map<String, TextSearchQueryPtr> & queries_by_virtual_column);
 
     TextIndexTokensCachePtr tokensCache() const { return tokens_cache; }
     TextIndexHeaderCachePtr headerCache() const { return header_cache; }
@@ -185,7 +211,10 @@ private:
     /// Builds the OR-list of token sets for a `match`-style regexp, folding the required substring
     /// into every alternative. Returns an empty list when the regexp imposes no token requirement.
     std::vector<VectorWithMemoryTracking<String>> regexpToTokensForQueries(const String & regexp_string) const;
-    std::vector<OptimizedRegularExpression> stringLikeToPatterns(const Field & field, bool case_insensitive = false) const;
+    std::vector<TextSearchPatternSource> stringLikeToPatterns(const Field & field, bool case_insensitive = false) const;
+
+    /// Creates token/header/postings caches (either the global ones or query-local ones).
+    void initializeCaches();
 
     bool tryPrepareSetForTextSearch(const RPNBuilderTreeNode & lhs, const RPNBuilderTreeNode & rhs, const String & function_name, RPNElement & out) const;
 

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1915,6 +1915,14 @@ MergeTreeIndexConditionPtr MergeTreeIndexText::createIndexCondition(const Action
     return std::make_shared<MergeTreeIndexConditionText>(predicate, context, index.sample_block, normalized_index_column_name, tokenizer.get(), preprocessor, postprocessor, params.positions);
 }
 
+MergeTreeIndexConditionPtr MergeTreeIndexText::createIndexConditionForVirtualColumns(
+    TextSearchMode global_search_mode,
+    std::unordered_map<String, TextSearchQueryPtr> queries_by_virtual_column,
+    ContextPtr context) const
+{
+    return std::make_shared<MergeTreeIndexConditionText>(global_search_mode, std::move(queries_by_virtual_column), context, index.sample_block, normalized_index_column_name, tokenizer.get(), preprocessor, postprocessor, params.positions);
+}
+
 DataTypePtr MergeTreeIndexText::getNestedDataType(const DataTypePtr & data_type)
 {
     DataTypePtr nested_type = data_type;

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -552,6 +552,12 @@ public:
     MergeTreeIndexAggregatorPtr createIndexAggregator() const override;
     MergeTreeIndexConditionPtr createIndexCondition(const ActionsDAG::Node * predicate, ContextPtr context) const override;
 
+    /// Builds a condition from the search queries shipped in a distributed plan instead of from a predicate.
+    MergeTreeIndexConditionPtr createIndexConditionForVirtualColumns(
+        TextSearchMode global_search_mode,
+        std::unordered_map<String, TextSearchQueryPtr> queries_by_virtual_column,
+        ContextPtr context) const;
+
     const IPostingListCodec * getPostingListCodec() const { return posting_list_codec.get(); }
     static DataTypePtr getNestedDataType(const DataTypePtr & data_type);
 

--- a/src/Storages/MergeTree/MergeTreeReadTask.h
+++ b/src/Storages/MergeTree/MergeTreeReadTask.h
@@ -70,7 +70,6 @@ struct IndexReadTask
 {
     NamesAndTypesList columns;
     MergeTreeIndexWithCondition index;
-    bool is_final = false;
 };
 
 /// Ordered map to ensure deterministic iteration order.

--- a/tests/queries/0_stateless/04656_distributed_plan_workers_disable_jit.reference
+++ b/tests/queries/0_stateless/04656_distributed_plan_workers_disable_jit.reference
@@ -1,5 +1,5 @@
 join with a skip-index filter and a JIT-eligible expression matches single-node
 500	12475500
 500	12475500
-worker tasks run with the unsupported settings disabled
-0	0
+worker tasks run with JIT disabled and skip-index reads propagated
+1	0

--- a/tests/queries/0_stateless/04656_distributed_plan_workers_disable_jit.sql
+++ b/tests/queries/0_stateless/04656_distributed_plan_workers_disable_jit.sql
@@ -1,11 +1,12 @@
 -- Tags: no-old-analyzer
 -- no-old-analyzer: make_distributed_plan requires the analyzer.
 
--- make_distributed_plan auto-disables use_skip_indexes_on_data_read and compile_expressions
--- (issue #109476), including on worker tasks, whose contexts are rebuilt from the initiator's
--- user-level settings and would otherwise keep the defaults (both are true by default). The
--- settings are enabled explicitly here on purpose: the override is unconditional, because a
--- worker cannot honor them regardless of how they were set.
+-- make_distributed_plan auto-disables compile_expressions (issue #109476), including on worker
+-- tasks, whose contexts are rebuilt from the initiator's user-level settings and would otherwise
+-- keep the default. The setting is enabled explicitly here on purpose: the override is
+-- unconditional, because a worker cannot honor it regardless of how it was set.
+-- use_skip_indexes_on_data_read is NOT overridden anymore: it propagates to workers as set,
+-- because direct reads from a text index depend on it (see 04836_text_index_direct_read_make_distributed_plan).
 
 DROP TABLE IF EXISTS t_dp_big;
 DROP TABLE IF EXISTS t_dp_small;
@@ -31,7 +32,7 @@ SELECT count(), sum(b.v + 1) FROM t_dp_big AS b INNER JOIN t_dp_small AS s ON b.
     WHERE b.v < 50000
     SETTINGS make_distributed_plan = 0;
 
-SELECT 'worker tasks run with the unsupported settings disabled';
+SELECT 'worker tasks run with JIT disabled and skip-index reads propagated';
 SYSTEM FLUSH LOGS query_log;
 -- Worker task entries log the task id ('main', 'stage_N_M' - not SQL) as the query text and share
 -- the initiator's query_id; their Settings column shows the task context, where the overrides

--- a/tests/queries/0_stateless/04657_distributed_plan_text_index_direct_read.sql
+++ b/tests/queries/0_stateless/04657_distributed_plan_text_index_direct_read.sql
@@ -3,16 +3,16 @@
 
 -- Repro of issue #109329: the direct-read rewrite replaces text-search functions with the
 -- __text_index_* virtual column; a fragment shipped to a worker rebuilds a storage snapshot
--- without it and failed with NOT_FOUND_COLUMN_IN_BLOCK. make_distributed_plan now auto-disables
--- query_plan_direct_read_from_text_index on the initiator and on workers.
+-- without it and failed with NOT_FOUND_COLUMN_IN_BLOCK. The serialized ReadFromMergeTree now
+-- ships the text search queries behind the virtual columns, and the worker rebuilds the index
+-- read tasks against its own copy of the table.
 
 DROP TABLE IF EXISTS t_text_dp;
 CREATE TABLE t_text_dp (id UInt64, s String, INDEX idx_text s TYPE text(tokenizer = 'splitByNonAlpha'))
     ENGINE = MergeTree ORDER BY id;
 INSERT INTO t_text_dp SELECT number, 'word' || toString(number) FROM numbers(100000);
 
--- The direct-read setting is pinned to its default (on) so the bug path is provably exercised;
--- the auto-switch disables it for distributed plans regardless.
+-- The direct-read setting is pinned to its default (on) so the bug path is provably exercised.
 SET make_distributed_plan = 1, distributed_plan_execute_locally = 1,
     distributed_plan_max_rows_to_broadcast = 0, distributed_plan_default_reader_bucket_count = 3,
     distributed_plan_default_shuffle_join_bucket_count = 3, max_rows_to_group_by = 0,

--- a/tests/queries/0_stateless/04836_text_index_direct_read_make_distributed_plan.reference
+++ b/tests/queries/0_stateless/04836_text_index_direct_read_make_distributed_plan.reference
@@ -1,0 +1,41 @@
+-- exact mode
+1
+1
+501
+501
+1
+1
+62496000
+62496000
+-- the same predicate in PREWHERE and WHERE
+1
+1
+-- the plan distributes
+distributes
+-- LIKE by dictionary scan (pattern queries)
+1111
+1111
+1111
+1111
+-- a part without the materialized index uses the shipped default expression
+1
+1
+1
+1
+2
+2
+-- preprocessor index
+1
+1
+1
+1
+-- postprocessor index (hint mode)
+1
+1
+0
+0
+-- phrase search
+100
+100
+100
+100

--- a/tests/queries/0_stateless/04836_text_index_direct_read_make_distributed_plan.reference
+++ b/tests/queries/0_stateless/04836_text_index_direct_read_make_distributed_plan.reference
@@ -17,6 +17,12 @@ distributes
 1111
 1111
 1111
+-- the fuzzer shape: mixed PREWHERE and a xor in WHERE
+42
+42
+-- text index read under a join
+1
+1
 -- a part without the materialized index uses the shipped default expression
 1
 1

--- a/tests/queries/0_stateless/04836_text_index_direct_read_make_distributed_plan.sql
+++ b/tests/queries/0_stateless/04836_text_index_direct_read_make_distributed_plan.sql
@@ -58,6 +58,35 @@ SELECT count() FROM t_text_mdp WHERE s ILIKE '%WORD42%'
 SELECT count() FROM t_text_mdp WHERE s ILIKE '%WORD42%'
     SETTINGS use_text_index_like_evaluation_by_dictionary_scan = 1, make_distributed_plan = 0;
 
+-- The AST-fuzzer shape from #108818: the text-search function appears both in a mixed PREWHERE
+-- conjunction and inside a xor in WHERE, so the rewrite reaches the step from two filter stages.
+SELECT '-- the fuzzer shape: mixed PREWHERE and a xor in WHERE';
+
+SELECT id FROM t_text_mdp
+PREWHERE (materialize(65537) >= id) AND hasToken(s, 'word42')
+WHERE xor(hasToken(s, 'word42'), (id >= 65537))
+ORDER BY id LIMIT 3;
+SELECT id FROM t_text_mdp
+PREWHERE (materialize(65537) >= id) AND hasToken(s, 'word42')
+WHERE xor(hasToken(s, 'word42'), (id >= 65537))
+ORDER BY id LIMIT 3 SETTINGS make_distributed_plan = 0;
+
+-- A text index read reached through a subquery under a join: the read ships in its own fragment
+-- of a multi-stage (shuffle join) plan.
+SELECT '-- text index read under a join';
+
+DROP TABLE IF EXISTS t_mdp_outer;
+CREATE TABLE t_mdp_outer (id UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_mdp_outer SELECT number FROM numbers(200000);
+
+SELECT count() FROM t_mdp_outer AS o
+JOIN (SELECT id FROM t_text_mdp PREWHERE hasToken(s, 'word42') WHERE id < 65537) AS t ON o.id = t.id;
+SELECT count() FROM t_mdp_outer AS o
+JOIN (SELECT id FROM t_text_mdp PREWHERE hasToken(s, 'word42') WHERE id < 65537) AS t ON o.id = t.id
+SETTINGS make_distributed_plan = 0;
+
+DROP TABLE t_mdp_outer;
+
 DROP TABLE t_text_mdp;
 
 SELECT '-- a part without the materialized index uses the shipped default expression';

--- a/tests/queries/0_stateless/04836_text_index_direct_read_make_distributed_plan.sql
+++ b/tests/queries/0_stateless/04836_text_index_direct_read_make_distributed_plan.sql
@@ -1,0 +1,124 @@
+-- Tags: no-old-analyzer
+-- no-old-analyzer: make_distributed_plan requires the analyzer.
+
+-- Direct read from a text index under make_distributed_plan (issue #109329). The initiator rewrites
+-- text-search functions into __text_index_* virtual columns before the plan is split into fragments;
+-- the serialized ReadFromMergeTree ships the text search queries and the default expressions behind
+-- the virtual columns, and every worker rebuilds the index read tasks against its own copy of the
+-- table. Every query is repeated with make_distributed_plan = 0; the results must be identical.
+
+SET make_distributed_plan = 1, distributed_plan_execute_locally = 1,
+    distributed_plan_max_rows_to_broadcast = 0, distributed_plan_default_reader_bucket_count = 3,
+    distributed_plan_default_shuffle_join_bucket_count = 3, max_rows_to_group_by = 0,
+    query_plan_direct_read_from_text_index = 1, use_skip_indexes = 1, use_skip_indexes_on_data_read = 1,
+    query_plan_text_index_add_hint = 1;
+
+DROP TABLE IF EXISTS t_text_mdp;
+
+SELECT '-- exact mode';
+
+CREATE TABLE t_text_mdp (id UInt64, s String, INDEX idx_text s TYPE text(tokenizer = 'splitByNonAlpha'))
+    ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO t_text_mdp SELECT number, 'word' || toString(number) FROM numbers(100000);
+INSERT INTO t_text_mdp SELECT number, 'other' || toString(number % 100) FROM numbers(100000, 50000);
+
+SELECT count() FROM t_text_mdp WHERE hasToken(s, 'word42');
+SELECT count() FROM t_text_mdp WHERE hasToken(s, 'word42') SETTINGS make_distributed_plan = 0;
+
+SELECT count() FROM t_text_mdp WHERE hasAnyTokens(s, ['word42', 'other42', 'nonexistent']);
+SELECT count() FROM t_text_mdp WHERE hasAnyTokens(s, ['word42', 'other42', 'nonexistent']) SETTINGS make_distributed_plan = 0;
+
+SELECT count() FROM t_text_mdp WHERE hasAllTokens(s, ['word42']);
+SELECT count() FROM t_text_mdp WHERE hasAllTokens(s, ['word42']) SETTINGS make_distributed_plan = 0;
+
+SELECT sum(id) FROM t_text_mdp WHERE hasToken(s, 'other42');
+SELECT sum(id) FROM t_text_mdp WHERE hasToken(s, 'other42') SETTINGS make_distributed_plan = 0;
+
+SELECT '-- the same predicate in PREWHERE and WHERE';
+
+SELECT count() FROM t_text_mdp PREWHERE hasToken(s, 'word42') WHERE hasToken(s, 'word42');
+SELECT count() FROM t_text_mdp PREWHERE hasToken(s, 'word42') WHERE hasToken(s, 'word42') SETTINGS make_distributed_plan = 0;
+
+SELECT '-- the plan distributes';
+
+SELECT 'distributes'
+FROM (EXPLAIN PIPELINE SELECT count() FROM t_text_mdp WHERE hasToken(s, 'word42'))
+WHERE explain LIKE '%ReadFromDistributedPlanSource%' LIMIT 1;
+
+SELECT '-- LIKE by dictionary scan (pattern queries)';
+
+SELECT count() FROM t_text_mdp WHERE s LIKE '%word42%'
+    SETTINGS use_text_index_like_evaluation_by_dictionary_scan = 1;
+SELECT count() FROM t_text_mdp WHERE s LIKE '%word42%'
+    SETTINGS use_text_index_like_evaluation_by_dictionary_scan = 1, make_distributed_plan = 0;
+
+SELECT count() FROM t_text_mdp WHERE s ILIKE '%WORD42%'
+    SETTINGS use_text_index_like_evaluation_by_dictionary_scan = 1;
+SELECT count() FROM t_text_mdp WHERE s ILIKE '%WORD42%'
+    SETTINGS use_text_index_like_evaluation_by_dictionary_scan = 1, make_distributed_plan = 0;
+
+DROP TABLE t_text_mdp;
+
+SELECT '-- a part without the materialized index uses the shipped default expression';
+
+DROP TABLE IF EXISTS t_text_mdp_mat;
+CREATE TABLE t_text_mdp_mat (id UInt64, s String) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO t_text_mdp_mat SELECT number, 'word' || toString(number) FROM numbers(1000);
+ALTER TABLE t_text_mdp_mat ADD INDEX idx_text s TYPE text(tokenizer = 'splitByNonAlpha');
+INSERT INTO t_text_mdp_mat SELECT number, 'word' || toString(number) FROM numbers(1000, 1000);
+
+SELECT count() FROM t_text_mdp_mat WHERE hasToken(s, 'word42');
+SELECT count() FROM t_text_mdp_mat WHERE hasToken(s, 'word42') SETTINGS make_distributed_plan = 0;
+SELECT count() FROM t_text_mdp_mat WHERE hasToken(s, 'word1042');
+SELECT count() FROM t_text_mdp_mat WHERE hasToken(s, 'word1042') SETTINGS make_distributed_plan = 0;
+SELECT count() FROM t_text_mdp_mat WHERE hasAnyTokens(s, ['word42', 'word1042']);
+SELECT count() FROM t_text_mdp_mat WHERE hasAnyTokens(s, ['word42', 'word1042']) SETTINGS make_distributed_plan = 0;
+
+DROP TABLE t_text_mdp_mat;
+
+SELECT '-- preprocessor index';
+
+DROP TABLE IF EXISTS t_text_mdp_prep;
+CREATE TABLE t_text_mdp_prep (id UInt64, s String, INDEX idx_text (s) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(s)))
+    ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO t_text_mdp_prep SELECT number, 'WORD' || toString(number) FROM numbers(10000);
+
+SELECT count() FROM t_text_mdp_prep WHERE hasToken(s, 'WoRd42');
+SELECT count() FROM t_text_mdp_prep WHERE hasToken(s, 'WoRd42') SETTINGS make_distributed_plan = 0;
+SELECT count() FROM t_text_mdp_prep WHERE hasAnyTokens(s, ['word42', 'WORD43']);
+SELECT count() FROM t_text_mdp_prep WHERE hasAnyTokens(s, ['word42', 'WORD43']) SETTINGS make_distributed_plan = 0;
+
+DROP TABLE t_text_mdp_prep;
+
+SELECT '-- postprocessor index (hint mode)';
+
+DROP TABLE IF EXISTS t_text_mdp_post;
+CREATE TABLE t_text_mdp_post (id UInt64, val Array(String), INDEX idx (val) TYPE text(tokenizer = 'array', postprocessor = lower(val)))
+    ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO t_text_mdp_post VALUES (1, ['Foo']), (2, ['BAR']), (3, ['baz']);
+
+SELECT count() FROM t_text_mdp_post WHERE has(val, 'Foo');
+SELECT count() FROM t_text_mdp_post WHERE has(val, 'Foo') SETTINGS make_distributed_plan = 0;
+SELECT count() FROM t_text_mdp_post WHERE has(val, 'foo');
+SELECT count() FROM t_text_mdp_post WHERE has(val, 'foo') SETTINGS make_distributed_plan = 0;
+
+DROP TABLE t_text_mdp_post;
+
+SELECT '-- phrase search';
+
+DROP TABLE IF EXISTS t_text_mdp_phrase;
+CREATE TABLE t_text_mdp_phrase (id UInt64, s String, INDEX idx_text (s) TYPE text(tokenizer = splitByNonAlpha, support_phrase_search = 1))
+    ENGINE = MergeTree ORDER BY id SETTINGS allow_experimental_text_index_phrase_search = 1;
+
+INSERT INTO t_text_mdp_phrase SELECT number, if(number % 100 = 42, 'hello brave world', 'brave hello new world') FROM numbers(10000);
+
+SELECT count() FROM t_text_mdp_phrase WHERE hasPhrase(s, 'hello brave');
+SELECT count() FROM t_text_mdp_phrase WHERE hasPhrase(s, 'hello brave') SETTINGS make_distributed_plan = 0;
+SELECT count() FROM t_text_mdp_phrase WHERE hasPhrase(s, 'brave world');
+SELECT count() FROM t_text_mdp_phrase WHERE hasPhrase(s, 'brave world') SETTINGS make_distributed_plan = 0;
+
+DROP TABLE t_text_mdp_phrase;

--- a/tests/queries/0_stateless/04837_text_index_direct_read_pr_plan_based_support.reference
+++ b/tests/queries/0_stateless/04837_text_index_direct_read_pr_plan_based_support.reference
@@ -1,0 +1,12 @@
+-- exact mode
+1
+1
+2
+2
+4242
+4242
+-- the same predicate in PREWHERE and WHERE
+1
+1
+-- the plan splits into a local and a remote parallel-replicas read
+1	1	1

--- a/tests/queries/0_stateless/04837_text_index_direct_read_pr_plan_based_support.reference
+++ b/tests/queries/0_stateless/04837_text_index_direct_read_pr_plan_based_support.reference
@@ -10,3 +10,6 @@
 1
 -- the plan splits into a local and a remote parallel-replicas read
 1	1	1
+-- a join side with a direct text-index read (filter-sensitive result)
+2
+2

--- a/tests/queries/0_stateless/04837_text_index_direct_read_pr_plan_based_support.sql
+++ b/tests/queries/0_stateless/04837_text_index_direct_read_pr_plan_based_support.sql
@@ -1,0 +1,52 @@
+-- Direct read from a text index under plan-based parallel replicas. The captured fragment carries
+-- the __text_index_* rewrite; a remote replica receives the serialized ReadFromMergeTree together
+-- with the text search queries behind the virtual columns and rebuilds the index read tasks against
+-- its own copy of the table. Every query is repeated with enable_parallel_replicas = 0; the results
+-- must be identical.
+
+DROP TABLE IF EXISTS t_text_pr_plan;
+
+CREATE TABLE t_text_pr_plan (id UInt64, s String, INDEX idx_text s TYPE text(tokenizer = 'splitByNonAlpha'))
+    ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO t_text_pr_plan SELECT number, 'word' || toString(number) FROM numbers(100000);
+
+SET enable_analyzer = 1;
+SET enable_parallel_replicas = 1;
+SET parallel_replicas_for_non_replicated_merge_tree = 1;
+SET max_parallel_replicas = 3;
+SET cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost';
+SET parallel_replicas_plan_based = 1;
+SET parallel_replicas_local_plan = 1;
+-- Pin the manual mode: otherwise CI's randomized automatic_parallel_replicas_mode can cost-decide
+-- against parallel replicas for this small table, so the plan-based split does not engage.
+SET automatic_parallel_replicas_mode = 0;
+SET query_plan_direct_read_from_text_index = 1, use_skip_indexes = 1, use_skip_indexes_on_data_read = 1;
+
+SELECT '-- exact mode';
+
+SELECT count() FROM t_text_pr_plan WHERE hasToken(s, 'word42');
+SELECT count() FROM t_text_pr_plan WHERE hasToken(s, 'word42') SETTINGS enable_parallel_replicas = 0;
+
+SELECT count() FROM t_text_pr_plan WHERE hasAnyTokens(s, ['word42', 'word43', 'nonexistent']);
+SELECT count() FROM t_text_pr_plan WHERE hasAnyTokens(s, ['word42', 'word43', 'nonexistent']) SETTINGS enable_parallel_replicas = 0;
+
+SELECT sum(id) FROM t_text_pr_plan WHERE hasAllTokens(s, ['word4242']);
+SELECT sum(id) FROM t_text_pr_plan WHERE hasAllTokens(s, ['word4242']) SETTINGS enable_parallel_replicas = 0;
+
+SELECT '-- the same predicate in PREWHERE and WHERE';
+
+-- The fuzzer shape that used to throw the logical error `Column ... already added for reading`
+-- when the local fragment of a plan-based parallel-replicas plan was re-optimized.
+SELECT count() FROM t_text_pr_plan PREWHERE hasToken(s, 'word42') WHERE hasToken(s, 'word42');
+SELECT count() FROM t_text_pr_plan PREWHERE hasToken(s, 'word42') WHERE hasToken(s, 'word42') SETTINGS enable_parallel_replicas = 0;
+
+SELECT '-- the plan splits into a local and a remote parallel-replicas read';
+
+SELECT
+    countIf(explain LIKE '%Union%') > 0 AS has_union,
+    countIf(explain LIKE '%ReadFromParallelReplicas%') > 0 AS has_remote_read,
+    countIf(explain LIKE '%ReadFromMergeTree%') > 0 AS has_local_read
+FROM (EXPLAIN pretty=0, description=0 SELECT count() FROM t_text_pr_plan WHERE hasToken(s, 'word42'));
+
+DROP TABLE t_text_pr_plan;

--- a/tests/queries/0_stateless/04837_text_index_direct_read_pr_plan_based_support.sql
+++ b/tests/queries/0_stateless/04837_text_index_direct_read_pr_plan_based_support.sql
@@ -49,4 +49,26 @@ SELECT
     countIf(explain LIKE '%ReadFromMergeTree%') > 0 AS has_local_read
 FROM (EXPLAIN pretty=0, description=0 SELECT count() FROM t_text_pr_plan WHERE hasToken(s, 'word42'));
 
+-- The join shape from #112723: one join side carries a direct text-index read, and the result is
+-- sensitive to that filter ('world bbb' matches the join key but not the token filter), so losing
+-- the shipped index read tasks would silently change the result.
+SELECT '-- a join side with a direct text-index read (filter-sensitive result)';
+
+DROP TABLE IF EXISTS t_pr_join_l;
+DROP TABLE IF EXISTS t_pr_join_r;
+
+CREATE TABLE t_pr_join_r (s String, INDEX idx s TYPE text(tokenizer = 'splitByNonAlpha'))
+    ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_pr_join_r VALUES ('hello aaa'), ('world bbb'), ('hello ccc');
+
+CREATE TABLE t_pr_join_l (s String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_pr_join_l VALUES ('hello aaa'), ('world bbb'), ('hello ccc'), ('unmatched');
+
+SELECT count() FROM t_pr_join_l AS l JOIN t_pr_join_r AS r ON l.s = r.s WHERE hasToken(r.s, 'hello');
+SELECT count() FROM t_pr_join_l AS l JOIN t_pr_join_r AS r ON l.s = r.s WHERE hasToken(r.s, 'hello')
+    SETTINGS enable_parallel_replicas = 0;
+
+DROP TABLE t_pr_join_l;
+DROP TABLE t_pr_join_r;
+
 DROP TABLE t_text_pr_plan;


### PR DESCRIPTION
### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Direct read from a text index now works in distributed query plans: with `make_distributed_plan = 1` and with plan-based parallel replicas.

Fixes #112723.
Fixes #108818.
Fixes #109329.
