### PR TITLE
Do not re-push an unchanged `silk` bump

### DIFF
--- a/ci/jobs/update_silk_submodule.py
+++ b/ci/jobs/update_silk_submodule.py
@@ -92,6 +92,23 @@ def has_changes():
     return bool(Shell.get_output(f"git status --porcelain -- {SILK_PATH}").strip())
 
 
+def is_published():
+    """True when the bot branch already pins the commit this run checked out.
+
+    Publishing force-pushes a freshly created commit, so re-publishing an unchanged
+    bump still rewrites the head: it re-parents onto a newer `master` and restamps the
+    commit date. A new head restarts every check, and a full CI run takes longer than
+    the six-hour period of this workflow, so the pull request would never hold a
+    complete run to merge on."""
+    return_code, published, _ = Shell.get_res_stdout_stderr(
+        f"gh api 'repos/{REPOSITORY}/contents/{SILK_PATH}?ref={BOT_BRANCH}' --jq '.sha'"
+    )
+    if return_code != 0:
+        return False
+
+    return published == Shell.get_output(f"git -C {SILK_PATH} rev-parse HEAD").strip()
+
+
 def pr_body():
     old = pinned_commit()
     new = Shell.get_output(f"git -C {SILK_PATH} rev-parse HEAD").strip()
@@ -187,7 +204,7 @@ if __name__ == "__main__":
         results.append(Result.from_commands_run(name="Bump submodule", command=bump))
 
     if results[-1].is_ok():
-        if has_changes():
+        if has_changes() and not is_published():
             results.append(
                 Result.from_commands_run(
                     name="Master is still current", command=on_current_base_branch
@@ -208,7 +225,7 @@ if __name__ == "__main__":
                 )
             )
             results[-1].set_info(
-                f"No changes; {SILK_PATH} already at the {SILK_BRANCH} tip"
+                f"Nothing new to publish; the {SILK_BRANCH} tip is already pinned"
             )
 
     Result.create_from(results=results).complete_job()


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/113796

The `SyncSilk` job (`ci/jobs/update_silk_submodule.py`, cron `17 */6 * * *`) rebuilds `robot/bump-silk` from the current `master` tip and force-pushes it. Whether it publishes at all is decided by `has_changes`, which compares the fetched `clickhouse-public` tip against the commit `master` pins — and `master` keeps the old pin until the bump merges. So the gate is true on every run, and each run republishes the same bump under a new commit: a new parent (`master` moved) and a new commit date.

The result on #113796: 15 force-pushes between 2026-08-07 and 2026-08-11, all carrying the identical payload (`contrib/silk` → `78aab9d603d`), each one restarting every check. A full CI run takes around five hours against a six-hour period, so the pull request is only mergeable for a short window before its checks are discarded again — and review threads pile up because the review job re-runs on each new head as well.

Compare against the commit the bot branch already pins instead. When it matches, the job reports that there is nothing new to publish and leaves the branch alone, so the head commit and its CI results survive until `silk` actually moves. A real advance of `clickhouse-public` still publishes, and a missing bot branch or an unreadable one still publishes, which is what the first run needs.

The branch is no longer re-parented onto a fresh `master` on every run, so the bump is tested against the `master` it was last published on. That is deliberate: it is the same trade-off any long-lived pull request makes, and it is what allows the checks to finish.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
