### PR TITLE
Preserve 64-bit row counts in PostgreSQL CommandComplete

### DIFF
--- a/src/Core/PostgreSQLProtocol.h
+++ b/src/Core/PostgreSQLProtocol.h
@@ -1330,7 +1330,7 @@ private:
     String value;
 
 public:
-    CommandComplete(Command cmd_, Int32 rows_count_)
+    CommandComplete(Command cmd_, UInt64 rows_count_)
     {
         value = enum_to_string[cmd_];
 

--- a/src/Core/tests/gtest_postgresql_protocol.cpp
+++ b/src/Core/tests/gtest_postgresql_protocol.cpp
@@ -5,6 +5,7 @@
 #include <IO/WriteBufferFromString.h>
 #include <Common/Exception.h>
 
+#include <limits>
 #include <string>
 
 namespace DB::ErrorCodes
@@ -208,4 +209,20 @@ TEST(PostgreSQLProtocol, CopyDataRejectsLengthBelowFour)
     Messaging::CopyInData msg;
     EXPECT_NO_THROW(msg.deserialize(in));
     EXPECT_EQ(msg.query, "ab");
+}
+
+TEST(PostgreSQLProtocol, CommandCompletePreservesUInt64RowCount)
+{
+    WriteBufferFromOwnString out;
+    Messaging::CommandComplete response(Messaging::CommandComplete::SELECT, std::numeric_limits<UInt64>::max());
+    response.serialize(out);
+    out.finalize();
+
+    std::string expected;
+    expected.push_back('C');
+    putInt32(expected, 32);
+    expected += "SELECT 18446744073709551615";
+    expected.push_back('\0');
+
+    EXPECT_EQ(out.str(), expected);
 }

--- a/src/Server/PostgreSQLHandler.cpp
+++ b/src/Server/PostgreSQLHandler.cpp
@@ -947,7 +947,7 @@ void PostgreSQLHandler::processQuery()
             out_bytes_before_statement = out->count();
             UInt64 affected_rows = executeQueryWithTracking(std::move(sql_query), query_context, command);
 
-            message_transport->send(PostgreSQLProtocol::Messaging::CommandComplete(command, static_cast<Int32>(affected_rows)), true);
+            message_transport->send(PostgreSQLProtocol::Messaging::CommandComplete(command, affected_rows), true);
         }
 
     }
@@ -1048,7 +1048,7 @@ bool PostgreSQLHandler::processExecute(const String & query, ContextMutablePtr q
 
     UInt64 affected_rows = executeQueryWithTracking(std::move(result_query), query_context, command);
 
-    message_transport->send(PostgreSQLProtocol::Messaging::CommandComplete(command, static_cast<Int32>(affected_rows)), true);
+    message_transport->send(PostgreSQLProtocol::Messaging::CommandComplete(command, affected_rows), true);
 
     return true;
 }
@@ -1173,7 +1173,7 @@ void PostgreSQLHandler::processExecuteQuery()
 
         UInt64 affected_rows = executeQueryWithTracking(std::move(sql_query), query_context, command);
 
-        message_transport->send(PostgreSQLProtocol::Messaging::CommandComplete(command, static_cast<Int32>(affected_rows)), true);
+        message_transport->send(PostgreSQLProtocol::Messaging::CommandComplete(command, affected_rows), true);
     }
     catch (const Exception & e)
     {


### PR DESCRIPTION
### Changelog category (leave one):
- **Bug Fix (user-visible misbehavior in an official stable release)**

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
**Preserve PostgreSQL protocol row counts above the signed 32-bit range.**

### Description

- The PostgreSQL handler tracks affected rows as `UInt64`.
- `CommandComplete` narrowed the count to `Int32`, so counts above 2147483647 could be reported as negative.
- **Keep:** the count as `UInt64` through command-tag formatting.

### Tests

- **Coverage:** a byte-level unit test for serializing `UInt64::max()`.
- **Cases:** git diff --check`

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114397&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114397](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114397+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.552` (included in `26.9` and later)
<!-- ch-version-info:end -->