### PR TITLE
Docs: MySQL dictionary TLS paths are also accepted from config-defined named collections

### DIFF
--- a/docs/reference/statements/create/dictionary/sources/mysql.mdx
+++ b/docs/reference/statements/create/dictionary/sources/mysql.mdx
@@ -80,14 +80,14 @@ Setting fields:
 | `ssl_ca_pem` | Contents of the CA certificate that the MySQL server certificate is verified against. Optional. |
 | `ssl_cert_pem` | Contents of the client certificate, for certificate-based authentication. Optional. |
 | `ssl_key_pem` | Contents of the private key belonging to `ssl_cert_pem`. Optional. |
-| `ssl_ca`, `ssl_cert`, `ssl_key` | The same credentials as paths to files on the server. Only allowed for a dictionary defined in a server configuration file, see below. Optional. |
+| `ssl_ca`, `ssl_cert`, `ssl_key` | The same credentials as paths to files on the server. Only allowed for a dictionary defined in a server configuration file, or through a named collection defined there, see below. Optional. |
 
 <Note>
 The `table` or `where` fields cannot be used together with the `query` field. And either one of the `table` or `query` fields must be declared.
 </Note>
 
 <Note>
-`ssl_ca`, `ssl_cert` and `ssl_key` name files that the server opens with its own privileges, so they are only accepted for a dictionary defined in a server configuration file. A dictionary created with a `CREATE DICTIONARY` query must pass the contents instead, in `ssl_ca_pem`, `ssl_cert_pem` and `ssl_key_pem`. Those values are masked in logs and in `SHOW` queries, the same way passwords are.
+`ssl_ca`, `ssl_cert` and `ssl_key` name files that the server opens with its own privileges, so they are only accepted for a dictionary defined in a server configuration file, or through a named collection defined there. A dictionary created with a `CREATE DICTIONARY` query must pass the contents instead, in `ssl_ca_pem`, `ssl_cert_pem` and `ssl_key_pem`. Those values are masked in logs and in `SHOW` queries, the same way passwords are.
 </Note>
 
 <Note>

--- a/docs/reference/statements/create/dictionary/sources/mysql.mdx
+++ b/docs/reference/statements/create/dictionary/sources/mysql.mdx
@@ -87,7 +87,7 @@ The `table` or `where` fields cannot be used together with the `query` field. An
 </Note>
 
 <Note>
-`ssl_ca`, `ssl_cert` and `ssl_key` name files that the server opens with its own privileges, so they are only accepted for a dictionary defined in a server configuration file, or through a named collection defined there. A dictionary created with a `CREATE DICTIONARY` query must pass the contents instead, in `ssl_ca_pem`, `ssl_cert_pem` and `ssl_key_pem`. Those values are masked in logs and in `SHOW` queries, the same way passwords are.
+`ssl_ca`, `ssl_cert` and `ssl_key` name files that the server opens with its own privileges, so they are only accepted for a dictionary defined in a server configuration file, or through a named collection defined there. A `CREATE DICTIONARY` query that specifies the TLS credentials directly must pass their contents instead, in `ssl_ca_pem`, `ssl_cert_pem` and `ssl_key_pem`. Those values are masked in logs and in `SHOW` queries, the same way passwords are.
 </Note>
 
 <Note>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Documentation fix: the note on `ssl_ca`, `ssl_cert` and `ssl_key` in the MySQL dictionary source said the path form is only accepted for a dictionary defined in a server configuration file, but a named collection defined in the configuration file is a supported path-based route as well (`StorageMySQL::getSSLParams` gates on the collection's source being the configuration file, and `CREATE DICTIONARY ... SOURCE(MYSQL(NAME <config-defined collection>))` consumes the paths from it). Widen the wording to cover both routes.

The same gap in the PostgreSQL counterpart was found by the automated review in https://github.com/ClickHouse/ClickHouse/pull/110615 and is fixed there; this PR applies the identical fix to the MySQL page, which is already on master since https://github.com/ClickHouse/ClickHouse/pull/112070.

Related: https://github.com/ClickHouse/ClickHouse/pull/110615
Related: https://github.com/ClickHouse/ClickHouse/pull/112070


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1166` (included in `26.8` and later)
<!-- ch-version-info:end -->