### PR TITLE
Sync the replica before reading it in test_replicated_database

### DIFF
--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -425,10 +425,17 @@ def test_alter_drop_part(started_cluster, engine):
         dummy_node.query(f"INSERT INTO {database}.alter_drop_part VALUES (456)")
     else:
         main_node.query(f"SYSTEM SYNC REPLICA {database}.alter_drop_part PULL")
+        # A part covered by a pending drop is never fetched, so sync before dropping.
+        dummy_node.query(f"SYSTEM SYNC REPLICA {database}.alter_drop_part LIGHTWEIGHT")
+        assert (
+            dummy_node.query(f"SELECT CounterID FROM {database}.alter_drop_part")
+            == "123\n"
+        )
     main_node.query(f"ALTER TABLE {database}.alter_drop_part DROP PART '{part_name}'")
     assert main_node.query(f"SELECT CounterID FROM {database}.alter_drop_part") == ""
     if engine == "ReplicatedMergeTree":
         # The DROP operation is still replicated at the table engine level
+        dummy_node.query(f"SYSTEM SYNC REPLICA {database}.alter_drop_part LIGHTWEIGHT")
         assert (
             dummy_node.query(f"SELECT CounterID FROM {database}.alter_drop_part") == ""
         )
@@ -460,11 +467,14 @@ def test_alter_detach_part(started_cluster, engine):
         dummy_node.query(f"INSERT INTO {database}.alter_detach VALUES (456)")
     else:
         main_node.query(f"SYSTEM SYNC REPLICA {database}.alter_detach PULL")
+        # A part covered by a pending detach is never fetched, so sync before detaching.
+        dummy_node.query(f"SYSTEM SYNC REPLICA {database}.alter_detach LIGHTWEIGHT")
     main_node.query(f"ALTER TABLE {database}.alter_detach DETACH PART '{part_name}'")
     detached_parts_query = f"SELECT name FROM system.detached_parts WHERE database='{database}' AND table='alter_detach'"
     assert main_node.query(detached_parts_query) == f"{part_name}\n"
     if engine == "ReplicatedMergeTree":
         # The detach operation is still replicated at the table engine level
+        dummy_node.query(f"SYSTEM SYNC REPLICA {database}.alter_detach LIGHTWEIGHT")
         assert dummy_node.query(detached_parts_query) == f"{part_name}\n"
     else:
         assert dummy_node.query(detached_parts_query) == ""
@@ -487,6 +497,11 @@ def test_alter_drop_detached_part(started_cluster, engine):
         f"CREATE TABLE {database}.alter_drop_detached (CounterID UInt32) ENGINE = {engine} ORDER BY (CounterID)"
     )
     main_node.query(f"INSERT INTO {database}.alter_drop_detached VALUES (123)")
+    if engine == "ReplicatedMergeTree":
+        # A part covered by a pending detach is never fetched, so sync before detaching.
+        dummy_node.query(
+            f"SYSTEM SYNC REPLICA {database}.alter_drop_detached LIGHTWEIGHT"
+        )
     main_node.query(
         f"ALTER TABLE {database}.alter_drop_detached DETACH PART '{part_name}'"
     )
@@ -500,6 +515,10 @@ def test_alter_drop_detached_part(started_cluster, engine):
     )
     detached_parts_query = f"SELECT name FROM system.detached_parts WHERE database='{database}' AND table='alter_drop_detached'"
     assert main_node.query(detached_parts_query) == ""
+    if engine == "ReplicatedMergeTree":
+        dummy_node.query(
+            f"SYSTEM SYNC REPLICA {database}.alter_drop_detached LIGHTWEIGHT"
+        )
     assert dummy_node.query(detached_parts_query) == f"{part_name}\n"
 
     main_node.query(f"DROP DATABASE {database} SYNC")


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/100377
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_replicated_database/test.py::test_alter_detach_part[ReplicatedMergeTree]` fails with
`AssertionError: assert '' == 'all_0_0_0\n'`. Failing report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100377&sha=e4718fa7d44aecc0a38047c7ad022ba5c53096cb&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%201%2F4%29

`ALTER TABLE ... DETACH|DROP PART` is excluded from Replicated database DDL replication by
`ASTAlterQuery::isDropPartitionAlter`, so it runs on the initiating replica only and creates a
`DROP_RANGE` log entry. At the default `alter_sync = 1` the statement waits for the local replica,
so its return says nothing about the other replica. The test read `system.detached_parts` on
`dummy_node` with no synchronization in between. In the failing run's server log the replica spent
204 ms pulling that entry and applied the detach 42 ms after the assertion had already read empty.
`test_alter_drop_part` and `test_alter_drop_detached_part` do the same unsynchronized read.

The replica also has to own the part before the operation is issued. A `GET_PART` covered by a
pending drop range is suppressed at schedule time by `isGoingToBeDroppedImpl` and erased at
execution time by `removePartProducingOpsInRange`; then nothing is ever detached and a later
`SYSTEM SYNC REPLICA` returns promptly with the table still empty, so a post-operation wait alone
cannot fix that case.

So each of the three tests gets a `LIGHTWEIGHT` sync on the replica before the part operation and
before the read, matching `test_alter_attach` and
`01451_replicated_detach_drop_part_long.sql`. `test_alter_drop_part` asserts `== ""` on the
replica, which suppression would satisfy for the wrong reason, so it also gets a positive control
asserting the row is visible before the drop.

Test-only change, 19 insertions, no deletions.

Validated by reproducing both failure modes deterministically and confirming each half of the
change is required for its own mode:

<details>
<summary>Validation matrix</summary>

| arm | generator | form | result |
|---|---|---|---|
| B (transient window) | `rmt_delay_execute_drop_range` on the replica | unmodified | FAIL `assert '' == 'all_0_0_0\n'` at the reported line |
| B | same | fixed | PASS, call 12.13 s vs 0.9 s (the sync blocks for the delay) |
| B | same | before-wait only | FAIL (so the after wait is load-bearing) |
| A (suppression) | replica stops pulling the log across INSERT+DETACH | unmodified | FAIL permanently: replica logs `tried to drop single part all_0_0_0, but part does not exist`, and an armed `SYSTEM SYNC REPLICA ... LIGHTWEIGHT` + 3 s returns `OK` with the table still empty |
| A | same, on `test_alter_drop_detached_part` | unmodified | FAIL `assert '' == 'all_0_0_0\n'` |
| A | same | after-wait only | FAIL (so the before wait is load-bearing) |
| A | same, on `test_alter_drop_part` | fix minus its before wait | positive control FAILs `assert '' == '123\n'` |
| order proof | none | fixed | replica fetches the part at `.982` before `Executing DROP_RANGE` at `28.338`, then `Detached 1 parts` |
| regression | none | fixed | 11 passed: all three tests plus `test_alter_attach`, `test_alter_drop_partition`, `test_alter_fetch`, both parametrizations |
| repetition | none | fixed | 20 consecutive runs of each of the three `ReplicatedMergeTree` parametrizations, 80 passed / 0 failed |

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1213` (included in `26.8` and later)
<!-- ch-version-info:end -->