### PR TITLE
Make lost folders during Ordinary => Atomic just empty

### DIFF
--- a/src/Interpreters/loadMetadata.cpp
+++ b/src/Interpreters/loadMetadata.cpp
@@ -423,7 +423,22 @@ static void convertOrdinaryDatabaseToAtomic(LoggerPtr log, ContextMutablePtr con
 
     for (auto iterator = database->getTablesIterator(context); iterator->isValid(); iterator->next())
     {
-        auto id = iterator->table()->getStorageID();
+        auto table = iterator->table();
+        auto id = table->getStorageID();
+        if (table->storesDataOnDisk())
+        {
+            auto table_data_path = fs::path(context->getPath()) / database->getTableDataPath(id.table_name);
+            if (!fs::exists(table_data_path))
+            {
+                LOG_INFO(
+                    log,
+                    "Creating missing data directory {} for table {} before converting database to Atomic",
+                    table_data_path,
+                    id.getNameForLogs());
+                fs::create_directories(table_data_path);
+            }
+        }
+
         if (inner_mv_tables.contains(id.table_name))
         {
             LOG_DEBUG(log, "Do not rename {}, because it will be renamed together with MV", id.getNameForLogs());

--- a/tests/integration/test_convert_ordinary_missing_data_directory/test.py
+++ b/tests/integration/test_convert_ordinary_missing_data_directory/test.py
@@ -1,0 +1,45 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", stay_alive=True)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_convert_ordinary_with_missing_data_directory(started_cluster):
+    database = "ordinary_missing_data_directory"
+    table = "table"
+
+    node.query(
+        f"CREATE DATABASE {database} ENGINE=Ordinary",
+        settings={"allow_deprecated_database_ordinary": 1},
+    )
+    node.query(f"CREATE TABLE {database}.{table} (n UInt64) ENGINE=MergeTree ORDER BY n")
+
+    node.stop_clickhouse()
+    node.exec_in_container(
+        ["bash", "-c", f"rm -rf /var/lib/clickhouse/data/{database}/{table}"],
+    )
+    node.exec_in_container(
+        ["bash", "-c", "touch /var/lib/clickhouse/flags/convert_ordinary_to_atomic"],
+    )
+    node.start_clickhouse()
+
+    assert "Atomic\n" == node.query(
+        f"SELECT engine FROM system.databases WHERE name = '{database}'"
+    )
+    assert node.contains_in_log(
+        f"Creating missing data directory .*{database}/{table}.* before converting database to Atomic"
+    )
+
+    node.query(f"DROP DATABASE {database} SYNC")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make empty folders for tables that had lost their data, during Ordinary to Atomic transformation
