### PR TITLE
Do not rewrite arrayExists to has when the element and needle string types differ

### DIFF
--- a/src/Analyzer/Passes/ArrayExistsToHasPass.cpp
+++ b/src/Analyzer/Passes/ArrayExistsToHasPass.cpp
@@ -11,6 +11,7 @@
 #include <Core/Settings.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/getLeastSupertype.h>
@@ -28,7 +29,7 @@ namespace
 /// `equals` compares the string family zero-padded, so a needle whose extra bytes are all NUL
 /// still matches a narrower element. `has` compares either the String supertype, which strips
 /// trailing NULs, or raw Fields, which are not padded. The two therefore agree only when the
-/// element and needle types are identical, and a tuple agrees only when all of its elements do.
+/// element and needle types are identical, and a container agrees only when its members do.
 bool stringFamilyPairIsNotEqualityEquivalent(const DataTypePtr & element_type, const DataTypePtr & needle_type)
 {
     auto element = removeNullable(removeLowCardinality(element_type));
@@ -49,6 +50,17 @@ bool stringFamilyPairIsNotEqualityEquivalent(const DataTypePtr & element_type, c
 
         return false;
     }
+
+    const auto * element_array = typeid_cast<const DataTypeArray *>(element.get());
+    const auto * needle_array = typeid_cast<const DataTypeArray *>(needle.get());
+    if (element_array && needle_array)
+        return stringFamilyPairIsNotEqualityEquivalent(element_array->getNestedType(), needle_array->getNestedType());
+
+    const auto * element_map = typeid_cast<const DataTypeMap *>(element.get());
+    const auto * needle_map = typeid_cast<const DataTypeMap *>(needle.get());
+    if (element_map && needle_map)
+        return stringFamilyPairIsNotEqualityEquivalent(element_map->getKeyType(), needle_map->getKeyType())
+            || stringFamilyPairIsNotEqualityEquivalent(element_map->getValueType(), needle_map->getValueType());
 
     return isStringOrFixedString(element) && isStringOrFixedString(needle) && !element->equals(*needle);
 }

--- a/src/Analyzer/Passes/ArrayExistsToHasPass.cpp
+++ b/src/Analyzer/Passes/ArrayExistsToHasPass.cpp
@@ -12,6 +12,7 @@
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/getLeastSupertype.h>
 
 namespace DB
@@ -23,6 +24,34 @@ namespace Setting
 
 namespace
 {
+
+/// `equals` compares the string family zero-padded, so a needle whose extra bytes are all NUL
+/// still matches a narrower element. `has` compares either the String supertype, which strips
+/// trailing NULs, or raw Fields, which are not padded. The two therefore agree only when the
+/// element and needle types are identical, and a tuple agrees only when all of its elements do.
+bool stringFamilyPairIsNotEqualityEquivalent(const DataTypePtr & element_type, const DataTypePtr & needle_type)
+{
+    auto element = removeNullable(removeLowCardinality(element_type));
+    auto needle = removeNullable(removeLowCardinality(needle_type));
+
+    const auto * element_tuple = typeid_cast<const DataTypeTuple *>(element.get());
+    const auto * needle_tuple = typeid_cast<const DataTypeTuple *>(needle.get());
+    if (element_tuple && needle_tuple)
+    {
+        const auto & element_elements = element_tuple->getElements();
+        const auto & needle_elements = needle_tuple->getElements();
+        if (element_elements.size() != needle_elements.size())
+            return false;
+
+        for (size_t i = 0; i < element_elements.size(); ++i)
+            if (stringFamilyPairIsNotEqualityEquivalent(element_elements[i], needle_elements[i]))
+                return true;
+
+        return false;
+    }
+
+    return isStringOrFixedString(element) && isStringOrFixedString(needle) && !element->equals(*needle);
+}
 
 class RewriteArrayExistsToHasVisitor : public InDepthQueryTreeVisitorWithContext<RewriteArrayExistsToHasVisitor>
 {
@@ -120,6 +149,11 @@ public:
 
         const auto * constant_node = has_constant_element_argument->as<ConstantNode>();
         if (constant_node && constant_node->getValue().isNull())
+            return;
+
+        /// Such a pair has a supertype, so the check below admits it, but the two spellings
+        /// still disagree.
+        if (stringFamilyPairIsNotEqualityEquivalent(nested_type, constant_type))
             return;
 
         bool types_compatible = (isNativeNumber(nested_type) || isEnum(nested_type)) && isNativeNumber(constant_type);

--- a/tests/queries/0_stateless/04792_array_exists_to_has_string_family.reference
+++ b/tests/queries/0_stateless/04792_array_exists_to_has_string_family.reference
@@ -1,0 +1,150 @@
+-- { echo }
+-- The arrayExists -> has rewrite must not change the answer for a String/FixedString pair.
+
+DROP TABLE IF EXISTS t_fs;
+CREATE TABLE t_fs (v Array(FixedString(3))) ENGINE = Memory;
+INSERT INTO t_fs SELECT [toFixedString('V0', 3)];
+-- Ground truth: equals compares the string family zero-padded.
+SELECT toFixedString('V0', 3) = 'V0\0', toFixedString('V0', 3) = 'V0\0\0';
+1	1
+-- A needle as wide as the element, and wider, with an all-NUL tail.
+SELECT arrayExists(x -> x = 'V0\0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> x = 'V0\0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+SELECT arrayExists(x -> x = 'V0\0\0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> x = 'V0\0\0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+-- The constant may sit on either side of the comparison.
+SELECT arrayExists(x -> 'V0\0' = x, v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> 'V0\0' = x, v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+-- A tail that is not all NUL must still not match.
+SELECT arrayExists(x -> x = 'V0abc', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 0;
+0
+SELECT arrayExists(x -> x = 'V0abc', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1;
+0
+-- A needle narrower than the element already agreed.
+SELECT arrayExists(x -> x = 'V0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> x = 'V0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+-- Cross-width FixedString over a constant array, where has() compares raw Fields.
+SELECT arrayExists(x -> x = toFixedString('V0', 4), [toFixedString('V0', 3)]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> x = toFixedString('V0', 4), [toFixedString('V0', 3)]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+SELECT arrayExists(x -> x = toFixedString('V0', 4), v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> x = toFixedString('V0', 4), v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+-- A FixedString needle against a String element diverges in the same way.
+DROP TABLE IF EXISTS t_str;
+CREATE TABLE t_str (v Array(String)) ENGINE = Memory;
+INSERT INTO t_str SELECT ['V0'];
+SELECT arrayExists(x -> x = toFixedString('V0', 3), v) FROM t_str SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> x = toFixedString('V0', 3), v) FROM t_str SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+-- LowCardinality: through the rewrite this used to throw TOO_LARGE_STRING_SIZE.
+DROP TABLE IF EXISTS t_lc;
+CREATE TABLE t_lc (v Array(LowCardinality(FixedString(3)))) ENGINE = Memory;
+INSERT INTO t_lc SELECT [toFixedString('V0', 3)];
+SELECT arrayExists(x -> x = 'V0\0\0', v) FROM t_lc SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> x = 'V0\0\0', v) FROM t_lc SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+DROP TABLE IF EXISTS t_null;
+CREATE TABLE t_null (v Array(Nullable(FixedString(3)))) ENGINE = Memory;
+INSERT INTO t_null SELECT [toFixedString('V0', 3)];
+SELECT arrayExists(x -> x = 'V0\0\0', v) FROM t_null SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> x = 'V0\0\0', v) FROM t_null SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+-- Tuple elements are compared element-wise, at any nesting depth.
+DROP TABLE IF EXISTS t_tuple;
+CREATE TABLE t_tuple (v Array(Tuple(FixedString(3)))) ENGINE = Memory;
+INSERT INTO t_tuple SELECT [tuple(toFixedString('V0', 3))];
+SELECT arrayExists(x -> x = tuple('V0\0'), v) FROM t_tuple SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> x = tuple('V0\0'), v) FROM t_tuple SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+DROP TABLE IF EXISTS t_tuple2;
+CREATE TABLE t_tuple2 (v Array(Tuple(Tuple(FixedString(3))))) ENGINE = Memory;
+INSERT INTO t_tuple2 SELECT [tuple(tuple(toFixedString('V0', 3)))];
+SELECT arrayExists(x -> x = tuple(tuple('V0\0')), v) FROM t_tuple2 SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> x = tuple(tuple('V0\0')), v) FROM t_tuple2 SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+-- Array and Map elements do not zero-pad on either side, so they keep the rewrite.
+DROP TABLE IF EXISTS t_nested_arr;
+CREATE TABLE t_nested_arr (v Array(Array(FixedString(3)))) ENGINE = Memory;
+INSERT INTO t_nested_arr SELECT [[toFixedString('V0', 3)]];
+SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 0;
+0
+SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1;
+0
+DROP TABLE IF EXISTS t_nested_map;
+CREATE TABLE t_nested_map (v Array(Map(String, FixedString(3)))) ENGINE = Memory;
+INSERT INTO t_nested_map SELECT [map('k', toFixedString('V0', 3))];
+SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 0;
+0
+SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1;
+0
+-- Which spelling the plan ends up with. Match `function_name:` rather than the bare name:
+-- the PROJECTION COLUMNS header echoes the original query text, so a bare `%arrayExists%`
+-- matches even when the rewrite did happen.
+
+-- Declined for a divergent pair: arrayExists stays, no has appears.
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = 'V0\0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+1
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = 'V0\0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+0
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = tuple('V0\0'), v) FROM t_tuple SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+1
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = tuple('V0\0'), v) FROM t_tuple SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+0
+-- Still rewritten where the two spellings provably agree.
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = 'V0', v) FROM t_str SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+0
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = 'V0', v) FROM t_str SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+1
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = toFixedString('V0', 3), v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+0
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = toFixedString('V0', 3), v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+1
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+0
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+1
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+0
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+1
+-- Over a constant array too: a same-type tuple keeps the rewrite, a cross-width pair declines.
+-- (A numeric constant array goes on to become `in` via the has -> in rewrite.)
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = tuple('V0'), [tuple('V0')]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+0
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = tuple('V0'), [tuple('V0')]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+1
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = toFixedString('V0', 4), [toFixedString('V0', 3)]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+1
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = toFixedString('V0', 4), [toFixedString('V0', 3)]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+0
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = 1, [1, 2]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+0
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = 1, [1, 2]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: in%';
+1
+-- Direct membership calls keep their current semantics: this change is only about the rewrite.
+SELECT has(v, 'V0\0'), indexOf(v, 'V0\0'), countEqual(v, 'V0\0') FROM t_fs;
+0	0	0
+DROP TABLE t_fs;
+DROP TABLE t_str;
+DROP TABLE t_lc;
+DROP TABLE t_null;
+DROP TABLE t_tuple;
+DROP TABLE t_tuple2;
+DROP TABLE t_nested_arr;
+DROP TABLE t_nested_map;

--- a/tests/queries/0_stateless/04792_array_exists_to_has_string_family.reference
+++ b/tests/queries/0_stateless/04792_array_exists_to_has_string_family.reference
@@ -1,6 +1,8 @@
 -- { echo }
 -- The arrayExists -> has rewrite must not change the answer for a String/FixedString pair.
+-- The rewrite is an analyzer pass, so the assertions below are only live with the analyzer on.
 
+SET enable_analyzer = 1;
 DROP TABLE IF EXISTS t_fs;
 CREATE TABLE t_fs (v Array(FixedString(3))) ENGINE = Memory;
 INSERT INTO t_fs SELECT [toFixedString('V0', 3)];
@@ -78,7 +80,12 @@ SELECT arrayExists(x -> x = tuple(tuple('V0\0')), v) FROM t_tuple2 SETTINGS opti
 1
 SELECT arrayExists(x -> x = tuple(tuple('V0\0')), v) FROM t_tuple2 SETTINGS optimize_rewrite_array_exists_to_has = 1;
 1
--- Array and Map elements do not zero-pad on either side, so they keep the rewrite.
+SELECT arrayExists(x -> x = tuple('V0\0'), [tuple(toFixedString('V0', 3))]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> x = tuple('V0\0'), [tuple(toFixedString('V0', 3))]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+-- Array and Map elements: over a column both spellings answer 0, but over a constant array
+-- `has` compares raw Fields and answers 1 where `equals` answers 0, so they diverge as well.
 DROP TABLE IF EXISTS t_nested_arr;
 CREATE TABLE t_nested_arr (v Array(Array(FixedString(3)))) ENGINE = Memory;
 INSERT INTO t_nested_arr SELECT [[toFixedString('V0', 3)]];
@@ -86,12 +93,52 @@ SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rew
 0
 SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1;
 0
+SELECT arrayExists(x -> x = ['V0\0'], [[toFixedString('V0', 3)]]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+0
+SELECT arrayExists(x -> x = ['V0\0'], [[toFixedString('V0', 3)]]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+0
 DROP TABLE IF EXISTS t_nested_map;
 CREATE TABLE t_nested_map (v Array(Map(String, FixedString(3)))) ENGINE = Memory;
 INSERT INTO t_nested_map SELECT [map('k', toFixedString('V0', 3))];
 SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 0;
 0
 SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1;
+0
+SELECT arrayExists(x -> x = map('k', 'V0\0'), [map('k', toFixedString('V0', 3))]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+0
+SELECT arrayExists(x -> x = map('k', 'V0\0'), [map('k', toFixedString('V0', 3))]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+0
+-- The key side of a Map is compared too.
+SELECT arrayExists(x -> x = map('k\0', 'V'), [map(toFixedString('k', 2), 'V')]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+0
+SELECT arrayExists(x -> x = map('k\0', 'V'), [map(toFixedString('k', 2), 'V')]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+0
+-- Mixed nesting: the pair is reached through a tuple and then an array.
+SELECT arrayExists(x -> x = tuple(['V0\0']), [tuple([toFixedString('V0', 3)])]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+0
+SELECT arrayExists(x -> x = tuple(['V0\0']), [tuple([toFixedString('V0', 3)])]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+0
+SELECT arrayExists(x -> x = tuple(['V0\0']), v) FROM (SELECT [tuple([toFixedString('V0', 3)])] AS v) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+0
+SELECT arrayExists(x -> x = tuple(['V0\0']), v) FROM (SELECT [tuple([toFixedString('V0', 3)])] AS v) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+0
+-- A container whose members have identical types keeps the rewrite, and so does a numeric one.
+SELECT arrayExists(x -> x = [toFixedString('V0', 3)], [[toFixedString('V0', 3)]]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> x = [toFixedString('V0', 3)], [[toFixedString('V0', 3)]]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+SELECT arrayExists(x -> x = map('k', toFixedString('V0', 3)), [map('k', toFixedString('V0', 3))]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> x = map('k', toFixedString('V0', 3)), [map('k', toFixedString('V0', 3))]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+SELECT arrayExists(x -> x = [1, 2], [[1, 2], [3]]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+1
+SELECT arrayExists(x -> x = [1, 2], [[1, 2], [3]]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+1
+-- A tail that is not all NUL must still not match inside a container.
+SELECT arrayExists(x -> x = ['V0abc'], [[toFixedString('V0', 3)]]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+0
+SELECT arrayExists(x -> x = ['V0abc'], [[toFixedString('V0', 3)]]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
 0
 -- Which spelling the plan ends up with. Match `function_name:` rather than the bare name:
 -- the PROJECTION COLUMNS header echoes the original query text, so a bare `%arrayExists%`
@@ -115,14 +162,31 @@ SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = toFixedStrin
 0
 SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = toFixedString('V0', 3), v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
 1
-SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = [toFixedString('V0', 3)], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
 0
-SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = [toFixedString('V0', 3)], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
 1
-SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', toFixedString('V0', 3)), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
 0
-SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', toFixedString('V0', 3)), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
 1
+-- Declined for a mismatched pair reached through Array, Map, or a mix of containers.
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+1
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+0
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+1
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+0
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k\0', 'V'), [map(toFixedString('k', 2), 'V')]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+1
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k\0', 'V'), [map(toFixedString('k', 2), 'V')]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+0
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = tuple(['V0\0']), [tuple([toFixedString('V0', 3)])]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+1
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = tuple(['V0\0']), [tuple([toFixedString('V0', 3)])]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+0
 -- Over a constant array too: a same-type tuple keeps the rewrite, a cross-width pair declines.
 -- (A numeric constant array goes on to become `in` via the has -> in rewrite.)
 SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = tuple('V0'), [tuple('V0')]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';

--- a/tests/queries/0_stateless/04792_array_exists_to_has_string_family.sql
+++ b/tests/queries/0_stateless/04792_array_exists_to_has_string_family.sql
@@ -1,0 +1,120 @@
+-- { echo }
+-- The arrayExists -> has rewrite must not change the answer for a String/FixedString pair.
+
+DROP TABLE IF EXISTS t_fs;
+CREATE TABLE t_fs (v Array(FixedString(3))) ENGINE = Memory;
+INSERT INTO t_fs SELECT [toFixedString('V0', 3)];
+
+-- Ground truth: equals compares the string family zero-padded.
+SELECT toFixedString('V0', 3) = 'V0\0', toFixedString('V0', 3) = 'V0\0\0';
+
+-- A needle as wide as the element, and wider, with an all-NUL tail.
+SELECT arrayExists(x -> x = 'V0\0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = 'V0\0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1;
+SELECT arrayExists(x -> x = 'V0\0\0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = 'V0\0\0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+-- The constant may sit on either side of the comparison.
+SELECT arrayExists(x -> 'V0\0' = x, v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> 'V0\0' = x, v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+-- A tail that is not all NUL must still not match.
+SELECT arrayExists(x -> x = 'V0abc', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = 'V0abc', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+-- A needle narrower than the element already agreed.
+SELECT arrayExists(x -> x = 'V0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = 'V0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+-- Cross-width FixedString over a constant array, where has() compares raw Fields.
+SELECT arrayExists(x -> x = toFixedString('V0', 4), [toFixedString('V0', 3)]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = toFixedString('V0', 4), [toFixedString('V0', 3)]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+SELECT arrayExists(x -> x = toFixedString('V0', 4), v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = toFixedString('V0', 4), v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+-- A FixedString needle against a String element diverges in the same way.
+DROP TABLE IF EXISTS t_str;
+CREATE TABLE t_str (v Array(String)) ENGINE = Memory;
+INSERT INTO t_str SELECT ['V0'];
+SELECT arrayExists(x -> x = toFixedString('V0', 3), v) FROM t_str SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = toFixedString('V0', 3), v) FROM t_str SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+-- LowCardinality: through the rewrite this used to throw TOO_LARGE_STRING_SIZE.
+DROP TABLE IF EXISTS t_lc;
+CREATE TABLE t_lc (v Array(LowCardinality(FixedString(3)))) ENGINE = Memory;
+INSERT INTO t_lc SELECT [toFixedString('V0', 3)];
+SELECT arrayExists(x -> x = 'V0\0\0', v) FROM t_lc SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = 'V0\0\0', v) FROM t_lc SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+DROP TABLE IF EXISTS t_null;
+CREATE TABLE t_null (v Array(Nullable(FixedString(3)))) ENGINE = Memory;
+INSERT INTO t_null SELECT [toFixedString('V0', 3)];
+SELECT arrayExists(x -> x = 'V0\0\0', v) FROM t_null SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = 'V0\0\0', v) FROM t_null SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+-- Tuple elements are compared element-wise, at any nesting depth.
+DROP TABLE IF EXISTS t_tuple;
+CREATE TABLE t_tuple (v Array(Tuple(FixedString(3)))) ENGINE = Memory;
+INSERT INTO t_tuple SELECT [tuple(toFixedString('V0', 3))];
+SELECT arrayExists(x -> x = tuple('V0\0'), v) FROM t_tuple SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = tuple('V0\0'), v) FROM t_tuple SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+DROP TABLE IF EXISTS t_tuple2;
+CREATE TABLE t_tuple2 (v Array(Tuple(Tuple(FixedString(3))))) ENGINE = Memory;
+INSERT INTO t_tuple2 SELECT [tuple(tuple(toFixedString('V0', 3)))];
+SELECT arrayExists(x -> x = tuple(tuple('V0\0')), v) FROM t_tuple2 SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = tuple(tuple('V0\0')), v) FROM t_tuple2 SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+-- Array and Map elements do not zero-pad on either side, so they keep the rewrite.
+DROP TABLE IF EXISTS t_nested_arr;
+CREATE TABLE t_nested_arr (v Array(Array(FixedString(3)))) ENGINE = Memory;
+INSERT INTO t_nested_arr SELECT [[toFixedString('V0', 3)]];
+SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+DROP TABLE IF EXISTS t_nested_map;
+CREATE TABLE t_nested_map (v Array(Map(String, FixedString(3)))) ENGINE = Memory;
+INSERT INTO t_nested_map SELECT [map('k', toFixedString('V0', 3))];
+SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+-- Which spelling the plan ends up with. Match `function_name:` rather than the bare name:
+-- the PROJECTION COLUMNS header echoes the original query text, so a bare `%arrayExists%`
+-- matches even when the rewrite did happen.
+
+-- Declined for a divergent pair: arrayExists stays, no has appears.
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = 'V0\0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = 'V0\0', v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = tuple('V0\0'), v) FROM t_tuple SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = tuple('V0\0'), v) FROM t_tuple SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+
+-- Still rewritten where the two spellings provably agree.
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = 'V0', v) FROM t_str SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = 'V0', v) FROM t_str SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = toFixedString('V0', 3), v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = toFixedString('V0', 3), v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+
+-- Over a constant array too: a same-type tuple keeps the rewrite, a cross-width pair declines.
+-- (A numeric constant array goes on to become `in` via the has -> in rewrite.)
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = tuple('V0'), [tuple('V0')]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = tuple('V0'), [tuple('V0')]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = toFixedString('V0', 4), [toFixedString('V0', 3)]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = toFixedString('V0', 4), [toFixedString('V0', 3)]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = 1, [1, 2]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = 1, [1, 2]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: in%';
+
+-- Direct membership calls keep their current semantics: this change is only about the rewrite.
+SELECT has(v, 'V0\0'), indexOf(v, 'V0\0'), countEqual(v, 'V0\0') FROM t_fs;
+
+DROP TABLE t_fs;
+DROP TABLE t_str;
+DROP TABLE t_lc;
+DROP TABLE t_null;
+DROP TABLE t_tuple;
+DROP TABLE t_tuple2;
+DROP TABLE t_nested_arr;
+DROP TABLE t_nested_map;

--- a/tests/queries/0_stateless/04792_array_exists_to_has_string_family.sql
+++ b/tests/queries/0_stateless/04792_array_exists_to_has_string_family.sql
@@ -1,5 +1,8 @@
 -- { echo }
 -- The arrayExists -> has rewrite must not change the answer for a String/FixedString pair.
+-- The rewrite is an analyzer pass, so the assertions below are only live with the analyzer on.
+
+SET enable_analyzer = 1;
 
 DROP TABLE IF EXISTS t_fs;
 CREATE TABLE t_fs (v Array(FixedString(3))) ENGINE = Memory;
@@ -64,19 +67,48 @@ CREATE TABLE t_tuple2 (v Array(Tuple(Tuple(FixedString(3))))) ENGINE = Memory;
 INSERT INTO t_tuple2 SELECT [tuple(tuple(toFixedString('V0', 3)))];
 SELECT arrayExists(x -> x = tuple(tuple('V0\0')), v) FROM t_tuple2 SETTINGS optimize_rewrite_array_exists_to_has = 0;
 SELECT arrayExists(x -> x = tuple(tuple('V0\0')), v) FROM t_tuple2 SETTINGS optimize_rewrite_array_exists_to_has = 1;
+SELECT arrayExists(x -> x = tuple('V0\0'), [tuple(toFixedString('V0', 3))]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = tuple('V0\0'), [tuple(toFixedString('V0', 3))]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
 
--- Array and Map elements do not zero-pad on either side, so they keep the rewrite.
+-- Array and Map elements: over a column both spellings answer 0, but over a constant array
+-- `has` compares raw Fields and answers 1 where `equals` answers 0, so they diverge as well.
 DROP TABLE IF EXISTS t_nested_arr;
 CREATE TABLE t_nested_arr (v Array(Array(FixedString(3)))) ENGINE = Memory;
 INSERT INTO t_nested_arr SELECT [[toFixedString('V0', 3)]];
 SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 0;
 SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1;
+SELECT arrayExists(x -> x = ['V0\0'], [[toFixedString('V0', 3)]]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = ['V0\0'], [[toFixedString('V0', 3)]]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
 
 DROP TABLE IF EXISTS t_nested_map;
 CREATE TABLE t_nested_map (v Array(Map(String, FixedString(3)))) ENGINE = Memory;
 INSERT INTO t_nested_map SELECT [map('k', toFixedString('V0', 3))];
 SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 0;
 SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1;
+SELECT arrayExists(x -> x = map('k', 'V0\0'), [map('k', toFixedString('V0', 3))]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = map('k', 'V0\0'), [map('k', toFixedString('V0', 3))]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+-- The key side of a Map is compared too.
+SELECT arrayExists(x -> x = map('k\0', 'V'), [map(toFixedString('k', 2), 'V')]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = map('k\0', 'V'), [map(toFixedString('k', 2), 'V')]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+-- Mixed nesting: the pair is reached through a tuple and then an array.
+SELECT arrayExists(x -> x = tuple(['V0\0']), [tuple([toFixedString('V0', 3)])]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = tuple(['V0\0']), [tuple([toFixedString('V0', 3)])]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+SELECT arrayExists(x -> x = tuple(['V0\0']), v) FROM (SELECT [tuple([toFixedString('V0', 3)])] AS v) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = tuple(['V0\0']), v) FROM (SELECT [tuple([toFixedString('V0', 3)])] AS v) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+-- A container whose members have identical types keeps the rewrite, and so does a numeric one.
+SELECT arrayExists(x -> x = [toFixedString('V0', 3)], [[toFixedString('V0', 3)]]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = [toFixedString('V0', 3)], [[toFixedString('V0', 3)]]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+SELECT arrayExists(x -> x = map('k', toFixedString('V0', 3)), [map('k', toFixedString('V0', 3))]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = map('k', toFixedString('V0', 3)), [map('k', toFixedString('V0', 3))]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+SELECT arrayExists(x -> x = [1, 2], [[1, 2], [3]]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = [1, 2], [[1, 2], [3]]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
+
+-- A tail that is not all NUL must still not match inside a container.
+SELECT arrayExists(x -> x = ['V0abc'], [[toFixedString('V0', 3)]]) SETTINGS optimize_rewrite_array_exists_to_has = 0;
+SELECT arrayExists(x -> x = ['V0abc'], [[toFixedString('V0', 3)]]) SETTINGS optimize_rewrite_array_exists_to_has = 1;
 
 -- Which spelling the plan ends up with. Match `function_name:` rather than the bare name:
 -- the PROJECTION COLUMNS header echoes the original query text, so a bare `%arrayExists%`
@@ -93,10 +125,20 @@ SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = 'V0', v) FRO
 SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = 'V0', v) FROM t_str SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
 SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = toFixedString('V0', 3), v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
 SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = toFixedString('V0', 3), v) FROM t_fs SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
-SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
-SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
-SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
-SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = [toFixedString('V0', 3)], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = [toFixedString('V0', 3)], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', toFixedString('V0', 3)), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', toFixedString('V0', 3)), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+
+-- Declined for a mismatched pair reached through Array, Map, or a mix of containers.
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = ['V0\0'], v) FROM t_nested_arr SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k', 'V0\0'), v) FROM t_nested_map SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k\0', 'V'), [map(toFixedString('k', 2), 'V')]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = map('k\0', 'V'), [map(toFixedString('k', 2), 'V')]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = tuple(['V0\0']), [tuple([toFixedString('V0', 3)])]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: arrayExists%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT arrayExists(x -> x = tuple(['V0\0']), [tuple([toFixedString('V0', 3)])]) SETTINGS optimize_rewrite_array_exists_to_has = 1) WHERE explain ILIKE '%function_name: has%';
 
 -- Over a constant array too: a same-type tuple keeps the rewrite, a cross-width pair declines.
 -- (A numeric constant array goes on to become `in` via the has -> in rewrite.)


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/112953
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes `arrayExists(x -> x = needle, arr)` returning a wrong result, or failing with `TOO_LARGE_STRING_SIZE`, when the array element and the needle are different string types (for example a `String` needle against an `Array(FixedString(N))` element). The `optimize_rewrite_array_exists_to_has` optimization, enabled by default, rewrote such a call to `has`, which does not compare zero-padded the way `=` does.


### Description

`optimize_rewrite_array_exists_to_has` (on by default) rewrites `arrayExists(x -> x = c, arr)` into `has(arr, c)`. The two do not agree for a string-family pair whose types differ, so the same query returns different answers depending on the setting. On released 26.7.4.21 and on master, with `v = ['V0']` of type `Array(FixedString(3))`, `arrayExists(x -> x = 'V0\0', v)` is `1` with the setting off and `0` with it on, while `toFixedString('V0', 3) = 'V0\0'` is `1`. Over an `Array(LowCardinality(FixedString(N)))` element the rewrite turns a working query into `Code: 131 TOO_LARGE_STRING_SIZE`, rejecting valid input.

<details>
<summary>Measured on 26.7.4.21 and master</summary>

| query on `v = ['V0']`, `Array(FixedString(3))` | setting off | setting on (default) |
|---|---|---|
| `arrayExists(x -> x = 'V0\0', v)` | 1 | **0** |
| `arrayExists(x -> x = 'V0\0\0', v)` | 1 | **0** |
| `arrayExists(x -> 'V0\0' = x, v)` | 1 | **0** |
| `arrayExists(x -> x = 'V0abc', v)` (control) | 0 | 0 |
| `arrayExists(x -> x = 'V0', v)` (control) | 1 | 1 |
| `arrayExists(x -> x = tuple('V0\0'), v)` on `Array(Tuple(FixedString(3)))` | 1 | **0** |
| `arrayExists(x -> x = toFixedString('V0',4), [toFixedString('V0',3)])` | 1 | **0** |
| `arrayExists(x -> x = 'V0\0\0', v)` on `Array(LowCardinality(FixedString(3)))` | 1 | **Code: 131** |
| `arrayExists(x -> x = ['V0\0'], [[toFixedString('V0',3)]])` | 0 | **1** |
| `arrayExists(x -> x = map('k','V0\0'), [map('k',toFixedString('V0',3))])` | 0 | **1** |

</details>

Root cause: the pass admits the rewrite whenever the element and needle have a common supertype. For `FixedString(N)` plus `String` that supertype exists, but reaching it casts the element to `String`, stripping its trailing NULs, while `equals` compares the pair zero-padded. A supertype is not sufficient for interchangeability, which is why this pass already declines for `NULL`, and `HasToInPass` for Date, Enum, IPv4 and floats.

The fix declines the rewrite when the element and needle are both in the string family but not the same type, recursing through `Tuple`, `Array` and `Map` members because the divergence reproduces at any nesting depth. Over a constant array the container cases diverge the other way (`0` off, `1` on): there `has` compares raw `Field`s, which are not padded either. Identical types cannot diverge, so `String`/`String` and equal-width `FixedString` pairs keep the optimization, as do numeric, Date and Enum elements. It takes no position on what `has` should mean here; that belongs to #112953.

Validated by an A/B over two binaries: every divergent cell goes from disagreeing to agreeing, the controls do not move, and a 298-test array/membership/FixedString sweep shows no regression against pristine master. The test's pinned direct `has`/`indexOf`/`countEqual` row is today's behaviour, held as a control; it moves when #112953 lands.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1535` (included in `26.8` and later)
<!-- ch-version-info:end -->