### PR TITLE
Enable async inserts while sending data to ci-logs to reduce amount of parts

### DIFF
--- a/tests/config/users.d/ci_logs_sender.yaml
+++ b/tests/config/users.d/ci_logs_sender.yaml
@@ -5,8 +5,11 @@ profiles:
         # the INSERTs will be retried anyway
         send_timeout: 15
         receive_timeout: 15
-        # Disable async INSERT, since the batches should be big enough
-        async_insert: 0
+        # Enable async INSERT, to reduce amount of parts
+        async_insert: 1
+        wait_for_async_insert: 0
+        async_insert_busy_timeout_min_ms: 1000
+        async_insert_busy_timeout_max_ms: 5000
         # Avoid polluting caches
         enable_filesystem_cache_on_write_operations: 0
         write_through_distributed_cache: 0
@@ -24,6 +27,12 @@ profiles:
             receive_timeout:
                 readonly: true
             async_insert:
+                readonly: true
+            wait_for_async_insert:
+                readonly: true
+            async_insert_busy_timeout_min_ms:
+                readonly: true
+            async_insert_busy_timeout_max_ms:
                 readonly: true
             enable_filesystem_cache_on_write_operations:
                 readonly: true


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

I remember I disabled it due to some bug, but AFAIR it has been resolved


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1255` (included in `26.8` and later)
<!-- ch-version-info:end -->