### PR TITLE
Chart iowait in the host usage timeline

### DIFF
--- a/ci/praktika/host_metrics.md
+++ b/ci/praktika/host_metrics.md
@@ -21,9 +21,9 @@ the window's peak instead of being averaged away.
 | `duration` | Sampled command runtime, seconds. |
 | `cpu_count` | Logical CPUs (whole-VM `cpu%` denominator). |
 | `mem_total_gb` / `disk_total_gb` | Total RAM / workspace-filesystem size. |
-| `series.cpu` / `series.mem` / `series.disk` | Timelines of `[t, avg, peak]` (percent), decimated to `HOST_METRICS_MAX_POINTS` while preserving the envelope. |
-| `averages.{cpu,mem,disk}` | Whole-run **time-weighted** average utilization %. |
-| `peaks.{cpu,mem,disk}` | Exact max utilization % over every fine sample (never decimated away); `mem_gb` / `disk_gb` are the same in absolute units. |
+| `series.cpu` / `series.iowait` / `series.mem` / `series.disk` | Timelines of `[t, avg, peak]` (percent), decimated to `HOST_METRICS_MAX_POINTS` while preserving the envelope. |
+| `averages.{cpu,iowait,mem,disk}` | Whole-run **time-weighted** average utilization %. |
+| `peaks.{cpu,iowait,mem,disk}` | Exact max utilization % over every fine sample (never decimated away); `mem_gb` / `disk_gb` are the same in absolute units. |
 | `psi.cpu_s` | Seconds at least one task stalled waiting for CPU (PSI `some`). |
 | `psi.mem_some_s` / `psi.mem_full_s` | Seconds ≥1 task / **all** tasks stalled on memory. |
 | `psi.io_some_s` / `psi.io_full_s` | Seconds ≥1 task / **all** tasks stalled on I/O. |
@@ -32,6 +32,15 @@ the window's peak instead of being averaged away.
 `disk` and `psi` are omitted when unavailable (bad `HOST_METRICS_DISK_PATH`,
 kernel without PSI). `peaks` are rate-independent; PSI totals are accumulated by
 the kernel continuously, so they capture contention even between samples.
+
+`cpu` counts `iowait` as idle (a core waiting on the disk does no work), so
+`cpu + iowait <= 100` and a job blocked on I/O is not mistaken for an idle one.
+Beware that the kernel charges `iowait` per CPU — only cores that go idle while a
+task of theirs is blocked in I/O — so a single stalled task shows up as a small
+fraction of a large host's capacity. `psi.io_*` is the fraction-of-time
+counterpart and does not dilute: a build that spends 100 s of a 950 s job
+flushing a freshly pulled docker image to a slow volume reads as ~0% `cpu`,
+single-digit `iowait` and ~100 s of `io_full_s`.
 
 ### Utilization labels
 

--- a/ci/praktika/host_metrics.py
+++ b/ci/praktika/host_metrics.py
@@ -16,8 +16,19 @@ class HostMetricsCollector:
     ``os.statvfs`` directly, so it reflects the load of the whole host (not just
     this process) regardless of whether the job itself runs inside Docker.
 
-    Three usage series are tracked (all as 0-100%): ``cpu`` (busy%), ``mem``
-    (used%) and ``disk`` (used% of the workspace filesystem).
+    Four usage series are tracked (all as 0-100%): ``cpu`` (busy%), ``iowait``
+    (share of CPU time idle with I/O outstanding), ``mem`` (used%) and ``disk``
+    (used% of the workspace filesystem).
+
+    ``cpu`` deliberately counts ``iowait`` as idle - a core waiting on the disk
+    is doing no work - so ``cpu + iowait <= 100`` and the two read as separate
+    lines. Without ``iowait`` a job blocked on I/O is indistinguishable from an
+    idle one: a build stalled for 100s flushing a freshly pulled docker image to
+    a slow EBS volume charts as a flat 0% CPU. Note that the kernel charges
+    ``iowait`` per CPU (only cores that go idle with a task of theirs blocked in
+    I/O), so a single stalled task dilutes to a fraction of a big host's
+    capacity; the ``psi`` totals below are the fraction-of-time counterpart and
+    do not dilute.
 
     Spike handling. Inputs are read at a fine cadence
     (``HOST_METRICS_FINE_INTERVAL_SEC``) but the timeline emits one aggregated
@@ -26,7 +37,8 @@ class HostMetricsCollector:
     RAM allocation shows up as the window's peak instead of being averaged away.
     Two signals are peak-exact and independent of the sampling rate:
 
-    * ``peaks`` - the maximum CPU%/RAM%/disk% seen across every fine sample.
+    * ``peaks`` - the maximum CPU%/iowait%/RAM%/disk% seen across every fine
+      sample.
     * ``psi`` - Linux Pressure Stall Information (``/proc/pressure/*``, for cpu,
       memory and io). The kernel accumulates stalled time continuously, so
       reading the totals once at start and once at stop captures all contention
@@ -85,10 +97,12 @@ class HostMetricsCollector:
         self._disk_available = False
         # Exact global peaks over every fine sample (never decimated away).
         self._cpu_peak = 0.0
+        self._iowait_peak = 0.0
         self._mem_peak = 0.0
         self._disk_peak = 0.0
         # Time-weighted running sums for whole-run averages (area = value * dt).
         self._cpu_area = 0.0
+        self._iowait_area = 0.0
         self._mem_area = 0.0
         self._disk_area = 0.0
         self._dt_total = 0.0
@@ -170,6 +184,7 @@ class HostMetricsCollector:
         # the forced tail sample after stop() may cover only a few ms and must
         # not carry the same weight as a full fine interval.
         win_cpu: List[Tuple[float, float]] = []
+        win_iowait: List[Tuple[float, float]] = []
         win_mem: List[Tuple[float, float]] = []
         win_disk: List[Tuple[float, float]] = []
 
@@ -185,8 +200,10 @@ class HostMetricsCollector:
             sample = {
                 "t": round(now - start, 1),
                 "cpu": wmean(win_cpu),
+                "iowait": wmean(win_iowait),
                 "mem": wmean(win_mem),
                 "cpu_peak": round(max(v for v, _ in win_cpu), 1),
+                "iowait_peak": round(max(v for v, _ in win_iowait), 1),
                 "mem_peak": round(max(v for v, _ in win_mem), 1),
             }
             if win_disk:
@@ -195,6 +212,7 @@ class HostMetricsCollector:
             self._samples.append(sample)
             self._append_to_fs(sample)
             win_cpu.clear()
+            win_iowait.clear()
             win_mem.clear()
             win_disk.clear()
 
@@ -209,6 +227,7 @@ class HostMetricsCollector:
             try:
                 cur_cpu = self._read_cpu_times()
                 cpu_pct = self._cpu_percent(prev_cpu, cur_cpu)
+                iowait_pct = self._iowait_percent(prev_cpu, cur_cpu)
                 prev_cpu = cur_cpu
                 mem_pct = self._mem_percent()
             except Exception as e:
@@ -222,13 +241,16 @@ class HostMetricsCollector:
             dt = now - last_time
             last_time = now
             win_cpu.append((cpu_pct, dt))
+            win_iowait.append((iowait_pct, dt))
             win_mem.append((mem_pct, dt))
             self._n_fine += 1
             # Exact global peaks, immune to windowing/decimation.
             self._cpu_peak = max(self._cpu_peak, cpu_pct)
+            self._iowait_peak = max(self._iowait_peak, iowait_pct)
             self._mem_peak = max(self._mem_peak, mem_pct)
             # Time-weighted running totals for the whole-run averages.
             self._cpu_area += cpu_pct * dt
+            self._iowait_area += iowait_pct * dt
             self._mem_area += mem_pct * dt
             self._dt_total += dt
             # Disk is sampled independently: a failure here disables only the
@@ -280,24 +302,35 @@ class HostMetricsCollector:
         except OSError:
             return 1
 
-    def _read_cpu_times(self) -> Tuple[int, int]:
-        """Return (idle_all, total) jiffies from the aggregate ``cpu`` line."""
+    def _read_cpu_times(self) -> Tuple[int, int, int]:
+        """Return (idle_all, iowait, total) jiffies from the aggregate ``cpu`` line."""
         with open(self._CPU_STAT, "r", encoding="utf8") as f:
             line = f.readline()
         # cpu  user nice system idle iowait irq softirq steal guest guest_nice
         fields = [int(x) for x in line.split()[1:]]
-        idle = fields[3] + (fields[4] if len(fields) > 4 else 0)  # idle + iowait
+        iowait = fields[4] if len(fields) > 4 else 0
+        idle = fields[3] + iowait  # iowait is idle time, reported on its own
         total = sum(fields)
-        return idle, total
+        return idle, iowait, total
 
     @staticmethod
-    def _cpu_percent(prev: Tuple[int, int], cur: Tuple[int, int]) -> float:
+    def _cpu_percent(prev: Tuple[int, int, int], cur: Tuple[int, int, int]) -> float:
+        """Busy% over the interval, with iowait counted as idle (see class doc)."""
         idle_delta = cur[0] - prev[0]
-        total_delta = cur[1] - prev[1]
+        total_delta = cur[2] - prev[2]
         if total_delta <= 0:
             return 0.0
         busy = 100.0 * (total_delta - idle_delta) / total_delta
         return round(max(0.0, min(100.0, busy)), 1)
+
+    @staticmethod
+    def _iowait_percent(prev: Tuple[int, int, int], cur: Tuple[int, int, int]) -> float:
+        """Share of CPU time over the interval spent idle with I/O outstanding."""
+        total_delta = cur[2] - prev[2]
+        if total_delta <= 0:
+            return 0.0
+        iowait = 100.0 * (cur[1] - prev[1]) / total_delta
+        return round(max(0.0, min(100.0, iowait)), 1)
 
     def _mem_percent(self) -> float:
         total_kb = 0
@@ -386,17 +419,20 @@ class HostMetricsCollector:
         mem_total_gb = round(self._mem_total_kb / 1024.0 / 1024.0, 2)
         peaks = {
             "cpu": round(self._cpu_peak, 1),
+            "iowait": round(self._iowait_peak, 1),
             "mem": round(self._mem_peak, 1),
             "mem_gb": round(mem_total_gb * self._mem_peak / 100.0, 2),
         }
         averages = {
             "cpu": round(self._cpu_area / self._dt_total, 1) if self._dt_total else 0.0,
+            "iowait": round(self._iowait_area / self._dt_total, 1) if self._dt_total else 0.0,
             "mem": round(self._mem_area / self._dt_total, 1) if self._dt_total else 0.0,
         }
         if self._disk_dt_total:
             averages["disk"] = round(self._disk_area / self._disk_dt_total, 1)
         series = {
             "cpu": self._decimate([(s["t"], s["cpu"], s["cpu_peak"]) for s in samples], self._max_points),
+            "iowait": self._decimate([(s["t"], s["iowait"], s["iowait_peak"]) for s in samples], self._max_points),
             "mem": self._decimate([(s["t"], s["mem"], s["mem_peak"]) for s in samples], self._max_points),
         }
         result = {

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1140,13 +1140,15 @@
     // Renders the whole-VM CPU/RAM timeline collected by praktika's
     // HostMetricsCollector and stored in a job Result's ext.metrics.
     // Shape: { interval, duration, mem_total_gb, n_raw, peaks: {cpu, mem, mem_gb},
-    //          psi?: {...}, series: { cpu: [[t,avg,peak],...], mem: [...] } }
+    //          psi?: {...}, series: { cpu: [[t,avg,peak],...], iowait?: [...], mem: [...] } }
     function addHostMetricsChart(metrics) {
         // Require the current schema (with exact `peaks`). Reports produced by
         // the earlier version lack it and use [t, v] points - skip rather than
         // degrade, so the chart code only ever handles one shape.
         if (!metrics || !metrics.series || !metrics.peaks) return;
         const cpu = metrics.series.cpu || [];
+        // Reports from before iowait was collected simply have no series.
+        const iowait = metrics.series.iowait || [];
         const mem = metrics.series.mem || [];
         const disk = metrics.series.disk || [];
         if (cpu.length < 2 && mem.length < 2 && disk.length < 2) return;
@@ -1157,6 +1159,7 @@
         wrapper.style.position = "relative";
 
         const CPU_COLOR = "#4e79a7";
+        const IOWAIT_COLOR = "#f28e2b";
         const MEM_COLOR = "#e15759";
         const DISK_COLOR = "#59a14f";
 
@@ -1165,12 +1168,13 @@
         const peakOf = (p) => p[2];
         // Exact global peaks (max over every fine sample, never decimated away).
         const cpuPeak = metrics.peaks.cpu;
+        const iowaitPeak = metrics.peaks.iowait;
         const memPeak = metrics.peaks.mem;
         const diskPeak = metrics.peaks.disk;
         const lastT = (s) => (s.length ? s[s.length - 1][0] : 0);
         const duration = Math.max(
             metrics.duration || 0,
-            lastT(cpu), lastT(mem), lastT(disk),
+            lastT(cpu), lastT(iowait), lastT(mem), lastT(disk),
             1
         );
 
@@ -1217,6 +1221,9 @@
         // Left column: peak legend, one metric per line.
         const legendCol = mkCol("left");
         addRow(legendCol, `<span style="color:${CPU_COLOR}">■</span> cpu ${cpuPeak.toFixed(0)}% peak`);
+        if (iowait.length && iowaitPeak != null) {
+            addRow(legendCol, `<span style="color:${IOWAIT_COLOR}">■</span> iowait ${iowaitPeak.toFixed(0)}% peak`);
+        }
         addRow(legendCol, `<span style="color:${MEM_COLOR}">■</span> ram ${memPeak.toFixed(0)}%` +
             (metrics.mem_total_gb ? ` of ${metrics.mem_total_gb}GB` : ""));
         if (disk.length) {
@@ -1309,6 +1316,8 @@
         mkPath(disk, DISK_COLOR, avgOf, "1.2", "1");
         mkPath(mem, MEM_COLOR, peakOf, "1", "0.35");
         mkPath(mem, MEM_COLOR, avgOf, "1.2", "1");
+        mkPath(iowait, IOWAIT_COLOR, peakOf, "1", "0.35");
+        mkPath(iowait, IOWAIT_COLOR, avgOf, "1.2", "1");
         mkPath(cpu, CPU_COLOR, peakOf, "1", "0.35");
         mkPath(cpu, CPU_COLOR, avgOf, "1.2", "1");
 
@@ -1346,13 +1355,14 @@
             const cx = xScale(t);
             cursor.setAttribute("x1", cx); cursor.setAttribute("x2", cx);
             cursor.setAttribute("stroke-opacity", 0.4);
-            const c = nearest(cpu, t), m = nearest(mem, t), d = nearest(disk, t);
+            const c = nearest(cpu, t), w = nearest(iowait, t), m = nearest(mem, t), d = nearest(disk, t);
             const fmtPt = (label, color, p) =>
                 `<span style="color:${color}">${label}</span> ${avgOf(p).toFixed(0)}%` +
                 ` <span style="opacity:0.7">(peak ${peakOf(p).toFixed(0)}%)</span>`;
             tip.innerHTML =
                 `${fmtT(t)}<br>` +
                 (c ? fmtPt("cpu", CPU_COLOR, c) + "<br>" : "") +
+                (w ? fmtPt("iowait", IOWAIT_COLOR, w) + "<br>" : "") +
                 (m ? fmtPt("ram", MEM_COLOR, m) + (d ? "<br>" : "") : "") +
                 (d ? fmtPt("disk", DISK_COLOR, d) : "");
             tip.style.display = "block";


### PR DESCRIPTION
The host usage chart computes CPU busy% as `1 - (idle + iowait)/total`, so a host that is fully blocked on disk draws exactly the same flat line as an idle one.

That made the first four minutes of `Build (arm_tidy)` on master unreadable: CPU sits at 0.1% from t=40s to t=175s, memory is flat and disk usage does not grow, while the runner is in fact flushing the freshly pulled `clickhouse/binary-builder` image (+16.6 GB of unpacked layers) to its root volume at ~103 MB/s. The only hint that the box was busy at all is `io stalled(all) 105.7s` in the header text.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=03ad5002ff1501ceb5d584b6d0bb028674b276e7&name_0=MasterCI&name_1=Build%20%28arm_tidy%29

Sample `iowait` from `/proc/stat` alongside the other series and draw it as its own line, so waiting on I/O is visible where it happens instead of only as a whole-run total. `cpu` keeps excluding `iowait` (a core waiting on the disk does no work), which makes `cpu + iowait <= 100` and the two lines complementary rather than overlapping.

One caveat, documented in `host_metrics.md` and in the collector: the kernel charges `iowait` per CPU — only cores that go idle while a task of theirs is blocked in I/O — so a single stalled task reads as a fraction of a large host's capacity. Measured here, one process writing 6 GB and fsyncing it holds 7–16% iowait on a 96-core box. `psi.io_*` is the fraction-of-time counterpart that does not dilute, and it is already displayed; the two together now tell the whole story.

Verified with a DOM-shim harness driving `addHostMetricsChart` over a report captured from the patched collector (a busy phase, then a write+fsync stall): the new series renders two paths under the cpu line, a legend row and a tooltip entry, `cpu + iowait <= 100` holds for every point, and a report with the `iowait` series stripped — what every existing report looks like — renders exactly as before.

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1186` (included in `26.8` and later)
<!-- ch-version-info:end -->