### PR TITLE
Docs: fix internal documentation badge links

### DIFF
--- a/ci/tests/test_docs_link_checker.py
+++ b/ci/tests/test_docs_link_checker.py
@@ -2,11 +2,15 @@
 
 import os
 import sys
+from pathlib import Path
 
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
 from ci.jobs.scripts.docs import locale_components_check, lychee_check
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def write_settings_explorer(docs_root, rendered_href):
@@ -67,3 +71,63 @@ def test_locale_static_link_parser_leaves_templates_to_template_parser():
     template = locale_components_check.TEMPLATE.search(rendered_href)
     assert template is not None
     assert template.group(1) == "/docs"
+
+
+def test_cloud_not_supported_badges_link_to_published_page():
+    docs_root = REPO_ROOT / "docs"
+    page_path = docs_root / "products/cloud/guides/cloud-compatibility.mdx"
+    page = page_path.read_text(encoding="utf-8")
+    anchor = "list-of-unsupported-features"
+    assert f"{{#{anchor}}}" in page
+    route = page_path.relative_to(docs_root).with_suffix("").as_posix()
+    expected_href = (
+        f'href="/docs/{route}#{anchor}"'
+    )
+
+    snippets = REPO_ROOT / "docs/snippets"
+    components = list(
+        snippets.glob(
+            "**/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx"
+        )
+    )
+    components += list(
+        snippets.glob("**/components/Badges/CloudNotSupportedBadge.jsx")
+    )
+    assert components
+    for component in components:
+        assert expected_href in component.read_text(encoding="utf-8")
+
+
+def test_feature_status_badges_link_to_published_pages():
+    docs_root = REPO_ROOT / "docs"
+    snippets = docs_root / "snippets"
+    page_route = "reference/settings/beta-and-experimental-features"
+    badges = (
+        ("BetaBadge", "beta-features"),
+        ("ExperimentalBadge", "experimental-features"),
+    )
+
+    for badge, anchor in badges:
+        components = list(
+            snippets.glob(f"**/components/{badge}/{badge}.jsx")
+        )
+        components += list(
+            snippets.glob(f"**/components/Badges/{badge}.jsx")
+        )
+        assert len(components) == 18
+
+        for component in components:
+            relative = component.relative_to(snippets)
+            locale = (
+                relative.parts[0]
+                if relative.parts[0] in locale_components_check.LOCALE_DIRS
+                else None
+            )
+            locale_prefix = f"/{locale}" if locale else ""
+            page = docs_root / locale_prefix.lstrip("/") / f"{page_route}.mdx"
+            assert anchor in page.read_text(encoding="utf-8")
+            expected_href = (
+                f'href="/docs{locale_prefix}/'
+                f'{page_route}#{anchor}"'
+            )
+            assert expected_href in component.read_text(encoding="utf-8")

--- a/ci/tests/test_docs_link_checker.py
+++ b/ci/tests/test_docs_link_checker.py
@@ -2,15 +2,11 @@
 
 import os
 import sys
-from pathlib import Path
 
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
 from ci.jobs.scripts.docs import locale_components_check, lychee_check
-
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def write_settings_explorer(docs_root, rendered_href):
@@ -71,63 +67,3 @@ def test_locale_static_link_parser_leaves_templates_to_template_parser():
     template = locale_components_check.TEMPLATE.search(rendered_href)
     assert template is not None
     assert template.group(1) == "/docs"
-
-
-def test_cloud_not_supported_badges_link_to_published_page():
-    docs_root = REPO_ROOT / "docs"
-    page_path = docs_root / "products/cloud/guides/cloud-compatibility.mdx"
-    page = page_path.read_text(encoding="utf-8")
-    anchor = "list-of-unsupported-features"
-    assert f"{{#{anchor}}}" in page
-    route = page_path.relative_to(docs_root).with_suffix("").as_posix()
-    expected_href = (
-        f'href="/docs/{route}#{anchor}"'
-    )
-
-    snippets = REPO_ROOT / "docs/snippets"
-    components = list(
-        snippets.glob(
-            "**/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx"
-        )
-    )
-    components += list(
-        snippets.glob("**/components/Badges/CloudNotSupportedBadge.jsx")
-    )
-    assert components
-    for component in components:
-        assert expected_href in component.read_text(encoding="utf-8")
-
-
-def test_feature_status_badges_link_to_published_pages():
-    docs_root = REPO_ROOT / "docs"
-    snippets = docs_root / "snippets"
-    page_route = "reference/settings/beta-and-experimental-features"
-    badges = (
-        ("BetaBadge", "beta-features"),
-        ("ExperimentalBadge", "experimental-features"),
-    )
-
-    for badge, anchor in badges:
-        components = list(
-            snippets.glob(f"**/components/{badge}/{badge}.jsx")
-        )
-        components += list(
-            snippets.glob(f"**/components/Badges/{badge}.jsx")
-        )
-        assert len(components) == 18
-
-        for component in components:
-            relative = component.relative_to(snippets)
-            locale = (
-                relative.parts[0]
-                if relative.parts[0] in locale_components_check.LOCALE_DIRS
-                else None
-            )
-            locale_prefix = f"/{locale}" if locale else ""
-            page = docs_root / locale_prefix.lstrip("/") / f"{page_route}.mdx"
-            assert anchor in page.read_text(encoding="utf-8")
-            expected_href = (
-                f'href="/docs{locale_prefix}/'
-                f'{page_route}#{anchor}"'
-            )
-            assert expected_href in component.read_text(encoding="utf-8")

--- a/docs/snippets/ar/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/ar/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/ar/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/ar/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>ميزة Beta</span>

--- a/docs/snippets/ar/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ar/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />غير متاح في ClickHouse Cloud
         </a>
     )

--- a/docs/snippets/ar/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/ar/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/ar/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/ar/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />ميزة تجريبية

--- a/docs/snippets/ar/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/ar/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/ar/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/ar/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>ميزة Beta</span>

--- a/docs/snippets/ar/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ar/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/ar/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/ar/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/ar/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/ar/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/components/Badges/BetaBadge.jsx
@@ -18,7 +18,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Beta feature</span>

--- a/docs/snippets/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/components/Badges/CloudNotSupportedBadge.jsx
@@ -13,7 +13,7 @@ const Icon = () => {
 
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />Not supported in ClickHouse Cloud
         </a>
     )

--- a/docs/snippets/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/components/Badges/ExperimentalBadge.jsx
@@ -14,7 +14,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />Experimental feature

--- a/docs/snippets/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Beta feature</span>

--- a/docs/snippets/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/es/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/es/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/es/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/es/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Funcionalidad Beta</span>

--- a/docs/snippets/es/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/es/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />No disponible en ClickHouse Cloud
         </a>
     )

--- a/docs/snippets/es/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/es/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/es/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/es/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />Funcionalidad experimental

--- a/docs/snippets/es/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/es/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/es/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/es/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Funcionalidad beta</span>

--- a/docs/snippets/es/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/es/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/es/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/es/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/es/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/es/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/fr/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/fr/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/fr/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/fr/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Fonctionnalité bêta</span>

--- a/docs/snippets/fr/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/fr/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />Non pris en charge sur ClickHouse Cloud
         </a>
     )

--- a/docs/snippets/fr/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/fr/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/fr/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/fr/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />Fonctionnalité expérimentale

--- a/docs/snippets/fr/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/fr/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/fr/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/fr/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Fonctionnalité en bêta</span>

--- a/docs/snippets/fr/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/fr/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/fr/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/fr/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/fr/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/fr/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/ja/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/ja/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/ja/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/ja/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>ベータ機能です</span>

--- a/docs/snippets/ja/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ja/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />ClickHouse Cloud では利用できません
         </a>
     )

--- a/docs/snippets/ja/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/ja/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/ja/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/ja/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />実験的機能です

--- a/docs/snippets/ja/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/ja/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/ja/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/ja/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>ベータ機能です</span>

--- a/docs/snippets/ja/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ja/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/ja/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/ja/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/ja/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/ja/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/ko/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/ko/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/ko/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/ko/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>베타 기능입니다</span>

--- a/docs/snippets/ko/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ko/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />ClickHouse Cloud에서 지원되지 않음
         </a>
     )

--- a/docs/snippets/ko/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/ko/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/ko/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/ko/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />실험적 기능입니다

--- a/docs/snippets/ko/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/ko/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/ko/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/ko/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>베타 기능</span>

--- a/docs/snippets/ko/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ko/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/ko/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/ko/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/ko/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/ko/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/pt-BR/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/pt-BR/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/pt-BR/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/pt-BR/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Recurso beta</span>

--- a/docs/snippets/pt-BR/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/pt-BR/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />Sem suporte no ClickHouse Cloud
         </a>
     )

--- a/docs/snippets/pt-BR/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/pt-BR/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/pt-BR/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/pt-BR/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />Recurso experimental

--- a/docs/snippets/pt-BR/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/pt-BR/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/pt-BR/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/pt-BR/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Funcionalidade Beta</span>

--- a/docs/snippets/pt-BR/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/pt-BR/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/pt-BR/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/pt-BR/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/pt-BR/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/pt-BR/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/ru/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/ru/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/ru/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/ru/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Возможность в бета-версии</span>

--- a/docs/snippets/ru/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ru/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />В ClickHouse Cloud не поддерживается
         </a>
     )

--- a/docs/snippets/ru/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/ru/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/ru/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/ru/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />Экспериментальная возможность

--- a/docs/snippets/ru/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/ru/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/ru/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/ru/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Возможность в статусе бета</span>

--- a/docs/snippets/ru/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ru/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/ru/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/ru/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/ru/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/ru/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/zh/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/zh/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/zh/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/zh/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Beta 功能</span>

--- a/docs/snippets/zh/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/zh/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />ClickHouse Cloud 中不支持
         </a>
     )

--- a/docs/snippets/zh/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/zh/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/zh/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/zh/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />Experimental 功能

--- a/docs/snippets/zh/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/zh/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/zh/reference/settings/beta-and-experimental-features#beta-features"
+            href="/docs/zh/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Beta 版功能</span>

--- a/docs/snippets/zh/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/zh/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/zh/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/zh/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/zh/reference/settings/beta-and-experimental-features#experimental-features"
+            href="/docs/zh/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">


### PR DESCRIPTION
The raw JSX badge components used paths rooted below the site origin instead of the `/docs` mount. Pages that preserve those hrefs navigate outside the documentation site and return a 404.

This prefixes every linked badge href with `/docs` while keeping the links relative. `CloudNotSupportedBadge` translations intentionally fall back to the English-only compatibility catalog, while `BetaBadge` and `ExperimentalBadge` preserve their localized settings-page targets. The locale component check reports zero violations.

Reproduced on:

- https://clickhouse.com/docs/guides/oss/deployment-and-scaling/keeper
- https://clickhouse.com/docs/concepts/features/security/tls/configuring-tls-acme-client

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix linked documentation badges so they open their intended documentation pages.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1229` (included in `26.8` and later)
<!-- ch-version-info:end -->