### PR TITLE
Do not throw a logical error when an ephemeral node is held by someone else

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -43,6 +43,7 @@ namespace DB
 {
 namespace ErrorCodes
 {
+    extern const int ABORTED;
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
     extern const int NO_ELEMENTS_IN_CONFIG;
@@ -1460,7 +1461,7 @@ void ZooKeeper::deleteEphemeralNodeIfContentMatches(const std::string & path, st
         int32_t timeout_ms = 3 * args.session_timeout_ms;
         if (!eph_node_disappeared->tryWait(timeout_ms))
             throw DB::Exception(
-                DB::ErrorCodes::LOGICAL_ERROR,
+                DB::ErrorCodes::ABORTED,
                 "Ephemeral node {} still exists after {}s, probably it's owned by someone else. "
                 "Either session_timeout_ms in client's config is different from server's config or it's a bug. "
                 "Node data: '{}'",

--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -1462,9 +1462,9 @@ void ZooKeeper::deleteEphemeralNodeIfContentMatches(const std::string & path, st
         if (!eph_node_disappeared->tryWait(timeout_ms))
             throw DB::Exception(
                 DB::ErrorCodes::ABORTED,
-                "Ephemeral node {} still exists after {}s, probably it's owned by someone else. "
-                "Either session_timeout_ms in client's config is different from server's config or it's a bug. "
-                "Node data: '{}'",
+                "Ephemeral node {} still exists after {}s and is not owned by us: most likely another session "
+                "still holds it, or a previous session's node has not expired yet. It can also mean that "
+                "session_timeout_ms in the client's config differs from the server's. Node data: '{}'",
                 path,
                 timeout_ms / 1000,
                 content);

--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -1452,8 +1452,7 @@ void ZooKeeper::deleteEphemeralNodeIfContentMatches(const std::string & path, st
     if (condition(content))
     {
         auto code = tryRemove(path, stat.version);
-        /// A version mismatch means the node was rewritten after it was read, so it is no longer the node
-        /// the condition accepted. Someone else owns it now, which is the same runtime state as below.
+        /// The node was rewritten after it was read, so the condition no longer describes it.
         if (code == Coordination::Error::ZBADVERSION)
             throw DB::Exception(
                 DB::ErrorCodes::REPLICA_ALREADY_EXISTS,

--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -43,9 +43,9 @@ namespace DB
 {
 namespace ErrorCodes
 {
-    extern const int ABORTED;
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
+    extern const int REPLICA_ALREADY_EXISTS;
     extern const int NO_ELEMENTS_IN_CONFIG;
     extern const int EXCESSIVE_ELEMENT_IN_CONFIG;
 }
@@ -1452,6 +1452,14 @@ void ZooKeeper::deleteEphemeralNodeIfContentMatches(const std::string & path, st
     if (condition(content))
     {
         auto code = tryRemove(path, stat.version);
+        /// A version mismatch means the node was rewritten after it was read, so it is no longer the node
+        /// the condition accepted. Someone else owns it now, which is the same runtime state as below.
+        if (code == Coordination::Error::ZBADVERSION)
+            throw DB::Exception(
+                DB::ErrorCodes::REPLICA_ALREADY_EXISTS,
+                "Ephemeral node {} was rewritten while it was being removed. Node data when it was read: '{}'",
+                path,
+                content);
         if (code != Coordination::Error::ZOK && code != Coordination::Error::ZNONODE)
             throw Coordination::Exception::fromPath(code, path);
     }
@@ -1461,7 +1469,7 @@ void ZooKeeper::deleteEphemeralNodeIfContentMatches(const std::string & path, st
         int32_t timeout_ms = 3 * args.session_timeout_ms;
         if (!eph_node_disappeared->tryWait(timeout_ms))
             throw DB::Exception(
-                DB::ErrorCodes::ABORTED,
+                DB::ErrorCodes::REPLICA_ALREADY_EXISTS,
                 "Ephemeral node {} still exists after {}s and is not owned by us: most likely another session "
                 "still holds it, or a previous session's node has not expired yet. It can also mean that "
                 "session_timeout_ms in the client's config differs from the server's. Node data: '{}'",

--- a/src/Common/ZooKeeper/ZooKeeper.h
+++ b/src/Common/ZooKeeper/ZooKeeper.h
@@ -492,7 +492,7 @@ public:
 
     /// Checks if a the ephemeral node exists. These nodes are removed automatically by ZK when the session ends
     /// If the node exists and its value is equal to fast_delete_if_equal_value it will remove it
-    /// If the node exists and its value is different, it will wait for it to disappear. It will throw a LOGICAL_ERROR if the node doesn't
+    /// If the node exists and its value is different, it will wait for it to disappear. It will throw ABORTED if the node doesn't
     /// disappear automatically after 3x session_timeout.
     void deleteEphemeralNodeIfContentMatches(const std::string & path, const std::string & fast_delete_if_equal_value);
     void deleteEphemeralNodeIfContentMatches(const std::string & path, std::function<bool(const std::string &)> condition);

--- a/src/Common/ZooKeeper/ZooKeeper.h
+++ b/src/Common/ZooKeeper/ZooKeeper.h
@@ -492,8 +492,9 @@ public:
 
     /// Checks if a the ephemeral node exists. These nodes are removed automatically by ZK when the session ends
     /// If the node exists and its value is equal to fast_delete_if_equal_value it will remove it
-    /// If the node exists and its value is different, it will wait for it to disappear. It will throw ABORTED if the node doesn't
-    /// disappear automatically after 3x session_timeout.
+    /// If the node exists and its value is different, it will wait for it to disappear. It will throw
+    /// REPLICA_ALREADY_EXISTS if the node doesn't disappear automatically after 3x session_timeout, or if it was
+    /// rewritten between the read and the removal.
     void deleteEphemeralNodeIfContentMatches(const std::string & path, const std::string & fast_delete_if_equal_value);
     void deleteEphemeralNodeIfContentMatches(const std::string & path, std::function<bool(const std::string &)> condition);
 

--- a/src/Common/ZooKeeper/tests/gtest_zookeeper.cpp
+++ b/src/Common/ZooKeeper/tests/gtest_zookeeper.cpp
@@ -3,12 +3,67 @@
 
 #include <Common/ZooKeeper/Types.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
+#include <Common/ZooKeeper/ZooKeeperArgs.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+
 using namespace Coordination;
 using namespace DB;
+
+namespace DB::ErrorCodes
+{
+    extern const int ABORTED;
+}
+
+namespace
+{
+
+zkutil::ZooKeeper::Ptr makeTestKeeperClient(int32_t session_timeout_ms)
+{
+    zkutil::ZooKeeperArgs args;
+    args.implementation = "testkeeper";
+    args.session_timeout_ms = session_timeout_ms;
+    return zkutil::ZooKeeper::createWithoutKillingPreviousSessions(args);
+}
+
+}
+
+TEST(ZooKeeperTest, DeleteEphemeralNodeIfContentMatchesForeignHolder)
+{
+    /// The node is persistent, so it never disappears and the wait always reaches its deadline.
+    constexpr int32_t session_timeout_ms = 200;
+    auto zk = makeTestKeeperClient(session_timeout_ms);
+    zk->create("/foreign", "someone-else", zkutil::CreateMode::Persistent);
+
+    const auto started_at = std::chrono::steady_clock::now();
+    try
+    {
+        zk->deleteEphemeralNodeIfContentMatches("/foreign", "me");
+        FAIL() << "Expected an exception for a node held by someone else";
+    }
+    catch (const DB::Exception & e)
+    {
+        /// A foreign or not-yet-expired holder is expected runtime state, not a broken invariant.
+        EXPECT_EQ(e.code(), DB::ErrorCodes::ABORTED);
+    }
+    const auto elapsed_ms
+        = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started_at).count();
+
+    EXPECT_GE(elapsed_ms, 3 * session_timeout_ms);
+    EXPECT_TRUE(zk->exists("/foreign"));
+}
+
+TEST(ZooKeeperTest, DeleteEphemeralNodeIfContentMatchesOwnNode)
+{
+    auto zk = makeTestKeeperClient(/*session_timeout_ms=*/ 200);
+    zk->create("/mine", "me", zkutil::CreateMode::Persistent);
+
+    EXPECT_NO_THROW(zk->deleteEphemeralNodeIfContentMatches("/mine", "me"));
+    EXPECT_FALSE(zk->exists("/mine"));
+}
 
 TEST(ZooKeeperTest, TestMatchPath)
 {

--- a/src/Common/ZooKeeper/tests/gtest_zookeeper.cpp
+++ b/src/Common/ZooKeeper/tests/gtest_zookeeper.cpp
@@ -42,7 +42,7 @@ TEST(ZooKeeperTest, DeleteEphemeralNodeIfContentMatchesForeignHolder)
     try
     {
         zk->deleteEphemeralNodeIfContentMatches("/foreign", "me");
-        FAIL() << "Expected an exception for a node held by someone else";
+        ADD_FAILURE() << "Expected an exception for a node held by someone else";
     }
     catch (const DB::Exception & e)
     {

--- a/src/Common/ZooKeeper/tests/gtest_zookeeper.cpp
+++ b/src/Common/ZooKeeper/tests/gtest_zookeeper.cpp
@@ -15,7 +15,7 @@ using namespace DB;
 
 namespace DB::ErrorCodes
 {
-    extern const int ABORTED;
+    extern const int REPLICA_ALREADY_EXISTS;
 }
 
 namespace
@@ -47,7 +47,7 @@ TEST(ZooKeeperTest, DeleteEphemeralNodeIfContentMatchesForeignHolder)
     catch (const DB::Exception & e)
     {
         /// A foreign or not-yet-expired holder is expected runtime state, not a broken invariant.
-        EXPECT_EQ(e.code(), DB::ErrorCodes::ABORTED);
+        EXPECT_EQ(e.code(), DB::ErrorCodes::REPLICA_ALREADY_EXISTS);
     }
     const auto elapsed_ms
         = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started_at).count();
@@ -63,6 +63,30 @@ TEST(ZooKeeperTest, DeleteEphemeralNodeIfContentMatchesOwnNode)
 
     EXPECT_NO_THROW(zk->deleteEphemeralNodeIfContentMatches("/mine", "me"));
     EXPECT_FALSE(zk->exists("/mine"));
+}
+
+TEST(ZooKeeperTest, DeleteEphemeralNodeIfContentMatchesRewrittenNode)
+{
+    auto zk = makeTestKeeperClient(/*session_timeout_ms=*/ 200);
+    zk->create("/rewritten", "me", zkutil::CreateMode::Persistent);
+
+    try
+    {
+        /// The condition runs after the node and its version have been read, so writing from here makes the
+        /// versioned removal lose the same race a concurrent writer would cause.
+        zk->deleteEphemeralNodeIfContentMatches("/rewritten", [&](const std::string & content)
+        {
+            zk->set("/rewritten", "me");
+            return content == "me";
+        });
+        ADD_FAILURE() << "Expected an exception for a node rewritten while it was being removed";
+    }
+    catch (const DB::Exception & e)
+    {
+        EXPECT_EQ(e.code(), DB::ErrorCodes::REPLICA_ALREADY_EXISTS);
+    }
+
+    EXPECT_TRUE(zk->exists("/rewritten"));
 }
 
 TEST(ZooKeeperTest, TestMatchPath)

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -1496,6 +1496,12 @@ void DDLWorker::markReplicasActive(bool reinitialized)
                 }
 
                 auto code = zookeeper->tryRemove(active_path, stat.version);
+                if (code == Coordination::Error::ZBADVERSION)
+                {
+                    // The node was rewritten after it was read, so the check above no longer describes it.
+                    LOG_TRACE(log, "Loopback host {} was rewritten while it was being claimed, skipping it", host_id);
+                    continue;
+                }
                 if (code != Coordination::Error::ZOK && code != Coordination::Error::ZNONODE)
                     throw Coordination::Exception::fromPath(code, active_path);
             }

--- a/tests/integration/test_replicated_database_active_node_taken/configs/cluster.xml
+++ b/tests/integration/test_replicated_database_active_node_taken/configs/cluster.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <remote_servers>
+        <two_nodes>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </two_nodes>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_replicated_database_active_node_taken/configs/zookeeper.xml
+++ b/tests/integration/test_replicated_database_active_node_taken/configs/zookeeper.xml
@@ -1,0 +1,19 @@
+<clickhouse>
+    <zookeeper>
+        <node index="1">
+            <host>zoo1</host>
+            <port>2181</port>
+        </node>
+        <node index="2">
+            <host>zoo2</host>
+            <port>2181</port>
+        </node>
+        <node index="3">
+            <host>zoo3</host>
+            <port>2181</port>
+        </node>
+        <!-- The replica waits 3x this before reporting the node as taken, so the default 15s would
+             make the test wait 45s. Kept well above a real round-trip to stay safe under sanitizers. -->
+        <session_timeout_ms>3000</session_timeout_ms>
+    </zookeeper>
+</clickhouse>

--- a/tests/integration/test_replicated_database_active_node_taken/test.py
+++ b/tests/integration/test_replicated_database_active_node_taken/test.py
@@ -1,0 +1,62 @@
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__, zookeeper_config_path="configs/zookeeper.xml")
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/cluster.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+)
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/cluster.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+)
+
+DATABASE = "db_active_node_taken"
+NODES = (node1, node2)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_active_node_owned_by_another_server(started_cluster):
+    # ON CLUSTER assigns one database UUID to every host, and literal shard/replica names make both
+    # hosts the same replica, so one of them finds <replica_path>/active owned by the live other one.
+    # The database is left unusable (issue #115818), but the failure is reachable from a single
+    # user query, so it must not be reported as a logical error.
+    node1.query(
+        f"CREATE DATABASE {DATABASE} ON CLUSTER 'two_nodes' "
+        f"ENGINE = Replicated('/clickhouse/databases/{DATABASE}', 's1', 'r1')",
+        settings={"distributed_ddl_task_timeout": 60},
+    )
+
+    # REPLICA_ALREADY_EXISTS, reported by the losing replica's own DDL worker after 3x session_timeout_ms.
+    expected = f"Error on initialization of {DATABASE}: Code: 253"
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        if any(node.contains_in_log(expected) for node in NODES):
+            break
+        time.sleep(1)
+    else:
+        raise AssertionError(f"No replica reported '{expected}'")
+
+    assert any(
+        node.contains_in_log("still exists after .*s and is not owned by us") for node in NODES
+    )
+
+    for node in NODES:
+        assert not node.contains_in_log("Logical error: 'Ephemeral node")
+        assert node.query("SELECT 1") == "1\n"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Related: https://github.com/ClickHouse/ClickHouse/issues/115818
Related: https://github.com/ClickHouse/ClickHouse/pull/113913
Related: https://github.com/ClickHouse/ClickHouse/issues/86434


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Activating a replica whose `active`/`is_active` node in Keeper is still held by another session is now reported as `REPLICA_ALREADY_EXISTS` instead of `LOGICAL_ERROR`, so it no longer aborts the server in debug and sanitizer builds. The same applies when that node is rewritten while it is being removed.


### Description

Related: #115818, #113913, #86434

`deleteEphemeralNodeIfContentMatches` finds the node held by a foreign owner, logs `isn't owned by us. Will wait until it disappears`, waits `3 * session_timeout_ms`, and then threw `LOGICAL_ERROR`. That is reachable from a single user query: in #115818 one `CREATE DATABASE ... ON CLUSTER` with literal shard and replica names makes two hosts the same replica, and the loser then aborts every 45s in debug builds. It is also ordinary runtime state, because Keeper drops a dead session's ephemerals only at expiry while activation retries sooner.

It is now reported as `REPLICA_ALREADY_EXISTS`, which is what the non-distributed path already returns for the same misconfiguration. `ABORTED` is raised from 66 places in `src/`, `REPLICA_ALREADY_EXISTS` from 7 others and every one of them is this same condition, so `system.errors` still separates an identity collision from a cancelled query. The wait, the control flow and all six call sites are unchanged, and none of them branches on the error code.

The fast-delete branch of the same function had the same defect. `tryRemove(path, stat.version)` rethrows every code other than `ZNONODE` as a `Coordination::Exception`, and a non-hardware one reaches `chassert(false)` in `DDLWorker::initializeMainThread`. The reachable code there is `ZBADVERSION`, since the content of an `active` node is rewritten in place, and it is now reported the same way. `DDLWorker::markReplicasActive` repeats that read and versioned removal inline for loopback hosts, where a rewritten node is now skipped like one claimed by another replica.

#115818 itself is not fixed here. The database is still left unusable, only without the abort.

Both directions are verified with `TestKeeper` unit tests and with the #115818 reproducer as an integration test: on this branch the losing replica logs `Code: 253`, and with `LOGICAL_ERROR` restored that test aborts the server.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114408&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114408](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114408+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
