### PR TITLE
Reject `arrayJoin` in an `ie_join` JOIN ON condition evaluated during the join

### DIFF
--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -221,6 +221,8 @@ key2    a2    1    1    1            0    0    \N
 key4    f    2    3    4            0    0    \N
 ```
 
+With the `ie_join` algorithm, a condition that is evaluated during the join may not contain `arrayJoin`, because such a condition must preserve the number of rows; where the expansion depends on one side only, move it into an `ARRAY JOIN` in a subquery before the join.
+
 ## NULL and NaN values in JOIN keys {#null-values-in-join-keys}
 
 `NULL` is not equal to any value, including itself. This means that if a `JOIN` key has a `NULL` value in one table, it won't match a `NULL` value in the other table.

--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -1568,7 +1568,19 @@ static QueryPlanNode buildPhysicalJoinImpl(
         /// For IEJoin the condition gates candidate pairs inside the operator; TableJoin's
         /// mixed join expression is consumed only by the hash-family algorithms.
         if (ie_join_description)
+        {
+            /// IEJoin evaluates this condition per batch of candidate pairs and indexes the result by
+            /// a pair's position in that batch, so it must preserve the number of rows.
+            if (on_clause_expression->hasArrayJoin())
+            {
+                throw Exception(
+                    ErrorCodes::INVALID_JOIN_ON_EXPRESSION,
+                    "Condition '{}' from JOIN ON section contains 'arrayJoin', which changes the number of rows. "
+                    "If the expansion depends on one side only, use ARRAY JOIN in a subquery before the JOIN",
+                    on_clause_condition.getColumnName());
+            }
             ie_join_residual_condition = std::move(on_clause_expression);
+        }
         else
             table_join->getMixedJoinExpression() = std::move(on_clause_expression);
         on_clause_condition = JoinActionRef(nullptr);

--- a/src/Processors/Transforms/IEJoinTransform.cpp
+++ b/src/Processors/Transforms/IEJoinTransform.cpp
@@ -1118,31 +1118,43 @@ void IEJoinAlgorithm::appendGathered(Chunk & chunk, size_t side, const ColumnUIn
 
 IColumn::Filter IEJoinAlgorithm::evaluateResidualMask(const ColumnUInt64 & left_rows, const ColumnUInt64 & right_rows)
 {
-    size_t num_rows = left_rows.size();
-    chassert(num_rows == right_rows.size());
-    produce_work += num_rows;
+    const size_t num_pairs = left_rows.size();
+    chassert(num_pairs == right_rows.size());
+    produce_work += num_pairs;
 
     Columns expression_columns;
     expression_columns.reserve(residual->inputs.size());
     for (const auto & source : residual->inputs)
         expression_columns.push_back(side_columns[source.side][source.position]->index(source.side == 0 ? left_rows : right_rows, 0));
 
+    /// The mask is indexed by candidate pair, so the residual must return one row per pair.
+    /// `executeOnColumns` reports the count its actions produced through the same reference, so
+    /// comparing it is a backstop against a row-count-changing action; it compares totals only.
+    size_t num_rows_after_execute = num_pairs;
     Columns results = residual->actions->executeOnColumns(
-        std::move(expression_columns), residual_input_header, residual_input_positions, num_rows);
+        std::move(expression_columns), residual_input_header, residual_input_positions, num_rows_after_execute);
+    if (num_rows_after_execute != num_pairs)
+    {
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Residual condition of IEJoin returned {} rows for {} candidate pairs",
+            num_rows_after_execute,
+            num_pairs);
+    }
     ColumnPtr result = results.at(0)->convertToFullColumnIfConst()->convertToFullColumnIfLowCardinality();
 
-    IColumn::Filter mask(num_rows);
+    IColumn::Filter mask(num_pairs);
     if (const auto * nullable = checkAndGetColumn<ColumnNullable>(result.get()))
     {
         const auto & null_map = nullable->getNullMapData();
         const auto & values = assert_cast<const ColumnUInt8 &>(nullable->getNestedColumn()).getData();
-        for (size_t row = 0; row < num_rows; ++row)
+        for (size_t row = 0; row < num_pairs; ++row)
             mask[row] = !null_map[row] && values[row];
     }
     else
     {
         const auto & values = assert_cast<const ColumnUInt8 &>(*result).getData();
-        for (size_t row = 0; row < num_rows; ++row)
+        for (size_t row = 0; row < num_pairs; ++row)
             mask[row] = values[row] ? 1 : 0;
     }
     return mask;

--- a/tests/queries/0_stateless/04854_ie_join_on_array_join_residual.reference
+++ b/tests/queries/0_stateless/04854_ie_join_on_array_join_residual.reference
@@ -1,0 +1,42 @@
+--- rejected: cross-side arrayJoin in a residual, every supported kind
+--- rejected: a large expansion read out of bounds instead of past the padding
+--- rejected: the unnest alias resolves to arrayJoin and is refused too
+--- rejected: not dependent on join_use_nulls
+--- rejected: a one-sided arrayJoin that is not split out of the ON clause
+--- kept: a one-sided arrayJoin is extracted into a filter before the join
+1
+1
+1
+2
+2
+2
+3
+3
+3
+1
+2
+3
+--- kept: ALL INNER applies the condition after the join instead of building a residual
+1
+1
+1
+2
+2
+--- kept: a residual without arrayJoin still runs
+1
+1
+2
+3
+\N
+\N
+2
+3
+--- kept: an equality key over arrayJoin is extracted before the join
+1
+3
+3
+--- kept: the supported rewrite, ARRAY JOIN in a subquery before the join
+1
+1
+2
+--- kept: without the analyzer the condition is refused during analysis

--- a/tests/queries/0_stateless/04854_ie_join_on_array_join_residual.reference
+++ b/tests/queries/0_stateless/04854_ie_join_on_array_join_residual.reference
@@ -1,9 +1,3 @@
---- rejected: cross-side arrayJoin in a residual, every supported kind
---- rejected: a large expansion read out of bounds instead of past the padding
---- rejected: the unnest alias resolves to arrayJoin and is refused too
---- rejected: not dependent on join_use_nulls
---- rejected: a one-sided arrayJoin that is not split out of the ON clause
---- kept: a one-sided arrayJoin is extracted into a filter before the join
 1
 1
 1
@@ -13,30 +7,3 @@
 3
 3
 3
-1
-2
-3
---- kept: ALL INNER applies the condition after the join instead of building a residual
-1
-1
-1
-2
-2
---- kept: a residual without arrayJoin still runs
-1
-1
-2
-3
-\N
-\N
-2
-3
---- kept: an equality key over arrayJoin is extracted before the join
-1
-3
-3
---- kept: the supported rewrite, ARRAY JOIN in a subquery before the join
-1
-1
-2
---- kept: without the analyzer the condition is refused during analysis

--- a/tests/queries/0_stateless/04854_ie_join_on_array_join_residual.sql
+++ b/tests/queries/0_stateless/04854_ie_join_on_array_join_residual.sql
@@ -1,0 +1,120 @@
+-- Tags: no-old-analyzer
+-- `ie_join` is not in the default `join_algorithm`, and no randomization list contains it,
+-- so every query below pins the algorithm itself.
+
+DROP TABLE IF EXISTS ie_l;
+DROP TABLE IF EXISTS ie_r;
+
+CREATE TABLE ie_l (id Int32, lo Int32, hi Int32, price Float64) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE ie_r (id Int32, lo Int32, hi Int32, bid Float64) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO ie_l VALUES (1, 10, 20, 150.0), (2, 20, 30, 151.0), (3, 30, 40, 380.0);
+INSERT INTO ie_r VALUES (1, 10, 30, 149.5), (2, 30, 40, 150.5), (3, 40, 50, 379.0);
+
+SELECT '--- rejected: cross-side arrayJoin in a residual, every supported kind';
+
+SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+SELECT l.id FROM ie_l AS l SEMI RIGHT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+SELECT l.id FROM ie_l AS l LEFT ANTI JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+SELECT l.id FROM ie_l AS l RIGHT ANTI JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+SELECT l.id FROM ie_l AS l ALL LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+SELECT l.id FROM ie_l AS l ALL RIGHT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+SELECT l.id FROM ie_l AS l ALL FULL JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+SELECT '--- rejected: a large expansion read out of bounds instead of past the padding';
+
+SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > minus(l.price + r.bid, arrayJoin(range(1000)))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+SELECT '--- rejected: the unnest alias resolves to arrayJoin and is refused too';
+
+SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > minus(l.price + r.bid, unnest(range(2)))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+SELECT '--- rejected: not dependent on join_use_nulls';
+
+SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+SELECT '--- rejected: a one-sided arrayJoin that is not split out of the ON clause';
+
+SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (l.price > arrayJoin(range(3))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1,
+        query_plan_split_filter = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+SELECT '--- kept: a one-sided arrayJoin is extracted into a filter before the join';
+
+SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (l.price > arrayJoin(range(3))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1,
+        query_plan_split_filter = 1;
+
+SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (r.bid > arrayJoin(range(3))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1,
+        query_plan_split_filter = 1;
+
+SELECT '--- kept: ALL INNER applies the condition after the join instead of building a residual';
+
+SELECT l.id FROM ie_l AS l ALL INNER JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > minus(l.price + r.bid, arrayJoin(range(3)))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1;
+
+SELECT '--- kept: a residual without arrayJoin still runs';
+
+SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > l.price + r.bid) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1;
+
+SELECT l.id FROM ie_l AS l ALL FULL JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > l.price + r.bid) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1;
+
+SELECT l.id FROM ie_l AS l LEFT ANTI JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > l.price + r.bid) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1;
+
+SELECT '--- kept: an equality key over arrayJoin is extracted before the join';
+
+SELECT l.id FROM ie_l AS l ALL INNER JOIN ie_r AS r ON l.lo = arrayJoin([r.lo, r.hi]) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1;
+
+SELECT '--- kept: the supported rewrite, ARRAY JOIN in a subquery before the join';
+
+SELECT l.id FROM (SELECT id, lo, hi, price, k FROM ie_l ARRAY JOIN range(2) AS k) AS l
+    SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi) AND (300 > l.price + r.bid - l.k)
+    ORDER BY ALL SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1;
+
+SELECT '--- kept: without the analyzer the condition is refused during analysis';
+
+SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
+    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
+    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1,
+        enable_analyzer = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+DROP TABLE ie_l;
+DROP TABLE ie_r;

--- a/tests/queries/0_stateless/04854_ie_join_on_array_join_residual.sql
+++ b/tests/queries/0_stateless/04854_ie_join_on_array_join_residual.sql
@@ -1,6 +1,5 @@
 -- Tags: no-old-analyzer
--- `ie_join` is not in the default `join_algorithm`, and no randomization list contains it,
--- so every query below pins the algorithm itself.
+-- `ie_join` is not in the default `join_algorithm`, so both queries pin the algorithm themselves.
 
 DROP TABLE IF EXISTS ie_l;
 DROP TABLE IF EXISTS ie_r;
@@ -11,110 +10,16 @@ CREATE TABLE ie_r (id Int32, lo Int32, hi Int32, bid Float64) ENGINE = MergeTree
 INSERT INTO ie_l VALUES (1, 10, 20, 150.0), (2, 20, 30, 151.0), (3, 30, 40, 380.0);
 INSERT INTO ie_r VALUES (1, 10, 30, 149.5), (2, 30, 40, 150.5), (3, 40, 50, 379.0);
 
-SELECT '--- rejected: cross-side arrayJoin in a residual, every supported kind';
-
+-- A cross-side `arrayJoin` lands in the condition that `ie_join` evaluates during the join.
 SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
     AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
     SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
 
-SELECT l.id FROM ie_l AS l SEMI RIGHT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
-
-SELECT l.id FROM ie_l AS l LEFT ANTI JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
-
-SELECT l.id FROM ie_l AS l RIGHT ANTI JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
-
-SELECT l.id FROM ie_l AS l ALL LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
-
-SELECT l.id FROM ie_l AS l ALL RIGHT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
-
-SELECT l.id FROM ie_l AS l ALL FULL JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
-
-SELECT '--- rejected: a large expansion read out of bounds instead of past the padding';
-
-SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (300 > minus(l.price + r.bid, arrayJoin(range(1000)))) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
-
-SELECT '--- rejected: the unnest alias resolves to arrayJoin and is refused too';
-
-SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (300 > minus(l.price + r.bid, unnest(range(2)))) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1; -- { serverError INVALID_JOIN_ON_EXPRESSION }
-
-SELECT '--- rejected: not dependent on join_use_nulls';
-
-SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }
-
-SELECT '--- rejected: a one-sided arrayJoin that is not split out of the ON clause';
-
-SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (l.price > arrayJoin(range(3))) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1,
-        query_plan_split_filter = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }
-
-SELECT '--- kept: a one-sided arrayJoin is extracted into a filter before the join';
-
+-- A one-sided `arrayJoin` is extracted into a filter before the join, so it stays accepted.
 SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
     AND (l.price > arrayJoin(range(3))) ORDER BY ALL
     SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1,
         query_plan_split_filter = 1;
-
-SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (r.bid > arrayJoin(range(3))) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1,
-        query_plan_split_filter = 1;
-
-SELECT '--- kept: ALL INNER applies the condition after the join instead of building a residual';
-
-SELECT l.id FROM ie_l AS l ALL INNER JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (300 > minus(l.price + r.bid, arrayJoin(range(3)))) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1;
-
-SELECT '--- kept: a residual without arrayJoin still runs';
-
-SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (300 > l.price + r.bid) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1;
-
-SELECT l.id FROM ie_l AS l ALL FULL JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (300 > l.price + r.bid) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1;
-
-SELECT l.id FROM ie_l AS l LEFT ANTI JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (300 > l.price + r.bid) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1;
-
-SELECT '--- kept: an equality key over arrayJoin is extracted before the join';
-
-SELECT l.id FROM ie_l AS l ALL INNER JOIN ie_r AS r ON l.lo = arrayJoin([r.lo, r.hi]) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1;
-
-SELECT '--- kept: the supported rewrite, ARRAY JOIN in a subquery before the join';
-
-SELECT l.id FROM (SELECT id, lo, hi, price, k FROM ie_l ARRAY JOIN range(2) AS k) AS l
-    SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi) AND (300 > l.price + r.bid - l.k)
-    ORDER BY ALL SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1;
-
-SELECT '--- kept: without the analyzer the condition is refused during analysis';
-
-SELECT l.id FROM ie_l AS l SEMI LEFT JOIN ie_r AS r ON (l.lo < r.hi) AND (r.lo < l.hi)
-    AND (300 > minus(l.price + r.bid, arrayJoin(range(2)))) ORDER BY ALL
-    SETTINGS join_algorithm = 'ie_join,hash', join_use_nulls = 1,
-        enable_analyzer = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }
 
 DROP TABLE ie_l;
 DROP TABLE ie_r;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112889
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed wrong results and a server abort when a `JOIN ON` condition evaluated during an `ie_join` join contains `arrayJoin`. Such a condition is now rejected with `INVALID_JOIN_ON_EXPRESSION`. Previously `SEMI`/`ANTI`/`LEFT`/`RIGHT`/`FULL` joins using the `ie_join` algorithm could return duplicated or missing rows, or abort the server.


### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/112889 (same defect in the hash-join family; that PR's guard sits in `HashJoin` and cannot reach `ie_join`).

Such a condition is evaluated *during* the join and its mask is indexed by a candidate pair's position in the batch, so it must preserve the row count.

Root cause: `ExpressionActions::executeOnColumns` takes its row count **by reference** and writes the post-execution count back, and `ARRAY_JOIN` is the one action that changes it. `IEJoinAlgorithm::evaluateResidualMask` passed its pair count in that variable and sized the mask *after* the call, so the mask was `pairs * K` long while the arrays it indexes still held `pairs` entries.

Observed on 26.8.1 with `join_algorithm = 'ie_join,hash'`: `SEMI LEFT` with `arrayJoin(range(2))` returns one left row **twice**, impossible under `SEMI` semantics; `ALL LEFT` and `ALL FULL` duplicate rows; `LEFT ANTI` fails to exclude a matched row. Larger expansions abort the server on a `PODArray` bounds assertion in two consumers. A release build has no assertion, and `flushPendingPairs` uses an out-of-bounds row id as a **write** index into `matched`.

The fix rejects the shape at plan time in `JoinStepLogical`, in the branch that builds the `ie_join` condition; the hash family is left to #112889, so the two PRs stay independent. It also separates the pair count from the by-reference out-param in `evaluateResidualMask` and raises `LOGICAL_ERROR` if they disagree, so a future row-count-changing action fails loudly instead of corrupting memory.

The rejection is scoped to the condition `ie_join` evaluates during the join: a one-sided condition the planner extracts into a pre-join filter, and an `ALL INNER` condition applied after the join, are unaffected. One that is not extracted, for example with `query_plan_split_filter = 0`, stays in the `ON` clause and is rejected too, which is correct: that shape reaches the same mask and is already wrong today. The test keeps one rejected and one accepted query.

Found by OranjeAI (@ oranjeai).

Closes https://github.com/ClickHouse/ClickHouse/issues/115235

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=114325&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114325](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114325+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1292` (included in `26.9` and later)
<!-- ch-version-info:end -->