### PR TITLE
Docs: fix settings explorers

### DIFF
--- a/ci/jobs/scripts/docs/autogenerate/autogenerate_docs.py
+++ b/ci/jobs/scripts/docs/autogenerate/autogenerate_docs.py
@@ -1337,7 +1337,7 @@ def _settings_explorer_component(pages, family=None):
                 <span aria-hidden="true" className="w-4 shrink-0" />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
                 <a
-                  href={item.value.href}
+                  href={`/docs${item.value.href}`}
                   className="min-w-0 whitespace-normal no-underline hover:underline"
                   style={{ overflowWrap: "anywhere" }}
                 >

--- a/ci/jobs/scripts/docs/autogenerate/test_session_settings_split.py
+++ b/ci/jobs/scripts/docs/autogenerate/test_session_settings_split.py
@@ -396,6 +396,7 @@ def main():
         assert "text-gray-500 dark:text-gray-400" in explorer
         assert 'gridTemplateColumns: "44ch max-content"' in explorer
         assert 'style={{ overflowWrap: "anywhere" }}' in explorer
+        assert 'href={`/docs${item.value.href}`}' in explorer
         assert 'item.value.name.split("_")' in explorer
         assert "<wbr />" in explorer
         assert "settingNameColumnWidth" not in explorer

--- a/ci/jobs/scripts/docs/locale_components_check.py
+++ b/ci/jobs/scripts/docs/locale_components_check.py
@@ -37,8 +37,9 @@ EXTS = (".mdx", ".md", ".jsx", ".tsx", ".js")
 # a repo-relative doc path, so it is out of scope for the locale check.
 SKIP_PREFIXES = ("/images/", "/assets/", "/_site/", "/.well-known/", "/docs/")
 SKIP_EXACT = {"/docs", "/"}
-# `href: "/x"`, `href="/x"`, `href={'/x'}`, `to: "/x"`, ...
-HREF = re.compile(r"""\b(?:href|to)\s*[:=]\s*\{?\s*(['"`])(/[^'"`\s]+)\1""")
+# `href: "/x"`, `href="/x"`, `href={'/x'}`, `to: "/x"`, ...; a `$` belongs
+# to a template literal handled by `TEMPLATE`, not a static href.
+HREF = re.compile(r"""\b(?:href|to)\s*[:=]\s*\{?\s*(['"`])(/[^'"`\s$]+)\1""")
 # A template literal whose static prefix is a doc path, e.g.
 # `` `/get-started/quickstarts/${f.id}` `` -- the href fallbacks in
 # QuickStartsGrid/KBExplorer. lychee and the static HREF pattern both miss these,

--- a/ci/jobs/scripts/docs/lychee_check.py
+++ b/ci/jobs/scripts/docs/lychee_check.py
@@ -37,6 +37,11 @@ anchors are invisible to fragment checking. The ``<a id>`` form is extracted by
 lychee even inside JSX. The copy holds only the files lychee actually checks
 (from ``lychee --dump-inputs``, which honours ``lychee.toml``), so the large
 image and generated-translation trees under ``docs/`` are never copied.
+
+The internal and locale link modes also materialize the generated settings
+explorers' JSX destinations as Markdown links. This makes lychee validate the
+pages those runtime links open, while an explicit check verifies that the JSX
+keeps the production `/docs` mount which is absent from the on-disk docs root.
 """
 
 import argparse
@@ -392,6 +397,127 @@ def report_snippet_links(docs_root, rel_files):
     return errors
 
 
+# Generated settings explorers keep their destinations in JSX data and render
+# them through ``href={`/docs${item.value.href}`}``. lychee does not parse JSX
+# data or evaluate template literals, so materialize those rendered links into a
+# Markdown input in the throwaway tree. The production mount is checked before
+# stripping `/docs` for offline resolution against the docs root.
+SETTINGS_EXPLORER_ENTRY_HREF = re.compile(
+    r'''(?:["']href["']|\bhref)\s*:\s*(?P<quote>["'])(?P<href>/[^"'`\s]+)(?P=quote)'''
+)
+SETTINGS_EXPLORER_TEMPLATE_HREF = re.compile(
+    r'''href\s*=\s*\{\s*`(?P<prefix>[^`]*)\$\{item\.value\.href\}(?P<suffix>[^`]*)`\s*\}'''
+)
+SETTINGS_EXPLORER_DIRECT_HREF = re.compile(
+    r'''href\s*=\s*\{\s*item\.value\.href\s*\}'''
+)
+
+
+def settings_explorer_files(docs_root, locales=()):
+    component_roots = [os.path.join(docs_root, "snippets", "components")]
+    if locales:
+        component_roots = [
+            os.path.join(docs_root, "snippets", locale, "components")
+            for locale in locales
+        ]
+
+    files = []
+    for component_root in component_roots:
+        if not os.path.isdir(component_root):
+            continue
+        for name in sorted(os.listdir(component_root)):
+            if not name.endswith("SettingsExplorer"):
+                continue
+            path = os.path.join(component_root, name, name + ".jsx")
+            if os.path.isfile(path):
+                files.append(path)
+    return files
+
+
+def write_settings_explorer_links(
+        docs_root, dest, locales=(), include_fragments=True):
+    """Render settings explorer URLs into Markdown for lychee to validate."""
+    output_name = (
+        "_lychee_locale_settings_explorer_links.md"
+        if locales else "_lychee_settings_explorer_links.md"
+    )
+    errors = 0
+    links = set()
+    files = settings_explorer_files(docs_root, locales)
+    if not files:
+        print(
+            "[ERROR] No settings explorer components found to link-check.",
+            flush=True,
+        )
+        errors += 1
+
+    for path in files:
+        rel = os.path.relpath(path, docs_root)
+        with open(path, encoding="utf-8", errors="replace") as f:
+            text = f.read()
+
+        templates = list(SETTINGS_EXPLORER_TEMPLATE_HREF.finditer(text))
+        direct = list(SETTINGS_EXPLORER_DIRECT_HREF.finditer(text))
+        renderers = templates + direct
+        if len(renderers) != 1:
+            print(
+                f"[ERROR] {rel} | expected exactly one rendered "
+                "`item.value.href` settings link",
+                flush=True,
+            )
+            errors += 1
+            continue
+
+        renderer = renderers[0]
+        if templates:
+            prefix = renderer.group("prefix")
+            suffix = renderer.group("suffix")
+        else:
+            prefix = ""
+            suffix = ""
+        line = text.count("\n", 0, renderer.start()) + 1
+        entry_hrefs = [
+            match.group("href")
+            for match in SETTINGS_EXPLORER_ENTRY_HREF.finditer(text)
+        ]
+        if not entry_hrefs:
+            print(f"[ERROR] {rel} | no settings links found", flush=True)
+            errors += 1
+            continue
+
+        rendered_links = [prefix + href + suffix for href in entry_hrefs]
+        malformed = next(
+            (
+                href for href in rendered_links
+                if not href.startswith("/docs/") or href.startswith("/docs//")
+            ),
+            None,
+        )
+        if malformed:
+            print(
+                f"[ERROR] {rel} (at {line}) | rendered settings links must "
+                f"start with `/docs/`; got {malformed}",
+                flush=True,
+            )
+            errors += 1
+
+        for href in rendered_links:
+            # `/docs` is ClickHouse's production mount; the throwaway tree is
+            # rooted at its contents, so remove only that leading mount segment.
+            offline_href = (
+                href[len("/docs"):] if href.startswith("/docs/") else href
+            )
+            if not include_fragments:
+                offline_href = offline_href.split("#", 1)[0]
+            links.add(offline_href)
+
+    with open(os.path.join(dest, output_name), "w", encoding="utf-8") as f:
+        f.write("# Generated settings explorer links\n\n")
+        for index, href in enumerate(sorted(links), 1):
+            f.write(f"- [Settings explorer link {index}]({href})\n")
+    return output_name, errors
+
+
 def locale_markdown_files(docs_root):
     # All .md/.mdx under the top-level locale trees and localized snippet trees.
     files = []
@@ -408,13 +534,15 @@ def locale_markdown_files(docs_root):
 def check_links(docs_root):
     dest = tempfile.mkdtemp(prefix="lychee-links-")
     build_tree(docs_root, dest)
+    _explorer_input, rc_explorer = write_settings_explorer_links(
+        docs_root, dest, include_fragments=True)
     rc = run_lychee(
         ["lychee", "--mode", "color", "--offline", "--include-fragments", "."], dest
     )
     # lychee cannot tell a snippet file (imported, not a page) from a real page,
     # so it blesses /snippets/... links; reject them here over the same inputs.
     rc_snip = report_snippet_links(docs_root, dump_inputs(docs_root))
-    return rc or (1 if rc_snip else 0)
+    return rc or (1 if rc_snip or rc_explorer else 0)
 
 
 def check_locale_links(docs_root):
@@ -427,6 +555,8 @@ def check_locale_links(docs_root):
     # it only when the locale trees change.
     dest = tempfile.mkdtemp(prefix="lychee-locales-")
     build_tree(docs_root, dest)
+    explorer_input, rc_explorer = write_settings_explorer_links(
+        docs_root, dest, locales=LOCALE_DIRS, include_fragments=False)
     # Both the top-level locale trees and the localized snippet trees
     # (snippets/<locale>/), which the locale pages import and render.
     inputs = [d for d in LOCALE_DIRS if os.path.isdir(os.path.join(dest, d))]
@@ -434,13 +564,17 @@ def check_locale_links(docs_root):
                if os.path.isdir(os.path.join(dest, "snippets", d))]
     if not inputs:
         print("No locale directories present; nothing to check.", flush=True)
-        return 0
+        return 1 if rc_explorer else 0
     cfg = write_locale_config(docs_root, dest)
     rc = run_lychee(
-        ["lychee", "--config", cfg, "--mode", "color", "--offline", *inputs], dest
+        [
+            "lychee", "--config", cfg, "--mode", "color", "--offline",
+            *inputs, explorer_input,
+        ],
+        dest,
     )
     rc_snip = report_snippet_links(docs_root, locale_markdown_files(docs_root))
-    return rc or (1 if rc_snip else 0)
+    return rc or (1 if rc_snip or rc_explorer else 0)
 
 
 def check_redirects(docs_root):

--- a/ci/tests/test_docs_link_checker.py
+++ b/ci/tests/test_docs_link_checker.py
@@ -1,0 +1,69 @@
+"""Regression tests for links extracted from generated docs components."""
+
+import os
+import sys
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.scripts.docs import locale_components_check, lychee_check
+
+
+def write_settings_explorer(docs_root, rendered_href):
+    component = (
+        docs_root
+        / "snippets/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx"
+    )
+    component.parent.mkdir(parents=True)
+    component.write_text(
+        'const entries = [{"name":"example_setting",'
+        '"href":"/reference/settings/session-settings/example#example_setting"}];\n'
+        f"<a {rendered_href}>example_setting</a>\n",
+        encoding="utf-8",
+    )
+
+
+def test_settings_explorer_links_are_materialized_for_lychee(tmp_path):
+    docs_root = tmp_path / "docs"
+    output = tmp_path / "output"
+    output.mkdir()
+    write_settings_explorer(
+        docs_root,
+        'href={`/docs${item.value.href}`}',
+    )
+
+    output_name, errors = lychee_check.write_settings_explorer_links(
+        docs_root, output)
+
+    assert errors == 0
+    materialized = (output / output_name).read_text(encoding="utf-8")
+    assert (
+        "](/reference/settings/session-settings/example#example_setting)"
+        in materialized
+    )
+    assert "/docs/reference/settings" not in materialized
+
+
+def test_settings_explorer_links_require_the_production_docs_mount(
+        tmp_path, capsys):
+    docs_root = tmp_path / "docs"
+    output = tmp_path / "output"
+    output.mkdir()
+    write_settings_explorer(docs_root, "href={item.value.href}")
+
+    _output_name, errors = lychee_check.write_settings_explorer_links(
+        docs_root, output)
+
+    assert errors == 1
+    report = capsys.readouterr().out
+    assert "rendered settings links must start with `/docs/`" in report
+    assert "/reference/settings/session-settings/example#example_setting" in report
+
+
+def test_locale_static_link_parser_leaves_templates_to_template_parser():
+    rendered_href = 'href={`/docs${item.value.href}`}'
+
+    assert locale_components_check.HREF.search(rendered_href) is None
+    template = locale_components_check.TEMPLATE.search(rendered_href)
+    assert template is not None
+    assert template.group(1) == "/docs"

--- a/docs/snippets/ar/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/ar/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ar/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/ar/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ar/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/ar/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ar/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/ar/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -164,7 +164,7 @@ const FormatSettingsExplorer = () => {
                 <span aria-hidden="true" className="w-4 shrink-0" />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
                 <a
-                  href={item.value.href}
+                  href={`/docs${item.value.href}`}
                   className="min-w-0 whitespace-normal no-underline hover:underline"
                   style={{ overflowWrap: "anywhere" }}
                 >

--- a/docs/snippets/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -164,7 +164,7 @@ const MergeTreeSettingsExplorer = () => {
                 <span aria-hidden="true" className="w-4 shrink-0" />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
                 <a
-                  href={item.value.href}
+                  href={`/docs${item.value.href}`}
                   className="min-w-0 whitespace-normal no-underline hover:underline"
                   style={{ overflowWrap: "anywhere" }}
                 >

--- a/docs/snippets/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -164,7 +164,7 @@ const ServerSettingsExplorer = () => {
                 <span aria-hidden="true" className="w-4 shrink-0" />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
                 <a
-                  href={item.value.href}
+                  href={`/docs${item.value.href}`}
                   className="min-w-0 whitespace-normal no-underline hover:underline"
                   style={{ overflowWrap: "anywhere" }}
                 >

--- a/docs/snippets/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -164,7 +164,7 @@ const SessionSettingsExplorer = () => {
                 <span aria-hidden="true" className="w-4 shrink-0" />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
                 <a
-                  href={item.value.href}
+                  href={`/docs${item.value.href}`}
                   className="min-w-0 whitespace-normal no-underline hover:underline"
                   style={{ overflowWrap: "anywhere" }}
                 >

--- a/docs/snippets/es/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/es/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/es/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/es/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/es/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/es/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/es/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/es/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/fr/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/fr/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/fr/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/fr/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/fr/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/fr/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/fr/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/fr/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ja/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/ja/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ja/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/ja/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ja/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/ja/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ja/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/ja/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ko/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/ko/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ko/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/ko/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ko/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/ko/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ko/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/ko/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/pt-BR/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/pt-BR/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/pt-BR/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/pt-BR/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/pt-BR/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/pt-BR/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/pt-BR/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/pt-BR/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ru/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/ru/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ru/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/ru/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ru/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/ru/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ru/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/ru/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/zh/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/zh/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/zh/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/zh/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/zh/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/zh/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/zh/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/zh/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={item.value.href} className="no-underline hover:underline">
+                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>


### PR DESCRIPTION
Fix settings explorer links so they retain the `/docs` mount when navigating to generated detail pages. The generated JSX stored docs-root paths and rendered them through plain anchors, bypassing Mintlify route rewriting and sending users to `/reference/...`.

Apply the fix to the session, server, `MergeTree`, and format settings explorers and their localized copies. Update the generator and extend the link checker to materialize and validate the generated explorer destinations.

Reported page: https://clickhouse.com/docs/reference/settings/session-settings

Validated with the focused generator and link-checker tests, the English and localized lychee passes, and the locale component checker.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix links in generated settings explorers.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1160` (included in `26.8` and later)
<!-- ch-version-info:end -->