### PR TITLE
Retry `apk add` in the Alpine server and Keeper image builds

### DIFF
--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -59,6 +59,12 @@ RUN addgroup -S -g "${DEFAULT_GID}" clickhouse && \
 ARG WGET_RETRIES=5
 ARG WGET_RETRY_DELAY=1
 
+# `apk` has no retry option, and it does not treat a failed repository index fetch
+# as fatal: it proceeds with an empty index, so every requested package is then
+# reported as `no such package`.
+ARG APK_RETRIES=5
+ARG APK_RETRY_DELAY=2
+
 ARG TARGETARCH
 RUN arch=${TARGETARCH:-amd64} \
     && cd /tmp && rm -f /tmp/*tgz && rm -f /tmp/*tgz.sha512 |: \
@@ -71,6 +77,16 @@ RUN arch=${TARGETARCH:-amd64} \
             attempt=$((attempt + 1)); \
         done; \
         echo "ERROR: Failed to download $url after ${WGET_RETRIES} attempts"; return 1; \
+    } \
+    && apk_add_with_retry() { \
+        local attempt=1; \
+        while [ "$attempt" -le "${APK_RETRIES}" ]; do \
+            if apk add --no-cache "$@"; then return 0; fi; \
+            echo "Attempt $attempt/${APK_RETRIES} failed for apk add $*, retrying in ${APK_RETRY_DELAY}s..."; \
+            sleep "${APK_RETRY_DELAY}"; \
+            attempt=$((attempt + 1)); \
+        done; \
+        echo "ERROR: Failed to apk add $* after ${APK_RETRIES} attempts"; return 1; \
     } \
     && if [ -n "${DIRECT_DOWNLOAD_URLS}" ]; then \
         echo "installing from provided urls with tgz packages: ${DIRECT_DOWNLOAD_URLS}" \
@@ -95,7 +111,7 @@ RUN arch=${TARGETARCH:-amd64} \
     ; done \
     && rm /tmp/*.tgz /install -r \
     && chmod +x /entrypoint.sh \
-    && apk add --no-cache su-exec bash tzdata \
+    && apk_add_with_retry su-exec bash tzdata \
     && cp /usr/share/zoneinfo/UTC /etc/localtime \
     && echo "UTC" > /etc/timezone
 

--- a/docker/server/Dockerfile.alpine
+++ b/docker/server/Dockerfile.alpine
@@ -53,6 +53,12 @@ RUN addgroup -S -g "${DEFAULT_GID}" clickhouse && \
 ARG WGET_RETRIES=5
 ARG WGET_RETRY_DELAY=1
 
+# `apk` has no retry option, and it does not treat a failed repository index fetch
+# as fatal: it proceeds with an empty index, so every requested package is then
+# reported as `no such package`.
+ARG APK_RETRIES=5
+ARG APK_RETRY_DELAY=2
+
 RUN arch=${TARGETARCH:-amd64} \
     && cd /tmp \
     && wget_with_retry() { \
@@ -64,6 +70,16 @@ RUN arch=${TARGETARCH:-amd64} \
             attempt=$((attempt + 1)); \
         done; \
         echo "ERROR: Failed to download $url after ${WGET_RETRIES} attempts"; return 1; \
+    } \
+    && apk_add_with_retry() { \
+        local attempt=1; \
+        while [ "$attempt" -le "${APK_RETRIES}" ]; do \
+            if apk add --no-cache "$@"; then return 0; fi; \
+            echo "Attempt $attempt/${APK_RETRIES} failed for apk add $*, retrying in ${APK_RETRY_DELAY}s..."; \
+            sleep "${APK_RETRY_DELAY}"; \
+            attempt=$((attempt + 1)); \
+        done; \
+        echo "ERROR: Failed to apk add $* after ${APK_RETRIES} attempts"; return 1; \
     } \
     && if [ -n "${DIRECT_DOWNLOAD_URLS}" ]; then \
         echo "installing from provided urls with tgz packages: ${DIRECT_DOWNLOAD_URLS}" \
@@ -87,7 +103,7 @@ RUN arch=${TARGETARCH:-amd64} \
     ; done \
     && rm /tmp/*.tgz /install -r \
     && chmod +x /entrypoint.sh \
-    && apk add --no-cache bash tzdata \
+    && apk_add_with_retry bash tzdata \
     && cp /usr/share/zoneinfo/UTC /etc/localtime \
     && echo "UTC" > /etc/timezone
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/114326
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`Docker server image` fails on its alpine leg with

```
WARNING: fetching https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/APKINDEX.tar.gz: TLS: unspecified error
ERROR: unable to select packages:
  bash (no such package): required by: world[bash]
```

`apk` fetches its repository index at run time and does not treat a failed index fetch as
fatal: it warns, proceeds with an empty index, and then reports packages that certainly exist
as `no such package`. In `docker/server/Dockerfile.alpine` and `docker/keeper/Dockerfile` that
command sits at the end of a `RUN` that has already downloaded ~1 GB of packages, verified
their checksums and unpacked them, so one transient CDN error throws the whole layer away.

That layer already retries its other network operation, via the `wget_with_retry` helper added
in f941493b858cc05. `apk` has no retry option of its own, so this adds the same shape:
`apk_add_with_retry`, 5 attempts, 2 s apart, `APK_RETRIES` / `APK_RETRY_DELAY` as build args.
One edit covers all three Keeper flavours, since `docker/keeper/Dockerfile.{alpine,ubuntu}` are
symlinks to `docker/keeper/Dockerfile`.

7cb40723f9ef6 dropped build-time `apt` retries from the published images because the in-region
mirror override made them unnecessary there. Alpine publishes no such mirror, so that
alternative is not available here: `us-east-1.ec2.alpinelinux.org` and
`mirror.us-east-1.amazonaws.com/alpine` both time out while `dl-cdn` returns 200. Retrying
`apk update` instead would be worse, since it returns 1 on a partial index failure where the
following `apk add` returns 0.

I did not widen `BUILDX_RETRY_ERRORS`: #108969 narrowed it deliberately, `no such package` also
describes a genuine typo, and retrying there re-runs the whole layer. A sustained outage still
fails, with an explicit message once the attempts are exhausted.

Measured over 180 days: 6 occurrences, 6 unrelated PRs, both arches, 0 on master. Latest:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114326&sha=fa316902aded2c52a48a255d70a3c2b88e1f767c&name_0=PR&name_1=Docker%20server%20image

Validated by blackholing `dl-cdn.alpinelinux.org` and building both images: without the change
the build dies on the first attempt, with it it recovers once the outage lifts and still fails
when it does not. On a healthy network both build with no retries emitted.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1270` (included in `26.8` and later)
<!-- ch-version-info:end -->