### PR TITLE
Add setting `optimize_rewrite_in_subquery_to_join` rewriting `IN (subquery)` to `LEFT SEMI/ANTI JOIN`

### DIFF
--- a/src/Analyzer/Passes/CrossToInnerJoinPass.cpp
+++ b/src/Analyzer/Passes/CrossToInnerJoinPass.cpp
@@ -9,7 +9,6 @@
 #include <Analyzer/FunctionNode.h>
 #include <Analyzer/Utils.h>
 
-#include <Functions/logical.h>
 
 #include <Core/Settings.h>
 
@@ -361,23 +360,6 @@ private:
             checkNotRewritten(item.is_comma, join_node);
     }
 
-    QueryTreeNodePtr makeConjunction(const QueryTreeNodes & nodes)
-    {
-        if (nodes.empty())
-            return nullptr;
-
-        if (nodes.size() == 1)
-            return nodes.front();
-
-        auto function_node = std::make_shared<FunctionNode>("and");
-        function_node->markAsOperator();
-        for (const auto & node : nodes)
-            function_node->getArguments().getNodes().push_back(node);
-
-        const auto & function = createInternalFunctionAndOverloadResolver();
-        function_node->resolveAsFunction(function->build(function_node->getArgumentColumns()));
-        return function_node;
-    }
 };
 
 }

--- a/src/Analyzer/Passes/RewriteInSubqueryToJoinPass.cpp
+++ b/src/Analyzer/Passes/RewriteInSubqueryToJoinPass.cpp
@@ -1,0 +1,460 @@
+#include <Analyzer/Passes/RewriteInSubqueryToJoinPass.h>
+
+#include <Analyzer/ArrayJoinNode.h>
+#include <Analyzer/ColumnNode.h>
+#include <Analyzer/ConstantNode.h>
+#include <Analyzer/FunctionNode.h>
+#include <Analyzer/InDepthQueryTreeVisitor.h>
+#include <Analyzer/JoinNode.h>
+#include <Analyzer/QueryNode.h>
+#include <Analyzer/TableFunctionNode.h>
+#include <Analyzer/TableNode.h>
+#include <Analyzer/UnionNode.h>
+#include <Analyzer/Utils.h>
+#include <Analyzer/createUniqueAliasesIfNecessary.h>
+
+#include <Core/Joins.h>
+#include <Core/Settings.h>
+#include <Core/SettingsEnums.h>
+
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeMap.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/getLeastSupertype.h>
+
+#include <Functions/logical.h>
+
+#include <Interpreters/TableJoin.h>
+
+#include <Storages/IStorage.h>
+
+namespace DB
+{
+namespace Setting
+{
+    extern const SettingsBool optimize_rewrite_in_subquery_to_join;
+    extern const SettingsBool rewrite_in_to_join;
+    extern const SettingsUInt64 max_rows_in_set;
+    extern const SettingsUInt64 max_bytes_in_set;
+    extern const SettingsJoinAlgorithm join_algorithm;
+}
+
+namespace
+{
+
+/// NULL never matches in a join, and top-level NULL keys behave identically on the IN path
+/// (with `transform_null_in = 0` they are dropped from the set and evaluate to `negative`).
+/// But a NULL *inside* a composite key is a regular part of the serialized set key and can match,
+/// while join equality on such values returns NULL and never matches. Variant/Dynamic/Object can
+/// hold NULLs the same way, so they are rejected too.
+bool typeMayHoldNullsInside(const DataTypePtr & type)
+{
+    if (isNullableOrLowCardinalityNullable(type))
+        return true;
+
+    WhichDataType which(type);
+    if (which.isVariant() || which.isDynamic() || which.isObject())
+        return true;
+
+    if (const auto * array_type = typeid_cast<const DataTypeArray *>(type.get()))
+        return typeMayHoldNullsInside(array_type->getNestedType());
+
+    if (const auto * tuple_type = typeid_cast<const DataTypeTuple *>(type.get()))
+    {
+        for (const auto & element_type : tuple_type->getElements())
+            if (typeMayHoldNullsInside(element_type))
+                return true;
+        return false;
+    }
+
+    if (const auto * map_type = typeid_cast<const DataTypeMap *>(type.get()))
+        return typeMayHoldNullsInside(map_type->getNestedType());
+
+    if (const auto * low_cardinality_type = typeid_cast<const DataTypeLowCardinality *>(type.get()))
+        return typeMayHoldNullsInside(low_cardinality_type->getDictionaryType());
+
+    return false;
+}
+
+bool findInTableExpression(const QueryTreeNodePtr & source, const QueryTreeNodePtr & table_expression)
+{
+    if (!source)
+        return false;
+
+    if (source->isEqual(*table_expression))
+        return true;
+
+    if (const auto * join_node = table_expression->as<JoinNode>())
+    {
+        return findInTableExpression(source, join_node->getLeftTableExpressionNode())
+            || findInTableExpression(source, join_node->getRightTableExpressionNode());
+    }
+
+    if (const auto * cross_join_node = table_expression->as<CrossJoinNode>())
+    {
+        for (const auto & expression : cross_join_node->getTableExpressions())
+            if (findInTableExpression(source, expression))
+                return true;
+        return false;
+    }
+
+    if (const auto * array_join_node = table_expression->as<ArrayJoinNode>())
+        return findInTableExpression(source, array_join_node->getTableExpressionNode());
+
+    return false;
+}
+
+/// Unlike `extractAllTableReferences`, also collects table functions: `remote(...)` and similar
+/// must be caught by the remote guard.
+bool joinTreesContainRemoteTable(const QueryTreeNodePtr & node)
+{
+    switch (node->getNodeType())
+    {
+        case QueryTreeNodeType::TABLE:
+            return node->as<TableNode>()->getStorage()->isRemote();
+        case QueryTreeNodeType::TABLE_FUNCTION:
+            return node->as<TableFunctionNode>()->getStorage()->isRemote();
+        case QueryTreeNodeType::QUERY:
+        {
+            const auto & join_tree = node->as<QueryNode>()->getJoinTreeNode();
+            return join_tree && joinTreesContainRemoteTable(join_tree);
+        }
+        case QueryTreeNodeType::UNION:
+        {
+            for (const auto & union_query : node->as<UnionNode>()->getQueries().getNodes())
+                if (joinTreesContainRemoteTable(union_query))
+                    return true;
+            return false;
+        }
+        case QueryTreeNodeType::ARRAY_JOIN:
+            return joinTreesContainRemoteTable(node->as<ArrayJoinNode>()->getTableExpressionNode());
+        case QueryTreeNodeType::CROSS_JOIN:
+        {
+            for (const auto & expression : node->as<CrossJoinNode>()->getTableExpressions())
+                if (joinTreesContainRemoteTable(expression))
+                    return true;
+            return false;
+        }
+        case QueryTreeNodeType::JOIN:
+        {
+            const auto & join_node = node->as<JoinNode &>();
+            return joinTreesContainRemoteTable(join_node.getLeftTableExpressionNode())
+                || joinTreesContainRemoteTable(join_node.getRightTableExpressionNode());
+        }
+        default:
+            return false;
+    }
+}
+
+void extractConjuncts(const QueryTreeNodePtr & node, QueryTreeNodes & conjuncts)
+{
+    if (const auto * function_node = node->as<FunctionNode>();
+        function_node && function_node->getFunctionName() == "and")
+    {
+        for (const auto & argument : function_node->getArguments().getNodes())
+            extractConjuncts(argument, conjuncts);
+        return;
+    }
+
+    conjuncts.push_back(node);
+}
+
+class RewriteInSubqueryToJoinVisitor : public InDepthQueryTreeVisitorWithContext<RewriteInSubqueryToJoinVisitor>
+{
+public:
+    using Base = InDepthQueryTreeVisitorWithContext<RewriteInSubqueryToJoinVisitor>;
+    using Base::Base;
+
+    void enterImpl(QueryTreeNodePtr & node)
+    {
+        const auto & settings = getSettings();
+        if (!settings[Setting::optimize_rewrite_in_subquery_to_join])
+            return;
+
+        /// The resolve-time `rewrite_in_to_join` rewrite has already turned IN into EXISTS by now,
+        /// so there is nothing to match; be explicit about the precedence anyway.
+        if (settings[Setting::rewrite_in_to_join])
+            return;
+
+        /// Explicit set limits are part of IN behavior: with `set_overflow_mode = 'break'` IN is
+        /// defined to evaluate against a truncated set, and with 'throw' the query is defined to
+        /// fail on a too-large subquery. A join honors neither, so keep the set path.
+        if (settings[Setting::max_rows_in_set] != 0 || settings[Setting::max_bytes_in_set] != 0)
+            return;
+
+        /// LEFT SEMI/ANTI JOIN is not implemented by full_sorting_merge, and ANTI is not implemented
+        /// by partial_merge; do not turn a working query into NOT_IMPLEMENTED.
+        const auto & join_algorithms = settings[Setting::join_algorithm];
+        if (!TableJoin::isEnabledAlgorithm(join_algorithms, JoinAlgorithm::HASH)
+            && !TableJoin::isEnabledAlgorithm(join_algorithms, JoinAlgorithm::PARALLEL_HASH)
+            && !TableJoin::isEnabledAlgorithm(join_algorithms, JoinAlgorithm::GRACE_HASH)
+            && !TableJoin::isEnabledAlgorithm(join_algorithms, JoinAlgorithm::AUTO))
+            return;
+
+        auto * query_node = node->as<QueryNode>();
+        if (!query_node || !query_node->hasWhere() || query_node->isCorrelated())
+            return;
+
+        if (!query_node->getJoinTreeNode())
+            return;
+
+        QueryTreeNodes conjuncts;
+        extractConjuncts(query_node->getWhere(), conjuncts);
+
+        QueryTreeNodes remaining_conjuncts;
+        bool any_rewritten = false;
+
+        for (auto & conjunct : conjuncts)
+        {
+            if (tryRewrite(*query_node, conjunct))
+                any_rewritten = true;
+            else
+                remaining_conjuncts.push_back(conjunct);
+        }
+
+        if (any_rewritten)
+        {
+            query_node->getWhere() = makeConjunction(remaining_conjuncts);
+            performed_rewrite = true;
+        }
+    }
+
+    bool performedRewrite() const { return performed_rewrite; }
+
+private:
+    bool tryRewrite(QueryNode & query_node, const QueryTreeNodePtr & conjunct)
+    {
+        auto * in_function = conjunct->as<FunctionNode>();
+        if (!in_function)
+            return false;
+
+        /// Matching only `in`/`notIn` excludes `globalIn`/`globalNotIn` (external-table broadcast in
+        /// distributed queries), `nullIn`/`notNullIn` (what `transform_null_in = 1` produces during
+        /// resolution; their NULL semantics differ from a join) and the `*IgnoreSet` variants.
+        const auto & function_name = in_function->getFunctionName();
+        const bool is_not_in = function_name == "notIn";
+        if (!is_not_in && function_name != "in")
+            return false;
+
+        const auto & in_arguments = in_function->getArguments().getNodes();
+        if (in_arguments.size() != 2)
+            return false;
+
+        const auto & left_argument = in_arguments[0];
+        const auto & right_argument = in_arguments[1];
+
+        if (left_argument->as<ConstantNode>())
+            return false;
+
+        auto * subquery_node = right_argument->as<QueryNode>();
+        if (!subquery_node)
+            return false;
+
+        /// A CTE body may be shared between multiple uses; renaming its projection in place is unsafe.
+        if (subquery_node->isCTE() || subquery_node->isCorrelated() || containsCorrelatedSubquery(right_argument))
+            return false;
+
+        const auto & subquery_columns = subquery_node->getProjectionColumns();
+
+        QueryTreeNodes left_keys;
+        auto * left_tuple_function = left_argument->as<FunctionNode>();
+        if (left_tuple_function && left_tuple_function->getFunctionName() == "tuple"
+            && subquery_columns.size() > 1
+            && left_tuple_function->getArguments().getNodes().size() == subquery_columns.size())
+            left_keys = left_tuple_function->getArguments().getNodes();
+        else if (subquery_columns.size() == 1)
+            left_keys = {left_argument};
+        else
+            return false;
+
+        if (!leftExpressionIsSafe(left_argument, query_node.getJoinTreeNode(), /*check_index_columns*/ !is_not_in))
+            return false;
+
+        for (size_t i = 0; i < left_keys.size(); ++i)
+        {
+            auto left_type = removeLowCardinality(left_keys[i]->getResultType());
+            auto right_type = removeLowCardinality(subquery_columns[i].type);
+
+            /// `notIn` evaluates to NULL for a NULL left key (the row is dropped by the filter),
+            /// while ANTI JOIN keeps unmatched NULL-keyed rows. `in` and SEMI JOIN agree: both drop.
+            if (is_not_in && left_type->isNullable())
+                return false;
+
+            /// An array on the right of IN would have been flattened during resolution when the left
+            /// side is scalar; the remaining array-vs-array case is left to the set path.
+            if (isArray(removeNullable(right_type)))
+                return false;
+
+            if (typeMayHoldNullsInside(removeNullable(left_type)) || typeMayHoldNullsInside(removeNullable(right_type)))
+                return false;
+
+            /// Join key type unification widens both sides losslessly, matching the semantics of the
+            /// accurate-or-null cast the set path applies to the left keys (`Set::execute`). Without a
+            /// common supertype the join would throw where IN works.
+            if (!tryGetLeastSupertype(DataTypes{left_type, right_type}))
+                return false;
+        }
+
+        /// GLOBAL IN is excluded by name above, but a plain IN over remote tables is subject to
+        /// `distributed_product_mode` rules that a join does not replicate. Shard-local secondary
+        /// queries still benefit: the pass runs on the shard again.
+        if (joinTreesContainRemoteTable(right_argument) || joinTreesContainRemoteTable(query_node.getJoinTreeNode()))
+            return false;
+
+        rewriteToJoin(query_node, right_argument, *subquery_node, left_keys, is_not_in);
+        return true;
+    }
+
+    void rewriteToJoin(
+        QueryNode & query_node,
+        const QueryTreeNodePtr & subquery,
+        QueryNode & subquery_node,
+        const QueryTreeNodes & left_keys,
+        bool is_not_in)
+    {
+        ++rewrite_index;
+
+        /// Rename the subquery projection to unique names to avoid collisions with columns of the
+        /// outer scope (same technique as the `rewrite_in_to_join` EXISTS rewrite).
+        auto subquery_columns = subquery_node.getProjectionColumns();
+        Names unique_names;
+        unique_names.reserve(subquery_columns.size());
+        for (size_t i = 0; i < subquery_columns.size(); ++i)
+            unique_names.push_back(fmt::format("__in_join_subquery_column_{}_{}", rewrite_index, i + 1));
+
+        subquery_node.clearProjectionColumns();
+        subquery_node.setProjectionAliasesToOverride(unique_names);
+        subquery_node.resolveProjectionColumns(subquery_columns);
+
+        QueryTreeNodes equalities;
+        equalities.reserve(left_keys.size());
+        for (size_t i = 0; i < left_keys.size(); ++i)
+        {
+            auto right_column_node = std::make_shared<ColumnNode>(
+                NameAndTypePair{unique_names[i], subquery_columns[i].type},
+                std::static_pointer_cast<ITableExpressionNode>(subquery));
+
+            auto equals_node = std::make_shared<FunctionNode>("equals");
+            equals_node->markAsOperator();
+            equals_node->getArguments().getNodes() = {left_keys[i], std::move(right_column_node)};
+            resolveOrdinaryFunctionNodeByName(*equals_node, "equals", getContext());
+            equalities.push_back(std::move(equals_node));
+        }
+
+        auto join_node = std::make_shared<JoinNode>(
+            query_node.getJoinTreeNode(),
+            subquery,
+            makeConjunction(equalities),
+            JoinLocality::Unspecified,
+            is_not_in ? JoinStrictness::Anti : JoinStrictness::Semi,
+            JoinKind::Left,
+            /*is_using_join_expression_*/ false);
+
+        query_node.getJoinTreeNode() = std::move(join_node);
+    }
+
+    /// The left expression must be computable from the current join tree alone and evaluate
+    /// identically when moved into a JOIN ON section. With `check_index_columns`, additionally
+    /// require that none of its columns can drive index analysis on its table: `x IN (subquery)`
+    /// over a primary-key/partition-key/skip-index column prunes parts and granules via
+    /// `KeyCondition::tryPrepareSetIndex`, which a join (without runtime-filter index analysis)
+    /// cannot replicate. Negative predicates do not prune, so `notIn` skips that check.
+    bool leftExpressionIsSafe(const QueryTreeNodePtr & node, const QueryTreeNodePtr & join_tree, bool check_index_columns)
+    {
+        if (const auto * column_node = node->as<ColumnNode>())
+        {
+            auto source = column_node->getColumnSourceOrNull();
+            if (!findInTableExpression(source, join_tree))
+                return false;
+            if (check_index_columns && columnMayDriveIndex(*column_node, source))
+                return false;
+            return true;
+        }
+
+        if (const auto * function_node = node->as<FunctionNode>())
+        {
+            if (function_node->getFunctionName() == "arrayJoin")
+                return false;
+            if (const auto & function = function_node->getFunction(); function && !function->isDeterministicInScopeOfQuery())
+                return false;
+            for (const auto & argument : function_node->getArguments().getNodes())
+                if (!leftExpressionIsSafe(argument, join_tree, check_index_columns))
+                    return false;
+            return true;
+        }
+
+        if (node->as<ConstantNode>())
+            return true;
+
+        /// Lambdas, nested subqueries and anything else unexpected.
+        return false;
+    }
+
+    static bool columnMayDriveIndex(const ColumnNode & column_node, const QueryTreeNodePtr & source)
+    {
+        const auto * table_node = source ? source->as<TableNode>() : nullptr;
+        if (!table_node)
+            return false;
+
+        const auto & snapshot = table_node->getStorageSnapshot();
+        if (!snapshot || !snapshot->metadata)
+            return false;
+
+        const auto & metadata = *snapshot->metadata;
+        const auto & column_name = column_node.getColumnName();
+
+        auto contains = [&](const Names & names)
+        {
+            return std::find(names.begin(), names.end(), column_name) != names.end();
+        };
+
+        if (metadata.hasPrimaryKey() && contains(metadata.getColumnsRequiredForPrimaryKey()))
+            return true;
+        if (metadata.hasPartitionKey() && contains(metadata.getColumnsRequiredForPartitionKey()))
+            return true;
+        for (const auto & index : metadata.getSecondaryIndices())
+            if (contains(index.column_names))
+                return true;
+
+        return false;
+    }
+
+    static QueryTreeNodePtr makeConjunction(const QueryTreeNodes & nodes)
+    {
+        if (nodes.empty())
+            return nullptr;
+
+        if (nodes.size() == 1)
+            return nodes.front();
+
+        auto function_node = std::make_shared<FunctionNode>("and");
+        function_node->markAsOperator();
+        for (const auto & node : nodes)
+            function_node->getArguments().getNodes().push_back(node);
+
+        const auto & function = createInternalFunctionAndOverloadResolver();
+        function_node->resolveAsFunction(function->build(function_node->getArgumentColumns()));
+        return function_node;
+    }
+
+    size_t rewrite_index = 0;
+    bool performed_rewrite = false;
+};
+
+}
+
+void RewriteInSubqueryToJoinPass::run(QueryTreeNodePtr & query_tree_node, ContextPtr context)
+{
+    RewriteInSubqueryToJoinVisitor visitor(context);
+    visitor.visit(query_tree_node);
+
+    /// Unique `__tableN` aliases were assigned at the end of query analysis, with each IN subquery
+    /// numbered in its own scope. Moving a subquery into the join tree merges the scopes and can
+    /// produce duplicate aliases (and thus duplicate planner column identifiers), so renumber.
+    if (visitor.performedRewrite())
+        createUniqueAliasesIfNecessary(query_tree_node, context);
+}
+
+}

--- a/src/Analyzer/Passes/RewriteInSubqueryToJoinPass.cpp
+++ b/src/Analyzer/Passes/RewriteInSubqueryToJoinPass.cpp
@@ -9,7 +9,6 @@
 #include <Analyzer/QueryNode.h>
 #include <Analyzer/TableFunctionNode.h>
 #include <Analyzer/TableNode.h>
-#include <Analyzer/UnionNode.h>
 #include <Analyzer/Utils.h>
 #include <Analyzer/createUniqueAliasesIfNecessary.h>
 
@@ -17,16 +16,12 @@
 #include <Core/Settings.h>
 #include <Core/SettingsEnums.h>
 
-#include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeLowCardinality.h>
-#include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
-#include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/getLeastSupertype.h>
+#include <DataTypes/hasNullable.h>
 
-#include <Functions/logical.h>
-
-#include <Interpreters/TableJoin.h>
+#include <Interpreters/MergeJoin.h>
 
 #include <Storages/IStorage.h>
 
@@ -35,7 +30,6 @@ namespace DB
 namespace Setting
 {
     extern const SettingsBool optimize_rewrite_in_subquery_to_join;
-    extern const SettingsBool rewrite_in_to_join;
     extern const SettingsUInt64 max_rows_in_set;
     extern const SettingsUInt64 max_bytes_in_set;
     extern const SettingsJoinAlgorithm join_algorithm;
@@ -44,46 +38,12 @@ namespace Setting
 namespace
 {
 
-/// NULL never matches in a join, and top-level NULL keys behave identically on the IN path
-/// (with `transform_null_in = 0` they are dropped from the set and evaluate to `negative`).
-/// But a NULL *inside* a composite key is a regular part of the serialized set key and can match,
-/// while join equality on such values returns NULL and never matches. Variant/Dynamic/Object can
-/// hold NULLs the same way, so they are rejected too.
-bool typeMayHoldNullsInside(const DataTypePtr & type)
-{
-    if (isNullableOrLowCardinalityNullable(type))
-        return true;
-
-    WhichDataType which(type);
-    if (which.isVariant() || which.isDynamic() || which.isObject())
-        return true;
-
-    if (const auto * array_type = typeid_cast<const DataTypeArray *>(type.get()))
-        return typeMayHoldNullsInside(array_type->getNestedType());
-
-    if (const auto * tuple_type = typeid_cast<const DataTypeTuple *>(type.get()))
-    {
-        for (const auto & element_type : tuple_type->getElements())
-            if (typeMayHoldNullsInside(element_type))
-                return true;
-        return false;
-    }
-
-    if (const auto * map_type = typeid_cast<const DataTypeMap *>(type.get()))
-        return typeMayHoldNullsInside(map_type->getNestedType());
-
-    if (const auto * low_cardinality_type = typeid_cast<const DataTypeLowCardinality *>(type.get()))
-        return typeMayHoldNullsInside(low_cardinality_type->getDictionaryType());
-
-    return false;
-}
-
 bool findInTableExpression(const QueryTreeNodePtr & source, const QueryTreeNodePtr & table_expression)
 {
     if (!source)
         return false;
 
-    if (source->isEqual(*table_expression))
+    if (source == table_expression || source->isEqual(*table_expression))
         return true;
 
     if (const auto * join_node = table_expression->as<JoinNode>())
@@ -106,46 +66,56 @@ bool findInTableExpression(const QueryTreeNodePtr & source, const QueryTreeNodeP
     return false;
 }
 
-/// Unlike `extractAllTableReferences`, also collects table functions: `remote(...)` and similar
-/// must be caught by the remote guard.
-bool joinTreesContainRemoteTable(const QueryTreeNodePtr & node)
+/// `extractAllTableReferences` skips table functions, but `remote(...)` and similar must be
+/// caught here, so use `extractTableExpressions` and inspect both node kinds.
+bool containsRemoteTable(const QueryTreeNodePtr & node)
 {
-    switch (node->getNodeType())
+    auto table_expressions = extractTableExpressions(
+        std::static_pointer_cast<ITableExpressionNode>(node), /*add_array_join*/ false, /*recursive*/ true);
+
+    for (const auto & table_expression : table_expressions)
     {
-        case QueryTreeNodeType::TABLE:
-            return node->as<TableNode>()->getStorage()->isRemote();
-        case QueryTreeNodeType::TABLE_FUNCTION:
-            return node->as<TableFunctionNode>()->getStorage()->isRemote();
-        case QueryTreeNodeType::QUERY:
+        if (const auto * table_node = table_expression->as<TableNode>())
         {
-            const auto & join_tree = node->as<QueryNode>()->getJoinTreeNode();
-            return join_tree && joinTreesContainRemoteTable(join_tree);
+            if (table_node->getStorage()->isRemote())
+                return true;
         }
-        case QueryTreeNodeType::UNION:
+        else if (const auto * table_function_node = table_expression->as<TableFunctionNode>())
         {
-            for (const auto & union_query : node->as<UnionNode>()->getQueries().getNodes())
-                if (joinTreesContainRemoteTable(union_query))
-                    return true;
-            return false;
+            if (table_function_node->getStorage()->isRemote())
+                return true;
         }
-        case QueryTreeNodeType::ARRAY_JOIN:
-            return joinTreesContainRemoteTable(node->as<ArrayJoinNode>()->getTableExpressionNode());
-        case QueryTreeNodeType::CROSS_JOIN:
-        {
-            for (const auto & expression : node->as<CrossJoinNode>()->getTableExpressions())
-                if (joinTreesContainRemoteTable(expression))
-                    return true;
-            return false;
-        }
-        case QueryTreeNodeType::JOIN:
-        {
-            const auto & join_node = node->as<JoinNode &>();
-            return joinTreesContainRemoteTable(join_node.getLeftTableExpressionNode())
-                || joinTreesContainRemoteTable(join_node.getRightTableExpressionNode());
-        }
-        default:
-            return false;
     }
+
+    return false;
+}
+
+/// Whether some enabled join algorithm can execute LEFT JOIN with the given strictness;
+/// rewriting must not turn a working IN into NOT_IMPLEMENTED. DIRECT is excluded because a
+/// subquery right side never qualifies for a direct join.
+bool joinAlgorithmsCanExecuteLeftJoin(const std::vector<JoinAlgorithm> & join_algorithms, JoinStrictness strictness)
+{
+    for (const auto & algorithm : join_algorithms)
+    {
+        switch (algorithm)
+        {
+            case JoinAlgorithm::DEFAULT:
+            case JoinAlgorithm::AUTO:
+            case JoinAlgorithm::HASH:
+            case JoinAlgorithm::PARALLEL_HASH:
+            case JoinAlgorithm::GRACE_HASH:
+            case JoinAlgorithm::PREFER_PARTIAL_MERGE:
+                return true;
+            case JoinAlgorithm::PARTIAL_MERGE:
+                if (MergeJoin::isSupported(JoinKind::Left, strictness))
+                    return true;
+                break;
+            default:
+                break;
+        }
+    }
+
+    return false;
 }
 
 void extractConjuncts(const QueryTreeNodePtr & node, QueryTreeNodes & conjuncts)
@@ -169,62 +139,47 @@ public:
 
     void enterImpl(QueryTreeNodePtr & node)
     {
+        auto * query_node = node->as<QueryNode>();
+        if (!query_node || !query_node->hasWhere() || !query_node->getJoinTreeNode() || query_node->isCorrelated())
+            return;
+
+        const auto * where_function = query_node->getWhere()->as<FunctionNode>();
+        if (!where_function)
+            return;
+
+        const auto & where_function_name = where_function->getFunctionName();
+        if (where_function_name != "and" && where_function_name != "in" && where_function_name != "notIn")
+            return;
+
         const auto & settings = getSettings();
         if (!settings[Setting::optimize_rewrite_in_subquery_to_join])
             return;
 
-        /// The resolve-time `rewrite_in_to_join` rewrite has already turned IN into EXISTS by now,
-        /// so there is nothing to match; be explicit about the precedence anyway.
-        if (settings[Setting::rewrite_in_to_join])
-            return;
-
-        /// Explicit set limits are part of IN behavior: with `set_overflow_mode = 'break'` IN is
-        /// defined to evaluate against a truncated set, and with 'throw' the query is defined to
-        /// fail on a too-large subquery. A join honors neither, so keep the set path.
+        /// Explicit set limits are part of IN behavior ('break' truncates the set, 'throw' fails
+        /// on a too-large subquery); a join honors neither.
         if (settings[Setting::max_rows_in_set] != 0 || settings[Setting::max_bytes_in_set] != 0)
-            return;
-
-        /// LEFT SEMI/ANTI JOIN is not implemented by full_sorting_merge, and ANTI is not implemented
-        /// by partial_merge; do not turn a working query into NOT_IMPLEMENTED.
-        const auto & join_algorithms = settings[Setting::join_algorithm];
-        if (!TableJoin::isEnabledAlgorithm(join_algorithms, JoinAlgorithm::HASH)
-            && !TableJoin::isEnabledAlgorithm(join_algorithms, JoinAlgorithm::PARALLEL_HASH)
-            && !TableJoin::isEnabledAlgorithm(join_algorithms, JoinAlgorithm::GRACE_HASH)
-            && !TableJoin::isEnabledAlgorithm(join_algorithms, JoinAlgorithm::AUTO))
-            return;
-
-        auto * query_node = node->as<QueryNode>();
-        if (!query_node || !query_node->hasWhere() || query_node->isCorrelated())
-            return;
-
-        if (!query_node->getJoinTreeNode())
             return;
 
         QueryTreeNodes conjuncts;
         extractConjuncts(query_node->getWhere(), conjuncts);
 
         QueryTreeNodes remaining_conjuncts;
-        bool any_rewritten = false;
+        std::optional<bool> join_tree_has_remote_table;
 
         for (auto & conjunct : conjuncts)
         {
-            if (tryRewrite(*query_node, conjunct))
-                any_rewritten = true;
-            else
+            if (!tryRewrite(*query_node, conjunct, join_tree_has_remote_table))
                 remaining_conjuncts.push_back(conjunct);
         }
 
-        if (any_rewritten)
-        {
+        if (remaining_conjuncts.size() != conjuncts.size())
             query_node->getWhere() = makeConjunction(remaining_conjuncts);
-            performed_rewrite = true;
-        }
     }
 
-    bool performedRewrite() const { return performed_rewrite; }
+    bool performedRewrite() const { return rewrite_index != 0; }
 
 private:
-    bool tryRewrite(QueryNode & query_node, const QueryTreeNodePtr & conjunct)
+    bool tryRewrite(QueryNode & query_node, const QueryTreeNodePtr & conjunct, std::optional<bool> & join_tree_has_remote_table)
     {
         auto * in_function = conjunct->as<FunctionNode>();
         if (!in_function)
@@ -253,7 +208,7 @@ private:
             return false;
 
         /// A CTE body may be shared between multiple uses; renaming its projection in place is unsafe.
-        if (subquery_node->isCTE() || subquery_node->isCorrelated() || containsCorrelatedSubquery(right_argument))
+        if (subquery_node->isCTE())
             return false;
 
         const auto & subquery_columns = subquery_node->getProjectionColumns();
@@ -269,7 +224,8 @@ private:
         else
             return false;
 
-        if (!leftExpressionIsSafe(left_argument, query_node.getJoinTreeNode(), /*check_index_columns*/ !is_not_in))
+        const std::vector<JoinAlgorithm> join_algorithms = getSettings()[Setting::join_algorithm];
+        if (!joinAlgorithmsCanExecuteLeftJoin(join_algorithms, is_not_in ? JoinStrictness::Anti : JoinStrictness::Semi))
             return false;
 
         for (size_t i = 0; i < left_keys.size(); ++i)
@@ -282,25 +238,36 @@ private:
             if (is_not_in && left_type->isNullable())
                 return false;
 
-            /// An array on the right of IN would have been flattened during resolution when the left
-            /// side is scalar; the remaining array-vs-array case is left to the set path.
+            /// Arrays on the right of IN have flattening semantics that join equality does not.
             if (isArray(removeNullable(right_type)))
                 return false;
 
-            if (typeMayHoldNullsInside(removeNullable(left_type)) || typeMayHoldNullsInside(removeNullable(right_type)))
+            /// A NULL inside a composite key is a regular part of the serialized set key and can
+            /// match, while join equality on such values returns NULL and never matches (top-level
+            /// NULL keys behave the same on both paths).
+            if (hasTypeThatCanContainNulls(removeNullable(left_type)) || hasTypeThatCanContainNulls(removeNullable(right_type)))
                 return false;
 
-            /// Join key type unification widens both sides losslessly, matching the semantics of the
-            /// accurate-or-null cast the set path applies to the left keys (`Set::execute`). Without a
-            /// common supertype the join would throw where IN works.
+            /// With a common supertype both sides widen losslessly, matching the accurate-or-null
+            /// cast of the set path; without one the join would throw where IN works.
             if (!tryGetLeastSupertype(DataTypes{left_type, right_type}))
                 return false;
         }
 
-        /// GLOBAL IN is excluded by name above, but a plain IN over remote tables is subject to
-        /// `distributed_product_mode` rules that a join does not replicate. Shard-local secondary
-        /// queries still benefit: the pass runs on the shard again.
-        if (joinTreesContainRemoteTable(right_argument) || joinTreesContainRemoteTable(query_node.getJoinTreeNode()))
+        if (containsCorrelatedSubquery(right_argument))
+            return false;
+
+        if (!leftExpressionIsSafe(left_argument, query_node.getJoinTreeNode(), /*check_index_columns*/ !is_not_in))
+            return false;
+
+        /// A plain IN over remote tables is subject to `distributed_product_mode` rules that a join
+        /// does not replicate. Shard-local secondary queries still benefit: the pass re-runs there.
+        if (containsRemoteTable(right_argument))
+            return false;
+
+        if (!join_tree_has_remote_table.has_value())
+            join_tree_has_remote_table = containsRemoteTable(query_node.getJoinTreeNode());
+        if (*join_tree_has_remote_table)
             return false;
 
         rewriteToJoin(query_node, right_argument, *subquery_node, left_keys, is_not_in);
@@ -316,17 +283,12 @@ private:
     {
         ++rewrite_index;
 
-        /// Rename the subquery projection to unique names to avoid collisions with columns of the
-        /// outer scope (same technique as the `rewrite_in_to_join` EXISTS rewrite).
+        /// Rename the subquery projection to avoid collisions with outer-scope column names.
         auto subquery_columns = subquery_node.getProjectionColumns();
         Names unique_names;
         unique_names.reserve(subquery_columns.size());
         for (size_t i = 0; i < subquery_columns.size(); ++i)
             unique_names.push_back(fmt::format("__in_join_subquery_column_{}_{}", rewrite_index, i + 1));
-
-        subquery_node.clearProjectionColumns();
-        subquery_node.setProjectionAliasesToOverride(unique_names);
-        subquery_node.resolveProjectionColumns(subquery_columns);
 
         QueryTreeNodes equalities;
         equalities.reserve(left_keys.size());
@@ -343,6 +305,10 @@ private:
             equalities.push_back(std::move(equals_node));
         }
 
+        subquery_node.clearProjectionColumns();
+        subquery_node.setProjectionAliasesToOverride(std::move(unique_names));
+        subquery_node.resolveProjectionColumns(std::move(subquery_columns));
+
         auto join_node = std::make_shared<JoinNode>(
             query_node.getJoinTreeNode(),
             subquery,
@@ -355,12 +321,10 @@ private:
         query_node.getJoinTreeNode() = std::move(join_node);
     }
 
-    /// The left expression must be computable from the current join tree alone and evaluate
-    /// identically when moved into a JOIN ON section. With `check_index_columns`, additionally
-    /// require that none of its columns can drive index analysis on its table: `x IN (subquery)`
-    /// over a primary-key/partition-key/skip-index column prunes parts and granules via
-    /// `KeyCondition::tryPrepareSetIndex`, which a join (without runtime-filter index analysis)
-    /// cannot replicate. Negative predicates do not prune, so `notIn` skips that check.
+    /// The left expression must be computable from the current join tree alone. With
+    /// `check_index_columns`, additionally require that none of its columns can drive
+    /// primary-key/partition/skip-index analysis, which the set path enables and a join loses.
+    /// Negative predicates do not prune, so `notIn` skips that check.
     bool leftExpressionIsSafe(const QueryTreeNodePtr & node, const QueryTreeNodePtr & join_tree, bool check_index_columns)
     {
         if (const auto * column_node = node->as<ColumnNode>())
@@ -421,26 +385,7 @@ private:
         return false;
     }
 
-    static QueryTreeNodePtr makeConjunction(const QueryTreeNodes & nodes)
-    {
-        if (nodes.empty())
-            return nullptr;
-
-        if (nodes.size() == 1)
-            return nodes.front();
-
-        auto function_node = std::make_shared<FunctionNode>("and");
-        function_node->markAsOperator();
-        for (const auto & node : nodes)
-            function_node->getArguments().getNodes().push_back(node);
-
-        const auto & function = createInternalFunctionAndOverloadResolver();
-        function_node->resolveAsFunction(function->build(function_node->getArgumentColumns()));
-        return function_node;
-    }
-
     size_t rewrite_index = 0;
-    bool performed_rewrite = false;
 };
 
 }
@@ -450,9 +395,8 @@ void RewriteInSubqueryToJoinPass::run(QueryTreeNodePtr & query_tree_node, Contex
     RewriteInSubqueryToJoinVisitor visitor(context);
     visitor.visit(query_tree_node);
 
-    /// Unique `__tableN` aliases were assigned at the end of query analysis, with each IN subquery
-    /// numbered in its own scope. Moving a subquery into the join tree merges the scopes and can
-    /// produce duplicate aliases (and thus duplicate planner column identifiers), so renumber.
+    /// `__tableN` aliases number each IN subquery in its own scope; moving one into the join tree
+    /// can produce duplicate aliases (and duplicate planner column identifiers), so renumber.
     if (visitor.performedRewrite())
         createUniqueAliasesIfNecessary(query_tree_node, context);
 }

--- a/src/Analyzer/Passes/RewriteInSubqueryToJoinPass.h
+++ b/src/Analyzer/Passes/RewriteInSubqueryToJoinPass.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <Analyzer/IQueryTreePass.h>
+
+namespace DB
+{
+
+/** Rewrite `x [NOT] IN (uncorrelated subquery)` in top-level WHERE conjuncts into LEFT SEMI/ANTI JOIN,
+  * so that the join planner can choose the build side and apply runtime filters, instead of always
+  * materializing the whole subquery result into an in-memory set.
+  *
+  * Example: SELECT a FROM t1 WHERE b NOT IN (SELECT c FROM t2)
+  * Result: SELECT a FROM t1 LEFT ANTI JOIN (SELECT c AS __in_join_subquery_column_1_1 FROM t2)
+  *         ON b = __in_join_subquery_column_1_1
+  *
+  * Enabled by the `optimize_rewrite_in_subquery_to_join` setting.
+  */
+class RewriteInSubqueryToJoinPass final : public IQueryTreePass
+{
+public:
+    String getName() override { return "RewriteInSubqueryToJoin"; }
+
+    String getDescription() override
+    {
+        return "Rewrite 'x [NOT] IN (uncorrelated subquery)' in top-level WHERE conjuncts to LEFT SEMI/ANTI JOIN";
+    }
+
+    void run(QueryTreeNodePtr & query_tree_node, ContextPtr context) override;
+};
+
+}

--- a/src/Analyzer/QueryTreePassManager.cpp
+++ b/src/Analyzer/QueryTreePassManager.cpp
@@ -26,6 +26,7 @@
 #include <Analyzer/Passes/ConvertQueryToCNFPass.h>
 #include <Analyzer/Passes/CountDistinctPass.h>
 #include <Analyzer/Passes/CrossToInnerJoinPass.h>
+#include <Analyzer/Passes/RewriteInSubqueryToJoinPass.h>
 #include <Analyzer/Passes/DisableParallelReplicasPass.h>
 #include <Analyzer/Passes/FunctionToSubcolumnsPass.h>
 #include <Analyzer/Passes/FuseFunctionsPass.h>
@@ -343,6 +344,7 @@ void addQueryTreePasses(QueryTreePassManager & manager, bool only_analyze)
     manager.addPass(std::make_unique<LogicalExpressionOptimizerPass>());
 
     manager.addPass(std::make_unique<CrossToInnerJoinPass>());
+    manager.addPass(std::make_unique<RewriteInSubqueryToJoinPass>());
     manager.addPass(std::make_unique<ShardNumColumnToFunctionPass>());
 
     manager.addPass(std::make_unique<OptimizeTrivialGroupByLimitPass>());

--- a/src/Analyzer/Utils.cpp
+++ b/src/Analyzer/Utils.cpp
@@ -36,6 +36,7 @@
 
 #include <Functions/FunctionHelpers.h>
 #include <Functions/FunctionFactory.h>
+#include <Functions/logical.h>
 
 #include <Storages/IStorage.h>
 
@@ -1071,6 +1072,23 @@ void resolveAggregateFunctionNodeByName(FunctionNode & function_node, const Stri
 {
     auto aggregate_function = resolveAggregateFunction(function_node, function_name);
     function_node.resolveAsAggregateFunction(std::move(aggregate_function));
+}
+
+QueryTreeNodePtr makeConjunction(const QueryTreeNodes & conditions)
+{
+    if (conditions.empty())
+        return nullptr;
+
+    if (conditions.size() == 1)
+        return conditions.front();
+
+    auto function_node = std::make_shared<FunctionNode>("and");
+    function_node->markAsOperator();
+    function_node->getArguments().getNodes() = conditions;
+
+    const auto & function = createInternalFunctionAndOverloadResolver();
+    function_node->resolveAsFunction(function->build(function_node->getArgumentColumns()));
+    return function_node;
 }
 
 std::pair<TableExpressionNodePtr, bool> getExpressionSource(const QueryTreeNodePtr & node)

--- a/src/Analyzer/Utils.h
+++ b/src/Analyzer/Utils.h
@@ -172,6 +172,10 @@ QueryTreeNodePtr foldConstantCast(const QueryTreeNodePtr & cast_node);
 /// Arguments and parameters are taken from the node.
 void resolveOrdinaryFunctionNodeByName(FunctionNode & function_node, const String & function_name, const ContextPtr & context);
 
+/// Combine expressions into a conjunction: nullptr for none, the expression itself for one,
+/// a resolved `and` function node otherwise.
+QueryTreeNodePtr makeConjunction(const QueryTreeNodes & conditions);
+
 /// Resolves function node as aggregate function with given name.
 /// Arguments and parameters are taken from the node.
 void resolveAggregateFunctionNodeByName(FunctionNode & function_node, const String & function_name);

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6044,6 +6044,9 @@ Rewrite `tupleElement(dictGet('dict', ('a', 'b', 'c'), key), 2)` into `dictGet('
     DECLARE(Bool, optimize_rewrite_like_perfect_affix, true, R"(
 Rewrite LIKE expressions with perfect prefix or suffix (e.g. `col LIKE 'ClickHouse%'`) to startsWith or endsWith functions (e.g. `startsWith(col, 'ClickHouse')`).
 )", 0) \
+    DECLARE(Bool, optimize_rewrite_in_subquery_to_join, false, R"(
+Rewrite `x [NOT] IN (uncorrelated subquery)` in top-level WHERE conjuncts to LEFT SEMI/ANTI JOIN. Unlike the IN set, which always materializes the whole subquery result in memory, the join lets the planner choose the smaller side for the hash table (`query_plan_join_swap_table`) and filter the probe side with runtime filters (`enable_join_runtime_filters`). The rewrite is skipped when it could lose primary-key/partition/skip-index analysis or change behavior (`transform_null_in = 1`, `GLOBAL IN`, correlated subqueries, remote tables, explicit `max_rows_in_set`/`max_bytes_in_set` limits).
+)", 0) \
 DECLARE(Bool, execute_exists_as_scalar_subquery, true, R"(
 Execute non-correlated EXISTS subqueries as scalar subqueries. As for scalar subqueries, the cache is used, and the constant folding applies to the result.
 

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -44,6 +44,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         addSettingsChanges(settings_changes_history, "26.8",
         {
             {"max_insert_threads", 1, 0, "Changed the default from 1 (no parallel execution) to auto (0), which resolves to the number of CPU cores available to the server, reduced under memory pressure via `max_insert_threads_min_free_memory_per_thread`. This parallelizes `INSERT SELECT` by default. Set to 1 to restore the previous single-threaded behavior."},
+            {"optimize_rewrite_in_subquery_to_join", false, false, "New setting. Rewrite 'x [NOT] IN (uncorrelated subquery)' in top-level WHERE conjuncts to LEFT SEMI/ANTI JOIN."},
             {"unique_key_probe_implementation", "auto", "auto", "New setting: selects the UNIQUE KEY probe implementation (currently only the simple baseline exists)"},
             {"s3_base", "", "", "New setting to specify the base URL for resolving relative URLs in the s3 table function and the S3 table engine."},
             {"use_query_condition_cache_for_top_k", false, false, "New setting to gate the query condition cache for `ORDER BY ... LIMIT n` (TopK) reads; disabled by default."},

--- a/tests/queries/0_stateless/04821_optimize_rewrite_in_subquery_to_join.reference
+++ b/tests/queries/0_stateless/04821_optimize_rewrite_in_subquery_to_join.reference
@@ -1,0 +1,47 @@
+-- IN rewritten to LEFT SEMI JOIN
+Type: LEFT
+Strictness: SEMI
+-- NOT IN rewritten to LEFT ANTI JOIN
+Type: LEFT
+Strictness: ANTI
+-- tuple IN rewritten with two key equalities
+Type: LEFT
+Strictness: SEMI
+-- IN over a primary key column is not rewritten (index analysis is better)
+-- NOT IN over a primary key column is rewritten (negative predicates do not prune)
+Type: LEFT
+Strictness: ANTI
+-- transform_null_in = 1 is not rewritten
+-- IN under OR is not rewritten
+-- IN in the SELECT list is not rewritten
+-- constant left argument is not rewritten
+-- Set-engine table on the right is not rewritten
+-- explicit set size limits disable the rewrite
+-- full_sorting_merge cannot run SEMI/ANTI joins, no rewrite
+-- results: IN and NOT IN with duplicates on the right
+2
+2
+2
+2
+-- results: empty subquery
+0
+4
+-- results: NULLs on both sides (NULL is not in, NULL is not not-in the set)
+-- IN with a Nullable left key is rewritten (both paths drop NULL-keyed rows)
+Type: LEFT
+Strictness: SEMI
+-- NOT IN with a Nullable left key is not rewritten (notIn drops NULL-keyed rows, ANTI JOIN keeps them)
+one
+one
+three
+three
+-- results: type widening keeps out-of-range values not-in
+0
+1
+0
+1
+-- results: LowCardinality keys
+1
+2
+-- results: name collision between inner and outer columns
+0

--- a/tests/queries/0_stateless/04821_optimize_rewrite_in_subquery_to_join.sql
+++ b/tests/queries/0_stateless/04821_optimize_rewrite_in_subquery_to_join.sql
@@ -1,0 +1,137 @@
+SET enable_analyzer = 1;
+SET optimize_rewrite_in_subquery_to_join = 1;
+-- Pinned so that CI setting randomization does not change the EXPLAIN output or disable the rewrite
+SET explain_query_plan_default = 'legacy';
+SET query_plan_optimize_join_order_randomize = 0;
+SET enable_parallel_replicas = 0;
+SET query_plan_join_swap_table = 0;
+SET enable_join_runtime_filters = 0;
+SET join_algorithm = 'hash';
+SET transform_null_in = 0;
+SET max_rows_in_set = 0, max_bytes_in_set = 0;
+
+DROP TABLE IF EXISTS t_outer;
+DROP TABLE IF EXISTS t_right;
+DROP TABLE IF EXISTS t_set;
+
+CREATE TABLE t_outer (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE t_right (x UInt64, y UInt64) ENGINE = MergeTree ORDER BY x;
+CREATE TABLE t_set (y UInt64) ENGINE = Set;
+
+INSERT INTO t_outer VALUES (1, 10), (2, 20), (3, 30), (4, 40);
+INSERT INTO t_right VALUES (1, 10), (2, 10), (3, 30), (4, 50);
+INSERT INTO t_set VALUES (10);
+
+SELECT '-- IN rewritten to LEFT SEMI JOIN';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_outer WHERE val IN (SELECT y FROM t_right)
+) WHERE trimLeft(explain) LIKE 'Type: %' OR trimLeft(explain) LIKE 'Strictness: %';
+
+SELECT '-- NOT IN rewritten to LEFT ANTI JOIN';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_outer WHERE val NOT IN (SELECT y FROM t_right)
+) WHERE trimLeft(explain) LIKE 'Type: %' OR trimLeft(explain) LIKE 'Strictness: %';
+
+SELECT '-- tuple IN rewritten with two key equalities';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_outer WHERE (val, val + 1) IN (SELECT y, x FROM t_right)
+) WHERE trimLeft(explain) LIKE 'Type: %' OR trimLeft(explain) LIKE 'Strictness: %';
+
+SELECT '-- IN over a primary key column is not rewritten (index analysis is better)';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_outer WHERE id IN (SELECT y FROM t_right)
+) WHERE trimLeft(explain) LIKE 'Type: %' OR trimLeft(explain) LIKE 'Strictness: %';
+
+SELECT '-- NOT IN over a primary key column is rewritten (negative predicates do not prune)';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_outer WHERE id NOT IN (SELECT y FROM t_right)
+) WHERE trimLeft(explain) LIKE 'Type: %' OR trimLeft(explain) LIKE 'Strictness: %';
+
+SELECT '-- transform_null_in = 1 is not rewritten';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_outer WHERE val IN (SELECT y FROM t_right) SETTINGS transform_null_in = 1
+) WHERE trimLeft(explain) LIKE 'Type: %' OR trimLeft(explain) LIKE 'Strictness: %';
+
+SELECT '-- IN under OR is not rewritten';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_outer WHERE val IN (SELECT y FROM t_right) OR val = 0
+) WHERE trimLeft(explain) LIKE 'Type: %' OR trimLeft(explain) LIKE 'Strictness: %';
+
+SELECT '-- IN in the SELECT list is not rewritten';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN actions = 1 SELECT val IN (SELECT y FROM t_right) FROM t_outer
+) WHERE trimLeft(explain) LIKE 'Type: %' OR trimLeft(explain) LIKE 'Strictness: %';
+
+SELECT '-- constant left argument is not rewritten';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_outer WHERE 10 IN (SELECT y FROM t_right)
+) WHERE trimLeft(explain) LIKE 'Type: %' OR trimLeft(explain) LIKE 'Strictness: %';
+
+SELECT '-- Set-engine table on the right is not rewritten';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_outer WHERE val IN t_set
+) WHERE trimLeft(explain) LIKE 'Type: %' OR trimLeft(explain) LIKE 'Strictness: %';
+
+SELECT '-- explicit set size limits disable the rewrite';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_outer WHERE val IN (SELECT y FROM t_right)
+    SETTINGS max_rows_in_set = 1000, set_overflow_mode = 'break'
+) WHERE trimLeft(explain) LIKE 'Type: %' OR trimLeft(explain) LIKE 'Strictness: %';
+
+SELECT '-- full_sorting_merge cannot run SEMI/ANTI joins, no rewrite';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_outer WHERE val IN (SELECT y FROM t_right) SETTINGS join_algorithm = 'full_sorting_merge'
+) WHERE trimLeft(explain) LIKE 'Type: %' OR trimLeft(explain) LIKE 'Strictness: %';
+
+SELECT '-- results: IN and NOT IN with duplicates on the right';
+SELECT count() FROM t_outer WHERE val IN (SELECT y FROM t_right) SETTINGS optimize_rewrite_in_subquery_to_join = 0;
+SELECT count() FROM t_outer WHERE val IN (SELECT y FROM t_right) SETTINGS optimize_rewrite_in_subquery_to_join = 1;
+SELECT count() FROM t_outer WHERE val NOT IN (SELECT y FROM t_right) SETTINGS optimize_rewrite_in_subquery_to_join = 0;
+SELECT count() FROM t_outer WHERE val NOT IN (SELECT y FROM t_right) SETTINGS optimize_rewrite_in_subquery_to_join = 1;
+
+SELECT '-- results: empty subquery';
+SELECT count() FROM t_outer WHERE val IN (SELECT y FROM t_right WHERE 0) SETTINGS optimize_rewrite_in_subquery_to_join = 1;
+SELECT count() FROM t_outer WHERE val NOT IN (SELECT y FROM t_right WHERE 0) SETTINGS optimize_rewrite_in_subquery_to_join = 1;
+
+SELECT '-- results: NULLs on both sides (NULL is not in, NULL is not not-in the set)';
+DROP TABLE IF EXISTS t_nulls_left;
+DROP TABLE IF EXISTS t_nulls_right;
+CREATE TABLE t_nulls_left (k Nullable(UInt64), tag String) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t_nulls_right (k Nullable(UInt64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_nulls_left VALUES (1, 'one'), (NULL, 'null'), (3, 'three');
+INSERT INTO t_nulls_right VALUES (1), (NULL);
+SELECT '-- IN with a Nullable left key is rewritten (both paths drop NULL-keyed rows)';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_nulls_left WHERE k IN (SELECT k FROM t_nulls_right)
+) WHERE trimLeft(explain) LIKE 'Type: %' OR trimLeft(explain) LIKE 'Strictness: %';
+SELECT '-- NOT IN with a Nullable left key is not rewritten (notIn drops NULL-keyed rows, ANTI JOIN keeps them)';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_nulls_left WHERE k NOT IN (SELECT k FROM t_nulls_right)
+) WHERE trimLeft(explain) LIKE 'Type: %' OR trimLeft(explain) LIKE 'Strictness: %';
+SELECT tag FROM t_nulls_left WHERE k IN (SELECT k FROM t_nulls_right) ORDER BY tag SETTINGS optimize_rewrite_in_subquery_to_join = 0;
+SELECT tag FROM t_nulls_left WHERE k IN (SELECT k FROM t_nulls_right) ORDER BY tag SETTINGS optimize_rewrite_in_subquery_to_join = 1;
+SELECT tag FROM t_nulls_left WHERE k NOT IN (SELECT k FROM t_nulls_right) ORDER BY tag SETTINGS optimize_rewrite_in_subquery_to_join = 0;
+SELECT tag FROM t_nulls_left WHERE k NOT IN (SELECT k FROM t_nulls_right) ORDER BY tag SETTINGS optimize_rewrite_in_subquery_to_join = 1;
+
+SELECT '-- results: type widening keeps out-of-range values not-in';
+SELECT toInt64(-1) IN (SELECT toUInt8(255) FROM system.one) SETTINGS optimize_rewrite_in_subquery_to_join = 0;
+SELECT toInt64(-1) NOT IN (SELECT toUInt8(255) FROM system.one) SETTINGS optimize_rewrite_in_subquery_to_join = 0;
+SELECT count() FROM (SELECT toInt64(-1) AS v FROM system.one) WHERE v IN (SELECT toUInt8(255) FROM system.one) SETTINGS optimize_rewrite_in_subquery_to_join = 1;
+SELECT count() FROM (SELECT toInt64(-1) AS v FROM system.one) WHERE v NOT IN (SELECT toUInt8(255) FROM system.one) SETTINGS optimize_rewrite_in_subquery_to_join = 1;
+
+SELECT '-- results: LowCardinality keys';
+DROP TABLE IF EXISTS t_lc;
+CREATE TABLE t_lc (s LowCardinality(String)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_lc VALUES ('a'), ('b'), ('c');
+SELECT count() FROM t_lc WHERE s IN (SELECT 'b') SETTINGS optimize_rewrite_in_subquery_to_join = 1;
+SELECT count() FROM t_lc WHERE s NOT IN (SELECT 'b') SETTINGS optimize_rewrite_in_subquery_to_join = 1;
+
+SELECT '-- results: name collision between inner and outer columns';
+SELECT count() FROM t_outer WHERE val IN (SELECT val * 10 AS val FROM t_outer WHERE id = 1) SETTINGS optimize_rewrite_in_subquery_to_join = 1;
+
+DROP TABLE t_outer;
+DROP TABLE t_right;
+DROP TABLE t_set;
+DROP TABLE t_nulls_left;
+DROP TABLE t_nulls_right;
+DROP TABLE t_lc;

--- a/tests/queries/0_stateless/04821_optimize_rewrite_in_subquery_to_join.sql
+++ b/tests/queries/0_stateless/04821_optimize_rewrite_in_subquery_to_join.sql
@@ -90,8 +90,8 @@ SELECT count() FROM t_outer WHERE val NOT IN (SELECT y FROM t_right) SETTINGS op
 SELECT count() FROM t_outer WHERE val NOT IN (SELECT y FROM t_right) SETTINGS optimize_rewrite_in_subquery_to_join = 1;
 
 SELECT '-- results: empty subquery';
-SELECT count() FROM t_outer WHERE val IN (SELECT y FROM t_right WHERE 0) SETTINGS optimize_rewrite_in_subquery_to_join = 1;
-SELECT count() FROM t_outer WHERE val NOT IN (SELECT y FROM t_right WHERE 0) SETTINGS optimize_rewrite_in_subquery_to_join = 1;
+SELECT count() FROM t_outer WHERE val IN (SELECT y FROM t_right WHERE 0);
+SELECT count() FROM t_outer WHERE val NOT IN (SELECT y FROM t_right WHERE 0);
 
 SELECT '-- results: NULLs on both sides (NULL is not in, NULL is not not-in the set)';
 DROP TABLE IF EXISTS t_nulls_left;
@@ -123,11 +123,11 @@ SELECT '-- results: LowCardinality keys';
 DROP TABLE IF EXISTS t_lc;
 CREATE TABLE t_lc (s LowCardinality(String)) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t_lc VALUES ('a'), ('b'), ('c');
-SELECT count() FROM t_lc WHERE s IN (SELECT 'b') SETTINGS optimize_rewrite_in_subquery_to_join = 1;
-SELECT count() FROM t_lc WHERE s NOT IN (SELECT 'b') SETTINGS optimize_rewrite_in_subquery_to_join = 1;
+SELECT count() FROM t_lc WHERE s IN (SELECT 'b');
+SELECT count() FROM t_lc WHERE s NOT IN (SELECT 'b');
 
 SELECT '-- results: name collision between inner and outer columns';
-SELECT count() FROM t_outer WHERE val IN (SELECT val * 10 AS val FROM t_outer WHERE id = 1) SETTINGS optimize_rewrite_in_subquery_to_join = 1;
+SELECT count() FROM t_outer WHERE val IN (SELECT val * 10 AS val FROM t_outer WHERE id = 1);
 
 DROP TABLE t_outer;
 DROP TABLE t_right;


### PR DESCRIPTION
`x [NOT] IN (subquery)` always materializes the whole subquery result into an in-memory set, regardless of how small the outer side is. The new analyzer pass rewrites such predicates (uncorrelated subqueries in top-level `WHERE` conjuncts) into `LEFT SEMI/ANTI JOIN`, so the join planner can pick the smaller side for the hash table and filter the probe side with runtime filters. On a 30k-row outer side against a 100M-row subquery, `IN` and `NOT IN` go from 3.7 s / 1.5 GiB to 0.14 s / 0.7 GiB. The rewrite is off by default and is skipped whenever it could change behavior or lose index analysis (`transform_null_in = 1`, `notIn` with a `Nullable` left key, `GLOBAL IN`, correlated subqueries, remote tables, explicit set size limits, join algorithms without `SEMI`/`ANTI` support, and, for `in`, left keys usable for primary-key/partition/skip-index pruning).

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added a new setting `optimize_rewrite_in_subquery_to_join` (disabled by default) that rewrites `x [NOT] IN (uncorrelated subquery)` in top-level `WHERE` conjuncts into `LEFT SEMI/ANTI JOIN`, letting the join planner choose the hash-table side and apply runtime filters instead of always materializing the subquery result into an in-memory set.