### PR TITLE
Require full field consumption on every Regexp escaping rule

### DIFF
--- a/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
@@ -117,7 +117,7 @@ bool RegexpRowInputFormat::readField(size_t index, MutableColumns & columns)
         /// value, while the `Raw` reader stops there. A field equal to the null representation keeps
         /// that reader, which owns the rule's null token where a null-aware one is selected at all.
         const bool null_token_is_live
-            = isNullableOrLowCardinalityNullable(type) || format_settings.null_as_default;
+            = isNullableOrLowCardinalityNullable(type) || isVariant(type) || format_settings.null_as_default;
         if (escaping_rule == FormatSettings::EscapingRule::Raw
             && matched_field.find('\t') != std::string_view::npos
             && !(null_token_is_live && matched_field == format_settings.tsv.null_representation))

--- a/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
@@ -115,10 +115,12 @@ bool RegexpRowInputFormat::readField(size_t index, MutableColumns & columns)
         bool read;
         /// A capture group is a whole field with no delimiter, so a tab inside it belongs to the
         /// value, while the `Raw` reader stops there. A field equal to the null representation keeps
-        /// that reader, which owns the rule's null token.
+        /// that reader, which owns the rule's null token where a null-aware one is selected at all.
+        const bool null_token_is_live
+            = isNullableOrLowCardinalityNullable(type) || format_settings.null_as_default;
         if (escaping_rule == FormatSettings::EscapingRule::Raw
             && matched_field.find('\t') != std::string_view::npos
-            && matched_field != format_settings.tsv.null_representation)
+            && !(null_token_is_live && matched_field == format_settings.tsv.null_representation))
         {
             if (format_settings.null_as_default && !isNullableOrLowCardinalityNullable(type))
                 read = SerializationNullable::deserializeNullAsDefaultOrNestedWholeText(

--- a/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <base/find_symbols.h>
 #include <Processors/Formats/Impl/RegexpRowInputFormat.h>
+#include <DataTypes/IDataType.h>
 #include <DataTypes/Serializations/SerializationNullable.h>
 #include <Formats/EscapingRuleUtils.h>
 #include <Formats/FormatFactory.h>
@@ -111,13 +112,39 @@ bool RegexpRowInputFormat::readField(size_t index, MutableColumns & columns)
     ReadBuffer field_buf(const_cast<char *>(matched_field.data()), matched_field.size(), 0);
     try
     {
-        bool read = deserializeFieldByEscapingRule(type, serializations[index], *columns[index], field_buf, escaping_rule, format_settings);
-        /// A capture group is the whole field, so the value must consume it entirely. The `Quoted`
-        /// readers stop at the first character that cannot belong to the value, and in a stream-based
-        /// format the leftover would fail the subsequent delimiter check; here there is no delimiter,
-        /// so without this check a trailing unparsed rest would be silently discarded (for example, a
-        /// fractional timestamp read by the integer-only compatibility parser would lose its fraction).
-        if (escaping_rule == FormatSettings::EscapingRule::Quoted && !field_buf.eof())
+        bool read;
+        /// A capture group is a whole field with no delimiter, so a tab inside it belongs to the
+        /// value, while the `Raw` reader stops there. A field equal to the null representation keeps
+        /// that reader, which owns the rule's null token.
+        if (escaping_rule == FormatSettings::EscapingRule::Raw
+            && matched_field.find('\t') != std::string_view::npos
+            && matched_field != format_settings.tsv.null_representation)
+        {
+            if (format_settings.null_as_default && !isNullableOrLowCardinalityNullable(type))
+                read = SerializationNullable::deserializeNullAsDefaultOrNestedWholeText(
+                    *columns[index], field_buf, format_settings, serializations[index]);
+            else
+            {
+                serializations[index]->deserializeWholeText(*columns[index], field_buf, format_settings);
+                read = true;
+            }
+        }
+        else
+            read = deserializeFieldByEscapingRule(type, serializations[index], *columns[index], field_buf, escaping_rule, format_settings);
+
+        /// A capture group is the whole field, so the value must consume it entirely: there is no
+        /// delimiter here whose parsing would otherwise reject the leftover. The `CSV` and `JSON`
+        /// rules permit whitespace after a value.
+        if (escaping_rule == FormatSettings::EscapingRule::CSV)
+        {
+            if (!format_settings.csv.allow_whitespace_or_tab_as_delimiter)
+                while (!field_buf.eof() && (*field_buf.position() == ' ' || *field_buf.position() == '\t'))
+                    ++field_buf.position();
+        }
+        else if (escaping_rule == FormatSettings::EscapingRule::JSON)
+            skipWhitespaceIfAny(field_buf);
+
+        if (!field_buf.eof())
             throw Exception(ErrorCodes::INCORRECT_DATA,
                 "Unexpected data '{}' after parsed value in the matched field '{}'",
                 String(field_buf.position(), field_buf.available()),

--- a/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
@@ -112,14 +112,14 @@ bool RegexpRowInputFormat::readField(size_t index, MutableColumns & columns)
     ReadBuffer field_buf(const_cast<char *>(matched_field.data()), matched_field.size(), 0);
     try
     {
-        bool read;
+        bool read = false;
         /// A capture group is a whole field with no delimiter, so a tab inside it belongs to the
         /// value, while the `Raw` reader stops there. A field equal to the null representation keeps
         /// that reader, which owns the rule's null token where a null-aware one is selected at all.
         const bool null_token_is_live
             = isNullableOrLowCardinalityNullable(type) || isVariant(type) || format_settings.null_as_default;
         if (escaping_rule == FormatSettings::EscapingRule::Raw
-            && matched_field.find('\t') != std::string_view::npos
+            && matched_field.contains('\t')
             && !(null_token_is_live && matched_field == format_settings.tsv.null_representation))
         {
             if (format_settings.null_as_default && !isNullableOrLowCardinalityNullable(type))

--- a/tests/queries/0_stateless/04869_regexp_full_field_consumption_all_rules.reference
+++ b/tests/queries/0_stateless/04869_regexp_full_field_consumption_all_rules.reference
@@ -33,9 +33,14 @@
 0	5C4E
 -- Raw: a tab-containing null token is a value where null handling is off
 610962
-1	a	b
+1
 
-1	a	b
+1
+-- Raw: Variant owns the null token without a Nullable wrapper
+1
+0	616263096A756E6B
+-- Raw: Dynamic does not own it, so a tab-containing field is read whole
+0	610962
 -- Raw: a null token followed by a tab is a value, not a null
 0	5C4E0978
 0	5C4E0978

--- a/tests/queries/0_stateless/04869_regexp_full_field_consumption_all_rules.reference
+++ b/tests/queries/0_stateless/04869_regexp_full_field_consumption_all_rules.reference
@@ -1,0 +1,49 @@
+-- Escaped: a partially parsed value is rejected
+-- Escaped: a tail after the null marker is rejected
+-- CSV: a partially parsed value is rejected
+-- JSON: a partially parsed value is rejected
+-- CSV and JSON accept trailing whitespace, like the formats they mirror
+1
+1
+1
+1
+1
+-- whitespace is not an amnesty for what follows it
+-- the other rules reject trailing whitespace, like the formats they mirror
+-- Raw reads a capture containing a tab as a whole, at the default rule and explicitly
+616263096A756E6B
+616263096A756E6B
+616263096A756E6B
+616263096A756E6B
+616263096A756E6B
+-- Raw: a tab that cannot belong to the value is rejected
+-- Raw: captures without a tab are unchanged
+616263206A756E6B
+48656C6C6F2C20776F726C6421
+616263
+1
+-- Raw null tokens
+1	\N
+0	4E554C4C
+1	XYZ
+0	5C4E
+1	\N
+0	4E554C4C
+1	XYZ
+0	5C4E
+-- Raw: a null token followed by a tab is a value, not a null
+0	5C4E0978
+0	5C4E0978
+-- well-formed fields are still accepted
+1
+str1
+[1,2,3]
+2020-01-01
+1
+610962
+str1
+1
+str1
+1
+[1,2,3]
+1

--- a/tests/queries/0_stateless/04869_regexp_full_field_consumption_all_rules.reference
+++ b/tests/queries/0_stateless/04869_regexp_full_field_consumption_all_rules.reference
@@ -31,6 +31,11 @@
 0	4E554C4C
 1	XYZ
 0	5C4E
+-- Raw: a tab-containing null token is a value where null handling is off
+610962
+1	a	b
+
+1	a	b
 -- Raw: a null token followed by a tab is a value, not a null
 0	5C4E0978
 0	5C4E0978

--- a/tests/queries/0_stateless/04869_regexp_full_field_consumption_all_rules.sql
+++ b/tests/queries/0_stateless/04869_regexp_full_field_consumption_all_rules.sql
@@ -1,0 +1,90 @@
+-- A matched capture group is a whole field, so the value must consume it entirely.
+
+SELECT '-- Escaped: a partially parsed value is rejected';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D2D310A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v UInt64', unhex('763D2D310A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D316162630A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D312E390A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Nullable(Int64)', unhex('763D313278797A0A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Nullable(Float64)', unhex('763D312E356162630A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Nullable(Date)', unhex('763D323032302D30312D30316A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Array(UInt64)', unhex('763D5B312C325D78797A0A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D6E756C6C0A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped'; -- { serverError INCORRECT_DATA }
+
+SELECT '-- Escaped: a tail after the null marker is rejected';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D5C4E6A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v UInt64', unhex('763D5C4E6A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped', input_format_null_as_default = 1; -- { serverError INCORRECT_DATA }
+
+SELECT '-- CSV: a partially parsed value is rejected';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D316162630A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'CSV'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D312E390A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'CSV'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D22312278797A0A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'CSV'; -- { serverError INCORRECT_DATA }
+
+SELECT '-- JSON: a partially parsed value is rejected';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D316162630A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'JSON'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D312E390A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'JSON'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Nullable(Bool)', unhex('763D316162630A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'JSON'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Nullable(Date)', unhex('763D323032302D30312D30316A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'JSON'; -- { serverError INCORRECT_DATA }
+
+SELECT '-- CSV and JSON accept trailing whitespace, like the formats they mirror';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31200A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'CSV';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31200A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'JSON';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31090A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'CSV';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31090A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'JSON';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D310D0A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'JSON';
+
+SELECT '-- whitespace is not an amnesty for what follows it';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31206162630A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'CSV'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31206162630A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'JSON'; -- { serverError INCORRECT_DATA }
+
+SELECT '-- the other rules reject trailing whitespace, like the formats they mirror';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31200A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31200A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Quoted'; -- { serverError INCORRECT_DATA }
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31200A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Raw'; -- { serverError UNEXPECTED_DATA_AFTER_PARSED_VALUE }
+
+SELECT '-- Raw reads a capture containing a tab as a whole, at the default rule and explicitly';
+SELECT hex(v) FROM format(Regexp, 'v String', unhex('763D616263096A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$';
+SELECT hex(v) FROM format(Regexp, 'v String', unhex('763D616263096A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Raw';
+SELECT hex(v) FROM format(Regexp, 'v LowCardinality(String)', unhex('763D616263096A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$';
+SELECT hex(v) FROM format(Regexp, 'v Nullable(String)', unhex('763D616263096A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$';
+SELECT hex(v) FROM format(Regexp, 'v LowCardinality(Nullable(String))', unhex('763D616263096A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$';
+
+SELECT '-- Raw: a tab that cannot belong to the value is rejected';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31096A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$'; -- { serverError UNEXPECTED_DATA_AFTER_PARSED_VALUE }
+SELECT * FROM format(Regexp, 'v Nullable(Float64)', unhex('763D31096A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$'; -- { serverError UNEXPECTED_DATA_AFTER_PARSED_VALUE }
+SELECT * FROM format(Regexp, 'v UInt64', unhex('763D31096A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$', input_format_null_as_default = 1; -- { serverError UNEXPECTED_DATA_AFTER_PARSED_VALUE }
+SELECT * FROM format(Regexp, 'v UInt64', unhex('763D5C4E096A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$', input_format_null_as_default = 1; -- { serverError UNEXPECTED_DATA_AFTER_PARSED_VALUE }
+
+SELECT '-- Raw: captures without a tab are unchanged';
+SELECT hex(v) FROM format(Regexp, 'v String', unhex('763D616263206A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$';
+SELECT hex(v) FROM format(Regexp, 'v String', unhex('763D48656C6C6F2C20776F726C64210A')) SETTINGS format_regexp = '^v=(.+)$';
+SELECT hex(v) FROM format(Regexp, 'v LowCardinality(String)', unhex('763D6162630A')) SETTINGS format_regexp = '^v=(.+)$';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D310A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Raw';
+
+SELECT '-- Raw null tokens';
+SELECT isNull(v), hex(v) FROM format(Regexp, 'v Nullable(String)', unhex('763D5C4E0A')) SETTINGS format_regexp = '^v=(.+)$';
+SELECT isNull(v), hex(v) FROM format(Regexp, 'v Nullable(String)', unhex('763D4E554C4C0A')) SETTINGS format_regexp = '^v=(.+)$';
+SELECT isNull(v), hex(v) FROM format(Regexp, 'v Nullable(String)', unhex('763D58595A0A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'XYZ';
+SELECT isNull(v), hex(v) FROM format(Regexp, 'v Nullable(String)', unhex('763D5C4E0A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'XYZ';
+SELECT isNull(v), hex(v) FROM format(Regexp, 'v LowCardinality(Nullable(String))', unhex('763D5C4E0A')) SETTINGS format_regexp = '^v=(.+)$';
+SELECT isNull(v), hex(v) FROM format(Regexp, 'v LowCardinality(Nullable(String))', unhex('763D4E554C4C0A')) SETTINGS format_regexp = '^v=(.+)$';
+SELECT isNull(v), hex(v) FROM format(Regexp, 'v LowCardinality(Nullable(String))', unhex('763D58595A0A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'XYZ';
+SELECT isNull(v), hex(v) FROM format(Regexp, 'v LowCardinality(Nullable(String))', unhex('763D5C4E0A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'XYZ';
+
+SELECT '-- Raw: a null token followed by a tab is a value, not a null';
+SELECT isNull(v), hex(v) FROM format(Regexp, 'v Nullable(String)', unhex('763D5C4E09780A')) SETTINGS format_regexp = '^v=(.+)$';
+SELECT isNull(v), hex(v) FROM format(Regexp, 'v LowCardinality(Nullable(String))', unhex('763D5C4E09780A')) SETTINGS format_regexp = '^v=(.+)$';
+
+SELECT '-- well-formed fields are still accepted';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D310A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped';
+SELECT * FROM format(Regexp, 'v String', unhex('763D737472310A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped';
+SELECT * FROM format(Regexp, 'v Array(UInt64)', unhex('763D5B312C322C335D0A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped';
+SELECT * FROM format(Regexp, 'v Nullable(Date)', unhex('763D323032302D30312D30310A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped';
+SELECT isNull(v) FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D5C4E0A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped';
+SELECT hex(v) FROM format(Regexp, 'v String', unhex('763D615C74620A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Escaped';
+SELECT * FROM format(Regexp, 'v String', unhex('763D2273747231220A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'CSV';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D310A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'CSV';
+SELECT * FROM format(Regexp, 'v String', unhex('763D2273747231220A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'JSON';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D310A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'JSON';
+SELECT * FROM format(Regexp, 'v Array(UInt64)', unhex('763D5B312C322C335D0A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'JSON';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D310A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'Quoted';

--- a/tests/queries/0_stateless/04869_regexp_full_field_consumption_all_rules.sql
+++ b/tests/queries/0_stateless/04869_regexp_full_field_consumption_all_rules.sql
@@ -32,6 +32,7 @@ SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31200A')) SETTINGS
 SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31090A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'CSV';
 SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31090A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'JSON';
 SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D310D0A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'JSON';
+SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31200A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'CSV', input_format_csv_allow_whitespace_or_tab_as_delimiter = 1; -- { serverError INCORRECT_DATA }
 
 SELECT '-- whitespace is not an amnesty for what follows it';
 SELECT * FROM format(Regexp, 'v Nullable(UInt64)', unhex('763D31206162630A')) SETTINGS format_regexp = '^v=(.+)$', format_regexp_escaping_rule = 'CSV'; -- { serverError INCORRECT_DATA }
@@ -70,6 +71,12 @@ SELECT isNull(v), hex(v) FROM format(Regexp, 'v LowCardinality(Nullable(String))
 SELECT isNull(v), hex(v) FROM format(Regexp, 'v LowCardinality(Nullable(String))', unhex('763D4E554C4C0A')) SETTINGS format_regexp = '^v=(.+)$';
 SELECT isNull(v), hex(v) FROM format(Regexp, 'v LowCardinality(Nullable(String))', unhex('763D58595A0A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'XYZ';
 SELECT isNull(v), hex(v) FROM format(Regexp, 'v LowCardinality(Nullable(String))', unhex('763D5C4E0A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'XYZ';
+
+SELECT '-- Raw: a tab-containing null token is a value where null handling is off';
+SELECT hex(v) FROM format(Regexp, 'v String', unhex('763D6109620A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'a\tb', input_format_null_as_default = 0;
+SELECT isNull(v), hex(v) FROM format(Regexp, 'v Nullable(String)', unhex('763D6109620A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'a\tb', input_format_null_as_default = 0;
+SELECT hex(v) FROM format(Regexp, 'v String', unhex('763D6109620A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'a\tb';
+SELECT isNull(v), hex(v) FROM format(Regexp, 'v LowCardinality(Nullable(String))', unhex('763D6109620A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'a\tb', input_format_null_as_default = 0;
 
 SELECT '-- Raw: a null token followed by a tab is a value, not a null';
 SELECT isNull(v), hex(v) FROM format(Regexp, 'v Nullable(String)', unhex('763D5C4E09780A')) SETTINGS format_regexp = '^v=(.+)$';

--- a/tests/queries/0_stateless/04869_regexp_full_field_consumption_all_rules.sql
+++ b/tests/queries/0_stateless/04869_regexp_full_field_consumption_all_rules.sql
@@ -74,9 +74,15 @@ SELECT isNull(v), hex(v) FROM format(Regexp, 'v LowCardinality(Nullable(String))
 
 SELECT '-- Raw: a tab-containing null token is a value where null handling is off';
 SELECT hex(v) FROM format(Regexp, 'v String', unhex('763D6109620A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'a\tb', input_format_null_as_default = 0;
-SELECT isNull(v), hex(v) FROM format(Regexp, 'v Nullable(String)', unhex('763D6109620A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'a\tb', input_format_null_as_default = 0;
+SELECT isNull(v) FROM format(Regexp, 'v Nullable(String)', unhex('763D6109620A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'a\tb', input_format_null_as_default = 0;
 SELECT hex(v) FROM format(Regexp, 'v String', unhex('763D6109620A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'a\tb';
-SELECT isNull(v), hex(v) FROM format(Regexp, 'v LowCardinality(Nullable(String))', unhex('763D6109620A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'a\tb', input_format_null_as_default = 0;
+SELECT isNull(v) FROM format(Regexp, 'v LowCardinality(Nullable(String))', unhex('763D6109620A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'a\tb', input_format_null_as_default = 0;
+
+SELECT '-- Raw: Variant owns the null token without a Nullable wrapper';
+SELECT isNull(v) FROM format(Regexp, 'v Variant(String, UInt64)', unhex('763D6109620A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'a\tb', input_format_null_as_default = 0;
+SELECT isNull(v), hex(v::String) FROM format(Regexp, 'v Variant(String, UInt64)', unhex('763D616263096A756E6B0A')) SETTINGS format_regexp = '^v=(.+)$', input_format_null_as_default = 0;
+SELECT '-- Raw: Dynamic does not own it, so a tab-containing field is read whole';
+SELECT isNull(v), hex(v::String) FROM format(Regexp, 'v Dynamic', unhex('763D6109620A')) SETTINGS format_regexp = '^v=(.+)$', format_tsv_null_representation = 'a\tb', input_format_null_as_default = 0;
 
 SELECT '-- Raw: a null token followed by a tab is a value, not a null';
 SELECT isNull(v), hex(v) FROM format(Regexp, 'v Nullable(String)', unhex('763D5C4E09780A')) SETTINGS format_regexp = '^v=(.+)$';


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/108091

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed the `Regexp` input format silently discarding the unparsed rest of a matched field, which stored a truncated or fabricated value instead of reporting an error: `v=-1` into `UInt64` read `0`, and `v=2020-01-01junk` into `Date` read `1975-07-14` under the `JSON` rule. Malformed fields are now rejected under the `Escaped`, `CSV` and `JSON` rules, matching the formats those rules are documented as behaving like. Under `Raw`, a matched field containing a tab is now read as a whole instead of being truncated at the tab.

### Description

**The problem.** A matched capture group is one complete field, and `Regexp` has no delimiter after it, so when a type's parser stopped early the bytes it left behind were discarded and the partial parse reported as success. `v=-1` into `UInt64` gave `0`, `v=1abc` gave `1`, and `v=2020-01-01junk` into `Date` under the `JSON` rule gave `1975-07-14`, which is not even a prefix of the input. `TSV`, `TSKV`, `CSV`, `JSONEachRow` and `CustomSeparated` all reject these same bytes, because there the leftover fails the delimiter that follows.

**Why the existing check was not enough.** #108091 added this check for the `Quoted` rule only; it now applies to every rule. `CSV` and `JSON` first skip trailing whitespace, because the formats they mirror accept it, so `v=1 ` still reads `1` while `v=1 abc` is rejected.

**A second, more reachable mechanism.** `Raw` is the default rule, so it needs no setting at all, and it fails differently: its reader stops at a tab, so `v=abc<TAB>junk` into `String` read `abc`. A tab is legal inside a `String`, so rejecting that field would be a new bug; it is now read as a whole instead, while a tab that cannot belong to the value (`v=1<TAB>junk` into `UInt64`) is rejected. A field equal to the null representation keeps the old reader wherever a null-aware one is selected, so `Raw`'s null tokens are unchanged.

The check stays inside `Regexp`: the two other formats sharing this deserialization helper have delimiters, so for them a leftover is normal.

Validation: run unchanged against unpatched master the new test fails, nearly every error assertion reporting a missing error; the exceptions are the pre-existing `Quoted` and `Raw` controls. It passes 50/50 under randomized settings.


Also noticed, not changed here: `Values` accepts `v=1 ` while `Regexp`+`Quoted` rejects it, a divergence predating this PR.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1534` (included in `26.8` and later)
<!-- ch-version-info:end -->