### PR TITLE
Preserve the RabbitMQ broker log in integration tests

### DIFF
--- a/tests/integration/compose/docker_compose_rabbitmq.yml
+++ b/tests/integration/compose/docker_compose_rabbitmq.yml
@@ -23,9 +23,11 @@ services:
             exec docker-entrypoint.sh rabbitmq-server
           "
         tmpfs:
-            - /rabbitmq_logs
             - /var/lib/rabbitmq
         volumes:
+            - type: ${RABBITMQ_LOGS_FS:-tmpfs}
+              source: ${RABBITMQ_LOGS:-}
+              target: /rabbitmq_logs/
             - /misc/rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
             - /misc/rabbitmq/ca-cert.pem:/etc/rabbitmq/ca-cert.pem
             - /misc/rabbitmq/server-cert.pem:/etc/rabbitmq/server-cert.pem

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import re
 import random
 import threading
@@ -133,6 +134,24 @@ def check_expected_result_polling(expected, query, instance=instance, timeout=DE
 
 
 # Tests
+
+
+def test_rabbitmq_broker_log_is_collected(rabbitmq_cluster):
+    logs_dir = rabbitmq_cluster.rabbitmq_logs_dir
+    path = os.path.join(logs_dir, "rabbit.log")
+
+    deadline = time.monotonic() + 30
+    size = 0
+    while time.monotonic() < deadline:
+        if os.path.exists(path):
+            size = os.path.getsize(path)
+            if size > 0:
+                break
+        time.sleep(1)
+
+    listing = sorted(os.listdir(logs_dir)) if os.path.isdir(logs_dir) else "<no such directory>"
+    assert os.path.exists(path), f"{path} is absent, {logs_dir} contains {listing}"
+    assert size > 0, f"{path} is empty, {logs_dir} contains {listing}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/114415
Related: https://github.com/ClickHouse/ClickHouse/pull/113610


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

When a RabbitMQ container never becomes available, `wait_rabbitmq_to_start` raises and every test in
the module fails from that one event. On master @ `e4d3698282346fcd7e496ef668ff517106c84ac5` that cost all 21 tests of
`test_storage_rabbitmq/test_system_stop.py` from one fixture failure
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=e4d3698282346fcd7e496ef668ff517106c84ac5&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%201%2F4%29)).
Four such events in 21 days, two on master.

The artifact that would say why does not survive the run. `rabbitmq.conf` sets
`log.file = /rabbitmq_logs/rabbit.log` and no `log.console`, so everything goes to that file and
nothing to the console, which is also why the `docker logs` capture is empty. `/rabbitmq_logs` was
declared `tmpfs`, so the log died with the container. `cluster.py` has always exported
`RABBITMQ_LOGS` and `RABBITMQ_LOGS_FS="bind"` and created the host directory, but no compose file
consumed them after 545bb5bae91233313868ee4d98d7e6dc6efe20db replaced the bind mount with tmpfs.
RabbitMQ was the only broker whose `*_LOGS` export was dead.
`rabbit.log` has zero hits in the failing run's whole artifact bundle.

This restores the mount in the same `${VAR_FS:-tmpfs}` / `${VAR:-}` form the siblings use, so an unset
`RABBITMQ_LOGS` still degrades to tmpfs. `/var/lib/rabbitmq` stays a tmpfs: it holds Mnesia state, and
persisting it would change test semantics.

`test_system_stop.py` passes 21/21 and `test.py` 58/58 with the mount, each producing a `rabbit.log`
of over 100 KB under `_instances*/rabbitmq/logs/`, which the integration job already tars. The new
`test_rabbitmq_broker_log_is_collected` asserts that log exists and is non-empty; reverting the hunk
alone leaves the rest of the module passing and reddens only that test, on an empty log directory.

This neither stops the abort nor explains why the Erlang node failed to register with epmd. #114415
recreates a hung container; this makes the next occurrence diagnosable. #113610 fixed only the second
diagnostics loop of `wait_rabbitmq_to_start` and is not a container-start fix.