### PR TITLE
Show the real per-query verdict in the performance comparison report

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -646,6 +646,38 @@ ORDER BY test, check_start_time
     return f"{base}#{Utils.to_base64(query)}"
 
 
+def build_check_results_children(tests_result, check_name_pattern):
+    """Per-query rows for "Check Results": one row per slower/unstable query.
+
+    Rows carry compare.sh's verdict, which the report renderer classifies
+    natively. They cannot affect the job status: the caller passes "Check
+    Results" an explicit status, and `Result.create_from` aggregates children
+    only when no status is given.
+    """
+    children = []
+    for tr in tests_result.results:
+        # compare.sh emits a row per side; skipping "::old" rather than requiring
+        # "::new" lets a suffixless row through instead of dropping it.
+        if tr.name.endswith("::old"):
+            continue
+        if tr.status not in ("slower", "unstable"):
+            continue
+        sub = Result(
+            name=tr.name.removesuffix("::new"),
+            status=tr.status,
+            duration=tr.duration,
+        )
+        sub.set_label(
+            "query history",
+            # The suffixed name: CIDB's test_name keeps it, and the link
+            # filters on an exact match.
+            link=build_perf_query_history_link(tr.name, check_name_pattern),
+            hint="Performance history for this query on master",
+        )
+        children.append(sub)
+    return children
+
+
 def get_insert_metadata(info, compare_against_release):
     return {
         "ARCH": escape_sql_string(get_perf_arch()),
@@ -1901,23 +1933,9 @@ def main():
             # the stable baseline.  The CIDB check_name looks like
             # "Performance Comparison (arm_release, master_head, 1/6)".
             arch = get_perf_arch()
-            check_name_pattern = f"%Performance%{arch}%master_head%"
-            for tr in tests_result.results:
-                if tr.status in ("slower", "unstable"):
-                    sub = Result(
-                        name=tr.name,
-                        status=Result.Status.FAIL,
-                        info=tr.status,
-                        duration=tr.duration,
-                    )
-                    sub.set_label(
-                        "query history",
-                        link=build_perf_query_history_link(
-                            tr.name, check_name_pattern
-                        ),
-                        hint="Performance history for this query on master",
-                    )
-                    check_sub_results.append(sub)
+            check_sub_results = build_check_results_children(
+                tests_result, f"%Performance%{arch}%master_head%"
+            )
 
         results.append(
             Result(

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -654,23 +654,27 @@ def build_check_results_children(tests_result, check_name_pattern):
     Results" an explicit status, and `Result.create_from` aggregates children
     only when no status is given.
     """
-    children = []
+    # compare.sh emits a row per side, but a truncated ci-checks.tsv can leave a
+    # query with either side alone, so group by query name and represent each
+    # group by its candidate side when it survived.
+    side_priority = {"::new": 0, "": 1, "::old": 2}
+    chosen = {}
     for tr in tests_result.results:
-        # compare.sh emits a row per side; skipping "::old" rather than requiring
-        # "::new" lets a suffixless row through instead of dropping it.
-        if tr.name.endswith("::old"):
-            continue
         if tr.status not in ("slower", "unstable"):
             continue
-        sub = Result(
-            name=tr.name.removesuffix("::new"),
-            status=tr.status,
-            duration=tr.duration,
-        )
+        side = next((s for s in ("::new", "::old") if tr.name.endswith(s)), "")
+        base = tr.name[: len(tr.name) - len(side)]
+        previous = chosen.get(base)
+        if previous is None or side_priority[side] < side_priority[previous[0]]:
+            chosen[base] = (side, tr)
+
+    children = []
+    for base, (_, tr) in chosen.items():
+        sub = Result(name=base, status=tr.status, duration=tr.duration)
         sub.set_label(
             "query history",
-            # The suffixed name: CIDB's test_name keeps it, and the link
-            # filters on an exact match.
+            # The represented row's own name: CIDB's test_name keeps the side
+            # suffix, and the link filters on an exact match.
             link=build_perf_query_history_link(tr.name, check_name_pattern),
             hint="Performance history for this query on master",
         )

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -758,6 +758,7 @@
         const lowerStatus = status.toLowerCase();
         if (lowerStatus === 'xfail') return 'status-other';  // expected failure: gray (known, not alarming)
         if (lowerStatus === 'xpass') return 'status-fail';    // unexpected pass: red
+        if (lowerStatus === 'slower') return 'status-fail';    // perf regression: red, as shouldShowRow counts it
         if (lowerStatus.includes('success') || lowerStatus === 'ok') return 'status-success';
         if (lowerStatus.includes('fail')) return 'status-fail';
         if (lowerStatus.includes('pending')) return 'status-pending';

--- a/ci/tests/fixtures/perf_check_results_green_shard.json
+++ b/ci/tests/fixtures/perf_check_results_green_shard.json
@@ -1,0 +1,414 @@
+{
+ "name": "Performance Comparison (arm_release, master_head, 1/6)",
+ "status": "OK",
+ "info": "3 too long, 1 faster, 11 unstable",
+ "results": [
+  {
+   "name": "Tests",
+   "status": "OK",
+   "duration": 2950.262,
+   "results": [
+    {
+     "name": "aggregate_functions_of_group_by_keys #0::old",
+     "status": "success",
+     "duration": 0.0079
+    },
+    {
+     "name": "aggregate_functions_of_group_by_keys #0::new",
+     "status": "success",
+     "duration": 0.0078
+    },
+    {
+     "name": "aggregate_functions_of_group_by_keys #1::old",
+     "status": "success",
+     "duration": 0.0803
+    },
+    {
+     "name": "aggregate_functions_of_group_by_keys #1::new",
+     "status": "success",
+     "duration": 0.0798
+    },
+    {
+     "name": "aggregate_partitions_independently_default #0::old",
+     "status": "success",
+     "duration": 0.0518
+    },
+    {
+     "name": "aggregate_partitions_independently_default #0::new",
+     "status": "success",
+     "duration": 0.051
+    },
+    {
+     "name": "aggregate_partitions_independently_default #1::old",
+     "status": "success",
+     "duration": 0.2022
+    },
+    {
+     "name": "aggregate_partitions_independently_default #1::new",
+     "status": "success",
+     "duration": 0.1992
+    },
+    {
+     "name": "aggregate_partitions_independently_default #2::old",
+     "status": "success",
+     "duration": 0.0519
+    },
+    {
+     "name": "aggregate_partitions_independently_default #2::new",
+     "status": "success",
+     "duration": 0.0496
+    },
+    {
+     "name": "aggregate_partitions_independently_default #3::old",
+     "status": "success",
+     "duration": 0.1996
+    },
+    {
+     "name": "aggregate_partitions_independently_default #3::new",
+     "status": "success",
+     "duration": 0.2005
+    },
+    {
+     "name": "aggregating_merge_tree #0::old",
+     "status": "success",
+     "duration": 0.1325
+    },
+    {
+     "name": "aggregating_merge_tree #0::new",
+     "status": "success",
+     "duration": 0.1322
+    },
+    {
+     "name": "aggregation_in_order_2 #0::old",
+     "status": "success",
+     "duration": 0.0229
+    },
+    {
+     "name": "aggregation_in_order_2 #0::new",
+     "status": "success",
+     "duration": 0.0237
+    },
+    {
+     "name": "aggregation_in_order_2 #1::old",
+     "status": "success",
+     "duration": 0.0271
+    },
+    {
+     "name": "aggregation_in_order_2 #1::new",
+     "status": "success",
+     "duration": 0.0275
+    },
+    {
+     "name": "aggregation_in_order_2 #2::old",
+     "status": "success",
+     "duration": 0.2309
+    },
+    {
+     "name": "aggregation_in_order_2 #2::new",
+     "status": "success",
+     "duration": 0.231
+    },
+    {
+     "name": "aggregation_in_order_2 #3::old",
+     "status": "success",
+     "duration": 0.1263
+    },
+    {
+     "name": "aggregation_in_order_2 #3::new",
+     "status": "success",
+     "duration": 0.118
+    },
+    {
+     "name": "aggregation_in_order_2 #4::old",
+     "status": "success",
+     "duration": 0.1131
+    },
+    {
+     "name": "aggregation_in_order_2 #4::new",
+     "status": "success",
+     "duration": 0.1149
+    },
+    {
+     "name": "aggregation_in_order_2 #5::old",
+     "status": "success",
+     "duration": 0.2941
+    },
+    {
+     "name": "aggregation_in_order_2 #5::new",
+     "status": "success",
+     "duration": 0.2935
+    },
+    {
+     "name": "aggregation_in_order_2 #6::old",
+     "status": "success",
+     "duration": 0.4232
+    },
+    {
+     "name": "aggregation_in_order_2 #6::new",
+     "status": "success",
+     "duration": 0.418
+    },
+    {
+     "name": "aggregation_in_order_2 #7::old",
+     "status": "success",
+     "duration": 0.438
+    },
+    {
+     "name": "aggregation_in_order_2 #7::new",
+     "status": "success",
+     "duration": 0.4115
+    },
+    {
+     "name": "dotProduct #1::old",
+     "status": "unstable",
+     "duration": 0.1539
+    },
+    {
+     "name": "dotProduct #1::new",
+     "status": "unstable",
+     "duration": 0.1624
+    },
+    {
+     "name": "dotProduct #2::old",
+     "status": "unstable",
+     "duration": 0.2393
+    },
+    {
+     "name": "dotProduct #2::new",
+     "status": "unstable",
+     "duration": 0.3035
+    },
+    {
+     "name": "dotProduct #4::old",
+     "status": "unstable",
+     "duration": 0.1615
+    },
+    {
+     "name": "dotProduct #4::new",
+     "status": "unstable",
+     "duration": 0.1598
+    },
+    {
+     "name": "dotProduct #5::old",
+     "status": "unstable",
+     "duration": 0.2108
+    },
+    {
+     "name": "dotProduct #5::new",
+     "status": "unstable",
+     "duration": 0.3039
+    },
+    {
+     "name": "group_by_multiple_strings #4::old",
+     "status": "unstable",
+     "duration": 0.0201
+    },
+    {
+     "name": "group_by_multiple_strings #4::new",
+     "status": "unstable",
+     "duration": 0.0161
+    },
+    {
+     "name": "group_by_multiple_strings #28::old",
+     "status": "unstable",
+     "duration": 0.1308
+    },
+    {
+     "name": "group_by_multiple_strings #28::new",
+     "status": "unstable",
+     "duration": 0.1285
+    },
+    {
+     "name": "map_bucketed_serialization #3::old",
+     "status": "unstable",
+     "duration": 0.0615
+    },
+    {
+     "name": "map_bucketed_serialization #3::new",
+     "status": "unstable",
+     "duration": 0.0704
+    },
+    {
+     "name": "polymorphic_parts_m #0::old",
+     "status": "unstable",
+     "duration": 1.2923
+    },
+    {
+     "name": "polymorphic_parts_m #0::new",
+     "status": "unstable",
+     "duration": 1.2146
+    },
+    {
+     "name": "polymorphic_parts_m #2::old",
+     "status": "unstable",
+     "duration": 3.1275
+    },
+    {
+     "name": "polymorphic_parts_m #2::new",
+     "status": "unstable",
+     "duration": 2.7559
+    },
+    {
+     "name": "set #8::old",
+     "status": "unstable",
+     "duration": 0.1806
+    },
+    {
+     "name": "set #8::new",
+     "status": "unstable",
+     "duration": 0.1896
+    },
+    {
+     "name": "set #9::old",
+     "status": "unstable",
+     "duration": 0.1435
+    },
+    {
+     "name": "set #9::new",
+     "status": "unstable",
+     "duration": 0.1465
+    }
+   ]
+  },
+  {
+   "name": "Check Results",
+   "status": "OK",
+   "info": "3 too long, 1 faster, 11 unstable",
+   "duration": 0.000514984130859375,
+   "results": [
+    {
+     "name": "dotProduct #1::old",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.1539
+    },
+    {
+     "name": "dotProduct #1::new",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.1624
+    },
+    {
+     "name": "dotProduct #2::old",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.2393
+    },
+    {
+     "name": "dotProduct #2::new",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.3035
+    },
+    {
+     "name": "dotProduct #4::old",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.1615
+    },
+    {
+     "name": "dotProduct #4::new",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.1598
+    },
+    {
+     "name": "dotProduct #5::old",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.2108
+    },
+    {
+     "name": "dotProduct #5::new",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.3039
+    },
+    {
+     "name": "group_by_multiple_strings #4::old",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.0201
+    },
+    {
+     "name": "group_by_multiple_strings #4::new",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.0161
+    },
+    {
+     "name": "group_by_multiple_strings #28::old",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.1308
+    },
+    {
+     "name": "group_by_multiple_strings #28::new",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.1285
+    },
+    {
+     "name": "map_bucketed_serialization #3::old",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.0615
+    },
+    {
+     "name": "map_bucketed_serialization #3::new",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.0704
+    },
+    {
+     "name": "polymorphic_parts_m #0::old",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 1.2923
+    },
+    {
+     "name": "polymorphic_parts_m #0::new",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 1.2146
+    },
+    {
+     "name": "polymorphic_parts_m #2::old",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 3.1275
+    },
+    {
+     "name": "polymorphic_parts_m #2::new",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 2.7559
+    },
+    {
+     "name": "set #8::old",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.1806
+    },
+    {
+     "name": "set #8::new",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.1896
+    },
+    {
+     "name": "set #9::old",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.1435
+    },
+    {
+     "name": "set #9::new",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.1465
+    }
+   ]
+  }
+ ]
+}

--- a/ci/tests/fixtures/perf_check_results_red_shard.json
+++ b/ci/tests/fixtures/perf_check_results_red_shard.json
@@ -1,0 +1,590 @@
+{
+ "name": "Performance Comparison (arm_release, release_base, 3/6)",
+ "status": "FAIL",
+ "info": "6 too long, 9 faster, 18 slower, 1 unstable",
+ "results": [
+  {
+   "name": "Tests",
+   "status": "OK",
+   "duration": 3699.409,
+   "results": [
+    {
+     "name": "aggregate_with_serialized_method #0::old",
+     "status": "success",
+     "duration": 0.4171
+    },
+    {
+     "name": "aggregate_with_serialized_method #0::new",
+     "status": "success",
+     "duration": 0.459
+    },
+    {
+     "name": "aggregate_with_serialized_method #1::old",
+     "status": "success",
+     "duration": 0.3483
+    },
+    {
+     "name": "aggregate_with_serialized_method #1::new",
+     "status": "success",
+     "duration": 0.3854
+    },
+    {
+     "name": "aggregate_with_serialized_method #2::old",
+     "status": "success",
+     "duration": 0.4489
+    },
+    {
+     "name": "aggregate_with_serialized_method #2::new",
+     "status": "success",
+     "duration": 0.4771
+    },
+    {
+     "name": "aggregate_with_serialized_method #3::old",
+     "status": "success",
+     "duration": 0.4894
+    },
+    {
+     "name": "aggregate_with_serialized_method #3::new",
+     "status": "success",
+     "duration": 0.5199
+    },
+    {
+     "name": "aggregate_with_serialized_method #4::old",
+     "status": "success",
+     "duration": 0.5515
+    },
+    {
+     "name": "aggregate_with_serialized_method #4::new",
+     "status": "success",
+     "duration": 0.5866
+    },
+    {
+     "name": "aggregating_merge_tree #0::old",
+     "status": "success",
+     "duration": 0.1268
+    },
+    {
+     "name": "aggregating_merge_tree #0::new",
+     "status": "success",
+     "duration": 0.1274
+    },
+    {
+     "name": "aggregation_in_order_2 #0::old",
+     "status": "success",
+     "duration": 0.0219
+    },
+    {
+     "name": "aggregation_in_order_2 #0::new",
+     "status": "success",
+     "duration": 0.0237
+    },
+    {
+     "name": "aggregation_in_order_2 #1::old",
+     "status": "success",
+     "duration": 0.0284
+    },
+    {
+     "name": "aggregation_in_order_2 #1::new",
+     "status": "success",
+     "duration": 0.029
+    },
+    {
+     "name": "aggregation_in_order_2 #2::old",
+     "status": "success",
+     "duration": 0.2324
+    },
+    {
+     "name": "aggregation_in_order_2 #2::new",
+     "status": "success",
+     "duration": 0.2298
+    },
+    {
+     "name": "aggregation_in_order_2 #3::old",
+     "status": "success",
+     "duration": 0.1193
+    },
+    {
+     "name": "aggregation_in_order_2 #3::new",
+     "status": "success",
+     "duration": 0.1281
+    },
+    {
+     "name": "aggregation_in_order_2 #4::old",
+     "status": "success",
+     "duration": 0.1175
+    },
+    {
+     "name": "aggregation_in_order_2 #4::new",
+     "status": "success",
+     "duration": 0.1254
+    },
+    {
+     "name": "aggregation_in_order_2 #5::old",
+     "status": "success",
+     "duration": 0.3172
+    },
+    {
+     "name": "aggregation_in_order_2 #5::new",
+     "status": "success",
+     "duration": 0.3211
+    },
+    {
+     "name": "aggregation_in_order_2 #6::old",
+     "status": "success",
+     "duration": 0.4979
+    },
+    {
+     "name": "aggregation_in_order_2 #6::new",
+     "status": "success",
+     "duration": 0.5007
+    },
+    {
+     "name": "aggregation_in_order_2 #7::old",
+     "status": "success",
+     "duration": 0.4205
+    },
+    {
+     "name": "aggregation_in_order_2 #7::new",
+     "status": "success",
+     "duration": 0.4536
+    },
+    {
+     "name": "aggregation_in_order_2 #8::old",
+     "status": "success",
+     "duration": 0.5091
+    },
+    {
+     "name": "aggregation_in_order_2 #8::new",
+     "status": "success",
+     "duration": 0.5235
+    },
+    {
+     "name": "array_join #1::old",
+     "status": "slower",
+     "duration": 0.1011
+    },
+    {
+     "name": "array_join #1::new",
+     "status": "slower",
+     "duration": 0.1373
+    },
+    {
+     "name": "array_join #2::old",
+     "status": "slower",
+     "duration": 0.2073
+    },
+    {
+     "name": "array_join #2::new",
+     "status": "slower",
+     "duration": 0.2483
+    },
+    {
+     "name": "array_join #3::old",
+     "status": "slower",
+     "duration": 0.2113
+    },
+    {
+     "name": "array_join #3::new",
+     "status": "slower",
+     "duration": 0.254
+    },
+    {
+     "name": "array_join #4::old",
+     "status": "slower",
+     "duration": 0.2457
+    },
+    {
+     "name": "array_join #4::new",
+     "status": "slower",
+     "duration": 0.2928
+    },
+    {
+     "name": "array_join #5::old",
+     "status": "slower",
+     "duration": 0.2443
+    },
+    {
+     "name": "array_join #5::new",
+     "status": "slower",
+     "duration": 0.2896
+    },
+    {
+     "name": "decimal_aggregates #18::old",
+     "status": "unstable",
+     "duration": 0.1438
+    },
+    {
+     "name": "decimal_aggregates #18::new",
+     "status": "unstable",
+     "duration": 0.0817
+    },
+    {
+     "name": "group_array_moving_sum #6::old",
+     "status": "slower",
+     "duration": 0.3191
+    },
+    {
+     "name": "group_array_moving_sum #6::new",
+     "status": "slower",
+     "duration": 0.4021
+    },
+    {
+     "name": "group_array_moving_sum #7::old",
+     "status": "slower",
+     "duration": 0.337
+    },
+    {
+     "name": "group_array_moving_sum #7::new",
+     "status": "slower",
+     "duration": 0.3942
+    },
+    {
+     "name": "group_array_moving_sum #8::old",
+     "status": "slower",
+     "duration": 0.3227
+    },
+    {
+     "name": "group_array_moving_sum #8::new",
+     "status": "slower",
+     "duration": 0.4035
+    },
+    {
+     "name": "insert_select_default_small_block #0::old",
+     "status": "slower",
+     "duration": 0.1034
+    },
+    {
+     "name": "insert_select_default_small_block #0::new",
+     "status": "slower",
+     "duration": 0.1315
+    },
+    {
+     "name": "limit_by_in_pk_order #0::old",
+     "status": "slower",
+     "duration": 0.0243
+    },
+    {
+     "name": "limit_by_in_pk_order #0::new",
+     "status": "slower",
+     "duration": 0.031
+    },
+    {
+     "name": "limit_by_in_pk_order #4::old",
+     "status": "slower",
+     "duration": 0.0256
+    },
+    {
+     "name": "limit_by_in_pk_order #4::new",
+     "status": "slower",
+     "duration": 0.032
+    },
+    {
+     "name": "limit_by_in_pk_order #6::old",
+     "status": "slower",
+     "duration": 0.025
+    },
+    {
+     "name": "limit_by_in_pk_order #6::new",
+     "status": "slower",
+     "duration": 0.0322
+    },
+    {
+     "name": "limit_by_in_pk_order #7::old",
+     "status": "slower",
+     "duration": 0.0307
+    },
+    {
+     "name": "limit_by_in_pk_order #7::new",
+     "status": "slower",
+     "duration": 0.0386
+    },
+    {
+     "name": "limit_by_in_pk_order #9::old",
+     "status": "slower",
+     "duration": 0.0364
+    },
+    {
+     "name": "limit_by_in_pk_order #9::new",
+     "status": "slower",
+     "duration": 0.0496
+    },
+    {
+     "name": "limit_by_partitions #21::old",
+     "status": "slower",
+     "duration": 0.0119
+    },
+    {
+     "name": "limit_by_partitions #21::new",
+     "status": "slower",
+     "duration": 0.0155
+    },
+    {
+     "name": "scalar #0::old",
+     "status": "slower",
+     "duration": 0.0984
+    },
+    {
+     "name": "scalar #0::new",
+     "status": "slower",
+     "duration": 0.1157
+    },
+    {
+     "name": "utc_timestamp_transform #2::old",
+     "status": "slower",
+     "duration": 0.067
+    },
+    {
+     "name": "utc_timestamp_transform #2::new",
+     "status": "slower",
+     "duration": 0.1806
+    },
+    {
+     "name": "utc_timestamp_transform #3::old",
+     "status": "slower",
+     "duration": 0.067
+    },
+    {
+     "name": "utc_timestamp_transform #3::new",
+     "status": "slower",
+     "duration": 0.1806
+    }
+   ]
+  },
+  {
+   "name": "Check Results",
+   "status": "FAIL",
+   "info": "6 too long, 9 faster, 18 slower, 1 unstable",
+   "duration": 0.0005431175231933594,
+   "results": [
+    {
+     "name": "array_join #1::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.1011
+    },
+    {
+     "name": "array_join #1::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.1373
+    },
+    {
+     "name": "array_join #2::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.2073
+    },
+    {
+     "name": "array_join #2::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.2483
+    },
+    {
+     "name": "array_join #3::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.2113
+    },
+    {
+     "name": "array_join #3::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.254
+    },
+    {
+     "name": "array_join #4::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.2457
+    },
+    {
+     "name": "array_join #4::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.2928
+    },
+    {
+     "name": "array_join #5::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.2443
+    },
+    {
+     "name": "array_join #5::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.2896
+    },
+    {
+     "name": "decimal_aggregates #18::old",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.1438
+    },
+    {
+     "name": "decimal_aggregates #18::new",
+     "status": "FAIL",
+     "info": "unstable",
+     "duration": 0.0817
+    },
+    {
+     "name": "group_array_moving_sum #6::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.3191
+    },
+    {
+     "name": "group_array_moving_sum #6::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.4021
+    },
+    {
+     "name": "group_array_moving_sum #7::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.337
+    },
+    {
+     "name": "group_array_moving_sum #7::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.3942
+    },
+    {
+     "name": "group_array_moving_sum #8::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.3227
+    },
+    {
+     "name": "group_array_moving_sum #8::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.4035
+    },
+    {
+     "name": "insert_select_default_small_block #0::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.1034
+    },
+    {
+     "name": "insert_select_default_small_block #0::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.1315
+    },
+    {
+     "name": "limit_by_in_pk_order #0::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.0243
+    },
+    {
+     "name": "limit_by_in_pk_order #0::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.031
+    },
+    {
+     "name": "limit_by_in_pk_order #4::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.0256
+    },
+    {
+     "name": "limit_by_in_pk_order #4::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.032
+    },
+    {
+     "name": "limit_by_in_pk_order #6::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.025
+    },
+    {
+     "name": "limit_by_in_pk_order #6::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.0322
+    },
+    {
+     "name": "limit_by_in_pk_order #7::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.0307
+    },
+    {
+     "name": "limit_by_in_pk_order #7::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.0386
+    },
+    {
+     "name": "limit_by_in_pk_order #9::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.0364
+    },
+    {
+     "name": "limit_by_in_pk_order #9::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.0496
+    },
+    {
+     "name": "limit_by_partitions #21::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.0119
+    },
+    {
+     "name": "limit_by_partitions #21::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.0155
+    },
+    {
+     "name": "scalar #0::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.0984
+    },
+    {
+     "name": "scalar #0::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.1157
+    },
+    {
+     "name": "utc_timestamp_transform #2::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.067
+    },
+    {
+     "name": "utc_timestamp_transform #2::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.1806
+    },
+    {
+     "name": "utc_timestamp_transform #3::old",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.067
+    },
+    {
+     "name": "utc_timestamp_transform #3::new",
+     "status": "FAIL",
+     "info": "slower",
+     "duration": 0.1806
+    }
+   ]
+  }
+ ]
+}

--- a/ci/tests/test_perf_check_results_children.py
+++ b/ci/tests/test_perf_check_results_children.py
@@ -1,0 +1,330 @@
+"""
+Tests for `ci.jobs.performance_tests.build_check_results_children`.
+
+The "Check Results" sub-result exists only to hang a per-query CIDB history link
+on every slower/unstable query. Two properties of those rows are what a human
+triaging a perf shard actually reads, and both are asserted here against real
+report artifacts:
+
+  * a row's status is the verdict compare.sh computed for that query, so a shard
+    that passed does not render a list of red rows;
+  * there is one row per query, not one per side - compare.sh emits both
+    ("<query>::old" and "<query>::new") from `array join map('old', left, 'new',
+    right)`, which otherwise doubles every count a reader sees.
+
+The two fixtures are trimmed copies of real `result_performance_comparison_*.json`
+artifacts, so the oracle is self-checking: the parent's own message states the
+QUERY count, which must equal the number of rows.
+"""
+
+import base64
+import collections
+import inspect
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+import ci.jobs.performance_tests as performance_tests
+from ci.jobs.performance_tests import (
+    build_check_results_children,
+    too_many_slow,
+)
+from ci.praktika.result import Result
+
+FIXTURES = Path(__file__).parent / "fixtures"
+CHECK_NAME_PATTERN = "%Performance%arm%master_head%"
+
+# Statuses compare.sh emits for a query that did not come out clean
+# (`multiIf(... 'slower', ... 'unstable', 'success')`).
+NON_SUCCESS_STATUSES = ("slower", "unstable")
+
+
+def _load(fixture):
+    with open(FIXTURES / fixture, encoding="utf8") as f:
+        return Result.from_dict(json.load(f))
+
+
+def _parse_message_counts(message):
+    """{'slower': 18, 'unstable': 1} from "6 too long, 9 faster, 18 slower, 1 unstable"."""
+    return {
+        status: int(count)
+        for count, status in re.findall(
+            r"(\d+)\s+(slower|unstable)", message
+        )
+    }
+
+
+def _link_test_name(child):
+    """The test_name the child's history link filters on."""
+    labels = child.ext.get("labels") or []
+    assert len(labels) == 1, f"expected one label on [{child.name}], got {labels}"
+    label = labels[0]
+    assert label["name"] == "query history", label
+    assert label.get("link"), f"empty history link on [{child.name}]"
+    query = base64.b64decode(label["link"].split("#", 1)[1]).decode("utf8")
+    match = re.search(r"test_name = '([^']*)'", query)
+    assert match, f"history link for [{child.name}] does not filter test_name"
+    return match.group(1)
+
+
+def _base_name(name):
+    return name.removesuffix("::old").removesuffix("::new")
+
+
+# ---------------------------------------------------------------------------
+# The two real artifacts. Each case is (fixture, parent status, pre-fix row count).
+# ---------------------------------------------------------------------------
+
+CASES = [
+    # The shard reported in PR #111992: it PASSED, yet rendered 22 red rows for
+    # 11 unstable queries.
+    ("perf_check_results_green_shard.json", Result.Status.OK, 22),
+    # A genuinely failing release_base shard - the negative control, and the
+    # only fixture carrying `slower` rows.
+    ("perf_check_results_red_shard.json", Result.Status.FAIL, 38),
+]
+
+
+def test_row_count_equals_query_count_from_parent_message():
+    # The parent's message counts QUERIES, so it is an independent oracle for
+    # the number of rows: it comes from report.py, not from this code path.
+    for fixture, _, pre_fix_count in CASES:
+        root = _load(fixture)
+        expected = sum(_parse_message_counts(root.info).values())
+        children = build_check_results_children(
+            root.get_sub_result_by_name("Tests"), CHECK_NAME_PATTERN
+        )
+        assert len(children) == expected, (
+            f"{fixture}: {len(children)} rows for a parent reporting "
+            f"{expected} queries ({root.info!r})"
+        )
+        # Both sides of every query used to be listed.
+        assert pre_fix_count == 2 * expected, fixture
+        assert len(children) == pre_fix_count // 2, fixture
+
+
+def test_row_count_equals_distinct_query_names():
+    for fixture, _, _ in CASES:
+        root = _load(fixture)
+        tests = root.get_sub_result_by_name("Tests")
+        distinct = {
+            _base_name(r.name)
+            for r in tests.results
+            if r.status in NON_SUCCESS_STATUSES
+        }
+        children = build_check_results_children(tests, CHECK_NAME_PATTERN)
+        assert {c.name for c in children} == distinct, fixture
+
+
+def test_rows_carry_the_compare_sh_verdict_not_fail():
+    # A hardcoded FAIL is what made a passing shard render red.
+    for fixture, _, _ in CASES:
+        root = _load(fixture)
+        tests = root.get_sub_result_by_name("Tests")
+        children = build_check_results_children(tests, CHECK_NAME_PATTERN)
+        verdicts = {
+            _base_name(r.name): r.status
+            for r in tests.results
+            if r.status in NON_SUCCESS_STATUSES
+        }
+        for child in children:
+            assert child.status != Result.Status.FAIL, f"{fixture}: {child.name}"
+            assert child.status in NON_SUCCESS_STATUSES, (
+                f"{fixture}: {child.name} has status {child.status!r}"
+            )
+            assert child.status == verdicts[child.name], f"{fixture}: {child.name}"
+
+
+def test_expected_verdict_mix_per_fixture():
+    # Pinned so a fixture swap cannot quietly drop `slower` coverage: only the
+    # red shard exercises it, and it is the status the renderer paints red.
+    green = build_check_results_children(
+        _load(CASES[0][0]).get_sub_result_by_name("Tests"), CHECK_NAME_PATTERN
+    )
+    red = build_check_results_children(
+        _load(CASES[1][0]).get_sub_result_by_name("Tests"), CHECK_NAME_PATTERN
+    )
+    assert collections.Counter(c.status for c in green) == {"unstable": 11}
+    assert collections.Counter(c.status for c in red) == {
+        "slower": 18,
+        "unstable": 1,
+    }
+
+
+def test_displayed_names_carry_no_side_suffix():
+    for fixture, _, _ in CASES:
+        root = _load(fixture)
+        children = build_check_results_children(
+            root.get_sub_result_by_name("Tests"), CHECK_NAME_PATTERN
+        )
+        for child in children:
+            assert "::" not in child.name, f"{fixture}: {child.name}"
+
+
+def test_history_link_keeps_the_suffixed_name():
+    # `build_perf_query_history_link` filters `test_name = '...'`, an exact
+    # match, and CIDB stores the suffixed name. Handing it the displayed name
+    # returns zero rows for every query, with no visible error.
+    for fixture, _, _ in CASES:
+        root = _load(fixture)
+        children = build_check_results_children(
+            root.get_sub_result_by_name("Tests"), CHECK_NAME_PATTERN
+        )
+        for child in children:
+            assert _link_test_name(child) == f"{child.name}::new", fixture
+
+
+def test_only_the_candidate_side_is_kept():
+    tests = Result(
+        name="Tests",
+        status=Result.Status.OK,
+        results=[
+            Result(name="q #1::old", status="unstable", duration=1.0),
+            Result(name="q #1::new", status="unstable", duration=2.0),
+        ],
+    )
+    children = build_check_results_children(tests, CHECK_NAME_PATTERN)
+    assert [c.name for c in children] == ["q #1"]
+    # The candidate side's timing, not the reference side's.
+    assert children[0].duration == 2.0
+
+
+def test_successful_queries_are_not_listed():
+    tests = Result(
+        name="Tests",
+        status=Result.Status.OK,
+        results=[
+            Result(name="q #1::old", status="success"),
+            Result(name="q #1::new", status="success"),
+            Result(name="q #2::old", status="slower"),
+            Result(name="q #2::new", status="slower"),
+        ],
+    )
+    children = build_check_results_children(tests, CHECK_NAME_PATTERN)
+    assert [(c.name, c.status) for c in children] == [("q #2", "slower")]
+
+
+def test_suffixless_row_passes_through_unchanged():
+    # Nothing emits such a row today. Dropping it silently would be the wrong
+    # failure mode if compare.sh ever stopped splitting sides, so the filter
+    # skips "::old" instead of requiring "::new".
+    tests = Result(
+        name="Tests",
+        status=Result.Status.OK,
+        results=[Result(name="q #7", status="slower", duration=3.0)],
+    )
+    children = build_check_results_children(tests, CHECK_NAME_PATTERN)
+    assert [c.name for c in children] == ["q #7"]
+    assert _link_test_name(children[0]) == "q #7"
+
+
+def test_suffix_stripping_is_anchored_to_the_end():
+    tests = Result(
+        name="Tests",
+        status=Result.Status.OK,
+        results=[Result(name="q::new #1::new", status="unstable")],
+    )
+    children = build_check_results_children(tests, CHECK_NAME_PATTERN)
+    assert [c.name for c in children] == ["q::new #1"]
+
+
+def test_both_sides_of_a_query_agree_on_status():
+    # Selecting one side is only sound because `test_status` is computed from
+    # the per-query columns of report/queries.tsv before compare.sh array-joins
+    # `map('old', left, 'new', right)`. If that ever moves after the join, the
+    # sides can disagree and this assertion says why the selection is wrong.
+    for fixture, _, _ in CASES:
+        rows = _load(fixture).get_sub_result_by_name("Tests").results
+        by_query = collections.defaultdict(set)
+        sides = collections.Counter()
+        for r in rows:
+            by_query[_base_name(r.name)].add(r.status)
+            sides[_base_name(r.name)] += 1
+        disagreeing = {q: s for q, s in by_query.items() if len(s) > 1}
+        assert not disagreeing, f"{fixture}: {disagreeing}"
+        # Every query really does carry both sides, or the check above is
+        # vacuous: a one-sided query trivially agrees with itself.
+        assert set(sides.values()) == {2}, (
+            f"{fixture}: side counts {collections.Counter(sides.values())}"
+        )
+
+
+def test_per_query_rows_cannot_change_the_job_status():
+    # "Check Results" is built with an explicit status, and `Result.create_from`
+    # aggregates children only when no status is given
+    # (`if results and not status`). That is why correcting these rows cannot
+    # turn a passing shard red. If the guard goes away, this fails here instead
+    # of reddening every perf shard in CI.
+    failing = [Result(name="q #1", status=Result.Status.FAIL, info="unstable")]
+    assert (
+        Result.create_from(
+            name="Check Results", results=failing, status=Result.Status.OK
+        ).status
+        == Result.Status.OK
+    )
+    assert (
+        Result.create_from(name="Check Results", results=failing).status
+        == Result.Status.FAIL
+    )
+
+
+def test_parent_status_is_preserved_for_both_fixtures():
+    # The negative control: a genuinely failing shard must stay FAIL, and a
+    # passing one must stay OK, with the corrected rows underneath.
+    for fixture, expected_status, _ in CASES:
+        root = _load(fixture)
+        children = build_check_results_children(
+            root.get_sub_result_by_name("Tests"), CHECK_NAME_PATTERN
+        )
+        parent = Result(
+            name="Check Results",
+            status=root.status,
+            info=root.info,
+            results=children,
+        )
+        job = Result.create_from(
+            name=root.name,
+            results=[root.get_sub_result_by_name("Tests"), parent],
+            info=root.info,
+        )
+        assert parent.status == expected_status, fixture
+        assert job.status == expected_status, fixture
+
+
+def test_slow_query_gate_is_untouched():
+    # The job verdict comes from the slower-query gate, not from these rows.
+    assert too_many_slow("11 slower") is True
+    assert too_many_slow("10 slower") is False
+
+
+def test_renderer_paints_the_two_verdicts():
+    # There is no JS runner in ci/tests, so assert the mapping at its source.
+    # `shouldShowRow` counts 'slower' as a failure and 'unstable' as a warning;
+    # `getStatusClass` has to agree, or a slower query renders gray.
+    source = (
+        Path(__file__).parents[1] / "praktika" / "json.html"
+    ).read_text(encoding="utf8")
+    assert "if (lowerStatus === 'slower') return 'status-fail';" in source
+    assert "status_ === 'slower')" in source
+    assert "status_ === 'unstable'" in source
+    # 'unstable' must NOT be painted as a failure: it is a warning.
+    assert "=== 'unstable') return 'status-fail'" not in source
+
+
+def test_hardcoded_fail_is_not_reintroduced():
+    source = inspect.getsource(performance_tests.build_check_results_children)
+    assert "Result.Status.FAIL" not in source, (
+        "A hardcoded FAIL renders a passing perf shard as a list of red rows. "
+        "Pass compare.sh's verdict (tr.status) through instead."
+    )
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+    print("All perf Check Results children tests passed.")

--- a/ci/tests/test_perf_check_results_children.py
+++ b/ci/tests/test_perf_check_results_children.py
@@ -24,6 +24,7 @@ import json
 import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
@@ -31,6 +32,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 import ci.jobs.performance_tests as performance_tests
 from ci.jobs.performance_tests import (
     build_check_results_children,
+    read_ci_checks_results,
     too_many_slow,
 )
 from ci.praktika.result import Result
@@ -200,6 +202,117 @@ def test_only_the_candidate_side_is_kept():
     assert children[0].duration == 2.0
 
 
+def test_orphaned_reference_side_still_lists_its_query():
+    # `read_ci_checks_results` imports the intact rows of a torn ci-checks.tsv,
+    # and rows are emitted "::old" before "::new", so a cut tail leaves a query
+    # represented by its "::old" side alone. Dropping it loses the query and its
+    # history link, and breaks the one-row-per-query count.
+    columns = [
+        ("pull_request_number", "UInt32"),
+        ("commit_sha", "LowCardinality(String)"),
+        ("check_name", "LowCardinality(String)"),
+        ("check_status", "LowCardinality(String)"),
+        ("check_duration_ms", "UInt64"),
+        ("check_start_time", "DateTime"),
+        ("test_name", "LowCardinality(String)"),
+        ("test_status", "LowCardinality(String)"),
+        ("test_duration_ms", "Float64"),
+        ("report_url", "String"),
+        ("pull_request_url", "String"),
+        ("commit_url", "String"),
+        ("task_url", "String"),
+        ("base_ref", "String"),
+        ("base_repo", "String"),
+        ("head_ref", "String"),
+        ("head_repo", "String"),
+    ]
+
+    def row(test_name, test_status, duration_ms):
+        return "\t".join(
+            ["0", "6c5c34bf", "Performance Comparison (arm_release, master_head, 1/6)"]
+            + ["success", "4740000", "2026-07-26 22:11:03"]
+            + [test_name, test_status, duration_ms]
+            + ["https://report", "https://pr", "", "", "", "", "", ""]
+        )
+
+    rows = [
+        row("q_a.xml #0::old", "unstable", "1000"),
+        row("q_a.xml #0::new", "unstable", "1100"),
+        row("q_b.xml #1::old", "unstable", "2000"),
+        row("q_b.xml #1::new", "unstable", "2100"),
+    ]
+    text = "\n".join(
+        ["\t".join(c for c, _ in columns), "\t".join(t for _, t in columns)]
+        + [row("", "2 unstable", "0")]
+        + rows
+    ) + "\n"
+    # Cut inside the final "::new" row, the ENOSPC shape compare.sh leaves.
+    truncated = text[: text.rindex(rows[3]) + 30]
+
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "ci-checks.tsv"
+        path.write_text(truncated, encoding="utf8")
+        parsed, malformed, complete = read_ci_checks_results(path)
+
+    assert complete is True
+    assert malformed == 1
+    # The fixture is only meaningful if the parser really did leave an orphan.
+    assert [r.name for r in parsed] == [
+        "q_a.xml #0::old",
+        "q_a.xml #0::new",
+        "q_b.xml #1::old",
+    ]
+
+    tests = Result(name="Tests", status=Result.Status.OK, results=parsed)
+    children = build_check_results_children(tests, CHECK_NAME_PATTERN)
+    assert [(c.name, c.status) for c in children] == [
+        ("q_a.xml #0", "unstable"),
+        ("q_b.xml #1", "unstable"),
+    ]
+    # The orphan's link must resolve, so it keeps the side CIDB stored.
+    assert _link_test_name(children[1]) == "q_b.xml #1::old"
+
+
+def test_reference_side_alone_keeps_its_own_duration():
+    tests = Result(
+        name="Tests",
+        status=Result.Status.OK,
+        results=[Result(name="q #1::old", status="slower", duration=4.0)],
+    )
+    children = build_check_results_children(tests, CHECK_NAME_PATTERN)
+    assert [(c.name, c.status, c.duration) for c in children] == [("q #1", "slower", 4.0)]
+
+
+def test_side_order_in_the_file_does_not_change_the_representative():
+    # The importer preserves compare.sh's order, but the selection must not
+    # depend on it: the candidate side wins from either position.
+    for names in (["q #1::old", "q #1::new"], ["q #1::new", "q #1::old"]):
+        tests = Result(
+            name="Tests",
+            status=Result.Status.OK,
+            results=[
+                Result(name=names[0], status="unstable", duration=1.0),
+                Result(name=names[1], status="unstable", duration=2.0),
+            ],
+        )
+        children = build_check_results_children(tests, CHECK_NAME_PATTERN)
+        assert [c.name for c in children] == ["q #1"], names
+        assert _link_test_name(children[0]) == "q #1::new", names
+
+
+def test_query_order_is_preserved():
+    tests = Result(
+        name="Tests",
+        status=Result.Status.OK,
+        results=[
+            Result(name=name, status="unstable")
+            for name in ("q_c #0::old", "q_c #0::new", "q_a #1::old", "q_a #1::new")
+        ],
+    )
+    children = build_check_results_children(tests, CHECK_NAME_PATTERN)
+    assert [c.name for c in children] == ["q_c #0", "q_a #1"]
+
+
 def test_successful_queries_are_not_listed():
     tests = Result(
         name="Tests",
@@ -217,8 +330,8 @@ def test_successful_queries_are_not_listed():
 
 def test_suffixless_row_passes_through_unchanged():
     # Nothing emits such a row today. Dropping it silently would be the wrong
-    # failure mode if compare.sh ever stopped splitting sides, so the filter
-    # skips "::old" instead of requiring "::new".
+    # failure mode if compare.sh ever stopped splitting sides, so a query with
+    # no side suffix is represented by itself.
     tests = Result(
         name="Tests",
         status=Result.Status.OK,

--- a/ci/tests/test_perf_check_results_children.py
+++ b/ci/tests/test_perf_check_results_children.py
@@ -95,6 +95,9 @@ def test_row_count_equals_query_count_from_parent_message():
     for fixture, _, pre_fix_count in CASES:
         root = _load(fixture)
         expected = sum(_parse_message_counts(root.info).values())
+        # A fixture whose message lost its counts would make every assertion
+        # below trivially true.
+        assert expected > 0, f"{fixture}: no counts in {root.info!r}"
         children = build_check_results_children(
             root.get_sub_result_by_name("Tests"), CHECK_NAME_PATTERN
         )
@@ -116,6 +119,7 @@ def test_row_count_equals_distinct_query_names():
             for r in tests.results
             if r.status in NON_SUCCESS_STATUSES
         }
+        assert distinct, fixture
         children = build_check_results_children(tests, CHECK_NAME_PATTERN)
         assert {c.name for c in children} == distinct, fixture
 
@@ -126,6 +130,7 @@ def test_rows_carry_the_compare_sh_verdict_not_fail():
         root = _load(fixture)
         tests = root.get_sub_result_by_name("Tests")
         children = build_check_results_children(tests, CHECK_NAME_PATTERN)
+        assert children, fixture
         verdicts = {
             _base_name(r.name): r.status
             for r in tests.results
@@ -161,6 +166,7 @@ def test_displayed_names_carry_no_side_suffix():
         children = build_check_results_children(
             root.get_sub_result_by_name("Tests"), CHECK_NAME_PATTERN
         )
+        assert children, fixture
         for child in children:
             assert "::" not in child.name, f"{fixture}: {child.name}"
 
@@ -174,6 +180,7 @@ def test_history_link_keeps_the_suffixed_name():
         children = build_check_results_children(
             root.get_sub_result_by_name("Tests"), CHECK_NAME_PATTERN
         )
+        assert children, fixture
         for child in children:
             assert _link_test_name(child) == f"{child.name}::new", fixture
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/111992

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

A `Performance Comparison` shard that PASSED renders a list of red rows, and every affected query is
listed twice. Reported in #111992: shard `arm_release, master_head, 1/6` was `OK`, its own message
said `11 unstable`, and the report showed 22 red rows that had to be hand-verified.

Two causes, both in the block that builds the `Check Results` rows:

- The rows exist only to carry a per-query "query history" link, and each was built with a hardcoded
  `FAIL`, discarding the `slower`/`unstable` verdict into `info`. The renderer already classifies
  both natively, so passing the real one through is enough.
- `compare.sh` emits one row per side (`array join map('old', left, 'new', right)`, named
  `<query> #<idx>::old` / `::new`), so 11 queries became 22 rows. Only the candidate side is now
  listed, and only its displayed name is stripped.

`compare.sh` is unchanged: its per-side rows are what goes into the CI database, so changing the
emission would fork that history and break every existing history link. Nothing is dropped, only
displayed once.

This cannot turn a passing shard red: `Check Results` is created with an explicit status, and
praktika aggregates child statuses only when none is given. A test pins that guard, and the
slower-query gate that decides the job verdict is untouched.

One more line in `json.html`: `getStatusClass` had no `slower` case and fell through to gray, while
the status filter and the row ordering both already treat it as a failure.

Tests: `ci/tests/test_perf_check_results_children.py`, driven by two trimmed real shard artifacts -
the one from #111992, and a failing `release_base` shard as the negative control, which must stay
red. The parent's own message states the query count, an independent oracle for the row count. The
CI database rows are byte-identical before and after, and the history links still resolve.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1537` (included in `26.8` and later)
<!-- ch-version-info:end -->