### PR TITLE
Enable ie_join by default

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -3589,7 +3589,7 @@ See also:
 - [Join table engine](/reference/engines/table-engines/special/join)
 - [join_default_strictness](#join_default_strictness)
 )", IMPORTANT) \
-    DECLARE(JoinAlgorithm, join_algorithm, "direct,parallel_hash,hash", R"(
+    DECLARE(JoinAlgorithm, join_algorithm, "direct,parallel_hash,hash,ie_join", R"(
 Specifies which [JOIN](/reference/statements/select/join) algorithm is used.
 
 Several algorithms can be specified, and an available one would be chosen for a particular query based on kind/strictness and table engine.
@@ -3652,7 +3652,7 @@ Possible values:
 
  The sort-based [IEJoin](https://vldb.org/pvldb/vol8/p2074-khayyat.pdf) algorithm for a `JOIN` whose `ON` section has two inequality comparisons (`<`, `<=`, `>`, `>=`) between expressions of the joined tables. Supports `ALL INNER/LEFT/RIGHT/FULL JOIN` and `SEMI`/`ANTI` `LEFT/RIGHT JOIN`.
 
- The position in the list sets the priority: listed after other algorithms, IEJoin is used only when they do not apply (the `ON` section has no equality conditions); listed first, it is used whenever the `ON` section has two inequality conditions. The remaining conditions (including equalities) are applied as a filter over the join result for `ALL INNER JOIN`, and evaluated inside the operator as a residual condition affecting matching for the other kinds. Without `ie_join` in the list, an `INNER JOIN` with only inequality conditions is executed as a `CROSS JOIN` with a filter, and the other kinds are not supported.
+ The position in the list sets the priority: listed after other algorithms, as in the default value, IEJoin is used only when they do not apply (the `ON` section has no equality conditions); listed first, it is used whenever the `ON` section has two inequality conditions. The remaining conditions (including equalities) are applied as a filter over the join result for `ALL INNER JOIN`, and evaluated inside the operator as a residual condition affecting matching for the other kinds. Without `ie_join` in the list, an `INNER JOIN` with only inequality conditions is executed as a `CROSS JOIN` with a filter, and the other kinds are not supported.
 
  Both inputs are accumulated in memory before joining: [`max_rows_in_join`](/operations/settings/settings#max_rows_in_join) and [`max_bytes_in_join`](/operations/settings/settings#max_bytes_in_join) limit the accumulated input of both sides together (not just the right side), with the action on overflow set by [`join_overflow_mode`](/operations/settings/settings#join_overflow_mode); the sort indexes the operator builds on top of the accumulated input are not counted against the limit. The join operator itself runs in a single thread; only the pre-join sorts of the inputs are parallelized.
 

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -44,6 +44,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         addSettingsChanges(settings_changes_history, "26.8",
         {
             {"max_insert_threads", 1, 0, "Changed the default from 1 (no parallel execution) to auto (0), which resolves to the number of CPU cores available to the server, reduced under memory pressure via `max_insert_threads_min_free_memory_per_thread`. This parallelizes `INSERT SELECT` by default. Set to 1 to restore the previous single-threaded behavior."},
+            {"join_algorithm", "direct,parallel_hash,hash", "direct,parallel_hash,hash,ie_join", "Appended `ie_join` to the default list, so a join whose `ON` section has only inequality conditions is executed with IEJoin instead of a `CROSS JOIN` with a filter. Being last, it is used only when the other algorithms do not apply."},
             {"unique_key_probe_implementation", "auto", "auto", "New setting: selects the UNIQUE KEY probe implementation (currently only the simple baseline exists)"},
             {"s3_base", "", "", "New setting to specify the base URL for resolving relative URLs in the s3 table function and the S3 table engine."},
             {"use_query_condition_cache_for_top_k", false, false, "New setting to gate the query condition cache for `ORDER BY ... LIMIT n` (TopK) reads; disabled by default."},

--- a/tests/queries/0_stateless/02815_join_algorithm_setting.sql
+++ b/tests/queries/0_stateless/02815_join_algorithm_setting.sql
@@ -13,7 +13,7 @@ INSERT INTO rdb VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
 CREATE TABLE t2 ( `k` UInt16 ) ENGINE = TinyLog;
 INSERT INTO t2 VALUES (4), (5), (6);
 
-SELECT value == 'direct,parallel_hash,hash' FROM system.settings WHERE name = 'join_algorithm';
+SELECT value == 'direct,parallel_hash,hash,ie_join' FROM system.settings WHERE name = 'join_algorithm';
 
 SELECT countIf(explain like '%Algorithm: DirectKeyValueJoin%'), countIf(explain like '%Algorithm: HashJoin%') FROM (
     EXPLAIN PLAN actions = 1

--- a/tests/queries/0_stateless/03274_join_algorithm_default.sql
+++ b/tests/queries/0_stateless/03274_join_algorithm_default.sql
@@ -8,7 +8,7 @@ SET max_bytes_before_external_join = 0, max_bytes_ratio_before_external_join = 0
 
 -- Test that with default join_algorithm setting, we are doing a parallel hash join
 
-SELECT value == 'direct,parallel_hash,hash' FROM system.settings WHERE name = 'join_algorithm';
+SELECT value == 'direct,parallel_hash,hash,ie_join' FROM system.settings WHERE name = 'join_algorithm';
 
 EXPLAIN PIPELINE
 SELECT

--- a/tests/queries/0_stateless/03356_threshold_for_parallel_hash.sql
+++ b/tests/queries/0_stateless/03356_threshold_for_parallel_hash.sql
@@ -12,7 +12,7 @@ set enable_parallel_replicas = 0; -- join optimization (and table size estimatio
 set enable_analyzer = 1, use_query_condition_cache = 0;
 set query_plan_optimize_join_order_limit = 10; -- CI may inject 0; chooseJoinOrder skipped → join swap never happens → right table stays large → ConcurrentHashJoin chosen instead of HashJoin
 
-set join_algorithm = 'direct,parallel_hash,hash'; -- default
+set join_algorithm = 'direct,parallel_hash,hash,ie_join'; -- default
 set parallel_hash_join_threshold = 100001;
 
 -- Tables should be swapped; the new right table is below the threshold - use HashJoin
@@ -58,7 +58,7 @@ from (
 )
 where explain ilike '%Algorithm%';
 
-set join_algorithm = 'direct,parallel_hash,hash'; -- default
+set join_algorithm = 'direct,parallel_hash,hash,ie_join'; -- default
 
 -- Check estimations obtained from the cache
 

--- a/tests/queries/0_stateless/04356_threshold_for_parallel_hash_2.sql
+++ b/tests/queries/0_stateless/04356_threshold_for_parallel_hash_2.sql
@@ -16,7 +16,7 @@ SET query_plan_optimize_join_order_randomize = 0;
 
 SET use_statistics = 0; -- statistics does not override estimation from cache
 
-set join_algorithm = 'direct,parallel_hash,hash'; -- default
+set join_algorithm = 'direct,parallel_hash,hash,ie_join'; -- default
 set parallel_hash_join_threshold = 100001;
 
 -- Pretend the right table is small so the first run is planned as `HashJoin`, even though it actually has 1e6 rows.

--- a/tests/queries/0_stateless/04548_ie_join_algorithm_priority.reference
+++ b/tests/queries/0_stateless/04548_ie_join_algorithm_priority.reference
@@ -1,3 +1,5 @@
+inequalities, default list	1
+1372	17617849164127806498
 inequalities, ie_join last	1
 1372	17617849164127806498
 inequalities, ie_join first	1

--- a/tests/queries/0_stateless/04548_ie_join_algorithm_priority.sql
+++ b/tests/queries/0_stateless/04548_ie_join_algorithm_priority.sql
@@ -20,6 +20,12 @@ CREATE TABLE prio_r (k Int32, x Int32, y Int32) ENGINE = MergeTree ORDER BY k;
 INSERT INTO prio_l SELECT number % 5, number, 100 - number FROM numbers(50);
 INSERT INTO prio_r SELECT number % 5, number + 3, 90 - number FROM numbers(50);
 
+-- `ie_join` is last in the default list, so a join with only inequality conditions reaches
+-- IEJoin with no setting at all.
+SET join_algorithm = DEFAULT;
+SELECT 'inequalities, default list', count() > 0 FROM (EXPLAIN SELECT count() FROM prio_l l JOIN prio_r r ON l.x < r.x AND l.y > r.y) WHERE explain LIKE '%IEJoin%';
+SELECT count(), sum(cityHash64(l.k, l.x, l.y, r.k, r.x, r.y)) FROM prio_l l JOIN prio_r r ON l.x < r.x AND l.y > r.y;
+
 -- A join with only inequality conditions goes to IEJoin from any position in the list
 SET join_algorithm = 'hash,ie_join';
 SELECT 'inequalities, ie_join last', count() > 0 FROM (EXPLAIN SELECT count() FROM prio_l l JOIN prio_r r ON l.x < r.x AND l.y > r.y) WHERE explain LIKE '%IEJoin%';

--- a/tests/queries/0_stateless/04667_mixed_join_condition_algorithm_selection.sql
+++ b/tests/queries/0_stateless/04667_mixed_join_condition_algorithm_selection.sql
@@ -170,7 +170,7 @@ DROP TABLE IF EXISTS t3;
 CREATE TABLE t3 (key UInt64, a UInt32) ENGINE = Memory;
 INSERT INTO t3 VALUES (1, 1), (2, 2), (3, 3);
 
--- join_algorithm defaults to 'direct,parallel_hash,hash', so DirectKeyValueJoin is tried
+-- join_algorithm defaults to 'direct,parallel_hash,hash,ie_join', so DirectKeyValueJoin is tried
 -- first and used to drop the residual. No pair satisfies a * 10 < d.a here, so every left
 -- row is unmatched. A dictionary fills unmatched rows with the attribute default (0)
 -- rather than NULL, so the oracle uses 0 for them too => count 3, sum 0.


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/109920
Ref https://github.com/ClickHouse/ClickHouse/issues/113847

Append `ie_join` to the default value of `join_algorithm`, making it `direct,parallel_hash,hash,ie_join`.

`ie_join` is last in the list, so it has the lowest priority and is picked only when no other algorithm applies: a join whose `ON` section has no equality conditions but has two inequality comparisons (`<`, `<=`, `>`, `>=`) between expressions of the two sides. Such a query was previously executed as a `CROSS JOIN` with a filter, which is quadratic; with IEJoin it uses the sort-based algorithm instead. Joins that any of the other algorithms can handle are unaffected, and `LEFT`/`RIGHT`/`FULL`/`SEMI`/`ANTI` joins on two inequalities, which were not supported at all before, now work with the default setting.

The IEJoin operator itself was added in https://github.com/ClickHouse/ClickHouse/pull/109920 behind an explicit `join_algorithm = 'ie_join'`.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Enabled `ie_join` by default: the default value of `join_algorithm` is now `direct,parallel_hash,hash,ie_join`. A `JOIN` whose `ON` section has only inequality conditions (two comparisons `<`, `<=`, `>`, `>=` between expressions of the joined tables) is now executed with the sort-based IEJoin algorithm instead of a `CROSS JOIN` with a filter, and `LEFT`/`RIGHT`/`FULL`/`SEMI`/`ANTI` joins with such conditions are supported. Since `ie_join` is last in the list, it is used only when the other algorithms do not apply.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1605` (included in `26.8` and later)
<!-- ch-version-info:end -->