### PR TITLE
ci: export only MergeTree %_log tables to the CI logs cluster

### DIFF
--- a/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
+++ b/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
@@ -104,7 +104,10 @@ function setup_logs_replication()
 
     # For each system log table:
     echo 'Create %_log tables'
-    clickhouse-client --query "SHOW TABLES FROM system LIKE '%\\_log'" | while read -r table
+    # Filter by engine to exclude virtual system tables that merely match the
+    # name pattern (e.g. `user_query_log`) - their engines cannot be created
+    # on the remote cluster.
+    clickhouse-client --query "SELECT name FROM system.tables WHERE database = 'system' AND name LIKE '%\\_log' AND engine LIKE '%MergeTree'" | while read -r table
     do
         EXTRA_COLUMNS_FOR_TABLE="${EXTRA_COLUMNS}"
         EXTRA_COLUMNS_EXPRESSION_FOR_TABLE="${EXTRA_COLUMNS_EXPRESSION}"


### PR DESCRIPTION
Exclude system.user_query_log (engine SystemUserQueryLog)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1233` (included in `26.8` and later)
<!-- ch-version-info:end -->