### PR TITLE
Fix PromQL stddev and stdvar for large finite values

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOneArgumentAggregationOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOneArgumentAggregationOperator.cpp
@@ -104,13 +104,13 @@ namespace
             {"stddev",
              {
                 [](ASTPtr && v, const DataTypePtr &) -> ASTPtr
-                { return makeASTFunction("stddevPopForEach", std::move(v)); },
+                { return makeASTFunction("stddevPopStableForEach", std::move(v)); },
             }},
 
             {"stdvar",
              {
                 [](ASTPtr && v, const DataTypePtr &) -> ASTPtr
-                { return makeASTFunction("varPopForEach", std::move(v)); },
+                { return makeASTFunction("varPopStableForEach", std::move(v)); },
             }},
 
             {"group",

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -278,6 +278,14 @@ def send_test_data():
                 {"__name__": "bar", "shape": "rectangle", "size": "l"},
                 {110: 9, 130: 90},
             ),
+            (
+                {"__name__": "large_values", "id": "a"},
+                {120: 1e155},
+            ),
+            (
+                {"__name__": "large_values", "id": "b"},
+                {120: 1e155},
+            ),
         ]
     )
 
@@ -4434,6 +4442,21 @@ def test_aggregation_operators():
         '{"resultType": "matrix", "result": [{"metric": {}, "values": [[110, "7.25"], [120, "144"], [130, "400"], [140, "0"], [150, "235225"]]}]}',
         [["[]", "[('1970-01-01 00:01:50.000',7.25),('1970-01-01 00:02:00.000',144),('1970-01-01 00:02:10.000',400),('1970-01-01 00:02:20.000',0),('1970-01-01 00:02:30.000',235225)]"]],
         eps=1e-9,
+    )
+
+    # Squaring these equal finite values overflows Float64, but their variance is zero.
+    do_query_test(
+        "stddev(large_values)",
+        120,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [120, "0"]}]}',
+        [["[]", "1970-01-01 00:02:00.000", 0]],
+    )
+
+    do_query_test(
+        "stdvar(large_values)",
+        120,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [120, "0"]}]}',
+        [["[]", "1970-01-01 00:02:00.000", 0]],
     )
 
     # FIXME: Not deterministic without sort_by_label(), and function sort_by_label() is not implemented yet.


### PR DESCRIPTION
### Description

PromQL `stddev` and `stdvar` were using the numerically unstable ClickHouse variance aggregates. With two equal samples of `1e155`, squaring the values overflows and the result becomes `NaN`, even though the expected population variance is `0`.

This switches the PromQL lowering to `stddevPopStableForEach` and `varPopStableForEach`. I also added integration coverage for both operators that compares the results with Prometheus.

### Changelog category (leave one):
- **Experimental Feature**

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
**Fix PromQL `stddev` and `stdvar` returning `NaN` for large finite values whose variance is representable.**

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114250&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114250](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114250+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1305` (included in `26.9` and later)
<!-- ch-version-info:end -->