### PR TITLE
PromQL/TimeSeries: use dense indexing for vectorized tag transformations

### DIFF
--- a/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
@@ -1078,22 +1078,54 @@ Group ContextTimeSeriesTagsCollector::transformTags(Group group, TransformFunc &
 template <typename TransformFunc>
 VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::transformTags(const VectorWithMemoryTracking<Group> & groups_, TransformFunc && transform_func)
 {
+    if (groups_.empty())
+        return {};
+
     auto tags_vector = getTagsByGroup(groups_);
     chassert(tags_vector.size() == groups_.size());
 
-    std::unordered_map<Group, size_t> indices_in_result_vector;
+    VectorWithMemoryTracking<Group> res;
+    res.resize(groups_.size());
+
     size_t num_new_tags = 0;
 
-    for (size_t i = 0; i != groups_.size(); ++i)
+    auto [min_group_it, max_group_it] = std::minmax_element(groups_.begin(), groups_.end());
+    Group min_group = *min_group_it;
+    Group group_range = *max_group_it - min_group;
+
+    /// Groups are dense integer indices, and a block usually contains a compact range of them.
+    /// Avoid a large lookup array when a block contains only a sparse subset of all known groups.
+    constexpr size_t max_dense_range_to_input_size_ratio = 4;
+    bool use_dense_mapping = group_range / groups_.size() < max_dense_range_to_input_size_ratio;
+
+    if (use_dense_mapping)
     {
-        Group group = groups_[i];
-        auto it = indices_in_result_vector.find(group);
-        if (it == indices_in_result_vector.end())
+        const size_t not_found = groups_.size();
+        VectorWithMemoryTracking<size_t> indices_by_group;
+        indices_by_group.resize(static_cast<size_t>(group_range) + 1, not_found);
+
+        for (size_t i = 0; i != groups_.size(); ++i)
         {
-            const auto & old_tags = tags_vector[i];
-            auto new_tags = transform_func(old_tags);
-            indices_in_result_vector[group] = num_new_tags;
-            tags_vector[num_new_tags++] = new_tags;
+            size_t & index = indices_by_group[groups_[i] - min_group];
+            if (index == not_found)
+            {
+                index = num_new_tags;
+                tags_vector[num_new_tags++] = transform_func(tags_vector[i]);
+            }
+            res[i] = index;
+        }
+    }
+    else
+    {
+        std::unordered_map<Group, size_t> indices_by_group;
+
+        for (size_t i = 0; i != groups_.size(); ++i)
+        {
+            Group group = groups_[i];
+            auto [it, inserted] = indices_by_group.try_emplace(group, num_new_tags);
+            if (inserted)
+                tags_vector[num_new_tags++] = transform_func(tags_vector[i]);
+            res[i] = it->second;
         }
     }
 
@@ -1101,14 +1133,8 @@ VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::transformTags(co
 
     auto new_groups = getGroupForTags(tags_vector);
 
-    VectorWithMemoryTracking<Group> res;
-    res.reserve(groups_.size());
-
-    for (auto old_group : groups_)
-    {
-        auto new_group = new_groups.at(indices_in_result_vector.at(old_group));
-        res.push_back(new_group);
-    }
+    for (auto & index : res)
+        index = new_groups.at(index);
 
     return res;
 }

--- a/tests/performance/promql_tags_transform.xml
+++ b/tests/performance/promql_tags_transform.xml
@@ -1,0 +1,65 @@
+<test>
+    <settings>
+        <allow_experimental_time_series_table>1</allow_experimental_time_series_table>
+        <max_insert_threads>8</max_insert_threads>
+    </settings>
+
+    <!-- Isolate vectorized tag transformation over unique and repeated dense group ids. -->
+    <query>
+        SELECT timeSeriesRemoveTag(
+            timeSeriesTagsToGroup(
+                [('__name__', 'metric'), ('namespace', toString(number % 100)), ('pod', toString(number))]),
+            '__name__')
+        FROM numbers(500000)
+        SETTINGS max_threads = 1
+        FORMAT Null
+    </query>
+
+    <query>
+        SELECT timeSeriesRemoveAllTagsExcept(
+            timeSeriesTagsToGroup(
+                [('__name__', 'metric'), ('namespace', toString(number % 100)), ('pod', toString(number % 10000))]),
+            ['namespace'])
+        FROM numbers(500000)
+        SETTINGS max_threads = 1
+        FORMAT Null
+    </query>
+
+    <!-- Exercise two repeated groups at the largest range accepted by the dense lookup heuristic. -->
+    <query>
+        WITH
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('shared', 'value'), ('unique', toString(number))]) AS group
+                    FROM numbers(262144)
+                    ORDER BY number
+                )
+            ) AS groups
+        SELECT timeSeriesRemoveAllTagsExcept(groups[if(number % 2 = 0, 1, 262144)], ['shared'])
+        FROM numbers(65536)
+        SETTINGS max_threads = 1, max_block_size = 65536
+        FORMAT Null
+    </query>
+
+    <!-- Exercise the same transformations through realistic instant PromQL aggregation and matching. -->
+    <create_query>
+        CREATE TABLE promql_tags_transform ENGINE = TimeSeries
+    </create_query>
+
+    <fill_query>
+        INSERT INTO promql_tags_transform (metric_name, tags, time_series)
+        SELECT
+            if(number &lt; 100000, 'foo', 'bar'),
+            map('namespace', 'ns' || toString(intDiv(number % 100000, 1000)), 'pod', 'pod' || toString(number % 100000)),
+            [(toDateTime64(100, 3), number::Float64)]
+        FROM numbers_mt(200000)
+    </fill_query>
+
+    <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'sum by (namespace) (foo)', 100) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'foo / on(pod) bar', 100) FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS promql_tags_transform</drop_query>
+</test>

--- a/tests/performance/promql_tags_transform.xml
+++ b/tests/performance/promql_tags_transform.xml
@@ -4,28 +4,50 @@
         <max_insert_threads>8</max_insert_threads>
     </settings>
 
-    <!-- Isolate vectorized tag transformation over unique and repeated dense group ids. -->
+    <!-- Register each unique tag group once, then replay the groups across multiple vectorized blocks so the
+         measured time is dominated by tag transformation rather than query-scoped tag registration. -->
     <query>
-        SELECT timeSeriesRemoveTag(
-            timeSeriesTagsToGroup(
-                [('__name__', 'metric'), ('namespace', toString(number % 100)), ('pod', toString(number))]),
-            '__name__')
-        FROM numbers(500000)
-        SETTINGS max_threads = 1
+        WITH
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT
+                        number,
+                        timeSeriesTagsToGroup(
+                            [('__name__', 'metric'), ('namespace', toString(number % 100)), ('pod', toString(number))]) AS group
+                    FROM numbers(500000)
+                    ORDER BY number
+                )
+            ) AS groups
+        SELECT timeSeriesRemoveTag(groups[number % 500000 + 1], '__name__')
+        FROM numbers(5000000)
+        SETTINGS max_threads = 1, max_block_size = 500000
         FORMAT Null
     </query>
 
     <query>
-        SELECT timeSeriesRemoveAllTagsExcept(
-            timeSeriesTagsToGroup(
-                [('__name__', 'metric'), ('namespace', toString(number % 100)), ('pod', toString(number % 10000))]),
-            ['namespace'])
-        FROM numbers(500000)
-        SETTINGS max_threads = 1
+        WITH
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT
+                        number,
+                        timeSeriesTagsToGroup(
+                            [('__name__', 'metric'), ('namespace', toString(number % 100)), ('pod', toString(number))]) AS group
+                    FROM numbers(10000)
+                    ORDER BY number
+                )
+            ) AS groups
+        SELECT timeSeriesRemoveAllTagsExcept(groups[number % 10000 + 1], ['namespace'])
+        FROM numbers(5000000)
+        SETTINGS max_threads = 1, max_block_size = 500000
         FORMAT Null
     </query>
 
-    <!-- Exercise two repeated groups at the largest range accepted by the dense lookup heuristic. -->
+    <!-- Exercise two repeated groups at the largest range accepted by the dense lookup heuristic for a
+         4096-row block. Repeating the block amortizes the one-time registration of all intervening groups. -->
     <query>
         WITH
             (
@@ -34,13 +56,32 @@
                 (
                     SELECT number,
                            timeSeriesTagsToGroup([('shared', 'value'), ('unique', toString(number))]) AS group
-                    FROM numbers(262144)
+                    FROM numbers(16384)
                     ORDER BY number
                 )
             ) AS groups
-        SELECT timeSeriesRemoveAllTagsExcept(groups[if(number % 2 = 0, 1, 262144)], ['shared'])
-        FROM numbers(65536)
-        SETTINGS max_threads = 1, max_block_size = 65536
+        SELECT timeSeriesRemoveAllTagsExcept(groups[if(number % 2 = 0, 1, 16384)], ['shared'])
+        FROM numbers(4096000)
+        SETTINGS max_threads = 1, max_block_size = 4096
+        FORMAT Null
+    </query>
+
+    <!-- Keep a wide-range control on the sparse fallback, also replayed across many blocks. -->
+    <query>
+        WITH
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('shared', 'value'), ('unique', toString(number))]) AS group
+                    FROM numbers(40000)
+                    ORDER BY number
+                )
+            ) AS groups
+        SELECT timeSeriesRemoveAllTagsExcept(groups[if(number % 2 = 0, 1, 40000)], ['shared'])
+        FROM numbers(4096000)
+        SETTINGS max_threads = 1, max_block_size = 4096
         FORMAT Null
     </query>
 

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.reference
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.reference
@@ -33,3 +33,23 @@ timeSeriesReplaceTag (2):
 
 timeSeriesThrowDuplicateSeriesIf:
 0
+
+timeSeriesRemoveTag vectorized dense groups:
+[('instance','0')]
+[('instance','1')]
+[('instance','2')]
+[('instance','3')]
+[('instance','4')]
+[('instance','5')]
+
+timeSeriesRemoveTag vectorized sparse groups:
+[('instance','0')]
+[('instance','8')]
+[('instance','16')]
+[('instance','24')]
+
+timeSeriesRemoveAllTagsExcept vectorized repeated dense groups:
+6	1	[[('shared','value')]]
+
+timeSeriesRemoveAllTagsExcept vectorized repeated sparse groups:
+5	1	[[('shared','value')]]

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.sql
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.sql
@@ -273,3 +273,80 @@ FROM
 (
     SELECT timeSeriesTagsToGroup([('__name__', 'up')]) AS group
 );  -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+
+SELECT '';
+SELECT 'timeSeriesRemoveTag vectorized dense groups:';
+
+SELECT timeSeriesGroupToTags(new_group)
+FROM
+(
+    SELECT number,
+           timeSeriesTagsToGroup([('__name__', 'metric'), ('instance', toString(number))]) AS old_group,
+           timeSeriesRemoveTag(old_group, '__name__') AS new_group
+    FROM numbers(6)
+)
+ORDER BY number;
+
+SELECT '';
+SELECT 'timeSeriesRemoveTag vectorized sparse groups:';
+
+WITH
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('__name__', 'metric'), ('instance', toString(number))]) AS group
+            FROM numbers(32)
+            ORDER BY number
+        )
+    ) AS groups
+SELECT timeSeriesGroupToTags(timeSeriesRemoveTag(groups[number * 8 + 1], '__name__'))
+FROM numbers(4)
+ORDER BY number;
+
+SELECT '';
+SELECT 'timeSeriesRemoveAllTagsExcept vectorized repeated dense groups:';
+
+WITH
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('shared', 'value'), ('unique', toString(number))]) AS group
+            FROM numbers(3)
+            ORDER BY number
+        )
+    ) AS groups
+SELECT count(),
+       uniqExact(new_group),
+       groupUniqArray(timeSeriesGroupToTags(new_group))
+FROM
+(
+    SELECT timeSeriesRemoveAllTagsExcept(groups[[1, 2, 1, 3, 2, 1][number + 1]], ['shared']) AS new_group
+    FROM numbers(6)
+);
+
+SELECT '';
+SELECT 'timeSeriesRemoveAllTagsExcept vectorized repeated sparse groups:';
+
+WITH
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('shared', 'value'), ('unique', toString(number))]) AS group
+            FROM numbers(32)
+            ORDER BY number
+        )
+    ) AS groups
+SELECT count(),
+       uniqExact(new_group),
+       groupUniqArray(timeSeriesGroupToTags(new_group))
+FROM
+(
+    SELECT timeSeriesRemoveAllTagsExcept(groups[[1, 25, 1, 25, 1][number + 1]], ['shared']) AS new_group
+    FROM numbers(5)
+);


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up vectorized TimeSeries tag transformations by replacing hash-based remapping with direct indexing when tag-group IDs occupy a compact range.

### Description

#### Problem

`ContextTimeSeriesTagsCollector` assigns tag groups consecutive integer IDs, but vectorized `transformTags()` stored the mapping from each old group to its transformed slot in a node-based `std::unordered_map`. Every input row performed a hash lookup while deduplicating groups and another hash lookup while reconstructing the result.

This path is used by TimeSeries tag operations such as removing, retaining, joining, and replacing tags, including the tag transformations generated for PromQL grouping and vector matching.

#### Change

For the common case where the group IDs in a block occupy a compact range, the mapping is now a lookup array indexed by `group - min_group`. The result column temporarily stores the transformed slot for each row, then rewrites those slots with the new group IDs, removing the second lookup.

A block whose ID range is at least four times its row count keeps the hash-map path, so a sparse subset of globally dense IDs cannot cause a large allocation. The sparse path also reuses the stored slot and avoids its previous second lookup.

The two-input `transformTags2()` path is intentionally unchanged.

#### Measured effect

An isolated remapping microbenchmark over 500,000 rows showed:

| input | before | after | speedup |
|---|--:|--:|--:|
| 500,000 unique groups in a compact range | 73.98 ms | 1.92 ms | **38.6x** |
| 10,000 repeated groups in a compact range | 3.53 ms | 1.50 ms | **2.35x** |
| sparse groups using the fallback | 68.13 ms | 64.86 ms | **1.05x** |

The dense threshold was also tested with 65,536 rows alternating between only two groups whose IDs differ by 262,143. This allocates a 2 MiB lookup array, the largest range admitted for that row count. Direct indexing took 0.200 ms versus 0.278 ms for the sparse `try_emplace` path, a **1.39x speedup**, so the dense path still wins in this deliberately unfavorable distribution.

`resize()` plus indexed result stores was retained after measuring it against `reserve()` plus `push_back()`: indexed stores were 1-15% faster across the unique, repeated, and threshold distributions.

These measurements isolate the group-to-slot remapping loop; they do not include tag transformation, tag registration, or complete query execution. `tests/performance/promql_tags_transform.xml` registers each unique tag group once, then replays the query-scoped group IDs across multiple vectorized blocks. It covers 500,000 unique groups and 10,000 repeated dense groups over 5 million transformed rows, dense-threshold and sparse-fallback controls over 4,096,000 rows each, and realistic instant PromQL aggregation and vector matching over 200,000 series.

#### Tests

Extended `03779_time_series_tags_functions` with compact and forced-sparse vectorized cases. Repeated dense and repeated sparse cases verify that each old group is deduplicated and that distinct old groups may collapse to the same transformed tag group. Added `promql_tags_transform.xml` covering replayed unique and repeated dense groups, dense-threshold and sparse-fallback controls, instant `sum by (...)`, and instant matching with `on(...)`.
