### PR TITLE
Raise a catchable error instead of LOGICAL_ERROR on spec-violating Iceberg metadata

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
@@ -695,7 +695,7 @@ std::shared_ptr<ActionsDAG> IcebergSchemaProcessor::getSchemaTransformationDag(
                 if (old_json->isObject(f_type) && !field->isObject(f_type))
                 {
                     throw Exception(
-                        ErrorCodes::LOGICAL_ERROR,
+                        ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
                         "Can't cast primitive type to the complex type, field id is {}, old schema id is {}, new schema id is {}",
                         id,
                         old_id,
@@ -727,7 +727,7 @@ std::shared_ptr<ActionsDAG> IcebergSchemaProcessor::getSchemaTransformationDag(
             if (!type->isNullable() && !field->isObject(f_type))
             {
                 throw Exception(
-                    ErrorCodes::LOGICAL_ERROR,
+                    ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
                     "Cannot add a column with id {} with required values to the table during schema evolution. This is forbidden by "
                     "Iceberg format specification. Old schema id is {}, new "
                     "schema id is {}",
@@ -787,7 +787,7 @@ void IcebergSchemaProcessor::registerSnapshotWithSchemaId(Int64 snapshot_id, Int
         if (old_id != schema_id)
         {
             throw Exception(
-                ErrorCodes::LOGICAL_ERROR,
+                ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
                 "Snapshot with id {} already registered with schema id {}, trying to register with new schema id {}",
                 snapshot_id,
                 old_id,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
@@ -684,6 +684,15 @@ std::shared_ptr<ActionsDAG> IcebergSchemaProcessor::getSchemaTransformationDag(
                     || field->getObject(f_type)->getValue<std::string>(f_type) == "list"
                     || field->getObject(f_type)->getValue<std::string>(f_type) == "map"))
             {
+                if (!old_json->isObject(f_type))
+                {
+                    throw Exception(
+                        ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
+                        "Can't cast primitive type to the complex type, field id is {}, old schema id is {}, new schema id is {}",
+                        id,
+                        old_id,
+                        new_id);
+                }
                 auto old_type = getFieldType(old_json, "type", required);
                 auto transform = std::make_shared<EvolutionFunctionStruct>(DataTypes{type}, DataTypes{old_type}, old_json, field);
                 old_node = &dag->addFunction(transform, std::vector<const Node *>{old_node}, name);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
@@ -696,7 +696,7 @@ std::shared_ptr<ActionsDAG> IcebergSchemaProcessor::getSchemaTransformationDag(
                 {
                     throw Exception(
                         ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
-                        "Can't cast primitive type to the complex type, field id is {}, old schema id is {}, new schema id is {}",
+                        "Can't cast complex type to the primitive type, field id is {}, old schema id is {}, new schema id is {}",
                         id,
                         old_id,
                         new_id);

--- a/tests/queries/0_stateless/04890_iceberg_metadata_spec_violation_no_abort.reference
+++ b/tests/queries/0_stateless/04890_iceberg_metadata_spec_violation_no_abort.reference
@@ -1,0 +1,8 @@
+1
+required column rejected
+1
+complex to primitive rejected
+1
+snapshot schema rebinding rejected
+alive
+OK

--- a/tests/queries/0_stateless/04890_iceberg_metadata_spec_violation_no_abort.reference
+++ b/tests/queries/0_stateless/04890_iceberg_metadata_spec_violation_no_abort.reference
@@ -4,5 +4,7 @@ required column rejected
 complex to primitive rejected
 1
 snapshot schema rebinding rejected
+1
+primitive to complex rejected
 alive
 OK

--- a/tests/queries/0_stateless/04890_iceberg_metadata_spec_violation_no_abort.sh
+++ b/tests/queries/0_stateless/04890_iceberg_metadata_spec_violation_no_abort.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-replicated-database
+# Tag no-replicated-database: IcebergLocal is non-replicated.
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/114487
+# Three validators in the Iceberg schema path reject spec-violating metadata
+# content. They used to raise LOGICAL_ERROR, which aborts the server in debug and
+# sanitizer builds and under abort_on_logical_error. Each must now raise a clean
+# ICEBERG_SPECIFICATION_VIOLATION, leaving the server up.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# --- Arm 1: a new field with no counterpart in the old schema is "required" ----
+
+TABLE1="t1_${CLICKHOUSE_DATABASE}_${RANDOM}"
+PATH1="${USER_FILES_PATH}/${TABLE1}/"
+rm -rf "${PATH1}" 2>/dev/null
+
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${TABLE1} (c0 Int32, c1 String) ENGINE = IcebergLocal('${PATH1}')"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE1} VALUES (1, 'a')"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE1}"
+
+LATEST1=$(ls "${PATH1}metadata/" | grep -E '^v[0-9]+\.metadata\.json$' | sort -t v -k2 -n | tail -1)
+python3 - "${PATH1}metadata" "${LATEST1}" <<'PY'
+import copy, json, os, re, sys
+
+metadata_dir, latest_file = sys.argv[1], sys.argv[2]
+with open(os.path.join(metadata_dir, latest_file)) as fh:
+    metadata = json.load(fh)
+
+schema = copy.deepcopy(metadata["schemas"][0])
+schema["schema-id"] = 1
+schema["fields"].append({"id": 3, "name": "extra", "required": True, "type": "long"})
+metadata["schemas"].append(schema)
+metadata["current-schema-id"] = 1
+metadata["last-column-id"] = 3
+metadata["last-updated-ms"] = metadata.get("last-updated-ms", 0) + 60000
+
+version = int(re.match(r"v(\d+)\.metadata\.json", latest_file).group(1)) + 1
+tmp_file = os.path.join(metadata_dir, ".tmp_next")
+with open(tmp_file, "w") as fh:
+    json.dump(metadata, fh)
+os.rename(tmp_file, os.path.join(metadata_dir, f"v{version}.metadata.json"))
+PY
+
+${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT * FROM ${TABLE1}" 2>&1 \
+    | grep -q -F "ICEBERG_SPECIFICATION_VIOLATION" && echo "required column rejected" || echo "NOT REJECTED"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE1}"
+rm -rf "${PATH1}" 2>/dev/null
+
+# --- Arm 2: an old struct-typed field becomes a primitive in the new schema ----
+
+TABLE2="t2_${CLICKHOUSE_DATABASE}_${RANDOM}"
+PATH2="${USER_FILES_PATH}/${TABLE2}/"
+rm -rf "${PATH2}" 2>/dev/null
+
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${TABLE2} (c0 Int32, s Tuple(a Int32, b String)) ENGINE = IcebergLocal('${PATH2}')"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE2} VALUES (1, (1, 'b'))"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE2}"
+
+LATEST2=$(ls "${PATH2}metadata/" | grep -E '^v[0-9]+\.metadata\.json$' | sort -t v -k2 -n | tail -1)
+python3 - "${PATH2}metadata" "${LATEST2}" <<'PY'
+import copy, json, os, re, sys
+
+metadata_dir, latest_file = sys.argv[1], sys.argv[2]
+with open(os.path.join(metadata_dir, latest_file)) as fh:
+    metadata = json.load(fh)
+
+schema = copy.deepcopy(metadata["schemas"][0])
+schema["schema-id"] = 1
+for field in schema["fields"]:
+    if field["name"] == "s":
+        field["type"] = "long"
+metadata["schemas"].append(schema)
+metadata["current-schema-id"] = 1
+metadata["last-updated-ms"] = metadata.get("last-updated-ms", 0) + 60000
+
+version = int(re.match(r"v(\d+)\.metadata\.json", latest_file).group(1)) + 1
+tmp_file = os.path.join(metadata_dir, ".tmp_next")
+with open(tmp_file, "w") as fh:
+    json.dump(metadata, fh)
+os.rename(tmp_file, os.path.join(metadata_dir, f"v{version}.metadata.json"))
+PY
+
+${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT * FROM ${TABLE2}" 2>&1 \
+    | grep -q -F "ICEBERG_SPECIFICATION_VIOLATION" && echo "complex to primitive rejected" || echo "NOT REJECTED"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE2}"
+rm -rf "${PATH2}" 2>/dev/null
+
+# --- Arm 3: one snapshot-id bound to two different schema-ids ------------------
+
+TABLE3="t3_${CLICKHOUSE_DATABASE}_${RANDOM}"
+PATH3="${USER_FILES_PATH}/${TABLE3}/"
+rm -rf "${PATH3}" 2>/dev/null
+
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${TABLE3} (c0 Int32, c1 String) ENGINE = IcebergLocal('${PATH3}')"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE3} VALUES (1, 'c')"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE3}"
+
+LATEST3=$(ls "${PATH3}metadata/" | grep -E '^v[0-9]+\.metadata\.json$' | sort -t v -k2 -n | tail -1)
+python3 - "${PATH3}metadata" "${LATEST3}" <<'PY'
+import copy, json, os, re, sys
+
+metadata_dir, latest_file = sys.argv[1], sys.argv[2]
+with open(os.path.join(metadata_dir, latest_file)) as fh:
+    metadata = json.load(fh)
+
+schema = copy.deepcopy(metadata["schemas"][0])
+schema["schema-id"] = 1
+metadata["schemas"].append(schema)
+
+snapshot = copy.deepcopy(metadata["snapshots"][0])
+snapshot["schema-id"] = 1
+metadata["snapshots"].append(snapshot)
+metadata["last-updated-ms"] = metadata.get("last-updated-ms", 0) + 60000
+
+version = int(re.match(r"v(\d+)\.metadata\.json", latest_file).group(1)) + 1
+tmp_file = os.path.join(metadata_dir, ".tmp_next")
+with open(tmp_file, "w") as fh:
+    json.dump(metadata, fh)
+os.rename(tmp_file, os.path.join(metadata_dir, f"v{version}.metadata.json"))
+PY
+
+${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT * FROM ${TABLE3}" 2>&1 \
+    | grep -q -F "ICEBERG_SPECIFICATION_VIOLATION" && echo "snapshot schema rebinding rejected" || echo "NOT REJECTED"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE3}"
+rm -rf "${PATH3}" 2>/dev/null
+
+# The server must still be alive: none of the three rejections aborted it.
+${CLICKHOUSE_CLIENT} --query "SELECT 'alive'"
+
+echo "OK"

--- a/tests/queries/0_stateless/04890_iceberg_metadata_spec_violation_no_abort.sh
+++ b/tests/queries/0_stateless/04890_iceberg_metadata_spec_violation_no_abort.sh
@@ -3,7 +3,7 @@
 # Tag no-replicated-database: IcebergLocal is non-replicated.
 
 # Regression test for https://github.com/ClickHouse/ClickHouse/issues/114487
-# Three validators in the Iceberg schema path reject spec-violating metadata
+# Four validators in the Iceberg schema path reject spec-violating metadata
 # content. They used to raise LOGICAL_ERROR, which aborts the server in debug and
 # sanitizer builds and under abort_on_logical_error. Each must now raise a clean
 # ICEBERG_SPECIFICATION_VIOLATION, leaving the server up.
@@ -131,7 +131,48 @@ ${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT * FROM ${
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE3}"
 rm -rf "${PATH3}" 2>/dev/null
 
-# The server must still be alive: none of the three rejections aborted it.
+# --- Arm 4: an old primitive field becomes a struct in the new schema ----------
+
+TABLE4="t4_${CLICKHOUSE_DATABASE}_${RANDOM}"
+PATH4="${USER_FILES_PATH}/${TABLE4}/"
+rm -rf "${PATH4}" 2>/dev/null
+
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${TABLE4} (c0 Int32, p Int64) ENGINE = IcebergLocal('${PATH4}')"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE4} VALUES (1, 42)"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE4}"
+
+LATEST4=$(ls "${PATH4}metadata/" | grep -E '^v[0-9]+\.metadata\.json$' | sort -t v -k2 -n | tail -1)
+python3 - "${PATH4}metadata" "${LATEST4}" <<'PY'
+import copy, json, os, re, sys
+
+metadata_dir, latest_file = sys.argv[1], sys.argv[2]
+with open(os.path.join(metadata_dir, latest_file)) as fh:
+    metadata = json.load(fh)
+
+schema = copy.deepcopy(metadata["schemas"][0])
+schema["schema-id"] = 1
+for field in schema["fields"]:
+    if field["name"] == "p":
+        field["type"] = {"type": "struct", "fields": [{"id": 5, "name": "a", "required": False, "type": "long"}]}
+metadata["schemas"].append(schema)
+metadata["current-schema-id"] = 1
+metadata["last-column-id"] = 5
+metadata["last-updated-ms"] = metadata.get("last-updated-ms", 0) + 60000
+
+version = int(re.match(r"v(\d+)\.metadata\.json", latest_file).group(1)) + 1
+tmp_file = os.path.join(metadata_dir, ".tmp_next")
+with open(tmp_file, "w") as fh:
+    json.dump(metadata, fh)
+os.rename(tmp_file, os.path.join(metadata_dir, f"v{version}.metadata.json"))
+PY
+
+${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT * FROM ${TABLE4}" 2>&1 \
+    | grep -q -F "ICEBERG_SPECIFICATION_VIOLATION" && echo "primitive to complex rejected" || echo "NOT REJECTED"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE4}"
+rm -rf "${PATH4}" 2>/dev/null
+
+# The server must still be alive: none of the four rejections aborted it.
 ${CLICKHOUSE_CLIENT} --query "SELECT 'alive'"
 
 echo "OK"


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/114487

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reading an Iceberg table whose metadata describes a schema evolution that the Iceberg specification forbids no longer aborts the server. Four spec violations in `IcebergSchemaProcessor` were reported as `LOGICAL_ERROR`, which is treated as a failed assertion, or reached a fatal assertion unchecked; they now raise `ICEBERG_SPECIFICATION_VIOLATION`.

### Description

Validators in `IcebergSchemaProcessor` reject genuinely invalid Iceberg metadata, but did so with `ErrorCodes::LOGICAL_ERROR`, which `Exception::handleErrorCode` treats as a failed assertion (`src/Common/Exception.cpp:112-116`). Metadata content alone took the server down: no `ALTER`, no write path, a corrupt or crafted `.metadata.json` is enough.

The three existing detections are correct, so only their error code changes. A fourth shape had no check.

Sites fixed, all reachable from metadata content:

- `getSchemaTransformationDag`: an old struct/list/map field becomes a primitive. Its message named the opposite direction and is corrected.
- `getSchemaTransformationDag`: a new field with no old counterpart is `required` with no default. The frame in the reported stack.
- `registerSnapshotWithSchemaId`: one `snapshot-id` bound to two `schema-id`s. Not named in the issue, but `IcebergMetadata.cpp:384-389` registers every entry of the `snapshots` array, both values read straight out of the JSON.
- `getSchemaTransformationDag`: the mirror shape, an old primitive becoming a struct, list or map. The complex branch keyed off the new field's type alone, so it built `EvolutionFunctionStruct` and aborted in its `lazyInitialize` `chassert` instead of reporting anything. Now rejected before the transform is built.

This file uses both conventions. `Utils.cpp:1196-1199` picks 743 over `BAD_ARGUMENTS` for a versioned specification rule broken by a file being read, which is what all four sites are, matching `SchemaProcessor.cpp:419`; `MetadataGenerator.cpp:452` keeps `BAD_ARGUMENTS` for the write path.

The exposure is wider than the issue states: `abort_on_logical_error` (`ServerSettings.cpp:1433`) is linked by `tests/config/install.sh:244-246` for every non-fast-test stateless run, so release-build CI aborts here too.

Not touched: `SchemaProcessor.cpp:189/194` fire when stringifying an already-parsed object, a genuine internal invariant. Manifest-file sites need their own proof.

A new stateless test covers all four sites. On master it kills the server (`[ FAIL ] Reason: server died`); with the fix each returns `Code: 743`, and 50/50 randomized runs pass.
