### PR TITLE
feat(clickpipes): document ClickPipes default propagation

### DIFF
--- a/docs/integrations/clickpipes/mysql/schema-changes.mdx
+++ b/docs/integrations/clickpipes/mysql/schema-changes.mdx
@@ -16,12 +16,22 @@ ClickPipes for MySQL can detect schema changes in the source tables and, in some
 | Schema Change Type                                                                  | Behaviour                             |
 | ----------------------------------------------------------------------------------- | ------------------------------------- |
 | Adding a new column (`ALTER TABLE ADD COLUMN ...`)                                  | Propagated automatically. The new columns will be populated for all rows replicated after the schema change                                                                         |
-| Adding a new column with a default value (`ALTER TABLE ADD COLUMN ... DEFAULT ...`) | Propagated automatically. The new columns will be populated for all rows replicated after the schema change, but existing rows won't show the default value without a full table refresh |
+| Adding a new column with a default value (`ALTER TABLE ADD COLUMN ... DEFAULT ...`) | Propagated automatically. [Supported defaults](#default-values-for-added-columns) are also added to the ClickHouse column, so they apply to rows already in ClickHouse as well as rows replicated after the schema change. |
 | Dropping an existing column (`ALTER TABLE DROP COLUMN ...`)                         | Detected, but **not** propagated. The dropped columns will be populated with `NULL` for all rows replicated after the schema change                                                                |
 
 <Note>
 Column additions during snapshot are currently not supported. The suggested workaround is to perform snapshots before or after planned schema changes, or, if the ClickPipe is already failing, to manually add a column of the appropriate type to the destination table.
 </Note>
+
+## Default values for added columns {#default-values-for-added-columns}
+
+For an added column, ClickPipes propagates a default only when it can translate the value safely to ClickHouse. When a default is propagated, ClickHouse uses it when reading data parts that predate the new column. As a result, rows already present in ClickHouse receive the source default without a full table refresh.
+
+ClickPipes propagates literal integer, decimal, and floating-point values; booleans; simple string and date values; and enum or set values when the MySQL server provides full binlog row metadata. It rewrites string literals using ClickHouse-compatible quoting.
+
+ClickPipes intentionally omits defaults that are not portable literals, including `NULL`, bit literals, function calls such as `CURRENT_TIMESTAMP`, `NOW()`, or `UUID()`, and string values containing backslashes or control characters. The column is still added, but ClickHouse uses its normal type default for parts that predate the column. A full table refresh is required if those existing rows must contain the source default.
+
+ClickPipes propagates defaults only as part of `ALTER TABLE ADD COLUMN`. Later operations that change or remove a column default are not propagated to ClickHouse.
 
 ### MySQL 5.x limitations {#mysql-5-limitations}
 

--- a/docs/integrations/clickpipes/postgres/schema-changes.mdx
+++ b/docs/integrations/clickpipes/postgres/schema-changes.mdx
@@ -16,7 +16,21 @@ ClickPipes for Postgres can detect schema changes in the source tables and, in s
 | Schema Change Type                                                                  | Behaviour                             |
 | ----------------------------------------------------------------------------------- | ------------------------------------- |
 | Adding a new column (`ALTER TABLE ADD COLUMN ...`)                                  | Propagated automatically once the table gets an insert/update/delete. The new columns will be populated for all rows replicated after the schema change                                                   |
-| Adding a new column with a default value (`ALTER TABLE ADD COLUMN ... DEFAULT ...`) | Propagated automatically once the table gets an insert/update/delete. The new columns will be populated for all rows replicated after the schema change, but existing rows won't show the default value without a full table refresh |
+| Adding a new column with a default value (`ALTER TABLE ADD COLUMN ... DEFAULT ...`) | Propagated automatically once the table gets an insert/update/delete. [Supported defaults](#default-values-for-added-columns) are also added to the ClickHouse column, so they apply to rows already in ClickHouse as well as rows replicated after the schema change. |
 | Dropping an existing column (`ALTER TABLE DROP COLUMN ...`)                         | Detected, but **not** propagated. The dropped columns will be populated with `NULL` for all rows replicated after the schema change                                                                |
 
 Note that column addition will be propagated at the end of a batch's sync, which could occur after the sync interval or pull batch size is reached. More information on controlling syncs [here](/integrations/clickpipes/postgres/controlling-sync)
+
+## Default values for added columns {#default-values-for-added-columns}
+
+For an added column, ClickPipes propagates a default only when it can translate the value safely to ClickHouse. When a default is propagated, ClickHouse uses it when reading data parts that predate the new column. As a result, rows already present in ClickHouse show the same value that PostgreSQL uses for rows that predate `ADD COLUMN`; a full table refresh is not required.
+
+For PostgreSQL, ClickPipes reads the value PostgreSQL stored for pre-existing rows, rather than the column's current default expression. This matters when the default is an expression: a non-volatile expression such as `now()` is evaluated by PostgreSQL when the column is added, and ClickPipes propagates that resulting value, not the expression. Later `SET DEFAULT` or `DROP DEFAULT` operations do not change the default used for existing rows and are not propagated to ClickHouse.
+
+The following values are propagated:
+
+- Boolean and finite numeric values.
+- Text values, including `varchar`, `char`, enums, UUIDs, JSON/JSONB, `hstore`, network addresses, and dates.
+- Timestamps. Timestamps with time zones are normalized to UTC.
+
+Defaults are omitted when their representation is not safely portable to ClickHouse, including `NULL`, non-finite numeric values, `bytea`, arrays, intervals, time-of-day values, and geometric types. The column is still added, but ClickHouse uses its normal type default for parts that predate the column. A full table refresh is required if those existing rows must contain the source default.


### PR DESCRIPTION
- https://github.com/PeerDB-io/peerdb/pull/4635
- https://github.com/PeerDB-io/peerdb/pull/4632

### Changelog category
- New Feature

### Changelog entry
Document `DEFAULT ...` DDL propagation for mysql and postgres ClickPipes.
