### PR TITLE
Push docker image layers zstd-compressed

### DIFF
--- a/ci/praktika/docker.py
+++ b/ci/praktika/docker.py
@@ -2,6 +2,7 @@ import dataclasses
 import os
 from typing import Dict, List
 
+from .settings import Settings
 from .utils import Shell, Utils
 
 
@@ -74,7 +75,24 @@ class Docker:
                 for name, value in config.build_args.items()
             )
 
-            command = f"docker buildx build {tags_substr} {from_tag}{build_args} --platform {','.join(platforms)} --provenance=mode=max --sbom=true {config.path} {'' if disable_push else ' --push'}"
+            # `--push` is shorthand for `--output type=image,push=true`; spell the
+            # exporter out so the layer compression can be set on it. Nothing is
+            # exported at all when pushing is disabled (local runs), as before.
+            if disable_push:
+                push_out = ""
+            else:
+                push_out = (
+                    " --output type=image,push=true"
+                    f",compression={Settings.DOCKER_LAYER_COMPRESSION}"
+                    f",compression-level={Settings.DOCKER_LAYER_COMPRESSION_LEVEL}"
+                    # Without this, layers inherited from the base image keep the
+                    # compression they were pushed with, so a chained image would
+                    # be a gzip/zstd mix and its biggest layers would never
+                    # convert.
+                    ",force-compression=true"
+                )
+
+            command = f"docker buildx build {tags_substr} {from_tag}{build_args} --platform {','.join(platforms)} --provenance=mode=max --sbom=true {config.path}{push_out}"
 
             return Result.from_commands_run(
                 name=name,

--- a/ci/praktika/docker.py
+++ b/ci/praktika/docker.py
@@ -75,9 +75,6 @@ class Docker:
                 for name, value in config.build_args.items()
             )
 
-            # `--push` is shorthand for `--output type=image,push=true`; spell the
-            # exporter out so the layer compression can be set on it. Nothing is
-            # exported at all when pushing is disabled (local runs), as before.
             if disable_push:
                 push_out = ""
             else:
@@ -85,10 +82,6 @@ class Docker:
                     " --output type=image,push=true"
                     f",compression={Settings.DOCKER_LAYER_COMPRESSION}"
                     f",compression-level={Settings.DOCKER_LAYER_COMPRESSION_LEVEL}"
-                    # Without this, layers inherited from the base image keep the
-                    # compression they were pushed with, so a chained image would
-                    # be a gzip/zstd mix and its biggest layers would never
-                    # convert.
                     ",force-compression=true"
                 )
 

--- a/ci/praktika/native_jobs.md
+++ b/ci/praktika/native_jobs.md
@@ -21,6 +21,13 @@ The file defines several job configurations:
 - `_docker_build_arm_linux_job` - Builds ARM64 Docker images
 - `_final_job` - Finalization job that runs even if workflow is cancelled
 
+An image is tagged with the digest of its build context, so it is built and
+pushed once and then pulled cold by every job that uses it. Its layers are
+therefore compressed for the pull side, with `DOCKER_LAYER_COMPRESSION` /
+`DOCKER_LAYER_COMPRESSION_LEVEL` (`zstd`, level 3 by default - smaller than gzip
+and several times faster to unpack). The compression is not part of the digest,
+so an image switches over the next time its build context changes.
+
 ## Config Workflow (`_config_workflow`)
 
 The configuration job performs critical setup at the start of each workflow run:

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -128,12 +128,6 @@ class _Settings:
 
     DOCKERHUB_USERNAME: str = ""
     DOCKERHUB_SECRET: str = ""
-    # Layer compression for images pushed by `Docker.build`. A CI image is built
-    # once and pulled cold by every job that uses it, so the pull side is what
-    # matters: zstd is both smaller and much faster to unpack than gzip. Set to
-    # "gzip" for maximum compatibility with old docker daemons (zstd layers need
-    # docker >= 23.0). Takes effect per image the next time it is built - the
-    # image tag is a digest of its build context, not of these settings.
     DOCKER_LAYER_COMPRESSION: str = "zstd"
     DOCKER_LAYER_COMPRESSION_LEVEL: int = 3
 

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -128,6 +128,14 @@ class _Settings:
 
     DOCKERHUB_USERNAME: str = ""
     DOCKERHUB_SECRET: str = ""
+    # Layer compression for images pushed by `Docker.build`. A CI image is built
+    # once and pulled cold by every job that uses it, so the pull side is what
+    # matters: zstd is both smaller and much faster to unpack than gzip. Set to
+    # "gzip" for maximum compatibility with old docker daemons (zstd layers need
+    # docker >= 23.0). Takes effect per image the next time it is built - the
+    # image tag is a digest of its build context, not of these settings.
+    DOCKER_LAYER_COMPRESSION: str = "zstd"
+    DOCKER_LAYER_COMPRESSION_LEVEL: int = 3
 
     ######################################
     #        CI DB Settings              #
@@ -191,6 +199,8 @@ _USER_DEFINED_SETTINGS = [
     "VALIDATE_FILE_PATHS",
     "DOCKERHUB_USERNAME",
     "DOCKERHUB_SECRET",
+    "DOCKER_LAYER_COMPRESSION",
+    "DOCKER_LAYER_COMPRESSION_LEVEL",
     "READY_FOR_MERGE_CUSTOM_STATUS_NAME",
     "SECRET_CI_DB_URL",
     "SECRET_CI_DB_USER",


### PR DESCRIPTION
A praktika docker image is built and pushed once, then pulled cold by every job that uses it — CI runners come up with an empty image store (`docker system df` reports one 356 MB image at job start), so each build job re-downloads and unpacks the whole builder image before it can do anything.

In `Build (arm_tidy)` on master that is 75 s of the job: 4.19 GB over 32 layers, unpacking to +16.6 GB, at 3–8% CPU of a 32-core host because gzip inflate is the bottleneck. Together with the writeback that follows it, docker image acquisition is 176 s of the 253 s that pass before `ninja` starts.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=03ad5002ff1501ceb5d584b6d0bb028674b276e7&name_0=MasterCI&name_1=Build%20%28arm_tidy%29

Compress the pushed layers with zstd instead. `--push` is shorthand for `--output type=image,push=true`, so the exporter is now spelled out to carry the compression attributes. `force-compression=true` is required: without it, layers inherited from a base image keep the compression they were pushed with, and the largest layers of a chained image (`fasttest` → `binary-builder`) would never convert.

Measured on the real `ubuntu:24.04` arm64 base layer (103.2 MB uncompressed), gzip as served by Docker Hub vs zstd level 3 as produced by buildkit:

| | gzip | zstd-3 | |
|---|---|---|---|
| size | 28.89 MB | 25.89 MB | 10.4% less to download |
| decompression | 372 ms (277 MB/s) | 81 ms (1280 MB/s) | 4.6x faster |

Scope, stated plainly: this shortens the download-and-unpack phase only. It does not touch the ~101 s the same job then spends stalled (PSI `io_full` 105.7 s) flushing those unpacked bytes to the runner's root volume, because the unpacked size is unchanged. That one needs faster runner storage (higher gp3 throughput or instance-store NVMe), which is a provisioning change, not a repo change.

Verification, end to end with the exact command praktika now generates (buildx `docker-container` driver, same as CI, including `--provenance=mode=max --sbom=true`):

- every layer is exported as `application/vnd.oci.image.layer.v1.tar+zstd`, alongside the attestation manifest;
- docker 29.1.3 loads and runs the resulting image;
- a unit-level check of the generated command covers both the push path and the local `disable_push` path (which still exports nothing, as before);
- `python -m ci.praktika yaml` regenerates every workflow unchanged.

Two things a reviewer should weigh:

1. **Daemon requirement.** zstd layer media types need docker >= 23.0 on the pulling host. Runners are far newer than that, and `DOCKER_LAYER_COMPRESSION` can be set back to `"gzip"` if an older daemon ever has to pull these images.
2. **Rollout.** The image tag is a digest of the build context, not of these settings, so existing images keep their gzip layers and each one converts the next time its build context changes. No mass rebuild is forced here, which also means this PR's own CI will not exercise a zstd pull unless it happens to rebuild an image. Say the word if you would rather force the conversion now — touching `ci/docker/binary-builder/Dockerfile` converts the image that dominates build-job pull time, and adding the compression settings to the docker digest would convert all 37 at the cost of one full rebuild on the 2-vCPU docker builders.

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1182` (included in `26.8` and later)
<!-- ch-version-info:end -->