### PR TITLE
Authorize backup destinations against the SOURCES grant model

### DIFF
--- a/docs/concepts/features/backup-restore/overview.mdx
+++ b/docs/concepts/features/backup-restore/overview.mdx
@@ -194,40 +194,6 @@ Each of the commands above is detailed below:
 | `[SETTINGS ...]`                                                       | See below for complete list of settings                                                                                                              |                                                                                                                         |
 | `[ASYNC]`                                                              | Makes the operation run asynchronously (returns immediately with an ID you can monitor)                                                              |
 
-### Required privileges for the destination {#destination-privileges}
-
-Besides `BACKUP`/`RESTORE` on the objects, the backup location itself is authorized against the
-user's `SOURCES` grants, the same way the matching table functions are:
-
-| Destination | Privilege for `BACKUP` | Privilege for `RESTORE` |
-|---|---|---|
-| `S3(...)` | `WRITE ON S3` | `READ ON S3` |
-| `AzureBlobStorage(...)` | `WRITE ON AZURE` | `READ ON AZURE` |
-| `File(...)` | `WRITE ON FILE` | `READ ON FILE` |
-| `Disk(...)` | none | none |
-
-`S3` and `AzureBlobStorage` accept a filtered grant, matched against the same string the
-corresponding table function uses: the full URL for `S3`, and the blob path alone for
-`AzureBlobStorage`. So `GRANT WRITE ON S3('https://mybucket.s3.amazonaws.com/backups/.*')`
-allows only that prefix, while an `AzureBlobStorage` filter is written against the path inside
-the container, as in `GRANT WRITE ON AZURE('backups/.*')`.
-
-`File` has no path-filter semantics, so it requires the whole-source grant; which paths are
-writable at all remains the `backups.allowed_path` server setting. A destination given as a
-named collection also requires the whole-source grant, because the collection can be re-pointed
-after the check.
-
-`Disk(...)` is not authorized against `SOURCES`: an allowed disk may be local, S3- or
-Azure-backed, so no single source describes it. It is instead restricted to the disks listed in
-the `backups.allowed_disk` server setting.
-
-A `base_backup` is read, so it needs the `READ` direction even when the outer destination is
-being written.
-
-With the `access_control_improvements.enable_read_write_grants` server setting disabled, the
-legacy whole-source syntax applies instead: `GRANT S3 ON *.* TO user` is equivalent to granting
-both directions. See [GRANT](/sql-reference/statements/grant#sources).
-
 ### Settings {#settings}
 
 **Generic backup/restore settings**

--- a/docs/concepts/features/backup-restore/overview.mdx
+++ b/docs/concepts/features/backup-restore/overview.mdx
@@ -206,11 +206,16 @@ user's `SOURCES` grants, the same way the matching table functions are:
 | `File(...)` | `WRITE ON FILE` | `READ ON FILE` |
 | `Disk(...)` | none | none |
 
-`S3` and `AzureBlobStorage` accept a URL-filtered grant, so `GRANT WRITE ON
-S3('https://mybucket.s3.amazonaws.com/backups/.*')` allows only that prefix. `File` has no
-path-filter semantics, so it requires the whole-source grant; which paths are writable at all
-remains the `backups.allowed_path` server setting. A destination given as a named collection
-requires the whole-source grant, because the collection can be re-pointed after the check.
+`S3` and `AzureBlobStorage` accept a filtered grant, matched against the same string the
+corresponding table function uses: the full URL for `S3`, and the blob path alone for
+`AzureBlobStorage`. So `GRANT WRITE ON S3('https://mybucket.s3.amazonaws.com/backups/.*')`
+allows only that prefix, while an `AzureBlobStorage` filter is written against the path inside
+the container, as in `GRANT WRITE ON AZURE('backups/.*')`.
+
+`File` has no path-filter semantics, so it requires the whole-source grant; which paths are
+writable at all remains the `backups.allowed_path` server setting. A destination given as a
+named collection also requires the whole-source grant, because the collection can be re-pointed
+after the check.
 
 `Disk(...)` is not authorized against `SOURCES`: an allowed disk may be local, S3- or
 Azure-backed, so no single source describes it. It is instead restricted to the disks listed in
@@ -219,8 +224,9 @@ the `backups.allowed_disk` server setting.
 A `base_backup` is read, so it needs the `READ` direction even when the outer destination is
 being written.
 
-These checks apply when the `access_control_improvements.enable_read_write_grants` server
-setting is enabled. See [GRANT](/sql-reference/statements/grant#sources).
+With the `access_control_improvements.enable_read_write_grants` server setting disabled, the
+legacy whole-source syntax applies instead: `GRANT S3 ON *.* TO user` is equivalent to granting
+both directions. See [GRANT](/sql-reference/statements/grant#sources).
 
 ### Settings {#settings}
 

--- a/docs/concepts/features/backup-restore/overview.mdx
+++ b/docs/concepts/features/backup-restore/overview.mdx
@@ -194,6 +194,34 @@ Each of the commands above is detailed below:
 | `[SETTINGS ...]`                                                       | See below for complete list of settings                                                                                                              |                                                                                                                         |
 | `[ASYNC]`                                                              | Makes the operation run asynchronously (returns immediately with an ID you can monitor)                                                              |
 
+### Required privileges for the destination {#destination-privileges}
+
+Besides `BACKUP`/`RESTORE` on the objects, the backup location itself is authorized against the
+user's `SOURCES` grants, the same way the matching table functions are:
+
+| Destination | Privilege for `BACKUP` | Privilege for `RESTORE` |
+|---|---|---|
+| `S3(...)` | `WRITE ON S3` | `READ ON S3` |
+| `AzureBlobStorage(...)` | `WRITE ON AZURE` | `READ ON AZURE` |
+| `File(...)` | `WRITE ON FILE` | `READ ON FILE` |
+| `Disk(...)` | none | none |
+
+`S3` and `AzureBlobStorage` accept a URL-filtered grant, so `GRANT WRITE ON
+S3('https://mybucket.s3.amazonaws.com/backups/.*')` allows only that prefix. `File` has no
+path-filter semantics, so it requires the whole-source grant; which paths are writable at all
+remains the `backups.allowed_path` server setting. A destination given as a named collection
+requires the whole-source grant, because the collection can be re-pointed after the check.
+
+`Disk(...)` is not authorized against `SOURCES`: an allowed disk may be local, S3- or
+Azure-backed, so no single source describes it. It is instead restricted to the disks listed in
+the `backups.allowed_disk` server setting.
+
+A `base_backup` is read, so it needs the `READ` direction even when the outer destination is
+being written.
+
+These checks apply when the `access_control_improvements.enable_read_write_grants` server
+setting is enabled. See [GRANT](/sql-reference/statements/grant#sources).
+
 ### Settings {#settings}
 
 **Generic backup/restore settings**

--- a/docs/reference/statements/grant.mdx
+++ b/docs/reference/statements/grant.mdx
@@ -628,7 +628,7 @@ Allows using [introspection](/concepts/features/performance/troubleshoot/samplin
 
 ### SOURCES {#sources}
 
-Allows using external data sources. Applies to [table engines](/reference/engines/table-engines/index) and [table functions](/reference/functions/table-functions/index).
+Allows using external data sources. Applies to [table engines](/reference/engines/table-engines/index), [table functions](/reference/functions/table-functions/index), the locations used by [BACKUP/RESTORE](/concepts/features/backup-restore/overview#destination-privileges), and the [Backup database engine](/reference/engines/database-engines/backup).
 
 - `READ`. Level: `GLOBAL_WITH_PARAMETER`  
 - `WRITE`. Level: `GLOBAL_WITH_PARAMETER`

--- a/docs/reference/statements/grant.mdx
+++ b/docs/reference/statements/grant.mdx
@@ -628,7 +628,7 @@ Allows using [introspection](/concepts/features/performance/troubleshoot/samplin
 
 ### SOURCES {#sources}
 
-Allows using external data sources. Applies to [table engines](/reference/engines/table-engines/index), [table functions](/reference/functions/table-functions/index), the locations used by [BACKUP/RESTORE](/concepts/features/backup-restore/overview#destination-privileges), and the [Backup database engine](/reference/engines/database-engines/backup).
+Allows using external data sources. Applies to [table engines](/reference/engines/table-engines/index) and [table functions](/reference/functions/table-functions/index).
 
 - `READ`. Level: `GLOBAL_WITH_PARAMETER`  
 - `WRITE`. Level: `GLOBAL_WITH_PARAMETER`

--- a/src/Backups/BackupFactory.cpp
+++ b/src/Backups/BackupFactory.cpp
@@ -1,5 +1,9 @@
+#include <Access/ContextAccess.h>
 #include <Backups/BackupFactory.h>
+#include <Interpreters/Context.h>
 #include <Common/Exception.h>
+
+#include <Poco/URI.h>
 
 #include <fmt/format.h>
 
@@ -20,6 +24,24 @@ namespace
     void appendIdentityComponent(String & identity, std::string_view component)
     {
         fmt::format_to(std::back_inserter(identity), ":{}:{}", component.size(), component);
+    }
+
+    /// Must normalize identically to `ITableFunction::getFunctionURINormalized`, or the same regex
+    /// grant matches a table function and not a backup. An empty result requires a whole-source grant.
+    String normalizeAccessURI(const String & uri)
+    {
+        if (uri.empty())
+            return uri;
+        try
+        {
+            Poco::URI parsed(uri);
+            parsed.normalize();
+            return parsed.toString();
+        }
+        catch (const Poco::Exception &)
+        {
+            return "";
+        }
     }
 }
 
@@ -48,12 +70,31 @@ BackupFactory & BackupFactory::instance()
     return the_instance;
 }
 
+void BackupFactory::checkSourceAccess(const BackupInfo & backup_info, ContextPtr context, OpenMode open_mode) const
+{
+    const String & engine_name = backup_info.backup_engine_name;
+    auto it = engines.find(engine_name);
+    if (it == engines.end())
+        throw Exception(ErrorCodes::BACKUP_ENGINE_NOT_FOUND, "Not found backup engine '{}'", engine_name);
+
+    if (!it->second.source_access)
+        return;
+
+    if (auto target = it->second.source_access(backup_info, context, open_mode))
+        context->getAccess()->checkAccessWithFilter(
+            target->flags, AccessTypeObjects::toStringSource(target->source), normalizeAccessURI(target->uri));
+}
+
 BackupMutablePtr BackupFactory::createBackup(const CreateParams & params) const
 {
     const String & engine_name = params.backup_info.backup_engine_name;
     auto it = engines.find(engine_name);
     if (it == engines.end())
         throw Exception(ErrorCodes::BACKUP_ENGINE_NOT_FOUND, "Not found backup engine '{}'", engine_name);
+
+    /// Authorize the location before the creator does any network or filesystem I/O.
+    checkSourceAccess(params.backup_info, params.context, params.open_mode);
+
     return it->second.creator(params);
 }
 
@@ -82,11 +123,12 @@ String BackupFactory::getDestinationIdentity(const BackupInfo & backup_info, Con
 void BackupFactory::registerBackupEngine(
     const String & engine_name,
     const CreatorFn & creator_fn,
-    const DestinationIdentityFn & destination_identity_fn)
+    const DestinationIdentityFn & destination_identity_fn,
+    const SourceAccessFn & source_access_fn)
 {
     if (engines.contains(engine_name))
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Backup engine '{}' was registered twice", engine_name);
-    engines.emplace(engine_name, RegisteredEngine{creator_fn, destination_identity_fn});
+    engines.emplace(engine_name, RegisteredEngine{creator_fn, destination_identity_fn, source_access_fn});
 }
 
 void registerBackupEnginesFileAndDisk(BackupFactory &);

--- a/src/Backups/BackupFactory.h
+++ b/src/Backups/BackupFactory.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <Access/Common/AccessFlags.h>
+#include <Access/Common/AccessType.h>
 #include <Backups/BackupDataFileNameGeneratorType.h>
 #include <Backups/BackupInfo.h>
 #include <Backups/IBackup.h>
@@ -64,18 +66,38 @@ public:
     /// observe the same collection state.
     String getDestinationIdentity(const BackupInfo & backup_info, ContextPtr context) const;
 
+    /// The SOURCES grant required to open `backup_info` in `open_mode`, as declared by its engine.
+    struct SourceAccessTarget
+    {
+        AccessTypeObjects::Source source;
+        /// The URI to match regex-filtered grants against. Empty means a whole-source grant is required.
+        String uri;
+        AccessFlags flags;
+    };
+
+    /// `std::nullopt` for engines with no external location (`Memory`, `Null`) or whose location is an
+    /// operator-allowlisted disk (`Disk`).
+    using SourceAccessFn
+        = std::function<std::optional<SourceAccessTarget>(const BackupInfo &, ContextPtr, IBackup::OpenMode)>;
+
+    /// Performs no I/O, so it is also callable as a preflight before a query is distributed or a
+    /// database is created.
+    void checkSourceAccess(const BackupInfo & backup_info, ContextPtr context, OpenMode open_mode) const;
+
     using CreatorFn = std::function<BackupMutablePtr(const CreateParams & params)>;
     using DestinationIdentityFn = std::function<Strings(const BackupInfo & backup_info, ContextPtr context)>;
     void registerBackupEngine(
         const String & engine_name,
         const CreatorFn & creator_fn,
-        const DestinationIdentityFn & destination_identity_fn);
+        const DestinationIdentityFn & destination_identity_fn,
+        const SourceAccessFn & source_access_fn);
 
 private:
     struct RegisteredEngine
     {
         CreatorFn creator;
         DestinationIdentityFn destination_identity;
+        SourceAccessFn source_access;
     };
 
     BackupFactory();

--- a/src/Backups/BackupIO_Memory.cpp
+++ b/src/Backups/BackupIO_Memory.cpp
@@ -118,7 +118,11 @@ void registerBackupEngineMemory(BackupFactory & factory)
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Memory backup destinations do not have a persistent identity");
     };
 
-    factory.registerBackupEngine("Memory", creator_fn, destination_identity_fn);
+    /// No external location: nothing to authorize against the SOURCES grant model.
+    auto source_access_fn = [](const BackupInfo &, ContextPtr, IBackup::OpenMode)
+        -> std::optional<BackupFactory::SourceAccessTarget> { return std::nullopt; };
+
+    factory.registerBackupEngine("Memory", creator_fn, destination_identity_fn, source_access_fn);
 }
 
 }

--- a/src/Backups/BackupIO_Null.cpp
+++ b/src/Backups/BackupIO_Null.cpp
@@ -115,7 +115,11 @@ void registerBackupEngineNull(BackupFactory & factory)
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Null backup destinations do not have a persistent identity");
     };
 
-    factory.registerBackupEngine("Null", creator_fn, destination_identity_fn);
+    /// No external location: nothing to authorize against the SOURCES grant model.
+    auto source_access_fn = [](const BackupInfo &, ContextPtr, IBackup::OpenMode)
+        -> std::optional<BackupFactory::SourceAccessTarget> { return std::nullopt; };
+
+    factory.registerBackupEngine("Null", creator_fn, destination_identity_fn, source_access_fn);
 }
 
 }

--- a/src/Backups/BackupSourceAccess.h
+++ b/src/Backups/BackupSourceAccess.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <Access/Common/AccessFlags.h>
+#include <Backups/IBackup.h>
+
+namespace DB
+{
+
+/// The SOURCES direction required to open a backup in `open_mode`, for an engine whose `UNLOCK` is
+/// served by a reader (`S3`, `AzureBlobStorage`). `UNLOCK` only mutates Keeper, under its own
+/// `SYSTEM_UNLOCK_SNAPSHOT` privilege.
+inline AccessFlags backupSourceAccessFlagsForReaderUnlock(IBackup::OpenMode open_mode)
+{
+    return open_mode == IBackup::OpenMode::WRITE ? AccessType::WRITE : AccessType::READ;
+}
+
+/// The same, for an engine whose creator routes every non-`READ` mode (including `UNLOCK`) through
+/// its writer branch (`File`, `Disk`).
+inline AccessFlags backupSourceAccessFlagsForWriterUnlock(IBackup::OpenMode open_mode)
+{
+    return open_mode == IBackup::OpenMode::READ ? AccessType::READ : AccessType::WRITE;
+}
+
+}

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -426,6 +426,12 @@ struct BackupsWorker::BackupStarter
         backup_settings = BackupSettings::fromBackupQuery(*backup_query);
         backup_context->makeQueryContext();
 
+        /// `makeQueryContext` above resets `backup_context` to a fresh, empty `QueryPrivilegesInfo`. Sharing
+        /// the originating one accounts privileges checked on copies of `backup_context` to the BACKUP query,
+        /// so they reach the `used_privileges`/`missing_privileges` columns of `system.query_log`.
+        /// `QueryPrivilegesInfo` has its own mutex and is not a field a concurrent originating thread mutates.
+        backup_context->setQueryPrivilegesInfo(query_context->getQueryPrivilegesInfoPtr());
+
         backup_info = BackupInfo::fromAST(*backup_query->backup_name);
         backup_name_for_logging = backup_info.toStringForLogging();
         is_internal_backup = backup_settings.internal;

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -149,6 +149,28 @@ namespace
         return status == BackupStatus::RESTORING;
     }
 
+    /// A base backup is only ever opened for reading, lazily, and an internal leg's context has no user,
+    /// so an explicitly requested one is authorized here: as the real user, before the query is
+    /// distributed.
+    void checkAccessToExplicitBaseBackup(
+        const BackupInfo & backup_info,
+        const std::optional<BackupInfo> & base_backup_info,
+        bool use_same_s3_credentials_for_base_backup,
+        bool is_internal,
+        const ContextPtr & context)
+    {
+        if (!base_backup_info || is_internal)
+            return;
+
+        /// Authorize the locator that will actually be opened: `BackupImpl::getBaseBackupUnlocked`
+        /// fills the credentials from the outer locator first, so a base missing them is not malformed.
+        BackupInfo effective_base_backup_info = *base_backup_info;
+        if (use_same_s3_credentials_for_base_backup && backup_info.canCopyS3CredentialsTo(effective_base_backup_info))
+            backup_info.copyS3CredentialsTo(effective_base_backup_info);
+
+        BackupFactory::instance().checkSourceAccess(effective_base_backup_info, context, IBackup::OpenMode::READ);
+    }
+
     /// We use slightly different read and write settings for backup/restore
     /// with a separate throttler and limited usage of filesystem cache.
     ReadSettings getReadSettingsForBackup(const ContextPtr & context, const BackupSettings & backup_settings)
@@ -639,6 +661,12 @@ BackupMutablePtr BackupsWorker::openBackupForWriting(
     backup_create_params.context = context;
     backup_create_params.backup_info = backup_info;
     backup_create_params.base_backup_info = backup_settings.base_backup_info;
+    checkAccessToExplicitBaseBackup(
+        backup_info,
+        backup_settings.base_backup_info,
+        backup_settings.use_same_s3_credentials_for_base_backup,
+        backup_settings.internal,
+        context);
     backup_create_params.compression_method = backup_settings.compression_method;
     backup_create_params.compression_level = backup_settings.compression_level;
     backup_create_params.password = backup_settings.password;
@@ -1096,6 +1124,12 @@ BackupPtr BackupsWorker::openBackupForReading(const BackupInfo & backup_info, co
     backup_open_params.context = context;
     backup_open_params.backup_info = backup_info;
     backup_open_params.base_backup_info = restore_settings.base_backup_info;
+    checkAccessToExplicitBaseBackup(
+        backup_info,
+        restore_settings.base_backup_info,
+        restore_settings.use_same_s3_credentials_for_base_backup,
+        restore_settings.internal,
+        context);
     backup_open_params.password = restore_settings.password;
     backup_open_params.allow_s3_native_copy = restore_settings.allow_s3_native_copy;
     backup_open_params.allow_azure_native_copy = restore_settings.allow_azure_native_copy;

--- a/src/Backups/RestorerFromBackup.cpp
+++ b/src/Backups/RestorerFromBackup.cpp
@@ -14,6 +14,7 @@
 #include <Backups/RestorerFromBackup.h>
 #include <Core/Settings.h>
 #include <Databases/DDLDependencyVisitor.h>
+#include <Databases/DatabaseBackup.h>
 #include <Databases/DatabaseFactory.h>
 #include <Databases/IDatabase.h>
 #include <Interpreters/Context.h>
@@ -289,7 +290,25 @@ void RestorerFromBackup::checkAccessForObjectsFoundInBackup() const
             AccessFlags flags;
 
             if (restore_settings.create_database != RestoreDatabaseCreationMode::kMustExist)
+            {
                 flags |= AccessType::CREATE_DATABASE;
+
+                /// The last point on this path that still runs as the real user. An existing local
+                /// database means nothing is created here, and `create_fn` authorizes it if it is
+                /// dropped in between. Under CHECK_ACCESS_ONLY the creating host is a different one,
+                /// so a local existence answer says nothing about it.
+                const bool database_exists_so_nothing_is_created
+                    = (mode != Mode::CHECK_ACCESS_ONLY) && DatabaseCatalog::instance().isDatabaseExist(database_name);
+
+                if (!context->getSettingsRef()[Setting::restore_replace_external_engines_to_null]
+                    && !database_exists_so_nothing_is_created && database_info.create_database_query)
+                {
+                    const auto & create = database_info.create_database_query->as<const ASTCreateQuery &>();
+                    if (create.storage && create.storage->engine && create.storage->engine->name == "Backup"
+                        && create.storage->engine->arguments)
+                        DatabaseBackup::parseAndAuthorizeLocator(create.storage->engine->arguments->children, context);
+                }
+            }
 
             if (!flags)
                 flags = AccessType::SHOW_DATABASES;

--- a/src/Backups/registerBackupEngineAzureBlobStorage.cpp
+++ b/src/Backups/registerBackupEngineAzureBlobStorage.cpp
@@ -9,6 +9,7 @@
 #include <Backups/BackupIO_AzureBlobStorage.h>
 #include <Backups/BackupImpl.h>
 #include <Backups/BackupInfo.h>
+#include <Backups/BackupSourceAccess.h>
 #include <Common/NamedCollections/NamedCollections.h>
 #include <IO/Archives/ArchiveUtils.h>
 #include <IO/Archives/hasRegisteredArchiveFileExtension.h>
@@ -43,6 +44,8 @@ namespace
         AzureBlobStorage::ConnectionParams connection_params;
         String blob_path;
         String archive_name;
+        /// `blob_path` before a trailing archive filename is stripped off it.
+        String blob_path_with_archive;
     };
 
     String removeFileNameFromURL(String & url)
@@ -175,9 +178,28 @@ namespace
                 "(storage account URL, container, path, account name, account key)");
         }
 
+        location.blob_path_with_archive = location.blob_path;
         if (hasRegisteredArchiveFileExtension(location.blob_path))
             location.archive_name = removeFileNameFromURL(location.blob_path);
         return location;
+    }
+
+    std::optional<BackupFactory::SourceAccessTarget>
+    getAzureSourceAccess(const BackupInfo & backup_info, ContextPtr context, IBackup::OpenMode open_mode)
+    {
+        BackupFactory::SourceAccessTarget target{
+            AccessTypeObjects::Source::AZURE, "", backupSourceAccessFlagsForReaderUnlock(open_mode)};
+
+        /// A collection can be re-pointed after this returns, so an empty URI keeps it whole-source.
+        /// Resolving it is still required: that is where `NAMED_COLLECTION` is enforced.
+        if (!backup_info.id_arg.empty())
+        {
+            backup_info.getNamedCollection(context);
+            return target;
+        }
+
+        target.uri = resolveAzureBackupLocation(backup_info, context).blob_path_with_archive;
+        return target;
     }
 
     Strings getAzureDestinationIdentity(const BackupInfo & backup_info, ContextPtr context)
@@ -320,7 +342,18 @@ void registerBackupEngineAzureBlobStorage(BackupFactory & factory)
 #endif
     };
 
-    factory.registerBackupEngine("AzureBlobStorage", creator_fn, destination_identity_fn);
+    auto source_access_fn = []([[maybe_unused]] const BackupInfo & backup_info,
+                               [[maybe_unused]] ContextPtr context,
+                               [[maybe_unused]] IBackup::OpenMode open_mode) -> std::optional<BackupFactory::SourceAccessTarget>
+    {
+#if USE_AZURE_BLOB_STORAGE
+        return getAzureSourceAccess(backup_info, context, open_mode);
+#else
+        throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "AzureBlobStorage support is disabled");
+#endif
+    };
+
+    factory.registerBackupEngine("AzureBlobStorage", creator_fn, destination_identity_fn, source_access_fn);
 }
 
 }

--- a/src/Backups/registerBackupEngineS3.cpp
+++ b/src/Backups/registerBackupEngineS3.cpp
@@ -8,6 +8,7 @@
 #include <Backups/BackupIO_S3.h>
 #include <Backups/BackupImpl.h>
 #include <Backups/BackupInfo.h>
+#include <Backups/BackupSourceAccess.h>
 #include <Common/NamedCollections/NamedCollections.h>
 #include <IO/Archives/ArchiveUtils.h>
 #include <IO/Archives/hasRegisteredArchiveFileExtension.h>
@@ -59,6 +60,9 @@ namespace
         String uri;
         String archive_name;
         NamedCollectionPtr collection;
+        /// `uri` before a trailing archive filename is stripped off it, which is the form the `s3`
+        /// table function authorizes.
+        String uri_with_archive;
     };
 
     String removeFileNameFromURL(String & url)
@@ -124,6 +128,7 @@ namespace
         }
 
         location.uri = removeURLUserInfo(location.uri);
+        location.uri_with_archive = location.uri;
         if (hasRegisteredArchiveFileExtension(location.uri))
             location.archive_name = removeFileNameFromURL(location.uri);
         return location;
@@ -153,6 +158,25 @@ namespace
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid S3 extra credentials for backup destination identity");
             }
         }
+    }
+
+    std::optional<BackupFactory::SourceAccessTarget>
+    getS3SourceAccess(const BackupInfo & backup_info, ContextPtr context, IBackup::OpenMode open_mode)
+    {
+        BackupFactory::SourceAccessTarget target{
+            AccessTypeObjects::Source::S3, "", backupSourceAccessFlagsForReaderUnlock(open_mode)};
+
+        /// A collection can be re-pointed after this check, so it is authorized whole-source rather
+        /// than on the URL it currently resolves to. Resolving it is still required: that is where
+        /// `NAMED_COLLECTION` is enforced.
+        if (!backup_info.id_arg.empty())
+        {
+            backup_info.getNamedCollection(context);
+            return target;
+        }
+
+        target.uri = resolveS3BackupLocation(backup_info, context).uri_with_archive;
+        return target;
     }
 
     Strings getS3DestinationIdentity(const BackupInfo & backup_info, ContextPtr context)
@@ -402,7 +426,18 @@ void registerBackupEngineS3(BackupFactory & factory)
 #endif
     };
 
-    factory.registerBackupEngine("S3", creator_fn, destination_identity_fn);
+    auto source_access_fn = []([[maybe_unused]] const BackupInfo & backup_info,
+                               [[maybe_unused]] ContextPtr context,
+                               [[maybe_unused]] IBackup::OpenMode open_mode) -> std::optional<BackupFactory::SourceAccessTarget>
+    {
+#if USE_AWS_S3
+        return getS3SourceAccess(backup_info, context, open_mode);
+#else
+        throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "S3 support is disabled");
+#endif
+    };
+
+    factory.registerBackupEngine("S3", creator_fn, destination_identity_fn, source_access_fn);
 }
 
 }

--- a/src/Backups/registerBackupEnginesFileAndDisk.cpp
+++ b/src/Backups/registerBackupEnginesFileAndDisk.cpp
@@ -3,6 +3,7 @@
 #include <Backups/BackupIO_Disk.h>
 #include <Backups/BackupIO_File.h>
 #include <Backups/BackupImpl.h>
+#include <Backups/BackupSourceAccess.h>
 #include <Core/Settings.h>
 #include <Disks/IDisk.h>
 #include <IO/Archives/ArchiveUtils.h>
@@ -235,8 +236,21 @@ void registerBackupEnginesFileAndDisk(BackupFactory & factory)
         return std::make_unique<BackupImpl>(params, archive_params, writer);
     };
 
-    factory.registerBackupEngine("File", creator_fn, getLocalDestinationIdentity);
-    factory.registerBackupEngine("Disk", creator_fn, getLocalDestinationIdentity);
+    /// `FILE` has no path-filter semantics, so the empty URI demands the whole-source grant. Path
+    /// containment is the operator's `backups.allowed_path`, not a grant.
+    auto file_source_access_fn = [](const BackupInfo &, ContextPtr, IBackup::OpenMode open_mode)
+        -> std::optional<BackupFactory::SourceAccessTarget>
+    {
+        return BackupFactory::SourceAccessTarget{
+            AccessTypeObjects::Source::FILE, "", backupSourceAccessFlagsForWriterUnlock(open_mode)};
+    };
+
+    /// An allowlisted disk may be local, S3- or Azure-backed, so no single `Source` describes it.
+    auto disk_source_access_fn = [](const BackupInfo &, ContextPtr, IBackup::OpenMode)
+        -> std::optional<BackupFactory::SourceAccessTarget> { return std::nullopt; };
+
+    factory.registerBackupEngine("File", creator_fn, getLocalDestinationIdentity, file_source_access_fn);
+    factory.registerBackupEngine("Disk", creator_fn, getLocalDestinationIdentity, disk_source_access_fn);
 }
 
 }

--- a/src/Databases/DatabaseBackup.cpp
+++ b/src/Databases/DatabaseBackup.cpp
@@ -564,8 +564,6 @@ The backup destination can be any valid backup [destination](/operations/backup/
 - `database_name_inside_backup` — Name of the database inside the backup.
 - `backup_destination` — Backup destination.
 
-The destination is read, so creating the database requires the `READ` [SOURCES](/sql-reference/statements/grant#sources) grant for it: `READ ON S3`, `READ ON AZURE` or `READ ON FILE`. A `Disk(...)` destination is restricted by the `backups.allowed_disk` server setting instead.
-
 ## Usage example {#usage-example}
 
 Let's make an example with a `Disk` backup destination. Let's first setup backups disk in `storage.xml`:

--- a/src/Databases/DatabaseBackup.cpp
+++ b/src/Databases/DatabaseBackup.cpp
@@ -564,6 +564,8 @@ The backup destination can be any valid backup [destination](/operations/backup/
 - `database_name_inside_backup` — Name of the database inside the backup.
 - `backup_destination` — Backup destination.
 
+The destination is read, so creating the database requires the `READ` [SOURCES](/sql-reference/statements/grant#sources) grant for it: `READ ON S3`, `READ ON AZURE` or `READ ON FILE`. A `Disk(...)` destination is restricted by the `backups.allowed_disk` server setting instead.
+
 ## Usage example {#usage-example}
 
 Let's make an example with a `Disk` backup destination. Let's first setup backups disk in `storage.xml`:

--- a/src/Databases/DatabaseBackup.cpp
+++ b/src/Databases/DatabaseBackup.cpp
@@ -32,6 +32,8 @@
 #include <Interpreters/SelectIntersectExceptQueryVisitor.h>
 #include <Interpreters/DatabaseCatalog.h>
 
+#include <Access/ContextAccess.h>
+
 #include <Backups/BackupFactory.h>
 
 #include <Disks/DiskBackup.h>
@@ -507,6 +509,16 @@ DatabaseBackup::Configuration parseArguments(ASTs engine_args, ContextPtr)
 
 }
 
+void DatabaseBackup::parseAndAuthorizeLocator(const ASTs & engine_args, ContextPtr query_context)
+{
+    /// A locator we cannot parse opens nothing: creation rejects it, so there is nothing to authorize.
+    if (engine_args.size() == 2 && !engine_args[1]->as<ASTFunction>())
+        return;
+
+    auto config = parseArguments(engine_args, query_context);
+    BackupFactory::instance().checkSourceAccess(config.backup_info, query_context, IBackup::OpenMode::READ);
+}
+
 void registerDatabaseBackup(DatabaseFactory & factory);
 void registerDatabaseBackup(DatabaseFactory & factory)
 {
@@ -520,6 +532,15 @@ void registerDatabaseBackup(DatabaseFactory & factory)
             engine_args = engine->arguments->children;
 
         auto config = parseArguments(engine_args, args.context);
+
+        /// Authorize only a newly introduced definition: one read back from this server's metadata was
+        /// already validated, and a context with no user cannot be checked per user.
+        const bool has_real_user = args.context->getAccess()->getUserID().has_value();
+        const bool from_existing_metadata
+            = isLoadingFromExistingMetadata(args.mode) || args.create_query.attach_short_syntax;
+        if (has_real_user && !from_existing_metadata)
+            BackupFactory::instance().checkSourceAccess(config.backup_info, args.context, IBackup::OpenMode::READ);
+
         return std::make_shared<DatabaseBackup>(args.database_name, args.metadata_path, config, args.context);
     };
 

--- a/src/Databases/DatabaseBackup.h
+++ b/src/Databases/DatabaseBackup.h
@@ -28,6 +28,12 @@ public:
 
     DatabaseBackup(const String & name, const String & metadata_path, const Configuration & config, ContextPtr context);
 
+    /// Authorizes reading this engine's backup destination against `context`'s SOURCES grants, and
+    /// does nothing for a destination that cannot decode (creation rejects it anyway). Performs no
+    /// I/O, so it also serves as a preflight before an `ON CLUSTER` query is distributed or a
+    /// definition found in a backup is created.
+    static void parseAndAuthorizeLocator(const ASTs & engine_args, ContextPtr query_context);
+
     String getEngineName() const override { return "Backup"; }
 
     bool shouldBeEmptyOnDetach() const override { return false; }

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -85,6 +85,7 @@
 #include <DataTypes/DataTypeAggregateFunction.h>
 #include <DataTypes/hasNullable.h>
 
+#include <Databases/DatabaseBackup.h>
 #include <Databases/DatabaseFactory.h>
 #include <Databases/DatabaseReplicated.h>
 #include <Databases/DatabaseOnDisk.h>
@@ -3412,7 +3413,15 @@ BlockIO InterpreterCreateQuery::execute()
 
         auto on_cluster_version = getContext()->getSettingsRef()[Setting::distributed_ddl_entry_format_version];
         if (is_create_database || on_cluster_version < DDLLogEntry::NORMALIZE_CREATE_ON_INITIATOR_VERSION)
+        {
+            /// Authorize here: this is the last point that still runs as the real user, and worker legs
+            /// run with no user by default.
+            if (is_create_database && create.storage && create.storage->engine
+                && create.storage->engine->name == "Backup" && create.storage->engine->arguments)
+                DatabaseBackup::parseAndAuthorizeLocator(create.storage->engine->arguments->children, getContext());
+
             return executeQueryOnCluster(create);
+        }
     }
 
     getContext()->checkAccess(getRequiredAccess());

--- a/tests/integration/test_backup_source_grants/configs/backups.xml
+++ b/tests/integration/test_backup_source_grants/configs/backups.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <backups>
+        <allowed_path>/var/lib/clickhouse/backups</allowed_path>
+    </backups>
+</clickhouse>

--- a/tests/integration/test_backup_source_grants/configs/enable_grants.xml
+++ b/tests/integration/test_backup_source_grants/configs/enable_grants.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <access_control_improvements>
+        <enable_read_write_grants>1</enable_read_write_grants>
+    </access_control_improvements>
+</clickhouse>

--- a/tests/integration/test_backup_source_grants/configs/remote_servers.xml
+++ b/tests/integration/test_backup_source_grants/configs/remote_servers.xml
@@ -1,0 +1,12 @@
+<clickhouse>
+    <remote_servers>
+        <one_shard>
+            <shard>
+                <replica>
+                    <host>node</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </one_shard>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_backup_source_grants/test.py
+++ b/tests/integration/test_backup_source_grants/test.py
@@ -1,0 +1,389 @@
+"""BACKUP/RESTORE destinations must be authorized against the user's SOURCES grants.
+
+`SOURCES ON *.*` revoked, a regex-scoped `WRITE ON S3` for one prefix, and MinIO. Without the
+check, the user can write a backup to (and read one from) any bucket the server can reach.
+"""
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.config_cluster import minio_secret_key
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=[
+        "configs/enable_grants.xml",
+        "configs/remote_servers.xml",
+        "configs/backups.xml",
+    ],
+    with_minio=True,
+    with_azurite=True,
+    with_zookeeper=True,
+)
+
+USER = "u67785"
+ALLOWED = "http://minio1:9001/root/data/allowed"
+DENIED = "http://minio1:9001/root/data/denied"
+
+
+def s3(url):
+    return f"S3('{url}', 'minio', '{minio_secret_key}')"
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        node.query(
+            """
+            CREATE DATABASE IF NOT EXISTS d67785;
+            CREATE TABLE d67785.secrets (x UInt64) ENGINE = MergeTree ORDER BY x;
+            INSERT INTO d67785.secrets VALUES (42);
+            """
+        )
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def restricted_user(started_cluster):
+    node.query(f"DROP USER IF EXISTS {USER}")
+    node.query(
+        f"""
+        CREATE USER {USER};
+        GRANT BACKUP ON d67785.* TO {USER};
+        GRANT CREATE DATABASE, DROP DATABASE ON *.* TO {USER};
+        GRANT CREATE TABLE, INSERT, SELECT ON d67785.* TO {USER};
+        GRANT CLUSTER ON *.* TO {USER};
+        REVOKE SOURCES ON *.* FROM {USER};
+        """
+    )
+    yield
+    node.query(f"DROP USER IF EXISTS {USER}")
+
+
+def test_backup_requires_write_on_the_destination(started_cluster):
+    # The reporter's exact case: only the `allowed` prefix is granted, so a backup to `denied`
+    # must be refused with ACCESS_DENIED rather than reaching S3 (which used to give S3_ERROR).
+    node.query(f"GRANT WRITE ON S3('{ALLOWED}/.*') TO {USER}")
+
+    error = node.query_and_get_error(
+        f"BACKUP TABLE d67785.secrets TO {s3(DENIED + '/b1')}", user=USER
+    )
+    assert "ACCESS_DENIED" in error, error
+    assert "WRITE ON S3" in error, error
+
+    node.query(
+        f"BACKUP TABLE d67785.secrets TO {s3(ALLOWED + '/b1')} FORMAT Null", user=USER
+    )
+
+
+def test_restore_requires_read_on_the_source(started_cluster):
+    node.query(f"BACKUP TABLE d67785.secrets TO {s3(DENIED + '/b2')} FORMAT Null")
+
+    # WRITE alone must not authorize reading a backup back.
+    node.query(f"GRANT WRITE ON S3 TO {USER}")
+    error = node.query_and_get_error(
+        f"RESTORE TABLE d67785.secrets AS d67785.r2 FROM {s3(DENIED + '/b2')}", user=USER
+    )
+    assert "ACCESS_DENIED" in error, error
+    assert (
+        node.query("SELECT count() FROM system.tables WHERE database = 'd67785' AND name = 'r2'")
+        == "0\n"
+    )
+
+    node.query(f"GRANT READ ON S3('{DENIED}/.*') TO {USER}")
+    node.query(
+        f"RESTORE TABLE d67785.secrets AS d67785.r2 FROM {s3(DENIED + '/b2')} FORMAT Null",
+        user=USER,
+    )
+    assert node.query("SELECT x FROM d67785.r2") == "42\n"
+    node.query("DROP TABLE d67785.r2 SYNC")
+
+
+def test_create_database_backup_engine_requires_read(started_cluster):
+    node.query(f"BACKUP DATABASE d67785 TO {s3(DENIED + '/b3')} FORMAT Null")
+
+    error = node.query_and_get_error(
+        f"CREATE DATABASE db67785 ENGINE = Backup('d67785', {s3(DENIED + '/b3')})", user=USER
+    )
+    assert "ACCESS_DENIED" in error, error
+    assert node.query("SELECT count() FROM system.databases WHERE name = 'db67785'") == "0\n"
+
+    node.query(f"GRANT READ ON S3('{DENIED}/.*') TO {USER}")
+    node.query(
+        f"CREATE DATABASE db67785 ENGINE = Backup('d67785', {s3(DENIED + '/b3')})", user=USER
+    )
+    assert node.query("SELECT x FROM db67785.secrets") == "42\n"
+    node.query("DROP DATABASE db67785 SYNC")
+
+
+def test_named_collection_destination_requires_the_whole_source_grant(started_cluster):
+    # A collection can be re-pointed after the check, so it is authorized whole-source: a grant
+    # filtered on the URL it currently resolves to is deliberately not enough.
+    collection = "nc67785"
+    node.query(
+        f"""
+        CREATE NAMED COLLECTION IF NOT EXISTS {collection} AS
+            url = '{DENIED}/b8',
+            access_key_id = 'minio',
+            secret_access_key = '{minio_secret_key}'
+        """
+    )
+    try:
+        # Not what this case tests: the collection itself must be usable by the user.
+        node.query(f"GRANT NAMED COLLECTION ON {collection} TO {USER}")
+        node.query(f"GRANT WRITE ON S3('{DENIED}/.*') TO {USER}")
+
+        error = node.query_and_get_error(
+            f"BACKUP TABLE d67785.secrets TO S3({collection})", user=USER
+        )
+        assert "ACCESS_DENIED" in error, error
+        # Not a missing NAMED COLLECTION privilege, which would also deny.
+        assert "WRITE ON S3" in error, error
+
+        node.query(f"GRANT WRITE ON S3 TO {USER}")
+        node.query(f"BACKUP TABLE d67785.secrets TO S3({collection}) FORMAT Null", user=USER)
+    finally:
+        node.query(f"DROP NAMED COLLECTION IF EXISTS {collection}")
+
+
+def azure(path):
+    return (
+        f"AzureBlobStorage('{cluster.env_variables['AZURITE_CONNECTION_STRING']}', "
+        f"'{cluster.azurite_container}', '{path}')"
+    )
+
+
+def test_azure_destination_requires_the_matching_direction(started_cluster):
+    # The Azure hook is not a copy of the S3 one: its own pre-split blob path and its own
+    # reader-UNLOCK direction, so S3 coverage does not transfer.
+    error = node.query_and_get_error(
+        f"BACKUP TABLE d67785.secrets TO {azure('b9')}", user=USER
+    )
+    assert "ACCESS_DENIED" in error, error
+    assert "WRITE ON AZURE" in error, error
+
+    node.query(f"GRANT WRITE ON AZURE TO {USER}")
+    node.query(f"BACKUP TABLE d67785.secrets TO {azure('b9')} FORMAT Null", user=USER)
+
+    # WRITE alone must not authorize reading it back.
+    error = node.query_and_get_error(
+        f"RESTORE TABLE d67785.secrets AS d67785.r9 FROM {azure('b9')}", user=USER
+    )
+    assert "ACCESS_DENIED" in error, error
+    assert "READ ON AZURE" in error, error
+    assert (
+        node.query("SELECT count() FROM system.tables WHERE database = 'd67785' AND name = 'r9'")
+        == "0\n"
+    )
+
+    node.query(f"GRANT READ ON AZURE TO {USER}")
+    node.query(
+        f"RESTORE TABLE d67785.secrets AS d67785.r9 FROM {azure('b9')} FORMAT Null", user=USER
+    )
+    assert node.query("SELECT x FROM d67785.r9") == "42\n"
+    node.query("DROP TABLE d67785.r9 SYNC")
+
+
+def test_create_database_on_cluster_is_authorized_on_the_initiator(started_cluster):
+    # `is_create_database` returns from executeQueryOnCluster before DatabaseFactory runs, so
+    # only the initiator preflight can gate this; worker legs have no user by default.
+    node.query(f"BACKUP DATABASE d67785 TO {s3(DENIED + '/b7')} FORMAT Null")
+
+    error = node.query_and_get_error(
+        f"CREATE DATABASE dbcluster ON CLUSTER one_shard "
+        f"ENGINE = Backup('d67785', {s3(DENIED + '/b7')})",
+        user=USER,
+    )
+    assert "ACCESS_DENIED" in error, error
+    assert "READ ON S3" in error, error
+    assert (
+        node.query("SELECT count() FROM system.databases WHERE name = 'dbcluster'")
+        == "0\n"
+    )
+
+    node.query(f"GRANT READ ON S3('{DENIED}/.*') TO {USER}")
+    node.query(
+        f"CREATE DATABASE dbcluster ON CLUSTER one_shard "
+        f"ENGINE = Backup('d67785', {s3(DENIED + '/b7')})",
+        user=USER,
+    )
+    assert node.query("SELECT x FROM dbcluster.secrets") == "42\n"
+    node.query("DROP DATABASE dbcluster ON CLUSTER one_shard SYNC")
+
+
+def test_restore_on_cluster_authorizes_an_embedded_definition_over_an_existing_database(
+    started_cluster,
+):
+    # `CHECK_ACCESS_ONLY` runs in the initiator process for every host, so a local existence answer
+    # cannot stand in for the host that will actually create the database. Without the mode conjunct
+    # the check is skipped here and the restricted user reaches the embedded locator unchecked.
+    #
+    # The outer locator is File and IS granted, so a denial naming READ ON S3 can only come from the
+    # embedded S3 locator. `BACKUP DATABASE` serializes the locator as a string that
+    # `BackupInfo::fromAST` rejects before any check, so the function form is written into the
+    # manifest directly - the attacker-controlled-manifest shape this authorization exists for.
+    # Every locator here is credential-free (File locally, a 1-argument S3 URL in the manifest): the
+    # later definition-mismatch error logs both definitions, and a masked credential in that line
+    # trips the tests-only `throw_on_match` masking rule and aborts the server.
+    node.query("DROP DATABASE IF EXISTS dbembedded SYNC")
+    node.query("BACKUP DATABASE d67785 TO File('inner10') FORMAT Null")
+    node.query("CREATE DATABASE dbembedded ENGINE = Backup('d67785', File('inner10'))")
+    node.query("BACKUP DATABASE dbembedded TO File('outer10') FORMAT Null")
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "printf \"CREATE DATABASE dbembedded ENGINE = Backup('d67785', "
+            "S3('http://minio1:9001/root/data/denied/b10'))\\n\" "
+            "> /var/lib/clickhouse/backups/outer10/metadata/dbembedded.sql",
+        ],
+        user="root",
+    )
+
+    # The target database exists on the initiator, which is what used to skip the check.
+    assert node.query("SELECT count() FROM system.databases WHERE name = 'dbembedded'") == "1\n"
+    node.query(f"GRANT READ ON FILE TO {USER}")
+
+    error = node.query_and_get_error(
+        "RESTORE DATABASE dbembedded ON CLUSTER one_shard FROM File('outer10')", user=USER
+    )
+    assert "ACCESS_DENIED" in error, error
+    # Not the outer File locator, and not some other missing privilege.
+    assert "READ ON S3" in error, error
+
+    # With the grant, authorization passes: the restore proceeds past CHECKING_ACCESS_RIGHTS and
+    # fails later on the pre-existing string-vs-function definition mismatch instead.
+    node.query(f"GRANT READ ON S3 TO {USER}")
+    error = node.query_and_get_error(
+        "RESTORE DATABASE dbembedded ON CLUSTER one_shard FROM File('outer10')", user=USER
+    )
+    assert "ACCESS_DENIED" not in error, error
+    assert "CANNOT_RESTORE_DATABASE" in error, error
+
+    node.query("DROP DATABASE dbembedded SYNC")
+
+
+def test_restore_on_cluster_of_a_real_backup_engine_manifest_is_unchanged(started_cluster):
+    # The manifest is NOT crafted here, which is the point: `BACKUP DATABASE` serializes the inner
+    # locator as a string, and authorizing it would parse it and reject it with BAD_ARGUMENTS before
+    # any access decision. Only this shape can catch that, so it is a separate case from the crafted
+    # one - which asserts the security property but cannot see this class.
+    node.query("DROP DATABASE IF EXISTS dbreal SYNC")
+    node.query("BACKUP DATABASE d67785 TO File('inner11') FORMAT Null")
+    node.query("CREATE DATABASE dbreal ENGINE = Backup('d67785', File('inner11'))")
+    node.query("BACKUP DATABASE dbreal TO File('outer11') FORMAT Null")
+    manifest = node.exec_in_container(
+        ["bash", "-c", "cat /var/lib/clickhouse/backups/outer11/metadata/dbreal.sql"],
+        user="root",
+    )
+    # The locator really is the string form: an ASTLiteral, not an ASTFunction.
+    assert "Backup('d67785', 'File(\\'inner11\\')')" in manifest, manifest
+
+    # Only the outer locator's own grant; the string-form inner one must not be authorized at all.
+    node.query(f"GRANT READ ON FILE TO {USER}")
+
+    # Target exists, so nothing is created and the restore fully succeeds. Authorizing the string
+    # form turns this into `Code: 36` out of CHECKING_ACCESS_RIGHTS.
+    node.query(
+        "RESTORE DATABASE dbreal ON CLUSTER one_shard FROM File('outer11') FORMAT Null", user=USER
+    )
+
+    # Target absent, so creation runs and rejects the string form - as it does without this feature.
+    # `While creating database` is what pins the failure to the creation stage rather than the
+    # access-check one, which is where the same code would report it.
+    node.query("DROP DATABASE dbreal SYNC")
+    error = node.query_and_get_error(
+        "RESTORE DATABASE dbreal ON CLUSTER one_shard FROM File('outer11')", user=USER
+    )
+    assert "ACCESS_DENIED" not in error, error
+    assert "BAD_ARGUMENTS" in error, error
+    assert "While creating database" in error, error
+
+
+def test_explicit_base_backup_locator_is_authorized_on_the_initiator(started_cluster):
+    # A base backup opens lazily and a worker leg carries no user, so on RESTORE ON CLUSTER the
+    # workers read the base while the initiator never opens it at all: only a preflight before
+    # dispatch can authorize it. The outer locator is granted throughout, so a denial naming
+    # READ ON S3 can only come from the base.
+    #
+    # The table comment makes the two manifests differ, which is load-bearing: with identical
+    # metadata the initiator's own manifest write opens the base and denies for that reason
+    # instead, so the case would pass without the preflight. Only the data file dedups, and that
+    # read happens exclusively on the workers. Measured on a binary without the preflight: this
+    # RESTORE succeeds and hands the user the base's rows.
+    node.query("DROP TABLE IF EXISTS d67785.based SYNC")
+    node.query(
+        "CREATE TABLE d67785.based (x UInt64) ENGINE = MergeTree ORDER BY x "
+        "COMMENT 'a comment long enough that dropping it shrinks the .sql file'"
+    )
+    node.query("INSERT INTO d67785.based VALUES (7)")
+    node.query(f"BACKUP TABLE d67785.based TO {s3(DENIED + '/base12')} FORMAT Null")
+    node.query("ALTER TABLE d67785.based MODIFY COMMENT ''")
+    node.query(
+        f"BACKUP TABLE d67785.based TO {s3(ALLOWED + '/outer12')} "
+        f"SETTINGS base_backup={s3(DENIED + '/base12')} FORMAT Null"
+    )
+
+    node.query(f"GRANT SELECT, INSERT ON d67785.based TO {USER}")
+    node.query(f"GRANT WRITE ON S3('{ALLOWED}/.*') TO {USER}")
+    node.query(f"GRANT READ ON S3('{ALLOWED}/.*') TO {USER}")
+
+    error = node.query_and_get_error(
+        f"RESTORE TABLE d67785.based AS d67785.r12 ON CLUSTER one_shard "
+        f"FROM {s3(ALLOWED + '/outer12')} SETTINGS base_backup={s3(DENIED + '/base12')}",
+        user=USER,
+    )
+    assert "ACCESS_DENIED" in error, error
+    assert "READ ON S3" in error, error
+    assert (
+        node.query("SELECT count() FROM system.tables WHERE database = 'd67785' AND name = 'r12'")
+        == "0\n"
+    )
+
+    # An incremental BACKUP reads its base, so the base is READ even though the outer locator is
+    # WRITE. A denial naming WRITE ON S3 would mean the base inherited the outer's direction.
+    error = node.query_and_get_error(
+        f"BACKUP TABLE d67785.based ON CLUSTER one_shard TO {s3(ALLOWED + '/inc12')} "
+        f"SETTINGS base_backup={s3(DENIED + '/base12')}",
+        user=USER,
+    )
+    assert "ACCESS_DENIED" in error, error
+    assert "READ ON S3" in error, error
+
+    node.query(f"GRANT READ ON S3('{DENIED}/.*') TO {USER}")
+    node.query(
+        f"BACKUP TABLE d67785.based ON CLUSTER one_shard TO {s3(ALLOWED + '/inc12')} "
+        f"SETTINGS base_backup={s3(DENIED + '/base12')} FORMAT Null",
+        user=USER,
+    )
+    node.query(
+        f"RESTORE TABLE d67785.based AS d67785.r12 ON CLUSTER one_shard "
+        f"FROM {s3(ALLOWED + '/outer12')} SETTINGS base_backup={s3(DENIED + '/base12')} FORMAT Null",
+        user=USER,
+    )
+    # The row lives in the base: `outer12`'s data file deduplicated fully against it, so a correct
+    # value here also proves the base really is read rather than skipped.
+    assert node.query("SELECT x FROM d67785.r12") == "7\n"
+    node.query("DROP TABLE d67785.r12 SYNC")
+    node.query("DROP TABLE d67785.based SYNC")
+
+
+def test_on_cluster_is_authorized_on_the_initiator(started_cluster):
+    # A worker leg runs with no user by default, so the initiator must reject the query before
+    # distributing it; and a granted user's ON CLUSTER backup must keep working.
+    error = node.query_and_get_error(
+        f"BACKUP TABLE d67785.secrets ON CLUSTER one_shard TO {s3(DENIED + '/b4')}", user=USER
+    )
+    assert "ACCESS_DENIED" in error, error
+    # The denial must be the source check, not some other missing privilege.
+    assert "WRITE ON S3" in error, error
+
+    node.query(f"GRANT WRITE ON S3 TO {USER}")
+    node.query(
+        f"BACKUP TABLE d67785.secrets ON CLUSTER one_shard TO {s3(ALLOWED + '/b4')} FORMAT Null",
+        user=USER,
+    )

--- a/tests/integration/test_backup_source_grants/test.py
+++ b/tests/integration/test_backup_source_grants/test.py
@@ -188,6 +188,39 @@ def test_azure_destination_requires_the_matching_direction(started_cluster):
     node.query("DROP TABLE d67785.r9 SYNC")
 
 
+def test_azure_filtered_grant_matches_the_blob_path(started_cluster):
+    # The whole-source case above would still pass if the hook returned an empty URI, which is what
+    # a filtered grant distinguishes: an empty URI can only be satisfied whole-source. It also pins
+    # WHICH string the filter is matched against - the blob path inside the container, the same one
+    # the `azureBlobStorage` table function authorizes, not a URL carrying account and container.
+    node.query(f"GRANT WRITE ON AZURE('backups/.*') TO {USER}")
+
+    node.query(f"BACKUP TABLE d67785.secrets TO {azure('backups/az_ok')} FORMAT Null", user=USER)
+
+    error = node.query_and_get_error(
+        f"BACKUP TABLE d67785.secrets TO {azure('other/az_denied')}", user=USER
+    )
+    assert "ACCESS_DENIED" in error, error
+    assert "WRITE ON AZURE" in error, error
+
+
+def test_archive_locator_is_authorized_with_the_archive_name(started_cluster):
+    # The locator is captured before a trailing archive filename is stripped from it, so the grant
+    # must match the path WITH the archive name. A filter for the containing directory alone must
+    # not be enough, otherwise the pre-split field has silently regressed to the stripped path.
+    node.query(f"GRANT WRITE ON S3('{ALLOWED}/arc/b.tar.gz') TO {USER}")
+
+    node.query(
+        f"BACKUP TABLE d67785.secrets TO {s3(ALLOWED + '/arc/b.tar.gz')} FORMAT Null", user=USER
+    )
+
+    error = node.query_and_get_error(
+        f"BACKUP TABLE d67785.secrets TO {s3(ALLOWED + '/arc/other.tar.gz')}", user=USER
+    )
+    assert "ACCESS_DENIED" in error, error
+    assert "WRITE ON S3" in error, error
+
+
 def test_create_database_on_cluster_is_authorized_on_the_initiator(started_cluster):
     # `is_create_database` returns from executeQueryOnCluster before DatabaseFactory runs, so
     # only the initiator preflight can gate this; worker legs have no user by default.

--- a/tests/queries/0_stateless/04774_backup_destination_source_grants.reference
+++ b/tests/queries/0_stateless/04774_backup_destination_source_grants.reference
@@ -34,5 +34,7 @@ Code: 82
 1
 -- with READ ON FILE as well: allowed
 allowed
+-- the source grant a BACKUP consumed is accounted to the BACKUP query
+1
 -- an admin holding SOURCES is unaffected
 42

--- a/tests/queries/0_stateless/04774_backup_destination_source_grants.reference
+++ b/tests/queries/0_stateless/04774_backup_destination_source_grants.reference
@@ -1,0 +1,38 @@
+-- BACKUP without WRITE ON FILE: denied, and it names the missing grant
+1
+-- BACKUP with WRITE ON FILE: allowed
+allowed
+-- RESTORE without READ ON FILE: denied
+denied
+-- the table was not created by the rejected restore
+0
+-- RESTORE with READ ON FILE: allowed
+allowed
+42
+-- CREATE DATABASE ENGINE = Backup without READ ON FILE: denied
+denied
+-- the database was not created
+0
+-- CREATE DATABASE ENGINE = Backup with READ ON FILE: allowed and readable
+allowed
+42
+-- WRITE ON FILE alone does not authorize reading a backup
+denied
+-- Disk(...) is exempt in this change: still allowed with SOURCES revoked
+allowed
+allowed
+-- re-attaching an already-authorized database does not re-demand the grant
+allowed
+42
+-- a full definition is a new definition, so it is still validated
+denied
+-- restoring over an existing Backup-engine database does not demand the inner locator
+allowed
+-- under create_database='create' the pre-existing DATABASE_ALREADY_EXISTS survives
+Code: 82
+-- an explicit base_backup locator is authorized for reading, not for the outer direction
+1
+-- with READ ON FILE as well: allowed
+allowed
+-- an admin holding SOURCES is unaffected
+42

--- a/tests/queries/0_stateless/04774_backup_destination_source_grants.sh
+++ b/tests/queries/0_stateless/04774_backup_destination_source_grants.sh
@@ -124,6 +124,22 @@ ${CLICKHOUSE_CLIENT} -q "GRANT READ ON FILE TO $user"
 deny_or_allow "BACKUP TABLE $src.t TO File('${CLICKHOUSE_TEST_UNIQUE_NAME}/b_inc_ok') SETTINGS base_backup=$bk FORMAT Null"
 ${CLICKHOUSE_CLIENT} -q "REVOKE READ, WRITE ON FILE FROM $user"
 
+echo "-- the source grant a BACKUP consumed is accounted to the BACKUP query"
+# `BackupStarter` runs the check on a copy of the query context, whose `QueryPrivilegesInfo` is
+# reset by `makeQueryContext`, so the grant reaches system.query_log only while that tracker is
+# shared with the originating query.
+audit_qid="04774_audit_${CLICKHOUSE_DATABASE}"
+${CLICKHOUSE_CLIENT} -q "GRANT WRITE ON FILE TO $user"
+${CLICKHOUSE_CLIENT} --user "$user" --query_id "$audit_qid" -q \
+    "BACKUP TABLE $src.t TO File('${CLICKHOUSE_TEST_UNIQUE_NAME}/b_audit') FORMAT Null"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS query_log"
+${CLICKHOUSE_CLIENT} -q "
+SELECT has(used_privileges, 'WRITE ON FILE')
+FROM system.query_log
+WHERE query_id = '$audit_qid' AND type = 'QueryFinish' AND current_database = currentDatabase()
+ORDER BY event_time_microseconds DESC LIMIT 1"
+${CLICKHOUSE_CLIENT} -q "REVOKE WRITE ON FILE FROM $user"
+
 echo "-- an admin holding SOURCES is unaffected"
 ${CLICKHOUSE_CLIENT} -q "BACKUP TABLE $src.t TO File('${CLICKHOUSE_TEST_UNIQUE_NAME}/b_adm') FORMAT Null"
 ${CLICKHOUSE_CLIENT} -q "RESTORE TABLE $src.t AS $db.r_adm FROM $bk FORMAT Null"

--- a/tests/queries/0_stateless/04774_backup_destination_source_grants.sh
+++ b/tests/queries/0_stateless/04774_backup_destination_source_grants.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Tags: no-encrypted-storage, no-replicated-database
+# no-replicated-database: the CREATE DATABASE runs with no user there, so its check is a no-op.
+
+# BACKUP/RESTORE and `ENGINE = Backup` must authorize the backup location against the SOURCES grant
+# model, like the matching table functions do. Without the fix, a user with SOURCES revoked can write
+# a backup to (and read one from) any location the server can reach.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+db=${CLICKHOUSE_DATABASE}
+user="user_04774_${CLICKHOUSE_DATABASE}"
+src="${CLICKHOUSE_TEST_UNIQUE_NAME}_src"
+bk="File('${CLICKHOUSE_TEST_UNIQUE_NAME}/b')"
+bk_disk="Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_disk')"
+
+${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS $user"
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS $src"
+${CLICKHOUSE_CLIENT} --multiquery -q "
+CREATE DATABASE $src;
+CREATE TABLE $src.t (x UInt64) ENGINE = MergeTree ORDER BY x;
+INSERT INTO $src.t VALUES (42);
+CREATE USER $user;
+GRANT BACKUP ON $src.* TO $user;
+GRANT CREATE DATABASE, DROP DATABASE ON *.* TO $user;
+GRANT CREATE TABLE, INSERT, SELECT ON $db.* TO $user;
+GRANT SELECT ON $src.* TO $user;
+GRANT SELECT ON ${db}_b2.* TO $user;
+-- Needed under table_engines_require_grant; the wildcard is the only spelling that reaches the
+-- Backup DATABASE engine. It confers no SOURCES, so every denial below still comes from SOURCES.
+GRANT TABLE ENGINE ON *.* TO $user;
+REVOKE SOURCES ON *.* FROM $user;
+"
+# An admin-made backup the restricted user will try to read.
+${CLICKHOUSE_CLIENT} -q "BACKUP DATABASE $src TO $bk FORMAT Null"
+${CLICKHOUSE_CLIENT} -q "BACKUP DATABASE $src TO $bk_disk FORMAT Null"
+
+deny_or_allow() {
+    local out
+    out=$(${CLICKHOUSE_CLIENT} --user "$user" -q "$1" 2>&1)
+    if [ $? -eq 0 ]; then echo "allowed"
+    elif echo "$out" | grep -q 'ACCESS_DENIED'; then echo "denied"
+    else echo "unexpected: $(echo "$out" | grep -oE 'Code: [0-9]+' | head -1)"; fi
+}
+
+# For a case whose expected outcome is a specific error other than an access denial.
+deny_or_code() {
+    local out
+    out=$(${CLICKHOUSE_CLIENT} --user "$user" -q "$1" 2>&1)
+    if [ $? -eq 0 ]; then echo "allowed"
+    elif echo "$out" | grep -q 'ACCESS_DENIED'; then echo "denied"
+    else echo "$out" | grep -oE 'Code: [0-9]+' | head -1; fi
+}
+
+echo "-- BACKUP without WRITE ON FILE: denied, and it names the missing grant"
+${CLICKHOUSE_CLIENT} --user "$user" -q \
+    "BACKUP TABLE $src.t TO File('${CLICKHOUSE_TEST_UNIQUE_NAME}/b_denied') FORMAT Null" 2>&1 \
+    | grep -c -m1 'WRITE ON FILE'
+echo "-- BACKUP with WRITE ON FILE: allowed"
+${CLICKHOUSE_CLIENT} -q "GRANT WRITE ON FILE TO $user"
+deny_or_allow "BACKUP TABLE $src.t TO File('${CLICKHOUSE_TEST_UNIQUE_NAME}/b_ok') FORMAT Null"
+${CLICKHOUSE_CLIENT} -q "REVOKE WRITE ON FILE FROM $user"
+
+echo "-- RESTORE without READ ON FILE: denied"
+deny_or_allow "RESTORE TABLE $src.t AS $db.r1 FROM $bk FORMAT Null"
+echo "-- the table was not created by the rejected restore"
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.tables WHERE database = '$db' AND name = 'r1'"
+echo "-- RESTORE with READ ON FILE: allowed"
+${CLICKHOUSE_CLIENT} -q "GRANT READ ON FILE TO $user"
+deny_or_allow "RESTORE TABLE $src.t AS $db.r2 FROM $bk FORMAT Null"
+${CLICKHOUSE_CLIENT} --user "$user" -q "SELECT x FROM $db.r2"
+${CLICKHOUSE_CLIENT} -q "REVOKE READ ON FILE FROM $user"
+
+echo "-- CREATE DATABASE ENGINE = Backup without READ ON FILE: denied"
+deny_or_allow "CREATE DATABASE ${db}_b1 ENGINE = Backup('$src', $bk)"
+echo "-- the database was not created"
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.databases WHERE name = '${db}_b1'"
+echo "-- CREATE DATABASE ENGINE = Backup with READ ON FILE: allowed and readable"
+${CLICKHOUSE_CLIENT} -q "GRANT READ ON FILE TO $user"
+deny_or_allow "CREATE DATABASE ${db}_b2 ENGINE = Backup('$src', $bk)"
+${CLICKHOUSE_CLIENT} --user "$user" -q "SELECT x FROM ${db}_b2.t"
+${CLICKHOUSE_CLIENT} -q "REVOKE READ ON FILE FROM $user"
+
+echo "-- WRITE ON FILE alone does not authorize reading a backup"
+${CLICKHOUSE_CLIENT} -q "GRANT WRITE ON FILE TO $user"
+deny_or_allow "RESTORE TABLE $src.t AS $db.r3 FROM $bk FORMAT Null"
+${CLICKHOUSE_CLIENT} -q "REVOKE WRITE ON FILE FROM $user"
+
+echo "-- Disk(...) is exempt in this change: still allowed with SOURCES revoked"
+deny_or_allow "BACKUP TABLE $src.t TO Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_disk2') FORMAT Null"
+deny_or_allow "CREATE DATABASE ${db}_b3 ENGINE = Backup('$src', $bk_disk)"
+
+echo "-- re-attaching an already-authorized database does not re-demand the grant"
+${CLICKHOUSE_CLIENT} --user "$user" -q "DETACH DATABASE ${db}_b2"
+deny_or_allow "ATTACH DATABASE ${db}_b2"
+${CLICKHOUSE_CLIENT} --user "$user" -q "SELECT x FROM ${db}_b2.t"
+
+echo "-- a full definition is a new definition, so it is still validated"
+deny_or_allow "ATTACH DATABASE ${db}_b4 ENGINE = Backup('$src', $bk)"
+
+echo "-- restoring over an existing Backup-engine database does not demand the inner locator"
+# An existing database makes creation a no-op (create_database='if not exists') or an error
+# (create_database='create'), so the definition found in the backup is never constructed and must
+# not be authorized either. Under 'create' the pre-existing DATABASE_ALREADY_EXISTS must survive.
+${CLICKHOUSE_CLIENT} -q "GRANT READ ON FILE TO $user"
+${CLICKHOUSE_CLIENT} -q "BACKUP DATABASE ${db}_b2 TO File('${CLICKHOUSE_TEST_UNIQUE_NAME}/b_outer') FORMAT Null"
+deny_or_allow "RESTORE DATABASE ${db}_b2 FROM File('${CLICKHOUSE_TEST_UNIQUE_NAME}/b_outer') FORMAT Null"
+echo "-- under create_database='create' the pre-existing DATABASE_ALREADY_EXISTS survives"
+deny_or_code "RESTORE DATABASE ${db}_b2 FROM File('${CLICKHOUSE_TEST_UNIQUE_NAME}/b_outer') SETTINGS create_database='create' FORMAT Null"
+${CLICKHOUSE_CLIENT} -q "REVOKE READ ON FILE FROM $user"
+
+echo "-- an explicit base_backup locator is authorized for reading, not for the outer direction"
+# The outer locator is written, so only the base can demand READ. A whole-source FILE grant cannot
+# distinguish the two locators, which is why the informative arm is the incremental BACKUP one: with
+# WRITE granted, a denial can only come from the base.
+${CLICKHOUSE_CLIENT} -q "GRANT WRITE ON FILE TO $user"
+${CLICKHOUSE_CLIENT} --user "$user" -q \
+    "BACKUP TABLE $src.t TO File('${CLICKHOUSE_TEST_UNIQUE_NAME}/b_inc_denied') SETTINGS base_backup=$bk FORMAT Null" 2>&1 \
+    | grep -c -m1 'READ ON FILE'
+echo "-- with READ ON FILE as well: allowed"
+${CLICKHOUSE_CLIENT} -q "GRANT READ ON FILE TO $user"
+deny_or_allow "BACKUP TABLE $src.t TO File('${CLICKHOUSE_TEST_UNIQUE_NAME}/b_inc_ok') SETTINGS base_backup=$bk FORMAT Null"
+${CLICKHOUSE_CLIENT} -q "REVOKE READ, WRITE ON FILE FROM $user"
+
+echo "-- an admin holding SOURCES is unaffected"
+${CLICKHOUSE_CLIENT} -q "BACKUP TABLE $src.t TO File('${CLICKHOUSE_TEST_UNIQUE_NAME}/b_adm') FORMAT Null"
+${CLICKHOUSE_CLIENT} -q "RESTORE TABLE $src.t AS $db.r_adm FROM $bk FORMAT Null"
+${CLICKHOUSE_CLIENT} -q "SELECT x FROM $db.r_adm"
+
+${CLICKHOUSE_CLIENT} --multiquery -q "
+DROP DATABASE IF EXISTS ${db}_b1;
+DROP DATABASE IF EXISTS ${db}_b2;
+DROP DATABASE IF EXISTS ${db}_b3;
+DROP DATABASE IF EXISTS ${db}_b4;
+DROP DATABASE IF EXISTS $src;
+DROP USER IF EXISTS $user;
+"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/113073

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`BACKUP`, `RESTORE` and `ENGINE = Backup` now authorize the backup location against the user's `SOURCES` grants, the same way `s3()`, `file()` and `azureBlobStorage()` do. Previously a user holding `BACKUP` but not `SOURCES` could write a backup to, and read one from, any location the server could reach. Writing a backup now requires the `WRITE` direction on the destination's source (`WRITE ON S3`, `WRITE ON AZURE`, `WRITE ON FILE`) and reading one requires `READ`; `Disk(...)` destinations stay restricted by `backups.allowed_disk` only.


### Description

A user with `SOURCES ON *.*` revoked could still name any `S3`, `AzureBlobStorage` or `File` location as a backup destination or restore source, so `BACKUP` alone was enough to exfiltrate data to an arbitrary bucket and to read back any backup the server could reach.

Each engine now declares the grant its location requires, and the check runs in `BackupFactory::createBackup` before any I/O. Needing no I/O itself, it also runs as a preflight at the four other points that still execute as the real user: an explicit `base_backup` (opened lazily, on the workers), `CREATE DATABASE ... ENGINE = Backup` under `ON CLUSTER` (which returns from `executeQueryOnCluster` before `DatabaseFactory` runs), an `ENGINE = Backup` definition embedded in a restored manifest, and a newly introduced `Backup` database definition. Worker legs run with no user, hence full access, so a check only there would enforce nothing.

`Disk(...)` is deliberately exempt: an allowlisted disk may be local, S3- or Azure-backed, so no single source describes it, and `backups.allowed_disk` already bounds it. A named collection is authorized whole-source rather than on the URL it currently resolves to, since it can be re-pointed after the check.

Validated by a stateless test and an 11-case integration suite over MinIO and Azurite. Each of the five sites was verified by reverting it alone and confirming a test reddens.

Two pre-existing gaps of the same class are **not** addressed here, described in a comment below: a base locator taken from a manifest rather than the setting, and the lightweight-snapshot manifest fields. I would rather take your call on scope than guess.

#113073 touches the same call site and is complementary; whichever merges second needs a trivial rebase there.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1384` (included in `26.8` and later)
<!-- ch-version-info:end -->