### PR TITLE
Targeted tests: skip previously failed tests that no longer exist

### DIFF
--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -356,8 +356,39 @@ class Targeting:
                     test_name = parts[0]
                     tests.append(test_name)
         print(f"Parsed {len(tests)} test names: {tests}")
-        tests = list(set(tests))
-        return sorted(tests)
+        tests = sorted(set(tests))
+        # A test that failed within the CIDB window (30 days) may have been
+        # deleted or renamed on master since — e.g. a flaky test that was
+        # removed instead of deflaked. Passing its name to clickhouse-test (or
+        # to the integration runner) selects nothing; with no other targeted
+        # tests the run ends with "No tests were run." and exit code 1 (the
+        # same failure mode `PR #104097` fixed for orphan data files). Rerun
+        # only tests that still exist in this checkout.
+        missing = [t for t in tests if not self._test_exists(t)]
+        if missing:
+            print(
+                f"Skipping {len(missing)} previously failed tests that no longer "
+                f"exist in the checkout: {missing}"
+            )
+            tests = [t for t in tests if t not in set(missing)]
+        return tests
+
+    def _test_exists(self, test_name: str) -> bool:
+        """Whether a test name reported by CIDB still resolves to a test in
+        this checkout."""
+        if self.job_type == self.INTEGRATION_JOB_TYPE:
+            # Integration test names look like
+            # `test_storage_kafka/test.py::test_case[param]`; the first path
+            # component is the test directory under `tests/integration/`.
+            test_dir = test_name.split("/", 1)[0].split("::", 1)[0]
+            return (Path("tests/integration") / test_dir).is_dir()
+        # Stateless test names are the base name of a file under
+        # `tests/queries/0_stateless/` with one of the known extensions.
+        test_dir = Path("tests/queries/0_stateless")
+        return any(
+            (test_dir / f"{test_name}{ext}").is_file()
+            for ext in self._TEST_FILE_EXTENSIONS
+        )
 
     @staticmethod
     def _escape_sql_string(s: str) -> str:

--- a/ci/tests/test_find_tests.py
+++ b/ci/tests/test_find_tests.py
@@ -180,3 +180,34 @@ def test_get_changed_tests_skips_unmappable_fixture():
     # would exit 1 on a zero-match run).
     diff = "+++ b/tests/queries/0_stateless/data_parquet/99999_no_such_test.parquet\n"
     assert _targeting_from_diff(diff).get_changed_tests() == []
+
+
+def _targeting_with_job_type(job_type):
+    targeter = Targeting.__new__(Targeting)
+    targeter.job_type = job_type
+    return targeter
+
+
+def test_existing_stateless_test_still_exists():
+    targeter = _targeting_with_job_type(Targeting.STATELESS_JOB_TYPE)
+    assert targeter._test_exists("00001_select_1")
+
+
+def test_deleted_stateless_test_no_longer_exists():
+    # PR #110958 reproducer: `04648_geohashes_in_box_cancellation` failed on
+    # the PR, was then deleted from master as flaky, and the targeted job kept
+    # replaying its name from CIDB — clickhouse-test matched zero tests and
+    # exited 1 with "No tests were run.".
+    targeter = _targeting_with_job_type(Targeting.STATELESS_JOB_TYPE)
+    assert not targeter._test_exists("04648_geohashes_in_box_cancellation")
+
+
+def test_existing_integration_test_still_exists():
+    targeter = _targeting_with_job_type(Targeting.INTEGRATION_JOB_TYPE)
+    assert targeter._test_exists("test_storage_s3/test.py::test_case[param]")
+    assert targeter._test_exists("test_storage_s3")
+
+
+def test_deleted_integration_test_no_longer_exists():
+    targeter = _targeting_with_job_type(Targeting.INTEGRATION_JOB_TYPE)
+    assert not targeter._test_exists("test_no_such_directory/test.py::test_case")


### PR DESCRIPTION
The targeted functional-test jobs replay tests that failed in previous CI runs of the PR (a 30-day CIDB window). When such a test is deleted or renamed on master in the meantime — e.g. a flaky test removed instead of deflaked — its name still comes back from CIDB, `clickhouse-test` matches zero tests, prints `No tests were run.` and exits with code 1, turning the whole job red for weeks on every PR that ever saw the test fail. The same failure mode existed for orphan data files and was fixed in #104097; this is the deleted-test variant.

Seen on #110958: `Stateless tests (arm_asan_ubsan, targeted)` kept replaying `04648_geohashes_in_box_cancellation`, which was deleted from master on 2026-08-09 (d5bc95515d9e "Remove recently added cancellation tests, they are flaky"). CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110958&sha=7acb5ba0dddf5862fe1cd118b17899a272708202&name_0=PR&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20targeted%29

The fix filters the CIDB result in `Targeting.get_previously_failed_tests` to tests that still exist in the checkout: a file with a known test extension under `tests/queries/0_stateless/` for stateless jobs, the test directory under `tests/integration/` for integration jobs. Skipped names are logged, not silently dropped. Unit tests added in `ci/tests/test_find_tests.py`.

Related: https://github.com/ClickHouse/ClickHouse/pull/110958
Related: https://github.com/ClickHouse/ClickHouse/pull/104097

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1290` (included in `26.8` and later)
<!-- ch-version-info:end -->