### PR TITLE
Register Iceberg namespace in the catalog before writing table files (needed for SeaweedFS)

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -149,6 +149,7 @@ _WITH_FLAG_TO_COMPOSE: dict[str, List[str]] = {
         "docker_compose_iceberg_hms_catalog.yml",
         "docker_compose_iceberg_lakekeeper_catalog.yml",
         "docker_compose_iceberg_nessie_catalog.yml",
+        "docker_compose_iceberg_seaweedfs_catalog.yml",
     ],
     "hms_catalog": ["docker_compose_iceberg_hms_catalog.yml"],
     "glue_catalog": ["docker_compose_glue_catalog.yml"],

--- a/src/Databases/DataLake/GlueCatalog.cpp
+++ b/src/Databases/DataLake/GlueCatalog.cpp
@@ -627,20 +627,25 @@ String GlueCatalog::resolveMetadataPathFromTableLocation(const String & table_lo
     }
 }
 
-void GlueCatalog::createNamespaceIfNotExists(const String & namespace_name) const
+void GlueCatalog::createNamespaceIfNotExists(const String & namespace_name, const String & /*location*/) const
 {
     Aws::Glue::Model::CreateDatabaseRequest create_request;
     Aws::Glue::Model::DatabaseInput db_input;
     db_input.SetName(namespace_name);
     create_request.SetDatabaseInput(db_input);
 
-    glue_client->CreateDatabase(create_request);
+    auto outcome = glue_client->CreateDatabase(create_request);
+    if (!outcome.IsSuccess() && outcome.GetError().GetErrorType() != Aws::Glue::GlueErrors::ALREADY_EXISTS)
+    {
+        throw DB::Exception(
+            DB::ErrorCodes::DATALAKE_DATABASE_ERROR,
+            "Exception calling CreateDatabase for namespace {}: {}",
+            namespace_name, outcome.GetError().GetMessage());
+    }
 }
 
 void GlueCatalog::createTable(const String & namespace_name, const String & table_name, const String & new_metadata_path, Poco::JSON::Object::Ptr /*metadata_content*/) const
 {
-    createNamespaceIfNotExists(namespace_name);
-
     Aws::Glue::Model::CreateTableRequest request;
     request.SetDatabaseName(namespace_name);
 

--- a/src/Databases/DataLake/GlueCatalog.h
+++ b/src/Databases/DataLake/GlueCatalog.h
@@ -69,6 +69,8 @@ public:
 
     void createTable(const String & namespace_name, const String & table_name, const String & new_metadata_path, Poco::JSON::Object::Ptr metadata_content) const override;
 
+    void createNamespaceIfNotExists(const String & namespace_name, const String & location) const override;
+
     bool updateMetadata(const String & namespace_name, const String & table_name, const String & new_metadata_path, Poco::JSON::Object::Ptr new_snapshot) const override;
 
     bool updateSchema(
@@ -95,8 +97,6 @@ public:
         const String & glue_column_type);
 
 private:
-    void createNamespaceIfNotExists(const String & namespace_name) const;
-
     std::unique_ptr<Aws::Glue::GlueClient> glue_client;
     const LoggerPtr log;
     std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider;

--- a/src/Databases/DataLake/ICatalog.cpp
+++ b/src/Databases/DataLake/ICatalog.cpp
@@ -374,6 +374,11 @@ void ICatalog::createTable(const String & /*namespace_name*/, const String & /*t
     throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "createTable is not implemented");
 }
 
+void ICatalog::createNamespaceIfNotExists(const String & /*namespace_name*/, const String & /*location*/) const
+{
+    throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "createNamespaceIfNotExists is not implemented");
+}
+
 bool ICatalog::updateMetadata(const String & /*namespace_name*/, const String & /*table_name*/, const String & /*new_metadata_path*/, Poco::JSON::Object::Ptr /*new_snapshot*/) const
 {
     throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "updateMetadata is not implemented");

--- a/src/Databases/DataLake/ICatalog.h
+++ b/src/Databases/DataLake/ICatalog.h
@@ -245,8 +245,13 @@ public:
     /// E.g. one of S3, Azure, Local, HDFS.
     virtual std::optional<StorageType> getStorageType() const = 0;
 
-    /// Creates new table in catalog.
+    /// Creates new table in catalog. Callers must ensure the namespace exists before
+    /// writing any table files to storage: a catalog that shares its storage view with
+    /// the data refuses to create a namespace over a plain directory those files create.
     virtual void createTable(const String & namespace_name, const String & table_name, const String & new_metadata_path, Poco::JSON::Object::Ptr metadata_content) const;
+
+    /// Creates the namespace unless it already exists.
+    virtual void createNamespaceIfNotExists(const String & namespace_name, const String & location) const;
 
     /// Updates metadata in catalog.
     virtual bool updateMetadata(const String & namespace_name, const String & table_name, const String & new_metadata_path, Poco::JSON::Object::Ptr new_snapshot) const;

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -1676,6 +1676,22 @@ void RestCatalog::sendRequest(const CatalogState & catalog_state, const String &
 void RestCatalog::createNamespaceIfNotExists(const String & namespace_name, const String & location) const
 {
     const auto state_snapshot = state.get();
+
+    /// Check existence first: creation may be denied to a principal that is still
+    /// allowed to use a pre-provisioned namespace.
+    const std::string check_endpoint
+        = (base_url / state_snapshot->config.prefix / NAMESPACES_ENDPOINT / encodeNamespaceForURI(namespace_name)).generic_string();
+    try
+    {
+        sendRequest(*state_snapshot, check_endpoint, /* request_body */ nullptr, Poco::Net::HTTPRequest::HTTP_GET, /* ignore_result */ true);
+        return;
+    }
+    catch (const DB::HTTPException & e)
+    {
+        if (e.getHTTPStatus() != Poco::Net::HTTPResponse::HTTPStatus::HTTP_NOT_FOUND)
+            throw;
+    }
+
     const std::string endpoint = (base_url / state_snapshot->config.prefix / NAMESPACES_ENDPOINT).generic_string();
 
     Poco::JSON::Object::Ptr request_body = new Poco::JSON::Object;
@@ -1694,16 +1710,16 @@ void RestCatalog::createNamespaceIfNotExists(const String & namespace_name, cons
     {
         sendRequest(*state_snapshot, endpoint, request_body);
     }
-    catch (...)
+    catch (const DB::HTTPException & e)
     {
-        DB::tryLogCurrentException(log);
+        /// Lost the race to a concurrent creator.
+        if (e.getHTTPStatus() != Poco::Net::HTTPResponse::HTTPStatus::HTTP_CONFLICT)
+            throw;
     }
 }
 
 void RestCatalog::createTable(const String & namespace_name, const String & table_name, const String & /*new_metadata_path*/, Poco::JSON::Object::Ptr metadata_content) const
 {
-    createNamespaceIfNotExists(namespace_name, metadata_content->getValue<String>("location"));
-
     const auto state_snapshot = state.get();
     const std::string endpoint = (base_url / state_snapshot->config.prefix / NAMESPACES_ENDPOINT / encodeNamespaceForURI(namespace_name) / "tables").generic_string();
 

--- a/src/Databases/DataLake/RestCatalog.h
+++ b/src/Databases/DataLake/RestCatalog.h
@@ -142,7 +142,7 @@ protected:
         bool oauth_server_use_request_body_,
         DB::ContextPtr context_);
 
-    void createNamespaceIfNotExists(const String & namespace_name, const String & location) const;
+    void createNamespaceIfNotExists(const String & namespace_name, const String & location) const override;
 
     const std::filesystem::path base_url;
     const LoggerPtr log;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -815,6 +815,7 @@ void IcebergMetadata::createInitial(
     if (local_context->getSettingsRef()[Setting::write_full_path_in_iceberg_metadata].value)
         location_path
             = configuration_ptr->getTypeName() + "://" + configuration_ptr->getNamespace() + "/" + configuration_ptr->getRawPath().path;
+
     auto [metadata_content_object, metadata_content] = createEmptyMetadataFile(
         location_path, *columns, partition_by, order_by, local_context, configuration_ptr->getDataLakeSettings()[DataLakeStorageSetting::iceberg_format_version]);
     auto compression_method_str = local_context->getSettingsRef()[Setting::iceberg_metadata_compression_method].value;
@@ -826,6 +827,15 @@ void IcebergMetadata::createInitial(
         compression_suffix = "." + compression_suffix;
 
     auto filename = fmt::format("{}metadata/v1{}.metadata.json", configuration_ptr->getRawPath().path, compression_suffix);
+
+    if (catalog)
+    {
+        /// Register the namespace before any files are written (but after all local
+        /// validation, so a rejected CREATE leaves no trace in the catalog): a catalog
+        /// that shares its storage view with the data (e.g. SeaweedFS) refuses to create
+        /// a namespace over the plain directory those files would leave behind.
+        catalog->createNamespaceIfNotExists(DataLake::parseTableName(table_id_.getTableName()).first, location_path);
+    }
 
     try
     {

--- a/tests/integration/compose/docker_compose_iceberg_seaweedfs_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_seaweedfs_catalog.yml
@@ -1,0 +1,29 @@
+services:
+  seaweedfs:
+    image: chrislusf/seaweedfs:4.41
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        mkdir -p /data /etc/seaweedfs
+        cat > /etc/seaweedfs/s3.json <<'EOF'
+        {
+          "identities": [
+            {
+              "name": "clickhouse",
+              "credentials": [{"accessKey": "clickhouse", "secretKey": "clickhouse"}],
+              "actions": ["Admin", "Read", "Write", "List", "Tagging"]
+            }
+          ]
+        }
+        EOF
+        exec weed mini -dir=/data -s3 -s3.config=/etc/seaweedfs/s3.json -tableBucket=analytics
+    ports:
+      - "${ICEBERG_REST_CATALOG_PORT}:8181"
+    healthcheck:
+      test: ["CMD-SHELL", "nc -w2 -z localhost 8333 && nc -w2 -z localhost 8181"]
+      interval: 1s
+      timeout: 5s
+      retries: 60
+      start_period: 10s
+    cpus: 3

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -41,7 +41,6 @@ try:
     import pymongo
     import pymysql
     import nats
-    from filelock import FileLock, Timeout
     from confluent_kafka.avro.cached_schema_registry_client import CachedSchemaRegistryClient
     # Not an easy dep
     import cassandra.cluster
@@ -52,6 +51,7 @@ except Exception as e:
 
 import docker
 from dict2xml import dict2xml
+from filelock import FileLock, Timeout
 from docker.models.containers import Container
 from kazoo.exceptions import KazooException
 from minio import Minio

--- a/tests/integration/test_database_iceberg_seaweedfs_catalog/test.py
+++ b/tests/integration/test_database_iceberg_seaweedfs_catalog/test.py
@@ -1,0 +1,88 @@
+import time
+
+import pytest
+import requests
+
+from helpers.cluster import ClickHouseCluster
+
+CATALOG_URL = "http://seaweedfs:8181/v1"
+STORAGE_URL = "http://seaweedfs:8333/analytics"
+ACCESS_KEY = "clickhouse"
+SECRET_KEY = "clickhouse"
+
+
+def wait_for_seaweedfs(cluster, timeout=120):
+    """Wait until both the Iceberg REST catalog and the pre-created bucket are ready."""
+    catalog_url = f"http://localhost:{cluster.iceberg_rest_catalog_port}/v1/config"
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            if requests.get(catalog_url, timeout=2).status_code == 200:
+                buckets = cluster.exec_in_container(
+                    cluster.get_container_id("seaweedfs"),
+                    ["sh", "-c", "echo s3.bucket.list | weed shell 2>/dev/null"],
+                )
+                if "analytics" in buckets:
+                    return
+        except Exception:
+            if time.monotonic() > deadline:
+                raise
+        if time.monotonic() > deadline:
+            raise TimeoutError("SeaweedFS did not become ready")
+        time.sleep(0.5)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    cluster = ClickHouseCluster(__file__)
+    try:
+        cluster.add_instance(
+            "node1",
+            with_iceberg_catalog=True,
+            extra_parameters={
+                "docker_compose_file_name": "docker_compose_iceberg_seaweedfs_catalog.yml"
+            },
+        )
+        cluster.start()
+        wait_for_seaweedfs(cluster)
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_create_insert_select(started_cluster):
+    node = started_cluster.instances["node1"]
+
+    node.query(
+        f"""
+        CREATE DATABASE lake
+        ENGINE = DataLakeCatalog('{CATALOG_URL}', '{ACCESS_KEY}', '{SECRET_KEY}')
+        SETTINGS catalog_type = 'rest',
+            warehouse = 's3://analytics',
+            storage_endpoint = '{STORAGE_URL}',
+            catalog_credential = '{ACCESS_KEY}:{SECRET_KEY}',
+            oauth_server_uri = '{CATALOG_URL}/oauth/tokens'
+        """,
+        settings={"allow_experimental_database_iceberg": 1},
+    )
+
+    node.query(
+        f"""
+        CREATE TABLE lake.`sales.returns` (id Int64, reason String)
+        ENGINE = IcebergS3('{STORAGE_URL}/sales/returns/', '{ACCESS_KEY}', '{SECRET_KEY}')
+        """,
+        settings={
+            "allow_experimental_database_iceberg": 1,
+            "write_full_path_in_iceberg_metadata": 1,
+        },
+    )
+
+    node.query(
+        "INSERT INTO lake.`sales.returns` VALUES (1, 'damaged'), (2, 'wrong size')",
+        settings={"allow_experimental_insert_into_iceberg": 1},
+    )
+
+    assert (
+        node.query("SELECT * FROM lake.`sales.returns` ORDER BY id")
+        == "1\tdamaged\n2\twrong size\n"
+    )


### PR DESCRIPTION
Files written first turn the namespace into a plain directory, which a catalog sharing the storage view (SeaweedFS) rejects with HTTP 500; the swallowed error left an orphaned metadata file that broke retries. Ensure the namespace before the first write; propagate failures except 404-then-create and 409 (REST) / AlreadyExists (Glue).

Example: https://pastila.nl/?01f91a25/620869a81af815ba6927860efbc72af4#NhE2Nbzh3AHhUHhA5Fdkzw==GCM

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Register Iceberg namespace in the catalog before writing table files (needed for SeaweedFS)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1402` (included in `26.8` and later)
- Backported to: `26.7.6.14`, `26.6.4.20`, `26.5.8.19`
<!-- ch-version-info:end -->