### PR TITLE
Reduce the 03835 fixture to the boundary window it tests

### DIFF
--- a/tests/queries/0_stateless/03835_todate_monotonicity_boundary.sql
+++ b/tests/queries/0_stateless/03835_todate_monotonicity_boundary.sql
@@ -8,9 +8,9 @@
 DROP TABLE IF EXISTS t_todate_mono;
 
 CREATE TABLE t_todate_mono (x UInt64) ENGINE = MergeTree ORDER BY x SETTINGS index_granularity = 1;
-INSERT INTO t_todate_mono SELECT number FROM numbers(100000);
+INSERT INTO t_todate_mono SELECT 12345 UNION ALL SELECT 65530 + number FROM numbers(10);
 
--- With index_granularity=1, mark 65535 covers the range [65535, 65536],
+-- With index_granularity=1, one mark covers the range [65535, 65536],
 -- which crosses the DATE_LUT_MAX_DAY_NUM boundary.
 -- The toDate conversion in the key condition chain must report this range as non-monotonic.
 SELECT count() > 0 FROM t_todate_mono WHERE toDate(x) IN (toDate(12345), toDate(67890));


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/90461
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/90461

`03835_todate_monotonicity_boundary` exceeded the 600 s per-test cap on `Stateless tests (amd_msan, WasmEdge, parallel)`. 4 failures in 30 days, 0 on master; 2 are this signature (the 2026-07-15 `distributed plan` pair are `MEMORY_LIMIT_EXCEEDED` victims of a fleet-wide OOM day).

The cost is the fixture INSERT, not the query under test. In the failing runs' `query_log` that INSERT took 766,587 ms and 741,852 ms, against 20,861-21,278 ms on passing runs of the same job; every other statement is milliseconds. It does not hang, it sits on the cap.

Root cause is the fixture's own DDL: `index_granularity = 1` over `numbers(100000)` produces 100,001 marks for 100,000 rows, so every per-granule cost in the part writer is paid 100,000 times. A DDL setting beats runner injection (`ClientBase::addMergeTreeSettings` appends a randomized setting only if the DDL has not set it), so the mark count is unconditional: measured 100,001 marks with `index_granularity 50135` injected.

The test needs one structural fact, a mark straddling `DATE_LUT_MAX_DAY_NUM` (65535), so `ToDateMonotonicity::get` sees a range crossing the day-number/timestamp discontinuity. Rows 65530..65539 give it. Row 12345 is kept as the timezone-independent satisfier: `toDate(x)` returns a day number for `x <= 65535` and `time_zone.toDayNum(x)` above it, so timestamp-side rows alone stop matching `toDate(67890)` in 4 of the 418 zones the CI timezone randomizer draws from. 11 rows total: 100,001 marks -> 12, INSERT 272.4 ms -> 4.2 ms locally under the culprit settings. Assertion and reference unchanged; the sibling `04109_todate32_monotonicity_boundary` already uses a two-row window.

Detection is verified: with the pre-fix boundary check restored locally, the new fixture still aborts with `Invalid binary search result in MergeTreeSetIndex`, including with a large `index_granularity` injected and in a fragile timezone. Through `clickhouse-test` it passes in all 4 fragile zones plus UTC, `America/Mazatlan` and `Africa/Khartoum`, and 50/50 green under randomized settings.

Failing run: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113909&sha=a99197d98f2ea59b42bab0b3432b32485105c983&name_0=PR&name_1=Stateless%20tests%20(amd_msan%2C%20WasmEdge%2C%20parallel%2C%201%2F3)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1237` (included in `26.8` and later)
<!-- ch-version-info:end -->