### PR TITLE
Do not apply DROP fault injection to CREATE OR REPLACE internal DROPs

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -2530,6 +2530,8 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
     {
         ContextMutablePtr drop_context = Context::createCopy(current_context);
         drop_context->setQueryContext(std::const_pointer_cast<Context>(current_context));
+        /// Steps of one user statement, not user DROPs: `ignore_drop_queries_probability` must not skip them.
+        drop_context->setDDLOrOnClusterInternal(true);
         /// Bypass = "the size guard was already enforced upstream; do not re-check or consume `force_drop_table` twice".
         if (bypass_size_guard)
         {

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -2241,7 +2241,6 @@ bool InterpreterCreateQuery::doCreateTable(ASTCreateQuery & create,
             /// Don't check dependencies during DROP of the view, because we will recreate
             /// it with the same name and all dependencies will remain valid.
             drop_context->setSetting("check_table_dependencies", false);
-            /// A step of one user statement, not a user DROP: `ignore_drop_queries_probability` must not skip it.
             drop_context->setDDLOrOnClusterInternal(true);
             InterpreterDropQuery interpreter(drop_ast, drop_context);
             interpreter.execute();
@@ -2532,7 +2531,6 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
     {
         ContextMutablePtr drop_context = Context::createCopy(current_context);
         drop_context->setQueryContext(std::const_pointer_cast<Context>(current_context));
-        /// Steps of one user statement, not user DROPs: `ignore_drop_queries_probability` must not skip them.
         drop_context->setDDLOrOnClusterInternal(true);
         /// Bypass = "the size guard was already enforced upstream; do not re-check or consume `force_drop_table` twice".
         if (bypass_size_guard)

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -2241,6 +2241,8 @@ bool InterpreterCreateQuery::doCreateTable(ASTCreateQuery & create,
             /// Don't check dependencies during DROP of the view, because we will recreate
             /// it with the same name and all dependencies will remain valid.
             drop_context->setSetting("check_table_dependencies", false);
+            /// A step of one user statement, not a user DROP: `ignore_drop_queries_probability` must not skip it.
+            drop_context->setDDLOrOnClusterInternal(true);
             InterpreterDropQuery interpreter(drop_ast, drop_context);
             interpreter.execute();
         }

--- a/tests/queries/0_stateless/04796_create_or_replace_internal_drop_not_ignored.reference
+++ b/tests/queries/0_stateless/04796_create_or_replace_internal_drop_not_ignored.reference
@@ -1,0 +1,13 @@
+-- failure path: the temporary table must be cleaned up, not stranded
+0
+10
+-- success path: the replaced table must be dropped, not left behind
+0
+3
+-- no leak accumulates across repeated replaces
+0
+-- a view temporary is not MergeTree, so its internal DROP would be rewritten to TRUNCATE
+0
+100
+-- a user DROP is still skipped: the setting keeps doing what it is for
+1

--- a/tests/queries/0_stateless/04796_create_or_replace_internal_drop_not_ignored.reference
+++ b/tests/queries/0_stateless/04796_create_or_replace_internal_drop_not_ignored.reference
@@ -9,5 +9,7 @@
 -- a view temporary is not MergeTree, so its internal DROP would be rewritten to TRUNCATE
 0
 100
+-- CREATE OR REPLACE VIEW on a non-Atomic database takes its own internal DROP path
+2
 -- a user DROP is still skipped: the setting keeps doing what it is for
 1

--- a/tests/queries/0_stateless/04796_create_or_replace_internal_drop_not_ignored.sql
+++ b/tests/queries/0_stateless/04796_create_or_replace_internal_drop_not_ignored.sql
@@ -1,18 +1,21 @@
--- Tags: no-ordinary-database, no-replicated-database
+-- Tags: no-ordinary-database, no-replicated-database, need-query-parameters
 -- no-ordinary-database: CREATE OR REPLACE requires an Atomic database.
 -- no-replicated-database: POPULATE is not supported in a Replicated database.
 
 -- The DROPs that CREATE OR REPLACE issues internally (cleaning up its temporary table on failure,
 -- and dropping the replaced table after the swap) are steps of one user statement, not user DROPs,
 -- so `ignore_drop_queries_probability` must not skip or rewrite them. When it does, the temporary
--- table is stranded as a `_tmp_replace_*` table that is invisible to the user, holds its data and
--- survives a restart, and one is leaked per statement.
+-- table is left behind as a `_tmp_replace_*` table that still holds its data and survives a
+-- restart, and one is leaked per statement.
+--
+-- The setup and teardown DROPs below pin the setting to 0: they are ordinary user DROPs, so the
+-- injection this test turns on would eat them too and leave the test's own tables behind.
 
 SET ignore_drop_queries_probability = 1;
 
 SELECT '-- failure path: the temporary table must be cleaned up, not stranded';
 
-DROP TABLE IF EXISTS dst_04796 SYNC;
+DROP TABLE IF EXISTS dst_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
 CREATE TABLE dst_04796 (a UInt64) ENGINE = MergeTree ORDER BY a;
 INSERT INTO dst_04796 SELECT number FROM numbers(10);
 
@@ -44,15 +47,13 @@ CREATE OR REPLACE TABLE dst_04796 (a UInt64) ENGINE = MergeTree ORDER BY a AS SE
 
 SELECT count() FROM system.tables WHERE database = currentDatabase() AND name LIKE '%tmp_replace%';
 
-DROP TABLE dst_04796 SYNC;
+DROP TABLE dst_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
 
 SELECT '-- a view temporary is not MergeTree, so its internal DROP would be rewritten to TRUNCATE';
 
--- A rewritten internal DROP takes an exclusive lock on the temporary storage under the outer
--- statement's query id (which already holds read locks on it), so it can also raise
--- `RWLockImpl::getLock(): Cannot acquire exclusive lock while RWLock is already locked`.
-DROP TABLE IF EXISTS src_04796 SYNC;
-DROP TABLE IF EXISTS mv_04796 SYNC;
+-- A rewritten internal DROP asks for an exclusive lock under the outer statement's query id.
+DROP TABLE IF EXISTS src_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS mv_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
 
 CREATE TABLE src_04796 (id UInt64) ENGINE = MergeTree ORDER BY id;
 INSERT INTO src_04796 SELECT number FROM numbers(100);
@@ -67,14 +68,29 @@ SELECT count() FROM system.tables WHERE database = currentDatabase() AND name LI
 -- The failed replace must leave the original view working.
 SELECT count() FROM mv_04796;
 
+SELECT '-- CREATE OR REPLACE VIEW on a non-Atomic database takes its own internal DROP path';
+
+-- On a non-Atomic database the replace is done by dropping the existing view in place, and a
+-- rewritten DROP reaches `StorageView`, which supports no TRUNCATE.
+SET allow_deprecated_database_ordinary = 1;
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = Ordinary;
+
+CREATE VIEW {CLICKHOUSE_DATABASE_1:Identifier}.v_04796 AS SELECT 1 AS x;
+CREATE OR REPLACE VIEW {CLICKHOUSE_DATABASE_1:Identifier}.v_04796 AS SELECT 2 AS x;
+-- The replacement must be the new definition, not the old one left in place.
+SELECT x FROM {CLICKHOUSE_DATABASE_1:Identifier}.v_04796;
+
+DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier} SETTINGS ignore_drop_queries_probability = 0;
+
 SELECT '-- a user DROP is still skipped: the setting keeps doing what it is for';
 
-DROP TABLE IF EXISTS user_drop_04796 SYNC;
+DROP TABLE IF EXISTS user_drop_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
 CREATE TABLE user_drop_04796 (a UInt64) ENGINE = MergeTree ORDER BY a;
 INSERT INTO user_drop_04796 SELECT number FROM numbers(10);
 DROP TABLE user_drop_04796;
 SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = 'user_drop_04796';
 
-DROP TABLE mv_04796 SYNC;
-DROP TABLE src_04796 SYNC;
+DROP TABLE mv_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE src_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
 DROP TABLE IF EXISTS user_drop_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;

--- a/tests/queries/0_stateless/04796_create_or_replace_internal_drop_not_ignored.sql
+++ b/tests/queries/0_stateless/04796_create_or_replace_internal_drop_not_ignored.sql
@@ -7,15 +7,17 @@
 -- so `ignore_drop_queries_probability` must not skip or rewrite them. When it does, the temporary
 -- table is left behind as a `_tmp_replace_*` table that still holds its data and survives a
 -- restart, and one is leaked per statement.
---
--- The setup and teardown DROPs below pin the setting to 0: they are ordinary user DROPs, so the
--- injection this test turns on would eat them too and leave the test's own tables behind.
+
+-- The test runs with the injection on, so it keeps its objects in databases it creates itself:
+-- DROP DATABASE is not injected, so one at the end removes everything without pinning the setting.
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_2:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE_2:Identifier};
+USE {CLICKHOUSE_DATABASE_2:Identifier};
 
 SET ignore_drop_queries_probability = 1;
 
 SELECT '-- failure path: the temporary table must be cleaned up, not stranded';
 
-DROP TABLE IF EXISTS dst_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
 CREATE TABLE dst_04796 (a UInt64) ENGINE = MergeTree ORDER BY a;
 INSERT INTO dst_04796 SELECT number FROM numbers(10);
 
@@ -47,14 +49,9 @@ CREATE OR REPLACE TABLE dst_04796 (a UInt64) ENGINE = MergeTree ORDER BY a AS SE
 
 SELECT count() FROM system.tables WHERE database = currentDatabase() AND name LIKE '%tmp_replace%';
 
-DROP TABLE dst_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
-
 SELECT '-- a view temporary is not MergeTree, so its internal DROP would be rewritten to TRUNCATE';
 
 -- A rewritten internal DROP asks for an exclusive lock under the outer statement's query id.
-DROP TABLE IF EXISTS src_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS mv_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
-
 CREATE TABLE src_04796 (id UInt64) ENGINE = MergeTree ORDER BY id;
 INSERT INTO src_04796 SELECT number FROM numbers(100);
 CREATE MATERIALIZED VIEW mv_04796 ENGINE = MergeTree ORDER BY id POPULATE AS SELECT id FROM src_04796;
@@ -81,16 +78,13 @@ CREATE OR REPLACE VIEW {CLICKHOUSE_DATABASE_1:Identifier}.v_04796 AS SELECT 2 AS
 -- The replacement must be the new definition, not the old one left in place.
 SELECT x FROM {CLICKHOUSE_DATABASE_1:Identifier}.v_04796;
 
-DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier} SETTINGS ignore_drop_queries_probability = 0;
+DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
 
 SELECT '-- a user DROP is still skipped: the setting keeps doing what it is for';
 
-DROP TABLE IF EXISTS user_drop_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
 CREATE TABLE user_drop_04796 (a UInt64) ENGINE = MergeTree ORDER BY a;
 INSERT INTO user_drop_04796 SELECT number FROM numbers(10);
 DROP TABLE user_drop_04796;
 SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = 'user_drop_04796';
 
-DROP TABLE mv_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE src_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
-DROP TABLE IF EXISTS user_drop_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;
+DROP DATABASE {CLICKHOUSE_DATABASE_2:Identifier};

--- a/tests/queries/0_stateless/04796_create_or_replace_internal_drop_not_ignored.sql
+++ b/tests/queries/0_stateless/04796_create_or_replace_internal_drop_not_ignored.sql
@@ -1,0 +1,80 @@
+-- Tags: no-ordinary-database, no-replicated-database
+-- no-ordinary-database: CREATE OR REPLACE requires an Atomic database.
+-- no-replicated-database: POPULATE is not supported in a Replicated database.
+
+-- The DROPs that CREATE OR REPLACE issues internally (cleaning up its temporary table on failure,
+-- and dropping the replaced table after the swap) are steps of one user statement, not user DROPs,
+-- so `ignore_drop_queries_probability` must not skip or rewrite them. When it does, the temporary
+-- table is stranded as a `_tmp_replace_*` table that is invisible to the user, holds its data and
+-- survives a restart, and one is leaked per statement.
+
+SET ignore_drop_queries_probability = 1;
+
+SELECT '-- failure path: the temporary table must be cleaned up, not stranded';
+
+DROP TABLE IF EXISTS dst_04796 SYNC;
+CREATE TABLE dst_04796 (a UInt64) ENGINE = MergeTree ORDER BY a;
+INSERT INTO dst_04796 SELECT number FROM numbers(10);
+
+-- One row per block, so blocks 0..49 land as parts in the temporary table before `throwIf` fires on
+-- row 50: the statement then fails with the temporary table already created and populated, which is
+-- the catch-block cleanup path.
+CREATE OR REPLACE TABLE dst_04796 (a UInt64) ENGINE = MergeTree ORDER BY a
+AS SELECT throwIf(number = 50, 'stop') AS a FROM numbers(100)
+SETTINGS max_insert_block_size = 1, min_insert_block_size_rows = 1,
+         min_insert_block_size_bytes = 1, max_block_size = 1; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
+
+SELECT count() FROM system.tables WHERE database = currentDatabase() AND name LIKE '%tmp_replace%';
+-- The failed replace must leave the original table untouched.
+SELECT count() FROM dst_04796;
+
+SELECT '-- success path: the replaced table must be dropped, not left behind';
+
+CREATE OR REPLACE TABLE dst_04796 (a UInt64) ENGINE = MergeTree ORDER BY a
+AS SELECT number AS a FROM numbers(3);
+
+SELECT count() FROM system.tables WHERE database = currentDatabase() AND name LIKE '%tmp_replace%';
+SELECT count() FROM dst_04796;
+
+SELECT '-- no leak accumulates across repeated replaces';
+
+CREATE OR REPLACE TABLE dst_04796 (a UInt64) ENGINE = MergeTree ORDER BY a AS SELECT number AS a FROM numbers(3);
+CREATE OR REPLACE TABLE dst_04796 (a UInt64) ENGINE = MergeTree ORDER BY a AS SELECT number AS a FROM numbers(3);
+CREATE OR REPLACE TABLE dst_04796 (a UInt64) ENGINE = MergeTree ORDER BY a AS SELECT number AS a FROM numbers(3);
+
+SELECT count() FROM system.tables WHERE database = currentDatabase() AND name LIKE '%tmp_replace%';
+
+DROP TABLE dst_04796 SYNC;
+
+SELECT '-- a view temporary is not MergeTree, so its internal DROP would be rewritten to TRUNCATE';
+
+-- A rewritten internal DROP takes an exclusive lock on the temporary storage under the outer
+-- statement's query id (which already holds read locks on it), so it can also raise
+-- `RWLockImpl::getLock(): Cannot acquire exclusive lock while RWLock is already locked`.
+DROP TABLE IF EXISTS src_04796 SYNC;
+DROP TABLE IF EXISTS mv_04796 SYNC;
+
+CREATE TABLE src_04796 (id UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO src_04796 SELECT number FROM numbers(100);
+CREATE MATERIALIZED VIEW mv_04796 ENGINE = MergeTree ORDER BY id POPULATE AS SELECT id FROM src_04796;
+
+CREATE OR REPLACE MATERIALIZED VIEW mv_04796 ENGINE = MergeTree ORDER BY id POPULATE
+AS SELECT throwIf(id = 50, 'stop') AS id FROM src_04796
+SETTINGS max_insert_block_size = 1, min_insert_block_size_rows = 1,
+         min_insert_block_size_bytes = 1, max_block_size = 1; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
+
+SELECT count() FROM system.tables WHERE database = currentDatabase() AND name LIKE '%tmp_replace%';
+-- The failed replace must leave the original view working.
+SELECT count() FROM mv_04796;
+
+SELECT '-- a user DROP is still skipped: the setting keeps doing what it is for';
+
+DROP TABLE IF EXISTS user_drop_04796 SYNC;
+CREATE TABLE user_drop_04796 (a UInt64) ENGINE = MergeTree ORDER BY a;
+INSERT INTO user_drop_04796 SELECT number FROM numbers(10);
+DROP TABLE user_drop_04796;
+SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = 'user_drop_04796';
+
+DROP TABLE mv_04796 SYNC;
+DROP TABLE src_04796 SYNC;
+DROP TABLE IF EXISTS user_drop_04796 SYNC SETTINGS ignore_drop_queries_probability = 0;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/110893
Related: https://github.com/ClickHouse/ClickHouse/pull/110971
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes `CREATE OR REPLACE` leaking an internal `_tmp_replace_*` table, and `CREATE OR REPLACE VIEW` failing with `NOT_IMPLEMENTED`, when `ignore_drop_queries_probability` is set. The DROPs it issues internally are steps of one user statement, so DROP fault injection no longer applies to them.


### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/110893
Related: https://github.com/ClickHouse/ClickHouse/pull/110971

`CREATE OR REPLACE` builds the replacement under a temporary `_tmp_replace_*` name and publishes it by rename. It issues two DROPs internally: cleaning up that temporary table if the statement fails, and dropping the replaced table after the swap. Both took their context from `make_drop_context`, which did not mark it DDL-internal, so `InterpreterDropQuery` treated them as *user* DROPs and injected faults.

Two things follow. If the storage keeps data on disk the DROP is skipped outright and a populated `_tmp_replace_*` table is stranded: listed by `SHOW TABLES`, holding its data, surviving a restart, one per statement. Otherwise (a materialized view, say) the DROP is rewritten to `TRUNCATE`, whose branch takes an exclusive lock under the outer statement's query id while that id already holds read locks, raising `RWLockImpl::getLock(): Cannot acquire exclusive lock while RWLock is already locked`. That fired twice on master, under [`Stress test (amd_tsan)`](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d134c6da364233695c456f9c51fbbc521a4fbd5b&name_0=MasterCI&name_1=Stress%20test%20%28amd_tsan%29) and [`Stress test (arm_debug)`](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=1033651ae6f23b6c10f0023dd1247c6feb8bde4f&name_0=MasterCI&name_1=Stress%20test%20%28arm_debug%29).

A third internal DROP is misclassified the same way. `CREATE OR REPLACE VIEW` uses that machinery only on `Atomic` or `Replicated`; other engines drop the view in place through `doCreateTable`. `StorageView` implements no `TRUNCATE`, so there the rewrite fails the statement with `NOT_IMPLEMENTED` and the stale view survives.

The fix marks both contexts DDL-internal, as the sibling helper in the same function and `InterpreterDropQuery::executeDropQuery` already do; that asymmetry is why plain `CREATE ... AS SELECT` was immune and only REPLACE was exposed. User DROPs are still skipped, which the new test pins. The setting defaults to 0, so a default configuration is unaffected. The read lock the assertion reports is not identified; the fix does not depend on it, since without the rewrite nothing requests an exclusive lock.

<details>
<summary>Validation</summary>

- New test `04796_create_or_replace_internal_drop_not_ignored` fails on master and passes with the fix, on every shape it covers.
- All three sites covered by shape: `CREATE OR REPLACE TABLE ... AS SELECT` over MergeTree takes the skip path (stray `_tmp_replace_*` count accumulates 1, 2, 5, 6 on master); `CREATE OR REPLACE MATERIALIZED VIEW ... POPULATE` takes the rewrite-to-`TRUNCATE` path; `CREATE OR REPLACE VIEW` on a non-Atomic database fails on master with `Truncate is not supported by storage View`, leaving the stale definition readable. Failure path, success path (which leaks the *replaced* table), and repeated replaces all covered.
- 50 randomized runs each, on the final binary, of the new test, `03013_ignore_drop_queries_probability`, `00916_create_or_replace_view` and `01866_view_persist_settings`: 200/200. Same for `04492`, `04524`, `04326`, `04328` on the first binary: 200/200.
- A/B sweep of the 41 tests matching `create_or_replace`/`replace_table`/`tmp_replace`/`create_as_select`, plus a focused sweep of the 14 that reach the view site: each removes exactly one failure (the new test) and introduces none.
- All 8 `Common.RWLock*` unit tests pass.
- Replicated databases measured on both binaries across every reachable `CREATE OR REPLACE` shape: no change, no `INCORRECT_QUERY`. That path already marks the context internal (`DatabaseReplicatedTask::makeQueryContext`), so the fix is a no-op there.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1308` (included in `26.8` and later)
<!-- ch-version-info:end -->