### PR TITLE
Keep heavy check in `ColumnArray` only in debug build

### DIFF
--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -68,6 +68,7 @@ ColumnArray::ColumnArray(MutableColumnPtr && nested_column, MutableColumnPtr && 
                 data->size(), last_offset);
     }
 
+#ifdef DEBUG_OR_SANITIZER_BUILD
     /// Matching the last offset with the size of the nested column is not enough: a decreasing offset
     /// in the middle makes `sizeAt` underflow to a huge value, and the consumers read the nested column
     /// out of bounds even though the last offset is correct. The offsets have to be non-decreasing.
@@ -77,6 +78,7 @@ ColumnArray::ColumnArray(MutableColumnPtr && nested_column, MutableColumnPtr && 
         throw Exception(ErrorCodes::LOGICAL_ERROR,
             "offsets_column is not monotonically increasing: the offset {} at position {} is greater than the next offset {}",
             *non_monotonic, non_monotonic - offsets_data.begin(), *(non_monotonic + 1));
+#endif
 
     /** NOTE
       * Arrays with constant value are possible and used in implementation of higher order functions (see FunctionReplicate).

--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -72,7 +72,7 @@ ColumnArray::ColumnArray(MutableColumnPtr && nested_column, MutableColumnPtr && 
     /// Matching the last offset with the size of the nested column is not enough: a decreasing offset
     /// in the middle makes `sizeAt` underflow to a huge value, and the consumers read the nested column
     /// out of bounds even though the last offset is correct. The offsets have to be non-decreasing.
-    /// The scan is linear, but it is cheap compared to filling the offsets in the first place.
+    /// The scan is linear - a heavy assertion, hence debug and sanitizer builds only.
     const auto * non_monotonic = std::adjacent_find(offsets_data.begin(), offsets_data.end(), std::greater<>());
     if (non_monotonic != offsets_data.end())
         throw Exception(ErrorCodes::LOGICAL_ERROR,

--- a/src/Columns/ColumnSparse.cpp
+++ b/src/Columns/ColumnSparse.cpp
@@ -54,7 +54,7 @@ ColumnSparse::ColumnSparse(MutableColumnPtr && values_, MutableColumnPtr && offs
             "Size of sparse column ({}) should be greater than last position of non-default value ({})",
                 _size, offsets_concrete->getData().back());
 
-#ifndef NDEBUG
+#ifdef DEBUG_OR_SANITIZER_BUILD
     const auto & offsets_data = getOffsetsData();
     const auto * it = std::adjacent_find(offsets_data.begin(), offsets_data.end(), std::greater_equal<>());
     if (it != offsets_data.end())

--- a/src/Columns/tests/gtest_column_array.cpp
+++ b/src/Columns/tests/gtest_column_array.cpp
@@ -64,16 +64,26 @@ TEST(ColumnArray, InconsistentOffsetsAreRejected)
     EXPECT_THROW(createArray({10}, {}), Exception);
 }
 
-/// A decreasing offset makes `sizeAt` underflow to a huge value even when the last offset
-/// matches the size of the nested column, so the offsets are checked for monotonicity as well.
-TEST(ColumnArray, NonMonotonicOffsetsAreRejected)
+#endif
+
+/// A decreasing offset makes `sizeAt` underflow to a huge value even when the last offset matches
+/// the size of the nested column, so the offsets are checked for monotonicity as well. The check is
+/// a linear scan - a heavy assertion, so it only runs in debug and sanitizer builds, where a
+/// LOGICAL_ERROR aborts the process: hence a death test.
+#ifdef DEBUG_OR_SANITIZER_BUILD
+
+TEST(ColumnArrayDeathTest, NonMonotonicOffsetsAreRejected)
 {
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+    /// The extra parentheses keep the preprocessor from splitting the braced lists into macro arguments.
+
     /// The nested column is empty and the last offset is 0, but the first row claims one element.
-    EXPECT_THROW(createArray({}, {1, 0}), Exception);
+    EXPECT_DEATH((createArray({}, {1, 0})), "not monotonically increasing");
 
     /// The last offset matches the nested column, but the offsets dip in the middle.
-    EXPECT_THROW(createArray({10, 20, 30}, {2, 1, 3}), Exception);
-    EXPECT_THROW(createArray({10, 20, 30}, {3, 0, 3}), Exception);
+    EXPECT_DEATH((createArray({10, 20, 30}, {2, 1, 3})), "not monotonically increasing");
+    EXPECT_DEATH((createArray({10, 20, 30}, {3, 0, 3})), "not monotonically increasing");
 }
 
 #endif


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes #114105.
Introduced in #112504.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1291` (included in `26.8` and later)
<!-- ch-version-info:end -->