### PR TITLE
Add test: No test kills a running atomic `POPULATE`; cancel-rollback path unguarded

### DIFF
--- a/tests/queries/0_stateless/04846_atomic_populate_materialized_view_kill_rollback.reference
+++ b/tests/queries/0_stateless/04846_atomic_populate_materialized_view_kill_rollback.reference
@@ -1,3 +1,4 @@
-create failed: 1
+subscribed before kill: 1
+create cancelled: 1
 view left behind:	0
 source has dependents:	0

--- a/tests/queries/0_stateless/04846_atomic_populate_materialized_view_kill_rollback.reference
+++ b/tests/queries/0_stateless/04846_atomic_populate_materialized_view_kill_rollback.reference
@@ -1,0 +1,3 @@
+create failed: 1
+view left behind:	0
+source has dependents:	0

--- a/tests/queries/0_stateless/04846_atomic_populate_materialized_view_kill_rollback.sh
+++ b/tests/queries/0_stateless/04846_atomic_populate_materialized_view_kill_rollback.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database
+# - no-replicated-database - there the CREATE is an entry of the replicated DDL log, which uses the legacy
+#   population and does not roll the view back.
+
+# Killing a running `CREATE MATERIALIZED VIEW ... POPULATE` must cancel the population and leave nothing
+# behind: no view, no subscription of the source.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "
+    CREATE TABLE src_04846 (id UInt64) ENGINE = MergeTree ORDER BY id;
+    INSERT INTO src_04846 SELECT number FROM numbers(10);
+"
+
+QUERY_ID="populate_04846_${CLICKHOUSE_DATABASE}"
+
+# `sleepEachRow` keeps the population running while it is killed.
+$CLICKHOUSE_CLIENT --query_id "$QUERY_ID" -q "
+    CREATE MATERIALIZED VIEW mv_04846 ENGINE = MergeTree ORDER BY id POPULATE
+        AS SELECT id, sleepEachRow(0.2) AS s FROM src_04846
+" > /dev/null 2>&1 &
+CREATE_PID=$!
+
+# The source is subscribed to the view at the cut, before the population starts reading.
+for _ in {1..300}; do
+    [[ "$($CLICKHOUSE_CLIENT -q "SELECT has(dependencies_table, 'mv_04846') FROM system.tables WHERE database = currentDatabase() AND name = 'src_04846'")" == "1" ]] && break
+    sleep 0.05
+done
+
+$CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '$QUERY_ID' SYNC FORMAT Null"
+
+wait $CREATE_PID
+CREATE_STATUS=$?
+
+echo "create failed: $((CREATE_STATUS != 0))"
+$CLICKHOUSE_CLIENT -q "
+    SELECT 'view left behind:', count() FROM system.tables WHERE database = currentDatabase() AND name = 'mv_04846';
+    SELECT 'source has dependents:', count() FROM system.tables WHERE database = currentDatabase() AND name = 'src_04846' AND notEmpty(dependencies_table);
+    DROP TABLE src_04846;
+"

--- a/tests/queries/0_stateless/04846_atomic_populate_materialized_view_kill_rollback.sh
+++ b/tests/queries/0_stateless/04846_atomic_populate_materialized_view_kill_rollback.sh
@@ -11,33 +11,44 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CUR_DIR"/../shell_config.sh
 
 $CLICKHOUSE_CLIENT -q "
+    DROP TABLE IF EXISTS mv_04846;
+    DROP TABLE IF EXISTS src_04846;
     CREATE TABLE src_04846 (id UInt64) ENGINE = MergeTree ORDER BY id;
-    INSERT INTO src_04846 SELECT number FROM numbers(10);
+    INSERT INTO src_04846 SELECT number FROM numbers(100);
 "
 
 QUERY_ID="populate_04846_${CLICKHOUSE_DATABASE}"
+CREATE_ERR="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}.err"
 
-# `sleepEachRow` keeps the population running while it is killed.
-$CLICKHOUSE_CLIENT --query_id "$QUERY_ID" -q "
+# 30 seconds of `sleepEachRow` keep the population running until it is killed, whatever the load is.
+$CLICKHOUSE_CLIENT --function_sleep_max_microseconds_per_block 60000000 --query_id "$QUERY_ID" -q "
     CREATE MATERIALIZED VIEW mv_04846 ENGINE = MergeTree ORDER BY id POPULATE
-        AS SELECT id, sleepEachRow(0.2) AS s FROM src_04846
-" > /dev/null 2>&1 &
+        AS SELECT id, sleepEachRow(0.3) AS s FROM src_04846
+" > /dev/null 2> "$CREATE_ERR" &
 CREATE_PID=$!
 
 # The source is subscribed to the view at the cut, before the population starts reading.
-for _ in {1..300}; do
-    [[ "$($CLICKHOUSE_CLIENT -q "SELECT has(dependencies_table, 'mv_04846') FROM system.tables WHERE database = currentDatabase() AND name = 'src_04846'")" == "1" ]] && break
+SUBSCRIBED=0
+DEADLINE=$((SECONDS + 15))
+while (( SECONDS < DEADLINE )); do
+    if [[ "$($CLICKHOUSE_CLIENT -q "SELECT has(dependencies_table, 'mv_04846') FROM system.tables WHERE database = currentDatabase() AND name = 'src_04846'")" == "1" ]]; then
+        SUBSCRIBED=1
+        break
+    fi
     sleep 0.05
 done
+echo "subscribed before kill: $SUBSCRIBED"
 
 $CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '$QUERY_ID' SYNC FORMAT Null"
 
 wait $CREATE_PID
-CREATE_STATUS=$?
 
-echo "create failed: $((CREATE_STATUS != 0))"
+echo "create cancelled: $(grep -c QUERY_WAS_CANCELLED "$CREATE_ERR")"
+rm -f "$CREATE_ERR"
+
 $CLICKHOUSE_CLIENT -q "
     SELECT 'view left behind:', count() FROM system.tables WHERE database = currentDatabase() AND name = 'mv_04846';
     SELECT 'source has dependents:', count() FROM system.tables WHERE database = currentDatabase() AND name = 'src_04846' AND notEmpty(dependencies_table);
+    DROP TABLE IF EXISTS mv_04846;
     DROP TABLE src_04846;
 "


### PR DESCRIPTION
_Found via ClickGap automated review — close or comment if this is wrong._

_Test-only PR. Review: are the gaps real, is the test right._

Adds test coverage for 1 untested code path, found during automated review of [PR #108715](https://github.com/ClickHouse/ClickHouse/pull/108715).
That PR: (1) Makes `CREATE MATERIALIZED VIEW ... POPULATE` atomic: the view is subscribed to the source and a storage snapshot is pinned together under a brief exclusive lock on the source (`InterpreterCreateQuery::fillMaterializedViewAtomically*`), then the population reads the pinned snapshot lock-free. …

**1. No test kills a running atomic `POPULATE`; cancel-rollback path unguarded**
  `src/Interpreters/InterpreterCreateQuery.cpp:3332`, `src/Interpreters/InterpreterCreateQuery.cpp:3180`
  **Risk:** The population runs eagerly inside the rollback scope (`InterpreterCreateQuery.cpp:3333` `executeTrivialBlockIO`), and cancellation only reaches it because the process-list element is attached by hand at `InterpreterCreateQuery.cpp:3332`. Risk: if either line regresses, `KILL QUERY` silently does …
  **Unique vs PR tests:** PR tests cover rollback on a fail-point failure (04653), on a runtime `throwIf` in the population (04759) and for a `TO target` (04815) - all self-inflicted exceptions raised by the pipeline. None cancels the query, so the process-list-element attach and the cancellation route into the rollback …

cc @alexey-milovidov (author of #108715) — could you take a look, and add the `can be tested` label if this looks good?

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)