### PR TITLE
Imply make_distributed_plan from distributed_plan_workers_num

### DIFF
--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -143,6 +143,10 @@ public:
         pool(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, max_concurrency)
     {
         global_context->makeGlobalContext();
+        /// A client-side context: the settings applied here are sent with every benchmarked query,
+        /// and server-side derivations (e.g. make_distributed_plan and its adjustments) must not
+        /// run on them - this context has no settings constraints to veto anything.
+        global_context->setApplicationType(Context::ApplicationType::CLIENT);
         global_context->setSettings(settings);
         global_context->setClientName(std::string(DEFAULT_CLIENT_NAME));
         global_context->setQueryKindInitial();

--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -121,6 +121,15 @@ void SettingsConstraints::get(const MergeTreeSettings &, std::string_view short_
     writability = checker.constraint.writability;
 }
 
+SettingConstraintWritability SettingsConstraints::getWritability(std::string_view setting_name) const
+{
+    auto it = constraints.find(resolveSettingNameWithCache(setting_name));
+    if (it == constraints.end())
+        return SettingConstraintWritability::WRITABLE;
+
+    return it->second.writability;
+}
+
 void SettingsConstraints::merge(const SettingsConstraints & other)
 {
     if (access_control->doesSettingsConstraintsReplacePrevious())

--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -121,13 +121,30 @@ void SettingsConstraints::get(const MergeTreeSettings &, std::string_view short_
     writability = checker.constraint.writability;
 }
 
-SettingConstraintWritability SettingsConstraints::getWritability(std::string_view setting_name) const
+bool SettingsConstraints::allowsValue(std::string_view setting_name, const Field & value) const
 {
     auto it = constraints.find(resolveSettingNameWithCache(setting_name));
     if (it == constraints.end())
-        return SettingConstraintWritability::WRITABLE;
+        return true;
 
-    return it->second.writability;
+    const auto & constraint = it->second;
+
+    if (constraint.writability == SettingConstraintWritability::CONST)
+        return false;
+
+    if (!constraint.min_value.isNull() && accurateLess(value, constraint.min_value))
+        return false;
+
+    if (!constraint.max_value.isNull() && accurateLess(constraint.max_value, value))
+        return false;
+
+    for (const auto & disallowed_value : constraint.disallowed_values)
+    {
+        if (accurateEquals(disallowed_value, value))
+            return false;
+    }
+
+    return true;
 }
 
 void SettingsConstraints::merge(const SettingsConstraints & other)

--- a/src/Access/SettingsConstraints.h
+++ b/src/Access/SettingsConstraints.h
@@ -75,6 +75,10 @@ public:
     void get(const Settings & current_settings, std::string_view short_name, Field & min_value, Field & max_value, std::vector<Field> & disallowed_values, SettingConstraintWritability & writability) const;
     void get(const MergeTreeSettings & current_settings, std::string_view short_name, Field & min_value, Field & max_value, std::vector<Field> & disallowed_values, SettingConstraintWritability & writability) const;
 
+    /// The stored writability of the setting, without the readonly-mode and feature-tier
+    /// restrictions that the check functions fold in.
+    SettingConstraintWritability getWritability(std::string_view setting_name) const;
+
     void merge(const SettingsConstraints & other);
 
     /// Checks whether `change` violates these constraints and throws an exception if so.

--- a/src/Access/SettingsConstraints.h
+++ b/src/Access/SettingsConstraints.h
@@ -75,9 +75,9 @@ public:
     void get(const Settings & current_settings, std::string_view short_name, Field & min_value, Field & max_value, std::vector<Field> & disallowed_values, SettingConstraintWritability & writability) const;
     void get(const MergeTreeSettings & current_settings, std::string_view short_name, Field & min_value, Field & max_value, std::vector<Field> & disallowed_values, SettingConstraintWritability & writability) const;
 
-    /// The stored writability of the setting, without the readonly-mode and feature-tier
-    /// restrictions that the check functions fold in.
-    SettingConstraintWritability getWritability(std::string_view setting_name) const;
+    /// Whether the stored constraint allows `value` for the setting, without the readonly-mode and
+    /// feature-tier restrictions that the check functions fold in.
+    bool allowsValue(std::string_view setting_name, const Field & value) const;
 
     void merge(const SettingsConstraints & other);
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8605,6 +8605,8 @@ Method to compress `.metadata.json` file.
     DECLARE(Bool, make_distributed_plan, false, R"(
 Make distributed query plan.
 
+It is enabled automatically when `distributed_plan_workers_num` is not zero, unless it is set explicitly.
+
 Enabling it automatically adjusts settings that control features not supported by distributed query plans yet:
 - `enable_parallel_replicas = 0` and `automatic_parallel_replicas_mode = 0` — the distributed plan does its own work distribution;
 - `correlated_subqueries_use_in_memory_buffer = 0`;
@@ -8625,7 +8627,9 @@ Default number of tasks for parallel reading in distributed query. Tasks are spr
 Removes unnecessary exchanges in distributed query plan. Disable it for debugging.
 )", 0) \
     DECLARE(UInt64, distributed_plan_workers_num, 0, R"(
-How many stateless workers will be used to execute this query. Zero disables stateless-worker leasing for distributed plans.
+How many Stateless Workers will be used to execute this query. Zero disables Stateless Worker leasing for distributed plans.
+
+A non-zero value enables `make_distributed_plan` unless that setting is set explicitly.
 )", EXPERIMENTAL) \
     DECLARE(String, distributed_plan_force_exchange_kind, "", R"(
 Force specified kind of Exchange operators between distributed query stages.

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8605,7 +8605,7 @@ Method to compress `.metadata.json` file.
     DECLARE(Bool, make_distributed_plan, false, R"(
 Make distributed query plan.
 
-It is enabled automatically when `distributed_plan_workers_num` is not zero, unless it is set explicitly.
+It is enabled automatically when `distributed_plan_workers_num` is not zero, unless it is set explicitly or a settings constraint forbids enabling it.
 
 Enabling it automatically adjusts settings that control features not supported by distributed query plans yet:
 - `enable_parallel_replicas = 0` and `automatic_parallel_replicas_mode = 0` — the distributed plan does its own work distribution;
@@ -8629,7 +8629,7 @@ Removes unnecessary exchanges in distributed query plan. Disable it for debuggin
     DECLARE(UInt64, distributed_plan_workers_num, 0, R"(
 How many Stateless Workers will be used to execute this query. Zero disables Stateless Worker leasing for distributed plans.
 
-A non-zero value enables `make_distributed_plan` unless that setting is set explicitly.
+A non-zero value enables `make_distributed_plan` unless that setting is set explicitly or a settings constraint forbids enabling it.
 )", EXPERIMENTAL) \
     DECLARE(String, distributed_plan_force_exchange_kind, "", R"(
 Force specified kind of Exchange operators between distributed query stages.

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8979,6 +8979,7 @@ struct SettingsImpl : public BaseSettings<SettingsTraits>, public IHints<2>
 
     void rememberBeforeDistributedPlanAdjustment(std::string_view name);
     void restoreDistributedPlanAdjustments();
+    void dropDistributedPlanAdjustmentMemory() { settings_adjusted_for_distributed_plan.clear(); }
 
 private:
     void applyCompatibilitySetting(const String & compatibility);
@@ -9231,7 +9232,10 @@ Settings::Settings()
 
 Settings::Settings(const Settings & settings)
     : impl(std::make_unique<SettingsImpl>(*settings.impl))
-{}
+{
+    /// The adjustment memory is local to the object it was recorded on - see the note in Settings.h.
+    impl->dropDistributedPlanAdjustmentMemory();
+}
 
 Settings::Settings(Settings && settings) noexcept = default;
 
@@ -9242,6 +9246,7 @@ Settings & Settings::operator=(const Settings & other)
     if (&other == this)
         return *this;
     *impl = *other.impl;
+    impl->dropDistributedPlanAdjustmentMemory();
     return *this;
 }
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -20,6 +20,9 @@
 #include <Storages/System/MutableColumnsAndConstraints.h>
 #include <base/types.h>
 #include <Common/NamePrompter.h>
+#include <Common/UnorderedMapWithMemoryTracking.h>
+
+#include <utility>
 #include <Common/typeid_cast.h>
 
 #include <boost/program_options.hpp>
@@ -8969,14 +8972,23 @@ struct SettingsImpl : public BaseSettings<SettingsTraits>, public IHints<2>
     VectorWithMemoryTracking<String> getAllRegisteredNames() const override;
 
     void set(std::string_view name, const Field & value) override;
+    void setDefaultValue(std::string_view name);
 
     bool hasSettingsChangedByCompatibility() const { return !settings_changed_by_compatibility_setting.empty(); }
     void resetSettingsChangedByCompatibility();
+
+    void rememberBeforeDistributedPlanAdjustment(std::string_view name);
+    void restoreDistributedPlanAdjustments();
 
 private:
     void applyCompatibilitySetting(const String & compatibility);
 
     UnorderedSetWithMemoryTracking<std::string_view> settings_changed_by_compatibility_setting;
+
+    /// The pre-override (value, changed) of the settings force-adjusted for a derived distributed
+    /// plan, so the overrides can be undone when the plan turns off. Not serialized: a receiver
+    /// re-derives the plan and re-adjusts from the changes it gets.
+    UnorderedMapWithMemoryTracking<std::string_view, std::pair<Field, bool>> settings_adjusted_for_distributed_plan;
 };
 
 /** Set the settings from the profile (in the server configuration, many settings can be listed in one profile).
@@ -9124,7 +9136,42 @@ void SettingsImpl::set(std::string_view name, const Field & value)
     else if (auto final_name = SettingsTraits::resolveName(name); settings_changed_by_compatibility_setting.contains(final_name))
         settings_changed_by_compatibility_setting.erase(final_name);
 
+    /// An explicit change takes the setting out of the distributed-plan adjustment memory, so
+    /// turning the derived plan off does not overwrite the new value with the remembered one.
+    if (!settings_adjusted_for_distributed_plan.empty())
+        settings_adjusted_for_distributed_plan.erase(SettingsTraits::resolveName(name));
+
     BaseSettings::set(name, value);
+}
+
+void SettingsImpl::setDefaultValue(std::string_view name)
+{
+    /// `SET name = DEFAULT` is an explicit change like any other - see the note in set().
+    if (!settings_adjusted_for_distributed_plan.empty())
+        settings_adjusted_for_distributed_plan.erase(SettingsTraits::resolveName(name));
+
+    resetToDefault(name);
+}
+
+void SettingsImpl::rememberBeforeDistributedPlanAdjustment(std::string_view name)
+{
+    auto final_name = SettingsTraits::resolveName(name);
+    if (settings_adjusted_for_distributed_plan.contains(final_name))
+        return;
+
+    settings_adjusted_for_distributed_plan.emplace(final_name, std::pair{get(final_name), isChanged(final_name)});
+}
+
+void SettingsImpl::restoreDistributedPlanAdjustments()
+{
+    const auto remembered = std::exchange(settings_adjusted_for_distributed_plan, {});
+    for (const auto & [name, value_and_changed] : remembered)
+    {
+        if (value_and_changed.second)
+            BaseSettings::set(name, value_and_changed.first);
+        else
+            resetToDefault(name);
+    }
 }
 
 void SettingsImpl::resetSettingsChangedByCompatibility()
@@ -9252,7 +9299,17 @@ void Settings::set(std::string_view name, const Field & value)
 
 void Settings::setDefaultValue(std::string_view name)
 {
-    impl->resetToDefault(name);
+    impl->setDefaultValue(name);
+}
+
+void Settings::rememberBeforeDistributedPlanAdjustment(std::string_view name)
+{
+    impl->rememberBeforeDistributedPlanAdjustment(name);
+}
+
+void Settings::restoreDistributedPlanAdjustments()
+{
+    impl->restoreDistributedPlanAdjustments();
 }
 
 bool Settings::hasSettingsChangedByCompatibility() const

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -158,6 +158,15 @@ struct Settings
     void set(std::string_view name, const Field & value);
     void setDefaultValue(std::string_view name);
 
+    /// Remember the current value of a setting before adjustSettingsForMakeDistributedPlan
+    /// overrides it for a derived distributed plan, so the override can be undone when the plan
+    /// turns off. The memory travels with copies. An explicit change of a remembered setting
+    /// revokes its memory, so the restore never overwrites a value the user set in the meantime.
+    /// `name` is kept as a key past the call and must point to static storage, such as the
+    /// setting-name literals the adjustment passes.
+    void rememberBeforeDistributedPlanAdjustment(std::string_view name);
+    void restoreDistributedPlanAdjustments();
+
     /// Whether any setting currently holds a value that was set by the `compatibility` setting.
     bool hasSettingsChangedByCompatibility() const;
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -160,10 +160,13 @@ struct Settings
 
     /// Remember the current value of a setting before adjustSettingsForMakeDistributedPlan
     /// overrides it for a derived distributed plan, so the override can be undone when the plan
-    /// turns off. The memory travels with copies. An explicit change of a remembered setting
-    /// revokes its memory, so the restore never overwrites a value the user set in the meantime.
-    /// `name` is kept as a key past the call and must point to static storage, such as the
-    /// setting-name literals the adjustment passes.
+    /// turns off. The memory is local to the object it was recorded on - copies do not inherit
+    /// it, so a context cloned from a distributed query keeps the adjusted values when it turns
+    /// `make_distributed_plan` off to run a local fragment: for a fragment the adjustments are
+    /// the point, not a leftover. An explicit change of a remembered setting revokes its memory,
+    /// so the restore never overwrites a value the user set in the meantime. `name` is kept as
+    /// a key past the call and must point to static storage, such as the setting-name literals
+    /// the adjustment passes.
     void rememberBeforeDistributedPlanAdjustment(std::string_view name);
     void restoreDistributedPlanAdjustments();
 

--- a/src/Core/SettingsQuirks.cpp
+++ b/src/Core/SettingsQuirks.cpp
@@ -102,9 +102,9 @@ void applySettingsQuirks(Settings & settings, LoggerPtr log)
 void adjustSettingsForMakeDistributedPlan(Settings & settings)
 {
     /// Stateless Workers only run the stages of a distributed plan, so asking for Workers implies
-    /// asking for the plan. An explicit value still wins, so a fragment can turn the plan back off.
-    if (settings[Setting::distributed_plan_workers_num] != 0 && !settings.isChanged("make_distributed_plan"))
-        settings[Setting::make_distributed_plan] = true;
+    /// asking for the plan. Deriving instead of assigning keeps a later zero count from pinning it on.
+    if (!settings[Setting::make_distributed_plan].changed)
+        settings[Setting::make_distributed_plan].value = settings[Setting::distributed_plan_workers_num] != 0;
 
     if (!settings[Setting::make_distributed_plan])
         return;

--- a/src/Core/SettingsQuirks.cpp
+++ b/src/Core/SettingsQuirks.cpp
@@ -48,6 +48,7 @@ namespace Setting
     extern const SettingsBool async_query_sending_for_remote;
     extern const SettingsBool async_socket_for_remote;
     extern const SettingsBool make_distributed_plan;
+    extern const SettingsUInt64 distributed_plan_workers_num;
     extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
     extern const SettingsUInt64 automatic_parallel_replicas_mode;
     extern const SettingsBool correlated_subqueries_use_in_memory_buffer;
@@ -100,6 +101,11 @@ void applySettingsQuirks(Settings & settings, LoggerPtr log)
 /// let the worker re-run the rewrite over its pinned part list instead of disabling it.
 void adjustSettingsForMakeDistributedPlan(Settings & settings)
 {
+    /// Stateless Workers only run the stages of a distributed plan, so asking for Workers implies
+    /// asking for the plan. An explicit value still wins, so a fragment can turn the plan back off.
+    if (settings[Setting::distributed_plan_workers_num] != 0 && !settings.isChanged("make_distributed_plan"))
+        settings[Setting::make_distributed_plan] = true;
+
     if (!settings[Setting::make_distributed_plan])
         return;
 

--- a/src/Core/SettingsQuirks.cpp
+++ b/src/Core/SettingsQuirks.cpp
@@ -99,12 +99,12 @@ void applySettingsQuirks(Settings & settings, LoggerPtr log)
 /// TODO: This is a temporary workaround (issues #109476, #109329). Remove each override once
 /// distributed plans support the corresponding feature - e.g. for the text index direct read,
 /// let the worker re-run the rewrite over its pinned part list instead of disabling it.
-void adjustSettingsForMakeDistributedPlan(Settings & settings)
+void adjustSettingsForMakeDistributedPlan(Settings & settings, bool derivation_allowed)
 {
     /// Stateless Workers only run the stages of a distributed plan, so asking for Workers implies
     /// asking for the plan. Deriving instead of assigning keeps a later zero count from pinning it on.
     if (!settings[Setting::make_distributed_plan].changed)
-        settings[Setting::make_distributed_plan].value = settings[Setting::distributed_plan_workers_num] != 0;
+        settings[Setting::make_distributed_plan].value = derivation_allowed && settings[Setting::distributed_plan_workers_num] != 0;
 
     if (!settings[Setting::make_distributed_plan])
         return;

--- a/src/Core/SettingsQuirks.cpp
+++ b/src/Core/SettingsQuirks.cpp
@@ -103,44 +103,63 @@ void adjustSettingsForMakeDistributedPlan(Settings & settings, bool derivation_a
 {
     /// Stateless Workers only run the stages of a distributed plan, so asking for Workers implies
     /// asking for the plan. Deriving instead of assigning keeps a later zero count from pinning it on.
-    if (!settings[Setting::make_distributed_plan].changed)
+    const bool derived = !settings[Setting::make_distributed_plan].changed;
+    if (derived)
         settings[Setting::make_distributed_plan].value = derivation_allowed && settings[Setting::distributed_plan_workers_num] != 0;
 
     if (!settings[Setting::make_distributed_plan])
+    {
+        /// A derived plan must leave no trace once it is off; an explicitly enabled plan never
+        /// remembers, so its adjustments stay, as they always have.
+        settings.restoreDistributedPlanAdjustments();
         return;
+    }
 
     Strings adjusted;
 
+    auto override_for_plan = [&](std::string_view name, auto && apply, const char * description)
+    {
+        if (derived)
+            settings.rememberBeforeDistributedPlanAdjustment(name);
+        apply();
+        adjusted.emplace_back(description);
+    };
+
     if (settings[Setting::allow_experimental_parallel_reading_from_replicas] > 0)
-    {
-        settings[Setting::allow_experimental_parallel_reading_from_replicas] = 0;
-        adjusted.emplace_back("enable_parallel_replicas = 0");
-    }
+        override_for_plan(
+            "allow_experimental_parallel_reading_from_replicas",
+            [&] { settings[Setting::allow_experimental_parallel_reading_from_replicas] = 0; },
+            "enable_parallel_replicas = 0");
+
     if (settings[Setting::automatic_parallel_replicas_mode] != 0)
-    {
-        settings[Setting::automatic_parallel_replicas_mode] = 0;
-        adjusted.emplace_back("automatic_parallel_replicas_mode = 0");
-    }
+        override_for_plan(
+            "automatic_parallel_replicas_mode",
+            [&] { settings[Setting::automatic_parallel_replicas_mode] = 0; },
+            "automatic_parallel_replicas_mode = 0");
+
     if (settings[Setting::correlated_subqueries_use_in_memory_buffer])
-    {
-        settings[Setting::correlated_subqueries_use_in_memory_buffer] = false;
-        adjusted.emplace_back("correlated_subqueries_use_in_memory_buffer = 0");
-    }
+        override_for_plan(
+            "correlated_subqueries_use_in_memory_buffer",
+            [&] { settings[Setting::correlated_subqueries_use_in_memory_buffer] = false; },
+            "correlated_subqueries_use_in_memory_buffer = 0");
+
     if (settings[Setting::use_skip_indexes_on_data_read])
-    {
-        settings[Setting::use_skip_indexes_on_data_read] = false;
-        adjusted.emplace_back("use_skip_indexes_on_data_read = 0");
-    }
+        override_for_plan(
+            "use_skip_indexes_on_data_read",
+            [&] { settings[Setting::use_skip_indexes_on_data_read] = false; },
+            "use_skip_indexes_on_data_read = 0");
+
     if (settings[Setting::compile_expressions])
-    {
-        settings[Setting::compile_expressions] = false;
-        adjusted.emplace_back("compile_expressions = 0");
-    }
+        override_for_plan(
+            "compile_expressions",
+            [&] { settings[Setting::compile_expressions] = false; },
+            "compile_expressions = 0");
+
     if (settings[Setting::query_plan_direct_read_from_text_index])
-    {
-        settings[Setting::query_plan_direct_read_from_text_index] = false;
-        adjusted.emplace_back("query_plan_direct_read_from_text_index = 0");
-    }
+        override_for_plan(
+            "query_plan_direct_read_from_text_index",
+            [&] { settings[Setting::query_plan_direct_read_from_text_index] = false; },
+            "query_plan_direct_read_from_text_index = 0");
 
     if (!adjusted.empty())
         LOG_DEBUG(

--- a/src/Core/SettingsQuirks.h
+++ b/src/Core/SettingsQuirks.h
@@ -19,9 +19,10 @@ inline constexpr UInt64 MAX_SANE_READ_BUFFER_SIZE = 256 * 1024 * 1024; /// 256 M
 /// Update some settings defaults to avoid some known issues.
 void applySettingsQuirks(Settings & settings, LoggerPtr log = nullptr);
 
-/// When make_distributed_plan is enabled, adjust the settings that control features distributed
-/// query plans do not support yet. Applied whenever settings changes are applied to a context, so
-/// that every context driving analysis, planning or task execution sees the adjusted values.
+/// Enable make_distributed_plan when a non-zero distributed_plan_workers_num implies it, then, when
+/// it is enabled, adjust the settings that control features distributed query plans do not support
+/// yet. Applied whenever settings changes are applied to a context, so that every context driving
+/// analysis, planning or task execution sees the adjusted values.
 void adjustSettingsForMakeDistributedPlan(Settings & settings);
 
 /// Verify that some settings have sane values. Alters the value to a reasonable one if not

--- a/src/Core/SettingsQuirks.h
+++ b/src/Core/SettingsQuirks.h
@@ -19,10 +19,10 @@ inline constexpr UInt64 MAX_SANE_READ_BUFFER_SIZE = 256 * 1024 * 1024; /// 256 M
 /// Update some settings defaults to avoid some known issues.
 void applySettingsQuirks(Settings & settings, LoggerPtr log = nullptr);
 
-/// Enable make_distributed_plan when a non-zero distributed_plan_workers_num implies it, then, when
-/// it is enabled, adjust the settings that control features distributed query plans do not support
-/// yet. Applied whenever settings changes are applied to a context, so that every context driving
-/// analysis, planning or task execution sees the adjusted values.
+/// Derive make_distributed_plan from distributed_plan_workers_num unless it is set explicitly, then,
+/// when it is enabled, adjust the settings that control features distributed query plans do not
+/// support yet. Applied whenever settings changes are applied to a context, so that every context
+/// driving analysis, planning or task execution sees the adjusted values.
 void adjustSettingsForMakeDistributedPlan(Settings & settings);
 
 /// Verify that some settings have sane values. Alters the value to a reasonable one if not

--- a/src/Core/SettingsQuirks.h
+++ b/src/Core/SettingsQuirks.h
@@ -23,7 +23,8 @@ void applySettingsQuirks(Settings & settings, LoggerPtr log = nullptr);
 /// when it is enabled, adjust the settings that control features distributed query plans do not
 /// support yet. Applied whenever settings changes are applied to a context, so that every context
 /// driving analysis, planning or task execution sees the adjusted values.
-void adjustSettingsForMakeDistributedPlan(Settings & settings);
+/// `derivation_allowed = false` vetoes the derivation (e.g. a `const` constraint pins the setting).
+void adjustSettingsForMakeDistributedPlan(Settings & settings, bool derivation_allowed);
 
 /// Verify that some settings have sane values. Alters the value to a reasonable one if not
 void doSettingsSanityCheckClamp(Settings & settings, LoggerPtr log);

--- a/src/Core/SettingsQuirks.h
+++ b/src/Core/SettingsQuirks.h
@@ -23,7 +23,7 @@ void applySettingsQuirks(Settings & settings, LoggerPtr log = nullptr);
 /// when it is enabled, adjust the settings that control features distributed query plans do not
 /// support yet. Applied whenever settings changes are applied to a context, so that every context
 /// driving analysis, planning or task execution sees the adjusted values.
-/// `derivation_allowed = false` vetoes the derivation (e.g. a `const` constraint pins the setting).
+/// `derivation_allowed = false` vetoes the derivation (e.g. a constraint forbids enabling it).
 void adjustSettingsForMakeDistributedPlan(Settings & settings, bool derivation_allowed);
 
 /// Verify that some settings have sane values. Alters the value to a reasonable one if not

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2398,6 +2398,9 @@ void Context::setCurrentProfilesWithLock(const SettingsProfilesInfo & profiles_i
     applySettingsChangesWithLock(profiles_info.settings, lock);
     settings_constraints_and_current_profiles = profiles_info.getConstraintsAndProfileIDs(settings_constraints_and_current_profiles);
     contextSanityClampSettingsWithLock(*this, *settings, lock);
+
+    /// The profile may have brought constraints that veto the value just derived above.
+    finalizeSettingsWithLock(lock);
 }
 
 void Context::setCurrentProfile(const String & profile_name, bool check_constraints)
@@ -3376,7 +3379,11 @@ void Context::applySettingChangeWithLock(const SettingChange & change, const std
 void Context::finalizeSettingsWithLock(const std::lock_guard<ContextSharedMutex> &)
 {
     applySettingsQuirks(*settings);
-    adjustSettingsForMakeDistributedPlan(*settings);
+
+    /// A `const` constraint pins make_distributed_plan against the derived value too.
+    const auto writability = getSettingsConstraintsAndCurrentProfilesWithLock()->constraints.getWritability("make_distributed_plan");
+
+    adjustSettingsForMakeDistributedPlan(*settings, writability != SettingConstraintWritability::CONST);
 }
 
 void Context::applySettingsChangesWithLock(const SettingsChanges & changes, const std::lock_guard<ContextSharedMutex>& lock)
@@ -7572,7 +7579,6 @@ void Context::setDefaultProfiles(const Poco::Util::AbstractConfiguration & confi
     setCurrentProfile(shared->system_profile_name, check_constraints);
 
     applySettingsQuirks(*settings, getLogger("SettingsQuirks"));
-    adjustSettingsForMakeDistributedPlan(*settings);
     doSettingsSanityCheckClamp(*settings, getLogger("SettingsSanity"));
 
     makeBackgroundContext(config);

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3325,6 +3325,7 @@ void Context::setSettings(const Settings & settings_)
     *settings = settings_;
     need_recalculate_access = true;
     contextSanityClampSettings(*this, *settings);
+    finalizeSettingsWithLock(lock);
 }
 
 void Context::setSettingWithLock(std::string_view name, const String & value, const std::lock_guard<ContextSharedMutex> & lock)
@@ -3372,18 +3373,24 @@ void Context::applySettingChangeWithLock(const SettingChange & change, const std
     }
 }
 
+void Context::finalizeSettingsWithLock(const std::lock_guard<ContextSharedMutex> &)
+{
+    applySettingsQuirks(*settings);
+    adjustSettingsForMakeDistributedPlan(*settings);
+}
+
 void Context::applySettingsChangesWithLock(const SettingsChanges & changes, const std::lock_guard<ContextSharedMutex>& lock)
 {
     for (const SettingChange & change : changes)
         applySettingChangeWithLock(change, lock);
-    applySettingsQuirks(*settings);
-    adjustSettingsForMakeDistributedPlan(*settings);
+    finalizeSettingsWithLock(lock);
 }
 
 void Context::setSetting(std::string_view name, const String & value)
 {
     std::lock_guard lock(mutex);
     setSettingWithLock(name, value, lock);
+    finalizeSettingsWithLock(lock);
 }
 
 void Context::setSetting(std::string_view name, const Field & value)
@@ -3391,6 +3398,7 @@ void Context::setSetting(std::string_view name, const Field & value)
     std::lock_guard lock(mutex);
     setSettingWithLock(name, value, lock);
     contextSanityClampSettingsWithLock(*this, *settings, lock);
+    finalizeSettingsWithLock(lock);
 }
 
 void Context::setServerSetting(std::string_view name, const Field & value)
@@ -3508,6 +3516,7 @@ void Context::resetSettingsToDefaultValue(const std::vector<String> & names)
     std::lock_guard lock(mutex);
     for (const String & name: names)
         settings->setDefaultValue(name);
+    finalizeSettingsWithLock(lock);
 }
 
 std::shared_ptr<const SettingsConstraintsAndProfileIDs> Context::getSettingsConstraintsAndCurrentProfilesWithLock() const

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3384,6 +3384,13 @@ void Context::finalizeSettingsWithLock(const std::lock_guard<ContextSharedMutex>
 {
     applySettingsQuirks(*settings);
 
+    /// Deriving the plan and adjusting for it is the server's call. clickhouse-client applies the
+    /// session settings the server pushes after the handshake onto a context that has no settings
+    /// constraints, so deriving here would enable the plan the server may have just vetoed, and the
+    /// adjustments would ride back to the server as explicit changes of the client.
+    if (getApplicationType() == ApplicationType::CLIENT)
+        return;
+
     /// A constraint that forbids enabling `make_distributed_plan` also vetoes the derived value.
     const bool derivation_allowed = getSettingsConstraintsAndCurrentProfilesWithLock()->constraints.allowsValue("make_distributed_plan", Field(true));
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3380,10 +3380,10 @@ void Context::finalizeSettingsWithLock(const std::lock_guard<ContextSharedMutex>
 {
     applySettingsQuirks(*settings);
 
-    /// A `const` constraint pins make_distributed_plan against the derived value too.
-    const auto writability = getSettingsConstraintsAndCurrentProfilesWithLock()->constraints.getWritability("make_distributed_plan");
+    /// A constraint that forbids enabling `make_distributed_plan` also vetoes the derived value.
+    const bool derivation_allowed = getSettingsConstraintsAndCurrentProfilesWithLock()->constraints.allowsValue("make_distributed_plan", Field(true));
 
-    adjustSettingsForMakeDistributedPlan(*settings, writability != SettingConstraintWritability::CONST);
+    adjustSettingsForMakeDistributedPlan(*settings, derivation_allowed);
 }
 
 void Context::applySettingsChangesWithLock(const SettingsChanges & changes, const std::lock_guard<ContextSharedMutex>& lock)

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2395,11 +2395,15 @@ void Context::setCurrentProfilesWithLock(const SettingsProfilesInfo & profiles_i
 {
     if (check_constraints)
         checkSettingsConstraintsWithLock(profiles_info.settings, SettingSource::PROFILE);
-    applySettingsChangesWithLock(profiles_info.settings, lock);
+
+    /// Apply the profile's settings without finalizing: deriving make_distributed_plan under the
+    /// outgoing constraints could latch the distributed-plan adjustments even though the incoming
+    /// constraints veto the plan. Finalize once the profile's own constraints are in place.
+    for (const SettingChange & change : profiles_info.settings)
+        applySettingChangeWithLock(change, lock);
+
     settings_constraints_and_current_profiles = profiles_info.getConstraintsAndProfileIDs(settings_constraints_and_current_profiles);
     contextSanityClampSettingsWithLock(*this, *settings, lock);
-
-    /// The profile may have brought constraints that veto the value just derived above.
     finalizeSettingsWithLock(lock);
 }
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1993,6 +1993,9 @@ private:
 
     void applySettingsChangesWithLock(const SettingsChanges & changes, const std::lock_guard<ContextSharedMutex> & lock);
 
+    /// Re-applies cross-setting invariants; must run last in every public mutator of `settings`.
+    void finalizeSettingsWithLock(const std::lock_guard<ContextSharedMutex> & lock);
+
     void setUserIDWithLock(const UUID & user_id_, const std::lock_guard<ContextSharedMutex> & lock);
 
     void setCurrentDatabaseWithLock(const String & name, const std::lock_guard<ContextSharedMutex> & lock);

--- a/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.reference
+++ b/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.reference
@@ -1,0 +1,14 @@
+off while the workers num is zero
+false
+implied by a per-query workers num
+true
+the implied plan still adjusts the settings it does not support
+false
+implied by a session workers num
+true
+the query distributes with make_distributed_plan left alone
+distributes
+an explicit value wins over the implication
+false
+and keeps winning when the workers num changes again
+false

--- a/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.reference
+++ b/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.reference
@@ -8,7 +8,7 @@ implied by a session workers num
 true
 the query distributes with make_distributed_plan left alone
 distributes
-an explicit value wins over the implication
+off again when the workers num goes back to zero
 false
-and keeps winning when the workers num changes again
+an explicit value wins over the implication
 false

--- a/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.reference
+++ b/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.reference
@@ -1,13 +1,13 @@
 off while the workers num is zero
 false
-implied by a per-query workers num
-true
-the implied plan still adjusts the settings it does not support
-false
-implied by a session workers num
-true
+implied by a per-query workers num unless pinned const
+1
+the implied plan adjusts the settings it does not support, unless pinned const
+1
+implied by a session workers num unless pinned const
+1
 the query distributes with make_distributed_plan left alone
-distributes
+1
 off again when the workers num goes back to zero
 false
 an explicit value wins over the implication

--- a/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.reference
+++ b/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.reference
@@ -4,9 +4,9 @@ implied by a per-query workers num unless pinned const
 1
 the implied plan adjusts the settings it does not support, unless pinned const
 1
-implied by a session workers num unless pinned const
-1
 the query distributes with make_distributed_plan left alone
+1
+implied by a session workers num unless pinned const
 1
 off again when the workers num goes back to zero
 false

--- a/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.sql
+++ b/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.sql
@@ -32,10 +32,11 @@ WHERE explain LIKE '%ReadFromDistributedPlanSource%' LIMIT 1;
 
 DROP TABLE t_dp_workers;
 
-SELECT 'an explicit value wins over the implication';
-SET make_distributed_plan = 0;
+SELECT 'off again when the workers num goes back to zero';
+SET distributed_plan_workers_num = 0;
 SELECT getSetting('make_distributed_plan');
 
-SELECT 'and keeps winning when the workers num changes again';
+SELECT 'an explicit value wins over the implication';
+SET make_distributed_plan = 0;
 SET distributed_plan_workers_num = 5;
 SELECT getSetting('make_distributed_plan');

--- a/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.sql
+++ b/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.sql
@@ -1,0 +1,41 @@
+-- Tags: no-old-analyzer
+-- no-old-analyzer: make_distributed_plan requires the analyzer.
+
+-- Stateless Workers only run the stages of a distributed plan, so a non-zero
+-- `distributed_plan_workers_num` enables `make_distributed_plan` on its own (issue #114501).
+-- Everything runs locally so that the implied plan never dials a Worker.
+
+SET distributed_plan_execute_locally = 1;
+
+DROP TABLE IF EXISTS t_dp_workers;
+CREATE TABLE t_dp_workers (id UInt64, v UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_dp_workers SELECT number, number FROM numbers(100000);
+
+SELECT 'off while the workers num is zero';
+SELECT getSetting('make_distributed_plan');
+
+SELECT 'implied by a per-query workers num';
+SELECT getSetting('make_distributed_plan') SETTINGS distributed_plan_workers_num = 3;
+
+SELECT 'the implied plan still adjusts the settings it does not support';
+SELECT getSetting('compile_expressions') SETTINGS distributed_plan_workers_num = 3, compile_expressions = 1;
+
+SELECT 'implied by a session workers num';
+SET distributed_plan_workers_num = 3;
+SELECT getSetting('make_distributed_plan');
+
+SELECT 'the query distributes with make_distributed_plan left alone';
+-- sum() and not a bare count() so the trivial-count optimization cannot fold the plan away.
+SELECT 'distributes'
+FROM (EXPLAIN PIPELINE SELECT sum(v) FROM t_dp_workers)
+WHERE explain LIKE '%ReadFromDistributedPlanSource%' LIMIT 1;
+
+DROP TABLE t_dp_workers;
+
+SELECT 'an explicit value wins over the implication';
+SET make_distributed_plan = 0;
+SELECT getSetting('make_distributed_plan');
+
+SELECT 'and keeps winning when the workers num changes again';
+SET distributed_plan_workers_num = 5;
+SELECT getSetting('make_distributed_plan');

--- a/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.sql
+++ b/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.sql
@@ -5,7 +5,9 @@
 -- `distributed_plan_workers_num` enables `make_distributed_plan` on its own (issue #114501).
 -- Everything runs locally so that the implied plan never dials a Worker.
 
-SET distributed_plan_execute_locally = 1;
+-- A global GROUP BY limit cannot be enforced once aggregation is split per bucket, and the test
+-- server profile sets one, so clear it for the aggregation below.
+SET distributed_plan_execute_locally = 1, max_rows_to_group_by = 0;
 
 DROP TABLE IF EXISTS t_dp_workers;
 CREATE TABLE t_dp_workers (id UInt64, v UInt64) ENGINE = MergeTree ORDER BY id;

--- a/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.sql
+++ b/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.sql
@@ -3,7 +3,10 @@
 
 -- Stateless Workers only run the stages of a distributed plan, so a non-zero
 -- `distributed_plan_workers_num` enables `make_distributed_plan` on its own (issue #114501).
--- Everything runs locally so that the implied plan never dials a Worker.
+-- The environment may pin `make_distributed_plan` with a `const` constraint (ClickHouse Cloud
+-- does), and the pin vetoes the derivation, so the assertions compare against the pin
+-- (`readonly` in `system.settings`) instead of expecting fixed values. Everything runs locally
+-- so that the implied plan never dials a Worker.
 
 -- A global GROUP BY limit cannot be enforced once aggregation is split per bucket, and the test
 -- server profile sets one, so clear it for the aggregation below.
@@ -16,21 +19,21 @@ INSERT INTO t_dp_workers SELECT number, number FROM numbers(100000);
 SELECT 'off while the workers num is zero';
 SELECT getSetting('make_distributed_plan');
 
-SELECT 'implied by a per-query workers num';
-SELECT getSetting('make_distributed_plan') SETTINGS distributed_plan_workers_num = 3;
+SELECT 'implied by a per-query workers num unless pinned const';
+SELECT getSetting('make_distributed_plan') = (SELECT readonly = 0 FROM system.settings WHERE name = 'make_distributed_plan') SETTINGS distributed_plan_workers_num = 3;
 
-SELECT 'the implied plan still adjusts the settings it does not support';
-SELECT getSetting('compile_expressions') SETTINGS distributed_plan_workers_num = 3, compile_expressions = 1;
+SELECT 'the implied plan adjusts the settings it does not support, unless pinned const';
+SELECT getSetting('compile_expressions') = (SELECT readonly != 0 FROM system.settings WHERE name = 'make_distributed_plan') SETTINGS distributed_plan_workers_num = 3, compile_expressions = 1;
 
-SELECT 'implied by a session workers num';
+SELECT 'implied by a session workers num unless pinned const';
 SET distributed_plan_workers_num = 3;
-SELECT getSetting('make_distributed_plan');
+SELECT getSetting('make_distributed_plan') = (SELECT readonly = 0 FROM system.settings WHERE name = 'make_distributed_plan');
 
 SELECT 'the query distributes with make_distributed_plan left alone';
 -- sum() and not a bare count() so the trivial-count optimization cannot fold the plan away.
-SELECT 'distributes'
+SELECT (count() > 0) = (SELECT readonly = 0 FROM system.settings WHERE name = 'make_distributed_plan')
 FROM (EXPLAIN PIPELINE SELECT sum(v) FROM t_dp_workers)
-WHERE explain LIKE '%ReadFromDistributedPlanSource%' LIMIT 1;
+WHERE explain LIKE '%ReadFromDistributedPlanSource%';
 
 DROP TABLE t_dp_workers;
 

--- a/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.sql
+++ b/tests/queries/0_stateless/04869_distributed_plan_workers_num_enables_plan.sql
@@ -25,17 +25,20 @@ SELECT getSetting('make_distributed_plan') = (SELECT readonly = 0 FROM system.se
 SELECT 'the implied plan adjusts the settings it does not support, unless pinned const';
 SELECT getSetting('compile_expressions') = (SELECT readonly != 0 FROM system.settings WHERE name = 'make_distributed_plan') SETTINGS distributed_plan_workers_num = 3, compile_expressions = 1;
 
-SELECT 'implied by a session workers num unless pinned const';
-SET distributed_plan_workers_num = 3;
-SELECT getSetting('make_distributed_plan') = (SELECT readonly = 0 FROM system.settings WHERE name = 'make_distributed_plan');
-
 SELECT 'the query distributes with make_distributed_plan left alone';
--- sum() and not a bare count() so the trivial-count optimization cannot fold the plan away.
+-- The workers num rides on the explained query itself: the wrapper query has to stay local,
+-- because a distributed wrapper could not serialize its read from the EXPLAIN table function
+-- for remote execution. sum() and not a bare count() so the trivial-count optimization cannot
+-- fold the plan away.
 SELECT (count() > 0) = (SELECT readonly = 0 FROM system.settings WHERE name = 'make_distributed_plan')
-FROM (EXPLAIN PIPELINE SELECT sum(v) FROM t_dp_workers)
+FROM (EXPLAIN PIPELINE SELECT sum(v) FROM t_dp_workers SETTINGS distributed_plan_workers_num = 3)
 WHERE explain LIKE '%ReadFromDistributedPlanSource%';
 
 DROP TABLE t_dp_workers;
+
+SELECT 'implied by a session workers num unless pinned const';
+SET distributed_plan_workers_num = 3;
+SELECT getSetting('make_distributed_plan') = (SELECT readonly = 0 FROM system.settings WHERE name = 'make_distributed_plan');
 
 SELECT 'off again when the workers num goes back to zero';
 SET distributed_plan_workers_num = 0;

--- a/tests/queries/0_stateless/04870_make_distributed_plan_set_default.reference
+++ b/tests/queries/0_stateless/04870_make_distributed_plan_set_default.reference
@@ -1,7 +1,7 @@
-derived again after DEFAULT clears an explicit off
+derived again after DEFAULT clears an explicit off, unless pinned const
 false
-true
+1
 stays off after DEFAULT when no workers are configured
 false
-DEFAULT in the same statement as the workers num still derives
-true
+DEFAULT in the same statement as the workers num still derives, unless pinned const
+1

--- a/tests/queries/0_stateless/04870_make_distributed_plan_set_default.reference
+++ b/tests/queries/0_stateless/04870_make_distributed_plan_set_default.reference
@@ -1,0 +1,7 @@
+derived again after DEFAULT clears an explicit off
+false
+true
+stays off after DEFAULT when no workers are configured
+false
+DEFAULT in the same statement as the workers num still derives
+true

--- a/tests/queries/0_stateless/04870_make_distributed_plan_set_default.sql
+++ b/tests/queries/0_stateless/04870_make_distributed_plan_set_default.sql
@@ -1,0 +1,24 @@
+-- Tags: no-old-analyzer
+-- no-old-analyzer: make_distributed_plan requires the analyzer.
+
+-- `SET ... = DEFAULT` mutates settings through Context::resetSettingsToDefaultValue, a path
+-- separate from applySettingsChanges, so the implication from `distributed_plan_workers_num`
+-- must be re-established there too.
+
+SET distributed_plan_execute_locally = 1;
+
+SELECT 'derived again after DEFAULT clears an explicit off';
+SET distributed_plan_workers_num = 3;
+SET make_distributed_plan = 0;
+SELECT getSetting('make_distributed_plan');
+SET make_distributed_plan = DEFAULT;
+SELECT getSetting('make_distributed_plan');
+
+SELECT 'stays off after DEFAULT when no workers are configured';
+SET distributed_plan_workers_num = 0;
+SET make_distributed_plan = DEFAULT;
+SELECT getSetting('make_distributed_plan');
+
+SELECT 'DEFAULT in the same statement as the workers num still derives';
+SET distributed_plan_workers_num = 3, make_distributed_plan = DEFAULT;
+SELECT getSetting('make_distributed_plan');

--- a/tests/queries/0_stateless/04870_make_distributed_plan_set_default.sql
+++ b/tests/queries/0_stateless/04870_make_distributed_plan_set_default.sql
@@ -3,22 +3,23 @@
 
 -- `SET ... = DEFAULT` mutates settings through Context::resetSettingsToDefaultValue, a path
 -- separate from applySettingsChanges, so the implication from `distributed_plan_workers_num`
--- must be re-established there too.
+-- must be re-established there too. A `const` pin on `make_distributed_plan` (`readonly` in
+-- `system.settings`) vetoes the derivation, so the assertions compare against it.
 
 SET distributed_plan_execute_locally = 1;
 
-SELECT 'derived again after DEFAULT clears an explicit off';
+SELECT 'derived again after DEFAULT clears an explicit off, unless pinned const';
 SET distributed_plan_workers_num = 3;
 SET make_distributed_plan = 0;
 SELECT getSetting('make_distributed_plan');
 SET make_distributed_plan = DEFAULT;
-SELECT getSetting('make_distributed_plan');
+SELECT getSetting('make_distributed_plan') = (SELECT readonly = 0 FROM system.settings WHERE name = 'make_distributed_plan');
 
 SELECT 'stays off after DEFAULT when no workers are configured';
 SET distributed_plan_workers_num = 0;
 SET make_distributed_plan = DEFAULT;
 SELECT getSetting('make_distributed_plan');
 
-SELECT 'DEFAULT in the same statement as the workers num still derives';
+SELECT 'DEFAULT in the same statement as the workers num still derives, unless pinned const';
 SET distributed_plan_workers_num = 3, make_distributed_plan = DEFAULT;
-SELECT getSetting('make_distributed_plan');
+SELECT getSetting('make_distributed_plan') = (SELECT readonly = 0 FROM system.settings WHERE name = 'make_distributed_plan');

--- a/tests/queries/0_stateless/04871_make_distributed_plan_const_constraint.reference
+++ b/tests/queries/0_stateless/04871_make_distributed_plan_const_constraint.reference
@@ -1,0 +1,6 @@
+derived while not pinned const
+1
+dropped when the const profile arrives
+false
+not derived under the constraint
+false

--- a/tests/queries/0_stateless/04871_make_distributed_plan_const_constraint.sql
+++ b/tests/queries/0_stateless/04871_make_distributed_plan_const_constraint.sql
@@ -1,0 +1,25 @@
+-- Tags: no-old-analyzer, no-parallel
+-- no-old-analyzer: make_distributed_plan requires the analyzer.
+-- no-parallel: creates a server-global settings profile under a fixed name.
+
+-- A `const` constraint on make_distributed_plan must veto the value derived from
+-- distributed_plan_workers_num, not just explicit changes.
+
+DROP SETTINGS PROFILE IF EXISTS profile_04871;
+CREATE SETTINGS PROFILE profile_04871 SETTINGS make_distributed_plan CONST;
+
+SELECT 'derived while not pinned const';
+SET distributed_plan_workers_num = 3;
+SELECT getSetting('make_distributed_plan') = (SELECT readonly = 0 FROM system.settings WHERE name = 'make_distributed_plan');
+
+SELECT 'dropped when the const profile arrives';
+SET profile = 'profile_04871';
+SELECT getSetting('make_distributed_plan');
+
+SELECT 'not derived under the constraint';
+SET distributed_plan_workers_num = 5;
+SELECT getSetting('make_distributed_plan');
+
+SET make_distributed_plan = 1; -- { serverError SETTING_CONSTRAINT_VIOLATION }
+
+DROP SETTINGS PROFILE profile_04871;

--- a/tests/queries/0_stateless/04872_make_distributed_plan_const_profile_at_login.reference
+++ b/tests/queries/0_stateless/04872_make_distributed_plan_const_profile_at_login.reference
@@ -1,0 +1,6 @@
+derived at login without the constraint
+OK
+vetoed at login by the const constraint
+OK
+still derived in a readonly session
+OK

--- a/tests/queries/0_stateless/04872_make_distributed_plan_const_profile_at_login.reference
+++ b/tests/queries/0_stateless/04872_make_distributed_plan_const_profile_at_login.reference
@@ -2,5 +2,7 @@ derived at login without the constraint
 OK
 vetoed at login by the const constraint
 OK
+the vetoed plan does not latch its adjustments
+OK
 still derived in a readonly session
 OK

--- a/tests/queries/0_stateless/04872_make_distributed_plan_const_profile_at_login.sh
+++ b/tests/queries/0_stateless/04872_make_distributed_plan_const_profile_at_login.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Tags: no-old-analyzer
+# no-old-analyzer: make_distributed_plan requires the analyzer.
+
+# The constraints of the user's own profile arrive at login, after the profile's settings are
+# applied. A `const` constraint there must still veto the make_distributed_plan derivation
+# from the profile's distributed_plan_workers_num. The environment itself may already pin the
+# setting const for every user (ClickHouse Cloud does); the probe below reads the ambient pin
+# from a readonly=0 session, and the expectations follow it.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+FREE_USER="u_free_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+FREE_PROFILE="p_free_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+PINNED_USER="u_pinned_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+PINNED_PROFILE="p_pinned_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+READONLY_USER="u_readonly_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+READONLY_PROFILE="p_readonly_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+
+cleanup()
+{
+    ${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS ${FREE_USER}, ${PINNED_USER}, ${READONLY_USER}"
+    ${CLICKHOUSE_CLIENT} -q "DROP SETTINGS PROFILE IF EXISTS ${FREE_PROFILE}, ${PINNED_PROFILE}, ${READONLY_PROFILE}"
+}
+trap cleanup EXIT
+cleanup
+
+AMBIENT_PIN=$(${CLICKHOUSE_CLIENT} -q "SELECT readonly FROM system.settings WHERE name = 'make_distributed_plan'")
+if [ "${AMBIENT_PIN}" == "0" ]; then EXPECTED_DERIVED="true"; else EXPECTED_DERIVED="false"; fi
+
+${CLICKHOUSE_CLIENT} -q "CREATE SETTINGS PROFILE ${FREE_PROFILE} SETTINGS distributed_plan_workers_num = 3"
+${CLICKHOUSE_CLIENT} -q "CREATE USER ${FREE_USER} SETTINGS PROFILE ${FREE_PROFILE}"
+
+${CLICKHOUSE_CLIENT} -q "CREATE SETTINGS PROFILE ${PINNED_PROFILE} SETTINGS distributed_plan_workers_num = 3, make_distributed_plan CONST"
+${CLICKHOUSE_CLIENT} -q "CREATE USER ${PINNED_USER} SETTINGS PROFILE ${PINNED_PROFILE}"
+
+${CLICKHOUSE_CLIENT} -q "CREATE SETTINGS PROFILE ${READONLY_PROFILE} SETTINGS readonly = 1, distributed_plan_workers_num = 3"
+${CLICKHOUSE_CLIENT} -q "CREATE USER ${READONLY_USER} SETTINGS PROFILE ${READONLY_PROFILE}"
+
+check()
+{
+    local label=$1 user=$2 expected=$3
+    local actual
+    # The bare binary, not ${CLICKHOUSE_CLIENT}: the harness options it carries (send_logs_level,
+    # log_comment, randomized settings) are rejected at query start by a readonly=1 session.
+    actual=$(${CLICKHOUSE_CLIENT_BINARY} --host "${CLICKHOUSE_HOST}" --port "${CLICKHOUSE_PORT_TCP}" --user "${user}" -q "SELECT getSetting('make_distributed_plan')")
+    echo "${label}"
+    if [ "${actual}" == "${expected}" ]; then echo "OK"; else echo "FAIL: got ${actual}, expected ${expected}"; fi
+}
+
+check "derived at login without the constraint" "${FREE_USER}" "${EXPECTED_DERIVED}"
+check "vetoed at login by the const constraint" "${PINNED_USER}" "false"
+check "still derived in a readonly session" "${READONLY_USER}" "${EXPECTED_DERIVED}"

--- a/tests/queries/0_stateless/04872_make_distributed_plan_const_profile_at_login.sh
+++ b/tests/queries/0_stateless/04872_make_distributed_plan_const_profile_at_login.sh
@@ -7,6 +7,11 @@
 # from the profile's distributed_plan_workers_num. The environment itself may already pin the
 # setting const for every user (ClickHouse Cloud does); the probe below reads the ambient pin
 # from a readonly=0 session, and the expectations follow it.
+#
+# A vetoed derivation must also leave no trace: the settings adjusted for distributed plans
+# must keep their profile values (`compile_expressions = 1` is the probe), not latch the
+# adjusted ones. That requires judging the derivation under the incoming profile's own
+# constraints rather than the ones it replaces.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -33,7 +38,7 @@ if [ "${AMBIENT_PIN}" == "0" ]; then EXPECTED_DERIVED="true"; else EXPECTED_DERI
 ${CLICKHOUSE_CLIENT} -q "CREATE SETTINGS PROFILE ${FREE_PROFILE} SETTINGS distributed_plan_workers_num = 3"
 ${CLICKHOUSE_CLIENT} -q "CREATE USER ${FREE_USER} SETTINGS PROFILE ${FREE_PROFILE}"
 
-${CLICKHOUSE_CLIENT} -q "CREATE SETTINGS PROFILE ${PINNED_PROFILE} SETTINGS distributed_plan_workers_num = 3, make_distributed_plan CONST"
+${CLICKHOUSE_CLIENT} -q "CREATE SETTINGS PROFILE ${PINNED_PROFILE} SETTINGS distributed_plan_workers_num = 3, compile_expressions = 1, make_distributed_plan CONST"
 ${CLICKHOUSE_CLIENT} -q "CREATE USER ${PINNED_USER} SETTINGS PROFILE ${PINNED_PROFILE}"
 
 ${CLICKHOUSE_CLIENT} -q "CREATE SETTINGS PROFILE ${READONLY_PROFILE} SETTINGS readonly = 1, distributed_plan_workers_num = 3"
@@ -41,15 +46,16 @@ ${CLICKHOUSE_CLIENT} -q "CREATE USER ${READONLY_USER} SETTINGS PROFILE ${READONL
 
 check()
 {
-    local label=$1 user=$2 expected=$3
+    local label=$1 user=$2 setting=$3 expected=$4
     local actual
     # The bare binary, not ${CLICKHOUSE_CLIENT}: the harness options it carries (send_logs_level,
     # log_comment, randomized settings) are rejected at query start by a readonly=1 session.
-    actual=$(${CLICKHOUSE_CLIENT_BINARY} --host "${CLICKHOUSE_HOST}" --port "${CLICKHOUSE_PORT_TCP}" --user "${user}" -q "SELECT getSetting('make_distributed_plan')")
+    actual=$(${CLICKHOUSE_CLIENT_BINARY} --host "${CLICKHOUSE_HOST}" --port "${CLICKHOUSE_PORT_TCP}" --user "${user}" -q "SELECT getSetting('${setting}')")
     echo "${label}"
     if [ "${actual}" == "${expected}" ]; then echo "OK"; else echo "FAIL: got ${actual}, expected ${expected}"; fi
 }
 
-check "derived at login without the constraint" "${FREE_USER}" "${EXPECTED_DERIVED}"
-check "vetoed at login by the const constraint" "${PINNED_USER}" "false"
-check "still derived in a readonly session" "${READONLY_USER}" "${EXPECTED_DERIVED}"
+check "derived at login without the constraint" "${FREE_USER}" make_distributed_plan "${EXPECTED_DERIVED}"
+check "vetoed at login by the const constraint" "${PINNED_USER}" make_distributed_plan "false"
+check "the vetoed plan does not latch its adjustments" "${PINNED_USER}" compile_expressions "true"
+check "still derived in a readonly session" "${READONLY_USER}" make_distributed_plan "${EXPECTED_DERIVED}"

--- a/tests/queries/0_stateless/04872_make_distributed_plan_const_profile_at_login.sh
+++ b/tests/queries/0_stateless/04872_make_distributed_plan_const_profile_at_login.sh
@@ -9,9 +9,11 @@
 # from a readonly=0 session, and the expectations follow it.
 #
 # A vetoed derivation must also leave no trace: the settings adjusted for distributed plans
-# must keep their profile values (`compile_expressions = 1` is the probe), not latch the
-# adjusted ones. That requires judging the derivation under the incoming profile's own
-# constraints rather than the ones it replaces.
+# must keep their profile values (`compile_expressions = 1` is the probe). This holds the
+# server to judging the derivation under the incoming profile's own constraints, and the
+# client to not deriving at all - a client context has no constraints, and its adjustments
+# would ride back to the server as explicit changes when it applies the pushed session
+# settings.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04873_make_distributed_plan_range_constraint.reference
+++ b/tests/queries/0_stateless/04873_make_distributed_plan_range_constraint.reference
@@ -1,0 +1,2 @@
+not derived under the range constraint
+false

--- a/tests/queries/0_stateless/04873_make_distributed_plan_range_constraint.sql
+++ b/tests/queries/0_stateless/04873_make_distributed_plan_range_constraint.sql
@@ -1,0 +1,22 @@
+-- Tags: no-old-analyzer, no-parallel
+-- no-old-analyzer: make_distributed_plan requires the analyzer.
+-- no-parallel: creates a server-global settings profile under a fixed name.
+
+-- A range constraint that forbids the enabled value must veto the `make_distributed_plan`
+-- derivation exactly like a `const` pin does. Where the environment already pins the setting
+-- const for every user (ClickHouse Cloud does), `CREATE SETTINGS PROFILE` below fails with
+-- `should not be changed`, which the Cloud test harness treats as a skip, so the expectations
+-- assume no ambient pin.
+
+DROP SETTINGS PROFILE IF EXISTS profile_04873;
+CREATE SETTINGS PROFILE profile_04873 SETTINGS make_distributed_plan MAX 0;
+
+SET profile = 'profile_04873';
+
+SELECT 'not derived under the range constraint';
+SET distributed_plan_workers_num = 3;
+SELECT getSetting('make_distributed_plan');
+
+SET make_distributed_plan = 1; -- { serverError SETTING_CONSTRAINT_VIOLATION }
+
+DROP SETTINGS PROFILE profile_04873;

--- a/tests/queries/0_stateless/04874_make_distributed_plan_adjustments_restore.reference
+++ b/tests/queries/0_stateless/04874_make_distributed_plan_adjustments_restore.reference
@@ -1,0 +1,8 @@
+the derived plan adjusts an explicitly set value, unless pinned const
+1
+the explicitly set value returns when the workers num goes back to zero
+true
+and no other setting keeps a trace of the derived window
+0
+a value set explicitly during the window survives the restore
+false

--- a/tests/queries/0_stateless/04874_make_distributed_plan_adjustments_restore.sql
+++ b/tests/queries/0_stateless/04874_make_distributed_plan_adjustments_restore.sql
@@ -1,0 +1,38 @@
+-- Tags: no-old-analyzer
+-- no-old-analyzer: make_distributed_plan requires the analyzer.
+
+-- A derived distributed plan force-adjusts the settings it does not support. Turning the
+-- workers num back to zero must undo those adjustments: a session that briefly asked for
+-- Workers must not keep degraded settings for its later ordinary queries. The assertions
+-- compare snapshots instead of fixed values, so they hold under randomized harness settings
+-- and under an ambient const pin on `make_distributed_plan` (ClickHouse Cloud), where the
+-- derivation never fires and nothing moves at all.
+
+SET compile_expressions = 1;
+
+CREATE TEMPORARY TABLE settings_before AS SELECT name, value, changed FROM system.settings;
+
+SET distributed_plan_workers_num = 3;
+
+SELECT 'the derived plan adjusts an explicitly set value, unless pinned const';
+SELECT getSetting('compile_expressions') = (SELECT readonly != 0 FROM system.settings WHERE name = 'make_distributed_plan');
+
+SET distributed_plan_workers_num = 0;
+
+SELECT 'the explicitly set value returns when the workers num goes back to zero';
+SELECT getSetting('compile_expressions');
+
+SELECT 'and no other setting keeps a trace of the derived window';
+SELECT count()
+FROM system.settings s
+JOIN settings_before b USING (name)
+WHERE (s.value != b.value OR s.changed != b.changed) AND name != 'distributed_plan_workers_num';
+
+SELECT 'a value set explicitly during the window survives the restore';
+-- Pinned explicitly: the harness randomizes this setting, and a window only remembers a setting
+-- it actually overrides.
+SET use_skip_indexes_on_data_read = 1;
+SET distributed_plan_workers_num = 3;
+SET use_skip_indexes_on_data_read = 0;
+SET distributed_plan_workers_num = 0;
+SELECT getSetting('use_skip_indexes_on_data_read');

--- a/tests/queries/0_stateless/04874_make_distributed_plan_adjustments_restore.sql
+++ b/tests/queries/0_stateless/04874_make_distributed_plan_adjustments_restore.sql
@@ -23,10 +23,14 @@ SELECT 'the explicitly set value returns when the workers num goes back to zero'
 SELECT getSetting('compile_expressions');
 
 SELECT 'and no other setting keeps a trace of the derived window';
+-- Both snapshots go through the same statement shape: the analyzer mutates some per-query
+-- settings (e.g. `parallel_replicas_for_cluster_engines`) on a plain SELECT context but not
+-- on the inner context of CREATE ... AS SELECT, and a shape mismatch would show that noise.
+CREATE TEMPORARY TABLE settings_after AS SELECT name, value, changed FROM system.settings;
 SELECT count()
-FROM system.settings s
+FROM settings_after a
 JOIN settings_before b USING (name)
-WHERE (s.value != b.value OR s.changed != b.changed) AND name != 'distributed_plan_workers_num';
+WHERE (a.value != b.value OR a.changed != b.changed) AND name != 'distributed_plan_workers_num';
 
 SELECT 'a value set explicitly during the window survives the restore';
 -- Pinned explicitly: the harness randomizes this setting, and a window only remembers a setting

--- a/tests/queries/0_stateless/04875_distributed_plan_derived_local_fragments_keep_overrides.reference
+++ b/tests/queries/0_stateless/04875_distributed_plan_derived_local_fragments_keep_overrides.reference
@@ -1,0 +1,5 @@
+join with a skip-index filter and a JIT-eligible expression matches single-node
+500	12475500
+500	12475500
+local fragment tasks run with the unsupported settings disabled
+0	0

--- a/tests/queries/0_stateless/04875_distributed_plan_derived_local_fragments_keep_overrides.sql
+++ b/tests/queries/0_stateless/04875_distributed_plan_derived_local_fragments_keep_overrides.sql
@@ -1,0 +1,63 @@
+-- Tags: no-old-analyzer
+-- no-old-analyzer: make_distributed_plan requires the analyzer.
+
+-- Same invariant as 04656, but with the plan derived from `distributed_plan_workers_num`
+-- instead of set explicitly: local fragment contexts are cloned from the initiator and turn
+-- `make_distributed_plan` off to run their already-split fragments, and that clone must keep
+-- the adjusted settings (`compile_expressions` and friends) rather than restore the values
+-- remembered on the initiator - for a fragment the adjustments are the point.
+
+-- Where the environment pins `make_distributed_plan` const (ClickHouse Cloud), the statement
+-- below fails with `should not be changed` and the harness skips the test; the derivation the
+-- test needs would be vetoed there anyway. Upstream, DEFAULT clears the explicit flag again so
+-- the derivation stays in charge.
+SET make_distributed_plan = 1;
+SET make_distributed_plan = DEFAULT;
+
+DROP TABLE IF EXISTS t_dp_big;
+DROP TABLE IF EXISTS t_dp_small;
+
+CREATE TABLE t_dp_big (id UInt64, v UInt64, INDEX idx_v v TYPE minmax GRANULARITY 1)
+    ENGINE = MergeTree ORDER BY id;
+CREATE TABLE t_dp_small (id UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_dp_big SELECT number, number FROM numbers(100000);
+INSERT INTO t_dp_small SELECT number * 100 FROM numbers(1000);
+
+SET distributed_plan_workers_num = 3, distributed_plan_execute_locally = 1,
+    distributed_plan_max_rows_to_broadcast = 0, distributed_plan_default_reader_bucket_count = 3,
+    distributed_plan_default_shuffle_join_bucket_count = 3, max_rows_to_group_by = 0,
+    enable_join_runtime_filters = 0;
+
+SET use_skip_indexes_on_data_read = 1, compile_expressions = 1, min_count_to_compile_expression = 0;
+SET log_comment = '04875_distributed_plan_derived_local_fragments';
+
+SELECT 'join with a skip-index filter and a JIT-eligible expression matches single-node';
+SELECT count(), sum(b.v + 1) FROM t_dp_big AS b INNER JOIN t_dp_small AS s ON b.v = s.id
+    WHERE b.v < 50000;
+SELECT count(), sum(b.v + 1) FROM t_dp_big AS b INNER JOIN t_dp_small AS s ON b.v = s.id
+    WHERE b.v < 50000
+    SETTINGS distributed_plan_workers_num = 0;
+
+SELECT 'local fragment tasks run with the unsupported settings disabled';
+SYSTEM FLUSH LOGS query_log;
+-- Task entries log the task id ('main', 'stage_N_M' - not SQL) as the query text and share the
+-- initiator's query_id; their Settings column shows the task context. Scoping to the query_id of
+-- the latest 'main' task makes the probe immune to earlier runs in the same database, and the
+-- task-id filter excludes the initiator row. The probe runs with the workers num at zero so it
+-- does not spawn 'main' tasks of its own.
+SELECT DISTINCT Settings['use_skip_indexes_on_data_read'], Settings['compile_expressions']
+FROM system.query_log
+WHERE event_date >= yesterday() AND type = 'QueryStart'
+  AND query NOT ILIKE '%SELECT%'
+  AND query_id = (
+      SELECT query_id FROM system.query_log
+      WHERE event_date >= yesterday() AND type = 'QueryStart'
+        AND current_database = currentDatabase()
+        AND Settings['log_comment'] = '04875_distributed_plan_derived_local_fragments'
+        AND query = 'main'
+      ORDER BY event_time_microseconds DESC
+      LIMIT 1)
+SETTINGS distributed_plan_workers_num = 0;
+
+DROP TABLE t_dp_big;
+DROP TABLE t_dp_small;


### PR DESCRIPTION
Leasing Stateless Workers only makes sense for a distributed query plan, so `distributed_plan_workers_num` no longer has to be paired with `make_distributed_plan`: a non-zero Worker count enables the plan on its own. An explicit `make_distributed_plan` still wins if provided.

The implication is applied before the adjustments added in https://github.com/ClickHouse/ClickHouse/pull/112463, so an implied plan still turns off the features it does not support yet.

The derivation is judged under the session's settings constraints: any constraint that forbids enabling `make_distributed_plan` (a `const` pin, a range, a disallowed value) silently vetoes it. A derived plan leaves no trace: the compatibility overrides it applies are remembered and restored when the workers count returns to zero, while an explicitly enabled plan keeps its existing latch semantics. The memory is local to the settings object, so fragment and worker contexts cloned from the initiator keep the overrides. Client-side contexts (`clickhouse-client`, `clickhouse-benchmark`) never derive: they apply server-pushed session settings without constraints and would echo the adjustments back to the server as explicit changes.

Closes: https://github.com/ClickHouse/ClickHouse/issues/114501
Related: https://github.com/ClickHouse/ClickHouse/pull/112463

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Setting `distributed_plan_workers_num` to a non-zero value now enables `make_distributed_plan` automatically, unless that setting is set explicitly.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114504&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114504](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114504+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

