### PR TITLE
Add coverage tests for three untested MergeTree/replication branches

### DIFF
--- a/tests/queries/0_stateless/04089_merge_tree_refresh_after_merge.reference
+++ b/tests/queries/0_stateless/04089_merge_tree_refresh_after_merge.reference
@@ -1,0 +1,9 @@
+reader before merge:
+Active	3
+reader after merge:
+Active	1
+Deleting	3
+reader rows:
+aaa
+bbb
+ccc

--- a/tests/queries/0_stateless/04089_merge_tree_refresh_after_merge.sh
+++ b/tests/queries/0_stateless/04089_merge_tree_refresh_after_merge.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Tags: no-random-settings, no-object-storage, no-replicated-database, no-shared-merge-tree, no-fasttest
+# Tag no-replicated-database: plain rewritable should not be shared between replicas
+
+# A readonly replica refreshing a shared plain_rewritable path must handle the writer having MERGED:
+# the refresh adds the merged part and must also retire the parts that merge superseded.
+#
+# The retirement step is observable only through the part STATE. A refresh commits the merged part
+# with the same Transaction::commit that demotes the parts it covers to Outdated, so the active set
+# is {merged part} either way; the superseded parts are Deleting once grabbed for removal and stay
+# Outdated otherwise. system.parts returns non-Active parts only when _state is selected, hence the
+# grouping below.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS writer SYNC"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS reader SYNC"
+
+disk_path="disks/04089/${CLICKHOUSE_DATABASE}/"
+
+${CLICKHOUSE_CLIENT} --query "
+CREATE TABLE writer (s String) ORDER BY ()
+SETTINGS table_disk = true,
+  disk = disk(
+      name = 04089_writer_${CLICKHOUSE_DATABASE},
+      type = object_storage,
+      object_storage_type = local,
+      metadata_type = plain_rewritable,
+      path = '${disk_path}')
+"
+
+# Same backing path, readonly and WITHOUT refresh_parts_interval: the background task would race the
+# assertions below, so the refresh is driven explicitly by SYSTEM RESTART DISK instead.
+${CLICKHOUSE_CLIENT} --query "
+CREATE TABLE reader (s String) ORDER BY ()
+SETTINGS table_disk = true,
+  disk = disk(
+      readonly = true,
+      name = 04089_reader_${CLICKHOUSE_DATABASE},
+      type = object_storage,
+      object_storage_type = local,
+      metadata_type = plain_rewritable,
+      path = '${disk_path}')
+"
+
+# The writer's own scheduler is otherwise free to merge these three parts before the first refresh.
+${CLICKHOUSE_CLIENT} --query "SYSTEM STOP MERGES writer"
+${CLICKHOUSE_CLIENT} --query "INSERT INTO writer VALUES ('aaa')"
+${CLICKHOUSE_CLIENT} --query "INSERT INTO writer VALUES ('bbb')"
+${CLICKHOUSE_CLIENT} --query "INSERT INTO writer VALUES ('ccc')"
+
+${CLICKHOUSE_CLIENT} --query "SYSTEM RESTART DISK 04089_reader_${CLICKHOUSE_DATABASE}"
+echo "reader before merge:"
+${CLICKHOUSE_CLIENT} --query "
+SELECT _state, count() FROM system.parts
+WHERE database = currentDatabase() AND table = 'reader' GROUP BY _state ORDER BY _state"
+
+${CLICKHOUSE_CLIENT} --query "SYSTEM START MERGES writer"
+${CLICKHOUSE_CLIENT} --query "OPTIMIZE TABLE writer FINAL"
+
+${CLICKHOUSE_CLIENT} --query "SYSTEM RESTART DISK 04089_reader_${CLICKHOUSE_DATABASE}"
+echo "reader after merge:"
+${CLICKHOUSE_CLIENT} --query "
+SELECT _state, count() FROM system.parts
+WHERE database = currentDatabase() AND table = 'reader' GROUP BY _state ORDER BY _state"
+
+echo "reader rows:"
+${CLICKHOUSE_CLIENT} --query "SELECT * FROM reader ORDER BY s"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE reader SYNC"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE writer SYNC"

--- a/tests/queries/0_stateless/04201_read_rows_external_group_by.reference
+++ b/tests/queries/0_stateless/04201_read_rows_external_group_by.reference
@@ -1,0 +1,2 @@
+spill_happened
+read_rows_correct

--- a/tests/queries/0_stateless/04201_read_rows_external_group_by.sh
+++ b/tests/queries/0_stateless/04201_read_rows_external_group_by.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-random-settings
+# Tag no-fasttest: external aggregation needs temporary files
+# Tag no-random-settings: randomized group_by_two_level_threshold*, optimize_aggregation_in_order and
+#                         the max_bytes_ratio_before_external_group_by family change whether and how
+#                         the aggregation spills, which is the path this asserts
+
+# When GROUP BY spills, the aggregated states are re-read from native-format temporary files. Those
+# re-read rows are not input rows, so the source that reads them reports no read progress of its own
+# (SourceFromNativeStream::getReadProgress in AggregatingTransform.cpp:150 returns nullopt). Reported
+# read_rows must therefore stay equal to the number of rows actually read from the input, not grow by
+# the spilled rows read back during the merge.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+QUERY="SELECT count() FROM (SELECT number FROM numbers(100000) GROUP BY number) SETTINGS max_bytes_before_external_group_by = 1, max_bytes_ratio_before_external_group_by = 0"
+
+# A run that never spilled would satisfy the read_rows assertion trivially, so require the spill first.
+SPILLED=$(${CLICKHOUSE_CLIENT} --print-profile-events -q "${QUERY}" 2>&1 | grep -c "ExternalAggregationMerge")
+if [[ "$SPILLED" -lt 1 ]]; then
+    echo "spill_did_not_happen"
+else
+    echo "spill_happened"
+fi
+
+SUMMARY=$(${CLICKHOUSE_CURL} -sS -i "${CLICKHOUSE_URL}" --data-binary "${QUERY}" 2>&1 | grep -i '^X-ClickHouse-Summary:' | head -1)
+READ_ROWS=$(echo "$SUMMARY" | grep -oP '"read_rows":"\K[0-9]+')
+
+if [[ "$READ_ROWS" == "100000" ]]; then
+    echo "read_rows_correct"
+else
+    echo "read_rows_wrong:$READ_ROWS"
+fi

--- a/tests/queries/0_stateless/04201_read_rows_external_group_by.sh
+++ b/tests/queries/0_stateless/04201_read_rows_external_group_by.sh
@@ -17,16 +17,28 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 QUERY="SELECT count() FROM (SELECT number FROM numbers(100000) GROUP BY number) SETTINGS max_bytes_before_external_group_by = 1, max_bytes_ratio_before_external_group_by = 0"
 
-# A run that never spilled would satisfy the read_rows assertion trivially, so require the spill first.
-SPILLED=$(${CLICKHOUSE_CLIENT} --print-profile-events -q "${QUERY}" 2>&1 | grep -c "ExternalAggregationMerge")
-if [[ "$SPILLED" -lt 1 ]]; then
+QID="04201_read_rows_${CLICKHOUSE_DATABASE}"
+
+${CLICKHOUSE_CLIENT} --query_id "$QID" -q "${QUERY}" > /dev/null
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS query_log"
+
+# Both facts come from that one execution: the query produces exactly group_by_two_level_threshold
+# keys, so whether it spills is decided per run, and a run that did not spill satisfies the
+# read_rows assertion trivially. LIMIT 1 rather than an aggregate, so that no row at all leaves both
+# values empty and fails loudly.
+read -r SPILLED READ_ROWS <<<"$(${CLICKHOUSE_CLIENT} -q "
+    SELECT ProfileEvents['ExternalAggregationMerge'], read_rows
+    FROM system.query_log
+    WHERE event_date >= yesterday() AND current_database = currentDatabase()
+        AND query_id = '${QID}' AND type = 'QueryFinish'
+    ORDER BY event_time_microseconds DESC LIMIT 1")"
+
+if [[ "${SPILLED:-0}" -lt 1 ]]; then
     echo "spill_did_not_happen"
 else
     echo "spill_happened"
 fi
-
-SUMMARY=$(${CLICKHOUSE_CURL} -sS -i "${CLICKHOUSE_URL}" --data-binary "${QUERY}" 2>&1 | grep -i '^X-ClickHouse-Summary:' | head -1)
-READ_ROWS=$(echo "$SUMMARY" | grep -oP '"read_rows":"\K[0-9]+')
 
 if [[ "$READ_ROWS" == "100000" ]]; then
     echo "read_rows_correct"

--- a/tests/queries/0_stateless/04201_replicated_replace_partition_drop_intent.reference
+++ b/tests/queries/0_stateless/04201_replicated_replace_partition_drop_intent.reference
@@ -1,0 +1,3 @@
+mutation postponed by drop-replace intent: yes
+rows in partition 1, and how many carry src's y:
+10	10

--- a/tests/queries/0_stateless/04201_replicated_replace_partition_drop_intent.sh
+++ b/tests/queries/0_stateless/04201_replicated_replace_partition_drop_intent.sh
@@ -57,11 +57,14 @@ ${CLICKHOUSE_CLIENT} -q "SYSTEM WAIT FAILPOINT ${FAILPOINT} PAUSE"
 # The intent is installed and the REPLACE is parked, so this mutation's entry meets the guard.
 ${CLICKHOUSE_CLIENT} -q "ALTER TABLE dst UPDATE y = y + 1 WHERE p = 1"
 
+# The guard runs before any entry-type branch in shouldExecuteLogEntry, so a fetch or merge entry
+# producing a part in the replaced range writes the same reason. The claim here is about the
+# mutation, so the entry type is named.
 postponed=no
 for _ in {1..120}; do
     if ${CLICKHOUSE_CLIENT} -q "
         SELECT postpone_reason FROM system.replication_queue
-        WHERE database = currentDatabase() AND table = 'dst' FORMAT TSVRaw" 2>/dev/null \
+        WHERE database = currentDatabase() AND table = 'dst' AND type = 'MUTATE_PART' FORMAT TSVRaw" 2>/dev/null \
         | grep -qF "because there is a drop or replace intent with part name"; then
         postponed=yes
         break
@@ -76,12 +79,16 @@ wait $REPLACE_PID 2>/dev/null ||:
 cat "$REPLACE_OUT"
 rm -f "$REPLACE_OUT"
 
+# The row assertion below is satisfied by the REPLACE alone, so a mutation that never settles must
+# say so rather than fall through to it. Silent on success, so the reference is unchanged.
+settled=no
 for _ in {1..120}; do
     [ "$(${CLICKHOUSE_CLIENT} -q "
         SELECT count() FROM system.mutations
-        WHERE database = currentDatabase() AND table = 'dst' AND is_done = 0")" = "0" ] && break
+        WHERE database = currentDatabase() AND table = 'dst' AND is_done = 0")" = "0" ] && { settled=yes; break; }
     sleep 0.5
 done
+[ "$settled" = "yes" ] || echo "mutation did not settle"
 
 # Partition 1 must be exactly src's 10 rows: no dst row survives, and none is resurrected by the
 # postponed mutation.

--- a/tests/queries/0_stateless/04201_replicated_replace_partition_drop_intent.sh
+++ b/tests/queries/0_stateless/04201_replicated_replace_partition_drop_intent.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Tags: zookeeper, no-parallel, no-shared-merge-tree, no-replicated-database, no-fasttest
+# Tag no-parallel: blocks on a PAUSEABLE_ONCE failpoint that fires once globally, so a concurrent copy
+#                  can consume the pause this one waits for
+# Tag no-shared-merge-tree: the drop-replace intent lives in ReplicatedMergeTreeQueue; SharedMergeTree
+#                           uses a different queue
+# Tag no-replicated-database: uses explicit ReplicatedMergeTree ZooKeeper paths
+
+# REPLACE PARTITION installs a drop-replace intent before its DROP_RANGE entry exists, so a mutation
+# entry scheduled in that window is refused by shouldExecuteLogEntry rather than allowed to produce a
+# part inside the range being replaced. The refusal surfaces as replication_queue.postpone_reason,
+# which is where shouldExecuteLogEntry writes its out-param.
+#
+# The intent window is entered deterministically: cancelRemovedPartsCheck, called by
+# replacePartitionFrom while the intent is held, pauses on
+# rmt_cancel_removed_parts_check_pause_in_gap.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+FAILPOINT="rmt_cancel_removed_parts_check_pause_in_gap"
+
+# SYSTEM WAIT FAILPOINT blocks until the pause is released, so an early exit anywhere below would
+# otherwise leave the REPLACE parked and the table undroppable.
+function cleanup()
+{
+    ${CLICKHOUSE_CLIENT} -q "SYSTEM DISABLE FAILPOINT ${FAILPOINT}" 2>/dev/null ||:
+    ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS dst SYNC" 2>/dev/null ||:
+    ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS src SYNC" 2>/dev/null ||:
+}
+trap cleanup EXIT
+cleanup
+
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE dst (p UInt8, x UInt64, y UInt64 DEFAULT 0)
+    ENGINE = ReplicatedMergeTree('/clickhouse/test/04201_${CLICKHOUSE_DATABASE}/dst', 'r1')
+    PARTITION BY p ORDER BY x
+    SETTINGS number_of_free_entries_in_pool_to_execute_mutation = 0;
+    CREATE TABLE src (p UInt8, x UInt64, y UInt64 DEFAULT 0)
+    ENGINE = ReplicatedMergeTree('/clickhouse/test/04201_${CLICKHOUSE_DATABASE}/src', 'r1')
+    PARTITION BY p ORDER BY x;
+"
+
+# y distinguishes the two tables' rows, so the final assertion shows which table partition 1 holds.
+${CLICKHOUSE_CLIENT} -q "INSERT INTO dst SELECT 1, number, 0 FROM numbers(100) SETTINGS insert_keeper_fault_injection_probability = 0"
+${CLICKHOUSE_CLIENT} -q "INSERT INTO src SELECT 1, number, 1000 FROM numbers(10) SETTINGS insert_keeper_fault_injection_probability = 0"
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM ENABLE FAILPOINT ${FAILPOINT}"
+
+REPLACE_OUT="${CLICKHOUSE_TMP}/04201_replace_partition_drop_intent.out"
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE dst REPLACE PARTITION id '1' FROM src" >"$REPLACE_OUT" 2>&1 &
+REPLACE_PID=$!
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM WAIT FAILPOINT ${FAILPOINT} PAUSE"
+
+# The intent is installed and the REPLACE is parked, so this mutation's entry meets the guard.
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE dst UPDATE y = y + 1 WHERE p = 1"
+
+postponed=no
+for _ in {1..120}; do
+    if ${CLICKHOUSE_CLIENT} -q "
+        SELECT postpone_reason FROM system.replication_queue
+        WHERE database = currentDatabase() AND table = 'dst' FORMAT TSVRaw" 2>/dev/null \
+        | grep -qF "because there is a drop or replace intent with part name"; then
+        postponed=yes
+        break
+    fi
+    sleep 0.5
+done
+# The reason string embeds generated part names, so report the outcome rather than the raw text.
+echo "mutation postponed by drop-replace intent: $postponed"
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM NOTIFY FAILPOINT ${FAILPOINT}"
+wait $REPLACE_PID 2>/dev/null ||:
+cat "$REPLACE_OUT"
+rm -f "$REPLACE_OUT"
+
+for _ in {1..120}; do
+    [ "$(${CLICKHOUSE_CLIENT} -q "
+        SELECT count() FROM system.mutations
+        WHERE database = currentDatabase() AND table = 'dst' AND is_done = 0")" = "0" ] && break
+    sleep 0.5
+done
+
+# Partition 1 must be exactly src's 10 rows: no dst row survives, and none is resurrected by the
+# postponed mutation.
+echo "rows in partition 1, and how many carry src's y:"
+${CLICKHOUSE_CLIENT} -q "SELECT count(), countIf(y = 1000) FROM dst WHERE p = 1"

--- a/tests/queries/0_stateless/04201_replicated_replace_partition_drop_intent.sh
+++ b/tests/queries/0_stateless/04201_replicated_replace_partition_drop_intent.sh
@@ -21,8 +21,8 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 FAILPOINT="rmt_cancel_removed_parts_check_pause_in_gap"
 
-# SYSTEM WAIT FAILPOINT blocks until the pause is released, so an early exit anywhere below would
-# otherwise leave the REPLACE parked and the table undroppable.
+# A paused thread stays parked until the failpoint is notified or disabled, so an early exit below
+# would leave the REPLACE parked and the table undroppable.
 function cleanup()
 {
     ${CLICKHOUSE_CLIENT} -q "SYSTEM DISABLE FAILPOINT ${FAILPOINT}" 2>/dev/null ||:
@@ -34,11 +34,11 @@ cleanup
 
 ${CLICKHOUSE_CLIENT} -q "
     CREATE TABLE dst (p UInt8, x UInt64, y UInt64 DEFAULT 0)
-    ENGINE = ReplicatedMergeTree('/clickhouse/test/04201_${CLICKHOUSE_DATABASE}/dst', 'r1')
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/dst', 'r1')
     PARTITION BY p ORDER BY x
     SETTINGS number_of_free_entries_in_pool_to_execute_mutation = 0;
     CREATE TABLE src (p UInt8, x UInt64, y UInt64 DEFAULT 0)
-    ENGINE = ReplicatedMergeTree('/clickhouse/test/04201_${CLICKHOUSE_DATABASE}/src', 'r1')
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/src', 'r1')
     PARTITION BY p ORDER BY x;
 "
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/101781
Related: https://github.com/ClickHouse/ClickHouse/pull/103935
Related: https://github.com/ClickHouse/ClickHouse/pull/103939

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Test-only, 6 files, no `src/` changes. @ zlareb1 [asked me](https://github.com/ClickHouse/ClickHouse/pull/101781#issuecomment-5244746014) to re-file a batch of closed `clickgapai` coverage PRs; this is the MergeTree-refresh / progress / replication group. A fourth (#101284, `skip_unused_shards` through nested views) is **not** included: its mechanism is already pinned by five existing tests, and I have said so on its own thread instead of shipping a duplicate.

For each original I mutated the exact line it claims to cover, rebuilt, and required that test to fail while the others and the pre-existing tests of the same mechanism stayed green. All three oracles passed with their mechanism broken:

- **#101781's `count() = 3` passes when the refresh never runs**, because the pre-merge state is also 3 rows. An active-part count is no better: `Transaction::commit` demotes the covered parts itself, upstream of `grabOldParts`, so the active set is 1 in both arms of the mutation. The test now asserts the part **state** via `_state`: `Deleting` on master, `Outdated` under the mutation.
- **#103939's `count() <= 10` passes whenever its race is not won**, the likely outcome, and it passes under the mutation too. Replaced by a deterministic sequence: the `REPLACE PARTITION` is parked inside its own intent window on an existing `PAUSEABLE_ONCE` failpoint, and the mutation entry's `system.replication_queue.postpone_reason` is asserted. No sleeps, no race.
- **#103935 asserted `read_rows` about an unverified run**: it ran the query twice, once to prove the spill and once over HTTP for the summary. The query yields exactly `group_by_two_level_threshold` keys, so spilling is decided per run, and a non-spilling second run reports `100000` and passes with the override deleted. It now runs once under a query id and reads both facts from that `system.query_log` row, the same accounting the summary reported. Its cited line was stale too (`AggregatingTransform.cpp:143` -> `:150`).

<details>
<summary>Validation</summary>

Debug build, `clickhouse-test` with randomization on (the CI default). Each mutation changes the branch's **output** rather than deleting it, so a fall-through to an equivalent path cannot be mistaken for a vacuous test. Every arm was reverted and rebuilt before the next, with the Build ID asserted to change and to match the running server's.

| test | mutated line | result |
|---|---|---|
| `04089_merge_tree_refresh_after_merge` | `MergeTreeData.cpp:3289` `grabOldParts(true)` -> `(false)` | FAIL (`Deleting 3` -> `Outdated 3`); other 2 OK |
| `04201_read_rows_external_group_by` | `AggregatingTransform.cpp:150` `getReadProgress` override deleted | FAIL (`read_rows_wrong:200000`, exactly 2x the input); other 2 OK |
| `04201_replicated_replace_partition_drop_intent` | `ReplicatedMergeTreeQueue.cpp:284` intent match neutered | FAIL (`intent: yes` -> `no`); other 2 OK |

Each mutation also had to leave the pre-existing tests of the same mechanism green, so that "it reddens when I break the code" is not mistaken for incremental coverage: the four `refresh_parts_interval` tests, the two spill tests, and seven `REPLACE PARTITION` / part-check tests respectively. All green.

- 50 randomized plus 50 `--no-random-settings` runs of each: 0 failures, so nothing needed pinning beyond the tags the sibling tests already carry.
- The two untagged tests run concurrently with themselves: 16/16 OK, so neither takes `no-parallel`.
- `no-parallel` on the third is earned rather than assumed: concurrently with itself the untagged form gives 2 OK / 2 FAIL, and with the once-only pause released mid-window it fails outright, while the tagged form is 4/4 OK.
- The gaps were re-measured against the mechanism, not the setting name: 0 of the 4 `refresh_parts_interval` tests ever `OPTIMIZE`; none asserts `read_rows` after a spill; none contains the intent guard's message.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1210` (included in `26.8` and later)
<!-- ch-version-info:end -->