### PR TITLE
Docs: fix absolute documentation component links

### DIFF
--- a/ci/jobs/scripts/docs/autogenerate/autogenerate_docs.py
+++ b/ci/jobs/scripts/docs/autogenerate/autogenerate_docs.py
@@ -1337,7 +1337,7 @@ def _settings_explorer_component(pages, family=None):
                 <span aria-hidden="true" className="w-4 shrink-0" />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
                 <a
-                  href={`https://clickhouse.com/docs${item.value.href}`}
+                  href={`/docs${item.value.href}`}
                   className="min-w-0 whitespace-normal no-underline hover:underline"
                   style={{ overflowWrap: "anywhere" }}
                 >

--- a/ci/jobs/scripts/docs/autogenerate/autogenerate_docs.py
+++ b/ci/jobs/scripts/docs/autogenerate/autogenerate_docs.py
@@ -1337,7 +1337,7 @@ def _settings_explorer_component(pages, family=None):
                 <span aria-hidden="true" className="w-4 shrink-0" />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
                 <a
-                  href={`/docs${item.value.href}`}
+                  href={`https://clickhouse.com/docs${item.value.href}`}
                   className="min-w-0 whitespace-normal no-underline hover:underline"
                   style={{ overflowWrap: "anywhere" }}
                 >

--- a/ci/jobs/scripts/docs/autogenerate/test_session_settings_split.py
+++ b/ci/jobs/scripts/docs/autogenerate/test_session_settings_split.py
@@ -396,10 +396,7 @@ def main():
         assert "text-gray-500 dark:text-gray-400" in explorer
         assert 'gridTemplateColumns: "44ch max-content"' in explorer
         assert 'style={{ overflowWrap: "anywhere" }}' in explorer
-        assert (
-            'href={`https://clickhouse.com/docs${item.value.href}`}'
-            in explorer
-        )
+        assert 'href={`/docs${item.value.href}`}' in explorer
         assert 'item.value.name.split("_")' in explorer
         assert "<wbr />" in explorer
         assert "settingNameColumnWidth" not in explorer

--- a/ci/jobs/scripts/docs/autogenerate/test_session_settings_split.py
+++ b/ci/jobs/scripts/docs/autogenerate/test_session_settings_split.py
@@ -396,7 +396,10 @@ def main():
         assert "text-gray-500 dark:text-gray-400" in explorer
         assert 'gridTemplateColumns: "44ch max-content"' in explorer
         assert 'style={{ overflowWrap: "anywhere" }}' in explorer
-        assert 'href={`/docs${item.value.href}`}' in explorer
+        assert (
+            'href={`https://clickhouse.com/docs${item.value.href}`}'
+            in explorer
+        )
         assert 'item.value.name.split("_")' in explorer
         assert "<wbr />" in explorer
         assert "settingNameColumnWidth" not in explorer

--- a/ci/jobs/scripts/docs/lychee_check.py
+++ b/ci/jobs/scripts/docs/lychee_check.py
@@ -41,8 +41,7 @@ image and generated-translation trees under ``docs/`` are never copied.
 The internal and locale link modes also materialize the generated settings
 explorers' JSX destinations as Markdown links. This makes lychee validate the
 pages those runtime links open, while an explicit check verifies that the JSX
-uses absolute production URLs. Absolute URLs prevent Mintlify from prepending
-the production `/docs` mount a second time.
+keeps the production `/docs` mount which is absent from the on-disk docs root.
 """
 
 import argparse
@@ -399,12 +398,10 @@ def report_snippet_links(docs_root, rel_files):
 
 
 # Generated settings explorers keep their destinations in JSX data and render
-# them through ``href={`https://clickhouse.com/docs${item.value.href}`}``.
-# lychee does not parse JSX data or evaluate template literals, so materialize
-# those rendered links into a Markdown input in the throwaway tree. The
-# production origin and mount are checked before stripping them for offline
-# resolution against the docs root.
-SETTINGS_EXPLORER_URL_PREFIX = "https://clickhouse.com/docs"
+# them through ``href={`/docs${item.value.href}`}``. lychee does not parse JSX
+# data or evaluate template literals, so materialize those rendered links into a
+# Markdown input in the throwaway tree. The production mount is checked before
+# stripping `/docs` for offline resolution against the docs root.
 SETTINGS_EXPLORER_ENTRY_HREF = re.compile(
     r'''(?:["']href["']|\bhref)\s*:\s*(?P<quote>["'])(?P<href>/[^"'`\s]+)(?P=quote)'''
 )
@@ -492,26 +489,23 @@ def write_settings_explorer_links(
         malformed = next(
             (
                 href for href in rendered_links
-                if not href.startswith(SETTINGS_EXPLORER_URL_PREFIX + "/")
-                or href.startswith(SETTINGS_EXPLORER_URL_PREFIX + "//")
+                if not href.startswith("/docs/") or href.startswith("/docs//")
             ),
             None,
         )
         if malformed:
             print(
                 f"[ERROR] {rel} (at {line}) | rendered settings links must "
-                f"start with `{SETTINGS_EXPLORER_URL_PREFIX}/`; got {malformed}",
+                f"start with `/docs/`; got {malformed}",
                 flush=True,
             )
             errors += 1
 
         for href in rendered_links:
-            # The throwaway tree is rooted at the contents of ClickHouse's
-            # production `/docs` mount, so remove the exact absolute prefix.
+            # `/docs` is ClickHouse's production mount; the throwaway tree is
+            # rooted at its contents, so remove only that leading mount segment.
             offline_href = (
-                href[len(SETTINGS_EXPLORER_URL_PREFIX):]
-                if href.startswith(SETTINGS_EXPLORER_URL_PREFIX + "/")
-                else href
+                href[len("/docs"):] if href.startswith("/docs/") else href
             )
             if not include_fragments:
                 offline_href = offline_href.split("#", 1)[0]

--- a/ci/jobs/scripts/docs/lychee_check.py
+++ b/ci/jobs/scripts/docs/lychee_check.py
@@ -41,7 +41,8 @@ image and generated-translation trees under ``docs/`` are never copied.
 The internal and locale link modes also materialize the generated settings
 explorers' JSX destinations as Markdown links. This makes lychee validate the
 pages those runtime links open, while an explicit check verifies that the JSX
-keeps the production `/docs` mount which is absent from the on-disk docs root.
+uses absolute production URLs. Absolute URLs prevent Mintlify from prepending
+the production `/docs` mount a second time.
 """
 
 import argparse
@@ -398,10 +399,12 @@ def report_snippet_links(docs_root, rel_files):
 
 
 # Generated settings explorers keep their destinations in JSX data and render
-# them through ``href={`/docs${item.value.href}`}``. lychee does not parse JSX
-# data or evaluate template literals, so materialize those rendered links into a
-# Markdown input in the throwaway tree. The production mount is checked before
-# stripping `/docs` for offline resolution against the docs root.
+# them through ``href={`https://clickhouse.com/docs${item.value.href}`}``.
+# lychee does not parse JSX data or evaluate template literals, so materialize
+# those rendered links into a Markdown input in the throwaway tree. The
+# production origin and mount are checked before stripping them for offline
+# resolution against the docs root.
+SETTINGS_EXPLORER_URL_PREFIX = "https://clickhouse.com/docs"
 SETTINGS_EXPLORER_ENTRY_HREF = re.compile(
     r'''(?:["']href["']|\bhref)\s*:\s*(?P<quote>["'])(?P<href>/[^"'`\s]+)(?P=quote)'''
 )
@@ -489,23 +492,26 @@ def write_settings_explorer_links(
         malformed = next(
             (
                 href for href in rendered_links
-                if not href.startswith("/docs/") or href.startswith("/docs//")
+                if not href.startswith(SETTINGS_EXPLORER_URL_PREFIX + "/")
+                or href.startswith(SETTINGS_EXPLORER_URL_PREFIX + "//")
             ),
             None,
         )
         if malformed:
             print(
                 f"[ERROR] {rel} (at {line}) | rendered settings links must "
-                f"start with `/docs/`; got {malformed}",
+                f"start with `{SETTINGS_EXPLORER_URL_PREFIX}/`; got {malformed}",
                 flush=True,
             )
             errors += 1
 
         for href in rendered_links:
-            # `/docs` is ClickHouse's production mount; the throwaway tree is
-            # rooted at its contents, so remove only that leading mount segment.
+            # The throwaway tree is rooted at the contents of ClickHouse's
+            # production `/docs` mount, so remove the exact absolute prefix.
             offline_href = (
-                href[len("/docs"):] if href.startswith("/docs/") else href
+                href[len(SETTINGS_EXPLORER_URL_PREFIX):]
+                if href.startswith(SETTINGS_EXPLORER_URL_PREFIX + "/")
+                else href
             )
             if not include_fragments:
                 offline_href = offline_href.split("#", 1)[0]

--- a/ci/tests/test_docs_link_checker.py
+++ b/ci/tests/test_docs_link_checker.py
@@ -29,7 +29,7 @@ def test_settings_explorer_links_are_materialized_for_lychee(tmp_path):
     output.mkdir()
     write_settings_explorer(
         docs_root,
-        'href={`https://clickhouse.com/docs${item.value.href}`}',
+        'href={`/docs${item.value.href}`}',
     )
 
     output_name, errors = lychee_check.write_settings_explorer_links(
@@ -41,33 +41,29 @@ def test_settings_explorer_links_are_materialized_for_lychee(tmp_path):
         "](/reference/settings/session-settings/example#example_setting)"
         in materialized
     )
-    assert "https://clickhouse.com/docs/reference/settings" not in materialized
+    assert "/docs/reference/settings" not in materialized
 
 
-def test_settings_explorer_links_require_an_absolute_production_url(
+def test_settings_explorer_links_require_the_production_docs_mount(
         tmp_path, capsys):
     docs_root = tmp_path / "docs"
     output = tmp_path / "output"
     output.mkdir()
-    write_settings_explorer(
-        docs_root,
-        'href={`/docs${item.value.href}`}',
-    )
+    write_settings_explorer(docs_root, "href={item.value.href}")
 
     _output_name, errors = lychee_check.write_settings_explorer_links(
         docs_root, output)
 
     assert errors == 1
     report = capsys.readouterr().out
-    assert (
-        "rendered settings links must start with "
-        "`https://clickhouse.com/docs/`"
-    ) in report
-    assert "/docs/reference/settings/session-settings/example#example_setting" in report
+    assert "rendered settings links must start with `/docs/`" in report
+    assert "/reference/settings/session-settings/example#example_setting" in report
 
 
-def test_locale_link_parsers_ignore_absolute_templates():
-    rendered_href = 'href={`https://clickhouse.com/docs${item.value.href}`}'
+def test_locale_static_link_parser_leaves_templates_to_template_parser():
+    rendered_href = 'href={`/docs${item.value.href}`}'
 
     assert locale_components_check.HREF.search(rendered_href) is None
-    assert locale_components_check.TEMPLATE.search(rendered_href) is None
+    template = locale_components_check.TEMPLATE.search(rendered_href)
+    assert template is not None
+    assert template.group(1) == "/docs"

--- a/ci/tests/test_docs_link_checker.py
+++ b/ci/tests/test_docs_link_checker.py
@@ -29,7 +29,7 @@ def test_settings_explorer_links_are_materialized_for_lychee(tmp_path):
     output.mkdir()
     write_settings_explorer(
         docs_root,
-        'href={`/docs${item.value.href}`}',
+        'href={`https://clickhouse.com/docs${item.value.href}`}',
     )
 
     output_name, errors = lychee_check.write_settings_explorer_links(
@@ -41,29 +41,33 @@ def test_settings_explorer_links_are_materialized_for_lychee(tmp_path):
         "](/reference/settings/session-settings/example#example_setting)"
         in materialized
     )
-    assert "/docs/reference/settings" not in materialized
+    assert "https://clickhouse.com/docs/reference/settings" not in materialized
 
 
-def test_settings_explorer_links_require_the_production_docs_mount(
+def test_settings_explorer_links_require_an_absolute_production_url(
         tmp_path, capsys):
     docs_root = tmp_path / "docs"
     output = tmp_path / "output"
     output.mkdir()
-    write_settings_explorer(docs_root, "href={item.value.href}")
+    write_settings_explorer(
+        docs_root,
+        'href={`/docs${item.value.href}`}',
+    )
 
     _output_name, errors = lychee_check.write_settings_explorer_links(
         docs_root, output)
 
     assert errors == 1
     report = capsys.readouterr().out
-    assert "rendered settings links must start with `/docs/`" in report
-    assert "/reference/settings/session-settings/example#example_setting" in report
+    assert (
+        "rendered settings links must start with "
+        "`https://clickhouse.com/docs/`"
+    ) in report
+    assert "/docs/reference/settings/session-settings/example#example_setting" in report
 
 
-def test_locale_static_link_parser_leaves_templates_to_template_parser():
-    rendered_href = 'href={`/docs${item.value.href}`}'
+def test_locale_link_parsers_ignore_absolute_templates():
+    rendered_href = 'href={`https://clickhouse.com/docs${item.value.href}`}'
 
     assert locale_components_check.HREF.search(rendered_href) is None
-    template = locale_components_check.TEMPLATE.search(rendered_href)
-    assert template is not None
-    assert template.group(1) == "/docs"
+    assert locale_components_check.TEMPLATE.search(rendered_href) is None

--- a/docs/snippets/ar/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/ar/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/ar/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/ar/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>ميزة Beta</span>

--- a/docs/snippets/ar/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ar/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />غير متاح في ClickHouse Cloud
         </a>
     )

--- a/docs/snippets/ar/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/ar/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/ar/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/ar/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />ميزة تجريبية

--- a/docs/snippets/ar/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/ar/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/ar/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/ar/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>ميزة Beta</span>

--- a/docs/snippets/ar/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ar/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/ar/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/ar/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/ar/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/ar/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/ar/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/ar/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ar/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/ar/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ar/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/ar/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ar/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/ar/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/components/Badges/BetaBadge.jsx
@@ -18,7 +18,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Beta feature</span>

--- a/docs/snippets/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/components/Badges/CloudNotSupportedBadge.jsx
@@ -13,7 +13,7 @@ const Icon = () => {
 
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />Not supported in ClickHouse Cloud
         </a>
     )

--- a/docs/snippets/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/components/Badges/ExperimentalBadge.jsx
@@ -14,7 +14,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />Experimental feature

--- a/docs/snippets/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Beta feature</span>

--- a/docs/snippets/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -164,7 +164,7 @@ const FormatSettingsExplorer = () => {
                 <span aria-hidden="true" className="w-4 shrink-0" />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
                 <a
-                  href={`/docs${item.value.href}`}
+                  href={`https://clickhouse.com/docs${item.value.href}`}
                   className="min-w-0 whitespace-normal no-underline hover:underline"
                   style={{ overflowWrap: "anywhere" }}
                 >

--- a/docs/snippets/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -164,7 +164,7 @@ const MergeTreeSettingsExplorer = () => {
                 <span aria-hidden="true" className="w-4 shrink-0" />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
                 <a
-                  href={`/docs${item.value.href}`}
+                  href={`https://clickhouse.com/docs${item.value.href}`}
                   className="min-w-0 whitespace-normal no-underline hover:underline"
                   style={{ overflowWrap: "anywhere" }}
                 >

--- a/docs/snippets/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -164,7 +164,7 @@ const ServerSettingsExplorer = () => {
                 <span aria-hidden="true" className="w-4 shrink-0" />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
                 <a
-                  href={`/docs${item.value.href}`}
+                  href={`https://clickhouse.com/docs${item.value.href}`}
                   className="min-w-0 whitespace-normal no-underline hover:underline"
                   style={{ overflowWrap: "anywhere" }}
                 >

--- a/docs/snippets/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -164,7 +164,7 @@ const SessionSettingsExplorer = () => {
                 <span aria-hidden="true" className="w-4 shrink-0" />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
                 <a
-                  href={`/docs${item.value.href}`}
+                  href={`https://clickhouse.com/docs${item.value.href}`}
                   className="min-w-0 whitespace-normal no-underline hover:underline"
                   style={{ overflowWrap: "anywhere" }}
                 >

--- a/docs/snippets/es/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/es/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/es/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/es/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Funcionalidad Beta</span>

--- a/docs/snippets/es/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/es/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />No disponible en ClickHouse Cloud
         </a>
     )

--- a/docs/snippets/es/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/es/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/es/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/es/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />Funcionalidad experimental

--- a/docs/snippets/es/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/es/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/es/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/es/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Funcionalidad beta</span>

--- a/docs/snippets/es/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/es/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/es/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/es/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/es/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/es/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/es/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/es/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/es/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/es/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/es/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/es/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/es/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/es/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/fr/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/fr/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/fr/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/fr/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Fonctionnalité bêta</span>

--- a/docs/snippets/fr/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/fr/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />Non pris en charge sur ClickHouse Cloud
         </a>
     )

--- a/docs/snippets/fr/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/fr/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/fr/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/fr/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />Fonctionnalité expérimentale

--- a/docs/snippets/fr/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/fr/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/fr/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/fr/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Fonctionnalité en bêta</span>

--- a/docs/snippets/fr/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/fr/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/fr/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/fr/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/fr/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/fr/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/fr/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/fr/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/fr/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/fr/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/fr/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/fr/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/fr/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/fr/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ja/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/ja/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/ja/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/ja/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>ベータ機能です</span>

--- a/docs/snippets/ja/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ja/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />ClickHouse Cloud では利用できません
         </a>
     )

--- a/docs/snippets/ja/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/ja/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/ja/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/ja/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />実験的機能です

--- a/docs/snippets/ja/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/ja/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/ja/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/ja/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>ベータ機能です</span>

--- a/docs/snippets/ja/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ja/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/ja/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/ja/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/ja/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/ja/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/ja/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/ja/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ja/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/ja/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ja/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/ja/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ja/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/ja/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ko/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/ko/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/ko/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/ko/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>베타 기능입니다</span>

--- a/docs/snippets/ko/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ko/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />ClickHouse Cloud에서 지원되지 않음
         </a>
     )

--- a/docs/snippets/ko/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/ko/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/ko/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/ko/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />실험적 기능입니다

--- a/docs/snippets/ko/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/ko/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/ko/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/ko/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>베타 기능</span>

--- a/docs/snippets/ko/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ko/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/ko/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/ko/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/ko/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/ko/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/ko/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/ko/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ko/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/ko/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ko/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/ko/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ko/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/ko/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/pt-BR/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/pt-BR/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/pt-BR/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/pt-BR/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Recurso beta</span>

--- a/docs/snippets/pt-BR/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/pt-BR/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />Sem suporte no ClickHouse Cloud
         </a>
     )

--- a/docs/snippets/pt-BR/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/pt-BR/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/pt-BR/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/pt-BR/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />Recurso experimental

--- a/docs/snippets/pt-BR/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/pt-BR/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/pt-BR/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/pt-BR/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Funcionalidade Beta</span>

--- a/docs/snippets/pt-BR/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/pt-BR/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/pt-BR/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/pt-BR/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/pt-BR/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/pt-BR/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/pt-BR/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/pt-BR/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/pt-BR/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/pt-BR/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/pt-BR/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/pt-BR/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/pt-BR/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/pt-BR/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ru/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/ru/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/ru/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/ru/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Возможность в бета-версии</span>

--- a/docs/snippets/ru/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ru/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />В ClickHouse Cloud не поддерживается
         </a>
     )

--- a/docs/snippets/ru/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/ru/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/ru/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/ru/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />Экспериментальная возможность

--- a/docs/snippets/ru/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/ru/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/ru/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/ru/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Возможность в статусе бета</span>

--- a/docs/snippets/ru/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/ru/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/ru/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/ru/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/ru/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/ru/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/ru/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/ru/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ru/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/ru/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ru/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/ru/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/ru/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/ru/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/zh/components/Badges/BetaBadge.jsx
+++ b/docs/snippets/zh/components/Badges/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/zh/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/zh/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Beta 功能</span>

--- a/docs/snippets/zh/components/Badges/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/zh/components/Badges/CloudNotSupportedBadge.jsx
@@ -11,7 +11,7 @@ const Icon = () => {
 }
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <Icon />ClickHouse Cloud 中不支持
         </a>
     )

--- a/docs/snippets/zh/components/Badges/ExperimentalBadge.jsx
+++ b/docs/snippets/zh/components/Badges/ExperimentalBadge.jsx
@@ -12,7 +12,7 @@ const Icon = () => {
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/zh/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/zh/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <Icon />Experimental 功能

--- a/docs/snippets/zh/components/BetaBadge/BetaBadge.jsx
+++ b/docs/snippets/zh/components/BetaBadge/BetaBadge.jsx
@@ -17,7 +17,7 @@ export const BetaBadge = ({ link, galaxyTrack, galaxyEvent }) => {
 
     return (
         <a
-            href="/docs/zh/reference/settings/beta-and-experimental-features#beta-features"
+            href="https://clickhouse.com/docs/zh/reference/settings/beta-and-experimental-features#beta-features"
             className="betaBadge"
         >
             <span>Beta 版功能</span>

--- a/docs/snippets/zh/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
+++ b/docs/snippets/zh/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx
@@ -1,6 +1,6 @@
 export const CloudNotSupportedBadge = () => {
     return (
-        <a href="/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
+        <a href="https://clickhouse.com/docs/products/cloud/guides/cloud-compatibility#list-of-unsupported-features" className="cloudNotSupportedBadge">
             <div className="cloudNotSupportedIcon">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path strokeWidth="1.5" d="M6.33366 12.6666L12.3739 12.6667C13.6593 12.6667 14.7073 11.6187 14.7073 10.3334C14.7073 9.04804 13.6593 8.00003 12.3739 8.00003C12.3739 8.00003 12.3337 7.66659 12.0003 7.33325M10.667 5.33322C8.00033 2.33325 4.45395 4.78537 4.14195 6.68203C2.55728 6.7627 1.29395 8.06203 1.29395 9.6667C1.29395 11.3234 2.66699 12.6666 4.00033 12.6666" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>

--- a/docs/snippets/zh/components/ExperimentalBadge/ExperimentalBadge.jsx
+++ b/docs/snippets/zh/components/ExperimentalBadge/ExperimentalBadge.jsx
@@ -1,7 +1,7 @@
 export const ExperimentalBadge = () => {
     return (
         <a
-            href="/docs/zh/reference/settings/beta-and-experimental-features#experimental-features"
+            href="https://clickhouse.com/docs/zh/reference/settings/beta-and-experimental-features#experimental-features"
             className="experimentalBadge"
         >
             <div className="experimentalIcon">

--- a/docs/snippets/zh/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
+++ b/docs/snippets/zh/components/FormatSettingsExplorer/FormatSettingsExplorer.jsx
@@ -898,7 +898,7 @@ const FormatSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/zh/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
+++ b/docs/snippets/zh/components/MergeTreeSettingsExplorer/MergeTreeSettingsExplorer.jsx
@@ -1510,7 +1510,7 @@ const MergeTreeSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/zh/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
+++ b/docs/snippets/zh/components/ServerSettingsExplorer/ServerSettingsExplorer.jsx
@@ -2120,7 +2120,7 @@ const ServerSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>

--- a/docs/snippets/zh/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
+++ b/docs/snippets/zh/components/SessionSettingsExplorer/SessionSettingsExplorer.jsx
@@ -4514,7 +4514,7 @@ const SessionSettingsExplorer = () => {
               <div key={item.value.name} className="flex min-w-max items-baseline whitespace-nowrap">
                 <span aria-hidden="true" style={{ display: "inline-block", width: "1rem" }} />
                 {branch(branchPrefix(childContinuations, itemIsLast))}
-                <a href={`/docs${item.value.href}`} className="no-underline hover:underline">
+                <a href={`https://clickhouse.com/docs${item.value.href}`} className="no-underline hover:underline">
                   {item.value.name}
                 </a>
               </div>


### PR DESCRIPTION
The settings explorers and documentation badges rendered root-relative links that already contained the production `/docs` mount. Mintlify prepended the mount again, producing broken `/docs/docs/...` destinations.

Use fully qualified ClickHouse documentation URLs for the generated settings explorers and all localized badge variants.

Example: https://clickhouse.com/docs/reference/settings/session-settings

Related: https://github.com/ClickHouse/ClickHouse/pull/114432

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed broken settings explorer and documentation badge links that resolved to `/docs/docs/...`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1282` (included in `26.8` and later)
<!-- ch-version-info:end -->