### PR TITLE
Advance the Iceberg version hint on a lost commit race

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -395,6 +395,12 @@ static Poco::JSON::Object::Ptr traverseMetadataAndFindNecessarySnapshotObject(
     return current_snapshot;
 }
 
+bool IcebergMetadata::registerMetadataSchemasAndSnapshots(
+    const Poco::JSON::Object::Ptr & metadata_object, Int64 snapshot_id, IcebergSchemaProcessorPtr schema_processor)
+{
+    return !traverseMetadataAndFindNecessarySnapshotObject(metadata_object, snapshot_id, schema_processor).isNull();
+}
+
 IcebergDataSnapshotPtr IcebergMetadata::createIcebergDataSnapshotFromSnapshotJSON(
     Poco::JSON::Object::Ptr snapshot_object, Int64 snapshot_id, ContextPtr local_context) const
 {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -98,6 +98,13 @@ public:
     std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(ContextPtr local_context, ObjectInfoPtr object_info) const override;
     std::shared_ptr<const ActionsDAG> getSchemaTransformer(ContextPtr local_context, ObjectInfoPtr object_info) const override;
 
+    /// Registers every schema and snapshot->schema binding in the document, applying the same
+    /// per-snapshot requirements a read applies. False if `snapshot_id` is not in the document.
+    static bool registerMetadataSchemasAndSnapshots(
+        const Poco::JSON::Object::Ptr & metadata_object,
+        Int64 snapshot_id,
+        Iceberg::IcebergSchemaProcessorPtr schema_processor);
+
     static Int32 parseTableSchema(
         const Poco::JSON::Object::Ptr & metadata_object,
         Iceberg::IcebergSchemaProcessor & schema_processor,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -106,6 +106,8 @@ namespace DB::Setting
 /// Hard to imagine a hint file larger than 10 MB
 static constexpr size_t MAX_HINT_FILE_SIZE = 10 * 1024 * 1024;
 static constexpr auto MAX_TRANSACTION_RETRIES = 1000;
+/// A contended hint must not turn into MAX_TRANSACTION_RETRIES rounds of probing the target.
+static constexpr size_t MAX_HINT_PUBLISH_ATTEMPTS = 3;
 
 static constexpr size_t MAX_LIST_RETRIES = 5;
 
@@ -323,50 +325,20 @@ void writeMessageToFile(
     }
 }
 
-bool writeMetadataFileAndVersionHint(
-    const IcebergPathResolver & resolver,
-    const GeneratedMetadataFileWithInfo & metadata_file_info,
-    const std::string & metadata_file_content,
-    const IcebergPathFromMetadata & version_hint_path,
-    DB::ObjectStoragePtr object_storage,
-    DB::ContextPtr context,
-    bool try_write_version_hint)
+/// Once any writer has created `version-hint.text`, every subsequent writer must keep it in sync,
+/// otherwise readers with `iceberg_use_version_hint = 1` observe stale data when a writer that does
+/// not have the setting enabled advances the table.
+static void convergeVersionHint(
+    const std::string & storage_version_hint_path,
+    Int32 target_version,
+    const DB::ObjectStoragePtr & object_storage,
+    const DB::ContextPtr & context,
+    bool try_write_version_hint,
+    const std::function<bool()> & can_publish_target = {})
 {
-    auto storage_metadata_path = resolver.resolve(metadata_file_info.path);
-    auto storage_version_hint_path = resolver.resolve(version_hint_path);
-    try
-    {
-        if (object_storage->exists(StoredObject(storage_metadata_path)))
-            return false;
-
-        Iceberg::writeMessageToFile(
-            metadata_file_content,
-            storage_metadata_path,
-            object_storage,
-            context,
-            /* write-if-none-match */ "*",
-            "",
-            metadata_file_info.compression_method);
-    }
-    catch (const Exception & e)
-    {
-        /// A backend that cannot express the commit's compare-and-swap will never be able to, so
-        /// reporting a lost race would make the caller retry an operation that can never succeed.
-        /// Propagate instead; every other failure (including a genuinely lost CAS) stays retryable.
-        if (e.code() == ErrorCodes::UNSUPPORTED_METHOD)
-            throw;
-        tryLogCurrentException(__PRETTY_FUNCTION__);
-        return false;
-    }
-    catch (...)
-    {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
-        return false;
-    }
-
-    /// Once any writer has created `version-hint.text`, every subsequent writer must keep it in
-    /// sync, otherwise readers with `iceberg_use_version_hint = 1` observe stale data when a
-    /// writer that does not have the setting enabled advances the table.
+    /// The objects `can_publish_target` probes are mutable, so its verdict is only valid for the
+    /// write that immediately follows it.
+    size_t publish_attempts = 0;
     size_t i = 0;
     while (i < MAX_TRANSACTION_RETRIES)
     {
@@ -400,13 +372,21 @@ bool writeMetadataFileAndVersionHint(
                 old_version = getMetadataFileAndVersion(version_hint_value).version;
             }
         }
-        if (old_version < metadata_file_info.version)
+        if (old_version < target_version)
         {
+            if (can_publish_target)
+            {
+                if (publish_attempts >= MAX_HINT_PUBLISH_ATTEMPTS)
+                    break;
+                ++publish_attempts;
+                if (!can_publish_target())
+                    break;
+            }
             try
             {
                 /// Write just the version number for Spark/spec compatibility.
                 Iceberg::writeMessageToFile(
-                    std::to_string(metadata_file_info.version),
+                    std::to_string(target_version),
                     storage_version_hint_path,
                     object_storage,
                     context,
@@ -425,6 +405,284 @@ bool writeMetadataFileAndVersionHint(
         }
         ++i;
     }
+}
+
+/// Followable = a reader of this document's current snapshot gets through its manifest list and
+/// finds every object it would then open.
+// NOLINTBEGIN(clang-analyzer-core.uninitialized.UndefReturn)
+// Clang analyzer wrongly thinks the avro GenericDatum value can be uninitialized.
+static bool isMetadataSnapshotFollowable(
+    const Poco::JSON::Object::Ptr & metadata_object,
+    const IcebergPathResolver & resolver,
+    const DB::ObjectStoragePtr & object_storage,
+    const DB::ContextPtr & context)
+{
+    auto log = getLogger("IcebergVersionHintConvergence");
+
+    if (!metadata_object->has(f_current_snapshot_id) || metadata_object->isNull(f_current_snapshot_id))
+        return true;
+    /// `-1` is how a table with no data records "no snapshot" (see `createInitialMetadataFile`).
+    Int64 current_snapshot_id = metadata_object->getValue<Int64>(f_current_snapshot_id);
+    if (current_snapshot_id < 0)
+        return true;
+
+    if (!metadata_object->has(f_snapshots))
+    {
+        LOG_DEBUG(log, "Metadata document has a current snapshot {} but no '{}'", current_snapshot_id, f_snapshots);
+        return false;
+    }
+    auto snapshots = metadata_object->get(f_snapshots).extract<Poco::JSON::Array::Ptr>();
+    for (UInt32 i = 0; i < snapshots->size(); ++i)
+    {
+        auto snapshot = snapshots->getObject(i);
+        if (snapshot->getValue<Int64>(f_metadata_snapshot_id) != current_snapshot_id)
+            continue;
+        if (!snapshot->has(f_manifest_list))
+        {
+            LOG_DEBUG(log, "Snapshot {} has no '{}'", current_snapshot_id, f_manifest_list);
+            return false;
+        }
+        /// Constructing a snapshot requires this, so a reader throws before it opens any object.
+        if (!snapshot->has(f_schema_id))
+        {
+            LOG_DEBUG(log, "Snapshot {} has no '{}'", current_snapshot_id, f_schema_id);
+            return false;
+        }
+        auto manifest_list_path = IcebergPathFromMetadata::deserialize(snapshot->getValue<String>(f_manifest_list));
+        auto resolved_manifest_list_path = resolver.resolve(manifest_list_path);
+        if (!object_storage->exists(StoredObject(resolved_manifest_list_path)))
+        {
+            LOG_DEBUG(log, "Manifest list {} of snapshot {} is missing", resolved_manifest_list_path, current_snapshot_id);
+            return false;
+        }
+
+        try
+        {
+            /// Every field the manifest-list read path requires, with the type it requires; an
+            /// entry failing any of them is one no reader gets past. `type()` resolves a union to
+            /// its branch, so a null reports `AVRO_NULL` and is refused here too.
+            auto reader_would_accept = [&](const avro::GenericRecord & entry, String & rejection)
+            {
+                auto typed = [&](const std::string & field, avro::Type type)
+                {
+                    if (!entry.hasField(field))
+                    {
+                        rejection = fmt::format("is missing '{}'", field);
+                        return false;
+                    }
+                    if (entry.field(field).type() != type)
+                    {
+                        rejection = fmt::format("has '{}' of an unexpected type", field);
+                        return false;
+                    }
+                    return true;
+                };
+
+                if (!typed(f_added_snapshot_id, avro::AVRO_LONG) || !typed(f_manifest_path, avro::AVRO_STRING)
+                    || !typed(f_manifest_length, avro::AVRO_LONG) || !typed(f_partition_spec_id, avro::AVRO_INT))
+                    return false;
+                if (entry.field(f_manifest_length).value<Int64>() < 0)
+                {
+                    rejection = fmt::format("has a negative '{}'", f_manifest_length);
+                    return false;
+                }
+                /// These two the read path takes only when present, but with a fixed type when it
+                /// does, so absence is acceptable here and a wrong type is not.
+                for (const auto & [field, type] : {std::pair{f_sequence_number, avro::AVRO_LONG},
+                                                   std::pair{f_content, avro::AVRO_INT}})
+                {
+                    if (entry.hasField(field) && !typed(field, type))
+                        return false;
+                }
+                return true;
+            };
+
+            /// A carried-forward manifest keeps its original adder id, so only the snapshot's own
+            /// files are at risk.
+            auto is_added_by_current_snapshot = [&](const avro::GenericRecord & entry)
+            { return entry.field(f_added_snapshot_id).value<Int64>() == current_snapshot_id; };
+
+            bool every_object_present = true;
+            std::vector<String> manifests_added_by_current_snapshot;
+            forEachAvroEntry(
+                resolved_manifest_list_path,
+                object_storage,
+                context,
+                "IcebergVersionHintConvergence",
+                [&](const avro::GenericDatum & datum)
+                {
+                    if (!every_object_present)
+                        return;
+                    const auto & entry = datum.value<avro::GenericRecord>();
+                    String rejection;
+                    if (!reader_would_accept(entry, rejection))
+                    {
+                        LOG_DEBUG(
+                            log,
+                            "Manifest list {} has an entry that {}, which a reader rejects",
+                            resolved_manifest_list_path,
+                            rejection);
+                        every_object_present = false;
+                        return;
+                    }
+                    auto manifest_path
+                        = IcebergPathFromMetadata::deserialize(entry.field(f_manifest_path).value<std::string>());
+                    auto resolved_manifest_path = resolver.resolve(manifest_path);
+                    if (!object_storage->exists(StoredObject(resolved_manifest_path)))
+                    {
+                        LOG_DEBUG(log, "Manifest {} named by {} is missing", resolved_manifest_path, resolved_manifest_list_path);
+                        every_object_present = false;
+                        return;
+                    }
+                    if (is_added_by_current_snapshot(entry))
+                        manifests_added_by_current_snapshot.push_back(resolved_manifest_path);
+                });
+            if (!every_object_present)
+                return false;
+
+            for (const auto & resolved_manifest_path : manifests_added_by_current_snapshot)
+            {
+                forEachAvroEntry(
+                    resolved_manifest_path,
+                    object_storage,
+                    context,
+                    "IcebergVersionHintConvergence",
+                    [&](const avro::GenericDatum & datum)
+                    {
+                        if (!every_object_present)
+                            return;
+                        const auto & entry = datum.value<avro::GenericRecord>();
+                        /// Only an ADDED entry names a file this snapshot wrote; an EXISTING one
+                        /// belongs to an ancestor and a DELETED one is no longer required.
+                        if (entry.field(f_status).value<Int32>() != static_cast<Int32>(ManifestEntryStatus::ADDED))
+                            return;
+                        auto file_path = IcebergPathFromMetadata::deserialize(
+                            entry.field(f_data_file).value<avro::GenericRecord>().field(f_file_path).value<std::string>());
+                        auto resolved_file_path = resolver.resolve(file_path);
+                        if (!object_storage->exists(StoredObject(resolved_file_path)))
+                        {
+                            LOG_DEBUG(log, "File {} named by {} is missing", resolved_file_path, resolved_manifest_path);
+                            every_object_present = false;
+                        }
+                    });
+                if (!every_object_present)
+                    return false;
+            }
+            return true;
+        }
+        catch (...)
+        {
+            /// What cannot be read here is what a reader could not read either.
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+            return false;
+        }
+    }
+    LOG_DEBUG(log, "Current snapshot {} is absent from the document's own '{}'", current_snapshot_id, f_snapshots);
+    return false;
+}
+// NOLINTEND(clang-analyzer-core.uninitialized.UndefReturn)
+
+/// The target metadata file already exists, so a hint naming an earlier version is behind. The
+/// target existing does not authorize publishing it: only a reader being able to follow it does.
+/// Always returns `false`, so the caller still sees a lost race.
+static bool convergeVersionHintForLostRace(
+    const std::string & storage_metadata_path,
+    const std::string & storage_version_hint_path,
+    const IcebergPathResolver & resolver,
+    Int32 target_version,
+    CompressionMethod compression_method,
+    const DB::ObjectStoragePtr & object_storage,
+    const DB::ContextPtr & context,
+    bool try_write_version_hint)
+{
+    try
+    {
+        /// Reached only where the hint would otherwise be written, so no read happens when the hint
+        /// is absent, already current, or ahead.
+        auto can_publish_target = [&]
+        {
+            /// `metadata_cache = nullptr`: a probe must not publish this document to other readers.
+            auto metadata_object = getMetadataJSONObject(
+                storage_metadata_path,
+                object_storage,
+                /* metadata_cache */ nullptr,
+                context,
+                getLogger("IcebergVersionHintConvergence"),
+                compression_method,
+                /* table_uuid */ std::nullopt);
+
+            if (!metadata_object)
+                return false;
+
+            return isMetadataSnapshotFollowable(metadata_object, resolver, object_storage, context);
+        };
+
+        convergeVersionHint(
+            storage_version_hint_path,
+            target_version,
+            object_storage,
+            context,
+            try_write_version_hint,
+            can_publish_target);
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+    return false;
+}
+
+bool writeMetadataFileAndVersionHint(
+    const IcebergPathResolver & resolver,
+    const GeneratedMetadataFileWithInfo & metadata_file_info,
+    const std::string & metadata_file_content,
+    const IcebergPathFromMetadata & version_hint_path,
+    DB::ObjectStoragePtr object_storage,
+    DB::ContextPtr context,
+    bool try_write_version_hint)
+{
+    auto storage_metadata_path = resolver.resolve(metadata_file_info.path);
+    auto storage_version_hint_path = resolver.resolve(version_hint_path);
+    try
+    {
+        if (object_storage->exists(StoredObject(storage_metadata_path)))
+            return convergeVersionHintForLostRace(
+                storage_metadata_path,
+                storage_version_hint_path,
+                resolver,
+                metadata_file_info.version,
+                metadata_file_info.compression_method,
+                object_storage,
+                context,
+                try_write_version_hint);
+
+        Iceberg::writeMessageToFile(
+            metadata_file_content,
+            storage_metadata_path,
+            object_storage,
+            context,
+            /* write-if-none-match */ "*",
+            "",
+            metadata_file_info.compression_method);
+    }
+    catch (const Exception & e)
+    {
+        /// A backend that cannot express the commit's compare-and-swap will never be able to, so
+        /// reporting a lost race would make the caller retry an operation that can never succeed.
+        /// Propagate instead; every other failure (including a genuinely lost CAS) stays retryable.
+        if (e.code() == ErrorCodes::UNSUPPORTED_METHOD)
+            throw;
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+        return false;
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+        return false;
+    }
+
+    convergeVersionHint(
+        storage_version_hint_path, metadata_file_info.version, object_storage, context, try_write_version_hint);
 
     return true;
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -25,6 +25,7 @@
 #include <Storages/ColumnsDescription.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergTableStateSnapshot.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h>
+#include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/PersistentTableComponents.h>
 #include <base/getThreadId.h>
@@ -99,6 +100,7 @@ namespace ProfileEvents
 
 namespace DB::Setting
 {
+    extern const SettingsBool allow_experimental_geo_types_in_iceberg;
     extern const SettingsUInt64 iceberg_metadata_staleness_ms;
     extern const SettingsUInt64 output_format_compression_level;
 }
@@ -409,15 +411,28 @@ static void convergeVersionHint(
 
 /// Followable = a reader of this document's current snapshot gets through its manifest list and
 /// finds every object it would then open.
-// NOLINTBEGIN(clang-analyzer-core.uninitialized.UndefReturn)
-// Clang analyzer wrongly thinks the avro GenericDatum value can be uninitialized.
 static bool isMetadataSnapshotFollowable(
     const Poco::JSON::Object::Ptr & metadata_object,
     const IcebergPathResolver & resolver,
+    CompressionMethod compression_method,
     const DB::ObjectStoragePtr & object_storage,
     const DB::ContextPtr & context)
 {
     auto log = getLogger("IcebergVersionHintConvergence");
+
+    /// The read path parses the document's own schema before it looks for a snapshot, so a
+    /// document that cannot be parsed at all is refused here without examining one either.
+    auto schema_processor = std::make_shared<IcebergSchemaProcessor>(
+        context->getSettingsRef()[Setting::allow_experimental_geo_types_in_iceberg]);
+    try
+    {
+        IcebergMetadata::parseTableSchema(metadata_object, *schema_processor, log);
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+        return false;
+    }
 
     if (!metadata_object->has(f_current_snapshot_id) || metadata_object->isNull(f_current_snapshot_id))
         return true;
@@ -458,115 +473,67 @@ static bool isMetadataSnapshotFollowable(
 
         try
         {
-            /// Every field the manifest-list read path requires, with the type it requires; an
-            /// entry failing any of them is one no reader gets past. `type()` resolves a union to
-            /// its branch, so a null reports `AVRO_NULL` and is refused here too.
-            auto reader_would_accept = [&](const avro::GenericRecord & entry, String & rejection)
-            {
-                auto typed = [&](const std::string & field, avro::Type type)
-                {
-                    if (!entry.hasField(field))
-                    {
-                        rejection = fmt::format("is missing '{}'", field);
-                        return false;
-                    }
-                    if (entry.field(field).type() != type)
-                    {
-                        rejection = fmt::format("has '{}' of an unexpected type", field);
-                        return false;
-                    }
-                    return true;
-                };
+            Int32 snapshot_schema_id = snapshot->getValue<Int32>(f_schema_id);
 
-                if (!typed(f_added_snapshot_id, avro::AVRO_LONG) || !typed(f_manifest_path, avro::AVRO_STRING)
-                    || !typed(f_manifest_length, avro::AVRO_LONG) || !typed(f_partition_spec_id, avro::AVRO_INT))
-                    return false;
-                if (entry.field(f_manifest_length).value<Int64>() < 0)
-                {
-                    rejection = fmt::format("has a negative '{}'", f_manifest_length);
-                    return false;
-                }
-                /// These two the read path takes only when present, but with a fixed type when it
-                /// does, so absence is acceptable here and a wrong type is not.
-                for (const auto & [field, type] : {std::pair{f_sequence_number, avro::AVRO_LONG},
-                                                   std::pair{f_content, avro::AVRO_INT}})
-                {
-                    if (entry.hasField(field) && !typed(field, type))
-                        return false;
-                }
-                return true;
+            /// `metadata_cache = nullptr` keeps this probe from publishing the document's
+            /// manifests to other readers, which also makes the `table_uuid` those cache keys
+            /// are built from unreachable.
+            auto probe_components = PersistentTableComponents{
+                .schema_processor = schema_processor,
+                .metadata_cache = nullptr,
+                .format_version = metadata_object->getValue<Int32>(f_format_version),
+                .table_location = resolver.getTableLocation(),
+                .metadata_compression_method = compression_method,
+                .table_path = resolver.getTableRoot(),
+                .table_uuid = std::nullopt,
+                .path_resolver = resolver,
             };
 
-            /// A carried-forward manifest keeps its original adder id, so only the snapshot's own
-            /// files are at risk.
-            auto is_added_by_current_snapshot = [&](const avro::GenericRecord & entry)
-            { return entry.field(f_added_snapshot_id).value<Int64>() == current_snapshot_id; };
-
-            bool every_object_present = true;
-            std::vector<String> manifests_added_by_current_snapshot;
-            forEachAvroEntry(
-                resolved_manifest_list_path,
-                object_storage,
-                context,
-                "IcebergVersionHintConvergence",
-                [&](const avro::GenericDatum & datum)
-                {
-                    if (!every_object_present)
-                        return;
-                    const auto & entry = datum.value<avro::GenericRecord>();
-                    String rejection;
-                    if (!reader_would_accept(entry, rejection))
-                    {
-                        LOG_DEBUG(
-                            log,
-                            "Manifest list {} has an entry that {}, which a reader rejects",
-                            resolved_manifest_list_path,
-                            rejection);
-                        every_object_present = false;
-                        return;
-                    }
-                    auto manifest_path
-                        = IcebergPathFromMetadata::deserialize(entry.field(f_manifest_path).value<std::string>());
-                    auto resolved_manifest_path = resolver.resolve(manifest_path);
-                    if (!object_storage->exists(StoredObject(resolved_manifest_path)))
-                    {
-                        LOG_DEBUG(log, "Manifest {} named by {} is missing", resolved_manifest_path, resolved_manifest_list_path);
-                        every_object_present = false;
-                        return;
-                    }
-                    if (is_added_by_current_snapshot(entry))
-                        manifests_added_by_current_snapshot.push_back(resolved_manifest_path);
-                });
-            if (!every_object_present)
-                return false;
-
-            for (const auto & resolved_manifest_path : manifests_added_by_current_snapshot)
+            /// Registers every schema and snapshot binding the manifests resolve against, with the
+            /// same requirements the read path applies to each one, including the history.
+            if (!IcebergMetadata::registerMetadataSchemasAndSnapshots(
+                    metadata_object, current_snapshot_id, probe_components.schema_processor))
             {
-                forEachAvroEntry(
-                    resolved_manifest_path,
-                    object_storage,
-                    context,
-                    "IcebergVersionHintConvergence",
-                    [&](const avro::GenericDatum & datum)
+                LOG_DEBUG(log, "Current snapshot {} is absent from the document's own '{}'", current_snapshot_id, f_snapshots);
+                return false;
+            }
+
+            auto manifest_list_entries
+                = getManifestList(object_storage, probe_components, context, manifest_list_path, log);
+
+            for (const auto & manifest_file : manifest_list_entries)
+            {
+                auto resolved_manifest_path = resolver.resolve(manifest_file.manifest_file_path);
+                if (!object_storage->exists(StoredObject(resolved_manifest_path)))
+                {
+                    LOG_DEBUG(log, "Manifest {} named by {} is missing", resolved_manifest_path, resolved_manifest_list_path);
+                    return false;
+                }
+
+                /// A carried-forward manifest keeps its original adder id, so only the ones this
+                /// snapshot added name files it wrote itself.
+                if (manifest_file.added_snapshot_id != current_snapshot_id)
+                    continue;
+
+                auto entries = getManifestFileEntriesHandle(
+                    object_storage, probe_components, context, log, manifest_file, snapshot_schema_id);
+
+                for (auto content : {FileContentType::DATA, FileContentType::POSITION_DELETE, FileContentType::EQUALITY_DELETE})
+                {
+                    for (const auto & entry : entries.getFilesWithoutDeleted(content))
                     {
-                        if (!every_object_present)
-                            return;
-                        const auto & entry = datum.value<avro::GenericRecord>();
-                        /// Only an ADDED entry names a file this snapshot wrote; an EXISTING one
-                        /// belongs to an ancestor and a DELETED one is no longer required.
-                        if (entry.field(f_status).value<Int32>() != static_cast<Int32>(ManifestEntryStatus::ADDED))
-                            return;
-                        auto file_path = IcebergPathFromMetadata::deserialize(
-                            entry.field(f_data_file).value<avro::GenericRecord>().field(f_file_path).value<std::string>());
-                        auto resolved_file_path = resolver.resolve(file_path);
+                        /// An EXISTING row names a file an ancestor wrote, which this commit does
+                        /// not own and a compaction carries forward for the whole live table.
+                        if (entry->parsed_entry->status != ManifestEntryStatus::ADDED)
+                            continue;
+                        auto resolved_file_path = resolver.resolve(entry->parsed_entry->file_path_key);
                         if (!object_storage->exists(StoredObject(resolved_file_path)))
                         {
                             LOG_DEBUG(log, "File {} named by {} is missing", resolved_file_path, resolved_manifest_path);
-                            every_object_present = false;
+                            return false;
                         }
-                    });
-                if (!every_object_present)
-                    return false;
+                    }
+                }
             }
             return true;
         }
@@ -580,7 +547,6 @@ static bool isMetadataSnapshotFollowable(
     LOG_DEBUG(log, "Current snapshot {} is absent from the document's own '{}'", current_snapshot_id, f_snapshots);
     return false;
 }
-// NOLINTEND(clang-analyzer-core.uninitialized.UndefReturn)
 
 /// The target metadata file already exists, so a hint naming an earlier version is behind. The
 /// target existing does not authorize publishing it: only a reader being able to follow it does.
@@ -614,7 +580,7 @@ static bool convergeVersionHintForLostRace(
             if (!metadata_object)
                 return false;
 
-            return isMetadataSnapshotFollowable(metadata_object, resolver, object_storage, context);
+            return isMetadataSnapshotFollowable(metadata_object, resolver, compression_method, object_storage, context);
         };
 
         convergeVersionHint(

--- a/tests/integration/test_storage_iceberg_no_spark/test_version_hint_crash_window.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_version_hint_crash_window.py
@@ -1,0 +1,955 @@
+import io
+import json
+
+import avro.datafile
+import avro.io
+import avro.schema
+import pytest
+
+from helpers.iceberg_utils import create_iceberg_table, get_uuid_str
+
+LOCAL_PREFIX = "/var/lib/clickhouse/user_files/iceberg_data/default"
+S3_PREFIX = "var/lib/clickhouse/user_files/iceberg_data/default"
+
+HINT = "metadata/version-hint.text"
+
+
+def _read(cluster, instance, storage_type, table_name, rel_path):
+    if storage_type == "local":
+        return instance.exec_in_container(
+            ["bash", "-c", f"cat {LOCAL_PREFIX}/{table_name}/{rel_path} 2>/dev/null || true"]
+        ).strip()
+    key = f"{S3_PREFIX}/{table_name}/{rel_path}"
+    try:
+        response = cluster.minio_client.get_object(cluster.minio_bucket, key)
+        return response.read().decode().strip()
+    finally:
+        try:
+            response.close()
+            response.release_conn()
+        except Exception:
+            pass
+
+
+def _write(cluster, instance, storage_type, table_name, rel_path, content):
+    if storage_type == "local":
+        instance.exec_in_container(
+            ["bash", "-c", f"printf '%s' '{content}' > {LOCAL_PREFIX}/{table_name}/{rel_path}"]
+        )
+        return
+    key = f"{S3_PREFIX}/{table_name}/{rel_path}"
+    data = content.encode()
+    cluster.minio_client.put_object(cluster.minio_bucket, key, io.BytesIO(data), len(data))
+
+
+def _read_bytes(cluster, instance, storage_type, table_name, rel_path):
+    if storage_type == "local":
+        return bytes.fromhex(
+            instance.exec_in_container(
+                ["bash", "-c", f"xxd -p {LOCAL_PREFIX}/{table_name}/{rel_path} | tr -d '\\n'"]
+            ).strip()
+        )
+    response = cluster.minio_client.get_object(
+        cluster.minio_bucket, f"{S3_PREFIX}/{table_name}/{rel_path}"
+    )
+    try:
+        return response.read()
+    finally:
+        response.close()
+        response.release_conn()
+
+
+def _write_bytes(cluster, instance, storage_type, table_name, rel_path, data):
+    if storage_type == "local":
+        instance.exec_in_container(
+            [
+                "bash",
+                "-c",
+                f"printf '%s' '{data.hex()}' | xxd -r -p > {LOCAL_PREFIX}/{table_name}/{rel_path}",
+            ]
+        )
+        return
+    cluster.minio_client.put_object(
+        cluster.minio_bucket,
+        f"{S3_PREFIX}/{table_name}/{rel_path}",
+        io.BytesIO(data),
+        len(data),
+    )
+
+
+def _rewrite_manifest_list(avro_bytes, patch_schema, patch_record):
+    """Rewrite every entry of a manifest list, and its schema if needed.
+
+    `patch_schema` receives the parsed schema and must report whether it found
+    anything to change, so a fixture that silently matched nothing fails loudly
+    instead of producing an undamaged list. The file's own Avro metadata is carried
+    over because `format-version` governs how the list is parsed.
+    """
+    reader = avro.datafile.DataFileReader(io.BytesIO(avro_bytes), avro.io.DatumReader())
+    schema = json.loads(str(reader.datum_reader.writers_schema))
+    metadata = dict(reader.meta)
+    records = list(reader)
+    reader.close()
+
+    assert patch_schema(schema), "Manifest list has no field for this fixture to patch"
+    for record in records:
+        patch_record(record)
+
+    out = io.BytesIO()
+    writer = avro.datafile.DataFileWriter(
+        out, avro.io.DatumWriter(), avro.schema.parse(json.dumps(schema))
+    )
+    for key, value in metadata.items():
+        if not key.startswith("avro."):
+            writer.set_meta(key, value)
+    for record in records:
+        writer.append(record)
+    writer.flush()
+    result = out.getvalue()
+    writer.close()
+    return result
+
+
+def _null_out_added_snapshot_id(avro_bytes):
+    """Rewrite a manifest list so `added_snapshot_id` is a null union branch.
+
+    ClickHouse cannot produce this shape: it declares the field as a non-nullable
+    `long` (`AvroSchema.h`) and refuses to carry one forward
+    (`IcebergWrites.cpp`, ICEBERG_SPECIFICATION_VIOLATION). It comes from an
+    externally written list, which is why the field's type is rewritten here
+    rather than only its value: the pre-apache/iceberg#11626 iceberg-spark schema
+    for it was `["null", "long"]`.
+    """
+
+    def patch_schema(schema):
+        patched = False
+        for field in schema["fields"]:
+            if field["name"] == "added_snapshot_id":
+                field["type"] = ["null", "long"]
+                patched = True
+        return patched
+
+    def patch_record(record):
+        record["added_snapshot_id"] = None
+
+    return _rewrite_manifest_list(avro_bytes, patch_schema, patch_record)
+
+
+def _negate_manifest_length(avro_bytes):
+    """Make `manifest_length` negative.
+
+    The manifest-list read path rejects a negative one with
+    ICEBERG_SPECIFICATION_VIOLATION. ClickHouse only ever stores a real file size,
+    so only the value is rewritten here and the schema keeps its plain `long`.
+    """
+
+    def patch_schema(schema):
+        return any(field["name"] == "manifest_length" for field in schema["fields"])
+
+    def patch_record(record):
+        record["manifest_length"] = -1
+
+    return _rewrite_manifest_list(avro_bytes, patch_schema, patch_record)
+
+
+def _drop_partition_spec_id(avro_bytes):
+    """Remove `partition_spec_id` from the list's schema entirely.
+
+    The read path requires the field to be present and rejects a list without it.
+    ClickHouse always writes it (`AvroSchema.h`), so removing it from the schema is
+    what an externally written list has to do to reach this shape.
+    """
+
+    def patch_schema(schema):
+        before = len(schema["fields"])
+        schema["fields"] = [f for f in schema["fields"] if f["name"] != "partition_spec_id"]
+        return len(schema["fields"]) != before
+
+    def patch_record(record):
+        record.pop("partition_spec_id", None)
+
+    return _rewrite_manifest_list(avro_bytes, patch_schema, patch_record)
+
+
+def _retype_sequence_number(avro_bytes):
+    """Declare `sequence_number` as a string instead of a long.
+
+    A v2 manifest list carrying the field is read with an exact type, so a
+    wrong-typed one is refused even though the field itself is optional.
+    """
+
+    def patch_schema(schema):
+        patched = False
+        for field in schema["fields"]:
+            if field["name"] == "sequence_number":
+                field["type"] = "string"
+                patched = True
+        return patched
+
+    def patch_record(record):
+        record["sequence_number"] = "not-a-long"
+
+    return _rewrite_manifest_list(avro_bytes, patch_schema, patch_record)
+
+
+def _drop_snapshot_schema_id(metadata_json):
+    """Remove `schema-id` from the document's current snapshot.
+
+    Constructing a snapshot requires the field and throws
+    ICEBERG_SPECIFICATION_VIOLATION without it, before any manifest or data file is
+    opened. ClickHouse always writes it (`MetadataGenerator.cpp`).
+    """
+    metadata = json.loads(metadata_json)
+    snapshot_id = metadata["current-snapshot-id"]
+    patched = False
+    for snapshot in metadata["snapshots"]:
+        if snapshot["snapshot-id"] == snapshot_id and "schema-id" in snapshot:
+            del snapshot["schema-id"]
+            patched = True
+    assert patched, "Current snapshot has no schema-id for this fixture to drop"
+    return json.dumps(metadata)
+
+
+def _delete(cluster, instance, storage_type, table_name, rel_path):
+    if storage_type == "local":
+        instance.exec_in_container(
+            ["bash", "-c", f"rm -f {LOCAL_PREFIX}/{table_name}/{rel_path}"]
+        )
+        return
+    cluster.minio_client.remove_object(
+        cluster.minio_bucket, f"{S3_PREFIX}/{table_name}/{rel_path}"
+    )
+
+
+def _exists(cluster, instance, storage_type, table_name, rel_path):
+    if storage_type == "local":
+        return (
+            instance.exec_in_container(
+                [
+                    "bash",
+                    "-c",
+                    f"test -e {LOCAL_PREFIX}/{table_name}/{rel_path} && echo yes || echo no",
+                ]
+            ).strip()
+            == "yes"
+        )
+    try:
+        cluster.minio_client.stat_object(
+            cluster.minio_bucket, f"{S3_PREFIX}/{table_name}/{rel_path}"
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _list_manifests(cluster, instance, storage_type, table_name):
+    """Every `metadata/*.avro` that is not a manifest list, as table-relative paths."""
+    if storage_type == "local":
+        listing = instance.exec_in_container(
+            [
+                "bash",
+                "-c",
+                f"ls {LOCAL_PREFIX}/{table_name}/metadata/*.avro 2>/dev/null || true",
+            ]
+        )
+        names = [line.rsplit("/", 1)[-1] for line in listing.split() if line]
+    else:
+        prefix = f"{S3_PREFIX}/{table_name}/metadata/"
+        names = [
+            obj.object_name.rsplit("/", 1)[-1]
+            for obj in cluster.minio_client.list_objects(
+                cluster.minio_bucket, prefix=prefix, recursive=True
+            )
+            if obj.object_name.endswith(".avro")
+        ]
+    return {f"metadata/{name}" for name in names if not name.startswith("snap-")}
+
+
+def _list_data_files(cluster, instance, storage_type, table_name):
+    """Every file outside `metadata/`, i.e. the data and delete files, table-relative."""
+    if storage_type == "local":
+        listing = instance.exec_in_container(
+            [
+                "bash",
+                "-c",
+                f"cd {LOCAL_PREFIX}/{table_name} 2>/dev/null && "
+                f"find . -type f ! -path './metadata/*' || true",
+            ]
+        )
+        return {line.lstrip("./") for line in listing.split() if line}
+    prefix = f"{S3_PREFIX}/{table_name}/"
+    return {
+        obj.object_name[len(prefix) :]
+        for obj in cluster.minio_client.list_objects(
+            cluster.minio_bucket, prefix=prefix, recursive=True
+        )
+        if not obj.object_name[len(prefix) :].startswith("metadata/")
+    }
+
+
+def _current_snapshot_manifest_list(metadata_json):
+    """The manifest list of the document's current snapshot, as a table-relative path."""
+    metadata = json.loads(metadata_json)
+    snapshot_id = metadata["current-snapshot-id"]
+    for snapshot in metadata["snapshots"]:
+        if snapshot["snapshot-id"] == snapshot_id:
+            raw = snapshot["manifest-list"]
+            # Metadata stores the table location as a prefix; the helpers are
+            # table-relative, so keep only the metadata/... tail.
+            return raw[raw.index("metadata/") :]
+    raise AssertionError(f"snapshot {snapshot_id} absent from its own snapshot list")
+
+
+def _attach_pinned_to_v1(cluster, storage_type, table_name):
+    """CREATE over an existing Iceberg table, pinned to v1 and without a schema."""
+    settings = (
+        "SETTINGS iceberg_metadata_file_path = 'metadata/v1.metadata.json', "
+        "iceberg_use_version_hint = true"
+    )
+    if storage_type == "local":
+        engine = f"IcebergLocal(local, path = '{LOCAL_PREFIX}/{table_name}', format=Parquet)"
+    else:
+        engine = (
+            f"IcebergS3(s3, filename = '{S3_PREFIX}/{table_name}/', format=Parquet, "
+            f"url = 'http://minio1:9001/{cluster.minio_bucket}/')"
+        )
+    return f"CREATE TABLE {table_name} ENGINE={engine} {settings}"
+
+
+@pytest.mark.parametrize("storage_type", ["local", "s3"])
+def test_version_hint_crash_window_does_not_wedge_writes(
+    started_cluster_iceberg_no_spark, storage_type
+):
+    """A commit interrupted between its two writes must not wedge the table.
+
+    The post-crash state needs no crash to construct: it is exactly
+    "vN.metadata.json durable, version-hint.text names N-1". Asserts that a
+    later INSERT succeeds and that the interrupted commit's row is visible.
+    """
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    table_name = "test_version_hint_crash_window_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        table_name,
+        started_cluster_iceberg_no_spark,
+        "(x Int32)",
+        use_version_hint=True,
+    )
+    instance.query(f"INSERT INTO {table_name} VALUES (1)")
+    instance.query(f"INSERT INTO {table_name} VALUES (2)")
+    assert instance.query(f"SELECT x FROM {table_name} ORDER BY x") == "1\n2\n"
+
+    # Guard against a fixture that never wrote a hint: the whole scenario is
+    # about the hint being consulted, so without this the test would pass on a
+    # binary that ignores it entirely.
+    hint = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert hint.isdigit(), f"Fixture did not write a numeric {HINT}, got {hint!r}"
+    committed_version = int(hint)
+    assert committed_version >= 3
+
+    # Roll the hint back one version: byte-identical to a crash between the
+    # metadata write of the last INSERT and its hint advance.
+    _write(
+        started_cluster_iceberg_no_spark,
+        instance,
+        storage_type,
+        table_name,
+        HINT,
+        str(committed_version - 1),
+    )
+    assert (
+        _read(started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT)
+        == str(committed_version - 1)
+    ), "The hint rollback did not take effect"
+
+    # The interrupted transaction's row is invisible while the hint is behind.
+    assert instance.query(f"SELECT x FROM {table_name} ORDER BY x") == "1\n"
+
+    # Before the fix this fails with DATALAKE_DATABASE_ERROR after exhausting
+    # every retry, and keeps failing forever.
+    instance.query(f"INSERT INTO {table_name} VALUES (3)")
+
+    # The hint must have moved past the version it was stuck on.
+    healed = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert healed.isdigit() and int(healed) > committed_version, (
+        f"version-hint.text did not advance past {committed_version}, got {healed!r}"
+    )
+
+    # The row committed by the interrupted transaction is visible again: the
+    # orphaned metadata file was adopted, not discarded. This is what separates
+    # healing the hint from merely letting writes through.
+    assert instance.query(f"SELECT x FROM {table_name} ORDER BY x") == "1\n2\n3\n"
+
+
+@pytest.mark.parametrize("storage_type", ["local", "s3"])
+def test_version_hint_not_rewritten_on_an_ordinary_lost_race(
+    started_cluster_iceberg_no_spark, storage_type
+):
+    """Healing must be monotonic: a lost race may never lower the hint.
+
+    The hint is parked above every version this scenario can reach, because
+    asserting its final value would be blind: the retry that eventually succeeds
+    rewrites it anyway. Parked, any write by either convergence site shows up as
+    a smaller number.
+    """
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    table_name = "test_version_hint_lost_race_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        table_name,
+        started_cluster_iceberg_no_spark,
+        "(x Int32)",
+        use_version_hint=True,
+    )
+    instance.query(f"INSERT INTO {table_name} VALUES (1)")
+    instance.query(f"INSERT INTO {table_name} VALUES (2)")
+    instance.query(f"DROP TABLE {table_name}")
+
+    hint = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert hint.isdigit(), f"Fixture did not write a numeric {HINT}, got {hint!r}"
+
+    parked = "99"
+    _write(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT, parked
+    )
+    assert (
+        _read(started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT)
+        == parked
+    ), "Could not park the hint above every reachable version"
+
+    # Re-attach to the existing table pinned to v1, so the first commit attempt
+    # targets v2, which is already on disk. The schema is intentionally omitted:
+    # with one, this would be a fresh table creation and would be refused
+    # because the table already exists on storage.
+    instance.query(_attach_pinned_to_v1(started_cluster_iceberg_no_spark, storage_type, table_name))
+    instance.query(f"INSERT INTO {table_name} VALUES (3)")
+
+    assert (
+        _read(started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT)
+        == parked
+    ), "A lost race lowered version-hint.text"
+
+
+@pytest.mark.parametrize("storage_type", ["local", "s3"])
+def test_version_hint_not_advanced_to_an_unflushed_metadata_file(
+    started_cluster_iceberg_no_spark, storage_type
+):
+    """The hint may only name a metadata file a reader can actually follow.
+
+    The zero-byte `vN.metadata.json` stands in for a backend that publishes a
+    path before committing its content, as ADLS Gen2 does between `Create` and
+    `Flush`. Neither `local` nor `s3` behaves that way, so the state is built by
+    hand and this is not ADLS coverage.
+    """
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    table_name = "test_version_hint_unflushed_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        table_name,
+        started_cluster_iceberg_no_spark,
+        "(x Int32)",
+        use_version_hint=True,
+    )
+    instance.query(f"INSERT INTO {table_name} VALUES (1)")
+    instance.query(f"INSERT INTO {table_name} VALUES (2)")
+    assert instance.query(f"SELECT x FROM {table_name} ORDER BY x") == "1\n2\n"
+
+    hint = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert hint.isdigit(), f"Fixture did not write a numeric {HINT}, got {hint!r}"
+    committed_version = int(hint)
+
+    # Create the version the next commit will target, with no content, and leave
+    # the hint where it is: a writer created its target and never flushed it.
+    unflushed = committed_version + 1
+    unflushed_path = f"metadata/v{unflushed}.metadata.json"
+    _write(
+        started_cluster_iceberg_no_spark,
+        instance,
+        storage_type,
+        table_name,
+        unflushed_path,
+        "",
+    )
+    assert (
+        _read(
+            started_cluster_iceberg_no_spark,
+            instance,
+            storage_type,
+            table_name,
+            unflushed_path,
+        )
+        == ""
+    ), "The unflushed metadata file was not created empty"
+
+    # The commit cannot tell whether the other writer will ever flush, so it
+    # refuses: a refused write is recoverable, an unreadable table is not.
+    instance.query_and_get_error(f"INSERT INTO {table_name} VALUES (3)")
+
+    assert (
+        _read(started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT)
+        == str(committed_version)
+    ), f"version-hint.text was advanced to the unflushed v{unflushed}"
+
+    assert instance.query(f"SELECT x FROM {table_name} ORDER BY x") == "1\n2\n"
+
+
+@pytest.mark.parametrize("storage_type", ["local", "s3"])
+def test_version_hint_not_advanced_to_a_snapshot_whose_manifest_list_is_gone(
+    started_cluster_iceberg_no_spark, storage_type
+):
+    """A parseable metadata file is not necessarily a followable one.
+
+    A commit whose conditional write reaches storage but reports failure locally
+    leaves `vN.metadata.json` behind and then runs its own cleanup, which deletes
+    that attempt's manifest entries and manifest list. The retry regenerates the
+    same version, meets its own orphan at the existence fence, and must not
+    publish it: the document parses, but a reader following its current snapshot
+    would look for a manifest list that no longer exists.
+    """
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    table_name = "test_version_hint_no_manifest_list_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        table_name,
+        started_cluster_iceberg_no_spark,
+        "(x Int32)",
+        use_version_hint=True,
+    )
+    instance.query(f"INSERT INTO {table_name} VALUES (1)")
+    instance.query(f"INSERT INTO {table_name} VALUES (2)")
+    assert instance.query(f"SELECT x FROM {table_name} ORDER BY x") == "1\n2\n"
+
+    hint = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert hint.isdigit(), f"Fixture did not write a numeric {HINT}, got {hint!r}"
+    committed_version = int(hint)
+
+    # Delete the manifest list of the latest metadata file's current snapshot,
+    # standing in for the cleanup that a lost-then-retried commit performs.
+    metadata_path = f"metadata/v{committed_version}.metadata.json"
+    manifest_list = _current_snapshot_manifest_list(
+        _read(
+            started_cluster_iceberg_no_spark,
+            instance,
+            storage_type,
+            table_name,
+            metadata_path,
+        )
+    )
+    _delete(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, manifest_list
+    )
+    assert not _exists(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, manifest_list
+    ), f"Fixture did not delete {manifest_list}"
+
+    # Roll the hint back so the next commit targets the version whose manifest
+    # list is now missing and hits the existence fence.
+    _write(
+        started_cluster_iceberg_no_spark,
+        instance,
+        storage_type,
+        table_name,
+        HINT,
+        str(committed_version - 1),
+    )
+    assert (
+        _read(started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT)
+        == str(committed_version - 1)
+    ), "The hint rollback did not take effect"
+
+    # Whether the statement succeeds is not the property under test; not adopting
+    # the unfollowable version is.
+    try:
+        instance.query(f"INSERT INTO {table_name} VALUES (3)")
+    except Exception:
+        pass
+
+    healed = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert healed.isdigit(), f"version-hint.text is no longer numeric: {healed!r}"
+    assert int(healed) != committed_version, (
+        f"version-hint.text was advanced to v{committed_version}, whose manifest "
+        f"list is missing"
+    )
+
+    # The table still reads. Without the check it does not: the hint names a
+    # snapshot whose manifest list cannot be opened.
+    instance.query(f"SELECT x FROM {table_name} ORDER BY x")
+
+
+@pytest.mark.parametrize("storage_type", ["local", "s3"])
+def test_version_hint_not_advanced_to_a_snapshot_whose_manifests_are_gone(
+    started_cluster_iceberg_no_spark, storage_type
+):
+    """A present manifest list does not mean its manifests are still there.
+
+    A commit's cleanup deletes the manifests it wrote before the list that names
+    them, so between the two deletions the list survives and points at manifests
+    that do not. A retry meeting its own orphan at the existence fence must not
+    publish it: the document parses and its list opens, yet a reader following it
+    fails on the first manifest.
+    """
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    table_name = "test_version_hint_manifests_gone_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        table_name,
+        started_cluster_iceberg_no_spark,
+        "(x Int32)",
+        use_version_hint=True,
+    )
+    instance.query(f"INSERT INTO {table_name} VALUES (1)")
+
+    # Only the last commit's own manifests may be deleted: cleanup() iterates the
+    # manifests that attempt wrote, never an ancestor's. Deleting an ancestor's
+    # too would make the version the hint falls back to unreadable, and a broken
+    # fixture would then be indistinguishable from a failed guard.
+    before = _list_manifests(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name
+    )
+    instance.query(f"INSERT INTO {table_name} VALUES (2)")
+    after = _list_manifests(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name
+    )
+    own_manifests = after - before
+    assert own_manifests, "The last commit added no manifest, so there is nothing to delete"
+
+    hint = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert hint.isdigit(), f"Fixture did not write a numeric {HINT}, got {hint!r}"
+    committed_version = int(hint)
+
+    for manifest in own_manifests:
+        _delete(
+            started_cluster_iceberg_no_spark, instance, storage_type, table_name, manifest
+        )
+        assert not _exists(
+            started_cluster_iceberg_no_spark, instance, storage_type, table_name, manifest
+        ), f"Fixture did not delete {manifest}"
+
+    # The list itself must survive, otherwise this is the already-covered
+    # missing-list case and says nothing about the manifests.
+    manifest_list = _current_snapshot_manifest_list(
+        _read(
+            started_cluster_iceberg_no_spark,
+            instance,
+            storage_type,
+            table_name,
+            f"metadata/v{committed_version}.metadata.json",
+        )
+    )
+    assert _exists(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, manifest_list
+    ), f"Fixture deleted {manifest_list}, which is the missing-list case instead"
+
+    _write(
+        started_cluster_iceberg_no_spark,
+        instance,
+        storage_type,
+        table_name,
+        HINT,
+        str(committed_version - 1),
+    )
+    assert (
+        _read(started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT)
+        == str(committed_version - 1)
+    ), "The hint rollback did not take effect"
+
+    # Control: the version the hint now names is intact, so a later unreadable
+    # table can only come from adopting the damaged one.
+    assert instance.query(f"SELECT x FROM {table_name} ORDER BY x") == "1\n"
+
+    # Whether the statement succeeds is not the property under test; not adopting
+    # the unfollowable version is.
+    try:
+        instance.query(f"INSERT INTO {table_name} VALUES (3)")
+    except Exception:
+        pass
+
+    healed = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert healed.isdigit(), f"version-hint.text is no longer numeric: {healed!r}"
+    assert int(healed) != committed_version, (
+        f"version-hint.text was advanced to v{committed_version}, whose manifests "
+        f"are missing"
+    )
+
+    # Without the check the hint names that version and the read fails on its
+    # first manifest.
+    instance.query(f"SELECT x FROM {table_name} ORDER BY x")
+
+
+@pytest.mark.parametrize("storage_type", ["local", "s3"])
+def test_version_hint_not_advanced_to_a_snapshot_whose_data_files_are_gone(
+    started_cluster_iceberg_no_spark, storage_type
+):
+    """Present manifests do not mean the files they name are still there.
+
+    A mutation's cleanup deletes its delete files, then its data files, then its
+    manifest entries, then its manifest list. Between the second and third
+    deletion every manifest is intact and names files that are gone, so a probe
+    stopping at the manifests would publish a snapshot whose first data file a
+    reader cannot open. The mutation path is the one whose cleanup ordering makes
+    the state reachable, so the fixture goes through DELETE, not INSERT.
+    """
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    table_name = "test_version_hint_data_files_gone_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        table_name,
+        started_cluster_iceberg_no_spark,
+        "(x Int32)",
+        use_version_hint=True,
+    )
+    instance.query(f"INSERT INTO {table_name} VALUES (1)")
+    instance.query(f"INSERT INTO {table_name} VALUES (2)")
+
+    # Only the mutation's OWN data and delete files may be deleted: cleanup()
+    # iterates the files that attempt wrote, never an ancestor's. Deleting an
+    # ancestor's too would make the version the hint falls back to unreadable,
+    # and a broken fixture would then be indistinguishable from a failed guard.
+    before_files = _list_data_files(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name
+    )
+    before_manifests = _list_manifests(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name
+    )
+    instance.query(f"DELETE FROM {table_name} WHERE x = 1")
+    own_files = (
+        _list_data_files(
+            started_cluster_iceberg_no_spark, instance, storage_type, table_name
+        )
+        - before_files
+    )
+    own_manifests = (
+        _list_manifests(
+            started_cluster_iceberg_no_spark, instance, storage_type, table_name
+        )
+        - before_manifests
+    )
+    assert own_files, "The mutation wrote no data or delete file, so there is nothing to delete"
+    assert own_manifests, "The mutation added no manifest, so the manifests-gone case is untested"
+
+    hint = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert hint.isdigit(), f"Fixture did not write a numeric {HINT}, got {hint!r}"
+    committed_version = int(hint)
+
+    for data_file in own_files:
+        _delete(
+            started_cluster_iceberg_no_spark, instance, storage_type, table_name, data_file
+        )
+        assert not _exists(
+            started_cluster_iceberg_no_spark, instance, storage_type, table_name, data_file
+        ), f"Fixture did not delete {data_file}"
+
+    # The manifests and their list must survive, otherwise this is the
+    # already-covered missing-manifest case and says nothing about data files.
+    for manifest in own_manifests:
+        assert _exists(
+            started_cluster_iceberg_no_spark, instance, storage_type, table_name, manifest
+        ), f"Fixture deleted {manifest}, which is the missing-manifest case instead"
+    manifest_list = _current_snapshot_manifest_list(
+        _read(
+            started_cluster_iceberg_no_spark,
+            instance,
+            storage_type,
+            table_name,
+            f"metadata/v{committed_version}.metadata.json",
+        )
+    )
+    assert _exists(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, manifest_list
+    ), f"Fixture deleted {manifest_list}, which is the missing-list case instead"
+
+    _write(
+        started_cluster_iceberg_no_spark,
+        instance,
+        storage_type,
+        table_name,
+        HINT,
+        str(committed_version - 1),
+    )
+    assert (
+        _read(started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT)
+        == str(committed_version - 1)
+    ), "The hint rollback did not take effect"
+
+    # Control: the version the hint now names is intact, so a later unreadable
+    # table can only come from adopting the damaged one.
+    assert instance.query(f"SELECT x FROM {table_name} ORDER BY x") == "1\n2\n"
+
+    # Whether the statement succeeds is not the property under test; not adopting
+    # the unfollowable version is.
+    try:
+        instance.query(f"INSERT INTO {table_name} VALUES (3)")
+    except Exception:
+        pass
+
+    healed = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert healed.isdigit(), f"version-hint.text is no longer numeric: {healed!r}"
+    assert int(healed) != committed_version, (
+        f"version-hint.text was advanced to v{committed_version}, whose data "
+        f"files are missing"
+    )
+
+    # Without the check the hint names that version and the read fails on its
+    # first data file.
+    instance.query(f"SELECT x FROM {table_name} ORDER BY x")
+
+
+@pytest.mark.parametrize("storage_type", ["local", "s3"])
+@pytest.mark.parametrize(
+    "damage,label,damages_metadata_document",
+    [
+        (_null_out_added_snapshot_id, "null_adder", False),
+        (_negate_manifest_length, "negative_manifest_length", False),
+        (_drop_partition_spec_id, "no_partition_spec_id", False),
+        (_retype_sequence_number, "wrong_typed_sequence_number", False),
+        (_drop_snapshot_schema_id, "no_snapshot_schema_id", True),
+    ],
+)
+def test_version_hint_not_advanced_to_a_snapshot_a_reader_refuses(
+    started_cluster_iceberg_no_spark, storage_type, damage, label, damages_metadata_document
+):
+    """Every object being present does not mean a reader can follow the snapshot.
+
+    Before opening any object a reader requires the snapshot to carry a `schema-id`,
+    and requires its manifest list to have `added_snapshot_id`, a non-negative
+    `manifest_length` and a present `partition_spec_id`, reading the fields it takes
+    with an exact type. Breaking any of that throws
+    ICEBERG_SPECIFICATION_VIOLATION however intact the files are, so publishing such
+    a version would replace a readable v(N-1) with a vN refused at the first read.
+    """
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    table_name = "test_version_hint_" + label + "_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        table_name,
+        started_cluster_iceberg_no_spark,
+        "(x Int32)",
+        use_version_hint=True,
+    )
+    instance.query(f"INSERT INTO {table_name} VALUES (1)")
+    instance.query(f"INSERT INTO {table_name} VALUES (2)")
+
+    hint = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert hint.isdigit(), f"Fixture did not write a numeric {HINT}, got {hint!r}"
+    committed_version = int(hint)
+
+    # Only the last commit's own document and list are damaged, so the version the
+    # hint falls back to keeps a readable pair of its own. Damaging that one too would
+    # make a broken fixture indistinguishable from a failed guard.
+    metadata_rel_path = f"metadata/v{committed_version}.metadata.json"
+    metadata_json = _read(
+        started_cluster_iceberg_no_spark,
+        instance,
+        storage_type,
+        table_name,
+        metadata_rel_path,
+    )
+    if damages_metadata_document:
+        _write(
+            started_cluster_iceberg_no_spark,
+            instance,
+            storage_type,
+            table_name,
+            metadata_rel_path,
+            damage(metadata_json),
+        )
+    else:
+        manifest_list = _current_snapshot_manifest_list(metadata_json)
+        _write_bytes(
+            started_cluster_iceberg_no_spark,
+            instance,
+            storage_type,
+            table_name,
+            manifest_list,
+            damage(
+                _read_bytes(
+                    started_cluster_iceberg_no_spark,
+                    instance,
+                    storage_type,
+                    table_name,
+                    manifest_list,
+                )
+            ),
+        )
+
+    # Everything the snapshot names must still exist, otherwise this is one of the
+    # already-covered missing-object cases and says nothing about the field rules.
+    for rel_path in _list_manifests(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name
+    ) | _list_data_files(started_cluster_iceberg_no_spark, instance, storage_type, table_name):
+        assert _exists(
+            started_cluster_iceberg_no_spark, instance, storage_type, table_name, rel_path
+        ), f"Fixture removed {rel_path}, which is a missing-object case instead"
+
+    _write(
+        started_cluster_iceberg_no_spark,
+        instance,
+        storage_type,
+        table_name,
+        HINT,
+        str(committed_version - 1),
+    )
+    assert (
+        _read(started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT)
+        == str(committed_version - 1)
+    ), "The hint rollback did not take effect"
+
+    # Control: the version the hint now names is readable, so a later unreadable
+    # table can only come from adopting the damaged one.
+    assert instance.query(f"SELECT x FROM {table_name} ORDER BY x") == "1\n"
+
+    # Whether the statement succeeds is not the property under test; not adopting
+    # the unfollowable version is.
+    try:
+        instance.query(f"INSERT INTO {table_name} VALUES (3)")
+    except Exception:
+        pass
+
+    healed = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert healed.isdigit(), f"version-hint.text is no longer numeric: {healed!r}"
+    assert int(healed) != committed_version, (
+        f"version-hint.text was advanced to v{committed_version}, which a reader "
+        f"refuses ({label})"
+    )
+
+    # Without the check the hint names that version and the read is refused with
+    # ICEBERG_SPECIFICATION_VIOLATION.
+    instance.query(f"SELECT x FROM {table_name} ORDER BY x")

--- a/tests/integration/test_storage_iceberg_no_spark/test_version_hint_crash_window.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_version_hint_crash_window.py
@@ -210,6 +210,129 @@ def _drop_snapshot_schema_id(metadata_json):
     return json.dumps(metadata)
 
 
+def _drop_current_schema_id(metadata_json):
+    """Remove the document's top-level `current-schema-id`.
+
+    Parsing a v2 table's schema requires it and throws BAD_ARGUMENTS without it
+    (`parseTableSchemaV2Method`), before any snapshot or manifest is examined, so the
+    document is unreadable however intact its objects are. ClickHouse always writes it
+    (`MetadataGenerator.cpp`).
+    """
+    metadata = json.loads(metadata_json)
+    assert "current-schema-id" in metadata, "Document has no current-schema-id to drop"
+    del metadata["current-schema-id"]
+    return json.dumps(metadata)
+
+
+def _drop_history_snapshot_schema_id(metadata_json):
+    """Remove `schema-id` from a snapshot that is not the current one.
+
+    Reading resolves manifest entries of older snapshots through the document, and the
+    traversal that registers those bindings requires the field on every snapshot, not
+    only the current one. So a document whose history is missing it is refused by a
+    reader while its own current snapshot looks intact.
+    """
+    metadata = json.loads(metadata_json)
+    current = metadata["current-snapshot-id"]
+    patched = False
+    for snapshot in metadata["snapshots"]:
+        if snapshot["snapshot-id"] != current and "schema-id" in snapshot:
+            del snapshot["schema-id"]
+            patched = True
+    assert patched, "Document has no non-current snapshot with a schema-id to drop"
+    return json.dumps(metadata)
+
+
+def _rewrite_manifest_file(avro_bytes, patch_metadata, patch_schema=None, patch_record=None):
+    """Rewrite a manifest file, its Avro header metadata, and optionally its rows.
+
+    A manifest file carries more of its own state in the Avro header than a manifest
+    list does: `partition-spec` and `schema` are read from there, so damaging a
+    manifest means damaging that header. `patch_metadata` reports whether it changed
+    anything, so a fixture that matched nothing fails loudly instead of writing an
+    undamaged manifest back.
+    """
+    reader = avro.datafile.DataFileReader(io.BytesIO(avro_bytes), avro.io.DatumReader())
+    schema = json.loads(str(reader.datum_reader.writers_schema))
+    metadata = dict(reader.meta)
+    records = list(reader)
+    reader.close()
+
+    assert patch_metadata(metadata), "Manifest has nothing for this fixture to patch"
+    if patch_schema is not None:
+        assert patch_schema(schema), "Manifest schema has no field for this fixture to patch"
+    for record in records:
+        if patch_record is not None:
+            patch_record(record)
+
+    out = io.BytesIO()
+    writer = avro.datafile.DataFileWriter(
+        out, avro.io.DatumWriter(), avro.schema.parse(json.dumps(schema))
+    )
+    for key, value in metadata.items():
+        if not key.startswith("avro."):
+            writer.set_meta(key, value)
+    for record in records:
+        writer.append(record)
+    writer.flush()
+    result = out.getvalue()
+    writer.close()
+    return result
+
+
+def _drop_manifest_partition_spec(avro_bytes):
+    """Remove the `partition-spec` key from a manifest file's Avro header.
+
+    Building a manifest reader requires it and throws
+    ICEBERG_SPECIFICATION_VIOLATION ("No partition-spec in iceberg manifest file")
+    without it. ClickHouse always writes it (`IcebergWrites.cpp`), so an externally
+    written manifest is what reaches this shape.
+    """
+
+    def patch_metadata(metadata):
+        return metadata.pop("partition-spec", None) is not None
+
+    return _rewrite_manifest_file(avro_bytes, patch_metadata)
+
+
+def _drop_manifest_schema(avro_bytes):
+    """Remove the `schema` key from a manifest file's Avro header.
+
+    The manifest's own schema is what resolves its entries' columns, so a reader
+    refuses the manifest without it (BAD_ARGUMENTS) before opening a data file.
+    """
+
+    def patch_metadata(metadata):
+        return metadata.pop("schema", None) is not None
+
+    return _rewrite_manifest_file(avro_bytes, patch_metadata)
+
+
+def _current_snapshot_added_manifests(cluster, instance, storage_type, table_name, metadata_json):
+    """The manifests the document's current snapshot added, table-relative.
+
+    Only these name files the snapshot wrote itself, which is the set the publish
+    fence reads; a carried-forward manifest keeps an older adder id.
+    """
+    manifest_list = _current_snapshot_manifest_list(metadata_json)
+    snapshot_id = json.loads(metadata_json)["current-snapshot-id"]
+    reader = avro.datafile.DataFileReader(
+        io.BytesIO(
+            _read_bytes(cluster, instance, storage_type, table_name, manifest_list)
+        ),
+        avro.io.DatumReader(),
+    )
+    try:
+        paths = [
+            record["manifest_path"]
+            for record in reader
+            if record.get("added_snapshot_id") == snapshot_id
+        ]
+    finally:
+        reader.close()
+    return [raw[raw.index("metadata/") :] for raw in paths]
+
+
 def _delete(cluster, instance, storage_type, table_name, rel_path):
     if storage_type == "local":
         instance.exec_in_container(
@@ -298,6 +421,19 @@ def _current_snapshot_manifest_list(metadata_json):
             # table-relative, so keep only the metadata/... tail.
             return raw[raw.index("metadata/") :]
     raise AssertionError(f"snapshot {snapshot_id} absent from its own snapshot list")
+
+
+def _attach_pinned_to_metadata(cluster, storage_type, table_name, new_table_name, metadata_rel_path):
+    """CREATE a second table over an existing one, pinned to one metadata document."""
+    settings = f"SETTINGS iceberg_metadata_file_path = '{metadata_rel_path}'"
+    if storage_type == "local":
+        engine = f"IcebergLocal(local, path = '{LOCAL_PREFIX}/{table_name}', format=Parquet)"
+    else:
+        engine = (
+            f"IcebergS3(s3, filename = '{S3_PREFIX}/{table_name}/', format=Parquet, "
+            f"url = 'http://minio1:9001/{cluster.minio_bucket}/')"
+        )
+    return f"CREATE TABLE {new_table_name} ENGINE={engine} {settings}"
 
 
 def _attach_pinned_to_v1(cluster, storage_type, table_name):
@@ -835,6 +971,8 @@ def test_version_hint_not_advanced_to_a_snapshot_whose_data_files_are_gone(
         (_drop_partition_spec_id, "no_partition_spec_id", False),
         (_retype_sequence_number, "wrong_typed_sequence_number", False),
         (_drop_snapshot_schema_id, "no_snapshot_schema_id", True),
+        (_drop_current_schema_id, "no_current_schema_id", True),
+        (_drop_history_snapshot_schema_id, "no_history_schema_id", True),
     ],
 )
 def test_version_hint_not_advanced_to_a_snapshot_a_reader_refuses(
@@ -953,3 +1091,235 @@ def test_version_hint_not_advanced_to_a_snapshot_a_reader_refuses(
     # Without the check the hint names that version and the read is refused with
     # ICEBERG_SPECIFICATION_VIOLATION.
     instance.query(f"SELECT x FROM {table_name} ORDER BY x")
+
+@pytest.mark.parametrize("storage_type", ["local", "s3"])
+@pytest.mark.parametrize(
+    "damage,label",
+    [
+        (_drop_manifest_partition_spec, "no_manifest_partition_spec"),
+        (_drop_manifest_schema, "no_manifest_schema"),
+    ],
+)
+def test_version_hint_not_advanced_to_a_snapshot_whose_manifests_a_reader_refuses(
+    started_cluster_iceberg_no_spark, storage_type, damage, label
+):
+    """A manifest list a reader accepts does not mean its manifests are readable.
+
+    Each manifest carries `partition-spec` and `schema` in its own Avro header, and a
+    reader refuses the manifest without either before it opens a data file. So a
+    version whose list and objects are all intact can still be one every reader
+    rejects, and publishing it would replace a readable v(N-1) with an unreadable vN.
+    """
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    table_name = "test_version_hint_" + label + "_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        table_name,
+        started_cluster_iceberg_no_spark,
+        "(x Int32)",
+        use_version_hint=True,
+    )
+    instance.query(f"INSERT INTO {table_name} VALUES (1)")
+    instance.query(f"INSERT INTO {table_name} VALUES (2)")
+
+    hint = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert hint.isdigit(), f"Fixture did not write a numeric {HINT}, got {hint!r}"
+    committed_version = int(hint)
+
+    # Only the manifests the last commit added are damaged, so the version the hint
+    # falls back to keeps readable manifests of its own. Damaging a carried-forward
+    # one would make a broken fixture indistinguishable from a failed guard.
+    metadata_json = _read(
+        started_cluster_iceberg_no_spark,
+        instance,
+        storage_type,
+        table_name,
+        f"metadata/v{committed_version}.metadata.json",
+    )
+    added_manifests = _current_snapshot_added_manifests(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, metadata_json
+    )
+    assert added_manifests, "Current snapshot added no manifest for this fixture to damage"
+    for rel_path in added_manifests:
+        _write_bytes(
+            started_cluster_iceberg_no_spark,
+            instance,
+            storage_type,
+            table_name,
+            rel_path,
+            damage(
+                _read_bytes(
+                    started_cluster_iceberg_no_spark,
+                    instance,
+                    storage_type,
+                    table_name,
+                    rel_path,
+                )
+            ),
+        )
+
+    # Everything the snapshot names must still exist, otherwise this is one of the
+    # already-covered missing-object cases and says nothing about the manifest rules.
+    for rel_path in _list_manifests(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name
+    ) | _list_data_files(started_cluster_iceberg_no_spark, instance, storage_type, table_name):
+        assert _exists(
+            started_cluster_iceberg_no_spark, instance, storage_type, table_name, rel_path
+        ), f"Fixture removed {rel_path}, which is a missing-object case instead"
+
+    _write(
+        started_cluster_iceberg_no_spark,
+        instance,
+        storage_type,
+        table_name,
+        HINT,
+        str(committed_version - 1),
+    )
+    assert (
+        _read(started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT)
+        == str(committed_version - 1)
+    ), "The hint rollback did not take effect"
+
+    # Control: the version the hint now names is readable, so a later unreadable
+    # table can only come from adopting the damaged one.
+    assert instance.query(f"SELECT x FROM {table_name} ORDER BY x") == "1\n"
+
+    # Whether the statement succeeds is not the property under test; not adopting
+    # the unfollowable version is.
+    try:
+        instance.query(f"INSERT INTO {table_name} VALUES (3)")
+    except Exception:
+        pass
+
+    healed = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert healed.isdigit(), f"version-hint.text is no longer numeric: {healed!r}"
+    assert int(healed) != committed_version, (
+        f"version-hint.text was advanced to v{committed_version}, whose manifests a "
+        f"reader refuses ({label})"
+    )
+
+    # Without the check the hint names that version and the read is refused before
+    # any data file is opened.
+    instance.query(f"SELECT x FROM {table_name} ORDER BY x")
+
+def _add_geo_schema(metadata_json):
+    """Append a schema carrying a `geometry` field, under an unused schema-id.
+
+    A table another engine wrote can hold geo fields, whose type resolves only with
+    `allow_experimental_geo_types_in_iceberg`. Every schema in the document is
+    registered eagerly (`SchemaProcessor.cpp`), so a probe whose parser disagrees with
+    the reader's throws on a document the reader accepts. The current snapshot keeps
+    its own schema-id, so this changes what must be registered without changing what
+    the snapshot's entries resolve against.
+    """
+    metadata = json.loads(metadata_json)
+    schema_ids = [schema["schema-id"] for schema in metadata["schemas"]]
+    metadata["schemas"].append(
+        {
+            "schema-id": max(schema_ids) + 1,
+            "type": "struct",
+            "fields": [{"id": 1, "name": "g", "required": False, "type": "geometry"}],
+        }
+    )
+    return json.dumps(metadata)
+
+
+@pytest.mark.parametrize("storage_type", ["local", "s3"])
+def test_version_hint_advanced_to_a_geo_schema_target(
+    started_cluster_iceberg_no_spark, storage_type
+):
+    """A followable target carrying a geo schema must still be published.
+
+    The fence reads the candidate through the production reader, so it builds a schema
+    processor of its own. Configuring that processor differently from the reader's would
+    make it refuse a document the reader accepts, leaving the hint stuck on v(N-1)
+    forever, which is the wedge this PR exists to remove rather than a safe refusal.
+    """
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    table_name = "test_version_hint_geo_schema_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        table_name,
+        started_cluster_iceberg_no_spark,
+        "(x Int32)",
+        use_version_hint=True,
+        settings={"allow_experimental_geo_types_in_iceberg": 1},
+    )
+    instance.query(f"INSERT INTO {table_name} VALUES (1)")
+    instance.query(f"INSERT INTO {table_name} VALUES (2)")
+
+    hint = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert hint.isdigit(), f"Fixture did not write a numeric {HINT}, got {hint!r}"
+    committed_version = int(hint)
+
+    metadata_rel_path = f"metadata/v{committed_version}.metadata.json"
+    _write(
+        started_cluster_iceberg_no_spark,
+        instance,
+        storage_type,
+        table_name,
+        metadata_rel_path,
+        _add_geo_schema(
+            _read(
+                started_cluster_iceberg_no_spark,
+                instance,
+                storage_type,
+                table_name,
+                metadata_rel_path,
+            )
+        ),
+    )
+
+    _write(
+        started_cluster_iceberg_no_spark,
+        instance,
+        storage_type,
+        table_name,
+        HINT,
+        str(committed_version - 1),
+    )
+
+    # Control: the geo document is readable through a table pinned to it, so a refusal
+    # below can only come from the fence disagreeing with the reader rather than from
+    # metadata this fixture broke.
+    probe_table = table_name + "_pinned"
+    instance.query(
+        _attach_pinned_to_metadata(
+            started_cluster_iceberg_no_spark, storage_type, table_name, probe_table, metadata_rel_path
+        ),
+        settings={"allow_experimental_geo_types_in_iceberg": 1},
+    )
+    assert (
+        instance.query(
+            f"SELECT x FROM {probe_table} ORDER BY x",
+            settings={"allow_experimental_geo_types_in_iceberg": 1},
+        )
+        == "1\n2\n"
+    )
+
+    try:
+        instance.query(
+            f"INSERT INTO {table_name} VALUES (3)",
+            settings={"allow_experimental_geo_types_in_iceberg": 1},
+        )
+    except Exception:
+        pass
+
+    healed = _read(
+        started_cluster_iceberg_no_spark, instance, storage_type, table_name, HINT
+    )
+    assert healed.isdigit(), f"version-hint.text is no longer numeric: {healed!r}"
+    assert int(healed) >= committed_version, (
+        f"version-hint.text stayed at v{healed} instead of adopting the followable "
+        f"v{committed_version}, whose only unusual feature is a geo schema"
+    )


### PR DESCRIPTION
Advance the Iceberg version hint on a lost commit race

Closes: https://github.com/ClickHouse/ClickHouse/issues/114108


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes Iceberg tables with `iceberg_use_version_hint = 1` becoming permanently unwritable after a server crash between a commit's metadata write and its `version-hint.text` advance. Writes kept failing with `DATALAKE_DATABASE_ERROR`, and the rows committed by the interrupted transaction stayed invisible.


### Description

A commit is two non-atomic writes: the conditional PUT of `vN.metadata.json`, then the advance of
`metadata/version-hint.text` to `N`. A crash in between leaves the metadata file durable and the hint
naming `N-1`. With `iceberg_use_version_hint = 1` that never resolves: every later writer resolves its
base through the stale hint, regenerates that same `vN`, and is refused by the existence check.

`writeMetadataFileAndVersionHint` reads "the target already exists" as only a lost race and returns
before its own hint-convergence loop. But the target carried `write-if-none-match: *`, so a completed
PUT claimed its version: the orphan is a finished commit to adopt. So converge the hint there too.

Existence alone does not authorize publishing it. The hint is left alone unless a reader could follow
the document's current snapshot, decided by reading the candidate through the same functions a `SELECT`
uses: every object that reader would open must be present (the manifest list, each manifest it names,
and the files that snapshot itself added), and every shape the read path rejects makes it refuse here
too, by construction rather than by restating the rules. Only its own additions are descended into, and
the branch is reached only where the hint would otherwise be written, so the default configuration reads
nothing. Deletions are not transactional, so this closes the window as of the decision, not for good.

The post-crash state needs no crash to build, so the tests construct it, on S3 and local disk: before
this the next write fails with `Code: 736`, after it it succeeds and returns the missing row. Eight
further cases pin what the hint must and must not do: one monotonicity, six covering refusal states,
and one asserting a followable target carrying a geo schema is still published.
