### PR TITLE
Add pre-hook to insert CI links into PR body

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/ci_links.py
+++ b/ci/jobs/scripts/workflow_hooks/ci_links.py
@@ -1,0 +1,71 @@
+import tempfile
+import traceback
+from urllib.parse import quote_plus
+
+from ci.praktika.gh import GH
+from ci.praktika.info import Info
+
+UPSTREAM_REPO = "ClickHouse/ClickHouse"
+BLOCK_START = "<!-- CI automatic block start :ci_links: -->"
+BLOCK_END = "<!-- CI automatic block end :ci_links: -->"
+
+
+def get_sync_pr_search_url(pr_number):
+    return (
+        "https://github.com/search?q="
+        + quote_plus(f"head:sync-upstream/pr/{pr_number} org:ClickHouse type:pr")
+        + "&type=pullrequests"
+    )
+
+
+def has_block(body):
+    return BLOCK_START in body and BLOCK_END in body
+
+
+def append_block(body, block):
+    if body.strip():
+        return body.rstrip() + "\n\n" + block + "\n"
+    return block + "\n"
+
+
+def main():
+    info = Info()
+    if info.pr_number <= 0 or info.repo_name != UPSTREAM_REPO:
+        print("NOTE: Not an upstream PR run - skip PR description update")
+        return
+
+    workflow_line = (
+        f"Workflow [[{info.workflow_name}]({info.get_report_url(latest=True)})]"
+    )
+    sync_line = f"Sync PR [[sync-upstream/pr/{info.pr_number}]({get_sync_pr_search_url(info.pr_number)})]"
+    block = f"{BLOCK_START}\n{workflow_line}\n{sync_line}\n{BLOCK_END}"
+
+    title, body, _labels = GH.get_pr_title_body_labels()
+    if not title:
+        print("WARNING: Failed to fetch PR data - skip PR description update")
+        return
+
+    body = body or ""
+    if has_block(body):
+        print("NOTE: CI links already present - skip PR description update")
+        return
+
+    new_body = append_block(body, block)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", encoding="utf-8") as f:
+        f.write(new_body)
+        f.flush()
+        if not GH.update_pr_body(body_file=f.name):
+            print("WARNING: Failed to update PR description")
+            return
+
+    info.env.PR_BODY = new_body
+    info.env.dump()
+    print("PR description updated with CI links")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        traceback.print_exc()

--- a/ci/jobs/scripts/workflow_hooks/ci_links.py
+++ b/ci/jobs/scripts/workflow_hooks/ci_links.py
@@ -34,6 +34,10 @@ def main():
         print("NOTE: Not an upstream PR run - skip PR description update")
         return
 
+    if has_block(info.pr_body or ""):
+        print("NOTE: CI links already present - skip PR description update")
+        return
+
     workflow_line = (
         f"Workflow [[{info.workflow_name}]({info.get_report_url(latest=True)})]"
     )
@@ -45,12 +49,7 @@ def main():
         print("WARNING: Failed to fetch PR data - skip PR description update")
         return
 
-    body = body or ""
-    if has_block(body):
-        print("NOTE: CI links already present - skip PR description update")
-        return
-
-    new_body = append_block(body, block)
+    new_body = append_block(body or "", block)
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", encoding="utf-8") as f:
         f.write(new_body)

--- a/ci/jobs/scripts/workflow_hooks/ci_links.py
+++ b/ci/jobs/scripts/workflow_hooks/ci_links.py
@@ -42,7 +42,10 @@ def main():
         f"Workflow [[{info.workflow_name}]({info.get_report_url(latest=True)})]"
     )
     sync_line = f"Sync PR [[sync-upstream/pr/{info.pr_number}]({get_sync_pr_search_url(info.pr_number)})]"
-    block = f"{BLOCK_START}\n{workflow_line}\n{sync_line}\n{BLOCK_END}"
+    # A horizontal rule visually separates the machine-owned block from the
+    # user-authored description. It lives inside the block markers so it is
+    # dropped together with the block.
+    block = f"{BLOCK_START}\n\n---\n{workflow_line}\n{sync_line}\n{BLOCK_END}"
 
     title, body, _labels = GH.get_pr_title_body_labels()
     if not title:

--- a/ci/jobs/scripts/workflow_hooks/new_tests_check.py
+++ b/ci/jobs/scripts/workflow_hooks/new_tests_check.py
@@ -84,10 +84,6 @@ def has_new_integration_test_docker_images(changed_files):
     return False
 
 
-def has_ci_report_link(pr_body):
-    return "s3.amazonaws.com/clickhouse-test-reports" in pr_body
-
-
 # Per-arch Bugfix Validation job names that this post-hook OR's together.
 # Each per-arch job runs the new/modified test on master HEAD and on the PR;
 # the per-arch runner inverts the test status (XFAIL): the job reports OK
@@ -173,13 +169,7 @@ def unit_bugfix_validation_refuted():
 
 
 def check():
-    # read actual PR body from GH API - fallback to workflow context if failed
-    title, body, labels = GH.get_pr_title_body_labels()
-    if body:
-        pr_body = body
-    else:
-        print("WARNING: Failed to get PR body from GH API - using workflow context")
-        pr_body = Info().pr_body
+    _title, _body, labels = GH.get_pr_title_body_labels()
     if not labels:
         labels = Info().pr_labels
 
@@ -198,18 +188,14 @@ def check():
 
     # Branching by what kinds of new tests the PR adds. The structure
     # below is deliberately mutually exclusive on the FT/IT-vs-rest axis
-    # so neither the unit-only shortcut nor the CI-report-link fallback
-    # can bypass per-arch Bugfix Validation when the PR adds functional
-    # or integration regression tests. (Bot reviews on PR #103541,
-    # 2026-05-03 / 2026-05-04 - concerns #5 and #6.)
+    # so the unit-only shortcut cannot bypass per-arch Bugfix Validation
+    # when the PR adds functional or integration regression tests. (Bot
+    # reviews on PR #103541, 2026-05-03 / 2026-05-04 - concerns #5 and #6.)
 
     # New functional or integration regression tests exist. Those tests
     # MUST validate on at least one arch (the bug reproduces on master
-    # HEAD and is fixed on the PR). The CI-report-link fallback is NOT
-    # accepted here - it would let an unvalidated FT/IT regression test
-    # through and weaken the contract this hook enforces. The presence
-    # of an additional unit test alongside FT/IT does not relax this
-    # requirement either.
+    # HEAD and is fixed on the PR). The presence of an additional unit
+    # test alongside FT/IT does not relax this requirement either.
     if has_ft or has_it:
         if any_bugfix_validation_passed():
             print(
@@ -259,16 +245,7 @@ def check():
         )
         return True
 
-    # No new tests at all. Allow a link to a CI report in the PR body as
-    # proof the bug exists and was fixed (operator-supplied evidence in
-    # lieu of an automated test). This fallback applies only here - it
-    # does NOT override per-arch Bugfix Validation when FT/IT tests are
-    # present (see the branch above).
-    if has_ci_report_link(pr_body):
-        print(
-            "No new tests have been added, but the PR description has a link to a CI report - pass"
-        )
-        return True
+    # No new tests at all.
     print("No new tests have been added")
     return False
 

--- a/ci/tests/test_new_tests_check.py
+++ b/ci/tests/test_new_tests_check.py
@@ -7,13 +7,17 @@ job (`OK`/`XFAIL`) confirmed the bug reproduces on master HEAD and is fixed
 on the PR. Earlier iterations of this branch had two bypasses in `check`
 (`has_unit` shortcut, CI-report-link fallback) that let an unvalidated FT/IT
 regression test through - both were caught only by review. These tests pin
-the truth table so future changes cannot reintroduce a bypass.
+the truth table so future changes cannot reintroduce a bypass. The
+CI-report-link fallback has since been removed entirely (the `ci_links.py`
+pre-hook auto-injects such a link into every upstream PR body, so it can no
+longer serve as operator-supplied evidence), so a Bug-Fix PR that adds no
+tests is rejected regardless of the links in its body.
 
 Invariant under test: when a Bug-Fix PR adds new functional or integration
 regression tests (`has_ft or has_it`), `check()` returns True iff at least
-one per-arch Bugfix Validation job is strict-success (`OK` or `XFAIL`).
-Neither the unit-test presence shortcut nor the CI-report-link fallback may
-override this; only the per-arch jobs decide.
+one per-arch Bugfix Validation job is strict-success (`OK` or `XFAIL`). The
+unit-test presence shortcut may not override this; only the per-arch jobs
+decide.
 
 See ClickHouse/ClickHouse#103541 (bot review, 2026-06-06).
 """
@@ -329,12 +333,11 @@ def test_ft_plus_unit_does_not_let_unit_bypass_per_arch(monkeypatch):
 
 
 def test_ft_plus_ci_report_link_does_not_bypass_per_arch(monkeypatch):
-    """Concern #6 - the CI-report-link fallback cannot bypass FT validation.
+    """A CI-report link in the PR body cannot bypass per-arch FT validation.
 
     A Bug-Fix PR that adds an FT regression test AND links a CI report in
-    the PR body must still validate via per-arch Bugfix Validation. The
-    CI-report-link fallback applies ONLY to PRs that add NO new tests at
-    all (the operator-supplied-evidence path).
+    the PR body must still validate via per-arch Bugfix Validation; a report
+    link in the body has no effect on this branch.
     """
     pr_body = (
         "Fix something.\n\n"
@@ -396,9 +399,13 @@ def test_unit_only_gtest_test_macro_takes_the_unit_branch(monkeypatch, tmp_path)
     assert new_tests_check.check() is True
 
 
-def test_no_test_with_ci_report_link_passes(monkeypatch):
-    """No new tests + CI-report-link in PR body -> operator-supplied
-    evidence path passes.
+def test_no_test_fails_even_with_ci_report_link(monkeypatch):
+    """No new tests -> reject, even when the PR body links a CI report.
+
+    The `ci_links.py` pre-hook auto-injects an
+    `s3.amazonaws.com/clickhouse-test-reports` link into every upstream PR body,
+    so a CI-report link is no longer accepted as operator-supplied evidence in
+    lieu of a test.
     """
     pr_body = (
         "Fix something.\n\n"
@@ -409,17 +416,6 @@ def test_no_test_with_ci_report_link_passes(monkeypatch):
     _install_stubs(
         monkeypatch,
         pr_body=pr_body,
-        changed_files=["src/Functions/UnrelatedSourceFile.cpp"],
-        workflow_subresults=[],
-    )
-    assert new_tests_check.check() is True
-
-
-def test_no_test_without_ci_report_link_fails(monkeypatch):
-    """No new tests and no CI-report-link -> reject."""
-    _install_stubs(
-        monkeypatch,
-        pr_body="A change.\n\n- [x]  Bug Fix\n",
         changed_files=["src/Functions/UnrelatedSourceFile.cpp"],
         workflow_subresults=[],
     )

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -234,6 +234,7 @@ workflow = Workflow.Config(
     enable_slack_feed=True,
     pre_hooks=[
         can_be_tested,
+        "python3 ./ci/jobs/scripts/workflow_hooks/ci_links.py",
         "python3 ./ci/jobs/scripts/workflow_hooks/store_data.py",
         "python3 ./ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py",
         "python3 ./ci/jobs/scripts/workflow_hooks/version_log.py",


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)


--

Adds a `ci_links.py` pre-hook to the `PR` workflow that, on upstream `ClickHouse/ClickHouse` pull request runs, appends a `:ci_links:` block to the PR description with:

- a link to the workflow report, and
- a link to a GitHub search for the corresponding sync PR (`sync-upstream/pr/<number>`).

The block is added only when it is not already present, so subsequent runs do not re-edit the PR body. Non-upstream / non-PR runs are skipped, and any failure is caught so it can never break the workflow.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114283&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114283](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114283+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
