### PR TITLE
Fix inner table drop hang

### DIFF
--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -195,7 +195,9 @@ void DatabaseAtomic::dropTable(ContextPtr local_context, const String & table_na
     waitDatabaseStarted();
     auto table = tryGetTable(table_name, local_context);
     /// Remove the inner table (if any) to avoid deadlock
-    /// (due to attempt to execute DROP from the worker thread)
+    /// (due to attempt to execute DROP from the worker thread).
+    /// The inner tables are dropped without waiting for them to be finally dropped
+    /// (see the comment for `InterpreterDropQuery::executeDropQuery`).
     if (table)
         table->dropInnerTableIfAny(sync, local_context);
     else

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -1699,6 +1699,7 @@ void DatabaseReplicated::recoverLostReplica(const ZooKeeperPtr & current_zookeep
 
     size_t moved_tables = 0;
     std::vector<UUID> dropped_tables;
+    std::vector<UUID> dropped_inner_tables;
     size_t dropped_dictionaries = 0;
 
     for (const auto & table_name : tables_to_detach)
@@ -1743,6 +1744,15 @@ void DatabaseReplicated::recoverLostReplica(const ZooKeeperPtr & current_zookeep
                 /// available: the deferred drop runs without one, so the inner DROP would be re-routed into the
                 /// replicated DDL log, rejected, and retried forever, and waitTableFinallyDropped never returns.
                 /// Yep, I hate inner tables of materialized views.
+                /// `dropInnerTableIfAny` does not wait for the inner tables to be finally dropped
+                /// (see the comment for `InterpreterDropQuery::executeDropQuery`), and their UUIDs
+                /// (and `store/` directories) must be free before the tables are re-created from
+                /// the metadata in ZooKeeper - so they are waited on below like the dropped tables.
+                for (const auto & inner_table_id : table->getInnerTableIds(getContext()))
+                {
+                    if (inner_table_id.hasUUID())
+                        dropped_inner_tables.push_back(inner_table_id.uuid);
+                }
                 auto mv_drop_inner_table_context = make_query_context();
                 table->dropInnerTableIfAny(/* sync */ true, mv_drop_inner_table_context);
                 mv_drop_inner_table_context->getZooKeeperMetadataTransaction()->commit();
@@ -1811,6 +1821,8 @@ void DatabaseReplicated::recoverLostReplica(const ZooKeeperPtr & current_zookeep
     LOG_DEBUG(log, "Renames completed successfully");
 
     for (const auto & id : dropped_tables)
+        DatabaseCatalog::instance().waitTableFinallyDropped(id);
+    for (const auto & id : dropped_inner_tables)
         DatabaseCatalog::instance().waitTableFinallyDropped(id);
 
     /// Create all needed tables in a proper order
@@ -2515,7 +2527,9 @@ void DatabaseReplicated::dropTable(ContextPtr local_context, const String & tabl
     {
         /// Drop inner tables here while the metadata transaction is available, so the background
         /// dropTableFinally task does not re-route the inner DROP through the replicated DDL log.
-        /// Avoid recursive locking of metadata_mutex
+        /// Avoid recursive locking of metadata_mutex.
+        /// The inner tables are dropped without waiting for them to be finally dropped - see the
+        /// comment in `DatabaseAtomic::dropTable`.
         table->dropInnerTableIfAny(sync, local_context);
     }
 

--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -146,14 +146,17 @@ void InterpreterDropQuery::waitForTableToBeActuallyDroppedOrDetached(const ASTDr
 BlockIO InterpreterDropQuery::executeToTable(ASTDropQuery & query)
 {
     DatabasePtr database;
-    UUID table_to_wait_on = UUIDHelpers::Nil;
-    auto res = executeToTableImpl(getContext(), query, database, table_to_wait_on);
-    if (query.sync)
-        waitForTableToBeActuallyDroppedOrDetached(query, database, table_to_wait_on, getContext());
+    std::vector<UUID> tables_to_wait_on;
+    auto res = executeToTableImpl(getContext(), query, database, tables_to_wait_on);
+    if (query.sync && !skip_sync_wait)
+    {
+        for (const auto & uuid_to_wait : tables_to_wait_on)
+            waitForTableToBeActuallyDroppedOrDetached(query, database, uuid_to_wait, getContext());
+    }
     return res;
 }
 
-BlockIO InterpreterDropQuery::executeToTableImpl(const ContextPtr & context_, ASTDropQuery & query, DatabasePtr & db, UUID & uuid_to_wait)
+BlockIO InterpreterDropQuery::executeToTableImpl(const ContextPtr & context_, ASTDropQuery & query, DatabasePtr & db, std::vector<UUID> & uuids_to_wait)
 {
     if (query.kind == ASTDropQuery::Kind::Detach && query.isTemporary())
         throw Exception(ErrorCodes::SYNTAX_ERROR, "DETACH of TEMPORARY tables are not supported");
@@ -361,9 +364,23 @@ BlockIO InterpreterDropQuery::executeToTableImpl(const ContextPtr & context_, AS
             if (database->getUUID() == UUIDHelpers::Nil)
                 table_lock = table->lockExclusively(context_->getCurrentQueryId(), context_->getSettingsRef()[Setting::lock_acquire_timeout]);
 
+            /// The inner tables (if any) are dropped by `database->dropTable` without waiting for
+            /// them to be finally dropped (see the comment for `executeDropQuery`). Their ids are
+            /// remembered before the drop, and the caller waits for them after the DDL guard is
+            /// released, together with the table itself.
+            std::vector<StorageID> inner_table_ids;
+            if (query.sync)
+                inner_table_ids = table->getInnerTableIds(context_);
+
             DatabaseCatalog::instance().removeDependencies(table_id, check_ref_deps, check_loading_deps, is_drop_or_detach_database);
             NamedCollectionFactory::instance().removeDependencies(table_id);
             database->dropTable(context_, table_id.table_name, query.sync);
+
+            for (const auto & inner_table_id : inner_table_ids)
+            {
+                if (inner_table_id.hasUUID())
+                    uuids_to_wait.push_back(inner_table_id.uuid);
+            }
 
             /// We have to clear mmapio cache when dropping table from Ordinary database
             /// to avoid reading old data if new table with the same name is created
@@ -374,7 +391,7 @@ BlockIO InterpreterDropQuery::executeToTableImpl(const ContextPtr & context_, AS
         db = database;
         /// Truncate does not enqueue the table for dropping.
         if (query.kind != ASTDropQuery::Kind::Truncate)
-            uuid_to_wait = table_id.uuid;
+            uuids_to_wait.push_back(table_id.uuid);
     }
 
     return {};
@@ -670,11 +687,9 @@ BlockIO InterpreterDropQuery::executeToDatabaseImpl(const ASTDropQuery & query, 
                 query_for_table.kind = original_kind;
                 query_for_table.sync = original_sync;
                 DatabasePtr db;
-                UUID table_to_wait = UUIDHelpers::Nil;
                 /// Note: if this throws exception, the remaining tables won't be dropped and will stay in a
                 /// limbo state where flushAndPrepareForShutdown() was called but no shutdown() followed. Not ideal.
-                executeToTableImpl(table_context, query_for_table, db, table_to_wait);
-                uuids_to_wait.push_back(table_to_wait);
+                executeToTableImpl(table_context, query_for_table, db, uuids_to_wait);
             }
         }
     }
@@ -763,13 +778,13 @@ BlockIO InterpreterDropQuery::executeToDatabaseImpl(const ASTDropQuery & query, 
                 sub_query.children.push_back(make_intrusive<ASTIdentifier>(table_id.table_name));
 
                 DatabasePtr dummy_db;
-                UUID table_uuid = UUIDHelpers::Nil;
-                executeToTableImpl(table_context, sub_query, dummy_db, table_uuid);
+                std::vector<UUID> table_uuids;
+                executeToTableImpl(table_context, sub_query, dummy_db, table_uuids);
 
                 if (query.sync)
                 {
                     std::lock_guard<std::mutex> lock(mutex_for_uuids);
-                    uuids_to_wait.push_back(table_uuid);
+                    uuids_to_wait.insert(uuids_to_wait.end(), table_uuids.begin(), table_uuids.end());
                 }
             });
         }
@@ -870,7 +885,8 @@ AccessRightsElements InterpreterDropQuery::getRequiredAccessForDDLOnCluster() co
 }
 
 void InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind kind, ContextPtr global_context, ContextPtr current_context,
-                                            const StorageID & target_table_id, bool sync, bool ignore_sync_setting, bool need_ddl_guard)
+                                            const StorageID & target_table_id, bool sync, bool ignore_sync_setting, bool need_ddl_guard,
+                                            bool skip_sync_wait)
 {
     auto ddl_guard = (need_ddl_guard ? DatabaseCatalog::instance().getDDLGuard(target_table_id.database_name, target_table_id.table_name, nullptr) : nullptr);
     if (DatabaseCatalog::instance().tryGetTable(target_table_id, current_context))
@@ -910,6 +926,7 @@ void InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind kind, ContextPtr 
             drop_context->initZooKeeperMetadataTransaction(txn, true);
         }
         InterpreterDropQuery drop_interpreter(ast_drop_query, drop_context);
+        drop_interpreter.skip_sync_wait = skip_sync_wait;
         drop_interpreter.execute();
     }
 }

--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -896,6 +896,12 @@ void InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind kind, ContextPtr 
         if (ignore_sync_setting)
             drop_context->setSetting("database_atomic_wait_for_drop_and_detach_synchronously", false);
         drop_context->setDDLOrOnClusterInternal(true);
+
+        /// The copy of the global context has no process list element. Attach the calling query's
+        /// element so that the synchronous wait for the inner table to be finally dropped
+        /// (`sync == true`) can be interrupted by `KILL QUERY` of the calling query
+        /// (see `waitForTableToBeActuallyDroppedOrDetached`).
+        drop_context->setProcessListElement(current_context->getProcessListElementSafe());
         if (auto txn = current_context->getZooKeeperMetadataTransaction())
         {
             /// For Replicated database

--- a/src/Interpreters/InterpreterDropQuery.h
+++ b/src/Interpreters/InterpreterDropQuery.h
@@ -24,8 +24,15 @@ public:
     /// Drop table or database.
     BlockIO execute() override;
 
+    /// `skip_sync_wait` executes a synchronous drop (`sync == true` also makes the dropped table
+    /// eligible for the final drop immediately) without waiting for the table to be finally
+    /// dropped. It is used for dropping inner tables: the caller waits for them after the DDL
+    /// guard of the parent table is released (see `IStorage::getInnerTableIds`), because waiting
+    /// under that guard can deadlock with a query which holds references to the inner tables
+    /// and blocks on the guard.
     static void executeDropQuery(ASTDropQuery::Kind kind, ContextPtr global_context, ContextPtr current_context,
-                                 const StorageID & target_table_id, bool sync, bool ignore_sync_setting = false, bool need_ddl_guard = false);
+                                 const StorageID & target_table_id, bool sync, bool ignore_sync_setting = false, bool need_ddl_guard = false,
+                                 bool skip_sync_wait = false);
 
     bool supportsTransactions() const override;
 
@@ -36,12 +43,15 @@ private:
     ASTPtr query_ptr;
     ASTPtr current_query_ptr;
 
+    /// See the comment for `executeDropQuery`.
+    bool skip_sync_wait = false;
+
     BlockIO executeSingleDropQuery(const ASTPtr & drop_query_ptr);
     BlockIO executeToDatabase(const ASTDropQuery & query);
     BlockIO executeToDatabaseImpl(const ASTDropQuery & query, DatabasePtr & database, std::vector<UUID> & uuids_to_wait);
 
     BlockIO executeToTable(ASTDropQuery & query);
-    BlockIO executeToTableImpl(const ContextPtr& context_, ASTDropQuery & query, DatabasePtr & db, UUID & uuid_to_wait);
+    BlockIO executeToTableImpl(const ContextPtr& context_, ASTDropQuery & query, DatabasePtr & db, std::vector<UUID> & uuids_to_wait);
 
     static void waitForTableToBeActuallyDroppedOrDetached(const ASTDropQuery & query, const DatabasePtr & db, const UUID & uuid_to_wait, ContextPtr context_);
 

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -490,6 +490,9 @@ public:
 
     virtual void dropInnerTableIfAny(bool /* sync */, ContextPtr /* context */) {}
 
+    /// Returns the ids of the inner tables which `dropInnerTableIfAny` would drop.
+    virtual std::vector<StorageID> getInnerTableIds(ContextPtr /* context */) const { return {}; }
+
     /// Return true if the storage supports TRUNCATE operation.
     /// Storages without their own data (e.g. View) return false.
     virtual bool supportsTruncate() const { return true; }

--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
@@ -277,7 +277,20 @@ void StorageMaterializedPostgreSQL::dropInnerTableIfAny(bool sync, ContextPtr lo
 
     auto nested_table = tryGetNested() != nullptr;
     if (nested_table)
-        InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind::Drop, getContext(), local_context, getNestedStorageID(), sync, /* ignore_sync_setting */ true);
+        InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind::Drop, getContext(), local_context, getNestedStorageID(), sync,
+                                               /* ignore_sync_setting */ true, /* need_ddl_guard */ false, /* skip_sync_wait */ true);
+}
+
+std::vector<StorageID> StorageMaterializedPostgreSQL::getInnerTableIds(ContextPtr /* local_context */) const
+{
+    /// If it is a table with database engine MaterializedPostgreSQL, the deletion of
+    /// the internal tables is managed there.
+    if (is_materialized_postgresql_database)
+        return {};
+
+    if (auto nested_table = tryGetNested())
+        return {nested_table->getStorageID()};
+    return {};
 }
 
 

--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.h
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.h
@@ -88,6 +88,7 @@ public:
 
     /// Used only for single MaterializedPostgreSQL storage.
     void dropInnerTableIfAny(bool sync, ContextPtr local_context) override;
+    std::vector<StorageID> getInnerTableIds(ContextPtr local_context) const override;
 
     /// Forward the size guard onto the nested table that `dropInnerTableIfAny` will
     /// actually drop, so `CREATE OR REPLACE` cannot delete an over-limit nested table

--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -537,14 +537,7 @@ void StorageMaterializedView::drop()
 
 void StorageMaterializedView::dropInnerTableIfAny(bool sync, ContextPtr local_context)
 {
-    if (!has_inner_table)
-        return;
-
-    std::vector<StorageID> to_drop = {getTargetTableId()};
-    if (!fixed_uuid)
-        to_drop.push_back(StorageID(to_drop[0].getDatabaseName(), ".tmp" + to_drop[0].getTableName()));
-
-    for (const StorageID & inner_table_id : to_drop)
+    for (const StorageID & inner_table_id : getInnerTableIds(local_context))
     {
         /// We will use `sync` argument when this function is called from a DROP query
         /// and will ignore database_atomic_wait_for_drop_and_detach_synchronously when it's called from drop task.
@@ -558,11 +551,27 @@ void StorageMaterializedView::dropInnerTableIfAny(bool sync, ContextPtr local_co
         /// (I'm not the author of this code and don't know for sure, just commenting).
         /// (Why not reverse DDLGuard locking order everywhere? Because in another place we lock
         /// DDLGuard for table "<name><suffix>" while holding DDLGuard for table "<name>".)
-        auto table_exists = DatabaseCatalog::instance().tryGetTable(inner_table_id, getContext()) != nullptr;
-        if (table_exists)
-            InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind::Drop, getContext(), local_context, inner_table_id,
-                                                   sync, /* ignore_sync_setting */ true, /*need_ddl_guard*/ false);
+        InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind::Drop, getContext(), local_context, inner_table_id,
+                                               sync, /* ignore_sync_setting */ true, /*need_ddl_guard*/ false, /* skip_sync_wait */ true);
     }
+}
+
+std::vector<StorageID> StorageMaterializedView::getInnerTableIds(ContextPtr local_context) const
+{
+    if (!has_inner_table)
+        return {};
+
+    std::vector<StorageID> candidates = {getTargetTableId()};
+    if (!fixed_uuid)
+        candidates.push_back(StorageID(candidates[0].getDatabaseName(), ".tmp" + candidates[0].getTableName()));
+
+    std::vector<StorageID> inner_table_ids;
+    for (const StorageID & candidate : candidates)
+    {
+        if (auto table = DatabaseCatalog::instance().tryGetTable(candidate, local_context))
+            inner_table_ids.push_back(table->getStorageID());
+    }
+    return inner_table_ids;
 }
 
 void StorageMaterializedView::truncate(const ASTPtr &, const StorageMetadataPtr &, ContextPtr local_context, TableExclusiveLockHolder &)
@@ -578,20 +587,14 @@ void StorageMaterializedView::checkTableSizeBelowDropLimit(ContextPtr query_cont
     if (!has_inner_table)
         return;
 
-    /// Mirror `dropInnerTableIfAny`: it builds `to_drop` from `getTargetTableId()` and,
-    /// when `!fixed_uuid` (refreshable / non-append), additionally from the `.tmp` inner
-    /// table name. We must size-check every table that the implicit drop could delete,
-    /// otherwise the zeroed `max_table_size_to_drop` context would silently bypass the
-    /// guard for a non-empty `.tmp.inner...` produced by a previous refresh.
-    auto target_id = getTargetTableId();
-    std::vector<StorageID> to_check = {target_id};
-    if (!fixed_uuid)
-        to_check.push_back(StorageID(target_id.getDatabaseName(), ".tmp" + target_id.getTableName()));
-
-    for (const StorageID & inner_id : to_check)
+    /// We must size-check every table that the implicit drop could delete (see
+    /// `getInnerTableIds`: the main inner table and, for a refreshable / non-append view,
+    /// the `.tmp` inner table), otherwise the zeroed `max_table_size_to_drop` context would
+    /// silently bypass the guard for a non-empty `.tmp.inner...` produced by a previous refresh.
+    for (const StorageID & inner_id : getInnerTableIds(getContext()))
     {
-        /// On a race (e.g. `SYSTEM RESTART REPLICA` detached the inner table),
-        /// `dropInnerTableIfAny` is a no-op too, so we mirror its tolerance.
+        /// `tryGetTable` covers only the tiny window between the lookup in `getInnerTableIds`
+        /// and this one (e.g. a concurrent `SYSTEM RESTART REPLICA` detaching the inner table).
         if (auto inner = DatabaseCatalog::instance().tryGetTable(inner_id, getContext()))
             inner->checkTableSizeBelowDropLimit(query_context);
     }

--- a/src/Storages/StorageMaterializedView.h
+++ b/src/Storages/StorageMaterializedView.h
@@ -52,6 +52,7 @@ public:
 
     void drop() override;
     void dropInnerTableIfAny(bool sync, ContextPtr local_context) override;
+    std::vector<StorageID> getInnerTableIds(ContextPtr local_context) const override;
 
     /// Forward the size guard onto the inner target table that `dropInnerTableIfAny`
     /// will actually drop, so `CREATE OR REPLACE MATERIALIZED VIEW` cannot delete an

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -268,23 +268,31 @@ void StorageTimeSeries::drop()
 
 void StorageTimeSeries::dropInnerTableIfAny(bool sync, ContextPtr local_context)
 {
-    if (!hasInnerTables())
-        return;
+    for (const auto & inner_table_id : getInnerTableIds(local_context))
+    {
+        /// Best-effort to make them work: the inner table name is almost always less than the TimeSeries name (so it's safe to lock DDLGuard).
+        /// (See the comment in StorageMaterializedView::dropInnerTableIfAny.)
+        bool may_lock_ddl_guard = getStorageID().getQualifiedName() < inner_table_id.getQualifiedName();
+        InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind::Drop, getContext(), local_context, inner_table_id,
+                                               sync, /* ignore_sync_setting= */ true, may_lock_ddl_guard, /* skip_sync_wait= */ true);
+    }
+}
 
+std::vector<StorageID> StorageTimeSeries::getInnerTableIds(ContextPtr local_context) const
+{
+    if (!hasInnerTables())
+        return {};
+
+    std::vector<StorageID> inner_table_ids;
     for (auto target_kind : getTargetKinds())
     {
         if (isInnerTable(target_kind))
         {
             if (auto inner_table_id = tryGetTargetTableID(target_kind, local_context))
-            {
-                /// Best-effort to make them work: the inner table name is almost always less than the TimeSeries name (so it's safe to lock DDLGuard).
-                /// (See the comment in StorageMaterializedView::dropInnerTableIfAny.)
-                bool may_lock_ddl_guard = getStorageID().getQualifiedName() < inner_table_id.getQualifiedName();
-                InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind::Drop, getContext(), local_context, inner_table_id,
-                                                    sync, /* ignore_sync_setting= */ true, may_lock_ddl_guard);
-            }
+                inner_table_ids.push_back(inner_table_id);
         }
     }
+    return inner_table_ids;
 }
 
 void StorageTimeSeries::checkTableSizeBelowDropLimit(ContextPtr query_context) const

--- a/src/Storages/StorageTimeSeries.h
+++ b/src/Storages/StorageTimeSeries.h
@@ -84,6 +84,7 @@ public:
 
     void drop() override;
     void dropInnerTableIfAny(bool sync, ContextPtr local_context) override;
+    std::vector<StorageID> getInnerTableIds(ContextPtr local_context) const override;
 
     /// Forward the size guard onto every inner target table that `dropInnerTableIfAny`
     /// will actually drop.

--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -1804,15 +1804,37 @@ void StorageWindowView::dropInnerTableIfAny(bool sync, ContextPtr local_context)
     try
     {
         InterpreterDropQuery::executeDropQuery(
-            ASTDropQuery::Kind::Drop, getContext(), local_context, inner_table_id, sync);
+            ASTDropQuery::Kind::Drop, getContext(), local_context, inner_table_id, sync,
+            /* ignore_sync_setting */ false, /* need_ddl_guard */ false, /* skip_sync_wait */ true);
 
         if (has_inner_target_table)
-            InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind::Drop, getContext(), local_context, target_table_id, sync, /* ignore_sync_setting */ true);
+            InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind::Drop, getContext(), local_context, target_table_id, sync,
+                                                   /* ignore_sync_setting */ true, /* need_ddl_guard */ false, /* skip_sync_wait */ true);
     }
     catch (...)
     {
         tryLogCurrentException(__PRETTY_FUNCTION__);
     }
+}
+
+std::vector<StorageID> StorageWindowView::getInnerTableIds(ContextPtr local_context) const
+{
+    if (!has_inner_table)
+        return {};
+
+    /// `inner_table_id` and `target_table_id` are constructed by name and carry no UUID,
+    /// so they are resolved through the catalog here.
+    std::vector<StorageID> candidates = {inner_table_id};
+    if (has_inner_target_table)
+        candidates.push_back(target_table_id);
+
+    std::vector<StorageID> inner_table_ids;
+    for (const StorageID & candidate : candidates)
+    {
+        if (auto table = DatabaseCatalog::instance().tryGetTable(candidate, local_context))
+            inner_table_ids.push_back(table->getStorageID());
+    }
+    return inner_table_ids;
 }
 
 Block StorageWindowView::getInputHeader() const

--- a/src/Storages/WindowView/StorageWindowView.h
+++ b/src/Storages/WindowView/StorageWindowView.h
@@ -128,6 +128,7 @@ public:
     void checkTableSizeBelowDropLimit(ContextPtr query_context) const override;
 
     void dropInnerTableIfAny(bool sync, ContextPtr context) override;
+    std::vector<StorageID> getInnerTableIds(ContextPtr local_context) const override;
 
     void drop() override;
 

--- a/tests/queries/0_stateless/04838_kill_drop_of_view_with_pinned_inner_table.reference
+++ b/tests/queries/0_stateless/04838_kill_drop_of_view_with_pinned_inner_table.reference
@@ -1,0 +1,1 @@
+drop returned while holder was still running

--- a/tests/queries/0_stateless/04838_kill_drop_of_view_with_pinned_inner_table.sh
+++ b/tests/queries/0_stateless/04838_kill_drop_of_view_with_pinned_inner_table.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Tags: long
+
+# `DROP TABLE ... SYNC` of a materialized view waits for its inner table to be finally dropped.
+# While another query holds a reference to the inner table, that wait cannot finish, so it must
+# be interruptible by `KILL QUERY`. The test checks that the killed `DROP` returns while the
+# reference holder is still running.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "
+    DROP TABLE IF EXISTS mv_04838;
+    DROP TABLE IF EXISTS src_04838;
+    CREATE TABLE src_04838 (x UInt64) ENGINE = MergeTree ORDER BY x;
+    CREATE MATERIALIZED VIEW mv_04838 ENGINE = MergeTree ORDER BY x AS SELECT x FROM src_04838;
+    INSERT INTO src_04838 SELECT number FROM numbers(600);
+"
+
+inner_table=$($CLICKHOUSE_CLIENT -q "SELECT name FROM system.tables WHERE database = currentDatabase() AND name LIKE '.inner_id.%' LIMIT 1")
+
+holder_query_id="04838_holder_${CLICKHOUSE_DATABASE}"
+drop_query_id="04838_drop_${CLICKHOUSE_DATABASE}"
+
+# Holds a reference to the inner table for up to ~3 minutes (killed right after the check below).
+$CLICKHOUSE_CLIENT --query_id "$holder_query_id" -q "SELECT sum(sleepEachRow(0.3)) FROM \`$inner_table\` SETTINGS max_block_size = 1, max_threads = 1, function_sleep_max_microseconds_per_block = 300000000, enable_parallel_replicas = 0 FORMAT Null" >/dev/null 2>&1 &
+holder_pid=$!
+
+for _ in {1..300}
+do
+    started=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.processes WHERE query_id = '$holder_query_id'")
+    [[ $started == 1 ]] && break
+    sleep 0.1
+done
+
+$CLICKHOUSE_CLIENT --query_id "$drop_query_id" -q "DROP TABLE mv_04838 SYNC" >/dev/null 2>&1 &
+drop_pid=$!
+
+# Wait until the DROP marks the inner table as dropped: right after that it starts waiting
+# for the inner table to be finally dropped, which cannot happen while the holder runs.
+for _ in {1..300}
+do
+    marked=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.dropped_tables WHERE database = currentDatabase() AND table = '$inner_table'")
+    [[ $marked -ge 1 ]] && break
+    sleep 0.1
+done
+
+$CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '$drop_query_id' ASYNC FORMAT Null"
+
+wait $drop_pid
+
+holder_still_running=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.processes WHERE query_id = '$holder_query_id'")
+if [[ $holder_still_running == 1 ]]
+then
+    echo "drop returned while holder was still running"
+else
+    echo "drop returned only after holder finished"
+fi
+
+$CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '$holder_query_id' ASYNC FORMAT Null"
+wait $holder_pid
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS mv_04838 SYNC"
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS src_04838"

--- a/tests/queries/0_stateless/04839_drop_of_view_with_pinned_inner_table_does_not_hold_ddl_guard.reference
+++ b/tests/queries/0_stateless/04839_drop_of_view_with_pinned_inner_table_does_not_hold_ddl_guard.reference
@@ -1,0 +1,9 @@
+materialized view: concurrent CREATE with the same name succeeded while drop was waiting
+materialized view: drop is still waiting for the pinned inner table
+materialized view: drop finished with code 0
+time series: concurrent CREATE with the same name succeeded while drop was waiting
+time series: drop is still waiting for the pinned inner table
+time series: drop finished with code 0
+window view: concurrent CREATE with the same name succeeded while drop was waiting
+window view: drop is still waiting for the pinned inner table
+window view: drop finished with code 0

--- a/tests/queries/0_stateless/04839_drop_of_view_with_pinned_inner_table_does_not_hold_ddl_guard.sh
+++ b/tests/queries/0_stateless/04839_drop_of_view_with_pinned_inner_table_does_not_hold_ddl_guard.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Tags: long, no-replicated-database
+# Tag no-replicated-database: DDL entries of a Replicated database execute in log order, so the
+# concurrent CREATE checked by the test queues behind the waiting DROP by design.
+
+# `DROP TABLE ... SYNC` of a table with inner tables (a materialized view, a `TimeSeries` table,
+# a window view) waits for the inner tables to be finally dropped, which cannot happen while
+# another query holds a reference to them. That wait must not run under the DDL guard of the
+# table's name: a concurrent query can hold references to the inner tables and block on that
+# DDL guard, which would deadlock with the waiting `DROP`. The test checks that while the `DROP`
+# waits, DDL on the same table name still works - and that the `DROP` does wait.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+function run_scenario()
+{
+    local label=$1
+    local table_name=$2
+    local inner_pattern=$3
+
+    local inner_table
+    inner_table=$($CLICKHOUSE_CLIENT -q "SELECT name FROM system.tables WHERE database = currentDatabase() AND name LIKE '$inner_pattern' LIMIT 1")
+
+    local holder_query_id="04839_holder_${label// /_}_${CLICKHOUSE_DATABASE}"
+
+    # Holds a reference to the inner table for up to ~3 minutes (killed right after the checks
+    # below). The right side of the join is its build side, so the query runs long while holding
+    # a reference to the inner table even when the inner table is empty.
+    $CLICKHOUSE_CLIENT --query_id "$holder_query_id" -q "SELECT count() FROM \`$inner_table\` AS a, (SELECT sleepEachRow(0.3) FROM numbers(600)) AS b SETTINGS max_block_size = 1, max_threads = 1, function_sleep_max_microseconds_per_block = 300000000, enable_parallel_replicas = 0, join_algorithm = 'hash', query_plan_join_swap_table = 'false' FORMAT Null" >/dev/null 2>&1 &
+    local holder_pid=$!
+
+    for _ in {1..300}
+    do
+        local started
+        started=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.processes WHERE query_id = '$holder_query_id'")
+        [[ $started == 1 ]] && break
+        sleep 0.1
+    done
+
+    $CLICKHOUSE_CLIENT -q "DROP TABLE $table_name SYNC" &
+    local drop_pid=$!
+
+    # Wait until the DROP marks the inner tables as dropped: right after that it starts waiting
+    # for them to be finally dropped, which cannot happen while the holder runs.
+    for _ in {1..300}
+    do
+        local marked
+        marked=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.dropped_tables WHERE database = currentDatabase() AND table = '$inner_table'")
+        [[ $marked -ge 1 ]] && break
+        sleep 0.1
+    done
+
+    # The waiting DROP must not hold the DDL guard of the name, so creating a new table
+    # with the same name must succeed while the DROP is still waiting.
+    if timeout 30 $CLICKHOUSE_CLIENT -q "CREATE TABLE $table_name (x UInt64) ENGINE = MergeTree ORDER BY x" >/dev/null 2>&1
+    then
+        echo "$label: concurrent CREATE with the same name succeeded while drop was waiting"
+    else
+        echo "$label: concurrent CREATE with the same name did not finish while drop was waiting"
+    fi
+
+    # The DROP must still be waiting for the pinned inner table (the wait is moved, not lost).
+    if kill -0 $drop_pid 2>/dev/null
+    then
+        echo "$label: drop is still waiting for the pinned inner table"
+    else
+        echo "$label: drop finished without waiting for the pinned inner table"
+    fi
+
+    $CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '$holder_query_id' ASYNC FORMAT Null"
+
+    wait $drop_pid
+    echo "$label: drop finished with code $?"
+    wait $holder_pid
+
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS $table_name SYNC"
+}
+
+$CLICKHOUSE_CLIENT -q "
+    DROP TABLE IF EXISTS mv_04839;
+    DROP TABLE IF EXISTS src_04839;
+    CREATE TABLE src_04839 (x UInt64) ENGINE = MergeTree ORDER BY x;
+    CREATE MATERIALIZED VIEW mv_04839 ENGINE = MergeTree ORDER BY x AS SELECT x FROM src_04839;
+"
+run_scenario "materialized view" mv_04839 '.inner_id.%'
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS src_04839 SYNC"
+
+$CLICKHOUSE_CLIENT --allow_experimental_time_series_table=1 -q "CREATE TABLE ts_04839 ENGINE = TimeSeries"
+run_scenario "time series" ts_04839 '.inner_id.samples.%'
+
+$CLICKHOUSE_CLIENT --allow_experimental_window_view=1 --allow_experimental_analyzer=0 -q "
+    CREATE TABLE wv_src_04839 (ts DateTime) ENGINE = MergeTree ORDER BY ts;
+    CREATE WINDOW VIEW wv_04839 ENGINE = Memory WATERMARK toIntervalSecond(5) AS
+        SELECT count() AS c, tumbleStart(w_id) AS w_start FROM wv_src_04839 GROUP BY tumble(ts, toIntervalSecond(1)) AS w_id;
+"
+run_scenario "window view" wv_04839 '.inner.%'
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS wv_src_04839"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix inner table drop hang

Fixed DROP TABLE ... SYNC of a materialized view (and other tables with inner tables, like TimeSeries and window views) hanging unkillably and blocking all DDL on the same table name while another query holds a reference to an inner table: the wait for the inner tables is now interruptible by KILL QUERY and no longer holds the DDL guard.