### PR TITLE
Text index: fix accidentally removed columns when the direct read is enabled

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -834,6 +834,20 @@ static const ActionsDAG::Node * processAndOptimizeTextIndexDAG(
     if (result.added_columns.empty())
         return result.filter_node;
 
+    /// Keep columns the PREWHERE or row-level filter still read, so this filter DAG's removal does not drop them from the shared read set.
+    {
+        NameSet required_columns_by_readers;
+        if (auto prewhere = read_from_merge_tree_step.getPrewhereInfo())
+            for (const auto & name : prewhere->prewhere_actions.getRequiredColumnsNames())
+                required_columns_by_readers.insert(name);
+
+        if (auto row_level_filter = read_from_merge_tree_step.getRowLevelFilter())
+            for (const auto & name : row_level_filter->actions.getRequiredColumnsNames())
+                required_columns_by_readers.insert(name);
+
+        std::erase_if(result.removed_columns, [&](const String & column) { return required_columns_by_readers.contains(column); });
+    }
+
     auto logger = getLogger("processAndOptimizeTextIndexFunctions");
     LOG_DEBUG(logger, "{}", optimizationInfoToString(result.added_columns, result.removed_columns));
 

--- a/tests/queries/0_stateless/02346_text_index_bug113320_shared_prewhere_where_column.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug113320_shared_prewhere_where_column.reference
@@ -1,0 +1,14 @@
+LIKE in PREWHERE, ILIKE in PREWHERE
+25
+25
+LIKE in PREWHERE, ILIKE in WHERE (the reported crash)
+25
+25
+LIKE in WHERE, ILIKE in PREWHERE
+25
+25
+LIKE in WHERE, ILIKE in WHERE
+25
+25
+Read column set
+Output: txt, __text_index_idx_ilike_cecf6b109512fb4eb871d08611e7d247

--- a/tests/queries/0_stateless/02346_text_index_bug113320_shared_prewhere_where_column.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug113320_shared_prewhere_where_column.reference
@@ -10,5 +10,3 @@ LIKE in WHERE, ILIKE in PREWHERE
 LIKE in WHERE, ILIKE in WHERE
 25
 25
-Read column set
-Output: txt, __text_index_idx_ilike_cecf6b109512fb4eb871d08611e7d247

--- a/tests/queries/0_stateless/02346_text_index_bug113320_shared_prewhere_where_column.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug113320_shared_prewhere_where_column.sql
@@ -1,0 +1,50 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/113320
+-- A column used by both PREWHERE and a WHERE text-search predicate must not be dropped from the read set.
+
+SET enable_full_text_index = 1;
+SET use_text_index_like_evaluation_by_dictionary_scan = 1;  -- avoid randomization
+SET text_index_like_min_pattern_length = 4;                 -- avoid randomization
+SET text_index_like_max_postings_to_read = 50;              -- avoid randomization
+SET optimize_move_to_prewhere = 0;                          -- keep each predicate in the clause it is written in
+
+CREATE TABLE tab
+(
+    id UInt64,
+    txt String,
+    INDEX idx txt TYPE text(tokenizer = splitByNonAlpha)
+)
+ENGINE = MergeTree()
+ORDER BY id;
+
+INSERT INTO tab SELECT toString(number), concat(['8Gamma', '8Delta', '7Gamma', '7Delta'][number % 4 + 1], toString(number)) FROM numbers(100);
+
+SELECT 'LIKE in PREWHERE, ILIKE in PREWHERE';
+
+SELECT count() FROM tab PREWHERE txt LIKE '8%' AND txt ILIKE '%gamma%' SETTINGS query_plan_direct_read_from_text_index = 0;
+SELECT count() FROM tab PREWHERE txt LIKE '8%' AND txt ILIKE '%gamma%' SETTINGS query_plan_direct_read_from_text_index = 1;
+
+SELECT 'LIKE in PREWHERE, ILIKE in WHERE (the reported crash)';
+
+SELECT count() FROM tab PREWHERE txt LIKE '8%' WHERE txt ILIKE '%gamma%' SETTINGS query_plan_direct_read_from_text_index = 0;
+SELECT count() FROM tab PREWHERE txt LIKE '8%' WHERE txt ILIKE '%gamma%' SETTINGS query_plan_direct_read_from_text_index = 1;
+
+SELECT 'LIKE in WHERE, ILIKE in PREWHERE';
+
+SELECT count() FROM tab PREWHERE txt ILIKE '%gamma%' WHERE txt LIKE '8%' SETTINGS query_plan_direct_read_from_text_index = 0;
+SELECT count() FROM tab PREWHERE txt ILIKE '%gamma%' WHERE txt LIKE '8%' SETTINGS query_plan_direct_read_from_text_index = 1;
+
+SELECT 'LIKE in WHERE, ILIKE in WHERE';
+
+SELECT count() FROM tab WHERE txt LIKE '8%' AND txt ILIKE '%gamma%' SETTINGS query_plan_direct_read_from_text_index = 0;
+SELECT count() FROM tab WHERE txt LIKE '8%' AND txt ILIKE '%gamma%' SETTINGS query_plan_direct_read_from_text_index = 1;
+
+SELECT 'Read column set';
+
+SELECT trimLeft(explain)
+FROM (
+    EXPLAIN actions = 1
+    SELECT count() FROM tab PREWHERE txt LIKE '8%' WHERE txt ILIKE '%gamma%' SETTINGS query_plan_direct_read_from_text_index = 1
+)
+WHERE explain LIKE '%Output: %' AND explain LIKE '%__text_index%';
+
+DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_bug113320_shared_prewhere_where_column.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug113320_shared_prewhere_where_column.sql
@@ -38,13 +38,4 @@ SELECT 'LIKE in WHERE, ILIKE in WHERE';
 SELECT count() FROM tab WHERE txt LIKE '8%' AND txt ILIKE '%gamma%' SETTINGS query_plan_direct_read_from_text_index = 0;
 SELECT count() FROM tab WHERE txt LIKE '8%' AND txt ILIKE '%gamma%' SETTINGS query_plan_direct_read_from_text_index = 1;
 
-SELECT 'Read column set';
-
-SELECT trimLeft(explain)
-FROM (
-    EXPLAIN actions = 1
-    SELECT count() FROM tab PREWHERE txt LIKE '8%' WHERE txt ILIKE '%gamma%' SETTINGS query_plan_direct_read_from_text_index = 1
-)
-WHERE explain LIKE '%Output: %' AND explain LIKE '%__text_index%';
-
 DROP TABLE tab;


### PR DESCRIPTION
When the same column is used in both `PREWHERE` and `WHERE` conditions, it must not be removed, since `PREWHERE` is executed before `WHERE`. Even if a `WHERE` filter column is rewritten into a text index virtual column, it still has to be read to apply the `PREWHERE` condition.

To fix it, now every column still required by the `PREWHERE` is kept in the read set instead of removing it.

Fixes #113320.

### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Do not remove columns when it's referenced in both `PREWHERE` and `WHERE` filter conditions even if it's rewritten into a text index virtual column.
