### PR TITLE
Use `contains` in the IPv6 host check of the Remote database engine

### DIFF
--- a/src/Databases/DatabaseRemote.cpp
+++ b/src/Databases/DatabaseRemote.cpp
@@ -1055,7 +1055,7 @@ void registerDatabaseRemote(DatabaseFactory & factory)
                 /// An IPv6 literal has to be bracketed before a port can be appended: the addresses are
                 /// later split with `parseAddress`, which treats the first `:` of an unbracketed address
                 /// as the port separator, so a bare `2001:db8::1` would be torn apart.
-                if (host.find(':') != String::npos && !host.starts_with('['))
+                if (host.contains(':') && !host.starts_with('['))
                     host = '[' + host + ']';
                 addresses_expr = named_collection->has("port") ? host + ':' + toString(named_collection->get<UInt64>("port")) : host;
             }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110975
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Master is red on `Build (arm_tidy)`:

```
/ClickHouse/src/Databases/DatabaseRemote.cpp:1058:26: error: use 'contains' to check for membership [readability-container-contains,-warnings-as-errors]
```

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=4efb1206aa13411eb1bab37a1f1902af486b1e60&name_0=MasterCI&name_1=Build%20%28arm_tidy%29

clang-tidy runs as warnings-as-errors there, so this single diagnostic aborts the whole build, and every PR that merges or rebases onto master inherits the red.

The line is not a mistake by its author. It was written on 2026-08-05, and every `Build (arm_tidy)` run on each of the three branch commits that carried it was green. A toolchain bump reclassified it: LLVM 22 lists "Improved `readability-container-contains` to support string comparisons to `npos`", so clang-tidy-21 flagged only the `find(...) != end()` container form, while clang-tidy-22 also flags `std::string::find(char) != npos`. #108400 landed clang-22 at 2026-08-10 17:33 UTC and the branch merged at 00:08 UTC, so the file entered master's tidy build already diagnosed.

This uses the idiom the check asks for, keeping the `!host.starts_with('[')` guard and the IPv6 comment intact:

```cpp
if (host.contains(':') && !host.starts_with('['))
```

The two forms are the same expression, not just equivalent in practice: libc++ implements `contains(charT c)` as `return find(c) != npos;`. `String` is `std::string` and the project builds at C++23, so the member is available. I also asserted `(s.find(':') != npos) == s.contains(':')` at runtime over 13 inputs including `""`, `":"`, `"2001:db8::1"`, `"[2001:db8::1]"` and an embedded NUL. No behaviour change, so there is nothing new to test and `Build (arm_tidy)` is itself the regression check.

`clang-tidy-22 -p build src/Databases/DatabaseRemote.cpp` reports the error at `:1058` before the change and nothing after. Master's last green `arm_tidy` commit already contained the clang-22 bump, so I swept the added lines between it and the red commit for every form the check recognises: this line is the only one.

Related: #110975


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1153` (included in `26.8` and later)
<!-- ch-version-info:end -->