### PR TITLE
Fix bash completion with bash-completion 2.12+ (_comp_get_words)

### DIFF
--- a/programs/bash-completion/completions/clickhouse
+++ b/programs/bash-completion/completions/clickhouse
@@ -13,7 +13,7 @@ function _complete_for_clickhouse_entrypoint_bin()
     _clickhouse_bin_exist "$cmd" || return 0
 
     COMPREPLY=()
-    _get_comp_words_by_ref cur prev cword words
+    _clickhouse_get_comp_words_by_ref cur prev cword words
 
     local util="$cur"
     # complete utils, until it will be finished

--- a/programs/bash-completion/completions/clickhouse-bootstrap
+++ b/programs/bash-completion/completions/clickhouse-bootstrap
@@ -213,6 +213,17 @@ function _complete_for_clickhouse_generic_bin_impl()
     return 0
 }
 
+# bash-completion 2.12 renamed _get_comp_words_by_ref to _comp_get_words, and
+# newer releases do not ship the compatibility shim anymore
+function _clickhouse_get_comp_words_by_ref()
+{
+    if type _comp_get_words >& /dev/null; then
+        _comp_get_words "$@"
+    else
+        _get_comp_words_by_ref "$@"
+    fi
+}
+
 function _complete_for_clickhouse_generic_bin()
 {
     local cur prev
@@ -220,7 +231,7 @@ function _complete_for_clickhouse_generic_bin()
     _clickhouse_bin_exist "$cmd" || return 0
 
     COMPREPLY=()
-    _get_comp_words_by_ref cur prev
+    _clickhouse_get_comp_words_by_ref cur prev
 
     if _complete_for_clickhouse_generic_bin_impl "$prev"; then
         COMPREPLY=( $(compgen -W "$(_clickhouse_get_options "$cmd")" -- "$cur") )
@@ -243,6 +254,11 @@ function _complete_clickhouse_generic()
     complete "${o[@]}"
 }
 
+function _clickhouse_completion_runtime_loaded()
+{
+    type _comp_get_words >& /dev/null || type _get_comp_words_by_ref >& /dev/null
+}
+
 function _complete_clickhouse_bootstrap_main()
 {
     local runtime=/usr/share/bash-completion/bash_completion
@@ -250,9 +266,9 @@ function _complete_clickhouse_bootstrap_main()
     # it also detects a load that is still in progress (this file can be
     # sourced by the runtime itself via BASH_COMPLETION_USER_FILE, and nested
     # sourcing must be avoided)
-    if [[ ! -v BASH_COMPLETION_VERSINFO ]] && ! type _get_comp_words_by_ref >& /dev/null && [[ -f $runtime ]]; then
+    if [[ ! -v BASH_COMPLETION_VERSINFO ]] && ! _clickhouse_completion_runtime_loaded && [[ -f $runtime ]]; then
         source $runtime
     fi
-    type _get_comp_words_by_ref >& /dev/null || return 0
+    _clickhouse_completion_runtime_loaded || return 0
 }
 _complete_clickhouse_bootstrap_main "$@"


### PR DESCRIPTION
bash-completion 2.12 renamed _get_comp_words_by_ref to _comp_get_words; without the optional compat startup file the old name is undefined and completion registration bails out. Prefer _comp_get_words with a fallback to _get_comp_words_by_ref, and accept either API in the runtime load detection.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1180` (included in `26.8` and later)
<!-- ch-version-info:end -->