### PR TITLE
Fix AST clones and DDL visitor

### DIFF
--- a/src/Databases/DDLRenamingVisitor.cpp
+++ b/src/Databases/DDLRenamingVisitor.cpp
@@ -129,8 +129,11 @@ namespace
         if (new_qualified_name == qualified_name)
             return;
 
-        expr.database_and_table_name = make_intrusive<ASTTableIdentifier>(new_qualified_name.database, new_qualified_name.table);
-        expr.children.push_back(expr.database_and_table_name);
+        /// `database_and_table_name` is registered as a child, so appending the renamed identifier
+        /// would leave the pre-rename one behind next to it. `replace` swaps both slots at once.
+        expr.replace(
+            expr.database_and_table_name,
+            make_intrusive<ASTTableIdentifier>(new_qualified_name.database, new_qualified_name.table));
     }
 
     /// ASTDictionary keeps a dictionary definition, for example

--- a/src/Parsers/ASTDescribeCacheQuery.cpp
+++ b/src/Parsers/ASTDescribeCacheQuery.cpp
@@ -10,6 +10,7 @@ String ASTDescribeCacheQuery::getID(char) const { return "DescribeCacheQuery"; }
 ASTPtr ASTDescribeCacheQuery::clone() const
 {
     auto res = make_intrusive<ASTDescribeCacheQuery>(*this);
+    res->children.clear();
     cloneOutputOptions(*res);
     return res;
 }

--- a/src/Parsers/ASTDropQuery.cpp
+++ b/src/Parsers/ASTDropQuery.cpp
@@ -32,8 +32,14 @@ String ASTDropQuery::getID(char delim) const
 ASTPtr ASTDropQuery::clone() const
 {
     auto res = make_intrusive<ASTDropQuery>(*this);
-    cloneOutputOptions(*res);
+    res->children.clear();
     cloneTableOptions(*res);
+    if (database_and_tables)
+    {
+        res->database_and_tables = database_and_tables->clone();
+        res->children.push_back(res->database_and_tables);
+    }
+    cloneOutputOptions(*res);
     return res;
 }
 

--- a/src/Parsers/ASTUndropQuery.cpp
+++ b/src/Parsers/ASTUndropQuery.cpp
@@ -15,8 +15,9 @@ String ASTUndropQuery::getID(char delim) const
 ASTPtr ASTUndropQuery::clone() const
 {
     auto res = make_intrusive<ASTUndropQuery>(*this);
-    cloneOutputOptions(*res);
+    res->children.clear();
     cloneTableOptions(*res);
+    cloneOutputOptions(*res);
     return res;
 }
 

--- a/src/Parsers/tests/gtest_Parser.cpp
+++ b/src/Parsers/tests/gtest_Parser.cpp
@@ -22,6 +22,7 @@
 #include <Parsers/PRQL/ParserPRQLQuery.h>
 #include <Common/re2.h>
 #include <string_view>
+#include <unordered_set>
 #include <gtest/gtest.h>
 #include <Parsers/tests/gtest_common.h>
 #include <boost/algorithm/string/replace.hpp>
@@ -142,6 +143,49 @@ TEST(ParserExecuteAsQuery, OutputOptionChildOrderIsCanonical)
         ASTPtr reparsed = parseQuery(parser, formatted, "", 0, 0, 0);
         ASSERT_NE(nullptr, reparsed) << "reparse of: " << formatted;
         EXPECT_EQ(ast->getTreeHash(false), reparsed->getTreeHash(false)) << "roundtrip of: " << query;
+    }
+}
+
+/// `IAST`'s copy constructor copies `children` as-is, so a `clone()` built on `make_intrusive<T>(*this)`
+/// has to clear them before re-adding: otherwise the clone keeps pointing at the original's nodes and
+/// mutating one is visible through the other. The AST fuzzer reports that as
+/// `IAST::clone() is broken for some AST node`. See `ASTDropQuery::clone`.
+TEST(ParserQueryWithOutput, CloneOwnsItsChildren)
+{
+    const std::vector<String> queries = {
+        "DROP TABLE db.t",
+        "DROP TABLE t1, t2, t3",
+        "DROP TABLE IF EXISTS db.t SYNC FORMAT JSONEachRow",
+        "TRUNCATE TABLE db.t",
+        "DETACH TABLE db.t PERMANENTLY",
+        "UNDROP TABLE db.t",
+        "UNDROP TABLE db.t FORMAT JSONEachRow",
+        "DESCRIBE FILESYSTEM CACHE 'cache'",
+        "DESCRIBE FILESYSTEM CACHE 'cache' FORMAT JSONEachRow",
+    };
+
+    const auto collect = [](const IAST & ast, auto & self) -> std::unordered_set<const IAST *>
+    {
+        std::unordered_set<const IAST *> nodes{&ast};
+        for (const auto & child : ast.children)
+            nodes.merge(self(*child, self));
+        return nodes;
+    };
+
+    for (const auto & query : queries)
+    {
+        ParserQuery parser(query.data() + query.size());
+        ASTPtr ast = parseQuery(parser, query, "", 0, 0, 0);
+        ASSERT_NE(nullptr, ast) << "query: " << query;
+
+        ASTPtr cloned = ast->clone();
+        const auto original_nodes = collect(*ast, collect);
+        for (const auto * node : collect(*cloned, collect))
+            EXPECT_FALSE(original_nodes.contains(node)) << "clone shares a node with the original: " << query;
+
+        /// The clone must also reproduce the child order a fresh parse produces, so that a query
+        /// and its clone hash the same.
+        EXPECT_EQ(ast->getTreeHash(false), cloned->getTreeHash(false)) << "clone of: " << query;
     }
 }
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Found while auditing the AST fuzzer


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1226` (included in `26.8` and later)
<!-- ch-version-info:end -->