### PR TITLE
Make the queue-removal check in test_rabbitmq_drop_table_properly precise

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -2130,14 +2130,23 @@ def test_rabbitmq_drop_table_properly(rabbitmq_cluster, db, unique):
     assert exists
 
     instance.query(f"DROP TABLE {db}.rabbitmq_drop")
-    time.sleep(30)
 
-    try:
-        exists = channel.queue_declare(queue=f"{unique}_rabbit_queue_drop", passive=True)
-    except Exception:
-        exists = False
-
-    assert not exists
+    # A failed passive declare closes the pika channel, so reopen it on every attempt:
+    # otherwise the next attempt raises for the wrong reason and the check passes vacuously.
+    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
+    while True:
+        channel = connection.channel()
+        try:
+            channel.queue_declare(queue=f"{unique}_rabbit_queue_drop", passive=True)
+        except pika.exceptions.ChannelClosedByBroker as e:
+            assert e.reply_code == 404, f"unexpected channel close: {e}"
+            break
+        if time.monotonic() >= deadline:
+            pytest.fail(
+                f"Queue {unique}_rabbit_queue_drop still exists {DEFAULT_TIMEOUT_SEC} seconds "
+                f"after DROP TABLE."
+            )
+        time.sleep(0.5)
 
 
 def test_rabbitmq_queue_settings(rabbitmq_cluster, db, unique):

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -2131,11 +2131,12 @@ def test_rabbitmq_drop_table_properly(rabbitmq_cluster, db, unique):
 
     instance.query(f"DROP TABLE {db}.rabbitmq_drop")
 
-    # A failed passive declare closes the pika channel, so reopen it on every attempt:
-    # otherwise the next attempt raises for the wrong reason and the check passes vacuously.
-    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
+    # Only a 404 means the queue is gone. A successful passive declare leaves the channel
+    # usable, and the 404 path breaks out at once, so the channel is never used after the
+    # broker closes it.
+    queue_removal_timeout_sec = 30
+    deadline = time.monotonic() + queue_removal_timeout_sec
     while True:
-        channel = connection.channel()
         try:
             channel.queue_declare(queue=f"{unique}_rabbit_queue_drop", passive=True)
         except pika.exceptions.ChannelClosedByBroker as e:
@@ -2143,8 +2144,8 @@ def test_rabbitmq_drop_table_properly(rabbitmq_cluster, db, unique):
             break
         if time.monotonic() >= deadline:
             pytest.fail(
-                f"Queue {unique}_rabbit_queue_drop still exists {DEFAULT_TIMEOUT_SEC} seconds "
-                f"after DROP TABLE."
+                f"Queue {unique}_rabbit_queue_drop still exists "
+                f"{queue_removal_timeout_sec} seconds after DROP TABLE."
             )
         time.sleep(0.5)
 

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -2142,12 +2142,15 @@ def test_rabbitmq_drop_table_properly(rabbitmq_cluster, db, unique):
         except pika.exceptions.ChannelClosedByBroker as e:
             assert e.reply_code == 404, f"unexpected channel close: {e}"
             break
-        if time.monotonic() >= deadline:
+        # The last declare lands at the deadline, so the accepted window is exactly
+        # queue_removal_timeout_sec.
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
             pytest.fail(
                 f"Queue {unique}_rabbit_queue_drop still exists "
                 f"{queue_removal_timeout_sec} seconds after DROP TABLE."
             )
-        time.sleep(0.5)
+        time.sleep(min(0.5, remaining))
 
 
 def test_rabbitmq_queue_settings(rabbitmq_cluster, db, unique):


### PR DESCRIPTION
<!--
No related open issue found (searched ClickHouse/ClickHouse open issues for
test_rabbitmq_drop_table_properly: 0 hits). The observed CI occurrences are on unrelated
PRs, so per the standing rule they are cited by count rather than linked - linking them
would create cross-references implying those PRs are connected.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`test_rabbitmq_drop_table_properly` asserts the broker queue is gone after `DROP TABLE`, and
intermittently fails (7 hits / 4 PRs in 180 days for this assertion, 0 on master, all on slow
configurations). This PR makes the assertion precise. It does not fix the leak behind those
failures, and it does not hide it either.

The assertion wrapped the passive declare in `except Exception: exists = False`, reading any
failure as "queue gone", so a dead connection or a non-404 channel close passed while the queue
was still there. It now requires `reply_code == 404`, and `time.sleep(30)` becomes a bounded poll
with the same 30 s budget, so a passing run finishes in milliseconds. The budget is deliberately
not widened, which would accept a real leak, and not cut to one immediate check, which would
reject the legitimately late delete the original accepted.

The failures are a real engine defect, visible in the server logs of two of those runs: the
broker refuses the delete with `PRECONDITION_FAILED - queue '...' in use`, 1 ms into a 1.5 ms
`DROP`. `closeConnections()` issues `channel->close()` without awaiting `close-ok`
(`RabbitMQConsumer.cpp:50-54`, from `StorageRabbitMQ.cpp:1012`); `cleanupRabbitMQ()` then issues
`removeQueue(queue, AMQP::ifunused)` on a different channel (`:1086`). AMQP 0-9-1 orders method
completion per channel, not across channels, so the table's own consumer can still be attached.
The queue is `AMQP::durable` with autodelete deliberately disallowed (`:772-774`), so it leaks
permanently. Awaiting `close-ok` fixes this path but stalls every `DROP` of a table that has
nacked, because `basic.nack` is misclassified as synchronous in `contrib/AMQP-CPP` and the close
frame is then never sent. That is the prerequisite, so the leak stands and this test keeps
catching it.

Also pre-existing: with `rabbitmq_num_queues > 1` the delete loop stops after the first
`delete-ok` (`StorageRabbitMQ.cpp:1092`), leaving deletes 2..N unconfirmed.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1228` (included in `26.8` and later)
<!-- ch-version-info:end -->