### PR TITLE
Fix flaky `test_url_reconnect`

### DIFF
--- a/tests/integration/test_redirect_url_storage/test.py
+++ b/tests/integration/test_redirect_url_storage/test.py
@@ -141,6 +141,14 @@ def test_url_reconnect(started_cluster):
             "insert into table function hdfs('hdfs://hdfs1:9000/storage_big', 'TSV', 'id Int32') select number from numbers(500000)"
         )
 
+        # The earlier tests in this module leave keep-alive connections to the
+        # datanode web port in the HTTP connection pool. A silent DROP kills
+        # such an already established connection only by the receive timeout
+        # (`http_receive_timeout`, 30 seconds by default) instead of by the
+        # one-second connect timeout, which is what this test waits for below.
+        # Drop the cache so that the query has to open a fresh connection.
+        node1.query("system drop connections cache")
+
         # `PartitionManager` executes iptables inside the container now, so block the
         # outgoing connections to the datanode web port with a silent DROP: the client
         # then observes connect timeouts (asserted below) and retries.
@@ -172,7 +180,10 @@ def test_url_reconnect(started_cluster):
         # attempt), then let a retry succeed. A fixed sleep is racy on a
         # loaded runner: the query may reach its first connect attempt only
         # after the rule is already deleted, timing out nothing.
-        for _ in range(60):
+        # The first attempt times out after a second, but a loaded runner can
+        # be slow to even start the query, so keep the budget generous - the
+        # loop exits as soon as the line shows up.
+        for _ in range(120):
             if int(node1.count_in_log("connect timed out")) > timeouts_before:
                 break
             time.sleep(0.5)


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110130

`test_redirect_url_storage/test.py::test_url_reconnect` blocks the outgoing connections to the HDFS datanode web port with a silent `DROP` and heals the network only after the client has demonstrably hit a connect timeout, waiting up to 30 seconds for a fresh `connect timed out` line in the server log.

That budget is not always enough, because the query does not necessarily open a new connection at all: the earlier tests in the module leave keep-alive connections to `hdfs1:50075` in the HTTP connection pool, and a silent `DROP` kills an already established connection only by the receive timeout - `http_receive_timeout`, 30 seconds by default - rather than by the one-second connect timeout. The first try then dies after 30 seconds with a bare `Timeout`, and the first `connect timed out` line appears only on the next try, about 31 seconds into the query, just past the budget:

```
16:57:35.001 executeQuery: select sum(cityHash64(id)) from url('http://hdfs1:50075/...
16:58:05.013 ReadWriteBufferFromHTTP: ... Error: Timeout. Failed at try 2/10.
16:58:06.115 ReadWriteBufferFromHTTP: ... Error: Timeout: connect timed out: 172.16.1.2:50075. Failed at try 3/10.
```

The fix drops the connection cache before installing the rule, so the query has to open a fresh connection and the first try fails by the connect timeout, as the test expects. The wait budget is also raised to 60 seconds: the loop exits as soon as the line shows up, so a generous budget costs nothing on a healthy run.

Seen in an unrelated pull request: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110130&sha=7acc19de7fb0c97f7ea0fb7c6c234930d188ac66&name_0=PR&name_1=Integration%20tests%20%28amd_msan%2C%205%2F8%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1294` (included in `26.8` and later)
<!-- ch-version-info:end -->