### PR TITLE
Docs: link OSS to Cloud row in migration overview table

### DIFF
--- a/docs/get-started/migrate/overview.mdx
+++ b/docs/get-started/migrate/overview.mdx
@@ -30,5 +30,5 @@ There are several migration paths into ClickHouse Cloud, depending on where your
 | [Snowflake](/get-started/migrate/snowflake/overview) | Migrate Snowflake data and SQL workloads to ClickHouse Cloud. |
 | [Elasticsearch](/get-started/migrate/elastic/overview) | Migrate Elasticsearch data and queries to ClickHouse. |
 | [Redshift](/get-started/migrate/redshift/overview) | Migrate Redshift data and workloads to ClickHouse Cloud. |
-| OSS to Cloud | Transfer data from a self-managed ClickHouse deployment using [`remoteSecure`](/get-started/migrate/oss-to-cloud/clickhouse-to-cloud) or [`BACKUP` and `RESTORE`](/get-started/migrate/oss-to-cloud/oss-to-cloud-backup-restore). |
+| [OSS to Cloud](/get-started/migrate/oss-to-cloud/clickhouse-to-cloud) | Transfer data from a self-managed ClickHouse deployment using [`remoteSecure`](/get-started/migrate/oss-to-cloud/clickhouse-to-cloud) or [`BACKUP` and `RESTORE`](/get-started/migrate/oss-to-cloud/oss-to-cloud-backup-restore). |
 | [Other methods](/get-started/migrate/other-methods/clickhouse-local-etl) | Use clickhouse-local, ETL tools, or object storage for other migration scenarios. |


### PR DESCRIPTION
The "OSS to Cloud" row label in the migration paths table on
[Migrating Data into ClickHouse](https://clickhouse.com/docs/get-started/migrate/overview)
was plain text, while every other row (PostgreSQL, BigQuery, Snowflake,
Elasticsearch, Redshift, Other methods) links its label to that path's
overview page. This links it to the same target already used inline in the
row's description (`/get-started/migrate/oss-to-cloud/clickhouse-to-cloud`),
matching the existing pattern.

### before
<img width="1179" height="568" alt="2026-08-12 13-22-08_before" src="https://github.com/user-attachments/assets/a4720606-bb86-41e1-b247-4181f6991cf6" />

### after
<img width="1154" height="570" alt="image" src="https://github.com/user-attachments/assets/8d412935-fbd0-4f57-bc39-5b1cf5771580" />


Verified locally:
- `python3 -m ci.praktika run "Docs check (Mintlify)" --test "Check internal links and anchors"` — 0 errors
- `mint dev` local preview — row now renders as a link consistent with sibling rows

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1242` (included in `26.8` and later)
<!-- ch-version-info:end -->