### PR TITLE
Fix flaky Q4 of 03753_join_runtime_filter_dynamically_disable

### DIFF
--- a/tests/queries/0_stateless/03753_join_runtime_filter_dynamically_disable.sql
+++ b/tests/queries/0_stateless/03753_join_runtime_filter_dynamically_disable.sql
@@ -25,6 +25,7 @@ SET query_plan_optimize_prewhere=1;
 SET enable_multiple_prewhere_read_steps=1;
 SET join_runtime_filter_min_probe_rows=0;
 SET join_runtime_filter_size_from_hash_table_stats=0;
+SET join_runtime_filter_from_fixed_hash_table=0;
 
 -- 1 row in filter
 SELECT count()
@@ -96,7 +97,7 @@ SELECT count()
 FROM customer, numbers(2000) AS n
 WHERE
     c_nationkey = n.number::Int32
-SETTINGS join_runtime_filter_exact_values_limit=1, join_runtime_bloom_filter_bytes=100, join_runtime_filter_from_fixed_hash_table=0, max_block_size=10, max_threads=1, log_comment='Q4';
+SETTINGS join_runtime_filter_exact_values_limit=1, join_runtime_bloom_filter_bytes=100, max_block_size=10, max_threads=1, log_comment='Q4';
 
 
 -- Check all blocks were skipped

--- a/tests/queries/0_stateless/03753_join_runtime_filter_dynamically_disable.sql
+++ b/tests/queries/0_stateless/03753_join_runtime_filter_dynamically_disable.sql
@@ -96,7 +96,7 @@ SELECT count()
 FROM customer, numbers(2000) AS n
 WHERE
     c_nationkey = n.number::Int32
-SETTINGS join_runtime_filter_exact_values_limit=1, join_runtime_bloom_filter_bytes=100, max_block_size=10, max_threads=1, log_comment='Q4';
+SETTINGS join_runtime_filter_exact_values_limit=1, join_runtime_bloom_filter_bytes=100, join_runtime_filter_from_fixed_hash_table=0, max_block_size=10, max_threads=1, log_comment='Q4';
 
 
 -- Check all blocks were skipped


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/111972
Related: https://github.com/ClickHouse/ClickHouse/pull/106734
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`03753_join_runtime_filter_dynamically_disable` fails on the **Q4** line only, printing `Q4 0 ...`
instead of `Q4 1 Ok`
([sighting](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111405&sha=52132ba17e43cd9d589e2988df497eefc4ccc10d&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29)).

**Root cause.** Q4 asserts `RuntimeFilterBlocksProcessed = 0`, which only the bloom filter reaches,
via `setFullyDisabled()` on over-fill. With `join_runtime_filter_from_fixed_hash_table` on,
`HashJoin::publishSharedRuntimeFilters` replaces that fully disabled bloom filter with a
`SharedFixedHashTableRuntimeFilter`, which has no full-disable path. Q4's probe keys all lie inside
the build range, so every row passes and only the pass-ratio heuristic throttles: the failing run
recorded `Processed = 12 / Skipped = 290`. `Processed = 0` is unreachable there.

**Onset is #111972**, as @ m-selmi identified in review.
`max_bytes_ratio_before_external_join` defaults to 0.5, so `SpillingHashJoin` wraps the join by
default and used to inherit `hasPostBuildPhase() = false`, which kept the shared filter unpublished.
A/B on one host, one test file, one server configuration: with those two overrides removed the
unpinned test passes 8 of 8 runs in one process; with them it passes the first run then fails 7 of 7
at `Processed = 12`, byte-identical to CI. CIDB shows 5 such failures across 5 PRs within 8 hours of
that merge, none in the preceding 45 days. The first run passes because the arm is
chosen from the process-global hash-table statistics cache, which is also why this is invisible on
master and shows up only in `parallel` jobs.

**The change** pins `join_runtime_filter_from_fixed_hash_table = 0` for the file, selecting the
implementation whose disabling behaviour Q4 exists to test. It costs no coverage: only Q4 ever
reaches the shared-filter arm (3 runs, 3 publications, all `log_comment = Q4`), and the other six
queries give identical counters pinned and unpinned. `04241` remains that arm's dedicated test.

**Validation.** 40 of 40 runs pass (20 randomized, 20 not); removing the pin reddens it 5 of 5.

Noticed, not filed: `SharedFixedHashTableRuntimeFilter` has no full-disable path at all.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1181` (included in `26.8` and later)
<!-- ch-version-info:end -->