### PR TITLE
Reject literal LF in ordinary quoted PromQL strings

### DIFF
--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
@@ -130,17 +130,54 @@ namespace
     /// byte. Only the first error is ever reported and a parse with a recorded error always fails,
     /// so lexing the remainder is wasted work - a megabyte of NUL bytes used to keep a thread busy
     /// for minutes, uncancellable because parsing happens during query analysis.
+    /// It also validates multiline STRING tokens as they are emitted, before a later lexer or parser
+    /// error can hide an earlier invalid quoted string.
     class PromQLLexerBailingOutOnError : public antlr4_grammars::PromQLLexer
     {
     public:
-        using antlr4_grammars::PromQLLexer::PromQLLexer;
+        explicit PromQLLexerBailingOutOnError(
+            antlr4::CharStream * input_, std::string_view promql_query_, ErrorListener & error_listener_)
+            : PromQLLexer(input_), promql_query(promql_query_), error_listener(error_listener_) {}
+
+        std::unique_ptr<antlr4::Token> nextToken() override
+        {
+            auto next_token = PromQLLexer::nextToken();
+            if (!error_listener.hasError() && next_token->getType() == STRING && next_token->getLine() != getLine())
+            {
+                const String token_text = next_token->getText();
+                if (!token_text.starts_with('`'))
+                {
+                    String parsed_string;
+                    String error_message;
+                    size_t error_pos = 0;
+                    if (!PrometheusQueryParsingUtil::tryParseStringLiteral(
+                            token_text, parsed_string, &error_message, &error_pos))
+                    {
+                        const size_t token_pos = convertCodePointPositionToByteOffset(promql_query, next_token->getStartIndex());
+                        error_listener.setError(error_message, token_pos + error_pos);
+                        stopLexing();
+                    }
+                }
+            }
+            return next_token;
+        }
 
         void recover(const antlr4::LexerNoViableAltException &) override
         {
             /// Pretend the input ended here, so that the lexer emits EOF and stops.
+            stopLexing();
+        }
+
+    private:
+        void stopLexing()
+        {
             antlr4::CharStream * stream = getInputStream();
             stream->seek(stream->size());
+            hitEOF = true;
         }
+
+        std::string_view promql_query;
+        ErrorListener & error_listener;
     };
 
     [[noreturn]] void throwInconsistentSchema(std::string_view context_name, std::string_view token)
@@ -919,7 +956,7 @@ bool PrometheusQueryParsingUtil::tryParseQuery([[maybe_unused]] std::string_view
     ErrorListener error_listener{input};
     antlr4::ANTLRInputStream input_stream{input};
 
-    PromQLLexerBailingOutOnError promql_lexer{&input_stream};
+    PromQLLexerBailingOutOnError promql_lexer{&input_stream, input, error_listener};
     promql_lexer.removeErrorListeners();
     promql_lexer.addErrorListener(&error_listener);
 

--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil.cpp
@@ -271,10 +271,20 @@ bool PrometheusQueryParsingUtil::tryParseStringLiteral(
 
     /// A string literal enclosed in quotes or double quotes: escape sequences need to be parsed.
     std::string_view unquoted = input.substr(1, input.length() - 2);
-    if (!tryUnescapeStringLiteral(unquoted, quote_char, res_string, error_message, error_pos))
+    const size_t newline_pos = unquoted.find('\n');
+    size_t unescape_error_pos = 0;
+    const bool unescape_succeeded = tryUnescapeStringLiteral(unquoted, quote_char, res_string, error_message, &unescape_error_pos);
+
+    if (newline_pos != String::npos && (unescape_succeeded || newline_pos < unescape_error_pos))
     {
-        if (error_pos)
-            ++*error_pos;
+        setErrorMessage(error_message, "unterminated quoted string");
+        setErrorPos(error_pos, 0);
+        return false;
+    }
+
+    if (!unescape_succeeded)
+    {
+        setErrorPos(error_pos, unescape_error_pos + 1);
         return false;
     }
 

--- a/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
+++ b/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
@@ -1233,6 +1233,10 @@ TEST(PromQLParser, InvalidStringQuoteEscapes)
     for (const auto & [query, expected_error_pos] : std::initializer_list<std::pair<std::string_view, size_t>>{
              {R"(up{label="a\'b"})", 11},
              {R"(up{label='a\"b'})", 11},
+             {R"("hello\
+world")", 6},
+             {R"("hello\x
+world")", 6},
          })
     {
         PrometheusQueryTree query_tree;
@@ -1243,6 +1247,43 @@ TEST(PromQLParser, InvalidStringQuoteEscapes)
         EXPECT_EQ(error_pos, expected_error_pos) << query;
         EXPECT_NE(error_message.find("Invalid escape sequence"), String::npos) << query;
     }
+}
+
+
+TEST(PromQLParser, RejectLiteralLFInQuotedStrings)
+{
+    for (const auto & [query, expected_error_pos] : std::initializer_list<std::pair<std::string_view, size_t>>{
+             {R"("hello
+world")", 0},
+             {R"('hello
+world')", 0},
+             {R"("hello\\
+world")", 0},
+             {"\"hello\r\nworld\"", 0},
+             {R"("hello
+world\q")", 0},
+             {R"(up{job="hello
+world"})", 7},
+             {R"("hello
+world" "x")", 0},
+             {R"("hello
+world" $)", 0},
+         })
+    {
+        PrometheusQueryTree query_tree;
+        String error_message;
+        size_t error_pos = String::npos;
+
+        EXPECT_FALSE(query_tree.tryParse(query, 3, &error_message, &error_pos)) << query;
+        EXPECT_EQ(error_message, "unterminated quoted string") << query;
+        EXPECT_EQ(error_pos, expected_error_pos) << query;
+    }
+
+    EXPECT_EQ(parseStringLiteral(R"(`hello
+world`)"), "hello\nworld");
+    EXPECT_EQ(parseStringLiteral(R"("hello\nworld")"), "hello\nworld");
+    EXPECT_EQ(parseStringLiteral(R"('hello\nworld')"), "hello\nworld");
+    EXPECT_EQ(parseStringLiteral("\"hello\rworld\""), "hello\rworld");
 }
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Reject literal line feeds in ordinary quoted PromQL strings.

### Why

Prometheus treats a physical LF inside a single-quoted or double-quoted string as an unterminated string:

```promql
"hello
world"
```

Raw backtick strings are different and can span lines. Escaped `\n` also remains valid.

ClickHouse's PromQL lexer currently includes LF in ordinary string tokens. The parsing helper then copied it into the result, so ClickHouse accepted the query.

Prometheus has handled these cases separately since the original PromQL lexer. The current behavior is in [`lexString`](https://github.com/prometheus/prometheus/blob/main/promql/parser/lex.go#L873-L890) and the [string literal documentation](https://prometheus.io/docs/prometheus/latest/querying/basics/#string-literals).

### What changed

- Reject physical LF in single-quoted and double-quoted PromQL strings.
- Return `unterminated quoted string` at the opening quote, matching Prometheus.
- Keep multiline backtick strings valid.
- Keep escaped `\n` and lone carriage returns valid.
- Preserve earlier invalid-escape errors when an escape sequence reaches LF.

### Testing

Added parser coverage for:

- single and double quotes
- label matcher strings
- CRLF and lone CR
- multiline backtick strings
- escaped `\n`
- LF after one or two backslashes
- LF before and inside malformed escape sequences

Also checked the first-error ordering against the current Prometheus parser.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1379` (included in `26.8` and later)
<!-- ch-version-info:end -->