### PR TITLE
Document that PREWHERE filters one join input before the JOIN

### DIFF
--- a/docs/reference/statements/select/index.mdx
+++ b/docs/reference/statements/select/index.mdx
@@ -44,7 +44,7 @@ Specifics of each optional clause are covered in separate sections, which are li
 - [SAMPLE clause](/reference/statements/select/sample)
 - [ARRAY JOIN clause](/reference/statements/select/array-join)
 - [JOIN clause](/reference/statements/select/join)
-- [PREWHERE clause](/reference/statements/select/prewhere) (filters the table it is applied to while that table is read, so it runs before `JOIN` despite its position in this list)
+- [PREWHERE clause](/reference/statements/select/prewhere) (filters the single table it is applied to, so it runs before `JOIN` despite its position in this list)
 - [WHERE clause](/reference/statements/select/where)
 - [GROUP BY clause](/reference/statements/select/group-by)
 - [HAVING clause](/reference/statements/select/having)

--- a/docs/reference/statements/select/index.mdx
+++ b/docs/reference/statements/select/index.mdx
@@ -44,7 +44,7 @@ Specifics of each optional clause are covered in separate sections, which are li
 - [SAMPLE clause](/reference/statements/select/sample)
 - [ARRAY JOIN clause](/reference/statements/select/array-join)
 - [JOIN clause](/reference/statements/select/join)
-- [PREWHERE clause](/reference/statements/select/prewhere)
+- [PREWHERE clause](/reference/statements/select/prewhere) (filters the table it is applied to while that table is read, so it runs before `JOIN` despite its position in this list)
 - [WHERE clause](/reference/statements/select/where)
 - [GROUP BY clause](/reference/statements/select/group-by)
 - [HAVING clause](/reference/statements/select/having)

--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -466,7 +466,7 @@ For `ON`, `WHERE`, and `GROUP BY` clauses:
 
 ### Performance {#performance}
 
-When running a `JOIN`, there is no optimization of the order of execution in relation to other stages of the query. The join (a search in the right table) is run before filtering in `WHERE` and before aggregation.
+When running a `JOIN`, there is no optimization of the order of execution in relation to other stages of the query. The join (a search in the right table) is run before filtering in `WHERE` and before aggregation. The query plan may still push a `WHERE` filter below the join where doing so returns the same rows; see [PREWHERE](/reference/statements/select/prewhere) for the clause that filters a join input unconditionally.
 
 Each time a query is run with the same `JOIN`, the subquery is run again because the result is not cached. To avoid this, use the special [Join](/reference/engines/table-engines/special/join) table engine, which is a prepared array for joining that is always in RAM.
 

--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -466,7 +466,7 @@ For `ON`, `WHERE`, and `GROUP BY` clauses:
 
 ### Performance {#performance}
 
-When running a `JOIN`, there is no optimization of the order of execution in relation to other stages of the query. The join (a search in the right table) is run before filtering in `WHERE` and before aggregation. The query plan may still push a `WHERE` filter below the join where doing so returns the same rows; see [PREWHERE](/reference/statements/select/prewhere) for the clause that filters a join input unconditionally.
+When running a `JOIN`, the join (a search in the right table) is evaluated before filtering in `WHERE` and before aggregation. The query plan may push a `WHERE` filter below the join when that returns the same rows, but it does not otherwise reorder the join with respect to those stages; see [PREWHERE](/reference/statements/select/prewhere) for the clause that filters a join input unconditionally.
 
 Each time a query is run with the same `JOIN`, the subquery is run again because the result is not cached. To avoid this, use the special [Join](/reference/engines/table-engines/special/join) table engine, which is a prepared array for joining that is always in RAM.
 

--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -466,7 +466,7 @@ For `ON`, `WHERE`, and `GROUP BY` clauses:
 
 ### Performance {#performance}
 
-When running a `JOIN`, the join (a search in the right table) is evaluated before filtering in `WHERE` and before aggregation. The query plan may push a `WHERE` filter below the join when that returns the same rows, but it does not otherwise reorder the join with respect to those stages; see [PREWHERE](/reference/statements/select/prewhere) for the clause that filters a join input unconditionally.
+When running a `JOIN`, there is no optimization of the order of execution in relation to other stages of the query. The join (a search in the right table) is run before filtering in `WHERE` and before aggregation.
 
 Each time a query is run with the same `JOIN`, the subquery is run again because the result is not cached. To avoid this, use the special [Join](/reference/engines/table-engines/special/join) table engine, which is a prepared array for joining that is always in RAM.
 

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -27,7 +27,7 @@ The `PREWHERE` section is executed before `FINAL`, so the results of `FROM ... F
 <Note>
 `PREWHERE` is applied while reading the table it belongs to, so it filters that one input before a [JOIN](/reference/statements/select/join) is performed. `WHERE` is evaluated on the result of the join, and the optimizer is free to move it below the join when that returns the same rows. The same condition can therefore give different results in the two clauses.
 
-For example, `SELECT a.id FROM a LEFT JOIN b ON a.id = b.x PREWHERE b.y > 50` is equivalent to `SELECT a.id FROM a LEFT JOIN (SELECT * FROM b WHERE y > 50) AS b ON a.id = b.x`, and not to the same query with `WHERE b.y > 50`: rows of `b` are removed before the join runs, so rows of `a` that lose their match are returned rather than dropped, with the columns of `b` filled as [join_use_nulls](/reference/settings/session-settings/join#join_use_nulls) specifies.
+For example, `SELECT a.id FROM a LEFT JOIN b ON a.id = b.x PREWHERE b.y > 50` is equivalent to `SELECT a.id FROM a LEFT JOIN (SELECT * FROM b WHERE y > 50) AS b ON a.id = b.x`, and not to the same query with `WHERE b.y > 50`: rows of `b` are removed before the join runs, so rows of `a` that lose their match are returned rather than dropped, with the columns of `b` filled as [join_use_nulls](/reference/settings/session-settings/join#join_use_nulls) specifies. Naming a joined table's column in `PREWHERE` like this requires the [analyzer](/guides/clickhouse/performance-and-monitoring/analyzer) (`enable_analyzer = 1`, the default); with `enable_analyzer = 0` the same query raises `UNKNOWN_IDENTIFIER`.
 </Note>
 
 ## Limitations {#limitations}

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -24,6 +24,12 @@ If query has [FINAL](/reference/statements/select/from#final-modifier) modifier,
 The `PREWHERE` section is executed before `FINAL`, so the results of `FROM ... FINAL` queries may be skewed when using `PREWHERE` with fields not in the `ORDER BY` section of a table.
 </Note>
 
+<Note>
+`PREWHERE` is applied while reading the table it belongs to, so it filters that one input before a [JOIN](/reference/statements/select/join) is performed, whereas `WHERE` is applied after the join. The same condition can therefore give different results in the two clauses.
+
+For example, `SELECT a.id FROM a LEFT JOIN b ON a.id = b.x PREWHERE b.y > 50` is equivalent to `SELECT a.id FROM a LEFT JOIN (SELECT * FROM b WHERE y > 50) AS b ON a.id = b.x`, and not to the same query with `WHERE b.y > 50`: rows of `b` are removed before the join runs, so rows of `a` that lose their match are returned filled with default values rather than dropped.
+</Note>
+
 ## Limitations {#limitations}
 
 `PREWHERE` is only supported by tables from the [*MergeTree](/reference/engines/table-engines/mergetree-family/index) family.

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -25,7 +25,7 @@ The `PREWHERE` section is executed before `FINAL`, so the results of `FROM ... F
 </Note>
 
 <Note>
-`PREWHERE` is applied while reading the table it belongs to, so it filters that one input before a [JOIN](/reference/statements/select/join) is performed. `WHERE` is evaluated on the result of the join, and the optimizer is free to move it below the join when that returns the same rows. The same condition can therefore give different results in the two clauses.
+`PREWHERE` belongs to a single table expression, so it filters that one input before a [JOIN](/reference/statements/select/join) is performed. `WHERE` is evaluated on the result of the join, and the optimizer is free to move it below the join when that returns the same rows. The same condition can therefore give different results in the two clauses.
 
 For example, `SELECT a.id FROM a LEFT JOIN b ON a.id = b.x PREWHERE b.y > 50` is equivalent to `SELECT a.id FROM a LEFT JOIN (SELECT * FROM b WHERE y > 50) AS b ON a.id = b.x`, and not to the same query with `WHERE b.y > 50`: rows of `b` are removed before the join runs, so rows of `a` that lose their match are returned rather than dropped, with the columns of `b` filled as [join_use_nulls](/reference/settings/session-settings/join#join_use_nulls) specifies. Naming a joined table's column in `PREWHERE` like this requires the [analyzer](/guides/clickhouse/performance-and-monitoring/analyzer) (`enable_analyzer = 1`, the default); with `enable_analyzer = 0` the same query raises `UNKNOWN_IDENTIFIER`.
 </Note>

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -25,7 +25,7 @@ The `PREWHERE` section is executed before `FINAL`, so the results of `FROM ... F
 </Note>
 
 <Note>
-`PREWHERE` is applied while reading the table it belongs to, so it filters that one input before a [JOIN](/reference/statements/select/join) is performed, whereas `WHERE` is applied after the join. The same condition can therefore give different results in the two clauses.
+`PREWHERE` is applied while reading the table it belongs to, so it filters that one input before a [JOIN](/reference/statements/select/join) is performed. `WHERE` is evaluated on the result of the join, and the optimizer is free to move it below the join when that returns the same rows. The same condition can therefore give different results in the two clauses.
 
 For example, `SELECT a.id FROM a LEFT JOIN b ON a.id = b.x PREWHERE b.y > 50` is equivalent to `SELECT a.id FROM a LEFT JOIN (SELECT * FROM b WHERE y > 50) AS b ON a.id = b.x`, and not to the same query with `WHERE b.y > 50`: rows of `b` are removed before the join runs, so rows of `a` that lose their match are returned rather than dropped, with the columns of `b` filled as [join_use_nulls](/reference/settings/session-settings/join#join_use_nulls) specifies.
 </Note>

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -27,7 +27,7 @@ The `PREWHERE` section is executed before `FINAL`, so the results of `FROM ... F
 <Note>
 `PREWHERE` is applied while reading the table it belongs to, so it filters that one input before a [JOIN](/reference/statements/select/join) is performed, whereas `WHERE` is applied after the join. The same condition can therefore give different results in the two clauses.
 
-For example, `SELECT a.id FROM a LEFT JOIN b ON a.id = b.x PREWHERE b.y > 50` is equivalent to `SELECT a.id FROM a LEFT JOIN (SELECT * FROM b WHERE y > 50) AS b ON a.id = b.x`, and not to the same query with `WHERE b.y > 50`: rows of `b` are removed before the join runs, so rows of `a` that lose their match are returned filled with default values rather than dropped.
+For example, `SELECT a.id FROM a LEFT JOIN b ON a.id = b.x PREWHERE b.y > 50` is equivalent to `SELECT a.id FROM a LEFT JOIN (SELECT * FROM b WHERE y > 50) AS b ON a.id = b.x`, and not to the same query with `WHERE b.y > 50`: rows of `b` are removed before the join runs, so rows of `a` that lose their match are returned rather than dropped, with the columns of `b` filled as [join_use_nulls](/reference/settings/session-settings/join#join_use_nulls) specifies.
 </Note>
 
 ## Limitations {#limitations}

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -12,7 +12,7 @@ With prewhere optimization, at first only the columns necessary for executing pr
 
 ## Controlling Prewhere Manually {#controlling-prewhere-manually}
 
-The clause has the same meaning as the `WHERE` clause. The difference is in which data is read from the table. When manually controlling `PREWHERE` for filtration conditions that are used by a minority of the columns in the query, but that provide strong data filtration. This reduces the volume of data to read.
+The clause controls which data is read from the table, not only which rows the query returns. When manually controlling `PREWHERE` for filtration conditions that are used by a minority of the columns in the query, but that provide strong data filtration. This reduces the volume of data to read.
 
 A query may simultaneously specify `PREWHERE` and `WHERE`. In this case, `PREWHERE` precedes `WHERE`.
 
@@ -27,7 +27,7 @@ The `PREWHERE` section is executed before `FINAL`, so the results of `FROM ... F
 <Note>
 `PREWHERE` belongs to a single table expression, so it filters that one input before a [JOIN](/reference/statements/select/join) is performed. `WHERE` is evaluated on the result of the join, and the optimizer is free to move it below the join when that returns the same rows. The same condition can therefore give different results in the two clauses.
 
-For example, `SELECT a.id FROM a LEFT JOIN b ON a.id = b.x PREWHERE b.y > 50` is equivalent to `SELECT a.id FROM a LEFT JOIN (SELECT * FROM b WHERE y > 50) AS b ON a.id = b.x`, and not to the same query with `WHERE b.y > 50`: rows of `b` are removed before the join runs, so rows of `a` that lose their match are returned rather than dropped, with the columns of `b` filled as [join_use_nulls](/reference/settings/session-settings/join#join_use_nulls) specifies. Naming a joined table's column in `PREWHERE` like this requires the [analyzer](/guides/clickhouse/performance-and-monitoring/analyzer) (`enable_analyzer = 1`, the default); with `enable_analyzer = 0` the same query raises `UNKNOWN_IDENTIFIER`.
+For example, `SELECT a.id FROM a LEFT JOIN b ON a.id = b.x PREWHERE b.y > 50` is equivalent to `SELECT a.id FROM a LEFT JOIN (SELECT * FROM b WHERE y > 50) AS b ON a.id = b.x`, and not to the same query with `WHERE b.y > 50`: rows of `b` are removed before the join runs, so rows of `a` that lose their match are returned rather than dropped, with the columns of `b` filled as [join_use_nulls](/reference/settings/session-settings/join#join_use_nulls) specifies.
 </Note>
 
 ## Limitations {#limitations}

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -12,7 +12,7 @@ With prewhere optimization, at first only the columns necessary for executing pr
 
 ## Controlling Prewhere Manually {#controlling-prewhere-manually}
 
-The clause controls which data is read from the table, not only which rows the query returns. When manually controlling `PREWHERE` for filtration conditions that are used by a minority of the columns in the query, but that provide strong data filtration. This reduces the volume of data to read.
+The clause filters the single table expression it is applied to, and normally does so while that table is read. When manually controlling `PREWHERE` for filtration conditions that are used by a minority of the columns in the query, but that provide strong data filtration. This reduces the volume of data to read.
 
 A query may simultaneously specify `PREWHERE` and `WHERE`. In this case, `PREWHERE` precedes `WHERE`.
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not required for a documentation change.

### Description

`prewhere.mdx` did not mention `JOIN` at all. This is the documentation
KochetovNicolai asked for when he closed issue 89097 as not-a-bug: "We need to
document this."

One `<Note>`, next to the existing note that documents the same class of fact for
`FINAL`. It states the rule and gives the equivalent explicit spelling as a
filtered subquery. The `SELECT` clause list is annotated to agree with it.

Measured on the example as it appears on the page: `PREWHERE b.y > 50` returns
`[1,2,3,4]`, the filtered-subquery spelling the same, the `WHERE` spelling
`[1,4]`. The `WHERE` result is unchanged whether `query_plan_filter_push_down` is
on or off, which is why the note credits `WHERE` to the join result rather than to
a fixed position, per PedroTadim's review.

The note claims nothing about individual join kinds or strictnesses, since
`FULL JOIN` and `ASOF INNER JOIN` both differ too, and it attributes the fill
value to
[join_use_nulls](https://clickhouse.com/docs/reference/settings/session-settings/join#join_use_nulls)
rather than naming one.

Related: https://github.com/ClickHouse/ClickHouse/issues/89097
Related: https://github.com/ClickHouse/ClickHouse/issues/114206


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1341` (included in `26.8` and later)
<!-- ch-version-info:end -->