### PR TITLE
ci: remove stale cache status files

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -1213,9 +1213,11 @@ clickhouse-client --query "SELECT count() FROM test.visits"
 
         self.restore_system_metadata_files_from_remote_database_disk()
 
+        # Caches created via the disk() function live one level deeper, under
+        # disks/<name>/status.
         cache_status_files = glob.glob(
             f"{self.ch_var_lib_dir}/filesystem_caches/*/status"
-        )
+        ) + glob.glob(f"{self.ch_var_lib_dir}/filesystem_caches/disks/*/status")
         if cache_status_files:
             print(
                 f"WARNING: Server died? Removing cache status files: {cache_status_files}"


### PR DESCRIPTION
Though note that the server was still active, not sure why (since it got SIGTRAP, maybe some deadlock in sanitizers build).

Fixes: https://pastila.nl/?004f7797/8607b82ba8c324e4f5081e6c747ad583#ad4mwd7GRSHyUgNa46pJHw==GCM

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1327` (included in `26.8` and later)
<!-- ch-version-info:end -->