### PR TITLE
Fix(PromQL): Use compensated summation for PromQL sum

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionSum.cpp
+++ b/src/AggregateFunctions/AggregateFunctionSum.cpp
@@ -44,10 +44,19 @@ struct SumKahan
     using Function = AggregateFunctionSum<T, ResultType, AggregateDataType, AggregateFunctionTypeSumKahan>;
 };
 
+template <typename T>
+struct SumPrometheus
+{
+    using ResultType = Float64;
+    using AggregateDataType = AggregateFunctionSumPrometheusData<ResultType>;
+    using Function = AggregateFunctionSum<T, ResultType, AggregateDataType, AggregateFunctionTypeSumPrometheus>;
+};
+
 template <typename T> using AggregateFunctionSumSimple = typename SumSimple<T>::Function;
 template <typename T> using AggregateFunctionSumWithOverflow = typename SumSameType<T>::Function;
 template <typename T> using AggregateFunctionSumKahan =
     std::conditional_t<is_decimal<T>, typename SumSimple<T>::Function, typename SumKahan<T>::Function>;
+template <typename T> using AggregateFunctionSumPrometheus = typename SumPrometheus<T>::Function;
 
 
 template <template <typename> class Function>
@@ -66,6 +75,23 @@ AggregateFunctionPtr createAggregateFunctionSum(const std::string & name, const 
     if (!res)
         throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument for aggregate function {}{}",
                         argument_types[0]->getName(), name, getNumericVariantSupertypeHint(argument_types[0]));
+    return res;
+}
+
+AggregateFunctionPtr createAggregateFunctionSumPrometheus(
+    const std::string & name, const DataTypes & argument_types, const Array & parameters, const Settings *)
+{
+    assertNoParameters(name, parameters);
+    assertUnary(name, argument_types);
+
+    AggregateFunctionPtr res(createWithNumericType<AggregateFunctionSumPrometheus>(*argument_types[0], argument_types));
+    if (!res)
+        throw Exception(
+            ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+            "Illegal type {} of argument for aggregate function {}{}",
+            argument_types[0]->getName(),
+            name,
+            getNumericVariantSupertypeHint(argument_types[0]));
     return res;
 }
 
@@ -206,6 +232,42 @@ SELECT sum(0.1), sumKahan(0.1) FROM numbers(10);
     FunctionDocumentation documentation_kahan = {description_kahan, syntax_kahan, arguments_kahan, {}, returned_value_kahan, examples_kahan, introduced_in_kahan, category_kahan};
 
     factory.registerFunction("sumKahan", {createAggregateFunctionSum<AggregateFunctionSumKahan>, documentation_kahan});
+
+    FunctionDocumentation::Description description_prometheus = R"(
+Calculates the sum using the compensated summation algorithm used by Prometheus.
+This function is intended for implementing PromQL aggregation.
+    )";
+    FunctionDocumentation::Syntax syntax_prometheus = R"(
+sumPrometheus(x)
+    )";
+    FunctionDocumentation::Arguments arguments_prometheus = {{"x", "Input value.", {"(U)Int*", "Float*"}}};
+    FunctionDocumentation::ReturnedValue returned_value_prometheus = {"Returns the sum of the values.", {"Float64"}};
+    FunctionDocumentation::Examples examples_prometheus = {
+    {
+        "Compensated summation",
+        R"(
+SELECT sumPrometheus(0.1) FROM numbers(10);
+        )",
+        R"(
+┌─sumPrometheus(0.1)─┐
+│                  1 │
+└────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_prometheus = {26, 8};
+    FunctionDocumentation::Category category_prometheus = FunctionDocumentation::Category::AggregateFunction;
+    FunctionDocumentation documentation_prometheus = {
+        description_prometheus,
+        syntax_prometheus,
+        arguments_prometheus,
+        {},
+        returned_value_prometheus,
+        examples_prometheus,
+        introduced_in_prometheus,
+        category_prometheus};
+
+    factory.registerFunction("sumPrometheus", {createAggregateFunctionSumPrometheus, documentation_prometheus});
 }
 
 }

--- a/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/src/AggregateFunctions/AggregateFunctionSum.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cmath>
 #include <cstring>
 #include <memory>
 #include <type_traits>
@@ -427,12 +428,107 @@ struct AggregateFunctionSumKahanData
     }
 };
 
+template <typename T>
+struct AggregateFunctionSumPrometheusData
+{
+    static_assert(is_floating_point<T>);
+
+    T sum{};
+    T correction{};
+
+    template <typename Value>
+    void ALWAYS_INLINE addImpl(Value value)
+    {
+        const T increment = static_cast<T>(value);
+        const T new_sum = sum + increment;
+
+        if (std::isinf(new_sum))
+            correction = 0;
+        else if (std::abs(sum) >= std::abs(increment))
+            correction += (sum - new_sum) + increment;
+        else
+            correction += (increment - new_sum) + sum;
+
+        sum = new_sum;
+    }
+
+    void ALWAYS_INLINE add(T value)
+    {
+        addImpl(value);
+    }
+
+    template <typename Value>
+    void NO_INLINE addMany(const Value * __restrict ptr, size_t start, size_t end)
+    {
+        ptr += start;
+        const auto * end_ptr = ptr + (end - start);
+        while (ptr < end_ptr)
+        {
+            addImpl(*ptr);
+            ++ptr;
+        }
+    }
+
+    template <typename Value, bool add_if_zero>
+    void NO_INLINE addManyConditionalInternal(
+        const Value * __restrict ptr, const UInt8 * __restrict condition_map, size_t start, size_t end)
+    {
+        ptr += start;
+        condition_map += start;
+        const auto * end_ptr = ptr + (end - start);
+        while (ptr < end_ptr)
+        {
+            if ((!*condition_map) == add_if_zero)
+                addImpl(*ptr);
+            ++ptr;
+            ++condition_map;
+        }
+    }
+
+    template <typename Value>
+    void ALWAYS_INLINE addManyNotNull(const Value * __restrict ptr, const UInt8 * __restrict null_map, size_t start, size_t end)
+    {
+        addManyConditionalInternal<Value, true>(ptr, null_map, start, end);
+    }
+
+    template <typename Value>
+    void ALWAYS_INLINE addManyConditional(const Value * __restrict ptr, const UInt8 * __restrict condition_map, size_t start, size_t end)
+    {
+        addManyConditionalInternal<Value, false>(ptr, condition_map, start, end);
+    }
+
+    void merge(const AggregateFunctionSumPrometheusData & rhs)
+    {
+        addImpl(rhs.sum);
+        if (!std::isinf(sum))
+            correction += rhs.correction;
+    }
+
+    void write(WriteBuffer & buf) const
+    {
+        writeBinary(sum, buf);
+        writeBinary(correction, buf);
+    }
+
+    void read(ReadBuffer & buf)
+    {
+        readBinary(sum, buf);
+        readBinary(correction, buf);
+    }
+
+    T get() const
+    {
+        return sum + correction;
+    }
+};
+
 
 enum AggregateFunctionSumType
 {
     AggregateFunctionTypeSum,
     AggregateFunctionTypeSumWithOverflow,
     AggregateFunctionTypeSumKahan,
+    AggregateFunctionTypeSumPrometheus,
 };
 /// Counts the sum of the numbers.
 template <typename T, typename TResult, typename Data, AggregateFunctionSumType Type>
@@ -451,6 +547,8 @@ public:
             return "sumWithOverflow";
         else if constexpr (Type == AggregateFunctionTypeSumKahan)
             return "sumKahan";
+        else if constexpr (Type == AggregateFunctionTypeSumPrometheus)
+            return "sumPrometheus";
     }
 
     explicit AggregateFunctionSum(const DataTypes & argument_types_)
@@ -579,7 +677,7 @@ public:
 
     bool isCompilable() const override
     {
-        if constexpr (Type == AggregateFunctionTypeSumKahan)
+        if constexpr (Type == AggregateFunctionTypeSumKahan || Type == AggregateFunctionTypeSumPrometheus)
             return false;
 
         bool can_be_compiled = true;

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOneArgumentAggregationOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOneArgumentAggregationOperator.cpp
@@ -61,7 +61,7 @@ namespace
             {"sum",
              {
                  [](ASTPtr && v, const DataTypePtr &) -> ASTPtr
-                 { return makeASTFunction("sumForEach", std::move(v)); },
+                 { return makeASTFunction("sumPrometheusForEach", std::move(v)); },
              }},
 
             {"min",

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -281,6 +281,13 @@ def send_test_data():
         ]
     )
 
+    send_data(
+        [
+            ({"__name__": "fractional_values", "id": str(i)}, {120: 0.1})
+            for i in range(10)
+        ]
+    )
+
     # Classic Prometheus histogram buckets for `histogram_quantile` testing.
     # At t=300 the cumulative counts are: le=0.1 -> 10, le=0.5 -> 30, le=1.0 -> 50, le=+Inf -> 60.
     # That describes 10 observations <= 0.1s, 20 in (0.1, 0.5], 20 in (0.5, 1.0], and 10 in (1.0, +Inf).
@@ -737,6 +744,29 @@ def test_at_start_and_end_modifiers():
         120,
         '{"resultType": "vector", "result": []}',
         [],
+    )
+
+
+def test_sum_prometheus_aggregate():
+    assert (
+        node.query(
+            "SELECT sumPrometheus(value) "
+            "FROM (SELECT arrayJoin([2, 8, 1e100, -1e100]::Array(Float64)) AS value)"
+        )
+        == "10\n"
+    )
+
+    # Verify that corrections from independently accumulated states survive merging.
+    assert (
+        node.query(
+            "SELECT sumPrometheusMerge(state) FROM "
+            "("
+            "    SELECT arrayReduce('sumPrometheusState', [2, 1e100]::Array(Float64)) AS state "
+            "    UNION ALL "
+            "    SELECT arrayReduce('sumPrometheusState', [8, -1e100]::Array(Float64)) AS state"
+            ")"
+        )
+        == "10\n"
     )
 
 
@@ -3834,6 +3864,37 @@ def test_aggregation_operators():
         120,
         '{"resultType": "vector", "result": [{"metric": {}, "value": [120, "73"]}]}',
         [["[]", "1970-01-01 00:02:00.000", 73]],
+    )
+
+    # Prometheus uses compensated summation, so ten 0.1 samples sum to exactly 1.
+    do_query_test(
+        "sum(fractional_values)",
+        120,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [120, "1"]}]}',
+        [["[]", "1970-01-01 00:02:00.000", 1]],
+    )
+
+    # Repeated infinities keep their sign instead of poisoning the compensation.
+    do_query_test(
+        "sum(bar / 0)",
+        120,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [120, "+Inf"]}]}',
+        [["[]", "1970-01-01 00:02:00.000", "inf"]],
+    )
+
+    do_query_test(
+        "sum(-bar / 0)",
+        120,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [120, "-Inf"]}]}',
+        [["[]", "1970-01-01 00:02:00.000", "-inf"]],
+    )
+
+    # Opposite infinities must still produce NaN.
+    do_query_test(
+        "sum((bar - 20) / 0)",
+        120,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [120, "NaN"]}]}',
+        [["[]", "1970-01-01 00:02:00.000", "nan"]],
     )
 
     do_query_test(


### PR DESCRIPTION
### Description

PromQL `sum` currently uses the regular `sumForEach` aggregate, while Prometheus uses compensated summation for floating-point samples. For example, summing ten series with the value `0.1` produces `0.9999999999999999` with ordinary sequential accumulation, while Prometheus returns exactly `1`.

This adds a dedicated `sumPrometheus` aggregate and lowers PromQL `sum` to `sumPrometheusForEach`. It follows Prometheus's compensated addition for samples, including its handling of infinities. A separate aggregate is needed because the existing `sumKahan` behavior is not equivalent for these cases.

The aggregate state stores the running sum and correction so partial states can still be combined by ClickHouse's parallel and distributed aggregation. As with other floating-point aggregates, merging independently accumulated states can produce a different result from Prometheus's serial evaluation for order-sensitive inputs. Exact bit-for-bit reproduction would require preserving the original sample order across partial states. The goal here is to improve PromQL sum accuracy while keeping normal ClickHouse aggregation behavior.

The integration tests cover fractional values, merged aggregate states, repeated same-sign infinities, and opposite-sign infinities, and compare the PromQL results with Prometheus.

### Changelog category (leave one):
- **Bug Fix (user-visible misbehavior in an official stable release)**

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
**Use compensated summation for PromQL `sum` aggregation to reduce floating-point errors.**

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114251&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114251](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114251+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
