### PR TITLE
Isolate `00180_no_seek_avoiding_when_reading_from_cache` from other cache users

### DIFF
--- a/tests/queries/0_stateless/00180_no_seek_avoiding_when_reading_from_cache.sh
+++ b/tests/queries/0_stateless/00180_no_seek_avoiding_when_reading_from_cache.sh
@@ -6,14 +6,29 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 
-# Test assumes that the whole table is residing in the cache, but `hits_s3` has only 128Mi of cache.
-# So we need to create a smaller table.
+# The queries below require the whole table to be in the cache, so it needs a cache large enough to
+# hold it and private to this test: on the shared `s3_cache` another user can hold every segment
+# non-releasable, and a reservation that then finds nothing to evict silently reads past the cache.
+# `test.hits_s3` is too large, hence the 1% sample.
+cache_name="cache_00180_${CLICKHOUSE_DATABASE}"
+
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS hits_s3_sampled"
-$CLICKHOUSE_CLIENT -q "CREATE TABLE hits_s3_sampled AS test.hits_s3"
+$CLICKHOUSE_CLIENT -q "
+    CREATE TABLE hits_s3_sampled AS test.hits_s3
+    ENGINE = MergeTree
+    SETTINGS disk = disk(
+        type = cache,
+        name = '$cache_name',
+        path = '$cache_name/',
+        max_size = '1Gi',
+        max_file_segment_size = '5Mi',
+        cache_on_write_operations = 1,
+        load_metadata_asynchronously = 0,
+        disk = 's3_disk')"
 $CLICKHOUSE_CLIENT -q "INSERT INTO hits_s3_sampled SELECT * FROM test.hits_s3 SAMPLE 0.01"
 $CLICKHOUSE_CLIENT -q "OPTIMIZE TABLE hits_s3_sampled FINAL"
 
-$CLICKHOUSE_CLIENT -q "SYSTEM CLEAR FILESYSTEM CACHE"
+$CLICKHOUSE_CLIENT -q "SYSTEM CLEAR FILESYSTEM CACHE '$cache_name'"
 
 # Warm up the cache
 $CLICKHOUSE_CLIENT -q "SELECT * FROM hits_s3_sampled WHERE URL LIKE '%google%' ORDER BY EventTime LIMIT 10 FORMAT Null SETTINGS filesystem_cache_reserve_space_wait_lock_timeout_milliseconds=2000"


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/114213
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/114213

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The test asserts that a query reads entirely from the filesystem cache, but its table inherits
`storage_policy = 's3_cache'` from `test.hits_s3`, so it shares one 200 MiB cache with everything
else on the server. Background merges of `test.hits_s3` write through that cache and can fill it
with file segments held open by a `FileSegmentsHolder`. Reservation then finds nothing releasable to
evict, both warm-up queries silently continue without caching, and the measured query reads from S3,
so `CachedReadBufferReadFromSourceBytes` is non-zero. `SYSTEM CLEAR FILESYSTEM CACHE` cannot help:
it removes only releasable segments.

Observed on
[this run](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112921&sha=ba9c3d4cc9183c01f61bc5383eabc5f5d42adc22&name_0=PR&name_1=Stateless%20tests%20(amd_debug,%20sequential)),
where the value was `10667287`. Raising
`filesystem_cache_reserve_space_wait_lock_timeout_milliseconds` and adding `no-parallel` were both
tried before and neither addresses this: the failure is `cannot evict enough space`, not lock
contention, and the competing cache user is the server's own background merge rather than another
test.

The fix gives the table a private inline cache disk, keyed on `$CLICKHOUSE_DATABASE` so it stays
unique per run, and scopes the cache clear to that cache. The assertion, the reference file and the
tags are unchanged. This mirrors `04695_filesystem_cache_wait_for_concurrent_download_timeout.sh`,
which was isolated the same way in `eca7e2270696c02` for the same mechanism. The explicit
`ENGINE = MergeTree` is required: without it the inherited `storage_policy` is merged next to the new
`disk` setting and the statement fails with `storage_policy and disk cannot be specified at the same
time`. Column and key clauses are still copied from the source table.

Shared-cache eviction behaviour stays covered by the other tests on the `s3_cache` policy.

Validation: I reproduced the failure mode locally with a concurrent workload that keeps the shared
cache full of held segments, and synthesized `test.hits_s3` so the real test could run.

<details>
<summary>Validation detail</summary>

Under the concurrent workload, a global `SYSTEM CLEAR FILESYSTEM CACHE` left 229.68 MiB across 46
segments resident, and the server log showed the failing job's signature
`releasable size: 0, releasable count: 0, non-releasable size: 207535569`.

Runs of the real test file via `clickhouse-test`, same binary and same workload:

| Arm | Runs | Result |
|---|---|---|
| Before this change | 20 | 2 pass, 18 fail |
| After this change | 50 | 50 pass |
| After this change, no concurrent workload | 20 | 20 pass |

All 18 failures are the assertion itself, with values such as `0 12123319`, matching the magnitude
seen in CI.

The assertion still catches what it exists for. With the same query and settings against a cold
cache, `AsynchronousReaderIgnoredBytes` is `4607579` and
`CachedReadBufferReadFromSourceBytes` is `7944923`; against the warm private cache both are `0`.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1214` (included in `26.8` and later)
<!-- ch-version-info:end -->