### PR TITLE
Allow to create table without providing credentials if catalog specified

### DIFF
--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -11,6 +11,7 @@
 #include <Databases/DataLake/ICatalog.h>
 #include <Databases/DataLake/StaticStorageCredentials.h>
 #include <Common/Exception.h>
+#include <Common/quoteString.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/ReadBuffer.h>
@@ -616,6 +617,140 @@ std::string DatabaseDataLake::getStorageEndpointForTable(const DataLake::TableMe
     return table_metadata.getLocationWithEndpoint(endpoint_from_settings, settings[DatabaseDataLakeSetting::storage_uri_style]);
 }
 
+bool DatabaseDataLake::catalogManagesProviderChain(const DataLake::ICatalog & catalog)
+{
+    return catalog.getCatalogType() == DatabaseDataLakeCatalogType::GLUE;
+}
+
+DatabaseDataLake::TableEngineArgs DatabaseDataLake::buildTableEngineArgs(
+    const DatabaseDataLakeSettings & settings,
+    const DataLake::ICatalog & catalog,
+    const DataLake::TableMetadata & table_metadata,
+    bool lightweight) const
+{
+    TableEngineArgs result;
+
+    /// Take database engine definition AST as base.
+    ASTStorage * storage = table_engine_definition->as<ASTStorage>();
+    result.args = storage->engine->arguments->children;
+
+    if (table_metadata.hasLocation())
+    {
+        auto table_endpoint = getStorageEndpointForTable(table_metadata);
+        LOG_DEBUG(log, "Table endpoint {}", table_endpoint);
+        if (table_endpoint.starts_with(DataLake::FILE_PATH_PREFIX))
+            table_endpoint = table_endpoint.substr(DataLake::FILE_PATH_PREFIX.length());
+        if (result.args.empty())
+            result.args.emplace_back(make_intrusive<ASTLiteral>(table_endpoint));
+        else
+            result.args[0] = make_intrusive<ASTLiteral>(table_endpoint);
+    }
+
+    auto storage_type_from_catalog = catalog.getStorageType();
+    if (storage_type_from_catalog.has_value())
+    {
+        result.storage_type = storage_type_from_catalog.value();
+    }
+    else
+    {
+        if (table_metadata.hasLocation() || !lightweight)
+            result.storage_type = table_metadata.getStorageType();
+    }
+
+    if (result.args.size() == 1)
+    {
+        std::array<DatabaseDataLakeCatalogType, 3> vended_credentials_catalogs = {DatabaseDataLakeCatalogType::ICEBERG_ONELAKE, DatabaseDataLakeCatalogType::ICEBERG_BIGLAKE, DatabaseDataLakeCatalogType::PAIMON_REST};
+
+        std::shared_ptr<DataLake::IStorageCredentials> static_credentials;
+        if (!catalogManagesProviderChain(catalog))
+            static_credentials = DataLake::tryGetStaticStorageCredentials(result.storage_type, settings);
+
+        if (table_metadata.hasStorageCredentials())
+        {
+            LOG_DEBUG(log, "Getting credentials");
+            auto storage_credentials = table_metadata.getStorageCredentials();
+            if (storage_credentials)
+            {
+                LOG_DEBUG(log, "Has credentials");
+                storage_credentials->addCredentialsToEngineArgs(result.args);
+            }
+            else
+            {
+                LOG_DEBUG(log, "Has no credentials");
+            }
+        }
+        else if (static_credentials)
+        {
+            LOG_TRACE(log, "Using static credentials from database settings");
+            static_credentials->addCredentialsToEngineArgs(result.args);
+            result.static_credentials_applied = true;
+        }
+        else if (!lightweight && table_metadata.requiresCredentials() && std::find(vended_credentials_catalogs.begin(), vended_credentials_catalogs.end(), catalog.getCatalogType()) == vended_credentials_catalogs.end())
+        {
+            throw Exception(
+               ErrorCodes::BAD_ARGUMENTS,
+               "Either vended credentials need to be enabled "
+               "or storage credentials need to be specified in database engine arguments in CREATE query");
+        }
+    }
+
+    return result;
+}
+
+static DatabaseDataLakeStorageType toDataLakeStorageType(ObjectStorageType type)
+{
+    switch (type)
+    {
+        case ObjectStorageType::S3:
+            return DatabaseDataLakeStorageType::S3;
+        case ObjectStorageType::Azure:
+            return DatabaseDataLakeStorageType::Azure;
+        case ObjectStorageType::HDFS:
+            return DatabaseDataLakeStorageType::HDFS;
+        case ObjectStorageType::Local:
+            return DatabaseDataLakeStorageType::Local;
+        case ObjectStorageType::None:
+        case ObjectStorageType::Web:
+        case ObjectStorageType::Max:
+            return DatabaseDataLakeStorageType::Other;
+    }
+}
+
+ASTs DatabaseDataLake::getEngineArgsForNewTable(const String & name, ObjectStorageType engine_storage_type) const
+{
+    const auto settings_version = database_settings.get();
+    const DatabaseDataLakeSettings & settings = *settings_version;
+
+    auto catalog = getCatalog();
+    const auto [namespace_name, table_name] = DataLake::parseTableName(name);
+
+    auto location = catalog->getDefaultTableLocation(namespace_name, table_name);
+    if (!location)
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Catalog of database {} cannot tell where table {} has to be created. "
+            "Specify the location in the table engine arguments explicitly",
+            backQuoteIfNeed(getDatabaseName()), name);
+
+    LOG_DEBUG(log, "Location assigned by the catalog for new table {}: {}", name, *location);
+
+    auto table_metadata = DataLake::TableMetadata().withLocation();
+    if (settings[DatabaseDataLakeSetting::force_add_bucket])
+        table_metadata.withForceAddBucket();
+    table_metadata.setLocation(*location);
+
+    const auto location_storage_type = table_metadata.getStorageType();
+    if (toDataLakeStorageType(engine_storage_type) != location_storage_type)
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Catalog of database {} places table {} in {} ({}), while its table engine writes to {}. "
+            "Use the table engine variant for {}",
+            backQuoteIfNeed(getDatabaseName()), name, location_storage_type, *location,
+            toDataLakeStorageType(engine_storage_type), location_storage_type);
+
+    return buildTableEngineArgs(settings, *catalog, table_metadata, /* lightweight */false).args;
+}
+
 bool DatabaseDataLake::empty() const
 {
     return getCatalog()->empty();
@@ -677,91 +812,14 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
         throw Exception::createRuntime(ErrorCodes::DATALAKE_DATABASE_ERROR, table_metadata.getReasonWhyTableIsUnreadable());
     }
 
-    /// Take database engine definition AST as base.
-    ASTStorage * storage = table_engine_definition->as<ASTStorage>();
-    ASTs args = storage->engine->arguments->children;
-
-    if (table_metadata.hasLocation())
-    {
-        /// Replace Iceberg Catalog endpoint with storage path endpoint of requested table.
-        auto table_endpoint = getStorageEndpointForTable(table_metadata);
-        LOG_DEBUG(log, "Table endpoint {}", table_endpoint);
-        if (table_endpoint.starts_with(DataLake::FILE_PATH_PREFIX))
-            table_endpoint = table_endpoint.substr(DataLake::FILE_PATH_PREFIX.length());
-        if (args.empty())
-            args.emplace_back(make_intrusive<ASTLiteral>(table_endpoint));
-        else
-            args[0] = make_intrusive<ASTLiteral>(table_endpoint);
-    }
+    auto table_engine_args = buildTableEngineArgs(settings, *catalog, table_metadata, lightweight);
+    ASTs & args = table_engine_args.args;
+    const auto storage_type = table_engine_args.storage_type;
+    const bool static_credentials_applied = table_engine_args.static_credentials_applied;
 
     const auto columns = ColumnsDescription(table_metadata.getSchema());
 
-    DatabaseDataLakeStorageType storage_type = DatabaseDataLakeStorageType::Other;
-    auto storage_type_from_catalog = catalog->getStorageType();
-    if (storage_type_from_catalog.has_value())
-    {
-        storage_type = storage_type_from_catalog.value();
-    }
-    else
-    {
-        if (table_metadata.hasLocation() || !lightweight)
-            storage_type = table_metadata.getStorageType();
-    }
-
-    /// We either fetch storage credentials from catalog
-    /// or get storage credentials from database settings
-    /// or get storage credentials from database engine arguments
-    /// in CREATE query (e.g. in `args`).
-    /// Vended credentials can be disabled in catalog itself,
-    /// so we have a separate setting to know whether we should even try to fetch them.
-    /// Some catalogs manage their own AWS credential provider chain (e.g. Glue uses the
-    /// database `aws_*` settings to authenticate to the catalog API and to drive STS
-    /// assume-role / instance-profile / web-identity providers, refreshed via
-    /// `getCredentialsConfigurationCallback`). For such catalogs the `aws_*` settings are
-    /// not authoritative static table-storage credentials: consuming them here would build
-    /// the S3 client from the raw key pair without the assumed-role/session-token identity
-    /// and would also suppress the provider-chain refresh callback below. So we only fall
-    /// back to static credentials for catalogs whose refresh callback vends storage
-    /// credentials (Unity/REST), which is exactly the case this fallback targets.
-    const bool catalog_manages_provider_chain = catalog->getCatalogType() == DatabaseDataLakeCatalogType::GLUE;
-
-    bool static_credentials_applied = false;
-    if (args.size() == 1)
-    {
-        std::array<DatabaseDataLakeCatalogType, 3> vended_credentials_catalogs = {DatabaseDataLakeCatalogType::ICEBERG_ONELAKE, DatabaseDataLakeCatalogType::ICEBERG_BIGLAKE, DatabaseDataLakeCatalogType::PAIMON_REST};
-
-        std::shared_ptr<DataLake::IStorageCredentials> static_credentials;
-        if (!catalog_manages_provider_chain)
-            static_credentials = DataLake::tryGetStaticStorageCredentials(storage_type, settings);
-
-        if (table_metadata.hasStorageCredentials())
-        {
-            LOG_DEBUG(log, "Getting credentials");
-            auto storage_credentials = table_metadata.getStorageCredentials();
-            if (storage_credentials)
-            {
-                LOG_DEBUG(log, "Has credentials");
-                storage_credentials->addCredentialsToEngineArgs(args);
-            }
-            else
-            {
-                LOG_DEBUG(log, "Has no credentials");
-            }
-        }
-        else if (static_credentials)
-        {
-            LOG_TRACE(log, "Using static credentials from database settings");
-            static_credentials->addCredentialsToEngineArgs(args);
-            static_credentials_applied = true;
-        }
-        else if (!lightweight && table_metadata.requiresCredentials() && std::find(vended_credentials_catalogs.begin(), vended_credentials_catalogs.end(), catalog->getCatalogType()) == vended_credentials_catalogs.end())
-        {
-            throw Exception(
-               ErrorCodes::BAD_ARGUMENTS,
-               "Either vended credentials need to be enabled "
-               "or storage credentials need to be specified in database engine arguments in CREATE query");
-        }
-    }
+    const bool catalog_manages_provider_chain = catalogManagesProviderChain(*catalog);
 
     LOG_TEST(log, "Using table endpoint: {}", args[0]->as<ASTLiteral>()->value.safeGet<String>());
 

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -716,6 +716,51 @@ static DatabaseDataLakeStorageType toDataLakeStorageType(ObjectStorageType type)
     }
 }
 
+void DatabaseDataLake::applyCatalogSpecificConfiguration(StorageObjectStorageConfiguration & configuration) const
+{
+    const auto settings_version = database_settings.get();
+    const DatabaseDataLakeSettings & settings = *settings_version;
+
+    auto catalog = getCatalog();
+
+    if (catalog->getCatalogType() == DatabaseDataLakeCatalogType::ICEBERG_ONELAKE)
+    {
+#if USE_AZURE_BLOB_STORAGE
+        auto * azure_configuration = dynamic_cast<StorageAzureConfiguration *>(&configuration);
+        if (!azure_configuration)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Configuration is not azure type for one lake catalog");
+        const auto & onelake_catalog = assert_cast<const DataLake::OneLakeCatalog &>(*catalog);
+        const auto auth = onelake_catalog.getStateSnapshot();
+        azure_configuration->setInitializationAsOneLake(
+            auth->client_id,
+            auth->client_secret,
+            auth->tenant_id,
+            auth->bearer_token,
+            settings[DatabaseDataLakeSetting::onelake_use_blob_endpoint].value
+        );
+#else
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Server does not contain support for storage type Azure for Iceberg OneLake catalog");
+#endif
+    }
+
+    if (catalog->getCatalogType() == DatabaseDataLakeCatalogType::ICEBERG_BIGLAKE)
+    {
+#if USE_AWS_S3
+        auto * s3_configuration = dynamic_cast<StorageS3Configuration *>(&configuration);
+        if (!s3_configuration)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Configuration is not S3 type for BigLake catalog");
+        const auto & biglake_catalog = assert_cast<const DataLake::BigLakeCatalog &>(*catalog);
+        s3_configuration->setInitializationAsBigLake(
+            biglake_catalog.getGoogleADCClientId(),
+            biglake_catalog.getGoogleADCClientSecret(),
+            biglake_catalog.getGoogleADCRefreshToken()
+        );
+#else
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Server does not contain support for storage type S3 for Iceberg BigLake catalog");
+#endif
+    }
+}
+
 ASTs DatabaseDataLake::getEngineArgsForNewTable(const String & name, ObjectStorageType engine_storage_type) const
 {
     const auto settings_version = database_settings.get();
@@ -846,44 +891,7 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
     settings_copy[Setting::use_hive_partitioning] = false;
     context_copy->setSettings(settings_copy);
 
-    if (catalog->getCatalogType() == DatabaseDataLakeCatalogType::ICEBERG_ONELAKE)
-    {
-#if USE_AZURE_BLOB_STORAGE
-        auto azure_configuration = std::static_pointer_cast<StorageAzureIcebergConfiguration>(configuration);
-        if (!azure_configuration)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Configuration is not azure type for one lake catalog");
-        auto rest_catalog = std::static_pointer_cast<DataLake::OneLakeCatalog>(catalog);
-        if (!rest_catalog)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Catalog is not equals to one lake");
-        const auto auth = rest_catalog->getStateSnapshot();
-        azure_configuration->setInitializationAsOneLake(
-            auth->client_id,
-            auth->client_secret,
-            auth->tenant_id,
-            auth->bearer_token,
-            settings[DatabaseDataLakeSetting::onelake_use_blob_endpoint].value
-        );
-#else
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Server does not contain support for storage type Azure for Iceberg OneLake catalog");
-#endif
-    }
-
-    if (catalog->getCatalogType() == DatabaseDataLakeCatalogType::ICEBERG_BIGLAKE)
-    {
-#if USE_AWS_S3
-        auto s3_configuration = std::dynamic_pointer_cast<StorageS3Configuration>(configuration);
-        if (!s3_configuration)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Configuration is not S3 type for BigLake catalog");
-        auto biglake_catalog = std::static_pointer_cast<DataLake::BigLakeCatalog>(catalog);
-        s3_configuration->setInitializationAsBigLake(
-            biglake_catalog->getGoogleADCClientId(),
-            biglake_catalog->getGoogleADCClientSecret(),
-            biglake_catalog->getGoogleADCRefreshToken()
-        );
-#else
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Server does not contain support for storage type S3 for Iceberg BigLake catalog");
-#endif
-    }
+    applyCatalogSpecificConfiguration(*configuration);
 
     /// with_table_structure = false: because there will be
     /// no table structure in table definition AST.

--- a/src/Databases/DataLake/DatabaseDataLake.h
+++ b/src/Databases/DataLake/DatabaseDataLake.h
@@ -7,6 +7,7 @@
 #include <Databases/DatabasesCommon.h>
 #include <Databases/DataLake/DatabaseDataLakeSettings.h>
 #include <Databases/DataLake/ICatalog.h>
+#include <Disks/DiskType.h>
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Common/MultiVersion.h>
 #include <Poco/Net/HTTPBasicCredentials.h>
@@ -85,6 +86,8 @@ public:
     void applySettingsChanges(const SettingsChanges & settings_changes, ContextPtr query_context) override;
 
     std::shared_ptr<DataLake::ICatalog> getCatalog() const;
+
+    ASTs getEngineArgsForNewTable(const String & name, ObjectStorageType engine_storage_type) const;
 protected:
     ASTPtr getCreateDatabaseQueryImpl() const override TSA_REQUIRES(mutex);
     ASTPtr getCreateTableQueryImpl(const String & table_name, ContextPtr context, bool throw_on_error) const override;
@@ -140,6 +143,20 @@ private:
         DataLakeStorageSettingsPtr storage_settings) const;
 
     std::string getStorageEndpointForTable(const DataLake::TableMetadata & table_metadata) const;
+
+    struct TableEngineArgs
+    {
+        ASTs args;
+        DatabaseDataLakeStorageType storage_type = DatabaseDataLakeStorageType::Other;
+        bool static_credentials_applied = false;
+    };
+
+    TableEngineArgs buildTableEngineArgs(
+        const DatabaseDataLakeSettings & settings,
+        const DataLake::ICatalog & catalog,
+        const DataLake::TableMetadata & table_metadata,
+        bool lightweight) const;
+
 
     /// Shared implementation of getTablesIterator / getTablesIteratorWithHint.
     /// keep_unresolved_tables controls what happens when a single table's metadata cannot

--- a/src/Databases/DataLake/DatabaseDataLake.h
+++ b/src/Databases/DataLake/DatabaseDataLake.h
@@ -88,6 +88,7 @@ public:
     std::shared_ptr<DataLake::ICatalog> getCatalog() const;
 
     ASTs getEngineArgsForNewTable(const String & name, ObjectStorageType engine_storage_type) const;
+    static bool catalogManagesProviderChain(const DataLake::ICatalog & catalog);
 protected:
     ASTPtr getCreateDatabaseQueryImpl() const override TSA_REQUIRES(mutex);
     ASTPtr getCreateTableQueryImpl(const String & table_name, ContextPtr context, bool throw_on_error) const override;

--- a/src/Databases/DataLake/DatabaseDataLake.h
+++ b/src/Databases/DataLake/DatabaseDataLake.h
@@ -88,6 +88,9 @@ public:
     std::shared_ptr<DataLake::ICatalog> getCatalog() const;
 
     ASTs getEngineArgsForNewTable(const String & name, ObjectStorageType engine_storage_type) const;
+
+    void applyCatalogSpecificConfiguration(StorageObjectStorageConfiguration & configuration) const;
+
     static bool catalogManagesProviderChain(const DataLake::ICatalog & catalog);
 protected:
     ASTPtr getCreateDatabaseQueryImpl() const override TSA_REQUIRES(mutex);

--- a/src/Databases/DataLake/GlueCatalog.cpp
+++ b/src/Databases/DataLake/GlueCatalog.cpp
@@ -9,6 +9,7 @@
 #include <aws/glue/GlueClient.h>
 #include <aws/glue/model/GetTablesRequest.h>
 #include <aws/glue/model/GetTableRequest.h>
+#include <aws/glue/model/GetDatabaseRequest.h>
 #include <aws/glue/model/GetDatabasesRequest.h>
 #include <aws/glue/model/CreateTableRequest.h>
 #include <aws/glue/model/DeleteTableRequest.h>
@@ -635,6 +636,29 @@ void GlueCatalog::createNamespaceIfNotExists(const String & namespace_name) cons
     create_request.SetDatabaseInput(db_input);
 
     glue_client->CreateDatabase(create_request);
+}
+
+std::optional<std::string> GlueCatalog::getDefaultTableLocation(
+    const std::string & namespace_name,
+    const std::string & table_name) const
+{
+    Aws::Glue::Model::GetDatabaseRequest request;
+    request.SetName(namespace_name);
+
+    auto outcome = glue_client->GetDatabase(request);
+    if (!outcome.IsSuccess())
+    {
+        LOG_DEBUG(
+            log, "Cannot get database {} from glue catalog: {}",
+            namespace_name, outcome.GetError().GetMessage());
+        return std::nullopt;
+    }
+
+    const auto & location_uri = outcome.GetResult().GetDatabase().GetLocationUri();
+    if (location_uri.empty())
+        return std::nullopt;
+
+    return std::string(std::filesystem::path(location_uri) / table_name);
 }
 
 void GlueCatalog::createTable(const String & namespace_name, const String & table_name, const String & new_metadata_path, Poco::JSON::Object::Ptr /*metadata_content*/) const

--- a/src/Databases/DataLake/GlueCatalog.h
+++ b/src/Databases/DataLake/GlueCatalog.h
@@ -67,6 +67,10 @@ public:
         return DB::DatabaseDataLakeCatalogType::GLUE;
     }
 
+    std::optional<std::string> getDefaultTableLocation(
+        const std::string & namespace_name,
+        const std::string & table_name) const override;
+
     void createTable(const String & namespace_name, const String & table_name, const String & new_metadata_path, Poco::JSON::Object::Ptr metadata_content) const override;
 
     bool updateMetadata(const String & namespace_name, const String & table_name, const String & new_metadata_path, Poco::JSON::Object::Ptr new_snapshot) const override;

--- a/src/Databases/DataLake/ICatalog.cpp
+++ b/src/Databases/DataLake/ICatalog.cpp
@@ -369,6 +369,11 @@ CatalogTables ICatalog::getTables(const TableNameFilter & filter) const
     return {};
 }
 
+std::optional<std::string> ICatalog::getDefaultTableLocation(const std::string & /*namespace_name*/, const std::string & /*table_name*/) const
+{
+    return std::nullopt;
+}
+
 void ICatalog::createTable(const String & /*namespace_name*/, const String & /*table_name*/, const String & /*new_metadata_path*/, Poco::JSON::Object::Ptr /*metadata_content*/) const
 {
     throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "createTable is not implemented");

--- a/src/Databases/DataLake/ICatalog.h
+++ b/src/Databases/DataLake/ICatalog.h
@@ -245,6 +245,10 @@ public:
     /// E.g. one of S3, Azure, Local, HDFS.
     virtual std::optional<StorageType> getStorageType() const = 0;
 
+    virtual std::optional<std::string> getDefaultTableLocation(
+        const std::string & namespace_name,
+        const std::string & table_name) const;
+
     /// Creates new table in catalog.
     virtual void createTable(const String & namespace_name, const String & table_name, const String & new_metadata_path, Poco::JSON::Object::Ptr metadata_content) const;
 

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -1480,7 +1480,8 @@ void RestCatalog::createNamespaceIfNotExists(const String & namespace_name, cons
     }
     {
         Poco::JSON::Object::Ptr properties = new Poco::JSON::Object;
-        properties->set("location", location);
+        if (!location.empty())
+            properties->set("location", location);
         request_body->set("properties", properties);
     }
 
@@ -1492,6 +1493,58 @@ void RestCatalog::createNamespaceIfNotExists(const String & namespace_name, cons
     {
         DB::tryLogCurrentException(log);
     }
+}
+
+std::optional<std::string> RestCatalog::getNamespaceLocation(const std::string & namespace_name) const
+{
+    const auto state_snapshot = state.get();
+    const std::string endpoint = std::filesystem::path(NAMESPACES_ENDPOINT) / encodeNamespaceForURI(namespace_name);
+
+    String json_str;
+    try
+    {
+        auto buf = createReadBuffer(*state_snapshot, state_snapshot->config.prefix / endpoint);
+        readJSONObjectPossiblyInvalid(json_str, *buf);
+    }
+    catch (const DB::HTTPException & ex)
+    {
+        if (ex.getHTTPStatus() == Poco::Net::HTTPResponse::HTTPStatus::HTTP_NOT_FOUND)
+        {
+            LOG_DEBUG(log, "Namespace {} does not exist: {}", namespace_name, ex.displayText());
+            return std::nullopt;
+        }
+        throw;
+    }
+
+    Poco::JSON::Parser parser;
+    Poco::Dynamic::Var json = parser.parse(json_str);
+    const Poco::JSON::Object::Ptr & object = json.extract<Poco::JSON::Object::Ptr>();
+
+    if (!object->has("properties"))
+        return std::nullopt;
+
+    auto properties = object->get("properties").extract<Poco::JSON::Object::Ptr>();
+    if (!properties || !properties->has("location"))
+        return std::nullopt;
+
+    return properties->get("location").extract<String>();
+}
+
+std::optional<std::string> RestCatalog::getDefaultTableLocation(
+    const std::string & namespace_name,
+    const std::string & table_name) const
+{
+    auto namespace_location = getNamespaceLocation(namespace_name);
+    if (!namespace_location)
+    {
+        createNamespaceIfNotExists(namespace_name, /* location */ "");
+        namespace_location = getNamespaceLocation(namespace_name);
+    }
+
+    if (!namespace_location)
+        return std::nullopt;
+
+    return std::string(std::filesystem::path(*namespace_location) / table_name);
 }
 
 void RestCatalog::createTable(const String & namespace_name, const String & table_name, const String & /*new_metadata_path*/, Poco::JSON::Object::Ptr metadata_content) const

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -87,6 +87,7 @@ namespace DataLake
 
 static constexpr auto CONFIG_ENDPOINT = "config";
 static constexpr auto NAMESPACES_ENDPOINT = "namespaces";
+static constexpr auto ONELAKE_DFS_HOST_SUFFIX = ".dfs.fabric.microsoft.com";
 
 namespace
 {
@@ -463,6 +464,35 @@ void RestCatalog::applySettingsChangesToState(
         new_access_token = std::make_unique<AccessToken>(retrieveAccessToken(new_state.client_id, new_state.client_secret));
         new_auth_headers = DB::HTTPHeaderEntries{{"Authorization", "Bearer " + new_access_token->token}};
     }
+}
+
+std::optional<std::string> OneLakeCatalog::getDefaultTableLocation(
+    const std::string & namespace_name,
+    const std::string & table_name) const
+{
+    auto location = RestCatalog::getDefaultTableLocation(namespace_name, table_name);
+    if (!location || location->contains("://"))
+        return location;
+
+    std::string_view relative_location = *location;
+    while (relative_location.starts_with('/'))
+        relative_location.remove_prefix(1);
+
+    const auto container_end = relative_location.find('/');
+    if (container_end == std::string_view::npos)
+        return std::nullopt;
+
+    const auto catalog_host = Poco::URI(base_url.string()).getHost();
+    const auto account = catalog_host.substr(0, catalog_host.find('.'));
+    if (account.empty())
+        return std::nullopt;
+
+    return fmt::format(
+        "abfss://{}@{}{}/{}",
+        relative_location.substr(0, container_end),
+        account,
+        ONELAKE_DFS_HOST_SUFFIX,
+        relative_location.substr(container_end + 1));
 }
 
 DB::HTTPHeaderEntries OneLakeCatalog::getAuthHeaders(const CatalogState & catalog_state, bool update_token) const
@@ -1586,6 +1616,16 @@ void RestCatalog::createTable(const String & namespace_name, const String & tabl
     }
     catch (const DB::HTTPException & ex)
     {
+        /// A catalog that registers tables from object storage (e.g. Fabric discovers them in
+        /// the lakehouse) has already picked up the initial metadata written just before this
+        /// call, so it reports the identifier as taken.
+        if (ex.getHTTPStatus() == Poco::Net::HTTPResponse::HTTPStatus::HTTP_CONFLICT)
+        {
+            LOG_DEBUG(
+                log, "Table {}.{} is already registered in the catalog: {}",
+                namespace_name, table_name, ex.displayText());
+            return;
+        }
         throw DB::Exception(DB::ErrorCodes::DATALAKE_DATABASE_ERROR, "Failed to create table {}", ex.displayText());
     }
 }

--- a/src/Databases/DataLake/RestCatalog.h
+++ b/src/Databases/DataLake/RestCatalog.h
@@ -73,6 +73,10 @@ public:
         return DB::DatabaseDataLakeCatalogType::ICEBERG_REST;
     }
 
+    std::optional<std::string> getDefaultTableLocation(
+        const std::string & namespace_name,
+        const std::string & table_name) const override;
+
     void createTable(const String & namespace_name, const String & table_name, const String & new_metadata_path, Poco::JSON::Object::Ptr metadata_content) const override;
 
     bool updateMetadata(const String & namespace_name, const String & table_name, const String & new_metadata_path, Poco::JSON::Object::Ptr new_snapshot) const override;
@@ -142,6 +146,8 @@ protected:
         DB::ContextPtr context_);
 
     void createNamespaceIfNotExists(const String & namespace_name, const String & location) const;
+
+    std::optional<std::string> getNamespaceLocation(const std::string & namespace_name) const;
 
     const std::filesystem::path base_url;
     const LoggerPtr log;

--- a/src/Databases/DataLake/RestCatalog.h
+++ b/src/Databases/DataLake/RestCatalog.h
@@ -261,6 +261,10 @@ public:
         return DB::DatabaseDataLakeCatalogType::ICEBERG_ONELAKE;
     }
 
+    std::optional<std::string> getDefaultTableLocation(
+        const std::string & namespace_name,
+        const std::string & table_name) const override;
+
     DB::HTTPHeaderEntries getAuthHeaders(const CatalogState & catalog_state, bool update_token) const override;
 
     /// `bearer_mode` means the catalog authenticates with `onelake_bearer_token`,

--- a/src/Storages/ObjectStorage/Azure/Configuration.cpp
+++ b/src/Storages/ObjectStorage/Azure/Configuration.cpp
@@ -845,9 +845,27 @@ void StorageAzureConfiguration::initializeFromParsedArguments(const AzureStorage
     connection_params = parsed_arguments.connection_params;
 }
 
+std::string StorageAzureConfiguration::getMetadataLocationURI() const
+{
+    static constexpr std::string_view blob_suffix = ".blob.fabric.microsoft.com";
+    static constexpr std::string_view dfs_suffix = ".dfs.fabric.microsoft.com";
+
+    std::string host = Poco::URI(connection_params.endpoint.storage_account_url).getHost();
+    if (host.ends_with(blob_suffix))
+        host = host.substr(0, host.size() - blob_suffix.size()) + std::string(dfs_suffix);
+
+    return fmt::format("abfss://{}@{}/{}", getNamespace(), host, getRawPath().path);
+}
+
 void StorageAzureConfiguration::addStructureAndFormatToArgsIfNeeded(
     ASTs & args, const String & structure_, const String & format_, ContextPtr context, bool with_structure)
 {
+    /// The OneLake signature is a single storage URL: the account and the container are
+    /// derived from it, and the format is dictated by the data lake metadata, so the
+    /// `azureBlobStorage` signatures do not apply and there is nothing to add.
+    if (is_onelake)
+        return;
+
     if (disk)
     {
         if (format == "auto")

--- a/src/Storages/ObjectStorage/Azure/Configuration.h
+++ b/src/Storages/ObjectStorage/Azure/Configuration.h
@@ -106,6 +106,8 @@ public:
     void setPaths(const Paths & paths) override { blobs_paths = paths; }
 
     String getNamespace() const override { return connection_params.getContainer(); }
+
+    std::string getMetadataLocationURI() const override;
     String getDataSourceDescription() const override { return std::filesystem::path(connection_params.getConnectionURL()) / connection_params.getContainer(); }
     StorageObjectStorageQuerySettings getQuerySettings(const ContextPtr &) const override;
 

--- a/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
@@ -365,17 +365,25 @@ public:
             || (*settings)[DataLakeStorageSetting::storage_aws_access_key_id].changed)
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
                 "Don't use deprecated settings storage_catalog_type, storage_catalog_url, storage_aws_access_key_id");
-        const String db_name = table_id.hasDatabase() ? table_id.database_name : context->getCurrentDatabase();
-        /// Having no associated `DataLakeDatabase` is a valid state (e.g. an `Iceberg` table in a
-        /// regular `Atomic`/`Ordinary` database, or a database not currently registered during
-        /// async load), so return nullptr rather than throwing. Callers treat a null catalog as
-        /// "no catalog integration", the same as the base-class default.
-        auto datalake_database = std::dynamic_pointer_cast<DatabaseDataLake>(DatabaseCatalog::instance().tryGetDatabase(db_name));
+        auto datalake_database = tryGetDataLakeDatabase(table_id, context);
         if (!datalake_database)
             return nullptr;
         return datalake_database->getCatalog();
 #else
         return nullptr;
+#endif
+    }
+
+    ASTs completeEngineArgsFromCatalog(
+        [[maybe_unused]] const StorageID & table_id, [[maybe_unused]] ContextPtr context) const override
+    {
+#if USE_AVRO && USE_PARQUET
+        auto datalake_database = tryGetDataLakeDatabase(table_id, context);
+        if (!datalake_database)
+            return {};
+        return datalake_database->getEngineArgsForNewTable(table_id.table_name, this->getType());
+#else
+        return {};
 #endif
     }
 
@@ -414,6 +422,14 @@ private:
     ObjectStoragePtr ready_object_storage;
     DataLakeMetadataPtr current_metadata;
     LoggerPtr log = getLogger("DataLakeConfiguration");
+
+#if USE_AVRO && USE_PARQUET
+    static std::shared_ptr<DatabaseDataLake> tryGetDataLakeDatabase(const StorageID & table_id, const ContextPtr & context)
+    {
+        const String db_name = table_id.hasDatabase() ? table_id.database_name : context->getCurrentDatabase();
+        return std::dynamic_pointer_cast<DatabaseDataLake>(DatabaseCatalog::instance().tryGetDatabase(db_name));
+    }
+#endif
 
     void assertLocalPathCorrect(ObjectStoragePtr object_storage, ContextPtr local_context)
     {

--- a/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
@@ -375,13 +375,15 @@ public:
     }
 
     ASTs completeEngineArgsFromCatalog(
-        [[maybe_unused]] const StorageID & table_id, [[maybe_unused]] ContextPtr context) const override
+        [[maybe_unused]] const StorageID & table_id, [[maybe_unused]] ContextPtr context) override
     {
 #if USE_AVRO && USE_PARQUET
         auto datalake_database = tryGetDataLakeDatabase(table_id, context);
         if (!datalake_database)
             return {};
-        return datalake_database->getEngineArgsForNewTable(table_id.table_name, this->getType());
+        auto args = datalake_database->getEngineArgsForNewTable(table_id.table_name, this->getType());
+        datalake_database->applyCatalogSpecificConfiguration(*this);
+        return args;
 #else
         return {};
 #endif

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -812,8 +812,7 @@ void IcebergMetadata::createInitial(
     if (location_path.find("://") == String::npos && !location_path.starts_with('/'))
         location_path = "/" + location_path;
     if (local_context->getSettingsRef()[Setting::write_full_path_in_iceberg_metadata].value)
-        location_path
-            = configuration_ptr->getTypeName() + "://" + configuration_ptr->getNamespace() + "/" + configuration_ptr->getRawPath().path;
+        location_path = configuration_ptr->getMetadataLocationURI();
     auto [metadata_content_object, metadata_content] = createEmptyMetadataFile(
         location_path, *columns, partition_by, order_by, local_context, configuration_ptr->getDataLakeSettings()[DataLakeStorageSetting::iceberg_format_version]);
     auto compression_method_str = local_context->getSettingsRef()[Setting::iceberg_metadata_compression_method].value;

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp
@@ -109,6 +109,9 @@ void StorageObjectStorageConfiguration::initialize(
             ? storage_settings[DataLakeStorageSetting::disk].value
             : "";
     }
+    if (disk_name.empty() && engine_args.empty() && table_id)
+        engine_args = configuration_to_initialize.completeEngineArgsFromCatalog(*table_id, local_context);
+
     if (!disk_name.empty())
         configuration_to_initialize.fromDisk(disk_name, engine_args, local_context, with_table_structure);
     else if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, local_context, true, nullptr, table_id))

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp
@@ -109,8 +109,17 @@ void StorageObjectStorageConfiguration::initialize(
             ? storage_settings[DataLakeStorageSetting::disk].value
             : "";
     }
-    if (disk_name.empty() && engine_args.empty() && table_id)
+    if (engine_args.empty() && table_id)
+    {
+        if (!disk_name.empty())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Table engine arguments cannot be omitted when `disk` is set: the catalog assigns an absolute "
+                "table location, while `disk` requires a path relative to its own root. "
+                "Specify the path in the table engine arguments explicitly");
+
         engine_args = configuration_to_initialize.completeEngineArgsFromCatalog(*table_id, local_context);
+    }
 
     if (!disk_name.empty())
         configuration_to_initialize.fromDisk(disk_name, engine_args, local_context, with_table_structure);

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
@@ -282,6 +282,11 @@ public:
         return nullptr;
     }
 
+    virtual ASTs completeEngineArgsFromCatalog(const StorageID & /*table_id*/, ContextPtr /*context*/) const
+    {
+        return {};
+    }
+
     virtual bool optimize(ObjectStoragePtr /*object_storage*/, const StorageMetadataPtr & /*metadata_snapshot*/, ContextPtr /*context*/, const std::optional<FormatSettings> & /*format_settings*/)
     {
         return false;

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
@@ -282,9 +282,14 @@ public:
         return nullptr;
     }
 
-    virtual ASTs completeEngineArgsFromCatalog(const StorageID & /*table_id*/, ContextPtr /*context*/) const
+    virtual ASTs completeEngineArgsFromCatalog(const StorageID & /*table_id*/, ContextPtr /*context*/)
     {
         return {};
+    }
+
+    virtual std::string getMetadataLocationURI() const
+    {
+        return getTypeName() + "://" + getNamespace() + "/" + getRawPath().path;
     }
 
     virtual bool optimize(ObjectStoragePtr /*object_storage*/, const StorageMetadataPtr & /*metadata_snapshot*/, ContextPtr /*context*/, const std::optional<FormatSettings> & /*format_settings*/)

--- a/tests/integration/helpers/catalog_manager.py
+++ b/tests/integration/helpers/catalog_manager.py
@@ -98,6 +98,11 @@ def arrow_to_iceberg_schema(data: pa.Table) -> Schema:
 class CatalogManager(ABC):
     """Unified interface for DataLakeCatalog e2e test backends."""
 
+    # Table engine whose object storage matches the locations this catalog
+    # assigns to new tables, and one that deliberately does not match it.
+    table_engine: str = "IcebergS3"
+    mismatched_table_engine: str = "IcebergAzure"
+
     @classmethod
     @abstractmethod
     def from_env(cls) -> "CatalogManager":
@@ -119,6 +124,27 @@ class CatalogManager(ABC):
     ) -> str:
         """Create a table from Arrow data. Returns a short table name."""
         ...
+
+    # The three methods below are only needed by tests of `CREATE TABLE` without table
+    # engine arguments, so they are not abstract: a backend that no such test covers
+    # stays instantiable, and one that is covered fails loudly instead of silently.
+
+    def create_namespace_with_location(self) -> str:
+        """Return a namespace whose location is known to the catalog.
+
+        `CREATE TABLE` without table engine arguments works only when the
+        catalog can tell where to place a new table, which for the catalogs
+        covered here means the namespace carries a location."""
+        raise NotImplementedError
+
+    def track_table(self, namespace: str, table_name: str) -> None:
+        """Register a table created outside this manager, so that
+        `cleanup_table` / `cleanup_all` remove it."""
+        raise NotImplementedError
+
+    def metadata_location(self, namespace: str, table_name: str) -> str:
+        """Return the metadata location the catalog holds for a table."""
+        raise NotImplementedError
 
     def resolve_table_name(
         self, node, database_name: str, short_name: str, retries: int = 5, delay: float = 3.0

--- a/tests/integration/helpers/catalog_manager_aws_glue.py
+++ b/tests/integration/helpers/catalog_manager_aws_glue.py
@@ -219,6 +219,23 @@ class AwsGlueCatalogManager(CatalogManager):
         log.info("Created Glue Iceberg table '%s'", table_identifier)
         return table_name
 
+    def create_namespace_with_location(self) -> str:
+        namespace = f"{NAMESPACE_PREFIX}{uuid.uuid4().hex[:10]}"
+        self.catalog.create_namespace(
+            namespace,
+            {"location": f"s3://{self.config.bucket}/{self.config.prefix}/{namespace}"},
+        )
+        self._namespaces_created.append(namespace)
+        log.info("Created Glue namespace '%s' with a location", namespace)
+        return namespace
+
+    def track_table(self, namespace: str, table_name: str) -> None:
+        self._tables_created.append((namespace, table_name))
+
+    def metadata_location(self, namespace: str, table_name: str) -> str:
+        table_info = self._glue.get_table(DatabaseName=namespace, Name=table_name)["Table"]
+        return table_info["Parameters"]["metadata_location"]
+
     def _namespace_for(self, table_name: str) -> Optional[str]:
         # Each create_table() puts the table in its own namespace; use the
         # most recent matching entry.

--- a/tests/integration/helpers/catalog_manager_biglake.py
+++ b/tests/integration/helpers/catalog_manager_biglake.py
@@ -236,6 +236,27 @@ class BigLakeCatalogManager(CatalogManager):
             return f"gs://{self.config.gcs_bucket}/{self.config.gcs_prefix}"
         return f"gs://{self.config.gcs_bucket}"
 
+    def create_namespace_with_location(self) -> str:
+        # BigLake supports only flat namespaces, so the session namespace is reused
+        # rather than creating a second one. A location assigned by BigLake itself
+        # (from the warehouse) is left alone; it is only set when absent.
+        self._refresh_token_if_needed()
+        namespace = self._session_namespace
+        if "location" in self.catalog.load_namespace_properties(namespace):
+            return namespace
+        self.catalog.update_namespace_properties(
+            namespace,
+            updates={"location": f"{self._warehouse_path()}/{namespace}"},
+        )
+        return namespace
+
+    def track_table(self, namespace: str, table_name: str) -> None:
+        self._tables_created.append(table_name)
+
+    def metadata_location(self, namespace: str, table_name: str) -> str:
+        self._refresh_token_if_needed()
+        return self.catalog.load_table(f"{namespace}.{table_name}").metadata_location
+
     def _refresh_token_if_needed(self) -> str:
         if not self._credential.valid:
             self._credential.refresh(GoogleAuthRequest())

--- a/tests/integration/helpers/catalog_manager_onelake.py
+++ b/tests/integration/helpers/catalog_manager_onelake.py
@@ -49,6 +49,10 @@ class OneLakeCatalogManager(CatalogManager):
     an Iceberg REST API, which is what ClickHouse reads.
     """
 
+    # OneLake hands out `abfss://` table locations.
+    table_engine = "IcebergAzure"
+    mismatched_table_engine = "IcebergS3"
+
     def __init__(self, config: OneLakeConfig):
         self.config = config
         self._credential = ClientSecretCredential(
@@ -342,6 +346,21 @@ class OneLakeCatalogManager(CatalogManager):
         self._tables_created.append(table_name)
         log.info("Created Iceberg table '%s' on OneLake", table_name)
         return table_name
+
+    def create_namespace_with_location(self) -> str:
+        return "dbo"
+
+    def track_table(self, namespace: str, table_name: str) -> None:
+        self._tables_created.append(table_name)
+
+    def metadata_location(self, namespace: str, table_name: str) -> str:
+        resp = requests.get(
+            self._table_api_url(table_name, namespace),
+            headers=self._authed_headers(),
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp.json()["metadata-location"]
 
     def create_sample_table(self) -> Tuple[str, pa.Table]:
         """Create a small ``(id Int64, value String)`` table.

--- a/tests/integration/test_database_glue/test.py
+++ b/tests/integration/test_database_glue/test.py
@@ -842,6 +842,67 @@ def test_create(started_cluster):
     assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`") == "AAPL\n"
 
 
+def test_create_without_engine_arguments(started_cluster):
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_create_without_engine_arguments_{uuid.uuid4()}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+
+    glue_client = boto3.client(
+        "glue", region_name="us-east-1", endpoint_url=get_glue_local_url(started_cluster)
+    )
+    glue_client.create_database(
+        DatabaseInput={
+            "Name": root_namespace,
+            "LocationUri": f"s3://warehouse-glue/{root_namespace}",
+        }
+    )
+
+    create_clickhouse_glue_database(started_cluster, node, CATALOG_NAME)
+    node.query(
+        f"CREATE TABLE {CATALOG_NAME}.`{root_namespace}.{table_name}` (x String) ENGINE = IcebergS3",
+        settings={
+            "allow_experimental_database_glue_catalog": 1,
+            "write_full_path_in_iceberg_metadata": 1,
+        },
+    )
+
+    node.query(
+        f"INSERT INTO {CATALOG_NAME}.`{root_namespace}.{table_name}` VALUES ('AAPL');",
+        settings={"allow_insert_into_iceberg": 1, "write_full_path_in_iceberg_metadata": 1},
+    )
+    assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`") == "AAPL\n"
+
+    table_info = glue_client.get_table(DatabaseName=root_namespace, Name=table_name)["Table"]
+    metadata_location = table_info["Parameters"]["metadata_location"]
+    assert f"/{root_namespace}/{table_name}/metadata/" in metadata_location, metadata_location
+
+
+def test_create_without_engine_arguments_no_database_location(started_cluster):
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_create_without_engine_arguments_no_location_{uuid.uuid4()}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+
+    glue_client = boto3.client(
+        "glue", region_name="us-east-1", endpoint_url=get_glue_local_url(started_cluster)
+    )
+    glue_client.create_database(DatabaseInput={"Name": root_namespace})
+
+    create_clickhouse_glue_database(started_cluster, node, CATALOG_NAME)
+    with pytest.raises(Exception) as exc:
+        node.query(
+            f"CREATE TABLE {CATALOG_NAME}.`{root_namespace}.{table_name}` (x String) ENGINE = IcebergS3",
+            settings={
+                "allow_experimental_database_glue_catalog": 1,
+                "write_full_path_in_iceberg_metadata": 1,
+            },
+        )
+    assert "cannot tell where table" in str(exc.value), str(exc.value)
+
+
 def test_create_gzip_metadata(started_cluster):
     # Regression for issue #109801: a catalog-backed CREATE TABLE from ClickHouse
     # with gzip metadata compression exercises IcebergMetadata::createInitial and

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -992,6 +992,65 @@ def test_create(started_cluster):
     assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`") == "AAPL\n"
 
 
+def test_create_without_engine_arguments(started_cluster):
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_create_without_engine_arguments_{uuid.uuid4()}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+    node.query(
+        f"CREATE TABLE {CATALOG_NAME}.`{root_namespace}.{table_name}` (x String) ENGINE = Iceberg",
+        settings={
+            "allow_experimental_database_iceberg": 1,
+            "write_full_path_in_iceberg_metadata": 1,
+        },
+    )
+
+    node.query(
+        f"INSERT INTO {CATALOG_NAME}.`{root_namespace}.{table_name}` VALUES ('AAPL');",
+        settings={"allow_insert_into_iceberg": 1, "write_full_path_in_iceberg_metadata": 1},
+    )
+    assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`") == "AAPL\n"
+
+    catalog = load_catalog_impl(started_cluster)
+    metadata_location = catalog.load_table(f"{root_namespace}.{table_name}").metadata_location
+    assert f"/{root_namespace}/{table_name}/metadata/" in metadata_location, metadata_location
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+    assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`") == "AAPL\n"
+
+
+def test_create_without_engine_arguments_storage_mismatch(started_cluster):
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_create_without_engine_arguments_storage_mismatch_{uuid.uuid4()}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+    with pytest.raises(QueryRuntimeException) as exc:
+        node.query(
+            f"CREATE TABLE {CATALOG_NAME}.`{root_namespace}.{table_name}` (x String) ENGINE = IcebergLocal",
+            settings={
+                "allow_experimental_database_iceberg": 1,
+                "write_full_path_in_iceberg_metadata": 1,
+            },
+        )
+    assert "while its table engine writes to Local" in str(exc.value), str(exc.value)
+
+
+def test_create_without_engine_arguments_outside_catalog(started_cluster):
+    node = started_cluster.instances["node1"]
+
+    table_name = f"test_create_without_engine_arguments_outside_catalog_{uuid.uuid4().hex}"
+
+    with pytest.raises(QueryRuntimeException) as exc:
+        node.query(f"CREATE TABLE default.{table_name} (x String) ENGINE = IcebergS3")
+    assert "requires 1 to" in str(exc.value), str(exc.value)
+
+
 def test_create_gzip_metadata(started_cluster):
     # Catalog-backed CREATE TABLE from ClickHouse with gzip metadata
     # compression exercises IcebergMetadata::createInitial and the
@@ -1027,8 +1086,11 @@ def test_create_gzip_metadata(started_cluster):
 
     # The initial metadata ClickHouse registered with the catalog must use the
     # spec `gz` extension, and the catalog must point at the file that exists.
+    catalog = load_catalog_impl(started_cluster)
+    metadata_location = catalog.load_table(f"{root_namespace}.{table_name}").metadata_location
+    metadata_bucket, metadata_key = metadata_location[len("s3://"):].split("/", 1)
     metadata_objects = list_s3_objects(
-        started_cluster.minio_client, "warehouse-rest", f"{table_name}/metadata/"
+        started_cluster.minio_client, metadata_bucket, metadata_key.rsplit("/", 1)[0] + "/"
     )
     assert any(obj.endswith(".gz.metadata.json") for obj in metadata_objects), metadata_objects
     assert not any(obj.endswith(".gzip.metadata.json") for obj in metadata_objects), metadata_objects

--- a/tests/integration/test_e2e_catalogs/test.py
+++ b/tests/integration/test_e2e_catalogs/test.py
@@ -727,6 +727,48 @@ def test_incremental_insert(node, shared_db, sales_table, catalog_manager):
         node.query(f"DROP TABLE IF EXISTS {local}")
 
 
+def test_create_without_engine_arguments(node, catalog_manager):
+    namespace = catalog_manager.create_namespace_with_location()
+    table_name = f"e2e_zero_arg_{uuid.uuid4().hex[:8]}"
+    qualified = f"`{namespace}.{table_name}`"
+
+    db = catalog_manager.make_database_name()
+    catalog_manager.create_catalog(node, db)
+    try:
+        node.query(
+            f"CREATE TABLE {db}.{qualified} (x String) "
+            f"ENGINE = {catalog_manager.table_engine}",
+            settings={"write_full_path_in_iceberg_metadata": 1},
+        )
+        catalog_manager.track_table(namespace, table_name)
+
+        metadata_location = catalog_manager.metadata_location(namespace, table_name)
+        assert f"/{namespace}/{table_name}/metadata/" in metadata_location, metadata_location
+
+        assert node.query(f"SELECT count() FROM {db}.{qualified}").strip() == "0"
+    finally:
+        node.query(f"DROP DATABASE IF EXISTS {db}")
+        catalog_manager.cleanup_table(table_name)
+
+
+def test_create_without_engine_arguments_storage_mismatch(node, catalog_manager):
+    namespace = catalog_manager.create_namespace_with_location()
+    table_name = f"e2e_zero_arg_mismatch_{uuid.uuid4().hex[:8]}"
+    qualified = f"`{namespace}.{table_name}`"
+
+    db = catalog_manager.make_database_name()
+    catalog_manager.create_catalog(node, db)
+    try:
+        error = node.query_and_get_error(
+            f"CREATE TABLE {db}.{qualified} (x String) "
+            f"ENGINE = {catalog_manager.mismatched_table_engine}"
+        )
+        assert "while its table engine writes to" in error, error
+        assert table_name not in node.query(f"SHOW TABLES FROM {db}")
+    finally:
+        node.query(f"DROP DATABASE IF EXISTS {db}")
+
+
 # ---------------------------------------------------------------------------
 # System tables & settings
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow to create table without providing credentials if catalog specified. Earlier the query to create table looked like `create table catalog.table enigine = IcebergS3(url, key1, key2)`, but now we can create it via `create table catalog.table enigine = IcebergS3`

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=114477&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114477](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114477+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
