### PR TITLE
Fix quadratic insert into Poco::ListMap for repeated keys

### DIFF
--- a/base/poco/Foundation/include/Poco/ListMap.h
+++ b/base/poco/Foundation/include/Poco/ListMap.h
@@ -139,10 +139,21 @@ public:
     /// sequentially at all times.
     /// Returns iterator pointing to the newly inserted value
     {
-        Iterator it = find(val.first);
-        while (it != _list.end() && isEqual(it->first, val.first))
-            ++it;
-        return _list.insert(it, val);
+        /// All entries with the same key sit next to each other, so the new
+        /// value belongs right after the last entry with this key. Look for
+        /// that entry starting from the back of the list. This makes adding
+        /// many values with the same key (e.g. a repeated HTTP query parameter)
+        /// cheap, because the match is usually the last element. If the key
+        /// is not in the map we still walk the whole list and append at the
+        /// end, same as before.
+        typename Container::reverse_iterator it = _list.rbegin();
+        typename Container::reverse_iterator itEnd = _list.rend();
+        for (; it != itEnd; ++it)
+        {
+            if (isEqual(it->first, val.first))
+                return _list.insert(it.base(), val);
+        }
+        return _list.insert(_list.end(), val);
     }
 
     void erase(Iterator it) { _list.erase(it); }

--- a/src/Common/tests/gtest_poco_list_map.cpp
+++ b/src/Common/tests/gtest_poco_list_map.cpp
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <Poco/ListMap.h>
+#include <Poco/Net/NameValueCollection.h>
+
+namespace
+{
+
+using Map = Poco::ListMap<std::string, std::string>;
+
+std::string dump(const Map & map)
+{
+    std::string res;
+    for (const auto & [key, value] : map)
+        res += key + "=" + value + " ";
+    return res;
+}
+
+}
+
+/// Poco::Net::NameValueCollection (HTTP headers, HTMLForm query parameters) is a
+/// Poco::ListMap: insertion-ordered, case-insensitive, and all entries with an
+/// equal key are kept in one contiguous block. ListMap::insert relies on that
+/// invariant to append to a block without scanning the whole map.
+
+TEST(PocoListMap, EqualKeysStayContiguousInInsertionOrder)
+{
+    Map map;
+    map.insert({"a", "1"});
+    map.insert({"b", "1"});
+    map.insert({"A", "2"});   /// case-insensitive: joins the "a" block
+    map.insert({"c", "1"});
+    map.insert({"b", "2"});
+    map.insert({"a", "3"});
+
+    EXPECT_EQ(dump(map), "a=1 A=2 a=3 b=1 b=2 c=1 ");
+    ASSERT_NE(map.find("B"), map.end());
+    EXPECT_EQ(map.find("B")->second, "1");   /// find returns the first of the block
+}
+
+TEST(PocoListMap, EraseAndSubscript)
+{
+    Map map;
+    map.insert({"a", "1"});
+    map.insert({"b", "1"});
+    map.insert({"a", "2"});
+    map.insert({"b", "2"});
+
+    EXPECT_EQ(map.erase("A"), 2u);
+    EXPECT_EQ(dump(map), "b=1 b=2 ");
+
+    map["b"] = "x";           /// assigns to the first entry of the block
+    map["z"];                 /// inserts a new key at the end
+    EXPECT_EQ(dump(map), "b=x b=2 z= ");
+
+    map.erase(map.find("b"));
+    map.insert({"B", "3"});   /// still appended to the (now shorter) block
+    EXPECT_EQ(dump(map), "b=2 B=3 z= ");
+}
+
+TEST(PocoListMap, ManyValuesForOneKey)
+{
+    /// A request like `?role=r1&role=r2&...` produces thousands of parameters
+    /// with the same name; they must all land in one block, in order, after
+    /// the parameters that came before them.
+    constexpr size_t n = 20000;
+
+    Poco::Net::NameValueCollection params;
+    params.add("user", "u");
+    params.add("password", "p");
+    for (size_t i = 0; i < n; ++i)
+        params.add("role", "r" + std::to_string(i));
+    params.add("query_id", "q");
+
+    ASSERT_EQ(params.size(), n + 3);
+
+    auto it = params.begin();
+    ASSERT_EQ((it++)->first, "user");
+    ASSERT_EQ((it++)->first, "password");
+    ASSERT_EQ(it, params.find("role"));
+    for (size_t i = 0; i < n; ++i, ++it)
+    {
+        ASSERT_NE(it, params.end());
+        ASSERT_EQ(it->first, "role");
+        ASSERT_EQ(it->second, "r" + std::to_string(i));
+    }
+    ASSERT_NE(it, params.end());
+    EXPECT_EQ(it->first, "query_id");
+    EXPECT_EQ(++it, params.end());
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Parsing an HTTP request that carries many query parameters or headers with the same name (for example thousands of repeated `role=` parameters) no longer takes quadratic time.


### Details

`HTMLForm` and `MessageHeader` keep their entries in `Poco::Net::NameValueCollection`, which is a `Poco::ListMap` over `std::list`. `ListMap::insert` keeps all entries with an equal key in one contiguous block, but it located the end of that block by scanning from the front of the list, so inserting *n* values under one key cost O(n²) case-insensitive comparisons.

This is visible when a client selects a large set of roles per request via `?role=a&role=b&…`: with ~10k `role` parameters roughly 0.2–0.3 s per request was spent inside `HTMLForm` before the query started (server-side `query_duration_ms` stays flat while client-observed latency grows super-linearly).

Because equal keys always form a single block (`insert` and `operator[]` are the only ways to add entries), the end of the block is simply one past the *last* matching entry, so search from the back instead. Appending under the most recently added key — the repeated-parameter case — becomes O(1); in general an insert now costs the distance from the back of the list to that key's block rather than the distance from the front. A key that is not present still costs one full scan, exactly as before; iteration order and `find()` (first of block) are unchanged.

Micro-benchmark of `Poco::ListMap<std::string, std::string>::insert`, *n* values under the same key (clang, `-O2`):

| n | before | after |
|---:|---:|---:|
| 1 000 | 2.4 ms | 0.09 ms |
| 10 000 | 226 ms | 0.85 ms |
| 30 000 | 2.2 s | 3.3 ms |

A unit test is added for the block-contiguity / `find` / `erase` / `operator[]` semantics and for the repeated-key ordering; it passes both before and after this change (no timing assertions).

Inserting many *distinct* keys is still O(n²) overall since each miss scans the list; that path is already bounded by `http_max_fields` and is left as is here.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1279` (included in `26.8` and later)
- Backported to: `26.6.9.14`
<!-- ch-version-info:end -->