### PR TITLE
Route documentation review requests

### DIFF
--- a/.github/workflows/team_review_requests.yml
+++ b/.github/workflows/team_review_requests.yml
@@ -1,0 +1,32 @@
+name: Documentation Team Review Requests
+
+on:
+  pull_request_target:
+    branches: [master]
+    types: [opened, reopened, synchronize, labeled]
+
+concurrency:
+  group: documentation-team-review-requests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  request-reviews:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(github.event.pull_request.labels.*.name, 'can be tested')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out trusted base revision
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Request documentation team reviews
+        env:
+          GH_TOKEN: ${{ secrets.ROBOT_CLICKHOUSE_COMMIT_TOKEN }}
+        run: python3 -m ci.jobs.scripts.team_review_requests

--- a/ci/jobs/scripts/team_review_requests.py
+++ b/ci/jobs/scripts/team_review_requests.py
@@ -1,0 +1,110 @@
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+from ci.praktika.gh import GH
+
+DOCS_PREFIX = "docs/"
+SOURCE_PREFIX = "src/"
+CLICKPIPES_DOCS_PREFIX = "docs/integrations/clickpipes/"
+INTEGRATIONS_DOCS_PREFIXES = (
+    "docs/integrations/language-clients/",
+    "docs/integrations/connectors/",
+)
+
+DOCS_TEAM = "docs"
+CLICKPIPES_TEAM = "clickpipes"
+INTEGRATIONS_ECOSYSTEM_TEAM = "integrations-ecosystem"
+
+CAN_BE_TESTED = "can be tested"
+REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+def normalize_path(file):
+    return file.removeprefix(".").removeprefix("/")
+
+
+def get_docs_teams_to_request(changed_files):
+    files = [normalize_path(file) for file in changed_files]
+    if any(file.startswith(SOURCE_PREFIX) for file in files):
+        return []
+
+    docs_files = [file for file in files if file.startswith(DOCS_PREFIX)]
+    if not docs_files:
+        return []
+
+    teams = []
+    if any(file.startswith(CLICKPIPES_DOCS_PREFIX) for file in docs_files):
+        teams.append(CLICKPIPES_TEAM)
+
+    if any(
+        file.startswith(prefix)
+        for file in docs_files
+        for prefix in INTEGRATIONS_DOCS_PREFIXES
+    ):
+        teams.append(INTEGRATIONS_ECOSYSTEM_TEAM)
+
+    teams.append(DOCS_TEAM)
+    return teams
+
+
+def is_authorized_event(event):
+    repository = event["repository"]["full_name"]
+    pull_request = event["pull_request"]
+    if pull_request["base"]["repo"]["full_name"] != repository:
+        raise RuntimeError(
+            "Pull request base repository does not match the event repository"
+        )
+
+    if pull_request["head"]["repo"]["full_name"] == repository:
+        return True
+
+    labels = {label["name"] for label in pull_request.get("labels", [])}
+    return CAN_BE_TESTED in labels
+
+
+def get_changed_files(repository, pull_request_number):
+    if not REPOSITORY_PATTERN.fullmatch(repository):
+        raise ValueError(f"Invalid repository name [{repository}]")
+    if not isinstance(pull_request_number, int) or pull_request_number <= 0:
+        raise ValueError(f"Invalid pull request number [{pull_request_number}]")
+
+    command = (
+        f"gh api repos/{repository}/pulls/{pull_request_number}/files "
+        "--paginate --jq '.[] | .filename, (.previous_filename // empty)'"
+    )
+    output = GH.get_output_with_retries(command, strict=True)
+    return list(dict.fromkeys(output.splitlines())) if output else []
+
+
+def check(event):
+    if not is_authorized_event(event):
+        print(
+            f"Skip team review requests: fork PR lacks the [{CAN_BE_TESTED}] label"
+        )
+        return True
+
+    repository = event["repository"]["full_name"]
+    pull_request_number = event["pull_request"]["number"]
+    changed_files = get_changed_files(repository, pull_request_number)
+    return GH.request_team_reviews(
+        get_docs_teams_to_request(changed_files),
+        pr=pull_request_number,
+        repo=repository,
+    )
+
+
+def main():
+    event_path = os.environ.get("GITHUB_EVENT_PATH", "")
+    if not event_path:
+        raise RuntimeError("GITHUB_EVENT_PATH is not set")
+    with Path(event_path).open(encoding="utf-8") as event_file:
+        event = json.load(event_file)
+    if not check(event):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/jobs/scripts/workflow_hooks/team_notifications.py
+++ b/ci/jobs/scripts/workflow_hooks/team_notifications.py
@@ -5,46 +5,6 @@ from ci.praktika.info import Info
 
 INTEGRATIONS_ECOSYSTEM_FILES = ("src/Core/TypeId.h",)
 
-DOCS_PREFIX = "docs/"
-CLICKPIPES_DOCS_PREFIX = "docs/integrations/clickpipes/"
-INTEGRATIONS_DOCS_PREFIXES = (
-    "docs/integrations/language-clients/",
-    "docs/integrations/connectors/",
-)
-
-DOCS_TEAM = "docs"
-CLICKPIPES_TEAM = "clickpipes"
-INTEGRATIONS_ECOSYSTEM_TEAM = "integrations-ecosystem"
-
-# GitHub requires review teams to have repository access. Enable this after
-# `docs`, `clickpipes`, and `integrations-ecosystem` receive it.
-ENABLE_DOCS_TEAM_REVIEW_REQUESTS = False
-
-
-def normalize_path(file):
-    return file.removeprefix(".").removeprefix("/")
-
-
-def get_docs_teams_to_request(changed_files):
-    files = [normalize_path(file) for file in changed_files]
-    teams = []
-
-    if not files or not all(file.startswith(DOCS_PREFIX) for file in files):
-        return teams
-
-    if any(file.startswith(CLICKPIPES_DOCS_PREFIX) for file in files):
-        teams.append(CLICKPIPES_TEAM)
-
-    if any(
-        file.startswith(prefix)
-        for file in files
-        for prefix in INTEGRATIONS_DOCS_PREFIXES
-    ):
-        teams.append(INTEGRATIONS_ECOSYSTEM_TEAM)
-
-    teams.append(DOCS_TEAM)
-    return teams
-
 
 def check():
     info = Info()
@@ -55,8 +15,6 @@ def check():
         "most likely failed to fetch the PR file list from the GitHub API. "
         "See the Config Workflow logs for the underlying error."
     )
-    if ENABLE_DOCS_TEAM_REVIEW_REQUESTS and info.event_action == "opened":
-        GH.request_team_reviews(get_docs_teams_to_request(changed_files))
 
     if any(
         file.startswith(prefix)

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -811,16 +811,7 @@ class GH:
             os.unlink(temp_file_path)
 
     @classmethod
-    def request_team_reviews(cls, team_slugs, pr=None, repo=None):
-        requested = set(team_slugs)
-        if not requested:
-            return True
-
-        if not repo:
-            repo = _Environment.get().REPOSITORY
-        if not pr:
-            pr = _Environment.get().PR_NUMBER
-
+    def _get_requested_team_reviews(cls, pr, repo):
         cmd = (
             f'gh api -H "Accept: application/vnd.github.v3+json" '
             f'"/repos/{repo}/pulls/{pr}/requested_reviewers" '
@@ -845,9 +836,32 @@ class GH:
                 f"Unexpected team review request response for pull request [{pr}]"
             )
 
-        teams_to_request = sorted(requested - set(requested_teams))
+        return set(requested_teams)
+
+    @classmethod
+    def request_team_reviews(cls, team_slugs, pr=None, repo=None):
+        requested = set(team_slugs)
+        if not requested:
+            return True
+
+        if not repo:
+            repo = _Environment.get().REPOSITORY
+        if not pr:
+            pr = _Environment.get().PR_NUMBER
+
+        teams_to_request = sorted(
+            requested - cls._get_requested_team_reviews(pr, repo)
+        )
         if teams_to_request:
             cls._submit_team_review_requests(teams_to_request, pr, repo)
+            missing_teams = set(teams_to_request) - cls._get_requested_team_reviews(
+                pr, repo
+            )
+            if missing_teams:
+                raise RuntimeError(
+                    "Failed to verify team review requests for pull request "
+                    f"[{pr}], missing teams [{', '.join(sorted(missing_teams))}]"
+                )
 
         return True
 

--- a/ci/tests/test_gh.py
+++ b/ci/tests/test_gh.py
@@ -5,7 +5,9 @@ Adding a new Result.Status value requires updating GH._STATUS_TO_GH.
 These tests verify that every status is mapped and the mapping is correct.
 """
 
+import json
 import os
+import shlex
 import sys
 from types import SimpleNamespace
 
@@ -334,10 +336,16 @@ def test_get_pr_state_by_branch_fails_closed(monkeypatch):
 
 def test_request_team_reviews_adds_only_missing_teams(monkeypatch):
     requests = []
+    responses = iter(
+        [
+            '["clickpipes", "unmanaged-team"]',
+            '["clickpipes", "docs", "integrations-ecosystem", "unmanaged-team"]',
+        ]
+    )
 
     def fake_get(command, verbose=False):
         assert "pulls/42/requested_reviewers" in command
-        return '["clickpipes", "unmanaged-team"]'
+        return next(responses)
 
     def fake_submit(team_slugs, pr, repo):
         requests.append((team_slugs, pr, repo))
@@ -353,6 +361,49 @@ def test_request_team_reviews_adds_only_missing_teams(monkeypatch):
     assert requests == [
         (["docs", "integrations-ecosystem"], 42, "ClickHouse/ClickHouse")
     ]
+
+
+def test_submit_team_review_requests_uses_rest_api(monkeypatch):
+    commands = []
+    payloads = []
+
+    def fake_submit(command, verbose=False):
+        commands.append(command)
+        args = shlex.split(command)
+        payload_path = args[args.index("--input") + 1]
+        with open(payload_path, encoding="utf-8") as payload_file:
+            payloads.append(json.load(payload_file))
+        return True
+
+    monkeypatch.setattr(GH, "do_command_with_retries", staticmethod(fake_submit))
+
+    GH._submit_team_review_requests(
+        team_slugs=["clickpipes", "docs"],
+        pr=42,
+        repo="ClickHouse/ClickHouse",
+    )
+
+    assert len(commands) == 1
+    assert "repos/ClickHouse/ClickHouse/pulls/42/requested_reviewers" in commands[0]
+    assert payloads == [
+        {"reviewers": [], "team_reviewers": ["clickpipes", "docs"]}
+    ]
+
+
+def test_request_team_reviews_fails_when_submission_is_not_applied(monkeypatch):
+    monkeypatch.setattr(
+        GH, "get_output_with_retries", staticmethod(lambda *_args, **_kwargs: "[]")
+    )
+    monkeypatch.setattr(
+        GH, "_submit_team_review_requests", staticmethod(lambda *_args: None)
+    )
+
+    with pytest.raises(RuntimeError, match=r"missing teams \[docs\]"):
+        GH.request_team_reviews(
+            team_slugs=["docs"],
+            pr=42,
+            repo="ClickHouse/ClickHouse",
+        )
 
 
 def test_request_team_reviews_does_nothing_without_teams(monkeypatch):

--- a/ci/tests/test_team_notifications.py
+++ b/ci/tests/test_team_notifications.py
@@ -3,122 +3,8 @@ import pytest
 from ci.jobs.scripts.workflow_hooks import team_notifications
 
 
-@pytest.mark.parametrize(
-    ("changed_files", "expected_teams"),
-    [
-        (["docs/reference/functions/array-functions.mdx"], ["docs"]),
-        (
-            ["docs/integrations/clickpipes/kafka/index.mdx"],
-            ["clickpipes", "docs"],
-        ),
-        (
-            [
-                "docs/integrations/language-clients/python/index.mdx",
-                "docs/integrations/connectors/data-ingestion/index.mdx",
-            ],
-            ["integrations-ecosystem", "docs"],
-        ),
-        (
-            [
-                "docs/integrations/clickpipes/home.mdx",
-                "docs/integrations/connectors/navigation.json",
-            ],
-            [
-                "clickpipes",
-                "integrations-ecosystem",
-                "docs",
-            ],
-        ),
-        (
-            [
-                "docs/pt-BR/integrations/clickpipes/home.mdx",
-                "docs/ja/integrations/connectors/navigation.json",
-            ],
-            ["docs"],
-        ),
-        (
-            ["docs/integrations/clickpipes/home.mdx", "src/Core/Block.cpp"],
-            [],
-        ),
-        (["src/Core/TypeId.h"], []),
-        ([], []),
-    ],
-)
-def test_get_docs_teams_to_request(changed_files, expected_teams):
-    assert team_notifications.get_docs_teams_to_request(changed_files) == expected_teams
-
-
-def test_check_skips_docs_teams_without_repository_access(monkeypatch):
-    class FakeInfo:
-        event_action = "opened"
-
-        def get_kv_data(self, key):
-            assert key == "changed_files"
-            return [
-                "docs/integrations/clickpipes/home.mdx",
-                "docs/integrations/language-clients/python/index.mdx",
-            ]
-
-    monkeypatch.setattr(team_notifications, "Info", FakeInfo)
-    monkeypatch.setattr(
-        team_notifications.GH,
-        "request_team_reviews",
-        staticmethod(lambda *_args: pytest.fail("unexpected review request")),
-    )
-
-    assert team_notifications.check()
-
-
-def test_check_requests_docs_teams_when_enabled(monkeypatch):
-    class FakeInfo:
-        event_action = "opened"
-
-        def get_kv_data(self, key):
-            assert key == "changed_files"
-            return [
-                "docs/integrations/clickpipes/home.mdx",
-                "docs/integrations/language-clients/python/index.mdx",
-            ]
-
-    requested = []
-
-    def fake_request(team_slugs):
-        requested.extend(team_slugs)
-
-    monkeypatch.setattr(team_notifications, "Info", FakeInfo)
-    monkeypatch.setattr(
-        team_notifications, "ENABLE_DOCS_TEAM_REVIEW_REQUESTS", True
-    )
-    monkeypatch.setattr(
-        team_notifications.GH, "request_team_reviews", staticmethod(fake_request)
-    )
-
-    assert team_notifications.check()
-    assert requested == ["clickpipes", "integrations-ecosystem", "docs"]
-
-
-def test_check_does_not_manage_docs_reviews_after_open(monkeypatch):
-    class FakeInfo:
-        event_action = "synchronize"
-
-        def get_kv_data(self, key):
-            assert key == "changed_files"
-            return ["docs/integrations/clickpipes/home.mdx"]
-
-    monkeypatch.setattr(team_notifications, "Info", FakeInfo)
-    monkeypatch.setattr(
-        team_notifications.GH,
-        "request_team_reviews",
-        staticmethod(lambda *_args: pytest.fail("unexpected review request")),
-    )
-
-    assert team_notifications.check()
-
-
 def test_check_preserves_existing_type_id_notification(monkeypatch):
     class FakeInfo:
-        event_action = "synchronize"
-
         def get_kv_data(self, key):
             assert key == "changed_files"
             return ["src/Core/TypeId.h"]
@@ -129,11 +15,6 @@ def test_check_preserves_existing_type_id_notification(monkeypatch):
         posted.update(comment_tags_and_bodies)
 
     monkeypatch.setattr(team_notifications, "Info", FakeInfo)
-    monkeypatch.setattr(
-        team_notifications.GH,
-        "request_team_reviews",
-        staticmethod(lambda *_args: pytest.fail("unexpected review request")),
-    )
     monkeypatch.setattr(
         team_notifications.GH, "post_updateable_comment", staticmethod(fake_post)
     )
@@ -146,8 +27,6 @@ def test_check_preserves_existing_type_id_notification(monkeypatch):
 
 def test_check_fails_when_changed_files_are_unavailable(monkeypatch):
     class FakeInfo:
-        event_action = "opened"
-
         def get_kv_data(self, key):
             assert key == "changed_files"
             return None

--- a/ci/tests/test_team_review_requests.py
+++ b/ci/tests/test_team_review_requests.py
@@ -1,0 +1,162 @@
+import pytest
+
+from ci.jobs.scripts import team_review_requests
+
+
+def make_event(*, internal, labels=None):
+    repository = "ClickHouse/ClickHouse"
+    return {
+        "repository": {"full_name": repository},
+        "pull_request": {
+            "number": 42,
+            "base": {"repo": {"full_name": repository}},
+            "head": {
+                "repo": {
+                    "full_name": repository if internal else "contributor/ClickHouse"
+                }
+            },
+            "labels": [{"name": label} for label in labels or []],
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("changed_files", "expected_teams"),
+    [
+        (["docs/reference/functions/array-functions.mdx"], ["docs"]),
+        (
+            ["docs/integrations/clickpipes/kafka/index.mdx"],
+            ["clickpipes", "docs"],
+        ),
+        (
+            ["docs/integrations/language-clients/python/index.mdx"],
+            ["integrations-ecosystem", "docs"],
+        ),
+        (
+            ["docs/integrations/connectors/data-ingestion/index.mdx"],
+            ["integrations-ecosystem", "docs"],
+        ),
+        (
+            [
+                "docs/integrations/clickpipes/home.mdx",
+                "docs/integrations/connectors/navigation.json",
+            ],
+            ["clickpipes", "integrations-ecosystem", "docs"],
+        ),
+        (
+            ["docs/integrations/clickpipes/home.mdx", "src/Core/Block.cpp"],
+            [],
+        ),
+        (
+            [
+                "ci/jobs/scripts/team_review_requests.py",
+                "docs/integrations/clickpipes/home.mdx",
+            ],
+            ["clickpipes", "docs"],
+        ),
+        (["src/Core/TypeId.h"], []),
+        ([], []),
+    ],
+)
+def test_get_docs_teams_to_request(changed_files, expected_teams):
+    assert (
+        team_review_requests.get_docs_teams_to_request(changed_files)
+        == expected_teams
+    )
+
+
+def test_check_requests_teams_for_internal_pr(monkeypatch):
+    requested = []
+    monkeypatch.setattr(
+        team_review_requests,
+        "get_changed_files",
+        lambda repository, pr: ["docs/integrations/clickpipes/home.mdx"],
+    )
+    monkeypatch.setattr(
+        team_review_requests.GH,
+        "request_team_reviews",
+        staticmethod(
+            lambda teams, pr, repo: requested.append((teams, pr, repo)) or True
+        ),
+    )
+
+    assert team_review_requests.check(make_event(internal=True))
+    assert requested == [
+        (["clickpipes", "docs"], 42, "ClickHouse/ClickHouse")
+    ]
+
+
+def test_check_requests_teams_for_approved_fork_pr(monkeypatch):
+    requested = []
+    monkeypatch.setattr(
+        team_review_requests,
+        "get_changed_files",
+        lambda repository, pr: ["docs/integrations/connectors/index.mdx"],
+    )
+    monkeypatch.setattr(
+        team_review_requests.GH,
+        "request_team_reviews",
+        staticmethod(
+            lambda teams, pr, repo: requested.append((teams, pr, repo)) or True
+        ),
+    )
+
+    assert team_review_requests.check(
+        make_event(internal=False, labels=["can be tested"])
+    )
+    assert requested == [
+        (["integrations-ecosystem", "docs"], 42, "ClickHouse/ClickHouse")
+    ]
+
+
+def test_check_skips_unapproved_fork_pr(monkeypatch):
+    monkeypatch.setattr(
+        team_review_requests,
+        "get_changed_files",
+        lambda *_args: pytest.fail("unexpected changed-files request"),
+    )
+    monkeypatch.setattr(
+        team_review_requests.GH,
+        "request_team_reviews",
+        staticmethod(
+            lambda *_args, **_kwargs: pytest.fail("unexpected review request")
+        ),
+    )
+
+    assert team_review_requests.check(make_event(internal=False))
+
+
+def test_get_changed_files_uses_paginated_pull_request_api(monkeypatch):
+    commands = []
+
+    def fake_get(command, strict=False):
+        commands.append((command, strict))
+        return "docs/new.mdx\ndocs/old.mdx\ndocs/new.mdx"
+
+    monkeypatch.setattr(
+        team_review_requests.GH,
+        "get_output_with_retries",
+        staticmethod(fake_get),
+    )
+
+    assert team_review_requests.get_changed_files("ClickHouse/ClickHouse", 42) == [
+        "docs/new.mdx",
+        "docs/old.mdx",
+    ]
+    assert len(commands) == 1
+    assert "pulls/42/files" in commands[0][0]
+    assert "--paginate" in commands[0][0]
+    assert commands[0][1]
+
+
+@pytest.mark.parametrize(
+    ("repository", "pull_request_number"),
+    [
+        ("ClickHouse/ClickHouse;echo bad", 42),
+        ("ClickHouse/ClickHouse", 0),
+        ("ClickHouse/ClickHouse", "42"),
+    ],
+)
+def test_get_changed_files_rejects_invalid_target(repository, pull_request_number):
+    with pytest.raises(ValueError):
+        team_review_requests.get_changed_files(repository, pull_request_number)

--- a/docs/integrations/clickpipes/home.mdx
+++ b/docs/integrations/clickpipes/home.mdx
@@ -14,7 +14,7 @@ import { Image } from "/snippets/components/Image.jsx";
 
 ## Introduction {#introduction}
 
-[ClickPipes](/integrations/clickpipes/home) is a managed integration platform that makes ingesting data from a diverse set of sources as simple as clicking a few buttons. Designed for the most demanding workloads, ClickPipes's robust and scalable architecture ensures consistent performance and reliability. ClickPipes can be used for long-term streaming needs or one-time data loading job.
+[ClickPipes](/integrations/clickpipes/home) is a managed integration platform that makes ingesting data from a diverse set of sources as simple as clicking a few buttons. Designed for the most demanding workloads, ClickPipes's robust and scalable architecture ensures consistent performance and reliability. ClickPipes can be used for long-term streaming needs or a one-time data loading job.
 
 ClickPipes can be deployed and managed manually using the ClickPipes UI, as well as programmatically using [OpenAPI](/integrations/clickpipes/programmatic-access/openapi) and [Terraform](/integrations/clickpipes/programmatic-access/terraform).
 


### PR DESCRIPTION
Enable documentation review requests now that the relevant teams have repository access. ClickPipes documentation changes request reviews from both `docs` and `clickpipes`; language-client and connector documentation changes request reviews from both `docs` and `integrations-ecosystem`. Documentation reviews are skipped when a PR also changes files under `src/`.

GitHub App installation tokens cannot resolve private teams when requesting reviews, even with the documented repository permission. Move this operation into a `pull_request_target` workflow that checks out only the trusted base revision and uses the existing robot credential. Fork PRs must have the `can be tested` label before the workflow runs.

The workflow becomes active after this change lands on `master`; this draft includes a one-line ClickPipes documentation edit for the follow-up integration test.

Related: https://github.com/ClickHouse/ClickHouse/pull/114453

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Enable automatic documentation team review requests through a trusted workflow.
